### PR TITLE
Record slash commands in prompt history

### DIFF
--- a/sdk/node/test-term-history.mjs
+++ b/sdk/node/test-term-history.mjs
@@ -81,14 +81,16 @@ await waitFor(
 );
 const restoreError = second.events.find((event) => event.type === "history.restore_error");
 if (restoreError) throw restoreError.error;
-if (!second.events.some((event) => event.type === "history.restore" && event.count === 1)) {
-  throw new Error("second terminal did not restore one host prompt history entry");
+if (!second.events.some((event) => event.type === "history.restore" && event.count === 2)) {
+  throw new Error("second terminal did not restore the host prompt and slash command history entries");
 }
 second.runtime.write("\x1b[A");
-await waitFor(second.terminal, () => grid(second.terminal).includes("remember this prompt"), "restored Up-arrow prompt");
+await waitFor(second.terminal, () => grid(second.terminal).includes("/exit"), "restored Up-arrow slash command");
+second.runtime.write("\x10");
+await waitFor(second.terminal, () => grid(second.terminal).includes("remember this prompt"), "restored Ctrl-P prompt");
 if (grid(second.terminal).includes("durable prompt history unavailable")) {
   throw new Error("terminal reported unavailable history despite a host provider");
 }
 second.runtime.write("\x15/exit\r");
 if (await waitForExit(second.runtime, "second terminal") !== 0) throw new Error("second terminal did not exit cleanly");
-console.log("headless history passed: host prompt history survived terminal recreation and restored through Up arrow");
+console.log("headless history passed: host prompt and slash command history survived terminal recreation");

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -11261,6 +11261,30 @@ test "app_input_runtime submit resolves slash completion through core command sp
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
 }
 
+test "app_input_runtime recalls a submitted slash command with history previous" {
+    const alloc = std.testing.allocator;
+    var app = FakeSubmitApp{ .alloc = alloc };
+    defer app.deinit();
+
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "/he");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
+    try std.testing.expectEqualStrings(
+        "/help",
+        app.input_runtime.composer_history.entryText(0).?,
+    );
+
+    try input_completion_runtime.CompletionRuntime(FakeSubmitApp).navigatePromptHistory(
+        &app,
+        -1,
+    );
+
+    try std.testing.expectEqualStrings("/help", app.input_runtime.edit_state.input.items);
+}
+
 test "app_input_runtime submit preserves a dismissed slash query" {
     const alloc = std.testing.allocator;
     var app = FakeSubmitApp{ .alloc = alloc };
@@ -11371,7 +11395,11 @@ test "app_input_runtime routes pending image list locally and preserves its plac
     try std.testing.expectEqual(@as(usize, 1), app.pending_images.items.len);
     try std.testing.expectEqual(@as(usize, 0), app.preflight_count);
     try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
-    try std.testing.expectEqual(@as(usize, 0), app.input_runtime.composer_history.count());
+    try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
+    try std.testing.expectEqualStrings(
+        "/images",
+        app.input_runtime.composer_history.entryText(0).?,
+    );
     try std.testing.expect(app.last_prompt == null);
 }
 
@@ -11430,7 +11458,17 @@ test "app_input_runtime clears pending image placeholders after image command st
         try std.testing.expectEqual(@as(usize, 0), app.pending_images.items.len);
         try std.testing.expectEqual(@as(usize, 0), app.preflight_count);
         try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
-        try std.testing.expectEqual(@as(usize, 0), app.input_runtime.composer_history.count());
+        const expected_history_count: usize = if (fail_after_clear) 0 else 1;
+        try std.testing.expectEqual(
+            expected_history_count,
+            app.input_runtime.composer_history.count(),
+        );
+        if (!fail_after_clear) {
+            try std.testing.expectEqualStrings(
+                "/images clear",
+                app.input_runtime.composer_history.entryText(0).?,
+            );
+        }
         try std.testing.expect(app.last_prompt == null);
     }
 }
@@ -11587,7 +11625,11 @@ test "app_input_runtime keeps a repeated image command local while an image is p
         try std.testing.expectEqualStrings("[Image #1][Image #2]", app.input_runtime.edit_state.input.items);
         try std.testing.expectEqual(@as(usize, 0), app.preflight_count);
         try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
-        try std.testing.expectEqual(@as(usize, 0), app.input_runtime.composer_history.count());
+        try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
+        try std.testing.expectEqualStrings(
+            last_command,
+            app.input_runtime.composer_history.entryText(0).?,
+        );
         try std.testing.expect(app.last_prompt == null);
         try std.testing.expectEqual(@as(usize, 0), app.last_images.len);
         try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
@@ -12533,7 +12575,7 @@ test "app_input_runtime persists expanded pasted prompt bytes" {
     );
 }
 
-test "app_input_runtime excludes slash commands from durable prompt history" {
+test "app_input_runtime persists slash commands in durable prompt history" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -12554,8 +12596,13 @@ test "app_input_runtime excludes slash commands from durable prompt history" {
         100,
     );
     defer prompt_history_store.freeLoadedEntries(alloc, entries);
-    try std.testing.expectEqual(@as(usize, 0), entries.len);
-    try std.testing.expectEqual(@as(usize, 0), app.input_runtime.composer_history.count());
+    try std.testing.expectEqual(@as(usize, 1), entries.len);
+    try std.testing.expectEqualStrings("/help", entries[0].text);
+    try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
+    try std.testing.expectEqualStrings(
+        "/help",
+        app.input_runtime.composer_history.entryText(0).?,
+    );
 }
 
 test "app_input_runtime excludes image-bearing prompts from durable history" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -11458,17 +11458,14 @@ test "app_input_runtime clears pending image placeholders after image command st
         try std.testing.expectEqual(@as(usize, 0), app.pending_images.items.len);
         try std.testing.expectEqual(@as(usize, 0), app.preflight_count);
         try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
-        const expected_history_count: usize = if (fail_after_clear) 0 else 1;
         try std.testing.expectEqual(
-            expected_history_count,
+            @as(usize, 1),
             app.input_runtime.composer_history.count(),
         );
-        if (!fail_after_clear) {
-            try std.testing.expectEqualStrings(
-                "/images clear",
-                app.input_runtime.composer_history.entryText(0).?,
-            );
-        }
+        try std.testing.expectEqualStrings(
+            "/images clear",
+            app.input_runtime.composer_history.entryText(0).?,
+        );
         try std.testing.expect(app.last_prompt == null);
     }
 }

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -237,14 +237,14 @@ pub fn SubmitRuntime(comptime App: type) type {
             commitStableExtractedImageIds(app, extracted.images);
             commitRemappedImageIds(app, visual_text.next_image_id);
             if (visual_text.text.len > 0) {
-                recordAcceptedPromptHistory(
+                recordAcceptedPromptComposerHistory(
                     app,
                     max_prompt_history,
                     &accepted_draft,
                 );
             }
             if (!has_images_for_submit and visual_text.text.len > 0) {
-                recordAcceptedPrompt(app, visual_text.text);
+                recordAcceptedInput(app, visual_text.text);
             }
             discard_extracted = false;
             releasePendingImages(app);
@@ -396,12 +396,12 @@ pub fn SubmitRuntime(comptime App: type) type {
                 }
                 app.shell.render_requests.request(.footer);
             };
-            try App.handleCommand(app, command_copy);
             recordAcceptedSlashCommandHistory(
                 app,
                 max_prompt_history,
                 command_copy,
             );
+            try App.handleCommand(app, command_copy);
         }
 
         fn projectRetainedImageTokens(
@@ -691,7 +691,7 @@ pub fn SubmitRuntime(comptime App: type) type {
             }
         }
 
-        fn recordAcceptedPrompt(app: *App, text: []const u8) void {
+        fn recordAcceptedInput(app: *App, text: []const u8) void {
             if (comptime !@hasField(App, "prompt_history")) return;
             const outcome = app.prompt_history.recordAccepted(
                 app.alloc,
@@ -704,7 +704,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                 error.PromptHistoryWriteFailed;
             const notice = std.fmt.allocPrint(
                 app.alloc,
-                "failed to save prompt history ({s}); prompt submission continued",
+                "failed to save input history ({s}); submission continued",
                 .{@errorName(err)},
             ) catch |notice_err| {
                 debug_trace.logf(
@@ -728,7 +728,7 @@ pub fn SubmitRuntime(comptime App: type) type {
             };
         }
 
-        fn recordAcceptedPromptHistory(
+        fn recordAcceptedPromptComposerHistory(
             app: *App,
             max_prompt_history: usize,
             accepted: *const AcceptedDraftProjection,
@@ -758,7 +758,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                 &.{},
                 &.{},
             );
-            recordAcceptedPrompt(app, command);
+            recordAcceptedInput(app, command);
         }
 
         fn recordComposerHistory(
@@ -784,7 +784,7 @@ pub fn SubmitRuntime(comptime App: type) type {
             ) catch |err| {
                 debug_trace.logf(
                     "input",
-                    "prompt history skipped after queue admission err={s}",
+                    "composer history record skipped err={s}",
                     .{@errorName(err)},
                 );
             };

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -69,11 +69,11 @@ pub fn SubmitRuntime(comptime App: type) type {
             const resolved_slash_submission = resolvedSlashSubmission(app, left_trimmed);
             if (knownSlashCommand(app, resolved_slash_submission)) |command| {
                 if (requiresPromptCredential(command, resolved_slash_submission) and !try preflightPrompt(app)) return;
-                try submitSlashCommand(app, left_trimmed, null);
+                try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
                 return;
             }
             if (shouldRouteUnknownSlashCommand(app, resolved_slash_submission)) {
-                try submitSlashCommand(app, left_trimmed, null);
+                try submitSlashCommand(app, left_trimmed, null, max_prompt_history);
                 return;
             }
             if (pendingImagesPrefixEnd(
@@ -90,6 +90,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                         app,
                         command_text,
                         expanded.text[0..command_start],
+                        max_prompt_history,
                     );
                     return;
                 }
@@ -345,7 +346,12 @@ pub fn SubmitRuntime(comptime App: type) type {
             return null;
         }
 
-        fn submitSlashCommand(app: *App, text: []const u8, retained_prefix: ?[]const u8) !void {
+        fn submitSlashCommand(
+            app: *App,
+            text: []const u8,
+            retained_prefix: ?[]const u8,
+            max_prompt_history: usize,
+        ) !void {
             const command_text = resolvedSlashSubmission(app, text);
             const command_copy = try app.alloc.dupe(u8, command_text);
             defer app.alloc.free(command_copy);
@@ -391,6 +397,11 @@ pub fn SubmitRuntime(comptime App: type) type {
                 app.shell.render_requests.request(.footer);
             };
             try App.handleCommand(app, command_copy);
+            recordAcceptedSlashCommandHistory(
+                app,
+                max_prompt_history,
+                command_copy,
+            );
         }
 
         fn projectRetainedImageTokens(
@@ -722,17 +733,54 @@ pub fn SubmitRuntime(comptime App: type) type {
             max_prompt_history: usize,
             accepted: *const AcceptedDraftProjection,
         ) void {
-            if (comptime @hasField(App, "prompt_history")) {
-                if (!app.prompt_history.enabled) return;
-            }
-            app.input_runtime.composer_history.record(
-                app.alloc,
+            recordComposerHistory(
+                app,
                 max_prompt_history,
                 accepted.input,
                 accepted.pasted_blocks.items,
                 app.pending_images.items,
                 accepted.image_tokens.items,
                 accepted.skill_tokens.items,
+            );
+        }
+
+        fn recordAcceptedSlashCommandHistory(
+            app: *App,
+            max_prompt_history: usize,
+            command: []const u8,
+        ) void {
+            recordComposerHistory(
+                app,
+                max_prompt_history,
+                command,
+                &.{},
+                &.{},
+                &.{},
+                &.{},
+            );
+            recordAcceptedPrompt(app, command);
+        }
+
+        fn recordComposerHistory(
+            app: *App,
+            max_prompt_history: usize,
+            text: []const u8,
+            pasted: []const paste_blocks.PastedBlock,
+            images: []const types.ImageAttachment,
+            image_tokens: []const entity_spans.ImageTokenSpan,
+            skill_tokens: []const registered_entities.SkillTokenSpan,
+        ) void {
+            if (comptime @hasField(App, "prompt_history")) {
+                if (!app.prompt_history.enabled) return;
+            }
+            app.input_runtime.composer_history.record(
+                app.alloc,
+                max_prompt_history,
+                text,
+                pasted,
+                images,
+                image_tokens,
+                skill_tokens,
             ) catch |err| {
                 debug_trace.logf(
                     "input",

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -432,7 +432,7 @@ const specs = [_]Spec{
     .{ .id = .sound_level, .category = .notifications, .label = "Sound level", .description = "Choose off, on, or max interface sounds" },
     .{ .id = .sandbox, .category = .advanced, .label = "Command sandbox", .description = "Choose command process isolation for this workspace" },
     .{ .id = .startup_scrollback, .category = .advanced, .label = "Startup scrollback", .description = "Restore terminal output when Fx starts" },
-    .{ .id = .prompt_history, .category = .advanced, .label = "Prompt history", .description = "Save accepted prompts for composer history" },
+    .{ .id = .prompt_history, .category = .advanced, .label = "Prompt history", .description = "Save accepted prompts and slash commands for composer history" },
 };
 
 const on_off_options = [_][]const u8{ "off", "on" };

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -1319,11 +1319,15 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
 
         expect(tree(home)).toEqual([
           ".fx",
+          ".fx/history.jsonl",
+          ".fx/history.lock",
           ".fx/sessions",
           ".fx/settings.json",
           ".fx/settings.lock",
         ]);
         expect(statSync(join(home, ".fx")).mode & 0o777).toBe(0o700);
+        expect(statSync(join(home, ".fx", "history.jsonl")).mode & 0o777).toBe(0o600);
+        expect(statSync(join(home, ".fx", "history.lock")).mode & 0o777).toBe(0o600);
         expect(statSync(join(home, ".fx", "settings.json")).mode & 0o777).toBe(0o600);
         expect(statSync(join(home, ".fx", "settings.lock")).mode & 0o777).toBe(0o600);
         expect(readFileSync(stderrPath, "utf8")).toBe("");

--- a/tests/e2e/prompt-history.test.ts
+++ b/tests/e2e/prompt-history.test.ts
@@ -85,7 +85,7 @@ describe.skipIf(!tmuxAvailable())("prompt history", () => {
   });
 
   serialTest(
-    "accepted model-facing prompts survive restart while slash commands do not",
+    "accepted prompts and slash commands survive restart",
     async () => {
       const root = mkdtempSync(join(tmpdir(), "fx-prompt-history-"));
       try {
@@ -119,7 +119,8 @@ describe.skipIf(!tmuxAvailable())("prompt history", () => {
         const historyPath = join(home, ".fx", "history.jsonl");
         const history = readFileSync(historyPath, "utf8");
         expect(history).toContain("PLAN10_PROMPT_HISTORY_SENTINEL");
-        expect(history).not.toContain("/help");
+        expect(history).toContain("/help");
+        expect(history).toContain("/quit");
 
         session = await TmuxSession.create({
           cwd: workspaceRoot,
@@ -127,8 +128,25 @@ describe.skipIf(!tmuxAvailable())("prompt history", () => {
         });
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendKeys("Up");
-        const pane = await session.waitForText("PLAN10_PROMPT_HISTORY_SENTINEL", TIMEOUT);
-        expect(pane).toContain("PLAN10_PROMPT_HISTORY_SENTINEL");
+        let pane = await session.waitForPane(
+          (current) => currentComposerLine(current).includes("/quit"),
+          TIMEOUT,
+        );
+        expect(currentComposerLine(pane)).toContain("/quit");
+
+        await session.sendKeys("C-p");
+        pane = await session.waitForPane(
+          (current) => currentComposerLine(current).includes("/help"),
+          TIMEOUT,
+        );
+        expect(currentComposerLine(pane)).toContain("/help");
+
+        await session.sendKeys("C-p");
+        pane = await session.waitForPane(
+          (current) => currentComposerLine(current).includes("PLAN10_PROMPT_HISTORY_SENTINEL"),
+          TIMEOUT,
+        );
+        expect(currentComposerLine(pane)).toContain("PLAN10_PROMPT_HISTORY_SENTINEL");
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
@@ -219,28 +237,58 @@ describe.skipIf(!tmuxAvailable())("prompt history", () => {
         await session.waitForText("HTTP 401", TIMEOUT);
         await session.waitForPane(hasEmptyComposer, TIMEOUT);
         await session.sendKeys("Up");
-        const recalled = await session.waitForPane(
+        let recalled = await session.waitForPane(
           (pane) => {
             const composer = currentComposerLine(pane);
             return (
-              composer.includes("PLAN10_HISTORY_WORKSPACE_A") ||
+              composer.includes("/settings") ||
               composer.includes("PLAN10_HISTORY_DISABLED")
             );
           },
           TIMEOUT,
         );
-        const composer = currentComposerLine(recalled);
+        let composer = currentComposerLine(recalled);
+        expect(composer).not.toContain("PLAN10_HISTORY_DISABLED");
+        expect(composer).toContain("/settings");
+
+        await session.sendKeys("C-p");
+        recalled = await session.waitForPane(
+          (pane) => {
+            const current = currentComposerLine(pane);
+            return (
+              current.includes("/quit") ||
+              current.includes("PLAN10_HISTORY_DISABLED")
+            );
+          },
+          TIMEOUT,
+        );
+        composer = currentComposerLine(recalled);
+        expect(composer).not.toContain("PLAN10_HISTORY_DISABLED");
+        expect(composer).toContain("/quit");
+
+        await session.sendKeys("C-p");
+        recalled = await session.waitForPane(
+          (pane) => {
+            const current = currentComposerLine(pane);
+            return (
+              current.includes("PLAN10_HISTORY_WORKSPACE_A") ||
+              current.includes("PLAN10_HISTORY_DISABLED")
+            );
+          },
+          TIMEOUT,
+        );
+        composer = currentComposerLine(recalled);
         expect(composer).not.toContain("PLAN10_HISTORY_DISABLED");
         expect(composer).toContain("PLAN10_HISTORY_WORKSPACE_A");
         await session.sendKeys("C-u");
         await session.waitForPane(hasEmptyComposer, TIMEOUT);
-        await session.sendText("/quit");
-        await session.waitForSessionEnd(TIMEOUT);
+        await session.kill();
         session = null;
 
         const history = readFileSync(historyPath, "utf8");
         expect(history).toContain("PLAN10_HISTORY_WORKSPACE_A");
         expect(history).toContain("PLAN10_HISTORY_WORKSPACE_B");
+        expect(history).toContain("/settings");
         expect(history).not.toContain("PLAN10_HISTORY_DISABLED");
       } finally {
         rmSync(root, { recursive: true, force: true });

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1285,27 +1285,26 @@ tmuxTest(
       AI_GATEWAY_API_KEY: undefined,
     });
     await session.waitForComposer(TIMEOUT);
-    chmodSync(fxDir, 0o500);
-    try {
-      await session.sendText("/logout");
-      const failed = await session.waitForText(
-        "Could not complete fx logout. The current source is unchanged.",
-        TIMEOUT,
-      );
-      expect(failed).not.toContain("Signed out of fx.");
-      expect(existsSync(join(fxDir, "auth.json"))).toBe(true);
+    const authPath = join(fxDir, "auth.json");
+    rmSync(authPath);
+    mkdirSync(authPath, { mode: 0o700 });
 
-      await session.sendText("/status");
-      await session.waitForText("auth=fx login", TIMEOUT);
-      await session.sendText("prove fx login remains active");
-      await session.waitForText(LOGIN_RESPONSE, TIMEOUT);
-      expect(gateway.requests).toHaveLength(1);
-      expect(gateway.requests[0].headers.get("authorization")).toBe(`Bearer ${LOGIN_TOKEN}`);
-      expect(oauth.requests).toEqual([]);
-      expect(readFileSync(stderrPath, "utf8")).toBe("");
-    } finally {
-      chmodSync(fxDir, 0o700);
-    }
+    await session.sendText("/logout");
+    const failed = await session.waitForText(
+      "Could not complete fx logout. The current source is unchanged.",
+      TIMEOUT,
+    );
+    expect(failed).not.toContain("Signed out of fx.");
+    expect(existsSync(authPath)).toBe(true);
+
+    await session.sendText("/status");
+    await session.waitForText("auth=fx login", TIMEOUT);
+    await session.sendText("prove fx login remains active");
+    await session.waitForText(LOGIN_RESPONSE, TIMEOUT);
+    expect(gateway.requests).toHaveLength(1);
+    expect(gateway.requests[0].headers.get("authorization")).toBe(`Bearer ${LOGIN_TOKEN}`);
+    expect(oauth.requests).toEqual([]);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
   },
   60_000,
 );

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -1705,7 +1705,12 @@ test.skipIf(!tmuxAvailable())(
     for (const record of sessionRecords(fixture.home)) {
       expect(record.history_len).toBe(0);
     }
-    expect(existsSync(join(fixture.home, ".fx", "history.jsonl"))).toBe(false);
+    const promptHistory = readFileSync(
+      join(fixture.home, ".fx", "history.jsonl"),
+      "utf8",
+    );
+    expect(promptHistory).toContain("/image ");
+    expect(promptHistory).toContain("/images");
     expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
   },
   45_000,
@@ -1762,7 +1767,9 @@ test.skipIf(!tmuxAvailable())(
     for (const record of sessionRecords(fixture.home)) {
       expect(record.history_len).toBe(0);
     }
-    expect(existsSync(join(fixture.home, ".fx", "history.jsonl"))).toBe(false);
+    expect(
+      readFileSync(join(fixture.home, ".fx", "history.jsonl"), "utf8"),
+    ).toContain("/quit");
     expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
 
     await waitForTerminalHostExit(fixture.home);


### PR DESCRIPTION
## Summary
- record slash commands as soon as routing accepts them, including commands whose handler returns an error
- persist slash commands so they remain available after restart
- store the resolved command, so a completion such as /he recalls as /help
- reuse prompt-history settings and deduplication, with copy that reflects prompts and slash commands

## Validation
- formatted the modified Zig files and verified a clean diff
- previous revision: Zig 0.16 build passed
- previous revision: focused prompt-history E2E passed (4 tests)
- previous revision: manually verified the built binary with /feedback followed by Up

## Pending
- Full CI and the local runtime ship gate must pass for the exact current commit before this draft is marked ready