### PR TITLE
Tighten comment discipline

### DIFF
--- a/src/builtins/context.zig
+++ b/src/builtins/context.zig
@@ -2085,8 +2085,7 @@ fn collectGitHubRepoIdentity(arena: Allocator, git_dir: []const u8, started_ns: 
 fn detectGitWorktreeState(arena: Allocator, workspace_root: []const u8, git_dir: []const u8, started_ns: i128) GitWorktreeState {
     if (gitReadExpired(started_ns)) return .unknown;
 
-    // This is a bounded hint, not `git status`: a small index can prove some
-    // obvious tracked-file dirtiness, but it cannot rule out untracked files.
+    // This bounded hint can prove tracked-file changes but cannot detect untracked files.
     const dirty_markers = [_][]const u8{
         "MERGE_HEAD",
         "CHERRY_PICK_HEAD",

--- a/src/builtins/hooks/herdr.zig
+++ b/src/builtins/hooks/herdr.zig
@@ -1,14 +1,7 @@
-//! Best-effort lifecycle-state reporter for the herdr agent multiplexer
-//! (https://herdr.dev). When fx runs inside a herdr pane, herdr injects
-//! HERDR_SOCKET_PATH and HERDR_PANE_ID; we open that unix socket and push
-//! newline-delimited JSON so the pane shows authoritative idle/working/blocked
-//! state instead of herdr's terminal-output heuristics.
+//! Best-effort lifecycle reporter for the herdr agent multiplexer.
 //!
-//! herdr closes the socket after responding to each request, so every report
-//! opens a fresh connection (connect, write one line, drain reply, close).
-//! Reporting is fire-and-forget: failures are swallowed so a slow or absent
-//! herdr never breaks the fx session. Reply drains use a short socket timeout
-//! so a hung herdr cannot freeze the main thread.
+//! Each report uses a short-lived Unix socket. Failures and reply timeouts are
+//! ignored so the integration cannot block or terminate an fx session.
 
 const std = @import("std");
 const io_mod = @import("../../core/shared/io.zig");
@@ -18,12 +11,12 @@ const jsonrpc = @import("../../acp/jsonrpc.zig");
 
 pub const State = enum { idle, working, blocked };
 
-/// herdr caps custom_status at 32 bytes.
+// herdr protocol limits custom status to 32 bytes.
 const custom_status_max = 32;
-/// Bound how long we wait for herdr's one-line reply before closing.
+/// Maximum wait for herdr's one-line reply.
 const response_timeout = std.posix.timeval{ .sec = 0, .usec = 250_000 };
 
-/// Non-official integrations report under a `custom:` source prefix.
+// Third-party reporters use the `custom:` source prefix.
 const source = "custom:fx";
 const agent_name = "fx";
 
@@ -45,8 +38,6 @@ pub const Client = struct {
     pane_id: []u8 = &.{},
     next_id: u64 = 1,
 
-    /// Enable reporting only when both env vars are present and FX_HERDR is not
-    /// an explicit opt-out. Pure so it can be unit-tested without touching env.
     pub fn shouldEnable(
         fx_herdr: ?[]const u8,
         socket_path: ?[]const u8,
@@ -61,8 +52,6 @@ pub const Client = struct {
         return path.len > 0 and pane.len > 0;
     }
 
-    /// Resolve config from the environment. No-op (stays disabled) when fx is
-    /// not running under herdr or the user opted out.
     pub fn initFromEnv(self: *Client, alloc: std.mem.Allocator) void {
         const socket_path = io_mod.getenv("HERDR_SOCKET_PATH");
         const pane_id = io_mod.getenv("HERDR_PANE_ID");

--- a/src/core/agent/question_prompt.zig
+++ b/src/core/agent/question_prompt.zig
@@ -1152,7 +1152,6 @@ test "syncFrom appends freeform slot to every entry" {
     };
     try prompt.syncFrom(std.testing.allocator, &entries);
 
-    // Each entry should have one extra option appended.
     try std.testing.expectEqual(@as(usize, 3), prompt.entries.items[0].options.items.len);
     try std.testing.expectEqual(@as(usize, 2), prompt.entries.items[1].options.items.len);
 
@@ -1231,7 +1230,6 @@ test "insert actions do not navigate freeform choices" {
     prompt.moveChoice(-1);
     try std.testing.expectEqual(@as(u8, 3), currentChoiceIndex(&prompt));
 
-    // Inserting a letter into freeform must not navigate options.
     _ = try prompt.apply(std.testing.allocator, .{ .insert_ascii = 'k' });
     try std.testing.expectEqual(@as(u8, 3), currentChoiceIndex(&prompt));
     try std.testing.expectEqualStrings("k", prompt.entries.items[0].freeform_buffer.items);

--- a/src/core/agent/runtime/vision_contracts.zig
+++ b/src/core/agent/runtime/vision_contracts.zig
@@ -483,11 +483,8 @@ pub noinline fn project_text_only_messages(
     return projected;
 }
 
-/// Produces an arena-scoped native-route view that preserves raw images and
-/// omits Vision evidence outside the root turn beginning at
-/// `current_user_message_index`. A Vision call is retained only when its
-/// assistant message is followed by a contiguous tool-result block containing
-/// its structured route rejection, and only that result position is retained.
+/// Produces arena-scoped native-route messages with raw images. Retains only
+/// root-turn Vision calls followed by contiguous structured route rejections.
 /// Canonical history is unchanged.
 pub noinline fn project_native_messages(
     alloc: Allocator,

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -862,9 +862,7 @@ pub fn Runtime(comptime App: type) type {
         ) !void {
             const byte = raw.byte;
             const max_input_len = input_limits.composer_bytes;
-            // max-level cue on the rising edge of the slash command menu: fire
-            // once when this byte makes it appear, not on every keystroke while
-            // it stays open. Cheap no-op unless the max level is on.
+            // Fire the max-level cue only when the slash menu becomes visible.
             const slash_menu_was_visible = slashMenuVisibleForCue(app);
             defer announceSlashMenuOpened(app, slash_menu_was_visible);
             if (try routeActivePasteByte(app, byte)) return;
@@ -10063,7 +10061,6 @@ test "escape on a freeform draft arms then clears before cancelling the batch" {
     try std.testing.expect(app.question_prompt.isFreeformSelected());
     _ = try app.question_prompt.apply(alloc, .{ .insert_ascii = 'k' });
 
-    // First Esc arms the double-tap clear and leaves the draft alone.
     app.input_runtime.terminal_action_decoder.stage = 1;
     app.input_runtime.terminal_action_decoder.cancel_pending = true;
     app.input_runtime.terminal_action_decoder.started_ms = 0;
@@ -10074,7 +10071,6 @@ test "escape on a freeform draft arms then clears before cancelling the batch" {
     try std.testing.expect(app.question_prompt.isActive());
     try std.testing.expect(!app.worker.cancel_requested);
 
-    // Second Esc inside the window clears the field but keeps the batch.
     app.input_runtime.terminal_action_decoder.stage = 1;
     app.input_runtime.terminal_action_decoder.cancel_pending = true;
     app.input_runtime.terminal_action_decoder.started_ms = 0;
@@ -10086,7 +10082,6 @@ test "escape on a freeform draft arms then clears before cancelling the batch" {
     try std.testing.expect(!app.input_runtime.gestures.escapeClearArmed());
     try std.testing.expect(!app.worker.cancel_requested);
 
-    // Third Esc on the empty field cancels the batch.
     app.input_runtime.terminal_action_decoder.stage = 1;
     app.input_runtime.terminal_action_decoder.cancel_pending = true;
     app.input_runtime.terminal_action_decoder.started_ms = 0;

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -32,16 +32,8 @@ const TranscriptRuntime = transcript_runtime.TranscriptRuntime;
 pub const ResizeHandler = shell_runtime.ResizeHandler;
 pub const default_permission_mode = config_runtime.default_permission_mode;
 
-/// Minimal terminal-state restoration emitted by the abnormal-exit
-/// signal handlers. Kept as a compile-time string so the handler can
-/// write it via a single async-signal-safe `write(2)` call without
-/// any formatting or allocation.
-///
-/// Restores: DECAWM (autowrap), SGR defaults, cursor visibility,
-/// bracketed paste and theme notifications off, kitty keyboard flags off,
-/// modifyOtherKeys off.
-/// Ends with a newline so the user's next shell prompt starts on its
-/// own row rather than bleeding into fx's last emit.
+/// Compile-time terminal restoration for one async-signal-safe `write(2)` call.
+/// Resets terminal modes and ends with a newline before the next shell prompt.
 const abnormal_exit_restore_prefix = "\x1b[?2026l\x1b[?1000l\x1b[?1002l\x1b[?1004l\x1b[?1006l\x1b[?1l\x1b>\x1b[?1049l\x1b[?7h\x1b[4l\x1b[?6l\x1b[0m\x1b[?25h\x1b[?2031l\x1b[?2004l";
 const abnormal_exit_restore = abnormal_exit_restore_prefix ++ "\x1b[<u\x1b[>4;0m\n";
 const tmux_abnormal_exit_restore = abnormal_exit_restore_prefix ++ "\x1b[>4;0m\n";
@@ -52,23 +44,15 @@ const alternate_screen_enter = "\x1b[?1049h";
 const alternate_mouse_tracking_enter = "\x1b[?1000h\x1b[?1006h";
 const terminal_takeover_reset = "\x1b[?2026l\x1b[?1000l\x1b[?1002l\x1b[?1004l\x1b[?1006l\x1b[?1l\x1b>\x1b[?2004l\x1b[<u\x1b[>4;0m\x1b[4l\x1b[?6l\x1b[?7h\x1b[0m\x1b[?25h";
 
-/// Stored so `uninstallAbnormalExitHandlers` can restore them. Only
-/// written from `installAbnormalExitHandlers` at bootstrap and read
-/// from `uninstallAbnormalExitHandlers` at shutdown. Never mutated from
-/// signal context.
+/// Original handlers, written at bootstrap and restored at shutdown.
+/// Signal context never mutates them.
 var old_sigterm_action: ?std.posix.Sigaction = null;
 var old_sighup_action: ?std.posix.Sigaction = null;
 
-/// Signal handler for SIGTERM / SIGHUP. It restores terminal state and
-/// re-raises the signal with the default disposition so the process
-/// terminates.
-///
-/// MUST be async-signal-safe: only `write(2)`, `sigaction(2)`, and
-/// `raise(3)` are used. No allocation, no std.Io wrappers, no Zig
-/// mutexes, because those can deadlock from signal context.
+/// Restores terminal state, installs the default disposition, and re-raises.
+/// Must remain async-signal-safe: only `write(2)`, `sigaction(2)`, and `raise(3)`.
 fn abnormalExitHandlerWithRestore(comptime restore: []const u8, sig: std.posix.SIG) void {
-    // libc write() is async-signal-safe. Ignore the return; there is
-    // nothing we can do from signal context if it fails.
+    // Signal context cannot recover from a failed async-signal-safe write.
     _ = std.c.write(
         std.posix.STDOUT_FILENO,
         restore.ptr,

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -1139,9 +1139,7 @@ pub fn CompletionRuntime(comptime App: type) type {
 
             const stage: ModelPickerStage = if (supports_effort) .effort else .fast;
             try setModelComposerText(app, "/model {s} ", .{model});
-            // Land on the recommended pair so switching is just Enter-Enter:
-            // product default (falling back to the model's first option) and
-            // fast on whenever the model offers it.
+            // Preselect the product effort default and enable Fast mode when supported.
             try app.input_runtime.picker.beginModelPickerFlow(
                 app.alloc,
                 model,

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1133,10 +1133,8 @@ pub const Runtime = struct {
         return self.adoptCredential(alloc, &credential);
     }
 
-    /// Drops the current selection and re-runs precedence. Distinct from the
-    /// logout reconcile, which only acts when a login was active: clearing a
-    /// remembered choice can leave any source selected, and leaving it in place
-    /// would keep the session on the source the user just un-remembered.
+    /// Drops the current selection and re-runs precedence after the user clears
+    /// a remembered credential source.
     pub fn reselectByPrecedence(self: *Self, alloc: Allocator) !bool {
         return self.reselectByPrecedenceWithDeps(alloc, self, probeCredentialSource, loadRuntimeCredentialSource);
     }

--- a/src/core/config/js_host_config_store.zig
+++ b/src/core/config/js_host_config_store.zig
@@ -54,7 +54,7 @@ pub fn load(alloc: Allocator, id: []const u8) LoadError!?[]u8 {
     return error.ValueTooLarge;
 }
 
-/// Persists a value only after Fx has accepted and applied it.
+/// Persists a value only after fx has accepted and applied it.
 pub fn setAccepted(id: []const u8, value: []const u8) SaveError!void {
     if (fx_config_set(id.ptr, id.len, value.ptr, value.len) != 0) {
         return error.HostFailure;

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -930,10 +930,8 @@ test "clearing the credential choice removes the key rather than blanking it" {
     var application = try applyUserPatchToRoot(arena.allocator(), &root, .{ .clear_credential_source = true });
     try std.testing.expect(application.changed);
     try std.testing.expect(!root.object.contains("credential_source"));
-    // Unrelated preferences survive the clear.
     try std.testing.expect(root.object.contains("model"));
 
-    // Clearing an absent key is a no-op rather than a spurious write.
     application = try applyUserPatchToRoot(arena.allocator(), &root, .{ .clear_credential_source = true });
     try std.testing.expect(!application.changed);
 }

--- a/src/core/images/image_attachments.zig
+++ b/src/core/images/image_attachments.zig
@@ -1001,8 +1001,6 @@ pub fn imageBadgeVisibleWidth(image_id: usize) usize {
     return "[Image ".len + digits + "]".len;
 }
 
-/// Bump-and-return helper for image-id counters. Centralises the trivial
-/// increment so every App / FakeApp doesn't reimplement it.
 pub fn allocateImageId(counter: *usize) usize {
     const id = counter.*;
     counter.* += 1;
@@ -1178,12 +1176,8 @@ pub fn imagePlaceholderSpanEndingAt(text: []const u8, byte_offset: usize) ?Image
 
 pub const ExpandWithBadgesResult = struct { cursor_out: ?usize, expanded_any: bool };
 
-/// Walks `text` and emits it to `writer`, replacing each `[Image #<id>]`
-/// placeholder with a path-free badge carrying the attachment's own id, so a
-/// badge names the same image everywhere the id is used.
-/// If `cursor_in` is non-null, returns the byte offset in the emitted output
-/// that corresponds to the cursor's byte offset in `text`.
-/// Placeholders whose id is not in `images` are emitted verbatim.
+/// Replaces known image placeholders with path-free badges keyed by attachment ID.
+/// Unknown placeholders pass through; `cursor_out` maps `cursor_in` to output bytes.
 pub fn expandPlaceholdersWithBadges(
     alloc: std.mem.Allocator,
     writer: *std.Io.Writer,

--- a/src/core/notifications/sound.zig
+++ b/src/core/notifications/sound.zig
@@ -15,14 +15,7 @@ pub const default_enabled: bool = builtin.os.tag == .macos;
 pub const Cue = notification_contract.Cue;
 pub const Kind = notification_contract.Kind;
 
-// Short chimes rendered from cuelume's recipes (MIT, Daniel White): `success`
-// is three ascending sine tones, `error` a muted knock with two descending
-// triangles, `bloom` a warm detuned swell for startup, `press` a dull knock
-// for cancellation, `click` cuelume's press+release pair for model/fast changes,
-// `release` a brighter springy tick for the max double-Esc input clear,
-// `toggle` a two-part click-clack for the max slash-menu open. The asset mapping
-// stays here so the semantic cue contract does not own player-specific files.
-// Assets are IMA4 CAF, afplay-native, to keep the embedded bytes small.
+// IMA4 CAF chimes derived from cuelume's MIT-licensed recipes by Daniel White.
 fn embeddedChime(cue: Cue) []const u8 {
     return switch (cue) {
         inline else => |named_cue| @embedFile(@tagName(named_cue) ++ ".caf"),
@@ -39,11 +32,7 @@ var sound_path_mutex: std.Io.Mutex = .init;
 var materialized_paths = [_]?[]const u8{null} ** std.enums.values(Cue).len;
 var sound_path_bufs: [std.enums.values(Cue).len][std.fs.max_path_bytes]u8 = undefined;
 
-// afplay needs a file path, so each embedded chime is written to the temp dir
-// on first use. Lazily, because startup has a tight budget. A size-matched
-// regular file from a prior launch is reused; rewrites are installed atomically
-// so a pre-existing symlink is replaced rather than followed. Returns null
-// (caller falls back to the bell) if the write fails.
+// Materialize lazily to protect startup latency. Atomic replacement avoids following symlinks.
 fn ensureCueSoundPath(cue: Cue) ?[]const u8 {
     const idx = @intFromEnum(cue);
     sound_path_mutex.lockUncancelable(io_mod.getIo());

--- a/src/core/output/activity_status.zig
+++ b/src/core/output/activity_status.zig
@@ -299,16 +299,12 @@ test "thinking clock freezes while waiting on user input and excludes the wait" 
     var stream: StreamState = .{ .active = true, .turn_started_ms = 1_000 };
     var buf: [64]u8 = undefined;
 
-    // 4s of thinking, then an approval opens.
     syncWaitingClock(&stream, true, 5_000);
     try std.testing.expectEqual(@as(i64, 5_000), stream.waiting_since_ms);
 
-    // The counter stays frozen at 4s and the marker holds steady no matter
-    // how long the approval sits unanswered.
     try std.testing.expectEqualStrings("• Thinking (4s)", buildThinkingLabel(&buf, stream, 900_000).?);
     try std.testing.expectEqual(@as(?bool, true), thinkingBlinkVisible(stream, 900_000));
 
-    // Answered after 895s: the wait is excluded, the clock resumes at 4s.
     syncWaitingClock(&stream, false, 900_000);
     try std.testing.expectEqual(@as(i64, 0), stream.waiting_since_ms);
     try std.testing.expectEqualStrings("• Thinking (4s)", buildThinkingLabel(&buf, stream, 900_000).?);
@@ -317,8 +313,6 @@ test "thinking clock freezes while waiting on user input and excludes the wait" 
 
 test "waiting clock accumulates across repeated prompts in one turn" {
     var stream: StreamState = .{ .active = true, .turn_started_ms = 0 };
-    // Without a turn clock there is nothing to shift, but the waiting flag
-    // still clears.
     syncWaitingClock(&stream, true, 1_000);
     syncWaitingClock(&stream, false, 9_000);
     try std.testing.expectEqual(@as(i64, 0), stream.turn_started_ms);
@@ -329,7 +323,6 @@ test "waiting clock accumulates across repeated prompts in one turn" {
     syncWaitingClock(&stream, false, 10_000);
     syncWaitingClock(&stream, true, 11_000);
     syncWaitingClock(&stream, false, 20_000);
-    // 1s + 1s of real thinking around two prompts totaling 17s of waiting.
     var buf: [64]u8 = undefined;
     try std.testing.expectEqualStrings("• Thinking (2s)", buildThinkingLabel(&buf, stream, 20_000).?);
 }

--- a/src/core/session/session_child_store.zig
+++ b/src/core/session/session_child_store.zig
@@ -757,7 +757,7 @@ pub const SessionChildCapability = struct {
     }
 
     /// Opens a capability restricted to holder proofs in the owning durable
-    /// Fx session. It does not imply access to host-owned terminal state.
+    /// fx session. It does not imply access to host-owned terminal state.
     pub fn initTerminalProofs(
         alloc: Allocator,
         session_dir: std.Io.Dir,

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -1484,14 +1484,8 @@ fn formatAllowlistChange(
     return out.toOwnedSlice();
 }
 
-/// Score a model ID against a user query for fuzzy matching.
-/// Higher score = better match. Returns 0 for no match.
-///
-/// Scoring:
-///  - Exact case-insensitive substring: 100 + length bonus
-///  - All query tokens present (space/dash/slash separated): 80 + token count bonus
-///  - Subsequence match: 40 + matched char density
-///  - Partial token match: 20
+/// Scores prefix and substring matches above token, subsequence, and partial matches.
+/// Higher scores rank first; zero means no match.
 pub fn fuzzyModelScore(id: []const u8, query: []const u8) i32 {
     if (query.len == 0) return 0;
     if (id.len == 0) return 0;

--- a/src/core/session/session_migration.zig
+++ b/src/core/session/session_migration.zig
@@ -91,19 +91,10 @@ fn runBoundary(test_controls: session_log.TestControls, boundary: session_log.Bo
     try test_controls.boundary(boundary);
 }
 
-/// Performs the legacy -> schema-v3 migration for a session whose writer lock
-/// is already held. This is one atomic responsibility: stage the canonical
-/// projection, then swap authority under the commit lock with crash boundaries,
-/// then replay the committed log into the returned writable session.
-///
-/// The staged-commit protocol (and its lock ordering) lives in the helpers
-/// below and must not be reordered: `assertMigratable` (fence + no existing
-/// authority), stable legacy snapshot, canonical projection write, unchanged
-/// re-check, then `commitMigrationAuthorityLocked` (intent -> marker -> manifest
-/// -> validate -> drop intent, each gated by a test boundary). On any error the
-/// orchestrator's errdefers release `legacy` and `state`; partial on-disk state
-/// is recovered by the resume path, not here. Takes ownership of `writable` and
-/// `lifecycle.*` only on success.
+/// Migrates legacy state to schema v3 while the caller holds the writer lock.
+/// Commit order is fixed: migration fence, stable snapshot, projection write,
+/// unchanged recheck, then intent, marker, manifest, validation, and intent removal.
+/// Resume handles partial disk state. Ownership transfers only on success.
 pub fn migrateLegacyLocked(
     ctx: StoreContext,
     alloc: Allocator,

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -496,7 +496,6 @@ pub const Store = struct {
         };
     }
 
-    /// Opens the store using HOME-based config discovery.
     /// Opens a writable store rooted at `$HOME`, creating the layout if needed.
     pub fn init(alloc: Allocator, workspace_root: []const u8) !Store {
         const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
@@ -12048,8 +12047,6 @@ test "history page rejects longer changed prefix and malformed cursor before rep
     try replaceHistoryPageFixture(alloc, ctx.store, "history-longer-stale", 30, 6, "new");
     try std.testing.expectError(error.StaleHistoryPageCursor, ctx.store.loadHistoryPage(alloc, "history-longer-stale", cursor, 2));
 
-    // If replay occurred first this nonexistent session would report not found.
-    // Invalid cursor wins, proving the parse/structure boundary runs first.
     try std.testing.expectError(
         error.InvalidHistoryPageCursor,
         ctx.store.loadHistoryPage(alloc, "not-created", "not-a-v2-cursor", 2),

--- a/src/core/session/session_store_types.zig
+++ b/src/core/session/session_store_types.zig
@@ -285,11 +285,8 @@ pub const DoctorInspectionOptions = struct {
     compaction_byte_threshold: u64 = 128 * 1024 * 1024,
 };
 
-/// A narrow, copyable view of the four `Store` fields the relocated discovery
-/// and migration helpers actually read. Passing this instead of `Store` lets
-/// those modules depend on a small data struct rather than the facade, which
-/// is what keeps the module graph acyclic. `canonical_root` is held by value to
-/// match the historical `var root = self.canonical_root;` copy semantics.
+/// Copyable store state shared with discovery and migration without introducing
+/// a dependency on the `Store` facade. `canonical_root` retains value semantics.
 pub const StoreContext = struct {
     sessions_dir: []const u8,
     home_dir: []const u8,

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -2025,7 +2025,7 @@ pub fn billingProjectionEql(first: Snapshot, second: Snapshot) bool {
 pub fn writeSnapshot(writer: *std.Io.Writer, snapshot: Snapshot) !void {
     try validateSnapshot(snapshot);
     // Keep the durable session payload in the exact pre-usage-dashboard
-    // shape. Older Fx binaries reject unknown snapshot fields instead of
+    // shape. Older fx binaries reject unknown snapshot fields instead of
     // ignoring them; richer metrics and recovery hints live in the validated
     // session sidecar.
     try writer.writeAll("{\"billing\":");

--- a/src/core/shared/debug_trace.zig
+++ b/src/core/shared/debug_trace.zig
@@ -81,12 +81,8 @@ pub fn eventf(scope: []const u8, event: []const u8, ctx: TraceContext, comptime 
     line.end();
 }
 
-// logf and eventf are instantiated once per format-args tuple, so anything in
-// their bodies is duplicated across every distinct call shape. TraceLine keeps
-// the line machinery in non-generic helpers compiled once; only the per-tuple
-// print call below stays generic. A failed line swallows the error, keeps
-// accepting prints, and end() drops it without writing, matching the old
-// catch-return behavior.
+// Keep generic trace wrappers small by centralizing line assembly here.
+// Failed lines accept remaining writes but emit nothing.
 const TraceLine = struct {
     out: std.Io.Writer.Allocating,
     failed: bool,

--- a/src/core/shared/display_width.zig
+++ b/src/core/shared/display_width.zig
@@ -172,20 +172,8 @@ noinline fn runeWidth(codepoint: u21) usize {
     return 1;
 }
 
-// Returns true when a rune of display width `w` starting at column `col`
-// would overflow a terminal of `cols` columns. fx runs DECAWM-OFF
-// session-wide, so the wrap is strict: a rune whose rightmost cell lands on
-// column `cols` does not wrap; only `col + w - 1 > cols` does.
-//
-// Preconditions (not re-checked; callers must enforce):
-// - cols >= 1
-// - w >= 1
-//
-// Future callers that cannot guarantee those preconditions should inline the
-// guards at the call site rather than weakening this helper.
-//
-// The intermediate sum is widened to `u32` so `col = 65535` cannot trap in
-// safety-checked builds.
+/// Returns whether width `w` at one-based `col` exceeds `cols` under DECAWM-OFF.
+/// Requires non-zero inputs and widens arithmetic to avoid `u16` overflow.
 pub fn shouldWrapAt(col: u16, w: u16, cols: u16) bool {
     return @as(u32, col) + @as(u32, w) - 1 > @as(u32, cols);
 }

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -4,14 +4,13 @@ const darwin_process_spawn = @import("darwin_process_spawn.zig");
 
 pub const RawEnviron = [*:null]const ?[*:0]const u8;
 
-// Set once from main() before any threads are spawned. Read-only thereafter.
+// Process globals are installed before threads start and remain read-only.
 var real_io: ?std.Io = null;
 
 // Fallback used by non-test code only when setIo was not called. The real
 // application installs `real_io` from main before spawning threads.
 var fallback_threaded: std.Io.Threaded = .init_single_threaded;
 
-// Set once from main() before any threads are spawned. Read-only thereafter.
 var global_environ: ?*const std.process.Environ.Map = null;
 var global_environ_block: ?std.process.Environ.Block = null;
 var global_raw_environ: ?RawEnviron = null;

--- a/src/core/shared/mem_utils.zig
+++ b/src/core/shared/mem_utils.zig
@@ -1,12 +1,7 @@
 const std = @import("std");
 
-// std.mem.Allocator.free and std.ArrayList.deinit are small generic
-// functions that LLVM inlines at every call site, and Zig re-materializes
-// every active defer at every error exit. In functions with many try sites
-// a single `defer list.deinit(alloc)` line expands into dozens of copies of
-// the full free path (safety fill plus devirtualized allocator free). This
-// module keeps that path in one non-generic function so each copy is a
-// single call.
+// Centralize generic free paths that Zig would otherwise duplicate at each
+// error exit, reducing generated code to one call per cleanup site.
 
 /// Drop-in replacement for `alloc.free(slice)`.
 pub fn free(alloc: std.mem.Allocator, memory: anytype) void {

--- a/src/core/shared/message.zig
+++ b/src/core/shared/message.zig
@@ -24,13 +24,8 @@ pub const Content = union(enum) {
     }
 };
 
-/// One role-tagged request message in a core conversation.
-///
-/// Ownership of `content` and `tool_calls` is tracked via the `owns_*` boolean
-/// flags rather than type-level distinctions (fx/AGENTS.md prefers `[]u8` for
-/// owned, `[]const u8` for borrowed). `tool_calls` aliases `types.ToolCall`,
-/// whose inner fields are `?[]const u8`, so the flags keep ownership explicit
-/// without duplicating the request message shape.
+/// One role-tagged request message. Explicit flags track ownership because
+/// `ToolCall` byte slices do not encode it at the type level.
 pub const Message = struct {
     role: Role,
     content: ?Content = null,

--- a/src/core/shared/sort_utils.zig
+++ b/src/core/shared/sort_utils.zig
@@ -1,15 +1,8 @@
 const std = @import("std");
 
-// std.mem.sort stamps out its entire stable block sort for every element
-// type and comparator pair; across fx call sites that adds hundreds of KiB
-// of near-identical machine code. This module keeps one non-generic stable
-// sort and reduces each call site to a comparator thunk.
-//
-// Algorithm: insertion-sorted runs merged bottom-up with symmerge
-// (Kim & Kutzner, "Stable Minimum Storage Merging by Symmetric Comparisons",
-// 2004): stable, in place, O(n log n) comparisons, O(n log^2 n) swaps. The
-// extra swap factor is irrelevant at fx data sizes (session, path, and
-// catalog scale lists).
+// Share one stable sort across element types to avoid duplicating generic code.
+// Uses insertion-sorted runs and in-place SymMerge (Kim and Kutzner, 2004):
+// O(n log n) comparisons and O(n log^2 n) swaps.
 
 /// Drop-in replacement for std.mem.sort: stable, in place, same signature.
 pub fn sort(

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -2178,15 +2178,12 @@ test "slash completion labels strip argument prefixes" {
     try std.testing.expectEqualStrings("lines", nthSlashCompletionLabel(testSlashRegistry(), "/input ", 0).?);
     try std.testing.expectEqualStrings("tint", nthSlashCompletionLabel(testSlashRegistry(), "/input ", 1).?);
     try std.testing.expectEqualStrings("tint", nthSlashCompletionLabel(testSlashRegistry(), "/input t", 0).?);
-    // Sandbox labels are also stripped
     try std.testing.expectEqualStrings("os", nthSlashCompletionLabel(testSlashRegistry(), "/sandbox ", 0).?);
     try std.testing.expectEqualStrings("none", nthSlashCompletionLabel(testSlashRegistry(), "/sandbox ", 1).?);
-    // Permission labels are also stripped
     try std.testing.expectEqualStrings("ask", nthSlashCompletionLabel(testSlashRegistry(), "/permissions ", 0).?);
     try std.testing.expectEqualStrings("auto", nthSlashCompletionLabel(testSlashRegistry(), "/permissions ", 1).?);
     try std.testing.expectEqualStrings("yolo", nthSlashCompletionLabel(testSlashRegistry(), "/permissions ", 2).?);
     try std.testing.expectEqualStrings("reset", nthSlashCompletionLabel(testSlashRegistry(), "/permissions ", 3).?);
-    // Allowlist labels reflect the argument stage
     try std.testing.expectEqualStrings("view", nthSlashCompletionLabel(testSlashRegistry(), "/allowlist ", 0).?);
     try std.testing.expectEqualStrings("add", nthSlashCompletionLabel(testSlashRegistry(), "/allowlist ", 1).?);
     try std.testing.expectEqualStrings("command", nthSlashCompletionLabel(testSlashRegistry(), "/allowlist add ", 0).?);
@@ -2194,7 +2191,6 @@ test "slash completion labels strip argument prefixes" {
     try std.testing.expectEqualStrings("url", nthSlashCompletionLabel(testSlashRegistry(), "/allowlist remove u", 0).?);
     try std.testing.expectEqualStrings("read_file", nthSlashCompletionLabel(testSlashRegistry(), "/allowlist remove tool ", 0).?);
     try std.testing.expectEqualStrings("commands", nthSlashCompletionLabel(testSlashRegistry(), "/allowlist reset c", 0).?);
-    // Non-arg completions return the full command
     try std.testing.expectEqualStrings("/help", nthSlashCompletionLabel(testSlashRegistry(), "/he", 0).?);
 }
 

--- a/src/core/subagent/communication.zig
+++ b/src/core/subagent/communication.zig
@@ -268,7 +268,7 @@ pub const RelationshipApproval = struct {
 
 /// Durable projection of one canonical prepared request. The executable
 /// payload is represented by its canonical digest; human surfaces receive only
-/// the bounded label, explanation, and optional file review exposed by Fx.
+/// the bounded label, explanation, and optional file review exposed by fx.
 pub const Approval = struct {
     id: []u8,
     kind: ApprovalKind,

--- a/src/core/subagent/tool_result.zig
+++ b/src/core/subagent/tool_result.zig
@@ -15,7 +15,7 @@ pub fn operationIdAlloc(alloc: Allocator, invocation_id: []const u8) ![]u8 {
     return alloc.dupe(u8, invocation_id);
 }
 
-/// Binds an untrusted invocation identifier to Fx-owned issuance metadata.
+/// Binds an untrusted invocation identifier to fx-owned issuance metadata.
 /// Only the digest of the provider/UI identifier is retained in the durable
 /// operation identity.
 pub fn boundOperationIdAlloc(

--- a/src/core/terminal/engine.zig
+++ b/src/core/terminal/engine.zig
@@ -252,21 +252,9 @@ pub const Grid = struct {
     tab_stops: []bool,
     sync_active: bool = false,
     sync_buffer: std.ArrayList(u8) = .empty,
-    /// When true (default), `\x1b[?2026h` ... `\x1b[?2026l` blocks are
-    /// buffered and applied atomically at the DECRST — matching what a
-    /// DEC-2026-aware terminal does. When false, bytes inside a sync
-    /// block are applied immediately; the DECSET/DECRST are still
-    /// parsed (so `sync_active` reflects state for anyone inspecting
-    /// it) but have no gating effect on writes.
-    ///
-    /// The shadow grid used by `TranscriptRuntime.renderTranscriptViewport`
-    /// sets this to false: the render emits a clear inside a sync block
-    /// and then clones the grid to build `next_screen`. If writes were
-    /// buffered, the clone would capture the pre-clear cells and the
-    /// diff would see "no change" → emit nothing → the clear silently
-    /// wins at DECRST, erasing everything the diff should have
-    /// preserved. Immediate apply keeps the shadow in sync with what
-    /// our diff is reasoning about.
+    /// Controls whether DEC-2026 blocks apply atomically or immediately.
+    /// Shadow grids disable buffering so clones include in-block clears;
+    /// otherwise DECRST could erase content omitted from the subsequent diff.
     defer_sync_updates: bool = true,
     /// Active SGR state. Updated by `\x1b[Nm` and applied to any cell
     /// the cursor writes into (and to the bg of cells cleared by EL/ED).
@@ -282,7 +270,7 @@ pub const Grid = struct {
     csi_intermediate_count: u8 = 0,
     osc_saw_esc: bool = false,
     /// Captured OSC payload bytes (between `\x1b]` and the terminator).
-    /// Kept so we can interpret OSC 8 (hyperlink) sequences; other OSC
+    /// Retained to interpret OSC 8 (hyperlink) sequences; other OSC
     /// codes are still ignored.
     osc_buffer: std.ArrayList(u8) = .empty,
     dcs_saw_esc: bool = false,
@@ -496,12 +484,8 @@ pub const Grid = struct {
         return physical_row * cols + col;
     }
 
-    /// Feed raw bytes (a fragment of fx's output) through the emulator.
-    /// Partial sequences are preserved across calls — if `bytes` ends
-    /// mid-CSI, the next call resumes correctly. When a sync-updates
-    /// block is active (`\x1b[?2026h`) writes are buffered until the
-    /// matching DECRST (`\x1b[?2026l`) is seen, at which point the
-    /// whole block is applied atomically.
+    /// Feeds output through the emulator, preserving partial control sequences.
+    /// DEC-2026 blocks are buffered until the matching DECRST when enabled.
     pub fn feed(self: *Grid, bytes: []const u8) !void {
         var result = try self.feedMode(bytes, .journal_replay);
         result.deinit(self.alloc);
@@ -847,13 +831,8 @@ pub const Grid = struct {
         try self.dispatchOsc();
     }
 
-    /// Interpret an OSC payload that has just been terminated by BEL or
-    /// ESC `\`. Only OSC 8 (hyperlink) is acted on; other codes are
-    /// dropped silently, matching the previous behaviour.
-    ///
-    /// OSC 8 syntax: `8 ; params ; URI`. An empty URI closes the
-    /// current hyperlink; a non-empty URI opens a new one and updates
-    /// `current_style.hyperlink_id` so subsequent writes inherit it.
+    /// Handles terminated OSC 8 payloads and ignores other OSC codes.
+    /// Empty URIs close the active link; non-empty URIs open one.
     fn dispatchOsc(self: *Grid) !void {
         const payload = self.osc_buffer.items;
         if (payload.len < 2 or payload[0] != '8' or payload[1] != ';') return;
@@ -1606,14 +1585,7 @@ pub const Grid = struct {
                 self.eraseRange(0, total);
             },
             3 => {
-                // `\x1b[3J` is an xterm extension that clears the
-                // scrollback buffer only; the visible display is
-                // untouched. This emulator has no scrollback model, so
-                // the correct behavior is a no-op. (Historically this
-                // branch was aliased to `2` which wiped the visible
-                // grid — wrong per the spec, and makes fx's
-                // scrollback-wipe-on-repaint appear to clobber pre-fx
-                // shell history in the harness.)
+                // ED 3 clears scrollback only; this emulator has no scrollback model.
             },
             else => {},
         }
@@ -1649,13 +1621,8 @@ pub const Grid = struct {
         if (self.feed_stats) |stats| stats.touchRow(bottom);
     }
 
-    /// Apply `\x1b[...m` SGR parameters to `current_style`. fx uses a
-    /// narrow subset: reset (0); bold/dim/italic/underline/reverse/strike
-    /// (1, 2, 3, 4, 7, 9) and their clears (22, 23, 24, 27, 29);
-    /// basic 8/16-colour palette (30-37,
-    /// 40-47, 90-97, 100-107), and the 256/truecolor extensions
-    /// (38/48 followed by ;5;N or ;2;R;G;B). Unknown codes are ignored.
-    /// `\x1b[m` with no params is treated as `\x1b[0m` (full reset).
+    /// Applies supported SGR attributes and palette, indexed, or truecolor values.
+    /// Unknown codes are ignored; an empty parameter list performs a full reset.
     fn applySgr(self: *Grid) !void {
         if (self.csi_param_count == 0) {
             self.resetSgrPresentation();
@@ -2212,35 +2179,15 @@ pub const Grid = struct {
         };
     }
 
-    /// Compare `prev` and `next` cell-by-cell and emit the minimal ANSI
-    /// byte stream that transforms a terminal currently displaying
-    /// `prev` into one displaying `next`. Grids must share dimensions.
-    ///
-    /// The algorithm walks rows independently. For each row that has
-    /// any differing cell it: positions the cursor to the first diff,
-    /// walks cells up to the last diff, and emits codepoints with
-    /// inline SGR transitions. A final `\x1b[0m` is emitted if the
-    /// last style was non-default so the terminal is not left in a
-    /// coloured state. The cursor is homed to row 1 col 1 after
-    /// emission so callers can chain subsequent output deterministically.
-    ///
-    /// Trailing-half cells of wide glyphs (width=0) are skipped when
-    /// emitting but still mark the row as changed when they differ.
+    /// Emits the ANSI diff between equal-sized grids. Wide-glyph continuation
+    /// cells affect change detection but are not emitted independently.
     pub fn diffTo(prev: Grid, next: Grid, out: *std.Io.Writer) !void {
         return diffBand(prev, next, 1, next.rows, out);
     }
 
-    /// Band-limited variant of `diffTo`. Only rows in the inclusive
-    /// range `[top_row, bottom_row]` are compared or emitted; cells
-    /// outside the band are left untouched. fx uses this to diff only
-    /// its own viewport band — rows above `viewport_top_row` carry
-    /// pre-fx shell scrollback that must never be clobbered by a
-    /// repaint, even when shadow_vt has no model of it.
-    ///
-    /// Returns without emitting if the band is empty (top > bottom).
-    /// Cursor is left at (top_row, 1) when there were no diffs, or
-    /// wherever the last emit landed it. Callers that care about
-    /// exact final position should emit a CUP themselves.
+    /// Diffs only the inclusive row band, preserving terminal content outside it.
+    /// Empty bands emit nothing; callers that require a final cursor position
+    /// must emit their own CUP sequence.
     pub fn diffBand(
         prev: Grid,
         next: Grid,
@@ -2995,7 +2942,7 @@ fn renderColor(color: Color) contracts.CellColor {
 }
 
 /// Paint an immutable engine snapshot as the complete outer terminal
-/// viewport. This deliberately does not add Fx chrome: every visible cell,
+/// viewport. This deliberately does not add fx chrome: every visible cell,
 /// cursor fact, and interactive terminal mode comes from the hosted child.
 pub fn writeFullSnapshot(
     snapshot: contracts.RenderSnapshot,
@@ -3137,21 +3084,9 @@ fn wideCellLead(cells: []const Cell, row_base: usize, col: u16) ?u16 {
     };
 }
 
-/// Emit an SGR sequence that moves the terminal from "some unknown
-/// prior style" to `next`. We play it safe and emit a full reset
-/// followed by the target state. Cost: a few bytes per transition,
-/// compared to tracking deltas perfectly — worth it for correctness
-/// since the prev-style tracking assumes a single unbroken emission
-/// stream, which breaks if anything else writes to the terminal
-/// between frames (e.g. a signal handler, a logging call).
+/// Transitions between OSC 8 hyperlinks without closing a valid active link first.
 fn emitHyperlinkTransition(out: *std.Io.Writer, grid: Grid, prev_id: u32, next_id: u32) !void {
-    // Per the OSC 8 spec, "it is perfectly legal to switch from one
-    // hyperlink to another without explicitly closing the first one",
-    // so a bare new-open is enough when transitioning between two
-    // links. An explicit close is only needed to terminate a link
-    // (next_id == 0) or to close out a previously-active link before
-    // entering plain text. When prev_id == 0 there is nothing to
-    // close.
+    // OSC 8 permits opening a new link without explicitly closing the active one.
     if (next_id == 0) {
         try out.writeAll("\x1b]8;;\x1b\\");
         return;
@@ -3175,6 +3110,7 @@ fn emitHyperlinkOpen(
     try out.writeAll("\x1b\\");
 }
 
+/// Resets unknown prior style before applying the target state.
 fn emitSgrTransition(out: *std.Io.Writer, next: Style) !void {
     try out.writeAll("\x1b[0m");
     if (next.flags.bold) try out.writeAll("\x1b[1m");
@@ -3808,7 +3744,6 @@ test "sync updates buffer until DECRST" {
 
     try g.feed("\x1b[?2026h");
     try g.feed("ab");
-    // Mid-sync: the grid has not yet applied the writes.
     try expectRow(g, 1, "");
 
     try g.feed("\x1b[?2026l");
@@ -3877,7 +3812,6 @@ test "SGR tracks indexed bg and applies it to written cells" {
     const c3 = g.cellAt(1, 3).?;
     try testing.expect(c1.style.bg.eql(.{ .indexed = 236 }));
     try testing.expect(c2.style.bg.eql(.{ .indexed = 236 }));
-    // Cell 3 was never written — keeps default bg.
     try testing.expect(c3.style.bg.eql(.default));
 }
 
@@ -3885,8 +3819,6 @@ test "EL with active bg fills cleared cells with that bg" {
     var g = try Grid.init(testing.allocator, 6, 1);
     defer g.deinit();
     try g.feed("\x1b[48;5;236mhi\x1b[K");
-    // Cells 1-2 have the written text with bg. Cells 3-6 were cleared
-    // by EL with the bg still active — they should carry the bg too.
     var col: u16 = 1;
     while (col <= 6) : (col += 1) {
         const c = g.cellAt(1, col).?;
@@ -4051,11 +3983,7 @@ fn gridsEqual(a: Grid, b: Grid) bool {
     return true;
 }
 
-/// Feed an initial state into a fresh Grid, clone it, mutate the
-/// clone with `mutate_bytes`, then run `diffTo(prev, next)` and feed
-/// the resulting bytes back into prev. Assert that prev ended up
-/// equal to next — this is the round-trip guarantee the renderer
-/// relies on.
+/// Verifies that applying the diff between two grids reproduces the target grid.
 fn assertDiffRoundTrip(
     cols: u16,
     rows: u16,
@@ -4248,8 +4176,6 @@ test "OSC 8 hyperlink round-trips through diffBand" {
     buf = writer.toArrayList();
 
     try testing.expect(std.mem.find(u8, buf.items, "\x1b]8;;https://x.com/vercel_dev\x1b\\") != null);
-    // Trailing close so the hyperlink does not leak into rows emitted
-    // after the band.
     try testing.expect(std.mem.endsWith(u8, buf.items, "\x1b]8;;\x1b\\"));
 }
 

--- a/src/core/terminal/store.zig
+++ b/src/core/terminal/store.zig
@@ -2365,7 +2365,7 @@ pub fn loadOrCreateOwnerCatalogClaim(
     return operation.ownOwnerCatalogClaim(alloc, claim);
 }
 
-/// Reloads authority for the current Fx owner without trusting caller-supplied
+/// Reloads authority for the current fx owner without trusting caller-supplied
 /// cwd, backend, or generation. Those facts are recovered from durable state;
 /// the active profile/session/workspace/transport/sandbox identity must still
 /// match exactly.
@@ -2461,7 +2461,7 @@ pub fn reloadHumanTakeoverAuthorityClaim(
     }, .humanTakeover());
 }
 
-/// Reloads a proof only through the managed-child capability of the durable Fx
+/// Reloads a proof only through the managed-child capability of the durable fx
 /// session that owns it. A terminal id alone cannot select proof storage.
 pub fn reloadAuthorityClaim(
     alloc: Allocator,

--- a/src/core/tooling/command_policy.zig
+++ b/src/core/tooling/command_policy.zig
@@ -13,7 +13,7 @@ pub fn command_risk_note_for(command: []const u8) ?[]const u8 {
     return risk_note_for(risk);
 }
 
-/// Returns a narrow alternative when the command text makes a safer path obvious.
+/// Returns a narrow alternative when the command text has an unambiguous safer path.
 pub fn command_safer_alternative_for(command: []const u8) ?[]const u8 {
     const analysis = command_classification.analysis_command_tail(command);
     if (risk_kind_in_analysis(analysis)) |risk| {

--- a/src/core/workspace/file_index.zig
+++ b/src/core/workspace/file_index.zig
@@ -1,29 +1,10 @@
-//! Ultra-fast workspace file index for the @-mention picker.
+//! Background workspace file index for the @-mention picker.
 //!
-//! The index is populated on a background thread from the canonical bounded
-//! Git/fallback workspace provider
-//! and stored in generation-owned parallel flat buffers:
-//!
-//!   - `paths_buf`        concatenated path bytes, no separators
-//!   - `lower_buf`        parallel buffer lowercased for case-insensitive match
-//!   - `offsets[i..i+1]`  byte range within both buffers for path `i`
-//!   - `basename_starts`  byte offset of each path's basename within the path
-//!   - `kinds`            authoritative file-or-directory kind for each path
-//!   - `char_masks`       per-path `u32` bitmap of a-z letters present, used
-//!                        as an O(1) reject before any subsequence scan; bit 31
-//!                        marks paths that need Unicode scoring
-//!
-//! Initial construction is progressive: the loader pre-allocates exact-size
-//! buffers up front, then fills them one path at a time, bumping that
-//! generation's atomic `ready_count` with `.release` ordering after each
-//! entry. Readers load `ready_count` with `.acquire` and scan indices in
-//! `[0, ready_count)`. Once a completed active generation exists, replacement
-//! loads remain private until a finished main-thread reap adopts them.
-//!
-//! Ready generation buffers are immutable and shared without locking. Search
-//! selects one generation, walks it once, and keeps the top-N in a small
-//! fixed-size array. ASCII subsequence scans operate on pre-lowercased bytes,
-//! so matching is a tight byte-compare loop suitable for 100k+ candidates.
+//! Each generation owns immutable parallel buffers. The loader publishes complete
+//! prefixes with release stores; readers acquire `ready_count` before scanning.
+//! Replacement generations remain private until the main thread adopts them.
+//! Search uses pre-lowercased paths and a per-path ASCII bitmap to reject
+//! impossible subsequence matches before scoring.
 
 const std = @import("std");
 const file_picker_path = @import("../input/file_picker_path.zig");
@@ -493,13 +474,7 @@ pub const FileIndex = struct {
         return candidateKindMatchesStat(expected_kind, stat.kind);
     }
 
-    /// Build the index synchronously from a pre-loaded path list. The list
-    /// uses nul bytes or newlines as separators, matching `git ls-files -z`
-    /// and the newline-separated directory-walk fallback. Intended for
-    /// benchmarks and tests that want to skip the threaded loader.
-    ///
-    /// On return the index has `ready_count == count()` and `state == .ready`,
-    /// so callers can search it immediately.
+    /// Builds a ready index synchronously from NUL- or newline-delimited paths.
     pub fn buildFromRaw(self: *FileIndex, alloc: Allocator, raw_list: []const u8) !void {
         try self.buildFromSource(alloc, .{ .file_raw = raw_list });
     }
@@ -990,9 +965,7 @@ fn acceptedCandidate(candidate: Candidate) ?Candidate {
     return candidate;
 }
 
-/// Pre-scan `raw_list` applying the same filters as the fill pass so we can
-/// allocate exact-size buffers once and avoid reallocation during the
-/// concurrent fill. Cheap: a single byte scan plus per-path bookkeeping.
+/// Applies fill-pass filters to size generation buffers before publication.
 fn countAndSize(source: CandidateSource) RawTotals {
     var n: u32 = 0;
     var bytes: u32 = 0;
@@ -1009,10 +982,7 @@ fn countAndSize(source: CandidateSource) RawTotals {
     return .{ .n = n, .bytes = bytes };
 }
 
-/// Compute the a-z bitmap for `bytes`. Bit `n` is set iff the lower-cased
-/// input contains the letter `'a' + n`. Non-letters and non-ASCII bytes
-/// contribute no bits, which is what makes the filter sound: a query with
-/// non-letter chars just produces a sparser query mask, never a false reject.
+/// Returns an a-z presence bitmap. Non-ASCII input cannot cause false rejection.
 fn alphaMask(bytes: []const u8) u32 {
     var m: u32 = 0;
     for (bytes) |b| {
@@ -2179,8 +2149,6 @@ test "bitmap prefilter rejects when required letter is absent" {
     const raw = "docs/readme.md\nsrc/main.zig\n";
     try index.buildFromRaw(alloc, raw);
 
-    // "xyz" shares no letters with either path, so rankTopN rejects both
-    // via the bitmap without touching the subsequence scan.
     var search: TestSearchBuffer(4) = .{};
     try std.testing.expectEqual(@as(usize, 0), (try search.run(&index, "xyz")).len);
 }
@@ -2208,9 +2176,6 @@ test "search returns partial results while ready_count is below total" {
     var index = FileIndex{};
     defer index.deinit(alloc);
 
-    // Build a full index, then simulate the loader thread being only partway
-    // through by pretending only the first two entries are published. The
-    // state stays .loading to model "still indexing".
     try index.buildFromRaw(alloc, "src/wasm_term_main.zig\nsrc/main.zig\nREADME.md\nsrc/core/shared/io.zig\n");
     try std.testing.expectEqual(@as(usize, 4), index.count());
 
@@ -2223,19 +2188,14 @@ test "search returns partial results while ready_count is below total" {
 
     var search: TestSearchBuffer(4) = .{};
     const results = try search.run(&index, "main");
-    // Only the first two entries are searchable; "main" matches both of
-    // them. README.md and src/core/shared/io.zig should not appear.
     try std.testing.expectEqual(@as(usize, 2), results.len);
     for (results) |result| {
         try std.testing.expect(std.mem.indexOf(u8, result.path, "main") != null);
     }
 
-    // Publishing the rest adds the non-matching entries without changing
-    // results for this query.
     generation.ready_count.store(4, .release);
     try std.testing.expectEqual(@as(usize, 2), (try search.run(&index, "main")).len);
 
-    // And a query that only the later entries match now returns them.
     const readme_results = try search.run(&index, "README");
     try std.testing.expectEqual(@as(usize, 1), readme_results.len);
     try std.testing.expectEqualStrings("README.md", readme_results[0].path);

--- a/src/core/workspace/network_metrics.zig
+++ b/src/core/workspace/network_metrics.zig
@@ -1,7 +1,4 @@
-// In-memory ring buffer of recent gateway HTTP calls. Used by /feedback
-// to surface latency / error patterns without forcing a persistent trace
-// log. Process-wide and lock-protected: callers do not need to plumb the
-// buffer through their context.
+// Process-wide ring buffer used by /feedback for recent network diagnostics.
 
 const std = @import("std");
 const io_mod = @import("../shared/io.zig");
@@ -115,7 +112,6 @@ pub fn snapshot(out: []NetworkCall) usize {
     const n = @min(stored, out.len);
     var i: usize = 0;
     while (i < n) : (i += 1) {
-        // Copy the last n records oldest-first.
         const idx = (head + ring_capacity - n + i) % ring_capacity;
         out[i] = ring[idx];
     }

--- a/src/tools/shell/background_process.zig
+++ b/src/tools/shell/background_process.zig
@@ -294,7 +294,7 @@ fn readLinuxProcStat(file: std.Io.File, buffer: []u8) !usize {
     while (true) {
         // A process can disappear after open, and procfs reports that read as
         // ESRCH. Read directly so the expected race does not reach Zig's
-        // unexpected-errno reporter before we can classify it.
+        // unexpected-errno reporter before classification.
         const rc = std.posix.system.read(file.handle, buffer.ptr, buffer.len);
         switch (std.posix.errno(rc)) {
             .SUCCESS => {

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -104,7 +104,7 @@ pub const MonitorOperationInput = struct {
 };
 
 /// Public semantic terminal input. Authority and persistence fields are
-/// intentionally absent; Core derives them from the current Fx session.
+/// intentionally absent; Core derives them from the current fx session.
 pub const Input = struct {
     action: contracts.Action,
     session_id: ?[]const u8 = null,

--- a/src/ui/assistant/pacer.zig
+++ b/src/ui/assistant/pacer.zig
@@ -70,7 +70,7 @@ pub const SgrState = struct {
         }
 
         // Exact full-body match against the known single-parameter codes the
-        // markdown renderer emits. Multi-parameter SGRs we recognize are
+        // markdown renderer emits. Recognized multi-parameter SGRs are
         // matched whole (e.g. "38;5;245"); anything else is ignored.
         if (std.mem.eql(u8, body, "1")) self.bold = true else if (std.mem.eql(u8, body, "2")) self.dim = true else if (std.mem.eql(u8, body, "3")) self.italic = true else if (std.mem.eql(u8, body, "4")) self.underline = true else if (std.mem.eql(u8, body, "9")) self.strike = true else if (std.mem.eql(u8, body, "22")) {
             self.bold = false;
@@ -115,7 +115,7 @@ pub const AssistantPacer = struct {
     deferred_started_ns: ?i128 = null,
     /// Tracks which SGR attributes the terminal should have active at the
     /// start of the next emit. Other frame-work (footer, body renders)
-    /// between ticks can emit their own `\x1b[0m`, so we re-establish state
+    /// between ticks can emit their own `\x1b[0m`, so state is restored
     /// by prefixing each emit with `\x1b[0m` + the active opens.
     sgr: SgrState = .{},
 
@@ -342,13 +342,7 @@ pub const AssistantPacer = struct {
         while (emitted < count and i < self.pending.items.len) {
             const first = self.pending.items[i];
             if (first == 0x1b) {
-                // ANSI escape sequences emit atomically without
-                // consuming codepoint budget. writeTranscript
-                // interposes cursor moves between batches, so
-                // splitting a sequence would produce literal `[1m`
-                // on screen. If the sequence is incomplete (no
-                // terminator yet), hold the tail for a later tick
-                // rather than emit a partial escape.
+                // Emit ANSI sequences atomically; hold incomplete tails for a later tick.
                 const end = display_width.ansiSequenceEnd(self.pending.items, i);
                 if (end > i) {
                     if (!ansiSequenceComplete(self.pending.items, i, end)) break;
@@ -361,20 +355,10 @@ pub const AssistantPacer = struct {
             i += len;
             emitted += 1;
         }
-        // Do NOT greedily include trailing escapes past the last
-        // visible character. Eagerly gobbling a trailing close SGR
-        // would flip `sgr` state in the same emit that was supposed
-        // to leave it open (breaking mid-turn styling), and the
-        // prefix-with-reset logic below re-establishes state on the
-        // next emit so attaching the close early buys nothing.
+        // Leave trailing close sequences for the next emit so tracked SGR state stays open.
         if (i == 0) return;
 
-        // Re-establish SGR state before emitting content. Other renderers
-        // (footer, body) may have emitted `\x1b[0m` between ticks, so the
-        // terminal could be in a clean state while our tracker says bold or
-        // bg-gray are still open. Prefix each emit with `\x1b[0m` + the
-        // active opens so the content always renders with the intended
-        // styling regardless of what happened since the previous emit.
+        // Restore tracked SGR state because other renderers may reset it between ticks.
         if (self.sgr.isActive()) {
             var prefix_buf: [48]u8 = undefined;
             const reset = "\x1b[0m";
@@ -490,11 +474,9 @@ test "enqueue and drain emits bytes paced by time" {
     try pacer.enqueue(alloc, "hello world");
     try std.testing.expect(pacer.hasPending());
 
-    // first tick seeds last_emit_ns AND emits 1 char immediately (no 8ms latency)
     try pacer.tick(alloc, 0, cap.callbacks());
     try std.testing.expectEqualStrings("h", cap.emitted.items);
 
-    // advance 100ms at base 400 cps → budget 40 → emits remaining 10 chars
     try pacer.tick(alloc, 100_000_000, cap.callbacks());
     try std.testing.expectEqualStrings("hello world", cap.emitted.items);
     try std.testing.expectEqual(@as(usize, 0), pacer.pending.items.len);
@@ -509,9 +491,7 @@ test "tick emits only budget-many codepoints" {
 
     try pacer.enqueue(alloc, "abcdefghij");
 
-    // first tick: emits "a" (1 char immediate)
     try pacer.tick(alloc, 0, cap.callbacks());
-    // 10ms at base 400 cps (backlog too small to scale) → 4 more chars = "bcde"
     try pacer.tick(alloc, 10_000_000, cap.callbacks());
     try std.testing.expectEqualStrings("abcde", cap.emitted.items);
     try std.testing.expectEqual(@as(usize, 5), pacer.pending.items.len);
@@ -524,10 +504,8 @@ test "emit preserves UTF-8 multi-byte boundaries" {
     var cap = TestCapture{};
     defer cap.deinit();
 
-    // "áñ" = 0xc3 0xa1 0xc3 0xb1 (4 bytes, 2 codepoints)
     try pacer.enqueue(alloc, "áñ");
 
-    // first tick emits 1 codepoint → "á" (2 bytes)
     try pacer.tick(alloc, 0, cap.callbacks());
     try std.testing.expectEqualStrings("á", cap.emitted.items);
     try std.testing.expectEqual(@as(usize, 2), pacer.pending.items.len);
@@ -540,16 +518,14 @@ test "partial UTF-8 at buffer tail is held until rest arrives" {
     var cap = TestCapture{};
     defer cap.deinit();
 
-    // 0xc3 alone is a valid 2-byte lead, incomplete
+    // 0xc3 begins a two-byte sequence.
     try pacer.enqueue(alloc, &[_]u8{0xc3});
 
-    // first tick tries to emit 1 codepoint, but the sequence is incomplete → no emit
     try pacer.tick(alloc, 0, cap.callbacks());
     try pacer.tick(alloc, 100_000_000, cap.callbacks());
     try std.testing.expectEqual(@as(usize, 0), cap.emitted.items.len);
     try std.testing.expectEqual(@as(usize, 1), pacer.pending.items.len);
 
-    // now arrives the continuation byte → "á"
     try pacer.enqueue(alloc, &[_]u8{0xa1});
     try pacer.tick(alloc, 200_000_000, cap.callbacks());
     try std.testing.expectEqualStrings("á", cap.emitted.items);
@@ -562,8 +538,7 @@ test "rate scales smoothly with backlog" {
     var cap = TestCapture{};
     defer cap.deinit();
 
-    // 1000 chars → after 1st tick emits 1, backlog=999, cps = 999*1000/1500 = 666
-    // 10ms budget = 10_000_000 * 666 / 1e9 = 6 → total 7 chars
+    // A 999-character backlog yields 666 cps and six characters in 10 ms.
     var big: [1000]u8 = undefined;
     @memset(&big, 'x');
     try pacer.enqueue(alloc, &big);
@@ -580,7 +555,6 @@ test "large backlog paces without atomic dump" {
     var cap = TestCapture{};
     defer cap.deinit();
 
-    // 5000 chars is a huge first burst — must NOT dump atomically
     var huge: [5000]u8 = undefined;
     @memset(&huge, 'y');
     try pacer.enqueue(alloc, &huge);
@@ -588,7 +562,7 @@ test "large backlog paces without atomic dump" {
     try pacer.tick(alloc, 0, cap.callbacks());
     try pacer.tick(alloc, 1_000_000, cap.callbacks());
 
-    // cps capped at max_chars_per_sec (5000) → 1ms budget = 5 chars; total 1 + 5 = 6
+    // The capped rate emits five characters in 1 ms after the initial tick.
     try std.testing.expect(cap.emitted.items.len < 50);
     try std.testing.expect(pacer.pending.items.len > 4900);
 }
@@ -769,7 +743,6 @@ test "deferFinish defers and fires when buffer drains" {
     try std.testing.expect(deferred);
     try std.testing.expect(pacer.finished);
 
-    // first tick emits "h"; second tick drains "i" and fires deferred finish
     try pacer.tick(alloc, 0, cap.callbacks());
     try pacer.tick(alloc, 10_000_000, cap.callbacks());
     try std.testing.expectEqualStrings("hi", cap.emitted.items);
@@ -939,7 +912,7 @@ test "finish-drain mode uses higher rate" {
     defer types.freeHistoryTurn(alloc, turn);
     _ = try pacer.deferFinish(alloc, .{ .turn = turn });
 
-    // finish-drain target_ms=200: backlog=499 → cps=2495, 10ms budget=24 → 1 (first) + 24 = 25
+    // At 2,495 cps, 10 ms emits 24 characters after the initial tick.
     try pacer.tick(alloc, 0, cap.callbacks());
     try pacer.tick(alloc, 10_000_000, cap.callbacks());
     try std.testing.expectEqual(@as(usize, 25), cap.emitted.items.len);
@@ -1005,14 +978,10 @@ test "ANSI escape sequences are emitted atomically without consuming codepoint b
 
     try pacer.enqueue(alloc, "\x1b[1mhi\x1b[22m!");
 
-    // first tick seeds + emits 1 codepoint: the preceding \x1b[1m rides along atomically
     try pacer.tick(alloc, 0, cap.callbacks());
     try std.testing.expectEqualStrings("\x1b[1mh", cap.emitted.items);
 
-    // advance 100ms, budget drains the rest. Because `\x1b[1m` was already
-    // seen but not yet closed, the next emit re-establishes bold state with
-    // a leading `\x1b[0m\x1b[1m` so any mid-stream SGR reset (e.g. from the
-    // footer) cannot leave the tail of this word unstyled.
+    // Each chunk restores open SGR state in case another renderer reset it.
     try pacer.tick(alloc, 100_000_000, cap.callbacks());
     try std.testing.expectEqualStrings("\x1b[1mh\x1b[0m\x1b[1mi\x1b[22m!", cap.emitted.items);
     try std.testing.expectEqual(@as(usize, 0), pacer.pending.items.len);
@@ -1025,13 +994,11 @@ test "incomplete ANSI sequence at tail is held until completion arrives" {
     var cap = TestCapture{};
     defer cap.deinit();
 
-    // \x1b[1 has no terminator yet
     try pacer.enqueue(alloc, "x\x1b[1");
     try pacer.tick(alloc, 0, cap.callbacks());
     try std.testing.expectEqualStrings("x", cap.emitted.items);
     try std.testing.expectEqual(@as(usize, 3), pacer.pending.items.len);
 
-    // now the terminator arrives
     try pacer.enqueue(alloc, "my");
     try pacer.tick(alloc, 100_000_000, cap.callbacks());
     try std.testing.expectEqualStrings("x\x1b[1my", cap.emitted.items);
@@ -1044,14 +1011,10 @@ test "sgr state re-established after open sgr in prior emit" {
     var cap = TestCapture{};
     defer cap.deinit();
 
-    // Inline code spans multiple emits.
     try pacer.enqueue(alloc, "\x1b[38;5;245mcode\x1b[39m done");
     try pacer.tick(alloc, 0, cap.callbacks()); // emits `\x1b[38;5;245mc`
     try pacer.tick(alloc, 100_000_000, cap.callbacks()); // emits rest
 
-    // Second emit must start with `\x1b[0m\x1b[38;5;245m` to re-establish the
-    // code foreground in case the footer or another renderer issued a reset
-    // between ticks.
     try std.testing.expect(std.mem.indexOf(u8, cap.emitted.items, "\x1b[38;5;245mc\x1b[0m\x1b[38;5;245m") != null);
     try std.testing.expect(std.mem.indexOf(u8, cap.emitted.items, "\x1b[39m") != null);
 }
@@ -1147,7 +1110,6 @@ test "no sgr prefix emitted when state is clean" {
     var cap = TestCapture{};
     defer cap.deinit();
 
-    // Plain text has no open SGR, so no reset prefix should be added.
     try pacer.enqueue(alloc, "hello");
     try pacer.tick(alloc, 0, cap.callbacks());
     try pacer.tick(alloc, 100_000_000, cap.callbacks());
@@ -1163,11 +1125,9 @@ test "sgr state clears after closing code" {
 
     try pacer.enqueue(alloc, "\x1b[1mA\x1b[22mB");
     try pacer.tick(alloc, 0, cap.callbacks()); // emits `\x1b[1mA`
-    // State should still be bold-on here.
     try std.testing.expect(pacer.sgr.bold);
 
     try pacer.tick(alloc, 100_000_000, cap.callbacks()); // emits `\x1b[0m\x1b[1m\x1b[22mB`
-    // After consuming the close, state is clean.
     try std.testing.expect(!pacer.sgr.bold);
 }
 

--- a/src/ui/assistant/user_message_card.zig
+++ b/src/ui/assistant/user_message_card.zig
@@ -1,6 +1,4 @@
-// Renders submitted user turns in the normal background-card presentation or
-// the experimental minimal presentation. Owns row collection and wrap math so
-// the rest of `ui/` treats the prompt as a single opaque helper.
+// Renders submitted user turns and owns their row collection and wrapping.
 const std = @import("std");
 const build_checkpoint = @import("../render_engine/build_checkpoint.zig");
 const display_width = @import("../../core/shared/display_width.zig");
@@ -25,9 +23,7 @@ const osc8_prefix = "\x1b]8;;";
 const osc8_terminator = "\x1b\\";
 const osc8_close = osc8_prefix ++ osc8_terminator;
 
-// Fallback card styles used ONLY when OSC-11 fails (no TTY, minimal terminal
-// that doesn't answer the query). Each fallback owns a contrasting indexed
-// foreground instead of relying on the terminal default.
+// Indexed-color fallbacks for terminals that do not answer OSC 11.
 const fallback_bar_dark = "\x1b[48;5;238m\x1b[38;5;250m";
 const fallback_bar_light = "\x1b[48;5;255m\x1b[38;5;16m";
 const accent_dark = "\x1b[38;5;252m";
@@ -39,8 +35,6 @@ pub var user_message_style: []const u8 = fallback_bar_dark;
 var user_message_style_buf: [64]u8 = undefined;
 var marker_style: []const u8 = dark_marker_style;
 
-// Called once from `initTheme`. Computes the stable card style from the
-// session's startup terminal bg and stores it into `user_message_style`.
 pub fn setStyle(light: bool, terminal_bg: ?Rgb) void {
     user_message_style = computeCardStyle(light, terminal_bg, &user_message_style_buf);
     marker_style = if (light) light_marker_style else dark_marker_style;
@@ -108,10 +102,7 @@ fn lastSpaceIn(slice: []const u8) ?usize {
     return null;
 }
 
-// Cuts the first row_budget display-cells off `text`, preferring the last
-// whitespace inside the cut so words don't split mid-glyph. Returns the byte
-// length of the cut AND the byte length to skip before the next iteration
-// (which may include a trailing wrap-point space).
+// Returns display-safe keep and skip boundaries, preferring whitespace.
 const WrapCut = struct { keep_bytes: usize, skip_bytes: usize };
 
 fn wrapCut(text: []const u8, row_budget: usize) WrapCut {
@@ -123,7 +114,7 @@ fn wrapCut(text: []const u8, row_budget: usize) WrapCut {
         return .{ .keep_bytes = sp, .skip_bytes = sp + 1 };
     }
 
-    // No space within budget — force at least one display unit so caller loops advance.
+    // Force one display unit when no break point fits so the loop advances.
     if (prefix.len == 0) {
         var end: usize = 0;
         while (end < text.len and text[end] == 0x1b) {

--- a/src/ui/footer/interaction_state.zig
+++ b/src/ui/footer/interaction_state.zig
@@ -327,13 +327,6 @@ test "approval prompt treats Ctrl+C as deny without exiting" {
 }
 
 test "kitty-protocol Ctrl+C decodes to byte 3" {
-    // `\x1b[99;5u` is how kitty-keyboard sends Ctrl+C. fx enables the
-    // protocol at startup, so any modern terminal (iTerm2, Ghostty,
-    // WezTerm, kitty) delivers Ctrl+C as this multi-byte sequence
-    // rather than the plain byte 3. The main escape decoder
-    // must translate it back to byte 3 before it reaches
-    // approval/subagent routing — otherwise Ctrl+C during an
-    // approval is silently swallowed.
     const input_runtime = @import("../input/runtime.zig");
     var stage: u8 = 1;
     var param: u16 = 0;

--- a/src/ui/footer/viewport.zig
+++ b/src/ui/footer/viewport.zig
@@ -103,10 +103,8 @@ pub const FooterViewport = struct {
     rows: std.ArrayList(ComposedFooterRow) = .empty,
     cursor: Cursor = .{ .row = 1, .col = 1 },
     cursor_visible: bool = true,
-    /// True once `beginFrame` has been called at least once, so we
-    /// know `geometry.top` points at a real footer band. Without this,
-    /// `eraseCurrentFrame` called before the footer has ever laid out
-    /// would clear from row 1 and wipe pre-fx shell scrollback.
+    /// True after `beginFrame` establishes valid footer geometry. Erasing
+    /// earlier would start at row 1 and wipe pre-fx shell scrollback.
     has_frame: bool = false,
     /// Set when transcript/body rendering emits a clear that can touch
     /// the footer band. A later footer render must repaint even when

--- a/src/ui/full_transcript_screen.zig
+++ b/src/ui/full_transcript_screen.zig
@@ -4242,7 +4242,6 @@ test "projection window handles scroll offsets at and past the document tail" {
     const measurement = try measureProjection(alloc, &projection, null, 10);
     try std.testing.expectEqual(@as(u32, 3), measurement.total_rows);
 
-    // A tail window taller than the remaining rows yields just those rows.
     const tail = try renderProjectionViewportSource(alloc, &projection, null, 10, 5, 2);
     defer alloc.free(tail);
     try std.testing.expect(std.mem.indexOf(u8, tail, "three") != null);

--- a/src/ui/input/runtime.zig
+++ b/src/ui/input/runtime.zig
@@ -4889,8 +4889,7 @@ test "input escape parser handles cmd+r as all-session resume picker" {
 }
 
 test "input escape parser handles ctrl+a/ctrl+e via kitty protocol" {
-    // ESC[97;5u — Kitty protocol for Ctrl+A (keycode 'a'=97, modifier 5=ctrl+1)
-    // Should remap to byte 1 (Ctrl+A) which the byte handler maps to Home.
+    // ESC[97;5u is Kitty's Ctrl+A encoding.
     var stage: u8 = 1;
     var param: u16 = 0;
     var param2: u16 = 0;
@@ -4903,8 +4902,7 @@ test "input escape parser handles ctrl+a/ctrl+e via kitty protocol" {
     try std.testing.expectEqual(@as(?InputEscapeAction, .{ .remapped_byte = 1 }), ctrl_a);
     try std.testing.expectEqual(@as(u8, 0), stage);
 
-    // ESC[101;5u — Kitty protocol for Ctrl+E (keycode 'e'=101, modifier 5=ctrl+1)
-    // Should remap to byte 5 (Ctrl+E) which the byte handler maps to End.
+    // ESC[101;5u is Kitty's Ctrl+E encoding.
     stage = 1;
     param = 0;
     param2 = 0;

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -127,11 +127,7 @@ pub fn themeNeedsUpdate(light: bool, terminal_bg: ?TerminalRgb) bool {
     return current.r != background.r or current.g != background.g or current.b != background.b;
 }
 
-// Theme detection result. `rgb` is present only when we actually probed the
-// terminal (no override, terminal answered OSC-11). On the override path
-// `rgb` is always null — the user explicitly chose light/dark so paying a
-// 200ms OSC-11 timeout is wasteful, and the card module has a conservative
-// fallback shade for that case.
+// Explicit theme overrides skip OSC 11, leaving `rgb` null for fallback shading.
 pub const ThemeDetection = theme_detection.Detection;
 pub const TerminalBackground = theme_protocol.Background;
 pub const explicitThemeOverride = theme_detection.explicitThemeOverride;

--- a/src/ui/render_engine/assistant_wrap.zig
+++ b/src/ui/render_engine/assistant_wrap.zig
@@ -112,8 +112,7 @@ fn wrapAssistantTextWithBaseGutter(
         if (ch == 0x1b) {
             const end = display_width.ansiSequenceEnd(text, i);
             if (end <= i) {
-                // Incomplete escape at end of buffer. Pass through and
-                // break so we do not loop forever.
+                // Preserve an incomplete trailing escape without stalling the loop.
                 try out.appendSlice(alloc, text[i..]);
                 break;
             }

--- a/src/ui/render_engine/frame_surface.zig
+++ b/src/ui/render_engine/frame_surface.zig
@@ -346,7 +346,7 @@ pub const FrameSurface = struct {
         return target;
     }
 
-    /// Removes Fx-owned color, emphasis, and hyperlink presentation while
+    /// Removes fx-owned color, emphasis, and hyperlink presentation while
     /// preserving glyphs, geometry, ownership, and shell-owned cells.
     pub fn neutralizeFxOwnedPresentation(self: *FrameSurface) void {
         for (self.cells) |*cell| {

--- a/src/ui/render_engine/terminal_diff.zig
+++ b/src/ui/render_engine/terminal_diff.zig
@@ -587,7 +587,7 @@ fn composeWireFrame(
     terminal_scroll_bytes: []const u8,
 ) !usize {
     if (input.surface.plan.reset_terminal and input.history_reset_uses_ris) {
-        // RIS clears modes that Fx enables at startup, so restore them before repainting.
+        // RIS clears modes that fx enables at startup, so restore them before repainting.
         try wire_frame.writer.writeAll("\x1bc");
         try wire_frame.writer.writeAll(ui_terminal.interactive_mode_enable_sequence);
     }

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -831,18 +831,6 @@ fn formatFullToolStatus(alloc: Allocator, text: []const u8, cols: u16) ![]u8 {
     return out.toOwnedSlice(alloc);
 }
 
-/// Walk the entry list and produce a byte stream shaped for the given
-/// column width. Each entry kind reshapes at paint time:
-///   - `raw_bytes`: fixed-shape banners, system notices, command
-///     summaries, and spinners with stored trailing tails normalized.
-///   - `user_turn`: rebuilt via the user prompt card renderer at the current
-///     cols so the card border and display-only skill spans track the
-///     terminal width.
-///   - `assistant_turn`: reflowed via `wrapAssistantText` so streamed
-///     markdown text wraps to the current cols with SGR preserved.
-/// Inter-block visual gaps are inserted here so producers do not own
-/// spacing policy.
-/// Returned slice is owned by the caller and freed with `alloc`.
 pub fn renderTableForTranscript(
     alloc: Allocator,
     table: assistant_presentation.TablePayload,
@@ -2021,6 +2009,7 @@ const RenderEntriesBuilder = struct {
     }
 };
 
+/// Reflows structured entries at paint-time width and centralizes block spacing.
 fn renderEntries(
     alloc: Allocator,
     entries: []const TranscriptEntry,

--- a/src/ui/render_engine/transcript_measure.zig
+++ b/src/ui/render_engine/transcript_measure.zig
@@ -7,14 +7,8 @@ pub const WalkResult = struct {
     end_col: u16,
 };
 
-/// Uncapped visual-row walker. Given `bytes` and a starting `(row, col)`
-/// at column-width `cols`, returns the `(row, col)` after the walk.
-///
-/// DECAWM-OFF wrap predicate: a rune of display width `w` at column
-/// `col` wraps only on strict overflow, `col + w - 1 > cols`. A rune
-/// whose rightmost cell lands on column `cols` does not wrap. This
-/// matches assistant wrapping and `visualRowsForLine`; a property test
-/// locks the agreement.
+/// Walks visual rows without capping the result to the viewport. Under
+/// DECAWM-OFF, glyphs wrap only when they exceed the right margin.
 pub fn walkText(start_row: u32, start_col: u16, bytes: []const u8, cols: u16) WalkResult {
     if (bytes.len == 0 or cols == 0) return .{ .end_row = start_row, .end_col = start_col };
 
@@ -81,16 +75,8 @@ pub fn nextCursorColForLine(line: []const u8, cols: u16) u16 {
     return @min(cols, walkText(1, 1, line, cols).end_col);
 }
 
-/// Return the byte offset in `text` where visual row (skip_rows + 1)
-/// begins. Used by the partial-tail renderer: when the oldest
-/// fully-fitting entry's predecessor overflows by K rows, we need to
-/// emit only the last `line_rows - K` rows of that predecessor to
-/// cover the top of the viewport without bleed. Walks the line the
-/// same way `visualRowsForLine` counts rows (ANSI skipped, `\r` resets
-/// col, `\n` advances row, `col + w - 1 > cols` soft-wraps) and
-/// returns the byte index where row (skip_rows + 1) starts. If
-/// `skip_rows` exceeds the line's actual row count, returns
-/// `text.len`.
+/// Returns the byte offset of visual row `skip_rows + 1` using the same
+/// ANSI-aware wrapping rules as `visualRowsForLine`.
 pub fn skipVisualRowsInLine(text: []const u8, cols: u16, skip_rows: u16) usize {
     if (skip_rows == 0 or cols == 0 or text.len == 0) return 0;
 

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -1,12 +1,5 @@
-//! Deterministic grid-level tests for the resize pipeline.
-//!
-//! Each test wires up a `TranscriptRuntime` whose stdout is a
-//! read/write tmp file, drives a scenario by calling public API
-//! (writeTranscript, applyResizeWithLayout, updateExtraInputRows, ...),
-//! feeds the emitted ANSI through `vt_emulator.Grid`, and asserts on
-//! the resulting cell grid. No real TTY, SIGWINCH, or tmux.
-//!
-//! Pulled into the test binary by `shell_runtime.zig`'s `test {}` block.
+//! Grid-level resize tests that replay `TranscriptRuntime` output through
+//! `vt_emulator.Grid` without a TTY or signals.
 
 const std = @import("std");
 
@@ -1097,8 +1090,7 @@ fn expectActiveInputSurvivesResize(
     defer approval.deinit(alloc);
 
     try h.shell.initViewport(&h.metrics, 15);
-    // The viewport call positions stale footer geometry below the tiny
-    // targets; the committed production frame owns from the terminal top.
+    // Tiny targets require the committed frame to own the full terminal.
     h.shell.owned_top_row = 1;
     h.frame_redraw = true;
     try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
@@ -4378,10 +4370,6 @@ test "settled resize emits a replay_viewport pass" {
     const before_replays = h.metrics.debounced_resizes;
     try h.driveResize(60, 20, 4, true);
 
-    // A settled resize with a real size change must emit exactly one
-    // redraw pass (metrics.debounced_resizes += 1). The mode is
-    // replay_viewport whenever either the geometry changed or a prior
-    // live pass flagged pending_settled_width_reflow.
     try std.testing.expectEqual(before_replays + 1, h.metrics.debounced_resizes);
 }
 
@@ -4425,7 +4413,6 @@ test "live resize keeps pending_settled_width_reflow set" {
     try h.driveResize(60, 24, 4, false);
     try std.testing.expect(h.shell.render_requests.pending_settled_width_reflow);
 
-    // A subsequent settled pass clears the flag.
     try h.driveResize(60, 24, 4, true);
     try std.testing.expect(!h.shell.render_requests.pending_settled_width_reflow);
 }
@@ -4437,7 +4424,6 @@ test "no-op resize at settled pass is a noop" {
 
     const before = h.metrics.debounced_resizes;
     try h.driveResize(80, 24, 4, true);
-    // Same dimensions, no prior pending replay -> no redraw.
     try std.testing.expectEqual(before, h.metrics.debounced_resizes);
 }
 
@@ -4448,9 +4434,6 @@ test "resize clips cursor_row into the new content band" {
 
     h.shell.cursor_row = 18;
     try h.driveResize(60, 12, 4, true);
-    // content_bottom after resize = 12 - 4 = 8. Cursor must be pulled
-    // inside that band before the footer repaint, otherwise the footer
-    // gets stomped.
     try std.testing.expect(h.shell.cursor_row <= h.shell.layout.content_bottom);
 }
 
@@ -4495,7 +4478,6 @@ test "updateExtraInputRows shrink repaints transcript into freed rows" {
     try h.shell.writeTranscript(h.alloc, &h.metrics, "alpha\nbeta\n", true);
     try h.flush();
 
-    // Picker opens (footer grows by 3 extra input rows) then closes.
     try h.shell.updateExtraInputRows(h.alloc, &h.metrics, 3);
     try h.renderTranscriptFrame();
     try h.flush();
@@ -4503,8 +4485,6 @@ test "updateExtraInputRows shrink repaints transcript into freed rows" {
     try h.renderTranscriptFrame();
     try h.flush();
 
-    // After the footer shrinks back, the transcript must be visible in
-    // the content band again — neither blank nor stale picker rows.
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(h.alloc);
     var found_alpha = false;
@@ -4767,7 +4747,6 @@ test "settled resize clears reflowed rows above the launch-owned viewport" {
     try h.renderTranscriptFrameIfDirty();
     try h.flush();
 
-    // Simulate a reflowed row just above the pre-resize Fx viewport.
     try h.vt.resize(80, 23);
     try h.vt.feed("\x1b[9;1HPRE-FX-ROW");
     try shell_runtime.applyResizeWithLayout(
@@ -5627,9 +5606,6 @@ test "approval footer growth preserves raw status row over stale footer frame" {
 
     try h.shell.initViewport(&h.metrics, 15);
 
-    // Frame 1: establish the existing transcript/footer ownership.
-    // With no approval banner active and no transcript content yet, the
-    // footer owns the current cursor row.
     try renderTestFooter(&h, &input, &approval, &frame_redraw);
     try h.flush();
 
@@ -5640,10 +5616,7 @@ test "approval footer growth preserves raw status row over stale footer frame" {
     _ = try h.shell.appendRawTranscriptEntry(alloc, status_line ++ "\n");
     _ = try approval.syncRequest(alloc, .{ .label = "skill next-best-practices" });
 
-    // Frame 2 models the production tick order: transcript paint first,
-    // then footer render notices approval activation and grows the
-    // footer band. The prior footer clear must not erase the just-painted
-    // status row.
+    // Footer growth follows transcript paint; its stale clear must preserve the status row.
     try renderTestFooter(&h, &input, &approval, &frame_redraw);
     try h.flush();
 
@@ -6109,12 +6082,8 @@ test "replaceable line survives a replay_viewport pass" {
     _ = try h.shell.appendReplaceableTranscriptLine(h.alloc, &h.metrics, "progress one\n");
     try h.flush();
 
-    // Drive a settled resize that triggers replay_viewport.
     try h.driveResize(40, 10, 4, true);
 
-    // The replaceable slot must still point at a real row so the next
-    // replace keeps updating the transcript in place rather than
-    // accumulating stale lines.
     try std.testing.expect(
         try h.shell.replaceTrailingTranscriptLine(h.alloc, &h.metrics, "progress two\n"),
     );
@@ -6139,20 +6108,12 @@ test "grow after shrink-overflow restores transcript inside fx's viewport band" 
     var h = try Harness.init(std.testing.allocator, 80, 30, 4);
     defer h.deinit();
 
-    // initViewport(1) simulates fx launched at the top of a fresh
-    // terminal. No pre-fx scrollback to protect, so fx's band is
-    // rows 1..content_bottom.
     try h.shell.initViewport(&h.metrics, 1);
     try h.shell.writeTranscript(h.alloc, &h.metrics, "header one\nheader two\nheader three\n", true);
     try h.flush();
 
-    // Shrink small enough that the content + footer overflow, as the
-    // user does when they drag the terminal short.
     try h.driveResize(80, 7, 4, true);
 
-    // Then grow back. The transcript must be painted at the top of
-    // fx's viewport band, not left as stale rows from the shrink and
-    // not left missing entirely.
     try h.driveResize(80, 30, 4, true);
 
     try expectRowPrefix(&h, 1, "header one");
@@ -6365,8 +6326,6 @@ test "settled resize clears pre-fx shell history and reanchors at row one" {
     var h = try Harness.init(std.testing.allocator, 40, 20, 4);
     defer h.deinit();
 
-    // Park the VT cursor at row 1 and simulate three rows of shell
-    // output that were on screen BEFORE fx launched.
     try h.vt.feed("\x1b[1;1H");
     try h.vt.feed("$ ls\n");
     try h.vt.feed("README.md  src  tests\n");
@@ -6376,7 +6335,6 @@ test "settled resize clears pre-fx shell history and reanchors at row one" {
     try h.shell.writeTranscript(h.alloc, &h.metrics, "first fx line\nsecond fx line\n", true);
     try h.flush();
 
-    // Trigger both directions of the settled-resize path.
     try h.driveResize(40, 24, 4, true);
     try h.driveResize(40, 16, 4, true);
 
@@ -6450,12 +6408,6 @@ test "visual epoch reset reanchors at row one and preserves viewport reservation
     try expectGridNotContains(&h, "old visual epoch");
 }
 
-// Replaceable lines whose original content spans multiple visual rows
-// must have every one of those rows cleared when the next replacement
-// lands, otherwise the tail rows remain on screen as orphans below the
-// new replacement text. The common real-world trigger is a streaming
-// assistant whose in-progress line contains embedded newlines, or a
-// short replacement following a longer one.
 test "multi-row replaceable line clears every old visual row on replace" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 40, 12, 4);
@@ -6487,11 +6439,6 @@ test "multi-row replaceable line clears every old visual row on replace" {
     }
 }
 
-// After a shrink, transcript lines that used to fit on one row now wrap
-// to multiple visual rows. The viewport replay must show the wrapped
-// content across those rows rather than silently truncating to the new
-// column width — otherwise the tail of every long message disappears
-// when the user narrows the window.
 test "shrink preserves wrapped line content across visual rows" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 20, 4);
@@ -6546,12 +6493,6 @@ test "compact file diffs retain their gutter and color after resize" {
     try std.testing.expect(continuation.style.fg.eql(.{ .indexed = 252 }));
 }
 
-// A settled replay_viewport pass must wipe any content that sits below
-// `content_bottom` before redrawing — otherwise a narrowing resize
-// leaves rows that the terminal reflowed (or any stray row that
-// pre-existed outside fx's viewport band) visible until something else
-// overwrites them. This is the "row below footer looks stale after drag
-// stops" symptom users see at the window bottom.
 test "replay_viewport wipes content below the viewport band" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 40, 12, 4);
@@ -6561,9 +6502,6 @@ test "replay_viewport wipes content below the viewport band" {
     try h.shell.writeTranscript(alloc, &h.metrics, "alpha\n", true);
     try h.flush();
 
-    // Plant a row OUTSIDE fx's content band (content_bottom = 12 - 4 = 8).
-    // Row 10 is below content_bottom and would normally hold terminal
-    // reflow remnants after a shrink.
     try h.vt.feed("\x1b[10;1Horphan_below_footer");
 
     try shell_runtime.requestRedraw(&h.shell, &h.metrics, .replay_viewport);
@@ -6573,11 +6511,6 @@ test "replay_viewport wipes content below the viewport band" {
     try expectRowEmpty(&h, 10);
 }
 
-// Default behavior: preserve terminal scrollback so the user can scroll
-// The transcript byte buffer is a paint-time cache derived from the
-// entries list; every paint regenerates it at the current cols. This
-// is what makes reshape work — a user card that was submitted at 80
-// cols shows up re-cut to 30 cols after a resize.
 test "large tabbed user turn keeps frame scroll plan aligned" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 72, 16, 4);
@@ -6662,9 +6595,6 @@ test "paint regenerates user card bytes at current cols" {
     try std.testing.expect(h.shell.transcript.items.len > wide_bytes.len);
 }
 
-// Assistant streams arrive as raw tokens with no wraps; paint reflows them
-// at the current width, including the assistant gutter, so resize produces
-// fresh wrap rows instead of clipping against DECAWM-off.
 test "paint regenerates assistant text with wraps at current cols" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);
@@ -6674,8 +6604,6 @@ test "paint regenerates assistant text with wraps at current cols" {
 
     const assistant_id = try h.shell.appendAssistantTurnEntry(alloc);
     const segs = h.shell.lookupAssistantSegments(assistant_id) orelse unreachable;
-    // 120 chars of ASCII — at 80 cols wraps once, at 30 cols wraps many
-    // times, exercising the wrapAssistantText reshape on each paint.
     const body = "abcdefghijklmnopqrstuvwxyz0123456789" ** 4;
     try segs.text.appendSlice(alloc, body[0..120]);
 
@@ -6695,10 +6623,6 @@ test "paint regenerates assistant text with wraps at current cols" {
     }
 }
 
-// Replaceable status lines are raw_bytes entries. After a paint regen,
-// `replaceable_start` must refresh to the start of the trailing
-// raw_bytes entry in the regenerated buffer so subsequent replaces
-// splice at the right offset.
 test "paint refreshes replaceable_start to trailing raw_bytes entry" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);
@@ -6719,10 +6643,6 @@ test "paint refreshes replaceable_start to trailing raw_bytes entry" {
     );
 }
 
-// Read every byte the shell has emitted since the last Harness.flush —
-// includes content the VT has already consumed. Useful for asserting
-// that a particular ANSI escape (like the scrollback-wipe) appears in
-// the raw output stream.
 fn readEmittedSince(h: *Harness, since_offset: u64) ![]u8 {
     const total = try h.file.length(io_mod.getIo());
     const want: usize = @intCast(total - since_offset);
@@ -6744,10 +6664,6 @@ fn gridContains(grid: Grid, needle: []const u8) !void {
     return error.TestMissingMarker;
 }
 
-// Mid-drag (settled=false) uses the cheap resize_light path. It must
-// NOT trigger reconstructive paint — doing so on every SIGWINCH during
-// a drag would flash the scrollback away a dozen times per drag and
-// create visible flicker.
 test "mid-drag resize does not emit scrollback wipe" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);
@@ -6851,9 +6767,6 @@ test "theme reset retints Fx entries and replays the retained transcript once" {
     try expectGridContains(&h, "FX THEME INLINE CODE");
 }
 
-// Reset replay must fill the cleared terminal with the reflowed transcript
-// before it advances into normal history. This fixture exceeds the viewport so
-// the first marker cannot be satisfied by the final-tail repaint alone.
 pub fn testReconstructiveFullTranscriptReplay() !void {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);
@@ -6907,8 +6820,7 @@ pub fn testReconstructiveFullTranscriptReplay() !void {
     const middle_idx = std.mem.find(u8, emitted, middle_marker) orelse return error.TestMissingMiddleEntry;
     const final_idx = std.mem.find(u8, emitted, final_marker) orelse return error.TestMissingFinalEntry;
 
-    // Bound the replay segment at the first complete transcript copy. The
-    // following final-tail repaint is allowed to repeat visible markers.
+    // Limit uniqueness checks to the reconstructive replay, before the final-tail paint.
     const replay = emitted[first_idx .. final_idx + final_marker.len];
     try std.testing.expect(reset_idx < first_idx);
     try std.testing.expect(reset_idx < replay_origin_idx);
@@ -6930,11 +6842,6 @@ pub fn testReconstructiveFullTranscriptReplay() !void {
     try std.testing.expect(h.last_frame.committed_scroll_rows > 0);
 }
 
-// A typical fx conversation alternates user → assistant → user. The
-// entries list should mirror that sequence one-to-one with
-// monotonically increasing ids; any ordering bug (e.g. the pacer
-// opening a duplicate assistant_turn mid-response) would show up as
-// an unexpected entry count or kind.
 test "turn ordering produces user → assistant → user entries with monotonic ids" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);
@@ -6961,13 +6868,6 @@ test "turn ordering produces user → assistant → user entries with monotonic 
     try std.testing.expect(id_assistant < id_b);
 }
 
-// The paint pipeline's value proposition during streaming is that
-// each paint diffs against the shadow grid and emits only what
-// changed. If a token lands on row N, rows 1..N-1 should produce
-// zero delta bytes — otherwise every keystroke flickers the whole
-// viewport. This test streams multiple tokens and asserts that the
-// second paint (after a small text append) emits far fewer bytes
-// than the first full paint.
 test "streaming paint produces a minimal delta on unchanged rows" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 80, 24, 4);
@@ -6982,26 +6882,15 @@ test "streaming paint produces a minimal delta on unchanged rows" {
     try h.flush();
     const baseline_end = try h.file.length(io_mod.getIo());
 
-    // One new character of content — should only repaint the one row
-    // that gained a token.
     try h.shell.writeTranscript(alloc, &h.metrics, "x", true);
     h.shell.transcript_band_dirty = true;
     try h.renderTranscriptFrameIfDirty();
     const delta_end = try h.file.length(io_mod.getIo());
 
     const delta_bytes: usize = @intCast(delta_end - baseline_end);
-    // A full repaint at 80x20 content band would be well over 2KB. A
-    // minimal delta for one new character should be dramatically
-    // smaller — ~100 bytes is the typical order when shadow diffing
-    // is working.
     try std.testing.expect(delta_bytes < 1024);
 }
 
-// When a single assistant turn's wrapped text exceeds the visible
-// band, the fit algorithm picks the last N visual rows. The top row
-// of the viewport shows the TAIL of an overflowing predecessor
-// thanks to partial-tail rendering (#39.4). Without this, the top
-// row would bleed through with stale cells from a previous frame.
 test "partial-tail emission fills top rows when an entry overflows the band" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 30, 10, 4);
@@ -7009,9 +6898,6 @@ test "partial-tail emission fills top rows when an entry overflows the band" {
 
     try h.shell.initViewport(&h.metrics, 1);
 
-    // Assistant turn with 200 chars at cols=30 wraps to ~7 visual
-    // rows — well over the ~5-row visible band (content_bottom=6
-    // minus top_row=1, so 6 visible rows, minus any trailing blank).
     const assistant_id = try h.shell.appendAssistantTurnEntry(alloc);
     const segs = h.shell.lookupAssistantSegments(assistant_id) orelse unreachable;
     const body = "abcdefghijklmnopqrstuvwxyz0123456789" ** 6;
@@ -7020,8 +6906,6 @@ test "partial-tail emission fills top rows when an entry overflows the band" {
     try h.renderTranscriptFrame();
     try h.flush();
 
-    // Every row in the content band must have SOME visible content
-    // (no blank-row holes that would be bleed-through).
     var r: u16 = 1;
     var filled_rows: u16 = 0;
     while (r <= h.shell.layout.content_bottom) : (r += 1) {
@@ -7033,8 +6917,6 @@ test "partial-tail emission fills top rows when an entry overflows the band" {
     try std.testing.expect(filled_rows >= h.shell.layout.content_bottom - 1);
 }
 
-// Partial-tail emission starts after a prefix reset. Until the renderer replays
-// skipped SGR state, the surviving tail is expected to be unstyled.
 test "partial-tail emission drops SGR state from the oldest-visible line" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 30, 10, 4);
@@ -7042,7 +6924,6 @@ test "partial-tail emission drops SGR state from the oldest-visible line" {
 
     try h.shell.initViewport(&h.metrics, 1);
 
-    // The line wraps past the content band and forces `partial_skip_rows`.
     const line = "\x1b[1m" ++ ("X" ** 200) ++ "\x1b[0m\n";
     try h.shell.writeTranscript(alloc, &h.metrics, line, true);
     try h.flush();
@@ -7060,7 +6941,6 @@ test "partial-tail emission drops SGR state from the oldest-visible line" {
     }
     try std.testing.expect(filled_rows >= h.shell.layout.content_bottom - 1);
 
-    // The top row begins after the skipped bold opener.
     const top_cell = h.vt.cellAt(1, 1) orelse {
         std.debug.print("expected cell at row 1 col 1\n", .{});
         return error.TestMissingTopCell;
@@ -7069,7 +6949,6 @@ test "partial-tail emission drops SGR state from the oldest-visible line" {
     try std.testing.expect(!top_cell.style.flags.bold);
 }
 
-// Continuation rows must reopen SGR after assistant text wraps.
 test "assistant text preserves SGR across wrap boundaries at narrow cols" {
     const alloc = std.testing.allocator;
 
@@ -7082,7 +6961,6 @@ test "assistant text preserves SGR across wrap boundaries at narrow cols" {
     var wrapped_lines: usize = 0;
     while (line_it.next()) |line| {
         if (line.len == 0) continue;
-        // The first row inherits SGR from the original input.
         if (!first) {
             if (std.mem.find(u8, line, "\x1b[1m") == null) {
                 std.debug.print("wrapped line missing bold reopen: '{s}'\n", .{line});
@@ -7095,15 +6973,12 @@ test "assistant text preserves SGR across wrap boundaries at narrow cols" {
     try std.testing.expect(wrapped_lines > 1);
 }
 
-// Overflowing resize content must stay pinned to the footer without interior
-// blank rows.
 test "narrow-drag resize pins overflowing content to content_bottom" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 120, 40, 4);
     defer h.deinit();
     try h.shell.initViewport(&h.metrics, 1);
 
-    // More content than the viewport can display at 30 columns.
     try h.shell.writeTranscript(alloc, &h.metrics, ("A" ** 3000) ++ "\n", true);
     try h.shell.writeTranscript(alloc, &h.metrics, ("B" ** 3000) ++ "\n", true);
     try h.shell.writeTranscript(alloc, &h.metrics, ("C" ** 3000) ++ "\n", true);

--- a/src/ui/transcript/io.zig
+++ b/src/ui/transcript/io.zig
@@ -1,6 +1,6 @@
 // Host contract:
 // - fields: stdout_file, shadow_vt, shadow_vt_alloc, layout,
-//   viewport_top_row, installed pre-Fx document state
+//   viewport_top_row, installed pre-fx document state
 // This module owns the normal frame sink. Exact probes, lifecycle controls,
 // titles, crash recovery, and noninteractive output stay with their domain
 // owners.
@@ -22,10 +22,7 @@ pub fn enableShadowVt(shell: anytype, alloc: Allocator) !void {
     const grid = try alloc.create(vt_emulator.Grid);
     errdefer alloc.destroy(grid);
     grid.* = try vt_emulator.Grid.init(alloc, cols, rows);
-    // The shadow is a render oracle, not a terminal emulator — we
-    // need writes to land in the grid immediately so the render's
-    // clone-and-diff can reason about current state, not a buffered
-    // pre-sync snapshot.
+    // The render oracle needs committed cells, not deferred sync state.
     grid.defer_sync_updates = false;
     grid.autowrap = false;
     shell.shadow_vt = grid;

--- a/src/ui/transcript/painter.zig
+++ b/src/ui/transcript/painter.zig
@@ -656,12 +656,8 @@ fn collectMeasuredSourceRows(
     return null;
 }
 
-/// Byte offset where measured visual row `rows` begins, walking `groups`
-/// forward from `span_start` and measuring each group at `target_cols`.
-/// Landing on a group boundary yields the next group's start; consuming
-/// every row lands on the span end. Returns null when the groups hold
-/// fewer than `rows` rows. Both the advance and rewind endpoint paths
-/// derive their offsets through this walk so the two stay inverse.
+/// Finds the byte offset after `rows` visual rows. Shared endpoint logic keeps
+/// forward and reverse projection walks inverse.
 fn flowOffsetAfterMeasuredRows(
     batch: VisibleTranscriptBatch,
     groups: []const MeasuredSourceRow,

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -155,7 +155,7 @@ const TranscriptRecoveryReceipt = struct {
     materialized_flow_len: ?usize = null,
     remaining_resize_reflow_rows: u16 = 0,
     remaining_semantic_rows: u32 = 0,
-    // This suffix of semantic debt may advance the current projection.
+    // Only this remaining semantic suffix may advance the current projection.
     remaining_semantic_progress_rows: u32 = 0,
     remaining_unplanned_scroll_rows: u16 = 0,
     attempt_cols: u16 = 0,
@@ -4297,9 +4297,8 @@ pub const TranscriptRuntime = struct {
     layout: Layout = undefined,
     cursor_row: u16 = 1,
     cursor_col: u16 = 1,
-    /// Top terminal row owned by fx. Rows above this belong to whatever
-    /// scrollback content existed before fx started (shell prompt, prior
-    /// command output) and must not be touched by our repaint logic.
+    /// Top terminal row owned by fx. Rows above this contain pre-fx scrollback
+    /// and must not be touched by fx repaint logic.
     /// Initialized to the cursor row captured at `initViewport`, and
     /// decreased as the transcript scrolls until it reaches row 1.
     viewport_top_row: u16 = 1,
@@ -4438,14 +4437,9 @@ pub const TranscriptRuntime = struct {
     replaceable_last_line: bool = false,
     replaceable_row: u16 = 1,
     replaceable_start: usize = 0,
-    /// The shadow terminal. Every byte emitted is also fed into this
-    /// in-process vt_emulator, so its cell grid always reflects what
-    /// the terminal is currently displaying. The viewport renderer
-    /// uses it as the `prev` state for cell-level diffing; under
-    /// FX_TRACE the grid is also dumped to the trace log at each
-    /// synchronized-update boundary. Enabled unconditionally at
-    /// bootstrap (see `app_lifecycle.zig`), so callers that run
-    /// after init can rely on it being non-null.
+    /// In-process terminal shadow used as the previous state for cell diffs.
+    /// Bootstrap enables it unconditionally; FX_TRACE dumps it at synchronized
+    /// update boundaries.
     shadow_vt: ?*vt_emulator.Grid = null,
     shadow_vt_alloc: ?Allocator = null,
     /// Detached presentations share a physical terminal shadow with their
@@ -6106,14 +6100,9 @@ pub const TranscriptRuntime = struct {
         );
     }
 
-    /// Append a user-turn entry. Takes ownership of `turn.text` and
-    /// every slice inside `turn.images` — all must be allocated by
-    /// `alloc`. On success the new entry owns the bundle and frees it on
-    /// `clearTranscript` / `deinit`. On error (OOM inside `entries.append`)
-    /// the method frees `turn.text`, each image's `.path` and
-    /// `.media_type`, and the outer `turn.images` slice before
-    /// propagating — callers must not double-free. Returns the stamped
-    /// entry id.
+    /// Consumes `turn` regardless of outcome. All owned slices must use `alloc`;
+    /// the entry owns them on success and this method frees them on failure.
+    /// Returns the stamped entry id.
     pub fn appendUserTurnOwned(self: *TranscriptRuntime, alloc: Allocator, turn: types.UserTurn) !u32 {
         return transcript_store.appendUserTurnOwned(self, alloc, turn);
     }
@@ -6162,7 +6151,7 @@ pub const TranscriptRuntime = struct {
     /// assistant-turn entry with `id`, or null if no such entry exists
     /// (including when `id` belongs to a `raw_bytes` or `user_turn`
     /// entry). The returned pointer is stable only until the next
-    /// `entries` append; resolve just before use.
+    /// `entries` append; resolve immediately before use.
     pub fn lookupAssistantSegments(self: *TranscriptRuntime, id: u32) ?*AssistantTurnSegments {
         return transcript_store.lookupAssistantSegments(self, id);
     }
@@ -6175,16 +6164,9 @@ pub const TranscriptRuntime = struct {
         return transcript_store.tailAssistantSegments(self);
     }
 
-    /// Mirror `text` into the transcript byte buffer and attach it to
-    /// the trailing `assistant_turn` entry. If the trailing entry is
-    /// already an `assistant_turn`, extend its segments in place;
-    /// otherwise open a new `assistant_turn` entry for this chunk.
-    /// Returns the id of the entry that received the chunk. This is
-    /// the pacer's canonical write path — routing bytes through the
-    /// byte-buffer writer directly (via `writeTranscript`) would
-    /// record them as `raw_bytes` entries, which would double-count
-    /// on paint-time reflow and stop `wrapAssistantText` from
-    /// re-flowing them at the current cols on resize.
+    /// Appends paced text to the trailing assistant entry, creating one if needed,
+    /// and mirrors it into the transcript buffer. Using `writeTranscript` here
+    /// would also create raw entries and double-count content during reflow.
     pub fn streamAssistantChunk(
         self: *TranscriptRuntime,
         alloc: Allocator,
@@ -8608,12 +8590,8 @@ pub const TranscriptRuntime = struct {
         transition.consumed = true;
     }
 
-    /// Writes bytes to the transcript buffer without mirroring them
-    /// into the structured entries list. Use this when the caller is
-    /// going to append a structured entry of its own (user card, pacer
-    /// stream) so the entries list does not double-record the content.
-    /// Prefer `writeTranscript` for raw banners, notices, and any
-    /// other content that should appear as a `raw_bytes` entry.
+    /// Writes only to the byte buffer for callers that separately append a
+    /// structured entry. Use `writeTranscript` when raw-entry mirroring is needed.
     pub fn writeTranscriptBytes(self: *TranscriptRuntime, alloc: Allocator, metrics: *Metrics, text: []const u8, record: bool) !void {
         return transcript_writer.writeTranscriptBytes(self, alloc, metrics, text, record);
     }
@@ -8680,12 +8658,8 @@ pub const TranscriptRuntime = struct {
         );
     }
 
-    /// Writes bytes to the transcript buffer AND mirrors them into the
-    /// structured entries list as a `raw_bytes` entry. Default path for
-    /// any caller that does not manage its own entry accounting.
-    /// Structured writers (user card, pacer) should call
-    /// `writeTranscriptBytes` and append their own entry instead to
-    /// avoid double-recording the content.
+    /// Writes to the byte buffer and mirrors the content as a raw entry.
+    /// Structured writers must use `writeTranscriptBytes` to avoid duplication.
     pub fn writeTranscript(self: *TranscriptRuntime, alloc: Allocator, metrics: *Metrics, text: []const u8, record: bool) !void {
         return transcript_writer.writeTranscript(self, alloc, metrics, text, record);
     }
@@ -9717,23 +9691,10 @@ pub const TranscriptRuntime = struct {
         }
     }
 
-    /// Thin cap-applying wrapper around `walkText`. The walk logic
-    /// lives in `walkText`; this function applies the DECAWM-OFF cap
-    /// on `self.cursor_row` (cursor cannot live below the viewport —
-    /// LF at the bottom row stays at the bottom while the terminal
-    /// scrolls) and returns the uncapped `WalkResult` for callers
-    /// that need the true row count.
-    ///
-    /// Scroll-math callers (`writeTranscriptBytes`,
-    /// `appendReplaceableTranscriptLine`)
-    /// MUST consume `result.end_row` from the return value — NOT
-    /// `self.cursor_row` — to compute `scroll_amount`. `self.cursor_row`
-    /// is capped at `layout.rows`, so it under-counts overflow and
-    /// would leave phantom blank rows at the top of the band when
-    /// content runs past the viewport bottom.
-    ///
-    /// `result.end_col` may equal `self.layout.cols + 1` in
-    /// wrap-exact cases; frame preparation tolerates this off-by-one.
+    /// Updates the capped terminal cursor and returns the uncapped text walk.
+    /// Scroll calculations must use `result.end_row`, not `self.cursor_row`,
+    /// which cannot represent overflow below the viewport. Wrap-exact walks may
+    /// return `layout.cols + 1` in `end_col`.
     pub fn advanceCursor(self: *TranscriptRuntime, text: []const u8) WalkResult {
         const result = walkText(@as(u32, self.cursor_row), self.cursor_col, text, self.layout.cols);
         self.cursor_col = result.end_col;
@@ -10882,7 +10843,6 @@ test "terminal reset drops stale mid-scrollback footer clear before reanchor" {
     runtime.footer_viewport.geometry.top = 25;
     runtime.footer_viewport.externally_invalidated = true;
 
-    // Job-control suspend records a footer erase against the pre-stop band.
     try runtime.recordFrameInvalidation(.{
         .reason = .external_clear,
         .top = 25,
@@ -10905,8 +10865,6 @@ test "terminal reset drops stale mid-scrollback footer clear before reanchor" {
     try std.testing.expectEqual(@as(u16, 1), pending.ranges()[0].top);
     try std.testing.expectEqual(@as(u16, 36), pending.ranges()[0].bottom);
 
-    // Compact post-reset bands must accept the reanchor and reject the old
-    // footer clear (the failure mode that aborted fg after idle park).
     var plan = render_engine.paint_plan.PaintPlan{
         .layout = runtime.layout,
         .viewport = .{

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -8407,9 +8407,6 @@ test "source-less surface paint keeps transcript lines one to one under full tra
     try runtime.enableShadowVt(alloc);
 
     try runtime.transcript.appendSlice(alloc, "a\nsummary\nb\n");
-    // A folded block with no captured lines: the paint walk never expands
-    // folded blocks without a source snapshot, so its capacity count must
-    // stay one to one with the transcript's hard lines.
     try runtime.folded_command_blocks.append(alloc, .{ .summary_transcript_index = 2 });
     runtime.full_transcript.depth = .review;
 
@@ -8706,9 +8703,6 @@ test "prepared command output paint clears stale hint before projecting newest h
     try std.testing.expectEqual(@as(usize, 8), block.total_lines);
     try std.testing.expectEqual(@as(usize, 8), block.lines.items.len);
     const newest_entry_id = block.lines.items[7].entry_id.?;
-    // The prepared batch only appends placeholders and requests paint. These
-    // raw bytes prove the regression exercises source-preparation overrides
-    // rather than an eager synchronization rewrite.
     try expectRawEntryBytes(
         &runtime,
         old_hint_entry_id,
@@ -9718,9 +9712,6 @@ test "recomputeCursorFromTranscript respects resized width" {
 }
 
 test "recomputeCursorFromTranscript skips ANSI in styled rows" {
-    // Replay math treats SGR bytes as controls, not visible cells. Styled
-    // transcript rows often end in `\x1b[0m` before the final newline; ANSI-aware
-    // width keeps cursor_col at the next visible cell.
     var runtime = TranscriptRuntime{
         .layout = .{
             .rows = 24,
@@ -9734,7 +9725,6 @@ test "recomputeCursorFromTranscript skips ANSI in styled rows" {
     };
     defer runtime.deinit(std.testing.allocator);
 
-    // One bar row, no trailing newline so the replay lands on the styled line.
     const bar_row = "\x1b[48;5;235m\x1b[39m❯ hello\x1b[0m";
     try runtime.transcript.appendSlice(std.testing.allocator, bar_row);
 
@@ -9742,7 +9732,6 @@ test "recomputeCursorFromTranscript skips ANSI in styled rows" {
     runtime.cursor_col = 99;
     runtime.recomputeCursorFromTranscript();
 
-    // Visible width of "❯ hello" is 7, so next-write column is 8.
     try std.testing.expectEqual(@as(u16, 8), runtime.cursor_col);
 }
 
@@ -9821,7 +9810,6 @@ test "updateExtraInputRows shrink preserves pre-fx scrollback" {
     try runtime.updateExtraInputRows(std.testing.allocator, &metrics, 7);
     try runtime.updateExtraInputRows(std.testing.allocator, &metrics, 0);
 
-    // Nothing has scrolled, so fx still owns rows 12..36 only.
     try std.testing.expectEqual(@as(u16, 12), runtime.viewport_top_row);
 }
 
@@ -10527,9 +10515,7 @@ test "streamAssistantChunk opens a new assistant_turn after a user_turn" {
 
 test "appendUserTurnOwned frees text, images, and image slices when entries.append OOMs" {
     const base = std.testing.allocator;
-    // fail_index = 4: the first four allocations (text dupe, images
-    // alloc, path dupe, media_type dupe) succeed; the fifth (entries
-    // internal grow on first append) returns OutOfMemory.
+    // Fail after all transferred slices exist, when the entries list first grows.
     var failing = std.testing.FailingAllocator.init(base, .{ .fail_index = 4 });
     const alloc = failing.allocator();
 
@@ -10548,9 +10534,6 @@ test "appendUserTurnOwned frees text, images, and image slices when entries.appe
         runtime.appendUserTurnOwned(alloc, .{ .text = text, .images = images }),
     );
 
-    // No entry landed — the append that would have owned the bundle
-    // failed. The method must have freed text + every image slice +
-    // the outer images slice itself before propagating.
     try std.testing.expectEqual(@as(usize, 0), runtime.entries.items.len);
     try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
 }
@@ -11551,8 +11534,6 @@ test "lookupAssistantSegments resolves assistant ids and rejects others" {
     var runtime = TranscriptRuntime{};
     defer runtime.deinit(alloc);
 
-    // Open a user turn first so the assistant entry sits mid-list and
-    // the lookup has to walk past a non-assistant variant.
     const prompt = try alloc.dupe(u8, "hello");
     const user_id = try runtime.appendUserTurnOwned(alloc, .{ .text = prompt, .images = &.{} });
 
@@ -11560,21 +11541,16 @@ test "lookupAssistantSegments resolves assistant ids and rejects others" {
     const segs = runtime.lookupAssistantSegments(assistant_id) orelse unreachable;
     try segs.text.appendSlice(alloc, "tok");
 
-    // Positive case — returned pointer references the right segments.
     const looked_up = runtime.lookupAssistantSegments(assistant_id);
     try std.testing.expect(looked_up != null);
     try std.testing.expectEqualStrings("tok", looked_up.?.text.items);
 
-    // A raw-bytes entry id must not resolve to an assistant segments
-    // pointer, even though it is a valid entry id.
     const raw = try alloc.dupe(u8, "banner");
     const raw_id = try runtime.appendRawBytesEntry(alloc, raw);
     try std.testing.expect(runtime.lookupAssistantSegments(raw_id) == null);
 
-    // A user-turn id is likewise not an assistant.
     try std.testing.expect(runtime.lookupAssistantSegments(user_id) == null);
 
-    // A stamped-but-absent id returns null.
     try std.testing.expect(runtime.lookupAssistantSegments(std.math.maxInt(u32)) == null);
 }
 
@@ -12914,7 +12890,6 @@ test "replaceTrailingTranscriptLineSilent swaps the trailing entry's bytes in pl
     const replaced = try runtime.replaceTrailingTranscriptLineSilent(alloc, "Thinking... done\n");
     try std.testing.expect(replaced);
     try std.testing.expectEqual(@as(usize, 1), runtime.entries.items.len);
-    // Entry id preserved — same slot, new bytes.
     try std.testing.expectEqual(initial_id, runtime.entries.items[0].id());
     try std.testing.expectEqualStrings("Thinking... done\n", runtime.entries.items[0].raw_bytes.bytes);
 }
@@ -12978,8 +12953,6 @@ test "updateRawBytesEntry returns false for non-raw_bytes entry" {
     try std.testing.expect(!ok);
 }
 
-// Raw entry updates are keyed by entry id, not by transcript tail position.
-// Intervening appends must not turn an update into a fresh copy below.
 test "updateRawBytesEntry updates modal entry in place after intervening append" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{};
@@ -13023,13 +12996,6 @@ test "tool status raw entry updates after command output appends" {
     try std.testing.expect(std.mem.indexOf(u8, source.bytes, "Running npm test") == null);
 }
 
-// Pin the shared wrapping contract between advanceCursor, visualRowsForLine,
-// and wrapAssistantText. Text that fills the last column must not add an extra
-// visual row or trigger resize scrollback fixups.
-//
-// For the same text and cols, advanceCursor advances cursor_row by the same
-// count as visualRowsForLine - 1: visualRowsForLine returns total rows, while
-// advanceCursor reports rows advanced from the starting row.
 test "advanceCursor row advance matches visualRowsForLine - 1 for wrap-exact content" {
     var sink = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), "/dev/null", .{ .mode = .write_only });
     defer sink.close(io_mod.getIo());
@@ -13048,8 +13014,6 @@ test "advanceCursor row advance matches visualRowsForLine - 1 for wrap-exact con
     };
     defer runtime.deinit(std.testing.allocator);
 
-    // "abcdef" at cols=3 is exactly two full rows ("abc" and "def").
-    // visualRowsForLine returns 2, so advanceCursor should advance by 1.
     const text = "abcdef";
     try std.testing.expectEqual(@as(u16, 2), visualRowsForLine(text, 3));
 
@@ -13059,11 +13023,6 @@ test "advanceCursor row advance matches visualRowsForLine - 1 for wrap-exact con
     try std.testing.expectEqual(@as(u16, 2), runtime.cursor_row);
 }
 
-// Same consistency check with a multi-line wrap to exercise both soft
-// wraps and hard newlines together. "abcdef\nghijkl" is 2 rows on the
-// first line ("abc", "def") then hard \n, then 2 rows on the second
-// line ("ghi", "jkl") — 4 rows total, so advanceCursor should advance
-// by 3 from the starting row.
 test "advanceCursor row advance matches visualRowsForLine - 1 across hard newlines" {
     var sink = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), "/dev/null", .{ .mode = .write_only });
     defer sink.close(io_mod.getIo());
@@ -13091,18 +13050,6 @@ test "advanceCursor row advance matches visualRowsForLine - 1 across hard newlin
     try std.testing.expectEqual(@as(u16, 4), runtime.cursor_row);
 }
 
-// Mid-row transcript continuations defer scroll until the next paint. The
-// cursor still clamps to content_bottom for footer placement, while
-// viewport_top_row moves upward so the repaint can use the reclaimed
-// terminal rows.
-//
-// 1000 X's at cols=80 from cursor_col=40:
-//   row 35 holds 41 runes (cols 40..80 = 41 cells), rune 42 wraps.
-//   rows 36..46: 80 runes each (880 runes, runes 42..921).
-//   row 47: 79 runes (runes 922..1000).
-//   walk.end_row = 47, so it overflows content_bottom.
-// After: viewport_top is unchanged; the next frame computes terminal
-// scroll from the committed and prepared viewport selections.
 test "writeTranscriptBytes mid-row continuation defers scroll after first paint" {
     const alloc = std.testing.allocator;
     var sink = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), "/dev/null", .{ .mode = .write_only });
@@ -13138,19 +13085,6 @@ test "writeTranscriptBytes mid-row continuation defers scroll after first paint"
     try std.testing.expectEqual(@as(u16, 35), runtime.cursor_row);
 }
 
-// Replaceable transcript lines update the buffer without terminal emission, so
-// they cannot cause natural scroll and must not emit explicit scroll. The
-// position tracker still updates `self.cursor_row` (capped at `layout.rows`)
-// and `self.cursor_col` for between-tick heuristics. Paint owns the
-// authoritative position state on the next render.
-//
-// Layout: rows=40, content_bottom=35, cols=10, viewport_top=35,
-//         cursor=(35, 1).
-// Text:   10 "XXXXXXXXXX" segments joined by 9 "\n"s → 10 rows.
-//         walk.end_row = 35 + 9 = 44.
-// After:  viewport_top stays at 35 (no scroll emitted).
-//         cursor_row = min(44, layout.rows=40) = 40.
-//         cursor_col = 11 (end of last segment, off-by-one tolerated).
 test "appendReplaceableTranscriptLine does not emit scroll (buffer-only)" {
     const alloc = std.testing.allocator;
     var sink = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), "/dev/null", .{ .mode = .write_only });
@@ -13189,11 +13123,6 @@ test "appendReplaceableTranscriptLine does not emit scroll (buffer-only)" {
     try std.testing.expectEqual(@as(u16, 40), runtime.cursor_row);
 }
 
-// Streaming chunk-split equivalence: the same total content written as one call
-// or two calls must produce identical viewport state.
-//
-// 2000 X's at cols=80, from cursor=(35, 1), viewport_top=35.
-// Both variants keep viewport_top=35 and cursor clamped to row 35.
 test "streamed chunk-split produces same viewport as single emission" {
     const alloc = std.testing.allocator;
 
@@ -14098,7 +14027,7 @@ test "transcript lifecycle identity updates are idempotent and atomic" {
         "read_file",
         runtime.toolActivityRecord(provisional_id).?.tool_name.?,
     );
-    // Fill the map and reuse its freed size class so stale record pointers fail deterministically.
+    // Force record-map growth so stale pointers fail deterministically.
     inline for ([_][]const u8{ "alias", "target", "fill-1", "fill-2", "fill-3" }) |call_id| {
         _ = try runtime.applyToolLifecycle(alloc, .{ .provisional = .{
             .id = lifecycleId(1, call_id),

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -906,7 +906,6 @@ async function continueRecovery(client: AcpClient, timeoutMs = LIVE_TIMEOUT) {
   throw new Error(`ACP recovery continuation timed out; messages=${JSON.stringify(messages)}`);
 }
 
-// Model-independent ACP scenarios.
 describe("acp: model-independent", () => {
   test("response waits continue across an internal read slice timeout", async () => {
     let reads = 0;
@@ -6720,7 +6719,6 @@ describe("acp: model catalog authentication", () => {
   }
 });
 
-// Model-backed ACP scenarios.
 describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {
   let client: AcpClient;
 
@@ -6974,11 +6972,9 @@ describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {
         await client.request("session/new", { mcpServers: [] }, 2);
         await client.readLine(); // consume session/update notification
 
-        // Cancel with no active prompt should be safe
         client.send({ jsonrpc: "2.0", method: "session/cancel", params: {} });
         await new Promise((r) => setTimeout(r, 300));
 
-        // Server is still alive — can still process requests
         const listResp = await client.request("session/list", {}, 3) as any;
         expect(listResp.result).toBeDefined();
         expect(Array.isArray(listResp.result.sessions)).toBe(true);

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -3224,9 +3224,7 @@ describe("cli: models", () => {
     TIMEOUT,
   );
 
-  // The real gateway grants team-private models on the API key alone; it ignores
-  // x-vercel-ai-gateway-team here and rejects fx login tokens outright. The fake
-  // below mirrors that, so the catalog credential rule is exercised as shipped.
+  // Mirror the gateway's credential handling for private model catalogs.
   for (const scenario of [
     {
       name: "uses the anonymous public catalog without a credential",

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -830,7 +830,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.waitForText("anthropic/claude-opus-4.8", TIMEOUT);
         expect(readFileSync(settingsPath, "utf8")).toBe(initialSettings);
         await session.sendKeys("Enter");
-        // Gateway order is preserved after Fx's default sentinel.
+        // Gateway order is preserved after fx's default sentinel.
         await session.waitForText("default", TIMEOUT);
         for (let i = 0; i < 2; i += 1) await session.sendKeys("Down");
         await session.waitForText("xhigh", TIMEOUT);

--- a/tests/e2e/file-tool-paths.test.ts
+++ b/tests/e2e/file-tool-paths.test.ts
@@ -249,10 +249,7 @@ type SubagentTurn = {
   execution?: { tool_steps?: Array<{ tool_results?: SubagentToolResult[] }> };
 };
 
-// The child's durable record is the authoritative account of what its tools
-// actually did, and it survives host shutdown. Its shape depends on how the
-// child ended: an interrupted turn reports completed_tool_names, a finished turn
-// reports full tool_results. Both carry the read outcome.
+// Interrupted and completed child turns persist tool outcomes in different fields.
 function readSubagentChild(home: string) {
   const sessionsDir = join(home, ".fx", "sessions");
   const children = readdirSync(sessionsDir)
@@ -292,12 +289,7 @@ function readSubagentChild(home: string) {
   };
 }
 
-// A noninteractive host exits as soon as the parent turn resolves, which can
-// interrupt a one-off child before it runs a single tool. Holding the parent's
-// post-create response keeps the host alive on a deterministic signal, the
-// child's own tool result, rather than on a timer, then releases it so ordinary
-// shutdown and the async host-exit contract still apply. The deadline exists
-// only so a regression reports a missing child read instead of hanging.
+// Hold the parent open until the child read completes; the deadline prevents hangs.
 function createChildReadGate(deadlineMs: number) {
   const { promise: opened, resolve: release } = Promise.withResolvers<void>();
   let output: string | null = null;

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -841,7 +841,7 @@ export class TmuxSession {
   }
 
   /**
-   * Complete pane history including the ANSI sequences emitted by Fx.
+   * Complete pane history including the ANSI sequences emitted by fx.
    * Keep this separate from the viewport capture so transcript-order tests
    * inspect all committed output rather than only the visible rows.
    */

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -4373,8 +4373,7 @@ describe("effect-aware command permissions", () => {
       let childInitialChecked = false;
       let childContinuationDeliveryChecked = false;
       const secondSeen: string[] = [];
-      // Only the root session writes progress lines to this process's stderr, so the
-      // root and child tool calls are counted separately.
+      // Only the root session writes progress to this process's stderr.
       const rootSubagentCallIds = new Set<string>();
       const childSubagentCallIds = new Set<string>();
       const secondRoute = (body: string) => {

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -979,9 +979,7 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
     writeMetrics();
     const finalScrollback = await waitForScrollback(session, LIVE_DONE, TIMEOUT * 2);
     expect(finalScrollback).toContain(LIVE_DONE);
-    // A physical terminal reset reconstructs scrollback and then paints the
-    // visible viewport, so one semantic line can legitimately appear twice in
-    // a tmux capture. Verify persisted product state, where duplication matters.
+    // Terminal reset may duplicate a visible line in tmux; durable state must not.
     expect(committedAssistantOccurrences(paths.home, LIVE_DONE)).toBe(1);
     if ((config.settledCycles ?? 0) > 0) {
       await thrashViewer(
@@ -1020,20 +1018,16 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
     const budgetTransitions = (config.settledCycles ?? 0) > 0
       ? summary.settledTransitions
       : summary.transitions;
-    // A 50k-line alternate-buffer swap includes terminal backpressure. Keep
-    // this below the pre-cache 4s tail while leaving room for host jitter.
+    // The budget includes terminal backpressure and host jitter.
     expect(budgetTransitions.review.p95Ms).toBeLessThan(3_500);
     expect(budgetTransitions.full.p95Ms).toBeLessThan(3_000);
     expect(budgetTransitions.close.p95Ms).toBeLessThan(1_500);
     expect(budgetTransitions.resize.p95Ms).toBeLessThan(3_000);
     if ((config.settledCycles ?? 0) > 0) {
-      // A resized alternate-screen close must not replay the complete compact
-      // transcript before the next Review open. Only the visible repair frame
-      // and the Review viewport should cross the terminal boundary.
+      // A resized close may emit the repair frame and next Review viewport only.
       expect(summary.settledTerminalBytes.review.maxBytes).toBeLessThan(64 * 1024);
     }
-    // Live tool/assistant mutations can invalidate the old primary viewport,
-    // but the next Review open must still be independent of total chat size.
+    // Review-open cost must remain independent of total chat size.
     expect(summary.terminalBytes.review.maxBytes).toBeLessThan(128 * 1024);
     expect(summary.terminalBytes.close.maxBytes).toBeLessThan(256 * 1024);
     expect(summary.memory.growthRssKib).toBeLessThan(256 * 1024);

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -1192,7 +1192,6 @@ tmuxTest(
     await active.waitForPane((pane) => pane.includes("[Image 1]"), READY_TIMEOUT);
     expect(localGateway.requests).toHaveLength(0);
 
-    // The regression: this second command used to submit "[Image #1]/image ..." as a prompt.
     await typeLiteral(active, `/image ${second}`);
     await active.sendKeys("Enter");
     await active.waitForPane(
@@ -1225,7 +1224,6 @@ tmuxTest(
     const body = localGateway.requests[0]!.body;
     const fileParts = body.match(/"type":"file"/g) ?? [];
     expect(fileParts).toHaveLength(2);
-    // Model-visible text must carry neither the command nor any local path or URI.
     expect(body).not.toContain("/image ");
     expect(body).not.toContain(first);
     expect(body).not.toContain(second);
@@ -1238,7 +1236,6 @@ tmuxTest(
     expect(fullScrollback).toContain("● Images: 2 pending");
     expect(fullScrollback).toContain("Both images received.");
     expect(fullScrollback).not.toContain("ImageContextAdapterFailed");
-    // Exactly one user turn reached the transcript.
     expect(fullScrollback.match(/describe both/g) ?? []).toHaveLength(1);
 
     const finalGrid = await active.capturePaneGrid();
@@ -1308,8 +1305,6 @@ tmuxTest(
     await active.sendKeys("Enter");
     await active.waitForPane((pane) => pane.includes("turn 1 complete"), READY_TIMEOUT);
 
-    // The regression: the second image used to render as [Image 1] because the
-    // badge was numbered by appearance inside the drafted text.
     await typeLiteral(active, `/image ${second}`);
     await active.sendKeys("Enter");
     await active.waitForPane((pane) => pane.includes("[Image 2]"), READY_TIMEOUT);

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -2795,7 +2795,6 @@ describe.skipIf(SKIP)("tui: resize", () => {
       expect(grid.length).toBeGreaterThan(0);
       const footer = findFooter(grid);
       expect(footer).not.toBeNull();
-      // Dividers should match the new width (tolerating trailing trims).
       const dividerRow = footerDividerRow(footer!);
       expect(grid[dividerRow]!.length).toBeGreaterThanOrEqual(40);
       expect(grid[dividerRow]!.length).toBeLessThanOrEqual(60);
@@ -3274,8 +3273,6 @@ describe.skipIf(SKIP)("tui: resize", () => {
       const grid = await session.capturePaneGrid();
       const dividerWidths = grid.filter(isDividerRow).map((line) => line.length);
       expect(dividerWidths.length).toBeGreaterThanOrEqual(1);
-      // At least one divider must match the NEW pane width (80), not the
-      // old 120. Tolerate trailing-space trim.
       const newWidth = dividerWidths.filter((w) => w >= 60 && w <= 80);
       expect(newWidth.length).toBeGreaterThanOrEqual(1);
     },
@@ -3291,9 +3288,6 @@ describe.skipIf(SKIP)("tui: resize", () => {
 
       const grid = await session.capturePaneGrid();
       const dividerWidths = grid.filter(isDividerRow).map((line) => line.length);
-      // A healthy footer has exactly two dividers (top + bottom). Three
-      // is the upper bound tolerated for a settled frame; anything higher
-      // means stale divider rows survived the settled resize repaint.
       expect(dividerWidths.length).toBeLessThanOrEqual(3);
       for (const w of dividerWidths) {
         expect(w).toBeGreaterThanOrEqual(60);
@@ -3308,14 +3302,9 @@ describe.skipIf(SKIP)("tui: resize", () => {
     async () => {
       session = await launchAt(120, 40);
       await session.sendKeys("invalid-dim-recovery");
-      // footer_rows is 4 in src/main.zig, so rows <= 4 triggers
-      // error.TerminalTooSmall; fx should swallow it (src/main.zig:748-752).
       await session.resizeWindow(40, 3, 400);
       expect(session.isAlive()).toBe(true);
 
-      // Recover to a sane size; app must still be responsive and have
-      // exactly one valid footer after the pending resize invalidation
-      // repaints the frame.
       await session.resizeWindow(100, 30, 500);
       const grid = await session.capturePaneGrid();
       expect(grid.join("\n")).toContain("invalid-dim-recovery");
@@ -3329,9 +3318,6 @@ describe.skipIf(SKIP)("tui: resize", () => {
     "rapid resize storm settles into exactly one footer",
     async () => {
       session = await launchAt(120, 40);
-      // Fire a burst faster than the 100 ms debounce so only the last
-      // size is latched. The test asserts that the settled frame has
-      // one and only one well-formed footer.
       await session.resizeWindow(110, 38, 20);
       await session.resizeWindow(100, 36, 20);
       await session.resizeWindow(90, 34, 20);

--- a/tests/evals/eval-helpers.ts
+++ b/tests/evals/eval-helpers.ts
@@ -156,10 +156,6 @@ export function buildEvalProcessEnv(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Eval runner
-// ---------------------------------------------------------------------------
-
 export async function runEval(
   prompt: string,
   opts: EvalOptions = {},


### PR DESCRIPTION
## Summary

- Remove redundant implementation and test narration.
- Preserve concise comments for ownership, protocol, concurrency, and terminal invariants.