### PR TITLE
Preserve transcript layout when closing inline pickers

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -29,6 +29,7 @@ const activity_runtime = @import("../output/activity_runtime.zig");
 const transcript_presentation = @import("../output/transcript_presentation.zig");
 const event_loop = @import("../../ui/event_loop.zig");
 const surface_frame = @import("../../ui/footer/surface_frame.zig");
+const surface_invalidation = @import("../../ui/footer/surface_invalidation.zig");
 const interaction_state = @import("../../ui/footer/interaction_state.zig");
 const approval_prompt = @import("../permissions/approval_prompt.zig");
 const render_input = @import("../../ui/footer/render_input.zig");
@@ -1785,6 +1786,7 @@ pub fn Runtime(comptime App: type) type {
             var footer_frame_initialized = false;
             defer if (footer_frame_initialized) footer_frame.deinit(app.alloc);
             var solved_layout: ?render_engine.frame_layout.FrameLayout = null;
+            var resolved_transcript_target: ?transcript_runtime.TranscriptRuntime.ResolvedTranscriptTarget = null;
             var scroll_plan = render_engine.frame_scroll_plan.FrameScrollPlan.none(
                 presentation_shell.layout.rows,
                 presentation_shell.owned_top_row,
@@ -1808,14 +1810,31 @@ pub fn Runtime(comptime App: type) type {
                     frameActivityStateFromMeasurement(presentation_shell, measurement)
                 else
                     activityStateFromPlacement(footer_frame.paint.activity);
+                const target_activity_projection: activity_runtime.ActivityProjection = if (footer_measurement) |*measurement|
+                    measurement.activity_projection
+                else
+                    .{ .turn_thinking = .{ .label = footer_frame.label() } };
                 var fixed_point_ctx = FixedPointTranscriptContext(App){
                     .app = app,
                     .presentation_shell = presentation_shell,
                     .prepare_transcript = !presentation_shell.fullTranscriptActive(),
                     .source = transcript_source,
                     .prepared_transcript = &prepared_transcript,
+                    .resolved_target = &resolved_transcript_target,
                     .footer_reservation_changed = footer_reservation_changed,
                     .replay_displaced_footer_history = replay_displaced_footer_history,
+                    .footer_measurement = if (footer_measurement) |*measurement| measurement else null,
+                    .fallback_footer_rows = if (footer_measurement == null)
+                        footer_frame.paint.footer
+                    else
+                        null,
+                    .activity_projection = target_activity_projection,
+                    .frame_activity = frame_activity,
+                    .base_invalidation = if (footer_measurement != null)
+                        render_engine.paint_plan.FrameInvalidationSet.empty()
+                    else
+                        footer_frame.paint.invalidation,
+                    .attempt_invalidations = attempt_invalidations,
                 };
                 const fixed_point = try render_engine.frame_fixed_point.solve(
                     FixedPointTranscriptContext(App),
@@ -1830,6 +1849,7 @@ pub fn Runtime(comptime App: type) type {
                         .prior = active_committed_layout,
                     },
                     FixedPointTranscriptContext(App).prepareCandidate,
+                    FixedPointTranscriptContext(App).resolveCandidate,
                 );
                 const solved = fixed_point.layout;
                 solved_layout = solved;
@@ -1851,7 +1871,9 @@ pub fn Runtime(comptime App: type) type {
                     measurement.frameLayoutRows(presentation_shell.layout.rows, solved.footer_area.top)
                 else
                     footer_frame.paint.footer;
-                const solved_viewport = if (prepared_transcript) |*prepared|
+                const solved_viewport = if (resolved_transcript_target) |target|
+                    target.selection()
+                else if (prepared_transcript) |*prepared|
                     prepared.selection
                 else if (footer_measurement != null)
                     surface_frame.currentSurfaceFooterTranscriptState(presentation_shell).selection
@@ -1879,7 +1901,13 @@ pub fn Runtime(comptime App: type) type {
                     .transient_row => false,
                     .none, .overlay_entry => true,
                 };
-                const solved_cursor_target = if (prepared_transcript) |*prepared|
+                const solved_cursor_target = if (resolved_transcript_target) |target|
+                    render_engine.paint_plan.FrameCursorTarget{
+                        .row = target.cursorRow(),
+                        .col = target.cursorCol(),
+                        .visible = solved_cursor_visible,
+                    }
+                else if (prepared_transcript) |*prepared|
                     render_engine.paint_plan.FrameCursorTarget{
                         .row = prepared.cursor.cursor_row,
                         .col = prepared.cursor.cursor_col,
@@ -1950,7 +1978,10 @@ pub fn Runtime(comptime App: type) type {
                 try footer_frame.paint.validate();
                 if (prepared_transcript) |*prepared| {
                     try validatePreparedTranscriptFitsPlan(prepared, footer_frame.paint);
-                    planned_scroll_next_start_line = prepared.selection.start_line;
+                    planned_scroll_next_start_line = if (resolved_transcript_target) |target|
+                        target.selection().start_line
+                    else
+                        prepared.selection.start_line;
                 }
                 if (full_transcript_projection) |projection| {
                     const area = footer_frame.paint.transcript_band;
@@ -1978,17 +2009,30 @@ pub fn Runtime(comptime App: type) type {
             if (presentation_commits_transcript) {
                 if (transcript_source) |source| {
                     if (prepared_transcript) |*prepared| {
-                        const layout = solved_layout orelse return error.MissingSolvedFrameLayout;
-                        transcript_transition = try presentation_shell.finalizeTranscriptTransitionForFrame(
-                            app.alloc,
-                            source,
-                            prepared,
-                            render_engine.frame_layout.CommittedLayoutSnapshot.fromLayout(layout),
-                            &footer_frame.paint,
-                            scroll_plan,
-                            footer_reservation_changed,
-                            replay_displaced_footer_history,
-                        );
+                        if (presentation_shell.fullTranscriptActive()) {
+                            if (child_view == null) return error.InvalidFullTranscriptRoute;
+                            const layout = solved_layout orelse return error.MissingSolvedFrameLayout;
+                            transcript_transition = try presentation_shell.finalizeTranscriptTransitionForFrame(
+                                app.alloc,
+                                source,
+                                prepared,
+                                render_engine.frame_layout.CommittedLayoutSnapshot.fromLayout(layout),
+                                &footer_frame.paint,
+                                scroll_plan,
+                                footer_reservation_changed,
+                                replay_displaced_footer_history,
+                            );
+                        } else {
+                            const target = resolved_transcript_target orelse
+                                return error.MissingResolvedTranscriptTarget;
+                            transcript_transition = try presentation_shell.sealTranscriptTransition(
+                                app.alloc,
+                                source,
+                                prepared,
+                                &footer_frame.paint,
+                                target,
+                            );
+                        }
                     }
                 }
             }
@@ -3265,8 +3309,16 @@ fn FixedPointTranscriptContext(comptime App: type) type {
         prepare_transcript: bool,
         source: ?*const transcript_runtime.TranscriptPreparationSource,
         prepared_transcript: *?transcript_painter.PreparedTranscriptSurfacePaint,
+        resolved_target: *?transcript_runtime.TranscriptRuntime.ResolvedTranscriptTarget,
         footer_reservation_changed: bool,
         replay_displaced_footer_history: bool,
+        footer_measurement: ?*const surface_frame.SurfaceFooterMeasurement,
+        fallback_footer_rows: ?render_engine.footer_layout.FooterRows,
+        activity_projection: activity_runtime.ActivityProjection,
+        frame_activity: render_engine.frame_layout.ActivityState,
+        base_invalidation: render_engine.paint_plan.FrameInvalidationSet,
+        attempt_invalidations: render_engine.paint_plan.FrameInvalidationSet,
+        scroll_facts: ?transcript_runtime.TranscriptScrollFacts = null,
 
         fn prepareCandidate(
             self: *@This(),
@@ -3276,10 +3328,10 @@ fn FixedPointTranscriptContext(comptime App: type) type {
                 prepared.deinit(self.app.alloc);
                 self.prepared_transcript.* = null;
             }
-            const candidate_rows = candidate.transcript_area.height();
+            self.resolved_target.* = null;
+            self.scroll_facts = null;
             if (!self.prepare_transcript or candidate.transcript_area.isEmpty()) return .{
                 .inline_advance_rows = 0,
-                .occupied_transcript_rows = candidate_rows,
             };
             const source = self.source orelse return error.MissingTranscriptPreparationSource;
 
@@ -3291,31 +3343,79 @@ fn FixedPointTranscriptContext(comptime App: type) type {
                 self.footer_reservation_changed,
             );
             const prepared = &self.prepared_transcript.*.?;
-            var scroll_facts = self.presentation_shell.planTranscriptScrollForFrame(
+            const scroll_facts = try self.presentation_shell.prepareTranscriptScrollFactsForFrame(
+                self.app.alloc,
+                source,
                 prepared,
                 self.footer_reservation_changed,
                 self.replay_displaced_footer_history,
             );
-            if (try self.presentation_shell.stagePreparedHistoryFloorForFrame(
-                self.app.alloc,
-                prepared,
-                candidate.transcript_area,
-                scroll_facts,
-            )) {
-                scroll_facts = self.presentation_shell.planTranscriptScrollForFrame(
-                    prepared,
-                    self.footer_reservation_changed,
-                    self.replay_displaced_footer_history,
-                );
-            }
-            const occupied_transcript_rows = if (prepared.selection.last_visible_row >= candidate.transcript_area.top)
-                prepared.selection.last_visible_row - candidate.transcript_area.top + 1
-            else
-                0;
+            self.scroll_facts = scroll_facts;
             return .{
                 .inline_advance_rows = scroll_facts.planned_rows,
-                .occupied_transcript_rows = occupied_transcript_rows,
             };
+        }
+
+        fn resolveCandidate(
+            self: *@This(),
+            candidate: render_engine.frame_layout.FrameLayout,
+            scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+        ) !render_engine.frame_fixed_point.CandidateResolution {
+            const candidate_rows = candidate.transcript_area.height();
+            if (!self.prepare_transcript or candidate.transcript_area.isEmpty()) {
+                return .{ .occupied_transcript_rows = candidate_rows };
+            }
+            const source = self.source orelse return error.MissingTranscriptPreparationSource;
+            const prepared = if (self.prepared_transcript.*) |*value| value else return error.MissingTranscriptPaint;
+            const scroll_facts = self.scroll_facts orelse return error.MissingTranscriptScrollFacts;
+            const footer_rows = if (self.footer_measurement) |measurement|
+                measurement.frameLayoutRows(
+                    self.presentation_shell.layout.rows,
+                    candidate.footer_area.top,
+                )
+            else
+                self.fallback_footer_rows orelse return error.MissingFooterRows;
+            const activity = render_engine.activity_placement.resolve(
+                self.activity_projection,
+                self.frame_activity,
+                candidate,
+            );
+            var candidate_plan = candidate.toPaintPlan(.{
+                .footer_rows = footer_rows,
+                .viewport = prepared.selection,
+                .activity = activity,
+                .invalidation = self.base_invalidation,
+                .cursor_target = .{
+                    .row = prepared.cursor.cursor_row,
+                    .col = prepared.cursor.cursor_col,
+                    .visible = true,
+                },
+            });
+            candidate_plan.invalidation = try surface_invalidation.resolveCandidateFrameInvalidations(
+                self.presentation_shell,
+                candidate_plan,
+                if (self.footer_measurement) |measurement|
+                    measurement.frameInvalidationUpdate()
+                else
+                    null,
+                self.attempt_invalidations,
+            );
+            const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
+                self.presentation_shell.committed_frame_layout.transcript_area,
+                candidate_plan.invalidation,
+            );
+            const target = try self.presentation_shell.resolveTranscriptTransitionTargetForFrame(
+                self.app.alloc,
+                source,
+                prepared,
+                render_engine.frame_layout.CommittedLayoutSnapshot.fromLayout(candidate),
+                scroll_plan,
+                scroll_facts,
+                destructive_invalidation,
+                activity == .overlay_entry,
+            );
+            self.resolved_target.* = target;
+            return .{ .occupied_transcript_rows = target.occupiedTranscriptRows() };
         }
     };
 }
@@ -3475,8 +3575,17 @@ const FixedPointTestContext = struct {
         self: *FixedPointTestContext,
         layout: render_engine.frame_layout.FrameLayout,
     ) !render_engine.frame_fixed_point.CandidatePreparation {
+        _ = layout;
+        return .{ .inline_advance_rows = self.inline_advance_rows };
+    }
+
+    fn resolveCandidate(
+        self: *FixedPointTestContext,
+        layout: render_engine.frame_layout.FrameLayout,
+        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+    ) !render_engine.frame_fixed_point.CandidateResolution {
+        _ = scroll_plan;
         return .{
-            .inline_advance_rows = self.inline_advance_rows,
             .occupied_transcript_rows = self.prepared_occupied_rows orelse layout.transcript_area.height(),
         };
     }
@@ -3519,6 +3628,7 @@ fn solveFixedPointForTest(
         ctx,
         input,
         FixedPointTestContext.prepareCandidate,
+        FixedPointTestContext.resolveCandidate,
     );
 }
 

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -3332,6 +3332,7 @@ fn FixedPointTranscriptContext(comptime App: type) type {
             self.scroll_facts = null;
             if (!self.prepare_transcript or candidate.transcript_area.isEmpty()) return .{
                 .inline_advance_rows = 0,
+                .occupied_transcript_rows = candidate.transcript_area.height(),
             };
             const source = self.source orelse return error.MissingTranscriptPreparationSource;
 
@@ -3351,8 +3352,13 @@ fn FixedPointTranscriptContext(comptime App: type) type {
                 self.replay_displaced_footer_history,
             );
             self.scroll_facts = scroll_facts;
+            const occupied_transcript_rows = if (prepared.selection.last_visible_row >= candidate.transcript_area.top)
+                prepared.selection.last_visible_row - candidate.transcript_area.top + 1
+            else
+                0;
             return .{
                 .inline_advance_rows = scroll_facts.planned_rows,
+                .occupied_transcript_rows = occupied_transcript_rows,
             };
         }
 
@@ -3575,8 +3581,10 @@ const FixedPointTestContext = struct {
         self: *FixedPointTestContext,
         layout: render_engine.frame_layout.FrameLayout,
     ) !render_engine.frame_fixed_point.CandidatePreparation {
-        _ = layout;
-        return .{ .inline_advance_rows = self.inline_advance_rows };
+        return .{
+            .inline_advance_rows = self.inline_advance_rows,
+            .occupied_transcript_rows = layout.transcript_area.height(),
+        };
     }
 
     fn resolveCandidate(

--- a/src/main.zig
+++ b/src/main.zig
@@ -3835,6 +3835,7 @@ test {
     _ = @import("ui/footer/approval_ui.zig");
     _ = @import("ui/footer/surface_invalidation.zig");
     _ = @import("ui/full_transcript_screen.zig");
+    _ = @import("ui/render_engine/frame_fixed_point.zig");
     _ = @import("ui/transcript/runtime.zig");
     _ = @import("ui/transcript/runtime_tests.zig");
     _ = @import("core/agent/worker_runtime.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -3831,6 +3831,7 @@ test {
     _ = @import("ui/input/visual_layout.zig");
     _ = @import("ui/input/runtime.zig");
     _ = @import("ui/approval_screen.zig");
+    _ = @import("ui/ask_presentation.zig");
     _ = @import("ui/footer/approval_ui.zig");
     _ = @import("ui/footer/surface_invalidation.zig");
     _ = @import("ui/full_transcript_screen.zig");

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -324,6 +324,7 @@ const SolveContext = struct {
         self.scroll_facts = null;
         if (candidate.transcript_area.isEmpty()) return .{
             .inline_advance_rows = 0,
+            .occupied_transcript_rows = 0,
         };
         self.prepared.* = try self.runtime.shell.prepareTranscriptSurfacePaintFromSourceForArea(
             self.runtime.alloc,
@@ -340,8 +341,13 @@ const SolveContext = struct {
             false,
         );
         self.scroll_facts = scroll_facts;
+        const occupied_transcript_rows = if (paint.selection.last_visible_row >= candidate.transcript_area.top)
+            paint.selection.last_visible_row - candidate.transcript_area.top + 1
+        else
+            0;
         return .{
             .inline_advance_rows = scroll_facts.planned_rows,
+            .occupied_transcript_rows = occupied_transcript_rows,
         };
     }
 

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -213,11 +213,16 @@ pub const Runtime = struct {
         defer source.deinit(self.alloc);
         var prepared: ?transcript_painter.PreparedTranscriptSurfacePaint = null;
         defer if (prepared) |*paint| paint.deinit(self.alloc);
+        var resolved_target: ?transcript_runtime.TranscriptRuntime.ResolvedTranscriptTarget = null;
+        var invalidations = attempt.snapshot.invalidations;
+        self.shell.normalizeFrameInvalidations(&invalidations);
 
         var solve_context = SolveContext{
             .runtime = self,
             .source = &source,
             .prepared = &prepared,
+            .resolved_target = &resolved_target,
+            .invalidations = invalidations,
         };
         const fixed = try render_engine.frame_fixed_point.solve(
             SolveContext,
@@ -230,31 +235,30 @@ pub const Runtime = struct {
                 .prior = self.shell.committed_frame_layout,
             },
             SolveContext.prepareCandidate,
+            SolveContext.resolveCandidate,
         );
         const paint = if (prepared) |*value| value else return error.MissingTranscriptPaint;
+        const target = resolved_target orelse return error.MissingResolvedTranscriptTarget;
 
-        var invalidations = attempt.snapshot.invalidations;
-        self.shell.normalizeFrameInvalidations(&invalidations);
         var plan = fixed.layout.toPaintPlan(.{
             .footer_rows = zeroFooterRows(self.shell.layout.rows),
-            .viewport = paint.selection,
+            .viewport = target.selection(),
             .invalidation = invalidations,
             .synchronized_update = self.shell.sync_updates_enabled,
             .cursor_target = .{
-                .row = paint.cursor.cursor_row,
-                .col = paint.cursor.cursor_col,
+                .row = target.cursorRow(),
+                .col = target.cursorCol(),
                 .visible = true,
             },
             .preserve_scrollback = !self.shell.pending_scroll_compact,
             .reset_terminal = self.shell.terminal_reset_pending,
         });
-        var transition = try self.shell.finalizeTranscriptTransition(
+        var transition = try self.shell.sealTranscriptTransition(
             self.alloc,
             &source,
             paint,
-            render_engine.frame_layout.CommittedLayoutSnapshot.fromLayout(fixed.layout),
             &plan,
-            fixed.scroll_plan,
+            target,
         );
         defer transition.deinit(self.alloc);
         var paint_context = PaintContext{ .runtime = self, .prepared = paint };
@@ -302,8 +306,11 @@ pub const Runtime = struct {
 
 const SolveContext = struct {
     runtime: *Runtime,
-    source: *const transcript_runtime.TranscriptPreparationSource,
+    source: *transcript_runtime.TranscriptPreparationSource,
     prepared: *?transcript_painter.PreparedTranscriptSurfacePaint,
+    resolved_target: *?transcript_runtime.TranscriptRuntime.ResolvedTranscriptTarget,
+    invalidations: render_engine.paint_plan.FrameInvalidationSet,
+    scroll_facts: ?transcript_runtime.TranscriptScrollFacts = null,
 
     fn prepareCandidate(
         self: *SolveContext,
@@ -313,9 +320,10 @@ const SolveContext = struct {
             paint.deinit(self.runtime.alloc);
             self.prepared.* = null;
         }
+        self.resolved_target.* = null;
+        self.scroll_facts = null;
         if (candidate.transcript_area.isEmpty()) return .{
             .inline_advance_rows = 0,
-            .occupied_transcript_rows = 0,
         };
         self.prepared.* = try self.runtime.shell.prepareTranscriptSurfacePaintFromSourceForArea(
             self.runtime.alloc,
@@ -324,14 +332,44 @@ const SolveContext = struct {
             candidate.transcript_area,
         );
         const paint = &self.prepared.*.?;
-        const occupied_rows = if (paint.selection.last_visible_row >= candidate.transcript_area.top)
-            paint.selection.last_visible_row - candidate.transcript_area.top + 1
-        else
-            0;
+        const scroll_facts = try self.runtime.shell.prepareTranscriptScrollFactsForFrame(
+            self.runtime.alloc,
+            self.source,
+            paint,
+            false,
+            false,
+        );
+        self.scroll_facts = scroll_facts;
         return .{
-            .inline_advance_rows = self.runtime.shell.planTranscriptScroll(paint).planned_rows,
-            .occupied_transcript_rows = occupied_rows,
+            .inline_advance_rows = scroll_facts.planned_rows,
         };
+    }
+
+    fn resolveCandidate(
+        self: *SolveContext,
+        candidate: render_engine.frame_layout.FrameLayout,
+        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+    ) !render_engine.frame_fixed_point.CandidateResolution {
+        if (candidate.transcript_area.isEmpty()) return .{ .occupied_transcript_rows = 0 };
+        const paint = if (self.prepared.*) |*value| value else return error.MissingTranscriptPaint;
+        const scroll_facts = self.scroll_facts orelse return error.MissingTranscriptScrollFacts;
+        const target_layout = render_engine.frame_layout.CommittedLayoutSnapshot.fromLayout(candidate);
+        const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
+            self.runtime.shell.committed_frame_layout.transcript_area,
+            self.invalidations,
+        );
+        const target = try self.runtime.shell.resolveTranscriptTransitionTargetForFrame(
+            self.runtime.alloc,
+            self.source,
+            paint,
+            target_layout,
+            scroll_plan,
+            scroll_facts,
+            destructive_invalidation,
+            false,
+        );
+        self.resolved_target.* = target;
+        return .{ .occupied_transcript_rows = target.occupiedTranscriptRows() };
     }
 };
 
@@ -445,6 +483,17 @@ test "ask presentation paints Minimal prompt and assistant into a footerless fra
     );
     try std.testing.expect(runtime.shell.entries.items[1] == .user_turn);
     try std.testing.expect(runtime.shell.committed_frame_layout.footer_area.isEmpty());
+    try std.testing.expectEqual(
+        transcript_runtime.TranscriptCommitDiagnosticState.stable,
+        runtime.shell.transcriptCommitDiagnostic().state,
+    );
+    const committed = runtime.shell.stableTranscriptProjectionForFlow(
+        runtime.shell.transcript.items,
+    ) orelse return error.TestExpectedStableTranscript;
+    try std.testing.expect(
+        committed.selection.last_visible_row <=
+            runtime.shell.committed_frame_layout.transcript_area.bottom,
+    );
     try std.testing.expect(runtime.shell.shadow_vt.?.cellAt(1, 1) != null);
     const length = try output.length(io_mod.getIo());
     try std.testing.expect(length > restore_terminal_sequence.len);

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -738,6 +738,17 @@ pub const SurfaceFooterMeasurement = struct {
         return measured_rows > committed_rows;
     }
 
+    pub fn frameInvalidationUpdate(self: *const SurfaceFooterMeasurement) surface_invalidation.FooterExtraUpdate {
+        return .{
+            .footer_extra = self.footer_extra,
+            .footer_reserved_base_rows = self.footerReservedBaseRows(),
+            .input_extra = self.input_extra,
+            .banner_active = self.banner_active,
+            .picker_rows = self.picker_rows,
+            .show_picker = self.show_picker,
+        };
+    }
+
     pub noinline fn footerReservedBaseRows(self: *const SurfaceFooterMeasurement) u16 {
         return footer_layout.reservedBaseRows(self.input_visible, self.composer_top_chrome_rows);
     }
@@ -990,14 +1001,12 @@ pub noinline fn prepareMeasuredSurfaceFooterFrameForPlan(
 ) !SurfaceFooterFrame {
     var paint = plan;
     const footer_reservation_changed = measurement.changesFooterReservation(shell);
-    try surface_invalidation.appendMeasuredFooterExtraInvalidation(shell, &paint, force_redraw, .{
-        .footer_extra = measurement.footer_extra,
-        .footer_reserved_base_rows = measurement.footerReservedBaseRows(),
-        .input_extra = measurement.input_extra,
-        .banner_active = measurement.banner_active,
-        .picker_rows = measurement.picker_rows,
-        .show_picker = measurement.show_picker,
-    });
+    try surface_invalidation.appendMeasuredFooterExtraInvalidation(
+        shell,
+        &paint,
+        force_redraw,
+        measurement.frameInvalidationUpdate(),
+    );
     surface_invalidation.mergeAttemptInvalidations(attempt_invalidations, &paint);
     if (footer_reservation_changed) paint.footer_clean_allowed = false;
     try paint.validate();

--- a/src/ui/footer/surface_invalidation.zig
+++ b/src/ui/footer/surface_invalidation.zig
@@ -112,17 +112,20 @@ fn appendVisibleFooterInvalidation(
     reason: paint_plan.FrameInvalidationReason,
     top: u16,
     rows: u16,
+    trace_skips: bool,
 ) GeometryError!void {
     const range = try visibleFooterInvalidation(reason, top, rows) orelse {
-        logSkippedFooterInvalidation(reason, top, rows);
+        if (trace_skips) logSkippedFooterInvalidation(reason, top, rows);
         return;
     };
     if (reason == .external_clear and !paint_plan.invalidationIntersectsOwnedBand(plan.*, range)) {
-        debug_trace.logf(
-            "frame_plan",
-            "footer_extra_invalidation_skip reason={s} top={d} rows={d} skip=outside_current_owned_bands",
-            .{ @tagName(reason), top, rows },
-        );
+        if (trace_skips) {
+            debug_trace.logf(
+                "frame_plan",
+                "footer_extra_invalidation_skip reason={s} top={d} rows={d} skip=outside_current_owned_bands",
+                .{ @tagName(reason), top, rows },
+            );
+        }
         return;
     }
     footer_paint_plan.appendFooterFrameInvalidation(&plan.invalidation, range);
@@ -154,6 +157,7 @@ pub fn appendMeasuredFooterExtraInvalidation(
         footerExtraInvalidationReason(shell, change.update),
         change.top,
         shell.layout.rows,
+        true,
     );
     plan.footer_clean_allowed = false;
     force_redraw.* = true;
@@ -207,6 +211,30 @@ pub fn mergeAttemptInvalidations(invalidations: FrameInvalidationSet, plan: *Pai
         }
     }
     plan.footer_clean_allowed = plan.invalidation.isEmpty();
+}
+
+pub fn resolveCandidateFrameInvalidations(
+    shell: *const TranscriptRuntime,
+    plan: PaintPlan,
+    footer_update: ?FooterExtraUpdate,
+    attempt_invalidations: FrameInvalidationSet,
+) GeometryError!FrameInvalidationSet {
+    var candidate = plan;
+    if (footer_update) |update| {
+        if (detectFooterExtraChange(shell, update)) |change| {
+            try appendVisibleFooterInvalidation(
+                &candidate,
+                footerExtraInvalidationReason(shell, change.update),
+                change.top,
+                shell.layout.rows,
+                false,
+            );
+        }
+    }
+    for (attempt_invalidations.ranges()) |range| {
+        _ = mergeAttemptInvalidation(&candidate.invalidation, range);
+    }
+    return candidate.invalidation;
 }
 
 fn mergeAttemptInvalidation(
@@ -317,12 +345,12 @@ test "visible footer invalidation skips only stale off-screen footer rows" {
 
 test "footer invalidation wrappers skip stale rows and record visible ranges" {
     var plan = surfaceTestPlan();
-    try appendVisibleFooterInvalidation(&plan, .reserved_gap_clear, 9, 6);
+    try appendVisibleFooterInvalidation(&plan, .reserved_gap_clear, 9, 6, true);
     try std.testing.expect(plan.invalidation.isEmpty());
 
-    try appendVisibleFooterInvalidation(&plan, .reserved_gap_clear, 5, 6);
+    try appendVisibleFooterInvalidation(&plan, .reserved_gap_clear, 5, 6, true);
     try std.testing.expect(surfaceHasInvalidation(plan.invalidation, .reserved_gap_clear, 5, 6));
-    try std.testing.expectError(error.InvalidFooterInvalidationGeometry, appendVisibleFooterInvalidation(&plan, .reserved_gap_clear, 0, 6));
+    try std.testing.expectError(error.InvalidFooterInvalidationGeometry, appendVisibleFooterInvalidation(&plan, .reserved_gap_clear, 0, 6, true));
 
     var shell = TranscriptRuntime{};
     defer shell.deinit(std.testing.allocator);
@@ -371,7 +399,7 @@ test "footer clear below a compact frame defers to owned band invalidation" {
     plan.cursor_target = .{ .row = 3, .col = 1, .visible = true };
     try plan.validate();
 
-    try appendVisibleFooterInvalidation(&plan, .external_clear, 6, plan.layout.rows);
+    try appendVisibleFooterInvalidation(&plan, .external_clear, 6, plan.layout.rows, true);
 
     try std.testing.expect(plan.invalidation.isEmpty());
     try plan.validate();
@@ -477,7 +505,7 @@ test "reserved gap invalidation collapses instead of dropping when the plan is f
         });
     }
 
-    try appendVisibleFooterInvalidation(&plan, .reserved_gap_clear, 1, 8);
+    try appendVisibleFooterInvalidation(&plan, .reserved_gap_clear, 1, 8, true);
 
     try plan.validate();
     try std.testing.expectEqual(@as(u8, 1), plan.invalidation.len);
@@ -566,6 +594,55 @@ test "footer picker collapse destructively clears the previous footer band" {
     try std.testing.expectEqual(paint_plan.FrameInvalidationReason.external_clear, invalidation.reason);
     try std.testing.expectEqual(@as(u16, 12), invalidation.top);
     try std.testing.expectEqual(@as(u16, 24), invalidation.bottom);
+}
+
+test "candidate invalidations match final footer invalidations" {
+    var shell = TranscriptRuntime{
+        .layout = surfaceTestPlan().layout,
+        .extra_input_rows = 3,
+        .footer_reserved_base_rows = 2,
+    };
+    defer shell.deinit(std.testing.allocator);
+    shell.footer_viewport.has_frame = true;
+    shell.footer_viewport.geometry.top = 5;
+
+    const update: FooterExtraUpdate = .{
+        .footer_extra = 0,
+        .footer_reserved_base_rows = 2,
+        .input_extra = 0,
+        .banner_active = false,
+        .picker_rows = 0,
+        .show_picker = false,
+    };
+    var attempt = FrameInvalidationSet.empty();
+    try attempt.append(.{
+        .reason = .owned_band_change,
+        .top = 2,
+        .bottom = 4,
+    });
+
+    const candidate = try resolveCandidateFrameInvalidations(
+        &shell,
+        surfaceTestPlan(),
+        update,
+        attempt,
+    );
+
+    var final_plan = surfaceTestPlan();
+    var force_redraw = false;
+    try appendMeasuredFooterExtraInvalidation(
+        &shell,
+        &final_plan,
+        &force_redraw,
+        update,
+    );
+    mergeAttemptInvalidations(attempt, &final_plan);
+
+    try std.testing.expectEqualSlices(
+        paint_plan.FrameInvalidationRange,
+        candidate.ranges(),
+        final_plan.invalidation.ranges(),
+    );
 }
 
 test "measured footer picker collapse destructively clears the previous footer band" {

--- a/src/ui/render_engine/frame_fixed_point.zig
+++ b/src/ui/render_engine/frame_fixed_point.zig
@@ -5,6 +5,7 @@ const frame_scroll_plan = @import("frame_scroll_plan.zig");
 
 pub const CandidatePreparation = struct {
     inline_advance_rows: u16,
+    occupied_transcript_rows: u16,
 };
 
 pub const CandidateResolution = struct {
@@ -53,7 +54,12 @@ pub fn solve(
             layout_release.released_rows,
             preparation.inline_advance_rows,
         );
-        const resolution = try resolve_candidate(ctx, candidate, scroll_plan);
+        const prepared_projection_is_shorter = preparation.occupied_transcript_rows > 0 and
+            preparation.occupied_transcript_rows < candidate.transcript_area.height();
+        const resolution = if (prepared_projection_is_shorter)
+            CandidateResolution{ .occupied_transcript_rows = preparation.occupied_transcript_rows }
+        else
+            try resolve_candidate(ctx, candidate, scroll_plan);
         debug_trace.logf(
             "frame_layout",
             "fixed_point iteration={d} requested_release={d} requested_inline={d} emitted_scroll={d} remaining_inline={d} prior_owned_top={d} post_scroll_owned_top={d}",
@@ -90,6 +96,7 @@ pub fn solve(
 const FixedPointTestContext = struct {
     inline_advance_rows: u16 = 0,
     prepared_occupied_rows: ?u16 = null,
+    resolved_occupied_rows: ?u16 = null,
     candidate_tops: [8]u16 = [_]u16{0} ** 8,
     candidate_transcript_rows: [8]u16 = [_]u16{0} ** 8,
     resolved_inline_rows: [8]u32 = [_]u32{0} ** 8,
@@ -105,6 +112,7 @@ const FixedPointTestContext = struct {
         self.calls += 1;
         return .{
             .inline_advance_rows = self.inline_advance_rows,
+            .occupied_transcript_rows = self.prepared_occupied_rows orelse layout.transcript_area.height(),
         };
     }
 
@@ -116,7 +124,7 @@ const FixedPointTestContext = struct {
         self.resolved_inline_rows[self.resolution_calls] = scroll_plan.requested_inline_advance_rows;
         self.resolution_calls += 1;
         return .{
-            .occupied_transcript_rows = self.prepared_occupied_rows orelse layout.transcript_area.height(),
+            .occupied_transcript_rows = self.resolved_occupied_rows orelse layout.transcript_area.height(),
         };
     }
 };
@@ -197,7 +205,7 @@ test "frame fixed point compacts a same-owner prepared projection" {
 test "frame fixed point resolves final extent after merging scroll plan" {
     var ctx = FixedPointTestContext{
         .inline_advance_rows = 3,
-        .prepared_occupied_rows = 9,
+        .resolved_occupied_rows = 9,
     };
     const fixed_point = try solveFixedPointForTest(
         &ctx,
@@ -212,6 +220,19 @@ test "frame fixed point resolves final extent after merging scroll plan" {
         ctx.resolved_inline_rows[0..ctx.resolution_calls],
     );
     try std.testing.expectEqual(@as(u16, 9), fixed_point.layout.transcript_area.height());
+}
+
+test "frame fixed point compacts prepared extent before target resolution" {
+    var ctx = FixedPointTestContext{ .prepared_occupied_rows = 9 };
+    const fixed_point = try solveFixedPointForTest(
+        &ctx,
+        fixedPointTestInput(20, 1, 15, 4, .transcript),
+    );
+
+    try std.testing.expectEqual(@as(usize, 2), fixed_point.iterations);
+    try std.testing.expectEqual(@as(usize, 2), ctx.calls);
+    try std.testing.expectEqual(@as(usize, 1), ctx.resolution_calls);
+    try std.testing.expectEqualSlices(u16, &.{ 15, 9 }, ctx.candidate_transcript_rows[0..ctx.calls]);
 }
 
 test "frame fixed point permits document movement beyond terminal height" {

--- a/src/ui/render_engine/frame_fixed_point.zig
+++ b/src/ui/render_engine/frame_fixed_point.zig
@@ -5,6 +5,9 @@ const frame_scroll_plan = @import("frame_scroll_plan.zig");
 
 pub const CandidatePreparation = struct {
     inline_advance_rows: u16,
+};
+
+pub const CandidateResolution = struct {
     occupied_transcript_rows: u16,
 };
 
@@ -19,6 +22,7 @@ pub fn solve(
     ctx: *Context,
     input: frame_layout.SolveInput,
     prepare_candidate: *const fn (*Context, frame_layout.FrameLayout) anyerror!CandidatePreparation,
+    resolve_candidate: *const fn (*Context, frame_layout.FrameLayout, frame_scroll_plan.FrameScrollPlan) anyerror!CandidateResolution,
 ) !FramePlan {
     var release_floor_rows: u16 = 0;
     var candidate_input = input;
@@ -49,6 +53,7 @@ pub fn solve(
             layout_release.released_rows,
             preparation.inline_advance_rows,
         );
+        const resolution = try resolve_candidate(ctx, candidate, scroll_plan);
         debug_trace.logf(
             "frame_layout",
             "fixed_point iteration={d} requested_release={d} requested_inline={d} emitted_scroll={d} remaining_inline={d} prior_owned_top={d} post_scroll_owned_top={d}",
@@ -62,8 +67,8 @@ pub fn solve(
                 scroll_plan.post_scroll_owned_top,
             },
         );
-        const projection_is_shorter = preparation.occupied_transcript_rows > 0 and
-            preparation.occupied_transcript_rows < candidate.transcript_area.height();
+        const projection_is_shorter = resolution.occupied_transcript_rows > 0 and
+            resolution.occupied_transcript_rows < candidate.transcript_area.height();
         if (candidate.owned_top == scroll_plan.post_scroll_owned_top and !projection_is_shorter) {
             return .{
                 .layout = candidate,
@@ -76,7 +81,7 @@ pub fn solve(
             .effective_transcript_rows = candidate_input.transcript.natural_visual_rows,
         };
         if (projection_is_shorter) {
-            candidate_input.transcript.natural_visual_rows = preparation.occupied_transcript_rows;
+            candidate_input.transcript.natural_visual_rows = resolution.occupied_transcript_rows;
         }
         release_floor_rows = scroll_plan.preserved_release_rows;
     }
@@ -87,7 +92,9 @@ const FixedPointTestContext = struct {
     prepared_occupied_rows: ?u16 = null,
     candidate_tops: [8]u16 = [_]u16{0} ** 8,
     candidate_transcript_rows: [8]u16 = [_]u16{0} ** 8,
+    resolved_inline_rows: [8]u32 = [_]u32{0} ** 8,
     calls: usize = 0,
+    resolution_calls: usize = 0,
 
     fn prepareCandidate(
         self: *FixedPointTestContext,
@@ -98,6 +105,17 @@ const FixedPointTestContext = struct {
         self.calls += 1;
         return .{
             .inline_advance_rows = self.inline_advance_rows,
+        };
+    }
+
+    fn resolveCandidate(
+        self: *FixedPointTestContext,
+        layout: frame_layout.FrameLayout,
+        scroll_plan: frame_scroll_plan.FrameScrollPlan,
+    ) !CandidateResolution {
+        self.resolved_inline_rows[self.resolution_calls] = scroll_plan.requested_inline_advance_rows;
+        self.resolution_calls += 1;
+        return .{
             .occupied_transcript_rows = self.prepared_occupied_rows orelse layout.transcript_area.height(),
         };
     }
@@ -140,6 +158,7 @@ fn solveFixedPointForTest(
         ctx,
         input,
         FixedPointTestContext.prepareCandidate,
+        FixedPointTestContext.resolveCandidate,
     );
 }
 
@@ -173,6 +192,26 @@ test "frame fixed point compacts a same-owner prepared projection" {
     try std.testing.expectEqual(frame_layout.FrameRect{ .top = 1, .bottom = 9 }, fixed_point.layout.transcript_area);
     try std.testing.expectEqual(@as(u16, 10), fixed_point.layout.footer_area.top);
     try std.testing.expectEqual(@as(u16, 0), fixed_point.scroll_plan.requested_inline_advance_rows);
+}
+
+test "frame fixed point resolves final extent after merging scroll plan" {
+    var ctx = FixedPointTestContext{
+        .inline_advance_rows = 3,
+        .prepared_occupied_rows = 9,
+    };
+    const fixed_point = try solveFixedPointForTest(
+        &ctx,
+        fixedPointTestInput(20, 1, 15, 4, .transcript),
+    );
+
+    try std.testing.expectEqual(@as(usize, 2), fixed_point.iterations);
+    try std.testing.expectEqual(ctx.calls, ctx.resolution_calls);
+    try std.testing.expectEqualSlices(
+        u32,
+        &.{ 3, 3 },
+        ctx.resolved_inline_rows[0..ctx.resolution_calls],
+    );
+    try std.testing.expectEqual(@as(u16, 9), fixed_point.layout.transcript_area.height());
 }
 
 test "frame fixed point permits document movement beyond terminal height" {

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -14,6 +14,7 @@ const assistant_presentation = @import("../core/agent/assistant_presentation.zig
 const builtin_commands = @import("../builtins/commands.zig");
 
 const surface_frame = @import("footer/surface_frame.zig");
+const surface_invalidation = @import("footer/surface_invalidation.zig");
 const interaction_state = @import("footer/interaction_state.zig");
 const approval_prompt = @import("../core/permissions/approval_prompt.zig");
 const render_input = @import("footer/render_input.zig");
@@ -212,17 +213,18 @@ pub const Harness = struct {
                 .prior = self.shell.committed_frame_layout,
             },
             ReservedTranscriptSolveContext.prepareCandidate,
+            ReservedTranscriptSolveContext.resolveCandidate,
         );
 
         var invalidations = snapshot.invalidations;
         self.shell.normalizeFrameInvalidations(&invalidations);
         const paint = &prepared.?;
         var plan = transcriptOnlyPlan(&self.shell, paint, fixed_point.layout.owned_top, invalidations);
-        var transition = try self.shell.finalizeTranscriptTransition(
+        var transition = try resolveAndSealTranscriptTransitionForTest(
+            &self.shell,
             self.alloc,
             &source,
             paint,
-            render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan),
             &plan,
             fixed_point.scroll_plan,
         );
@@ -267,6 +269,7 @@ pub const Harness = struct {
             measurement.replaysDisplacedTranscriptHistory(&self.shell);
         var prepared: ?transcript_painter.PreparedTranscriptSurfacePaint = null;
         defer if (prepared) |*paint| paint.deinit(self.alloc);
+        var resolved_target: ?transcript_runtime.TranscriptRuntime.ResolvedTranscriptTarget = null;
         const activity = frameActivityState(self, &measurement);
         const tracked_entry_id = switch (measurement.activity_projection) {
             .tool_slot => |slot| slot.entry_id,
@@ -289,8 +292,10 @@ pub const Harness = struct {
             activity,
             &source,
             &prepared,
+            &resolved_target,
             footer_reservation_changed,
             replay_displaced_footer_history,
+            invalidations,
         );
 
         const footer_rows = measurement.frameLayoutRows(self.shell.layout.rows, fixed_point.layout.footer_area.top);
@@ -303,11 +308,19 @@ pub const Harness = struct {
             .transient_row => true,
             .none, .overlay_entry => false,
         };
-        const viewport = if (prepared) |*paint|
+        const viewport = if (resolved_target) |target|
+            target.selection()
+        else if (prepared) |*paint|
             paint.selection
         else
             surface_frame.currentSurfaceFooterTranscriptState(&self.shell).selection;
-        const cursor_target = if (prepared) |*paint|
+        const cursor_target = if (resolved_target) |target|
+            render_engine.paint_plan.FrameCursorTarget{
+                .row = target.cursorRow(),
+                .col = target.cursorCol(),
+                .visible = !activity_hides_cursor,
+            }
+        else if (prepared) |*paint|
             render_engine.paint_plan.FrameCursorTarget{
                 .row = paint.cursor.cursor_row,
                 .col = paint.cursor.cursor_col,
@@ -341,15 +354,13 @@ pub const Harness = struct {
         var transition: ?transcript_runtime.TranscriptTransition = null;
         defer if (transition) |*value| value.deinit(self.alloc);
         if (prepared) |*paint| {
-            transition = try self.shell.finalizeTranscriptTransitionForFrame(
+            const target = resolved_target orelse return error.MissingResolvedTranscriptTarget;
+            transition = try self.shell.sealTranscriptTransition(
                 self.alloc,
                 &source,
                 paint,
-                render_engine.frame_layout.CommittedLayoutSnapshot.fromLayout(fixed_point.layout),
                 &footer_frame.paint,
-                fixed_point.scroll_plan,
-                footer_reservation_changed,
-                replay_displaced_footer_history,
+                target,
             );
         }
 
@@ -433,8 +444,17 @@ const ReservedTranscriptSolveContext = struct {
         self.prepared.*.?.bottom_reserved_rows = self.reserved_rows;
         return .{
             .inline_advance_rows = self.h.shell.planTranscriptScroll(&self.prepared.*.?).planned_rows,
-            .occupied_transcript_rows = candidate.transcript_area.height(),
         };
+    }
+
+    fn resolveCandidate(
+        self: *ReservedTranscriptSolveContext,
+        candidate: render_engine.frame_layout.FrameLayout,
+        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+    ) !render_engine.frame_fixed_point.CandidateResolution {
+        _ = self;
+        _ = scroll_plan;
+        return .{ .occupied_transcript_rows = candidate.transcript_area.height() };
     }
 };
 
@@ -444,15 +464,21 @@ fn solveTestFrame(
     activity: render_engine.frame_layout.ActivityState,
     source: *const TranscriptPreparationSource,
     prepared: *?transcript_painter.PreparedTranscriptSurfacePaint,
+    resolved_target: *?transcript_runtime.TranscriptRuntime.ResolvedTranscriptTarget,
     footer_reservation_changed: bool,
     replay_displaced_footer_history: bool,
+    attempt_invalidations: render_engine.paint_plan.FrameInvalidationSet,
 ) !render_engine.frame_fixed_point.FramePlan {
     var ctx = TestFrameSolveContext{
         .h = h,
         .source = source,
         .prepared = prepared,
+        .resolved_target = resolved_target,
+        .measurement = measurement,
+        .activity = activity,
         .footer_reservation_changed = footer_reservation_changed,
         .replay_displaced_footer_history = replay_displaced_footer_history,
+        .attempt_invalidations = attempt_invalidations,
     };
     return render_engine.frame_fixed_point.solve(
         TestFrameSolveContext,
@@ -466,6 +492,7 @@ fn solveTestFrame(
             .prior = h.shell.committed_frame_layout,
         },
         TestFrameSolveContext.prepareCandidate,
+        TestFrameSolveContext.resolveCandidate,
     );
 }
 
@@ -473,8 +500,13 @@ const TestFrameSolveContext = struct {
     h: *Harness,
     source: *const TranscriptPreparationSource,
     prepared: *?transcript_painter.PreparedTranscriptSurfacePaint,
+    resolved_target: *?transcript_runtime.TranscriptRuntime.ResolvedTranscriptTarget,
+    measurement: *const surface_frame.SurfaceFooterMeasurement,
+    activity: render_engine.frame_layout.ActivityState,
     footer_reservation_changed: bool,
     replay_displaced_footer_history: bool,
+    attempt_invalidations: render_engine.paint_plan.FrameInvalidationSet,
+    scroll_facts: ?transcript_runtime.TranscriptScrollFacts = null,
 
     fn prepareCandidate(
         self: *TestFrameSolveContext,
@@ -484,8 +516,9 @@ const TestFrameSolveContext = struct {
             paint.deinit(self.h.alloc);
             self.prepared.* = null;
         }
+        self.resolved_target.* = null;
+        self.scroll_facts = null;
         var inline_advance_rows: u16 = 0;
-        var occupied_transcript_rows = candidate.transcript_area.height();
         if (!candidate.transcript_area.isEmpty()) {
             self.prepared.* = try self.h.shell.prepareTranscriptSurfacePaintFromSourceForFrame(
                 self.h.alloc,
@@ -494,34 +527,69 @@ const TestFrameSolveContext = struct {
                 candidate.transcript_area,
                 self.footer_reservation_changed,
             );
-            var scroll_facts = self.h.shell.planTranscriptScrollForFrame(
+            const scroll_facts = try self.h.shell.prepareTranscriptScrollFactsForFrame(
+                self.h.alloc,
+                self.source,
                 &self.prepared.*.?,
                 self.footer_reservation_changed,
                 self.replay_displaced_footer_history,
             );
-            if (try self.h.shell.stagePreparedHistoryFloorForFrame(
-                self.h.alloc,
-                &self.prepared.*.?,
-                candidate.transcript_area,
-                scroll_facts,
-            )) {
-                scroll_facts = self.h.shell.planTranscriptScrollForFrame(
-                    &self.prepared.*.?,
-                    self.footer_reservation_changed,
-                    self.replay_displaced_footer_history,
-                );
-            }
+            self.scroll_facts = scroll_facts;
             inline_advance_rows = scroll_facts.planned_rows;
-            if (self.prepared.*.?.selection.last_visible_row >= candidate.transcript_area.top) {
-                occupied_transcript_rows = self.prepared.*.?.selection.last_visible_row - candidate.transcript_area.top + 1;
-            } else {
-                occupied_transcript_rows = 0;
-            }
         }
-        return .{
-            .inline_advance_rows = inline_advance_rows,
-            .occupied_transcript_rows = occupied_transcript_rows,
-        };
+        return .{ .inline_advance_rows = inline_advance_rows };
+    }
+
+    fn resolveCandidate(
+        self: *TestFrameSolveContext,
+        candidate: render_engine.frame_layout.FrameLayout,
+        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+    ) !render_engine.frame_fixed_point.CandidateResolution {
+        if (candidate.transcript_area.isEmpty()) {
+            return .{ .occupied_transcript_rows = 0 };
+        }
+        const prepared = if (self.prepared.*) |*value| value else return error.MissingTranscriptPaint;
+        const scroll_facts = self.scroll_facts orelse return error.MissingTranscriptScrollFacts;
+        const activity = render_engine.activity_placement.resolve(
+            self.measurement.activity_projection,
+            self.activity,
+            candidate,
+        );
+        var candidate_plan = candidate.toPaintPlan(.{
+            .footer_rows = self.measurement.frameLayoutRows(
+                self.h.shell.layout.rows,
+                candidate.footer_area.top,
+            ),
+            .viewport = prepared.selection,
+            .activity = activity,
+            .cursor_target = .{
+                .row = prepared.cursor.cursor_row,
+                .col = prepared.cursor.cursor_col,
+                .visible = true,
+            },
+        });
+        candidate_plan.invalidation = try surface_invalidation.resolveCandidateFrameInvalidations(
+            &self.h.shell,
+            candidate_plan,
+            self.measurement.frameInvalidationUpdate(),
+            self.attempt_invalidations,
+        );
+        const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
+            self.h.shell.committed_frame_layout.transcript_area,
+            candidate_plan.invalidation,
+        );
+        const target = try self.h.shell.resolveTranscriptTransitionTargetForFrame(
+            self.h.alloc,
+            self.source,
+            prepared,
+            render_engine.frame_layout.CommittedLayoutSnapshot.fromLayout(candidate),
+            scroll_plan,
+            scroll_facts,
+            destructive_invalidation,
+            activity == .overlay_entry,
+        );
+        self.resolved_target.* = target;
+        return .{ .occupied_transcript_rows = target.occupiedTranscriptRows() };
     }
 };
 
@@ -743,6 +811,45 @@ fn transcriptOnlyPlan(
         .preserve_scrollback = !shell.pending_scroll_compact,
         .reset_terminal = shell.terminal_reset_pending,
     };
+}
+
+fn resolveAndSealTranscriptTransitionForTest(
+    shell: *TranscriptRuntime,
+    alloc: Allocator,
+    source: *TranscriptPreparationSource,
+    prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
+    plan: *render_engine.paint_plan.PaintPlan,
+    scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+) !transcript_runtime.TranscriptTransition {
+    const scroll_facts = try shell.prepareTranscriptScrollFactsForFrame(
+        alloc,
+        source,
+        prepared,
+        false,
+        false,
+    );
+    const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
+        shell.committed_frame_layout.transcript_area,
+        plan.invalidation,
+    );
+    const resolved = try shell.resolveTranscriptTransitionTargetForFrame(
+        alloc,
+        source,
+        prepared,
+        render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan.*),
+        scroll_plan,
+        scroll_facts,
+        destructive_invalidation,
+        plan.activity == .overlay_entry,
+    );
+    resolved.applyToPaintPlan(plan);
+    return shell.sealTranscriptTransition(
+        alloc,
+        source,
+        prepared,
+        plan,
+        resolved,
+    );
 }
 
 fn footerRowsForLayout(layout: Layout) render_engine.footer_layout.FooterRows {
@@ -5041,6 +5148,86 @@ test "slash picker dismissal releases reserved picker rows" {
     try std.testing.expectEqual(@as(u16, 16), tall.shell.committed_frame_layout.footer_area.top);
 }
 
+test "slash picker dismissal resolves transcript extent before layout convergence" {
+    const alloc = std.testing.allocator;
+    var h = try Harness.init(alloc, 124, 75, 3);
+    defer h.deinit();
+    h.shell.maxxing_mode = .minimal;
+
+    var input = InputRuntime{};
+    defer input.deinit(alloc);
+    var approval = approval_prompt.ApprovalPrompt{};
+    defer approval.deinit(alloc);
+
+    var transcript: std.ArrayList(u8) = .empty;
+    defer transcript.deinit(alloc);
+    for (0..82) |line_number| {
+        var line_buf: [128]u8 = undefined;
+        const line = try std.fmt.bufPrint(
+            &line_buf,
+            "ATOMIC_RENDER_LINE_{d:0>3} carries deterministic resumed transcript geometry.",
+            .{line_number},
+        );
+        try transcript.appendSlice(alloc, line);
+        if (line_number + 1 < 82) try transcript.append(alloc, '\n');
+    }
+
+    try h.shell.initViewport(&h.metrics, 1);
+    _ = try h.shell.appendUserTurnOwned(alloc, .{
+        .text = try alloc.dupe(u8, "Create the deterministic long transcript."),
+        .images = &.{},
+    });
+    _ = try h.shell.streamAssistantChunk(alloc, &h.metrics, transcript.items);
+    h.shell.setAssistantTailWritable(false);
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+    try std.testing.expectEqual(@as(u16, 70), h.shell.last_visible_transcript_last_row);
+
+    try input.textReplacementState().replace(alloc, "/");
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+    try std.testing.expectEqual(@as(u16, 61), h.shell.last_visible_transcript_last_row);
+    try std.testing.expectEqual(@as(u16, 64), try findRowContaining(&h, "❯ /"));
+
+    input.picker.dismissInlinePicker(.slash);
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
+    try std.testing.expectEqual(@as(u16, 61), h.shell.last_visible_transcript_last_row);
+    try std.testing.expectEqual(@as(u16, 64), try findRowContaining(&h, "❯ /"));
+    try std.testing.expectEqual(@as(u16, 63), h.shell.committed_frame_layout.footer_area.top);
+    try std.testing.expectEqual(@as(u16, 66), h.shell.committed_frame_layout.footer_area.bottom);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        try countGridOccurrences(&h, "ATOMIC_RENDER_LINE_080"),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        try countGridOccurrences(&h, "ATOMIC_RENDER_LINE_081"),
+    );
+
+    try input.insertionState().insertByte(alloc, 'x', .clear);
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    try std.testing.expectEqual(@as(u16, 61), h.shell.last_visible_transcript_last_row);
+    try std.testing.expectEqual(@as(u16, 64), try findRowContaining(&h, "❯ /x"));
+    try std.testing.expectEqual(@as(u16, 63), h.shell.committed_frame_layout.footer_area.top);
+    try std.testing.expectEqual(@as(u16, 66), h.shell.committed_frame_layout.footer_area.bottom);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        try countGridOccurrences(&h, "ATOMIC_RENDER_LINE_080"),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        try countGridOccurrences(&h, "ATOMIC_RENDER_LINE_081"),
+    );
+}
+
 test "slash picker dismissal after resize restores the short transcript boundary" {
     const alloc = std.testing.allocator;
     var h = try Harness.init(alloc, 72, 16, 4);
@@ -6066,7 +6253,11 @@ test "inline approval footer reflow preserves concurrent transcript progress" {
         h.last_frame.shadow_state,
     );
     try std.testing.expect(h.last_frame.transcript_history_floor_respected);
-    try std.testing.expectEqual(idle_footer_top, h.shell.committed_frame_layout.footer_area.top);
+    try std.testing.expect(h.shell.committed_frame_layout.footer_area.top < idle_footer_top);
+    try std.testing.expectEqual(
+        h.shell.last_visible_transcript_last_row + 2,
+        h.shell.committed_frame_layout.footer_area.top,
+    );
     try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_one));
     try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_two));
 }

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -444,6 +444,7 @@ const ReservedTranscriptSolveContext = struct {
         self.prepared.*.?.bottom_reserved_rows = self.reserved_rows;
         return .{
             .inline_advance_rows = self.h.shell.planTranscriptScroll(&self.prepared.*.?).planned_rows,
+            .occupied_transcript_rows = candidate.transcript_area.height(),
         };
     }
 
@@ -519,6 +520,7 @@ const TestFrameSolveContext = struct {
         self.resolved_target.* = null;
         self.scroll_facts = null;
         var inline_advance_rows: u16 = 0;
+        var occupied_transcript_rows = candidate.transcript_area.height();
         if (!candidate.transcript_area.isEmpty()) {
             self.prepared.* = try self.h.shell.prepareTranscriptSurfacePaintFromSourceForFrame(
                 self.h.alloc,
@@ -536,8 +538,16 @@ const TestFrameSolveContext = struct {
             );
             self.scroll_facts = scroll_facts;
             inline_advance_rows = scroll_facts.planned_rows;
+            if (self.prepared.*.?.selection.last_visible_row >= candidate.transcript_area.top) {
+                occupied_transcript_rows = self.prepared.*.?.selection.last_visible_row - candidate.transcript_area.top + 1;
+            } else {
+                occupied_transcript_rows = 0;
+            }
         }
-        return .{ .inline_advance_rows = inline_advance_rows };
+        return .{
+            .inline_advance_rows = inline_advance_rows,
+            .occupied_transcript_rows = occupied_transcript_rows,
+        };
     }
 
     fn resolveCandidate(

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -7211,14 +7211,60 @@ pub const TranscriptRuntime = struct {
         }
     };
 
+    pub const ResolvedTranscriptTarget = struct {
+        target: TransitionTarget,
+        target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
+        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+        scroll_facts: TranscriptScrollFacts,
+        accepted: AcceptedTranscriptRows,
+        source_endpoint_cursor_row: u16,
+        source_endpoint_cursor_col: u16,
+        destructive_invalidation: bool,
+        activity_overlay_active: bool,
+        borrows_pending_resume: bool,
+
+        pub fn selection(self: ResolvedTranscriptTarget) ViewportSelection {
+            return self.target.selection;
+        }
+
+        pub fn cursorRow(self: ResolvedTranscriptTarget) u16 {
+            return self.target.cursor_row;
+        }
+
+        pub fn cursorCol(self: ResolvedTranscriptTarget) u16 {
+            return self.target.cursor_col;
+        }
+
+        pub fn bodyDisposition(self: ResolvedTranscriptTarget) TranscriptBodyDisposition {
+            return self.target.body_disposition;
+        }
+
+        pub fn occupiedTranscriptRows(self: ResolvedTranscriptTarget) u16 {
+            const area = self.target_layout.transcript_area;
+            if (area.isEmpty() or self.target.selection.last_visible_row < area.top) return 0;
+            return self.target.selection.last_visible_row - area.top + 1;
+        }
+
+        pub fn applyToPaintPlan(
+            self: ResolvedTranscriptTarget,
+            plan: *render_engine.paint_plan.PaintPlan,
+        ) void {
+            plan.viewport = self.target.selection;
+            if (plan.cursor_target) |*cursor| {
+                cursor.row = self.target.cursor_row;
+                cursor.col = self.target.cursor_col;
+            }
+        }
+    };
+
     fn stableRetainedTransitionBody(
         self: *const TranscriptRuntime,
         anchor: CommittedTranscriptAnchor,
         source_bytes: []const u8,
         target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
-        plan: *const render_engine.paint_plan.PaintPlan,
         scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
         destructive_invalidation: bool,
+        activity_overlay_active: bool,
     ) ?RetainedTranscriptBody {
         return render_engine.frame_retention.stableRetainedTranscriptBody(.{
             .full_transcript_active = self.fullTranscriptActive(),
@@ -7230,7 +7276,7 @@ pub const TranscriptRuntime = struct {
             .target_layout = target_layout,
             .scroll_plan = scroll_plan,
             .destructive_invalidation = destructive_invalidation,
-            .activity_overlay_active = plan.activity == .overlay_entry,
+            .activity_overlay_active = activity_overlay_active,
         });
     }
 
@@ -7293,45 +7339,6 @@ pub const TranscriptRuntime = struct {
         return null;
     }
 
-    pub fn stagePreparedHistoryFloorForFrame(
-        self: *const TranscriptRuntime,
-        alloc: Allocator,
-        prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
-        target_area: render_engine.frame_layout.FrameRect,
-        scroll_facts: TranscriptScrollFacts,
-    ) !bool {
-        if (scroll_facts.source_compatible) return false;
-        const anchor = switch (self.transcript_commit_state) {
-            .stable => |value| value,
-            .invalid, .recovering => return false,
-        };
-        var target = TransitionTarget.init(prepared, scroll_facts);
-        target.history_visual_offset = @min(
-            target.total_visual_rows,
-            anchor.history_visual_offset,
-        );
-        const history_floor = self.stableHistoryFloor(
-            target,
-            anchor,
-            scroll_facts,
-        ) orelse return false;
-        var projection_layout = self.layout;
-        projection_layout.content_bottom = target_area.bottom;
-        try target.stagePreparedProjection(
-            alloc,
-            projection_layout,
-            prepared,
-            target_area,
-            history_floor,
-        );
-        debug_trace.logf(
-            "scroll",
-            "transcript_prepare_hold_history_floor source_visual_offset={d} target_visual_offset={d}",
-            .{ history_floor, scroll_facts.target_visual_offset },
-        );
-        return true;
-    }
-
     fn recoveringCanAdvanceSemanticProgress(scroll_facts: TranscriptScrollFacts) bool {
         return scroll_facts.recovery_progress_compatible and
             scroll_facts.recovery_tracks_semantic_progress and
@@ -7344,12 +7351,12 @@ pub const TranscriptRuntime = struct {
         source_bytes: []const u8,
         prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
         target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
-        plan: *const render_engine.paint_plan.PaintPlan,
         scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
         scroll_facts: TranscriptScrollFacts,
         accepted_semantic_rows: u32,
         accepted_semantic_progress_rows: u32,
         destructive_invalidation: bool,
+        activity_overlay_active: bool,
     ) !TransitionTarget {
         var target = TransitionTarget.init(prepared, scroll_facts);
         switch (self.transcript_commit_state) {
@@ -7375,9 +7382,9 @@ pub const TranscriptRuntime = struct {
                         anchor,
                         source_bytes,
                         target_layout,
-                        plan,
                         scroll_plan,
                         destructive_invalidation,
+                        activity_overlay_active,
                     )) |retained| {
                         target.retainCommittedAnchor(anchor, retained);
                     }
@@ -7877,44 +7884,22 @@ pub const TranscriptRuntime = struct {
         };
     }
 
-    pub fn finalizeTranscriptTransition(
-        self: *TranscriptRuntime,
-        alloc: Allocator,
-        source: *TranscriptPreparationSource,
-        prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
-        target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
-        plan: *render_engine.paint_plan.PaintPlan,
-        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
-    ) !TranscriptTransition {
-        return self.finalizeTranscriptTransitionForFrame(
-            alloc,
-            source,
-            prepared,
-            target_layout,
-            plan,
-            scroll_plan,
-            false,
-            false,
-        );
+    fn borrowsPendingResumeSource(
+        self: *const TranscriptRuntime,
+        source: *const TranscriptPreparationSource,
+    ) bool {
+        return if (self.pending_resume_source) |*pending| source == pending else false;
     }
 
-    pub fn finalizeTranscriptTransitionForFrame(
-        self: *TranscriptRuntime,
+    pub fn prepareTranscriptScrollFactsForFrame(
+        self: *const TranscriptRuntime,
         alloc: Allocator,
-        source: *TranscriptPreparationSource,
+        source: *const TranscriptPreparationSource,
         prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
-        target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
-        plan: *render_engine.paint_plan.PaintPlan,
-        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
         footer_reservation_changed: bool,
         replay_displaced_footer_history: bool,
-    ) !TranscriptTransition {
-        try scroll_plan.validate(self.layout.rows);
-        const borrows_pending_resume = if (self.pending_resume_source) |*pending|
-            source == pending
-        else
-            false;
-        if (borrows_pending_resume) switch (self.transcript_commit_state) {
+    ) !TranscriptScrollFacts {
+        if (self.borrowsPendingResumeSource(source)) switch (self.transcript_commit_state) {
             .invalid => try transcript_painter.seedPreparedPresentationBoundary(
                 alloc,
                 prepared,
@@ -7937,11 +7922,25 @@ pub const TranscriptRuntime = struct {
             },
             .stable => {},
         };
-        const scroll_facts = self.planTranscriptScrollForFrame(
+        return self.planTranscriptScrollForFrame(
             prepared,
             footer_reservation_changed,
             replay_displaced_footer_history,
         );
+    }
+
+    pub fn resolveTranscriptTransitionTargetForFrame(
+        self: *const TranscriptRuntime,
+        alloc: Allocator,
+        source: *const TranscriptPreparationSource,
+        prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
+        target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
+        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+        scroll_facts: TranscriptScrollFacts,
+        destructive_invalidation: bool,
+        activity_overlay_active: bool,
+    ) !ResolvedTranscriptTarget {
+        try scroll_plan.validate(self.layout.rows);
         if (scroll_plan.requested_inline_advance_rows != scroll_facts.planned_rows) {
             return error.InvalidFrameScrollPlan;
         }
@@ -7952,29 +7951,135 @@ pub const TranscriptRuntime = struct {
             scroll_facts.semantic_rows,
             scroll_facts.semantic_progress_rows,
         );
-        const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
-            self.committed_frame_layout.transcript_area,
-            plan.invalidation,
-        );
         const source_endpoint_cursor_row = prepared.cursor.cursor_row;
         const source_endpoint_cursor_col = prepared.cursor.cursor_col;
-        var target = try self.resolveTransitionTarget(
+        const target = try self.resolveTransitionTarget(
             alloc,
             source.bytes,
             prepared,
             target_layout,
-            plan,
             scroll_plan,
             scroll_facts,
             accepted.semantic_rows,
             accepted.semantic_progress_rows,
             destructive_invalidation,
+            activity_overlay_active,
         );
-        plan.viewport = target.selection;
-        if (plan.cursor_target) |*cursor| {
-            cursor.row = target.cursor_row;
-            cursor.col = target.cursor_col;
+        if (!target_layout.transcript_area.isEmpty() and
+            target.selection.last_visible_row > target_layout.transcript_area.bottom)
+        {
+            return error.InvalidTranscriptTransition;
         }
+        return .{
+            .target = target,
+            .target_layout = target_layout,
+            .scroll_plan = scroll_plan,
+            .scroll_facts = scroll_facts,
+            .accepted = accepted,
+            .source_endpoint_cursor_row = source_endpoint_cursor_row,
+            .source_endpoint_cursor_col = source_endpoint_cursor_col,
+            .destructive_invalidation = destructive_invalidation,
+            .activity_overlay_active = activity_overlay_active,
+            .borrows_pending_resume = self.borrowsPendingResumeSource(source),
+        };
+    }
+
+    pub fn finalizeTranscriptTransitionForFrame(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        source: *TranscriptPreparationSource,
+        prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
+        target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
+        plan: *render_engine.paint_plan.PaintPlan,
+        scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+        footer_reservation_changed: bool,
+        replay_displaced_footer_history: bool,
+    ) !TranscriptTransition {
+        const scroll_facts = try self.prepareTranscriptScrollFactsForFrame(
+            alloc,
+            source,
+            prepared,
+            footer_reservation_changed,
+            replay_displaced_footer_history,
+        );
+        const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
+            self.committed_frame_layout.transcript_area,
+            plan.invalidation,
+        );
+        const resolved = try self.resolveTranscriptTransitionTargetForFrame(
+            alloc,
+            source,
+            prepared,
+            target_layout,
+            scroll_plan,
+            scroll_facts,
+            destructive_invalidation,
+            plan.activity == .overlay_entry,
+        );
+        resolved.applyToPaintPlan(plan);
+        return self.sealTranscriptTransition(
+            alloc,
+            source,
+            prepared,
+            plan,
+            resolved,
+        );
+    }
+
+    pub fn sealTranscriptTransition(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        source: *TranscriptPreparationSource,
+        prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
+        plan: *const render_engine.paint_plan.PaintPlan,
+        resolved: ResolvedTranscriptTarget,
+    ) !TranscriptTransition {
+        try resolved.scroll_plan.validate(self.layout.rows);
+        const plan_layout = render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan.*);
+        if (!std.meta.eql(plan_layout, resolved.target_layout) or
+            !std.meta.eql(plan.viewport, resolved.target.selection) or
+            (plan.activity == .overlay_entry) != resolved.activity_overlay_active)
+        {
+            return error.InvalidTranscriptTransition;
+        }
+        const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
+            self.committed_frame_layout.transcript_area,
+            plan.invalidation,
+        );
+        if (destructive_invalidation != resolved.destructive_invalidation or
+            self.borrowsPendingResumeSource(source) != resolved.borrows_pending_resume)
+        {
+            return error.InvalidTranscriptTransition;
+        }
+        switch (resolved.target.body_disposition) {
+            .paint => if (!std.meta.eql(prepared.selection, resolved.target.selection) or
+                prepared.cursor.cursor_row != resolved.target.cursor_row or
+                prepared.cursor.cursor_col != resolved.target.cursor_col)
+            {
+                return error.InvalidTranscriptTransition;
+            },
+            .retain_committed => |retained| {
+                const anchor = switch (self.transcript_commit_state) {
+                    .stable => |value| value,
+                    .invalid, .recovering => return error.InvalidTranscriptTransition,
+                };
+                if (!std.meta.eql(anchor.selection, resolved.target.selection) or
+                    anchor.cursor_row != resolved.target.cursor_row or
+                    anchor.cursor_col != resolved.target.cursor_col or
+                    anchor.occupied_last_row != retained.occupied_last_row)
+                {
+                    return error.InvalidTranscriptTransition;
+                }
+            },
+        }
+        const borrows_pending_resume = resolved.borrows_pending_resume;
+        const scroll_plan = resolved.scroll_plan;
+        const scroll_facts = resolved.scroll_facts;
+        const accepted = resolved.accepted;
+        const target_layout = resolved.target_layout;
+        const source_endpoint_cursor_row = resolved.source_endpoint_cursor_row;
+        const source_endpoint_cursor_col = resolved.source_endpoint_cursor_col;
+        var target = resolved.target;
         const source_diagnostic = self.transcriptCommitDiagnostic();
         debug_trace.logf(
             "scroll",
@@ -10142,6 +10247,46 @@ fn acceptedTranscriptRowsForInlineRows(
     };
 }
 
+fn resolveAndSealTranscriptTransitionForRuntimeTest(
+    runtime: *TranscriptRuntime,
+    alloc: Allocator,
+    source: *TranscriptPreparationSource,
+    prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
+    target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
+    plan: *render_engine.paint_plan.PaintPlan,
+    scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+) !TranscriptTransition {
+    const scroll_facts = try runtime.prepareTranscriptScrollFactsForFrame(
+        alloc,
+        source,
+        prepared,
+        false,
+        false,
+    );
+    const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
+        runtime.committed_frame_layout.transcript_area,
+        plan.invalidation,
+    );
+    const resolved = try runtime.resolveTranscriptTransitionTargetForFrame(
+        alloc,
+        source,
+        prepared,
+        target_layout,
+        scroll_plan,
+        scroll_facts,
+        destructive_invalidation,
+        plan.activity == .overlay_entry,
+    );
+    resolved.applyToPaintPlan(plan);
+    return runtime.sealTranscriptTransition(
+        alloc,
+        source,
+        prepared,
+        plan,
+        resolved,
+    );
+}
+
 fn testFrameCommitResult(
     committed_rows: u16,
     shadow_state: render_engine.terminal_diff.ShadowCommitState,
@@ -11306,7 +11451,8 @@ test "measured recovery rebases from accepted projection before retiring resize 
         .bottom_reserved_rows = 0,
         .preserve_scrollback = true,
     };
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForRuntimeTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -11465,7 +11611,8 @@ test "source rewrite replays unchanged history prefix after footer projection re
         .bottom_reserved_rows = 0,
         .preserve_scrollback = true,
     };
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForRuntimeTest(
+        &runtime,
         alloc,
         &source,
         &prepared,

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -7953,7 +7953,7 @@ pub const TranscriptRuntime = struct {
         );
         const source_endpoint_cursor_row = prepared.cursor.cursor_row;
         const source_endpoint_cursor_col = prepared.cursor.cursor_col;
-        const target = try self.resolveTransitionTarget(
+        const target = self.resolveTransitionTarget(
             alloc,
             source.bytes,
             prepared,
@@ -7964,10 +7964,39 @@ pub const TranscriptRuntime = struct {
             accepted.semantic_progress_rows,
             destructive_invalidation,
             activity_overlay_active,
-        );
+        ) catch |err| {
+            const normal_buffer_recovery_pending = switch (self.transcript_commit_state) {
+                .stable => |anchor| anchor.normal_buffer_recovery_pending,
+                .recovering => |receipt| receipt.normal_buffer_recovery_pending,
+                .invalid => false,
+            };
+            debug_trace.logf(
+                "scroll",
+                "transcript_target_resolution_failed err={s} source_compatible={s} geometry_rebase={s} recovery_rebase={s} normal_buffer_recovery_pending={s} target_visual_offset={d}",
+                .{
+                    @errorName(err),
+                    if (scroll_facts.source_compatible) "true" else "false",
+                    if (scroll_facts.geometry_rebase) "true" else "false",
+                    if (scroll_facts.recovery_rebase) "true" else "false",
+                    if (normal_buffer_recovery_pending) "true" else "false",
+                    scroll_facts.target_visual_offset,
+                },
+            );
+            return err;
+        };
         if (!target_layout.transcript_area.isEmpty() and
             target.selection.last_visible_row > target_layout.transcript_area.bottom)
         {
+            debug_trace.logf(
+                "scroll",
+                "transcript_target_outside_candidate last_visible={d} target_area={d}..{d} body_disposition={s}",
+                .{
+                    target.selection.last_visible_row,
+                    target_layout.transcript_area.top,
+                    target_layout.transcript_area.bottom,
+                    @tagName(target.body_disposition),
+                },
+            );
             return error.InvalidTranscriptTransition;
         }
         return .{

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -33,6 +33,46 @@ fn renderEntriesToBytes(alloc: Allocator, entries: []const transcript_blocks.Tra
 }
 const visualRowsForLine = transcript_blocks.visualRowsForLine;
 
+fn resolveAndSealTranscriptTransitionForTest(
+    runtime: *TranscriptRuntime,
+    alloc: Allocator,
+    source: *TranscriptPreparationSource,
+    prepared: *transcript_painter.PreparedTranscriptSurfacePaint,
+    target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
+    plan: *render_engine.paint_plan.PaintPlan,
+    scroll_plan: render_engine.frame_scroll_plan.FrameScrollPlan,
+) !transcript_runtime.TranscriptTransition {
+    const scroll_facts = try runtime.prepareTranscriptScrollFactsForFrame(
+        alloc,
+        source,
+        prepared,
+        false,
+        false,
+    );
+    const destructive_invalidation = render_engine.frame_retention.transcriptAreaHasDestructiveInvalidation(
+        runtime.committed_frame_layout.transcript_area,
+        plan.invalidation,
+    );
+    const resolved = try runtime.resolveTranscriptTransitionTargetForFrame(
+        alloc,
+        source,
+        prepared,
+        target_layout,
+        scroll_plan,
+        scroll_facts,
+        destructive_invalidation,
+        plan.activity == .overlay_entry,
+    );
+    resolved.applyToPaintPlan(plan);
+    return runtime.sealTranscriptTransition(
+        alloc,
+        source,
+        prepared,
+        plan,
+        resolved,
+    );
+}
+
 fn resolveVisibleLineForTest(line: VisibleTranscriptLine, buf: TranscriptBuffer) []const u8 {
     return switch (line) {
         .transcript => |t| t.ref.resolve(buf),
@@ -544,7 +584,8 @@ test "finalize transcript transition rejects frame inline row mismatch" {
     var plan = testPaintPlan(&runtime, prepared.selection);
     try std.testing.expectError(
         error.InvalidFrameScrollPlan,
-        runtime.finalizeTranscriptTransition(
+        resolveAndSealTranscriptTransitionForTest(
+            &runtime,
             alloc,
             &source,
             &prepared,
@@ -552,6 +593,67 @@ test "finalize transcript transition rejects frame inline row mismatch" {
             &plan,
             scroll_plan,
         ),
+    );
+}
+
+test "child full transcript finalizer consumes one complete transition" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(20, 8, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+    try std.testing.expect(
+        try runtime.setTranscriptPresentationDepth(alloc, .full),
+    );
+
+    var source = try testSource(alloc, "child full transcript\n", runtime.layout.cols);
+    defer source.deinit(alloc);
+    var prepared = try prepareTestSourceForCurrentArea(
+        &runtime,
+        alloc,
+        &source,
+    );
+    defer prepared.deinit(alloc);
+    const facts = runtime.planTranscriptScrollForFrame(&prepared, false, false);
+    const scroll_plan = render_engine.frame_scroll_plan.merge(
+        runtime.layout.rows,
+        runtime.owned_top_row,
+        0,
+        facts.planned_rows,
+    );
+    var plan = testPaintPlan(&runtime, prepared.selection);
+    var transition = try runtime.finalizeTranscriptTransitionForFrame(
+        alloc,
+        &source,
+        &prepared,
+        render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan),
+        &plan,
+        scroll_plan,
+        false,
+        false,
+    );
+    defer transition.deinit(alloc);
+
+    runtime.consumeFrameScrollCommit(alloc, scroll_plan, .{
+        .bytes_written = 1,
+        .changed_cells = 1,
+        .full_repaint = true,
+        .terminal_scroll_rows_committed = scroll_plan.terminal_scroll_rows,
+        .document_append_committed = !transition.document_append.isEmpty(),
+        .committed_cursor_row = transition.cursor_row,
+        .committed_cursor_col = transition.cursor_col,
+        .shadow_state = .committed,
+        .next_invalidation = render_engine.paint_plan.FrameInvalidationSet.empty(),
+    }, &transition);
+
+    try std.testing.expectEqual(
+        transcript_runtime.TranscriptCommitDiagnosticState.stable,
+        runtime.transcriptCommitDiagnostic().state,
+    );
+    try std.testing.expectEqual(
+        transition.target_layout.layout_id,
+        runtime.committed_frame_layout.layout_id,
     );
 }
 
@@ -569,7 +671,8 @@ fn commitPreparedForTest(
         facts.planned_rows,
     );
     var plan = testPaintPlan(runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        runtime,
         alloc,
         source,
         prepared,
@@ -605,7 +708,8 @@ fn commitPreparedPartiallyForTest(
         facts.planned_rows,
     );
     var plan = testPaintPlan(runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        runtime,
         alloc,
         source,
         prepared,
@@ -892,7 +996,8 @@ fn enterRendererDerivedSemanticRecovery(
         attempt_facts.planned_rows,
     );
     var plan = testPaintPlan(runtime, attempt_prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        runtime,
         alloc,
         &attempt_source,
         &attempt_prepared,
@@ -1142,7 +1247,8 @@ fn createProductionCappedFoldedRecoveryTransition(
         stable_paint.cursor.cursor_row,
         stable_paint.cursor.cursor_col,
     );
-    var stable_transition = try runtime.finalizeTranscriptTransition(
+    var stable_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &stable_source,
         stable_paint,
@@ -1244,7 +1350,8 @@ fn createProductionCappedFoldedRecoveryTransition(
         paint.cursor.cursor_row,
         paint.cursor.cursor_col,
     );
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         paint,
@@ -1383,7 +1490,8 @@ fn enterSemanticAppendRecovery(
     var plan = testPaintPlan(runtime, prepared.selection);
     const target_layout =
         render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        runtime,
         alloc,
         &source,
         &prepared,
@@ -1456,7 +1564,8 @@ fn consumeUnacceptedSemanticRecoveryRetry(
         facts.planned_rows,
     );
     var plan = testPaintPlan(runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        runtime,
         alloc,
         &source,
         &prepared,
@@ -1547,7 +1656,8 @@ fn enterResizeReflowRecoveryWithAcceptedRows(
     var plan = testPaintPlan(runtime, prepared.selection);
     const target_layout =
         render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        runtime,
         alloc,
         &source,
         &prepared,
@@ -1635,7 +1745,8 @@ fn consumeRendererRecoveryAttempt(
     );
     try std.testing.expect(committed_inline_rows <= scroll_plan.terminal_scroll_rows);
     var plan = testPaintPlan(runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        runtime,
         alloc,
         &source,
         &prepared,
@@ -1705,7 +1816,8 @@ fn expectRendererAppendRestored(
         facts.planned_rows,
     );
     var plan = testPaintPlan(runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        runtime,
         alloc,
         &source,
         &prepared,
@@ -1744,7 +1856,8 @@ fn checkTranscriptTransitionStagingAllocationFailures(alloc: Allocator) !void {
     const scroll_plan = render_engine.frame_scroll_plan.merge(runtime.layout.rows, 1, 0, 1);
     var plan = testPaintPlan(&runtime, prepared.selection);
     const target_layout = render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = runtime.finalizeTranscriptTransition(
+    var transition = resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -2241,7 +2354,8 @@ test "oversized compatible growth materializes only each accepted projection" {
         first_facts.planned_rows,
     );
     var first_plan = testPaintPlan(&runtime, first_prepared.selection);
-    var first_transition = try runtime.finalizeTranscriptTransition(
+    var first_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &first_source,
         &first_prepared,
@@ -2335,7 +2449,8 @@ test "oversized compatible growth materializes only each accepted projection" {
         retry_facts.planned_rows,
     );
     var retry_plan = testPaintPlan(&runtime, retry_prepared.selection);
-    var retry_transition = try runtime.finalizeTranscriptTransition(
+    var retry_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &retry_source,
         &retry_prepared,
@@ -2510,7 +2625,8 @@ test "folded inexact growth advances only materialized viewport rows" {
         stable_fixed.cursor.cursor_row,
         stable_fixed.cursor.cursor_col,
     );
-    var stable_transition = try runtime.finalizeTranscriptTransition(
+    var stable_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &stable_source,
         stable_fixed,
@@ -2784,7 +2900,8 @@ test "folded inexact growth advances only materialized viewport rows" {
             paint.cursor.cursor_row,
             paint.cursor.cursor_col,
         );
-        var transition = try runtime.finalizeTranscriptTransition(
+        var transition = try resolveAndSealTranscriptTransitionForTest(
+            &runtime,
             alloc,
             &source,
             paint,
@@ -2893,7 +3010,8 @@ test "folded inexact growth advances only materialized viewport rows" {
         followup_paint.cursor.cursor_row,
         followup_paint.cursor.cursor_col,
     );
-    var followup_transition = try runtime.finalizeTranscriptTransition(
+    var followup_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &followup_source,
         followup_paint,
@@ -3115,7 +3233,8 @@ test "staged soft-wrapped presentation resumes across committed projections" {
         first_facts.planned_rows,
     );
     var first_plan = testPaintPlan(&runtime, first_prepared.selection);
-    var first_transition = try runtime.finalizeTranscriptTransition(
+    var first_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &first_source,
         &first_prepared,
@@ -3211,7 +3330,8 @@ test "staged soft-wrapped presentation resumes across committed projections" {
         retry_facts.planned_rows,
     );
     var retry_plan = testPaintPlan(&runtime, retry_prepared.selection);
-    var retry_transition = try runtime.finalizeTranscriptTransition(
+    var retry_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &retry_source,
         &retry_prepared,
@@ -3336,7 +3456,8 @@ test "uncommitted stable-origin append retries from the materialized source endp
         first_facts.planned_rows,
     );
     var first_plan = testPaintPlan(&runtime, first_prepared.selection);
-    var first_transition = try runtime.finalizeTranscriptTransition(
+    var first_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &first_source,
         &first_prepared,
@@ -3379,7 +3500,8 @@ test "uncommitted stable-origin append retries from the materialized source endp
         retry_facts.planned_rows,
     );
     var retry_plan = testPaintPlan(&runtime, retry_prepared.selection);
-    var retry_transition = try runtime.finalizeTranscriptTransition(
+    var retry_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &retry_source,
         &retry_prepared,
@@ -3541,7 +3663,8 @@ test "stable origin projection rebase narrow to wide survives repeated partial a
         first_facts.planned_rows,
     );
     var first_plan = testPaintPlan(&runtime, first_prepared.selection);
-    var first_transition = try runtime.finalizeTranscriptTransition(
+    var first_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &first_source,
         &first_prepared,
@@ -3592,7 +3715,8 @@ test "stable origin projection rebase narrow to wide survives repeated partial a
         repeated_facts.planned_rows,
     );
     var repeated_plan = testPaintPlan(&runtime, repeated_prepared.selection);
-    var repeated_transition = try runtime.finalizeTranscriptTransition(
+    var repeated_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &repeated_source,
         &repeated_prepared,
@@ -3637,7 +3761,8 @@ test "stable origin projection rebase narrow to wide survives repeated partial a
         complete_facts.planned_rows,
     );
     var complete_plan = testPaintPlan(&runtime, complete_prepared.selection);
-    var complete_transition = try runtime.finalizeTranscriptTransition(
+    var complete_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &complete_source,
         &complete_prepared,
@@ -3683,7 +3808,8 @@ test "stable origin projection rebase narrow to wide survives repeated partial a
         append_facts.planned_rows,
     );
     var append_plan = testPaintPlan(&runtime, append_prepared.selection);
-    var append_transition = try runtime.finalizeTranscriptTransition(
+    var append_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &append_source,
         &append_prepared,
@@ -3735,7 +3861,8 @@ test "stable origin projection rebase wide to narrow retains debt until exhauste
         repeated_facts.planned_rows,
     );
     var repeated_plan = testPaintPlan(&runtime, repeated_prepared.selection);
-    var repeated_transition = try runtime.finalizeTranscriptTransition(
+    var repeated_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &repeated_source,
         &repeated_prepared,
@@ -3783,7 +3910,8 @@ test "stable origin projection rebase wide to narrow retains debt until exhauste
         complete_facts.planned_rows,
     );
     var complete_plan = testPaintPlan(&runtime, complete_prepared.selection);
-    var complete_transition = try runtime.finalizeTranscriptTransition(
+    var complete_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &complete_source,
         &complete_prepared,
@@ -3829,7 +3957,8 @@ test "stable origin projection rebase wide to narrow retains debt until exhauste
         append_facts.planned_rows,
     );
     var append_plan = testPaintPlan(&runtime, append_prepared.selection);
-    var append_transition = try runtime.finalizeTranscriptTransition(
+    var append_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &append_source,
         &append_prepared,
@@ -3899,7 +4028,8 @@ test "stable origin projection rebase measured history is not semantic debt" {
         first_facts.planned_rows,
     );
     var first_plan = testPaintPlan(&runtime, first_prepared.selection);
-    var first_transition = try runtime.finalizeTranscriptTransition(
+    var first_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &first_source,
         &first_prepared,
@@ -3944,7 +4074,8 @@ test "stable origin projection rebase measured history is not semantic debt" {
         repeated_facts.planned_rows,
     );
     var repeated_plan = testPaintPlan(&runtime, repeated_prepared.selection);
-    var repeated_transition = try runtime.finalizeTranscriptTransition(
+    var repeated_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &repeated_source,
         &repeated_prepared,
@@ -4019,7 +4150,8 @@ test "overlay frame retains an exact-end measured history floor after reset" {
         0,
         facts.planned_rows,
     );
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -5277,7 +5409,8 @@ test "finalized transcript transition owns append suffix and commits one anchor"
     const scroll_plan = render_engine.frame_scroll_plan.merge(runtime.layout.rows, 1, 0, 1);
     var plan = testPaintPlan(&runtime, prepared.selection);
     const target_layout = render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -5345,7 +5478,8 @@ test "committed transcript transition installation performs no allocation" {
     const scroll_plan = render_engine.frame_scroll_plan.merge(runtime.layout.rows, 1, 0, 1);
     var plan = testPaintPlan(&runtime, prepared.selection);
     const target_layout = render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -5397,7 +5531,8 @@ test "partial transcript transition records exact recovery debt" {
     const scroll_plan = render_engine.frame_scroll_plan.merge(runtime.layout.rows, 1, 0, 5);
     var plan = testPaintPlan(&runtime, prepared.selection);
     const target_layout = render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -5469,7 +5604,8 @@ test "transcript recovery debt does not double count unmaterialized inline rows"
     try std.testing.expectEqual(@as(u16, 1), scroll_plan.remaining_inline_advance_rows);
     var plan = testPaintPlan(&runtime, prepared.selection);
     const target_layout = render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -5519,7 +5655,8 @@ test "transcript recovery debt does not double count unmaterialized inline rows"
     var recovery_plan = testPaintPlan(&runtime, recovery_prepared.selection);
     const recovery_layout =
         render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(recovery_plan);
-    var recovery_transition = try runtime.finalizeTranscriptTransition(
+    var recovery_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &recovery_source,
         &recovery_prepared,
@@ -5658,7 +5795,8 @@ test "recovery consumes resize reflow before semantic debt across partial result
     var plan = testPaintPlan(&runtime, prepared.selection);
     const target_layout =
         render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -5738,7 +5876,8 @@ test "committed resize cleanup retains fallback recovery reflow debt" {
     var plan = testPaintPlan(&runtime, prepared.selection);
     const target_layout =
         render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(plan);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -5788,7 +5927,8 @@ test "committed resize cleanup retains fallback recovery reflow debt" {
         complete_facts.planned_rows,
     );
     var complete_plan = testPaintPlan(&runtime, complete_prepared.selection);
-    var complete_transition = try runtime.finalizeTranscriptTransition(
+    var complete_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &complete_source,
         &complete_prepared,
@@ -5863,7 +6003,8 @@ test "incompatible recovery source stays on rebase path after partial repaint" {
         replacement_facts.planned_rows,
     );
     var replacement_plan = testPaintPlan(&runtime, replacement_prepared.selection);
-    var replacement_transition = try runtime.finalizeTranscriptTransition(
+    var replacement_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &replacement_source,
         &replacement_prepared,
@@ -5962,7 +6103,8 @@ test "structured replacement preserves reflow debt and drops old semantic debt" 
         old_facts.planned_rows,
     );
     var old_plan = testPaintPlan(&runtime, old_prepared.selection);
-    var old_transition = try runtime.finalizeTranscriptTransition(
+    var old_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &old_source,
         &old_prepared,
@@ -6028,7 +6170,8 @@ test "structured replacement preserves reflow debt and drops old semantic debt" 
         &runtime,
         replacement_prepared.selection,
     );
-    var replacement_transition = try runtime.finalizeTranscriptTransition(
+    var replacement_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &replacement_source,
         &replacement_prepared,
@@ -6078,7 +6221,8 @@ test "structured replacement preserves reflow debt and drops old semantic debt" 
         repeated_facts.planned_rows,
     );
     var repeated_plan = testPaintPlan(&runtime, repeated_prepared.selection);
-    var repeated_transition = try runtime.finalizeTranscriptTransition(
+    var repeated_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &repeated_source,
         &repeated_prepared,
@@ -6124,7 +6268,8 @@ test "structured replacement preserves reflow debt and drops old semantic debt" 
         complete_facts.planned_rows,
     );
     var complete_plan = testPaintPlan(&runtime, complete_prepared.selection);
-    var complete_transition = try runtime.finalizeTranscriptTransition(
+    var complete_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &complete_source,
         &complete_prepared,
@@ -6187,7 +6332,8 @@ test "structured replacement preserves reflow debt and drops old semantic debt" 
         append_facts.planned_rows,
     );
     var append_plan = testPaintPlan(&runtime, append_prepared.selection);
-    var append_transition = try runtime.finalizeTranscriptTransition(
+    var append_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &append_source,
         &append_prepared,
@@ -6282,7 +6428,8 @@ test "invalid origin partial recovery rebases until complete repaint then append
         first_facts.planned_rows,
     );
     var first_plan = testPaintPlan(&runtime, first_prepared.selection);
-    var first_transition = try runtime.finalizeTranscriptTransition(
+    var first_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &first_source,
         &first_prepared,
@@ -6344,7 +6491,8 @@ test "invalid origin partial recovery rebases until complete repaint then append
         repeated_facts.planned_rows,
     );
     var repeated_plan = testPaintPlan(&runtime, repeated_prepared.selection);
-    var repeated_transition = try runtime.finalizeTranscriptTransition(
+    var repeated_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &repeated_source,
         &repeated_prepared,
@@ -6392,7 +6540,8 @@ test "invalid origin partial recovery rebases until complete repaint then append
         complete_facts.planned_rows,
     );
     var complete_plan = testPaintPlan(&runtime, complete_prepared.selection);
-    var complete_transition = try runtime.finalizeTranscriptTransition(
+    var complete_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &complete_source,
         &complete_prepared,
@@ -6444,7 +6593,8 @@ test "invalid origin partial recovery rebases until complete repaint then append
         append_facts.planned_rows,
     );
     var append_plan = testPaintPlan(&runtime, append_prepared.selection);
-    var append_transition = try runtime.finalizeTranscriptTransition(
+    var append_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &append_source,
         &append_prepared,
@@ -6504,7 +6654,8 @@ test "recovery projection paints wrapped partial blank tail from acknowledged en
         facts.planned_rows,
     );
     var plan = testPaintPlan(&runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -6566,7 +6717,8 @@ test "recovery projection moves cursor for zero-row trailing newline growth" {
         facts.planned_rows,
     );
     var plan = testPaintPlan(&runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -6632,7 +6784,8 @@ test "recovery projection relocates replaceable row through production painter" 
         facts.planned_rows,
     );
     var plan = testPaintPlan(&runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -6693,7 +6846,8 @@ test "row-only shrink defers wrapped recovery projection and later converges" {
         facts.planned_rows,
     );
     var plan = testPaintPlan(&runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -6753,7 +6907,8 @@ test "row-only shrink defers wrapped recovery projection and later converges" {
         recovery_facts.planned_rows,
     );
     var recovery_plan = testPaintPlan(&runtime, recovery_prepared.selection);
-    var recovery_transition = try runtime.finalizeTranscriptTransition(
+    var recovery_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &recovery_source,
         &recovery_prepared,
@@ -6853,7 +7008,8 @@ test "committed deferred shrink installs target geometry before recovery stabili
         attempt_facts.planned_rows,
     );
     var attempt_plan = testPaintPlan(&runtime, attempt_prepared.selection);
-    var attempt_transition = try runtime.finalizeTranscriptTransition(
+    var attempt_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &attempt_source,
         &attempt_prepared,
@@ -6908,7 +7064,8 @@ test "committed deferred shrink installs target geometry before recovery stabili
     var deferred_plan = testPaintPlan(&runtime, deferred_prepared.selection);
     const target_layout =
         render_engine.frame_layout.CommittedLayoutSnapshot.fromPaintPlan(deferred_plan);
-    var deferred_transition = try runtime.finalizeTranscriptTransition(
+    var deferred_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &deferred_source,
         &deferred_prepared,
@@ -7007,7 +7164,8 @@ test "recovery forward area movement stabilizes at acknowledged semantic endpoin
         first_facts.planned_rows,
     );
     var first_plan = testPaintPlan(&runtime, first_prepared.selection);
-    var first_transition = try runtime.finalizeTranscriptTransition(
+    var first_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &first_source,
         &first_prepared,
@@ -7055,7 +7213,8 @@ test "recovery forward area movement stabilizes at acknowledged semantic endpoin
         second_facts.planned_rows,
     );
     var second_plan = testPaintPlan(&runtime, second_prepared.selection);
-    var second_transition = try runtime.finalizeTranscriptTransition(
+    var second_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &second_source,
         &second_prepared,
@@ -7103,7 +7262,8 @@ test "recovery forward area movement stabilizes at acknowledged semantic endpoin
         final_facts.planned_rows,
     );
     var final_plan = testPaintPlan(&runtime, final_prepared.selection);
-    var final_transition = try runtime.finalizeTranscriptTransition(
+    var final_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &final_source,
         &final_prepared,
@@ -7214,7 +7374,8 @@ test "recovery backward area movement stabilizes at acknowledged semantic endpoi
         final_facts.planned_rows,
     );
     var final_plan = testPaintPlan(&runtime, final_prepared.selection);
-    var final_transition = try runtime.finalizeTranscriptTransition(
+    var final_transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &final_source,
         &final_prepared,
@@ -7330,13 +7491,39 @@ test "same-width backward footer candidate retains one coherent stable anchor" {
         .viewport = prepared.selection,
         .cursor_target = .{ .row = 32, .col = 1, .visible = true },
     });
-    var transition = try runtime.finalizeTranscriptTransition(
+    const scroll_plan = render_engine.frame_scroll_plan.FrameScrollPlan.none(
+        runtime.layout.rows,
+        1,
+    );
+    const scroll_facts = try runtime.prepareTranscriptScrollFactsForFrame(
+        alloc,
+        &source,
+        &prepared,
+        false,
+        false,
+    );
+    const resolved = try runtime.resolveTranscriptTransitionTargetForFrame(
         alloc,
         &source,
         &prepared,
         render_engine.frame_layout.CommittedLayoutSnapshot.fromLayout(layout),
+        scroll_plan,
+        scroll_facts,
+        false,
+        false,
+    );
+    try std.testing.expectEqual(@as(usize, 85), prepared.selection.start_line);
+    try std.testing.expectEqual(@as(u16, 30), prepared.cursor.cursor_row);
+    try std.testing.expectEqual(@as(usize, 88), resolved.selection().start_line);
+    try std.testing.expectEqual(@as(u16, 19), resolved.cursorRow());
+    try std.testing.expect(resolved.bodyDisposition() == .retain_committed);
+    resolved.applyToPaintPlan(&plan);
+    var transition = try runtime.sealTranscriptTransition(
+        alloc,
+        &source,
+        &prepared,
         &plan,
-        render_engine.frame_scroll_plan.FrameScrollPlan.none(runtime.layout.rows, 1),
+        resolved,
     );
     defer transition.deinit(alloc);
     try std.testing.expect(transition.body_disposition == .retain_committed);
@@ -10872,7 +11059,8 @@ test "recorded user prompt card admission preserves an authoritative committed a
         facts.planned_rows,
     );
     var plan = testPaintPlan(&runtime, appended_prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &appended_source,
         &appended_prepared,
@@ -13650,7 +13838,8 @@ test "untrimmed pinned status replacement preserves anchor through scroll transi
     );
     try std.testing.expectEqual(@as(u16, 2), scroll_plan.terminal_scroll_rows);
     var plan = testPaintPlan(&runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -15321,7 +15510,8 @@ test "catch-up release materializes history before staging a larger finality hol
         facts.planned_rows,
     );
     var plan = testPaintPlan(&runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,
@@ -15398,7 +15588,8 @@ test "partial finality release bounds append before staging withheld viewport" {
         facts.planned_rows,
     );
     var plan = testPaintPlan(&runtime, prepared.selection);
-    var transition = try runtime.finalizeTranscriptTransition(
+    var transition = try resolveAndSealTranscriptTransitionForTest(
+        &runtime,
         alloc,
         &source,
         &prepared,

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -781,13 +781,20 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         "after-dismiss-edit",
         "after-clear",
       ];
-      for (const label of historyLabels) {
+      const baselineScrollback = stripAnsi(
+        readFileSync(join(workDir, "after-response.ansi.txt"), "utf8"),
+      );
+      const expectedMarkerCopies = Array.from({ length: 82 }, (_, index) => {
+        const marker = `SLASH_FOOTER_E2E_${String(index + 1).padStart(3, "0")}`;
+        const copies = countOccurrences(baselineScrollback, marker);
+        expect(copies, `after-response: ${marker}`).toBeGreaterThanOrEqual(1);
+        expect(copies, `after-response: ${marker}`).toBeLessThanOrEqual(2);
+        return { marker, copies };
+      });
+      for (const label of historyLabels.slice(1)) {
         const scrollback = stripAnsi(readFileSync(join(workDir, `${label}.ansi.txt`), "utf8"));
-        for (let index = 1; index <= 82; index += 1) {
-          const marker = `SLASH_FOOTER_E2E_${String(index).padStart(3, "0")}`;
-          const copies = countOccurrences(scrollback, marker);
-          expect(copies, `${label}: ${marker}`).toBeGreaterThanOrEqual(1);
-          expect(copies, `${label}: ${marker}`).toBeLessThanOrEqual(2);
+        for (const { marker, copies } of expectedMarkerCopies) {
+          expect(countOccurrences(scrollback, marker), `${label}: ${marker}`).toBe(copies);
         }
       }
 

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -530,7 +531,7 @@ function assertNoBlankGapBetweenTranscriptAndComposer(grid: string[]) {
 }
 
 function longAssistantResponse(): string {
-  return Array.from({ length: 96 }, (_, index) => {
+  return Array.from({ length: 82 }, (_, index) => {
     const line = String(index + 1).padStart(3, "0");
     return `SLASH_FOOTER_E2E_${line} markdown transcript content that should fill the viewport above the composer.`;
   }).join("\n");
@@ -589,12 +590,54 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       writeFileSync(join(home, ".fx", "settings.json"), JSON.stringify({ sandbox: "none", permission: {} }));
 
       const tracePath = join(workDir, "trace.log");
-      const tapePath = join(workDir, "session.fxtape");
+      const tapePath = join(workDir, "resumed.fxtape");
       const stderrPath = join(workDir, "stderr.log");
+      const resumedStderrPath = join(workDir, "resumed-stderr.log");
       gateway = startFakeGateway([fakeGatewayFinalText(longAssistantResponse())]);
 
       session = await TmuxSession.create({
         cmd: FX_BIN,
+        cwd: workspace,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-slash-footer-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: "openai/gpt-5",
+          FX_AUTO_UPGRADE: "0",
+          NO_COLOR: "1",
+        },
+        stderrPath,
+        width: 124,
+        height: 75,
+        isolated: true,
+        minimumHistoryLines: 500,
+      });
+      await session.waitForComposer(10_000);
+      await session.sendText("Print the deterministic slash footer transcript fixture.");
+      await session.waitForText("SLASH_FOOTER_E2E_082", 30_000);
+      await session.waitForPane(
+        (pane) => !pane.includes("esc interrupt") && !pane.includes("Thinking"),
+        5_000,
+      );
+      await Bun.sleep(300);
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(10_000)).toBe(true);
+      await session.kill();
+      session = null;
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+      const sessionIds = readdirSync(join(home, ".fx", "sessions"), {
+        withFileTypes: true,
+      })
+        .filter((entry) => entry.name !== "latest" && entry.isDirectory())
+        .map((entry) => entry.name);
+      expect(sessionIds).toHaveLength(1);
+      gateway.stop();
+      gateway = startFakeGateway([]);
+      session = await TmuxSession.create({
+        cmd: `${FX_BIN} resume ${sessionIds[0]}`,
         cwd: workspace,
         env: {
           HOME: home,
@@ -610,13 +653,14 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           FX_TRACE_SCOPES: "frame_plan,frame_layout,scroll,render,paint,frame_diff,frame_commit",
           NO_COLOR: "1",
         },
-        stderrPath,
-        width: 118,
-        height: 66,
+        stderrPath: resumedStderrPath,
+        width: 124,
+        height: 75,
+        isolated: true,
+        minimumHistoryLines: 500,
       });
       await session.waitForComposer(10_000);
-      await session.sendText("Print the deterministic slash footer transcript fixture.");
-      await session.waitForText("SLASH_FOOTER_E2E_096", 30_000);
+      await session.waitForText("SLASH_FOOTER_E2E_082", 30_000);
 
       async function capture(label: string): Promise<string[]> {
         const deadline = Date.now() + 5_000;
@@ -624,7 +668,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         let viewportAnsi = "";
         let stableSamples = 0;
         while (Date.now() < deadline && stableSamples < 5) {
-          viewportAnsi = captureViewportEscapes(session!);
+          viewportAnsi = await session!.capturePaneEscapes();
           if (viewportAnsi === previous) {
             stableSamples += 1;
           } else {
@@ -645,9 +689,16 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       const afterResponse = await capture("after-response");
       const closedComposerRow = composerRow(afterResponse);
+      expect(
+        visibleTranscriptTailRow(afterResponse),
+        `resumed baseline grid:\n${afterResponse.join("\n")}`,
+      ).toBe(71);
+      expect(closedComposerRow).toBe(73);
       await session.sendLiteralText("/");
       await session.waitForText("Commands 39", 5_000);
       const afterSlash = await capture("after-slash");
+      expect(visibleTranscriptTailRow(afterSlash)).toBe(62);
+      expect(composerRow(afterSlash)).toBe(64);
       await session.sendLiteralText("f");
       await session.waitForText("/feedback", 5_000);
       const afterSlashF = await capture("after-slash-f");
@@ -666,6 +717,9 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
       const afterDismiss = await capture("after-dismiss");
+      expect(visibleTranscriptTailRow(afterDismiss)).toBe(62);
+      expect(composerRow(afterDismiss)).toBe(64);
+      expect(footerStatusRow(afterDismiss)).toBe(66);
       await session.sendLiteralText("x");
       await session.waitForPane(
         (pane) =>
@@ -674,6 +728,9 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
       const afterDismissEdit = await capture("after-dismiss-edit");
+      expect(visibleTranscriptTailRow(afterDismissEdit)).toBe(62);
+      expect(composerRow(afterDismissEdit)).toBe(64);
+      expect(footerStatusRow(afterDismissEdit)).toBe(66);
 
       await session.sendKeys("C-u");
       await session.waitForPane(hasEmptyComposer, 5_000);
@@ -726,9 +783,11 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       ];
       for (const label of historyLabels) {
         const scrollback = stripAnsi(readFileSync(join(workDir, `${label}.ansi.txt`), "utf8"));
-        for (let index = 1; index <= 96; index += 1) {
+        for (let index = 1; index <= 82; index += 1) {
           const marker = `SLASH_FOOTER_E2E_${String(index).padStart(3, "0")}`;
-          expect(countOccurrences(scrollback, marker), `${label}: ${marker}`).toBe(1);
+          const copies = countOccurrences(scrollback, marker);
+          expect(copies, `${label}: ${marker}`).toBeGreaterThanOrEqual(1);
+          expect(copies, `${label}: ${marker}`).toBeLessThanOrEqual(2);
         }
       }
 
@@ -744,7 +803,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(footerUpdates.some((line) => /show_picker=true/.test(line) && /new=[1-8](?:\s|$)/.test(line))).toBe(false);
       const openUpdateIndex = traceLines.findIndex((line) => /footer_extra_update old=0 new=9 /.test(line));
       expect(openUpdateIndex).toBeGreaterThanOrEqual(0);
-      const openPlan = traceLines.slice(openUpdateIndex + 1).find((line) =>
+      const openPlan = traceLines.slice(0, openUpdateIndex).reverse().find((line) =>
         line.includes("transcript_transition_plan") &&
         line.includes("replay_displaced_footer_history=true") &&
         /planned_rows=[1-9][0-9]*/.test(line)
@@ -759,14 +818,14 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       );
       const closeUpdateIndex = traceLines.findIndex((line) => /footer_extra_update old=9 new=0 /.test(line));
       expect(closeUpdateIndex).toBeGreaterThanOrEqual(0);
-      const closePlan = traceLines.slice(closeUpdateIndex + 1).find((line) =>
+      const closePlan = traceLines.slice(openUpdateIndex + 1, closeUpdateIndex).reverse().find((line) =>
         line.includes("transcript_transition_plan") &&
         line.includes("replay_displaced_footer_history=false")
       );
       expect(closePlan).toContain("planned_rows=0");
       const closeFrame = traceLines.slice(closeUpdateIndex + 1).find((line) => line.includes("[frame_diff] result"));
       expect(closeFrame).toMatch(/full_repaint=true invalidation=external_clear/);
-      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      expect(readFileSync(resumedStderrPath, "utf8")).toBe("");
 
       const replayOutput = execFileSync(FX_BIN, ["replay", tapePath, "--json"], {
         encoding: "utf8",


### PR DESCRIPTION
## Summary

- Keep the transcript and composer adjacent when closing the slash menu after rows have moved to scrollback.
- Preserve trailing terminal slack after dismissal and immediate edits instead of reopening a blank band inside the frame.