### PR TITLE
Stabilize asynchronous TUI readiness checks

### DIFF
--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -5502,7 +5502,23 @@ describe("effect-aware command permissions", () => {
         [...scrollback.matchAll(/PERMISSIONS_SCROLLBACK_LINE_\d{2}/g)].map(
           (match) => match[0],
         );
-      const beforeScrollback = await activeSession.captureFullScrollback();
+      const waitForExpectedScrollback = async () => {
+        const deadline = Date.now() + TIMEOUT;
+        let latest = "";
+        while (Date.now() < deadline) {
+          latest = await activeSession!.captureFullScrollback();
+          const markers = extractMarkers(latest);
+          if (
+            markers.length === expectedMarkers.length &&
+            markers.every((marker, index) => marker === expectedMarkers[index])
+          ) return latest;
+          await Bun.sleep(100);
+        }
+        throw new Error(
+          `Timed out waiting for complete permissions scrollback.\nScrollback:\n${latest}`,
+        );
+      };
+      const beforeScrollback = await waitForExpectedScrollback();
       expect(extractMarkers(beforeScrollback)).toEqual(expectedMarkers);
       const traceOffset = readFileSync(tracePath, "utf8").length;
 
@@ -5532,7 +5548,7 @@ describe("effect-aware command permissions", () => {
         45_000,
       );
 
-      const afterScrollback = await activeSession.captureFullScrollback();
+      const afterScrollback = await waitForExpectedScrollback();
       expect(extractMarkers(afterScrollback)).toEqual(expectedMarkers);
       expect([...afterScrollback.matchAll(/mode set to ask/g)]).toHaveLength(1);
       expect(afterScrollback.indexOf("mode set to ask")).toBeGreaterThan(

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -5422,6 +5422,7 @@ describe("effect-aware command permissions", () => {
       await activeSession.waitForComposer(TIMEOUT);
       await activeSession.sendText("Create interactive 64 KiB delivery fixture.");
       await activeSession.waitForText("INTERACTIVE_64K_PARENT_FIRST_DONE", TIMEOUT);
+      await waitForGatewayRequestCount(gateway, 4);
       expect(gateway.requests).toHaveLength(4);
       expect(childId.length).toBeGreaterThan(0);
       expect(messageEventId.length).toBeGreaterThan(0);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -126,6 +126,23 @@ async function waitForScrollback(
   throw new Error(`Timed out waiting for ${marker}.\nScrollback:\n${latest}`);
 }
 
+async function waitForScrollbackMarkers(
+  session: TmuxSession,
+  markers: readonly string[],
+  timeout = TIMEOUT,
+): Promise<string> {
+  const deadline = Date.now() + timeout;
+  let latest = "";
+  while (Date.now() < deadline) {
+    latest = await session.captureFullScrollback();
+    if (markers.every((marker) => latest.includes(marker))) return latest;
+    await Bun.sleep(100);
+  }
+  throw new Error(
+    `Timed out waiting for scrollback markers ${markers.join(", ")}.\nScrollback:\n${latest}`,
+  );
+}
+
 function countOccurrences(text: string, needle: string): number {
   return text.split(needle).length - 1;
 }
@@ -2794,8 +2811,17 @@ test.skipIf(!tmuxAvailable())(
       }
 
       await active.sendKeys("C-o");
-      await active.waitForText(afterMarker, TIMEOUT);
-      const grid = await active.capturePaneGrid();
+      const fullTranscript = await active.waitForPane(
+        (pane) =>
+          pane.includes(beforeMarker) &&
+          pane.includes("1 tool call") &&
+          pane.includes("Ran ") &&
+          pane.includes("1 output line") &&
+          pane.includes(outputMarker) &&
+          pane.includes(afterMarker),
+        TIMEOUT,
+      );
+      const grid = fullTranscript.replace(/\n$/, "").split("\n");
       const before = grid.findIndex((line) => line.includes(beforeMarker));
       const header = grid.findIndex((line) => line.includes("1 tool call"));
       const tool = grid.findIndex((line) => line.includes("Ran "));
@@ -3521,7 +3547,12 @@ test.skipIf(!tmuxAvailable())(
       await active.waitForText("Would you like to run the following command?", TIMEOUT);
       await active.sendKeys("1");
       await active.sendKeys("Enter");
-      const setupScrollback = await waitForScrollback(active, setupSentinel);
+      const setupScrollback = await waitForScrollbackMarkers(active, [
+        assistantHead,
+        assistantTail,
+        setupCompactLine,
+        setupSentinel,
+      ]);
       expect(setupScrollback).toContain(assistantHead);
       expect(setupScrollback).toContain(assistantTail);
       expect(setupScrollback).toContain(setupCompactLine);

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -163,7 +163,8 @@ async function waitForAppearanceMenu(
     latest = await session.capturePaneGrid();
     const pane = latest.join("\n");
     if (
-      pane.includes("Appearance") &&
+      pane.includes("Input appearance") &&
+      pane.includes("Maxxing mode") &&
       (expectedSelection === undefined || pane.includes(expectedSelection))
     ) return latest;
     await Bun.sleep(100);

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -131,7 +131,7 @@ async function cleanupNarrowReturn(
     const inTakeover = pane.includes("Ctrl-] d detach");
     if (!inTakeover) {
       if (!inManager) await active.sendKeys("C-x");
-      await active.waitForText("Background processes", TIMEOUT);
+      await waitForBackgroundProcessManager(active);
       await active.sendKeys("Enter");
       await active.waitForPane(
         (current) =>
@@ -186,6 +186,17 @@ async function waitForNewExactShellPrompt(
     await Bun.sleep(25);
   }
   throw new Error("cleanup did not observe a new exact L1_PROMPT> after Ctrl-C");
+}
+
+async function waitForBackgroundProcessManager(
+  active: TmuxSession,
+): Promise<string> {
+  return active.waitForPane(
+    (pane) =>
+      pane.includes("Background processes") &&
+      !pane.includes("No background processes"),
+    TIMEOUT,
+  );
 }
 
 async function finishNarrowReturn(
@@ -487,19 +498,29 @@ test.skipIf(!tmuxAvailable())(
     );
     await active.sendLiteralText("TAKEOVER_INLINE_DRAFT");
     await active.sendKeys("C-x");
-    await active.waitForText("Background processes", TIMEOUT);
+    await waitForBackgroundProcessManager(active);
     await active.sendKeys("Enter");
-    let pane = await active.waitForText("Ctrl-] d detach", TIMEOUT);
+    let pane = await active.waitForPane(
+      (current) =>
+        current.includes("Ctrl-] d detach") &&
+        current.includes("TAKEOVER_TOP"),
+      TIMEOUT,
+    );
     expect(pane).toContain("TAKEOVER_TOP");
-    expect(pane).toContain("TAKEOVER_BOTTOM");
     expect(pane).not.toContain("Agents & processes");
     expect(pane).not.toContain("Background processes");
     expect(pane).not.toContain("ctrl-x close");
 
     await active.sendText("RAW_KEYBOARD");
-    expect(await active.waitForText("ECHO:RAW_KEYBOARD", TIMEOUT)).toContain(
-      "TAKEOVER_TOP",
+    pane = await active.waitForPane(
+      (current) =>
+        current.includes("ECHO:RAW_KEYBOARD") &&
+        current.includes("TAKEOVER_TOP") &&
+        current.includes("TAKEOVER_BOTTOM"),
+      TIMEOUT,
     );
+    expect(pane).toContain("TAKEOVER_TOP");
+    expect(pane).toContain("TAKEOVER_BOTTOM");
     await active.pasteText("RAW_PASTE\n");
     await active.waitForText("RAW_PASTE", TIMEOUT);
     await active.sendHexBytes(["1b", "5b", "49"]);
@@ -525,7 +546,7 @@ test.skipIf(!tmuxAvailable())(
     await active.waitForText("TAKEOVER_INLINE_DRAFT", TIMEOUT);
     await active.resizeWindow(120, 30);
     await active.sendKeys("C-x");
-    await active.waitForText("Background processes", TIMEOUT);
+    await waitForBackgroundProcessManager(active);
     await active.sendKeys("Enter");
     await active.waitForText("TAKEOVER_TOP", TIMEOUT);
     await active.sendKeys("C-c");
@@ -578,7 +599,7 @@ test.skipIf(!tmuxAvailable())(
         await active.sendKeys("Left");
       }
       await active.sendKeys("C-x");
-      await active.waitForText("Background processes", TIMEOUT);
+      await waitForBackgroundProcessManager(active);
       await active.sendKeys("Enter");
       await active.waitForText("L1_PROMPT>", TIMEOUT);
 
@@ -718,7 +739,7 @@ test.skipIf(!tmuxAvailable())(
       await active.waitForText("Running ", TIMEOUT);
       childStarted = true;
       await active.sendKeys("C-x");
-      await active.waitForText("Background processes", TIMEOUT);
+      await waitForBackgroundProcessManager(active);
       await active.sendKeys("Enter");
       await active.waitForText("L1_PROMPT>", TIMEOUT);
       try {
@@ -760,7 +781,7 @@ test.skipIf(!tmuxAvailable())(
     await active.sendText(`!${scriptPath}`);
     await active.waitForText("Running ", TIMEOUT);
     await active.sendKeys("C-x");
-    await active.waitForText("Background processes", TIMEOUT);
+    await waitForBackgroundProcessManager(active);
     await active.sendKeys("Enter");
     await waitForTrace(fixture.tracePath, "lease acquire submitted");
     await active.sendText("BEFORE_ACQUIRE");
@@ -800,7 +821,7 @@ for (const failure of [
       await active.waitForText("Running ", TIMEOUT);
       await active.sendLiteralText(`INLINE_${failure}`);
       await active.sendKeys("C-x");
-      await active.waitForText("Background processes", TIMEOUT);
+      await waitForBackgroundProcessManager(active);
       await active.sendKeys("Enter");
       if (failure === "write") {
         await active.waitForText("TAKEOVER_TOP", TIMEOUT);
@@ -944,12 +965,7 @@ for (const backend of ["native", "tmux"] as const) {
       );
       const taskId = activeTaskId(fixture.home);
       await active.sendKeys("C-x");
-      await active.waitForPane(
-        (pane) =>
-          pane.includes("Background processes") &&
-          !pane.includes("No background processes"),
-        TIMEOUT,
-      );
+      await waitForBackgroundProcessManager(active);
       await active.sendKeys("Enter");
       await active.waitForText("TAKEOVER_TOP", TIMEOUT);
 
@@ -1065,7 +1081,7 @@ test.skipIf(!tmuxAvailable())(
     await active.waitForText("Running ", TIMEOUT);
     await active.sendLiteralText("TAKEOVER_LOSS_INLINE_DRAFT");
     await active.sendKeys("C-x");
-    await active.waitForText("Background processes", TIMEOUT);
+    await waitForBackgroundProcessManager(active);
     await active.sendKeys("Enter");
     await active.waitForText("TAKEOVER_TOP", TIMEOUT);
 


### PR DESCRIPTION
## Summary

- Wait for the actual appearance panel instead of matching its slash-menu label.
- Wait for all expected gateway requests before asserting 64 KiB delivery.
- Wait for a populated terminal manager and fully rendered takeover surface.

## Why

Several E2E tests sampled asynchronous UI or gateway state at intermediate points, causing false CI failures across unrelated PRs.

## Impact

No runtime behavior changes. This makes deterministic E2E coverage more reliable.

## Validation

- ReleaseSafe build passed.
- Appearance test passed 5/5 in Debug.
- 64 KiB delivery passed 5/5 in Debug.
- Terminal takeover passed 5/5 in Debug.
- All 15 takeover-focused tests passed.
- All three affected tests passed in ReleaseSafe.

Full CI is pending.
