### PR TITLE
Move transcript presentation state into Core

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -14,6 +14,7 @@ const composer_insertion = @import("../input/composer_insertion.zig");
 const gesture_state = @import("../input/gesture_state.zig");
 const horizontal_navigation = @import("../input/horizontal_navigation.zig");
 const input_action = @import("../input/input_action.zig");
+const transcript_presentation = @import("../output/transcript_presentation.zig");
 const core_input_runtime = @import("../input/runtime.zig");
 const input_limit_rejection = @import("../input/input_limit_rejection.zig");
 const input_reset = @import("../input/input_reset.zig");
@@ -2833,9 +2834,9 @@ const FakeApprovalCancelApp = struct {
 
     pub fn transitionFullTranscriptProjection(
         _: *FakeApprovalCancelApp,
-        event: transcript_runtime.TranscriptPresentationEvent,
-    ) !transcript_runtime.TranscriptPresentationDepth {
-        return transcript_runtime.TranscriptPresentationDepth.inline_mode.transition(
+        event: transcript_presentation.Event,
+    ) !transcript_presentation.Depth {
+        return transcript_presentation.Depth.inline_mode.transition(
             event,
         );
     }
@@ -3514,8 +3515,8 @@ const RoutingFakeApp = struct {
 
     pub fn transitionFullTranscriptProjection(
         self: *RoutingFakeApp,
-        event: transcript_runtime.TranscriptPresentationEvent,
-    ) !transcript_runtime.TranscriptPresentationDepth {
+        event: transcript_presentation.Event,
+    ) !transcript_presentation.Depth {
         self.shell.setCommandOutputRenderPolicy(
             routingFullTranscriptStyles(),
         );
@@ -9156,7 +9157,7 @@ test "app_input_runtime inline scroll actions do not open the transcript viewer"
         try feedRoutingBytes(&app, bytes);
         try std.testing.expect(!app.terminal.fullTranscriptScreenActive());
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.inline_mode,
+            transcript_presentation.Depth.inline_mode,
             app.shell.transcriptPresentationDepth(),
         );
         try std.testing.expect(app.stream.active);
@@ -9186,20 +9187,20 @@ test "app_input_runtime ctrl-o toggles transcript viewer while arrows switch det
         try std.testing.expect(app.shell.full_transcript.follow_tail);
         try std.testing.expect(app.shell.render_requests.hasReason(.modal));
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.review,
+            transcript_presentation.Depth.review,
             app.shell.transcriptPresentationDepth(),
         );
 
         try feedRoutingBytes(&app, "\x1b[C");
         try std.testing.expect(app.terminal.fullTranscriptScreenActive());
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.full,
+            transcript_presentation.Depth.full,
             app.shell.transcriptPresentationDepth(),
         );
 
         try feedRoutingBytes(&app, "\x1b[D");
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.review,
+            transcript_presentation.Depth.review,
             app.shell.transcriptPresentationDepth(),
         );
 
@@ -9220,13 +9221,13 @@ test "app_input_runtime ctrl-o toggles transcript viewer while arrows switch det
         try std.testing.expectEqualStrings("ab", app.input_runtime.edit_state.input.items);
         try std.testing.expectEqual(@as(usize, 2), app.input_runtime.edit_state.cursor);
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.review,
+            transcript_presentation.Depth.review,
             app.shell.transcriptPresentationDepth(),
         );
         try feedRoutingBytes(&app, "\x1b[C");
         try std.testing.expectEqual(@as(usize, 2), app.input_runtime.edit_state.cursor);
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.full,
+            transcript_presentation.Depth.full,
             app.shell.transcriptPresentationDepth(),
         );
         try std.testing.expect(app.terminal.fullTranscriptScreenActive());
@@ -9356,7 +9357,7 @@ test "app_input_runtime full transcript rejects ctrl-x manager entry without los
     try std.testing.expectEqualStrings("ab", app.input_runtime.edit_state.input.items);
     try std.testing.expectEqual(@as(usize, 2), app.input_runtime.edit_state.cursor);
     try std.testing.expectEqual(
-        transcript_runtime.TranscriptPresentationDepth.review,
+        transcript_presentation.Depth.review,
         app.shell.transcriptPresentationDepth(),
     );
 
@@ -9422,14 +9423,14 @@ test "app_input_runtime ctrl-o opens review and closes active transcript from ea
         try Runtime(RoutingFakeApp).handleByte(&app, 15, 4096, 100);
         try feedRoutingBytes(&app, "\x1b[C");
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.full,
+            transcript_presentation.Depth.full,
             app.shell.transcriptPresentationDepth(),
         );
         try std.testing.expect(app.terminal.fullTranscriptScreenActive());
 
         try Runtime(RoutingFakeApp).handleByte(&app, 15, 4096, 100);
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.inline_mode,
+            transcript_presentation.Depth.inline_mode,
             app.shell.transcriptPresentationDepth(),
         );
         try std.testing.expect(!app.terminal.fullTranscriptScreenActive());

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -18,6 +18,7 @@ const tool_result_limits = @import("../tooling/tool_result_limits.zig");
 const types = @import("../shared/types.zig");
 const ui_render = @import("../../ui/render.zig");
 const presentation_mode = @import("../config/presentation_mode.zig");
+const transcript_presentation = @import("../output/transcript_presentation.zig");
 const shell_runtime = @import("../../ui/shell_runtime.zig");
 const ui_terminal = @import("../../ui/terminal/terminal.zig");
 const terminal_diff = @import("../../ui/render_engine/terminal_diff.zig");
@@ -935,7 +936,7 @@ pub fn handoffFullTranscriptToApproval(
 fn setFullTranscriptProjection(
     alloc: Allocator,
     shell: *TranscriptRuntime,
-    depth: transcript_runtime.TranscriptPresentationDepth,
+    depth: transcript_presentation.Depth,
 ) !void {
     _ = try shell.setTranscriptPresentationDepth(alloc, depth);
 }

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -26,6 +26,7 @@ const subagent_domain = @import("../subagent/domain.zig");
 const subagent_projection = @import("../subagent/ui_projection.zig");
 const file_index = @import("../workspace/file_index.zig");
 const activity_runtime = @import("../output/activity_runtime.zig");
+const transcript_presentation = @import("../output/transcript_presentation.zig");
 const event_loop = @import("../../ui/event_loop.zig");
 const surface_frame = @import("../../ui/footer/surface_frame.zig");
 const interaction_state = @import("../../ui/footer/interaction_state.zig");
@@ -6149,7 +6150,7 @@ const ChildApprovalReconcileBinding = struct {
 };
 
 const ChildApprovalReconcileSubagents = struct {
-    depth: transcript_runtime.TranscriptPresentationDepth,
+    depth: transcript_presentation.Depth,
     close_calls: usize = 0,
 
     pub fn mainApprovalBinding(
@@ -6162,7 +6163,7 @@ const ChildApprovalReconcileSubagents = struct {
 
     pub fn childTranscriptPresentationDepth(
         self: *const ChildApprovalReconcileSubagents,
-    ) transcript_runtime.TranscriptPresentationDepth {
+    ) transcript_presentation.Depth {
         return self.depth;
     }
 
@@ -6200,8 +6201,8 @@ test "child approval arrival closes review and full transcript depths before ren
     try debug_trace.configureForTestWithScopes(alloc, trace_path, "full_transcript");
 
     inline for (.{
-        transcript_runtime.TranscriptPresentationDepth.review,
-        transcript_runtime.TranscriptPresentationDepth.full,
+        transcript_presentation.Depth.review,
+        transcript_presentation.Depth.full,
     }) |depth| {
         var app = ChildApprovalReconcileApp{
             .alloc = alloc,
@@ -6220,7 +6221,7 @@ test "child approval arrival closes review and full transcript depths before ren
         ));
 
         try std.testing.expectEqual(
-            transcript_runtime.TranscriptPresentationDepth.inline_mode,
+            transcript_presentation.Depth.inline_mode,
             app.subagents.depth,
         );
         try std.testing.expectEqual(@as(usize, 1), app.subagents.close_calls);

--- a/src/core/app/input_full_transcript_runtime.zig
+++ b/src/core/app/input_full_transcript_runtime.zig
@@ -4,6 +4,7 @@ const app_lifecycle = @import("app_lifecycle.zig");
 const app_render_runtime = @import("app_render_runtime.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const input_action = @import("../input/input_action.zig");
+const transcript_presentation = @import("../output/transcript_presentation.zig");
 const types = @import("../shared/types.zig");
 const interaction_state = @import("../../ui/footer/interaction_state.zig");
 const approval_prompt = @import("../permissions/approval_prompt.zig");
@@ -15,7 +16,7 @@ pub fn Runtime(comptime App: type) type {
     return struct {
         const FullTranscriptKey = union(enum) {
             toggle,
-            navigate: transcript_runtime.TranscriptPresentationEvent,
+            navigate: transcript_presentation.Event,
             close,
             interrupt,
             subagent_manager,
@@ -84,7 +85,7 @@ pub fn Runtime(comptime App: type) type {
 
         fn transitionScreen(
             app: *App,
-            event: transcript_runtime.TranscriptPresentationEvent,
+            event: transcript_presentation.Event,
         ) !void {
             if (childRouteActive(app)) {
                 const from = childPresentationDepth(app);
@@ -302,7 +303,7 @@ pub fn Runtime(comptime App: type) type {
 
         fn childPresentationDepth(
             app: *App,
-        ) transcript_runtime.TranscriptPresentationDepth {
+        ) transcript_presentation.Depth {
             if (comptime @hasDecl(
                 @TypeOf(app.subagents),
                 "childTranscriptPresentationDepth",
@@ -317,7 +318,7 @@ pub fn Runtime(comptime App: type) type {
         const TransitionTrigger = enum { ctrl_o, left, right, escape, ctrl_c };
 
         fn triggerForEvent(
-            event: transcript_runtime.TranscriptPresentationEvent,
+            event: transcript_presentation.Event,
         ) TransitionTrigger {
             return switch (event) {
                 .toggle => .ctrl_o,
@@ -327,8 +328,8 @@ pub fn Runtime(comptime App: type) type {
         }
 
         fn logDepthTransition(
-            from: transcript_runtime.TranscriptPresentationDepth,
-            to: transcript_runtime.TranscriptPresentationDepth,
+            from: transcript_presentation.Depth,
+            to: transcript_presentation.Depth,
             route: TransitionRoute,
             trigger: TransitionTrigger,
         ) void {
@@ -339,7 +340,7 @@ pub fn Runtime(comptime App: type) type {
             );
         }
 
-        fn depthName(depth: transcript_runtime.TranscriptPresentationDepth) []const u8 {
+        fn depthName(depth: transcript_presentation.Depth) []const u8 {
             return switch (depth) {
                 .inline_mode => "inline",
                 .review => "review",
@@ -350,7 +351,7 @@ pub fn Runtime(comptime App: type) type {
 }
 
 const ApprovalRoutingSubagents = struct {
-    depth: transcript_runtime.TranscriptPresentationDepth = .review,
+    depth: transcript_presentation.Depth = .review,
     selected_child_id: []const u8 = "child-one",
     approval_child_id: []const u8 = "child-one",
 
@@ -364,15 +365,15 @@ const ApprovalRoutingSubagents = struct {
 
     pub fn childTranscriptPresentationDepth(
         self: *const ApprovalRoutingSubagents,
-    ) transcript_runtime.TranscriptPresentationDepth {
+    ) transcript_presentation.Depth {
         return self.depth;
     }
 
     pub fn setChildTranscriptPresentationDepth(
         self: *ApprovalRoutingSubagents,
         _: std.mem.Allocator,
-        requested: transcript_runtime.TranscriptPresentationDepth,
-    ) !transcript_runtime.TranscriptPresentationDepth {
+        requested: transcript_presentation.Depth,
+    ) !transcript_presentation.Depth {
         self.depth = requested;
         return self.depth;
     }
@@ -410,9 +411,9 @@ const ApprovalRoutingApp = struct {
 
     pub fn transitionFullTranscriptProjection(
         _: *ApprovalRoutingApp,
-        event: transcript_runtime.TranscriptPresentationEvent,
-    ) !transcript_runtime.TranscriptPresentationDepth {
-        return transcript_runtime.TranscriptPresentationDepth.inline_mode.transition(
+        event: transcript_presentation.Event,
+    ) !transcript_presentation.Depth {
+        return transcript_presentation.Depth.inline_mode.transition(
             event,
         );
     }
@@ -432,7 +433,7 @@ test "full transcript owns raw semantic and remapped ctrl-l" {
         .remapped_byte = 12,
     }));
     try std.testing.expectEqual(
-        transcript_runtime.TranscriptPresentationDepth.review,
+        transcript_presentation.Depth.review,
         app.subagents.depth,
     );
 }
@@ -452,7 +453,7 @@ test "selected child approval owns ctrl-o ahead of transcript depth" {
     );
 
     try std.testing.expectEqual(
-        transcript_runtime.TranscriptPresentationDepth.review,
+        transcript_presentation.Depth.review,
         app.subagents.depth,
     );
     try std.testing.expect(app.approval_prompt.isActive());

--- a/src/core/output/transcript_presentation.zig
+++ b/src/core/output/transcript_presentation.zig
@@ -1,0 +1,384 @@
+const std = @import("std");
+
+pub const Event = enum {
+    toggle,
+    left,
+    right,
+};
+
+pub const Depth = enum {
+    inline_mode,
+    review,
+    full,
+
+    pub fn transition(self: Depth, event: Event) Depth {
+        return switch (event) {
+            .toggle => if (self == .inline_mode) .review else .inline_mode,
+            .left => if (self.active()) .review else .inline_mode,
+            .right => if (self.active()) .full else .inline_mode,
+        };
+    }
+
+    pub fn active(self: Depth) bool {
+        return self != .inline_mode;
+    }
+};
+
+pub const ScrollDirection = enum {
+    up,
+    down,
+};
+
+pub const ItemRow = struct {
+    entry_id: u32,
+    row: u32,
+};
+
+pub const Snapshot = struct {
+    depth: Depth,
+    scroll_rows: u32,
+    follow_tail: bool,
+    anchor_entry_id: ?u32,
+    anchor_pending: bool,
+    bookmark_entry_id: ?u32,
+    bookmark_intra_row: u32,
+    bookmark_pending: bool,
+    projection_cols: ?u16,
+};
+
+pub const OffsetSelection = struct {
+    state: State,
+    offset: u32,
+};
+
+pub const State = struct {
+    depth: Depth = .inline_mode,
+    scroll_rows: u32 = 0,
+    follow_tail: bool = true,
+    anchor_entry_id: ?u32 = null,
+    anchor_pending: bool = false,
+    bookmark_entry_id: ?u32 = null,
+    bookmark_intra_row: u32 = 0,
+    bookmark_pending: bool = false,
+    projection_cols: ?u16 = null,
+
+    pub fn with_depth(self: State, requested: Depth) State {
+        if (self.depth == requested) return self;
+
+        var next = self;
+        if (self.depth.active() and requested.active()) {
+            next = next.queue_bookmark();
+        }
+        next = switch (requested) {
+            .inline_mode => next.closed(),
+            .review => if (self.depth == .inline_mode)
+                next.open_review()
+            else blk: {
+                next.depth = .review;
+                break :blk next;
+            },
+            .full => blk: {
+                if (self.depth == .inline_mode) next = next.open_review();
+                next.depth = .full;
+                break :blk next;
+            },
+        };
+        return next;
+    }
+
+    pub fn closed(self: State) State {
+        var next = self.reset_viewport().clear_anchor();
+        next.depth = .inline_mode;
+        return next;
+    }
+
+    pub fn clear_anchor(self: State) State {
+        var next = self;
+        next.anchor_entry_id = null;
+        next.anchor_pending = false;
+        next.bookmark_entry_id = null;
+        next.bookmark_intra_row = 0;
+        next.bookmark_pending = false;
+        next.projection_cols = null;
+        return next;
+    }
+
+    pub fn capture_anchor(self: State, entry_id: ?u32) State {
+        var next = self;
+        next.anchor_entry_id = entry_id;
+        next.anchor_pending = entry_id != null;
+        return next;
+    }
+
+    pub fn retarget_anchor(self: State, entry_id: u32) State {
+        var next = self;
+        next.anchor_entry_id = entry_id;
+        return next;
+    }
+
+    pub fn prepare_projection(self: State, cols: u16) State {
+        var next = self;
+        if (next.projection_cols) |previous_cols| {
+            if (previous_cols != cols) next = next.queue_bookmark();
+        }
+        next.projection_cols = cols;
+        return next;
+    }
+
+    pub fn scroll(self: State, direction: ScrollDirection, rows: u32) State {
+        var next = self;
+        next.follow_tail = false;
+        next.bookmark_pending = false;
+        switch (direction) {
+            .up => next.scroll_rows -|= rows,
+            .down => next.scroll_rows +|= rows,
+        }
+        return next;
+    }
+
+    pub fn select_visual_offset(
+        self: State,
+        total_rows: u32,
+        visible_rows: u16,
+        item_rows: []const ItemRow,
+    ) OffsetSelection {
+        var next = self;
+        const max_offset = total_rows -| visible_rows;
+        const anchor_rows = resolve_bookmark_row(item_rows, next.anchor_entry_id);
+        const offset = if (next.bookmark_pending) blk: {
+            next.bookmark_pending = false;
+            next.follow_tail = false;
+            const item_row = resolve_bookmark_row(
+                item_rows,
+                next.bookmark_entry_id,
+            ) orelse break :blk @min(next.scroll_rows, max_offset);
+            const item_end = next_bookmark_item_row(item_rows, item_row) orelse
+                total_rows;
+            const max_intra_row = item_end -| item_row -| 1;
+            break :blk @min(
+                item_row +| @min(next.bookmark_intra_row, max_intra_row),
+                max_offset,
+            );
+        } else if (next.anchor_pending and anchor_rows != null) blk: {
+            next.anchor_pending = false;
+            next.follow_tail = false;
+            break :blk @min(anchor_rows.?, max_offset);
+        } else if (next.follow_tail)
+            max_offset
+        else
+            @min(next.scroll_rows, max_offset);
+
+        next.scroll_rows = offset;
+        next.follow_tail = offset == max_offset;
+        next = next.refresh_bookmark(item_rows, offset);
+        return .{ .state = next, .offset = offset };
+    }
+
+    pub fn snapshot(self: State) Snapshot {
+        return .{
+            .depth = self.depth,
+            .scroll_rows = self.scroll_rows,
+            .follow_tail = self.follow_tail,
+            .anchor_entry_id = self.anchor_entry_id,
+            .anchor_pending = self.anchor_pending,
+            .bookmark_entry_id = self.bookmark_entry_id,
+            .bookmark_intra_row = self.bookmark_intra_row,
+            .bookmark_pending = self.bookmark_pending,
+            .projection_cols = self.projection_cols,
+        };
+    }
+
+    pub fn from_snapshot(saved: Snapshot) State {
+        return .{
+            .depth = saved.depth,
+            .scroll_rows = saved.scroll_rows,
+            .follow_tail = saved.follow_tail,
+            .anchor_entry_id = saved.anchor_entry_id,
+            .anchor_pending = saved.anchor_pending,
+            .bookmark_entry_id = saved.bookmark_entry_id,
+            .bookmark_intra_row = saved.bookmark_intra_row,
+            .bookmark_pending = saved.bookmark_pending,
+            .projection_cols = saved.projection_cols,
+        };
+    }
+
+    fn open_review(self: State) State {
+        var next = self.reset_viewport();
+        next.depth = .review;
+        // The identity remains available for retention retargeting, but a
+        // normal open starts at the tail instead of consuming the old anchor.
+        next.anchor_pending = false;
+        return next;
+    }
+
+    fn reset_viewport(self: State) State {
+        var next = self;
+        next.scroll_rows = 0;
+        next.follow_tail = true;
+        return next;
+    }
+
+    fn queue_bookmark(self: State) State {
+        var next = self;
+        next.bookmark_pending = next.bookmark_entry_id != null;
+        return next;
+    }
+
+    fn refresh_bookmark(
+        self: State,
+        item_rows: []const ItemRow,
+        offset: u32,
+    ) State {
+        var selected: ?ItemRow = null;
+        for (item_rows) |item| {
+            if (item.row > offset) break;
+            selected = item;
+        }
+        const item = selected orelse if (item_rows.len > 0)
+            item_rows[0]
+        else
+            return self;
+        var next = self;
+        next.bookmark_entry_id = item.entry_id;
+        next.bookmark_intra_row = offset -| item.row;
+        return next;
+    }
+};
+
+fn resolve_bookmark_row(item_rows: []const ItemRow, entry_id: ?u32) ?u32 {
+    const target = entry_id orelse return null;
+    var preceding: ?ItemRow = null;
+    var following: ?ItemRow = null;
+    for (item_rows) |item| {
+        if (item.entry_id == target) return item.row;
+        if (item.entry_id < target) {
+            if (preceding == null or item.entry_id > preceding.?.entry_id) {
+                preceding = item;
+            }
+        } else if (following == null or item.entry_id < following.?.entry_id) {
+            following = item;
+        }
+    }
+    return if (preceding) |item|
+        item.row
+    else if (following) |item|
+        item.row
+    else
+        null;
+}
+
+fn next_bookmark_item_row(item_rows: []const ItemRow, current_row: u32) ?u32 {
+    for (item_rows) |item| {
+        if (item.row > current_row) return item.row;
+    }
+    return null;
+}
+
+test "transcript presentation depth preserves viewer transitions" {
+    const Case = struct {
+        from: Depth,
+        input: Event,
+        expected: Depth,
+    };
+    const cases = [_]Case{
+        .{ .from = .inline_mode, .input = .toggle, .expected = .review },
+        .{ .from = .review, .input = .toggle, .expected = .inline_mode },
+        .{ .from = .full, .input = .toggle, .expected = .inline_mode },
+        .{ .from = .inline_mode, .input = .left, .expected = .inline_mode },
+        .{ .from = .review, .input = .left, .expected = .review },
+        .{ .from = .full, .input = .left, .expected = .review },
+        .{ .from = .inline_mode, .input = .right, .expected = .inline_mode },
+        .{ .from = .review, .input = .right, .expected = .full },
+        .{ .from = .full, .input = .right, .expected = .full },
+    };
+
+    for (cases) |case| {
+        try std.testing.expectEqual(
+            case.expected,
+            case.from.transition(case.input),
+        );
+    }
+}
+
+test "transcript presentation scroll saturates and leaves follow tail" {
+    const initial = State{ .scroll_rows = 1 };
+    const at_start = initial.scroll(.up, 3);
+    try std.testing.expectEqual(@as(u32, 0), at_start.scroll_rows);
+    try std.testing.expect(!at_start.follow_tail);
+
+    const near_end = State{ .scroll_rows = std.math.maxInt(u32) - 1 };
+    const at_end = near_end.scroll(.down, 3);
+    try std.testing.expectEqual(std.math.maxInt(u32), at_end.scroll_rows);
+}
+
+test "transcript presentation preserves semantic item across depth and width" {
+    const initial = State{
+        .depth = .review,
+        .scroll_rows = 6,
+        .follow_tail = false,
+        .bookmark_entry_id = 20,
+        .bookmark_intra_row = 2,
+        .projection_cols = 80,
+    };
+    const resized = initial.with_depth(.full).prepare_projection(40);
+    try std.testing.expect(resized.bookmark_pending);
+
+    const selected = resized.select_visual_offset(20, 5, &.{
+        .{ .entry_id = 10, .row = 0 },
+        .{ .entry_id = 20, .row = 4 },
+        .{ .entry_id = 30, .row = 10 },
+    });
+    try std.testing.expectEqual(@as(u32, 6), selected.offset);
+    try std.testing.expectEqual(@as(?u32, 20), selected.state.bookmark_entry_id);
+    try std.testing.expectEqual(@as(u32, 2), selected.state.bookmark_intra_row);
+    try std.testing.expect(!selected.state.bookmark_pending);
+}
+
+test "transcript presentation clamps bookmarks and selects retained neighbor" {
+    const item_rows = [_]ItemRow{
+        .{ .entry_id = 10, .row = 1 },
+        .{ .entry_id = 30, .row = 8 },
+    };
+    const clamped = (State{
+        .scroll_rows = 4,
+        .follow_tail = false,
+        .bookmark_entry_id = 10,
+        .bookmark_intra_row = 99,
+        .bookmark_pending = true,
+    }).select_visual_offset(14, 4, &item_rows);
+    try std.testing.expectEqual(@as(u32, 7), clamped.offset);
+
+    const neighbor = (State{
+        .scroll_rows = 4,
+        .follow_tail = false,
+        .bookmark_entry_id = 20,
+        .bookmark_pending = true,
+    }).select_visual_offset(14, 4, &item_rows);
+    try std.testing.expectEqual(@as(u32, 1), neighbor.offset);
+    try std.testing.expectEqual(@as(?u32, 10), neighbor.state.bookmark_entry_id);
+
+    const following = (State{
+        .scroll_rows = 4,
+        .follow_tail = false,
+        .bookmark_entry_id = 5,
+        .bookmark_intra_row = 1,
+        .bookmark_pending = true,
+    }).select_visual_offset(14, 4, &item_rows);
+    try std.testing.expectEqual(@as(u32, 2), following.offset);
+    try std.testing.expectEqual(@as(?u32, 10), following.state.bookmark_entry_id);
+}
+
+test "transcript presentation snapshot round trips all state" {
+    const state = State{
+        .depth = .full,
+        .scroll_rows = 7,
+        .follow_tail = false,
+        .anchor_entry_id = 11,
+        .anchor_pending = true,
+        .bookmark_entry_id = 12,
+        .bookmark_intra_row = 2,
+        .bookmark_pending = true,
+        .projection_cols = 40,
+    };
+    try std.testing.expectEqualDeep(state, State.from_snapshot(state.snapshot()));
+}

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -17,6 +17,7 @@ const workspace_access = @import("../../core/workspace/workspace_access.zig");
 const file_index = @import("../../core/workspace/file_index.zig");
 const workspace_menu = @import("../../core/workspace/workspace_menu.zig");
 const activity_runtime = @import("../../core/output/activity_runtime.zig");
+const transcript_presentation = @import("../../core/output/transcript_presentation.zig");
 const usage_menu = @import("../../core/session/usage_menu.zig");
 const core_input_runtime = @import("../../core/input/runtime.zig");
 const presentation_mode = @import("../../core/config/presentation_mode.zig");
@@ -371,7 +372,7 @@ pub const RenderContext = struct {
     question: ?question_prompt.Projection = null,
     statusline: ui_render.StatuslineItems = .{},
     activity: ActivityProjection = .none,
-    transcript_depth: transcript_runtime.TranscriptPresentationDepth = .inline_mode,
+    transcript_depth: transcript_presentation.Depth = .inline_mode,
     input: *const InputRuntime,
 };
 

--- a/src/ui/full_transcript_screen.zig
+++ b/src/ui/full_transcript_screen.zig
@@ -9,6 +9,7 @@ const command_replay_store = @import("../core/session/command_replay_store.zig")
 const result_store = @import("../core/session/result_store.zig");
 const session_child_store = @import("../core/session/session_child_store.zig");
 const diff_mod = @import("../core/output/diff.zig");
+const transcript_presentation = @import("../core/output/transcript_presentation.zig");
 const assistant_wrap = @import("render_engine/assistant_wrap.zig");
 const build_checkpoint = @import("render_engine/build_checkpoint.zig");
 const transcript_blocks = @import("render_engine/transcript_blocks.zig");
@@ -402,7 +403,7 @@ pub const Projection = struct {
     segments: std.ArrayList(Segment) = .empty,
     anchor_segment_index: ?usize = null,
     item_boundaries: std.ArrayList(ItemBoundary) = .empty,
-    measured_item_rows: std.ArrayList(ItemRow) = .empty,
+    measured_item_rows: std.ArrayList(transcript_presentation.ItemRow) = .empty,
     measured_segment_checkpoints: std.ArrayList(ProjectionCheckpoint) = .empty,
     measurement_cols: ?u16 = null,
     measured_total_rows: u32 = 0,
@@ -627,15 +628,10 @@ test "projection applies actions by transcript position after lifecycle repositi
     try std.testing.expect(std.mem.find(u8, rendered, "old status") == null);
 }
 
-pub const ItemRow = struct {
-    entry_id: u32,
-    row: u32,
-};
-
 pub const ProjectionMeasurement = struct {
     total_rows: u32,
     anchor_row: ?u32,
-    item_rows: []const ItemRow = &.{},
+    item_rows: []const transcript_presentation.ItemRow = &.{},
 };
 
 /// Owns the in-progress static writer while composing a Projection, so every
@@ -4444,7 +4440,7 @@ pub fn measureProjectionInterruptible(
                 null
         else
             null;
-        var item_rows: std.ArrayList(ItemRow) = .empty;
+        var item_rows: std.ArrayList(transcript_presentation.ItemRow) = .empty;
         defer item_rows.deinit(alloc);
         var segment_checkpoints: std.ArrayList(ProjectionCheckpoint) = .empty;
         defer segment_checkpoints.deinit(alloc);
@@ -4513,7 +4509,7 @@ fn walkProjectionSegments(
     walker: *ProjectionRowWalker,
     start_segment_index: usize,
     start_item_index: usize,
-    item_rows: ?*std.ArrayList(ItemRow),
+    item_rows: ?*std.ArrayList(transcript_presentation.ItemRow),
     segment_checkpoints: ?*std.ArrayList(ProjectionCheckpoint),
 ) !?u32 {
     var anchor_row: ?u32 = null;

--- a/src/ui/subagent/controller.zig
+++ b/src/ui/subagent/controller.zig
@@ -8,6 +8,7 @@ const execution = @import("../../core/subagent/execution.zig");
 const domain = @import("../../core/subagent/domain.zig");
 const input_action = @import("../../core/input/input_action.zig");
 const core_input_runtime = @import("../../core/input/runtime.zig");
+const transcript_presentation = @import("../../core/output/transcript_presentation.zig");
 const skill_contract = @import("../../core/skills/skill_contract.zig");
 const subagent_runtime = @import("runtime.zig");
 const render_request = @import("../render_request.zig");
@@ -370,7 +371,7 @@ pub const Controller = struct {
 
     pub fn childTranscriptPresentationDepth(
         self: Controller,
-    ) transcript_runtime.TranscriptPresentationDepth {
+    ) transcript_presentation.Depth {
         if (!self.view_active) return .inline_mode;
         return self.runtime.childTranscriptPresentationDepth();
     }
@@ -378,8 +379,8 @@ pub const Controller = struct {
     pub fn setChildTranscriptPresentationDepth(
         self: *Controller,
         alloc: Allocator,
-        requested: transcript_runtime.TranscriptPresentationDepth,
-    ) !transcript_runtime.TranscriptPresentationDepth {
+        requested: transcript_presentation.Depth,
+    ) !transcript_presentation.Depth {
         if (!self.view_active) return .inline_mode;
         return self.runtime.setChildTranscriptPresentationDepth(
             alloc,

--- a/src/ui/subagent/runtime.zig
+++ b/src/ui/subagent/runtime.zig
@@ -6,6 +6,7 @@ const types = @import("../../core/shared/types.zig");
 const domain = @import("../../core/subagent/domain.zig");
 const execution = @import("../../core/subagent/execution.zig");
 const diff_mod = @import("../../core/output/diff.zig");
+const transcript_presentation = @import("../../core/output/transcript_presentation.zig");
 const worker_runtime = @import("../../core/agent/worker_runtime.zig");
 const io_mod = @import("../../core/shared/io.zig");
 const manager_mod = @import("../../core/subagent/manager.zig");
@@ -717,7 +718,7 @@ pub const ChildRouteState = struct {
     rendered_chat_rows: ?usize = null,
     viewport_mutation: ViewportMutation = .none,
     presentation: ?transcript_runtime.TranscriptRuntime = null,
-    presentation_transcript_depth: transcript_runtime.TranscriptPresentationDepth = .inline_mode,
+    presentation_transcript_depth: transcript_presentation.Depth = .inline_mode,
     presentation_live_work_id: ?[]u8 = null,
     presentation_live_event_count: usize = 0,
     presentation_next_diff_id: u32 = 1,
@@ -794,7 +795,7 @@ pub const ChildPresentationView = struct {
 const ChildViewportBookmark = struct {
     rows_from_bottom: usize,
     prior_total_rows: ?usize,
-    full_transcript: ?transcript_runtime.FullTranscriptViewportSnapshot,
+    full_transcript: ?transcript_presentation.Snapshot,
 };
 
 const ChildDraft = struct {
@@ -1887,7 +1888,7 @@ pub const Runtime = struct {
 
     pub fn childTranscriptPresentationDepth(
         self: Runtime,
-    ) transcript_runtime.TranscriptPresentationDepth {
+    ) transcript_presentation.Depth {
         if (self.childRouteId() == null) return .inline_mode;
         return self.child.presentation_transcript_depth;
     }
@@ -1895,8 +1896,8 @@ pub const Runtime = struct {
     pub fn setChildTranscriptPresentationDepth(
         self: *Runtime,
         alloc: Allocator,
-        requested: transcript_runtime.TranscriptPresentationDepth,
-    ) !transcript_runtime.TranscriptPresentationDepth {
+        requested: transcript_presentation.Depth,
+    ) !transcript_presentation.Depth {
         _ = self.childRouteId() orelse return .inline_mode;
         if (self.child.presentation) |*runtime| {
             _ = try runtime.setTranscriptPresentationDepth(alloc, requested);
@@ -3764,7 +3765,7 @@ pub const Runtime = struct {
 
     fn selectedChildFullTranscriptBookmark(
         self: *const Runtime,
-    ) ?transcript_runtime.FullTranscriptViewportSnapshot {
+    ) ?transcript_presentation.Snapshot {
         const child_id = self.childRouteId() orelse return null;
         const selected_id = self.selected_id orelse return null;
         if (!std.mem.eql(u8, selected_id, child_id)) return null;
@@ -7705,7 +7706,7 @@ test "child transcript depth survives transient presentation rebuilds" {
         try runtime.handle(alloc, .enter),
     );
     try std.testing.expectEqual(
-        transcript_runtime.TranscriptPresentationDepth.review,
+        transcript_presentation.Depth.review,
         try runtime.setChildTranscriptPresentationDepth(alloc, .review),
     );
     try std.testing.expect(runtime.childFullTranscriptRequested());
@@ -7743,7 +7744,7 @@ test "child transcript depth survives transient presentation rebuilds" {
 
     runtime.child.clearPresentation(alloc);
     try std.testing.expectEqual(
-        transcript_runtime.TranscriptPresentationDepth.full,
+        transcript_presentation.Depth.full,
         try runtime.setChildTranscriptPresentationDepth(alloc, .full),
     );
     try std.testing.expect(runtime.childFullTranscriptRequested());
@@ -7761,12 +7762,12 @@ test "child transcript depth survives transient presentation rebuilds" {
         runtime.childConversationRuntime().?.fullTranscriptActive(),
     );
     try std.testing.expectEqual(
-        transcript_runtime.TranscriptPresentationDepth.full,
+        transcript_presentation.Depth.full,
         runtime.childConversationRuntime().?.transcriptPresentationDepth(),
     );
 
     try std.testing.expectEqual(
-        transcript_runtime.TranscriptPresentationDepth.inline_mode,
+        transcript_presentation.Depth.inline_mode,
         try runtime.setChildTranscriptPresentationDepth(alloc, .inline_mode),
     );
     try std.testing.expect(

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -5,6 +5,7 @@ const input_action = @import("../../core/input/input_action.zig");
 const io_mod = @import("../../core/shared/io.zig");
 const activity_status = @import("../../core/output/activity_status.zig");
 const activity_runtime = @import("../../core/output/activity_runtime.zig");
+const transcript_presentation = @import("../../core/output/transcript_presentation.zig");
 const worker_status = @import("../../core/output/worker_status.zig");
 const footer_viewport_runtime = @import("../footer/viewport.zig");
 const render_request = @import("../render_request.zig");
@@ -903,7 +904,7 @@ test "full transcript projection cache survives navigation and invalidates on co
     try std.testing.expectEqual(@as(?u16, 40), review.measurement_cols);
     const same_review = try runtime.cachedFullTranscriptProjection(alloc, null);
     try std.testing.expectEqual(@as(?u16, 40), same_review.measurement_cols);
-    runtime.full_transcript.captureAnchor(1);
+    runtime.full_transcript = runtime.full_transcript.capture_anchor(1);
     const reanchored_review = try runtime.cachedFullTranscriptProjection(alloc, null);
     try std.testing.expectEqual(review, reanchored_review);
 
@@ -967,7 +968,7 @@ const CacheBuildProbe = struct {
     }
 };
 
-fn cacheTestRuntime(depth: TranscriptPresentationDepth, cols: u16) TranscriptRuntime {
+fn cacheTestRuntime(depth: transcript_presentation.Depth, cols: u16) TranscriptRuntime {
     var layout = testLayoutWithRows(8);
     layout.cols = cols;
     return .{
@@ -1020,7 +1021,7 @@ fn renderCacheTail(
 
 test "full transcript cache reuses retained entries across append and width changes" {
     const alloc = std.testing.allocator;
-    for ([_]TranscriptPresentationDepth{ .review, .full }) |depth| {
+    for ([_]transcript_presentation.Depth{ .review, .full }) |depth| {
         var runtime = cacheTestRuntime(depth, 40);
         defer runtime.deinit(alloc);
 
@@ -1240,7 +1241,7 @@ test "command and lifecycle updates reuse measured prefix and publish atomically
     try std.testing.expectEqual(baseline.total_rows, resumed.total_rows);
     try std.testing.expectEqual(baseline.anchor_row, resumed.anchor_row);
     try std.testing.expectEqualSlices(
-        full_transcript_screen.ItemRow,
+        transcript_presentation.ItemRow,
         baseline.item_rows,
         resumed.item_rows,
     );
@@ -1265,7 +1266,7 @@ test "command and lifecycle updates reuse measured prefix and publish atomically
     );
     try std.testing.expectEqual(closed_baseline.total_rows, closed_measurement.total_rows);
     try std.testing.expectEqualSlices(
-        full_transcript_screen.ItemRow,
+        transcript_presentation.ItemRow,
         closed_baseline.item_rows,
         closed_measurement.item_rows,
     );
@@ -1802,8 +1803,7 @@ test "full transcript opening follows the tail instead of consuming its compact 
         "anchor\n",
         .unknown_raw,
     );
-    runtime.full_transcript.captureAnchor(anchor_id);
-    runtime.full_transcript.openReview();
+    runtime.full_transcript = runtime.full_transcript.capture_anchor(anchor_id).with_depth(.review);
     _ = try runtime.appendRawTranscriptEntryClassified(
         alloc,
         "row-4\nrow-5\nrow-6\nrow-7\n",
@@ -1914,77 +1914,6 @@ test "full transcript recovery starts at closest visible entry before a hidden a
     try std.testing.expectEqual(
         @as(?usize, null),
         TranscriptRuntime.fullTranscriptRecoveryPredecessorStartLine(&provenance, 9),
-    );
-}
-
-test "full transcript depth changes preserve the semantic viewport item" {
-    var state = FullTranscriptState{
-        .depth = .full,
-        .scroll_rows = 8,
-        .follow_tail = false,
-        .bookmark_entry_id = 20,
-        .bookmark_intra_row = 2,
-        .bookmark_pending = true,
-    };
-    const item_rows = [_]full_transcript_screen.ItemRow{
-        .{ .entry_id = 10, .row = 4 },
-        .{ .entry_id = 20, .row = 40 },
-        .{ .entry_id = 30, .row = 70 },
-    };
-
-    try std.testing.expectEqual(
-        @as(u32, 42),
-        state.selectVisualOffset(100, 10, null, &item_rows),
-    );
-    try std.testing.expectEqual(@as(?u32, 20), state.bookmark_entry_id);
-    try std.testing.expectEqual(@as(u32, 2), state.bookmark_intra_row);
-    try std.testing.expect(!state.follow_tail);
-}
-
-test "semantic viewport bookmark clamps within its reflowed item" {
-    var state = FullTranscriptState{
-        .depth = .review,
-        .follow_tail = false,
-        .bookmark_entry_id = 20,
-        .bookmark_intra_row = 20,
-        .bookmark_pending = true,
-    };
-    const item_rows = [_]full_transcript_screen.ItemRow{
-        .{ .entry_id = 20, .row = 40 },
-        .{ .entry_id = 30, .row = 43 },
-    };
-
-    try std.testing.expectEqual(
-        @as(u32, 42),
-        state.selectVisualOffset(100, 10, null, &item_rows),
-    );
-    try std.testing.expectEqual(@as(?u32, 20), state.bookmark_entry_id);
-    try std.testing.expectEqual(@as(u32, 2), state.bookmark_intra_row);
-}
-
-test "missing semantic viewport item falls back to the nearest retained neighbor" {
-    const item_rows = [_]full_transcript_screen.ItemRow{
-        .{ .entry_id = 10, .row = 5 },
-        .{ .entry_id = 30, .row = 50 },
-    };
-    var preceding = FullTranscriptState{
-        .bookmark_entry_id = 20,
-        .bookmark_intra_row = 3,
-        .bookmark_pending = true,
-    };
-    try std.testing.expectEqual(
-        @as(u32, 8),
-        preceding.selectVisualOffset(100, 10, null, &item_rows),
-    );
-
-    var following = FullTranscriptState{
-        .bookmark_entry_id = 5,
-        .bookmark_intra_row = 1,
-        .bookmark_pending = true,
-    };
-    try std.testing.expectEqual(
-        @as(u32, 6),
-        following.selectVisualOffset(100, 10, null, &item_rows),
     );
 }
 
@@ -3791,219 +3720,11 @@ pub fn renderEntriesToBytes(
     return transcript_blocks.renderEntriesToBytes(alloc, entries, cols, styles);
 }
 
-pub const TranscriptPresentationEvent = enum {
-    toggle,
-    left,
-    right,
-};
-
-pub const TranscriptPresentationDepth = enum {
-    inline_mode,
-    review,
-    full,
-
-    pub fn transition(
-        self: TranscriptPresentationDepth,
-        event: TranscriptPresentationEvent,
-    ) TranscriptPresentationDepth {
-        return switch (event) {
-            .toggle => if (self == .inline_mode) .review else .inline_mode,
-            .left => if (self.active()) .review else .inline_mode,
-            .right => if (self.active()) .full else .inline_mode,
-        };
-    }
-
-    pub fn active(self: TranscriptPresentationDepth) bool {
-        return self != .inline_mode;
-    }
-};
-
-test "transcript presentation transition toggles viewer and selects detail with arrows" {
-    const Case = struct {
-        from: TranscriptPresentationDepth,
-        input: TranscriptPresentationEvent,
-        expected: TranscriptPresentationDepth,
-    };
-    const cases = [_]Case{
-        .{ .from = .inline_mode, .input = .toggle, .expected = .review },
-        .{ .from = .review, .input = .toggle, .expected = .inline_mode },
-        .{ .from = .full, .input = .toggle, .expected = .inline_mode },
-        .{ .from = .inline_mode, .input = .left, .expected = .inline_mode },
-        .{ .from = .review, .input = .left, .expected = .review },
-        .{ .from = .full, .input = .left, .expected = .review },
-        .{ .from = .inline_mode, .input = .right, .expected = .inline_mode },
-        .{ .from = .review, .input = .right, .expected = .full },
-        .{ .from = .full, .input = .right, .expected = .full },
-    };
-
-    for (cases) |case| {
-        try std.testing.expectEqual(
-            case.expected,
-            case.from.transition(case.input),
-        );
-    }
-}
-
 pub const FullTranscriptPrimaryRestore = enum {
     changed,
     changed_resized,
     exact,
     resized,
-};
-
-pub const FullTranscriptState = struct {
-    depth: TranscriptPresentationDepth = .inline_mode,
-    scroll_rows: u32 = 0,
-    follow_tail: bool = true,
-    anchor_entry_id: ?u32 = null,
-    anchor_pending: bool = false,
-    bookmark_entry_id: ?u32 = null,
-    bookmark_intra_row: u32 = 0,
-    bookmark_pending: bool = false,
-    projection_cols: ?u16 = null,
-
-    fn openReview(self: *FullTranscriptState) void {
-        self.depth = .review;
-        self.scroll_rows = 0;
-        self.follow_tail = true;
-        // Keep the compact source identity for retention retargeting, but an
-        // ordinary Ctrl-O open always starts at the latest full row.
-        self.anchor_pending = false;
-    }
-
-    fn close(self: *FullTranscriptState) void {
-        self.depth = .inline_mode;
-        self.resetViewport();
-        self.clearAnchor();
-    }
-
-    fn resetViewport(self: *FullTranscriptState) void {
-        self.scroll_rows = 0;
-        self.follow_tail = true;
-    }
-
-    fn clearAnchor(self: *FullTranscriptState) void {
-        self.anchor_entry_id = null;
-        self.anchor_pending = false;
-        self.bookmark_entry_id = null;
-        self.bookmark_intra_row = 0;
-        self.bookmark_pending = false;
-        self.projection_cols = null;
-    }
-
-    fn captureAnchor(self: *FullTranscriptState, entry_id: ?u32) void {
-        self.anchor_entry_id = entry_id;
-        self.anchor_pending = entry_id != null;
-    }
-
-    fn retargetAnchor(self: *FullTranscriptState, entry_id: u32) void {
-        self.anchor_entry_id = entry_id;
-    }
-
-    fn selectVisualOffset(
-        self: *FullTranscriptState,
-        total_rows: u32,
-        visible_rows: u16,
-        anchor_rows: ?u32,
-        item_rows: []const full_transcript_screen.ItemRow,
-    ) u32 {
-        const max_offset = total_rows -| visible_rows;
-        const offset = if (self.bookmark_pending) blk: {
-            self.bookmark_pending = false;
-            self.follow_tail = false;
-            const item_row = resolveBookmarkRow(item_rows, self.bookmark_entry_id) orelse
-                break :blk @min(self.scroll_rows, max_offset);
-            const item_end = nextBookmarkItemRow(item_rows, item_row) orelse total_rows;
-            const max_intra_row = item_end -| item_row -| 1;
-            break :blk @min(
-                item_row +| @min(self.bookmark_intra_row, max_intra_row),
-                max_offset,
-            );
-        } else if (self.anchor_pending and anchor_rows != null) blk: {
-            self.anchor_pending = false;
-            self.follow_tail = false;
-            break :blk @min(anchor_rows.?, max_offset);
-        } else if (self.follow_tail)
-            max_offset
-        else
-            @min(self.scroll_rows, max_offset);
-        self.scroll_rows = offset;
-        self.follow_tail = offset == max_offset;
-        self.refreshBookmark(item_rows, offset);
-        return offset;
-    }
-
-    fn queueBookmark(self: *FullTranscriptState) void {
-        self.bookmark_pending = self.bookmark_entry_id != null;
-    }
-
-    fn refreshBookmark(
-        self: *FullTranscriptState,
-        item_rows: []const full_transcript_screen.ItemRow,
-        offset: u32,
-    ) void {
-        var selected: ?full_transcript_screen.ItemRow = null;
-        for (item_rows) |item| {
-            if (item.row > offset) break;
-            selected = item;
-        }
-        const item = selected orelse if (item_rows.len > 0) item_rows[0] else return;
-        self.bookmark_entry_id = item.entry_id;
-        self.bookmark_intra_row = offset -| item.row;
-    }
-
-    fn scroll(
-        self: *FullTranscriptState,
-        direction: input_action.MouseWheel,
-        rows: u32,
-    ) void {
-        self.follow_tail = false;
-        self.bookmark_pending = false;
-        switch (direction) {
-            .up => self.scroll_rows -|= rows,
-            .down => self.scroll_rows +|= rows,
-        }
-    }
-};
-
-fn resolveBookmarkRow(
-    item_rows: []const full_transcript_screen.ItemRow,
-    entry_id: ?u32,
-) ?u32 {
-    const target = entry_id orelse return null;
-    var preceding: ?full_transcript_screen.ItemRow = null;
-    var following: ?full_transcript_screen.ItemRow = null;
-    for (item_rows) |item| {
-        if (item.entry_id == target) return item.row;
-        if (item.entry_id < target) {
-            if (preceding == null or item.entry_id > preceding.?.entry_id) preceding = item;
-        } else if (following == null or item.entry_id < following.?.entry_id) {
-            following = item;
-        }
-    }
-    return if (preceding) |item| item.row else if (following) |item| item.row else null;
-}
-
-fn nextBookmarkItemRow(
-    item_rows: []const full_transcript_screen.ItemRow,
-    current_row: u32,
-) ?u32 {
-    for (item_rows) |item| {
-        if (item.row > current_row) return item.row;
-    }
-    return null;
-}
-
-pub const FullTranscriptViewportSnapshot = struct {
-    depth: TranscriptPresentationDepth,
-    scroll_rows: u32,
-    follow_tail: bool,
-    anchor_entry_id: ?u32,
-    anchor_pending: bool,
-    bookmark_entry_id: ?u32,
-    bookmark_intra_row: u32,
-    bookmark_pending: bool,
-    projection_cols: ?u16,
 };
 
 const ProjectionCacheDirty = union(enum) {
@@ -4363,7 +4084,7 @@ pub const TranscriptRuntime = struct {
     command_output_blocks: std.ArrayList(CommandOutputBlock) = .empty,
     /// Viewer state used only while Ctrl-O owns the alternate screen.
     /// The compact transcript keeps its independent viewport selection.
-    full_transcript: FullTranscriptState = .{},
+    full_transcript: transcript_presentation.State = .{},
     full_transcript_open_content_revision: ?u64 = null,
     full_transcript_open_cols: u16 = 0,
     full_transcript_open_rows: u16 = 0,
@@ -5947,7 +5668,7 @@ pub const TranscriptRuntime = struct {
         self.compact_transcript_source_cache.deinit(alloc);
         self.full_transcript_projection_cache.deinit(alloc);
         self.clearToolDetails(alloc);
-        self.full_transcript.close();
+        self.full_transcript = self.full_transcript.closed();
     }
 
     pub fn resetCommandOutputDisplay(self: *TranscriptRuntime, alloc: Allocator, reason: []const u8) void {
@@ -6205,29 +5926,17 @@ pub const TranscriptRuntime = struct {
     pub fn setTranscriptPresentationDepth(
         self: *TranscriptRuntime,
         alloc: Allocator,
-        depth: TranscriptPresentationDepth,
+        depth: transcript_presentation.Depth,
     ) !bool {
         const current = self.full_transcript.depth;
         if (current == depth) return false;
-        if (current.active() and depth.active()) self.full_transcript.queueBookmark();
         if (current == .inline_mode and depth != .inline_mode) {
             self.full_transcript_open_content_revision = self.full_transcript_content_revision;
             self.full_transcript_open_cols = self.layout.cols;
             self.full_transcript_open_rows = self.layout.rows;
             try self.captureFullTranscriptAnchor(alloc);
         }
-        switch (depth) {
-            .inline_mode => self.full_transcript.close(),
-            .review => if (current == .inline_mode) {
-                self.full_transcript.openReview();
-            } else {
-                self.full_transcript.depth = .review;
-            },
-            .full => {
-                if (current == .inline_mode) self.full_transcript.openReview();
-                self.full_transcript.depth = .full;
-            },
-        }
+        self.full_transcript = self.full_transcript.with_depth(depth);
         if (depth == .inline_mode) {
             self.full_transcript_open_content_revision = null;
             self.full_transcript_open_cols = 0;
@@ -6346,7 +6055,7 @@ pub const TranscriptRuntime = struct {
 
     fn captureFullTranscriptAnchor(self: *TranscriptRuntime, alloc: Allocator) !void {
         _ = alloc;
-        self.full_transcript.clearAnchor();
+        self.full_transcript = self.full_transcript.clear_anchor();
         const fallback_recovery_entry_id = self.primaryRecoveryFallbackEntryId();
         self.full_transcript_primary_recovery_entry_id = fallback_recovery_entry_id;
         const selection = self.last_viewport_selection orelse return;
@@ -6368,7 +6077,7 @@ pub const TranscriptRuntime = struct {
             null;
         self.full_transcript_primary_recovery_entry_id =
             source_entry_id orelse fallback_recovery_entry_id;
-        self.full_transcript.captureAnchor(anchor_entry_id);
+        self.full_transcript = self.full_transcript.capture_anchor(anchor_entry_id);
     }
 
     fn primaryRecoveryFallbackEntryId(self: *const TranscriptRuntime) ?u32 {
@@ -6407,41 +6116,21 @@ pub const TranscriptRuntime = struct {
 
     pub fn transcriptPresentationDepth(
         self: *const TranscriptRuntime,
-    ) TranscriptPresentationDepth {
+    ) transcript_presentation.Depth {
         return self.full_transcript.depth;
     }
 
     pub fn snapshotFullTranscriptViewport(
         self: *const TranscriptRuntime,
-    ) FullTranscriptViewportSnapshot {
-        return .{
-            .depth = self.full_transcript.depth,
-            .scroll_rows = self.full_transcript.scroll_rows,
-            .follow_tail = self.full_transcript.follow_tail,
-            .anchor_entry_id = self.full_transcript.anchor_entry_id,
-            .anchor_pending = self.full_transcript.anchor_pending,
-            .bookmark_entry_id = self.full_transcript.bookmark_entry_id,
-            .bookmark_intra_row = self.full_transcript.bookmark_intra_row,
-            .bookmark_pending = self.full_transcript.bookmark_pending,
-            .projection_cols = self.full_transcript.projection_cols,
-        };
+    ) transcript_presentation.Snapshot {
+        return self.full_transcript.snapshot();
     }
 
     pub fn restoreFullTranscriptViewport(
         self: *TranscriptRuntime,
-        snapshot: FullTranscriptViewportSnapshot,
+        snapshot: transcript_presentation.Snapshot,
     ) void {
-        self.full_transcript = .{
-            .depth = snapshot.depth,
-            .scroll_rows = snapshot.scroll_rows,
-            .follow_tail = snapshot.follow_tail,
-            .anchor_entry_id = snapshot.anchor_entry_id,
-            .anchor_pending = snapshot.anchor_pending,
-            .bookmark_entry_id = snapshot.bookmark_entry_id,
-            .bookmark_intra_row = snapshot.bookmark_intra_row,
-            .bookmark_pending = snapshot.bookmark_pending,
-            .projection_cols = snapshot.projection_cols,
-        };
+        self.full_transcript = .from_snapshot(snapshot);
         self.markTranscriptDirty();
     }
 
@@ -6471,7 +6160,7 @@ pub const TranscriptRuntime = struct {
     }
 
     pub fn closeFullTranscriptState(self: *TranscriptRuntime) void {
-        self.full_transcript.close();
+        self.full_transcript = self.full_transcript.closed();
     }
 
     pub fn fullTranscriptAnchorEntryId(self: *const TranscriptRuntime) ?u32 {
@@ -6479,7 +6168,7 @@ pub const TranscriptRuntime = struct {
     }
 
     pub fn retargetFullTranscriptAnchor(self: *TranscriptRuntime, entry_id: u32) void {
-        self.full_transcript.retargetAnchor(entry_id);
+        self.full_transcript = self.full_transcript.retarget_anchor(entry_id);
     }
 
     pub fn scrollFullTranscript(
@@ -6492,7 +6181,10 @@ pub const TranscriptRuntime = struct {
             .page => self.fullTranscriptPageRows(),
         };
         const before = self.full_transcript.scroll_rows;
-        self.full_transcript.scroll(direction, rows);
+        self.full_transcript = self.full_transcript.scroll(switch (direction) {
+            .up => .up,
+            .down => .down,
+        }, rows);
         debug_trace.logf(
             "full_transcript_cache",
             "scroll depth={s} direction={s} unit={s} rows={d} before={d} after={d}",
@@ -9539,10 +9231,9 @@ pub const TranscriptRuntime = struct {
     }
 
     fn prepareFullTranscriptProjectionLayout(self: *TranscriptRuntime) void {
-        if (self.full_transcript.projection_cols) |previous_cols| {
-            if (previous_cols != self.layout.cols) self.full_transcript.queueBookmark();
-        }
-        self.full_transcript.projection_cols = self.layout.cols;
+        self.full_transcript = self.full_transcript.prepare_projection(
+            self.layout.cols,
+        );
     }
 
     fn buildFullTranscriptProjectionUncached(
@@ -9744,15 +9435,13 @@ pub const TranscriptRuntime = struct {
         visible_rows: u16,
     ) u32 {
         const self: *TranscriptRuntime = @ptrCast(@alignCast(context));
-        return self.full_transcript.selectVisualOffset(
+        const selection = self.full_transcript.select_visual_offset(
             measurement.total_rows,
             visible_rows,
-            resolveBookmarkRow(
-                measurement.item_rows,
-                self.fullTranscriptAnchorEntryId(),
-            ),
             measurement.item_rows,
         );
+        self.full_transcript = selection.state;
+        return selection.offset;
     }
 
     pub fn prepareTranscriptSurfacePaintFromSourceForArea(


### PR DESCRIPTION
## Summary

- Keep root and selected-child transcript navigation on the same state transition rules.
- Preserve review/full switching, scrolling, resize retargeting, and viewport restoration.
- Remove the previous UI-owned presentation state path after the Core cutover.