### PR TITLE
Signal terminal jobs outside the shell process group

### DIFF
--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -12,6 +12,7 @@ const process_supervisor = @import("../background/process_supervisor.zig");
 const background_process_provider = @import(
     "../execution/background_process_provider.zig",
 );
+const process_tree = @import("../execution/process_tree.zig");
 const command_admission = @import("../permissions/command_admission.zig");
 const sandbox = @import("../permissions/sandbox.zig");
 const execution_router = @import("../execution/router.zig");
@@ -3128,6 +3129,11 @@ fn applyMonitorSocketTimeout(stream: std.Io.net.Stream, timeout_ms: i64) void {
     ) catch {};
 }
 
+const SignalTarget = struct {
+    pid: std.posix.pid_t,
+    token: process_supervisor.ProcessInstanceToken,
+};
+
 const Session = struct {
     alloc: Allocator,
     tracker: WorkTracker,
@@ -4107,6 +4113,58 @@ const Session = struct {
 
     fn signalProcess(self: *Session, signal: contracts.Signal) bool {
         return self.signalNative(signalValue(signal));
+    }
+
+    fn signalTarget(self: *Session) ?SignalTarget {
+        const zio = io_mod.getIo();
+        self.mutex.lockUncancelable(zio);
+        defer self.mutex.unlock(zio);
+        if (!contracts.lifecycle_controls(self.lifecycle).signal) return null;
+        return .{
+            .pid = self.child_pid orelse return null,
+            .token = self.child_token orelse return null,
+        };
+    }
+
+    fn matchesSignalTarget(self: *Session, target: SignalTarget) bool {
+        var pid_buffer: [32]u8 = undefined;
+        const pid_text = std.fmt.bufPrint(
+            &pid_buffer,
+            "{d}",
+            .{target.pid},
+        ) catch return false;
+        return self.durable.profile.process_provider.matchToken(
+            self.alloc,
+            pid_text,
+            target.token,
+        ) == .matched;
+    }
+
+    fn signalTerminalProcesses(
+        self: *Session,
+        signal: contracts.Signal,
+    ) !bool {
+        const target = self.signalTarget() orelse return false;
+        if (!self.matchesSignalTarget(target)) return false;
+
+        var descendants = try process_tree.Tracker.init(self.alloc);
+        defer descendants.deinit();
+        descendants.refresh(target.pid) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.ProcessIdentityUnavailable,
+        };
+        if (!self.matchesSignalTarget(target)) return false;
+
+        const delivered = descendants.signalOutsideProcessGroup(
+            signalValue(signal),
+            target.pid,
+        );
+        debug_trace.logf(
+            "terminal_host",
+            "session signal reached outside-group descendants id={s} count={d}",
+            .{ self.id, delivered },
+        );
+        return self.signalProcess(signal);
     }
 
     fn signalNative(self: *Session, signal: std.c.SIG) bool {
@@ -5431,7 +5489,7 @@ fn signalAction(
         request.authority.?,
         .signal,
     );
-    if (!session.signalProcess(request.signal)) {
+    if (!try session.signalTerminalProcesses(request.signal)) {
         return error.ProcessIdentityUnavailable;
     }
     session.mutex.lockUncancelable(zio);

--- a/tests/e2e/terminal-host.test.ts
+++ b/tests/e2e/terminal-host.test.ts
@@ -262,6 +262,18 @@ function processExists(pid: number): boolean {
   }
 }
 
+function processGroupId(pid: number): number {
+  const value = Number(
+    execFileSync("ps", ["-p", String(pid), "-o", "pgid="], {
+      encoding: "utf8",
+    }).trim(),
+  );
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`missing process group for ${pid}`);
+  }
+  return value;
+}
+
 function processFdCount(pid: number): number {
   const proc = `/proc/${pid}/fd`;
   if (existsSync(proc)) return readdirSync(proc).length;
@@ -7538,6 +7550,85 @@ test("writes resize waits cancellation signals and close remain session-scoped",
   expect(await waitForExit(host)).toBe(0);
   expect(existsSync(paths.socket)).toBe(false);
 }, NATIVE_STARTUP_OBSERVATION_BUDGET_MS * 8 + 60_000);
+
+test("signal reaches a background job outside the shell process group", async () => {
+  if (!existsSync("/bin/zsh")) return;
+  const home = makeHome();
+  const paths = hostPaths(home);
+  const proofPath = join(home, "background-signal.proof");
+  const termPath = join(home, "background-signal.term");
+  const stopPath = join(home, "background-signal.stop");
+  const scriptPath = join(home, "background-signal.sh");
+  writeFileSync(
+    scriptPath,
+    `#!/bin/sh
+trap 'printf term > ${JSON.stringify(termPath)}; exit 0' TERM
+printf '%s %s %s\n' "$$" "$PPID" "$(ps -o pgid= -p $$ | tr -d ' ')" > ${JSON.stringify(proofPath)}
+while [ ! -e ${JSON.stringify(stopPath)} ]; do sleep 0.05; done
+`,
+  );
+  chmodSync(scriptPath, 0o700);
+
+  const host = startHost(home, undefined, 200);
+  await waitFor(() => existsSync(paths.socket));
+  const control = await handshake(paths.socket, { minimum: 4, current: 5 });
+  let targetPid = 0;
+
+  try {
+    const started = await startNativeCommandFixture(
+      control.client,
+      control.revision!,
+      313_000,
+      {
+        cwd: home,
+        command:
+          `${JSON.stringify(scriptPath)} & child=$!; ` +
+          `while [ ! -s ${JSON.stringify(proofPath)} ]; do sleep 0.05; done; ` +
+          "printf 'background-signal-ready\\n'; wait \"$child\"",
+        shell: { executable: { path: "/bin/zsh", clean_start: true } },
+        returnWhen: { match: "background-signal-ready" },
+      },
+    );
+    const sessionId = (started.session as { session_id: string }).session_id;
+    const [pidText, parentText, pgidText] = readFileSync(proofPath, "utf8")
+      .trim()
+      .split(/\s+/);
+    targetPid = Number(pidText);
+    const targetParentPid = Number(parentText);
+    const targetPgid = Number(pgidText);
+    const shellPid = Number(durableTerminalRecordFor(home, sessionId).pid);
+    expect(targetPid).toBeGreaterThan(0);
+    expect(targetParentPid).toBe(shellPid);
+    expect(targetPgid).toBe(processGroupId(targetPid));
+    expect(targetPgid).not.toBe(processGroupId(shellPid));
+
+    const signaled = await requestAction(
+      control.client,
+      control.revision!,
+      313_010,
+      "signal",
+      { session_id: sessionId, signal: "terminate" },
+    );
+    expect(success(signaled, "signal").signal).toBe("terminate");
+    await waitFor(
+      () => existsSync(termPath) && readFileSync(termPath, "utf8") === "term",
+      2_000,
+    );
+    expect(readFileSync(termPath, "utf8")).toBe("term");
+    await waitFor(() => !processExists(targetPid), 5_000);
+  } finally {
+    writeFileSync(stopPath, "");
+    if (targetPid > 0 && processExists(targetPid)) {
+      await waitFor(() => !processExists(targetPid), 5_000).catch(() => {
+        try {
+          process.kill(targetPid, "SIGKILL");
+        } catch {}
+      });
+    }
+    control.client.close();
+    if (host.exitCode === null) await waitForExit(host);
+  }
+}, NATIVE_STARTUP_OBSERVATION_BUDGET_MS * 3 + 30_000);
 
 test.skipIf(!tmuxAvailable())(
   "malformed close recovery cleans only its tmux owner and preserves a live sibling",

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -68,6 +68,27 @@ function processExists(pid: number): boolean {
   }
 }
 
+function processGroupId(pid: number): number {
+  const value = Number(
+    execFileSync("ps", ["-p", String(pid), "-o", "pgid="], {
+      encoding: "utf8",
+    }).trim(),
+  );
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`missing process group for ${pid}`);
+  }
+  return value;
+}
+
+async function waitForSignalMarker(path: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (existsSync(path) && readFileSync(path, "utf8") === "term") return;
+    await Bun.sleep(25);
+  }
+  throw new Error(`terminal signal marker did not appear at ${path}`);
+}
+
 function directChildPids(pid: number): number[] {
   return execFileSync("ps", ["-axo", "pid=,ppid="], { encoding: "utf8" })
     .trim()
@@ -1520,6 +1541,100 @@ test.skipIf(!tmuxAvailable())(
     expect(listResult).toContain('"lifecycle":"exited"');
     expect(listResult).not.toContain("owner_authority");
     expect(listResult).not.toContain("proof");
+    expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
+  "TUI public signal reaches a foreground job outside the shell process group",
+  async () => {
+    const fixture = createFixture("fx-tui-terminal-public-signal-");
+    const proofPath = join(fixture.root, "foreground-signal.proof");
+    const termPath = join(fixture.root, "foreground-signal.term");
+    const scriptPath = join(fixture.workspace, "foreground-signal.sh");
+    writeFileSync(
+      scriptPath,
+      `#!${TERMINAL_FIXTURE_SHELL}
+trap 'printf term > ${JSON.stringify(termPath)}; exit 0' TERM
+printf '%s %s %s\n' "$$" "$PPID" "$(ps -o pgid= -p $$ | tr -d ' ')" > ${JSON.stringify(proofPath)}
+printf 'TUI_PUBLIC_SIGNAL_READY\n'
+${holdUntilCleanup(fixture.root)}
+`,
+    );
+    chmodSync(scriptPath, 0o700);
+
+    let terminalSessionId = "";
+    let targetPid = 0;
+    const gateway = startFakeGateway([
+      fakeGatewayToolCall("tui_terminal_signal_start", "terminal", {
+        action: "start",
+        cwd: fixture.workspace,
+        command: JSON.stringify(scriptPath),
+        shell: {
+          kind: "executable",
+          path: TERMINAL_FIXTURE_SHELL,
+          clean_start: true,
+        },
+        backend: "native",
+        return_when: {
+          kind: "match",
+          pattern: "TUI_PUBLIC_SIGNAL_READY",
+        },
+        wait_ceiling_ms: 20_000,
+        dimensions: { rows: 24, columns: 80 },
+      }),
+      async (body) => {
+        const result = JSON.parse(
+          toolResultText(body, "tui_terminal_signal_start"),
+        ) as {
+          success: { start: { session: { session_id: string } } };
+        };
+        terminalSessionId = result.success.start.session.session_id;
+        expect(terminalSessionId.length).toBeGreaterThan(0);
+        await waitForTrace(proofPath, " ");
+        const [pidText, parentText, pgidText] = readFileSync(proofPath, "utf8")
+          .trim()
+          .split(/\s+/);
+        targetPid = Number(pidText);
+        const targetParentPid = Number(parentText);
+        const targetPgid = Number(pgidText);
+        const record = await waitForTerminalRecord(
+          fixture.home,
+          (candidate) => candidate.session_id === terminalSessionId,
+        );
+        const shellPid = Number(record.pid);
+        expect(targetPid).toBeGreaterThan(0);
+        expect(targetParentPid).toBe(shellPid);
+        expect(targetPgid).toBe(processGroupId(targetPid));
+        expect(targetPgid).not.toBe(processGroupId(shellPid));
+        return fakeGatewayToolCall("tui_terminal_signal", "terminal", {
+          action: "signal",
+          session_id: terminalSessionId,
+          signal: "terminate",
+        });
+      },
+      (body) => {
+        const result = JSON.parse(
+          toolResultText(body, "tui_terminal_signal"),
+        ) as { success: { signal: { signal: string } } };
+        expect(result.success.signal.signal).toBe("terminate");
+        return fakeGatewayFinalText("TUI public terminal signal complete");
+      },
+    ]);
+    gateways.push(gateway);
+    const active = await launch(fixture, gateway);
+
+    await active.sendText("Signal the foreground terminal fixture.");
+    const pane = await active.waitForText(
+      "TUI public terminal signal complete",
+      TIMEOUT,
+    );
+    expect(pane).toContain("Used terminal start");
+    expect(pane).toContain("Used terminal signal");
+    expect(gateway.requests).toHaveLength(3);
+    await waitForSignalMarker(termPath);
+    await waitForOwnedProcessExit([targetPid]);
     expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
   },
   TIMEOUT,


### PR DESCRIPTION
## Summary

- Deliver explicit terminal signals to foreground and background jobs outside the shell process group.
- Preserve the existing shell-group delivery result as the signal success condition.

Stacked on #30.