### PR TITLE
Define pull request type labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ Every pull request must have exactly one `type:` label, chosen by its primary in
 
 * `type: security`: fixes or hardens a security boundary
 
-Assign the label when the PR is opened and keep it accurate when the PR changes. For a mixed PR, choose the label that describes the primary reason the PR exists. If that is ambiguous, ask before applying or changing the label.
+Assign the label when the PR is opened and keep it accurate when the PR changes. If the authenticated contributor cannot manage labels, state the required label and keep the PR in draft until a maintainer or repository agent applies it. For a mixed PR, choose the label that describes the primary reason the PR exists. If that is ambiguous, ask before applying or changing the label.
 
 Keep PR titles as clean imperative sentences, such as `Restore feedback report file clipboard`. Do not add bracketed prefixes such as `[bug]`, `[feature]`, or `[improvement]`. Type belongs in the label, not the title.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,28 @@ cd tests/e2e && bun test tui-*.test.ts               # just TUI tests (requires 
 
 TUI tests use tmux to drive the interactive terminal. They require `tmux` to be installed.
 
+## Pull Request Classification
+
+Every pull request must have exactly one `type:` label, chosen by its primary intent:
+
+* `type: bug` — fixes incorrect behavior
+
+* `type: feature` — adds a new user-facing capability
+
+* `type: improvement` — improves existing user-facing behavior
+
+* `type: docs` — changes documentation only
+
+* `type: maintenance` — changes internal tooling, dependencies, CI, or implementation structure without a user-facing behavior change
+
+* `type: release` — prepares or repairs a release
+
+* `type: security` — fixes or hardens a security boundary
+
+Assign the label when the PR is opened and keep it accurate when the PR changes. For a mixed PR, choose the label that describes the primary reason the PR exists. If that is ambiguous, ask before applying or changing the label.
+
+Keep PR titles as clean imperative sentences, such as `Restore feedback report file clipboard`. Do not add bracketed prefixes such as `[bug]`, `[feature]`, or `[improvement]`. Type belongs in the label, not the title.
+
 ## Full CI on Feature Branches
 
 Do not run the complete deterministic test suite locally as the default development loop. Run the focused test for the changed path, build the binary, and exercise that path with `./zig-out/bin/fx`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,19 +220,19 @@ TUI tests use tmux to drive the interactive terminal. They require `tmux` to be 
 
 Every pull request must have exactly one `type:` label, chosen by its primary intent:
 
-* `type: bug` — fixes incorrect behavior
+* `type: bug`: fixes incorrect behavior
 
-* `type: feature` — adds a new user-facing capability
+* `type: feature`: adds a new user-facing capability
 
-* `type: improvement` — improves existing user-facing behavior
+* `type: improvement`: improves existing user-facing behavior
 
-* `type: docs` — changes documentation only
+* `type: docs`: changes documentation only
 
-* `type: maintenance` — changes internal tooling, dependencies, CI, or implementation structure without a user-facing behavior change
+* `type: maintenance`: changes internal tooling, dependencies, CI, or implementation structure without a user-facing behavior change
 
-* `type: release` — prepares or repairs a release
+* `type: release`: prepares or repairs a release
 
-* `type: security` — fixes or hardens a security boundary
+* `type: security`: fixes or hardens a security boundary
 
 Assign the label when the PR is opened and keep it accurate when the PR changes. For a mixed PR, choose the label that describes the primary reason the PR exists. If that is ambiguous, ask before applying or changing the label.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,26 @@ Once the focused checks pass, create a clean checkpoint commit, push the non-`ma
 
 Standard PR CI labels Debug and ReleaseSafe Build & Test and deterministic E2E results separately. Do not mark the draft PR ready until all four Full CI jobs and the final ship gate have succeeded for the exact current commit. Each platform aggregate requires both optimization modes. A result from an older commit does not count. Live model evals are separate from this gate because they require credentials and are not deterministic.
 
+## Pull Requests
+
+Assign exactly one label that describes the PR's primary intent:
+
+* `type: bug` — fixes incorrect behavior
+
+* `type: feature` — adds a new user-facing capability
+
+* `type: improvement` — improves existing user-facing behavior
+
+* `type: docs` — changes documentation only
+
+* `type: maintenance` — changes internal tooling, dependencies, CI, or implementation structure without a user-facing behavior change
+
+* `type: release` — prepares or repairs a release
+
+* `type: security` — fixes or hardens a security boundary
+
+For a mixed PR, choose the label that best describes why the PR exists. Keep the title as a clean imperative sentence and do not add bracketed type prefixes such as `[bug]` or `[improvement]`.
+
 ## Repo Shape
 
 * `src/main.zig`: composition root only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,19 +47,19 @@ Standard PR CI labels Debug and ReleaseSafe Build & Test and deterministic E2E r
 
 Assign exactly one label that describes the PR's primary intent:
 
-* `type: bug` — fixes incorrect behavior
+* `type: bug`: fixes incorrect behavior
 
-* `type: feature` — adds a new user-facing capability
+* `type: feature`: adds a new user-facing capability
 
-* `type: improvement` — improves existing user-facing behavior
+* `type: improvement`: improves existing user-facing behavior
 
-* `type: docs` — changes documentation only
+* `type: docs`: changes documentation only
 
-* `type: maintenance` — changes internal tooling, dependencies, CI, or implementation structure without a user-facing behavior change
+* `type: maintenance`: changes internal tooling, dependencies, CI, or implementation structure without a user-facing behavior change
 
-* `type: release` — prepares or repairs a release
+* `type: release`: prepares or repairs a release
 
-* `type: security` — fixes or hardens a security boundary
+* `type: security`: fixes or hardens a security boundary
 
 For a mixed PR, choose the label that best describes why the PR exists. Keep the title as a clean imperative sentence and do not add bracketed type prefixes such as `[bug]` or `[improvement]`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Standard PR CI labels Debug and ReleaseSafe Build & Test and deterministic E2E r
 
 ## Pull Requests
 
-Assign exactly one label that describes the PR's primary intent:
+Every PR must carry exactly one label that describes its primary intent:
 
 * `type: bug`: fixes incorrect behavior
 
@@ -61,7 +61,7 @@ Assign exactly one label that describes the PR's primary intent:
 
 * `type: security`: fixes or hardens a security boundary
 
-For a mixed PR, choose the label that best describes why the PR exists. Keep the title as a clean imperative sentence and do not add bracketed type prefixes such as `[bug]` or `[improvement]`.
+If you cannot manage labels, a maintainer or repository agent will apply the label before review. For a mixed PR, choose the label that best describes why the PR exists. Keep the title as a clean imperative sentence and do not add bracketed type prefixes such as `[bug]` or `[improvement]`.
 
 ## Repo Shape
 


### PR DESCRIPTION
## Summary

- Require one namespaced type label based on each pull request's primary intent.
- Let maintainers or repository agents label contributions when authors lack permission.
- Keep pull request titles as imperative sentences without bracketed type prefixes.
