### PR TITLE
Scope native fetches to stream handles

### DIFF
--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -57,7 +57,7 @@ shared createFxAgent() logic in sdk/fx-sdk.js
 - `exited` settles when the native runtime exits.
 - `abort()` aborts Node fetch and closes native input.
 
-The adapter polls `drainCore()` and `takeCoreFetch()` every 2 milliseconds. ACP output is accumulated to newline boundaries and parsed as JSON. Gateway requests are transferred to Node as bounded request records; Node runs the configured `fetch`, streams bounded response chunks back to Zig, and owns the `AbortController`. This matches the WebAssembly host-fetch boundary and ensures the N-API core never uses the native `std.http` Gateway transport.
+The adapter checks fetch control and drains ACP output on its existing timer. While no body pump exists it may call `takeCoreFetch()`; while a pump exists it calls only `coreFetchActive()` for that fetch handle. An inactive handle aborts its matching `AbortController` on the next callback that observes it. No exact callback latency is guaranteed. ACP output is accumulated to newline boundaries and parsed as JSON. Gateway requests are transferred to Node as bounded request records; Node runs the configured `fetch`, streams bounded response chunks back to Zig, and owns the `AbortController`. This matches the WebAssembly host-fetch boundary and ensures the N-API core never uses the native `std.http` Gateway transport.
 
 ## Native module ABI
 
@@ -65,21 +65,24 @@ The adapter polls `drainCore()` and `takeCoreFetch()` every 2 milliseconds. ACP 
 
 | Export | Purpose |
 | --- | --- |
-| `libfxApiVersion` | Checks compatibility with the JavaScript loader. Currently `1`. |
+| `libfxApiVersion` | Checks compatibility with the JavaScript loader. Currently `2`. Low-level `createCore` backends must declare this exact version. |
 | `createCore(options)` | Allocates a runtime and starts its ACP thread. |
 | `writeCore(handle, buffer)` | Appends bytes to the bounded input queue. |
 | `closeCore(handle)` | Closes input and wakes a blocked ACP reader. |
 | `drainCore(handle)` | Returns up to 1 MiB of queued output as a Node Buffer. |
-| `takeCoreFetch(handle)` | Takes the pending bounded Gateway request for Node-owned fetch. |
-| `startCoreFetchResponse(handle, status)` | Publishes the fetch response status. |
-| `pushCoreFetchResponse(handle, buffer)` | Appends a bounded response chunk. |
-| `finishCoreFetch(handle)` / `failCoreFetch(handle)` | Completes the host stream successfully or with transport failure. |
-| `abortCoreFetch(handle)` | Wakes the Zig worker while Node aborts the matching `AbortController`. |
+| `takeCoreFetch(runtime)` | Takes the pending bounded Gateway request, including its positive `fetchHandle`, for Node-owned fetch. |
+| `coreFetchActive(runtime, fetchHandle)` | Reports whether that request may still receive host response operations. |
+| `startCoreFetchResponse(runtime, fetchHandle, status)` | Publishes the matching fetch response status. |
+| `pushCoreFetchResponse(runtime, fetchHandle, buffer)` | Appends a bounded matching response chunk. |
+| `finishCoreFetch(runtime, fetchHandle)` / `failCoreFetch(runtime, fetchHandle)` | Completes only the matching host stream successfully or with transport failure. |
+| `abortCoreFetch(runtime)` | Wakes the Zig worker while Node aborts the current matching `AbortController`. |
 | `coreExited(handle)` | Reports whether the ACP thread has exited. |
 | `coreExitCode(handle)` | Returns the ACP thread's numeric exit status. |
 | `destroyCore(handle)` | Closes input, joins the thread, and releases native memory. |
 
 This ABI is internal. Consumers should use `createFxAgent()` from `sdk/node.js`; exposing the primitive functions keeps the native boundary small and testable.
+
+Response operations return numeric outcomes: `0` means the operation was stale and ignored, `1` means it was applied, and `2` means a response push encountered bounded backpressure. Stale callbacks never mutate a newer fetch. They emit one payload-free `napi` trace containing only the operation, numeric fetch handle, and drop reason.
 
 Each handle is a JavaScript object wrapped around a `RuntimeHandle`. It is branded with `napi_type_tag` and checked before every operation. A structurally similar object cannot be substituted for a real handle. The wrapper owns a finalizer, so garbage collection invokes the same destruction path as explicit `destroyCore()`.
 
@@ -98,7 +101,7 @@ Creating a core performs these steps:
 
 The runtime thread never calls N-API. It blocks on the fetch bridge while the Node event-loop poller owns `fetch`, response-body iteration, and `AbortController`. Destruction marks the bridge shutting down and wakes every wait before joining the runtime thread, so worker teardown does not depend on further JavaScript callbacks.
 
-The addon initializes one process-wide `std.Io.Threaded` instance. Atomic state protects one-time initialization when the addon is loaded in multiple Node worker environments.
+The addon initializes one process-wide `std.Io.Threaded` instance. Atomic state protects one-time initialization when the addon is loaded in multiple Node worker environments. The same initialization installs the inherited process environment and configures the existing `debug_trace` owner before any runtime thread starts; individual runtimes do not shut global tracing down.
 
 Input and output queues have independent `std.Io.Mutex` protection. The input queue also has a condition variable so the ACP reader sleeps while no input is available. Closing input broadcasts the condition and allows the server thread to terminate.
 

--- a/sdk/browser.js
+++ b/sdk/browser.js
@@ -8,7 +8,7 @@ import {
 } from "./fx-sdk.js";
 
 export { encodeXtermKeyEvent, fxSdkApiVersion, supportsJspi, xtermAdapter };
-export const libfxApiVersion = 1;
+export const libfxApiVersion = 2;
 
 const defaultCoreWasm = new URL("./fx-core.wasm", import.meta.url).href;
 const defaultTermWasm = new URL("./fx-term.wasm", import.meta.url).href;

--- a/sdk/node.js
+++ b/sdk/node.js
@@ -13,7 +13,11 @@ import {
 } from "./fx-sdk.js";
 
 export { encodeXtermKeyEvent, fxSdkApiVersion, supportsJspi, xtermAdapter };
-export const libfxApiVersion = 1;
+export const libfxApiVersion = 2;
+
+const fetchOperationStale = 0;
+const fetchOperationApplied = 1;
+const fetchOperationBackpressure = 2;
 
 const require = createRequire(import.meta.url);
 const defaultCoreWasm = new URL("./fx-core.wasm", import.meta.url);
@@ -56,8 +60,11 @@ async function loadNativeCandidate(candidate) {
 
 function validateNativeBackend(backend) {
   if (!backend) return null;
-  if (backend.libfxApiVersion !== undefined && backend.libfxApiVersion !== libfxApiVersion) {
-    throw new Error(`native addon API version ${backend.libfxApiVersion} is incompatible with libfx API version ${libfxApiVersion}`);
+  const hasLowLevelCore = typeof backend.createCore === "function";
+  if ((hasLowLevelCore && backend.libfxApiVersion !== libfxApiVersion) ||
+    (!hasLowLevelCore && backend.libfxApiVersion !== undefined && backend.libfxApiVersion !== libfxApiVersion)) {
+    const actualVersion = backend.libfxApiVersion ?? "missing";
+    throw new Error(`native addon API version ${actualVersion} is incompatible with libfx API version ${libfxApiVersion}`);
   }
   if (typeof backend.createFxAgent !== "function" && typeof backend.createCore !== "function" &&
     typeof backend.createFxTerminal !== "function") {
@@ -150,7 +157,7 @@ function createNativeCoreRuntime(addon, options) {
   };
   const pumpFetch = async (request) => {
     const controller = new AbortController();
-    const state = { controller };
+    const state = { handle: request.handle, controller };
     fetchState = state;
     try {
       const response = await (options.fetch ?? globalThis.fetch)(request.url, {
@@ -159,25 +166,35 @@ function createNativeCoreRuntime(addon, options) {
         body: request.body?.length ? Buffer.from(request.body, "base64") : undefined,
         signal: controller.signal,
       });
-      addon.startCoreFetchResponse(core, response.status);
+      const started = addon.startCoreFetchResponse(core, state.handle, response.status);
+      if (started === fetchOperationStale) return;
+      if (started !== fetchOperationApplied) throw new Error(`invalid native fetch start result ${started}`);
       if (response.body) {
         for await (const chunk of response.body) {
           const buffer = Buffer.from(chunk);
           let offset = 0;
           while (offset < buffer.length) {
             const end = Math.min(offset + 64 * 1024, buffer.length);
-            if (addon.pushCoreFetchResponse(core, buffer.subarray(offset, end))) {
+            const pushed = addon.pushCoreFetchResponse(core, state.handle, buffer.subarray(offset, end));
+            if (pushed === fetchOperationApplied) {
               offset = end;
-            } else {
-              await new Promise((resolve) => setTimeout(resolve, 2));
+              continue;
             }
+            if (pushed === fetchOperationStale) return;
+            if (pushed !== fetchOperationBackpressure) throw new Error(`invalid native fetch push result ${pushed}`);
+            await new Promise((resolve) => setTimeout(resolve, 2));
           }
         }
       }
-      addon.finishCoreFetch(core);
+      const finished = addon.finishCoreFetch(core, state.handle);
+      if (finished !== fetchOperationApplied && finished !== fetchOperationStale) {
+        throw new Error(`invalid native fetch finish result ${finished}`);
+      }
     } catch (error) {
       if (error?.name !== "AbortError" || !controller.signal.aborted) {
-        try { addon.failCoreFetch(core); } catch {}
+        try {
+          if (addon.coreFetchActive(core, state.handle)) addon.failCoreFetch(core, state.handle);
+        } catch {}
       }
     } finally {
       if (fetchState === state) fetchState = null;
@@ -185,8 +202,14 @@ function createNativeCoreRuntime(addon, options) {
   };
   const timer = setInterval(() => {
     try {
-      const fetchRequest = addon.takeCoreFetch(core);
-      if (fetchRequest && !fetchState) void pumpFetch(JSON.parse(fetchRequest.toString("utf8")));
+      if (fetchState) {
+        if (!fetchState.controller.signal.aborted && !addon.coreFetchActive(core, fetchState.handle)) {
+          fetchState.controller.abort();
+        }
+      } else {
+        const fetchRequest = addon.takeCoreFetch(core);
+        if (fetchRequest) void pumpFetch(JSON.parse(fetchRequest.toString("utf8")));
+      }
       const chunk = addon.drainCore(core);
       if (chunk.length && lineHandler) {
         lineBuffer += chunk.toString("utf8");

--- a/sdk/tests/test-libfx-loader.mjs
+++ b/sdk/tests/test-libfx-loader.mjs
@@ -12,16 +12,15 @@ import {
 } from "../node.js";
 import * as browser from "../browser.js";
 
-assert.equal(libfxApiVersion, 1);
+assert.equal(libfxApiVersion, 2);
 assert.equal(fxSdkApiVersion, 1);
-assert.equal(browser.libfxApiVersion, 1);
+assert.equal(browser.libfxApiVersion, 2);
 assert.equal(typeof browser.createFxAgent, "function");
 assert.equal(typeof browser.createFxTerminal, "function");
 
 const dir = await mkdtemp(resolve(tmpdir(), "libfx-loader-"));
 const nativePath = resolve(dir, "native.mjs");
 await writeFile(nativePath, `
-  export const libfxApiVersion = 1;
   export async function createFxAgent(options) { return { backend: "native-agent", options }; }
   export async function createFxTerminal(options) { return { backend: "native-terminal", options }; }
 `);
@@ -57,7 +56,7 @@ await assert.rejects(
 
 const coreOnlyPath = resolve(dir, "core-only.mjs");
 await writeFile(coreOnlyPath, `
-  export const libfxApiVersion = 1;
+  export const libfxApiVersion = 2;
   export async function createFxAgent() { return { backend: "core-only" }; }
 `);
 await assert.rejects(
@@ -68,7 +67,7 @@ await assert.rejects(
 
 const incompatiblePath = resolve(dir, "incompatible.mjs");
 await writeFile(incompatiblePath, `
-  export const libfxApiVersion = 2;
+  export const libfxApiVersion = 3;
   export async function createFxAgent() {}
 `);
 await assert.rejects(
@@ -77,4 +76,39 @@ await assert.rejects(
     error.message.includes("incompatible"),
 );
 
-console.log("libfx loader passed: browser exports, native preference, fallback diagnostics, and API validation");
+for (const [name, source] of [
+  ["missing-version", `
+    export function createCore() { throw new Error("missing-version createCore invoked"); }
+  `],
+  ["unequal-version", `
+    export const libfxApiVersion = 3;
+    export function createCore() { throw new Error("unequal-version createCore invoked"); }
+  `],
+]) {
+  const modulePath = resolve(dir, `${name}.mjs`);
+  await writeFile(modulePath, source);
+  await assert.rejects(
+    createFxAgent({ nativeAddon: pathToFileURL(modulePath), backend: "native" }),
+    (error) => error?.code === "LIBFX_NATIVE_UNAVAILABLE" &&
+      error.message.includes("incompatible") &&
+      !String(error.cause).includes("createCore invoked"),
+    `${name} low-level addon must fail before createCore invocation`,
+  );
+}
+
+const matchingVersionPath = resolve(dir, "matching-version.mjs");
+await writeFile(matchingVersionPath, `
+  export const libfxApiVersion = 2;
+  export function createCore() {
+    const error = new Error("matching-version createCore invoked");
+    error.code = "MATCHING_VERSION_INVOKED";
+    throw error;
+  }
+`);
+await assert.rejects(
+  createFxAgent({ nativeAddon: pathToFileURL(matchingVersionPath), backend: "native" }),
+  (error) => error?.code === "MATCHING_VERSION_INVOKED",
+  "matching v2 low-level addon must reach createCore",
+);
+
+console.log("libfx loader passed: browser exports, native preference, fallback diagnostics, and strict low-level API validation");

--- a/sdk/tests/test-native-core-misuse.mjs
+++ b/sdk/tests/test-native-core-misuse.mjs
@@ -1,13 +1,38 @@
 #!/usr/bin/env node
 import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 const scriptDir = fileURLToPath(new URL(".", import.meta.url));
 const addonPath = resolve(process.argv[2] || resolve(scriptDir, "../../zig-out/lib/libfx.node"));
+const traceChild = process.env.LIBFX_STALE_TRACE_CHILD === "1";
+if (!traceChild) {
+  delete process.env.FX_TRACE;
+  delete process.env.FX_TRACE_LOG;
+  delete process.env.FX_TRACE_SCOPES;
+  delete process.env.FX_TRACE_STDERR;
+}
 const addon = require(addonPath);
+
+if (traceChild) {
+  const traceCore = addon.createCore({
+    apiKey: "trace-test-key",
+    home: "/tmp",
+    workspaceRoot: "/tmp",
+  });
+  try {
+    assert.equal(addon.pushCoreFetchResponse(traceCore, 17, Buffer.from("secret-response-payload")), 0);
+  } finally {
+    addon.closeCore(traceCore);
+    addon.destroyCore(traceCore);
+  }
+  process.exit(0);
+}
 
 for (const [name, args] of [
   ["createCore", []],
@@ -15,6 +40,12 @@ for (const [name, args] of [
   ["writeCore", [{}]],
   ["closeCore", []],
   ["drainCore", []],
+  ["takeCoreFetch", []],
+  ["coreFetchActive", []],
+  ["startCoreFetchResponse", []],
+  ["pushCoreFetchResponse", []],
+  ["finishCoreFetch", []],
+  ["failCoreFetch", []],
   ["coreExited", []],
   ["coreExitCode", []],
   ["destroyCore", []],
@@ -67,4 +98,132 @@ assert.throws(
   (error) => error.code === "LIBFX_NATIVE_CLOSED",
 );
 
-console.log("native core misuse passed: argument, size, backpressure, and closed-handle checks are enforced");
+const lifecycleCore = addon.createCore({
+  apiKey: "lifecycle-test-key",
+  model: "native/test-model",
+  home: "/tmp",
+  workspaceRoot: "/tmp",
+  gatewayChatUrl: "http://127.0.0.1:31337/chat",
+});
+let nextId = 1;
+let buffered = "";
+const timeout = (label, ms = 5000) => new Promise((_, reject) => {
+  const timer = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), ms);
+  timer.unref();
+});
+const send = (method, params = {}) => {
+  const id = nextId++;
+  addon.writeCore(lifecycleCore, Buffer.from(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`));
+  return id;
+};
+const waitForResponse = async (id) => {
+  for (;;) {
+    buffered += addon.drainCore(lifecycleCore).toString("utf8");
+    const lines = buffered.split("\n");
+    buffered = lines.pop();
+    for (const line of lines) {
+      if (!line) continue;
+      const message = JSON.parse(line);
+      if (message.id === id) return message;
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 2));
+  }
+};
+const request = async (method, params = {}) => {
+  const id = send(method, params);
+  return Promise.race([waitForResponse(id), timeout(method)]);
+};
+const takeFetch = async () => {
+  for (;;) {
+    const bytes = addon.takeCoreFetch(lifecycleCore);
+    if (bytes) return JSON.parse(bytes.toString("utf8"));
+    await new Promise((resolveWait) => setTimeout(resolveWait, 2));
+  }
+};
+const responseBytes = (text) => Buffer.from([
+  `data: ${JSON.stringify({ type: "text-delta", delta: text })}\n\n`,
+  'data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\n',
+  "data: [DONE]\n\n",
+].join(""));
+const sendPrompt = (sessionId, text) => send("session/prompt", {
+  sessionId,
+  prompt: [{ type: "text", text }],
+});
+
+try {
+  assert.ok((await request("initialize", { protocolVersion: 1, clientCapabilities: {} })).result);
+  const created = await request("session/new");
+  const sessionId = created.result.sessionId;
+
+  const firstPrompt = sendPrompt(sessionId, "first low-level prompt");
+  const firstFetch = await Promise.race([takeFetch(), timeout("first host fetch")]);
+  assert.ok(Number.isInteger(firstFetch.handle) && firstFetch.handle > 0, "fetch request must carry a positive handle");
+  const firstHandle = firstFetch.handle;
+  const futureHandle = firstHandle + 1;
+  assert.equal(addon.coreFetchActive(lifecycleCore, firstHandle), true);
+  assert.equal(addon.coreFetchActive(lifecycleCore, futureHandle), false);
+  assert.equal(addon.startCoreFetchResponse(lifecycleCore, futureHandle, 200), 0);
+  assert.equal(addon.coreFetchActive(lifecycleCore, firstHandle), true, "stale start must not mutate the active handle");
+  assert.equal(addon.startCoreFetchResponse(lifecycleCore, firstHandle, 200), 1);
+  assert.equal(addon.pushCoreFetchResponse(lifecycleCore, firstHandle, Buffer.alloc(8 * 1024 * 1024 + 1)), 2);
+  assert.equal(addon.pushCoreFetchResponse(lifecycleCore, firstHandle, responseBytes("first")), 1);
+  assert.equal(addon.finishCoreFetch(lifecycleCore, firstHandle), 1);
+  assert.equal((await Promise.race([waitForResponse(firstPrompt), timeout("first prompt result")])).result.stopReason, "end_turn");
+
+  const secondPrompt = sendPrompt(sessionId, "second low-level prompt");
+  const secondFetch = await Promise.race([takeFetch(), timeout("second host fetch")]);
+  assert.notEqual(secondFetch.handle, firstHandle, "sequential fetches must use unique handles");
+  const secondHandle = secondFetch.handle;
+  assert.equal(addon.startCoreFetchResponse(lifecycleCore, firstHandle, 200), 0);
+  assert.equal(addon.pushCoreFetchResponse(lifecycleCore, firstHandle, Buffer.from("stale")), 0);
+  assert.equal(addon.finishCoreFetch(lifecycleCore, firstHandle), 0);
+  assert.equal(addon.failCoreFetch(lifecycleCore, firstHandle), 0);
+  assert.equal(addon.coreFetchActive(lifecycleCore, secondHandle), true, "stale operations must not mutate the newer handle");
+  assert.equal(addon.startCoreFetchResponse(lifecycleCore, secondHandle, 200), 1);
+  assert.equal(addon.pushCoreFetchResponse(lifecycleCore, secondHandle, responseBytes("second")), 1);
+  assert.equal(addon.finishCoreFetch(lifecycleCore, secondHandle), 1);
+  assert.equal((await Promise.race([waitForResponse(secondPrompt), timeout("second prompt result")])).result.stopReason, "end_turn");
+
+  for (const [name, args] of [
+    ["coreFetchActive", [lifecycleCore, 0]],
+    ["startCoreFetchResponse", [lifecycleCore, 0, 200]],
+    ["pushCoreFetchResponse", [lifecycleCore, 0, Buffer.alloc(0)]],
+    ["finishCoreFetch", [lifecycleCore, 0]],
+    ["failCoreFetch", [lifecycleCore, 0]],
+  ]) {
+    assert.throws(() => addon[name](...args), {
+      name: "TypeError",
+      code: "LIBFX_INVALID_ARGUMENT",
+    });
+  }
+} finally {
+  addon.closeCore(lifecycleCore);
+  addon.destroyCore(lifecycleCore);
+}
+
+const traceDir = mkdtempSync(resolve(tmpdir(), "libfx-stale-trace-"));
+const traceLog = resolve(traceDir, "trace.log");
+try {
+  const traced = spawnSync(process.execPath, [fileURLToPath(import.meta.url), addonPath], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      LIBFX_STALE_TRACE_CHILD: "1",
+      FX_TRACE_LOG: traceLog,
+      FX_TRACE_SCOPES: "napi",
+    },
+  });
+  assert.equal(traced.status, 0, traced.stderr || traced.stdout);
+  assert.equal(traced.stdout, "", "stale tracing must not change normal stdout");
+  assert.equal(traced.stderr, "", "file tracing must not write stderr");
+  const trace = readFileSync(traceLog, "utf8");
+  const staleLines = trace.split("\n").filter((line) => line.includes("dropping stale host fetch"));
+  assert.equal(staleLines.length, 1, "one stale operation must emit one bounded trace");
+  assert.match(staleLines[0], /operation=push handle=17 reason=no_active_fetch/);
+  assert.doesNotMatch(trace, /secret-response-payload/);
+} finally {
+  rmSync(traceDir, { recursive: true, force: true });
+}
+
+console.log("native core misuse passed: argument, handle, stale, trace, backpressure, and closed-handle checks are enforced");

--- a/sdk/tests/test-native-core-stream.mjs
+++ b/sdk/tests/test-native-core-stream.mjs
@@ -5,6 +5,11 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createFxAgent } from "../node.js";
 
+const events = [];
+let requestCount = 0;
+let firstResponse;
+let firstConnectionClosedResolve;
+const firstConnectionClosed = new Promise((resolveClosed) => { firstConnectionClosedResolve = resolveClosed; });
 const server = createServer((request, response) => {
   if (request.method !== "POST") {
     response.writeHead(404).end();
@@ -14,12 +19,24 @@ const server = createServer((request, response) => {
   request.setEncoding("utf8");
   request.on("data", (chunk) => { body += chunk; });
   request.on("end", () => {
+    requestCount += 1;
     const payload = JSON.parse(body);
     assert.ok(payload);
     assert.ok(payload.tools == null || payload.tools.length === 0, "N-API core must not advertise native tools");
     response.writeHead(200, { "content-type": "text/event-stream" });
-    response.write('data: {"type":"text-delta","delta":"native"}\n\n');
-    response.write('data: {"type":"text-delta","delta":" stream"}\n\n');
+    if (requestCount === 1) {
+      firstResponse = response;
+      response.on("close", () => {
+        events.push("first-connection-close");
+        firstConnectionClosedResolve();
+      });
+      response.write('data: {"type":"text-delta","delta":"native one"}\n\n');
+      response.write('data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n\n');
+      events.push("first-finish-sent");
+      return;
+    }
+    assert.equal(requestCount, 2, "only two Gateway requests are expected");
+    response.write('data: {"type":"text-delta","delta":"native two"}\n\n');
     response.write('data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n\n');
     response.end("data: [DONE]\n\n");
   });
@@ -29,13 +46,28 @@ const { port } = server.address();
 
 const scriptDir = fileURLToPath(new URL(".", import.meta.url));
 const addon = resolve(process.argv[2] || resolve(scriptDir, "../../zig-out/lib/libfx.node"));
+const timeout = (label, ms = 5000) => new Promise((_, reject) => {
+  const timer = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), ms);
+  timer.unref();
+});
+let agent;
 try {
   let fetchCalls = 0;
-  const agent = await createFxAgent({
+  let firstAbortResolve;
+  const firstAbort = new Promise((resolveAbort) => { firstAbortResolve = resolveAbort; });
+  agent = await createFxAgent({
     nativeAddon: addon,
     backend: "native",
     fetch(input, init) {
       fetchCalls += 1;
+      if (fetchCalls === 1) {
+        init.signal.addEventListener("abort", () => {
+          events.push("first-abort");
+          firstAbortResolve();
+        }, { once: true });
+      } else if (fetchCalls === 2) {
+        events.push("second-fetch");
+      }
       return fetch(input, init);
     },
     env: {
@@ -45,19 +77,43 @@ try {
     },
   });
   const session = await agent.createSession();
-  const turn = session.prompt("hello from native");
-  let text = "";
-  for await (const update of turn) {
+  const firstTurn = session.prompt("first native prompt");
+  let firstText = "";
+  for await (const update of firstTurn) {
     if (update.sessionUpdate === "agent_message_chunk" && !update.content.text.startsWith("[context]")) {
-      text += update.content.text;
+      firstText += update.content.text;
     }
   }
-  assert.equal(text.trimEnd(), "native stream");
-  assert.equal(fetchCalls, 1, "N-API Gateway transport must use the Node-owned fetch option");
-  assert.equal((await turn.result).stopReason, "end_turn");
+  assert.equal(firstText.trimEnd(), "native one");
+  assert.equal((await firstTurn.result).stopReason, "end_turn");
+  events.push("first-turn-complete");
+  assert.equal(firstResponse.writableEnded, false, "prompt one must finish before [DONE] or EOF");
+
+  const secondTurn = session.prompt("second native prompt");
+  await Promise.race([
+    Promise.any([firstAbort, firstConnectionClosed]),
+    timeout("first response abort or connection close"),
+  ]);
+  let secondText = "";
+  for await (const update of secondTurn) {
+    if (update.sessionUpdate === "agent_message_chunk" && !update.content.text.startsWith("[context]")) {
+      secondText += update.content.text;
+    }
+  }
+  assert.equal(secondText.trimEnd(), "native two");
+  assert.equal((await secondTurn.result).stopReason, "end_turn");
+  assert.equal(fetchCalls, 2, "both prompts must use the Node-owned fetch option");
+  const releaseEvents = [events.indexOf("first-abort"), events.indexOf("first-connection-close")]
+    .filter((index) => index >= 0);
+  assert.ok(releaseEvents.length > 0, "the first response must be aborted or closed");
+  assert.ok(events.indexOf("second-fetch") > Math.min(...releaseEvents), "request two must start after response one releases the pump slot");
   await session.close();
   assert.equal(await agent.close(), 0);
-  console.log("native core stream passed: POST, SSE deltas, async iteration, and graceful close");
+  agent = null;
+  console.log("native core stream passed: split terminal tail, matching abort, prompt reuse, and graceful close");
 } finally {
-  server.close();
+  agent?.abort();
+  firstResponse?.destroy();
+  server.closeAllConnections();
+  await new Promise((resolveClose) => server.close(resolveClose));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3654,6 +3654,7 @@ test "semantic code block preserves indentation on wrapped continuation rows" {
 }
 
 test {
+    _ = @import("napi_fetch_state.zig");
     _ = @import("acp/prompt.zig");
     _ = @import("core/output/activity_status.zig");
     _ = @import("core/agent/agent_runtime.zig");

--- a/src/napi_core_main.zig
+++ b/src/napi_core_main.zig
@@ -8,6 +8,7 @@ const generation_usage_provider = @import("core/session/generation_usage_provide
 const host = @import("core/hosts/host.zig");
 const debug_trace = @import("core/shared/debug_trace.zig");
 const io_mod = @import("core/shared/io.zig");
+const fetch_state = @import("napi_fetch_state.zig");
 const streamable_http = @import("core/mcp/streamable_http.zig");
 const host_stream_provider = @import("gateway/host_stream_provider.zig");
 const oauth_transport = @import("core/auth/oauth_transport.zig");
@@ -152,19 +153,29 @@ const FetchBridge = struct {
     request: std.ArrayList(u8) = .empty,
     response: std.ArrayList(u8) = .empty,
     response_offset: usize = 0,
-    request_pending: bool = false,
-    response_started: bool = false,
-    response_done: bool = false,
-    failed: bool = false,
-    aborted: bool = false,
-    shutting_down: bool = false,
+    phase: fetch_state.Phase = .idle,
+    next_handle: fetch_state.Handle = 1,
     status: u16 = 0,
 
     fn clearPendingRequest(self: *FetchBridge, reason: []const u8) void {
-        if (!self.request_pending) return;
+        if (self.request.items.len == 0) return;
         debug_trace.logf("napi", "dropping pending host fetch reason={s} bytes={d}", .{ reason, self.request.items.len });
         self.request.clearRetainingCapacity();
-        self.request_pending = false;
+    }
+
+    fn trace_stale(operation: []const u8, handle: fetch_state.Handle, reason: fetch_state.StaleReason) void {
+        debug_trace.logf(
+            "napi",
+            "dropping stale host fetch operation={s} handle={d} reason={s}",
+            .{ operation, handle, @tagName(reason) },
+        );
+    }
+
+    fn advance_handle(self: *FetchBridge) void {
+        self.next_handle = if (self.next_handle == std.math.maxInt(fetch_state.Handle))
+            0
+        else
+            self.next_handle + 1;
     }
 
     fn open(raw: ?*anyopaque, method: []const u8, url: []const u8, headers: []const u8, body: []const u8) !i32 {
@@ -172,15 +183,18 @@ const FetchBridge = struct {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        if (self.shutting_down) return error.HostStreamUnavailable;
-        if (self.aborted) {
-            self.clearPendingRequest("open_after_abort");
-            self.aborted = false;
-            return error.Cancelled;
+        if (self.next_handle == 0) return error.HostStreamUnavailable;
+        const handle = self.next_handle;
+        const decision = fetch_state.decide(self.phase, .{ .open = handle });
+        switch (decision.action) {
+            .cancelled => {
+                self.phase = decision.phase;
+                return error.Cancelled;
+            },
+            .unavailable, .shutting_down => return error.HostStreamUnavailable,
+            .applied => {},
+            else => unreachable,
         }
-        if (self.request_pending or self.response_started) return error.HostStreamUnavailable;
-        self.failed = false;
-        self.response_done = false;
         self.response_offset = 0;
         self.response.clearRetainingCapacity();
         var writer: std.Io.Writer.Allocating = .init(std.heap.c_allocator);
@@ -189,82 +203,128 @@ const FetchBridge = struct {
         const body_base64 = try std.heap.c_allocator.alloc(u8, encoded_body);
         defer std.heap.c_allocator.free(body_base64);
         _ = std.base64.standard.Encoder.encode(body_base64, body);
-        try std.json.Stringify.value(.{ .method = method, .url = url, .headers = headers, .body = body_base64 }, .{}, &writer.writer);
+        try std.json.Stringify.value(.{
+            .handle = handle,
+            .method = method,
+            .url = url,
+            .headers = headers,
+            .body = body_base64,
+        }, .{}, &writer.writer);
         const bytes = writer.writer.buffered();
         if (bytes.len > max_fetch_request_bytes) return error.HostStreamBackpressure;
+        self.request.clearRetainingCapacity();
         try self.request.appendSlice(std.heap.c_allocator, bytes);
-        self.request_pending = true;
+        self.phase = decision.phase;
+        self.advance_handle();
         self.wake.broadcast(io);
-        return 1;
+        return handle;
     }
 
-    fn statusFn(raw: ?*anyopaque, _: i32, status_out: *u16) i32 {
+    fn statusFn(raw: ?*anyopaque, handle: i32, status_out: *u16) i32 {
         const self: *FetchBridge = @ptrCast(@alignCast(raw.?));
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        while (!self.response_started and !self.aborted) self.wake.waitUncancelable(io, &self.mutex);
-        if (self.aborted) return -2;
-        if (self.failed) return -1;
-        status_out.* = self.status;
-        return 1;
+        while (true) switch (self.phase) {
+            .request_pending, .awaiting_response => |active| {
+                if (active != handle) return -2;
+                self.wake.waitUncancelable(io, &self.mutex);
+            },
+            .streaming => |active| {
+                if (active != handle) return -2;
+                status_out.* = self.status;
+                return 1;
+            },
+            .terminal => |terminal| {
+                if (terminal.handle != handle) return -2;
+                return switch (terminal.kind) {
+                    .success => result: {
+                        status_out.* = self.status;
+                        break :result 1;
+                    },
+                    .failure => -1,
+                    .aborted => -2,
+                };
+            },
+            else => return -2,
+        };
     }
 
-    fn next(raw: ?*anyopaque, _: i32, out: []u8) i32 {
+    fn next(raw: ?*anyopaque, handle: i32, out: []u8) i32 {
         const self: *FetchBridge = @ptrCast(@alignCast(raw.?));
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        while (self.response_offset == self.response.items.len and !self.response_done and !self.aborted) {
+        while (true) {
+            const terminal_kind: ?fetch_state.TerminalKind = switch (self.phase) {
+                .streaming => |active| if (active == handle) null else return -2,
+                .terminal => |terminal| if (terminal.handle == handle) terminal.kind else return -2,
+                else => return -2,
+            };
+            if (terminal_kind) |kind| switch (kind) {
+                .failure => return -1,
+                .aborted => return -2,
+                .success => {},
+            };
+            const available = self.response.items.len - self.response_offset;
+            if (available > 0) {
+                const len = @min(out.len, available);
+                @memcpy(out[0..len], self.response.items[self.response_offset..][0..len]);
+                self.response_offset += len;
+                self.wake.broadcast(io);
+                return @intCast(len);
+            }
             self.response.clearRetainingCapacity();
             self.response_offset = 0;
+            if (terminal_kind != null) return 0;
             self.wake.waitUncancelable(io, &self.mutex);
         }
-        if (self.aborted) return -2;
-        if (self.failed) return -1;
-        const available = self.response.items.len - self.response_offset;
-        if (available == 0) return 0;
-        const len = @min(out.len, available);
-        @memcpy(out[0..len], self.response.items[self.response_offset..][0..len]);
-        self.response_offset += len;
-        self.wake.broadcast(io);
-        return @intCast(len);
     }
 
-    fn close(raw: ?*anyopaque, _: i32) void {
+    fn close(raw: ?*anyopaque, handle: i32) void {
         const self: *FetchBridge = @ptrCast(@alignCast(raw.?));
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        const decision = fetch_state.decide(self.phase, .{ .close = handle });
+        if (decision.action == .stale) {
+            trace_stale("close", handle, decision.stale_reason.?);
+            return;
+        }
         self.clearPendingRequest("stream_close");
-        self.response_started = false;
-        self.response_done = false;
-        self.failed = false;
-        self.aborted = false;
+        self.phase = decision.phase;
+        self.status = 0;
         self.response.clearRetainingCapacity();
         self.response_offset = 0;
         self.wake.broadcast(io);
-        self.mutex.unlock(io);
     }
 
-    fn startResponse(self: *FetchBridge, status: u16) !void {
+    fn startResponse(self: *FetchBridge, handle: fetch_state.Handle, status: u16) FetchOperationResult {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        if (self.aborted) return error.FetchAborted;
-        if (self.response_started) return error.ResponseAlreadyStarted;
+        const decision = fetch_state.decide(self.phase, .{ .start = handle });
+        if (decision.action == .stale) {
+            trace_stale("start", handle, decision.stale_reason.?);
+            return .stale;
+        }
         self.status = status;
-        self.response_started = true;
+        self.phase = decision.phase;
         self.wake.broadcast(io);
+        return .applied;
     }
 
-    fn pushResponse(self: *FetchBridge, data: []const u8) !void {
+    fn pushResponse(self: *FetchBridge, handle: fetch_state.Handle, data: []const u8) !FetchOperationResult {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
-        if (self.aborted) return error.FetchAborted;
-        if (!self.response_started or self.response_done) return error.InvalidResponseState;
+        const decision = fetch_state.decide(self.phase, .{ .push = handle });
+        if (decision.action == .stale) {
+            trace_stale("push", handle, decision.stale_reason.?);
+            return .stale;
+        }
         const queued = self.response.items.len - self.response_offset;
-        if (data.len > max_fetch_response_bytes or queued > max_fetch_response_bytes - data.len) return error.ResponseQueueFull;
+        if (data.len > max_fetch_response_bytes or queued > max_fetch_response_bytes - data.len) return .backpressure;
         if (self.response_offset > 0) {
             std.mem.copyForwards(u8, self.response.items[0..queued], self.response.items[self.response_offset..]);
             self.response.items.len = queued;
@@ -272,49 +332,74 @@ const FetchBridge = struct {
         }
         try self.response.appendSlice(std.heap.c_allocator, data);
         self.wake.broadcast(io);
+        return .applied;
     }
 
-    fn finishResponse(self: *FetchBridge) void {
+    fn finishResponse(self: *FetchBridge, handle: fetch_state.Handle) FetchOperationResult {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
-        self.response_done = true;
+        defer self.mutex.unlock(io);
+        const decision = fetch_state.decide(self.phase, .{ .finish = handle });
+        if (decision.action == .stale) {
+            trace_stale("finish", handle, decision.stale_reason.?);
+            return .stale;
+        }
+        self.phase = decision.phase;
         self.wake.broadcast(io);
-        self.mutex.unlock(io);
+        return .applied;
     }
 
-    fn failResponse(self: *FetchBridge) void {
+    fn failResponse(self: *FetchBridge, handle: fetch_state.Handle) FetchOperationResult {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
-        self.failed = true;
-        self.response_started = true;
-        self.response_done = true;
+        defer self.mutex.unlock(io);
+        const decision = fetch_state.decide(self.phase, .{ .fail = handle });
+        if (decision.action == .stale) {
+            trace_stale("fail", handle, decision.stale_reason.?);
+            return .stale;
+        }
+        self.phase = decision.phase;
         self.wake.broadcast(io);
-        self.mutex.unlock(io);
+        return .applied;
+    }
+
+    fn is_active(self: *FetchBridge, handle: fetch_state.Handle) bool {
+        const io = io_mod.getIo();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        return fetch_state.is_active(self.phase, handle);
     }
 
     fn abort(self: *FetchBridge) void {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        const decision = fetch_state.decide(self.phase, .cancel);
         self.clearPendingRequest("abort");
-        self.aborted = true;
+        self.phase = decision.phase;
         self.wake.broadcast(io);
-        self.mutex.unlock(io);
     }
 
     fn shutdown(self: *FetchBridge) void {
         const io = io_mod.getIo();
         self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        const decision = fetch_state.decide(self.phase, .shutdown);
         self.clearPendingRequest("shutdown");
-        self.shutting_down = true;
-        self.aborted = true;
+        self.phase = decision.phase;
         self.wake.broadcast(io);
-        self.mutex.unlock(io);
     }
 
     fn deinit(self: *FetchBridge) void {
         self.request.deinit(std.heap.c_allocator);
         self.response.deinit(std.heap.c_allocator);
     }
+};
+
+const FetchOperationResult = enum(u8) {
+    stale = 0,
+    applied = 1,
+    backpressure = 2,
 };
 
 const Runtime = struct {
@@ -456,6 +541,11 @@ fn ensureThreadedIo() void {
     if (threaded_io_state.cmpxchgStrong(0, 1, .acq_rel, .acquire) == null) {
         threaded_io = std.Io.Threaded.init(std.heap.c_allocator, .{});
         io_mod.setIo(threaded_io.?.io());
+        const raw_environ: io_mod.RawEnviron = @ptrCast(std.c.environ);
+        io_mod.setRawEnviron(raw_environ);
+        const workspace_root = io_mod.realpathAlloc(std.heap.c_allocator, ".") catch null;
+        defer if (workspace_root) |path| std.heap.c_allocator.free(path);
+        debug_trace.configureFromEnv(std.heap.c_allocator, workspace_root orelse ".");
         threaded_io_state.store(2, .release);
         return;
     }
@@ -657,6 +747,26 @@ fn unlockRuntime(handle: *RuntimeHandle) void {
     handle.mutex.unlock(io_mod.getIo());
 }
 
+fn fetch_handle_arg(env: c.napi_env, value: c.napi_value) ?fetch_state.Handle {
+    var number: f64 = 0;
+    if (c.napi_get_value_double(env, value, &number) != c.napi_ok or
+        !std.math.isFinite(number) or
+        number < 1 or
+        number > @as(f64, @floatFromInt(std.math.maxInt(fetch_state.Handle))) or
+        @floor(number) != number)
+    {
+        _ = c.napi_throw_type_error(env, "LIBFX_INVALID_ARGUMENT", "fetch handle must be a positive int32");
+        return null;
+    }
+    return @intFromFloat(number);
+}
+
+fn fetch_operation_value(env: c.napi_env, result: FetchOperationResult) c.napi_value {
+    var value: c.napi_value = undefined;
+    if (!statusOk(env, c.napi_create_uint32(env, @intFromEnum(result), &value), "could not create fetch operation result")) return null;
+    return value;
+}
+
 fn writeCore(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
     var argv: [2]c.napi_value = undefined;
     const handle = runtimeHandleArg(env, info, &argv) orelse return null;
@@ -710,7 +820,8 @@ fn takeCoreFetch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     const io = io_mod.getIo();
     runtime.fetch.mutex.lockUncancelable(io);
     defer runtime.fetch.mutex.unlock(io);
-    if (!runtime.fetch.request_pending) {
+    const decision = fetch_state.decide(runtime.fetch.phase, .take_request);
+    if (decision.action != .applied) {
         var value: c.napi_value = undefined;
         _ = c.napi_get_null(env, &value);
         return value;
@@ -721,67 +832,64 @@ fn takeCoreFetch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     if (!statusOk(env, c.napi_create_buffer(env, len, &data, &value), "could not allocate fetch request Buffer")) return null;
     if (len > 0) @memcpy(@as([*]u8, @ptrCast(data.?))[0..len], runtime.fetch.request.items);
     runtime.fetch.request.clearRetainingCapacity();
-    runtime.fetch.request_pending = false;
+    runtime.fetch.phase = decision.phase;
+    return value;
+}
+
+fn coreFetchActive(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argv: [2]c.napi_value = undefined;
+    const runtime_handle = runtimeHandleArg(env, info, &argv) orelse return null;
+    const fetch_handle = fetch_handle_arg(env, argv[1]) orelse return null;
+    const runtime = lockRuntime(env, runtime_handle) orelse return null;
+    defer unlockRuntime(runtime_handle);
+    var value: c.napi_value = undefined;
+    _ = c.napi_get_boolean(env, runtime.fetch.is_active(fetch_handle), &value);
     return value;
 }
 
 fn startCoreFetchResponse(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argv: [2]c.napi_value = undefined;
-    const handle = runtimeHandleArg(env, info, &argv) orelse return null;
-    const runtime = lockRuntime(env, handle) orelse return null;
-    defer unlockRuntime(handle);
+    var argv: [3]c.napi_value = undefined;
+    const runtime_handle = runtimeHandleArg(env, info, &argv) orelse return null;
+    const fetch_handle = fetch_handle_arg(env, argv[1]) orelse return null;
+    const runtime = lockRuntime(env, runtime_handle) orelse return null;
+    defer unlockRuntime(runtime_handle);
     var status: u32 = 0;
-    if (c.napi_get_value_uint32(env, argv[1], &status) != c.napi_ok or status > std.math.maxInt(u16))
+    if (c.napi_get_value_uint32(env, argv[2], &status) != c.napi_ok or status > std.math.maxInt(u16))
         return throw(env, "LIBFX_INVALID_ARGUMENT", "fetch response status must be a uint16");
-    runtime.fetch.startResponse(@intCast(status)) catch return throw(env, "LIBFX_NATIVE_CLOSED", "native fetch is closed");
-    var value: c.napi_value = undefined;
-    _ = c.napi_get_undefined(env, &value);
-    return value;
+    return fetch_operation_value(env, runtime.fetch.startResponse(fetch_handle, @intCast(status)));
 }
 
 fn pushCoreFetchResponse(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argv: [2]c.napi_value = undefined;
-    const handle = runtimeHandleArg(env, info, &argv) orelse return null;
-    const runtime = lockRuntime(env, handle) orelse return null;
-    defer unlockRuntime(handle);
+    var argv: [3]c.napi_value = undefined;
+    const runtime_handle = runtimeHandleArg(env, info, &argv) orelse return null;
+    const fetch_handle = fetch_handle_arg(env, argv[1]) orelse return null;
+    const runtime = lockRuntime(env, runtime_handle) orelse return null;
+    defer unlockRuntime(runtime_handle);
     var data: ?*anyopaque = null;
     var len: usize = 0;
-    if (!statusOk(env, c.napi_get_buffer_info(env, argv[1], &data, &len), "fetch response chunk requires a Buffer")) return null;
+    if (!statusOk(env, c.napi_get_buffer_info(env, argv[2], &data, &len), "fetch response chunk requires a Buffer")) return null;
     const bytes = if (len == 0) &.{} else @as([*]const u8, @ptrCast(data.?))[0..len];
-    runtime.fetch.pushResponse(bytes) catch |err| switch (err) {
-        error.ResponseQueueFull => {
-            var value: c.napi_value = undefined;
-            _ = c.napi_get_boolean(env, false, &value);
-            return value;
-        },
-        error.OutOfMemory => return throw(env, "LIBFX_NATIVE_OOM", "could not queue fetch response"),
-        else => return throw(env, "LIBFX_NATIVE_CLOSED", "native fetch is closed"),
-    };
-    var value: c.napi_value = undefined;
-    _ = c.napi_get_boolean(env, true, &value);
-    return value;
+    const result = runtime.fetch.pushResponse(fetch_handle, bytes) catch
+        return throw(env, "LIBFX_NATIVE_OOM", "could not queue fetch response");
+    return fetch_operation_value(env, result);
 }
 
 fn finishCoreFetch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argv: [1]c.napi_value = undefined;
-    const handle = runtimeHandleArg(env, info, &argv) orelse return null;
-    const runtime = lockRuntime(env, handle) orelse return null;
-    defer unlockRuntime(handle);
-    runtime.fetch.finishResponse();
-    var value: c.napi_value = undefined;
-    _ = c.napi_get_undefined(env, &value);
-    return value;
+    var argv: [2]c.napi_value = undefined;
+    const runtime_handle = runtimeHandleArg(env, info, &argv) orelse return null;
+    const fetch_handle = fetch_handle_arg(env, argv[1]) orelse return null;
+    const runtime = lockRuntime(env, runtime_handle) orelse return null;
+    defer unlockRuntime(runtime_handle);
+    return fetch_operation_value(env, runtime.fetch.finishResponse(fetch_handle));
 }
 
 fn failCoreFetch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argv: [1]c.napi_value = undefined;
-    const handle = runtimeHandleArg(env, info, &argv) orelse return null;
-    const runtime = lockRuntime(env, handle) orelse return null;
-    defer unlockRuntime(handle);
-    runtime.fetch.failResponse();
-    var value: c.napi_value = undefined;
-    _ = c.napi_get_undefined(env, &value);
-    return value;
+    var argv: [2]c.napi_value = undefined;
+    const runtime_handle = runtimeHandleArg(env, info, &argv) orelse return null;
+    const fetch_handle = fetch_handle_arg(env, argv[1]) orelse return null;
+    const runtime = lockRuntime(env, runtime_handle) orelse return null;
+    defer unlockRuntime(runtime_handle);
+    return fetch_operation_value(env, runtime.fetch.failResponse(fetch_handle));
 }
 
 fn abortCoreFetch(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
@@ -833,13 +941,14 @@ fn exportFunction(env: c.napi_env, exports: c.napi_value, name: [*:0]const u8, c
 export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) callconv(.c) c.napi_value {
     ensureThreadedIo();
     var api_version: c.napi_value = undefined;
-    if (!statusOk(env, c.napi_create_uint32(env, 1, &api_version), "could not create API version")) return null;
+    if (!statusOk(env, c.napi_create_uint32(env, 2, &api_version), "could not create API version")) return null;
     if (!statusOk(env, c.napi_set_named_property(env, exports, "libfxApiVersion", api_version), "could not export API version")) return null;
     if (!exportFunction(env, exports, "createCore", createCore)) return null;
     if (!exportFunction(env, exports, "writeCore", writeCore)) return null;
     if (!exportFunction(env, exports, "closeCore", closeCore)) return null;
     if (!exportFunction(env, exports, "drainCore", drainCore)) return null;
     if (!exportFunction(env, exports, "takeCoreFetch", takeCoreFetch)) return null;
+    if (!exportFunction(env, exports, "coreFetchActive", coreFetchActive)) return null;
     if (!exportFunction(env, exports, "startCoreFetchResponse", startCoreFetchResponse)) return null;
     if (!exportFunction(env, exports, "pushCoreFetchResponse", pushCoreFetchResponse)) return null;
     if (!exportFunction(env, exports, "finishCoreFetch", finishCoreFetch)) return null;

--- a/src/napi_fetch_state.zig
+++ b/src/napi_fetch_state.zig
@@ -1,0 +1,288 @@
+const std = @import("std");
+
+pub const Handle = i32;
+
+pub const TerminalKind = enum {
+    success,
+    failure,
+    aborted,
+};
+
+pub const Terminal = struct {
+    handle: Handle,
+    kind: TerminalKind,
+};
+
+pub const Phase = union(enum) {
+    idle,
+    cancel_pending,
+    request_pending: Handle,
+    awaiting_response: Handle,
+    streaming: Handle,
+    terminal: Terminal,
+    shutdown,
+};
+
+pub const Event = union(enum) {
+    open: Handle,
+    take_request,
+    start: Handle,
+    push: Handle,
+    finish: Handle,
+    fail: Handle,
+    close: Handle,
+    cancel,
+    shutdown,
+};
+
+pub const Action = enum {
+    applied,
+    stale,
+    no_request,
+    cancelled,
+    unavailable,
+    shutting_down,
+};
+
+pub const StaleReason = enum {
+    no_active_fetch,
+    handle_mismatch,
+    phase_mismatch,
+    terminal,
+    shutdown,
+};
+
+pub const Decision = struct {
+    phase: Phase,
+    action: Action,
+    stale_reason: ?StaleReason = null,
+};
+
+pub fn decide(phase: Phase, event: Event) Decision {
+    return switch (event) {
+        .open => |handle| switch (phase) {
+            .idle => .{
+                .phase = .{ .request_pending = handle },
+                .action = .applied,
+            },
+            .cancel_pending => .{ .phase = .idle, .action = .cancelled },
+            .shutdown => .{ .phase = .shutdown, .action = .shutting_down },
+            else => .{ .phase = phase, .action = .unavailable },
+        },
+        .take_request => switch (phase) {
+            .request_pending => |handle| .{
+                .phase = .{ .awaiting_response = handle },
+                .action = .applied,
+            },
+            .shutdown => .{ .phase = .shutdown, .action = .shutting_down },
+            else => .{ .phase = phase, .action = .no_request },
+        },
+        .start => |handle| switch (phase) {
+            .awaiting_response => |active| if (active == handle)
+                .{ .phase = .{ .streaming = handle }, .action = .applied }
+            else
+                stale(phase, handle),
+            else => stale(phase, handle),
+        },
+        .push => |handle| switch (phase) {
+            .streaming => |active| if (active == handle)
+                .{ .phase = phase, .action = .applied }
+            else
+                stale(phase, handle),
+            else => stale(phase, handle),
+        },
+        .finish => |handle| switch (phase) {
+            .streaming => |active| if (active == handle)
+                .{
+                    .phase = .{ .terminal = .{ .handle = handle, .kind = .success } },
+                    .action = .applied,
+                }
+            else
+                stale(phase, handle),
+            else => stale(phase, handle),
+        },
+        .fail => |handle| switch (phase) {
+            .awaiting_response, .streaming => |active| if (active == handle)
+                .{
+                    .phase = .{ .terminal = .{ .handle = handle, .kind = .failure } },
+                    .action = .applied,
+                }
+            else
+                stale(phase, handle),
+            else => stale(phase, handle),
+        },
+        .close => |handle| switch (phase) {
+            .request_pending, .awaiting_response, .streaming => |active| if (active == handle)
+                .{ .phase = .idle, .action = .applied }
+            else
+                stale(phase, handle),
+            .terminal => |terminal| if (terminal.handle == handle)
+                .{ .phase = .idle, .action = .applied }
+            else
+                stale(phase, handle),
+            else => stale(phase, handle),
+        },
+        .cancel => switch (phase) {
+            .idle => .{ .phase = .cancel_pending, .action = .applied },
+            .request_pending, .awaiting_response, .streaming => |handle| .{
+                .phase = .{ .terminal = .{ .handle = handle, .kind = .aborted } },
+                .action = .applied,
+            },
+            .shutdown => .{ .phase = .shutdown, .action = .shutting_down },
+            else => .{ .phase = phase, .action = .no_request },
+        },
+        .shutdown => switch (phase) {
+            .shutdown => .{ .phase = .shutdown, .action = .no_request },
+            else => .{ .phase = .shutdown, .action = .applied },
+        },
+    };
+}
+
+pub fn is_active(phase: Phase, handle: Handle) bool {
+    return switch (phase) {
+        .request_pending, .awaiting_response, .streaming => |active| active == handle,
+        else => false,
+    };
+}
+
+fn stale(phase: Phase, handle: Handle) Decision {
+    return .{
+        .phase = phase,
+        .action = .stale,
+        .stale_reason = switch (phase) {
+            .idle, .cancel_pending => .no_active_fetch,
+            .shutdown => .shutdown,
+            .terminal => |terminal| if (terminal.handle == handle) .terminal else .handle_mismatch,
+            .request_pending, .awaiting_response, .streaming => |active| if (active == handle)
+                .phase_mismatch
+            else
+                .handle_mismatch,
+        },
+    };
+}
+
+fn expectDecision(expected: Decision, actual: Decision) !void {
+    try std.testing.expectEqualDeep(expected, actual);
+}
+
+test "N-API fetch state applies matching lifecycle transitions" {
+    const handle: Handle = 7;
+    const opened = decide(.idle, .{ .open = handle });
+    try expectDecision(.{
+        .phase = .{ .request_pending = handle },
+        .action = .applied,
+    }, opened);
+
+    const taken = decide(opened.phase, .take_request);
+    try expectDecision(.{
+        .phase = .{ .awaiting_response = handle },
+        .action = .applied,
+    }, taken);
+
+    const started = decide(taken.phase, .{ .start = handle });
+    try expectDecision(.{
+        .phase = .{ .streaming = handle },
+        .action = .applied,
+    }, started);
+    try std.testing.expect(is_active(started.phase, handle));
+
+    const pushed = decide(started.phase, .{ .push = handle });
+    try expectDecision(.{
+        .phase = .{ .streaming = handle },
+        .action = .applied,
+    }, pushed);
+
+    const finished = decide(pushed.phase, .{ .finish = handle });
+    try expectDecision(.{
+        .phase = .{ .terminal = .{ .handle = handle, .kind = .success } },
+        .action = .applied,
+    }, finished);
+    try std.testing.expect(!is_active(finished.phase, handle));
+
+    const closed = decide(finished.phase, .{ .close = handle });
+    try expectDecision(.{ .phase = .idle, .action = .applied }, closed);
+}
+
+test "N-API fetch state keeps stale operations inert" {
+    const active: Phase = .{ .streaming = 11 };
+    inline for (.{
+        Event{ .push = 12 },
+        Event{ .finish = 12 },
+        Event{ .fail = 12 },
+        Event{ .close = 12 },
+    }) |event| {
+        try expectDecision(.{
+            .phase = active,
+            .action = .stale,
+            .stale_reason = .handle_mismatch,
+        }, decide(active, event));
+    }
+
+    const terminal: Phase = .{ .terminal = .{ .handle = 11, .kind = .success } };
+    inline for (.{
+        Event{ .push = 11 },
+        Event{ .finish = 11 },
+        Event{ .fail = 11 },
+    }) |event| {
+        try expectDecision(.{
+            .phase = terminal,
+            .action = .stale,
+            .stale_reason = .terminal,
+        }, decide(terminal, event));
+    }
+
+    try expectDecision(.{
+        .phase = .idle,
+        .action = .stale,
+        .stale_reason = .no_active_fetch,
+    }, decide(.idle, .{ .close = 11 }));
+}
+
+test "N-API fetch state handles failure cancellation and shutdown" {
+    const handle: Handle = 19;
+    const awaiting: Phase = .{ .awaiting_response = handle };
+    try expectDecision(.{
+        .phase = .{ .terminal = .{ .handle = handle, .kind = .failure } },
+        .action = .applied,
+    }, decide(awaiting, .{ .fail = handle }));
+
+    const cancelled = decide(awaiting, .cancel);
+    try expectDecision(.{
+        .phase = .{ .terminal = .{ .handle = handle, .kind = .aborted } },
+        .action = .applied,
+    }, cancelled);
+    try std.testing.expect(!is_active(cancelled.phase, handle));
+
+    const pending_cancel = decide(.idle, .cancel);
+    try expectDecision(.{ .phase = .cancel_pending, .action = .applied }, pending_cancel);
+    try expectDecision(.{ .phase = .idle, .action = .cancelled }, decide(
+        pending_cancel.phase,
+        .{ .open = 20 },
+    ));
+
+    const stopped = decide(.{ .request_pending = handle }, .shutdown);
+    try expectDecision(.{ .phase = .shutdown, .action = .applied }, stopped);
+    inline for (.{ Event{ .open = 20 }, Event.take_request, Event.cancel }) |event| {
+        try expectDecision(.{
+            .phase = .shutdown,
+            .action = .shutting_down,
+        }, decide(.shutdown, event));
+    }
+    inline for (.{
+        Event{ .start = handle },
+        Event{ .push = handle },
+        Event{ .finish = handle },
+        Event{ .fail = handle },
+        Event{ .close = handle },
+    }) |event| {
+        try expectDecision(.{
+            .phase = .shutdown,
+            .action = .stale,
+            .stale_reason = .shutdown,
+        }, decide(.shutdown, event));
+    }
+    try expectDecision(.{
+        .phase = .shutdown,
+        .action = .no_request,
+    }, decide(.shutdown, .shutdown));
+}


### PR DESCRIPTION
## Summary

- Keep native sessions reusable when a Gateway response finishes before a delayed `[DONE]` tail or EOF.
- Abort the matching Node fetch when the native consumer closes and leave newer requests untouched by stale callbacks.
- Reject missing or incompatible low-level addon ABI versions before native runtime creation.
- Emit payload-free stale-fetch diagnostics through the existing trace settings.