### PR TITLE
Implement the Vercel authentication provider

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -48,6 +48,7 @@ pub fn build(b: *std.Build) void {
     build_options.addOption([]const u8, "app_version", app_version);
     build_options.addOption([]const u8, "update_channel", @tagName(update_channel));
     build_options.addOption(WasmSurface, "wasm_surface", .none);
+    build_options.addOption(bool, "native_auth_e2e", false);
 
     const exe = b.addExecutable(.{
         .name = "fx",
@@ -76,6 +77,38 @@ pub fn build(b: *std.Build) void {
 
     const run_step = b.step("run", "Run fx");
     run_step.dependOn(&run_cmd.step);
+
+    const native_auth_e2e_options = b.addOptions();
+    native_auth_e2e_options.addOption([]const u8, "git_commit", git_commit);
+    native_auth_e2e_options.addOption([]const u8, "app_version", app_version);
+    native_auth_e2e_options.addOption([]const u8, "update_channel", @tagName(update_channel));
+    native_auth_e2e_options.addOption(WasmSurface, "wasm_surface", .none);
+    native_auth_e2e_options.addOption(bool, "native_auth_e2e", true);
+    const native_auth_e2e = b.addExecutable(.{
+        .name = "fx-native-auth-e2e",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+            .stack_check = false,
+            .stack_protector = false,
+            .omit_frame_pointer = true,
+            .unwind_tables = .none,
+            .error_tracing = false,
+            .strip = optimize != .Debug,
+        }),
+    });
+    native_auth_e2e.root_module.addImport(
+        "build_options",
+        native_auth_e2e_options.createModule(),
+    );
+    const install_native_auth_e2e = b.addInstallArtifact(native_auth_e2e, .{});
+    const native_auth_e2e_step = b.step(
+        "native-auth-e2e",
+        "Build the isolated native authentication E2E fixture",
+    );
+    native_auth_e2e_step.dependOn(&install_native_auth_e2e.step);
 
     const exe_tests = b.addTest(.{
         .root_module = exe.root_module,
@@ -335,6 +368,7 @@ fn addWasmArtifact(
     wasm_options.addOption([]const u8, "app_version", app_version);
     wasm_options.addOption([]const u8, "update_channel", @tagName(update_channel));
     wasm_options.addOption(WasmSurface, "wasm_surface", surface);
+    wasm_options.addOption(bool, "native_auth_e2e", false);
 
     const wasm_root = switch (surface) {
         .core => "src/wasm_core_main.zig",

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -150,6 +150,7 @@ pub const agent_stream_provider = agent_stream_provider_contract.Provider{
 pub fn auth_provider_for_transport(transport: *const oauth_transport.Provider) adapter_auth.Provider {
     return .{
         .kind = connection_seed.adapter_id,
+        .auth_service_label = "Vercel",
         .context = transport,
         .acquire_fn = acquireVercelCredential,
         .logout_fn = logoutVercel,
@@ -157,6 +158,8 @@ pub fn auth_provider_for_transport(transport: *const oauth_transport.Provider) a
         .load_teams_fn = loadVercelTeams,
         .invalidate_fn = invalidateVercelCredential,
         .status_fn = loadVercelStatus,
+        .source_inventory_fn = loadVercelSourceInventory,
+        .submit_entered_secret_fn = submitVercelEnteredSecret,
     };
 }
 
@@ -590,6 +593,10 @@ fn loadVercelStatus(
     var credential = switch (acquisition) {
         .acquired => |value| value,
         .missing => |store_status| return .{ .loaded = .{
+            .missing_help = if (store_status == .unavailable)
+                try alloc.dupe(u8, credentials.unreadable_store_message)
+            else
+                null,
             .store_status = store_status,
         } },
         .failed => |failure| return .{ .failed = failure },
@@ -608,6 +615,224 @@ fn loadVercelStatus(
         .team = owned_team,
         .expired = if (credential.refresh_after_ms) |deadline| deadline <= io_mod.milliTimestamp() else false,
     } };
+}
+
+const vercel_credential_source_order = [_]credentials.Source{
+    .vercel_oidc_token,
+    .ai_gateway_api_key,
+    .fx_login,
+    .stored_key,
+};
+
+fn loadVercelSourceInventory(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    request: *adapter_auth.SourceInventoryRequest,
+) Allocator.Error!adapter_auth.SourceInventoryOutcome {
+    var sources: std.ArrayList(adapter_auth.CredentialSourceDescriptor) = .empty;
+    errdefer {
+        for (sources.items) |*source_value| source_value.deinit(alloc);
+        sources.deinit(alloc);
+    }
+
+    for (vercel_credential_source_order) |source_value| {
+        if (request.cancelled()) return .cancelled;
+        const available = credentials.sourceExists(alloc, request.host.secret_store, source_value) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return .{ .failed = normalizeAuthFailure(err) };
+        };
+        const active = if (request.current_source_id) |id|
+            std.mem.eql(u8, id, @tagName(source_value))
+        else
+            false;
+        if (!available and !active and source_value != .stored_key) continue;
+
+        var entered_secret: ?adapter_auth.EnteredSecretPresentation = if (source_value == .stored_key)
+            adapter_auth.EnteredSecretPresentation.init(
+                alloc,
+                "API key",
+                "AI Gateway",
+                request.host.secret_store.backend_label,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return .invalid_configuration,
+            }
+        else
+            null;
+        defer if (entered_secret) |*value| value.deinit(alloc);
+        var descriptor = adapter_auth.CredentialSourceDescriptor.init(
+            alloc,
+            @tagName(source_value),
+            credentials.sourceLabel(source_value),
+            available or active,
+            credentials.sourceRefreshable(source_value),
+            entered_secret,
+            source_value == .fx_login and (available or active),
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return .invalid_configuration,
+        };
+        sources.append(alloc, descriptor) catch |err| {
+            descriptor.deinit(alloc);
+            return err;
+        };
+    }
+
+    const owned_sources = try sources.toOwnedSlice(alloc);
+    errdefer {
+        for (owned_sources) |*source_value| source_value.deinit(alloc);
+        alloc.free(owned_sources);
+    }
+    var auth_service = adapter_auth.AuthServicePresentation.init(alloc, "Vercel") catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => unreachable,
+    };
+    errdefer auth_service.deinit(alloc);
+    const origin_profile = try request.profile.clone(alloc);
+    var inventory = adapter_auth.CredentialSourceInventory{
+        .origin_profile = origin_profile,
+        .auth_service = auth_service,
+        .sources = owned_sources,
+    };
+    inventory.validate(request.current_source_id) catch {
+        inventory.deinit(alloc);
+        return .invalid_configuration;
+    };
+    if (request.cancelled()) {
+        inventory.deinit(alloc);
+        return .cancelled;
+    }
+    _ = raw;
+    return .{ .loaded = inventory };
+}
+
+fn submitVercelEnteredSecret(
+    raw: *const anyopaque,
+    alloc: Allocator,
+    submission: *adapter_auth.EnteredSecretSubmission,
+) adapter_auth.EnteredSecretCompletion {
+    return submitVercelEnteredSecretWithValidator(raw, api_key_validator, alloc, submission);
+}
+
+fn submitVercelEnteredSecretWithValidator(
+    raw: *const anyopaque,
+    validator: api_key_validator_contract.Provider,
+    alloc: Allocator,
+    submission: *adapter_auth.EnteredSecretSubmission,
+) adapter_auth.EnteredSecretCompletion {
+    if (!std.mem.eql(u8, submission.source_id, @tagName(credentials.Source.stored_key))) {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .unchanged,
+            .terminal = .{ .missing = .source },
+        });
+    }
+    if (submission.secret_value.bytes.len == 0) {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .unchanged,
+            .terminal = .{ .invalid = .input },
+        });
+    }
+    if (submission.cancelled()) {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .unchanged,
+            .terminal = .cancelled,
+        });
+    }
+
+    switch (validator.validate(alloc, submission.secret_value.bytes)) {
+        .accepted => {},
+        .refused => return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .unchanged,
+            .terminal = .{ .failed = .{
+                .stage = .validation,
+                .cause = .{ .adapter = .{ .category = .denied } },
+            } },
+        }),
+        .unavailable => return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .unchanged,
+            .terminal = .{ .failed = .{
+                .stage = .validation,
+                .cause = .{ .adapter = .{ .category = .unavailable } },
+            } },
+        }),
+    }
+    if (submission.cancelled()) {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .unchanged,
+            .terminal = .cancelled,
+        });
+    }
+
+    const report = submission.host.secret_store.storeWithDisposition(alloc, submission.secret_value.bytes);
+    if (submission.cancelled()) {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = report.durable_write,
+            .terminal = .cancelled,
+        });
+    }
+    if (report.failure != null) {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = report.durable_write,
+            .terminal = .{ .failed = .{
+                .stage = .persistence,
+                .cause = .{ .adapter = .{ .category = .persistence } },
+            } },
+        });
+    }
+    if (report.durable_write != .replaced) {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = report.durable_write,
+            .terminal = .{ .invalid = .configuration },
+        });
+    }
+
+    const loaded = credentials.resolveExact(
+        alloc,
+        vercelTransport(raw),
+        submission.host.secret_store,
+        .refresh_if_needed,
+        .stored_key,
+    ) catch |err| {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .replaced,
+            .terminal = .{ .failed = .{
+                .stage = .reacquisition,
+                .cause = if (err == error.OutOfMemory)
+                    .allocation
+                else
+                    .{ .adapter = normalizeAuthFailure(err) },
+            } },
+        });
+    };
+    var credential = loaded.credential orelse {
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .replaced,
+            .terminal = .{ .failed = .{
+                .stage = .reacquisition,
+                .cause = .{ .adapter = .{ .category = .unavailable } },
+            } },
+        });
+    };
+    defer credential.deinit(alloc);
+    var normalized = takeNormalizedCredential(&credential);
+    if (!std.mem.eql(u8, normalized.source.id, submission.source_id)) {
+        normalized.deinit(alloc);
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .replaced,
+            .terminal = .{ .invalid = .configuration },
+        });
+    }
+    if (submission.cancelled()) {
+        normalized.deinit(alloc);
+        return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+            .durable_write = .replaced,
+            .terminal = .cancelled,
+        });
+    }
+    return adapter_auth.takeEnteredSecretCompletion(alloc, submission, .{
+        .durable_write = .replaced,
+        .terminal = .{ .acquired = normalized },
+    });
 }
 
 const AdapterEventBridge = struct {
@@ -3891,6 +4116,258 @@ const AdapterAuthStoreProbe = struct {
     }
 };
 
+const EnteredSecretValidationProbe = struct {
+    result: api_key_validator_contract.Result = .accepted,
+    calls: usize = 0,
+    cancel_after: ?*std.atomic.Value(bool) = null,
+
+    fn provider(self: *@This()) api_key_validator_contract.Provider {
+        return .{ .context = self, .validate_fn = validate };
+    }
+
+    fn validate(
+        raw: ?*anyopaque,
+        _: Allocator,
+        _: []const u8,
+    ) api_key_validator_contract.Result {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        self.calls += 1;
+        if (self.cancel_after) |flag| flag.store(true, .seq_cst);
+        return self.result;
+    }
+};
+
+const EnteredSecretStoreProbe = struct {
+    const Load = enum { value, missing, unreadable };
+
+    report: host.SecretStoreWriteReport = .{ .durable_write = .replaced },
+    load_result: Load = .value,
+    stored_value: [256]u8 = undefined,
+    stored_value_len: usize = 0,
+    store_calls: usize = 0,
+    load_calls: usize = 0,
+    cancel_after_store: ?*std.atomic.Value(bool) = null,
+    cancel_during_load: ?*std.atomic.Value(bool) = null,
+
+    fn provider(self: *@This()) host.SecretStore {
+        return .{
+            .context = self,
+            .backend_label = "test credential store",
+            .is_disabled_fn = isDisabled,
+            .load_fn = load,
+            .store_fn = store,
+            .store_interactive_fn = storeInteractive,
+            .store_with_disposition_fn = storeWithDisposition,
+        };
+    }
+
+    fn isDisabled(_: ?*anyopaque) bool {
+        return false;
+    }
+
+    fn load(
+        raw: ?*anyopaque,
+        alloc: Allocator,
+    ) host.SecretStoreLoadError!?[]u8 {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        self.load_calls += 1;
+        if (self.cancel_during_load) |flag| flag.store(true, .seq_cst);
+        return switch (self.load_result) {
+            .value => if (self.stored_value_len > 0)
+                try alloc.dupe(u8, self.stored_value[0..self.stored_value_len])
+            else
+                null,
+            .missing => null,
+            .unreadable => error.StoredKeyUnreadable,
+        };
+    }
+
+    fn store(
+        _: ?*anyopaque,
+        _: Allocator,
+        _: []const u8,
+    ) host.SecretStoreWriteError!void {}
+
+    fn storeInteractive(_: ?*anyopaque) host.SecretStoreWriteError!bool {
+        return false;
+    }
+
+    fn storeWithDisposition(
+        raw: ?*anyopaque,
+        _: Allocator,
+        value: []const u8,
+    ) host.SecretStoreWriteReport {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        self.store_calls += 1;
+        if (self.report.durable_write == .replaced and value.len <= self.stored_value.len) {
+            @memcpy(self.stored_value[0..value.len], value);
+            self.stored_value_len = value.len;
+        }
+        if (self.cancel_after_store) |flag| flag.store(true, .seq_cst);
+        return self.report;
+    }
+};
+
+fn enteredSecretTestSubmission(
+    alloc: Allocator,
+    store: host.SecretStore,
+    cancel_flag: *const std.atomic.Value(bool),
+    source_id_value: []const u8,
+    secret_value: []const u8,
+) !adapter_auth.EnteredSecretSubmission {
+    const profile = adapterAuthTestProfile(connection_seed.adapter_id, "automatic");
+    const identity = try adapter_auth.AuthProfileIdentity.init(alloc, profile);
+    errdefer {
+        var owned = identity;
+        owned.deinit(alloc);
+    }
+    const source_id = try alloc.dupe(u8, source_id_value);
+    errdefer alloc.free(source_id);
+    const presentation = try adapter_auth.EnteredSecretPresentation.init(
+        alloc,
+        "API key",
+        "AI Gateway",
+        store.backend_label,
+    );
+    errdefer {
+        var owned = presentation;
+        owned.deinit(alloc);
+    }
+    return .{
+        .request_id = 42,
+        .profile = identity,
+        .source_id = source_id,
+        .presentation = presentation,
+        .secret_value = .{ .bytes = try alloc.dupe(u8, secret_value) },
+        .host = .{ .secret_store = store },
+        .cancel_flag = cancel_flag,
+    };
+}
+
+test "entered-secret store cancellation and reacquisition matrix preserves durable truth" {
+    const alloc = std.testing.allocator;
+    const transport = oauth_transport.unavailable_provider;
+
+    const Case = struct {
+        name: []const u8,
+        source_id: []const u8 = "stored_key",
+        secret_value: []const u8 = "entered-secret",
+        validation: api_key_validator_contract.Result = .accepted,
+        report: host.SecretStoreWriteReport = .{ .durable_write = .replaced },
+        load_result: EnteredSecretStoreProbe.Load = .value,
+        cancel_before: bool = false,
+        cancel_after_validation: bool = false,
+        cancel_after_store: bool = false,
+        cancel_during_load: bool = false,
+        expected_write: adapter_auth.DurableWriteState,
+        expected_terminal: std.meta.Tag(adapter_auth.EnteredSecretTerminal),
+        expected_stage: ?adapter_auth.EnteredSecretFailureStage = null,
+        expected_validation_calls: usize = 1,
+        expected_store_calls: usize,
+        expected_load_calls: usize,
+    };
+    const cases = [_]Case{
+        .{ .name = "missing exact source", .source_id = "other", .expected_write = .unchanged, .expected_terminal = .missing, .expected_validation_calls = 0, .expected_store_calls = 0, .expected_load_calls = 0 },
+        .{ .name = "empty input", .secret_value = "", .expected_write = .unchanged, .expected_terminal = .invalid, .expected_validation_calls = 0, .expected_store_calls = 0, .expected_load_calls = 0 },
+        .{ .name = "validation refusal", .validation = .refused, .expected_write = .unchanged, .expected_terminal = .failed, .expected_stage = .validation, .expected_store_calls = 0, .expected_load_calls = 0 },
+        .{ .name = "validation unavailable", .validation = .unavailable, .expected_write = .unchanged, .expected_terminal = .failed, .expected_stage = .validation, .expected_store_calls = 0, .expected_load_calls = 0 },
+        .{ .name = "cancel before validation", .cancel_before = true, .expected_write = .unchanged, .expected_terminal = .cancelled, .expected_validation_calls = 0, .expected_store_calls = 0, .expected_load_calls = 0 },
+        .{ .name = "cancel after validation", .cancel_after_validation = true, .expected_write = .unchanged, .expected_terminal = .cancelled, .expected_store_calls = 0, .expected_load_calls = 0 },
+        .{ .name = "pre-publication persistence failure", .report = .{ .durable_write = .unchanged, .failure = error.StoredKeyWriteFailed }, .expected_write = .unchanged, .expected_terminal = .failed, .expected_stage = .persistence, .expected_store_calls = 1, .expected_load_calls = 0 },
+        .{ .name = "indeterminate publication", .report = .{ .durable_write = .indeterminate, .failure = error.StoredKeyWriteFailed }, .expected_write = .indeterminate, .expected_terminal = .failed, .expected_stage = .persistence, .expected_store_calls = 1, .expected_load_calls = 0 },
+        .{ .name = "cancel after replacement", .cancel_after_store = true, .expected_write = .replaced, .expected_terminal = .cancelled, .expected_store_calls = 1, .expected_load_calls = 0 },
+        .{ .name = "reacquisition missing", .load_result = .missing, .expected_write = .replaced, .expected_terminal = .failed, .expected_stage = .reacquisition, .expected_store_calls = 1, .expected_load_calls = 1 },
+        .{ .name = "reacquisition unreadable", .load_result = .unreadable, .expected_write = .replaced, .expected_terminal = .failed, .expected_stage = .reacquisition, .expected_store_calls = 1, .expected_load_calls = 1 },
+        .{ .name = "cancel during reacquisition", .cancel_during_load = true, .expected_write = .replaced, .expected_terminal = .cancelled, .expected_store_calls = 1, .expected_load_calls = 1 },
+        .{ .name = "replacement and exact reacquisition", .expected_write = .replaced, .expected_terminal = .acquired, .expected_store_calls = 1, .expected_load_calls = 1 },
+    };
+
+    for (cases) |case| {
+        var cancel_flag = std.atomic.Value(bool).init(case.cancel_before);
+        var validation = EnteredSecretValidationProbe{
+            .result = case.validation,
+            .cancel_after = if (case.cancel_after_validation) &cancel_flag else null,
+        };
+        var store = EnteredSecretStoreProbe{
+            .report = case.report,
+            .load_result = case.load_result,
+            .cancel_after_store = if (case.cancel_after_store) &cancel_flag else null,
+            .cancel_during_load = if (case.cancel_during_load) &cancel_flag else null,
+        };
+        var submission = try enteredSecretTestSubmission(
+            alloc,
+            store.provider(),
+            &cancel_flag,
+            case.source_id,
+            case.secret_value,
+        );
+        var completion = submitVercelEnteredSecretWithValidator(
+            &transport,
+            validation.provider(),
+            alloc,
+            &submission,
+        );
+        defer completion.deinit(alloc);
+        try std.testing.expectEqual(case.expected_write, completion.outcome.durable_write);
+        try std.testing.expectEqual(case.expected_terminal, std.meta.activeTag(completion.outcome.terminal));
+        if (case.expected_stage) |stage| {
+            try std.testing.expectEqual(stage, completion.outcome.terminal.failed.stage);
+        }
+        try std.testing.expectEqual(case.expected_validation_calls, validation.calls);
+        try std.testing.expectEqual(case.expected_store_calls, store.store_calls);
+        try std.testing.expectEqual(case.expected_load_calls, store.load_calls);
+        if (case.expected_terminal == .acquired) {
+            try std.testing.expectEqualStrings("stored_key", completion.outcome.terminal.acquired.source.id);
+            try std.testing.expectEqualStrings("entered-secret", completion.outcome.terminal.acquired.secret_bytes);
+        }
+        _ = case.name;
+    }
+}
+
+test "post-replacement allocation failure and later exact reacquisition retain the store fact" {
+    const backing = std.testing.allocator;
+    var failing = std.testing.FailingAllocator.init(backing, .{});
+    const alloc = failing.allocator();
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    var validation = EnteredSecretValidationProbe{};
+    var store = EnteredSecretStoreProbe{};
+    var submission = try enteredSecretTestSubmission(
+        alloc,
+        store.provider(),
+        &cancel_flag,
+        "stored_key",
+        "post-write-secret",
+    );
+    failing.fail_index = failing.alloc_index;
+    const transport = oauth_transport.unavailable_provider;
+    var completion = submitVercelEnteredSecretWithValidator(
+        &transport,
+        validation.provider(),
+        alloc,
+        &submission,
+    );
+    try std.testing.expectEqual(adapter_auth.DurableWriteState.replaced, completion.outcome.durable_write);
+    try std.testing.expect(completion.outcome.terminal == .failed);
+    try std.testing.expectEqual(adapter_auth.EnteredSecretFailureStage.reacquisition, completion.outcome.terminal.failed.stage);
+    try std.testing.expect(completion.outcome.terminal.failed.cause == .allocation);
+    completion.deinit(alloc);
+    try std.testing.expect(failing.has_induced_failure);
+    try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+
+    cancel_flag.store(false, .seq_cst);
+    const recovered = try credentials.resolveExact(
+        backing,
+        transport,
+        store.provider(),
+        .refresh_if_needed,
+        .stored_key,
+    );
+    var credential = recovered.credential orelse return error.ExpectedRecoveredCredential;
+    defer credential.deinit(backing);
+    try std.testing.expectEqualStrings("post-write-secret", credential.token);
+    try std.testing.expectEqual(credentials.Source.stored_key, credential.source);
+}
+
 const PeerAuthProbe = struct {
     acquire_calls: usize = 0,
     cancel_during_acquire: ?*std.atomic.Value(bool) = null,
@@ -3949,6 +4426,101 @@ fn adapterAuthTestProfile(kind: []const u8, credential_ref: []const u8) connecti
         .remembered_model = @constCast("model"),
         .internal_models = .{},
     };
+}
+
+test "Vercel source inventory preserves exact order labels and entered-secret copy" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(home);
+    const env = try AdapterAuthTestEnv.install(alloc, &.{
+        .{ "HOME", home },
+        .{ "VERCEL_OIDC_TOKEN", "oidc-secret" },
+        .{ "AI_GATEWAY_API_KEY", "gateway-secret" },
+    });
+    defer env.deinit();
+    var session = oauth_session.Session{
+        .issuer = try alloc.dupe(u8, "https://vercel.com"),
+        .client_id = try alloc.dupe(u8, "test-client"),
+        .access_token = try alloc.dupe(u8, "login-secret"),
+        .refresh_token = try alloc.dupe(u8, "refresh-secret"),
+        .expires_at_ms = std.math.maxInt(i64),
+        .scope = try alloc.dupe(u8, "openid offline_access"),
+        .token_type = try alloc.dupe(u8, "Bearer"),
+    };
+    defer session.deinit(alloc);
+    try oauth_session.saveNewSession(alloc, session);
+
+    var store = AdapterAuthStoreProbe{ .value = "stored-secret" };
+    const profile = adapterAuthTestProfile(connection_seed.adapter_id, "fx_login");
+    var request = adapter_auth.SourceInventoryRequest{
+        .profile = try adapter_auth.AuthProfileIdentity.init(alloc, profile),
+        .host = .{ .secret_store = store.store() },
+        .current_source_id = "fx_login",
+    };
+    defer request.deinit(alloc);
+    var outcome = try auth_provider.sourceInventory(alloc, &request);
+    defer outcome.deinit(alloc);
+    const inventory = switch (outcome) {
+        .loaded => |*value| value,
+        else => return error.UnexpectedInventoryOutcome,
+    };
+
+    try std.testing.expectEqualStrings("Vercel", inventory.auth_service.service_label);
+    try std.testing.expectEqual(@as(usize, 4), inventory.sources.len);
+    const expected_sources = [_]credentials.Source{
+        .vercel_oidc_token,
+        .ai_gateway_api_key,
+        .fx_login,
+        .stored_key,
+    };
+    for (inventory.sources, expected_sources) |actual, expected| {
+        try std.testing.expectEqualStrings(@tagName(expected), actual.id);
+        try std.testing.expectEqualStrings(credentials.sourceLabel(expected), actual.presentation_label);
+        try std.testing.expect(actual.available);
+        try std.testing.expectEqual(credentials.sourceRefreshable(expected), actual.refreshable);
+    }
+    const entered = inventory.sources[3].entered_secret.?;
+    try std.testing.expectEqualStrings("API key", entered.secret_kind_label);
+    try std.testing.expectEqualStrings("AI Gateway", entered.verification_service_label);
+    try std.testing.expectEqualStrings("adapter test store", entered.storage_destination_label);
+    try std.testing.expectEqual(@as(usize, 1), store.loads);
+}
+
+test "Vercel source inventory cleans every induced allocation failure" {
+    const backing = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const home = try io_mod.dirRealpathAlloc(backing, tmp.dir, ".");
+    defer backing.free(home);
+    const env = try AdapterAuthTestEnv.install(backing, &.{.{ "HOME", home }});
+    defer env.deinit();
+    var store = AdapterAuthStoreProbe{ .value = "stored-secret" };
+    const profile = adapterAuthTestProfile(connection_seed.adapter_id, "automatic");
+    var request = adapter_auth.SourceInventoryRequest{
+        .profile = try adapter_auth.AuthProfileIdentity.init(backing, profile),
+        .host = .{ .secret_store = store.store() },
+    };
+    defer request.deinit(backing);
+
+    var probe = std.testing.FailingAllocator.init(backing, .{});
+    var complete = try loadVercelSourceInventory(&oauth_transport_provider, probe.allocator(), &request);
+    complete.deinit(probe.allocator());
+    try std.testing.expectEqual(probe.allocated_bytes, probe.freed_bytes);
+
+    for (0..probe.alloc_index) |fail_index| {
+        var failing = std.testing.FailingAllocator.init(
+            backing,
+            .{ .fail_index = fail_index },
+        );
+        if (loadVercelSourceInventory(&oauth_transport_provider, failing.allocator(), &request)) |outcome_value| {
+            var outcome = outcome_value;
+            outcome.deinit(failing.allocator());
+        } else |err| try std.testing.expectEqual(error.OutOfMemory, err);
+        try std.testing.expect(failing.has_induced_failure);
+        try std.testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+    }
 }
 
 test "production registry contains only Vercel" {

--- a/src/core/hosts/native_keychain.zig
+++ b/src/core/hosts/native_keychain.zig
@@ -12,6 +12,8 @@ pub const oauth_session_service_name = "FX_OAUTH_SESSION_V1";
 pub const AccountBuffer = [256]u8;
 
 const passwd_scratch_bytes = 2048;
+const max_store_service_bytes: usize = 256;
+const max_store_secret_bytes: usize = 8 * 1024;
 const max_mcp_credentials_bytes: usize = 1024 * 1024;
 const max_oauth_session_bytes: usize = 64 * 1024;
 const keychain_process_timeout: std.Io.Timeout = .{
@@ -31,13 +33,31 @@ pub const Error = error{
     KeychainDeleteFailed,
 };
 
+pub const StoreDisposition = enum {
+    unchanged,
+    replaced,
+    indeterminate,
+};
+
+pub const StoreReport = struct {
+    disposition: StoreDisposition,
+    failure: ?Error = null,
+};
+
 pub fn isAvailable() bool {
     return builtin.os.tag == .macos;
 }
 
 pub fn isDisabled() bool {
-    const value = io_mod.getenv("FX_DISABLE_KEYCHAIN") orelse return false;
+    const value = processKeychainDisableValue() orelse
+        io_mod.getenv("FX_DISABLE_KEYCHAIN") orelse return false;
     return std.mem.eql(u8, value, "1") or std.ascii.eqlIgnoreCase(value, "true");
+}
+
+fn processKeychainDisableValue() ?[]const u8 {
+    if (comptime !builtin.link_libc) return null;
+    const value = std.c.getenv("FX_DISABLE_KEYCHAIN") orelse return null;
+    return std.mem.sliceTo(value, 0);
 }
 
 /// Returns a slice borrowing `buf`. `USER` stays authoritative when set, because it
@@ -139,16 +159,55 @@ fn storeArgv(account: []const u8) [8][]const u8 {
     return .{ "/usr/bin/security", "add-generic-password", "-a", account, "-s", service_name, "-U", "-w" };
 }
 
-const store_value_script =
+const store_value_frame_script =
     \\log_user 0
     \\set timeout 10
     \\fconfigure stdin -translation binary -encoding binary
-    \\set account_length [gets stdin]
-    \\set service_length [gets stdin]
-    \\set secret_length [gets stdin]
-    \\set account [read stdin $account_length]
-    \\set service [read stdin $service_length]
-    \\set secret [read stdin $secret_length]
+    \\proc frame_error {} { exit 64 }
+    \\proc read_length {minimum maximum} {
+    \\    set digits ""
+    \\    while {1} {
+    \\        set byte [read stdin 1]
+    \\        if {[string length "$byte"] != 1} { frame_error }
+    \\        if {$byte eq "\n"} { break }
+    \\        if {![string is digit -strict $byte]} { frame_error }
+    \\        if {[string length "$digits"] >= 20} { frame_error }
+    \\        append digits $byte
+    \\    }
+    \\    if {$digits eq "" || ![string is integer -strict $digits]} { frame_error }
+    \\    if {$digits < $minimum || $digits > $maximum} { frame_error }
+    \\    return $digits
+    \\}
+    \\proc read_exact {length} {
+    \\    set value ""
+    \\    set remaining $length
+    \\    while {$remaining > 0} {
+    \\        set chunk [read stdin $remaining]
+    \\        set count [string length "$chunk"]
+    \\        if {$count == 0} { frame_error }
+    \\        append value $chunk
+    \\        incr remaining -$count
+    \\    }
+    \\    return $value
+    \\}
+    \\if {[catch {
+    \\    set account_length [read_length 1 256]
+    \\    set service_length [read_length 1 256]
+    \\    set secret_length [read_length 1 8192]
+    \\    set account [read_exact $account_length]
+    \\    set service [read_exact $service_length]
+    \\    set secret [read_exact $secret_length]
+    \\    if {[regexp {[\x00-\x1f\x7f]} $account] ||
+    \\        [regexp {[\x00-\x1f\x7f]} $service] ||
+    \\        [regexp {[\x00-\x1f\x7f]} $secret]} { frame_error }
+    \\    set trailing [read stdin 1]
+    \\    if {[string length "$trailing"] != 0} { frame_error }
+    \\}]} { exit 64 }
+    \\
+;
+
+const store_value_script = store_value_frame_script ++
+    \\# Publication boundary: the complete bounded frame is now authoritative.
     \\spawn -noecho /usr/bin/security add-generic-password -a $account -s $service -U -w
     \\expect {
     \\    -exact "password data for new item:" {}
@@ -168,7 +227,12 @@ const store_value_script =
     \\}
     \\set result [wait]
     \\if {![string is integer -strict [lindex $result 3]]} { exit 1 }
-    \\exit [lindex $result 3]
+    \\if {[lindex $result 3] != 0} { exit 1 }
+    \\exit 0
+;
+
+const store_value_probe_script = store_value_frame_script ++
+    \\exit 0
 ;
 
 // `security add-generic-password -w` uses a 128-byte interactive buffer. MCP's
@@ -254,11 +318,20 @@ pub fn storeInteractive() Error!void {
 }
 
 pub fn storeValue(value: []const u8) Error!void {
-    if (!isAvailable()) return error.UnsupportedPlatform;
-    if (value.len == 0) return error.KeychainWriteFailed;
+    const report = storeValueWithDisposition(value);
+    if (report.failure) |failure| return failure;
+}
 
-    if (comptime builtin.os.tag == .macos) return storeValueMac(service_name, value);
-    return error.UnsupportedPlatform;
+pub fn storeValueWithDisposition(value: []const u8) StoreReport {
+    if (!isAvailable()) return .{ .disposition = .unchanged, .failure = error.UnsupportedPlatform };
+    if (value.len == 0 or value.len > max_store_secret_bytes) {
+        return .{ .disposition = .unchanged, .failure = error.KeychainWriteFailed };
+    }
+    if (comptime builtin.os.tag == .macos) {
+        var state = NativeStoreValueProcess{};
+        return storeValueWithProcess(service_name, value, state.process());
+    }
+    return .{ .disposition = .unchanged, .failure = error.UnsupportedPlatform };
 }
 
 pub fn storeMcpCredentials(value: []const u8) Error!void {
@@ -317,38 +390,194 @@ fn writeFailedTerm(step: []const u8, term: std.process.Child.Term) Error {
     return error.KeychainWriteFailed;
 }
 
-fn storeValueMac(service: []const u8, value: []const u8) Error!void {
-    var account_buf: AccountBuffer = undefined;
-    const account = try accountName(&account_buf);
-    const argv = storeValueArgv();
-    var child = std.process.spawn(io_mod.getIo(), .{
-        .argv = &argv,
-        .stdin = .pipe,
-        .stdout = .ignore,
-        .stderr = .ignore,
-    }) catch |err| return writeFailed("spawn", err);
-    defer child.kill(io_mod.getIo());
+const StoreValueStep = enum {
+    account_name,
+    spawn,
+    stdin,
+    header,
+    write_header,
+    write_account,
+    write_service,
+    write_secret,
+    frame,
+    wait,
+    exit,
+};
 
-    var input = child.stdin orelse return writeFailed("stdin", error.BrokenPipe);
-    child.stdin = null;
-    var input_open = true;
-    defer if (input_open) input.close(io_mod.getIo());
+const StoreValueWrite = enum {
+    header,
+    account,
+    service,
+    secret,
+};
+
+const StoreValueProcess = struct {
+    context: *anyopaque,
+    account_fn: *const fn (*anyopaque, *AccountBuffer) anyerror![]const u8,
+    spawn_fn: *const fn (*anyopaque) anyerror!void,
+    take_stdin_fn: *const fn (*anyopaque) anyerror!void,
+    format_header_fn: *const fn (*anyopaque, *[96]u8, usize, usize, usize) anyerror![]const u8,
+    write_fn: *const fn (*anyopaque, StoreValueWrite, []const u8) anyerror!void,
+    close_stdin_fn: *const fn (*anyopaque) void,
+    wait_fn: *const fn (*anyopaque) anyerror!std.process.Child.Term,
+    deinit_fn: *const fn (*anyopaque) void,
+};
+
+const NativeStoreValueProcess = struct {
+    child: ?std.process.Child = null,
+    input: ?std.Io.File = null,
+
+    fn process(self: *@This()) StoreValueProcess {
+        return .{
+            .context = self,
+            .account_fn = account,
+            .spawn_fn = spawn,
+            .take_stdin_fn = takeStdin,
+            .format_header_fn = formatHeader,
+            .write_fn = write,
+            .close_stdin_fn = closeStdin,
+            .wait_fn = wait,
+            .deinit_fn = deinit,
+        };
+    }
+
+    fn account(_: *anyopaque, buf: *AccountBuffer) anyerror![]const u8 {
+        return accountName(buf);
+    }
+
+    fn spawn(raw: *anyopaque) anyerror!void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        const argv = storeValueArgv();
+        self.child = try std.process.spawn(io_mod.getIo(), .{
+            .argv = &argv,
+            .stdin = .pipe,
+            .stdout = .ignore,
+            .stderr = .ignore,
+        });
+    }
+
+    fn takeStdin(raw: *anyopaque) anyerror!void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        const child = if (self.child) |*value| value else return error.ProcessNotStarted;
+        self.input = child.stdin orelse return error.BrokenPipe;
+        child.stdin = null;
+    }
+
+    fn formatHeader(
+        _: *anyopaque,
+        buffer: *[96]u8,
+        account_len: usize,
+        service_len: usize,
+        value_len: usize,
+    ) anyerror![]const u8 {
+        return std.fmt.bufPrint(
+            buffer,
+            "{d}\n{d}\n{d}\n",
+            .{ account_len, service_len, value_len },
+        );
+    }
+
+    fn write(raw: *anyopaque, _: StoreValueWrite, bytes: []const u8) anyerror!void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        const input = if (self.input) |*value| value else return error.BrokenPipe;
+        try input.writeStreamingAll(io_mod.getIo(), bytes);
+    }
+
+    fn closeStdin(raw: *anyopaque) void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        if (self.input) |*input| input.close(io_mod.getIo());
+        self.input = null;
+    }
+
+    fn wait(raw: *anyopaque) anyerror!std.process.Child.Term {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        const child = if (self.child) |*value| value else return error.ProcessNotStarted;
+        return child.wait(io_mod.getIo());
+    }
+
+    fn deinit(raw: *anyopaque) void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        closeStdin(raw);
+        if (self.child) |*child| child.kill(io_mod.getIo());
+        self.child = null;
+    }
+};
+
+fn failedStoreValueProcess(step: StoreValueStep, err: anyerror) StoreReport {
+    debug_trace.logf("keychain", "store failed step={s} err={s}", .{ @tagName(step), @errorName(err) });
+    return .{
+        .disposition = switch (step) {
+            .account_name,
+            .spawn,
+            .stdin,
+            .header,
+            .write_header,
+            .write_account,
+            .write_service,
+            .frame,
+            => .unchanged,
+            .write_secret,
+            .wait,
+            .exit,
+            => .indeterminate,
+        },
+        .failure = error.KeychainWriteFailed,
+    };
+}
+
+fn storeValueWithProcess(
+    service: []const u8,
+    value: []const u8,
+    process: StoreValueProcess,
+) StoreReport {
+    defer process.deinit_fn(process.context);
+    if (service.len == 0 or service.len > max_store_service_bytes or
+        value.len == 0 or value.len > max_store_secret_bytes)
+    {
+        return .{ .disposition = .unchanged, .failure = error.KeychainWriteFailed };
+    }
+    var account_buf: AccountBuffer = undefined;
+    const account = process.account_fn(process.context, &account_buf) catch |err|
+        return failedStoreValueProcess(.account_name, err);
+    process.spawn_fn(process.context) catch |err|
+        return failedStoreValueProcess(.spawn, err);
+    process.take_stdin_fn(process.context) catch |err|
+        return failedStoreValueProcess(.stdin, err);
 
     var header_buffer: [96]u8 = undefined;
-    const header = std.fmt.bufPrint(
+    const header = process.format_header_fn(
+        process.context,
         &header_buffer,
-        "{d}\n{d}\n{d}\n",
-        .{ account.len, service.len, value.len },
-    ) catch |err| return writeFailed("header", err);
-    input.writeStreamingAll(io_mod.getIo(), header) catch |err| return writeFailed("write_header", err);
-    input.writeStreamingAll(io_mod.getIo(), account) catch |err| return writeFailed("write_account", err);
-    input.writeStreamingAll(io_mod.getIo(), service) catch |err| return writeFailed("write_service", err);
-    input.writeStreamingAll(io_mod.getIo(), value) catch |err| return writeFailed("write_secret", err);
-    input.close(io_mod.getIo());
-    input_open = false;
+        account.len,
+        service.len,
+        value.len,
+    ) catch |err| return failedStoreValueProcess(.header, err);
+    process.write_fn(process.context, .header, header) catch |err|
+        return failedStoreValueProcess(.write_header, err);
+    process.write_fn(process.context, .account, account) catch |err|
+        return failedStoreValueProcess(.write_account, err);
+    process.write_fn(process.context, .service, service) catch |err|
+        return failedStoreValueProcess(.write_service, err);
+    process.write_fn(process.context, .secret, value) catch |err|
+        return failedStoreValueProcess(.write_secret, err);
+    process.close_stdin_fn(process.context);
 
-    const term = child.wait(io_mod.getIo()) catch |err| return writeFailed("wait", err);
-    if (term != .exited or term.exited != 0) return writeFailedTerm("exit", term);
+    const term = process.wait_fn(process.context) catch |err|
+        return failedStoreValueProcess(.wait, err);
+    if (term == .exited and term.exited == 64) {
+        return failedStoreValueProcess(.frame, error.InvalidStoreValueFrame);
+    }
+    if (term != .exited or term.exited != 0) {
+        debug_trace.logf("keychain", "store failed step=exit term={t}", .{term});
+        return .{ .disposition = .indeterminate, .failure = error.KeychainWriteFailed };
+    }
+    return .{ .disposition = .replaced };
+}
+
+fn storeValueMac(service: []const u8, value: []const u8) Error!void {
+    var state = NativeStoreValueProcess{};
+    const report = storeValueWithProcess(service, value, state.process());
+    if (report.failure) |failure| return failure;
 }
 
 fn mcpScriptArgv(
@@ -653,8 +882,250 @@ fn deleteServiceItem(
 
 const test_service_name = "FX_TEST_AI_GATEWAY_API_KEY";
 
+const StoreFrameProbeResult = struct {
+    term: std.process.Child.Term,
+};
+
+fn runStoreFrameProbe(
+    _: std.mem.Allocator,
+    frame: []const u8,
+) !StoreFrameProbeResult {
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+    var child = try std.process.spawn(io_mod.getIo(), .{
+        .argv = &.{ "/usr/bin/expect", "-c", store_value_probe_script },
+        .stdin = .pipe,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    defer if (child.id != null) child.kill(io_mod.getIo());
+
+    var input = child.stdin orelse return error.BrokenPipe;
+    child.stdin = null;
+    try input.writeStreamingAll(io_mod.getIo(), frame);
+    input.close(io_mod.getIo());
+
+    return .{ .term = try child.wait(io_mod.getIo()) };
+}
+
+fn expectRejectedStoreFrame(frame: []const u8) !void {
+    const result = try runStoreFrameProbe(std.testing.allocator, frame);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 64 }, result.term);
+}
+
+const TestStoreValueProcess = struct {
+    failure: ?StoreValueStep = null,
+    deinit_calls: usize = 0,
+    secret_write_calls: usize = 0,
+
+    fn process(self: *@This()) StoreValueProcess {
+        return .{
+            .context = self,
+            .account_fn = account,
+            .spawn_fn = spawn,
+            .take_stdin_fn = takeStdin,
+            .format_header_fn = formatHeader,
+            .write_fn = write,
+            .close_stdin_fn = closeStdin,
+            .wait_fn = wait,
+            .deinit_fn = deinit,
+        };
+    }
+
+    fn failAt(self: *@This(), step: StoreValueStep) !void {
+        if (self.failure == step) return error.InjectedStoreValueFailure;
+    }
+
+    fn account(raw: *anyopaque, buf: *AccountBuffer) anyerror![]const u8 {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        try self.failAt(.account_name);
+        const name = "test-user";
+        @memcpy(buf[0..name.len], name);
+        return buf[0..name.len];
+    }
+
+    fn spawn(raw: *anyopaque) anyerror!void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        try self.failAt(.spawn);
+    }
+
+    fn takeStdin(raw: *anyopaque) anyerror!void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        try self.failAt(.stdin);
+    }
+
+    fn formatHeader(
+        raw: *anyopaque,
+        buffer: *[96]u8,
+        account_len: usize,
+        service_len: usize,
+        value_len: usize,
+    ) anyerror![]const u8 {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        try self.failAt(.header);
+        return std.fmt.bufPrint(
+            buffer,
+            "{d}\n{d}\n{d}\n",
+            .{ account_len, service_len, value_len },
+        );
+    }
+
+    fn write(raw: *anyopaque, phase: StoreValueWrite, _: []const u8) anyerror!void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        const step: StoreValueStep = switch (phase) {
+            .header => .write_header,
+            .account => .write_account,
+            .service => .write_service,
+            .secret => .write_secret,
+        };
+        if (phase == .secret) self.secret_write_calls += 1;
+        try self.failAt(step);
+    }
+
+    fn closeStdin(_: *anyopaque) void {}
+
+    fn wait(raw: *anyopaque) anyerror!std.process.Child.Term {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        try self.failAt(.wait);
+        return if (self.failure == .exit)
+            .{ .exited = 1 }
+        else if (self.failure == .frame)
+            .{ .exited = 64 }
+        else
+            .{ .exited = 0 };
+    }
+
+    fn deinit(raw: *anyopaque) void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        self.deinit_calls += 1;
+    }
+};
+
 fn deleteTestServiceItem(alloc: std.mem.Allocator) void {
     _ = deleteServiceItem(alloc, test_service_name) catch {};
+}
+
+test "Keychain store disposition follows the injected publication boundary" {
+    inline for (&.{
+        StoreValueStep.account_name,
+        .spawn,
+        .stdin,
+        .header,
+        .write_header,
+        .write_account,
+        .write_service,
+    }) |step| {
+        var process = TestStoreValueProcess{ .failure = step };
+        const report = storeValueWithProcess(service_name, "secret", process.process());
+        try std.testing.expectEqual(StoreDisposition.unchanged, report.disposition);
+        try std.testing.expectEqual(error.KeychainWriteFailed, report.failure.?);
+        try std.testing.expectEqual(@as(usize, 1), process.deinit_calls);
+        try std.testing.expectEqual(@as(usize, 0), process.secret_write_calls);
+    }
+
+    inline for (&.{ StoreValueStep.write_secret, .wait, .exit }) |step| {
+        var process = TestStoreValueProcess{ .failure = step };
+        const report = storeValueWithProcess(service_name, "secret", process.process());
+        try std.testing.expectEqual(StoreDisposition.indeterminate, report.disposition);
+        try std.testing.expectEqual(error.KeychainWriteFailed, report.failure.?);
+        try std.testing.expectEqual(@as(usize, 1), process.deinit_calls);
+        try std.testing.expectEqual(@as(usize, 1), process.secret_write_calls);
+    }
+
+    var rejected_frame = TestStoreValueProcess{ .failure = .frame };
+    const rejected_report = storeValueWithProcess(service_name, "secret", rejected_frame.process());
+    try std.testing.expectEqual(StoreDisposition.unchanged, rejected_report.disposition);
+    try std.testing.expectEqual(error.KeychainWriteFailed, rejected_report.failure.?);
+    try std.testing.expectEqual(@as(usize, 1), rejected_frame.deinit_calls);
+    try std.testing.expectEqual(@as(usize, 1), rejected_frame.secret_write_calls);
+
+    var process = TestStoreValueProcess{};
+    const report = storeValueWithProcess(service_name, "secret", process.process());
+    try std.testing.expectEqual(StoreDisposition.replaced, report.disposition);
+    try std.testing.expect(report.failure == null);
+    try std.testing.expectEqual(@as(usize, 1), process.deinit_calls);
+    try std.testing.expectEqual(@as(usize, 1), process.secret_write_calls);
+}
+
+test "Keychain bridge acquires and validates the complete frame before publication" {
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+    try std.testing.expect(std.mem.find(u8, store_value_probe_script, "/usr/bin/security") == null);
+    try std.testing.expect(std.mem.find(u8, store_value_probe_script, "add-generic-password") == null);
+    try std.testing.expect(std.mem.find(u8, store_value_probe_script, "Publication boundary") == null);
+    const boundary = std.mem.find(u8, store_value_script, "# Publication boundary") orelse
+        return error.MissingPublicationBoundary;
+    const security = std.mem.find(u8, store_value_script, "/usr/bin/security") orelse
+        return error.MissingSecurityCommand;
+    try std.testing.expect(boundary < security);
+    try std.testing.expectEqual(store_value_frame_script.len, boundary);
+
+    const account = "frame-user";
+    const service = "FRAME_TEST_SERVICE";
+    const secret_value = "frame-secret-must-not-appear";
+    const frame = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{d}\n{d}\n{d}\n{s}{s}{s}",
+        .{ account.len, service.len, secret_value.len, account, service, secret_value },
+    );
+    defer std.testing.allocator.free(frame);
+
+    for (0..frame.len) |end| try expectRejectedStoreFrame(frame[0..end]);
+
+    const accepted = try runStoreFrameProbe(std.testing.allocator, frame);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, accepted.term);
+
+    const malformed = [_][]const u8{
+        "",
+        "\n",
+        "x\n1\n1\nas",
+        "+1\n1\n1\nas",
+        "1x\n1\n1\nas",
+        "000000000000000000000\n1\n1\nas",
+        "0\n1\n1\nas",
+        "257\n1\n1\nas",
+        "1\n0\n1\nas",
+        "1\n257\n1\nas",
+        "1\n1\n0\nas",
+        "1\n1\n8193\nas",
+        "1\n1\n1\nasxy",
+        "1\n1\n1\n\nas",
+        "1\n1\n1\na\ns",
+    };
+    for (malformed) |value| try expectRejectedStoreFrame(value);
+
+    for (0..0x20) |control| {
+        const secret_control = [_]u8{ 'x', @intCast(control), 'y' };
+        const control_frame = try std.fmt.allocPrint(
+            std.testing.allocator,
+            "{d}\n{d}\n{d}\n{s}{s}{s}",
+            .{ account.len, service.len, secret_control.len, account, service, &secret_control },
+        );
+        defer std.testing.allocator.free(control_frame);
+        try expectRejectedStoreFrame(control_frame);
+    }
+    const del_secret = [_]u8{ 'x', 0x7f, 'y' };
+    const del_frame = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{d}\n{d}\n{d}\n{s}{s}{s}",
+        .{ account.len, service.len, del_secret.len, account, service, &del_secret },
+    );
+    defer std.testing.allocator.free(del_frame);
+    try expectRejectedStoreFrame(del_frame);
+}
+
+test "Keychain store rejects invalid bounds before starting a process" {
+    var process = TestStoreValueProcess{};
+    const empty_service = storeValueWithProcess("", "secret", process.process());
+    try std.testing.expectEqual(StoreDisposition.unchanged, empty_service.disposition);
+    try std.testing.expectEqual(@as(usize, 1), process.deinit_calls);
+    try std.testing.expectEqual(@as(usize, 0), process.secret_write_calls);
+
+    var oversized: [max_store_secret_bytes + 1]u8 = undefined;
+    @memset(&oversized, 'x');
+    process = .{};
+    const oversized_secret = storeValueWithProcess(service_name, &oversized, process.process());
+    try std.testing.expectEqual(StoreDisposition.unchanged, oversized_secret.disposition);
+    try std.testing.expectEqual(@as(usize, 1), process.deinit_calls);
+    try std.testing.expectEqual(@as(usize, 0), process.secret_write_calls);
 }
 
 test "account name resolves from the operating system when USER is unset" {

--- a/src/core/hosts/native_secret_store.zig
+++ b/src/core/hosts/native_secret_store.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const build_options = @import("build_options");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("host.zig");
 const io_mod = @import("../shared/io.zig");
@@ -11,7 +12,12 @@ const Allocator = std.mem.Allocator;
 
 /// Names the backend that answers on this platform so operators can tell where a
 /// stored key lives without knowing how the backend is selected.
-const backend_label = if (builtin.os.tag == .macos) "macOS Keychain" else "profile file";
+const backend_label = if (build_options.native_auth_e2e)
+    "profile file"
+else if (builtin.os.tag == .macos)
+    "macOS Keychain"
+else
+    "profile file";
 
 const max_key_file_bytes: usize = 8 * 1024;
 
@@ -24,22 +30,26 @@ pub const provider: host.SecretStore = .{
     .load_fn = loadCallback,
     .store_fn = storeCallback,
     .store_interactive_fn = storeInteractiveCallback,
+    .store_with_disposition_fn = storeWithDispositionCallback,
 };
 
 /// The disable switch is named for the macOS backend, so its reader stays there.
 fn isDisabled() bool {
+    if (comptime build_options.native_auth_e2e) return false;
     return keychain.isDisabled();
 }
 
 /// Returns the stored key, or null when no key is stored. An error means the store
 /// could not be read, which callers must keep distinct from absence.
 fn load(alloc: Allocator) LoadError!?[]u8 {
+    if (comptime build_options.native_auth_e2e) return loadFromProfile(alloc);
     if (comptime builtin.os.tag == .macos) return loadFromKeychain(alloc);
     return loadFromProfile(alloc);
 }
 
 fn store(alloc: Allocator, value: []const u8) StoreError!void {
     if (value.len == 0) return error.StoredKeyWriteFailed;
+    if (comptime build_options.native_auth_e2e) return storeInProfile(alloc, value);
     if (comptime builtin.os.tag == .macos) {
         keychain.storeValue(value) catch |err| return writeFailed("keychain", err);
         return;
@@ -50,6 +60,7 @@ fn store(alloc: Allocator, value: []const u8) StoreError!void {
 /// Let the platform credential store own terminal input when it supports a
 /// secure prompt, keeping plaintext out of the fx process.
 fn storeInteractive() StoreError!bool {
+    if (comptime build_options.native_auth_e2e) return false;
     if (comptime builtin.os.tag == .macos) {
         keychain.storeInteractive() catch |err| return writeFailed("keychain_interactive", err);
         return true;
@@ -75,6 +86,134 @@ fn storeCallback(
 
 fn storeInteractiveCallback(_: ?*anyopaque) StoreError!bool {
     return storeInteractive();
+}
+
+fn storeWithDispositionCallback(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    value: []const u8,
+) host.SecretStoreWriteReport {
+    if (value.len == 0) {
+        return .{ .durable_write = .unchanged, .failure = error.StoredKeyWriteFailed };
+    }
+    if (comptime build_options.native_auth_e2e) {
+        return nativeAuthE2eStoreWithDisposition(alloc, value);
+    }
+    if (comptime builtin.os.tag == .macos) {
+        return keychainStoreWriteReport(keychain.storeValueWithDisposition(value));
+    }
+    return storeInProfileWithDisposition(alloc, value);
+}
+
+const NativeAuthE2eMode = enum {
+    replaced,
+    unchanged,
+    indeterminate,
+    cancel_before,
+    cancel_after,
+};
+
+fn nativeAuthE2eControlPath(alloc: Allocator, name: []const u8) ![]u8 {
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    return std.fs.path.join(alloc, &.{ home, profile_paths.root_dir_name, name });
+}
+
+fn nativeAuthE2eMode(alloc: Allocator) NativeAuthE2eMode {
+    const path = nativeAuthE2eControlPath(alloc, "native-auth-store-mode") catch return .replaced;
+    defer alloc.free(path);
+    var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{}) catch return .replaced;
+    defer file.close(io_mod.getIo());
+    const value = io_mod.readFileToEnd(alloc, &file, 64) catch return .replaced;
+    defer alloc.free(value);
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.meta.stringToEnum(NativeAuthE2eMode, trimmed) orelse .unchanged;
+}
+
+fn nativeAuthE2eWriteFact(alloc: Allocator, name: []const u8, value: []const u8) void {
+    const path = nativeAuthE2eControlPath(alloc, name) catch return;
+    defer alloc.free(path);
+    var file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), path, .{ .truncate = true }) catch return;
+    defer file.close(io_mod.getIo());
+    file.writeStreamingAll(io_mod.getIo(), value) catch {};
+}
+
+fn nativeAuthE2eWriteMarker(alloc: Allocator, name: []const u8) void {
+    nativeAuthE2eWriteFact(alloc, name, "1");
+}
+
+fn nativeAuthE2eWaitForRelease(alloc: Allocator) bool {
+    const path = nativeAuthE2eControlPath(alloc, "native-auth-store-release") catch return false;
+    defer alloc.free(path);
+    for (0..400) |_| {
+        var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{}) catch {
+            std.Io.Timeout.sleep(.{
+                .duration = .{ .raw = .{ .nanoseconds = 25 * std.time.ns_per_ms }, .clock = .awake },
+            }, io_mod.getIo()) catch return false;
+            continue;
+        };
+        file.close(io_mod.getIo());
+        return true;
+    }
+    return false;
+}
+
+fn nativeAuthE2eStoreWithDisposition(
+    alloc: Allocator,
+    value: []const u8,
+) host.SecretStoreWriteReport {
+    const mode = nativeAuthE2eMode(alloc);
+    nativeAuthE2eWriteFact(alloc, "native-auth-store-observed", @tagName(mode));
+    return switch (mode) {
+        .replaced => storeInProfileWithDisposition(alloc, value),
+        .unchanged => .{
+            .durable_write = .unchanged,
+            .failure = error.StoredKeyWriteFailed,
+        },
+        .indeterminate => indeterminate: {
+            storeInProfile(alloc, value) catch |err| {
+                nativeAuthE2eWriteFact(alloc, "native-auth-store-error", @errorName(err));
+                break :indeterminate .{
+                    .durable_write = .unchanged,
+                    .failure = error.StoredKeyWriteFailed,
+                };
+            };
+            break :indeterminate .{
+                .durable_write = .indeterminate,
+                .failure = error.StoredKeyWriteFailed,
+            };
+        },
+        .cancel_before => cancel_before: {
+            nativeAuthE2eWriteMarker(alloc, "native-auth-store-entered");
+            if (!nativeAuthE2eWaitForRelease(alloc)) break :cancel_before .{
+                .durable_write = .unchanged,
+                .failure = error.StoredKeyWriteFailed,
+            };
+            break :cancel_before .{
+                .durable_write = .unchanged,
+                .failure = error.StoredKeyWriteFailed,
+            };
+        },
+        .cancel_after => cancel_after: {
+            storeInProfile(alloc, value) catch break :cancel_after .{
+                .durable_write = .unchanged,
+                .failure = error.StoredKeyWriteFailed,
+            };
+            nativeAuthE2eWriteMarker(alloc, "native-auth-store-published");
+            _ = nativeAuthE2eWaitForRelease(alloc);
+            break :cancel_after .{ .durable_write = .replaced };
+        },
+    };
+}
+
+fn keychainStoreWriteReport(report: keychain.StoreReport) host.SecretStoreWriteReport {
+    return .{
+        .durable_write = switch (report.disposition) {
+            .unchanged => .unchanged,
+            .replaced => .replaced,
+            .indeterminate => .indeterminate,
+        },
+        .failure = if (report.failure != null) error.StoredKeyWriteFailed else null,
+    };
 }
 
 fn loadFromKeychain(alloc: Allocator) LoadError!?[]u8 {
@@ -171,6 +310,36 @@ fn storeInProfile(alloc: Allocator, value: []const u8) StoreError!void {
     return storeInDir(alloc, &fx_dir, value);
 }
 
+fn storeInProfileWithDisposition(alloc: Allocator, value: []const u8) host.SecretStoreWriteReport {
+    const home = io_mod.getenv("HOME") orelse {
+        logWriteFailed("home", error.HomeNotSet);
+        return .{ .durable_write = .unchanged, .failure = error.StoredKeyWriteFailed };
+    };
+    var home_dir = io_mod.VerifiedDir{
+        .dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch |err| {
+            logWriteFailed("open_home", err);
+            return .{ .durable_write = .unchanged, .failure = error.StoredKeyWriteFailed };
+        },
+    };
+    defer home_dir.close();
+
+    var fx_dir = io_mod.openOrCreateVerifiedPrivateDir(&home_dir, profile_paths.root_dir_name) catch |err| {
+        logWriteFailed("open_profile", err);
+        return .{ .durable_write = .unchanged, .failure = error.StoredKeyWriteFailed };
+    };
+    defer fx_dir.close();
+
+    io_mod.durableReplaceVerified(alloc, &fx_dir, profile_paths.api_key_file_name, value) catch |err| {
+        const durable_write: host.DurableWriteState = switch (err) {
+            error.DurableReplacePostRenameFailed => .replaced,
+            else => .unchanged,
+        };
+        logWriteFailed("replace", err);
+        return .{ .durable_write = durable_write, .failure = error.StoredKeyWriteFailed };
+    };
+    return .{ .durable_write = .replaced };
+}
+
 /// `durableReplaceVerified` creates the file at 0600 and re-stats it after the rename,
 /// so the mode this store depends on is enforced rather than assumed.
 fn storeInDir(alloc: Allocator, fx_dir: *io_mod.VerifiedDir, value: []const u8) StoreError!void {
@@ -181,8 +350,12 @@ fn storeInDir(alloc: Allocator, fx_dir: *io_mod.VerifiedDir, value: []const u8) 
 }
 
 fn writeFailed(step: []const u8, err: anyerror) StoreError {
-    debug_trace.logf("stored_key", "store failed step={s} err={s}", .{ step, @errorName(err) });
+    logWriteFailed(step, err);
     return error.StoredKeyWriteFailed;
+}
+
+fn logWriteFailed(step: []const u8, err: anyerror) void {
+    debug_trace.logf("stored_key", "store failed step={s} err={s}", .{ step, @errorName(err) });
 }
 
 test "stored key backend label names the platform store" {
@@ -192,6 +365,26 @@ test "stored key backend label names the platform store" {
         try std.testing.expectEqualStrings("profile file", backend_label);
     }
     try std.testing.expectEqualStrings(backend_label, provider.backend_label);
+}
+
+test "native secret store preserves Keychain publication certainty" {
+    const unchanged = keychainStoreWriteReport(.{
+        .disposition = .unchanged,
+        .failure = error.KeychainWriteFailed,
+    });
+    try std.testing.expectEqual(host.DurableWriteState.unchanged, unchanged.durable_write);
+    try std.testing.expectEqual(error.StoredKeyWriteFailed, unchanged.failure.?);
+
+    const indeterminate = keychainStoreWriteReport(.{
+        .disposition = .indeterminate,
+        .failure = error.KeychainWriteFailed,
+    });
+    try std.testing.expectEqual(host.DurableWriteState.indeterminate, indeterminate.durable_write);
+    try std.testing.expectEqual(error.StoredKeyWriteFailed, indeterminate.failure.?);
+
+    const replaced = keychainStoreWriteReport(.{ .disposition = .replaced });
+    try std.testing.expectEqual(host.DurableWriteState.replaced, replaced.durable_write);
+    try std.testing.expect(replaced.failure == null);
 }
 
 test "stored key file round-trips byte-identically at mode 0600" {

--- a/src/gateway/auth/api_key_validator.zig
+++ b/src/gateway/auth/api_key_validator.zig
@@ -11,6 +11,7 @@ pub const Result = enum {
 pub const ValidateFn = *const fn (?*anyopaque, Allocator, []const u8) Result;
 
 pub const Provider = struct {
+    /// Vercel adapter validation capability; generic auth sees only normalized outcomes.
     /// When set, context must remain valid until every in-flight validation returns.
     context: ?*anyopaque = null,
     validate_fn: ValidateFn,


### PR DESCRIPTION
Stack: 9 of 10.
Depends on #54.
Next: #2.

Summary
- Implement Vercel source inventory and entered-secret handling behind the adapter.
- Harden native secret publication and keep ordinary builds isolated from the test seam.

Verification
- zig build test
- native-auth-e2e ReleaseSafe build
- fresh binary help and status smoke