### PR TITLE
Route upgrades through releases.fx.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,7 +317,7 @@ Releases are triggered automatically when the version in `src/main.zig` changes 
 2. Merge to `main`
 3. The release workflow checks if `vX.Y.Z` tag exists; if not, it builds four platform binaries, creates the git tag, and publishes a GitHub Release with the binaries attached
 
-The install script and `fx upgrade` fetch binaries from the public Vercel Blob CDN. No authentication or external CLI tools are required. The release workflow also publishes binaries to the CDN and updates `latest.txt` automatically.
+The install script and `fx upgrade` fetch binaries from `releases.fx.sh`, backed by the public Vercel Blob CDN. No authentication or external CLI tools are required. The release workflow also publishes binaries to the CDN and updates `latest.txt` automatically.
 
 After CI passes for a push to `main`, the dev release workflow publishes commit-addressed binaries and then updates `dev.json`. Dogfooders opt in with `fx upgrade --channel dev`; the choice is stored in their user settings and applies to manual upgrades, automatic upgrades, and the `ctrl+g` handoff. `fx upgrade --channel stable` returns to tagged releases. Dev publishing does not create tags or GitHub Releases.
 

--- a/src/core/upgrade/upgrade_helpers.zig
+++ b/src/core/upgrade/upgrade_helpers.zig
@@ -18,7 +18,7 @@ fn setRecvTimeout(conn: *std.http.Client.Connection) void {
     std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
 }
 
-pub const cdn_base = "https://ugiwefobuo4tac0m.public.blob.vercel-storage.com/cli";
+pub const cdn_base = "https://releases.fx.sh";
 
 pub fn resolveCdnBase() []const u8 {
     if (io_mod.getenv("FX_E2E_UPGRADE_BASE_URL")) |url| {
@@ -327,6 +327,10 @@ test "E2E upgrade base accepts only explicit IPv4 loopback origins" {
     try std.testing.expect(!isLoopbackE2eUpgradeBase("http://127.0.0.1"));
     try std.testing.expect(!isLoopbackE2eUpgradeBase("http://127.0.0.1:80@example.com"));
     try std.testing.expect(!isLoopbackE2eUpgradeBase("http://localhost:1234"));
+}
+
+test "production upgrade base uses the fx release domain" {
+    try std.testing.expectEqualStrings("https://releases.fx.sh", resolveCdnBase());
 }
 
 test "extractChecksumHex parses sha256sum format" {


### PR DESCRIPTION
## Summary

- Fetch stable and dev fx upgrades through `releases.fx.sh` instead of the Vercel Blob store hostname.