### PR TITLE
Explain terminal monitor workspace rejections

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -116,7 +116,7 @@ const terminal_monitor_condition_schema = gateway_schema.ObjectSchema{
         .{ .name = "signal", .json_type = .string, .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } },
         .{ .name = "host", .json_type = .string },
         .{ .name = "port", .json_type = .integer, .minimum = 1, .maximum = 65535 },
-        .{ .name = "path", .json_type = .string },
+        .{ .name = "path", .json_type = .string, .description = "Required for path conditions. The path must resolve within the terminal workspace; external paths are rejected." },
         .{ .name = "minimum_bytes", .json_type = .integer },
         .{ .name = "command", .json_type = .string },
         .{ .name = "cwd", .json_type = .string },
@@ -1028,6 +1028,7 @@ pub const terminal = ToolSpec{
     .decode = terminal_impl.decode,
     .validate = terminal_impl.validate,
     .call = terminal_impl.call,
+    .authorized_result_mapper = terminal_impl.mapAuthorizedResult,
     .reads_only_fn = terminal_impl.readsOnly,
     .irreversible_fn = terminal_impl.isIrreversible,
 };
@@ -1390,6 +1391,7 @@ test "terminal tool schema exposes one exact object branch per action" {
     try std.testing.expect(terminal.requires_approval);
     try std.testing.expectEqual(tool_dispatch.ExecutorKind.terminal, terminal.executor_kind);
     try std.testing.expectEqual(tool_dispatch.PermissionTargetKind.none, terminal.permission_target_kind);
+    try std.testing.expect(terminal.authorized_result_mapper != null);
 
     const expected = [_]struct {
         action: []const u8,
@@ -1446,6 +1448,7 @@ test "terminal tool schema exposes one exact object branch per action" {
     );
 
     const output_quiet_duration = schemaProperty(terminal_monitor_condition_schema, "duration_ms").?;
+    const monitor_path = schemaProperty(terminal_monitor_condition_schema, "path").?;
     const notification_interval = schemaProperty(terminal_monitor_notify_schema, "interval_ms").?;
     const lifetime_duration = schemaProperty(terminal_monitor_lifetime_schema, "duration_ms").?;
     const check_interval = schemaProperty(terminal_monitor_definition_schema, "check_interval_ms").?;
@@ -1460,6 +1463,10 @@ test "terminal tool schema exposes one exact object branch per action" {
     try std.testing.expectEqual(@as(?usize, maximum_lifetime_ms), lifetime_duration.maximum);
     try std.testing.expectEqual(@as(?usize, minimum_schedule_ms), check_interval.minimum);
     try std.testing.expectEqual(@as(?usize, maximum_schedule_ms), check_interval.maximum);
+    try std.testing.expectEqualStrings(
+        "Required for path conditions. The path must resolve within the terminal workspace; external paths are rejected.",
+        monitor_path.description,
+    );
     try std.testing.expectEqualStrings(
         "Required for polling conditions tcp_ready, http_ready, path_exists, path_changed, path_size, and custom_probe. Event-driven conditions process_exit, exit_code, signal, output_contains, output_matches, output_quiet, and screen_matches omit it; materialized values are ignored.",
         check_interval.description,

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -1820,6 +1820,59 @@ test "file edit preflight failure reports the exact mismatch" {
     );
 }
 
+test "terminal path scope failure appends the exact status detail" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+    defer capture.deinit();
+    var hooks = capture.hooks();
+    hooks.describe_tool_action_denied = struct {
+        fn describe(
+            _: *anyopaque,
+            target: Allocator,
+            _: ToolCall,
+            _: ?[]const u8,
+            label: []const u8,
+            _: []const []const u8,
+        ) ![]const u8 {
+            return std.fmt.allocPrint(target, "{s} start", .{label});
+        }
+    }.describe;
+    const failure = "{\"failure\":{\"action\":\"start\",\"code\":\"path_outside_workspace\"}}";
+
+    try finishExecutedToolStatus(
+        &hooks,
+        arena,
+        5,
+        .{
+            .id = "terminal_path_scope",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"start\"}",
+        },
+        true,
+        null,
+        .{
+            .status = .failure,
+            .model_output = failure,
+            .status_detail = "path is outside the workspace",
+        },
+        failure,
+        .{ .output_bytes = failure.len, .stored_output_bytes = failure.len },
+        null,
+        &.{},
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), capture.events.items.len);
+    const terminal = capture.events.items[0].terminal;
+    try std.testing.expectEqual(types.ToolOutcomeKind.failed, terminal.outcome.kind);
+    try std.testing.expectEqualStrings(
+        "Failed start: path is outside the workspace",
+        terminal.outcome.summary,
+    );
+}
+
 test "command completion publishes its combined artifact handle" {
     const alloc = std.testing.allocator;
     var arena_state = std.heap.ArenaAllocator.init(alloc);

--- a/src/core/terminal/contracts.zig
+++ b/src/core/terminal/contracts.zig
@@ -27,10 +27,12 @@ pub const compatibility_hello_revision: u16 = previous_protocol_revision - 1;
 pub const protocol_capability_authority_generations: u64 = 1 << 0;
 pub const protocol_capability_screen_checkpoints: u64 = 1 << 1;
 pub const protocol_capability_tmux_recovery: u64 = 1 << 2;
+pub const protocol_capability_path_outside_workspace_error: u64 = 1 << 3;
 pub const known_protocol_capabilities: u64 =
     protocol_capability_authority_generations |
     protocol_capability_screen_checkpoints |
-    protocol_capability_tmux_recovery;
+    protocol_capability_tmux_recovery |
+    protocol_capability_path_outside_workspace_error;
 
 pub const Action = enum {
     start,
@@ -2366,6 +2368,7 @@ pub const HostMessage = struct {
 
 pub const StructuredErrorCode = enum {
     invalid_request,
+    path_outside_workspace,
     unsupported_host,
     shell_unavailable,
     pty_unavailable,

--- a/src/core/terminal/host.zig
+++ b/src/core/terminal/host.zig
@@ -896,12 +896,16 @@ const Connection = struct {
         if (testRequestFailureRequested("response_encoding", correlation_id)) {
             return error.OutOfMemory;
         }
+        const compatible_result = protocol.projectResultForCapabilities(
+            result,
+            self.capabilities,
+        );
         var frame = try protocol.encodeFrame(
             self.alloc,
             self.revision,
             0,
             correlation_id,
-            .{ .response = result },
+            .{ .response = compatible_result },
         );
         defer frame.deinit(self.alloc);
         const zio = io_mod.getIo();

--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -1118,7 +1118,14 @@ const SupportedRegistry = struct {
             session.durable.rollback_unreleased_start() catch {};
             session.deinitUnlaunched();
             if (err == error.OutOfMemory) return error.OutOfMemory;
-            return self.failure(.start, .invalid_request, null);
+            return self.failure(
+                .start,
+                if (err == error.PathOutsideWorkspace)
+                    .path_outside_workspace
+                else
+                    .invalid_request,
+                null,
+            );
         };
         self.profile.register_resident(&session.durable) catch {
             session.deinitUnlaunched();

--- a/src/core/terminal/protocol.zig
+++ b/src/core/terminal/protocol.zig
@@ -175,6 +175,24 @@ fn projectResultV4(result: contracts.Result) contracts.Result {
     return result;
 }
 
+pub fn projectResultForCapabilities(
+    result: contracts.Result,
+    capabilities: u64,
+) contracts.Result {
+    const failure = switch (result) {
+        .success => return result,
+        .failure => |value| value,
+    };
+    if (failure.code != .path_outside_workspace or
+        capabilities & contracts.protocol_capability_path_outside_workspace_error != 0)
+    {
+        return result;
+    }
+    var compatible = failure;
+    compatible.code = .invalid_request;
+    return .{ .failure = compatible };
+}
+
 pub fn decodeFrame(alloc: Allocator, bytes: []const u8) DecodeError!DecodedFrame {
     const header = try Header.decode(bytes);
     const payload_len: usize = header.envelope.payload_len;
@@ -462,6 +480,52 @@ test "revision four projection never exposes degraded monitor state" {
     const response_json = response.bytes[header_len..];
     try std.testing.expect(std.mem.find(u8, response_json, "degraded") == null);
     try std.testing.expect(std.mem.find(u8, response_json, "protocol_incompatible") != null);
+}
+
+fn expectProjectedErrorCode(
+    capabilities: u64,
+    expected: contracts.StructuredErrorCode,
+) !void {
+    const projected = projectResultForCapabilities(.{ .failure = .{
+        .action = .start,
+        .code = .path_outside_workspace,
+    } }, capabilities);
+    var encoded = try encodeFrame(
+        std.testing.allocator,
+        contracts.current_protocol_revision,
+        0,
+        .{ .value = 1 },
+        .{ .response = projected },
+    );
+    defer encoded.deinit(std.testing.allocator);
+    var decoded = try decodeFrame(std.testing.allocator, encoded.bytes);
+    defer decoded.deinit();
+    const response = switch (decoded.message().payload) {
+        .response => |value| value,
+        else => return error.TestExpectedResponse,
+    };
+    const failure = switch (response) {
+        .failure => |value| value,
+        .success => return error.TestExpectedFailure,
+    };
+    try std.testing.expectEqual(expected, failure.code);
+}
+
+test "host protocol projects path scope failures by negotiated capability" {
+    try expectProjectedErrorCode(
+        contracts.protocol_capability_path_outside_workspace_error,
+        .path_outside_workspace,
+    );
+    try expectProjectedErrorCode(0, .invalid_request);
+
+    const generic: contracts.Result = .{ .failure = .{
+        .action = .start,
+        .code = .invalid_request,
+    } };
+    try std.testing.expectEqual(
+        contracts.StructuredErrorCode.invalid_request,
+        projectResultForCapabilities(generic, 0).failure.code,
+    );
 }
 
 test "host protocol fuzzes the real untrusted frame decoder" {

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -40,6 +40,14 @@ const NotifyKind = enum {
 };
 const LifetimeKind = enum { until_match, until_session_end, duration };
 const MonitorOperationKind = enum { add, update, pause, @"resume", remove };
+const composite_argument_fields = [_][]const u8{
+    "shell",
+    "return_when",
+    "dimensions",
+    "initial_monitors",
+    "write",
+    "monitor",
+};
 
 pub const ShellInput = struct {
     kind: ShellKind = .user_login,
@@ -180,25 +188,27 @@ pub fn decode(
     ctx: tool_dispatch.DispatchContext,
     args_json: []const u8,
 ) tool_dispatch.DispatchError!tool_dispatch.DecodeResult {
-    var raw = std.json.parseFromSlice(
+    var arena_state = std.heap.ArenaAllocator.init(ctx.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var raw = std.json.parseFromSliceLeaky(
         std.json.Value,
-        ctx.allocator,
+        arena,
         args_json,
-        .{},
+        .{ .allocate = .alloc_always },
     ) catch {
         return .{ .failure = try ctx.allocator.dupe(
             u8,
             "terminal arguments must match the advertised action schema",
         ) };
     };
-    defer raw.deinit();
-    if (raw.value != .object) {
+    if (raw != .object) {
         return .{ .failure = try ctx.allocator.dupe(
             u8,
             "terminal arguments must match the advertised action schema",
         ) };
     }
-    const raw_action = raw.value.object.get("action") orelse {
+    const raw_action = raw.object.get("action") orelse {
         return .{ .failure = try ctx.allocator.dupe(
             u8,
             "terminal arguments must match the advertised action schema",
@@ -216,7 +226,7 @@ pub fn decode(
             "terminal arguments must match the advertised action schema",
         ) };
     };
-    if (unexpectedActionField(action, raw.value.object)) |field_name| {
+    if (unexpectedActionField(action, raw.object)) |field_name| {
         return .{ .failure = try std.fmt.allocPrint(
             ctx.allocator,
             "terminal {s} field \"{s}\" is not allowed",
@@ -224,10 +234,27 @@ pub fn decode(
         ) };
     }
 
+    normalizeCompositeArguments(arena, &raw) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => {
+            return .{ .failure = try ctx.allocator.dupe(
+                u8,
+                "terminal arguments must match the advertised action schema",
+            ) };
+        },
+    };
+
+    var normalized: std.Io.Writer.Allocating = .init(ctx.allocator);
+    defer normalized.deinit();
+    std.json.Stringify.value(raw, .{}, &normalized.writer) catch
+        return error.OutOfMemory;
+    const normalized_json = try normalized.toOwnedSlice();
+    defer ctx.allocator.free(normalized_json);
+
     const parsed = std.json.parseFromSlice(
         Input,
         ctx.allocator,
-        args_json,
+        normalized_json,
         .{ .allocate = .alloc_always },
     ) catch {
         return .{ .failure = try ctx.allocator.dupe(
@@ -241,6 +268,39 @@ pub fn decode(
         .ptr = owned,
         .deinit_fn = inputDeinit,
     } };
+}
+
+fn normalizeCompositeArguments(
+    alloc: Allocator,
+    root: *std.json.Value,
+) !void {
+    for (composite_argument_fields) |field_name| {
+        const value = root.object.getPtr(field_name) orelse continue;
+        if (value.* != .string) continue;
+        const decoded = try std.json.parseFromSliceLeaky(
+            std.json.Value,
+            alloc,
+            value.string,
+            .{ .allocate = .alloc_always },
+        );
+        if (decoded != .object and decoded != .array) {
+            return error.InvalidCompositeArgument;
+        }
+        value.* = decoded;
+    }
+
+    const initial_monitors = root.object.getPtr("initial_monitors") orelse return;
+    if (initial_monitors.* != .array) return;
+    for (initial_monitors.array.items) |*monitor| {
+        if (monitor.* != .object) continue;
+        const condition = monitor.object.getPtr("condition") orelse continue;
+        if (condition.* != .object) continue;
+        const interval = condition.object.get("check_interval_ms") orelse continue;
+        _ = condition.object.orderedRemove("check_interval_ms");
+        if (monitor.object.get("check_interval_ms") == null) {
+            try monitor.object.put(alloc, "check_interval_ms", interval);
+        }
+    }
 }
 
 fn inputDeinit(ptr: *anyopaque, alloc: Allocator) void {
@@ -1064,6 +1124,55 @@ test "terminal start accepts native and tmux backend contracts" {
                 }
             },
         }
+    }
+}
+
+test "terminal decoder normalizes gateway stringified start composites" {
+    const alloc = std.testing.allocator;
+    const args =
+        "{\"action\":\"start\",\"cwd\":\"/workspace\",\"backend\":\"native\",\"command\":\"printf SHOULD_NOT_RUN\",\"return_when\":\"{\\\"kind\\\":\\\"started\\\"}\",\"initial_monitors\":\"[{\\\"condition\\\":{\\\"kind\\\":\\\"path_exists\\\",\\\"path\\\":\\\"/private/tmp/fx-monitor-outside-ready\\\",\\\"check_interval_ms\\\":1000},\\\"notify\\\":{\\\"kind\\\":\\\"on_match\\\"},\\\"lifetime\\\":{\\\"kind\\\":\\\"until_match\\\"}}]\"}";
+    const decoded = try decode(.{ .allocator = alloc }, args);
+    switch (decoded) {
+        .failure => |message| {
+            defer alloc.free(message);
+            return error.TestUnexpectedResult;
+        },
+        .input => |input| {
+            defer input.deinit(alloc);
+            const parsed = input.as(OwnedInput).parsed.value;
+            try std.testing.expectEqual(ReturnKind.started, parsed.return_when.?.kind);
+            try std.testing.expectEqual(@as(usize, 1), parsed.initial_monitors.len);
+            const monitor = parsed.initial_monitors[0];
+            try std.testing.expectEqual(MonitorConditionKind.path_exists, monitor.condition.kind);
+            try std.testing.expectEqualStrings(
+                "/private/tmp/fx-monitor-outside-ready",
+                monitor.condition.path.?,
+            );
+            try std.testing.expectEqual(@as(?u64, 1000), monitor.check_interval_ms);
+            try std.testing.expectEqual(NotifyKind.on_match, monitor.notify.kind);
+            try std.testing.expectEqual(LifetimeKind.until_match, monitor.lifetime.kind);
+        },
+    }
+}
+
+test "terminal decoder rejects malformed gateway composite strings" {
+    const alloc = std.testing.allocator;
+    const decoded = try decode(
+        .{ .allocator = alloc },
+        "{\"action\":\"start\",\"return_when\":\"not-json\"}",
+    );
+    switch (decoded) {
+        .input => |input| {
+            input.deinit(alloc);
+            return error.TestUnexpectedResult;
+        },
+        .failure => |message| {
+            defer alloc.free(message);
+            try std.testing.expectEqualStrings(
+                "terminal arguments must match the advertised action schema",
+                message,
+            );
+        },
     }
 }
 

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -867,6 +867,32 @@ fn stringifyResult(
     };
 }
 
+pub fn mapAuthorizedResult(
+    alloc: Allocator,
+    result: tool_dispatch.DispatchResult,
+) Allocator.Error!tool_dispatch.DispatchResult {
+    if (result.status != .failure or result.status_detail != null) return result;
+    var parsed = std.json.parseFromSlice(
+        contracts.Result,
+        alloc,
+        result.body,
+        .{},
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return result,
+    };
+    defer parsed.deinit();
+    const code = switch (parsed.value) {
+        .success => return result,
+        .failure => |failure| failure.code,
+    };
+    if (code != .path_outside_workspace) return result;
+
+    var mapped = result;
+    mapped.status_detail = try alloc.dupe(u8, "path is outside the workspace");
+    return mapped;
+}
+
 fn structuredFailure(
     alloc: Allocator,
     action: contracts.Action,
@@ -1175,6 +1201,47 @@ test "registered terminal validation enforces action-specific input before execu
         else => {},
     };
     try std.testing.expect(rejected == .failure);
+}
+
+test "terminal result mapper adds detail only for workspace path failures" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        status: tool_dispatch.DispatchResult.Status,
+        body: []const u8,
+        expected_detail: ?[]const u8,
+    }{
+        .{
+            .status = .failure,
+            .body = "{\"failure\":{\"action\":\"start\",\"code\":\"path_outside_workspace\",\"session_id\":null,\"retryable\":false}}",
+            .expected_detail = "path is outside the workspace",
+        },
+        .{
+            .status = .failure,
+            .body = "{\"failure\":{\"action\":\"start\",\"code\":\"invalid_request\",\"session_id\":null,\"retryable\":false}}",
+            .expected_detail = null,
+        },
+        .{ .status = .failure, .body = "not json", .expected_detail = null },
+        .{
+            .status = .success,
+            .body = "{\"success\":{\"close\":{\"session\":{}}}}",
+            .expected_detail = null,
+        },
+    };
+
+    for (cases) |case| {
+        const body = try alloc.dupe(u8, case.body);
+        var mapped = try mapAuthorizedResult(alloc, .{
+            .status = case.status,
+            .body = body,
+        });
+        defer mapped.deinit(alloc);
+        try std.testing.expectEqualStrings(case.body, mapped.body);
+        if (case.expected_detail) |expected| {
+            try std.testing.expectEqualStrings(expected, mapped.status_detail.?);
+        } else {
+            try std.testing.expect(mapped.status_detail == null);
+        }
+    }
 }
 
 test "terminal public wait ceiling maps to action-specific Core requests" {

--- a/tests/e2e/terminal-host.test.ts
+++ b/tests/e2e/terminal-host.test.ts
@@ -657,7 +657,7 @@ const protocolFixtureDefinitions = {
   },
   current_checkpoint: {
     range: { minimum: 4, current: 5 },
-    capabilities: 7,
+    capabilities: 15,
   },
 } as const;
 
@@ -812,7 +812,7 @@ class FrameClient {
 async function handshake(
   socketPath: string,
   clientRange: Range,
-  capabilities = 7,
+  capabilities = 15,
   helloRevision = clientRange.current,
 ): Promise<{
   client: FrameClient;
@@ -4504,37 +4504,49 @@ test.each([
   expect(await waitForExit(host)).toBe(0);
 }, 10_000);
 
-test("poll paths reject symlink escapes before child release", async () => {
-  const home = makeHome();
-  const outside = mkdtempSync(join(tmpdir(), "fx-terminal-monitor-outside-"));
-  homes.push(outside);
-  writeFileSync(join(outside, "ready"), "ready");
-  symlinkSync(outside, join(home, "escape"));
-  const paths = hostPaths(home);
-  const marker = join(home, "monitor-started");
-  const host = startHost(home, undefined, 500);
-  await waitFor(() => existsSync(paths.socket));
-  const connected = await handshake(paths.socket, { minimum: 4, current: 5 });
-  const frame = await requestAction(connected.client, connected.revision!, 211, "start", {
-    cwd: home,
-    command: `: > '${marker}'`,
-    shell: { executable: { path: TERMINAL_FIXTURE_SHELL, clean_start: true } },
-    backend: "native",
-    return_when: { exit: {} },
-    wait_ceiling_ms: 5_000,
-    dimensions: { rows: 24, columns: 80 },
-    initial_monitors: [{
-      condition: { path_exists: join(home, "escape", "ready") },
-      check_schedule: { interval_ms: 25 },
-      notify_schedule: { on_match: {} },
-      lifetime: { until_match: {} },
-    }],
-  });
-  expect(failure(frame).code).toBe("invalid_request");
-  expect(existsSync(marker)).toBe(false);
-  expect(directChildPids(host.pid!)).toEqual([]);
-  connected.client.close();
-  expect(await waitForExit(host)).toBe(0);
+test("poll path escapes preserve exact failures only for capable peers", async () => {
+  for (const testCase of [
+    { capabilities: 15, expectedCode: "path_outside_workspace" },
+    { capabilities: 7, expectedCode: "invalid_request" },
+  ]) {
+    const home = makeHome();
+    const outside = mkdtempSync(join(tmpdir(), "fx-terminal-monitor-outside-"));
+    homes.push(outside);
+    writeFileSync(join(outside, "ready"), "ready");
+    symlinkSync(outside, join(home, "escape"));
+    const paths = hostPaths(home);
+    const marker = join(home, "monitor-started");
+    const host = startHost(home, undefined, 500);
+    await waitFor(() => existsSync(paths.socket));
+    const connected = await handshake(
+      paths.socket,
+      { minimum: 4, current: 5 },
+      testCase.capabilities,
+    );
+    const frame = await requestAction(connected.client, connected.revision!, 211, "start", {
+      cwd: home,
+      command: `: > '${marker}'`,
+      shell: { executable: { path: TERMINAL_FIXTURE_SHELL, clean_start: true } },
+      backend: "native",
+      return_when: { exit: {} },
+      wait_ceiling_ms: 5_000,
+      dimensions: { rows: 24, columns: 80 },
+      initial_monitors: [{
+        condition: { path_exists: join(home, "escape", "ready") },
+        check_schedule: { interval_ms: 25 },
+        notify_schedule: { on_match: {} },
+        lifetime: { until_match: {} },
+      }],
+    });
+    expect(failure(frame).code).toBe(testCase.expectedCode);
+    expect(existsSync(marker)).toBe(false);
+    expect(directChildPids(host.pid!)).toEqual([]);
+    const terminalState = join(home, ".fx", "sessions", TERMINAL_OWNER_SESSION);
+    expect(readdirSync(terminalState).filter((name) => name.includes("terminal-")))
+      .toEqual([]);
+    connected.client.close();
+    expect(await waitForExit(host)).toBe(0);
+  }
 }, 10_000);
 
 test("custom probe re-canonicalization rejects a post-install symlink swap", async () => {

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -458,6 +458,15 @@ function sessionRecords(home: string): Array<Record<string, unknown>> {
   });
 }
 
+function sessionEventLogs(home: string): string {
+  const sessionsRoot = join(home, ".fx", "sessions");
+  if (!existsSync(sessionsRoot)) return "";
+  return readdirSync(sessionsRoot).map((name) => {
+    const path = join(sessionsRoot, name, "events.jsonl");
+    return existsSync(path) ? readFileSync(path, "utf8") : "";
+  }).join("\n");
+}
+
 test.skipIf(!tmuxAvailable())(
   "manager terminal takeover forwards raw input resizes detaches and restores inline state",
   async () => {
@@ -1260,6 +1269,140 @@ test.skipIf(!tmuxAvailable())(
     expect(pane).not.toContain("InvalidCommand");
     expect(pane).not.toContain("Failed start");
     expect(gateway.requests).toHaveLength(3);
+
+    const record = await waitForTerminalRecord(
+      fixture.home,
+      (candidate) =>
+        candidate.session_id === terminalSessionId &&
+        candidate.lifecycle === "closed",
+    );
+    const terminalPid = Number(record.pid);
+    expect(Number.isSafeInteger(terminalPid) && terminalPid > 0).toBe(true);
+    await waitForOwnedProcessExit([terminalPid]);
+    expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
+  "TUI explains external monitor rejection and preserves local monitor flow",
+  async () => {
+    const fixture = createFixture("fx-tui-terminal-monitor-path-scope-");
+    const outsidePath = join(fixture.root, "outside-ready");
+    const localPath = join(fixture.workspace, "local-ready");
+    const rejectedMarker = join(fixture.workspace, "rejected-start-ran");
+    writeFileSync(outsidePath, "ready");
+    let terminalSessionId = "";
+    const gateway = startFakeGateway([
+      fakeGatewayToolCall("terminal_external_path", "terminal", {
+        action: "start",
+        cwd: fixture.workspace,
+        command: `printf SHOULD_NOT_RUN > ${JSON.stringify(rejectedMarker)}`,
+        shell: {
+          kind: "executable",
+          path: TERMINAL_FIXTURE_SHELL,
+          clean_start: true,
+        },
+        backend: "native",
+        return_when: { kind: "exit" },
+        wait_ceiling_ms: 20_000,
+        initial_monitors: [{
+          condition: { kind: "path_exists", path: outsidePath },
+          check_interval_ms: 25,
+          notify: { kind: "on_match" },
+          lifetime: { kind: "until_match" },
+        }],
+      }),
+      (body) => {
+        const result = toolResultText(body, "terminal_external_path");
+        expect(result).toContain('"code":"path_outside_workspace"');
+        expect(terminalRecords(fixture.home)).toEqual([]);
+        expect(existsSync(rejectedMarker)).toBe(false);
+        expect(sessionEventLogs(fixture.home)).toContain("path_outside_workspace");
+        const identity = JSON.parse(
+          readFileSync(
+            join(fixture.home, ".fx", "terminal-host", "host.json"),
+            "utf8",
+          ),
+        ) as { pid: string };
+        expect(directChildPids(Number(identity.pid))).toEqual([]);
+        return fakeGatewayToolCall("terminal_local_path", "terminal", {
+          action: "start",
+          cwd: fixture.workspace,
+          command: holdUntilCleanup(fixture.root),
+          shell: {
+            kind: "executable",
+            path: TERMINAL_FIXTURE_SHELL,
+            clean_start: true,
+          },
+          backend: "native",
+          return_when: { kind: "started" },
+          dimensions: { rows: 24, columns: 80 },
+          initial_monitors: [{
+            condition: { kind: "path_exists", path: localPath },
+            check_interval_ms: 25,
+            notify: { kind: "on_match" },
+            lifetime: { kind: "until_match" },
+          }],
+        });
+      },
+      async (body) => {
+        const result = JSON.parse(
+          toolResultText(body, "terminal_local_path"),
+        ) as {
+          success: { start: { session: { session_id: string } } };
+        };
+        terminalSessionId = result.success.start.session.session_id;
+        expect(terminalSessionId.length).toBeGreaterThan(0);
+        writeFileSync(localPath, "ready");
+        await Bun.sleep(150);
+        return fakeGatewayToolCall("terminal_local_inspect", "terminal", {
+          action: "inspect",
+          session_id: terminalSessionId,
+          after_event_id: 0,
+          max_events: 16,
+        });
+      },
+      (body) => {
+        const result = JSON.parse(
+          toolResultText(body, "terminal_local_inspect"),
+        ) as {
+          success: {
+            inspect: {
+              events: Array<{ monitor_id: string; reason: string }>;
+            };
+          };
+        };
+        expect(result.success.inspect.events.some((event) =>
+          event.monitor_id === "monitor-1" && event.reason === "matched"
+        )).toBe(true);
+        return fakeGatewayToolCall("terminal_local_close", "terminal", {
+          action: "close",
+          session_id: terminalSessionId,
+          close_policy: "force",
+        });
+      },
+      (body) => {
+        const result = toolResultText(body, "terminal_local_close");
+        expect(result).toContain('"lifecycle":"closed"');
+        return fakeGatewayFinalText("Terminal monitor path scope verified");
+      },
+    ]);
+    gateways.push(gateway);
+    const active = await launch(fixture, gateway);
+
+    await active.sendText("Verify terminal monitor workspace paths.");
+    const pane = await active.waitForText(
+      "Terminal monitor path scope verified",
+      TIMEOUT,
+    );
+    expect(pane).toContain("Failed start: path is outside the workspace");
+    expect(pane).toContain("Used terminal start");
+    expect(pane).toContain("Used terminal inspect");
+    expect(pane).toContain("Used terminal close");
+    expect(gateway.requests).toHaveLength(5);
+    expect(gateway.requests[1]!.body).toContain("path_outside_workspace");
+    expect(existsSync(rejectedMarker)).toBe(false);
 
     const record = await waitForTerminalRecord(
       fixture.home,

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -1285,7 +1285,7 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
-  "TUI explains external monitor rejection and preserves local monitor flow",
+  "TUI normalizes gateway start composites, explains external monitor rejection, and preserves local monitor flow",
   async () => {
     const fixture = createFixture("fx-tui-terminal-monitor-path-scope-");
     const outsidePath = join(fixture.root, "outside-ready");
@@ -1304,14 +1304,16 @@ test.skipIf(!tmuxAvailable())(
           clean_start: true,
         },
         backend: "native",
-        return_when: { kind: "exit" },
-        wait_ceiling_ms: 20_000,
-        initial_monitors: [{
-          condition: { kind: "path_exists", path: outsidePath },
-          check_interval_ms: 25,
+        return_when: JSON.stringify({ kind: "started" }),
+        initial_monitors: JSON.stringify([{
+          condition: {
+            kind: "path_exists",
+            path: outsidePath,
+            check_interval_ms: 25,
+          },
           notify: { kind: "on_match" },
           lifetime: { kind: "until_match" },
-        }],
+        }]),
       }),
       (body) => {
         const result = toolResultText(body, "terminal_external_path");


### PR DESCRIPTION
## Summary

- Accept structured terminal arguments that arrive as JSON strings.
- Normalize initial monitor polling intervals when they arrive inside the condition object.
- Report `path_outside_workspace` when a terminal start monitor resolves outside the workspace.
- Show `Failed start: path is outside the workspace` in the terminal transcript.
- Keep older terminal-host peers compatible by returning `invalid_request`.
- Document that monitor paths must resolve within the terminal workspace.