### PR TITLE
Report pull request binary size

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -1,0 +1,134 @@
+name: Binary Size
+
+on:
+  pull_request:
+
+concurrency:
+  group: binary-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    name: macOS arm64 ReleaseSafe delta
+    runs-on: macos-15
+    timeout-minutes: 30
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: "0.16.0"
+          use-cache: false
+
+      - name: Test size reporter
+        run: python3 -m unittest scripts.tests.test_binary_size -v
+
+      - name: Build pull request binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/fx-binary-size-evidence"
+          mkdir -p "$evidence_dir"
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          zig build \
+            -Dtarget=aarch64-macos \
+            -Doptimize=ReleaseSafe \
+            --cache-dir "$RUNNER_TEMP/fx-head-cache" \
+            --global-cache-dir "$RUNNER_TEMP/fx-global-cache"
+          cp zig-out/bin/fx "$evidence_dir/head-fx"
+          file "$evidence_dir/head-fx" > "$evidence_dir/head-file.txt"
+          cat "$evidence_dir/head-file.txt"
+          grep -q "Mach-O 64-bit executable arm64" "$evidence_dir/head-file.txt"
+          size -m "$evidence_dir/head-fx" > "$evidence_dir/head-sections.txt"
+          cat "$evidence_dir/head-sections.txt"
+
+      - name: Build base binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/fx-binary-size-evidence"
+          base_worktree="$RUNNER_TEMP/fx-binary-size-base"
+          cleanup() {
+            git worktree remove --force "$base_worktree" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT INT TERM
+          git worktree add --detach "$base_worktree" "$BASE_SHA"
+          test "$(git -C "$base_worktree" rev-parse HEAD)" = "$BASE_SHA"
+          (
+            cd "$base_worktree"
+            zig build \
+              -Dtarget=aarch64-macos \
+              -Doptimize=ReleaseSafe \
+              --cache-dir "$RUNNER_TEMP/fx-base-cache" \
+              --global-cache-dir "$RUNNER_TEMP/fx-global-cache"
+          )
+          cp "$base_worktree/zig-out/bin/fx" "$evidence_dir/base-fx"
+          file "$evidence_dir/base-fx" > "$evidence_dir/base-file.txt"
+          cat "$evidence_dir/base-file.txt"
+          grep -q "Mach-O 64-bit executable arm64" "$evidence_dir/base-file.txt"
+          size -m "$evidence_dir/base-fx" > "$evidence_dir/base-sections.txt"
+          cat "$evidence_dir/base-sections.txt"
+
+      - name: Compare binary sizes
+        id: size
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/fx-binary-size-evidence"
+          python3 -m scripts.binary_size \
+            --base-binary "$evidence_dir/base-fx" \
+            --head-binary "$evidence_dir/head-fx" \
+            --base-sections "$evidence_dir/base-sections.txt" \
+            --head-sections "$evidence_dir/head-sections.txt" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --target aarch64-macos \
+            --warning-bytes 52429 \
+            --output-json "$evidence_dir/report.json" \
+            --output-markdown "$evidence_dir/report.md" \
+            --github-output "$GITHUB_OUTPUT"
+          cat "$evidence_dir/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Annotate notable growth
+        if: steps.size.outputs.warning == 'true'
+        env:
+          DELTA_BYTES: ${{ steps.size.outputs.delta_bytes }}
+        run: |
+          printf '%s\n' \
+            "::warning title=Binary size increase::ReleaseSafe grew by ${DELTA_BYTES} bytes; inspect the retained section report."
+
+      - name: Upload size evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-size-evidence-${{ github.event.pull_request.number }}
+          path: |
+            ${{ runner.temp }}/fx-binary-size-evidence/report.json
+            ${{ runner.temp }}/fx-binary-size-evidence/report.md
+            ${{ runner.temp }}/fx-binary-size-evidence/base-file.txt
+            ${{ runner.temp }}/fx-binary-size-evidence/head-file.txt
+            ${{ runner.temp }}/fx-binary-size-evidence/base-sections.txt
+            ${{ runner.temp }}/fx-binary-size-evidence/head-sections.txt
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload binaries for investigation
+        if: steps.size.outputs.warning == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-size-binaries-${{ github.event.pull_request.number }}
+          path: |
+            ${{ runner.temp }}/fx-binary-size-evidence/base-fx
+            ${{ runner.temp }}/fx-binary-size-evidence/head-fx
+          compression-level: 0
+          retention-days: 7

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -12,12 +12,39 @@ permissions:
 
 jobs:
   compare:
-    name: macOS arm64 ReleaseSafe delta
-    runs-on: macos-15
+    name: ReleaseSafe delta (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            target: x86_64-linux
+            runner: ubuntu-24.04
+            section_format: elf
+            expected_file: "ELF 64-bit LSB.*x86-64"
+          - name: linux-aarch64
+            target: aarch64-linux
+            runner: ubuntu-24.04-arm
+            section_format: elf
+            expected_file: "ELF 64-bit LSB.*ARM aarch64"
+          - name: macos-x86_64
+            target: x86_64-macos
+            runner: macos-15-intel
+            section_format: macho
+            expected_file: "Mach-O 64-bit executable x86_64"
+          - name: macos-aarch64
+            target: aarch64-macos
+            runner: macos-15
+            section_format: macho
+            expected_file: "Mach-O 64-bit executable arm64"
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.sha }}
+      EXPECTED_FILE: ${{ matrix.expected_file }}
+      SECTION_FORMAT: ${{ matrix.section_format }}
+      TARGET: ${{ matrix.target }}
 
     steps:
       - uses: actions/checkout@v4
@@ -41,15 +68,19 @@ jobs:
           mkdir -p "$evidence_dir"
           test "$(git rev-parse HEAD)" = "$HEAD_SHA"
           zig build \
-            -Dtarget=aarch64-macos \
+            -Dtarget=${{ matrix.target }} \
             -Doptimize=ReleaseSafe \
             --cache-dir "$RUNNER_TEMP/fx-head-cache" \
             --global-cache-dir "$RUNNER_TEMP/fx-global-cache"
           cp zig-out/bin/fx "$evidence_dir/head-fx"
           file "$evidence_dir/head-fx" > "$evidence_dir/head-file.txt"
           cat "$evidence_dir/head-file.txt"
-          grep -q "Mach-O 64-bit executable arm64" "$evidence_dir/head-file.txt"
-          size -m "$evidence_dir/head-fx" > "$evidence_dir/head-sections.txt"
+          grep -Eq "$EXPECTED_FILE" "$evidence_dir/head-file.txt"
+          if [ "$SECTION_FORMAT" = "macho" ]; then
+            size -m "$evidence_dir/head-fx" > "$evidence_dir/head-sections.txt"
+          else
+            size -A -d "$evidence_dir/head-fx" > "$evidence_dir/head-sections.txt"
+          fi
           cat "$evidence_dir/head-sections.txt"
 
       - name: Build base binary
@@ -67,7 +98,7 @@ jobs:
           (
             cd "$base_worktree"
             zig build \
-              -Dtarget=aarch64-macos \
+              -Dtarget=${{ matrix.target }} \
               -Doptimize=ReleaseSafe \
               --cache-dir "$RUNNER_TEMP/fx-base-cache" \
               --global-cache-dir "$RUNNER_TEMP/fx-global-cache"
@@ -75,8 +106,12 @@ jobs:
           cp "$base_worktree/zig-out/bin/fx" "$evidence_dir/base-fx"
           file "$evidence_dir/base-fx" > "$evidence_dir/base-file.txt"
           cat "$evidence_dir/base-file.txt"
-          grep -q "Mach-O 64-bit executable arm64" "$evidence_dir/base-file.txt"
-          size -m "$evidence_dir/base-fx" > "$evidence_dir/base-sections.txt"
+          grep -Eq "$EXPECTED_FILE" "$evidence_dir/base-file.txt"
+          if [ "$SECTION_FORMAT" = "macho" ]; then
+            size -m "$evidence_dir/base-fx" > "$evidence_dir/base-sections.txt"
+          else
+            size -A -d "$evidence_dir/base-fx" > "$evidence_dir/base-sections.txt"
+          fi
           cat "$evidence_dir/base-sections.txt"
 
       - name: Compare binary sizes
@@ -92,7 +127,7 @@ jobs:
             --head-sections "$evidence_dir/head-sections.txt" \
             --base-sha "$BASE_SHA" \
             --head-sha "$HEAD_SHA" \
-            --target aarch64-macos \
+            --target "$TARGET" \
             --warning-bytes 52429 \
             --output-json "$evidence_dir/report.json" \
             --output-markdown "$evidence_dir/report.md" \
@@ -105,13 +140,13 @@ jobs:
           DELTA_BYTES: ${{ steps.size.outputs.delta_bytes }}
         run: |
           printf '%s\n' \
-            "::warning title=Binary size increase::ReleaseSafe grew by ${DELTA_BYTES} bytes; inspect the retained section report."
+            "::warning title=Binary size increase::${TARGET} ReleaseSafe grew by ${DELTA_BYTES} bytes; inspect the retained section report."
 
       - name: Upload size evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: binary-size-evidence-${{ github.event.pull_request.number }}
+          name: binary-size-evidence-${{ matrix.name }}-${{ github.event.pull_request.number }}
           path: |
             ${{ runner.temp }}/fx-binary-size-evidence/report.json
             ${{ runner.temp }}/fx-binary-size-evidence/report.md
@@ -126,7 +161,7 @@ jobs:
         if: steps.size.outputs.warning == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: binary-size-binaries-${{ github.event.pull_request.number }}
+          name: binary-size-binaries-${{ matrix.name }}-${{ github.event.pull_request.number }}
           path: |
             ${{ runner.temp }}/fx-binary-size-evidence/base-fx
             ${{ runner.temp }}/fx-binary-size-evidence/head-fx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,19 @@ process baseline is diagnostic only and is never subtracted.
 
 When adding features, consider their impact on startup latency. The `fx help` path is the baseline cold-start benchmark.
 
+## Binary Size Observability
+
+Every pull request runs `.github/workflows/binary-size.yml`. The workflow builds
+the pull request merge commit and its base commit as stripped macOS arm64
+ReleaseSafe binaries on the same runner, then reports the exact byte and MiB
+delta plus Mach-O segment and section changes.
+
+The check is informational. An increase of at least 52,429 bytes (0.050000 MiB)
+emits a warning and retains both binaries for investigation, but does not reject
+the pull request. Investigate notable unexplained growth before changing the
+threshold. The full macOS arm64 PGSO release qualification remains authoritative
+for the 7.800 MiB production ceiling and performance gates.
+
 ## Documentation
 
 When adding or changing user-facing features, update **all** relevant files:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,16 +336,18 @@ When adding features, consider their impact on startup latency. The `fx help` pa
 
 ## Binary Size Observability
 
-Every pull request runs `.github/workflows/binary-size.yml`. The workflow builds
-the pull request merge commit and its base commit as stripped macOS arm64
-ReleaseSafe binaries on the same runner, then reports the exact byte and MiB
-delta plus Mach-O segment and section changes.
+Every pull request runs `.github/workflows/binary-size.yml` across Linux x86_64,
+Linux arm64, macOS x86_64, and macOS arm64. Each matrix job builds the pull
+request merge commit and its base commit as stripped ReleaseSafe binaries on
+the same native runner, then reports the exact byte and MiB delta plus ELF or
+Mach-O section changes.
 
-The check is informational. An increase of at least 52,429 bytes (0.050000 MiB)
-emits a warning and retains both binaries for investigation, but does not reject
-the pull request. Investigate notable unexplained growth before changing the
-threshold. The full macOS arm64 PGSO release qualification remains authoritative
-for the 7.800 MiB production ceiling and performance gates.
+Each platform check is informational. An increase of at least 52,429 bytes
+(0.050000 MiB) emits a warning and retains that platform's binaries for
+investigation, but does not reject the pull request. Investigate notable
+unexplained growth before changing the threshold. The full macOS arm64 PGSO
+release qualification remains authoritative for the 7.800 MiB production
+ceiling and performance gates.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,13 @@ Standard PR CI labels Debug and ReleaseSafe Build & Test and deterministic E2E r
 
 Changes to `build.zig` or `scripts/pgso/` also run the native macOS arm64 PGSO candidate workflow. That lane produces retained size, behavior, and performance evidence but does not alter any release artifact or update channel. Its pinned toolchain, local reproduction command, corpus exclusions, and failure rules are documented in [`scripts/pgso/README.md`](scripts/pgso/README.md).
 
+Every pull request also receives an informational macOS arm64 ReleaseSafe
+binary-size comparison. It builds the pull request merge commit and base commit
+on the same runner, reports exact file and Mach-O section deltas, and emits a
+warning at increases of 52,429 bytes (0.050000 MiB) or more. The warning requests
+investigation but does not replace the full PGSO release gate or reject a valid
+feature solely for adding code.
+
 ## Pull Requests
 
 Every PR must carry exactly one label that describes its primary intent:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,10 @@ Standard PR CI labels Debug and ReleaseSafe Build & Test and deterministic E2E r
 
 Changes to `build.zig` or `scripts/pgso/` also run the native macOS arm64 PGSO candidate workflow. That lane produces retained size, behavior, and performance evidence but does not alter any release artifact or update channel. Its pinned toolchain, local reproduction command, corpus exclusions, and failure rules are documented in [`scripts/pgso/README.md`](scripts/pgso/README.md).
 
-Every pull request also receives an informational macOS arm64 ReleaseSafe
-binary-size comparison. It builds the pull request merge commit and base commit
-on the same runner, reports exact file and Mach-O section deltas, and emits a
+Every pull request also receives informational ReleaseSafe binary-size
+comparisons for Linux x86_64, Linux arm64, macOS x86_64, and macOS arm64. Each
+comparison builds the pull request merge commit and base commit on the same
+native runner, reports exact file and ELF or Mach-O section deltas, and emits a
 warning at increases of 52,429 bytes (0.050000 MiB) or more. The warning requests
 investigation but does not replace the full PGSO release gate or reject a valid
 feature solely for adding code.

--- a/scripts/binary_size.py
+++ b/scripts/binary_size.py
@@ -14,6 +14,7 @@ SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 TARGET_PATTERN = re.compile(r"[A-Za-z0-9_.-]+")
 SEGMENT_PATTERN = re.compile(r"^Segment\s+(\S+):\s+(\d+)")
 SECTION_PATTERN = re.compile(r"^Section\s+(\S+):\s+(\d+)")
+ELF_SECTION_PATTERN = re.compile(r"^(\S+)\s+(\d+)\s+(?:0x)?[0-9A-Fa-f]+$")
 
 
 class BinarySizeError(RuntimeError):
@@ -76,6 +77,38 @@ def parse_macho_sections(path: pathlib.Path) -> tuple[dict[str, int], dict[str, 
     return segments, sections
 
 
+def parse_elf_sections(path: pathlib.Path) -> tuple[dict[str, int], dict[str, int]]:
+    if not path.is_file():
+        raise BinarySizeError(f"section report does not exist: {path}")
+    sections: dict[str, int] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        section_match = ELF_SECTION_PATTERN.match(raw_line.strip())
+        if not section_match:
+            continue
+        name = section_match.group(1)
+        if name in sections:
+            raise BinarySizeError(
+                f"section report contains duplicate section {name}: {path}"
+            )
+        sections[name] = int(section_match.group(2))
+    if not sections:
+        raise BinarySizeError(f"section report contains no ELF sections: {path}")
+    if ".text" not in sections:
+        raise BinarySizeError(f"section report is missing .text section: {path}")
+    return {}, sections
+
+
+def parse_sections(
+    path: pathlib.Path,
+    target: str,
+) -> tuple[dict[str, int], dict[str, int]]:
+    if target.endswith("-macos"):
+        return parse_macho_sections(path)
+    if target.endswith("-linux"):
+        return parse_elf_sections(path)
+    raise BinarySizeError(f"unsupported target: {target}")
+
+
 def deltas(base: dict[str, int], head: dict[str, int]) -> dict[str, int]:
     return {
         key: head.get(key, 0) - base.get(key, 0)
@@ -104,8 +137,8 @@ def build_report(
 
     base = artifact_evidence(base_binary, base_sha)
     head = artifact_evidence(head_binary, head_sha)
-    base_segments, base_section_values = parse_macho_sections(base_sections)
-    head_segments, head_section_values = parse_macho_sections(head_sections)
+    base_segments, base_section_values = parse_sections(base_sections, target)
+    head_segments, head_section_values = parse_sections(head_sections, target)
     delta_bytes = int(head["size_bytes"]) - int(base["size_bytes"])
     if delta_bytes > 0:
         direction = "increase"

--- a/scripts/binary_size.py
+++ b/scripts/binary_size.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+from collections.abc import Sequence
+
+
+MIB = 1_048_576
+DEFAULT_WARNING_BYTES = 52_429
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+TARGET_PATTERN = re.compile(r"[A-Za-z0-9_.-]+")
+SEGMENT_PATTERN = re.compile(r"^Segment\s+(\S+):\s+(\d+)")
+SECTION_PATTERN = re.compile(r"^Section\s+(\S+):\s+(\d+)")
+
+
+class BinarySizeError(RuntimeError):
+    pass
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def artifact_evidence(path: pathlib.Path, source_sha: str) -> dict[str, object]:
+    if not path.is_file() or path.stat().st_size <= 0:
+        raise BinarySizeError(f"binary is missing or empty: {path}")
+    size_bytes = path.stat().st_size
+    return {
+        "source_sha": source_sha,
+        "sha256": sha256_file(path),
+        "size_bytes": size_bytes,
+        "size_mib": size_bytes / MIB,
+    }
+
+
+def parse_macho_sections(path: pathlib.Path) -> tuple[dict[str, int], dict[str, int]]:
+    if not path.is_file():
+        raise BinarySizeError(f"section report does not exist: {path}")
+    segments: dict[str, int] = {}
+    sections: dict[str, int] = {}
+    seen_segments: set[str] = set()
+    current_segment: str | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        segment_match = SEGMENT_PATTERN.match(line)
+        if segment_match:
+            current_segment = segment_match.group(1)
+            if current_segment in seen_segments:
+                raise BinarySizeError(
+                    "section report contains duplicate segment "
+                    f"{current_segment}: {path}"
+                )
+            seen_segments.add(current_segment)
+            if current_segment != "__PAGEZERO":
+                segments[current_segment] = int(segment_match.group(2))
+            continue
+        section_match = SECTION_PATTERN.match(line)
+        if section_match and current_segment and current_segment != "__PAGEZERO":
+            key = f"{current_segment}.{section_match.group(1)}"
+            if key in sections:
+                raise BinarySizeError(
+                    f"section report contains duplicate section {key}: {path}"
+                )
+            sections[key] = int(section_match.group(2))
+    if not segments:
+        raise BinarySizeError(f"section report contains no Mach-O segments: {path}")
+    if "__TEXT" not in segments:
+        raise BinarySizeError(f"section report is missing __TEXT segment: {path}")
+    return segments, sections
+
+
+def deltas(base: dict[str, int], head: dict[str, int]) -> dict[str, int]:
+    return {
+        key: head.get(key, 0) - base.get(key, 0)
+        for key in sorted(set(base) | set(head))
+        if head.get(key, 0) != base.get(key, 0)
+    }
+
+
+def build_report(
+    *,
+    base_binary: pathlib.Path,
+    head_binary: pathlib.Path,
+    base_sections: pathlib.Path,
+    head_sections: pathlib.Path,
+    base_sha: str,
+    head_sha: str,
+    target: str,
+    warning_bytes: int,
+) -> dict[str, object]:
+    if not SHA_PATTERN.fullmatch(base_sha) or not SHA_PATTERN.fullmatch(head_sha):
+        raise BinarySizeError("source SHAs must be lowercase 40-character hex values")
+    if not TARGET_PATTERN.fullmatch(target):
+        raise BinarySizeError(f"invalid target: {target!r}")
+    if warning_bytes <= 0:
+        raise BinarySizeError("warning threshold must be positive")
+
+    base = artifact_evidence(base_binary, base_sha)
+    head = artifact_evidence(head_binary, head_sha)
+    base_segments, base_section_values = parse_macho_sections(base_sections)
+    head_segments, head_section_values = parse_macho_sections(head_sections)
+    delta_bytes = int(head["size_bytes"]) - int(base["size_bytes"])
+    if delta_bytes > 0:
+        direction = "increase"
+    elif delta_bytes < 0:
+        direction = "decrease"
+    else:
+        direction = "unchanged"
+    return {
+        "schema_version": 1,
+        "status": "warning" if delta_bytes >= warning_bytes else "ok",
+        "target": target,
+        "warning_threshold_bytes": warning_bytes,
+        "base": base,
+        "head": head,
+        "delta": {
+            "direction": direction,
+            "size_bytes": delta_bytes,
+            "size_mib": delta_bytes / MIB,
+            "percent": (delta_bytes / int(base["size_bytes"])) * 100,
+        },
+        "segment_deltas_bytes": deltas(base_segments, head_segments),
+        "section_deltas_bytes": deltas(base_section_values, head_section_values),
+    }
+
+
+def signed_bytes(value: int) -> str:
+    return f"{value:+,} bytes"
+
+
+def append_delta_table(
+    lines: list[str],
+    heading: str,
+    values: dict[str, int],
+    *,
+    limit: int | None = None,
+) -> None:
+    lines.extend(["", heading, ""])
+    ranked = sorted(values.items(), key=lambda item: (-abs(item[1]), item[0]))
+    if limit is not None:
+        ranked = ranked[:limit]
+    if not ranked:
+        lines.append("No changes detected.")
+        return
+    lines.extend(["| Name | Change in bytes |", "| --- | ---: |"])
+    lines.extend(f"| `{name}` | {value:+,} |" for name, value in ranked)
+
+
+def markdown_report(report: dict[str, object]) -> str:
+    base = report["base"]
+    head = report["head"]
+    delta = report["delta"]
+    assert isinstance(base, dict)
+    assert isinstance(head, dict)
+    assert isinstance(delta, dict)
+    status = str(report["status"])
+    direction = str(delta["direction"])
+    if status == "warning":
+        warning_bytes = int(report["warning_threshold_bytes"])
+        signal = (
+            "Review recommended: the increase meets the informational threshold of "
+            f"{warning_bytes:,} bytes ({warning_bytes / MIB:.6f} MiB)."
+        )
+    elif direction == "decrease":
+        signal = "The PR binary is smaller than the base binary."
+    elif direction == "unchanged":
+        signal = "The PR and base binaries have the same file size."
+    else:
+        signal = "The increase is within the informational warning threshold."
+    lines: list[str] = [
+        "# Binary size",
+        "",
+        "This comparison is informational. "
+        "Release PGSO qualification remains authoritative.",
+        "",
+        f"Target: `{report['target']}`",
+        "",
+        "| Artifact | Bytes | MiB | Source | SHA-256 |",
+        "| --- | ---: | ---: | --- | --- |",
+        (
+            f"| Base | {int(base['size_bytes']):,} | "
+            f"{float(base['size_mib']):.6f} | `{base['source_sha']}` | "
+            f"`{base['sha256']}` |"
+        ),
+        (
+            f"| PR | {int(head['size_bytes']):,} | "
+            f"{float(head['size_mib']):.6f} | `{head['source_sha']}` | "
+            f"`{head['sha256']}` |"
+        ),
+        "",
+        (
+            f"Change: **{signed_bytes(int(delta['size_bytes']))}** "
+            f"({float(delta['size_mib']):+.6f} MiB, "
+            f"{float(delta['percent']):+.3f}%)."
+        ),
+        "",
+        signal,
+    ]
+    segment_deltas = report["segment_deltas_bytes"]
+    section_deltas = report["section_deltas_bytes"]
+    assert isinstance(segment_deltas, dict)
+    assert isinstance(section_deltas, dict)
+    append_delta_table(lines, "## Segment changes", segment_deltas)
+    append_delta_table(
+        lines,
+        "## Largest section changes",
+        section_deltas,
+        limit=10,
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare stripped ReleaseSafe fx binaries",
+    )
+    parser.add_argument("--base-binary", type=pathlib.Path, required=True)
+    parser.add_argument("--head-binary", type=pathlib.Path, required=True)
+    parser.add_argument("--base-sections", type=pathlib.Path, required=True)
+    parser.add_argument("--head-sections", type=pathlib.Path, required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument(
+        "--warning-bytes",
+        type=int,
+        default=DEFAULT_WARNING_BYTES,
+    )
+    parser.add_argument("--output-json", type=pathlib.Path, required=True)
+    parser.add_argument("--output-markdown", type=pathlib.Path, required=True)
+    parser.add_argument("--github-output", type=pathlib.Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = build_report(
+            base_binary=args.base_binary,
+            head_binary=args.head_binary,
+            base_sections=args.base_sections,
+            head_sections=args.head_sections,
+            base_sha=args.base_sha,
+            head_sha=args.head_sha,
+            target=args.target,
+            warning_bytes=args.warning_bytes,
+        )
+    except BinarySizeError as error:
+        raise SystemExit(str(error)) from error
+
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.output_markdown.write_text(markdown_report(report), encoding="utf-8")
+    if args.github_output:
+        warning = str(report["status"] == "warning").lower()
+        delta = report["delta"]
+        assert isinstance(delta, dict)
+        args.github_output.write_text(
+            f"warning={warning}\n"
+            f"delta_bytes={int(delta['size_bytes'])}\n"
+            f"status={report['status']}\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_binary_size.py
+++ b/scripts/tests/test_binary_size.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from scripts.binary_size import (
+    BinarySizeError,
+    append_delta_table,
+    build_report,
+    markdown_report,
+    parse_macho_sections,
+)
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "binary-size.yml"
+
+
+class BinarySizeCliTests(unittest.TestCase):
+    def test_empty_delta_table_uses_generic_message(self) -> None:
+        lines: list[str] = []
+
+        append_delta_table(lines, "## Segment changes", {})
+
+        self.assertEqual(["", "## Segment changes", "", "No changes detected."], lines)
+
+    def test_threshold_increase_emits_warning_and_exact_evidence(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="fx-binary-size-") as tmp:
+            root = pathlib.Path(tmp)
+            base_binary = root / "base-fx"
+            head_binary = root / "head-fx"
+            base_binary.write_bytes(b"b" * 100_000)
+            head_binary.write_bytes(b"h" * 152_429)
+            base_sections = root / "base-sections.txt"
+            head_sections = root / "head-sections.txt"
+            base_sections.write_text(
+                "Segment __TEXT: 65536\n"
+                "\tSection __text: 50000\n"
+                "\ttotal 50000\n"
+                "Segment __LINKEDIT: 32768\n"
+                "total 98304\n",
+                encoding="utf-8",
+            )
+            head_sections.write_text(
+                "Segment __TEXT: 114688\n"
+                "\tSection __text: 102429\n"
+                "\ttotal 102429\n"
+                "Segment __LINKEDIT: 32768\n"
+                "total 147456\n",
+                encoding="utf-8",
+            )
+            json_path = root / "report.json"
+            markdown_path = root / "report.md"
+            github_output = root / "github-output.txt"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "scripts.binary_size",
+                    "--base-binary",
+                    str(base_binary),
+                    "--head-binary",
+                    str(head_binary),
+                    "--base-sections",
+                    str(base_sections),
+                    "--head-sections",
+                    str(head_sections),
+                    "--base-sha",
+                    "a" * 40,
+                    "--head-sha",
+                    "b" * 40,
+                    "--target",
+                    "aarch64-macos",
+                    "--warning-bytes",
+                    "52429",
+                    "--output-json",
+                    str(json_path),
+                    "--output-markdown",
+                    str(markdown_path),
+                    "--github-output",
+                    str(github_output),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            report = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual(1, report["schema_version"])
+            self.assertEqual("warning", report["status"])
+            self.assertEqual(52_429, report["delta"]["size_bytes"])
+            self.assertEqual(52_429, report["section_deltas_bytes"]["__TEXT.__text"])
+            self.assertEqual(49_152, report["segment_deltas_bytes"]["__TEXT"])
+            self.assertEqual(100_000, report["base"]["size_bytes"])
+            self.assertEqual(152_429, report["head"]["size_bytes"])
+            self.assertEqual("a" * 40, report["base"]["source_sha"])
+            self.assertEqual("b" * 40, report["head"]["source_sha"])
+            markdown = markdown_path.read_text(encoding="utf-8")
+            self.assertIn("+52,429 bytes", markdown)
+            self.assertIn("52,429 bytes (0.050000 MiB)", markdown)
+            self.assertIn("## Segment changes", markdown)
+            self.assertIn("| `__TEXT` | +49,152 |", markdown)
+            self.assertIn("## Largest section changes", markdown)
+            self.assertIn("| `__TEXT.__text` | +52,429 |", markdown)
+            self.assertEqual(
+                "warning=true\ndelta_bytes=52429\nstatus=warning\n",
+                github_output.read_text(encoding="utf-8"),
+            )
+
+    def test_section_parser_rejects_duplicate_architecture_output(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="fx-binary-size-") as tmp:
+            report = pathlib.Path(tmp) / "sections.txt"
+            report.write_text(
+                "Segment __TEXT: 65536\n"
+                "\tSection __text: 50000\n"
+                "Segment __TEXT: 73728\n"
+                "\tSection __text: 60000\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(BinarySizeError, "duplicate segment __TEXT"):
+                parse_macho_sections(report)
+
+    def test_decrease_is_informational_and_named_explicitly(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="fx-binary-size-") as tmp:
+            root = pathlib.Path(tmp)
+            base_binary = root / "base-fx"
+            head_binary = root / "head-fx"
+            base_binary.write_bytes(b"b" * 100)
+            head_binary.write_bytes(b"h" * 90)
+            base_sections = root / "base-sections.txt"
+            head_sections = root / "head-sections.txt"
+            base_sections.write_text("Segment __TEXT: 100\n", encoding="utf-8")
+            head_sections.write_text("Segment __TEXT: 90\n", encoding="utf-8")
+
+            report = build_report(
+                base_binary=base_binary,
+                head_binary=head_binary,
+                base_sections=base_sections,
+                head_sections=head_sections,
+                base_sha="a" * 40,
+                head_sha="b" * 40,
+                target="aarch64-macos",
+                warning_bytes=52_429,
+            )
+
+            delta = report["delta"]
+            self.assertIsInstance(delta, dict)
+            assert isinstance(delta, dict)
+            self.assertEqual("ok", report["status"])
+            self.assertEqual("decrease", delta.get("direction"))
+            self.assertIn(
+                "The PR binary is smaller than the base binary.",
+                markdown_report(report),
+            )
+
+    def test_section_parser_requires_executable_text_segment(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="fx-binary-size-") as tmp:
+            report = pathlib.Path(tmp) / "sections.txt"
+            report.write_text("Segment __DATA: 16384\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(BinarySizeError, "missing __TEXT segment"):
+                parse_macho_sections(report)
+
+
+class BinarySizeWorkflowTests(unittest.TestCase):
+    def test_pr_workflow_compares_isolated_release_safe_arm64_builds(self) -> None:
+        self.assertTrue(WORKFLOW_PATH.is_file(), "binary-size workflow is missing")
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("pull_request:", workflow)
+        self.assertNotIn("pull_request_target", workflow)
+        self.assertIn("contents: read", workflow)
+        self.assertIn("runs-on: macos-15", workflow)
+        self.assertIn("fetch-depth: 0", workflow)
+        self.assertIn("github.event.pull_request.base.sha", workflow)
+        self.assertIn('test "$(git rev-parse HEAD)" = "$HEAD_SHA"', workflow)
+        self.assertIn(
+            'test "$(git -C "$base_worktree" rev-parse HEAD)" = "$BASE_SHA"',
+            workflow,
+        )
+        self.assertIn("-Dtarget=aarch64-macos", workflow)
+        self.assertIn("-Doptimize=ReleaseSafe", workflow)
+        self.assertGreaterEqual(workflow.count("zig build"), 2)
+        self.assertGreaterEqual(workflow.count("size -m"), 2)
+        self.assertIn("python3 -m scripts.binary_size", workflow)
+        self.assertIn("$GITHUB_STEP_SUMMARY", workflow)
+        self.assertIn("::warning title=Binary size increase::", workflow)
+        self.assertIn("actions/upload-artifact@v4", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_binary_size.py
+++ b/scripts/tests/test_binary_size.py
@@ -114,6 +114,73 @@ class BinarySizeCliTests(unittest.TestCase):
                 github_output.read_text(encoding="utf-8"),
             )
 
+    def test_linux_report_attributes_elf_section_growth(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="fx-binary-size-") as tmp:
+            root = pathlib.Path(tmp)
+            base_binary = root / "base-fx"
+            head_binary = root / "head-fx"
+            base_binary.write_bytes(b"b" * 100_000)
+            head_binary.write_bytes(b"h" * 100_100)
+            base_sections = root / "base-sections.txt"
+            head_sections = root / "head-sections.txt"
+            base_sections.write_text(
+                f"{base_binary}  :\n"
+                "section              size       addr\n"
+                ".text               70000      16384\n"
+                ".rodata             20000      86016\n"
+                ".data                1000     106496\n"
+                "Total               91000\n",
+                encoding="utf-8",
+            )
+            head_sections.write_text(
+                f"{head_binary}  :\n"
+                "section              size       addr\n"
+                ".text               70060      16384\n"
+                ".rodata             20040      86016\n"
+                ".data                1000     106496\n"
+                "Total               91100\n",
+                encoding="utf-8",
+            )
+            json_path = root / "report.json"
+            markdown_path = root / "report.md"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "scripts.binary_size",
+                    "--base-binary",
+                    str(base_binary),
+                    "--head-binary",
+                    str(head_binary),
+                    "--base-sections",
+                    str(base_sections),
+                    "--head-sections",
+                    str(head_sections),
+                    "--base-sha",
+                    "a" * 40,
+                    "--head-sha",
+                    "b" * 40,
+                    "--target",
+                    "x86_64-linux",
+                    "--output-json",
+                    str(json_path),
+                    "--output-markdown",
+                    str(markdown_path),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            report = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual({}, report["segment_deltas_bytes"])
+            self.assertEqual(60, report["section_deltas_bytes"][".text"])
+            self.assertEqual(40, report["section_deltas_bytes"][".rodata"])
+            self.assertIn("| `.text` | +60 |", markdown_path.read_text())
+
     def test_section_parser_rejects_duplicate_architecture_output(self) -> None:
         with tempfile.TemporaryDirectory(prefix="fx-binary-size-") as tmp:
             report = pathlib.Path(tmp) / "sections.txt"
@@ -171,14 +238,23 @@ class BinarySizeCliTests(unittest.TestCase):
 
 
 class BinarySizeWorkflowTests(unittest.TestCase):
-    def test_pr_workflow_compares_isolated_release_safe_arm64_builds(self) -> None:
+    def test_pr_workflow_compares_all_supported_release_safe_targets(self) -> None:
         self.assertTrue(WORKFLOW_PATH.is_file(), "binary-size workflow is missing")
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
 
         self.assertIn("pull_request:", workflow)
         self.assertNotIn("pull_request_target", workflow)
         self.assertIn("contents: read", workflow)
-        self.assertIn("runs-on: macos-15", workflow)
+        self.assertIn("runs-on: ${{ matrix.runner }}", workflow)
+        for name, target, runner in (
+            ("linux-x86_64", "x86_64-linux", "ubuntu-24.04"),
+            ("linux-aarch64", "aarch64-linux", "ubuntu-24.04-arm"),
+            ("macos-x86_64", "x86_64-macos", "macos-15-intel"),
+            ("macos-aarch64", "aarch64-macos", "macos-15"),
+        ):
+            self.assertIn(f"name: {name}", workflow)
+            self.assertIn(f"target: {target}", workflow)
+            self.assertIn(f"runner: {runner}", workflow)
         self.assertIn("fetch-depth: 0", workflow)
         self.assertIn("github.event.pull_request.base.sha", workflow)
         self.assertIn('test "$(git rev-parse HEAD)" = "$HEAD_SHA"', workflow)
@@ -186,14 +262,17 @@ class BinarySizeWorkflowTests(unittest.TestCase):
             'test "$(git -C "$base_worktree" rev-parse HEAD)" = "$BASE_SHA"',
             workflow,
         )
-        self.assertIn("-Dtarget=aarch64-macos", workflow)
+        self.assertIn("-Dtarget=${{ matrix.target }}", workflow)
         self.assertIn("-Doptimize=ReleaseSafe", workflow)
         self.assertGreaterEqual(workflow.count("zig build"), 2)
         self.assertGreaterEqual(workflow.count("size -m"), 2)
+        self.assertGreaterEqual(workflow.count("size -A -d"), 2)
         self.assertIn("python3 -m scripts.binary_size", workflow)
         self.assertIn("$GITHUB_STEP_SUMMARY", workflow)
         self.assertIn("::warning title=Binary size increase::", workflow)
         self.assertIn("actions/upload-artifact@v4", workflow)
+        self.assertIn("binary-size-evidence-${{ matrix.name }}", workflow)
+        self.assertIn("binary-size-binaries-${{ matrix.name }}", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Compare stripped ReleaseSafe binaries for Linux x86_64, Linux arm64, macOS x86_64, and macOS arm64 with their base commit.
- Report exact file and ELF or Mach-O section deltas as retained evidence without blocking ordinary growth.
- Warn separately when a platform grows by at least 52,429 bytes and retain that platform's binaries for investigation.