### PR TITLE
Unify inline settings menus

### DIFF
--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -3027,6 +3027,108 @@ pub fn settingsCatalogSnapshot(app: anytype) settings_catalog.Snapshot {
     return snapshot;
 }
 
+pub fn applySettingsCatalogMenuChange(app: anytype, change: settings_catalog.Change) !void {
+    switch (change.setting) {
+        .input_appearance => {
+            const next = input_appearance.InputAppearance.parse(change.value) orelse
+                return error.InvalidSettingsCatalogValue;
+            const runtime_changed = next != app.input_runtime.input_appearance;
+            if (runtime_changed) app.input_runtime.input_appearance = next;
+            try persistUserPreferencesSilently(
+                app,
+                "input",
+                .{ .input_appearance = next.label() },
+                runtime_changed,
+            );
+        },
+        .maxxing_mode => {
+            const next = presentation_mode.MaxxingMode.parse(change.value) orelse
+                return error.InvalidSettingsCatalogValue;
+            const runtime_changed = next != app.shell.maxxing_mode;
+            if (runtime_changed) {
+                app.shell.maxxing_mode = next;
+                app.shell.render_requests.request(.transcript);
+            }
+            try persistUserPreferencesSilently(
+                app,
+                "maxxing",
+                .{ .maxxing_mode = next.label() },
+                runtime_changed,
+            );
+        },
+        .statusline_sandbox, .statusline_context, .statusline_session => {
+            const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;
+            const runtime_changed = switch (change.setting) {
+                .statusline_sandbox => blk: {
+                    const changed = enabled != app.statusline_sandbox;
+                    app.statusline_sandbox = enabled;
+                    break :blk changed;
+                },
+                .statusline_context => blk: {
+                    const changed = enabled != app.statusline_context;
+                    app.statusline_context = enabled;
+                    break :blk changed;
+                },
+                .statusline_session => blk: {
+                    const changed = enabled != app.statusline_session;
+                    app.statusline_session = enabled;
+                    break :blk changed;
+                },
+                else => unreachable,
+            };
+            const item: config_runtime.UserSettingsPatch = switch (change.setting) {
+                .statusline_sandbox => .{ .statusline_item = .{ .item = .sandbox, .enabled = enabled } },
+                .statusline_context => .{ .statusline_item = .{ .item = .context, .enabled = enabled } },
+                .statusline_session => .{ .statusline_item = .{ .item = .session, .enabled = enabled } },
+                else => unreachable,
+            };
+            try persistUserPreferencesSilently(app, "statusline", item, runtime_changed);
+        },
+        .sandbox => {
+            const mode = sandbox.PublicMode.parse(change.value) orelse return error.InvalidSettingsCatalogValue;
+            if (mode == .os and !sandbox.osSandboxAvailable()) {
+                try app.writeDomainNotice(.{
+                    .topic = "sandbox",
+                    .tone = .warning,
+                    .body = sandbox.unsupported_os_sandbox_message,
+                }, true);
+                return;
+            }
+            _ = app_permission_runtime.Runtime(@TypeOf(app.*)).setSandboxBackend(
+                app,
+                sandbox.backendForPublicMode(mode),
+            );
+            var outcome = config_runtime.setSandbox(app.alloc, app.workspace_root, mode.label()) catch |err| {
+                try writeSandboxPersistenceFailure(app, err);
+                return;
+            };
+            outcome.deinit(app.alloc);
+        },
+        else => try applySettingsCatalogChange(app, change),
+    }
+    app.shell.render_requests.request(.footer);
+}
+
+fn persistUserPreferencesSilently(
+    app: anytype,
+    label: []const u8,
+    patch: config_runtime.UserSettingsPatch,
+    runtime_changed: bool,
+) !void {
+    var attempt = config_runtime.attemptUserPreferences(app.alloc, patch);
+    defer attempt.deinit(app.alloc);
+    switch (attempt) {
+        .failure => |failure| try session_commands.reportUserSettingsFailure(
+            app,
+            label,
+            failure.err,
+            failure.cleanup,
+            runtime_changed,
+        ),
+        .outcome => {},
+    }
+}
+
 pub fn applySettingsCatalogChange(app: anytype, change: settings_catalog.Change) !void {
     switch (change.setting) {
         .model => unreachable,

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1024,7 +1024,7 @@ pub fn Runtime(comptime App: type) type {
             }
 
             if (appearanceMenuActive(app)) {
-                routeAppearanceMenuEscapeAction(app, resolved);
+                try routeAppearanceMenuEscapeAction(app, resolved);
                 return .done;
             }
 
@@ -1967,7 +1967,7 @@ pub fn Runtime(comptime App: type) type {
         fn submitAppearanceMenuSelection(app: *App) !void {
             const change = app.input_runtime.appearance_menu.selectedChange() orelse return;
             if (comptime @hasDecl(App, "notificationPreferences")) {
-                try app_commands.applySettingsCatalogChange(app, change);
+                try app_commands.applySettingsCatalogMenuChange(app, change);
             }
             app.shell.render_requests.request(.footer);
         }
@@ -1995,7 +1995,7 @@ pub fn Runtime(comptime App: type) type {
                 .usage, .workspace => unreachable,
             } orelse return;
             if (comptime @hasDecl(App, "notificationPreferences")) {
-                try app_commands.applySettingsCatalogChange(app, change);
+                try app_commands.applySettingsCatalogMenuChange(app, change);
             }
             app.shell.render_requests.request(.footer);
         }
@@ -2067,6 +2067,21 @@ pub fn Runtime(comptime App: type) type {
                 }
                 return;
             }
+            if ((menu == .statusline or menu == .sandbox) and
+                (resolved == .cursor_left or resolved == .cursor_right))
+            {
+                const snapshot = app_commands.settingsCatalogSnapshot(app);
+                const delta: i32 = if (resolved == .cursor_left) -1 else 1;
+                const change = switch (menu) {
+                    .statusline => app.input_runtime.statusline_menu.changeSelectedOption(&snapshot, delta),
+                    .sandbox => app.input_runtime.sandbox_menu.changeSelectedOption(&snapshot, delta),
+                    .usage, .workspace => unreachable,
+                } orelse return;
+                if (comptime @hasDecl(App, "notificationPreferences")) {
+                    try app_commands.applySettingsCatalogMenuChange(app, change);
+                }
+                return;
+            }
             const delta: i32 = switch (resolved) {
                 .cursor_up => -1,
                 .cursor_down => 1,
@@ -2085,10 +2100,21 @@ pub fn Runtime(comptime App: type) type {
             }
         }
 
-        fn routeAppearanceMenuEscapeAction(app: *App, resolved: input_action.Action) void {
+        fn routeAppearanceMenuEscapeAction(app: *App, resolved: input_action.Action) !void {
             switch (resolved) {
-                .cursor_up => _ = app.input_runtime.appearance_menu.move(-1),
-                .cursor_down => _ = app.input_runtime.appearance_menu.move(1),
+                .cursor_up, .cursor_down => {
+                    _ = app.input_runtime.appearance_menu.cycleSection(1);
+                },
+                .cursor_left, .cursor_right => {
+                    const snapshot = app_commands.settingsCatalogSnapshot(app);
+                    const change = app.input_runtime.appearance_menu.changeSelectedOption(
+                        &snapshot,
+                        if (resolved == .cursor_left) -1 else 1,
+                    ) orelse return;
+                    if (comptime @hasDecl(App, "notificationPreferences")) {
+                        try app_commands.applySettingsCatalogMenuChange(app, change);
+                    }
+                },
                 .toggle_permission_mode => _ = app.input_runtime.appearance_menu.cycleSection(-1),
                 else => return,
             }

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -185,6 +185,15 @@ pub const AppearanceMenu = struct {
     pub fn selectedChange(self: *const AppearanceMenu) ?Change {
         return (self.selectedChoice() orelse return null).change;
     }
+
+    pub fn changeSelectedOption(self: *const AppearanceMenu, snapshot: *const Snapshot, delta: i32) ?Change {
+        if (!self.active or delta == 0) return null;
+        const setting: SettingId = if (self.selected_index % appearance_choices.len < 2)
+            .input_appearance
+        else
+            .maxxing_mode;
+        return cycleChange(snapshot, setting, delta);
+    }
 };
 
 pub fn appearanceChoiceCount() usize {
@@ -257,6 +266,12 @@ pub const StatuslineMenu = struct {
     pub fn selectedChange(self: *const StatuslineMenu, snapshot: Snapshot) ?Change {
         return (self.selectedChoice() orelse return null).toggledChange(snapshot);
     }
+
+    pub fn changeSelectedOption(self: *const StatuslineMenu, snapshot: *const Snapshot, delta: i32) ?Change {
+        if (delta == 0) return null;
+        const choice = self.selectedChoice() orelse return null;
+        return cycleChange(snapshot, choice.setting, delta);
+    }
 };
 
 pub fn statuslineChoiceCount() usize {
@@ -316,6 +331,11 @@ pub const SandboxMenu = struct {
 
     pub fn selectedChange(self: *const SandboxMenu) ?Change {
         return (self.selectedChoice() orelse return null).change;
+    }
+
+    pub fn changeSelectedOption(self: *const SandboxMenu, snapshot: *const Snapshot, delta: i32) ?Change {
+        if (!self.active or delta == 0) return null;
+        return cycleChange(snapshot, .sandbox, delta);
     }
 };
 
@@ -406,15 +426,7 @@ pub const Menu = struct {
     ) ?Change {
         if (delta == 0) return null;
         const item = self.selectedItem(snapshot, query) orelse return null;
-        const count = optionCount(snapshot, item.id);
-        if (count == 0) return null;
-
-        const current: i32 = @intCast(selectedOptionIndex(snapshot, item.id) orelse 0);
-        const count_signed: i32 = @intCast(count);
-        var next = current + delta;
-        while (next < 0) next += count_signed;
-        while (next >= count_signed) next -= count_signed;
-        return changeAt(snapshot, item.id, @intCast(next));
+        return cycleChange(snapshot, item.id, delta);
     }
 };
 
@@ -508,6 +520,17 @@ pub fn optionAt(snapshot: *const Snapshot, id: SettingId, index: usize) ?[]const
     const options = staticOptionsFor(id);
     if (index >= options.len) return null;
     return options[index];
+}
+
+fn cycleChange(snapshot: *const Snapshot, id: SettingId, delta: i32) ?Change {
+    const count = optionCount(snapshot, id);
+    if (count == 0) return null;
+    const current: i32 = @intCast(selectedOptionIndex(snapshot, id) orelse 0);
+    const count_signed: i32 = @intCast(count);
+    var next = current + delta;
+    while (next < 0) next += count_signed;
+    while (next >= count_signed) next -= count_signed;
+    return changeAt(snapshot, id, @intCast(next));
 }
 
 pub fn selectedOptionIndex(snapshot: *const Snapshot, id: SettingId) ?usize {

--- a/src/ui/footer/appearance_menu_presentation.zig
+++ b/src/ui/footer/appearance_menu_presentation.zig
@@ -8,8 +8,7 @@ const ui_render = @import("../render.zig");
 const Allocator = std.mem.Allocator;
 const AppearanceMenuProjection = render_input.AppearanceMenuProjection;
 
-pub const row_count: u16 = 11;
-const option_label_column: usize = 16;
+pub const row_count: u16 = 4;
 
 pub noinline fn composeAppearanceMenuRow(
     alloc: Allocator,
@@ -20,88 +19,31 @@ pub noinline fn composeAppearanceMenuRow(
 ) !std.ArrayList(u8) {
     const empty: std.ArrayList(u8) = .empty;
     if (width == 0 or row_index >= visible_rows) return empty;
-    return switch (menuRowAt(projection, row_index, visible_rows)) {
-        .empty => empty,
-        .header => composeStyledRow(alloc, "Appearance · Choose one", width, ui_render.selected_completion_style),
-        .input_heading => composeStyledRow(alloc, settings_catalog.AppearanceSection.input_style.label(), width, ui_render.dim_style),
-        .presentation_heading => composeStyledRow(alloc, settings_catalog.AppearanceSection.presentation.label(), width, ui_render.dim_style),
-        .choice => |choice_index| composeChoiceRow(alloc, projection, choice_index, width),
+    if (visible_rows == 1) {
+        return composeSettingRow(
+            alloc,
+            projection,
+            selectedSetting(projection),
+            true,
+            width,
+        );
+    }
+    if (row_index == 0) return composeStyledRow(alloc, "Appearance", width, ui_render.selected_completion_style);
+    if (visible_rows >= row_count and row_index == 1) return empty;
+
+    const setting_row = row_index - if (visible_rows >= row_count) @as(u16, 2) else 1;
+    return switch (setting_row) {
+        0 => composeSettingRow(alloc, projection, .input_appearance, selectedSetting(projection) == .input_appearance, width),
+        1 => composeSettingRow(alloc, projection, .maxxing_mode, selectedSetting(projection) == .maxxing_mode, width),
+        else => empty,
     };
 }
 
-const MenuRow = union(enum) {
-    empty,
-    header,
-    input_heading,
-    presentation_heading,
-    choice: usize,
-};
-
-fn menuRowAt(projection: AppearanceMenuProjection, row_index: u16, visible_rows: u16) MenuRow {
-    if (visible_rows >= 7) return groupedMenuRowAt(row_index, @min(visible_rows, row_count) - 7);
-    if (visible_rows == 6) {
-        return switch (row_index) {
-            0 => .input_heading,
-            1 => .{ .choice = 0 },
-            2 => .{ .choice = 1 },
-            3 => .presentation_heading,
-            4 => .{ .choice = 2 },
-            5 => .{ .choice = 3 },
-            else => .empty,
-        };
-    }
-    if (visible_rows >= 4) {
-        if (visible_rows == 5 and row_index == 0) return .header;
-        const choice_index: usize = @intCast(row_index - @intFromBool(visible_rows == 5));
-        return if (choice_index < settings_catalog.appearanceChoiceCount())
-            .{ .choice = choice_index }
-        else
-            .empty;
-    }
-
-    const selected = projection.selected_index % settings_catalog.appearanceChoiceCount();
-    const section_start: usize = if (selected < 2) 0 else 2;
-    if (visible_rows == 3) {
-        return switch (row_index) {
-            0 => if (section_start == 0) .input_heading else .presentation_heading,
-            1 => .{ .choice = section_start },
-            2 => .{ .choice = section_start + 1 },
-            else => .empty,
-        };
-    }
-    if (visible_rows == 2) {
-        return .{ .choice = section_start + @as(usize, row_index) };
-    }
-    if (visible_rows == 1 and row_index == 0) return .{ .choice = selected };
-    return .empty;
-}
-
-fn groupedMenuRowAt(row_index: u16, gap_count: u16) MenuRow {
-    var row: u16 = 0;
-    if (takeMenuRow(row_index, &row, .header)) |menu_row| return menu_row;
-    if (gap_count >= 2) {
-        if (takeMenuRow(row_index, &row, .empty)) |menu_row| return menu_row;
-    }
-    if (takeMenuRow(row_index, &row, .input_heading)) |menu_row| return menu_row;
-    if (gap_count >= 4) {
-        if (takeMenuRow(row_index, &row, .empty)) |menu_row| return menu_row;
-    }
-    if (takeMenuRow(row_index, &row, .{ .choice = 0 })) |menu_row| return menu_row;
-    if (takeMenuRow(row_index, &row, .{ .choice = 1 })) |menu_row| return menu_row;
-    if (gap_count >= 1) {
-        if (takeMenuRow(row_index, &row, .empty)) |menu_row| return menu_row;
-    }
-    if (takeMenuRow(row_index, &row, .presentation_heading)) |menu_row| return menu_row;
-    if (gap_count >= 3) {
-        if (takeMenuRow(row_index, &row, .empty)) |menu_row| return menu_row;
-    }
-    if (takeMenuRow(row_index, &row, .{ .choice = 2 })) |menu_row| return menu_row;
-    return if (row_index == row) .{ .choice = 3 } else .empty;
-}
-
-fn takeMenuRow(target: u16, row_index: *u16, menu_row: MenuRow) ?MenuRow {
-    defer row_index.* += 1;
-    return if (target == row_index.*) menu_row else null;
+fn selectedSetting(projection: AppearanceMenuProjection) settings_catalog.SettingId {
+    return if (projection.selected_index % settings_catalog.appearanceChoiceCount() < 2)
+        .input_appearance
+    else
+        .maxxing_mode;
 }
 
 fn composeStyledRow(
@@ -118,41 +60,60 @@ fn composeStyledRow(
     return row;
 }
 
-fn composeChoiceRow(
+fn composeSettingRow(
     alloc: Allocator,
     projection: AppearanceMenuProjection,
-    choice_index: usize,
+    setting: settings_catalog.SettingId,
+    selected: bool,
     width: u16,
 ) !std.ArrayList(u8) {
-    const choice = settings_catalog.appearanceChoiceAt(choice_index) orelse return .empty;
-    const selected = choice_index == projection.selected_index % settings_catalog.appearanceChoiceCount();
-    const current = choice.isCurrent(projection.snapshot);
     var row: std.ArrayList(u8) = .empty;
     errdefer row.deinit(alloc);
-
-    try row.appendSlice(alloc, if (selected) ui_render.system_notice_label_style else ui_render.dim_style);
-    try row_text.appendClipped(alloc, &row, if (selected) "❯ " else "  ", width);
-    var label_buf: [64]u8 = undefined;
-    const label = if (current)
-        std.fmt.bufPrint(&label_buf, "{s} ✓", .{choice.label}) catch choice.label
-    else
-        choice.label;
-    const prefix_used = display_width.visibleWidthIgnoringAnsi(row.items);
-    try row_text.appendSingleLineEllipsized(alloc, &row, label, @as(usize, width) -| prefix_used);
+    const indent: usize = if (width <= 2) 0 else 2;
+    if (indent > 0) try row.appendSlice(alloc, "  ");
+    try row.appendSlice(alloc, if (selected) ui_render.selected_completion_style else ui_render.dim_style);
+    const value_col = valueColumn(projection.snapshot, setting, width);
+    try row_text.appendSingleLineEllipsized(
+        alloc,
+        &row,
+        settings_catalog.specFor(setting).label,
+        value_col -| indent,
+    );
     try row.appendSlice(alloc, ui_render.reset_style);
+    try row_text.appendSpacesToColumn(alloc, &row, value_col);
 
-    const used = display_width.visibleWidthIgnoringAnsi(row.items);
-    const total_width: usize = width;
-    if (used >= total_width or total_width < option_label_column + 8) return row;
-    const description_col = @max(option_label_column, used + 2);
-    try row.appendNTimes(alloc, ' ', description_col - used);
-    try row.appendSlice(alloc, ui_render.dim_style);
-    try row_text.appendSingleLineEllipsized(alloc, &row, choice.description, total_width - description_col);
-    try row.appendSlice(alloc, ui_render.reset_style);
+    const option_count = settings_catalog.optionCount(&projection.snapshot, setting);
+    for (0..option_count) |index| {
+        const before_option = display_width.visibleWidthIgnoringAnsi(row.items);
+        if (before_option >= width) break;
+        if (index > 0) try row.appendNTimes(alloc, ' ', @min(@as(usize, 2), @as(usize, width) - before_option));
+        const option = settings_catalog.optionAt(&projection.snapshot, setting, index) orelse continue;
+        const current = std.ascii.eqlIgnoreCase(option, projection.snapshot.value(setting));
+        try row.appendSlice(alloc, if (current) ui_render.selected_completion_style else ui_render.dim_style);
+        const used = display_width.visibleWidthIgnoringAnsi(row.items);
+        try row_text.appendSingleLineEllipsized(alloc, &row, option, @as(usize, width) -| used);
+        try row.appendSlice(alloc, ui_render.reset_style);
+        if (display_width.visibleWidthIgnoringAnsi(row.items) >= width) break;
+    }
     return row;
 }
 
-test "appearance menu renders grouped current choices and selection" {
+fn valueColumn(snapshot: settings_catalog.Snapshot, setting: settings_catalog.SettingId, width: u16) usize {
+    const total_width: usize = width;
+    const right_column_start = total_width * 2 / 3;
+    const right_column_width = total_width - right_column_start;
+    var options_width: usize = 0;
+    const option_count = settings_catalog.optionCount(&snapshot, setting);
+    for (0..option_count) |index| {
+        if (index > 0) options_width += 2;
+        const option = settings_catalog.optionAt(&snapshot, setting, index) orelse continue;
+        options_width += display_width.visibleWidth(option);
+    }
+    const block_width = @min(options_width, right_column_width);
+    return right_column_start + (right_column_width - block_width) / 2;
+}
+
+test "appearance menu matches settings rows without markers or descriptions" {
     const projection: AppearanceMenuProjection = .{
         .active = true,
         .selected_index = 0,
@@ -161,75 +122,29 @@ test "appearance menu renders grouped current choices and selection" {
 
     var header = try composeAppearanceMenuRow(std.testing.allocator, projection, 0, row_count, 80);
     defer header.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, header.items, "Appearance · Choose one") != null);
+    try std.testing.expect(std.mem.find(u8, header.items, "Appearance") != null);
 
-    var input_gap = try composeAppearanceMenuRow(std.testing.allocator, projection, 3, row_count, 80);
-    defer input_gap.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 0), input_gap.items.len);
+    var input = try composeAppearanceMenuRow(std.testing.allocator, projection, 2, row_count, 80);
+    defer input.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.find(u8, input.items, "Input appearance") != null);
+    try std.testing.expect(std.mem.find(u8, input.items, "lines") != null);
+    try std.testing.expect(std.mem.find(u8, input.items, "tint") != null);
+    try std.testing.expect(std.mem.find(u8, input.items, "✓") == null);
+    try std.testing.expect(std.mem.find(u8, input.items, "❯") == null);
 
-    var selected = try composeAppearanceMenuRow(std.testing.allocator, projection, 4, row_count, 80);
-    defer selected.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, selected.items, "❯ Lines") != null);
-
-    var tint = try composeAppearanceMenuRow(std.testing.allocator, projection, 5, row_count, 80);
-    defer tint.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, tint.items, "Tint ✓") != null);
-
-    var presentation_gap = try composeAppearanceMenuRow(std.testing.allocator, projection, 8, row_count, 80);
-    defer presentation_gap.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 0), presentation_gap.items.len);
-
-    var minimal = try composeAppearanceMenuRow(std.testing.allocator, projection, 10, row_count, 80);
-    defer minimal.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, minimal.items, "Minimal ✓") != null);
+    var presentation = try composeAppearanceMenuRow(std.testing.allocator, projection, 3, row_count, 80);
+    defer presentation.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.find(u8, presentation.items, "Maxxing mode") != null);
+    try std.testing.expect(std.mem.find(u8, presentation.items, "minimal") != null);
+    try std.testing.expect(std.mem.find(u8, presentation.items, "legacy") != null);
 }
 
 test "appearance menu rows remain single-line and width safe" {
     const projection: AppearanceMenuProjection = .{ .active = true };
     for ([_]u16{ 1, 4, 18 }) |width| {
-        var row = try composeAppearanceMenuRow(std.testing.allocator, projection, 4, row_count, width);
+        var row = try composeAppearanceMenuRow(std.testing.allocator, projection, 2, row_count, width);
         defer row.deinit(std.testing.allocator);
         try std.testing.expect(std.mem.findScalar(u8, row.items, '\n') == null);
         try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= width);
     }
-}
-
-test "appearance menu keeps actionable choices visible as rows compact" {
-    const full_projection: AppearanceMenuProjection = .{
-        .active = true,
-        .selected_index = 0,
-        .snapshot = .{ .input_appearance = "lines", .maxxing_mode = "normal" },
-    };
-    try expectMenuContains(full_projection, 9, "Lines");
-    try expectMenuContains(full_projection, 9, "Tint");
-    try expectMenuContains(full_projection, 9, "Normal");
-    try expectMenuContains(full_projection, 9, "Minimal");
-
-    const selected_section: AppearanceMenuProjection = .{
-        .active = true,
-        .selected_index = 2,
-        .snapshot = full_projection.snapshot,
-    };
-    try expectMenuContains(selected_section, 3, "Normal");
-    try expectMenuContains(selected_section, 3, "Minimal");
-}
-
-fn expectMenuContains(
-    projection: AppearanceMenuProjection,
-    visible_rows: u16,
-    expected: []const u8,
-) !void {
-    var row_index: u16 = 0;
-    while (row_index < visible_rows) : (row_index += 1) {
-        var row = try composeAppearanceMenuRow(
-            std.testing.allocator,
-            projection,
-            row_index,
-            visible_rows,
-            60,
-        );
-        defer row.deinit(std.testing.allocator);
-        if (std.mem.find(u8, row.items, expected) != null) return;
-    }
-    return error.TestExpectedText;
 }

--- a/src/ui/footer/compact_command_menu_presentation.zig
+++ b/src/ui/footer/compact_command_menu_presentation.zig
@@ -13,7 +13,6 @@ const ui_render = @import("../render.zig");
 const Allocator = std.mem.Allocator;
 const CompactCommandMenuProjection = render_input.CompactCommandMenuProjection;
 
-const settings_label_column: usize = 16;
 const usage_value_column: usize = 20;
 const workspace_summary_value_column: usize = 30;
 const workspace_pinned_rows: usize = 5;
@@ -22,15 +21,15 @@ const settings_row_offset: usize = 2;
 
 const ChoiceView = struct {
     label: []const u8,
-    description: []const u8,
+    setting: settings_catalog.SettingId,
+    snapshot: settings_catalog.Snapshot,
     selected: bool,
-    current: bool,
 };
 
 pub fn desiredRowCount(projection: CompactCommandMenuProjection) u16 {
     const count: usize = switch (projection) {
         .statusline => settings_row_offset + settings_catalog.statuslineChoiceCount(),
-        .sandbox => settings_row_offset + settings_catalog.sandboxChoiceCount(),
+        .sandbox => settings_row_offset + 1,
         .usage => |usage| usageDesiredRowCount(usage),
         .workspace => |workspace| workspace_pinned_rows +
             workspace_menu.State.rowCount(workspace.entries),
@@ -71,8 +70,8 @@ fn composeSettingsRow(
 
 fn title(projection: CompactCommandMenuProjection) []const u8 {
     return switch (projection) {
-        .statusline => "Status line:",
-        .sandbox => "Sandbox:",
+        .statusline => "Status line",
+        .sandbox => "Sandbox",
         .usage => "Usage:",
         .workspace => "Workspace:",
     };
@@ -84,21 +83,18 @@ fn choiceView(projection: CompactCommandMenuProjection, choice_index: usize) ?Ch
             const choice = settings_catalog.statuslineChoiceAt(choice_index) orelse return null;
             return .{
                 .label = choice.label,
-                .description = choice.description,
+                .setting = choice.setting,
+                .snapshot = statusline.snapshot,
                 .selected = choice_index == statusline.selected_index % settings_catalog.statuslineChoiceCount(),
-                .current = choice.isEnabled(statusline.snapshot),
             };
         },
         .sandbox => |sandbox| {
-            const choice = settings_catalog.sandboxChoiceAt(choice_index) orelse return null;
+            if (choice_index != 0) return null;
             return .{
-                .label = choice.label,
-                .description = if (choice_index == 0 and !sandbox.os_sandbox_available)
-                    "Unavailable on this system"
-                else
-                    choice.description,
-                .selected = choice_index == sandbox.selected_index % settings_catalog.sandboxChoiceCount(),
-                .current = choice.isCurrent(sandbox.snapshot),
+                .label = settings_catalog.specFor(.sandbox).label,
+                .setting = .sandbox,
+                .snapshot = sandbox.snapshot,
+                .selected = true,
             };
         },
         .usage, .workspace => null,
@@ -745,27 +741,59 @@ fn composeChoiceRow(
 ) !std.ArrayList(u8) {
     var row: std.ArrayList(u8) = .empty;
     errdefer row.deinit(alloc);
-
-    try row.appendSlice(alloc, if (choice.selected) ui_render.system_notice_label_style else ui_render.dim_style);
-    try row_text.appendClipped(alloc, &row, if (choice.selected) "❯ " else "  ", width);
-    var label_buf: [64]u8 = undefined;
-    const label = if (choice.current)
-        std.fmt.bufPrint(&label_buf, "{s} ✓", .{choice.label}) catch choice.label
+    const indent: usize = if (width <= 2) 0 else 2;
+    if (indent > 0) try row.appendSlice(alloc, "  ");
+    try row.appendSlice(alloc, if (choice.selected) ui_render.selected_completion_style else ui_render.dim_style);
+    const value_col = settingsValueColumn(choice.snapshot, choice.setting, width);
+    const description_col: usize = if (choice.setting == .sandbox and width >= 48)
+        @max(@as(usize, width) / 3, indent + 18)
     else
-        choice.label;
-    const prefix_used = display_width.visibleWidthIgnoringAnsi(row.items);
-    try row_text.appendSingleLineEllipsized(alloc, &row, label, @as(usize, width) -| prefix_used);
+        value_col;
+    try row_text.appendSingleLineEllipsized(alloc, &row, choice.label, description_col -| indent -| 2);
     try row.appendSlice(alloc, ui_render.reset_style);
+    if (description_col < value_col) {
+        try row_text.appendSpacesToColumn(alloc, &row, description_col);
+        try row.appendSlice(alloc, ui_render.dim_style);
+        try row_text.appendSingleLineEllipsized(
+            alloc,
+            &row,
+            settings_catalog.specFor(.sandbox).description,
+            value_col - description_col -| 2,
+        );
+        try row.appendSlice(alloc, ui_render.reset_style);
+    }
+    try row_text.appendSpacesToColumn(alloc, &row, value_col);
 
-    const used = display_width.visibleWidthIgnoringAnsi(row.items);
-    const total_width: usize = width;
-    if (used >= total_width or total_width < settings_label_column + 8) return row;
-    const description_col = @max(settings_label_column, used + 2);
-    try row.appendNTimes(alloc, ' ', description_col - used);
-    try row.appendSlice(alloc, ui_render.dim_style);
-    try row_text.appendSingleLineEllipsized(alloc, &row, choice.description, total_width - description_col);
-    try row.appendSlice(alloc, ui_render.reset_style);
+    const option_count = settings_catalog.optionCount(&choice.snapshot, choice.setting);
+    var option_index: usize = 0;
+    while (option_index < option_count) : (option_index += 1) {
+        const before_option = display_width.visibleWidthIgnoringAnsi(row.items);
+        if (before_option >= width) break;
+        if (option_index > 0) try row.appendNTimes(alloc, ' ', @min(@as(usize, 2), @as(usize, width) - before_option));
+        const option = settings_catalog.optionAt(&choice.snapshot, choice.setting, option_index) orelse continue;
+        const current = std.ascii.eqlIgnoreCase(option, choice.snapshot.value(choice.setting));
+        try row.appendSlice(alloc, if (current) ui_render.selected_completion_style else ui_render.dim_style);
+        const used = display_width.visibleWidthIgnoringAnsi(row.items);
+        try row_text.appendSingleLineEllipsized(alloc, &row, option, @as(usize, width) -| used);
+        try row.appendSlice(alloc, ui_render.reset_style);
+        if (display_width.visibleWidthIgnoringAnsi(row.items) >= width) break;
+    }
     return row;
+}
+
+fn settingsValueColumn(snapshot: settings_catalog.Snapshot, setting: settings_catalog.SettingId, width: u16) usize {
+    const total_width: usize = width;
+    const right_column_start = total_width * 2 / 3;
+    const right_column_width = total_width - right_column_start;
+    var options_width: usize = 0;
+    const option_count = settings_catalog.optionCount(&snapshot, setting);
+    for (0..option_count) |index| {
+        if (index > 0) options_width += 2;
+        const option = settings_catalog.optionAt(&snapshot, setting, index) orelse continue;
+        options_width += display_width.visibleWidth(option);
+    }
+    const block_width = @min(options_width, right_column_width);
+    return right_column_start + (right_column_width - block_width) / 2;
 }
 
 fn formatDuration(buf: anytype, duration_ms: u64) []const u8 {
@@ -802,23 +830,27 @@ test "compact status line menu renders toggled items without choose copy" {
 
     var header = try composeCompactCommandMenuRow(std.testing.allocator, projection, 0, rows, 80);
     defer header.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, header.items, "Status line:") != null);
+    try std.testing.expect(std.mem.find(u8, header.items, "Status line") != null);
     try std.testing.expect(std.mem.find(u8, header.items, "Choose") == null);
 
     var sandbox = try composeCompactCommandMenuRow(std.testing.allocator, projection, 2, rows, 80);
     defer sandbox.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, sandbox.items, "❯ Sandbox ✓") != null);
+    try std.testing.expect(std.mem.find(u8, sandbox.items, "Sandbox") != null);
+    try std.testing.expect(std.mem.find(u8, sandbox.items, "on") != null);
+    try std.testing.expect(std.mem.find(u8, sandbox.items, "❯") == null);
 
     var context = try composeCompactCommandMenuRow(std.testing.allocator, projection, 3, rows, 80);
     defer context.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, context.items, "Context ✓") == null);
+    try std.testing.expect(std.mem.find(u8, context.items, "Context") != null);
+    try std.testing.expect(std.mem.find(u8, context.items, "off") != null);
 
     var session = try composeCompactCommandMenuRow(std.testing.allocator, projection, 4, rows, 80);
     defer session.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, session.items, "Session ✓") != null);
+    try std.testing.expect(std.mem.find(u8, session.items, "Session") != null);
+    try std.testing.expect(std.mem.find(u8, session.items, "on") != null);
 }
 
-test "compact sandbox menu renders availability and current mode" {
+test "compact sandbox menu renders settings columns without markers" {
     const projection: CompactCommandMenuProjection = .{ .sandbox = .{
         .active = true,
         .selected_index = 0,
@@ -826,14 +858,14 @@ test "compact sandbox menu renders availability and current mode" {
         .os_sandbox_available = false,
     } };
 
-    var os = try composeCompactCommandMenuRow(std.testing.allocator, projection, 2, 4, 80);
-    defer os.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, os.items, "❯ OS sandbox") != null);
-    try std.testing.expect(std.mem.find(u8, os.items, "Unavailable on this system") != null);
-
-    var none = try composeCompactCommandMenuRow(std.testing.allocator, projection, 3, 4, 80);
-    defer none.deinit(std.testing.allocator);
-    try std.testing.expect(std.mem.find(u8, none.items, "None ✓") != null);
+    var row = try composeCompactCommandMenuRow(std.testing.allocator, projection, 2, 3, 100);
+    defer row.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.find(u8, row.items, "Command sandbox") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "Choose command process isolation") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "os") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "none") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "❯") == null);
+    try std.testing.expect(std.mem.find(u8, row.items, "✓") == null);
 }
 
 test "usage menu renders token-first totals and selectable model rows" {

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -490,11 +490,11 @@ pub fn composeSettingsMenuHintRow(
 
 pub fn composeAppearanceMenuHintRow(alloc: Allocator, width: u16) !std.ArrayList(u8) {
     const variants = [_][]const u8{
-        "↑↓ Navigate     Tab Section     Enter Apply     Esc Close",
-        "↑↓ Navigate  Tab Section  Enter Apply  Esc Close",
-        "↑↓ Move  Tab Section  Enter Apply  Esc",
-        "Enter Apply  Esc Close",
-        "Enter Esc",
+        "↑↓ Navigate     ←→ Change     Tab Section     Esc Close",
+        "↑↓ Navigate  ←→ Change  Tab Section  Esc Close",
+        "↑↓ Move  ←→ Change  Tab  Esc",
+        "←→ Change  Esc Close",
+        "←→ Esc",
     };
     var hint = variants[variants.len - 1];
     for (variants) |candidate| {
@@ -519,14 +519,14 @@ pub fn composeCompactCommandMenuHintRow(
 ) !std.ArrayList(u8) {
     const variants = switch (menu) {
         .statusline => [_][]const u8{
-            "↑↓ Navigate     Enter Toggle     Esc Close",
-            "↑↓ Move  Enter Toggle  Esc",
-            "Enter Esc",
+            "",
+            "",
+            "",
         },
         .sandbox => [_][]const u8{
-            "↑↓ Navigate     Enter Apply     Esc Close",
-            "↑↓ Move  Enter Apply  Esc",
-            "Enter Esc",
+            "↑↓ Navigate     ←→ Change     Esc Close",
+            "↑↓ Move  ←→ Change  Esc",
+            "←→ Esc",
         },
         .usage => [_][]const u8{
             "←→ Scope     ↑↓ Model     Enter Expand     R Refresh     Esc Close",

--- a/src/ui/footer/model_menu_presentation.zig
+++ b/src/ui/footer/model_menu_presentation.zig
@@ -12,15 +12,14 @@ const ModelMenuProjection = render_input.ModelMenuProjection;
 
 const header_rows: u16 = 1;
 const roomy_top_gap_rows: u16 = 1;
-const title_rows: u16 = 1;
-const item_gap_rows: u16 = 1;
+const item_rows: u16 = 1;
 
 const ModelMenuLayout = struct {
     match_count: usize = 0,
     selected: usize = 0,
     visible_items: u16 = 0,
     first_item_row: u16 = header_rows,
-    item_stride: u16 = title_rows,
+    item_stride: u16 = item_rows,
     row_count: u16 = 0,
 
     fn build(projection: ModelMenuProjection, row_budget: u16) ModelMenuLayout {
@@ -52,16 +51,15 @@ const ModelMenuLayout = struct {
             };
         }
         const first_item_row = header_rows + roomy_top_gap_rows;
-        const item_stride = title_rows + item_gap_rows;
-        const item_budget = (row_budget - first_item_row +| item_gap_rows) / item_stride;
+        const item_budget = row_budget - first_item_row;
         const visible_items: u16 = @intCast(@min(match_count, @max(item_budget, 1)));
         return .{
             .match_count = match_count,
             .selected = selected,
             .visible_items = visible_items,
             .first_item_row = first_item_row,
-            .item_stride = item_stride,
-            .row_count = first_item_row + visible_items * item_stride - item_gap_rows,
+            .item_stride = item_rows,
+            .row_count = first_item_row + visible_items,
         };
     }
 };
@@ -229,13 +227,13 @@ fn providerRangeWidth(
 }
 
 fn modelFactsColumn(projection: ModelMenuProjection, width: u16) ?usize {
-    const prefix_width: usize = if (width <= 4) 2 else 4;
-    const content_width = @as(usize, width) -| 2;
+    const indent_width: usize = if (width <= 2) 0 else 2;
+    const content_width: usize = width;
     var facts_width: usize = 0;
     for (projection.items) |item| {
         facts_width = @max(facts_width, compactFactsWidth(item.capabilities));
     }
-    if (facts_width == 0 or content_width < prefix_width + 8 + 2 + facts_width) return null;
+    if (facts_width == 0 or content_width < indent_width + 8 + 2 + facts_width) return null;
     return content_width - facts_width;
 }
 
@@ -248,21 +246,19 @@ fn composeTitleRow(
 ) !std.ArrayList(u8) {
     var row: std.ArrayList(u8) = .empty;
     errdefer row.deinit(alloc);
-    const indent_width: u16 = if (width <= 4) 0 else 2;
+    const indent_width: u16 = if (width <= 2) 0 else 2;
     if (indent_width > 0) try row.appendSlice(alloc, "  ");
-    try row.appendSlice(alloc, if (selected) ui_render.tag_style else ui_render.dim_style);
-    try row_text.appendClipped(alloc, &row, if (selected) "● " else "○ ", width -| indent_width);
-    if (!selected) try row.appendSlice(alloc, ui_render.reset_style);
+    try row.appendSlice(alloc, if (selected) ui_render.selected_completion_style else ui_render.dim_style);
 
     var facts: std.ArrayList(u8) = .empty;
     defer facts.deinit(alloc);
     try appendCompactFacts(alloc, &facts, item.capabilities);
 
     const prefix_width = display_width.visibleWidthIgnoringAnsi(row.items);
-    const content_width = @as(usize, width) -| 2;
+    const content_width = @as(usize, width);
     const facts_start = facts_column orelse content_width;
     const show_facts = facts.items.len > 0 and facts_start >= prefix_width + 8 + 2;
-    const id_budget = if (show_facts) facts_start - prefix_width - 2 else @as(usize, width) -| prefix_width;
+    const id_budget = if (show_facts) facts_start - prefix_width - 2 else content_width -| prefix_width;
     try row_text.appendSingleLineMiddleEllipsized(alloc, &row, item.id, id_budget);
     if (selected) try row.appendSlice(alloc, ui_render.reset_style);
 
@@ -337,7 +333,6 @@ fn composeStateRow(alloc: Allocator, projection: ModelMenuProjection, width: u16
 
 fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]const u8 {
     if (retryableFailureText(state.failure)) |text| return text;
-    if (state.access_level == .authenticated) return "Authenticated model catalog loaded.";
     if (state.private_models_hidden) {
         const reason = state.public_only_reason orelse return "Using the public model catalog.";
         return switch (reason) {
@@ -407,7 +402,7 @@ test "model menu renders provider tabs and compact model facts" {
         .items = &items,
     };
     const rows = menuRowCount(projection, 120, 20);
-    try std.testing.expectEqual(@as(u16, 5), rows);
+    try std.testing.expectEqual(@as(u16, 4), rows);
 
     var header = try composeModelMenuRow(alloc, projection, 0, 120, rows);
     defer header.deinit(alloc);
@@ -417,7 +412,9 @@ test "model menu renders provider tabs and compact model facts" {
 
     var title = try composeModelMenuRow(alloc, projection, 2, 120, rows);
     defer title.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, title.items, "● anthropic/claude-opus-4.8") != null);
+    try std.testing.expect(std.mem.find(u8, title.items, "anthropic/claude-opus-4.8") != null);
+    try std.testing.expect(std.mem.find(u8, title.items, "●") == null);
+    try std.testing.expect(std.mem.find(u8, title.items, "○") == null);
     try std.testing.expect(std.mem.find(u8, title.items, "1M context · 128K output · Fast") != null);
     try std.testing.expect(std.mem.find(u8, title.items, "Anthropic") == null);
     try std.testing.expect(std.mem.find(u8, title.items, "Current") == null);
@@ -509,6 +506,8 @@ test "model menu states and navigation budget stay bounded" {
 }
 
 test "model menu status follows provenance and retryable failure precedence" {
+    try std.testing.expect(loadedCatalogStatusText(.{ .access_level = .authenticated }) == null);
+
     const cases = [_]struct {
         state: model_cache_runtime.ModelMenuCatalogState,
         expected: []const u8,
@@ -517,7 +516,6 @@ test "model menu status follows provenance and retryable failure precedence" {
         .{ .state = .{ .public_only_reason = .fx_login_team_required, .private_models_hidden = true }, .expected = "Choose a Vercel team to load its private models." },
         .{ .state = .{ .public_only_reason = .fx_login_refresh_required, .private_models_hidden = true }, .expected = "Vercel sign-in must refresh before team-private models can load." },
         .{ .state = .{ .public_only_reason = .credential_refresh_failed, .private_models_hidden = true }, .expected = "Vercel sign-in refresh failed; using the public model catalog." },
-        .{ .state = .{ .access_level = .authenticated }, .expected = "Authenticated model catalog loaded." },
         .{ .state = .{ .public_only_reason = .authenticated_credential_rejected, .private_models_hidden = true }, .expected = "Your Gateway credential was rejected; using the public model catalog." },
         .{ .state = .{ .failure = .{ .category = .transport, .retryable = true } }, .expected = "Could not reach AI Gateway; retry /models." },
         .{ .state = .{ .access_level = .public_only, .public_only_reason = .no_credential, .private_models_hidden = true, .failure = .{ .category = .rate_limited, .retryable = true } }, .expected = "AI Gateway rate limited model discovery; retry /models." },
@@ -594,7 +592,7 @@ test "model menu facts share a left-aligned column" {
 
     var first = try composeModelMenuRow(alloc, projection, 2, 80, rows);
     defer first.deinit(alloc);
-    var second = try composeModelMenuRow(alloc, projection, 4, 80, rows);
+    var second = try composeModelMenuRow(alloc, projection, 3, 80, rows);
     defer second.deinit(alloc);
 
     const first_label = std.mem.find(u8, first.items, "1M context").?;

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -956,7 +956,16 @@ pub fn composeFooterFrame(
     else if (appearance_active)
         try input_presentation.composeAppearanceMenuHintRow(alloc, shell.layout.cols)
     else if (compact_command_menu) |menu|
-        try input_presentation.composeCompactCommandMenuHintRow(alloc, shell.layout.cols, menu)
+        switch (menu) {
+            .statusline => try input_presentation.composeHintRow(
+                alloc,
+                false,
+                input.active_label,
+                ctx,
+                shell.layout.cols,
+            ),
+            else => try input_presentation.composeCompactCommandMenuHintRow(alloc, shell.layout.cols, menu),
+        }
     else if (input.show_picker and input.picker_kind == .slash and input.slash_menu_layout != null)
         try input_presentation.composeSlashMenuHintRow(alloc, shell.layout.cols)
     else blk: {

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -143,9 +143,9 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         });
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendText("/appearance");
-        await session.waitForText("Appearance · Choose one", TIMEOUT);
-        expect(await session.capturePane()).toContain("Tint ✓");
-        expect(await session.capturePane()).toContain("Minimal ✓");
+        await session.waitForText("Input appearance", TIMEOUT);
+        expect(await session.capturePane()).toContain("lines  tint");
+        expect(await session.capturePane()).toContain("minimal  legacy");
         await session.sendKeys("Escape");
         await session.waitForComposer(TIMEOUT);
         await session.sendText("/appearance input lines");
@@ -167,9 +167,9 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         });
         await secondSession.waitForText("Run /help", TIMEOUT);
         await secondSession.sendText("/appearance");
-        await secondSession.waitForText("Appearance · Choose one", TIMEOUT);
-        expect(await secondSession.capturePane()).toContain("Lines ✓");
-        expect(await secondSession.capturePane()).toContain("Normal ✓");
+        await secondSession.waitForText("Input appearance", TIMEOUT);
+        expect(await secondSession.capturePane()).toContain("lines  tint");
+        expect(await secondSession.capturePane()).toContain("minimal  legacy");
         await secondSession.sendKeys("Escape");
         await secondSession.waitForComposer(TIMEOUT);
         await secondSession.sendText("/appearance input tint");
@@ -366,11 +366,12 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
           TIMEOUT,
         );
         await session.sendText("/statusline");
-        const statusline = await session.waitForText("Enter Toggle", TIMEOUT);
-        expect(statusline).toContain("Status line:");
-        expect(statusline).toContain("Sandbox ✓");
-        expect(statusline).toContain("Context ✓");
-        expect(statusline).toContain("Session ✓");
+        const statusline = await session.waitForText("Sandbox  ", TIMEOUT);
+        expect(statusline).toContain("Status line");
+        expect(statusline).toContain("Sandbox");
+        expect(statusline).toContain("Context");
+        expect(statusline).toContain("Session");
+        expect(statusline).toContain("off  on");
         await session.sendKeys("Escape");
         await session.waitForComposer(TIMEOUT);
         await session.sendText("/quit");
@@ -464,9 +465,11 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         });
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendText("/sandbox");
-        const sandbox = await session.waitForText("Enter Apply", TIMEOUT);
-        expect(sandbox).toContain("Sandbox:");
-        expect(sandbox).toContain("None ✓");
+        const sandbox = await session.waitForText("←→ Change", TIMEOUT);
+        expect(sandbox).toContain("Sandbox");
+        expect(sandbox).toContain("Command sandbox");
+        expect(sandbox).toContain("os  none");
+        expect(sandbox).not.toContain("✓");
         await session.sendKeys("Escape");
         await session.waitForComposer(TIMEOUT);
         await session.sendText("/allowlist view local");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -857,7 +857,7 @@ tmuxTest(
     await session.waitForPane(
       (pane) =>
         pane.includes("private/blue-hornbill") &&
-        pane.includes("Authenticated model catalog loaded."),
+        !pane.includes("Authenticated model catalog loaded."),
       TIMEOUT,
     );
 
@@ -1527,7 +1527,7 @@ tmuxTest(
     await session.waitForPane(
       (pane) =>
         pane.includes("private/blue-hornbill") &&
-        pane.includes("Authenticated model catalog loaded."),
+        !pane.includes("Authenticated model catalog loaded."),
       TIMEOUT,
     );
     const refreshedCatalogRequest = gateway.modelRequests[1];

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -5991,8 +5991,9 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendText("/maxxing");
       await session.waitForPane(
         (pane) =>
-          pane.includes("Appearance · Choose one") &&
-          pane.includes("Minimal ✓"),
+          pane.includes("Appearance") &&
+          pane.includes("Maxxing mode") &&
+          pane.includes("minimal  legacy"),
         TIMEOUT,
       );
       await session.sendKeys("Escape");
@@ -6119,8 +6120,9 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendText("/maxxing");
       await session.waitForPane(
         (pane) =>
-          pane.includes("Appearance · Choose one") &&
-          pane.includes("Minimal ✓"),
+          pane.includes("Appearance") &&
+          pane.includes("Maxxing mode") &&
+          pane.includes("minimal  legacy"),
         TIMEOUT,
       );
       await session.sendKeys("Escape");
@@ -6221,8 +6223,9 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendText("/maxxing");
       await session.waitForPane(
         (pane) =>
-          pane.includes("Appearance · Choose one") &&
-          pane.includes("Minimal ✓"),
+          pane.includes("Appearance") &&
+          pane.includes("Maxxing mode") &&
+          pane.includes("minimal  legacy"),
         TIMEOUT,
       );
       await session.sendKeys("Escape");

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -1594,8 +1594,9 @@ tmuxTest(
     await active.sendText("/input");
     await active.waitForPane(
       (pane) =>
-        pane.includes("Appearance · Choose one") &&
-        pane.includes("Tint ✓"),
+        pane.includes("Appearance") &&
+        pane.includes("Input appearance") &&
+        pane.includes("lines  tint"),
       READY_TIMEOUT,
     );
     await active.sendKeys("Escape");

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -2469,16 +2469,15 @@ describe.skipIf(SKIP)("tui: resize", () => {
       label: "statusline",
       width: 72,
       height: 16,
-      surfaceMarker: "Status line:",
+      surfaceMarker: "Status line",
       editedInput: "x",
       async openSurface(active) {
         await active.sendText("/statusline");
-        await active.waitForText("Status line:", TIMEOUT);
-        await active.sendKeys("Enter");
-        await active.waitForText("sandbox: on", TIMEOUT);
+        await active.waitForText("Status line", TIMEOUT);
+        await active.sendKeys("Right");
+        await active.waitForText("sandbox:none", TIMEOUT);
         await active.sendKeys("Down");
-        await active.sendKeys("Enter");
-        await active.waitForText("context: on", TIMEOUT);
+        await active.sendKeys("Right");
       },
     },
     {
@@ -2486,13 +2485,13 @@ describe.skipIf(SKIP)("tui: resize", () => {
       label: "appearance",
       width: 72,
       height: 16,
-      surfaceMarker: "Appearance · Choose one",
+      surfaceMarker: "Appearance",
       editedInput: "x",
       async openSurface(active) {
         await active.sendText("/appearance");
-        await active.waitForText("Appearance · Choose one", TIMEOUT);
-        await active.sendKeys("Enter");
-        await active.waitForText("Input: switched to lines", TIMEOUT);
+        await active.waitForText("Input appearance", TIMEOUT);
+        await active.sendKeys("Right");
+        await active.waitForText("lines  tint", TIMEOUT);
       },
     },
     {
@@ -2513,11 +2512,11 @@ describe.skipIf(SKIP)("tui: resize", () => {
       label: "sandbox",
       width: 120,
       height: 36,
-      surfaceMarker: "Sandbox:",
+      surfaceMarker: "Command sandbox",
       editedInput: "x",
       async openSurface(active) {
         await active.sendText("/sandbox");
-        await active.waitForText("Sandbox:", TIMEOUT);
+        await active.waitForText("Command sandbox", TIMEOUT);
         await active.resizeWindow(60, 12, 500);
       },
     },

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -156,7 +156,7 @@ async function waitForAppearanceMenu(
     latest = await session.capturePaneGrid();
     const pane = latest.join("\n");
     if (
-      pane.includes("Appearance · Choose one") &&
+      pane.includes("Appearance") &&
       (expectedSelection === undefined || pane.includes(expectedSelection))
     ) return latest;
     await Bun.sleep(100);
@@ -174,8 +174,9 @@ async function waitForStatuslineMenu(
     latest = await session.capturePaneGrid();
     const pane = latest.join("\n");
     if (
-      pane.includes("Status line:") &&
-      pane.includes("Enter Toggle") &&
+      pane.includes("Status line") &&
+      !pane.includes("↑↓ Navigate") &&
+      !pane.includes("←→ Change") &&
       (expectedSelection === undefined || pane.includes(expectedSelection))
     ) return latest;
     await Bun.sleep(100);
@@ -189,7 +190,7 @@ async function waitForSandboxMenu(session: TmuxSession): Promise<string[]> {
   while (Date.now() < deadline) {
     latest = await session.capturePaneGrid();
     const pane = latest.join("\n");
-    if (pane.includes("Sandbox:") && pane.includes("Enter Apply")) return latest;
+    if (pane.includes("Sandbox") && pane.includes("←→ Change")) return latest;
     await Bun.sleep(100);
   }
   throw new Error(`Timed out waiting for sandbox menu.\nPane:\n${latest.join("\n")}`);
@@ -1270,26 +1271,27 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       let grid = await waitForAppearanceMenu(session);
       let pane = grid.join("\n");
       expect(pane).toContain("𝒇x");
-      expect(pane).toContain("INPUT STYLE");
-      expect(pane).toContain("PRESENTATION");
-      expect(pane).toContain("❯ Lines");
-      expect(pane).toContain("Tint ✓");
-      expect(pane).toContain("Minimal ✓");
+      expect(pane).toContain("Input appearance");
+      expect(pane).toContain("Maxxing mode");
+      expect(pane).toContain("lines  tint");
+      expect(pane).toContain("minimal  legacy");
+      expect(pane).not.toContain("❯");
+      expect(pane).not.toContain("✓");
       expect(pane).toContain("Tab Section");
-      expect(pane).toContain("Enter Apply");
+      expect(pane).toContain("←→ Change");
 
-      await session.sendKeys("Enter");
-      grid = await waitForAppearanceMenu(session, "Lines ✓");
+      await session.sendKeys("Right");
+      grid = await waitForAppearanceMenu(session, "lines  tint");
       pane = grid.join("\n");
-      expect(pane).toContain("Lines ✓");
+      expect(pane).not.toContain("✓");
       expect(JSON.parse(readFileSync(settingsPath, "utf8")).input_appearance).toBe("lines");
 
       await session.sendKeys("Tab");
-      await session.waitForText("❯ Normal", 5_000);
-      await session.sendKeys("Enter");
-      grid = await waitForAppearanceMenu(session, "Normal ✓");
+      await session.waitForText("minimal  legacy", 5_000);
+      await session.sendKeys("Right");
+      grid = await waitForAppearanceMenu(session, "minimal  legacy");
       pane = grid.join("\n");
-      expect(pane).toContain("Normal ✓");
+      expect(pane).not.toContain("✓");
       expect(JSON.parse(readFileSync(settingsPath, "utf8")).maxxing_mode).toBe("legacy");
 
       await session.sendKeys("Escape");
@@ -1358,17 +1360,15 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       await session.resizeWindow(60, 12, 500);
       await session.sendText("/appearance");
-      pane = await session.waitForText("Appearance · Choose one", 5_000);
-      expect(pane).toContain("Lines");
-      expect(pane).toContain("Tint");
-      expect(pane).toContain("Normal");
-      expect(pane).toContain("Minimal");
+      pane = await session.waitForText("Appearance", 5_000);
+      expect(pane).toContain("Input appearance");
+      expect(pane).toContain("lines  tint");
+      expect(pane).toContain("Maxxing mode");
+      expect(pane).toContain("minimal  legacy");
 
       await session.sendKeys("Escape");
       await session.waitForPane(
-        (current) =>
-          hasEmptyComposer(current) &&
-          !current.includes("Appearance · Choose one"),
+        (current) => hasEmptyComposer(current) && !current.includes("←→ Change"),
         5_000,
       );
       await session.sendText("/quit");
@@ -1411,22 +1411,26 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendText("/statusline");
       let grid = await waitForStatuslineMenu(session);
       let pane = grid.join("\n");
-      expect(pane).toContain("❯ Sandbox");
+      expect(pane).toContain("Sandbox");
       expect(pane).toContain("Context");
+      expect(pane).toContain("off  on");
+      expect(pane).not.toContain("❯");
       expect(pane).not.toContain("Choose what appears");
-      expect(pane).toContain("Enter Toggle");
+      expect(pane).not.toContain("↑↓ Navigate");
+      expect(pane).not.toContain("←→ Change");
 
-      await session.sendKeys("Enter");
-      grid = await waitForStatuslineMenu(session, "Sandbox ✓");
+      await session.sendKeys("Right");
+      grid = await waitForStatuslineMenu(session, "off  on");
       pane = grid.join("\n");
-      expect(pane).toContain("Sandbox ✓");
+      expect(JSON.parse(readFileSync(settingsPath, "utf8")).statusLine.sandbox).toBe(true);
       expect(JSON.parse(readFileSync(settingsPath, "utf8")).statusLine.sandbox).toBe(true);
 
       await session.sendKeys("Down");
-      await session.sendKeys("Enter");
-      grid = await waitForStatuslineMenu(session, "Context ✓");
+      await session.sendKeys("Right");
+      grid = await waitForStatuslineMenu(session, "Context");
       pane = grid.join("\n");
-      expect(pane).toContain("Context ✓");
+      expect(pane).not.toContain("saved to user settings");
+      expect(pane).not.toContain("● Statusline:");
       expect(JSON.parse(readFileSync(settingsPath, "utf8")).statusLine.context).toBe(true);
 
       await session.sendKeys("Escape");
@@ -1434,7 +1438,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         (current) =>
           hasEmptyComposer(current) &&
           current.includes("𝒇x") &&
-          !current.includes("Enter Toggle"),
+          !current.includes("←→ Change"),
         5_000,
       );
       expect(session.isAlive()).toBe(true);
@@ -1474,16 +1478,22 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendText("/sandbox");
       let grid = await waitForSandboxMenu(session);
       let pane = grid.join("\n");
-      expect(pane).toContain("❯ OS sandbox");
-      expect(pane).toContain("None ✓");
+      expect(pane).toContain("Command sandbox");
+      expect(pane).toContain("Choose command process isolation");
+      expect(pane).toContain("os  none");
+      expect(pane).not.toContain("✓");
+      expect(pane).not.toContain("❯");
       expect(pane).not.toContain("Choose one");
-      expect(pane).toContain("Enter Apply");
+      expect(pane).toContain("←→ Change");
 
       await session.sendKeys("Down");
-      await session.sendKeys("Enter");
+      await session.sendKeys("Right");
       grid = await waitForSandboxMenu(session);
       pane = grid.join("\n");
-      expect(pane).toContain("❯ None ✓");
+      expect(pane).toContain("Command sandbox");
+      expect(pane).toContain("os  none");
+      expect(pane).not.toContain("✓");
+      expect(pane).not.toContain("❯");
       expect(JSON.parse(readFileSync(settingsPath, "utf8")).sandbox).toBe("none");
 
       await session.sendKeys("Escape");
@@ -1491,7 +1501,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         (current) =>
           hasEmptyComposer(current) &&
           current.includes("𝒇x") &&
-          !current.includes("Enter Apply"),
+          !current.includes("←→ Change"),
         5_000,
       );
       expect(session.isAlive()).toBe(true);
@@ -2400,7 +2410,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).toContain("[All]");
       expect(pane).toContain(currentModel);
       expect(pane).toContain("1M context · 32K output · Fast");
-      expect(pane).toContain("Authenticated model catalog loaded.");
+      expect(pane).not.toContain("Authenticated model catalog loaded.");
       expect(pane).not.toContain("Current");
       expect(pane).not.toContain("Reasoning");
       expect(pane).toContain("↑↓ Navigate");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -1281,6 +1281,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).toContain("←→ Change");
 
       await session.sendKeys("Right");
+      await waitForSettingValue(settingsPath, "input_appearance", "lines");
       grid = await waitForAppearanceMenu(session, "lines  tint");
       pane = grid.join("\n");
       expect(pane).not.toContain("✓");
@@ -1289,6 +1290,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("Tab");
       await session.waitForText("minimal  legacy", 5_000);
       await session.sendKeys("Right");
+      await waitForSettingValue(settingsPath, "maxxing_mode", "legacy");
       grid = await waitForAppearanceMenu(session, "minimal  legacy");
       pane = grid.join("\n");
       expect(pane).not.toContain("✓");

--- a/tests/e2e/yolo-permission-mode.test.ts
+++ b/tests/e2e/yolo-permission-mode.test.ts
@@ -218,8 +218,8 @@ describe.skipIf(!tmuxAvailable())("yolo interactive mode", () => {
       expect(resumedWarning).toContain("YOLO ·");
 
       await session.sendText("/sandbox");
-      const sandboxPane = await session.waitForText("Enter Apply", TIMEOUT);
-      expect(sandboxPane).toContain("Sandbox:");
+      const sandboxPane = await session.waitForText("←→ Change", TIMEOUT);
+      expect(sandboxPane).toContain("Command sandbox");
       expect(sandboxPane).not.toContain(WARNING);
       await Bun.sleep(4_300);
 


### PR DESCRIPTION
## Summary

- align `/appearance`, `/statusline`, and `/sandbox` with the compact inline settings layout
- show the live status line while editing `/statusline`
- add concise sandbox context and simplify model catalog presentation
- apply inline changes without adding confirmation messages to the transcript

## Testing

- `PATH="$HOME/.local/bin:$PATH" zig fmt --check src/`
- `PATH="$HOME/.local/bin:$PATH" zig build`
- `PATH="$HOME/.local/bin:$PATH" zig build test`
- `cd tests/e2e && bun test tui-slash-menu.test.ts`
- `cd tests/e2e && bun test config-persistence.test.ts`
- `cd tests/e2e && bun test tui-resize.test.ts`
- `cd tests/e2e && bun test yolo-permission-mode.test.ts`
