### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # fx
 
-## 0.3.73
+## 0.4.0
 
 <!-- release:start -->
+
+### Improvements
+
+- **Interactive terminal startup:** Start an interactive shell when the `terminal` tool receives an empty command (#3)
+
+### Contributors
+
+- @fazxes
+<!-- release:end -->
+
+## 0.3.73
 
 ### New Features
 
@@ -38,7 +49,6 @@
 - @suarezesteban
 - @rauchg
 - @shaper
-<!-- release:end -->
 
 ## 0.3.72
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,22 @@
 
 <!-- release:start -->
 
+### New Features
+
+- **WebAssembly terminal sessions:** The experimental terminal SDK can now sign in and restore persisted sessions across reloads
+- **Hosted workspace commands:** The WebAssembly terminal can run commands supplied by its host workspace
+
 ### Improvements
 
-- **Interactive terminal startup:** Start an interactive shell when the `terminal` tool receives an empty command (#3)
+- **WebAssembly terminal output:** Stream assistant Markdown and tables more smoothly in the terminal SDK
+- **Feedback reports:** `/feedback` now copies a diagnostic report and opens a prefilled GitHub issue form, with guidance to review and redact sensitive information before submitting
+- **Agents and processes:** The Ctrl+X manager now groups agents and background processes with clearer labels, actions, counts, and compact layouts
+- **Background terminals:** Background sessions remain available through Ctrl+X while the normal footer stays quieter, and terminal takeover now shows how to detach
 
-### Contributors
+### Bug Fixes
 
-- @fazxes
+- **Interactive terminal startup:** Start an interactive shell when the `terminal` tool receives an empty command
+- **Ctrl+X manager layout:** Keep the close action visible on narrow terminals and align status labels correctly for wide Unicode names
 <!-- release:end -->
 
 ## 0.3.73

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const build_options = @import("build_options");
 const io_mod = @import("core/shared/io.zig");
 
-pub const version = "0.3.73";
+pub const version = "0.4.0";
 
 const app_lifecycle = @import("core/app/app_lifecycle.zig");
 const auth_runtime = @import("core/auth/auth_runtime.zig");


### PR DESCRIPTION
## Summary

- Bump `src/main.zig` to 0.4.0
- Add the `CHANGELOG.md` entry for 0.4.0
- Move the active release markers from 0.3.73 to 0.4.0