### PR TITLE
Use GLM 5.2 as the default model

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -37,7 +37,7 @@ const Request = web_search_contract.ProviderRequest;
 const Response = web_search_contract.ProviderResponse;
 const ProgressFn = web_search_contract.ProgressFn;
 
-pub const default_model = "zai/glm-5.2-fast";
+pub const default_model = "zai/glm-5.2";
 pub const default_chat_url = "https://ai-gateway.vercel.sh/v3/ai/language-model";
 pub const models_path = "/v1/models";
 const credits_path = "/v1/credits";
@@ -1583,7 +1583,7 @@ test "possibly sent web search failure marks billing incomplete" {
 }
 
 test "built-in gateway defaults preserve active provider policy" {
-    try std.testing.expectEqualStrings("zai/glm-5.2-fast", default_model);
+    try std.testing.expectEqualStrings("zai/glm-5.2", default_model);
     try std.testing.expectEqualStrings("https://ai-gateway.vercel.sh/v3/ai/language-model", default_chat_url);
     try std.testing.expectEqualStrings("/v1/models", models_path);
     try std.testing.expectEqual(@as(usize, 3), retry_count);


### PR DESCRIPTION
## Summary

- Start new fx sessions with `zai/glm-5.2` instead of `zai/glm-5.2-fast` when no model override is configured.