### PR TITLE
Route terminal titles through a host capability

### DIFF
--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -32,6 +32,7 @@ const Allocator = std.mem.Allocator;
 pub const CapabilityProviders = struct {
     load_mcp_runtime: mcp_runtime.LoadRuntimeFn,
     skill_root_policy: skill_contract.RootPolicy,
+    terminal_title: host.TerminalTitle,
 };
 
 fn BootstrapDeps(comptime App: type) type {
@@ -56,8 +57,6 @@ fn BootstrapDeps(comptime App: type) type {
         const WelcomeMessageFn = *const fn (Allocator) anyerror![]u8;
         const BeginFreshPersistedSessionFn = *const fn (*App) anyerror!void;
         const EnableSessionStoresFn = *const fn (*App) void;
-        const SetTerminalTitleFn = *const fn ([]const u8) void;
-
         bootstrap_interactive_app: BootstrapInteractiveAppFn,
         configure_session_preferences: ConfigureSessionPreferencesFn,
         initialize_persistence: InitializePersistenceFn,
@@ -69,7 +68,7 @@ fn BootstrapDeps(comptime App: type) type {
         welcome_message: WelcomeMessageFn,
         begin_fresh_persisted_session: BeginFreshPersistedSessionFn,
         enable_session_stores: EnableSessionStoresFn,
-        set_terminal_title: SetTerminalTitleFn,
+        terminal_title: host.TerminalTitle,
     };
 }
 
@@ -108,7 +107,7 @@ pub fn Runtime(comptime App: type) type {
                 .welcome_message = welcomeMessageDefault,
                 .begin_fresh_persisted_session = beginFreshPersistedSessionDefault,
                 .enable_session_stores = enableSessionStoresDefault,
-                .set_terminal_title = setTerminalTitleDefault,
+                .terminal_title = capability_providers.terminal_title,
             };
         }
 
@@ -164,10 +163,6 @@ pub fn Runtime(comptime App: type) type {
             app_session_runtime.Runtime(App).enableSessionStores(app);
         }
 
-        fn setTerminalTitleDefault(model: []const u8) void {
-            ui_render.setTerminalTitle(model);
-        }
-
         // Neutral one-line summary inline; the full detail stays behind Ctrl+O.
         fn writeCollapsedStartupNotice(app: *App, topic: []const u8, summary_lead: []const u8, detail: []const u8) !void {
             const summary = try std.fmt.allocPrint(app.alloc, "{s} (ctrl o to view)", .{summary_lead});
@@ -192,6 +187,7 @@ pub fn Runtime(comptime App: type) type {
                 .terminal = &app.terminal,
                 .shell = &app.shell,
                 .metrics = &app.metrics,
+                .terminal_title = deps.terminal_title,
                 .footer_rows = footer_rows,
                 .startup_min_body_rows = ui_render.welcome_message_reserved_rows,
                 .default_model = default_model,
@@ -441,7 +437,7 @@ pub fn Runtime(comptime App: type) type {
             if (app.requested_resume == null) {
                 try deps.begin_fresh_persisted_session(app);
                 deps.enable_session_stores(app);
-                deps.set_terminal_title(app.selected_model.items);
+                deps.terminal_title.setModel(app.selected_model.items);
             }
 
             switch (staged_resume_view) {
@@ -632,7 +628,10 @@ fn testDeps() BootstrapDeps(TestApp) {
         .welcome_message = welcomeMessageForTest,
         .begin_fresh_persisted_session = beginFreshPersistedSessionForTest,
         .enable_session_stores = enableSessionStoresForTest,
-        .set_terminal_title = setTerminalTitleForTest,
+        .terminal_title = .{
+            .set_model_fn = setTerminalTitleModelForTest,
+            .clear_fn = clearTerminalTitleForTest,
+        },
     };
 }
 
@@ -803,11 +802,17 @@ fn enableSessionStoresForTest(_: *TestApp) void {
     capture.recordEvent("enable_stores");
 }
 
-fn setTerminalTitleForTest(model: []const u8) void {
+fn setTerminalTitleModelForTest(_: ?*anyopaque, model: []const u8) void {
     const capture = active_capture.?;
     capture.title_len = @min(model.len, capture.title.len);
     @memcpy(capture.title[0..capture.title_len], model[0..capture.title_len]);
     capture.recordEvent("title");
+}
+
+fn clearTerminalTitleForTest(_: ?*anyopaque) void {
+    const capture = active_capture.?;
+    capture.title_len = 0;
+    capture.recordEvent("title_clear");
 }
 
 fn runBootstrapForTest(app: *TestApp, capture: *TestCapture) !void {

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -245,6 +245,7 @@ pub const BootstrapConfig = struct {
     terminal: *TerminalState,
     shell: *TranscriptRuntime,
     metrics: *Metrics,
+    terminal_title: host.TerminalTitle,
     footer_rows: u16,
     startup_min_body_rows: u16 = 0,
     default_model: []const u8,
@@ -426,7 +427,12 @@ pub fn bootstrapInteractiveApp(cfg: BootstrapConfig) !StartupState {
 
     state.credential_onboarding_skipped = credentialOnboardingDisabled();
 
-    errdefer shutdownInteractiveShell(cfg.terminal, cfg.shell, cfg.metrics);
+    errdefer shutdownInteractiveShell(
+        cfg.terminal,
+        cfg.shell,
+        cfg.metrics,
+        cfg.terminal_title,
+    );
 
     try cfg.terminal.enableRawMode();
     cfg.terminal.installResizeSignal(cfg.resize_handler);
@@ -533,12 +539,17 @@ fn pushLaunchRowsIntoScrollback(
     }
 }
 
-pub fn shutdownInteractiveShell(terminal: *TerminalState, shell: *TranscriptRuntime, metrics: *Metrics) void {
+pub fn shutdownInteractiveShell(
+    terminal: *TerminalState,
+    shell: *TranscriptRuntime,
+    metrics: *Metrics,
+    terminal_title: host.TerminalTitle,
+) void {
     leaveAlternateScreens(terminal, shell, metrics);
     terminal.uninstallResizeSignal();
     uninstallAbnormalExitHandlers();
     _ = writeLifecycleTerminalBytes(shell, metrics, normalExitRestoreSequence(io_mod.getenv("TMUX"))) catch {};
-    ui_render.clearTerminalTitle();
+    terminal_title.clear();
     record_tape.shutdown();
     finishLeavingInteractiveMode(terminal, shell, metrics);
 }

--- a/src/core/hosts/host.zig
+++ b/src/core/hosts/host.zig
@@ -53,6 +53,31 @@ fn unavailableUrlOpen(
     return false;
 }
 
+pub const TerminalTitle = struct {
+    context: ?*anyopaque = null,
+    set_model_fn: *const fn (?*anyopaque, []const u8) void,
+    clear_fn: *const fn (?*anyopaque) void,
+
+    /// Borrows `model` for this call. Terminal write failures are intentionally
+    /// non-fatal because the title is presentation metadata.
+    pub fn setModel(self: TerminalTitle, model: []const u8) void {
+        self.set_model_fn(self.context, model);
+    }
+
+    pub fn clear(self: TerminalTitle) void {
+        self.clear_fn(self.context);
+    }
+};
+
+pub const unavailable_terminal_title: TerminalTitle = .{
+    .set_model_fn = ignoreTerminalTitleSetModel,
+    .clear_fn = ignoreTerminalTitleClear,
+};
+
+fn ignoreTerminalTitleSetModel(_: ?*anyopaque, _: []const u8) void {}
+
+fn ignoreTerminalTitleClear(_: ?*anyopaque) void {}
+
 pub const SecretStoreLoadError = std.mem.Allocator.Error || error{
     StoredKeyInsecure,
     StoredKeyUnreadable,
@@ -241,6 +266,47 @@ pub fn operatingSystemText(alloc: std.mem.Allocator) std.mem.Allocator.Error![]u
     const release = std.mem.sliceTo(&uts.release, 0);
     if (release.len == 0) return alloc.dupe(u8, sysname);
     return std.fmt.allocPrint(alloc, "{s} {s}", .{ sysname, release });
+}
+
+test "terminal title forwards borrowed model bytes and clear" {
+    const Capture = struct {
+        model: [64]u8 = undefined,
+        model_len: usize = 0,
+        clear_count: usize = 0,
+
+        fn setModel(raw: ?*anyopaque, model: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.model_len = @min(model.len, self.model.len);
+            @memcpy(self.model[0..self.model_len], model[0..self.model_len]);
+        }
+
+        fn clear(raw: ?*anyopaque) void {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.clear_count += 1;
+        }
+
+        fn model_text(self: *const @This()) []const u8 {
+            return self.model[0..self.model_len];
+        }
+    };
+
+    var capture = Capture{};
+    const terminal_title = TerminalTitle{
+        .context = &capture,
+        .set_model_fn = Capture.setModel,
+        .clear_fn = Capture.clear,
+    };
+
+    terminal_title.setModel("provider/model");
+    terminal_title.clear();
+
+    try std.testing.expectEqualStrings("provider/model", capture.model_text());
+    try std.testing.expectEqual(@as(usize, 1), capture.clear_count);
+}
+
+test "unavailable terminal title accepts set and clear" {
+    unavailable_terminal_title.setModel("provider/model");
+    unavailable_terminal_title.clear();
 }
 
 test "native host capabilities expose sandbox and background process support" {

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -6,6 +6,7 @@ const auth_runtime = @import("../auth/auth_runtime.zig");
 const collections = @import("../shared/collections.zig");
 const config_runtime = @import("../config/config_runtime.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
+const host = @import("../hosts/host.zig");
 const io_mod = @import("../shared/io.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
 const output_contracts = @import("../output/output_contracts.zig");
@@ -16,7 +17,6 @@ const prompt_history_runtime = @import("../app/prompt_history_runtime.zig");
 const tool_dispatch = @import("../tooling/tool_dispatch.zig");
 const text_utils = @import("../shared/text_utils.zig");
 const types = @import("../shared/types.zig");
-const ui_render = @import("../../ui/render.zig");
 const render_request = @import("../../ui/render_request.zig");
 
 const freeStringList = collections.freeStringList;
@@ -253,15 +253,16 @@ fn appendLegacyCleanup(writer: *std.Io.Writer, cleanup: config_runtime.LegacyCle
     }
 }
 
-fn setTerminalTitle(model: []const u8) void {
-    if (builtin.is_test) {
-        return;
-    }
-    ui_render.setTerminalTitle(model);
-}
-
 pub fn Commands(comptime App: type) type {
     return struct {
+        fn terminalTitle(app: *App) host.TerminalTitle {
+            if (comptime @hasDecl(App, "terminalTitle")) {
+                return app.terminalTitle();
+            }
+            if (comptime builtin.is_test) return host.unavailable_terminal_title;
+            @compileError("interactive session commands require a terminal title host capability");
+        }
+
         fn update_channel_label(app: *App) []const u8 {
             if (comptime @hasField(App, "upgrader")) {
                 const Upgrader = @TypeOf(app.upgrader);
@@ -1124,7 +1125,7 @@ pub fn Commands(comptime App: type) type {
             try app.selected_model.appendSlice(app.alloc, resolved);
             try app.worker.syncQueuedPromptModel(std.heap.c_allocator, resolved);
             if (comptime @hasDecl(App, "persistAcceptedModel")) try app.persistAcceptedModel(resolved);
-            setTerminalTitle(resolved);
+            terminalTitle(app).setModel(resolved);
 
             if (announce) {
                 const active_response = if (comptime @hasField(App, "stream"))
@@ -1686,6 +1687,8 @@ const FakeApp = struct {
     permission_mode_preference_commit_count: usize = 0,
     last_preference_permission_mode: ?types.PermissionMode = null,
     semantic_write_count: usize = 0,
+    terminal_title_model: [128]u8 = undefined,
+    terminal_title_model_len: usize = 0,
 
     fn init(alloc: std.mem.Allocator, workspace_root: []const u8, model: []const u8) !FakeApp {
         var app = FakeApp{
@@ -1734,6 +1737,32 @@ const FakeApp = struct {
 
     fn toolRegistry(self: *const FakeApp) tool_dispatch.Registry {
         return self.tool_registry;
+    }
+
+    fn terminalTitle(self: *FakeApp) host.TerminalTitle {
+        return .{
+            .context = self,
+            .set_model_fn = setTerminalTitleModelForTest,
+            .clear_fn = clearTerminalTitleForTest,
+        };
+    }
+
+    fn setTerminalTitleModelForTest(raw: ?*anyopaque, model: []const u8) void {
+        const self: *FakeApp = @ptrCast(@alignCast(raw.?));
+        self.terminal_title_model_len = @min(model.len, self.terminal_title_model.len);
+        @memcpy(
+            self.terminal_title_model[0..self.terminal_title_model_len],
+            model[0..self.terminal_title_model_len],
+        );
+    }
+
+    fn clearTerminalTitleForTest(raw: ?*anyopaque) void {
+        const self: *FakeApp = @ptrCast(@alignCast(raw.?));
+        self.terminal_title_model_len = 0;
+    }
+
+    fn terminalTitleModelText(self: *const FakeApp) []const u8 {
+        return self.terminal_title_model[0..self.terminal_title_model_len];
     }
 
     fn snapshotCachedModelIds(self: *FakeApp, alloc: std.mem.Allocator) !?std.ArrayList([]u8) {
@@ -2164,6 +2193,7 @@ test "session_commands handleModel reports current model for empty query" {
 
     try std.testing.expectEqualStrings("● Model: anthropic/claude-opus-4.6\n", app.text());
     try std.testing.expect(app.worker.synced_model == null);
+    try std.testing.expectEqualStrings("", app.terminalTitleModelText());
 }
 
 test "session_commands handleModel resolves fuzzy cached model and syncs queued prompts" {
@@ -2180,6 +2210,7 @@ test "session_commands handleModel resolves fuzzy cached model and syncs queued 
 
     try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", app.selected_model.items);
     try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", app.worker.synced_model.?);
+    try std.testing.expectEqualStrings(app.selected_model.items, app.terminalTitleModelText());
     try expectTranscriptContains(&app, "● Switched to anthropic/claude-sonnet-4-20250514");
 }
 
@@ -2193,6 +2224,7 @@ test "session_commands handleModel falls back to raw query when model fetch fail
 
     try std.testing.expectEqualStrings("custom/provider-model", app.selected_model.items);
     try std.testing.expectEqualStrings("custom/provider-model", app.worker.synced_model.?);
+    try std.testing.expectEqualStrings(app.selected_model.items, app.terminalTitleModelText());
 }
 
 test "session_commands handlePermissions persists modes and reset clears session grants" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -450,6 +450,10 @@ const App = struct {
         return if (comptime host_profile.clipboard) native_host.clipboard else host.unavailable_clipboard;
     }
 
+    pub fn terminalTitle(_: *const Self) host.TerminalTitle {
+        return ui_render.terminal_title;
+    }
+
     alloc: Allocator,
     terminal: TerminalState = .{},
 
@@ -589,6 +593,7 @@ const App = struct {
             .{
                 .load_mcp_runtime = if (comptime host_target.is_wasm) loadNoMcpRuntime else builtin_mcp.loadRuntime,
                 .skill_root_policy = if (comptime host_target.is_wasm) wasm_skill_root_policy else builtin_skills.root_policy,
+                .terminal_title = ui_render.terminal_title,
             },
         );
         errdefer app.deinit();
@@ -601,7 +606,7 @@ const App = struct {
         if (comptime host_profile.durable_sessions or host_profile.js_host_sessions) {
             if (app.requested_resume != null) {
                 try SessionAppRuntime.resumeRequestedSession(&app);
-                ui_render.setTerminalTitle(app.selected_model.items);
+                app.terminalTitle().setModel(app.selected_model.items);
             }
         }
         if (comptime host_profile.durable_sessions) {
@@ -827,7 +832,12 @@ const App = struct {
 
     pub fn releaseTerminal(self: *App) void {
         if (!self.terminal.raw_enabled and !self.terminal.signal_handler_installed) return;
-        app_lifecycle.shutdownInteractiveShell(&self.terminal, &self.shell, &self.metrics);
+        app_lifecycle.shutdownInteractiveShell(
+            &self.terminal,
+            &self.shell,
+            &self.metrics,
+            self.terminalTitle(),
+        );
     }
 
     pub fn runExternalInteractive(self: *App, argv: []const []const u8) !void {

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const io_mod = @import("../core/shared/io.zig");
+const host = @import("../core/hosts/host.zig");
 const display_width = @import("../core/shared/display_width.zig");
 const types = @import("../core/shared/types.zig");
 const image_attachments = @import("../core/images/image_attachments.zig");
@@ -522,14 +523,19 @@ test "render width zero emits no row bytes and first cursor column" {
     try std.testing.expectEqual(@as(u16, 1), view.cursor_col);
 }
 
-pub fn setTerminalTitle(model: []const u8) void {
+pub const terminal_title: host.TerminalTitle = .{
+    .set_model_fn = setTerminalTitleModel,
+    .clear_fn = clearTerminalTitleProvider,
+};
+
+fn setTerminalTitleModel(_: ?*anyopaque, model: []const u8) void {
     const stdout = std.Io.File.stdout();
     stdout.writeStreamingAll(io_mod.getIo(), "\x1b]2;fx · ") catch return;
     stdout.writeStreamingAll(io_mod.getIo(), model) catch return;
     stdout.writeStreamingAll(io_mod.getIo(), "\x07") catch return;
 }
 
-pub fn clearTerminalTitle() void {
+fn clearTerminalTitleProvider(_: ?*anyopaque) void {
     const stdout = std.Io.File.stdout();
     stdout.writeStreamingAll(io_mod.getIo(), "\x1b]2;\x07") catch return;
 }

--- a/tests/e2e/render-lab/audit-direct-writes.ts
+++ b/tests/e2e/render-lab/audit-direct-writes.ts
@@ -55,7 +55,7 @@ const allowlist: AllowRule[] = [
   rule("src/ui/ask_presentation.zig", "init", /stdio_acquisition/, "interactive_terminal_owner", "stored ask presenter stdout handle"),
   rule("src/ui/ask_presentation.zig", "refreshGeometry", /fixed_descriptor/, "terminal_probe", "ask stdout geometry refresh"),
   rule("src/ui/ask_presentation.zig", "writeTerminalBytes", /stdio_write/, "initialization_teardown", "ask terminal prepare and restore control"),
-  rule("src/ui/render.zig", "(?:setTerminalTitle|clearTerminalTitle)", /stdio_(?:acquisition|write)/, "title_control", "terminal title control"),
+  rule("src/ui/render.zig", "(?:setTerminalTitleModel|clearTerminalTitleProvider)", /stdio_(?:acquisition|write)/, "title_control", "terminal title control"),
   rule("src/acp/jsonrpc.zig", ".+", /stdio_(?:acquisition|write)/, "acp_protocol_transport", "ACP JSON-RPC transport"),
   rule("src/core/permissions/sandbox.zig", "(?:runForegroundSessionBootstrap|writeForegroundSessionReplaceFailure)", /stdio_acquisition_write/, "subprocess_protocol_transport", "foreground command bootstrap protocol"),
   rule("src/core/terminal/native_session.zig", "(?:acceptMarker|runLauncher)", /fixed_descriptor/, "subprocess_protocol_transport", "private native launcher PTY and control descriptors"),

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -82,6 +82,13 @@ function captureViewportEscapes(session: TmuxSession): string {
   });
 }
 
+function capturePaneTitle(session: TmuxSession): string {
+  return execFileSync("tmux", ["display-message", "-p", "-t", session.name, "#{pane_title}"], {
+    stdio: "pipe",
+    encoding: "utf-8",
+  }).trimEnd();
+}
+
 async function waitForSkillsMenu(session: TmuxSession, count: number): Promise<string[]> {
   const deadline = Date.now() + TIMEOUT;
   let latest: string[] = [];
@@ -2403,6 +2410,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         height: 32,
       });
       await session.waitForComposer(10_000);
+      expect(capturePaneTitle(session)).toBe(`fx · ${currentModel}`);
 
       await session.sendText("/models");
       let grid = await waitForModelsMenu(session, 4);
@@ -2462,6 +2470,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       const settings = JSON.parse(readFileSync(fixture.settingsPath, "utf8")) as { model?: string };
       expect(settings.model).toBe(selectedModel);
+      expect(capturePaneTitle(session)).toBe(`fx · ${selectedModel}`);
       expect(session.isAlive()).toBe(true);
 
       await session.sendText("/quit");


### PR DESCRIPTION
## Summary

- Preserve `fx · <model>` titles on fresh interactive startup.
- Update the terminal title after session resume and model selection.
- Clear the terminal title after startup failures and normal shutdown.
- Route title effects through a Core host capability and the native UI provider.