### PR TITLE
Restore upgrade handoff test target

### DIFF
--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -4835,7 +4835,7 @@ test.skipIf(!tmuxAvailable())(
       fakeGatewayFinalText("UPGRADE_CTRL_G_INITIAL_DONE"),
       fakeGatewayFinalText("UPGRADE_CTRL_G_FOLLOWUP_DONE"),
     ]);
-    const release = startUpgradeServer(root, argvLogPath, "v0.0.1");
+    const release = startUpgradeServer(root, argvLogPath);
 
     try {
       writeFileSync(stderrPath, "");


### PR DESCRIPTION
## Summary

- Keep the Ctrl+G upgrade handoff E2E runnable after the public version reset.
- Preserve the dedicated 0.4.5 to 0.0.1 bridge policy coverage.
