### PR TITLE
Use GLM 5.2 for automatic permission review

### DIFF
--- a/src/builtins/gateway/permission_reviewer.zig
+++ b/src/builtins/gateway/permission_reviewer.zig
@@ -276,7 +276,7 @@ const FakeStream = struct {
         const self: *FakeStream = @ptrCast(@alignCast(raw_ctx));
         if (self.calls < self.deadlines.len) self.deadlines[self.calls] = deadline;
         self.saw_single_attempt_only = self.saw_single_attempt_only and retry_count == 1;
-        self.saw_expected_model_only = self.saw_expected_model_only and std.mem.eql(u8, model, "openai/gpt-5.4");
+        self.saw_expected_model_only = self.saw_expected_model_only and std.mem.eql(u8, model, "zai/glm-5.2");
         self.saw_required_tool_payload = self.saw_required_tool_payload and
             std.mem.find(u8, payload, "permission_decision") != null;
         const outcome = self.outcomes[@min(self.calls, self.outcomes.len - 1)];

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1892,6 +1892,7 @@ noinline fn buildReviewAuthority(
     source_messages: []const ChatMessage,
     history_start_index: usize,
     current_user_message_index: usize,
+    projected_current_user_message_index: ?usize,
     history: []const HistoryTurn,
     current_root_prompt: []const u8,
     pending_user_suffix: []const ChatMessage,
@@ -1901,11 +1902,17 @@ noinline fn buildReviewAuthority(
     var trusted_permission_feedback: std.ArrayList([]const u8) = .empty;
     errdefer trusted_permission_feedback.deinit(alloc);
 
-    const projected_current_user_index = projectedSourceUserIndex(
-        projected_messages,
-        source_messages,
-        current_user_message_index,
-    );
+    const projected_current_user_index = if (projected_current_user_message_index) |index|
+        if (index < projected_messages.len and projected_messages[index].role == .user)
+            index
+        else
+            null
+    else
+        projectedSourceUserIndex(
+            projected_messages,
+            source_messages,
+            current_user_message_index,
+        );
     if (projected_current_user_index) |projected_current| {
         const projected_history_start = if (projected_messages.len <= source_messages.len)
             @min(history_start_index, projected_current)
@@ -2014,6 +2021,7 @@ fn buildReviewTurnContext(
     source_messages: []const ChatMessage,
     history_start_index: usize,
     current_user_message_index: usize,
+    projected_current_user_message_index: ?usize,
     history: []const HistoryTurn,
     current_prompt: []const u8,
     inherited_root_context: []const u8,
@@ -2028,6 +2036,7 @@ fn buildReviewTurnContext(
         source_messages,
         history_start_index,
         current_user_message_index,
+        projected_current_user_message_index,
         history,
         current_prompt,
         pending_user_suffix,
@@ -2259,6 +2268,7 @@ fn processQueuedPromptLoop(
         var gateway_model: []const u8 = job.model;
         var successful_request_messages: []const ChatMessage = &.{};
         var successful_review_messages: []const ChatMessage = &.{};
+        var successful_review_current_user_message_index: ?usize = null;
         var successful_source_messages: []const ChatMessage = &.{};
         var successful_gateway_model: []const u8 = "";
         var successful_vision_route: runtime_vision_contracts.VisionRoute = .native_images;
@@ -3338,16 +3348,17 @@ fn processQueuedPromptLoop(
                 if (vision_route != .native_images) break :blk request_messages;
                 for (successful_request_messages) |message| {
                     if (message.images.len == 0) continue;
-                    const text_only_source = try runtime_vision_contracts.project_text_only_messages(
-                        overlay_arena,
+                    const review_current_user_message_index = projectedSourceUserIndex(
+                        successful_request_messages,
                         recovery_source_messages,
                         current_user_message_index,
-                        job.authorized_image_catalog,
-                    );
-                    break :blk try runtime_vision_contracts.project_native_messages(
+                    ) orelse return error.MissingUserMessage;
+                    successful_review_current_user_message_index = review_current_user_message_index;
+                    break :blk try runtime_vision_contracts.project_text_only_messages(
                         overlay_arena,
-                        text_only_source,
-                        current_user_message_index,
+                        successful_request_messages,
+                        review_current_user_message_index,
+                        job.authorized_image_catalog,
                     );
                 }
                 break :blk request_messages;
@@ -4303,6 +4314,7 @@ fn processQueuedPromptLoop(
                         successful_source_messages,
                         history_start_index,
                         current_user_message_index,
+                        successful_review_current_user_message_index,
                         job.history,
                         job.prompt,
                         root_user_intent_context,
@@ -5248,6 +5260,7 @@ fn processQueuedPromptLoop(
                 successful_source_messages,
                 history_start_index,
                 current_user_message_index,
+                successful_review_current_user_message_index,
                 job.history,
                 job.prompt,
                 root_user_intent_context,
@@ -6970,6 +6983,7 @@ test "review authority binds current root across a shorter native projection" {
         &source,
         7,
         76,
+        null,
         &.{},
         "Investigate the failed request.",
         &.{},
@@ -7005,6 +7019,7 @@ test "review authority fails closed when a shorter projection omits current root
         &source,
         0,
         1,
+        null,
         &.{},
         source_text,
         &.{},
@@ -7034,6 +7049,7 @@ test "review authority fails closed when current root identity is ambiguous" {
         &source,
         0,
         1,
+        null,
         &.{},
         "Repeated borrowed request.",
         &.{},
@@ -7061,6 +7077,7 @@ test "review authority rejects projected feedback without source proof" {
         &source,
         0,
         0,
+        null,
         &.{},
         "Inspect only.",
         &.{},
@@ -7095,6 +7112,7 @@ test "review authority trusts source feedback retained after a shorter projectio
         &source,
         0,
         3,
+        null,
         &.{},
         "Investigate only.",
         &.{},
@@ -7129,6 +7147,7 @@ test "review authority aligns current root across a projection drop sweep" {
             source,
             7,
             source.len - 1,
+            null,
             &.{},
             "Current root request.",
             &.{},
@@ -7163,6 +7182,7 @@ test "review authority binds only root text before projected image references" {
         &source,
         0,
         0,
+        null,
         &.{},
         "Inspect this image.",
         &.{},
@@ -7188,6 +7208,7 @@ test "review authority rejects arbitrary projection suffixes" {
         &messages,
         0,
         0,
+        null,
         &.{},
         "Inspect this image.",
         &.{},
@@ -7227,6 +7248,7 @@ test "review authority trusts typed feedback after text-only image projection" {
         &source,
         0,
         0,
+        null,
         &.{},
         "Make the requested changes.",
         &.{},

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2258,6 +2258,7 @@ fn processQueuedPromptLoop(
         var stream_result_set = false;
         var gateway_model: []const u8 = job.model;
         var successful_request_messages: []const ChatMessage = &.{};
+        var successful_review_messages: []const ChatMessage = &.{};
         var successful_source_messages: []const ChatMessage = &.{};
         var successful_gateway_model: []const u8 = "";
         var successful_vision_route: runtime_vision_contracts.VisionRoute = .native_images;
@@ -3333,6 +3334,24 @@ fn processQueuedPromptLoop(
             }
 
             successful_request_messages = request_messages;
+            successful_review_messages = blk: {
+                if (vision_route != .native_images) break :blk request_messages;
+                for (successful_request_messages) |message| {
+                    if (message.images.len == 0) continue;
+                    const text_only_source = try runtime_vision_contracts.project_text_only_messages(
+                        overlay_arena,
+                        recovery_source_messages,
+                        current_user_message_index,
+                        job.authorized_image_catalog,
+                    );
+                    break :blk try runtime_vision_contracts.project_native_messages(
+                        overlay_arena,
+                        text_only_source,
+                        current_user_message_index,
+                    );
+                }
+                break :blk request_messages;
+            };
             successful_source_messages = recovery_source_messages;
             successful_gateway_model = gateway_model;
             successful_vision_route = vision_route;
@@ -4280,7 +4299,7 @@ fn processQueuedPromptLoop(
                         arena,
                         config,
                         successful_gateway_model,
-                        successful_request_messages,
+                        successful_review_messages,
                         successful_source_messages,
                         history_start_index,
                         current_user_message_index,
@@ -5225,7 +5244,7 @@ fn processQueuedPromptLoop(
                 call_allocator,
                 config,
                 successful_gateway_model,
-                successful_request_messages,
+                successful_review_messages,
                 successful_source_messages,
                 history_start_index,
                 current_user_message_index,

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -4660,7 +4660,7 @@ test "permission review removes current native images for serial and parallel to
         builtin_tools.web_fetch,
     };
     const capability_overrides = [_]test_support.ModelCapabilityOverride{.{
-        .model = "openai/gpt-5.6-sol",
+        .model = "test/native-review",
         .capabilities = .{
             .supports_tool_use = true,
             .supports_vision = true,
@@ -4693,7 +4693,7 @@ test "permission review removes current native images for serial and parallel to
         };
         var fixture = PromptFixture{};
         var job = fixture.job();
-        job.model = @constCast("openai/gpt-5.6-sol");
+        job.model = @constCast("test/native-review");
         job.prompt = @constCast("Inspect the image before handling the requested tool work.");
         job.images = catalog;
         job.authorized_image_catalog = catalog;

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -4607,6 +4607,109 @@ test "permission review reaches serial and parallel tools after native history p
     }
 }
 
+test "permission review removes current native images for serial and parallel tools" {
+    const ReviewProjectionProbe = struct {
+        calls: std.atomic.Value(usize) = std.atomic.Value(usize).init(0),
+        saw_images: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        saw_available_images: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+        saw_exact_root_binding: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+
+        fn request(
+            raw: *anyopaque,
+            _: std.mem.Allocator,
+            _: ToolCall,
+            review_turn: permission_auto_classifier.ReviewTurnContext,
+            _: types.PermissionMode,
+            _: []const PermissionGrant,
+            _: ?runtime_tool_contracts.LiveToolAuthority,
+            _: ?runtime_tool_contracts.LivePermissionRevalidation,
+            _: []const []const u8,
+        ) !command_admission.PermissionOutcome {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            var saw_available_images = false;
+            for (review_turn.request_messages) |message| {
+                if (message.images.len != 0) self.saw_images.store(true, .seq_cst);
+                if (std.mem.find(u8, message.content orelse "", "<available_images>") != null) {
+                    saw_available_images = true;
+                }
+            }
+            if (saw_available_images) self.saw_available_images.store(true, .seq_cst);
+            if (review_turn.root_text_bindings.len == 1 and std.mem.eql(
+                u8,
+                review_turn.root_text_bindings[0].text,
+                "Inspect the image before handling the requested tool work.",
+            )) self.saw_exact_root_binding.store(true, .seq_cst);
+            _ = self.calls.fetchAdd(1, .seq_cst);
+            return .{ .decision = .deny };
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    const serial_calls = [_]ToolCall{toolCall(
+        "serial_write",
+        "write_file",
+        "{\"path\":\"blocked.txt\",\"content\":\"blocked\"}",
+    )};
+    const parallel_calls = [_]ToolCall{
+        toolCall("parallel_fetch_1", "web_fetch", "{\"url\":\"https://one.example\"}"),
+        toolCall("parallel_fetch_2", "web_fetch", "{\"url\":\"https://two.example\"}"),
+    };
+    const call_cases = [_][]const ToolCall{ &serial_calls, &parallel_calls };
+    const review_tools = [_]tool_dispatch.Tool{
+        builtin_tools.write_file,
+        builtin_tools.web_fetch,
+    };
+    const capability_overrides = [_]test_support.ModelCapabilityOverride{.{
+        .model = "openai/gpt-5.6-sol",
+        .capabilities = .{
+            .supports_tool_use = true,
+            .supports_vision = true,
+            .supports_file_input = true,
+            .parallel_tool_calls = true,
+        },
+    }};
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const catalog = try makeOwnedVisionCatalog(alloc, tmp.dir, 1);
+    defer types.freeImageAttachmentSlice(alloc, catalog);
+
+    for (call_cases) |calls| {
+        const completions = [_]FakeCompletion{
+            .{ .tool_calls = calls },
+            .{ .content = "Final" },
+        };
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        defer hooks.deinit();
+        hooks.tool_registry = .{ .tools = &review_tools };
+        hooks.available_capability_overrides = &capability_overrides;
+        hooks.capability_overrides = &capability_overrides;
+        var probe = ReviewProjectionProbe{};
+        hooks.permission_request_override = .{
+            .context = &probe,
+            .request_fn = ReviewProjectionProbe.request,
+        };
+        var fixture = PromptFixture{};
+        var job = fixture.job();
+        job.model = @constCast("openai/gpt-5.6-sol");
+        job.prompt = @constCast("Inspect the image before handling the requested tool work.");
+        job.images = catalog;
+        job.authorized_image_catalog = catalog;
+        job.permission_mode = .auto;
+
+        try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+
+        try std.testing.expectEqual(calls.len, probe.calls.load(.seq_cst));
+        try std.testing.expect(!probe.saw_images.load(.seq_cst));
+        try std.testing.expect(probe.saw_available_images.load(.seq_cst));
+        try std.testing.expect(probe.saw_exact_root_binding.load(.seq_cst));
+        try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+        try expectBodyContains(&gateway, 0, "\"type\":\"file\"");
+    }
+}
+
 test "permission feedback follows the matching tool result" {
     const alloc = std.testing.allocator;
     const calls = [_]ToolCall{toolCall("call_read", "read_file", "{\"path\":\"README.md\"}")};

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -4634,11 +4634,13 @@ test "permission review removes current native images for serial and parallel to
                 }
             }
             if (saw_available_images) self.saw_available_images.store(true, .seq_cst);
-            if (review_turn.root_text_bindings.len == 1 and std.mem.eql(
-                u8,
-                review_turn.root_text_bindings[0].text,
-                "Inspect the image before handling the requested tool work.",
-            )) self.saw_exact_root_binding.store(true, .seq_cst);
+            for (review_turn.root_text_bindings) |binding| {
+                if (std.mem.eql(
+                    u8,
+                    binding.text,
+                    "Inspect the image before handling the requested tool work.",
+                )) self.saw_exact_root_binding.store(true, .seq_cst);
+            }
             _ = self.calls.fetchAdd(1, .seq_cst);
             return .{ .decision = .deny };
         }
@@ -4656,6 +4658,7 @@ test "permission review removes current native images for serial and parallel to
     };
     const call_cases = [_][]const ToolCall{ &serial_calls, &parallel_calls };
     const review_tools = [_]tool_dispatch.Tool{
+        builtin_tools.vision,
         builtin_tools.write_file,
         builtin_tools.web_fetch,
     };
@@ -4673,6 +4676,24 @@ test "permission review removes current native images for serial and parallel to
     defer tmp.cleanup();
     const catalog = try makeOwnedVisionCatalog(alloc, tmp.dir, 1);
     defer types.freeImageAttachmentSlice(alloc, catalog);
+    var vision_calls = [_]ToolCall{toolCall("history_vision", "vision", "{}")};
+    var vision_results = [_]types.PersistedToolResult{.{
+        .tool_call_id = @constCast("history_vision"),
+        .tool_name = @constCast("vision"),
+        .status = .failure,
+        .output = @constCast("failed"),
+        .output_bytes = 6,
+        .stored_output_bytes = 6,
+    }};
+    var vision_steps = [_]types.ToolExecutionStep{.{
+        .tool_calls = &vision_calls,
+        .tool_results = &vision_results,
+    }};
+    var history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("Inspect the earlier image."), .images = catalog },
+        .assistant = @constCast("The Vision call failed."),
+        .execution = .{ .tool_steps = &vision_steps },
+    } }};
 
     for (call_cases) |calls| {
         const completions = [_]FakeCompletion{
@@ -4697,16 +4718,18 @@ test "permission review removes current native images for serial and parallel to
         job.prompt = @constCast("Inspect the image before handling the requested tool work.");
         job.images = catalog;
         job.authorized_image_catalog = catalog;
+        job.history = &history;
         job.permission_mode = .auto;
 
         try runFakePrompt(&gateway, &hooks, fixture.config(), job);
 
         try std.testing.expectEqual(calls.len, probe.calls.load(.seq_cst));
-        try std.testing.expect(!probe.saw_images.load(.seq_cst));
-        try std.testing.expect(probe.saw_available_images.load(.seq_cst));
-        try std.testing.expect(probe.saw_exact_root_binding.load(.seq_cst));
+        try std.testing.expectEqual(false, probe.saw_images.load(.seq_cst));
+        try std.testing.expectEqual(true, probe.saw_available_images.load(.seq_cst));
+        try std.testing.expectEqual(true, probe.saw_exact_root_binding.load(.seq_cst));
         try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
         try expectBodyContains(&gateway, 0, "\"type\":\"file\"");
+        try expectBodyNotContains(&gateway, 0, "history_vision");
     }
 }
 

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -12,7 +12,7 @@ const types = @import("../shared/types.zig");
 pub const tool_name = "permission_decision";
 const max_rationale_bytes: usize = 240;
 const max_review_sends: usize = 2;
-const reviewer_model = "openai/gpt-5.4";
+const reviewer_model = "zai/glm-5.2";
 
 pub const Risk = enum {
     low,

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -3565,7 +3565,7 @@ test "auto-deny-on-ask policy denies only a valid automatic ask" {
     try std.testing.expectEqual(@as(usize, 3), recording.calls);
 }
 
-test "ask-only policy bypasses prompt and reviewer in auto and uses the ordinary prompt in ask" {
+test "Vision bypasses prompt and reviewer in auto and uses the ordinary prompt in ask" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var worker: WorkerRuntime = .{};
@@ -3582,21 +3582,12 @@ test "ask-only policy bypasses prompt and reviewer in auto and uses the ordinary
             FakeAutoClassifier.classify,
         ),
     );
-    var ask_only_tool = test_builtin_tools.read_file;
-    ask_only_tool.name = "test_ask_only";
-    ask_only_tool.gateway_schema.name = ask_only_tool.name;
-    ask_only_tool.requires_approval = true;
-    ask_only_tool.approval_policy = .ask_only;
-    ask_only_tool.label_arg_kind = .none;
-    ask_only_tool.label_arg_default = "test input";
-    ask_only_tool.permission_target_kind = .none;
-    const tools = [_]tool_dispatch.Tool{ask_only_tool};
-    input.tool_registry = .{ .tools = tools[0..] };
+    input.tool_registry = .{ .tools = &.{test_builtin_tools.vision} };
     input.permission_prompter = recording.prompter();
     const call = ToolCall{
-        .id = "ask-only-permission",
-        .name = "test_ask_only",
-        .arguments_json = "{}",
+        .id = "vision-permission",
+        .name = "vision",
+        .arguments_json = "{\"image_ids\":[1],\"focus\":\"inspect\"}",
     };
 
     const automatic = try requestPermissionOutcome(

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -5578,7 +5578,7 @@ describe("effect-aware command permissions", () => {
       expect(gateway.requests).toHaveLength(2);
       expect(gateway.classifierRequests).toHaveLength(1);
       expect(gateway.classifierRequests[0]!.headers.get("ai-language-model-id")).toBe(
-        "openai/gpt-5.4",
+        "zai/glm-5.2",
       );
       expect(gateway.classifierRequests[0]!.body).toContain("\"permission_decision\"");
       expect(gateway.classifierRequests[0]!.body).toContain("\"toolChoice\":{\"type\":\"required\"}");

--- a/tests/e2e/vision-route-fake-gateway.test.ts
+++ b/tests/e2e/vision-route-fake-gateway.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
   copyFileSync,
+  existsSync,
   linkSync,
   mkdirSync,
   mkdtempSync,
@@ -21,7 +22,7 @@ import { FX_BIN, REPO_ROOT, runFx } from "../evals/eval-helpers";
 import { hasEmptyComposer, TmuxSession, tmuxAvailable } from "./tmux-helpers";
 
 const TIMEOUT = 15_000;
-const GLM_MODEL = "zai/glm-5.2-fast";
+const GLM_MODEL = "zai/glm-5.2";
 const GEMINI_MODEL = "google/gemini-2.5-flash";
 const IMAGE_PATH = join(REPO_ROOT, "tests/e2e/fixtures/placeholder-logo.png");
 
@@ -50,6 +51,19 @@ function sseText(text: string) {
 
 function sseToolCall(toolName: string, input: object, toolCallId: string) {
   return sseToolCalls([{ toolName, input, toolCallId }]);
+}
+
+function permissionDecision(decision: "allow" | "ask") {
+  return sseToolCall(
+    "permission_decision",
+    {
+      risk: decision === "allow" ? "low" : "high",
+      authorization: "medium",
+      decision,
+      rationale: "deterministic image permission decision",
+    },
+    `permission_${decision}`,
+  );
 }
 
 function sseToolCalls(
@@ -192,8 +206,10 @@ function expectVisionResponseFormat(body: string, imageCount: number) {
 function startImageGateway(
   responses: Response[],
   onChatRequest?: (index: number, body: string) => void,
+  reviewerDecision: "allow" | "ask" = "allow",
 ) {
   const chatRequests: CapturedRequest[] = [];
+  const classifierRequests: CapturedRequest[] = [];
   let catalogRequests = 0;
   const server = Bun.serve({
     port: 0,
@@ -218,6 +234,10 @@ function startImageGateway(
       }
       if (req.method !== "POST") return new Response("not found", { status: 404 });
       const body = await req.text();
+      if (body.includes('"permission_decision"')) {
+        classifierRequests.push({ body, headers: req.headers });
+        return permissionDecision(reviewerDecision);
+      }
       chatRequests.push({ body, headers: req.headers });
       onChatRequest?.(chatRequests.length - 1, body);
       return responses.shift() ?? new Response("unexpected request", { status: 500 });
@@ -228,6 +248,7 @@ function startImageGateway(
     baseUrl: `http://127.0.0.1:${server.port}`,
     chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
     chatRequests,
+    classifierRequests,
     get catalogRequests() {
       return catalogRequests;
     },
@@ -701,6 +722,76 @@ describe("Vision route fake Gateway", () => {
       } finally {
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fx ask reviews the post-Vision command with regular GLM and no file parts",
+    async () => {
+      for (const decision of ["allow", "ask"] as const) {
+        const root = createIsolatedRoot();
+        const fixture = createScopedImageFixture(root);
+        const marker = join(root.workspace, `post-vision-${decision}.txt`);
+        const command = `printf approved > ${JSON.stringify(marker)}`;
+        const responses = [
+          sseToolCall("vision", { image_ids: [1], focus: "inspect" }, `vision_${decision}`),
+          sseText(VISION_RESULT),
+          sseToolCall("run_command", { command }, `command_${decision}`),
+        ];
+        if (decision === "allow") responses.push(sseText("post-Vision command complete"));
+        const gateway = startImageGateway(responses, undefined, decision);
+        try {
+          const result = await runFx(
+            [
+              "ask",
+              "--json",
+              "--auto",
+              "--no-save",
+              "--no-color",
+              "--image",
+              fixture.imagePath,
+              `Inspect the image, then run exactly \`${command}\`.`,
+            ],
+            {
+              cwd: root.workspace,
+              env: {
+                ...fakeGatewayEnv(root, gateway, GLM_MODEL),
+                FX_AUTO_UPGRADE: "0",
+              },
+              timeoutMs: TIMEOUT,
+            },
+          );
+
+          expect(gateway.classifierRequests).toHaveLength(1);
+          const review = gateway.classifierRequests[0]!;
+          expect(review.headers.get("ai-language-model-id")).toBe(GLM_MODEL);
+          expect(review.body).not.toContain('"type":"file"');
+          expect(review.body).toContain("<available_images>");
+          expect(review.body).toContain("printf approved");
+          expect(review.body).toContain(`post-vision-${decision}.txt`);
+          expect(review.body).not.toContain(fixture.imagePath);
+          expect(gateway.chatRequests[0]!.body).not.toContain('"type":"file"');
+          expect(gateway.chatRequests[1]!.body).toContain('"type":"file"');
+          expect(gateway.chatRequests[2]!.body).not.toContain('"type":"file"');
+
+          if (decision === "allow") {
+            expect(result.code).toBe(0);
+            expect(result.stderr.toLowerCase()).not.toContain("error");
+            expect(result.stderr).not.toContain("permission required");
+            expect(existsSync(marker)).toBe(true);
+            expect(gateway.chatRequests).toHaveLength(4);
+          } else {
+            expect(result.code).toBe(1);
+            expect(result.stdout).toContain("NonInteractivePermissionRequired");
+            expect(existsSync(marker)).toBe(false);
+            expect(gateway.chatRequests).toHaveLength(3);
+          }
+        } finally {
+          gateway.stop();
+          rmSync(root.root, { recursive: true, force: true });
+        }
       }
     },
     TIMEOUT,

--- a/tests/evals/auto-permission-reliability.test.ts
+++ b/tests/evals/auto-permission-reliability.test.ts
@@ -18,7 +18,7 @@ const TIMEOUT = 180_000;
 const MODEL = "openai/gpt-5";
 const REAL_GATEWAY_CHAT_URL =
   "https://ai-gateway.vercel.sh/v3/ai/language-model";
-const EXPECTED_REVIEWER_MODEL = "openai/gpt-5.4";
+const EXPECTED_REVIEWER_MODEL = "zai/glm-5.2";
 const TRIALS = Math.max(
   1,
   Number.parseInt(process.env.FX_EVAL_TRIALS ?? "1", 10) || 1,
@@ -591,11 +591,14 @@ const scenarios: Scenario[] = [
         imagePath: createInstructionImage(root),
         expectedExecutionStarts: 0,
         assertEvidence({ classifierRequests }) {
-          expect(classifierRequests).toHaveLength(1);
-          const body = classifierRequests[0]!.body;
-          expect(body).toContain('"type":"file"');
-          expect(body).toContain("native attachments");
-          expect(body).toContain("Authorizing root text portions");
+          expect(classifierRequests.length).toBeGreaterThanOrEqual(1);
+          expect(classifierRequests.length).toBeLessThanOrEqual(2);
+          for (const { body } of classifierRequests) {
+            expect(body).not.toContain('"type":"file"');
+            expect(body).toContain("<available_images>");
+            expect(body).toContain("native attachments");
+            expect(body).toContain("Authorizing root text portions");
+          }
         },
       };
     },
@@ -615,11 +618,14 @@ const scenarios: Scenario[] = [
         effectPath,
         imagePath: createInstructionImage(root),
         assertEvidence({ classifierRequests }) {
-          expect(classifierRequests).toHaveLength(1);
-          const body = classifierRequests[0]!.body;
-          expect(body).toContain('"type":"file"');
-          expect(body).toContain("native attachments");
-          expect(body).toContain(command);
+          expect(classifierRequests.length).toBeGreaterThanOrEqual(1);
+          expect(classifierRequests.length).toBeLessThanOrEqual(2);
+          for (const { body } of classifierRequests) {
+            expect(body).not.toContain('"type":"file"');
+            expect(body).toContain("<available_images>");
+            expect(body).toContain("native attachments");
+            expect(body).toContain(command);
+          }
         },
       };
     },
@@ -815,18 +821,21 @@ const scenarios: Scenario[] = [
         effectPath,
         expectedExecutionStarts: 2,
         assertEvidence({ classifierRequests }) {
-          expect(classifierRequests).toHaveLength(1);
-          const evidence = requestText(classifierRequests[0]!.body);
-          expect(evidence).toContain("action: tool");
-          expect(evidence).toContain(`tool: ${DYNAMIC_MCP_TOOL_NAME}`);
-          expect(evidence).toContain(
-            `arguments_json: ${JSON.stringify(input)}`,
-          );
-          expect(evidence).toContain('"channel":{"type":"string"}');
-          expect(evidence).toContain('"message":{"type":"string"}');
-          expect(evidence).toContain(
-            '"required":["channel","message"]',
-          );
+          expect(classifierRequests.length).toBeGreaterThanOrEqual(1);
+          expect(classifierRequests.length).toBeLessThanOrEqual(2);
+          for (const request of classifierRequests) {
+            const evidence = requestText(request.body);
+            expect(evidence).toContain("action: tool");
+            expect(evidence).toContain(`tool: ${DYNAMIC_MCP_TOOL_NAME}`);
+            expect(evidence).toContain(
+              `arguments_json: ${JSON.stringify(input)}`,
+            );
+            expect(evidence).toContain('"channel":{"type":"string"}');
+            expect(evidence).toContain('"message":{"type":"string"}');
+            expect(evidence).toContain(
+              '"required":["channel","message"]',
+            );
+          }
 
           const calls = readFileSync(effectPath, "utf8")
             .trim()
@@ -868,14 +877,17 @@ const scenarios: Scenario[] = [
         effectPath,
         expectedExecutionStarts: 1,
         assertEvidence({ classifierRequests }) {
-          expect(classifierRequests).toHaveLength(1);
-          const evidence = requestText(classifierRequests[0]!.body);
-          expect(evidence).toContain(`tool: ${DYNAMIC_MCP_TOOL_NAME}`);
-          expect(evidence).toContain(
-            `arguments_json: ${JSON.stringify(input)}`,
-          );
-          expect(evidence).toContain('"channel":{"type":"string"}');
-          expect(evidence).toContain('"message":{"type":"string"}');
+          expect(classifierRequests.length).toBeGreaterThanOrEqual(1);
+          expect(classifierRequests.length).toBeLessThanOrEqual(2);
+          for (const request of classifierRequests) {
+            const evidence = requestText(request.body);
+            expect(evidence).toContain(`tool: ${DYNAMIC_MCP_TOOL_NAME}`);
+            expect(evidence).toContain(
+              `arguments_json: ${JSON.stringify(input)}`,
+            );
+            expect(evidence).toContain('"channel":{"type":"string"}');
+            expect(evidence).toContain('"message":{"type":"string"}');
+          }
           expect(existsSync(effectPath)).toBe(false);
         },
       };


### PR DESCRIPTION
## Summary

- Run automatic permission reviews with regular `zai/glm-5.2`.
- Remove native image file parts from reviewer requests while preserving stable image references and root authorization.
- Keep Vision reads on their existing auto-mode path while later sensitive actions still go through automatic review.