### PR TITLE
Prepare v0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # fx
 
-## 0.4.2
+## 0.4.3
 
 <!-- release:start -->
+
+### Improvements
+
+- **Smaller macOS arm64 binary:** Reduce the native binary size with profile-guided optimization tuned to common fx workloads
+<!-- release:end -->
+
+## 0.4.2
 
 ### New Features
 
@@ -22,7 +29,6 @@
 - **Recovery continuation:** Accept one `/continue` as soon as a recovery pause appears, even while the previous worker finishes cleanup
 - **Recovery pacing:** Keep one recovery attempt budget across failure causes and reset backoff after the cause changes, an explicit retry delay, authentication refresh, or a successful request
 - **Terminal tool compatibility:** Keep the `terminal` tool available when providers apply stricter schema validation while continuing to reject fields unsupported by the selected action
-<!-- release:end -->
 
 ## 0.4.1
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const build_options = @import("build_options");
 const io_mod = @import("core/shared/io.zig");
 
-pub const version = "0.4.2";
+pub const version = "0.4.3";
 
 const app_lifecycle = @import("core/app/app_lifecycle.zig");
 const auth_runtime = @import("core/auth/auth_runtime.zig");


### PR DESCRIPTION
## Summary

- Bump `src/main.zig` to 0.4.3
- Add the `CHANGELOG.md` entry for 0.4.3
- Move the active release markers from 0.4.2 to 0.4.3