### PR TITLE
Clarify update and session resume notices

### DIFF
--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -324,6 +324,7 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
                 request.executablePath(),
                 "resume",
                 handoff.session_id,
+                cli_surface.upgrade_relaunch_arg,
             };
             const replace_err = deps.replace_process(
                 deps.replace_ctx,
@@ -597,8 +598,8 @@ const TestCapture = struct {
     replace_error: std.process.ReplaceError = error.InvalidExe,
     replace_calls: usize = 0,
     replace_arg_count: usize = 0,
-    replace_arg_bufs: [3][128]u8 = undefined,
-    replace_arg_lens: [3]usize = .{ 0, 0, 0 },
+    replace_arg_bufs: [4][128]u8 = undefined,
+    replace_arg_lens: [4]usize = .{ 0, 0, 0, 0 },
     fail_unexpected_format: bool = false,
 
     fn init(run_result: cli_surface.RunResult) TestCapture {
@@ -925,10 +926,11 @@ test "app entry relaunches only after teardown with the validated handoff" {
 
     try std.testing.expectEqual(@as(u8, 1), outcome.exit);
     try std.testing.expectEqual(@as(usize, 1), capture.replace_calls);
-    try std.testing.expectEqual(@as(usize, 3), capture.replace_arg_count);
+    try std.testing.expectEqual(@as(usize, 4), capture.replace_arg_count);
     try std.testing.expectEqualStrings("/tmp/fx-upgraded", capture.replaceArg(0));
     try std.testing.expectEqualStrings("resume", capture.replaceArg(1));
     try std.testing.expectEqualStrings("session-123", capture.replaceArg(2));
+    try std.testing.expectEqualStrings("--upgrade-relaunch", capture.replaceArg(3));
     try std.testing.expect(std.mem.find(
         u8,
         capture.stderr.written(),

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -79,6 +79,11 @@ pub const ResumeHandoffIntent = enum {
     upgrade_requested,
 };
 
+const ResumeNotice = union(enum) {
+    session,
+    upgrade: []const u8,
+};
+
 pub const ResumeViewStage = union(enum) {
     none,
     ready: u32,
@@ -1358,10 +1363,24 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn resumeRequestedSession(app: *App) !void {
+            return resumeRequestedSessionWithNotice(app, .session);
+        }
+
+        pub fn resumeRequestedSessionAfterUpgrade(
+            app: *App,
+            version: []const u8,
+        ) !void {
+            return resumeRequestedSessionWithNotice(app, .{ .upgrade = version });
+        }
+
+        fn resumeRequestedSessionWithNotice(
+            app: *App,
+            notice: ResumeNotice,
+        ) !void {
             if (comptime runtime_profile.allows(App, .js_host_sessions) and
                 !runtime_profile.allows(App, .durable_sessions))
             {
-                return resumeRequestedJsHostSession(app);
+                return resumeRequestedJsHostSessionWithNotice(app, notice);
             }
             var target = app.requested_resume orelse return;
             app.requested_resume = null;
@@ -1396,12 +1415,19 @@ pub fn Runtime(comptime App: type) type {
             errdefer if (loaded_owned) loaded.deinit(app.alloc);
 
             loaded_owned = false;
-            try installResumedSession(app, &loaded);
+            try installResumedSession(app, &loaded, notice);
             errdefer closeWritableSession(app, .{});
             try app.commitStartupResumeReplayAnchor();
         }
 
         fn resumeRequestedJsHostSession(app: *App) !void {
+            return resumeRequestedJsHostSessionWithNotice(app, .session);
+        }
+
+        fn resumeRequestedJsHostSessionWithNotice(
+            app: *App,
+            notice: ResumeNotice,
+        ) !void {
             var target = app.requested_resume orelse return;
             app.requested_resume = null;
             defer target.deinit(app.alloc);
@@ -1480,7 +1506,7 @@ pub fn Runtime(comptime App: type) type {
                 return;
             };
             defer display.deinit(app.alloc);
-            hydrateResumedSession(app, loaded.state, display.title) catch |err| {
+            hydrateResumedSession(app, loaded.state, display.title, notice) catch |err| {
                 traceJsHostRestoreFailure("hydrate", session_id, err);
                 try continueWithFreshJsHostSession(app);
                 return;
@@ -1558,7 +1584,7 @@ pub fn Runtime(comptime App: type) type {
 
             try app.prepareLiveSessionResume(log_options);
             loaded_owned = false;
-            try installResumedSession(app, &loaded);
+            try installResumedSession(app, &loaded, .session);
             requestSubagentBackgroundRecovery(app);
             startResumedSessionReconciliation(app);
             try app.finishLiveSessionResume();
@@ -1587,6 +1613,7 @@ pub fn Runtime(comptime App: type) type {
         fn installResumedSession(
             app: *App,
             loaded: *session_store.LoadedWritableSession,
+            notice: ResumeNotice,
         ) !void {
             var loaded_owned = true;
             errdefer if (loaded_owned) loaded.deinit(app.alloc);
@@ -1603,7 +1630,7 @@ pub fn Runtime(comptime App: type) type {
                 app.session_persistence.writable = null;
             }
             const active = &app.session_persistence.writable.?;
-            try hydrateResumedSession(app, active.state, display.title);
+            try hydrateResumedSession(app, active.state, display.title, notice);
             active.resume_view_stale = true;
             enableSessionStores(app);
             refreshSubagentProjectionAfterSessionInstall(app);
@@ -1613,6 +1640,7 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             state: session_codec.DurableSessionState,
             display_title: []const u8,
+            notice: ResumeNotice,
         ) !void {
             if (comptime @hasField(App, "next_image_id")) {
                 app.next_image_id = try nextImageIdForResumedHistory(
@@ -1654,7 +1682,7 @@ pub fn Runtime(comptime App: type) type {
                     .app = app,
                     .projection = &projection,
                 };
-                try writeResumedSessionNotice(app, &sink, display_title);
+                try writeResumeNotice(app, &sink, display_title, notice);
                 try replayHistoryToSink(app, &sink, state.history);
                 try writeRecoveryCheckpointToSink(app, &sink, state);
                 const projection_finished_ns = io_mod.nanoTimestamp();
@@ -1674,7 +1702,7 @@ pub fn Runtime(comptime App: type) type {
                 );
             } else {
                 var sink = LiveHistorySink(App){ .app = app };
-                try writeResumedSessionNotice(app, &sink, display_title);
+                try writeResumeNotice(app, &sink, display_title, notice);
                 try replayHistoryToSink(app, &sink, state.history);
                 try writeRecoveryCheckpointToSink(app, &sink, state);
             }
@@ -3257,19 +3285,33 @@ pub fn Runtime(comptime App: type) type {
             return display;
         }
 
-        fn writeResumedSessionNotice(
+        fn writeResumeNotice(
             app: *App,
             sink: anytype,
             display_title: []const u8,
+            notice: ResumeNotice,
         ) !void {
             try setCachedSessionTitle(app, display_title);
-            const notice = try std.fmt.allocPrint(app.alloc, "resumed: {s}", .{display_title});
-            defer app.alloc.free(notice);
-            try sink.appendNotice(.{
-                .topic = "session",
-                .tone = .neutral,
-                .body = notice,
-            });
+            switch (notice) {
+                .session => try sink.appendNotice(.{
+                    .topic = "session resumed",
+                    .tone = .neutral,
+                    .body = display_title,
+                }),
+                .upgrade => |version| {
+                    const body = try std.fmt.allocPrint(
+                        app.alloc,
+                        "𝒇x has been updated to v{s}",
+                        .{version},
+                    );
+                    defer app.alloc.free(body);
+                    try sink.appendNotice(.{
+                        .topic = "",
+                        .tone = .success,
+                        .body = body,
+                    });
+                },
+            }
         }
 
         fn writeRecoveryCheckpointToSink(
@@ -6790,7 +6832,7 @@ test "resume view persistence waits for main frame and retries failed writes" {
     try std.testing.expectEqual(std.Io.File.Kind.file, stat.kind);
 }
 
-test "resumeRequestedSession restores active session and replays history" {
+test "upgrade resume restores active session with the installed version notice" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -6876,7 +6918,7 @@ test "resumeRequestedSession restores active session and replays history" {
     app.requested_resume = .{ .id = try alloc.dupe(u8, "session-1") };
     app.total_web_search_requests = 99;
 
-    try Runtime(TestApp).resumeRequestedSession(&app);
+    try Runtime(TestApp).resumeRequestedSessionAfterUpgrade(&app, "9.9.9");
 
     try std.testing.expect(app.requested_resume == null);
     try std.testing.expectEqual(@as(usize, 1), app.startup_resume_anchor_count);
@@ -6900,7 +6942,7 @@ test "resumeRequestedSession restores active session and replays history" {
     try std.testing.expectEqualStrings("inspect file", context[1].assistant.user.text);
     try std.testing.expectEqualStrings("run server", context[2].background_command.user.text);
     try std.testing.expectEqual(@as(usize, 3), app.notices.items.len);
-    try std.testing.expectEqualStrings("● Session: resumed: hello", app.notices.items[0]);
+    try std.testing.expectEqualStrings("● 𝒇x has been updated to v9.9.9", app.notices.items[0]);
     try std.testing.expect(std.mem.find(u8, app.notices.items[1], "older context") != null);
     try std.testing.expect(std.mem.find(u8, app.notices.items[2], "Re-check runtime context") != null);
     try std.testing.expectEqual(@as(usize, 2), app.completed_tool_statuses.items.len);
@@ -7236,7 +7278,7 @@ test "interactive session resume uses the live transition and shared restore pat
     );
     try std.testing.expectEqual(@as(usize, 1), app.session.historyLen());
     try std.testing.expectEqual(@as(usize, 1), app.notices.items.len);
-    try std.testing.expectEqualStrings("● Session: resumed: saved prompt", app.notices.items[0]);
+    try std.testing.expectEqualStrings("● Session resumed: saved prompt", app.notices.items[0]);
     try std.testing.expect(!app.session_persistence.session_picker.active);
 
     const host = app.session_persistence.subagent_host.?;
@@ -7523,7 +7565,7 @@ test "resumeRequestedSession replays active-tool interruption with live cancella
     try std.testing.expectEqualStrings("inspect the browser", app.cards.items[0].text);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
     try std.testing.expectEqual(@as(usize, 2), app.notices.items.len);
-    try std.testing.expectEqualStrings("● Session: resumed: inspect the browser", app.notices.items[0]);
+    try std.testing.expectEqualStrings("● Session resumed: inspect the browser", app.notices.items[0]);
     try std.testing.expectEqualStrings("● System: cancelled", app.notices.items[1]);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "localhost") == null);
 }

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -81,6 +81,7 @@ const ResumeInvocation = struct {
 };
 
 const resume_id_alias_prefix = "--resume-";
+pub const upgrade_relaunch_arg = "--upgrade-relaunch";
 
 // The one resume alias that asks which session to open. Every other spelling
 // names its target, so it resumes without a prompt.
@@ -119,6 +120,7 @@ pub const LaunchModifiers = struct {
 
 pub const InteractiveLaunch = struct {
     requested_resume: ?ResumeTarget = null,
+    upgrade_relaunch: bool = false,
     record_requested: bool = false,
     modifiers: LaunchModifiers = .{},
 
@@ -523,14 +525,22 @@ pub fn parseInteractiveLaunch(
                 invocation.args[0 .. invocation.args.len - 1]
             else
                 invocation.args;
+            const upgrade_relaunch = !invocation.top_level_alias and
+                resume_args.len == 2 and
+                std.mem.eql(u8, resume_args[1], upgrade_relaunch_arg);
+            const target_args = if (upgrade_relaunch)
+                resume_args[0..1]
+            else
+                resume_args;
             const target = try parseResumeArgs(
                 alloc,
                 command_catalog,
-                resume_args,
+                target_args,
                 invocation.top_level_alias,
             );
             return .{ .interactive = .{
                 .requested_resume = target,
+                .upgrade_relaunch = upgrade_relaunch,
                 .record_requested = record_requested,
                 .modifiers = global_args.takeModifiers(),
             } };

--- a/src/main.zig
+++ b/src/main.zig
@@ -605,7 +605,14 @@ const App = struct {
         app.context_limits.applyCommandLine(launch.modifiers.context_limit_overrides);
         if (comptime host_profile.durable_sessions or host_profile.js_host_sessions) {
             if (app.requested_resume != null) {
-                try SessionAppRuntime.resumeRequestedSession(&app);
+                if (launch.upgrade_relaunch) {
+                    try SessionAppRuntime.resumeRequestedSessionAfterUpgrade(
+                        &app,
+                        app_version,
+                    );
+                } else {
+                    try SessionAppRuntime.resumeRequestedSession(&app);
+                }
                 app.terminalTitle().setModel(app.selected_model.items);
             }
         }

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -5232,7 +5232,7 @@ describe("effect-aware command permissions", () => {
         toolCall("touch must-not-exist"),
         finalText("permission resume denial complete"),
       ]);
-      await resumed.session.waitForText("● Session: resumed", TIMEOUT);
+      await resumed.session.waitForText("● Session resumed", TIMEOUT);
       await resumed.session.waitForText("ask · gpt-5", TIMEOUT);
       await resumed.session.sendText("Create the marker after resuming.");
 
@@ -5252,7 +5252,7 @@ describe("effect-aware command permissions", () => {
 
       const resumedScrollback = await resumed.session.captureFullScrollback();
       expect(resumedScrollback).toContain("permission resume seed complete");
-      expect(resumedScrollback).toContain("● Session: resumed");
+      expect(resumedScrollback).toContain("● Session resumed");
     },
     90_000,
   );

--- a/tests/e2e/tui-cost.test.ts
+++ b/tests/e2e/tui-cost.test.ts
@@ -492,7 +492,7 @@ describe.skipIf(!tmuxAvailable())("tui: durable session cost", () => {
             TIMEOUT,
           );
           await session.sendKeys("Enter");
-          await session.waitForText("● Session: resumed:", TIMEOUT);
+          await session.waitForText("● Session resumed:", TIMEOUT);
         }
 
         await waitForGenerationRequests(gateway, 2);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -3978,7 +3978,7 @@ test.skipIf(!tmuxAvailable())(
 
       await contender.sendKeys("Enter");
       const resumed = await waitForScrollback(contender, savedMarker);
-      expect(resumed).toContain(`● Session: resumed: ${savedTitle}`);
+      expect(resumed).toContain(`● Session resumed: ${savedTitle}`);
       expect(resumed).toContain(savedMarker);
       expect(resumed).not.toContain("SessionBusy");
       await waitForSessionPickerClosed(contender);
@@ -4846,16 +4846,21 @@ test.skipIf(!tmuxAvailable())(
       await fresh.kill();
       fresh = null;
 
+      const version = (await runFx(["--version"])).stdout.trim();
       await active.sendHexBytes(["07"]);
 
-      await active.waitForText("● Session: resumed", TIMEOUT);
+      const updatedNotice = `● 𝒇x has been updated to v${version}`;
+      await active.waitForText(updatedNotice, TIMEOUT);
       const resumed = await waitForScrollback(active, "UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain("UPGRADE_CTRL_G_INITIAL_DONE");
+      expect(resumed).toContain(updatedNotice);
+      expect(resumed).not.toContain("● Session resumed:");
+      expect(resumed).not.toContain("● Session: resumed:");
 
       const argvLines = readFileSync(argvLogPath, "utf8").trim().split("\n");
       expect(argvLines).toEqual([
         installedFx,
-        `${installedFx}\tresume\t${sessionId}`,
+        `${installedFx}\tresume\t${sessionId}\t--upgrade-relaunch`,
       ]);
 
       await active.sendText("Continue after upgrade handoff.");
@@ -4939,9 +4944,10 @@ test.skipIf(!tmuxAvailable())(
         (name) => name.startsWith("commit.") && name.endsWith(".json"),
       )!;
       writeFileSync(join(sessionDir, watermarkName), "{}\n", { mode: 0o600 });
+      const version = (await runFx(["--version"])).stdout.trim();
       await active.sendHexBytes(["07"]);
 
-      await active.waitForText("● Session: resumed", TIMEOUT);
+      await active.waitForText(`● 𝒇x has been updated to v${version}`, TIMEOUT);
       const resumed = await waitForScrollback(
         active,
         "UPGRADE_CORRUPT_INITIAL_DONE",
@@ -4949,7 +4955,9 @@ test.skipIf(!tmuxAvailable())(
       expect(resumed).toContain("UPGRADE_CORRUPT_INITIAL_DONE");
       expect(active.isPaneAlive()).toBe(true);
       const argvLines = readFileSync(argvLogPath, "utf8").trim().split("\n");
-      expect(argvLines).toEqual([`${installedFx}\tresume\t${sessionId}`]);
+      expect(argvLines).toEqual([
+        `${installedFx}\tresume\t${sessionId}\t--upgrade-relaunch`,
+      ]);
 
       await active.sendText("Continue after repaired upgrade handoff.");
       await active.waitForText("UPGRADE_CORRUPT_FOLLOWUP_DONE", TIMEOUT);
@@ -5566,7 +5574,7 @@ test.skipIf(!tmuxAvailable())(
       }
       await active.sendKeys("Enter");
       const resumed = await waitForScrollback(active, workspaceBMarker);
-      expect(resumed).toContain("● Session: resumed: Save the workspace B transcript.");
+      expect(resumed).toContain("● Session resumed: Save the workspace B transcript.");
       expect(resumed).toContain(workspaceBMarker);
       expect(resumed).not.toContain(workspaceAMarker);
       expect(active.isPaneAlive()).toBe(true);
@@ -5877,16 +5885,16 @@ test.skipIf(!tmuxAvailable())(
       );
       await active.sendKeys("Enter");
       const resumed = await waitForSessionPickerClosed(active);
-      expect(resumed).toContain(`● Session: resumed: Save ${savedMarkers[0]!}.`);
+      expect(resumed).toContain(`● Session resumed: Save ${savedMarkers[0]!}.`);
       expect(resumed).toContain(savedMarkers[0]!);
 
       await active.sendText("/resume");
       await waitForSessionPicker(active);
       await active.sendKeys("Escape");
       const afterEscape = await waitForSessionPickerClosed(active);
-      expect(afterEscape).toContain(`● Session: resumed: Save ${savedMarkers[0]!}.`);
+      expect(afterEscape).toContain(`● Session resumed: Save ${savedMarkers[0]!}.`);
       expect(afterEscape).toContain(savedMarkers[0]!);
-      expect(afterEscape).not.toContain(`● Session: resumed: Save ${savedMarkers[10]!}.`);
+      expect(afterEscape).not.toContain(`● Session resumed: Save ${savedMarkers[10]!}.`);
       expect(afterEscape).not.toContain(savedMarkers[10]!);
 
       await active.sendText("/resume");
@@ -5902,7 +5910,7 @@ test.skipIf(!tmuxAvailable())(
       );
       await active.sendKeys("Enter");
       const secondResume = await waitForSessionPickerClosed(active);
-      expect(secondResume).toContain(`● Session: resumed: Save ${savedMarkers[10]!}.`);
+      expect(secondResume).toContain(`● Session resumed: Save ${savedMarkers[10]!}.`);
       expect(active.isPaneAlive()).toBe(true);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
 

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -2987,7 +2987,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
           stderrPath: resumedStderrPath,
         });
         active = session;
-        const resumedRoot = await active.waitForText("● Session: resumed:", TIMEOUT);
+        const resumedRoot = await active.waitForText("● Session resumed:", TIMEOUT);
         expect(resumedRoot).toContain("CHECKPOINT3_PARENT_CREATED_CHILD");
         expect(resumedRoot).not.toContain("ctrl+x manager");
         expect(hasEmptyComposer(resumedRoot)).toBe(true);
@@ -3177,7 +3177,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
           height: 28,
           stderrPath: directStderrPath,
         });
-        const directPane = await direct.waitForText("● Session: resumed:", TIMEOUT);
+        const directPane = await direct.waitForText("● Session resumed:", TIMEOUT);
         expect(hasEmptyComposer(directPane)).toBe(true);
         expect(directPane).not.toContain("Agents & processes");
 
@@ -3443,7 +3443,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
           TIMEOUT,
         );
         await parent.sendKeys("Enter");
-        await parent.waitForText(`● Session: resumed: ${parentPrompt}`, TIMEOUT);
+        await parent.waitForText(`● Session resumed: ${parentPrompt}`, TIMEOUT);
         const recoveryMarker = `background host recovery finished root_id=${parentId}`;
         await parent.waitForPane(
           () => readFileSync(parentTracePath, "utf8").includes(recoveryMarker),


### PR DESCRIPTION
## Summary

- Show `𝒇x has been updated to v<version>` after a Ctrl+G update relaunch.
- Format ordinary session restores as `Session resumed: <title>`.