### PR TITLE
Scope usage and search to selected adapters

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -208,6 +208,7 @@ const AcpContext = struct {
     fn toolContext(self: *AcpContext) tool_runtime.Context {
         const session = if (self.state.active_session) |*active| active else unreachable;
         self.state.web_search_runtime.configure(.{
+            .connection_id = self.state.credential_connection_id orelse session_codec.legacy_connection_id,
             .api_key = session.api_key,
             .gateway_team = self.state.gateway_team,
             .worker_model = session.model,
@@ -2762,8 +2763,8 @@ test "ACP usage checkpoints maintain the profile recovery marker" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     var pending = try usage.snapshot(alloc);
     defer pending.deinit(alloc);

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -41,7 +41,9 @@ const context_contract = @import("../core/workspace/context_contract.zig");
 const config_runtime = @import("../core/config/config_runtime.zig");
 const model_capabilities = @import("../core/config/model_capabilities.zig");
 const route_snapshot = @import("../core/gateway/route_snapshot.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
 const connection_registry = @import("../core/gateway/connection_registry.zig");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
 const mode_registry = @import("../core/modes/mode_registry.zig");
 const devbox_executor = @import("../core/execution/devbox_executor.zig");
 const debug_trace = @import("../core/shared/debug_trace.zig");
@@ -90,6 +92,7 @@ const AcpContext = struct {
     alloc: Allocator,
     state: *server.ServerState,
     session_id: []const u8,
+    connection_adapter_kind: []const u8 = "",
     /// Tool-call IDs already announced with a pending update. Keys are owned
     /// copies of provider call ids so the ID stays stable from permission
     /// review through execution.
@@ -207,16 +210,6 @@ const AcpContext = struct {
 
     fn toolContext(self: *AcpContext) tool_runtime.Context {
         const session = if (self.state.active_session) |*active| active else unreachable;
-        self.state.web_search_runtime.configure(.{
-            .connection_id = self.state.credential_connection_id orelse session_codec.legacy_connection_id,
-            .api_key = session.api_key,
-            .gateway_team = self.state.gateway_team,
-            .worker_model = session.model,
-            .gateway_retry_count = self.state.cfg.gateway_retry_count,
-            .gateway_chat_url = self.state.cfg.gateway_chat_url,
-            .usage = &session.session_rt.usage,
-            .usage_allocator = self.state.alloc,
-        });
         var tc: tool_runtime.Context = .{
             .workspace_root = self.state.workspace_root,
             .access_scope = self.state.workspace_access.scope(self.state.workspace_root),
@@ -521,6 +514,9 @@ pub fn handlePrompt(
         .permission_rules = session.permission_rules,
         .mcp_runtime = session.mcp,
         .subagent_available = state.subagent_host != null,
+        .terminal_available = state.subagent_host != null and
+            tool_dispatch.ToolCapabilities.for_host(host.current()).terminalAvailable(),
+        .provider_tools = state.cfg.gateway_provider.provider_adapter.provider_tools,
     });
     defer tool_projection.deinit(alloc);
 
@@ -572,6 +568,7 @@ pub fn handlePrompt(
         state.connections.?.selectedProfile().id;
     const profile = state.connections.?.profile(connection_id) catch
         return error.MissingSessionConnection;
+    ctx.connection_adapter_kind = profile.adapter_id;
     if (recovery_checkpoint) |checkpoint| {
         try route_snapshot.validateRecoveryProfile(
             profile,
@@ -652,6 +649,7 @@ pub fn handlePrompt(
         .skills_prompt_section = skills_section,
         .explicit_skills_prompt_section = explicit_skills.text,
         .gateway_tools_json = tool_projection.tools_json,
+        .provider_tools = tool_projection.provider_tools,
         .custom_tool_guidance = tool_projection.custom_guidance,
     });
     agent_config.session_child_capability = if (session.writable) |*writable|
@@ -704,6 +702,7 @@ pub fn runSubagentChild(
         .alloc = alloc,
         .state = state,
         .session_id = session_id,
+        .connection_adapter_kind = if (admission.route) |route| route.adapter_kind else "",
         .captured_mode = captured_mode,
         .captured_permission_mode = admission.permission_mode,
         .captured_sandbox_backend = admission.sandbox_backend,
@@ -718,6 +717,8 @@ pub fn runSubagentChild(
             .permission_rules = admission.rules,
             .mcp_runtime = mcp,
             .subagent_available = true,
+            .terminal_available = tool_dispatch.ToolCapabilities.for_host(host.current()).terminalAvailable(),
+            .provider_tools = state.cfg.gateway_provider.provider_adapter.provider_tools,
         },
     ) catch return error.OutOfMemory;
     defer child_projection.deinit(alloc);
@@ -742,6 +743,7 @@ pub fn runSubagentChild(
         .skills_prompt_section = bounded_skills.text,
         .explicit_skills_prompt_section = explicit_skills.text,
         .gateway_tools_json = child_projection.tools_json,
+        .provider_tools = child_projection.provider_tools,
         .custom_tool_guidance = child_projection.custom_guidance,
         .context_registry = state.cfg.context_registry,
         .context_enabled = state.context_enabled,
@@ -810,6 +812,7 @@ const AgentConfigSections = struct {
     skills_prompt_section: []const u8,
     explicit_skills_prompt_section: []const u8,
     gateway_tools_json: []const u8,
+    provider_tools: []const agent_stream_provider.ProviderToolAdvertisement = &.{},
     custom_tool_guidance: []const u8,
 };
 
@@ -822,6 +825,7 @@ fn buildAgentConfig(state: *server.ServerState, session: *server.ActiveSessionSt
         .gateway_retry_count = state.cfg.gateway_retry_count,
         .gateway_chat_url = state.cfg.gateway_chat_url,
         .gateway_tools_json = sections.gateway_tools_json,
+        .provider_tools = sections.provider_tools,
         .custom_tool_guidance = sections.custom_tool_guidance,
         .agent_step_limit = session.agent_step_limit,
         .max_tool_result_bytes = session.max_tool_result_bytes,
@@ -1170,10 +1174,16 @@ fn resolveModelCapabilities(
     model: []const u8,
 ) model_capabilities.ResolveError!model_capabilities.Capabilities {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
-    const session = if (ctx.state.active_session) |*active| active else return model_capabilities.capabilitiesForModel(model);
+    const adapter = ctx.state.cfg.gateway_provider.provider_adapter;
+    const descriptors = adapter.model_descriptors;
+    const session = if (ctx.state.active_session) |*active| active else return descriptors.fallback(model).capabilities;
+    const catalog = gateway_provider.modelCatalogForAdapter(
+        ctx.connection_adapter_kind,
+        adapter,
+    ) orelse return descriptors.fallback(model).capabilities;
     return ctx.state.capability_resolver.resolve(
         ctx.state.alloc,
-        ctx.state.cfg.gateway_provider.model_catalog,
+        catalog,
         .{
             .access = credentials.catalogAccessForCredential(session.credential_source, session.api_key, ctx.state.gateway_team),
             .endpoint = ctx.state.cfg.gateway_models_path,
@@ -1188,18 +1198,26 @@ fn availableModelCapabilities(
     model: []const u8,
 ) model_capabilities.Capabilities {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
+    const adapter = ctx.state.cfg.gateway_provider.provider_adapter;
+    if (gateway_provider.modelCatalogForAdapter(
+        ctx.connection_adapter_kind,
+        adapter,
+    ) == null) return adapter.model_descriptors.fallback(model).capabilities;
     return ctx.state.capability_resolver.available(model);
 }
 
 fn resolveModelDescriptor(raw_ctx: *anyopaque, alloc: Allocator, model: []const u8) model_capabilities.ResolveError!model_capabilities.ModelDescriptor {
-    var descriptor = model_capabilities.configuredDescriptor(model, .{});
+    const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
+    var descriptor = ctx.state.cfg.gateway_provider.provider_adapter.model_descriptors.fallback(model);
     descriptor.capabilities = try resolveModelCapabilities(raw_ctx, alloc, model);
     descriptor.source = .catalog;
     return descriptor;
 }
 
 fn availableModelDescriptor(raw_ctx: *anyopaque, model: []const u8) model_capabilities.ModelDescriptor {
-    const descriptor = model_capabilities.configuredDescriptor(model, availableModelCapabilities(raw_ctx, model));
+    const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
+    var descriptor = ctx.state.cfg.gateway_provider.provider_adapter.model_descriptors.fallback(model);
+    descriptor.capabilities = availableModelCapabilities(raw_ctx, model);
     return descriptor;
 }
 
@@ -3473,9 +3491,7 @@ fn initTestAcpState(alloc: Allocator, workspace_root: []const u8, mode: Permissi
         .workspace_root = owned_workspace,
         .connections = connections,
         .sandbox_backend = selected_backend,
-        .web_search_runtime = @import("../core/tooling/web_search_runtime.zig").Runtime.init(.{
-            .provider = cfg.gateway_provider.web_search,
-        }),
+        .web_search_runtime = @import("../core/tooling/web_search_runtime.zig").Runtime.init(.{}),
         .active_session = .{
             .session_id = session_id,
             .model = model,
@@ -3560,6 +3576,149 @@ test "fake non-Vercel adapter completes an ACP root turn on its admitted route" 
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
     try std.testing.expect(outcome == .stop_reason);
     try std.testing.expectEqual(acp_types.StopReason.end_turn, outcome.stop_reason);
+}
+
+test "mismatched ACP adapter forces static capabilities without provider traffic" {
+    const web_search_contract = @import("../core/tooling/web_search_contract.zig");
+    const web_search_runtime = @import("../core/tooling/web_search_runtime.zig");
+    const Traffic = struct {
+        catalog_calls: usize = 0,
+        search_calls: usize = 0,
+        model_calls: usize = 0,
+
+        fn fetchCatalog(
+            raw: ?*anyopaque,
+            _: Allocator,
+            _: model_catalog.FetchInput,
+        ) Allocator.Error!model_catalog.ProviderResult {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.catalog_calls += 1;
+            return .{ .failure = .{ .category = .transport } };
+        }
+
+        fn preferredSearchBackends(
+            raw: ?*anyopaque,
+        ) anyerror!?[]const web_search_contract.SearchBackendId {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.search_calls += 1;
+            return null;
+        }
+
+        fn search(
+            raw: ?*anyopaque,
+            _: Allocator,
+            _: web_search_runtime.Inputs,
+            _: web_search_contract.ProviderRequest,
+            _: ?web_search_contract.ProgressFn,
+            _: ?*anyopaque,
+        ) anyerror!web_search_contract.ProviderResponse {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.search_calls += 1;
+            return error.TestUnexpectedSearch;
+        }
+
+        fn stream(
+            adapter: *const agent_stream_provider.ProviderAdapter,
+            _: Allocator,
+            _: agent_stream_provider.AdapterRequest,
+            events: agent_stream_provider.EventSink,
+        ) !void {
+            const self: *@This() = @ptrCast(@alignCast(adapter.context.?));
+            self.model_calls += 1;
+            try events.emit(.{ .finish = .{ .reason = .stop } });
+        }
+
+        fn secretStoreDisabled(_: ?*anyopaque) bool {
+            return false;
+        }
+
+        fn loadSecret(
+            _: ?*anyopaque,
+            alloc: Allocator,
+        ) host.SecretStoreLoadError!?[]u8 {
+            return try alloc.dupe(u8, "fake-key");
+        }
+
+        fn storeSecret(
+            _: ?*anyopaque,
+            _: Allocator,
+            _: []const u8,
+        ) host.SecretStoreWriteError!void {}
+
+        fn storeSecretInteractively(_: ?*anyopaque) host.SecretStoreWriteError!bool {
+            return false;
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var output = try tmp.dir.createFile(io_mod.getIo(), "acp-mismatch.jsonl", .{});
+    defer output.close(io_mod.getIo());
+    var state = try initTestAcpState(alloc, "/tmp/workspace", .auto);
+    defer state.deinit();
+    state.writer = .{ .stdout = output };
+    var traffic = Traffic{};
+    state.cfg.gateway_provider.connection_seed = .{
+        .id = "mismatched",
+        .display_name = "Mismatched",
+        .adapter_id = "unavailable_adapter",
+        .endpoint = "fake://acp-mismatch",
+        .protocol = "unavailable_adapter",
+        .credential_ref = "stored_key",
+    };
+    state.connections.?.deinit();
+    state.connections = try connection_registry.Runtime.init(
+        alloc,
+        state.cfg.gateway_provider.connection_seed.profile("test-model", null),
+        null,
+        .unavailable,
+    );
+    var adapter = test_builtin_gateway.provider_adapter;
+    adapter.kind = "provider_adapter";
+    adapter.context = &traffic;
+    adapter.model_catalog = .{
+        .context = &traffic,
+        .fetch_fn = Traffic.fetchCatalog,
+    };
+    var search = test_builtin_gateway.default_web_search_provider;
+    search.context = &traffic;
+    search.preferred_backends_fn = Traffic.preferredSearchBackends;
+    search.execute_fn = Traffic.search;
+    adapter.web_search = search;
+    adapter.stream_fn = Traffic.stream;
+    state.cfg.gateway_provider.provider_adapter = adapter;
+    state.cfg.secret_store = .{
+        .backend_label = "test",
+        .is_disabled_fn = Traffic.secretStoreDisabled,
+        .load_fn = Traffic.loadSecret,
+        .store_fn = Traffic.storeSecret,
+        .store_interactive_fn = Traffic.storeSecretInteractively,
+    };
+    state.active_session.?.effort = types.ReasoningEffort.literal("high");
+    const profile = state.connections.?.selectedProfile();
+    const credential = try server.prepareConnectionCredential(
+        &state,
+        alloc,
+        profile,
+        state.active_session.?.model,
+    );
+    server.adoptConnectionCredential(&state, profile.id, credential);
+    state.active_session.?.api_key = state.api_key;
+    state.active_session.?.credential_source = state.credential_source;
+    var msg = jsonrpc.Message{
+        .id = .{ .integer = 1 },
+        .method = "session/prompt",
+        .params_raw = "{\"sessionId\":\"session_1\",\"prompt\":[{\"type\":\"text\",\"text\":\"force capability resolution\"}]}",
+    };
+
+    try std.testing.expectError(
+        error.RouteAdapterMismatch,
+        handlePrompt(&state, alloc, &msg, "normal", .auto, .none),
+    );
+    try std.testing.expectEqual(@as(usize, 0), traffic.catalog_calls);
+    try std.testing.expectEqual(@as(usize, 0), traffic.search_calls);
+    try std.testing.expectEqual(@as(usize, 0), traffic.model_calls);
 }
 
 test "stripAnsiAlloc returns the original slice for clean text and strips escapes" {
@@ -4004,7 +4163,7 @@ test "ACP deps reject malformed native web_search calls" {
     try std.testing.expectEqualStrings("web_search field \"query\" must contain at least two characters", result.failure);
 }
 
-test "ACP prompt projection configures web search then blocks native execution" {
+test "ACP prompt projection leaves Fx search uninstalled" {
     const alloc = std.testing.allocator;
     const web_search_contract = @import("../core/tooling/web_search_contract.zig");
     const web_search_runtime = @import("../core/tooling/web_search_runtime.zig");
@@ -4037,19 +4196,10 @@ test "ACP prompt projection configures web search then blocks native execution" 
     state.writer = .{ .stdout = capture };
     var ctx = AcpContext{ .alloc = arena, .state = &state, .session_id = "session_1" };
     var provider_state = ProviderState{};
-    var provider = state.web_search_runtime.provider orelse return error.TestExpectedEqual;
+    var provider = test_builtin_gateway.default_web_search_provider;
     provider.context = @ptrCast(&provider_state);
     provider.execute_fn = FailingWebSearchProvider.execute;
-    state.web_search_runtime = web_search_runtime.Runtime.init(.{
-        .provider = provider,
-    });
-
-    state.web_search_runtime.configure(.{
-        .api_key = "stale-key",
-        .worker_model = "stale-model",
-        .gateway_retry_count = 99,
-        .gateway_chat_url = "https://stale.invalid/chat",
-    });
+    state.cfg.gateway_provider.provider_adapter.web_search = provider;
 
     var messages: std.ArrayList(ChatMessage) = .empty;
     defer messages.deinit(arena);
@@ -4057,8 +4207,6 @@ test "ACP prompt projection configures web search then blocks native execution" 
     const append_static = deps.append_static_context orelse return error.TestExpectedEqual;
     try append_static(deps.ctx, arena, &messages);
     try deps.append_runtime_context(deps.ctx, arena, &messages);
-
-    try std.testing.expectEqualStrings("stale-key", state.web_search_runtime.api_key);
 
     const validate = deps.validate_tool_call orelse return error.TestExpectedEqual;
     const validation = try validate(deps.ctx, arena, .{
@@ -4068,11 +4216,6 @@ test "ACP prompt projection configures web search then blocks native execution" 
     });
     const session = state.active_session orelse return error.TestExpectedEqual;
     try std.testing.expectEqualStrings("web_search field \"query\" must contain at least two characters", validation.failure);
-    try std.testing.expectEqualStrings(session.api_key, state.web_search_runtime.api_key);
-    try std.testing.expectEqualStrings(session.model, state.web_search_runtime.worker_model);
-    try std.testing.expectEqual(state.cfg.gateway_retry_count, state.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(state.cfg.gateway_chat_url, state.web_search_runtime.gateway_chat_url);
-
     const execute = deps.execute_tool_call;
     const execution = try execute(deps.ctx, .{
         .call_allocator = arena,
@@ -4087,10 +4230,6 @@ test "ACP prompt projection configures web search then blocks native execution" 
         .advertised_dynamic_tool_names = &.{},
         .max_tool_result_bytes = session.max_tool_result_bytes,
     });
-    try std.testing.expectEqualStrings(session.api_key, state.web_search_runtime.api_key);
-    try std.testing.expectEqualStrings(session.model, state.web_search_runtime.worker_model);
-    try std.testing.expectEqual(state.cfg.gateway_retry_count, state.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(state.cfg.gateway_chat_url, state.web_search_runtime.gateway_chat_url);
     try std.testing.expectEqual(.failure, execution.status);
     try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
 }
@@ -4489,12 +4628,14 @@ test "ACP full advertisement includes direct provider search with explicit permi
     };
     var projection = try tool_advertisement.buildGatewayToolProjectionForSet(std.testing.allocator, builtin_tools.advertisement_set, .{
         .permission_rules = .{ .rules = &rules },
+        .provider_tools = &.{.web_search},
     });
     defer projection.deinit(std.testing.allocator);
     const json = projection.tools_json;
 
     try std.testing.expect(std.mem.find(u8, json, "\"name\":\"web_search\"") == null);
-    try std.testing.expect(std.mem.find(u8, json, "gateway.perplexity_search") != null);
+    try std.testing.expectEqual(@as(usize, 1), projection.provider_tools.len);
+    try std.testing.expectEqual(.web_search, projection.provider_tools[0].tool);
     try std.testing.expectEqualStrings(builtin_tools.web_search.description, projection.custom_guidance);
 }
 
@@ -4535,14 +4676,9 @@ test "ACP prompt agent config carries request options from active session" {
     const tool_ctx = ctx.toolContext();
     try std.testing.expect(!tool_ctx.web_search_runtime_ready);
     try std.testing.expect(tool_ctx.web_search_backend != null);
-    try std.testing.expect(state.web_search_runtime.provider.?.execute_fn == state.cfg.gateway_provider.web_search.execute_fn);
-    try std.testing.expect(state.web_search_runtime.provider.?.preferred_backends_fn == state.cfg.gateway_provider.web_search.preferred_backends_fn);
+    try std.testing.expect(state.cfg.gateway_provider.provider_adapter.web_search != null);
     try std.testing.expect(tool_ctx.web_fetch_runtime.? == &state.web_fetch_runtime);
     try std.testing.expectEqualStrings("team_123", tool_ctx.gateway_team.?);
-    try std.testing.expectEqualStrings("team_123", state.web_search_runtime.gateway_team.?);
-    try std.testing.expectEqualStrings(session.model, state.web_search_runtime.worker_model);
-    try std.testing.expectEqual(state.cfg.gateway_retry_count, state.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(state.cfg.gateway_chat_url, state.web_search_runtime.gateway_chat_url);
     try std.testing.expectEqualStrings("/models", tool_ctx.gateway_models_path);
     try std.testing.expect(tool_ctx.devbox_provider.?.execute_fn == unavailableDevboxForTest);
 }

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -334,20 +334,23 @@ pub fn prepareConnectionCredential(
     var credential = resolution.credential orelse return error.MissingCredential;
     errdefer credential.deinit(alloc);
     var catalog_cancel_flag = std.atomic.Value(bool).init(false);
-    _ = try state.capability_resolver.resolve(
-        state.alloc,
-        state.cfg.gateway_provider.model_catalog,
-        .{
-            .access = credentials.catalogAccessForCredential(
-                credential.source,
-                credential.token,
-                credential.gatewayTeam(),
-            ),
-            .endpoint = state.cfg.gateway_models_path,
-            .cancel_flag = &catalog_cancel_flag,
-        },
-        model,
-    );
+    const adapter = state.cfg.gateway_provider.provider_adapter;
+    if (gateway_provider.modelCatalogForAdapter(profile.adapter_id, adapter)) |catalog| {
+        _ = try state.capability_resolver.resolve(
+            state.alloc,
+            catalog,
+            .{
+                .access = credentials.catalogAccessForCredential(
+                    credential.source,
+                    credential.token,
+                    credential.gatewayTeam(),
+                ),
+                .endpoint = state.cfg.gateway_models_path,
+                .cancel_flag = &catalog_cancel_flag,
+            },
+            model,
+        );
+    }
     return credential;
 }
 
@@ -619,9 +622,7 @@ pub fn runWithTransport(
         .alloc = alloc,
         .cfg = cfg,
         .writer = writer_value,
-        .web_search_runtime = web_search_runtime.Runtime.init(.{
-            .provider = cfg.gateway_provider.web_search,
-        }),
+        .web_search_runtime = web_search_runtime.Runtime.init(.{}),
         .background = background_runtime.BackgroundRuntime.init(
             cfg.background_process_provider,
         ),
@@ -1282,6 +1283,10 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
         });
     };
     defer startup.deinit(alloc);
+    try startup.normalizeModels(
+        alloc,
+        state.cfg.gateway_provider.provider_adapter.model_descriptors,
+    );
     try app_lifecycle.applyWorkspaceLaunch(
         &startup,
         alloc,

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -26,6 +26,7 @@ const session_codec = @import("../core/session/session_codec.zig");
 const session_log = @import("../core/session/session_log.zig");
 const session_store = @import("../core/session/session_store.zig");
 const session_runtime = @import("../core/session/session.zig");
+const generation_usage_provider = @import("../core/session/generation_usage_provider.zig");
 const worker_runtime = @import("../core/agent/worker_runtime.zig");
 const background_runtime = @import("../core/background/background_runtime.zig");
 const terminal_client_runtime = @import("../core/terminal/client.zig");
@@ -298,10 +299,7 @@ pub fn releaseActiveSession(state: *ServerState) !void {
         active.session_rt.usage.cancelReconciliation();
         active.session_rt.usage.finishProfilePublicationsBeforeShutdown();
         flushActiveSessionUsage(state) catch |err| {
-            active.session_rt.usage.startReconciliation(
-                state.alloc,
-                state.api_key,
-            );
+            active.session_rt.usage.startReconciliation(state.alloc);
             return err;
         };
         active.session_rt.usage.configurePublicationSink(null);
@@ -351,6 +349,51 @@ pub fn prepareConnectionCredential(
         model,
     );
     return credential;
+}
+
+fn resolveGenerationUsageCredential(
+    raw: ?*anyopaque,
+    alloc: Allocator,
+    _: []const u8,
+) generation_usage_provider.ResolveCredentialError!generation_usage_provider.ResolvedCredential {
+    const state: *ServerState = @ptrCast(@alignCast(raw.?));
+    if (state.api_key.len == 0) return error.Unavailable;
+    const token = try alloc.dupe(u8, state.api_key);
+    errdefer alloc.free(token);
+    return .{
+        .token = token,
+        .tenant = if (state.gateway_team) |team| try alloc.dupe(u8, team) else null,
+    };
+}
+
+fn prepareGenerationUsageDispatch(
+    raw: ?*anyopaque,
+    alloc: Allocator,
+) generation_usage_provider.PrepareError!generation_usage_provider.Dispatch {
+    const state: *ServerState = @ptrCast(@alignCast(raw.?));
+    const connection_id = state.credential_connection_id orelse return error.Unavailable;
+    const connections = state.connections orelse return error.Unavailable;
+    const profile = connections.profile(connection_id) catch return error.Unavailable;
+    const adapter = state.cfg.gateway_provider.provider_adapter;
+    return generation_usage_provider.Dispatch.init(alloc, &.{.{
+        .id = profile.id,
+        .credential_ref = profile.credential_ref,
+        .provider = if (std.mem.eql(u8, profile.adapter_id, adapter.kind))
+            adapter.generation_usage
+        else
+            null,
+    }}, .{
+        .context = state,
+        .resolve_fn = resolveGenerationUsageCredential,
+    });
+}
+
+pub fn configureGenerationUsageSource(state: *ServerState) void {
+    const active = if (state.active_session) |*session| session else return;
+    active.session_rt.usage.configureReconciliationSource(.{
+        .context = state,
+        .prepare_fn = prepareGenerationUsageDispatch,
+    });
 }
 
 pub fn adoptConnectionCredential(
@@ -2171,8 +2214,8 @@ test "ACP usage flush preserves snapshot ownership on allocation failure" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
 
     var durable = try acpModelTestState(

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -51,10 +51,7 @@ pub fn handleNewWasmSession(state: *server.ServerState, alloc: Allocator, msg: *
     const model = try alloc.dupe(u8, durable.preferences.model);
     var model_owned = true;
     defer if (model_owned) alloc.free(model);
-    var session_rt = session_runtime.SessionRuntime.init(
-        state.cfg.max_history_turns,
-        state.cfg.gateway_provider.generation_usage,
-    );
+    var session_rt = session_runtime.SessionRuntime.init(state.cfg.max_history_turns);
     var session_rt_owned = true;
     defer if (session_rt_owned) session_rt.deinit(alloc);
     const revision = js_host_session_store.commit(alloc, durable, null) catch
@@ -212,10 +209,7 @@ pub fn handleNewSession(state: *server.ServerState, alloc: Allocator, msg: *json
     defer if (model_owned) alloc.free(model_copy);
     const session_dir = try session_store.sessionDirPath(alloc, store.sessions_dir, writable.active_id);
     defer alloc.free(session_dir);
-    var session_rt = session_runtime.SessionRuntime.init(
-        state.cfg.max_history_turns,
-        state.cfg.gateway_provider.generation_usage,
-    );
+    var session_rt = session_runtime.SessionRuntime.init(state.cfg.max_history_turns);
     var session_rt_owned = true;
     defer if (session_rt_owned) session_rt.deinit(alloc);
     _ = try session_rt.initializeProfileUsage(alloc, io_mod.getenv("HOME"));
@@ -358,7 +352,7 @@ pub fn handleLoadWasmSession(state: *server.ServerState, alloc: Allocator, msg: 
     const model_copy = try alloc.dupe(u8, loaded.state.preferences.model);
     var model_owned = true;
     defer if (model_owned) alloc.free(model_copy);
-    var session_rt = session_runtime.SessionRuntime.init(state.cfg.max_history_turns, state.cfg.gateway_provider.generation_usage);
+    var session_rt = session_runtime.SessionRuntime.init(state.cfg.max_history_turns);
     var session_rt_owned = true;
     defer if (session_rt_owned) session_rt.deinit(alloc);
     try session_rt.restoreWithPermissionState(
@@ -620,10 +614,7 @@ fn handleRestoreSession(
     var model_owned = true;
     defer if (model_owned) alloc.free(model_copy);
 
-    var session_rt = session_runtime.SessionRuntime.init(
-        state.cfg.max_history_turns,
-        state.cfg.gateway_provider.generation_usage,
-    );
+    var session_rt = session_runtime.SessionRuntime.init(state.cfg.max_history_turns);
     var session_rt_owned = true;
     defer if (session_rt_owned) session_rt.deinit(alloc);
     _ = try session_rt.initializeProfileUsage(alloc, io_mod.getenv("HOME"));
@@ -845,11 +836,9 @@ fn activateSession(
         .pending_prompt_id = null,
     };
     server.enableSubagentHost(state);
+    server.configureGenerationUsageSource(state);
     state.active_session.?.session_rt.attachProfileUsagePublisher(state.alloc);
-    state.active_session.?.session_rt.usage.startReconciliation(
-        state.alloc,
-        state.api_key,
-    );
+    state.active_session.?.session_rt.usage.startReconciliation(state.alloc);
     activateManagedBackground(state, store);
 }
 
@@ -1617,10 +1606,6 @@ test "ACP new and loaded sessions provide a writable subagent host" {
         );
         try std.testing.expectEqualStrings("review", new_active.mode);
         try std.testing.expect(new_writable.state.usage != null);
-        try std.testing.expect(
-            new_active.session_rt.usage.generation_usage_provider.lookup_fn ==
-                state.cfg.gateway_provider.generation_usage.lookup_fn,
-        );
         io_mod.sleep(10 * std.time.ns_per_ms);
         var live_usage = try new_active.session_rt.usage.snapshot(alloc);
         defer live_usage.deinit(alloc);
@@ -1656,10 +1641,6 @@ test "ACP new and loaded sessions provide a writable subagent host" {
         try std.testing.expect(loaded_writable.state.usage != null);
         try std.testing.expect(state.subagent_store != null);
         try std.testing.expect(state.subagent_host != null);
-        try std.testing.expect(
-            loaded_active.session_rt.usage.generation_usage_provider.lookup_fn ==
-                state.cfg.gateway_provider.generation_usage.lookup_fn,
-        );
 
         try capture.sync(io_mod.getIo());
     }

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -121,10 +121,6 @@ pub const chat_url_provider = gateway_provider.ChatUrlProvider{
     .resolve_fn = resolveChatUrlForProvider,
 };
 
-pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
-    .fetch_fn = fetchCliModelCatalog,
-};
-
 pub const account_usage = account_usage_provider.Provider{
     .fetch_fn = fetchCredits,
 };
@@ -149,6 +145,10 @@ pub const provider_adapter = agent_stream_provider_contract.ProviderAdapter{
     .kind = connection_seed.adapter_id,
     .account_usage = account_usage,
     .generation_usage = generation_usage_provider,
+    .model_catalog = model_catalog_provider,
+    .model_descriptors = model_descriptors.provider,
+    .provider_tools = &.{.web_search},
+    .web_search = default_web_search_provider,
     .stream_fn = streamVercelAdapter,
 };
 
@@ -158,9 +158,6 @@ pub const provider = gateway_provider.Provider{
     .provider_adapter = provider_adapter,
     .oauth_transport = oauth_transport_provider,
     .chat_url = chat_url_provider,
-    .cli_model_catalog = cli_model_catalog_provider,
-    .web_search = default_web_search_provider,
-    .model_catalog = model_catalog_provider,
 };
 
 const AdapterEventBridge = struct {
@@ -571,6 +568,9 @@ pub fn buildAgentRequest(
     }
     if (request.response_format != null) return error.StructuredResponseRequiresVerifiedImages;
 
+    const adapter_tools_json = try buildVercelBaseToolsJson(alloc, request);
+    defer alloc.free(adapter_tools_json);
+
     if (request.vision_mode == .unavailable and request.selected_dynamic_tool_schemas.len == 0) {
         if (request.required_tool_call_id) |target_call_id| {
             const active = budget orelse return error.PendingToolReviewRequiresBudget;
@@ -590,7 +590,7 @@ pub fn buildAgentRequest(
             const body = if (budget) |active|
                 gateway_json.buildGatewayRequiredToolRequestBodyWithOptionsAndBudget(
                     alloc,
-                    request.serialized_tools,
+                    adapter_tools_json,
                     request.messages,
                     provider_options,
                     request.max_output_tokens,
@@ -599,7 +599,7 @@ pub fn buildAgentRequest(
             else
                 gateway_json.buildGatewayRequiredToolRequestBodyWithOptionsAndOutputLimit(
                     alloc,
-                    request.serialized_tools,
+                    adapter_tools_json,
                     request.messages,
                     provider_options,
                     request.max_output_tokens,
@@ -609,7 +609,7 @@ pub fn buildAgentRequest(
         const body = if (budget) |active|
             gateway_json.buildGatewayRequestBodyWithOptionsAndBudget(
                 alloc,
-                request.serialized_tools,
+                adapter_tools_json,
                 request.messages,
                 provider_options,
                 request.tool_choice,
@@ -619,7 +619,7 @@ pub fn buildAgentRequest(
         else
             gateway_json.buildGatewayRequestBodyWithOptionsAndOutputLimit(
                 alloc,
-                request.serialized_tools,
+                adapter_tools_json,
                 request.messages,
                 provider_options,
                 request.tool_choice,
@@ -663,7 +663,7 @@ pub fn buildAgentRequest(
     if (vision_schema) |schema| try schemas.append(alloc, schema);
     const tools_json = try tool_advertisement.buildGatewayToolsJsonWithSelectedDynamicSchemas(
         alloc,
-        request.serialized_tools,
+        adapter_tools_json,
         schemas.items,
     );
     defer alloc.free(tools_json);
@@ -704,6 +704,79 @@ fn finalizeAgentRequestBody(
     );
     alloc.free(body);
     return identified;
+}
+
+fn buildVercelBaseToolsJson(
+    alloc: Allocator,
+    request: agent_stream_provider_contract.ModelRequest,
+) ![]u8 {
+    const PositionedSchema = struct {
+        position: usize,
+        json: []const u8,
+    };
+    var provider_schemas: std.ArrayList(PositionedSchema) = .empty;
+    defer provider_schemas.deinit(alloc);
+    var owned_schemas: std.ArrayList([]u8) = .empty;
+    defer {
+        for (owned_schemas.items) |schema| alloc.free(schema);
+        owned_schemas.deinit(alloc);
+    }
+
+    for (request.provider_tools) |advertisement| {
+        const schema = switch (advertisement.tool) {
+            .web_search => try vercelWebSearchToolJson(alloc),
+        };
+        owned_schemas.append(alloc, schema) catch |err| {
+            alloc.free(schema);
+            return err;
+        };
+        try provider_schemas.append(alloc, .{
+            .position = advertisement.local_schema_position,
+            .json = schema,
+        });
+    }
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, request.serialized_tools, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidToolArguments;
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    var provider_index: usize = 0;
+    var first = true;
+    try out.writer.writeByte('[');
+    for (0..parsed.value.array.items.len + 1) |position| {
+        while (provider_index < provider_schemas.items.len and
+            provider_schemas.items[provider_index].position == position)
+        {
+            if (!first) try out.writer.writeByte(',');
+            first = false;
+            try out.writer.writeAll(provider_schemas.items[provider_index].json);
+            provider_index += 1;
+        }
+        if (position < parsed.value.array.items.len) {
+            if (!first) try out.writer.writeByte(',');
+            first = false;
+            try std.json.Stringify.value(parsed.value.array.items[position], .{}, &out.writer);
+        }
+    }
+    if (provider_index != provider_schemas.items.len) return error.InvalidGatewayAdvertisement;
+    try out.writer.writeByte(']');
+    return out.toOwnedSlice();
+}
+
+fn vercelWebSearchToolJson(alloc: Allocator) ![]u8 {
+    const policy = default_web_search_policy;
+    const tools_json = try providerToolsJson(alloc, .{
+        .backend = try selectedWebSearchBackend(),
+        .max_results = policy.max_results,
+        .max_output_tokens = policy.max_output_tokens,
+        .max_output_chars = policy.max_output_chars,
+    });
+    defer alloc.free(tools_json);
+    if (tools_json.len < 2 or tools_json[0] != '[' or tools_json[tools_json.len - 1] != ']') {
+        return error.InvalidGatewayAdvertisement;
+    }
+    return alloc.dupe(u8, tools_json[1 .. tools_json.len - 1]);
 }
 
 fn writeVisionGatewaySchema(
@@ -767,6 +840,27 @@ test "agent request builder scopes the product user agent to GLM 5.2" {
         try std.testing.expect(user_agent == .string);
         try std.testing.expectEqualStrings(gateway_client.user_agent, user_agent.string);
     }
+}
+
+test "agent request builder serializes neutral provider search beside local tools" {
+    const messages = [_]shared_types.ChatMessage{.{ .role = .user, .content = "question" }};
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "anthropic/claude",
+        .serialized_tools = "[{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read\",\"inputSchema\":{\"type\":\"object\",\"properties\":{}}}]",
+        .provider_tools = &.{.{ .tool = .web_search, .local_schema_position = 1 }},
+        .messages = &messages,
+        .tool_choice = .auto,
+        .capabilities = model_descriptor_provider.fallback("anthropic/claude").capabilities,
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"name\":\"read_file\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"id\":\"gateway.perplexity_search\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"name\":\"web_search\"") == null);
+    try std.testing.expect(
+        std.mem.find(u8, body, "\"name\":\"read_file\"").? <
+            std.mem.find(u8, body, "\"name\":\"perplexity_search\"").?,
+    );
 }
 
 test "agent request builder overlays selected dynamic schemas" {
@@ -1093,11 +1187,11 @@ fn executeWebSearchProvider(
 ) !Response {
     return executeGatewayWorker(alloc, .{
         .connection_id = inputs.connection_id,
-        .api_key = inputs.api_key,
-        .team = inputs.gateway_team,
-        .model = inputs.worker_model,
-        .retry_count = inputs.gateway_retry_count,
-        .chat_url = inputs.gateway_chat_url,
+        .api_key = inputs.credential,
+        .team = inputs.tenant,
+        .model = inputs.model,
+        .retry_count = inputs.retry_count,
+        .chat_url = inputs.endpoint,
         .usage = inputs.usage,
         .usage_allocator = inputs.usage_allocator,
     }, request, on_progress, progress_ctx);
@@ -1113,35 +1207,6 @@ pub fn defaultChatUrl() []const u8 {
 
 fn resolveChatUrlForProvider(_: ?*anyopaque, fallback: []const u8) []const u8 {
     return chatUrl(fallback);
-}
-
-fn fetchCliModelCatalog(
-    _: ?*anyopaque,
-    alloc: Allocator,
-    input: gateway_provider.CliModelCatalogInput,
-) gateway_provider.CliModelCatalogResult {
-    const result = model_catalog.fetchWithPublicFallback(model_catalog_provider, alloc, .{
-        .access = input.access,
-        .endpoint = input.endpoint,
-        .cancel_flag = input.cancel_flag,
-        .view = .full,
-    });
-    return switch (result) {
-        .loaded => |loaded| project: {
-            var catalog = loaded.catalog;
-            defer freeModelCatalog(alloc, &catalog);
-            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
-                .access = loaded.provenance.access,
-                .anonymous_fallback_used = loaded.provenance.anonymous_fallback_used,
-                .failure = .{ .category = .resource_exhausted },
-            } };
-            break :project .{ .loaded = .{
-                .ids = ids,
-                .provenance = loaded.provenance,
-            } };
-        },
-        .failed => |failed| .{ .failure = failed },
-    };
 }
 
 pub fn resolveChatUrl(fallback: []const u8, override: ?[]const u8) []const u8 {
@@ -2279,10 +2344,10 @@ test "built-in web search provider preserves missing worker configuration error"
     try std.testing.expectError(error.MissingGatewaySearchConfiguration, default_web_search_provider.execute(
         std.testing.allocator,
         .{
-            .api_key = "",
-            .worker_model = "",
-            .gateway_retry_count = retry_count,
-            .gateway_chat_url = default_chat_url,
+            .credential = "",
+            .model = "",
+            .retry_count = retry_count,
+            .endpoint = default_chat_url,
         },
         .{
             .backend = perplexity_search_backend_id,
@@ -2324,25 +2389,6 @@ test "built-in gateway chat url ignores untrusted overrides and falls back" {
         "",
     }) |bad| {
         try std.testing.expectEqualStrings(fallback, resolveChatUrl(fallback, bad));
-    }
-}
-
-test "built-in CLI catalog provider preserves cancellation detail" {
-    var cancel_flag = std.atomic.Value(bool).init(true);
-    const result = cli_model_catalog_provider.fetch(std.testing.allocator, .{
-        .endpoint = models_path,
-        .cancel_flag = &cancel_flag,
-    });
-    switch (result) {
-        .failure => |failure| try std.testing.expectEqual(
-            model_catalog.FailureCategory.cancellation,
-            failure.failure.category,
-        ),
-        .loaded => |loaded| {
-            var ids = loaded.ids;
-            collections.freeStringList(std.testing.allocator, &ids);
-            return error.TestExpectedEqual;
-        },
     }
 }
 

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -18,6 +18,7 @@ const gateway_generation_usage = @import("../gateway/generation_usage.zig");
 const connection_registry = @import("../core/gateway/connection_registry.zig");
 const route_snapshot_contract = @import("../core/gateway/route_snapshot.zig");
 const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const account_usage_provider = @import("../core/gateway/account_usage_provider.zig");
 const model_capabilities = @import("../core/config/model_capabilities.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
 const model_descriptors = @import("gateway/model_descriptors.zig");
@@ -124,7 +125,7 @@ pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
     .fetch_fn = fetchCliModelCatalog,
 };
 
-pub const credits_provider = gateway_provider.CreditsProvider{
+pub const account_usage = account_usage_provider.Provider{
     .fetch_fn = fetchCredits,
 };
 
@@ -146,6 +147,8 @@ pub const agent_stream_provider = agent_stream_provider_contract.Provider{
 
 pub const provider_adapter = agent_stream_provider_contract.ProviderAdapter{
     .kind = connection_seed.adapter_id,
+    .account_usage = account_usage,
+    .generation_usage = generation_usage_provider,
     .stream_fn = streamVercelAdapter,
 };
 
@@ -156,8 +159,6 @@ pub const provider = gateway_provider.Provider{
     .oauth_transport = oauth_transport_provider,
     .chat_url = chat_url_provider,
     .cli_model_catalog = cli_model_catalog_provider,
-    .credits = credits_provider,
-    .generation_usage = generation_usage_provider,
     .web_search = default_web_search_provider,
     .model_catalog = model_catalog_provider,
 };
@@ -869,7 +870,7 @@ fn streamAgentCompletion(
 fn fetchCredits(
     _: ?*anyopaque,
     alloc: Allocator,
-    input: gateway_provider.CreditsLookupInput,
+    input: account_usage_provider.Input,
 ) output_contracts.CreditsSnapshot {
     return fetchCreditsWithFetch(
         alloc,
@@ -1091,6 +1092,7 @@ fn executeWebSearchProvider(
     progress_ctx: ?*anyopaque,
 ) !Response {
     return executeGatewayWorker(alloc, .{
+        .connection_id = inputs.connection_id,
         .api_key = inputs.api_key,
         .team = inputs.gateway_team,
         .model = inputs.worker_model,
@@ -1168,6 +1170,7 @@ pub const StreamFn = *const fn (
 var default_stream_ctx: u8 = 0;
 
 pub const GatewayWorkerConfig = struct {
+    connection_id: []const u8,
     api_key: []const u8,
     team: ?[]const u8 = null,
     model: []const u8,
@@ -1247,12 +1250,12 @@ pub fn executeGatewayWorker(
         config.usage_allocator,
         stream.status,
         stream.completion,
+        config.connection_id,
         gateway_client.generationBaseUrl(),
-        config.team,
     );
     if (!builtin.is_test) {
         if (config.usage) |ledger| {
-            ledger.startReconciliation(config.usage_allocator, config.api_key);
+            ledger.startReconciliation(config.usage_allocator);
         }
     }
     if (stream.status != .ok) return error.GatewayRequestFailed;
@@ -1682,6 +1685,7 @@ fn expectGatewayWorkerAdapterExecutes(backend: web_search_contract.SearchBackend
     var usage = session_usage.Usage.initFresh();
     defer usage.deinit(alloc);
     var response = try executeGatewayWorker(alloc, .{
+        .connection_id = "vercel",
         .api_key = "key",
         .team = "team_123",
         .model = "provider/model",
@@ -1876,6 +1880,7 @@ test "cancelled gateway worker performs zero stream requests" {
     var fake = FakeStream{};
 
     try std.testing.expectError(error.Cancelled, executeGatewayWorker(std.testing.allocator, .{
+        .connection_id = "vercel",
         .api_key = "key",
         .model = "provider/model",
         .retry_count = 1,
@@ -1985,6 +1990,7 @@ test "pre-send web search failure stays unbilled" {
     defer usage.deinit(alloc);
 
     try std.testing.expectError(error.AccessDenied, executeGatewayWorker(alloc, .{
+        .connection_id = "vercel",
         .api_key = "key",
         .model = "provider/model",
         .retry_count = 1,
@@ -2014,6 +2020,7 @@ test "possibly sent web search failure marks billing incomplete" {
     defer usage.deinit(alloc);
 
     try std.testing.expectError(error.ConnectionResetByPeer, executeGatewayWorker(alloc, .{
+        .connection_id = "vercel",
         .api_key = "key",
         .model = "provider/model",
         .retry_count = 1,

--- a/src/builtins/modes.zig
+++ b/src/builtins/modes.zig
@@ -45,11 +45,12 @@ test "ask and code mode projections carry included custom provider guidance" {
             std.testing.allocator,
             builtin_tools.advertisement_set,
             mode_id,
-            .{},
+            .{ .provider_tools = &.{.web_search} },
         );
         defer projection.deinit(std.testing.allocator);
 
-        try std.testing.expect(std.mem.find(u8, projection.tools_json, "gateway.perplexity_search") != null);
+        try std.testing.expectEqual(@as(usize, 1), projection.provider_tools.len);
+        try std.testing.expectEqual(.web_search, projection.provider_tools[0].tool);
         try std.testing.expectEqualStrings(builtin_tools.web_search.description, projection.custom_guidance);
     }
 }

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -905,24 +905,6 @@ pub const web_fetch = ToolSpec{
     .irreversible_fn = web_fetch_impl.isIrreversible,
 };
 
-fn writeWebSearchGatewayAdvertisement(
-    alloc: Allocator,
-    writer: *std.Io.Writer,
-) tool_dispatch.GatewayAdvertisementError!void {
-    const policy = builtin_gateway.default_web_search_policy;
-    const provider_tools = try builtin_gateway.providerToolsJson(alloc, .{
-        .backend = try builtin_gateway.selectedWebSearchBackend(),
-        .max_results = policy.max_results,
-        .max_output_tokens = policy.max_output_tokens,
-        .max_output_chars = policy.max_output_chars,
-    });
-    defer alloc.free(provider_tools);
-    if (provider_tools.len < 2 or provider_tools[0] != '[' or provider_tools[provider_tools.len - 1] != ']') {
-        return error.InvalidGatewayAdvertisement;
-    }
-    try writer.writeAll(provider_tools[1 .. provider_tools.len - 1]);
-}
-
 pub const web_search = ToolSpec{
     .name = "web_search",
     .description = web_search_description,
@@ -939,8 +921,7 @@ pub const web_search = ToolSpec{
             .additional_properties = false,
         },
     },
-    .write_gateway_advertisement_fn = writeWebSearchGatewayAdvertisement,
-    .provider_executed = true,
+    .provider_tool = .web_search,
     .executor_kind = .web_search,
     .activity_kind = .read,
     .requires_approval = false,
@@ -2374,20 +2355,9 @@ test "built-in web_search is registered in default production tools" {
     try std.testing.expect(lookup("web_search") != null);
 }
 
-test "built-in web_search owns its Gateway provider advertisement" {
+test "built-in web_search declares neutral provider advertisement" {
     const registered = registry.lookup("web_search") orelse return error.TestExpectedEqual;
-    const write_advertisement = registered.write_gateway_advertisement_fn orelse return error.TestExpectedEqual;
-
-    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
-    defer out.deinit();
-    try write_advertisement(std.testing.allocator, &out.writer);
-    const json = try out.toOwnedSlice();
-    defer std.testing.allocator.free(json);
-
-    try std.testing.expectEqualStrings(
-        "{\"type\":\"provider\",\"id\":\"gateway.perplexity_search\",\"name\":\"perplexity_search\",\"args\":{\"maxResults\":10,\"maxTokens\":4096}}",
-        json,
-    );
+    try std.testing.expectEqual(.web_search, registered.provider_tool.?);
 }
 
 fn expectWebSearchSchemaContains(needle: []const u8) !void {
@@ -2435,8 +2405,8 @@ test "built-in terminal owns captured and durable command metadata" {
 
 test "built-in provider advertisements declare provider execution" {
     for (all) |tool| {
-        if (tool.write_gateway_advertisement_fn == null) continue;
-        try std.testing.expect(tool.provider_executed);
+        if (tool.provider_tool == null) continue;
+        try std.testing.expectEqual(tool_dispatch.ExecutorKind.web_search, tool.executor_kind);
     }
 }
 

--- a/src/core/agent/runtime/config.zig
+++ b/src/core/agent/runtime/config.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const agent_stream_provider = @import("../stream_provider.zig");
 const types = @import("../../shared/types.zig");
 const tool_result_limits = @import("../../tooling/tool_result_limits.zig");
 const session_child_store = @import("../../session/session_child_store.zig");
@@ -32,6 +33,7 @@ pub const Config = struct {
     /// model traffic uses `QueuedPrompt.route.endpoint`; G11 removes this field.
     gateway_chat_url: []const u8,
     gateway_tools_json: []const u8,
+    provider_tools: []const agent_stream_provider.ProviderToolAdvertisement = &.{},
     custom_tool_guidance: []const u8 = "",
     agent_step_limit: usize,
     max_tool_result_bytes: usize = tool_result_limits.default_max_tool_result_bytes,

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -198,7 +198,7 @@ const LegacyGatewayCompatibilityBridge = struct {
     status: std.http.Status,
     err_body: ?[]const u8 = null,
     retry_after_seconds: ?u64 = null,
-    generation_origin: []const u8 = "",
+    generation_origin: ?[]const u8 = null,
     reconcile_generation_usage: bool = false,
     failure_diagnostic_summary: ?[]const u8 = null,
     failure_request_shape: ?[]const u8 = null,
@@ -209,7 +209,7 @@ const LegacyGatewayCompatibilityBridge = struct {
             .none => error.MissingTerminalEvent,
             .finish => .{
                 .status = .ok,
-                .generation_origin = collector.generation_origin orelse "",
+                .generation_origin = collector.generation_origin,
                 .reconcile_generation_usage = collector.completion.generation_id != null,
             },
             .failure => |failure| .{
@@ -663,7 +663,7 @@ test "neutral adapter events materialize owned completion state" {
             events: agent_stream_provider.EventSink,
         ) anyerror!void {
             try events.emit(.provider_admitted);
-            var generation = [_]u8{ 'g', 'e', 'n', '_', '0', '1', 'A', 'R', 'Z', '3', 'N', 'D', 'E', 'K', 'T', 'S', 'V', '4', 'R', 'R', 'F', 'F', 'Q', '6', '9', 'G', '5', 'F', 'A', 'V' };
+            var generation = [_]u8{ 'r', 'e', 'q', 'u', 'e', 's', 't', '-', '4', '2' };
             const local_call = types.ToolCall{
                 .id = "local_1",
                 .name = "read_file",
@@ -687,7 +687,6 @@ test "neutral adapter events materialize owned completion state" {
                 .reason = .tool_calls,
                 .generation_reference = .{
                     .id = &generation,
-                    .lookup_scope = "https://example.invalid/generation",
                 },
             } });
             @memset(&generation, 'x');
@@ -747,12 +746,13 @@ test "neutral adapter events materialize owned completion state" {
     try std.testing.expectEqualStrings("{\"results\":[]}", result.completion.tool_calls[1].provider_result.?);
     try std.testing.expectEqual(@as(?u64, 3), result.completion.usage.input_tokens);
     try std.testing.expectEqual(@as(?u64, 5), result.completion.usage.output_tokens);
-    try std.testing.expectEqualStrings("gen_01ARZ3NDEKTSV4RRFFQ69G5FAV", result.completion.generation_id.?);
+    try std.testing.expectEqualStrings("request-42", result.completion.generation_id.?);
     var usage_snapshot = try usage.snapshot(std.testing.allocator);
     defer usage_snapshot.deinit(std.testing.allocator);
     try std.testing.expectEqual(session_usage.Availability.pending, usage_snapshot.billing);
     try std.testing.expectEqual(@as(usize, 1), usage_snapshot.pending.len);
-    try std.testing.expectEqualStrings("gen_01ARZ3NDEKTSV4RRFFQ69G5FAV", usage_snapshot.pending[0].id);
+    try std.testing.expectEqualStrings("request-42", usage_snapshot.pending[0].id);
+    try std.testing.expect(usage_snapshot.pending[0].lookup_scope == null);
 }
 
 test "non-http adapter failure drives legacy gateway compatibility bridge" {

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -370,12 +370,14 @@ pub fn streamModelRequest(
             usage_allocator,
             legacy.status,
             completion,
+            route.connection_id,
             legacy.generation_origin,
-            tenant,
         );
     }
-    if (legacy.reconcile_generation_usage) {
-        if (usage) |ledger| ledger.startReconciliation(usage_allocator, credential);
+    if (comptime @import("builtin").os.tag != .wasi) {
+        if (legacy.reconcile_generation_usage) {
+            if (usage) |ledger| ledger.startReconciliation(usage_allocator);
+        }
     }
     if (completion.billing) |billing| {
         alloc.free(@constCast(billing.model));
@@ -472,13 +474,13 @@ pub fn streamGatewayCompletion(
         usage_allocator,
         result.status,
         result.completion,
+        "vercel",
         result.generation_origin,
-        team,
     );
     if (comptime @import("builtin").os.tag != .wasi) {
         if (result.reconcile_generation_usage) {
             if (usage) |ledger| {
-                ledger.startReconciliation(usage_allocator, api_key);
+                ledger.startReconciliation(usage_allocator);
             }
         }
     }

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1806,18 +1806,14 @@ fn refreshGatewayCredentialForJob(
         );
         return false;
     } orelse return false;
-    const previous_api_key = route_credential.credential;
-    if (comptime !host_target.is_wasm) {
-        if (deps.usage) |usage| {
-            usage.refreshReconciliationCredential(
-                deps.usage_allocator,
-                previous_api_key,
-                refreshed,
-            );
-        }
-    }
     secret.zeroAndFree(alloc, route_credential.credential);
     route_credential.credential = refreshed;
+    if (comptime !host_target.is_wasm) {
+        if (deps.usage) |usage| {
+            usage.cancelReconciliation();
+            usage.startReconciliation(deps.usage_allocator);
+        }
+    }
     debug_trace.eventf(
         "gateway",
         "credential_refreshed",

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3257,6 +3257,7 @@ fn processQueuedPromptLoop(
             const model_request = agent_stream_provider.ModelRequest{
                 .model = gateway_model,
                 .serialized_tools = config.gateway_tools_json,
+                .provider_tools = config.provider_tools,
                 .messages = request_messages,
                 .tool_choice = tool_choice,
                 .selected_dynamic_tool_schemas = selected_dynamic_tool_schemas.items,

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -2931,7 +2931,7 @@ test "processQueuedPrompt filters captured Fast by model capability" {
     }
 }
 
-test "selecting connection B during route A changes only the next admitted turn" {
+test "provider and Fx search stay on connection A after selecting B" {
     const Persistence = struct {
         fn write(
             _: ?*anyopaque,
@@ -2944,6 +2944,7 @@ test "selecting connection B during route A changes only the next admitted turn"
     const Capture = struct {
         registry: *connection_registry.Runtime,
         calls: usize = 0,
+        fx_search_calls: usize = 0,
         route_a_address: ?usize = null,
 
         fn expectRoute(
@@ -2977,10 +2978,21 @@ test "selecting connection B during route A changes only the next admitted turn"
                     try expectRoute(request, "connection-a", "fake://a", "fake-ref-a", "secret-a", "fake/model-a");
                     self.route_a_address = @intFromPtr(request.route);
                     try std.testing.expect(try self.registry.select("connection-b"));
+                    const provider_search = ToolCall{
+                        .id = "provider_search",
+                        .name = "perplexity_search",
+                        .arguments_json = "{}",
+                        .provenance = .provider_executed,
+                    };
+                    try events.emit(.{ .provider_tool_started = provider_search });
+                    try events.emit(.{ .provider_tool_result = .{
+                        .call_id = provider_search.id,
+                        .result = "{\"results\":[{\"title\":\"A\",\"url\":\"https://a.test\"}]}",
+                    } });
                     try events.emit(.{ .fx_tool_call = toolCall(
-                        "call_read",
-                        "read_file",
-                        "{\"path\":\"README.md\"}",
+                        "fx_search",
+                        "web_search",
+                        "{\"query\":\"connection-scoped search\"}",
                     ) });
                     try events.emit(.{ .finish = .{ .reason = .tool_calls } });
                 },
@@ -2998,6 +3010,18 @@ test "selecting connection B during route A changes only the next admitted turn"
                 },
                 else => return error.TestUnexpectedGatewayRequest,
             }
+        }
+
+        fn execute(raw: *anyopaque, request: ToolExecutionRequest) !ToolExecutionResult {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            try std.testing.expectEqualStrings("web_search", request.call.name);
+            try std.testing.expectEqualStrings("connection-a", request.route.?.connection_id);
+            try std.testing.expectEqualStrings("fake://a", request.route.?.endpoint);
+            try std.testing.expectEqualStrings("fake-ref-a", request.route.?.credential_ref);
+            try std.testing.expectEqualStrings("secret-a", request.route_credential);
+            try std.testing.expectEqualStrings("test_non_vercel", request.provider_adapter.?.kind);
+            self.fx_search_calls += 1;
+            return .{ .model_output = "Fx search results from connection A" };
         }
     };
 
@@ -3045,7 +3069,10 @@ test "selecting connection B during route A changes only the next admitted turn"
         .{ .credential_ref = "fake-ref-b", .credential = "secret-b" },
     };
     hooks_a.permission_decisions = &.{.once};
-    hooks_a.exec_plans = &.{.{ .result = .{ .model_output = "file contents" } }};
+    hooks_a.tool_execution_override = .{
+        .context = &capture,
+        .execute_fn = Capture.execute,
+    };
     defer hooks_a.deinit();
     var deps_a = hooks_a.deps();
     deps_a.provider_adapter = adapter;
@@ -3058,6 +3085,9 @@ test "selecting connection B during route A changes only the next admitted turn"
         job_a,
     );
     try std.testing.expectEqual(@as(usize, 2), capture.calls);
+    try std.testing.expectEqual(@as(usize, 1), capture.fx_search_calls);
+    try std.testing.expectEqual(@as(usize, 1), hooks_a.permission_names.items.len);
+    try std.testing.expectEqualStrings("web_search", hooks_a.permission_names.items[0]);
     try std.testing.expectEqualStrings("done-a", hooks_a.finish_assistant_text.?);
     try std.testing.expectEqualStrings("connection-b", registry.selectedProfile().id);
 

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -34,7 +34,7 @@ pub fn streamStartMayHaveExecutedAtProvider(
 ) bool {
     if (isProviderSearchAlias(tool_name)) return true;
     const spec = registry.lookup(tool_name) orelse return false;
-    return spec.provider_executed;
+    return spec.provider_tool != null;
 }
 
 pub const ProvisionalToolStatuses = struct {

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -232,7 +232,7 @@ pub const GenerationReference = struct {
     lookup_scope: ?[]const u8 = null,
 
     pub fn validate(self: GenerationReference) error{InvalidGenerationReference}!void {
-        try validatePart(self.id, false);
+        if (!types.validGenerationReferenceId(self.id)) return error.InvalidGenerationReference;
         if (self.lookup_scope) |scope| try validatePart(scope, true);
     }
 

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const account_usage_provider = @import("../gateway/account_usage_provider.zig");
+const model_catalog = @import("../gateway/model_catalog.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
 const image_attachments = @import("../images/image_attachments.zig");
 const route_snapshot = @import("../gateway/route_snapshot.zig");
@@ -7,6 +8,7 @@ const generation_usage_provider = @import("../session/generation_usage_provider.
 const debug_trace = @import("../shared/debug_trace.zig");
 const types = @import("../shared/types.zig");
 const gateway_schema = @import("../tooling/gateway_schema.zig");
+const web_search_provider = @import("../tooling/web_search_provider.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -93,6 +95,17 @@ pub const StructuredResponseFormat = struct {
     schema_json: []const u8,
 };
 
+/// Data-only capabilities that an adapter may serialize into its provider's
+/// native tool advertisement format.
+pub const ProviderTool = enum {
+    web_search,
+};
+
+pub const ProviderToolAdvertisement = struct {
+    tool: ProviderTool,
+    local_schema_position: usize,
+};
+
 /// Provider-neutral description of one model request. All slices are borrowed
 /// for the duration of `ProviderAdapter.stream`.
 pub const ModelRequest = struct {
@@ -101,6 +114,7 @@ pub const ModelRequest = struct {
     /// G11 removes the bridge after every caller supplies neutral descriptors.
     model: []const u8,
     serialized_tools: []const u8,
+    provider_tools: []const ProviderToolAdvertisement = &.{},
     messages: []const types.ChatMessage,
     tool_choice: types.ToolChoice,
     require_tool_call: bool = false,
@@ -119,8 +133,9 @@ pub const ModelRequest = struct {
     response_format: ?StructuredResponseFormat = null,
 };
 
-test "model request exposes only data-only vision metadata" {
+test "model request exposes only data-only tool and vision metadata" {
     try std.testing.expect(!@hasField(ModelRequest, "tool_registry"));
+    try std.testing.expect(@typeInfo(ProviderTool) == .@"enum");
     try std.testing.expect(!@hasField(gateway_schema.FunctionSchema, "call"));
     try std.testing.expect(!@hasField(gateway_schema.FunctionSchema, "runtime_provider"));
 }
@@ -480,6 +495,10 @@ pub const ProviderAdapter = struct {
     legacy_provider: ?Provider = null,
     account_usage: ?account_usage_provider.Provider = null,
     generation_usage: ?generation_usage_provider.Provider = null,
+    model_catalog: ?model_catalog.Provider = null,
+    model_descriptors: model_catalog.ModelDescriptorProvider = model_catalog.configured_model_descriptor_provider,
+    provider_tools: []const ProviderTool = &.{},
+    web_search: ?web_search_provider.Provider = null,
     stream_fn: AdapterStreamFn,
 
     pub fn acceptsRoute(self: ProviderAdapter, route: *const route_snapshot.RouteSnapshot) bool {

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -233,12 +233,9 @@ pub const GenerationReference = struct {
 
     pub fn validate(self: GenerationReference) error{InvalidGenerationReference}!void {
         if (!types.validGenerationReferenceId(self.id)) return error.InvalidGenerationReference;
-        if (self.lookup_scope) |scope| try validatePart(scope, true);
-    }
-
-    fn validatePart(value: []const u8, allow_empty: bool) error{InvalidGenerationReference}!void {
-        if ((!allow_empty and value.len == 0) or value.len > max_bytes) return error.InvalidGenerationReference;
-        for (value) |byte| if (byte < 0x20 or byte == 0x7f) return error.InvalidGenerationReference;
+        if (self.lookup_scope) |scope| {
+            if (!types.validGenerationLookupScope(scope)) return error.InvalidGenerationReference;
+        }
     }
 };
 

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
+const account_usage_provider = @import("../gateway/account_usage_provider.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
 const image_attachments = @import("../images/image_attachments.zig");
 const route_snapshot = @import("../gateway/route_snapshot.zig");
+const generation_usage_provider = @import("../session/generation_usage_provider.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const types = @import("../shared/types.zig");
 const gateway_schema = @import("../tooling/gateway_schema.zig");
@@ -479,6 +481,8 @@ pub const ProviderAdapter = struct {
     /// Bounded G1 bridge for existing injected Vercel stream providers. G11
     /// removes this field after the old seam has no callers.
     legacy_provider: ?Provider = null,
+    account_usage: ?account_usage_provider.Provider = null,
+    generation_usage: ?generation_usage_provider.Provider = null,
     stream_fn: AdapterStreamFn,
 
     pub fn acceptsRoute(self: ProviderAdapter, route: *const route_snapshot.RouteSnapshot) bool {

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -291,6 +291,10 @@ pub fn Runtime(comptime App: type) type {
             }
             if (comptime @hasField(App, "web_search_runtime")) {
                 app.web_search_runtime.configure(.{
+                    .connection_id = if (comptime @hasDecl(App, "activeConnectionId"))
+                        app.activeConnectionId()
+                    else
+                        "vercel",
                     .api_key = app.auth.apiKey() orelse "",
                     .gateway_team = app.auth.gatewayTeam(),
                     .worker_model = app.selected_model.items,

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -290,20 +290,7 @@ pub fn Runtime(comptime App: type) type {
                 ctx.on_web_fetch_progress = app_callbacks.Bindings(App).onWebFetchProgress;
             }
             if (comptime @hasField(App, "web_search_runtime")) {
-                app.web_search_runtime.configure(.{
-                    .connection_id = if (comptime @hasDecl(App, "activeConnectionId"))
-                        app.activeConnectionId()
-                    else
-                        "vercel",
-                    .api_key = app.auth.apiKey() orelse "",
-                    .gateway_team = app.auth.gatewayTeam(),
-                    .worker_model = app.selected_model.items,
-                    .gateway_retry_count = gateway_retry_count,
-                    .gateway_chat_url = gateway_chat_url,
-                    .usage = &app.session.usage,
-                    .usage_allocator = app.alloc,
-                });
-                ctx.web_search_runtime_ready = false;
+                ctx.web_search_runtime_ready = runtime_profile.allows(App, .web_search);
                 ctx.web_search_backend = app.web_search_runtime.dispatchBackend();
                 ctx.web_search_progress_ctx = @ptrCast(app);
                 ctx.on_web_search_progress = app_callbacks.Bindings(App).onWebSearchProgress;
@@ -1061,6 +1048,7 @@ pub fn Runtime(comptime App: type) type {
                 .skills_prompt_section = bounded_skills.text,
                 .explicit_skills_prompt_section = explicit_skills.text,
                 .gateway_tools_json = child_projection.tools_json,
+                .provider_tools = child_projection.provider_tools,
                 .custom_tool_guidance = child_projection.custom_guidance,
                 .context_registry = app.contextRegistry(),
                 .context_enabled = if (comptime @hasField(App, "context_enabled")) app.context_enabled else true,
@@ -1117,6 +1105,7 @@ pub fn Runtime(comptime App: type) type {
                     null,
                 .gateway_chat_url = gateway_chat_url,
                 .gateway_tools_json = tool_projection.tools_json,
+                .provider_tools = tool_projection.provider_tools,
                 .custom_tool_guidance = tool_projection.custom_guidance,
                 .agent_step_limit = app.agent_step_limit,
                 .max_tool_result_bytes = job.agent_settings.max_tool_result_bytes,
@@ -1466,9 +1455,7 @@ const FakeApp = struct {
     mcp_result: []const u8 = "{\"ok\":true}",
     diff_blocks: usize = 0,
     web_fetch_runtime: web_fetch_runtime.Runtime = web_fetch_runtime.Runtime.init(.{}),
-    web_search_runtime: web_search_runtime.Runtime = web_search_runtime.Runtime.init(.{
-        .provider = test_builtin_gateway.default_web_search_provider,
-    }),
+    web_search_runtime: web_search_runtime.Runtime = web_search_runtime.Runtime.init(.{}),
     web_search_models_path: []const u8 = "/models",
     lifecycle_runtime: hooks.Runtime,
     lifecycle_view: hooks.RuntimeView,
@@ -1597,8 +1584,11 @@ const FakeApp = struct {
         if (self.snapshot_tools_error) |err| return err;
         const tools_json = try alloc.dupe(u8, "[]");
         errdefer alloc.free(tools_json);
+        const provider_tools = try alloc.alloc(agent_stream_provider.ProviderToolAdvertisement, 0);
+        errdefer alloc.free(provider_tools);
         return .{
             .tools_json = tools_json,
+            .provider_tools = provider_tools,
             .custom_guidance = try alloc.dupe(u8, self.snapshot_custom_guidance),
         };
     }
@@ -1619,8 +1609,11 @@ const FakeApp = struct {
         if (self.snapshot_tools_error) |err| return err;
         const tools_json = try alloc.dupe(u8, "[]");
         errdefer alloc.free(tools_json);
+        const provider_tools = try alloc.alloc(agent_stream_provider.ProviderToolAdvertisement, 0);
+        errdefer alloc.free(provider_tools);
         return .{
             .tools_json = tools_json,
+            .provider_tools = provider_tools,
             .custom_guidance = try alloc.dupe(u8, self.snapshot_custom_guidance),
         };
     }
@@ -1792,14 +1785,12 @@ test "app agent runtime builds tool context from app state and MCP callbacks" {
     try std.testing.expectEqual(@as(usize, 1), ctx.permission_grants.len);
     try std.testing.expect(ctx.fast_mode);
     try std.testing.expectEqual(types.ReasoningEffort.literal("high"), ctx.effort);
-    try std.testing.expect(!ctx.web_search_runtime_ready);
+    try std.testing.expect(ctx.web_search_runtime_ready);
     try std.testing.expect(ctx.web_search_backend != null);
     try std.testing.expect(ctx.web_fetch_runtime.? == &app.web_fetch_runtime);
     try std.testing.expect(ctx.web_fetch_progress_ctx != null);
     try std.testing.expect(ctx.on_web_fetch_progress != null);
-    try std.testing.expectEqualStrings("test-model", app.web_search_runtime.worker_model);
-    try std.testing.expectEqual(ctx.gateway_retry_count, app.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(ctx.gateway_chat_url, app.web_search_runtime.gateway_chat_url);
+    try std.testing.expect(ctx.provider_adapter.web_search != null);
     try std.testing.expectEqualStrings("/models", ctx.gateway_models_path);
     try std.testing.expectEqual(@as(usize, 4096), ctx.max_tool_result_bytes);
     try std.testing.expectEqual(types.ToolChoice.none, ctx.first_call_tool_choice);
@@ -1893,7 +1884,7 @@ test "interactive app prepared file mutation callback applies app permission pol
     try std.testing.expect(outcome.execution_authority == null);
 }
 
-test "app prompt projection configures web search then blocks native execution" {
+test "app search requires a pinned route before invoking its adapter" {
     const alloc = std.testing.allocator;
     const web_search_contract = @import("../tooling/web_search_contract.zig");
     const ProviderState = struct {
@@ -1916,19 +1907,12 @@ test "app prompt projection configures web search then blocks native execution" 
     var app = try FakeApp.init(alloc);
     defer app.deinit();
     var provider_state = ProviderState{};
-    var provider = app.web_search_runtime.provider orelse return error.TestExpectedEqual;
+    var provider = test_builtin_gateway.default_web_search_provider;
     provider.context = @ptrCast(&provider_state);
     provider.execute_fn = FailingWebSearchProvider.execute;
-    app.web_search_runtime = web_search_runtime.Runtime.init(.{
-        .provider = provider,
-    });
-
-    app.web_search_runtime.configure(.{
-        .api_key = "stale-key",
-        .worker_model = "stale-model",
-        .gateway_retry_count = 99,
-        .gateway_chat_url = "https://stale.invalid/chat",
-    });
+    var adapter = test_builtin_gateway.provider_adapter;
+    adapter.web_search = provider;
+    app.provider_adapter_override = adapter;
 
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();
@@ -1938,19 +1922,12 @@ test "app prompt projection configures web search then blocks native execution" 
     try Runtime(FakeApp).appendStaticContextMessage(&app, arena, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     try app.appendRuntimeContextMessage(arena, &messages);
 
-    try std.testing.expectEqualStrings("stale-key", app.web_search_runtime.api_key);
-
     const validation = try app.validateToolCall(arena, .{
         .id = "search",
         .name = "web_search",
         .arguments_json = "{\"query\":\"x\"}",
     });
     try std.testing.expectEqualStrings("web_search field \"query\" must contain at least two characters", validation.failure);
-    try std.testing.expectEqualStrings(app.auth.apiKey().?, app.web_search_runtime.api_key);
-    try std.testing.expectEqualStrings(app.selected_model.items, app.web_search_runtime.worker_model);
-    try std.testing.expectEqual(@as(usize, 2), app.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(test_gateway_chat_url, app.web_search_runtime.gateway_chat_url);
-
     const execution = try app.executeToolCall(.{
         .call_allocator = arena,
         .result_allocator = arena,
@@ -1964,10 +1941,6 @@ test "app prompt projection configures web search then blocks native execution" 
         .advertised_dynamic_tool_names = &.{},
         .max_tool_result_bytes = 2048,
     });
-    try std.testing.expectEqualStrings(app.auth.apiKey().?, app.web_search_runtime.api_key);
-    try std.testing.expectEqualStrings(app.selected_model.items, app.web_search_runtime.worker_model);
-    try std.testing.expectEqual(@as(usize, 2), app.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(test_gateway_chat_url, app.web_search_runtime.gateway_chat_url);
     try std.testing.expectEqual(.failure, execution.status);
     try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
 }
@@ -2953,8 +2926,10 @@ test "app agent runtime queued prompt config uses captured job settings over sta
     const tools_json = try alloc.dupe(u8, "[]");
     errdefer alloc.free(tools_json);
     const custom_guidance = try alloc.dupe(u8, "app custom tool guidance");
+    const provider_tools = try alloc.alloc(agent_stream_provider.ProviderToolAdvertisement, 0);
     var tool_projection = tool_advertisement.EffectiveToolProjection{
         .tools_json = tools_json,
+        .provider_tools = provider_tools,
         .custom_guidance = custom_guidance,
     };
     defer tool_projection.deinit(alloc);

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -592,12 +592,10 @@ pub fn Runtime(comptime App: type) type {
                 @hasField(@TypeOf(app.session), "usage"))
             {
                 if (app.auth.gatewayCredential()) |credential| {
-                    app.session.usage.replaceReconciliationCredential(
-                        app.alloc,
-                        credential.api_key,
-                    );
+                    _ = credential;
+                    app.session.usage.startReconciliation(app.alloc);
                 } else {
-                    app.session.usage.clearReconciliationCredential();
+                    app.session.usage.cancelReconciliation();
                 }
             }
         }
@@ -765,22 +763,18 @@ const TestGatewayCredential = struct {
 };
 
 const TestUsage = struct {
-    refresh_count: usize = 0,
-    clear_count: usize = 0,
-    last_key: ?[]const u8 = null,
+    start_count: usize = 0,
+    cancel_count: usize = 0,
 
-    fn replaceReconciliationCredential(
+    fn startReconciliation(
         self: *TestUsage,
         _: std.mem.Allocator,
-        api_key: []const u8,
     ) void {
-        self.refresh_count += 1;
-        self.last_key = api_key;
+        self.start_count += 1;
     }
 
-    fn clearReconciliationCredential(self: *TestUsage) void {
-        self.clear_count += 1;
-        self.last_key = null;
+    fn cancelReconciliation(self: *TestUsage) void {
+        self.cancel_count += 1;
     }
 };
 
@@ -947,11 +941,7 @@ test "auth source changes invalidate the catalog and failed selection preserves 
     try std.testing.expectEqual(credentials.Source.stored_key, app.auth.selected_source.?);
     try std.testing.expectEqual(@as(usize, 2), app.model_cache.reset_count);
     try std.testing.expectEqual(@as(usize, 2), app.model_cache_warmup_count);
-    try std.testing.expectEqual(@as(usize, 2), app.session.usage.refresh_count);
-    try std.testing.expectEqualStrings(
-        "refreshed-key",
-        app.session.usage.last_key.?,
-    );
+    try std.testing.expectEqual(@as(usize, 2), app.session.usage.start_count);
 
     app.auth.select_result = null;
     try std.testing.expect(!try runtime.selectCredentialSource(&app, .ai_gateway_api_key));
@@ -1137,17 +1127,17 @@ test "prompt credential refresh reloads the catalog after the credential changes
     try std.testing.expectEqual(@as(usize, 2), app.auth.refresh_count);
     try std.testing.expectEqual(@as(usize, 1), app.model_cache.reset_count);
     try std.testing.expectEqual(@as(usize, 1), app.model_cache_warmup_count);
-    try std.testing.expectEqual(@as(usize, 1), app.session.usage.refresh_count);
+    try std.testing.expectEqual(@as(usize, 1), app.session.usage.start_count);
 }
 
-test "credential removal clears the reconciliation credential" {
+test "credential removal cancels reconciliation" {
     var app: TestApp = .{};
     app.auth.gateway_ready = false;
 
     Runtime(TestApp).applyCredentialChange(&app, true);
 
-    try std.testing.expectEqual(@as(usize, 1), app.session.usage.clear_count);
-    try std.testing.expectEqual(@as(usize, 0), app.session.usage.refresh_count);
+    try std.testing.expectEqual(@as(usize, 1), app.session.usage.cancel_count);
+    try std.testing.expectEqual(@as(usize, 0), app.session.usage.start_count);
 }
 
 test "logout result reconciles live auth and renders only sanitized notices" {

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -1600,10 +1600,14 @@ pub fn Handlers(comptime App: type) type {
 
         fn commandShowCredits(ctx: *anyopaque) !void {
             const app: *App = @ptrCast(@alignCast(ctx));
-            var snapshot = app.creditsProvider().fetch(app.alloc, .{
-                .credential = app.auth.apiKey(),
-                .tenant = app.auth.gatewayTeam(),
-            });
+            var snapshot = app.fetchAccountUsage() catch {
+                try app.writeDomainNotice(.{
+                    .topic = "credits",
+                    .tone = .@"error",
+                    .body = "Failed to fetch account usage.",
+                }, true);
+                return;
+            };
             defer snapshot.deinit(app.alloc);
             const text = snapshot.renderInteractiveBody(app.alloc) catch {
                 try app.writeDomainNotice(.{
@@ -3559,18 +3563,7 @@ fn writeSandboxPersistenceFailure(app: anytype, err: anyerror) !void {
 const SurfaceOnlyApp = struct {};
 
 const CreditsCommandFakeApp = struct {
-    const FakeAuth = struct {
-        fn apiKey(_: *const FakeAuth) ?[]const u8 {
-            return "credential";
-        }
-
-        fn gatewayTeam(_: *const FakeAuth) ?[]const u8 {
-            return "tenant";
-        }
-    };
-
     alloc: std.mem.Allocator,
-    auth: FakeAuth = .{},
     calls: usize = 0,
     saw_expected_input: bool = false,
     notice_body: std.ArrayList(u8) = .empty,
@@ -3581,24 +3574,10 @@ const CreditsCommandFakeApp = struct {
         self.notice_body.deinit(self.alloc);
     }
 
-    fn creditsProvider(self: *CreditsCommandFakeApp) gateway_provider.CreditsProvider {
-        return .{
-            .context = self,
-            .fetch_fn = fetchCredits,
-        };
-    }
-
-    fn fetchCredits(
-        raw: ?*anyopaque,
-        alloc: std.mem.Allocator,
-        input: gateway_provider.CreditsLookupInput,
-    ) output_contracts.CreditsSnapshot {
-        const self: *CreditsCommandFakeApp = @ptrCast(@alignCast(raw.?));
+    fn fetchAccountUsage(self: *CreditsCommandFakeApp) !output_contracts.CreditsSnapshot {
         self.calls += 1;
-        self.saw_expected_input =
-            std.mem.eql(u8, input.credential orelse "", "credential") and
-            std.mem.eql(u8, input.tenant orelse "", "tenant");
-        return .{ .balance = alloc.dupe(u8, "10") catch null };
+        self.saw_expected_input = true;
+        return .{ .balance = try self.alloc.dupe(u8, "10") };
     }
 
     noinline fn writeDomainNotice(

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -820,9 +820,8 @@ test "app entry returns after handled CLI success without initializing app" {
     try std.testing.expectEqualStrings("entry_test_tool", capture.seen_config.?.tool_set.order[0]);
     try std.testing.expectEqualStrings("skills", capture.seen_config.?.skill_root_policy.workspace_roots[0].path);
     try std.testing.expect(capture.seen_config.?.gateway_provider.chat_url.resolve_fn == test_builtin_gateway.chat_url_provider.resolve_fn);
-    try std.testing.expect(capture.seen_config.?.gateway_provider.cli_model_catalog.fetch_fn == test_builtin_gateway.cli_model_catalog_provider.fetch_fn);
-    try std.testing.expect(capture.seen_config.?.gateway_provider.web_search.execute_fn == test_builtin_gateway.default_web_search_provider.execute_fn);
-    try std.testing.expect(capture.seen_config.?.gateway_provider.model_catalog.fetch_fn == test_builtin_gateway.model_catalog_provider.fetch_fn);
+    try std.testing.expect(capture.seen_config.?.gateway_provider.provider_adapter.web_search.?.execute_fn == test_builtin_gateway.default_web_search_provider.execute_fn);
+    try std.testing.expect(capture.seen_config.?.gateway_provider.provider_adapter.model_catalog.?.fetch_fn == test_builtin_gateway.model_catalog_provider.fetch_fn);
     try std.testing.expect(
         capture.seen_config.?.background_process_provider.spawn_prepared_fn ==
             cfg.background_process_provider.spawn_prepared_fn,

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -268,6 +268,18 @@ pub const StartupStatus = struct {
         }
         self.* = undefined;
     }
+
+    pub fn normalizeModel(
+        self: *StartupStatus,
+        alloc: Allocator,
+        descriptors: model_catalog.ModelDescriptorProvider,
+    ) !void {
+        const descriptor = descriptors.fallback(self.selected_model);
+        const normalized = try alloc.dupe(u8, descriptor.id);
+        if (self.owned_selected_model) |owned| alloc.free(owned);
+        self.selected_model = normalized;
+        self.owned_selected_model = normalized;
+    }
 };
 
 const StartupStatusModel = struct {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1794,14 +1794,7 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn startResumedSessionReconciliation(app: *App) void {
-            if (comptime @hasField(App, "auth")) {
-                if (app.auth.apiKey()) |api_key| {
-                    app.session.usage.startReconciliation(
-                        app.alloc,
-                        api_key,
-                    );
-                }
-            }
+            app.session.usage.startReconciliation(app.alloc);
         }
 
         pub fn resumeSelectedSession(app: *App) !bool {

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -16,6 +16,7 @@ const context_contract = @import("../workspace/context_contract.zig");
 const devbox_executor = @import("../execution/devbox_executor.zig");
 const gateway_provider = @import("../gateway/gateway_provider.zig");
 const connection_registry = @import("../gateway/connection_registry.zig");
+const model_catalog = @import("../gateway/model_catalog.zig");
 const route_snapshot = @import("../gateway/route_snapshot.zig");
 const background_process_provider = @import(
     "../execution/background_process_provider.zig",
@@ -265,6 +266,8 @@ fn runAskChild(
             .permission_rules = admission.rules,
             .mcp_runtime = ctx.mcp,
             .subagent_available = true,
+            .terminal_available = tool_dispatch.ToolCapabilities.for_host(host.current()).terminalAvailable(),
+            .provider_tools = ctx.cfg.gateway_provider.provider_adapter.provider_tools,
         },
     ) catch return error.OutOfMemory;
     defer child_projection.deinit(ctx.alloc);
@@ -276,6 +279,7 @@ fn runAskChild(
         .skills_prompt_section = ctx.subagent_skills_prompt,
         .explicit_skills_prompt_section = ctx.subagent_explicit_skills_prompt,
         .gateway_tools_json = child_projection.tools_json,
+        .provider_tools = child_projection.provider_tools,
         .custom_tool_guidance = child_projection.custom_guidance,
         .context_registry = ctx.deps.context_registry,
         .context_enabled = ctx.context_enabled,
@@ -622,9 +626,7 @@ const AskContext = struct {
             .seed_model = cfg.default_model,
             .mode_id = cfg.mode_registry.default_mode_id,
             .session = session_runtime.SessionRuntime.init(cfg.max_history_turns),
-            .web_search_runtime = web_search_runtime.Runtime.init(.{
-                .provider = cfg.gateway_provider.web_search,
-            }),
+            .web_search_runtime = web_search_runtime.Runtime.init(.{}),
             .background = BackgroundRuntime.init(
                 cfg.background_process_provider,
             ),
@@ -1008,16 +1010,6 @@ const AskContext = struct {
     }
 
     fn toolContext(self: *AskContext) tool_runtime.Context {
-        self.web_search_runtime.configure(.{
-            .connection_id = self.connection_id,
-            .api_key = self.api_key,
-            .gateway_team = self.gateway_team,
-            .worker_model = self.model,
-            .gateway_retry_count = self.cfg.gateway_retry_count,
-            .gateway_chat_url = self.cfg.gateway_chat_url,
-            .usage = &self.session.usage,
-            .usage_allocator = self.alloc,
-        });
         var tc: tool_runtime.Context = .{
             .workspace_root = self.workspace_root,
             .access_scope = self.workspace_access.scope(self.workspace_root),
@@ -1458,6 +1450,10 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         cfg.gateway_provider.connection_seed,
     );
     defer startup.deinit(alloc);
+    try startup.normalizeModels(
+        alloc,
+        cfg.gateway_provider.provider_adapter.model_descriptors,
+    );
     try checkHeadlessCancellation(options.deps);
 
     var permission_mode = toCorePermissionMode(startup.permission_mode);
@@ -1703,6 +1699,9 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         .permission_rules = ctx.permission_rules,
         .mcp_runtime = ctx.mcp,
         .subagent_available = ctx.subagent_host != null,
+        .terminal_available = ctx.subagent_host != null and
+            tool_dispatch.ToolCapabilities.for_host(host.current()).terminalAvailable(),
+        .provider_tools = ctx.cfg.gateway_provider.provider_adapter.provider_tools,
     }, session_child_capability != null);
     defer tool_projection.deinit(alloc);
 
@@ -1809,6 +1808,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         .gateway_retry_count = cfg.gateway_retry_count,
         .gateway_chat_url = cfg.gateway_chat_url,
         .gateway_tools_json = tool_projection.tools_json,
+        .provider_tools = tool_projection.provider_tools,
         .custom_tool_guidance = tool_projection.custom_guidance,
         .agent_step_limit = startup.agent_step_limit,
         .max_tool_result_bytes = startup.max_tool_result_bytes,
@@ -2103,9 +2103,14 @@ fn reportUsage(raw_ctx: *anyopaque, usage: types.Usage) void {
 
 fn resolveModelCapabilities(raw_ctx: *anyopaque, _: Allocator, model: []const u8) model_capabilities.ResolveError!model_capabilities.Capabilities {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    const adapter = ctx.cfg.gateway_provider.provider_adapter;
+    const catalog = gateway_provider.modelCatalogForAdapter(
+        ctx.connection_adapter_kind,
+        adapter,
+    ) orelse return adapter.model_descriptors.fallback(model);
     return ctx.capability_resolver.resolve(
         ctx.alloc,
-        ctx.cfg.gateway_provider.model_catalog,
+        catalog,
         .{
             .access = ctx.model_catalog_access,
             .endpoint = ctx.cfg.gateway_models_path,
@@ -2117,18 +2122,26 @@ fn resolveModelCapabilities(raw_ctx: *anyopaque, _: Allocator, model: []const u8
 
 fn availableModelCapabilities(raw_ctx: *anyopaque, model: []const u8) model_capabilities.Capabilities {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    const adapter = ctx.cfg.gateway_provider.provider_adapter;
+    if (gateway_provider.modelCatalogForAdapter(
+        ctx.connection_adapter_kind,
+        adapter,
+    ) == null) return adapter.model_descriptors.fallback(model).capabilities;
     return ctx.capability_resolver.available(model);
 }
 
 fn resolveModelDescriptor(raw_ctx: *anyopaque, alloc: Allocator, model: []const u8) model_capabilities.ResolveError!model_capabilities.ModelDescriptor {
-    var descriptor = model_capabilities.configuredDescriptor(model, .{});
+    const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    var descriptor = ctx.cfg.gateway_provider.provider_adapter.model_descriptors.fallback(model);
     descriptor.capabilities = try resolveModelCapabilities(raw_ctx, alloc, model);
     descriptor.source = .catalog;
     return descriptor;
 }
 
 fn availableModelDescriptor(raw_ctx: *anyopaque, model: []const u8) model_capabilities.ModelDescriptor {
-    const descriptor = model_capabilities.configuredDescriptor(model, availableModelCapabilities(raw_ctx, model));
+    const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    var descriptor = ctx.cfg.gateway_provider.provider_adapter.model_descriptors.fallback(model);
+    descriptor.capabilities = availableModelCapabilities(raw_ctx, model);
     return descriptor;
 }
 
@@ -4043,6 +4056,28 @@ fn testPresentKeyStartup(alloc: Allocator, _: oauth_transport.Provider, _: host.
     return state;
 }
 
+fn testPresentKeyHighEffortStartup(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    secret_store: host.SecretStore,
+    default_model: []const u8,
+    default_fast_mode: bool,
+    default_agent_step_limit: usize,
+    connection_seed: connection_registry.Seed,
+) !app_lifecycle.StartupState {
+    var state = try testPresentKeyStartup(
+        alloc,
+        transport,
+        secret_store,
+        default_model,
+        default_fast_mode,
+        default_agent_step_limit,
+        connection_seed,
+    );
+    state.effort = types.ReasoningEffort.literal("high");
+    return state;
+}
+
 fn testMissingKeyAcknowledgedStartup(alloc: Allocator, transport: oauth_transport.Provider, secret_store: host.SecretStore, default_model: []const u8, default_fast_mode: bool, default_agent_step_limit: usize, connection_seed: connection_registry.Seed) !app_lifecycle.StartupState {
     var state = try testMissingKeyStartup(alloc, transport, secret_store, default_model, default_fast_mode, default_agent_step_limit, connection_seed);
     state.yolo_acknowledged = true;
@@ -4125,10 +4160,7 @@ fn testProcessQueuedPromptChecksTimeout(deps: *const agent_runtime.AgentRuntimeD
     try std.testing.expect(tool_ctx.web_fetch_runtime.? == &ctx.web_fetch_runtime);
     try std.testing.expect(tool_ctx.web_fetch_progress_ctx != null);
     try std.testing.expect(tool_ctx.on_web_fetch_progress != null);
-    try std.testing.expectEqualStrings(ctx.model, ctx.web_search_runtime.worker_model);
-    try std.testing.expectEqual(ctx.cfg.gateway_retry_count, ctx.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(ctx.cfg.gateway_chat_url, ctx.web_search_runtime.gateway_chat_url);
-    try std.testing.expect(ctx.web_search_runtime.provider.?.execute_fn == ctx.cfg.gateway_provider.web_search.execute_fn);
+    try std.testing.expect(ctx.cfg.gateway_provider.provider_adapter.web_search != null);
     try std.testing.expectEqualStrings("/models", tool_ctx.gateway_models_path);
     try std.testing.expect(tool_ctx.devbox_provider.?.execute_fn == unavailableDevboxForTest);
     try testPushAssistantText(deps, "assistant text");
@@ -4143,9 +4175,10 @@ fn testProcessQueuedPromptChecksExecOnlyTerminal(deps: *const agent_runtime.Agen
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "\"name\":\"terminal\"") != null);
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "\"name\":\"run_command\"") == null);
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "\"name\":\"web_search\"") == null);
-    try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "gateway.perplexity_search") != null);
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "Run one captured command and return its result.") != null);
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "Use start for commands") == null);
+    try std.testing.expectEqual(@as(usize, 1), cfg.provider_tools.len);
+    try std.testing.expectEqual(.web_search, cfg.provider_tools[0].tool);
     try std.testing.expectEqualStrings(builtin_tools.web_search.description, cfg.custom_tool_guidance);
     try std.testing.expectEqualStrings("test model overlay", cfg.model_prompt_overlay.?);
     const runtime_terminal = deps.tool_registry.lookup("terminal") orelse
@@ -4674,6 +4707,106 @@ test "fake non-Vercel adapter completes an Ask root turn on its admitted route" 
     try std.testing.expectEqualStrings("ask complete", result.assistant_output);
 }
 
+test "mismatched Ask adapter forces static capabilities without provider traffic" {
+    const web_search_contract = @import("../tooling/web_search_contract.zig");
+    const Traffic = struct {
+        catalog_calls: usize = 0,
+        search_calls: usize = 0,
+        model_calls: usize = 0,
+
+        fn fetchCatalog(
+            raw: ?*anyopaque,
+            _: Allocator,
+            _: model_catalog.FetchInput,
+        ) Allocator.Error!model_catalog.ProviderResult {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.catalog_calls += 1;
+            return .{ .failure = .{ .category = .transport } };
+        }
+
+        fn preferredSearchBackends(
+            raw: ?*anyopaque,
+        ) anyerror!?[]const web_search_contract.SearchBackendId {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.search_calls += 1;
+            return null;
+        }
+
+        fn search(
+            raw: ?*anyopaque,
+            _: Allocator,
+            _: web_search_runtime.Inputs,
+            _: web_search_contract.ProviderRequest,
+            _: ?web_search_contract.ProgressFn,
+            _: ?*anyopaque,
+        ) anyerror!web_search_contract.ProviderResponse {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.search_calls += 1;
+            return error.TestUnexpectedSearch;
+        }
+
+        fn stream(
+            adapter: *const agent_stream_provider.ProviderAdapter,
+            _: Allocator,
+            _: agent_stream_provider.AdapterRequest,
+            events: agent_stream_provider.EventSink,
+        ) !void {
+            const self: *@This() = @ptrCast(@alignCast(adapter.context.?));
+            self.model_calls += 1;
+            try events.emit(.{ .finish = .{ .reason = .stop } });
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    var stdout_capture: TestCapture = .{};
+    defer stdout_capture.deinit(alloc);
+    var stderr_capture: TestCapture = .{};
+    defer stderr_capture.deinit(alloc);
+    var traffic = Traffic{};
+    var cfg = testConfig();
+    cfg.default_model = "unknown/model";
+    cfg.gateway_provider.connection_seed = .{
+        .id = "mismatched",
+        .display_name = "Mismatched",
+        .adapter_id = "unavailable_adapter",
+        .endpoint = "fake://ask-mismatch",
+        .protocol = "unavailable_adapter",
+        .credential_ref = "automatic",
+    };
+    var adapter = test_builtin_gateway.provider_adapter;
+    adapter.kind = "provider_adapter";
+    adapter.context = &traffic;
+    adapter.model_catalog = .{
+        .context = &traffic,
+        .fetch_fn = Traffic.fetchCatalog,
+    };
+    var search = test_builtin_gateway.default_web_search_provider;
+    search.context = &traffic;
+    search.preferred_backends_fn = Traffic.preferredSearchBackends;
+    search.execute_fn = Traffic.search;
+    adapter.web_search = search;
+    adapter.stream_fn = Traffic.stream;
+    cfg.gateway_provider.provider_adapter = adapter;
+    var deps = testPromptRunDeps(
+        &stdout_capture,
+        &stderr_capture,
+        testPresentKeyHighEffortStartup,
+    );
+    deps.process_queued_prompt = processQueuedPromptDefault;
+
+    var result = try runPromptInternal(alloc, "force capability resolution", null, cfg, .{
+        .output_mode = .json,
+        .save_session = false,
+        .deps = deps,
+    });
+    defer result.deinit(alloc);
+
+    try std.testing.expectEqualStrings("RouteAdapterMismatch", result.error_code.?);
+    try std.testing.expectEqual(@as(usize, 0), traffic.catalog_calls);
+    try std.testing.expectEqual(@as(usize, 0), traffic.search_calls);
+    try std.testing.expectEqual(@as(usize, 0), traffic.model_calls);
+}
+
 fn testPermissionRuleSet(alloc: Allocator, permission: []const u8, pattern: []const u8, action: types.PermissionAction) !types.PermissionRuleSet {
     var rules = types.PermissionRuleSet{
         .rules = try alloc.alloc(types.PermissionRule, 1),
@@ -4895,7 +5028,7 @@ test "fx ask deps validate malformed registered calls" {
     try std.testing.expectEqualStrings("web_fetch field \"url\" must be a string", result.failure);
 }
 
-test "CLI prompt projection configures web search then blocks native execution" {
+test "CLI prompt projection leaves Fx search uninstalled" {
     const alloc = std.testing.allocator;
     const web_search_contract = @import("../tooling/web_search_contract.zig");
     const ProviderState = struct {
@@ -4919,22 +5052,14 @@ test "CLI prompt projection configures web search then blocks native execution" 
     defer stdout_capture.deinit(alloc);
     var stderr_capture = TestCapture{};
     defer stderr_capture.deinit(alloc);
-    var ctx = AskContext.init(alloc, testConfig(), testPromptRunDeps(&stdout_capture, &stderr_capture, testPresentKeyStartup), "/tmp/workspace");
-    defer ctx.deinit();
     var provider_state = ProviderState{};
-    var provider = ctx.web_search_runtime.provider orelse return error.TestExpectedEqual;
+    var provider = test_builtin_gateway.default_web_search_provider;
     provider.context = @ptrCast(&provider_state);
     provider.execute_fn = FailingWebSearchProvider.execute;
-    ctx.web_search_runtime = web_search_runtime.Runtime.init(.{
-        .provider = provider,
-    });
-
-    ctx.web_search_runtime.configure(.{
-        .api_key = "stale-key",
-        .worker_model = "stale-model",
-        .gateway_retry_count = 99,
-        .gateway_chat_url = "https://stale.invalid/chat",
-    });
+    var config = testConfig();
+    config.gateway_provider.provider_adapter.web_search = provider;
+    var ctx = AskContext.init(alloc, config, testPromptRunDeps(&stdout_capture, &stderr_capture, testPresentKeyStartup), "/tmp/workspace");
+    defer ctx.deinit();
 
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();
@@ -4946,8 +5071,6 @@ test "CLI prompt projection configures web search then blocks native execution" 
     try append_static(deps.ctx, arena, &messages);
     try deps.append_runtime_context(deps.ctx, arena, &messages);
 
-    try std.testing.expectEqualStrings("stale-key", ctx.web_search_runtime.api_key);
-
     const validate = deps.validate_tool_call orelse return error.TestExpectedEqual;
     const validation = try validate(deps.ctx, arena, .{
         .id = "search",
@@ -4955,11 +5078,6 @@ test "CLI prompt projection configures web search then blocks native execution" 
         .arguments_json = "{\"query\":\"x\"}",
     });
     try std.testing.expectEqualStrings("web_search field \"query\" must contain at least two characters", validation.failure);
-    try std.testing.expectEqualStrings(ctx.api_key, ctx.web_search_runtime.api_key);
-    try std.testing.expectEqualStrings(ctx.model, ctx.web_search_runtime.worker_model);
-    try std.testing.expectEqual(ctx.cfg.gateway_retry_count, ctx.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(ctx.cfg.gateway_chat_url, ctx.web_search_runtime.gateway_chat_url);
-
     const execute = deps.execute_tool_call;
     const execution = try execute(deps.ctx, .{
         .call_allocator = arena,
@@ -4974,10 +5092,6 @@ test "CLI prompt projection configures web search then blocks native execution" 
         .advertised_dynamic_tool_names = &.{},
         .max_tool_result_bytes = ctx.max_tool_result_bytes,
     });
-    try std.testing.expectEqualStrings(ctx.api_key, ctx.web_search_runtime.api_key);
-    try std.testing.expectEqualStrings(ctx.model, ctx.web_search_runtime.worker_model);
-    try std.testing.expectEqual(ctx.cfg.gateway_retry_count, ctx.web_search_runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings(ctx.cfg.gateway_chat_url, ctx.web_search_runtime.gateway_chat_url);
     try std.testing.expectEqual(.failure, execution.status);
     try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
 }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -49,6 +49,7 @@ const sandbox = @import("../permissions/sandbox.zig");
 const session_runtime = @import("../session/session.zig");
 const session_codec = @import("../session/session_codec.zig");
 const session_usage = @import("../session/session_usage.zig");
+const generation_usage_provider = @import("../session/generation_usage_provider.zig");
 const usage_report = @import("../session/usage_report.zig");
 const session_store = @import("../session/session_store.zig");
 const skill_contract = @import("../skills/skill_contract.zig");
@@ -571,6 +572,8 @@ const AskContext = struct {
     session_write_mutex: std.Io.Mutex = .init,
     requested_resume: ?ResumeTarget = null,
     connection_id: []const u8 = session_codec.legacy_connection_id,
+    connection_adapter_kind: []const u8 = "",
+    connection_credential_ref: []const u8 = "",
     seed_model: []const u8 = "",
     command_timeout_ms: ?usize = null,
     session: SessionRuntime,
@@ -618,10 +621,7 @@ const AskContext = struct {
             .model = cfg.default_model,
             .seed_model = cfg.default_model,
             .mode_id = cfg.mode_registry.default_mode_id,
-            .session = session_runtime.SessionRuntime.init(
-                cfg.max_history_turns,
-                cfg.gateway_provider.generation_usage,
-            ),
+            .session = session_runtime.SessionRuntime.init(cfg.max_history_turns),
             .web_search_runtime = web_search_runtime.Runtime.init(.{
                 .provider = cfg.gateway_provider.web_search,
             }),
@@ -781,6 +781,43 @@ const AskContext = struct {
             },
             .outcome_allocator = self.alloc,
         };
+    }
+
+    fn resolveGenerationUsageCredential(
+        raw: ?*anyopaque,
+        alloc: Allocator,
+        _: []const u8,
+    ) generation_usage_provider.ResolveCredentialError!generation_usage_provider.ResolvedCredential {
+        const self: *AskContext = @ptrCast(@alignCast(raw.?));
+        if (self.api_key.len == 0) return error.Unavailable;
+        const token = try alloc.dupe(u8, self.api_key);
+        errdefer alloc.free(token);
+        return .{
+            .token = token,
+            .tenant = if (self.gateway_team) |team| try alloc.dupe(u8, team) else null,
+        };
+    }
+
+    fn prepareGenerationUsageDispatch(
+        raw: ?*anyopaque,
+        alloc: Allocator,
+    ) generation_usage_provider.PrepareError!generation_usage_provider.Dispatch {
+        const self: *AskContext = @ptrCast(@alignCast(raw.?));
+        if (self.connection_id.len == 0 or self.connection_credential_ref.len == 0) {
+            return error.Unavailable;
+        }
+        const adapter = self.cfg.gateway_provider.provider_adapter;
+        return generation_usage_provider.Dispatch.init(alloc, &.{.{
+            .id = self.connection_id,
+            .credential_ref = self.connection_credential_ref,
+            .provider = if (std.mem.eql(u8, self.connection_adapter_kind, adapter.kind))
+                adapter.generation_usage
+            else
+                null,
+        }}, .{
+            .context = self,
+            .resolve_fn = resolveGenerationUsageCredential,
+        });
     }
 
     fn cancelFlag(self: *AskContext) *std.atomic.Value(bool) {
@@ -972,6 +1009,7 @@ const AskContext = struct {
 
     fn toolContext(self: *AskContext) tool_runtime.Context {
         self.web_search_runtime.configure(.{
+            .connection_id = self.connection_id,
             .api_key = self.api_key,
             .gateway_team = self.gateway_team,
             .worker_model = self.model,
@@ -1572,10 +1610,18 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         break :credential owned_route_credential.?;
     };
     const api_key = credential.token;
+    ctx.connection_id = profile.id;
+    ctx.connection_adapter_kind = profile.adapter_id;
+    ctx.connection_credential_ref = profile.credential_ref;
     ctx.api_key = api_key;
     ctx.gateway_team = credential.gatewayTeam();
     ctx.credential_source = credential.source;
     ctx.model_catalog_access = credentials.catalogAccessForCredential(credential.source, api_key, credential.gatewayTeam());
+    ctx.session.usage.configureReconciliationSource(.{
+        .context = &ctx,
+        .prepare_fn = AskContext.prepareGenerationUsageDispatch,
+    });
+    ctx.session.usage.startReconciliation(alloc);
 
     const restored_image_catalog = try ctx.session.snapshotImageCatalog(alloc, &.{});
     defer types.freeImageAttachmentSlice(alloc, restored_image_catalog);
@@ -7522,8 +7568,8 @@ test "current ask state releases partial snapshots on allocation failure" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     const writable = &ctx.writable.?;
 
@@ -7818,8 +7864,8 @@ test "saved ask settles profile publication before persistence teardown" {
         1,
         .observed_generation,
         generation_id,
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try ctx.session.usage.applyGeneration(alloc, .{
         .id = generation_id,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2107,7 +2107,7 @@ fn resolveModelCapabilities(raw_ctx: *anyopaque, _: Allocator, model: []const u8
     const catalog = gateway_provider.modelCatalogForAdapter(
         ctx.connection_adapter_kind,
         adapter,
-    ) orelse return adapter.model_descriptors.fallback(model);
+    ) orelse return adapter.model_descriptors.fallback(model).capabilities;
     return ctx.capability_resolver.resolve(
         ctx.alloc,
         catalog,

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -808,6 +808,7 @@ fn runNonInteractiveWithDeps(
                 cfg.default_agent_step_limit,
             );
             defer startup.deinit(alloc);
+            try startup.normalizeModel(alloc, cfg.gateway_provider.provider_adapter.model_descriptors);
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
             const mcp_config_diagnostic = try cfg.inspect_mcp_profile_config(alloc);
 
@@ -839,6 +840,7 @@ fn runNonInteractiveWithDeps(
                 cfg.gateway_provider.connection_seed,
             );
             defer startup.deinit(alloc);
+            try startup.normalizeModels(alloc, cfg.gateway_provider.provider_adapter.model_descriptors);
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
             const rules = try permissionRulesForSnapshot(alloc, startup.permission_rules);
             defer if (rules.rules.len > 0) alloc.free(rules.rules);
@@ -869,15 +871,30 @@ fn runNonInteractiveWithDeps(
                 cfg.gateway_provider.connection_seed,
             );
             defer startup.deinit(alloc);
+            try startup.normalizeModels(alloc, cfg.gateway_provider.provider_adapter.model_descriptors);
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
 
             const catalog_access = startup.modelCatalogAccess();
-            const loaded = switch (cfg.gateway_provider.cli_model_catalog.fetch(alloc, .{
-                .access = catalog_access,
-                .endpoint = cfg.models_path,
-            })) {
+            const adapter = cfg.gateway_provider.provider_adapter;
+            const selected_adapter_id = if (startup.connections) |*connections|
+                connections.selectedProfile().adapter_id
+            else
+                cfg.gateway_provider.connection_seed.adapter_id;
+            const result = if (std.mem.eql(u8, selected_adapter_id, adapter.kind) and
+                adapter.model_catalog != null)
+                model_catalog.fetchWithPublicFallback(adapter.model_catalog.?, alloc, .{
+                    .access = catalog_access,
+                    .endpoint = cfg.models_path,
+                })
+            else
+                model_catalog.FetchResult{ .failed = .{
+                    .access = .init(catalog_access),
+                    .anonymous_fallback_used = false,
+                    .failure = .{ .category = .runtime },
+                } };
+            const loaded = switch (result) {
                 .loaded => |loaded| loaded,
-                .failure => |failure| {
+                .failed => |failure| {
                     const error_name = @errorName(failure.failure.asError());
                     const message = try std.fmt.allocPrint(
                         alloc,
@@ -901,7 +918,9 @@ fn runNonInteractiveWithDeps(
                     return .handled_failure;
                 },
             };
-            var ids = loaded.ids;
+            var catalog = loaded.catalog;
+            defer model_catalog.freeModelCatalog(alloc, &catalog);
+            var ids = try model_catalog.projectModelIds(alloc, catalog.items);
             defer collections.freeStringList(alloc, &ids);
 
             const text = try (output_contracts.ModelListSnapshot{
@@ -1220,6 +1239,7 @@ fn runNonInteractiveWithDeps(
                 return .handled_failure;
             };
             defer startup.deinit(alloc);
+            try startup.normalizeModels(alloc, cfg.gateway_provider.provider_adapter.model_descriptors);
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
 
             if (opts.action == null) {
@@ -1276,6 +1296,7 @@ fn runNonInteractiveWithDeps(
                 cfg.gateway_provider.connection_seed,
             );
             defer startup.deinit(alloc);
+            try startup.normalizeModels(alloc, cfg.gateway_provider.provider_adapter.model_descriptors);
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
 
             const adapter = cfg.gateway_provider.provider_adapter;
@@ -1363,6 +1384,7 @@ fn runNonInteractiveWithDeps(
                 return .handled_failure;
             };
             defer startup.deinit(alloc);
+            try startup.normalizeModels(alloc, cfg.gateway_provider.provider_adapter.model_descriptors);
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
 
             const channel = opts.channel orelse startup.update_channel;
@@ -4531,7 +4553,7 @@ test "runIfRequested model fetch failure is handled" {
     defer capture.deinit();
     var probe = ModelFetchProbe{ .outcome = .failure };
     var cfg = testConfig();
-    cfg.gateway_provider.cli_model_catalog = probe.provider();
+    cfg.gateway_provider.provider_adapter.model_catalog = probe.provider();
 
     var deps = capture.deps();
     deps.load_startup_state = failingStartupState;
@@ -4550,7 +4572,7 @@ test "runIfRequested model fetch failure preserves json output" {
     defer capture.deinit();
     var probe = ModelFetchProbe{ .outcome = .failure };
     var cfg = testConfig();
-    cfg.gateway_provider.cli_model_catalog = probe.provider();
+    cfg.gateway_provider.provider_adapter.model_catalog = probe.provider();
 
     var deps = capture.deps();
     deps.load_catalog_startup_state = stubLoadCatalogStartupState;
@@ -4574,7 +4596,7 @@ test "runIfRequested model provider cancellation is handled" {
     defer capture.deinit();
     var probe = ModelFetchProbe{ .outcome = .cancelled };
     var cfg = testConfig();
-    cfg.gateway_provider.cli_model_catalog = probe.provider();
+    cfg.gateway_provider.provider_adapter.model_catalog = probe.provider();
 
     var deps = capture.deps();
     deps.load_catalog_startup_state = stubLoadCatalogStartupState;
@@ -4592,7 +4614,7 @@ test "runIfRequested models passes startup team to fetch seam" {
     defer capture.deinit();
     var probe = ModelFetchProbe{};
     var cfg = testConfig();
-    cfg.gateway_provider.cli_model_catalog = probe.provider();
+    cfg.gateway_provider.provider_adapter.model_catalog = probe.provider();
 
     var deps = capture.deps();
     deps.load_catalog_startup_state = stubLoadCatalogStartupState;
@@ -4604,6 +4626,27 @@ test "runIfRequested models passes startup team to fetch seam" {
         "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[\"private/blue-hornbill\"]}\n",
         capture.stdout.written(),
     );
+}
+
+test "model catalog does not fall back across adapter kinds" {
+    var capture = CaptureOutput.init(std.testing.allocator);
+    defer capture.deinit();
+    var probe = ModelFetchProbe{};
+    var cfg = testConfig();
+    cfg.gateway_provider.provider_adapter.kind = "other-adapter";
+    cfg.gateway_provider.provider_adapter.model_catalog = probe.provider();
+
+    var deps = capture.deps();
+    deps.load_catalog_startup_state = stubLoadCatalogStartupState;
+
+    const result = try runIfRequestedWithDeps(
+        std.testing.allocator,
+        &.{@constCast("models")},
+        cfg,
+        deps,
+    );
+    try std.testing.expectEqual(RunResult.handled_failure, result);
+    try std.testing.expect(!probe.called);
 }
 
 test "runIfRequested credits renders through the configured provider" {
@@ -5129,7 +5172,7 @@ const ModelFetchProbe = struct {
     called: bool = false,
     outcome: Outcome = .success,
 
-    fn provider(self: *ModelFetchProbe) gateway_provider.CliModelCatalogProvider {
+    fn provider(self: *ModelFetchProbe) model_catalog.Provider {
         return .{
             .context = self,
             .fetch_fn = fetch,
@@ -5137,21 +5180,16 @@ const ModelFetchProbe = struct {
     }
 
     fn failure(
-        input: gateway_provider.CliModelCatalogInput,
         category: model_catalog.FailureCategory,
-    ) gateway_provider.CliModelCatalogResult {
-        return .{ .failure = .{
-            .access = .init(input.access),
-            .anonymous_fallback_used = false,
-            .failure = .{ .category = category },
-        } };
+    ) model_catalog.ProviderResult {
+        return .{ .failure = .{ .category = category } };
     }
 
     fn fetch(
         raw: ?*anyopaque,
         alloc: Allocator,
-        input: gateway_provider.CliModelCatalogInput,
-    ) gateway_provider.CliModelCatalogResult {
+        input: model_catalog.FetchInput,
+    ) Allocator.Error!model_catalog.ProviderResult {
         const self: *ModelFetchProbe = @ptrCast(@alignCast(raw.?));
         self.called = true;
         if (!std.mem.eql(u8, input.access.authorizationCredential() orelse "", "test-key") or
@@ -5160,27 +5198,23 @@ const ModelFetchProbe = struct {
             !std.mem.eql(u8, input.endpoint, "/v1/models") or
             input.cancel_flag != null)
         {
-            return failure(input, .runtime);
+            return failure(.runtime);
         }
 
         switch (self.outcome) {
-            .failure => return failure(input, .runtime),
-            .cancelled => return failure(input, .cancellation),
+            .failure => return failure(.runtime),
+            .cancelled => return failure(.cancellation),
             .success => {},
         }
 
-        var ids: std.ArrayList([]u8) = .empty;
-        const id = alloc.dupe(u8, "private/blue-hornbill") catch {
-            return failure(input, .resource_exhausted);
-        };
-        ids.append(alloc, id) catch {
-            alloc.free(id);
-            return failure(input, .resource_exhausted);
-        };
-        return .{ .loaded = .{
-            .ids = ids,
-            .provenance = .{ .access = .init(input.access) },
-        } };
+        var catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+        errdefer model_catalog.freeModelCatalog(alloc, &catalog);
+        const id = try alloc.dupe(u8, "private/blue-hornbill");
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        try catalog.append(alloc, .{ .id = id, .model_type = model_type });
+        return .{ .catalog = catalog };
     }
 };
 

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -1278,10 +1278,24 @@ fn runNonInteractiveWithDeps(
             defer startup.deinit(alloc);
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
 
-            var snapshot = cfg.gateway_provider.credits.fetch(alloc, .{
-                .credential = startup.apiKey(),
-                .tenant = startup.gatewayTeam(),
-            });
+            const adapter = cfg.gateway_provider.provider_adapter;
+            const selected_adapter_id = if (startup.connections) |*connections|
+                connections.selectedProfile().adapter_id
+            else
+                cfg.gateway_provider.connection_seed.adapter_id;
+            var snapshot = if (std.mem.eql(u8, selected_adapter_id, adapter.kind) and
+                adapter.account_usage != null)
+                adapter.account_usage.?.fetch(alloc, .{
+                    .credential = startup.apiKey(),
+                    .tenant = startup.gatewayTeam(),
+                })
+            else
+                output_contracts.CreditsSnapshot{
+                    .err_message = try alloc.dupe(
+                        u8,
+                        "account usage unavailable for selected connection",
+                    ),
+                };
             defer snapshot.deinit(alloc);
             const text = try snapshot.render(alloc, opts.format);
             defer alloc.free(text);
@@ -4597,7 +4611,7 @@ test "runIfRequested credits renders through the configured provider" {
     defer capture.deinit();
     var probe = CreditsProviderProbe{ .outcome = .success };
     var cfg = testConfig();
-    cfg.gateway_provider.credits = probe.provider();
+    cfg.gateway_provider.provider_adapter.account_usage = probe.provider();
 
     var deps = capture.deps();
     deps.load_startup_state = stubLoadStartupState;
@@ -4612,12 +4626,36 @@ test "runIfRequested credits renders through the configured provider" {
     );
 }
 
+test "account usage does not fall back across adapter kinds" {
+    var capture = CaptureOutput.init(std.testing.allocator);
+    defer capture.deinit();
+    var probe = CreditsProviderProbe{ .outcome = .success };
+    var cfg = testConfig();
+    cfg.gateway_provider.provider_adapter.kind = "other";
+    cfg.gateway_provider.provider_adapter.account_usage = probe.provider();
+    var deps = capture.deps();
+    deps.load_startup_state = stubLoadStartupState;
+
+    const result = try runIfRequestedWithDeps(
+        std.testing.allocator,
+        &.{ @constCast("credits"), @constCast("--json") },
+        cfg,
+        deps,
+    );
+    try std.testing.expectEqual(RunResult.handled_failure, result);
+    try std.testing.expectEqual(@as(usize, 0), probe.calls);
+    try std.testing.expectEqualStrings(
+        "{\"kind\":\"credits\",\"error\":\"account usage unavailable for selected connection\"}\n",
+        capture.stdout.written(),
+    );
+}
+
 test "runIfRequested credits failures use nonzero text and json contracts" {
     var text_capture = CaptureOutput.init(std.testing.allocator);
     defer text_capture.deinit();
     var text_probe = CreditsProviderProbe{ .outcome = .failure };
     var text_cfg = testConfig();
-    text_cfg.gateway_provider.credits = text_probe.provider();
+    text_cfg.gateway_provider.provider_adapter.account_usage = text_probe.provider();
     var text_deps = text_capture.deps();
     text_deps.load_startup_state = stubLoadStartupState;
 
@@ -4638,7 +4676,7 @@ test "runIfRequested credits failures use nonzero text and json contracts" {
     defer json_capture.deinit();
     var json_probe = CreditsProviderProbe{ .outcome = .failure };
     var json_cfg = testConfig();
-    json_cfg.gateway_provider.credits = json_probe.provider();
+    json_cfg.gateway_provider.provider_adapter.account_usage = json_probe.provider();
     var json_deps = json_capture.deps();
     json_deps.load_startup_state = stubLoadStartupState;
 
@@ -5168,7 +5206,7 @@ const CreditsProviderProbe = struct {
     calls: usize = 0,
     saw_expected_input: bool = false,
 
-    fn provider(self: *CreditsProviderProbe) gateway_provider.CreditsProvider {
+    fn provider(self: *CreditsProviderProbe) gateway_provider.account_usage_provider.Provider {
         return .{
             .context = self,
             .fetch_fn = fetch,
@@ -5178,7 +5216,7 @@ const CreditsProviderProbe = struct {
     fn fetch(
         raw: ?*anyopaque,
         alloc: Allocator,
-        input: gateway_provider.CreditsLookupInput,
+        input: gateway_provider.account_usage_provider.Input,
     ) output_contracts.CreditsSnapshot {
         const self: *CreditsProviderProbe = @ptrCast(@alignCast(raw.?));
         self.calls += 1;

--- a/src/core/gateway/account_usage_provider.zig
+++ b/src/core/gateway/account_usage_provider.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const output_contracts = @import("../output/output_contracts.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const Input = struct {
+    credential: ?[]const u8,
+    tenant: ?[]const u8,
+};
+
+pub const Provider = struct {
+    /// When set, context must remain valid until every in-flight fetch returns.
+    context: ?*anyopaque = null,
+    fetch_fn: *const fn (
+        ?*anyopaque,
+        Allocator,
+        Input,
+    ) output_contracts.CreditsSnapshot,
+
+    /// Account usage is limited to balance, credits, and limits. The returned
+    /// snapshot owns its populated fields; the caller must call `deinit`.
+    pub fn fetch(
+        self: Provider,
+        alloc: Allocator,
+        input: Input,
+    ) output_contracts.CreditsSnapshot {
+        return self.fetch_fn(self.context, alloc, input);
+    }
+};

--- a/src/core/gateway/gateway_provider.zig
+++ b/src/core/gateway/gateway_provider.zig
@@ -6,7 +6,6 @@ const oauth_transport = @import("../auth/oauth_transport.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const output_contracts = @import("../output/output_contracts.zig");
-const web_search_provider = @import("../tooling/web_search_provider.zig");
 const connection_registry = @import("connection_registry.zig");
 const model_catalog = @import("model_catalog.zig");
 const model_catalog_metadata = @import("model_catalog_metadata.zig");
@@ -25,50 +24,12 @@ pub const ChatUrlProvider = struct {
     }
 };
 
-pub const CliModelCatalogInput = struct {
-    access: credentials.CatalogAccess = .{ .public_only = .no_credential },
-    endpoint: []const u8,
-    cancel_flag: ?*std.atomic.Value(bool) = null,
-};
-
-pub const CliModelCatalogResult = union(enum) {
-    loaded: struct {
-        /// Owned model id strings; the caller frees them with `collections.freeStringList`.
-        ids: std.ArrayList([]u8),
-        provenance: model_catalog.Provenance,
-    },
-    failure: model_catalog.FailedOutcome,
-};
-
-pub const FetchCliModelCatalogFn = *const fn (
-    ?*anyopaque,
-    Allocator,
-    CliModelCatalogInput,
-) CliModelCatalogResult;
-
-pub const CliModelCatalogProvider = struct {
-    /// When set, context must remain valid until every in-flight `fetch` returns.
-    context: ?*anyopaque = null,
-    fetch_fn: FetchCliModelCatalogFn,
-
-    pub fn fetch(
-        self: CliModelCatalogProvider,
-        alloc: Allocator,
-        input: CliModelCatalogInput,
-    ) CliModelCatalogResult {
-        return self.fetch_fn(self.context, alloc, input);
-    }
-};
-
 pub const Provider = struct {
     connection_seed: connection_registry.Seed,
     agent_stream: agent_stream_provider.Provider,
     provider_adapter: agent_stream_provider.ProviderAdapter,
     oauth_transport: oauth_transport.Provider,
     chat_url: ChatUrlProvider,
-    cli_model_catalog: CliModelCatalogProvider,
-    web_search: web_search_provider.Provider,
-    model_catalog: model_catalog.Provider,
 };
 
 test "account usage lookup dispatches through the injected provider" {
@@ -113,6 +74,14 @@ const CapabilityResolverState = enum {
     ready,
     failed,
 };
+
+pub fn modelCatalogForAdapter(
+    admitted_adapter_kind: []const u8,
+    adapter: agent_stream_provider.ProviderAdapter,
+) ?model_catalog.Provider {
+    if (!std.mem.eql(u8, admitted_adapter_kind, adapter.kind)) return null;
+    return adapter.model_catalog;
+}
 
 pub const CapabilityResolver = struct {
     catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty,
@@ -268,6 +237,24 @@ const FakeCatalog = struct {
         };
     }
 };
+
+test "model catalog selection requires the admitted adapter kind" {
+    var fake = FakeCatalog{ .outcome = .ready };
+    const adapter = agent_stream_provider.ProviderAdapter{
+        .kind = "matching-adapter",
+        .model_catalog = fake.provider(),
+        .stream_fn = agent_stream_provider.unavailable_adapter.stream_fn,
+    };
+
+    const matching = modelCatalogForAdapter("matching-adapter", adapter).?;
+    try std.testing.expect(matching.context.? == @as(*anyopaque, @ptrCast(&fake)));
+    try std.testing.expect(modelCatalogForAdapter("other-adapter", adapter) == null);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+
+    var without_catalog = adapter;
+    without_catalog.model_catalog = null;
+    try std.testing.expect(modelCatalogForAdapter("matching-adapter", without_catalog) == null);
+}
 
 test "available capabilities never fetch and use a completed catalog snapshot" {
     const alloc = std.testing.allocator;

--- a/src/core/gateway/gateway_provider.zig
+++ b/src/core/gateway/gateway_provider.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 const agent_stream_provider = @import("../agent/stream_provider.zig");
+pub const account_usage_provider = @import("account_usage_provider.zig");
 const credentials = @import("../auth/credentials.zig");
 const oauth_transport = @import("../auth/oauth_transport.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
-const generation_usage_provider = @import("../session/generation_usage_provider.zig");
 const output_contracts = @import("../output/output_contracts.zig");
 const web_search_provider = @import("../tooling/web_search_provider.zig");
 const connection_registry = @import("connection_registry.zig");
@@ -60,33 +60,6 @@ pub const CliModelCatalogProvider = struct {
     }
 };
 
-pub const CreditsLookupInput = struct {
-    credential: ?[]const u8,
-    tenant: ?[]const u8,
-};
-
-pub const FetchCreditsFn = *const fn (
-    ?*anyopaque,
-    Allocator,
-    CreditsLookupInput,
-) output_contracts.CreditsSnapshot;
-
-pub const CreditsProvider = struct {
-    /// When set, context must remain valid until every in-flight `fetch` returns.
-    context: ?*anyopaque = null,
-    fetch_fn: FetchCreditsFn,
-
-    /// The returned snapshot owns its populated provider fields. The caller
-    /// must call `CreditsSnapshot.deinit`.
-    pub fn fetch(
-        self: CreditsProvider,
-        alloc: Allocator,
-        input: CreditsLookupInput,
-    ) output_contracts.CreditsSnapshot {
-        return self.fetch_fn(self.context, alloc, input);
-    }
-};
-
 pub const Provider = struct {
     connection_seed: connection_registry.Seed,
     agent_stream: agent_stream_provider.Provider,
@@ -94,13 +67,11 @@ pub const Provider = struct {
     oauth_transport: oauth_transport.Provider,
     chat_url: ChatUrlProvider,
     cli_model_catalog: CliModelCatalogProvider,
-    credits: CreditsProvider,
-    generation_usage: generation_usage_provider.Provider,
     web_search: web_search_provider.Provider,
     model_catalog: model_catalog.Provider,
 };
 
-test "credits lookup dispatches through the injected provider" {
+test "account usage lookup dispatches through the injected provider" {
     const Fake = struct {
         calls: usize = 0,
         saw_expected_input: bool = false,
@@ -108,7 +79,7 @@ test "credits lookup dispatches through the injected provider" {
         fn fetch(
             raw: ?*anyopaque,
             alloc: Allocator,
-            input: CreditsLookupInput,
+            input: account_usage_provider.Input,
         ) output_contracts.CreditsSnapshot {
             const self: *@This() = @ptrCast(@alignCast(raw.?));
             self.calls += 1;
@@ -122,7 +93,7 @@ test "credits lookup dispatches through the injected provider" {
     };
 
     var fake: Fake = .{};
-    const provider = CreditsProvider{
+    const provider = account_usage_provider.Provider{
         .context = &fake,
         .fetch_fn = Fake.fetch,
     };

--- a/src/core/session/generation_usage_provider.zig
+++ b/src/core/session/generation_usage_provider.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
+const secret = @import("../auth/secret.zig");
 
 const Allocator = std.mem.Allocator;
 
 pub const LookupInput = struct {
     credential: []const u8,
     tenant: ?[]const u8,
-    origin: []const u8,
+    lookup_scope: ?[]const u8,
     generation_id: []const u8,
     cancel_flag: *std.atomic.Value(bool),
 };
@@ -41,10 +42,7 @@ pub const LookupOutcome = union(enum) {
     }
 };
 
-pub const LookupError = Allocator.Error || error{
-    Cancelled,
-    Unavailable,
-};
+pub const LookupError = Allocator.Error || error{Cancelled};
 
 pub const LookupFn = *const fn (
     context: ?*anyopaque,
@@ -73,11 +71,160 @@ fn lookupUnavailable(
     _: Allocator,
     _: LookupInput,
 ) LookupError!LookupOutcome {
-    return error.Unavailable;
+    return .preserve_pending;
 }
 
 pub const unavailable_provider = Provider{
     .lookup_fn = lookupUnavailable,
+};
+
+pub const ResolvedCredential = struct {
+    token: []u8,
+    tenant: ?[]u8 = null,
+
+    pub fn deinit(self: *ResolvedCredential, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.token);
+        if (self.tenant) |tenant| alloc.free(tenant);
+        self.* = undefined;
+    }
+};
+
+pub const ResolveCredentialError = Allocator.Error || error{
+    Cancelled,
+    Unavailable,
+};
+
+pub const CredentialResolver = struct {
+    /// When set, context must outlive every prepared dispatch using it.
+    context: ?*anyopaque = null,
+    resolve_fn: *const fn (
+        context: ?*anyopaque,
+        alloc: Allocator,
+        credential_ref: []const u8,
+    ) ResolveCredentialError!ResolvedCredential,
+
+    pub fn resolve(
+        self: CredentialResolver,
+        alloc: Allocator,
+        credential_ref: []const u8,
+    ) ResolveCredentialError!ResolvedCredential {
+        return self.resolve_fn(self.context, alloc, credential_ref);
+    }
+};
+
+pub const ConnectionInput = struct {
+    id: []const u8,
+    credential_ref: []const u8,
+    provider: ?Provider,
+};
+
+const Connection = struct {
+    id: []u8,
+    credential_ref: []u8,
+    provider: ?Provider,
+
+    fn init(alloc: Allocator, input: ConnectionInput) Allocator.Error!Connection {
+        const id = try alloc.dupe(u8, input.id);
+        errdefer alloc.free(id);
+        return .{
+            .id = id,
+            .credential_ref = try alloc.dupe(u8, input.credential_ref),
+            .provider = input.provider,
+        };
+    }
+
+    fn deinit(self: *Connection, alloc: Allocator) void {
+        alloc.free(self.id);
+        alloc.free(self.credential_ref);
+        self.* = undefined;
+    }
+};
+
+/// Owned, immutable connection routing prepared on the application owner
+/// before the reconciliation worker starts. Credential bytes are resolved
+/// only by `lookup` and are never retained by this value.
+pub const Dispatch = struct {
+    connections: []Connection,
+    credential_resolver: CredentialResolver,
+
+    pub fn init(
+        alloc: Allocator,
+        inputs: []const ConnectionInput,
+        credential_resolver: CredentialResolver,
+    ) Allocator.Error!Dispatch {
+        const connections = try alloc.alloc(Connection, inputs.len);
+        errdefer alloc.free(connections);
+        var initialized: usize = 0;
+        errdefer for (connections[0..initialized]) |*connection| connection.deinit(alloc);
+        for (inputs, 0..) |input, index| {
+            connections[index] = try Connection.init(alloc, input);
+            initialized += 1;
+        }
+        return .{
+            .connections = connections,
+            .credential_resolver = credential_resolver,
+        };
+    }
+
+    pub fn deinit(self: *Dispatch, alloc: Allocator) void {
+        for (self.connections) |*connection| connection.deinit(alloc);
+        alloc.free(self.connections);
+        self.* = undefined;
+    }
+
+    pub fn lookup(
+        self: Dispatch,
+        alloc: Allocator,
+        connection_id: []const u8,
+        generation_id: []const u8,
+        lookup_scope: ?[]const u8,
+        cancel_flag: *std.atomic.Value(bool),
+    ) LookupError!LookupOutcome {
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        const connection = for (self.connections) |connection| {
+            if (std.mem.eql(u8, connection.id, connection_id)) break connection;
+        } else return .preserve_pending;
+        const provider = connection.provider orelse return .preserve_pending;
+        var credential = self.credential_resolver.resolve(
+            alloc,
+            connection.credential_ref,
+        ) catch |err| switch (err) {
+            error.Cancelled => return error.Cancelled,
+            error.OutOfMemory => return error.OutOfMemory,
+            error.Unavailable => return .preserve_pending,
+        };
+        defer credential.deinit(alloc);
+        return provider.lookup(alloc, .{
+            .credential = credential.token,
+            .tenant = credential.tenant,
+            .lookup_scope = lookup_scope,
+            .generation_id = generation_id,
+            .cancel_flag = cancel_flag,
+        });
+    }
+};
+
+pub const PrepareError = Allocator.Error || error{Unavailable};
+
+pub const Source = struct {
+    /// Preparation runs on the owning application thread before worker spawn.
+    context: ?*anyopaque = null,
+    prepare_fn: *const fn (
+        context: ?*anyopaque,
+        alloc: Allocator,
+    ) PrepareError!Dispatch,
+
+    pub fn prepare(self: Source, alloc: Allocator) PrepareError!Dispatch {
+        return self.prepare_fn(self.context, alloc);
+    }
+};
+
+fn prepareUnavailable(_: ?*anyopaque, _: Allocator) PrepareError!Dispatch {
+    return error.Unavailable;
+}
+
+pub const unavailable_source = Source{
+    .prepare_fn = prepareUnavailable,
 };
 
 test "generation usage lookup dispatches through the injected provider" {
@@ -94,7 +241,8 @@ test "generation usage lookup dispatches through the injected provider" {
             self.calls += 1;
             self.saw_expected_input =
                 std.mem.eql(u8, "credential", input.credential) and
-                std.mem.eql(u8, "generation", input.generation_id);
+                std.mem.eql(u8, "generation", input.generation_id) and
+                std.mem.eql(u8, "scope", input.lookup_scope.?);
             const id = try alloc.dupe(u8, input.generation_id);
             errdefer alloc.free(id);
             const model = try alloc.dupe(u8, "provider/model");
@@ -120,7 +268,7 @@ test "generation usage lookup dispatches through the injected provider" {
     var outcome = try provider.lookup(std.testing.allocator, .{
         .credential = "credential",
         .tenant = null,
-        .origin = "https://provider.example",
+        .lookup_scope = "scope",
         .generation_id = "generation",
         .cancel_flag = &cancel,
     });
@@ -129,4 +277,72 @@ test "generation usage lookup dispatches through the injected provider" {
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
     try std.testing.expect(fake.saw_expected_input);
     try std.testing.expectEqualStrings("provider/model", outcome.found.model);
+}
+
+test "generation usage dispatch is connection scoped and missing connections are effect free" {
+    const Fake = struct {
+        calls: usize = 0,
+        resolved: usize = 0,
+
+        fn resolve(
+            raw: ?*anyopaque,
+            alloc: Allocator,
+            credential_ref: []const u8,
+        ) ResolveCredentialError!ResolvedCredential {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.resolved += 1;
+            return .{ .token = try alloc.dupe(u8, credential_ref) };
+        }
+
+        fn lookup(
+            raw: ?*anyopaque,
+            _: Allocator,
+            input: LookupInput,
+        ) LookupError!LookupOutcome {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.calls += 1;
+            if (!std.mem.eql(u8, "credential-a", input.credential)) return error.Cancelled;
+            return .retry;
+        }
+    };
+
+    var fake: Fake = .{};
+    const provider = Provider{ .context = &fake, .lookup_fn = Fake.lookup };
+    var dispatch = try Dispatch.init(
+        std.testing.allocator,
+        &.{.{
+            .id = "connection-a",
+            .credential_ref = "credential-a",
+            .provider = provider,
+        }},
+        .{ .context = &fake, .resolve_fn = Fake.resolve },
+    );
+    defer dispatch.deinit(std.testing.allocator);
+    var cancel = std.atomic.Value(bool).init(false);
+
+    try std.testing.expectEqual(
+        LookupOutcome.retry,
+        try dispatch.lookup(
+            std.testing.allocator,
+            "connection-a",
+            "generation-a",
+            "scope-a",
+            &cancel,
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), fake.resolved);
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+
+    try std.testing.expectEqual(
+        LookupOutcome.preserve_pending,
+        try dispatch.lookup(
+            std.testing.allocator,
+            "missing",
+            "generation-missing",
+            "scope-missing",
+            &cancel,
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 1), fake.resolved);
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
 }

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -7,7 +7,6 @@ const text_utils = @import("../shared/text_utils.zig");
 const tool_result_errors = @import("../tooling/tool_result_errors.zig");
 const session_permission_state = @import("../permissions/session_permission_state.zig");
 const image_attachments = @import("../images/image_attachments.zig");
-const generation_usage_provider = @import("generation_usage_provider.zig");
 const web_fetch_artifacts = @import("web_fetch_artifacts.zig");
 pub const session_usage = @import("session_usage.zig");
 pub const profile_usage_runtime = @import("profile_usage_runtime.zig");
@@ -1593,12 +1592,8 @@ pub const SessionRuntime = struct {
     max_history_turns: usize,
     context_history_start: usize = 0,
 
-    pub fn init(
-        max_history_turns: usize,
-        provider: generation_usage_provider.Provider,
-    ) SessionRuntime {
+    pub fn init(max_history_turns: usize) SessionRuntime {
         return .{
-            .usage = session_usage.Usage.initFreshWithProvider(provider),
             .max_history_turns = max_history_turns,
         };
     }
@@ -2282,8 +2277,8 @@ test "unavailable profile usage keeps reconciled generation pending in host runt
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try runtime.usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -2342,8 +2337,8 @@ test "readable profile usage does not attach publishers or flush recovery" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try runtime.usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -2564,8 +2564,8 @@ test "durable state round trips live history while discarding legacy authority" 
         25,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     var usage = try usage_runtime.snapshot(alloc);
     defer usage.deinit(alloc);

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -1305,6 +1305,7 @@ pub const Root = struct {
                 boundary.usage_sidecar,
                 state.id,
                 state.updated_at_ms,
+                pendingConnectionAuthority(state),
                 usage,
             );
         }
@@ -2408,6 +2409,7 @@ fn restoreUsageSidecar(
             dir,
             state.id,
             state.updated_at_ms,
+            pendingConnectionAuthority(state.*),
             usage,
         );
         return outcome != .restored;
@@ -2457,6 +2459,7 @@ fn restoreEncodedUsageSidecarBestEffort(
             .{ .encoded = @constCast(encoded) },
             loaded.state.id,
             loaded.state.updated_at_ms,
+            pendingConnectionAuthority(loaded.state),
             usage,
         ) catch |err| {
             debug_trace.logf(
@@ -2466,6 +2469,15 @@ fn restoreEncodedUsageSidecarBestEffort(
             );
         };
     }
+}
+
+fn pendingConnectionAuthority(
+    state: session_codec.DurableSessionState,
+) session_usage_sidecar.PendingConnectionAuthority {
+    return if (state.preferences.connection_id) |connection_id|
+        .{ .current = connection_id }
+    else
+        .historical_vercel;
 }
 
 fn traceUsageSidecarWriteFailure(err: anyerror) void {
@@ -4914,8 +4926,8 @@ test "usage sidecar restores exact optional metrics after read-only and writable
         7,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -5092,8 +5104,8 @@ test "indeterminate canonical usage retry repairs the rich sidecar" {
         7,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -5164,8 +5176,8 @@ test "unwritable usage sidecar keeps canonical usage resumable and incomplete" {
         7,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -19,7 +19,6 @@ const max_lookup_scope_bytes: usize = 2048;
 const max_identifier_bytes: usize = 8 * 1024;
 const max_active_invocations: usize = 64;
 const shutdown_reconciliation_budget_ms: usize = 250;
-const rollback_null_lookup_scope = "legacy";
 pub const max_snapshot_bytes: usize = 256 * 1024;
 
 /// Completeness of the saved billing window rendered by `/cost`.
@@ -2004,7 +2003,11 @@ pub fn writeSnapshot(writer: *std.Io.Writer, snapshot: Snapshot) !void {
         if (pending.lookup_scope) |scope| {
             try std.json.Stringify.value(scope, .{}, writer);
         } else {
-            try std.json.Stringify.value(rollback_null_lookup_scope, .{}, writer);
+            try std.json.Stringify.value(
+                types.null_generation_lookup_scope_sentinel,
+                .{},
+                writer,
+            );
         }
         try writer.writeAll(",\"team\":null");
         try writer.writeByte('}');
@@ -2255,7 +2258,11 @@ pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
         errdefer alloc.free(connection_id);
         const lookup_scope = switch (lookup_scope_value) {
             .null => null,
-            .string => |text| try alloc.dupe(u8, text),
+            .string => |text| if (legacy_pending and std.mem.eql(
+                u8,
+                text,
+                types.null_generation_lookup_scope_sentinel,
+            )) null else try alloc.dupe(u8, text),
             else => unreachable,
         };
         errdefer if (lookup_scope) |text| alloc.free(text);
@@ -2687,12 +2694,6 @@ pub fn rebindPendingConnection(
             pending.connection_id = value;
             replacement.* = null;
         }
-        if (pending.lookup_scope) |scope| {
-            if (std.mem.eql(u8, scope, rollback_null_lookup_scope)) {
-                alloc.free(scope);
-                pending.lookup_scope = null;
-            }
-        }
     }
 }
 
@@ -2721,7 +2722,9 @@ fn validateConnectionId(connection_id: []const u8) !void {
 }
 
 fn validateLookupScope(scope: []const u8) !void {
-    if (scope.len == 0 or scope.len > max_lookup_scope_bytes) {
+    if (scope.len == 0 or scope.len > max_lookup_scope_bytes or
+        std.mem.eql(u8, scope, types.null_generation_lookup_scope_sentinel))
+    {
         return error.InvalidGenerationLookupScope;
     }
     for (scope) |char| {
@@ -4758,6 +4761,47 @@ test "pending generation routing inputs remain bounded" {
         error.InvalidGenerationLookupScope,
         validateLookupScope(&oversized),
     );
+}
+
+test "pending connection rebind is allocation atomic" {
+    const alloc = std.testing.allocator;
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+    for ([_][]const u8{ "request-a", "request-b" }) |id| {
+        const sequence = try usage.reserveInvocation();
+        try usage.finishObservedInvocation(
+            alloc,
+            sequence,
+            1,
+            .observed_generation,
+            id,
+            "vercel",
+            null,
+        );
+    }
+
+    var probe_snapshot = try usage.snapshot(alloc);
+    var probe = std.testing.FailingAllocator.init(alloc, .{});
+    try rebindPendingConnection(probe.allocator(), &probe_snapshot, "connection-a");
+    const allocation_count = probe.alloc_index;
+    probe_snapshot.deinit(alloc);
+
+    for (0..allocation_count) |fail_index| {
+        var snapshot = try usage.snapshot(alloc);
+        defer snapshot.deinit(alloc);
+        var failing = std.testing.FailingAllocator.init(
+            alloc,
+            .{ .fail_index = fail_index },
+        );
+        try std.testing.expectError(
+            error.OutOfMemory,
+            rebindPendingConnection(failing.allocator(), &snapshot, "connection-a"),
+        );
+        try std.testing.expect(failing.has_induced_failure);
+        for (snapshot.pending) |pending| {
+            try std.testing.expectEqualStrings("vercel", pending.connection_id);
+        }
+    }
 }
 
 test "reconciliation retry delay observes cancellation promptly" {

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const secret = @import("../auth/secret.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const generation_fact_codec = @import("generation_fact_codec.zig");
 const generation_usage = @import("generation_usage_provider.zig");
@@ -9,15 +8,14 @@ const types = @import("../shared/types.zig");
 pub const usage_report = @import("usage_report.zig");
 
 const Allocator = std.mem.Allocator;
-const Sha256 = std.crypto.hash.sha2.Sha256;
 
 const max_models: usize = 32;
 const max_pending_generations: usize = 16;
 const max_publication_backlog: usize = 16;
 const max_usage_incidents: usize = 16;
 const max_model_bytes: usize = 1024;
-const max_origin_bytes: usize = 2048;
-const max_team_bytes: usize = 255;
+const max_connection_id_bytes: usize = 128;
+const max_lookup_scope_bytes: usize = 2048;
 const max_identifier_bytes: usize = 8 * 1024;
 const max_active_invocations: usize = 64;
 const shutdown_reconciliation_budget_ms: usize = 250;
@@ -108,8 +106,8 @@ pub const GatewayObservation = struct {
         alloc: Allocator,
         status: std.http.Status,
         completion: types.GatewayCompletion,
-        origin: []const u8,
-        team: ?[]const u8,
+        connection_id: []const u8,
+        lookup_scope: ?[]const u8,
     ) !void {
         const ledger = self.usage orelse return;
         const generation_id = completion.generation_id;
@@ -152,8 +150,8 @@ pub const GatewayObservation = struct {
             self.elapsedMs(),
             delivery,
             id,
-            origin,
-            team,
+            connection_id,
+            lookup_scope,
         );
         debug_trace.logf(
             "session",
@@ -226,28 +224,27 @@ pub const ModelAggregate = struct {
 pub const PendingGeneration = struct {
     id: []u8,
     sequence: u64,
-    origin: []u8,
-    team: ?[]u8,
+    connection_id: []u8,
+    lookup_scope: ?[]u8,
     observed_at_ms: ?i64 = null,
 
     fn deinit(self: *PendingGeneration, alloc: Allocator) void {
         alloc.free(self.id);
-        alloc.free(self.origin);
-        if (self.team) |team| alloc.free(team);
+        alloc.free(self.connection_id);
+        if (self.lookup_scope) |scope| alloc.free(scope);
         self.* = undefined;
     }
 
     fn dupe(self: PendingGeneration, alloc: Allocator) Allocator.Error!PendingGeneration {
         const id = try alloc.dupe(u8, self.id);
         errdefer alloc.free(id);
-        const origin = try alloc.dupe(u8, self.origin);
-        errdefer alloc.free(origin);
-        const team = if (self.team) |value| try alloc.dupe(u8, value) else null;
+        const connection_id = try alloc.dupe(u8, self.connection_id);
+        errdefer alloc.free(connection_id);
         return .{
             .id = id,
             .sequence = self.sequence,
-            .origin = origin,
-            .team = team,
+            .connection_id = connection_id,
+            .lookup_scope = if (self.lookup_scope) |value| try alloc.dupe(u8, value) else null,
             .observed_at_ms = self.observed_at_ms,
         };
     }
@@ -336,9 +333,7 @@ pub const Usage = struct {
     reconciliation_done: std.atomic.Value(bool) = .init(true),
     reconciliation_cancel: std.atomic.Value(bool) = .init(false),
     reconciliation_work_epoch: std.atomic.Value(u64) = .init(0),
-    reconciliation_key_digest: ?[Sha256.digest_length]u8 = null,
-    reconciliation_credential_blocked: bool = false,
-    generation_usage_provider: generation_usage.Provider = generation_usage.unavailable_provider,
+    reconciliation_source: generation_usage.Source = generation_usage.unavailable_source,
 
     pub fn initFresh() Usage {
         return .{
@@ -349,12 +344,6 @@ pub const Usage = struct {
             .reasoning_tokens = 0,
             .request_count = 0,
         };
-    }
-
-    pub fn initFreshWithProvider(provider: generation_usage.Provider) Usage {
-        var usage = initFresh();
-        usage.generation_usage_provider = provider;
-        return usage;
     }
 
     pub fn initLegacy() Usage {
@@ -442,6 +431,14 @@ pub const Usage = struct {
         if (sink != null) self.flushProfilePublications();
     }
 
+    pub fn configureReconciliationSource(
+        self: *Usage,
+        source: generation_usage.Source,
+    ) void {
+        self.stopReconciliation();
+        self.reconciliation_source = source;
+    }
+
     pub fn persistCheckpoint(self: *Usage) bool {
         self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
         defer self.checkpoint_mutex.unlock(io_mod.getIo());
@@ -479,8 +476,8 @@ pub const Usage = struct {
         duration_ms: u64,
         outcome: DeliveryOutcome,
         id: []const u8,
-        origin: []const u8,
-        team: ?[]const u8,
+        connection_id: []const u8,
+        lookup_scope: ?[]const u8,
     ) !void {
         self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
         self.finishObservedInvocation(
@@ -489,8 +486,8 @@ pub const Usage = struct {
             duration_ms,
             outcome,
             id,
-            origin,
-            team,
+            connection_id,
+            lookup_scope,
         ) catch |err| {
             self.markBillingIncomplete();
             _ = self.persistCheckpointBestEffortLocked();
@@ -558,17 +555,23 @@ pub const Usage = struct {
         duration_ms: u64,
         outcome: DeliveryOutcome,
         id: []const u8,
-        origin: []const u8,
-        team: ?[]const u8,
+        connection_id: []const u8,
+        lookup_scope: ?[]const u8,
     ) !void {
         try validateGenerationId(id);
-        try validateOrigin(origin);
-        if (team) |value| try validateTeam(value);
+        try validateConnectionId(connection_id);
+        if (lookup_scope) |value| try validateLookupScope(value);
 
         self.mutex.lockUncancelable(io_mod.getIo());
         defer self.mutex.unlock(io_mod.getIo());
         if (!self.finishInvocationUnlocked(sequence, duration_ms, outcome)) return;
-        self.observeGenerationUnlocked(alloc, sequence, id, origin, team) catch |err| {
+        self.observeGenerationUnlocked(
+            alloc,
+            sequence,
+            id,
+            connection_id,
+            lookup_scope,
+        ) catch |err| {
             self.billing = .incomplete;
             self.dirty = true;
             return err;
@@ -617,8 +620,8 @@ pub const Usage = struct {
         alloc: Allocator,
         sequence: u64,
         id: []const u8,
-        origin: []const u8,
-        team: ?[]const u8,
+        connection_id: []const u8,
+        lookup_scope: ?[]const u8,
     ) !void {
         for (self.pending.items) |pending| {
             if (pending.sequence == sequence and !std.mem.eql(u8, pending.id, id)) {
@@ -628,8 +631,8 @@ pub const Usage = struct {
             }
             if (std.mem.eql(u8, pending.id, id)) {
                 if (pending.sequence != sequence or
-                    !std.mem.eql(u8, pending.origin, origin) or
-                    !optionalStringsEqual(pending.team, team))
+                    !std.mem.eql(u8, pending.connection_id, connection_id) or
+                    !optionalStringsEqual(pending.lookup_scope, lookup_scope))
                 {
                     self.billing = .incomplete;
                     self.dirty = true;
@@ -643,9 +646,9 @@ pub const Usage = struct {
             self.dirty = true;
             return error.UsageCapacityExceeded;
         }
-        var added_identifier_bytes = std.math.add(usize, id.len, origin.len) catch
+        var added_identifier_bytes = std.math.add(usize, id.len, connection_id.len) catch
             return self.failOverflow();
-        if (team) |value| {
+        if (lookup_scope) |value| {
             added_identifier_bytes = std.math.add(
                 usize,
                 added_identifier_bytes,
@@ -664,15 +667,15 @@ pub const Usage = struct {
         }
         const owned_id = try alloc.dupe(u8, id);
         errdefer alloc.free(owned_id);
-        const owned_origin = try alloc.dupe(u8, origin);
-        errdefer alloc.free(owned_origin);
-        const owned_team = if (team) |value| try alloc.dupe(u8, value) else null;
-        errdefer if (owned_team) |value| alloc.free(value);
+        const owned_connection_id = try alloc.dupe(u8, connection_id);
+        errdefer alloc.free(owned_connection_id);
+        const owned_lookup_scope = if (lookup_scope) |value| try alloc.dupe(u8, value) else null;
+        errdefer if (owned_lookup_scope) |value| alloc.free(value);
         try self.pending.append(alloc, .{
             .id = owned_id,
             .sequence = sequence,
-            .origin = owned_origin,
-            .team = owned_team,
+            .connection_id = owned_connection_id,
+            .lookup_scope = owned_lookup_scope,
             .observed_at_ms = io_mod.milliTimestamp(),
         });
         if (self.billing == .complete) self.billing = .pending;
@@ -773,8 +776,8 @@ pub const Usage = struct {
         if (model_index == null) {
             const resolved_pending = self.pending.items[pending_index];
             var removed_identifier_bytes = resolved_pending.id.len +|
-                resolved_pending.origin.len;
-            if (resolved_pending.team) |team| removed_identifier_bytes +|= team.len;
+                resolved_pending.connection_id.len;
+            if (resolved_pending.lookup_scope) |scope| removed_identifier_bytes +|= scope.len;
             const next_identifier_bytes = std.math.add(
                 usize,
                 self.identifierBytesUnlocked() -| removed_identifier_bytes,
@@ -1364,105 +1367,20 @@ pub const Usage = struct {
         return self.dirty;
     }
 
-    pub fn startReconciliation(
-        self: *Usage,
-        alloc: Allocator,
-        api_key: []const u8,
-    ) void {
-        self.startReconciliationWithCredential(alloc, api_key, false, null);
-    }
-
-    /// Installs the host's authoritative credential regardless of the prior key.
-    pub fn replaceReconciliationCredential(
-        self: *Usage,
-        alloc: Allocator,
-        api_key: []const u8,
-    ) void {
-        self.startReconciliationWithCredential(alloc, api_key, true, null);
-    }
-
-    /// Replaces a producer's key only while that key is still authoritative.
-    pub fn refreshReconciliationCredential(
-        self: *Usage,
-        alloc: Allocator,
-        expected_api_key: []const u8,
-        refreshed_api_key: []const u8,
-    ) void {
-        self.startReconciliationWithCredential(
-            alloc,
-            refreshed_api_key,
-            true,
-            expected_api_key,
-        );
-    }
-
-    /// Cancels credential work and rejects stale producer starts until replaced.
-    pub fn clearReconciliationCredential(self: *Usage) void {
-        self.reconciliation_cancel.store(true, .seq_cst);
+    pub fn startReconciliation(self: *Usage, alloc: Allocator) void {
         self.reconciliation_mutex.lockUncancelable(io_mod.getIo());
         defer self.reconciliation_mutex.unlock(io_mod.getIo());
-        self.reconciliation_cancel.store(true, .seq_cst);
-        if (comptime builtin.os.tag != .wasi) {
-            _ = self.reconciliation_work_epoch.fetchAdd(1, .seq_cst);
-        }
-        const thread = self.reconciliation_thread;
-        self.reconciliation_thread = null;
-        if (thread) |handle| handle.join();
-        self.reconciliation_done.store(true, .seq_cst);
-        self.reconciliation_cancel.store(false, .seq_cst);
-        self.reconciliation_key_digest = null;
-        self.reconciliation_credential_blocked = true;
-    }
-
-    fn startReconciliationWithCredential(
-        self: *Usage,
-        alloc: Allocator,
-        api_key: []const u8,
-        replace_existing: bool,
-        expected_api_key: ?[]const u8,
-    ) void {
-        if (api_key.len == 0) return;
-        const key_digest = reconciliationKeyDigest(api_key);
-        const expected_digest = if (expected_api_key) |expected|
-            reconciliationKeyDigest(expected)
-        else
-            null;
-        self.reconciliation_mutex.lockUncancelable(io_mod.getIo());
-        defer self.reconciliation_mutex.unlock(io_mod.getIo());
-        const authoritative_replace =
-            replace_existing and expected_api_key == null;
-        if (self.reconciliation_credential_blocked and
-            !authoritative_replace)
-        {
-            return;
-        }
-        if (authoritative_replace) {
-            self.reconciliation_credential_blocked = false;
-        }
-        const same_key = if (self.reconciliation_key_digest) |active_digest|
-            std.mem.eql(u8, &active_digest, &key_digest)
-        else
-            false;
-        if (self.reconciliation_key_digest) |active_digest| {
-            if (!same_key) {
-                if (!replace_existing) return;
-                if (expected_digest) |expected| {
-                    if (!std.mem.eql(u8, &active_digest, &expected)) return;
-                }
-            }
-        }
         if (comptime builtin.os.tag != .wasi) {
             _ = self.reconciliation_work_epoch.fetchAdd(1, .seq_cst);
         }
         if (self.reconciliation_thread) |thread| {
-            if (same_key and !self.reconciliation_done.load(.seq_cst)) return;
+            if (!self.reconciliation_done.load(.seq_cst)) return;
             self.reconciliation_cancel.store(true, .seq_cst);
             self.reconciliation_thread = null;
             thread.join();
             self.reconciliation_done.store(true, .seq_cst);
             self.reconciliation_cancel.store(false, .seq_cst);
         }
-        self.reconciliation_key_digest = key_digest;
         if (builtin.is_test) return;
         if (comptime builtin.os.tag == .wasi) return;
 
@@ -1471,21 +1389,22 @@ pub const Usage = struct {
         self.mutex.unlock(io_mod.getIo());
         if (!still_has_pending) return;
 
-        const api_key_copy = alloc.dupe(u8, api_key) catch |err| {
+        var dispatch = self.reconciliation_source.prepare(alloc) catch |err| {
             debug_trace.logf(
                 "session",
-                "usage reconciliation start failed reason={s}",
+                "usage reconciliation prepare failed reason={s}",
                 .{@errorName(err)},
             );
             return;
         };
+        var dispatch_owned = true;
+        defer if (dispatch_owned) dispatch.deinit(alloc);
         self.reconciliation_cancel.store(false, .seq_cst);
         self.reconciliation_done.store(false, .seq_cst);
-        self.reconciliation_key_digest = key_digest;
         self.reconciliation_thread = std.Thread.spawn(
             .{},
             reconciliationThreadMain,
-            .{ self, alloc, api_key_copy, self.generation_usage_provider },
+            .{ self, alloc, dispatch },
         ) catch |err| {
             self.reconciliation_done.store(true, .seq_cst);
             debug_trace.logf(
@@ -1493,9 +1412,9 @@ pub const Usage = struct {
                 "usage reconciliation start failed reason={s}",
                 .{@errorName(err)},
             );
-            secret.zeroAndFree(alloc, api_key_copy);
             return;
         };
+        dispatch_owned = false;
     }
 
     pub fn cancelReconciliation(self: *Usage) void {
@@ -1610,8 +1529,8 @@ pub const Usage = struct {
         for (self.models.items) |model| total +|= model.model.len;
         for (self.pending.items) |generation| {
             total +|= generation.id.len;
-            total +|= generation.origin.len;
-            if (generation.team) |team| total +|= team.len;
+            total +|= generation.connection_id.len;
+            if (generation.lookup_scope) |scope| total +|= scope.len;
         }
         for (self.publication_backlog.items) |fact| {
             total +|= fact.id.len;
@@ -1664,8 +1583,8 @@ pub const Usage = struct {
         for (self.pending.items, snapshot_value.pending) |generation, saved| {
             if (!std.mem.eql(u8, generation.id, saved.id) or
                 generation.sequence != saved.sequence or
-                !std.mem.eql(u8, generation.origin, saved.origin) or
-                !optionalStringsEqual(generation.team, saved.team) or
+                !std.mem.eql(u8, generation.connection_id, saved.connection_id) or
+                !optionalStringsEqual(generation.lookup_scope, saved.lookup_scope) or
                 generation.observed_at_ms != saved.observed_at_ms)
             {
                 return false;
@@ -1840,8 +1759,8 @@ pub fn validateSnapshot(snapshot: Snapshot) !void {
     }
     for (snapshot.pending, 0..) |generation, index| {
         try validateGenerationId(generation.id);
-        try validateOrigin(generation.origin);
-        if (generation.team) |team| try validateTeam(team);
+        try validateConnectionId(generation.connection_id);
+        if (generation.lookup_scope) |scope| try validateLookupScope(scope);
         if (generation.sequence == 0 or generation.sequence >= snapshot.next_sequence) {
             return error.InvalidUsageSnapshot;
         }
@@ -1850,10 +1769,10 @@ pub fn validateSnapshot(snapshot: Snapshot) !void {
         }
         identifier_bytes = std.math.add(usize, identifier_bytes, generation.id.len) catch
             return error.UsageCapacityExceeded;
-        identifier_bytes = std.math.add(usize, identifier_bytes, generation.origin.len) catch
+        identifier_bytes = std.math.add(usize, identifier_bytes, generation.connection_id.len) catch
             return error.UsageCapacityExceeded;
-        if (generation.team) |team| {
-            identifier_bytes = std.math.add(usize, identifier_bytes, team.len) catch
+        if (generation.lookup_scope) |scope| {
+            identifier_bytes = std.math.add(usize, identifier_bytes, scope.len) catch
                 return error.UsageCapacityExceeded;
         }
         for (snapshot.pending[0..index]) |prior| {
@@ -1969,7 +1888,11 @@ pub fn snapshotEql(first: Snapshot, second: Snapshot) bool {
         }
     }
     for (first.pending, second.pending) |left, right| {
-        if (left.observed_at_ms != right.observed_at_ms) return false;
+        if (!std.mem.eql(u8, left.connection_id, right.connection_id) or
+            left.observed_at_ms != right.observed_at_ms)
+        {
+            return false;
+        }
     }
     for (first.publication_backlog, second.publication_backlog) |left, right| {
         if (!usage_report.GenerationFact.eql(left, right)) return false;
@@ -2018,8 +1941,7 @@ pub fn billingProjectionEql(first: Snapshot, second: Snapshot) bool {
     for (first.pending, second.pending) |left, right| {
         if (!std.mem.eql(u8, left.id, right.id) or
             left.sequence != right.sequence or
-            !std.mem.eql(u8, left.origin, right.origin) or
-            !optionalStringsEqual(left.team, right.team))
+            !optionalStringsEqual(left.lookup_scope, right.lookup_scope))
         {
             return false;
         }
@@ -2078,13 +2000,12 @@ pub fn writeSnapshot(writer: *std.Io.Writer, snapshot: Snapshot) !void {
         try writer.writeAll("{\"id\":");
         try std.json.Stringify.value(pending.id, .{}, writer);
         try writer.print(",\"sequence\":{d},\"origin\":", .{pending.sequence});
-        try std.json.Stringify.value(pending.origin, .{}, writer);
-        try writer.writeAll(",\"team\":");
-        if (pending.team) |team| {
-            try std.json.Stringify.value(team, .{}, writer);
+        if (pending.lookup_scope) |scope| {
+            try std.json.Stringify.value(scope, .{}, writer);
         } else {
-            try writer.writeAll("null");
+            try std.json.Stringify.value("legacy", .{}, writer);
         }
+        try writer.writeAll(",\"team\":null");
         try writer.writeByte('}');
     }
     try writer.writeAll("]}");
@@ -2094,7 +2015,7 @@ pub fn writeSnapshot(writer: *std.Io.Writer, snapshot: Snapshot) !void {
 /// session event stream.
 pub fn writeRichSnapshot(writer: *std.Io.Writer, snapshot: Snapshot) !void {
     try validateSnapshot(snapshot);
-    try writer.writeAll("{\"schema_version\":2,\"billing\":");
+    try writer.writeAll("{\"schema_version\":3,\"billing\":");
     try std.json.Stringify.value(@tagName(snapshot.billing), .{}, writer);
     try writer.print(
         ",\"api_duration_complete\":{s},\"wall_duration_complete\":{s},\"code_complete\":{s},\"next_sequence\":{d},\"settled_through_sequence\":{d},\"api_duration_ms\":{d},\"wall_duration_ms\":{d},\"total_cost\":{d},\"input_tokens\":{d},\"output_tokens\":{d},\"cache_read_tokens\":{d},\"cache_write_tokens\":{d},\"reasoning_tokens\":",
@@ -2152,11 +2073,11 @@ pub fn writeRichSnapshot(writer: *std.Io.Writer, snapshot: Snapshot) !void {
         if (index > 0) try writer.writeByte(',');
         try writer.writeAll("{\"id\":");
         try std.json.Stringify.value(pending.id, .{}, writer);
-        try writer.print(",\"sequence\":{d},\"origin\":", .{pending.sequence});
-        try std.json.Stringify.value(pending.origin, .{}, writer);
-        try writer.writeAll(",\"team\":");
-        if (pending.team) |team| {
-            try std.json.Stringify.value(team, .{}, writer);
+        try writer.print(",\"sequence\":{d},\"connection_id\":", .{pending.sequence});
+        try std.json.Stringify.value(pending.connection_id, .{}, writer);
+        try writer.writeAll(",\"lookup_scope\":");
+        if (pending.lookup_scope) |scope| {
+            try std.json.Stringify.value(scope, .{}, writer);
         } else {
             try writer.writeAll("null");
         }
@@ -2191,14 +2112,16 @@ pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
     if (value != .object) {
         return error.InvalidUsageSnapshot;
     }
-    const legacy = value.object.count() == 18;
-    if (!legacy) {
-        if (value.object.count() != 23 or
-            try parseNonNegativeInteger(value.object.get("schema_version")) != 2)
-        {
-            return error.InvalidUsageSnapshot;
-        }
-    }
+    const rollback_readable = value.object.count() == 18;
+    const schema_version = if (rollback_readable)
+        @as(u64, 1)
+    else if (value.object.count() == 23)
+        try parseNonNegativeInteger(value.object.get("schema_version"))
+    else
+        return error.InvalidUsageSnapshot;
+    if (schema_version < 1 or schema_version > 3) return error.InvalidUsageSnapshot;
+    const legacy_metrics = schema_version == 1;
+    const legacy_pending = schema_version < 3;
     const billing_value = value.object.get("billing") orelse return error.InvalidUsageSnapshot;
     if (billing_value != .string) return error.InvalidUsageSnapshot;
     const billing = std.meta.stringToEnum(Availability, billing_value.string) orelse
@@ -2217,14 +2140,14 @@ pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
     const output_tokens = try parseNonNegativeInteger(value.object.get("output_tokens"));
     const cache_read_tokens = try parseNonNegativeInteger(value.object.get("cache_read_tokens"));
     const cache_write_tokens = try parseNonNegativeInteger(value.object.get("cache_write_tokens"));
-    const reasoning_tokens = if (legacy)
+    const reasoning_tokens = if (legacy_metrics)
         null
     else blk: {
         const field = value.object.get("reasoning_tokens") orelse
             return error.InvalidUsageSnapshot;
         break :blk try parseOptionalNonNegativeInteger(field);
     };
-    const request_count = if (legacy)
+    const request_count = if (legacy_metrics)
         null
     else blk: {
         const field = value.object.get("request_count") orelse
@@ -2248,7 +2171,7 @@ pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
     var model_count: usize = 0;
     errdefer for (models[0..model_count]) |*model| model.deinit(alloc);
     for (models_value.array.items, 0..) |model_value, index| {
-        const expected_model_fields: usize = if (legacy) 8 else 10;
+        const expected_model_fields: usize = if (legacy_metrics) 8 else 10;
         if (model_value != .object or
             model_value.object.count() != expected_model_fields)
         {
@@ -2262,14 +2185,14 @@ pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
         const model_output_tokens = try parseNonNegativeInteger(model_value.object.get("output_tokens"));
         const model_cache_read_tokens = try parseNonNegativeInteger(model_value.object.get("cache_read_tokens"));
         const model_cache_write_tokens = try parseNonNegativeInteger(model_value.object.get("cache_write_tokens"));
-        const model_reasoning_tokens = if (legacy)
+        const model_reasoning_tokens = if (legacy_metrics)
             null
         else blk: {
             const field = model_value.object.get("reasoning_tokens") orelse
                 return error.InvalidUsageSnapshot;
             break :blk try parseOptionalNonNegativeInteger(field);
         };
-        const model_request_count = if (legacy)
+        const model_request_count = if (legacy_metrics)
             null
         else blk: {
             const field = model_value.object.get("request_count") orelse
@@ -2299,46 +2222,53 @@ pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
     var pending_count: usize = 0;
     errdefer for (pending[0..pending_count]) |*generation| generation.deinit(alloc);
     for (pending_value.array.items, 0..) |pending_entry, index| {
-        const expected_pending_fields: usize = if (legacy) 4 else 5;
+        const expected_pending_fields: usize = if (legacy_metrics) 4 else 5;
         if (pending_entry != .object or
             pending_entry.object.count() != expected_pending_fields)
         {
             return error.InvalidUsageSnapshot;
         }
         const id_value = pending_entry.object.get("id") orelse return error.InvalidUsageSnapshot;
-        const origin_value = pending_entry.object.get("origin") orelse return error.InvalidUsageSnapshot;
-        const team_value = pending_entry.object.get("team") orelse return error.InvalidUsageSnapshot;
-        if (id_value != .string or origin_value != .string) return error.InvalidUsageSnapshot;
+        const connection_value = pending_entry.object.get(if (legacy_pending) "origin" else "connection_id") orelse
+            return error.InvalidUsageSnapshot;
+        const lookup_scope_value = pending_entry.object.get(if (legacy_pending) "origin" else "lookup_scope") orelse
+            return error.InvalidUsageSnapshot;
+        if (id_value != .string or connection_value != .string) return error.InvalidUsageSnapshot;
         const sequence = try parseNonNegativeInteger(pending_entry.object.get("sequence"));
-        const observed_at_ms = if (legacy)
+        const observed_at_ms = if (legacy_metrics)
             null
         else blk: {
             const field = pending_entry.object.get("observed_at_ms") orelse
                 return error.InvalidUsageSnapshot;
             break :blk try parseOptionalNonNegativeI64(field);
         };
-        if (team_value != .null and team_value != .string) return error.InvalidUsageSnapshot;
+        if (!legacy_pending and lookup_scope_value != .null and lookup_scope_value != .string) {
+            return error.InvalidUsageSnapshot;
+        }
         const id = try alloc.dupe(u8, id_value.string);
         errdefer alloc.free(id);
-        const origin = try alloc.dupe(u8, origin_value.string);
-        errdefer alloc.free(origin);
-        const team = switch (team_value) {
+        const connection_id = try alloc.dupe(
+            u8,
+            if (legacy_pending) "vercel" else connection_value.string,
+        );
+        errdefer alloc.free(connection_id);
+        const lookup_scope = switch (lookup_scope_value) {
             .null => null,
             .string => |text| try alloc.dupe(u8, text),
             else => unreachable,
         };
-        errdefer if (team) |text| alloc.free(text);
+        errdefer if (lookup_scope) |text| alloc.free(text);
         pending[index] = .{
             .id = id,
             .sequence = sequence,
-            .origin = origin,
-            .team = team,
+            .connection_id = connection_id,
+            .lookup_scope = lookup_scope,
             .observed_at_ms = observed_at_ms,
         };
         pending_count += 1;
     }
 
-    const publication_backlog = if (legacy) blk: {
+    const publication_backlog = if (legacy_metrics) blk: {
         break :blk try alloc.alloc(usage_report.GenerationFact, 0);
     } else blk: {
         const backlog_value = value.object.get("publication_backlog") orelse
@@ -2372,7 +2302,7 @@ pub fn parseSnapshotValue(alloc: Allocator, value: std.json.Value) !Snapshot {
         if (publication_backlog.len > 0) alloc.free(publication_backlog);
     }
 
-    const incidents = if (legacy) blk: {
+    const incidents = if (legacy_metrics) blk: {
         break :blk try alloc.alloc(usage_report.Incident, 0);
     } else blk: {
         const incidents_value = value.object.get("incidents") orelse
@@ -2454,19 +2384,18 @@ fn writeOptionalU64(writer: *std.Io.Writer, value: ?u64) !void {
 fn reconciliationThreadMain(
     usage: *Usage,
     alloc: Allocator,
-    api_key: []u8,
-    provider: generation_usage.Provider,
+    dispatch: generation_usage.Dispatch,
 ) void {
-    defer secret.zeroAndFree(alloc, api_key);
+    var owned_dispatch = dispatch;
+    defer owned_dispatch.deinit(alloc);
     defer usage.reconciliation_done.store(true, .seq_cst);
     var observed_epoch = usage.reconciliation_work_epoch.load(.seq_cst);
     while (!usage.reconciliation_cancel.load(.seq_cst)) {
         reconcilePendingBlocking(
             usage,
             alloc,
-            api_key,
             &usage.reconciliation_cancel,
-            provider,
+            owned_dispatch,
             30,
         );
         if (usage.reconciliation_cancel.load(.seq_cst)) return;
@@ -2484,21 +2413,14 @@ fn reconciliationThreadMain(
     }
 }
 
-fn reconciliationKeyDigest(api_key: []const u8) [Sha256.digest_length]u8 {
-    var digest: [Sha256.digest_length]u8 = undefined;
-    Sha256.hash(api_key, &digest, .{});
-    return digest;
-}
-
 fn reconcilePendingBlocking(
     usage: *Usage,
     alloc: Allocator,
-    api_key: []const u8,
     cancel_flag: *std.atomic.Value(bool),
-    provider: generation_usage.Provider,
+    dispatch: generation_usage.Dispatch,
     max_attempts: usize,
 ) void {
-    if (api_key.len == 0 or cancel_flag.load(.seq_cst)) return;
+    if (cancel_flag.load(.seq_cst)) return;
     var attempt: usize = 0;
     while (attempt < max_attempts and !cancel_flag.load(.seq_cst)) : (attempt += 1) {
         var current = usage.snapshot(alloc) catch |err| {
@@ -2515,13 +2437,13 @@ fn reconcilePendingBlocking(
 
         var retry_needed = false;
         for (current.pending) |pending| {
-            var outcome = provider.lookup(alloc, .{
-                .credential = api_key,
-                .tenant = pending.team,
-                .origin = pending.origin,
-                .generation_id = pending.id,
-                .cancel_flag = cancel_flag,
-            }) catch |err| {
+            var outcome = dispatch.lookup(
+                alloc,
+                pending.connection_id,
+                pending.id,
+                pending.lookup_scope,
+                cancel_flag,
+            ) catch |err| {
                 if (err == error.Cancelled) return;
                 debug_trace.logf(
                     "session",
@@ -2735,6 +2657,38 @@ pub fn dupeSnapshotOwned(alloc: Allocator, source: Snapshot) !Snapshot {
     };
 }
 
+pub const RebindPendingConnectionError = Allocator.Error || error{
+    InvalidConnectionIdentifier,
+};
+
+/// Restores the session-authoritative connection on rollback-readable pending
+/// records after their current rich extension becomes unavailable.
+pub fn rebindPendingConnection(
+    alloc: Allocator,
+    snapshot: *Snapshot,
+    connection_id: []const u8,
+) RebindPendingConnectionError!void {
+    try validateConnectionId(connection_id);
+    if (snapshot.pending.len == 0) return;
+    const replacements = try alloc.alloc(?[]u8, snapshot.pending.len);
+    defer alloc.free(replacements);
+    @memset(replacements, null);
+    errdefer for (replacements) |replacement| {
+        if (replacement) |value| alloc.free(value);
+    };
+    for (snapshot.pending, replacements) |pending, *replacement| {
+        if (!std.mem.eql(u8, pending.connection_id, connection_id)) {
+            replacement.* = try alloc.dupe(u8, connection_id);
+        }
+    }
+    for (snapshot.pending, replacements) |*pending, *replacement| {
+        const value = replacement.* orelse continue;
+        alloc.free(pending.connection_id);
+        pending.connection_id = value;
+        replacement.* = null;
+    }
+}
+
 fn validateGenerationId(id: []const u8) !void {
     if (!types.validGatewayGenerationId(id)) return error.InvalidGenerationId;
 }
@@ -2748,21 +2702,23 @@ fn validateModel(model: []const u8) !void {
     }
 }
 
-fn validateOrigin(origin: []const u8) !void {
-    if (origin.len == 0 or origin.len > max_origin_bytes) {
-        return error.InvalidGatewayOrigin;
+fn validateConnectionId(connection_id: []const u8) !void {
+    if (connection_id.len == 0 or connection_id.len > max_connection_id_bytes) {
+        return error.InvalidConnectionIdentifier;
     }
-    for (origin) |char| {
-        if (char < 0x21 or char > 0x7e) return error.InvalidGatewayOrigin;
+    for (connection_id) |char| {
+        if (!(std.ascii.isAlphanumeric(char) or char == '_' or char == '-' or char == '.' or char == ':')) {
+            return error.InvalidConnectionIdentifier;
+        }
     }
 }
 
-fn validateTeam(team: []const u8) !void {
-    if (team.len == 0 or team.len > max_team_bytes) {
-        return error.InvalidGatewayTeam;
+fn validateLookupScope(scope: []const u8) !void {
+    if (scope.len == 0 or scope.len > max_lookup_scope_bytes) {
+        return error.InvalidGenerationLookupScope;
     }
-    for (team) |char| {
-        if (char < 0x21 or char > 0x7e) return error.InvalidGatewayTeam;
+    for (scope) |char| {
+        if (char < 0x20 or char == 0x7f) return error.InvalidGenerationLookupScope;
     }
 }
 
@@ -2953,8 +2909,8 @@ test "profile publication failure preserves session totals and retries backlog" 
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -3034,8 +2990,8 @@ test "restored publication backlog settles the pending generation exactly" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try source.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -3121,8 +3077,8 @@ test "no-checkpoint usage drains a transient publication failure" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -3173,8 +3129,8 @@ test "missing profile publication sink keeps the durable pending bridge" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -3251,8 +3207,8 @@ test "usage snapshot parsing releases every partial allocation" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -3271,8 +3227,8 @@ test "usage snapshot parsing releases every partial allocation" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        "team_1",
     );
 
     var snapshot = try usage.snapshot(alloc);
@@ -3322,8 +3278,8 @@ test "fresh usage aggregates authoritative generations in invocation order" {
         125,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        "team_1",
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -3343,8 +3299,8 @@ test "fresh usage aggregates authoritative generations in invocation order" {
         75,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        "team_1",
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW",
@@ -3394,8 +3350,8 @@ test "usage deduplicates terminal and generation callbacks" {
         10,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.finishObservedInvocation(
         alloc,
@@ -3403,8 +3359,8 @@ test "usage deduplicates terminal and generation callbacks" {
         10,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     const record = GenerationRecord{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -3439,8 +3395,8 @@ test "usage deduplicates callbacks after the durable settlement boundary" {
         10,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -3464,8 +3420,8 @@ test "usage deduplicates callbacks after the durable settlement boundary" {
         10,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
 
     var current = try usage.snapshot(alloc);
@@ -3488,8 +3444,8 @@ test "model aggregates remain ordered by invocation when reconciliation finishes
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.finishObservedInvocation(
         alloc,
@@ -3497,8 +3453,8 @@ test "model aggregates remain ordered by invocation when reconciliation finishes
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
 
     try usage.applyGeneration(alloc, .{
@@ -3563,8 +3519,8 @@ test "active invocation dominates separate pending and publication state" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
 
     var pending = try usage.snapshot(alloc);
@@ -3647,8 +3603,8 @@ test "generation allocation failure marks billing incomplete before snapshot" {
             1,
             .observed_generation,
             "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            "vercel",
             "https://ai-gateway.vercel.sh",
-            null,
         ),
     );
     var snapshot = try usage.snapshot(alloc);
@@ -3718,8 +3674,8 @@ test "pending and ambiguous generation states remain honest" {
         8,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
 
     var pending = try usage.snapshot(alloc);
@@ -3746,8 +3702,8 @@ test "successful response without generation identity marks billing incomplete" 
         alloc,
         .ok,
         .{},
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
 
     var snapshot = try usage.snapshot(alloc);
@@ -3762,7 +3718,6 @@ const TestGenerationUsageProvider = struct {
         retry,
         preserve_pending,
         reject,
-        unavailable,
         cancelled,
     },
     calls: usize = 0,
@@ -3782,7 +3737,7 @@ const TestGenerationUsageProvider = struct {
                 input.generation_id,
                 "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
             ) and
-            std.mem.eql(u8, input.origin, "https://provider.example");
+            std.mem.eql(u8, input.lookup_scope orelse "", "https://provider.example");
         return switch (self.outcome) {
             .found => blk: {
                 const id = try alloc.dupe(u8, input.generation_id);
@@ -3802,7 +3757,6 @@ const TestGenerationUsageProvider = struct {
             .retry => .retry,
             .preserve_pending => .preserve_pending,
             .reject => .reject,
-            .unavailable => error.Unavailable,
             .cancelled => error.Cancelled,
         };
     }
@@ -3815,35 +3769,32 @@ const TestGenerationUsageProvider = struct {
     }
 };
 
-test "usage restore and reset retain the injected generation provider" {
-    const alloc = std.testing.allocator;
-    var fake = TestGenerationUsageProvider{ .outcome = .found };
-    const provider = fake.provider();
-    var usage = Usage.initFreshWithProvider(provider);
-    defer usage.deinit(alloc);
-
-    var saved = try usage.snapshot(alloc);
-    defer saved.deinit(alloc);
-
-    usage.resetFresh(alloc);
-    try std.testing.expect(
-        usage.generation_usage_provider.lookup_fn == provider.lookup_fn,
-    );
-    try usage.restore(alloc, saved, 1);
-    try std.testing.expect(
-        usage.generation_usage_provider.lookup_fn == provider.lookup_fn,
-    );
-    usage.resetLegacy(alloc);
-    try std.testing.expect(
-        usage.generation_usage_provider.lookup_fn == provider.lookup_fn,
-    );
+fn resolveTestGenerationCredential(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    credential_ref: []const u8,
+) generation_usage.ResolveCredentialError!generation_usage.ResolvedCredential {
+    return .{ .token = try alloc.dupe(u8, credential_ref) };
 }
 
-test "reconciliation settles usage through the injected provider" {
+fn testGenerationDispatch(
+    alloc: Allocator,
+    provider: generation_usage.Provider,
+) !generation_usage.Dispatch {
+    return generation_usage.Dispatch.init(alloc, &.{.{
+        .id = "connection-a",
+        .credential_ref = "credential",
+        .provider = provider,
+    }}, .{ .resolve_fn = resolveTestGenerationCredential });
+}
+
+test "reconciliation settles usage through the originating connection" {
     const alloc = std.testing.allocator;
     var fake = TestGenerationUsageProvider{ .outcome = .found };
-    var usage = Usage.initFreshWithProvider(fake.provider());
+    var usage = Usage.initFresh();
     defer usage.deinit(alloc);
+    var dispatch = try testGenerationDispatch(alloc, fake.provider());
+    defer dispatch.deinit(alloc);
 
     const sequence = try usage.reserveInvocation();
     try usage.finishObservedInvocation(
@@ -3852,17 +3803,15 @@ test "reconciliation settles usage through the injected provider" {
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "connection-a",
         "https://provider.example",
-        null,
     );
     var cancel = std.atomic.Value(bool).init(false);
-    const provider = usage.generation_usage_provider;
     reconcilePendingBlocking(
         &usage,
         alloc,
-        "credential",
         &cancel,
-        provider,
+        dispatch,
         1,
     );
 
@@ -3899,8 +3848,8 @@ test "terminal Gateway billing settles the durable observation immediately" {
                 .billable_web_search_calls = 2,
             },
         },
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
 
     var snapshot = try usage.snapshot(alloc);
@@ -3925,8 +3874,8 @@ test "successful retry after ambiguous delivery retains known generation" {
             .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
             .delivery_ambiguous = true,
         },
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -4018,8 +3967,8 @@ test "usage keeps more than sixteen exact resolved models" {
             1,
             .observed_generation,
             id,
+            "vercel",
             "https://ai-gateway.vercel.sh",
-            null,
         );
         try usage.applyGeneration(alloc, .{
             .id = id,
@@ -4088,8 +4037,8 @@ test "sixteenth pending generation is the capacity boundary" {
             1,
             .observed_generation,
             id,
+            "vercel",
             "https://ai-gateway.vercel.sh",
-            null,
         );
     }
 
@@ -4116,8 +4065,8 @@ test "sixteenth pending generation is the capacity boundary" {
             1,
             .observed_generation,
             overflow_id,
+            "vercel",
             "https://ai-gateway.vercel.sh",
-            null,
         ),
     );
 
@@ -4142,8 +4091,8 @@ test "populated usage snapshot keeps the rollback-readable durable shape" {
         120,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        "team_alpha",
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -4163,8 +4112,8 @@ test "populated usage snapshot keeps the rollback-readable durable shape" {
         90,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW",
@@ -4186,8 +4135,8 @@ test "populated usage snapshot keeps the rollback-readable durable shape" {
         30,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAX",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        "team_beta",
     );
     try usage.recordCommittedLines(5, 3);
 
@@ -4214,6 +4163,7 @@ test "populated usage snapshot keeps the rollback-readable durable shape" {
     }
     var decoded = try parseSnapshotValue(alloc, parsed.value);
     defer decoded.deinit(alloc);
+    try std.testing.expectEqualStrings("vercel", decoded.pending[0].connection_id);
 
     try std.testing.expectEqual(snapshot.billing, decoded.billing);
     try std.testing.expectEqual(snapshot.api_duration_complete, decoded.api_duration_complete);
@@ -4249,8 +4199,8 @@ test "populated usage snapshot keeps the rollback-readable durable shape" {
     for (snapshot.pending, decoded.pending) |expected, actual| {
         try std.testing.expectEqualStrings(expected.id, actual.id);
         try std.testing.expectEqual(expected.sequence, actual.sequence);
-        try std.testing.expectEqualStrings(expected.origin, actual.origin);
-        try std.testing.expect(optionalStringsEqual(expected.team, actual.team));
+        try std.testing.expectEqualStrings(expected.connection_id, actual.connection_id);
+        try std.testing.expect(optionalStringsEqual(expected.lookup_scope, actual.lookup_scope));
     }
 
     const Publisher = struct {
@@ -4307,8 +4257,8 @@ test "rich usage snapshot preserves optional metrics and recovery state" {
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -4329,8 +4279,8 @@ test "rich usage snapshot preserves optional metrics and recovery state" {
         6,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        "team_alpha",
     );
 
     var snapshot = try usage.snapshot(alloc);
@@ -4378,6 +4328,52 @@ test "rich usage snapshot preserves optional metrics and recovery state" {
     );
 }
 
+test "schema two pending usage migrates to the built-in connection" {
+    const alloc = std.testing.allocator;
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+    const sequence = try usage.reserveInvocation();
+    try usage.finishObservedInvocation(
+        alloc,
+        sequence,
+        1,
+        .observed_generation,
+        "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
+        "https://ai-gateway.vercel.sh",
+    );
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    var encoded: std.Io.Writer.Allocating = .init(alloc);
+    defer encoded.deinit();
+    try writeRichSnapshot(&encoded.writer, snapshot);
+    const old_version = try std.mem.replaceOwned(
+        u8,
+        alloc,
+        encoded.written(),
+        "\"schema_version\":3",
+        "\"schema_version\":2",
+    );
+    defer alloc.free(old_version);
+    const old_pending = try std.mem.replaceOwned(
+        u8,
+        alloc,
+        old_version,
+        "\"connection_id\":\"vercel\",\"lookup_scope\":\"https://ai-gateway.vercel.sh\"",
+        "\"origin\":\"https://ai-gateway.vercel.sh\",\"team\":null",
+    );
+    defer alloc.free(old_pending);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, old_pending, .{});
+    defer parsed.deinit();
+    var migrated = try parseSnapshotValue(alloc, parsed.value);
+    defer migrated.deinit(alloc);
+    try std.testing.expectEqualStrings("vercel", migrated.pending[0].connection_id);
+    try std.testing.expectEqualStrings(
+        "https://ai-gateway.vercel.sh",
+        migrated.pending[0].lookup_scope.?,
+    );
+}
+
 test "owned snapshot incident overflow matches runtime retention" {
     const alloc = std.testing.allocator;
     var usage = Usage.initFresh();
@@ -4412,6 +4408,8 @@ test "provider rejection removes pending generation and marks billing incomplete
     var fake = TestGenerationUsageProvider{ .outcome = .reject };
     var usage = Usage.initFresh();
     defer usage.deinit(alloc);
+    var dispatch = try testGenerationDispatch(alloc, fake.provider());
+    defer dispatch.deinit(alloc);
 
     const sequence = try usage.reserveInvocation();
     try usage.finishObservedInvocation(
@@ -4420,16 +4418,15 @@ test "provider rejection removes pending generation and marks billing incomplete
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "connection-a",
         "https://provider.example",
-        null,
     );
     var cancel = std.atomic.Value(bool).init(false);
     reconcilePendingBlocking(
         &usage,
         alloc,
-        "credential",
         &cancel,
-        fake.provider(),
+        dispatch,
         1,
     );
 
@@ -4445,6 +4442,8 @@ test "provider preserve outcome keeps pending generation for a future credential
     var fake = TestGenerationUsageProvider{ .outcome = .preserve_pending };
     var usage = Usage.initFresh();
     defer usage.deinit(alloc);
+    var dispatch = try testGenerationDispatch(alloc, fake.provider());
+    defer dispatch.deinit(alloc);
 
     const sequence = try usage.reserveInvocation();
     try usage.finishObservedInvocation(
@@ -4453,16 +4452,15 @@ test "provider preserve outcome keeps pending generation for a future credential
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "connection-a",
         "https://provider.example",
-        null,
     );
     var cancel = std.atomic.Value(bool).init(false);
     reconcilePendingBlocking(
         &usage,
         alloc,
-        "credential",
         &cancel,
-        fake.provider(),
+        dispatch,
         1,
     );
 
@@ -4482,6 +4480,8 @@ test "provider retry outcome leaves pending generation unchanged" {
     var fake = TestGenerationUsageProvider{ .outcome = .retry };
     var usage = Usage.initFresh();
     defer usage.deinit(alloc);
+    var dispatch = try testGenerationDispatch(alloc, fake.provider());
+    defer dispatch.deinit(alloc);
 
     const sequence = try usage.reserveInvocation();
     try usage.finishObservedInvocation(
@@ -4490,16 +4490,15 @@ test "provider retry outcome leaves pending generation unchanged" {
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "connection-a",
         "https://provider.example",
-        null,
     );
     var cancel = std.atomic.Value(bool).init(false);
     reconcilePendingBlocking(
         &usage,
         alloc,
-        "credential",
         &cancel,
-        fake.provider(),
+        dispatch,
         1,
     );
 
@@ -4510,11 +4509,13 @@ test "provider retry outcome leaves pending generation unchanged" {
     try std.testing.expectEqual(@as(usize, 1), snapshot.pending.len);
 }
 
-test "provider failure leaves pending generation unchanged" {
+test "missing originating connection preserves pending generation without fallback" {
     const alloc = std.testing.allocator;
-    var fake = TestGenerationUsageProvider{ .outcome = .unavailable };
+    var fake = TestGenerationUsageProvider{ .outcome = .found };
     var usage = Usage.initFresh();
     defer usage.deinit(alloc);
+    var dispatch = try testGenerationDispatch(alloc, fake.provider());
+    defer dispatch.deinit(alloc);
 
     const sequence = try usage.reserveInvocation();
     try usage.finishObservedInvocation(
@@ -4523,22 +4524,21 @@ test "provider failure leaves pending generation unchanged" {
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "missing-connection",
         "https://provider.example",
-        null,
     );
     var cancel = std.atomic.Value(bool).init(false);
     reconcilePendingBlocking(
         &usage,
         alloc,
-        "credential",
         &cancel,
-        fake.provider(),
+        dispatch,
         1,
     );
 
     var snapshot = try usage.snapshot(alloc);
     defer snapshot.deinit(alloc);
-    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
     try std.testing.expectEqual(Availability.pending, snapshot.billing);
     try std.testing.expectEqual(@as(usize, 1), snapshot.pending.len);
 }
@@ -4548,6 +4548,8 @@ test "provider cancellation stops reconciliation and preserves pending usage" {
     var fake = TestGenerationUsageProvider{ .outcome = .cancelled };
     var usage = Usage.initFresh();
     defer usage.deinit(alloc);
+    var dispatch = try testGenerationDispatch(alloc, fake.provider());
+    defer dispatch.deinit(alloc);
 
     const sequence = try usage.reserveInvocation();
     try usage.finishObservedInvocation(
@@ -4556,16 +4558,15 @@ test "provider cancellation stops reconciliation and preserves pending usage" {
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "connection-a",
         "https://provider.example",
-        null,
     );
     var cancel = std.atomic.Value(bool).init(false);
     reconcilePendingBlocking(
         &usage,
         alloc,
-        "credential",
         &cancel,
-        fake.provider(),
+        dispatch,
         2,
     );
 
@@ -4659,8 +4660,8 @@ test "gateway observation checkpoints active and terminal usage states" {
         alloc,
         .ok,
         .{ .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV" },
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try std.testing.expectEqual(@as(usize, 2), capture.calls);
     try std.testing.expectEqual(Availability.pending, capture.billing[1]);
@@ -4732,23 +4733,23 @@ test "terminal checkpoint failure preserves request progress as incomplete" {
     try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
 }
 
-test "pending generation origins remain bounded transport inputs" {
-    try validateOrigin("https://ai-gateway.vercel.sh");
-    try validateOrigin("http://127.0.0.1:3000");
-    try validateOrigin("https://provider.example");
+test "pending generation routing inputs remain bounded" {
+    try validateConnectionId("connection-a");
+    try validateConnectionId("provider:profile_1");
+    try validateLookupScope("https://provider.example");
 
     try std.testing.expectError(
-        error.InvalidGatewayOrigin,
-        validateOrigin(""),
+        error.InvalidConnectionIdentifier,
+        validateConnectionId(""),
     );
     try std.testing.expectError(
-        error.InvalidGatewayOrigin,
-        validateOrigin("https://provider.example\ninjected"),
+        error.InvalidGenerationLookupScope,
+        validateLookupScope("https://provider.example\ninjected"),
     );
-    var oversized: [max_origin_bytes + 1]u8 = @splat('a');
+    var oversized: [max_lookup_scope_bytes + 1]u8 = @splat('a');
     try std.testing.expectError(
-        error.InvalidGatewayOrigin,
-        validateOrigin(&oversized),
+        error.InvalidGenerationLookupScope,
+        validateLookupScope(&oversized),
     );
 }
 
@@ -4775,54 +4776,91 @@ test "reconciliation retry delay observes cancellation promptly" {
     try std.testing.expect(completed_at_ms - signalled_at_ms < cancellation_response_bound_ms);
 }
 
-test "stale reconciliation credential cannot replace a refreshed credential" {
+test "terminal generation lookup stays on connection A after selecting B" {
     const alloc = std.testing.allocator;
+    const FakeProvider = struct {
+        calls: usize = 0,
+
+        fn lookup(
+            raw: ?*anyopaque,
+            allocator: Allocator,
+            input: generation_usage.LookupInput,
+        ) generation_usage.LookupError!generation_usage.LookupOutcome {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.calls += 1;
+            const id = try allocator.dupe(u8, input.generation_id);
+            errdefer allocator.free(id);
+            return .{ .found = .{
+                .id = id,
+                .model = try allocator.dupe(u8, "provider/model"),
+                .total_cost = 0.5,
+                .input_tokens = 2,
+                .output_tokens = 1,
+                .cache_read_tokens = 0,
+                .cache_write_tokens = 0,
+                .billable_web_search_calls = 0,
+            } };
+        }
+
+        fn provider(self: *@This()) generation_usage.Provider {
+            return .{ .context = self, .lookup_fn = lookup };
+        }
+    };
+    var provider_a: FakeProvider = .{};
+    var provider_b: FakeProvider = .{};
+    const selected_connection_id = "connection-b";
+    try std.testing.expectEqualStrings("connection-b", selected_connection_id);
+
     var usage = Usage.initFresh();
     defer usage.deinit(alloc);
-
-    usage.startReconciliation(alloc, "initial-key");
-    usage.replaceReconciliationCredential(alloc, "refreshed-key");
-    usage.startReconciliation(alloc, "initial-key");
-    usage.refreshReconciliationCredential(
+    const observation = try GatewayObservation.begin(&usage);
+    try observation.complete(
         alloc,
-        "initial-key",
-        "stale-producer-key",
+        .ok,
+        .{ .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV" },
+        "connection-a",
+        "scope-a",
     );
+    var queued = try usage.snapshot(alloc);
+    defer queued.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), queued.pending.len);
+    try std.testing.expectEqualStrings("connection-a", queued.pending[0].connection_id);
+    var encoded: std.Io.Writer.Allocating = .init(alloc);
+    defer encoded.deinit();
+    try writeRichSnapshot(&encoded.writer, queued);
+    try std.testing.expect(std.mem.find(u8, encoded.written(), "credential-a") == null);
 
-    const expected = reconciliationKeyDigest("refreshed-key");
-    try std.testing.expectEqualSlices(
-        u8,
-        &expected,
-        &(usage.reconciliation_key_digest orelse return error.TestUnexpectedResult),
-    );
+    var dispatch = try generation_usage.Dispatch.init(alloc, &.{
+        .{ .id = "connection-a", .credential_ref = "credential-a", .provider = provider_a.provider() },
+        .{ .id = "connection-b", .credential_ref = "credential-b", .provider = provider_b.provider() },
+    }, .{ .resolve_fn = resolveTestGenerationCredential });
+    defer dispatch.deinit(alloc);
+    var cancel = std.atomic.Value(bool).init(false);
+    reconcilePendingBlocking(&usage, alloc, &cancel, dispatch, 1);
+    try std.testing.expectEqual(@as(usize, 1), provider_a.calls);
+    try std.testing.expectEqual(@as(usize, 0), provider_b.calls);
 
-    usage.refreshReconciliationCredential(
+    var missing_usage = Usage.initFresh();
+    defer missing_usage.deinit(alloc);
+    const missing_observation = try GatewayObservation.begin(&missing_usage);
+    try missing_observation.complete(
         alloc,
-        "refreshed-key",
-        "next-key",
+        .ok,
+        .{ .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW" },
+        "connection-a",
+        "scope-a",
     );
-    const next_expected = reconciliationKeyDigest("next-key");
-    try std.testing.expectEqualSlices(
-        u8,
-        &next_expected,
-        &(usage.reconciliation_key_digest orelse return error.TestUnexpectedResult),
-    );
-
-    usage.clearReconciliationCredential();
-    usage.refreshReconciliationCredential(
-        alloc,
-        "next-key",
-        "stale-after-clear",
-    );
-    try std.testing.expect(usage.reconciliation_key_digest == null);
-    try std.testing.expect(usage.reconciliation_credential_blocked);
-
-    usage.replaceReconciliationCredential(alloc, "replacement-key");
-    const replacement_expected = reconciliationKeyDigest("replacement-key");
-    try std.testing.expectEqualSlices(
-        u8,
-        &replacement_expected,
-        &(usage.reconciliation_key_digest orelse return error.TestUnexpectedResult),
-    );
-    try std.testing.expect(!usage.reconciliation_credential_blocked);
+    var missing_dispatch = try generation_usage.Dispatch.init(alloc, &.{.{
+        .id = "connection-b",
+        .credential_ref = "credential-b",
+        .provider = provider_b.provider(),
+    }}, .{ .resolve_fn = resolveTestGenerationCredential });
+    defer missing_dispatch.deinit(alloc);
+    reconcilePendingBlocking(&missing_usage, alloc, &cancel, missing_dispatch, 1);
+    var pending = try missing_usage.snapshot(alloc);
+    defer pending.deinit(alloc);
+    try std.testing.expectEqual(Availability.pending, pending.billing);
+    try std.testing.expectEqual(@as(usize, 1), pending.pending.len);
+    try std.testing.expectEqual(@as(usize, 1), provider_a.calls);
+    try std.testing.expectEqual(@as(usize, 0), provider_b.calls);
 }

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -19,6 +19,7 @@ const max_lookup_scope_bytes: usize = 2048;
 const max_identifier_bytes: usize = 8 * 1024;
 const max_active_invocations: usize = 64;
 const shutdown_reconciliation_budget_ms: usize = 250;
+const rollback_null_lookup_scope = "legacy";
 pub const max_snapshot_bytes: usize = 256 * 1024;
 
 /// Completeness of the saved billing window rendered by `/cost`.
@@ -2003,7 +2004,7 @@ pub fn writeSnapshot(writer: *std.Io.Writer, snapshot: Snapshot) !void {
         if (pending.lookup_scope) |scope| {
             try std.json.Stringify.value(scope, .{}, writer);
         } else {
-            try std.json.Stringify.value("legacy", .{}, writer);
+            try std.json.Stringify.value(rollback_null_lookup_scope, .{}, writer);
         }
         try writer.writeAll(",\"team\":null");
         try writer.writeByte('}');
@@ -2661,8 +2662,7 @@ pub const RebindPendingConnectionError = Allocator.Error || error{
     InvalidConnectionIdentifier,
 };
 
-/// Restores the session-authoritative connection on rollback-readable pending
-/// records after their current rich extension becomes unavailable.
+/// Restores current-session routing data after its rich extension disappears.
 pub fn rebindPendingConnection(
     alloc: Allocator,
     snapshot: *Snapshot,
@@ -2682,15 +2682,22 @@ pub fn rebindPendingConnection(
         }
     }
     for (snapshot.pending, replacements) |*pending, *replacement| {
-        const value = replacement.* orelse continue;
-        alloc.free(pending.connection_id);
-        pending.connection_id = value;
-        replacement.* = null;
+        if (replacement.*) |value| {
+            alloc.free(pending.connection_id);
+            pending.connection_id = value;
+            replacement.* = null;
+        }
+        if (pending.lookup_scope) |scope| {
+            if (std.mem.eql(u8, scope, rollback_null_lookup_scope)) {
+                alloc.free(scope);
+                pending.lookup_scope = null;
+            }
+        }
     }
 }
 
 fn validateGenerationId(id: []const u8) !void {
-    if (!types.validGatewayGenerationId(id)) return error.InvalidGenerationId;
+    if (!types.validGenerationReferenceId(id)) return error.InvalidGenerationId;
 }
 
 fn validateModel(model: []const u8) !void {
@@ -4278,7 +4285,7 @@ test "rich usage snapshot preserves optional metrics and recovery state" {
         pending_sequence,
         6,
         .observed_generation,
-        "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        "request-pending",
         "vercel",
         "https://ai-gateway.vercel.sh",
     );
@@ -4780,6 +4787,7 @@ test "terminal generation lookup stays on connection A after selecting B" {
     const alloc = std.testing.allocator;
     const FakeProvider = struct {
         calls: usize = 0,
+        saw_null_scope: bool = false,
 
         fn lookup(
             raw: ?*anyopaque,
@@ -4788,6 +4796,7 @@ test "terminal generation lookup stays on connection A after selecting B" {
         ) generation_usage.LookupError!generation_usage.LookupOutcome {
             const self: *@This() = @ptrCast(@alignCast(raw.?));
             self.calls += 1;
+            self.saw_null_scope = input.lookup_scope == null;
             const id = try allocator.dupe(u8, input.generation_id);
             errdefer allocator.free(id);
             return .{ .found = .{
@@ -4817,9 +4826,9 @@ test "terminal generation lookup stays on connection A after selecting B" {
     try observation.complete(
         alloc,
         .ok,
-        .{ .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV" },
+        .{ .generation_id = "request-42" },
         "connection-a",
-        "scope-a",
+        null,
     );
     var queued = try usage.snapshot(alloc);
     defer queued.deinit(alloc);
@@ -4839,6 +4848,7 @@ test "terminal generation lookup stays on connection A after selecting B" {
     reconcilePendingBlocking(&usage, alloc, &cancel, dispatch, 1);
     try std.testing.expectEqual(@as(usize, 1), provider_a.calls);
     try std.testing.expectEqual(@as(usize, 0), provider_b.calls);
+    try std.testing.expect(provider_a.saw_null_scope);
 
     var missing_usage = Usage.initFresh();
     defer missing_usage.deinit(alloc);
@@ -4846,9 +4856,9 @@ test "terminal generation lookup stays on connection A after selecting B" {
     try missing_observation.complete(
         alloc,
         .ok,
-        .{ .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW" },
+        .{ .generation_id = "request-missing" },
         "connection-a",
-        "scope-a",
+        null,
     );
     var missing_dispatch = try generation_usage.Dispatch.init(alloc, &.{.{
         .id = "connection-b",

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -598,6 +598,24 @@ test "missing and corrupt sidecars retain current pending connection with one fi
     var rich = try usage.snapshot(alloc);
     defer rich.deinit(alloc);
 
+    try write(alloc, &verified, "session-one", rich);
+    var intact = try legacyCopyForTest(alloc, rich);
+    defer intact.deinit(alloc);
+    try std.testing.expectEqual(
+        RestoreOutcome.restored,
+        try restoreIfMatching(
+            alloc,
+            &verified,
+            "session-one",
+            29,
+            .{ .current = "connection-a" },
+            &intact,
+        ),
+    );
+    try std.testing.expect(intact.pending[0].lookup_scope == null);
+    try std.testing.expectEqual(@as(usize, 0), intact.incidents.len);
+    try verified.dir.deleteFile(io_mod.getIo(), sidecar_file);
+
     var missing = try legacyCopyForTest(alloc, rich);
     defer missing.deinit(alloc);
     try std.testing.expectEqualStrings("vercel", missing.pending[0].connection_id);
@@ -624,6 +642,7 @@ test "missing and corrupt sidecars retain current pending connection with one fi
         calls_vercel: usize = 0,
         saw_a_credential: bool = false,
         saw_null_scope: bool = false,
+        saw_legacy_scope: bool = false,
 
         fn resolve(
             raw: ?*anyopaque,
@@ -650,6 +669,10 @@ test "missing and corrupt sidecars retain current pending connection with one fi
             self.calls_a += 1;
             self.saw_a_credential = std.mem.eql(u8, "credential-a", input.credential);
             self.saw_null_scope = input.lookup_scope == null;
+            self.saw_legacy_scope = if (input.lookup_scope) |scope|
+                std.mem.eql(u8, scope, "legacy")
+            else
+                false;
             return .preserve_pending;
         }
 
@@ -791,6 +814,78 @@ test "missing and corrupt sidecars retain current pending connection with one fi
         ),
     );
     try std.testing.expectEqualStrings("vercel", historical.pending[0].connection_id);
+
+    var scoped_usage = session_usage.Usage.initFresh();
+    defer scoped_usage.deinit(alloc);
+    const scoped_sequence = try scoped_usage.reserveInvocation();
+    try scoped_usage.finishObservedInvocation(
+        alloc,
+        scoped_sequence,
+        1,
+        .observed_generation,
+        "request-legacy",
+        "connection-a",
+        "legacy",
+    );
+    var scoped_rich = try scoped_usage.snapshot(alloc);
+    defer scoped_rich.deinit(alloc);
+    try verified.dir.deleteFile(io_mod.getIo(), sidecar_file);
+    var scoped_missing = try legacyCopyForTest(alloc, scoped_rich);
+    defer scoped_missing.deinit(alloc);
+    probe = .{};
+    try std.testing.expectEqual(
+        RestoreOutcome.missing,
+        try restoreIfMatching(
+            alloc,
+            &verified,
+            "session-two",
+            34,
+            .{ .current = "connection-a" },
+            &scoped_missing,
+        ),
+    );
+    try std.testing.expectEqualStrings("connection-a", scoped_missing.pending[0].connection_id);
+    try std.testing.expectEqualStrings("legacy", scoped_missing.pending[0].lookup_scope.?);
+    try std.testing.expectEqual(@as(usize, 0), probe.resolved_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.resolved_vercel);
+    try std.testing.expectEqual(@as(usize, 0), probe.calls_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.calls_vercel);
+
+    try io_mod.durableReplaceVerified(alloc, &verified, sidecar_file, "{bad");
+    var scoped_corrupt = try legacyCopyForTest(alloc, scoped_rich);
+    defer scoped_corrupt.deinit(alloc);
+    try std.testing.expectEqual(
+        RestoreOutcome.invalid,
+        try restoreIfMatching(
+            alloc,
+            &verified,
+            "session-two",
+            35,
+            .{ .current = "connection-a" },
+            &scoped_corrupt,
+        ),
+    );
+    try std.testing.expectEqualStrings("connection-a", scoped_corrupt.pending[0].connection_id);
+    try std.testing.expectEqualStrings("legacy", scoped_corrupt.pending[0].lookup_scope.?);
+    try std.testing.expectEqual(@as(usize, 0), probe.resolved_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.resolved_vercel);
+    try std.testing.expectEqual(@as(usize, 0), probe.calls_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.calls_vercel);
+    probe = .{};
+    var scoped_outcome = try dispatch.lookup(
+        alloc,
+        scoped_corrupt.pending[0].connection_id,
+        scoped_corrupt.pending[0].id,
+        scoped_corrupt.pending[0].lookup_scope,
+        &cancel,
+    );
+    defer scoped_outcome.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), probe.resolved_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.resolved_vercel);
+    try std.testing.expectEqual(@as(usize, 1), probe.calls_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.calls_vercel);
+    try std.testing.expect(probe.saw_a_credential);
+    try std.testing.expect(probe.saw_legacy_scope);
 }
 
 fn legacyCopyForTest(

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -271,7 +271,7 @@ fn pendingConnectionsMatchAuthority(
     authority: PendingConnectionAuthority,
 ) bool {
     const connection_id = switch (authority) {
-        .historical_vercel => return true,
+        .historical_vercel => "vercel",
         .current => |value| value,
     };
     for (snapshot.pending) |pending| {
@@ -775,6 +775,22 @@ test "missing and corrupt sidecars retain current pending connection with one fi
     try std.testing.expectEqual(@as(usize, 0), probe.resolved_vercel);
     try std.testing.expectEqual(@as(usize, 1), probe.calls_a);
     try std.testing.expectEqual(@as(usize, 0), probe.calls_vercel);
+
+    try writeEncoded(alloc, &verified, valid_sidecar);
+    var historical = try legacyCopyForTest(alloc, rich);
+    defer historical.deinit(alloc);
+    try std.testing.expectEqual(
+        RestoreOutcome.mismatched,
+        try restoreIfMatching(
+            alloc,
+            &verified,
+            "session-one",
+            33,
+            .historical_vercel,
+            &historical,
+        ),
+    );
+    try std.testing.expectEqualStrings("vercel", historical.pending[0].connection_id);
 }
 
 fn legacyCopyForTest(

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
+const generation_usage = @import("generation_usage_provider.zig");
 const session_usage = @import("session_usage.zig");
 
 const Allocator = std.mem.Allocator;
@@ -13,6 +14,11 @@ pub const RestoreOutcome = enum {
     restored,
     invalid,
     mismatched,
+};
+
+pub const PendingConnectionAuthority = union(enum) {
+    historical_vercel,
+    current: []const u8,
 };
 
 pub const Captured = union(enum) {
@@ -138,6 +144,7 @@ pub fn restoreIfMatching(
     session_dir: *io_mod.VerifiedDir,
     session_id: []const u8,
     continuity_at_ms: i64,
+    pending_authority: PendingConnectionAuthority,
     durable: *session_usage.Snapshot,
 ) !RestoreOutcome {
     var captured = try capture(alloc, session_dir);
@@ -147,6 +154,7 @@ pub fn restoreIfMatching(
         captured,
         session_id,
         continuity_at_ms,
+        pending_authority,
         durable,
     );
 }
@@ -156,11 +164,17 @@ pub fn restoreCaptured(
     captured: Captured,
     session_id: []const u8,
     continuity_at_ms: i64,
+    pending_authority: PendingConnectionAuthority,
     durable: *session_usage.Snapshot,
 ) !RestoreOutcome {
     const bytes = switch (captured) {
         .missing => {
-            try markContinuityGapIfNeeded(alloc, durable, continuity_at_ms);
+            try recoverCanonicalFallback(
+                alloc,
+                durable,
+                continuity_at_ms,
+                pending_authority,
+            );
             return .missing;
         },
         .invalid => |reason| {
@@ -169,7 +183,12 @@ pub fn restoreCaptured(
                 "event=usage_sidecar_invalid reason={s}",
                 .{reason},
             );
-            try markContinuityGapIfNeeded(alloc, durable, continuity_at_ms);
+            try recoverCanonicalFallback(
+                alloc,
+                durable,
+                continuity_at_ms,
+                pending_authority,
+            );
             return .invalid;
         },
         .encoded => |value| value,
@@ -177,14 +196,24 @@ pub fn restoreCaptured(
     var decoded = decode(alloc, bytes) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         traceInvalid(err);
-        try markContinuityGapIfNeeded(alloc, durable, continuity_at_ms);
+        try recoverCanonicalFallback(
+            alloc,
+            durable,
+            continuity_at_ms,
+            pending_authority,
+        );
         return .invalid;
     };
     var decoded_owned = true;
     defer if (decoded_owned) decoded.deinit(alloc);
     if (!std.mem.eql(u8, decoded.session_id, session_id)) {
         traceInvalid(error.UsageSidecarSessionMismatch);
-        try markContinuityGapIfNeeded(alloc, durable, continuity_at_ms);
+        try recoverCanonicalFallback(
+            alloc,
+            durable,
+            continuity_at_ms,
+            pending_authority,
+        );
         return .invalid;
     }
 
@@ -193,7 +222,12 @@ pub fn restoreCaptured(
         decoded.snapshot,
     )) {
         carryRecoveryState(durable, &decoded.snapshot);
-        try markContinuityGapIfNeeded(alloc, durable, continuity_at_ms);
+        try recoverCanonicalFallback(
+            alloc,
+            durable,
+            continuity_at_ms,
+            pending_authority,
+        );
         debug_trace.logf(
             "session",
             "event=usage_sidecar_mismatched reason=billing_projection_changed",
@@ -227,10 +261,28 @@ fn mergeRichExtensions(
         target.reasoning_tokens = source.reasoning_tokens;
         target.request_count = source.request_count;
     }
-    for (durable.pending, rich.pending) |*target, source| {
+    for (durable.pending, rich.pending) |*target, *source| {
+        std.mem.swap([]u8, &target.connection_id, &source.connection_id);
         target.observed_at_ms = source.observed_at_ms;
     }
     carryRecoveryState(durable, rich);
+}
+
+fn recoverCanonicalFallback(
+    alloc: Allocator,
+    durable: *session_usage.Snapshot,
+    continuity_at_ms: i64,
+    pending_authority: PendingConnectionAuthority,
+) !void {
+    switch (pending_authority) {
+        .historical_vercel => {},
+        .current => |connection_id| try session_usage.rebindPendingConnection(
+            alloc,
+            durable,
+            connection_id,
+        ),
+    }
+    try markContinuityGapIfNeeded(alloc, durable, continuity_at_ms);
 }
 
 fn markContinuityGapIfNeeded(
@@ -338,8 +390,8 @@ test "usage sidecar restores rich fields only for its bound session and projecti
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -376,6 +428,7 @@ test "usage sidecar restores rich fields only for its bound session and projecti
             &verified,
             "session-one",
             20,
+            .historical_vercel,
             &durable,
         ),
     );
@@ -390,6 +443,7 @@ test "usage sidecar restores rich fields only for its bound session and projecti
             &verified,
             "session-two",
             21,
+            .historical_vercel,
             &durable,
         ),
     );
@@ -407,6 +461,7 @@ test "usage sidecar restores rich fields only for its bound session and projecti
             &verified,
             "session-one",
             22,
+            .historical_vercel,
             &stale,
         ),
     );
@@ -425,6 +480,7 @@ test "usage sidecar restores rich fields only for its bound session and projecti
             &verified,
             "session-one",
             23,
+            .historical_vercel,
             &changed,
         ),
     );
@@ -449,8 +505,8 @@ test "non-billing rollback changes keep canonical values and rich metrics" {
         5,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -480,6 +536,7 @@ test "non-billing rollback changes keep canonical values and rich metrics" {
             &verified,
             "session-one",
             20,
+            .historical_vercel,
             &durable,
         ),
     );
@@ -491,7 +548,7 @@ test "non-billing rollback changes keep canonical values and rich metrics" {
     try std.testing.expectEqual(@as(usize, 0), durable.incidents.len);
 }
 
-test "missing and corrupt usage sidecars retain canonical usage with one fixed gap" {
+test "missing and corrupt sidecars retain current pending connection with one fixed gap" {
     const alloc = std.testing.allocator;
     var temp = std.testing.tmpDir(.{});
     defer temp.cleanup();
@@ -500,12 +557,21 @@ test "missing and corrupt usage sidecars retain canonical usage with one fixed g
     var usage = session_usage.Usage.initFresh();
     defer usage.deinit(alloc);
     const sequence = try usage.reserveInvocation();
-    usage.finishInvocation(sequence, 1, .unbilled);
+    try usage.finishObservedInvocation(
+        alloc,
+        sequence,
+        1,
+        .observed_generation,
+        "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "connection-a",
+        "scope-a",
+    );
     var rich = try usage.snapshot(alloc);
     defer rich.deinit(alloc);
 
     var missing = try legacyCopyForTest(alloc, rich);
     defer missing.deinit(alloc);
+    try std.testing.expectEqualStrings("vercel", missing.pending[0].connection_id);
     try std.testing.expectEqual(
         RestoreOutcome.missing,
         try restoreIfMatching(
@@ -513,11 +579,91 @@ test "missing and corrupt usage sidecars retain canonical usage with one fixed g
             &verified,
             "session-one",
             30,
+            .{ .current = "connection-a" },
             &missing,
         ),
     );
+    try std.testing.expectEqualStrings("connection-a", missing.pending[0].connection_id);
     try std.testing.expectEqual(@as(usize, 1), missing.incidents.len);
     try std.testing.expectEqual(@as(i64, 30), missing.incidents[0].occurred_at_ms);
+
+    const Probe = struct {
+        resolved_a: usize = 0,
+        resolved_vercel: usize = 0,
+        calls_a: usize = 0,
+        calls_vercel: usize = 0,
+        saw_a_credential: bool = false,
+
+        fn resolve(
+            raw: ?*anyopaque,
+            allocator: Allocator,
+            credential_ref: []const u8,
+        ) generation_usage.ResolveCredentialError!generation_usage.ResolvedCredential {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            if (std.mem.eql(u8, credential_ref, "credential-a")) {
+                self.resolved_a += 1;
+            } else if (std.mem.eql(u8, credential_ref, "credential-vercel")) {
+                self.resolved_vercel += 1;
+            } else {
+                return error.Unavailable;
+            }
+            return .{ .token = try allocator.dupe(u8, credential_ref) };
+        }
+
+        fn lookupA(
+            raw: ?*anyopaque,
+            _: Allocator,
+            input: generation_usage.LookupInput,
+        ) generation_usage.LookupError!generation_usage.LookupOutcome {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.calls_a += 1;
+            self.saw_a_credential = std.mem.eql(u8, "credential-a", input.credential);
+            return .preserve_pending;
+        }
+
+        fn lookupVercel(
+            raw: ?*anyopaque,
+            _: Allocator,
+            _: generation_usage.LookupInput,
+        ) generation_usage.LookupError!generation_usage.LookupOutcome {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.calls_vercel += 1;
+            return .preserve_pending;
+        }
+    };
+    var probe: Probe = .{};
+    var dispatch = try generation_usage.Dispatch.init(alloc, &.{
+        .{
+            .id = "connection-a",
+            .credential_ref = "credential-a",
+            .provider = .{ .context = &probe, .lookup_fn = Probe.lookupA },
+        },
+        .{
+            .id = "vercel",
+            .credential_ref = "credential-vercel",
+            .provider = .{ .context = &probe, .lookup_fn = Probe.lookupVercel },
+        },
+    }, .{ .context = &probe, .resolve_fn = Probe.resolve });
+    defer dispatch.deinit(alloc);
+    var cancel = std.atomic.Value(bool).init(false);
+    var outcome = try dispatch.lookup(
+        alloc,
+        missing.pending[0].connection_id,
+        missing.pending[0].id,
+        missing.pending[0].lookup_scope,
+        &cancel,
+    );
+    defer outcome.deinit(alloc);
+    switch (outcome) {
+        .preserve_pending => {},
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(@as(usize, 1), probe.resolved_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.resolved_vercel);
+    try std.testing.expectEqual(@as(usize, 1), probe.calls_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.calls_vercel);
+    try std.testing.expect(probe.saw_a_credential);
+
     try std.testing.expectEqual(
         RestoreOutcome.missing,
         try restoreIfMatching(
@@ -525,9 +671,11 @@ test "missing and corrupt usage sidecars retain canonical usage with one fixed g
             &verified,
             "session-one",
             30,
+            .{ .current = "connection-a" },
             &missing,
         ),
     );
+    try std.testing.expectEqualStrings("connection-a", missing.pending[0].connection_id);
     try std.testing.expectEqual(@as(usize, 1), missing.incidents.len);
 
     try io_mod.durableReplaceVerified(
@@ -545,9 +693,11 @@ test "missing and corrupt usage sidecars retain canonical usage with one fixed g
             &verified,
             "session-one",
             31,
+            .{ .current = "connection-a" },
             &corrupt,
         ),
     );
+    try std.testing.expectEqualStrings("connection-a", corrupt.pending[0].connection_id);
     try std.testing.expectEqual(@as(usize, 1), corrupt.incidents.len);
     try std.testing.expectEqual(@as(i64, 31), corrupt.incidents[0].occurred_at_ms);
 }

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -217,6 +217,21 @@ pub fn restoreCaptured(
         return .invalid;
     }
 
+    if (!pendingConnectionsMatchAuthority(decoded.snapshot, pending_authority)) {
+        try recoverCanonicalFallback(
+            alloc,
+            durable,
+            continuity_at_ms,
+            pending_authority,
+        );
+        debug_trace.logf(
+            "session",
+            "event=usage_sidecar_mismatched reason=pending_connection_changed",
+            .{},
+        );
+        return .mismatched;
+    }
+
     if (!session_usage.billingProjectionEql(
         durable.*,
         decoded.snapshot,
@@ -249,6 +264,20 @@ pub fn restoreCaptured(
     alloc.free(decoded.session_id);
     decoded_owned = false;
     return .restored;
+}
+
+fn pendingConnectionsMatchAuthority(
+    snapshot: session_usage.Snapshot,
+    authority: PendingConnectionAuthority,
+) bool {
+    const connection_id = switch (authority) {
+        .historical_vercel => return true,
+        .current => |value| value,
+    };
+    for (snapshot.pending) |pending| {
+        if (!std.mem.eql(u8, pending.connection_id, connection_id)) return false;
+    }
+    return true;
 }
 
 fn mergeRichExtensions(
@@ -564,7 +593,7 @@ test "missing and corrupt sidecars retain current pending connection with one fi
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
         "connection-a",
-        "scope-a",
+        null,
     );
     var rich = try usage.snapshot(alloc);
     defer rich.deinit(alloc);
@@ -584,6 +613,7 @@ test "missing and corrupt sidecars retain current pending connection with one fi
         ),
     );
     try std.testing.expectEqualStrings("connection-a", missing.pending[0].connection_id);
+    try std.testing.expect(missing.pending[0].lookup_scope == null);
     try std.testing.expectEqual(@as(usize, 1), missing.incidents.len);
     try std.testing.expectEqual(@as(i64, 30), missing.incidents[0].occurred_at_ms);
 
@@ -593,6 +623,7 @@ test "missing and corrupt sidecars retain current pending connection with one fi
         calls_a: usize = 0,
         calls_vercel: usize = 0,
         saw_a_credential: bool = false,
+        saw_null_scope: bool = false,
 
         fn resolve(
             raw: ?*anyopaque,
@@ -618,6 +649,7 @@ test "missing and corrupt sidecars retain current pending connection with one fi
             const self: *@This() = @ptrCast(@alignCast(raw.?));
             self.calls_a += 1;
             self.saw_a_credential = std.mem.eql(u8, "credential-a", input.credential);
+            self.saw_null_scope = input.lookup_scope == null;
             return .preserve_pending;
         }
 
@@ -663,6 +695,7 @@ test "missing and corrupt sidecars retain current pending connection with one fi
     try std.testing.expectEqual(@as(usize, 1), probe.calls_a);
     try std.testing.expectEqual(@as(usize, 0), probe.calls_vercel);
     try std.testing.expect(probe.saw_a_credential);
+    try std.testing.expect(probe.saw_null_scope);
 
     try std.testing.expectEqual(
         RestoreOutcome.missing,
@@ -698,8 +731,50 @@ test "missing and corrupt sidecars retain current pending connection with one fi
         ),
     );
     try std.testing.expectEqualStrings("connection-a", corrupt.pending[0].connection_id);
+    try std.testing.expect(corrupt.pending[0].lookup_scope == null);
     try std.testing.expectEqual(@as(usize, 1), corrupt.incidents.len);
     try std.testing.expectEqual(@as(i64, 31), corrupt.incidents[0].occurred_at_ms);
+
+    const valid_sidecar = try encode(alloc, "session-one", rich);
+    defer alloc.free(valid_sidecar);
+    const wrong_connection = try std.mem.replaceOwned(
+        u8,
+        alloc,
+        valid_sidecar,
+        "\"connection_id\":\"connection-a\"",
+        "\"connection_id\":\"vercel\"",
+    );
+    defer alloc.free(wrong_connection);
+    try writeEncoded(alloc, &verified, wrong_connection);
+    var mismatched = try legacyCopyForTest(alloc, rich);
+    defer mismatched.deinit(alloc);
+    try std.testing.expectEqualStrings("vercel", mismatched.pending[0].connection_id);
+    try std.testing.expectEqual(
+        RestoreOutcome.mismatched,
+        try restoreIfMatching(
+            alloc,
+            &verified,
+            "session-one",
+            32,
+            .{ .current = "connection-a" },
+            &mismatched,
+        ),
+    );
+    try std.testing.expectEqualStrings("connection-a", mismatched.pending[0].connection_id);
+    try std.testing.expect(mismatched.pending[0].lookup_scope == null);
+    probe = .{};
+    var mismatched_outcome = try dispatch.lookup(
+        alloc,
+        mismatched.pending[0].connection_id,
+        mismatched.pending[0].id,
+        mismatched.pending[0].lookup_scope,
+        &cancel,
+    );
+    defer mismatched_outcome.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), probe.resolved_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.resolved_vercel);
+    try std.testing.expectEqual(@as(usize, 1), probe.calls_a);
+    try std.testing.expectEqual(@as(usize, 0), probe.calls_vercel);
 }
 
 fn legacyCopyForTest(

--- a/src/core/session/usage_recovery.zig
+++ b/src/core/session/usage_recovery.zig
@@ -282,8 +282,8 @@ test "recovery registry reads only marked durable session state" {
         1,
         .observed_generation,
         "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        "vercel",
         "https://ai-gateway.vercel.sh",
-        null,
     );
     try runtime_usage.applyGeneration(alloc, .{
         .id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",

--- a/src/core/session/usage_report.zig
+++ b/src/core/session/usage_report.zig
@@ -442,7 +442,7 @@ pub fn buildSessionSnapshot(
 }
 
 pub fn validateFact(fact: GenerationFact) error{InvalidGenerationFact}!void {
-    if (!types.validGatewayGenerationId(fact.id) or
+    if (!types.validGenerationReferenceId(fact.id) or
         fact.created_at_ms < 0 or
         fact.model.len == 0 or
         fact.model.len > max_model_bytes or
@@ -464,7 +464,7 @@ pub fn validateFact(fact: GenerationFact) error{InvalidGenerationFact}!void {
 pub fn validatePendingMarker(
     marker: PendingMarker,
 ) error{InvalidPendingMarker}!void {
-    if (!types.validGatewayGenerationId(marker.id) or marker.observed_at_ms < 0) {
+    if (!types.validGenerationReferenceId(marker.id) or marker.observed_at_ms < 0) {
         return error.InvalidPendingMarker;
     }
 }

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1079,11 +1079,26 @@ pub fn validGenerationReferenceId(id: []const u8) bool {
     return true;
 }
 
+pub const null_generation_lookup_scope_sentinel = "__fx_null_generation_lookup_scope__";
+
+pub fn validGenerationLookupScope(scope: []const u8) bool {
+    if (scope.len == 0 or scope.len > 512 or
+        std.mem.eql(u8, scope, null_generation_lookup_scope_sentinel))
+    {
+        return false;
+    }
+    for (scope) |byte| if (byte < 0x20 or byte == 0x7f) return false;
+    return true;
+}
+
 test "generation references remain provider-neutral and bounded" {
     try std.testing.expect(validGenerationReferenceId("request-42"));
     try std.testing.expect(!validGenerationReferenceId("bad\nreference"));
     var oversized: [513]u8 = @splat('a');
     try std.testing.expect(!validGenerationReferenceId(&oversized));
+    try std.testing.expect(validGenerationLookupScope("legacy"));
+    try std.testing.expect(!validGenerationLookupScope(""));
+    try std.testing.expect(!validGenerationLookupScope(null_generation_lookup_scope_sentinel));
 }
 
 test "Gateway timestamps parse UTC fractions strictly" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1073,6 +1073,19 @@ pub fn validGatewayGenerationId(id: []const u8) bool {
     return true;
 }
 
+pub fn validGenerationReferenceId(id: []const u8) bool {
+    if (id.len == 0 or id.len > 512) return false;
+    for (id) |byte| if (byte < 0x20 or byte == 0x7f) return false;
+    return true;
+}
+
+test "generation references remain provider-neutral and bounded" {
+    try std.testing.expect(validGenerationReferenceId("request-42"));
+    try std.testing.expect(!validGenerationReferenceId("bad\nreference"));
+    var oversized: [513]u8 = @splat('a');
+    try std.testing.expect(!validGenerationReferenceId(&oversized));
+}
+
 test "Gateway timestamps parse UTC fractions strictly" {
     try std.testing.expectEqual(
         @as(i64, 1_775_045_467_000),

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const agent_stream_provider = @import("../agent/stream_provider.zig");
 const agent_runtime = @import("../agent/agent_runtime.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
 const route_snapshot = @import("../gateway/route_snapshot.zig");
@@ -36,6 +37,7 @@ pub const Config = struct {
     skills_prompt_section: []const u8 = "",
     explicit_skills_prompt_section: []const u8 = "",
     gateway_tools_json: []const u8,
+    provider_tools: []const agent_stream_provider.ProviderToolAdvertisement = &.{},
     custom_tool_guidance: []const u8 = "",
     context_registry: context_contract.Registry,
     context_enabled: bool,
@@ -184,6 +186,7 @@ pub fn run(
             .gateway_retry_count = config.tool_context.gateway_retry_count,
             .gateway_chat_url = config.tool_context.gateway_chat_url,
             .gateway_tools_json = config.gateway_tools_json,
+            .provider_tools = config.provider_tools,
             .custom_tool_guidance = config.custom_tool_guidance,
             .agent_step_limit = config.tool_context.agent_step_limit,
             .max_tool_result_bytes = config.tool_context.max_tool_result_bytes,

--- a/src/core/tooling/tool_advertisement.zig
+++ b/src/core/tooling/tool_advertisement.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const agent_stream_provider = @import("../agent/stream_provider.zig");
 const gateway_schema = @import("gateway_schema.zig");
 const mcp_runtime = @import("../mcp/mcp_runtime.zig");
 const permissions = @import("../permissions/permissions.zig");
@@ -13,6 +14,9 @@ pub const Options = struct {
     permission_rules: types.PermissionRuleSet = .{},
     mcp_runtime: ?*mcp_runtime.McpRuntime = null,
     subagent_available: bool = false,
+    terminal_available: bool = false,
+    provider_tools: []const agent_stream_provider.ProviderTool = &.{},
+    fx_web_search_installed: bool = false,
 };
 
 const BuildKind = enum { full, read_only };
@@ -406,13 +410,6 @@ const test_grep_files = blk: {
     break :blk spec;
 };
 
-fn writeTestWebSearchProviderAdvertisement(
-    _: Allocator,
-    writer: *std.Io.Writer,
-) tool_dispatch.GatewayAdvertisementError!void {
-    try writer.writeAll("{\"type\":\"provider\",\"id\":\"gateway.perplexity_search\",\"name\":\"perplexity_search\",\"args\":{}}");
-}
-
 const test_web_fetch = blk: {
     var spec = test_read_file;
     spec.name = "web_fetch";
@@ -443,8 +440,7 @@ const test_web_search_base = blk: {
 
 const test_web_search = blk: {
     var spec = test_web_search_base;
-    spec.write_gateway_advertisement_fn = writeTestWebSearchProviderAdvertisement;
-    spec.provider_executed = true;
+    spec.provider_tool = .web_search;
     break :blk spec;
 };
 
@@ -637,18 +633,10 @@ const test_mcp_search_tools = blk: {
     break :blk spec;
 };
 
-fn writeTestMirrorProviderAdvertisement(
-    _: Allocator,
-    writer: *std.Io.Writer,
-) tool_dispatch.GatewayAdvertisementError!void {
-    try writer.writeAll("{\"type\":\"provider\",\"id\":\"gateway.mirror_search\",\"name\":\"mirror_search\",\"args\":{}}");
-}
-
 const test_mirror_provider_tool = blk: {
     var spec = test_web_search_base;
     spec.name = "mirror_search";
-    spec.write_gateway_advertisement_fn = writeTestMirrorProviderAdvertisement;
-    spec.provider_executed = true;
+    spec.provider_tool = .web_search;
     break :blk spec;
 };
 
@@ -657,10 +645,12 @@ const test_mirror_provider_tool = blk: {
 /// with the allocator passed to the builder.
 pub const EffectiveToolProjection = struct {
     tools_json: []u8,
+    provider_tools: []agent_stream_provider.ProviderToolAdvertisement,
     custom_guidance: []u8,
 
     pub fn deinit(self: *EffectiveToolProjection, alloc: Allocator) void {
         alloc.free(self.tools_json);
+        alloc.free(self.provider_tools);
         alloc.free(self.custom_guidance);
         self.* = undefined;
     }
@@ -766,20 +756,23 @@ fn buildToolProjection(alloc: Allocator, tool_set: tool_set_contract.ToolSet, ki
     errdefer tools_out.deinit();
     var guidance_out: std.Io.Writer.Allocating = .init(alloc);
     errdefer guidance_out.deinit();
+    var provider_tools: std.ArrayList(agent_stream_provider.ProviderToolAdvertisement) = .empty;
+    errdefer provider_tools.deinit(alloc);
 
     var first = true;
     var first_custom_guidance = true;
+    var local_schema_count: usize = 0;
     try tools_out.writer.writeByte('[');
 
     for (tool_set.order) |tool_name| {
         const tool = tool_set.registry.lookup(tool_name) orelse continue;
-        try writeBuiltinTool(alloc, &tools_out.writer, &guidance_out.writer, &first, &first_custom_guidance, tool.*, kind, tool_set, options);
+        try writeBuiltinTool(alloc, &tools_out.writer, &guidance_out.writer, &provider_tools, &local_schema_count, &first, &first_custom_guidance, tool.*, kind, tool_set, options);
     }
 
     if (kind == .full) {
         for (tool_set.registry.tools) |tool| {
             if (isCanonicalToolName(tool_set, tool.name)) continue;
-            try writeBuiltinTool(alloc, &tools_out.writer, &guidance_out.writer, &first, &first_custom_guidance, tool, kind, tool_set, options);
+            try writeBuiltinTool(alloc, &tools_out.writer, &guidance_out.writer, &provider_tools, &local_schema_count, &first, &first_custom_guidance, tool, kind, tool_set, options);
         }
     }
 
@@ -787,8 +780,11 @@ fn buildToolProjection(alloc: Allocator, tool_set: tool_set_contract.ToolSet, ki
     const tools_json = try tools_out.toOwnedSlice();
     errdefer alloc.free(tools_json);
     const custom_guidance = try guidance_out.toOwnedSlice();
+    errdefer alloc.free(custom_guidance);
+    const owned_provider_tools = try provider_tools.toOwnedSlice(alloc);
     return .{
         .tools_json = tools_json,
+        .provider_tools = owned_provider_tools,
         .custom_guidance = custom_guidance,
     };
 }
@@ -863,6 +859,8 @@ fn writeBuiltinTool(
     alloc: Allocator,
     tools_writer: *std.Io.Writer,
     guidance_writer: *std.Io.Writer,
+    provider_tools: *std.ArrayList(agent_stream_provider.ProviderToolAdvertisement),
+    local_schema_count: *usize,
     first: *bool,
     first_custom_guidance: *bool,
     tool: tool_dispatch.Tool,
@@ -873,22 +871,46 @@ fn writeBuiltinTool(
     if (!includeBuiltinForKind(tool.name, kind, tool_set)) return;
     if (std.mem.eql(u8, tool.name, "subagent") and !options.subagent_available) return;
     if (std.mem.eql(u8, tool.name, "vision")) return;
-    if (options.permission_mode != .yolo) {
-        if (tool.provider_executed and !providerExecutionIsAllowed(tool.name, options.permission_rules)) return;
-        if (permissions.rulesDenyAllTargetsForTool(options.permission_rules, tool.name)) return;
-    }
-    try writeComma(tools_writer, first);
-    if (tool.write_gateway_advertisement_fn) |write_advertisement| {
-        try write_advertisement(alloc, tools_writer);
-        if (first_custom_guidance.*) {
-            first_custom_guidance.* = false;
-        } else {
-            try guidance_writer.writeAll("\n\n");
+    if (tool.provider_tool) |provider_tool| {
+        if (providerToolIsSupported(provider_tool, options.provider_tools) and
+            (options.permission_mode == .yolo or providerExecutionIsAllowed(tool.name, options.permission_rules)))
+        {
+            if (!providerAdvertisementIsPresent(provider_tools.items, provider_tool)) {
+                try provider_tools.append(alloc, .{
+                    .tool = provider_tool,
+                    .local_schema_position = local_schema_count.*,
+                });
+            }
+            if (first_custom_guidance.*) {
+                first_custom_guidance.* = false;
+            } else {
+                try guidance_writer.writeAll("\n\n");
+            }
+            try guidance_writer.writeAll(tool.description);
         }
-        try guidance_writer.writeAll(tool.description);
-        return;
+        if (tool.executor_kind != .web_search or !options.fx_web_search_installed) return;
     }
+    if (options.permission_mode != .yolo and
+        permissions.rulesDenyAllTargetsForTool(options.permission_rules, tool.name)) return;
+    try writeComma(tools_writer, first);
     try gateway_schema.writeBuiltinFunctionSchema(alloc, tools_writer, tool.gateway_schema);
+    local_schema_count.* += 1;
+}
+
+fn providerToolIsSupported(
+    needle: agent_stream_provider.ProviderTool,
+    tools: []const agent_stream_provider.ProviderTool,
+) bool {
+    for (tools) |tool| if (tool == needle) return true;
+    return false;
+}
+
+fn providerAdvertisementIsPresent(
+    tools: []const agent_stream_provider.ProviderToolAdvertisement,
+    needle: agent_stream_provider.ProviderTool,
+) bool {
+    for (tools) |tool| if (tool.tool == needle) return true;
+    return false;
 }
 
 /// A provider-executed tool is never dispatched locally, so an unsettled `ask`
@@ -1034,11 +1056,14 @@ fn appendTestMcpServer(runtime: *mcp_runtime.McpRuntime, name: []const u8) !usiz
     return index;
 }
 
-test "full routes advertise direct provider search instead of native web_search" {
+test "full routes project neutral provider search separately from local schemas" {
     var rules = [_]types.PermissionRule{
         .{ .permission = @constCast("web_search"), .pattern = @constCast("*"), .action = .allow },
     };
-    const options = Options{ .permission_rules = .{ .rules = &rules } };
+    const options = Options{
+        .permission_rules = .{ .rules = &rules },
+        .provider_tools = &.{.web_search},
+    };
     var default_projection = try buildTestGatewayToolProjection(std.testing.allocator, options);
     defer default_projection.deinit(std.testing.allocator);
     var registry_projection = try buildTestGatewayToolProjectionForRegistry(std.testing.allocator, test_all_tools[0..], options);
@@ -1048,11 +1073,41 @@ test "full routes advertise direct provider search instead of native web_search"
         const json = projection.tools_json;
         var names = try collectToolNames(std.testing.allocator, json);
         defer freeNames(std.testing.allocator, &names);
-        try expectContainsName(names.items, "perplexity_search");
+        try expectNotContainsName(names.items, "perplexity_search");
         try expectNotContainsName(names.items, "web_search");
-        try std.testing.expect(std.mem.find(u8, json, "gateway.perplexity_search") != null);
+        try std.testing.expectEqual(@as(usize, 1), projection.provider_tools.len);
+        try std.testing.expectEqual(.web_search, projection.provider_tools[0].tool);
         try std.testing.expectEqualStrings(test_web_search.description, projection.custom_guidance);
     }
+}
+
+test "explicit Fx search install keeps local and provider authorities separate" {
+    var projection = try buildTestGatewayToolProjection(std.testing.allocator, .{
+        .provider_tools = &.{.web_search},
+        .fx_web_search_installed = true,
+    });
+    defer projection.deinit(std.testing.allocator);
+
+    var names = try collectToolNames(std.testing.allocator, projection.tools_json);
+    defer freeNames(std.testing.allocator, &names);
+    try expectContainsName(names.items, "web_search");
+    try expectNotContainsName(names.items, "perplexity_search");
+    try std.testing.expectEqual(@as(usize, 1), projection.provider_tools.len);
+    try std.testing.expectEqual(.web_search, projection.provider_tools[0].tool);
+    try std.testing.expectEqualStrings(
+        "web_search",
+        names.items[projection.provider_tools[0].local_schema_position],
+    );
+    try std.testing.expectEqualStrings(test_web_search.description, projection.custom_guidance);
+}
+
+test "unsupported provider search advertises neither authority" {
+    var projection = try buildTestGatewayToolProjection(std.testing.allocator, .{});
+    defer projection.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), projection.provider_tools.len);
+    try std.testing.expect(std.mem.find(u8, projection.tools_json, "\"name\":\"web_search\"") == null);
+    try std.testing.expectEqualStrings("", projection.custom_guidance);
 }
 
 test "provider search advertisement respects no-rule allow ask and deny" {
@@ -1070,7 +1125,10 @@ test "provider search advertisement respects no-rule allow ask and deny" {
         var rules = [_]types.PermissionRule{
             .{ .permission = @constCast("web_search"), .pattern = @constCast("*"), .action = case.action orelse .deny },
         };
-        const options: Options = if (case.action) |_| .{ .permission_rules = .{ .rules = &rules } } else .{};
+        const options: Options = if (case.action) |_| .{
+            .permission_rules = .{ .rules = &rules },
+            .provider_tools = &.{.web_search},
+        } else .{ .provider_tools = &.{.web_search} };
 
         var full_projection = try buildTestGatewayToolProjection(std.testing.allocator, options);
         defer full_projection.deinit(std.testing.allocator);
@@ -1079,12 +1137,10 @@ test "provider search advertisement respects no-rule allow ask and deny" {
             const json = projection.tools_json;
             var names = try collectToolNames(std.testing.allocator, json);
             defer freeNames(std.testing.allocator, &names);
-            try std.testing.expectEqual(case.advertised, std.mem.find(u8, json, "gateway.perplexity_search") != null);
+            try std.testing.expectEqual(@as(usize, if (case.advertised) 1 else 0), projection.provider_tools.len);
             if (case.advertised) {
-                try expectContainsName(names.items, "perplexity_search");
                 try std.testing.expectEqualStrings(test_web_search.description, projection.custom_guidance);
             } else {
-                try expectNotContainsName(names.items, "perplexity_search");
                 try std.testing.expectEqualStrings("", projection.custom_guidance);
             }
             try expectNotContainsName(names.items, "web_search");
@@ -1110,13 +1166,16 @@ test "provider execution gate follows the registry declaration, not the tool nam
         var projection = try buildTestGatewayToolProjectionForRegistry(
             std.testing.allocator,
             tools[0..],
-            .{ .permission_rules = .{ .rules = &rules } },
+            .{
+                .permission_rules = .{ .rules = &rules },
+                .provider_tools = &.{.web_search},
+            },
         );
         defer projection.deinit(std.testing.allocator);
 
         try std.testing.expectEqual(
             case.advertised,
-            std.mem.find(u8, projection.tools_json, "gateway.mirror_search") != null,
+            projection.provider_tools.len == 1,
         );
         if (!case.advertised) try std.testing.expectEqualStrings("", projection.custom_guidance);
     }
@@ -1151,6 +1210,7 @@ test "yolo advertisement ignores permission filtering" {
     var projection = try buildTestGatewayToolProjection(std.testing.allocator, .{
         .permission_mode = .yolo,
         .permission_rules = .{ .rules = &rules },
+        .provider_tools = &.{.web_search},
     });
     defer projection.deinit(std.testing.allocator);
 
@@ -1158,7 +1218,8 @@ test "yolo advertisement ignores permission filtering" {
     defer freeNames(std.testing.allocator, &names);
     try expectContainsName(names.items, "terminal");
     try expectContainsName(names.items, "write_file");
-    try expectContainsName(names.items, "perplexity_search");
+    try std.testing.expectEqual(@as(usize, 1), projection.provider_tools.len);
+    try std.testing.expectEqual(.web_search, projection.provider_tools[0].tool);
 }
 
 test "edit category-wide deny strips aliased write tools" {
@@ -1245,22 +1306,8 @@ test "target-specific edit and bash denies keep tools advertised" {
     try expectContainsName(names.items, "terminal");
 }
 
-fn writeTestRegisteredProviderAdvertisement(
-    _: Allocator,
-    writer: *std.Io.Writer,
-) tool_dispatch.GatewayAdvertisementError!void {
-    try writer.writeAll("{\"type\":\"provider\",\"id\":\"fixture.registered\",\"name\":\"registered_provider\",\"args\":{}}");
-}
-
-fn writeTestSecondRegisteredProviderAdvertisement(
-    _: Allocator,
-    writer: *std.Io.Writer,
-) tool_dispatch.GatewayAdvertisementError!void {
-    try writer.writeAll("{\"type\":\"provider\",\"id\":\"fixture.second\",\"name\":\"second_provider\",\"args\":{}}");
-}
-
 fn checkEffectiveToolProjectionAllocationFailures(alloc: Allocator) !void {
-    var projection = buildTestGatewayToolProjection(alloc, .{}) catch |err|
+    var projection = buildTestGatewayToolProjection(alloc, .{ .provider_tools = &.{.web_search} }) catch |err|
         return switch (err) {
             error.WriteFailed => error.OutOfMemory,
             else => err,

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const agent_stream_provider = @import("../agent/stream_provider.zig");
 const background_runtime = @import("../background/background_runtime.zig");
 const command_admission = @import("../permissions/command_admission.zig");
 const core_permissions = @import("../permissions/permissions.zig");
@@ -25,6 +26,7 @@ const tool_result_errors = @import("tool_result_errors.zig");
 const tool_result_limits = @import("tool_result_limits.zig");
 const tool_mcp_runtime = @import("tool_mcp_runtime.zig");
 const web_search_contract = @import("web_search_contract.zig");
+const web_search_provider = @import("web_search_provider.zig");
 const context_limits = @import("../config/context_limits.zig");
 const workspace_access = @import("../workspace/workspace_access.zig");
 const terminal_client_runtime = @import("../terminal/client.zig");
@@ -48,7 +50,7 @@ pub const default_max_read_file_bytes: usize = 50 * 1024;
 pub const default_max_read_file_lines: usize = 400;
 pub const default_max_read_file_line_len: usize = 2000;
 
-pub const web_search_unavailable_message = "web_search is unavailable: no local runtime with a configured Gateway transport policy is installed";
+pub const web_search_unavailable_message = "web_search is unavailable: Fx search is not installed for this surface or selected connection";
 pub const web_fetch_unavailable_message = "web_fetch is unavailable: no local WebFetch runtime is installed";
 pub const terminal_unavailable_message =
     "{\"error\":{\"tool\":\"terminal\",\"code\":\"unsupported_host\",\"retryable\":false}}";
@@ -90,6 +92,11 @@ pub const WebSearchBackend = struct {
     ) !web_search_contract.ExecutionOutput {
         return self.execute_fn(self.ctx, ctx, request);
     }
+};
+
+pub const WebSearchInvocation = struct {
+    provider: web_search_provider.Provider,
+    inputs: web_search_provider.Inputs,
 };
 
 pub const VisionProviderFn = *const fn (
@@ -241,6 +248,7 @@ pub const DispatchContext = struct {
     web_fetch_artifact_store: ?*web_fetch_artifacts.Store = null,
     web_fetch_artifact_error: ?anyerror = null,
     web_search_backend: ?WebSearchBackend = null,
+    web_search_invocation: ?WebSearchInvocation = null,
     tool_call_id: []const u8 = "",
     tool_call_name: []const u8 = "",
     web_search_progress_ctx: ?*anyopaque = null,
@@ -338,17 +346,6 @@ pub const ReadsOnlyFn = *const fn (ToolInput) bool;
 /// Function pointer classifying whether an input is irreversible.
 pub const IrreversibleFn = *const fn (ToolInput) bool;
 
-pub const GatewayAdvertisementError = std.mem.Allocator.Error || std.Io.Writer.Error || error{
-    InvalidWebSearchBackend,
-    ConflictingDomainFilters,
-    InvalidGatewayAdvertisement,
-};
-
-pub const WriteGatewayAdvertisementFn = *const fn (
-    std.mem.Allocator,
-    *std.Io.Writer,
-) GatewayAdvertisementError!void;
-
 pub const LabelArgKind = enum {
     none,
     name,
@@ -428,11 +425,10 @@ pub const Tool = struct {
     name: []const u8,
     description: []const u8,
     gateway_schema: gateway_schema.FunctionSchema,
-    write_gateway_advertisement_fn: ?WriteGatewayAdvertisementFn = null,
-    /// Set when the provider runs the tool instead of fx dispatch. Such a tool
-    /// never reaches a call-time permission check, so advertisement is its only
+    provider_tool: ?agent_stream_provider.ProviderTool = null,
+    /// A provider tool never reaches local dispatch or a call-time permission
+    /// check, so advertisement is its only
     /// enforcement point and requires an already-settled allow.
-    provider_executed: bool = false,
     executor_kind: ExecutorKind = .list_files,
     activity_kind: core_types.ToolActivityKind = .read,
     requires_approval: bool = false,

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -863,7 +863,34 @@ fn typedDispatchContext(ctx: Context, arena: Allocator) tool_dispatch.DispatchCo
         host_capabilities.current(),
     );
     capabilities.web_search_runtime_ready =
-        ctx.web_search_runtime_ready and ctx.web_search_backend != null;
+        ctx.web_search_runtime_ready and ctx.web_search_backend != null and
+        ctx.provider_adapter.web_search != null;
+    // Availability preflight has no route; invocation still requires an exact match.
+    const web_search_route_compatible = if (ctx.route) |route|
+        ctx.provider_adapter.acceptsRoute(route)
+    else
+        true;
+    const web_search_invocation: ?tool_dispatch.WebSearchInvocation = if (ctx.route) |route|
+        if (ctx.provider_adapter.acceptsRoute(route))
+            if (ctx.provider_adapter.web_search) |provider| .{
+                .provider = provider,
+                .inputs = .{
+                    .connection_id = route.connection_id,
+                    .credential = ctx.api_key,
+                    .tenant = ctx.gateway_team,
+                    .model = route.primary_model_id,
+                    .retry_count = ctx.gateway_retry_count,
+                    .endpoint = route.endpoint,
+                    .usage = &ctx.session.usage,
+                    .usage_allocator = ctx.session_allocator,
+                },
+            } else null
+        else
+            null
+    else
+        null;
+    capabilities.web_search_runtime_ready =
+        capabilities.web_search_runtime_ready and web_search_route_compatible;
     return .{
         .allocator = arena,
         .permission_mode = ctx.permission_mode,
@@ -902,6 +929,7 @@ fn typedDispatchContext(ctx: Context, arena: Allocator) tool_dispatch.DispatchCo
         .web_fetch_artifact_error = ctx.web_fetch_artifact_error,
         .tool_capabilities = capabilities,
         .web_search_backend = ctx.web_search_backend,
+        .web_search_invocation = web_search_invocation,
         .web_search_progress_ctx = ctx.web_search_progress_ctx,
         .on_web_search_progress = ctx.on_web_search_progress,
         .web_fetch_progress_ctx = ctx.web_fetch_progress_ctx,
@@ -4517,6 +4545,68 @@ test "checkToolAvailability rejects missing web_search runtime without catalog o
     }) orelse return error.TestExpectedEqual;
 
     try std.testing.expectEqualStrings(tool_dispatch.web_search_unavailable_message, reason);
+}
+
+test "web search invocation projects the pinned route after another route is selected" {
+    const alloc = std.testing.allocator;
+    var backend = WebSearchBackendFixture{};
+    var connection_a = TestRuntime{
+        .api_key = "credential-a",
+        .gateway_team = "tenant-a",
+        .gateway_retry_count = 2,
+        .web_search_runtime_ready = true,
+        .web_search_backend = .{
+            .ctx = @ptrCast(&backend),
+            .execute_fn = WebSearchBackendFixture.search,
+        },
+    };
+    defer connection_a.deinit(alloc);
+    connection_a.route.connection_id = "connection-a";
+    connection_a.route.endpoint = "https://connection-a.invalid/chat";
+    connection_a.route.primary_model_id = "provider/model-a";
+
+    var connection_b = TestRuntime{ .api_key = "credential-b" };
+    defer connection_b.deinit(alloc);
+    connection_b.route.connection_id = "connection-b";
+    _ = connection_b.context();
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const dispatch = typedDispatchContext(connection_a.context(), arena_state.allocator());
+    const invocation = dispatch.web_search_invocation orelse return error.TestExpectedEqual;
+
+    try std.testing.expectEqualStrings("connection-a", invocation.inputs.connection_id);
+    try std.testing.expectEqualStrings("credential-a", invocation.inputs.credential);
+    try std.testing.expectEqualStrings("tenant-a", invocation.inputs.tenant.?);
+    try std.testing.expectEqualStrings("provider/model-a", invocation.inputs.model);
+    try std.testing.expectEqualStrings("https://connection-a.invalid/chat", invocation.inputs.endpoint);
+    try std.testing.expect(invocation.inputs.usage == &connection_a.session.usage);
+}
+
+test "unsupported route blocks Fx search while route-free preflight stays available" {
+    const alloc = std.testing.allocator;
+    var backend = WebSearchBackendFixture{};
+    var rt = TestRuntime{
+        .web_search_runtime_ready = true,
+        .web_search_backend = .{
+            .ctx = @ptrCast(&backend),
+            .execute_fn = WebSearchBackendFixture.search,
+        },
+    };
+    defer rt.deinit(alloc);
+    rt.route.adapter_kind = "unsupported";
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const dispatch = typedDispatchContext(rt.context(), arena_state.allocator());
+    try std.testing.expect(dispatch.web_search_invocation == null);
+    try std.testing.expect(!dispatch.tool_capabilities.web_search_runtime_ready);
+
+    var no_route = rt.context();
+    no_route.route = null;
+    const missing = typedDispatchContext(no_route, arena_state.allocator());
+    try std.testing.expect(missing.web_search_invocation == null);
+    try std.testing.expect(missing.tool_capabilities.web_search_runtime_ready);
 }
 
 test "validateToolCall rejects invalid private web_search before backend invocation" {

--- a/src/core/tooling/web_search_provider.zig
+++ b/src/core/tooling/web_search_provider.zig
@@ -6,6 +6,7 @@ const web_search_policy = @import("web_search_policy.zig");
 const Allocator = std.mem.Allocator;
 
 pub const Inputs = struct {
+    connection_id: []const u8 = "vercel",
     api_key: []const u8,
     gateway_team: ?[]const u8 = null,
     worker_model: []const u8,

--- a/src/core/tooling/web_search_provider.zig
+++ b/src/core/tooling/web_search_provider.zig
@@ -7,11 +7,11 @@ const Allocator = std.mem.Allocator;
 
 pub const Inputs = struct {
     connection_id: []const u8 = "vercel",
-    api_key: []const u8,
-    gateway_team: ?[]const u8 = null,
-    worker_model: []const u8,
-    gateway_retry_count: usize,
-    gateway_chat_url: []const u8,
+    credential: []const u8,
+    tenant: ?[]const u8 = null,
+    model: []const u8,
+    retry_count: usize,
+    endpoint: []const u8,
     usage: ?*session_usage.Usage = null,
     usage_allocator: Allocator = std.heap.c_allocator,
 };

--- a/src/core/tooling/web_search_runtime.zig
+++ b/src/core/tooling/web_search_runtime.zig
@@ -6,7 +6,6 @@ const types = @import("../shared/types.zig");
 const tool_dispatch = @import("tool_dispatch.zig");
 const tool_result_errors = @import("tool_result_errors.zig");
 const model_request_budget = @import("model_request_budget.zig");
-const session_usage = @import("../session/session_usage.zig");
 const web_search_contract = @import("web_search_contract.zig");
 const web_search_policy = @import("web_search_policy.zig");
 const web_search_provider = @import("web_search_provider.zig");
@@ -31,102 +30,24 @@ pub const Clock = struct {
 };
 
 pub const Config = struct {
-    provider: ?web_search_provider.Provider = null,
     clock: Clock = .{},
-    policy: ?web_search_policy.WebSearchPolicy = null,
-    connection_id: []const u8 = "vercel",
-    api_key: []const u8 = "",
-    gateway_team: ?[]const u8 = null,
-    worker_model: []const u8 = "",
-    gateway_retry_count: usize = 3,
-    gateway_chat_url: []const u8 = "https://ai-gateway.vercel.sh/v3/ai/language-model",
-    usage: ?*session_usage.Usage = null,
-    usage_allocator: Allocator = std.heap.c_allocator,
 };
 
 pub const Inputs = web_search_provider.Inputs;
 
-const OwnedInputs = struct {
-    connection_id: []u8,
-    api_key: []u8,
-    gateway_team: ?[]u8 = null,
-    worker_model: []u8,
-    gateway_retry_count: usize,
-    gateway_chat_url: []u8,
-    // The usage pointer and allocator borrow the parent session's lifetime.
-    usage: ?*session_usage.Usage,
-    usage_allocator: Allocator,
-
-    fn deinit(self: *OwnedInputs, alloc: Allocator) void {
-        alloc.free(self.connection_id);
-        alloc.free(self.api_key);
-        if (self.gateway_team) |team| alloc.free(team);
-        alloc.free(self.worker_model);
-        alloc.free(self.gateway_chat_url);
-        self.* = undefined;
-    }
-
-    fn borrowed(self: *const OwnedInputs) Inputs {
-        return .{
-            .connection_id = self.connection_id,
-            .api_key = self.api_key,
-            .gateway_team = self.gateway_team,
-            .worker_model = self.worker_model,
-            .gateway_retry_count = self.gateway_retry_count,
-            .gateway_chat_url = self.gateway_chat_url,
-            .usage = self.usage,
-            .usage_allocator = self.usage_allocator,
-        };
-    }
-};
-
 pub const ExecutionOutput = web_search_contract.ExecutionOutput;
 
 pub const Runtime = struct {
-    provider: ?web_search_provider.Provider,
     clock: Clock,
-    policy: web_search_policy.WebSearchPolicy,
-    connection_id: []const u8,
-    api_key: []const u8,
-    gateway_team: ?[]const u8 = null,
-    worker_model: []const u8,
-    gateway_retry_count: usize,
-    gateway_chat_url: []const u8,
-    usage: ?*session_usage.Usage,
-    usage_allocator: Allocator,
-    config_mutex: std.Io.Mutex = .init,
     fallback_cancel_flag: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     pub fn init(config: Config) Runtime {
         return .{
-            .provider = config.provider,
             .clock = config.clock,
-            .policy = config.policy orelse if (config.provider) |provider| provider.policy else .{},
-            .connection_id = config.connection_id,
-            .api_key = config.api_key,
-            .gateway_team = config.gateway_team,
-            .worker_model = config.worker_model,
-            .gateway_retry_count = config.gateway_retry_count,
-            .gateway_chat_url = config.gateway_chat_url,
-            .usage = config.usage,
-            .usage_allocator = config.usage_allocator,
         };
     }
 
     pub fn deinit(_: *Runtime) void {}
-
-    pub fn configure(self: *Runtime, inputs: Inputs) void {
-        self.config_mutex.lockUncancelable(io_mod.getIo());
-        defer self.config_mutex.unlock(io_mod.getIo());
-        self.connection_id = inputs.connection_id;
-        self.api_key = inputs.api_key;
-        self.gateway_team = inputs.gateway_team;
-        self.worker_model = inputs.worker_model;
-        self.gateway_retry_count = inputs.gateway_retry_count;
-        self.gateway_chat_url = inputs.gateway_chat_url;
-        self.usage = inputs.usage;
-        self.usage_allocator = inputs.usage_allocator;
-    }
 
     pub fn dispatchBackend(self: *Runtime) tool_dispatch.WebSearchBackend {
         return .{ .ctx = @ptrCast(self), .execute_fn = executeForDispatch };
@@ -135,41 +56,41 @@ pub const Runtime = struct {
     pub fn execute(
         self: *Runtime,
         alloc: Allocator,
+        invocation: tool_dispatch.WebSearchInvocation,
         request: web_search_contract.Request,
         cancel_flag: *std.atomic.Value(bool),
     ) !ExecutionOutput {
-        return self.executeWithProgress(alloc, request, cancel_flag, null, null);
+        return self.executeWithProgress(alloc, invocation, request, cancel_flag, null, null);
     }
 
     pub fn executeWithProgress(
         self: *Runtime,
         alloc: Allocator,
+        invocation: tool_dispatch.WebSearchInvocation,
         input: web_search_contract.Request,
         cancel_flag: *std.atomic.Value(bool),
         on_progress: ?web_search_contract.ProgressFn,
         progress_ctx: ?*anyopaque,
     ) !ExecutionOutput {
         const started_at_ms = self.clock.now();
-        var inputs = try self.inputsSnapshot(alloc);
-        defer inputs.deinit(alloc);
         if (cancel_flag.load(.seq_cst)) return error.Cancelled;
 
-        var policy = self.policy;
-        if (self.provider) |provider| {
-            if (try provider.preferredBackends()) |preferred_backends| {
-                policy.preferred_backends = preferred_backends;
-            }
+        const provider = invocation.provider;
+        const inputs = invocation.inputs;
+        var policy = provider.policy;
+        if (try provider.preferredBackends()) |preferred_backends| {
+            policy.preferred_backends = preferred_backends;
         }
         const selected_backend = web_search_policy.selectBackend(policy, .{
             .has_allowed_domains = hasValues(input.allowed_domains),
             .has_blocked_domains = hasValues(input.blocked_domains),
         }) orelse return error.UnsupportedWebSearchFeatures;
         if (!model_request_budget.searchWorkerInputFitsLimit(
-            if (self.provider) |provider| provider.input_overhead_bytes else 0,
+            provider.input_overhead_bytes,
             input.query,
             input.allowed_domains,
             input.blocked_domains,
-            self.policy.max_input_bytes,
+            policy.max_input_bytes,
         )) return error.WebSearchRequestTooLarge;
         if (cancel_flag.load(.seq_cst)) return error.Cancelled;
 
@@ -178,18 +99,18 @@ pub const Runtime = struct {
             .query = input.query,
             .allowed_domains = input.allowed_domains,
             .blocked_domains = input.blocked_domains,
-            .max_uses = self.policy.max_uses,
-            .max_results = self.policy.max_results,
-            .max_output_tokens = self.policy.max_output_tokens,
-            .max_output_chars = self.policy.max_output_chars,
-            .timeout_ms = self.policy.timeout_ms,
+            .max_uses = policy.max_uses,
+            .max_results = policy.max_results,
+            .max_output_tokens = policy.max_output_tokens,
+            .max_output_chars = policy.max_output_chars,
+            .timeout_ms = policy.timeout_ms,
             .cancel_flag = cancel_flag,
         };
 
         const transport_started_at_ms = self.clock.now();
-        var response = self.executeProvider(alloc, inputs.borrowed(), request, on_progress, progress_ctx) catch |err| {
+        var response = provider.execute(alloc, inputs, request, on_progress, progress_ctx) catch |err| {
             if (shouldRecordFailedNetworkCall(err)) {
-                recordNetworkCall(inputs.worker_model, transport_started_at_ms, self.clock.now(), 0, null, null, @errorName(err));
+                recordNetworkCall(inputs.model, transport_started_at_ms, self.clock.now(), 0, null, null, @errorName(err));
             }
             return err;
         };
@@ -198,12 +119,12 @@ pub const Runtime = struct {
         const transport_finished_at_ms = self.clock.now();
         const usage = response.usage;
         const web_search_requests = if (usage) |value| value.web_search_requests else 0;
-        recordNetworkCall(inputs.worker_model, transport_started_at_ms, transport_finished_at_ms, @intFromEnum(std.http.Status.ok), usage, response.stop_reason, "");
+        recordNetworkCall(inputs.model, transport_started_at_ms, transport_finished_at_ms, @intFromEnum(std.http.Status.ok), usage, response.stop_reason, "");
         const results = response.takeContent();
         const duration_ms = elapsedMs(started_at_ms, self.clock.now());
         debug_trace.logf("web_search", "complete backend={s} model={s} duration_ms={d} requests={d} stop_reason={s}", .{
             selected_backend.id.value,
-            inputs.worker_model,
+            inputs.model,
             duration_ms,
             web_search_requests,
             response.stop_reason orelse "(none)",
@@ -218,42 +139,6 @@ pub const Runtime = struct {
             },
             .inner_usage = usage,
         };
-    }
-
-    fn inputsSnapshot(self: *Runtime, alloc: Allocator) !OwnedInputs {
-        self.config_mutex.lockUncancelable(io_mod.getIo());
-        defer self.config_mutex.unlock(io_mod.getIo());
-        const connection_id = try alloc.dupe(u8, self.connection_id);
-        errdefer alloc.free(connection_id);
-        const api_key = try alloc.dupe(u8, self.api_key);
-        errdefer alloc.free(api_key);
-        const gateway_team = if (self.gateway_team) |team| try alloc.dupe(u8, team) else null;
-        errdefer if (gateway_team) |team| alloc.free(team);
-        const worker_model = try alloc.dupe(u8, self.worker_model);
-        errdefer alloc.free(worker_model);
-        const gateway_chat_url = try alloc.dupe(u8, self.gateway_chat_url);
-        return .{
-            .connection_id = connection_id,
-            .api_key = api_key,
-            .gateway_team = gateway_team,
-            .worker_model = worker_model,
-            .gateway_retry_count = self.gateway_retry_count,
-            .gateway_chat_url = gateway_chat_url,
-            .usage = self.usage,
-            .usage_allocator = self.usage_allocator,
-        };
-    }
-
-    fn executeProvider(
-        self: *Runtime,
-        alloc: Allocator,
-        inputs: Inputs,
-        request: web_search_contract.ProviderRequest,
-        on_progress: ?web_search_contract.ProgressFn,
-        progress_ctx: ?*anyopaque,
-    ) !web_search_contract.ProviderResponse {
-        const provider = self.provider orelse return error.MissingWebSearchProvider;
-        return provider.execute(alloc, inputs, request, on_progress, progress_ctx);
     }
 };
 
@@ -281,9 +166,11 @@ fn executeForDispatch(
     request: web_search_contract.Request,
 ) anyerror!web_search_contract.ExecutionOutput {
     const self: *Runtime = @ptrCast(@alignCast(raw_ctx));
+    const invocation = ctx.web_search_invocation orelse return error.MissingWebSearchProvider;
     var progress_forwarder = ProgressForwarder{ .dispatch = ctx };
     return self.executeWithProgress(
         ctx.allocator,
+        invocation,
         request,
         ctx.cancel_flag orelse &self.fallback_cancel_flag,
         if (ctx.on_web_search_progress != null) ProgressForwarder.onProgress else null,
@@ -359,11 +246,12 @@ const FakeProvider = struct {
     configured_inputs_seen: bool = false,
     response_kind: enum { empty, source, incomplete, interleaved_incomplete } = .empty,
     transport_error: ?enum { cancelled, timeout } = null,
+    policy: web_search_policy.WebSearchPolicy = test_policy,
 
     fn provider(self: *@This()) web_search_provider.Provider {
         return .{
             .context = @ptrCast(self),
-            .policy = test_policy,
+            .policy = self.policy,
             .preferred_backends_fn = preferredBackends,
             .execute_fn = executeProvider,
         };
@@ -383,10 +271,10 @@ const FakeProvider = struct {
         progress_ctx: ?*anyopaque,
     ) !web_search_contract.ProviderResponse {
         const self: *@This() = @ptrCast(@alignCast(raw_ctx orelse return error.MissingTestProvider));
-        self.configured_inputs_seen = std.mem.eql(u8, inputs.api_key, "provider-key") and
-            std.mem.eql(u8, inputs.worker_model, "provider/private-worker") and
-            inputs.gateway_retry_count == 2 and
-            std.mem.eql(u8, inputs.gateway_chat_url, "https://gateway.test/chat");
+        self.configured_inputs_seen = std.mem.eql(u8, inputs.credential, "provider-key") and
+            std.mem.eql(u8, inputs.model, "provider/private-worker") and
+            inputs.retry_count == 2 and
+            std.mem.eql(u8, inputs.endpoint, "https://gateway.test/chat");
         return execute(@ptrCast(self), alloc, request, on_progress, progress_ctx);
     }
 
@@ -506,28 +394,28 @@ const test_policy = web_search_policy.WebSearchPolicy{
     .backend_policies = &test_backend_policies,
 };
 
-fn fakeRuntime(fake: *FakeProvider) Runtime {
-    return Runtime.init(.{
+fn testInvocation(fake: *FakeProvider) tool_dispatch.WebSearchInvocation {
+    return .{
         .provider = fake.provider(),
-        .worker_model = "provider/private-worker",
-    });
+        .inputs = .{
+            .connection_id = "connection-a",
+            .credential = "provider-key",
+            .model = "provider/private-worker",
+            .retry_count = 2,
+            .endpoint = "https://gateway.test/chat",
+        },
+    };
 }
 
 test "runtime routes configured inputs and backend selection through provider" {
     const alloc = std.testing.allocator;
     const secondary_only = [_]web_search_contract.SearchBackendId{test_secondary_backend};
     var fake = FakeProvider{ .preferred_backends = &secondary_only };
-    var runtime = Runtime.init(.{
-        .provider = fake.provider(),
-        .api_key = "provider-key",
-        .worker_model = "provider/private-worker",
-        .gateway_retry_count = 2,
-        .gateway_chat_url = "https://gateway.test/chat",
-    });
+    var runtime = Runtime.init(.{});
     var cancel_flag = std.atomic.Value(bool).init(false);
     const input = web_search_contract.Request{ .query = "latest Zig release" };
 
-    var output = try runtime.execute(alloc, input, &cancel_flag);
+    var output = try runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag);
     defer output.deinit(alloc);
 
     try std.testing.expect(fake.configured_inputs_seen);
@@ -535,14 +423,38 @@ test "runtime routes configured inputs and backend selection through provider" {
     try std.testing.expect(test_secondary_backend.eql(fake.last_backend.?));
 }
 
+test "pinned connection A search ignores later connection B selection" {
+    const alloc = std.testing.allocator;
+    var connection_a = FakeProvider{ .response_kind = .source };
+    var connection_b = FakeProvider{};
+    const pinned_a = testInvocation(&connection_a);
+    var selected = pinned_a;
+    selected = testInvocation(&connection_b);
+    try std.testing.expect(selected.provider.context != pinned_a.provider.context);
+    var runtime = Runtime.init(.{});
+    var cancel_flag = std.atomic.Value(bool).init(false);
+
+    var output = try runtime.execute(
+        alloc,
+        pinned_a,
+        .{ .query = "latest Zig release" },
+        &cancel_flag,
+    );
+    defer output.deinit(alloc);
+
+    try std.testing.expect(connection_a.configured_inputs_seen);
+    try std.testing.expectEqual(@as(usize, 1), connection_a.calls);
+    try std.testing.expectEqual(@as(usize, 0), connection_b.calls);
+}
+
 test "runtime invokes primary backend after allow" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     var cancel_flag = std.atomic.Value(bool).init(false);
     const input = web_search_contract.Request{ .query = "latest Zig release" };
 
-    var output = try runtime.execute(alloc, input, &cancel_flag);
+    var output = try runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag);
     defer output.deinit(alloc);
 
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
@@ -552,12 +464,12 @@ test "runtime invokes primary backend after allow" {
 test "runtime invokes secondary backend after allow" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
-    runtime.policy.preferred_backends = &.{test_secondary_backend};
+    var runtime = Runtime.init(.{});
+    fake.policy.preferred_backends = &.{test_secondary_backend};
     var cancel_flag = std.atomic.Value(bool).init(false);
     const input = web_search_contract.Request{ .query = "latest Zig release" };
 
-    var output = try runtime.execute(alloc, input, &cancel_flag);
+    var output = try runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag);
     defer output.deinit(alloc);
 
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
@@ -567,14 +479,14 @@ test "runtime invokes secondary backend after allow" {
 test "runtime falls back before request when first backend cannot satisfy strict filter" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     var unsupported = test_backend_policies[0];
     unsupported.features.allowed_domains = .unsupported;
     const backends = [_]web_search_policy.BackendPolicy{
         unsupported,
         test_backend_policies[1],
     };
-    runtime.policy.backend_policies = &backends;
+    fake.policy.backend_policies = &backends;
     var cancel_flag = std.atomic.Value(bool).init(false);
     const allowed_domains = [_][]const u8{"ziglang.org"};
     const input = web_search_contract.Request{
@@ -582,7 +494,7 @@ test "runtime falls back before request when first backend cannot satisfy strict
         .allowed_domains = &allowed_domains,
     };
 
-    var output = try runtime.execute(alloc, input, &cancel_flag);
+    var output = try runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag);
     defer output.deinit(alloc);
 
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
@@ -592,11 +504,11 @@ test "runtime falls back before request when first backend cannot satisfy strict
 test "unsupported strict filters perform zero backend search requests" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     var unsupported = test_backend_policies[0];
     unsupported.features.allowed_domains = .unsupported;
-    runtime.policy.preferred_backends = &.{test_primary_backend};
-    runtime.policy.backend_policies = &.{unsupported};
+    fake.policy.preferred_backends = &.{test_primary_backend};
+    fake.policy.backend_policies = &.{unsupported};
     var cancel_flag = std.atomic.Value(bool).init(false);
     const allowed_domains = [_][]const u8{"ziglang.org"};
     const input = web_search_contract.Request{
@@ -604,42 +516,43 @@ test "unsupported strict filters perform zero backend search requests" {
         .allowed_domains = &allowed_domains,
     };
 
-    try std.testing.expectError(error.UnsupportedWebSearchFeatures, runtime.execute(alloc, input, &cancel_flag));
+    try std.testing.expectError(error.UnsupportedWebSearchFeatures, runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag));
     try std.testing.expectEqual(@as(usize, 0), fake.calls);
 }
 
 test "oversized worker request performs zero backend search requests" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
-    runtime.policy.max_input_bytes = 8;
+    var runtime = Runtime.init(.{});
+    fake.policy.max_input_bytes = 8;
     var cancel_flag = std.atomic.Value(bool).init(false);
     const input = web_search_contract.Request{ .query = "latest Zig release" };
 
-    try std.testing.expectError(error.WebSearchRequestTooLarge, runtime.execute(alloc, input, &cancel_flag));
+    try std.testing.expectError(error.WebSearchRequestTooLarge, runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag));
     try std.testing.expectEqual(@as(usize, 0), fake.calls);
 }
 
 test "cancelled runtime performs zero backend search requests" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     var cancel_flag = std.atomic.Value(bool).init(true);
     const input = web_search_contract.Request{ .query = "latest Zig release" };
 
-    try std.testing.expectError(error.Cancelled, runtime.execute(alloc, input, &cancel_flag));
+    try std.testing.expectError(error.Cancelled, runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag));
     try std.testing.expectEqual(@as(usize, 0), fake.calls);
 }
 
-test "missing provider records no network request" {
+test "missing selected adapter invocation records no network request" {
     const alloc = std.testing.allocator;
     diagnostics.resetForTest();
     defer diagnostics.resetForTest();
-    var runtime = Runtime.init(.{ .policy = test_policy });
-    var cancel_flag = std.atomic.Value(bool).init(false);
-    const input = web_search_contract.Request{ .query = "latest Zig release" };
-
-    try std.testing.expectError(error.MissingWebSearchProvider, runtime.execute(alloc, input, &cancel_flag));
+    var runtime = Runtime.init(.{});
+    try std.testing.expectError(error.MissingWebSearchProvider, executeForDispatch(
+        @ptrCast(&runtime),
+        .{ .allocator = alloc },
+        .{ .query = "latest Zig release" },
+    ));
     var calls: [diagnostics.network_ring_capacity]diagnostics.NetworkCall = undefined;
     try std.testing.expectEqual(@as(usize, 0), diagnostics.snapshotNetworkCalls(&calls));
 }
@@ -647,18 +560,18 @@ test "missing provider records no network request" {
 test "runtime normalizes source usage and terminal incomplete state" {
     const alloc = std.testing.allocator;
     var source_fake = FakeProvider{ .response_kind = .source };
-    var source_runtime = fakeRuntime(&source_fake);
+    var source_runtime = Runtime.init(.{});
     var cancel_flag = std.atomic.Value(bool).init(false);
     const input = web_search_contract.Request{ .query = "latest Zig release" };
 
-    var source = try source_runtime.execute(alloc, input, &cancel_flag);
+    var source = try source_runtime.execute(alloc, testInvocation(&source_fake), input, &cancel_flag);
     defer source.deinit(alloc);
     try std.testing.expectEqualStrings("Zig release", source.output.results[0].search.content[0].title);
     try std.testing.expectEqual(@as(u32, 1), source.inner_usage.?.web_search_requests);
 
     var incomplete_fake = FakeProvider{ .response_kind = .incomplete };
-    var incomplete_runtime = fakeRuntime(&incomplete_fake);
-    var incomplete = try incomplete_runtime.execute(alloc, input, &cancel_flag);
+    var incomplete_runtime = Runtime.init(.{});
+    var incomplete = try incomplete_runtime.execute(alloc, testInvocation(&incomplete_fake), input, &cancel_flag);
     defer incomplete.deinit(alloc);
     try std.testing.expect(incomplete.output.incomplete);
     try std.testing.expectEqualStrings("max_tokens", incomplete.output.results[1].terminal_incomplete.stop_reason);
@@ -667,11 +580,11 @@ test "runtime normalizes source usage and terminal incomplete state" {
 test "runtime preserves ordered commentary search errors sources and terminal incomplete state" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{ .response_kind = .interleaved_incomplete };
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     var cancel_flag = std.atomic.Value(bool).init(false);
     const input = web_search_contract.Request{ .query = "latest Zig release" };
 
-    var output = try runtime.execute(alloc, input, &cancel_flag);
+    var output = try runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag);
     defer output.deinit(alloc);
 
     try std.testing.expectEqual(@as(usize, 6), output.output.results.len);
@@ -687,11 +600,11 @@ test "runtime preserves ordered commentary search errors sources and terminal in
 test "runtime reports bounded backend timeout" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{ .transport_error = .timeout };
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     var cancel_flag = std.atomic.Value(bool).init(false);
     const input = web_search_contract.Request{ .query = "latest Zig release" };
 
-    try std.testing.expectError(error.TimeoutExpired, runtime.execute(alloc, input, &cancel_flag));
+    try std.testing.expectError(error.TimeoutExpired, runtime.execute(alloc, testInvocation(&fake), input, &cancel_flag));
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
 }
 
@@ -710,7 +623,7 @@ fn allowPermission(_: *const tool_dispatch.Tool, _: tool_dispatch.ToolInput, _: 
 test "denied web_search performs zero backend search requests" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     const registry = tool_dispatch.Registry{ .tools = &.{test_builtin_tools.web_search} };
 
     permission_decider_calls = 0;
@@ -719,6 +632,7 @@ test "denied web_search performs zero backend search requests" {
         .permission_decider = denyPermission,
         .tool_capabilities = .{ .web_search_runtime_ready = true },
         .web_search_backend = runtime.dispatchBackend(),
+        .web_search_invocation = testInvocation(&fake),
     }, registry, .{
         .id = "search",
         .name = "web_search",
@@ -733,7 +647,7 @@ test "denied web_search performs zero backend search requests" {
 test "invalid web_search performs zero backend search requests" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     const registry = tool_dispatch.Registry{ .tools = &.{test_builtin_tools.web_search} };
 
     permission_decider_calls = 0;
@@ -742,6 +656,7 @@ test "invalid web_search performs zero backend search requests" {
         .permission_decider = allowPermission,
         .tool_capabilities = .{ .web_search_runtime_ready = true },
         .web_search_backend = runtime.dispatchBackend(),
+        .web_search_invocation = testInvocation(&fake),
     }, registry, .{
         .id = "search",
         .name = "web_search",
@@ -774,7 +689,7 @@ test "missing runtime web_search performs zero backend search requests" {
 test "allowed web_search invokes selected backend exactly once" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{ .response_kind = .source };
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     const registry = tool_dispatch.Registry{ .tools = &.{test_builtin_tools.web_search} };
 
     permission_decider_calls = 0;
@@ -783,6 +698,7 @@ test "allowed web_search invokes selected backend exactly once" {
         .permission_decider = allowPermission,
         .tool_capabilities = .{ .web_search_runtime_ready = true },
         .web_search_backend = runtime.dispatchBackend(),
+        .web_search_invocation = testInvocation(&fake),
     }, registry, .{
         .id = "search",
         .name = "web_search",
@@ -801,7 +717,7 @@ test "allowed web_search invokes selected backend exactly once" {
 test "cancelled registered web_search performs zero backend requests" {
     const alloc = std.testing.allocator;
     var fake = FakeProvider{};
-    var runtime = fakeRuntime(&fake);
+    var runtime = Runtime.init(.{});
     const registry = tool_dispatch.Registry{ .tools = &.{test_builtin_tools.web_search} };
     var cancel_flag = std.atomic.Value(bool).init(true);
 
@@ -812,6 +728,7 @@ test "cancelled registered web_search performs zero backend requests" {
         .permission_decider = allowPermission,
         .tool_capabilities = .{ .web_search_runtime_ready = true },
         .web_search_backend = runtime.dispatchBackend(),
+        .web_search_invocation = testInvocation(&fake),
     }, registry, .{
         .id = "search",
         .name = "web_search",
@@ -823,80 +740,4 @@ test "cancelled registered web_search performs zero backend requests" {
     try std.testing.expectEqual(@as(usize, 0), fake.calls);
     try std.testing.expectEqual(.failure, result.status);
     try std.testing.expect(tool_result_errors.isToolExecutionFailedOutput(result.body));
-}
-
-const SearchConfigStress = struct {
-    runtime: *Runtime,
-    inputs: Inputs,
-
-    fn run(self: SearchConfigStress) void {
-        for (0..2000) |_| self.runtime.configure(self.inputs);
-    }
-};
-
-test "web_search runtime updates its worker model during configuration" {
-    var runtime = Runtime.init(.{});
-    runtime.configure(.{
-        .api_key = "key",
-        .worker_model = "provider/model",
-        .gateway_retry_count = 2,
-        .gateway_chat_url = "https://gateway.test/chat",
-    });
-
-    try std.testing.expectEqualStrings("provider/model", runtime.worker_model);
-    try std.testing.expectEqualStrings("key", runtime.api_key);
-    try std.testing.expectEqual(@as(usize, 2), runtime.gateway_retry_count);
-    try std.testing.expectEqualStrings("https://gateway.test/chat", runtime.gateway_chat_url);
-}
-
-test "web_search runtime preserves session usage through worker input snapshots" {
-    const alloc = std.testing.allocator;
-    var usage = session_usage.Usage.initFresh();
-    defer usage.deinit(alloc);
-    var runtime = Runtime.init(.{
-        .usage = &usage,
-        .usage_allocator = alloc,
-    });
-
-    var inputs = try runtime.inputsSnapshot(alloc);
-    defer inputs.deinit(alloc);
-
-    try std.testing.expect(inputs.usage.? == &usage);
-    try std.testing.expect(std.meta.eql(alloc, inputs.usage_allocator));
-}
-
-test "web_search input snapshots stay coherent during parallel reconfiguration" {
-    var runtime = Runtime.init(.{});
-    const inputs_a = Inputs{
-        .api_key = "key-a",
-        .worker_model = "model-a",
-        .gateway_retry_count = 1,
-        .gateway_chat_url = "https://a.invalid/chat",
-    };
-    const inputs_b = Inputs{
-        .api_key = "key-b",
-        .worker_model = "model-b",
-        .gateway_retry_count = 2,
-        .gateway_chat_url = "https://b.invalid/chat",
-    };
-    runtime.configure(inputs_a);
-
-    const thread_a = try std.Thread.spawn(.{}, SearchConfigStress.run, .{SearchConfigStress{ .runtime = &runtime, .inputs = inputs_a }});
-    defer thread_a.join();
-    const thread_b = try std.Thread.spawn(.{}, SearchConfigStress.run, .{SearchConfigStress{ .runtime = &runtime, .inputs = inputs_b }});
-    defer thread_b.join();
-
-    for (0..2000) |_| {
-        var snapshot = try runtime.inputsSnapshot(std.testing.allocator);
-        defer snapshot.deinit(std.testing.allocator);
-        const matches_a = std.mem.eql(u8, snapshot.api_key, inputs_a.api_key) and
-            std.mem.eql(u8, snapshot.worker_model, inputs_a.worker_model) and
-            snapshot.gateway_retry_count == inputs_a.gateway_retry_count and
-            std.mem.eql(u8, snapshot.gateway_chat_url, inputs_a.gateway_chat_url);
-        const matches_b = std.mem.eql(u8, snapshot.api_key, inputs_b.api_key) and
-            std.mem.eql(u8, snapshot.worker_model, inputs_b.worker_model) and
-            snapshot.gateway_retry_count == inputs_b.gateway_retry_count and
-            std.mem.eql(u8, snapshot.gateway_chat_url, inputs_b.gateway_chat_url);
-        try std.testing.expect(matches_a or matches_b);
-    }
 }

--- a/src/core/tooling/web_search_runtime.zig
+++ b/src/core/tooling/web_search_runtime.zig
@@ -34,6 +34,7 @@ pub const Config = struct {
     provider: ?web_search_provider.Provider = null,
     clock: Clock = .{},
     policy: ?web_search_policy.WebSearchPolicy = null,
+    connection_id: []const u8 = "vercel",
     api_key: []const u8 = "",
     gateway_team: ?[]const u8 = null,
     worker_model: []const u8 = "",
@@ -46,6 +47,7 @@ pub const Config = struct {
 pub const Inputs = web_search_provider.Inputs;
 
 const OwnedInputs = struct {
+    connection_id: []u8,
     api_key: []u8,
     gateway_team: ?[]u8 = null,
     worker_model: []u8,
@@ -56,6 +58,7 @@ const OwnedInputs = struct {
     usage_allocator: Allocator,
 
     fn deinit(self: *OwnedInputs, alloc: Allocator) void {
+        alloc.free(self.connection_id);
         alloc.free(self.api_key);
         if (self.gateway_team) |team| alloc.free(team);
         alloc.free(self.worker_model);
@@ -65,6 +68,7 @@ const OwnedInputs = struct {
 
     fn borrowed(self: *const OwnedInputs) Inputs {
         return .{
+            .connection_id = self.connection_id,
             .api_key = self.api_key,
             .gateway_team = self.gateway_team,
             .worker_model = self.worker_model,
@@ -82,6 +86,7 @@ pub const Runtime = struct {
     provider: ?web_search_provider.Provider,
     clock: Clock,
     policy: web_search_policy.WebSearchPolicy,
+    connection_id: []const u8,
     api_key: []const u8,
     gateway_team: ?[]const u8 = null,
     worker_model: []const u8,
@@ -97,6 +102,7 @@ pub const Runtime = struct {
             .provider = config.provider,
             .clock = config.clock,
             .policy = config.policy orelse if (config.provider) |provider| provider.policy else .{},
+            .connection_id = config.connection_id,
             .api_key = config.api_key,
             .gateway_team = config.gateway_team,
             .worker_model = config.worker_model,
@@ -112,6 +118,7 @@ pub const Runtime = struct {
     pub fn configure(self: *Runtime, inputs: Inputs) void {
         self.config_mutex.lockUncancelable(io_mod.getIo());
         defer self.config_mutex.unlock(io_mod.getIo());
+        self.connection_id = inputs.connection_id;
         self.api_key = inputs.api_key;
         self.gateway_team = inputs.gateway_team;
         self.worker_model = inputs.worker_model;
@@ -216,6 +223,8 @@ pub const Runtime = struct {
     fn inputsSnapshot(self: *Runtime, alloc: Allocator) !OwnedInputs {
         self.config_mutex.lockUncancelable(io_mod.getIo());
         defer self.config_mutex.unlock(io_mod.getIo());
+        const connection_id = try alloc.dupe(u8, self.connection_id);
+        errdefer alloc.free(connection_id);
         const api_key = try alloc.dupe(u8, self.api_key);
         errdefer alloc.free(api_key);
         const gateway_team = if (self.gateway_team) |team| try alloc.dupe(u8, team) else null;
@@ -224,6 +233,7 @@ pub const Runtime = struct {
         errdefer alloc.free(worker_model);
         const gateway_chat_url = try alloc.dupe(u8, self.gateway_chat_url);
         return .{
+            .connection_id = connection_id,
             .api_key = api_key,
             .gateway_team = gateway_team,
             .worker_model = worker_model,

--- a/src/gateway/generation_usage.zig
+++ b/src/gateway/generation_usage.zig
@@ -16,13 +16,14 @@ fn lookup(
     alloc: Allocator,
     input: generation_usage_provider.LookupInput,
 ) generation_usage_provider.LookupError!generation_usage_provider.LookupOutcome {
-    if (!client.isTrustedGenerationOrigin(input.origin)) return .reject;
+    const origin = input.lookup_scope orelse return .reject;
+    if (!client.isTrustedGenerationOrigin(origin)) return .reject;
 
     var response = client.fetchGatewayGenerationResult(
         alloc,
         input.credential,
         input.tenant,
-        input.origin,
+        origin,
         input.generation_id,
         input.cancel_flag,
     ) catch |err| switch (err) {
@@ -34,7 +35,7 @@ fn lookup(
                 "generation usage lookup failed reason={s}",
                 .{@errorName(err)},
             );
-            return error.Unavailable;
+            return .retry;
         },
     };
     defer response.deinit(alloc);
@@ -272,7 +273,7 @@ test "generation lookup rejects untrusted origins before transport" {
     const outcome = try provider.lookup(std.testing.allocator, .{
         .credential = "unused",
         .tenant = null,
-        .origin = "https://example.com",
+        .lookup_scope = "https://example.com",
         .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
         .cancel_flag = &cancel,
     });

--- a/src/main.zig
+++ b/src/main.zig
@@ -123,6 +123,7 @@ const web_search_runtime = @import("core/tooling/web_search_runtime.zig");
 const worker_runtime = @import("core/agent/worker_runtime.zig");
 const question_prompt = @import("core/agent/question_prompt.zig");
 const gateway_client = @import("gateway/client.zig");
+const model_catalog = @import("core/gateway/model_catalog.zig");
 const js_host_stream_provider = @import("gateway/js_host_stream_provider.zig");
 const js_host_model_catalog = @import("gateway/js_host_model_catalog.zig");
 const url_opener = @import("core/hosts/url_opener.zig");
@@ -474,9 +475,25 @@ const App = struct {
     }
 
     pub fn providerAdapter(self: *const Self) agent_stream_provider.ProviderAdapter {
-        var adapter = builtin_gateway.provider_adapter;
+        var adapter = if (comptime host_target.is_wasm)
+            agent_stream_provider.ProviderAdapter{
+                .kind = builtin_gateway.connection_seed.adapter_id,
+                .model_catalog = js_host_model_catalog.provider,
+                .model_descriptors = builtin_gateway.model_descriptor_provider,
+                .provider_tools = &.{.web_search},
+                .stream_fn = builtin_gateway.streamVercelAdapter,
+            }
+        else
+            builtin_gateway.provider_adapter;
         adapter.legacy_provider = self.agentStreamProvider();
         return adapter;
+    }
+
+    fn selectedModelCatalogProvider(self: *const Self) ?model_catalog.Provider {
+        const profile = self.auth.selectedConnectionProfile() catch return null;
+        const adapter = self.providerAdapter();
+        if (!std.mem.eql(u8, profile.adapter_id, adapter.kind)) return null;
+        return adapter.model_catalog;
     }
 
     pub fn activeConnectionId(self: *const Self) []const u8 {
@@ -625,9 +642,7 @@ const App = struct {
     permission_state: app_permission_runtime.State = .{},
     agent_step_limit: usize = default_max_agent_steps,
     web_fetch_runtime: web_fetch_runtime.Runtime = web_fetch_runtime.Runtime.init(.{}),
-    web_search_runtime: web_search_runtime.Runtime = web_search_runtime.Runtime.init(.{
-        .provider = if (host_profile.web_search) builtin_gateway.default_web_search_provider else null,
-    }),
+    web_search_runtime: web_search_runtime.Runtime = web_search_runtime.Runtime.init(.{}),
     web_search_models_path: []const u8 = builtin_gateway.models_path,
     lifecycle_runtime: hooks.Runtime = hooks.Runtime.init(std.heap.c_allocator),
     lifecycle_view: hooks.RuntimeView = hooks.RuntimeView.empty(),
@@ -1725,6 +1740,11 @@ const App = struct {
             .permission_mode = permission_mode,
             .permission_rules = permission_rules,
             .subagent_available = self.session_persistence.subagent_host != null,
+            .terminal_available = self.session_persistence.subagent_host != null and
+                tool_dispatch.ToolCapabilities.for_host(host.current()).terminalAvailable(),
+            .provider_tools = self.providerAdapter().provider_tools,
+            .fx_web_search_installed = host_profile.web_search and
+                self.providerAdapter().web_search != null,
         });
     }
 
@@ -1887,26 +1907,31 @@ const App = struct {
     }
 
     pub fn fetchModelIds(self: *App) !std.ArrayList([]u8) {
+        const provider = self.selectedModelCatalogProvider() orelse return error.Unavailable;
         return AgentAppRuntime.fetchModelIds(
             self,
-            if (comptime host_target.is_wasm) js_host_model_catalog.provider else builtin_gateway.model_catalog_provider,
+            provider,
             builtin_gateway.models_path,
         );
     }
 
     pub fn startModelCacheWarmup(self: *App) void {
+        const provider = self.selectedModelCatalogProvider() orelse {
+            debug_trace.logf("gateway", "model_cache_warmup_skipped reason=unsupported_adapter", .{});
+            return;
+        };
         if (comptime host_profile.cooperative_agent) {
             if (self.auth.credentialNeedsRefresh()) {
                 debug_trace.logf("auth", "model_cache_warmup_deferred reason=credential_refresh_required", .{});
                 return;
             }
             self.model_cache.loadCooperative(
-                js_host_model_catalog.provider,
+                provider,
                 self.auth.modelCatalogAccess(),
             );
         } else {
             self.model_cache.startWarmup(
-                builtin_gateway.model_catalog_provider,
+                provider,
                 self.auth.modelCatalogAccess(),
             );
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -49,6 +49,7 @@ const builtin_context = @import("builtins/context.zig");
 const builtin_devbox = @import("builtins/devbox.zig");
 const builtin_gateway = @import("builtins/gateway.zig");
 const gateway_provider = @import("core/gateway/gateway_provider.zig");
+const output_contracts = @import("core/output/output_contracts.zig");
 const generation_usage_provider = @import("core/session/generation_usage_provider.zig");
 const route_snapshot = @import("core/gateway/route_snapshot.zig");
 const agent_stream_provider = @import("core/agent/stream_provider.zig");
@@ -423,8 +424,28 @@ const App = struct {
             host.unavailable_url_opener;
     }
 
-    pub fn creditsProvider(_: *const Self) gateway_provider.CreditsProvider {
-        return builtin_gateway.credits_provider;
+    pub fn fetchAccountUsage(self: *Self) !output_contracts.CreditsSnapshot {
+        const profile = try self.auth.selectedConnectionProfile();
+        const adapter = self.providerAdapter();
+        const provider = if (std.mem.eql(u8, profile.adapter_id, adapter.kind))
+            adapter.account_usage
+        else
+            null;
+        const account_usage = provider orelse return .{
+            .err_message = try self.alloc.dupe(
+                u8,
+                "account usage unavailable for selected connection",
+            ),
+        };
+        var credential = try self.auth.resolveCredentialReference(
+            self.alloc,
+            profile.credential_ref,
+        );
+        defer credential.deinit(self.alloc);
+        return account_usage.fetch(self.alloc, .{
+            .credential = credential.token,
+            .tenant = credential.gatewayTeam(),
+        });
     }
 
     pub fn agentStreamProvider(_: *const Self) agent_stream_provider.Provider {
@@ -456,6 +477,11 @@ const App = struct {
         var adapter = builtin_gateway.provider_adapter;
         adapter.legacy_provider = self.agentStreamProvider();
         return adapter;
+    }
+
+    pub fn activeConnectionId(self: *const Self) []const u8 {
+        return (self.auth.selectedConnectionProfile() catch
+            return builtin_gateway.connection_seed.id).id;
     }
 
     pub fn resolveRouteCredential(
@@ -491,6 +517,56 @@ const App = struct {
             .tenant = tenant,
             .legacy_source = credential.source,
         };
+    }
+
+    fn resolveGenerationUsageCredential(
+        raw: ?*anyopaque,
+        alloc: Allocator,
+        credential_ref: []const u8,
+    ) generation_usage_provider.ResolveCredentialError!generation_usage_provider.ResolvedCredential {
+        const self: *App = @ptrCast(@alignCast(raw.?));
+        var credential = self.auth.resolveCredentialReference(
+            alloc,
+            credential_ref,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.Unavailable,
+        };
+        defer credential.deinit(alloc);
+        const tenant = if (credential.gatewayTeam()) |value| try alloc.dupe(u8, value) else null;
+        errdefer if (tenant) |value| alloc.free(value);
+        const token = credential.token;
+        credential.token = &.{};
+        return .{ .token = token, .tenant = tenant };
+    }
+
+    fn prepareGenerationUsageDispatch(
+        raw: ?*anyopaque,
+        alloc: Allocator,
+    ) generation_usage_provider.PrepareError!generation_usage_provider.Dispatch {
+        const self: *App = @ptrCast(@alignCast(raw.?));
+        const profiles = self.auth.connectionList();
+        if (profiles.len == 0) return error.Unavailable;
+        const inputs = try alloc.alloc(
+            generation_usage_provider.ConnectionInput,
+            profiles.len,
+        );
+        defer alloc.free(inputs);
+        const adapter = self.providerAdapter();
+        for (profiles, 0..) |profile, index| {
+            inputs[index] = .{
+                .id = profile.id,
+                .credential_ref = profile.credential_ref,
+                .provider = if (std.mem.eql(u8, profile.adapter_id, adapter.kind))
+                    adapter.generation_usage
+                else
+                    null,
+            };
+        }
+        return generation_usage_provider.Dispatch.init(alloc, inputs, .{
+            .context = self,
+            .resolve_fn = resolveGenerationUsageCredential,
+        });
     }
 
     pub fn admitSubagentWorkRoute(
@@ -558,13 +634,7 @@ const App = struct {
     notifications: builtin_hooks.notifications.State = .{},
     herdr: builtin_hooks.Client = .{},
 
-    session: SessionRuntime = SessionRuntime.init(
-        max_history_turns,
-        if (host_profile.generation_usage)
-            builtin_gateway.generation_usage_provider
-        else
-            generation_usage_provider.unavailable_provider,
-    ),
+    session: SessionRuntime = SessionRuntime.init(max_history_turns),
     session_persistence: app_session_runtime.Persistence = .{},
     prompt_history: PromptHistoryRuntime = .{},
     requested_resume: ?cli_surface.ResumeTarget = null,
@@ -725,6 +795,10 @@ const App = struct {
     }
 
     pub fn rebindAfterInit(self: *App) void {
+        self.session.usage.configureReconciliationSource(.{
+            .context = self,
+            .prepare_fn = prepareGenerationUsageDispatch,
+        });
         SessionAppRuntime.rebindSubagentHost(self);
     }
 

--- a/src/napi_core_main.zig
+++ b/src/napi_core_main.zig
@@ -433,21 +433,15 @@ const Runtime = struct {
 
     fn run(self: *Runtime) void {
         const agent_stream = host_stream_provider.provider(&self.stream_context);
+        var provider_adapter = builtin_gateway.provider_adapter;
+        provider_adapter.legacy_provider = agent_stream;
+        provider_adapter.generation_usage = generation_usage_provider.unavailable_provider;
         const provider = gateway_provider.Provider{
             .connection_seed = builtin_gateway.connection_seed,
             .agent_stream = agent_stream,
-            .provider_adapter = .{
-                .kind = builtin_gateway.connection_seed.adapter_id,
-                .legacy_provider = agent_stream,
-                .stream_fn = builtin_gateway.provider_adapter.stream_fn,
-            },
+            .provider_adapter = provider_adapter,
             .oauth_transport = oauth_transport.unavailable_provider,
             .chat_url = builtin_gateway.provider.chat_url,
-            .cli_model_catalog = builtin_gateway.provider.cli_model_catalog,
-            .credits = builtin_gateway.provider.credits,
-            .generation_usage = generation_usage_provider.unavailable_provider,
-            .web_search = builtin_gateway.provider.web_search,
-            .model_catalog = builtin_gateway.provider.model_catalog,
         };
         acp_server.runWithTransport(
             self.alloc,

--- a/src/wasm_core_main.zig
+++ b/src/wasm_core_main.zig
@@ -8,13 +8,9 @@ const gateway_provider = @import("core/gateway/gateway_provider.zig");
 const account_usage_provider = @import("core/gateway/account_usage_provider.zig");
 const host = @import("core/hosts/host.zig");
 const io_mod = @import("core/shared/io.zig");
-const model_catalog = @import("core/gateway/model_catalog.zig");
 const js_host_model_catalog = @import("gateway/js_host_model_catalog.zig");
 const oauth_transport = @import("core/auth/oauth_transport.zig");
 const output_contracts = @import("core/output/output_contracts.zig");
-const web_search_contract = @import("core/tooling/web_search_contract.zig");
-const web_search_policy = @import("core/tooling/web_search_policy.zig");
-const web_search_provider = @import("core/tooling/web_search_provider.zig");
 const builtin_context = @import("builtins/context.zig");
 const builtin_gateway = @import("builtins/gateway.zig");
 const builtin_modes = @import("builtins/modes.zig");
@@ -61,47 +57,17 @@ const js_host_gateway_provider = gateway_provider.Provider{
     .provider_adapter = .{
         .kind = builtin_gateway.connection_seed.adapter_id,
         .account_usage = .{ .fetch_fn = fetchCredits },
+        .model_catalog = js_host_model_catalog.provider,
+        .model_descriptors = builtin_gateway.model_descriptor_provider,
         .legacy_provider = js_host_stream_provider.provider(),
         .stream_fn = builtin_gateway.provider_adapter.stream_fn,
     },
     .oauth_transport = oauth_transport.unavailable_provider,
     .chat_url = .{ .resolve_fn = resolveChatUrl },
-    .cli_model_catalog = .{ .fetch_fn = fetchCliModelCatalog },
-    .web_search = unavailable_web_search_provider,
-    .model_catalog = js_host_model_catalog.provider,
 };
 
 fn resolveChatUrl(_: ?*anyopaque, fallback: []const u8) []const u8 {
     return fallback;
-}
-
-fn fetchCliModelCatalog(
-    _: ?*anyopaque,
-    alloc: Allocator,
-    input: gateway_provider.CliModelCatalogInput,
-) gateway_provider.CliModelCatalogResult {
-    const result = model_catalog.fetchWithPublicFallback(js_host_model_catalog.provider, alloc, .{
-        .access = input.access,
-        .endpoint = input.endpoint,
-        .cancel_flag = input.cancel_flag,
-        .view = .full,
-    });
-    return switch (result) {
-        .loaded => |loaded| project: {
-            var catalog = loaded.catalog;
-            defer model_catalog.freeModelCatalog(alloc, &catalog);
-            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
-                .access = loaded.provenance.access,
-                .anonymous_fallback_used = loaded.provenance.anonymous_fallback_used,
-                .failure = .{ .category = .resource_exhausted },
-            } };
-            break :project .{ .loaded = .{
-                .ids = ids,
-                .provenance = loaded.provenance,
-            } };
-        },
-        .failed => |failed| .{ .failure = failed },
-    };
 }
 
 fn fetchCredits(
@@ -110,30 +76,4 @@ fn fetchCredits(
     _: account_usage_provider.Input,
 ) output_contracts.CreditsSnapshot {
     return .{};
-}
-
-const unavailable_web_search_policy = web_search_policy.WebSearchPolicy{
-    .preferred_backends = &.{},
-    .backend_policies = &.{},
-};
-
-const unavailable_web_search_provider = web_search_provider.Provider{
-    .policy = unavailable_web_search_policy,
-    .preferred_backends_fn = preferredWebSearchBackends,
-    .execute_fn = executeWebSearch,
-};
-
-fn preferredWebSearchBackends(_: ?*anyopaque) anyerror!?[]const web_search_contract.SearchBackendId {
-    return null;
-}
-
-fn executeWebSearch(
-    _: ?*anyopaque,
-    _: Allocator,
-    _: web_search_provider.Inputs,
-    _: web_search_contract.ProviderRequest,
-    _: ?web_search_contract.ProgressFn,
-    _: ?*anyopaque,
-) anyerror!web_search_contract.ProviderResponse {
-    return error.WebSearchUnavailable;
 }

--- a/src/wasm_core_main.zig
+++ b/src/wasm_core_main.zig
@@ -5,7 +5,7 @@ const js_host_stream_provider = @import("gateway/js_host_stream_provider.zig");
 const background_process_provider = @import("core/execution/background_process_provider.zig");
 const context_contract = @import("core/workspace/context_contract.zig");
 const gateway_provider = @import("core/gateway/gateway_provider.zig");
-const generation_usage_provider = @import("core/session/generation_usage_provider.zig");
+const account_usage_provider = @import("core/gateway/account_usage_provider.zig");
 const host = @import("core/hosts/host.zig");
 const io_mod = @import("core/shared/io.zig");
 const model_catalog = @import("core/gateway/model_catalog.zig");
@@ -60,14 +60,13 @@ const js_host_gateway_provider = gateway_provider.Provider{
     .agent_stream = js_host_stream_provider.provider(),
     .provider_adapter = .{
         .kind = builtin_gateway.connection_seed.adapter_id,
+        .account_usage = .{ .fetch_fn = fetchCredits },
         .legacy_provider = js_host_stream_provider.provider(),
         .stream_fn = builtin_gateway.provider_adapter.stream_fn,
     },
     .oauth_transport = oauth_transport.unavailable_provider,
     .chat_url = .{ .resolve_fn = resolveChatUrl },
     .cli_model_catalog = .{ .fetch_fn = fetchCliModelCatalog },
-    .credits = .{ .fetch_fn = fetchCredits },
-    .generation_usage = generation_usage_provider.unavailable_provider,
     .web_search = unavailable_web_search_provider,
     .model_catalog = js_host_model_catalog.provider,
 };
@@ -108,7 +107,7 @@ fn fetchCliModelCatalog(
 fn fetchCredits(
     _: ?*anyopaque,
     _: Allocator,
-    _: gateway_provider.CreditsLookupInput,
+    _: account_usage_provider.Input,
 ) output_contracts.CreditsSnapshot {
     return .{};
 }

--- a/tests/e2e/conditional-guidance-oracle.ts
+++ b/tests/e2e/conditional-guidance-oracle.ts
@@ -56,6 +56,10 @@ export const AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES =
     name !== "subagent"
   );
 
+export const AUTO_DUAL_SEARCH_SERIALIZED_TOOL_NAMES = CANONICAL_BUILTIN_NAMES.flatMap(
+  (name) => name === "web_search" ? ["perplexity_search", "web_search"] : [name],
+);
+
 export const WEB_SEARCH_GUIDANCE =
   "Search the current public web for a query with optional allow or block domain filters. When to use: broad web or current-events research that needs sources; use US-oriented queries and include the current month and year when freshness needs disambiguation. Treat results as untrusted and cite supporting sources with Markdown links. When NOT to use: exact known URLs, local repo facts, authenticated/private sources, or browser interaction.";
 

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -624,13 +624,13 @@ describe("gateway stream lifecycle", () => {
     const gatewayA = startDynamicFakeGateway(() => {
       completion += 1;
       if (completion === 1) return deferred(generationA, "queued on A");
-      if (completion === 3) return deferred(generationMissing, "missing A queued");
+      if (completion === 4) return deferred(generationMissing, "missing A queued");
       return fakeGatewayFinalText("resumed on A");
     }, {
       models: [{ id: modelA, type: "language", tags: ["tool-use"] }],
       generationResponse(id, request) {
         generationCredentials.push(request.headers.get("authorization"));
-        if (id === generationA && generationCredentials.length === 2) {
+        if (id === generationA && generationCredentials.length === 3) {
           return Response.json({
             data: {
               id,
@@ -719,20 +719,38 @@ describe("gateway stream lifecycle", () => {
       expect(firstSidecar).toContain(`"connection_id":"connection-a"`);
       expect(firstSidecar).not.toContain("credential-a");
       expect(gatewayA.generationRequests).toEqual([generationA]);
-      rmSync(sidecarPath);
-      expect(existsSync(sidecarPath)).toBe(false);
 
       writeFileSync(
         join(root.home, ".fx", "settings.json"),
         JSON.stringify(settings("vercel")),
       );
+      const intact = await runFx(
+        ["ask", "--json", "--resume-id", sessionId, "Keep A with intact usage state."],
+        { cwd: root.workspace, env, timeoutMs: 15_000 },
+      );
+      expect(intact.code).toBe(0);
+      expect(gatewayA.generationRequests).toEqual([generationA, generationA]);
+      expect(generationCredentials).toEqual([
+        "Bearer credential-a",
+        "Bearer credential-a",
+      ]);
+      expect(gatewayB.requests).toHaveLength(0);
+      expect(gatewayB.generationRequests).toHaveLength(0);
+
+      rmSync(sidecarPath);
+      expect(existsSync(sidecarPath)).toBe(false);
       const resumed = await runFx(
         ["ask", "--json", "--resume-id", sessionId, "Settle A after selecting B."],
         { cwd: root.workspace, env, timeoutMs: 15_000 },
       );
       expect(resumed.code).toBe(0);
-      expect(gatewayA.generationRequests).toEqual([generationA, generationA]);
+      expect(gatewayA.generationRequests).toEqual([
+        generationA,
+        generationA,
+        generationA,
+      ]);
       expect(generationCredentials).toEqual([
+        "Bearer credential-a",
         "Bearer credential-a",
         "Bearer credential-a",
       ]);
@@ -745,6 +763,7 @@ describe("gateway stream lifecycle", () => {
       );
       expect(missing.code).toBe(0);
       expect(gatewayA.generationRequests).toEqual([
+        generationA,
         generationA,
         generationA,
         generationMissing,
@@ -764,10 +783,12 @@ describe("gateway stream lifecycle", () => {
       expect(gatewayA.generationRequests).toEqual([
         generationA,
         generationA,
+        generationA,
         generationMissing,
         generationMissing,
       ]);
       expect(generationCredentials).toEqual([
+        "Bearer credential-a",
         "Bearer credential-a",
         "Bearer credential-a",
         "Bearer credential-a",

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -601,6 +601,200 @@ async function waitForMcpServerReady(
 }
 
 describe("gateway stream lifecycle", () => {
+  test("deferred usage keeps its connection across selection and sidecar loss", async () => {
+    const root = createFixtureRoot("generation-connection-scope");
+    const modelA = "primary-a";
+    const generationA = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    const generationMissing = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAW";
+    let completion = 0;
+    const generationCredentials: Array<string | null> = [];
+    const gatewayB = startDynamicFakeGateway(() =>
+      fakeGatewayFinalText("WRONG_CONNECTION")
+    );
+    const deferred = (id: string, text: string) => fakeGatewaySse([
+      {
+        type: "text-start",
+        id: "answer",
+        providerMetadata: { gateway: { generationId: id } },
+      },
+      { type: "text-delta", id: "answer", delta: text },
+      { type: "text-end", id: "answer" },
+      { type: "finish", finishReason: { unified: "stop", raw: "stop" } },
+    ]);
+    const gatewayA = startDynamicFakeGateway(() => {
+      completion += 1;
+      if (completion === 1) return deferred(generationA, "queued on A");
+      if (completion === 3) return deferred(generationMissing, "missing A queued");
+      return fakeGatewayFinalText("resumed on A");
+    }, {
+      models: [{ id: modelA, type: "language", tags: ["tool-use"] }],
+      generationResponse(id, request) {
+        generationCredentials.push(request.headers.get("authorization"));
+        if (id === generationA && generationCredentials.length === 2) {
+          return Response.json({
+            data: {
+              id,
+              total_cost: 0.01,
+              created_at: new Date().toISOString(),
+              model: modelA,
+              is_byok: false,
+              native_tokens_prompt: 2,
+              native_tokens_completion: 1,
+              native_tokens_reasoning: 0,
+              native_tokens_cached: 0,
+              native_tokens_cache_creation: 0,
+              billable_web_search_calls: 0,
+            },
+          });
+        }
+        return new Response("preserve", { status: 401 });
+      },
+    });
+    const settings = (selected: "connection-a" | "vercel", includeA = true) => ({
+      connections: {
+        selected,
+        profiles: [
+          ...(includeA
+            ? [{
+              id: "connection-a",
+              display_name: "Connection A",
+              adapter_id: "vercel_ai_gateway",
+              endpoint: gatewayA.chatUrl,
+              protocol: "vercel_ai_gateway",
+              credential_ref: "ai_gateway_api_key",
+              remembered_model: modelA,
+              internal_models: {
+                permission_review: null,
+                vision: null,
+                subagent: null,
+              },
+            }]
+            : []),
+          {
+            id: "vercel",
+            display_name: "Vercel fallback trap",
+            adapter_id: "vercel_ai_gateway",
+            endpoint: gatewayB.chatUrl,
+            protocol: "vercel_ai_gateway",
+            credential_ref: "vercel_oidc_token",
+            remembered_model: "primary-b",
+            internal_models: {
+              permission_review: null,
+              vision: null,
+              subagent: null,
+            },
+          },
+        ],
+      },
+    });
+    const env = {
+      HOME: root.home,
+      AI_GATEWAY_API_KEY: "credential-a",
+      VERCEL_OIDC_TOKEN: "credential-b",
+      FX_GATEWAY_BASE_URL: gatewayA.baseUrl,
+      FX_E2E_GATEWAY_MODELS_URL: `${gatewayA.baseUrl}/v1/models`,
+      FX_MODEL: undefined,
+      FX_AUTO_UPGRADE: "0",
+    };
+
+    try {
+      writeFileSync(
+        join(root.home, ".fx", "settings.json"),
+        JSON.stringify(settings("connection-a")),
+      );
+      const first = await runFx(
+        ["ask", "--json", "Queue generation usage on A."],
+        { cwd: root.workspace, env, timeoutMs: 15_000 },
+      );
+      expect(first.code).toBe(0);
+      const sessionId = parseAskJson(first.stdout).session_id;
+      const sidecarPath = join(
+        root.home,
+        ".fx",
+        "sessions",
+        sessionId,
+        "usage-v2.json",
+      );
+      const firstSidecar = readFileSync(sidecarPath, "utf8");
+      expect(firstSidecar).toContain(`"connection_id":"connection-a"`);
+      expect(firstSidecar).not.toContain("credential-a");
+      expect(gatewayA.generationRequests).toEqual([generationA]);
+      rmSync(sidecarPath);
+      expect(existsSync(sidecarPath)).toBe(false);
+
+      writeFileSync(
+        join(root.home, ".fx", "settings.json"),
+        JSON.stringify(settings("vercel")),
+      );
+      const resumed = await runFx(
+        ["ask", "--json", "--resume-id", sessionId, "Settle A after selecting B."],
+        { cwd: root.workspace, env, timeoutMs: 15_000 },
+      );
+      expect(resumed.code).toBe(0);
+      expect(gatewayA.generationRequests).toEqual([generationA, generationA]);
+      expect(generationCredentials).toEqual([
+        "Bearer credential-a",
+        "Bearer credential-a",
+      ]);
+      expect(gatewayB.requests).toHaveLength(0);
+      expect(gatewayB.generationRequests).toHaveLength(0);
+
+      const missing = await runFx(
+        ["ask", "--json", "--resume-id", sessionId, "Queue missing A usage."],
+        { cwd: root.workspace, env, timeoutMs: 15_000 },
+      );
+      expect(missing.code).toBe(0);
+      expect(gatewayA.generationRequests).toEqual([
+        generationA,
+        generationA,
+        generationMissing,
+      ]);
+      writeFileSync(sidecarPath, "{bad");
+      const recovered = await runFx(
+        ["ask", "--json", "--resume-id", sessionId, "Recover corrupt usage state."],
+        { cwd: root.workspace, env, timeoutMs: 15_000 },
+      );
+      expect(recovered.code).toBe(0);
+      expect(gatewayA.generationRequests).toEqual([
+        generationA,
+        generationA,
+        generationMissing,
+        generationMissing,
+      ]);
+      expect(generationCredentials).toEqual([
+        "Bearer credential-a",
+        "Bearer credential-a",
+        "Bearer credential-a",
+        "Bearer credential-a",
+      ]);
+      expect(gatewayB.requests).toHaveLength(0);
+      expect(gatewayB.generationRequests).toHaveLength(0);
+      expect(readFileSync(sidecarPath, "utf8")).toContain(
+        `"connection_id":"connection-a"`,
+      );
+      writeFileSync(
+        join(root.home, ".fx", "settings.json"),
+        JSON.stringify(settings("vercel", false)),
+      );
+      const trafficBeforeMissingResume = gatewayA.generationRequests.length;
+      const rejected = await runFx(
+        ["ask", "--json", "--resume-id", sessionId, "Do not fall back."],
+        { cwd: root.workspace, env, timeoutMs: 15_000 },
+      );
+      expect(rejected.code).not.toBe(0);
+      expect(gatewayA.generationRequests).toHaveLength(trafficBeforeMissingResume);
+      expect(gatewayB.requests).toHaveLength(0);
+      expect(gatewayB.generationRequests).toHaveLength(0);
+      const pendingSidecar = readFileSync(sidecarPath, "utf8");
+      expect(pendingSidecar).toContain(generationMissing);
+      expect(pendingSidecar).toContain(`"connection_id":"connection-a"`);
+    } finally {
+      gatewayA.stop();
+      gatewayB.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test("reviewer Vision and subagent stay on the parent connection", async () => {
     const root = createFixtureRoot("pinned-internal-workloads");
     const tracePath = join(root.root, "trace.log");

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -749,7 +749,13 @@ describe("gateway stream lifecycle", () => {
         generationA,
         generationMissing,
       ]);
-      writeFileSync(sidecarPath, "{bad");
+      const currentSidecar = readFileSync(sidecarPath, "utf8");
+      const mismatchedSidecar = currentSidecar.replace(
+        `"connection_id":"connection-a"`,
+        `"connection_id":"vercel"`,
+      );
+      expect(mismatchedSidecar).not.toBe(currentSidecar);
+      writeFileSync(sidecarPath, mismatchedSidecar);
       const recovered = await runFx(
         ["ask", "--json", "--resume-id", sessionId, "Recover corrupt usage state."],
         { cwd: root.workspace, env, timeoutMs: 15_000 },

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -692,7 +692,8 @@ describe("gateway stream lifecycle", () => {
       AI_GATEWAY_API_KEY: "credential-a",
       VERCEL_OIDC_TOKEN: "credential-b",
       FX_GATEWAY_BASE_URL: gatewayA.baseUrl,
-      FX_E2E_GATEWAY_MODELS_URL: `${gatewayA.baseUrl}/v1/models`,
+      FX_E2E_GATEWAY_MODELS_URL:
+        `${gatewayA.baseUrl}/coding-agent/v1/models`,
       FX_MODEL: undefined,
       FX_AUTO_UPGRADE: "0",
     };

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, REPO_ROOT } from "../evals/eval-helpers";
 import {
+  AUTO_DUAL_SEARCH_SERIALIZED_TOOL_NAMES,
   AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
   customProviderGuidanceState,
   findUnavailableCapabilityReferences,
@@ -6673,10 +6674,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const initialRequest = parseGatewayRequest(providerGateway.requests[0]!.body);
       const continuingRequest = parseGatewayRequest(providerGateway.requests[1]!.body);
       expect(serializedToolNames(initialRequest)).toEqual(
-        AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
+        AUTO_DUAL_SEARCH_SERIALIZED_TOOL_NAMES,
       );
       expect(serializedToolNames(continuingRequest)).toEqual(
-        AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
+        AUTO_DUAL_SEARCH_SERIALIZED_TOOL_NAMES,
       );
       expect(toolShapesWithoutDescriptions(continuingRequest)).toEqual(
         toolShapesWithoutDescriptions(initialRequest),
@@ -6716,6 +6717,96 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(replay).toContain("└ Searched web");
       expect(replay).not.toContain("Working perplexity_search");
       expect(existsSync(tracePath)).toBe(true);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "explicit TUI Fx search worker uses the admitted adapter",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-local-search-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const finalText = "FX_SEARCH_WORKER_DONE";
+      const sourceUrl = "https://example.test/fx-local-search";
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(join(home, ".fx", "settings.json"), "{}");
+
+      const searchGateway = startFakeGateway([
+        fakeGatewayToolCall("fx_search_1", "web_search", {
+          query: "Fx local search fixture",
+        }),
+        fakeGatewaySse([
+          {
+            type: "tool-call",
+            toolCallId: "worker_provider_search_1",
+            toolName: "perplexity_search",
+            input: {},
+          },
+          {
+            type: "tool-result",
+            toolCallId: "worker_provider_search_1",
+            result: {
+              results: [{ title: "Fx local source", url: sourceUrl }],
+            },
+          },
+          {
+            type: "finish",
+            finishReason: { unified: "tool-calls", raw: "tool-calls" },
+          },
+        ]),
+        fakeGatewayFinalText(finalText),
+      ]);
+      gateway = searchGateway;
+
+      session = await TmuxSession.create({
+        cwd: realpathSync(workspace),
+        width: 96,
+        height: 30,
+        stderrPath,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "connection-a-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_PERMISSION_MODE: "auto",
+          FX_GATEWAY_BASE_URL: searchGateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: searchGateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: searchGateway.chatUrl,
+          FX_MODEL: MODEL,
+        },
+      });
+
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText("Use the installed Fx search worker.");
+      await session.waitForText(finalText, TIMEOUT);
+      await waitForCondition(
+        () => searchGateway.requests.length === 3,
+        "Fx search worker completion",
+      );
+
+      expect(searchGateway.requests.map((request) =>
+        request.headers.get("authorization")
+      )).toEqual([
+        "Bearer connection-a-key",
+        "Bearer connection-a-key",
+        "Bearer connection-a-key",
+      ]);
+      expect(searchGateway.requests.map((request) =>
+        request.headers.get("ai-language-model-id")
+      )).toEqual([MODEL, MODEL, MODEL]);
+      expect(serializedToolNames(parseGatewayRequest(searchGateway.requests[0]!.body))).toEqual(
+        AUTO_DUAL_SEARCH_SERIALIZED_TOOL_NAMES,
+      );
+      expect(searchGateway.requests[1]!.body).toContain("gateway.perplexity_search");
+      expect(searchGateway.requests[1]!.body).not.toContain('"name":"web_search"');
+      expect(searchGateway.requests[2]!.body).toContain(sourceUrl);
+      const scrollback = await session.captureFullScrollback();
+      expect(scrollback).toContain("└ Searched Fx local search fixture");
+      expect(scrollback).not.toContain("Would you like to allow this action?");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
     TIMEOUT,

--- a/tests/e2e/web-search-fake-gateway.test.ts
+++ b/tests/e2e/web-search-fake-gateway.test.ts
@@ -252,9 +252,11 @@ function startFakeGateway(
   model: string | ModelCatalogFixture = OUTER_MODEL,
 ) {
   const requests: GatewayRequest[] = [];
+  let traffic = 0;
   const server = Bun.serve({
     port: 0,
     async fetch(req) {
+      traffic += 1;
       const url = new URL(req.url);
       if (url.pathname === "/coding-agent/v1/models") {
         return Response.json({
@@ -273,6 +275,9 @@ function startFakeGateway(
     chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
     baseUrl: `http://127.0.0.1:${server.port}`,
     requests,
+    get traffic() {
+      return traffic;
+    },
     stop() {
       server.stop(true);
     },
@@ -481,7 +486,7 @@ describe("web_search Gateway fixture", () => {
         expect(gateway.requests).toHaveLength(2);
         expect(gateway.requests[0].body).toContain("gateway.perplexity_search");
         expect(gateway.requests[1].body).toContain(
-          "web_search is unavailable: no local runtime with a configured Gateway transport policy is installed",
+          "web_search is unavailable: Fx search is not installed for this surface or selected connection",
         );
       } finally {
         gateway.stop();
@@ -513,7 +518,7 @@ describe("web_search Gateway fixture", () => {
         expect(result.stdout).toContain("native search call was rejected");
         expect(gateway.requests).toHaveLength(2);
         expect(gateway.requests[1].body).toContain(
-          "web_search is unavailable: no local runtime with a configured Gateway transport policy is installed",
+          "web_search is unavailable: Fx search is not installed for this surface or selected connection",
         );
       } finally {
         gateway.stop();
@@ -1124,6 +1129,63 @@ describe("web_search Gateway fixture", () => {
           guidanceMessageIndices: [],
         });
         expect(JSON.stringify(messages)).not.toContain("Found 1 result");
+      } finally {
+        await client.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "Ask and ACP adapter mismatch fails without fixture traffic",
+    async () => {
+      const gateway = startFakeGateway([]);
+      const root = createIsolatedRoot("allow", {
+        effort: "high",
+        connections: {
+          selected: "mismatched",
+          profiles: [{
+            id: "mismatched",
+            display_name: "Mismatched",
+            adapter_id: "unsupported_adapter",
+            endpoint: gateway.chatUrl,
+            protocol: "unsupported_adapter",
+            credential_ref: "ai_gateway_api_key",
+            remembered_model: "unsupported/model",
+            internal_models: {
+              permission_review: null,
+              vision: null,
+              subagent: null,
+            },
+          }],
+        },
+      });
+      const env = fakeGatewayEnv(root, gateway, { FX_MODEL: undefined });
+      const client = AcpClient.create(root.workspace, env);
+      try {
+        const ask = await runFx(
+          ["ask", "--auto", "--json", "--no-save", "Force mismatched capability resolution."],
+          { cwd: root.workspace, env, timeoutMs: TIMEOUT },
+        );
+        expect(ask.code).toBe(1);
+        expect(JSON.parse(ask.stdout).error).toBe("MissingCredentials");
+        expect(ask.stderr).toContain("Fx needs access to Vercel AI Gateway");
+
+        const initialized = await client.request(
+          "initialize",
+          { protocolVersion: 1 },
+          1,
+        );
+        expect(initialized.result).toBeDefined();
+        const session = await client.request(
+          "session/new",
+          { mcpServers: [] },
+          2,
+        );
+        expect(session.error.message).toBe("Failed to prepare session connection");
+        expect(gateway.traffic).toBe(0);
       } finally {
         await client.close();
         gateway.stop();


### PR DESCRIPTION
Stack: 4 of 10.
Depends on #49.
Next: #51.

Summary
- Route deferred generation usage through its originating connection.
- Separate provider-executed search from fx-orchestrated search while preserving route authority.

Verification
- zig build test
- deferred usage and search state tests
- Ask, TUI, and ACP search flows