### PR TITLE
Preserve Ctrl-O tail across detail views

### DIFF
--- a/src/core/output/transcript_presentation.zig
+++ b/src/core/output/transcript_presentation.zig
@@ -220,7 +220,7 @@ pub const State = struct {
 
     fn queue_bookmark(self: State) State {
         var next = self;
-        next.bookmark_pending = next.bookmark_entry_id != null;
+        next.bookmark_pending = !next.follow_tail and next.bookmark_entry_id != null;
         return next;
     }
 
@@ -311,27 +311,54 @@ test "transcript presentation scroll saturates and leaves follow tail" {
     try std.testing.expectEqual(std.math.maxInt(u32), at_end.scroll_rows);
 }
 
-test "transcript presentation preserves semantic item across depth and width" {
-    const initial = State{
-        .depth = .review,
-        .scroll_rows = 6,
-        .follow_tail = false,
-        .bookmark_entry_id = 20,
-        .bookmark_intra_row = 2,
-        .projection_cols = 80,
-    };
-    const resized = initial.with_depth(.full).prepare_projection(40);
-    try std.testing.expect(resized.bookmark_pending);
-
-    const selected = resized.select_visual_offset(20, 5, &.{
+test "transcript presentation depth changes preserve viewport intent" {
+    const item_rows = [_]ItemRow{
         .{ .entry_id = 10, .row = 0 },
         .{ .entry_id = 20, .row = 4 },
         .{ .entry_id = 30, .row = 10 },
-    });
-    try std.testing.expectEqual(@as(u32, 6), selected.offset);
-    try std.testing.expectEqual(@as(?u32, 20), selected.state.bookmark_entry_id);
-    try std.testing.expectEqual(@as(u32, 2), selected.state.bookmark_intra_row);
-    try std.testing.expect(!selected.state.bookmark_pending);
+    };
+
+    for ([_]struct { from: Depth, to: Depth }{
+        .{ .from = .review, .to = .full },
+        .{ .from = .full, .to = .review },
+    }) |transition| {
+        const tail = (State{
+            .depth = transition.from,
+            .scroll_rows = 4,
+            .follow_tail = true,
+            .bookmark_entry_id = 20,
+            .bookmark_intra_row = 2,
+        }).with_depth(transition.to);
+        try std.testing.expect(!tail.bookmark_pending);
+
+        const tail_selected = tail.select_visual_offset(20, 5, &item_rows);
+        try std.testing.expectEqual(@as(u32, 15), tail_selected.offset);
+        try std.testing.expect(tail_selected.state.follow_tail);
+
+        const history = (State{
+            .depth = transition.from,
+            .scroll_rows = 6,
+            .follow_tail = false,
+            .bookmark_entry_id = 20,
+            .bookmark_intra_row = 2,
+        }).with_depth(transition.to);
+        try std.testing.expect(history.bookmark_pending);
+
+        const history_selected = history.select_visual_offset(20, 5, &item_rows);
+        try std.testing.expectEqual(@as(u32, 6), history_selected.offset);
+        try std.testing.expectEqual(@as(?u32, 20), history_selected.state.bookmark_entry_id);
+        try std.testing.expectEqual(@as(u32, 2), history_selected.state.bookmark_intra_row);
+        try std.testing.expect(!history_selected.state.bookmark_pending);
+    }
+
+    const no_bookmark = (State{
+        .depth = .review,
+        .scroll_rows = 99,
+        .follow_tail = false,
+    }).with_depth(.full);
+    try std.testing.expect(!no_bookmark.bookmark_pending);
+    const clamped = no_bookmark.select_visual_offset(20, 5, &item_rows);
+    try std.testing.expectEqual(@as(u32, 15), clamped.offset);
 }
 
 test "transcript presentation clamps bookmarks and selects retained neighbor" {

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -9444,6 +9444,55 @@ pub const TranscriptRuntime = struct {
         return selection.offset;
     }
 
+    test "full transcript depth changes preserve tail and history viewport intent" {
+        const alloc = std.testing.allocator;
+        const review_measurement = full_transcript_screen.ProjectionMeasurement{
+            .total_rows = 13,
+            .anchor_row = null,
+            .item_rows = &.{
+                .{ .entry_id = 10, .row = 0 },
+                .{ .entry_id = 20, .row = 6 },
+            },
+        };
+        const full_measurement = full_transcript_screen.ProjectionMeasurement{
+            .total_rows = 30,
+            .anchor_row = null,
+            .item_rows = &.{
+                .{ .entry_id = 10, .row = 0 },
+                .{ .entry_id = 20, .row = 12 },
+                .{ .entry_id = 30, .row = 24 },
+            },
+        };
+
+        var tail = TranscriptRuntime{ .full_transcript = .{ .depth = .review } };
+        defer tail.deinit(alloc);
+        try std.testing.expectEqual(
+            @as(u32, 8),
+            selectProjectionViewportOffset(&tail, review_measurement, 5),
+        );
+        try std.testing.expect(try tail.setTranscriptPresentationDepth(alloc, .full));
+        try std.testing.expectEqual(
+            @as(u32, 25),
+            selectProjectionViewportOffset(&tail, full_measurement, 5),
+        );
+        try std.testing.expect(tail.full_transcript.follow_tail);
+
+        var history = TranscriptRuntime{ .full_transcript = .{ .depth = .review } };
+        defer history.deinit(alloc);
+        _ = selectProjectionViewportOffset(&history, review_measurement, 5);
+        history.full_transcript = history.full_transcript.scroll(.up, 2);
+        try std.testing.expectEqual(
+            @as(u32, 6),
+            selectProjectionViewportOffset(&history, review_measurement, 5),
+        );
+        try std.testing.expect(try history.setTranscriptPresentationDepth(alloc, .full));
+        try std.testing.expectEqual(
+            @as(u32, 12),
+            selectProjectionViewportOffset(&history, full_measurement, 5),
+        );
+        try std.testing.expect(!history.full_transcript.follow_tail);
+    }
+
     pub fn prepareTranscriptSurfacePaintFromSourceForArea(
         self: *TranscriptRuntime,
         alloc: Allocator,

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -36,6 +36,7 @@ const LIVE_START = "CTRL_O_BRUTAL_LIVE_0001";
 const LIVE_DONE = "CTRL_O_BRUTAL_LIVE_DONE";
 const DRAFT = "CTRL_O_BRUTAL_UNSENT_DRAFT";
 const RESUME_DRAFT = "CTRL_O_BRUTAL_RESUME_DRAFT";
+const TAIL_SENTINEL = "CTRL_O_TAIL_SENTINEL";
 const CTRL_O = ["0f"] as const;
 const PAGE_UP = ["1b", "5b", "35", "7e"] as const;
 const PAGE_DOWN = ["1b", "5b", "36", "7e"] as const;
@@ -322,6 +323,11 @@ function batchResponse(
     events.push(toolEvent(firstTool + offset, config.fileLines));
   }
   events.push({
+    type: "text-delta",
+    id: `ctrl-o-brutal-tail-${batch}`,
+    delta: `${TAIL_SENTINEL}_B${pad(batch, 2)}\n`,
+  });
+  events.push({
     type: "finish",
     finishReason: { unified: "tool-calls", raw: "tool-calls" },
   });
@@ -382,7 +388,7 @@ done
   for (let batch = 0; batch < config.batches; batch += 1) {
     responses.push(batchResponse(batch, config));
   }
-  responses.push(fakeGatewayFinalText(HISTORY_DONE));
+  responses.push(fakeGatewayFinalText(`${HISTORY_DONE}\n${TAIL_SENTINEL}`));
   responses.push(fakeGatewayToolCall("ctrl-o-brutal-live", "run_command", {
     command: "./ctrl-o-live.sh",
   }));
@@ -699,6 +705,22 @@ async function thrashViewer(
   }
 }
 
+async function verifyTailSurvivesReviewToFull(
+  session: TmuxSession,
+): Promise<void> {
+  await session.sendHexBytes(CTRL_O);
+  const review = await waitForMode(session, "review", "");
+  expect(review).toContain(TAIL_SENTINEL);
+
+  await session.sendKeys("Right");
+  const full = await waitForMode(session, "full", "");
+  expect(full).toContain(TAIL_SENTINEL);
+  expect(session.paneStatus().dead).toBe(false);
+
+  await session.sendHexBytes(CTRL_O);
+  await session.waitForComposer(TIMEOUT);
+}
+
 async function verifyOldestTranscriptEntrySurvives(
   session: TmuxSession,
   draft: string,
@@ -856,6 +878,9 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
     expect(history).toContain(firstChatMarker(config));
     expect(history).toContain(lastChatMarker(config));
     expect(history).toContain(compactToolMarker(0));
+
+    await verifyTailSurvivesReviewToFull(session);
+    expect(readFileSync(paths.stderrPath, "utf8")).toBe("");
 
     await session.sendText("Run the prepared live command while I inspect the transcript.");
     await session.waitForText(LIVE_START, TIMEOUT);

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -1113,10 +1113,10 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
       await session.waitForComposer(TIMEOUT);
       const resumedScrollback = await waitForScrollback(
         session,
-        HISTORY_DONE,
+        LIVE_DONE,
         TIMEOUT * 2,
       );
-      expect(resumedScrollback).toContain(LIVE_DONE);
+      expect(resumedScrollback).toContain(HISTORY_DONE);
       await session.sendLiteralText(RESUME_DRAFT);
       await waitForMode(session, "main", RESUME_DRAFT);
       const resumedPid = fxProcessId(session);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -5801,8 +5801,11 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       await session.sendKeys("Right");
       const full = await session.waitForText("Full detail · ←/→ switch · ctrl o close", TIMEOUT);
-      expect(full).toContain("● 3 tool calls · 3 commands");
-      expect(full).not.toContain(workspace);
+      expect(full).toContain(finalText);
+      await session.sendKeys("PPage");
+      const fullAtSummary = await session.waitForText("● 3 tool calls · 3 commands", TIMEOUT);
+      expect(fullAtSummary).toContain("● 3 tool calls · 3 commands");
+      expect(fullAtSummary).not.toContain(workspace);
 
       const trace = readFileSync(tracePath, "utf8");
       for (const callId of [

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -1010,11 +1010,16 @@ test.skipIf(!tmuxAvailable())(
 
       await active.sendKeys("Right");
       await active.waitForText("Full detail · ←/→ switch · ctrl o close · PgUp/PgDn scroll · Esc close", TIMEOUT);
-      const expandedAtReviewAnchor = await active.capturePane();
-      expect(expandedAtReviewAnchor).toContain("command: awk");
-      expect(expandedAtReviewAnchor).toContain(commandArgumentTail);
-      expect(expandedAtReviewAnchor).toContain("FULL_CTRL_O_LINE_0001");
-      expect(expandedAtReviewAnchor).not.toContain(tailMarker);
+      const expandedAtTail = await active.capturePane();
+      expect(expandedAtTail).toContain(tailMarker);
+      expect(expandedAtTail).not.toContain("FULL_CTRL_O_LINE_0001");
+
+      await active.sendKeys(Array.from({ length: 140 }, () => "PPage").join(" "));
+      const expandedAtHead = await active.waitForText("command: awk", TIMEOUT);
+      expect(expandedAtHead).toContain(commandArgumentTail);
+      expect(expandedAtHead).toContain("FULL_CTRL_O_LINE_0001");
+      expect(expandedAtHead).not.toContain(tailMarker);
+
       await active.sendKeys(Array.from({ length: 140 }, () => "NPage").join(" "));
       await active.waitForText(tailMarker, TIMEOUT);
       const full = await active.capturePane();
@@ -5340,19 +5345,21 @@ printf '${stdoutTail2}\\n'
       await session.waitForText("┃ Review · ←/→ switch · ctrl o close", TIMEOUT);
       await session.sendKeys("Right");
       await session.waitForText("┃ Full detail · ←/→ switch · ctrl o close", TIMEOUT);
-      const beforePageDown = await session.capturePane();
-      expect(beforePageDown).toContain(`│ ${firstMarker}`);
-      expect(countOccurrences(beforePageDown, firstMarker)).toBe(1);
-      expect(beforePageDown).not.toContain(stdoutTail2);
-      const pages = [beforePageDown];
-      for (let page = 0; page < 8 && !pages.at(-1)!.includes(stdoutTail2); page += 1) {
-        await session.sendHexBytes(["1b", "5b", "36", "7e"]);
+      const tail = await session.capturePane();
+      expect(tail).toContain(stdoutTail2);
+      expect(tail).not.toContain(firstMarker);
+
+      const pages = [tail];
+      for (let page = 0; page < 8 && !pages.at(-1)!.includes(firstMarker); page += 1) {
+        await session.sendHexBytes(["1b", "5b", "35", "7e"]);
         const next = await waitForChangedPane(session, pages.at(-1)!);
         if (next === null) break;
         pages.push(next);
       }
-      const tail = pages.at(-1)!;
-      const output = pages.join("\n").split("\n").filter((line) =>
+      const head = pages.at(-1)!;
+      expect(head).toContain(`│ ${firstMarker}`);
+      expect(countOccurrences(head, firstMarker)).toBe(1);
+      const output = [...pages].reverse().join("\n").split("\n").filter((line) =>
         line.trimStart().startsWith("│ ") && !line.includes("command:")
       ).join("\n");
       for (const marker of orderedTailMarkers) {


### PR DESCRIPTION
## Summary

- Keep tail-following Ctrl-O viewports pinned when switching between Review and Full detail.
- Preserve semantic bookmarks for manually scrolled history across detail changes.
- Keep expanded command history reachable with Page Up after switching to Full detail.
- Preserve retained stdout/stderr ordering across flag and picker resume.