### PR TITLE
Reset retry pacing across recovery causes

### DIFF
--- a/src/core/agent/runtime/model_response_recovery.zig
+++ b/src/core/agent/runtime/model_response_recovery.zig
@@ -40,6 +40,33 @@ pub const AttemptState = struct {
     }
 };
 
+/// Ephemeral backoff state. AttemptState remains the durable request budget.
+pub const RetryPacingState = union(enum) {
+    idle,
+    implicit: struct {
+        cause: FailureCause,
+        attempt: usize,
+    },
+
+    fn afterFailure(
+        self: RetryPacingState,
+        cause: FailureCause,
+        retry_after_seconds: ?u64,
+    ) RetryPacingState {
+        if (retry_after_seconds != null) return .idle;
+        return switch (self) {
+            .idle => .{ .implicit = .{ .cause = cause, .attempt = 1 } },
+            .implicit => |previous| if (previous.cause == cause)
+                .{ .implicit = .{
+                    .cause = cause,
+                    .attempt = previous.attempt +| 1,
+                } }
+            else
+                .{ .implicit = .{ .cause = cause, .attempt = 1 } },
+        };
+    }
+};
+
 pub const Strategy = enum {
     retry_request,
     continue_response,
@@ -63,6 +90,7 @@ pub const Evidence = struct {
     attempts: AttemptState,
     output: OutputEvidence = .none,
     tool: ToolEvidence = .none,
+    pacing: RetryPacingState = .idle,
     retry_after_seconds: ?u64 = null,
     cancelled: bool = false,
 };
@@ -70,6 +98,7 @@ pub const Evidence = struct {
 pub const Decision = struct {
     strategy: Strategy,
     delay_ns: u64 = 0,
+    next_pacing: RetryPacingState = .idle,
     reserve_provider_attempt: bool = false,
     required_action: RequiredAction = .none,
 };
@@ -112,26 +141,35 @@ pub noinline fn decide(evidence: Evidence) Decision {
         else
             .retry_request,
     };
+    const next_pacing = evidence.pacing.afterFailure(
+        evidence.cause,
+        evidence.retry_after_seconds,
+    );
     const delay_ns = if (evidence.retry_after_seconds) |seconds| blk: {
         const bounded_seconds: u64 = @min(seconds, max_retry_after_seconds);
         break :blk bounded_seconds * std.time.ns_per_s;
-    } else retryDelayNs(evidence.attempts.consumed);
+    } else switch (next_pacing) {
+        .idle => unreachable,
+        .implicit => |pacing| retryDelayNs(pacing.attempt),
+    };
     return .{
         .strategy = strategy,
         .delay_ns = delay_ns,
+        .next_pacing = next_pacing,
         .reserve_provider_attempt = true,
     };
 }
 
-/// Delay before the next provider request after `consumed` attempts: 250 ms,
+/// Delay before the next provider request after `attempt` consecutive implicit
+/// backoffs: 250 ms,
 /// 1 s, then exponential growth capped at 30 s.
-pub fn retryDelayNs(consumed: usize) u64 {
-    if (consumed == 0) return 0;
-    if (consumed == 1) return 250 * std.time.ns_per_ms;
+pub fn retryDelayNs(attempt: usize) u64 {
+    if (attempt == 0) return 0;
+    if (attempt == 1) return 250 * std.time.ns_per_ms;
 
     var seconds: u64 = 1;
-    var attempt: usize = 2;
-    while (attempt < consumed and seconds < max_retry_after_seconds) : (attempt += 1) {
+    var current: usize = 2;
+    while (current < attempt and seconds < max_retry_after_seconds) : (current += 1) {
         seconds = @min(seconds * 2, max_retry_after_seconds);
     }
     return seconds * std.time.ns_per_s;
@@ -326,8 +364,8 @@ test "retry schedule uses the approved cap" {
         30 * std.time.ns_per_s,
     };
     var total: u64 = 0;
-    for (expected, 1..) |delay, consumed| {
-        try std.testing.expectEqual(delay, retryDelayNs(consumed));
+    for (expected, 1..) |delay, attempt| {
+        try std.testing.expectEqual(delay, retryDelayNs(attempt));
         total += delay;
     }
     try std.testing.expectEqual(
@@ -336,14 +374,60 @@ test "retry schedule uses the approved cap" {
     );
 }
 
-test "system resume uses the same evidence sensitive recovery strategy" {
+test "implicit retry pacing is independent from the shared attempt budget" {
+    const first_network = decide(.{
+        .cause = .transport_interrupted,
+        .delivery = .possibly_sent,
+        .attempts = .{ .consumed = 6 },
+    });
+
+    try std.testing.expectEqual(Strategy.retry_request, first_network.strategy);
+    try std.testing.expectEqual(
+        @as(u64, 250 * std.time.ns_per_ms),
+        first_network.delay_ns,
+    );
+
+    const second_network = decide(.{
+        .cause = .transport_interrupted,
+        .delivery = .possibly_sent,
+        .attempts = .{ .consumed = 7 },
+        .pacing = first_network.next_pacing,
+    });
+    try std.testing.expectEqual(
+        @as(u64, std.time.ns_per_s),
+        second_network.delay_ns,
+    );
+
+    const provider_failure = decide(.{
+        .cause = .provider_unavailable,
+        .delivery = .possibly_sent,
+        .attempts = .{ .consumed = 8 },
+        .pacing = second_network.next_pacing,
+    });
+    try std.testing.expectEqual(
+        @as(u64, 250 * std.time.ns_per_ms),
+        provider_failure.delay_ns,
+    );
+
+    const explicitly_timed = decide(.{
+        .cause = .provider_unavailable,
+        .delivery = .possibly_sent,
+        .attempts = .{ .consumed = 9 },
+        .pacing = provider_failure.next_pacing,
+        .retry_after_seconds = 0,
+    });
+    try std.testing.expectEqual(@as(u64, 0), explicitly_timed.delay_ns);
+    try std.testing.expectEqual(RetryPacingState.idle, explicitly_timed.next_pacing);
+}
+
+test "system resume strategy uses independent retry pacing" {
     const retrying = decide(.{
         .cause = .system_resumed,
         .delivery = .definitely_unsent,
         .attempts = .{ .consumed = 4 },
     });
     try std.testing.expectEqual(Strategy.retry_request, retrying.strategy);
-    try std.testing.expectEqual(@as(u64, 4 * std.time.ns_per_s), retrying.delay_ns);
+    try std.testing.expectEqual(@as(u64, 250 * std.time.ns_per_ms), retrying.delay_ns);
     try std.testing.expect(retrying.reserve_provider_attempt);
 
     const continuing = decide(.{

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2185,6 +2185,7 @@ fn processQueuedPromptLoop(
         0
     else
         restored_attempts;
+    var retry_pacing: model_response_recovery.RetryPacingState = .idle;
     var recovery_strategy: ?model_response_recovery.Strategy = if (job.recovery_checkpoint) |checkpoint|
         restoredRecoveryStrategy(checkpoint)
     else
@@ -2602,6 +2603,7 @@ fn processQueuedPromptLoop(
                             .possibly_sent => .possibly_sent,
                         },
                         .attempts = .{ .consumed = consumed_attempts, .limit = semantic_limit },
+                        .pacing = retry_pacing,
                         .output = if (stream_ctx.raw_text.items.len > 0) .partial else .none,
                         .tool = effectiveRecoveryToolEvidence(
                             preserved_tool_evidence,
@@ -2752,6 +2754,7 @@ fn processQueuedPromptLoop(
                     );
                     recovery_strategy = recovery_decision.strategy;
                     recovery_cause = failure_cause;
+                    retry_pacing = recovery_decision.next_pacing;
                     if (recovery_strategy == .regenerate_tool) {
                         recovery_has_unexecuted_tool_start = true;
                     }
@@ -2957,6 +2960,7 @@ fn processQueuedPromptLoop(
                     semantic_attempt += 1;
                     recovery_strategy = .retry_request;
                     recovery_cause = .authentication;
+                    retry_pacing = .idle;
                     reset_stream_for_next_attempt = true;
                     skip_next_preflight_refresh = true;
                     continue;
@@ -2982,6 +2986,7 @@ fn processQueuedPromptLoop(
                     .cause = cause,
                     .delivery = .possibly_sent,
                     .attempts = .{ .consumed = semantic_attempt + 1, .limit = semantic_limit },
+                    .pacing = retry_pacing,
                     .output = if (stream_ctx.raw_text.items.len > 0) .partial else .none,
                     .tool = effectiveRecoveryToolEvidence(
                         preserved_tool_evidence,
@@ -3076,6 +3081,7 @@ fn processQueuedPromptLoop(
                         semantic_attempt += 1;
                         recovery_strategy = decision.strategy;
                         recovery_cause = cause;
+                        retry_pacing = decision.next_pacing;
                         reset_stream_for_next_attempt = true;
                         continue;
                     }
@@ -3147,6 +3153,7 @@ fn processQueuedPromptLoop(
                     .cause = cause,
                     .delivery = .possibly_sent,
                     .attempts = .{ .consumed = semantic_attempt + 1, .limit = semantic_limit },
+                    .pacing = retry_pacing,
                     .output = if (partial_assistant.len > 0) .partial else .none,
                     .tool = effectiveRecoveryToolEvidence(
                         preserved_tool_evidence,
@@ -3257,6 +3264,7 @@ fn processQueuedPromptLoop(
                         semantic_attempt += 1;
                         recovery_strategy = decision.strategy;
                         recovery_cause = cause;
+                        retry_pacing = decision.next_pacing;
                         if (decision.strategy == .regenerate_tool) {
                             recovery_has_unexecuted_tool_start = true;
                         }
@@ -3526,6 +3534,7 @@ fn processQueuedPromptLoop(
         }
         recovery_strategy = null;
         recovery_cause = .transport_interrupted;
+        retry_pacing = .idle;
         preserved_tool_evidence = .none;
 
         if (deps.report_usage) |report_fn| {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -4108,6 +4108,35 @@ test "processQueuedPrompt routes native network failure classes through one hear
     }
 }
 
+test "processQueuedPrompt starts network pacing independently from the shared retry budget" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{
+        .{ .status = .service_unavailable, .retry_after_seconds = 0 },
+        .{ .status = .service_unavailable, .retry_after_seconds = 0 },
+        .{ .status = .service_unavailable, .retry_after_seconds = 0 },
+        .{ .status = .service_unavailable, .retry_after_seconds = 0 },
+        .{ .status = .service_unavailable, .retry_after_seconds = 0 },
+        .{ .stream_error = error.ReadFailed },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    hooks.cancel_on_auto_retry_status = &fixture.cancel_flag;
+    hooks.cancel_on_auto_retry_attempt = 6;
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 6), gateway.request_models.items.len);
+    try std.testing.expectEqual(@as(usize, 6), hooks.route_recovery_statuses.items.len);
+    const network_status = hooks.route_recovery_statuses.items[5];
+    try std.testing.expectEqual(types.RouteRecoveryStatus.Kind.auto_retry, network_status.kind);
+    try std.testing.expectEqual(types.ModelRecoveryCause.network_interrupted, network_status.cause.?);
+    try std.testing.expectEqual(@as(usize, 6), network_status.failed_attempt);
+    try std.testing.expectEqual(@as(u64, 0), network_status.delay_seconds);
+}
+
 test "processQueuedPrompt does not retry opaque JS host stream failures" {
     const alloc = std.testing.allocator;
     const completions = [_]FakeCompletion{.{ .stream_error = error.JsHostStreamFailed }};

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -212,6 +212,7 @@ fn testExecutionAuthorityWithScope(
 pub const FakeCompletion = struct {
     status: std.http.Status = .ok,
     err_body: ?[]const u8 = null,
+    retry_after_seconds: ?u64 = null,
     pre_send_error: ?anyerror = null,
     stream_error: ?anyerror = null,
     stream_error_after_chunks: ?anyerror = null,
@@ -333,6 +334,7 @@ pub const FakeGateway = struct {
             return .{
                 .status = completion.status,
                 .err_body = err_body,
+                .retry_after_seconds = completion.retry_after_seconds,
                 .failure_schema = diagnostics.schema,
                 .failure_request_shape = diagnostics.request_shape,
                 .ownership = .owned,
@@ -582,6 +584,7 @@ pub const FakeAgentRuntimeDeps = struct {
     cancel_on_text: ?*std.atomic.Value(bool) = null,
     cancel_on_text_match: ?[]const u8 = null,
     cancel_on_auto_retry_status: ?*std.atomic.Value(bool) = null,
+    cancel_on_auto_retry_attempt: ?usize = null,
     cancel_on_permission: ?*std.atomic.Value(bool) = null,
     cancel_on_permission_name: ?[]const u8 = null,
     cancel_on_execute: ?*std.atomic.Value(bool) = null,
@@ -1666,7 +1669,13 @@ pub const FakeAgentRuntimeDeps = struct {
         const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
         try self.route_recovery_statuses.append(self.alloc, status);
         if (status.kind == .auto_retry) {
-            if (self.cancel_on_auto_retry_status) |flag| flag.store(true, .seq_cst);
+            if (self.cancel_on_auto_retry_status) |flag| {
+                if (self.cancel_on_auto_retry_attempt == null or
+                    self.cancel_on_auto_retry_attempt.? == status.failed_attempt)
+                {
+                    flag.store(true, .seq_cst);
+                }
+            }
         }
         if (self.pause_on_auto_retry_status and status.kind == .auto_retry) {
             if (self.recovery_pause_flag) |flag| flag.store(true, .seq_cst);

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3151,6 +3151,125 @@ describe("gateway stream lifecycle", () => {
     }
   }, 60_000);
 
+  test("default fx ask starts fresh network pacing after explicitly timed provider retries", async () => {
+    const root = createFixtureRoot("mixed-provider-network-pacing");
+    const tracePath = join(root.root, "trace.log");
+    const expectedOutput = "Recovered after mixed provider and network failures.";
+    const responseBody = await fakeGatewayFinalText(expectedOutput).text();
+    const sockets = new Set<Socket>();
+    let connections = 0;
+    let requests = 0;
+    let socketFailure: Error | undefined;
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+      socket.on("error", (error) => {
+        socketFailure ??= error;
+      });
+      connections += 1;
+      if (connections === 6) {
+        socket.resetAndDestroy();
+        return;
+      }
+
+      let request = Buffer.alloc(0);
+      let requestHandled = false;
+      socket.on("data", (chunk) => {
+        if (requestHandled) return;
+        if (request.length + chunk.length > 1024 * 1024) {
+          socketFailure ??= new Error("mixed retry fixture request exceeded 1 MiB");
+          socket.destroy();
+          return;
+        }
+        request = Buffer.concat([request, chunk]);
+        const headerEnd = request.indexOf("\r\n\r\n");
+        if (headerEnd < 0) return;
+        const headers = request.subarray(0, headerEnd).toString("utf8");
+        const lengthMatch = /\r\ncontent-length:\s*(\d+)/i.exec(`\r\n${headers}`);
+        const contentLength = lengthMatch ? Number.parseInt(lengthMatch[1]!, 10) : 0;
+        if (request.length < headerEnd + 4 + contentLength) return;
+
+        requestHandled = true;
+        requests += 1;
+        if (connections < 6) {
+          const body = JSON.stringify({
+            error: { message: "provider temporarily unavailable" },
+          });
+          socket.end(
+            "HTTP/1.1 503 Service Unavailable\r\n" +
+              "Content-Type: application/json\r\n" +
+              "Retry-After: 0\r\n" +
+              `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+              "Connection: close\r\n\r\n" +
+              body,
+          );
+          return;
+        }
+
+        socket.end(
+          "HTTP/1.1 200 OK\r\n" +
+            "Content-Type: text/event-stream\r\n" +
+            `Content-Length: ${Buffer.byteLength(responseBody)}\r\n` +
+            "Connection: close\r\n\r\n" +
+            responseBody,
+        );
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        throw new Error("missing mixed retry fixture address");
+      }
+      const result = await runFx(
+        ["ask", "--auto", "--no-save", "Recover after mixed provider and network failures."],
+        {
+          cwd: root.workspace,
+          env: {
+            HOME: root.home,
+            AI_GATEWAY_API_KEY: "fake-gateway-lifecycle-key",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_E2E_GATEWAY_CHAT_URL:
+              `http://127.0.0.1:${address.port}/v1/ai/chat/completions`,
+            FX_MODEL: MODEL,
+            FX_TRACE_LOG: tracePath,
+            FX_TRACE_SCOPES: "agent,core,gateway,stream",
+          },
+          timeoutMs: 15_000,
+        },
+      );
+      const trace = readFileSync(tracePath, "utf8");
+
+      expect(result.code).toBe(0);
+      expect(result.signal).toBeNull();
+      expect(result.stdout).toContain(expectedOutput);
+      expect(result.stderr).toContain(
+        "Provider unavailable · retrying request · attempt 5/10",
+      );
+      expect(result.stderr).toContain(
+        "Network interrupted · retrying request · attempt 6/10",
+      );
+      expect(result.stderr).not.toContain("Network interrupted · retrying request in 16s");
+      expect(result.stderr).toContain("recovered · succeeded on attempt 7/10");
+      expect(connections).toBe(7);
+      expect(requests).toBe(6);
+      expect(socketFailure).toBeUndefined();
+      expect(trace).toContain("event=receive_head_error");
+      expect(trace).toContain("provider_attempts=6/10");
+      expect(trace).toContain("recovery=retry_request");
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      if (server.listening) {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   test("default fx ask regenerates an unstarted streamed tool after provider failure", async () => {
     const root = createFixtureRoot("provider-error-tool-start-turn");
     const tracePath = join(root.root, "trace.log");


### PR DESCRIPTION
## Summary

- Keep the ten-attempt recovery budget shared across provider and network failures.
- Restart implicit backoff at 250 ms when recovery changes failure cause.
- Clear implicit backoff after an explicit `Retry-After` response, authentication refresh, or successful request.