### PR TITLE
Prepare v0.4.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
 # fx
 
-## 0.4.3
+## 0.4.4
 
 <!-- release:start -->
+
+### New Features
+
+- **Native Node.js agents:** Run headless fx agents inside Node.js through a native `libfx` addon, with fetch streaming and cancellation handled by the host
+- **Shared JavaScript SDK:** Use `createFxAgent()` and `createFxTerminal()` from `libfx` in Node.js or the browser, with WebAssembly fallback when a native surface is unavailable
+
+### Bug Fixes
+
+- **Signed-in account data:** Restore model catalog and credit balance loading for Vercel-authenticated sessions
+<!-- release:end -->
+
+## 0.4.3
 
 ### Improvements
 
 - **Smaller macOS arm64 binary:** Reduce the native binary size with profile-guided optimization tuned to common fx workloads
-<!-- release:end -->
 
 ## 0.4.2
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const build_options = @import("build_options");
 const io_mod = @import("core/shared/io.zig");
 
-pub const version = "0.4.3";
+pub const version = "0.4.4";
 
 const app_lifecycle = @import("core/app/app_lifecycle.zig");
 const auth_runtime = @import("core/auth/auth_runtime.zig");


### PR DESCRIPTION
## Summary

- Bump `src/main.zig` to 0.4.4
- Add the `CHANGELOG.md` entry for 0.4.4
- Move the active release markers from 0.4.3 to 0.4.4
