### PR TITLE
Fix terminal close and admission contracts

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -167,7 +167,7 @@ const terminal_write_schema = gateway_schema.ObjectSchema{
         .{ .name = "kind", .json_type = .string, .enum_values = &.{ "text", "keys", "controls", "paste" } },
         .{ .name = "text", .json_type = .string, .description = "Required for text or paste." },
         .{ .name = "keys", .json_type = .array, .item_json_type = .string, .item_enum_values = &.{ "enter", "tab", "escape", "backspace", "delete", "insert", "arrow_up", "arrow_down", "arrow_left", "arrow_right", "home", "end", "page_up", "page_down" } },
-        .{ .name = "controls", .json_type = .array, .item_json_type = .integer, .description = "ASCII byte values for control characters, such as 99 for Ctrl+C." },
+        .{ .name = "controls", .json_type = .array, .item_json_type = .integer, .description = "ASCII code of the printable key designator used with Ctrl; for example, 108 (`l`) for Ctrl+L. Send the printable key code, not the resulting control byte." },
     },
     .required = &.{"kind"},
     .additional_properties = false,
@@ -1537,6 +1537,11 @@ test "terminal gateway advertisement projects a provider-compatible object schem
     try std.testing.expectEqual(false, input_schema.get("additionalProperties").?.bool);
     const properties = input_schema.get("properties").?.object;
     try std.testing.expectEqual(terminal_gateway_properties.len, properties.count());
+    const write_properties = properties.get("write").?.object.get("properties").?.object;
+    try std.testing.expectEqualStrings(
+        "ASCII code of the printable key designator used with Ctrl; for example, 108 (`l`) for Ctrl+L. Send the printable key code, not the resulting control byte.",
+        write_properties.get("controls").?.object.get("description").?.string,
+    );
     try std.testing.expectEqual(
         terminal_actions.len,
         properties.get("action").?.object.get("enum").?.array.items.len,

--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -5544,11 +5544,18 @@ fn closeAction(
         session.lifecycle == .running;
     session.mutex.unlock(zio);
     if (still_live) {
-        const requested_signal: contracts.Signal = if (request.policy == .force)
-            .kill
+        const delivered = if (request.policy == .force)
+            session.signalTerminalProcesses(.kill) catch |err| blk: {
+                debug_trace.logf(
+                    "terminal_host",
+                    "force close tree signal failed id={s} err={s}; falling back to shell group",
+                    .{ session.id, @errorName(err) },
+                );
+                break :blk session.signalProcess(.kill);
+            }
         else
-            .terminate;
-        if (!session.signalProcess(requested_signal)) session.markLost();
+            session.signalProcess(.terminate);
+        if (!delivered) session.markLost();
     }
     if (request.policy == .graceful and still_live) {
         const started = io_mod.milliTimestamp();

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -86,6 +86,37 @@ fn toolRequiresApproval(input: Input, name: []const u8) bool {
     return if (registeredTool(input, name)) |spec| spec.requires_approval else false;
 }
 
+fn registeredTerminalCallReadsOnly(
+    input: Input,
+    arena: Allocator,
+    call: ToolCall,
+) !bool {
+    const tool = registeredTool(input, call.name) orelse return false;
+    if (tool.executor_kind != .terminal) return false;
+    const decode_ctx = tool_dispatch.DispatchContext{
+        .allocator = arena,
+        .workspace_root = input.workspace_root,
+        .access_scope = input.access_scope,
+    };
+    const decoded = try tool.decode(decode_ctx, call.arguments_json);
+    return switch (decoded) {
+        .failure => |reason| blk: {
+            arena.free(reason);
+            break :blk false;
+        },
+        .input => |tool_input| blk: {
+            defer tool_input.deinit(arena);
+            if (tool.validate) |validate| {
+                if (try validate(decode_ctx, tool_input)) |reason| {
+                    arena.free(reason);
+                    break :blk false;
+                }
+            }
+            break :blk tool.reads_only_fn(tool_input);
+        },
+    };
+}
+
 fn toolApprovalPolicy(input: Input, name: []const u8) tool_dispatch.ApprovalPolicy {
     return if (registeredTool(input, name)) |spec| spec.approval_policy else .standard;
 }
@@ -824,6 +855,13 @@ fn resolveOrdinaryPermissionOutcome(
             ordinaryPermissionOutcome(.once)
         else
             .{ .decision = .permission_required };
+    }
+    if (permission_mode == .auto and
+        !command_call and
+        !is_dynamic_tool and
+        try registeredTerminalCallReadsOnly(input, arena, call))
+    {
+        return ordinaryPermissionOutcome(.once);
     }
     if (!command_call and !toolRequiresApproval(input, call.name) and !is_dynamic_tool) {
         return ordinaryPermissionOutcome(.once);
@@ -3913,6 +3951,72 @@ test "ask-only policy bypasses prompt and reviewer in auto and uses the ordinary
     try std.testing.expect(denied.execution_authority == null);
     try std.testing.expectEqual(@as(usize, 0), fake.calls);
     try std.testing.expectEqual(@as(usize, 2), recording.calls);
+}
+
+test "automatic terminal admission reviews only sensitive typed input" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(std.testing.allocator);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(std.testing.allocator);
+    var fake = FakeAutoClassifier{};
+    var input = testInputWithClassifier(
+        &worker,
+        &background,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+    const list_call = ToolCall{
+        .id = "terminal-list",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"list\"}",
+    };
+
+    const list = try requestPermissionOutcome(input, arena, list_call, .auto, &.{});
+    try std.testing.expectEqual(ToolPermissionDecision.once, list.decision);
+    try std.testing.expectEqual(command_admission.ToolExecutionAuthority.ordinary, list.execution_authority.?);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+
+    const start = try requestPermissionOutcome(input, arena, .{
+        .id = "terminal-start",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"start\"}",
+    }, .auto, &.{});
+    try std.testing.expectEqual(ToolPermissionDecision.once, start.decision);
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+
+    const asked = try requestPermissionOutcome(input, arena, list_call, .ask, &.{});
+    try std.testing.expectEqual(ToolPermissionDecision.permission_required, asked.decision);
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+
+    var rules = [_]types.PermissionRule{.{
+        .permission = @constCast("terminal"),
+        .pattern = @constCast("terminal"),
+        .action = .deny,
+    }};
+    input.permission_rules = .{ .rules = &rules };
+    const denied = try requestPermissionOutcome(input, arena, list_call, .auto, &.{});
+    try std.testing.expectEqual(ToolPermissionDecision.policy_denied, denied.decision);
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+
+    rules[0].action = .ask;
+    const configured_ask = try requestPermissionOutcome(input, arena, list_call, .auto, &.{});
+    try std.testing.expectEqual(ToolPermissionDecision.permission_required, configured_ask.decision);
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+
+    try std.testing.expectError(
+        error.UnexpectedEndOfInput,
+        requestPermissionOutcome(input, arena, .{
+            .id = "malformed-terminal-list",
+            .name = "terminal",
+            .arguments_json = "{",
+        }, .auto, &.{}),
+    );
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
 }
 
 test "existing tool approval policies retain the standard default" {

--- a/tests/e2e/terminal-host.test.ts
+++ b/tests/e2e/terminal-host.test.ts
@@ -7630,6 +7630,85 @@ while [ ! -e ${JSON.stringify(stopPath)} ]; do sleep 0.05; done
   }
 }, NATIVE_STARTUP_OBSERVATION_BUDGET_MS * 3 + 30_000);
 
+test("force close reaches a background job outside the shell process group", async () => {
+  if (!existsSync("/bin/zsh")) return;
+  const home = makeHome();
+  const paths = hostPaths(home);
+  const proofPath = join(home, "background-force-close.proof");
+  const stopPath = join(home, "background-force-close.stop");
+  const scriptPath = join(home, "background-force-close.sh");
+  writeFileSync(
+    scriptPath,
+    `#!/bin/sh
+printf '%s %s %s\n' "$$" "$PPID" "$(ps -o pgid= -p $$ | tr -d ' ')" > ${JSON.stringify(proofPath)}
+while [ ! -e ${JSON.stringify(stopPath)} ]; do sleep 0.05; done
+`,
+  );
+  chmodSync(scriptPath, 0o700);
+
+  const host = startHost(home, undefined, 200);
+  await waitFor(() => existsSync(paths.socket));
+  const control = await handshake(paths.socket, { minimum: 4, current: 5 });
+  let shellPid = 0;
+  let targetPid = 0;
+
+  try {
+    const started = await startNativeCommandFixture(
+      control.client,
+      control.revision!,
+      313_020,
+      {
+        cwd: home,
+        command:
+          `${JSON.stringify(scriptPath)} & child=$!; ` +
+          `while [ ! -s ${JSON.stringify(proofPath)} ]; do sleep 0.05; done; ` +
+          "printf 'background-force-close-ready\\n'; wait \"$child\"",
+        shell: { executable: { path: "/bin/zsh", clean_start: true } },
+        returnWhen: { match: "background-force-close-ready" },
+      },
+    );
+    const sessionId = (started.session as { session_id: string }).session_id;
+    const [pidText, parentText, pgidText] = readFileSync(proofPath, "utf8")
+      .trim()
+      .split(/\s+/);
+    targetPid = Number(pidText);
+    const targetParentPid = Number(parentText);
+    const targetPgid = Number(pgidText);
+    shellPid = Number(durableTerminalRecordFor(home, sessionId).pid);
+    expect(targetPid).toBeGreaterThan(0);
+    expect(targetParentPid).toBe(shellPid);
+    expect(targetPgid).toBe(processGroupId(targetPid));
+    expect(targetPgid).not.toBe(processGroupId(shellPid));
+
+    const closed = await requestAction(
+      control.client,
+      control.revision!,
+      313_030,
+      "close",
+      { session_id: sessionId, policy: "force" },
+    );
+    expect(success(closed, "close").session).toMatchObject({
+      lifecycle: "closed",
+    });
+    await waitFor(() => !processExists(shellPid), 5_000);
+    await waitFor(() => !processExists(targetPid), 5_000);
+  } finally {
+    writeFileSync(stopPath, "");
+    if (targetPid > 0 && processExists(targetPid)) {
+      try {
+        process.kill(targetPid, "SIGKILL");
+      } catch {}
+    }
+    if (shellPid > 0 && processExists(shellPid)) {
+      try {
+        process.kill(shellPid, "SIGKILL");
+      } catch {}
+    }
+    control.client.close();
+    if (host.exitCode === null) await waitForExit(host);
+  }
+}, NATIVE_STARTUP_OBSERVATION_BUDGET_MS * 3 + 30_000);
+
 test.skipIf(!tmuxAvailable())(
   "malformed close recovery cleans only its tmux owner and preserves a live sibling",
   async () => {

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -16,6 +16,7 @@ import { userInfo } from "node:os";
 import { join } from "node:path";
 import { FX_BIN } from "../evals/eval-helpers";
 import {
+  classifierEvidenceFromRequest,
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
   fakeGatewayToolCall,
@@ -1477,7 +1478,7 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
-  "TUI executes public native terminal start and owner-scoped list",
+  "TUI auto mode reviews terminal start but not owner-scoped list",
   async () => {
     const fixture = createFixture("fx-tui-terminal-public-");
     let startedSessionId = "";
@@ -1512,7 +1513,11 @@ test.skipIf(!tmuxAvailable())(
       fakeGatewayFinalText("TUI public terminal complete"),
     ]);
     gateways.push(gateway);
-    const active = await launch(fixture, gateway);
+    const active = await launch(fixture, gateway, {
+      FX_PERMISSION_MODE: "auto",
+      FX_TRACE_SCOPES:
+        "input,terminal,terminal_client,terminal_store,terminal_host,agent,worker,gateway,permission",
+    });
 
     await active.sendText("Run and list the native terminal fixture.");
     const pane = await active.waitForText("TUI public terminal complete", TIMEOUT);
@@ -1541,6 +1546,112 @@ test.skipIf(!tmuxAvailable())(
     expect(listResult).toContain('"lifecycle":"exited"');
     expect(listResult).not.toContain("owner_authority");
     expect(listResult).not.toContain("proof");
+    expect(gateway.classifierRequests).toHaveLength(1);
+    expect(classifierEvidenceFromRequest(gateway.classifierRequests[0]!.body))
+      .toContain('"action":"start"');
+    expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
+  "TUI public terminal controls reject encoded bytes and deliver key designators",
+  async () => {
+    const fixture = createFixture("fx-tui-terminal-public-controls-");
+    const bytePath = join(fixture.root, "control-byte.txt");
+    let terminalSessionId = "";
+    const gateway = startFakeGateway([
+      fakeGatewayToolCall("tui_terminal_controls_start", "terminal", {
+        action: "start",
+        cwd: fixture.workspace,
+        command:
+          "printf 'TUI_PUBLIC_CONTROLS_READY\\n'; stty raw -echo; " +
+          `od -An -tu1 -N1 | tr -d '[:space:]' > ${JSON.stringify(bytePath)}; ` +
+          "printf '\\nTUI_PUBLIC_CONTROLS_DONE\\n'; " +
+          holdUntilCleanup(fixture.root),
+        shell: {
+          kind: "executable",
+          path: TERMINAL_FIXTURE_SHELL,
+          clean_start: true,
+        },
+        backend: "native",
+        return_when: { kind: "match", pattern: "TUI_PUBLIC_CONTROLS_READY" },
+        wait_ceiling_ms: 20_000,
+        dimensions: { rows: 24, columns: 80 },
+      }),
+      (body) => {
+        const result = JSON.parse(
+          toolResultText(body, "tui_terminal_controls_start"),
+        ) as {
+          success: { start: { session: { session_id: string } } };
+        };
+        terminalSessionId = result.success.start.session.session_id;
+        return fakeGatewayToolCall(
+          "tui_terminal_controls_acquire",
+          "terminal",
+          {
+            action: "write",
+            session_id: terminalSessionId,
+            lease: "acquire",
+          },
+        );
+      },
+      (body) => {
+        expect(toolResultText(body, "tui_terminal_controls_acquire"))
+          .toContain('"write_lease":"agent"');
+        return fakeGatewayToolCall(
+          "tui_terminal_controls_encoded_byte",
+          "terminal",
+          {
+            action: "write",
+            session_id: terminalSessionId,
+            lease: "use",
+            write: { kind: "controls", controls: [12] },
+          },
+        );
+      },
+      (body) => {
+        expect(toolResultText(body, "tui_terminal_controls_encoded_byte"))
+          .toContain("InvalidWritePayload");
+        return fakeGatewayToolCall(
+          "tui_terminal_controls_designator",
+          "terminal",
+          {
+            action: "write",
+            session_id: terminalSessionId,
+            lease: "use",
+            write: { kind: "controls", controls: [108] },
+          },
+        );
+      },
+      async (body) => {
+        expect(toolResultText(body, "tui_terminal_controls_designator"))
+          .toContain('"accepted_bytes":1');
+        expect((await waitForTrace(bytePath, "12")).trim()).toBe("12");
+        return fakeGatewayToolCall("tui_terminal_controls_close", "terminal", {
+          action: "close",
+          session_id: terminalSessionId,
+          close_policy: "force",
+        });
+      },
+      (body) => {
+        expect(toolResultText(body, "tui_terminal_controls_close"))
+          .toContain('"lifecycle":"closed"');
+        return fakeGatewayFinalText("TUI public terminal controls complete");
+      },
+    ]);
+    gateways.push(gateway);
+    const active = await launch(fixture, gateway);
+
+    await active.sendText("Exercise public terminal Ctrl+L input.");
+    const pane = await active.waitForText(
+      "TUI public terminal controls complete",
+      TIMEOUT,
+    );
+    expect(pane).toContain("Failed write");
+    expect(pane).toContain("Used terminal write");
+    expect(gateway.requests).toHaveLength(6);
+    expect(readFileSync(bytePath, "utf8").trim()).toBe("12");
     expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
   },
   TIMEOUT,


### PR DESCRIPTION
## Summary

- Terminate terminal-owned jobs in other process groups during force close.
- Skip automatic review for read-only terminal actions in auto mode.
- Preserve ask-mode prompts and sensitive terminal review.
- Document printable Ctrl key designators while keeping encoded control bytes invalid.

Stacked on #60.