### PR TITLE
Preserve diff gutters on wrapped rows

### DIFF
--- a/src/ui/full_transcript_screen.zig
+++ b/src/ui/full_transcript_screen.zig
@@ -868,13 +868,13 @@ test "full projection matches file details to full diffs by marker and lifecycle
     const compact_first = try @import("../core/output/diff.zig").wrapWithMarkers(
         alloc,
         101,
-        "COMPACT_FIRST\n",
+        "\x1b[38;5;252m  │ \x1b[38;5;203m1 -\x1b[38;5;252m ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnCOMPACT_FIRST_TAIL\x1b[0m\n",
     );
     defer alloc.free(compact_first);
     const compact_second = try @import("../core/output/diff.zig").wrapWithMarkers(
         alloc,
         102,
-        "COMPACT_SECOND\n",
+        "\x1b[38;5;252m  │ \x1b[38;5;77m1 +\x1b[38;5;252m ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnCOMPACT_SECOND_TAIL\x1b[0m\n",
     );
     defer alloc.free(compact_second);
     const entries = [_]transcript_blocks.TranscriptEntry{
@@ -900,8 +900,10 @@ test "full projection matches file details to full diffs by marker and lifecycle
     defer for (&details) |*detail| detail.deinit(alloc);
 
     const Resolver = struct {
+        const full_first = "\x1b[38;5;252m  │ \x1b[38;5;203m1 -\x1b[38;5;252m ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnFULL_FIRST_TAIL\x1b[0m\n";
+
         fn fullForMarker(_: *anyopaque, id: u32) ?[]const u8 {
-            return if (id == 101) "FULL_FIRST\n" else null;
+            return if (id == 101) full_first else null;
         }
 
         fn hasFullForLifecycle(_: *anyopaque, lifecycle_id: types.ToolLifecycleId) bool {
@@ -909,13 +911,14 @@ test "full projection matches file details to full diffs by marker and lifecycle
         }
     };
     var resolver_context: u8 = 0;
+    const styles: transcript_blocks.Styles = .{ .system_notice_label_style = "", .system_notice_text_style = "", .reset_style = "", .dim_style = "", .red_style = "" };
     var projection = try buildProjectionWithDiffResolver(
         alloc,
         &entries,
         &details,
         &.{},
-        .{ .system_notice_label_style = "", .system_notice_text_style = "", .reset_style = "", .dim_style = "", .red_style = "" },
-        80,
+        styles,
+        48,
         null,
         .{
             .context = &resolver_context,
@@ -924,14 +927,46 @@ test "full projection matches file details to full diffs by marker and lifecycle
         },
     );
     defer projection.deinit(alloc);
-    const source = try renderProjectionViewportSource(alloc, &projection, null, 80, 24, 0);
+    const measurement = try measureProjection(alloc, &projection, null, 48);
+    const source = try renderProjectionViewportSource(alloc, &projection, null, 48, @intCast(measurement.total_rows), 0);
     defer alloc.free(source);
 
-    try std.testing.expect(std.mem.indexOf(u8, source, "FULL_FIRST") != null);
-    try std.testing.expect(std.mem.indexOf(u8, source, "COMPACT_FIRST") == null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "  │     FULL_FIRST_TAIL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "COMPACT_FIRST_TAIL") == null);
     try std.testing.expect(std.mem.indexOf(u8, source, "RAW_FIRST") == null);
-    try std.testing.expect(std.mem.indexOf(u8, source, "COMPACT_SECOND") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "  │     COMPACT_SECOND_TAIL") != null);
     try std.testing.expect(std.mem.indexOf(u8, source, "RAW_SECOND") != null);
+
+    var wide_projection = try buildProjectionWithDiffResolver(
+        alloc,
+        &entries,
+        &details,
+        &.{},
+        styles,
+        120,
+        null,
+        .{
+            .context = &resolver_context,
+            .full_for_marker = Resolver.fullForMarker,
+            .has_full_for_lifecycle = Resolver.hasFullForLifecycle,
+        },
+    );
+    defer wide_projection.deinit(alloc);
+    const wide_measurement = try measureProjection(alloc, &wide_projection, null, 120);
+    const wide_source = try renderProjectionViewportSource(
+        alloc,
+        &wide_projection,
+        null,
+        120,
+        @intCast(wide_measurement.total_rows),
+        0,
+    );
+    defer alloc.free(wide_source);
+
+    try std.testing.expect(std.mem.indexOf(u8, wide_source, "FULL_FIRST_TAIL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, wide_source, "COMPACT_SECOND_TAIL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, wide_source, "  │     ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, wide_source, "RAW_SECOND") != null);
 }
 
 test "review bounds compact diff without a full retained sidecar" {
@@ -939,9 +974,9 @@ test "review bounds compact diff without a full retained sidecar" {
     const compact = try diff_mod.wrapWithMarkers(
         alloc,
         103,
-        "COMPACT_REVIEW_1\n" ++
-            "COMPACT_REVIEW_2\n" ++
-            "COMPACT_REVIEW_3\n" ++
+        "\x1b[38;5;252m  │ \x1b[38;5;203m1 -\x1b[38;5;252m ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnCOMPACT_REVIEW_1_TAIL\x1b[0m\n" ++
+            "\x1b[38;5;252m  │ \x1b[38;5;77m2 +\x1b[38;5;252m ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnCOMPACT_REVIEW_2_TAIL\x1b[0m\n" ++
+            "\x1b[38;5;245m  │ 3   ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnCOMPACT_REVIEW_3_TAIL\x1b[0m\n" ++
             "COMPACT_REVIEW_4\n" ++
             "COMPACT_REVIEW_5\n" ++
             "COMPACT_REVIEW_6\n" ++
@@ -979,7 +1014,7 @@ test "review bounds compact diff without a full retained sidecar" {
         &details,
         &.{},
         .{ .system_notice_label_style = "", .system_notice_text_style = "", .reset_style = "", .dim_style = "", .red_style = "" },
-        80,
+        48,
         null,
         .review,
         .{
@@ -990,19 +1025,20 @@ test "review bounds compact diff without a full retained sidecar" {
         null,
     );
     defer projection.deinit(alloc);
-    const measurement = try measureProjection(alloc, &projection, null, 80);
+    const measurement = try measureProjection(alloc, &projection, null, 48);
     const source = try renderProjectionViewportSource(
         alloc,
         &projection,
         null,
-        80,
+        48,
         @intCast(measurement.total_rows),
         0,
     );
     defer alloc.free(source);
 
-    try std.testing.expect(std.mem.indexOf(u8, source, "COMPACT_REVIEW_1") != null);
-    try std.testing.expect(std.mem.indexOf(u8, source, "COMPACT_REVIEW_3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "  │     COMPACT_REVIEW_1_TAIL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "  │     COMPACT_REVIEW_2_TAIL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, source, "  │     COMPACT_REVIEW_3_TAIL") != null);
     try std.testing.expect(std.mem.indexOf(u8, source, "COMPACT_REVIEW_4") == null);
     try std.testing.expect(std.mem.indexOf(u8, source, "COMPACT_REVIEW_10") == null);
     try std.testing.expect(std.mem.indexOf(u8, source, "7 more lines · → to expand") != null);
@@ -1017,7 +1053,7 @@ test "review bounds compact diff without a full retained sidecar" {
         &details,
         &.{},
         .{ .system_notice_label_style = "", .system_notice_text_style = "", .reset_style = "", .dim_style = "", .red_style = "" },
-        80,
+        48,
         null,
         .full,
         .{
@@ -1028,18 +1064,19 @@ test "review bounds compact diff without a full retained sidecar" {
         null,
     );
     defer full.deinit(alloc);
-    const full_measurement = try measureProjection(alloc, &full, null, 80);
+    const full_measurement = try measureProjection(alloc, &full, null, 48);
     const full_source = try renderProjectionViewportSource(
         alloc,
         &full,
         null,
-        80,
+        48,
         @intCast(full_measurement.total_rows),
         0,
     );
     defer alloc.free(full_source);
 
     try std.testing.expect(std.mem.indexOf(u8, full_source, "COMPACT_REVIEW_10") != null);
+    try std.testing.expect(std.mem.indexOf(u8, full_source, "  │     COMPACT_REVIEW_1_TAIL") != null);
     try std.testing.expect(std.mem.indexOf(u8, full_source, "FULL_ARGUMENT_TAIL") != null);
     try std.testing.expect(std.mem.indexOf(u8, full_source, "{\"path\"") == null);
 }
@@ -6881,8 +6918,7 @@ const ProjectionComposeContext = struct {
 
     fn overrideKind(context: *anyopaque, entry: transcript_blocks.TranscriptEntry) ?transcript_blocks.TranscriptBlockKind {
         const self = fromOpaque(context);
-        if (self.depth == .review and self.reviewDiffForEntry(entry) != null) return .diff_block;
-        if (self.fullDiffForEntry(entry) != null) return .diff_block;
+        if (self.diffForEntry(entry) != null) return .diff_block;
         if (self.source_index.renderableCommandBlockIndexForEntry(entry.id()) != null) return .command_output;
         return switch (self.entryAction(entry)) {
             .override => |value| value.kind,
@@ -6896,14 +6932,14 @@ const ProjectionComposeContext = struct {
         out: *std.Io.Writer.Allocating,
     ) !bool {
         const self = fromOpaque(context);
-        if (self.depth == .review) {
-            if (self.reviewDiffForEntry(entry)) |diff| {
-                return appendReviewDiffLines(out, diff, self.builder.styles());
+        if (self.diffForEntry(entry)) |diff| {
+            if (self.depth == .review) {
+                return appendReviewDiffLines(out, self.alloc, diff, self.builder.styles(), self.cols);
             }
-        }
-        if (self.fullDiffForEntry(entry)) |full| {
-            try out.writer.writeAll(full);
-            return std.mem.endsWith(u8, full, "\n");
+            const reflowed = try transcript_blocks.reflowDiffBlock(self.alloc, diff, self.cols);
+            defer self.alloc.free(reflowed);
+            try out.writer.writeAll(reflowed);
+            return std.mem.endsWith(u8, reflowed, "\n");
         }
         if (self.source_index.renderableCommandBlockIndexForEntry(entry.id())) |index| {
             return appendCommandBlockAtEntry(self, out, index, entry.id());
@@ -6954,7 +6990,7 @@ const ProjectionComposeContext = struct {
         return self.entry_actions[self.entry_index];
     }
 
-    fn reviewDiffForEntry(
+    fn diffForEntry(
         self: *const ProjectionComposeContext,
         entry: transcript_blocks.TranscriptEntry,
     ) ?[]const u8 {
@@ -7496,13 +7532,17 @@ fn appendReviewLines(
 
 fn appendReviewDiffLines(
     out: *std.Io.Writer.Allocating,
+    alloc: Allocator,
     bytes: []const u8,
     styles: transcript_blocks.Styles,
+    cols: u16,
 ) !bool {
     const max_lines = review_detail_line_limit;
     const total_lines = logicalLineCount(bytes);
     const preview = prefixThroughLogicalLines(bytes, max_lines);
-    try out.writer.writeAll(preview);
+    const reflowed = try transcript_blocks.reflowDiffBlock(alloc, preview, cols);
+    defer alloc.free(reflowed);
+    try out.writer.writeAll(reflowed);
     if (preview.len > 0 and preview[preview.len - 1] != '\n') try out.writer.writeByte('\n');
     if (total_lines > max_lines) {
         try out.writer.writeAll("  ");

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -597,33 +597,60 @@ fn appendToolStatusSgrReplay(alloc: Allocator, out: *std.ArrayList(u8), text: []
     }
 }
 
-const CompactDiffPrefix = struct {
+const DiffPrefix = struct {
     text_start: usize,
     width: u16,
 };
 
-fn compactDiffPrefix(line: []const u8) ?CompactDiffPrefix {
-    const gutter_start = std.mem.indexOf(u8, line, "  │ ") orelse return null;
-    var prefix_index: usize = 0;
-    while (prefix_index < gutter_start) {
-        if (line[prefix_index] != 0x1b) return null;
-        const end = display_width.ansiSequenceEnd(line, prefix_index);
-        if (end <= prefix_index) return null;
-        prefix_index = end;
+fn skipDiffPrefixAnsi(line: []const u8, index: *usize) bool {
+    while (index.* < line.len and line[index.*] == 0x1b) {
+        const end = display_width.ansiSequenceEnd(line, index.*);
+        if (end <= index.*) return false;
+        index.* = end;
     }
+    return true;
+}
 
-    var number_end = gutter_start + "  │ ".len;
-    while (number_end < line.len and line[number_end] == ' ') : (number_end += 1) {}
-    const digit_start = number_end;
-    while (number_end < line.len and std.ascii.isDigit(line[number_end])) : (number_end += 1) {}
-    if (digit_start == number_end or number_end + 2 >= line.len) return null;
-    if (line[number_end] != ' ' or line[number_end + 2] != ' ') return null;
-    switch (line[number_end + 1]) {
+fn consumeDiffPrefixByte(line: []const u8, index: *usize, expected: u8) bool {
+    if (!skipDiffPrefixAnsi(line, index)) return false;
+    if (index.* >= line.len or line[index.*] != expected) return false;
+    index.* += 1;
+    return true;
+}
+
+fn diffPrefix(line: []const u8) ?DiffPrefix {
+    var index: usize = 0;
+    if (!consumeDiffPrefixByte(line, &index, ' ')) return null;
+    if (!consumeDiffPrefixByte(line, &index, ' ')) return null;
+    if (!skipDiffPrefixAnsi(line, &index)) return null;
+    if (!std.mem.startsWith(u8, line[index..], "│")) return null;
+    index += "│".len;
+    if (!consumeDiffPrefixByte(line, &index, ' ')) return null;
+
+    while (true) {
+        if (!skipDiffPrefixAnsi(line, &index)) return null;
+        if (index >= line.len or line[index] != ' ') break;
+        index += 1;
+    }
+    var digit_count: usize = 0;
+    while (true) {
+        if (!skipDiffPrefixAnsi(line, &index)) return null;
+        if (index >= line.len or !std.ascii.isDigit(line[index])) break;
+        digit_count += 1;
+        index += 1;
+    }
+    if (digit_count == 0) return null;
+    if (!consumeDiffPrefixByte(line, &index, ' ')) return null;
+    if (!skipDiffPrefixAnsi(line, &index) or index >= line.len) return null;
+    switch (line[index]) {
         '+', '-', ' ' => {},
         else => return null,
     }
+    index += 1;
+    if (!consumeDiffPrefixByte(line, &index, ' ')) return null;
+    if (!skipDiffPrefixAnsi(line, &index)) return null;
 
-    const text_start = number_end + 3;
+    const text_start = index;
     const width = std.math.cast(u16, display_width.visibleWidthIgnoringAnsi(line[0..text_start])) orelse return null;
     if (width < 4) return null;
     return .{ .text_start = text_start, .width = width };
@@ -652,11 +679,11 @@ fn appendSgrTransitions(
     }
 }
 
-fn reflowCompactDiffRow(
+fn reflowDiffRow(
     alloc: Allocator,
     out: *std.ArrayList(u8),
     line: []const u8,
-    prefix: CompactDiffPrefix,
+    prefix: DiffPrefix,
     cols: u16,
 ) !void {
     try out.appendSlice(alloc, line[0..prefix.text_start]);
@@ -702,7 +729,9 @@ fn reflowCompactDiffRow(
     }
 }
 
-fn reflowCompactDiffBlock(alloc: Allocator, text: []const u8, cols: u16) ![]u8 {
+/// Reflows logical diff rows for the current terminal width. The caller owns
+/// the returned bytes.
+pub fn reflowDiffBlock(alloc: Allocator, text: []const u8, cols: u16) ![]u8 {
     if (cols == 0 or text.len == 0) return alloc.dupe(u8, text);
 
     var out: std.ArrayList(u8) = .empty;
@@ -712,9 +741,9 @@ fn reflowCompactDiffBlock(alloc: Allocator, text: []const u8, cols: u16) ![]u8 {
         const newline = std.mem.indexOfScalarPos(u8, text, start, '\n');
         const end = newline orelse text.len;
         const line = text[start..end];
-        if (compactDiffPrefix(line)) |prefix| {
+        if (diffPrefix(line)) |prefix| {
             if (prefix.width < cols) {
-                try reflowCompactDiffRow(alloc, &out, line, prefix, cols);
+                try reflowDiffRow(alloc, &out, line, prefix, cols);
             } else {
                 try out.appendSlice(alloc, line);
             }
@@ -1518,7 +1547,7 @@ fn renderEntryToBlockForPresentationInterruptible(
             const preview = try formatToolStatusPreview(alloc, e.bytes, cols);
             break :blk try normalizeOwnedRenderedBlock(alloc, kind, preview);
         } else if (e.class == .diff_block and presentation == .compact) blk: {
-            const compact = try reflowCompactDiffBlock(alloc, e.bytes, cols);
+            const compact = try reflowDiffBlock(alloc, e.bytes, cols);
             break :blk try normalizeOwnedRenderedBlock(alloc, kind, compact);
         } else try normalizeRenderedBlockTail(alloc, kind, e.bytes),
         .semantic_notice => |e| blk: {
@@ -3399,8 +3428,8 @@ test "compact diff blocks reflow styled rows inside their gutters" {
     const source =
         "\x1b]9050;17\x07" ++
         "\x1b[38;5;245m  │ 2   CONTEXT_ROW_MARKER with a deliberately long value that must wrap inside the gutter\x1b[0m\n" ++
-        "\x1b[38;5;252m  │ 3 - REMOVED_ROW_MARKER with a deliberately long value that must wrap inside the gutter\x1b[0m\n" ++
-        "\x1b[38;5;252m  │ 3 + MUTATION_NEW_MARKER with a deliberately long replacement value that must wrap correctly in the diff preview\x1b[0m\n" ++
+        "\x1b[38;5;252m  │ \x1b[38;5;203m3 -\x1b[38;5;252m REMOVED_ROW_MARKER with a deliberately long value that must wrap inside the gutter\x1b[0m\n" ++
+        "\x1b[38;5;252m  │ \x1b[38;5;77m3 +\x1b[38;5;252m MUTATION_NEW_MARKER with a deliberately long replacement value that must wrap correctly in the diff preview\x1b[0m\n" ++
         "\x1b]9051;17\x07";
     var entries: std.ArrayList(TranscriptEntry) = .empty;
     defer deinitTestEntries(&entries, alloc);
@@ -3409,8 +3438,8 @@ test "compact diff blocks reflow styled rows inside their gutters" {
     const narrow = try renderEntriesToBytes(alloc, entries.items, 48, .{});
     defer alloc.free(narrow);
     try std.testing.expect(std.mem.indexOf(u8, narrow, "\x1b[0m\n\x1b[38;5;245m  │     ") != null);
-    try std.testing.expect(std.mem.indexOf(u8, narrow, "\x1b[0m\n\x1b[38;5;252m  │     ") != null);
-    try std.testing.expect(std.mem.indexOf(u8, narrow, "\x1b[0m\n\x1b[38;5;252m  │     ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, narrow, "\x1b[0m\n\x1b[38;5;252m\x1b[38;5;203m\x1b[38;5;252m  │     ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, narrow, "\x1b[0m\n\x1b[38;5;252m\x1b[38;5;77m\x1b[38;5;252m  │     ") != null);
     try std.testing.expect(std.mem.indexOf(u8, narrow, "CONTEXT_ROW_MARKER") != null);
     try std.testing.expect(std.mem.indexOf(u8, narrow, "REMOVED_ROW_MARKER") != null);
     try std.testing.expect(std.mem.indexOf(u8, narrow, "MUTATION_NEW_MARKER") != null);
@@ -3422,6 +3451,30 @@ test "compact diff blocks reflow styled rows inside their gutters" {
         try std.testing.expect(display_width.visibleWidthIgnoringAnsi(line) <= 48);
     }
     try std.testing.expectEqualStrings(source, entries.items[0].raw_bytes.bytes);
+}
+
+test "diff block reflow preserves fitting malformed and unicode rows" {
+    const alloc = std.testing.allocator;
+    const fitting = "\x1b[38;5;252m  │ \x1b[38;5;203m1 -\x1b[38;5;252m short λ value\x1b[0m\n";
+    const wide = try reflowDiffBlock(alloc, fitting, 80);
+    defer alloc.free(wide);
+    try std.testing.expectEqualStrings(fitting, wide);
+
+    const malformed = "\x1b[38;5;252m  │ not-a-diff-row that remains byte-identical\x1b[0m\n";
+    const unchanged = try reflowDiffBlock(alloc, malformed, 16);
+    defer alloc.free(unchanged);
+    try std.testing.expectEqualStrings(malformed, unchanged);
+
+    const unicode = "\x1b[38;5;252m  │ \x1b[38;5;77m2 +\x1b[38;5;252m 😀😀😀😀UNICODE_TAIL\x1b[0m\n";
+    const narrow = try reflowDiffBlock(alloc, unicode, 16);
+    defer alloc.free(narrow);
+    try std.testing.expect(std.mem.indexOf(u8, narrow, "  │     UNICODE_") != null);
+    try std.testing.expect(std.mem.indexOf(u8, narrow, "TAIL") != null);
+    var lines = std.mem.splitScalar(u8, narrow, '\n');
+    while (lines.next()) |line| {
+        if (display_width.visibleWidthIgnoringAnsi(line) == 0) continue;
+        try std.testing.expect(display_width.visibleWidthIgnoringAnsi(line) <= 16);
+    }
 }
 
 test "renderEntriesToBytes normalizes raw byte entry tails and inserts block gaps" {

--- a/tests/e2e/tui-permissions.test.ts
+++ b/tests/e2e/tui-permissions.test.ts
@@ -138,6 +138,12 @@ function expectCleanStderr(path: string) {
   expect(readFileSync(path, "utf8")).toBe("");
 }
 
+function expectDiffSentinelOnRail(text: string, sentinel: string) {
+  const rows = text.split("\n").filter((row) => row.includes(sentinel));
+  expect(rows.length).toBeGreaterThan(0);
+  for (const row of rows) expect(row.startsWith("  │")).toBe(true);
+}
+
 function fullDisplayClearCount(tapePath: string): number {
   const clear = Buffer.from("\x1b[2J");
   let count = 0;
@@ -1417,6 +1423,77 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
       expect(replay.stderr).toBe("");
       expect(replay.stdout).toContain("CTRL_O_FIRST_001");
       expect(replay.stdout).toContain("CTRL_O_SECOND_060");
+    },
+    90_000,
+  );
+
+  test(
+    "wraps file diff continuations inside their gutters",
+    async () => {
+      const root = createIsolatedRoot();
+      const target = join(root.workspace, "wrapped.txt");
+      const oldLine = `const wrapped_value = "${"A".repeat(180)}OLD_WRAP_TAIL";\n`;
+      const newLine = `const wrapped_value = "${"B".repeat(180)}NEW_WRAP_TAIL";\n`;
+      writeFileSync(target, oldLine);
+      const gateway = startFakeGateway([
+        toolCall("wrap_diff", "edit_file", {
+          path: "wrapped.txt",
+          old_string: oldLine,
+          new_string: newLine,
+        }),
+        finalText("WRAP_DIFF_COMPLETE"),
+      ]);
+      const tapePath = join(root.root, "diff-wrap.fxtape");
+      const { session, stderrPath } = await launch(
+        root,
+        gateway,
+        { width: 72, height: 40 },
+        { FX_RECORD: tapePath },
+      );
+
+      await session.sendText("Replace the wrapped fixture value.");
+      await waitForFileApproval(session, {
+        required: ["OLD_WRAP_TAIL", "NEW_WRAP_TAIL"],
+      });
+      await decide(session, 1);
+      await session.waitForText("WRAP_DIFF_COMPLETE", TIMEOUT);
+      expect(readFileSync(target, "utf8")).toBe(newLine);
+
+      const inline = await session.captureFullScrollback();
+      expectDiffSentinelOnRail(inline, "OLD_WRAP_TAIL");
+      expectDiffSentinelOnRail(inline, "NEW_WRAP_TAIL");
+
+      await session.sendKeys("C-o");
+      await session.waitForText("Review · ←/→ switch · ctrl o close", TIMEOUT);
+      const review = await session.capturePane();
+      expectDiffSentinelOnRail(review, "OLD_WRAP_TAIL");
+      expectDiffSentinelOnRail(review, "NEW_WRAP_TAIL");
+
+      await session.sendKeys("Right");
+      await session.waitForText("Full detail · ←/→ switch · ctrl o close", TIMEOUT);
+      const full = await session.capturePane();
+      expectDiffSentinelOnRail(full, "OLD_WRAP_TAIL");
+      expectDiffSentinelOnRail(full, "NEW_WRAP_TAIL");
+
+      await session.resizeWindow(56, 40, 500);
+      const narrow = await session.capturePane();
+      expectDiffSentinelOnRail(narrow, "OLD_WRAP_TAIL");
+      expectDiffSentinelOnRail(narrow, "NEW_WRAP_TAIL");
+
+      await session.resizeWindow(100, 40, 500);
+      const wide = await session.capturePane();
+      expectDiffSentinelOnRail(wide, "OLD_WRAP_TAIL");
+      expectDiffSentinelOnRail(wide, "NEW_WRAP_TAIL");
+
+      expect(session.isAlive()).toBe(true);
+      expectCleanStderr(stderrPath);
+      const replay = await runFx(["replay", tapePath, "--frames"], {
+        cwd: root.workspace,
+        env: { HOME: root.home },
+      });
+      expect(replay.code).toBe(0);
+      expect(replay.stderr).toBe("");
+      expect(replay.stdout).toContain("NEW_WRAP_TAIL");
     },
     90_000,
   );


### PR DESCRIPTION
## Summary

- Keep wrapped file-diff rows aligned inside their gutters in Inline, Review, and Full detail.
- Preserve marked-preview fallback content and attached detail when a full diff sidecar is unavailable.
- Reflow file diffs with their gutters when Full detail is resized.