### PR TITLE
Harden MCP authentication, reloads, and tool calls

### DIFF
--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -10,6 +10,7 @@ const mcp_runtime = @import("../core/mcp/mcp_runtime.zig");
 const elicitation = @import("../core/mcp/elicitation.zig");
 const streamable_http = @import("../core/mcp/streamable_http.zig");
 const profile_paths = @import("../core/shared/profile_paths.zig");
+const text_utils = @import("../core/shared/text_utils.zig");
 
 const Allocator = std.mem.Allocator;
 const CommandRequest = command_provider_contract.Request;
@@ -29,7 +30,16 @@ pub const command_provider = command_provider_contract.Provider{ .handle_fn = ha
 
 fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandRequest) !CommandResult {
     const trimmed = std.mem.trim(u8, rest, " \t");
-    if (trimmed.len == 0 or std.mem.eql(u8, trimmed, "list")) {
+    if (trimmed.len == 0) {
+        const summarize = command_request.summarize_servers orelse
+            command_request.list_servers_and_tools;
+        return .{
+            .display = .{
+                .block = try summarize(command_request.list_ctx, alloc),
+            },
+        };
+    }
+    if (std.mem.eql(u8, trimmed, "list")) {
         return .{
             .display = .{
                 .block = try command_request.list_servers_and_tools(command_request.list_ctx, alloc),
@@ -98,14 +108,29 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
                 "Interactive MCP authentication is unavailable here.",
                 false,
             );
-        authenticate(command_request.auth_ctx orelse command_request.list_ctx, name) catch |err| {
+        var authentication = authenticate(
+            command_request.auth_ctx orelse command_request.list_ctx,
+            name,
+        ) catch |err| {
             return lineParts(
                 alloc,
                 &.{ "MCP authentication for '", name, "' failed: ", @errorName(err), "." },
                 false,
             );
         };
-        return lineParts(alloc, &.{ "Authenticated MCP server '", name, "'." }, true);
+        defer authentication.deinit();
+        return switch (authentication) {
+            .authenticated => lineParts(
+                alloc,
+                &.{ "Authenticated MCP server '", name, "'." },
+                true,
+            ),
+            .issuer_mismatch => |mismatch| issuerMismatchResult(
+                alloc,
+                name,
+                mismatch,
+            ),
+        };
     }
 
     if (std.mem.startsWith(u8, trimmed, "logout ")) {
@@ -302,6 +327,28 @@ fn lineLiteral(alloc: Allocator, text: []const u8, reload: bool) !CommandResult 
 // string splice.
 fn lineParts(alloc: Allocator, parts: []const []const u8, reload: bool) !CommandResult {
     return .{ .display = .{ .line = try std.mem.concat(alloc, u8, parts) }, .reload = reload };
+}
+
+fn issuerMismatchResult(
+    alloc: Allocator,
+    server_name: []const u8,
+    mismatch: mcp_auth.IssuerMismatch,
+) !CommandResult {
+    var expected = try text_utils.encodeTerminalSafe(alloc, mismatch.expected, 1024);
+    defer expected.deinit(alloc);
+    var returned = try text_utils.encodeTerminalSafe(alloc, mismatch.returned, 1024);
+    defer returned.deinit(alloc);
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.print("MCP authentication for '{s}' was rejected: expected issuer ", .{server_name});
+    try std.json.Stringify.value(expected.bytes, .{}, &out.writer);
+    try out.writer.writeAll(" but metadata returned ");
+    try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
+    try out.writer.writeAll(". Add \"oauth\":{\"issuer\":");
+    try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
+    try out.writer.writeAll("} to this server's entry in ~/.fx/mcp.json and retry.");
+    return .{ .display = .{ .line = try out.toOwnedSlice() } };
 }
 
 pub fn configPathFromHome(alloc: Allocator, home: []const u8) ![]u8 {
@@ -1171,11 +1218,18 @@ const TestHome = struct {
 const ListFixture = struct {
     text: []const u8,
     calls: usize = 0,
+    summary_calls: usize = 0,
 
     fn list(raw_ctx: *anyopaque, alloc: Allocator) ![]u8 {
         const self: *ListFixture = @ptrCast(@alignCast(raw_ctx));
         self.calls += 1;
         return alloc.dupe(u8, self.text);
+    }
+
+    fn summary(raw_ctx: *anyopaque, alloc: Allocator) ![]u8 {
+        const self: *ListFixture = @ptrCast(@alignCast(raw_ctx));
+        self.summary_calls += 1;
+        return alloc.dupe(u8, "MCP: no servers configured. Use /mcp add <name> <command> [args...].");
     }
 };
 
@@ -1183,6 +1237,7 @@ fn request(home: ?[]const u8, fixture: *ListFixture) CommandRequest {
     return .{
         .home = home,
         .list_ctx = @ptrCast(fixture),
+        .summarize_servers = ListFixture.summary,
         .list_servers_and_tools = ListFixture.list,
     };
 }
@@ -1452,9 +1507,18 @@ test "built-in MCP command handles list path and reload requests" {
 
     var list_result = try handleCommand(alloc, "", request(null, &fixture));
     defer list_result.deinit(alloc);
-    try expectBlock(list_result, "No MCP servers configured.\n");
-    try std.testing.expectEqual(@as(usize, 1), fixture.calls);
+    try expectBlock(
+        list_result,
+        "MCP: no servers configured. Use /mcp add <name> <command> [args...].",
+    );
+    try std.testing.expectEqual(@as(usize, 1), fixture.summary_calls);
+    try std.testing.expectEqual(@as(usize, 0), fixture.calls);
     try std.testing.expect(!list_result.reload);
+
+    var details = try handleCommand(alloc, "list", request(null, &fixture));
+    defer details.deinit(alloc);
+    try expectBlock(details, "No MCP servers configured.\n");
+    try std.testing.expectEqual(@as(usize, 1), fixture.calls);
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1622,10 +1686,22 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
             return alloc.dupe(u8, "");
         }
 
-        fn authenticate(raw: *anyopaque, name: []const u8) !void {
+        fn authenticate(
+            raw: *anyopaque,
+            name: []const u8,
+        ) !mcp_auth.AuthenticationResult {
             const self: *@This() = @ptrCast(@alignCast(raw));
+            if (std.mem.eql(u8, name, "mismatch")) {
+                self.auth_calls += 1;
+                return .{ .issuer_mismatch = try mcp_auth.IssuerMismatch.init(
+                    std.testing.allocator,
+                    "https://signin.auth.plain.com/",
+                    "https://signin.auth.plain.com",
+                ) };
+            }
             try std.testing.expectEqualStrings("remote", name);
             self.auth_calls += 1;
+            return .authenticated;
         }
 
         fn validate(raw: *anyopaque, name: []const u8) !void {
@@ -1634,7 +1710,9 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
             if (std.mem.eql(u8, name, "local")) {
                 return error.McpAuthenticationNotRemote;
             }
-            try std.testing.expectEqualStrings("remote", name);
+            if (!std.mem.eql(u8, name, "mismatch")) {
+                try std.testing.expectEqualStrings("remote", name);
+            }
         }
 
         fn logout(
@@ -1679,6 +1757,20 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
     try std.testing.expectEqual(@as(usize, 2), fixture.validation_calls);
     try std.testing.expectEqual(@as(usize, 1), fixture.auth_calls);
 
+    var mismatch = try handleCommand(
+        alloc,
+        "auth mismatch --open",
+        command_request,
+    );
+    defer mismatch.deinit(alloc);
+    try expectLine(
+        mismatch,
+        "MCP authentication for 'mismatch' was rejected: expected issuer \"https://signin.auth.plain.com/\" but metadata returned \"https://signin.auth.plain.com\". Add \"oauth\":{\"issuer\":\"https://signin.auth.plain.com\"} to this server's entry in ~/.fx/mcp.json and retry.",
+        false,
+    );
+    try std.testing.expectEqual(@as(usize, 3), fixture.validation_calls);
+    try std.testing.expectEqual(@as(usize, 2), fixture.auth_calls);
+
     var local = try handleCommand(alloc, "auth local", command_request);
     defer local.deinit(alloc);
     try expectLine(
@@ -1686,8 +1778,8 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
         "MCP authentication for 'local' failed: McpAuthenticationNotRemote.",
         false,
     );
-    try std.testing.expectEqual(@as(usize, 3), fixture.validation_calls);
-    try std.testing.expectEqual(@as(usize, 1), fixture.auth_calls);
+    try std.testing.expectEqual(@as(usize, 4), fixture.validation_calls);
+    try std.testing.expectEqual(@as(usize, 2), fixture.auth_calls);
 
     var logged_out = try handleCommand(alloc, "logout remote", command_request);
     defer logged_out.deinit(alloc);

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4468,6 +4468,15 @@ fn processQueuedPromptLoop(
                         finish_trace.finish("interrupted");
                         return;
                     }
+                    if (try runtime_tool_admission.repeatedDynamicMcpFailure(
+                        arena,
+                        within_turn_suffix.items,
+                        parallel_call,
+                        advertised_dynamic_tool_names,
+                    )) |failure| {
+                        precomputed_results[group_index] = failure;
+                        continue;
+                    }
                     if (preparation_batch.preparations[tool_call_index + group_index]) |preparation| {
                         switch (preparation) {
                             .candidate => |candidate| {
@@ -5183,6 +5192,59 @@ fn processQueuedPromptLoop(
                         continue;
                     },
                 }
+            }
+            if (try runtime_tool_admission.repeatedDynamicMcpFailure(
+                arena,
+                within_turn_suffix.items,
+                tool_call,
+                advertised_dynamic_tool_names,
+            )) |execution| {
+                const prepared = try runtime_execution_memory.prepareToolModelOutput(
+                    arena,
+                    config,
+                    tool_call,
+                    execution.model_output,
+                );
+                const safe_tool_output = prepared.model_output;
+                _ = try stream_ctx.provisional_statuses.finishExecutedCall(
+                    deps,
+                    stream_ctx.alloc,
+                    arena,
+                    turn_id,
+                    tool_call,
+                    false,
+                    null,
+                    execution,
+                    safe_tool_output,
+                    prepared.memory,
+                    null,
+                    advertised_dynamic_tool_names,
+                );
+                try runtime_tool_admission.recordRejectedToolCall(
+                    deps,
+                    arena,
+                    tool_call,
+                    safe_tool_output,
+                    null,
+                );
+                debug_trace.eventf(
+                    "tool",
+                    "execution_result",
+                    step_ctx,
+                    "call_id={s} name={s} result_kind=repeated_mcp_failure model_output_bytes={d}",
+                    .{ tool_call.id, tool_call.name, safe_tool_output.len },
+                );
+                try runtime_tool_batch.appendToolResultContent(
+                    arena,
+                    &within_turn_suffix,
+                    &completed_tool_names,
+                    &step_batch,
+                    tool_call,
+                    safe_tool_output,
+                    prepared.memory,
+                    .{ .increment_error = true },
+                );
+                continue;
             }
             const requires_legacy_classification = if (preparation_batch.preparations[tool_call_index]) |preparation|
                 switch (preparation) {

--- a/src/core/agent/runtime/tool_admission.zig
+++ b/src/core/agent/runtime/tool_admission.zig
@@ -289,6 +289,274 @@ pub fn retainSessionGrant(hooks: *const AgentRuntimeDeps, arena: Allocator, loca
     try propagateGrant(hooks, grant);
 }
 
+pub fn repeatedDynamicMcpFailure(
+    arena: Allocator,
+    current_turn_messages: []const types.ChatMessage,
+    call: ToolCall,
+    advertised_dynamic_tool_names: []const []const u8,
+) !?ToolExecutionResult {
+    if (!containsName(advertised_dynamic_tool_names, call.name)) return null;
+    if (!try hasTwoEquivalentDynamicMcpFailures(
+        arena,
+        current_turn_messages,
+        call,
+    )) return null;
+    return .{
+        .status = .failure,
+        .model_output = try arena.dupe(
+            u8,
+            "Repeated MCP tool call blocked: two equivalent attempts failed. Change the top-level argument structure, reselect the tool, ask the user, or stop.",
+        ),
+    };
+}
+
+fn hasTwoEquivalentDynamicMcpFailures(
+    arena: Allocator,
+    messages: []const types.ChatMessage,
+    current_call: ToolCall,
+) !bool {
+    var matching_failures: usize = 0;
+    var batch_end = messages.len;
+    while (batch_end > 0) {
+        var assistant_index = batch_end;
+        var found_assistant = false;
+        while (assistant_index > 0) {
+            assistant_index -= 1;
+            if (messages[assistant_index].role == .assistant) {
+                found_assistant = true;
+                break;
+            }
+        }
+        if (!found_assistant) return false;
+
+        const calls = messages[assistant_index].tool_calls;
+        const results = messages[assistant_index + 1 .. batch_end];
+        var completed_calls: usize = 0;
+        var matching_in_batch: usize = 0;
+        var target_completed = false;
+        for (calls) |prior_call| {
+            const status = completedResultStatus(results, prior_call) orelse continue;
+            completed_calls += 1;
+            if (std.mem.eql(u8, prior_call.name, "mcp_select_tool") and
+                status == .success)
+            {
+                return false;
+            }
+            if (!std.mem.eql(u8, prior_call.name, current_call.name)) continue;
+            target_completed = true;
+            if (status != .failure or
+                !try sameTopLevelArgumentShape(
+                    arena,
+                    prior_call.arguments_json,
+                    current_call.arguments_json,
+                ))
+            {
+                return false;
+            }
+            matching_in_batch += 1;
+        }
+        if (target_completed) {
+            matching_failures += matching_in_batch;
+            if (matching_failures >= 2) return true;
+        } else if (completed_calls > 0) {
+            return false;
+        }
+        batch_end = assistant_index;
+    }
+    return false;
+}
+
+fn completedResultStatus(
+    messages: []const types.ChatMessage,
+    call: ToolCall,
+) ?types.PersistedToolStatus {
+    var matched: ?types.PersistedToolStatus = null;
+    for (messages) |message| {
+        if (message.role != .tool) continue;
+        const call_id = message.tool_call_id orelse continue;
+        if (!std.mem.eql(u8, call_id, call.id)) continue;
+        if (matched != null or
+            message.tool_name == null or
+            !std.mem.eql(u8, message.tool_name.?, call.name) or
+            message.tool_result_status == null)
+        {
+            return null;
+        }
+        matched = message.tool_result_status.?;
+    }
+    return matched;
+}
+
+fn sameTopLevelArgumentShape(
+    alloc: Allocator,
+    left_json: []const u8,
+    right_json: []const u8,
+) Allocator.Error!bool {
+    var left = try parseArgumentValue(alloc, left_json);
+    defer if (left) |*parsed| parsed.deinit();
+    var right = try parseArgumentValue(alloc, right_json);
+    defer if (right) |*parsed| parsed.deinit();
+    if (left == null or right == null) return left == null and right == null;
+
+    const left_value = left.?.value;
+    const right_value = right.?.value;
+    if (std.meta.activeTag(left_value) != std.meta.activeTag(right_value)) return false;
+    if (left_value != .object) return true;
+    if (left_value.object.count() != right_value.object.count()) return false;
+    var fields = left_value.object.iterator();
+    while (fields.next()) |field| {
+        const right_field = right_value.object.get(field.key_ptr.*) orelse return false;
+        if (std.meta.activeTag(field.value_ptr.*) != std.meta.activeTag(right_field)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+fn parseArgumentValue(
+    alloc: Allocator,
+    bytes: []const u8,
+) Allocator.Error!?std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch |err| switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => null,
+    };
+}
+
+fn containsName(values: []const []const u8, needle: []const u8) bool {
+    for (values) |value| {
+        if (std.mem.eql(u8, value, needle)) return true;
+    }
+    return false;
+}
+
+test "third equivalent dynamic MCP failure is blocked from existing turn history" {
+    const first_calls = [_]ToolCall{.{
+        .id = "call-1",
+        .name = "mcp_plain_getThreads",
+        .arguments_json = "{\"customerId\":\"\",\"labels\":[]}",
+    }};
+    const second_calls = [_]ToolCall{.{
+        .id = "call-2",
+        .name = "mcp_plain_getThreads",
+        .arguments_json = "{\"customerId\":\"placeholder\",\"labels\":[\"fake\"]}",
+    }};
+    const messages = [_]types.ChatMessage{
+        .{ .role = .assistant, .tool_calls = &first_calls },
+        .{ .role = .tool, .tool_call_id = "call-1", .tool_name = "mcp_plain_getThreads", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &second_calls },
+        .{ .role = .tool, .tool_call_id = "call-2", .tool_name = "mcp_plain_getThreads", .tool_result_status = .failure },
+    };
+    const advertised = [_][]const u8{"mcp_plain_getThreads"};
+    const current = ToolCall{
+        .id = "call-3",
+        .name = "mcp_plain_getThreads",
+        .arguments_json = "{\"labels\":[\"another\"],\"customerId\":\"invented\"}",
+    };
+
+    const blocked = (try repeatedDynamicMcpFailure(
+        std.testing.allocator,
+        &messages,
+        current,
+        &advertised,
+    )) orelse return error.TestExpectedEqual;
+    defer std.testing.allocator.free(blocked.model_output);
+    try std.testing.expectEqual(runtime_tool_contracts.ToolExecutionStatus.failure, blocked.status);
+    try std.testing.expect(std.mem.find(u8, blocked.model_output, "two equivalent attempts") != null);
+}
+
+test "dynamic MCP retry containment resets on success shape tool and reselection" {
+    const failures = [_]ToolCall{
+        .{ .id = "failure-1", .name = "mcp_plain_getThreads", .arguments_json = "{\"id\":\"one\"}" },
+        .{ .id = "failure-2", .name = "mcp_plain_getThreads", .arguments_json = "{\"id\":\"two\"}" },
+    };
+    const other = [_]ToolCall{.{ .id = "other", .name = "read_file", .arguments_json = "{}" }};
+    const reselect = [_]ToolCall{.{ .id = "select", .name = "mcp_select_tool", .arguments_json = "{\"name\":\"mcp_plain_getThreads\"}" }};
+    const current = ToolCall{ .id = "current", .name = "mcp_plain_getThreads", .arguments_json = "{\"id\":\"three\"}" };
+    const advertised = [_][]const u8{"mcp_plain_getThreads"};
+
+    const success_messages = [_]types.ChatMessage{
+        .{ .role = .assistant, .tool_calls = failures[0..1] },
+        .{ .role = .tool, .tool_call_id = "failure-1", .tool_name = current.name, .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = failures[1..2] },
+        .{ .role = .tool, .tool_call_id = "failure-2", .tool_name = current.name, .tool_result_status = .success },
+    };
+    try std.testing.expect((try repeatedDynamicMcpFailure(
+        std.testing.allocator,
+        &success_messages,
+        current,
+        &advertised,
+    )) == null);
+
+    const other_messages = [_]types.ChatMessage{
+        .{ .role = .assistant, .tool_calls = &failures },
+        .{ .role = .tool, .tool_call_id = "failure-1", .tool_name = current.name, .tool_result_status = .failure },
+        .{ .role = .tool, .tool_call_id = "failure-2", .tool_name = current.name, .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &other },
+        .{ .role = .tool, .tool_call_id = "other", .tool_name = "read_file", .tool_result_status = .failure },
+    };
+    try std.testing.expect((try repeatedDynamicMcpFailure(
+        std.testing.allocator,
+        &other_messages,
+        current,
+        &advertised,
+    )) == null);
+
+    const reselected_messages = [_]types.ChatMessage{
+        .{ .role = .assistant, .tool_calls = &failures },
+        .{ .role = .tool, .tool_call_id = "failure-1", .tool_name = current.name, .tool_result_status = .failure },
+        .{ .role = .tool, .tool_call_id = "failure-2", .tool_name = current.name, .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &reselect },
+        .{ .role = .tool, .tool_call_id = "select", .tool_name = "mcp_select_tool", .tool_result_status = .success },
+    };
+    try std.testing.expect((try repeatedDynamicMcpFailure(
+        std.testing.allocator,
+        &reselected_messages,
+        current,
+        &advertised,
+    )) == null);
+
+    const changed_shape = ToolCall{ .id = "changed", .name = current.name, .arguments_json = "{\"id\":3}" };
+    try std.testing.expect((try repeatedDynamicMcpFailure(
+        std.testing.allocator,
+        other_messages[0..3],
+        changed_shape,
+        &advertised,
+    )) == null);
+}
+
+test "parallel unrelated results do not reset matching dynamic MCP failures" {
+    const first_batch = [_]ToolCall{
+        .{ .id = "target-1", .name = "mcp_plain_getThreads", .arguments_json = "not-json" },
+        .{ .id = "other-1", .name = "read_file", .arguments_json = "{}" },
+    };
+    const second_batch = [_]ToolCall{.{
+        .id = "target-2",
+        .name = "mcp_plain_getThreads",
+        .arguments_json = "also-not-json",
+    }};
+    const messages = [_]types.ChatMessage{
+        .{ .role = .assistant, .tool_calls = &first_batch },
+        .{ .role = .tool, .tool_call_id = "other-1", .tool_name = "read_file", .tool_result_status = .success },
+        .{ .role = .tool, .tool_call_id = "target-1", .tool_name = "mcp_plain_getThreads", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &second_batch },
+        .{ .role = .tool, .tool_call_id = "target-2", .tool_name = "mcp_plain_getThreads", .tool_result_status = .failure },
+    };
+    const advertised = [_][]const u8{"mcp_plain_getThreads"};
+    const current = ToolCall{
+        .id = "target-3",
+        .name = "mcp_plain_getThreads",
+        .arguments_json = "still-not-json",
+    };
+    const blocked = (try repeatedDynamicMcpFailure(
+        std.testing.allocator,
+        &messages,
+        current,
+        &advertised,
+    )) orelse return error.TestExpectedEqual;
+    defer std.testing.allocator.free(blocked.model_output);
+}
+
 fn appendLocalGrant(arena: Allocator, grants: *std.ArrayList(PermissionGrant), grant: PermissionGrant) !void {
     if (permissions.sessionGrantAllowed(grants.items, grant.tool_name, grant.target_path)) return;
     try grants.append(arena, grant);

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -1001,7 +1001,13 @@ pub fn finishExecutedToolStatus(
                 "Failed",
                 advertised_dynamic_tool_names,
             );
-            const detail = failureStatusDetail(call, result, safe_result) orelse break :blk base;
+            const detail = (try failureStatusDetail(
+                arena,
+                call,
+                result,
+                safe_result,
+                advertised_dynamic_tool_names,
+            )) orelse break :blk base;
             if (detail.len == 0) break :blk base;
             break :blk try std.fmt.allocPrint(arena, "{s}: {s}", .{ base, detail });
         },
@@ -1037,29 +1043,90 @@ pub fn finishExecutedToolStatus(
 }
 
 fn failureStatusDetail(
+    arena: Allocator,
     call: ToolCall,
     result: ToolExecutionResult,
     safe_result: []const u8,
-) ?[]const u8 {
-    const detail = result.status_detail orelse return null;
-    if (!std.mem.eql(u8, detail, "preflight failed") or
-        !file_mutation_contract.isToolName(call.name) or
-        !std.mem.startsWith(u8, safe_result, call.name))
-    {
-        return detail;
+    advertised_dynamic_tool_names: []const []const u8,
+) !?[]const u8 {
+    if (result.status_detail) |detail| {
+        if (!std.mem.eql(u8, detail, "preflight failed") or
+            !file_mutation_contract.isToolName(call.name) or
+            !std.mem.startsWith(u8, safe_result, call.name))
+        {
+            return detail;
+        }
+
+        const failure_prefix = " failed: ";
+        const remainder = safe_result[call.name.len..];
+        if (!std.mem.startsWith(u8, remainder, failure_prefix)) return detail;
+        const actionable = remainder[failure_prefix.len..];
+        if (actionable.len == 0 or
+            std.mem.findScalar(u8, actionable, '\n') != null or
+            std.mem.findScalar(u8, actionable, '\r') != null)
+        {
+            return detail;
+        }
+        return actionable;
     }
 
-    const failure_prefix = " failed: ";
-    const remainder = safe_result[call.name.len..];
-    if (!std.mem.startsWith(u8, remainder, failure_prefix)) return detail;
-    const actionable = remainder[failure_prefix.len..];
-    if (actionable.len == 0 or
-        std.mem.findScalar(u8, actionable, '\n') != null or
-        std.mem.findScalar(u8, actionable, '\r') != null)
+    if (safe_result.len == 0 or
+        !containsName(advertised_dynamic_tool_names, call.name))
     {
-        return detail;
+        return null;
     }
-    return actionable;
+    const detail = try mcpFailureEnvelopeText(arena, safe_result) orelse safe_result;
+    const encoded = try text_utils.encodeTerminalSafe(arena, detail, 256);
+    return if (encoded.bytes.len == 0) null else encoded.bytes;
+}
+
+fn mcpFailureEnvelopeText(
+    arena: Allocator,
+    safe_result: []const u8,
+) Allocator.Error!?[]const u8 {
+    var parsed = std.json.parseFromSlice(
+        std.json.Value,
+        arena,
+        safe_result,
+        .{},
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
+    defer parsed.deinit();
+    const envelope = switch (parsed.value) {
+        .object => |object| object,
+        else => return null,
+    };
+    const payload = envelope.get("result") orelse envelope.get("error") orelse
+        return null;
+    const payload_object = switch (payload) {
+        .object => |object| object,
+        else => return null,
+    };
+    if (payload_object.get("content")) |content| {
+        if (content == .array) {
+            for (content.array.items) |item| {
+                if (item != .object) continue;
+                const text = item.object.get("text") orelse continue;
+                if (text == .string and text.string.len > 0) {
+                    const owned: []const u8 = try arena.dupe(u8, text.string);
+                    return owned;
+                }
+            }
+        }
+    }
+    const message = payload_object.get("message") orelse return null;
+    if (message != .string or message.string.len == 0) return null;
+    const owned: []const u8 = try arena.dupe(u8, message.string);
+    return owned;
+}
+
+fn containsName(values: []const []const u8, needle: []const u8) bool {
+    for (values) |value| {
+        if (std.mem.eql(u8, value, needle)) return true;
+    }
+    return false;
 }
 
 fn commandArtifactHandle(
@@ -1875,6 +1942,45 @@ test "file edit preflight failure reports the exact mismatch" {
     try std.testing.expectEqual(types.ToolOutcomeKind.failed, terminal.outcome.kind);
     try std.testing.expectEqualStrings(
         "Failed edit_file: old_string not found in file",
+        terminal.outcome.summary,
+    );
+}
+
+test "dynamic MCP failure derives a bounded terminal-safe detail from the safe result" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+    defer capture.deinit();
+    const hooks = capture.hooks();
+    const failure =
+        \\{"server":"plain","tool":"mcp_plain_getThreads","result":{"resultType":"complete","isError":true,"content":[{"type":"text","text":"Invalid input: labels require at least one item\nretry rejected"}]}}
+    ;
+    const advertised = [_][]const u8{"mcp_plain_getThreads"};
+
+    try finishExecutedToolStatus(
+        &hooks,
+        arena,
+        7,
+        .{
+            .id = "plain_failure",
+            .name = "mcp_plain_getThreads",
+            .arguments_json = "{}",
+        },
+        true,
+        null,
+        .{ .status = .failure, .model_output = failure },
+        failure,
+        .{ .output_bytes = failure.len, .stored_output_bytes = failure.len },
+        null,
+        &advertised,
+    );
+
+    const terminal = capture.events.items[0].terminal;
+    try std.testing.expectEqual(types.ToolOutcomeKind.failed, terminal.outcome.kind);
+    try std.testing.expectEqualStrings(
+        "Failed mcp_plain_getThreads: Invalid input: labels require at least one item\\x0aretry rejected",
         terminal.outcome.summary,
     );
 }

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -22,6 +22,7 @@ const output_contracts = @import("../output/output_contracts.zig");
 const diagnostics = @import("../workspace/diagnostics.zig");
 const workspace_commands = @import("../workspace/workspace_commands.zig");
 const image_commands = @import("../images/image_commands.zig");
+const mcp_auth = @import("../mcp/mcp_auth.zig");
 const mcp_command_provider = @import("../mcp/command_provider.zig");
 const mcp_runtime = @import("../mcp/mcp_runtime.zig");
 const app_mcp_runtime = @import("app_mcp_runtime.zig");
@@ -312,6 +313,56 @@ pub fn Handlers(comptime App: type) type {
                 .show_version = commandShowVersion,
                 .unknown = commandUnknown,
             };
+        }
+
+        pub fn collectMcpReloadFacts(app: *App) !void {
+            if (comptime !@hasDecl(App, "takeMcpReloadCompletion")) return;
+            var completion = (try app.takeMcpReloadCompletion()) orelse return;
+            defer completion.deinit(app.alloc);
+            var warning = false;
+            const body = switch (completion) {
+                .outcome => |outcome| switch (outcome) {
+                    .published => |published| if (published.generation) |generation|
+                        try std.fmt.allocPrint(
+                            app.alloc,
+                            "MCP profile reloaded ({s}, runtime {d}).",
+                            .{ @tagName(published.health), generation },
+                        )
+                    else
+                        try std.fmt.allocPrint(
+                            app.alloc,
+                            "MCP profile reloaded ({s}; no servers configured).",
+                            .{@tagName(published.health)},
+                        ),
+                    .retained_required_failure => |failure| retained: {
+                        warning = true;
+                        break :retained try std.fmt.allocPrint(
+                            app.alloc,
+                            "MCP reload rejected; the existing runtime was retained. {s}",
+                            .{failure},
+                        );
+                    },
+                },
+                .failed => |err| failed: {
+                    warning = true;
+                    debug_trace.logf(
+                        "mcp",
+                        "profile reload retained current runtime err={s}",
+                        .{@errorName(err)},
+                    );
+                    break :failed try std.fmt.allocPrint(
+                        app.alloc,
+                        "MCP reload rejected; the existing runtime was retained. Fix the trusted profile configuration ({s}) and retry.",
+                        .{@errorName(err)},
+                    );
+                },
+            };
+            defer app.alloc.free(body);
+            try app.writeDomainNotice(.{
+                .topic = "mcp",
+                .tone = if (warning) .warning else .neutral,
+                .body = body,
+            }, true);
         }
 
         fn handleFeedback(app: *App) !void {
@@ -693,6 +744,7 @@ pub fn Handlers(comptime App: type) type {
             const result = try app.mcpCommandProvider().handle(app.alloc, rest, .{
                 .home = io_mod.getenv("HOME"),
                 .list_ctx = @ptrCast(app),
+                .summarize_servers = summarizeMcpServers,
                 .list_servers_and_tools = listMcpServersAndTools,
                 .auth_ctx = @ptrCast(app),
                 .validate_authentication_server = validateMcpAuthenticationServer,
@@ -716,7 +768,7 @@ pub fn Handlers(comptime App: type) type {
             defer if (reload_notice) |notice| app.alloc.free(notice);
             var reload_warning = false;
             if (result.reload) {
-                var outcome = app.reloadMcp() catch |err| {
+                app.beginMcpReload() catch |err| {
                     reload_warning = true;
                     reload_notice = if (result.report_reload)
                         try std.fmt.allocPrint(
@@ -727,7 +779,7 @@ pub fn Handlers(comptime App: type) type {
                     else
                         try std.fmt.allocPrint(
                             app.alloc,
-                            "{s}\nWarning: MCP runtime reload was rejected; the previous runtime remains active. Fix the trusted profile configuration ({s}) and run /mcp reload.",
+                            "{s}\nMCP reload rejected; the existing runtime was retained. Fix the trusted profile configuration ({s}) and run /mcp reload.",
                             .{ command_body, @errorName(err) },
                         );
                     debug_trace.logf("mcp", "profile reload retained current runtime err={s}", .{@errorName(err)});
@@ -735,41 +787,15 @@ pub fn Handlers(comptime App: type) type {
                     try app.writeDomainNotice(.{ .topic = "mcp", .tone = .warning, .body = notice }, true);
                     return;
                 };
-                defer outcome.deinit(app.alloc);
-                if (result.report_reload) {
-                    reload_notice = switch (outcome) {
-                        .published => |published| if (published.generation) |generation|
-                            try std.fmt.allocPrint(
-                                app.alloc,
-                                "MCP profile reloaded ({s}, runtime {d}).",
-                                .{ @tagName(published.health), generation },
-                            )
-                        else
-                            try std.fmt.allocPrint(
-                                app.alloc,
-                                "MCP profile reloaded ({s}; no servers configured).",
-                                .{@tagName(published.health)},
-                            ),
-                        .retained_required_failure => |failure| retained: {
-                            reload_warning = true;
-                            break :retained try std.fmt.allocPrint(
-                                app.alloc,
-                                "MCP reload rejected; the existing runtime was retained. {s}",
-                                .{failure},
-                            );
-                        },
-                    };
-                } else switch (outcome) {
-                    .published => {},
-                    .retained_required_failure => |failure| {
-                        reload_warning = true;
-                        reload_notice = try std.fmt.allocPrint(
-                            app.alloc,
-                            "{s}\nWarning: MCP runtime reload was rejected; the previous runtime remains active. {s} Fix the trusted profile configuration and run /mcp reload.",
-                            .{ command_body, failure },
-                        );
-                    },
-                }
+                const started = "MCP reconnection started. The existing runtime remains active until replacement completes.";
+                reload_notice = if (result.report_reload)
+                    try app.alloc.dupe(u8, started)
+                else
+                    try std.fmt.allocPrint(
+                        app.alloc,
+                        "{s}\n{s}",
+                        .{ command_body, started },
+                    );
             }
             const body = reload_notice orelse command_body;
             try app.writeDomainNotice(.{
@@ -782,6 +808,11 @@ pub fn Handlers(comptime App: type) type {
         fn listMcpServersAndTools(ctx: *anyopaque, alloc: std.mem.Allocator) ![]u8 {
             const app: *App = @ptrCast(@alignCast(ctx));
             return app.listMcpServersAndTools(alloc);
+        }
+
+        fn summarizeMcpServers(ctx: *anyopaque, alloc: std.mem.Allocator) ![]u8 {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            return app.summarizeMcpServers(alloc);
         }
 
         fn listMcpResources(
@@ -993,7 +1024,10 @@ pub fn Handlers(comptime App: type) type {
             return try out.toOwnedSlice();
         }
 
-        fn authenticateMcpServer(ctx: *anyopaque, name: []const u8) !void {
+        fn authenticateMcpServer(
+            ctx: *anyopaque,
+            name: []const u8,
+        ) !mcp_auth.AuthenticationResult {
             if (comptime !@hasDecl(App, "acquireMcpRuntime") or
                 !@hasDecl(App, "urlOpener"))
             {
@@ -1002,7 +1036,7 @@ pub fn Handlers(comptime App: type) type {
             const app: *App = @ptrCast(@alignCast(ctx));
             var lease = app.acquireMcpRuntime() orelse return error.McpServerNotFound;
             defer lease.deinit();
-            try lease.runtime.authenticateServer(name, app, openMcpAuthUrl);
+            return lease.runtime.authenticateServer(name, app, openMcpAuthUrl);
         }
 
         fn validateMcpAuthenticationServer(ctx: *anyopaque, name: []const u8) !void {
@@ -3306,6 +3340,7 @@ const McpCommandFakeApp = struct {
     last_topic: ?[]const u8 = null,
     last_tone: ?types.NoticeTone = null,
     reload_behavior: ReloadBehavior = .published,
+    reload_pending: bool = false,
 
     fn deinit(self: *McpCommandFakeApp) void {
         self.notice_body.deinit(self.alloc);
@@ -3344,17 +3379,28 @@ const McpCommandFakeApp = struct {
         return alloc.dupe(u8, "configured server and tool\n");
     }
 
-    fn reloadMcp(self: *McpCommandFakeApp) !app_mcp_runtime.ReloadOutcome {
+    fn summarizeMcpServers(self: *McpCommandFakeApp, alloc: std.mem.Allocator) ![]u8 {
+        return self.listMcpServersAndTools(alloc);
+    }
+
+    fn beginMcpReload(self: *McpCommandFakeApp) !void {
         self.reload_count += 1;
+        if (self.reload_behavior == .failed) return error.TestReloadFailed;
+        self.reload_pending = true;
+    }
+
+    fn takeMcpReloadCompletion(self: *McpCommandFakeApp) !?app_mcp_runtime.ReloadCompletion {
+        if (!self.reload_pending) return null;
+        self.reload_pending = false;
         return switch (self.reload_behavior) {
-            .published => .{ .published = .{ .generation = null, .health = .ready } },
-            .retained => .{
+            .published => .{ .outcome = .{ .published = .{ .generation = null, .health = .ready } } },
+            .retained => .{ .outcome = .{
                 .retained_required_failure = try self.alloc.dupe(
                     u8,
                     "Required MCP server 'fixture' failed to start.",
                 ),
-            },
-            .failed => error.TestReloadFailed,
+            } },
+            .failed => unreachable,
         };
     }
 
@@ -4035,9 +4081,16 @@ test "app_commands renders transactional status for explicit MCP reload" {
     try std.testing.expectEqualStrings("mcp", app.last_topic.?);
     try std.testing.expectEqual(types.NoticeTone.neutral, app.last_tone.?);
     try std.testing.expectEqualStrings(
-        "MCP profile reloaded (ready; no servers configured).",
+        "MCP reconnection started. The existing runtime remains active until replacement completes.",
         app.notice_body.items,
     );
+    try Handlers(McpCommandFakeApp).collectMcpReloadFacts(&app);
+    try std.testing.expectEqual(@as(usize, 2), app.notice_count);
+    try std.testing.expect(std.mem.endsWith(
+        u8,
+        app.notice_body.items,
+        "MCP profile reloaded (ready; no servers configured).",
+    ));
 }
 
 test "app_commands preserves command display after implicit MCP reload" {
@@ -4050,7 +4103,12 @@ test "app_commands preserves command display after implicit MCP reload" {
     try std.testing.expectEqual(@as(usize, 1), app.notice_count);
     try std.testing.expectEqualStrings("mcp", app.last_topic.?);
     try std.testing.expectEqual(types.NoticeTone.neutral, app.last_tone.?);
-    try std.testing.expectEqualStrings("Authenticated MCP server 'fixture'.", app.notice_body.items);
+    try std.testing.expectEqualStrings(
+        "Authenticated MCP server 'fixture'.\nMCP reconnection started. The existing runtime remains active until replacement completes.",
+        app.notice_body.items,
+    );
+    try Handlers(McpCommandFakeApp).collectMcpReloadFacts(&app);
+    try std.testing.expectEqual(@as(usize, 2), app.notice_count);
 }
 
 test "app_commands warns when implicit MCP reload retains the active runtime" {
@@ -4066,12 +4124,24 @@ test "app_commands warns when implicit MCP reload retains the active runtime" {
         try std.testing.expectEqual(@as(usize, 1), app.reload_count);
         try std.testing.expectEqual(@as(usize, 1), app.notice_count);
         try std.testing.expectEqualStrings("mcp", app.last_topic.?);
-        try std.testing.expectEqual(types.NoticeTone.warning, app.last_tone.?);
-        try std.testing.expect(std.mem.startsWith(
-            u8,
-            app.notice_body.items,
-            "Authenticated MCP server 'fixture'.\nWarning: MCP runtime reload was rejected; the previous runtime remains active.",
-        ));
+        if (behavior == .retained) {
+            try std.testing.expectEqual(types.NoticeTone.neutral, app.last_tone.?);
+            try Handlers(McpCommandFakeApp).collectMcpReloadFacts(&app);
+            try std.testing.expectEqual(@as(usize, 2), app.notice_count);
+            try std.testing.expectEqual(types.NoticeTone.warning, app.last_tone.?);
+            try std.testing.expect(std.mem.find(
+                u8,
+                app.notice_body.items,
+                "MCP reload rejected; the existing runtime was retained.",
+            ) != null);
+        } else {
+            try std.testing.expectEqual(types.NoticeTone.warning, app.last_tone.?);
+            try std.testing.expect(std.mem.find(
+                u8,
+                app.notice_body.items,
+                "MCP reload rejected; the existing runtime was retained.",
+            ) != null);
+        }
     }
 }
 

--- a/src/core/app/app_mcp_runtime.zig
+++ b/src/core/app/app_mcp_runtime.zig
@@ -39,11 +39,81 @@ pub const ReloadOutcome = union(enum) {
     }
 };
 
+pub const ReloadCompletion = union(enum) {
+    outcome: ReloadOutcome,
+    failed: anyerror,
+
+    pub fn deinit(self: *ReloadCompletion, alloc: Allocator) void {
+        switch (self.*) {
+            .outcome => |*outcome| outcome.deinit(alloc),
+            .failed => {},
+        }
+        self.* = undefined;
+    }
+};
+
+const PendingResult = union(enum) {
+    outcome: ReloadOutcome,
+    failed: anyerror,
+    cancelled,
+};
+
+const PendingReload = struct {
+    owner: *State,
+    alloc: Allocator,
+    elicitation_capabilities: elicitation.Capabilities,
+    loader: mcp_runtime.LoadRuntimeFn,
+    registry: tool_dispatch.Registry,
+    captured_at_ms: u64,
+    cancel_requested: std.atomic.Value(bool) = .init(false),
+    done: std.atomic.Value(bool) = .init(false),
+    thread: ?std.Thread = null,
+    result: ?PendingResult = null,
+
+    fn run(self: *PendingReload) void {
+        const outcome = self.owner.reloadControlled(
+            self.alloc,
+            self.elicitation_capabilities,
+            self.loader,
+            self.registry,
+            self.captured_at_ms,
+            &self.cancel_requested,
+            self,
+        ) catch |err| {
+            self.result = if (err == error.Cancelled)
+                .cancelled
+            else
+                .{ .failed = err };
+            self.done.store(true, .release);
+            return;
+        };
+        self.result = .{ .outcome = outcome };
+        self.done.store(true, .release);
+    }
+
+    fn join(self: *PendingReload) void {
+        if (self.thread) |thread| {
+            self.thread = null;
+            thread.join();
+        }
+    }
+
+    fn deinit(self: *PendingReload) void {
+        self.join();
+        if (self.result) |*result| switch (result.*) {
+            .outcome => |*outcome| outcome.deinit(self.alloc),
+            .failed, .cancelled => {},
+        };
+        self.alloc.destroy(self);
+    }
+};
+
 /// Owns the native profile MCP runtime. All transport work and retirement happen
 /// after releasing this state lock; the lock protects only pointer publication.
 pub const State = struct {
     lock: std.Io.RwLock = .init,
     runtime: ?*mcp_runtime.McpRuntime = null,
+    pending_reload: ?*PendingReload = null,
 
     pub fn installInitial(self: *State, runtime: ?*mcp_runtime.McpRuntime) void {
         std.debug.assert(self.runtime == null);
@@ -152,6 +222,20 @@ pub const State = struct {
         return lease.runtime.listServersAndTools(alloc);
     }
 
+    pub fn renderHealthSummary(self: *State, alloc: Allocator) ![]u8 {
+        var lease = self.acquire() orelse return mcp_health.renderSummary(
+            alloc,
+            .{ .captured_at_ms = 0, .servers = &.{} },
+        );
+        defer lease.deinit();
+        var snapshot = try lease.runtime.snapshotHealth(
+            alloc,
+            @intCast(@max(io_mod.milliTimestamp(), 0)),
+        );
+        defer snapshot.deinit(alloc);
+        return mcp_health.renderSummary(alloc, snapshot);
+    }
+
     pub fn snapshotToolNames(
         self: *State,
         alloc: Allocator,
@@ -202,12 +286,103 @@ pub const State = struct {
         registry: tool_dispatch.Registry,
         captured_at_ms: u64,
     ) !ReloadOutcome {
+        var cancel_requested = std.atomic.Value(bool).init(false);
+        return self.reloadControlled(
+            alloc,
+            elicitation_capabilities,
+            loader,
+            registry,
+            captured_at_ms,
+            &cancel_requested,
+            null,
+        );
+    }
+
+    pub fn beginReload(
+        self: *State,
+        alloc: Allocator,
+        elicitation_capabilities: elicitation.Capabilities,
+        loader: mcp_runtime.LoadRuntimeFn,
+        registry: tool_dispatch.Registry,
+        captured_at_ms: u64,
+    ) !void {
+        self.cancelPendingReload();
+
+        const pending = try alloc.create(PendingReload);
+        pending.* = .{
+            .owner = self,
+            .alloc = alloc,
+            .elicitation_capabilities = elicitation_capabilities,
+            .loader = loader,
+            .registry = registry,
+            .captured_at_ms = captured_at_ms,
+        };
+        self.lock.lockUncancelable(io_mod.getIo());
+        std.debug.assert(self.pending_reload == null);
+        self.pending_reload = pending;
+        self.lock.unlock(io_mod.getIo());
+
+        pending.thread = std.Thread.spawn(.{}, PendingReload.run, .{pending}) catch |err| {
+            self.lock.lockUncancelable(io_mod.getIo());
+            if (self.pending_reload == pending) self.pending_reload = null;
+            self.lock.unlock(io_mod.getIo());
+            alloc.destroy(pending);
+            return err;
+        };
+    }
+
+    pub fn takeReloadCompletion(self: *State) ?ReloadCompletion {
+        self.lock.lockUncancelable(io_mod.getIo());
+        const pending = self.pending_reload orelse {
+            self.lock.unlock(io_mod.getIo());
+            return null;
+        };
+        if (!pending.done.load(.acquire)) {
+            self.lock.unlock(io_mod.getIo());
+            return null;
+        }
+        self.pending_reload = null;
+        self.lock.unlock(io_mod.getIo());
+
+        pending.join();
+        const result = pending.result.?;
+        pending.result = null;
+        pending.alloc.destroy(pending);
+        return switch (result) {
+            .outcome => |outcome| .{ .outcome = outcome },
+            .failed => |err| .{ .failed = err },
+            .cancelled => null,
+        };
+    }
+
+    fn cancelPendingReload(self: *State) void {
+        self.lock.lockUncancelable(io_mod.getIo());
+        const pending = self.pending_reload;
+        if (pending) |task| task.cancel_requested.store(true, .release);
+        self.pending_reload = null;
+        self.lock.unlock(io_mod.getIo());
+        if (pending) |task| task.deinit();
+    }
+
+    fn reloadControlled(
+        self: *State,
+        alloc: Allocator,
+        elicitation_capabilities: elicitation.Capabilities,
+        loader: mcp_runtime.LoadRuntimeFn,
+        registry: tool_dispatch.Registry,
+        captured_at_ms: u64,
+        cancel_requested: *std.atomic.Value(bool),
+        pending: ?*PendingReload,
+    ) !ReloadOutcome {
+        if (cancel_requested.load(.acquire)) return error.Cancelled;
         const candidate = try loader(alloc, elicitation_capabilities);
         var candidate_owned = candidate != null;
         errdefer if (candidate_owned) destroyRuntime(alloc, candidate.?);
+        if (cancel_requested.load(.acquire)) return error.Cancelled;
 
         const decision: mcp_health.StartupDecision = if (candidate) |runtime| decision: {
-            runtime.connectAll(registry);
+            runtime.connectAllCancellable(registry, cancel_requested);
+            if (cancel_requested.load(.acquire)) return error.Cancelled;
             const value = try runtime.startupDecision(alloc, captured_at_ms);
             if (!mcp_health.publishCandidateForDecision(value)) {
                 const failure = (try runtime.requiredStartupFailure(alloc, captured_at_ms)) orelse
@@ -220,6 +395,12 @@ pub const State = struct {
         } else .ready;
 
         self.lock.lockUncancelable(io_mod.getIo());
+        if (cancel_requested.load(.acquire) or
+            (pending != null and self.pending_reload != pending.?))
+        {
+            self.lock.unlock(io_mod.getIo());
+            return error.Cancelled;
+        }
         const previous = self.runtime;
         self.runtime = candidate;
         self.lock.unlock(io_mod.getIo());
@@ -233,6 +414,7 @@ pub const State = struct {
     }
 
     pub fn deinit(self: *State, alloc: Allocator) void {
+        self.cancelPendingReload();
         self.lock.lockUncancelable(io_mod.getIo());
         const previous = self.runtime;
         self.runtime = null;
@@ -270,6 +452,8 @@ const TestReloadMode = enum {
     required_disabled,
     optional_failed,
     empty,
+    delayed_empty,
+    stalled_candidate,
 };
 
 var test_reload_mode: TestReloadMode = .empty;
@@ -281,7 +465,11 @@ fn loadTestReloadRuntime(
     switch (test_reload_mode) {
         .parse_failure => return error.McpConfigInvalidJson,
         .empty => return null,
-        .required_disabled, .optional_failed => {},
+        .delayed_empty => {
+            io_mod.sleep(100 * std.time.ns_per_ms);
+            return null;
+        },
+        .required_disabled, .optional_failed, .stalled_candidate => {},
     }
     const runtime = try alloc.create(mcp_runtime.McpRuntime);
     errdefer alloc.destroy(runtime);
@@ -291,14 +479,34 @@ fn loadTestReloadRuntime(
     errdefer alloc.free(name);
     const command = try alloc.dupe(
         u8,
-        if (test_reload_mode == .optional_failed) "__fx_missing_mcp_executable__" else "disabled",
+        switch (test_reload_mode) {
+            .optional_failed => "__fx_missing_mcp_executable__",
+            .stalled_candidate => "awk",
+            else => "disabled",
+        },
     );
     errdefer alloc.free(command);
+    const args = if (test_reload_mode == .stalled_candidate) args: {
+        const values = try alloc.alloc([]const u8, 1);
+        errdefer alloc.free(values);
+        values[0] = try alloc.dupe(u8, "{}");
+        break :args values;
+    } else &.{};
+    errdefer if (args.len > 0) {
+        for (args) |arg| alloc.free(arg);
+        alloc.free(args);
+    };
     const config = mcp_contract.McpServerConfig{
         .name = name,
         .command = command,
-        .enabled = test_reload_mode == .optional_failed,
+        .args = args,
+        .enabled = test_reload_mode == .optional_failed or
+            test_reload_mode == .stalled_candidate,
         .required = test_reload_mode == .required_disabled,
+        .startup_timeout_ms = if (test_reload_mode == .stalled_candidate)
+            60_000
+        else
+            10_000,
     };
     try runtime.addServer(config);
     return runtime;
@@ -362,4 +570,78 @@ test "transactional reload retains old runtime and publishes only accepted candi
         .retained_required_failure => return error.TestUnexpectedResult,
     }
     try std.testing.expect(state.acquire() == null);
+}
+
+test "pending reload returns immediately and publishes one completion" {
+    const alloc = std.testing.allocator;
+    var state: State = .{};
+    defer state.deinit(alloc);
+    const original = try alloc.create(mcp_runtime.McpRuntime);
+    original.* = mcp_runtime.McpRuntime.init(alloc);
+    const original_generation = original.generation;
+    state.installInitial(original);
+
+    test_reload_mode = .delayed_empty;
+    const started_ms = io_mod.milliTimestamp();
+    try state.beginReload(alloc, .{}, loadTestReloadRuntime, .{}, 50);
+    try std.testing.expect(io_mod.milliTimestamp() - started_ms < 50);
+    {
+        var lease = state.acquire() orelse return error.TestUnexpectedResult;
+        defer lease.deinit();
+        try std.testing.expectEqual(original_generation, lease.runtime.generation);
+    }
+    try std.testing.expect(state.takeReloadCompletion() == null);
+
+    var completion: ?ReloadCompletion = null;
+    const deadline = io_mod.milliTimestamp() + 2_000;
+    while (completion == null and io_mod.milliTimestamp() < deadline) {
+        io_mod.sleep(std.time.ns_per_ms);
+        completion = state.takeReloadCompletion();
+    }
+    var loaded = completion orelse return error.TestUnexpectedResult;
+    defer loaded.deinit(alloc);
+    switch (loaded) {
+        .outcome => |outcome| switch (outcome) {
+            .published => |published| {
+                try std.testing.expectEqual(mcp_health.StartupDecision.ready, published.health);
+                try std.testing.expect(published.generation == null);
+            },
+            .retained_required_failure => return error.TestUnexpectedResult,
+        },
+        .failed => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(state.takeReloadCompletion() == null);
+    try std.testing.expect(state.acquire() == null);
+}
+
+test "superseding and deinitializing a stalled pending reload cancel before join" {
+    const alloc = std.testing.allocator;
+    var state: State = .{};
+    const original = try alloc.create(mcp_runtime.McpRuntime);
+    original.* = mcp_runtime.McpRuntime.init(alloc);
+    state.installInitial(original);
+
+    test_reload_mode = .stalled_candidate;
+    try state.beginReload(alloc, .{}, loadTestReloadRuntime, .{}, 60);
+    io_mod.sleep(25 * std.time.ns_per_ms);
+    test_reload_mode = .empty;
+    const supersede_started_ms = io_mod.milliTimestamp();
+    try state.beginReload(alloc, .{}, loadTestReloadRuntime, .{}, 70);
+    try std.testing.expect(io_mod.milliTimestamp() - supersede_started_ms < 1_000);
+
+    var completion: ?ReloadCompletion = null;
+    const completion_deadline = io_mod.milliTimestamp() + 2_000;
+    while (completion == null and io_mod.milliTimestamp() < completion_deadline) {
+        io_mod.sleep(std.time.ns_per_ms);
+        completion = state.takeReloadCompletion();
+    }
+    var loaded = completion orelse return error.TestUnexpectedResult;
+    loaded.deinit(alloc);
+
+    test_reload_mode = .stalled_candidate;
+    try state.beginReload(alloc, .{}, loadTestReloadRuntime, .{}, 80);
+    io_mod.sleep(25 * std.time.ns_per_ms);
+    const deinit_started_ms = io_mod.milliTimestamp();
+    state.deinit(alloc);
+    try std.testing.expect(io_mod.milliTimestamp() - deinit_started_ms < 1_000);
 }

--- a/src/core/app/app_mcp_runtime.zig
+++ b/src/core/app/app_mcp_runtime.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const io_mod = @import("../shared/io.zig");
 const mcp_access = @import("../mcp/access_policy.zig");
 const mcp_contract = @import("../mcp/mcp_contract.zig");
@@ -92,6 +93,10 @@ const PendingReload = struct {
     }
 
     fn join(self: *PendingReload) void {
+        if (comptime builtin.single_threaded) {
+            std.debug.assert(self.thread == null);
+            return;
+        }
         if (self.thread) |thread| {
             self.thread = null;
             thread.join();
@@ -322,13 +327,17 @@ pub const State = struct {
         self.pending_reload = pending;
         self.lock.unlock(io_mod.getIo());
 
-        pending.thread = std.Thread.spawn(.{}, PendingReload.run, .{pending}) catch |err| {
-            self.lock.lockUncancelable(io_mod.getIo());
-            if (self.pending_reload == pending) self.pending_reload = null;
-            self.lock.unlock(io_mod.getIo());
-            alloc.destroy(pending);
-            return err;
-        };
+        if (comptime builtin.single_threaded) {
+            pending.run();
+        } else {
+            pending.thread = std.Thread.spawn(.{}, PendingReload.run, .{pending}) catch |err| {
+                self.lock.lockUncancelable(io_mod.getIo());
+                if (self.pending_reload == pending) self.pending_reload = null;
+                self.lock.unlock(io_mod.getIo());
+                alloc.destroy(pending);
+                return err;
+            };
+        }
     }
 
     pub fn takeReloadCompletion(self: *State) ?ReloadCompletion {

--- a/src/core/hosts/native_keychain.zig
+++ b/src/core/hosts/native_keychain.zig
@@ -20,6 +20,7 @@ const keychain_process_timeout: std.Io.Timeout = .{
 };
 
 pub const Error = error{
+    Cancelled,
     UnsupportedPlatform,
     UserNotSet,
     KeychainItemNotFound,
@@ -80,7 +81,18 @@ pub fn load(alloc: std.mem.Allocator) !?[]u8 {
 }
 
 pub fn loadMcpCredentials(alloc: std.mem.Allocator) !?[]u8 {
-    return loadMcpValueMac(alloc, mcp_credentials_service_name);
+    return loadMcpValueMacControlled(alloc, mcp_credentials_service_name, null);
+}
+
+pub fn loadMcpCredentialsCancellable(
+    alloc: std.mem.Allocator,
+    cancel_flag: *const std.atomic.Value(bool),
+) !?[]u8 {
+    return loadMcpValueMacControlled(
+        alloc,
+        mcp_credentials_service_name,
+        cancel_flag,
+    );
 }
 
 fn loadFromService(alloc: std.mem.Allocator, service: []const u8) !?[]u8 {
@@ -244,13 +256,31 @@ pub fn storeValue(value: []const u8) Error!void {
 }
 
 pub fn storeMcpCredentials(value: []const u8) Error!void {
+    return storeMcpCredentialsControlled(value, null);
+}
+
+pub fn storeMcpCredentialsCancellable(
+    value: []const u8,
+    cancel_flag: *const std.atomic.Value(bool),
+) Error!void {
+    return storeMcpCredentialsControlled(value, cancel_flag);
+}
+
+fn storeMcpCredentialsControlled(
+    value: []const u8,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) Error!void {
     if (!isAvailable()) return error.UnsupportedPlatform;
     if (value.len == 0 or value.len > max_mcp_credentials_bytes) {
         return error.KeychainWriteFailed;
     }
 
     if (comptime builtin.os.tag == .macos) {
-        return storeMcpValueMac(mcp_credentials_service_name, value);
+        return storeMcpValueMacControlled(
+            mcp_credentials_service_name,
+            value,
+            cancel_flag,
+        );
     }
     return error.UnsupportedPlatform;
 }
@@ -324,17 +354,26 @@ fn loadMcpValueMac(
     alloc: std.mem.Allocator,
     service: []const u8,
 ) Error!?[]u8 {
+    return loadMcpValueMacControlled(alloc, service, null);
+}
+
+fn loadMcpValueMacControlled(
+    alloc: std.mem.Allocator,
+    service: []const u8,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) Error!?[]u8 {
     if (!isAvailable()) return error.UnsupportedPlatform;
 
     var account_buf: AccountBuffer = undefined;
     const account = try accountName(&account_buf);
     const argv = mcpScriptArgv("load", account, service);
-    const result = std.process.run(alloc, io_mod.getIo(), .{
-        .argv = &argv,
-        .stdout_limit = .limited(max_mcp_credentials_bytes + 1),
-        .stderr_limit = .limited(4096),
-        .timeout = keychain_process_timeout,
-    }) catch |err| {
+    const result = runMcpKeychainProcess(
+        alloc,
+        &argv,
+        cancel_flag,
+        .limited(max_mcp_credentials_bytes + 1),
+    ) catch |err| {
+        if (err == error.Cancelled) return error.Cancelled;
         debug_trace.logf("keychain", "load failed step=native err={s}", .{@errorName(err)});
         return error.KeychainReadFailed;
     };
@@ -355,9 +394,91 @@ fn loadMcpValueMac(
     return result.stdout;
 }
 
+const McpKeychainRunContext = struct {
+    alloc: std.mem.Allocator,
+    argv: []const []const u8,
+    stdout_limit: std.Io.Limit,
+};
+
+const McpKeychainRunEvent = union(enum) {
+    process: anyerror!std.process.RunResult,
+    cancelled: anyerror!void,
+};
+
+fn runMcpKeychainChild(
+    context: *const McpKeychainRunContext,
+) anyerror!std.process.RunResult {
+    return std.process.run(context.alloc, io_mod.getIo(), .{
+        .argv = context.argv,
+        .stdout_limit = context.stdout_limit,
+        .stderr_limit = .limited(4096),
+        .timeout = keychain_process_timeout,
+    });
+}
+
+fn waitForMcpKeychainCancellation(
+    cancel_flag: *const std.atomic.Value(bool),
+) anyerror!void {
+    while (!cancel_flag.load(.acquire)) {
+        try io_mod.getIo().sleep(.fromMilliseconds(5), .awake);
+    }
+}
+
+fn runMcpKeychainProcess(
+    alloc: std.mem.Allocator,
+    argv: []const []const u8,
+    cancel_flag: ?*const std.atomic.Value(bool),
+    stdout_limit: std.Io.Limit,
+) anyerror!std.process.RunResult {
+    const flag = cancel_flag orelse return runMcpKeychainChild(&.{
+        .alloc = alloc,
+        .argv = argv,
+        .stdout_limit = stdout_limit,
+    });
+    var context = McpKeychainRunContext{
+        .alloc = alloc,
+        .argv = argv,
+        .stdout_limit = stdout_limit,
+    };
+    var select_buffer: [2]McpKeychainRunEvent = undefined;
+    var select: std.Io.Select(McpKeychainRunEvent) = .init(
+        io_mod.getIo(),
+        &select_buffer,
+    );
+    select.concurrent(.process, runMcpKeychainChild, .{&context}) catch |err|
+        return err;
+    select.concurrent(
+        .cancelled,
+        waitForMcpKeychainCancellation,
+        .{flag},
+    ) catch |err| {
+        select.cancelDiscard();
+        return err;
+    };
+    const event = select.await() catch |err| {
+        select.cancelDiscard();
+        return err;
+    };
+    return switch (event) {
+        .process => |result| blk: {
+            select.cancelDiscard();
+            break :blk result catch |err| return err;
+        },
+        .cancelled => |result| {
+            result catch |err| {
+                select.cancelDiscard();
+                return err;
+            };
+            select.cancelDiscard();
+            return error.Cancelled;
+        },
+    };
+}
+
 const McpStoreEvent = union(enum) {
     wait: anyerror!std.process.Child.Term,
     timeout: anyerror!void,
+    cancelled: anyerror!void,
 };
 
 fn waitForMcpStoreChild(child: *std.process.Child) anyerror!std.process.Child.Term {
@@ -368,8 +489,11 @@ fn waitForMcpStoreTimeout() anyerror!void {
     return std.Io.Timeout.sleep(keychain_process_timeout, io_mod.getIo());
 }
 
-fn waitForMcpStore(child: *std.process.Child) Error!std.process.Child.Term {
-    var select_buffer: [2]McpStoreEvent = undefined;
+fn waitForMcpStore(
+    child: *std.process.Child,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) Error!std.process.Child.Term {
+    var select_buffer: [3]McpStoreEvent = undefined;
     var select: std.Io.Select(McpStoreEvent) = .init(io_mod.getIo(), &select_buffer);
     select.concurrent(.wait, waitForMcpStoreChild, .{child}) catch |err|
         return writeFailed("native_wait_start", err);
@@ -377,6 +501,16 @@ fn waitForMcpStore(child: *std.process.Child) Error!std.process.Child.Term {
         select.cancelDiscard();
         return writeFailed("native_timeout_start", err);
     };
+    if (cancel_flag) |flag| {
+        select.concurrent(
+            .cancelled,
+            waitForMcpKeychainCancellation,
+            .{flag},
+        ) catch |err| {
+            select.cancelDiscard();
+            return writeFailed("native_cancel_start", err);
+        };
+    }
     const event = select.await() catch |err| {
         select.cancelDiscard();
         return writeFailed("native_wait", err);
@@ -394,10 +528,26 @@ fn waitForMcpStore(child: *std.process.Child) Error!std.process.Child.Term {
             select.cancelDiscard();
             return writeFailed("native_wait", error.Timeout);
         },
+        .cancelled => |result| {
+            result catch |err| {
+                select.cancelDiscard();
+                return writeFailed("native_cancel", err);
+            };
+            select.cancelDiscard();
+            return error.Cancelled;
+        },
     }
 }
 
 fn storeMcpValueMac(service: []const u8, value: []const u8) Error!void {
+    return storeMcpValueMacControlled(service, value, null);
+}
+
+fn storeMcpValueMacControlled(
+    service: []const u8,
+    value: []const u8,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) Error!void {
     var account_buf: AccountBuffer = undefined;
     const account = try accountName(&account_buf);
     const argv = mcpScriptArgv("store", account, service);
@@ -418,7 +568,7 @@ fn storeMcpValueMac(service: []const u8, value: []const u8) Error!void {
     input.close(io_mod.getIo());
     input_open = false;
 
-    const term = try waitForMcpStore(&child);
+    const term = try waitForMcpStore(&child, cancel_flag);
     if (term != .exited or term.exited != 0) {
         return writeFailedTerm("native_exit", term);
     }
@@ -549,6 +699,68 @@ test "Keychain store command has no secret argument" {
     for (argv) |arg| {
         try std.testing.expect(!std.mem.eql(u8, arg, "vca_secret_value"));
     }
+}
+
+test "cancellable MCP Keychain runner interrupts and reaps a stalled child" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    }
+    const Canceller = struct {
+        flag: *std.atomic.Value(bool),
+
+        fn run(self: *@This()) void {
+            io_mod.sleep(25 * std.time.ns_per_ms);
+            self.flag.store(true, .release);
+        }
+    };
+
+    var cancel = std.atomic.Value(bool).init(false);
+    var canceller = Canceller{ .flag = &cancel };
+    const thread = try std.Thread.spawn(.{}, Canceller.run, .{&canceller});
+    const started_ms = io_mod.milliTimestamp();
+    try std.testing.expectError(
+        error.Cancelled,
+        runMcpKeychainProcess(
+            std.testing.allocator,
+            &.{ "/bin/sh", "-c", "exec sleep 60" },
+            &cancel,
+            .limited(16),
+        ),
+    );
+    thread.join();
+    try std.testing.expect(io_mod.milliTimestamp() - started_ms < 1_000);
+}
+
+test "cancellable MCP Keychain store wait interrupts a stalled child" {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    }
+    const Canceller = struct {
+        flag: *std.atomic.Value(bool),
+
+        fn run(self: *@This()) void {
+            io_mod.sleep(25 * std.time.ns_per_ms);
+            self.flag.store(true, .release);
+        }
+    };
+
+    var child = try std.process.spawn(std.testing.io, .{
+        .argv = &.{ "/bin/sh", "-c", "exec sleep 60" },
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    defer child.kill(std.testing.io);
+    var cancel = std.atomic.Value(bool).init(false);
+    var canceller = Canceller{ .flag = &cancel };
+    const thread = try std.Thread.spawn(.{}, Canceller.run, .{&canceller});
+    const started_ms = io_mod.milliTimestamp();
+    try std.testing.expectError(
+        error.Cancelled,
+        waitForMcpStore(&child, &cancel),
+    );
+    thread.join();
+    try std.testing.expect(io_mod.milliTimestamp() - started_ms < 1_000);
 }
 
 test "Keychain value store uses a bounded PTY bridge without a secret argument" {

--- a/src/core/mcp/command_provider.zig
+++ b/src/core/mcp/command_provider.zig
@@ -1,12 +1,14 @@
 const std = @import("std");
+const mcp_auth = @import("mcp_auth.zig");
 
 const Allocator = std.mem.Allocator;
 
 pub const ListServersFn = *const fn (ctx: *anyopaque, alloc: Allocator) anyerror![]u8;
+pub const SummarizeServersFn = *const fn (ctx: *anyopaque, alloc: Allocator) anyerror![]u8;
 pub const AuthenticateServerFn = *const fn (
     ctx: *anyopaque,
     name: []const u8,
-) anyerror!void;
+) anyerror!mcp_auth.AuthenticationResult;
 pub const ValidateAuthenticationServerFn = *const fn (
     ctx: *anyopaque,
     name: []const u8,
@@ -66,6 +68,7 @@ pub const CompleteResourceFn = *const fn (
 pub const Request = struct {
     home: ?[]const u8,
     list_ctx: *anyopaque,
+    summarize_servers: ?SummarizeServersFn = null,
     list_servers_and_tools: ListServersFn,
     auth_ctx: ?*anyopaque = null,
     validate_authentication_server: ?ValidateAuthenticationServerFn = null,

--- a/src/core/mcp/health.zig
+++ b/src/core/mcp/health.zig
@@ -196,6 +196,52 @@ pub fn render(alloc: Allocator, snapshot: Snapshot) ![]u8 {
     return out.toOwnedSlice();
 }
 
+pub fn renderSummary(alloc: Allocator, snapshot: Snapshot) ![]u8 {
+    if (snapshot.servers.len == 0) {
+        return alloc.dupe(
+            u8,
+            "MCP: no servers configured. Use /mcp add <name> <command> [args...].",
+        );
+    }
+    var ready: usize = 0;
+    var connecting: usize = 0;
+    var auth_required: usize = 0;
+    var failed: usize = 0;
+    var first_auth_server: ?[]const u8 = null;
+    for (snapshot.servers) |server| {
+        if (server.authentication == .required) {
+            auth_required += 1;
+            if (first_auth_server == null) first_auth_server = server.configured_name;
+            continue;
+        }
+        switch (server.connection) {
+            .ready => ready += 1,
+            .connecting => connecting += 1,
+            .failed => failed += 1,
+            .disconnected, .disabled => {},
+        }
+    }
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.print(
+        "MCP: {d} {s} — {d} ready, {d} connecting, {d} needs auth, {d} failed.",
+        .{
+            snapshot.servers.len,
+            if (snapshot.servers.len == 1) "server" else "servers",
+            ready,
+            connecting,
+            auth_required,
+            failed,
+        },
+    );
+    if (first_auth_server) |name| {
+        try out.writer.print(" Run /mcp auth {s} --open.", .{name});
+    }
+    try out.writer.writeAll(" Use /mcp list for details.");
+    return out.toOwnedSlice();
+}
+
 fn writeOptionalCount(writer: *std.Io.Writer, count: ?usize) !void {
     if (count) |value| try writer.print("{d}", .{value}) else try writer.writeAll("unknown");
 }
@@ -291,6 +337,39 @@ test "health rendering includes complete typed state without secret-bearing conf
     try std.testing.expect(std.mem.find(u8, output, "catalog_generation") == null);
     try std.testing.expect(std.mem.find(u8, output, "Authorization") == null);
     try std.testing.expect(std.mem.find(u8, output, "https://") == null);
+}
+
+test "compact health summary reports actionable aggregate state" {
+    const alloc = std.testing.allocator;
+    const empty = Snapshot{ .captured_at_ms = 0, .servers = &.{} };
+    const empty_output = try renderSummary(alloc, empty);
+    defer alloc.free(empty_output);
+    try std.testing.expectEqualStrings(
+        "MCP: no servers configured. Use /mcp add <name> <command> [args...].",
+        empty_output,
+    );
+
+    var servers = [_]ServerSnapshot{
+        emptyServerSnapshot(),
+        emptyServerSnapshot(),
+        emptyServerSnapshot(),
+        emptyServerSnapshot(),
+    };
+    servers[0].configured_name = @constCast("ready");
+    servers[0].connection = .ready;
+    servers[1].configured_name = @constCast("loading");
+    servers[1].connection = .connecting;
+    servers[2].configured_name = @constCast("plain");
+    servers[2].connection = .failed;
+    servers[2].authentication = .required;
+    servers[3].configured_name = @constCast("broken");
+    servers[3].connection = .failed;
+    const summary = try renderSummary(alloc, .{ .captured_at_ms = 0, .servers = &servers });
+    defer alloc.free(summary);
+    try std.testing.expectEqualStrings(
+        "MCP: 4 servers — 1 ready, 1 connecting, 1 needs auth, 1 failed. Run /mcp auth plain --open. Use /mcp list for details.",
+        summary,
+    );
 }
 
 fn emptyServerSnapshot() ServerSnapshot {

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -154,6 +154,50 @@ pub const Credentials = struct {
     }
 };
 
+pub const IssuerMismatch = struct {
+    owner_alloc: Allocator,
+    expected: []u8,
+    returned: []u8,
+
+    pub fn init(
+        alloc: Allocator,
+        expected: []const u8,
+        returned: []const u8,
+    ) !IssuerMismatch {
+        const owned_expected = try alloc.dupe(u8, expected);
+        errdefer alloc.free(owned_expected);
+        return .{
+            .owner_alloc = alloc,
+            .expected = owned_expected,
+            .returned = try alloc.dupe(u8, returned),
+        };
+    }
+
+    pub fn deinit(self: *IssuerMismatch) void {
+        self.owner_alloc.free(self.expected);
+        self.owner_alloc.free(self.returned);
+        self.* = undefined;
+    }
+};
+
+pub const AuthorizationResult = union(enum) {
+    credentials: Credentials,
+    issuer_mismatch: IssuerMismatch,
+};
+
+pub const AuthenticationResult = union(enum) {
+    authenticated,
+    issuer_mismatch: IssuerMismatch,
+
+    pub fn deinit(self: *AuthenticationResult) void {
+        switch (self.*) {
+            .authenticated => {},
+            .issuer_mismatch => |*mismatch| mismatch.deinit(),
+        }
+        self.* = undefined;
+    }
+};
+
 pub const AutomatedAuthorizationOptions = struct {
     endpoint: []const u8,
     challenge: Challenge,
@@ -499,13 +543,41 @@ pub fn parseAuthorizationMetadata(
     bytes: []const u8,
     expected_issuer: []const u8,
 ) !AuthorizationMetadata {
+    return switch (try parseAuthorizationMetadataOutcome(
+        alloc,
+        bytes,
+        expected_issuer,
+    )) {
+        .metadata => |metadata| metadata,
+        .issuer_mismatch => |owned_mismatch| {
+            var mismatch = owned_mismatch;
+            mismatch.deinit();
+            return error.AuthorizationMetadataIssuerMismatch;
+        },
+    };
+}
+
+const AuthorizationMetadataOutcome = union(enum) {
+    metadata: AuthorizationMetadata,
+    issuer_mismatch: IssuerMismatch,
+};
+
+fn parseAuthorizationMetadataOutcome(
+    alloc: Allocator,
+    bytes: []const u8,
+    expected_issuer: []const u8,
+) !AuthorizationMetadataOutcome {
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidAuthorizationMetadata;
     const object = parsed.value.object;
     const issuer = try requiredString(object, "issuer");
     if (!std.mem.eql(u8, issuer, expected_issuer)) {
-        return error.AuthorizationMetadataIssuerMismatch;
+        return .{ .issuer_mismatch = try IssuerMismatch.init(
+            alloc,
+            expected_issuer,
+            issuer,
+        ) };
     }
     const authorization_endpoint = try dupeRequiredUrl(alloc, object, "authorization_endpoint");
     errdefer alloc.free(authorization_endpoint);
@@ -532,7 +604,7 @@ pub fn parseAuthorizationMetadata(
         "code_challenge_methods_supported",
     );
     errdefer freeStrings(alloc, code_challenge_methods_supported);
-    return .{
+    return .{ .metadata = .{
         .issuer = try alloc.dupe(u8, issuer),
         .authorization_endpoint = authorization_endpoint,
         .token_endpoint = token_endpoint,
@@ -550,7 +622,7 @@ pub fn parseAuthorizationMetadata(
             object,
             "authorization_response_iss_parameter_supported",
         ) orelse false,
-    };
+    } };
 }
 
 pub fn requestedScope(
@@ -857,7 +929,7 @@ pub fn revokeCredentials(alloc: Allocator, credentials: Credentials) !void {
 pub fn authorizeAutomated(
     alloc: Allocator,
     options: AutomatedAuthorizationOptions,
-) !Credentials {
+) !AuthorizationResult {
     return authorizeWithRedirect(
         alloc,
         options,
@@ -870,7 +942,7 @@ pub fn authorizeAutomated(
 pub fn authorizeInteractive(
     alloc: Allocator,
     options: InteractiveAuthorizationOptions,
-) !Credentials {
+) !AuthorizationResult {
     if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
         return error.InteractiveMcpAuthorizationUnsupported;
     }
@@ -917,7 +989,7 @@ fn authorizeWithRedirect(
     redirect_uri: []const u8,
     authorization_ctx: ?*anyopaque,
     request_authorization: AuthorizationRequestFn,
-) !Credentials {
+) !AuthorizationResult {
     try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
     const endpoint = try canonicalResource(alloc, options.endpoint);
     errdefer alloc.free(endpoint);
@@ -940,7 +1012,10 @@ fn authorizeWithRedirect(
     }
     const issuer = options.config.issuer orelse prm.authorization_servers[0];
     try validateOAuthUrlForResource(issuer, resource);
-    var metadata = try discoverAuthorizationMetadata(alloc, issuer);
+    var metadata = switch (try discoverAuthorizationMetadata(alloc, issuer)) {
+        .metadata => |value| value,
+        .issuer_mismatch => |mismatch| return .{ .issuer_mismatch = mismatch },
+    };
     defer metadata.deinit(alloc);
     try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
     try validateAuthorizationMetadataUrls(metadata, resource);
@@ -1008,12 +1083,21 @@ fn authorizeWithRedirect(
     );
     defer callback.deinit(alloc);
     try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
-    try validateAuthorizationResponse(
+    validateAuthorizationResponse(
         state,
         metadata.issuer,
         metadata.authorization_response_iss_parameter_supported,
         callback,
-    );
+    ) catch |err| switch (err) {
+        error.AuthorizationResponseIssuerMismatch => return .{
+            .issuer_mismatch = try IssuerMismatch.init(
+                alloc,
+                metadata.issuer,
+                callback.issuer.?,
+            ),
+        },
+        else => return err,
+    };
 
     var grant = try exchangeAuthorizationCode(
         alloc,
@@ -1054,7 +1138,7 @@ fn authorizeWithRedirect(
         .revocation_endpoint = revocation_endpoint,
     };
     grant = undefined;
-    return credentials;
+    return .{ .credentials = credentials };
 }
 
 fn requestAutomatedAuthorization(
@@ -1244,7 +1328,7 @@ fn discoverResourceMetadata(
 fn discoverAuthorizationMetadata(
     alloc: Allocator,
     issuer: []const u8,
-) !AuthorizationMetadata {
+) !AuthorizationMetadataOutcome {
     const urls = try authorizationMetadataUrls(alloc, issuer);
     defer freeStrings(alloc, urls);
     for (urls) |url| {
@@ -1252,7 +1336,7 @@ fn discoverAuthorizationMetadata(
         defer response.deinit(alloc);
         if (response.status != .ok) continue;
         try validateJsonContentType(response.content_type);
-        return parseAuthorizationMetadata(alloc, response.body, issuer);
+        return parseAuthorizationMetadataOutcome(alloc, response.body, issuer);
     }
     return error.AuthorizationMetadataUnavailable;
 }
@@ -2169,6 +2253,43 @@ test "authorization metadata defaults omitted token endpoint authentication to c
     try std.testing.expectEqualStrings(
         "client_secret_basic",
         try chooseTokenEndpointAuthMethod(metadata, false),
+    );
+}
+
+test "authorization metadata mismatch retains exact issuer values and fails closed" {
+    const alloc = std.testing.allocator;
+    const bytes =
+        "{\"issuer\":\"https://login.example.com\",\"authorization_endpoint\":\"https://login.example.com/authorize\",\"token_endpoint\":\"https://login.example.com/token\"}";
+
+    var outcome = try parseAuthorizationMetadataOutcome(
+        alloc,
+        bytes,
+        "https://login.example.com/",
+    );
+    defer switch (outcome) {
+        .metadata => |*metadata| metadata.deinit(alloc),
+        .issuer_mismatch => |*mismatch| mismatch.deinit(),
+    };
+    switch (outcome) {
+        .metadata => return error.TestUnexpectedResult,
+        .issuer_mismatch => |mismatch| {
+            try std.testing.expectEqualStrings(
+                "https://login.example.com/",
+                mismatch.expected,
+            );
+            try std.testing.expectEqualStrings(
+                "https://login.example.com",
+                mismatch.returned,
+            );
+        },
+    }
+    try std.testing.expectError(
+        error.AuthorizationMetadataIssuerMismatch,
+        parseAuthorizationMetadata(
+            alloc,
+            bytes,
+            "https://login.example.com/",
+        ),
     );
 }
 

--- a/src/core/mcp/mcp_auth_store.zig
+++ b/src/core/mcp/mcp_auth_store.zig
@@ -27,16 +27,32 @@ const KeychainError = Allocator.Error || native_keychain.Error;
 
 const KeychainBackend = struct {
     context: ?*anyopaque = null,
-    load_fn: *const fn (?*anyopaque, Allocator) KeychainError!?[]u8,
-    store_fn: *const fn (?*anyopaque, []const u8) KeychainError!void,
+    load_fn: *const fn (
+        ?*anyopaque,
+        Allocator,
+        ?*const std.atomic.Value(bool),
+    ) KeychainError!?[]u8,
+    store_fn: *const fn (
+        ?*anyopaque,
+        []const u8,
+        ?*const std.atomic.Value(bool),
+    ) KeychainError!void,
     delete_fn: *const fn (?*anyopaque, Allocator) KeychainError!bool,
 
-    fn load(self: KeychainBackend, alloc: Allocator) KeychainError!?[]u8 {
-        return self.load_fn(self.context, alloc);
+    fn load(
+        self: KeychainBackend,
+        alloc: Allocator,
+        cancel_flag: ?*const std.atomic.Value(bool),
+    ) KeychainError!?[]u8 {
+        return self.load_fn(self.context, alloc, cancel_flag);
     }
 
-    fn store(self: KeychainBackend, value: []const u8) KeychainError!void {
-        return self.store_fn(self.context, value);
+    fn store(
+        self: KeychainBackend,
+        value: []const u8,
+        cancel_flag: ?*const std.atomic.Value(bool),
+    ) KeychainError!void {
+        return self.store_fn(self.context, value, cancel_flag);
     }
 
     fn delete(self: KeychainBackend, alloc: Allocator) KeychainError!bool {
@@ -50,12 +66,26 @@ const native_keychain_backend: KeychainBackend = .{
     .delete_fn = nativeKeychainDelete,
 };
 
-fn nativeKeychainLoad(_: ?*anyopaque, alloc: Allocator) KeychainError!?[]u8 {
-    return native_keychain.loadMcpCredentials(alloc);
+fn nativeKeychainLoad(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) KeychainError!?[]u8 {
+    return if (cancel_flag) |flag|
+        native_keychain.loadMcpCredentialsCancellable(alloc, flag)
+    else
+        native_keychain.loadMcpCredentials(alloc);
 }
 
-fn nativeKeychainStore(_: ?*anyopaque, value: []const u8) KeychainError!void {
-    return native_keychain.storeMcpCredentials(value);
+fn nativeKeychainStore(
+    _: ?*anyopaque,
+    value: []const u8,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) KeychainError!void {
+    return if (cancel_flag) |flag|
+        native_keychain.storeMcpCredentialsCancellable(value, flag)
+    else
+        native_keychain.storeMcpCredentials(value);
 }
 
 fn nativeKeychainDelete(_: ?*anyopaque, alloc: Allocator) KeychainError!bool {
@@ -136,10 +166,55 @@ pub fn load(
     configured_resource: ?[]const u8,
     configured_issuer: ?[]const u8,
 ) !?mcp_auth.Credentials {
+    return loadControlled(
+        alloc,
+        server_identity,
+        endpoint,
+        configured_resource,
+        configured_issuer,
+        null,
+    );
+}
+
+pub fn loadCancellable(
+    alloc: Allocator,
+    server_identity: []const u8,
+    endpoint: []const u8,
+    configured_resource: ?[]const u8,
+    configured_issuer: ?[]const u8,
+    cancel_flag: *const std.atomic.Value(bool),
+) !?mcp_auth.Credentials {
+    return loadControlled(
+        alloc,
+        server_identity,
+        endpoint,
+        configured_resource,
+        configured_issuer,
+        cancel_flag,
+    );
+}
+
+fn loadControlled(
+    alloc: Allocator,
+    server_identity: []const u8,
+    endpoint: []const u8,
+    configured_resource: ?[]const u8,
+    configured_issuer: ?[]const u8,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) !?mcp_auth.Credentials {
     const backend = storageBackend();
-    var locked = (try openLockedDirForRead(backend)) orelse return null;
+    var locked = (try openLockedDirForReadControlled(
+        backend,
+        cancel_flag,
+    )) orelse return null;
     defer locked.deinit();
-    var store = try loadStore(alloc, &locked.dir, backend, native_keychain_backend);
+    var store = try loadStoreControlled(
+        alloc,
+        &locked.dir,
+        backend,
+        native_keychain_backend,
+        cancel_flag,
+    );
     defer store.deinit(alloc);
 
     const canonical_endpoint = try mcp_auth.canonicalResource(alloc, endpoint);
@@ -266,6 +341,12 @@ fn sameIdentity(
 }
 
 fn openOrCreateLockedDir() !LockedDir {
+    return openOrCreateLockedDirControlled(null);
+}
+
+fn openOrCreateLockedDirControlled(
+    cancel_flag: ?*const std.atomic.Value(bool),
+) !LockedDir {
     const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
@@ -281,16 +362,30 @@ fn openOrCreateLockedDir() !LockedDir {
         profile_paths.mcp_credentials_dir_name,
     );
     errdefer credentials_dir.close();
-    var lock = try io_mod.acquireTimedAdvisoryLock(
-        &credentials_dir,
-        lock_file_name,
-        lock_deadline_ms,
-    );
+    var lock = if (cancel_flag) |flag|
+        try io_mod.acquireTimedAdvisoryLockCancellable(
+            &credentials_dir,
+            lock_file_name,
+            lock_deadline_ms,
+            flag,
+        )
+    else
+        try io_mod.acquireTimedAdvisoryLock(
+            &credentials_dir,
+            lock_file_name,
+            lock_deadline_ms,
+        );
     errdefer lock.release();
     return .{ .dir = credentials_dir, .lock = lock };
 }
 
 fn openExistingLockedDir() !?LockedDir {
+    return openExistingLockedDirControlled(null);
+}
+
+fn openExistingLockedDirControlled(
+    cancel_flag: ?*const std.atomic.Value(bool),
+) !?LockedDir {
     const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{
@@ -314,19 +409,34 @@ fn openExistingLockedDir() !?LockedDir {
         else => return err,
     };
     errdefer credentials_dir.close();
-    var lock = try io_mod.acquireTimedAdvisoryLock(
-        &credentials_dir,
-        lock_file_name,
-        lock_deadline_ms,
-    );
+    var lock = if (cancel_flag) |flag|
+        try io_mod.acquireTimedAdvisoryLockCancellable(
+            &credentials_dir,
+            lock_file_name,
+            lock_deadline_ms,
+            flag,
+        )
+    else
+        try io_mod.acquireTimedAdvisoryLock(
+            &credentials_dir,
+            lock_file_name,
+            lock_deadline_ms,
+        );
     errdefer lock.release();
     return .{ .dir = credentials_dir, .lock = lock };
 }
 
 fn openLockedDirForRead(backend: StorageBackend) !?LockedDir {
+    return openLockedDirForReadControlled(backend, null);
+}
+
+fn openLockedDirForReadControlled(
+    backend: StorageBackend,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) !?LockedDir {
     return switch (backend) {
-        .profile_file => openExistingLockedDir(),
-        .macos_keychain => try openOrCreateLockedDir(),
+        .profile_file => openExistingLockedDirControlled(cancel_flag),
+        .macos_keychain => try openOrCreateLockedDirControlled(cancel_flag),
     };
 }
 
@@ -365,20 +475,38 @@ fn loadStore(
     backend: StorageBackend,
     keychain: KeychainBackend,
 ) !Store {
+    return loadStoreControlled(alloc, dir, backend, keychain, null);
+}
+
+fn loadStoreControlled(
+    alloc: Allocator,
+    dir: *io_mod.VerifiedDir,
+    backend: StorageBackend,
+    keychain: KeychainBackend,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) !Store {
+    try checkCancellation(cancel_flag);
     const from_file = try loadFromDir(alloc, dir);
     switch (selectReadDecision(backend, from_file != null)) {
         .use_profile_file => return from_file orelse .{},
         .migrate_profile_file => {
             var store = from_file.?;
             errdefer store.deinit(alloc);
-            try writeStoreToKeychain(alloc, store, keychain);
+            try writeStoreToKeychainControlled(
+                alloc,
+                store,
+                keychain,
+                cancel_flag,
+            );
+            try checkCancellation(cancel_flag);
             try deleteCredentialFile(dir);
             return store;
         },
         .read_keychain => {},
     }
 
-    const maybe_bytes = keychain.load(alloc) catch |err| switch (err) {
+    try checkCancellation(cancel_flag);
+    const maybe_bytes = keychain.load(alloc, cancel_flag) catch |err| switch (err) {
         error.KeychainItemNotFound => null,
         else => return err,
     };
@@ -541,16 +669,33 @@ fn writeStoreToKeychain(
     store: Store,
     keychain: KeychainBackend,
 ) !void {
+    return writeStoreToKeychainControlled(alloc, store, keychain, null);
+}
+
+fn writeStoreToKeychainControlled(
+    alloc: Allocator,
+    store: Store,
+    keychain: KeychainBackend,
+    cancel_flag: ?*const std.atomic.Value(bool),
+) !void {
     const bytes = try serializeStore(alloc, store);
     defer secret.zeroAndFree(alloc, bytes);
-    try keychain.store(bytes);
-    const persisted = keychain.load(alloc) catch |err| switch (err) {
+    try checkCancellation(cancel_flag);
+    try keychain.store(bytes, cancel_flag);
+    try checkCancellation(cancel_flag);
+    const persisted = keychain.load(alloc, cancel_flag) catch |err| switch (err) {
         error.KeychainItemNotFound => return error.McpCredentialStoreWriteMismatch,
         else => return err,
     } orelse return error.McpCredentialStoreWriteMismatch;
     defer secret.zeroAndFree(alloc, persisted);
     if (!std.mem.eql(u8, bytes, persisted)) {
         return error.McpCredentialStoreWriteMismatch;
+    }
+}
+
+fn checkCancellation(cancel_flag: ?*const std.atomic.Value(bool)) !void {
+    if (cancel_flag) |flag| {
+        if (flag.load(.acquire)) return error.Cancelled;
     }
 }
 
@@ -780,6 +925,10 @@ const FakeKeychain = struct {
     delete_calls: usize = 0,
     fail_store: bool = false,
     corrupt_store: bool = false,
+    stall_load: bool = false,
+    stall_store: bool = false,
+    load_started: std.atomic.Value(bool) = .init(false),
+    store_started: std.atomic.Value(bool) = .init(false),
 
     fn deinit(self: *FakeKeychain) void {
         if (self.value) |value| secret.zeroAndFree(self.alloc, value);
@@ -798,8 +947,15 @@ const FakeKeychain = struct {
     fn loadCallback(
         raw_context: ?*anyopaque,
         alloc: Allocator,
+        cancel_flag: ?*const std.atomic.Value(bool),
     ) KeychainError!?[]u8 {
         const self: *FakeKeychain = @ptrCast(@alignCast(raw_context.?));
+        if (self.stall_load) {
+            self.load_started.store(true, .release);
+            const flag = cancel_flag orelse return error.KeychainReadFailed;
+            while (!flag.load(.acquire)) io_mod.sleep(std.time.ns_per_ms);
+            return error.Cancelled;
+        }
         const value = self.value orelse return null;
         return try alloc.dupe(u8, value);
     }
@@ -807,8 +963,15 @@ const FakeKeychain = struct {
     fn storeCallback(
         raw_context: ?*anyopaque,
         value: []const u8,
+        cancel_flag: ?*const std.atomic.Value(bool),
     ) KeychainError!void {
         const self: *FakeKeychain = @ptrCast(@alignCast(raw_context.?));
+        if (self.stall_store) {
+            self.store_started.store(true, .release);
+            const flag = cancel_flag orelse return error.KeychainWriteFailed;
+            while (!flag.load(.acquire)) io_mod.sleep(std.time.ns_per_ms);
+            return error.Cancelled;
+        }
         self.store_calls += 1;
         if (self.fail_store) return error.KeychainWriteFailed;
         const replacement = try self.alloc.dupe(
@@ -1062,6 +1225,138 @@ test "credential store is private atomic and supports restart deletion" {
         null,
         null,
     )) == null);
+}
+
+test "credential load cancellation interrupts a held advisory lock" {
+    const Waiter = struct {
+        cancel: *std.atomic.Value(bool),
+        started: std.atomic.Value(bool) = .init(false),
+        result_error: ?anyerror = null,
+
+        fn run(self: *@This()) void {
+            self.started.store(true, .release);
+            var credentials = loadCancellable(
+                std.heap.smp_allocator,
+                "fixture",
+                "https://mcp.example/service",
+                null,
+                null,
+                self.cancel,
+            ) catch |err| {
+                self.result_error = err;
+                return;
+            };
+            if (credentials) |*owned| owned.deinit(std.heap.smp_allocator);
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home");
+    const home = try tmp.dir.realPathFileAlloc(std.testing.io, "home", alloc);
+    defer alloc.free(home);
+    var test_home = try TestHome.init(home);
+    defer test_home.deinit();
+    test_home.activate();
+
+    var held = try openOrCreateLockedDir();
+    defer held.deinit();
+    var cancel = std.atomic.Value(bool).init(false);
+    var waiter = Waiter{ .cancel = &cancel };
+    const thread = try std.Thread.spawn(.{}, Waiter.run, .{&waiter});
+    while (!waiter.started.load(.acquire)) io_mod.sleep(std.time.ns_per_ms);
+    io_mod.sleep(25 * std.time.ns_per_ms);
+    const started_ms = io_mod.milliTimestamp();
+    cancel.store(true, .release);
+    thread.join();
+
+    try std.testing.expectEqual(error.Cancelled, waiter.result_error.?);
+    try std.testing.expect(io_mod.milliTimestamp() - started_ms < 1_000);
+}
+
+test "credential cancellation interrupts Keychain read and preserves migration source" {
+    const Canceller = struct {
+        started: *const std.atomic.Value(bool),
+        cancel: *std.atomic.Value(bool),
+
+        fn run(self: *@This()) void {
+            while (!self.started.load(.acquire)) io_mod.sleep(std.time.ns_per_ms);
+            self.cancel.store(true, .release);
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home");
+    const home = try tmp.dir.realPathFileAlloc(std.testing.io, "home", alloc);
+    defer alloc.free(home);
+    var test_home = try TestHome.init(home);
+    defer test_home.deinit();
+    test_home.activate();
+
+    {
+        var locked = try openOrCreateLockedDir();
+        defer locked.deinit();
+        var fake = FakeKeychain{ .alloc = alloc, .stall_load = true };
+        defer fake.deinit();
+        var cancel = std.atomic.Value(bool).init(false);
+        var canceller = Canceller{
+            .started = &fake.load_started,
+            .cancel = &cancel,
+        };
+        const thread = try std.Thread.spawn(.{}, Canceller.run, .{&canceller});
+        const started_ms = io_mod.milliTimestamp();
+        try std.testing.expectError(
+            error.Cancelled,
+            loadStoreControlled(
+                alloc,
+                &locked.dir,
+                .macos_keychain,
+                fake.backend(),
+                &cancel,
+            ),
+        );
+        thread.join();
+        try std.testing.expect(io_mod.milliTimestamp() - started_ms < 1_000);
+    }
+
+    var credentials = try testCredentials(
+        alloc,
+        "https://mcp.example/service",
+        "migration-secret",
+    );
+    defer credentials.deinit(alloc);
+    try save(alloc, "fixture", credentials);
+    {
+        var locked = (try openExistingLockedDir()).?;
+        defer locked.deinit();
+        var fake = FakeKeychain{ .alloc = alloc, .stall_store = true };
+        defer fake.deinit();
+        var cancel = std.atomic.Value(bool).init(false);
+        var canceller = Canceller{
+            .started = &fake.store_started,
+            .cancel = &cancel,
+        };
+        const thread = try std.Thread.spawn(.{}, Canceller.run, .{&canceller});
+        try std.testing.expectError(
+            error.Cancelled,
+            loadStoreControlled(
+                alloc,
+                &locked.dir,
+                .macos_keychain,
+                fake.backend(),
+                &cancel,
+            ),
+        );
+        thread.join();
+        _ = try locked.dir.dir.statFile(
+            std.testing.io,
+            profile_paths.mcp_credentials_file_name,
+            .{},
+        );
+    }
 }
 
 test "credential load refuses an ambiguous discovered issuer identity" {

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -4937,9 +4937,17 @@ pub const McpRuntime = struct {
     }
 
     pub fn connectAll(self: *McpRuntime, tool_registry: tool_dispatch.Registry) void {
-        if (self.discovery_state.cmpxchgStrong(.idle, .loading, .seq_cst, .seq_cst) != null) return;
         self.discovery_cancel_requested.store(false, .seq_cst);
-        self.connectAllControlled(tool_registry, null, .all);
+        self.connectAllCancellable(tool_registry, &self.discovery_cancel_requested);
+    }
+
+    pub fn connectAllCancellable(
+        self: *McpRuntime,
+        tool_registry: tool_dispatch.Registry,
+        cancel_requested: *std.atomic.Value(bool),
+    ) void {
+        if (self.discovery_state.cmpxchgStrong(.idle, .loading, .seq_cst, .seq_cst) != null) return;
+        self.connectAllControlled(tool_registry, cancel_requested, null, .all);
         self.finishDeferredDiscovery();
         self.discovery_state.store(.complete, .seq_cst);
     }
@@ -4953,7 +4961,12 @@ pub const McpRuntime = struct {
     ) void {
         if (self.discovery_state.cmpxchgStrong(.idle, .loading, .seq_cst, .seq_cst) != null) return;
         self.discovery_cancel_requested.store(false, .seq_cst);
-        self.connectAllControlled(tool_registry, null, .ask_startup);
+        self.connectAllControlled(
+            tool_registry,
+            &self.discovery_cancel_requested,
+            null,
+            .ask_startup,
+        );
         self.discovery_state.store(.complete, .seq_cst);
     }
 
@@ -4974,7 +4987,12 @@ pub const McpRuntime = struct {
                         .acq_rel,
                         .acquire,
                     ) != null) continue;
-                    self.connectAllControlled(tool_registry, null, .ask_deferred);
+                    self.connectAllControlled(
+                        tool_registry,
+                        &self.discovery_cancel_requested,
+                        null,
+                        .ask_deferred,
+                    );
                     self.finishDeferredDiscovery();
                     return;
                 },
@@ -5028,7 +5046,12 @@ pub const McpRuntime = struct {
         tool_registry: tool_dispatch.Registry,
         server_timeout: ?std.Io.Duration,
     ) void {
-        self.connectAllControlled(tool_registry, server_timeout, .all);
+        self.connectAllControlled(
+            tool_registry,
+            &self.discovery_cancel_requested,
+            server_timeout,
+            .all,
+        );
         self.finishDeferredDiscovery();
         self.discovery_state.store(.complete, .seq_cst);
     }
@@ -5036,6 +5059,7 @@ pub const McpRuntime = struct {
     fn connectAllControlled(
         self: *McpRuntime,
         tool_registry: tool_dispatch.Registry,
+        cancel_requested: *std.atomic.Value(bool),
         server_timeout: ?std.Io.Duration,
         phase: startup_admission.Phase,
     ) void {
@@ -5066,7 +5090,7 @@ pub const McpRuntime = struct {
         self.catalog_mutex.unlockShared(io_mod.getIo());
 
         for (self.servers.items) |*server| {
-            if (self.discovery_cancel_requested.load(.seq_cst)) return;
+            if (cancel_requested.load(.acquire)) return;
             switch (startup_admission.decide(
                 server.config.enabled,
                 server.config.required,
@@ -5084,10 +5108,10 @@ pub const McpRuntime = struct {
                 self,
                 server,
                 &used_tool_names,
-                &self.discovery_cancel_requested,
+                cancel_requested,
                 server_timeout,
             ) catch |err| {
-                if (self.discovery_cancel_requested.load(.seq_cst)) return;
+                if (cancel_requested.load(.acquire)) return;
                 debug_trace.logf("mcp", "connection failed for server {s}: {s}", .{ server.config.name, @errorName(err) });
                 if (server.last_error == null) {
                     server.setFailed(self.alloc, @errorName(err));
@@ -5103,7 +5127,7 @@ pub const McpRuntime = struct {
         name: []const u8,
         open_ctx: ?*anyopaque,
         open_url: mcp_auth.OpenUrlFn,
-    ) !void {
+    ) !mcp_auth.AuthenticationResult {
         const server = try self.authenticationServer(name);
         server.connection_lock.lockSharedUncancelable(io_mod.getIo());
         var connection_locked = true;
@@ -5136,7 +5160,7 @@ pub const McpRuntime = struct {
         };
         defer source.challenge.deinit(self.alloc);
         defer if (source.previous_scope) |value| self.alloc.free(value);
-        var credentials = try mcp_auth.authorizeInteractive(self.alloc, .{
+        var credentials = switch (try mcp_auth.authorizeInteractive(self.alloc, .{
             .endpoint = try server.config.remoteUrl(),
             .challenge = source.challenge,
             .config = .{
@@ -5151,7 +5175,10 @@ pub const McpRuntime = struct {
             .open_ctx = open_ctx,
             .open_url = open_url,
             .lifecycle_cancel_flag = &self.retiring,
-        });
+        })) {
+            .credentials => |credentials| credentials,
+            .issuer_mismatch => |mismatch| return .{ .issuer_mismatch = mismatch },
+        };
         var transferred = false;
         defer if (!transferred) credentials.deinit(self.alloc);
         {
@@ -5180,6 +5207,7 @@ pub const McpRuntime = struct {
         server.connection_lock.unlockShared(io_mod.getIo());
         connection_locked = false;
         try resumeToolSubscriptionAfterAuthentication(self, server, deadline);
+        return .authenticated;
     }
 
     pub fn validateAuthenticationServer(self: *McpRuntime, name: []const u8) !void {
@@ -5736,7 +5764,10 @@ pub const McpRuntime = struct {
         access: tool_mcp_runtime.Access,
     ) !tool_mcp_runtime.SearchResult {
         if (self.isDiscovering()) {
-            return .{ .model_output = try alloc.dupe(u8, "{\"tools\":[],\"count\":0}") };
+            return .{ .model_output = try alloc.dupe(
+                u8,
+                "{\"tools\":[],\"count\":0,\"state\":\"discovering\",\"retryable\":true}",
+            ) };
         }
         var operation_access = try OperationAccessGuard.init(
             self.alloc,
@@ -8408,7 +8439,12 @@ fn renderAuthenticationRequired(
     return null;
 }
 
-fn loadStoredCredentials(alloc: Allocator, server: *McpServer) !void {
+fn loadStoredCredentials(
+    alloc: Allocator,
+    server: *McpServer,
+    control: ConnectionControl,
+) !void {
+    try checkConnectionControl(control);
     if (server.config.transport == .stdio or
         !server.config.allow_stored_credentials or
         server.auth_credentials != null)
@@ -8416,13 +8452,27 @@ fn loadStoredCredentials(alloc: Allocator, server: *McpServer) !void {
         return;
     }
     const auth = server.config.auth orelse mcp_contract.McpAuthConfig{};
-    server.auth_credentials = try mcp_auth_store.load(
-        alloc,
-        server.config.name,
-        try server.config.remoteUrl(),
-        auth.resource,
-        auth.issuer,
-    );
+    var credentials = if (control.cancel_flag) |cancel_flag|
+        try mcp_auth_store.loadCancellable(
+            alloc,
+            server.config.name,
+            try server.config.remoteUrl(),
+            auth.resource,
+            auth.issuer,
+            cancel_flag,
+        )
+    else
+        try mcp_auth_store.load(
+            alloc,
+            server.config.name,
+            try server.config.remoteUrl(),
+            auth.resource,
+            auth.issuer,
+        );
+    errdefer if (credentials) |*owned| owned.deinit(alloc);
+    try checkConnectionControl(control);
+    server.auth_credentials = credentials;
+    credentials = null;
     server.auth_credentials_present.store(
         server.auth_credentials != null,
         .release,
@@ -9498,7 +9548,8 @@ fn connectServerForDiscovery(
     used_tool_names: *std.StringHashMap(void),
     control: ConnectionControl,
 ) !void {
-    loadStoredCredentials(runtime.alloc, server) catch |err| {
+    loadStoredCredentials(runtime.alloc, server, control) catch |err| {
+        if (err == error.Cancelled) return err;
         debug_trace.logf(
             "mcp",
             "credential load failed server={s} err={s}",
@@ -11780,7 +11831,7 @@ fn authorizeForChallenge(
         };
     };
     defer if (source.previous_scope) |value| alloc.free(value);
-    var credentials = try mcp_auth.authorizeAutomated(alloc, .{
+    var credentials = switch (try mcp_auth.authorizeAutomated(alloc, .{
         .endpoint = try server.config.remoteUrl(),
         .challenge = challenge,
         .config = .{
@@ -11792,7 +11843,14 @@ fn authorizeForChallenge(
             .scopes = auth_config.scopes,
         },
         .previous_scope = source.previous_scope,
-    });
+    })) {
+        .credentials => |credentials| credentials,
+        .issuer_mismatch => |owned_mismatch| {
+            var mismatch = owned_mismatch;
+            mismatch.deinit();
+            return error.AuthorizationMetadataIssuerMismatch;
+        },
+    };
     var credentials_transferred = false;
     errdefer if (!credentials_transferred) credentials.deinit(alloc);
     try lockMutexWithControl(&server.auth_lock, control);
@@ -15482,7 +15540,10 @@ test "discovery classification separates modern negotiation from legacy fallback
     );
     defer invalid_params.deinit();
     switch (try classifyDiscoveryResponse(invalid_params.value)) {
-        .modern_protocol_error => |protocol_error| try std.testing.expectEqual(@as(i64, -32602), protocol_error.code),
+        .legacy_fallback => |version| try std.testing.expectEqual(
+            LegacyStdioVersion.v2025_11_25,
+            version,
+        ),
         else => return error.TestUnexpectedResult,
     }
 
@@ -16798,12 +16859,52 @@ test "McpRuntime cancels blocked stdio discovery without exposing partial state"
 
     var results = try runtime.searchTools(alloc, "echo", 5, .{}, .{}, .unrestricted);
     defer results.deinit(alloc);
-    try std.testing.expectEqualStrings("{\"tools\":[],\"count\":0}", results.model_output);
+    try std.testing.expectEqualStrings(
+        "{\"tools\":[],\"count\":0,\"state\":\"discovering\",\"retryable\":true}",
+        results.model_output,
+    );
 
     const started_ms = io_mod.milliTimestamp();
     runtime.deinit();
     runtime_deinitialized = true;
     try std.testing.expect(io_mod.milliTimestamp() - started_ms < 1000);
+}
+
+test "caller cancellation interrupts blocked candidate connection" {
+    const Connector = struct {
+        runtime: *McpRuntime,
+        cancel: *std.atomic.Value(bool),
+        started: std.atomic.Value(bool) = .init(false),
+
+        fn run(self: *@This()) void {
+            self.started.store(true, .release);
+            self.runtime.connectAllCancellable(.{}, self.cancel);
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    const args = try alloc.alloc([]const u8, 1);
+    args[0] = try alloc.dupe(u8, "{}");
+    var runtime = McpRuntime.init(alloc);
+    defer runtime.deinit();
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "candidate"),
+        .command = try alloc.dupe(u8, "awk"),
+        .args = args,
+        .startup_timeout_ms = 60_000,
+    });
+    var cancel = std.atomic.Value(bool).init(false);
+    var connector = Connector{ .runtime = &runtime, .cancel = &cancel };
+    const thread = try std.Thread.spawn(.{}, Connector.run, .{&connector});
+    while (!connector.started.load(.acquire)) io_mod.sleep(std.time.ns_per_ms);
+    io_mod.sleep(25 * std.time.ns_per_ms);
+    const started_ms = io_mod.milliTimestamp();
+    cancel.store(true, .release);
+    thread.join();
+
+    try std.testing.expect(io_mod.milliTimestamp() - started_ms < 1_000);
+    try std.testing.expectEqual(ServerState.disconnected, runtime.servers.items[0].state);
+    try std.testing.expect(runtime.servers.items[0].last_error == null);
 }
 
 test "MCP health terminal-encodes external identity and omits secret-bearing configuration" {

--- a/src/core/mcp/protocol_negotiation.zig
+++ b/src/core/mcp/protocol_negotiation.zig
@@ -9,7 +9,7 @@ pub const legacy_2025_06_protocol_version = "2025-06-18";
 pub const legacy_2025_11_protocol_version = "2025-11-25";
 pub const modern_protocol_version = "2026-07-28";
 pub const unsupported_protocol_version_code: i64 = -32022;
-pub const method_not_found_code: i64 = -32601;
+const missing_required_client_capability_code: i64 = -32021;
 
 pub const Protocol = enum {
     unselected,
@@ -166,11 +166,11 @@ pub fn classifyDiscoveryResponse(value: std.json.Value) !DiscoveryOutcome {
             .complete => unreachable,
             .protocol_error => |err| err,
         };
-        if (protocol_error.code == method_not_found_code) {
-            return .{ .legacy_fallback = .v2025_11_25 };
+        if (protocol_error.code == missing_required_client_capability_code) {
+            return .{ .modern_protocol_error = protocol_error };
         }
         if (protocol_error.code != unsupported_protocol_version_code) {
-            return .{ .modern_protocol_error = protocol_error };
+            return .{ .legacy_fallback = .v2025_11_25 };
         }
         if (selectLegacyStdioVersion(protocol_error)) |version| {
             return .{ .legacy_fallback = version };
@@ -347,6 +347,51 @@ test "method-not-found discovery begins fallback at the newest legacy version" {
     switch (try classifyDiscoveryResponse(response.value)) {
         .legacy_fallback => |version| try std.testing.expectEqual(LegacyStdioVersion.v2025_11_25, version),
         else => return error.TestUnexpectedResult,
+    }
+}
+
+test "ordinary well-formed discovery errors begin legacy fallback independent of code" {
+    const responses = [_][]const u8{
+        "{\"jsonrpc\":\"2.0\",\"id\":0,\"error\":{\"code\":-32602,\"message\":\"Invalid params\"}}",
+        "{\"jsonrpc\":\"2.0\",\"id\":0,\"error\":{\"code\":-32000,\"message\":\"Server not initialized\"}}",
+    };
+    for (responses) |text| {
+        var response = try std.json.parseFromSlice(
+            std.json.Value,
+            std.testing.allocator,
+            text,
+            .{},
+        );
+        defer response.deinit();
+
+        switch (try classifyDiscoveryResponse(response.value)) {
+            .legacy_fallback => |version| try std.testing.expectEqual(
+                LegacyStdioVersion.v2025_11_25,
+                version,
+            ),
+            else => return error.TestUnexpectedResult,
+        }
+    }
+}
+
+test "recognized modern discovery errors never downgrade" {
+    const responses = [_][]const u8{
+        "{\"jsonrpc\":\"2.0\",\"id\":0,\"error\":{\"code\":-32021,\"message\":\"Missing required client capability\",\"data\":{\"capability\":\"roots\"}}}",
+        "{\"jsonrpc\":\"2.0\",\"id\":0,\"error\":{\"code\":-32022,\"message\":\"Unsupported protocol version\",\"data\":{\"supported\":[\"2026-07-28\"],\"requested\":\"2026-07-28\"}}}",
+    };
+    for (responses) |text| {
+        var response = try std.json.parseFromSlice(
+            std.json.Value,
+            std.testing.allocator,
+            text,
+            .{},
+        );
+        defer response.deinit();
+
+        switch (try classifyDiscoveryResponse(response.value)) {
+            .modern_protocol_error => {},
+            else => return error.TestUnexpectedResult,
+        }
     }
 }
 

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -593,7 +593,7 @@ pub fn acquireTimedAdvisoryLock(
     name: []const u8,
     deadline_ms: u64,
 ) !TimedAdvisoryLock {
-    return acquireTimedAdvisoryLockWithOps(dir, name, deadline_ms, .{});
+    return acquireTimedAdvisoryLockControlled(dir, name, deadline_ms, null, .{});
 }
 
 pub fn acquireTimedAdvisoryLockWithOps(
@@ -602,12 +602,56 @@ pub fn acquireTimedAdvisoryLockWithOps(
     deadline_ms: u64,
     ops: LockOps,
 ) !TimedAdvisoryLock {
+    return acquireTimedAdvisoryLockControlled(dir, name, deadline_ms, null, ops);
+}
+
+pub fn acquireTimedAdvisoryLockCancellable(
+    dir: *VerifiedDir,
+    name: []const u8,
+    deadline_ms: u64,
+    cancel_flag: *const std.atomic.Value(bool),
+) !TimedAdvisoryLock {
+    return acquireTimedAdvisoryLockControlled(
+        dir,
+        name,
+        deadline_ms,
+        cancel_flag,
+        .{},
+    );
+}
+
+pub fn acquireTimedAdvisoryLockCancellableWithOps(
+    dir: *VerifiedDir,
+    name: []const u8,
+    deadline_ms: u64,
+    cancel_flag: *const std.atomic.Value(bool),
+    ops: LockOps,
+) !TimedAdvisoryLock {
+    return acquireTimedAdvisoryLockControlled(
+        dir,
+        name,
+        deadline_ms,
+        cancel_flag,
+        ops,
+    );
+}
+
+fn acquireTimedAdvisoryLockControlled(
+    dir: *VerifiedDir,
+    name: []const u8,
+    deadline_ms: u64,
+    cancel_flag: ?*const std.atomic.Value(bool),
+    ops: LockOps,
+) !TimedAdvisoryLock {
     const file = try openOrCreatePrivateLockFile(dir, name);
     errdefer file.close(getIo());
 
     const started = ops.now_ms(ops.ctx);
     const deadline: i64 = started + @as(i64, @intCast(deadline_ms));
     while (true) {
+        if (cancel_flag) |flag| {
+            if (flag.load(.acquire)) return error.Cancelled;
+        }
         const locked = ops.try_lock(ops.ctx, file) catch |err| switch (err) {
             error.FileLocksUnsupported => return error.LockUnsupported,
             else => return err,
@@ -1122,6 +1166,56 @@ test "timed advisory lock returns busy after deadline" {
         acquireTimedAdvisoryLockWithOps(&dir, "settings.lock", 25, ops),
     );
     try std.testing.expect(state.lock_attempts > 1);
+}
+
+test "cancellable timed advisory lock stops between busy attempts" {
+    const CancelState = struct {
+        cancel: *std.atomic.Value(bool),
+        now_ms: i64 = 0,
+
+        fn tryLock(_: ?*anyopaque, _: std.Io.File) anyerror!bool {
+            return false;
+        }
+
+        fn now(raw: ?*anyopaque) i64 {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            return self.now_ms;
+        }
+
+        fn sleep(raw: ?*anyopaque, millis: u64) void {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.now_ms += @intCast(millis);
+            self.cancel.store(true, .release);
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var dir = VerifiedDir{ .dir = try tmp.dir.openDir(
+        getIo(),
+        ".",
+        .{ .iterate = true, .follow_symlinks = false },
+    ) };
+    defer dir.close();
+    var cancel = std.atomic.Value(bool).init(false);
+    var state = CancelState{ .cancel = &cancel };
+
+    try std.testing.expectError(
+        error.Cancelled,
+        acquireTimedAdvisoryLockCancellableWithOps(
+            &dir,
+            "credentials.lock",
+            2_000,
+            &cancel,
+            .{
+                .ctx = &state,
+                .try_lock = CancelState.tryLock,
+                .now_ms = CancelState.now,
+                .sleep_ms = CancelState.sleep,
+            },
+        ),
+    );
+    try std.testing.expectEqual(@as(i64, 10), state.now_ms);
 }
 
 test "timed advisory lock reports unsupported without unlocked fallback" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1357,14 +1357,18 @@ const App = struct {
         );
     }
 
-    pub fn reloadMcp(self: *App) !app_mcp_runtime.ReloadOutcome {
-        return self.mcp.reload(
+    pub fn beginMcpReload(self: *App) !void {
+        return self.mcp.beginReload(
             self.alloc,
             .{ .form = true, .url = true },
             if (comptime host_target.is_wasm) loadNoMcpRuntime else builtin_mcp.loadRuntime,
             self.toolRegistry(),
             @intCast(@max(io_mod.milliTimestamp(), 0)),
         );
+    }
+
+    pub fn takeMcpReloadCompletion(self: *App) !?app_mcp_runtime.ReloadCompletion {
+        return self.mcp.takeReloadCompletion();
     }
 
     pub fn startMcpDiscovery(self: *App) void {
@@ -1424,6 +1428,10 @@ const App = struct {
 
     pub fn listMcpServersAndTools(self: *App, alloc: Allocator) ![]u8 {
         return self.mcp.renderHealth(alloc);
+    }
+
+    pub fn summarizeMcpServers(self: *App, alloc: Allocator) ![]u8 {
+        return self.mcp.renderHealthSummary(alloc);
     }
 
     pub fn snapshotMcpToolNames(self: *App, alloc: Allocator) ![][]u8 {
@@ -2409,6 +2417,7 @@ const App = struct {
         if (try self.model_cache.pollLoadTransition()) {
             RenderAppRuntime.requestActiveSurfaceFrame(self, .footer);
         }
+        try app_commands.Handlers(App).collectMcpReloadFacts(self);
         if (comptime host_profile.native_auth or host_profile.js_host_auth) {
             try AuthAppRuntime.collectSignInFacts(self);
         }

--- a/src/ui/footer/approval_ui.zig
+++ b/src/ui/footer/approval_ui.zig
@@ -1448,6 +1448,7 @@ pub fn composeApprovalPanelRow(alloc: Allocator, approval: ApprovalProjection, w
             &action_line.writer,
             label.bytes,
             if (preview) |value| value.bytes else null,
+            width,
         );
 
         var action_row: std.ArrayList(u8) = .empty;
@@ -1926,6 +1927,7 @@ fn writeApprovalActionLine(
     writer: *std.Io.Writer,
     label: []const u8,
     tool_arguments_preview: ?[]const u8,
+    width: u16,
 ) !void {
     const target = approvalActionTarget(approvalTarget(label));
     if (std.mem.startsWith(u8, label, "run_command ")) {
@@ -1933,10 +1935,15 @@ fn writeApprovalActionLine(
         return;
     }
     if (tool_arguments_preview) |preview| {
-        try writer.print(
-            "  {s} · Arguments for this request: {s}",
-            .{ target, preview },
-        );
+        const verbose_prefix_bytes = 2 + target.len + " · Arguments for this request: ".len;
+        if (width < verbose_prefix_bytes + 16) {
+            try writer.print("  {s} · {s}", .{ target, preview });
+        } else {
+            try writer.print(
+                "  {s} · Arguments for this request: {s}",
+                .{ target, preview },
+            );
+        }
         return;
     }
     try writer.print("  {s}", .{target});

--- a/src/ui/footer/approval_ui.zig
+++ b/src/ui/footer/approval_ui.zig
@@ -1510,17 +1510,18 @@ fn buildApprovalPanelLineWithLabel(
     const r = ui_render.reset_style;
     const target = approvalTarget(label);
     const explanation = approval.request.explanation;
+    const dynamic_mcp = approval.request.tool_arguments_preview != null;
 
     if (row_count >= interaction_state.approval_panel_rows_spacious) {
         return switch (row_index) {
             0 => "  Permission needed · Choose one",
             1 => "",
-            2 => std.fmt.bufPrint(buf, "  {s}{s}{s}", .{ b, approvalQuestion(label), r }) catch "  Permission request",
-            3 => approvalReasonLine(buf, label, target, explanation),
+            2 => std.fmt.bufPrint(buf, "  {s}{s}{s}", .{ b, approvalQuestion(label, dynamic_mcp), r }) catch "  Permission request",
+            3 => approvalReasonLine(buf, label, target, explanation, dynamic_mcp),
             4 => approvalActionLine(buf, label, target),
             5 => "",
             6 => approvalChoiceLine(buf, approval.choice_index == 0, approvalChoiceLabel(approval, 0)),
-            7 => approvalChoiceLine(buf, approval.choice_index == 1, approvalAlwaysChoice(label)),
+            7 => approvalChoiceLine(buf, approval.choice_index == 1, approvalAlwaysChoice(approval, label)),
             8 => approvalChoiceLine(buf, approval.choice_index == 2, approvalChoiceLabel(approval, 2)),
             9 => "",
             10 => std.fmt.bufPrint(buf, "  {s}{s}{s}", .{ dim, approvalHint(approval, width -| 2), r }) catch interaction_state.approval_hint,
@@ -1530,11 +1531,11 @@ fn buildApprovalPanelLineWithLabel(
 
     return switch (row_index) {
         0 => "  Permission needed · Choose one",
-        1 => std.fmt.bufPrint(buf, "  {s}{s}{s}", .{ b, approvalQuestion(label), r }) catch "  Permission request",
-        2 => approvalReasonLine(buf, label, target, explanation),
+        1 => std.fmt.bufPrint(buf, "  {s}{s}{s}", .{ b, approvalQuestion(label, dynamic_mcp), r }) catch "  Permission request",
+        2 => approvalReasonLine(buf, label, target, explanation, dynamic_mcp),
         3 => approvalActionLine(buf, label, target),
         4 => approvalChoiceLine(buf, approval.choice_index == 0, approvalChoiceLabel(approval, 0)),
-        5 => approvalChoiceLine(buf, approval.choice_index == 1, approvalAlwaysChoice(label)),
+        5 => approvalChoiceLine(buf, approval.choice_index == 1, approvalAlwaysChoice(approval, label)),
         6 => approvalChoiceLine(buf, approval.choice_index == 2, approvalChoiceLabel(approval, 2)),
         7 => std.fmt.bufPrint(buf, "  {s}{s}{s}", .{ dim, approvalHint(approval, width -| 2), r }) catch interaction_state.approval_hint,
         else => "",
@@ -1689,6 +1690,13 @@ fn writeApprovalPlaceholder(writer: *std.Io.Writer, placeholder: []const u8) !vo
 
 fn approvalChoiceLabel(approval: ApprovalProjection, choice: u8) []const u8 {
     if (approval.amendmentChoice() == choice) return approvalAmendmentLabel(choice);
+    if (approval.request.tool_arguments_preview != null) {
+        return switch (choice) {
+            0 => "1. Allow once",
+            2 => "3. Deny",
+            else => "",
+        };
+    }
     return switch (choice) {
         0 => interaction_state.approval_once_label,
         2 => interaction_state.approval_deny_label,
@@ -1760,7 +1768,10 @@ fn composeApprovalHeaderRow(
         "Permission needed · Choose one",
     );
     defer title.deinit(alloc);
-    const kind = approvalKind(label);
+    const kind = approvalKind(
+        label,
+        approval.request.tool_arguments_preview != null,
+    );
     const inset_width = 2;
     const right_margin = 2;
     const inner_width = @as(usize, width) -| (inset_width + right_margin);
@@ -1817,7 +1828,8 @@ fn approvalTitle(
     };
 }
 
-fn approvalKind(label: []const u8) []const u8 {
+fn approvalKind(label: []const u8, dynamic_mcp: bool) []const u8 {
+    if (dynamic_mcp) return "MCP tool";
     if (std.mem.startsWith(u8, label, "run_command ")) return "Command";
     if (std.mem.startsWith(u8, label, "write_file ")) return "Write file";
     if (std.mem.startsWith(u8, label, "edit_file ")) return "Edit file";
@@ -1830,7 +1842,8 @@ fn approvalKind(label: []const u8) []const u8 {
     return "Tool";
 }
 
-fn approvalQuestion(label: []const u8) []const u8 {
+fn approvalQuestion(label: []const u8, dynamic_mcp: bool) []const u8 {
+    if (dynamic_mcp) return "Allow this MCP tool call?";
     if (std.mem.startsWith(u8, label, "run_command ")) return "Would you like to run the following command?";
     if (std.mem.startsWith(u8, label, "write_file ")) return "Would you like to create or update this file?";
     if (std.mem.startsWith(u8, label, "edit_file ")) return "Would you like to edit this file?";
@@ -1861,7 +1874,13 @@ fn approvalTarget(label: []const u8) []const u8 {
     return label;
 }
 
-fn approvalReasonLine(buf: []u8, label: []const u8, target: []const u8, explanation: ?[]const u8) []const u8 {
+fn approvalReasonLine(
+    buf: []u8,
+    label: []const u8,
+    target: []const u8,
+    explanation: ?[]const u8,
+    dynamic_mcp: bool,
+) []const u8 {
     const dim = ui_render.dim_style;
     const r = ui_render.reset_style;
     if (explanation) |text| {
@@ -1869,6 +1888,13 @@ fn approvalReasonLine(buf: []u8, label: []const u8, target: []const u8, explanat
     }
     if (approvalAnnotation(target)) |annotation| {
         return std.fmt.bufPrint(buf, "  {s}Reason:{s} {s}", .{ dim, r, annotation }) catch "  Reason: permission required";
+    }
+    if (dynamic_mcp) {
+        return std.fmt.bufPrint(
+            buf,
+            "  {s}Reason:{s} This MCP tool needs approval before fx can send the request.",
+            .{ dim, r },
+        ) catch "  Reason: MCP tool approval required";
     }
     if (std.mem.startsWith(u8, label, "run_command ")) {
         if (firstUrlHost(target)) |host| {
@@ -1906,10 +1932,14 @@ fn writeApprovalActionLine(
         try writer.print("  $ {s}", .{target});
         return;
     }
-    try writer.print("  {s}", .{target});
     if (tool_arguments_preview) |preview| {
-        try writer.print("  {s}", .{preview});
+        try writer.print(
+            "  {s} · Arguments for this request: {s}",
+            .{ target, preview },
+        );
+        return;
     }
+    try writer.print("  {s}", .{target});
 }
 
 pub fn commandTarget(label: []const u8) ?[]const u8 {
@@ -1921,7 +1951,10 @@ pub fn commandTargetForApproval(label: []const u8, command: ?[]const u8) ?[]cons
     return command orelse commandTarget(label);
 }
 
-fn approvalAlwaysChoice(label: []const u8) []const u8 {
+fn approvalAlwaysChoice(approval: ApprovalProjection, label: []const u8) []const u8 {
+    if (approval.request.tool_arguments_preview != null) {
+        return "2. Allow this MCP tool for this session";
+    }
     if (std.mem.startsWith(u8, label, "run_command ")) return "2. Yes, and don't ask again for this exact command";
     return "2. Yes, and don't ask again for this request";
 }
@@ -2174,8 +2207,28 @@ test "approval panel shows bounded terminal-safe tool arguments with ellipsis" {
     try std.testing.expect(std.mem.find(
         u8,
         wide.items,
-        "mcp_fixture_echo  {\"text\":\"\\x1b\\x0a\\xff sentinel\"}",
+        "Arguments for this request: {\"text\":\"\\x1b\\x0a\\xff sentinel\"}",
     ) != null);
+
+    const projection = prompt.projection().?;
+    inline for ([_]struct { row: u16, expected: []const u8 }{
+        .{ .row = 0, .expected = "MCP tool" },
+        .{ .row = 2, .expected = "Allow this MCP tool call?" },
+        .{ .row = 3, .expected = "This MCP tool needs approval" },
+        .{ .row = 6, .expected = "Allow once" },
+        .{ .row = 7, .expected = "Allow this MCP tool for this session" },
+        .{ .row = 8, .expected = "Deny" },
+    }) |expectation| {
+        var row = try composeApprovalPanelRow(
+            alloc,
+            projection,
+            120,
+            expectation.row,
+            interaction_state.approval_panel_rows_spacious,
+        );
+        defer row.deinit(alloc);
+        try std.testing.expect(std.mem.find(u8, row.items, expectation.expected) != null);
+    }
 
     var narrow = try composeApprovalPanelRow(
         alloc,

--- a/tests/e2e/fixtures/mcp-legacy-stdio.mjs
+++ b/tests/e2e/fixtures/mcp-legacy-stdio.mjs
@@ -8,6 +8,7 @@ const invalidationReleasePath = process.env.FX_MCP_INVALIDATION_RELEASE_PATH;
 const legacyVersion = process.env.FX_MCP_LEGACY_VERSION ?? "2024-11-05";
 const discoveryVersions = process.env.FX_MCP_LEGACY_DISCOVERY_VERSIONS?.split(",");
 const discoveryMethodNotFound = process.env.FX_MCP_LEGACY_DISCOVERY_METHOD_NOT_FOUND === "1";
+const discoveryInvalidParams = process.env.FX_MCP_LEGACY_DISCOVERY_INVALID_PARAMS === "1";
 const rejectNewerInitialize = process.env.FX_MCP_LEGACY_REJECT_NEWER_INITIALIZE === "1";
 const draft7Pattern = process.env.FX_MCP_DRAFT7_PATTERN;
 const elicitationUrl = process.env.FX_MCP_ELICITATION_URL ?? "https://example.test/authorize";
@@ -179,6 +180,14 @@ function handle(message) {
   }
 
   if (message.method === "server/discover") {
+    if (discoveryInvalidParams) {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32602, message: "Invalid params" },
+      });
+      return;
+    }
     if (discoveryVersions) {
       send({
         jsonrpc: "2.0",

--- a/tests/e2e/fixtures/mcp-modern-stdio.mjs
+++ b/tests/e2e/fixtures/mcp-modern-stdio.mjs
@@ -492,6 +492,21 @@ function handle(message) {
   }
   if (message.method === "tools/call") {
     if (mode === "stall_operation") return;
+    if (mode === "tool_failure") {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          resultType: "complete",
+          isError: true,
+          content: [{
+            type: "text",
+            text: "Invalid input: labels require at least one item",
+          }],
+        },
+      });
+      return;
+    }
     if (mode === "crash_always") process.exit(42);
     if (
       [

--- a/tests/e2e/fixtures/mcp-stdio-dispatcher-driver.zig
+++ b/tests/e2e/fixtures/mcp-stdio-dispatcher-driver.zig
@@ -758,13 +758,15 @@ const InteractiveAuthAttempt = struct {
             return;
         }
         defer if (self.acquire_lease) self.runtime.releaseUse();
-        self.runtime.authenticateServer(
+        var result = self.runtime.authenticateServer(
             "fixture",
             @ptrCast(self.opener),
             InteractiveAuthOpener.open,
         ) catch |err| {
             self.err = err;
+            return;
         };
+        result.deinit();
     }
 };
 

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -572,7 +572,7 @@ async function waitForMcpServerReady(
     pane.split("\n").some((line) =>
       line.includes(`${serverName} `) && line.includes(` state=${state}`)
     );
-  await session.sendText("/mcp");
+  await session.sendText("/mcp list");
   const status = await session.waitForPane(
     (pane) => hasServerState(pane, "ready") || hasServerState(pane, "failed"),
     timeoutMs,

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -177,6 +177,7 @@ function startAuthFixture(
     rotateOnResourceReadCall?: number;
     failFeatureRefreshAfterRotation?: boolean;
     rejectResourceTemplateAuth?: boolean;
+    authorizationServerTrailingSlash?: boolean;
   } = {},
 ) {
   const transport = options.transport ?? "http";
@@ -371,7 +372,9 @@ function startAuthFixture(
       ) {
         return Response.json({
           resource,
-          authorization_servers: [origin],
+          authorization_servers: [
+            options.authorizationServerTrailingSlash ? `${origin}/` : origin,
+          ],
           scopes_supported: ["tools.read", "tools.call", "offline_access"],
         });
       }
@@ -1712,6 +1715,9 @@ describe("MCP remote authentication lifecycle", () => {
       });
       await tui.waitForComposer(15_000);
       await tui.sendText("/mcp");
+      const summary = await tui.waitForText("1 ready", 5_000);
+      expect(summary).toContain("Use /mcp list for details.");
+      await tui.sendText("/mcp list");
       const status = await tui.waitForText("auth=authenticated", 5_000);
       expect(status).not.toContain(ACCESS_REFRESHED);
       await tui.sendText("/mcp logout fixture");
@@ -1740,6 +1746,57 @@ describe("MCP remote authentication lifecycle", () => {
       }
     },
     60_000,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "issuer mismatch stays exact and reports the configuration override",
+    async () => {
+      upstream = startModernMcpHttpFixture("json");
+      auth = startAuthFixture(upstream.url, {
+        authorizationServerTrailingSlash: true,
+      });
+      const root = createRoot(auth);
+      gateway = startFakeGateway([], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+      tui = await TmuxSession.create({
+        isolated: true,
+        cwd: root.workspace,
+        env: {
+          ...baseEnv(root),
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+        },
+        width: 120,
+        height: 34,
+      });
+      await tui.waitForComposer(15_000);
+
+      await tui.sendText("/mcp auth fixture --open");
+      const mismatch = await tui.waitForText(
+        "Add \"oauth\":{\"issuer\":",
+        15_000,
+      );
+      const origin = new URL(auth.url).origin;
+      const compactMismatch = mismatch.replace(/\s+/g, " ");
+      expect(compactMismatch).toContain(`expected issuer "${origin}/"`);
+      expect(compactMismatch).toContain(`metadata returned "${origin}"`);
+      expect(compactMismatch).toContain(`\"issuer\":\"${origin}\"`);
+      expect(auth.authorizationRequests).toBe(0);
+      expect(auth.tokenExchanges).toBe(0);
+
+      const profilePath = join(root.home, ".fx", "mcp.json");
+      const profile = JSON.parse(readFileSync(profilePath, "utf8"));
+      profile.mcp.fixture.oauth.issuer = origin;
+      writeFileSync(profilePath, JSON.stringify(profile));
+      await tui.sendText("/mcp reload");
+      await tui.waitForText("MCP profile reloaded", 15_000);
+      await tui.sendText("/mcp auth fixture --open");
+      await tui.waitForText("Authenticated MCP server 'fixture'.", 15_000);
+      expect(auth.authorizationRequests).toBe(1);
+      expect(auth.tokenExchanges).toBe(1);
+    },
+    45_000,
   );
 
   test.skipIf(!tmuxAvailable())(

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -86,6 +86,7 @@ type RootOptions = {
     | "progress"
     | "stall_operation"
     | "stall_startup"
+    | "tool_failure"
     | "response_missing_jsonrpc"
     | "response_wrong_jsonrpc"
     | "response_missing_payload"
@@ -116,6 +117,7 @@ type RootOptions = {
   legacyVersion?: "2025-06-18" | "2025-11-25";
   legacyDiscoveryVersions?: readonly ["2024-11-05", "2025-06-18", "2025-11-25"];
   legacyDiscoveryMethodNotFound?: boolean;
+  legacyDiscoveryInvalidParams?: boolean;
   legacyRejectNewerInitialize?: boolean;
   draft7Pattern?: string;
   urlRequiredOperation?: "tools" | "resources" | "prompts";
@@ -187,6 +189,8 @@ function createRoot(
               options.legacyDiscoveryVersions?.join(","),
             FX_MCP_LEGACY_DISCOVERY_METHOD_NOT_FOUND:
               options.legacyDiscoveryMethodNotFound ? "1" : undefined,
+            FX_MCP_LEGACY_DISCOVERY_INVALID_PARAMS:
+              options.legacyDiscoveryInvalidParams ? "1" : undefined,
             FX_MCP_LEGACY_REJECT_NEWER_INITIALIZE:
               options.legacyRejectNewerInitialize ? "1" : undefined,
             FX_MCP_DRAFT7_PATTERN: options.draft7Pattern,
@@ -1224,6 +1228,72 @@ describe("modern MCP stdio compatibility", () => {
     await expectFixtureProcessesExited(wire);
   }, 30_000);
 
+  test("invalid-params discovery falls back through initialize and tools call", async () => {
+    const root = createRoot("legacy-invalid-params", LEGACY_FIXTURE, {
+      legacyVersion: "2025-11-25",
+      legacyDiscoveryInvalidParams: true,
+    });
+    gateway = startToolGateway("Invalid params fallback complete.");
+
+    const result = await runFx(
+      ["ask", "--json", "--auto", "--no-save", "Use the legacy stdio MCP tool."],
+      {
+        cwd: root.workspace,
+        env: fixtureEnv(root, gateway),
+        timeoutMs: 20_000,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout).output).toContain(
+      "Invalid params fallback complete.",
+    );
+    const wire = readWire(root.wireLogPath);
+    expect(wire.filter((entry) => entry.message.method === "server/discover"))
+      .toHaveLength(1);
+    expect(wire.filter((entry) => entry.message.method === "initialize"))
+      .toHaveLength(1);
+    expect(wire.filter((entry) => entry.message.method === "tools/list"))
+      .toHaveLength(1);
+    expect(wire.filter((entry) => entry.message.method === "tools/call"))
+      .toHaveLength(1);
+    await expectFixtureProcessesExited(wire);
+  }, 30_000);
+
+  test("third equivalent dynamic MCP failure is blocked before transport", async () => {
+    const root = createRoot("bounded-equivalent-retries", MODERN_FIXTURE, {
+      mode: "tool_failure",
+    });
+    gateway = startFakeGateway([
+      fakeGatewayToolCall("retry_select", "mcp_select_tool", { name: TOOL_NAME }),
+      fakeGatewayToolCall("retry_call_1", TOOL_NAME, { text: "one" }),
+      fakeGatewayToolCall("retry_call_2", TOOL_NAME, { text: "two" }),
+      fakeGatewayToolCall("retry_call_3", TOOL_NAME, { text: "three" }),
+      fakeGatewayFinalText("Bounded MCP retries complete."),
+    ], {
+      models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+    });
+
+    const result = await runFx(
+      ["ask", "--json", "--auto", "--no-save", "Call the failing MCP tool."],
+      {
+        cwd: root.workspace,
+        env: fixtureEnv(root, gateway),
+        timeoutMs: 20_000,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout).output).toContain("Bounded MCP retries complete.");
+    const wire = readWire(root.wireLogPath);
+    expect(wire.filter((entry) => entry.message.method === "tools/call"))
+      .toHaveLength(2);
+    expect(gateway.requests.at(-1)?.body).toContain(
+      "Repeated MCP tool call blocked: two equivalent attempts failed",
+    );
+    await expectFixtureProcessesExited(wire);
+  }, 30_000);
+
   test("successful discovery selects the latest legacy version from an oldest-first list", async () => {
     const root = createRoot("legacy-discovery-oldest-first", LEGACY_FIXTURE, {
       legacyVersion: "2025-11-25",
@@ -2029,6 +2099,48 @@ describe("modern MCP stdio compatibility", () => {
       expect(wire[2]?.message.params?._meta).toMatchObject({
         progressToken: expect.any(Number),
       });
+
+      await tui.kill();
+      tui = null;
+      await expectFixtureProcessesExited(wire);
+    },
+    30_000,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "the TUI shows a safe MCP failure detail while preserving model context",
+    async () => {
+      const root = createRoot("tui-tool-failure", MODERN_FIXTURE, {
+        mode: "tool_failure",
+        expectedElicitation: "both",
+      });
+      const activeGateway = startToolGateway("MCP failure detail complete.");
+      gateway = activeGateway;
+      const stderrPath = join(root.root, "stderr.log");
+      tui = await TmuxSession.create({
+        isolated: true,
+        cwd: root.workspace,
+        width: 120,
+        height: 32,
+        stderrPath,
+        env: fixtureEnv(root, activeGateway),
+      });
+
+      await tui.waitForComposer(15_000);
+      await tui.sendText("Call the failing MCP fixture once.");
+      await tui.waitForText(
+        `Failed ${TOOL_NAME}: Invalid input: labels require at least one item`,
+        20_000,
+      );
+      await tui.waitForText("MCP failure detail complete.", 20_000);
+
+      expect(activeGateway.requests.at(-1)?.body).toContain(
+        "Invalid input: labels require at least one item",
+      );
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      const wire = readWire(root.wireLogPath);
+      expect(wire.filter((entry) => entry.message.method === "tools/call"))
+        .toHaveLength(1);
 
       await tui.kill();
       tui = null;
@@ -3604,6 +3716,50 @@ describe("modern MCP stdio compatibility", () => {
   );
 
   test.skipIf(process.platform === "win32" || !tmuxAvailable())(
+    "MCP reload keeps queued input responsive and cancels a superseded candidate",
+    async () => {
+      const root = createRoot("reload-responsive", MODERN_FIXTURE);
+      const activeGateway = startFakeGateway([], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+      gateway = activeGateway;
+      tui = await TmuxSession.create({
+        isolated: true,
+        cwd: root.workspace,
+        width: 110,
+        height: 32,
+        env: fixtureEnv(root, activeGateway),
+      });
+      await tui.waitForComposer(15_000);
+
+      const profilePath = join(root.home, ".fx", "mcp.json");
+      const profile = JSON.parse(readFileSync(profilePath, "utf8"));
+      profile.mcp.fixture.environment.FX_MCP_MODE = "stall_startup";
+      profile.mcp.fixture.startup_timeout_ms = 60_000;
+      writeFileSync(profilePath, JSON.stringify(profile));
+
+      await tui.sendText("/mcp reload");
+      await tui.waitForText("MCP reconnection started", 2_000);
+      const pathStarted = Date.now();
+      await tui.sendText("/mcp path");
+      await tui.waitForText("mcp.json", 1_000);
+      expect(Date.now() - pathStarted).toBeLessThan(1_000);
+
+      profile.mcp.fixture.environment.FX_MCP_MODE = "normal";
+      writeFileSync(profilePath, JSON.stringify(profile));
+      const supersedeStarted = Date.now();
+      await tui.sendText("/mcp reload");
+      await tui.waitForText("MCP profile reloaded (ready, runtime ", 1_000);
+      expect(Date.now() - supersedeStarted).toBeLessThan(1_000);
+
+      await tui.kill();
+      tui = null;
+      await expectFixtureProcessesExited(readWire(root.wireLogPath));
+    },
+    30_000,
+  );
+
+  test.skipIf(process.platform === "win32" || !tmuxAvailable())(
     "implicit MCP reload rejection preserves command success and warns that the prior runtime remains active",
     async () => {
       const root = createRoot("implicit-reload-warning", MODERN_FIXTURE);
@@ -3633,10 +3789,13 @@ describe("modern MCP stdio compatibility", () => {
       writeFileSync(profilePath, JSON.stringify(profile));
 
       await tui.sendText("/mcp add extra /definitely/missing-optional-mcp-command");
-      const pane = await tui.waitForText("the previous runtime remains active", 10_000);
+      const pane = await tui.waitForText(
+        "MCP reload rejected; the existing runtime was retained",
+        10_000,
+      );
       expect(pane).toContain("Saved MCP server 'extra'.");
-      expect(pane).toContain("Warning: MCP runtime reload was rejected");
-      expect(pane).toContain("run /mcp reload");
+      expect(pane).toContain("MCP reconnection started");
+      expect(pane).toContain("Required MCP server 'fixture' is failed");
       expect(isProcessAlive(originalPid)).toBe(true);
 
       await tui.sendText(prompt);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -5114,12 +5114,13 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
   );
 
   test(
-    "dynamic MCP approval shows exact arguments and gates deny and allow",
+    "dynamic MCP approval shows exact arguments and preserves deny once and session scope",
     async () => {
       root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-mcp-approval-")));
       const dynamicToolName = "mcp_fixture_echo";
       const argumentSentinel = "FXC194_ARGUMENT_SENTINEL";
-      for (const decision of ["deny", "allow"] as const) {
+      const secondArgumentSentinel = "FXC194_SECOND_ARGUMENT_SENTINEL";
+      for (const decision of ["deny", "allow", "session"] as const) {
         const runRoot = join(root, decision);
         const home = join(runRoot, "home");
         const workspace = join(runRoot, "workspace");
@@ -5157,6 +5158,20 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
               finishReason: { unified: "tool-calls", raw: "tool-calls" },
             },
           ]),
+          ...(decision === "session"
+            ? [fakeGatewaySse([
+              {
+                type: "tool-call",
+                toolCallId: "call_approval_mcp_session_second",
+                toolName: dynamicToolName,
+                input: { text: secondArgumentSentinel },
+              },
+              {
+                type: "finish",
+                finishReason: { unified: "tool-calls", raw: "tool-calls" },
+              },
+            ])]
+            : []),
           fakeGatewayFinalText(finalText),
         ]);
         gateway = mcpGateway;
@@ -5182,19 +5197,32 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
           await session.waitForComposer(TIMEOUT);
           await session.sendText("Run the MCP fixture with the exact sentinel.");
-          const approval = await session.waitForText(APPROVAL_PROMPT, TIMEOUT);
+          const approval = await session.waitForText(
+            "Allow this MCP tool call?",
+            TIMEOUT,
+          );
+          expect(approval).toContain("MCP tool");
+          expect(approval).toContain("Arguments for this request");
+          expect(approval).toContain("Allow once");
+          expect(approval).toContain("Allow this MCP tool for this session");
+          expect(approval).toContain("Deny");
           expect(approval).toContain(dynamicToolName);
           expect(approval).toContain(`{"text":"${argumentSentinel}"}`);
           expect(existsSync(fixture.callStartedPath)).toBe(false);
 
-          await session.sendLiteralText(decision === "deny" ? "3" : "1");
+          await session.sendLiteralText(
+            decision === "deny" ? "3" : decision === "session" ? "2" : "1",
+          );
           await session.waitForText(finalText, TIMEOUT);
           if (decision === "deny") {
             expect(existsSync(fixture.callStartedPath)).toBe(false);
           } else {
             const calls = readDelayedMcpCalls(fixture.callStartedPath);
-            expect(calls).toHaveLength(1);
+            expect(calls).toHaveLength(decision === "session" ? 2 : 1);
             expect(calls[0]?.arguments).toEqual({ text: argumentSentinel });
+            if (decision === "session") {
+              expect(calls[1]?.arguments).toEqual({ text: secondArgumentSentinel });
+            }
           }
           expect(readFileSync(stderrPath, "utf8")).toBe("");
         } finally {

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -5331,7 +5331,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
           await session.waitForComposer(TIMEOUT);
           await session.sendText(parentPrompt);
-          const approval = await session.waitForText(APPROVAL_PROMPT, TIMEOUT);
+          const approval = await session.waitForText(
+            "Allow this MCP tool call?",
+            TIMEOUT,
+          );
           expect(approval).toContain(dynamicToolName);
           expect(approval).toContain(`{"text":"${argumentSentinel}"}`);
           expect(existsSync(fixture.callStartedPath)).toBe(false);
@@ -5436,7 +5439,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       await session.waitForComposer(TIMEOUT);
       await session.sendText("Run the MCP fixture with overlong arguments.");
-      const approval = await session.waitForText(APPROVAL_PROMPT, TIMEOUT);
+      const approval = await session.waitForText(
+        "Allow this MCP tool call?",
+        TIMEOUT,
+      );
       expect(approval).toContain(dynamicToolName);
       expect(approval).toContain("FXC194_OVER");
       expect(approval).toContain("…");
@@ -5526,7 +5532,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       let mcpStatus = "";
       const readyStatus = "fixture source=profile scope=profile policy=optional transport=stdio state=ready";
       while (Date.now() < readyDeadline) {
-        await session.sendText("/mcp");
+        await session.sendText("/mcp list");
         mcpStatus = await session.captureFullScrollback();
         if (mcpStatus.includes(readyStatus)) break;
         await Bun.sleep(100);

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -171,6 +171,9 @@ describe.skipIf(SKIP_TMUX)("tui: MCP startup", () => {
         expect(discoveryRequests).toBe(1);
 
         await session.sendText("/mcp");
+        const summary = await session.waitForText("1 connecting", 5_000);
+        expect(summary).toContain("Use /mcp list for details.");
+        await session.sendText("/mcp list");
         const status = await session.waitForText("state=connecting", 5_000);
         expect(status).toContain("pending source=profile scope=profile policy=optional");
 


### PR DESCRIPTION
## Summary

- Fall back from non-modern stdio discovery errors to the standard initialize handshake while preserving recognized modern failures.
- Report exact OAuth issuer mismatches with a usable `oauth.issuer` override.
- Keep transactional MCP reloads responsive by cancelling transport, credential-lock, and Keychain work.
- Surface bounded MCP server failures and stop a third matching failed call before approval or transport.
- Make bare `/mcp` concise while retaining detailed `/mcp list` diagnostics and explicit browser consent.
- Show current MCP arguments separately from truthful tool-level session approval.