### PR TITLE
Show model recovery error details

### DIFF
--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -621,6 +621,7 @@ fn sendPendingRecoveryUpdate(
             .inspect_uncertain_tool
         else
             .continue_later,
+        .diagnostic = types.ModelFailureDiagnostic.forCause(recovery.cause),
     }, true);
     try out.writer.writeByte('}');
     try state.writer.writeNotification(

--- a/src/acp/types.zig
+++ b/src/acp/types.zig
@@ -53,7 +53,7 @@ pub fn writeModelRecoveryInfoUpdate(
         try writer.print(",\"delaySeconds\":{d}", .{recovery.delay_seconds});
     }
     try writer.print(",\"durable\":{s},\"message\":", .{if (durable) "true" else "false"});
-    var label_buf: [256]u8 = undefined;
+    var label_buf: [core_types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;
     try writeJsonStr(recovery.label(&label_buf), writer);
     try writer.writeAll("}}}}");
 }
@@ -345,12 +345,14 @@ test "model recovery info update is structured and clearable" {
         .cause = .system_resumed,
         .action = .paused,
         .required_action = .continue_later,
+        .diagnostic = core_types.ModelFailureDiagnostic.init("ConnectionResetByPeer"),
     }, true);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"state\":\"paused\"") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"cause\":\"system_resumed\"") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"requiredAction\":\"continue_later\"") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"attempt\":4") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"durable\":true") != null);
+    try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "ConnectionResetByPeer") != null);
 
     out.writer.end = 0;
     try writeModelRecoveryInfoUpdate(&out.writer, .{
@@ -360,6 +362,7 @@ test "model recovery info update is structured and clearable" {
     }, true);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"state\":\"recovered\"") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"attempt\":5") != null);
+    try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "ConnectionResetByPeer") == null);
 
     out.writer.end = 0;
     try writeModelRecoveryInfoUpdate(&out.writer, null, false);

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -1705,7 +1705,7 @@ test "built-in credits provider maps Gateway HTTP denial" {
     try std.testing.expect(snapshot.used == null);
     try std.testing.expect(snapshot.plan == null);
     try std.testing.expectEqualStrings(
-        "API access denied · HTTP 403 · Buy credits to use AI Gateway.",
+        "API access denied · HTTP 403 · credit_card_required: Buy credits to use AI Gateway.",
         snapshot.err_message.?,
     );
 }

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -7,7 +7,9 @@ const worker_runtime = @import("../worker_runtime.zig");
 const session_runtime = @import("../../session/session.zig");
 const session_codec = @import("../../session/session_codec.zig");
 const debug_trace = @import("../../shared/debug_trace.zig");
+const gateway_error_format = @import("../../shared/gateway_error_format.zig");
 const mem_utils = @import("../../shared/mem_utils.zig");
+const text_utils = @import("../../shared/text_utils.zig");
 const file_mutation_contract = @import("../../tooling/file_mutation_contract.zig");
 const io_mod = @import("../../shared/io.zig");
 const host_target = @import("../../hosts/target.zig");
@@ -1289,12 +1291,14 @@ fn pushTerminalAutoRetryStatusIfNeeded(
     recovery_active: bool,
     semantic_attempt: usize,
     semantic_limit: usize,
+    diagnostic: types.ModelFailureDiagnostic,
 ) !void {
     if (!recovery_active) return;
     try pushRouteRecoveryStatus(deps, .{
         .kind = .terminal_provider_error,
         .failed_attempt = semantic_attempt + 1,
         .attempt_limit = semantic_limit,
+        .diagnostic = diagnostic,
     });
 }
 
@@ -1379,6 +1383,7 @@ fn pushAutoRetryStatus(
     attempt_limit: usize,
     cause: model_response_recovery.FailureCause,
     decision: model_response_recovery.Decision,
+    diagnostic: types.ModelFailureDiagnostic,
 ) !void {
     try pushRouteRecoveryStatus(deps, .{
         .kind = .auto_retry,
@@ -1404,6 +1409,7 @@ fn pushAutoRetryStatus(
             .stop => null,
         },
         .delay_seconds = decision.delay_ns / std.time.ns_per_s,
+        .diagnostic = diagnostic,
     });
 }
 
@@ -1424,12 +1430,14 @@ fn pushTerminalProviderFailureStatus(
     attempts: usize,
     attempt_limit: usize,
     completion: types.GatewayCompletion,
+    diagnostic: types.ModelFailureDiagnostic,
 ) !void {
     const reason = completion.finish_reason orelse return;
     if (reason == .content_filter) {
         try pushRouteRecoveryStatus(deps, .{
             .kind = .content_filter,
             .required_action = .change_request,
+            .diagnostic = diagnostic,
         });
         return;
     }
@@ -1437,6 +1445,7 @@ fn pushTerminalProviderFailureStatus(
         .kind = .terminal_provider_error,
         .failed_attempt = attempts,
         .attempt_limit = attempt_limit,
+        .diagnostic = diagnostic,
     });
 }
 
@@ -1448,6 +1457,7 @@ fn finishRecoveryPaused(
     consumed_attempts: usize,
     attempt_limit: usize,
     required_action: types.ModelRecoveryRequiredAction,
+    diagnostic: ?types.ModelFailureDiagnostic,
 ) !void {
     try pushRouteRecoveryStatus(deps, .{
         .kind = .terminal_provider_error,
@@ -1456,6 +1466,7 @@ fn finishRecoveryPaused(
         .cause = checkpointCause(cause),
         .action = .paused,
         .required_action = required_action,
+        .diagnostic = diagnostic orelse defaultRecoveryDiagnostic(cause),
     });
     try finalization.finish(.paused, null, null);
     finish_trace.finish("recovery_paused");
@@ -1464,13 +1475,83 @@ fn finishRecoveryPaused(
 fn pushUnsafeNoRetryStatus(
     deps: *const AgentRuntimeDeps,
     reason: types.RouteRecoveryUnsafeReason,
+    diagnostic: types.ModelFailureDiagnostic,
 ) !void {
     try pushRouteRecoveryStatus(deps, .{
         .kind = switch (reason) {
             .assistant_output => .unsafe_assistant_output,
             .tool_start => .unsafe_tool_start,
         },
+        .diagnostic = diagnostic,
     });
+}
+
+fn defaultRecoveryDiagnostic(cause: model_response_recovery.FailureCause) types.ModelFailureDiagnostic {
+    if (cause == .content_filter) return types.ModelFailureDiagnostic.init("content_filter");
+    return types.ModelFailureDiagnostic.forCause(checkpointCause(cause));
+}
+
+fn defaultRecoveryDiagnosticText(cause: model_response_recovery.FailureCause) []const u8 {
+    if (cause == .content_filter) return "content_filter";
+    return types.ModelFailureDiagnostic.defaultTextForCause(checkpointCause(cause));
+}
+
+fn prepareExternalFailureDiagnostic(
+    alloc: Allocator,
+    raw: []const u8,
+    fallback: []const u8,
+) !types.ModelFailureDiagnostic {
+    const trimmed = std.mem.trim(u8, raw, " \t\r\n");
+    const owned_source = if (trimmed.len > 0 and !hasDiagnosticIdentifier(trimmed))
+        try std.fmt.allocPrint(alloc, "{s}: {s}", .{ fallback, trimmed })
+    else
+        null;
+    defer if (owned_source) |source| alloc.free(source);
+    const source = owned_source orelse if (trimmed.len > 0) trimmed else fallback;
+    const masked = try text_utils.maskSecrets(alloc, source);
+    defer if (masked.ptr != source.ptr) alloc.free(masked);
+
+    var encoded = try text_utils.encodeTerminalSafe(
+        alloc,
+        masked,
+        types.ModelFailureDiagnostic.max_bytes,
+    );
+    defer encoded.deinit(alloc);
+    if (encoded.bytes.len == 0) return types.ModelFailureDiagnostic.init(fallback);
+    return types.ModelFailureDiagnostic.init(encoded.bytes);
+}
+
+fn hasDiagnosticIdentifier(text: []const u8) bool {
+    if (std.mem.indexOf(u8, text, ": ")) |separator| {
+        if (separator == 0) return false;
+        return std.mem.indexOfAny(u8, text[0..separator], " \t\r\n") == null;
+    }
+    for (text) |byte| {
+        if (!std.ascii.isAlphanumeric(byte) and byte != '_' and byte != '-' and byte != '.') return false;
+    }
+    return text.len > 0;
+}
+
+fn providerCompletionDiagnostic(
+    alloc: Allocator,
+    completion: types.GatewayCompletion,
+    fallback: []const u8,
+) !types.ModelFailureDiagnostic {
+    return prepareExternalFailureDiagnostic(
+        alloc,
+        completion.provider_failure_detail orelse "",
+        fallback,
+    );
+}
+
+fn httpFailureDiagnostic(
+    alloc: Allocator,
+    status: std.http.Status,
+    detail: []const u8,
+) !types.ModelFailureDiagnostic {
+    const formatted = try gateway_error_format.formatHttpRecoveryDiagnostic(alloc, status, detail);
+    defer alloc.free(formatted);
+    return types.ModelFailureDiagnostic.init(formatted);
 }
 
 fn traceRouteFailure(
@@ -2193,6 +2274,7 @@ fn processQueuedPromptLoop(
         restoredRecoveryCause(checkpoint.cause)
     else
         .transport_interrupted;
+    var latest_recovery_diagnostic: ?types.ModelFailureDiagnostic = null;
     var preserved_tool_evidence: model_response_recovery.ToolEvidence = if (job.recovery_checkpoint) |checkpoint|
         restoredRecoveryToolEvidence(checkpoint.tool_state)
     else
@@ -2331,6 +2413,7 @@ fn processQueuedPromptLoop(
                     semantic_attempt,
                     semantic_limit,
                     pausedRequiredAction(preserved_tool_evidence),
+                    latest_recovery_diagnostic,
                 );
                 return;
             }
@@ -2366,6 +2449,7 @@ fn processQueuedPromptLoop(
                     semantic_attempt,
                     semantic_limit,
                     pausedRequiredAction(preserved_tool_evidence),
+                    defaultRecoveryDiagnostic(.request_limit_reached),
                 );
                 return;
             }
@@ -2552,6 +2636,8 @@ fn processQueuedPromptLoop(
                     }
                 else
                     recovery_cause;
+                const failure_diagnostic = types.ModelFailureDiagnostic.init(@errorName(err));
+                latest_recovery_diagnostic = failure_diagnostic;
                 if (recoveryPauseRequested(config)) {
                     try persistRecoveryCheckpoint(
                         deps,
@@ -2591,6 +2677,7 @@ fn processQueuedPromptLoop(
                             null,
                             &stream_ctx,
                         )),
+                        failure_diagnostic,
                     );
                     return;
                 }
@@ -2680,6 +2767,7 @@ fn processQueuedPromptLoop(
                         semantic_limit,
                         failure_cause,
                         recovery_decision,
+                        failure_diagnostic,
                     );
                 }
                 const delay_completed = !will_auto_retry or waitForRecoveryDelay(
@@ -2725,6 +2813,7 @@ fn processQueuedPromptLoop(
                             null,
                             &stream_ctx,
                         )),
+                        failure_diagnostic,
                     );
                     return;
                 }
@@ -2769,6 +2858,7 @@ fn processQueuedPromptLoop(
                         consumed_attempts,
                         semantic_limit,
                         recoveryRequiredAction(recovery_decision.required_action),
+                        failure_diagnostic,
                     );
                     return;
                 }
@@ -2782,6 +2872,7 @@ fn processQueuedPromptLoop(
                             .kind = .terminal_provider_error,
                             .failed_attempt = semantic_attempt + 1,
                             .attempt_limit = semantic_limit,
+                            .diagnostic = failure_diagnostic,
                         });
                     } else {
                         try pushUnsafeNoRetryStatus(
@@ -2790,6 +2881,7 @@ fn processQueuedPromptLoop(
                                 .tool_start
                             else
                                 .assistant_output,
+                            failure_diagnostic,
                         );
                     }
                 } else if (semantic_attempt > 0) {
@@ -2797,6 +2889,7 @@ fn processQueuedPromptLoop(
                         .kind = .terminal_provider_error,
                         .failed_attempt = semantic_attempt + 1,
                         .attempt_limit = semantic_limit,
+                        .diagnostic = failure_diagnostic,
                     });
                 }
                 try runtime_assistant_stream.flushAssistantStream(&stream_ctx);
@@ -2884,6 +2977,7 @@ fn processQueuedPromptLoop(
                     semantic_attempt + 1,
                     semantic_limit,
                     .inspect_uncertain_tool,
+                    types.ModelFailureDiagnostic.init("UnexpectedToolCallDuringReconciliation"),
                 );
                 return;
             }
@@ -2970,6 +3064,12 @@ fn processQueuedPromptLoop(
                     .rate_limited
                 else
                     .provider_unavailable;
+                const diagnostic = try httpFailureDiagnostic(
+                    arena,
+                    stream_result.status,
+                    stream_result.err_body orelse "",
+                );
+                latest_recovery_diagnostic = diagnostic;
                 const route_changed = disableFastRouteAfterFailure(
                     &route_fast_mode,
                     &gateway_model,
@@ -3026,6 +3126,7 @@ fn processQueuedPromptLoop(
                         semantic_attempt + 1,
                         semantic_limit,
                         recoveryRequiredAction(decision.required_action),
+                        diagnostic,
                     );
                     return;
                 }
@@ -3063,6 +3164,7 @@ fn processQueuedPromptLoop(
                         semantic_limit,
                         cause,
                         decision,
+                        diagnostic,
                     );
                     if (waitForRecoveryDelay(config.cancel_flag, decision.delay_ns)) {
                         preserved_tool_evidence = effectiveRecoveryToolEvidence(
@@ -3132,6 +3234,7 @@ fn processQueuedPromptLoop(
             }
 
             const attempt_disposition = settled_disposition;
+            var attempt_failure_diagnostic: ?types.ModelFailureDiagnostic = null;
             if (stream_result.status == .ok and
                 (attempt_disposition == .interrupted or
                     attempt_disposition == .provider_failure))
@@ -3143,6 +3246,13 @@ fn processQueuedPromptLoop(
                     .content_filter
                 else
                     .provider_unavailable;
+                const diagnostic = try providerCompletionDiagnostic(
+                    arena,
+                    attempt_completion,
+                    defaultRecoveryDiagnosticText(cause),
+                );
+                attempt_failure_diagnostic = diagnostic;
+                latest_recovery_diagnostic = diagnostic;
                 const decision = model_response_recovery.decide(.{
                     .cause = cause,
                     .delivery = .possibly_sent,
@@ -3210,6 +3320,7 @@ fn processQueuedPromptLoop(
                         semantic_attempt + 1,
                         semantic_limit,
                         recoveryRequiredAction(decision.required_action),
+                        diagnostic,
                     );
                     return;
                 }
@@ -3247,6 +3358,7 @@ fn processQueuedPromptLoop(
                         semantic_limit,
                         cause,
                         decision,
+                        diagnostic,
                     );
                     if (waitForRecoveryDelay(config.cancel_flag, decision.delay_ns)) {
                         preserved_tool_evidence = effectiveRecoveryToolEvidence(
@@ -3284,6 +3396,8 @@ fn processQueuedPromptLoop(
             }
             if (stream_result.status == .ok and attempt_disposition == .provider_failure) {
                 const finish_reason = attempt_completion.finish_reason.?;
+                const diagnostic = attempt_failure_diagnostic orelse
+                    try providerCompletionDiagnostic(arena, attempt_completion, finish_reason.label());
                 const replay_safe = providerFailureReplaySafe(attempt_completion, &stream_ctx);
                 debug_trace.eventf("agent", "provider_completion_failed", step_ctx, "finish_reason={s} content_bytes={d} tool_call_count={d}", .{
                     finish_reason.label(),
@@ -3292,14 +3406,30 @@ fn processQueuedPromptLoop(
                 });
                 if (finish_reason == .provider_error) {
                     if (replay_safe) {
-                        try pushTerminalProviderFailureStatus(deps, semantic_attempt + 1, semantic_limit, attempt_completion);
+                        try pushTerminalProviderFailureStatus(
+                            deps,
+                            semantic_attempt + 1,
+                            semantic_limit,
+                            attempt_completion,
+                            diagnostic,
+                        );
                     } else {
-                        try pushUnsafeNoRetryStatus(deps, unsafeNoRetryReason(attempt_completion, &stream_ctx));
+                        try pushUnsafeNoRetryStatus(
+                            deps,
+                            unsafeNoRetryReason(attempt_completion, &stream_ctx),
+                            diagnostic,
+                        );
                     }
                 }
 
                 if (finish_reason == .content_filter) {
-                    try pushTerminalProviderFailureStatus(deps, semantic_attempt + 1, semantic_limit, attempt_completion);
+                    try pushTerminalProviderFailureStatus(
+                        deps,
+                        semantic_attempt + 1,
+                        semantic_limit,
+                        attempt_completion,
+                        diagnostic,
+                    );
                     if (deps.request_route_recovery) |recover| {
                         const decision = try recover(deps.ctx, arena, .{
                             .selected_model = job.model,
@@ -3364,6 +3494,7 @@ fn processQueuedPromptLoop(
                     if (successful_recovery_strategy != null) {
                         try pushAutoRecoveredStatus(deps, semantic_attempt, semantic_limit);
                     }
+                    latest_recovery_diagnostic = null;
                     recovery_strategy = null;
                     recovery_cause = .transport_interrupted;
                     preserved_tool_evidence = .none;
@@ -3455,6 +3586,7 @@ fn processQueuedPromptLoop(
                     successful_recovery_strategy != null,
                     semantic_attempt,
                     semantic_limit,
+                    types.ModelFailureDiagnostic.init("StreamInterrupted"),
                 );
                 debug_trace.eventf("agent", "provider_finish_missing", step_ctx, "content_bytes={d} tool_call_count={d}", .{
                     if (completion.content) |content| content.len else 0,
@@ -3479,6 +3611,7 @@ fn processQueuedPromptLoop(
                     successful_recovery_strategy != null,
                     semantic_attempt,
                     semantic_limit,
+                    types.ModelFailureDiagnostic.init("InvalidProviderCompletion"),
                 );
                 const finish_reason = completion.finish_reason.?;
                 if (completion.tool_calls.len > 0) {
@@ -3499,6 +3632,7 @@ fn processQueuedPromptLoop(
                 successful_recovery_strategy != null,
                 semantic_attempt,
                 semantic_limit,
+                types.ModelFailureDiagnostic.init("RequiredVisionToolCallMissing"),
             );
             debug_trace.eventf(
                 "agent",
@@ -3524,6 +3658,7 @@ fn processQueuedPromptLoop(
         if (successful_recovery_strategy != null) {
             try pushAutoRecoveredStatus(deps, semantic_attempt, semantic_limit);
         }
+        latest_recovery_diagnostic = null;
         recovery_strategy = null;
         recovery_cause = .transport_interrupted;
         preserved_tool_evidence = .none;

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -131,7 +131,7 @@ fn expectRouteStatus(
     try std.testing.expect(index < hooks.route_recovery_statuses.items.len);
     const status = hooks.route_recovery_statuses.items[index];
     try std.testing.expectEqual(kind, status.kind);
-    var label_buf: [128]u8 = undefined;
+    var label_buf: [types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;
     try std.testing.expectEqualStrings(expected_label, status.label(&label_buf));
 }
 
@@ -3510,7 +3510,7 @@ test "processQueuedPrompt reconciles provider error before tool execution" {
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_count);
     try expectBodyContains(&gateway, 1, "\"toolChoice\":{\"type\":\"none\"}");
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Provider unavailable · checking uncertain tool state · attempt 1/2");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error · checking uncertain tool state · attempt 1/2");
     try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
 }
 
@@ -3765,7 +3765,7 @@ test "processQueuedPrompt rejects content filter before tool execution" {
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_count);
     try std.testing.expectEqual(types.ProviderFinishReason.content_filter, hooks.last_route_recovery_finish_reason.?);
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .content_filter, "▲ blocked · content filter");
+    try expectRouteStatus(&hooks, 0, .content_filter, "⚠ blocked · content_filter · content filter");
 }
 
 test "processQueuedPrompt retries replay-safe provider errors before success" {
@@ -3793,9 +3793,34 @@ test "processQueuedPrompt retries replay-safe provider errors before success" {
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "Recovered"));
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Provider unavailable · retrying request · attempt 1/3");
-    try expectRouteStatus(&hooks, 1, .auto_retry, "▲ Provider unavailable · retrying request in 1s · attempt 2/3");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error: route failed once · retrying request · attempt 1/3");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Provider unavailable · provider_error: route failed twice · retrying request in 1s · attempt 2/3");
     try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 3/3");
+}
+
+test "processQueuedPrompt masks and terminal-encodes provider diagnostics" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{.{
+        .finish_reason = .provider_error,
+        .provider_failure_detail = "provider_down: AI_GATEWAY_API_KEY=abcdefghijklmnop bad\x1b[31m",
+    }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.max_provider_attempts = 1;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
+    try expectRouteStatus(
+        &hooks,
+        0,
+        .terminal_provider_error,
+        "⚠ Provider unavailable · provider_down: AI_GATEWAY_API_KEY=[redacted] bad\\x1b[31m · recovery paused after 1/1 attempts",
+    );
 }
 
 test "processQueuedPrompt cancellation during provider backoff finishes interrupted" {
@@ -4010,7 +4035,7 @@ test "processQueuedPrompt retries replay-safe ReadFailed before success" {
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "Recovered"));
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · retrying request · attempt 1/3");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/3");
     try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/3");
 
     const trace = try readTraceFile(alloc, trace_path, 65536);
@@ -4050,7 +4075,7 @@ test "processQueuedPrompt counts and retries a definitely unsent native setup fa
         &hooks,
         0,
         .auto_retry,
-        "▲ Network interrupted · retrying request · attempt 1/2",
+        "⚠ Network interrupted · TlsInitializationFailed · retrying request · attempt 1/2",
     );
     try expectRouteStatus(
         &hooks,
@@ -4336,7 +4361,7 @@ test "processQueuedPrompt counts only failed provider attempts across tool follo
     try std.testing.expect(!checkpoint.outstanding_reservation);
     try std.testing.expectEqual(@as(usize, 1), checkpoint.execution.tool_steps.len);
     try std.testing.expectEqual(types.ModelRecoveryCause.provider_unavailable, checkpoint.cause);
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "▲ Provider unavailable · recovery paused after 2/2 attempts");
+    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Provider unavailable · HTTP 502: gateway unavailable · recovery paused after 2/2 attempts");
 
     var continued_checkpoint = try checkpoint.dupe(alloc);
     defer continued_checkpoint.deinit(alloc);
@@ -4428,7 +4453,7 @@ test "processQueuedPrompt retries system resume through the heartbeat" {
         &hooks,
         0,
         .auto_retry,
-        "▲ Mac woke from sleep · retrying request · attempt 1/2",
+        "⚠ Mac woke from sleep · SystemResumed · retrying request · attempt 1/2",
     );
 }
 
@@ -4548,9 +4573,9 @@ test "processQueuedPrompt pauses replay-safe ReadFailed at attempt limit" {
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
     try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · retrying request · attempt 1/3");
-    try expectRouteStatus(&hooks, 1, .auto_retry, "▲ Network interrupted · retrying request in 1s · attempt 2/3");
-    try expectRouteStatus(&hooks, 2, .terminal_provider_error, "▲ Network interrupted · recovery paused after 3/3 attempts");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/3");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request in 1s · attempt 2/3");
+    try expectRouteStatus(&hooks, 2, .terminal_provider_error, "⚠ Network interrupted · ReadFailed · recovery paused after 3/3 attempts");
 }
 
 test "processQueuedPrompt replaces retry status after a different stream error" {
@@ -4572,8 +4597,8 @@ test "processQueuedPrompt replaces retry status after a different stream error" 
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · retrying request · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "▲ Network interrupted · recovery paused after 2/2 attempts");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/2");
+    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Network interrupted · ConnectionResetByPeer · recovery paused after 2/2 attempts");
 }
 
 test "processQueuedPrompt clears retry status when a replay is cancelled" {
@@ -4595,7 +4620,7 @@ test "processQueuedPrompt clears retry status when a replay is cancelled" {
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · retrying request · attempt 1/3");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/3");
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_clear_count);
     try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
 }
@@ -4619,8 +4644,8 @@ test "processQueuedPrompt replaces retry status when replay finish is missing" {
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · retrying request · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "▲ Response ended early · recovery paused after 2/2 attempts");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/2");
+    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Response ended early · StreamInterrupted · recovery paused after 2/2 attempts");
 }
 
 test "processQueuedPrompt replaces retry status after an invalid replay completion" {
@@ -4645,8 +4670,8 @@ test "processQueuedPrompt replaces retry status after an invalid replay completi
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · retrying request · attempt 1/3");
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "▲ Provider unavailable · recovery paused after 2/3 attempts");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/3");
+    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Provider unavailable · InvalidProviderCompletion · recovery paused after 2/3 attempts");
 }
 
 test "processQueuedPrompt pauses ReadFailed after assistant source is published" {
@@ -4677,7 +4702,7 @@ test "processQueuedPrompt pauses ReadFailed after assistant source is published"
     try std.testing.expectEqual(@as(usize, 1), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .terminal_provider_error, "▲ Network interrupted · recovery paused after 1/1 attempts");
+    try expectRouteStatus(&hooks, 0, .terminal_provider_error, "⚠ Network interrupted · ReadFailed · recovery paused after 1/1 attempts");
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "partial"));
     try std.testing.expectEqual(@as(usize, 0), hooks.history_turns.items.len);
     try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
@@ -4707,7 +4732,7 @@ test "processQueuedPrompt preserves whitespace source bytes in a paused response
     try std.testing.expectEqual(@as(usize, 1), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .terminal_provider_error, "▲ Network interrupted · recovery paused after 1/1 attempts");
+    try expectRouteStatus(&hooks, 0, .terminal_provider_error, "⚠ Network interrupted · ReadFailed · recovery paused after 1/1 attempts");
     try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
 }
 
@@ -4733,7 +4758,7 @@ test "processQueuedPrompt pauses a local tool after assistant source when budget
 
     try std.testing.expectEqual(@as(usize, 1), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
-    try expectRouteStatus(&hooks, 0, .terminal_provider_error, "▲ Network interrupted · recovery paused after 1/1 attempts");
+    try expectRouteStatus(&hooks, 0, .terminal_provider_error, "⚠ Network interrupted · ReadFailed · recovery paused after 1/1 attempts");
     try std.testing.expectEqual(@as(usize, 0), hooks.history_turns.items.len);
     try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
 }
@@ -4802,7 +4827,7 @@ test "processQueuedPrompt regenerates and executes a local tool once after ReadF
     try std.testing.expectEqualStrings("read_file", hooks.executed_names.items[0]);
     try std.testing.expectEqualStrings("call_read_recovered", hooks.executed_call_ids.items[0]);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · regenerating unstarted tool · attempt 1/3");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · regenerating unstarted tool · attempt 1/3");
     try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/3");
     try expectBodyContains(&gateway, 1, "did not execute the incomplete tool call");
     try expectBodyContains(&gateway, 2, "call_read_recovered");
@@ -4838,8 +4863,8 @@ test "processQueuedPrompt settles an interrupted local tool after a different st
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · regenerating unstarted tool · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "▲ Network interrupted · recovery paused after 2/2 attempts");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · regenerating unstarted tool · attempt 1/2");
+    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Network interrupted · ConnectionResetByPeer · recovery paused after 2/2 attempts");
     try expectFailedLifecycleContains(
         hooks.lifecycle_events.items,
         "call_read_interrupted",
@@ -4985,7 +5010,7 @@ test "processQueuedPrompt reconciles ReadFailed after provider-executed tool sta
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Network interrupted · checking uncertain tool state · attempt 1/2");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · checking uncertain tool state · attempt 1/2");
     try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
 }
 
@@ -5018,7 +5043,7 @@ test "processQueuedPrompt continues provider error after visible text without du
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "partial"));
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Provider unavailable · continuing response · attempt 1/2");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error: failed after text · continuing response · attempt 1/2");
     try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
     try std.testing.expectEqualStrings("partial response", hooks.history_turns.items[0].assistant.assistant);
 }
@@ -5050,7 +5075,7 @@ test "processQueuedPrompt recovers provider error after streamed tool start" {
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Provider unavailable · regenerating unstarted tool · attempt 1/2");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error: failed after tool start · regenerating unstarted tool · attempt 1/2");
     try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
 }
 
@@ -5058,7 +5083,7 @@ test "processQueuedPrompt routes content filter to local recovery without replay
     const alloc = std.testing.allocator;
     const completions = [_]FakeCompletion{.{
         .finish_reason = .content_filter,
-        .provider_failure_detail = "filtered",
+        .provider_failure_detail = "content_filter: filtered",
     }};
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
@@ -5080,7 +5105,7 @@ test "processQueuedPrompt routes content filter to local recovery without replay
     try std.testing.expectEqual(types.ProviderFinishReason.content_filter, hooks.last_route_recovery_finish_reason.?);
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .content_filter, "▲ blocked · content filter");
+    try expectRouteStatus(&hooks, 0, .content_filter, "⚠ blocked · content_filter: filtered · content filter");
 }
 
 test "processQueuedPrompt disable Fast recovery retries the same exact model" {
@@ -5129,7 +5154,7 @@ test "processQueuedPrompt disable Fast recovery retries the same exact model" {
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "Recovered without Fast"));
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .auto_retry, "▲ Provider unavailable · retrying request · attempt 1/2");
+    try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error: fast route failed · retrying request · attempt 1/2");
     try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
 }
 
@@ -5153,7 +5178,7 @@ test "processQueuedPrompt exhaustion pauses without invoking route recovery" {
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_count);
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
-    try expectRouteStatus(&hooks, 0, .terminal_provider_error, "▲ Provider unavailable · recovery paused after 1/1 attempts");
+    try expectRouteStatus(&hooks, 0, .terminal_provider_error, "⚠ Provider unavailable · provider_error: route failed · recovery paused after 1/1 attempts");
 }
 
 test "processQueuedPrompt spacer newline is skipped for ask first tool" {

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -1671,7 +1671,7 @@ pub const FakeAgentRuntimeDeps = struct {
         if (self.pause_on_auto_retry_status and status.kind == .auto_retry) {
             if (self.recovery_pause_flag) |flag| flag.store(true, .seq_cst);
         }
-        var label_buf: [128]u8 = undefined;
+        var label_buf: [types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;
         try self.record("route_recovery_status:{s}", .{status.label(&label_buf)});
     }
 

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -925,11 +925,11 @@ pub fn Bindings(comptime App: type) type {
             const label = if (auth_failure != null)
                 try std.fmt.allocPrint(
                     std.heap.c_allocator,
-                    "▲ {s} · Run /setup to choose another source.",
+                    "⚠ {s} · Run /setup to choose another source.",
                     .{message},
                 )
             else
-                try std.fmt.allocPrint(std.heap.c_allocator, "▲ {s}", .{message});
+                try std.fmt.allocPrint(std.heap.c_allocator, "⚠ {s}", .{message});
             defer std.heap.c_allocator.free(label);
             try app_worker_runtime.Runtime(App).pushEvent(app, .{ .api_status_text = label });
         }

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -2210,7 +2210,7 @@ test "core.app_worker_runtime projects route recovery status activity and clears
     switch (app.shell.activityProjection()) {
         .turn_thinking => |thinking| {
             try std.testing.expectEqual(activity_runtime.ActivityProjection.Tone.warning, thinking.tone);
-            try std.testing.expectEqualStrings("▲ Provider unavailable · retrying request · attempt 1/3", thinking.label);
+            try std.testing.expectEqualStrings("⚠ Provider unavailable · retrying request · attempt 1/3", thinking.label);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
@@ -2255,7 +2255,7 @@ test "core.app_worker_runtime clears route recovery activity on clear event but 
     } });
     try tickNoop(&app);
     switch (app.shell.activityProjection()) {
-        .turn_thinking => |thinking| try std.testing.expectEqualStrings("▲ Provider unavailable · recovery paused after 3/3 attempts", thinking.label),
+        .turn_thinking => |thinking| try std.testing.expectEqualStrings("⚠ Provider unavailable · recovery paused after 3/3 attempts", thinking.label),
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
 }
@@ -2286,7 +2286,7 @@ test "core.app_worker_runtime recovery pause replaces cancelled waiting status" 
 
     switch (app.shell.activityProjection()) {
         .turn_thinking => |thinking| try std.testing.expectEqualStrings(
-            "▲ Mac woke from sleep · connection still unavailable · recovery paused · attempt 2/10 · /continue to resume",
+            "⚠ Mac woke from sleep · connection still unavailable · recovery paused · attempt 2/10 · /continue to resume",
             thinking.label,
         ),
         .none, .tool_slot => return error.TestUnexpectedResult,
@@ -2338,13 +2338,13 @@ test "core.app_worker_runtime projects API status text as sticky status row" {
     var app = FakeApp.init(std.testing.allocator);
     defer app.deinit();
 
-    try app.worker.pushEvent(std.heap.c_allocator, .{ .api_status_text = try std.heap.c_allocator.dupe(u8, "▲ API access denied · HTTP 403 · Provider: wafer") });
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .api_status_text = try std.heap.c_allocator.dupe(u8, "⚠ API access denied · HTTP 403 · Provider: wafer") });
     try tickNoop(&app);
 
     switch (app.shell.activityProjection()) {
         .turn_thinking => |thinking| {
             try std.testing.expectEqual(activity_runtime.ActivityProjection.Tone.danger, thinking.tone);
-            try std.testing.expectEqualStrings("▲ API access denied · HTTP 403 · Provider: wafer", thinking.label);
+            try std.testing.expectEqualStrings("⚠ API access denied · HTTP 403 · Provider: wafer", thinking.label);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,
     }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2749,7 +2749,7 @@ fn pushRouteRecoveryStatus(raw_ctx: *anyopaque, status: types.RouteRecoveryStatu
     ctx.last_recovery_status = status;
     const terminal = status.kind == .terminal_provider_error;
     if (ctx.output_mode == .json or (ctx.output_mode == .quiet and !terminal)) return;
-    var label_buf: [128]u8 = undefined;
+    var label_buf: [types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;
     try pushSystemNotice(raw_ctx, status.label(&label_buf));
     if (terminal and ctx.writable == null) {
         try pushSystemNotice(
@@ -3351,7 +3351,7 @@ fn renderFinalJsonResult(alloc: Allocator, result: PromptRunResult) ![]u8 {
         try failure.writeJson(&out.writer);
     }
     if (result.recovery) |recovery| {
-        var label_buf: [256]u8 = undefined;
+        var label_buf: [types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;
         try out.writer.writeAll(",\"recovery\":{\"state\":");
         try std.json.Stringify.value(
             if (recovery.kind == .terminal_provider_error) "paused" else if (recovery.isRecovered()) "recovered" else "active",
@@ -7594,6 +7594,40 @@ test "render final JSON reports the successful recovery attempt" {
     const recovery = parsed.value.object.get("recovery").?.object;
     try std.testing.expectEqual(@as(i64, 3), recovery.get("attempt").?.integer);
     try std.testing.expectEqualStrings("recovered", recovery.get("state").?.string);
+    try std.testing.expectEqualStrings(
+        "✓ recovered · succeeded on attempt 3/10",
+        recovery.get("message").?.string,
+    );
+    try std.testing.expect(std.mem.find(u8, recovery.get("message").?.string, "provider_error") == null);
+}
+
+test "render final JSON includes the latest terminal recovery diagnostic" {
+    const alloc = std.testing.allocator;
+    const result = PromptRunResult{
+        .exit_code = 1,
+        .assistant_output = try alloc.dupe(u8, ""),
+        .recovery = .{
+            .kind = .terminal_provider_error,
+            .failed_attempt = 2,
+            .attempt_limit = 2,
+            .cause = .provider_unavailable,
+            .diagnostic = types.ModelFailureDiagnostic.init(
+                "HTTP 503 · no_available_providers: No providers are currently available",
+            ),
+        },
+    };
+    defer result.deinit(alloc);
+
+    const json = try renderFinalJsonResult(alloc, result);
+    defer alloc.free(json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+    const recovery = parsed.value.object.get("recovery").?.object;
+    try std.testing.expectEqualStrings("paused", recovery.get("state").?.string);
+    try std.testing.expectEqualStrings(
+        "⚠ Provider unavailable · HTTP 503 · no_available_providers: No providers are currently available · recovery paused after 2/2 attempts",
+        recovery.get("message").?.string,
+    );
 }
 
 test "cli json records built in web_search completion" {

--- a/src/core/output/worker_status.zig
+++ b/src/core/output/worker_status.zig
@@ -6,7 +6,7 @@ const recovered_status_visible_ms: i64 = 1_500;
 
 const RouteRecoveryStatus = struct {
     status: types.RouteRecoveryStatus,
-    label: [192]u8 = undefined,
+    label: [types.RouteRecoveryStatus.label_max_bytes + 64]u8 = undefined,
     label_len: usize = 0,
     expires_at_ms: i64 = 0,
 
@@ -18,7 +18,7 @@ const RouteRecoveryStatus = struct {
             else
                 0,
         };
-        var base_buf: [128]u8 = undefined;
+        var base_buf: [types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;
         const label = if (status.isRecovered())
             format_recovered_label(&result.label, status)
         else if (status.action == .waiting_for_connectivity)
@@ -197,7 +197,7 @@ test "worker status projects route recovery and expires recovered state" {
     switch (state.projection().?) {
         .turn_thinking => |projection| {
             try std.testing.expectEqual(activity_runtime.ActivityProjection.Tone.warning, projection.tone);
-            try std.testing.expectEqualStrings("▲ Provider unavailable · retrying request · attempt 1/3", projection.label);
+            try std.testing.expectEqualStrings("⚠ Provider unavailable · retrying request · attempt 1/3", projection.label);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
@@ -214,13 +214,13 @@ test "worker status projects route recovery and expires recovered state" {
 
 test "worker status API state is sticky until explicitly cleared" {
     var state: State = .none;
-    state.set_api("▲ API access denied · HTTP 403 · Provider: wafer", .danger);
+    state.set_api("⚠ API access denied · HTTP 403 · Provider: wafer", .danger);
 
     try std.testing.expect(!state.expire_transient(std.math.maxInt(i64)));
     switch (state.projection().?) {
         .turn_thinking => |projection| {
             try std.testing.expectEqual(activity_runtime.ActivityProjection.Tone.danger, projection.tone);
-            try std.testing.expectEqualStrings("▲ API access denied · HTTP 403 · Provider: wafer", projection.label);
+            try std.testing.expectEqualStrings("⚠ API access denied · HTTP 403 · Provider: wafer", projection.label);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
@@ -239,7 +239,7 @@ test "worker status route recovery labels expose required controls" {
     }, 0);
     switch (state.projection().?) {
         .turn_thinking => |projection| try std.testing.expectEqualStrings(
-            "▲ Mac woke from sleep · waiting for connection · attempt 2/10 · Esc to try later",
+            "⚠ Mac woke from sleep · waiting for connection · attempt 2/10 · Esc to try later",
             projection.label,
         ),
         .none, .tool_slot => return error.TestUnexpectedResult,
@@ -255,7 +255,7 @@ test "worker status route recovery labels expose required controls" {
     }, 0);
     switch (state.projection().?) {
         .turn_thinking => |projection| try std.testing.expectEqualStrings(
-            "▲ Mac woke from sleep · connection still unavailable · recovery paused · attempt 2/10 · /continue to resume",
+            "⚠ Mac woke from sleep · connection still unavailable · recovery paused · attempt 2/10 · /continue to resume",
             projection.label,
         ),
         .none, .tool_slot => return error.TestUnexpectedResult,
@@ -271,7 +271,7 @@ test "worker status route recovery labels expose required controls" {
     }, 0);
     switch (state.projection().?) {
         .turn_thinking => |projection| try std.testing.expectEqualStrings(
-            "▲ Response ended early · recovery paused after 10/10 attempts · inspect tool state before /continue",
+            "⚠ Response ended early · recovery paused after 10/10 attempts · inspect tool state before /continue",
             projection.label,
         ),
         .none, .tool_slot => return error.TestUnexpectedResult,

--- a/src/core/shared/gateway_error_format.zig
+++ b/src/core/shared/gateway_error_format.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
 const display_width = @import("display_width.zig");
+const text_utils = @import("text_utils.zig");
 
 const Allocator = std.mem.Allocator;
+const max_published_error_bytes: usize = 1024;
+const max_recovery_diagnostic_bytes: usize = 600;
 
 pub fn formatSchemaDiagnostic(alloc: Allocator, detail: []const u8) !?[]u8 {
     if (detail.len == 0) return null;
@@ -59,56 +62,84 @@ pub fn formatSchemaDiagnostic(alloc: Allocator, detail: []const u8) !?[]u8 {
 }
 
 pub fn formatHttpErrorMessage(alloc: Allocator, status: std.http.Status, detail: []const u8) ![]u8 {
-    if (detail.len == 0) return std.fmt.allocPrint(alloc, "HTTP {d}", .{@intFromEnum(status)});
-
-    var parsed = std.json.parseFromSlice(std.json.Value, alloc, detail, .{}) catch
-        return formatFallback(alloc, status, detail);
-    defer parsed.deinit();
-
-    const root = objectValue(parsed.value) orelse return formatFallback(alloc, status, detail);
-    const error_value = root.get("error") orelse return formatFallback(alloc, status, detail);
-    const error_object = objectValue(error_value) orelse return formatFallback(alloc, status, detail);
-    const param_object = if (error_object.get("param")) |param_value| objectValue(param_value) else null;
-    const code = stringField(error_object, "code") orelse if (param_object) |param| stringField(param, "name") else null;
-    const message = stringField(error_object, "message") orelse if (param_object) |param| stringField(param, "message") else null;
-    const provider = stringField(error_object, "provider") orelse providerFromGatewayMessage(message);
-
     const status_code = @intFromEnum(status);
     const title = if (status_code == 401 or status_code == 403)
         "API access denied"
     else
         "API request failed";
-    const description: ?[]const u8 = if (message) |message_text|
-        message_text
-    else if (code) |code_text|
-        code_text
-    else
-        null;
+    return formatHttpDiagnostic(alloc, status, detail, title, max_published_error_bytes);
+}
+
+pub fn formatHttpRecoveryDiagnostic(alloc: Allocator, status: std.http.Status, detail: []const u8) ![]u8 {
+    return formatHttpDiagnostic(alloc, status, detail, null, max_recovery_diagnostic_bytes);
+}
+
+fn formatHttpDiagnostic(
+    alloc: Allocator,
+    status: std.http.Status,
+    detail: []const u8,
+    title: ?[]const u8,
+    max_bytes: usize,
+) ![]u8 {
+    if (detail.len == 0) return std.fmt.allocPrint(alloc, "HTTP {d}", .{@intFromEnum(status)});
+
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, detail, .{}) catch
+        return formatFallbackBounded(alloc, status, detail, max_bytes);
+    defer parsed.deinit();
+
+    const root = objectValue(parsed.value) orelse
+        return formatFallbackBounded(alloc, status, detail, max_bytes);
+    const error_value = root.get("error") orelse
+        return formatFallbackBounded(alloc, status, detail, max_bytes);
+    const error_object = objectValue(error_value) orelse
+        return formatFallbackBounded(alloc, status, detail, max_bytes);
+    const param_object = if (error_object.get("param")) |param_value| objectValue(param_value) else null;
+    const code = stringField(error_object, "code") orelse if (param_object) |param| stringField(param, "name") else null;
+    const message = stringField(error_object, "message") orelse if (param_object) |param| stringField(param, "message") else null;
+    const provider = stringField(error_object, "provider") orelse providerFromGatewayMessage(message);
+
+    const raw = try formatParsedHttpMessage(
+        alloc,
+        title,
+        @intFromEnum(status),
+        provider,
+        code,
+        message,
+    );
+    defer alloc.free(raw);
+    return sanitizeExternalText(alloc, raw, max_bytes);
+}
+
+fn formatParsedHttpMessage(
+    alloc: Allocator,
+    title: ?[]const u8,
+    status_code: u16,
+    provider: ?[]const u8,
+    code: ?[]const u8,
+    message: ?[]const u8,
+) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+
+    if (title) |title_text| {
+        try out.writer.print("{s} · ", .{title_text});
+    }
+    try out.writer.print("HTTP {d}", .{status_code});
 
     if (provider) |provider_text| {
-        if (description) |description_text| {
-            return std.fmt.allocPrint(
-                alloc,
-                "{s} · HTTP {d} · Provider: {s} · {s}",
-                .{ title, status_code, provider_text, description_text },
-            );
+        try out.writer.print(" · Provider: {s}", .{provider_text});
+    }
+    if (code) |code_text| {
+        try out.writer.print(" · {s}", .{code_text});
+        if (message) |message_text| {
+            if (!std.mem.eql(u8, code_text, message_text)) {
+                try out.writer.print(": {s}", .{message_text});
+            }
         }
-        return std.fmt.allocPrint(
-            alloc,
-            "{s} · HTTP {d} · Provider: {s}",
-            .{ title, status_code, provider_text },
-        );
+    } else if (message) |message_text| {
+        try out.writer.print(" · {s}", .{message_text});
     }
-
-    if (description) |description_text| {
-        return std.fmt.allocPrint(
-            alloc,
-            "{s} · HTTP {d} · {s}",
-            .{ title, status_code, description_text },
-        );
-    }
-
-    return formatFallback(alloc, status, detail);
+    return out.toOwnedSlice();
 }
 
 pub fn formatMarkedLine(alloc: Allocator, marker_prefix: []const u8, message: []const u8, cols: u16) ![]u8 {
@@ -148,9 +179,24 @@ pub fn formatMarkedLine(alloc: Allocator, marker_prefix: []const u8, message: []
     return try out.toOwnedSlice(alloc);
 }
 
-fn formatFallback(alloc: Allocator, status: std.http.Status, detail: []const u8) ![]u8 {
+fn formatFallbackBounded(
+    alloc: Allocator,
+    status: std.http.Status,
+    detail: []const u8,
+    max_bytes: usize,
+) ![]u8 {
     if (detail.len == 0) return std.fmt.allocPrint(alloc, "HTTP {d}", .{@intFromEnum(status)});
-    return std.fmt.allocPrint(alloc, "HTTP {d}: {s}", .{ @intFromEnum(status), detail });
+    const raw = try std.fmt.allocPrint(alloc, "HTTP {d}: {s}", .{ @intFromEnum(status), detail });
+    defer alloc.free(raw);
+    return sanitizeExternalText(alloc, raw, max_bytes);
+}
+
+fn sanitizeExternalText(alloc: Allocator, raw: []const u8, max_bytes: usize) ![]u8 {
+    const masked = try text_utils.maskSecrets(alloc, raw);
+    defer if (masked.ptr != raw.ptr) alloc.free(masked);
+
+    const encoded = try text_utils.encodeTerminalSafe(alloc, masked, max_bytes);
+    return encoded.bytes;
 }
 
 fn objectValue(value: std.json.Value) ?std.json.ObjectMap {
@@ -312,7 +358,7 @@ test "formatHttpErrorMessage renders restricted provider details without raw JSO
     defer std.testing.allocator.free(line);
 
     try std.testing.expectEqualStrings(
-        "API access denied · HTTP 403 · Provider: wafer · demo account is restricted from provider wafer",
+        "API access denied · HTTP 403 · Provider: wafer · RestrictedProvidersError: demo account is restricted from provider wafer",
         line,
     );
 }
@@ -325,7 +371,7 @@ test "formatHttpErrorMessage renders live restricted provider body shape" {
     defer std.testing.allocator.free(line);
 
     try std.testing.expectEqualStrings(
-        "API access denied · HTTP 403 · Provider: wafer · Your team has restricted access to this provider. Contact the owner of the account for more details. Providers considered: wafer",
+        "API access denied · HTTP 403 · Provider: wafer · RestrictedProvidersError: Your team has restricted access to this provider. Contact the owner of the account for more details. Providers considered: wafer",
         line,
     );
 }
@@ -337,7 +383,7 @@ test "formatHttpErrorMessage renders API key and credits setup bodies" {
     const api_key_line = try formatHttpErrorMessage(std.testing.allocator, .unauthorized, api_key_detail);
     defer std.testing.allocator.free(api_key_line);
     try std.testing.expectEqualStrings(
-        "API access denied · HTTP 401 · Set AI_GATEWAY_API_KEY to use this endpoint.",
+        "API access denied · HTTP 401 · api_key_required: Set AI_GATEWAY_API_KEY to use this endpoint.",
         api_key_line,
     );
 
@@ -347,8 +393,49 @@ test "formatHttpErrorMessage renders API key and credits setup bodies" {
     const credits_line = try formatHttpErrorMessage(std.testing.allocator, .forbidden, credits_detail);
     defer std.testing.allocator.free(credits_line);
     try std.testing.expectEqualStrings(
-        "API access denied · HTTP 403 · Buy credits to use AI Gateway.",
+        "API access denied · HTTP 403 · credit_card_required: Buy credits to use AI Gateway.",
         credits_line,
+    );
+}
+
+test "formatHttpErrorMessage masks structured and fallback secrets" {
+    const alloc = std.testing.allocator;
+    const secret = "abcdefghijklmnop";
+    const structured_detail =
+        \\{"error":{"code":"provider_error","message":"AI_GATEWAY_API_KEY=abcdefghijklmnop"}}
+    ;
+    const structured = try formatHttpErrorMessage(alloc, .service_unavailable, structured_detail);
+    defer alloc.free(structured);
+    try std.testing.expectEqualStrings(
+        "API request failed · HTTP 503 · provider_error: AI_GATEWAY_API_KEY=[redacted]",
+        structured,
+    );
+    try std.testing.expect(std.mem.find(u8, structured, secret) == null);
+
+    const fallback = try formatHttpErrorMessage(
+        alloc,
+        .service_unavailable,
+        "API_KEY=abcdefghijklmnop",
+    );
+    defer alloc.free(fallback);
+    try std.testing.expectEqualStrings("HTTP 503: API_KEY=[redacted]", fallback);
+    try std.testing.expect(std.mem.find(u8, fallback, secret) == null);
+}
+
+test "formatHttpRecoveryDiagnostic keeps status code and provider error identity" {
+    const detail =
+        \\{"error":{"code":"no_available_providers","message":"No providers are currently available","provider":"wafer"}}
+    ;
+    const diagnostic = try formatHttpRecoveryDiagnostic(
+        std.testing.allocator,
+        .service_unavailable,
+        detail,
+    );
+    defer std.testing.allocator.free(diagnostic);
+
+    try std.testing.expectEqualStrings(
+        "HTTP 503 · Provider: wafer · no_available_providers: No providers are currently available",
+        diagnostic,
     );
 }
 

--- a/src/core/shared/gateway_error_format.zig
+++ b/src/core/shared/gateway_error_format.zig
@@ -94,7 +94,9 @@ fn formatHttpDiagnostic(
     const error_object = objectValue(error_value) orelse
         return formatFallbackBounded(alloc, status, detail, max_bytes);
     const param_object = if (error_object.get("param")) |param_value| objectValue(param_value) else null;
-    const code = stringField(error_object, "code") orelse if (param_object) |param| stringField(param, "name") else null;
+    const code = stringField(error_object, "code") orelse
+        stringField(error_object, "type") orelse
+        if (param_object) |param| stringField(param, "name") else null;
     const message = stringField(error_object, "message") orelse if (param_object) |param| stringField(param, "message") else null;
     const provider = stringField(error_object, "provider") orelse providerFromGatewayMessage(message);
 
@@ -371,7 +373,7 @@ test "formatHttpErrorMessage renders live restricted provider body shape" {
     defer std.testing.allocator.free(line);
 
     try std.testing.expectEqualStrings(
-        "API access denied · HTTP 403 · Provider: wafer · RestrictedProvidersError: Your team has restricted access to this provider. Contact the owner of the account for more details. Providers considered: wafer",
+        "API access denied · HTTP 403 · Provider: wafer · no_providers_available: Your team has restricted access to this provider. Contact the owner of the account for more details. Providers considered: wafer",
         line,
     );
 }

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const text_utils = @import("text_utils.zig");
 
 pub const Layout = struct {
     rows: u16,
@@ -236,7 +237,52 @@ pub const ModelRecoveryRequiredAction = enum {
     change_request,
 };
 
+pub const ModelFailureDiagnostic = struct {
+    pub const max_bytes: usize = 256;
+
+    bytes: [max_bytes]u8 = [_]u8{0} ** max_bytes,
+    len: u16 = 0,
+
+    pub fn defaultTextForCause(cause: ModelRecoveryCause) []const u8 {
+        return switch (cause) {
+            .network_interrupted => "NetworkInterrupted",
+            .response_interrupted => "StreamInterrupted",
+            .provider_unavailable => "provider_error",
+            .rate_limited => "HTTP 429",
+            .system_resumed => "SystemResumed",
+            .authentication => "AuthenticationExpired",
+            .request_limit_reached => "ProviderRequestLimitReached",
+        };
+    }
+
+    pub fn forCause(cause: ModelRecoveryCause) ModelFailureDiagnostic {
+        return init(defaultTextForCause(cause));
+    }
+
+    pub fn init(text: []const u8) ModelFailureDiagnostic {
+        var diagnostic: ModelFailureDiagnostic = .{};
+        if (text.len <= max_bytes) {
+            @memcpy(diagnostic.bytes[0..text.len], text);
+            diagnostic.len = @intCast(text.len);
+            return diagnostic;
+        }
+
+        const marker = "...";
+        const prefix = text_utils.utf8PrefixByBytes(text, max_bytes - marker.len);
+        @memcpy(diagnostic.bytes[0..prefix.len], prefix);
+        @memcpy(diagnostic.bytes[prefix.len .. prefix.len + marker.len], marker);
+        diagnostic.len = @intCast(prefix.len + marker.len);
+        return diagnostic;
+    }
+
+    pub fn view(self: *const ModelFailureDiagnostic) []const u8 {
+        return self.bytes[0..self.len];
+    }
+};
+
 pub const RouteRecoveryStatus = struct {
+    pub const label_max_bytes: usize = 512;
+
     pub const Kind = enum {
         auto_retry,
         auto_recovered,
@@ -256,6 +302,7 @@ pub const RouteRecoveryStatus = struct {
     action: ?ModelRecoveryAction = null,
     required_action: ModelRecoveryRequiredAction = .none,
     delay_seconds: u64 = 0,
+    diagnostic: ?ModelFailureDiagnostic = null,
 
     pub fn tone(self: RouteRecoveryStatus) RouteRecoveryStatusTone {
         return switch (self.kind) {
@@ -297,13 +344,48 @@ pub const RouteRecoveryStatus = struct {
                 "✓ recovered · succeeded on attempt {d}/{d}",
                 .{ self.succeeded_attempt, self.attempt_limit },
             ) catch "✓ recovered",
-            .manual_retry_without_fast => "▲ Provider route unavailable · continuing without Fast",
+            .manual_retry_without_fast => self.manualRetryLabel(buf),
             .manual_recovered_without_fast => "✓ recovered · Fast disabled",
             .terminal_provider_error => self.pausedLabel(buf),
-            .unsafe_assistant_output => "▲ Response interrupted · partial output preserved",
-            .unsafe_tool_start => "▲ Tool state needs review · context preserved",
-            .content_filter => "▲ blocked · content filter",
+            .unsafe_assistant_output => self.fixedFailureLabel(
+                buf,
+                "Response interrupted",
+                "partial output preserved",
+            ),
+            .unsafe_tool_start => self.fixedFailureLabel(
+                buf,
+                "Tool state needs review",
+                "context preserved",
+            ),
+            .content_filter => self.fixedFailureLabel(buf, "blocked", "content filter"),
         };
+    }
+
+    fn manualRetryLabel(self: RouteRecoveryStatus, buf: []u8) []const u8 {
+        if (self.diagnostic) |diagnostic| {
+            return std.fmt.bufPrint(
+                buf,
+                "⚠ Provider route unavailable · {s} · continuing without Fast",
+                .{diagnostic.view()},
+            ) catch "⚠ Provider route unavailable · continuing without Fast";
+        }
+        return "⚠ Provider route unavailable · continuing without Fast";
+    }
+
+    fn fixedFailureLabel(
+        self: RouteRecoveryStatus,
+        buf: []u8,
+        cause: []const u8,
+        action: []const u8,
+    ) []const u8 {
+        if (self.diagnostic) |diagnostic| {
+            return std.fmt.bufPrint(
+                buf,
+                "⚠ {s} · {s} · {s}",
+                .{ cause, diagnostic.view(), action },
+            ) catch "⚠ Model response failed";
+        }
+        return std.fmt.bufPrint(buf, "⚠ {s} · {s}", .{ cause, action }) catch "⚠ Model response failed";
     }
 
     fn recoveryLabel(self: RouteRecoveryStatus, buf: []u8) []const u8 {
@@ -326,45 +408,76 @@ pub const RouteRecoveryStatus = struct {
             .paused => "recovery paused",
         };
         if (self.delay_seconds > 0) {
+            if (self.diagnostic) |diagnostic| {
+                return std.fmt.bufPrint(
+                    buf,
+                    "⚠ {s} · {s} · {s} in {d}s · attempt {d}/{d}",
+                    .{ cause, diagnostic.view(), action, self.delay_seconds, self.failed_attempt, self.attempt_limit },
+                ) catch "⚠ Recovering model response";
+            }
             return std.fmt.bufPrint(
                 buf,
-                "▲ {s} · {s} in {d}s · attempt {d}/{d}",
+                "⚠ {s} · {s} in {d}s · attempt {d}/{d}",
                 .{ cause, action, self.delay_seconds, self.failed_attempt, self.attempt_limit },
-            ) catch "▲ Recovering model response";
+            ) catch "⚠ Recovering model response";
+        }
+        if (self.diagnostic) |diagnostic| {
+            return std.fmt.bufPrint(
+                buf,
+                "⚠ {s} · {s} · {s} · attempt {d}/{d}",
+                .{ cause, diagnostic.view(), action, self.failed_attempt, self.attempt_limit },
+            ) catch "⚠ Recovering model response";
         }
         return std.fmt.bufPrint(
             buf,
-            "▲ {s} · {s} · attempt {d}/{d}",
+            "⚠ {s} · {s} · attempt {d}/{d}",
             .{ cause, action, self.failed_attempt, self.attempt_limit },
-        ) catch "▲ Recovering model response";
+        ) catch "⚠ Recovering model response";
     }
 
     fn pausedLabel(self: RouteRecoveryStatus, buf: []u8) []const u8 {
-        const cause = self.cause orelse return std.fmt.bufPrint(
-            buf,
-            "▲ Provider unavailable · recovery paused after {d}/{d} attempts",
-            .{ self.failed_attempt, self.attempt_limit },
-        ) catch "▲ Provider unavailable · recovery paused";
+        const cause = self.cause orelse return self.pausedCauseLabel(buf, "Provider unavailable");
         if (cause == .rate_limited and self.failed_attempt < self.attempt_limit) {
+            if (self.diagnostic) |diagnostic| {
+                return std.fmt.bufPrint(
+                    buf,
+                    "⚠ Rate limited · {s} · server requested a longer wait · recovery paused · attempt {d}/{d}",
+                    .{ diagnostic.view(), self.failed_attempt, self.attempt_limit },
+                ) catch "⚠ Rate limited · recovery paused";
+            }
             return std.fmt.bufPrint(
                 buf,
-                "▲ Rate limited · server requested a longer wait · recovery paused · attempt {d}/{d}",
+                "⚠ Rate limited · server requested a longer wait · recovery paused · attempt {d}/{d}",
                 .{ self.failed_attempt, self.attempt_limit },
-            ) catch "▲ Rate limited · recovery paused";
+            ) catch "⚠ Rate limited · recovery paused";
         }
         if (cause == .system_resumed and self.failed_attempt < self.attempt_limit) {
+            if (self.diagnostic) |diagnostic| {
+                return std.fmt.bufPrint(
+                    buf,
+                    "⚠ Mac woke from sleep · {s} · connection still unavailable · recovery paused · attempt {d}/{d}",
+                    .{ diagnostic.view(), self.failed_attempt, self.attempt_limit },
+                ) catch "⚠ Connection unavailable · recovery paused";
+            }
             return std.fmt.bufPrint(
                 buf,
-                "▲ Mac woke from sleep · connection still unavailable · recovery paused · attempt {d}/{d}",
+                "⚠ Mac woke from sleep · connection still unavailable · recovery paused · attempt {d}/{d}",
                 .{ self.failed_attempt, self.attempt_limit },
-            ) catch "▲ Connection unavailable · recovery paused";
+            ) catch "⚠ Connection unavailable · recovery paused";
         }
         if (cause == .request_limit_reached) {
+            if (self.diagnostic) |diagnostic| {
+                return std.fmt.bufPrint(
+                    buf,
+                    "⚠ Response paused · {s} · {d}/{d} provider-request safety limit reached",
+                    .{ diagnostic.view(), self.failed_attempt, self.attempt_limit },
+                ) catch "⚠ Response paused · provider-request safety limit reached";
+            }
             return std.fmt.bufPrint(
                 buf,
-                "▲ Response paused · {d}/{d} provider-request safety limit reached",
+                "⚠ Response paused · {d}/{d} provider-request safety limit reached",
                 .{ self.failed_attempt, self.attempt_limit },
-            ) catch "▲ Response paused · provider-request safety limit reached";
+            ) catch "⚠ Response paused · provider-request safety limit reached";
         }
         const name = switch (cause) {
             .network_interrupted => "Network interrupted",
@@ -375,11 +488,26 @@ pub const RouteRecoveryStatus = struct {
             .authentication => "Authentication expired",
             .request_limit_reached => unreachable,
         };
+        return self.pausedCauseLabel(buf, name);
+    }
+
+    fn pausedCauseLabel(
+        self: RouteRecoveryStatus,
+        buf: []u8,
+        name: []const u8,
+    ) []const u8 {
+        if (self.diagnostic) |diagnostic| {
+            return std.fmt.bufPrint(
+                buf,
+                "⚠ {s} · {s} · recovery paused after {d}/{d} attempts",
+                .{ name, diagnostic.view(), self.failed_attempt, self.attempt_limit },
+            ) catch "⚠ Model response recovery paused";
+        }
         return std.fmt.bufPrint(
             buf,
-            "▲ {s} · recovery paused after {d}/{d} attempts",
+            "⚠ {s} · recovery paused after {d}/{d} attempts",
             .{ name, self.failed_attempt, self.attempt_limit },
-        ) catch "▲ Model response recovery paused";
+        ) catch "⚠ Model response recovery paused";
     }
 };
 
@@ -395,6 +523,37 @@ test "route recovery reports the attempt owned by its state" {
         .succeeded_attempt = 4,
         .attempt_limit = 10,
     }).reportedAttempt());
+}
+
+test "route recovery label includes a value-owned diagnostic" {
+    var status = RouteRecoveryStatus{
+        .kind = .auto_retry,
+        .failed_attempt = 4,
+        .attempt_limit = 10,
+        .cause = .provider_unavailable,
+        .action = .retrying_request,
+        .delay_seconds = 4,
+        .diagnostic = ModelFailureDiagnostic.init(
+            "HTTP 503 · no_available_providers: No providers are currently available",
+        ),
+    };
+    const copied = status;
+    status.diagnostic = null;
+
+    var label_buf: [RouteRecoveryStatus.label_max_bytes]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "⚠ Provider unavailable · HTTP 503 · no_available_providers: No providers are currently available · retrying request in 4s · attempt 4/10",
+        copied.label(&label_buf),
+    );
+}
+
+test "model failure diagnostic truncation is bounded and utf8 safe" {
+    const long = "provider_error: " ++ ("é" ** 200);
+    const diagnostic = ModelFailureDiagnostic.init(long);
+
+    try std.testing.expect(diagnostic.view().len <= ModelFailureDiagnostic.max_bytes);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(diagnostic.view()));
+    try std.testing.expect(std.mem.endsWith(u8, diagnostic.view(), "..."));
 }
 
 pub const ChatRole = enum {

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -2272,8 +2272,14 @@ fn captureProviderFailureObject(
     alloc: std.mem.Allocator,
     current: *?[]u8,
     object: std.json.ObjectMap,
+    include_type: bool,
 ) !bool {
-    const code = if (object.get("code")) |value| jsonValueString(value) else null;
+    const code = if (object.get("code")) |value|
+        jsonValueString(value)
+    else if (include_type)
+        if (object.get("type")) |value| jsonValueString(value) else null
+    else
+        null;
     const message = if (object.get("message")) |value| jsonValueString(value) else null;
     if (code) |code_text| {
         if (message) |message_text| {
@@ -2302,14 +2308,14 @@ fn captureProviderFailureObject(
 
 fn captureProviderFailureDetail(alloc: std.mem.Allocator, current: *?[]u8, root: std.json.Value) !void {
     if (root != .object or current.* != null) return;
-    if (try captureProviderFailureObject(alloc, current, root.object)) return;
+    if (try captureProviderFailureObject(alloc, current, root.object, false)) return;
     if (root.object.get("error")) |value| {
         if (jsonValueString(value)) |text| {
             try replaceProviderFailureMessage(alloc, current, text);
             return;
         }
         if (value == .object) {
-            if (try captureProviderFailureObject(alloc, current, value.object)) return;
+            if (try captureProviderFailureObject(alloc, current, value.object, true)) return;
             const rendered = try stringifyJsonValueOwned(alloc, value);
             defer alloc.free(rendered);
             try replaceProviderFailureDetail(alloc, current, rendered);
@@ -2320,6 +2326,9 @@ fn captureProviderFailureDetail(alloc: std.mem.Allocator, current: *?[]u8, root:
         if (jsonValueString(value)) |text| {
             try replaceProviderFailureMessage(alloc, current, text);
             return;
+        }
+        if (value == .object) {
+            if (try captureProviderFailureObject(alloc, current, value.object, true)) return;
         }
         const rendered = try stringifyJsonValueOwned(alloc, value);
         defer alloc.free(rendered);
@@ -3478,6 +3487,26 @@ test "captureProviderFailureDetail preserves top-level provider code and message
     try captureProviderFailureDetail(alloc, &detail, parsed.value);
 
     try std.testing.expectEqualStrings("provider_down: wafer route unavailable", detail.?);
+}
+
+test "captureProviderFailureDetail preserves nested provider type and message" {
+    const alloc = std.testing.allocator;
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        "{\"type\":\"error\",\"error\":{\"type\":\"no_available_providers\",\"message\":\"No providers are currently available\"}}",
+        .{},
+    );
+    defer parsed.deinit();
+    var detail: ?[]u8 = null;
+    defer if (detail) |owned| alloc.free(owned);
+
+    try captureProviderFailureDetail(alloc, &detail, parsed.value);
+
+    try std.testing.expectEqualStrings(
+        "no_available_providers: No providers are currently available",
+        detail.?,
+    );
 }
 
 test "consumeSseStream returns immediately after valid finish without waiting for done" {

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -2254,35 +2254,62 @@ fn replaceProviderFailureDetail(alloc: std.mem.Allocator, current: *?[]u8, text:
     current.* = owned;
 }
 
+fn replaceProviderFailureMessage(
+    alloc: std.mem.Allocator,
+    current: *?[]u8,
+    text: []const u8,
+) !void {
+    const combined = try std.fmt.allocPrint(alloc, "provider_error: {s}", .{text});
+    defer alloc.free(combined);
+    try replaceProviderFailureDetail(alloc, current, combined);
+}
+
 fn jsonValueString(value: std.json.Value) ?[]const u8 {
     return if (value == .string and value.string.len > 0) value.string else null;
 }
 
-fn captureProviderFailureDetail(alloc: std.mem.Allocator, current: *?[]u8, root: std.json.Value) !void {
-    if (root != .object or current.* != null) return;
-    const keys = [_][]const u8{ "message", "detail", "details", "code", "reason" };
-    for (&keys) |key| {
-        if (root.object.get(key)) |value| {
+fn captureProviderFailureObject(
+    alloc: std.mem.Allocator,
+    current: *?[]u8,
+    object: std.json.ObjectMap,
+) !bool {
+    const code = if (object.get("code")) |value| jsonValueString(value) else null;
+    const message = if (object.get("message")) |value| jsonValueString(value) else null;
+    if (code) |code_text| {
+        if (message) |message_text| {
+            const combined = try std.fmt.allocPrint(alloc, "{s}: {s}", .{ code_text, message_text });
+            defer alloc.free(combined);
+            try replaceProviderFailureDetail(alloc, current, combined);
+            return true;
+        }
+    }
+
+    const message_keys = [_][]const u8{ "message", "detail", "details", "reason" };
+    for (&message_keys) |key| {
+        if (object.get(key)) |value| {
             if (jsonValueString(value)) |text| {
-                try replaceProviderFailureDetail(alloc, current, text);
-                return;
+                try replaceProviderFailureMessage(alloc, current, text);
+                return true;
             }
         }
     }
+    if (code) |code_text| {
+        try replaceProviderFailureDetail(alloc, current, code_text);
+        return true;
+    }
+    return false;
+}
+
+fn captureProviderFailureDetail(alloc: std.mem.Allocator, current: *?[]u8, root: std.json.Value) !void {
+    if (root != .object or current.* != null) return;
+    if (try captureProviderFailureObject(alloc, current, root.object)) return;
     if (root.object.get("error")) |value| {
         if (jsonValueString(value)) |text| {
-            try replaceProviderFailureDetail(alloc, current, text);
+            try replaceProviderFailureMessage(alloc, current, text);
             return;
         }
         if (value == .object) {
-            for (&keys) |key| {
-                if (value.object.get(key)) |nested| {
-                    if (jsonValueString(nested)) |text| {
-                        try replaceProviderFailureDetail(alloc, current, text);
-                        return;
-                    }
-                }
-            }
+            if (try captureProviderFailureObject(alloc, current, value.object)) return;
             const rendered = try stringifyJsonValueOwned(alloc, value);
             defer alloc.free(rendered);
             try replaceProviderFailureDetail(alloc, current, rendered);
@@ -2291,7 +2318,7 @@ fn captureProviderFailureDetail(alloc: std.mem.Allocator, current: *?[]u8, root:
     }
     if (root.object.get("providerError")) |value| {
         if (jsonValueString(value)) |text| {
-            try replaceProviderFailureDetail(alloc, current, text);
+            try replaceProviderFailureMessage(alloc, current, text);
             return;
         }
         const rendered = try stringifyJsonValueOwned(alloc, value);
@@ -3408,9 +3435,49 @@ test "consumeSseStream preserves provider error detail" {
     defer deinitGatewayCompletion(std.testing.allocator, &completion);
 
     try std.testing.expectEqual(types.ProviderFinishReason.provider_error, completion.finish_reason.?);
-    try std.testing.expectEqualStrings("wafer route unavailable", completion.provider_failure_detail.?);
+    try std.testing.expectEqualStrings("provider_down: wafer route unavailable", completion.provider_failure_detail.?);
     try std.testing.expectEqual(@as(u64, 1), completion.usage.input_tokens.?);
     try std.testing.expectEqual(@as(u64, 1), completion.usage.output_tokens.?);
+}
+
+test "consumeSseStream assigns a fallback identity to message-only provider errors" {
+    const payload =
+        "data: {\"type\":\"error\",\"message\":\"wafer route unavailable\"}\n" ++
+        "\n" ++
+        "data: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"error\",\"raw\":\"provider_error\"}}\n" ++
+        "\n";
+
+    var reader = std.Io.Reader.fixed(payload);
+    var cancel_flag = std.atomic.Value(bool).init(false);
+
+    const Noop = struct {
+        fn chunk(_: *anyopaque, _: []const u8) void {}
+    };
+
+    var completion = try consumeSseStream(std.testing.allocator, &reader, undefined, Noop.chunk, null, &cancel_flag);
+    defer deinitGatewayCompletion(std.testing.allocator, &completion);
+
+    try std.testing.expectEqualStrings(
+        "provider_error: wafer route unavailable",
+        completion.provider_failure_detail.?,
+    );
+}
+
+test "captureProviderFailureDetail preserves top-level provider code and message" {
+    const alloc = std.testing.allocator;
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        "{\"code\":\"provider_down\",\"message\":\"wafer route unavailable\"}",
+        .{},
+    );
+    defer parsed.deinit();
+    var detail: ?[]u8 = null;
+    defer if (detail) |owned| alloc.free(owned);
+
+    try captureProviderFailureDetail(alloc, &detail, parsed.value);
+
+    try std.testing.expectEqualStrings("provider_down: wafer route unavailable", detail.?);
 }
 
 test "consumeSseStream returns immediately after valid finish without waiting for done" {

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -884,7 +884,7 @@ test "frame-owned activity preserves route recovery status tone" {
         .selected_subagent_label = null,
         .selected_subagent_status = null,
         .activity = .{ .turn_thinking = .{
-            .label = "▲ API error · attempt 1/3 failed · retrying",
+            .label = "⚠ API error · attempt 1/3 failed · retrying",
             .tone = .warning,
         } },
         .input = &input,
@@ -894,7 +894,7 @@ test "frame-owned activity preserves route recovery status tone" {
     switch (frameOwnedActivityProjection(&active_buf, &shell, ctx, null)) {
         .turn_thinking => |thinking| {
             try std.testing.expectEqual(ActivityProjection.Tone.warning, thinking.tone);
-            try std.testing.expectEqualStrings("▲ API error · attempt 1/3 failed · retrying", thinking.label);
+            try std.testing.expectEqualStrings("⚠ API error · attempt 1/3 failed · retrying", thinking.label);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
@@ -988,7 +988,7 @@ test "frame-owned activity shows live streaming token progress" {
 }
 
 test "static turn status reserves wrapped activity rows" {
-    const label = "▲ API access denied · HTTP 403 · Provider: wafer · Your team has restricted access to this provider. Contact the owner of the account.";
+    const label = "⚠ API access denied · HTTP 403 · Provider: wafer · Your team has restricted access to this provider. Contact the owner of the account.";
     const projection: ActivityProjection = .{ .turn_thinking = .{
         .label = label,
         .tone = .danger,
@@ -1004,7 +1004,7 @@ test "static turn status reserves wrapped activity rows" {
 }
 
 test "static turn status wraps at word boundaries" {
-    const label = "▲ aaaaaaaa bbbbbbbbbbb";
+    const label = "⚠ aaaaaaaa bbbbbbbbbbb";
     const projection: ActivityProjection = .{ .turn_thinking = .{
         .label = label,
         .tone = .danger,

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -1447,7 +1447,7 @@ test "surface footer measurement preserves route recovery status tone" {
         .selected_subagent_label = null,
         .selected_subagent_status = null,
         .activity = .{ .turn_thinking = .{
-            .label = "▲ blocked · content filter",
+            .label = "⚠ blocked · content filter",
             .tone = .danger,
         } },
         .input = &input,
@@ -1460,7 +1460,7 @@ test "surface footer measurement preserves route recovery status tone" {
     switch (measurement.activity_projection) {
         .turn_thinking => |thinking| {
             try std.testing.expectEqual(ActivityProjection.Tone.danger, thinking.tone);
-            try std.testing.expectEqualStrings("▲ blocked · content filter", thinking.label);
+            try std.testing.expectEqualStrings("⚠ blocked · content filter", thinking.label);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,
     }

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -650,7 +650,7 @@ test "appendTurnSummaryEntry leaves terminal route status visible" {
     });
 
     switch (runtime.activityProjection()) {
-        .turn_thinking => |thinking| try std.testing.expectEqualStrings("▲ blocked · content filter", thinking.label),
+        .turn_thinking => |thinking| try std.testing.expectEqualStrings("⚠ blocked · content filter", thinking.label),
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
     try std.testing.expect(std.mem.find(u8, runtime.entries.items[0].raw_bytes.bytes, "  2m 10s (↑10k ↓5k)") != null);

--- a/src/ui/transcript/shimmer_runtime.zig
+++ b/src/ui/transcript/shimmer_runtime.zig
@@ -317,11 +317,11 @@ fn writeStaticStyledText(out: []u8, label: []const u8, style: []const u8) []cons
 
 test "activity status styles paint static colored text" {
     var buf: [128]u8 = undefined;
-    const result = writeStaticStyledText(&buf, "▲ API error", ui_render.warning_style);
+    const result = writeStaticStyledText(&buf, "⚠ API error", ui_render.warning_style);
     var expected_buf: [128]u8 = undefined;
     const expected = std.fmt.bufPrint(
         &expected_buf,
-        "{s}▲ API error{s}",
+        "{s}⚠ API error{s}",
         .{ ui_render.warning_style, ui_render.reset_style },
     ) catch return error.TestUnexpectedResult;
     try std.testing.expectEqualStrings(expected, result);
@@ -524,14 +524,14 @@ test "activity surface painter wraps static status labels under marker" {
     defer fixtures.shadow.deinit();
 
     const result = try paintActivityIntoSurface(&fixtures.surface, .{
-        .label = "▲ API access denied · HTTP 403 · Provider: wafer · Your team has restricted access to this provider. Contact the owner of the account.",
+        .label = "⚠ API access denied · HTTP 403 · Provider: wafer · Your team has restricted access to this provider. Contact the owner of the account.",
         .shimmer_pos = -8,
         .style = .danger,
     });
 
     try std.testing.expect(result.painted);
     try std.testing.expectEqual(@as(u16, 3), result.row);
-    try std.testing.expectEqual(@as(u21, '▲'), fixtures.surface.cellAt(3, 1).?.codepoint);
+    try std.testing.expectEqual(@as(u21, '⚠'), fixtures.surface.cellAt(3, 1).?.codepoint);
     try std.testing.expectEqual(@as(u21, ' '), fixtures.surface.cellAt(4, 1).?.codepoint);
     try std.testing.expectEqual(@as(u21, ' '), fixtures.surface.cellAt(4, 2).?.codepoint);
     try std.testing.expect(fixtures.surface.cellAt(4, 3).?.codepoint != ' ');
@@ -551,13 +551,13 @@ test "activity surface painter breaks static status rows at word boundaries" {
     defer fixtures.shadow.deinit();
 
     const result = try paintActivityIntoSurface(&fixtures.surface, .{
-        .label = "▲ aaaaaa bbbb",
+        .label = "⚠ aaaaaa bbbb",
         .shimmer_pos = -8,
         .style = .danger,
     });
 
     try std.testing.expect(result.painted);
-    try std.testing.expectEqual(@as(u21, '▲'), fixtures.surface.cellAt(3, 1).?.codepoint);
+    try std.testing.expectEqual(@as(u21, '⚠'), fixtures.surface.cellAt(3, 1).?.codepoint);
     try std.testing.expectEqual(@as(u21, 'a'), fixtures.surface.cellAt(3, 8).?.codepoint);
     try std.testing.expectEqual(@as(u21, ' '), fixtures.surface.cellAt(3, 10).?.codepoint);
     try std.testing.expectEqual(@as(u21, ' '), fixtures.surface.cellAt(4, 2).?.codepoint);

--- a/src/ui/transcript/shimmer_runtime.zig
+++ b/src/ui/transcript/shimmer_runtime.zig
@@ -113,18 +113,12 @@ fn wrappedStaticActivityLabel(
         const available = if (safe_cols > indent_width) safe_cols - indent_width else 1;
         const last_row = row_count + 1 == max_rows;
         var chunk: []const u8 = undefined;
-        if (last_row) {
+        if (last_row and display_width.visibleWidthIgnoringAnsi(remaining) > available) {
             const marker = omissionMarker(@intCast(@min(available, std.math.maxInt(u16))));
-            const chunk_width = if (available > marker.len) available - marker.len else 0;
-            chunk = display_width.wrapCutIgnoringAnsi(remaining, chunk_width);
-            if (chunk.len == 0 and remaining.len > 0 and chunk_width > 0) {
-                const unit = display_width.displayUnitAt(remaining, 0);
-                chunk = remaining[0..unit.byte_len];
-            }
-            try appendStaticActivityLine(alloc, &out, prefix, continuation_indent_width, chunk, first);
-            if (display_width.trimBreakWhitespace(remaining[chunk.len..]).len > 0 and marker.len > 0) {
-                try out.appendSlice(alloc, marker);
-            }
+            const suffix_width = available -| marker.len;
+            const suffix = display_width.suffixByWidthIgnoringAnsi(remaining, suffix_width);
+            try appendStaticActivityLine(alloc, &out, prefix, continuation_indent_width, marker, first);
+            try out.appendSlice(alloc, suffix);
             remaining = "";
         } else {
             chunk = display_width.wrapCutIgnoringAnsi(remaining, available);
@@ -538,6 +532,29 @@ test "activity surface painter wraps static status labels under marker" {
     try std.testing.expectEqual(paint_plan.CellOwner.activity, fixtures.surface.cellAt(5, 1).?.owner);
     try std.testing.expectEqual(paint_plan.CellOwner.footer, fixtures.surface.cellAt(6, 1).?.owner);
     try fixtures.surface.validate();
+}
+
+test "static status truncation preserves recovery action and attempt suffix" {
+    const preview = try wrappedStaticActivityLabel(
+        std.testing.allocator,
+        "⚠ Provider unavailable · no_available_providers: No providers are currently available · retrying request in 4s · attempt 4/10",
+        32,
+        3,
+    );
+    defer preview.deinit(std.testing.allocator);
+
+    try std.testing.expect(std.mem.startsWith(u8, preview.bytes, "⚠ Provider unavailable ·"));
+    try std.testing.expect(std.mem.indexOf(u8, preview.bytes, "no_available_providers:") != null);
+    try std.testing.expect(std.mem.indexOf(u8, preview.bytes, "...") != null);
+    try std.testing.expect(std.mem.endsWith(u8, preview.bytes, "attempt 4/10"));
+
+    var lines = std.mem.splitScalar(u8, preview.bytes, '\n');
+    var line_count: usize = 0;
+    while (lines.next()) |line| {
+        line_count += 1;
+        try std.testing.expect(display_width.visibleWidthIgnoringAnsi(line) <= 32);
+    }
+    try std.testing.expectEqual(@as(usize, 3), line_count);
 }
 
 test "activity surface painter breaks static status rows at word boundaries" {

--- a/src/ui/transcript/shimmer_runtime.zig
+++ b/src/ui/transcript/shimmer_runtime.zig
@@ -91,6 +91,7 @@ fn wrappedStaticActivityLabel(
     label: []const u8,
     cols: u16,
     max_rows: u16,
+    preserve_trailing_context: bool,
 ) !ActivityLabelPreview {
     const row = activityRowLabel(label);
     if (max_rows <= 1 or display_width.visibleWidthIgnoringAnsi(row) <= cols) {
@@ -112,16 +113,25 @@ fn wrappedStaticActivityLabel(
         const indent_width = if (first) prefix_width else continuation_indent_width;
         const available = if (safe_cols > indent_width) safe_cols - indent_width else 1;
         const last_row = row_count + 1 == max_rows;
-        var chunk: []const u8 = undefined;
         if (last_row and display_width.visibleWidthIgnoringAnsi(remaining) > available) {
             const marker = omissionMarker(@intCast(@min(available, std.math.maxInt(u16))));
-            const suffix_width = available -| marker.len;
-            const suffix = display_width.suffixByWidthIgnoringAnsi(remaining, suffix_width);
-            try appendStaticActivityLine(alloc, &out, prefix, continuation_indent_width, marker, first);
-            try out.appendSlice(alloc, suffix);
+            const content_width = available -| marker.len;
+            if (preserve_trailing_context) {
+                const suffix = display_width.suffixByWidthIgnoringAnsi(remaining, content_width);
+                try appendStaticActivityLine(alloc, &out, prefix, continuation_indent_width, marker, first);
+                try out.appendSlice(alloc, suffix);
+            } else {
+                var chunk = display_width.wrapCutIgnoringAnsi(remaining, content_width);
+                if (chunk.len == 0 and content_width > 0) {
+                    const unit = display_width.displayUnitAt(remaining, 0);
+                    chunk = remaining[0..unit.byte_len];
+                }
+                try appendStaticActivityLine(alloc, &out, prefix, continuation_indent_width, chunk, first);
+                try out.appendSlice(alloc, marker);
+            }
             remaining = "";
         } else {
-            chunk = display_width.wrapCutIgnoringAnsi(remaining, available);
+            var chunk = display_width.wrapCutIgnoringAnsi(remaining, available);
             if (chunk.len == 0) {
                 const unit = display_width.displayUnitAt(remaining, 0);
                 chunk = remaining[0..unit.byte_len];
@@ -189,8 +199,18 @@ fn paintPlannedActivityRow(
         .neutral, .warning, .success, .danger => true,
         .thinking, .tool_marker => false,
     };
+    const preserve_trailing_context = switch (input.style) {
+        .warning, .danger => true,
+        .thinking, .tool_marker, .neutral, .success => false,
+    };
     const preview = if (static_status)
-        try wrappedStaticActivityLabel(surface.alloc, input.label, surface.cols, max_rows)
+        try wrappedStaticActivityLabel(
+            surface.alloc,
+            input.label,
+            surface.cols,
+            max_rows,
+            preserve_trailing_context,
+        )
     else
         try previewActivityRowLabel(surface.alloc, input.label, surface.cols);
     defer preview.deinit(surface.alloc);
@@ -540,6 +560,7 @@ test "static status truncation preserves recovery action and attempt suffix" {
         "⚠ Provider unavailable · no_available_providers: No providers are currently available · retrying request in 4s · attempt 4/10",
         32,
         3,
+        true,
     );
     defer preview.deinit(std.testing.allocator);
 
@@ -555,6 +576,21 @@ test "static status truncation preserves recovery action and attempt suffix" {
         try std.testing.expect(display_width.visibleWidthIgnoringAnsi(line) <= 32);
     }
     try std.testing.expectEqual(@as(usize, 3), line_count);
+}
+
+test "static status truncation preserves leading context for non-error statuses" {
+    const preview = try wrappedStaticActivityLabel(
+        std.testing.allocator,
+        "✓ Recovered · resumed after provider retry · later details are omitted",
+        24,
+        2,
+        false,
+    );
+    defer preview.deinit(std.testing.allocator);
+
+    try std.testing.expect(std.mem.startsWith(u8, preview.bytes, "✓ Recovered · resumed"));
+    try std.testing.expect(std.mem.endsWith(u8, preview.bytes, "..."));
+    try std.testing.expect(std.mem.indexOf(u8, preview.bytes, "later details") == null);
 }
 
 test "activity surface painter breaks static status rows at word boundaries" {

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -1109,12 +1109,18 @@ describe("acp: model-independent", () => {
         expect(pausedUpdates).toContain("modelResponseRecovery");
         expect(pausedUpdates).toContain('"state":"paused"');
         expect(pausedUpdates).toContain('"durable":true');
+        expect(pausedUpdates).toContain(
+          "HTTP 503 · provider temporarily unavailable",
+        );
         expect(pausedUpdates).toContain(partialText);
 
         const resumed = await continueRecovery(client, TIMEOUT);
         expect(resumed.promptResult.error).toBeUndefined();
         expect(resumed.promptResult.result.stopReason).toBe("end_turn");
         expect(gateway.requests).toHaveLength(11);
+        const resumedUpdates = JSON.stringify(resumed.messages);
+        expect(resumedUpdates).toContain('"state":"recovered"');
+        expect(resumedUpdates).not.toContain("provider temporarily unavailable");
         expect(gateway.requests[10]!.body).toContain(
           "Preserve this ACP prompt through recovery.",
         );

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3017,8 +3017,8 @@ describe("gateway stream lifecycle", () => {
       const trace = readFileSync(tracePath, "utf8");
 
       expect(result.code).toBe(0);
-      expect(result.stderr).toContain("Provider unavailable · retrying request · attempt 1/10");
-      expect(result.stderr).toContain("Provider unavailable · retrying request in 1s · attempt 2/10");
+      expect(result.stderr).toContain("Provider unavailable · provider_error: turn route failure one · retrying request · attempt 1/10");
+      expect(result.stderr).toContain("Provider unavailable · provider_error: turn route failure two · retrying request in 1s · attempt 2/10");
       expect(result.stderr).toContain("recovered · succeeded on attempt 3/10");
       expect(result.stdout).toContain("Recovered in ask turn.");
       expect(gateway.requestCount()).toBe(3);
@@ -3028,8 +3028,8 @@ describe("gateway stream lifecycle", () => {
       expect(trace).toContain("semantic_attempt=1/10");
       expect(trace).toContain("semantic_attempt=2/10");
       expect(trace).toContain("retry=true");
-      expect(trace).toContain("detail=turn route failure one");
-      expect(trace).toContain("detail=turn route failure two");
+      expect(trace).toContain("detail=provider_error: turn route failure one");
+      expect(trace).toContain("detail=provider_error: turn route failure two");
     } finally {
       gateway.stop();
       rmSync(root.root, { recursive: true, force: true });
@@ -4242,9 +4242,11 @@ describe("gateway stream lifecycle", () => {
       expect(result.code).toBe(0);
       expect(json.exit_code).toBe(0);
       expect(json.output).toContain("Recovered after route retry.");
-      expect(json.output).not.toContain("▲ API error");
+      expect(json.output).not.toContain("⚠ API error");
       expect(json.recovery?.state).toBe("recovered");
       expect(json.recovery?.attempt).toBe(3);
+      expect(json.recovery?.message).not.toContain("provider_error");
+      expect(json.recovery?.message).not.toContain("first route failure");
       expect(result.stderr).toBe("");
       expect(gateway.requestCount()).toBe(3);
       expect(trace).toContain("event=route_failure");
@@ -4253,8 +4255,8 @@ describe("gateway stream lifecycle", () => {
       expect(trace).toContain("semantic_attempt=1/10");
       expect(trace).toContain("semantic_attempt=2/10");
       expect(trace).toContain("retry=true");
-      expect(trace).toContain("detail=first route failure");
-      expect(trace).toContain("detail=second route failure");
+      expect(trace).toContain("detail=provider_error: first route failure");
+      expect(trace).toContain("detail=provider_error: second route failure");
     } finally {
       gateway.stop();
       rmSync(root.root, { recursive: true, force: true });
@@ -4285,6 +4287,9 @@ describe("gateway stream lifecycle", () => {
       expect(json.recovery?.attempt_limit).toBe(10);
       expect(json.recovery?.required_action).toBe("continue_later");
       expect(json.recovery?.durable).toBe(true);
+      expect(json.recovery?.message).toContain(
+        "HTTP 503 · provider temporarily unavailable",
+      );
       expect(result.stderr).toBe("");
     } finally {
       gateway.stop();
@@ -4319,6 +4324,9 @@ describe("gateway stream lifecycle", () => {
       expect(paused.recovery?.attempt_limit).toBe(10);
       expect(paused.recovery?.required_action).toBe("continue_later");
       expect(paused.recovery?.durable).toBe(true);
+      expect(paused.recovery?.message).toContain(
+        "HTTP 503 · provider temporarily unavailable",
+      );
 
       const detail = await runFx(
         ["session", "--id", paused.session_id, "--json"],
@@ -4406,6 +4414,10 @@ describe("gateway stream lifecycle", () => {
       const recovered = parseAskJson(resumed.stdout);
       expect(resumed.code).toBe(0);
       expect(recovered.output).toBe(`${partialText}${finalText}`);
+      expect(recovered.recovery?.state).toBe("recovered");
+      expect(recovered.recovery?.message).not.toContain(
+        "provider temporarily unavailable",
+      );
       expect(gateway.requestCount()).toBe(11);
     } finally {
       gateway.stop();
@@ -4432,6 +4444,9 @@ describe("gateway stream lifecycle", () => {
       expect(result.code).toBe(1);
       expect(json.exit_code).toBe(1);
       expect(json.error).toBe("ModelError");
+      expect(json.recovery?.message).toContain(
+        "⚠ blocked · content_filter · content filter",
+      );
       expect(gateway.requestCount()).toBe(1);
       expect(result.stderr).toBe("");
       expect(trace).toContain("event=route_failure");

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -1630,19 +1630,19 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       await session!.sendText("Trigger restricted provider.");
       await session!.waitForText(
-        "▲ API access denied · HTTP 403 · Provider: wafer",
+        "⚠ API access denied · HTTP 403 · Provider: wafer",
         TIMEOUT,
       );
       const scrollback = await session!.captureFullScrollback();
 
       expect(queuedGateway.requests.length).toBe(1);
       expect(scrollback).toContain(
-        "▲ API access denied · HTTP 403 · Provider: wafer",
+        "⚠ API access denied · HTTP 403 · Provider: wafer",
       );
       expect(scrollback).toContain(
-        "  restricted access to this provider. Contact the owner of the account",
+        "RestrictedProvidersError: Your team has restricted access to this",
       );
-      expect(scrollback).not.toContain("RestrictedProvidersError");
+      expect(scrollback).toContain("RestrictedProvidersError");
       expect(scrollback).not.toContain('{"error"');
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
@@ -1818,7 +1818,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       await session.waitForComposer(TIMEOUT);
       const retryVisible = session.waitForText(
-        "▲ Provider unavailable · retrying request · attempt 1/10",
+        "provider_error: tui route failed once",
         TIMEOUT,
       );
       await session.sendText("Recover from provider route failure.");
@@ -1857,7 +1857,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session!.sendKeys("Down");
       await session!.sendKeys("Enter");
       await session!.waitForComposer(TIMEOUT);
-      await session!.waitForText("▲ blocked · content filter", TIMEOUT);
+      await session!.waitForText("⚠ blocked · content_filter · content filter", TIMEOUT);
       const scrollback = await session!.captureFullScrollback();
 
       expect(queuedGateway.requests.length).toBe(1);
@@ -1865,7 +1865,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(pane).toContain("Change model");
       expect(pane).toContain("Try again later");
       expect(pane).toContain("Response blocked by content filter");
-      expect(scrollback).toContain("▲ blocked · content filter");
+      expect(scrollback).toContain("⚠ blocked · content_filter · content filter");
       expect(pane).not.toContain("Disable Fast");
       expect(pane).not.toContain("Retry same route");
       expect(scrollback).not.toContain("System");
@@ -2061,7 +2061,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       await session!.sendText("Keep the canonical fallback through restart.");
       await session!.waitForText(
-        "Provider unavailable · retrying request in 5s",
+        "HTTP 503",
         TIMEOUT,
       );
       expect(queuedGateway.requests).toHaveLength(1);
@@ -2121,7 +2121,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       await session!.sendText("Cancel during provider recovery backoff.");
       await session!.waitForText(
-        "Provider unavailable · retrying request in 2s",
+        "provider_error: route failed three times",
         TIMEOUT,
       );
       await session!.sendKeys("Escape");

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -198,13 +198,14 @@ function hasEmptyStandaloneAssistant(body: string): boolean {
 }
 
 function restrictedProviderResponse(): Response {
+  const message =
+    "Your team has restricted access to this provider. Contact the owner of the account for more details. Providers considered: wafer";
   return new Response(
     JSON.stringify({
       error: {
-        code: "RestrictedProvidersError",
-        message:
-          "Your team has restricted access to this provider. Contact the owner of the account for more details. Providers considered: wafer",
-        provider: "wafer",
+        message,
+        type: "no_providers_available",
+        param: { name: "RestrictedProvidersError", message },
       },
     }),
     {
@@ -1640,9 +1641,9 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         "⚠ API access denied · HTTP 403 · Provider: wafer",
       );
       expect(scrollback).toContain(
-        "RestrictedProvidersError: Your team has restricted access to this",
+        "no_providers_available: Your team has restricted access to this",
       );
-      expect(scrollback).toContain("RestrictedProvidersError");
+      expect(scrollback).toContain("no_providers_available");
       expect(scrollback).not.toContain('{"error"');
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -1830,6 +1830,15 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
           "second route recovery request",
         ),
       ]);
+
+      await session.resizeWindow(32, 24);
+      const narrowPane = await session.capturePane();
+      expect(narrowPane).toContain("⚠ Provider unavailable");
+      expect(narrowPane).toContain("provider_error:");
+      expect(narrowPane).toContain("attempt 1/10");
+      expect(narrowPane).not.toContain("▲");
+
+      await session.resizeWindow(72, 24);
       releaseFinalResponse?.();
       await session.waitForText(finalText, TIMEOUT);
       const scrollback = await session.captureFullScrollback();

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -6572,7 +6572,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
       const tapePath = join(root!, "selected-child-route-recovery.fxtape");
       const childPrompt = "SELECTED_CHILD_ROUTE_RECOVERY";
       const finalText = "SELECTED_CHILD_RECOVERED";
-      const retryText = "Provider unavailable · retrying request · attempt 1/10";
+      const retryText = "⚠ Provider unavailable · provider_error: selected child route failed once";
       let childRequests = 0;
       let releaseProviderError!: (response: Response) => void;
       const providerError = new Promise<Response>((resolve) => {


### PR DESCRIPTION
## Summary

- Show HTTP status codes, provider error codes and messages, or transport error names in retry and paused recovery statuses.
- Redact secrets and escape terminal control bytes before provider error text reaches CLI, TUI, or ACP output.
- Use the warning symbol for model and Gateway error statuses.
- Keep successful recovered JSON and ACP statuses free of transient failure details.