### PR TITLE
Add adapter-scoped authentication

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -146,26 +146,28 @@ pub const agent_stream_provider = agent_stream_provider_contract.Provider{
     .stream_fn = streamAgentCompletion,
 };
 
-const VercelAuthContext = struct {
-    transport: oauth_transport.Provider,
-};
+/// The transport must outlive every operation through the returned provider.
+pub fn auth_provider_for_transport(transport: *const oauth_transport.Provider) adapter_auth.Provider {
+    return .{
+        .kind = connection_seed.adapter_id,
+        .context = transport,
+        .acquire_fn = acquireVercelCredential,
+        .logout_fn = logoutVercel,
+        .start_sign_in_fn = startVercelSignIn,
+        .load_teams_fn = loadVercelTeams,
+        .invalidate_fn = invalidateVercelCredential,
+        .status_fn = loadVercelStatus,
+    };
+}
 
-const vercel_auth_context = VercelAuthContext{
-    .transport = oauth_transport_provider,
-};
+fn native_auth_provider() adapter_auth.Provider {
+    var value = auth_provider_for_transport(&oauth_transport_provider);
+    value.login_fn = runVercelLogin;
+    value.teams_fn = runVercelTeams;
+    return value;
+}
 
-pub const auth_provider = adapter_auth.Provider{
-    .kind = connection_seed.adapter_id,
-    .context = &vercel_auth_context,
-    .acquire_fn = acquireVercelCredential,
-    .login_fn = runVercelLogin,
-    .logout_fn = logoutVercel,
-    .teams_fn = runVercelTeams,
-    .start_sign_in_fn = startVercelSignIn,
-    .load_teams_fn = loadVercelTeams,
-    .invalidate_fn = invalidateVercelCredential,
-    .status_fn = loadVercelStatus,
-};
+pub const auth_provider = native_auth_provider();
 
 pub const provider_adapter = agent_stream_provider_contract.ProviderAdapter{
     .kind = connection_seed.adapter_id,
@@ -194,8 +196,8 @@ pub const provider = gateway_provider.Provider{
     .chat_url = chat_url_provider,
 };
 
-fn vercelContext(raw: *const anyopaque) *const VercelAuthContext {
-    return @ptrCast(@alignCast(raw));
+fn vercelTransport(raw: *const anyopaque) oauth_transport.Provider {
+    return @as(*const oauth_transport.Provider, @ptrCast(@alignCast(raw))).*;
 }
 
 fn credentialSourceFromReference(reference: []const u8) !?credentials.Source {
@@ -274,7 +276,7 @@ fn acquireVercelCredential(
     alloc: Allocator,
     request: adapter_auth.Request,
 ) Allocator.Error!adapter_auth.Acquisition {
-    const context = vercelContext(raw);
+    const transport = vercelTransport(raw);
 
     const resolution = switch (request.mode) {
         .stored, .if_needed => acquisition: {
@@ -284,7 +286,7 @@ fn acquireVercelCredential(
             const resolved = switch (request.source_resolution) {
                 .allow_fallback => credentials.resolvePreferring(
                     alloc,
-                    context.transport,
+                    transport,
                     request.host.secret_store,
                     if (request.mode == .stored) .stored else .refresh_if_needed,
                     source,
@@ -292,7 +294,7 @@ fn acquireVercelCredential(
                 .exact => if (source) |selected|
                     credentials.resolveExact(
                         alloc,
-                        context.transport,
+                        transport,
                         request.host.secret_store,
                         if (request.mode == .stored) .stored else .refresh_if_needed,
                         selected,
@@ -311,7 +313,7 @@ fn acquireVercelCredential(
             if (!std.mem.eql(u8, source_id, @tagName(credentials.Source.fx_login))) {
                 return .{ .failed = .{ .category = .unavailable } };
             }
-            const credential = credentials.refreshFxLoginCredential(alloc, context.transport) catch |err| {
+            const credential = credentials.refreshFxLoginCredential(alloc, transport) catch |err| {
                 if (err == error.OutOfMemory) return error.OutOfMemory;
                 return normalizedAcquisitionFailure(err);
             };
@@ -333,7 +335,7 @@ fn runVercelLogin(
     _: connection_registry.Profile,
     auth_host: adapter_auth.AuthHost,
 ) Allocator.Error!adapter_auth.OperationOutcome {
-    login_flow.runLogin(alloc, vercelContext(raw).transport, auth_host.url_opener) catch |err| {
+    login_flow.runLogin(alloc, vercelTransport(raw), auth_host.url_opener) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         const failure = normalizeAuthFailure(err);
         return if (failure.category == .cancelled) .cancelled else .{ .failed = failure };
@@ -347,7 +349,7 @@ fn logoutVercel(
     _: connection_registry.Profile,
     _: adapter_auth.AuthHost,
 ) Allocator.Error!adapter_auth.LogoutOutcome {
-    const result = login_flow.logout(alloc, vercelContext(raw).transport) catch |err| {
+    const result = login_flow.logout(alloc, vercelTransport(raw)) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         return .{ .failed = normalizeAuthFailure(err) };
     };
@@ -364,7 +366,7 @@ fn runVercelTeams(
     _: connection_registry.Profile,
     _: adapter_auth.AuthHost,
 ) Allocator.Error!adapter_auth.OperationOutcome {
-    login_flow.runTeams(alloc, vercelContext(raw).transport) catch |err| {
+    login_flow.runTeams(alloc, vercelTransport(raw)) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         const failure = normalizeAuthFailure(err);
         return if (failure.category == .cancelled) .cancelled else .{ .failed = failure };
@@ -430,7 +432,7 @@ fn startVercelSignIn(
 ) Allocator.Error!adapter_auth.StartSignInOutcome {
     const state = try alloc.create(VercelSignIn);
     state.* = .{};
-    const started = state.runtime.start(alloc, vercelContext(raw).transport) catch |err| {
+    const started = state.runtime.start(alloc, vercelTransport(raw)) catch |err| {
         state.runtime.deinit(alloc);
         alloc.destroy(state);
         if (err == error.OutOfMemory) return error.OutOfMemory;
@@ -505,7 +507,7 @@ fn loadVercelTeams(
     _: connection_registry.Profile,
     _: adapter_auth.AuthHost,
 ) Allocator.Error!adapter_auth.TeamsOutcome {
-    var selection = login_flow.loadTeamSelection(alloc, vercelContext(raw).transport) catch |err| {
+    var selection = login_flow.loadTeamSelection(alloc, vercelTransport(raw)) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         const failure = normalizeAuthFailure(err);
         return if (failure.category == .cancelled) .cancelled else .{ .failed = failure };
@@ -3893,12 +3895,8 @@ test "exact conditional fx login refresh failure is normalized without fallback"
     try oauth_session.saveNewSession(alloc, session);
 
     var refresh_probe: ConditionalRefreshProbe = .{};
-    const context = VercelAuthContext{ .transport = refresh_probe.provider() };
-    const test_provider = adapter_auth.Provider{
-        .kind = connection_seed.adapter_id,
-        .context = &context,
-        .acquire_fn = acquireVercelCredential,
-    };
+    const transport = refresh_probe.provider();
+    const test_provider = auth_provider_for_transport(&transport);
     var store = AdapterAuthStoreProbe{ .value = "stored-fallback-secret" };
     const outcome = try test_provider.acquire(alloc, .{
         .profile = adapterAuthTestProfile(connection_seed.adapter_id, "fx_login"),

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -534,6 +534,7 @@ fn loadVercelStatus(
         .profile = profile,
         .host = auth_host,
         .mode = .stored,
+        .source_resolution = .allow_fallback,
     });
     var credential = switch (acquisition) {
         .acquired => |value| value,
@@ -3746,6 +3747,7 @@ test "top-level status and interactive acquire resolve one adapter with zero cro
         .profile = peer_profile,
         .host = .{ .secret_store = peer_store.store() },
         .mode = .if_needed,
+        .source_resolution = .allow_fallback,
     })) {
         .acquired => |value| value,
         .missing, .failed, .cancelled => return error.UnexpectedAdapterAcquisition,
@@ -3774,6 +3776,7 @@ test "adapter auth preserves invalid references refresh failures and late cancel
         .profile = invalid_profile,
         .host = .{ .secret_store = vercel_store.store() },
         .mode = .if_needed,
+        .source_resolution = .exact,
     });
     switch (invalid) {
         .failed => |failure| try std.testing.expectEqual(adapter_auth.FailureCategory.configuration, failure.category),
@@ -3796,6 +3799,7 @@ test "adapter auth preserves invalid references refresh failures and late cancel
         .profile = adapterAuthTestProfile(connection_seed.adapter_id, "fx_login"),
         .host = .{ .secret_store = vercel_store.store() },
         .mode = .force,
+        .source_resolution = .exact,
         .current_source_id = "fx_login",
     });
     switch (refresh) {
@@ -3828,6 +3832,7 @@ test "adapter auth preserves invalid references refresh failures and late cancel
         .profile = peer_profile,
         .host = .{ .secret_store = peer_store.store() },
         .mode = .if_needed,
+        .source_resolution = .exact,
         .cancel_flag = &cancel_flag,
     });
     try std.testing.expect(cancelled == .cancelled);

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -478,6 +478,7 @@ fn vercelSignInBrowserUrl(raw: ?*anyopaque, alloc: Allocator) Allocator.Error!?[
 
 fn pollVercelSignIn(raw: ?*anyopaque, alloc: Allocator) Allocator.Error!adapter_auth.SignInTransition {
     const state: *VercelSignIn = @ptrCast(@alignCast(raw.?));
+    state.runtime.pulse(alloc);
     return switch (state.runtime.pollTransition(alloc)) {
         .none => .none,
         .cancelled => .cancelled,

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -559,8 +559,6 @@ fn loadVercelStatus(
     } };
 }
 
-pub const model_descriptor_provider = model_descriptors.provider;
-
 const AdapterEventBridge = struct {
     events: agent_stream_provider_contract.EventSink,
     failure: ?anyerror = null,

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -2,9 +2,13 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const api_key_validator_contract = @import("../core/auth/api_key_validator.zig");
+const adapter_auth = @import("../core/gateway/adapter_auth.zig");
+const adapter_registry = @import("../core/gateway/adapter_registry.zig");
 const agent_stream_provider_contract = @import("../core/agent/stream_provider.zig");
 const agent_runtime_telemetry = @import("../core/agent/runtime/telemetry.zig");
 const credentials = @import("../core/auth/credentials.zig");
+const login_flow = @import("../core/auth/login_flow.zig");
+const oauth_session = @import("../core/auth/oauth_session.zig");
 const oauth_transport = @import("../core/auth/oauth_transport.zig");
 const secret = @import("../core/auth/secret.zig");
 const collections = @import("../core/shared/collections.zig");
@@ -14,6 +18,7 @@ const gateway_client = @import("../gateway/client.zig");
 const gateway_failure_diagnostics = @import("../core/gateway/gateway_failure_diagnostics.zig");
 const gateway_json = @import("../core/gateway/gateway_json.zig");
 const io_mod = @import("../core/shared/io.zig");
+const host = @import("../core/hosts/host.zig");
 const gateway_generation_usage = @import("../gateway/generation_usage.zig");
 const connection_registry = @import("../core/gateway/connection_registry.zig");
 const route_snapshot_contract = @import("../core/gateway/route_snapshot.zig");
@@ -141,8 +146,30 @@ pub const agent_stream_provider = agent_stream_provider_contract.Provider{
     .stream_fn = streamAgentCompletion,
 };
 
+const VercelAuthContext = struct {
+    transport: oauth_transport.Provider,
+};
+
+const vercel_auth_context = VercelAuthContext{
+    .transport = oauth_transport_provider,
+};
+
+pub const auth_provider = adapter_auth.Provider{
+    .kind = connection_seed.adapter_id,
+    .context = &vercel_auth_context,
+    .acquire_fn = acquireVercelCredential,
+    .login_fn = runVercelLogin,
+    .logout_fn = logoutVercel,
+    .teams_fn = runVercelTeams,
+    .start_sign_in_fn = startVercelSignIn,
+    .load_teams_fn = loadVercelTeams,
+    .invalidate_fn = invalidateVercelCredential,
+    .status_fn = loadVercelStatus,
+};
+
 pub const provider_adapter = agent_stream_provider_contract.ProviderAdapter{
     .kind = connection_seed.adapter_id,
+    .auth = auth_provider,
     .account_usage = account_usage,
     .generation_usage = generation_usage_provider,
     .model_catalog = model_catalog_provider,
@@ -152,13 +179,384 @@ pub const provider_adapter = agent_stream_provider_contract.ProviderAdapter{
     .stream_fn = streamVercelAdapter,
 };
 
+const production_adapters = [_]agent_stream_provider_contract.ProviderAdapter{provider_adapter};
+
+pub const production_adapter_registry = adapter_registry.AdapterRegistry{
+    .adapters = &production_adapters,
+};
+
 pub const provider = gateway_provider.Provider{
     .connection_seed = connection_seed,
     .agent_stream = agent_stream_provider,
     .provider_adapter = provider_adapter,
+    .adapter_registry = production_adapter_registry,
     .oauth_transport = oauth_transport_provider,
     .chat_url = chat_url_provider,
 };
+
+fn vercelContext(raw: *const anyopaque) *const VercelAuthContext {
+    return @ptrCast(@alignCast(raw));
+}
+
+fn credentialSourceFromReference(reference: []const u8) !?credentials.Source {
+    if (std.mem.eql(u8, reference, "automatic")) return null;
+    return shared_types.parseCredentialSource(reference) orelse error.InvalidCredentialReference;
+}
+
+fn normalizeAuthFailure(err: anyerror) adapter_auth.Failure {
+    return .{ .category = switch (err) {
+        error.ClientIdMissing, error.InvalidCredentialReference => .configuration,
+        error.AccessDenied => .denied,
+        error.ExpiredToken, error.LoginTimedOut => .expired,
+        error.NoSession => .missing_session,
+        error.NoTeams => .no_teams,
+        error.SessionChanged => .session_changed,
+        error.InvalidTeamSelection => .invalid_selection,
+        error.SessionDeleteFailed => .persistence,
+        error.Cancelled => .cancelled,
+        else => .unavailable,
+    } };
+}
+
+fn normalizedSource(source: credentials.Source) adapter_auth.Source {
+    return .{
+        .id = @tagName(source),
+        .label = credentials.sourceLabel(source),
+        .refreshable = credentials.sourceRefreshable(source),
+    };
+}
+
+fn normalizedCatalogAccess(access: credentials.CatalogAccess) adapter_auth.CatalogAccess {
+    return switch (access) {
+        .authenticated => .authenticated,
+        .public_only => |value| .{ .public_only = switch (value) {
+            .no_credential => .no_credential,
+            .fx_login_team_required => .tenant_required,
+            .fx_login_refresh_required => .refresh_required,
+            .credential_refresh_failed => .refresh_failed,
+            .authenticated_credential_rejected => .credential_rejected,
+        } },
+    };
+}
+
+fn takeNormalizedCredential(credential: *credentials.Credential) adapter_auth.Credential {
+    const source = credential.source;
+    const catalog_access = normalizedCatalogAccess(credentials.catalogAccessAt(credential.*, io_mod.milliTimestamp()));
+    const result = adapter_auth.Credential{
+        .secret_bytes = credential.token,
+        .source = normalizedSource(source),
+        .tenant_id = credential.team_id,
+        .tenant_slug = credential.team_slug,
+        .refresh_after_ms = credential.refresh_after_ms,
+        .catalog_access = catalog_access,
+    };
+    credential.token = &.{};
+    credential.team_id = null;
+    credential.team_slug = null;
+    return result;
+}
+
+fn normalizedStoreStatus(status: credentials.StoredKeyReadStatus) adapter_auth.StoreStatus {
+    return switch (status) {
+        .not_attempted => .not_attempted,
+        .not_found => .not_found,
+        .unavailable => .unavailable,
+    };
+}
+
+fn normalizedAcquisitionFailure(err: anyerror) adapter_auth.Acquisition {
+    const failure = normalizeAuthFailure(err);
+    return if (failure.category == .cancelled) .cancelled else .{ .failed = failure };
+}
+
+fn acquireVercelCredential(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    request: adapter_auth.Request,
+) Allocator.Error!adapter_auth.Acquisition {
+    const context = vercelContext(raw);
+
+    const resolution = switch (request.mode) {
+        .stored, .if_needed => acquisition: {
+            const source = credentialSourceFromReference(
+                request.current_source_id orelse request.profile.credential_ref,
+            ) catch return .{ .failed = .{ .category = .configuration } };
+            const resolved = switch (request.source_resolution) {
+                .allow_fallback => credentials.resolvePreferring(
+                    alloc,
+                    context.transport,
+                    request.host.secret_store,
+                    if (request.mode == .stored) .stored else .refresh_if_needed,
+                    source,
+                ),
+                .exact => if (source) |selected|
+                    credentials.resolveExact(
+                        alloc,
+                        context.transport,
+                        request.host.secret_store,
+                        if (request.mode == .stored) .stored else .refresh_if_needed,
+                        selected,
+                    )
+                else
+                    return .{ .missing = .not_attempted },
+            } catch |err| {
+                if (err == error.OutOfMemory) return error.OutOfMemory;
+                return normalizedAcquisitionFailure(err);
+            };
+            break :acquisition resolved;
+        },
+        .force => force: {
+            const source_id = request.current_source_id orelse
+                return .{ .failed = .{ .category = .configuration } };
+            if (!std.mem.eql(u8, source_id, @tagName(credentials.Source.fx_login))) {
+                return .{ .failed = .{ .category = .unavailable } };
+            }
+            const credential = credentials.refreshFxLoginCredential(alloc, context.transport) catch |err| {
+                if (err == error.OutOfMemory) return error.OutOfMemory;
+                return normalizedAcquisitionFailure(err);
+            };
+            if (credential == null) return .{ .missing = .not_attempted };
+            break :force credentials.Resolution{ .credential = credential };
+        },
+    };
+    if (resolution.credential) |value| {
+        var credential = value;
+        defer credential.deinit(alloc);
+        return .{ .acquired = takeNormalizedCredential(&credential) };
+    }
+    return .{ .missing = normalizedStoreStatus(resolution.stored_key_status) };
+}
+
+fn runVercelLogin(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    _: connection_registry.Profile,
+    auth_host: adapter_auth.AuthHost,
+) Allocator.Error!adapter_auth.OperationOutcome {
+    login_flow.runLogin(alloc, vercelContext(raw).transport, auth_host.url_opener) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        const failure = normalizeAuthFailure(err);
+        return if (failure.category == .cancelled) .cancelled else .{ .failed = failure };
+    };
+    return .succeeded;
+}
+
+fn logoutVercel(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    _: connection_registry.Profile,
+    _: adapter_auth.AuthHost,
+) Allocator.Error!adapter_auth.LogoutOutcome {
+    const result = login_flow.logout(alloc, vercelContext(raw).transport) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failed = normalizeAuthFailure(err) };
+    };
+    return .{ .completed = .{
+        .session_deleted = result.session_deleted,
+        .local_durability_failed = result.local_durability_failed,
+        .remote_revocation_failed = result.remote_revocation_failed,
+    } };
+}
+
+fn runVercelTeams(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    _: connection_registry.Profile,
+    _: adapter_auth.AuthHost,
+) Allocator.Error!adapter_auth.OperationOutcome {
+    login_flow.runTeams(alloc, vercelContext(raw).transport) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        const failure = normalizeAuthFailure(err);
+        return if (failure.category == .cancelled) .cancelled else .{ .failed = failure };
+    };
+    return .succeeded;
+}
+
+const VercelTeamSelection = struct {
+    selection: login_flow.TeamSelection,
+    teams: []adapter_auth.Team,
+};
+
+fn takeVercelTeamSelection(
+    alloc: Allocator,
+    selection: *login_flow.TeamSelection,
+) Allocator.Error!adapter_auth.TeamSelection {
+    const team_count = selection.teams.items.len;
+    const state = try alloc.create(VercelTeamSelection);
+    errdefer alloc.destroy(state);
+    state.* = .{
+        .selection = selection.take(),
+        .teams = &.{},
+    };
+    errdefer state.selection.deinit(alloc);
+    state.teams = try alloc.alloc(adapter_auth.Team, team_count);
+    for (state.selection.teams.items, 0..) |team, index| {
+        state.teams[index] = .{ .id = team.id, .slug = team.slug, .name = team.name };
+    }
+    return .{
+        .context = state,
+        .teams = state.teams,
+        .current_team = state.selection.currentTeam(),
+        .select_fn = selectVercelTeam,
+        .deinit_fn = deinitVercelTeamSelection,
+    };
+}
+
+fn selectVercelTeam(raw: ?*anyopaque, alloc: Allocator, index: usize) Allocator.Error!adapter_auth.SelectOutcome {
+    const state: *VercelTeamSelection = @ptrCast(@alignCast(raw.?));
+    const selected = state.selection.select(alloc, index) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failed = normalizeAuthFailure(err) };
+    };
+    return .{ .selected = .{ .id = selected.id, .slug = selected.slug } };
+}
+
+fn deinitVercelTeamSelection(raw: ?*anyopaque, alloc: Allocator) void {
+    const state: *VercelTeamSelection = @ptrCast(@alignCast(raw.?));
+    state.selection.deinit(alloc);
+    alloc.free(state.teams);
+    alloc.destroy(state);
+}
+
+const VercelSignIn = struct {
+    runtime: login_flow.SignInRuntime = .{},
+};
+
+fn startVercelSignIn(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    _: connection_registry.Profile,
+    _: adapter_auth.AuthHost,
+) Allocator.Error!adapter_auth.StartSignInOutcome {
+    const state = try alloc.create(VercelSignIn);
+    state.* = .{};
+    const started = state.runtime.start(alloc, vercelContext(raw).transport) catch |err| {
+        state.runtime.deinit(alloc);
+        alloc.destroy(state);
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        const failure = normalizeAuthFailure(err);
+        return if (failure.category == .cancelled) .cancelled else .{ .failed = failure };
+    };
+    if (!started) {
+        state.runtime.deinit(alloc);
+        alloc.destroy(state);
+        return .busy;
+    }
+    return .{ .started = .{
+        .context = state,
+        .snapshot_fn = snapshotVercelSignIn,
+        .browser_url_fn = vercelSignInBrowserUrl,
+        .poll_fn = pollVercelSignIn,
+        .cancel_fn = cancelVercelSignIn,
+        .deinit_fn = deinitVercelSignIn,
+    } };
+}
+
+fn snapshotVercelSignIn(raw: ?*anyopaque) adapter_auth.SignInSnapshot {
+    const state: *VercelSignIn = @ptrCast(@alignCast(raw.?));
+    const snapshot = state.runtime.snapshot();
+    return .{
+        .state = switch (snapshot.state) {
+            .idle => .idle,
+            .polling => .polling,
+            .succeeded => .succeeded,
+            .failed => .failed,
+            .cancelled => .cancelled,
+        },
+        .verification_uri = snapshot.verification_uri,
+        .verification_uri_complete = snapshot.verification_uri_complete,
+        .user_code = snapshot.user_code,
+    };
+}
+
+fn vercelSignInBrowserUrl(raw: ?*anyopaque, alloc: Allocator) Allocator.Error!?[]u8 {
+    const state: *VercelSignIn = @ptrCast(@alignCast(raw.?));
+    return state.runtime.browserUrlAlloc(alloc);
+}
+
+fn pollVercelSignIn(raw: ?*anyopaque, alloc: Allocator) Allocator.Error!adapter_auth.SignInTransition {
+    const state: *VercelSignIn = @ptrCast(@alignCast(raw.?));
+    return switch (state.runtime.pollTransition(alloc)) {
+        .none => .none,
+        .cancelled => .cancelled,
+        .failed => |err| .{ .failed = normalizeAuthFailure(err) },
+        .succeeded => |value| blk: {
+            var selection = value;
+            defer selection.deinit(alloc);
+            break :blk .{ .succeeded = try takeVercelTeamSelection(alloc, &selection) };
+        },
+    };
+}
+
+fn cancelVercelSignIn(raw: ?*anyopaque, alloc: Allocator) bool {
+    const state: *VercelSignIn = @ptrCast(@alignCast(raw.?));
+    return state.runtime.cancel(alloc);
+}
+
+fn deinitVercelSignIn(raw: ?*anyopaque, alloc: Allocator) void {
+    const state: *VercelSignIn = @ptrCast(@alignCast(raw.?));
+    state.runtime.deinit(alloc);
+    alloc.destroy(state);
+}
+
+fn loadVercelTeams(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    _: connection_registry.Profile,
+    _: adapter_auth.AuthHost,
+) Allocator.Error!adapter_auth.TeamsOutcome {
+    var selection = login_flow.loadTeamSelection(alloc, vercelContext(raw).transport) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        const failure = normalizeAuthFailure(err);
+        return if (failure.category == .cancelled) .cancelled else .{ .failed = failure };
+    };
+    defer selection.deinit(alloc);
+    return .{ .loaded = try takeVercelTeamSelection(alloc, &selection) };
+}
+
+fn invalidateVercelCredential(
+    _: *const anyopaque,
+    _: connection_registry.Profile,
+    failure: adapter_auth.Failure,
+) adapter_auth.Invalidation {
+    return .{ .drop_credential = failure.category == .denied };
+}
+
+fn loadVercelStatus(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    profile: connection_registry.Profile,
+    auth_host: adapter_auth.AuthHost,
+) Allocator.Error!adapter_auth.StatusOutcome {
+    const acquisition = try acquireVercelCredential(raw, alloc, .{
+        .profile = profile,
+        .host = auth_host,
+        .mode = .stored,
+    });
+    var credential = switch (acquisition) {
+        .acquired => |value| value,
+        .missing => |store_status| return .{ .loaded = .{
+            .store_status = store_status,
+        } },
+        .failed => |failure| return .{ .failed = failure },
+        .cancelled => return .cancelled,
+    };
+    defer credential.deinit(alloc);
+    const owned_team = if (credential.tenant_slug) |value| blk: {
+        credential.tenant_slug = null;
+        break :blk value;
+    } else if (credential.tenant_id) |value| blk: {
+        credential.tenant_id = null;
+        break :blk value;
+    } else null;
+    return .{ .loaded = .{
+        .source = credential.source,
+        .team = owned_team,
+        .expired = if (credential.refresh_after_ms) |deadline| deadline <= io_mod.milliTimestamp() else false,
+    } };
+}
+
+pub const model_descriptor_provider = model_descriptors.provider;
 
 const AdapterEventBridge = struct {
     events: agent_stream_provider_contract.EventSink,
@@ -3213,4 +3611,315 @@ test "gateway catalog controls are explicit ordered and bounded" {
     try std.testing.expectEqualStrings("provider/malformed", catalog.items[2].id);
     try std.testing.expectEqual(@as(usize, 0), catalog.items[2].reasoning_efforts.items.len);
     try std.testing.expect(!catalog.items[2].supports_fast_mode);
+}
+
+const AdapterAuthStoreProbe = struct {
+    loads: usize = 0,
+    value: []const u8,
+
+    fn store(self: *@This()) host.SecretStore {
+        return .{
+            .context = self,
+            .backend_label = "adapter test store",
+            .is_disabled_fn = isDisabled,
+            .load_fn = load,
+            .store_fn = write,
+            .store_interactive_fn = writeInteractive,
+        };
+    }
+
+    fn isDisabled(_: ?*anyopaque) bool {
+        return false;
+    }
+
+    fn load(raw: ?*anyopaque, alloc: Allocator) host.SecretStoreLoadError!?[]u8 {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        self.loads += 1;
+        return try alloc.dupe(u8, self.value);
+    }
+
+    fn write(_: ?*anyopaque, _: Allocator, _: []const u8) host.SecretStoreWriteError!void {}
+
+    fn writeInteractive(_: ?*anyopaque) host.SecretStoreWriteError!bool {
+        return false;
+    }
+};
+
+const PeerAuthProbe = struct {
+    acquire_calls: usize = 0,
+    cancel_during_acquire: ?*std.atomic.Value(bool) = null,
+
+    fn acquire(raw: *const anyopaque, alloc: Allocator, request: adapter_auth.Request) Allocator.Error!adapter_auth.Acquisition {
+        const self: *@This() = @ptrCast(@alignCast(@constCast(raw)));
+        self.acquire_calls += 1;
+        const value = request.host.secret_store.load(alloc) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return .{ .missing = .unavailable };
+        } orelse return .{ .missing = .not_found };
+        if (self.cancel_during_acquire) |flag| flag.store(true, .seq_cst);
+        return .{ .acquired = .{
+            .secret_bytes = value,
+            .source = .{ .id = "peer_key", .label = "peer key", .refreshable = false },
+            .catalog_access = .authenticated,
+        } };
+    }
+};
+
+const AdapterAuthTestEnv = struct {
+    alloc: Allocator,
+    map: std.process.Environ.Map,
+
+    fn install(alloc: Allocator, entries: []const [2][]const u8) !*AdapterAuthTestEnv {
+        _ = try stableModelsTestEnviron();
+        const self = try alloc.create(AdapterAuthTestEnv);
+        errdefer alloc.destroy(self);
+        self.* = .{ .alloc = alloc, .map = std.process.Environ.Map.init(alloc) };
+        errdefer self.map.deinit();
+        for (entries) |entry| try self.map.put(entry[0], entry[1]);
+        io_mod.setEnvironMap(&self.map);
+        return self;
+    }
+
+    fn deinit(self: *AdapterAuthTestEnv) void {
+        if (stable_models_test_environ) |map| io_mod.setEnvironMap(map);
+        self.map.deinit();
+        const alloc = self.alloc;
+        alloc.destroy(self);
+    }
+};
+
+fn adapterAuthTestProfile(kind: []const u8, credential_ref: []const u8) connection_registry.Profile {
+    return .{
+        .id = @constCast("test"),
+        .display_name = @constCast("Test"),
+        .adapter_id = @constCast(kind),
+        .endpoint = null,
+        .protocol = null,
+        .credential_ref = @constCast(credential_ref),
+        .remembered_model = @constCast("model"),
+        .internal_models = .{},
+    };
+}
+
+test "production registry contains only Vercel" {
+    const validated = try adapter_registry.AdapterRegistry.init(production_adapter_registry.adapters);
+    try std.testing.expectEqual(@as(usize, 1), validated.adapters.len);
+    try std.testing.expectEqualStrings(connection_seed.adapter_id, validated.adapters[0].kind);
+}
+
+test "top-level status and interactive acquire resolve one adapter with zero cross traffic" {
+    var peer_probe: PeerAuthProbe = .{};
+    const peer_auth = adapter_auth.Provider{
+        .kind = "test_peer",
+        .context = &peer_probe,
+        .acquire_fn = PeerAuthProbe.acquire,
+    };
+    const peer_adapter = agent_stream_provider_contract.ProviderAdapter{
+        .kind = "test_peer",
+        .auth = peer_auth,
+        .stream_fn = agent_stream_provider_contract.unavailable_adapter.stream_fn,
+    };
+    const adapters = [_]agent_stream_provider_contract.ProviderAdapter{ provider_adapter, peer_adapter };
+    const registry = try adapter_registry.AdapterRegistry.init(&adapters);
+    var vercel_store = AdapterAuthStoreProbe{ .value = "vercel-secret" };
+    var peer_store = AdapterAuthStoreProbe{ .value = "peer-secret" };
+
+    const vercel_profile = adapterAuthTestProfile(connection_seed.adapter_id, "stored_key");
+    const vercel_auth = try registry.resolveAuthForProfile(vercel_profile);
+    var status = switch (try vercel_auth.status(std.testing.allocator, vercel_profile, .{
+        .secret_store = vercel_store.store(),
+    })) {
+        .loaded => |value| value,
+        .failed, .cancelled => return error.UnexpectedAdapterStatus,
+    };
+    defer status.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), vercel_store.loads);
+    try std.testing.expectEqual(@as(usize, 0), peer_store.loads);
+    try std.testing.expectEqual(@as(usize, 0), peer_probe.acquire_calls);
+    try std.testing.expectEqualStrings(credentials.sourceLabel(.stored_key), status.source.?.label);
+
+    const peer_profile = adapterAuthTestProfile("test_peer", "automatic");
+    const selected_peer = try registry.resolveAuthForProfile(peer_profile);
+    var credential = switch (try selected_peer.acquire(std.testing.allocator, .{
+        .profile = peer_profile,
+        .host = .{ .secret_store = peer_store.store() },
+        .mode = .if_needed,
+    })) {
+        .acquired => |value| value,
+        .missing, .failed, .cancelled => return error.UnexpectedAdapterAcquisition,
+    };
+    defer credential.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), vercel_store.loads);
+    try std.testing.expectEqual(@as(usize, 1), peer_store.loads);
+    try std.testing.expectEqual(@as(usize, 1), peer_probe.acquire_calls);
+
+    try std.testing.expectError(
+        error.MissingAdapter,
+        registry.resolveAuthForProfile(adapterAuthTestProfile("missing", "automatic")),
+    );
+    try std.testing.expectEqual(@as(usize, 1), vercel_store.loads);
+    try std.testing.expectEqual(@as(usize, 1), peer_store.loads);
+}
+
+test "adapter auth preserves invalid references refresh failures and late cancellation" {
+    const env_secret = "invalid-reference-must-not-fallback";
+    const env = try AdapterAuthTestEnv.install(std.testing.allocator, &.{.{ "AI_GATEWAY_API_KEY", env_secret }});
+    defer env.deinit();
+    var vercel_store = AdapterAuthStoreProbe{ .value = "stored-secret" };
+
+    const invalid_profile = adapterAuthTestProfile(connection_seed.adapter_id, "not_a_credential_source");
+    const invalid = try auth_provider.acquire(std.testing.allocator, .{
+        .profile = invalid_profile,
+        .host = .{ .secret_store = vercel_store.store() },
+        .mode = .if_needed,
+    });
+    switch (invalid) {
+        .failed => |failure| try std.testing.expectEqual(adapter_auth.FailureCategory.configuration, failure.category),
+        .acquired, .missing, .cancelled => return error.UnexpectedInvalidReferenceOutcome,
+    }
+    var failure_json: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer failure_json.deinit();
+    try std.json.Stringify.value(invalid, .{}, &failure_json.writer);
+    try std.testing.expect(std.mem.find(u8, failure_json.written(), env_secret) == null);
+    const invalid_status = try auth_provider.status(std.testing.allocator, invalid_profile, .{
+        .secret_store = vercel_store.store(),
+    });
+    switch (invalid_status) {
+        .failed => |failure| try std.testing.expectEqual(adapter_auth.FailureCategory.configuration, failure.category),
+        .loaded, .cancelled => return error.UnexpectedInvalidReferenceStatus,
+    }
+    try std.testing.expectEqual(@as(usize, 0), vercel_store.loads);
+
+    const refresh = try auth_provider.acquire(std.testing.allocator, .{
+        .profile = adapterAuthTestProfile(connection_seed.adapter_id, "fx_login"),
+        .host = .{ .secret_store = vercel_store.store() },
+        .mode = .force,
+        .current_source_id = "fx_login",
+    });
+    switch (refresh) {
+        .failed => |failure| try std.testing.expectEqual(adapter_auth.FailureCategory.unavailable, failure.category),
+        .acquired, .missing, .cancelled => return error.UnexpectedRefreshFailureOutcome,
+    }
+    try std.testing.expectEqual(@as(usize, 0), vercel_store.loads);
+
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    var peer_probe = PeerAuthProbe{ .cancel_during_acquire = &cancel_flag };
+    const peer_auth = adapter_auth.Provider{
+        .kind = "test_peer",
+        .context = &peer_probe,
+        .acquire_fn = PeerAuthProbe.acquire,
+    };
+    const adapters = [_]agent_stream_provider_contract.ProviderAdapter{
+        provider_adapter,
+        .{
+            .kind = "test_peer",
+            .auth = peer_auth,
+            .stream_fn = agent_stream_provider_contract.unavailable_adapter.stream_fn,
+        },
+    };
+    const registry = try adapter_registry.AdapterRegistry.init(&adapters);
+    const peer_profile = adapterAuthTestProfile("test_peer", "automatic");
+    var backing: [128]u8 = [_]u8{0xa5} ** 128;
+    var fixed = std.heap.FixedBufferAllocator.init(&backing);
+    var peer_store = AdapterAuthStoreProbe{ .value = "late-cancel-secret" };
+    const cancelled = try (try registry.resolveAuthForProfile(peer_profile)).acquire(fixed.allocator(), .{
+        .profile = peer_profile,
+        .host = .{ .secret_store = peer_store.store() },
+        .mode = .if_needed,
+        .cancel_flag = &cancel_flag,
+    });
+    try std.testing.expect(cancelled == .cancelled);
+    try std.testing.expectEqual(@as(usize, 1), peer_store.loads);
+    try std.testing.expectEqual(@as(usize, 1), peer_probe.acquire_calls);
+    try std.testing.expect(std.mem.find(u8, &backing, "late-cancel-secret") == null);
+}
+
+const ConditionalRefreshProbe = struct {
+    discovery_calls: usize = 0,
+    refresh_calls: usize = 0,
+    saw_refresh_secret: bool = false,
+
+    fn provider(self: *@This()) oauth_transport.Provider {
+        return .{ .context = self, .execute_fn = execute };
+    }
+
+    fn execute(raw: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        return switch (request.method) {
+            .get => blk: {
+                self.discovery_calls += 1;
+                break :blk .{
+                    .disposition = .accepted,
+                    .body = try alloc.dupe(u8,
+                        \\{"issuer":"https://vercel.com","device_authorization_endpoint":"https://vercel.com/oauth/device","token_endpoint":"https://vercel.com/oauth/token"}
+                    ),
+                };
+            },
+            .post_form => {
+                self.refresh_calls += 1;
+                self.saw_refresh_secret = if (request.payload) |payload|
+                    std.mem.find(u8, payload, "conditional-refresh-secret") != null
+                else
+                    false;
+                return error.InjectedRefreshFailure;
+            },
+        };
+    }
+};
+
+test "exact conditional fx login refresh failure is normalized without fallback" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(home);
+    const fallback_secret = "conditional-fallback-secret";
+    const env = try AdapterAuthTestEnv.install(alloc, &.{
+        .{ "HOME", home },
+        .{ "AI_GATEWAY_API_KEY", fallback_secret },
+    });
+    defer env.deinit();
+
+    var session = oauth_session.Session{
+        .issuer = try alloc.dupe(u8, "https://vercel.com"),
+        .client_id = try alloc.dupe(u8, "test-client"),
+        .access_token = try alloc.dupe(u8, "expired-access-secret"),
+        .refresh_token = try alloc.dupe(u8, "conditional-refresh-secret"),
+        .expires_at_ms = 0,
+        .scope = try alloc.dupe(u8, "openid offline_access"),
+        .token_type = try alloc.dupe(u8, "Bearer"),
+    };
+    defer session.deinit(alloc);
+    try oauth_session.saveNewSession(alloc, session);
+
+    var refresh_probe: ConditionalRefreshProbe = .{};
+    const context = VercelAuthContext{ .transport = refresh_probe.provider() };
+    const test_provider = adapter_auth.Provider{
+        .kind = connection_seed.adapter_id,
+        .context = &context,
+        .acquire_fn = acquireVercelCredential,
+    };
+    var store = AdapterAuthStoreProbe{ .value = "stored-fallback-secret" };
+    const outcome = try test_provider.acquire(alloc, .{
+        .profile = adapterAuthTestProfile(connection_seed.adapter_id, "fx_login"),
+        .host = .{ .secret_store = store.store() },
+        .mode = .if_needed,
+        .source_resolution = .exact,
+        .current_source_id = "fx_login",
+    });
+    switch (outcome) {
+        .failed => |failure| try std.testing.expectEqual(adapter_auth.FailureCategory.unavailable, failure.category),
+        .acquired, .missing, .cancelled => return error.UnexpectedConditionalRefreshOutcome,
+    }
+    try std.testing.expectEqual(@as(usize, 1), refresh_probe.discovery_calls);
+    try std.testing.expectEqual(@as(usize, 1), refresh_probe.refresh_calls);
+    try std.testing.expect(refresh_probe.saw_refresh_secret);
+    try std.testing.expectEqual(@as(usize, 0), store.loads);
+
+    var rendered: std.Io.Writer.Allocating = .init(alloc);
+    defer rendered.deinit();
+    try std.json.Stringify.value(outcome, .{}, &rendered.writer);
+    for ([_][]const u8{ "expired-access-secret", "conditional-refresh-secret", fallback_secret, store.value }) |value| {
+        try std.testing.expect(std.mem.find(u8, rendered.written(), value) == null);
+    }
 }

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const agent_steps = @import("../../config/agent_steps.zig");
 const model_capabilities = @import("../../config/model_capabilities.zig");
 const route_snapshot = @import("../../gateway/route_snapshot.zig");
+const adapter_auth = @import("../../gateway/adapter_auth.zig");
 const types = @import("../../shared/types.zig");
 const agent_stream_provider = @import("../stream_provider.zig");
 const worker_runtime = @import("../worker_runtime.zig");
@@ -3074,8 +3075,8 @@ fn processQueuedPromptLoop(
         var successful_vision_route: runtime_vision_contracts.VisionRoute = .native_images;
         var successful_vision_mode: runtime_gateway_step.VisionToolMode = .unavailable;
         var reset_stream_for_next_attempt = false;
-        var auth_retry_used = false;
         var assistant_prefill_recovery_used = false;
+        var unauthorized_refresh: adapter_auth.UnauthorizedRefresh = .{};
         var skip_next_preflight_refresh = false;
         var recovery_has_unexecuted_tool_start = false;
         var successful_recovery_strategy: ?model_response_recovery.Strategy = null;
@@ -3768,28 +3769,31 @@ fn processQueuedPromptLoop(
             runtime_assistant_stream.pushTokenProgressUpdate(&stream_ctx, summary_accumulator.reconcileTokenRequest(stream_result.completion.usage, stream_result.completion.delivery_ambiguous)) catch |progress_err| {
                 debug_trace.logf("agent", "token progress publication failed source=gateway_usage err={s}", .{@errorName(progress_err)});
             };
-            if (stream_result.status == .unauthorized and
-                !auth_retry_used and
-                semantic_attempt + 1 < semantic_limit)
-            {
-                if (try refreshGatewayCredentialForJob(
-                    deps,
-                    std.heap.c_allocator,
-                    &route_credential,
-                    .force,
-                    step_ctx,
-                )) {
-                    auth_retry_used = true;
-                    if (stream_result.err_body) |body| mem_utils.free(arena, body);
-                    stream_result.err_body = null;
-                    stream_result_set = false;
-                    semantic_attempt += 1;
-                    recovery_strategy = .retry_request;
-                    recovery_cause = .authentication;
-                    retry_pacing = .idle;
-                    reset_stream_for_next_attempt = true;
-                    skip_next_preflight_refresh = true;
-                    continue;
+            if (stream_result.status == .unauthorized and semantic_attempt + 1 < semantic_limit) {
+                const refreshable = route_credential.legacy_source == .fx_login;
+                if (unauthorized_refresh.next(refreshable)) |refresh_mode| {
+                    if (try refreshGatewayCredentialForJob(
+                        deps,
+                        std.heap.c_allocator,
+                        &route_credential,
+                        switch (refresh_mode) {
+                            .force => .force,
+                            .if_needed => .if_needed,
+                            .stored => unreachable,
+                        },
+                        step_ctx,
+                    )) {
+                        if (stream_result.err_body) |body| mem_utils.free(arena, body);
+                        stream_result.err_body = null;
+                        stream_result_set = false;
+                        semantic_attempt += 1;
+                        recovery_strategy = .retry_request;
+                        recovery_cause = .authentication;
+                        retry_pacing = .idle;
+                        reset_stream_for_next_attempt = true;
+                        skip_next_preflight_refresh = true;
+                        continue;
+                    }
                 }
             }
             const gateway_wait_finished_ms = io_mod.milliTimestamp();

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1805,7 +1805,7 @@ fn refreshGatewayCredentialForJob(
             "source={s} mode={s} err={s}",
             .{ @tagName(source), @tagName(mode), @errorName(err) },
         );
-        return false;
+        return err;
     } orelse return false;
     secret.zeroAndFree(alloc, route_credential.credential);
     route_credential.credential = refreshed;

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -5806,15 +5806,9 @@ test "processQueuedPrompt keeps the selected fx login credential when forced ref
     try std.testing.expectEqual(types.TurnPresentationOutcome.failed, hooks.finalized_outcome.?);
 }
 
-test "processQueuedPrompt reports the selected login after refresh failure without fallback" {
+test "processQueuedPrompt stops before Gateway after conditional refresh failure" {
     const alloc = std.testing.allocator;
-    const completions = [_]FakeCompletion{
-        .{
-            .status = .unauthorized,
-            .err_body = "{\"error\":{\"message\":\"expired\"}}",
-        },
-        .{ .content = "must not be requested" },
-    };
+    const completions = [_]FakeCompletion{.{ .content = "must not be requested" }};
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
     var hooks = FakeAgentRuntimeDeps.init(alloc);
@@ -5824,16 +5818,14 @@ test "processQueuedPrompt reports the selected login after refresh failure witho
     var fixture = PromptFixture{};
     const job = fixture.job();
 
-    try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+    try std.testing.expectError(
+        error.OAuthRequestFailed,
+        runFakePrompt(&gateway, &hooks, fixture.config(), job),
+    );
 
-    try std.testing.expectEqual(@as(usize, 1), gateway.request_api_keys.items.len);
-    try std.testing.expectEqualStrings("key", gateway.request_api_keys.items[0]);
-    try std.testing.expectEqual(@as(usize, 2), hooks.credential_refresh_modes.items.len);
+    try std.testing.expectEqual(@as(usize, 0), gateway.request_api_keys.items.len);
+    try std.testing.expectEqual(@as(usize, 1), hooks.credential_refresh_modes.items.len);
     try std.testing.expectEqual(runtime_deps.CredentialRefreshMode.if_needed, hooks.credential_refresh_modes.items[0]);
-    try std.testing.expectEqual(runtime_deps.CredentialRefreshMode.force, hooks.credential_refresh_modes.items[1]);
-    try std.testing.expectEqual(std.http.Status.unauthorized, hooks.http_status.?);
-    try std.testing.expectEqual(types.CredentialSource.fx_login, hooks.http_credential_source.?);
-    try std.testing.expectEqual(types.TurnPresentationOutcome.failed, hooks.finalized_outcome.?);
 }
 
 test "processQueuedPrompt does not refresh or retry non-refreshable credential sources" {

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const adapter_auth = @import("../gateway/adapter_auth.zig");
 const account_usage_provider = @import("../gateway/account_usage_provider.zig");
 const model_catalog = @import("../gateway/model_catalog.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
@@ -488,6 +489,7 @@ pub const AdapterStreamFn = *const fn (
 
 pub const ProviderAdapter = struct {
     kind: []const u8,
+    auth: ?adapter_auth.Provider = null,
     /// When set, context must remain valid until every in-flight stream returns.
     context: ?*anyopaque = null,
     /// Bounded G1 bridge for existing injected Vercel stream providers. G11

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -6,7 +6,7 @@ const runtime_profile = @import("../hosts/runtime_profile.zig");
 const io_mod = @import("../shared/io.zig");
 const credentials = @import("../auth/credentials.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
-const login_flow = @import("../auth/login_flow.zig");
+const adapter_auth = @import("../gateway/adapter_auth.zig");
 const types = @import("../shared/types.zig");
 
 fn oauthAuthEnabled(comptime App: type) bool {
@@ -56,8 +56,25 @@ pub fn Runtime(comptime App: type) type {
                 return;
             }
             try app.flushBeforeBlockingExternalWork();
-            const result = login_flow.logout(app.alloc, app.auth.oauthTransport()) catch |err| switch (err) {
-                error.SessionDeleteFailed => {
+            const outcome = app.auth.logoutSelected(app.alloc) catch {
+                try writeAuthNotice(app, .{
+                    .topic = "auth",
+                    .tone = .@"error",
+                    .body = "Could not complete fx logout. The current source is unchanged.",
+                });
+                return;
+            };
+            const result = switch (outcome) {
+                .completed => |value| value,
+                .failed => {
+                    try writeAuthNotice(app, .{
+                        .topic = "auth",
+                        .tone = .@"error",
+                        .body = "Could not complete fx logout. The current source is unchanged.",
+                    });
+                    return;
+                },
+                .cancelled => {
                     try writeAuthNotice(app, .{
                         .topic = "auth",
                         .tone = .@"error",
@@ -83,7 +100,7 @@ pub fn Runtime(comptime App: type) type {
             app.shell.render_requests.request(.footer);
         }
 
-        fn applyLogoutResult(app: *App, result: login_flow.LogoutResult) !void {
+        fn applyLogoutResult(app: *App, result: adapter_auth.LogoutResult) !void {
             // Logging out is an explicit rejection of that credential, so a
             // remembered pointer to it would silently reactivate on next login.
             // A remembered source always wins resolution, so an active fx login
@@ -113,7 +130,7 @@ pub fn Runtime(comptime App: type) type {
                 try writeAuthNotice(app, .{
                     .topic = "auth",
                     .tone = .warning,
-                    .body = login_flow.remote_revocation_warning,
+                    .body = "Warning: signed out locally, but the remote session could not be revoked.",
                 });
             }
         }
@@ -191,15 +208,13 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn collectSignInFacts(app: *App) !void {
-            if (comptime !oauthAuthEnabled(App)) return;
-            app.auth.pulseSignIn(app.alloc);
-            switch (app.auth.pollSignInTransition(app.alloc)) {
+            switch (try app.auth.pollSignInTransition(app.alloc)) {
                 .none => {},
                 .cancelled => app.shell.render_requests.request(.footer),
-                .failed => |err| {
-                    debug_trace.logf("auth", "login failed err={s}", .{@errorName(err)});
+                .failed => |failure| {
+                    debug_trace.logf("auth", "login failed category={t}", .{failure.category});
                     _ = app.auth.popPickerStage(app.alloc);
-                    try writeLoginError(app, err);
+                    try writeLoginFailure(app, failure);
                 },
                 .succeeded => |completed| {
                     var selection = completed;
@@ -216,7 +231,7 @@ pub fn Runtime(comptime App: type) type {
                     }
                     rememberCredentialSource(app, .fx_login);
 
-                    if (selection.teams.items.len > 0) {
+                    if (selection.teams.len > 0) {
                         app.auth.openTeamPicker(app.alloc, &selection);
                     } else {
                         _ = app.auth.popPickerStage(app.alloc);
@@ -418,18 +433,31 @@ pub fn Runtime(comptime App: type) type {
             if (!app.auth.pickerView().fx_login_session_available) return;
             try app.flushBeforeBlockingExternalWork();
 
-            var selection = login_flow.loadTeamSelection(app.alloc, app.auth.oauthTransport()) catch |err| {
+            const outcome = app.auth.loadSelectedTeams(app.alloc) catch |err| {
                 debug_trace.logf("auth", "team picker load failed err={s}", .{@errorName(err)});
                 try app.writeDomainNotice(.{
                     .topic = "auth",
                     .tone = .@"error",
-                    .body = switch (err) {
-                        error.NoSession => "The fx login session is no longer available. Sign in to change teams.",
-                        error.NoTeams => "No Vercel teams are available for this account.",
-                        else => "Could not load Vercel teams. The current team is unchanged.",
-                    },
+                    .body = "Could not load Vercel teams. The current team is unchanged.",
                 }, true);
                 return;
+            };
+            var selection = switch (outcome) {
+                .loaded => |value| value,
+                .cancelled => return,
+                .failed => |failure| {
+                    debug_trace.logf("auth", "team picker load failed category={t}", .{failure.category});
+                    try app.writeDomainNotice(.{
+                        .topic = "auth",
+                        .tone = .@"error",
+                        .body = switch (failure.category) {
+                            .missing_session => "The fx login session is no longer available. Sign in to change teams.",
+                            .no_teams => "No Vercel teams are available for this account.",
+                            else => "Could not load Vercel teams. The current team is unchanged.",
+                        },
+                    }, true);
+                    return;
+                },
             };
             defer selection.deinit(app.alloc);
             app.auth.openTeamPicker(app.alloc, &selection);
@@ -438,8 +466,8 @@ pub fn Runtime(comptime App: type) type {
 
         fn applyTeamChoice(app: *App, index: usize) !void {
             const selection = app.auth.teamSelection() orelse return;
-            if (index >= selection.teams.items.len) return;
-            const team = selection.teams.items[index];
+            if (index >= selection.teams.len) return;
+            const team = selection.teams[index];
             const body = try std.fmt.allocPrint(
                 app.alloc,
                 "Changed Vercel team to {s} ({s}).",
@@ -447,18 +475,31 @@ pub fn Runtime(comptime App: type) type {
             );
             defer app.alloc.free(body);
 
-            var selected_team = selection.select(app.alloc, index) catch |err| {
+            const selection_outcome = selection.select(app.alloc, index) catch |err| {
                 debug_trace.logf("auth", "team change failed err={s}", .{@errorName(err)});
                 app.auth.closePicker(app.alloc);
                 try app.writeDomainNotice(.{
                     .topic = "auth",
                     .tone = .@"error",
-                    .body = switch (err) {
-                        error.SessionChanged, error.NoSession => "The fx login session changed before the team could be saved.",
-                        else => "Could not change the Vercel team. The current team is unchanged.",
-                    },
+                    .body = "Could not change the Vercel team. The current team is unchanged.",
                 }, true);
                 return;
+            };
+            var selected_team = switch (selection_outcome) {
+                .selected => |value| value,
+                .failed => |failure| {
+                    debug_trace.logf("auth", "team change failed category={t}", .{failure.category});
+                    app.auth.closePicker(app.alloc);
+                    try app.writeDomainNotice(.{
+                        .topic = "auth",
+                        .tone = .@"error",
+                        .body = switch (failure.category) {
+                            .session_changed, .missing_session => "The fx login session changed before the team could be saved.",
+                            else => "Could not change the Vercel team. The current team is unchanged.",
+                        },
+                    }, true);
+                    return;
+                },
             };
             defer selected_team.deinit(app.alloc);
 
@@ -602,9 +643,19 @@ pub fn Runtime(comptime App: type) type {
 
         fn writeLoginError(app: *App, err: anyerror) !void {
             const notice: types.SemanticNotice = switch (err) {
-                error.ClientIdMissing => .{ .topic = "auth", .tone = .@"error", .body = "fx login is not configured yet. The current credential is unchanged." },
-                error.AccessDenied => .{ .topic = "auth", .tone = .@"error", .body = "Vercel sign-in was denied. The current credential is unchanged." },
-                error.ExpiredToken, error.LoginTimedOut => .{ .topic = "auth", .tone = .warning, .body = "The Vercel sign-in code expired. The current credential is unchanged; run /login to try again." },
+                error.AuthConfiguration => .{ .topic = "auth", .tone = .@"error", .body = "fx login is not configured yet. The current credential is unchanged." },
+                error.AuthDenied => .{ .topic = "auth", .tone = .@"error", .body = "Vercel sign-in was denied. The current credential is unchanged." },
+                error.AuthExpired => .{ .topic = "auth", .tone = .warning, .body = "The Vercel sign-in code expired. The current credential is unchanged; run /login to try again." },
+                else => .{ .topic = "auth", .tone = .@"error", .body = "Vercel sign-in failed. The current credential is unchanged." },
+            };
+            try writeAuthNotice(app, notice);
+        }
+
+        fn writeLoginFailure(app: *App, failure: adapter_auth.Failure) !void {
+            const notice: types.SemanticNotice = switch (failure.category) {
+                .configuration => .{ .topic = "auth", .tone = .@"error", .body = "fx login is not configured yet. The current credential is unchanged." },
+                .denied => .{ .topic = "auth", .tone = .@"error", .body = "Vercel sign-in was denied. The current credential is unchanged." },
+                .expired => .{ .topic = "auth", .tone = .warning, .body = "The Vercel sign-in code expired. The current credential is unchanged; run /login to try again." },
                 else => .{ .topic = "auth", .tone = .@"error", .body = "Vercel sign-in failed. The current credential is unchanged." },
             };
             try writeAuthNotice(app, notice);
@@ -636,30 +687,27 @@ const test_teams = [_]TestTeam{.{
     .slug = "vercel-labs",
 }};
 
-const TestSelectedTeam = struct {
-    fn deinit(_: *TestSelectedTeam, _: std.mem.Allocator) void {}
-};
-
 const TestTeamSelection = struct {
-    teams: struct {
-        items: []const TestTeam = &test_teams,
-    } = .{},
+    teams: []const TestTeam = &test_teams,
     select_count: usize = 0,
 
     fn select(
         self: *TestTeamSelection,
-        _: std.mem.Allocator,
+        alloc: std.mem.Allocator,
         index: usize,
-    ) error{ InvalidTeamSelection, SessionChanged, NoSession }!TestSelectedTeam {
-        if (index >= self.teams.items.len) return error.InvalidTeamSelection;
+    ) std.mem.Allocator.Error!adapter_auth.SelectOutcome {
+        if (index >= self.teams.len) return .{ .failed = .{ .category = .invalid_selection } };
         self.select_count += 1;
-        return .{};
+        const team = self.teams[index];
+        const id = try alloc.dupe(u8, team.slug);
+        errdefer alloc.free(id);
+        return .{ .selected = .{ .id = id, .slug = try alloc.dupe(u8, team.slug) } };
     }
 };
 
 const TestAuth = struct {
     select_result: ?bool = false,
-    sign_in_transition: login_flow.SignInTransition = .none,
+    sign_in_transition: adapter_auth.SignInTransition = .none,
     logout_changed: bool = false,
     refresh_changed: bool = false,
     refresh_error: ?anyerror = null,
@@ -689,7 +737,7 @@ const TestAuth = struct {
         return self.select_result;
     }
 
-    fn pollSignInTransition(self: *TestAuth, _: std.mem.Allocator) login_flow.SignInTransition {
+    fn pollSignInTransition(self: *TestAuth, _: std.mem.Allocator) !adapter_auth.SignInTransition {
         const transition = self.sign_in_transition;
         self.sign_in_transition = .none;
         return transition;
@@ -702,7 +750,7 @@ const TestAuth = struct {
         return true;
     }
 
-    fn openTeamPicker(_: *TestAuth, _: std.mem.Allocator, _: *login_flow.TeamSelection) void {}
+    fn openTeamPicker(_: *TestAuth, _: std.mem.Allocator, _: *adapter_auth.TeamSelection) void {}
 
     fn refreshFxLoginIfNeeded(self: *TestAuth, _: std.mem.Allocator) !bool {
         self.refresh_count += 1;
@@ -743,7 +791,7 @@ const TestAuth = struct {
         return &self.team_selection;
     }
 
-    fn adoptSelectedTeam(self: *TestAuth, _: std.mem.Allocator, _: *TestSelectedTeam) bool {
+    fn adoptSelectedTeam(self: *TestAuth, _: std.mem.Allocator, _: *adapter_auth.SelectedTeam) bool {
         self.selected_team_adopted = true;
         return true;
     }
@@ -1024,7 +1072,7 @@ test "successful direct login remembers fx login after activation" {
     var app: TestApp = .{};
     defer app.deinit();
     app.auth.select_result = true;
-    app.auth.sign_in_transition = .{ .succeeded = .{} };
+    app.auth.sign_in_transition = .{ .succeeded = adapter_auth.unavailable_team_selection };
 
     try Runtime(TestApp).collectSignInFacts(&app);
 
@@ -1038,7 +1086,7 @@ test "direct login source load failure leaves the environment preference unchang
     var app: TestApp = .{};
     defer app.deinit();
     app.auth.select_result = null;
-    app.auth.sign_in_transition = .{ .succeeded = .{} };
+    app.auth.sign_in_transition = .{ .succeeded = adapter_auth.unavailable_team_selection };
 
     try Runtime(TestApp).collectSignInFacts(&app);
 
@@ -1052,7 +1100,7 @@ test "failed preference persistence keeps a successful direct login active" {
     var app: TestApp = .{};
     defer app.deinit();
     app.auth.select_result = true;
-    app.auth.sign_in_transition = .{ .succeeded = .{} };
+    app.auth.sign_in_transition = .{ .succeeded = adapter_auth.unavailable_team_selection };
     app.preference_write_succeeds = false;
 
     try Runtime(TestApp).collectSignInFacts(&app);
@@ -1154,7 +1202,7 @@ test "logout result reconciles live auth and renders only sanitized notices" {
     try std.testing.expectEqual(@as(usize, 1), app.model_cache.reset_count);
     try std.testing.expectEqual(@as(usize, 1), app.model_cache_warmup_count);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Signed out of fx.") != null);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, login_flow.remote_revocation_warning) != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "remote session could not be revoked") != null);
     for ([_][]const u8{ "access-secret", "refresh-secret", "RemoteRevokeFailed", "https://issuer.example" }) |detail| {
         try std.testing.expect(std.mem.find(u8, app.transcript.items, detail) == null);
     }
@@ -1174,7 +1222,7 @@ test "logout durability failure still reconciles live auth" {
     try std.testing.expectEqual(@as(usize, 1), app.auth.logout_reconcile_count);
     try std.testing.expectEqual(@as(usize, 1), app.model_cache.reset_count);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "Could not confirm durable fx logout.") != null);
-    try std.testing.expect(std.mem.find(u8, app.transcript.items, login_flow.remote_revocation_warning) != null);
+    try std.testing.expect(std.mem.find(u8, app.transcript.items, "remote session could not be revoked") != null);
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "current source is unchanged") == null);
 }
 

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
+const adapter_auth = @import("../gateway/adapter_auth.zig");
+const agent_stream_provider = @import("../agent/stream_provider.zig");
 const app_lifecycle = @import("app_lifecycle.zig");
 const model_catalog = @import("../gateway/model_catalog.zig");
 const connection_registry = @import("../gateway/connection_registry.zig");
+const adapter_registry = @import("../gateway/adapter_registry.zig");
 const app_input_runtime = @import("app_input_runtime.zig");
 const app_permission_runtime = @import("app_permission_runtime.zig");
 const app_render_runtime = @import("app_render_runtime.zig");
@@ -37,6 +40,7 @@ pub const CapabilityProviders = struct {
     skill_root_policy: skill_contract.RootPolicy,
     terminal_title: host.TerminalTitle,
     connection_seed: connection_registry.Seed,
+    adapter_registry: adapter_registry.AdapterRegistry = .{ .adapters = &.{} },
     model_descriptors: model_catalog.ModelDescriptorProvider = model_catalog.configured_model_descriptor_provider,
 };
 
@@ -98,6 +102,7 @@ pub fn Runtime(comptime App: type) type {
                 resize_handler,
                 record_requested,
                 capability_providers.connection_seed,
+                capability_providers.adapter_registry,
                 capability_providers.model_descriptors,
                 defaultDeps(capability_providers),
             );
@@ -189,6 +194,7 @@ pub fn Runtime(comptime App: type) type {
             resize_handler: app_lifecycle.ResizeHandler,
             record_requested: bool,
             connection_seed: connection_registry.Seed,
+            registry: adapter_registry.AdapterRegistry,
             model_descriptors: model_catalog.ModelDescriptorProvider,
             deps: BootstrapDeps(App),
         ) !void {
@@ -205,6 +211,7 @@ pub fn Runtime(comptime App: type) type {
                 .default_model = default_model,
                 .default_fast_mode = default_fast_mode,
                 .connection_seed = connection_seed,
+                .adapter_registry = registry,
                 .default_agent_step_limit = default_agent_step_limit,
                 .model_descriptors = model_descriptors,
                 .secret_store = if (comptime @hasDecl(App, "secretStore"))
@@ -541,6 +548,20 @@ const test_global_skill_roots = [_]skill_contract.RootSpec{
     .{ .source = .global_codex, .path = ".codex/skills" },
 };
 
+const test_connection_seed = connection_registry.Seed{
+    .id = "test",
+    .display_name = "Test Gateway",
+    .adapter_id = "test_gateway",
+    .credential_ref = "automatic",
+};
+const test_auth_provider = adapter_auth.Provider{ .kind = "test_gateway" };
+const test_adapters = [_]agent_stream_provider.ProviderAdapter{.{
+    .kind = "test_gateway",
+    .auth = test_auth_provider,
+    .stream_fn = agent_stream_provider.unavailable_adapter.stream_fn,
+}};
+const test_adapter_registry = adapter_registry.AdapterRegistry{ .adapters = &test_adapters };
+
 const TestApp = struct {
     pub const app_version = "0.2.10-test";
 
@@ -575,7 +596,10 @@ const TestApp = struct {
     deinit_calls: usize = 0,
 
     fn init(alloc: Allocator) TestApp {
-        return .{ .alloc = alloc };
+        return .{
+            .alloc = alloc,
+            .auth = .{ .adapter_registry = test_adapter_registry },
+        };
     }
 
     fn deinit(self: *TestApp) void {
@@ -693,6 +717,13 @@ fn makeStartupState(alloc: Allocator) !app_lifecycle.StartupState {
     state.first_call_tool_choice = .none;
     state.workspace_root = try alloc.dupe(u8, "/workspace");
     errdefer alloc.free(state.workspace_root);
+    state.connections = try connection_registry.Runtime.init(
+        alloc,
+        test_connection_seed.profile("model-x", null),
+        null,
+        .unavailable,
+    );
+    errdefer state.connections.?.deinit();
     if (active_capture.?.startup_with_credential) {
         const credential_token = try alloc.dupe(u8, "api-key");
         errdefer alloc.free(credential_token);
@@ -856,12 +887,8 @@ fn runBootstrapForTest(app: *TestApp, capture: *TestCapture) !void {
         24,
         resizeHandlerForTest,
         false,
-        .{
-            .id = "test",
-            .display_name = "Test Gateway",
-            .adapter_id = "test_gateway",
-            .credential_ref = "automatic",
-        },
+        test_connection_seed,
+        test_adapter_registry,
         model_catalog.configured_model_descriptor_provider,
         testDeps(),
     );

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -382,12 +382,11 @@ pub fn Bindings(comptime App: type) type {
             mode: auth_runtime.CredentialRefreshMode,
         ) !?[]u8 {
             const app: *App = @ptrCast(@alignCast(raw_ctx));
-            return auth_runtime.refreshFxLoginToken(
-                app.auth.oauthTransport(),
-                alloc,
-                source,
-                mode,
-            );
+            if (source != .fx_login) return null;
+            return app.auth.refreshSelectedCredential(alloc, switch (mode) {
+                .if_needed => .if_needed,
+                .force => .force,
+            });
         }
 
         pub fn modelCapabilityResolver(app: *App) model_capabilities.Resolver {

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -400,6 +400,7 @@ pub fn loadCatalogStartupStateWithRegistry(
         .profile = profile,
         .host = .{ .secret_store = secret_store },
         .mode = .stored,
+        .source_resolution = .allow_fallback,
     });
     switch (acquisition) {
         .acquired => |value| {

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -375,6 +375,7 @@ pub fn loadCatalogStartupStateWithRegistry(
     registry: adapter_registry.AdapterRegistry,
     secret_store: host.SecretStore,
     default_model: []const u8,
+    default_fast_mode: bool,
     default_agent_step_limit: usize,
     connection_seed: connection_registry.Seed,
 ) !StartupState {
@@ -385,6 +386,7 @@ pub fn loadCatalogStartupStateWithRegistry(
         host.unavailable_secret_store,
         workspace_root,
         default_model,
+        default_fast_mode,
         default_agent_step_limit,
         connection_seed,
         null,
@@ -2339,6 +2341,7 @@ test "registry startup preserves invalid credential references as configuration 
         registry,
         host.unavailable_secret_store,
         "default-model",
+        false,
         12,
         seed,
     );

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -7,6 +7,9 @@ const auth_runtime = @import("../auth/auth_runtime.zig");
 const credentials = @import("../auth/credentials.zig");
 const host = @import("../hosts/host.zig");
 const oauth_transport = @import("../auth/oauth_transport.zig");
+const stream_provider = if (builtin.is_test) @import("../agent/stream_provider.zig") else struct {};
+const adapter_auth = if (builtin.is_test) @import("../gateway/adapter_auth.zig") else struct {};
+const adapter_registry = @import("../gateway/adapter_registry.zig");
 const input_appearance = @import("../config/input_appearance.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
 const connection_registry = @import("../gateway/connection_registry.zig");
@@ -298,6 +301,7 @@ pub const BootstrapConfig = struct {
     default_model: []const u8,
     default_fast_mode: bool = false,
     connection_seed: connection_registry.Seed,
+    adapter_registry: adapter_registry.AdapterRegistry = .{ .adapters = &.{} },
     default_agent_step_limit: usize,
     model_descriptors: model_catalog.ModelDescriptorProvider,
     secret_store: host.SecretStore,
@@ -364,6 +368,65 @@ pub fn loadCatalogStartupState(
 ) !StartupState {
     const workspace_root = try io_mod.realpathAlloc(alloc, ".");
     return loadStartupStateFromOwnedWorkspace(alloc, oauth_transport.unavailable_provider, secret_store, workspace_root, default_model, default_fast_mode, default_agent_step_limit, connection_seed, null, .stored);
+}
+
+pub fn loadCatalogStartupStateWithRegistry(
+    alloc: Allocator,
+    registry: adapter_registry.AdapterRegistry,
+    secret_store: host.SecretStore,
+    default_model: []const u8,
+    default_agent_step_limit: usize,
+    connection_seed: connection_registry.Seed,
+) !StartupState {
+    const workspace_root = try io_mod.realpathAlloc(alloc, ".");
+    var state = try loadStartupStateFromOwnedWorkspace(
+        alloc,
+        oauth_transport.unavailable_provider,
+        host.unavailable_secret_store,
+        workspace_root,
+        default_model,
+        default_agent_step_limit,
+        connection_seed,
+        null,
+    );
+    errdefer state.deinit(alloc);
+    const connections = &state.connections.?;
+    const profile = connections.selectedProfile();
+    const auth = registry.resolveAuthForProfile(profile) catch {
+        connections.markSelectedDisconnected(.unsupported_adapter);
+        return state;
+    };
+    const acquisition = try auth.acquire(alloc, .{
+        .profile = profile,
+        .host = .{ .secret_store = secret_store },
+        .mode = .stored,
+    });
+    switch (acquisition) {
+        .acquired => |value| {
+            var normalized = value;
+            defer normalized.deinit(alloc);
+            state.credential = auth_runtime.takeAdapterCredential(&normalized) orelse {
+                connections.markSelectedDisconnected(.invalid_credential_reference);
+                return state;
+            };
+            connections.markSelectedConnected();
+        },
+        .missing => |store_status| {
+            state.stored_key_status = switch (store_status) {
+                .not_attempted => .not_attempted,
+                .not_found => .not_found,
+                .unavailable => .unavailable,
+            };
+            connections.markSelectedDisconnected(.missing_credential);
+        },
+        .failed => |failure| connections.markSelectedDisconnected(switch (failure.category) {
+            .configuration => .invalid_credential_reference,
+            .denied => .authentication_failed,
+            else => .not_checked,
+        }),
+        .cancelled => connections.markSelectedDisconnected(.not_checked),
+    }
+    return state;
 }
 
 pub fn loadStartupStatus(
@@ -613,8 +676,9 @@ pub fn bootstrapInteractiveApp(cfg: BootstrapConfig) !StartupState {
     cfg.shell.layout = minimalLayout();
     try cfg.shell.initBacking(cfg.alloc);
 
-    var state = try loadCatalogStartupState(
+    var state = try loadCatalogStartupStateWithRegistry(
         cfg.alloc,
+        cfg.adapter_registry,
         cfg.secret_store,
         cfg.default_model,
         cfg.default_fast_mode,
@@ -2242,7 +2306,52 @@ test "built-in Vercel connection reuses credential resolution and CatalogAccess 
     try std.testing.expect(!@hasField(connection_registry.Profile, "api_key"));
 }
 
-test "loadStartupState canonicalizes fast model defaults" {
+test "registry startup preserves invalid credential references as configuration failures" {
+    const FailedAuth = struct {
+        calls: usize = 0,
+
+        fn acquire(raw: *const anyopaque, _: Allocator, _: adapter_auth.Request) Allocator.Error!adapter_auth.Acquisition {
+            const self: *@This() = @ptrCast(@alignCast(@constCast(raw)));
+            self.calls += 1;
+            return .{ .failed = .{ .category = .configuration } };
+        }
+    };
+    var env = try TestEnv.install(std.testing.allocator, &.{});
+    defer env.deinit();
+    var failed_auth: FailedAuth = .{};
+    const auth = adapter_auth.Provider{
+        .kind = test_connection_seed.adapter_id,
+        .context = &failed_auth,
+        .acquire_fn = FailedAuth.acquire,
+    };
+    const adapters = [_]stream_provider.ProviderAdapter{.{
+        .kind = test_connection_seed.adapter_id,
+        .auth = auth,
+        .stream_fn = stream_provider.unavailable_adapter.stream_fn,
+    }};
+    const registry = try adapter_registry.AdapterRegistry.init(&adapters);
+    var seed = test_connection_seed;
+    seed.credential_ref = "invalid_reference";
+
+    var state = try loadCatalogStartupStateWithRegistry(
+        std.testing.allocator,
+        registry,
+        host.unavailable_secret_store,
+        "default-model",
+        12,
+        seed,
+    );
+    defer state.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), failed_auth.calls);
+    try std.testing.expect(state.credential == null);
+    try std.testing.expectEqual(
+        connection_registry.DisconnectReason.invalid_credential_reference,
+        state.connections.?.selectedProfile().auth.disconnected,
+    );
+}
+
+test "loadStartupState preserves exact fast model defaults" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -390,6 +390,7 @@ pub fn loadCatalogStartupStateWithRegistry(
         default_agent_step_limit,
         connection_seed,
         null,
+        null,
     );
     errdefer state.deinit(alloc);
     const connections = &state.connections.?;

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
 const api_key_validator = @import("api_key_validator.zig");
 const credentials = @import("credentials.zig");
+const adapter_auth = @import("../gateway/adapter_auth.zig");
+const adapter_registry = @import("../gateway/adapter_registry.zig");
+const stream_provider = @import("../agent/stream_provider.zig");
 const host = @import("../hosts/host.zig");
-const login_flow = @import("login_flow.zig");
 const connection_registry = @import("../gateway/connection_registry.zig");
 const oauth_transport = @import("oauth_transport.zig");
 const secret = @import("secret.zig");
@@ -96,27 +98,6 @@ pub const FailureSnapshot = struct {
         try writer.writeByte('}');
     }
 };
-
-/// Returns an owned token when the selected fx-login credential can be
-/// refreshed. The caller must release it with `secret.zeroAndFree`.
-pub fn refreshFxLoginToken(
-    transport: oauth_transport.Provider,
-    alloc: Allocator,
-    source: credentials.Source,
-    mode: CredentialRefreshMode,
-) !?[]u8 {
-    if (source != .fx_login) return null;
-
-    var credential = switch (mode) {
-        .if_needed => (try credentials.loadFxLoginCredential(alloc, transport)) orelse return null,
-        .force => (try credentials.refreshFxLoginCredential(alloc, transport)) orelse return null,
-    };
-    defer credential.deinit(alloc);
-
-    const token = credential.token;
-    credential.token = &.{};
-    return token;
-}
 
 pub const AcquisitionAction = enum {
     login,
@@ -334,10 +315,10 @@ pub const PickerView = struct {
     include_skip: bool,
     stage: PickerStage = .root,
     fx_login_session_available: bool = false,
-    teams: []const login_flow.Team = &.{},
+    teams: []const adapter_auth.Team = &.{},
     current_team: ?[]const u8 = null,
     team_query: []const u8 = &.{},
-    sign_in: login_flow.SignInSnapshot = .{},
+    sign_in: adapter_auth.SignInSnapshot = .{},
     api_key_mask_count: usize = 0,
 
     pub fn activeSourceLabel(self: PickerView) []const u8 {
@@ -448,7 +429,7 @@ pub const PickerView = struct {
     }
 };
 
-fn teamMatchesQuery(team: login_flow.Team, query: []const u8) bool {
+fn teamMatchesQuery(team: adapter_auth.Team, query: []const u8) bool {
     return text_utils.containsIgnoreCase(team.name, query) or
         text_utils.containsIgnoreCase(team.slug, query);
 }
@@ -477,6 +458,7 @@ pub const StatusSnapshot = struct {
     team: ?[]const u8 = null,
     owned_team: ?[]u8 = null,
     stored_key_status: credentials.StoredKeyReadStatus = .not_attempted,
+    failure: ?adapter_auth.FailureCategory = null,
     /// The active credential is past its refresh deadline. Distinct from `refreshable`,
     /// which answers whether this source type can refresh at all.
     expired: bool = false,
@@ -487,6 +469,12 @@ pub const StatusSnapshot = struct {
     }
 
     pub fn activeSourceLabel(self: StatusSnapshot) []const u8 {
+        if (self.active_source == null) {
+            if (self.failure) |failure| return switch (failure) {
+                .configuration => "invalid_configuration",
+                else => @tagName(failure),
+            };
+        }
         return sourceLabelOrMissing(self.active_source);
     }
 
@@ -496,7 +484,7 @@ pub const StatusSnapshot = struct {
     }
 
     pub fn missingHelp(self: StatusSnapshot, surface: MissingHelpSurface) ?[]const u8 {
-        if (self.active_source != null) return null;
+        if (self.active_source != null or self.failure != null) return null;
         if (self.stored_key_status == .unavailable) return credentials.unreadable_store_message;
         return switch (surface) {
             .cli => credentials.missing_credential_message,
@@ -557,6 +545,27 @@ pub fn loadStatusSnapshot(
     return .{ .stored_key_status = resolution.stored_key_status };
 }
 
+pub fn takeAdapterStatus(status: *adapter_auth.Status) !StatusSnapshot {
+    const active_source = if (status.source) |source|
+        types.parseCredentialSource(source.id) orelse return error.InvalidCredentialReference
+    else
+        null;
+    const owned_team = status.team;
+    const result = StatusSnapshot{
+        .active_source = active_source,
+        .team = owned_team,
+        .owned_team = owned_team,
+        .stored_key_status = switch (status.store_status) {
+            .not_attempted => .not_attempted,
+            .not_found => .not_found,
+            .unavailable => .unavailable,
+        },
+        .expired = status.expired,
+    };
+    status.team = null;
+    return result;
+}
+
 pub const View = struct {
     active_source: ?credentials.Source,
     available_inactive_sources: SourceSet,
@@ -587,6 +596,7 @@ pub const Runtime = struct {
     api_key_validator: api_key_validator.Provider = api_key_validator.unavailable_provider,
     oauth_transport: oauth_transport.Provider = oauth_transport.unavailable_provider,
     secret_store: host.SecretStore = host.unavailable_secret_store,
+    adapter_registry: adapter_registry.AdapterRegistry = .{ .adapters = &.{} },
     connections: ?connection_registry.Runtime = null,
     selected_credential: ?credentials.Credential = null,
     credential_connection_id: [connection_registry.max_connection_id_bytes]u8 = undefined,
@@ -600,9 +610,10 @@ pub const Runtime = struct {
     picker_include_skip: bool = false,
     picker_stage: PickerStage = .root,
     fx_login_session_available: bool = false,
-    team_selection: ?login_flow.TeamSelection = null,
+    team_selection: ?adapter_auth.TeamSelection = null,
     team_query: std.ArrayList(u8) = .empty,
-    sign_in_flow: login_flow.SignInRuntime = .{},
+    sign_in_session: adapter_auth.SignInSession = adapter_auth.unavailable_sign_in_session,
+    sign_in_session_active: bool = false,
     sign_in_returns_to_root: bool = false,
     api_key_input: std.ArrayList(u8) = .empty,
     api_key_returns_to_root: bool = false,
@@ -612,17 +623,19 @@ pub const Runtime = struct {
         validator: api_key_validator.Provider,
         transport: oauth_transport.Provider,
         secret_store: host.SecretStore,
+        registry: adapter_registry.AdapterRegistry,
     ) Self {
         return .{
             .api_key_validator = validator,
             .oauth_transport = transport,
             .secret_store = secret_store,
+            .adapter_registry = registry,
         };
     }
 
     pub fn deinit(self: *Self, alloc: Allocator) void {
         self.api_key_save.deinit(alloc);
-        self.sign_in_flow.deinit(alloc);
+        self.clearSignInSession(alloc);
         self.exitApiKeyStage(alloc, .runtime_deinit);
         self.clearTeamSelection(alloc);
         self.team_query.deinit(alloc);
@@ -652,6 +665,10 @@ pub const Runtime = struct {
         return connections.selectedProfile();
     }
 
+    fn authHost(self: *const Self) adapter_auth.AuthHost {
+        return .{ .secret_store = self.secret_store };
+    }
+
     pub fn connectionProfile(self: *const Self, id: []const u8) !connection_registry.Profile {
         const connections = if (self.connections) |*value| value else return error.ConnectionRegistryUnavailable;
         return connections.profile(id);
@@ -664,18 +681,55 @@ pub const Runtime = struct {
         alloc: Allocator,
         reference: []const u8,
     ) !credentials.Credential {
-        const preferred = if (std.mem.eql(u8, reference, "automatic"))
-            null
-        else
-            types.parseCredentialSource(reference) orelse return error.InvalidCredentialReference;
-        const resolution = try credentials.resolvePreferring(
+        var profile = try self.selectedConnectionProfile();
+        profile.credential_ref = @constCast(reference);
+        return self.resolveProfileCredential(alloc, profile, .if_needed, null);
+    }
+
+    pub fn resolveProfileCredential(
+        self: *const Self,
+        alloc: Allocator,
+        profile: connection_registry.Profile,
+        mode: adapter_auth.RefreshMode,
+        current_source_id: ?[]const u8,
+    ) !credentials.Credential {
+        return self.resolveProfileCredentialWithSourceResolution(
             alloc,
-            self.oauth_transport,
-            self.secret_store,
-            .refresh_if_needed,
-            preferred,
+            profile,
+            mode,
+            current_source_id,
+            .allow_fallback,
         );
-        return resolution.credential orelse error.MissingCredential;
+    }
+
+    fn resolveProfileCredentialWithSourceResolution(
+        self: *const Self,
+        alloc: Allocator,
+        profile: connection_registry.Profile,
+        mode: adapter_auth.RefreshMode,
+        current_source_id: ?[]const u8,
+        source_resolution: adapter_auth.SourceResolution,
+    ) !credentials.Credential {
+        const auth = try self.adapter_registry.resolveAuthForProfile(profile);
+        const acquisition = try auth.acquire(alloc, .{
+            .profile = profile,
+            .host = self.authHost(),
+            .mode = mode,
+            .source_resolution = source_resolution,
+            .current_source_id = current_source_id,
+        });
+        var normalized = switch (acquisition) {
+            .acquired => |value| value,
+            .missing => return error.MissingCredential,
+            .failed => |failure| return switch (failure.category) {
+                .configuration => error.InvalidCredentialReference,
+                .cancelled => error.Cancelled,
+                else => error.CredentialAcquisitionFailed,
+            },
+            .cancelled => return error.Cancelled,
+        };
+        defer normalized.deinit(alloc);
+        return takeAdapterCredential(&normalized) orelse error.InvalidCredentialReference;
     }
 
     pub fn addConnection(self: *Self, input: connection_registry.ProfileInput) !void {
@@ -714,7 +768,10 @@ pub const Runtime = struct {
     }
 
     pub fn recordSelectedAuthenticationFailure(self: *Self, alloc: Allocator) void {
-        self.clearCredential(alloc);
+        const profile = self.selectedConnectionProfile() catch return;
+        const auth = self.adapter_registry.resolveAuthForProfile(profile) catch return;
+        const invalidation = auth.invalidate(profile, .{ .category = .denied }) catch return;
+        if (invalidation.drop_credential) self.clearCredential(alloc);
         const connections = if (self.connections) |*value| value else return;
         connections.markSelectedDisconnected(.authentication_failed);
     }
@@ -785,12 +842,26 @@ pub const Runtime = struct {
     }
 
     fn statusSnapshotAt(self: *const Self, now_ms: i64) StatusSnapshot {
-        if (!self.credentialMatchesSelectedConnection()) return .{};
-        const credential = self.selected_credential orelse return .{};
+        if (!self.credentialMatchesSelectedConnection()) return self.disconnectedStatusSnapshot();
+        const credential = self.selected_credential orelse return self.disconnectedStatusSnapshot();
         return .{
             .active_source = credential.source,
             .team = displayTeam(credential),
             .expired = credential.needsRefreshAt(now_ms),
+        };
+    }
+
+    fn disconnectedStatusSnapshot(self: *const Self) StatusSnapshot {
+        const failure: ?adapter_auth.FailureCategory = if (self.connections) |*connections|
+            switch (connections.selectedProfile().auth) {
+                .disconnected => |reason| if (reason == .invalid_credential_reference) .configuration else null,
+                .connected => null,
+            }
+        else
+            null;
+        return .{
+            .stored_key_status = self.stored_key_status,
+            .failure = failure,
         };
     }
 
@@ -823,6 +894,7 @@ pub const Runtime = struct {
     }
 
     pub fn refreshSourceInventory(self: *Self, alloc: Allocator) !void {
+        _ = try self.adapter_registry.resolveAuthForProfile(try self.selectedConnectionProfile());
         try self.refreshSourceInventoryWithProbe(alloc, self, probeCredentialSource);
     }
 
@@ -868,10 +940,10 @@ pub const Runtime = struct {
             .include_skip = self.picker_include_skip,
             .stage = self.picker_stage,
             .fx_login_session_available = self.fx_login_session_available,
-            .teams = if (self.team_selection) |*selection| selection.teams.items else &.{},
-            .current_team = if (self.team_selection) |*selection| selection.currentTeam() else null,
+            .teams = if (self.team_selection) |*selection| selection.teams else &.{},
+            .current_team = if (self.team_selection) |*selection| selection.current_team else null,
             .team_query = self.team_query.items,
-            .sign_in = self.sign_in_flow.snapshot(),
+            .sign_in = if (self.sign_in_session_active) self.sign_in_session.snapshot() else .{},
             .api_key_mask_count = @min(self.api_key_input.items.len, max_api_key_mask_glyphs),
         };
     }
@@ -892,7 +964,7 @@ pub const Runtime = struct {
         return true;
     }
 
-    pub fn openTeamPicker(self: *Self, alloc: Allocator, selection: *login_flow.TeamSelection) void {
+    pub fn openTeamPicker(self: *Self, alloc: Allocator, selection: *adapter_auth.TeamSelection) void {
         self.exitSignInStage(alloc);
         self.exitApiKeyStage(alloc, .screen_replacement);
         self.clearTeamSelection(alloc);
@@ -967,7 +1039,18 @@ pub const Runtime = struct {
 
     fn openSignInPickerWithParent(self: *Self, alloc: Allocator, returns_to_root: bool) !bool {
         self.exitSignInStage(alloc);
-        if (!try self.sign_in_flow.start(alloc, self.oauth_transport)) return false;
+        const profile = try self.selectedConnectionProfile();
+        const auth = try self.adapter_registry.resolveAuthForProfile(profile);
+        const outcome = try auth.startSignIn(alloc, profile, self.authHost());
+        switch (outcome) {
+            .started => |session| {
+                self.sign_in_session = session;
+                self.sign_in_session_active = true;
+            },
+            .busy => return false,
+            .cancelled => return error.Cancelled,
+            .failed => |failure| return errorForAuthFailure(failure),
+        }
         self.exitApiKeyStage(alloc, .screen_replacement);
         self.clearTeamSelection(alloc);
         self.picker_active = true;
@@ -983,11 +1066,12 @@ pub const Runtime = struct {
 
     pub fn signInBrowserUrlAlloc(self: *Self, alloc: Allocator) !?[]u8 {
         if (!self.signInEntryActive()) return null;
-        return self.sign_in_flow.browserUrlAlloc(alloc);
+        return self.sign_in_session.browserUrlAlloc(alloc);
     }
 
-    pub fn pollSignInTransition(self: *Self, alloc: Allocator) login_flow.SignInTransition {
-        return self.sign_in_flow.pollTransition(alloc);
+    pub fn pollSignInTransition(self: *Self, alloc: Allocator) !adapter_auth.SignInTransition {
+        if (!self.sign_in_session_active) return .none;
+        return self.sign_in_session.poll(alloc);
     }
 
     pub fn pulseSignIn(self: *Self, alloc: Allocator) void {
@@ -1075,7 +1159,7 @@ pub const Runtime = struct {
 
         if (stage == .sign_in) {
             const returns_to_root = self.sign_in_returns_to_root;
-            _ = self.sign_in_flow.cancel(alloc);
+            self.clearSignInSession(alloc);
             self.sign_in_returns_to_root = false;
             if (!returns_to_root) {
                 self.picker_active = false;
@@ -1157,11 +1241,11 @@ pub const Runtime = struct {
 
     fn exitSignInStage(self: *Self, alloc: Allocator) void {
         if (self.picker_stage != .sign_in) return;
-        _ = self.sign_in_flow.cancel(alloc);
+        self.clearSignInSession(alloc);
         self.sign_in_returns_to_root = false;
     }
 
-    pub fn teamSelection(self: *Self) ?*login_flow.TeamSelection {
+    pub fn teamSelection(self: *Self) ?*adapter_auth.TeamSelection {
         if (!self.picker_active or self.picker_stage != .change_team) return null;
         return if (self.team_selection) |*selection| selection else null;
     }
@@ -1225,7 +1309,7 @@ pub const Runtime = struct {
         self.credential_connection_id_len = 0;
     }
 
-    pub fn adoptSelectedTeam(self: *Self, alloc: Allocator, selected_team: *login_flow.SelectedTeam) bool {
+    pub fn adoptSelectedTeam(self: *Self, alloc: Allocator, selected_team: *adapter_auth.SelectedTeam) bool {
         const credential = if (self.selected_credential) |*selected| selected else return false;
         if (credential.source != .fx_login) return false;
 
@@ -1254,26 +1338,95 @@ pub const Runtime = struct {
     }
 
     pub fn selectSource(self: *Self, alloc: Allocator, source: credentials.Source) !?bool {
-        return self.selectSourceWithLoader(alloc, source, self, loadRuntimeCredentialSource);
+        var profile = try self.selectedConnectionProfile();
+        profile.credential_ref = @constCast(@tagName(source));
+        var credential = self.resolveProfileCredentialWithSourceResolution(
+            alloc,
+            profile,
+            .if_needed,
+            @tagName(source),
+            .exact,
+        ) catch |err| switch (err) {
+            error.MissingCredential => return null,
+            else => return err,
+        };
+        defer credential.deinit(alloc);
+        if (credential.source != source) return error.CredentialSourceMismatch;
+        return self.adoptCredential(alloc, &credential);
     }
 
     pub fn refreshFxLoginIfNeeded(self: *Self, alloc: Allocator) !bool {
         const source = self.credentialSource() orelse return false;
         if (source != .fx_login) return false;
-
-        const loaded = (try credentials.loadFxLoginCredential(alloc, self.oauth_transport)) orelse {
-            if (self.credentialNeedsRefresh()) return error.CredentialRefreshUnavailable;
-            return false;
+        const profile = try self.selectedConnectionProfile();
+        var credential = self.resolveProfileCredentialWithSourceResolution(
+            alloc,
+            profile,
+            .if_needed,
+            @tagName(source),
+            .exact,
+        ) catch |err| switch (err) {
+            error.MissingCredential => {
+                if (self.credentialNeedsRefresh()) return error.CredentialRefreshUnavailable;
+                return false;
+            },
+            else => return err,
         };
-        var credential = loaded;
         defer credential.deinit(alloc);
         return self.adoptCredential(alloc, &credential);
     }
 
-    /// Drops the current selection and re-runs precedence after the user clears
-    /// a remembered credential source.
+    pub fn refreshSelectedCredential(self: *Self, alloc: Allocator, mode: adapter_auth.RefreshMode) !?[]u8 {
+        const source = self.credentialSource() orelse return null;
+        const profile = try self.selectedConnectionProfile();
+        var credential = self.resolveProfileCredentialWithSourceResolution(
+            alloc,
+            profile,
+            mode,
+            @tagName(source),
+            .exact,
+        ) catch |err| switch (err) {
+            error.MissingCredential => return null,
+            else => return err,
+        };
+        defer credential.deinit(alloc);
+        const token = credential.token;
+        credential.token = &.{};
+        return token;
+    }
+
+    pub fn logoutSelected(self: *Self, alloc: Allocator) !adapter_auth.LogoutOutcome {
+        const profile = try self.selectedConnectionProfile();
+        const auth = try self.adapter_registry.resolveAuthForProfile(profile);
+        return auth.logout(alloc, profile, self.authHost());
+    }
+
+    pub fn loadSelectedTeams(self: *Self, alloc: Allocator) !adapter_auth.TeamsOutcome {
+        const profile = try self.selectedConnectionProfile();
+        const auth = try self.adapter_registry.resolveAuthForProfile(profile);
+        return auth.loadTeams(alloc, profile, self.authHost());
+    }
+
+    /// Drops the current selection and re-runs precedence. Distinct from the
+    /// logout reconcile, which only acts when a login was active: clearing a
+    /// remembered choice can leave any source selected, and leaving it in place
+    /// would keep the session on the source the user just un-remembered.
     pub fn reselectByPrecedence(self: *Self, alloc: Allocator) !bool {
-        return self.reselectByPrecedenceWithDeps(alloc, self, probeCredentialSource, loadRuntimeCredentialSource);
+        const previous = self.credentialSource();
+        self.clearCredential(alloc);
+        var profile = try self.selectedConnectionProfile();
+        profile.credential_ref = @constCast("automatic");
+        var credential = self.resolveProfileCredential(alloc, profile, .if_needed, null) catch |err| switch (err) {
+            error.MissingCredential => {
+                self.onboarding_skipped = false;
+                return previous != null;
+            },
+            else => return err,
+        };
+        defer credential.deinit(alloc);
+        _ = self.adoptCredential(alloc, &credential);
+        try self.refreshSourceInventory(alloc);
+        return self.credentialSource() != previous;
     }
 
     fn reselectByPrecedenceWithDeps(
@@ -1299,12 +1452,27 @@ pub const Runtime = struct {
     }
 
     pub fn reconcileAfterFxLoginLogout(self: *Self, alloc: Allocator) !bool {
-        return self.reconcileAfterFxLoginLogoutWithDeps(
-            alloc,
-            self,
-            probeCredentialSource,
-            loadRuntimeCredentialSource,
-        );
+        const login_was_active = self.credentialSource() == .fx_login;
+        if (login_was_active) self.clearCredential(alloc);
+        if (!login_was_active) {
+            try self.refreshSourceInventory(alloc);
+            return false;
+        }
+
+        var profile = try self.selectedConnectionProfile();
+        profile.credential_ref = @constCast("automatic");
+        var credential = self.resolveProfileCredential(alloc, profile, .if_needed, null) catch |err| switch (err) {
+            error.MissingCredential => {
+                self.source_inventory = .empty;
+                self.onboarding_skipped = false;
+                return true;
+            },
+            else => return err,
+        };
+        defer credential.deinit(alloc);
+        _ = self.adoptCredential(alloc, &credential);
+        try self.refreshSourceInventory(alloc);
+        return true;
     }
 
     fn reconcileAfterFxLoginLogoutWithDeps(
@@ -1344,6 +1512,13 @@ pub const Runtime = struct {
         if (self.team_selection) |*selection| selection.deinit(alloc);
         self.team_selection = null;
         self.team_query.clearRetainingCapacity();
+    }
+
+    fn clearSignInSession(self: *Self, alloc: Allocator) void {
+        if (!self.sign_in_session_active) return;
+        _ = self.sign_in_session.cancel(alloc);
+        self.sign_in_session.deinit(alloc);
+        self.sign_in_session_active = false;
     }
 
     fn resetTeamPickerSelection(self: *Self) void {
@@ -1429,6 +1604,36 @@ fn optionalBytesEqual(a: ?[]const u8, b: ?[]const u8) bool {
     if (a == null and b == null) return true;
     if (a == null or b == null) return false;
     return std.mem.eql(u8, a.?, b.?);
+}
+
+pub fn takeAdapterCredential(value: *adapter_auth.Credential) ?credentials.Credential {
+    const source = types.parseCredentialSource(value.source.id) orelse return null;
+    const result = credentials.Credential{
+        .token = value.secret_bytes,
+        .source = source,
+        .team_id = value.tenant_id,
+        .team_slug = value.tenant_slug,
+        .refresh_after_ms = value.refresh_after_ms,
+    };
+    value.secret_bytes = &.{};
+    value.tenant_id = null;
+    value.tenant_slug = null;
+    return result;
+}
+
+fn errorForAuthFailure(failure: adapter_auth.Failure) anyerror {
+    return switch (failure.category) {
+        .configuration => error.AuthConfiguration,
+        .denied => error.AuthDenied,
+        .expired => error.AuthExpired,
+        .missing_session => error.AuthSessionMissing,
+        .no_teams => error.AuthTeamsMissing,
+        .session_changed => error.AuthSessionChanged,
+        .invalid_selection => error.AuthSelectionInvalid,
+        .persistence => error.AuthPersistence,
+        .cancelled => error.Cancelled,
+        .unavailable => error.AuthUnavailable,
+    };
 }
 
 fn makeTestCredential(
@@ -1542,20 +1747,60 @@ fn enterTestApiKey(runtime: *Runtime, alloc: Allocator, value: []const u8) !void
     for (value) |byte| try std.testing.expect(try runtime.appendApiKeyByte(alloc, byte));
 }
 
-fn appendTestTeam(
-    selection: *login_flow.TeamSelection,
+const TestTeamSelectionState = struct {
+    teams: []adapter_auth.Team,
+
+    fn select(raw: ?*anyopaque, alloc: Allocator, index: usize) Allocator.Error!adapter_auth.SelectOutcome {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        const team = self.teams[index];
+        const id = try alloc.dupe(u8, team.id);
+        errdefer alloc.free(id);
+        return .{ .selected = .{ .id = id, .slug = try alloc.dupe(u8, team.slug) } };
+    }
+
+    fn deinit(raw: ?*anyopaque, alloc: Allocator) void {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        for (self.teams) |team| {
+            alloc.free(@constCast(team.id));
+            alloc.free(@constCast(team.slug));
+            alloc.free(@constCast(team.name));
+        }
+        alloc.free(self.teams);
+        alloc.destroy(self);
+    }
+};
+
+fn makeTestTeamSelection(
     alloc: Allocator,
-    id_value: []const u8,
-    slug_value: []const u8,
-    name_value: []const u8,
-) !void {
-    const id = try alloc.dupe(u8, id_value);
-    errdefer alloc.free(id);
-    const slug = try alloc.dupe(u8, slug_value);
-    errdefer alloc.free(slug);
-    const name = try alloc.dupe(u8, name_value);
-    errdefer alloc.free(name);
-    try selection.teams.append(alloc, .{ .id = id, .slug = slug, .name = name });
+    inputs: []const adapter_auth.Team,
+    current_team: ?[]const u8,
+) !adapter_auth.TeamSelection {
+    const state = try alloc.create(TestTeamSelectionState);
+    errdefer alloc.destroy(state);
+    state.teams = try alloc.alloc(adapter_auth.Team, inputs.len);
+    errdefer alloc.free(state.teams);
+    var initialized: usize = 0;
+    errdefer for (state.teams[0..initialized]) |team| {
+        alloc.free(@constCast(team.id));
+        alloc.free(@constCast(team.slug));
+        alloc.free(@constCast(team.name));
+    };
+    for (inputs, 0..) |input, index| {
+        const id = try alloc.dupe(u8, input.id);
+        errdefer alloc.free(id);
+        const slug = try alloc.dupe(u8, input.slug);
+        errdefer alloc.free(slug);
+        const name = try alloc.dupe(u8, input.name);
+        state.teams[index] = .{ .id = id, .slug = slug, .name = name };
+        initialized += 1;
+    }
+    return .{
+        .context = state,
+        .teams = state.teams,
+        .current_team = current_team,
+        .select_fn = TestTeamSelectionState.select,
+        .deinit_fn = TestTeamSelectionState.deinit,
+    };
 }
 
 fn expectApiKeyAllocationCleared(
@@ -1566,17 +1811,6 @@ fn expectApiKeyAllocationCleared(
     try std.testing.expectEqual(@as(usize, 0), runtime.api_key_input.items.len);
     try std.testing.expectEqual(@as(usize, 0), runtime.api_key_input.capacity);
     try std.testing.expect(std.mem.indexOf(u8, backing, sentinel) == null);
-}
-
-test "auth runtime token refresher ignores non-refreshable credential sources" {
-    for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .stored_key }) |source| {
-        try std.testing.expect((try refreshFxLoginToken(
-            oauth_transport.unavailable_provider,
-            std.testing.allocator,
-            source,
-            .force,
-        )) == null);
-    }
 }
 
 test "auth failure snapshot names every selected source without exposing styling" {
@@ -1795,6 +2029,19 @@ test "auth status snapshot preserves display team and surface-specific missing h
     const selected = runtime.statusSnapshot();
     try std.testing.expectEqualStrings("vercel-labs", selected.team.?);
     try std.testing.expect(selected.missingHelp(.cli) == null);
+}
+
+test "auth status keeps an invalid credential reference distinct from missing" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    var connections = try initTestConnectionRegistry(alloc);
+    connections.markSelectedDisconnected(.invalid_credential_reference);
+    runtime.adoptConnections(alloc, &connections);
+
+    const status = runtime.statusSnapshot();
+    try std.testing.expectEqualStrings("invalid_configuration", status.activeSourceLabel());
+    try std.testing.expect(status.missingHelp(.cli) == null);
 }
 
 test "auth status snapshot distinguishes an absent store from an unreadable one" {
@@ -2200,9 +2447,12 @@ test "change team stage owns fetched rows and releases them when popped" {
     defer runtime.deinit(alloc);
     runtime.openPicker(alloc);
 
-    var selection: login_flow.TeamSelection = .{};
+    var selection = try makeTestTeamSelection(alloc, &.{.{
+        .id = "team_123",
+        .slug = "vercel-labs",
+        .name = "Vercel Labs",
+    }}, null);
     defer selection.deinit(alloc);
-    try appendTestTeam(&selection, alloc, "team_123", "vercel-labs", "Vercel Labs");
 
     runtime.openTeamPicker(alloc, &selection);
     const team_view = runtime.pickerView();
@@ -2221,18 +2471,12 @@ test "change team search filters by name and slug without losing original indexe
     defer runtime.deinit(alloc);
     runtime.openPicker(alloc);
 
-    var selection: login_flow.TeamSelection = .{};
+    var selection = try makeTestTeamSelection(alloc, &.{
+        .{ .id = "team_456", .slug = "other-team", .name = "Other Team" },
+        .{ .id = "team_123", .slug = "vercel-internal-playground", .name = "Internal Playground" },
+        .{ .id = "team_789", .slug = "zero-conf", .name = "Zero Conf" },
+    }, null);
     defer selection.deinit(alloc);
-    try appendTestTeam(&selection, alloc, "team_456", "other-team", "Other Team");
-    try appendTestTeam(
-        &selection,
-        alloc,
-        "team_123",
-        "example-internal-team",
-        "Example Internal Team",
-    );
-    try appendTestTeam(&selection, alloc, "team_789", "zero-conf", "Zero Conf");
-
     runtime.openTeamPicker(alloc, &selection);
     for ("EXAMPLE") |byte| try std.testing.expect(try runtime.appendTeamQueryByte(alloc, byte));
 
@@ -2253,13 +2497,10 @@ test "change team search filters by name and slug without losing original indexe
 }
 
 test "change team view marks the session team as current" {
-    var team_id = [_]u8{ 't', 'e', 'a', 'm', '_', '1' };
-    var team_slug = [_]u8{ 'v', 'e', 'r', 'c', 'e', 'l' };
-    var team_name = [_]u8{ 'V', 'e', 'r', 'c', 'e', 'l' };
-    const teams = [_]login_flow.Team{.{
-        .id = &team_id,
-        .slug = &team_slug,
-        .name = &team_name,
+    const teams = [_]adapter_auth.Team{.{
+        .id = "team_1",
+        .slug = "vercel",
+        .name = "Vercel",
     }};
     const view = PickerView{
         .active = true,
@@ -2328,6 +2569,7 @@ test "auth runtime saves and reloads through its injected secret store" {
         fixture.validator(),
         oauth_transport.unavailable_provider,
         fixture.secretStore(),
+        .{ .adapters = &.{} },
     );
     defer runtime.deinit(alloc);
 
@@ -2647,6 +2889,58 @@ fn initTestConnectionRegistry(alloc: Allocator) !connection_registry.Runtime {
     );
 }
 
+test "auth runtime preserves every adapter acquisition outcome" {
+    const AcquireProbe = struct {
+        outcome: enum { acquired, missing, configuration, failed, cancelled } = .acquired,
+        calls: usize = 0,
+
+        fn acquire(raw: *const anyopaque, alloc: Allocator, _: adapter_auth.Request) Allocator.Error!adapter_auth.Acquisition {
+            const self: *@This() = @ptrCast(@alignCast(@constCast(raw)));
+            self.calls += 1;
+            return switch (self.outcome) {
+                .acquired => .{ .acquired = .{
+                    .secret_bytes = try alloc.dupe(u8, "adapter-secret"),
+                    .source = .{ .id = "ai_gateway_api_key", .label = "test key", .refreshable = false },
+                    .catalog_access = .authenticated,
+                } },
+                .missing => .{ .missing = .unavailable },
+                .configuration => .{ .failed = .{ .category = .configuration } },
+                .failed => .{ .failed = .{ .category = .unavailable } },
+                .cancelled => .cancelled,
+            };
+        }
+    };
+    const alloc = std.testing.allocator;
+    var probe: AcquireProbe = .{};
+    const auth = adapter_auth.Provider{
+        .kind = "vercel_ai_gateway",
+        .context = &probe,
+        .acquire_fn = AcquireProbe.acquire,
+    };
+    const adapters = [_]stream_provider.ProviderAdapter{.{
+        .kind = "vercel_ai_gateway",
+        .auth = auth,
+        .stream_fn = stream_provider.unavailable_adapter.stream_fn,
+    }};
+    var runtime: Runtime = .{ .adapter_registry = try adapter_registry.AdapterRegistry.init(&adapters) };
+    defer runtime.deinit(alloc);
+    var connections = try initTestConnectionRegistry(alloc);
+    runtime.adoptConnections(alloc, &connections);
+    const profile = try runtime.selectedConnectionProfile();
+
+    var credential = try runtime.resolveProfileCredential(alloc, profile, .if_needed, null);
+    credential.deinit(alloc);
+    probe.outcome = .missing;
+    try std.testing.expectError(error.MissingCredential, runtime.resolveProfileCredential(alloc, profile, .if_needed, null));
+    probe.outcome = .configuration;
+    try std.testing.expectError(error.InvalidCredentialReference, runtime.resolveProfileCredential(alloc, profile, .if_needed, null));
+    probe.outcome = .failed;
+    try std.testing.expectError(error.CredentialAcquisitionFailed, runtime.resolveProfileCredential(alloc, profile, .force, "fx_login"));
+    probe.outcome = .cancelled;
+    try std.testing.expectError(error.Cancelled, runtime.resolveProfileCredential(alloc, profile, .if_needed, null));
+    try std.testing.expectEqual(@as(usize, 5), probe.calls);
+}
+
 test "credentials are bound to the selected connection and invalid auth disconnects it" {
     const alloc = std.testing.allocator;
     var connections = try connection_registry.Runtime.init(
@@ -2671,6 +2965,21 @@ test "credentials are bound to the selected connection and invalid auth disconne
 
     var runtime: Runtime = .{};
     defer runtime.deinit(alloc);
+    const Invalidating = struct {
+        fn invalidate(_: *const anyopaque, _: connection_registry.Profile, _: adapter_auth.Failure) adapter_auth.Invalidation {
+            return .{ .drop_credential = true };
+        }
+    };
+    const auth = adapter_auth.Provider{
+        .kind = "vercel_ai_gateway",
+        .invalidate_fn = Invalidating.invalidate,
+    };
+    const adapters = [_]stream_provider.ProviderAdapter{.{
+        .kind = "vercel_ai_gateway",
+        .auth = auth,
+        .stream_fn = stream_provider.unavailable_adapter.stream_fn,
+    }};
+    runtime.adapter_registry = try adapter_registry.AdapterRegistry.init(&adapters);
     runtime.adoptConnections(alloc, &connections);
     var credential = credentials.Credential{
         .token = try alloc.dupe(u8, "vercel-secret"),

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -674,6 +674,18 @@ pub const Runtime = struct {
         return connections.profile(id);
     }
 
+    /// Returns the admitted connection with this session's acquired source.
+    /// A failed preference write must not make route resolution fall back.
+    pub fn connectionProfileForRoute(self: *const Self, id: []const u8) !connection_registry.Profile {
+        var profile = try self.connectionProfile(id);
+        if (!self.credentialMatchesSelectedConnection()) return profile;
+        const selected = try self.selectedConnectionProfile();
+        if (!std.mem.eql(u8, profile.id, selected.id)) return profile;
+        const credential = self.selected_credential orelse return profile;
+        profile.credential_ref = @constCast(@tagName(credential.source));
+        return profile;
+    }
+
     /// Resolves one owned credential from an admitted reference without
     /// consulting the currently selected connection.
     pub fn resolveCredentialReference(
@@ -2939,6 +2951,38 @@ test "auth runtime preserves every adapter acquisition outcome" {
     probe.outcome = .cancelled;
     try std.testing.expectError(error.Cancelled, runtime.resolveProfileCredential(alloc, profile, .if_needed, null));
     try std.testing.expectEqual(@as(usize, 5), probe.calls);
+}
+
+test "route profile preserves the acquired source when preference persistence fails" {
+    const alloc = std.testing.allocator;
+    var connections = try initTestConnectionRegistry(alloc);
+    try connections.add(.{
+        .id = "peer",
+        .display_name = "Peer",
+        .adapter_id = "test_peer",
+        .credential_ref = "peer_key",
+        .remembered_model = "model/peer",
+    });
+
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    runtime.adoptConnections(alloc, &connections);
+    var credential = try makeTestCredential(alloc, "login-token", .fx_login, null, null);
+    defer credential.deinit(alloc);
+    _ = runtime.adoptCredential(alloc, &credential);
+
+    var persistence: ConnectionSelectionPersistence = .{};
+    runtime.connections.?.persistence = .{
+        .context = &persistence,
+        .write_fn = ConnectionSelectionPersistence.write,
+    };
+    try std.testing.expectError(
+        error.ConnectionWriteFailed,
+        runtime.rememberSelectedCredentialReference("fx_login"),
+    );
+    try std.testing.expectEqualStrings("automatic", (try runtime.selectedConnectionProfile()).credential_ref);
+    try std.testing.expectEqualStrings("fx_login", (try runtime.connectionProfileForRoute("vercel")).credential_ref);
+    try std.testing.expectEqualStrings("peer_key", (try runtime.connectionProfileForRoute("peer")).credential_ref);
 }
 
 test "credentials are bound to the selected connection and invalid auth disconnects it" {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -2506,15 +2506,15 @@ test "change team search filters by name and slug without losing original indexe
     }, null);
     defer selection.deinit(alloc);
     runtime.openTeamPicker(alloc, &selection);
-    for ("EXAMPLE") |byte| try std.testing.expect(try runtime.appendTeamQueryByte(alloc, byte));
+    for ("PLAY") |byte| try std.testing.expect(try runtime.appendTeamQueryByte(alloc, byte));
 
     const name_match = runtime.pickerView();
-    try std.testing.expectEqualStrings("EXAMPLE", name_match.team_query);
+    try std.testing.expectEqualStrings("PLAY", name_match.team_query);
     try std.testing.expectEqual(@as(usize, 1), name_match.choiceCount());
     try std.testing.expect((Choice{ .team = 1 }).eql(name_match.choiceAt(0).?));
-    try std.testing.expectEqualStrings("Example Internal Team", name_match.choiceLabel(name_match.choiceAt(0).?));
+    try std.testing.expectEqualStrings("Internal Playground", name_match.choiceLabel(name_match.choiceAt(0).?));
 
-    for (0..7) |_| try std.testing.expect(runtime.deleteTeamQueryByte());
+    for (0..4) |_| try std.testing.expect(runtime.deleteTeamQueryByte());
     for ("zero-conf") |byte| try std.testing.expect(try runtime.appendTeamQueryByte(alloc, byte));
     const slug_match = runtime.pickerView();
     try std.testing.expectEqual(@as(usize, 1), slug_match.choiceCount());

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -2501,7 +2501,7 @@ test "change team search filters by name and slug without losing original indexe
 
     var selection = try makeTestTeamSelection(alloc, &.{
         .{ .id = "team_456", .slug = "other-team", .name = "Other Team" },
-        .{ .id = "team_123", .slug = "vercel-internal-playground", .name = "Internal Playground" },
+        .{ .id = "team_123", .slug = "example-playground", .name = "Example Playground" },
         .{ .id = "team_789", .slug = "zero-conf", .name = "Zero Conf" },
     }, null);
     defer selection.deinit(alloc);
@@ -2512,7 +2512,7 @@ test "change team search filters by name and slug without losing original indexe
     try std.testing.expectEqualStrings("PLAY", name_match.team_query);
     try std.testing.expectEqual(@as(usize, 1), name_match.choiceCount());
     try std.testing.expect((Choice{ .team = 1 }).eql(name_match.choiceAt(0).?));
-    try std.testing.expectEqualStrings("Internal Playground", name_match.choiceLabel(name_match.choiceAt(0).?));
+    try std.testing.expectEqualStrings("Example Playground", name_match.choiceLabel(name_match.choiceAt(0).?));
 
     for (0..4) |_| try std.testing.expect(runtime.deleteTeamQueryByte());
     for ("zero-conf") |byte| try std.testing.expect(try runtime.appendTeamQueryByte(alloc, byte));

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -714,6 +714,22 @@ pub const Runtime = struct {
         );
     }
 
+    pub fn resolveExactProfileCredential(
+        self: *const Self,
+        alloc: Allocator,
+        profile: connection_registry.Profile,
+        mode: adapter_auth.RefreshMode,
+        current_source_id: ?[]const u8,
+    ) !credentials.Credential {
+        return self.resolveProfileCredentialWithSourceResolution(
+            alloc,
+            profile,
+            mode,
+            current_source_id,
+            .exact,
+        );
+    }
+
     fn resolveProfileCredentialWithSourceResolution(
         self: *const Self,
         alloc: Allocator,

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -225,7 +225,7 @@ pub fn resolvePreferring(
     if (preferred) |source| {
         if (source != .stored_key or !secret_store.isDisabled()) {
             const chosen = loadPreferredSource(alloc, transport, secret_store, mode, source) catch |err| blk: {
-                if (err == error.OutOfMemory) return err;
+                if (err == error.OutOfMemory or err == error.Cancelled) return err;
                 debug_trace.logf("auth", "preferred source load failed source={t} err={s}", .{ source, @errorName(err) });
                 break :blk null;
             };
@@ -254,6 +254,25 @@ pub fn resolvePreferring(
     };
     if (stored) |credential| return .{ .credential = credential };
     return .{ .stored_key_status = status };
+}
+
+/// An exact lookup never substitutes a different credential source.
+pub fn resolveExact(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+    secret_store: host.SecretStore,
+    mode: LoadMode,
+    source: Source,
+) !Resolution {
+    if (source == .stored_key and secret_store.isDisabled()) return .{};
+    const credential = loadPreferredSource(alloc, transport, secret_store, mode, source) catch |err| {
+        if (err == error.OutOfMemory or err == error.Cancelled) return err;
+        debug_trace.logf("auth", "exact source load failed source={t} err={s}", .{ source, @errorName(err) });
+        if (source == .stored_key) return .{ .stored_key_status = .unavailable };
+        return err;
+    };
+    if (credential) |value| return .{ .credential = value };
+    return .{ .stored_key_status = if (source == .stored_key) .not_found else .not_attempted };
 }
 
 /// `loadSource` always refreshes an expired fx login, which `.stored` mode
@@ -762,6 +781,23 @@ test "a remembered choice that no longer resolves falls back to precedence" {
     try std.testing.expectEqual(Source.ai_gateway_api_key, credential.source);
 }
 
+test "an exact source that no longer resolves does not fall through" {
+    const alloc = std.testing.allocator;
+    const env = try CredentialTestEnv.install(alloc, &.{
+        .{ "AI_GATEWAY_API_KEY", "api-key" },
+    });
+    defer env.deinit();
+
+    const resolution = try resolveExact(
+        alloc,
+        oauth_transport.unavailable_provider,
+        host.unavailable_secret_store,
+        .refresh_if_needed,
+        .fx_login,
+    );
+    try std.testing.expect(resolution.credential == null);
+}
+
 test "no remembered choice resolves exactly as plain precedence" {
     const alloc = std.testing.allocator;
     const env = try CredentialTestEnv.install(alloc, &.{
@@ -830,4 +866,15 @@ test "credential resolution preserves unreadable store classification" {
     try std.testing.expectEqual(@as(usize, 1), store_fixture.load_calls);
     try std.testing.expect(resolution.credential == null);
     try std.testing.expectEqual(StoredKeyReadStatus.unavailable, resolution.stored_key_status);
+
+    const exact = try resolveExact(
+        alloc,
+        oauth_transport.unavailable_provider,
+        store_fixture.provider(),
+        .stored,
+        .stored_key,
+    );
+    try std.testing.expectEqual(@as(usize, 2), store_fixture.load_calls);
+    try std.testing.expect(exact.credential == null);
+    try std.testing.expectEqual(StoredKeyReadStatus.unavailable, exact.stored_key_status);
 }

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -1067,7 +1067,9 @@ fn selectTeam(alloc: Allocator, teams: []const Team, current: ?[]const u8) !?usi
     if (teams.len == 1) return 0;
 
     const default_index = defaultTeamIndex(teams, current);
-    const index = if (canUseInteractiveTeamPicker())
+    const index = if (comptime host_target.is_wasm)
+        try selectTeamByLine(alloc, teams, default_index)
+    else if (canUseInteractiveTeamPicker())
         selectTeamInteractive(alloc, teams, default_index) catch |err| switch (err) {
             error.NotATerminal => try selectTeamByLine(alloc, teams, default_index),
             else => return err,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2059,6 +2059,7 @@ fn refreshGatewayCredential(
             .if_needed => .if_needed,
             .force => .force,
         },
+        .source_resolution = .exact,
         .current_source_id = @tagName(source),
         .cancel_flag = ctx.cancelFlag(),
     });
@@ -4054,12 +4055,16 @@ test "ask refresh handles every adapter acquisition outcome without fallback" {
     const RefreshProbe = struct {
         outcome: enum { acquired, missing, failed, cancelled } = .acquired,
         calls: usize = 0,
+        exact_calls: usize = 0,
+        saw_if_needed: bool = false,
         saw_force: bool = false,
 
         fn acquire(raw: *const anyopaque, alloc: Allocator, request: adapter_auth.Request) Allocator.Error!adapter_auth.Acquisition {
             const self: *@This() = @ptrCast(@alignCast(@constCast(raw)));
             self.calls += 1;
-            self.saw_force = request.mode == .force;
+            self.exact_calls += @intFromBool(request.source_resolution == .exact);
+            self.saw_if_needed = self.saw_if_needed or request.mode == .if_needed;
+            self.saw_force = self.saw_force or request.mode == .force;
             return switch (self.outcome) {
                 .acquired => .{ .acquired = .{
                     .secret_bytes = try alloc.dupe(u8, "refreshed-secret"),
@@ -4096,7 +4101,7 @@ test "ask refresh handles every adapter acquisition outcome without fallback" {
     ctx.connection_credential_ref = "fx_login";
     ctx.model = "model";
 
-    const refreshed = (try refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .force)).?;
+    const refreshed = (try refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .if_needed)).?;
     @memset(refreshed, 0);
     std.testing.allocator.free(refreshed);
     probe.outcome = .missing;
@@ -4104,7 +4109,7 @@ test "ask refresh handles every adapter acquisition outcome without fallback" {
     probe.outcome = .failed;
     try std.testing.expectError(
         error.CredentialRefreshFailed,
-        refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .force),
+        refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .if_needed),
     );
     probe.outcome = .cancelled;
     try std.testing.expectError(
@@ -4112,6 +4117,8 @@ test "ask refresh handles every adapter acquisition outcome without fallback" {
         refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .force),
     );
     try std.testing.expectEqual(@as(usize, 4), probe.calls);
+    try std.testing.expectEqual(probe.calls, probe.exact_calls);
+    try std.testing.expect(probe.saw_if_needed);
     try std.testing.expect(probe.saw_force);
 }
 

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -4092,7 +4092,7 @@ test "ask refresh handles every adapter acquisition outcome without fallback" {
     cfg.gateway_provider.adapter_registry = try adapter_registry.AdapterRegistry.init(&adapters);
     var ctx = AskContext.init(std.testing.allocator, cfg, .{
         .context_registry = test_no_context_registry,
-        .tool_set = test_builtin_tools.advertisement_set,
+        .tool_set = builtin_tools.advertisement_set,
         .load_mcp_runtime = testNoMcpRuntime,
     }, "/tmp/workspace");
     defer ctx.deinit();

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -15,6 +15,8 @@ const process_supervisor = @import("../background/process_supervisor.zig");
 const context_contract = @import("../workspace/context_contract.zig");
 const devbox_executor = @import("../execution/devbox_executor.zig");
 const gateway_provider = @import("../gateway/gateway_provider.zig");
+const adapter_auth = @import("../gateway/adapter_auth.zig");
+const adapter_registry = @import("../gateway/adapter_registry.zig");
 const connection_registry = @import("../gateway/connection_registry.zig");
 const model_catalog = @import("../gateway/model_catalog.zig");
 const route_snapshot = @import("../gateway/route_snapshot.zig");
@@ -2038,12 +2040,38 @@ fn refreshGatewayCredential(
     mode: auth_runtime.CredentialRefreshMode,
 ) !?[]u8 {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
-    return auth_runtime.refreshFxLoginToken(
-        ctx.cfg.gateway_provider.oauth_transport,
-        alloc,
-        source,
-        mode,
-    );
+    if (source != .fx_login) return null;
+    const profile = connection_registry.Profile{
+        .id = @constCast(ctx.connection_id),
+        .display_name = @constCast(ctx.connection_id),
+        .adapter_id = @constCast(ctx.connection_adapter_kind),
+        .endpoint = null,
+        .protocol = null,
+        .credential_ref = @constCast(ctx.connection_credential_ref),
+        .remembered_model = @constCast(ctx.model),
+        .internal_models = .{},
+    };
+    const auth = try ctx.cfg.gateway_provider.adapter_registry.resolveAuthForProfile(profile);
+    const acquisition = try auth.acquire(alloc, .{
+        .profile = profile,
+        .host = .{ .secret_store = ctx.cfg.secret_store },
+        .mode = switch (mode) {
+            .if_needed => .if_needed,
+            .force => .force,
+        },
+        .current_source_id = @tagName(source),
+        .cancel_flag = ctx.cancelFlag(),
+    });
+    var credential = switch (acquisition) {
+        .acquired => |value| value,
+        .missing => return null,
+        .failed => return error.CredentialRefreshFailed,
+        .cancelled => return error.Cancelled,
+    };
+    defer credential.deinit(alloc);
+    const token = credential.secret_bytes;
+    credential.secret_bytes = &.{};
+    return token;
 }
 
 fn persistUsageCheckpoint(
@@ -4020,6 +4048,71 @@ fn testConfig() Config {
         .load_mcp_runtime = testNoMcpRuntime,
         .devbox_provider = .{ .execute_fn = unavailableDevboxForTest },
     };
+}
+
+test "ask refresh handles every adapter acquisition outcome without fallback" {
+    const RefreshProbe = struct {
+        outcome: enum { acquired, missing, failed, cancelled } = .acquired,
+        calls: usize = 0,
+        saw_force: bool = false,
+
+        fn acquire(raw: *const anyopaque, alloc: Allocator, request: adapter_auth.Request) Allocator.Error!adapter_auth.Acquisition {
+            const self: *@This() = @ptrCast(@alignCast(@constCast(raw)));
+            self.calls += 1;
+            self.saw_force = request.mode == .force;
+            return switch (self.outcome) {
+                .acquired => .{ .acquired = .{
+                    .secret_bytes = try alloc.dupe(u8, "refreshed-secret"),
+                    .source = .{ .id = "fx_login", .label = "test login", .refreshable = true },
+                    .catalog_access = .authenticated,
+                } },
+                .missing => .{ .missing = .not_attempted },
+                .failed => .{ .failed = .{ .category = .unavailable } },
+                .cancelled => .cancelled,
+            };
+        }
+    };
+    var probe: RefreshProbe = .{};
+    const auth = adapter_auth.Provider{
+        .kind = test_builtin_gateway.connection_seed.adapter_id,
+        .context = &probe,
+        .acquire_fn = RefreshProbe.acquire,
+    };
+    const adapters = [_]agent_stream_provider.ProviderAdapter{.{
+        .kind = test_builtin_gateway.connection_seed.adapter_id,
+        .auth = auth,
+        .stream_fn = agent_stream_provider.unavailable_adapter.stream_fn,
+    }};
+    var cfg = testConfig();
+    cfg.gateway_provider.adapter_registry = try adapter_registry.AdapterRegistry.init(&adapters);
+    var ctx = AskContext.init(std.testing.allocator, cfg, .{
+        .context_registry = test_no_context_registry,
+        .tool_set = test_builtin_tools.advertisement_set,
+        .load_mcp_runtime = testNoMcpRuntime,
+    }, "/tmp/workspace");
+    defer ctx.deinit();
+    ctx.connection_id = test_builtin_gateway.connection_seed.id;
+    ctx.connection_adapter_kind = test_builtin_gateway.connection_seed.adapter_id;
+    ctx.connection_credential_ref = "fx_login";
+    ctx.model = "model";
+
+    const refreshed = (try refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .force)).?;
+    @memset(refreshed, 0);
+    std.testing.allocator.free(refreshed);
+    probe.outcome = .missing;
+    try std.testing.expect((try refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .force)) == null);
+    probe.outcome = .failed;
+    try std.testing.expectError(
+        error.CredentialRefreshFailed,
+        refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .force),
+    );
+    probe.outcome = .cancelled;
+    try std.testing.expectError(
+        error.Cancelled,
+        refreshGatewayCredential(&ctx, std.testing.allocator, .fx_login, .force),
+    );
+    try std.testing.expectEqual(@as(usize, 4), probe.calls);
+    try std.testing.expect(probe.saw_force);
 }
 
 fn testMissingKeyStartup(alloc: Allocator, _: oauth_transport.Provider, _: host.SecretStore, default_model: []const u8, default_fast_mode: bool, default_agent_step_limit: usize, connection_seed: connection_registry.Seed) !app_lifecycle.StartupState {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -340,6 +340,7 @@ fn resolveTopLevelAuth(alloc: Allocator, cfg: Config, deps: RunDeps) !TopLevelAu
     var startup = try deps.load_startup_state_without_credentials(
         alloc,
         cfg.default_model,
+        cfg.default_fast_mode,
         cfg.default_agent_step_limit,
         cfg.gateway_provider.connection_seed,
     );
@@ -5270,6 +5271,7 @@ fn failingStartupState(
 fn failingStartupStateWithoutCredentials(
     _: Allocator,
     _: []const u8,
+    _: bool,
     _: usize,
     _: connection_registry.Seed,
 ) !app_lifecycle.StartupState {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const io_mod = @import("../shared/io.zig");
+const adapter_auth = @import("../gateway/adapter_auth.zig");
+const auth_runtime = @import("../auth/auth_runtime.zig");
 const app_lifecycle = @import("../app/app_lifecycle.zig");
 const background_record_liveness = @import("../background/background_record_liveness.zig");
 const background_store = @import("../background/background_store.zig");
@@ -21,7 +23,6 @@ const background_process_provider = @import(
 const github_publish = @import("../github/github_publish.zig");
 const github_workflows = @import("../github/github_workflows.zig");
 const host = @import("../hosts/host.zig");
-const login_flow = @import("../auth/login_flow.zig");
 const oauth_transport = @import("../auth/oauth_transport.zig");
 const secret = @import("../auth/secret.zig");
 const output_contracts = @import("../output/output_contracts.zig");
@@ -322,6 +323,36 @@ const RunDeps = struct {
     read_masked_key: ReadMaskedKeyFn = readMaskedKeyDefault,
     setup_terminal_available: SetupTerminalAvailableFn = setupTerminalAvailableDefault,
 };
+
+const TopLevelAuthBinding = struct {
+    startup: app_lifecycle.StartupState,
+    profile: connection_registry.Profile,
+    auth: adapter_auth.Provider,
+    host: adapter_auth.AuthHost,
+
+    fn deinit(self: *TopLevelAuthBinding, alloc: Allocator) void {
+        self.startup.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+fn resolveTopLevelAuth(alloc: Allocator, cfg: Config, deps: RunDeps) !TopLevelAuthBinding {
+    var startup = try deps.load_startup_state_without_credentials(
+        alloc,
+        cfg.default_model,
+        cfg.default_agent_step_limit,
+        cfg.gateway_provider.connection_seed,
+    );
+    errdefer startup.deinit(alloc);
+    const connections = if (startup.connections) |*value| value else return error.ConnectionRegistryUnavailable;
+    const profile = connections.selectedProfile();
+    return .{
+        .startup = startup,
+        .profile = profile,
+        .auth = try cfg.gateway_provider.adapter_registry.resolveAuthForProfile(profile),
+        .host = .{ .secret_store = cfg.secret_store, .url_opener = cfg.url_opener },
+    };
+}
 
 const GlobalLaunchArgs = struct {
     remaining: []const [:0]const u8,
@@ -729,29 +760,54 @@ fn runNonInteractiveWithDeps(
                 try writeStderr(deps, "usage: fx login\n");
                 return .handled_failure;
             }
-            login_flow.runLogin(
-                alloc,
-                cfg.gateway_provider.oauth_transport,
-                cfg.url_opener,
-            ) catch |err| {
-                const message = switch (err) {
-                    error.ClientIdMissing => "fx login: missing FX_OAUTH_CLIENT_ID; configure the fx Vercel App client id first\n",
-                    error.AccessDenied => "fx login: authorization denied\n",
-                    error.ExpiredToken, error.LoginTimedOut => "fx login: authorization expired; run fx login again\n",
-                    else => "fx login: failed to sign in\n",
-                };
-                try writeStderr(deps, message);
-                return .handled_failure;
+            var binding = resolveTopLevelAuth(alloc, cfg, deps) catch |err| switch (err) {
+                error.MissingAdapter, error.MissingAuthCapability => {
+                    try writeStderr(deps, "fx login: unsupported connection adapter\n");
+                    return .handled_failure;
+                },
+                else => return err,
             };
-            return .handled_success;
+            defer binding.deinit(alloc);
+            const outcome = try binding.auth.login(alloc, binding.profile, binding.host);
+            switch (outcome) {
+                .succeeded => return .handled_success,
+                .cancelled => {
+                    try writeStderr(deps, "fx login: authorization cancelled\n");
+                    return .handled_failure;
+                },
+                .failed => |failure| {
+                    const message = switch (failure.category) {
+                        .configuration => "fx login: missing FX_OAUTH_CLIENT_ID; configure the fx Vercel App client id first\n",
+                        .denied => "fx login: authorization denied\n",
+                        .expired => "fx login: authorization expired; run fx login again\n",
+                        else => "fx login: failed to sign in\n",
+                    };
+                    try writeStderr(deps, message);
+                    return .handled_failure;
+                },
+            }
         },
         .logout => |rest| {
             if (rest.len != 0) {
                 try writeStderr(deps, "usage: fx logout\n");
                 return .handled_failure;
             }
-            const result = login_flow.logout(alloc, cfg.gateway_provider.oauth_transport) catch |err| switch (err) {
-                error.SessionDeleteFailed => {
+            var binding = resolveTopLevelAuth(alloc, cfg, deps) catch |err| switch (err) {
+                error.MissingAdapter, error.MissingAuthCapability => {
+                    try writeStderr(deps, "fx logout: unsupported connection adapter\n");
+                    return .handled_failure;
+                },
+                else => return err,
+            };
+            defer binding.deinit(alloc);
+            const outcome = try binding.auth.logout(alloc, binding.profile, binding.host);
+            const result = switch (outcome) {
+                .completed => |value| value,
+                .failed => {
+                    try writeStderr(deps, "fx logout: failed to durably remove saved Fx login\n");
+                    return .handled_failure;
+                },
+                .cancelled => {
                     try writeStderr(deps, "fx logout: failed to durably remove saved Fx login\n");
                     return .handled_failure;
                 },
@@ -765,7 +821,7 @@ fn runNonInteractiveWithDeps(
                 );
             }
             if (result.remote_revocation_failed) {
-                try writeStderr(deps, login_flow.remote_revocation_warning);
+                try writeStderr(deps, "Warning: signed out locally, but the remote session could not be revoked.");
                 try writeStderr(deps, "\n");
             }
             return if (result.local_durability_failed) .handled_failure else .handled_success;
@@ -775,19 +831,33 @@ fn runNonInteractiveWithDeps(
                 try writeStderr(deps, "usage: fx teams\n");
                 return .handled_failure;
             }
-            login_flow.runTeams(alloc, cfg.gateway_provider.oauth_transport) catch |err| {
-                const message = switch (err) {
-                    error.NoSession => "fx teams: run fx login first\n",
-                    error.SessionChanged => "fx teams: authentication changed; try again\n",
-                    error.TeamRequestFailed => "fx teams: failed to list Vercel teams\n",
-                    error.InvalidTeamSelection => "fx teams: no team selected\n",
-                    error.AccessDenied => "fx teams: authorization denied\n",
-                    else => "fx teams: failed to switch team\n",
-                };
-                try writeStderr(deps, message);
-                return .handled_failure;
+            var binding = resolveTopLevelAuth(alloc, cfg, deps) catch |err| switch (err) {
+                error.MissingAdapter, error.MissingAuthCapability => {
+                    try writeStderr(deps, "fx teams: unsupported connection adapter\n");
+                    return .handled_failure;
+                },
+                else => return err,
             };
-            return .handled_success;
+            defer binding.deinit(alloc);
+            const outcome = try binding.auth.teams(alloc, binding.profile, binding.host);
+            switch (outcome) {
+                .succeeded => return .handled_success,
+                .cancelled => {
+                    try writeStderr(deps, "fx teams: failed to switch team\n");
+                    return .handled_failure;
+                },
+                .failed => |failure| {
+                    const message = switch (failure.category) {
+                        .missing_session => "fx teams: run fx login first\n",
+                        .session_changed => "fx teams: authentication changed; try again\n",
+                        .invalid_selection => "fx teams: no team selected\n",
+                        .denied => "fx teams: authorization denied\n",
+                        else => "fx teams: failed to switch team\n",
+                    };
+                    try writeStderr(deps, message);
+                    return .handled_failure;
+                },
+            }
         },
         .setup => |rest| {
             if (rest.len != 0) {
@@ -803,11 +873,33 @@ fn runNonInteractiveWithDeps(
             };
             var startup = try deps.load_startup_status(
                 alloc,
-                cfg.secret_store,
+                host.unavailable_secret_store,
                 cfg.default_model,
                 cfg.default_agent_step_limit,
             );
             defer startup.deinit(alloc);
+            var binding = resolveTopLevelAuth(alloc, cfg, deps) catch |err| switch (err) {
+                error.MissingAdapter, error.MissingAuthCapability => {
+                    try writeStderr(deps, "fx status: unsupported connection adapter\n");
+                    return .handled_failure;
+                },
+                else => return err,
+            };
+            defer binding.deinit(alloc);
+            const replacement_auth: auth_runtime.StatusSnapshot = switch (try binding.auth.status(alloc, binding.profile, binding.host)) {
+                .loaded => |value| status: {
+                    var adapter_status = value;
+                    defer adapter_status.deinit(alloc);
+                    break :status try auth_runtime.takeAdapterStatus(&adapter_status);
+                },
+                .failed => |failure| .{ .failure = failure.category },
+                .cancelled => {
+                    try writeStderr(deps, "fx status: authentication check cancelled\n");
+                    return .handled_failure;
+                },
+            };
+            startup.auth.deinit(alloc);
+            startup.auth = replacement_auth;
             try startup.normalizeModel(alloc, cfg.gateway_provider.provider_adapter.model_descriptors);
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
             const mcp_config_diagnostic = try cfg.inspect_mcp_profile_config(alloc);
@@ -4351,6 +4443,19 @@ test "runIfRequested invalid json local flags write json error" {
     try std.testing.expect(std.mem.find(u8, capture.stdout.written(), "\"code\":\"InvalidLocalSurfaceArgs\"") != null);
 }
 
+test "top-level auth does not relabel startup failures as unsupported adapters" {
+    var capture = CaptureOutput.init(std.testing.allocator);
+    defer capture.deinit();
+    var deps = capture.deps();
+    deps.load_startup_state_without_credentials = failingStartupStateWithoutCredentials;
+
+    try std.testing.expectError(
+        error.StartupShouldNotRun,
+        runIfRequestedWithDeps(std.testing.allocator, &.{@constCast("login")}, testConfig(), deps),
+    );
+    try std.testing.expectEqualStrings("", capture.stderr.written());
+}
+
 test "runIfRequested resume no args returns last target" {
     var capture = CaptureOutput.init(std.testing.allocator);
     defer capture.deinit();
@@ -5156,6 +5261,15 @@ fn failingStartupState(
     _: host.SecretStore,
     _: []const u8,
     _: bool,
+    _: usize,
+    _: connection_registry.Seed,
+) !app_lifecycle.StartupState {
+    return error.StartupShouldNotRun;
+}
+
+fn failingStartupStateWithoutCredentials(
+    _: Allocator,
+    _: []const u8,
     _: usize,
     _: connection_registry.Seed,
 ) !app_lifecycle.StartupState {

--- a/src/core/gateway/adapter_auth.zig
+++ b/src/core/gateway/adapter_auth.zig
@@ -92,7 +92,7 @@ pub const Request = struct {
     profile: connection_registry.Profile,
     host: AuthHost,
     mode: RefreshMode,
-    source_resolution: SourceResolution = .allow_fallback,
+    source_resolution: SourceResolution,
     current_source_id: ?[]const u8 = null,
     cancel_flag: ?*const std.atomic.Value(bool) = null,
 
@@ -494,6 +494,7 @@ test "profile mismatch and cancellation precede adapter effects" {
         .profile = testProfile("other"),
         .host = auth_host,
         .mode = .if_needed,
+        .source_resolution = .exact,
     }));
     try std.testing.expectEqual(@as(usize, 0), state.acquire_calls);
 
@@ -502,6 +503,7 @@ test "profile mismatch and cancellation precede adapter effects" {
         .profile = testProfile("peer"),
         .host = auth_host,
         .mode = .if_needed,
+        .source_resolution = .exact,
         .cancel_flag = &cancelled,
     });
     try std.testing.expect(outcome == .cancelled);
@@ -513,6 +515,7 @@ test "profile mismatch and cancellation precede adapter effects" {
         .profile = testProfile("peer"),
         .host = auth_host,
         .mode = .if_needed,
+        .source_resolution = .exact,
         .cancel_flag = &cancelled,
     });
     try std.testing.expect(late_cancelled == .cancelled);
@@ -535,6 +538,7 @@ test "adapter acquisition reports allocation failure without publishing a creden
         .profile = testProfile("peer"),
         .host = .{ .secret_store = host_contract.unavailable_secret_store },
         .mode = .if_needed,
+        .source_resolution = .exact,
     }));
     try std.testing.expectEqual(@as(usize, 1), state.acquire_calls);
 }

--- a/src/core/gateway/adapter_auth.zig
+++ b/src/core/gateway/adapter_auth.zig
@@ -1,0 +1,558 @@
+const std = @import("std");
+const connection_registry = @import("connection_registry.zig");
+const host_contract = @import("../hosts/host.zig");
+const secret = @import("../auth/secret.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const RefreshMode = enum {
+    stored,
+    if_needed,
+    force,
+};
+
+pub const SourceResolution = enum {
+    allow_fallback,
+    exact,
+};
+
+pub const StoreStatus = enum {
+    not_attempted,
+    not_found,
+    unavailable,
+};
+
+pub const FailureCategory = enum {
+    configuration,
+    denied,
+    expired,
+    unavailable,
+    missing_session,
+    no_teams,
+    session_changed,
+    invalid_selection,
+    persistence,
+    cancelled,
+};
+
+pub const Failure = struct {
+    category: FailureCategory,
+};
+
+pub const Source = struct {
+    id: []const u8,
+    label: []const u8,
+    refreshable: bool,
+};
+
+pub const CatalogPublicOnlyReason = enum {
+    no_credential,
+    tenant_required,
+    refresh_required,
+    refresh_failed,
+    credential_rejected,
+};
+
+pub const CatalogAccess = union(enum) {
+    public_only: CatalogPublicOnlyReason,
+    authenticated,
+};
+
+/// One adapter-produced credential. The auth runtime owns an acquired value and
+/// must call `deinit` on replacement and every terminal path.
+pub const Credential = struct {
+    secret_bytes: []u8,
+    source: Source,
+    tenant_id: ?[]u8 = null,
+    tenant_slug: ?[]u8 = null,
+    refresh_after_ms: ?i64 = null,
+    catalog_access: CatalogAccess,
+
+    pub fn deinit(self: *Credential, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.secret_bytes);
+        if (self.tenant_id) |value| alloc.free(value);
+        if (self.tenant_slug) |value| alloc.free(value);
+        self.* = undefined;
+    }
+};
+
+pub const Acquisition = union(enum) {
+    acquired: Credential,
+    missing: StoreStatus,
+    failed: Failure,
+    cancelled,
+};
+
+pub const AuthHost = struct {
+    secret_store: host_contract.SecretStore,
+    url_opener: host_contract.UrlOpener = host_contract.unavailable_url_opener,
+};
+
+pub const Request = struct {
+    profile: connection_registry.Profile,
+    host: AuthHost,
+    mode: RefreshMode,
+    source_resolution: SourceResolution = .allow_fallback,
+    current_source_id: ?[]const u8 = null,
+    cancel_flag: ?*const std.atomic.Value(bool) = null,
+
+    pub fn cancelled(self: Request) bool {
+        return if (self.cancel_flag) |flag| flag.load(.seq_cst) else false;
+    }
+};
+
+pub const OperationOutcome = union(enum) {
+    succeeded,
+    failed: Failure,
+    cancelled,
+};
+
+pub const LogoutResult = struct {
+    session_deleted: bool = false,
+    local_durability_failed: bool = false,
+    remote_revocation_failed: bool = false,
+};
+
+pub const LogoutOutcome = union(enum) {
+    completed: LogoutResult,
+    failed: Failure,
+    cancelled,
+};
+
+pub const SignInState = enum {
+    idle,
+    polling,
+    succeeded,
+    failed,
+    cancelled,
+};
+
+pub const SignInSnapshot = struct {
+    state: SignInState = .idle,
+    verification_uri: []const u8 = "",
+    verification_uri_complete: ?[]const u8 = null,
+    user_code: []const u8 = "",
+};
+
+pub const Team = struct {
+    id: []const u8,
+    slug: []const u8,
+    name: []const u8,
+};
+
+pub const SelectedTeam = struct {
+    id: []u8,
+    slug: []u8,
+
+    pub fn deinit(self: *SelectedTeam, alloc: Allocator) void {
+        alloc.free(self.id);
+        alloc.free(self.slug);
+        self.* = undefined;
+    }
+};
+
+pub const TeamSelection = struct {
+    context: ?*anyopaque = null,
+    teams: []const Team = &.{},
+    current_team: ?[]const u8 = null,
+    select_fn: *const fn (?*anyopaque, Allocator, usize) Allocator.Error!SelectOutcome,
+    deinit_fn: *const fn (?*anyopaque, Allocator) void,
+
+    pub fn deinit(self: *TeamSelection, alloc: Allocator) void {
+        self.deinit_fn(self.context, alloc);
+        self.* = unavailable_team_selection;
+    }
+
+    pub fn take(self: *TeamSelection) TeamSelection {
+        const result = self.*;
+        self.* = unavailable_team_selection;
+        return result;
+    }
+
+    pub fn select(self: TeamSelection, alloc: Allocator, index: usize) Allocator.Error!SelectOutcome {
+        if (index >= self.teams.len) return .{ .failed = .{ .category = .invalid_selection } };
+        return self.select_fn(self.context, alloc, index);
+    }
+};
+
+pub const SelectOutcome = union(enum) {
+    selected: SelectedTeam,
+    failed: Failure,
+};
+
+fn unavailableTeamSelect(_: ?*anyopaque, _: Allocator, _: usize) Allocator.Error!SelectOutcome {
+    return .{ .failed = .{ .category = .unavailable } };
+}
+
+fn unavailableTeamDeinit(_: ?*anyopaque, _: Allocator) void {}
+
+pub const unavailable_team_selection = TeamSelection{
+    .select_fn = unavailableTeamSelect,
+    .deinit_fn = unavailableTeamDeinit,
+};
+
+pub const SignInTransition = union(enum) {
+    none,
+    succeeded: TeamSelection,
+    failed: Failure,
+    cancelled,
+};
+
+pub const SignInSession = struct {
+    context: ?*anyopaque = null,
+    snapshot_fn: *const fn (?*anyopaque) SignInSnapshot,
+    browser_url_fn: *const fn (?*anyopaque, Allocator) Allocator.Error!?[]u8,
+    poll_fn: *const fn (?*anyopaque, Allocator) Allocator.Error!SignInTransition,
+    cancel_fn: *const fn (?*anyopaque, Allocator) bool,
+    deinit_fn: *const fn (?*anyopaque, Allocator) void,
+
+    pub fn snapshot(self: SignInSession) SignInSnapshot {
+        return self.snapshot_fn(self.context);
+    }
+
+    pub fn browserUrlAlloc(self: SignInSession, alloc: Allocator) Allocator.Error!?[]u8 {
+        return self.browser_url_fn(self.context, alloc);
+    }
+
+    pub fn poll(self: SignInSession, alloc: Allocator) Allocator.Error!SignInTransition {
+        return self.poll_fn(self.context, alloc);
+    }
+
+    pub fn cancel(self: SignInSession, alloc: Allocator) bool {
+        return self.cancel_fn(self.context, alloc);
+    }
+
+    pub fn deinit(self: *SignInSession, alloc: Allocator) void {
+        self.deinit_fn(self.context, alloc);
+        self.* = unavailable_sign_in_session;
+    }
+};
+
+fn unavailableSignInSnapshot(_: ?*anyopaque) SignInSnapshot {
+    return .{};
+}
+
+fn unavailableSignInUrl(_: ?*anyopaque, _: Allocator) Allocator.Error!?[]u8 {
+    return null;
+}
+
+fn unavailableSignInPoll(_: ?*anyopaque, _: Allocator) Allocator.Error!SignInTransition {
+    return .none;
+}
+
+fn unavailableSignInCancel(_: ?*anyopaque, _: Allocator) bool {
+    return false;
+}
+
+fn unavailableSignInDeinit(_: ?*anyopaque, _: Allocator) void {}
+
+pub const unavailable_sign_in_session = SignInSession{
+    .snapshot_fn = unavailableSignInSnapshot,
+    .browser_url_fn = unavailableSignInUrl,
+    .poll_fn = unavailableSignInPoll,
+    .cancel_fn = unavailableSignInCancel,
+    .deinit_fn = unavailableSignInDeinit,
+};
+
+pub const StartSignInOutcome = union(enum) {
+    started: SignInSession,
+    busy,
+    failed: Failure,
+    cancelled,
+};
+
+pub const Status = struct {
+    source: ?Source = null,
+    team: ?[]u8 = null,
+    store_status: StoreStatus = .not_attempted,
+    expired: bool = false,
+
+    pub fn deinit(self: *Status, alloc: Allocator) void {
+        if (self.team) |value| alloc.free(value);
+        self.* = .{};
+    }
+};
+
+pub const StatusOutcome = union(enum) {
+    loaded: Status,
+    failed: Failure,
+    cancelled,
+};
+
+pub const Invalidation = struct {
+    drop_credential: bool,
+};
+
+const AcquireFn = *const fn (*const anyopaque, Allocator, Request) Allocator.Error!Acquisition;
+const LoginFn = *const fn (*const anyopaque, Allocator, connection_registry.Profile, AuthHost) Allocator.Error!OperationOutcome;
+const LogoutFn = *const fn (*const anyopaque, Allocator, connection_registry.Profile, AuthHost) Allocator.Error!LogoutOutcome;
+const TeamsFn = *const fn (*const anyopaque, Allocator, connection_registry.Profile, AuthHost) Allocator.Error!OperationOutcome;
+const StartSignInFn = *const fn (*const anyopaque, Allocator, connection_registry.Profile, AuthHost) Allocator.Error!StartSignInOutcome;
+pub const TeamsOutcome = union(enum) {
+    loaded: TeamSelection,
+    failed: Failure,
+    cancelled,
+};
+const LoadTeamsFn = *const fn (*const anyopaque, Allocator, connection_registry.Profile, AuthHost) Allocator.Error!TeamsOutcome;
+const InvalidateFn = *const fn (*const anyopaque, connection_registry.Profile, Failure) Invalidation;
+const StatusFn = *const fn (*const anyopaque, Allocator, connection_registry.Profile, AuthHost) Allocator.Error!StatusOutcome;
+
+const unavailable_context: u8 = 0;
+
+fn unavailableAcquire(_: *const anyopaque, _: Allocator, _: Request) Allocator.Error!Acquisition {
+    return .{ .failed = .{ .category = .unavailable } };
+}
+
+fn unavailableLogin(_: *const anyopaque, _: Allocator, _: connection_registry.Profile, _: AuthHost) Allocator.Error!OperationOutcome {
+    return .{ .failed = .{ .category = .unavailable } };
+}
+
+fn unavailableLogout(_: *const anyopaque, _: Allocator, _: connection_registry.Profile, _: AuthHost) Allocator.Error!LogoutOutcome {
+    return .{ .failed = .{ .category = .unavailable } };
+}
+
+fn unavailableTeams(_: *const anyopaque, _: Allocator, _: connection_registry.Profile, _: AuthHost) Allocator.Error!OperationOutcome {
+    return .{ .failed = .{ .category = .unavailable } };
+}
+
+fn unavailableStartSignIn(_: *const anyopaque, _: Allocator, _: connection_registry.Profile, _: AuthHost) Allocator.Error!StartSignInOutcome {
+    return .{ .failed = .{ .category = .unavailable } };
+}
+
+fn unavailableLoadTeams(_: *const anyopaque, _: Allocator, _: connection_registry.Profile, _: AuthHost) Allocator.Error!TeamsOutcome {
+    return .{ .failed = .{ .category = .unavailable } };
+}
+
+fn unavailableInvalidate(_: *const anyopaque, _: connection_registry.Profile, _: Failure) Invalidation {
+    return .{ .drop_credential = false };
+}
+
+fn unavailableStatus(_: *const anyopaque, _: Allocator, _: connection_registry.Profile, _: AuthHost) Allocator.Error!StatusOutcome {
+    return .{ .failed = .{ .category = .unavailable } };
+}
+
+pub const Provider = struct {
+    kind: []const u8,
+    context: *const anyopaque = &unavailable_context,
+    acquire_fn: AcquireFn = unavailableAcquire,
+    login_fn: LoginFn = unavailableLogin,
+    logout_fn: LogoutFn = unavailableLogout,
+    teams_fn: TeamsFn = unavailableTeams,
+    start_sign_in_fn: StartSignInFn = unavailableStartSignIn,
+    load_teams_fn: LoadTeamsFn = unavailableLoadTeams,
+    invalidate_fn: InvalidateFn = unavailableInvalidate,
+    status_fn: StatusFn = unavailableStatus,
+
+    pub fn acquire(self: Provider, alloc: Allocator, request: Request) (Allocator.Error || error{AdapterMismatch})!Acquisition {
+        try self.validateProfile(request.profile);
+        if (request.cancelled()) return .cancelled;
+        var acquisition = try self.acquire_fn(self.context, alloc, request);
+        if (!request.cancelled()) return acquisition;
+        switch (acquisition) {
+            .acquired => |*credential| credential.deinit(alloc),
+            .missing, .failed, .cancelled => {},
+        }
+        return .cancelled;
+    }
+
+    pub fn login(self: Provider, alloc: Allocator, profile: connection_registry.Profile, auth_host: AuthHost) (Allocator.Error || error{AdapterMismatch})!OperationOutcome {
+        try self.validateProfile(profile);
+        return self.login_fn(self.context, alloc, profile, auth_host);
+    }
+
+    pub fn logout(self: Provider, alloc: Allocator, profile: connection_registry.Profile, auth_host: AuthHost) (Allocator.Error || error{AdapterMismatch})!LogoutOutcome {
+        try self.validateProfile(profile);
+        return self.logout_fn(self.context, alloc, profile, auth_host);
+    }
+
+    pub fn teams(self: Provider, alloc: Allocator, profile: connection_registry.Profile, auth_host: AuthHost) (Allocator.Error || error{AdapterMismatch})!OperationOutcome {
+        try self.validateProfile(profile);
+        return self.teams_fn(self.context, alloc, profile, auth_host);
+    }
+
+    pub fn startSignIn(self: Provider, alloc: Allocator, profile: connection_registry.Profile, auth_host: AuthHost) (Allocator.Error || error{AdapterMismatch})!StartSignInOutcome {
+        try self.validateProfile(profile);
+        return self.start_sign_in_fn(self.context, alloc, profile, auth_host);
+    }
+
+    pub fn loadTeams(self: Provider, alloc: Allocator, profile: connection_registry.Profile, auth_host: AuthHost) (Allocator.Error || error{AdapterMismatch})!TeamsOutcome {
+        try self.validateProfile(profile);
+        return self.load_teams_fn(self.context, alloc, profile, auth_host);
+    }
+
+    pub fn invalidate(self: Provider, profile: connection_registry.Profile, failure: Failure) error{AdapterMismatch}!Invalidation {
+        try self.validateProfile(profile);
+        return self.invalidate_fn(self.context, profile, failure);
+    }
+
+    pub fn status(self: Provider, alloc: Allocator, profile: connection_registry.Profile, auth_host: AuthHost) (Allocator.Error || error{AdapterMismatch})!StatusOutcome {
+        try self.validateProfile(profile);
+        return self.status_fn(self.context, alloc, profile, auth_host);
+    }
+
+    fn validateProfile(self: Provider, profile: connection_registry.Profile) error{AdapterMismatch}!void {
+        if (!std.mem.eql(u8, profile.adapter_id, self.kind)) return error.AdapterMismatch;
+    }
+};
+
+/// Pure retry state owned by one admitted workload. It permits no more than one
+/// forced refresh after an unauthorized response.
+pub const UnauthorizedRefresh = struct {
+    force_used: bool = false,
+
+    pub fn next(self: *UnauthorizedRefresh, refreshable: bool) ?RefreshMode {
+        if (!refreshable or self.force_used) return null;
+        self.force_used = true;
+        return .force;
+    }
+};
+
+test "unauthorized refresh permits exactly one forced attempt" {
+    var refresh: UnauthorizedRefresh = .{};
+    try std.testing.expectEqual(RefreshMode.force, refresh.next(true).?);
+    try std.testing.expect(refresh.next(true) == null);
+
+    var fixed: UnauthorizedRefresh = .{};
+    try std.testing.expect(fixed.next(false) == null);
+    try std.testing.expect(fixed.next(true) != null);
+}
+
+test "credential destruction zeroes secret bytes" {
+    var backing: [32]u8 = undefined;
+    var fixed = std.heap.FixedBufferAllocator.init(&backing);
+    const alloc = fixed.allocator();
+    var credential = Credential{
+        .secret_bytes = try alloc.dupe(u8, "adapter-secret"),
+        .source = .{ .id = "test", .label = "test", .refreshable = false },
+        .catalog_access = .authenticated,
+    };
+    credential.deinit(alloc);
+    try std.testing.expect(std.mem.indexOf(u8, &backing, "adapter-secret") == null);
+}
+
+test "status serialization is redacted" {
+    const alloc = std.testing.allocator;
+    const status = Status{
+        .source = .{ .id = "opaque", .label = "peer login", .refreshable = true },
+    };
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try std.json.Stringify.value(status, .{}, &out.writer);
+    const text = try out.toOwnedSlice();
+    defer alloc.free(text);
+    try std.testing.expect(std.mem.indexOf(u8, text, "credential-secret") == null);
+    try std.testing.expect(std.mem.indexOf(u8, text, "peer login") != null);
+}
+
+const TestProviderState = struct {
+    acquire_calls: usize = 0,
+    invalidate_calls: usize = 0,
+    cancel_during_acquire: ?*std.atomic.Value(bool) = null,
+
+    fn acquire(raw: *const anyopaque, alloc: Allocator, _: Request) Allocator.Error!Acquisition {
+        const self: *@This() = @ptrCast(@alignCast(@constCast(raw)));
+        self.acquire_calls += 1;
+        if (self.cancel_during_acquire) |flag| flag.store(true, .seq_cst);
+        return .{ .acquired = .{
+            .secret_bytes = try alloc.dupe(u8, "peer-secret"),
+            .source = .{ .id = "peer_login", .label = "peer login", .refreshable = true },
+            .catalog_access = .authenticated,
+        } };
+    }
+
+    fn invalidate(raw: *const anyopaque, _: connection_registry.Profile, _: Failure) Invalidation {
+        const self: *@This() = @ptrCast(@alignCast(@constCast(raw)));
+        self.invalidate_calls += 1;
+        return .{ .drop_credential = true };
+    }
+};
+
+fn testProfile(kind: []const u8) connection_registry.Profile {
+    return .{
+        .id = @constCast("test"),
+        .display_name = @constCast("Test"),
+        .adapter_id = @constCast(kind),
+        .endpoint = null,
+        .protocol = null,
+        .credential_ref = @constCast("automatic"),
+        .remembered_model = @constCast("model"),
+        .internal_models = .{},
+    };
+}
+
+test "profile mismatch and cancellation precede adapter effects" {
+    var state: TestProviderState = .{};
+    const provider = Provider{
+        .kind = "peer",
+        .context = &state,
+        .acquire_fn = TestProviderState.acquire,
+        .invalidate_fn = TestProviderState.invalidate,
+    };
+    const auth_host = AuthHost{ .secret_store = host_contract.unavailable_secret_store };
+
+    try std.testing.expectError(error.AdapterMismatch, provider.acquire(std.testing.allocator, .{
+        .profile = testProfile("other"),
+        .host = auth_host,
+        .mode = .if_needed,
+    }));
+    try std.testing.expectEqual(@as(usize, 0), state.acquire_calls);
+
+    var cancelled = std.atomic.Value(bool).init(true);
+    const outcome = try provider.acquire(std.testing.allocator, .{
+        .profile = testProfile("peer"),
+        .host = auth_host,
+        .mode = .if_needed,
+        .cancel_flag = &cancelled,
+    });
+    try std.testing.expect(outcome == .cancelled);
+    try std.testing.expectEqual(@as(usize, 0), state.acquire_calls);
+
+    state.cancel_during_acquire = &cancelled;
+    cancelled.store(false, .seq_cst);
+    const late_cancelled = try provider.acquire(std.testing.allocator, .{
+        .profile = testProfile("peer"),
+        .host = auth_host,
+        .mode = .if_needed,
+        .cancel_flag = &cancelled,
+    });
+    try std.testing.expect(late_cancelled == .cancelled);
+    try std.testing.expectEqual(@as(usize, 1), state.acquire_calls);
+
+    const invalidation = try provider.invalidate(testProfile("peer"), .{ .category = .denied });
+    try std.testing.expect(invalidation.drop_credential);
+    try std.testing.expectEqual(@as(usize, 1), state.invalidate_calls);
+}
+
+test "adapter acquisition reports allocation failure without publishing a credential" {
+    var state: TestProviderState = .{};
+    const provider = Provider{
+        .kind = "peer",
+        .context = &state,
+        .acquire_fn = TestProviderState.acquire,
+    };
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    try std.testing.expectError(error.OutOfMemory, provider.acquire(failing.allocator(), .{
+        .profile = testProfile("peer"),
+        .host = .{ .secret_store = host_contract.unavailable_secret_store },
+        .mode = .if_needed,
+    }));
+    try std.testing.expectEqual(@as(usize, 1), state.acquire_calls);
+}
+
+test "normalized sign-in transition carries only generic team state" {
+    const Poll = struct {
+        fn poll(_: ?*anyopaque, _: Allocator) Allocator.Error!SignInTransition {
+            return .{ .succeeded = unavailable_team_selection };
+        }
+    };
+    var session = unavailable_sign_in_session;
+    session.poll_fn = Poll.poll;
+    var transition = try session.poll(std.testing.allocator);
+    switch (transition) {
+        .succeeded => |*selection| {
+            try std.testing.expectEqual(@as(usize, 0), selection.teams.len);
+            selection.deinit(std.testing.allocator);
+        },
+        else => return error.UnexpectedSignInTransition,
+    }
+}

--- a/src/core/gateway/adapter_registry.zig
+++ b/src/core/gateway/adapter_registry.zig
@@ -1,0 +1,102 @@
+const std = @import("std");
+const stream_provider = @import("../agent/stream_provider.zig");
+const connection_registry = @import("connection_registry.zig");
+
+const max_adapters: usize = 16;
+
+pub const InitError = error{
+    EmptyRegistry,
+    TooManyAdapters,
+    EmptyAdapterKind,
+    DuplicateAdapterKind,
+    AuthAdapterKindMismatch,
+};
+
+pub const ResolveError = error{
+    MissingAdapter,
+    MissingAuthCapability,
+};
+
+/// A bounded, borrowed registry assembled once by composition. It owns no
+/// adapters, persistence, discovery, or mutation API.
+pub const AdapterRegistry = struct {
+    adapters: []const stream_provider.ProviderAdapter,
+
+    pub fn init(adapters: []const stream_provider.ProviderAdapter) InitError!AdapterRegistry {
+        if (adapters.len == 0) return error.EmptyRegistry;
+        if (adapters.len > max_adapters) return error.TooManyAdapters;
+        for (adapters, 0..) |adapter, index| {
+            if (adapter.kind.len == 0) return error.EmptyAdapterKind;
+            if (adapter.auth) |auth| {
+                if (!std.mem.eql(u8, adapter.kind, auth.kind)) return error.AuthAdapterKindMismatch;
+            }
+            for (adapters[0..index]) |previous| {
+                if (std.mem.eql(u8, adapter.kind, previous.kind)) return error.DuplicateAdapterKind;
+            }
+        }
+        return .{ .adapters = adapters };
+    }
+
+    pub fn resolve(self: AdapterRegistry, kind: []const u8) ResolveError!stream_provider.ProviderAdapter {
+        for (self.adapters) |adapter| {
+            if (std.mem.eql(u8, adapter.kind, kind)) return adapter;
+        }
+        return error.MissingAdapter;
+    }
+
+    fn resolveProfile(self: AdapterRegistry, profile: connection_registry.Profile) ResolveError!stream_provider.ProviderAdapter {
+        return self.resolve(profile.adapter_id);
+    }
+
+    pub fn resolveAuthForProfile(self: AdapterRegistry, profile: connection_registry.Profile) ResolveError!@import("adapter_auth.zig").Provider {
+        const adapter = try self.resolveProfile(profile);
+        return adapter.auth orelse error.MissingAuthCapability;
+    }
+};
+
+fn unavailableStream(
+    _: *const stream_provider.ProviderAdapter,
+    _: std.mem.Allocator,
+    _: stream_provider.AdapterRequest,
+    _: stream_provider.EventSink,
+) anyerror!void {}
+
+test "adapter registry rejects invalid manifests and missing kinds" {
+    const adapter = stream_provider.ProviderAdapter{ .kind = "one", .stream_fn = unavailableStream };
+    try std.testing.expectError(error.EmptyRegistry, AdapterRegistry.init(&.{}));
+    try std.testing.expectError(error.EmptyAdapterKind, AdapterRegistry.init(&.{.{ .kind = "", .stream_fn = unavailableStream }}));
+    try std.testing.expectError(error.DuplicateAdapterKind, AdapterRegistry.init(&.{ adapter, adapter }));
+    try std.testing.expectError(error.AuthAdapterKindMismatch, AdapterRegistry.init(&.{.{
+        .kind = "one",
+        .auth = .{ .kind = "two" },
+        .stream_fn = unavailableStream,
+    }}));
+
+    const registry = try AdapterRegistry.init(&.{adapter});
+    try std.testing.expectError(error.MissingAdapter, registry.resolve("two"));
+    try std.testing.expectError(error.MissingAuthCapability, registry.resolveAuthForProfile(.{
+        .id = @constCast("one"),
+        .display_name = @constCast("One"),
+        .adapter_id = @constCast("one"),
+        .endpoint = null,
+        .protocol = null,
+        .credential_ref = @constCast("automatic"),
+        .remembered_model = @constCast("model"),
+        .internal_models = .{},
+    }));
+}
+
+test "adapter registry accepts sixteen adapters and rejects seventeen" {
+    const adapters = comptime blk: {
+        var values: [17]stream_provider.ProviderAdapter = undefined;
+        for (&values, 0..) |*adapter, index| {
+            adapter.* = .{
+                .kind = std.fmt.comptimePrint("adapter-{d}", .{index}),
+                .stream_fn = unavailableStream,
+            };
+        }
+        break :blk values;
+    };
+    try std.testing.expectEqual(@as(usize, 16), (try AdapterRegistry.init(adapters[0..16])).adapters.len);
+    try std.testing.expectError(error.TooManyAdapters, AdapterRegistry.init(&adapters));
+}

--- a/src/core/gateway/gateway_provider.zig
+++ b/src/core/gateway/gateway_provider.zig
@@ -7,6 +7,7 @@ const model_capabilities = @import("../config/model_capabilities.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const output_contracts = @import("../output/output_contracts.zig");
 const connection_registry = @import("connection_registry.zig");
+const adapter_registry = @import("adapter_registry.zig");
 const model_catalog = @import("model_catalog.zig");
 const model_catalog_metadata = @import("model_catalog_metadata.zig");
 
@@ -28,6 +29,7 @@ pub const Provider = struct {
     connection_seed: connection_registry.Seed,
     agent_stream: agent_stream_provider.Provider,
     provider_adapter: agent_stream_provider.ProviderAdapter,
+    adapter_registry: adapter_registry.AdapterRegistry = .{ .adapters = &.{} },
     oauth_transport: oauth_transport.Provider,
     chat_url: ChatUrlProvider,
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -506,6 +506,8 @@ const App = struct {
         alloc: Allocator,
         route: *const route_snapshot.RouteSnapshot,
     ) !agent_runtime.RouteCredential {
+        var profile = try self.auth.connectionProfile(route.connection_id);
+        if (!std.mem.eql(u8, profile.adapter_id, route.adapter_kind)) return error.RouteAdapterMismatch;
         const selected = try self.auth.selectedConnectionProfile();
         if (std.mem.eql(u8, route.connection_id, selected.id)) {
             if (self.auth.gatewayCredential()) |credential| {
@@ -523,7 +525,8 @@ const App = struct {
                 return result;
             }
         }
-        var credential = try self.auth.resolveCredentialReference(alloc, route.credential_ref);
+        profile.credential_ref = @constCast(route.credential_ref);
+        var credential = try self.auth.resolveProfileCredential(alloc, profile, .if_needed, null);
         defer credential.deinit(alloc);
         const tenant = if (credential.gatewayTeam()) |value| try alloc.dupe(u8, value) else null;
         errdefer if (tenant) |value| alloc.free(value);
@@ -631,6 +634,7 @@ const App = struct {
         else
             oauth_transport.unavailable_provider,
         if (host_target.is_wasm) host.unavailable_secret_store else native_host.secret_store,
+        builtin_gateway.production_adapter_registry,
     ),
     selected_model: std.ArrayList(u8) = .empty,
     model_cache: model_cache_runtime.Runtime = model_cache_runtime.Runtime.init(std.heap.c_allocator, builtin_gateway.models_path),
@@ -755,6 +759,7 @@ const App = struct {
                 .skill_root_policy = if (comptime host_target.is_wasm) wasm_skill_root_policy else builtin_skills.root_policy,
                 .terminal_title = app.terminalTitle(),
                 .connection_seed = builtin_gateway.connection_seed,
+                .adapter_registry = builtin_gateway.production_adapter_registry,
                 .model_descriptors = builtin_gateway.model_descriptor_provider,
             },
         );

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,6 +48,7 @@ const command_specs = @import("core/slash_commands/command_specs.zig");
 const builtin_context = @import("builtins/context.zig");
 const builtin_devbox = @import("builtins/devbox.zig");
 const builtin_gateway = @import("builtins/gateway.zig");
+const adapter_registry = @import("core/gateway/adapter_registry.zig");
 const gateway_provider = @import("core/gateway/gateway_provider.zig");
 const output_contracts = @import("core/output/output_contracts.zig");
 const generation_usage_provider = @import("core/session/generation_usage_provider.zig");
@@ -359,6 +360,22 @@ fn currentBuild() update_target.CurrentBuild {
     };
 }
 
+const wasm_provider_adapter = agent_stream_provider.ProviderAdapter{
+    .kind = builtin_gateway.connection_seed.adapter_id,
+    .auth = builtin_gateway.auth_provider_for_transport(&js_host_auth.oauth_provider),
+    .model_catalog = js_host_model_catalog.provider,
+    .model_descriptors = builtin_gateway.model_descriptor_provider,
+    .provider_tools = &.{.web_search},
+    .stream_fn = builtin_gateway.streamVercelAdapter,
+};
+
+const wasm_production_adapters = [_]agent_stream_provider.ProviderAdapter{wasm_provider_adapter};
+
+const production_adapter_registry = if (host_target.is_wasm)
+    adapter_registry.AdapterRegistry{ .adapters = &wasm_production_adapters }
+else
+    builtin_gateway.production_adapter_registry;
+
 const App = struct {
     pub const app_version = version;
     pub const host_profile = if (host_target.is_wasm) host_runtime_profile.wasm else host_runtime_profile.native;
@@ -476,13 +493,7 @@ const App = struct {
 
     pub fn providerAdapter(self: *const Self) agent_stream_provider.ProviderAdapter {
         var adapter = if (comptime host_target.is_wasm)
-            agent_stream_provider.ProviderAdapter{
-                .kind = builtin_gateway.connection_seed.adapter_id,
-                .model_catalog = js_host_model_catalog.provider,
-                .model_descriptors = builtin_gateway.model_descriptor_provider,
-                .provider_tools = &.{.web_search},
-                .stream_fn = builtin_gateway.streamVercelAdapter,
-            }
+            wasm_provider_adapter
         else
             builtin_gateway.provider_adapter;
         adapter.legacy_provider = self.agentStreamProvider();
@@ -634,7 +645,7 @@ const App = struct {
         else
             oauth_transport.unavailable_provider,
         if (host_target.is_wasm) host.unavailable_secret_store else native_host.secret_store,
-        builtin_gateway.production_adapter_registry,
+        production_adapter_registry,
     ),
     selected_model: std.ArrayList(u8) = .empty,
     model_cache: model_cache_runtime.Runtime = model_cache_runtime.Runtime.init(std.heap.c_allocator, builtin_gateway.models_path),
@@ -759,7 +770,7 @@ const App = struct {
                 .skill_root_policy = if (comptime host_target.is_wasm) wasm_skill_root_policy else builtin_skills.root_policy,
                 .terminal_title = app.terminalTitle(),
                 .connection_seed = builtin_gateway.connection_seed,
-                .adapter_registry = builtin_gateway.production_adapter_registry,
+                .adapter_registry = production_adapter_registry,
                 .model_descriptors = builtin_gateway.model_descriptor_provider,
             },
         );

--- a/src/main.zig
+++ b/src/main.zig
@@ -537,7 +537,7 @@ const App = struct {
             }
         }
         profile.credential_ref = @constCast(route.credential_ref);
-        var credential = try self.auth.resolveProfileCredential(alloc, profile, .if_needed, null);
+        var credential = try self.auth.resolveExactProfileCredential(alloc, profile, .if_needed, null);
         defer credential.deinit(alloc);
         const tenant = if (credential.gatewayTeam()) |value| try alloc.dupe(u8, value) else null;
         errdefer if (tenant) |value| alloc.free(value);
@@ -3444,6 +3444,84 @@ test "native app preserves the built-in tool set without workspace metadata" {
     const advertised = app.toolAdvertisementSet();
     try std.testing.expect(advertised.order.ptr == builtin_tools.advertisement_set.order.ptr);
     try std.testing.expectEqual(builtin_tools.advertisement_set.order.len, advertised.order.len);
+}
+
+test "interactive route credential resolution keeps the admitted source exact" {
+    const adapter_auth = @import("core/gateway/adapter_auth.zig");
+    const connection_registry = @import("core/gateway/connection_registry.zig");
+    const Probe = struct {
+        calls: usize = 0,
+        fallback_reads: usize = 0,
+
+        fn acquire(
+            raw: *const anyopaque,
+            alloc: std.mem.Allocator,
+            request: adapter_auth.Request,
+        ) std.mem.Allocator.Error!adapter_auth.Acquisition {
+            const self: *@This() = @ptrCast(@alignCast(@constCast(raw)));
+            self.calls += 1;
+            if (request.source_resolution == .exact) {
+                return .{ .failed = .{ .category = .unavailable } };
+            }
+            self.fallback_reads += 1;
+            return .{ .acquired = .{
+                .secret_bytes = try alloc.dupe(u8, "fallback-secret"),
+                .source = .{ .id = "ai_gateway_api_key", .label = "fallback", .refreshable = false },
+                .catalog_access = .authenticated,
+            } };
+        }
+    };
+    const alloc = std.testing.allocator;
+    var probe: Probe = .{};
+    const adapters = [_]agent_stream_provider.ProviderAdapter{.{
+        .kind = "test_adapter",
+        .auth = .{
+            .kind = "test_adapter",
+            .context = &probe,
+            .acquire_fn = Probe.acquire,
+        },
+        .stream_fn = agent_stream_provider.unavailable_adapter.stream_fn,
+    }};
+    var app = App{ .alloc = alloc };
+    app.auth.adapter_registry = try adapter_registry.AdapterRegistry.init(&adapters);
+    var connections = try connection_registry.Runtime.init(alloc, .{
+        .id = "test",
+        .display_name = "Test",
+        .adapter_id = "test_adapter",
+        .endpoint = "https://example.invalid",
+        .protocol = "test",
+        .credential_ref = "fx_login",
+        .remembered_model = "test/model",
+    }, null, .unavailable);
+    app.auth.adoptConnections(alloc, &connections);
+    defer app.auth.deinit(alloc);
+
+    const route = route_snapshot.RouteSnapshot{
+        .connection_id = "test",
+        .adapter_kind = "test_adapter",
+        .endpoint = "https://example.invalid",
+        .protocol = "test",
+        .credential_ref = "fx_login",
+        .primary_model_id = "test/model",
+        .permission_review_model_id = null,
+        .vision_model_id = null,
+        .subagent_model_id = "test/model",
+        .capabilities = .{},
+        .capability_source = .@"adapter-static",
+        .selected_fast_mode = false,
+        .fast_model_suffix = null,
+    };
+    var failed = false;
+    if (app.resolveRouteCredential(alloc, &route)) |value| {
+        var credential = value;
+        credential.deinit(alloc);
+    } else |err| {
+        failed = true;
+        try std.testing.expectEqual(error.CredentialAcquisitionFailed, err);
+    }
+    try std.testing.expect(failed);
+    try std.testing.expectEqual(@as(usize, 1), probe.calls);
+    try std.testing.expectEqual(@as(usize, 0), probe.fallback_reads);
 }
 
 fn fullEntryConfig() app_entry_runtime.Config {

--- a/src/main.zig
+++ b/src/main.zig
@@ -608,7 +608,7 @@ const App = struct {
             preferences.connection_id orelse session_codec.legacy_connection_id
         else
             (try self.auth.selectedConnectionProfile()).id;
-        const profile = self.auth.connectionProfile(connection_id) catch |err| switch (err) {
+        const profile = self.auth.connectionProfileForRoute(connection_id) catch |err| switch (err) {
             error.UnknownConnection => return error.MissingSessionConnection,
             else => return err,
         };
@@ -1440,7 +1440,7 @@ const App = struct {
             preferences.connection_id orelse session_codec.legacy_connection_id
         else
             (try self.auth.selectedConnectionProfile()).id;
-        const profile = self.auth.connectionProfile(connection_id) catch |err| switch (err) {
+        const profile = self.auth.connectionProfileForRoute(connection_id) catch |err| switch (err) {
             error.UnknownConnection => return error.MissingSessionConnection,
             else => return err,
         };

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const auth_runtime = @import("../../core/auth/auth_runtime.zig");
+const adapter_auth = @import("../../core/gateway/adapter_auth.zig");
 const credentials = @import("../../core/auth/credentials.zig");
-const login_flow = @import("../../core/auth/login_flow.zig");
 const picker_state = @import("../../core/input/picker_state.zig");
 const command_specs = @import("../../core/slash_commands/command_specs.zig");
 const display_width = @import("../../core/shared/display_width.zig");
@@ -230,7 +230,7 @@ fn composeOnboardingPickerRow(
 
 fn composeSignInPickerRow(
     alloc: Allocator,
-    snapshot: login_flow.SignInSnapshot,
+    snapshot: adapter_auth.SignInSnapshot,
     row_index: u16,
     width: u16,
 ) !std.ArrayList(u8) {

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -1728,8 +1728,8 @@ test "surface footer places the cursor after the Vercel team query" {
     var shell = surfaceTestShell(24, 80);
     defer shell.deinit(alloc);
     var team_id = "team_123".*;
-    var team_slug = "vercel-internal-playground".*;
-    var team_name = "Internal Playground".*;
+    var team_slug = "example-playground".*;
+    var team_name = "Example Playground".*;
     const teams = [_]adapter_auth.Team{.{
         .id = &team_id,
         .slug = &team_slug,

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -1719,7 +1719,7 @@ test "surface footer measurement reserves only the compact auth picker rows" {
 
 test "surface footer places the cursor after the Vercel team query" {
     const auth_runtime = @import("../../core/auth/auth_runtime.zig");
-    const login_flow = @import("../../core/auth/login_flow.zig");
+    const adapter_auth = @import("../../core/gateway/adapter_auth.zig");
     const alloc = std.testing.allocator;
     var approval = ApprovalPrompt{};
     defer approval.deinit(alloc);
@@ -1728,9 +1728,9 @@ test "surface footer places the cursor after the Vercel team query" {
     var shell = surfaceTestShell(24, 80);
     defer shell.deinit(alloc);
     var team_id = "team_123".*;
-    var team_slug = "example-internal-team".*;
-    var team_name = "Example Internal Team".*;
-    const teams = [_]login_flow.Team{.{
+    var team_slug = "vercel-internal-playground".*;
+    var team_name = "Internal Playground".*;
+    const teams = [_]adapter_auth.Team{.{
         .id = &team_id,
         .slug = &team_slug,
         .name = &team_name,

--- a/tests/e2e/auth-refresh.test.ts
+++ b/tests/e2e/auth-refresh.test.ts
@@ -296,6 +296,70 @@ test(
 );
 
 test(
+  "fx ask stops after a normalized forced-refresh failure",
+  async () => {
+    const home = mkdtempSync(join(tmpdir(), "fx-auth-forced-refresh-failure-e2e-"));
+    const tracePath = join(home, "trace.log");
+    writeFileSync(tracePath, "");
+    const oauth = startFakeOAuth([EXPIRED_REFRESH_TOKEN]);
+    writeFxLogin(home, oauth.issuerUrl);
+    const gateway = startFakeGateway([
+      new Response(JSON.stringify({ error: { message: "expired" } }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--no-save", "stop after the failed forced refresh"],
+        {
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: undefined,
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_SKIP_ONBOARDING: "1",
+            FX_AUTO_UPGRADE: "0",
+            FX_E2E_OAUTH_ISSUER_URL: oauth.issuerUrl,
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_MODEL: FAKE_GATEWAY_MODEL,
+            FX_TRACE_LOG: tracePath,
+            FX_TRACE_SCOPES: "gateway",
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code).toBe(1);
+      expect(gateway.requests).toHaveLength(1);
+      expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+        "GET /.well-known/openid-configuration",
+        "POST /oauth/token",
+        "GET /.well-known/openid-configuration",
+        "POST /oauth/token",
+      ]);
+      const trace = readFileSync(tracePath, "utf8");
+      const refreshFailure = trace.split("\n").find((line) =>
+        line.includes("event=credential_refresh_failed ")
+      );
+      expect(refreshFailure).toContain("source=fx_login mode=force err=CredentialRefreshFailed");
+      for (const secretValue of [EXPIRED_REFRESH_TOKEN, "seeded-refresh-token"]) {
+        expect(result.stdout).not.toContain(secretValue);
+        expect(result.stderr).not.toContain(secretValue);
+        expect(trace).not.toContain(secretValue);
+      }
+    } finally {
+      gateway.stop();
+      oauth.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT,
+);
+
+test(
   "status and doctor report an expired login instead of refreshing it",
   async () => {
     const home = mkdtempSync(join(tmpdir(), "fx-auth-expired-report-e2e-"));

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -397,6 +397,72 @@ tmuxTest(
   60_000,
 );
 
+tmuxTest(
+  "invalid credential reference stays visible and normal auth still works",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-invalid-credential-reference-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([fakeGatewayFinalText(ENV_RESPONSE)]);
+    const fxDir = join(home, ".fx");
+    mkdirSync(fxDir, { recursive: true, mode: 0o700 });
+    const settingsPath = join(fxDir, "settings.json");
+    const settings = {
+      connections: {
+        selected: "vercel",
+        profiles: [{
+          id: "vercel",
+          display_name: "Vercel AI Gateway",
+          adapter_id: "vercel_ai_gateway",
+          endpoint: gateway.chatUrl,
+          protocol: "vercel_ai_gateway",
+          credential_ref: "invalid_reference",
+          remembered_model: FAKE_GATEWAY_MODEL,
+          permission_review_model: "openai/gpt-5.4",
+        }],
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(settings) + "\n", { mode: 0o600 });
+
+    const env = {
+      HOME: home,
+      AI_GATEWAY_API_KEY: ENV_TOKEN,
+      VERCEL_OIDC_TOKEN: undefined,
+      FX_DISABLE_KEYCHAIN: "1",
+      FX_AUTO_UPGRADE: "0",
+      FX_MODEL: FAKE_GATEWAY_MODEL,
+    };
+    const status = await runFx(["status", "--json"], { env, timeoutMs: TIMEOUT });
+    expect(status.code).toBe(0);
+    expect(JSON.parse(status.stdout)).toMatchObject({
+      auth: "invalid_configuration",
+      auth_refreshable: false,
+    });
+    expect(status.stdout).not.toContain(ENV_TOKEN);
+
+    session = await startFx(home, stderrPath, gateway);
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/status");
+    await session.waitForText("auth=invalid_configuration", TIMEOUT);
+    expect(gateway.requests).toHaveLength(0);
+
+    await session.kill();
+    settings.connections.profiles[0]!.credential_ref = "automatic";
+    writeFileSync(settingsPath, JSON.stringify(settings) + "\n", { mode: 0o600 });
+    session = await startFx(home, stderrPath, gateway);
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/status");
+    await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
+    await session.sendText("use normal auth after fixing the reference");
+    await session.waitForText(ENV_RESPONSE, TIMEOUT);
+    expect(gateway.requests).toHaveLength(1);
+    expect(gateway.requests[0]!.headers.get("authorization")).toBe(`Bearer ${ENV_TOKEN}`);
+    expect(await session.captureFullScrollback()).not.toContain(ENV_TOKEN);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
 async function startFxWithoutAuth(
   testHome: string,
   testStderrPath: string,
@@ -1471,6 +1537,56 @@ tmuxTest(
       expect(trace).not.toContain(secret);
     }
     expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
+  "initial expired login refresh failure is visible before any model request",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-auth-initial-refresh-failure-"));
+    stderrPath = join(home, "stderr.log");
+    const tracePath = join(home, "trace.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    oauth = startFakeOAuth(null);
+    writeSeededFxLogin(home, Date.now() - 60_000, oauth.issuerUrl);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ credential_source: "fx_login" }) + "\n",
+      { mode: 0o600 },
+    );
+
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, tracePath);
+    await session.waitForComposer(TIMEOUT);
+    const prompt = "stop before the initial model request";
+    await session.sendText(prompt);
+    const failed = await session.waitForPane(
+      (pane) =>
+        pane.includes(prompt) &&
+        pane.includes("fx login credential refresh failed.") &&
+        pane.includes("Choose another source below"),
+      TIMEOUT,
+    );
+
+    expect(gateway.requests).toHaveLength(0);
+    expect(gateway.classifierRequests).toHaveLength(0);
+    expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
+      "GET /.well-known/openid-configuration",
+      "POST /oauth/token",
+    ]);
+    const trace = readFileSync(tracePath, "utf8");
+    for (const secret of [LOGIN_TOKEN, ENV_TOKEN, "seeded-refresh-token", oauth.providerDetail]) {
+      expect(failed).not.toContain(secret);
+      expect(trace).not.toContain(secret);
+    }
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+    await session.sendKeys("Escape");
+    await session.sendKeys("C-u");
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/quit");
+    expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
   },
   60_000,
 );


### PR DESCRIPTION
Stack: 5 of 10.
Depends on #50.
Next: #52.

Summary
- Introduce bounded adapter registry and normalized authentication outcomes.
- Resolve explicit profiles before credential, catalog, or network effects.

Verification
- zig build test
- auth refresh and source-selection flows
- ACP catalog authentication flows