### PR TITLE
Notify parent agents of child approvals

### DIFF
--- a/src/core/agent/runtime/deps.zig
+++ b/src/core/agent/runtime/deps.zig
@@ -147,7 +147,9 @@ pub const ParentTurnDeliveryAck = struct {
 };
 
 /// Slices are owned by the allocator passed to `prepare_parent_turn_context`
-/// and remain valid for the whole agent turn.
+/// and remain valid until that allocator is reset or deinitialized. The caller
+/// must finish every acknowledgement callback before ending that lifetime;
+/// acknowledgement callbacks borrow these slices only for the callback.
 pub const PreparedParentTurnContext = struct {
     content: []const u8,
     acknowledgements: []const ParentTurnDeliveryAck,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -363,13 +363,13 @@ const ParentTurnDeliveryState = struct {
 fn appendPreparedParentTurnContext(
     deps: *const AgentRuntimeDeps,
     arena: Allocator,
-    stable_prefix: *std.ArrayList(ChatMessage),
+    messages: *std.ArrayList(ChatMessage),
 ) !ParentTurnDeliveryState {
     const prepare = deps.prepare_parent_turn_context orelse return .{};
     const prepared = try prepare(deps.ctx, arena) orelse return .{};
     if (prepared.content.len == 0) return .{};
-    try stable_prefix.ensureUnusedCapacity(arena, 1);
-    stable_prefix.appendAssumeCapacity(.{
+    try messages.ensureUnusedCapacity(arena, 1);
+    messages.appendAssumeCapacity(.{
         .role = .system,
         .content = prepared.content,
     });
@@ -1718,11 +1718,6 @@ fn processQueuedPromptInner(
     if (deps.append_static_context) |append_static_context| {
         try append_static_context(deps.ctx, arena, &stable_prefix);
     }
-    var parent_turn_delivery = try appendPreparedParentTurnContext(
-        deps,
-        arena,
-        &stable_prefix,
-    );
     var request_capabilities = deps.available_model_capabilities(deps.ctx, job.model);
     if (requiresResolvedRequestCapabilities(
         job.images.len > 0 or job.authorized_image_catalog.len > 0,
@@ -1821,7 +1816,6 @@ fn processQueuedPromptInner(
         &summary_accumulator,
         &finish_trace,
         &interrupted_persisted,
-        &parent_turn_delivery,
         current_user_message,
         &stop_state,
     ) catch |err| {
@@ -2179,7 +2173,6 @@ fn processQueuedPromptLoop(
     summary_accumulator_ptr: *runtime_telemetry.TurnSummaryAccumulator,
     finish_trace_ptr: *PromptFinishTrace,
     interrupted_persisted_ptr: *bool,
-    parent_turn_delivery: *ParentTurnDeliveryState,
     current_user_message: ChatMessage,
     stop_state: *CommonStopState,
 ) !void {
@@ -2304,6 +2297,11 @@ fn processQueuedPromptLoop(
             try ephemeral_overlay.append(overlay_arena, .{ .role = .system, .content = config.explicit_skills_prompt_section });
         }
         try deps.append_runtime_context(deps.ctx, overlay_arena, &ephemeral_overlay);
+        var parent_turn_delivery = try appendPreparedParentTurnContext(
+            deps,
+            overlay_arena,
+            &ephemeral_overlay,
+        );
         var gateway_messages = try runtime_prompt_context.buildGatewayMessages(overlay_arena, stable_prefix.items, ephemeral_overlay.items, history_messages.items, current_user_effective, within_turn_suffix.items);
         last_gateway_message_count = gateway_messages.items.len;
         const history_start_index = stable_prefix.items.len + ephemeral_overlay.items.len;
@@ -2620,7 +2618,7 @@ fn processQueuedPromptLoop(
             ) catch |err| {
                 parent_turn_delivery.observeGatewayDelivery(
                     deps,
-                    arena,
+                    overlay_arena,
                     gateway_delivery.load(),
                 );
                 runtime_assistant_stream.pushTokenProgressUpdate(&stream_ctx, summary_accumulator.finishTokenRequestWithoutUsage(gateway_delivery.load() == .possibly_sent)) catch |progress_err| {
@@ -2934,7 +2932,7 @@ fn processQueuedPromptLoop(
             };
             parent_turn_delivery.observeGatewayDelivery(
                 deps,
-                arena,
+                overlay_arena,
                 gateway_delivery.load(),
             );
             stream_result_set = true;

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3218,10 +3218,11 @@ test "processQueuedPrompt refreshes runtime overlay each step and preserves turn
     try expectBodyContainsInOrder(&gateway, 1, &second_request_order);
 }
 
-test "processQueuedPrompt prepares parent deliveries once and reuses them across tool steps" {
+test "processQueuedPrompt refreshes and acknowledges parent deliveries for each tool step" {
     const alloc = std.testing.allocator;
     const calls = [_]ToolCall{toolCall("call_read", "read_file", "{\"path\":\"a\"}")};
     const completions = [_]FakeCompletion{
+        .{ .finish_reason = .provider_error },
         .{ .content = "Checking.", .tool_calls = &calls },
         .{ .content = "Final" },
     };
@@ -3230,22 +3231,27 @@ test "processQueuedPrompt prepares parent deliveries once and reuses them across
     var hooks = FakeAgentRuntimeDeps.init(alloc);
     defer hooks.deinit();
     const prepared_contexts = [_][]const u8{
-        "prepared child delivery for this parent turn",
-        "must not be read during the same parent turn",
+        "prepared child delivery for step one",
+        "prepared child delivery for step two",
     };
     hooks.parent_turn_context_texts = &prepared_contexts;
     var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.max_provider_attempts = 2;
 
-    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
-    try std.testing.expectEqual(@as(usize, 1), hooks.parent_turn_prepare_count);
-    try std.testing.expectEqual(@as(usize, 1), hooks.parent_turn_ack_count);
-    try std.testing.expectEqual(@as(u64, 1), hooks.parent_turn_last_ack_sequence);
-    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
-    try expectBodyContains(&gateway, 0, "prepared child delivery for this parent turn");
-    try expectBodyContains(&gateway, 1, "prepared child delivery for this parent turn");
-    try expectBodyNotContains(&gateway, 0, "must not be read during the same parent turn");
-    try expectBodyNotContains(&gateway, 1, "must not be read during the same parent turn");
+    try std.testing.expectEqual(@as(usize, 2), hooks.parent_turn_prepare_count);
+    try std.testing.expectEqual(@as(usize, 2), hooks.parent_turn_ack_count);
+    try std.testing.expectEqual(@as(u64, 2), hooks.parent_turn_last_ack_sequence);
+    try std.testing.expect(hooks.parent_turn_ack_contract_valid);
+    try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
+    try expectBodyContains(&gateway, 0, "prepared child delivery for step one");
+    try expectBodyNotContains(&gateway, 0, "prepared child delivery for step two");
+    try expectBodyContains(&gateway, 1, "prepared child delivery for step one");
+    try expectBodyNotContains(&gateway, 1, "prepared child delivery for step two");
+    try expectBodyContains(&gateway, 2, "prepared child delivery for step two");
+    try expectBodyNotContains(&gateway, 2, "prepared child delivery for step one");
 }
 
 test "processQueuedPrompt leaves parent delivery pending after pre-dispatch cancellation" {
@@ -3262,7 +3268,7 @@ test "processQueuedPrompt leaves parent delivery pending after pre-dispatch canc
 
     try runFakePrompt(&first_gateway, &hooks, fixture.config(), fixture.job());
 
-    try std.testing.expectEqual(@as(usize, 1), hooks.parent_turn_prepare_count);
+    try std.testing.expectEqual(@as(usize, 0), hooks.parent_turn_prepare_count);
     try std.testing.expectEqual(@as(usize, 0), hooks.parent_turn_ack_count);
     try std.testing.expectEqual(@as(usize, 0), first_gateway.request_bodies.items.len);
 
@@ -3272,7 +3278,7 @@ test "processQueuedPrompt leaves parent delivery pending after pre-dispatch canc
     defer second_gateway.deinit();
     try runFakePrompt(&second_gateway, &hooks, fixture.config(), fixture.job());
 
-    try std.testing.expectEqual(@as(usize, 2), hooks.parent_turn_prepare_count);
+    try std.testing.expectEqual(@as(usize, 1), hooks.parent_turn_prepare_count);
     try std.testing.expectEqual(@as(usize, 1), hooks.parent_turn_ack_count);
     try std.testing.expectEqual(@as(u64, 41), hooks.parent_turn_last_ack_sequence);
     try expectBodyContains(
@@ -3345,7 +3351,7 @@ test "processQueuedPrompt acknowledges parent delivery after ambiguous send fail
     );
 }
 
-test "processQueuedPrompt defers parent deliveries created after step one to the next turn" {
+test "processQueuedPrompt delivers parent context created between tool steps" {
     const alloc = std.testing.allocator;
     const calls = [_]ToolCall{toolCall("call_read", "read_file", "{\"path\":\"a\"}")};
     const first_completions = [_]FakeCompletion{
@@ -3361,19 +3367,10 @@ test "processQueuedPrompt defers parent deliveries created after step one to the
 
     try runFakePrompt(&first_gateway, &hooks, fixture.config(), fixture.job());
 
-    try std.testing.expectEqual(@as(usize, 1), hooks.parent_turn_prepare_count);
-    try std.testing.expectEqual(@as(usize, 0), hooks.parent_turn_ack_count);
-    try expectBodyNotContains(&first_gateway, 0, "late child delivery");
-    try expectBodyNotContains(&first_gateway, 1, "late child delivery");
-
-    const second_completions = [_]FakeCompletion{.{ .content = "Final after late delivery" }};
-    var second_gateway = FakeGateway.init(alloc, &second_completions);
-    defer second_gateway.deinit();
-    try runFakePrompt(&second_gateway, &hooks, fixture.config(), fixture.job());
-
     try std.testing.expectEqual(@as(usize, 2), hooks.parent_turn_prepare_count);
     try std.testing.expectEqual(@as(usize, 1), hooks.parent_turn_ack_count);
-    try expectBodyContains(&second_gateway, 0, "late child delivery");
+    try expectBodyNotContains(&first_gateway, 0, "late child delivery");
+    try expectBodyContains(&first_gateway, 1, "late child delivery");
 }
 
 test "processQueuedPrompt blocks accidental restart of non-live background history command" {

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -546,6 +546,8 @@ pub const FakeAgentRuntimeDeps = struct {
     parent_turn_prepare_count: usize = 0,
     parent_turn_ack_count: usize = 0,
     parent_turn_last_ack_sequence: u64 = 0,
+    parent_turn_last_ack_prepare_count: usize = 0,
+    parent_turn_ack_contract_valid: bool = true,
     runtime_context_text: ?[]const u8 = null,
     runtime_context_texts: []const []const u8 = &.{},
     runtime_context_index: usize = 0,
@@ -870,6 +872,15 @@ pub const FakeAgentRuntimeDeps = struct {
     ) void {
         const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
         self.parent_turn_ack_count += acknowledgements.len;
+        self.parent_turn_ack_contract_valid = self.parent_turn_ack_contract_valid and
+            self.parent_turn_prepare_count == self.parent_turn_last_ack_prepare_count + 1;
+        self.parent_turn_last_ack_prepare_count = self.parent_turn_prepare_count;
+        for (acknowledgements) |ack| {
+            self.parent_turn_ack_contract_valid = self.parent_turn_ack_contract_valid and
+                std.mem.eql(u8, ack.child_id, "child") and
+                std.mem.eql(u8, ack.target_session_id, "parent") and
+                std.mem.eql(u8, ack.delivery_id, "delivery");
+        }
         if (acknowledgements.len != 0) {
             self.parent_turn_last_ack_sequence = acknowledgements[acknowledgements.len - 1].through_sequence;
         }

--- a/src/core/subagent/communication.zig
+++ b/src/core/subagent/communication.zig
@@ -1146,7 +1146,11 @@ pub const ParentDeliveryPayload = union(ParentDeliveryKind) {
         state: domain.State,
         coalesced_ticks: u32,
     },
-    approval: []u8,
+    approval: struct {
+        label: []u8,
+        truncated: bool,
+        total_bytes: u64,
+    },
     tool_activity: ToolActivity,
     retention_gap: struct {
         evicted_through: u64,
@@ -1175,7 +1179,8 @@ pub const ParentDeliveryPart = struct {
         if (self.operation_id) |value| alloc.free(value);
         switch (self.payload) {
             .message => |value| alloc.free(value.content),
-            .milestone, .approval => |value| alloc.free(value),
+            .milestone => |value| alloc.free(value),
+            .approval => |value| alloc.free(value.label),
             .tool_activity => |value| alloc.free(value.tool_name),
             .terminal, .interval, .retention_gap => {},
         }
@@ -1217,7 +1222,11 @@ pub const ParentDeliveryPart = struct {
                     .state = value.state,
                     .coalesced_ticks = value.coalesced_ticks,
                 } },
-                .approval => |value| .{ .approval = try alloc.dupe(u8, value) },
+                .approval => |value| .{ .approval = .{
+                    .label = try alloc.dupe(u8, value.label),
+                    .truncated = value.truncated,
+                    .total_bytes = value.total_bytes,
+                } },
                 .tool_activity => |value| .{ .tool_activity = .{
                     .tool_name = try alloc.dupe(u8, value.tool_name),
                     .phase = value.phase,
@@ -1579,7 +1588,16 @@ fn ownParentDeliveryPart(
             .state = value.state,
             .coalesced_ticks = value.coalesced_ticks,
         } },
-        .approval, .tool_activity => return error.InvalidDelivery,
+        .approval => |value| blk: {
+            const end = selectApprovalPartEnd(delivery) orelse
+                return error.InvalidDelivery;
+            break :blk .{ .approval = .{
+                .label = try alloc.dupe(u8, value[0..end]),
+                .truncated = end != value.len,
+                .total_bytes = @intCast(value.len),
+            } };
+        },
+        .tool_activity => return error.InvalidDelivery,
     };
     return part;
 }
@@ -2011,8 +2029,8 @@ fn visibleInProjection(delivery: Delivery, projection: Projection) bool {
     return switch (projection) {
         .human => true,
         .parent_turn => switch (delivery.payload) {
-            .message, .milestone, .terminal, .interval => true,
-            .approval, .tool_activity => false,
+            .message, .milestone, .terminal, .interval, .approval => true,
+            .tool_activity => false,
         },
     };
 }
@@ -2081,6 +2099,55 @@ fn selectMessagePartEnd(delivery: Delivery, start: usize) ?usize {
         }
     }
     return if (low > start) low else null;
+}
+
+fn selectApprovalPartEnd(delivery: Delivery) ?usize {
+    const label = delivery.payload.approval;
+    const full = borrowedParentApprovalPart(delivery, label.len, false);
+    if (parentDeliveryPartFits(full)) return label.len;
+    if (!parentDeliveryPartFits(borrowedParentApprovalPart(delivery, 0, true))) {
+        return null;
+    }
+
+    var low: usize = 0;
+    var high = utf8BoundaryBefore(label, label.len) orelse return 0;
+    while (low < high) {
+        var candidate = low + (high - low + 1) / 2;
+        candidate = utf8BoundaryAtOrBefore(label, low, candidate);
+        if (candidate == low) {
+            candidate = utf8NextBoundary(label, low) orelse return low;
+        }
+        if (candidate > high) return low;
+        const probe = borrowedParentApprovalPart(delivery, candidate, true);
+        if (parentDeliveryPartFits(probe)) {
+            low = candidate;
+        } else {
+            high = utf8BoundaryBefore(label, candidate) orelse return low;
+        }
+    }
+    return low;
+}
+
+fn borrowedParentApprovalPart(
+    delivery: Delivery,
+    end: usize,
+    truncated: bool,
+) ParentDeliveryPart {
+    return .{
+        .sequence = delivery.sequence,
+        .revision = delivery.revision,
+        .id = delivery.id,
+        .source_id = delivery.source_id,
+        .target_id = delivery.target_id,
+        .work_id = delivery.work_id,
+        .operation_id = delivery.operation_id,
+        .timestamp_ms = delivery.timestamp_ms,
+        .payload = .{ .approval = .{
+            .label = delivery.payload.approval[0..end],
+            .truncated = truncated,
+            .total_bytes = @intCast(delivery.payload.approval.len),
+        } },
+    };
 }
 
 fn borrowedParentMessagePart(
@@ -3728,7 +3795,10 @@ test "human first read after target eviction exposes and recovers retention gap"
         .source_id = "child",
         .target_id = "parent-a",
         .timestamp_ms = 1,
-        .payload = .{ .approval = "human only" },
+        .payload = .{ .tool_activity = .{
+            .tool_name = "human-only-activity",
+            .phase = .started,
+        } },
     });
     for (0..max_deliveries) |index| {
         var id_buffer: [64]u8 = undefined;
@@ -4242,7 +4312,7 @@ test "approval correlation ids are not classified as replay operations" {
     try std.testing.expect(accepted == .appended);
 }
 
-test "parent turn projection excludes approval and tool activity with independent pagination" {
+test "parent turn projection includes approval and excludes tool activity with independent pagination" {
     const alloc = std.testing.allocator;
     var ledger = try Ledger.init(alloc, "child");
     defer ledger.deinit(alloc);
@@ -4287,12 +4357,21 @@ test "parent turn projection excludes approval and tool activity with independen
     var parent = try pageForParentTurn(alloc, ledger, "surface", "parent", null, 1);
     defer parent.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 1), parent.deliveries.len);
-    try std.testing.expect(parent.deliveries[0].payload == .message);
+    try std.testing.expect(parent.deliveries[0].payload == .approval);
+    try std.testing.expectEqualStrings(
+        "approval requested",
+        parent.deliveries[0].payload.approval.label,
+    );
+    try std.testing.expect(!parent.deliveries[0].payload.approval.truncated);
+    try std.testing.expectEqual(
+        @as(u64, "approval requested".len),
+        parent.deliveries[0].payload.approval.total_bytes,
+    );
     try std.testing.expect(parent.has_more);
     const context = try renderTrustedContext(alloc, parent.deliveries);
     defer alloc.free(context);
-    try std.testing.expect(std.mem.indexOf(u8, context, "explicit child message") != null);
-    try std.testing.expect(std.mem.indexOf(u8, context, "approval requested") == null);
+    try std.testing.expect(std.mem.indexOf(u8, context, "approval requested") != null);
+    try std.testing.expect(std.mem.indexOf(u8, context, "explicit child message") == null);
     try std.testing.expect(std.mem.indexOf(u8, context, "read_file") == null);
 
     try acknowledgeParentTurn(
@@ -4302,10 +4381,10 @@ test "parent turn projection excludes approval and tool activity with independen
         "parent",
         acknowledgementForParentPart(parent.deliveries[0]),
     );
-    var terminal = try pageForParentTurn(alloc, ledger, "surface", "parent", null, 1);
-    defer terminal.deinit(alloc);
-    try std.testing.expectEqual(@as(usize, 1), terminal.deliveries.len);
-    try std.testing.expect(terminal.deliveries[0].payload == .terminal);
+    var message = try pageForParentTurn(alloc, ledger, "surface", "parent", null, 1);
+    defer message.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), message.deliveries.len);
+    try std.testing.expect(message.deliveries[0].payload == .message);
 
     try acknowledgeTarget(alloc, &ledger, "surface", "parent", human.through_sequence);
     var human_next = try pageForTarget(alloc, ledger, "surface", "parent", null, 1);
@@ -4326,31 +4405,24 @@ test "parent turn page honors limits replay and ordered acknowledgements" {
         .payload = .{ .message = "filtered by target" },
     });
     _ = try appendDelivery(alloc, &ledger, .{
-        .id = "approval-event",
-        .source_id = "child",
-        .target_id = "parent",
-        .timestamp_ms = 2,
-        .payload = .{ .approval = "filtered by projection" },
-    });
-    _ = try appendDelivery(alloc, &ledger, .{
         .id = "first-message",
         .source_id = "child",
         .target_id = "parent",
-        .timestamp_ms = 3,
+        .timestamp_ms = 2,
         .payload = .{ .message = "first" },
     });
     _ = try appendDelivery(alloc, &ledger, .{
         .id = "second-message",
         .source_id = "child",
         .target_id = "parent",
-        .timestamp_ms = 4,
+        .timestamp_ms = 3,
         .payload = .{ .message = "second" },
     });
     _ = try appendDelivery(alloc, &ledger, .{
         .id = "terminal-event",
         .source_id = "child",
         .target_id = "parent",
-        .timestamp_ms = 5,
+        .timestamp_ms = 4,
         .payload = .{ .terminal = .completed },
     });
 
@@ -4915,6 +4987,59 @@ test "parent message sizes around one trusted envelope remain admissible" {
         defer alloc.free(context);
         try std.testing.expect(context.len <= max_trusted_context_bytes);
     }
+}
+
+test "escape-heavy approval projects as one bounded marked envelope" {
+    const alloc = std.testing.allocator;
+    var source_id: [255]u8 = undefined;
+    @memset(&source_id, 's');
+    var target_id: [255]u8 = undefined;
+    @memset(&target_id, 't');
+    var delivery_id: [domain.max_operation_id_bytes]u8 = undefined;
+    @memset(&delivery_id, 'd');
+    var work_id: [domain.max_operation_id_bytes]u8 = undefined;
+    @memset(&work_id, 'w');
+    var operation_id: [domain.max_operation_id_bytes]u8 = undefined;
+    @memset(&operation_id, 'o');
+    var ledger = try Ledger.init(alloc, &source_id);
+    defer ledger.deinit(alloc);
+    const label = try alloc.alloc(u8, 4 * 1024);
+    defer alloc.free(label);
+    @memset(label, 0x01);
+
+    _ = try appendDelivery(alloc, &ledger, .{
+        .id = &delivery_id,
+        .source_id = &source_id,
+        .target_id = &target_id,
+        .work_id = &work_id,
+        .operation_id = &operation_id,
+        .timestamp_ms = std.math.maxInt(i64),
+        .payload = .{ .approval = label },
+    });
+    try std.testing.expect(parentDeliveryPartFits(
+        borrowedParentApprovalPart(ledger.deliveries[0], 0, true),
+    ));
+
+    var parent = try pageForParentTurn(
+        alloc,
+        ledger,
+        "parent-model",
+        &target_id,
+        null,
+        1,
+    );
+    defer parent.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), parent.deliveries.len);
+    const projected = parent.deliveries[0].payload.approval;
+    try std.testing.expect(projected.truncated);
+    try std.testing.expectEqual(@as(u64, label.len), projected.total_bytes);
+    try std.testing.expect(projected.label.len < label.len);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(projected.label));
+    const context = try renderTrustedContext(alloc, parent.deliveries);
+    defer alloc.free(context);
+    try std.testing.expect(context.len <= max_trusted_context_bytes);
+    try std.testing.expect(std.mem.find(u8, context, "\"truncated\":true") != null);
+    try std.testing.expect(std.mem.find(u8, context, "\"total_bytes\":4096") != null);
 }
 
 test "exact 64 KiB message projects as a bounded parent continuation" {
@@ -5661,7 +5786,7 @@ fn checkCommunicationAllocationFailures(alloc: Allocator) !void {
         .target_id = "root",
         .work_id = "work",
         .timestamp_ms = 2,
-        .payload = .{ .milestone = "halfway" },
+        .payload = .{ .approval = "prepared action" },
     });
     var page = try pageForParentTurn(alloc, ledger, "parent-model", "root", null, 2);
     defer page.deinit(alloc);

--- a/src/core/subagent/communication.zig
+++ b/src/core/subagent/communication.zig
@@ -4996,11 +4996,11 @@ test "escape-heavy approval projects as one bounded marked envelope" {
     var target_id: [255]u8 = undefined;
     @memset(&target_id, 't');
     var delivery_id: [domain.max_operation_id_bytes]u8 = undefined;
-    @memset(&delivery_id, 'd');
+    @memset(&delivery_id, '"');
     var work_id: [domain.max_operation_id_bytes]u8 = undefined;
-    @memset(&work_id, 'w');
+    @memset(&work_id, '"');
     var operation_id: [domain.max_operation_id_bytes]u8 = undefined;
-    @memset(&operation_id, 'o');
+    @memset(&operation_id, '"');
     var ledger = try Ledger.init(alloc, &source_id);
     defer ledger.deinit(alloc);
     const label = try alloc.alloc(u8, 4 * 1024);
@@ -5013,11 +5013,14 @@ test "escape-heavy approval projects as one bounded marked envelope" {
         .target_id = &target_id,
         .work_id = &work_id,
         .operation_id = &operation_id,
-        .timestamp_ms = std.math.maxInt(i64),
+        .timestamp_ms = std.math.minInt(i64),
         .payload = .{ .approval = label },
     });
+    var max_metadata_delivery = ledger.deliveries[0];
+    max_metadata_delivery.sequence = std.math.maxInt(u64);
+    max_metadata_delivery.revision = std.math.maxInt(u64);
     try std.testing.expect(parentDeliveryPartFits(
-        borrowedParentApprovalPart(ledger.deliveries[0], 0, true),
+        borrowedParentApprovalPart(max_metadata_delivery, 0, true),
     ));
 
     var parent = try pageForParentTurn(

--- a/src/core/subagent/parent_delivery_projector.zig
+++ b/src/core/subagent/parent_delivery_projector.zig
@@ -696,6 +696,95 @@ test "parent delivery projector prepares one trusted envelope and acknowledges a
     try std.testing.expectEqual(@as(usize, 0), loaded_parent.history.len);
 }
 
+test "parent delivery projector acknowledges bounded approval before later delivery" {
+    const alloc = std.testing.allocator;
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, "parent");
+    try preparePersistentChild(alloc, &env, "parent", "child", "child");
+    const label = try alloc.alloc(u8, 4 * 1024);
+    defer alloc.free(label);
+    @memset(label, 0x01);
+
+    {
+        var capability = try env.store.openSubagentControlCapabilityWritable(
+            alloc,
+            "child",
+            .{},
+        );
+        defer capability.deinit();
+        const store = communication_store.Store{
+            .capability = &capability,
+            .expected_session_id = "child",
+        };
+        var lock = try store.acquireLock();
+        defer lock.release();
+        var ledger = try communication.Ledger.init(alloc, "child");
+        defer ledger.deinit(alloc);
+        _ = try communication.appendDelivery(alloc, &ledger, .{
+            .id = "escape-heavy-approval",
+            .source_id = "child",
+            .target_id = "parent",
+            .work_id = "approval-work",
+            .operation_id = "approval-operation",
+            .timestamp_ms = 1,
+            .payload = .{ .approval = label },
+        });
+        _ = try communication.appendDelivery(alloc, &ledger, .{
+            .id = "delivery-after-approval",
+            .source_id = "child",
+            .target_id = "parent",
+            .timestamp_ms = 2,
+            .payload = .{ .message = "progress after bounded approval" },
+        });
+        try store.save(alloc, ledger);
+    }
+
+    var approval = (try prepare(alloc, &env.store, "parent", .{})).?;
+    defer deinitPrepared(alloc, &approval);
+    try std.testing.expect(approval.content.len <= communication.max_trusted_context_bytes);
+    try std.testing.expectEqual(@as(usize, 1), approval.acknowledgements.len);
+    try std.testing.expectEqualStrings(
+        "escape-heavy-approval",
+        approval.acknowledgements[0].delivery_id,
+    );
+    try std.testing.expect(std.mem.find(u8, approval.content, "\"truncated\":true") != null);
+    try std.testing.expect(std.mem.find(u8, approval.content, "\"total_bytes\":4096") != null);
+    try std.testing.expect(std.mem.find(u8, approval.content, "\"source_id\":\"child\"") != null);
+    try std.testing.expect(std.mem.find(u8, approval.content, "\"target_id\":\"parent\"") != null);
+    try std.testing.expect(std.mem.find(u8, approval.content, "\"work_id\":\"approval-work\"") != null);
+    try std.testing.expect(std.mem.find(u8, approval.content, "\"operation_id\":\"approval-operation\"") != null);
+    try std.testing.expect(std.mem.find(u8, approval.content, "\"status\"") == null);
+    try std.testing.expect(std.mem.find(u8, approval.content, "\"grants\"") == null);
+    try std.testing.expect(std.mem.find(u8, approval.content, "delivery-after-approval") == null);
+    acknowledge(alloc, &env.store, .{}, approval.acknowledgements);
+
+    var query = communication_manager.Manager{
+        .sessions = &env.store,
+        .child_store_options = .{},
+    };
+    var human = try query.page(alloc, "child", "human", "parent", null, 1);
+    defer human.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), human.deliveries.len);
+    try std.testing.expectEqualStrings("escape-heavy-approval", human.deliveries[0].id);
+
+    var progress = (try prepare(alloc, &env.store, "parent", .{})).?;
+    defer deinitPrepared(alloc, &progress);
+    try std.testing.expectEqual(@as(usize, 1), progress.acknowledgements.len);
+    try std.testing.expectEqualStrings(
+        "delivery-after-approval",
+        progress.acknowledgements[0].delivery_id,
+    );
+    try std.testing.expect(
+        std.mem.find(u8, progress.content, "progress after bounded approval") != null,
+    );
+    try std.testing.expect(
+        std.mem.find(u8, progress.content, "escape-heavy-approval") == null,
+    );
+    acknowledge(alloc, &env.store, .{}, progress.acknowledgements);
+    try expectNoPrepared(alloc, &env, "parent");
+}
+
 test "parent delivery projector acknowledges retention gap then resumes after restart" {
     const alloc = std.testing.allocator;
     var env = try TestEnvironment.init(alloc);

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -6213,7 +6213,7 @@ describe("acp: model-independent", () => {
         if (parentPhase === "inspect_result" &&
             body.includes('"toolCallId":"acp_delivery_inspect_1"') &&
             body.includes('"type":"tool-result"')) {
-          expectAcpParentDeliveries(body, childId, intervalEventIds, intervalPayload);
+          expectNoAcpParentDeliveries(body);
           secondContinuationChecked = true;
           parentPhase = "third_prompt";
           return finalText("ACP_PARENT_DELIVERY_CONSUMED");

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -278,6 +278,17 @@ function acpParentDeliveryEnvelope(text: string): string {
   return text.slice(start, end + "</subagent_deliveries>".length);
 }
 
+function acpParentDeliveryIds(body: string): string[] {
+  const text = acpPromptText(body);
+  if (!text.includes("<subagent_deliveries")) return [];
+  return acpParentDeliveryEnvelope(text)
+    .split("\n")
+    .filter((line) => line.startsWith("- "))
+    .map((line) =>
+      String((JSON.parse(line.slice(2)) as { id?: unknown }).id ?? "")
+    );
+}
+
 function persistedAcpPayloadText(payload: unknown): string {
   if (!payload || typeof payload !== "object") return JSON.stringify(payload);
   const message = (payload as { message?: unknown }).message;
@@ -391,6 +402,19 @@ function expectAcpParentDeliveries(
   }
   expect(occurrenceCount(envelope, `"source_id":"${childId}"`)).toBe(eventIds.length);
   expect(occurrenceCount(envelope, payload)).toBe(eventIds.length);
+}
+
+function expectAcpParentDeliveriesOrNone(
+  body: string,
+  childId: string,
+  eventIds: string[],
+  payload: string,
+) {
+  if (eventIds.length > 0) {
+    expectAcpParentDeliveries(body, childId, eventIds, payload);
+  } else {
+    expectNoAcpParentDeliveries(body);
+  }
 }
 
 type AcpParentMessagePart = {
@@ -6168,13 +6192,14 @@ describe("acp: model-independent", () => {
   );
 
   test(
-    "ACP delivers periodic child notifications at the next parent turn boundary",
+    "ACP delivers periodic child notifications at the next available parent step",
     async () => {
       const root = createIsolatedRoot("fx-acp-parent-delivery-");
       const childPrompt = "ACP_PARENT_DELIVERY_CHILD_PROMPT";
       const intervalPayload = "coalesced_ticks";
       let intervalEventIds: string[] = [];
       let childId = "";
+      let sameTurnEventIds: string[] = [];
       let parentContinuationChecked = false;
       let secondInitialChecked = false;
       let secondContinuationChecked = false;
@@ -6219,7 +6244,15 @@ describe("acp: model-independent", () => {
           return finalText("ACP_PARENT_DELIVERY_CONSUMED");
         }
         if (parentPhase === "second_prompt" && text.includes("ACP_PARENT_SECOND_PROMPT")) {
-          expectAcpParentDeliveries(body, childId, intervalEventIds, intervalPayload);
+          const pendingEventIds = intervalEventIds.filter(
+            (eventId) => !sameTurnEventIds.includes(eventId),
+          );
+          expectAcpParentDeliveriesOrNone(
+            body,
+            childId,
+            pendingEventIds,
+            intervalPayload,
+          );
           secondInitialChecked = true;
           parentPhase = "inspect_result";
           return fakeGatewayToolCall("acp_delivery_inspect_1", "subagent", {
@@ -6240,7 +6273,13 @@ describe("acp: model-independent", () => {
             ) as { child_id: string; status: string };
             expect(created.status).toBe("created");
             childId = created.child_id;
-            expectNoAcpParentDeliveries(body);
+            sameTurnEventIds = acpParentDeliveryIds(body);
+            expectAcpParentDeliveriesOrNone(
+              body,
+              childId,
+              sameTurnEventIds,
+              intervalPayload,
+            );
             parentContinuationChecked = true;
             parentPhase = "second_prompt";
             parentCompletion = childStarted
@@ -6254,6 +6293,9 @@ describe("acp: model-independent", () => {
                 );
                 intervalEventIds = findPersistedAcpDeliveryIds(root, childId, intervalPayload);
                 expect(intervalEventIds.length).toBeGreaterThan(0);
+                for (const eventId of sameTurnEventIds) {
+                  expect(intervalEventIds).toContain(eventId);
+                }
                 return finalText("ACP_PARENT_FIRST_TURN_COMPLETE");
               });
           }
@@ -6331,7 +6373,7 @@ describe("acp: model-independent", () => {
   );
 
   test(
-    "ACP delivers a 64 KiB child message in five bounded parent prompts",
+    "ACP delivers a 64 KiB child message in five bounded projections",
     async () => {
       const root = createIsolatedRoot("fx-acp-64k-parent-delivery-");
       const childPrompt = "ACP_64K_DELIVERY_CHILD_PROMPT";
@@ -6371,13 +6413,27 @@ describe("acp: model-independent", () => {
           ) as { child_id: string; status: string };
           expect(created.status).toBe("created");
           childId = created.child_id;
-          expectNoAcpParentDeliveries(body);
+          const sameTurnEventIds = acpParentDeliveryIds(body);
+          expect(sameTurnEventIds.length).toBeLessThanOrEqual(1);
+          if (sameTurnEventIds.length === 1) {
+            messageEventId = sameTurnEventIds[0]!;
+            const part = acpParentMessagePart(body, childId, messageEventId);
+            expect(part.offset).toBe(0);
+            expect(part.total_bytes).toBe(largeMessage.length);
+            parts.push(part);
+          } else {
+            expectNoAcpParentDeliveries(body);
+          }
           return waitForPersistedAcpDeliveryId(
             root,
             childId,
             "ACP_64K_PARENT_MESSAGE:",
           ).then((eventId) => {
-            messageEventId = eventId;
+            if (messageEventId.length > 0) {
+              expect(eventId).toBe(messageEventId);
+            } else {
+              messageEventId = eventId;
+            }
             return finalText("ACP_64K_PARENT_FIRST_DONE");
           });
         }
@@ -6433,7 +6489,8 @@ describe("acp: model-independent", () => {
         );
         expect(gateway.requests).toHaveLength(4);
 
-        for (let index = 0; index < 5; index += 1) {
+        const sameTurnPartCount = parts.length;
+        for (let index = parts.length; index < 5; index += 1) {
           const requestsBefore = gateway.requests.length;
           const turn = await runPrompt(
             client,
@@ -6451,7 +6508,7 @@ describe("acp: model-independent", () => {
         expect(final.promptResult.result.stopReason).toBe("end_turn");
         expect(JSON.stringify(final)).toContain("ACP_64K_NO_REDELIVERY_DONE");
         expect(noRedeliveryChecked).toBe(true);
-        expect(gateway.requests).toHaveLength(10);
+        expect(gateway.requests).toHaveLength(10 - sameTurnPartCount);
         expectAcpHumanUnreadIndependent(root, childId, messageEventId);
         expectAcpParentHistoryClean(root, parentSessionId, [
           "<subagent_deliveries",

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -3763,7 +3763,7 @@ describe("effect-aware command permissions", () => {
           return subagentInspectCall("ask_delivery_inspect_1", childId);
         },
         (body) => {
-          expectParentDeliveries(body, childId, intervalEventIds, intervalPayload);
+          expectNoParentDeliveries(body);
           secondContinuationChecked = true;
           return finalText("ASK_PARENT_DELIVERY_CONSUMED");
         },
@@ -3960,7 +3960,7 @@ describe("effect-aware command permissions", () => {
         if (text.includes(freshChildWork)) return freshChildCompletion;
         if (body.includes('"toolCallId":"multi_delivery_send_fresh"') &&
             body.includes('"type":"tool-result"')) {
-          expectOrderedParentDeliveries(body, childId, expectedMessages);
+          expectNoParentDeliveries(body);
           expect(toolResultText(body, "multi_delivery_send_fresh")).toContain(
             '"status":"message_queued"',
           );
@@ -3984,7 +3984,7 @@ describe("effect-aware command permissions", () => {
         }
         if (body.includes('"toolCallId":"multi_delivery_configure"') &&
             body.includes('"type":"tool-result"')) {
-          expectOrderedParentDeliveries(body, childId, expectedMessages);
+          expectNoParentDeliveries(body);
           configureContinuationChecked = true;
           return gatewayToolCall("subagent", {
             command: {
@@ -4498,7 +4498,7 @@ describe("effect-aware command permissions", () => {
         ].filter(Boolean).join("+") || "root-initial");
         if (body.includes('"toolCallId":"nested_child_inspect_grandchild_1"') &&
             body.includes('"type":"tool-result"')) {
-          expectParentDeliveries(body, grandchildId, grandchildEventIds, intervalPayload);
+          expectNoParentDeliveries(body);
           childContinuationDeliveryChecked = true;
           return finalText("NESTED_CHILD_CONSUMED_GRANDCHILD");
         }
@@ -5088,7 +5088,7 @@ describe("effect-aware command permissions", () => {
         if (parentPhase === "inspect_result" &&
             body.includes('"toolCallId":"interactive_delivery_inspect_1"') &&
             body.includes('"type":"tool-result"')) {
-          expectParentDeliveries(body, childId, intervalEventIds, intervalPayload);
+          expectNoParentDeliveries(body);
           secondContinuationChecked = true;
           parentPhase = "third_prompt";
           return finalText("INTERACTIVE_PARENT_DELIVERY_CONSUMED");

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -534,6 +534,19 @@ function expectParentDeliveries(
   expect(occurrenceCount(envelope, payload)).toBe(eventIds.length);
 }
 
+function expectParentDeliveriesOrNone(
+  body: string,
+  childId: string,
+  eventIds: string[],
+  payload: string,
+) {
+  if (eventIds.length > 0) {
+    expectParentDeliveries(body, childId, eventIds, payload);
+  } else {
+    expectNoParentDeliveries(body);
+  }
+}
+
 function expectOrderedParentDeliveries(
   body: string,
   childId: string,
@@ -3660,13 +3673,14 @@ describe("effect-aware command permissions", () => {
   );
 
   test(
-    "fx ask resumes with periodic child deliveries at the next parent turn only",
+    "fx ask delivers periodic child notifications at the next available parent step",
     async () => {
       const root = createIsolatedRoot();
       const childPrompt = "ASK_PARENT_DELIVERY_CHILD_PROMPT";
       const intervalPayload = "coalesced_ticks";
       let intervalEventIds: string[] = [];
       let childId = "";
+      let sameTurnEventIds: string[] = [];
       let parentCreatePromptChecked = false;
       let parentContinuationChecked = false;
       const parentCompletion = heldFinalText();
@@ -3696,7 +3710,13 @@ describe("effect-aware command permissions", () => {
             ) as { child_id: string; status: string };
             expect(created.status).toBe("created");
             childId = created.child_id;
-            expectNoParentDeliveries(body);
+            sameTurnEventIds = parentDeliveryIds(body);
+            expectParentDeliveriesOrNone(
+              body,
+              childId,
+              sameTurnEventIds,
+              intervalPayload,
+            );
             parentContinuationChecked = true;
             deliveryBarrier = childStarted
               .then(() => waitForPersistedDeliveryIds(root, childId, intervalPayload))
@@ -3705,6 +3725,9 @@ describe("effect-aware command permissions", () => {
                 await waitForSubagentIdle(root, childId);
                 intervalEventIds = findPersistedDeliveryIds(root, childId, intervalPayload);
                 expect(intervalEventIds.length).toBeGreaterThan(0);
+                for (const eventId of sameTurnEventIds) {
+                  expect(intervalEventIds).toContain(eventId);
+                }
                 parentCompletion.release("ASK_PARENT_FIRST_TURN_COMPLETE");
               })
               .catch((error) => {
@@ -3758,9 +3781,9 @@ describe("effect-aware command permissions", () => {
       expect(parentContinuationChecked).toBe(true);
       expect(childRequestObserved).toBe(true);
       expect(unexpectedRequests).toEqual([]);
-      expect(firstGateway.requests.some((request) =>
-        promptText(request.body).includes("<subagent_deliveries")
-      )).toBe(false);
+      expect(firstGateway.requests.flatMap((request) =>
+        parentDeliveryIds(request.body)
+      )).toEqual(sameTurnEventIds);
       const parentSessionId = JSON.parse(first.stdout.trim()).session_id as string;
       expect(intervalEventIds.length).toBeGreaterThan(0);
       await waitForSubagentIdleOrInterruptedAfterHostExit(root, childId);
@@ -3769,7 +3792,15 @@ describe("effect-aware command permissions", () => {
       let secondContinuationChecked = false;
       const secondGateway = startFakeGateway([
         (body) => {
-          expectParentDeliveries(body, childId, intervalEventIds, intervalPayload);
+          const pendingEventIds = intervalEventIds.filter(
+            (eventId) => !sameTurnEventIds.includes(eventId),
+          );
+          expectParentDeliveriesOrNone(
+            body,
+            childId,
+            pendingEventIds,
+            intervalPayload,
+          );
           secondInitialChecked = true;
           return subagentInspectCall("ask_delivery_inspect_1", childId);
         },
@@ -3977,15 +4008,12 @@ describe("effect-aware command permissions", () => {
           expect(text).not.toContain(secondEventId);
           expect(text).not.toContain(firstPayload);
           expect(text).not.toContain(secondPayload);
-          if (sameTurnFreshEventIds.length > 0) {
-            const envelope = parentDeliveryEnvelope(text);
-            expect(occurrenceCount(envelope, `"source_id":"${childId}"`)).toBe(
-              sameTurnFreshEventIds.length,
-            );
-            expect(occurrenceCount(envelope, "coalesced_ticks")).toBe(
-              sameTurnFreshEventIds.length,
-            );
-          }
+          expectParentDeliveriesOrNone(
+            body,
+            childId,
+            sameTurnFreshEventIds,
+            "coalesced_ticks",
+          );
           expect(toolResultText(body, "multi_delivery_send_fresh")).toContain(
             '"status":"message_queued"',
           );
@@ -4072,16 +4100,12 @@ describe("effect-aware command permissions", () => {
           const pendingFreshEventIds = freshIntervalEventIds.filter(
             (eventId) => !sameTurnFreshEventIds.includes(eventId),
           );
-          if (pendingFreshEventIds.length > 0) {
-            expectParentDeliveries(
-              body,
-              childId,
-              pendingFreshEventIds,
-              "coalesced_ticks",
-            );
-          } else {
-            expectNoParentDeliveries(body);
-          }
+          expectParentDeliveriesOrNone(
+            body,
+            childId,
+            pendingFreshEventIds,
+            "coalesced_ticks",
+          );
           expect(text).not.toContain(firstEventId);
           expect(text).not.toContain(secondEventId);
           expect(text).not.toContain(firstPayload);
@@ -4365,7 +4389,7 @@ describe("effect-aware command permissions", () => {
   );
 
   test(
-    "fx ask nested child turn receives periodic grandchild delivery through the child runtime",
+    "fx ask nested child receives periodic grandchild delivery at the next available step",
     async () => {
       const root = createIsolatedRoot();
       const childPrompt = "NESTED_DELIVERY_CHILD_PROMPT";
@@ -4376,6 +4400,7 @@ describe("effect-aware command permissions", () => {
       const childThirdMessage = "NESTED_CHILD_THIRD_MESSAGE";
       let childId = "";
       let grandchildId = "";
+      let sameTurnGrandchildEventIds: string[] = [];
       let childContinuationChecked = false;
       let grandchildFinalObserved = false;
       const grandchildCompletion = heldFinalText();
@@ -4416,7 +4441,13 @@ describe("effect-aware command permissions", () => {
             ) as { child_id: string; status: string };
             expect(created.status).toBe("created");
             grandchildId = created.child_id;
-            expectNoParentDeliveries(body);
+            sameTurnGrandchildEventIds = parentDeliveryIds(body);
+            expectParentDeliveriesOrNone(
+              body,
+              grandchildId,
+              sameTurnGrandchildEventIds,
+              intervalPayload,
+            );
             childContinuationChecked = true;
             deliveryBarrier = grandchildStarted
               .then(() => waitForPersistedDeliveryIds(root, grandchildId, intervalPayload))
@@ -4429,6 +4460,9 @@ describe("effect-aware command permissions", () => {
                   intervalPayload,
                 );
                 expect(grandchildEventIds.length).toBeGreaterThan(0);
+                for (const eventId of sameTurnGrandchildEventIds) {
+                  expect(grandchildEventIds).toContain(eventId);
+                }
                 grandchildFinalObserved = true;
                 childCompletion.release("NESTED_CHILD_FIRST_PRIVATE_DONE");
                 maybeReleaseFirstRoot();
@@ -4537,7 +4571,15 @@ describe("effect-aware command permissions", () => {
           return finalText("NESTED_CHILD_CONSUMED_GRANDCHILD");
         }
         if (text.includes(childSecondMessage)) {
-          expectParentDeliveries(body, grandchildId, grandchildEventIds, intervalPayload);
+          const pendingEventIds = grandchildEventIds.filter(
+            (eventId) => !sameTurnGrandchildEventIds.includes(eventId),
+          );
+          expectParentDeliveriesOrNone(
+            body,
+            grandchildId,
+            pendingEventIds,
+            intervalPayload,
+          );
           childInitialChecked = true;
           return subagentInspectCall("nested_child_inspect_grandchild_1", grandchildId);
         }
@@ -5133,11 +5175,12 @@ describe("effect-aware command permissions", () => {
           const pendingEventIds = intervalEventIds.filter(
             (eventId) => !sameTurnEventIds.includes(eventId),
           );
-          if (pendingEventIds.length > 0) {
-            expectParentDeliveries(body, childId, pendingEventIds, intervalPayload);
-          } else {
-            expectNoParentDeliveries(body);
-          }
+          expectParentDeliveriesOrNone(
+            body,
+            childId,
+            pendingEventIds,
+            intervalPayload,
+          );
           secondInitialChecked = true;
           parentPhase = "inspect_result";
           return subagentInspectCall("interactive_delivery_inspect_1", childId);
@@ -5151,15 +5194,12 @@ describe("effect-aware command permissions", () => {
           expect(created.status).toBe("created");
           childId = created.child_id;
           sameTurnEventIds = parentDeliveryIds(body);
-          if (sameTurnEventIds.length > 0) {
-            const envelope = parentDeliveryEnvelope(text);
-            expect(occurrenceCount(envelope, `"source_id":"${childId}"`)).toBe(
-              sameTurnEventIds.length,
-            );
-            expect(occurrenceCount(envelope, intervalPayload)).toBe(
-              sameTurnEventIds.length,
-            );
-          }
+          expectParentDeliveriesOrNone(
+            body,
+            childId,
+            sameTurnEventIds,
+            intervalPayload,
+          );
           parentContinuationChecked = true;
           parentPhase = "second_prompt";
           return waitForPersistedDeliveryIds(root, childId, intervalPayload)

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -330,6 +330,17 @@ function parentDeliveryEnvelope(text: string): string {
   return text.slice(start, end + "</subagent_deliveries>".length);
 }
 
+function parentDeliveryIds(body: string): string[] {
+  const text = promptText(body);
+  if (!text.includes("<subagent_deliveries")) return [];
+  return parentDeliveryEnvelope(text)
+    .split("\n")
+    .filter((line) => line.startsWith("- "))
+    .map((line) =>
+      String((JSON.parse(line.slice(2)) as { id?: unknown }).id ?? "")
+    );
+}
+
 function persistedPayloadText(payload: unknown): string {
   if (!payload || typeof payload !== "object") return JSON.stringify(payload);
   const message = (payload as { message?: unknown }).message;
@@ -3947,6 +3958,7 @@ describe("effect-aware command permissions", () => {
       let configureContinuationChecked = false;
       let runningTurnChecked = false;
       let freshIntervalEventIds: string[] = [];
+      let sameTurnFreshEventIds: string[] = [];
       let releaseFreshChild!: (response: Response) => void;
       const freshChildCompletion = new Promise<Response>((resolve) => {
         releaseFreshChild = resolve;
@@ -3960,11 +3972,23 @@ describe("effect-aware command permissions", () => {
         if (text.includes(freshChildWork)) return freshChildCompletion;
         if (body.includes('"toolCallId":"multi_delivery_send_fresh"') &&
             body.includes('"type":"tool-result"')) {
-          expectNoParentDeliveries(body);
+          sameTurnFreshEventIds = parentDeliveryIds(body);
+          expect(text).not.toContain(firstEventId);
+          expect(text).not.toContain(secondEventId);
+          expect(text).not.toContain(firstPayload);
+          expect(text).not.toContain(secondPayload);
+          if (sameTurnFreshEventIds.length > 0) {
+            const envelope = parentDeliveryEnvelope(text);
+            expect(occurrenceCount(envelope, `"source_id":"${childId}"`)).toBe(
+              sameTurnFreshEventIds.length,
+            );
+            expect(occurrenceCount(envelope, "coalesced_ticks")).toBe(
+              sameTurnFreshEventIds.length,
+            );
+          }
           expect(toolResultText(body, "multi_delivery_send_fresh")).toContain(
             '"status":"message_queued"',
           );
-          expect(text).not.toContain("coalesced_ticks");
           runningTurnChecked = true;
           return waitForPersistedDeliveryIds(
             root,
@@ -3979,6 +4003,9 @@ describe("effect-aware command permissions", () => {
               "coalesced_ticks",
             );
             expect(freshIntervalEventIds.length).toBeGreaterThan(0);
+            for (const eventId of sameTurnFreshEventIds) {
+              expect(freshIntervalEventIds).toContain(eventId);
+            }
             return finalText("ASK_MULTI_DELIVERY_MESSAGES_CONSUMED");
           });
         }
@@ -4042,12 +4069,19 @@ describe("effect-aware command permissions", () => {
       const thirdGateway = startFakeGateway([
         (body) => {
           const text = promptText(body);
-          expectParentDeliveries(
-            body,
-            childId,
-            freshIntervalEventIds,
-            "coalesced_ticks",
+          const pendingFreshEventIds = freshIntervalEventIds.filter(
+            (eventId) => !sameTurnFreshEventIds.includes(eventId),
           );
+          if (pendingFreshEventIds.length > 0) {
+            expectParentDeliveries(
+              body,
+              childId,
+              pendingFreshEventIds,
+              "coalesced_ticks",
+            );
+          } else {
+            expectNoParentDeliveries(body);
+          }
           expect(text).not.toContain(firstEventId);
           expect(text).not.toContain(secondEventId);
           expect(text).not.toContain(firstPayload);
@@ -5052,7 +5086,7 @@ describe("effect-aware command permissions", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
-    "interactive Fx delivers periodic child notifications at the next parent turn boundary",
+    "interactive Fx delivers periodic child notifications at the next available parent step",
     async () => {
       const root = createIsolatedRoot();
       const stderrPath = join(root.root, "interactive-parent-delivery-stderr.log");
@@ -5064,6 +5098,7 @@ describe("effect-aware command permissions", () => {
       let secondInitialChecked = false;
       let secondContinuationChecked = false;
       let thirdChecked = false;
+      let sameTurnEventIds: string[] = [];
       let parentPhase:
         | "create_prompt"
         | "create_result"
@@ -5095,7 +5130,14 @@ describe("effect-aware command permissions", () => {
         }
         if (parentPhase === "second_prompt" &&
             text.includes("INTERACTIVE_PARENT_SECOND_PROMPT")) {
-          expectParentDeliveries(body, childId, intervalEventIds, intervalPayload);
+          const pendingEventIds = intervalEventIds.filter(
+            (eventId) => !sameTurnEventIds.includes(eventId),
+          );
+          if (pendingEventIds.length > 0) {
+            expectParentDeliveries(body, childId, pendingEventIds, intervalPayload);
+          } else {
+            expectNoParentDeliveries(body);
+          }
           secondInitialChecked = true;
           parentPhase = "inspect_result";
           return subagentInspectCall("interactive_delivery_inspect_1", childId);
@@ -5108,7 +5150,16 @@ describe("effect-aware command permissions", () => {
           ) as { child_id: string; status: string };
           expect(created.status).toBe("created");
           childId = created.child_id;
-          expectNoParentDeliveries(body);
+          sameTurnEventIds = parentDeliveryIds(body);
+          if (sameTurnEventIds.length > 0) {
+            const envelope = parentDeliveryEnvelope(text);
+            expect(occurrenceCount(envelope, `"source_id":"${childId}"`)).toBe(
+              sameTurnEventIds.length,
+            );
+            expect(occurrenceCount(envelope, intervalPayload)).toBe(
+              sameTurnEventIds.length,
+            );
+          }
           parentContinuationChecked = true;
           parentPhase = "second_prompt";
           return waitForPersistedDeliveryIds(root, childId, intervalPayload)
@@ -5117,6 +5168,9 @@ describe("effect-aware command permissions", () => {
               await waitForSubagentIdle(root, childId);
               intervalEventIds = findPersistedDeliveryIds(root, childId, intervalPayload);
               expect(intervalEventIds.length).toBeGreaterThan(0);
+              for (const eventId of sameTurnEventIds) {
+                expect(intervalEventIds).toContain(eventId);
+              }
               return finalText("INTERACTIVE_PARENT_FIRST_TURN_COMPLETE");
             });
         }

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -4153,13 +4153,14 @@ describe("effect-aware command permissions", () => {
   );
 
   test(
-    "fx ask resumes a 64 KiB child message through ordered parent turn continuations",
+    "fx ask resumes a 64 KiB child message through five bounded projections",
     async () => {
       const root = createIsolatedRoot();
       const childPrompt = "ASK_64K_DELIVERY_CHILD_PROMPT";
       const largeMessage = "ASK_64K_PARENT_MESSAGE:".padEnd(64 * 1024, "x");
       let childId = "";
       let messageEventId = "";
+      const parts: ParentMessagePart[] = [];
       const firstRoute = (body: string) => {
         const text = promptText(body);
         if (body.includes('"toolCallId":"ask_64k_send_1"') &&
@@ -4176,13 +4177,27 @@ describe("effect-aware command permissions", () => {
           ) as { child_id: string; status: string };
           expect(created.status).toBe("created");
           childId = created.child_id;
-          expectNoParentDeliveries(body);
+          const sameTurnEventIds = parentDeliveryIds(body);
+          expect(sameTurnEventIds.length).toBeLessThanOrEqual(1);
+          if (sameTurnEventIds.length === 1) {
+            messageEventId = sameTurnEventIds[0]!;
+            const part = parentMessagePart(body, childId, messageEventId);
+            expect(part.offset).toBe(0);
+            expect(part.total_bytes).toBe(largeMessage.length);
+            parts.push(part);
+          } else {
+            expectNoParentDeliveries(body);
+          }
           return waitForPersistedDeliveryId(
             root,
             childId,
             "ASK_64K_PARENT_MESSAGE:",
           ).then((eventId) => {
-            messageEventId = eventId;
+            if (messageEventId.length > 0) {
+              expect(eventId).toBe(messageEventId);
+            } else {
+              messageEventId = eventId;
+            }
             return waitForSubagentIdle(root, childId)
               .then(() => finalText("ASK_64K_PARENT_FIRST_DONE"));
           });
@@ -4238,7 +4253,7 @@ describe("effect-aware command permissions", () => {
       const parentSessionId = JSON.parse(first.stdout.trim()).session_id as string;
       await waitForSubagentIdleOrInterruptedAfterHostExit(root, childId);
 
-      const parts: ParentMessagePart[] = [];
+      const sameTurnPartCount = parts.length;
       let noRedeliveryChecked = false;
       const continuationRoute = (body: string) => {
         const text = promptText(body);
@@ -4260,7 +4275,7 @@ describe("effect-aware command permissions", () => {
       const continuationGateway = startFakeGateway(
         Array.from({ length: 6 }, () => continuationRoute),
       );
-      for (let index = 0; index < 5; index += 1) {
+      for (let index = parts.length; index < 5; index += 1) {
         const requestsBefore = continuationGateway.requests.length;
         const turn = await runFx(
           [
@@ -4308,7 +4323,7 @@ describe("effect-aware command permissions", () => {
       expect(final.code).toBe(0);
       expect(final.stderr).toBe("");
       expect(noRedeliveryChecked).toBe(true);
-      expect(continuationGateway.requests).toHaveLength(6);
+      expect(continuationGateway.requests).toHaveLength(6 - sameTurnPartCount);
       expectHumanUnreadIndependent(root, childId, messageEventId);
       expectParentHistoryClean(root, parentSessionId, [
         "<subagent_deliveries",
@@ -4680,7 +4695,7 @@ describe("effect-aware command permissions", () => {
   );
 
   test(
-    "nested child receives a 64 KiB grandchild message in five bounded turns",
+    "nested child receives a 64 KiB grandchild message in five bounded projections",
     async () => {
       const root = createIsolatedRoot();
       const childPrompt = "NESTED_64K_DELIVERY_CHILD_PROMPT";
@@ -4689,6 +4704,7 @@ describe("effect-aware command permissions", () => {
       let childId = "";
       let grandchildId = "";
       let messageEventId = "";
+      const parts: ParentMessagePart[] = [];
       const firstRoute = (body: string) => {
         const text = promptText(body);
         if (body.includes('"toolCallId":"nested_64k_send_1"') &&
@@ -4705,13 +4721,27 @@ describe("effect-aware command permissions", () => {
           ) as { child_id: string; status: string };
           expect(created.status).toBe("created");
           grandchildId = created.child_id;
-          expectNoParentDeliveries(body);
+          const sameTurnEventIds = parentDeliveryIds(body);
+          expect(sameTurnEventIds.length).toBeLessThanOrEqual(1);
+          if (sameTurnEventIds.length === 1) {
+            messageEventId = sameTurnEventIds[0]!;
+            const part = parentMessagePart(body, grandchildId, messageEventId);
+            expect(part.offset).toBe(0);
+            expect(part.total_bytes).toBe(largeMessage.length);
+            parts.push(part);
+          } else {
+            expectNoParentDeliveries(body);
+          }
           return waitForPersistedDeliveryId(
             root,
             grandchildId,
             "NESTED_64K_CHILD_MESSAGE:",
           ).then((eventId) => {
-            messageEventId = eventId;
+            if (messageEventId.length > 0) {
+              expect(eventId).toBe(messageEventId);
+            } else {
+              messageEventId = eventId;
+            }
             return waitForSubagentIdle(root, grandchildId)
               .then(() => finalText("NESTED_64K_CHILD_FIRST_PRIVATE_DONE"));
           });
@@ -4790,8 +4820,7 @@ describe("effect-aware command permissions", () => {
       expect(messageEventId.length).toBeGreaterThan(0);
       const parentSessionId = JSON.parse(first.stdout.trim()).session_id as string;
 
-      const parts: ParentMessagePart[] = [];
-      for (let index = 0; index < 5; index += 1) {
+      for (let index = parts.length; index < 5; index += 1) {
         const childMessage = `NESTED_64K_CHILD_TURN_${index + 1}`;
         const sendCallId = `nested_64k_root_send_${index + 1}`;
         const route = (body: string) => {
@@ -5281,7 +5310,7 @@ describe("effect-aware command permissions", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
-    "interactive Fx delivers a 64 KiB child message in five bounded turns",
+    "interactive Fx delivers a 64 KiB child message in five bounded projections",
     async () => {
       const root = createIsolatedRoot();
       const stderrPath = join(root.root, "interactive-64k-delivery-stderr.log");
@@ -5324,13 +5353,27 @@ describe("effect-aware command permissions", () => {
           ) as { child_id: string; status: string };
           expect(created.status).toBe("created");
           childId = created.child_id;
-          expectNoParentDeliveries(body);
+          const sameTurnEventIds = parentDeliveryIds(body);
+          expect(sameTurnEventIds.length).toBeLessThanOrEqual(1);
+          if (sameTurnEventIds.length === 1) {
+            messageEventId = sameTurnEventIds[0]!;
+            const part = parentMessagePart(body, childId, messageEventId);
+            expect(part.offset).toBe(0);
+            expect(part.total_bytes).toBe(largeMessage.length);
+            parts.push(part);
+          } else {
+            expectNoParentDeliveries(body);
+          }
           return waitForPersistedDeliveryId(
             root,
             childId,
             "INTERACTIVE_64K_PARENT_MESSAGE:",
           ).then((eventId) => {
-            messageEventId = eventId;
+            if (messageEventId.length > 0) {
+              expect(eventId).toBe(messageEventId);
+            } else {
+              messageEventId = eventId;
+            }
             return finalText("INTERACTIVE_64K_PARENT_FIRST_DONE");
           });
         }
@@ -5384,13 +5427,15 @@ describe("effect-aware command permissions", () => {
       expect(messageEventId.length).toBeGreaterThan(0);
       await waitForSubagentIdle(root, childId);
 
-      for (let index = 0; index < 5; index += 1) {
+      const sameTurnPartCount = parts.length;
+      for (let index = parts.length; index < 5; index += 1) {
+        const requestsBefore = gateway.requests.length;
         await activeSession.sendText(`INTERACTIVE_64K_PARENT_TURN_${index + 1}`);
         await activeSession.waitForText(
           `INTERACTIVE_64K_PART_${index + 1}_DONE`,
           TIMEOUT,
         );
-        expect(gateway.requests).toHaveLength(5 + index);
+        expect(gateway.requests).toHaveLength(requestsBefore + 1);
       }
       expect(parts).toHaveLength(5);
       expect(parts.map((part) => part.content).join("")).toBe(largeMessage);
@@ -5402,7 +5447,7 @@ describe("effect-aware command permissions", () => {
         TIMEOUT,
       );
       expect(noRedeliveryChecked).toBe(true);
-      expect(gateway.requests).toHaveLength(10);
+      expect(gateway.requests).toHaveLength(10 - sameTurnPartCount);
 
       await activeSession.sendText("/quit");
       expect(await activeSession.waitForSessionEnd(5_000)).toBe(true);

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -305,6 +305,15 @@ function latestPromptText(body: string): string {
   return contentText(request.prompt?.at(-1)?.content);
 }
 
+function currentUserText(body: string): string {
+  const request = JSON.parse(body) as {
+    prompt?: Array<{ role?: string; content?: unknown }>;
+  };
+  return contentText(
+    request.prompt?.findLast((message) => message.role === "user")?.content,
+  );
+}
+
 function occurrenceCount(text: string, needle: string): number {
   return text.split(needle).length - 1;
 }
@@ -390,6 +399,43 @@ async function waitForPersistedDeliveryIds(
     await Bun.sleep(20);
   }
   throw new Error(`Timed out waiting for persisted delivery child=${childId} payload=${payload}`);
+}
+
+type PendingSubagentApproval = {
+  id: string;
+  label: string;
+  rootId: string;
+  workId: string;
+};
+
+async function waitForPendingSubagentApproval(
+  root: IsolatedRoot,
+  childId: string,
+): Promise<PendingSubagentApproval> {
+  const id = await waitForPersistedDeliveryId(
+    root,
+    childId,
+    "run_command /usr/bin/touch",
+  );
+  const communicationPath = join(
+    root.home,
+    ".fx",
+    "sessions",
+    childId,
+    "subagent",
+    "communication.json",
+  );
+  const stored = JSON.parse(readFileSync(communicationPath, "utf8")) as {
+    ledger: { approvals: Array<Record<string, unknown>> };
+  };
+  const approval = stored.ledger.approvals.find((entry) => entry.id === id);
+  if (!approval) throw new Error(`Missing approval child=${childId} id=${id}`);
+  return {
+    id,
+    label: String(approval.label ?? ""),
+    rootId: String(approval.root_id ?? ""),
+    workId: String(approval.work_id ?? ""),
+  };
 }
 
 async function waitForTraceSlice(
@@ -4832,6 +4878,177 @@ describe("effect-aware command permissions", () => {
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
     TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "interactive fx delivers a child approval to the next same-turn parent step",
+    async () => {
+      const root = createIsolatedRoot();
+      const stderrPath = join(root.root, "interactive-child-approval-stderr.log");
+      const fixturePath = join(root.workspace, "approval-fixture.txt");
+      const markerPath = join(root.workspace, "approval-must-not-exist");
+      const rootPrompt = "INTERACTIVE_CREATE_APPROVAL_CHILD";
+      const childPrompt = "INTERACTIVE_CHILD_REQUEST_APPROVAL";
+      const rootCreateCallId = "interactive_approval_create";
+      const rootProbeCallId = "interactive_approval_probe";
+      const childCommandCallId = "interactive_approval_command";
+      let childId = "";
+      let approval: PendingSubagentApproval | null = null;
+      let sameTurnChecked = false;
+      let noRedeliveryChecked = false;
+      let releaseApprovalUi!: () => void;
+      const approvalUiObserved = new Promise<void>((resolve) => {
+        releaseApprovalUi = resolve;
+      });
+      writeFileSync(fixturePath, "approval parent projection fixture\n");
+      writeFileSync(stderrPath, "");
+
+      const checkApprovalDelivery = (body: string) => {
+        expect(approval).not.toBeNull();
+        expectParentDelivery(body, childId, approval!.id, approval!.label);
+        const envelope = parentDeliveryEnvelope(promptText(body));
+        expect(envelope).toContain(`"target_id":"${approval!.rootId}"`);
+        expect(envelope).toContain(`"work_id":"${approval!.workId}"`);
+        expect(envelope).toContain('"truncated":false');
+        expect(envelope).toContain(
+          `"total_bytes":${Buffer.byteLength(approval!.label, "utf8")}`,
+        );
+        sameTurnChecked = true;
+      };
+
+      const route = async (body: string): Promise<Response> => {
+        const userText = currentUserText(body);
+        if (userText.includes("INTERACTIVE_VERIFY_APPROVAL_NOT_REPEATED")) {
+          expect(promptText(body)).not.toContain(approval!.id);
+          expect(promptText(body)).not.toContain(approval!.label);
+          noRedeliveryChecked = true;
+          return finalText("INTERACTIVE_APPROVAL_NOT_REPEATED");
+        }
+        if (body.includes(`\"toolCallId\":\"${childCommandCallId}\"`) &&
+            body.includes('"type":"tool-result"')) {
+          return finalText("INTERACTIVE_CHILD_DENIED_COMPLETE");
+        }
+        if (userText.includes(childPrompt)) {
+          return gatewayToolCall("run_command", {
+            command: `/usr/bin/touch ${shellQuote(markerPath)}`,
+          }, childCommandCallId);
+        }
+        if (body.includes(`\"toolCallId\":\"${rootProbeCallId}\"`) &&
+            body.includes('"type":"tool-result"')) {
+          const text = promptText(body);
+          if (text.includes(`"id":"${approval!.id}"`)) {
+            checkApprovalDelivery(body);
+          } else {
+            expect(sameTurnChecked).toBe(true);
+            expect(text).not.toContain(approval!.id);
+            expect(text).not.toContain(approval!.label);
+          }
+          return finalText("INTERACTIVE_PARENT_SAW_CHILD_APPROVAL");
+        }
+        if (body.includes(`\"toolCallId\":\"${rootCreateCallId}\"`) &&
+            body.includes('"type":"tool-result"')) {
+          const created = JSON.parse(
+            toolResultText(body, rootCreateCallId),
+          ) as { child_id: string; status: string };
+          expect(created.status).toBe("created");
+          childId = created.child_id;
+          approval = await waitForPendingSubagentApproval(root, childId);
+          expect(subagentState(root, childId)).toBe("awaiting_approval");
+          await approvalUiObserved;
+          if (promptText(body).includes(`"id":"${approval.id}"`)) {
+            checkApprovalDelivery(body);
+          }
+          return gatewayToolCall(
+            "read_file",
+            { path: "approval-fixture.txt" },
+            rootProbeCallId,
+          );
+        }
+        if (userText.includes(rootPrompt)) {
+          return gatewayToolCall("subagent", {
+            command: {
+              create: {
+                name: "interactive-approval-child",
+                mode: "one_off",
+                prompt: childPrompt,
+              },
+            },
+          }, rootCreateCallId);
+        }
+        throw new Error(`Unexpected approval projection request: ${body}`);
+      };
+      const gateway = startDynamicFakeGateway(route, {
+        classifierDecision: "ask",
+      });
+      gateways.push(gateway);
+
+      activeSession = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: root.workspace,
+        env: gatewayEnv(root, gateway, {
+          FX_PERMISSION_MODE: "auto",
+          PATH: hostilePath(root),
+        }),
+        stderrPath,
+        width: 120,
+        height: 40,
+      });
+      await activeSession.waitForComposer(TIMEOUT);
+      await activeSession.sendText(rootPrompt);
+      const approvalPane = await activeSession.waitForText(
+        COMMAND_APPROVAL_PROMPT,
+        TIMEOUT,
+      );
+      expect(approvalPane).toContain("touch");
+      expect(approval).not.toBeNull();
+      expect(subagentState(root, childId)).toBe("awaiting_approval");
+      expect(gateway.classifierRequests).toHaveLength(1);
+      expect(existsSync(markerPath)).toBe(false);
+      releaseApprovalUi();
+
+      const sameTurnDeadline = Date.now() + TIMEOUT;
+      while (!sameTurnChecked && Date.now() < sameTurnDeadline) {
+        await Bun.sleep(20);
+      }
+      expect(sameTurnChecked).toBe(true);
+      expect(existsSync(markerPath)).toBe(false);
+      await activeSession.sendKeys("3");
+      await activeSession.waitForText(
+        "INTERACTIVE_PARENT_SAW_CHILD_APPROVAL",
+        TIMEOUT,
+      );
+      expect(existsSync(markerPath)).toBe(false);
+      const childDeadline = Date.now() + TIMEOUT;
+      while (subagentState(root, childId) !== "completed" &&
+             Date.now() < childDeadline) {
+        await Bun.sleep(20);
+      }
+      expect(subagentState(root, childId)).toBe("completed");
+      const stored = JSON.parse(readFileSync(
+        join(root.home, ".fx", "sessions", childId, "subagent", "communication.json"),
+        "utf8",
+      )) as { ledger: { approvals: Array<Record<string, unknown>> } };
+      expect(stored.ledger.approvals.find((item) => item.id === approval!.id)?.status)
+        .toBe("denied");
+
+      await activeSession.sendText("INTERACTIVE_VERIFY_APPROVAL_NOT_REPEATED");
+      await activeSession.waitForText("INTERACTIVE_APPROVAL_NOT_REPEATED", TIMEOUT);
+      expect(noRedeliveryChecked).toBe(true);
+
+      await activeSession.sendText("/quit");
+      expect(await activeSession.waitForSessionEnd(5_000)).toBe(true);
+      activeSession = null;
+      expectHumanUnreadIndependent(root, childId, approval!.id);
+      const parentSessionId = onlyParentSessionId(root, [childId]);
+      expectParentHistoryClean(root, parentSessionId, [
+        "<subagent_deliveries",
+        approval!.label,
+      ]);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      expectNoHostileExecutables(root);
+      expectNoCommandArtifacts(root);
+    },
+    60_000,
   );
 
   test.skipIf(!tmuxAvailable())(


### PR DESCRIPTION
## Summary

- expose child approval requests to the parent model at each agent step
- acknowledge projected deliveries after dispatch while preserving retry and cancellation behavior
- keep escape-heavy approval labels inside the trusted-context envelope with explicit truncation metadata

## Testing

- `zig fmt --check src/`
- `zig build test`
- `zig build`
- `bun test acp.test.ts`
- `bun test tui-command-permissions.test.ts -t "interactive fx delivers a child approval to the next same-turn parent step"`
- live Gateway TTY flow: the parent-model cursor acknowledged the approval while the child remained blocked, and the denied command produced no side effect