### PR TITLE
Release closed tool groups into native scrollback

### DIFF
--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -5319,6 +5319,31 @@ test "tool presentation groups span silent steps and split on visible assistant 
     try std.testing.expect(
         groups[0].anchor_step_id != groups[2].anchor_step_id,
     );
+
+    var group_b_start_index: ?usize = null;
+    var group_a_terminal_count: usize = 0;
+    for (hooks.lifecycle_events.items, 0..) |event, index| {
+        switch (event) {
+            .authoritative_started => |started| {
+                if (started.presentation_group_id) |group| {
+                    if (std.meta.eql(group, groups[2])) {
+                        group_b_start_index = index;
+                        break;
+                    }
+                }
+            },
+            .terminal => |terminal| {
+                if (std.mem.eql(u8, terminal.id.call_id, "call_1") or
+                    std.mem.eql(u8, terminal.id.call_id, "call_2"))
+                {
+                    group_a_terminal_count += 1;
+                }
+            },
+            .provisional, .progress, .turn_finished => {},
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 2), group_a_terminal_count);
+    try std.testing.expect(group_b_start_index != null);
 }
 
 test "processQueuedPrompt no-tool length bypasses silent-tool continuation" {

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -3398,6 +3398,86 @@ test "structured command-output rewrite materializes committed transcript scroll
     try expectGridContains(&h, "follow-up table row 60");
 }
 
+fn applyCompletedReadForGroupFinalityResizeTest(
+    h: *Harness,
+    turn_id: u64,
+    call_id: []const u8,
+    group_id: types.ToolPresentationGroupId,
+) !void {
+    const id = types.ToolLifecycleId{ .turn_id = turn_id, .call_id = call_id };
+    _ = try h.shell.applyToolLifecycle(h.alloc, .{ .authoritative_started = .{
+        .id = id,
+        .presentation_group_id = group_id,
+        .reconciles_provisional_call_id = null,
+        .tool_name = "read_file",
+        .activity_kind = .read,
+    } });
+    _ = try h.shell.applyToolLifecycle(h.alloc, .{ .terminal = .{
+        .id = id,
+        .outcome = .{ .kind = .completed, .summary = "Read fixed-point fixture" },
+    } });
+}
+
+test "closed tool group finality flows through fixed point resolution and sealing" {
+    const alloc = std.testing.allocator;
+    var h = try Harness.init(alloc, 80, 14, 3);
+    defer h.deinit();
+    h.shell.maxxing_mode = .minimal;
+
+    var input = InputRuntime{};
+    defer input.deinit(alloc);
+    var approval = approval_prompt.ApprovalPrompt{};
+    defer approval.deinit(alloc);
+
+    try h.shell.initViewport(&h.metrics, 8);
+    for (0..4) |index| {
+        var line: [32]u8 = undefined;
+        const text = try std.fmt.bufPrint(&line, "startup row {d}\n", .{index});
+        _ = try h.shell.appendRawTranscriptEntry(alloc, text);
+    }
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    const group_a = types.ToolPresentationGroupId{ .turn_id = 92, .anchor_step_id = 1 };
+    var group_a_call_ids: [18][20]u8 = undefined;
+    for (0..group_a_call_ids.len) |index| {
+        const call_id = try std.fmt.bufPrint(
+            &group_a_call_ids[index],
+            "fixed-a-{d:0>2}",
+            .{index},
+        );
+        try applyCompletedReadForGroupFinalityResizeTest(&h, 92, call_id, group_a);
+    }
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    var held_source = try h.shell.prepareTranscriptSource(alloc, null);
+    defer held_source.deinit(alloc);
+    const held = h.shell.stableTranscriptProjectionForFlow(held_source.bytes) orelse
+        return error.TestExpectedStableTranscript;
+    try std.testing.expect(held.visual_offset > held.history_visual_offset);
+
+    _ = try h.shell.appendRawTranscriptEntry(alloc, "SECOND_GROUP_INTRO\n");
+    const group_b = types.ToolPresentationGroupId{ .turn_id = 92, .anchor_step_id = 2 };
+    try applyCompletedReadForGroupFinalityResizeTest(&h, 92, "fixed-b-1", group_b);
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    try std.testing.expect(h.last_frame.planned_scroll_rows > 0);
+    try std.testing.expect(h.last_frame.committed_scroll_rows > 0);
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
+
+    var released_source = try h.shell.prepareTranscriptSource(alloc, null);
+    defer released_source.deinit(alloc);
+    const released = h.shell.stableTranscriptProjectionForFlow(released_source.bytes) orelse
+        return error.TestExpectedStableTranscript;
+    try std.testing.expect(released.history_visual_offset > held.history_visual_offset);
+    try std.testing.expect(released.visual_offset >= released.history_visual_offset);
+    try expectGridContains(&h, "SECOND_GROUP_INTRO");
+}
+
 test "hidden auto approval lifecycle reposition adds no compact scroll rows" {
     var h = try Harness.init(std.testing.allocator, 80, 12, 4);
     defer h.deinit();

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -15769,3 +15769,122 @@ test "finality candidates keep tool turn and replaceable tail offsets independen
     try std.testing.expect(source.replaceable_start > group_floor.start_byte);
     try std.testing.expect(source.replaceable_start < source.bytes.len);
 }
+
+fn applyCompletedReadForFinalityTest(
+    runtime: *TranscriptRuntime,
+    alloc: Allocator,
+    turn_id: u64,
+    call_id: []const u8,
+    presentation_group_id: ?types.ToolPresentationGroupId,
+) !void {
+    const id = types.ToolLifecycleId{ .turn_id = turn_id, .call_id = call_id };
+    _ = try runtime.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = id,
+        .presentation_group_id = presentation_group_id,
+        .reconciles_provisional_call_id = null,
+        .tool_name = "read_file",
+        .activity_kind = .read,
+    } });
+    _ = try runtime.applyToolLifecycle(alloc, .{ .terminal = .{
+        .id = id,
+        .outcome = .{ .kind = .completed, .summary = "Read finality fixture" },
+    } });
+}
+
+test "finality candidates anchor a fully grouped turn at its newest rendered group" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(80, 14, 10),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+    runtime.maxxing_mode = .minimal;
+
+    const group_a = types.ToolPresentationGroupId{ .turn_id = 9, .anchor_step_id = 1 };
+    for ([_][]const u8{ "group-a-1", "group-a-2", "group-a-3" }) |call_id| {
+        try applyCompletedReadForFinalityTest(&runtime, alloc, 9, call_id, group_a);
+    }
+    _ = try runtime.appendRawTranscriptEntry(alloc, "SECOND_GROUP_INTRO\n");
+    const group_b = types.ToolPresentationGroupId{ .turn_id = 9, .anchor_step_id = 2 };
+    try applyCompletedReadForFinalityTest(&runtime, alloc, 9, "group-b-1", group_b);
+
+    var source = try runtime.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), source.finality.tool_turn_floors.len);
+    try std.testing.expect(source.finality.mutation_pin_start == null);
+
+    const group_a_header = try std.fmt.allocPrint(
+        alloc,
+        "{s}●\x1b[0m {s}3 tool calls · 3 read\x1b[0m",
+        .{ user_message_card.minimalMarkerStyle(), ui_render.statusline_style },
+    );
+    defer alloc.free(group_a_header);
+    const group_b_header = try std.fmt.allocPrint(
+        alloc,
+        "{s}●\x1b[0m {s}1 tool call · 1 read\x1b[0m",
+        .{ user_message_card.minimalMarkerStyle(), ui_render.statusline_style },
+    );
+    defer alloc.free(group_b_header);
+    const group_a_start = std.mem.find(u8, source.bytes, group_a_header) orelse
+        return error.TestExpectedGroupAHeader;
+    const group_b_start = std.mem.find(u8, source.bytes, group_b_header) orelse
+        return error.TestExpectedGroupBHeader;
+    try std.testing.expect(group_a_start < group_b_start);
+
+    const floor = source.finality.tool_turn_floors[0];
+    try std.testing.expectEqual(@as(u64, 9), floor.turn_id);
+    try std.testing.expectEqual(group_b_start, floor.start_byte);
+}
+
+test "finality candidates keep a mixed legacy turn at its earliest rendered tool row" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(80, 14, 10),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+    runtime.maxxing_mode = .minimal;
+
+    const group_a = types.ToolPresentationGroupId{ .turn_id = 10, .anchor_step_id = 1 };
+    try applyCompletedReadForFinalityTest(&runtime, alloc, 10, "mixed-group-a", group_a);
+    try applyCompletedReadForFinalityTest(&runtime, alloc, 10, "mixed-legacy", null);
+    _ = try runtime.appendRawTranscriptEntry(alloc, "LATEST_GROUP_INTRO\n");
+    const group_b = types.ToolPresentationGroupId{ .turn_id = 10, .anchor_step_id = 2 };
+    try applyCompletedReadForFinalityTest(&runtime, alloc, 10, "mixed-group-b", group_b);
+
+    var source = try runtime.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), source.finality.tool_turn_floors.len);
+    try std.testing.expect(source.finality.mutation_pin_start == null);
+
+    const group_a_header = try std.fmt.allocPrint(
+        alloc,
+        "{s}●\x1b[0m {s}1 tool call · 1 read\x1b[0m",
+        .{ user_message_card.minimalMarkerStyle(), ui_render.statusline_style },
+    );
+    defer alloc.free(group_a_header);
+    const earliest_tool_start = std.mem.find(u8, source.bytes, group_a_header) orelse
+        return error.TestExpectedGroupAHeader;
+    const floor = source.finality.tool_turn_floors[0];
+    try std.testing.expectEqual(@as(u64, 10), floor.turn_id);
+    try std.testing.expectEqual(earliest_tool_start, floor.start_byte);
+}
+
+test "finality candidates retain the global pin for an unidentified tool row" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(60, 12, 8),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    _ = try transcript_store.appendPinnedToolStatusAtomic(
+        &runtime,
+        alloc,
+        "● Running unidentified tool\n",
+    );
+    var source = try runtime.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), source.finality.tool_turn_floors.len);
+    try std.testing.expect(source.finality.mutation_pin_start != null);
+}

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -6,6 +6,7 @@ const tool_group_projection = @import("tool_group_projection.zig");
 const render_engine = @import("../render_engine.zig");
 const user_message_card = @import("../assistant/user_message_card.zig");
 const ui_render = @import("../render.zig");
+const types = @import("../../core/shared/types.zig");
 
 const Allocator = std.mem.Allocator;
 const transcript_blocks = render_engine.transcript_blocks;
@@ -68,6 +69,17 @@ const FinalityNomination = struct {
     turn_id: u64 = 0,
 };
 
+const ToolFinalityIdentity = struct {
+    turn_id: u64,
+    presentation_group_id: ?types.ToolPresentationGroupId,
+};
+
+const ToolTurnNomination = struct {
+    earliest_entry_id: u32,
+    selected_entry_id: u32,
+    selected_group_id: ?types.ToolPresentationGroupId,
+};
+
 fn entryHiddenByActions(
     entry_actions: []const transcript_blocks.EntryRenderAction,
     index: usize,
@@ -89,51 +101,82 @@ fn collectFinalityNominations(
     var nominations: std.ArrayList(FinalityNomination) = .empty;
     errdefer nominations.deinit(alloc);
 
-    var entry_turn_ids: std.AutoHashMapUnmanaged(u32, u64) = .empty;
-    defer entry_turn_ids.deinit(alloc);
+    var entry_tool_identities: std.AutoHashMapUnmanaged(u32, ToolFinalityIdentity) = .empty;
+    defer entry_tool_identities.deinit(alloc);
     for (self.tool_details.items) |detail| {
-        const turn_id: u64 = if (detail.presentation_group_id) |group|
-            group.turn_id
+        const identity: ToolFinalityIdentity = if (detail.presentation_group_id) |group|
+            .{ .turn_id = group.turn_id, .presentation_group_id = group }
         else if (detail.lifecycle_id) |lifecycle|
-            lifecycle.turn_id
+            .{ .turn_id = lifecycle.turn_id, .presentation_group_id = null }
         else
             continue;
-        try entry_turn_ids.put(alloc, detail.entry_id, turn_id);
+        try entry_tool_identities.put(alloc, detail.entry_id, identity);
     }
 
-    var pin_nominated = false;
-    var seen_turns: std.AutoHashMapUnmanaged(u64, void) = .empty;
-    defer seen_turns.deinit(alloc);
+    var mutation_pin_entry_id: ?u32 = null;
+    var turn_nominations: std.AutoHashMapUnmanaged(u64, ToolTurnNomination) = .empty;
+    defer turn_nominations.deinit(alloc);
     for (self.entries.items, 0..) |entry, index| {
         const entry_id = entry.id();
         if (omitted_entry_id == entry_id) continue;
         if (entryHiddenByActions(entry_actions, index)) continue;
-        if (!pin_nominated) {
+        const tool_identity = if (entry == .raw_bytes and entry.raw_bytes.class == .tool_status)
+            entry_tool_identities.get(entry_id)
+        else
+            null;
+        if (mutation_pin_entry_id == null) {
             const pinned = switch (entry) {
-                .raw_bytes => |raw| raw.lifecycle_pinned,
+                .raw_bytes => |raw| raw.lifecycle_pinned and tool_identity == null,
                 .semantic_notice => |notice| notice.pending_replacement,
                 else => false,
             };
-            if (pinned) {
-                try nominations.append(alloc, .{
-                    .entry_id = entry_id,
-                    .kind = .mutation_pin,
-                });
-                pin_nominated = true;
+            if (pinned) mutation_pin_entry_id = entry_id;
+        }
+
+        if (tool_identity) |identity| {
+            const result = try turn_nominations.getOrPut(alloc, identity.turn_id);
+            if (!result.found_existing) {
+                result.value_ptr.* = .{
+                    .earliest_entry_id = entry_id,
+                    .selected_entry_id = entry_id,
+                    .selected_group_id = identity.presentation_group_id,
+                };
+                continue;
+            }
+            const turn = result.value_ptr;
+            if (turn.selected_group_id == null) continue;
+            const group_id = identity.presentation_group_id orelse {
+                turn.selected_entry_id = turn.earliest_entry_id;
+                turn.selected_group_id = null;
+                continue;
+            };
+            const selected_group = turn.selected_group_id.?;
+            if (group_id.anchor_step_id > selected_group.anchor_step_id) {
+                turn.selected_entry_id = entry_id;
+                turn.selected_group_id = group_id;
             }
         }
-        if (entry == .raw_bytes and entry.raw_bytes.class == .tool_status) {
-            if (entry_turn_ids.get(entry_id)) |turn_id| {
-                const seen = try seen_turns.getOrPut(alloc, turn_id);
-                if (!seen.found_existing) {
-                    try nominations.append(alloc, .{
-                        .entry_id = entry_id,
-                        .kind = .tool_turn,
-                        .turn_id = turn_id,
-                    });
-                }
-            }
+    }
+
+    for (self.entries.items, 0..) |entry, index| {
+        const entry_id = entry.id();
+        if (omitted_entry_id == entry_id) continue;
+        if (entryHiddenByActions(entry_actions, index)) continue;
+        if (mutation_pin_entry_id == entry_id) {
+            try nominations.append(alloc, .{
+                .entry_id = entry_id,
+                .kind = .mutation_pin,
+            });
         }
+        if (entry != .raw_bytes or entry.raw_bytes.class != .tool_status) continue;
+        const identity = entry_tool_identities.get(entry_id) orelse continue;
+        const turn = turn_nominations.get(identity.turn_id).?;
+        if (turn.selected_entry_id != entry_id) continue;
+        try nominations.append(alloc, .{
+            .entry_id = entry_id,
+            .kind = .tool_turn,
+            .turn_id = identity.turn_id,
+        });
     }
     if (self.entries.items.len > 0) {
         const tail = self.entries.items[self.entries.items.len - 1];

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -7523,6 +7523,107 @@ describe.skipIf(!tmuxAvailable())("transcript scrollback release", () => {
   }
 
   test(
+    "closed tool groups enter native scrollback before the turn finishes",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-sb-tool-groups-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      for (let index = 1; index <= 3; index += 1) {
+        writeFileSync(join(workspace, `source-${index}.txt`), `source ${index}\n`);
+      }
+      writeFileSync(join(home, ".fx", "settings.json"), sbSettings());
+      writeFileSync(stderrPath, "");
+
+      const finalText = "TOOL_GROUP_SCROLLBACK_FINAL";
+      gateway = startFakeGateway([
+        sbToolCallBatch(
+          Array.from({ length: 3 }, (_, index) => ({
+            id: `group-a-read-${index + 1}`,
+            name: "read_file",
+            input: { path: `source-${index + 1}.txt` },
+          })),
+          "FIRST_GROUP_INTRO",
+        ),
+        sbToolCallBatch(
+          [
+            {
+              id: "group-b-command",
+              name: "run_command",
+              input: { command: "sleep 5; printf HELD_COMMAND_DONE" },
+            },
+          ],
+          "SECOND_GROUP_INTRO",
+        ),
+        fakeGatewayFinalText(finalText),
+      ]);
+      const fakeGateway = gateway as ReturnType<typeof startFakeGateway>;
+
+      session = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: workspace,
+        width: 80,
+        height: 14,
+        minimumHistoryLines: 10_000,
+        stderrPath,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-sb-tool-groups-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_GATEWAY_BASE_URL: fakeGateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: fakeGateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: fakeGateway.chatUrl,
+          FX_MODEL: MODEL,
+          FX_MAX_AGENT_STEPS: "4",
+        },
+      });
+
+      const assertClosedGroupOnce = (scrollback: string, label: string) => {
+        expect(
+          countOccurrences(scrollback, "FIRST_GROUP_INTRO"),
+          `${label}: first intro`,
+        ).toBe(1);
+        expect(
+          countOccurrences(scrollback, "● 3 tool calls · 3 read"),
+          `${label}: first header`,
+        ).toBe(1);
+        for (let index = 1; index <= 3; index += 1) {
+          expect(
+            countOccurrences(scrollback, `Read source-${index}.txt`),
+            `${label}: source ${index}`,
+          ).toBe(1);
+        }
+      };
+
+      await session.waitForComposer(SB_TIMEOUT);
+      await session.sendText("Run the two prepared groups.");
+      await session.waitForText("Running sleep 5; printf HELD_COMMAND_DONE", SB_TIMEOUT);
+      await Bun.sleep(150);
+
+      const beforeResize = await session.captureFullScrollback();
+      assertClosedGroupOnce(beforeResize, "before resize");
+      expect(beforeResize).toContain("SECOND_GROUP_INTRO");
+
+      await session.resizeWindow(81, 15, 500);
+      const afterResize = await session.captureFullScrollback();
+      assertClosedGroupOnce(afterResize, "after resize");
+      expect(afterResize).toContain("SECOND_GROUP_INTRO");
+
+      await session.waitForText(finalText, SB_TIMEOUT);
+      await session.waitForPane(hasEmptyComposer, SB_TIMEOUT);
+      const completed = await session.captureFullScrollback();
+      assertClosedGroupOnce(completed, "after completion");
+      expect(countOccurrences(completed, finalText)).toBe(1);
+      expect(fakeGateway.requests).toHaveLength(3);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    SB_TIMEOUT + 30_000,
+  );
+
+  test(
     "sequential tool group and streamed markdown keep native scrollback final",
     async () => {
       root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-sb-release-")));


### PR DESCRIPTION
## Summary

- Keep completed tool-group headers and rows in native scrollback while later tools are still running.
- Preserve closed tool groups exactly once across terminal resize and turn completion.