### PR TITLE
Preserve tool calls across scoped context updates

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -421,6 +421,49 @@ fn appendNotExecutedToolResult(
     );
 }
 
+fn appendContextDeferredToolResult(
+    deps: *const AgentRuntimeDeps,
+    provisional_statuses: *runtime_tool_presentation.ProvisionalToolStatuses,
+    provisional_alloc: Allocator,
+    arena: Allocator,
+    turn_id: u64,
+    call: ToolCall,
+    advertised_dynamic_tool_names: []const []const u8,
+    step_ctx: TraceContext,
+    within_turn_suffix: *std.ArrayList(ChatMessage),
+    completed_tool_names: *std.ArrayList([]u8),
+    batch: *runtime_tool_batch.StepBatchState,
+) !void {
+    _ = try provisional_statuses.settleDeferredCall(
+        deps,
+        provisional_alloc,
+        arena,
+        turn_id,
+        call,
+        advertised_dynamic_tool_names,
+    );
+    debug_trace.eventf(
+        "tool",
+        "execution_result",
+        step_ctx,
+        "call_id={s} name={s} result_kind=context_deferred model_output_bytes={d}",
+        .{ call.id, call.name, types.context_deferred_tool_result_output.len },
+    );
+    try runtime_tool_batch.appendToolResultContent(
+        arena,
+        within_turn_suffix,
+        completed_tool_names,
+        batch,
+        call,
+        types.context_deferred_tool_result_output,
+        null,
+        .{
+            .increment_total = false,
+            .status = .failure,
+        },
+    );
+}
+
 fn providerExecutedResult(call: ToolCall) ?ToolExecutionResult {
     if (call.provenance != .provider_executed) return null;
     const provider_result = call.provider_result orelse return null;
@@ -4816,10 +4859,12 @@ fn processQueuedPromptLoop(
                 );
                 continue;
             }
-            if (context_delta) {
+            if (context_delta and
+                !runtime_parallel_execution.isReadOnlyCall(deps.tool_registry, tool_call))
+            {
                 if (preparation_batch.preparations[tool_call_index]) |preparation| {
                     if (preparation == .candidate) {
-                        try appendNotExecutedToolResult(
+                        try appendContextDeferredToolResult(
                             deps,
                             &stream_ctx.provisional_statuses,
                             stream_ctx.alloc,
@@ -4831,7 +4876,6 @@ fn processQueuedPromptLoop(
                             &within_turn_suffix,
                             &completed_tool_names,
                             &step_batch,
-                            "context_deferred",
                         );
                         continue;
                     }

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -333,6 +333,30 @@ fn commitSelectedContext(
     }
 }
 
+fn candidateHasApplicableContextDelta(
+    arena: Allocator,
+    context_registry: context_contract.Registry,
+    config: Config,
+    context_delivery_state: *const context_contract.DeliveryState,
+    candidate: tool_preparation.Candidate,
+) !bool {
+    switch (candidate.kind) {
+        .advertised_dynamic, .deferred_dynamic, .legacy_target_resolution => return true,
+        .registered => if (candidate.applicable_targets.len == 0) return false,
+    }
+
+    var selected = try context_registry.selectDefaultApplicableContext(arena, .{
+        .workspace_root = config.workspace_root,
+        .access_scope = config.access_scope,
+        .targets = candidate.applicable_targets,
+        .delivered_sources = context_delivery_state.delivered_sources.items,
+        .evaluated_endpoints = context_delivery_state.evaluated_endpoints.items,
+        .context_limits = config.context_limits,
+    });
+    defer selected.deinit(arena);
+    return selected.content != null;
+}
+
 const ParentTurnDeliveryState = struct {
     acknowledgements: []const runtime_deps.ParentTurnDeliveryAck = &.{},
     acknowledged: bool = false,
@@ -4200,6 +4224,18 @@ fn processQueuedPromptLoop(
             }
         }
 
+        const context_deferred_calls = arena.alloc(bool, prepared_tool_calls.len) catch |err| {
+            return settleFailedContextGate(
+                deps,
+                &stream_ctx.provisional_statuses,
+                stream_ctx.alloc,
+                turn_id,
+                effective_tool_calls,
+                advertised_dynamic_tool_names,
+                err,
+            );
+        };
+        @memset(context_deferred_calls, false);
         var context_delta = false;
         if (deps.context_enabled and preparation_batch.applicable_targets.items.len > 0) {
             const context_registry = deps.context_registry orelse
@@ -4224,6 +4260,51 @@ fn processQueuedPromptLoop(
             };
             defer selected.deinit(arena);
             for (selected.notices) |notice| try deps.pushContextNotice(notice);
+
+            context_delta = selected.content != null;
+            if (context_delta) {
+                if (prepared_tool_calls.len == 1) {
+                    if (!runtime_parallel_execution.isReadOnlyCall(
+                        deps.tool_registry,
+                        effective_tool_calls[0],
+                    )) {
+                        if (preparation_batch.preparations[0]) |preparation| {
+                            context_deferred_calls[0] = preparation == .candidate;
+                        }
+                    }
+                } else if (!config.cancel_flag.load(.seq_cst)) context_probes: {
+                    for (preparation_batch.preparations, effective_tool_calls, 0..) |maybe_preparation, tool_call, index| {
+                        if (runtime_parallel_execution.isReadOnlyCall(
+                            deps.tool_registry,
+                            tool_call,
+                        )) continue;
+                        const preparation = maybe_preparation orelse continue;
+                        const candidate = switch (preparation) {
+                            .terminal => continue,
+                            .candidate => |candidate| candidate,
+                        };
+                        context_deferred_calls[index] = candidateHasApplicableContextDelta(
+                            arena,
+                            context_registry,
+                            config,
+                            &context_delivery_state,
+                            candidate,
+                        ) catch |err| {
+                            if (config.cancel_flag.load(.seq_cst)) break :context_probes;
+                            return settleFailedContextGate(
+                                deps,
+                                &stream_ctx.provisional_statuses,
+                                stream_ctx.alloc,
+                                turn_id,
+                                effective_tool_calls,
+                                advertised_dynamic_tool_names,
+                                err,
+                            );
+                        };
+                        if (config.cancel_flag.load(.seq_cst)) break :context_probes;
+                    }
+                }
+            }
 
             if (config.cancel_flag.load(.seq_cst)) {
                 var cancelled_call: ?ToolCall = null;
@@ -4268,7 +4349,6 @@ fn processQueuedPromptLoop(
                 return;
             }
 
-            context_delta = selected.content != null;
             commitSelectedContext(
                 arena,
                 &stable_prefix,
@@ -4859,9 +4939,7 @@ fn processQueuedPromptLoop(
                 );
                 continue;
             }
-            if (context_delta and
-                !runtime_parallel_execution.isReadOnlyCall(deps.tool_registry, tool_call))
-            {
+            if (context_deferred_calls[tool_call_index]) {
                 if (preparation_batch.preparations[tool_call_index]) |preparation| {
                     if (preparation == .candidate) {
                         try appendContextDeferredToolResult(

--- a/src/core/agent/runtime/parallel_execution.zig
+++ b/src/core/agent/runtime/parallel_execution.zig
@@ -13,7 +13,7 @@ const ToolCall = types.ToolCall;
 const AgentRuntimeDeps = runtime_deps.AgentRuntimeDeps;
 const ToolExecutionResult = runtime_tool_contracts.ToolExecutionResult;
 
-fn isParallelReadOnlyCall(registry: tool_dispatch.Registry, call: ToolCall) bool {
+pub fn isReadOnlyCall(registry: tool_dispatch.Registry, call: ToolCall) bool {
     if (call.provider_result != null) return false;
 
     const tool = registry.lookup(call.name) orelse return false;
@@ -33,7 +33,7 @@ fn isParallelReadOnlyCall(registry: tool_dispatch.Registry, call: ToolCall) bool
 
 pub fn parallelReadOnlyPrefixLen(registry: tool_dispatch.Registry, calls: []const ToolCall) usize {
     var len: usize = 0;
-    while (len < calls.len and isParallelReadOnlyCall(registry, calls[len])) : (len += 1) {}
+    while (len < calls.len and isReadOnlyCall(registry, calls[len])) : (len += 1) {}
     return len;
 }
 
@@ -501,9 +501,9 @@ test "parallel classifier keeps only a leading safe read-only group" {
     };
 
     try std.testing.expectEqual(@as(usize, 2), parallelReadOnlyPrefixLen(registry, &calls));
-    try std.testing.expect(isParallelReadOnlyCall(registry, calls[0]));
-    try std.testing.expect(isParallelReadOnlyCall(registry, calls[1]));
-    try std.testing.expect(!isParallelReadOnlyCall(registry, calls[2]));
+    try std.testing.expect(isReadOnlyCall(registry, calls[0]));
+    try std.testing.expect(isReadOnlyCall(registry, calls[1]));
+    try std.testing.expect(!isReadOnlyCall(registry, calls[2]));
 }
 
 test "parallel classifier admits approval-bearing web fetch read groups" {
@@ -543,12 +543,12 @@ test "parallel classifier rejects prompts approvals dynamic tools and mutations"
     };
 
     for (cases) |call| {
-        try std.testing.expect(!isParallelReadOnlyCall(registry, call));
+        try std.testing.expect(!isReadOnlyCall(registry, call));
     }
 
     var provider_call = toolCall("provider_1", "read_file", "{\"path\":\"README.md\"}");
     provider_call.provider_result = "provider result";
-    try std.testing.expect(!isParallelReadOnlyCall(registry, provider_call));
+    try std.testing.expect(!isReadOnlyCall(registry, provider_call));
 }
 
 test "parallel read-only execution preserves order and failure fan-in" {

--- a/src/core/agent/runtime/parallel_execution.zig
+++ b/src/core/agent/runtime/parallel_execution.zig
@@ -24,6 +24,7 @@ pub fn isReadOnlyCall(registry: tool_dispatch.Registry, call: ToolCall) bool {
         .semantic_search,
         .grep_files,
         .file_info,
+        .skill,
         .web_fetch,
         .web_search,
         => tool.activity_kind == .read,
@@ -519,6 +520,20 @@ test "parallel classifier admits approval-bearing web fetch read groups" {
     };
 
     try std.testing.expectEqual(@as(usize, 2), parallelReadOnlyPrefixLen(registry, &calls));
+}
+
+test "parallel classifier admits installed skill reads" {
+    const builtin_tools = @import("../../../builtins/tools.zig");
+    const tools = [_]tool_dispatch.Tool{builtin_tools.skill};
+    const registry = tool_dispatch.Registry{ .tools = &tools };
+    const calls = [_]ToolCall{toolCall(
+        "skill_1",
+        "skill",
+        "{\"name\":\"demo\",\"location\":\"/tmp/demo\",\"resource\":\"SKILL.md\"}",
+    )};
+
+    try std.testing.expectEqual(@as(usize, 1), parallelReadOnlyPrefixLen(registry, &calls));
+    try std.testing.expect(isReadOnlyCall(registry, calls[0]));
 }
 
 test "parallel classifier rejects prompts approvals dynamic tools and mutations" {

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -3413,6 +3413,85 @@ test "modern context delta defers effectful call exactly once" {
     try std.testing.expectEqualStrings("Context updated write_file", terminal.outcome.summary);
 }
 
+test "modern context delta does not defer unrelated effectful call" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "workspace/nested");
+    {
+        var rules = try tmp.dir.createFile(
+            std.testing.io,
+            "workspace/nested/AGENTS.md",
+            .{},
+        );
+        defer rules.close(std.testing.io);
+        try rules.writeStreamingAll(
+            std.testing.io,
+            "UNRELATED_NESTED_SCOPE_RULE",
+        );
+        var input = try tmp.dir.createFile(
+            std.testing.io,
+            "workspace/nested/input.txt",
+            .{},
+        );
+        defer input.close(std.testing.io);
+        try input.writeStreamingAll(std.testing.io, "unchanged");
+    }
+    const workspace = try io_mod.dirRealpathAlloc(
+        alloc,
+        tmp.dir,
+        "workspace",
+    );
+    defer alloc.free(workspace);
+
+    const calls = [_]ToolCall{
+        toolCall(
+            "nested_read",
+            "read_file",
+            "{\"path\":\"nested/input.txt\"}",
+        ),
+        toolCall(
+            "root_create",
+            "create_folder",
+            "{\"path\":\"root-output\"}",
+        ),
+    };
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Final" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.context_enabled = true;
+    hooks.context_registry = .{ .default_provider = builtin_context.provider };
+    hooks.exec_plans = &.{
+        .{ .result = .{ .model_output = "nested input" } },
+        .{ .result = .{ .model_output = "root folder created" } },
+    };
+    var fixture = PromptFixture{ .workspace_root = workspace };
+    var job = fixture.job();
+    job.permission_mode = .auto;
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+    try expectBodyContains(&gateway, 1, "UNRELATED_NESTED_SCOPE_RULE");
+    try expectBodyNotContains(
+        &gateway,
+        1,
+        types.context_deferred_tool_result_output,
+    );
+    const expected_ids = [_][]const u8{ "nested_read", "root_create" };
+    try std.testing.expectEqual(expected_ids.len, hooks.permission_call_ids.items.len);
+    try std.testing.expectEqual(expected_ids.len, hooks.executed_call_ids.items.len);
+    for (expected_ids, hooks.permission_call_ids.items, hooks.executed_call_ids.items) |expected, permission_id, execution_id| {
+        try std.testing.expectEqualStrings(expected, permission_id);
+        try std.testing.expectEqualStrings(expected, execution_id);
+    }
+}
+
 test "modern later selector errors escape atomically and settle changed provisional identity" {
     const alloc = std.testing.allocator;
     defer FailingApplicableContext.reset(.out_of_memory, "");

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -2704,7 +2704,7 @@ test "modern serial preparation classifies once and disabled context keeps legac
     }
 }
 
-test "modern directory file_info waits for nested project instructions" {
+test "modern directory file_info executes while nested project instructions load" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -2733,14 +2733,8 @@ test "modern directory file_info waits for nested project instructions" {
         "file_info",
         "{\"path\":\"nested\"}",
     )};
-    const reissued_calls = [_]ToolCall{toolCall(
-        "inspect_directory_b",
-        "file_info",
-        "{\"path\":\"nested\"}",
-    )};
     const completions = [_]FakeCompletion{
         .{ .tool_calls = &first_calls },
-        .{ .tool_calls = &reissued_calls },
         .{ .content = "Final" },
     };
     var gateway = FakeGateway.init(alloc, &completions);
@@ -2755,18 +2749,18 @@ test "modern directory file_info waits for nested project instructions" {
 
     try runFakePrompt(&gateway, &hooks, fixture.config(), job);
 
-    try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
     try expectBodyNotContains(&gateway, 0, "MODERN_DIRECTORY_SCOPE_RULE");
     try expectBodyContains(&gateway, 1, "MODERN_DIRECTORY_SCOPE_RULE");
-    try expectBodyContains(&gateway, 1, "Not executed");
+    try expectBodyNotContains(&gateway, 1, types.context_deferred_tool_result_output);
     try std.testing.expectEqual(@as(usize, 1), hooks.permission_names.items.len);
     try std.testing.expectEqualStrings(
-        "inspect_directory_b",
+        "inspect_directory_a",
         hooks.permission_call_ids.items[0],
     );
     try std.testing.expectEqual(@as(usize, 1), hooks.executed_names.items.len);
     try std.testing.expectEqualStrings(
-        "inspect_directory_b",
+        "inspect_directory_a",
         hooks.executed_call_ids.items[0],
     );
 }
@@ -2866,13 +2860,9 @@ test "same-batch retarget defers stale scoped call before permission and reloads
     const scoped_reissue_calls = [_]ToolCall{
         toolCall("scoped_reissue", "read_file", "{\"path\":\"link/secret.txt\"}"),
     };
-    const execution_reissue_calls = [_]ToolCall{
-        toolCall("execution_reissue", "read_file", "{\"path\":\"link/secret.txt\"}"),
-    };
     const completions = [_]FakeCompletion{
         .{ .tool_calls = &first_calls, .streamed_tool_starts = &first_calls },
         .{ .tool_calls = &scoped_reissue_calls, .streamed_tool_starts = &scoped_reissue_calls },
-        .{ .tool_calls = &execution_reissue_calls, .streamed_tool_starts = &execution_reissue_calls },
         .{ .content = "Final" },
     };
     var gateway = FakeGateway.init(alloc, &completions);
@@ -2896,12 +2886,13 @@ test "same-batch retarget defers stale scoped call before permission and reloads
 
     try runFakePrompt(&gateway, &hooks, fixture.config(), job);
 
-    try std.testing.expectEqual(@as(usize, 3), FreshnessApplicableContext.select_calls);
+    try std.testing.expectEqual(@as(usize, 2), FreshnessApplicableContext.select_calls);
     try std.testing.expect(FreshnessApplicableContext.first_saw_old_target);
     try std.testing.expect(FreshnessApplicableContext.reissue_saw_new_target);
-    try std.testing.expect(FreshnessApplicableContext.execution_reissue_saw_new_target);
+    try std.testing.expect(!FreshnessApplicableContext.execution_reissue_saw_new_target);
+    try expectBodyNotContains(&gateway, 1, FreshnessApplicableContext.content);
     try expectBodyContains(&gateway, 2, FreshnessApplicableContext.content);
-    const expected_ids = [_][]const u8{ "retarget", "stable_info", "execution_reissue" };
+    const expected_ids = [_][]const u8{ "retarget", "stable_info", "scoped_reissue" };
     try std.testing.expectEqual(expected_ids.len, hooks.permission_call_ids.items.len);
     try std.testing.expectEqual(expected_ids.len, hooks.executed_call_ids.items.len);
     for (expected_ids, hooks.permission_call_ids.items, hooks.executed_call_ids.items) |expected, permission_id, execution_id| {
@@ -2937,15 +2928,14 @@ test "same-batch retarget defers stale scoped call before permission and reloads
     try std.testing.expectEqual(@as(usize, 0), stale_authoritative);
 
     const execution = hooks.history_turns.items[0].assistant.execution;
-    try std.testing.expectEqual(@as(usize, 3), execution.tool_steps.len);
+    try std.testing.expectEqual(@as(usize, 2), execution.tool_steps.len);
     try std.testing.expectEqual(@as(usize, 3), execution.tool_steps[0].tool_results.len);
     try std.testing.expectEqualStrings("retargeted", execution.tool_steps[0].tool_results[0].output);
     try std.testing.expectEqualStrings("Not executed", execution.tool_steps[0].tool_results[1].output);
     try std.testing.expectEqual(types.PersistedToolStatus.failure, execution.tool_steps[0].tool_results[1].status);
     try std.testing.expectEqualStrings("stable info", execution.tool_steps[0].tool_results[2].output);
-    try std.testing.expectEqualStrings("Not executed", execution.tool_steps[1].tool_results[0].output);
-    try std.testing.expectEqual(types.PersistedToolStatus.failure, execution.tool_steps[1].tool_results[0].status);
-    try std.testing.expectEqualStrings("new scope access", execution.tool_steps[2].tool_results[0].output);
+    try std.testing.expectEqualStrings("new scope access", execution.tool_steps[1].tool_results[0].output);
+    try std.testing.expectEqual(types.PersistedToolStatus.success, execution.tool_steps[1].tool_results[0].status);
 }
 
 test "same-batch file mutation retarget stops before permission and execution" {
@@ -3047,13 +3037,9 @@ test "same-batch missing target defers newly resolvable scope until reissue" {
     const scoped_reissue_calls = [_]ToolCall{
         toolCall("scoped_reissue", "read_file", "{\"path\":\"link/secret.txt\"}"),
     };
-    const execution_reissue_calls = [_]ToolCall{
-        toolCall("execution_reissue", "read_file", "{\"path\":\"link/secret.txt\"}"),
-    };
     const completions = [_]FakeCompletion{
         .{ .tool_calls = &first_calls, .streamed_tool_starts = &first_calls },
         .{ .tool_calls = &scoped_reissue_calls, .streamed_tool_starts = &scoped_reissue_calls },
-        .{ .tool_calls = &execution_reissue_calls, .streamed_tool_starts = &execution_reissue_calls },
         .{ .content = "Final" },
     };
     var gateway = FakeGateway.init(alloc, &completions);
@@ -3076,14 +3062,14 @@ test "same-batch missing target defers newly resolvable scope until reissue" {
 
     try runFakePrompt(&gateway, &hooks, fixture.config(), job);
 
-    try std.testing.expectEqual(@as(usize, 3), FreshnessApplicableContext.select_calls);
+    try std.testing.expectEqual(@as(usize, 2), FreshnessApplicableContext.select_calls);
     try std.testing.expect(!FreshnessApplicableContext.first_saw_new_target);
     try std.testing.expect(FreshnessApplicableContext.reissue_saw_new_target);
-    try std.testing.expect(FreshnessApplicableContext.execution_reissue_saw_new_target);
+    try std.testing.expect(!FreshnessApplicableContext.execution_reissue_saw_new_target);
     try expectBodyNotContains(&gateway, 0, FreshnessApplicableContext.content);
     try expectBodyNotContains(&gateway, 1, FreshnessApplicableContext.content);
     try expectBodyContains(&gateway, 2, FreshnessApplicableContext.content);
-    const expected_ids = [_][]const u8{ "resolve_scope", "execution_reissue" };
+    const expected_ids = [_][]const u8{ "resolve_scope", "scoped_reissue" };
     try std.testing.expectEqual(expected_ids.len, hooks.permission_call_ids.items.len);
     try std.testing.expectEqual(expected_ids.len, hooks.executed_call_ids.items.len);
     for (expected_ids, hooks.permission_call_ids.items, hooks.executed_call_ids.items) |expected, permission_id, execution_id| {
@@ -3110,11 +3096,10 @@ test "same-batch missing target defers newly resolvable scope until reissue" {
     try std.testing.expectEqual(@as(usize, 0), stale_authoritative);
 
     const execution = hooks.history_turns.items[0].assistant.execution;
-    try std.testing.expectEqual(@as(usize, 3), execution.tool_steps.len);
+    try std.testing.expectEqual(@as(usize, 2), execution.tool_steps.len);
     try std.testing.expectEqualStrings("scope resolved", execution.tool_steps[0].tool_results[0].output);
     try std.testing.expectEqualStrings("Not executed", execution.tool_steps[0].tool_results[1].output);
-    try std.testing.expectEqualStrings("Not executed", execution.tool_steps[1].tool_results[0].output);
-    try std.testing.expectEqualStrings("new scope access", execution.tool_steps[2].tool_results[0].output);
+    try std.testing.expectEqualStrings("new scope access", execution.tool_steps[1].tool_results[0].output);
 }
 
 test "modern mixed batch materializes unsupported terminal before admission" {
@@ -3366,7 +3351,7 @@ test "modern cancellation during later context selection stops before context or
     try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
 }
 
-test "modern context delta settles changed provisional identity exactly once" {
+test "modern context delta defers effectful call exactly once" {
     const alloc = std.testing.allocator;
     defer ApplicableContextDelta.reset("", null);
     var tmp = std.testing.tmpDir(.{});
@@ -3383,15 +3368,15 @@ test "modern context delta settles changed provisional identity exactly once" {
     defer alloc.free(target);
 
     const streamed = [_]ToolCall{toolCall(
-        "provisional_read",
-        "read_file",
-        "{\"path\":\"nested/input.txt\"}",
+        "provisional_write",
+        "write_file",
+        "{\"path\":\"nested/input.txt\",\"content\":\"changed\"}",
     )};
     const calls = [_]ToolCall{.{
-        .id = "final_read",
-        .provisional_id = "provisional_read",
-        .name = "read_file",
-        .arguments_json = "{\"path\":\"nested/input.txt\"}",
+        .id = "final_write",
+        .provisional_id = "provisional_write",
+        .name = "write_file",
+        .arguments_json = "{\"path\":\"nested/input.txt\",\"content\":\"changed\"}",
     }};
     const completions = [_]FakeCompletion{
         .{ .tool_calls = &calls, .streamed_tool_starts = &streamed },
@@ -3411,24 +3396,21 @@ test "modern context delta settles changed provisional identity exactly once" {
     try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
     try expectBodyNotContains(&gateway, 0, ApplicableContextDelta.content);
     try expectBodyContains(&gateway, 1, ApplicableContextDelta.content);
-    try expectBodyContains(&gateway, 1, "Not executed");
+    try expectBodyContains(&gateway, 1, types.context_deferred_tool_result_output);
     try std.testing.expectEqual(@as(usize, 1), ApplicableContextDelta.select_calls);
     try std.testing.expect(ApplicableContextDelta.saw_expected_input);
     try std.testing.expectEqual(@as(usize, 0), hooks.permission_names.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try expectLifecycleCallIds(
         hooks.lifecycle_events.items,
-        &.{ "provisional_read", "provisional_read", "provisional_read" },
+        &.{ "final_write", "final_write", "final_write" },
     );
-    try std.testing.expect(hooks.lifecycle_events.items[0] == .provisional);
+    try std.testing.expect(hooks.lifecycle_events.items[0] == .authoritative_started);
     try std.testing.expect(hooks.lifecycle_events.items[1] == .progress);
     try std.testing.expect(hooks.lifecycle_events.items[2] == .terminal);
     const terminal = hooks.lifecycle_events.items[2].terminal;
-    try std.testing.expectEqual(types.ToolOutcomeKind.denied, terminal.outcome.kind);
-    try std.testing.expectEqualStrings("Not executed read_file", terminal.outcome.summary);
-    for (hooks.lifecycle_events.items) |event| {
-        try std.testing.expect(event != .authoritative_started);
-    }
+    try std.testing.expectEqual(types.ToolOutcomeKind.deferred, terminal.outcome.kind);
+    try std.testing.expectEqualStrings("Context updated write_file", terminal.outcome.summary);
 }
 
 test "modern later selector errors escape atomically and settle changed provisional identity" {

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -216,6 +216,41 @@ pub const ProvisionalToolStatuses = struct {
         );
     }
 
+    pub fn settleDeferredCall(
+        self: *ProvisionalToolStatuses,
+        hooks: *const AgentRuntimeDeps,
+        alloc: Allocator,
+        arena: Allocator,
+        turn_id: u64,
+        call: ToolCall,
+        advertised_dynamic_tool_names: []const []const u8,
+    ) !bool {
+        const recorded_terminal = try self.recordTerminal(alloc, call.id);
+        if (!recorded_terminal) return false;
+        errdefer self.forgetTerminal(alloc, call.id);
+        const target = try self.ensureTerminalTarget(
+            hooks,
+            arena,
+            turn_id,
+            call,
+            false,
+            null,
+            advertised_dynamic_tool_names,
+        ) orelse {
+            self.forgetTerminal(alloc, call.id);
+            return false;
+        };
+        try finishDeferredToolStatus(
+            hooks,
+            arena,
+            turn_id,
+            target.call,
+            advertised_dynamic_tool_names,
+        );
+        if (target.tracked_id) |tracked_id| self.forget(alloc, tracked_id);
+        return true;
+    }
+
     pub fn finishDeniedCall(
         self: *ProvisionalToolStatuses,
         hooks: *const AgentRuntimeDeps,
@@ -794,6 +829,30 @@ pub fn finishDeniedToolStatus(
         null,
         null,
     );
+}
+
+fn finishDeferredToolStatus(
+    hooks: *const AgentRuntimeDeps,
+    arena: Allocator,
+    turn_id: u64,
+    call: ToolCall,
+    advertised_dynamic_tool_names: []const []const u8,
+) !void {
+    const line = try hooks.describe_tool_action_denied(
+        hooks.ctx,
+        arena,
+        call,
+        null,
+        types.context_deferred_tool_status_label,
+        advertised_dynamic_tool_names,
+    );
+    try hooks.push_tool_lifecycle(hooks.ctx, .{ .terminal = .{
+        .id = .{ .turn_id = turn_id, .call_id = call.id },
+        .outcome = .{
+            .kind = .deferred,
+            .summary = line,
+        },
+    } });
 }
 
 pub fn finishDeniedToolStatusWithResultMemory(

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -3553,6 +3553,7 @@ pub fn Runtime(comptime App: type) type {
             if (try writeCommittedFilePresentation(app, sink, call, result)) return;
 
             const is_command = std.mem.eql(u8, result.tool_name, "run_command");
+            const context_deferred = types.isContextDeferredToolResult(result);
             const deferred = types.isDeferredToolResult(result);
             const process_ran = is_command and
                 result.command_process_presentation != null;
@@ -3564,7 +3565,10 @@ pub fn Runtime(comptime App: type) type {
                     action_arena.allocator(),
                     call,
                     null,
-                    types.context_deferred_tool_status_label,
+                    if (context_deferred)
+                        types.context_deferred_tool_status_label
+                    else
+                        types.deferred_tool_result_output,
                     &.{},
                 )
             else if (result.status == .success or process_ran)
@@ -3585,8 +3589,10 @@ pub fn Runtime(comptime App: type) type {
             const action = try app.alloc.dupe(u8, formatted_action);
             defer app.alloc.free(action);
 
-            const outcome: types.ToolOutcomeKind = if (deferred)
+            const outcome: types.ToolOutcomeKind = if (context_deferred)
                 .deferred
+            else if (deferred)
+                .denied
             else if (result.status == .success or process_ran)
                 .completed
             else
@@ -6538,6 +6544,11 @@ test "execution replay preserves paired deferred tools without command output" {
             .name = "run_command",
             .arguments_json = "{\"command\":\"cat nested/input.txt\"}",
         },
+        .{
+            .id = "call_legacy",
+            .name = "read_file",
+            .arguments_json = "{\"path\":\"stale.txt\"}",
+        },
     };
     var results = [_]types.PersistedToolResult{
         .{
@@ -6561,6 +6572,14 @@ test "execution replay preserves paired deferred tools without command output" {
             .command_output_replay = .unavailable,
             .command_process_presentation = .{ .exit_code = 7 },
         },
+        .{
+            .tool_call_id = @constCast("call_legacy"),
+            .tool_name = @constCast("read_file"),
+            .status = .failure,
+            .output = @constCast(types.deferred_tool_result_output),
+            .output_bytes = types.deferred_tool_result_output.len,
+            .stored_output_bytes = types.deferred_tool_result_output.len,
+        },
     };
     var steps = [_]types.ToolExecutionStep{.{
         .tool_calls = calls[0..],
@@ -6571,13 +6590,14 @@ test "execution replay preserves paired deferred tools without command output" {
 
     try std.testing.expectEqualSlices(
         types.ToolOutcomeKind,
-        &.{ .deferred, .deferred },
+        &.{ .deferred, .deferred, .denied },
         app.completed_tool_outcomes.items,
     );
-    try std.testing.expectEqual(@as(usize, 2), app.completed_tool_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), app.completed_tool_statuses.items.len);
     try std.testing.expectEqualStrings("● Context updated read_file\n", app.completed_tool_statuses.items[0]);
     try std.testing.expectEqualStrings("● Context updated run_command\n", app.completed_tool_statuses.items[1]);
-    try std.testing.expectEqual(@as(usize, 2), app.historical_tool_detail_entry_ids.items.len);
+    try std.testing.expectEqualStrings("● Not executed read_file\n", app.completed_tool_statuses.items[2]);
+    try std.testing.expectEqual(@as(usize, 3), app.historical_tool_detail_entry_ids.items.len);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
     try std.testing.expectEqual(@as(usize, 0), app.command_output_writes.items.len);
     try std.testing.expectEqual(@as(usize, 0), app.command_stdout.items.len);
@@ -6585,7 +6605,7 @@ test "execution replay preserves paired deferred tools without command output" {
     try std.testing.expectEqual(@as(usize, 0), app.command_output_flush_count);
     try std.testing.expectEqualSlices(
         ReplayEvent,
-        &.{ .completed_tool_status, .completed_tool_status },
+        &.{ .completed_tool_status, .completed_tool_status, .completed_tool_status },
         app.replay_events.items,
     );
 }

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -3564,7 +3564,7 @@ pub fn Runtime(comptime App: type) type {
                     action_arena.allocator(),
                     call,
                     null,
-                    types.deferred_tool_result_output,
+                    types.context_deferred_tool_status_label,
                     &.{},
                 )
             else if (result.status == .success or process_ran)
@@ -3586,7 +3586,7 @@ pub fn Runtime(comptime App: type) type {
             defer app.alloc.free(action);
 
             const outcome: types.ToolOutcomeKind = if (deferred)
-                .denied
+                .deferred
             else if (result.status == .success or process_ran)
                 .completed
             else
@@ -6544,19 +6544,19 @@ test "execution replay preserves paired deferred tools without command output" {
             .tool_call_id = @constCast("call_read"),
             .tool_name = @constCast("read_file"),
             .status = .failure,
-            .output = @constCast("Not executed"),
-            .output_bytes = 12,
-            .stored_output_bytes = 12,
+            .output = @constCast(types.context_deferred_tool_result_output),
+            .output_bytes = types.context_deferred_tool_result_output.len,
+            .stored_output_bytes = types.context_deferred_tool_result_output.len,
         },
         .{
             .tool_call_id = @constCast("call_command"),
             .tool_name = @constCast("run_command"),
             .status = .failure,
-            .output = @constCast("Not executed"),
+            .output = @constCast(types.context_deferred_tool_result_output),
             .output_handle = @constCast("should-not-be-read.txt"),
             .preview = @constCast("should not be rendered"),
-            .output_bytes = 12,
-            .stored_output_bytes = 12,
+            .output_bytes = types.context_deferred_tool_result_output.len,
+            .stored_output_bytes = types.context_deferred_tool_result_output.len,
             .truncated = true,
             .command_output_replay = .unavailable,
             .command_process_presentation = .{ .exit_code = 7 },
@@ -6571,12 +6571,12 @@ test "execution replay preserves paired deferred tools without command output" {
 
     try std.testing.expectEqualSlices(
         types.ToolOutcomeKind,
-        &.{ .denied, .denied },
+        &.{ .deferred, .deferred },
         app.completed_tool_outcomes.items,
     );
     try std.testing.expectEqual(@as(usize, 2), app.completed_tool_statuses.items.len);
-    try std.testing.expectEqualStrings("● Not executed read_file\n", app.completed_tool_statuses.items[0]);
-    try std.testing.expectEqualStrings("● Not executed run_command\n", app.completed_tool_statuses.items[1]);
+    try std.testing.expectEqualStrings("● Context updated read_file\n", app.completed_tool_statuses.items[0]);
+    try std.testing.expectEqualStrings("● Context updated run_command\n", app.completed_tool_statuses.items[1]);
     try std.testing.expectEqual(@as(usize, 2), app.historical_tool_detail_entry_ids.items.len);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
     try std.testing.expectEqual(@as(usize, 0), app.command_output_writes.items.len);

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2634,8 +2634,8 @@ fn settlePendingToolProgress(ctx: *AskContext, call_id: []const u8, outcome: typ
     defer ctx.pending_tool_progress_mutex.unlock(io_mod.getIo());
     var pending = takePendingToolProgressLocked(ctx, call_id) orelse return;
     defer pending.deinit(ctx.alloc);
-    if (outcome.kind != .denied or
-        !std.mem.startsWith(u8, outcome.summary, types.deferred_tool_result_output ++ ": ")) return;
+    if (outcome.kind != .deferred or
+        !std.mem.startsWith(u8, outcome.summary, types.context_deferred_tool_status_label ++ ": ")) return;
     if (!pending.visible) return;
     const text = pending.text orelse return;
     try ctx.deferred_tool_progress.append(ctx.alloc, text);
@@ -8833,7 +8833,7 @@ test "CLI nonterminal progress preserves distinct deferred labels without duplic
     } });
     try deps.push_tool_lifecycle(deps.ctx, .{ .terminal = .{
         .id = .{ .turn_id = 1, .call_id = "deferred_write" },
-        .outcome = .{ .kind = .denied, .summary = "Not executed: Writing file" },
+        .outcome = .{ .kind = .deferred, .summary = "Context updated: Writing file" },
     } });
     try std.testing.expectEqualStrings("Writing file\n", stderr_capture.bytes.items);
 
@@ -8850,7 +8850,7 @@ test "CLI nonterminal progress preserves distinct deferred labels without duplic
     try std.testing.expectEqualStrings("Writing file\n", stderr_capture.bytes.items);
     try deps.push_tool_lifecycle(deps.ctx, .{ .terminal = .{
         .id = .{ .turn_id = 2, .call_id = "retry_write" },
-        .outcome = .{ .kind = .denied, .summary = "Not executed: Writing file" },
+        .outcome = .{ .kind = .deferred, .summary = "Context updated: Writing file" },
     } });
 
     try deps.push_tool_lifecycle(deps.ctx, .{ .authoritative_started = .{

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2634,8 +2634,11 @@ fn settlePendingToolProgress(ctx: *AskContext, call_id: []const u8, outcome: typ
     defer ctx.pending_tool_progress_mutex.unlock(io_mod.getIo());
     var pending = takePendingToolProgressLocked(ctx, call_id) orelse return;
     defer pending.deinit(ctx.alloc);
-    if (outcome.kind != .deferred or
-        !std.mem.startsWith(u8, outcome.summary, types.context_deferred_tool_status_label ++ ": ")) return;
+    const context_deferred = outcome.kind == .deferred and
+        std.mem.startsWith(u8, outcome.summary, types.context_deferred_tool_status_label ++ ": ");
+    const legacy_deferred = outcome.kind == .denied and
+        std.mem.startsWith(u8, outcome.summary, types.deferred_tool_result_output ++ ": ");
+    if (!context_deferred and !legacy_deferred) return;
     if (!pending.visible) return;
     const text = pending.text orelse return;
     try ctx.deferred_tool_progress.append(ctx.alloc, text);
@@ -8906,6 +8909,40 @@ test "CLI nonterminal progress preserves distinct deferred labels without duplic
     } });
     try std.testing.expectEqualStrings(
         "Writing file\nWriting build/pkg/proof.txt\nReading streamed input\n",
+        stderr_capture.bytes.items,
+    );
+
+    try deps.push_tool_lifecycle(deps.ctx, .{ .authoritative_started = .{
+        .id = .{ .turn_id = 7, .call_id = "legacy_deferred_write" },
+        .reconciles_provisional_call_id = null,
+        .tool_name = "write_file",
+        .activity_kind = .write,
+    } });
+    try deps.push_tool_lifecycle(deps.ctx, .{ .progress = .{
+        .id = .{ .turn_id = 7, .call_id = "legacy_deferred_write" },
+        .text = "Writing legacy file",
+    } });
+    try deps.push_tool_lifecycle(deps.ctx, .{ .terminal = .{
+        .id = .{ .turn_id = 7, .call_id = "legacy_deferred_write" },
+        .outcome = .{ .kind = .denied, .summary = "Not executed: Writing legacy file" },
+    } });
+    try std.testing.expectEqualStrings(
+        "Writing file\nWriting build/pkg/proof.txt\nReading streamed input\nWriting legacy file\n",
+        stderr_capture.bytes.items,
+    );
+
+    try deps.push_tool_lifecycle(deps.ctx, .{ .authoritative_started = .{
+        .id = .{ .turn_id = 8, .call_id = "legacy_retry_write" },
+        .reconciles_provisional_call_id = null,
+        .tool_name = "write_file",
+        .activity_kind = .write,
+    } });
+    try deps.push_tool_lifecycle(deps.ctx, .{ .progress = .{
+        .id = .{ .turn_id = 8, .call_id = "legacy_retry_write" },
+        .text = "Writing legacy file",
+    } });
+    try std.testing.expectEqualStrings(
+        "Writing file\nWriting build/pkg/proof.txt\nReading streamed input\nWriting legacy file\n",
         stderr_capture.bytes.items,
     );
 }

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -132,6 +132,7 @@ pub const ToolOutcomeKind = enum {
     denied,
     cancelled,
     failed,
+    deferred,
 };
 
 pub const ToolOutcome = struct {
@@ -753,10 +754,13 @@ pub const CommandProcessPresentation = union(enum) {
 };
 
 pub const deferred_tool_result_output = "Not executed";
+pub const context_deferred_tool_result_output = "Scoped project instructions were added before execution. Review them and reissue this tool call if it is still appropriate.";
+pub const context_deferred_tool_status_label = "Context updated";
 
 pub fn isDeferredToolResult(result: PersistedToolResult) bool {
     return result.status == .failure and
-        std.mem.eql(u8, result.output, deferred_tool_result_output);
+        (std.mem.eql(u8, result.output, deferred_tool_result_output) or
+            std.mem.eql(u8, result.output, context_deferred_tool_result_output));
 }
 
 test "persisted deferred tool result classifier is exact" {
@@ -783,6 +787,9 @@ test "persisted deferred tool result classifier is exact" {
 
     result.output = @constCast("tool failed");
     try std.testing.expect(!isDeferredToolResult(result));
+
+    result.output = @constCast(context_deferred_tool_result_output);
+    try std.testing.expect(isDeferredToolResult(result));
 }
 
 pub const ToolResultMemory = struct {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -757,6 +757,11 @@ pub const deferred_tool_result_output = "Not executed";
 pub const context_deferred_tool_result_output = "Scoped project instructions were added before execution. Review them and reissue this tool call if it is still appropriate.";
 pub const context_deferred_tool_status_label = "Context updated";
 
+pub fn isContextDeferredToolResult(result: PersistedToolResult) bool {
+    return result.status == .failure and
+        std.mem.eql(u8, result.output, context_deferred_tool_result_output);
+}
+
 pub fn isDeferredToolResult(result: PersistedToolResult) bool {
     return result.status == .failure and
         (std.mem.eql(u8, result.output, deferred_tool_result_output) or
@@ -774,9 +779,11 @@ test "persisted deferred tool result classifier is exact" {
     };
 
     try std.testing.expect(isDeferredToolResult(result));
+    try std.testing.expect(!isContextDeferredToolResult(result));
 
     result.status = .success;
     try std.testing.expect(!isDeferredToolResult(result));
+    try std.testing.expect(!isContextDeferredToolResult(result));
 
     result.status = .failure;
     result.output = @constCast("Not executed\n");
@@ -790,6 +797,7 @@ test "persisted deferred tool result classifier is exact" {
 
     result.output = @constCast(context_deferred_tool_result_output);
     try std.testing.expect(isDeferredToolResult(result));
+    try std.testing.expect(isContextDeferredToolResult(result));
 }
 
 pub const ToolResultMemory = struct {

--- a/src/core/subagent/ui_projection.zig
+++ b/src/core/subagent/ui_projection.zig
@@ -558,6 +558,7 @@ pub const ChildChat = struct {
                         .tone = switch (value.outcome.kind) {
                             .completed => .success,
                             .denied, .cancelled, .failed => .danger,
+                            .deferred => .thinking,
                         },
                     } },
                     .turn_finished => {},

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -2404,6 +2404,35 @@ test "historical deferred tool detail keeps the call without result evidence" {
     try std.testing.expect(detail.command_process_presentation == null);
     try std.testing.expect(detail.command_output_entry_id == null);
 
+    const legacy_entry_id = try runtime.writeCompletedToolStatusReturningEntryId(
+        alloc,
+        &metrics,
+        .denied,
+        "Not executed: Reading stale.txt",
+        true,
+    );
+    try runtime.attachHistoricalToolDetail(
+        alloc,
+        legacy_entry_id,
+        .{
+            .id = "legacy-deferred-read",
+            .name = "read_file",
+            .arguments_json = "{\"path\":\"stale.txt\"}",
+        },
+        .read,
+        .{
+            .tool_call_id = @constCast("legacy-deferred-read"),
+            .tool_name = @constCast("read_file"),
+            .status = .failure,
+            .output = @constCast(types.deferred_tool_result_output),
+            .output_bytes = types.deferred_tool_result_output.len,
+            .stored_output_bytes = types.deferred_tool_result_output.len,
+        },
+    );
+    const legacy_detail = runtime.toolDetailForEntry(legacy_entry_id).?;
+    try std.testing.expectEqual(types.ToolOutcomeKind.denied, legacy_detail.outcome.?);
+    try std.testing.expect(legacy_detail.result == null);
+
     const failed_entry_id = try runtime.writeCompletedToolStatusReturningEntryId(
         alloc,
         &metrics,
@@ -5184,6 +5213,7 @@ pub const TranscriptRuntime = struct {
         lifecycle_id: ?types.ToolLifecycleId,
         command_output_entry_id: ?u32,
     ) !void {
+        const context_deferred = types.isContextDeferredToolResult(result);
         const deferred = types.isDeferredToolResult(result);
         const command_artifact_handle = if (!deferred and activity_kind == .command)
             command_output_runtime.commandArtifactHandleFromResult(result.output)
@@ -5196,8 +5226,10 @@ pub const TranscriptRuntime = struct {
             lifecycle_id,
             call.name,
             activity_kind,
-            if (deferred)
+            if (context_deferred)
                 .deferred
+            else if (deferred)
+                .denied
             else if (result.status == .success or
                 (activity_kind == .command and
                     result.command_process_presentation != null))

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -475,6 +475,7 @@ fn lifecycleMarker(kind: types.ToolOutcomeKind) LifecycleMarker {
         .failed => .{ .style = ui_render.red_style, .glyph = "●" },
         .denied => .{ .style = ui_render.red_style, .glyph = "⊘" },
         .cancelled => .{ .style = ui_render.warning_style, .glyph = "■" },
+        .deferred => .{ .style = ui_render.warning_style, .glyph = "↻" },
     };
 }
 
@@ -2364,8 +2365,8 @@ test "historical deferred tool detail keeps the call without result evidence" {
     const entry_id = try runtime.writeCompletedToolStatusReturningEntryId(
         alloc,
         &metrics,
-        .denied,
-        "Not executed cat nested/input.txt",
+        .deferred,
+        "Context updated: Running cat nested/input.txt",
         true,
     );
     try runtime.attachHistoricalToolDetail(
@@ -2381,11 +2382,11 @@ test "historical deferred tool detail keeps the call without result evidence" {
             .tool_call_id = @constCast("deferred-command"),
             .tool_name = @constCast("run_command"),
             .status = .failure,
-            .output = @constCast("Not executed"),
+            .output = @constCast(types.context_deferred_tool_result_output),
             .output_handle = @constCast("should-not-be-exposed.txt"),
             .preview = @constCast("should not be exposed"),
-            .output_bytes = 12,
-            .stored_output_bytes = 12,
+            .output_bytes = types.context_deferred_tool_result_output.len,
+            .stored_output_bytes = types.context_deferred_tool_result_output.len,
             .truncated = true,
             .command_output_replay = .unavailable,
             .command_process_presentation = .{ .exit_code = 7 },
@@ -2395,7 +2396,7 @@ test "historical deferred tool detail keeps the call without result evidence" {
     const detail = runtime.toolDetailForEntry(entry_id).?;
     try std.testing.expectEqualStrings("run_command", detail.tool_name);
     try std.testing.expectEqualStrings("{\"command\":\"cat nested/input.txt\"}", detail.arguments_json.?);
-    try std.testing.expectEqual(types.ToolOutcomeKind.denied, detail.outcome.?);
+    try std.testing.expectEqual(types.ToolOutcomeKind.deferred, detail.outcome.?);
     try std.testing.expect(detail.result == null);
     try std.testing.expect(detail.result_handle == null);
     try std.testing.expect(detail.command_artifact_handle == null);
@@ -5196,7 +5197,7 @@ pub const TranscriptRuntime = struct {
             call.name,
             activity_kind,
             if (deferred)
-                .denied
+                .deferred
             else if (result.status == .success or
                 (activity_kind == .command and
                     result.command_process_presentation != null))

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -137,6 +137,7 @@ const Summary = struct {
     failed: usize = 0,
     denied: usize = 0,
     cancelled: usize = 0,
+    deferred: usize = 0,
     completion_unreported: usize = 0,
     not_executed: usize = 0,
 };
@@ -263,6 +264,7 @@ fn observeTool(summary: *Summary, detail: ?*const ToolDetailRecord) void {
             .failed => summary.failed += 1,
             .denied => summary.denied += 1,
             .cancelled => summary.cancelled += 1,
+            .deferred => summary.deferred += 1,
         }
     }
 }
@@ -404,6 +406,7 @@ fn formatGroupHeader(
     try appendSegment(&out.writer, summary.failed, "failed");
     try appendSegment(&out.writer, summary.denied, "denied");
     try appendSegment(&out.writer, summary.cancelled, "cancelled");
+    try appendSegment(&out.writer, summary.deferred, "deferred");
 
     const plain = try out.toOwnedSlice();
     defer alloc.free(plain);

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -5717,8 +5717,8 @@ describe("acp: model-independent", () => {
         expect(deferredBody).not.toContain(siblingRule);
         expect(occurrenceCount(deferredBody, rootRule)).toBe(1);
         expect(occurrenceCount(deferredBody, nestedRule)).toBe(1);
-        expect(acpToolResultText(deferredBody, firstCallId)).toContain(
-          "Not executed",
+        expect(acpToolResultText(deferredBody, firstCallId)).toBe(
+          "Scoped project instructions were added before execution. Review them and reissue this tool call if it is still appropriate.",
         );
 
         const executedBody = gateway.requests[2]!.body;

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2004,7 +2004,9 @@ describe("gateway stream lifecycle", () => {
         expect(deferredBody).toContain(buildRule);
         expect(deferredBody).not.toContain(siblingRule);
         expect(deferredBody.indexOf(rootRule)).toBeLessThan(deferredBody.indexOf(buildRule));
-        expect(toolResultOutput(deferredBody, firstCallId)).toContain("Not executed");
+        expect(toolResultOutput(deferredBody, firstCallId)).toBe(
+          "Scoped project instructions were added before execution. Review them and reissue this tool call if it is still appropriate.",
+        );
         expect(existsSync(targetPath)).toBe(true);
 
         const executedBody = gateway.requests[2]!.body;

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -4001,7 +4001,7 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
-  "deferred scoped tools remain not executed after resume",
+  "context-deferred scoped tools remain deferred after resume",
   async () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-resume-deferred-tools-")));
     const home = join(root, "home");
@@ -4022,7 +4022,7 @@ test.skipIf(!tmuxAvailable())(
     writeFileSync(resumeStderrPath, "");
 
     const workspaceRoot = realpathSync(workspace);
-    const command = "cat nested/input.txt";
+    const command = "printf 'effectful payload\\n' > output.txt";
     const failureCommand = "printf 'ordinary-failure-control\\n' >&2; exit 7";
     const finalMarker = "DEFERRED_TOOL_RESUME_COMPLETE";
     const gateway = startFakeGateway([
@@ -4038,7 +4038,7 @@ test.skipIf(!tmuxAvailable())(
         {
           type: "tool-input-delta",
           id: "deferred-command",
-          delta: JSON.stringify({ command }),
+          delta: JSON.stringify({ command, cwd: "nested" }),
         },
         { type: "tool-input-end", id: "deferred-command" },
         {
@@ -4051,7 +4051,7 @@ test.skipIf(!tmuxAvailable())(
           type: "tool-call",
           toolCallId: "deferred-command",
           toolName: "run_command",
-          input: { command },
+          input: { command, cwd: "nested" },
         },
         { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
       ]),
@@ -4066,7 +4066,7 @@ test.skipIf(!tmuxAvailable())(
           type: "tool-call",
           toolCallId: "reissued-command",
           toolName: "run_command",
-          input: { command },
+          input: { command, cwd: "nested" },
         },
         {
           type: "tool-call",
@@ -4082,14 +4082,13 @@ test.skipIf(!tmuxAvailable())(
     let active: TmuxSession | null = null;
 
     function expectDeferredPresentation(scrollback: string): void {
-      expect(scrollback).toContain("⊘ Not executed nested/input.txt");
-      expect(scrollback).toContain("⊘ Not executed cat nested/input.txt");
-      expect(countOccurrences(scrollback, "Not executed")).toBe(2);
+      expect(scrollback).toContain(`↻ Context updated ${command}`);
+      expect(countOccurrences(scrollback, "Context updated")).toBe(1);
+      expect(scrollback).not.toContain("Not executed");
       expect(scrollback).not.toContain("● Failed nested/input.txt");
-      expect(scrollback).not.toContain("● Failed cat nested/input.txt");
-      expect(scrollback).not.toContain("\nNot executed\n");
+      expect(scrollback).not.toContain(`● Failed ${command}`);
       expect(scrollback).toContain("● Read nested/input.txt");
-      expect(scrollback).toContain("● Ran cat nested/input.txt");
+      expect(scrollback).toContain(`● Ran ${command}`);
       expect(scrollback).toContain(`● Ran ${failureCommand}`);
       expect(scrollback).toContain("│ exit code 7");
     }
@@ -4105,7 +4104,7 @@ test.skipIf(!tmuxAvailable())(
       });
       await active.waitForComposer(TIMEOUT);
       await active.sendText(
-        "Read nested/input.txt, run cat nested/input.txt, and exercise the failure control.",
+        "Read nested/input.txt, write nested/output.txt from that directory, and exercise the failure control.",
       );
       await waitForScrollback(active, finalMarker);
       await waitForCondition(
@@ -4136,16 +4135,16 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("C-o");
       const detail = await active.waitForPane(
         (pane) =>
-          pane.includes("⊘ Not executed nested/input.txt") &&
-          pane.includes("⊘ Not executed cat nested/input.txt") &&
+          pane.includes(`↻ Context updated ${command}`) &&
           pane.includes("ordinary-failure-control"),
         TIMEOUT,
       );
-      expect(countOccurrences(detail, "Not executed")).toBe(2);
-      expect(detail).not.toContain("\nNot executed\n");
+      expect(countOccurrences(detail, "Context updated")).toBe(1);
+      expect(detail).not.toContain("Not executed");
       expect(detail).not.toContain('{"path":"nested/input.txt"}');
-      expect(detail).not.toContain('{"command":"cat nested/input.txt"}');
+      expect(detail).not.toContain(JSON.stringify({ command, cwd: "nested" }));
       expect(detail).toContain(failureCommand);
+      expect(detail).toContain("1 deferred");
       expect(detail).toContain("1 failed");
       expect(readFileSync(resumeStderrPath, "utf8")).toBe("");
 


### PR DESCRIPTION
## Summary

- Continue safe inspections after loading newly applicable project instructions.
- Treat installed skill reads as safe inspections while keeping skill installation deferred.
- Defer effectful calls only when the new instructions apply to that call.
- Show scoped-context deferrals as context updates instead of failed executions.