### PR TITLE
Keep WASM terminal input responsive during streaming

### DIFF
--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -332,6 +332,7 @@ function createRuntime(options) {
     options.onTerminalPoll?.();
     if (stdin.chunks.length) return 1;
     if (stdin.closed) return -1;
+    if (timeoutMs === 0) return 0;
     return stdin.wait(timeoutMs >= 0 ? timeoutMs : undefined).then(() =>
       stdin.chunks.length ? 1 : (stdin.closed ? -1 : 0));
   }

--- a/sdk/tests/test-term.mjs
+++ b/sdk/tests/test-term.mjs
@@ -14,10 +14,15 @@ if (!supportsJspi()) {
 }
 
 const output = [];
-let firstTokenAt;
-const startedAt = performance.now();
 const streamedDecoder = new TextDecoder();
 let streamedText = "";
+const originalSetTimeout = globalThis.setTimeout;
+let observeZeroTimeouts = false;
+let zeroTimeoutCount = 0;
+globalThis.setTimeout = (callback, delay = 0, ...args) => {
+  if (observeZeroTimeouts && Number(delay) === 0) zeroTimeoutCount += 1;
+  return originalSetTimeout(callback, delay, ...args);
+};
 const dataListeners = new Set();
 const resizeListeners = new Set();
 let drainCalls = 0;
@@ -29,7 +34,6 @@ const terminal = {
     const chunk = bytes instanceof Uint8Array ? bytes : new TextEncoder().encode(bytes);
     output.push(chunk);
     streamedText += streamedDecoder.decode(chunk, { stream: true });
-    if (firstTokenAt === undefined && streamedText.includes("hello")) firstTokenAt = performance.now();
     process.stdout.write(chunk);
   },
   async drain() {
@@ -109,17 +113,19 @@ runtime.write("!");
 runtime.write("\x7f");
 runtime.write("\r");
 const deadline = performance.now() + 5000;
-while (firstTokenAt === undefined) {
-  if (performance.now() >= deadline) throw new Error("timed out waiting for first streamed fx-term response");
+while (streamStartedAt === undefined) {
+  if (performance.now() >= deadline) throw new Error("timed out waiting for continuous fx-term response");
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 const liveDraft = "queued draft";
+observeZeroTimeouts = true;
 runtime.write(liveDraft);
 while (!streamedText.includes(liveDraft)) {
   if (streamFinishedAt !== undefined) throw new Error("terminal did not render follow-up input while the response was active");
   if (performance.now() >= deadline) throw new Error("timed out waiting for live follow-up input");
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
+observeZeroTimeouts = false;
 while (streamFinishedAt === undefined) {
   if (performance.now() >= deadline) throw new Error("timed out waiting for streamed fx-term response");
   await new Promise((resolve) => setTimeout(resolve, 10));
@@ -131,14 +137,15 @@ const exitCode = await Promise.race([
   runtime.exited,
   new Promise((_, reject) => setTimeout(() => reject(new Error("timed out waiting for fx-term exit")), 5000)),
 ]);
+globalThis.setTimeout = originalSetTimeout;
 const text = new TextDecoder().decode(Buffer.concat(output.map((chunk) => Buffer.from(chunk))));
 
 if (exitCode !== 0) throw new Error(`fx-term exited with code ${exitCode}`);
 if (!text.includes("𝒇x")) throw new Error("shared Fx welcome frame was not observed");
 if (!text.includes("Run /help for commands")) throw new Error("shared Fx welcome guidance was not observed");
 if (requestedModel !== "sdk/term-model") throw new Error(`terminal prompt did not use the host-restored model: ${requestedModel}`);
-if (!(streamStartedAt >= startedAt)) throw new Error("terminal fetch did not start after the runtime");
-if (!(firstTokenAt < streamFinishedAt)) throw new Error("terminal did not render output before the continuous stream finished");
+if (!(streamStartedAt < streamFinishedAt)) throw new Error("terminal fetch did not remain active for continuous streaming");
+if (zeroTimeoutCount !== 0) throw new Error(`terminal allocated ${zeroTimeoutCount} zero-timeout poll timer(s)`);
 if (!events.some((event) => event.type === "config.restore" && event.configId === "model")) throw new Error("terminal model restore event was not emitted");
 if (!events.some((event) => event.type === "config.restore" && event.configId === "mode")) throw new Error("terminal mode restore event was not emitted");
 console.error(`term SDK smoke passed: exit=${exitCode}, bytes=${Buffer.byteLength(text)}`);

--- a/sdk/tests/test-term.mjs
+++ b/sdk/tests/test-term.mjs
@@ -54,24 +54,28 @@ const persistedConfig = new Map([
 const events = [];
 const encoded = new TextEncoder();
 let requestedModel;
-let secondTokenSentAt;
-let outputBytesAtFirstChunk;
-let outputBytesBeforeSecondChunk;
-const outputByteLength = () => output.reduce((total, chunk) => total + chunk.byteLength, 0);
+let streamStartedAt;
+let streamFinishedAt;
 const mockFetch = async (_url, init) => {
   requestedModel = new Headers(init.headers).get("ai-language-model-id");
   return new Response(new ReadableStream({
     start(controller) {
       controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n'));
-      outputBytesAtFirstChunk = outputByteLength();
-      setTimeout(() => {
-        outputBytesBeforeSecondChunk = outputByteLength();
-        secondTokenSentAt = performance.now();
+      streamStartedAt = performance.now();
+      let emitted = 0;
+      const interval = setInterval(() => {
+        emitted += 1;
+        if (emitted < 30) {
+          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"."}\n'));
+          return;
+        }
+        clearInterval(interval);
+        streamFinishedAt = performance.now();
         controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n'));
         controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
         controller.enqueue(encoded.encode("data: [DONE]\n"));
         controller.close();
-      }, 250);
+      }, 20);
     },
   }), { status: 200, headers: { "content-type": "text/event-stream" } });
 };
@@ -105,11 +109,23 @@ runtime.write("!");
 runtime.write("\x7f");
 runtime.write("\r");
 const deadline = performance.now() + 5000;
-while (secondTokenSentAt === undefined) {
+while (firstTokenAt === undefined) {
+  if (performance.now() >= deadline) throw new Error("timed out waiting for first streamed fx-term response");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+const liveDraft = "queued draft";
+runtime.write(liveDraft);
+while (!streamedText.includes(liveDraft)) {
+  if (streamFinishedAt !== undefined) throw new Error("terminal did not render follow-up input while the response was active");
+  if (performance.now() >= deadline) throw new Error("timed out waiting for live follow-up input");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+while (streamFinishedAt === undefined) {
   if (performance.now() >= deadline) throw new Error("timed out waiting for streamed fx-term response");
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
 await new Promise((resolve) => setTimeout(resolve, 100));
+runtime.write("\x7f".repeat(liveDraft.length));
 runtime.write("/exit\r");
 const exitCode = await Promise.race([
   runtime.exited,
@@ -121,7 +137,8 @@ if (exitCode !== 0) throw new Error(`fx-term exited with code ${exitCode}`);
 if (!text.includes("𝒇x")) throw new Error("shared Fx welcome frame was not observed");
 if (!text.includes("Run /help for commands")) throw new Error("shared Fx welcome guidance was not observed");
 if (requestedModel !== "sdk/term-model") throw new Error(`terminal prompt did not use the host-restored model: ${requestedModel}`);
-if (!(outputBytesBeforeSecondChunk > outputBytesAtFirstChunk)) throw new Error("terminal did not render output before the delayed second token arrived");
+if (!(streamStartedAt >= startedAt)) throw new Error("terminal fetch did not start after the runtime");
+if (!(firstTokenAt < streamFinishedAt)) throw new Error("terminal did not render output before the continuous stream finished");
 if (!events.some((event) => event.type === "config.restore" && event.configId === "model")) throw new Error("terminal model restore event was not emitted");
 if (!events.some((event) => event.type === "config.restore" && event.configId === "mode")) throw new Error("terminal mode restore event was not emitted");
 console.error(`term SDK smoke passed: exit=${exitCode}, bytes=${Buffer.byteLength(text)}`);

--- a/src/gateway/host_stream_provider.zig
+++ b/src/gateway/host_stream_provider.zig
@@ -152,7 +152,7 @@ const HostStreamReader = struct {
     handle: i32 = -1,
     cancel_flag: *std.atomic.Value(bool) = undefined,
     cooperative_pulse: ?stream_provider.CooperativePulse = null,
-    last_cooperative_pulse: std.Io.Clock.Timestamp = undefined,
+    last_cooperative_pulse: ?std.Io.Clock.Timestamp = null,
     aborted: bool = false,
     buffer: [16 * 1024]u8 = undefined,
     interface: std.Io.Reader = undefined,
@@ -163,7 +163,10 @@ const HostStreamReader = struct {
             .handle = handle,
             .cancel_flag = cancel_flag,
             .cooperative_pulse = cooperative_pulse,
-            .last_cooperative_pulse = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake),
+            .last_cooperative_pulse = if (cooperative_pulse != null)
+                std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake)
+            else
+                null,
         };
         self.interface = .{ .vtable = &.{ .stream = streamReader, .readVec = readVec }, .buffer = &self.buffer, .seek = 0, .end = 0 };
     }
@@ -192,7 +195,8 @@ const HostStreamReader = struct {
 
     fn pulseIfDueAt(self: *@This(), now: std.Io.Clock.Timestamp) !void {
         if (self.cooperative_pulse == null) return;
-        const elapsed_ms = self.last_cooperative_pulse.durationTo(now).raw.toMilliseconds();
+        const last_pulse = self.last_cooperative_pulse orelse return;
+        const elapsed_ms = last_pulse.durationTo(now).raw.toMilliseconds();
         if (elapsed_ms < cooperative_pulse_interval_ms) return;
         try self.pulseAt(now);
     }
@@ -200,11 +204,15 @@ const HostStreamReader = struct {
     fn readHost(self: *@This(), dest: []u8) std.Io.Reader.Error!usize {
         while (true) {
             if (self.cancel_flag.load(.seq_cst)) return self.abortRead();
-            self.pulseIfDueAt(std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake)) catch return error.ReadFailed;
+            if (self.cooperative_pulse != null) {
+                self.pulseIfDueAt(std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake)) catch return error.ReadFailed;
+            }
             if (self.cancel_flag.load(.seq_cst)) return self.abortRead();
             const count = self.transport.next(self.handle, dest);
             if (count == -3) {
-                self.pulseAt(std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake)) catch return error.ReadFailed;
+                if (self.cooperative_pulse != null) {
+                    self.pulseAt(std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake)) catch return error.ReadFailed;
+                }
                 continue;
             }
             if (count == -2) return self.abortRead();
@@ -266,6 +274,36 @@ test "error response bodies are bounded" {
         error.HostStreamFailed,
         readBody(std.testing.allocator, transport, 1, &cancel_flag, null),
     );
+}
+
+test "host stream reader omits pulse timing state without callback" {
+    const FakeTransport = struct {
+        fn open(_: ?*anyopaque, _: []const u8, _: []const u8, _: []const u8, _: []const u8) anyerror!i32 {
+            return 1;
+        }
+
+        fn status(_: ?*anyopaque, _: i32, _: *u16) i32 {
+            return 1;
+        }
+
+        fn next(_: ?*anyopaque, _: i32, _: []u8) i32 {
+            return 0;
+        }
+
+        fn close(_: ?*anyopaque, _: i32) void {}
+    };
+
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    var reader: HostStreamReader = undefined;
+    reader.init(.{
+        .context = null,
+        .open_fn = FakeTransport.open,
+        .status_fn = FakeTransport.status,
+        .next_fn = FakeTransport.next,
+        .close_fn = FakeTransport.close,
+    }, 1, &cancel_flag, null);
+
+    try std.testing.expect(reader.last_cooperative_pulse == null);
 }
 
 test "host stream reader throttles cooperative pulses" {

--- a/src/gateway/host_stream_provider.zig
+++ b/src/gateway/host_stream_provider.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
 const stream_provider = @import("../core/agent/stream_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
 const gateway_client = @import("client.zig");
 
 const Allocator = std.mem.Allocator;
 const max_error_body_bytes = 1024 * 1024;
+const cooperative_pulse_interval_ms = 50;
 
 pub const Transport = struct {
     context: ?*anyopaque,
@@ -150,12 +152,19 @@ const HostStreamReader = struct {
     handle: i32 = -1,
     cancel_flag: *std.atomic.Value(bool) = undefined,
     cooperative_pulse: ?stream_provider.CooperativePulse = null,
+    last_cooperative_pulse: std.Io.Clock.Timestamp = undefined,
     aborted: bool = false,
     buffer: [16 * 1024]u8 = undefined,
     interface: std.Io.Reader = undefined,
 
     fn init(self: *@This(), transport: Transport, handle: i32, cancel_flag: *std.atomic.Value(bool), cooperative_pulse: ?stream_provider.CooperativePulse) void {
-        self.* = .{ .transport = transport, .handle = handle, .cancel_flag = cancel_flag, .cooperative_pulse = cooperative_pulse };
+        self.* = .{
+            .transport = transport,
+            .handle = handle,
+            .cancel_flag = cancel_flag,
+            .cooperative_pulse = cooperative_pulse,
+            .last_cooperative_pulse = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake),
+        };
         self.interface = .{ .vtable = &.{ .stream = streamReader, .readVec = readVec }, .buffer = &self.buffer, .seek = 0, .end = 0 };
     }
 
@@ -175,12 +184,27 @@ const HostStreamReader = struct {
         return error.ReadFailed;
     }
 
+    fn pulseAt(self: *@This(), now: std.Io.Clock.Timestamp) !void {
+        if (self.cooperative_pulse == null) return;
+        self.last_cooperative_pulse = now;
+        try pulse(self.cooperative_pulse);
+    }
+
+    fn pulseIfDueAt(self: *@This(), now: std.Io.Clock.Timestamp) !void {
+        if (self.cooperative_pulse == null) return;
+        const elapsed_ms = self.last_cooperative_pulse.durationTo(now).raw.toMilliseconds();
+        if (elapsed_ms < cooperative_pulse_interval_ms) return;
+        try self.pulseAt(now);
+    }
+
     fn readHost(self: *@This(), dest: []u8) std.Io.Reader.Error!usize {
         while (true) {
             if (self.cancel_flag.load(.seq_cst)) return self.abortRead();
+            self.pulseIfDueAt(std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake)) catch return error.ReadFailed;
+            if (self.cancel_flag.load(.seq_cst)) return self.abortRead();
             const count = self.transport.next(self.handle, dest);
             if (count == -3) {
-                pulse(self.cooperative_pulse) catch return error.ReadFailed;
+                self.pulseAt(std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake)) catch return error.ReadFailed;
                 continue;
             }
             if (count == -2) return self.abortRead();
@@ -242,4 +266,38 @@ test "error response bodies are bounded" {
         error.HostStreamFailed,
         readBody(std.testing.allocator, transport, 1, &cancel_flag, null),
     );
+}
+
+test "host stream reader throttles cooperative pulses" {
+    const PulseTrace = struct {
+        calls: usize = 0,
+
+        fn run(raw: *anyopaque) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.calls += 1;
+        }
+    };
+    const awake_timestamp = struct {
+        fn at(milliseconds: i64) std.Io.Clock.Timestamp {
+            return .{
+                .clock = .awake,
+                .raw = .fromNanoseconds(@as(i96, milliseconds) * std.time.ns_per_ms),
+            };
+        }
+    }.at;
+
+    var trace: PulseTrace = .{};
+    var reader: HostStreamReader = .{
+        .cooperative_pulse = .{ .ctx = &trace, .run = PulseTrace.run },
+        .last_cooperative_pulse = awake_timestamp(100),
+    };
+
+    try reader.pulseIfDueAt(awake_timestamp(149));
+    try std.testing.expectEqual(@as(usize, 0), trace.calls);
+    try reader.pulseIfDueAt(awake_timestamp(150));
+    try std.testing.expectEqual(@as(usize, 1), trace.calls);
+    try reader.pulseIfDueAt(awake_timestamp(199));
+    try std.testing.expectEqual(@as(usize, 1), trace.calls);
+    try reader.pulseIfDueAt(awake_timestamp(200));
+    try std.testing.expectEqual(@as(usize, 2), trace.calls);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -434,6 +434,14 @@ const App = struct {
 
     pub fn cooperativeTransportPulse(self: *Self) !void {
         if (comptime !host_target.is_wasm) return;
+        if (try event_loop.pump_ready_input(
+            self.terminal,
+            &self.should_exit,
+            RenderAppRuntime.eventLoopCallbacks(self),
+        )) |exit_cause| {
+            if (exit_cause == .input_closed) self.should_exit = true;
+            return;
+        }
         try WorkerAppRuntime.tick(
             self,
             app_callbacks.Bindings(App).onTaskCompletion,
@@ -3841,4 +3849,5 @@ test {
     _ = @import("ui/transcript/runtime_tests.zig");
     _ = @import("core/agent/worker_runtime.zig");
     _ = @import("gateway/client.zig");
+    _ = @import("gateway/host_stream_provider.zig");
 }

--- a/src/ui/event_loop.zig
+++ b/src/ui/event_loop.zig
@@ -28,6 +28,51 @@ pub const ExitCause = enum {
     input_closed,
 };
 
+pub fn pump_ready_input(terminal: anytype, should_exit: *bool, callbacks: EventLoopCallbacks) !?ExitCause {
+    var buf: [128]u8 = undefined;
+    var handled_input = false;
+
+    while (callbacks.next_collected_byte(callbacks.ctx)) |byte| {
+        handled_input = true;
+        try callbacks.handle_byte(callbacks.ctx, byte);
+        if (should_exit.*) return .requested_exit;
+    }
+
+    var poll_result = try terminal.pollInput(0);
+    var input_reads: usize = 0;
+
+    while (poll_result.readable and input_reads < max_input_reads_per_fact_collection) : (input_reads += 1) {
+        const read_len = try terminal.read(&buf);
+        if (read_len == 0) {
+            if (input_reads > 0) attemptFinalFrameCommit(callbacks, "eof");
+            return .input_closed;
+        }
+
+        handled_input = true;
+        record_tape.recordStdin(buf[0..read_len]);
+        for (buf[0..read_len]) |byte| {
+            try callbacks.handle_byte(callbacks.ctx, byte);
+            if (should_exit.*) return .requested_exit;
+        }
+        poll_result = try terminal.pollInput(0);
+    }
+
+    if (poll_result.readable) {
+        try callbacks.commit_frame(callbacks.ctx);
+        return null;
+    }
+    if (poll_result.closed()) {
+        if (input_reads > 0) attemptFinalFrameCommit(callbacks, "hangup");
+        return .input_closed;
+    }
+
+    if (handled_input) {
+        try callbacks.settle_delivery_epoch(callbacks.ctx);
+        try callbacks.commit_frame(callbacks.ctx);
+    }
+    return null;
+}
+
 pub fn run(terminal: anytype, should_exit: *bool, poll_timeout_ms: i32, callbacks: EventLoopCallbacks) !ExitCause {
     var buf: [128]u8 = undefined;
 
@@ -152,6 +197,11 @@ fn commitEventLoopTestFrame(ctx: *anyopaque) !void {
     trace.should_exit.* = true;
 }
 
+fn commitEventLoopTestFrameWithoutExit(ctx: *anyopaque) !void {
+    const trace: *EventLoopTestTrace = @ptrCast(@alignCast(ctx));
+    trace.append('c');
+}
+
 fn settleEventLoopTestDeliveryEpoch(ctx: *anyopaque) !void {
     const trace: *EventLoopTestTrace = @ptrCast(@alignCast(ctx));
     trace.append('s');
@@ -222,6 +272,57 @@ test "event loop batches already readable input before committing a frame" {
 
     try std.testing.expectEqual(ExitCause.requested_exit, exit_cause);
     try std.testing.expectEqualStrings("tabdesc", trace.bytes[0..trace.len]);
+}
+
+test "cooperative input pump renders ready input without collecting facts" {
+    var should_exit = false;
+    var polls: usize = 0;
+    var reads: usize = 0;
+    var trace = EventLoopTestTrace{ .should_exit = &should_exit };
+
+    const exit_cause = try pump_ready_input(EventLoopTestTerminal{
+        .polls = &polls,
+        .burst_reads = &reads,
+    }, &should_exit, .{
+        .ctx = &trace,
+        .collect_facts = collectEventLoopTestFacts,
+        .next_collected_byte = noCollectedEventLoopByte,
+        .handle_byte = handleEventLoopTestByte,
+        .settle_delivery_epoch = settleEventLoopTestDeliveryEpoch,
+        .commit_frame = commitEventLoopTestFrameWithoutExit,
+    });
+
+    try std.testing.expectEqual(@as(?ExitCause, null), exit_cause);
+    try std.testing.expect(!should_exit);
+    try std.testing.expectEqualStrings("abdesc", trace.bytes[0..trace.len]);
+}
+
+test "cooperative input pump is idle when no input is ready" {
+    const Terminal = struct {
+        fn pollInput(_: @This(), timeout_ms: i32) !shell_runtime.PollResult {
+            try std.testing.expectEqual(@as(i32, 0), timeout_ms);
+            return .{};
+        }
+
+        fn read(_: @This(), _: []u8) !usize {
+            return error.UnexpectedRead;
+        }
+    };
+
+    var should_exit = false;
+    var trace = EventLoopTestTrace{ .should_exit = &should_exit };
+    const exit_cause = try pump_ready_input(Terminal{}, &should_exit, .{
+        .ctx = &trace,
+        .collect_facts = collectEventLoopTestFacts,
+        .next_collected_byte = noCollectedEventLoopByte,
+        .handle_byte = rejectUnexpectedEventLoopByte,
+        .settle_delivery_epoch = rejectUnexpectedEventLoopCommit,
+        .commit_frame = rejectUnexpectedEventLoopCommit,
+    });
+
+    try std.testing.expectEqual(@as(?ExitCause, null), exit_cause);
+    try std.testing.expect(!should_exit);
+    try std.testing.expectEqual(@as(usize, 0), trace.len);
 }
 
 test "event loop settles a facts-only delivery epoch before committing" {


### PR DESCRIPTION
## Summary

- process ready terminal input during cooperative WASM transport pulses
- pulse the UI at a bounded 50 ms cadence even when stream chunks arrive continuously
- keep zero-timeout terminal polls synchronous so cooperative checks do not allocate timers
- cover continuous streaming and pulse throttling with regressions

## Validation

- `zig fmt --check src/`
- `zig build -Dwasm-surface=term`
- `node --experimental-wasm-jspi sdk/tests/test-term.mjs`
- `npm run --prefix sdk/node test:term`
- `zig build -Dwasm-surface=core`
- core streaming and cancellation SDK tests
- focused Zig tests for cooperative input and pulse throttling
- `./zig-out/bin/fx help` with clean stderr

`zig build test` reaches 8,150 passing tests and reproduces the existing ANSI presentation snapshot failure. A clean checkout of `main` reproduces the same failure.