### PR TITLE
Gate transcript scrollback release on producer finality

### DIFF
--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -336,7 +336,7 @@ pub fn Handlers(comptime App: type) type {
         }
 
         fn handleTraceReport(app: *App) !void {
-            const progress_entry_id = try app.appendDomainNotice(.{
+            const progress_entry_id = try app.appendReplaceableDomainNotice(.{
                 .topic = "",
                 .tone = .neutral,
                 .body = "Preparing trace...",

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -3422,6 +3422,10 @@ const RoutingFakeApp = struct {
         return self.shell.appendSemanticNotice(self.alloc, notice);
     }
 
+    pub fn appendReplaceableDomainNotice(self: *RoutingFakeApp, notice: types.SemanticNotice) !u32 {
+        return self.shell.appendReplaceableSemanticNotice(self.alloc, notice);
+    }
+
     pub fn replaceDomainNotice(self: *RoutingFakeApp, entry_id: u32, notice: types.SemanticNotice) !bool {
         return self.shell.replaceSemanticNotice(self.alloc, entry_id, notice);
     }

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1149,6 +1149,9 @@ pub fn Runtime(comptime App: type) type {
             }
 
             const runtime = app.subagents.childConversationRuntime().?;
+            // A live child can still stream into its trailing assistant
+            // entry; a finished child's tail is final.
+            runtime.setAssistantTailWritable(view.chat.live != null);
             if (!std.meta.eql(runtime.layout, app.shell.layout)) {
                 runtime.layout = app.shell.layout;
                 runtime.markTranscriptDirty();

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1577,6 +1577,12 @@ pub fn Runtime(comptime App: type) type {
                     try syncChildConversationProjection(app, view);
                 }
             }
+            // Frame-fresh producer fact for the finality floor: the trailing
+            // assistant entry stays non-final while the stream is open or
+            // the pacer still holds undelivered output.
+            app.shell.setAssistantTailWritable(
+                app.stream.active or app.pacer.hasPending(),
+            );
             const presentation_shell: *transcript_runtime.TranscriptRuntime =
                 if (child_view != null)
                     app.subagents.childConversationRuntime() orelse &app.shell

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1828,6 +1828,10 @@ fn finalizeTurn(raw_ctx: *anyopaque, turn_id: u64, outcome: types.TurnPresentati
     std.debug.assert(turn_id != 0);
     _ = disposition;
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    try pushToolLifecycle(raw_ctx, .{ .turn_finished = .{
+        .turn_id = turn_id,
+        .outcome = outcome,
+    } });
     if (outcome == .failed or outcome == .paused) {
         ctx.failed = true;
     }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1828,10 +1828,6 @@ fn finalizeTurn(raw_ctx: *anyopaque, turn_id: u64, outcome: types.TurnPresentati
     std.debug.assert(turn_id != 0);
     _ = disposition;
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
-    try pushToolLifecycle(raw_ctx, .{ .turn_finished = .{
-        .turn_id = turn_id,
-        .outcome = outcome,
-    } });
     if (outcome == .failed or outcome == .paused) {
         ctx.failed = true;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1955,6 +1955,10 @@ const App = struct {
         return self.shell.appendSemanticNotice(self.alloc, notice);
     }
 
+    pub fn appendReplaceableDomainNotice(self: *App, notice: types.SemanticNotice) !u32 {
+        return self.shell.appendReplaceableSemanticNotice(self.alloc, notice);
+    }
+
     pub fn replaceDomainNotice(self: *App, entry_id: u32, notice: types.SemanticNotice) !bool {
         return self.shell.replaceSemanticNotice(self.alloc, entry_id, notice);
     }

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -64,6 +64,7 @@ pub const Runtime = struct {
                 .history_reset_uses_ris = shell_runtime.detectHistoryResetUsesRis(alloc),
                 .layout = layout,
                 .maxxing_mode = presentation_mode.MaxxingMode.minimal,
+                .history_release_policy = .append_only,
             },
             .no_color = no_color,
         };
@@ -105,7 +106,6 @@ pub const Runtime = struct {
     pub fn pushText(self: *Runtime, text: []const u8) !void {
         try self.checkPendingError();
         errdefer |err| self.rememberFailure(err);
-        self.shell.setAssistantTailWritable(true);
         _ = try self.shell.streamAssistantChunk(self.alloc, &self.metrics, text);
         try self.render();
     }
@@ -114,10 +114,6 @@ pub const Runtime = struct {
         try self.checkPendingError();
         errdefer |err| self.rememberFailure(err);
         _ = try self.shell.applyToolLifecycle(self.alloc, event);
-        switch (event) {
-            .turn_finished => self.shell.setAssistantTailWritable(false),
-            else => {},
-        }
         try self.render();
         switch (event) {
             .turn_finished => try self.shell.finishLifecycleBatch(self.alloc),
@@ -147,8 +143,7 @@ pub const Runtime = struct {
     pub fn finish(self: *Runtime) !void {
         try self.checkPendingError();
         if (self.finished) return;
-        self.shell.setAssistantTailWritable(false);
-        try self.render();
+        if (self.shell.render_requests.hasPending()) try self.render();
         try self.restoreTerminal();
         self.finished = true;
     }
@@ -479,36 +474,4 @@ test "ask presentation retains a streaming write failure until finish" {
     };
     const write_err = observed orelse return error.TestExpectedError;
     try std.testing.expectError(write_err, runtime.finish());
-}
-
-test "ask presentation finish closes the assistant producer" {
-    const alloc = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    var output = try tmp.dir.createFile(std.testing.io, "ask-finish.log", .{ .read = true });
-    defer output.close(io_mod.getIo());
-
-    var runtime = try Runtime.initConfigured(
-        alloc,
-        .{ .text = @constCast("show output") },
-        false,
-        output,
-        zeroFooterLayout(.{
-            .rows = 12,
-            .cols = 48,
-            .content_bottom = 12,
-            .divider_top_row = 12,
-            .input_row = 12,
-            .divider_bottom_row = 12,
-            .hint_row = 12,
-        }),
-        .{ .row = 1, .col = 1 },
-        true,
-    );
-    defer runtime.deinit();
-
-    try runtime.pushText("answer\n");
-    try std.testing.expect(runtime.shell.assistant_tail_writable);
-    try runtime.finish();
-    try std.testing.expect(!runtime.shell.assistant_tail_writable);
 }

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -105,6 +105,7 @@ pub const Runtime = struct {
     pub fn pushText(self: *Runtime, text: []const u8) !void {
         try self.checkPendingError();
         errdefer |err| self.rememberFailure(err);
+        self.shell.setAssistantTailWritable(true);
         _ = try self.shell.streamAssistantChunk(self.alloc, &self.metrics, text);
         try self.render();
     }
@@ -113,6 +114,10 @@ pub const Runtime = struct {
         try self.checkPendingError();
         errdefer |err| self.rememberFailure(err);
         _ = try self.shell.applyToolLifecycle(self.alloc, event);
+        switch (event) {
+            .turn_finished => self.shell.setAssistantTailWritable(false),
+            else => {},
+        }
         try self.render();
         switch (event) {
             .turn_finished => try self.shell.finishLifecycleBatch(self.alloc),

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -147,7 +147,8 @@ pub const Runtime = struct {
     pub fn finish(self: *Runtime) !void {
         try self.checkPendingError();
         if (self.finished) return;
-        if (self.shell.render_requests.hasPending()) try self.render();
+        self.shell.setAssistantTailWritable(false);
+        try self.render();
         try self.restoreTerminal();
         self.finished = true;
     }
@@ -478,4 +479,36 @@ test "ask presentation retains a streaming write failure until finish" {
     };
     const write_err = observed orelse return error.TestExpectedError;
     try std.testing.expectError(write_err, runtime.finish());
+}
+
+test "ask presentation finish closes the assistant producer" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var output = try tmp.dir.createFile(std.testing.io, "ask-finish.log", .{ .read = true });
+    defer output.close(io_mod.getIo());
+
+    var runtime = try Runtime.initConfigured(
+        alloc,
+        .{ .text = @constCast("show output") },
+        false,
+        output,
+        zeroFooterLayout(.{
+            .rows = 12,
+            .cols = 48,
+            .content_bottom = 12,
+            .divider_top_row = 12,
+            .input_row = 12,
+            .divider_bottom_row = 12,
+            .hint_row = 12,
+        }),
+        .{ .row = 1, .col = 1 },
+        true,
+    );
+    defer runtime.deinit();
+
+    try runtime.pushText("answer\n");
+    try std.testing.expect(runtime.shell.assistant_tail_writable);
+    try runtime.finish();
+    try std.testing.expect(!runtime.shell.assistant_tail_writable);
 }

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -312,6 +312,9 @@ pub const TranscriptEntry = union(enum) {
         tone: types.NoticeTone,
         body: []const u8,
         visibility: types.NoticeVisibility,
+        // The producer will replace this entry in place; its bytes are not
+        // final and must not be released into terminal history.
+        pending_replacement: bool = false,
     };
 
     pub const UserTurnEntry = struct {
@@ -1870,6 +1873,8 @@ const BlockSequenceState = struct {
 const RenderEntriesOptions = struct {
     target_entry_id: ?u32 = null,
     target_byte_entry_id: ?u32 = null,
+    finality_entry_ids: []const u32 = &.{},
+    finality_entry_start_bytes: []?usize = &.{},
     omitted_entry_id: ?u32 = null,
     entry_actions: []const EntryRenderAction = &.{},
     summary_entry_ids: []const ?u32 = &.{},
@@ -1984,6 +1989,11 @@ const RenderEntriesBuilder = struct {
         const entry_id = entry.id();
         if (options.target_entry_id == entry_id) self.target_entry_start_line = self.line_index;
         if (options.target_byte_entry_id == entry_id) self.target_entry_start_byte = self.out.items.len;
+        for (options.finality_entry_ids, 0..) |finality_entry_id, index| {
+            if (finality_entry_id == entry_id) {
+                options.finality_entry_start_bytes[index] = self.out.items.len;
+            }
+        }
         for (options.summary_entry_ids, 0..) |summary_entry_id, index| {
             if (summary_entry_id != null and summary_entry_id.? == entry_id) {
                 options.summary_transcript_indices[index] = self.line_index + 1;
@@ -2211,6 +2221,8 @@ pub const TranscriptPreparationBytes = struct {
 pub const TranscriptPreparationOptions = struct {
     target_entry_id: ?u32 = null,
     target_byte_entry_id: ?u32 = null,
+    finality_entry_ids: []const u32 = &.{},
+    finality_entry_start_bytes: []?usize = &.{},
     omitted_entry_id: ?u32 = null,
     entry_actions: []const EntryRenderAction = &.{},
     folded_summary_entry_ids: []const ?u32 = &.{},
@@ -2259,6 +2271,8 @@ pub fn renderEntriesForPreparationInterruptible(
         .{
             .target_entry_id = options.target_entry_id,
             .target_byte_entry_id = options.target_byte_entry_id,
+            .finality_entry_ids = options.finality_entry_ids,
+            .finality_entry_start_bytes = options.finality_entry_start_bytes,
             .omitted_entry_id = options.omitted_entry_id,
             .entry_actions = options.entry_actions,
             .summary_entry_ids = options.folded_summary_entry_ids,

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -3156,6 +3156,9 @@ test "structured command-output rewrite materializes committed transcript scroll
         const text = try std.fmt.bufPrint(&line, "assistant table row {d}\n", .{index + 1});
         try first_assistant.text.appendSlice(h.alloc, text);
     }
+    // Assistant content is complete before each frame; report producer
+    // closure so the finality floor does not hold the tail.
+    h.shell.setAssistantTailWritable(false);
 
     try h.renderTranscriptFrame();
     try h.flush();
@@ -3185,6 +3188,14 @@ test "structured command-output rewrite materializes committed transcript scroll
         try second_assistant.text.appendSlice(h.alloc, text);
     }
 
+    try h.renderTranscriptFrame();
+    try h.flush();
+    // The structured rewrite is byte-incompatible with the committed
+    // anchor: this frame re-anchors in place with zero release.
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.planned_scroll_rows);
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
+
+    // The following compatible frame settles the held rows with final bytes.
     try h.renderTranscriptFrame();
     try h.flush();
     try std.testing.expect(h.last_frame.planned_scroll_rows > 0);
@@ -5921,8 +5932,6 @@ test "inline approval footer reflow preserves concurrent transcript progress" {
         @as(?u16, footer_history_rows),
         h.last_frame.document_append_clear_rows,
     );
-    const expected_append_rows: u16 = 2;
-
     _ = try h.shell.streamAssistantChunk(
         alloc,
         &h.metrics,
@@ -5932,11 +5941,12 @@ test "inline approval footer reflow preserves concurrent transcript progress" {
     try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
     try h.flush();
 
-    try std.testing.expectEqual(expected_append_rows, h.last_frame.planned_scroll_rows);
-    try std.testing.expectEqual(expected_append_rows, h.last_frame.committed_scroll_rows);
+    // The assistant producer is still open, so the streamed rows are not
+    // final: the viewport follows them through an in-place repaint and no
+    // transcript row is released into scrollback.
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.planned_scroll_rows);
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.committed_scroll_rows);
     try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
-    try std.testing.expect(h.last_frame.document_append_bytes > 0);
-    try std.testing.expectEqual(@as(?u16, null), h.last_frame.document_append_clear_rows);
     try std.testing.expectEqual(
         @as(usize, 1),
         std.mem.count(u8, h.shell.transcript.items, append_one),
@@ -5945,6 +5955,25 @@ test "inline approval footer reflow preserves concurrent transcript progress" {
         @as(usize, 1),
         std.mem.count(u8, h.shell.transcript.items, append_two),
     );
+    try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_one));
+    try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_two));
+
+    // Closing the producer finalizes the tail; the held rows settle through
+    // the catch-up replay, possibly across frames.
+    h.shell.setAssistantTailWritable(false);
+    var settle_frames: usize = 0;
+    var settled_scroll_rows: u32 = 0;
+    while (settle_frames < 8) : (settle_frames += 1) {
+        h.frame_redraw = true;
+        try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+        try h.flush();
+        try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
+        if (h.last_frame.planned_scroll_rows == 0) break;
+        settled_scroll_rows += h.last_frame.planned_scroll_rows;
+    }
+    try std.testing.expect(settled_scroll_rows > 0);
+    try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_one));
+    try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_two));
 
     approval.clear(alloc);
     h.frame_redraw = true;

--- a/src/ui/transcript/painter.zig
+++ b/src/ui/transcript/painter.zig
@@ -1122,9 +1122,14 @@ pub const PreparedTranscriptSurfacePaint = struct {
     measured_history_origin: ?MeasuredHistoryOrigin = null,
     measured_history_origin_consumed: bool = false,
     measured_resize_target_provenance: MeasuredResizeTargetProvenance = .none,
+    // Owned copy of the source's finality boundary candidates; the scroll
+    // planner selects the release floor from these against frame-fresh
+    // producer facts. Empty candidates mean the whole flow is final.
+    finality_candidates: source_preparation.FinalityCandidates = .{},
     cursor: ViewportCursorResult = .{ .cursor_row = 1, .cursor_col = 1, .replaceable_row = 1 },
 
     pub fn deinit(self: *PreparedTranscriptSurfacePaint, alloc: Allocator) void {
+        self.finality_candidates.deinit(alloc);
         if (self.owns_bytes and self.bytes.len > 0) alloc.free(self.bytes);
         self.visible_lines.deinit(alloc);
         self.line_visual_rows.deinit(alloc);
@@ -1725,6 +1730,7 @@ fn prepareTranscriptSurfacePaintInternal(
         },
     };
     errdefer prepared.deinit(alloc);
+    prepared.finality_candidates = try source.finality.clone(alloc);
     const transcript_buf = TranscriptBuffer{ .bytes = prepared.bytes };
 
     debug_trace.logf("render", "viewport_enter layout={d}x{d} content_bottom={d} viewport_top={d} cursor={d},{d} replaceable={{last={s} row={d} start={d}}} transcript_bytes={d} entries={d}", .{ self.layout.cols, self.layout.rows, self.layout.content_bottom, self.viewport_top_row, self.cursor_row, self.cursor_col, if (effective_replaceable_last_line) "true" else "false", effective_replaceable_row, effective_replaceable_start, prepared.bytes.len, self.entries.items.len });

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -7076,9 +7076,38 @@ pub const TranscriptRuntime = struct {
                         receipt.remaining_semantic_progress_rows
                     else
                         0;
-                const semantic_rows = retained_semantic_rows + growth_rows;
-                const semantic_progress_rows =
+                const candidate_semantic_rows = retained_semantic_rows + growth_rows;
+                const candidate_semantic_progress_rows =
                     retained_semantic_progress_rows + growth_rows;
+                // Retained debt repairs the attempted frame. Only source
+                // growth is a new content release that needs finality.
+                const semantic_rows, const semantic_progress_rows = if (self.finalityFloorBytes(prepared) != null) bounded: {
+                    const releasable_offset = self.finalityReleasableOffset(
+                        prepared,
+                        target_offset,
+                    );
+                    const bounded_growth_rows = @min(
+                        growth_rows,
+                        releasable_offset -| (receipt.accepted_history_visual_offset +
+                            retained_semantic_rows),
+                    );
+                    const bounded_rows = retained_semantic_rows + bounded_growth_rows;
+                    const bounded_progress_growth_rows = @min(
+                        growth_rows,
+                        releasable_offset -| (receipt.accepted_visual_offset +
+                            retained_semantic_progress_rows),
+                    );
+                    break :bounded .{
+                        bounded_rows,
+                        @min(
+                            retained_semantic_progress_rows + bounded_progress_growth_rows,
+                            bounded_rows,
+                        ),
+                    };
+                } else .{
+                    candidate_semantic_rows,
+                    candidate_semantic_progress_rows,
+                };
                 const acknowledged_visual_offset =
                     receipt.accepted_visual_offset + semantic_progress_rows;
                 const recovery_projection_deferred = recovery_progress_compatible and
@@ -7687,6 +7716,7 @@ pub const TranscriptRuntime = struct {
                     target.body_disposition == .paint and
                     !scroll_facts.geometry_rebase and
                     !scroll_facts.recovery_rebase and
+                    scroll_facts.semantic_rows == 0 and
                     !self.fullTranscriptActive() and
                     !prepared.selection.split_active and
                     !target_layout.transcript_area.isEmpty() and

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -7208,8 +7208,12 @@ pub const TranscriptRuntime = struct {
         const semantic_rows: u32 = if (geometry_rebase)
             geometry_history_rows
         else if (!recovery_rebase)
-            if (anchor.normal_buffer_recovery_pending or
-                anchor.history_catchup_pending)
+            // Normal-buffer recovery restores rows the takeover already
+            // displaced into scrollback; that restore is display repair,
+            // not a content release, so the finality clamp does not apply.
+            if (anchor.normal_buffer_recovery_pending)
+                target_offset -| anchor.history_visual_offset
+            else if (anchor.history_catchup_pending)
                 releasable_advance
             else
                 // Rows leaving the screen top are [visual..visual+scroll);
@@ -7368,6 +7372,10 @@ pub const TranscriptRuntime = struct {
         history_catchup_pending: bool = false,
         staged_flow_end: ?usize = null,
         projection_staged: bool = false,
+        // The frame slides the viewport past withheld release with an
+        // in-place repaint; a document append would scroll the same rows
+        // physically without a matching plan.
+        hold_staged: bool = false,
 
         fn init(
             prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
@@ -7700,6 +7708,7 @@ pub const TranscriptRuntime = struct {
                         target_layout.transcript_area,
                         scroll_facts.target_visual_offset,
                     );
+                    target.hold_staged = true;
                     debug_trace.logf(
                         "scroll",
                         "transcript_transition_hold_release target_visual_offset={d} history_visual_offset={d} semantic_rows={d}",
@@ -8352,6 +8361,7 @@ pub const TranscriptRuntime = struct {
                 },
             );
         } else if (append_base != null and
+            !target.hold_staged and
             (!scroll_facts.recovery_rebase or append_is_history_replay) and
             !scroll_facts.recovery_projection_deferred and
             (if (append_is_history_replay)
@@ -8471,10 +8481,12 @@ pub const TranscriptRuntime = struct {
             .scroll_plan = scroll_plan,
             .document_append = document_append,
             .document_append_bytes = document_append_bytes,
-            .history_settle_pending = self.finalityReleasableOffset(
-                prepared,
-                scroll_facts.target_visual_offset,
-            ) > target.history_visual_offset,
+            .history_settle_pending = scroll_facts.recovery_rebase and
+                !self.fullTranscriptActive() and
+                self.finalityReleasableOffset(
+                    prepared,
+                    scroll_facts.target_visual_offset,
+                ) > target.history_visual_offset,
             .resize_reflow_rows = scroll_facts.resize_reflow_rows,
             .semantic_rows = scroll_facts.semantic_rows,
             .semantic_progress_rows = scroll_facts.semantic_progress_rows,

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -225,6 +225,12 @@ pub const TranscriptScrollFacts = struct {
     recovery_progress_compatible: bool = false,
     recovery_tracks_semantic_progress: bool = false,
     recovery_projection_deferred: bool = false,
+    /// The finality floor withheld release this frame (mutable rows above
+    /// the viewport top), or final rows remain to settle beyond what this
+    /// frame planned. Routes into history_catchup_pending at commit so the
+    /// existing catch-up machinery settles the debt; footer displacement
+    /// (visual ahead of history with nothing to settle) stays unflagged.
+    finality_hold: bool = false,
 };
 
 pub const RetainedTranscriptBody = render_engine.frame_retention.RetainedTranscriptBody;
@@ -245,6 +251,10 @@ const MaterializedEndpoint = struct {
 pub const TranscriptTransition = struct {
     scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
     document_append: render_engine.frame_scroll_plan.FrameDocumentAppend,
+    /// Final rows exist beyond materialized history that this frame could
+    /// not release; consuming the transition requests a follow-up frame so
+    /// the debt settles promptly instead of waiting for outside activity.
+    history_settle_pending: bool = false,
     /// Owns `document_append.bytes` when append preparation allocates wire bytes.
     document_append_bytes: []u8 = &.{},
     resize_reflow_rows: u16 = 0,
@@ -4371,6 +4381,12 @@ pub const TranscriptRuntime = struct {
     entries: std.ArrayList(TranscriptEntry) = .empty,
     lifecycle_state: activity_runtime.ToolActivityState = .{},
     worker_status: worker_status.State = .none,
+    /// Frame-fresh producer fact: whether a trailing assistant entry can
+    /// still receive bytes (stream open or pacer holding pending/deferred
+    /// output). Drivers set it before each frame; the scroll planner treats
+    /// a writable tail as non-final. Defaults to writable so a driver that
+    /// never reports closure over-holds instead of releasing mutable rows.
+    assistant_tail_writable: bool = true,
     /// Sorted by entry id so exact lookup stays bounded as history grows.
     tool_details: std.ArrayList(ToolDetailRecord) = .empty,
     /// Monotonically increasing id stamped onto each new entry by the
@@ -6893,6 +6909,107 @@ pub const TranscriptRuntime = struct {
         return self.planTranscriptScrollForFrame(prepared, false, false);
     }
 
+    pub fn setAssistantTailWritable(self: *TranscriptRuntime, writable: bool) void {
+        self.assistant_tail_writable = writable;
+    }
+
+    /// Selects the finality floor in flow bytes from the prepared paint's
+    /// activity-independent candidates plus the frame-fresh producer facts
+    /// (lifecycle watermark, assistant-tail writability, replaceable tail).
+    /// Null means the whole flow is final. Pure over its inputs, so repeated
+    /// calls within one frame agree.
+    fn finalityFloorBytes(
+        self: *const TranscriptRuntime,
+        prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
+    ) ?usize {
+        const candidates = prepared.finality_candidates;
+        var floor: ?usize = null;
+        if (candidates.mutation_pin_start) |start| {
+            floor = if (floor) |value| @min(value, start) else start;
+        }
+        const watermark = self.finalizedToolTurnWatermark();
+        for (candidates.tool_turn_floors) |turn_floor| {
+            if (turn_floor.turn_id <= watermark) continue;
+            floor = if (floor) |value|
+                @min(value, turn_floor.start_byte)
+            else
+                turn_floor.start_byte;
+        }
+        if (prepared.replaceable_last_line) {
+            floor = if (floor) |value|
+                @min(value, prepared.replaceable_start)
+            else
+                prepared.replaceable_start;
+        }
+        if (candidates.assistant_tail_start) |start| {
+            if (self.assistant_tail_writable) {
+                floor = if (floor) |value| @min(value, start) else start;
+            }
+        }
+        return floor;
+    }
+
+    /// Visual rows contributed by the flow prefix [0..flow_offset). The
+    /// prefix boundary always lands on an entry start, which is a hard-line
+    /// start; a mid-line offset rounds down to its line, the safe direction.
+    fn preparedVisualRowsForFlowOffset(
+        prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
+        flow_offset: usize,
+    ) u32 {
+        if (flow_offset == 0) return 0;
+        if (flow_offset >= prepared.bytes.len) return prepared.sourceTotalVisualRows();
+        const lines = prepared.sourceVisibleLines();
+        const visual_rows = prepared.sourceVisualRows();
+        var rows: u32 = 0;
+        for (lines, 0..) |line, index| {
+            switch (line) {
+                .transcript => |t| if (t.ref.ref.start >= flow_offset) return rows,
+                .folded_line => {},
+            }
+            if (index < visual_rows.len) rows += visual_rows[index];
+        }
+        return rows;
+    }
+
+    /// Ability check for releasing on a byte-incompatible frame: the exact
+    /// held range must be materializable this frame through the history
+    /// replay. Mirrors resolveTransitionAppendBase's admission conditions so
+    /// the plan never authorizes a scroll the append path cannot back with
+    /// content.
+    fn incompatibleReleaseReplayResolves(
+        self: *const TranscriptRuntime,
+        prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
+        anchor: CommittedTranscriptAnchor,
+        releasable_offset: u32,
+    ) bool {
+        if (releasable_offset <= anchor.history_visual_offset) return false;
+        if (anchor.layout_id != self.committed_frame_layout.layout_id) return false;
+        if (self.committed_frame_layout.terminal_cols != self.layout.cols) return false;
+        if (self.committed_frame_layout.terminal_rows != self.layout.rows) return false;
+        if (self.resize_history_row_delta != null) return false;
+        return compatibleHistoryReplayRange(
+            prepared,
+            self.layout.cols,
+            prepared.bytes,
+            anchor.flow,
+            anchor.history_visual_offset,
+            releasable_offset,
+        ) != null;
+    }
+
+    /// The largest visual offset whose rows are all backed by final entries,
+    /// clamped to the frame's target offset. Release permission never
+    /// extends past this value.
+    fn finalityReleasableOffset(
+        self: *const TranscriptRuntime,
+        prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
+        target_offset: u32,
+    ) u32 {
+        const floor_bytes = self.finalityFloorBytes(prepared) orelse return target_offset;
+        const floor_rows = preparedVisualRowsForFlowOffset(prepared, floor_bytes);
+        return @min(target_offset, floor_rows);
+    }
+
     pub fn planTranscriptScrollForFrame(
         self: *const TranscriptRuntime,
         prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
@@ -7068,14 +7185,14 @@ pub const TranscriptRuntime = struct {
         const recovery_rebase = (!source_compatible and !geometry_rebase) or
             !width_stable or
             self.resize_history_row_delta != null;
-        const history_advance_rows: u32 = if (!source_compatible and
-            width_stable and
-            self.committed_frame_layout.terminal_rows == self.layout.rows and
-            self.resize_history_row_delta == null and
-            target_offset > anchor.history_visual_offset)
-            target_offset - anchor.history_visual_offset
-        else
-            0;
+        // Release requires two independent facts: permission (the rows are
+        // final, expressed by the finality floor) and ability (this frame
+        // materializes their exact bytes, which an incompatible frame
+        // cannot). Either fact missing forces zero release; the frame
+        // re-anchors on the new flow and the derived history debt settles
+        // on the next compatible frame through the existing replay.
+        const releasable_offset = self.finalityReleasableOffset(prepared, target_offset);
+        const releasable_advance = releasable_offset -| anchor.history_visual_offset;
         const committed_projection_offset = committedProjectionVisualOffset(anchor);
         const geometry_history_rows: u32 = if (geometry_rebase and
             ((source_compatible and source_visual_growth) or
@@ -7083,16 +7200,40 @@ pub const TranscriptRuntime = struct {
             target_offset -| anchor.history_visual_offset
         else
             0;
+        // Geometry displacement (footer growth over transcript rows) keeps
+        // its pre-existing semantics: displaced rows are preserved into
+        // history even when mutable, because inline rendering has nowhere
+        // else to keep them. The finality clamp governs content-driven
+        // release only.
         const semantic_rows: u32 = if (geometry_rebase)
             geometry_history_rows
         else if (!recovery_rebase)
             if (anchor.normal_buffer_recovery_pending or
                 anchor.history_catchup_pending)
-                target_offset -| anchor.history_visual_offset
+                releasable_advance
             else
-                target_offset -| anchor.visual_offset
+                // Rows leaving the screen top are [visual..visual+scroll);
+                // the floor clamps that range, so the budget is measured
+                // from the committed viewport, not from history.
+                releasable_offset -| anchor.visual_offset
+        else if (self.incompatibleReleaseReplayResolves(
+            prepared,
+            anchor,
+            releasable_offset,
+        ))
+            releasable_advance
         else
-            history_advance_rows;
+            0;
+        // A finality hold is either the floor sitting below the viewport
+        // (mutable rows above the top) or a same-geometry incompatible frame
+        // that had permission to release but no ability to materialize;
+        // geometry-driven recovery (resize, reflow) owns its own debt.
+        const finality_hold = releasable_offset < target_offset or
+            (recovery_rebase and
+                width_stable and
+                self.committed_frame_layout.terminal_rows == self.layout.rows and
+                self.resize_history_row_delta == null and
+                releasable_offset > anchor.history_visual_offset +| semantic_rows);
         const semantic_progress_rows: u32 = if (source_compatible or geometry_rebase)
             semantic_rows
         else
@@ -7117,13 +7258,14 @@ pub const TranscriptRuntime = struct {
         );
         debug_trace.logf(
             "scroll",
-            "transcript_transition_plan source_state=stable source_start={d} target_start={d} source_visual_offset={d} source_history_visual_offset={d} target_visual_offset={d} source_total_visual_rows={d} target_total_visual_rows={d} resize_reflow_candidate={d} resize_reflow_rows={d} semantic_rows={d} planned_rows={d} width_stable={s} source_compatible={s} footer_reservation_changed={s} replay_displaced_footer_history={s} geometry_rebase={s} recovery_rebase={s}",
+            "transcript_transition_plan source_state=stable source_start={d} target_start={d} source_visual_offset={d} source_history_visual_offset={d} target_visual_offset={d} releasable_visual_offset={d} source_total_visual_rows={d} target_total_visual_rows={d} resize_reflow_candidate={d} resize_reflow_rows={d} semantic_rows={d} planned_rows={d} width_stable={s} source_compatible={s} footer_reservation_changed={s} replay_displaced_footer_history={s} geometry_rebase={s} recovery_rebase={s}",
             .{
                 anchor.selection.start_line,
                 prepared.selection.start_line,
                 anchor.visual_offset,
                 anchor.history_visual_offset,
                 target_offset,
+                releasable_offset,
                 anchor.total_visual_rows,
                 target_total_visual_rows,
                 resize_reflow_candidate,
@@ -7148,6 +7290,7 @@ pub const TranscriptRuntime = struct {
             .source_compatible = source_compatible,
             .geometry_rebase = geometry_rebase,
             .recovery_rebase = recovery_rebase,
+            .finality_hold = finality_hold,
             .recovery_progress_compatible = !recovery_rebase,
             .recovery_tracks_semantic_progress = source_compatible or geometry_rebase,
         };
@@ -7473,7 +7616,16 @@ pub const TranscriptRuntime = struct {
                 target.normal_buffer_recovery_pending =
                     anchor.normal_buffer_recovery_pending;
                 target.history_catchup_pending = anchor.history_catchup_pending;
-                if (!scroll_facts.geometry_rebase) {
+                // A retained body advances only by the released rows. When
+                // the finality clamp withholds release from the plan itself
+                // (as opposed to a partial acceptance, which the recovery
+                // debt machinery owns), the viewport must still follow the
+                // flow, so the frame repaints instead of retaining.
+                const plan_covers_advance =
+                    scroll_facts.target_visual_offset -|
+                    committedProjectionVisualOffset(anchor) <=
+                    scroll_facts.semantic_rows;
+                if (!scroll_facts.geometry_rebase and plan_covers_advance) {
                     if (self.stableRetainedTransitionBody(
                         anchor,
                         source_bytes,
@@ -7523,6 +7675,41 @@ pub const TranscriptRuntime = struct {
                 {
                     target.normal_buffer_recovery_pending = false;
                 }
+                if (!target.projection_staged and
+                    target.body_disposition == .paint and
+                    !scroll_facts.geometry_rebase and
+                    !scroll_facts.recovery_rebase and
+                    !self.fullTranscriptActive() and
+                    !prepared.selection.split_active and
+                    !target_layout.transcript_area.isEmpty() and
+                    scroll_facts.target_visual_offset -|
+                        committedProjectionVisualOffset(anchor) >
+                        scroll_facts.semantic_rows and
+                    scroll_facts.target_visual_offset >= target.history_visual_offset)
+                {
+                    // The viewport advanced further than the plan may
+                    // release: slide the window with an in-place repaint at
+                    // the target offset. The rows passed over stay
+                    // unreleased and settle later through the replay.
+                    var projection_layout = self.layout;
+                    projection_layout.content_bottom = target_layout.transcript_area.bottom;
+                    try target.stagePreparedProjection(
+                        alloc,
+                        projection_layout,
+                        prepared,
+                        target_layout.transcript_area,
+                        scroll_facts.target_visual_offset,
+                    );
+                    debug_trace.logf(
+                        "scroll",
+                        "transcript_transition_hold_release target_visual_offset={d} history_visual_offset={d} semantic_rows={d}",
+                        .{
+                            scroll_facts.target_visual_offset,
+                            target.history_visual_offset,
+                            scroll_facts.semantic_rows,
+                        },
+                    );
+                }
                 if (self.stableHistoryFloor(target, anchor, scroll_facts)) |history_floor| {
                     var projection_layout = self.layout;
                     projection_layout.content_bottom = target_layout.transcript_area.bottom;
@@ -7545,6 +7732,13 @@ pub const TranscriptRuntime = struct {
                         target.visual_offset > target.history_visual_offset;
                 } else if (target.history_visual_offset >= target.visual_offset) {
                     target.history_catchup_pending = false;
+                } else if (scroll_facts.finality_hold) {
+                    // Finality withheld release; mark the debt so the next
+                    // eligible frame settles it through the existing
+                    // catch-up replay. Recomputed from the floor on every
+                    // commit, so the mark survives any interlude that drops
+                    // it. Footer displacement never sets this.
+                    target.history_catchup_pending = true;
                 }
             },
             .recovering => |receipt| {
@@ -8277,6 +8471,10 @@ pub const TranscriptRuntime = struct {
             .scroll_plan = scroll_plan,
             .document_append = document_append,
             .document_append_bytes = document_append_bytes,
+            .history_settle_pending = self.finalityReleasableOffset(
+                prepared,
+                scroll_facts.target_visual_offset,
+            ) > target.history_visual_offset,
             .resize_reflow_rows = scroll_facts.resize_reflow_rows,
             .semantic_rows = scroll_facts.semantic_rows,
             .semantic_progress_rows = scroll_facts.semantic_progress_rows,
@@ -8587,6 +8785,11 @@ pub const TranscriptRuntime = struct {
             alloc.free(transition.folded_summary_indices);
             transition.folded_summary_indices = &.{};
         }
+        if (transition.history_settle_pending) {
+            // Final rows remain unmaterialized past this commit; guarantee a
+            // follow-up frame so the debt settles without external activity.
+            self.render_requests.request(.transcript);
+        }
         transition.consumed = true;
     }
 
@@ -8780,6 +8983,14 @@ pub const TranscriptRuntime = struct {
             error.InputPending => unreachable,
             else => |other| return other,
         };
+    }
+
+    pub fn appendReplaceableSemanticNotice(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        notice: types.SemanticNotice,
+    ) !u32 {
+        return transcript_store.appendReplaceableSemanticNoticeAtomic(self, alloc, notice);
     }
 
     pub fn appendSemanticNotice(

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -129,6 +129,10 @@ const CommittedTranscriptAnchor = struct {
     measured_history_origin: ?transcript_painter.MeasuredHistoryOrigin = null,
     row_provenance: []transcript_blocks.RowProvenance = &.{},
     normal_buffer_recovery_pending: bool = false,
+    /// Stable-anchor settlement obligation. It is preserved while final rows
+    /// remain ahead of history and cleared once history reaches the viewport.
+    /// The offset gap alone is insufficient because footer displacement can
+    /// create the same shape without content debt.
     history_catchup_pending: bool = false,
 
     fn deinit(self: *CommittedTranscriptAnchor, alloc: Allocator) void {
@@ -6910,7 +6914,13 @@ pub const TranscriptRuntime = struct {
     }
 
     pub fn setAssistantTailWritable(self: *TranscriptRuntime, writable: bool) void {
+        if (self.assistant_tail_writable == writable) return;
         self.assistant_tail_writable = writable;
+        debug_trace.logf(
+            "scroll",
+            "assistant tail writability changed writable={s}",
+            .{if (writable) "true" else "false"},
+        );
     }
 
     /// Selects the finality floor in flow bytes from the prepared paint's
@@ -6969,32 +6979,6 @@ pub const TranscriptRuntime = struct {
             if (index < visual_rows.len) rows += visual_rows[index];
         }
         return rows;
-    }
-
-    /// Ability check for releasing on a byte-incompatible frame: the exact
-    /// held range must be materializable this frame through the history
-    /// replay. Mirrors resolveTransitionAppendBase's admission conditions so
-    /// the plan never authorizes a scroll the append path cannot back with
-    /// content.
-    fn incompatibleReleaseReplayResolves(
-        self: *const TranscriptRuntime,
-        prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
-        anchor: CommittedTranscriptAnchor,
-        releasable_offset: u32,
-    ) bool {
-        if (releasable_offset <= anchor.history_visual_offset) return false;
-        if (anchor.layout_id != self.committed_frame_layout.layout_id) return false;
-        if (self.committed_frame_layout.terminal_cols != self.layout.cols) return false;
-        if (self.committed_frame_layout.terminal_rows != self.layout.rows) return false;
-        if (self.resize_history_row_delta != null) return false;
-        return compatibleHistoryReplayRange(
-            prepared,
-            self.layout.cols,
-            prepared.bytes,
-            anchor.flow,
-            anchor.history_visual_offset,
-            releasable_offset,
-        ) != null;
     }
 
     /// The largest visual offset whose rows are all backed by final entries,
@@ -7249,11 +7233,12 @@ pub const TranscriptRuntime = struct {
                 // the floor clamps that range, so the budget is measured
                 // from the committed viewport, not from history.
                 releasable_offset -| anchor.visual_offset
-        else if (self.incompatibleReleaseReplayResolves(
+        else if (self.compatibleCommittedHistoryReplayRange(
             prepared,
             anchor,
+            prepared.bytes,
             releasable_offset,
-        ))
+        ) != null)
             releasable_advance
         else
             0;
@@ -7771,11 +7756,9 @@ pub const TranscriptRuntime = struct {
                 } else if (target.history_visual_offset >= target.visual_offset) {
                     target.history_catchup_pending = false;
                 } else if (scroll_facts.finality_hold) {
-                    // Finality withheld release; mark the debt so the next
-                    // eligible frame settles it through the existing
-                    // catch-up replay. Recomputed from the floor on every
-                    // commit, so the mark survives any interlude that drops
-                    // it. Footer displacement never sets this.
+                    // Finality withheld release. Preserve the obligation on
+                    // stable anchors until history catches the viewport;
+                    // footer displacement alone never creates one.
                     target.history_catchup_pending = true;
                 }
             },
@@ -7849,6 +7832,15 @@ pub const TranscriptRuntime = struct {
         clear_rows: u16,
     };
 
+    fn committedLayoutMatches(
+        self: *const TranscriptRuntime,
+        anchor: CommittedTranscriptAnchor,
+    ) bool {
+        return anchor.layout_id == self.committed_frame_layout.layout_id and
+            self.committed_frame_layout.terminal_cols == self.layout.cols and
+            self.committed_frame_layout.terminal_rows == self.layout.rows;
+    }
+
     fn compatibleHistoryReplayRange(
         prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
         cols: u16,
@@ -7890,6 +7882,25 @@ pub const TranscriptRuntime = struct {
         };
     }
 
+    fn compatibleCommittedHistoryReplayRange(
+        self: *const TranscriptRuntime,
+        prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
+        anchor: CommittedTranscriptAnchor,
+        target_flow: []const u8,
+        target_history_visual_offset: u32,
+    ) ?TransitionHistoryReplay {
+        if (!self.committedLayoutMatches(anchor)) return null;
+        if (self.resize_history_row_delta != null) return null;
+        return compatibleHistoryReplayRange(
+            prepared,
+            self.layout.cols,
+            target_flow,
+            anchor.flow,
+            anchor.history_visual_offset,
+            target_history_visual_offset,
+        );
+    }
+
     const TransitionAppendBase = struct {
         flow_len: usize,
         history_replay: ?TransitionHistoryReplay = null,
@@ -7909,23 +7920,17 @@ pub const TranscriptRuntime = struct {
     ) !?TransitionAppendBase {
         switch (self.transcript_commit_state) {
             .stable => |anchor| {
-                if (!destructive_invalidation and
-                    anchor.layout_id == self.committed_frame_layout.layout_id and
-                    self.committed_frame_layout.terminal_cols == self.layout.cols and
-                    self.committed_frame_layout.terminal_rows == self.layout.rows)
-                {
+                if (!destructive_invalidation) {
                     const replay_from_history = target_history_visual_offset >
                         anchor.history_visual_offset and
                         (scroll_facts.geometry_rebase or
                             anchor.normal_buffer_recovery_pending or
                             anchor.history_catchup_pending);
                     if (replay_from_history) {
-                        const replay = compatibleHistoryReplayRange(
+                        const replay = self.compatibleCommittedHistoryReplayRange(
                             prepared,
-                            self.layout.cols,
+                            anchor,
                             target_flow,
-                            anchor.flow,
-                            anchor.history_visual_offset,
                             target_history_visual_offset,
                         );
                         if (replay) |history_replay| {
@@ -7943,7 +7948,8 @@ pub const TranscriptRuntime = struct {
                             };
                         }
                     }
-                    if (target_flow.len >= anchor.flow.len and
+                    if (self.committedLayoutMatches(anchor) and
+                        target_flow.len >= anchor.flow.len and
                         std.mem.startsWith(u8, target_flow, anchor.flow))
                     {
                         return .{
@@ -10680,6 +10686,42 @@ test "owned stable transition traces a superseded pending resume source" {
     ) != null);
 }
 
+test "assistant tail writability transitions are traceable" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const trace_path = try std.fs.path.join(alloc, &.{ root, "assistant-tail.log" });
+    defer alloc.free(trace_path);
+
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "scroll");
+    debug_trace.logf("scroll", "assistant tail trace test start", .{});
+
+    var runtime = TranscriptRuntime{ .layout = testLayoutWithRows(8) };
+    defer runtime.deinit(alloc);
+    runtime.setAssistantTailWritable(false);
+    runtime.setAssistantTailWritable(true);
+    debug_trace.shutdown();
+
+    var trace_file = try std.Io.Dir.openFileAbsolute(std.testing.io, trace_path, .{});
+    defer trace_file.close(std.testing.io);
+    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 4096);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "assistant tail writability changed writable=false",
+    ) != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "assistant tail writability changed writable=true",
+    ) != null);
+}
+
 test "stable resume publication starts a fresh retained source epoch" {
     const alloc = std.testing.allocator;
     const retained_flow =
@@ -11639,7 +11681,7 @@ test "source rewrite replays unchanged history prefix after footer projection re
     }
 }
 
-test "history replay starts at committed source top before preserved row release" {
+test "history replay starts at committed source top and follows resize eligibility" {
     const alloc = std.testing.allocator;
     const committed_flow =
         "source-row-01\nsource-row-02\nsource-row-03\nsource-row-04\n";
@@ -11735,6 +11777,17 @@ test "history replay starts at committed source top before preserved row release
     );
     try std.testing.expectEqual(@as(u16, 4), scroll_plan.preserved_release_rows);
     try std.testing.expectEqual(@as(u16, 8), scroll_plan.terminal_scroll_rows);
+
+    runtime.resize_history_row_delta = 1;
+    const resize_facts = runtime.planTranscriptScroll(&prepared);
+    const resize_append_base = (try runtime.resolveTransitionAppendBase(
+        &prepared,
+        resize_facts,
+        false,
+        source.bytes,
+        resize_facts.target_visual_offset,
+    )) orelse return error.TestExpectedNaturalAppendBase;
+    try std.testing.expect(resize_append_base.history_replay == null);
 }
 
 test "preserved source rewrite holds the normal buffer at committed history" {

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -7402,8 +7402,8 @@ pub const TranscriptRuntime = struct {
         staged_flow_end: ?usize = null,
         projection_staged: bool = false,
         // The frame slides the viewport past withheld release with an
-        // in-place repaint; a document append would scroll the same rows
-        // physically without a matching plan.
+        // in-place repaint. Any document append is bounded separately to
+        // the rows the frame may release.
         hold_staged: bool = false,
 
         fn init(
@@ -7716,7 +7716,6 @@ pub const TranscriptRuntime = struct {
                     target.body_disposition == .paint and
                     !scroll_facts.geometry_rebase and
                     !scroll_facts.recovery_rebase and
-                    scroll_facts.semantic_rows == 0 and
                     !self.fullTranscriptActive() and
                     !prepared.selection.split_active and
                     !target_layout.transcript_area.isEmpty() and
@@ -8342,11 +8341,23 @@ pub const TranscriptRuntime = struct {
             target_flow.len
         else
             null;
+        const held_projected_flow_end: ?usize = if (target.hold_staged)
+            if (append_base) |base|
+                transcript_painter.preparedTranscriptFlowOffsetForVisualOffset(
+                    prepared,
+                    self.layout.cols,
+                    base.visual_offset + base.visual_rows +
+                        accepted.semantic_progress_rows,
+                )
+            else
+                null
+        else
+            null;
         const projected_flow_end: ?usize = if (append_base) |base|
             if (base.history_replay) |replay|
                 replay.flow_end
             else
-                natural_projected_flow_end
+                held_projected_flow_end orelse natural_projected_flow_end
         else
             natural_projected_flow_end;
         var document_append = render_engine.frame_scroll_plan.FrameDocumentAppend{};
@@ -8391,7 +8402,6 @@ pub const TranscriptRuntime = struct {
                 },
             );
         } else if (append_base != null and
-            !target.hold_staged and
             (!scroll_facts.recovery_rebase or append_is_history_replay) and
             !scroll_facts.recovery_projection_deferred and
             (if (append_is_history_replay)

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -60,6 +60,11 @@ pub const ResizeObservationPhase = enum {
     reset_queued,
 };
 
+pub const HistoryReleasePolicy = enum {
+    finality_gated,
+    append_only,
+};
+
 pub const ResizeObservationResult = union(enum) {
     awaiting,
     measured: i32,
@@ -4391,6 +4396,10 @@ pub const TranscriptRuntime = struct {
     /// a writable tail as non-final. Defaults to writable so a driver that
     /// never reports closure over-holds instead of releasing mutable rows.
     assistant_tail_writable: bool = true,
+    /// Interactive transcripts gate native-history release on producer
+    /// finality. One-shot presenters use append-only release because they do
+    /// not revisit rows after writing them.
+    history_release_policy: HistoryReleasePolicy = .finality_gated,
     /// Sorted by entry id so exact lookup stays bounded as history grows.
     tool_details: std.ArrayList(ToolDetailRecord) = .empty,
     /// Monotonically increasing id stamped onto each new entry by the
@@ -6932,6 +6941,7 @@ pub const TranscriptRuntime = struct {
         self: *const TranscriptRuntime,
         prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
     ) ?usize {
+        if (self.history_release_policy == .append_only) return null;
         const candidates = prepared.finality_candidates;
         var floor: ?usize = null;
         if (candidates.mutation_pin_start) |start| {
@@ -8348,15 +8358,31 @@ pub const TranscriptRuntime = struct {
         else
             null;
         const held_projected_flow_end: ?usize = if (target.hold_staged)
-            if (append_base) |base|
-                transcript_painter.preparedTranscriptFlowOffsetForVisualOffset(
+            if (append_base) |base| held: {
+                const base_visual_end = base.visual_offset + base.visual_rows;
+                const target_base_flow_end =
+                    transcript_painter.preparedTranscriptFlowOffsetForVisualOffset(
+                        prepared,
+                        self.layout.cols,
+                        base_visual_end,
+                    ) orelse break :held null;
+                if (target_base_flow_end < base.flow_len) break :held null;
+                // Target growth can terminate the committed line at its byte
+                // endpoint. Charge that cursor movement before advancing into
+                // the final rows this frame may release.
+                const drift = walkText(
+                    1,
+                    base.cursor_col,
+                    target_flow[base.flow_len..target_base_flow_end],
+                    self.layout.cols,
+                ).end_row - 1;
+                if (drift > accepted.semantic_progress_rows) break :held base.flow_len;
+                break :held transcript_painter.preparedTranscriptFlowOffsetForVisualOffset(
                     prepared,
                     self.layout.cols,
-                    base.visual_offset + base.visual_rows +
-                        accepted.semantic_progress_rows,
-                )
-            else
-                null
+                    base_visual_end + accepted.semantic_progress_rows - drift,
+                );
+            } else null
         else
             null;
         const projected_flow_end: ?usize = if (append_base) |base|

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -1812,13 +1812,14 @@ test "semantic notice append and replacement preserve ownership identity and tim
     defer runtime.deinit(alloc);
     runtime.setCommandOutputRenderPolicy(semanticNoticePaletteA());
 
-    const entry_id = try runtime.appendSemanticNotice(alloc, .{
+    const entry_id = try runtime.appendReplaceableSemanticNotice(alloc, .{
         .topic = "build",
         .tone = .warning,
         .body = "first body",
     });
     try std.testing.expectEqual(@as(usize, 1), runtime.entries.items.len);
     try std.testing.expect(runtime.entries.items[0] == .semantic_notice);
+    try std.testing.expect(runtime.entries.items[0].semantic_notice.pending_replacement);
     const created_at_ms = runtime.entries.items[0].createdAtMs();
     try std.testing.expectEqualStrings("build", runtime.entries.items[0].semantic_notice.topic);
     try std.testing.expectEqualStrings("first body", runtime.entries.items[0].semantic_notice.body);
@@ -1837,6 +1838,17 @@ test "semantic notice append and replacement preserve ownership identity and tim
     try std.testing.expectEqualStrings("replacement body with /tmp/output/path", runtime.entries.items[0].semantic_notice.body);
     try std.testing.expectEqual(types.NoticeVisibility.full_only, runtime.entries.items[0].semantic_notice.visibility);
     try std.testing.expectEqualStrings("", runtime.transcript.items);
+    // The finished replacement clears the pending-replacement pin, making
+    // the entry immutable history: a second in-place replacement is refused.
+    try std.testing.expect(!runtime.entries.items[0].semantic_notice.pending_replacement);
+    try std.testing.expectError(
+        error.MissingNoticeReplacementPin,
+        runtime.replaceSemanticNotice(alloc, entry_id, .{
+            .topic = "again",
+            .tone = .information,
+            .body = "must not apply",
+        }),
+    );
     try std.testing.expect(!(try runtime.replaceSemanticNotice(alloc, entry_id + 1, .{
         .topic = "missing",
         .tone = .information,
@@ -1870,7 +1882,7 @@ fn checkSemanticNoticeReplacementAllocationFailures(alloc: Allocator) !void {
     const base = std.testing.allocator;
     var runtime = TranscriptRuntime{ .layout = transcriptTestLayout(32, 16, 12) };
     defer runtime.deinit(base);
-    const entry_id = try runtime.appendSemanticNotice(base, .{
+    const entry_id = try runtime.appendReplaceableSemanticNotice(base, .{
         .topic = "before",
         .tone = .information,
         .body = "stable body",
@@ -8487,6 +8499,9 @@ test "command output consolidation preserves committed prompt scrollback anchor"
         const text = try std.fmt.bufPrint(&line, "assistant table row {d}\n", .{index + 1});
         try first_assistant.text.appendSlice(alloc, text);
     }
+    // The assistant content above is complete; report producer closure so
+    // the finality floor does not hold the tail.
+    runtime.setAssistantTailWritable(false);
 
     var live_source = try runtime.prepareTranscriptSource(alloc, null);
     defer live_source.deinit(alloc);
@@ -8558,7 +8573,29 @@ test "command output consolidation preserves committed prompt scrollback anchor"
     defer compact_prepared.deinit(alloc);
     const facts = runtime.planTranscriptScroll(&compact_prepared);
     try std.testing.expect(facts.target_visual_offset > facts.source_visual_offset);
-    try std.testing.expect(facts.planned_rows > 0);
+    // The consolidation changed committed rows in place, so this frame has
+    // no ability to materialize the held range: zero release, re-anchor on
+    // the rewritten flow, and mark the finality debt.
+    try std.testing.expect(!facts.source_compatible);
+    try std.testing.expect(facts.recovery_rebase);
+    try std.testing.expectEqual(@as(u32, 0), facts.semantic_rows);
+    try std.testing.expectEqual(@as(u16, 0), facts.planned_rows);
+    try std.testing.expect(facts.finality_hold);
+    try commitPreparedForTest(&runtime, alloc, &compact_source, &compact_prepared);
+
+    // The following compatible frame settles the debt with final bytes.
+    var settle_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer settle_source.deinit(alloc);
+    var settle_prepared = try prepareTestSourceForCurrentArea(
+        &runtime,
+        alloc,
+        &settle_source,
+    );
+    defer settle_prepared.deinit(alloc);
+    const settle_facts = runtime.planTranscriptScroll(&settle_prepared);
+    try std.testing.expect(settle_facts.source_compatible);
+    try std.testing.expect(settle_facts.semantic_rows > 0);
+    try std.testing.expect(settle_facts.planned_rows > 0);
 }
 
 fn removeRawEntriesForTest(
@@ -15105,4 +15142,240 @@ test "lifecycle pins survive low cap until batch cleanup restores prune eligibil
         !transcriptContainsEntry(&runtime, first) or
             !transcriptContainsEntry(&runtime, second),
     );
+}
+
+test "finality floor holds unfenced tool turn across quiet ticks and settles after the fence" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(60, 10, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    for (0..6) |index| {
+        var line: [32]u8 = undefined;
+        const text = try std.fmt.bufPrint(&line, "final context {d:0>2}\n", .{index});
+        _ = try runtime.appendRawTranscriptEntry(alloc, text);
+    }
+    var base_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer base_source.deinit(alloc);
+    var base_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &base_source);
+    defer base_prepared.deinit(alloc);
+    try commitPreparedForTest(&runtime, alloc, &base_source, &base_prepared);
+
+    var turn_call_ids: [8][12]u8 = undefined;
+    for (0..8) |index| {
+        const call_id = try std.fmt.bufPrint(&turn_call_ids[index], "t2-call-{d:0>2}", .{index});
+        const id = types.ToolLifecycleId{ .turn_id = 2, .call_id = call_id };
+        _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+            .id = id,
+            .presentation_group_id = .{ .turn_id = 2, .anchor_step_id = 1 },
+            .reconciles_provisional_call_id = null,
+            .tool_name = "read_file",
+            .activity_kind = .read,
+        } });
+        _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+            .id = id,
+            .outcome = .{ .kind = .completed, .summary = "Read one file" },
+        } });
+    }
+    try runtime.finishLifecycleBatch(alloc);
+    try std.testing.expectEqual(@as(u64, 0), runtime.finalizedToolTurnWatermark());
+
+    var live_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer live_source.deinit(alloc);
+    var live_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &live_source);
+    defer live_prepared.deinit(alloc);
+    try commitPreparedForTest(&runtime, alloc, &live_source, &live_prepared);
+
+    const held = runtime.transcript_commit_state.stable;
+    try std.testing.expect(held.visual_offset > held.history_visual_offset);
+
+    // Quiet ticks over the unchanged flow release nothing: byte stability
+    // is not finality while the turn is unfenced.
+    var quiet_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer quiet_source.deinit(alloc);
+    var quiet_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &quiet_source);
+    defer quiet_prepared.deinit(alloc);
+    const quiet_facts = runtime.planTranscriptScroll(&quiet_prepared);
+    try std.testing.expect(quiet_facts.source_compatible);
+    try std.testing.expectEqual(@as(u32, 0), quiet_facts.semantic_rows);
+    try std.testing.expect(quiet_facts.finality_hold);
+
+    // A later mutation of the same group still releases nothing.
+    const late_call = types.ToolLifecycleId{ .turn_id = 2, .call_id = "t2-late" };
+    _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = late_call,
+        .presentation_group_id = .{ .turn_id = 2, .anchor_step_id = 1 },
+        .reconciles_provisional_call_id = null,
+        .tool_name = "read_file",
+        .activity_kind = .read,
+    } });
+    _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+        .id = late_call,
+        .outcome = .{ .kind = .completed, .summary = "Read late file" },
+    } });
+    try runtime.finishLifecycleBatch(alloc);
+    var mutated_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer mutated_source.deinit(alloc);
+    var mutated_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &mutated_source);
+    defer mutated_prepared.deinit(alloc);
+    const mutated_facts = runtime.planTranscriptScroll(&mutated_prepared);
+    try std.testing.expectEqual(@as(u32, 0), mutated_facts.semantic_rows);
+    try std.testing.expectEqual(@as(u16, 0), mutated_facts.planned_rows);
+    try commitPreparedForTest(&runtime, alloc, &mutated_source, &mutated_prepared);
+
+    // The fence and the final mutation arrive in one batch: the first
+    // post-fence frame is byte-incompatible and must hold (zero release),
+    // re-anchoring on the final flow.
+    _ = try runtime.applyToolLifecycle(alloc, .{ .turn_finished = .{
+        .turn_id = 2,
+        .outcome = .completed,
+    } });
+    try runtime.finishLifecycleBatch(alloc);
+    try std.testing.expectEqual(@as(u64, 2), runtime.finalizedToolTurnWatermark());
+
+    // The debt settles on the first eligible frame after the fence: the
+    // same frame when the fence publication changed no bytes, or the frame
+    // after a byte-incompatible publication re-anchors (Phase A then B).
+    var released: u32 = 0;
+    for (0..2) |frame_index| {
+        var frame_source = try runtime.prepareTranscriptSource(alloc, null);
+        defer frame_source.deinit(alloc);
+        var frame_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &frame_source);
+        defer frame_prepared.deinit(alloc);
+        const frame_facts = runtime.planTranscriptScroll(&frame_prepared);
+        if (!frame_facts.source_compatible) {
+            // Phase A: zero release while the anchor is stale.
+            try std.testing.expectEqual(@as(u32, 0), frame_facts.semantic_rows);
+            try std.testing.expectEqual(@as(u16, 0), frame_facts.planned_rows);
+            try std.testing.expect(frame_facts.finality_hold);
+            try std.testing.expectEqual(@as(usize, 0), frame_index);
+        }
+        released += frame_facts.semantic_rows;
+        try commitPreparedForTest(&runtime, alloc, &frame_source, &frame_prepared);
+    }
+    try std.testing.expect(released > 0);
+    const settled = runtime.transcript_commit_state.stable;
+    try std.testing.expectEqual(settled.visual_offset, settled.history_visual_offset);
+}
+
+test "pending replacement notice holds release until the finished replacement settles" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(24, 10, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    for (0..4) |index| {
+        var line: [24]u8 = undefined;
+        const text = try std.fmt.bufPrint(&line, "history {d:0>2}\n", .{index});
+        _ = try runtime.appendRawTranscriptEntry(alloc, text);
+    }
+    var base_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer base_source.deinit(alloc);
+    var base_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &base_source);
+    defer base_prepared.deinit(alloc);
+    try commitPreparedForTest(&runtime, alloc, &base_source, &base_prepared);
+    const notice_id = try runtime.appendReplaceableSemanticNotice(alloc, .{
+        .topic = "feedback",
+        .tone = .neutral,
+        .body = "Preparing feedback report while external work is blocking",
+    });
+    for (0..6) |index| {
+        var line: [24]u8 = undefined;
+        const text = try std.fmt.bufPrint(&line, "later {d:0>2}\n", .{index});
+        _ = try runtime.appendRawTranscriptEntry(alloc, text);
+    }
+
+    var live_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer live_source.deinit(alloc);
+    var live_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &live_source);
+    defer live_prepared.deinit(alloc);
+    try commitPreparedForTest(&runtime, alloc, &live_source, &live_prepared);
+    const held = runtime.transcript_commit_state.stable;
+    try std.testing.expect(held.visual_offset > held.history_visual_offset);
+
+    // Quiet frames while the producer blocks release nothing.
+    var quiet_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer quiet_source.deinit(alloc);
+    var quiet_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &quiet_source);
+    defer quiet_prepared.deinit(alloc);
+    const quiet_facts = runtime.planTranscriptScroll(&quiet_prepared);
+    try std.testing.expect(quiet_facts.source_compatible);
+    try std.testing.expectEqual(@as(u32, 0), quiet_facts.semantic_rows);
+    try std.testing.expect(quiet_facts.finality_hold);
+
+    // The finished replacement clears the pin; the incompatible frame
+    // re-anchors with zero release and the next frame settles everything.
+    try std.testing.expect(try runtime.replaceSemanticNotice(alloc, notice_id, .{
+        .topic = "feedback",
+        .tone = .success,
+        .body = "Feedback report ready",
+    }));
+    var replaced_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer replaced_source.deinit(alloc);
+    var replaced_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &replaced_source);
+    defer replaced_prepared.deinit(alloc);
+    const replaced_facts = runtime.planTranscriptScroll(&replaced_prepared);
+    try std.testing.expect(!replaced_facts.source_compatible);
+    try std.testing.expectEqual(@as(u32, 0), replaced_facts.semantic_rows);
+    try std.testing.expectEqual(@as(u16, 0), replaced_facts.planned_rows);
+    try commitPreparedForTest(&runtime, alloc, &replaced_source, &replaced_prepared);
+
+    var settle_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer settle_source.deinit(alloc);
+    try std.testing.expect(
+        std.mem.find(u8, settle_source.bytes, "report ready") != null,
+    );
+    var settle_prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &settle_source);
+    defer settle_prepared.deinit(alloc);
+    const settle_facts = runtime.planTranscriptScroll(&settle_prepared);
+    try std.testing.expect(settle_facts.source_compatible);
+    try std.testing.expect(settle_facts.semantic_rows > 0);
+    try commitPreparedForTest(&runtime, alloc, &settle_source, &settle_prepared);
+    const settled = runtime.transcript_commit_state.stable;
+    try std.testing.expectEqual(settled.visual_offset, settled.history_visual_offset);
+}
+
+test "finality candidates keep tool turn and replaceable tail offsets independent" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(60, 12, 8),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    const id = types.ToolLifecycleId{ .turn_id = 5, .call_id = "boundary-call" };
+    _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = id,
+        .presentation_group_id = .{ .turn_id = 5, .anchor_step_id = 1 },
+        .reconciles_provisional_call_id = null,
+        .tool_name = "read_file",
+        .activity_kind = .read,
+    } });
+    _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+        .id = id,
+        .outcome = .{ .kind = .completed, .summary = "Read boundary file" },
+    } });
+    try runtime.finishLifecycleBatch(alloc);
+    _ = try runtime.appendRawTranscriptEntry(alloc, "settled context line\n");
+    _ = try transcript_store.appendReplaceableTranscriptLineSilent(
+        &runtime,
+        alloc,
+        "working status line",
+    );
+
+    var source = try runtime.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), source.finality.tool_turn_floors.len);
+    const group_floor = source.finality.tool_turn_floors[0];
+    try std.testing.expectEqual(@as(u64, 5), group_floor.turn_id);
+    try std.testing.expect(group_floor.start_byte < source.bytes.len);
+    // The replaceable-tail contract keeps its own offset; the finality
+    // boundary does not repurpose it.
+    try std.testing.expect(source.replaceable_last_line);
+    try std.testing.expect(source.replaceable_start > group_floor.start_byte);
+    try std.testing.expect(source.replaceable_start < source.bytes.len);
 }

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -15341,6 +15341,81 @@ test "catch-up release materializes history before staging a larger finality hol
     }
 }
 
+test "partial finality release bounds append before staging withheld viewport" {
+    const alloc = std.testing.allocator;
+    const committed_flow =
+        "row-00\nrow-01\nrow-02\nrow-03\n" ++
+        "row-04\nrow-05\nrow-06\nrow-07\n";
+    const target_flow = committed_flow ++
+        "row-08\nrow-09\nrow-10\nrow-11\nrow-12\nrow-13\n";
+    const finality_floor = "row-00\nrow-01\nrow-02\nrow-03\nrow-04\n".len;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(20, 8, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    var committed_source = try testSource(alloc, committed_flow, runtime.layout.cols);
+    defer committed_source.deinit(alloc);
+    var committed_prepared = try prepareTestSourceForCurrentArea(
+        &runtime,
+        alloc,
+        &committed_source,
+    );
+    defer committed_prepared.deinit(alloc);
+    try installStableAnchorForTest(
+        &runtime,
+        alloc,
+        committed_flow,
+        committed_prepared.selection,
+        preparedVisualOffsetForTest(&committed_prepared),
+        committed_prepared.cursor.cursor_row,
+        committed_prepared.cursor.cursor_col,
+        1,
+    );
+    switch (runtime.transcript_commit_state) {
+        .stable => |*anchor| anchor.total_visual_rows = 8,
+        .invalid, .recovering => return error.TestExpectedStableTranscript,
+    }
+
+    var source = try testSource(alloc, target_flow, runtime.layout.cols);
+    defer source.deinit(alloc);
+    source.finality.mutation_pin_start = finality_floor;
+    var prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &source);
+    defer prepared.deinit(alloc);
+    const facts = runtime.planTranscriptScroll(&prepared);
+    try std.testing.expect(facts.source_compatible);
+    try std.testing.expectEqual(@as(u32, 4), facts.source_visual_offset);
+    try std.testing.expectEqual(@as(u32, 10), facts.target_visual_offset);
+    try std.testing.expectEqual(@as(u32, 1), facts.semantic_rows);
+    try std.testing.expectEqual(@as(u16, 1), facts.planned_rows);
+    try std.testing.expect(facts.finality_hold);
+
+    const scroll_plan = render_engine.frame_scroll_plan.merge(
+        runtime.layout.rows,
+        runtime.owned_top_row,
+        0,
+        facts.planned_rows,
+    );
+    var plan = testPaintPlan(&runtime, prepared.selection);
+    var transition = try runtime.finalizeTranscriptTransition(
+        alloc,
+        &source,
+        &prepared,
+        render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan),
+        &plan,
+        scroll_plan,
+    );
+    defer transition.deinit(alloc);
+
+    try std.testing.expectEqualStrings(
+        "row-08\r\n",
+        transition.document_append.bytes,
+    );
+    try std.testing.expectEqual(@as(u32, 10), transition.visual_offset);
+    try std.testing.expectEqual(@as(u32, 5), transition.history_visual_offset);
+}
+
 test "recovery growth does not release rows past the finality floor" {
     const alloc = std.testing.allocator;
     const attempt_flow =

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -15260,6 +15260,130 @@ test "finality floor holds unfenced tool turn across quiet ticks and settles aft
     try std.testing.expectEqual(settled.visual_offset, settled.history_visual_offset);
 }
 
+test "catch-up release materializes history before staging a larger finality hold" {
+    const alloc = std.testing.allocator;
+    const committed_flow =
+        "row-00\nrow-01\nrow-02\nrow-03\n" ++
+        "row-04\nrow-05\nrow-06\nrow-07\n";
+    const target_flow = committed_flow ++
+        "row-08\nrow-09\nrow-10\nrow-11\nrow-12\nrow-13\n";
+    const finality_floor = "row-00\nrow-01\nrow-02\n".len;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(20, 8, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    var committed_source = try testSource(alloc, committed_flow, runtime.layout.cols);
+    defer committed_source.deinit(alloc);
+    var committed_prepared = try prepareTestSourceForCurrentArea(
+        &runtime,
+        alloc,
+        &committed_source,
+    );
+    defer committed_prepared.deinit(alloc);
+    try installStableAnchorForTest(
+        &runtime,
+        alloc,
+        committed_flow,
+        committed_prepared.selection,
+        preparedVisualOffsetForTest(&committed_prepared),
+        committed_prepared.cursor.cursor_row,
+        committed_prepared.cursor.cursor_col,
+        1,
+    );
+    switch (runtime.transcript_commit_state) {
+        .stable => |*anchor| {
+            anchor.history_visual_offset = 0;
+            anchor.history_catchup_pending = true;
+        },
+        .invalid, .recovering => return error.TestExpectedStableTranscript,
+    }
+
+    var source = try testSource(alloc, target_flow, runtime.layout.cols);
+    defer source.deinit(alloc);
+    source.finality.mutation_pin_start = finality_floor;
+    var prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &source);
+    defer prepared.deinit(alloc);
+    const facts = runtime.planTranscriptScroll(&prepared);
+    try std.testing.expect(facts.source_compatible);
+    try std.testing.expectEqual(@as(u32, 3), facts.semantic_rows);
+    try std.testing.expect(facts.semantic_rows > 0);
+    try std.testing.expect(
+        facts.target_visual_offset - facts.source_visual_offset > facts.semantic_rows,
+    );
+    try std.testing.expect(facts.finality_hold);
+
+    const scroll_plan = render_engine.frame_scroll_plan.merge(
+        runtime.layout.rows,
+        runtime.owned_top_row,
+        0,
+        facts.planned_rows,
+    );
+    var plan = testPaintPlan(&runtime, prepared.selection);
+    var transition = try runtime.finalizeTranscriptTransition(
+        alloc,
+        &source,
+        &prepared,
+        render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan),
+        &plan,
+        scroll_plan,
+    );
+    defer transition.deinit(alloc);
+
+    try std.testing.expectEqualStrings(
+        "row-00\r\nrow-01\r\nrow-02\r\n",
+        transition.document_append.bytes,
+    );
+    switch (transition.document_append.clear) {
+        .rows => |rows| try std.testing.expectEqual(@as(u16, 3), rows),
+        .remainder => return error.TestExpectedHistoryReplay,
+    }
+}
+
+test "recovery growth does not release rows past the finality floor" {
+    const alloc = std.testing.allocator;
+    const attempt_flow =
+        "row-00\nrow-01\nrow-02\nrow-03\n" ++
+        "row-04\nrow-05\nrow-06\nrow-07\n";
+    const grown_flow = attempt_flow ++
+        "row-08\nrow-09\nrow-10\nrow-11\n";
+    const finality_floor = "row-00\nrow-01\nrow-02\nrow-03\n".len;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(20, 8, 4),
+        .owned_top_row = 1,
+        .transcript_commit_state = .{ .recovering = .{
+            .accepted_visual_offset = 4,
+            .accepted_history_visual_offset = 4,
+            .attempt_visual_offset = 4,
+            .attempt_total_visual_rows = 8,
+            .materialized_visual_offset = 4,
+            .materialized_visual_rows = 4,
+            .materialized_flow_len = attempt_flow.len,
+            .attempt_cols = 20,
+            .tracks_semantic_progress = true,
+            .flow = try alloc.dupe(u8, attempt_flow),
+            .cursor_row = 4,
+            .cursor_col = 1,
+        } },
+    };
+    defer runtime.deinit(alloc);
+
+    var source = try testSource(alloc, grown_flow, runtime.layout.cols);
+    defer source.deinit(alloc);
+    source.finality.mutation_pin_start = finality_floor;
+    var prepared = try prepareTestSourceForCurrentArea(&runtime, alloc, &source);
+    defer prepared.deinit(alloc);
+
+    const facts = runtime.planTranscriptScroll(&prepared);
+    try std.testing.expect(facts.source_compatible);
+    try std.testing.expect(facts.recovery_progress_compatible);
+    try std.testing.expectEqual(@as(u32, 8), facts.target_visual_offset);
+    try std.testing.expectEqual(@as(u32, 0), facts.semantic_rows);
+    try std.testing.expectEqual(@as(u32, 0), facts.semantic_progress_rows);
+    try std.testing.expectEqual(@as(u16, 0), facts.planned_rows);
+}
+
 test "pending replacement notice holds release until the finished replacement settles" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const command_output_runtime = @import("command_output_runtime.zig");
+const debug_trace = @import("../../core/shared/debug_trace.zig");
 const build_checkpoint = @import("../render_engine/build_checkpoint.zig");
 const tool_group_projection = @import("tool_group_projection.zig");
 const render_engine = @import("../render_engine.zig");
@@ -26,6 +27,129 @@ test {
     _ = tool_group_projection;
 }
 
+/// Byte offset where an unfenced tool turn's first rendered entry begins.
+/// Whether the turn is still open is a frame-fresh fact (the lifecycle
+/// watermark), so every retained turn keeps a candidate and the planner
+/// selects against the live watermark.
+pub const ToolTurnFloor = struct {
+    turn_id: u64,
+    start_byte: usize,
+};
+
+/// Activity-independent finality boundary candidates recorded while the flow
+/// was rendered. Offsets are valid for the source's `bytes` at its `cols`.
+/// Selection against frame-fresh producer facts (lifecycle watermark,
+/// assistant-tail writability) happens in the scroll planner, outside any
+/// source cache.
+pub const FinalityCandidates = struct {
+    mutation_pin_start: ?usize = null,
+    assistant_tail_start: ?usize = null,
+    tool_turn_floors: []ToolTurnFloor = &.{},
+
+    pub fn deinit(self: *FinalityCandidates, alloc: Allocator) void {
+        if (self.tool_turn_floors.len > 0) alloc.free(self.tool_turn_floors);
+        self.* = .{};
+    }
+
+    pub fn clone(self: *const FinalityCandidates, alloc: Allocator) !FinalityCandidates {
+        return .{
+            .mutation_pin_start = self.mutation_pin_start,
+            .assistant_tail_start = self.assistant_tail_start,
+            .tool_turn_floors = try alloc.dupe(ToolTurnFloor, self.tool_turn_floors),
+        };
+    }
+};
+
+const FinalityNominationKind = enum { mutation_pin, tool_turn, assistant_tail };
+
+const FinalityNomination = struct {
+    entry_id: u32,
+    kind: FinalityNominationKind,
+    turn_id: u64 = 0,
+};
+
+fn entryHiddenByActions(
+    entry_actions: []const transcript_blocks.EntryRenderAction,
+    index: usize,
+) bool {
+    if (entry_actions.len == 0) return false;
+    return entry_actions[index] == .hide;
+}
+
+/// Nominate the entries whose rendered start bytes bound the final flow
+/// prefix: the first entry carrying a live mutation pin, the first rendered
+/// entry of each tool turn, and a trailing assistant entry. Omitted and
+/// hidden entries contribute no flow bytes and are skipped.
+fn collectFinalityNominations(
+    self: anytype,
+    alloc: Allocator,
+    omitted_entry_id: ?u32,
+    entry_actions: []const transcript_blocks.EntryRenderAction,
+) !std.ArrayList(FinalityNomination) {
+    var nominations: std.ArrayList(FinalityNomination) = .empty;
+    errdefer nominations.deinit(alloc);
+
+    var entry_turn_ids: std.AutoHashMapUnmanaged(u32, u64) = .empty;
+    defer entry_turn_ids.deinit(alloc);
+    for (self.tool_details.items) |detail| {
+        const turn_id: u64 = if (detail.presentation_group_id) |group|
+            group.turn_id
+        else if (detail.lifecycle_id) |lifecycle|
+            lifecycle.turn_id
+        else
+            continue;
+        try entry_turn_ids.put(alloc, detail.entry_id, turn_id);
+    }
+
+    var pin_nominated = false;
+    var seen_turns: std.AutoHashMapUnmanaged(u64, void) = .empty;
+    defer seen_turns.deinit(alloc);
+    for (self.entries.items, 0..) |entry, index| {
+        const entry_id = entry.id();
+        if (omitted_entry_id == entry_id) continue;
+        if (entryHiddenByActions(entry_actions, index)) continue;
+        if (!pin_nominated) {
+            const pinned = switch (entry) {
+                .raw_bytes => |raw| raw.lifecycle_pinned,
+                .semantic_notice => |notice| notice.pending_replacement,
+                else => false,
+            };
+            if (pinned) {
+                try nominations.append(alloc, .{
+                    .entry_id = entry_id,
+                    .kind = .mutation_pin,
+                });
+                pin_nominated = true;
+            }
+        }
+        if (entry == .raw_bytes and entry.raw_bytes.class == .tool_status) {
+            if (entry_turn_ids.get(entry_id)) |turn_id| {
+                const seen = try seen_turns.getOrPut(alloc, turn_id);
+                if (!seen.found_existing) {
+                    try nominations.append(alloc, .{
+                        .entry_id = entry_id,
+                        .kind = .tool_turn,
+                        .turn_id = turn_id,
+                    });
+                }
+            }
+        }
+    }
+    if (self.entries.items.len > 0) {
+        const tail = self.entries.items[self.entries.items.len - 1];
+        if (tail == .assistant_turn and
+            omitted_entry_id != tail.id() and
+            !entryHiddenByActions(entry_actions, self.entries.items.len - 1))
+        {
+            try nominations.append(alloc, .{
+                .entry_id = tail.id(),
+                .kind = .assistant_tail,
+            });
+        }
+    }
+    return nominations;
+}
+
 pub const TranscriptPreparationSource = struct {
     bytes: []u8,
     folded_summary_indices: []usize,
@@ -47,6 +171,7 @@ pub const TranscriptPreparationSource = struct {
     transcript_visible_lines: []viewport_selection.VisibleTranscriptLine = &.{},
     transcript_line_visual_rows: []u16 = &.{},
     transcript_visual_row_offsets: []u32 = &.{},
+    finality: FinalityCandidates = .{},
 
     pub fn deinit(self: *TranscriptPreparationSource, alloc: Allocator) void {
         if (self.bytes.len > 0) alloc.free(self.bytes);
@@ -56,6 +181,7 @@ pub const TranscriptPreparationSource = struct {
         if (self.transcript_visible_lines.len > 0) alloc.free(self.transcript_visible_lines);
         if (self.transcript_line_visual_rows.len > 0) alloc.free(self.transcript_line_visual_rows);
         if (self.transcript_visual_row_offsets.len > 0) alloc.free(self.transcript_visual_row_offsets);
+        self.finality.deinit(alloc);
         self.* = undefined;
     }
 
@@ -119,6 +245,8 @@ pub const TranscriptPreparationSource = struct {
         errdefer alloc.free(transcript_line_visual_rows);
         const transcript_visual_row_offsets = try alloc.dupe(u32, self.transcript_visual_row_offsets);
         errdefer alloc.free(transcript_visual_row_offsets);
+        var finality = try self.finality.clone(alloc);
+        errdefer finality.deinit(alloc);
         return .{
             .bytes = bytes,
             .folded_summary_indices = folded_summary_indices,
@@ -140,6 +268,7 @@ pub const TranscriptPreparationSource = struct {
             .transcript_visible_lines = transcript_visible_lines,
             .transcript_line_visual_rows = transcript_line_visual_rows,
             .transcript_visual_row_offsets = transcript_visual_row_offsets,
+            .finality = finality,
         };
     }
 };
@@ -339,6 +468,8 @@ fn prepareTranscriptSourceInternal(
     else
         aligned_actions;
 
+    var finality: FinalityCandidates = .{};
+    errdefer finality.deinit(alloc);
     if (self.entries.items.len > 0 and self.layout.cols > 0) {
         rendered_from_entries = true;
         const capture_provenance = observationEnabled(self, alloc) or
@@ -348,6 +479,21 @@ fn prepareTranscriptSourceInternal(
             self.entries.items[self.entries.items.len - 1].raw_bytes.id
         else
             null;
+        var finality_nominations = try collectFinalityNominations(
+            self,
+            alloc,
+            omitted_entry_id,
+            entry_actions,
+        );
+        defer finality_nominations.deinit(alloc);
+        const finality_entry_ids = try alloc.alloc(u32, finality_nominations.items.len);
+        defer alloc.free(finality_entry_ids);
+        const finality_entry_start_bytes = try alloc.alloc(?usize, finality_nominations.items.len);
+        defer alloc.free(finality_entry_start_bytes);
+        for (finality_nominations.items, 0..) |nomination, index| {
+            finality_entry_ids[index] = nomination.entry_id;
+            finality_entry_start_bytes[index] = null;
+        }
         const summary_entry_ids = try alloc.alloc(?u32, self.folded_command_blocks.items.len);
         defer alloc.free(summary_entry_ids);
         for (self.folded_command_blocks.items, 0..) |block, index| {
@@ -362,6 +508,8 @@ fn prepareTranscriptSourceInternal(
             .{
                 .target_entry_id = tracked_entry_id,
                 .target_byte_entry_id = replaceable_entry_id,
+                .finality_entry_ids = finality_entry_ids,
+                .finality_entry_start_bytes = finality_entry_start_bytes,
                 .omitted_entry_id = omitted_entry_id,
                 .folded_summary_entry_ids = summary_entry_ids,
                 .capture_provenance = capture_provenance,
@@ -376,6 +524,29 @@ fn prepareTranscriptSourceInternal(
         trailing_boundary_blank_rows = rendered.trailing_boundary_blank_rows;
         tracked_entry_start_line = rendered.target_entry_start_line;
         replaceable_entry_start_byte = rendered.target_entry_start_byte;
+        var tool_turn_floors: std.ArrayList(ToolTurnFloor) = .empty;
+        errdefer tool_turn_floors.deinit(alloc);
+        for (finality_nominations.items, 0..) |nomination, index| {
+            const start_byte = finality_entry_start_bytes[index] orelse blk: {
+                // A nominated entry that produced no bytes cannot anchor the
+                // boundary; hold the whole flow rather than release past it.
+                debug_trace.logf(
+                    "scroll",
+                    "finality_nomination_unrecorded entry_id={d} kind={s}",
+                    .{ nomination.entry_id, @tagName(nomination.kind) },
+                );
+                break :blk 0;
+            };
+            switch (nomination.kind) {
+                .mutation_pin => finality.mutation_pin_start = start_byte,
+                .assistant_tail => finality.assistant_tail_start = start_byte,
+                .tool_turn => try tool_turn_floors.append(alloc, .{
+                    .turn_id = nomination.turn_id,
+                    .start_byte = start_byte,
+                }),
+            }
+        }
+        finality.tool_turn_floors = try tool_turn_floors.toOwnedSlice(alloc);
     } else {
         bytes = try alloc.dupe(u8, self.transcript.items);
         folded_summary_indices = try alloc.alloc(usize, self.folded_command_blocks.items.len);
@@ -514,6 +685,7 @@ fn prepareTranscriptSourceInternal(
         .cols = self.layout.cols,
         .recorded_entries_authoritative = rendered_from_entries,
         .cache_origin_untrimmed = cache_origin_untrimmed,
+        .finality = finality,
     };
 }
 

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -36,8 +36,8 @@ pub const ToolTurnFloor = struct {
     start_byte: usize,
 };
 
-/// Activity-independent finality boundary candidates recorded while the flow
-/// was rendered. Offsets are valid for the source's `bytes` at its `cols`.
+/// Activity-independent finality boundary candidates for the prepared flow.
+/// Each offset addresses the source's `bytes` at its `cols`.
 /// Selection against frame-fresh producer facts (lifecycle watermark,
 /// assistant-tail writability) happens in the scroll planner, outside any
 /// source cache.

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -1070,6 +1070,7 @@ fn appendSemanticNoticeEntry(
     self: anytype,
     alloc: Allocator,
     notice: types.SemanticNotice,
+    pending_replacement: bool,
 ) !u32 {
     std.debug.assert(notice.body.len > 0);
 
@@ -1083,6 +1084,7 @@ fn appendSemanticNoticeEntry(
         .tone = owned.tone,
         .body = owned.body,
         .visibility = owned.visibility,
+        .pending_replacement = pending_replacement,
     } });
     self.next_entry_id +%= 1;
     return entry_id;
@@ -1093,13 +1095,38 @@ pub fn appendSemanticNoticeAtomic(
     alloc: Allocator,
     notice: types.SemanticNotice,
 ) !u32 {
+    return appendSemanticNoticeAtomicPinned(self, alloc, notice, false);
+}
+
+/// Appends a semantic notice the producer intends to replace in place later.
+/// The entry carries a pending-replacement pin; replaceSemanticNoticeAtomic
+/// requires that pin, and the finished replacement clears it.
+pub fn appendReplaceableSemanticNoticeAtomic(
+    self: anytype,
+    alloc: Allocator,
+    notice: types.SemanticNotice,
+) !u32 {
+    return appendSemanticNoticeAtomicPinned(self, alloc, notice, true);
+}
+
+fn appendSemanticNoticeAtomicPinned(
+    self: anytype,
+    alloc: Allocator,
+    notice: types.SemanticNotice,
+    pending_replacement: bool,
+) !u32 {
     std.debug.assert(notice.body.len > 0);
     try self.assertCanMutateTranscript();
 
     var shadow = try cloneMutationState(self, alloc);
     defer shadow.deinit(alloc);
 
-    const entry_id = try appendSemanticNoticeEntry(&shadow, alloc, notice);
+    const entry_id = try appendSemanticNoticeEntry(
+        &shadow,
+        alloc,
+        notice,
+        pending_replacement,
+    );
     const retention_changed = try enforceStructuredRetentionAndReport(
         &shadow,
         alloc,
@@ -1143,6 +1170,12 @@ pub fn replaceSemanticNoticeAtomic(
     var shadow = try cloneMutationState(self, alloc);
     defer shadow.deinit(alloc);
     const entry_index = semanticNoticeIndex(&shadow, entry_id) orelse return false;
+    // In-place replacement requires the producer-owned pin, mirroring the
+    // raw-bytes lifecycle pin: an unpinned notice is immutable history and
+    // may already be released into terminal scrollback.
+    if (!shadow.entries.items[entry_index].semantic_notice.pending_replacement) {
+        return error.MissingNoticeReplacementPin;
+    }
     const created_at_ms = shadow.entries.items[entry_index].semantic_notice.created_at_ms;
     const owned = try types.dupeSemanticNotice(alloc, notice);
     var handed_off = false;
@@ -1958,6 +1991,7 @@ fn cloneEntry(alloc: Allocator, entry: TranscriptEntry) !TranscriptEntry {
                 .tone = owned.tone,
                 .body = owned.body,
                 .visibility = owned.visibility,
+                .pending_replacement = notice.pending_replacement,
             } };
         },
         .user_turn => |user| blk: {

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -19,6 +19,7 @@ import {
   fakeGatewaySse,
   fakeGatewaySerializedToolCall,
   fakeGatewayToolCall,
+  startDynamicFakeGateway,
   startFakeGateway,
   terminalFixtureShell,
   TmuxSession,
@@ -101,6 +102,38 @@ function terminalCommand(args: string[]): string {
   const fx = [FX_BIN, ...args].map(shellQuote).join(" ");
   const script = `${fx}; code=$?; printf '\\n__FX_EXIT_%s__\\n' "$code"; exit "$code"`;
   return `/bin/sh -c ${shellQuote(script)}`;
+}
+
+function fakeGatewayStreamingText(lines: string[], delayMs: number) {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      async start(controller) {
+        for (const line of lines) {
+          controller.enqueue(encoder.encode(
+            `data: ${JSON.stringify({
+              type: "text-delta",
+              id: "answer_1",
+              delta: `${line}\n`,
+            })}\n\n`,
+          ));
+          if (delayMs > 0) await Bun.sleep(delayMs);
+        }
+        controller.enqueue(encoder.encode(
+          `data: ${JSON.stringify({
+            type: "finish",
+            finishReason: { unified: "stop", raw: "stop" },
+            usage: {
+              inputTokens: { total: 3 },
+              outputTokens: { total: lines.length },
+            },
+          })}\n\ndata: [DONE]\n\n`,
+        ));
+        controller.close();
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
 }
 
 describe("fx ask presentation", () => {
@@ -336,6 +369,147 @@ describe("fx ask presentation", () => {
       for (const line of answerLines) {
         const index = scrollback.indexOf(line);
         expect(index, line).toBeGreaterThan(previousIndex);
+        previousIndex = index;
+      }
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "TTY output enters native scrollback before the response finishes",
+    async () => {
+      const root = createRoot();
+      const answerLines = Array.from(
+        { length: 40 },
+        (_, index) => `OPEN_STREAM_LINE_${String(index + 1).padStart(2, "0")}`,
+      );
+      let releaseResponse = () => {};
+      const responseGate = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      const gateway = startDynamicFakeGateway(() => {
+        const encoder = new TextEncoder();
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              for (const line of answerLines) {
+                controller.enqueue(encoder.encode(
+                  `data: ${JSON.stringify({
+                    type: "text-delta",
+                    id: "answer_1",
+                    delta: `${line}\n`,
+                  })}\n\n`,
+                ));
+              }
+              void responseGate.then(() => {
+                controller.enqueue(encoder.encode(
+                  `data: ${JSON.stringify({
+                    type: "finish",
+                    finishReason: { unified: "stop", raw: "stop" },
+                    usage: {
+                      inputTokens: { total: 3 },
+                      outputTokens: { total: answerLines.length },
+                    },
+                  })}\n\ndata: [DONE]\n\n`,
+                ));
+                controller.close();
+              });
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      });
+      gateways.push(gateway);
+      const stderrPath = join(root.root, "stderr.log");
+      writeFileSync(stderrPath, "");
+
+      const session = await TmuxSession.create({
+        cmd: terminalCommand([
+          "ask",
+          "--no-save",
+          "Stream every answer line.",
+        ]),
+        cwd: root.workspace,
+        env: gatewayEnv(root.home, gateway),
+        width: 80,
+        height: 12,
+        minimumHistoryLines: 200,
+        remainOnExit: true,
+        stderrPath,
+      });
+      sessions.push(session);
+
+      try {
+        const requestDeadline = Date.now() + 5_000;
+        while (gateway.requestCount() === 0 && Date.now() < requestDeadline) {
+          await Bun.sleep(25);
+        }
+        expect(gateway.requestCount()).toBe(1);
+
+        const releaseDeadline = Date.now() + 5_000;
+        let openScrollback = "";
+        while (Date.now() < releaseDeadline) {
+          openScrollback = await session.captureFullScrollback();
+          if (openScrollback.includes(answerLines[0]!)) break;
+          await Bun.sleep(25);
+        }
+        expect(openScrollback).toContain(answerLines[0]!);
+      } finally {
+        releaseResponse();
+      }
+
+      await session.waitForText("__FX_EXIT_0__", TIMEOUT);
+      const finalScrollback = await session.captureFullScrollback();
+      for (const line of answerLines) {
+        expect(finalScrollback.split(line)).toHaveLength(2);
+      }
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "TTY wrapped output stays ordered and appears exactly once",
+    async () => {
+      const root = createRoot();
+      const answerLines = Array.from(
+        { length: 7 },
+        (_, index) =>
+          `WRAPPED_LINE_${String(index + 1).padStart(2, "0")} ${"x".repeat(190)}`,
+      );
+      const gateway = startFakeGateway([
+        () => fakeGatewayStreamingText(answerLines, 3),
+      ]);
+      gateways.push(gateway);
+      const stderrPath = join(root.root, "stderr.log");
+      writeFileSync(stderrPath, "");
+
+      const session = await TmuxSession.create({
+        cmd: terminalCommand([
+          "ask",
+          "--no-save",
+          "Render every wrapped answer line.",
+        ]),
+        cwd: root.workspace,
+        env: gatewayEnv(root.home, gateway),
+        width: 100,
+        height: 20,
+        minimumHistoryLines: 100,
+        remainOnExit: true,
+        stderrPath,
+      });
+      sessions.push(session);
+
+      await session.waitForText(/__FX_EXIT_[0-9]+__/, TIMEOUT);
+      const scrollback = await session.captureFullScrollback();
+      expect(scrollback).toContain("__FX_EXIT_0__");
+      let previousIndex = -1;
+      for (const line of answerLines) {
+        const marker = line.slice(0, "WRAPPED_LINE_00".length);
+        const index = scrollback.indexOf(marker);
+        expect(index, marker).toBeGreaterThan(previousIndex);
+        expect(scrollback.split(marker)).toHaveLength(2);
         previousIndex = index;
       }
       expect(readFileSync(stderrPath, "utf8")).toBe("");

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -15,6 +16,7 @@ import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
   fakeGatewayPermissionDecision,
+  fakeGatewaySse,
   fakeGatewaySerializedToolCall,
   fakeGatewayToolCall,
   startFakeGateway,
@@ -279,6 +281,64 @@ describe("fx ask presentation", () => {
       expect(pane).toContain("const answer: u8 = 42;");
       expect(escaped).not.toMatch(/\x1b\[[0-9;]*m/);
       expect(escaped).not.toContain("\x1b]8;");
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "TTY output taller than the pane survives in native scrollback",
+    async () => {
+      const root = createRoot();
+      const answerLines = Array.from(
+        { length: 60 },
+        (_, index) => `ANSWER_LINE_${String(index + 1).padStart(2, "0")}`,
+      );
+      const gateway = startFakeGateway([
+        fakeGatewaySse([
+          ...answerLines.map((line) => ({
+            type: "text-delta",
+            id: "answer_1",
+            delta: `${line}\n`,
+          })),
+          {
+            type: "finish",
+            finishReason: { unified: "stop", raw: "stop" },
+            usage: {
+              inputTokens: { total: 3 },
+              outputTokens: { total: 60 },
+            },
+          },
+        ]),
+      ]);
+      gateways.push(gateway);
+      const stderrPath = join(root.root, "stderr.log");
+      writeFileSync(stderrPath, "");
+
+      const session = await TmuxSession.create({
+        cmd: terminalCommand([
+          "ask",
+          "--no-save",
+          "Render every answer line.",
+        ]),
+        cwd: root.workspace,
+        env: gatewayEnv(root.home, gateway),
+        width: 80,
+        height: 12,
+        minimumHistoryLines: 200,
+        remainOnExit: true,
+        stderrPath,
+      });
+      sessions.push(session);
+
+      await session.waitForText("__FX_EXIT_0__", TIMEOUT);
+      const scrollback = await session.captureFullScrollback();
+      let previousIndex = -1;
+      for (const line of answerLines) {
+        const index = scrollback.indexOf(line);
+        expect(index, line).toBeGreaterThan(previousIndex);
+        previousIndex = index;
+      }
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
     TIMEOUT,
   );

--- a/tests/e2e/render-lab/analyzer.ts
+++ b/tests/e2e/render-lab/analyzer.ts
@@ -10,6 +10,8 @@ import type {
 export const ACTIVE_TOOL_MARKER = "Running sleep 1; i=1";
 export const TERMINAL_TOOL_MARKER = "Ran sleep 1; i=1";
 const ACTIVE_TOOL_FINAL_MARKER = "RENDER_LAB_LOCAL_GATEWAY_OK";
+const OBSERVABILITY_PERMISSION_PROMPT = "Would you like to run the following command?";
+const OBSERVABILITY_PERMISSION_REVIEW = "Permission needed";
 
 export function commandMoreCount(text: string): number | null {
   const match = text.match(/│ … (\d+) (?:(?:line|lines) more \(ctrl(?:\+| )o to view\)|more \(ctrl(?:\+| )o\)|more)/);
@@ -76,6 +78,7 @@ export function analyzeRun(manifest: RenderLabManifest) {
 
     assertActiveToolPlacementScenario(failures, frame, manifest);
     assertUserCardResizeScenario(failures, frame, manifest);
+    assertTuiObservabilityFrame(failures, frame, manifest);
 
     if (countLogoBlocks(frame.grid, logoRows) > 1) {
       push(failures, "single-active-logo", frame, "more than one active Fx logo block is visible");
@@ -173,6 +176,7 @@ export function analyzeRun(manifest: RenderLabManifest) {
 
   const trace = readOptional(manifest.traceLogPath);
   assertActiveToolScenarioSequence(failures, frames, manifest);
+  assertTuiObservabilitySequence(failures, frames, manifest);
   const finalFrame = frames.find((frame) => frame.index === manifest.finalFrameIndex) ?? frames.at(-1);
   if (finalFrame) {
     const clearedShellMarkers = new Set(manifest.markers.clearedShell ?? []);
@@ -212,7 +216,12 @@ export function analyzeRun(manifest: RenderLabManifest) {
     if (traceFrame && footerCleanCount > 1500) {
       push(failures, "footer-clean-spam", traceFrame, `trace contains ${footerCleanCount} footer clean lines`);
     }
-    if (traceFrame && repaintCount > 500 && manifest.scenario !== "active-tool-placement") {
+    if (
+      traceFrame &&
+      repaintCount > 500 &&
+      manifest.scenario !== "active-tool-placement" &&
+      manifest.scenario !== "tui-observability-gauntlet"
+    ) {
       push(failures, "repaint-spam", traceFrame, `trace contains ${repaintCount} repaint/render lines`);
     }
     if (
@@ -227,12 +236,16 @@ export function analyzeRun(manifest: RenderLabManifest) {
     assertStartupOverflowTrace(failures, traceFrame, manifest, trace);
     assertStartupOverflowTape(failures, traceFrame, manifest);
   }
+  if (traceFrame && manifest.scenario === "tui-observability-gauntlet") {
+    assertTuiObservabilityTape(failures, traceFrame, manifest);
+  }
   if (
     traceFrame &&
     (
       isStartupOverflowScenario(manifest.scenario) ||
       manifest.scenario === "user-card-resize-replay-scrollback" ||
-      manifest.scenario === "active-tool-placement"
+      manifest.scenario === "active-tool-placement" ||
+      manifest.scenario === "tui-observability-gauntlet"
     )
   ) {
     const stderr = readOptional(join(manifest.artifactDir, "stderr.log"));
@@ -785,6 +798,209 @@ function assertUserCardResizeScenario(
   }
 }
 
+function assertTuiObservabilityFrame(
+  failures: RenderLabFailure[],
+  frame: RenderLabFrame,
+  manifest: RenderLabManifest,
+): void {
+  if (manifest.scenario !== "tui-observability-gauntlet") return;
+
+  const grid = frame.grid.join("\n");
+  if (
+    frame.event === "observability-permission-inline" ||
+    frame.event === "observability-permission-restored"
+  ) {
+    assertObservabilityCount(
+      failures,
+      frame,
+      grid,
+      OBSERVABILITY_PERMISSION_PROMPT,
+      1,
+      "observability-permission-singleton",
+      "active grid",
+    );
+  }
+  if (frame.event === "observability-permission-review") {
+    assertObservabilityCount(
+      failures,
+      frame,
+      grid,
+      OBSERVABILITY_PERMISSION_REVIEW,
+      1,
+      "observability-permission-review-singleton",
+      "active grid",
+    );
+  }
+
+  if (
+    frame.event === "observability-permission-inline" ||
+    frame.event === "observability-permission-restored" ||
+    frame.event === "observability-tool-completed"
+  ) {
+    assertObservabilityScrollbackMarkers(
+      failures,
+      frame,
+      [
+        ...manifest.markers.submitted,
+        "OBSERVABILITY_TRANSCRIPT_HEAD",
+        "OBSERVABILITY_TRANSCRIPT_TAIL",
+        ...(frame.event === "observability-tool-completed"
+          ? ["OBSERVABILITY_TOOL_OUTPUT"]
+          : []),
+      ],
+    );
+  }
+
+  if (frame.event.startsWith("observability-final-")) {
+    if (
+      grid.includes(OBSERVABILITY_PERMISSION_PROMPT) ||
+      grid.includes(OBSERVABILITY_PERMISSION_REVIEW)
+    ) {
+      push(
+        failures,
+        "observability-permission-dismissed",
+        frame,
+        "permission UI remained visible after approval",
+      );
+    }
+    const orderedMarkers = [
+      ...manifest.markers.submitted,
+      "OBSERVABILITY_TRANSCRIPT_HEAD",
+      "OBSERVABILITY_TRANSCRIPT_TAIL",
+      "OBSERVABILITY_TOOL_OUTPUT",
+      "OBSERVABILITY_FINAL_RESPONSE",
+    ];
+    assertObservabilityScrollbackMarkers(failures, frame, orderedMarkers);
+    assertObservabilityMarkerOrder(failures, frame, orderedMarkers);
+  }
+}
+
+function assertObservabilityScrollbackMarkers(
+  failures: RenderLabFailure[],
+  frame: RenderLabFrame,
+  markers: string[],
+): void {
+  for (const marker of markers) {
+    assertObservabilityCount(
+      failures,
+      frame,
+      frame.scrollback,
+      marker,
+      1,
+      "observability-scrollback-once",
+      "full scrollback",
+    );
+  }
+}
+
+function assertObservabilityMarkerOrder(
+  failures: RenderLabFailure[],
+  frame: RenderLabFrame,
+  markers: string[],
+): void {
+  let previous = -1;
+  for (const marker of markers) {
+    const index = frame.scrollback.indexOf(marker);
+    if (index < 0) return;
+    if (index <= previous) {
+      push(
+        failures,
+        "observability-scrollback-order",
+        frame,
+        `marker ${JSON.stringify(marker)} is out of transcript order`,
+      );
+      return;
+    }
+    previous = index;
+  }
+}
+
+function assertObservabilityCount(
+  failures: RenderLabFailure[],
+  frame: RenderLabFrame,
+  text: string,
+  marker: string,
+  expected: number,
+  invariant: string,
+  source: string,
+): void {
+  const actual = countOccurrences(text, marker);
+  if (actual === expected) return;
+  push(
+    failures,
+    invariant,
+    frame,
+    `expected ${JSON.stringify(marker)} ${expected} time(s) in ${source}, found ${actual}`,
+  );
+}
+
+function assertTuiObservabilitySequence(
+  failures: RenderLabFailure[],
+  frames: RenderLabFrame[],
+  manifest: RenderLabManifest,
+): void {
+  if (manifest.scenario !== "tui-observability-gauntlet") return;
+  const required = [
+    "observability-permission-inline",
+    "observability-permission-review",
+    "observability-permission-restored",
+    "observability-tool-completed",
+    "observability-final-wide",
+    "observability-final-narrow",
+    "observability-final-restored",
+  ];
+  const anchor = frames.at(-1);
+  if (!anchor) return;
+  const indices = required.map((event) =>
+    frames.findIndex((frame) => frame.event === event)
+  );
+  for (const [offset, event] of required.entries()) {
+    if (indices[offset] < 0) {
+      push(failures, "observability-stage-missing", anchor, `missing ${event}`);
+    }
+  }
+  const present = indices.filter((index) => index >= 0);
+  if (present.some((index, offset) => offset > 0 && index <= present[offset - 1]!)) {
+    push(
+      failures,
+      "observability-stage-order",
+      anchor,
+      `stages are out of order: ${required.join(", ")}`,
+    );
+  }
+}
+
+function assertTuiObservabilityTape(
+  failures: RenderLabFailure[],
+  frame: RenderLabFrame,
+  manifest: RenderLabManifest,
+): void {
+  let tape: string;
+  try {
+    tape = Buffer.concat(
+      stdoutFrames(manifest.tapePath).map((entry) => entry.payload),
+    ).toString("binary");
+  } catch (error) {
+    push(
+      failures,
+      "observability-tape-parse",
+      frame,
+      error instanceof Error ? error.message : String(error),
+    );
+    return;
+  }
+  const enters = countOccurrences(tape, "\x1b[?1049h");
+  const exits = countOccurrences(tape, "\x1b[?1049l");
+  if (enters < 1 || exits < 1 || enters !== exits) {
+    push(
+      failures,
+      "observability-alternate-screen-lifecycle",
+      frame,
+      `expected balanced alternate-screen ownership, found ${enters} enter(s) and ${exits} exit(s)`,
+    );
+  }
+}
+
 function assertMarkerCount(
   failures: RenderLabFailure[],
   frame: RenderLabFrame,
@@ -842,6 +1058,7 @@ function expectsFxChrome(
   if (
     frame.event.startsWith("shell-") ||
     frame.event.startsWith("native-shell-") ||
+    frame.event.startsWith("observability-permission-") ||
     frame.event.includes("fx-quit-requested") ||
     frame.event.includes("post-quit-shell-prompt")
   ) {

--- a/tests/e2e/render-lab/index.ts
+++ b/tests/e2e/render-lab/index.ts
@@ -78,6 +78,7 @@ type FxLaunchOptions = {
   gatewayApiKey?: string;
   gatewayChatUrl?: string;
   gatewayModelsUrl?: string;
+  permissionMode?: "ask" | "auto" | "yolo";
 };
 
 type LocalGatewayFixture = {
@@ -121,7 +122,14 @@ const STARTUP_SCROLLBACK_DISABLED_OVERFLOW = "startup-scrollback-disabled-overfl
 const STARTUP_SCROLLBACK_ENABLED_OVERFLOW = "startup-scrollback-enabled-overflow";
 const ACTIVE_TOOL_PLACEMENT = "active-tool-placement";
 const USER_CARD_RESIZE_REPLAY_SCROLLBACK = "user-card-resize-replay-scrollback";
+const TUI_OBSERVABILITY_GAUNTLET = "tui-observability-gauntlet";
 const LOCAL_GATEWAY_COMPLETION = "RENDER_LAB_LOCAL_GATEWAY_OK";
+const OBSERVABILITY_TRANSCRIPT_HEAD = "OBSERVABILITY_TRANSCRIPT_HEAD";
+const OBSERVABILITY_TRANSCRIPT_TAIL = "OBSERVABILITY_TRANSCRIPT_TAIL";
+const OBSERVABILITY_FINAL_MARKER = "OBSERVABILITY_FINAL_RESPONSE";
+const OBSERVABILITY_PERMISSION_PROMPT = "Would you like to run the following command?";
+const OBSERVABILITY_PERMISSION_REVIEW = "Permission needed";
+const OBSERVABILITY_TOOL_COMMAND = "touch render-lab-observability-approved.txt";
 const LOCAL_GATEWAY_CHAT_PATH = "/v3/ai/language-model";
 const LOCAL_GATEWAY_MODELS_PATH = "/v1/models";
 const DEFAULT_BENCH_SIZES: RenderLabTerminalSize[] = [
@@ -133,7 +141,7 @@ const BENCHMARK_COMBINED_P95_LIMIT_MS = 8;
 const BENCHMARK_P95_MIN_RUNS = 20;
 const PROMPT_TEXT = "FX_RENDER_LAB%";
 const TRACE_SCOPES =
-  "render,paint,resize,scroll,footer.clean,input,frame_layout,frame_plan,frame_diff,frame_commit,frame_owner_violation,frame_schedule,ui_activity";
+  "render,paint,resize,scroll,footer.clean,input,permission,frame_layout,frame_plan,frame_diff,frame_commit,frame_owner_violation,frame_schedule,ui_activity";
 const QUIESCENCE_INTERVAL_MS = 300;
 const ACTIVE_TOOL_RESIZE_CAPTURE_TIMEOUT_MS = 30_000;
 
@@ -174,6 +182,8 @@ export async function runRenderLab(rawOptions: Partial<Options> = {}): Promise<R
       results.push(await runActiveToolPlacement(options.out, i + 1));
     } else if (options.scenario === USER_CARD_RESIZE_REPLAY_SCROLLBACK) {
       results.push(await runUserCardResizeReplayScrollback(options.out, i + 1));
+    } else if (options.scenario === TUI_OBSERVABILITY_GAUNTLET) {
+      results.push(await runTuiObservabilityGauntlet(options.out, i + 1));
     } else if (
       options.scenario === STARTUP_SCROLLBACK_DISABLED_OVERFLOW ||
       options.scenario === STARTUP_SCROLLBACK_ENABLED_OVERFLOW
@@ -194,6 +204,7 @@ export async function runRenderLab(rawOptions: Partial<Options> = {}): Promise<R
           BUFFER_SYSTEM_FRAME_BENCH,
           ACTIVE_TOOL_PLACEMENT,
           USER_CARD_RESIZE_REPLAY_SCROLLBACK,
+          TUI_OBSERVABILITY_GAUNTLET,
           STARTUP_SCROLLBACK_DISABLED_OVERFLOW,
           STARTUP_SCROLLBACK_ENABLED_OVERFLOW,
           ...nativeScenarioNames(),
@@ -756,6 +767,216 @@ async function runUserCardResizeReplayScrollback(
     gateway.releaseResponse();
     gateway.stop();
     writeFileSync(join(artifactDir, "gateway-requests.log"), `${gateway.requests.join("\n")}\n`);
+    rmSync(fixture.root, { recursive: true, force: true });
+  }
+}
+
+async function runTuiObservabilityGauntlet(
+  outRoot: string,
+  runNumber: number,
+): Promise<RenderLabManifest> {
+  preflight();
+
+  const scenario = TUI_OBSERVABILITY_GAUNTLET;
+  const startedAt = new Date();
+  const markerSuffix = randomBytes(4).toString("hex");
+  const runId = `${scenario}-${timestampForPath(startedAt)}-${runNumber}-${markerSuffix}`;
+  const artifactDir = join(outRoot, `run-${timestampForPath(startedAt)}-${runNumber}`);
+  mkdirSync(join(artifactDir, "replay", "frames"), { recursive: true });
+
+  const binarySha256 = sha256(FX_BIN);
+  const shellMarker = `OBSERVABILITY_SHELL_HISTORY_${markerSuffix}`;
+  const promptHead = `OBSERVABILITY_PROMPT_HEAD_${markerSuffix}`;
+  const promptTail = `OBSERVABILITY_PROMPT_TAIL_${markerSuffix}`;
+  const prompt = [
+    promptHead,
+    "exercise transcript, permission UI, tmux resize, scrollback, and final composer recovery",
+    promptTail,
+  ].join(" ");
+  const manifest: RenderLabManifest = {
+    version: 1,
+    scenario,
+    runId,
+    startedAt: startedAt.toISOString(),
+    completedAt: null,
+    repoRoot: REPO_ROOT,
+    artifactDir,
+    binaryPath: FX_BIN,
+    binarySha256,
+    traceLogPath: join(artifactDir, "trace.log"),
+    tapePath: join(artifactDir, "render.fxtape"),
+    finalGridPath: join(artifactDir, "final-grid.txt"),
+    replaySummaryPath: join(artifactDir, "replay-summary.json"),
+    runtimeEvidencePath: join(artifactDir, "runtime-evidence.json"),
+    reportPath: join(artifactDir, "report.html"),
+    failurePath: join(artifactDir, "failure.md"),
+    finalFrameIndex: null,
+    evidence: runtimeEvidenceDefaults(),
+    markers: {
+      shell: [shellMarker],
+      clearedShell: [shellMarker],
+      submitted: [promptHead, promptTail],
+      history: [
+        "Run /help for commands",
+        OBSERVABILITY_TRANSCRIPT_HEAD,
+        OBSERVABILITY_TRANSCRIPT_TAIL,
+        "OBSERVABILITY_TOOL_OUTPUT",
+        OBSERVABILITY_FINAL_MARKER,
+      ],
+    },
+    frames: [],
+    failures: [],
+  };
+  writeManifest(manifest);
+  writeReproScript(manifest);
+
+  const fixture = createFixture(runId);
+  const gateway = startObservabilityGatewayFixture(promptTail);
+  let session: RenderLabTmux | null = null;
+  try {
+    session = await RenderLabTmux.create({
+      fixture,
+      manifest,
+      width: 120,
+      height: 36,
+    });
+    const context = { fixture, manifest, binarySha256 };
+
+    await runShellCommand(
+      context,
+      session,
+      `printf '%s\\n' ${shQuote(shellMarker)}`,
+      shellMarker,
+      "observability-shell-seed",
+    );
+
+    await launchFx(context, session, "observability", {
+      stderrPath: join(artifactDir, "stderr.log"),
+      gatewayApiKey: "render-lab-local-gateway-key",
+      gatewayChatUrl: gateway.chatUrl,
+      gatewayModelsUrl: gateway.modelsUrl,
+      permissionMode: "ask",
+    });
+    await session.sendText(prompt);
+    await waitForLocalGatewayRequest(
+      gateway.requests,
+      `POST ${LOCAL_GATEWAY_CHAT_PATH}`,
+      10_000,
+    );
+    await session.waitForPane(
+      (pane) =>
+        pane.includes(OBSERVABILITY_PERMISSION_PROMPT) &&
+        pane.includes(OBSERVABILITY_TRANSCRIPT_TAIL),
+      15_000,
+    );
+    await capture(context, session, "observability-permission-inline");
+
+    await session.resize(40, 13);
+    await session.waitForPane(
+      (pane) => pane.includes(OBSERVABILITY_PERMISSION_REVIEW),
+      10_000,
+    );
+    await capture(context, session, "observability-permission-review");
+
+    await session.resize(120, 36);
+    await session.waitForPane(
+      (pane) => pane.includes(OBSERVABILITY_PERMISSION_PROMPT),
+      10_000,
+    );
+    await capture(context, session, "observability-permission-restored");
+
+    await session.sendLiteral("1");
+    await waitForLocalGatewayRequestCount(
+      gateway.requests,
+      `POST ${LOCAL_GATEWAY_CHAT_PATH}`,
+      2,
+      20_000,
+    );
+    await session.waitForPane(
+      (pane) => pane.includes("OBSERVABILITY_TOOL_OUTPUT"),
+      10_000,
+    );
+    await capture(context, session, "observability-tool-completed");
+    if (!existsSync(join(fixture.work, "render-lab-observability-approved.txt"))) {
+      throw new Error("approved observability command did not execute");
+    }
+
+    gateway.releaseResponse();
+    await session.waitForPane(
+      (pane) => pane.includes(OBSERVABILITY_FINAL_MARKER),
+      15_000,
+    );
+    await capture(context, session, "observability-final-wide");
+
+    await session.resize(76, 24);
+    await session.waitForPane(
+      (pane) => pane.includes(OBSERVABILITY_FINAL_MARKER),
+      10_000,
+    );
+    await capture(context, session, "observability-final-narrow");
+
+    await session.resize(132, 42);
+    await session.waitForPane(
+      (pane) => pane.includes(OBSERVABILITY_FINAL_MARKER),
+      10_000,
+    );
+    const finalFrame = await capture(
+      context,
+      session,
+      "observability-final-restored",
+    );
+    manifest.finalFrameIndex = finalFrame.index;
+    await recordQuiescentInterval(
+      manifest,
+      "observability-final-quiescent",
+      QUIESCENCE_INTERVAL_MS,
+    );
+
+    await quitFx(context, session, "observability-cleanup");
+    await session.sendText("exit");
+    await session.waitForEnd(10_000);
+    session = null;
+
+    const postRequests = gateway.requests.filter(
+      (request) => request === `POST ${LOCAL_GATEWAY_CHAT_PATH}`,
+    );
+    if (postRequests.length !== 2) {
+      throw new Error(`expected two gateway chat requests, found ${postRequests.length}`);
+    }
+
+    await writeReplaySummary(manifest);
+    writeRuntimeEvidence(manifest);
+    const analysis = analyzeRun(manifest);
+    manifest.failures = analysis.failures;
+    manifest.completedAt = new Date().toISOString();
+    writeManifest(manifest);
+    writeFailureFile(manifest);
+    writeReport(manifest);
+    return manifest;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const failure: RenderLabFailure = {
+      invariant: "scenario-error",
+      frameIndex: manifest.frames.at(-1)?.index ?? 0,
+      event: manifest.frames.at(-1)?.event ?? "startup",
+      message,
+    };
+    manifest.failures = [...manifest.failures, failure];
+    manifest.completedAt = new Date().toISOString();
+    writeManifest(manifest);
+    writeFailureFile(manifest);
+    try {
+      writeReport(manifest);
+    } catch {}
+    throw error;
+  } finally {
+    if (session) await session.kill();
+    gateway.releaseResponse();
+    gateway.stop();
+    writeFileSync(
+      join(artifactDir, "gateway-requests.log"),
+      `${gateway.requests.join("\n")}\n`,
+    );
     rmSync(fixture.root, { recursive: true, force: true });
   }
 }
@@ -1418,6 +1639,7 @@ async function launchFx(
     options.gatewayApiKey ? `AI_GATEWAY_API_KEY=${shQuote(options.gatewayApiKey)}` : null,
     options.gatewayChatUrl ? `FX_E2E_GATEWAY_CHAT_URL=${shQuote(options.gatewayChatUrl)}` : null,
     options.gatewayModelsUrl ? `FX_E2E_GATEWAY_MODELS_URL=${shQuote(options.gatewayModelsUrl)}` : null,
+    options.permissionMode ? `FX_PERMISSION_MODE=${shQuote(options.permissionMode)}` : null,
   ].filter((entry): entry is string => entry !== null).join(" ");
   const environmentPrefix = environment.length > 0 ? `${environment} ` : "";
   const stderrRedirect = options.stderrPath ? ` 2>${shQuote(options.stderrPath)}` : "";
@@ -1564,6 +1786,117 @@ function startActiveToolGatewayFixture(): LocalGatewayFixture {
       releaseResponseGate();
     },
     stop() { server.stop(true); },
+  };
+}
+
+function startObservabilityGatewayFixture(
+  expectedPromptTail: string,
+): LocalGatewayFixture {
+  const requests: string[] = [];
+  let chatRequestCount = 0;
+  let responseReleased = false;
+  let releaseResponseGate!: () => void;
+  const responseGate = new Promise<void>((resolve) => {
+    releaseResponseGate = resolve;
+  });
+  const transcript = [
+    OBSERVABILITY_TRANSCRIPT_HEAD,
+    ...Array.from(
+      { length: 28 },
+      (_, index) =>
+        `OBSERVABILITY_TRANSCRIPT_LINE_${String(index + 1).padStart(2, "0")}`,
+    ),
+    OBSERVABILITY_TRANSCRIPT_TAIL,
+  ].join("\n");
+  const command =
+    `printf '\\117\\102\\123\\105\\122\\126\\101\\102\\111\\114\\111\\124\\131\\137\\124\\117\\117\\114\\137\\117\\125\\124\\120\\125\\124\\n'; ${OBSERVABILITY_TOOL_COMMAND}`;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    idleTimeout: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (request.method === "GET" && url.pathname === LOCAL_GATEWAY_MODELS_PATH) {
+        requests.push(`${request.method} ${url.pathname}`);
+        return Response.json({
+          data: [
+            {
+              id: "anthropic/claude-opus-4.7",
+              type: "language",
+              released: 1,
+              tags: ["tool-use"],
+            },
+          ],
+        });
+      }
+      if (request.method === "POST" && url.pathname === LOCAL_GATEWAY_CHAT_PATH) {
+        const body = await request.text();
+        requests.push(`${request.method} ${url.pathname}`);
+        chatRequestCount += 1;
+        if (chatRequestCount === 1 && !body.includes(expectedPromptTail)) {
+          return new Response("prompt tail missing", { status: 422 });
+        }
+        if (chatRequestCount === 2) await responseGate;
+        const events = chatRequestCount === 1
+          ? [
+              {
+                type: "text-delta",
+                id: "observability-transcript",
+                delta: transcript,
+              },
+              {
+                type: "tool-input-start",
+                id: "observability-tool-1",
+                toolName: "run_command",
+              },
+              {
+                type: "tool-call",
+                toolCallId: "observability-tool-1",
+                toolName: "run_command",
+                input: { command },
+              },
+              {
+                type: "finish",
+                finishReason: { unified: "tool-calls", raw: "tool-calls" },
+                usage: {
+                  inputTokens: { total: 1 },
+                  outputTokens: { total: 1 },
+                },
+              },
+            ]
+          : [
+              {
+                type: "text-delta",
+                id: "observability-final",
+                delta: OBSERVABILITY_FINAL_MARKER,
+              },
+              {
+                type: "finish",
+                finishReason: { unified: "stop", raw: "stop" },
+                usage: {
+                  inputTokens: { total: 1 },
+                  outputTokens: { total: 1 },
+                },
+              },
+            ];
+        return gatewaySse(events);
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const baseUrl = `http://127.0.0.1:${server.port}`;
+  return {
+    chatUrl: `${baseUrl}${LOCAL_GATEWAY_CHAT_PATH}`,
+    modelsUrl: `${baseUrl}${LOCAL_GATEWAY_MODELS_PATH}`,
+    requests,
+    releaseResponse() {
+      if (responseReleased) return;
+      responseReleased = true;
+      releaseResponseGate();
+    },
+    stop() {
+      server.stop(true);
+    },
   };
 }
 
@@ -2158,6 +2491,9 @@ function printHelp(): void {
       "user-card scenarios:",
       `  ${USER_CARD_RESIZE_REPLAY_SCROLLBACK}`,
       "",
+      "observability scenarios:",
+      `  ${TUI_OBSERVABILITY_GAUNTLET}`,
+      "",
       ...nativeScenarioHelpLines(),
     ].join("\n"),
   );
@@ -2181,6 +2517,9 @@ function printScenarioList(): void {
       "",
       "user-card scenarios:",
       `  ${USER_CARD_RESIZE_REPLAY_SCROLLBACK}`,
+      "",
+      "observability scenarios:",
+      `  ${TUI_OBSERVABILITY_GAUNTLET}`,
       "",
       ...nativeScenarioHelpLines(),
     ].join("\n"),

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -838,16 +838,24 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
     });
     await session.waitForComposer(TIMEOUT);
     await session.sendText("Build the prepared mixed history under sustained load.");
-    const history = await waitForScrollback(
+    await waitForScrollback(
       session,
       HISTORY_DONE,
       config.historyTimeoutMs ?? TIMEOUT * 4,
+    );
+    // Held transcript rows settle into native scrollback on the frames
+    // right after the answer completes; wait for the settled markers
+    // instead of asserting one racy snapshot.
+    await waitForScrollback(session, compactToolMarker(0), TIMEOUT);
+    const history = await waitForScrollback(
+      session,
+      compactToolMarker(totalTools - 1),
+      TIMEOUT,
     );
     expect(countOccurrences(history, HISTORY_DONE)).toBe(1);
     expect(history).toContain(firstChatMarker(config));
     expect(history).toContain(lastChatMarker(config));
     expect(history).toContain(compactToolMarker(0));
-    expect(history).toContain(compactToolMarker(totalTools - 1));
 
     await session.sendText("Run the prepared live command while I inspect the transcript.");
     await session.waitForText(LIVE_START, TIMEOUT);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -7246,3 +7246,629 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
     TIMEOUT,
   );
 });
+
+describe.skipIf(!tmuxAvailable())("transcript scrollback release", () => {
+  const SB_TIMEOUT = 60_000;
+  let root: string | undefined;
+  let session: TmuxSession | undefined;
+  let gateway: { stop: () => void } | undefined;
+
+  afterEach(async () => {
+    await session?.kill();
+    session = undefined;
+    gateway?.stop();
+    gateway = undefined;
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  function sbSseEvent(event: object): string {
+    return `data: ${JSON.stringify(event)}\n\n`;
+  }
+
+  function sbTokenChunks(text: string, size: number): string[] {
+    const chunks: string[] = [];
+    for (let index = 0; index < text.length; index += size) {
+      chunks.push(text.slice(index, index + size));
+    }
+    return chunks;
+  }
+
+  function sbStreamedFinalText(lines: string[], delayMs: number) {
+    return () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            for (const line of lines) {
+              controller.enqueue(
+                encoder.encode(
+                  sbSseEvent({
+                    type: "text-delta",
+                    id: "answer_1",
+                    delta: `${line}\n`,
+                  }),
+                ),
+              );
+              await Bun.sleep(delayMs);
+            }
+            controller.enqueue(
+              encoder.encode(
+                sbSseEvent({
+                  type: "finish",
+                  finishReason: { unified: "stop", raw: "stop" },
+                  usage: {
+                    inputTokens: { total: 3 },
+                    outputTokens: { total: 5 },
+                  },
+                }),
+              ),
+            );
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+  }
+
+  // Models an ordinary model/network wait: the transcript sits byte-stable
+  // for several render ticks while this response is already pending. Release
+  // must not treat that quiet window as finality.
+  function sbHeldSerializedToolCall(
+    id: string,
+    name: string,
+    input: string,
+    holdMs: number,
+  ) {
+    return () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            await Bun.sleep(holdMs);
+            controller.enqueue(
+              encoder.encode(
+                sbSseEvent({
+                  type: "tool-call",
+                  toolCallId: id,
+                  toolName: name,
+                  input,
+                }),
+              ),
+            );
+            controller.enqueue(
+              encoder.encode(
+                sbSseEvent({
+                  type: "finish",
+                  finishReason: { unified: "tool-calls", raw: "tool-calls" },
+                }),
+              ),
+            );
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+  }
+
+  function sbToolCallBatch(
+    calls: Array<{ id: string; name: string; input: object }>,
+    assistantText?: string,
+    reasoning?: { chunks: string[]; delayMs: number; id: string },
+  ) {
+    const finishEvents = (): object[] => {
+      const events: object[] = [];
+      if (assistantText) {
+        events.push({
+          type: "text-delta",
+          id: "answer_1",
+          delta: assistantText,
+        });
+      }
+      for (const call of calls) {
+        events.push({
+          type: "tool-call",
+          toolCallId: call.id,
+          toolName: call.name,
+          input: call.input,
+        });
+      }
+      events.push({
+        type: "finish",
+        finishReason: { unified: "tool-calls", raw: "tool-calls" },
+      });
+      return events;
+    };
+    if (!reasoning) {
+      return new Response(
+        `${finishEvents()
+          .map((event) => sbSseEvent(event))
+          .join("")}data: [DONE]\n\n`,
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    }
+    return () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            controller.enqueue(
+              encoder.encode(
+                sbSseEvent({ type: "reasoning-start", id: reasoning.id }),
+              ),
+            );
+            for (const chunk of reasoning.chunks) {
+              controller.enqueue(
+                encoder.encode(
+                  sbSseEvent({
+                    type: "reasoning-delta",
+                    id: reasoning.id,
+                    delta: chunk,
+                  }),
+                ),
+              );
+              await Bun.sleep(reasoning.delayMs);
+            }
+            controller.enqueue(
+              encoder.encode(
+                sbSseEvent({ type: "reasoning-end", id: reasoning.id }),
+              ),
+            );
+            for (const event of finishEvents()) {
+              controller.enqueue(encoder.encode(sbSseEvent(event)));
+            }
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+  }
+
+  function sbReasoningThenStreamedFinalText(
+    reasoningChunks: string[],
+    chunks: string[],
+    delayMs: number,
+  ) {
+    return () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          async start(controller) {
+            const encoder = new TextEncoder();
+            controller.enqueue(
+              encoder.encode(
+                sbSseEvent({ type: "reasoning-start", id: "r-final" }),
+              ),
+            );
+            for (const chunk of reasoningChunks) {
+              controller.enqueue(
+                encoder.encode(
+                  sbSseEvent({
+                    type: "reasoning-delta",
+                    id: "r-final",
+                    delta: chunk,
+                  }),
+                ),
+              );
+              await Bun.sleep(delayMs);
+            }
+            controller.enqueue(
+              encoder.encode(
+                sbSseEvent({ type: "reasoning-end", id: "r-final" }),
+              ),
+            );
+            controller.enqueue(
+              encoder.encode(sbSseEvent({ type: "text-start", id: "answer_1" })),
+            );
+            for (const chunk of chunks) {
+              controller.enqueue(
+                encoder.encode(
+                  sbSseEvent({
+                    type: "text-delta",
+                    id: "answer_1",
+                    delta: chunk,
+                  }),
+                ),
+              );
+              await Bun.sleep(delayMs);
+            }
+            controller.enqueue(
+              encoder.encode(sbSseEvent({ type: "text-end", id: "answer_1" })),
+            );
+            controller.enqueue(
+              encoder.encode(
+                sbSseEvent({
+                  type: "finish",
+                  finishReason: { unified: "stop", raw: "stop" },
+                  usage: {
+                    inputTokens: { total: 3 },
+                    outputTokens: { total: 5 },
+                  },
+                }),
+              ),
+            );
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      );
+  }
+
+  function sbSettings(): string {
+    return JSON.stringify({
+      sandbox: "none",
+      permission_mode: "yolo",
+      permission: {},
+      startup_scrollback: false,
+      input_appearance: "lines",
+      maxxing_mode: "minimal",
+      statusLine: { context: true },
+      yolo_acknowledged: true,
+    });
+  }
+
+  test(
+    "sequential tool group and streamed markdown keep native scrollback final",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-sb-release-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const tapePath = join(root, "sb-release.fxtape");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(join(workspace, "docs"), { recursive: true });
+      for (let index = 1; index <= 17; index += 1) {
+        writeFileSync(
+          join(workspace, "docs", `source-${String(index).padStart(2, "0")}.md`),
+          `source row ${index}\n`,
+        );
+      }
+      writeFileSync(join(home, ".fx", "settings.json"), sbSettings());
+      writeFileSync(stderrPath, "");
+
+      const codeALines = Array.from(
+        { length: 6 },
+        (_, index) => `CODE_A_LINE_${String(index + 1).padStart(2, "0")}();`,
+      );
+      const codeBLines = Array.from(
+        { length: 4 },
+        (_, index) => `CODE_B_LINE_${String(index + 1).padStart(2, "0")}();`,
+      );
+      const responseLines = [
+        "RESP_INTRO here is how the hook works today.",
+        "",
+        "1. RESP_ITEM_ONE the hook is mounted with:",
+        "",
+        "```ts",
+        ...codeALines,
+        "```",
+        "",
+        "2. RESP_ITEM_TWO its logical cache key is generated from only:",
+        "",
+        "```ts",
+        ...codeBLines,
+        "```",
+        "",
+        "RESP_TAIL that is the whole flow.",
+      ];
+
+      const readResponse = (index: number) => {
+        const input = JSON.stringify({
+          path: `docs/source-${String(index).padStart(2, "0")}.md`,
+        });
+        if (index === 15) {
+          return sbHeldSerializedToolCall(
+            `sb-read-${index}`,
+            "read_file",
+            input,
+            350,
+          );
+        }
+        return fakeGatewaySerializedToolCall(
+          `sb-read-${index}`,
+          "read_file",
+          input,
+        );
+      };
+      gateway = startFakeGateway([
+        fakeGatewaySerializedToolCall(
+          "sb-list",
+          "list_files",
+          JSON.stringify({ path: "docs" }),
+          "I'll inspect the SWR wiring end to end.",
+        ),
+        ...Array.from({ length: 17 }, (_, index) => readResponse(index + 1)),
+        sbStreamedFinalText(responseLines, 60),
+      ]);
+      const fakeGateway = gateway as ReturnType<typeof startFakeGateway>;
+
+      session = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: workspace,
+        width: 100,
+        height: 20,
+        minimumHistoryLines: 10_000,
+        stderrPath,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-sb-release-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_GATEWAY_BASE_URL: fakeGateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: fakeGateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: fakeGateway.chatUrl,
+          FX_MODEL: MODEL,
+          FX_RECORD: tapePath,
+          FX_RECORD_INPUT: "1",
+        },
+      });
+
+      await session.waitForComposer(SB_TIMEOUT);
+      await session.sendText("Explain the SWR hook wiring.");
+      await session.waitForText("RESP_TAIL", SB_TIMEOUT);
+      await session.waitForPane(hasEmptyComposer, SB_TIMEOUT);
+      await Bun.sleep(250);
+
+      const scrollback = await session.captureFullScrollback();
+
+      // The group header must survive as its final text exactly once; a
+      // frozen intermediate count would add another "tool call" line.
+      expect(countOccurrences(scrollback, "tool call")).toBe(1);
+      expect(scrollback).toContain("18 tool calls");
+      for (let index = 1; index <= 17; index += 1) {
+        expect(
+          countOccurrences(
+            scrollback,
+            `Read docs/source-${String(index).padStart(2, "0")}.md`,
+          ),
+        ).toBe(1);
+      }
+
+      const orderedMarkers = [
+        "RESP_INTRO",
+        "RESP_ITEM_ONE",
+        ...codeALines.map((line) => line.slice(0, line.length - 3)),
+        "RESP_ITEM_TWO",
+        ...codeBLines.map((line) => line.slice(0, line.length - 3)),
+        "RESP_TAIL",
+      ];
+      let previousIndex = -1;
+      for (const marker of orderedMarkers) {
+        expect(countOccurrences(scrollback, marker)).toBe(1);
+        const index = scrollback.indexOf(marker);
+        expect(index).toBeGreaterThan(previousIndex);
+        previousIndex = index;
+      }
+      const introIndex = scrollback.indexOf("RESP_INTRO");
+      const tailIndex = scrollback.indexOf("RESP_TAIL");
+      const responseRegion = scrollback.slice(introIndex, tailIndex);
+      expect(responseRegion).not.toContain("Read docs/source-");
+      expect(responseRegion).not.toMatch(/(?:Thinking \(|\(↑\d)/);
+      expect(existsSync(tapePath)).toBe(true);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    SB_TIMEOUT + 30_000,
+  );
+
+  test(
+    "parallel tool batches and token-streamed markdown keep native scrollback final",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-sb-batch-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const tapePath = join(root, "sb-batch.fxtape");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(join(workspace, "docs"), { recursive: true });
+      for (let index = 1; index <= 20; index += 1) {
+        writeFileSync(
+          join(workspace, "docs", `source-${String(index).padStart(2, "0")}.md`),
+          `alpha scoped row ${index}\n`.repeat(3),
+        );
+      }
+      writeFileSync(join(home, ".fx", "settings.json"), sbSettings());
+      writeFileSync(stderrPath, "");
+
+      const fillerLines = Array.from(
+        { length: 45 },
+        (_, index) =>
+          `FILLER_ROW_${String(index + 1).padStart(2, "0")} history line.`,
+      );
+      let readCounter = 0;
+      const readCall = () => {
+        readCounter += 1;
+        return {
+          id: `sb-read-${readCounter}`,
+          name: "read_file",
+          input: {
+            path: `docs/source-${String(readCounter).padStart(2, "0")}.md`,
+          },
+        };
+      };
+      let grepCounter = 0;
+      const grepCall = (pattern: string) => {
+        grepCounter += 1;
+        return {
+          id: `sb-grep-${grepCounter}`,
+          name: "grep_files",
+          input: { pattern, path: "docs", include: "*.md", mode: "matches" },
+        };
+      };
+      const responseLines = [
+        "RESP_INTRO teamData is cached client-side, but not by scope.",
+        "The path is:",
+        "",
+        "1. RESP_ITEM_ONE the dropdown calls:",
+        "",
+        "```ts",
+        "CODE_A_LINE_01(['scoped', 'team'], {}, {",
+        "CODE_A_LINE_02: true,",
+        "CODE_A_LINE_03: true,",
+        "})",
+        "```",
+        "",
+        "2. RESP_ITEM_TWO its logical cache key is generated from only:",
+        "",
+        "```ts",
+        'CODE_B_LINE_01 // ["team", {}]',
+        "```",
+        "",
+        "3. RESP_ITEM_THREE scoped data is stored in a singleton atom:",
+        "",
+        "```ts",
+        "CODE_C_LINE_01: atom(ASSERT_SWR_DATA)",
+        "```",
+        "",
+        "4. RESP_ITEM_FOUR revalidateNever disables all refresh paths:",
+        "",
+        "```ts",
+        "CODE_D_LINE_01: false",
+        "CODE_D_LINE_02: false",
+        "CODE_D_LINE_03: false",
+        "CODE_D_LINE_04: false",
+        "```",
+        "",
+        "RESP_TAIL that is why the previous atom value remains indefinitely.",
+      ];
+
+      gateway = startFakeGateway([
+        sbStreamedFinalText(fillerLines, 10),
+        sbToolCallBatch(
+          [
+            readCall(),
+            readCall(),
+            grepCall("useServerQuerySWR"),
+            grepCall("revalidateNever"),
+          ],
+          "I'll trace how the cache keys are built end to end.",
+        ),
+        sbToolCallBatch([
+          {
+            id: "sb-glob",
+            name: "glob_files",
+            input: { pattern: "**/*.md", path: "docs", mode: "matches" },
+          },
+          readCall(),
+          readCall(),
+          grepCall("ScopedPromisesProvider"),
+        ]),
+        sbToolCallBatch([
+          readCall(),
+          readCall(),
+          readCall(),
+          grepCall("revalidateOnFocus"),
+        ]),
+        sbToolCallBatch([
+          readCall(),
+          readCall(),
+          readCall(),
+          grepCall("ContextSWRProvider"),
+        ]),
+        sbToolCallBatch([
+          readCall(),
+          grepCall("getWritableScopedAtoms"),
+          grepCall("AltProvidersProbe"),
+          grepCall("scope change"),
+        ]),
+        sbToolCallBatch([grepCall("router.")], undefined, {
+          chunks: Array.from(
+            { length: 10 },
+            (_, index) => `thinking hard step ${index} `,
+          ),
+          delayMs: 350,
+          id: "r-pause",
+        }),
+        sbToolCallBatch([readCall()]),
+        sbReasoningThenStreamedFinalText(
+          Array.from(
+            { length: 8 },
+            (_, index) => `assembling the final answer ${index} `,
+          ),
+          sbTokenChunks(responseLines.join("\n"), 10),
+          20,
+        ),
+      ]);
+      const fakeGateway = gateway as ReturnType<typeof startFakeGateway>;
+
+      session = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: workspace,
+        width: 149,
+        height: 51,
+        minimumHistoryLines: 10_000,
+        stderrPath,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-sb-batch-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_GATEWAY_BASE_URL: fakeGateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: fakeGateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: fakeGateway.chatUrl,
+          FX_MODEL: MODEL,
+          FX_RECORD: tapePath,
+          FX_RECORD_INPUT: "1",
+        },
+      });
+
+      await session.waitForComposer(SB_TIMEOUT);
+      await session.sendText("Fill the history first.");
+      await session.waitForText("FILLER_ROW_45", SB_TIMEOUT);
+      await session.waitForPane(hasEmptyComposer, SB_TIMEOUT);
+      await session.sendText("How would client-side teamData go stale?");
+      await session.waitForText("RESP_TAIL", SB_TIMEOUT);
+      await session.waitForPane(hasEmptyComposer, SB_TIMEOUT);
+      await Bun.sleep(250);
+
+      const scrollback = await session.captureFullScrollback();
+
+      const childMarkers = [
+        ...Array.from(
+          { length: 12 },
+          (_, index) =>
+            `Read docs/source-${String(index + 1).padStart(2, "0")}.md`,
+        ),
+        "Searched useServerQuerySWR",
+        "Searched revalidateNever",
+        "Searched ScopedPromisesProvider",
+        "Searched revalidateOnFocus",
+        "Searched ContextSWRProvider",
+        "Searched getWritableScopedAtoms",
+        "Searched AltProvidersProbe",
+        "Searched scope change",
+        "Searched router.",
+        "Matched **/*.md",
+      ];
+      for (const marker of childMarkers) {
+        expect(countOccurrences(scrollback, marker)).toBe(1);
+      }
+      const orderedResponseMarkers = [
+        "RESP_INTRO",
+        "RESP_ITEM_ONE",
+        "CODE_A_LINE_01",
+        "CODE_A_LINE_02",
+        "CODE_A_LINE_03",
+        "RESP_ITEM_TWO",
+        "CODE_B_LINE_01",
+        "RESP_ITEM_THREE",
+        "CODE_C_LINE_01",
+        "RESP_ITEM_FOUR",
+        "CODE_D_LINE_01",
+        "CODE_D_LINE_04",
+        "RESP_TAIL",
+      ];
+      let previousIndex = -1;
+      for (const marker of orderedResponseMarkers) {
+        expect(countOccurrences(scrollback, marker)).toBe(1);
+        const index = scrollback.indexOf(marker);
+        expect(index).toBeGreaterThan(previousIndex);
+        previousIndex = index;
+      }
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    SB_TIMEOUT + 60_000,
+  );
+});

--- a/tests/e2e/tui-render-lab.test.ts
+++ b/tests/e2e/tui-render-lab.test.ts
@@ -33,6 +33,7 @@ test("render-lab lists gated Plan B native scenarios", () => {
   expect(output).toContain("startup-scrollback-enabled-overflow");
   expect(output).toContain("active-tool-placement");
   expect(output).toContain("user-card-resize-replay-scrollback");
+  expect(output).toContain("tui-observability-gauntlet");
   expect(output).toContain("native-ghostty-relaunch");
   expect(output).toContain("native-terminal-app-relaunch");
   expect(output).toContain("native-terminal-app-command-k");
@@ -472,6 +473,82 @@ test("render-lab analyzer rejects expanded command marker corruption", () => {
       (failure) => failure.invariant,
     );
     expect(failures).toContain(entry.invariant);
+  }
+});
+
+test("render-lab analyzer rejects duplicate permission UI", () => {
+  outDir = mkdtempSync(join(tmpdir(), "fx-render-lab-analyzer-test-"));
+  const prompt = "Would you like to run the following command?";
+  for (const [name, prompts, rejected] of [
+    ["single", [prompt], false],
+    ["duplicate", [prompt, prompt], true],
+  ] as const) {
+    const manifest = writeAnalyzerFixture(
+      join(outDir, name),
+      [
+        "OBSERVABILITY_TRANSCRIPT_HEAD",
+        "OBSERVABILITY_TRANSCRIPT_TAIL",
+        ...prompts,
+        "1. Yes",
+      ],
+      null,
+      [],
+      "observability-permission-inline",
+    );
+    manifest.scenario = "tui-observability-gauntlet";
+
+    const failures = analyzeRun(manifest).failures.map(
+      (failure) => failure.invariant,
+    );
+
+    expect(failures.includes("observability-permission-singleton")).toBe(
+      rejected,
+    );
+  }
+});
+
+test("render-lab analyzer rejects reordered observability scrollback", () => {
+  outDir = mkdtempSync(join(tmpdir(), "fx-render-lab-analyzer-test-"));
+  const markers = ["OBSERVABILITY_PROMPT_HEAD", "OBSERVABILITY_PROMPT_TAIL"];
+  for (const [name, transcript, rejected] of [
+    [
+      "ordered",
+      ["OBSERVABILITY_TRANSCRIPT_HEAD", "OBSERVABILITY_TRANSCRIPT_TAIL"],
+      false,
+    ],
+    [
+      "reordered",
+      ["OBSERVABILITY_TRANSCRIPT_TAIL", "OBSERVABILITY_TRANSCRIPT_HEAD"],
+      true,
+    ],
+  ] as const) {
+    const scrollback = [
+      ...markers,
+      ...transcript,
+      "OBSERVABILITY_TOOL_OUTPUT",
+      "OBSERVABILITY_FINAL_RESPONSE",
+    ].join("\n");
+    const manifest = writeAnalyzerFixture(
+      join(outDir, name),
+      [
+        "OBSERVABILITY_FINAL_RESPONSE",
+        "────────────────",
+        "❯",
+        "────────────────",
+        "model",
+      ],
+      null,
+      markers,
+      "observability-final-restored",
+      scrollback,
+    );
+    manifest.scenario = "tui-observability-gauntlet";
+
+    const failures = analyzeRun(manifest).failures.map(
+      (failure) => failure.invariant,
+    );
+
+    expect(failures.includes("observability-scrollback-order")).toBe(rejected);
   }
 });
 

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -5403,7 +5403,15 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         await active.waitForComposer(TIMEOUT);
         await active.sendText("Fill the main transcript for resize isolation.");
         await active.waitForText("MAIN_SCROLLBACK_160", TIMEOUT);
-        const mainScrollbackBefore = await active.captureFullScrollback();
+        // Finished rows settle into native scrollback a frame after the final
+        // marker paints, so wait for the settled capture instead of sampling
+        // the instant the marker appears.
+        const mainScrollbackBefore = await waitForFullScrollback(
+          active,
+          (scrollback) =>
+            scrollback.includes("MAIN_SCROLLBACK_001") &&
+            countOccurrences(scrollback, "MAIN_SCROLLBACK_") >= 150,
+        );
         const mainLineCountBefore = countOccurrences(
           mainScrollbackBefore,
           "MAIN_SCROLLBACK_",


### PR DESCRIPTION
## Summary

- Keep mutable interactive transcript rows out of native scrollback until their tool turn, replacement, or assistant stream is final.
- Re-anchor byte-incompatible frames before releasing held history and account for committed-line growth during partial release.
- Keep one-shot `fx ask` output append-only instead of requiring interactive turn-finality signals.
- Continue updating the live viewport while held rows wait for safe scrollback release.
- Cover streamed responses, tool batches, permission review, resize recovery, and final composer recovery with deterministic terminal scenarios.