### PR TITLE
Make terminal tool inputs action-specific

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -174,6 +174,153 @@ const terminal_write_schema = gateway_schema.ObjectSchema{
     .required = &.{"kind"},
     .additional_properties = false,
 };
+
+const terminal_properties = [_]gateway_schema.Property{
+    .{ .name = "session_id", .json_type = .string, .description = "Required for session-targeted actions. Omit for start and list; owner-catalog authority is private." },
+    .{ .name = "cwd", .json_type = .string, .description = "Start working directory; defaults to the workspace." },
+    .{ .name = "command", .json_type = .string, .description = "Optional command for start; omit for an interactive shell." },
+    .{ .name = "shell", .json_type = .object, .object_schema = &terminal_shell_schema },
+    .{ .name = "backend", .json_type = .string, .enum_values = &.{ "native", "tmux" }, .description = "Start backend or optional list filter." },
+    .{ .name = "return_when", .json_type = .object, .object_schema = &terminal_return_schema },
+    .{ .name = "wait_ceiling_ms", .json_type = .integer, .minimum = 1, .description = "Required for wait; required for start when return_when is non-immediate; maximum blocking time in milliseconds." },
+    .{ .name = "dimensions", .json_type = .object, .object_schema = &terminal_dimensions_schema },
+    .{ .name = "initial_monitors", .json_type = .array, .max_items = 32, .items = &terminal_monitor_definition_schema },
+    .{ .name = "cursor_segment", .json_type = .integer, .minimum = 1 },
+    .{ .name = "cursor_offset", .json_type = .integer },
+    .{ .name = "after_event_id", .json_type = .integer },
+    .{ .name = "acknowledge_event_id", .json_type = .integer, .minimum = 1 },
+    .{ .name = "max_events", .json_type = .integer, .minimum = 1, .maximum = 256 },
+    .{ .name = "write", .json_type = .object, .object_schema = &terminal_write_schema },
+    .{ .name = "lease", .json_type = .string, .enum_values = &.{ "acquire", "use", "release", "revoke" } },
+    .{ .name = "monitor", .json_type = .object, .object_schema = &terminal_monitor_operation_schema },
+    .{ .name = "task_id", .json_type = .string },
+    .{ .name = "workspace_root", .json_type = .string },
+    .{ .name = "rows", .json_type = .integer, .minimum = 1, .maximum = 4096 },
+    .{ .name = "columns", .json_type = .integer, .minimum = 1, .maximum = 4096 },
+    .{ .name = "signal", .json_type = .string, .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } },
+    .{ .name = "close_policy", .json_type = .string, .enum_values = &.{ "graceful", "force" } },
+};
+
+fn terminalProperty(comptime name: []const u8) gateway_schema.Property {
+    inline for (terminal_properties) |property| {
+        if (std.mem.eql(u8, property.name, name)) return property;
+    }
+    @compileError("unknown terminal property: " ++ name);
+}
+
+const terminal_action_schemas = [_]gateway_schema.ObjectSchema{
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"start"} },
+            terminalProperty("cwd"),
+            terminalProperty("command"),
+            terminalProperty("shell"),
+            terminalProperty("backend"),
+            terminalProperty("return_when"),
+            terminalProperty("wait_ceiling_ms"),
+            terminalProperty("dimensions"),
+            terminalProperty("initial_monitors"),
+        },
+        .required = &.{"action"},
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"read"} },
+            terminalProperty("session_id"),
+            terminalProperty("cursor_segment"),
+            terminalProperty("cursor_offset"),
+        },
+        .required = &.{ "action", "session_id", "cursor_segment" },
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"screen"} },
+            terminalProperty("session_id"),
+        },
+        .required = &.{ "action", "session_id" },
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"write"} },
+            terminalProperty("session_id"),
+            terminalProperty("write"),
+            terminalProperty("lease"),
+        },
+        .required = &.{ "action", "session_id" },
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"wait"} },
+            terminalProperty("session_id"),
+            terminalProperty("return_when"),
+            terminalProperty("wait_ceiling_ms"),
+        },
+        .required = &.{ "action", "session_id", "return_when", "wait_ceiling_ms" },
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"monitor"} },
+            terminalProperty("session_id"),
+            terminalProperty("monitor"),
+        },
+        .required = &.{ "action", "session_id", "monitor" },
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"inspect"} },
+            terminalProperty("session_id"),
+            terminalProperty("after_event_id"),
+            terminalProperty("acknowledge_event_id"),
+            terminalProperty("max_events"),
+        },
+        .required = &.{ "action", "session_id" },
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"list"} },
+            terminalProperty("task_id"),
+            terminalProperty("workspace_root"),
+            terminalProperty("backend"),
+        },
+        .required = &.{"action"},
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"resize"} },
+            terminalProperty("session_id"),
+            terminalProperty("rows"),
+            terminalProperty("columns"),
+        },
+        .required = &.{ "action", "session_id", "rows", "columns" },
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"signal"} },
+            terminalProperty("session_id"),
+            terminalProperty("signal"),
+        },
+        .required = &.{ "action", "session_id", "signal" },
+        .additional_properties = false,
+    },
+    .{
+        .properties = &.{
+            .{ .name = "action", .json_type = .string, .enum_values = &.{"close"} },
+            terminalProperty("session_id"),
+            terminalProperty("close_policy"),
+        },
+        .required = &.{ "action", "session_id", "close_policy" },
+        .additional_properties = false,
+    },
+};
 const skill_description =
     "Read an installed skill or one of its relative text resources in bounded chunks. Pass the exact advertised location when one is listed, then use next_offset to continue. When to use: the user explicitly invokes a listed skill or the task clearly matches one. When NOT to use: generic exploration, ordinary file edits, guessing from vague words, or installing a missing skill.";
 const install_skill_description =
@@ -866,34 +1013,7 @@ pub const terminal = ToolSpec{
         .name = "terminal",
         .description = terminal_description,
         .input_schema = .{
-            .properties = &.{
-                .{ .name = "action", .json_type = .string, .enum_values = &.{ "start", "read", "screen", "write", "wait", "monitor", "inspect", "list", "resize", "signal", "close" } },
-                .{ .name = "session_id", .json_type = .string, .description = "Required for session-targeted actions. Omit for start and list; owner-catalog authority is private." },
-                .{ .name = "cwd", .json_type = .string, .description = "Start working directory; defaults to the workspace." },
-                .{ .name = "command", .json_type = .string, .description = "Optional command for start; omit for an interactive shell." },
-                .{ .name = "shell", .json_type = .object, .object_schema = &terminal_shell_schema },
-                .{ .name = "backend", .json_type = .string, .enum_values = &.{ "native", "tmux" }, .description = "Start backend or optional list filter." },
-                .{ .name = "return_when", .json_type = .object, .object_schema = &terminal_return_schema },
-                .{ .name = "wait_ceiling_ms", .json_type = .integer, .minimum = 1, .description = "Required for wait; required for start when return_when is non-immediate; maximum blocking time in milliseconds." },
-                .{ .name = "dimensions", .json_type = .object, .object_schema = &terminal_dimensions_schema },
-                .{ .name = "initial_monitors", .json_type = .array, .max_items = 32, .items = &terminal_monitor_definition_schema },
-                .{ .name = "cursor_segment", .json_type = .integer, .minimum = 1 },
-                .{ .name = "cursor_offset", .json_type = .integer },
-                .{ .name = "after_event_id", .json_type = .integer },
-                .{ .name = "acknowledge_event_id", .json_type = .integer, .minimum = 1 },
-                .{ .name = "max_events", .json_type = .integer, .minimum = 1, .maximum = 256 },
-                .{ .name = "write", .json_type = .object, .object_schema = &terminal_write_schema },
-                .{ .name = "lease", .json_type = .string, .enum_values = &.{ "acquire", "use", "release", "revoke" } },
-                .{ .name = "monitor", .json_type = .object, .object_schema = &terminal_monitor_operation_schema },
-                .{ .name = "task_id", .json_type = .string },
-                .{ .name = "workspace_root", .json_type = .string },
-                .{ .name = "rows", .json_type = .integer, .minimum = 1, .maximum = 4096 },
-                .{ .name = "columns", .json_type = .integer, .minimum = 1, .maximum = 4096 },
-                .{ .name = "signal", .json_type = .string, .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } },
-                .{ .name = "close_policy", .json_type = .string, .enum_values = &.{ "graceful", "force" } },
-            },
-            .required = &.{"action"},
-            .additional_properties = false,
+            .one_of = &terminal_action_schemas,
         },
     },
     .executor_kind = .terminal,
@@ -1258,95 +1378,118 @@ test "registry classifies every built-in progress label" {
     }
 }
 
-test "terminal tool schema exposes the complete action and backend surface" {
+fn schemaProperty(schema: gateway_schema.ObjectSchema, name: []const u8) ?gateway_schema.Property {
+    for (schema.properties) |property| {
+        if (std.mem.eql(u8, property.name, name)) return property;
+    }
+    return null;
+}
+
+test "terminal tool schema exposes one exact object branch per action" {
     try std.testing.expect(terminal.requires_approval);
     try std.testing.expectEqual(tool_dispatch.ExecutorKind.terminal, terminal.executor_kind);
     try std.testing.expectEqual(tool_dispatch.PermissionTargetKind.none, terminal.permission_target_kind);
 
-    var action_values: ?[]const []const u8 = null;
-    var backend_values: ?[]const []const u8 = null;
-    var session_id_description: ?[]const u8 = null;
-    var wait_ceiling_description: ?[]const u8 = null;
-    var wait_ceiling_count: usize = 0;
-    var has_safety_ceiling = false;
-    var has_initial_monitors = false;
-    var has_return_when = false;
-    var has_lifecycle = false;
-    var output_quiet_duration: ?gateway_schema.Property = null;
-    var notification_interval: ?gateway_schema.Property = null;
-    var lifetime_duration: ?gateway_schema.Property = null;
-    var check_interval: ?gateway_schema.Property = null;
-    for (terminal.gateway_schema.input_schema.properties) |property| {
-        if (std.mem.eql(u8, property.name, "action")) action_values = property.enum_values;
-        if (std.mem.eql(u8, property.name, "backend")) backend_values = property.enum_values;
-        if (std.mem.eql(u8, property.name, "session_id")) session_id_description = property.description;
-        if (std.mem.eql(u8, property.name, "wait_ceiling_ms")) {
-            wait_ceiling_description = property.description;
-            wait_ceiling_count += 1;
+    const expected = [_]struct {
+        action: []const u8,
+        properties: []const []const u8,
+        required: []const []const u8,
+    }{
+        .{ .action = "start", .properties = &.{ "action", "cwd", "command", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors" }, .required = &.{"action"} },
+        .{ .action = "read", .properties = &.{ "action", "session_id", "cursor_segment", "cursor_offset" }, .required = &.{ "action", "session_id", "cursor_segment" } },
+        .{ .action = "screen", .properties = &.{ "action", "session_id" }, .required = &.{ "action", "session_id" } },
+        .{ .action = "write", .properties = &.{ "action", "session_id", "write", "lease" }, .required = &.{ "action", "session_id" } },
+        .{ .action = "wait", .properties = &.{ "action", "session_id", "return_when", "wait_ceiling_ms" }, .required = &.{ "action", "session_id", "return_when", "wait_ceiling_ms" } },
+        .{ .action = "monitor", .properties = &.{ "action", "session_id", "monitor" }, .required = &.{ "action", "session_id", "monitor" } },
+        .{ .action = "inspect", .properties = &.{ "action", "session_id", "after_event_id", "acknowledge_event_id", "max_events" }, .required = &.{ "action", "session_id" } },
+        .{ .action = "list", .properties = &.{ "action", "task_id", "workspace_root", "backend" }, .required = &.{"action"} },
+        .{ .action = "resize", .properties = &.{ "action", "session_id", "rows", "columns" }, .required = &.{ "action", "session_id", "rows", "columns" } },
+        .{ .action = "signal", .properties = &.{ "action", "session_id", "signal" }, .required = &.{ "action", "session_id", "signal" } },
+        .{ .action = "close", .properties = &.{ "action", "session_id", "close_policy" }, .required = &.{ "action", "session_id", "close_policy" } },
+    };
+
+    try std.testing.expectEqual(expected.len, terminal.gateway_schema.input_schema.one_of.len);
+    try std.testing.expectEqual(@as(usize, 0), terminal.gateway_schema.input_schema.properties.len);
+    for (expected, terminal.gateway_schema.input_schema.one_of) |want, branch| {
+        try std.testing.expectEqual(want.properties.len, branch.properties.len);
+        for (want.properties, branch.properties) |want_name, property| {
+            try std.testing.expectEqualStrings(want_name, property.name);
         }
-        if (std.mem.eql(u8, property.name, "safety_ceiling_ms")) has_safety_ceiling = true;
-        if (std.mem.eql(u8, property.name, "initial_monitors")) has_initial_monitors = true;
-        if (std.mem.eql(u8, property.name, "return_when")) has_return_when = true;
-        if (std.mem.eql(u8, property.name, "lifecycle")) has_lifecycle = true;
+        const action = schemaProperty(branch, "action").?;
+        try std.testing.expectEqual(@as(usize, 1), action.enum_values.len);
+        try std.testing.expectEqualStrings(want.action, action.enum_values[0]);
+        try std.testing.expectEqualSlices([]const u8, want.required, branch.required);
+        try std.testing.expectEqual(@as(?bool, false), branch.additional_properties);
     }
-    for (terminal_monitor_condition_schema.properties) |property| {
-        if (std.mem.eql(u8, property.name, "duration_ms")) output_quiet_duration = property;
-    }
-    for (terminal_monitor_notify_schema.properties) |property| {
-        if (std.mem.eql(u8, property.name, "interval_ms")) notification_interval = property;
-    }
-    for (terminal_monitor_lifetime_schema.properties) |property| {
-        if (std.mem.eql(u8, property.name, "duration_ms")) lifetime_duration = property;
-    }
-    for (terminal_monitor_definition_schema.properties) |property| {
-        if (std.mem.eql(u8, property.name, "check_interval_ms")) check_interval = property;
-    }
+
+    const start_branch = terminal.gateway_schema.input_schema.one_of[0];
+    const read_branch = terminal.gateway_schema.input_schema.one_of[1];
+    const list_branch = terminal.gateway_schema.input_schema.one_of[7];
     try std.testing.expectEqualSlices(
         []const u8,
-        &.{ "start", "read", "screen", "write", "wait", "monitor", "inspect", "list", "resize", "signal", "close" },
-        action_values.?,
+        &.{ "native", "tmux" },
+        schemaProperty(start_branch, "backend").?.enum_values,
     );
     try std.testing.expectEqualSlices(
         []const u8,
         &.{ "native", "tmux" },
-        backend_values.?,
+        schemaProperty(list_branch, "backend").?.enum_values,
     );
-    try std.testing.expectEqualSlices(
-        []const u8,
-        &.{"action"},
-        terminal.gateway_schema.input_schema.required,
-    );
-    try std.testing.expectEqual(
-        @as(?bool, false),
-        terminal.gateway_schema.input_schema.additional_properties,
-    );
-    try std.testing.expect(has_initial_monitors);
-    try std.testing.expect(has_return_when);
-    try std.testing.expect(!has_lifecycle);
-    try std.testing.expectEqual(@as(usize, 1), wait_ceiling_count);
-    try std.testing.expect(!has_safety_ceiling);
     try std.testing.expectEqualStrings(
         "Required for wait; required for start when return_when is non-immediate; maximum blocking time in milliseconds.",
-        wait_ceiling_description.?,
+        schemaProperty(start_branch, "wait_ceiling_ms").?.description,
     );
     try std.testing.expectEqualStrings(
         "Required for session-targeted actions. Omit for start and list; owner-catalog authority is private.",
-        session_id_description.?,
+        schemaProperty(read_branch, "session_id").?.description,
     );
+
+    const output_quiet_duration = schemaProperty(terminal_monitor_condition_schema, "duration_ms").?;
+    const notification_interval = schemaProperty(terminal_monitor_notify_schema, "interval_ms").?;
+    const lifetime_duration = schemaProperty(terminal_monitor_lifetime_schema, "duration_ms").?;
+    const check_interval = schemaProperty(terminal_monitor_definition_schema, "check_interval_ms").?;
     const minimum_schedule_ms: usize = @intCast(terminal_monitor.minimum_schedule_ms);
     const maximum_schedule_ms: usize = @intCast(terminal_monitor.maximum_schedule_ms);
     const maximum_lifetime_ms: usize = @intCast(terminal_monitor.maximum_lifetime_ms);
-    try std.testing.expectEqual(@as(?usize, minimum_schedule_ms), output_quiet_duration.?.minimum);
-    try std.testing.expectEqual(@as(?usize, maximum_schedule_ms), output_quiet_duration.?.maximum);
-    try std.testing.expectEqual(@as(?usize, minimum_schedule_ms), notification_interval.?.minimum);
-    try std.testing.expectEqual(@as(?usize, maximum_schedule_ms), notification_interval.?.maximum);
-    try std.testing.expectEqual(@as(?usize, 1), lifetime_duration.?.minimum);
-    try std.testing.expectEqual(@as(?usize, maximum_lifetime_ms), lifetime_duration.?.maximum);
-    try std.testing.expectEqual(@as(?usize, minimum_schedule_ms), check_interval.?.minimum);
-    try std.testing.expectEqual(@as(?usize, maximum_schedule_ms), check_interval.?.maximum);
+    try std.testing.expectEqual(@as(?usize, minimum_schedule_ms), output_quiet_duration.minimum);
+    try std.testing.expectEqual(@as(?usize, maximum_schedule_ms), output_quiet_duration.maximum);
+    try std.testing.expectEqual(@as(?usize, minimum_schedule_ms), notification_interval.minimum);
+    try std.testing.expectEqual(@as(?usize, maximum_schedule_ms), notification_interval.maximum);
+    try std.testing.expectEqual(@as(?usize, 1), lifetime_duration.minimum);
+    try std.testing.expectEqual(@as(?usize, maximum_lifetime_ms), lifetime_duration.maximum);
+    try std.testing.expectEqual(@as(?usize, minimum_schedule_ms), check_interval.minimum);
+    try std.testing.expectEqual(@as(?usize, maximum_schedule_ms), check_interval.maximum);
     try std.testing.expectEqualStrings(
         "Required for polling conditions tcp_ready, http_ready, path_exists, path_changed, path_size, and custom_probe. Event-driven conditions process_exit, exit_code, signal, output_contains, output_matches, output_quiet, and screen_matches omit it; materialized values are ignored.",
-        check_interval.?.description,
+        check_interval.description,
+    );
+}
+
+test "terminal gateway advertisement projects action-specific alternatives" {
+    const alloc = std.testing.allocator;
+    var projection = try tool_advertisement.buildGatewayToolProjectionForSet(
+        alloc,
+        advertisement_set,
+        .{ .terminal_available = true },
+    );
+    defer projection.deinit(alloc);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, projection.tools_json, .{});
+    defer parsed.deinit();
+
+    var terminal_schema: ?std.json.ObjectMap = null;
+    for (parsed.value.array.items) |tool_value| {
+        if (tool_value != .object) continue;
+        const name = tool_value.object.get("name") orelse continue;
+        if (name != .string or !std.mem.eql(u8, name.string, "terminal")) continue;
+        terminal_schema = tool_value.object.get("inputSchema").?.object;
+        break;
+    }
+
+    const input_schema = terminal_schema orelse return error.TestExpectedEqual;
+    try std.testing.expect(input_schema.get("properties") == null);
+    try std.testing.expectEqual(
+        @as(usize, 11),
+        input_schema.get("oneOf").?.array.items.len,
     );
 }
 

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin_gateway = @import("gateway.zig");
+const terminal_contracts = @import("../core/terminal/contracts.zig");
 const terminal_monitor = @import("../core/terminal/monitor.zig");
 const gateway_schema = @import("../core/tooling/gateway_schema.zig");
 const subagent_domain = @import("../core/subagent/domain.zig");
@@ -1463,6 +1464,25 @@ test "terminal tool schema exposes one exact object branch per action" {
         "Required for polling conditions tcp_ready, http_ready, path_exists, path_changed, path_size, and custom_probe. Event-driven conditions process_exit, exit_code, signal, output_contains, output_matches, output_quiet, and screen_matches omit it; materialized values are ignored.",
         check_interval.description,
     );
+}
+
+test "terminal advertisement and admission agree on every action field" {
+    const branches = terminal.gateway_schema.input_schema.one_of;
+    try std.testing.expectEqual(std.meta.tags(terminal_contracts.Action).len, branches.len);
+
+    for (branches) |branch| {
+        const action_property = schemaProperty(branch, "action").?;
+        try std.testing.expectEqual(@as(usize, 1), action_property.enum_values.len);
+        const action = std.meta.stringToEnum(
+            terminal_contracts.Action,
+            action_property.enum_values[0],
+        ) orelse return error.TestUnexpectedResult;
+        const admitted_fields = terminal_impl.actionFieldNames(action);
+        try std.testing.expectEqual(branch.properties.len, admitted_fields.len);
+        for (branch.properties, admitted_fields) |property, admitted_field| {
+            try std.testing.expectEqualStrings(property.name, admitted_field);
+        }
+    }
 }
 
 test "terminal gateway advertisement projects action-specific alternatives" {

--- a/src/core/tooling/gateway_schema.zig
+++ b/src/core/tooling/gateway_schema.zig
@@ -34,6 +34,7 @@ pub const ObjectSchema = struct {
     additional_properties: ?bool = null,
     min_properties: ?usize = null,
     max_properties: ?usize = null,
+    one_of: []const ObjectSchema = &.{},
 };
 
 pub const FunctionSchema = struct {
@@ -116,6 +117,24 @@ fn writeObjectSchema(
     writer: *std.Io.Writer,
     schema: ObjectSchema,
 ) anyerror!void {
+    if (schema.one_of.len > 0) {
+        if (schema.properties.len > 0 or
+            schema.required.len > 0 or
+            schema.additional_properties != null or
+            schema.min_properties != null or
+            schema.max_properties != null)
+        {
+            return error.InvalidObjectSchema;
+        }
+        try writer.writeAll("{\"oneOf\":[");
+        for (schema.one_of, 0..) |alternative, index| {
+            if (index > 0) try writer.writeByte(',');
+            try writeObjectSchema(alloc, writer, alternative);
+        }
+        try writer.writeAll("]}");
+        return;
+    }
+
     try writer.writeAll("{\"type\":\"object\",\"properties\":{");
     for (schema.properties, 0..) |property, index| {
         if (index > 0) try writer.writeByte(',');
@@ -214,6 +233,71 @@ test "nested object schema serializes exact property bounds" {
     try std.testing.expect(std.mem.find(u8, json, "\"maxProperties\":1") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"create\":{\"type\":\"object\",\"properties\":{") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"additionalProperties\":false") != null);
+}
+
+test "object alternatives serialize as exclusive object branches" {
+    const alloc = std.testing.allocator;
+    const alternatives = [_]ObjectSchema{
+        .{
+            .properties = &.{
+                .{ .name = "action", .json_type = .string, .enum_values = &.{"read"} },
+                .{ .name = "path", .json_type = .string },
+            },
+            .required = &.{ "action", "path" },
+            .additional_properties = false,
+        },
+        .{
+            .properties = &.{
+                .{ .name = "action", .json_type = .string, .enum_values = &.{"list"} },
+            },
+            .required = &.{"action"},
+            .additional_properties = false,
+        },
+    };
+    const schema = FunctionSchema{
+        .name = "alternative",
+        .description = "alternative",
+        .input_schema = .{ .one_of = &alternatives },
+    };
+
+    const json = try builtinFunctionSchemaJsonAlloc(alloc, schema);
+    defer alloc.free(json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+
+    const input_schema = parsed.value.object.get("inputSchema").?.object;
+    try std.testing.expect(input_schema.get("type") == null);
+    try std.testing.expect(input_schema.get("properties") == null);
+    const one_of = input_schema.get("oneOf").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), one_of.len);
+    try std.testing.expectEqualStrings(
+        "read",
+        one_of[0].object.get("properties").?.object.get("action").?.object.get("enum").?.array.items[0].string,
+    );
+    try std.testing.expectEqualStrings(
+        "list",
+        one_of[1].object.get("properties").?.object.get("action").?.object.get("enum").?.array.items[0].string,
+    );
+    try std.testing.expectEqual(false, one_of[0].object.get("additionalProperties").?.bool);
+    try std.testing.expectEqual(false, one_of[1].object.get("additionalProperties").?.bool);
+}
+
+test "object alternatives reject contradictory ordinary object metadata" {
+    const schema = FunctionSchema{
+        .name = "invalid_alternative",
+        .description = "invalid alternative",
+        .input_schema = .{
+            .properties = &.{.{ .name = "value", .json_type = .string }},
+            .one_of = &.{.{
+                .properties = &.{.{ .name = "action", .json_type = .string }},
+            }},
+        },
+    };
+
+    try std.testing.expectError(
+        error.InvalidObjectSchema,
+        builtinFunctionSchemaJsonAlloc(std.testing.allocator, schema),
+    );
 }
 
 test "cappedDescriptionAlloc appends explicit truncation marker" {

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -136,7 +136,7 @@ pub const Input = struct {
     close_policy: ?contracts.ClosePolicy = null,
 };
 
-fn actionFieldNames(action: contracts.Action) []const []const u8 {
+pub fn actionFieldNames(action: contracts.Action) []const []const u8 {
     return switch (action) {
         .start => &.{ "action", "cwd", "command", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors" },
         .read => &.{ "action", "session_id", "cursor_segment", "cursor_offset" },

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -136,6 +136,37 @@ pub const Input = struct {
     close_policy: ?contracts.ClosePolicy = null,
 };
 
+fn actionFieldNames(action: contracts.Action) []const []const u8 {
+    return switch (action) {
+        .start => &.{ "action", "cwd", "command", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors" },
+        .read => &.{ "action", "session_id", "cursor_segment", "cursor_offset" },
+        .screen => &.{ "action", "session_id" },
+        .write => &.{ "action", "session_id", "write", "lease" },
+        .wait => &.{ "action", "session_id", "return_when", "wait_ceiling_ms" },
+        .monitor => &.{ "action", "session_id", "monitor" },
+        .inspect => &.{ "action", "session_id", "after_event_id", "acknowledge_event_id", "max_events" },
+        .list => &.{ "action", "task_id", "workspace_root", "backend" },
+        .resize => &.{ "action", "session_id", "rows", "columns" },
+        .signal => &.{ "action", "session_id", "signal" },
+        .close => &.{ "action", "session_id", "close_policy" },
+    };
+}
+
+fn actionAllowsField(action: contracts.Action, field_name: []const u8) bool {
+    for (actionFieldNames(action)) |allowed_name| {
+        if (std.mem.eql(u8, allowed_name, field_name)) return true;
+    }
+    return false;
+}
+
+fn unexpectedActionField(action: contracts.Action, object: std.json.ObjectMap) ?[]const u8 {
+    var fields = object.iterator();
+    while (fields.next()) |entry| {
+        if (!actionAllowsField(action, entry.key_ptr.*)) return entry.key_ptr.*;
+    }
+    return null;
+}
+
 const OwnedInput = struct {
     parsed: std.json.Parsed(Input),
 
@@ -149,6 +180,50 @@ pub fn decode(
     ctx: tool_dispatch.DispatchContext,
     args_json: []const u8,
 ) tool_dispatch.DispatchError!tool_dispatch.DecodeResult {
+    var raw = std.json.parseFromSlice(
+        std.json.Value,
+        ctx.allocator,
+        args_json,
+        .{},
+    ) catch {
+        return .{ .failure = try ctx.allocator.dupe(
+            u8,
+            "terminal arguments must match the advertised action schema",
+        ) };
+    };
+    defer raw.deinit();
+    if (raw.value != .object) {
+        return .{ .failure = try ctx.allocator.dupe(
+            u8,
+            "terminal arguments must match the advertised action schema",
+        ) };
+    }
+    const raw_action = raw.value.object.get("action") orelse {
+        return .{ .failure = try ctx.allocator.dupe(
+            u8,
+            "terminal arguments must match the advertised action schema",
+        ) };
+    };
+    if (raw_action != .string) {
+        return .{ .failure = try ctx.allocator.dupe(
+            u8,
+            "terminal arguments must match the advertised action schema",
+        ) };
+    }
+    const action = std.meta.stringToEnum(contracts.Action, raw_action.string) orelse {
+        return .{ .failure = try ctx.allocator.dupe(
+            u8,
+            "terminal arguments must match the advertised action schema",
+        ) };
+    };
+    if (unexpectedActionField(action, raw.value.object)) |field_name| {
+        return .{ .failure = try std.fmt.allocPrint(
+            ctx.allocator,
+            "terminal {s} field \"{s}\" is not allowed",
+            .{ @tagName(action), field_name },
+        ) };
+    }
+
     const parsed = std.json.parseFromSlice(
         Input,
         ctx.allocator,
@@ -865,6 +940,77 @@ test "terminal decoder accepts every public action and owns its input" {
     }
 }
 
+test "terminal action field ownership is exact for every public action" {
+    const expected = [_]struct {
+        action: contracts.Action,
+        fields: []const []const u8,
+    }{
+        .{ .action = .start, .fields = &.{ "action", "cwd", "command", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors" } },
+        .{ .action = .read, .fields = &.{ "action", "session_id", "cursor_segment", "cursor_offset" } },
+        .{ .action = .screen, .fields = &.{ "action", "session_id" } },
+        .{ .action = .write, .fields = &.{ "action", "session_id", "write", "lease" } },
+        .{ .action = .wait, .fields = &.{ "action", "session_id", "return_when", "wait_ceiling_ms" } },
+        .{ .action = .monitor, .fields = &.{ "action", "session_id", "monitor" } },
+        .{ .action = .inspect, .fields = &.{ "action", "session_id", "after_event_id", "acknowledge_event_id", "max_events" } },
+        .{ .action = .list, .fields = &.{ "action", "task_id", "workspace_root", "backend" } },
+        .{ .action = .resize, .fields = &.{ "action", "session_id", "rows", "columns" } },
+        .{ .action = .signal, .fields = &.{ "action", "session_id", "signal" } },
+        .{ .action = .close, .fields = &.{ "action", "session_id", "close_policy" } },
+    };
+
+    try std.testing.expectEqual(std.meta.tags(contracts.Action).len, expected.len);
+    for (expected) |want| {
+        try std.testing.expectEqualSlices(
+            []const u8,
+            want.fields,
+            actionFieldNames(want.action),
+        );
+        inline for (@typeInfo(Input).@"struct".fields) |field| {
+            var want_allowed = false;
+            for (want.fields) |allowed_name| {
+                if (std.mem.eql(u8, allowed_name, field.name)) {
+                    want_allowed = true;
+                    break;
+                }
+            }
+            try std.testing.expectEqual(
+                want_allowed,
+                actionAllowsField(want.action, field.name),
+            );
+        }
+    }
+}
+
+test "terminal decoder rejects cross-action fields regardless of value" {
+    const alloc = std.testing.allocator;
+    inline for (&.{
+        .{
+            "{\"action\":\"start\",\"session_id\":\"\"}",
+            "terminal start field \"session_id\" is not allowed",
+        },
+        .{
+            "{\"action\":\"list\",\"cwd\":\"\",\"task_id\":\"\"}",
+            "terminal list field \"cwd\" is not allowed",
+        },
+        .{
+            "{\"action\":\"close\",\"close_policy\":\"force\",\"session_id\":\"terminal-a\",\"rows\":0}",
+            "terminal close field \"rows\" is not allowed",
+        },
+    }) |case| {
+        const decoded = try decode(.{ .allocator = alloc }, case[0]);
+        switch (decoded) {
+            .failure => |message| {
+                defer alloc.free(message);
+                try std.testing.expectEqualStrings(case[1], message);
+            },
+            .input => |input| {
+                input.deinit(alloc);
+                return error.TestUnexpectedResult;
+            },
+        }
+    }
+}
+
 test "terminal start accepts native and tmux backend contracts" {
     const alloc = std.testing.allocator;
     inline for (.{ "native", "tmux" }) |backend| {
@@ -958,7 +1104,7 @@ test "terminal start canonicalizes interactive command representations" {
     }
 }
 
-test "registered terminal validation accepts an exact empty start command" {
+test "registered terminal validation enforces action-specific input before execution" {
     const terminal_tool = tool_dispatch.Tool{
         .name = "terminal",
         .description = "Terminal test adapter.",
@@ -978,16 +1124,46 @@ test "registered terminal validation accepts an exact empty start command" {
         .workspace_root = "/tmp",
     };
 
-    const accepted = try tool_dispatch.validateRegisteredToolCall(ctx, registry, .{
-        .id = "terminal-empty-start",
+    inline for (&.{
+        "{\"action\":\"start\",\"command\":\"\"}",
+        "{\"action\":\"read\",\"session_id\":\"terminal-a\",\"cursor_segment\":1}",
+        "{\"action\":\"screen\",\"session_id\":\"terminal-a\"}",
+        "{\"action\":\"write\",\"session_id\":\"terminal-a\",\"lease\":\"acquire\"}",
+        "{\"action\":\"wait\",\"session_id\":\"terminal-a\",\"return_when\":{\"kind\":\"exit\"},\"wait_ceiling_ms\":1000}",
+        "{\"action\":\"monitor\",\"session_id\":\"terminal-a\",\"monitor\":{\"kind\":\"remove\",\"monitor_id\":\"monitor-a\"}}",
+        "{\"action\":\"inspect\",\"session_id\":\"terminal-a\"}",
+        "{\"action\":\"list\",\"task_id\":\"\",\"workspace_root\":\"\"}",
+        "{\"action\":\"resize\",\"session_id\":\"terminal-a\",\"rows\":24,\"columns\":80}",
+        "{\"action\":\"signal\",\"session_id\":\"terminal-a\",\"signal\":\"interrupt\"}",
+        "{\"action\":\"close\",\"session_id\":\"terminal-a\",\"close_policy\":\"force\"}",
+    }) |arguments_json| {
+        const accepted = try tool_dispatch.validateRegisteredToolCall(ctx, registry, .{
+            .id = "terminal-valid",
+            .name = "terminal",
+            .arguments_json = arguments_json,
+        });
+        defer switch (accepted) {
+            .failure => |reason| std.testing.allocator.free(reason),
+            else => {},
+        };
+        try std.testing.expectEqual(.valid, accepted);
+    }
+
+    const mixed = try tool_dispatch.validateRegisteredToolCall(ctx, registry, .{
+        .id = "terminal-mixed-start",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"start\",\"command\":\"\"}",
+        .arguments_json = "{\"action\":\"start\",\"command\":\"printf wrong\",\"session_id\":\"terminal-a\",\"write\":{\"kind\":\"text\",\"text\":\"wrong\"},\"rows\":24,\"columns\":80,\"signal\":\"terminate\",\"close_policy\":\"force\"}",
     });
-    defer switch (accepted) {
+    defer switch (mixed) {
         .failure => |reason| std.testing.allocator.free(reason),
         else => {},
     };
-    try std.testing.expectEqual(.valid, accepted);
+    switch (mixed) {
+        .failure => |reason| try std.testing.expect(
+            std.mem.find(u8, reason, "terminal start field \"session_id\" is not allowed") != null,
+        ),
+        else => return error.TestUnexpectedResult,
+    }
 
     const rejected = try tool_dispatch.validateRegisteredToolCall(ctx, registry, .{
         .id = "terminal-invalid-resize",
@@ -1248,7 +1424,7 @@ test "terminal public list rejects lifecycle and projects supported filters" {
 
     const empty_decoded = try decode(
         .{ .allocator = alloc },
-        "{\"action\":\"list\",\"session_id\":\"\",\"cwd\":\"\",\"task_id\":\"\",\"workspace_root\":\"\"}",
+        "{\"action\":\"list\",\"task_id\":\"\",\"workspace_root\":\"\"}",
     );
     switch (empty_decoded) {
         .failure => |message| {

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -1082,6 +1082,141 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "terminal action-specific schema rejects mixed input before starting a session",
+  async () => {
+    const fixture = createFixture("fx-tui-terminal-action-schema-");
+    const mixedMarker = join(fixture.workspace, "mixed-start-ran");
+    let terminalSessionId = "";
+    const gateway = startFakeGateway([
+      fakeGatewayToolCall("terminal_mixed_start", "terminal", {
+        action: "start",
+        cwd: fixture.workspace,
+        command: `printf SHOULD_NOT_RUN > ${JSON.stringify(mixedMarker)}`,
+        backend: "native",
+        session_id: "terminal-foreign",
+        cursor_segment: 1,
+        cursor_offset: 0,
+        after_event_id: 0,
+        acknowledge_event_id: 1,
+        max_events: 1,
+        write: { kind: "text", text: "wrong action" },
+        lease: "use",
+        monitor: { kind: "remove", monitor_id: "monitor-foreign" },
+        task_id: "task-foreign",
+        workspace_root: fixture.workspace,
+        rows: 24,
+        columns: 80,
+        signal: "terminate",
+        close_policy: "force",
+      }),
+      (body) => {
+        expect(toolResultText(body, "terminal_mixed_start")).toContain(
+          'terminal start field "session_id" is not allowed',
+        );
+        expect(terminalRecords(fixture.home)).toEqual([]);
+        expect(existsSync(mixedMarker)).toBe(false);
+        return fakeGatewayToolCall("terminal_valid_start", "terminal", {
+          action: "start",
+          cwd: fixture.workspace,
+          command: "printf ACTION_SCHEMA_OK",
+          shell: {
+            kind: "executable",
+            path: TERMINAL_FIXTURE_SHELL,
+            clean_start: true,
+          },
+          backend: "native",
+          return_when: { kind: "exit" },
+          wait_ceiling_ms: 20_000,
+        });
+      },
+      (body) => {
+        const resultText = toolResultText(body, "terminal_valid_start");
+        const result = JSON.parse(resultText) as {
+          success: { start: { session: { session_id: string } } };
+        };
+        terminalSessionId = result.success.start.session.session_id;
+        expect(terminalSessionId.length).toBeGreaterThan(0);
+        return fakeGatewayToolCall("terminal_valid_close", "terminal", {
+          action: "close",
+          session_id: terminalSessionId,
+          close_policy: "force",
+        });
+      },
+      (body) => {
+        const result = toolResultText(body, "terminal_valid_close");
+        expect(result).toContain(`"session_id":"${terminalSessionId}"`);
+        expect(result).toContain('"lifecycle":"closed"');
+        return fakeGatewayFinalText("Terminal action schema verified");
+      },
+    ]);
+    gateways.push(gateway);
+    const active = await launch(fixture, gateway);
+
+    await active.sendText("Verify the terminal action schema.");
+    await active.waitForText("Terminal action schema verified", TIMEOUT);
+    expect(gateway.requests).toHaveLength(4);
+
+    const firstRequest = JSON.parse(gateway.requests[0]!.body) as {
+      tools: Array<{
+        name?: string;
+        inputSchema?: {
+          properties?: Record<string, unknown>;
+          oneOf?: Array<{
+            properties?: Record<string, { enum?: string[] }>;
+            required?: string[];
+            additionalProperties?: boolean;
+          }>;
+        };
+      }>;
+    };
+    const terminalSchema = firstRequest.tools.find(
+      (tool) => tool.name === "terminal",
+    )?.inputSchema;
+    expect(terminalSchema).toBeDefined();
+    expect(terminalSchema!.properties).toBeUndefined();
+    const branches = terminalSchema!.oneOf ?? [];
+    const expectedBranches = [
+      { action: "start", properties: ["action", "cwd", "command", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors"], required: ["action"] },
+      { action: "read", properties: ["action", "session_id", "cursor_segment", "cursor_offset"], required: ["action", "session_id", "cursor_segment"] },
+      { action: "screen", properties: ["action", "session_id"], required: ["action", "session_id"] },
+      { action: "write", properties: ["action", "session_id", "write", "lease"], required: ["action", "session_id"] },
+      { action: "wait", properties: ["action", "session_id", "return_when", "wait_ceiling_ms"], required: ["action", "session_id", "return_when", "wait_ceiling_ms"] },
+      { action: "monitor", properties: ["action", "session_id", "monitor"], required: ["action", "session_id", "monitor"] },
+      { action: "inspect", properties: ["action", "session_id", "after_event_id", "acknowledge_event_id", "max_events"], required: ["action", "session_id"] },
+      { action: "list", properties: ["action", "task_id", "workspace_root", "backend"], required: ["action"] },
+      { action: "resize", properties: ["action", "session_id", "rows", "columns"], required: ["action", "session_id", "rows", "columns"] },
+      { action: "signal", properties: ["action", "session_id", "signal"], required: ["action", "session_id", "signal"] },
+      { action: "close", properties: ["action", "session_id", "close_policy"], required: ["action", "session_id", "close_policy"] },
+    ];
+    expect(branches).toHaveLength(expectedBranches.length);
+    for (const expected of expectedBranches) {
+      const branch = branches.find((candidate) =>
+        candidate.properties?.action?.enum?.[0] === expected.action
+      );
+      expect(branch).toBeDefined();
+      expect(branch!.properties!.action!.enum).toEqual([expected.action]);
+      expect(Object.keys(branch!.properties!)).toEqual(expected.properties);
+      expect(branch!.required).toEqual(expected.required);
+      expect(branch!.additionalProperties).toBe(false);
+    }
+
+    const scrollback = await active.captureFullScrollback();
+    expect(countOccurrences(scrollback, "Used terminal start")).toBe(1);
+    expect(scrollback).toContain("Used terminal close");
+    expect(existsSync(mixedMarker)).toBe(false);
+    const records = terminalRecords(fixture.home);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.session_id).toBe(terminalSessionId);
+    expect(records[0]!.lifecycle).toBe("closed");
+    const terminalPid = Number(records[0]!.pid);
+    expect(Number.isSafeInteger(terminalPid) && terminalPid > 0).toBe(true);
+    await waitForOwnedProcessExit([terminalPid]);
+    expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
   "TUI starts an interactive terminal when the command is exact empty",
   async () => {
     const fixture = createFixture("fx-tui-terminal-empty-command-");
@@ -1300,14 +1435,27 @@ test.skipIf(!tmuxAvailable())(
     const request = JSON.parse(gateway.requests[0]!.body) as {
       tools: Array<{
         name?: string;
-        inputSchema?: { properties?: Record<string, unknown> };
+        inputSchema?: {
+          properties?: Record<string, unknown>;
+          oneOf?: Array<{
+            properties?: Record<string, {
+              enum?: string[];
+            }>;
+          }>;
+        };
       }>;
     };
     const terminalSchema = request.tools.find(
       (tool) => tool.name === "terminal",
     )?.inputSchema;
     expect(terminalSchema).toBeDefined();
-    const terminalProperties = Object.keys(terminalSchema!.properties ?? {});
+    expect(terminalSchema!.properties).toBeUndefined();
+    expect(terminalSchema!.oneOf).toHaveLength(11);
+    const waitBranch = terminalSchema!.oneOf!.find((branch) =>
+      branch.properties?.action?.enum?.[0] === "wait"
+    );
+    expect(waitBranch).toBeDefined();
+    const terminalProperties = Object.keys(waitBranch!.properties ?? {});
     expect(
       terminalProperties.filter((name) => name === "wait_ceiling_ms"),
     ).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Advertise one exact input shape for each terminal action.
- Reject fields from other terminal actions before permission or terminal session changes.
- Keep valid terminal calls, including empty-command interactive starts, unchanged.