### PR TITLE
Move transcript release policy into Core

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -72,40 +72,6 @@ fn set_transcript_assistant_tail_writable(
     );
 }
 
-test "assistant tail writability changes remain traceable" {
-    const alloc = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
-    defer alloc.free(root);
-    const trace_path = try std.fs.path.join(alloc, &.{ root, "assistant-tail.log" });
-    defer alloc.free(trace_path);
-
-    debug_trace.resetForTest();
-    defer debug_trace.resetForTest();
-    try debug_trace.configureForTestWithScopes(alloc, trace_path, "scroll");
-
-    var runtime = transcript_runtime.TranscriptRuntime{};
-    set_transcript_assistant_tail_writable(&runtime, false);
-    set_transcript_assistant_tail_writable(&runtime, true);
-    debug_trace.shutdown();
-
-    var trace_file = try std.Io.Dir.openFileAbsolute(std.testing.io, trace_path, .{});
-    defer trace_file.close(std.testing.io);
-    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 4096);
-    defer alloc.free(trace);
-    try std.testing.expect(std.mem.find(
-        u8,
-        trace,
-        "assistant tail writability changed writable=false",
-    ) != null);
-    try std.testing.expect(std.mem.find(
-        u8,
-        trace,
-        "assistant tail writability changed writable=true",
-    ) != null);
-}
-
 pub const VisualEpochResetTrigger = enum {
     native_clear_probe,
     ctrl_l,
@@ -3567,6 +3533,40 @@ fn solveFixedPointForTest(
         input,
         FixedPointTestContext.prepareCandidate,
     );
+}
+
+test "assistant tail writability changes remain traceable" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const trace_path = try std.fs.path.join(alloc, &.{ root, "assistant-tail.log" });
+    defer alloc.free(trace_path);
+
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "scroll");
+
+    var runtime = transcript_runtime.TranscriptRuntime{};
+    set_transcript_assistant_tail_writable(&runtime, false);
+    set_transcript_assistant_tail_writable(&runtime, true);
+    debug_trace.shutdown();
+
+    var trace_file = try std.Io.Dir.openFileAbsolute(std.testing.io, trace_path, .{});
+    defer trace_file.close(std.testing.io);
+    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 4096);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "assistant tail writability changed writable=false",
+    ) != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "assistant tail writability changed writable=true",
+    ) != null);
 }
 
 test "core.app_render_runtime makes selected child display names terminal safe" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -59,6 +59,52 @@ const transcript_runtime = @import("../../ui/transcript/runtime.zig");
 const ui_render = @import("../../ui/render.zig");
 const assistant_pacer = @import("../../ui/assistant/pacer.zig");
 
+fn set_transcript_assistant_tail_writable(
+    runtime: *transcript_runtime.TranscriptRuntime,
+    writable: bool,
+) void {
+    if (!runtime.transcript_release.set_assistant_tail_writable(writable)) return;
+    debug_trace.logf(
+        "scroll",
+        "assistant tail writability changed writable={s}",
+        .{if (writable) "true" else "false"},
+    );
+}
+
+test "assistant tail writability changes remain traceable" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const trace_path = try std.fs.path.join(alloc, &.{ root, "assistant-tail.log" });
+    defer alloc.free(trace_path);
+
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "scroll");
+
+    var runtime = transcript_runtime.TranscriptRuntime{};
+    set_transcript_assistant_tail_writable(&runtime, false);
+    set_transcript_assistant_tail_writable(&runtime, true);
+    debug_trace.shutdown();
+
+    var trace_file = try std.Io.Dir.openFileAbsolute(std.testing.io, trace_path, .{});
+    defer trace_file.close(std.testing.io);
+    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 4096);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "assistant tail writability changed writable=false",
+    ) != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "assistant tail writability changed writable=true",
+    ) != null);
+}
+
 pub const VisualEpochResetTrigger = enum {
     native_clear_probe,
     ctrl_l,
@@ -1144,7 +1190,7 @@ pub fn Runtime(comptime App: type) type {
             const runtime = app.subagents.childConversationRuntime().?;
             // A live child can still stream into its trailing assistant
             // entry; a finished child's tail is final.
-            runtime.setAssistantTailWritable(view.chat.live != null);
+            set_transcript_assistant_tail_writable(runtime, view.chat.live != null);
             if (!std.meta.eql(runtime.layout, app.shell.layout)) {
                 runtime.layout = app.shell.layout;
                 runtime.markTranscriptDirty();
@@ -1576,7 +1622,8 @@ pub fn Runtime(comptime App: type) type {
             // Frame-fresh producer fact for the finality floor: the trailing
             // assistant entry stays non-final while the stream is open or
             // the pacer still holds undelivered output.
-            app.shell.setAssistantTailWritable(
+            set_transcript_assistant_tail_writable(
+                &app.shell,
                 app.stream.active or app.pacer.hasPending(),
             );
             const presentation_shell: *transcript_runtime.TranscriptRuntime =

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -63,7 +63,8 @@ fn set_transcript_assistant_tail_writable(
     runtime: *transcript_runtime.TranscriptRuntime,
     writable: bool,
 ) void {
-    if (!runtime.transcript_release.set_assistant_tail_writable(writable)) return;
+    if (runtime.transcript_release.assistant_tail_writable == writable) return;
+    runtime.transcript_release = runtime.transcript_release.with_assistant_tail_writable(writable);
     debug_trace.logf(
         "scroll",
         "assistant tail writability changed writable={s}",

--- a/src/core/output/transcript_release.zig
+++ b/src/core/output/transcript_release.zig
@@ -39,10 +39,10 @@ pub const State = struct {
     policy: Policy = .finality_gated,
     assistant_tail_writable: bool = true,
 
-    pub fn set_assistant_tail_writable(self: *State, writable: bool) bool {
-        if (self.assistant_tail_writable == writable) return false;
-        self.assistant_tail_writable = writable;
-        return true;
+    pub fn with_assistant_tail_writable(self: State, writable: bool) State {
+        var next = self;
+        next.assistant_tail_writable = writable;
+        return next;
     }
 
     /// Returns the earliest byte that is not final, or null when the entire
@@ -114,10 +114,10 @@ test "transcript release ignores final producers and preserves append-only outpu
     );
 }
 
-test "assistant tail writability reports state changes" {
-    var state = State{};
-    try std.testing.expect(!state.set_assistant_tail_writable(true));
-    try std.testing.expect(state.set_assistant_tail_writable(false));
-    try std.testing.expect(!state.set_assistant_tail_writable(false));
-    try std.testing.expect(state.set_assistant_tail_writable(true));
+test "assistant tail writability returns a new state" {
+    const open = State{};
+    const closed = open.with_assistant_tail_writable(false);
+    try std.testing.expect(open.assistant_tail_writable);
+    try std.testing.expect(!closed.assistant_tail_writable);
+    try std.testing.expect(closed.with_assistant_tail_writable(true).assistant_tail_writable);
 }

--- a/src/core/output/transcript_release.zig
+++ b/src/core/output/transcript_release.zig
@@ -1,0 +1,123 @@
+const std = @import("std");
+
+pub const Policy = enum {
+    finality_gated,
+    append_only,
+};
+
+pub const ToolTurnFloor = struct {
+    turn_id: u64,
+    start_byte: usize,
+};
+
+/// Activity-independent finality boundaries for one prepared transcript flow.
+/// `tool_turn_floors` is owned when populated and must be released with the
+/// allocator that created or cloned it.
+pub const Candidates = struct {
+    mutation_pin_start: ?usize = null,
+    assistant_tail_start: ?usize = null,
+    tool_turn_floors: []const ToolTurnFloor = &.{},
+
+    pub fn deinit(self: *Candidates, alloc: std.mem.Allocator) void {
+        if (self.tool_turn_floors.len > 0) alloc.free(self.tool_turn_floors);
+        self.* = .{};
+    }
+
+    pub fn clone(self: *const Candidates, alloc: std.mem.Allocator) !Candidates {
+        return .{
+            .mutation_pin_start = self.mutation_pin_start,
+            .assistant_tail_start = self.assistant_tail_start,
+            .tool_turn_floors = if (self.tool_turn_floors.len == 0)
+                &.{}
+            else
+                try alloc.dupe(ToolTurnFloor, self.tool_turn_floors),
+        };
+    }
+};
+
+pub const State = struct {
+    policy: Policy = .finality_gated,
+    assistant_tail_writable: bool = true,
+
+    pub fn set_assistant_tail_writable(self: *State, writable: bool) bool {
+        if (self.assistant_tail_writable == writable) return false;
+        self.assistant_tail_writable = writable;
+        return true;
+    }
+
+    /// Returns the earliest byte that is not final, or null when the entire
+    /// prepared flow may enter native terminal history.
+    pub fn finality_floor(
+        self: State,
+        candidates: Candidates,
+        finalized_tool_turn_watermark: u64,
+        replaceable_start: ?usize,
+    ) ?usize {
+        if (self.policy == .append_only) return null;
+
+        var floor = candidates.mutation_pin_start;
+        for (candidates.tool_turn_floors) |turn_floor| {
+            if (turn_floor.turn_id <= finalized_tool_turn_watermark) continue;
+            floor = earlier(floor, turn_floor.start_byte);
+        }
+        if (replaceable_start) |start| floor = earlier(floor, start);
+        if (self.assistant_tail_writable) {
+            if (candidates.assistant_tail_start) |start| {
+                floor = earlier(floor, start);
+            }
+        }
+        return floor;
+    }
+};
+
+fn earlier(current: ?usize, candidate: usize) usize {
+    return if (current) |value| @min(value, candidate) else candidate;
+}
+
+test "transcript release chooses the earliest mutable boundary" {
+    const tool_turns = [_]ToolTurnFloor{
+        .{ .turn_id = 4, .start_byte = 48 },
+        .{ .turn_id = 6, .start_byte = 24 },
+    };
+    const candidates = Candidates{
+        .mutation_pin_start = 32,
+        .assistant_tail_start = 16,
+        .tool_turn_floors = &tool_turns,
+    };
+
+    try std.testing.expectEqual(
+        @as(?usize, 16),
+        (State{}).finality_floor(candidates, 4, 40),
+    );
+}
+
+test "transcript release ignores final producers and preserves append-only output" {
+    const tool_turns = [_]ToolTurnFloor{
+        .{ .turn_id = 4, .start_byte = 8 },
+    };
+    const candidates = Candidates{
+        .assistant_tail_start = 12,
+        .tool_turn_floors = &tool_turns,
+    };
+
+    try std.testing.expectEqual(
+        @as(?usize, null),
+        (State{ .assistant_tail_writable = false }).finality_floor(
+            candidates,
+            4,
+            null,
+        ),
+    );
+    try std.testing.expectEqual(
+        @as(?usize, null),
+        (State{ .policy = .append_only }).finality_floor(candidates, 0, 3),
+    );
+}
+
+test "assistant tail writability reports state changes" {
+    var state = State{};
+    try std.testing.expect(!state.set_assistant_tail_writable(true));
+    try std.testing.expect(state.set_assistant_tail_writable(false));
+    try std.testing.expect(!state.set_assistant_tail_writable(false));
+    try std.testing.expect(state.set_assistant_tail_writable(true));
+}

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -64,7 +64,7 @@ pub const Runtime = struct {
                 .history_reset_uses_ris = shell_runtime.detectHistoryResetUsesRis(alloc),
                 .layout = layout,
                 .maxxing_mode = presentation_mode.MaxxingMode.minimal,
-                .history_release_policy = .append_only,
+                .transcript_release = .{ .policy = .append_only },
             },
             .no_color = no_color,
         };

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -3207,7 +3207,7 @@ test "structured command-output rewrite materializes committed transcript scroll
     }
     // Assistant content is complete before each frame; report producer
     // closure so the finality floor does not hold the tail.
-    h.shell.setAssistantTailWritable(false);
+    _ = h.shell.transcript_release.set_assistant_tail_writable(false);
 
     try h.renderTranscriptFrame();
     try h.flush();
@@ -6009,7 +6009,7 @@ test "inline approval footer reflow preserves concurrent transcript progress" {
 
     // Closing the producer finalizes the tail; the held rows settle through
     // the catch-up replay, possibly across frames.
-    h.shell.setAssistantTailWritable(false);
+    _ = h.shell.transcript_release.set_assistant_tail_writable(false);
     var settle_frames: usize = 0;
     var settled_scroll_rows: u32 = 0;
     while (settle_frames < 8) : (settle_frames += 1) {

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -3207,7 +3207,7 @@ test "structured command-output rewrite materializes committed transcript scroll
     }
     // Assistant content is complete before each frame; report producer
     // closure so the finality floor does not hold the tail.
-    _ = h.shell.transcript_release.set_assistant_tail_writable(false);
+    h.shell.transcript_release = h.shell.transcript_release.with_assistant_tail_writable(false);
 
     try h.renderTranscriptFrame();
     try h.flush();
@@ -6009,7 +6009,7 @@ test "inline approval footer reflow preserves concurrent transcript progress" {
 
     // Closing the producer finalizes the tail; the held rows settle through
     // the catch-up replay, possibly across frames.
-    _ = h.shell.transcript_release.set_assistant_tail_writable(false);
+    h.shell.transcript_release = h.shell.transcript_release.with_assistant_tail_writable(false);
     var settle_frames: usize = 0;
     var settled_scroll_rows: u32 = 0;
     while (settle_frames < 8) : (settle_frames += 1) {

--- a/src/ui/transcript/painter.zig
+++ b/src/ui/transcript/painter.zig
@@ -18,6 +18,7 @@ const types = @import("../../core/shared/types.zig");
 const command_output_content = @import("../../core/tooling/command_output_content.zig");
 const render_engine = @import("../render_engine.zig");
 const source_preparation = @import("source_preparation.zig");
+const transcript_release = @import("../../core/output/transcript_release.zig");
 const transcript_writer = @import("writer.zig");
 const vt_emulator = @import("../../core/terminal/engine.zig");
 
@@ -1125,7 +1126,7 @@ pub const PreparedTranscriptSurfacePaint = struct {
     // Owned copy of the source's finality boundary candidates; the scroll
     // planner selects the release floor from these against frame-fresh
     // producer facts. Empty candidates mean the whole flow is final.
-    finality_candidates: source_preparation.FinalityCandidates = .{},
+    finality_candidates: transcript_release.Candidates = .{},
     cursor: ViewportCursorResult = .{ .cursor_row = 1, .cursor_col = 1, .replaceable_row = 1 },
 
     pub fn deinit(self: *PreparedTranscriptSurfacePaint, alloc: Allocator) void {

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -5,6 +5,7 @@ const input_action = @import("../../core/input/input_action.zig");
 const io_mod = @import("../../core/shared/io.zig");
 const activity_status = @import("../../core/output/activity_status.zig");
 const activity_runtime = @import("../../core/output/activity_runtime.zig");
+const transcript_release = @import("../../core/output/transcript_release.zig");
 const transcript_presentation = @import("../../core/output/transcript_presentation.zig");
 const worker_status = @import("../../core/output/worker_status.zig");
 const footer_viewport_runtime = @import("../footer/viewport.zig");
@@ -59,11 +60,6 @@ pub const ResizeObservationPhase = enum {
     live,
     settle_pending,
     reset_queued,
-};
-
-pub const HistoryReleasePolicy = enum {
-    finality_gated,
-    append_only,
 };
 
 pub const ResizeObservationResult = union(enum) {
@@ -4099,16 +4095,8 @@ pub const TranscriptRuntime = struct {
     entries: std.ArrayList(TranscriptEntry) = .empty,
     lifecycle_state: activity_runtime.ToolActivityState = .{},
     worker_status: worker_status.State = .none,
-    /// Frame-fresh producer fact: whether a trailing assistant entry can
-    /// still receive bytes (stream open or pacer holding pending/deferred
-    /// output). Drivers set it before each frame; the scroll planner treats
-    /// a writable tail as non-final. Defaults to writable so a driver that
-    /// never reports closure over-holds instead of releasing mutable rows.
-    assistant_tail_writable: bool = true,
-    /// Interactive transcripts gate native-history release on producer
-    /// finality. One-shot presenters use append-only release because they do
-    /// not revisit rows after writing them.
-    history_release_policy: HistoryReleasePolicy = .finality_gated,
+    /// Core-owned producer state and policy for native-history release.
+    transcript_release: transcript_release.State = .{},
     /// Sorted by entry id so exact lookup stays bounded as history grows.
     tool_details: std.ArrayList(ToolDetailRecord) = .empty,
     /// Monotonically increasing id stamped onto each new entry by the
@@ -6602,16 +6590,6 @@ pub const TranscriptRuntime = struct {
         return self.planTranscriptScrollForFrame(prepared, false, false);
     }
 
-    pub fn setAssistantTailWritable(self: *TranscriptRuntime, writable: bool) void {
-        if (self.assistant_tail_writable == writable) return;
-        self.assistant_tail_writable = writable;
-        debug_trace.logf(
-            "scroll",
-            "assistant tail writability changed writable={s}",
-            .{if (writable) "true" else "false"},
-        );
-    }
-
     /// Selects the finality floor in flow bytes from the prepared paint's
     /// activity-independent candidates plus the frame-fresh producer facts
     /// (lifecycle watermark, assistant-tail writability, replaceable tail).
@@ -6621,32 +6599,11 @@ pub const TranscriptRuntime = struct {
         self: *const TranscriptRuntime,
         prepared: *const transcript_painter.PreparedTranscriptSurfacePaint,
     ) ?usize {
-        if (self.history_release_policy == .append_only) return null;
-        const candidates = prepared.finality_candidates;
-        var floor: ?usize = null;
-        if (candidates.mutation_pin_start) |start| {
-            floor = if (floor) |value| @min(value, start) else start;
-        }
-        const watermark = self.finalizedToolTurnWatermark();
-        for (candidates.tool_turn_floors) |turn_floor| {
-            if (turn_floor.turn_id <= watermark) continue;
-            floor = if (floor) |value|
-                @min(value, turn_floor.start_byte)
-            else
-                turn_floor.start_byte;
-        }
-        if (prepared.replaceable_last_line) {
-            floor = if (floor) |value|
-                @min(value, prepared.replaceable_start)
-            else
-                prepared.replaceable_start;
-        }
-        if (candidates.assistant_tail_start) |start| {
-            if (self.assistant_tail_writable) {
-                floor = if (floor) |value| @min(value, start) else start;
-            }
-        }
-        return floor;
+        return self.transcript_release.finality_floor(
+            prepared.finality_candidates,
+            self.finalizedToolTurnWatermark(),
+            if (prepared.replaceable_last_line) prepared.replaceable_start else null,
+        );
     }
 
     /// Visual rows contributed by the flow prefix [0..flow_offset). The
@@ -10404,42 +10361,6 @@ test "owned stable transition traces a superseded pending resume source" {
         u8,
         trace,
         "pending resume flow dropped reason=superseded bytes=5",
-    ) != null);
-}
-
-test "assistant tail writability transitions are traceable" {
-    const alloc = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
-    defer alloc.free(root);
-    const trace_path = try std.fs.path.join(alloc, &.{ root, "assistant-tail.log" });
-    defer alloc.free(trace_path);
-
-    debug_trace.resetForTest();
-    defer debug_trace.resetForTest();
-    try debug_trace.configureForTestWithScopes(alloc, trace_path, "scroll");
-    debug_trace.logf("scroll", "assistant tail trace test start", .{});
-
-    var runtime = TranscriptRuntime{ .layout = testLayoutWithRows(8) };
-    defer runtime.deinit(alloc);
-    runtime.setAssistantTailWritable(false);
-    runtime.setAssistantTailWritable(true);
-    debug_trace.shutdown();
-
-    var trace_file = try std.Io.Dir.openFileAbsolute(std.testing.io, trace_path, .{});
-    defer trace_file.close(std.testing.io);
-    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 4096);
-    defer alloc.free(trace);
-    try std.testing.expect(std.mem.find(
-        u8,
-        trace,
-        "assistant tail writability changed writable=false",
-    ) != null);
-    try std.testing.expect(std.mem.find(
-        u8,
-        trace,
-        "assistant tail writability changed writable=true",
     ) != null);
 }
 

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -8501,7 +8501,7 @@ test "command output consolidation preserves committed prompt scrollback anchor"
     }
     // The assistant content above is complete; report producer closure so
     // the finality floor does not hold the tail.
-    _ = runtime.transcript_release.set_assistant_tail_writable(false);
+    runtime.transcript_release = runtime.transcript_release.with_assistant_tail_writable(false);
 
     var live_source = try runtime.prepareTranscriptSource(alloc, null);
     defer live_source.deinit(alloc);

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -8501,7 +8501,7 @@ test "command output consolidation preserves committed prompt scrollback anchor"
     }
     // The assistant content above is complete; report producer closure so
     // the finality floor does not hold the tail.
-    runtime.setAssistantTailWritable(false);
+    _ = runtime.transcript_release.set_assistant_tail_writable(false);
 
     var live_source = try runtime.prepareTranscriptSource(alloc, null);
     defer live_source.deinit(alloc);

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const command_output_runtime = @import("command_output_runtime.zig");
 const debug_trace = @import("../../core/shared/debug_trace.zig");
+const transcript_release = @import("../../core/output/transcript_release.zig");
 const build_checkpoint = @import("../render_engine/build_checkpoint.zig");
 const tool_group_projection = @import("tool_group_projection.zig");
 const render_engine = @import("../render_engine.zig");
@@ -26,39 +27,6 @@ const visualRowsForLine = transcript_blocks.visualRowsForLine;
 test {
     _ = tool_group_projection;
 }
-
-/// Byte offset where an unfenced tool turn's first rendered entry begins.
-/// Whether the turn is still open is a frame-fresh fact (the lifecycle
-/// watermark), so every retained turn keeps a candidate and the planner
-/// selects against the live watermark.
-pub const ToolTurnFloor = struct {
-    turn_id: u64,
-    start_byte: usize,
-};
-
-/// Activity-independent finality boundary candidates for the prepared flow.
-/// Each offset addresses the source's `bytes` at its `cols`.
-/// Selection against frame-fresh producer facts (lifecycle watermark,
-/// assistant-tail writability) happens in the scroll planner, outside any
-/// source cache.
-pub const FinalityCandidates = struct {
-    mutation_pin_start: ?usize = null,
-    assistant_tail_start: ?usize = null,
-    tool_turn_floors: []ToolTurnFloor = &.{},
-
-    pub fn deinit(self: *FinalityCandidates, alloc: Allocator) void {
-        if (self.tool_turn_floors.len > 0) alloc.free(self.tool_turn_floors);
-        self.* = .{};
-    }
-
-    pub fn clone(self: *const FinalityCandidates, alloc: Allocator) !FinalityCandidates {
-        return .{
-            .mutation_pin_start = self.mutation_pin_start,
-            .assistant_tail_start = self.assistant_tail_start,
-            .tool_turn_floors = try alloc.dupe(ToolTurnFloor, self.tool_turn_floors),
-        };
-    }
-};
 
 const FinalityNominationKind = enum { mutation_pin, tool_turn, assistant_tail };
 
@@ -171,7 +139,7 @@ pub const TranscriptPreparationSource = struct {
     transcript_visible_lines: []viewport_selection.VisibleTranscriptLine = &.{},
     transcript_line_visual_rows: []u16 = &.{},
     transcript_visual_row_offsets: []u32 = &.{},
-    finality: FinalityCandidates = .{},
+    finality: transcript_release.Candidates = .{},
 
     pub fn deinit(self: *TranscriptPreparationSource, alloc: Allocator) void {
         if (self.bytes.len > 0) alloc.free(self.bytes);
@@ -468,7 +436,7 @@ fn prepareTranscriptSourceInternal(
     else
         aligned_actions;
 
-    var finality: FinalityCandidates = .{};
+    var finality: transcript_release.Candidates = .{};
     errdefer finality.deinit(alloc);
     if (self.entries.items.len > 0 and self.layout.cols > 0) {
         rendered_from_entries = true;
@@ -524,7 +492,7 @@ fn prepareTranscriptSourceInternal(
         trailing_boundary_blank_rows = rendered.trailing_boundary_blank_rows;
         tracked_entry_start_line = rendered.target_entry_start_line;
         replaceable_entry_start_byte = rendered.target_entry_start_byte;
-        var tool_turn_floors: std.ArrayList(ToolTurnFloor) = .empty;
+        var tool_turn_floors: std.ArrayList(transcript_release.ToolTurnFloor) = .empty;
         errdefer tool_turn_floors.deinit(alloc);
         for (finality_nominations.items, 0..) |nomination, index| {
             const start_byte = finality_entry_start_bytes[index] orelse blk: {


### PR DESCRIPTION
## Summary

- Keep interactive transcript rows out of native scrollback while tool turns, replaceable lines, or assistant output can still change.
- Keep `fx ask` transcript output append-only while it streams.