### PR TITLE
Harden macOS arm64 PGSO qualification

### DIFF
--- a/.github/workflows/pgso-macos-arm64.yml
+++ b/.github/workflows/pgso-macos-arm64.yml
@@ -38,6 +38,8 @@ jobs:
     outputs:
       training: ${{ steps.plan.outputs.training }}
       behavior: ${{ steps.plan.outputs.behavior }}
+      startup: ${{ steps.plan.outputs.startup }}
+      heavy: ${{ steps.plan.outputs.heavy }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,10 +74,18 @@ jobs:
         run: |
           training="$(python3 -m scripts.pgso.distributed plan --phase training --maximum-shards 20)"
           behavior="$(python3 -m scripts.pgso.distributed plan --phase behavior --maximum-shards 20)"
-          echo "training=$training" >> "$GITHUB_OUTPUT"
-          echo "behavior=$behavior" >> "$GITHUB_OUTPUT"
+          startup="$(python3 -m scripts.pgso.distributed plan --phase startup)"
+          heavy="$(python3 -m scripts.pgso.distributed plan --phase heavy)"
+          {
+            echo "training=$training"
+            echo "behavior=$behavior"
+            echo "startup=$startup"
+            echo "heavy=$heavy"
+          } >> "$GITHUB_OUTPUT"
           echo "Training matrix: $training"
           echo "Behavior matrix: $behavior"
+          echo "Startup matrix: $startup"
+          echo "Heavy matrix: $heavy"
 
       - name: Upload immutable seed
         uses: actions/upload-artifact@v4
@@ -286,14 +296,13 @@ jobs:
 
   startup:
     name: Startup ${{ matrix.name }}
-    needs: candidate
+    needs: [seed, candidate]
     runs-on: macos-15
     timeout-minutes: 45
     strategy:
       fail-fast: false
       max-parallel: 6
-      matrix:
-        name: [help, version, status, background, doctor, sessions]
+      matrix: ${{ fromJSON(needs.seed.outputs.startup) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -342,20 +351,13 @@ jobs:
 
   heavy:
     name: Heavy ${{ matrix.name }}
-    needs: candidate
+    needs: [seed, candidate]
     runs-on: macos-15
     timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 6
-      matrix:
-        name:
-          - file-index-100k
-          - ui-activity
-          - approval-transcript
-          - approval-diff
-          - approval-combined
-          - approval-payload
+      matrix: ${{ fromJSON(needs.seed.outputs.heavy) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/pgso/README.md
+++ b/scripts/pgso/README.md
@@ -41,7 +41,7 @@ python3 -m scripts.pgso all \
 
 `build` verifies the control, bitcode, instrumented link, profile-section alignment, signature, and one profile-producing smoke. `train` additionally runs the versioned corpus and creates a checked candidate. Both are useful diagnostics but finish with `eligible: false` because they do not run the complete release-safety gate.
 
-`qualify` and `all` run the complete fresh-build path: training, profile use, candidate verification, the candidate behavior corpus, six startup comparisons, and six heavy-workload comparisons. `all` is the canonical CI entry point. `report --output-dir <path>` is the only command that may reuse an existing directory, and it only reads a complete eligible manifest.
+`all` runs the complete fresh-build path: training, profile use, candidate verification, the candidate behavior corpus, six startup comparisons, and six heavy-workload comparisons. It is the canonical CI entry point. `report --output-dir <path>` is the only command that may reuse an existing directory, and it only reads a complete eligible manifest.
 
 The production workflow runs the same gate as a distributed DAG. One seed job
 builds the control, bitcode, and instrumented binary. Up to twenty training
@@ -115,7 +115,9 @@ manifest.json
 
 Generated binaries, bitcode, objects, profiles, caches, measurements, and logs are evidence artifacts and must not be committed. `manifest.json` is rewritten atomically after every stage. A failed manifest retains completed evidence, names the failing stage, records `eligible: false`, and never falls back to an unprofiled candidate.
 
-The driver also streams operational progress to the invoking terminal or GitHub Actions log. Every stage announces its start and terminal status with elapsed time, every child command announces its start and terminal status, and child stdout and stderr remain visible while the process runs. A silent child emits a heartbeat every 30 seconds. Full stdout and stderr continue to be retained in the command's JSON log, and no environment variables are printed.
+The driver also streams operational progress to the invoking terminal or GitHub Actions log. Every stage announces its start and terminal status with elapsed time, every child command announces its start and terminal status, and child stdout and stderr remain visible while the process runs. A silent child emits a heartbeat every 30 seconds. JSON evidence retains at most the last 1,048,576 characters from each output stream per command and records the total character counts and truncation status; no environment variables are printed.
+
+Corpus scenarios inherit only a small operating-system environment allowlist. Credentials, live-test flags, tracing settings, and repository dotenv files are excluded unless a value is explicitly declared in the versioned corpus. The runner temporarily installs the assigned artifact at `zig-out/bin/fx` for E2E compatibility, then restores the prior file (or prior absence) after success, failure, timeout, or cancellation.
 
 The native workflow uploads bounded phase evidence rather than caches or
 intermediate compiler objects. Pull requests and manual runs have read-only

--- a/scripts/pgso/__main__.py
+++ b/scripts/pgso/__main__.py
@@ -35,14 +35,14 @@ from scripts.pgso.qualify import (
     relink_profile_linked_benchmarks,
     require_measurements_passed,
 )
-from scripts.pgso.runner import run_checked
+from scripts.pgso.runner import cancellation_guard, run_checked
 from scripts.pgso.toolchain import SUPPORTED_TARGET
 from scripts.pgso.toolchain import Toolchain
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 DEFAULT_CORPUS = REPO_ROOT / "scripts" / "pgso" / "corpus.json"
-MUTATING_COMMANDS = ("build", "train", "qualify", "all")
+MUTATING_COMMANDS = ("build", "train", "all")
 REQUIRED_BUN_VERSION = "1.3.14"
 REQUIRED_HYPERFINE_VERSION = "1.20.0"
 
@@ -107,7 +107,6 @@ def _parser() -> argparse.ArgumentParser:
     descriptions = {
         "build": "Build the control and instrumented compiler artifacts",
         "train": "Build a candidate from the versioned production corpus",
-        "qualify": "Build and run correctness and performance qualification",
         "all": "Run the complete non-publishing Stage 1 candidate gate",
     }
     for command in MUTATING_COMMANDS:
@@ -132,7 +131,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         return arguments
     if arguments.timeout_seconds <= 0:
         parser.error("--timeout-seconds must be positive")
-    if arguments.command in ("qualify", "all") and arguments.samples < 50:
+    if arguments.command == "all" and arguments.samples < 50:
         parser.error("--samples must be at least 50 for qualification")
     return arguments
 
@@ -553,21 +552,22 @@ def run_command(arguments: argparse.Namespace) -> pathlib.Path:
 
         recorder.complete()
         return recorder.path
-    except Exception as error:
+    except BaseException as error:
         recorder.fail(stage, error)
         raise
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     try:
-        arguments = parse_args(argv)
-        if arguments.command == "report":
-            payload = load_read_only_manifest(arguments.output_dir)
-            print(json.dumps(payload, indent=2, sort_keys=True))
+        with cancellation_guard():
+            arguments = parse_args(argv)
+            if arguments.command == "report":
+                payload = load_read_only_manifest(arguments.output_dir)
+                print(json.dumps(payload, indent=2, sort_keys=True))
+                return 0
+            manifest_path = run_command(arguments)
+            print(manifest_path)
             return 0
-        manifest_path = run_command(arguments)
-        print(manifest_path)
-        return 0
     except PgsoError as error:
         print(f"PGSO failed: {error}", file=sys.stderr)
         return 1

--- a/scripts/pgso/corpus.py
+++ b/scripts/pgso/corpus.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import dataclasses
 import json
 import os
@@ -9,11 +10,12 @@ import re
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Callable, Mapping, Sequence
+import uuid
+from collections.abc import Callable, Iterator, Mapping, Sequence
 
 from scripts.pgso.model import PgsoError, sha256_file
 from scripts.pgso.pipeline import merge_profile_batch
-from scripts.pgso.runner import CommandResult, run_checked
+from scripts.pgso.runner import CommandResult, hermetic_environment, run_checked
 
 
 REQUIRED_DIRECT_COMMANDS = (
@@ -40,8 +42,8 @@ ISOLATED_ENVIRONMENT_KEYS = (
     "TMUX_TMPDIR",
     "FX_TRACE_LOG",
     "FX_TRACE_SCOPES",
+    "FX_E2E_DISABLE_DOTENV",
 )
-
 
 @dataclasses.dataclass(frozen=True)
 class Scenario:
@@ -54,7 +56,6 @@ class Scenario:
     requires_tmux: bool
     allow_keychain: bool
     test_file: str | None
-    skip_reason: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -97,7 +98,6 @@ class ScenarioResult:
     status: str
     elapsed_seconds: float
     raw_profiles: int
-    skip_reason: str | None = None
     error: str | None = None
 
 
@@ -244,11 +244,8 @@ def _parse_scenario(
         if not expected_test.is_file():
             raise PgsoError(f"test file does not exist: {test_file}")
 
-    skip_reason = values.get("skip_reason")
-    if skip_reason is not None and (
-        not isinstance(skip_reason, str) or not skip_reason.strip()
-    ):
-        raise PgsoError(f"scenario {name} skip_reason must be nonempty")
+    if "skip_reason" in defaults or "skip_reason" in scenario_raw:
+        raise PgsoError(f"scenario {name} cannot be skipped")
 
     return Scenario(
         name=name,
@@ -260,7 +257,6 @@ def _parse_scenario(
         requires_tmux=requires_tmux,
         allow_keychain=allow_keychain,
         test_file=test_file,
-        skip_reason=skip_reason,
     )
 
 
@@ -364,14 +360,33 @@ def load_corpus(
     )
 
 
-def _install_training_binary(corpus: Corpus, binary: pathlib.Path) -> pathlib.Path:
+@contextlib.contextmanager
+def _installed_training_binary(
+    corpus: Corpus,
+    binary: pathlib.Path,
+) -> Iterator[pathlib.Path]:
     if not binary.is_file() or binary.stat().st_size == 0:
         raise PgsoError(f"training binary is missing or empty: {binary}")
     canonical = corpus.repo_root / "zig-out" / "bin" / "fx"
     canonical.parent.mkdir(parents=True, exist_ok=True)
     if canonical.is_symlink():
         raise PgsoError(f"canonical training binary cannot be a symlink: {canonical}")
-    if binary.resolve() != canonical.resolve():
+    if binary.resolve() == canonical.resolve():
+        yield canonical
+        return
+
+    backup: pathlib.Path | None = None
+    original_hash: str | None = None
+    if canonical.exists():
+        if not canonical.is_file():
+            raise PgsoError(f"canonical training binary is not a file: {canonical}")
+        original_hash = sha256_file(canonical)
+        backup = canonical.with_name(
+            f".{canonical.name}.pgso-backup-{uuid.uuid4().hex}"
+        )
+        os.replace(canonical, backup)
+
+    try:
         with tempfile.NamedTemporaryFile(
             dir=canonical.parent,
             prefix=f".{canonical.name}.",
@@ -384,9 +399,16 @@ def _install_training_binary(corpus: Corpus, binary: pathlib.Path) -> pathlib.Pa
             os.replace(temporary, canonical)
         finally:
             temporary.unlink(missing_ok=True)
-    if sha256_file(canonical) != sha256_file(binary):
-        raise PgsoError("canonical training binary hash mismatch after installation")
-    return canonical
+        if sha256_file(canonical) != sha256_file(binary):
+            raise PgsoError("canonical training binary hash mismatch after installation")
+        yield canonical
+    finally:
+        if canonical.is_file() or canonical.is_symlink():
+            canonical.unlink(missing_ok=True)
+        if backup is not None:
+            os.replace(backup, canonical)
+            if original_hash is None or sha256_file(canonical) != original_hash:
+                raise PgsoError("canonical training binary hash mismatch after restoration")
 
 
 def _cleanup_tmux(
@@ -439,10 +461,8 @@ def _new_tmux_dir() -> pathlib.Path:
 
 
 def _scenario_environment(runtime_home: pathlib.Path) -> dict[str, str]:
-    environment = os.environ.copy()
-    for key in ISOLATED_ENVIRONMENT_KEYS:
-        environment.pop(key, None)
-    environment["HOME"] = str(runtime_home)
+    environment = hermetic_environment(runtime_home)
+    environment["FX_E2E_DISABLE_DOTENV"] = "1"
     return environment
 
 
@@ -498,6 +518,112 @@ def _scenario_argv(
     return tuple(resolved)
 
 
+def _execute_scenario(
+    corpus: Corpus,
+    scenario: Scenario,
+    canonical: pathlib.Path,
+    bun: pathlib.Path | str,
+    runtime_home: pathlib.Path,
+    log_dir: pathlib.Path,
+    environment: dict[str, str],
+    command_runner: Callable[..., CommandResult],
+) -> CommandResult:
+    scenario_home = runtime_home / scenario.name
+    _prepare_runtime_home(scenario_home, allow_keychain=scenario.allow_keychain)
+    environment.update(_scenario_environment(scenario_home))
+    for key in scenario.env_unset:
+        environment.pop(key, None)
+    environment.update(dict(scenario.env_set))
+    environment["HOME"] = str(scenario_home)
+    environment["FX_E2E_DISABLE_DOTENV"] = "1"
+    tmux_dir: pathlib.Path | None = None
+    if scenario.requires_tmux:
+        tmux_dir = _new_tmux_dir()
+        environment["TMUX_TMPDIR"] = str(tmux_dir)
+
+    primary_error: BaseException | None = None
+    try:
+        return command_runner(
+            _scenario_argv(scenario, canonical, bun),
+            cwd=_resolve_cwd(corpus.repo_root, scenario.cwd),
+            env=environment,
+            timeout_s=scenario.timeout_seconds,
+            log_path=log_dir / f"{scenario.name}.json",
+        )
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        if tmux_dir is not None:
+            try:
+                _cleanup_tmux(environment, tmux_dir)
+            except Exception:
+                if primary_error is None:
+                    raise
+
+
+def _run_scenarios(
+    corpus: Corpus,
+    binary: pathlib.Path,
+    scenarios: Sequence[Scenario],
+    *,
+    bun: pathlib.Path | str,
+    runtime_home: pathlib.Path,
+    log_dir: pathlib.Path,
+    prepare: Callable[[Scenario, dict[str, str]], object],
+    finish: Callable[[Scenario, CommandResult, object], int],
+    failure_label: str,
+    command_runner: Callable[..., CommandResult],
+) -> CorpusResult:
+    results: list[ScenarioResult] = []
+    merged_raw_profiles = 0
+    with _installed_training_binary(corpus, binary) as canonical:
+        for scenario in scenarios:
+            command_result: CommandResult | None = None
+            try:
+                environment: dict[str, str] = {}
+                state = prepare(scenario, environment)
+                command_result = _execute_scenario(
+                    corpus,
+                    scenario,
+                    canonical,
+                    bun,
+                    runtime_home,
+                    log_dir,
+                    environment,
+                    command_runner,
+                )
+                raw_profiles = finish(scenario, command_result, state)
+                merged_raw_profiles += raw_profiles
+            except Exception as error:
+                results.append(
+                    ScenarioResult(
+                        name=scenario.name,
+                        status="failed",
+                        elapsed_seconds=(
+                            0 if command_result is None else command_result.elapsed_seconds
+                        ),
+                        raw_profiles=0,
+                        error=str(error),
+                    )
+                )
+                result = _result(results, merged_raw_profiles)
+                raise CorpusRunError(
+                    f"{failure_label} scenario failed: {scenario.name}: {error}",
+                    result,
+                ) from error
+
+            results.append(
+                ScenarioResult(
+                    name=scenario.name,
+                    status="passed",
+                    elapsed_seconds=command_result.elapsed_seconds,
+                    raw_profiles=raw_profiles,
+                )
+            )
+    return _result(results, merged_raw_profiles)
+
+
 def run_corpus(
     corpus: Corpus,
     binary: pathlib.Path,
@@ -509,135 +635,53 @@ def run_corpus(
     command_runner: Callable[..., CommandResult] = run_checked,
     profile_merger: Callable[..., int] = merge_profile_batch,
 ) -> CorpusResult:
-    canonical = _install_training_binary(corpus, binary)
     profile_dir.mkdir(parents=True, exist_ok=True)
     log_dir = profile_dir.parent.parent / "logs" / "corpus"
     log_dir.mkdir(parents=True, exist_ok=True)
     runtime_home = profile_dir.parent / "home"
     runtime_home.mkdir(parents=True, exist_ok=True)
-    results: list[ScenarioResult] = []
-    merged_raw_profiles = 0
-    for scenario in corpus.scenarios:
-        if scenario.skip_reason is not None:
-            results.append(
-                ScenarioResult(
-                    name=scenario.name,
-                    status="skipped",
-                    elapsed_seconds=0,
-                    raw_profiles=0,
-                    skip_reason=scenario.skip_reason,
-                )
-            )
-            continue
-
-        scenario_home = runtime_home / scenario.name
-        _prepare_runtime_home(
-            scenario_home,
-            allow_keychain=scenario.allow_keychain,
-        )
-        environment = _scenario_environment(scenario_home)
-        for key in scenario.env_unset:
-            environment.pop(key, None)
-        environment.update(dict(scenario.env_set))
-        environment["HOME"] = str(scenario_home)
+    def prepare(scenario: Scenario, environment: dict[str, str]) -> object:
         environment["LLVM_PROFILE_FILE"] = str(
             profile_dir / f"{scenario.name}-%m-%p-%c.profraw"
         )
-        if scenario.requires_tmux:
-            tmux_dir = _new_tmux_dir()
-            environment["TMUX_TMPDIR"] = str(tmux_dir)
+        return set(profile_dir.glob("*.profraw"))
 
-        argv = _scenario_argv(scenario, canonical, bun)
-        before = set(profile_dir.glob("*.profraw"))
-        command_result: CommandResult | None = None
-        scenario_error: Exception | None = None
-        try:
-            command_result = command_runner(
-                argv,
-                cwd=_resolve_cwd(corpus.repo_root, scenario.cwd),
-                env=environment,
-                timeout_s=scenario.timeout_seconds,
-                log_path=log_dir / f"{scenario.name}.json",
-            )
-        except Exception as error:
-            scenario_error = error
-
-        if scenario.requires_tmux:
-            try:
-                _cleanup_tmux(environment, tmux_dir)
-            except Exception as error:
-                if scenario_error is None:
-                    scenario_error = error
-
-        if scenario_error is not None:
-            results.append(
-                ScenarioResult(
-                    name=scenario.name,
-                    status="failed",
-                    elapsed_seconds=0,
-                    raw_profiles=0,
-                    error=str(scenario_error),
-                )
-            )
-            result = _result(results, merged_raw_profiles)
-            raise CorpusRunError(
-                f"corpus scenario failed: {scenario.name}: {scenario_error}",
-                result,
-            ) from scenario_error
-
+    def finish(
+        scenario: Scenario,
+        _command_result: CommandResult,
+        state: object,
+    ) -> int:
+        before = state
+        if not isinstance(before, set):
+            raise PgsoError("invalid training profile snapshot")
         generated = tuple(sorted(set(profile_dir.glob("*.profraw")) - before))
         if not generated or any(
             not profile.is_file() or profile.stat().st_size == 0
             for profile in generated
         ):
-            results.append(
-                ScenarioResult(
-                    name=scenario.name,
-                    status="failed",
-                    elapsed_seconds=command_result.elapsed_seconds,
-                    raw_profiles=len(generated),
-                    error="produced no raw profile",
-                )
-            )
-            result = _result(results, merged_raw_profiles)
-            raise CorpusRunError(
-                f"corpus scenario produced no raw profile: {scenario.name}",
-                result,
-            )
-
+            raise PgsoError("produced no raw profile")
         try:
-            merged_raw_profiles += profile_merger(
+            return profile_merger(
                 toolchain,
                 generated,
                 merged_profile,
                 log_dir / f"{scenario.name}-merge.json",
             )
         except Exception as error:
-            results.append(
-                ScenarioResult(
-                    name=scenario.name,
-                    status="failed",
-                    elapsed_seconds=command_result.elapsed_seconds,
-                    raw_profiles=len(generated),
-                    error=str(error),
-                )
-            )
-            result = _result(results, merged_raw_profiles)
-            raise CorpusRunError(
-                f"corpus profile merge failed: {scenario.name}: {error}",
-                result,
-            ) from error
+            raise PgsoError(f"profile merge failed: {error}") from error
 
-        results.append(
-            ScenarioResult(
-                name=scenario.name,
-                status="passed",
-                elapsed_seconds=command_result.elapsed_seconds,
-                raw_profiles=len(generated),
-            )
-        )
-
-    return _result(results, merged_raw_profiles)
+    return _run_scenarios(
+        corpus,
+        binary,
+        corpus.scenarios,
+        bun=bun,
+        runtime_home=runtime_home,
+        log_dir=log_dir,
+        prepare=prepare,
+        finish=finish,
+        failure_label="training corpus",
+        command_runner=command_runner,
+    )
 
 
 def run_behavior_corpus(
@@ -648,94 +692,37 @@ def run_behavior_corpus(
     bun: pathlib.Path | str = "bun",
     command_runner: Callable[..., CommandResult] = run_checked,
 ) -> CorpusResult:
-    canonical = _install_training_binary(corpus, binary)
     log_dir = output_dir / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     trace_dir = output_dir / "traces"
     trace_dir.mkdir(parents=True, exist_ok=True)
     runtime_home = output_dir / "home"
     runtime_home.mkdir(parents=True, exist_ok=True)
-    results: list[ScenarioResult] = []
-    for scenario in corpus.candidate_scenarios:
-        if scenario.skip_reason is not None:
-            results.append(
-                ScenarioResult(
-                    name=scenario.name,
-                    status="skipped",
-                    elapsed_seconds=0,
-                    raw_profiles=0,
-                    skip_reason=scenario.skip_reason,
-                )
-            )
-            continue
-
-        scenario_home = runtime_home / scenario.name
-        _prepare_runtime_home(
-            scenario_home,
-            allow_keychain=scenario.allow_keychain,
-        )
-        environment = _scenario_environment(scenario_home)
-        for key in scenario.env_unset:
-            environment.pop(key, None)
-        environment.update(dict(scenario.env_set))
-        environment["HOME"] = str(scenario_home)
+    def prepare(scenario: Scenario, environment: dict[str, str]) -> object:
         trace_path = trace_dir / f"{scenario.name}.log"
         trace_path.unlink(missing_ok=True)
         environment["FX_TRACE_LOG"] = str(trace_path)
-        if scenario.requires_tmux:
-            tmux_dir = _new_tmux_dir()
-            environment["TMUX_TMPDIR"] = str(tmux_dir)
+        return None
 
-        argv = _scenario_argv(scenario, canonical, bun)
-        command_result: CommandResult | None = None
-        scenario_error: Exception | None = None
-        try:
-            command_result = command_runner(
-                argv,
-                cwd=_resolve_cwd(corpus.repo_root, scenario.cwd),
-                env=environment,
-                timeout_s=scenario.timeout_seconds,
-                log_path=log_dir / f"{scenario.name}.json",
-            )
-        except Exception as error:
-            scenario_error = error
+    def finish(
+        _scenario: Scenario,
+        _command_result: CommandResult,
+        _state: object,
+    ) -> int:
+        return 0
 
-        if scenario.requires_tmux:
-            try:
-                _cleanup_tmux(environment, tmux_dir)
-            except Exception as error:
-                if scenario_error is None:
-                    scenario_error = error
-
-        if scenario_error is not None:
-            results.append(
-                ScenarioResult(
-                    name=scenario.name,
-                    status="failed",
-                    elapsed_seconds=0,
-                    raw_profiles=0,
-                    error=str(scenario_error),
-                )
-            )
-            result = _result(results, 0)
-            raise CorpusRunError(
-                f"behavior corpus scenario failed: {scenario.name}: "
-                f"{scenario_error}",
-                result,
-            ) from scenario_error
-
-        if command_result is None:
-            raise PgsoError(f"scenario completed without a result: {scenario.name}")
-        results.append(
-            ScenarioResult(
-                name=scenario.name,
-                status="passed",
-                elapsed_seconds=command_result.elapsed_seconds,
-                raw_profiles=0,
-            )
-        )
-
-    return _result(results, 0)
+    return _run_scenarios(
+        corpus,
+        binary,
+        corpus.candidate_scenarios,
+        bun=bun,
+        runtime_home=runtime_home,
+        log_dir=log_dir,
+        prepare=prepare,
+        finish=finish,
+        failure_label="behavior corpus",
+        command_runner=command_runner,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/pgso/distributed.py
+++ b/scripts/pgso/distributed.py
@@ -49,7 +49,7 @@ from scripts.pgso.qualify import (
     relink_profile_linked_benchmarks,
     require_measurements_passed,
 )
-from scripts.pgso.runner import run_checked
+from scripts.pgso.runner import cancellation_guard, run_checked
 from scripts.pgso.toolchain import SUPPORTED_TARGET, Toolchain
 
 
@@ -714,6 +714,16 @@ def _load_documents(
 
 
 def run_plan(phase: str, corpus_path: pathlib.Path, maximum_shards: int) -> dict[str, object]:
+    if phase == "startup":
+        return {"include": [{"name": name} for name, _argv in STARTUP_COMMANDS]}
+    if phase == "heavy":
+        return {
+            "include": [
+                {"name": workload.name}
+                for plan in BENCHMARK_PLANS
+                for workload in plan.workloads
+            ]
+        }
     corpus = load_corpus(corpus_path, repo_root=REPO_ROOT)
     if phase == "training":
         scenarios = corpus.scenarios
@@ -1170,7 +1180,11 @@ def _parser() -> argparse.ArgumentParser:
 
     plan = subparsers.add_parser("plan")
     _add_common(plan)
-    plan.add_argument("--phase", choices=("training", "behavior"), required=True)
+    plan.add_argument(
+        "--phase",
+        choices=("training", "behavior", "startup", "heavy"),
+        required=True,
+    )
     plan.add_argument("--maximum-shards", type=int, default=20)
 
     training = subparsers.add_parser("train-shard")
@@ -1222,24 +1236,29 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
     try:
-        if arguments.command == "plan":
-            payload = run_plan(arguments.phase, arguments.corpus, arguments.maximum_shards)
-            print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+        with cancellation_guard():
+            if arguments.command == "plan":
+                payload = run_plan(
+                    arguments.phase,
+                    arguments.corpus,
+                    arguments.maximum_shards,
+                )
+                print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+                return 0
+            if arguments.command == "train-shard":
+                manifest = run_training_shard(arguments)
+            elif arguments.command == "candidate":
+                manifest = run_candidate(arguments)
+            elif arguments.command == "behavior-shard":
+                manifest = run_behavior_shard(arguments)
+            elif arguments.command == "measure":
+                if arguments.samples < 50:
+                    raise PgsoError("measurement requires at least 50 samples")
+                manifest = run_measurement_shard(arguments)
+            else:
+                manifest = run_aggregate(arguments)
+            print(manifest)
             return 0
-        if arguments.command == "train-shard":
-            manifest = run_training_shard(arguments)
-        elif arguments.command == "candidate":
-            manifest = run_candidate(arguments)
-        elif arguments.command == "behavior-shard":
-            manifest = run_behavior_shard(arguments)
-        elif arguments.command == "measure":
-            if arguments.samples < 50:
-                raise PgsoError("measurement requires at least 50 samples")
-            manifest = run_measurement_shard(arguments)
-        else:
-            manifest = run_aggregate(arguments)
-        print(manifest)
-        return 0
     except PgsoError as error:
         output = getattr(arguments, "output_dir", None)
         if isinstance(output, pathlib.Path):

--- a/scripts/pgso/model.py
+++ b/scripts/pgso/model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import hashlib
-import json
 import pathlib
 
 
@@ -34,15 +33,6 @@ class ArtifactEvidence:
     headroom_mib: float
     preferred_headroom_mib: float
     preferred_headroom_met: bool
-
-
-@dataclasses.dataclass(frozen=True)
-class RunManifest:
-    identity: BuildIdentity
-    status: str
-    stage: str
-    artifact: ArtifactEvidence | None = None
-    warnings: tuple[str, ...] = ()
 
 
 def sha256_file(path: pathlib.Path) -> str:
@@ -113,12 +103,3 @@ def size_gate(
 def require_empty_stderr(stage: str, stderr: str) -> None:
     if stderr:
         raise PgsoError(f"{stage} wrote unexpected stderr: {stderr}")
-
-
-def write_manifest(path: pathlib.Path, manifest: RunManifest) -> None:
-    payload = json.dumps(
-        dataclasses.asdict(manifest),
-        indent=2,
-        sort_keys=True,
-    )
-    path.write_text(payload + "\n", encoding="utf-8")

--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import argparse
 import dataclasses
-import json
 import os
 import pathlib
 import re
@@ -16,7 +14,7 @@ from scripts.pgso.model import (
     sha256_file,
     size_gate,
 )
-from scripts.pgso.runner import run_checked
+from scripts.pgso.runner import hermetic_environment, run_checked
 from scripts.pgso.toolchain import SUPPORTED_TARGET, Toolchain
 
 
@@ -229,7 +227,6 @@ class CandidateEvidence:
     artifact: ArtifactEvidence
     sha256: str
     metadata: CandidateMetadata
-    help_output: str
     version_output: str
 
 
@@ -239,7 +236,7 @@ def _require_nonempty_file(path: pathlib.Path, label: str) -> None:
 
 
 def _runtime_environment(paths: PipelinePaths) -> dict[str, str]:
-    environment = os.environ.copy()
+    environment = hermetic_environment(paths.runtime_home)
     environment.update(
         {
             "FX_AUTO_UPGRADE": "0",
@@ -964,76 +961,5 @@ def verify_candidate(
         artifact=artifact,
         sha256=sha256_file(paths.candidate_binary),
         metadata=metadata,
-        help_output=help_result.stdout,
         version_output=version_result.stdout.strip(),
     )
-
-
-def _smoke(llvm_bin: str, output_dir: pathlib.Path, zig: str) -> None:
-    toolchain = Toolchain.discover(zig, llvm_bin, SUPPORTED_TARGET)
-    paths = PipelinePaths.create(output_dir)
-    spec = ArtifactSpec(repo_root=pathlib.Path.cwd())
-
-    control = build_control(toolchain, spec, paths)
-    control_minos = read_macos_minos(
-        toolchain,
-        control,
-        paths.logs / "control-load-commands.json",
-    )
-    bitcode_sha256 = emit_bitcode(toolchain, spec, paths)
-    raw_profiles = build_instrumented(toolchain, paths, control_minos)
-    merged_count = merge_profile_batch(
-        toolchain,
-        raw_profiles,
-        paths.merged_profile,
-        paths.logs / "merge-smoke.json",
-    )
-    emit_bitcode(
-        toolchain,
-        spec,
-        paths,
-        expected_sha256=bitcode_sha256,
-    )
-    apply_profile(toolchain, paths, bitcode_sha256)
-    link_candidate(toolchain, paths)
-    candidate = verify_candidate(
-        toolchain,
-        paths,
-        expected_minos=control_minos,
-    )
-    report = {
-        "bitcode_sha256": bitcode_sha256,
-        "candidate_sha256": candidate.sha256,
-        "candidate_size_bytes": candidate.artifact.size_bytes,
-        "candidate_size_mib": candidate.artifact.size_mib,
-        "control_minos": control_minos,
-        "control_sha256": sha256_file(control),
-        "control_size_bytes": control.stat().st_size,
-        "merged_profile_count": merged_count,
-        "status": "passed",
-        "version": candidate.version_output,
-    }
-    (paths.root / "smoke.json").write_text(
-        json.dumps(report, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    print(json.dumps(report, indent=2, sort_keys=True))
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Build and validate the macOS arm64 fx PGSO pipeline",
-    )
-    parser.add_argument("--smoke", action="store_true")
-    parser.add_argument("--llvm-bin", required=True)
-    parser.add_argument("--output-dir", required=True, type=pathlib.Path)
-    parser.add_argument("--zig", default="zig")
-    arguments = parser.parse_args(argv)
-    if not arguments.smoke:
-        parser.error("only --smoke is supported by this module")
-    _smoke(arguments.llvm_bin, arguments.output_dir, arguments.zig)
-    return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/scripts/pgso/qualify.py
+++ b/scripts/pgso/qualify.py
@@ -15,7 +15,6 @@ from scripts.pgso.pipeline import (
     ArtifactSpec,
     PipelinePaths,
     apply_profile,
-    build_control,
     build_instrumented,
     collect_instrumented_profile,
     emit_bitcode,
@@ -31,7 +30,7 @@ from scripts.pgso.profile_supplement import (
     merge_profile_supplement,
     verify_supplement_functions,
 )
-from scripts.pgso.runner import emit_progress, run_checked
+from scripts.pgso.runner import emit_progress, hermetic_environment, run_checked
 from scripts.pgso.toolchain import Toolchain
 
 
@@ -294,7 +293,7 @@ class EvidenceRecorder:
                 raise PgsoError("passed stage is missing elapsed time")
             emit_progress(f"stage passed in {elapsed_seconds:.3f}s: {name}")
 
-    def fail(self, stage: str, error: Exception) -> None:
+    def fail(self, stage: str, error: BaseException) -> None:
         elapsed_seconds = self._stage_elapsed(stage)
         self.payload["stage"] = stage
         self.payload["status"] = "failed"
@@ -603,14 +602,13 @@ def build_benchmark_pair(
 ) -> BenchmarkPair:
     paths = PipelinePaths.create(output_root, selector=plan.selector)
     spec = ArtifactSpec(repo_root=repo_root, selector=plan.selector)
-    ordinary_control = build_control(toolchain, spec, paths)
-    minimum_macos = read_macos_minos(
-        toolchain,
-        ordinary_control,
-        paths.logs / "control-load-commands.json",
-    )
     bitcode_sha256 = emit_bitcode(toolchain, spec, paths)
     external_control = build_external_o2_control(toolchain, paths)
+    minimum_macos = read_macos_minos(
+        toolchain,
+        external_control,
+        paths.logs / "control-load-commands.json",
+    )
 
     first_training = plan.training_argvs[0]
     raw_profiles = list(
@@ -847,9 +845,7 @@ def profile_linked_benchmark_evidence(
 
 
 def _measurement_environment(home: pathlib.Path) -> dict[str, str]:
-    environment = os.environ.copy()
-    for key in ("AI_GATEWAY_API_KEY", "VERCEL_OIDC_TOKEN", "LLVM_PROFILE_FILE"):
-        environment.pop(key, None)
+    environment = hermetic_environment(home)
     environment.update(
         {
             "FX_AUTO_UPGRADE": "0",

--- a/scripts/pgso/runner.py
+++ b/scripts/pgso/runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import json
 import os
@@ -10,13 +11,31 @@ import subprocess
 import sys
 import threading
 import time
-from collections.abc import Mapping, Sequence
+from collections import deque
+from collections.abc import Iterator, Mapping, Sequence
 from typing import TextIO
 
 from scripts.pgso.model import PgsoError, require_empty_stderr as ensure_empty_stderr
 
 
 COMMAND_HEARTBEAT_SECONDS = 30.0
+MAX_CAPTURED_OUTPUT_CHARS = 1024 * 1024
+INHERITED_ENVIRONMENT_KEYS = (
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LOGNAME",
+    "PATH",
+    "SHELL",
+    "SYSTEM_VERSION_COMPAT",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "TZ",
+    "USER",
+    "__CF_USER_TEXT_ENCODING",
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -26,10 +45,79 @@ class CommandResult:
     stdout: str
     stderr: str
     elapsed_seconds: float
+    stdout_total_chars: int = 0
+    stderr_total_chars: int = 0
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+
+
+class _BoundedCapture:
+    def __init__(self, maximum_chars: int) -> None:
+        self.maximum_chars = maximum_chars
+        self.chunks: deque[str] = deque()
+        self.retained_chars = 0
+        self.total_chars = 0
+
+    @property
+    def truncated(self) -> bool:
+        return self.total_chars > self.retained_chars
+
+    def append(self, chunk: str) -> None:
+        self.total_chars += len(chunk)
+        self.chunks.append(chunk)
+        self.retained_chars += len(chunk)
+        while self.retained_chars > self.maximum_chars and self.chunks:
+            excess = self.retained_chars - self.maximum_chars
+            oldest = self.chunks[0]
+            if len(oldest) <= excess:
+                self.chunks.popleft()
+                self.retained_chars -= len(oldest)
+            else:
+                self.chunks[0] = oldest[excess:]
+                self.retained_chars -= excess
+
+    def text(self) -> str:
+        retained = "".join(self.chunks)
+        if not self.truncated:
+            return retained
+        omitted = self.total_chars - self.retained_chars
+        return f"[pgso truncated {omitted} earlier characters]\n{retained}"
 
 
 def emit_progress(message: str) -> None:
     print(f"[pgso] {message}", flush=True)
+
+
+def hermetic_environment(home: pathlib.Path) -> dict[str, str]:
+    environment = {
+        key: os.environ[key]
+        for key in INHERITED_ENVIRONMENT_KEYS
+        if key in os.environ
+    }
+    environment["HOME"] = str(home)
+    return environment
+
+
+@contextlib.contextmanager
+def cancellation_guard() -> Iterator[None]:
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    handled = (signal.SIGINT, signal.SIGTERM)
+    previous = {item: signal.getsignal(item) for item in handled}
+
+    def cancel(signum, _frame) -> None:
+        name = signal.Signals(signum).name
+        raise PgsoError(f"pipeline cancelled by {name}")
+
+    try:
+        for item in handled:
+            signal.signal(item, cancel)
+        yield
+    finally:
+        for item, handler in previous.items():
+            signal.signal(item, handler)
 
 
 def _write_log(
@@ -41,6 +129,10 @@ def _write_log(
     stdout: str,
     stderr: str,
     status: str,
+    stdout_total_chars: int | None = None,
+    stderr_total_chars: int | None = None,
+    stdout_truncated: bool = False,
+    stderr_truncated: bool = False,
 ) -> None:
     payload = {
         "argv": argv,
@@ -49,7 +141,15 @@ def _write_log(
         "returncode": returncode,
         "status": status,
         "stderr": stderr,
+        "stderr_total_chars": (
+            len(stderr) if stderr_total_chars is None else stderr_total_chars
+        ),
+        "stderr_truncated": stderr_truncated,
         "stdout": stdout,
+        "stdout_total_chars": (
+            len(stdout) if stdout_total_chars is None else stdout_total_chars
+        ),
+        "stdout_truncated": stdout_truncated,
     }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -77,14 +177,14 @@ def _terminate_process_group(process: subprocess.Popen[str]) -> None:
 def _stream_pipe(
     pipe: TextIO,
     sink: TextIO,
-    chunks: list[str],
+    capture: _BoundedCapture,
 ) -> None:
     try:
         while True:
             chunk = pipe.read(4096)
             if not chunk:
                 return
-            chunks.append(chunk)
+            capture.append(chunk)
             sink.write(chunk)
             sink.flush()
     finally:
@@ -144,16 +244,16 @@ def run_checked(
         _terminate_process_group(process)
         raise PgsoError("command output pipes were not created")
 
-    stdout_chunks: list[str] = []
-    stderr_chunks: list[str] = []
+    stdout_capture = _BoundedCapture(MAX_CAPTURED_OUTPUT_CHARS)
+    stderr_capture = _BoundedCapture(MAX_CAPTURED_OUTPUT_CHARS)
     stdout_thread = threading.Thread(
         target=_stream_pipe,
-        args=(process.stdout, sys.stdout, stdout_chunks),
+        args=(process.stdout, sys.stdout, stdout_capture),
         daemon=True,
     )
     stderr_thread = threading.Thread(
         target=_stream_pipe,
-        args=(process.stderr, sys.stderr, stderr_chunks),
+        args=(process.stderr, sys.stderr, stderr_capture),
         daemon=True,
     )
     stdout_thread.start()
@@ -162,45 +262,73 @@ def run_checked(
     timed_out = False
     deadline = time.monotonic() + timeout_s
     next_heartbeat = time.monotonic() + COMMAND_HEARTBEAT_SECONDS
-    while process.poll() is None:
-        now = time.monotonic()
-        if now >= deadline:
-            timed_out = True
-            _terminate_process_group(process)
-            break
-        wait_seconds = max(0.001, min(deadline, next_heartbeat) - now)
-        try:
-            process.wait(timeout=wait_seconds)
-        except subprocess.TimeoutExpired:
+    try:
+        while process.poll() is None:
             now = time.monotonic()
             if now >= deadline:
                 timed_out = True
                 _terminate_process_group(process)
                 break
-            if now >= next_heartbeat:
-                emit_progress(
-                    f"command still running after {now - started:.1f}s: "
-                    f"{command_display} (log: {log_path})"
-                )
-                while next_heartbeat <= now:
-                    next_heartbeat += COMMAND_HEARTBEAT_SECONDS
-
-    stdout_thread.join()
-    stderr_thread.join()
-    stdout = "".join(stdout_chunks)
-    stderr = "".join(stderr_chunks)
-
-    if timed_out:
+            wait_seconds = max(0.001, min(deadline, next_heartbeat) - now)
+            try:
+                process.wait(timeout=wait_seconds)
+            except subprocess.TimeoutExpired:
+                now = time.monotonic()
+                if now >= deadline:
+                    timed_out = True
+                    _terminate_process_group(process)
+                    break
+                if now >= next_heartbeat:
+                    emit_progress(
+                        f"command still running after {now - started:.1f}s: "
+                        f"{command_display} (log: {log_path})"
+                    )
+                    while next_heartbeat <= now:
+                        next_heartbeat += COMMAND_HEARTBEAT_SECONDS
+    except BaseException:
+        _terminate_process_group(process)
+        stdout_thread.join()
+        stderr_thread.join()
         elapsed_seconds = time.monotonic() - started
         _write_log(
             log_path,
             argv=argv_tuple,
             elapsed_seconds=elapsed_seconds,
             returncode=process.returncode,
+            stdout=stdout_capture.text(),
+            stderr=stderr_capture.text(),
+            status="cancelled",
+            stdout_total_chars=stdout_capture.total_chars,
+            stderr_total_chars=stderr_capture.total_chars,
+            stdout_truncated=stdout_capture.truncated,
+            stderr_truncated=stderr_capture.truncated,
+        )
+        emit_progress(f"command cancelled after {elapsed_seconds:.3f}s: {command_display}")
+        raise
+
+    stdout_thread.join()
+    stderr_thread.join()
+    stdout = stdout_capture.text()
+    stderr = stderr_capture.text()
+
+    def write_status(status: str) -> None:
+        _write_log(
+            log_path,
+            argv=argv_tuple,
+            elapsed_seconds=time.monotonic() - started,
+            returncode=process.returncode,
             stdout=stdout,
             stderr=stderr,
-            status="timed_out",
+            status=status,
+            stdout_total_chars=stdout_capture.total_chars,
+            stderr_total_chars=stderr_capture.total_chars,
+            stdout_truncated=stdout_capture.truncated,
+            stderr_truncated=stderr_capture.truncated,
         )
+
+    if timed_out:
+        elapsed_seconds = time.monotonic() - started
+        write_status("timed_out")
         emit_progress(
             f"command timed out in {elapsed_seconds:.3f}s: {command_display}"
         )
@@ -215,17 +343,13 @@ def run_checked(
         stdout=stdout,
         stderr=stderr,
         elapsed_seconds=elapsed_seconds,
+        stdout_total_chars=stdout_capture.total_chars,
+        stderr_total_chars=stderr_capture.total_chars,
+        stdout_truncated=stdout_capture.truncated,
+        stderr_truncated=stderr_capture.truncated,
     )
     if result.returncode != 0:
-        _write_log(
-            log_path,
-            argv=argv_tuple,
-            elapsed_seconds=elapsed_seconds,
-            returncode=result.returncode,
-            stdout=stdout,
-            stderr=stderr,
-            status="failed",
-        )
+        write_status("failed")
         emit_progress(
             f"command failed in {elapsed_seconds:.3f}s: {command_display} "
             f"(exit: {result.returncode})"
@@ -235,28 +359,12 @@ def run_checked(
         )
 
     if require_empty_stderr and stderr:
-        _write_log(
-            log_path,
-            argv=argv_tuple,
-            elapsed_seconds=elapsed_seconds,
-            returncode=result.returncode,
-            stdout=stdout,
-            stderr=stderr,
-            status="unexpected_stderr",
-        )
+        write_status("unexpected_stderr")
         emit_progress(
             f"command rejected stderr in {elapsed_seconds:.3f}s: {command_display}"
         )
         ensure_empty_stderr("command", stderr)
 
-    _write_log(
-        log_path,
-        argv=argv_tuple,
-        elapsed_seconds=elapsed_seconds,
-        returncode=result.returncode,
-        stdout=stdout,
-        stderr=stderr,
-        status="passed",
-    )
+    write_status("passed")
     emit_progress(f"command passed in {elapsed_seconds:.3f}s: {command_display}")
     return result

--- a/scripts/pgso/tests/test_cli.py
+++ b/scripts/pgso/tests/test_cli.py
@@ -50,16 +50,20 @@ class PgsoCliTests(unittest.TestCase):
         self.assertEqual("hyperfine", arguments.hyperfine)
 
     def test_every_mutating_command_requires_toolchain_and_output(self) -> None:
-        for command in ("build", "train", "qualify", "all"):
+        for command in ("build", "train", "all"):
             with self.subTest(command=command):
                 with self.assertRaises(SystemExit):
                     parse_args([command])
 
     def test_qualification_rejects_fewer_than_fifty_samples(self) -> None:
-        for command in ("qualify", "all"):
+        for command in ("all",):
             with self.subTest(command=command):
                 with self.assertRaises(SystemExit):
                     parse_args([*self.required_arguments(command), "--samples", "49"])
+
+    def test_redundant_qualify_alias_is_not_exposed(self) -> None:
+        with self.assertRaises(SystemExit):
+            parse_args(self.required_arguments("qualify"))
 
     def test_fresh_output_rejects_nonempty_state(self) -> None:
         output = self.root / "output"
@@ -131,6 +135,22 @@ class PgsoCliTests(unittest.TestCase):
         self.assertEqual("validate", payload["stage"])
         self.assertFalse(payload["eligible"])
         self.assertEqual("wrong LLVM version", payload["error"])
+
+    def test_driver_marks_the_manifest_failed_when_interrupted(self) -> None:
+        arguments = parse_args(self.required_arguments())
+        with mock.patch(
+            "scripts.pgso.__main__.Toolchain.discover",
+            side_effect=KeyboardInterrupt(),
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                run_command(arguments)
+
+        payload = json.loads(
+            (arguments.output_dir / "manifest.json").read_text()
+        )
+        self.assertEqual("failed", payload["status"])
+        self.assertEqual("validate", payload["stage"])
+        self.assertFalse(payload["eligible"])
 
     def test_runtime_validation_rejects_the_wrong_bun_version(self) -> None:
         arguments = parse_args(self.required_arguments())

--- a/scripts/pgso/tests/test_corpus.py
+++ b/scripts/pgso/tests/test_corpus.py
@@ -317,6 +317,15 @@ class PgsoCorpusTests(unittest.TestCase):
                 with self.assertRaisesRegex(PgsoError, "reserved environment key"):
                     load_corpus(self.write_manifest(payload), repo_root=self.root)
 
+    def test_load_rejects_skipped_scenarios(self) -> None:
+        payload = self.manifest()
+        scenarios = payload["scenarios"]
+        assert isinstance(scenarios, list)
+        scenarios[0]["skip_reason"] = "not applicable"
+
+        with self.assertRaisesRegex(PgsoError, "cannot be skipped"):
+            load_corpus(self.write_manifest(payload), repo_root=self.root)
+
     def test_production_manifest_classifies_every_e2e_file(self) -> None:
         repo_root = pathlib.Path(__file__).resolve().parents[3]
         corpus = load_corpus(
@@ -417,7 +426,6 @@ class PgsoCorpusTests(unittest.TestCase):
         name: str,
         *,
         requires_tmux: bool = False,
-        skip_reason: str | None = None,
     ) -> Scenario:
         return Scenario(
             name=name,
@@ -429,7 +437,6 @@ class PgsoCorpusTests(unittest.TestCase):
             requires_tmux=requires_tmux,
             allow_keychain=False,
             test_file=None,
-            skip_reason=skip_reason,
         )
 
     def make_corpus(self, *scenarios: Scenario) -> Corpus:
@@ -507,7 +514,7 @@ class PgsoCorpusTests(unittest.TestCase):
         )
         return result, calls, merges, binary, merged_profile
 
-    def test_run_inherits_environment_and_owns_per_scenario_profiles(self) -> None:
+    def test_run_uses_a_hermetic_environment_and_owns_per_scenario_profiles(self) -> None:
         corpus = self.make_corpus(
             self.make_scenario("first"),
             self.make_scenario("second"),
@@ -530,20 +537,17 @@ class PgsoCorpusTests(unittest.TestCase):
         self.assertEqual(0, result.skipped)
         self.assertEqual(0, result.failed)
         self.assertEqual(2, result.merged_raw_profiles)
-        self.assertEqual(
-            sha256_bytes(binary.read_bytes()),
-            sha256_bytes(
-                (self.root / "zig-out" / "bin" / "fx").read_bytes()
-            ),
-        )
+        self.assertFalse((self.root / "zig-out" / "bin" / "fx").exists())
         self.assertTrue(merged.is_file())
         self.assertEqual(2, len(calls))
-        self.assertEqual("yes", calls[0]["env"]["PGSO_INHERITED"])
+        self.assertNotIn("PGSO_INHERITED", calls[0]["env"])
         self.assertNotIn("PGSO_UNSET_ME", calls[0]["env"])
         self.assertNotIn("TMUX", calls[0]["env"])
         self.assertNotIn("TMUX_PANE", calls[0]["env"])
         self.assertNotIn("FX_TRACE_LOG", calls[0]["env"])
         self.assertNotIn("FX_TRACE_SCOPES", calls[0]["env"])
+        self.assertEqual("1", calls[0]["env"]["FX_E2E_DISABLE_DOTENV"])
+        self.assertEqual(os.environ["PATH"], calls[0]["env"]["PATH"])
         self.assertEqual(
             str(self.root / "output" / "profiles" / "home" / "first"),
             calls[0]["env"]["HOME"],
@@ -636,21 +640,7 @@ class PgsoCorpusTests(unittest.TestCase):
         with self.assertRaisesRegex(CorpusRunError, "produced no raw profile"):
             self.run_fixture(corpus, omit_profile_for="missing-profile")
 
-    def test_run_records_only_explicit_manifest_skips(self) -> None:
-        corpus = self.make_corpus(
-            self.make_scenario("skip", skip_reason="not applicable in smoke"),
-            self.make_scenario("run"),
-        )
-
-        result, calls, merges, _, _ = self.run_fixture(corpus)
-
-        self.assertEqual(1, result.passed)
-        self.assertEqual(1, result.skipped)
-        self.assertEqual(0, result.failed)
-        self.assertEqual(1, len(calls))
-        self.assertEqual(1, len(merges))
-
-    def test_behavior_corpus_replaces_canonical_binary_with_fresh_inode(self) -> None:
+    def test_behavior_corpus_restores_the_previous_canonical_binary(self) -> None:
         corpus = self.make_corpus(self.make_scenario("first"))
         canonical = self.root / "zig-out" / "bin" / "fx"
         canonical.parent.mkdir(parents=True)
@@ -675,8 +665,33 @@ class PgsoCorpusTests(unittest.TestCase):
             command_runner=command_runner,
         )
 
-        self.assertEqual(b"candidate", canonical.read_bytes())
-        self.assertNotEqual(stale_inode, canonical.stat().st_ino)
+        self.assertEqual(b"stale", canonical.read_bytes())
+        self.assertEqual(stale_inode, canonical.stat().st_ino)
+
+    def test_interruption_cleans_tmux_and_restores_the_canonical_binary(self) -> None:
+        corpus = self.make_corpus(self.make_scenario("first", requires_tmux=True))
+        canonical = self.root / "zig-out" / "bin" / "fx"
+        canonical.parent.mkdir(parents=True)
+        canonical.write_bytes(b"original")
+        binary = self.root / "candidate-fx"
+        binary.write_bytes(b"candidate")
+
+        def interrupted_runner(*_args, **_kwargs):
+            raise KeyboardInterrupt()
+
+        with (
+            mock.patch("scripts.pgso.corpus._cleanup_tmux") as cleanup,
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            run_behavior_corpus(
+                corpus,
+                binary,
+                self.root / "behavior-output",
+                command_runner=interrupted_runner,
+            )
+
+        cleanup.assert_called_once()
+        self.assertEqual(b"original", canonical.read_bytes())
 
     def test_behavior_corpus_runs_the_exact_binary_without_profile_output(self) -> None:
         corpus = self.make_corpus(
@@ -745,12 +760,6 @@ class PgsoCorpusTests(unittest.TestCase):
                 / ".tmux.conf"
             ).read_text(),
         )
-
-
-def sha256_bytes(contents: bytes) -> str:
-    import hashlib
-
-    return hashlib.sha256(contents).hexdigest()
 
 
 def dataclasses_replace_env(

--- a/scripts/pgso/tests/test_distributed.py
+++ b/scripts/pgso/tests/test_distributed.py
@@ -11,6 +11,7 @@ from scripts.pgso.distributed import (
     aggregate_scenario_shards,
     matrix_payload,
     plan_shards,
+    run_plan,
     select_corpus,
     validate_seed_identity,
 )
@@ -72,8 +73,54 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn('          llvm: "true"', heavy_job)
         self.assertNotIn("--llvm-bin", heavy_job)
 
+    def test_measurement_matrices_are_generated_from_python_definitions(self) -> None:
+        repo_root = pathlib.Path(__file__).resolve().parents[3]
+        workflow = (
+            repo_root / ".github/workflows/pgso-macos-arm64.yml"
+        ).read_text()
+        startup_job = workflow.split("\n  startup:\n", 1)[1].split(
+            "\n  heavy:\n", 1
+        )[0]
+        heavy_job = workflow.split("\n  heavy:\n", 1)[1].split(
+            "\n  aggregate:\n", 1
+        )[0]
+
+        self.assertIn("fromJSON(needs.seed.outputs.startup)", startup_job)
+        self.assertIn("fromJSON(needs.seed.outputs.heavy)", heavy_job)
+        self.assertNotIn("name: [help, version", startup_job)
+        self.assertNotIn("- file-index-100k", heavy_job)
+
 
 class ShardPlanningTests(unittest.TestCase):
+    def test_measurement_plans_come_from_the_authoritative_definitions(self) -> None:
+        missing_corpus = pathlib.Path("/does/not/need/to/exist.json")
+
+        self.assertEqual(
+            {
+                "include": [
+                    {"name": name}
+                    for name in ("help", "version", "status", "background", "doctor", "sessions")
+                ]
+            },
+            run_plan("startup", missing_corpus, 20),
+        )
+        self.assertEqual(
+            {
+                "include": [
+                    {"name": name}
+                    for name in (
+                        "file-index-100k",
+                        "ui-activity",
+                        "approval-transcript",
+                        "approval-diff",
+                        "approval-combined",
+                        "approval-payload",
+                    )
+                ]
+            },
+            run_plan("heavy", missing_corpus, 20),
+        )
+
     def test_plan_assigns_every_scenario_exactly_once(self) -> None:
         scenarios = tuple(
             scenario(f"scenario-{index:02d}", float(index + 1))
@@ -205,7 +252,6 @@ class ShardAggregationTests(unittest.TestCase):
                         "status": "passed",
                         "elapsed_seconds": 1.0,
                         "raw_profiles": 1,
-                        "skip_reason": None,
                         "error": None,
                     }
                     for name in names

--- a/scripts/pgso/tests/test_model.py
+++ b/scripts/pgso/tests/test_model.py
@@ -8,14 +8,12 @@ import unittest
 from scripts.pgso.model import (
     BuildIdentity,
     PgsoError,
-    RunManifest,
     bytes_to_mib,
     profile_evidence,
     require_empty_stderr,
     sha256_file,
     size_gate,
     verify_identity,
-    write_manifest,
 )
 
 
@@ -124,49 +122,6 @@ class PgsoModelTests(unittest.TestCase):
             "profile use wrote unexpected stderr: optimizer warning",
         ):
             require_empty_stderr("profile use", "optimizer warning")
-
-    def test_write_manifest_uses_canonical_sorted_json(self) -> None:
-        manifest = RunManifest(
-            identity=self.identity(),
-            status="running",
-            stage="control",
-            artifact=size_gate(7_837_920),
-            warnings=(),
-        )
-        expected = """{
-  "artifact": {
-    "ceiling_mib": 7.8,
-    "headroom_mib": 0.3251770019531248,
-    "preferred_headroom_met": true,
-    "preferred_headroom_mib": 0.25,
-    "size_bytes": 7837920,
-    "size_mib": 7.474822998046875
-  },
-  "identity": {
-    "bitcode_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "corpus_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-    "generation_flags": [
-      "--disable-vp"
-    ],
-    "host_arch": "arm64",
-    "llvm_version": "21.1.8",
-    "source_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "target": "aarch64-macos",
-    "update_channel": "stable",
-    "zig_version": "0.16.0"
-  },
-  "stage": "control",
-  "status": "running",
-  "warnings": []
-}
-"""
-
-        with tempfile.TemporaryDirectory(prefix="fx-pgso-model-") as tmp:
-            path = pathlib.Path(tmp) / "manifest.json"
-            write_manifest(path, manifest)
-
-            self.assertEqual(expected, path.read_text())
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/pgso/tests/test_qualify.py
+++ b/scripts/pgso/tests/test_qualify.py
@@ -18,6 +18,7 @@ from scripts.pgso.qualify import (
     BenchmarkPair,
     EvidenceRecorder,
     _read_hyperfine_samples,
+    build_benchmark_pair,
     build_profile_linked_benchmarks,
     compare_samples,
     measure_alternating,
@@ -351,7 +352,14 @@ class PgsoQualificationTests(unittest.TestCase):
             return base_runner(argv, **kwargs)
 
         with (
-            mock.patch.dict(os.environ, {"FX_DISABLE_KEYCHAIN": "0"}),
+            mock.patch.dict(
+                os.environ,
+                {
+                    "FX_DISABLE_KEYCHAIN": "0",
+                    "AI_GATEWAY_API_KEY": "must-not-leak",
+                    "FX_E2E_REAL_API": "1",
+                },
+            ),
             mock.patch("scripts.pgso.qualify.run_checked", side_effect=fake_run),
         ):
             measure_startup(
@@ -367,6 +375,12 @@ class PgsoQualificationTests(unittest.TestCase):
         self.assertTrue(environments)
         self.assertTrue(
             all(environment["FX_DISABLE_KEYCHAIN"] == "1" for environment in environments)
+        )
+        self.assertTrue(
+            all("AI_GATEWAY_API_KEY" not in environment for environment in environments)
+        )
+        self.assertTrue(
+            all("FX_E2E_REAL_API" not in environment for environment in environments)
         )
 
     def test_startup_measurement_rejects_a_truncated_hyperfine_round(self) -> None:
@@ -487,6 +501,45 @@ class PgsoQualificationTests(unittest.TestCase):
         self.assertEqual(str(control), calls[0][0])
         self.assertEqual(str(candidate), calls[1][0])
         self.assertTrue(results[0].passed)
+
+    def test_benchmark_pair_uses_the_external_control_for_minimum_macos(self) -> None:
+        plan = BENCHMARK_PLANS[0]
+        output = self.root / "pair"
+        external = self.root / "fixtures" / "external-control"
+        candidate = self.root / "fixtures" / "candidate"
+        raw_profile = self.root / "fixtures" / "training.profraw"
+        for path in (external, candidate, raw_profile):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"evidence")
+
+        with (
+            mock.patch(
+                "scripts.pgso.qualify.build_control",
+                side_effect=AssertionError("ordinary control build is wasteful"),
+                create=True,
+            ),
+            mock.patch("scripts.pgso.qualify.emit_bitcode", return_value="b" * 64),
+            mock.patch(
+                "scripts.pgso.qualify.build_external_o2_control",
+                return_value=external,
+            ),
+            mock.patch(
+                "scripts.pgso.qualify.read_macos_minos",
+                return_value="15.0",
+            ) as read_minos,
+            mock.patch(
+                "scripts.pgso.qualify.build_instrumented",
+                return_value=(raw_profile,),
+            ) as instrument,
+            mock.patch("scripts.pgso.qualify.merge_profile_batch", return_value=1),
+            mock.patch("scripts.pgso.qualify.apply_profile"),
+            mock.patch("scripts.pgso.qualify.link_candidate", return_value=candidate),
+        ):
+            pair = build_benchmark_pair(object(), self.root, output, plan)
+
+        self.assertEqual(external, pair.control_binary)
+        self.assertEqual(external, read_minos.call_args.args[1])
+        self.assertEqual("15.0", instrument.call_args.args[2])
 
     def test_builds_all_profile_linked_benchmarks_before_candidate_link(self) -> None:
         paths = PipelinePaths.create(self.root / "run")

--- a/scripts/pgso/tests/test_runner.py
+++ b/scripts/pgso/tests/test_runner.py
@@ -6,6 +6,7 @@ import json
 import os
 import pathlib
 import shlex
+import signal
 import sys
 import tempfile
 import threading
@@ -14,10 +15,29 @@ import unittest
 from unittest import mock
 
 from scripts.pgso.model import PgsoError
-from scripts.pgso.runner import run_checked
+from scripts.pgso.runner import cancellation_guard, run_checked
 
 
 class PgsoRunnerTests(unittest.TestCase):
+    def test_cancellation_guard_converts_sigterm_and_restores_handlers(self) -> None:
+        installed: dict[object, object] = {}
+
+        def install(signum, handler):
+            installed[signum] = handler
+
+        with (
+            mock.patch("scripts.pgso.runner.signal.getsignal", return_value="original"),
+            mock.patch("scripts.pgso.runner.signal.signal", side_effect=install),
+        ):
+            with self.assertRaisesRegex(PgsoError, "cancelled by SIGTERM"):
+                with cancellation_guard():
+                    handler = installed[signal.SIGTERM]
+                    assert callable(handler)
+                    handler(signal.SIGTERM, None)
+
+        self.assertEqual("original", installed[signal.SIGINT])
+        self.assertEqual("original", installed[signal.SIGTERM])
+
     def test_child_output_is_visible_before_the_command_finishes(self) -> None:
         class LiveOutput(io.StringIO):
             def __init__(self) -> None:
@@ -179,6 +199,69 @@ class PgsoRunnerTests(unittest.TestCase):
             self.assertEqual("passed", log["status"])
             self.assertNotIn("environment", log)
             self.assertNotIn("must-not-be-logged", log_path.read_text())
+
+    def test_noisy_output_is_truncated_in_memory_and_in_the_json_log(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="fx-pgso-runner-") as tmp:
+            root = pathlib.Path(tmp)
+            log_path = root / "bounded.json"
+            with (
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(io.StringIO()),
+                mock.patch(
+                    "scripts.pgso.runner.MAX_CAPTURED_OUTPUT_CHARS",
+                    128,
+                ),
+            ):
+                result = run_checked(
+                    [
+                        sys.executable,
+                        "-c",
+                        "import sys; print('x' * 4096); print('y' * 4096, file=sys.stderr)",
+                    ],
+                    cwd=root,
+                    env=os.environ.copy(),
+                    timeout_s=5,
+                    log_path=log_path,
+                )
+
+            log = json.loads(log_path.read_text())
+            self.assertTrue(result.stdout_truncated)
+            self.assertTrue(result.stderr_truncated)
+            self.assertTrue(log["stdout_truncated"])
+            self.assertTrue(log["stderr_truncated"])
+            self.assertGreater(log["stdout_total_chars"], 4096)
+            self.assertGreater(log["stderr_total_chars"], 4096)
+            self.assertLess(len(log["stdout"]), 256)
+            self.assertLess(len(log["stderr"]), 256)
+
+    def test_interruption_terminates_the_process_group_and_logs_cancellation(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="fx-pgso-runner-") as tmp:
+            root = pathlib.Path(tmp)
+            process = mock.Mock()
+            process.stdout = io.StringIO("partial stdout\n")
+            process.stderr = io.StringIO("")
+            process.poll.return_value = None
+            process.wait.side_effect = KeyboardInterrupt()
+            process.returncode = -2
+            log_path = root / "cancelled.json"
+
+            with (
+                mock.patch("scripts.pgso.runner.subprocess.Popen", return_value=process),
+                mock.patch("scripts.pgso.runner._terminate_process_group") as terminate,
+                self.assertRaises(KeyboardInterrupt),
+            ):
+                run_checked(
+                    ["fixture"],
+                    cwd=root,
+                    env={},
+                    timeout_s=5,
+                    log_path=log_path,
+                )
+
+            terminate.assert_called_once_with(process)
+            log = json.loads(log_path.read_text())
+            self.assertEqual("cancelled", log["status"])
+            self.assertEqual("partial stdout\n", log["stdout"])
 
     def test_nonzero_exit_raises_after_logging_output(self) -> None:
         with tempfile.TemporaryDirectory(prefix="fx-pgso-runner-") as tmp:

--- a/tests/evals/eval-helpers.test.ts
+++ b/tests/evals/eval-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildEvalProcessEnv } from "./eval-helpers";
+import { buildEvalProcessEnv, shouldLoadDotEnv } from "./eval-helpers";
 
 describe("eval helpers", () => {
   test("passes the selected eval model to fx through FX_MODEL", () => {
@@ -19,5 +19,10 @@ describe("eval helpers", () => {
         process.env.FX_MODEL = previous;
       }
     }
+  });
+
+  test("does not load repository dotenv files in a hermetic run", () => {
+    expect(shouldLoadDotEnv({ FX_E2E_DISABLE_DOTENV: "1" })).toBe(false);
+    expect(shouldLoadDotEnv({})).toBe(true);
   });
 });

--- a/tests/evals/eval-helpers.ts
+++ b/tests/evals/eval-helpers.ts
@@ -47,7 +47,13 @@ function loadDotEnv(): Record<string, string> {
   return vars;
 }
 
-const dotEnvVars = loadDotEnv();
+export function shouldLoadDotEnv(
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return environment.FX_E2E_DISABLE_DOTENV !== "1";
+}
+
+const dotEnvVars = shouldLoadDotEnv() ? loadDotEnv() : {};
 
 for (const [k, v] of Object.entries(dotEnvVars)) {
   if (!process.env[k]) process.env[k] = v;


### PR DESCRIPTION
## Summary

- Require every declared PGSO scenario to execute successfully.
- Isolate training and qualification from host credentials, live-test flags, and repository dotenv files.
- Restore the canonical fx binary and terminate child processes and tmux servers after failure or cancellation.
- Bound command output retained in PGSO evidence.
- Generate startup and heavy-workload matrices from the Python benchmark definitions.
- Remove redundant PGSO entry points and the discarded benchmark control build.