### PR TITLE
Enforce public changelog policy

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,7 @@
 name: Benchmarks
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -1,6 +1,7 @@
 name: Full CI
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - main

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,6 +13,7 @@ on:
           - major
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -242,20 +243,60 @@ jobs:
         run: |
           NEW="${{ steps.version.outputs.new }}"
           BRANCH="prepare-v${NEW}"
+          REF="refs/heads/${BRANCH}"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
-          git add src/main.zig README.md CHANGELOG.md
-          git commit -m "Prepare v${NEW} release"
           EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING_PR" ]; then
             echo "Closing existing PR #${EXISTING_PR} for ${BRANCH}"
             gh pr close "$EXISTING_PR" --comment "Superseded by a new prepare-release run."
           fi
 
-          git push origin --delete "$BRANCH" 2>/dev/null || true
-          git push -u origin "$BRANCH"
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" >/dev/null 2>&1 || true
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="$REF" \
+            -f sha="$GITHUB_SHA" \
+            >/dev/null
+
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg ref "$REF" \
+            --arg expected_head "$GITHUB_SHA" \
+            --arg headline "Prepare v${NEW} release" \
+            --arg main_zig "$(base64 -w 0 src/main.zig)" \
+            --arg readme "$(base64 -w 0 README.md)" \
+            --arg changelog "$(base64 -w 0 CHANGELOG.md)" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {
+                input: {
+                  branch: {
+                    repositoryNameWithOwner: $repository,
+                    refName: $ref
+                  },
+                  expectedHeadOid: $expected_head,
+                  message: {headline: $headline},
+                  fileChanges: {
+                    additions: [
+                      {path: "src/main.zig", contents: $main_zig},
+                      {path: "README.md", contents: $readme},
+                      {path: "CHANGELOG.md", contents: $changelog}
+                    ]
+                  }
+                }
+              }
+            }' > /tmp/create-release-commit.json
+
+          COMMIT_SHA=$(gh api graphql --input /tmp/create-release-commit.json --jq '.data.createCommitOnBranch.commit.oid')
+          if [ -z "$COMMIT_SHA" ]; then
+            echo "::error::GitHub did not return the release commit SHA"
+            exit 1
+          fi
+
+          VERIFIED=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT_SHA}" --jq '.commit.verification.verified')
+          if [ "$VERIFIED" != "true" ]; then
+            echo "::error::Release commit ${COMMIT_SHA} does not have a verified signature"
+            exit 1
+          fi
 
           gh pr create \
             --title "Prepare v${NEW} release" \
@@ -269,3 +310,7 @@ jobs:
           When merged, CI will detect the version change, cross-compile platform binaries, and publish the GitHub release automatically.
           EOF
           )"
+
+          gh workflow run ci.yml --ref "$BRANCH"
+          gh workflow run bench.yml --ref "$BRANCH"
+          gh workflow run full-ci.yml --ref "$BRANCH"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -271,7 +271,7 @@ jobs:
                 input: {
                   branch: {
                     repositoryNameWithOwner: $repository,
-                    refName: $ref
+                    branchName: $ref
                   },
                   expectedHeadOid: $expected_head,
                   message: {headline: $headline},

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -61,14 +61,8 @@ jobs:
           fi
 
           git log "${PREV_TAG}..HEAD" --oneline > /tmp/log.txt
-          git log "${PREV_TAG}..HEAD" --format='%an <%ae>' | sort -u > /tmp/authors.txt
-
-          head -60 CHANGELOG.md > /tmp/prev-changelog.txt
-
           echo "Diff: ${DIFF_SIZE} bytes, $(wc -l < /tmp/diff.txt) lines"
           echo "Commits: $(wc -l < /tmp/log.txt)"
-          echo "Authors:"
-          cat /tmp/authors.txt
 
       - name: Generate changelog with AI
         env:
@@ -80,17 +74,18 @@ jobs:
           cat > /tmp/system-prompt.txt <<'SYSPROMPT'
           You write changelogs for fx, an open-source AI-powered CLI tool written in Zig.
 
-          You will receive the actual code diff since the last release, a diff stat summary, a commit log, contributor info, and a previous changelog for format reference.
+          You will receive the actual code diff since the last release, a diff stat summary, and a commit log. Treat the commit log as private research context.
 
           Rules:
           - Base your changelog ONLY on what the diff actually shows. Do not trust commit messages or PR descriptions as authoritative — they go stale. The diff is the source of truth.
-          - Group changes under ### New Features, ### Bug Fixes, ### Improvements, ### Breaking Changes as appropriate. Omit empty sections.
-          - Bold the feature/fix name, then describe concisely what changed. Use an emdash (—) as separator, never double hyphens (--).
-          - Reference PR numbers in parentheses where visible in merge commits (e.g. #42). If you cannot determine a PR number, omit it rather than guessing.
-          - Include a ### Contributors section with GitHub @usernames. You will be given git author names to help map these.
-          - Match the tone and format of the previous changelog entries exactly.
+          - Write public, user-facing product notes. Describe observable behavior and outcomes, not how the work was implemented or delivered.
+          - Always spell the product name fx. Preserve different casing only for exact code identifiers such as FX_MODEL.
+          - Group changes under ### Breaking Changes, ### New Features, ### Improvements, ### Bug Fixes, and ### Security as appropriate. Omit empty sections.
+          - Bold a short feature or fix name, then describe the user-visible change after a colon.
+          - Do not include pull request or issue numbers, links to trackers, commit hashes, contributor names, author attribution, or a Contributors section.
+          - Do not include internal details such as repository moves, website or marketing work, CDN layout, CI workflows, tests or fixtures, branch history, or implementation-only refactors. Translate relevant work into its public user outcome or omit it.
+          - Do not force every commit into the changelog. Omit changes without a public user outcome.
           - Output ONLY the changelog body (the content that goes between the release markers). Do not include the ## version heading, do not include the <!-- release:start/end --> markers, do not include any preamble or explanation.
-          - Do not prefix entries with commit hashes.
           - Do not use emojis.
           SYSPROMPT
 
@@ -104,8 +99,6 @@ jobs:
             --rawfile diff_stat /tmp/diff-stat.txt \
             --rawfile src_diff /tmp/diff.txt \
             --rawfile commit_log /tmp/log.txt \
-            --rawfile authors /tmp/authors.txt \
-            --rawfile prev_changelog /tmp/prev-changelog.txt \
             '{
               prompt: [
                 {role: "system", content: $system},
@@ -115,8 +108,6 @@ jobs:
                     $user_header + "\n\n## Diff stat (file-level summary)\n" + $diff_stat
                     + "\n\n## Source diff (src/ changes — the ground truth)\n" + $src_diff
                     + "\n\n## Commit log (supplementary context only — do not trust these as authoritative)\n" + $commit_log
-                    + "\n\n## Git authors\n" + $authors
-                    + "\n\n## Previous changelog (for format and voice reference)\n" + $prev_changelog
                   )
                 }]}
               ]
@@ -170,6 +161,42 @@ jobs:
             exit 1
           fi
           cat /tmp/changelog-body.md
+
+          python3 <<'PYEOF'
+          import re
+          from pathlib import Path
+
+          body = Path("/tmp/changelog-body.md").read_text()
+          forbidden = {
+              "contributor attribution": r"(?im)^###\s+contributors\b|\bcontributors?\b|\bauthors?\b",
+              "tracker references": r"(?i)#[0-9]+\b|\bPRs?\s*#?[0-9]+\b|\bpull requests?\b|github\.com/[^\s)]+/(?:pull|issues|commit)/",
+              "internal web or delivery details": r"(?i)\b(?:fx-web|website|marketing|CDN|deployments?|repository moves?|repository split|repo(?:sitory)? migration)\b|vercel-labs/[A-Za-z0-9_.-]+",
+              "internal engineering details": r"(?i)\b(?:CI|workflows?|tests?|fixtures?|branch history|Git history|commit hashes?|implementation-only refactors?|refactors?)\b",
+          }
+          errors = [label for label, pattern in forbidden.items() if re.search(pattern, body)]
+          if re.search(r"(?<![A-Za-z0-9_])(?:Fx|FX)(?![A-Za-z0-9_])", body):
+              errors.append("product name is not lowercase fx")
+
+          allowed_headings = {
+              "### Breaking Changes",
+              "### New Features",
+              "### Improvements",
+              "### Bug Fixes",
+              "### Security",
+          }
+          headings = set(re.findall(r"(?m)^### .+$", body))
+          if not headings.issubset(allowed_headings):
+              errors.append("unsupported changelog section")
+
+          bullets = re.findall(r"(?m)^- .+$", body)
+          if not bullets or any(not re.match(r"^- \*\*[^*]+:\*\* \S", bullet) for bullet in bullets):
+              errors.append("release bullets must use '- **Name:** Description'")
+
+          if errors:
+              for error in errors:
+                  print(f"::error::Public changelog policy violation: {error}")
+              raise SystemExit(1)
+          PYEOF
 
       - name: Update version and changelog
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -259,7 +259,7 @@ jobs:
 
           jq -n \
             --arg repository "$GITHUB_REPOSITORY" \
-            --arg ref "$REF" \
+            --arg branch "$BRANCH" \
             --arg expected_head "$GITHUB_SHA" \
             --arg headline "Prepare v${NEW} release" \
             --arg main_zig "$(base64 -w 0 src/main.zig)" \
@@ -271,7 +271,7 @@ jobs:
                 input: {
                   branch: {
                     repositoryNameWithOwner: $repository,
-                    branchName: $ref
+                    branchName: $branch
                   },
                   expectedHeadOid: $expected_head,
                   message: {headline: $headline},

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,7 +330,16 @@ When the PR merges, CI compares the version tag to what exists in git. If the ta
 
 ### Writing the changelog
 
-Whether automated or manual, the changelog follows the same format. Group changes under `### New Features`, `### Bug Fixes`, `### Improvements`, etc. Bold the feature/fix name, then describe it concisely. Reference PR numbers in parentheses.
+Whether automated or manual, the changelog is public product copy. Describe observable user behavior, not the engineering process behind it. Use the diff, commits, and merged pull requests as research evidence only.
+
+Public changelog entries must:
+
+* Spell the product name `fx`. Preserve different casing only when it is part of an exact code identifier such as `FX_MODEL`.
+* Use only relevant sections from `### Breaking Changes`, `### New Features`, `### Improvements`, `### Bug Fixes`, and `### Security`. Omit empty sections.
+* Bold a short feature or fix name, then describe the user-visible change after a colon.
+* Omit pull request numbers, issue numbers, commit hashes, contributor names, and author attribution.
+* Omit internal details such as repository moves, website or marketing work, CDN layout, CI workflows, test fixtures, branch history, and implementation-only refactors. Translate relevant work into its public user outcome or leave it out.
+* Avoid forcing every merged change into the notes. A change without a public user outcome does not need a bullet.
 
 Only the current release should have markers; remove `<!-- release:start -->` and `<!-- release:end -->` from any previous entry:
 
@@ -340,23 +349,17 @@ Only the current release should have markers; remove `<!-- release:start -->` an
 <!-- release:start -->
 ### New Features
 
-- **Foo command** — Added `foo` command for bar (#42)
-
-### Contributors
-
-- @ctate
+- **Interactive terminal startup:** Start an interactive shell when the `terminal` tool receives an empty command
 <!-- release:end -->
 
 ## 0.2.5
 
 ### Improvements
 
-- **Inline CLI rendering** — Replaced the alternate-screen TUI ...
+- **Inline rendering:** Keep the active conversation visible in terminal scrollback
 ```
 
-Include a `### Contributors` section listing GitHub usernames (with `@` prefix) of everyone who contributed. Check the git log between the previous tag and HEAD.
-
-Do not prefix entries with commit hashes. Use descriptive section names.
+Do not add a `### Contributors` section or tracker references. Use descriptive section names.
 
 Do not create version tags manually. Do not change `build.zig.zon` version (it is a placeholder).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,6 +277,8 @@ The install script and `fx upgrade` fetch binaries from the public Vercel Blob C
 
 After CI passes for a push to `main`, the dev release workflow publishes commit-addressed binaries and then updates `dev.json`. Dogfooders opt in with `fx upgrade --channel dev`; the choice is stored in their user settings and applies to manual upgrades, automatic upgrades, and the `ctrl+g` handoff. `fx upgrade --channel stable` returns to tagged releases. Dev publishing does not create tags or GitHub Releases.
 
+Release notes are public product copy. Describe user-visible behavior, always spell the product `fx`, and omit contributor attribution, tracker references, repository or website work, delivery infrastructure, CI and test details, branch history, and implementation-only refactors. Use commits and pull requests as research evidence only. Changelog formatting and release-marker rules live in `AGENTS.md`.
+
 Do not create tags manually. The workflow owns tag creation.
 
 ## Benchmarks


### PR DESCRIPTION
## Summary

- Define one public release-note format for manual and automated releases.
- Reject generated notes that expose attribution, tracker references, internal work, or incorrect fx branding.
- Keep contributor and legacy changelog data out of automated release drafts.
- Create verified release commits that satisfy repository signing rules.
- Start standard validation for automated release PRs without additional credentials.