### PR TITLE
Improve light terminal contrast

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -363,6 +363,7 @@ pub fn Runtime(comptime App: type) type {
                 .notice_warning_style = ui_render.warning_style,
                 .notice_error_style = ui_render.red_style,
                 .notice_cancelled_style = ui_render.dim_style,
+                .code_highlight_theme = if (ui_render.is_light) .light else .dark,
             };
         }
 

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1492,11 +1492,11 @@ fn writeStyleEnd(writer: *std.Io.Writer, style: HelpStyle) !void {
 fn styleStart(style: HelpStyle, role: HelpRole) []const u8 {
     if (style == .plain) return "";
     return switch (role) {
-        .brand => "\x1b[1;97m",
+        .brand => "\x1b[1m",
         .heading, .label => "\x1b[1m",
-        .syntax => "\x1b[38;5;252m",
-        .muted => "\x1b[38;5;245m",
-        .link => "\x1b[4;38;5;252m",
+        .syntax => "\x1b[39m",
+        .muted => "\x1b[38;5;243m",
+        .link => "\x1b[4m",
     };
 }
 
@@ -1715,11 +1715,14 @@ test "terminal top-level help adds styling without changing visible content" {
     defer std.testing.allocator.free(stripped);
 
     try std.testing.expect(std.mem.find(u8, plain, "\x1b[") == null);
-    try std.testing.expect(std.mem.startsWith(u8, terminal, "\x1b[1;97m𝒇x\x1b[0m"));
+    try std.testing.expect(std.mem.startsWith(u8, terminal, "\x1b[1m𝒇x\x1b[0m"));
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[1mUsage:\x1b[0m") != null);
-    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;252mask <prompt>\x1b[0m") != null);
-    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[4;38;5;252mhttps://fx.sh/docs\x1b[0m") != null);
-    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;252mrun `/feedback` inside 𝒇x\x1b[0m") != null);
+    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[39mask <prompt>\x1b[0m") != null);
+    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;243mFast, native coding agent") != null);
+    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[4mhttps://fx.sh/docs\x1b[0m") != null);
+    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[39mrun `/feedback` inside 𝒇x\x1b[0m") != null);
+    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;252m") == null);
+    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;245m") == null);
     try std.testing.expectEqualStrings(plain, stripped);
 }
 

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -356,23 +356,14 @@ fn probeTerminal(
     no_color: bool,
 ) shell_runtime.CursorPosition {
     const fallback = shell_runtime.CursorPosition{ .row = layout.rows, .col = 1 };
-    if (std.c.isatty(std.posix.STDIN_FILENO) == 0) {
-        ui_render.initTheme(false, null);
-        return fallback;
-    }
-    terminal.captureOriginalTermios() catch {
-        ui_render.initTheme(false, null);
-        return fallback;
-    };
-    terminal.enableRawMode() catch {
-        ui_render.initTheme(false, null);
-        return fallback;
-    };
+    const fallback_light = if (no_color) false else ui_render.explicitThemeOverride() orelse false;
+    ui_render.initTheme(fallback_light, null);
+    if (std.c.isatty(std.posix.STDIN_FILENO) == 0) return fallback;
+    terminal.captureOriginalTermios() catch return fallback;
+    terminal.enableRawMode() catch return fallback;
     defer terminal.disableRawMode();
 
-    if (no_color) {
-        ui_render.initTheme(false, null);
-    } else {
+    if (!no_color) {
         const theme = ui_render.detectTheme(std.heap.c_allocator, terminal);
         ui_render.initTheme(theme.light, theme.rgb);
     }

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -72,6 +72,9 @@ pub const Runtime = struct {
 
         try self.shell.initBacking(alloc);
         try self.shell.enableShadowVt(alloc);
+        self.shell.setCommandOutputRenderPolicy(.{
+            .code_highlight_theme = if (ui_render.is_light) .light else .dark,
+        });
         const start = normalizeStartCursor(layout, cursor);
         self.shell.shadow_vt.?.cursor_row = start.row;
         self.shell.shadow_vt.?.cursor_col = start.col;
@@ -454,6 +457,38 @@ test "ask presentation paints Minimal prompt and assistant into a footerless fra
     try std.testing.expect(runtime.shell.shadow_vt.?.cellAt(1, 1) != null);
     const length = try output.length(io_mod.getIo());
     try std.testing.expect(length > restore_terminal_sequence.len);
+}
+
+test "ask presentation carries the light theme into semantic code blocks" {
+    const alloc = std.testing.allocator;
+    ui_render.initTheme(true, null);
+    defer ui_render.initTheme(false, null);
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var output = try tmp.dir.createFile(std.testing.io, "ask-light-frame.log", .{ .read = true });
+    defer output.close(io_mod.getIo());
+
+    var runtime = try Runtime.initConfigured(
+        alloc,
+        .{ .text = @constCast("show code") },
+        false,
+        output,
+        zeroFooterLayout(.{
+            .rows = 12,
+            .cols = 48,
+            .content_bottom = 12,
+            .divider_top_row = 12,
+            .input_row = 12,
+            .divider_bottom_row = 12,
+            .hint_row = 12,
+        }),
+        .{ .row = 1, .col = 1 },
+        true,
+    );
+    defer runtime.deinit();
+
+    try std.testing.expect(runtime.shell.retainedTranscriptStyles().code_highlight_theme == .light);
 }
 
 test "ask presentation retains a streaming write failure until finish" {

--- a/src/ui/render_engine/code_highlight.zig
+++ b/src/ui/render_engine/code_highlight.zig
@@ -3,15 +3,50 @@ const languages = @import("code_highlight_languages.zig");
 
 const Allocator = std.mem.Allocator;
 
-const keyword_style = "\x1b[38;5;252m";
-const string_style = "\x1b[38;5;250m";
-const number_style = "\x1b[38;5;250m";
-const comment_style = "\x1b[38;5;245m";
 const reset_style = "\x1b[39m";
 
-pub fn highlight(alloc: Allocator, source: []const u8, profile: *const languages.Profile) ![]u8 {
+pub const Theme = enum {
+    dark,
+    light,
+};
+
+const Palette = struct {
+    keyword_style: []const u8,
+    string_style: []const u8,
+    number_style: []const u8,
+    comment_style: []const u8,
+};
+
+const dark_palette: Palette = .{
+    .keyword_style = "\x1b[38;5;252m",
+    .string_style = "\x1b[38;5;250m",
+    .number_style = "\x1b[38;5;250m",
+    .comment_style = "\x1b[38;5;245m",
+};
+
+const light_palette: Palette = .{
+    .keyword_style = "\x1b[38;5;238m",
+    .string_style = "\x1b[38;5;241m",
+    .number_style = "\x1b[38;5;241m",
+    .comment_style = "\x1b[38;5;243m",
+};
+
+fn paletteForTheme(theme: Theme) Palette {
+    return switch (theme) {
+        .dark => dark_palette,
+        .light => light_palette,
+    };
+}
+
+pub fn highlight(
+    alloc: Allocator,
+    source: []const u8,
+    profile: *const languages.Profile,
+    theme: Theme,
+) ![]u8 {
     var styled: std.ArrayList(u8) = .empty;
     errdefer styled.deinit(alloc);
+    const palette = paletteForTheme(theme);
 
     var index: usize = 0;
     while (index < source.len) {
@@ -21,24 +56,24 @@ pub fn highlight(alloc: Allocator, source: []const u8, profile: *const languages
             continue;
         }
         if (blockCommentEnd(source, index, profile.block_comment)) |end| {
-            try appendStyled(alloc, &styled, comment_style, source[index..end]);
+            try appendStyled(alloc, &styled, palette.comment_style, source[index..end]);
             index = end;
             continue;
         }
         if (lineCommentEnd(source, index, profile.line_comments)) |end| {
-            try appendStyled(alloc, &styled, comment_style, source[index..end]);
+            try appendStyled(alloc, &styled, palette.comment_style, source[index..end]);
             index = end;
             continue;
         }
         if (isQuote(source[index], profile.quotes)) {
             const end = quotedEnd(source, index);
-            try appendStyled(alloc, &styled, string_style, source[index..end]);
+            try appendStyled(alloc, &styled, palette.string_style, source[index..end]);
             index = end;
             continue;
         }
         if (isNumberStart(source, index)) {
             const end = numberEnd(source, index);
-            try appendStyled(alloc, &styled, number_style, source[index..end]);
+            try appendStyled(alloc, &styled, palette.number_style, source[index..end]);
             index = end;
             continue;
         }
@@ -46,9 +81,9 @@ pub fn highlight(alloc: Allocator, source: []const u8, profile: *const languages
             const end = identifierEnd(source, index);
             const token = source[index..end];
             if (inList(token, profile.keywords, profile.keyword_case)) {
-                try appendStyled(alloc, &styled, keyword_style, token);
+                try appendStyled(alloc, &styled, palette.keyword_style, token);
             } else if (inList(token, profile.literals, profile.keyword_case)) {
-                try appendStyled(alloc, &styled, number_style, token);
+                try appendStyled(alloc, &styled, palette.number_style, token);
             } else {
                 try styled.appendSlice(alloc, token);
             }
@@ -180,7 +215,7 @@ fn count(text: []const u8, needle: []const u8) usize {
 test "supported source gains balanced colors without changing code bytes" {
     const alloc = std.testing.allocator;
     const source = "const value = \"const\"; // return\n";
-    const styled = try highlight(alloc, source, languages.resolve("zig").?);
+    const styled = try highlight(alloc, source, languages.resolve("zig").?, .dark);
     defer alloc.free(styled);
 
     const plain = try stripAnsi(alloc, styled);
@@ -192,6 +227,21 @@ test "supported source gains balanced colors without changing code bytes" {
     try std.testing.expectEqual(@as(usize, 1), count(styled, "\x1b[38;5;252mconst"));
     try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[38;5;250m\"const\"\x1b[39m") != null);
     try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[38;5;252mreturn") == null);
+}
+
+test "light theme uses a readable syntax palette without changing code bytes" {
+    const alloc = std.testing.allocator;
+    const source = "const value = \"ready\"; // comment\n";
+    const styled = try highlight(alloc, source, languages.resolve("zig").?, .light);
+    defer alloc.free(styled);
+
+    const plain = try stripAnsi(alloc, styled);
+    defer alloc.free(plain);
+    try std.testing.expectEqualStrings(source, plain);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[38;5;238mconst\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[38;5;241m\"ready\"\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[38;5;243m// comment\x1b[39m") != null);
+    try std.testing.expectEqual(count(styled, "\x1b[38;5;"), count(styled, "\x1b[39m"));
 }
 
 test "every registered profile highlights representative source" {
@@ -228,7 +278,7 @@ test "every registered profile highlights representative source" {
     };
 
     for (cases) |case| {
-        const styled = try highlight(alloc, case.source, languages.resolve(case.label).?);
+        const styled = try highlight(alloc, case.source, languages.resolve(case.label).?, .dark);
         defer alloc.free(styled);
         const plain = try stripAnsi(alloc, styled);
         defer alloc.free(plain);
@@ -240,11 +290,11 @@ test "every registered profile highlights representative source" {
 test "profiles use configured block comments and case-insensitive keywords" {
     const alloc = std.testing.allocator;
     const source = "/* comment */\nSELECT id FROM users\n<!-- note -->";
-    const css = try highlight(alloc, source[0..13], languages.resolve("css").?);
+    const css = try highlight(alloc, source[0..13], languages.resolve("css").?, .dark);
     defer alloc.free(css);
-    const sql = try highlight(alloc, source[14..34], languages.resolve("sql").?);
+    const sql = try highlight(alloc, source[14..34], languages.resolve("sql").?, .dark);
     defer alloc.free(sql);
-    const html = try highlight(alloc, source[35..], languages.resolve("html").?);
+    const html = try highlight(alloc, source[35..], languages.resolve("html").?, .dark);
     defer alloc.free(html);
 
     try std.testing.expect(std.mem.indexOf(u8, css, "\x1b[38;5;245m/* comment */\x1b[39m") != null);

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -27,6 +27,8 @@ pub const CommandOutputDisplayState = struct {
     open_command_block: ?usize = null,
 };
 
+pub const CodeHighlightTheme = code_highlight.Theme;
+
 pub const Styles = struct {
     system_notice_label_style: []const u8 = "",
     system_notice_text_style: []const u8 = "",
@@ -39,6 +41,7 @@ pub const Styles = struct {
     notice_warning_style: []const u8 = "",
     notice_error_style: []const u8 = "",
     notice_cancelled_style: []const u8 = "",
+    code_highlight_theme: CodeHighlightTheme = .dark,
 };
 
 pub const ToolFallbackDisposition = enum {
@@ -865,6 +868,15 @@ pub fn renderCodeBlockForTranscript(
     block: assistant_presentation.CodeBlockPayload,
     cols: u16,
 ) ![]u8 {
+    return renderCodeBlockForTranscriptWithTheme(alloc, block, cols, .dark);
+}
+
+fn renderCodeBlockForTranscriptWithTheme(
+    alloc: Allocator,
+    block: assistant_presentation.CodeBlockPayload,
+    cols: u16,
+    theme: CodeHighlightTheme,
+) ![]u8 {
     var rendered: std.ArrayList(u8) = .empty;
     errdefer rendered.deinit(alloc);
     if (cols == 0) return rendered.toOwnedSlice(alloc);
@@ -880,7 +892,7 @@ pub fn renderCodeBlockForTranscript(
     else
         "";
     const styled_code = if (profile) |resolved|
-        try code_highlight.highlight(alloc, block.code, resolved)
+        try code_highlight.highlight(alloc, block.code, resolved, theme)
     else
         null;
     defer if (styled_code) |code| alloc.free(code);
@@ -1570,7 +1582,12 @@ fn renderEntryToBlockForPresentationInterruptible(
         },
         .assistant_code_block => |e| blk: {
             const gutter = assistant_wrap.gutterWidth(cols);
-            const rendered = try renderCodeBlockForTranscript(alloc, e.block, cols -| gutter);
+            const rendered = try renderCodeBlockForTranscriptWithTheme(
+                alloc,
+                e.block,
+                cols -| gutter,
+                styles.code_highlight_theme,
+            );
             defer alloc.free(rendered);
             const prefixed = try assistant_wrap.prefixStructuralRows(alloc, rendered, gutter);
             break :blk try normalizeOwnedRenderedBlock(alloc, kind, prefixed);
@@ -3050,6 +3067,30 @@ test "renderCodeBlockForTranscript highlights registered profiles without stylin
     defer alloc.free(raw);
     try std.testing.expect(std.mem.indexOf(u8, raw, "\x1b[38;5;") == null);
     try std.testing.expect(std.mem.indexOf(u8, raw, "+++[>+++<-]") != null);
+}
+
+test "semantic code blocks use the light syntax palette when requested" {
+    const alloc = std.testing.allocator;
+    const language = try alloc.dupe(u8, "zig");
+    defer alloc.free(language);
+    const code = try alloc.dupe(u8, "const value = \"ready\"; // comment");
+    defer alloc.free(code);
+    const entry = TranscriptEntry{ .assistant_code_block = .{
+        .id = 1,
+        .block = .{
+            .language = language,
+            .code = code,
+        },
+    } };
+
+    const rendered = try renderEntryToBlock(alloc, entry, 80, .{
+        .code_highlight_theme = .light,
+    });
+    defer rendered.deinit(alloc);
+
+    try std.testing.expect(std.mem.indexOf(u8, rendered.bytes, "\x1b[38;5;238mconst\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered.bytes, "\x1b[38;5;241m\"ready\"\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered.bytes, "\x1b[38;5;243m// comment\x1b[39m") != null);
 }
 
 test "renderCodeBlockForTranscript infers registered high-confidence code blocks" {

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -1830,6 +1830,35 @@ test "semantic code block colors source and keeps structural rows default throug
     try std.testing.expect(resized_footer_cell.style.fg.eql(.default));
 }
 
+test "semantic code block keeps readable light theme colors through resize" {
+    var h = try Harness.init(std.testing.allocator, 40, 40, 4);
+    defer h.deinit();
+    try h.shell.initViewport(&h.metrics, 1);
+    h.shell.setCommandOutputRenderPolicy(.{ .code_highlight_theme = .light });
+
+    {
+        var block = assistant_presentation.CodeBlockPayload{
+            .language = try h.alloc.dupe(u8, "zig"),
+            .code = try h.alloc.dupe(u8, "const value = \"ready\"; // comment\n"),
+        };
+        errdefer block.deinit(h.alloc);
+        _ = try h.shell.appendAssistantCodeBlockOwned(h.alloc, block);
+    }
+    try h.renderTranscriptFrame();
+    try h.flush();
+
+    var code_row = try findRowContaining(&h, "const value");
+    var keyword_cell = h.vt.cellAt(code_row, 5) orelse return error.TestMissingCodeCell;
+    try std.testing.expectEqual(@as(u21, 'c'), keyword_cell.codepoint);
+    try std.testing.expect(keyword_cell.style.fg.eql(.{ .indexed = 238 }));
+
+    try h.driveResize(20, 40, 4, true);
+    code_row = try findRowContaining(&h, "const value");
+    keyword_cell = h.vt.cellAt(code_row, 5) orelse return error.TestMissingCodeCell;
+    try std.testing.expectEqual(@as(u21, 'c'), keyword_cell.codepoint);
+    try std.testing.expect(keyword_cell.style.fg.eql(.{ .indexed = 238 }));
+}
+
 test "semantic code block drops its frame before wrapping source that fits" {
     var h = try Harness.init(std.testing.allocator, 44, 40, 4);
     defer h.deinit();

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -319,7 +319,7 @@ describe("fx ask presentation", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
-    "light theme uses readable syntax colors in TTY code blocks",
+    "light theme uses readable syntax colors in TTY code blocks with redirected stdin",
     async () => {
       const root = createRoot();
       const gateway = startFakeGateway([fakeGatewayFinalText(MARKDOWN)]);
@@ -328,11 +328,11 @@ describe("fx ask presentation", () => {
       writeFileSync(stderrPath, "");
 
       const session = await TmuxSession.create({
-        cmd: terminalCommand([
+        cmd: `${terminalCommand([
           "ask",
           "--no-save",
           "Render the light-theme fixture.",
-        ]),
+        ])} </dev/null`,
         cwd: root.workspace,
         env: {
           ...gatewayEnv(root.home, gateway),

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -319,6 +319,43 @@ describe("fx ask presentation", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
+    "light theme uses readable syntax colors in TTY code blocks",
+    async () => {
+      const root = createRoot();
+      const gateway = startFakeGateway([fakeGatewayFinalText(MARKDOWN)]);
+      gateways.push(gateway);
+      const stderrPath = join(root.root, "stderr.log");
+      writeFileSync(stderrPath, "");
+
+      const session = await TmuxSession.create({
+        cmd: terminalCommand([
+          "ask",
+          "--no-save",
+          "Render the light-theme fixture.",
+        ]),
+        cwd: root.workspace,
+        env: {
+          ...gatewayEnv(root.home, gateway),
+          FX_THEME: "light",
+          NO_COLOR: undefined,
+        },
+        width: 120,
+        height: 40,
+        remainOnExit: true,
+        stderrPath,
+      });
+      sessions.push(session);
+
+      await session.waitForText("__FX_EXIT_0__", TIMEOUT);
+      const escaped = await session.captureFullScrollbackEscapes();
+      expect(escaped).toContain("\x1b[38;5;238mconst\x1b[39m");
+      expect(escaped).not.toContain("\x1b[38;5;252mconst\x1b[39m");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
     "TTY output taller than the pane survives in native scrollback",
     async () => {
       const root = createRoot();

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -5501,7 +5501,23 @@ describe("effect-aware command permissions", () => {
         [...scrollback.matchAll(/PERMISSIONS_SCROLLBACK_LINE_\d{2}/g)].map(
           (match) => match[0],
         );
-      const beforeScrollback = await activeSession.captureFullScrollback();
+      const waitForExpectedScrollback = async () => {
+        const deadline = Date.now() + TIMEOUT;
+        let latest = "";
+        while (Date.now() < deadline) {
+          latest = await activeSession!.captureFullScrollback();
+          const markers = extractMarkers(latest);
+          if (
+            markers.length === expectedMarkers.length &&
+            markers.every((marker, index) => marker === expectedMarkers[index])
+          ) return latest;
+          await Bun.sleep(100);
+        }
+        throw new Error(
+          `Timed out waiting for complete permissions scrollback.\nScrollback:\n${latest}`,
+        );
+      };
+      const beforeScrollback = await waitForExpectedScrollback();
       expect(extractMarkers(beforeScrollback)).toEqual(expectedMarkers);
       const traceOffset = readFileSync(tracePath, "utf8").length;
 
@@ -5531,7 +5547,7 @@ describe("effect-aware command permissions", () => {
         45_000,
       );
 
-      const afterScrollback = await activeSession.captureFullScrollback();
+      const afterScrollback = await waitForExpectedScrollback();
       expect(extractMarkers(afterScrollback)).toEqual(expectedMarkers);
       expect([...afterScrollback.matchAll(/mode set to ask/g)]).toHaveLength(1);
       expect(afterScrollback.indexOf("mode set to ask")).toBeGreaterThan(


### PR DESCRIPTION
## Summary

- use a dedicated high-contrast syntax palette on light terminal backgrounds
- pass the detected theme through interactive and fx ask transcript rendering
- make top-level TTY help use the terminal foreground for commands, flags, branding, and links
- use a readable middle gray for secondary help text on both light and dark backgrounds
- keep plain-text, piped, quiet, and JSON command output free of presentation colors
- cover direct highlighting, semantic rendering, resize, top-level help, and real TTY output

## Verification

- zig fmt --check src/
- zig test src/ui/render_engine/code_highlight.zig
- focused semantic transcript test
- focused resize regression
- focused top-level help styling test
- zig build
- focused fx ask TTY E2E with FX_THEME=light and the built ./zig-out/bin/fx
- real ./zig-out/bin/fx --help invocation in a pseudo-TTY, exit 0, with the old 252 and 245 help colors absent