### PR TITLE
Stabilize terminal and TUI CI races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - optimize: Debug
-            test_timeout_seconds: 300
+            test_timeout_seconds: 600
           - optimize: ReleaseSafe
             test_timeout_seconds: 900
     steps:
@@ -45,7 +45,10 @@ jobs:
       - name: Test
         env:
           TEST_TIMEOUT_SECONDS: ${{ matrix.test_timeout_seconds }}
-        run: timeout "${TEST_TIMEOUT_SECONDS}s" zig build test -Doptimize=${{ matrix.optimize }}
+        run: |
+          started_at=$SECONDS
+          trap 'printf "Unit tests elapsed: %ss\n" "$((SECONDS - started_at))"' EXIT
+          timeout "${TEST_TIMEOUT_SECONDS}s" zig build test -Doptimize=${{ matrix.optimize }}
 
   zig:
     name: Build & Test

--- a/src/core/terminal/tmux_session.zig
+++ b/src/core/terminal/tmux_session.zig
@@ -28,6 +28,7 @@ const control_nonce_len: usize = 32;
 const marker_frame_len: usize = control_nonce_len + 1;
 const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
 const poll_ns: u64 = 5 * std.time.ns_per_ms;
+const cleanup_settle_deadline_ms: i64 = 500;
 const capture_accept_deadline_ms: i64 = 2_000;
 pub const marker_acknowledgement_timeout_ms: i64 = 15_000;
 const marker_acknowledgement_delivery_margin_ms: i64 = 1_000;
@@ -895,7 +896,7 @@ fn cleanupOwnedNamespaceWithEvidence(
             "-t",
             paths.session_name,
         }) catch |err| {
-            requireOwnedNamespaceAbsent(
+            waitForOwnedNamespaceAbsent(
                 alloc,
                 process_provider,
                 paths,
@@ -911,7 +912,7 @@ fn cleanupOwnedNamespaceWithEvidence(
                 },
             };
         };
-        requireOwnedNamespaceAbsent(
+        waitForOwnedNamespaceAbsent(
             alloc,
             process_provider,
             paths,
@@ -921,7 +922,7 @@ fn cleanupOwnedNamespaceWithEvidence(
             return err;
         };
     } else {
-        requireOwnedNamespaceAbsent(
+        waitForOwnedNamespaceAbsent(
             alloc,
             process_provider,
             paths,
@@ -1784,6 +1785,33 @@ fn requireOwnedNamespaceAbsent(
     try requireSavedPaneProcessAbsent(alloc, process_provider, evidence);
 }
 
+fn waitForOwnedNamespaceAbsent(
+    alloc: Allocator,
+    process_provider: background_process_provider.Provider,
+    paths: *const Paths,
+    evidence: OwnerEvidence,
+) !void {
+    const started_at = io_mod.milliTimestamp();
+    while (true) {
+        requireOwnedNamespaceAbsent(
+            alloc,
+            process_provider,
+            paths,
+            evidence,
+        ) catch |err| switch (err) {
+            error.TmuxCleanupIncomplete => {
+                if (io_mod.milliTimestamp() - started_at >= cleanup_settle_deadline_ms) {
+                    return err;
+                }
+                io_mod.sleep(poll_ns);
+                continue;
+            },
+            else => return err,
+        };
+        return;
+    }
+}
+
 fn writeLauncherConfig(
     alloc: Allocator,
     path: []const u8,
@@ -2473,6 +2501,8 @@ test "checked tmux cleanup requires saved process absence without a socket" {
     const alloc = std.testing.allocator;
     const MatchStub = struct {
         result: process_supervisor.TokenMatch,
+        matches_before_result: usize = 0,
+        match_calls: usize = 0,
 
         fn match(
             raw: ?*anyopaque,
@@ -2481,6 +2511,11 @@ test "checked tmux cleanup requires saved process absence without a socket" {
             _: process_supervisor.ProcessInstanceToken,
         ) process_supervisor.TokenMatch {
             const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.match_calls += 1;
+            if (self.matches_before_result > 0) {
+                self.matches_before_result -= 1;
+                return .matched;
+            }
             return self.result;
         }
     };
@@ -2614,6 +2649,8 @@ test "checked tmux cleanup requires saved process absence without a socket" {
         ),
     );
     stub.result = .missing;
+    stub.matches_before_result = 2;
+    const settling_match_calls = stub.match_calls;
     try cleanupOwnedNamespaceChecked(
         alloc,
         provider,
@@ -2621,6 +2658,10 @@ test "checked tmux cleanup requires saved process absence without a socket" {
         transport_root,
         identity,
         recovered_identity,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 3),
+        stub.match_calls - settling_match_calls,
     );
 }
 

--- a/tests/e2e/terminal-host.test.ts
+++ b/tests/e2e/terminal-host.test.ts
@@ -1348,19 +1348,16 @@ async function forceCloseTerminalFixture(
   correlation: number,
   sessionId: string,
 ): Promise<void> {
-  let frame: WireFrame | undefined;
-  for (let attempt = 0; attempt < 2; attempt++) {
-    frame = await requestAction(
+  success(
+    await requestAction(
       client,
       revision,
-      correlation + attempt * 10_000,
+      correlation,
       "close",
       { session_id: sessionId, policy: "force" },
-    );
-    if (failureCode(frame) !== "invalid_request" || attempt === 1) break;
-    await Bun.sleep(100);
-  }
-  success(frame!, "close");
+    ),
+    "close",
+  );
 }
 
 type StartedFixtureCleanup = {

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -989,10 +989,6 @@ tmuxTest(
       expect(body).not.toContain(siblingRule);
       expect(body.indexOf(rootRule)).toBeLessThan(body.indexOf(nestedRule));
     };
-    const hasAttachedImage = (pane: string) =>
-      pane.split("\n").some((line) =>
-        isComposerLine(line) && line.includes("[Image 1]")
-      );
     const localGateway = startFakeGateway(
       [
         fakeGatewayFinalText("IMAGE_TYPED_OK"),
@@ -1040,7 +1036,10 @@ tmuxTest(
     expectScopedContext(localGateway.requests[0]!.body);
 
     await active.pasteText(scopedImage);
-    await active.waitForPane(hasAttachedImage, READY_TIMEOUT);
+    await waitForActiveFooter(
+      active,
+      (footer) => footer.includes("[Image 2]"),
+    );
     await active.sendKeys("Enter");
     await active.waitForPane(
       (pane) => pane.includes("IMAGE_PASTED_OK") && hasEmptyComposer(pane),
@@ -1053,7 +1052,10 @@ tmuxTest(
 
     await typeLiteral(active, `/image ${scopedImage}`);
     await active.sendKeys("Enter");
-    await active.waitForPane(hasAttachedImage, READY_TIMEOUT);
+    await waitForActiveFooter(
+      active,
+      (footer) => footer.includes("[Image 3]"),
+    );
     expect(localGateway.requests).toHaveLength(2);
     await typeLiteral(active, " describe via command");
     await active.sendKeys("Enter");


### PR DESCRIPTION
## Summary

- wait for the active composer footer and exact image count in the TUI paste test
- allow bounded settling after ownership-safe tmux cleanup
- keep terminal fixture closure strict instead of masking teardown races with a retry
- raise the Debug unit-test ceiling to 600 seconds and print elapsed time

## Why

The image assertion scanned the whole pane, so stale transcript text could satisfy it before the active composer updated. Separately, `tmux kill-session` may return before the pane disappears, while cleanup immediately asserted absence. The Debug suite's 300-second ceiling was also too close to its normal runtime (about 244 seconds), making shared-runner variance disproportionately costly.

## Impact

This does not weaken paste safety or terminal ownership checks. It absorbs only the expected process-teardown delay, keeps ambiguous identity and ownership failures intact, and makes the CI gate less sensitive to normal timing variance.

## Verification

- `zig build`
- `zig build test -Doptimize=Debug` with the bundled Zig toolchain on `PATH` (8,136 passed, 1 skipped)
- `zig build -Doptimize=ReleaseSafe`
- `zig fmt --check src/`
- focused TUI image test: 10 consecutive passes
- terminal recovery tests: 3 consecutive passes together
- fresh ReleaseSafe binary smoke: `fx help` and `fx status --json`
- workflow YAML parse and `git diff --check`

GitHub Full CI will validate the pushed commit in the runner environment.
