### PR TITLE
Restore terminal tool schema compatibility

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -202,6 +202,10 @@ const terminal_properties = [_]gateway_schema.Property{
     .{ .name = "close_policy", .json_type = .string, .enum_values = &.{ "graceful", "force" } },
 };
 
+const terminal_gateway_properties = [_]gateway_schema.Property{
+    .{ .name = "action", .json_type = .string, .enum_values = &.{ "start", "read", "screen", "write", "wait", "monitor", "inspect", "list", "resize", "signal", "close" } },
+} ++ terminal_properties;
+
 fn terminalProperty(comptime name: []const u8) gateway_schema.Property {
     inline for (terminal_properties) |property| {
         if (std.mem.eql(u8, property.name, name)) return property;
@@ -1014,7 +1018,9 @@ pub const terminal = ToolSpec{
         .name = "terminal",
         .description = terminal_description,
         .input_schema = .{
-            .one_of = &terminal_action_schemas,
+            .properties = &terminal_gateway_properties,
+            .required = &.{"action"},
+            .additional_properties = false,
         },
     },
     .executor_kind = .terminal,
@@ -1387,7 +1393,7 @@ fn schemaProperty(schema: gateway_schema.ObjectSchema, name: []const u8) ?gatewa
     return null;
 }
 
-test "terminal tool schema exposes one exact object branch per action" {
+test "terminal tool schema exposes a compatible object and exact internal action branches" {
     try std.testing.expect(terminal.requires_approval);
     try std.testing.expectEqual(tool_dispatch.ExecutorKind.terminal, terminal.executor_kind);
     try std.testing.expectEqual(tool_dispatch.PermissionTargetKind.none, terminal.permission_target_kind);
@@ -1411,9 +1417,16 @@ test "terminal tool schema exposes one exact object branch per action" {
         .{ .action = "close", .properties = &.{ "action", "session_id", "close_policy" }, .required = &.{ "action", "session_id", "close_policy" } },
     };
 
-    try std.testing.expectEqual(expected.len, terminal.gateway_schema.input_schema.one_of.len);
-    try std.testing.expectEqual(@as(usize, 0), terminal.gateway_schema.input_schema.properties.len);
-    for (expected, terminal.gateway_schema.input_schema.one_of) |want, branch| {
+    const gateway_input = terminal.gateway_schema.input_schema;
+    try std.testing.expectEqual(@as(usize, 0), gateway_input.one_of.len);
+    try std.testing.expectEqual(terminal_gateway_properties.len, gateway_input.properties.len);
+    try std.testing.expectEqualSlices([]const u8, &.{"action"}, gateway_input.required);
+    try std.testing.expectEqual(@as(?bool, false), gateway_input.additional_properties);
+    const gateway_action = schemaProperty(gateway_input, "action").?;
+    try std.testing.expectEqual(std.meta.tags(terminal_contracts.Action).len, gateway_action.enum_values.len);
+
+    try std.testing.expectEqual(expected.len, terminal_action_schemas.len);
+    for (expected, terminal_action_schemas) |want, branch| {
         try std.testing.expectEqual(want.properties.len, branch.properties.len);
         for (want.properties, branch.properties) |want_name, property| {
             try std.testing.expectEqualStrings(want_name, property.name);
@@ -1425,9 +1438,9 @@ test "terminal tool schema exposes one exact object branch per action" {
         try std.testing.expectEqual(@as(?bool, false), branch.additional_properties);
     }
 
-    const start_branch = terminal.gateway_schema.input_schema.one_of[0];
-    const read_branch = terminal.gateway_schema.input_schema.one_of[1];
-    const list_branch = terminal.gateway_schema.input_schema.one_of[7];
+    const start_branch = terminal_action_schemas[0];
+    const read_branch = terminal_action_schemas[1];
+    const list_branch = terminal_action_schemas[7];
     try std.testing.expectEqualSlices(
         []const u8,
         &.{ "native", "tmux" },
@@ -1473,8 +1486,8 @@ test "terminal tool schema exposes one exact object branch per action" {
     );
 }
 
-test "terminal advertisement and admission agree on every action field" {
-    const branches = terminal.gateway_schema.input_schema.one_of;
+test "terminal action contracts and admission agree on every action field" {
+    const branches = &terminal_action_schemas;
     try std.testing.expectEqual(std.meta.tags(terminal_contracts.Action).len, branches.len);
 
     for (branches) |branch| {
@@ -1492,7 +1505,7 @@ test "terminal advertisement and admission agree on every action field" {
     }
 }
 
-test "terminal gateway advertisement projects action-specific alternatives" {
+test "terminal gateway advertisement projects a provider-compatible object schema" {
     const alloc = std.testing.allocator;
     var projection = try tool_advertisement.buildGatewayToolProjectionForSet(
         alloc,
@@ -1513,11 +1526,18 @@ test "terminal gateway advertisement projects action-specific alternatives" {
     }
 
     const input_schema = terminal_schema orelse return error.TestExpectedEqual;
-    try std.testing.expect(input_schema.get("properties") == null);
+    try std.testing.expectEqualStrings("object", input_schema.get("type").?.string);
+    try std.testing.expect(input_schema.get("oneOf") == null);
+    try std.testing.expectEqual(false, input_schema.get("additionalProperties").?.bool);
+    const properties = input_schema.get("properties").?.object;
+    try std.testing.expectEqual(terminal_gateway_properties.len, properties.count());
     try std.testing.expectEqual(
-        @as(usize, 11),
-        input_schema.get("oneOf").?.array.items.len,
+        std.meta.tags(terminal_contracts.Action).len,
+        properties.get("action").?.object.get("enum").?.array.items.len,
     );
+    const required = input_schema.get("required").?.array.items;
+    try std.testing.expectEqual(@as(usize, 1), required.len);
+    try std.testing.expectEqualStrings("action", required[0].string);
 }
 
 fn allowTerminalTool(

--- a/src/core/tooling/gateway_schema.zig
+++ b/src/core/tooling/gateway_schema.zig
@@ -335,6 +335,100 @@ test "builtinFunctionSchemaJsonAlloc serializes strings and object schema" {
     try std.testing.expect(std.mem.find(u8, json, "\\\"with quotes\\\"") != null);
 }
 
+test "builtinFunctionSchemaJsonAlloc serializes every supported property shape" {
+    const alloc = std.testing.allocator;
+    const object_value_schema = ObjectSchema{
+        .properties = &.{.{ .name = "name", .json_type = .string }},
+        .required = &.{"name"},
+        .additional_properties = false,
+    };
+    const array_item_schema = ObjectSchema{
+        .properties = &.{.{ .name = "id", .json_type = .integer }},
+        .required = &.{"id"},
+        .additional_properties = false,
+    };
+    const schema = FunctionSchema{
+        .name = "schema_matrix",
+        .description = "schema matrix",
+        .input_schema = .{
+            .properties = &.{
+                .{
+                    .name = "text",
+                    .json_type = .string,
+                    .description = "bounded choice",
+                    .enum_values = &.{ "alpha", "beta" },
+                    .min_length = 1,
+                    .max_length = 8,
+                },
+                .{ .name = "count", .json_type = .integer, .minimum = 2, .maximum = 9 },
+                .{ .name = "enabled", .json_type = .boolean },
+                .{ .name = "config", .json_type = .object, .object_schema = &object_value_schema },
+                .{
+                    .name = "tags",
+                    .json_type = .array,
+                    .min_items = 1,
+                    .max_items = 3,
+                    .item_json_type = .string,
+                    .item_enum_values = &.{ "red", "blue" },
+                },
+                .{ .name = "records", .json_type = .array, .items = &array_item_schema },
+            },
+            .required = &.{ "text", "count", "enabled", "config", "tags", "records" },
+            .additional_properties = false,
+            .min_properties = 6,
+            .max_properties = 6,
+        },
+    };
+
+    const json = try builtinFunctionSchemaJsonAlloc(alloc, schema);
+    defer alloc.free(json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json, .{});
+    defer parsed.deinit();
+
+    const input_schema = parsed.value.object.get("inputSchema").?.object;
+    try std.testing.expectEqualStrings("object", input_schema.get("type").?.string);
+    try std.testing.expectEqual(false, input_schema.get("additionalProperties").?.bool);
+    try std.testing.expectEqual(@as(i64, 6), input_schema.get("minProperties").?.integer);
+    try std.testing.expectEqual(@as(i64, 6), input_schema.get("maxProperties").?.integer);
+    try std.testing.expectEqual(@as(usize, 6), input_schema.get("required").?.array.items.len);
+
+    const properties = input_schema.get("properties").?.object;
+    const text_property = properties.get("text").?.object;
+    try std.testing.expectEqualStrings("string", text_property.get("type").?.string);
+    try std.testing.expectEqualStrings("bounded choice", text_property.get("description").?.string);
+    try std.testing.expectEqual(@as(usize, 2), text_property.get("enum").?.array.items.len);
+    try std.testing.expectEqual(@as(i64, 1), text_property.get("minLength").?.integer);
+    try std.testing.expectEqual(@as(i64, 8), text_property.get("maxLength").?.integer);
+
+    const count_property = properties.get("count").?.object;
+    try std.testing.expectEqualStrings("integer", count_property.get("type").?.string);
+    try std.testing.expectEqual(@as(i64, 2), count_property.get("minimum").?.integer);
+    try std.testing.expectEqual(@as(i64, 9), count_property.get("maximum").?.integer);
+    try std.testing.expectEqualStrings("boolean", properties.get("enabled").?.object.get("type").?.string);
+
+    const config_property = properties.get("config").?.object;
+    try std.testing.expectEqualStrings("object", config_property.get("type").?.string);
+    try std.testing.expectEqual(false, config_property.get("additionalProperties").?.bool);
+    try std.testing.expectEqualStrings(
+        "string",
+        config_property.get("properties").?.object.get("name").?.object.get("type").?.string,
+    );
+
+    const tags_property = properties.get("tags").?.object;
+    try std.testing.expectEqualStrings("array", tags_property.get("type").?.string);
+    try std.testing.expectEqual(@as(i64, 1), tags_property.get("minItems").?.integer);
+    try std.testing.expectEqual(@as(i64, 3), tags_property.get("maxItems").?.integer);
+    try std.testing.expectEqualStrings("string", tags_property.get("items").?.object.get("type").?.string);
+    try std.testing.expectEqual(@as(usize, 2), tags_property.get("items").?.object.get("enum").?.array.items.len);
+
+    const record_items = properties.get("records").?.object.get("items").?.object;
+    try std.testing.expectEqualStrings("object", record_items.get("type").?.string);
+    try std.testing.expectEqualStrings(
+        "integer",
+        record_items.get("properties").?.object.get("id").?.object.get("type").?.string,
+    );
+}
+
 test "dynamicFunctionSchemaJsonAlloc wraps rendered input schema in the flattened envelope" {
     const alloc = std.testing.allocator;
     const description = ("d" ** (description_max_bytes + 1)) ++ "tail";

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -1169,12 +1169,11 @@ test.skipIf(!tmuxAvailable())(
       tools: Array<{
         name?: string;
         inputSchema?: {
-          properties?: Record<string, unknown>;
-          oneOf?: Array<{
-            properties?: Record<string, { enum?: string[] }>;
-            required?: string[];
-            additionalProperties?: boolean;
-          }>;
+          type?: string;
+          properties?: Record<string, { type?: string; enum?: string[] }>;
+          required?: string[];
+          additionalProperties?: boolean;
+          oneOf?: unknown[];
         };
       }>;
     };
@@ -1182,32 +1181,45 @@ test.skipIf(!tmuxAvailable())(
       (tool) => tool.name === "terminal",
     )?.inputSchema;
     expect(terminalSchema).toBeDefined();
-    expect(terminalSchema!.properties).toBeUndefined();
-    const branches = terminalSchema!.oneOf ?? [];
-    const expectedBranches = [
-      { action: "start", properties: ["action", "cwd", "command", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors"], required: ["action"] },
-      { action: "read", properties: ["action", "session_id", "cursor_segment", "cursor_offset"], required: ["action", "session_id", "cursor_segment"] },
-      { action: "screen", properties: ["action", "session_id"], required: ["action", "session_id"] },
-      { action: "write", properties: ["action", "session_id", "write", "lease"], required: ["action", "session_id"] },
-      { action: "wait", properties: ["action", "session_id", "return_when", "wait_ceiling_ms"], required: ["action", "session_id", "return_when", "wait_ceiling_ms"] },
-      { action: "monitor", properties: ["action", "session_id", "monitor"], required: ["action", "session_id", "monitor"] },
-      { action: "inspect", properties: ["action", "session_id", "after_event_id", "acknowledge_event_id", "max_events"], required: ["action", "session_id"] },
-      { action: "list", properties: ["action", "task_id", "workspace_root", "backend"], required: ["action"] },
-      { action: "resize", properties: ["action", "session_id", "rows", "columns"], required: ["action", "session_id", "rows", "columns"] },
-      { action: "signal", properties: ["action", "session_id", "signal"], required: ["action", "session_id", "signal"] },
-      { action: "close", properties: ["action", "session_id", "close_policy"], required: ["action", "session_id", "close_policy"] },
-    ];
-    expect(branches).toHaveLength(expectedBranches.length);
-    for (const expected of expectedBranches) {
-      const branch = branches.find((candidate) =>
-        candidate.properties?.action?.enum?.[0] === expected.action
-      );
-      expect(branch).toBeDefined();
-      expect(branch!.properties!.action!.enum).toEqual([expected.action]);
-      expect(Object.keys(branch!.properties!)).toEqual(expected.properties);
-      expect(branch!.required).toEqual(expected.required);
-      expect(branch!.additionalProperties).toBe(false);
-    }
+    expect(terminalSchema!.type).toBe("object");
+    expect(terminalSchema!.oneOf).toBeUndefined();
+    expect(terminalSchema!.required).toEqual(["action"]);
+    expect(terminalSchema!.additionalProperties).toBe(false);
+    const properties = terminalSchema!.properties ?? {};
+    expect(Object.keys(properties)).toEqual([
+      "action",
+      "session_id",
+      "cwd",
+      "command",
+      "shell",
+      "backend",
+      "return_when",
+      "wait_ceiling_ms",
+      "dimensions",
+      "initial_monitors",
+      "cursor_segment",
+      "cursor_offset",
+      "after_event_id",
+      "acknowledge_event_id",
+      "max_events",
+      "write",
+      "lease",
+      "monitor",
+      "task_id",
+      "workspace_root",
+      "rows",
+      "columns",
+      "signal",
+      "close_policy",
+    ]);
+    expect(properties.action!.enum).toEqual([
+      "start", "read", "screen", "write", "wait", "monitor", "inspect",
+      "list", "resize", "signal", "close",
+    ]);
+    expect(properties.action!.type).toBe("string");
+    expect(properties.wait_ceiling_ms!.type).toBe("integer");
+    expect(properties.shell!.type).toBe("object");
+    expect(properties.initial_monitors!.type).toBe("array");
 
     const scrollback = await active.captureFullScrollback();
     expect(countOccurrences(scrollback, "Used terminal start")).toBe(1);
@@ -1581,12 +1593,8 @@ test.skipIf(!tmuxAvailable())(
       tools: Array<{
         name?: string;
         inputSchema?: {
-          properties?: Record<string, unknown>;
-          oneOf?: Array<{
-            properties?: Record<string, {
-              enum?: string[];
-            }>;
-          }>;
+          properties?: Record<string, { enum?: string[] }>;
+          oneOf?: unknown[];
         };
       }>;
     };
@@ -1594,13 +1602,9 @@ test.skipIf(!tmuxAvailable())(
       (tool) => tool.name === "terminal",
     )?.inputSchema;
     expect(terminalSchema).toBeDefined();
-    expect(terminalSchema!.properties).toBeUndefined();
-    expect(terminalSchema!.oneOf).toHaveLength(11);
-    const waitBranch = terminalSchema!.oneOf!.find((branch) =>
-      branch.properties?.action?.enum?.[0] === "wait"
-    );
-    expect(waitBranch).toBeDefined();
-    const terminalProperties = Object.keys(waitBranch!.properties ?? {});
+    expect(terminalSchema!.oneOf).toBeUndefined();
+    expect(terminalSchema!.properties?.action?.enum).toContain("wait");
+    const terminalProperties = Object.keys(terminalSchema!.properties ?? {});
     expect(
       terminalProperties.filter((name) => name === "wait_ceiling_ms"),
     ).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Allow model providers to accept the terminal tool during interactive sessions.
- Keep rejecting fields that do not belong to the selected terminal action.