### PR TITLE
Define adapter-owned authentication contracts

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -234,13 +234,30 @@ pub fn credentialOverrideSource(reference: []const u8) !adapter_auth.Source {
 
 fn normalizedCatalogAccess(access: credentials.CatalogAccess) adapter_auth.CatalogAccess {
     return switch (access) {
-        .authenticated => .authenticated,
-        .public_only => |value| .{ .public_only = switch (value) {
-            .no_credential => .no_credential,
-            .fx_login_team_required => .tenant_required,
-            .fx_login_refresh_required => .refresh_required,
-            .credential_refresh_failed => .refresh_failed,
-            .authenticated_credential_rejected => .credential_rejected,
+        .authenticated => |value| .{ .authenticated = .{
+            .source = normalizedSource(switch (value.source) {
+                .vercel_oidc_token => .vercel_oidc_token,
+                .ai_gateway_api_key => .ai_gateway_api_key,
+                .fx_login => .fx_login,
+                .stored_key => .stored_key,
+            }),
+            .credential = value.credential,
+            .team_context = value.team_context,
+        } },
+        .public_only => |value| .{ .public_only = .{
+            .reason = switch (value) {
+                .no_credential => .no_credential,
+                .fx_login_team_required => .tenant_required,
+                .fx_login_refresh_required => .refresh_required,
+                .credential_refresh_failed => .refresh_failed,
+                .authenticated_credential_rejected => .credential_rejected,
+            },
+            .source = switch (value) {
+                .no_credential => null,
+                .fx_login_team_required, .fx_login_refresh_required => normalizedSource(.fx_login),
+                .credential_refresh_failed => |source_value| normalizedSource(source_value),
+                .authenticated_credential_rejected => |source_value| normalizedSource(source_value),
+            },
         } },
     };
 }
@@ -359,6 +376,7 @@ fn logoutVercel(
         return .{ .failed = normalizeAuthFailure(err) };
     };
     return .{ .completed = .{
+        .logged_out_source_id = @tagName(credentials.Source.fx_login),
         .session_deleted = result.session_deleted,
         .local_durability_failed = result.local_durability_failed,
         .remote_revocation_failed = result.remote_revocation_failed,
@@ -381,20 +399,24 @@ fn runVercelTeams(
 
 const VercelTeamSelection = struct {
     selection: login_flow.TeamSelection,
+    origin_profile: adapter_auth.AuthProfileIdentity,
     teams: []adapter_auth.Team,
 };
 
 fn takeVercelTeamSelection(
     alloc: Allocator,
     selection: *login_flow.TeamSelection,
+    profile: connection_registry.Profile,
 ) Allocator.Error!adapter_auth.TeamSelection {
     const team_count = selection.teams.items.len;
     const state = try alloc.create(VercelTeamSelection);
     errdefer alloc.destroy(state);
     state.* = .{
         .selection = selection.take(),
+        .origin_profile = try adapter_auth.AuthProfileIdentity.init(alloc, profile),
         .teams = &.{},
     };
+    errdefer state.origin_profile.deinit(alloc);
     errdefer state.selection.deinit(alloc);
     state.teams = try alloc.alloc(adapter_auth.Team, team_count);
     for (state.selection.teams.items, 0..) |team, index| {
@@ -411,34 +433,48 @@ fn takeVercelTeamSelection(
 
 fn selectVercelTeam(raw: ?*anyopaque, alloc: Allocator, index: usize) Allocator.Error!adapter_auth.SelectOutcome {
     const state: *VercelTeamSelection = @ptrCast(@alignCast(raw.?));
-    const selected = state.selection.select(alloc, index) catch |err| {
+    var selected = state.selection.select(alloc, index) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         return .{ .failed = normalizeAuthFailure(err) };
     };
-    return .{ .selected = .{ .id = selected.id, .slug = selected.slug } };
+    errdefer selected.deinit(alloc);
+    const origin_profile = try state.origin_profile.clone(alloc);
+    return .{ .selected = .{
+        .origin_profile = origin_profile,
+        .source = normalizedSource(.fx_login),
+        .id = selected.id,
+        .slug = selected.slug,
+    } };
 }
 
 fn deinitVercelTeamSelection(raw: ?*anyopaque, alloc: Allocator) void {
     const state: *VercelTeamSelection = @ptrCast(@alignCast(raw.?));
     state.selection.deinit(alloc);
+    state.origin_profile.deinit(alloc);
     alloc.free(state.teams);
     alloc.destroy(state);
 }
 
 const VercelSignIn = struct {
     runtime: login_flow.SignInRuntime = .{},
+    origin_profile: adapter_auth.AuthProfileIdentity,
 };
 
 fn startVercelSignIn(
     raw: *const anyopaque,
     alloc: Allocator,
-    _: connection_registry.Profile,
+    profile: connection_registry.Profile,
     _: adapter_auth.AuthHost,
 ) Allocator.Error!adapter_auth.StartSignInOutcome {
     const state = try alloc.create(VercelSignIn);
-    state.* = .{};
+    const origin_profile = adapter_auth.AuthProfileIdentity.init(alloc, profile) catch |err| {
+        alloc.destroy(state);
+        return err;
+    };
+    state.* = .{ .origin_profile = origin_profile };
     const started = state.runtime.start(alloc, vercelTransport(raw)) catch |err| {
         state.runtime.deinit(alloc);
+        state.origin_profile.deinit(alloc);
         alloc.destroy(state);
         if (err == error.OutOfMemory) return error.OutOfMemory;
         if (err == error.Cancelled) return .cancelled;
@@ -446,6 +482,7 @@ fn startVercelSignIn(
     };
     if (!started) {
         state.runtime.deinit(alloc);
+        state.origin_profile.deinit(alloc);
         alloc.destroy(state);
         return .busy;
     }
@@ -494,7 +531,11 @@ fn pollVercelSignIn(raw: ?*anyopaque, alloc: Allocator) Allocator.Error!adapter_
         .succeeded => |value| blk: {
             var selection = value;
             defer selection.deinit(alloc);
-            break :blk .{ .succeeded = try takeVercelTeamSelection(alloc, &selection) };
+            break :blk .{ .succeeded = try takeVercelTeamSelection(
+                alloc,
+                &selection,
+                state.origin_profile.profile(),
+            ) };
         },
     };
 }
@@ -507,13 +548,14 @@ fn cancelVercelSignIn(raw: ?*anyopaque, alloc: Allocator) bool {
 fn deinitVercelSignIn(raw: ?*anyopaque, alloc: Allocator) void {
     const state: *VercelSignIn = @ptrCast(@alignCast(raw.?));
     state.runtime.deinit(alloc);
+    state.origin_profile.deinit(alloc);
     alloc.destroy(state);
 }
 
 fn loadVercelTeams(
     raw: *const anyopaque,
     alloc: Allocator,
-    _: connection_registry.Profile,
+    profile: connection_registry.Profile,
     _: adapter_auth.AuthHost,
 ) Allocator.Error!adapter_auth.TeamsOutcome {
     var selection = login_flow.loadTeamSelection(alloc, vercelTransport(raw)) catch |err| {
@@ -522,7 +564,7 @@ fn loadVercelTeams(
         return .{ .failed = normalizeAuthFailure(err) };
     };
     defer selection.deinit(alloc);
-    return .{ .loaded = try takeVercelTeamSelection(alloc, &selection) };
+    return .{ .loaded = try takeVercelTeamSelection(alloc, &selection, profile) };
 }
 
 fn invalidateVercelCredential(
@@ -3864,7 +3906,11 @@ const PeerAuthProbe = struct {
         return .{ .acquired = .{
             .secret_bytes = value,
             .source = .{ .id = "peer_key", .label = "peer key", .refreshable = false },
-            .catalog_access = .authenticated,
+            .catalog_access = .{ .authenticated = .{
+                .source = .{ .id = "peer_key", .label = "peer key", .refreshable = false },
+                .credential = value,
+                .team_context = null,
+            } },
         } };
     }
 };

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -701,7 +701,25 @@ const TestTeamSelection = struct {
         const team = self.teams[index];
         const id = try alloc.dupe(u8, team.slug);
         errdefer alloc.free(id);
-        return .{ .selected = .{ .id = id, .slug = try alloc.dupe(u8, team.slug) } };
+        const slug = try alloc.dupe(u8, team.slug);
+        errdefer alloc.free(slug);
+        const connection_id = try alloc.dupe(u8, "test");
+        errdefer alloc.free(connection_id);
+        const adapter_id = try alloc.dupe(u8, "test_auth");
+        errdefer alloc.free(adapter_id);
+        const credential_ref = try alloc.dupe(u8, "fx_login");
+        return .{ .selected = .{
+            .origin_profile = .{
+                .connection_id = connection_id,
+                .adapter_id = adapter_id,
+                .credential_ref = credential_ref,
+                .endpoint = null,
+                .protocol = null,
+            },
+            .source = .{ .id = "fx_login", .label = "fx login", .refreshable = true },
+            .id = id,
+            .slug = slug,
+        } };
     }
 };
 

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -2412,12 +2412,20 @@ test "connection credential resolution is exact and isolated after profile selec
                 .acquired => .{ .acquired = .{
                     .secret_bytes = try alloc.dupe(u8, "selected-secret"),
                     .source = .{ .id = "fx_login", .label = "selected login", .refreshable = true },
-                    .catalog_access = .authenticated,
+                    .catalog_access = .{ .authenticated = .{
+                        .source = .{ .id = "fx_login", .label = "selected login", .refreshable = true },
+                        .credential = "selected-secret",
+                        .team_context = null,
+                    } },
                 } },
                 .mismatched => .{ .acquired = .{
                     .secret_bytes = try alloc.dupe(u8, "wrong-source-secret"),
                     .source = .{ .id = "stored_key", .label = "wrong source", .refreshable = false },
-                    .catalog_access = .authenticated,
+                    .catalog_access = .{ .authenticated = .{
+                        .source = .{ .id = "stored_key", .label = "wrong source", .refreshable = false },
+                        .credential = "wrong-source-secret",
+                        .team_context = null,
+                    } },
                 } },
                 .missing => .{ .missing = .unavailable },
                 .failed => .{ .failed = .{ .category = .unavailable } },

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1827,7 +1827,25 @@ const TestTeamSelectionState = struct {
         const team = self.teams[index];
         const id = try alloc.dupe(u8, team.id);
         errdefer alloc.free(id);
-        return .{ .selected = .{ .id = id, .slug = try alloc.dupe(u8, team.slug) } };
+        const slug = try alloc.dupe(u8, team.slug);
+        errdefer alloc.free(slug);
+        const connection_id = try alloc.dupe(u8, "test");
+        errdefer alloc.free(connection_id);
+        const adapter_id = try alloc.dupe(u8, "test_auth");
+        errdefer alloc.free(adapter_id);
+        const credential_ref = try alloc.dupe(u8, "fx_login");
+        return .{ .selected = .{
+            .origin_profile = .{
+                .connection_id = connection_id,
+                .adapter_id = adapter_id,
+                .credential_ref = credential_ref,
+                .endpoint = null,
+                .protocol = null,
+            },
+            .source = .{ .id = "fx_login", .label = "fx login", .refreshable = true },
+            .id = id,
+            .slug = slug,
+        } };
     }
 
     fn deinit(raw: ?*anyopaque, alloc: Allocator) void {
@@ -2973,7 +2991,11 @@ test "auth runtime preserves every adapter acquisition outcome" {
                 .acquired => .{ .acquired = .{
                     .secret_bytes = try alloc.dupe(u8, "adapter-secret"),
                     .source = .{ .id = "ai_gateway_api_key", .label = "test key", .refreshable = false },
-                    .catalog_access = .authenticated,
+                    .catalog_access = .{ .authenticated = .{
+                        .source = .{ .id = "ai_gateway_api_key", .label = "test key", .refreshable = false },
+                        .credential = "adapter-secret",
+                        .team_context = null,
+                    } },
                 } },
                 .missing => .{ .missing = .unavailable },
                 .configuration => .{ .failed = .{ .category = .configuration } },

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -4058,7 +4058,11 @@ test "ask refresh handles every adapter acquisition outcome without fallback" {
                 .acquired => .{ .acquired = .{
                     .secret_bytes = try alloc.dupe(u8, "refreshed-secret"),
                     .source = .{ .id = "fx_login", .label = "test login", .refreshable = true },
-                    .catalog_access = .authenticated,
+                    .catalog_access = .{ .authenticated = .{
+                        .source = .{ .id = "fx_login", .label = "test login", .refreshable = true },
+                        .credential = "refreshed-secret",
+                        .team_context = null,
+                    } },
                 } },
                 .missing => .{ .missing = .not_attempted },
                 .failed => .{ .failed = .{ .category = .unavailable } },

--- a/src/core/gateway/adapter_auth.zig
+++ b/src/core/gateway/adapter_auth.zig
@@ -5,6 +5,341 @@ const secret = @import("../auth/secret.zig");
 
 const Allocator = std.mem.Allocator;
 
+pub const max_credential_sources: usize = 16;
+pub const max_credential_source_id_bytes: usize = 128;
+pub const max_credential_source_label_bytes: usize = 256;
+pub const max_credential_presentation_fact_bytes: usize = 256;
+pub const max_auth_service_label_bytes: usize = 256;
+
+pub const DurableWriteState = host_contract.DurableWriteState;
+
+pub const AuthServicePresentation = struct {
+    service_label: []u8,
+
+    pub fn init(alloc: Allocator, service_label: []const u8) !AuthServicePresentation {
+        try validatePresentation(service_label, max_auth_service_label_bytes);
+        return .{ .service_label = try alloc.dupe(u8, service_label) };
+    }
+
+    pub fn deinit(self: *AuthServicePresentation, alloc: Allocator) void {
+        alloc.free(self.service_label);
+        self.* = undefined;
+    }
+};
+
+pub const EnteredSecretPresentation = struct {
+    secret_kind_label: []u8,
+    verification_service_label: []u8,
+    storage_destination_label: []u8,
+
+    pub fn init(
+        alloc: Allocator,
+        secret_kind_label: []const u8,
+        verification_service_label: []const u8,
+        storage_destination_label: []const u8,
+    ) !EnteredSecretPresentation {
+        try validatePresentation(secret_kind_label, max_credential_presentation_fact_bytes);
+        try validatePresentation(verification_service_label, max_credential_presentation_fact_bytes);
+        try validatePresentation(storage_destination_label, max_credential_presentation_fact_bytes);
+        const owned_secret_kind = try alloc.dupe(u8, secret_kind_label);
+        errdefer alloc.free(owned_secret_kind);
+        const owned_verification = try alloc.dupe(u8, verification_service_label);
+        errdefer alloc.free(owned_verification);
+        return .{
+            .secret_kind_label = owned_secret_kind,
+            .verification_service_label = owned_verification,
+            .storage_destination_label = try alloc.dupe(u8, storage_destination_label),
+        };
+    }
+
+    pub fn clone(self: EnteredSecretPresentation, alloc: Allocator) !EnteredSecretPresentation {
+        return init(
+            alloc,
+            self.secret_kind_label,
+            self.verification_service_label,
+            self.storage_destination_label,
+        );
+    }
+
+    pub fn deinit(self: *EnteredSecretPresentation, alloc: Allocator) void {
+        alloc.free(self.secret_kind_label);
+        alloc.free(self.verification_service_label);
+        alloc.free(self.storage_destination_label);
+        self.* = undefined;
+    }
+};
+
+pub const AuthProfileIdentity = struct {
+    connection_id: []u8,
+    adapter_id: []u8,
+    credential_ref: []u8,
+    endpoint: ?[]u8,
+    protocol: ?[]u8,
+
+    pub fn init(alloc: Allocator, source_profile: connection_registry.Profile) !AuthProfileIdentity {
+        const connection_id = try alloc.dupe(u8, source_profile.id);
+        errdefer alloc.free(connection_id);
+        const adapter_id = try alloc.dupe(u8, source_profile.adapter_id);
+        errdefer alloc.free(adapter_id);
+        const credential_ref = try alloc.dupe(u8, source_profile.credential_ref);
+        errdefer alloc.free(credential_ref);
+        const endpoint = if (source_profile.endpoint) |value| try alloc.dupe(u8, value) else null;
+        errdefer if (endpoint) |value| alloc.free(value);
+        const protocol = if (source_profile.protocol) |value| try alloc.dupe(u8, value) else null;
+        return .{
+            .connection_id = connection_id,
+            .adapter_id = adapter_id,
+            .credential_ref = credential_ref,
+            .endpoint = endpoint,
+            .protocol = protocol,
+        };
+    }
+
+    pub fn clone(self: AuthProfileIdentity, alloc: Allocator) !AuthProfileIdentity {
+        return init(alloc, self.profile());
+    }
+
+    pub fn eqlProfile(self: AuthProfileIdentity, source_profile: connection_registry.Profile) bool {
+        return std.mem.eql(u8, self.connection_id, source_profile.id) and
+            std.mem.eql(u8, self.adapter_id, source_profile.adapter_id) and
+            std.mem.eql(u8, self.credential_ref, source_profile.credential_ref) and
+            optionalBytesEqual(self.endpoint, source_profile.endpoint) and
+            optionalBytesEqual(self.protocol, source_profile.protocol);
+    }
+
+    pub fn eqlProfileRoute(self: AuthProfileIdentity, source_profile: connection_registry.Profile) bool {
+        return std.mem.eql(u8, self.connection_id, source_profile.id) and
+            std.mem.eql(u8, self.adapter_id, source_profile.adapter_id) and
+            optionalBytesEqual(self.endpoint, source_profile.endpoint) and
+            optionalBytesEqual(self.protocol, source_profile.protocol);
+    }
+
+    pub fn profile(self: AuthProfileIdentity) connection_registry.Profile {
+        return .{
+            .id = self.connection_id,
+            .display_name = self.connection_id,
+            .adapter_id = self.adapter_id,
+            .endpoint = self.endpoint,
+            .protocol = self.protocol,
+            .credential_ref = self.credential_ref,
+            .remembered_model = self.connection_id,
+            .internal_models = .{},
+        };
+    }
+
+    pub fn deinit(self: *AuthProfileIdentity, alloc: Allocator) void {
+        alloc.free(self.connection_id);
+        alloc.free(self.adapter_id);
+        alloc.free(self.credential_ref);
+        if (self.endpoint) |value| alloc.free(value);
+        if (self.protocol) |value| alloc.free(value);
+        self.* = undefined;
+    }
+};
+
+pub const CredentialSourceDescriptor = struct {
+    id: []u8,
+    presentation_label: []u8,
+    available: bool,
+    refreshable: bool,
+    entered_secret: ?EnteredSecretPresentation = null,
+    supports_team_selection: bool,
+
+    pub fn init(
+        alloc: Allocator,
+        id: []const u8,
+        presentation_label: []const u8,
+        available: bool,
+        refreshable: bool,
+        entered_secret: ?EnteredSecretPresentation,
+        supports_team_selection: bool,
+    ) !CredentialSourceDescriptor {
+        try validateSourceId(id);
+        try validatePresentation(presentation_label, max_credential_source_label_bytes);
+        const owned_id = try alloc.dupe(u8, id);
+        errdefer alloc.free(owned_id);
+        const owned_label = try alloc.dupe(u8, presentation_label);
+        errdefer alloc.free(owned_label);
+        return .{
+            .id = owned_id,
+            .presentation_label = owned_label,
+            .available = available,
+            .refreshable = refreshable,
+            .entered_secret = if (entered_secret) |value| try value.clone(alloc) else null,
+            .supports_team_selection = supports_team_selection,
+        };
+    }
+
+    pub fn deinit(self: *CredentialSourceDescriptor, alloc: Allocator) void {
+        alloc.free(self.id);
+        alloc.free(self.presentation_label);
+        if (self.entered_secret) |*value| value.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+pub const CredentialSourceInventory = struct {
+    origin_profile: AuthProfileIdentity,
+    auth_service: AuthServicePresentation,
+    sources: []CredentialSourceDescriptor,
+
+    pub fn validate(self: CredentialSourceInventory, current_source_id: ?[]const u8) !void {
+        if (self.sources.len > max_credential_sources) return error.TooManyCredentialSources;
+        var entered_secret_count: usize = 0;
+        var active_found = current_source_id == null;
+        for (self.sources, 0..) |source_value, index| {
+            try validateSourceId(source_value.id);
+            try validatePresentation(source_value.presentation_label, max_credential_source_label_bytes);
+            if (source_value.entered_secret) |presentation| {
+                try validatePresentation(presentation.secret_kind_label, max_credential_presentation_fact_bytes);
+                try validatePresentation(presentation.verification_service_label, max_credential_presentation_fact_bytes);
+                try validatePresentation(presentation.storage_destination_label, max_credential_presentation_fact_bytes);
+                entered_secret_count += 1;
+            }
+            for (self.sources[0..index]) |previous| {
+                if (std.mem.eql(u8, previous.id, source_value.id)) return error.DuplicateCredentialSource;
+            }
+            if (current_source_id) |active| {
+                if (std.mem.eql(u8, source_value.id, active)) active_found = true;
+            }
+        }
+        if (entered_secret_count > 1) return error.AmbiguousEnteredSecretSource;
+        if (!active_found) return error.UnknownActiveCredentialSource;
+    }
+
+    pub fn deinit(self: *CredentialSourceInventory, alloc: Allocator) void {
+        self.origin_profile.deinit(alloc);
+        self.auth_service.deinit(alloc);
+        for (self.sources) |*source_value| source_value.deinit(alloc);
+        alloc.free(self.sources);
+        self.* = undefined;
+    }
+};
+
+pub const SourceInventoryRequest = struct {
+    profile: AuthProfileIdentity,
+    host: AuthHost,
+    current_source_id: ?[]const u8 = null,
+    cancel_flag: ?*const std.atomic.Value(bool) = null,
+
+    pub fn cancelled(self: SourceInventoryRequest) bool {
+        return if (self.cancel_flag) |flag| flag.load(.seq_cst) else false;
+    }
+
+    pub fn deinit(self: *SourceInventoryRequest, alloc: Allocator) void {
+        self.profile.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+pub const SourceInventoryOutcome = union(enum) {
+    loaded: CredentialSourceInventory,
+    invalid_configuration,
+    missing_capability,
+    failed: Failure,
+    cancelled,
+
+    pub fn deinit(self: *SourceInventoryOutcome, alloc: Allocator) void {
+        if (self.* == .loaded) self.loaded.deinit(alloc);
+        self.* = .invalid_configuration;
+    }
+};
+
+pub const OwnedEnteredSecret = struct {
+    bytes: []u8,
+
+    pub fn deinit(self: *OwnedEnteredSecret, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.bytes);
+        self.* = undefined;
+    }
+};
+
+pub const EnteredSecretSubmission = struct {
+    request_id: u64,
+    profile: AuthProfileIdentity,
+    source_id: []u8,
+    presentation: EnteredSecretPresentation,
+    secret_value: OwnedEnteredSecret,
+    host: AuthHost,
+    cancel_flag: ?*const std.atomic.Value(bool) = null,
+
+    pub fn cancelled(self: EnteredSecretSubmission) bool {
+        return if (self.cancel_flag) |flag| flag.load(.seq_cst) else false;
+    }
+
+    pub fn deinit(self: *EnteredSecretSubmission, alloc: Allocator) void {
+        self.profile.deinit(alloc);
+        alloc.free(self.source_id);
+        self.presentation.deinit(alloc);
+        self.secret_value.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+pub const EnteredSecretFailureStage = enum { validation, persistence, reacquisition };
+pub const EnteredSecretFailureCause = union(enum) { allocation, adapter: Failure };
+pub const EnteredSecretFailure = struct {
+    stage: EnteredSecretFailureStage,
+    cause: EnteredSecretFailureCause,
+};
+pub const EnteredSecretInvalid = enum { input, configuration, adapter_mismatch };
+pub const EnteredSecretMissing = enum { capability, source };
+
+pub const EnteredSecretTerminal = union(enum) {
+    acquired: Credential,
+    invalid: EnteredSecretInvalid,
+    missing: EnteredSecretMissing,
+    failed: EnteredSecretFailure,
+    cancelled,
+};
+
+pub const EnteredSecretOutcome = struct {
+    durable_write: DurableWriteState,
+    terminal: EnteredSecretTerminal,
+
+    pub fn deinit(self: *EnteredSecretOutcome, alloc: Allocator) void {
+        if (self.terminal == .acquired) self.terminal.acquired.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+pub const EnteredSecretCompletion = struct {
+    request_id: u64,
+    profile: AuthProfileIdentity,
+    source_id: []u8,
+    presentation: EnteredSecretPresentation,
+    outcome: EnteredSecretOutcome,
+
+    pub fn deinit(self: *EnteredSecretCompletion, alloc: Allocator) void {
+        self.profile.deinit(alloc);
+        alloc.free(self.source_id);
+        self.presentation.deinit(alloc);
+        self.outcome.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+fn validatePresentation(value: []const u8, max_bytes: usize) !void {
+    if (value.len == 0 or value.len > max_bytes or !std.unicode.utf8ValidateSlice(value)) {
+        return error.InvalidAuthPresentation;
+    }
+    for (value) |byte| if (std.ascii.isControl(byte)) return error.InvalidAuthPresentation;
+}
+
+fn validateSourceId(value: []const u8) !void {
+    if (value.len == 0 or value.len > max_credential_source_id_bytes) return error.InvalidCredentialSourceId;
+    for (value) |byte| {
+        if (!(std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '-' or byte == '.' or byte == ':')) {
+            return error.InvalidCredentialSourceId;
+        }
+    }
+}
+
+fn optionalBytesEqual(left: ?[]const u8, right: ?[]const u8) bool {
+    if (left == null or right == null) return left == null and right == null;
+    return std.mem.eql(u8, left.?, right.?);
+}
+
 pub const RefreshMode = enum {
     stored,
     if_needed,
@@ -56,9 +391,56 @@ pub const CatalogPublicOnlyReason = enum {
     credential_rejected,
 };
 
+pub const CatalogPublicOnly = struct {
+    reason: CatalogPublicOnlyReason,
+    source: ?Source = null,
+};
+
 pub const CatalogAccess = union(enum) {
-    public_only: CatalogPublicOnlyReason,
-    authenticated,
+    public_only: CatalogPublicOnly,
+    authenticated: struct {
+        source: Source,
+        credential: []const u8,
+        team_context: ?[]const u8,
+    },
+
+    pub fn credentialSource(self: CatalogAccess) ?Source {
+        return switch (self) {
+            .public_only => |access| access.source,
+            .authenticated => |access| access.source,
+        };
+    }
+
+    pub fn publicOnlyReason(self: CatalogAccess) ?CatalogPublicOnlyReason {
+        return switch (self) {
+            .public_only => |access| access.reason,
+            .authenticated => null,
+        };
+    }
+
+    pub fn teamContext(self: CatalogAccess) ?[]const u8 {
+        return switch (self) {
+            .public_only => null,
+            .authenticated => |access| access.team_context,
+        };
+    }
+
+    pub fn authorizationCredential(self: CatalogAccess) ?[]const u8 {
+        return switch (self) {
+            .public_only => null,
+            .authenticated => |access| access.credential,
+        };
+    }
+
+    pub fn publicFallbackAfterRejection(self: CatalogAccess) ?CatalogAccess {
+        return switch (self) {
+            .public_only => null,
+            .authenticated => |access| .{ .public_only = .{
+                .reason = .credential_rejected,
+                .source = access.source,
+            } },
+        };
+    }
 };
 
 /// One adapter-produced credential. The auth runtime owns an acquired value and
@@ -76,6 +458,27 @@ pub const Credential = struct {
         if (self.tenant_id) |value| alloc.free(value);
         if (self.tenant_slug) |value| alloc.free(value);
         self.* = undefined;
+    }
+
+    pub fn tenantContext(self: Credential) ?[]const u8 {
+        return self.tenant_id orelse self.tenant_slug;
+    }
+
+    pub fn takeTenantContext(self: *Credential) ?[]u8 {
+        if (self.tenant_id) |value| {
+            self.tenant_id = null;
+            return value;
+        }
+        if (self.tenant_slug) |value| {
+            self.tenant_slug = null;
+            return value;
+        }
+        return null;
+    }
+
+    pub fn needsRefreshAt(self: Credential, now_ms: i64) bool {
+        const refresh_after_ms = self.refresh_after_ms orelse return false;
+        return now_ms >= refresh_after_ms;
     }
 };
 
@@ -111,6 +514,7 @@ pub const OperationOutcome = union(enum) {
 };
 
 pub const LogoutResult = struct {
+    logged_out_source_id: ?[]const u8 = null,
     session_deleted: bool = false,
     local_durability_failed: bool = false,
     remote_revocation_failed: bool = false,
@@ -144,10 +548,13 @@ pub const Team = struct {
 };
 
 pub const SelectedTeam = struct {
+    origin_profile: AuthProfileIdentity,
+    source: Source,
     id: []u8,
     slug: []u8,
 
     pub fn deinit(self: *SelectedTeam, alloc: Allocator) void {
+        self.origin_profile.deinit(alloc);
         alloc.free(self.id);
         alloc.free(self.slug);
         self.* = undefined;
@@ -267,11 +674,13 @@ pub const StartSignInOutcome = union(enum) {
 pub const Status = struct {
     source: ?Source = null,
     team: ?[]u8 = null,
+    missing_help: ?[]u8 = null,
     store_status: StoreStatus = .not_attempted,
     expired: bool = false,
 
     pub fn deinit(self: *Status, alloc: Allocator) void {
         if (self.team) |value| alloc.free(value);
+        if (self.missing_help) |value| alloc.free(value);
         self.* = .{};
     }
 };
@@ -299,6 +708,8 @@ pub const TeamsOutcome = union(enum) {
 const LoadTeamsFn = *const fn (*const anyopaque, Allocator, connection_registry.Profile, AuthHost) Allocator.Error!TeamsOutcome;
 const InvalidateFn = *const fn (*const anyopaque, connection_registry.Profile, Failure) Invalidation;
 const StatusFn = *const fn (*const anyopaque, Allocator, connection_registry.Profile, AuthHost) Allocator.Error!StatusOutcome;
+const SourceInventoryFn = *const fn (*const anyopaque, Allocator, *SourceInventoryRequest) Allocator.Error!SourceInventoryOutcome;
+const SubmitEnteredSecretFn = *const fn (*const anyopaque, Allocator, *EnteredSecretSubmission) EnteredSecretCompletion;
 
 const unavailable_context: u8 = 0;
 
@@ -334,8 +745,20 @@ fn unavailableStatus(_: *const anyopaque, _: Allocator, _: connection_registry.P
     return .{ .failed = .{ .category = .unavailable } };
 }
 
+fn unavailableSourceInventory(_: *const anyopaque, _: Allocator, _: *SourceInventoryRequest) Allocator.Error!SourceInventoryOutcome {
+    return .missing_capability;
+}
+
+fn unavailableSubmitEnteredSecret(_: *const anyopaque, alloc: Allocator, submission: *EnteredSecretSubmission) EnteredSecretCompletion {
+    return takeEnteredSecretCompletion(alloc, submission, .{
+        .durable_write = .unchanged,
+        .terminal = .{ .missing = .capability },
+    });
+}
+
 pub const Provider = struct {
     kind: []const u8,
+    auth_service_label: ?[]const u8 = null,
     context: *const anyopaque = &unavailable_context,
     acquire_fn: AcquireFn = unavailableAcquire,
     login_fn: LoginFn = unavailableLogin,
@@ -345,6 +768,8 @@ pub const Provider = struct {
     load_teams_fn: LoadTeamsFn = unavailableLoadTeams,
     invalidate_fn: InvalidateFn = unavailableInvalidate,
     status_fn: StatusFn = unavailableStatus,
+    source_inventory_fn: SourceInventoryFn = unavailableSourceInventory,
+    submit_entered_secret_fn: SubmitEnteredSecretFn = unavailableSubmitEnteredSecret,
 
     pub fn acquire(self: Provider, alloc: Allocator, request: Request) (Allocator.Error || error{AdapterMismatch})!Acquisition {
         try self.validateProfile(request.profile);
@@ -393,10 +818,67 @@ pub const Provider = struct {
         return self.status_fn(self.context, alloc, profile, auth_host);
     }
 
+    pub fn authServicePresentation(self: Provider, alloc: Allocator) !AuthServicePresentation {
+        const label = self.auth_service_label orelse return error.MissingAuthPresentation;
+        return AuthServicePresentation.init(alloc, label);
+    }
+
+    pub fn sourceInventory(
+        self: Provider,
+        alloc: Allocator,
+        request: *SourceInventoryRequest,
+    ) (Allocator.Error || error{AdapterMismatch})!SourceInventoryOutcome {
+        try self.validateProfile(request.profile.profile());
+        if (request.cancelled()) return .cancelled;
+        var outcome = try self.source_inventory_fn(self.context, alloc, request);
+        if (!request.cancelled()) return outcome;
+        outcome.deinit(alloc);
+        return .cancelled;
+    }
+
+    pub fn submitEnteredSecret(
+        self: Provider,
+        alloc: Allocator,
+        submission: *EnteredSecretSubmission,
+    ) EnteredSecretCompletion {
+        self.validateProfile(submission.profile.profile()) catch {
+            return takeEnteredSecretCompletion(alloc, submission, .{
+                .durable_write = .unchanged,
+                .terminal = .{ .invalid = .adapter_mismatch },
+            });
+        };
+        if (submission.cancelled()) {
+            return takeEnteredSecretCompletion(alloc, submission, .{
+                .durable_write = .unchanged,
+                .terminal = .cancelled,
+            });
+        }
+        return self.submit_entered_secret_fn(self.context, alloc, submission);
+    }
+
     fn validateProfile(self: Provider, profile: connection_registry.Profile) error{AdapterMismatch}!void {
         if (!std.mem.eql(u8, profile.adapter_id, self.kind)) return error.AdapterMismatch;
     }
 };
+
+pub fn takeEnteredSecretCompletion(
+    alloc: Allocator,
+    submission: *EnteredSecretSubmission,
+    outcome: EnteredSecretOutcome,
+) EnteredSecretCompletion {
+    submission.secret_value.deinit(alloc);
+    const completion = EnteredSecretCompletion{
+        .request_id = submission.request_id,
+        .profile = submission.profile,
+        .source_id = submission.source_id,
+        .presentation = submission.presentation,
+        .outcome = outcome,
+    };
+    submission.profile = undefined;
+    submission.source_id = &.{};
+    submission.presentation = undefined;
+    return completion;
+}
 
 /// Pure retry state owned by one admitted workload. It permits no more than one
 /// forced refresh after an unauthorized response.
@@ -427,7 +909,11 @@ test "credential destruction zeroes secret bytes" {
     var credential = Credential{
         .secret_bytes = try alloc.dupe(u8, "adapter-secret"),
         .source = .{ .id = "test", .label = "test", .refreshable = false },
-        .catalog_access = .authenticated,
+        .catalog_access = .{ .authenticated = .{
+            .source = .{ .id = "test", .label = "test", .refreshable = false },
+            .credential = "adapter-secret",
+            .team_context = null,
+        } },
     };
     credential.deinit(alloc);
     try std.testing.expect(std.mem.indexOf(u8, &backing, "adapter-secret") == null);
@@ -447,6 +933,109 @@ test "status serialization is redacted" {
     try std.testing.expect(std.mem.indexOf(u8, text, "peer login") != null);
 }
 
+fn inventoryForValidationTest(sources: []CredentialSourceDescriptor) CredentialSourceInventory {
+    return .{
+        .origin_profile = .{
+            .connection_id = @constCast("test"),
+            .adapter_id = @constCast("test"),
+            .credential_ref = @constCast("automatic"),
+            .endpoint = null,
+            .protocol = null,
+        },
+        .auth_service = .{ .service_label = @constCast("Test Service") },
+        .sources = sources,
+    };
+}
+
+test "credential source inventory enforces every bound and identity invariant" {
+    var empty = inventoryForValidationTest(&.{});
+    try empty.validate(null);
+    try std.testing.expectError(error.UnknownActiveCredentialSource, empty.validate("missing"));
+
+    var sources: [max_credential_sources + 1]CredentialSourceDescriptor = undefined;
+    const ids = [_][]const u8{
+        "source-00", "source-01", "source-02", "source-03",
+        "source-04", "source-05", "source-06", "source-07",
+        "source-08", "source-09", "source-10", "source-11",
+        "source-12", "source-13", "source-14", "source-15",
+        "source-16",
+    };
+    for (&sources, ids) |*source_value, id| source_value.* = .{
+        .id = @constCast(id),
+        .presentation_label = @constCast("Credential source"),
+        .available = true,
+        .refreshable = false,
+        .supports_team_selection = false,
+    };
+
+    var bounded = inventoryForValidationTest(sources[0..max_credential_sources]);
+    try bounded.validate("source-15");
+    var oversized = inventoryForValidationTest(&sources);
+    try std.testing.expectError(error.TooManyCredentialSources, oversized.validate(null));
+
+    sources[1].id = sources[0].id;
+    try std.testing.expectError(error.DuplicateCredentialSource, bounded.validate(null));
+    sources[1].id = @constCast(ids[1]);
+    sources[1].id = @constCast("invalid source");
+    try std.testing.expectError(error.InvalidCredentialSourceId, bounded.validate(null));
+    sources[1].id = @constCast(ids[1]);
+
+    sources[1].presentation_label = @constCast("bad\nlabel");
+    try std.testing.expectError(error.InvalidAuthPresentation, bounded.validate(null));
+    sources[1].presentation_label = @constCast("Credential source");
+    const long_label = "x" ** (max_credential_source_label_bytes + 1);
+    sources[1].presentation_label = @constCast(long_label);
+    try std.testing.expectError(error.InvalidAuthPresentation, bounded.validate(null));
+    sources[1].presentation_label = @constCast("Credential source");
+
+    sources[0].entered_secret = .{
+        .secret_kind_label = @constCast(""),
+        .verification_service_label = @constCast("Verification service"),
+        .storage_destination_label = @constCast("Credential store"),
+    };
+    try std.testing.expectError(error.InvalidAuthPresentation, bounded.validate(null));
+    sources[0].entered_secret.?.secret_kind_label = @constCast("API key");
+    sources[1].entered_secret = .{
+        .secret_kind_label = @constCast("Peer key"),
+        .verification_service_label = @constCast("Verification service"),
+        .storage_destination_label = @constCast("Credential store"),
+    };
+    try std.testing.expectError(error.AmbiguousEnteredSecretSource, bounded.validate(null));
+}
+
+fn exerciseSubmissionOwnershipAllocation(alloc: Allocator) !void {
+    const profile = testProfile("peer");
+    var identity = try AuthProfileIdentity.init(alloc, profile);
+    errdefer identity.deinit(alloc);
+    const source_id = try alloc.dupe(u8, "peer_key");
+    errdefer alloc.free(source_id);
+    var presentation = try EnteredSecretPresentation.init(
+        alloc,
+        "API key",
+        "Example Cloud Gateway",
+        "test credential store",
+    );
+    errdefer presentation.deinit(alloc);
+    const secret_bytes = try alloc.dupe(u8, "submission-secret");
+    var submission = EnteredSecretSubmission{
+        .request_id = 1,
+        .profile = identity,
+        .source_id = source_id,
+        .presentation = presentation,
+        .secret_value = .{ .bytes = secret_bytes },
+        .host = .{ .secret_store = host_contract.unavailable_secret_store },
+    };
+    submission.deinit(alloc);
+}
+
+test "entered-secret submission ownership cleans every induced allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        exerciseSubmissionOwnershipAllocation,
+        .{},
+    );
+}
+
 const TestProviderState = struct {
     acquire_calls: usize = 0,
     invalidate_calls: usize = 0,
@@ -460,7 +1049,11 @@ const TestProviderState = struct {
         return .{ .acquired = .{
             .secret_bytes = try alloc.dupe(u8, "peer-secret"),
             .source = .{ .id = "peer_login", .label = "peer login", .refreshable = true },
-            .catalog_access = .authenticated,
+            .catalog_access = .{ .authenticated = .{
+                .source = .{ .id = "peer_login", .label = "peer login", .refreshable = true },
+                .credential = "peer-secret",
+                .team_context = null,
+            } },
         } };
     }
 

--- a/src/core/gateway/connection_registry.zig
+++ b/src/core/gateway/connection_registry.zig
@@ -203,6 +203,25 @@ pub const Snapshot = struct {
     profiles: []const Profile,
 };
 
+/// Borrowed semantic identity for one in-flight authentication operation.
+/// Display and model fields are intentionally excluded because they cannot
+/// retarget credential persistence.
+pub const AuthIdentity = struct {
+    connection_id: []const u8,
+    adapter_id: []const u8,
+    credential_ref: []const u8,
+    endpoint: ?[]const u8,
+    protocol: ?[]const u8,
+};
+
+pub const CredentialReferenceUpdate = union(enum) {
+    unchanged_same_reference,
+    updated,
+    updated_persistence_indeterminate: anyerror,
+    stale_origin,
+    failed_before_commit: anyerror,
+};
+
 /// Owned persisted representation. It contains references and profile metadata,
 /// never credential bytes or live authentication state.
 pub const Stored = struct {
@@ -473,6 +492,77 @@ pub const Runtime = struct {
         try self.commit(&next);
     }
 
+    /// Compare the complete captured auth identity and update only its exact
+    /// origin profile. Definite pre-publication failure leaves the runtime
+    /// untouched; indeterminate persistence publishes the in-memory update to
+    /// match the registry's existing commit rule.
+    pub fn compareAndRememberCredentialReference(
+        self: *Self,
+        identity: AuthIdentity,
+        credential_ref: []const u8,
+    ) CredentialReferenceUpdate {
+        return self.compareAndPublishCredentialReferenceImpl(
+            identity,
+            credential_ref,
+            false,
+        );
+    }
+
+    /// Publishes the canonical snapshot even when the reference already
+    /// matches, allowing a compatibility field outside the registry to be
+    /// removed by the same persistence transaction.
+    pub fn compareAndPublishCredentialReference(
+        self: *Self,
+        identity: AuthIdentity,
+        credential_ref: []const u8,
+    ) CredentialReferenceUpdate {
+        return self.compareAndPublishCredentialReferenceImpl(
+            identity,
+            credential_ref,
+            true,
+        );
+    }
+
+    fn compareAndPublishCredentialReferenceImpl(
+        self: *Self,
+        identity: AuthIdentity,
+        credential_ref: []const u8,
+        publish_same_reference: bool,
+    ) CredentialReferenceUpdate {
+        validateIdentifier(credential_ref) catch |err| return .{ .failed_before_commit = err };
+        const index = self.indexOf(identity.connection_id) orelse return .stale_origin;
+        const current = self.profiles.items[index];
+        if (!std.mem.eql(u8, current.adapter_id, identity.adapter_id) or
+            !std.mem.eql(u8, current.credential_ref, identity.credential_ref) or
+            !optionalStringsEqual(current.endpoint, identity.endpoint) or
+            !optionalStringsEqual(current.protocol, identity.protocol)) return .stale_origin;
+        const same_reference = std.mem.eql(u8, current.credential_ref, credential_ref);
+        if (same_reference and !publish_same_reference) {
+            return .unchanged_same_reference;
+        }
+
+        var next = self.clone() catch |err| return .{ .failed_before_commit = err };
+        defer next.deinit();
+        if (!same_reference) {
+            const replacement = self.alloc.dupe(u8, credential_ref) catch |err|
+                return .{ .failed_before_commit = err };
+            self.alloc.free(next.profiles.items[index].credential_ref);
+            next.profiles.items[index].credential_ref = replacement;
+        }
+        const outcome = self.persistence.write(self.alloc, next.snapshot()) catch |err|
+            return .{ .failed_before_commit = err };
+
+        for (self.profiles.items) |*profile_value| profile_value.deinit(self.alloc);
+        self.profiles.deinit(self.alloc);
+        self.profiles = next.profiles;
+        self.selected_index = next.selected_index;
+        next.profiles = .empty;
+        return switch (outcome) {
+            .committed => .updated,
+            .replaced_indeterminate => |err| .{ .updated_persistence_indeterminate = err },
+        };
+    }
+
     pub fn markConnected(self: *Self, id: []const u8) error{UnknownConnection}!void {
         const index = self.indexOf(id) orelse return error.UnknownConnection;
         self.profiles.items[index].auth = .connected;
@@ -570,6 +660,10 @@ pub fn parseStored(alloc: Allocator, value: std.json.Value) !Stored {
 
 pub fn validate(snapshot_value: Snapshot) !void {
     try validateSnapshot(snapshot_value);
+}
+
+pub fn validateCredentialReference(value: []const u8) !void {
+    try validateIdentifier(value);
 }
 
 fn validateSnapshot(snapshot: Snapshot) !void {

--- a/src/core/hosts/host.zig
+++ b/src/core/hosts/host.zig
@@ -88,6 +88,21 @@ pub const SecretStoreWriteError = std.mem.Allocator.Error || error{
     StoredKeyWriteFailed,
 };
 
+pub const DurableWriteState = enum {
+    unchanged,
+    replaced,
+    indeterminate,
+};
+
+pub const SecretStoreWriteReport = struct {
+    durable_write: DurableWriteState,
+    failure: ?SecretStoreWriteError = null,
+
+    pub fn valid(self: SecretStoreWriteReport) bool {
+        return self.durable_write == .replaced or self.failure != null;
+    }
+};
+
 pub const SecretStore = struct {
     context: ?*anyopaque = null,
     backend_label: []const u8,
@@ -104,6 +119,11 @@ pub const SecretStore = struct {
     store_interactive_fn: *const fn (
         ?*anyopaque,
     ) SecretStoreWriteError!bool,
+    store_with_disposition_fn: *const fn (
+        ?*anyopaque,
+        std.mem.Allocator,
+        []const u8,
+    ) SecretStoreWriteReport = unavailableSecretStoreWriteWithDisposition,
 
     pub fn isDisabled(self: SecretStore) bool {
         return self.is_disabled_fn(self.context);
@@ -133,6 +153,16 @@ pub const SecretStore = struct {
         self: SecretStore,
     ) SecretStoreWriteError!bool {
         return self.store_interactive_fn(self.context);
+    }
+
+    pub fn storeWithDisposition(
+        self: SecretStore,
+        alloc: std.mem.Allocator,
+        value: []const u8,
+    ) SecretStoreWriteReport {
+        const report = self.store_with_disposition_fn(self.context, alloc, value);
+        std.debug.assert(report.valid());
+        return report;
     }
 };
 
@@ -167,6 +197,14 @@ fn unavailableSecretStoreInteractiveWrite(
     _: ?*anyopaque,
 ) SecretStoreWriteError!bool {
     return false;
+}
+
+fn unavailableSecretStoreWriteWithDisposition(
+    _: ?*anyopaque,
+    _: std.mem.Allocator,
+    _: []const u8,
+) SecretStoreWriteReport {
+    return .{ .durable_write = .unchanged, .failure = error.StoredKeyWriteFailed };
 }
 
 pub const ClipboardError = error{CopyFailed};

--- a/src/main.zig
+++ b/src/main.zig
@@ -3557,7 +3557,11 @@ test "interactive route credential resolution keeps the admitted source exact" {
             return .{ .acquired = .{
                 .secret_bytes = try alloc.dupe(u8, "fallback-secret"),
                 .source = .{ .id = "ai_gateway_api_key", .label = "fallback", .refreshable = false },
-                .catalog_access = .authenticated,
+                .catalog_access = .{ .authenticated = .{
+                    .source = .{ .id = "ai_gateway_api_key", .label = "fallback", .refreshable = false },
+                    .credential = "fallback-secret",
+                    .team_context = null,
+                } },
             } };
         }
     };

--- a/src/napi_core_main.zig
+++ b/src/napi_core_main.zig
@@ -490,6 +490,7 @@ const Runtime = struct {
     fn authProvider(self: *Runtime) adapter_auth.Provider {
         return .{
             .kind = builtin_gateway.connection_seed.adapter_id,
+            .auth_service_label = "Vercel",
             .context = self,
             .acquire_fn = acquireCredential,
             .status_fn = credentialStatus,
@@ -505,10 +506,15 @@ const Runtime = struct {
         if (self.credential.len == 0) return .{ .missing = .not_found };
         const source = builtin_gateway.credentialOverrideSource(request.profile.credential_ref) catch
             return .{ .failed = .{ .category = .configuration } };
+        const credential = try alloc.dupe(u8, self.credential);
         return .{ .acquired = .{
-            .secret_bytes = try alloc.dupe(u8, self.credential),
+            .secret_bytes = credential,
             .source = source,
-            .catalog_access = .authenticated,
+            .catalog_access = .{ .authenticated = .{
+                .source = source,
+                .credential = credential,
+                .team_context = null,
+            } },
         } };
     }
 


### PR DESCRIPTION
Stack: 8 of 10.
Depends on #53.
Next: #55.

Summary
- Add bounded source inventory, entered-secret, presentation, and durable-write contracts.
- Pin profile identity and exact-origin credential adoption without adding another store owner.

Verification
- zig build test
- allocation and identity state tests
- fresh binary help and status smoke