### PR TITLE
Route subagent controls through typed actions

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -37,6 +37,7 @@ const skill_runtime = @import("../skills/skill_runtime.zig");
 const file_index = @import("../workspace/file_index.zig");
 const command_specs = @import("../slash_commands/command_specs.zig");
 const types = @import("../shared/types.zig");
+const subagent_input = @import("../subagent/input_action.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
 const auto_upgrade = @import("../upgrade/auto_upgrade.zig");
 const upgrade_helpers = @import("../upgrade/upgrade_helpers.zig");
@@ -624,6 +625,7 @@ pub fn Runtime(comptime App: type) type {
                             decoded.composer_shortcut,
                             decoded.approval_focused_edit,
                             decoded.question_action,
+                            decoded.subagent_action,
                             decoded.cancel_pending,
                             input_limits.composer_bytes,
                         )) {
@@ -926,6 +928,7 @@ pub fn Runtime(comptime App: type) type {
             composer_shortcut: ?input_action.ShortcutAction,
             approval_focused_edit: ?approval_decision.DraftAction,
             question_action: ?question_prompt.Action,
+            subagent_action: ?subagent_input.Action,
             was_cancel_pending: bool,
             max_input_len: usize,
         ) !ResolvedEscapeRoute {
@@ -994,7 +997,12 @@ pub fn Runtime(comptime App: type) type {
                             approval_focused_edit,
                         );
                     } else {
-                        try subagent_rt.routeSubagentEscapeAction(app, resolved);
+                        try subagent_rt.routeSubagentEscapeAction(
+                            app,
+                            resolved,
+                            composer_shortcut,
+                            subagent_action,
+                        );
                     }
                     return .done;
                 }
@@ -1287,7 +1295,7 @@ pub fn Runtime(comptime App: type) type {
             }
             if (comptime runtime_profile.allows(App, .subagents)) {
                 if (app.subagents.isViewActive()) {
-                    try subagent_rt.handleSubagentViewByte(app, byte);
+                    try subagent_rt.handleSubagentRawInput(app, raw);
                     return true;
                 }
             }
@@ -2418,7 +2426,12 @@ pub fn Runtime(comptime App: type) type {
                         }
                         return;
                     }
-                    try subagent_rt.routeSubagentEscapeAction(app, .escape);
+                    try subagent_rt.routeSubagentEscapeAction(
+                        app,
+                        .escape,
+                        null,
+                        .escape,
+                    );
                     return;
                 }
             }
@@ -2479,7 +2492,12 @@ pub fn Runtime(comptime App: type) type {
             if (comptime runtime_profile.allows(App, .subagents)) {
                 if (app.subagents.isViewActive()) {
                     _ = disarmEscapeClear(app);
-                    try subagent_rt.routeSubagentEscapeAction(app, .escape);
+                    try subagent_rt.routeSubagentEscapeAction(
+                        app,
+                        .escape,
+                        null,
+                        .escape,
+                    );
                     return;
                 }
             }
@@ -2808,6 +2826,8 @@ const RoutingSubagents = struct {
     active: bool = false,
     main_approval_presented: bool = false,
     handled_keys: usize = 0,
+    handled_raw_keys: usize = 0,
+    handled_actions: usize = 0,
     last_handled_key: ?u8 = null,
     last_main_approval_id: ?u64 = null,
     toggle_view_calls: usize = 0,
@@ -2837,14 +2857,16 @@ const RoutingSubagents = struct {
         return alloc.dupe(u8, "");
     }
 
-    pub fn handleKey(self: *RoutingSubagents, _: std.mem.Allocator, byte: u8) !@import("../../ui/subagent/controller.zig").KeyAction {
+    pub fn handleKey(self: *RoutingSubagents, _: std.mem.Allocator, byte: u8) !subagent_input.Command {
         self.handled_keys += 1;
+        self.handled_raw_keys += 1;
         self.last_handled_key = byte;
         return .none;
     }
 
-    pub fn handleAction(self: *RoutingSubagents, _: std.mem.Allocator, action: @import("../../ui/subagent/controller.zig").InputAction) !@import("../../ui/subagent/controller.zig").KeyAction {
+    pub fn handleAction(self: *RoutingSubagents, _: std.mem.Allocator, action: subagent_input.Action) !subagent_input.Command {
         self.handled_keys += 1;
+        self.handled_actions += 1;
         self.last_handled_key = switch (action) {
             .escape => 0x1b,
             .up, .left => 25,
@@ -2854,12 +2876,12 @@ const RoutingSubagents = struct {
         return .none;
     }
 
-    pub fn handleKeyWithMainApproval(self: *RoutingSubagents, alloc: std.mem.Allocator, byte: u8, main_approval_id: ?u64) !@import("../../ui/subagent/controller.zig").KeyAction {
+    pub fn handleKeyWithMainApproval(self: *RoutingSubagents, alloc: std.mem.Allocator, byte: u8, main_approval_id: ?u64) !subagent_input.Command {
         self.last_main_approval_id = main_approval_id;
         return self.handleKey(alloc, byte);
     }
 
-    pub fn handleActionWithMainApproval(self: *RoutingSubagents, alloc: std.mem.Allocator, action: @import("../../ui/subagent/controller.zig").InputAction, main_approval_id: ?u64) !@import("../../ui/subagent/controller.zig").KeyAction {
+    pub fn handleActionWithMainApproval(self: *RoutingSubagents, alloc: std.mem.Allocator, action: subagent_input.Action, main_approval_id: ?u64) !subagent_input.Command {
         self.last_main_approval_id = main_approval_id;
         return self.handleAction(alloc, action);
     }
@@ -4906,6 +4928,7 @@ test "app_input_runtime ctrl-l preserves an active inline picker" {
         &app,
         .{ .composer_shortcut = .redraw },
         .redraw,
+        null,
         null,
         null,
         false,
@@ -8071,6 +8094,7 @@ test "app_input_runtime active multiline history moves vertically before advanci
         null,
         null,
         null,
+        null,
         false,
         4096,
     );
@@ -9030,9 +9054,13 @@ test "app_input_runtime routes keys to subagent view when no modal is active" {
 
     try feedRoutingBytes(&app, "\x1b[A");
     try std.testing.expectEqual(@as(usize, 1), app.subagents.handled_keys);
+    try std.testing.expectEqual(@as(usize, 1), app.subagents.handled_actions);
+    try std.testing.expectEqual(@as(usize, 0), app.subagents.handled_raw_keys);
 
     try Runtime(RoutingFakeApp).handleByte(&app, 'x', 4096, 100);
     try std.testing.expectEqual(@as(usize, 2), app.subagents.handled_keys);
+    try std.testing.expectEqual(@as(usize, 1), app.subagents.handled_actions);
+    try std.testing.expectEqual(@as(usize, 1), app.subagents.handled_raw_keys);
     try std.testing.expectEqual(@as(usize, 0), app.input_runtime.edit_state.input.items.len);
 }
 
@@ -11062,6 +11090,7 @@ test "composer shortcut line delete handles decoded and raw mutations" {
             .delete_to_line_start,
             null,
             null,
+            null,
             false,
             4096,
         );
@@ -11141,6 +11170,7 @@ test "composer shortcut line delete preserves no-op picker redraw and metadata s
         .delete_to_line_start,
         null,
         null,
+        null,
         false,
         4096,
     );
@@ -11154,6 +11184,7 @@ test "composer shortcut line delete preserves no-op picker redraw and metadata s
         &app,
         .delete_to_line_end,
         .delete_to_line_end,
+        null,
         null,
         null,
         false,

--- a/src/core/app/input_subagent_runtime.zig
+++ b/src/core/app/input_subagent_runtime.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const ui_input = @import("../../ui/input/runtime.zig");
 const input_action = @import("../input/input_action.zig");
 const input_visual_layout = @import("../../ui/input/visual_layout.zig");
 const shell_runtime = @import("../../ui/shell_runtime.zig");
@@ -13,6 +12,7 @@ const debug_trace = @import("../shared/debug_trace.zig");
 const skill_runtime = @import("../skills/skill_runtime.zig");
 const types = @import("../shared/types.zig");
 const subagent_domain = @import("../subagent/domain.zig");
+const subagent_input = @import("../subagent/input_action.zig");
 const catalog_screen_layout = @import("../../ui/catalog_screen_layout.zig");
 const input_presentation = @import("../../ui/footer/input_presentation.zig");
 const model_menu_presentation = @import("../../ui/footer/model_menu_presentation.zig");
@@ -21,7 +21,12 @@ const render_input = @import("../../ui/footer/render_input.zig");
 
 pub fn SubagentRuntime(comptime App: type) type {
     return struct {
-        pub fn routeSubagentEscapeAction(app: *App, action: input_action.Action) !void {
+        pub fn routeSubagentEscapeAction(
+            app: *App,
+            action: input_action.Action,
+            shortcut: ?input_action.ShortcutAction,
+            typed_action: ?subagent_input.Action,
+        ) !void {
             if (comptime !@hasDecl(@TypeOf(app.subagents), "handleAction")) return;
             app.input_runtime.vertical_navigation.reset();
             if (comptime @hasField(App, "model_cache") and
@@ -79,33 +84,15 @@ pub fn SubagentRuntime(comptime App: type) type {
                     return;
                 }
             }
-            if (ui_input.shortcutFromEscapeAction(action)) |shortcut| {
-                if (try routeChildComposerShortcut(app, shortcut)) return;
+            if (shortcut) |composer_action| {
+                if (try routeChildComposerShortcut(app, composer_action)) return;
             }
-            switch (action) {
-                .escape => try handleSubagentAction(app, .escape),
-                .history_up, .cursor_up => try handleSubagentAction(app, .up),
-                .history_down, .cursor_down => try handleSubagentAction(app, .down),
-                .cursor_left => try handleSubagentAction(app, .left),
-                .cursor_right => try handleSubagentAction(app, .right),
-                .home => try handleSubagentAction(app, .home),
-                .end => try handleSubagentAction(app, .end),
-                .word_left => try handleSubagentAction(app, .word_left),
-                .word_right => try handleSubagentAction(app, .word_right),
-                .delete_next => try handleSubagentAction(app, .delete_next),
-                .delete_word_left => try handleSubagentAction(app, .delete_word_left),
-                .delete_word_right => try handleSubagentAction(app, .delete_word_right),
-                .delete_to_line_start => try handleSubagentAction(app, .delete_to_line_start),
-                .delete_to_line_end => try handleSubagentAction(app, .delete_to_line_end),
-                .clear_line => try handleSubagentAction(app, .clear_line),
-                .insert_newline => try handleSubagentAction(app, .insert_newline),
-                .page_up => try handleSubagentAction(app, .page_up),
-                .page_down => try handleSubagentAction(app, .page_down),
-                .mouse_pointer => |pointer| {
-                    _ = routeChildComposerPointerAction(app, pointer);
-                },
-                .remapped_byte => |b| try handleSubagentViewByte(app, b),
-                else => {},
+            if (typed_action) |resolved| {
+                try handleSubagentAction(app, resolved);
+                return;
+            }
+            if (action == .mouse_pointer) {
+                _ = routeChildComposerPointerAction(app, action.mouse_pointer);
             }
         }
 
@@ -282,7 +269,11 @@ pub fn SubagentRuntime(comptime App: type) type {
             );
         }
 
-        pub fn handleSubagentViewByte(app: *App, byte: u8) !void {
+        pub fn handleSubagentRawInput(
+            app: *App,
+            raw: input_action.RawTerminalInput,
+        ) !void {
+            const byte = raw.byte;
             if (comptime @hasField(App, "model_cache") and
                 @hasDecl(@TypeOf(app.subagents), "childRouteId") and
                 @hasDecl(@TypeOf(app.subagents), "childPresentationView"))
@@ -298,9 +289,14 @@ pub fn SubagentRuntime(comptime App: type) type {
                     return;
                 }
             }
-            if (ui_input.shortcutFromControlByte(byte)) |shortcut| {
+            if (raw.composer_shortcut) |shortcut| {
                 if (try routeChildComposerShortcut(app, shortcut)) return;
             }
+            if (raw.subagent_action) |action| {
+                try handleSubagentAction(app, action);
+                return;
+            }
+            if (raw.composer_shortcut != null) return;
             const failure_before = if (comptime @hasDecl(
                 @TypeOf(app.subagents),
                 "childPresentationView",
@@ -346,7 +342,7 @@ pub fn SubagentRuntime(comptime App: type) type {
             }
         }
 
-        fn handleSubagentAction(app: *App, action: @import("../../ui/subagent/controller.zig").InputAction) !void {
+        fn handleSubagentAction(app: *App, action: subagent_input.Action) !void {
             const result = if (comptime @hasDecl(@TypeOf(app.subagents), "handleActionWithMainApproval"))
                 try app.subagents.handleActionWithMainApproval(app.alloc, action, mainApprovalId(app))
             else
@@ -719,7 +715,7 @@ pub fn SubagentRuntime(comptime App: type) type {
             app: *App,
             action: input_action.Action,
         ) !void {
-            const mapped: @import("../../ui/subagent/controller.zig").InputAction =
+            const mapped: subagent_input.Action =
                 switch (action) {
                     .cursor_left => .left,
                     .cursor_right => .right,
@@ -747,7 +743,7 @@ pub fn SubagentRuntime(comptime App: type) type {
             app: *App,
             action: input_action.Action,
         ) !void {
-            const mapped: @import("../../ui/subagent/controller.zig").InputAction =
+            const mapped: subagent_input.Action =
                 switch (action) {
                     .cursor_left => .left,
                     .cursor_right => .right,
@@ -862,9 +858,17 @@ const TestSubagents = struct {
     pub fn handleKey(
         _: *TestSubagents,
         _: std.mem.Allocator,
-        byte: u8,
-    ) !@import("../../ui/subagent/controller.zig").KeyAction {
-        return if (byte == 3) .exit_app else .none;
+        _: u8,
+    ) !subagent_input.Command {
+        return .none;
+    }
+
+    pub fn handleAction(
+        _: *TestSubagents,
+        _: std.mem.Allocator,
+        action: subagent_input.Action,
+    ) !subagent_input.Command {
+        return if (action == .ctrl_c) .exit_app else .none;
     }
 
     pub fn isViewActive(_: *const TestSubagents) bool {
@@ -874,7 +878,7 @@ const TestSubagents = struct {
 
 const TestApp = struct {
     alloc: std.mem.Allocator = std.testing.allocator,
-    input_runtime: ui_input.InputRuntime = .{},
+    input_runtime: @import("../../ui/input/runtime.zig").InputRuntime = .{},
     subagents: TestSubagents = .{},
     session_persistence: app_session_runtime.Persistence = .{},
     shell: transcript_runtime.TranscriptRuntime = .{},
@@ -910,7 +914,7 @@ const CatalogTestState = struct {
 
 const CatalogTestApp = struct {
     alloc: std.mem.Allocator = std.testing.allocator,
-    input_runtime: ui_input.InputRuntime = .{},
+    input_runtime: @import("../../ui/input/runtime.zig").InputRuntime = .{},
     subagents: CatalogTestSubagents = .{},
     model_cache: CatalogTestState = .{},
     skills: CatalogTestState = .{},
@@ -931,7 +935,10 @@ test "subagent Ctrl-C requests resume handoff before exit" {
         app.shell.deinit(std.testing.allocator);
     }
 
-    try SubagentRuntime(TestApp).handleSubagentViewByte(&app, 3);
+    try SubagentRuntime(TestApp).handleSubagentRawInput(&app, .{
+        .byte = 3,
+        .subagent_action = .ctrl_c,
+    });
 
     try std.testing.expect(app.should_exit);
     try std.testing.expectEqual(

--- a/src/core/input/input_action.zig
+++ b/src/core/input/input_action.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const question_prompt = @import("../agent/question_prompt.zig");
 const approval_decision = @import("../permissions/approval_decision.zig");
+const subagent_input = @import("../subagent/input_action.zig");
 
 /// Describes a mouse-wheel direction after terminal input has been decoded by UI.
 pub const MouseWheel = enum {
@@ -109,6 +110,7 @@ pub const RawTerminalInput = struct {
     composer_shortcut: ?ShortcutAction = null,
     approval_action: ?approval_decision.Action = null,
     question_action: ?question_prompt.Action = null,
+    subagent_action: ?subagent_input.Action = null,
 };
 
 /// A decoded terminal action plus the state captured when its leading Escape
@@ -118,6 +120,7 @@ pub const DecodedTerminalAction = struct {
     composer_shortcut: ?ShortcutAction = null,
     approval_focused_edit: ?approval_decision.DraftAction = null,
     question_action: ?question_prompt.Action = null,
+    subagent_action: ?subagent_input.Action = null,
     cancel_pending: bool = false,
 };
 

--- a/src/core/subagent/input_action.zig
+++ b/src/core/subagent/input_action.zig
@@ -1,0 +1,52 @@
+/// Layout-independent input accepted by the subagent manager and selected-child
+/// composer after UI has translated terminal encodings.
+pub const Action = enum {
+    up,
+    down,
+    left,
+    right,
+    page_up,
+    page_down,
+    enter,
+    focus_next,
+    activity,
+    notifications,
+    archived,
+    next_page,
+    previous_page,
+    escape,
+    toggle,
+    ctrl_c,
+    home,
+    end,
+    word_left,
+    word_right,
+    delete_backward,
+    delete_next,
+    delete_word_left,
+    delete_word_right,
+    delete_to_line_start,
+    delete_to_line_end,
+    clear_line,
+    insert_newline,
+};
+
+/// Effect requested by the subagent state transition. The Core app runtime
+/// performs the effect after the UI-owned state machine returns this value.
+pub const Command = enum {
+    none,
+    redraw,
+    page_changed,
+    exit_app,
+    close_manager,
+    acknowledge,
+    child_changed,
+    load_older_history,
+    refresh_newest_history,
+    submit_child_message,
+    load_attach_candidates,
+    load_more_attach_candidates,
+    submit_manager_mutation,
+    resolve_child_approval,
+    open_terminal,
+};

--- a/src/ui/input/runtime.zig
+++ b/src/ui/input/runtime.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const question_prompt = @import("../../core/agent/question_prompt.zig");
 const approval_decision = @import("../../core/permissions/approval_decision.zig");
+const subagent_input = @import("../../core/subagent/input_action.zig");
 const command_specs = @import("../../core/slash_commands/command_specs.zig");
 const input_appearance = @import("../../core/config/input_appearance.zig");
 const settings_catalog = @import("../../core/config/settings_catalog.zig");
@@ -277,6 +278,179 @@ fn withQuestionInput(
         .paste_byte, .unrecognized_escape => event,
     };
     return typed;
+}
+
+fn subagentActionFromShortcut(
+    action: input_action.ShortcutAction,
+) ?subagent_input.Action {
+    return switch (action) {
+        .move => |intent| if (intent.extend_selection)
+            null
+        else switch (intent.kind) {
+            .character_left => .left,
+            .character_right => .right,
+            .word_left => .word_left,
+            .word_right => .word_right,
+            .line_start, .draft_start => .home,
+            .line_end, .draft_end => .end,
+            .visual_up => .up,
+            .visual_down => .down,
+            .page_up => .page_up,
+            .page_down => .page_down,
+            .paragraph_up, .paragraph_down => null,
+        },
+        .delete_backward => .delete_backward,
+        .delete_forward => .delete_next,
+        .delete_word_left => .delete_word_left,
+        .delete_word_right => .delete_word_right,
+        .delete_to_line_start => .delete_to_line_start,
+        .delete_to_line_end => .delete_to_line_end,
+        .insert_newline => .insert_newline,
+        .select_all,
+        .copy_selection,
+        .cut_selection,
+        .undo,
+        .redo,
+        .history_previous,
+        .history_next,
+        .delete_whitespace_word_left,
+        .yank,
+        .redraw,
+        => null,
+    };
+}
+
+fn subagentActionFromRawByte(byte: u8) ?subagent_input.Action {
+    return switch (byte) {
+        3 => .ctrl_c,
+        24 => .toggle,
+        '\r' => .enter,
+        '\t' => .focus_next,
+        1 => .home,
+        5 => .end,
+        0x7f, 8 => .delete_backward,
+        11 => .delete_to_line_end,
+        21 => .clear_line,
+        23 => .delete_word_left,
+        else => null,
+    };
+}
+
+fn subagentActionFromDecoded(action: input_action.Action) ?subagent_input.Action {
+    return switch (action) {
+        .escape => .escape,
+        .history_up, .cursor_up => .up,
+        .history_down, .cursor_down => .down,
+        .cursor_left => .left,
+        .cursor_right => .right,
+        .home => .home,
+        .end => .end,
+        .word_left => .word_left,
+        .word_right => .word_right,
+        .delete_next => .delete_next,
+        .delete_word_left => .delete_word_left,
+        .delete_word_right => .delete_word_right,
+        .delete_to_line_start => .delete_to_line_start,
+        .delete_to_line_end => .delete_to_line_end,
+        .clear_line => .clear_line,
+        .insert_newline => .insert_newline,
+        .page_up => .page_up,
+        .page_down => .page_down,
+        .composer_shortcut => |typed| subagentActionFromShortcut(typed),
+        .remapped_byte => |byte| subagentActionFromRawByte(byte),
+        .mouse_wheel,
+        .mouse_pointer,
+        .toggle_full_transcript,
+        .toggle_permission_mode,
+        .open_all_sessions,
+        .paste_start,
+        .paste_end,
+        .ignore,
+        => null,
+    };
+}
+
+fn withSubagentInput(
+    ingress: input_action.TerminalInputIngress,
+) input_action.TerminalInputIngress {
+    var typed = ingress;
+    const event = typed.event orelse return typed;
+    typed.event = switch (event) {
+        .raw => |raw| input_action.TerminalInputEvent{ .raw = .{
+            .byte = raw.byte,
+            .composer_shortcut = raw.composer_shortcut,
+            .approval_action = raw.approval_action,
+            .question_action = raw.question_action,
+            .subagent_action = subagentActionFromRawByte(raw.byte),
+        } },
+        .action => |decoded| input_action.TerminalInputEvent{ .action = .{
+            .action = decoded.action,
+            .composer_shortcut = decoded.composer_shortcut,
+            .approval_focused_edit = decoded.approval_focused_edit,
+            .question_action = decoded.question_action,
+            .subagent_action = subagentActionFromDecoded(decoded.action),
+            .cancel_pending = decoded.cancel_pending,
+        } },
+        .paste_byte, .unrecognized_escape => event,
+    };
+    return typed;
+}
+
+test "terminal input carries typed subagent controls and shortcuts" {
+    var runtime = InputRuntime{};
+    defer runtime.deinit(std.testing.allocator);
+    const context: input_action.TerminalDecodeContext = .{
+        .now_ms = 1,
+        .paste_active = false,
+        .cancel_pending = false,
+        .child_route_active = true,
+    };
+
+    const toggle = runtime.decodeTerminalByte(24, context);
+    try std.testing.expectEqual(
+        subagent_input.Action.toggle,
+        toggle.event.?.raw.subagent_action.?,
+    );
+
+    const line_start = runtime.decodeTerminalByte(1, context);
+    try std.testing.expectEqual(
+        subagent_input.Action.home,
+        line_start.event.?.raw.subagent_action.?,
+    );
+
+    const clear_line = runtime.decodeTerminalByte(21, context);
+    try std.testing.expectEqual(
+        subagent_input.Action.clear_line,
+        clear_line.event.?.raw.subagent_action.?,
+    );
+
+    const child_only_shortcut = runtime.decodeTerminalByte(2, context);
+    try std.testing.expect(child_only_shortcut.event.?.raw.subagent_action == null);
+    try std.testing.expectEqual(
+        input_action.ShortcutAction{ .move = .{ .kind = .character_left } },
+        child_only_shortcut.event.?.raw.composer_shortcut.?,
+    );
+
+    const text = runtime.decodeTerminalByte('j', context);
+    try std.testing.expect(text.event.?.raw.subagent_action == null);
+
+    var word_delete = input_action.TerminalInputIngress{};
+    for ("\x1bd") |byte| {
+        word_delete = runtime.decodeTerminalByte(byte, context);
+    }
+    try std.testing.expectEqual(
+        subagent_input.Action.delete_word_right,
+        word_delete.event.?.action.subagent_action.?,
+    );
+
+    var arrow = input_action.TerminalInputIngress{};
+    for ("\x1b[A") |byte| {
+        arrow = runtime.decodeTerminalByte(byte, context);
+    }
+    try std.testing.expectEqual(
+        subagent_input.Action.up,
+        arrow.event.?.action.subagent_action.?,
+    );
 }
 
 test "question bytes translate to typed prompt actions" {
@@ -747,10 +921,10 @@ pub const InputRuntime = struct {
         context: input_action.TerminalDecodeContext,
     ) input_action.TerminalInputIngress {
         if (context.paste_active) return terminal_action_decoder.pasteByteIngress(byte);
-        return withQuestionInput(
+        return withSubagentInput(withQuestionInput(
             withApprovalInput(self.terminal_action_decoder.feed(byte, context)),
             context.question_freeform_selected,
-        );
+        ));
     }
 
     pub fn flushTerminalAction(

--- a/src/ui/subagent/runtime.zig
+++ b/src/ui/subagent/runtime.zig
@@ -14,6 +14,7 @@ const projection = @import("../../core/subagent/ui_projection.zig");
 const terminal_projection = @import("../../core/terminal/ui_projection.zig");
 const skill_contract = @import("../../core/skills/skill_contract.zig");
 const input_action = @import("../../core/input/input_action.zig");
+const subagent_input = @import("../../core/subagent/input_action.zig");
 const horizontal_navigation = @import("../../core/input/horizontal_navigation.zig");
 const paste_framing = @import("../../core/input/paste_framing.zig");
 const ui_input = @import("../input/runtime.zig");
@@ -106,54 +107,11 @@ pub const Route = union(enum) {
     }
 };
 
-pub const Command = enum {
-    none,
-    redraw,
-    page_changed,
-    exit_app,
-    close_manager,
-    acknowledge,
-    child_changed,
-    load_older_history,
-    refresh_newest_history,
-    submit_child_message,
-    load_attach_candidates,
-    load_more_attach_candidates,
-    submit_manager_mutation,
-    resolve_child_approval,
-    open_terminal,
-};
+pub const Command = subagent_input.Command;
 
 const RootSelection = enum { child, terminal };
 
-pub const Action = enum {
-    up,
-    down,
-    left,
-    right,
-    page_up,
-    page_down,
-    enter,
-    activity,
-    notifications,
-    archived,
-    next_page,
-    previous_page,
-    escape,
-    toggle,
-    ctrl_c,
-    home,
-    end,
-    word_left,
-    word_right,
-    delete_next,
-    delete_word_left,
-    delete_word_right,
-    delete_to_line_start,
-    delete_to_line_end,
-    clear_line,
-    insert_newline,
-};
+pub const Action = subagent_input.Action;
 
 pub const SubmissionFailure = struct {
     code: manager_mod.FailureCode,
@@ -2763,6 +2721,8 @@ pub const Runtime = struct {
             .end,
             .word_left,
             .word_right,
+            .focus_next,
+            .delete_backward,
             .delete_next,
             .delete_word_left,
             .delete_word_right,
@@ -2775,6 +2735,19 @@ pub const Runtime = struct {
     }
 
     fn handleChildAction(self: *Runtime, alloc: Allocator, action: Action) !Command {
+        if (action == .focus_next) {
+            const messageable = if (self.child.chat) |chat|
+                chat.messageable()
+            else
+                false;
+            self.focus = if (self.focus == .child_composer)
+                .child_detail
+            else if (messageable)
+                .child_composer
+            else
+                .child_detail;
+            return .redraw;
+        }
         const messageable = if (self.child.chat) |chat|
             chat.messageable()
         else
@@ -2858,6 +2831,11 @@ pub const Runtime = struct {
                 &self.child.editor.entities,
                 &self.child.editor.vertical_navigation,
             ),
+            .delete_backward => edited = self.child.editor.deletionState(null).delete(
+                alloc,
+                .character_left,
+                .clear,
+            ),
             .delete_next => edited = self.child.editor.deletionState(null).delete(
                 alloc,
                 .character_right,
@@ -2896,6 +2874,7 @@ pub const Runtime = struct {
             .toggle,
             .escape,
             => return .none,
+            .focus_next => unreachable,
             .up,
             .down,
             .page_up,
@@ -2961,6 +2940,13 @@ pub const Runtime = struct {
                     &value.vertical_navigation,
                 );
             },
+            .delete_backward => if (editor) |value| {
+                edited = value.deletionState(null).delete(
+                    alloc,
+                    .character_left,
+                    .clear,
+                );
+            },
             .delete_next => if (editor) |value| {
                 edited = value.deletionState(null).delete(
                     alloc,
@@ -2999,6 +2985,7 @@ pub const Runtime = struct {
                     edited = true;
                 }
             },
+            .focus_next => self.moveFormField(1),
             .enter => return .submit_manager_mutation,
             else => return .none,
         }
@@ -7316,6 +7303,49 @@ test "child and form editors keep Home End and control aliases on the current li
     try std.testing.expectEqual(second_line_start, form_runtime.form.editors[2].edit_state.cursor);
     try std.testing.expectEqual(Command.redraw, try form_runtime.handleByte(alloc, 5, null));
     try std.testing.expectEqual(multiline.len, form_runtime.form.editors[2].edit_state.cursor);
+}
+
+test "typed terminal controls preserve child and form edit behavior" {
+    const alloc = std.testing.allocator;
+
+    var child_runtime = Runtime{};
+    defer child_runtime.deinit(alloc);
+    try std.testing.expect(try child_runtime.replaceSnapshot(
+        alloc,
+        try testSnapshot(alloc, 1, &.{"child"}),
+    ));
+    try std.testing.expectEqual(Command.child_changed, try child_runtime.handle(alloc, .enter));
+    try child_runtime.installChildChat(
+        alloc,
+        try testChildChat(alloc, child_runtime.routedNode().?),
+        false,
+        true,
+    );
+    try child_runtime.child.editor.insertionState().insertSlice(alloc, "ab", .preserve);
+
+    try std.testing.expect(child_runtime.childComposerFocused());
+    try std.testing.expectEqual(Command.redraw, try child_runtime.handle(alloc, .focus_next));
+    try std.testing.expect(!child_runtime.childComposerFocused());
+    try std.testing.expectEqual(Command.redraw, try child_runtime.handle(alloc, .focus_next));
+    try std.testing.expect(child_runtime.childComposerFocused());
+    try std.testing.expectEqual(Command.redraw, try child_runtime.handle(alloc, .delete_backward));
+    try std.testing.expectEqualStrings("a", child_runtime.child.editor.edit_state.input.items);
+
+    var form_runtime = Runtime{};
+    defer form_runtime.deinit(alloc);
+    try form_runtime.setDefaults(alloc, "test/model", types.ReasoningEffort.literal("high"));
+    try std.testing.expect(try form_runtime.replaceSnapshot(
+        alloc,
+        try testSnapshot(alloc, 1, &.{}),
+    ));
+    try std.testing.expectEqual(Command.redraw, try form_runtime.handleByte(alloc, 'c', null));
+    form_runtime.form.field_index = 2;
+    try form_runtime.form.replaceEditor(alloc, .initial_message, "ab");
+
+    try std.testing.expectEqual(Command.redraw, try form_runtime.handle(alloc, .delete_backward));
+    try std.testing.expectEqualStrings("a", form_runtime.form.editors[2].edit_state.input.items);
+    try std.testing.expectEqual(Command.redraw, try form_runtime.handle(alloc, .focus_next));
+    try std.testing.expectEqual(@as(usize, 3), form_runtime.form.field_index);
 }
 
 test "unchanged live child snapshots do not mutate the viewport or request repaint" {


### PR DESCRIPTION
## Summary

- Preserve Ctrl-X close, manager navigation, selected-child focus and editing, and Ctrl-C cancellation through a typed input contract.
- Keep printable manager shortcuts on their existing state-dependent route.