### PR TITLE
Load contained instruction and skill symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The WebAssembly SDK is experimental. See the [WebAssembly SDK](sdk/README.md) an
 
 ## Extend fx
 
-Add reusable instructions with [skills](https://fx.sh/docs/capabilities/skills), connect external tools through [MCP](https://fx.sh/docs/capabilities/mcp), or delegate independent work to [subagents](https://fx.sh/docs/capabilities/subagents). `fx status` and `fx doctor` report an invalid trusted MCP profile without starting its servers.
+Add reusable instructions with [skills](https://fx.sh/docs/capabilities/skills), connect external tools through [MCP](https://fx.sh/docs/capabilities/mcp), or delegate independent work to [subagents](https://fx.sh/docs/capabilities/subagents). Project instruction files may link within their scope, and read-only workspace or compatibility skill directories may link within their owning workspace or home; managed skills, `SKILL.md` files, resources, and escaping links remain no-follow. `fx status` and `fx doctor` report an invalid trusted MCP profile without starting its servers.
 
 ## Documentation
 

--- a/src/builtins/context.zig
+++ b/src/builtins/context.zig
@@ -513,12 +513,36 @@ fn loadRule(arena: Allocator, path: []const u8, limit: context_limits.Resolved) 
             else => .{ .omitted = .unreadable },
         };
     };
-    if (stat.kind == .sym_link) return .{ .omitted = .symlink };
-    if (stat.kind != .file) return .{ .omitted = .non_regular };
-    const observed_bytes = std.math.cast(usize, stat.size) orelse return .{ .omitted = .oversized };
-    if (observed_bytes > context_limits.emergency_ceiling_bytes) return .{ .omitted = .oversized };
+    if (stat.kind != .file and stat.kind != .sym_link) return .{ .omitted = .non_regular };
 
-    var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{
+    var file = if (stat.kind == .sym_link) blk: {
+        const logical_parent = std.fs.path.dirname(path) orelse return .{ .omitted = .symlink };
+        const authority = io_mod.realpathAlloc(arena, logical_parent) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return .{ .omitted = .symlink };
+        };
+        const canonical_target = io_mod.realpathAlloc(arena, path) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return .{ .omitted = .symlink };
+        };
+        if (!pathing.pathInside(authority, canonical_target)) return .{ .omitted = .symlink };
+
+        const target_parent = std.fs.path.dirname(canonical_target) orelse return .{ .omitted = .symlink };
+        const target_name = std.fs.path.basename(canonical_target);
+        if (target_name.len == 0) return .{ .omitted = .symlink };
+        var parent_dir = io_mod.openDirAbsoluteNoFollow(target_parent, .{}) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return .{ .omitted = .symlink };
+        };
+        defer parent_dir.close(io_mod.getIo());
+        break :blk parent_dir.openFile(io_mod.getIo(), target_name, .{
+            .allow_directory = false,
+            .follow_symlinks = false,
+        }) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return .{ .omitted = .symlink };
+        };
+    } else std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{
         .allow_directory = false,
         .follow_symlinks = false,
     }) catch |err| {
@@ -530,6 +554,11 @@ fn loadRule(arena: Allocator, path: []const u8, limit: context_limits.Resolved) 
         };
     };
     defer file.close(io_mod.getIo());
+
+    const opened_stat = file.stat(io_mod.getIo()) catch return .{ .omitted = .unreadable };
+    if (opened_stat.kind != .file) return .{ .omitted = if (stat.kind == .sym_link) .symlink else .non_regular };
+    const observed_bytes = std.math.cast(usize, opened_stat.size) orelse return .{ .omitted = .oversized };
+    if (observed_bytes > context_limits.emergency_ceiling_bytes) return .{ .omitted = .oversized };
 
     const has_content = validateRuleUtf8(&file, observed_bytes) catch
         return .{ .omitted = .unreadable };
@@ -1226,16 +1255,43 @@ test "rule loader classifies bodies blanks oversized non-regular and symlink fil
         else => return error.TestExpectedEqual,
     }
 
-    try writeTestFile(tmp.dir, "secret.md", "must stay hidden");
+    try writeTestFile(tmp.dir, "secret.md", "contained linked instructions");
     const secret_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "secret.md");
     defer alloc.free(secret_path);
     try createSymlinkOrSkip(tmp.dir, secret_path, "linked.md");
     const linked_path = try std.fs.path.join(alloc, &.{ std.fs.path.dirname(secret_path).?, "linked.md" });
     defer alloc.free(linked_path);
     switch (try loadRule(arena, linked_path, rule_limit)) {
-        .omitted => |reason| try std.testing.expectEqual(context_contract.OmissionReason.symlink, reason),
+        .body => |body| try std.testing.expectEqualStrings("contained linked instructions", body.text),
         else => return error.TestExpectedEqual,
     }
+}
+
+test "initial gather loads a contained AGENTS symlink with logical provenance" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestFile(tmp.dir, "home/work/CLAUDE.md", "LINKED_PROJECT_RULE");
+    try createSymlinkOrSkip(tmp.dir, "CLAUDE.md", "home/work/AGENTS.md");
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/work");
+    defer alloc.free(workspace);
+    const logical_source = try std.fs.path.join(alloc, &.{ workspace, "AGENTS.md" });
+    defer alloc.free(logical_source);
+
+    var context = try gatherProjectContextWithHome(alloc, .{
+        .workspace_root = workspace,
+    }, home);
+    defer context.deinit(alloc);
+
+    try std.testing.expect(std.mem.find(u8, context.modelVisibleBytes(), "LINKED_PROJECT_RULE") != null);
+    try std.testing.expect(std.mem.find(u8, context.modelVisibleBytes(), logical_source) != null);
+    try std.testing.expectEqual(@as(usize, 1), context.delivered_sources.len);
+    try std.testing.expectEqualStrings(logical_source, context.delivered_sources[0]);
+    try std.testing.expect(std.mem.find(u8, context.modelVisibleBytes(), "symlinked rule file") == null);
 }
 
 test "initial gather orders global ancestors workspace and exact hidden and build target scopes" {

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -29,6 +29,39 @@ pub fn getIo() std.Io {
     return process_io_for(builtin.os.tag, fallback_threaded.io());
 }
 
+/// Opens an absolute directory path without following any path component.
+/// The caller owns the returned directory handle.
+pub fn openDirAbsoluteNoFollow(path: []const u8, options: std.Io.Dir.OpenOptions) !std.Io.Dir {
+    if (!std.fs.path.isAbsolute(path)) return error.InvalidPath;
+    var components = std.fs.path.componentIterator(path);
+    const root = components.root() orelse return error.InvalidPath;
+    var component = components.next() orelse {
+        var root_options = options;
+        root_options.follow_symlinks = false;
+        return std.Io.Dir.openDirAbsolute(getIo(), root, root_options);
+    };
+
+    var dir = try std.Io.Dir.openDirAbsolute(getIo(), root, .{ .follow_symlinks = false });
+    errdefer dir.close(getIo());
+    while (components.next()) |next_component| {
+        if (std.mem.eql(u8, component.name, ".") or std.mem.eql(u8, component.name, "..")) {
+            return error.InvalidPath;
+        }
+        const next_dir = try dir.openDir(getIo(), component.name, .{ .follow_symlinks = false });
+        dir.close(getIo());
+        dir = next_dir;
+        component = next_component;
+    }
+    if (std.mem.eql(u8, component.name, ".") or std.mem.eql(u8, component.name, "..")) {
+        return error.InvalidPath;
+    }
+    var final_options = options;
+    final_options.follow_symlinks = false;
+    const result = try dir.openDir(getIo(), component.name, final_options);
+    dir.close(getIo());
+    return result;
+}
+
 test "Darwin process I/O replaces only processSpawn with stable storage" {
     const original = std.testing.io;
     const selected = process_io_for(.macos, original);
@@ -86,6 +119,38 @@ test "non-Darwin process I/O keeps the original vtable" {
 
     try std.testing.expect(selected.userdata == original.userdata);
     try std.testing.expect(selected.vtable == original.vtable);
+}
+
+test "openDirAbsoluteNoFollow rejects unsafe path components" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(getIo(), "real/child");
+    try writeTempFile(tmp.dir, "plain-file", "not a directory");
+    tmp.dir.symLink(std.testing.io, "real", "linked", .{ .is_directory = true }) catch |err| {
+        if (err == error.AccessDenied or err == error.FileSystem) return error.SkipZigTest;
+        return err;
+    };
+
+    const root = try dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const linked_child = try std.fs.path.join(alloc, &.{ root, "linked/child" });
+    defer alloc.free(linked_child);
+    const missing = try std.fs.path.join(alloc, &.{ root, "missing" });
+    defer alloc.free(missing);
+    const wrong_kind = try std.fs.path.join(alloc, &.{ root, "plain-file" });
+    defer alloc.free(wrong_kind);
+
+    if (openDirAbsoluteNoFollow(linked_child, .{})) |dir| {
+        dir.close(getIo());
+        return error.TestExpectedError;
+    } else |err| switch (err) {
+        error.NotDir, error.SymLinkLoop => {},
+        else => return err,
+    }
+    try std.testing.expectError(error.FileNotFound, openDirAbsoluteNoFollow(missing, .{}));
+    try std.testing.expectError(error.NotDir, openDirAbsoluteNoFollow(wrong_kind, .{}));
 }
 
 /// Opens an existing regular file without following the final symlink and

--- a/src/core/skills/skill_runtime.zig
+++ b/src/core/skills/skill_runtime.zig
@@ -3,6 +3,7 @@ const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
 const list_window = @import("../shared/list_window.zig");
 const model_context_encoding = @import("../shared/model_context_encoding.zig");
+const pathing = @import("../workspace/pathing.zig");
 const skill_contract = @import("skill_contract.zig");
 const context_limits = @import("../config/context_limits.zig");
 const sort_utils = @import("../shared/sort_utils.zig");
@@ -18,6 +19,8 @@ pub const Skill = struct {
     description: []const u8,
     path: []const u8,
     source: SkillSource,
+    /// Owned with discovered catalog entries. Null keeps managed skills strict.
+    read_authority: ?[]const u8 = null,
 };
 
 pub const BoundedPromptSection = struct {
@@ -260,6 +263,12 @@ pub const SkillMenuTarget = struct {
 const SkillRoot = struct {
     path: []const u8,
     source: SkillSource,
+    read_authority: ?[]const u8,
+};
+
+const SkillEntry = struct {
+    name: []u8,
+    linked: bool,
 };
 
 pub fn loadVisibleSkills(
@@ -333,14 +342,20 @@ fn appendWorkspaceRoots(
 }
 
 fn appendSpecRoot(alloc: Allocator, roots: *std.ArrayList(SkillRoot), base: []const u8, spec: skill_contract.RootSpec) !void {
-    try appendOwnedRoot(alloc, roots, try std.fs.path.join(alloc, &.{ base, spec.path }), spec.source);
+    try appendOwnedRoot(alloc, roots, try std.fs.path.join(alloc, &.{ base, spec.path }), spec.source, base);
 }
 
 fn appendDupeRoot(alloc: Allocator, roots: *std.ArrayList(SkillRoot), source: SkillSource, path: []const u8) !void {
-    try appendOwnedRoot(alloc, roots, try alloc.dupe(u8, path), source);
+    try appendOwnedRoot(alloc, roots, try alloc.dupe(u8, path), source, null);
 }
 
-fn appendOwnedRoot(alloc: Allocator, roots: *std.ArrayList(SkillRoot), path: []u8, source: SkillSource) !void {
+fn appendOwnedRoot(
+    alloc: Allocator,
+    roots: *std.ArrayList(SkillRoot),
+    path: []u8,
+    source: SkillSource,
+    read_authority: ?[]const u8,
+) !void {
     if (containsRootPath(roots.items, path)) {
         alloc.free(path);
         return;
@@ -349,10 +364,23 @@ fn appendOwnedRoot(alloc: Allocator, roots: *std.ArrayList(SkillRoot), path: []u
     roots.append(alloc, .{
         .path = path,
         .source = source,
+        .read_authority = read_authority,
     }) catch |err| {
         alloc.free(path);
         return err;
     };
+}
+
+fn openContainedDir(
+    alloc: Allocator,
+    logical_path: []const u8,
+    read_authority: []const u8,
+    options: std.Io.Dir.OpenOptions,
+) !std.Io.Dir {
+    const canonical_path = try io_mod.realpathAlloc(alloc, logical_path);
+    defer alloc.free(canonical_path);
+    if (!pathing.pathInside(read_authority, canonical_path)) return error.PathOutsideReadAuthority;
+    return io_mod.openDirAbsoluteNoFollow(canonical_path, options);
 }
 
 fn containsRootPath(roots: []const SkillRoot, path: []const u8) bool {
@@ -362,57 +390,27 @@ fn containsRootPath(roots: []const SkillRoot, path: []const u8) bool {
     return false;
 }
 
-pub fn openDirAbsoluteNoFollow(path: []const u8, options: std.Io.Dir.OpenOptions) !std.Io.Dir {
-    if (!std.fs.path.isAbsolute(path)) return error.InvalidSkillRoot;
-    var components = std.fs.path.componentIterator(path);
-    const root = components.root() orelse return error.InvalidSkillRoot;
-    var component = components.next() orelse {
-        var root_options = options;
-        root_options.follow_symlinks = false;
-        return std.Io.Dir.openDirAbsolute(io_mod.getIo(), root, root_options);
-    };
-
-    var dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), root, .{ .follow_symlinks = false });
-    errdefer dir.close(io_mod.getIo());
-    while (components.next()) |next_component| {
-        if (std.mem.eql(u8, component.name, ".") or std.mem.eql(u8, component.name, "..")) {
-            return error.InvalidSkillRoot;
-        }
-        const next_dir = try dir.openDir(io_mod.getIo(), component.name, .{ .follow_symlinks = false });
-        dir.close(io_mod.getIo());
-        dir = next_dir;
-        component = next_component;
-    }
-    if (std.mem.eql(u8, component.name, ".") or std.mem.eql(u8, component.name, "..")) {
-        return error.InvalidSkillRoot;
-    }
-    var final_options = options;
-    final_options.follow_symlinks = false;
-    const result = try dir.openDir(io_mod.getIo(), component.name, final_options);
-    dir.close(io_mod.getIo());
-    return result;
-}
-
 fn appendSkillsFromDir(
     alloc: Allocator,
     skills: *std.ArrayList(Skill),
     diagnostics: ?*std.ArrayList(SkillDiagnostic),
     root: SkillRoot,
 ) !void {
-    var dir = openDirAbsoluteNoFollow(root.path, .{
-        .iterate = true,
-    }) catch |err| {
-        if (err == error.FileNotFound or (err == error.NotDir and rootPathIsMissing(root.path))) return;
+    var dir = (if (root.read_authority) |read_authority|
+        openContainedDir(alloc, root.path, read_authority, .{ .iterate = true })
+    else
+        io_mod.openDirAbsoluteNoFollow(root.path, .{ .iterate = true })) catch |err| {
+        if ((err == error.FileNotFound or err == error.NotDir) and rootPathIsMissing(root.path)) return;
         if (err == error.OutOfMemory) return error.OutOfMemory;
         if (diagnostics) |items| try appendSkillDiagnostic(alloc, items, root.path, root.source, .root, .unreadable);
         return;
     };
     defer dir.close(io_mod.getIo());
 
-    var entry_names: std.ArrayList([]u8) = .empty;
+    var entries: std.ArrayList(SkillEntry) = .empty;
     defer {
-        for (entry_names.items) |name| alloc.free(name);
-        entry_names.deinit(alloc);
+        for (entries.items) |entry| alloc.free(entry.name);
+        entries.deinit(alloc);
     }
 
     var it = dir.iterate();
@@ -422,23 +420,24 @@ fn appendSkillsFromDir(
             if (diagnostics) |items| try appendSkillDiagnostic(alloc, items, root.path, root.source, .root, .unreadable);
             return;
         } orelse break;
-        if (entry.kind != .directory) continue;
+        const linked = entry.kind == .sym_link;
+        if (entry.kind != .directory and !(linked and root.read_authority != null)) continue;
 
         const owned_name = try alloc.dupe(u8, entry.name);
-        entry_names.append(alloc, owned_name) catch |err| {
+        entries.append(alloc, .{ .name = owned_name, .linked = linked }) catch |err| {
             alloc.free(owned_name);
             return err;
         };
     }
 
-    sort_utils.sort([]u8, entry_names.items, {}, struct {
-        fn lessThan(_: void, left: []u8, right: []u8) bool {
-            return std.mem.order(u8, left, right) == .lt;
+    sort_utils.sort(SkillEntry, entries.items, {}, struct {
+        fn lessThan(_: void, left: SkillEntry, right: SkillEntry) bool {
+            return std.mem.order(u8, left.name, right.name) == .lt;
         }
     }.lessThan);
 
-    for (entry_names.items) |entry_name| {
-        try appendSkillCandidate(alloc, skills, diagnostics, root, &dir, entry_name);
+    for (entries.items) |entry| {
+        try appendSkillCandidate(alloc, skills, diagnostics, root, &dir, entry.name, entry.linked);
     }
 }
 
@@ -471,11 +470,19 @@ fn appendSkillCandidate(
     root: SkillRoot,
     root_dir: *std.Io.Dir,
     entry_name: []const u8,
+    linked: bool,
 ) !void {
     const candidate_path = try std.fs.path.join(alloc, &.{ root.path, entry_name });
     defer alloc.free(candidate_path);
 
-    var candidate_dir = root_dir.openDir(io_mod.getIo(), entry_name, .{ .follow_symlinks = false }) catch |err| {
+    var candidate_dir = if (linked) linked_candidate: {
+        const read_authority = root.read_authority orelse return;
+        break :linked_candidate openContainedDir(alloc, candidate_path, read_authority, .{}) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            if (diagnostics) |items| try appendSkillDiagnostic(alloc, items, candidate_path, root.source, .candidate, .unreadable);
+            return;
+        };
+    } else root_dir.openDir(io_mod.getIo(), entry_name, .{ .follow_symlinks = false }) catch |err| {
         if (err == error.FileNotFound) return;
         if (err == error.OutOfMemory) return error.OutOfMemory;
         if (diagnostics) |items| try appendSkillDiagnostic(alloc, items, candidate_path, root.source, .candidate, .unreadable);
@@ -532,12 +539,18 @@ fn appendSkillCandidate(
     candidate.metadata.write_description(description);
     const path = try alloc.dupe(u8, candidate_path);
     errdefer alloc.free(path);
+    const read_authority = if (root.read_authority) |authority|
+        try alloc.dupe(u8, authority)
+    else
+        null;
+    errdefer if (read_authority) |authority| alloc.free(authority);
 
     try skills.append(alloc, .{
         .name = skill_name,
         .description = description,
         .path = path,
         .source = root.source,
+        .read_authority = read_authority,
     });
 }
 
@@ -588,18 +601,25 @@ fn inspectSkillCandidateFile(
 /// Opens and validates the exact advertised candidate without rescanning skill roots.
 /// The caller must deinitialize a `.current` candidate.
 pub fn openValidatedSkillCandidate(alloc: Allocator, skill: Skill) error{OutOfMemory}!SkillCandidateOpenResult {
-    const parent_path = std.fs.path.dirname(skill.path) orelse return .{ .skipped = .unreadable };
     const candidate_name = std.fs.path.basename(skill.path);
     if (candidate_name.len == 0) return .{ .skipped = .unreadable };
 
-    var parent_dir = openDirAbsoluteNoFollow(parent_path, .{}) catch |err| {
-        if (err == error.OutOfMemory) return error.OutOfMemory;
-        return if (err == error.FileNotFound) .missing else .{ .skipped = .unreadable };
-    };
-    defer parent_dir.close(io_mod.getIo());
-    var candidate_dir = parent_dir.openDir(io_mod.getIo(), candidate_name, .{ .follow_symlinks = false }) catch |err| {
-        if (err == error.OutOfMemory) return error.OutOfMemory;
-        return if (err == error.FileNotFound) .missing else .{ .skipped = .unreadable };
+    var candidate_dir = if (skill.read_authority) |read_authority| authorized: {
+        break :authorized openContainedDir(alloc, skill.path, read_authority, .{}) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return if (err == error.FileNotFound) .missing else .{ .skipped = .unreadable };
+        };
+    } else strict: {
+        const parent_path = std.fs.path.dirname(skill.path) orelse return .{ .skipped = .unreadable };
+        var parent_dir = io_mod.openDirAbsoluteNoFollow(parent_path, .{}) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return if (err == error.FileNotFound) .missing else .{ .skipped = .unreadable };
+        };
+        defer parent_dir.close(io_mod.getIo());
+        break :strict parent_dir.openDir(io_mod.getIo(), candidate_name, .{ .follow_symlinks = false }) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            return if (err == error.FileNotFound) .missing else .{ .skipped = .unreadable };
+        };
     };
     var file = candidate_dir.openFile(io_mod.getIo(), "SKILL.md", .{
         .allow_directory = false,
@@ -1557,6 +1577,7 @@ pub fn freeSkill(alloc: Allocator, skill: Skill) void {
     alloc.free(skill.name);
     alloc.free(skill.description);
     alloc.free(skill.path);
+    if (skill.read_authority) |read_authority| alloc.free(read_authority);
 }
 
 pub fn freeSkills(alloc: Allocator, skills: []Skill) void {
@@ -2469,6 +2490,181 @@ test "loadVisibleSkills discovers workspace and global codex roots" {
     try std.testing.expectEqual(@as(usize, 2), skills.len);
     try std.testing.expectEqual(SkillSource.workspace_codex, findSkillByName(skills, "local-codex").?.source);
     try std.testing.expectEqual(SkillSource.global_codex, findSkillByName(skills, "global-codex").?.source);
+}
+
+test "loadVisibleSkills discovers and reopens a contained linked workspace candidate" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(
+        &tmp,
+        "home/workspace/skill-source/linked-skill/SKILL.md",
+        "---\nname: linked-skill\ndescription: contained link\n---\n\nLINKED_SKILL_BODY\n",
+    );
+    try createTempSymlinkOrSkip(
+        &tmp,
+        "../../skill-source/linked-skill",
+        "home/workspace/.codex/skills/linked-skill",
+    );
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx/skills");
+
+    const workspace_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/workspace");
+    defer alloc.free(workspace_root);
+    const home_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home_root);
+    const managed_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/.fx/skills");
+    defer alloc.free(managed_root);
+    const logical_path = try std.fs.path.join(alloc, &.{ workspace_root, ".codex/skills/linked-skill" });
+    defer alloc.free(logical_path);
+
+    var discovery = try loadVisibleSkills(alloc, workspace_root, home_root, managed_root, test_root_policy);
+    defer discovery.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), discovery.skills.len);
+    try std.testing.expectEqualStrings("linked-skill", discovery.skills[0].name);
+    try std.testing.expectEqualStrings(logical_path, discovery.skills[0].path);
+    try std.testing.expectEqual(SkillSource.workspace_codex, discovery.skills[0].source);
+    try std.testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
+
+    var candidate = switch (try openValidatedSkillCandidate(alloc, discovery.skills[0])) {
+        .current => |current| current,
+        .missing, .name_mismatch, .skipped => return error.TestExpectedCurrentSkill,
+    };
+    candidate.deinit();
+
+    try writeTempFile(
+        &tmp,
+        "home/outside-skill/SKILL.md",
+        "---\nname: linked-skill\ndescription: outside\n---\n\nOUTSIDE_BODY_MUST_NOT_LOAD\n",
+    );
+    try tmp.dir.deleteFile(io_mod.getIo(), "home/workspace/.codex/skills/linked-skill");
+    try createTempSymlinkOrSkip(
+        &tmp,
+        "../../../outside-skill",
+        "home/workspace/.codex/skills/linked-skill",
+    );
+    switch (try openValidatedSkillCandidate(alloc, discovery.skills[0])) {
+        .skipped => |cause| try std.testing.expectEqual(SkillDiagnosticCause.unreadable, cause),
+        .current => |current_value| {
+            var current = current_value;
+            current.deinit();
+            return error.TestExpectedSkippedSkill;
+        },
+        .missing, .name_mismatch => return error.TestExpectedSkippedSkill,
+    }
+}
+
+test "loadVisibleSkills discovers a contained linked workspace root" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(
+        &tmp,
+        "home/workspace/skill-root/root-linked/SKILL.md",
+        "---\nname: root-linked\ndescription: linked root\n---\n\nROOT_LINKED_BODY\n",
+    );
+    try createTempSymlinkOrSkip(
+        &tmp,
+        "../skill-root",
+        "home/workspace/.codex/skills",
+    );
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx/skills");
+
+    const workspace_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/workspace");
+    defer alloc.free(workspace_root);
+    const home_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home_root);
+    const managed_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/.fx/skills");
+    defer alloc.free(managed_root);
+
+    var discovery = try loadVisibleSkills(alloc, workspace_root, home_root, managed_root, test_root_policy);
+    defer discovery.deinit(alloc);
+
+    const skill = findSkillByName(discovery.skills, "root-linked") orelse return error.TestExpectedSkill;
+    try std.testing.expectEqual(SkillSource.workspace_codex, skill.source);
+    try std.testing.expectEqualStrings(workspace_root, skill.read_authority.?);
+    try std.testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
+}
+
+test "loadVisibleSkills diagnoses an escaping linked workspace candidate" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(
+        &tmp,
+        "home/outside-skill/SKILL.md",
+        "---\nname: escaping-skill\ndescription: outside\n---\n\nOUTSIDE_BODY_MUST_NOT_LOAD\n",
+    );
+    try createTempSymlinkOrSkip(
+        &tmp,
+        "../../../outside-skill",
+        "home/workspace/.codex/skills/escaping-skill",
+    );
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx/skills");
+
+    const workspace_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/workspace");
+    defer alloc.free(workspace_root);
+    const home_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home_root);
+    const managed_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/.fx/skills");
+    defer alloc.free(managed_root);
+    const logical_path = try std.fs.path.join(alloc, &.{ workspace_root, ".codex/skills/escaping-skill" });
+    defer alloc.free(logical_path);
+
+    var discovery = try loadVisibleSkills(alloc, workspace_root, home_root, managed_root, test_root_policy);
+    defer discovery.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 0), discovery.skills.len);
+    try std.testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try std.testing.expectEqualStrings(logical_path, discovery.diagnostics[0].path);
+    try std.testing.expectEqual(SkillDiagnosticScope.candidate, discovery.diagnostics[0].scope);
+    try std.testing.expectEqual(SkillDiagnosticCause.unreadable, discovery.diagnostics[0].cause);
+}
+
+fn checkContainedLinkedSkillAllocationFailures(
+    alloc: Allocator,
+    workspace_root: []const u8,
+    home_root: []const u8,
+    managed_root: []const u8,
+) !void {
+    var discovery = try loadVisibleSkills(alloc, workspace_root, home_root, managed_root, test_root_policy);
+    defer discovery.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), discovery.skills.len);
+    try std.testing.expect(discovery.skills[0].read_authority != null);
+}
+
+test "loadVisibleSkills cleans contained-link authority allocation failures" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(
+        &tmp,
+        "home/workspace/skill-source/linked-skill/SKILL.md",
+        "---\nname: linked-skill\ndescription: allocation cleanup\n---\n\nbody\n",
+    );
+    try createTempSymlinkOrSkip(
+        &tmp,
+        "../../skill-source/linked-skill",
+        "home/workspace/.codex/skills/linked-skill",
+    );
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx/skills");
+
+    const workspace_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/workspace");
+    defer alloc.free(workspace_root);
+    const home_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home_root);
+    const managed_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/.fx/skills");
+    defer alloc.free(managed_root);
+
+    try std.testing.checkAllAllocationFailures(
+        alloc,
+        checkContainedLinkedSkillAllocationFailures,
+        .{ workspace_root, home_root, managed_root },
+    );
 }
 
 test "loadVisibleSkills skips missing or unreadable skill files without failing" {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   truncateSync,
   writeFileSync,
 } from "node:fs";
@@ -975,6 +976,75 @@ describe("gateway stream lifecycle", () => {
         "<skill_content name=\"oversized-context\"",
       );
       expect(negatedPrompt).not.toContain("SKILL_FIRST_LINE");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  test("contained instruction and skill links reach one ask request", async () => {
+    const root = createFixtureRoot("contained-links-ask");
+    const tracePath = join(root.root, "trace.log");
+    const skillSource = join(
+      root.workspace,
+      "skill-source",
+      "linked-skill",
+    );
+    const skillsRoot = join(root.workspace, ".codex", "skills");
+    mkdirSync(skillSource, { recursive: true });
+    mkdirSync(skillsRoot, { recursive: true });
+    writeFileSync(
+      join(root.workspace, "CLAUDE.md"),
+      "LINKED_INSTRUCTION_SENTINEL\n",
+    );
+    symlinkSync("CLAUDE.md", join(root.workspace, "AGENTS.md"));
+    writeFileSync(
+      join(skillSource, "SKILL.md"),
+      "---\nname: linked-skill\ndescription: contained linked skill\n---\n\nLINKED_SKILL_SENTINEL\n",
+    );
+    symlinkSync(
+      "../../skill-source/linked-skill",
+      join(skillsRoot, "linked-skill"),
+      "dir",
+    );
+
+    const gateway = startGateway(() =>
+      fakeGatewayFinalText("CONTAINED_LINKS_COMPLETE")
+    );
+    try {
+      const result = await runFx(
+        [
+          "ask",
+          "--json",
+          "--auto",
+          "--no-save",
+          "$linked-skill apply the linked instructions and skill.",
+        ],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          timeoutMs: 30_000,
+        },
+      );
+      const output = parseAskJson(result.stdout);
+      const prompt = promptText(gateway.requests[0]!.body);
+
+      expect(result.code).toBe(0);
+      expect(output.output).toContain("CONTAINED_LINKS_COMPLETE");
+      expect(gateway.requestCount()).toBe(1);
+      expect(prompt).toContain("LINKED_INSTRUCTION_SENTINEL");
+      expect(prompt).toContain(
+        `<project-rules from="${join(root.workspace, "AGENTS.md")}">`,
+      );
+      expect(prompt).toContain("LINKED_SKILL_SENTINEL");
+      expect(prompt).toContain(
+        '<skill_content name="linked-skill" resource="SKILL.md"',
+      );
+      expect(prompt).toContain(
+        `<location>${join(root.workspace, ".codex", "skills", "linked-skill")}</location>`,
+      );
+      expect(prompt).not.toContain("symlinked rule file");
+      expect(result.stderr).not.toContain("symlinked rule file");
     } finally {
       gateway.stop();
       rmSync(root.root, { recursive: true, force: true });

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2477,10 +2477,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       mkdirSync(workspacePath, { recursive: true });
       writeFileSync(join(home, ".fx", "settings.json"), "{}");
       writeFileSync(
-        join(workspacePath, "CLAUDE.md"),
-        "# Workspace instructions\n",
+        join(root, "outside-instructions.md"),
+        "# Outside instructions\n",
       );
-      symlinkSync("CLAUDE.md", join(workspacePath, "AGENTS.md"));
+      symlinkSync("../outside-instructions.md", join(workspacePath, "AGENTS.md"));
       const workspace = realpathSync(workspacePath);
 
       const heldGateway = startFakeGateway([

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -374,6 +374,31 @@ function createSkillRankingFixture() {
   return { home, workspace, stderrPath };
 }
 
+function createLinkedSkillsMenuFixture() {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-linked-skills-menu-")));
+  workDirs.push(root);
+  const home = join(root, "home");
+  const workspace = join(root, "workspace");
+  const source = join(workspace, "skill-source", "linked-menu");
+  const skillsRoot = join(workspace, ".codex", "skills");
+  const stderrPath = join(root, "stderr.log");
+  mkdirSync(join(home, ".fx"), { recursive: true });
+  mkdirSync(source, { recursive: true });
+  mkdirSync(skillsRoot, { recursive: true });
+  writeFileSync(join(home, ".fx", "settings.json"), "{}\n");
+  writeFileSync(
+    join(source, "SKILL.md"),
+    "---\nname: linked-menu\ndescription: linked menu skill\n---\n\nLINKED_MENU_BODY\n",
+  );
+  symlinkSync(
+    "../../skill-source/linked-menu",
+    join(skillsRoot, "linked-menu"),
+    "dir",
+  );
+  writeFileSync(stderrPath, "");
+  return { home, workspace, stderrPath };
+}
+
 function createModelsMenuFixture() {
   const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-models-menu-")));
   workDirs.push(root);
@@ -538,6 +563,56 @@ function longAssistantResponse(): string {
 }
 
 describe.skipIf(SKIP)("tui: slash menu", () => {
+  test(
+    "linked workspace skill is visible and usable from the skills menu",
+    async () => {
+      const fixture = createLinkedSkillsMenuFixture();
+      gateway = startFakeGateway([
+        fakeGatewayFinalText("LINKED_MENU_COMPLETE"),
+      ]);
+      session = await TmuxSession.create({
+        cwd: fixture.workspace,
+        env: {
+          HOME: fixture.home,
+          AI_GATEWAY_API_KEY: "fake-linked-menu-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_AUTO_UPGRADE: "0",
+        },
+        width: 120,
+        height: 32,
+        stderrPath: fixture.stderrPath,
+      });
+      await session.waitForComposer(10_000);
+
+      await session.sendText("/skills");
+      const menu = await waitForSkillsMenu(session, 1);
+      expect(menu.join("\n")).toContain("linked-menu");
+      expect(menu.join("\n")).toContain("Codex · Workspace");
+      await session.sendKeys("Enter");
+      await session.waitForPane(
+        (pane) => composerContains(pane, "linked-menu"),
+        5_000,
+      );
+      await session.sendLiteralText(" apply it");
+      await session.sendKeys("Enter");
+      await session.waitForText("LINKED_MENU_COMPLETE", 10_000);
+
+      expect(gateway.requests).toHaveLength(1);
+      expect(gatewayPromptText(gateway.requests[0]!.body)).toContain(
+        "LINKED_MENU_BODY",
+      );
+      expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      session = null;
+    },
+    TEST_TIMEOUT,
+  );
+
   test(
     "skill picker selects a name match before a metadata-only match",
     async () => {


### PR DESCRIPTION
## Summary

- Load project instruction symlinks when their targets stay within the instruction scope.
- Discover and invoke workspace and compatibility skill directory symlinks when their targets stay within the owning workspace or home directory.
- Report rejected linked skill roots and candidates through bounded discovery warnings.
- Reject escaping project instruction and skill links without reading their contents.
- Keep managed skill roots, `SKILL.md` files, and skill resources strict no-follow.