### PR TITLE
Keep retained cancellation frames aligned

### DIFF
--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2907,6 +2907,55 @@ test "cancel notice keeps one blank row before idle footer" {
     try expectExactlyOneBlankRowBetween(&h, cancel_row, footer_row);
 }
 
+test "settled cancel projection keeps the retained transcript aligned with the footer" {
+    var h = try Harness.init(std.testing.allocator, 125, 37, 4);
+    defer h.deinit();
+
+    var input = InputRuntime{};
+    defer input.deinit(h.alloc);
+    var approval: approval_prompt.ApprovalPrompt = .{};
+    defer approval.deinit(h.alloc);
+
+    try h.shell.initViewport(&h.metrics, 1);
+    _ = try h.shell.appendRawTranscriptEntryClassified(
+        h.alloc,
+        "line 01\nline 02\nline 03\nline 04\nline 05\nline 06\nline 07\n" ++
+            "line 08\nline 09\nline 10\nline 11\nline 12\nline 13\nline 14\n" ++
+            "line 15\nline 16\nline 17\nline 18\nline 19\nline 20\nline 21\n" ++
+            "line 22\nline 23\nline 24\nline 25\nline 26\nline 27\nline 28\n" ++
+            "line 29\nline 30\nline 31\nline 32\nline 33\nline 34\n",
+        .subagent_status,
+    );
+    try input.textReplacementState().replace(h.alloc, "/");
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    _ = try h.shell.appendRawTranscriptEntryClassified(
+        h.alloc,
+        "cancelled\n",
+        .question_resolution,
+    );
+    input.picker.dismissInlinePicker(.slash);
+    input.inputResetState().clearCurrent(h.alloc);
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    const cancel_row = try findRowContaining(&h, "cancelled");
+    const initial_footer_row = try findFirstDividerRowAfter(&h, cancel_row);
+    try expectExactlyOneBlankRowBetween(&h, cancel_row, initial_footer_row);
+
+    h.shell.render_requests.request(.footer);
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    const settled_footer_row = try findFirstDividerRowAfter(&h, cancel_row);
+    try std.testing.expectEqual(TestBodyDisposition.retain, h.last_frame.body_disposition);
+    try std.testing.expectEqual(initial_footer_row, settled_footer_row);
+    try expectExactlyOneBlankRowBetween(&h, cancel_row, settled_footer_row);
+}
+
 test "question prompt footer state does not mutate transcript gaps" {
     var h = try Harness.init(std.testing.allocator, 80, 24, 4);
     defer h.deinit();

--- a/src/ui/transcript/painter.zig
+++ b/src/ui/transcript/painter.zig
@@ -6,7 +6,7 @@
 //   replaceable_last_line, replaceable_row, replaceable_start,
 //   last_rendered_cols, last_paint_bottom_reserved_rows,
 //   last_visible_transcript_*, last_viewport_selection,
-//   paint_trace, has_painted_transcript,
+//   paint_trace, has_painted_transcript, resize_bottom_anchor_pending,
 //   footer_viewport, full_transcript, folded_command_blocks
 // - methods: ensurePaintReservation, beginPaint, endPaint,
 //   resetCursorTracking, advanceCursor,
@@ -1935,6 +1935,10 @@ fn prepareTranscriptSurfacePaintInternal(
                     stable.flow_unchanged and
                     stable.visual_offset == stable.history_visual_offset and
                     source.tail_kind != .assistant_turn;
+                const resize_anchored_cancel_growth =
+                    !stable.flow_unchanged and
+                    self.resize_bottom_anchor_pending and
+                    source.tail_kind == .cancel_notice;
                 const repaint_required = self.render_requests.attemptHasInvalidations();
                 const invalidation_allows_preservation =
                     !repaint_required or
@@ -1962,6 +1966,15 @@ fn prepareTranscriptSurfacePaintInternal(
                         "transcript_projection_history_floor source_offset={d} natural_offset={d}",
                         .{ stable.history_visual_offset, next_offset },
                     );
+                }
+                if (resize_anchored_cancel_growth and
+                    rows_budget > 0 and
+                    rows_budget < visible_rows)
+                {
+                    top_row += rows_budget;
+                    visible_rows -= rows_budget;
+                    prepared.projection_area.top = top_row;
+                    viewport_selection_snapshot.top_row = top_row;
                 }
                 if (invalidation_allows_preservation and
                     (!allow_projection_rebase or

--- a/src/ui/transcript/painter.zig
+++ b/src/ui/transcript/painter.zig
@@ -1935,8 +1935,9 @@ fn prepareTranscriptSurfacePaintInternal(
                     stable.flow_unchanged and
                     stable.visual_offset == stable.history_visual_offset and
                     source.tail_kind != .assistant_turn;
+                const repaint_required = self.render_requests.attemptHasInvalidations();
                 const invalidation_allows_preservation =
-                    !self.render_requests.attemptHasInvalidations() or
+                    !repaint_required or
                     settled_history_reflow;
                 const next_offset = prepared.sourceVisualOffsetFor(viewport_selection_snapshot);
                 if (allow_projection_rebase and
@@ -1976,11 +1977,13 @@ fn prepareTranscriptSurfacePaintInternal(
                         viewport_selection_snapshot.partial_skip_rows = committed.partial_skip_rows;
                         const stable_occupied_rows =
                             stable.occupied_last_row -| stable.selection.top_row +| 1;
-                        if (settled_history_reflow and
+                        const align_stable_cancel_to_bottom =
+                            (repaint_required or stable.occupied_last_row == bottom_row) and
+                            settled_history_reflow and
                             source.tail_kind == .cancel_notice and
                             stable_occupied_rows > 0 and
-                            stable_occupied_rows < visible_rows)
-                        {
+                            stable_occupied_rows < visible_rows;
+                        if (align_stable_cancel_to_bottom) {
                             top_row = bottom_row - stable_occupied_rows + 1;
                             visible_rows = stable_occupied_rows;
                             prepared.projection_area.top = top_row;

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -249,6 +249,60 @@ pub const TranscriptBodyDisposition = union(enum) {
     retain_committed: RetainedTranscriptBody,
 };
 
+fn nextResizeBottomAnchorPending(
+    pending: bool,
+    terminal_reset_commit: bool,
+    resize_reset_commit: bool,
+    tail_kind: ?TranscriptBlockKind,
+    occupied_last_row: u16,
+    content_bottom_row: u16,
+) bool {
+    const next = if (terminal_reset_commit)
+        resize_reset_commit
+    else
+        pending;
+    if (tail_kind == .cancel_notice and
+        occupied_last_row == content_bottom_row)
+    {
+        return false;
+    }
+    return next;
+}
+
+test "resize bottom anchor remains pending until a cancel projection reaches it" {
+    const Case = struct {
+        pending: bool,
+        terminal_reset_commit: bool,
+        resize_reset_commit: bool,
+        tail_kind: ?TranscriptBlockKind,
+        occupied_last_row: u16,
+        content_bottom_row: u16,
+        expected: bool,
+    };
+    const cases = [_]Case{
+        .{ .pending = false, .terminal_reset_commit = false, .resize_reset_commit = false, .tail_kind = null, .occupied_last_row = 4, .content_bottom_row = 8, .expected = false },
+        .{ .pending = false, .terminal_reset_commit = true, .resize_reset_commit = true, .tail_kind = null, .occupied_last_row = 4, .content_bottom_row = 8, .expected = true },
+        .{ .pending = true, .terminal_reset_commit = false, .resize_reset_commit = false, .tail_kind = .assistant_turn, .occupied_last_row = 4, .content_bottom_row = 8, .expected = true },
+        .{ .pending = true, .terminal_reset_commit = false, .resize_reset_commit = false, .tail_kind = .cancel_notice, .occupied_last_row = 4, .content_bottom_row = 8, .expected = true },
+        .{ .pending = true, .terminal_reset_commit = false, .resize_reset_commit = false, .tail_kind = .cancel_notice, .occupied_last_row = 8, .content_bottom_row = 8, .expected = false },
+        .{ .pending = true, .terminal_reset_commit = true, .resize_reset_commit = false, .tail_kind = null, .occupied_last_row = 4, .content_bottom_row = 8, .expected = false },
+    };
+
+    for (cases) |case| {
+        try std.testing.expectEqual(
+            case.expected,
+            nextResizeBottomAnchorPending(
+                case.pending,
+                case.terminal_reset_commit,
+                case.resize_reset_commit,
+                case.tail_kind,
+                case.occupied_last_row,
+                case.content_bottom_row,
+            ),
+        );
+    }
+}
+
 const MaterializedEndpoint = struct {
     visual_offset: u32 = 0,
     visual_rows: u16 = 0,
@@ -4286,6 +4340,9 @@ pub const TranscriptRuntime = struct {
     /// A settled terminal resize needs a canonical repaint from row one.
     /// It remains pending until the reset frame commits successfully.
     terminal_reset_pending: bool = false,
+    /// A committed resize reset established terminal-bottom ownership that
+    /// the next cancellation projection must preserve.
+    resize_bottom_anchor_pending: bool = false,
     render_requests: render_request.RenderRequestState = .{},
     maxxing_mode: presentation_mode.MaxxingMode = presentation_mode.MaxxingMode.default,
     /// Set after the frame commit path has successfully written and fed
@@ -8549,12 +8606,30 @@ pub const TranscriptRuntime = struct {
         result: render_engine.terminal_diff.FrameCommitResult,
         transition: ?*TranscriptTransition,
     ) void {
+        const terminal_reset_commit =
+            result.is_committed() and self.terminal_reset_pending;
+        const resize_reset_commit =
+            terminal_reset_commit and
+            (self.pending_resize_observation != null or
+                self.resize_history_row_delta != null);
         const scroll_commit = result.scrollCommit(scroll_plan);
         self.ackPreservedRowReleaseCommit(scroll_plan, scroll_commit);
         if (transition) |value| {
             std.debug.assert(std.meta.eql(scroll_plan, value.scroll_plan));
             self.consumeTranscriptTransitionWithCommit(alloc, value, result, scroll_commit);
         }
+        const committed_selection = if (result.is_committed())
+            if (transition) |value| value.selection else null
+        else
+            null;
+        self.resize_bottom_anchor_pending = nextResizeBottomAnchorPending(
+            self.resize_bottom_anchor_pending,
+            terminal_reset_commit,
+            resize_reset_commit,
+            if (committed_selection) |selection| selection.tail_kind else null,
+            if (committed_selection) |selection| selection.last_visible_row else 0,
+            self.layout.content_bottom,
+        );
     }
 
     fn consumeTranscriptTransitionWithCommit(

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3248,12 +3248,12 @@ describe("gateway stream lifecycle", () => {
       expect(result.signal).toBeNull();
       expect(result.stdout).toContain(expectedOutput);
       expect(result.stderr).toContain(
-        "Provider unavailable · retrying request · attempt 5/10",
+        "Provider unavailable · HTTP 503 · provider temporarily unavailable · retrying request · attempt 5/10",
       );
-      expect(result.stderr).toContain(
-        "Network interrupted · retrying request · attempt 6/10",
+      expect(result.stderr).toMatch(
+        /Network interrupted · [^\r\n]+ · retrying request · attempt 6\/10/,
       );
-      expect(result.stderr).not.toContain("Network interrupted · retrying request in 16s");
+      expect(result.stderr).not.toContain("retrying request in 16s");
       expect(result.stderr).toContain("recovered · succeeded on attempt 7/10");
       expect(connections).toBe(7);
       expect(requests).toBe(6);

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -481,6 +481,10 @@ test.skipIf(!tmuxAvailable())(
 
     await active.sendText(`!${scriptPath}`);
     await active.waitForText("Running ", TIMEOUT);
+    await waitForTerminalRecord(
+      fixture.home,
+      (record) => record.command === scriptPath && record.lifecycle === "running",
+    );
     await active.sendLiteralText("TAKEOVER_INLINE_DRAFT");
     await active.sendKeys("C-x");
     await active.waitForText("Background processes", TIMEOUT);


### PR DESCRIPTION
## Summary

- Keep the composer aligned when a settled cancellation frame retains the existing transcript.
- Preserve bottom-aligned cancellation repainting after terminal resize.