### PR TITLE
Make configured MCP servers visible to the model

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -15,6 +15,7 @@ const diff_mod = @import("../core/output/diff.zig");
 const file_mutation = @import("../core/tooling/file_mutation.zig");
 const file_mutation_contract = @import("../core/tooling/file_mutation_contract.zig");
 const mcp_runtime = @import("../core/mcp/mcp_runtime.zig");
+const mcp_model_catalog = @import("../core/mcp/model_catalog.zig");
 const mcp_elicitation = @import("../core/mcp/elicitation.zig");
 const mrtr = @import("../core/mcp/mrtr.zig");
 const permission_auto_classifier = @import("../core/permissions/auto_classifier.zig");
@@ -1113,6 +1114,20 @@ fn appendStaticContext(raw_ctx: *anyopaque, arena: Allocator, messages: *std.Arr
     try ctx.state.cfg.context_registry.appendDefaultStatic(.{
         .project_context = ctx.modelVisibleProjectContext(),
     }, arena, messages);
+    const active_session = if (ctx.state.active_session) |*session| session else null;
+    var snapshot = if (active_session) |session|
+        if (session.mcp) |mcp|
+            try mcp.snapshotModelCatalog(arena, session.permission_rules, false)
+        else
+            try mcp_model_catalog.Snapshot.empty(arena)
+    else
+        try mcp_model_catalog.Snapshot.empty(arena);
+    defer snapshot.deinit(arena);
+    const section = try mcp_model_catalog.render(arena, snapshot);
+    if (section.text.len > 0) {
+        try messages.append(arena, .{ .role = .system, .content = section.text });
+    }
+    if (section.notice) |notice| try pushContextNotice(raw_ctx, notice);
 }
 
 fn validateToolCall(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall) !agent_runtime.ToolCallValidationResult {
@@ -3596,10 +3611,11 @@ test "ACP registry callbacks preserve snapshot bytes before transient context" {
     try deps.append_static_context.?(deps.ctx, arena, &messages);
     try deps.append_runtime_context(deps.ctx, arena, &messages);
 
-    try std.testing.expectEqual(@as(usize, 3), messages.items.len);
+    try std.testing.expectEqual(@as(usize, 4), messages.items.len);
     try std.testing.expectEqualStrings("base system", messages.items[0].content.?);
     try std.testing.expectEqualStrings("ACP registry context 1", messages.items[1].content.?);
-    try std.testing.expectEqualStrings("ACP registry transient", messages.items[2].content.?);
+    try std.testing.expect(std.mem.find(u8, messages.items[2].content.?, "<mcp_servers>") != null);
+    try std.testing.expectEqualStrings("ACP registry transient", messages.items[3].content.?);
     try std.testing.expectEqualStrings("ACP registry context 1", AcpContextRegistryFixture.static_context.?);
     try std.testing.expectEqual(@as(usize, 1), AcpContextRegistryFixture.transient_calls);
     try std.testing.expectEqual(

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -245,7 +245,7 @@ const skill_description =
 const install_skill_description =
     "Install a reusable skill from a supported source into fx managed skill storage. When to use: the user asks to install a skill or pastes a skills install command. When NOT to use: no installation is required, install packages, fetch unrelated repos, or modify project code.";
 const mcp_search_tools_description =
-    "Search metadata for configured MCP/dynamic tools without loading every dynamic schema into the main prompt. When to use: you need a specialized external/MCP capability but do not know its exact tool name. When NOT to use: the needed capability is already advertised directly, or ordinary local inspection, execution, web, or user interaction can handle the work.";
+    "Search bounded metadata for configured MCP/dynamic tools without loading every dynamic schema into the main prompt. Include the configured server alias and requested use case in the query; refine the use case when more_available is true. When to use: you need a specialized external/MCP capability but do not know its exact tool name. When NOT to use: the needed capability is already advertised directly, or ordinary local inspection, execution, web, or user interaction can handle the work.";
 const mcp_select_tool_description =
     "Exact-select one configured MCP/dynamic tool by name so its executable schema is advertised on the next model step. When to use: after discovering the exact specialized tool name in configured metadata. When NOT to use: guessing partial names, selecting built-in tools, or executing the dynamic tool directly.";
 const mcp_features_description =

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -16,6 +16,7 @@ const file_mutation_contract = @import("../tooling/file_mutation_contract.zig");
 const hooks = @import("../hooks/hooks.zig");
 const io_mod = @import("../shared/io.zig");
 const mcp_elicitation_interaction = @import("../mcp/elicitation_interaction.zig");
+const mcp_model_catalog = @import("../mcp/model_catalog.zig");
 const permission_gate = @import("../permissions/permission_gate.zig");
 const permissions = @import("../permissions/permissions.zig");
 const prompt_policy_contract = @import("../config/prompt_policy.zig");
@@ -749,6 +750,34 @@ pub fn Runtime(comptime App: type) type {
             try app.contextRegistry().appendDefaultStatic(.{
                 .project_context = modelVisibleProjectContext(app),
             }, arena, messages);
+            var snapshot = if (comptime @hasDecl(App, "snapshotMcpModelCatalog"))
+                try app.snapshotMcpModelCatalog(
+                    arena,
+                    if (comptime @hasField(App, "permission_engine")) app.permission_engine.rules else .{},
+                    false,
+                )
+            else
+                try mcp_model_catalog.Snapshot.empty(arena);
+            defer snapshot.deinit(arena);
+            const section = try mcp_model_catalog.render(arena, snapshot);
+            if (section.text.len > 0) {
+                try messages.append(arena, .{ .role = .system, .content = section.text });
+            }
+            if (section.notice) |notice| try pushMcpModelCatalogNotice(app, notice);
+        }
+
+        fn pushMcpModelCatalogNotice(app: *App, notice: []const u8) !void {
+            if (comptime @hasDecl(@TypeOf(app.session), "claimContextNotice")) {
+                if (!try app.session.claimContextNotice(std.heap.c_allocator, notice)) return;
+            }
+            const body = try types.renderContextNoticeBody(std.heap.c_allocator, notice);
+            defer std.heap.c_allocator.free(body);
+            try app_worker_runtime.Runtime(App).pushSemanticNotice(app, .{
+                .topic = "context",
+                .tone = .warning,
+                .body = body,
+                .visibility = .full_only,
+            });
         }
 
         pub fn appendTransientRuntimeContextMessage(
@@ -1423,6 +1452,15 @@ const FakeApp = struct {
 
     fn contextRegistry(self: *const FakeApp) context_contract.Registry {
         return self.context_registry;
+    }
+
+    fn snapshotMcpModelCatalog(
+        _: *FakeApp,
+        alloc: Allocator,
+        _: types.PermissionRuleSet,
+        _: bool,
+    ) !mcp_model_catalog.Snapshot {
+        return mcp_model_catalog.Snapshot.empty(alloc);
     }
 
     fn promptPolicy(_: *const FakeApp) prompt_policy_contract.Policy {
@@ -2288,10 +2326,11 @@ test "app agent runtime appends static and transient context through configured 
     try Runtime(FakeApp).appendStaticContextMessage(&app, arena, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     try Runtime(FakeApp).appendTransientRuntimeContextMessage(&app, arena, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
 
-    try std.testing.expectEqual(@as(usize, 2), messages.items.len);
+    try std.testing.expectEqual(@as(usize, 3), messages.items.len);
     try std.testing.expectEqual(types.ChatRole.system, messages.items[0].role);
     try std.testing.expectEqualStrings("provider static:project context", messages.items[0].content.?);
-    try std.testing.expectEqualStrings("provider transient:/tmp/workspace:auto:macos", messages.items[1].content.?);
+    try std.testing.expect(std.mem.find(u8, messages.items[1].content.?, "<mcp_servers>") != null);
+    try std.testing.expectEqualStrings("provider transient:/tmp/workspace:auto:macos", messages.items[2].content.?);
 }
 
 test "app agent runtime prefers active queued project context snapshot" {
@@ -2311,8 +2350,9 @@ test "app agent runtime prefers active queued project context snapshot" {
 
     try Runtime(FakeApp).appendStaticContextMessage(&app, arena, &messages, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
 
-    try std.testing.expectEqual(@as(usize, 1), messages.items.len);
+    try std.testing.expectEqual(@as(usize, 2), messages.items.len);
     try std.testing.expectEqualStrings("provider static:queued project context", messages.items[0].content.?);
+    try std.testing.expect(std.mem.find(u8, messages.items[1].content.?, "<mcp_servers>") != null);
     const tool_context = testToolContext(&app);
     try std.testing.expectEqualStrings("test.default_context", tool_context.context_registry.defaultProvider().id);
 }

--- a/src/core/app/app_mcp_runtime.zig
+++ b/src/core/app/app_mcp_runtime.zig
@@ -5,6 +5,7 @@ const mcp_access = @import("../mcp/access_policy.zig");
 const mcp_contract = @import("../mcp/mcp_contract.zig");
 const elicitation = @import("../mcp/elicitation.zig");
 const mcp_health = @import("../mcp/health.zig");
+const mcp_model_catalog = @import("../mcp/model_catalog.zig");
 const mcp_runtime = @import("../mcp/mcp_runtime.zig");
 const context_limits = @import("../config/context_limits.zig");
 const tool_advertisement = @import("../tooling/tool_advertisement.zig");
@@ -269,6 +270,21 @@ pub const State = struct {
             features_visible,
         );
         return view;
+    }
+
+    pub fn snapshotModelCatalog(
+        self: *State,
+        alloc: Allocator,
+        permission_rules: types.PermissionRuleSet,
+        include_ask_deferred: bool,
+    ) !mcp_model_catalog.Snapshot {
+        var lease = self.acquire() orelse return mcp_model_catalog.Snapshot.empty(alloc);
+        defer lease.deinit();
+        return lease.runtime.snapshotModelCatalog(
+            alloc,
+            permission_rules,
+            include_ask_deferred,
+        );
     }
 
     pub fn waitForRequired(

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -33,6 +33,7 @@ const model_capabilities = @import("../config/model_capabilities.zig");
 const mcp_elicitation_interaction = @import("../mcp/elicitation_interaction.zig");
 const mcp_elicitation = @import("../mcp/elicitation.zig");
 const mcp_access_policy = @import("../mcp/access_policy.zig");
+const mcp_model_catalog = @import("../mcp/model_catalog.zig");
 const mcp_runtime = @import("../mcp/mcp_runtime.zig");
 const mode_registry = @import("../modes/mode_registry.zig");
 const permission_auto_classifier = @import("../permissions/auto_classifier.zig");
@@ -1878,6 +1879,16 @@ fn appendStaticContext(raw_ctx: *anyopaque, arena: Allocator, messages: *std.Arr
     try ctx.deps.context_registry.appendDefaultStatic(.{
         .project_context = ctx.modelVisibleProjectContext(),
     }, arena, messages);
+    var snapshot = if (ctx.mcp) |mcp|
+        try mcp.snapshotModelCatalog(arena, ctx.permission_rules, true)
+    else
+        try mcp_model_catalog.Snapshot.empty(arena);
+    defer snapshot.deinit(arena);
+    const section = try mcp_model_catalog.render(arena, snapshot);
+    if (section.text.len > 0) {
+        try messages.append(arena, .{ .role = .system, .content = section.text });
+    }
+    if (section.notice) |notice| try pushContextNotice(raw_ctx, notice);
 }
 
 fn validateToolCall(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall) !agent_runtime.ToolCallValidationResult {
@@ -4123,12 +4134,14 @@ const TestContextRegistryFixture = struct {
         );
 
         if (expected_static_context) |expected_static| {
-            try std.testing.expectEqual(@as(usize, 2), messages.items.len);
+            try std.testing.expectEqual(@as(usize, 3), messages.items.len);
             try std.testing.expectEqualStrings(expected_static, messages.items[0].content.?);
-            try std.testing.expectEqualStrings(test_registry_transient_context, messages.items[1].content.?);
+            try std.testing.expect(std.mem.find(u8, messages.items[1].content.?, "<mcp_servers>") != null);
+            try std.testing.expectEqualStrings(test_registry_transient_context, messages.items[2].content.?);
         } else {
-            try std.testing.expectEqual(@as(usize, 1), messages.items.len);
-            try std.testing.expectEqualStrings(test_registry_transient_context, messages.items[0].content.?);
+            try std.testing.expectEqual(@as(usize, 2), messages.items.len);
+            try std.testing.expect(std.mem.find(u8, messages.items[0].content.?, "<mcp_servers>") != null);
+            try std.testing.expectEqualStrings(test_registry_transient_context, messages.items[1].content.?);
         }
 
         try testPushAssistantText(deps, "assistant text");

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -31,6 +31,7 @@ const streamable_http = @import("streamable_http.zig");
 const feature_cache = @import("feature_cache.zig");
 const access_policy = @import("access_policy.zig");
 const health = @import("health.zig");
+const model_catalog = @import("model_catalog.zig");
 const startup_admission = @import("startup_admission.zig");
 const tool_subscription = @import("tool_subscription.zig");
 const completion_feature = @import("features/completion.zig");
@@ -3121,12 +3122,7 @@ fn snapshotServerHealthBeforeDiscoveryPublication(
         .connecting
     else
         .disconnected;
-    const authentication: health.AuthenticationState = if (server.config.auth != null or
-        server.config.bearer_token_env != null or
-        server.config.header_env.len > 0)
-        .configured
-    else
-        .none;
+    const authentication = configuredAuthenticationState(server);
     const failure = try healthFailureForState(
         alloc,
         server.config.required,
@@ -3193,16 +3189,7 @@ fn snapshotServerHealth(
         published_connection,
         transport_running,
     );
-    const authentication: health.AuthenticationState = if (server.auth_credentials_present.load(.acquire))
-        .authenticated
-    else if (server.auth_challenge_present.load(.acquire))
-        .required
-    else if (server.config.auth != null or
-        server.config.bearer_token_env != null or
-        server.config.header_env.len > 0)
-        .configured
-    else
-        .none;
+    const authentication = serverAuthenticationState(server);
     const failure = try healthFailureForState(
         alloc,
         server.config.required,
@@ -3254,6 +3241,69 @@ fn snapshotServerHealth(
         ),
         .last_successful_discovery_ms = server.last_successful_discovery_ms,
         .failure = failure,
+    };
+}
+
+fn configuredAuthenticationState(server: *const McpServer) health.AuthenticationState {
+    return if (server.config.auth != null or
+        server.config.bearer_token_env != null or
+        server.config.header_env.len > 0)
+        .configured
+    else
+        .none;
+}
+
+fn serverAuthenticationState(server: *const McpServer) health.AuthenticationState {
+    if (server.auth_credentials_present.load(.acquire)) return .authenticated;
+    if (server.auth_challenge_present.load(.acquire)) return .required;
+    return configuredAuthenticationState(server);
+}
+
+fn snapshotServerModelSummary(
+    alloc: Allocator,
+    server: *const McpServer,
+    permission_rules: types.PermissionRuleSet,
+    deferred_pending: bool,
+) !model_catalog.ServerSummary {
+    const name = try alloc.dupe(u8, server.config.name);
+    errdefer alloc.free(name);
+    const published_connection: health.ConnectionState = switch (server.state) {
+        .disconnected => .disconnected,
+        .disabled => .disabled,
+        .ready => .ready,
+        .failed => .failed,
+    };
+    const transport_running: ?bool = if (server.config.transport == .stdio)
+        if (server.dispatcher) |dispatcher| dispatcher.isRunning() else false
+    else
+        null;
+    const connection = health.observedConnection(published_connection, transport_running);
+    const deferred_for_ask = deferred_pending and
+        startup_admission.decide(
+            server.config.enabled,
+            server.config.required,
+            .ask_startup,
+        ) == .deferred;
+    var tool_count: ?usize = null;
+    if (connection == .ready and serverCatalogAvailable(server)) {
+        var visible_count: usize = 0;
+        for (server.tool_catalog.tools.items) |tool| {
+            if (permissions.rulesDenyAllTargetsForPermission(
+                permission_rules,
+                tool.prefixed_name,
+            )) continue;
+            visible_count += 1;
+        }
+        tool_count = visible_count;
+    }
+    return .{
+        .name = name,
+        .availability = model_catalog.classifyAvailability(
+            connection,
+            serverAuthenticationState(server),
+            deferred_for_ask,
+        ),
+        .tool_count = tool_count,
     };
 }
 
@@ -4832,6 +4882,65 @@ pub const McpRuntime = struct {
         return .{ .captured_at_ms = captured_at_ms, .servers = items };
     }
 
+    /// Returns an owned model-safe catalog snapshot. The caller releases it with `deinit`.
+    pub fn snapshotModelCatalog(
+        self: *McpRuntime,
+        alloc: Allocator,
+        permission_rules: types.PermissionRuleSet,
+        include_ask_deferred: bool,
+    ) !model_catalog.Snapshot {
+        const servers = try alloc.alloc(model_catalog.ServerSummary, self.servers.items.len);
+        var initialized: usize = 0;
+        errdefer {
+            for (servers[0..initialized]) |server| alloc.free(server.name);
+            alloc.free(servers);
+        }
+
+        const discovery_state = self.discovery_state.load(.acquire);
+        const deferred_pending = include_ask_deferred and
+            self.deferred_discovery_state.load(.acquire) != .complete;
+        for (self.servers.items, 0..) |*server, index| {
+            if (discovery_state != .complete) {
+                const connection: health.ConnectionState = if (!server.config.enabled)
+                    .disabled
+                else if (discovery_state == .loading)
+                    .connecting
+                else
+                    .disconnected;
+                servers[index] = .{
+                    .name = try alloc.dupe(u8, server.config.name),
+                    .availability = model_catalog.classifyAvailability(
+                        connection,
+                        configuredAuthenticationState(server),
+                        false,
+                    ),
+                };
+                initialized += 1;
+                continue;
+            }
+
+            server.connection_lock.lockSharedUncancelable(io_mod.getIo());
+            self.catalog_mutex.lockSharedUncancelable(io_mod.getIo());
+            server.status_lock.lockUncancelable(io_mod.getIo());
+            servers[index] = snapshotServerModelSummary(
+                alloc,
+                server,
+                permission_rules,
+                deferred_pending,
+            ) catch |err| {
+                server.status_lock.unlock(io_mod.getIo());
+                self.catalog_mutex.unlockShared(io_mod.getIo());
+                server.connection_lock.unlockShared(io_mod.getIo());
+                return err;
+            };
+            server.status_lock.unlock(io_mod.getIo());
+            self.catalog_mutex.unlockShared(io_mod.getIo());
+            server.connection_lock.unlockShared(io_mod.getIo());
+            initialized += 1;
+        }
+        return .{ .servers = servers };
+    }
+
     pub fn requiredStartupFailure(
         self: *McpRuntime,
         alloc: Allocator,
@@ -5785,7 +5894,8 @@ pub const McpRuntime = struct {
             defer matches.deinit(alloc);
             var auth_witnesses: std.ArrayList(CatalogAuthWitness) = .empty;
             defer auth_witnesses.deinit(alloc);
-            for (self.servers.items) |*server| {
+            var more_available = false;
+            server_loop: for (self.servers.items) |*server| {
                 if (server.state != .ready) continue;
                 if (!serverCatalogAvailable(server)) continue;
                 if (!operation_access.allows(.{ .tool_server = server.config.name })) continue;
@@ -5793,15 +5903,19 @@ pub const McpRuntime = struct {
                     instructions[0..context_limits.utf8PrefixLength(instructions, mcp_server_instruction_search_bytes)]
                 else
                     "";
-                const match_count_before = matches.items.len;
+                var server_matched = false;
                 for (server.tool_catalog.tools.items) |tool| {
                     if (!operation_access.allows(.{ .tool = tool.prefixed_name })) continue;
                     if (permissions.rulesDenyAllTargetsForPermission(permission_rules, tool.prefixed_name)) continue;
                     if (!toolMatchesQuery(tool, searchable_instructions, query)) continue;
+                    server_matched = true;
+                    if (matches.items.len >= capped_limit) {
+                        more_available = true;
+                        break;
+                    }
                     try matches.append(alloc, tool);
-                    if (matches.items.len >= capped_limit) break;
                 }
-                if (matches.items.len > match_count_before) {
+                if (server_matched) {
                     if (catalogAuthWitness(server)) |generation| {
                         try auth_witnesses.append(alloc, .{
                             .server = server,
@@ -5809,7 +5923,7 @@ pub const McpRuntime = struct {
                         });
                     }
                 }
-                if (matches.items.len >= capped_limit) break;
+                if (more_available) break :server_loop;
             }
             if (matches.items.len == 0) {
                 if (try renderAuthenticationRequired(
@@ -5829,6 +5943,7 @@ pub const McpRuntime = struct {
                 limits.mcp_search_result_bytes,
                 0,
                 false,
+                more_available,
             );
             const observed_bytes = full.len;
             const effective_bytes = limits.mcp_search_result_bytes.effectiveBytes();
@@ -5852,6 +5967,7 @@ pub const McpRuntime = struct {
                     limits.mcp_search_result_bytes,
                     observed_bytes,
                     true,
+                    more_available,
                 );
                 if (candidate.len <= effective_bytes) {
                     model_output = candidate;
@@ -11120,6 +11236,7 @@ fn renderSearchResult(
     result_limit: context_limits.Resolved,
     observed_bytes: usize,
     limit_triggered: bool,
+    more_available: bool,
 ) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
@@ -11129,6 +11246,7 @@ fn renderSearchResult(
         try writeToolMetadataJson(alloc, &out.writer, tool, description_limit);
     }
     try out.writer.print("],\"count\":{d}", .{selected_count});
+    if (more_available) try out.writer.writeAll(",\"more_available\":true");
     if (limit_triggered) {
         try out.writer.print(
             ",\"context_limit\":{{\"name\":\"mcp_search_result_bytes\",\"action\":\"omitted\",\"omitted_count\":{d},\"observed_bytes\":{d},\"effective_bytes\":{d},\"source\":",
@@ -16937,6 +17055,89 @@ test "MCP health snapshot cleans up every partial allocation" {
     );
 }
 
+test "model catalog reports deferred ask servers without connecting and counts only visible tools" {
+    const alloc = std.testing.allocator;
+    var runtime = McpRuntime.init(alloc);
+    defer runtime.deinit();
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "required"),
+        .transport = .http,
+        .url = try alloc.dupe(u8, "https://required.example/mcp"),
+        .required = true,
+    });
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "optional"),
+        .transport = .http,
+        .url = try alloc.dupe(u8, "https://optional.example/mcp"),
+    });
+    runtime.discovery_state.store(.complete, .seq_cst);
+    runtime.servers.items[0].state = .ready;
+
+    var used = std.StringHashMap(void).init(alloc);
+    defer used.deinit();
+    const response =
+        \\{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"one","inputSchema":{"type":"object"}},{"name":"two","inputSchema":{"type":"object"}}]}}
+    ;
+    try parseAndStoreTools(alloc, &runtime.servers.items[0], .{}, response, &used);
+
+    var denied_rules = [_]types.PermissionRule{.{
+        .permission = @constCast("mcp_required_two"),
+        .pattern = @constCast("*"),
+        .action = .deny,
+    }};
+    var before = try runtime.snapshotModelCatalog(
+        alloc,
+        .{ .rules = &denied_rules },
+        true,
+    );
+    defer before.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 2), before.servers.len);
+    try std.testing.expectEqual(model_catalog.Availability.ready, before.servers[0].availability);
+    try std.testing.expectEqual(@as(?usize, 1), before.servers[0].tool_count);
+    try std.testing.expectEqual(model_catalog.Availability.available_on_demand, before.servers[1].availability);
+    try std.testing.expectEqual(@as(?usize, null), before.servers[1].tool_count);
+    try std.testing.expectEqual(ServerState.disconnected, runtime.servers.items[1].state);
+    try std.testing.expectEqual(DiscoveryState.idle, runtime.deferred_discovery_state.load(.acquire));
+
+    runtime.servers.items[1].state = .ready;
+    try parseAndStoreTools(alloc, &runtime.servers.items[1], .{}, response, &used);
+    runtime.deferred_discovery_state.store(.complete, .release);
+    var after = try runtime.snapshotModelCatalog(alloc, .{}, true);
+    defer after.deinit(alloc);
+
+    try std.testing.expectEqual(model_catalog.Availability.ready, after.servers[1].availability);
+    try std.testing.expectEqual(@as(?usize, 2), after.servers[1].tool_count);
+}
+
+fn checkModelCatalogSnapshotAllocationFailures(alloc: Allocator) !void {
+    var runtime = McpRuntime.init(std.testing.allocator);
+    defer runtime.deinit();
+    try runtime.addServer(.{
+        .name = try std.testing.allocator.dupe(u8, "one"),
+        .command = try std.testing.allocator.dupe(u8, "fixture"),
+        .enabled = false,
+    });
+    try runtime.addServer(.{
+        .name = try std.testing.allocator.dupe(u8, "two"),
+        .command = try std.testing.allocator.dupe(u8, "fixture"),
+        .enabled = false,
+    });
+    runtime.discovery_state.store(.complete, .release);
+    for (runtime.servers.items) |*server| server.state = .disabled;
+
+    var snapshot = try runtime.snapshotModelCatalog(alloc, .{}, false);
+    snapshot.deinit(alloc);
+}
+
+test "model catalog snapshot cleans up every partial allocation" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        checkModelCatalogSnapshotAllocationFailures,
+        .{},
+    );
+}
+
 fn checkHealthSnapshotAllocationFailures(alloc: Allocator) !void {
     var runtime = McpRuntime.init(std.testing.allocator);
     defer runtime.deinit();
@@ -17400,6 +17601,53 @@ test "MCP search returns metadata without advertising every executable schema" {
     try std.testing.expect(std.mem.find(u8, results.model_output, "inputSchema") == null);
     try std.testing.expect(std.mem.find(u8, results.model_output, "Repository name") == null);
     try std.testing.expect(std.mem.find(u8, results.model_output, "server_instructions") == null);
+}
+
+test "MCP search reports an authorized match beyond the count cap" {
+    const alloc = std.testing.allocator;
+    var runtime = McpRuntime.init(alloc);
+    defer runtime.deinit();
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "chrome"),
+        .command = try alloc.dupe(u8, "fixture"),
+    });
+    runtime.discovery_state.store(.complete, .seq_cst);
+    runtime.servers.items[0].state = .ready;
+
+    var response: std.Io.Writer.Allocating = .init(alloc);
+    defer response.deinit();
+    try response.writer.writeAll("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[");
+    for (0..21) |index| {
+        if (index > 0) try response.writer.writeByte(',');
+        try response.writer.print(
+            "{{\"name\":\"item{d:0>2}\",\"description\":\"Chrome item {d}\",\"inputSchema\":{{\"type\":\"object\"}}}}",
+            .{ index, index },
+        );
+    }
+    try response.writer.writeAll("]}}");
+
+    var used = std.StringHashMap(void).init(alloc);
+    defer used.deinit();
+    try parseAndStoreTools(
+        alloc,
+        &runtime.servers.items[0],
+        .{},
+        response.written(),
+        &used,
+    );
+
+    var broad = try runtime.searchTools(alloc, "chrome", 20, .{}, .{}, .unrestricted);
+    defer broad.deinit(alloc);
+    var broad_json = try std.json.parseFromSlice(std.json.Value, alloc, broad.model_output, .{});
+    defer broad_json.deinit();
+    try std.testing.expectEqual(@as(i64, 20), broad_json.value.object.get("count").?.integer);
+    try std.testing.expect(broad_json.value.object.get("more_available").?.bool);
+
+    var targeted = try runtime.searchTools(alloc, "item00", 20, .{}, .{}, .unrestricted);
+    defer targeted.deinit(alloc);
+    var targeted_json = try std.json.parseFromSlice(std.json.Value, alloc, targeted.model_output, .{});
+    defer targeted_json.deinit();
+    try std.testing.expect(targeted_json.value.object.get("more_available") == null);
 }
 
 test "scoped MCP cached tool and feature operations reject authority revoked after admission" {

--- a/src/core/mcp/model_catalog.zig
+++ b/src/core/mcp/model_catalog.zig
@@ -1,0 +1,311 @@
+const std = @import("std");
+const health = @import("health.zig");
+const model_context_encoding = @import("../shared/model_context_encoding.zig");
+const sort_utils = @import("../shared/sort_utils.zig");
+
+const Allocator = std.mem.Allocator;
+
+const max_prompt_bytes: usize = 4 * 1024;
+const header =
+    "Configured MCP servers visible to this model turn are listed below.\n" ++
+    "Use mcp_search_tools with the server alias and requested use case. Then use mcp_select_tool with one exact result. Do not guess tool names.\n" ++
+    "<mcp_servers>\n";
+const footer = "</mcp_servers>\n";
+const empty_entry = "  <none />\n";
+
+pub const Availability = enum {
+    ready,
+    discovering,
+    available_on_demand,
+    authentication_required,
+    disabled,
+    failed,
+    unavailable,
+};
+
+pub const ServerSummary = struct {
+    name: []u8,
+    availability: Availability,
+    tool_count: ?usize = null,
+};
+
+pub const Snapshot = struct {
+    servers: []ServerSummary,
+
+    /// Returns an owned empty snapshot. The caller releases it with `deinit`.
+    pub fn empty(alloc: Allocator) !Snapshot {
+        return .{ .servers = try alloc.alloc(ServerSummary, 0) };
+    }
+
+    pub fn deinit(self: *Snapshot, alloc: Allocator) void {
+        for (self.servers) |server| alloc.free(server.name);
+        alloc.free(self.servers);
+        self.* = undefined;
+    }
+};
+
+pub const PromptSection = struct {
+    text: []u8,
+    notice: ?[]u8 = null,
+
+    pub fn deinit(self: *PromptSection, alloc: Allocator) void {
+        alloc.free(self.text);
+        if (self.notice) |notice| alloc.free(notice);
+        self.* = undefined;
+    }
+};
+
+pub fn classifyAvailability(
+    connection: health.ConnectionState,
+    authentication: health.AuthenticationState,
+    deferred_for_ask: bool,
+) Availability {
+    if (authentication == .required) return .authentication_required;
+    return switch (connection) {
+        .disabled => .disabled,
+        .connecting => .discovering,
+        .ready => .ready,
+        .failed => .failed,
+        .disconnected => if (deferred_for_ask) .available_on_demand else .unavailable,
+    };
+}
+
+/// Returns an owned prompt section. The caller releases it with `deinit` unless
+/// both values are intentionally retained by the supplied request arena.
+pub fn render(alloc: Allocator, snapshot: Snapshot) Allocator.Error!PromptSection {
+    return renderWithLimit(alloc, snapshot, max_prompt_bytes);
+}
+
+fn renderWithLimit(alloc: Allocator, snapshot: Snapshot, limit: usize) Allocator.Error!PromptSection {
+    if (snapshot.servers.len == 0) {
+        if (!partsFit(limit, &.{ header, empty_entry, footer })) {
+            return .{ .text = try alloc.dupe(u8, "") };
+        }
+        return .{ .text = try std.mem.concat(alloc, u8, &.{ header, empty_entry, footer }) };
+    }
+
+    const sorted = try alloc.alloc(*const ServerSummary, snapshot.servers.len);
+    defer alloc.free(sorted);
+    for (snapshot.servers, 0..) |*server, index| sorted[index] = server;
+    sort_utils.sort(*const ServerSummary, sorted, {}, lessServerSummary);
+
+    const entries = try alloc.alloc([]u8, sorted.len);
+    var initialized: usize = 0;
+    defer {
+        for (entries[0..initialized]) |entry| alloc.free(entry);
+        alloc.free(entries);
+    }
+    for (sorted, 0..) |server, index| {
+        entries[index] = try renderEntry(alloc, server.*);
+        initialized += 1;
+    }
+
+    if (entriesFit(limit, entries, null)) {
+        return .{ .text = try joinEntries(alloc, entries, null) };
+    }
+
+    var retained_count: usize = 0;
+    for (0..entries.len + 1) |candidate_count| {
+        const marker = try truncationMarker(alloc, entries.len - candidate_count);
+        defer alloc.free(marker);
+        if (!entriesFit(limit, entries[0..candidate_count], marker)) break;
+        retained_count = candidate_count;
+    }
+    const omitted_count = entries.len - retained_count;
+    const marker = try truncationMarker(alloc, omitted_count);
+    defer alloc.free(marker);
+    const text = if (entriesFit(limit, entries[0..retained_count], marker))
+        try joinEntries(alloc, entries[0..retained_count], marker)
+    else
+        try alloc.dupe(u8, "");
+    errdefer alloc.free(text);
+    return .{
+        .text = text,
+        .notice = try std.fmt.allocPrint(
+            alloc,
+            "[context] omitted {d} MCP server{s} from the model catalog because the fixed {d}-byte budget was reached",
+            .{ omitted_count, if (omitted_count == 1) "" else "s", limit },
+        ),
+    };
+}
+
+fn lessServerSummary(_: void, lhs: *const ServerSummary, rhs: *const ServerSummary) bool {
+    return std.mem.lessThan(u8, lhs.name, rhs.name);
+}
+
+fn renderEntry(alloc: Allocator, server: ServerSummary) Allocator.Error![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    out.writer.writeAll("  <server name=\"") catch return error.OutOfMemory;
+    model_context_encoding.writeScalar(&out.writer, server.name) catch return error.OutOfMemory;
+    out.writer.print("\" state=\"{s}\"", .{@tagName(server.availability)}) catch return error.OutOfMemory;
+    if (server.tool_count) |count| {
+        out.writer.print(" tools=\"{d}\"", .{count}) catch return error.OutOfMemory;
+    }
+    out.writer.writeAll(" />\n") catch return error.OutOfMemory;
+    return out.toOwnedSlice() catch return error.OutOfMemory;
+}
+
+fn truncationMarker(alloc: Allocator, omitted_count: usize) ![]u8 {
+    return std.fmt.allocPrint(
+        alloc,
+        "  <catalog_truncated omitted_count=\"{d}\" />\n",
+        .{omitted_count},
+    );
+}
+
+fn entriesFit(limit: usize, entries: []const []const u8, marker: ?[]const u8) bool {
+    var remaining = limit;
+    if (!consume(&remaining, header.len)) return false;
+    for (entries) |entry| {
+        if (!consume(&remaining, entry.len)) return false;
+    }
+    if (marker) |value| {
+        if (!consume(&remaining, value.len)) return false;
+    }
+    return consume(&remaining, footer.len);
+}
+
+fn partsFit(limit: usize, parts: []const []const u8) bool {
+    var remaining = limit;
+    for (parts) |part| {
+        if (!consume(&remaining, part.len)) return false;
+    }
+    return true;
+}
+
+fn consume(remaining: *usize, bytes: usize) bool {
+    if (bytes > remaining.*) return false;
+    remaining.* -= bytes;
+    return true;
+}
+
+fn joinEntries(alloc: Allocator, entries: []const []const u8, marker: ?[]const u8) Allocator.Error![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    out.writer.writeAll(header) catch return error.OutOfMemory;
+    for (entries) |entry| out.writer.writeAll(entry) catch return error.OutOfMemory;
+    if (marker) |value| out.writer.writeAll(value) catch return error.OutOfMemory;
+    out.writer.writeAll(footer) catch return error.OutOfMemory;
+    return out.toOwnedSlice() catch return error.OutOfMemory;
+}
+
+fn ownedSnapshot(
+    alloc: Allocator,
+    inputs: []const struct {
+        name: []const u8,
+        availability: Availability,
+        tool_count: ?usize = null,
+    },
+) !Snapshot {
+    const servers = try alloc.alloc(ServerSummary, inputs.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (servers[0..initialized]) |server| alloc.free(server.name);
+        alloc.free(servers);
+    }
+    for (inputs, 0..) |input, index| {
+        servers[index] = .{
+            .name = try alloc.dupe(u8, input.name),
+            .availability = input.availability,
+            .tool_count = input.tool_count,
+        };
+        initialized += 1;
+    }
+    return .{ .servers = servers };
+}
+
+test "availability follows canonical connection authentication and deferred state" {
+    const Case = struct {
+        connection: health.ConnectionState,
+        authentication: health.AuthenticationState = .none,
+        deferred_for_ask: bool = false,
+        expected: Availability,
+    };
+    const cases = [_]Case{
+        .{ .connection = .ready, .expected = .ready },
+        .{ .connection = .connecting, .expected = .discovering },
+        .{ .connection = .disconnected, .deferred_for_ask = true, .expected = .available_on_demand },
+        .{ .connection = .failed, .authentication = .required, .expected = .authentication_required },
+        .{ .connection = .disabled, .expected = .disabled },
+        .{ .connection = .failed, .expected = .failed },
+        .{ .connection = .disconnected, .expected = .unavailable },
+    };
+    for (cases) |case| {
+        try std.testing.expectEqual(
+            case.expected,
+            classifyAvailability(case.connection, case.authentication, case.deferred_for_ask),
+        );
+    }
+}
+
+test "render exposes sorted server summaries without tool metadata" {
+    const alloc = std.testing.allocator;
+    var snapshot = try ownedSnapshot(alloc, &.{
+        .{ .name = "zeta", .availability = .authentication_required },
+        .{ .name = "alpha", .availability = .ready, .tool_count = 2 },
+    });
+    defer snapshot.deinit(alloc);
+
+    var section = try render(alloc, snapshot);
+    defer section.deinit(alloc);
+
+    try std.testing.expectEqualStrings(
+        "Configured MCP servers visible to this model turn are listed below.\n" ++
+            "Use mcp_search_tools with the server alias and requested use case. Then use mcp_select_tool with one exact result. Do not guess tool names.\n" ++
+            "<mcp_servers>\n" ++
+            "  <server name=\"alpha\" state=\"ready\" tools=\"2\" />\n" ++
+            "  <server name=\"zeta\" state=\"authentication_required\" />\n" ++
+            "</mcp_servers>\n",
+        section.text,
+    );
+    try std.testing.expectEqual(@as(?[]u8, null), section.notice);
+}
+
+test "render encodes names and bounds omissions without revealing omitted aliases" {
+    const alloc = std.testing.allocator;
+    var snapshot = try ownedSnapshot(alloc, &.{
+        .{ .name = "alpha", .availability = .ready, .tool_count = 1 },
+        .{ .name = "bravo", .availability = .ready, .tool_count = 2 },
+        .{ .name = "hidden<&\"", .availability = .failed },
+    });
+    defer snapshot.deinit(alloc);
+
+    var section = try renderWithLimit(alloc, snapshot, 280);
+    defer section.deinit(alloc);
+
+    try std.testing.expect(section.text.len <= 280);
+    try std.testing.expect(section.notice != null);
+    try std.testing.expect(std.mem.find(u8, section.notice.?, "omitted 3 MCP servers") != null);
+    try std.testing.expect(std.mem.find(u8, section.notice.?, "hidden") == null);
+    try std.testing.expect(std.mem.find(u8, section.text, "hidden<&\"") == null);
+}
+
+test "render explicitly reports an empty catalog" {
+    const alloc = std.testing.allocator;
+    var snapshot = try ownedSnapshot(alloc, &.{});
+    defer snapshot.deinit(alloc);
+
+    var section = try render(alloc, snapshot);
+    defer section.deinit(alloc);
+
+    try std.testing.expect(std.mem.find(u8, section.text, "<none />") != null);
+    try std.testing.expectEqual(@as(?[]u8, null), section.notice);
+}
+
+fn checkRenderAllocationFailures(alloc: Allocator) !void {
+    var servers = [_]ServerSummary{
+        .{ .name = @constCast("alpha"), .availability = .ready, .tool_count = 2 },
+        .{ .name = @constCast("beta"), .availability = .failed },
+    };
+    var section = try render(alloc, .{ .servers = &servers });
+    section.deinit(alloc);
+}
+
+test "render cleans up every partial allocation" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        checkRenderAllocationFailures,
+        .{},
+    );
+}

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -11,6 +11,7 @@ const tool_result_errors = @import("../tooling/tool_result_errors.zig");
 const tool_runtime = @import("../tooling/tool_runtime.zig");
 const tool_mcp_runtime = @import("../tooling/tool_mcp_runtime.zig");
 const mcp_access = @import("../mcp/access_policy.zig");
+const model_catalog = @import("../mcp/model_catalog.zig");
 const context_contract = @import("../workspace/context_contract.zig");
 const hooks = @import("../hooks/hooks.zig");
 const execution_memory = @import("../agent/execution_memory.zig");
@@ -309,6 +310,74 @@ fn appendStaticContext(raw: *anyopaque, arena: Allocator, messages: *std.ArrayLi
     try context.config.context_registry.appendDefaultStatic(.{
         .project_context = context.config.project_context,
     }, arena, messages);
+    var snapshot = try snapshotModelCatalogForView(
+        arena,
+        if (context.admission.mcp_view) |*view| view else null,
+    );
+    defer snapshot.deinit(arena);
+    const section = try model_catalog.render(arena, snapshot);
+    if (section.text.len > 0) {
+        try messages.append(arena, .{ .role = .system, .content = section.text });
+    }
+    if (section.notice) |notice| try pushLiveNotice(raw, notice);
+}
+
+fn snapshotModelCatalogForView(
+    alloc: Allocator,
+    maybe_view: ?*const mcp_access.View,
+) !model_catalog.Snapshot {
+    const view = maybe_view orelse return model_catalog.Snapshot.empty(alloc);
+    const servers = try alloc.alloc(model_catalog.ServerSummary, view.servers.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (servers[0..initialized]) |server| alloc.free(server.name);
+        alloc.free(servers);
+    }
+    for (view.servers, 0..) |server, index| {
+        var tool_count: usize = 0;
+        for (view.tools) |tool| {
+            if (std.mem.eql(u8, tool.server_name, server.name)) tool_count += 1;
+        }
+        servers[index] = .{
+            .name = try alloc.dupe(u8, server.name),
+            .availability = .ready,
+            .tool_count = tool_count,
+        };
+        initialized += 1;
+    }
+    return .{ .servers = servers };
+}
+
+test "subagent model catalog counts only tools in the captured MCP view" {
+    const alloc = std.testing.allocator;
+    var servers = [_]mcp_access.ServerIdentity{.{
+        .name = @constCast("chrome-devtools"),
+        .source = .profile,
+        .scope = .profile,
+        .connection_generation = 1,
+        .catalog_generation = 2,
+        .auth_generation = 3,
+    }};
+    var tools = [_]mcp_access.ToolIdentity{
+        .{ .name = @constCast("mcp_chrome_one"), .server_name = @constCast("chrome-devtools") },
+        .{ .name = @constCast("mcp_chrome_two"), .server_name = @constCast("chrome-devtools") },
+    };
+    const view = mcp_access.View{
+        .runtime_generation = 1,
+        .owner_id = @constCast("child"),
+        .parent_id = @constCast("parent"),
+        .features_visible = false,
+        .servers = &servers,
+        .tools = &tools,
+    };
+
+    var snapshot = try snapshotModelCatalogForView(alloc, &view);
+    defer snapshot.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), snapshot.servers.len);
+    try std.testing.expectEqualStrings("chrome-devtools", snapshot.servers[0].name);
+    try std.testing.expectEqual(model_catalog.Availability.ready, snapshot.servers[0].availability);
+    try std.testing.expectEqual(@as(?usize, 2), snapshot.servers[0].tool_count);
 }
 
 fn validateToolCall(raw: *anyopaque, arena: Allocator, call: types.ToolCall) !agent_runtime.ToolCallValidationResult {

--- a/src/core/workspace/context_contract.zig
+++ b/src/core/workspace/context_contract.zig
@@ -545,28 +545,28 @@ pub fn writeEntrypointLayoutSnapshot(writer: *std.Io.Writer) !void {
         \\model_visible_layout:
         \\- entrypoint: interactive
         \\  static_context_refresh: one applicable snapshot before enqueue; scoped deltas attach before affected tool execution
-        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, optional_prepared_parent_turn_delivery_context
+        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, mcp_server_catalog, optional_prepared_parent_turn_delivery_context
         \\  stable_prefix_later_additions: applicable_project_context_deltas committed mid-turn when a tool batch has applicable targets
         \\  per_step_overlay_order: explicit_skill_chunks, transient_runtime_context
         \\  user_prompt_position: after stable system context and history
         \\  intentional_difference: live terminal approvals and clarification UI
         \\- entrypoint: fx ask
         \\  static_context_refresh: one applicable snapshot before the prompt; scoped deltas attach before affected tool execution
-        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, optional_prepared_parent_turn_delivery_context
+        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, mcp_server_catalog, optional_prepared_parent_turn_delivery_context
         \\  stable_prefix_later_additions: applicable_project_context_deltas committed mid-turn when a tool batch has applicable targets
         \\  per_step_overlay_order: explicit_skill_chunks, transient_runtime_context
         \\  user_prompt_position: after stable system context and empty or saved history
         \\  intentional_difference: approval-required actions become noninteractive blockers
         \\- entrypoint: ACP
         \\  static_context_refresh: one applicable snapshot per ACP prompt including accepted local resource targets; scoped deltas attach before affected tool execution
-        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, optional_prepared_parent_turn_delivery_context
+        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, mcp_server_catalog, optional_prepared_parent_turn_delivery_context
         \\  stable_prefix_later_additions: applicable_project_context_deltas committed mid-turn when a tool batch has applicable targets
         \\  per_step_overlay_order: explicit_skill_chunks, transient_runtime_context
         \\  user_prompt_position: after stable system context and ACP session history
         \\  intentional_difference: ACP protocol maps prompts, refusals, and updates to JSON-RPC session messages
         \\- entrypoint: subagent
         \\  static_context_refresh: the launching surface's snapshot with empty child delivery state; scoped deltas attach before affected tool execution
-        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, optional_prepared_parent_turn_delivery_context
+        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, mcp_server_catalog, optional_prepared_parent_turn_delivery_context
         \\  stable_prefix_later_additions: applicable_project_context_deltas committed mid-turn when a tool batch has applicable targets
         \\  per_step_overlay_order: explicit_skill_chunks, transient_runtime_context
         \\  user_prompt_position: after stable system context and canonical child session history
@@ -703,28 +703,28 @@ test "entrypoint model-visible layout snapshot covers major entrypoints" {
         \\model_visible_layout:
         \\- entrypoint: interactive
         \\  static_context_refresh: one applicable snapshot before enqueue; scoped deltas attach before affected tool execution
-        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, optional_prepared_parent_turn_delivery_context
+        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, mcp_server_catalog, optional_prepared_parent_turn_delivery_context
         \\  stable_prefix_later_additions: applicable_project_context_deltas committed mid-turn when a tool batch has applicable targets
         \\  per_step_overlay_order: explicit_skill_chunks, transient_runtime_context
         \\  user_prompt_position: after stable system context and history
         \\  intentional_difference: live terminal approvals and clarification UI
         \\- entrypoint: fx ask
         \\  static_context_refresh: one applicable snapshot before the prompt; scoped deltas attach before affected tool execution
-        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, optional_prepared_parent_turn_delivery_context
+        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, mcp_server_catalog, optional_prepared_parent_turn_delivery_context
         \\  stable_prefix_later_additions: applicable_project_context_deltas committed mid-turn when a tool batch has applicable targets
         \\  per_step_overlay_order: explicit_skill_chunks, transient_runtime_context
         \\  user_prompt_position: after stable system context and empty or saved history
         \\  intentional_difference: approval-required actions become noninteractive blockers
         \\- entrypoint: ACP
         \\  static_context_refresh: one applicable snapshot per ACP prompt including accepted local resource targets; scoped deltas attach before affected tool execution
-        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, optional_prepared_parent_turn_delivery_context
+        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, mcp_server_catalog, optional_prepared_parent_turn_delivery_context
         \\  stable_prefix_later_additions: applicable_project_context_deltas committed mid-turn when a tool batch has applicable targets
         \\  per_step_overlay_order: explicit_skill_chunks, transient_runtime_context
         \\  user_prompt_position: after stable system context and ACP session history
         \\  intentional_difference: ACP protocol maps prompts, refusals, and updates to JSON-RPC session messages
         \\- entrypoint: subagent
         \\  static_context_refresh: the launching surface's snapshot with empty child delivery state; scoped deltas attach before affected tool execution
-        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, optional_prepared_parent_turn_delivery_context
+        \\  stable_prefix_initial_order: system_prompt, effective_custom_tool_guidance, visible_skills, optional_model_prompt_overlay, optional_interruption_or_resume_intent_context, shared_project_context, mcp_server_catalog, optional_prepared_parent_turn_delivery_context
         \\  stable_prefix_later_additions: applicable_project_context_deltas committed mid-turn when a tool batch has applicable targets
         \\  per_step_overlay_order: explicit_skill_chunks, transient_runtime_context
         \\  user_prompt_position: after stable system context and canonical child session history

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,6 +66,7 @@ const display_width = @import("core/shared/display_width.zig");
 const file_index_mod = @import("core/workspace/file_index.zig");
 const mcp_command_provider = @import("core/mcp/command_provider.zig");
 const mcp_runtime_mod = @import("core/mcp/mcp_runtime.zig");
+const mcp_model_catalog = @import("core/mcp/model_catalog.zig");
 const mcp_access_policy = @import("core/mcp/access_policy.zig");
 const app_mcp_runtime = @import("core/app/app_mcp_runtime.zig");
 const skill_commands = @import("core/skills/skill_commands.zig");
@@ -1350,6 +1351,19 @@ const App = struct {
 
     pub fn acquireMcpRuntime(self: *App) ?app_mcp_runtime.Lease {
         return self.mcp.acquire();
+    }
+
+    pub fn snapshotMcpModelCatalog(
+        self: *App,
+        alloc: Allocator,
+        permission_rules: types.PermissionRuleSet,
+        include_ask_deferred: bool,
+    ) !mcp_model_catalog.Snapshot {
+        return self.mcp.snapshotModelCatalog(
+            alloc,
+            permission_rules,
+            include_ask_deferred,
+        );
     }
 
     pub fn waitForRequiredMcp(

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -1808,6 +1808,14 @@ describe("acp: model-independent", () => {
           `${MODERN_HTTP_TOOL_RESULT}:acp`,
         );
 
+        const initialPrompt = acpGatewayRequest(gateway.requests[0]!.body).prompt
+          .map((message) => acpContentText(message.content))
+          .join("\n");
+        expect(initialPrompt).toContain(
+          '<server name="fixture" state="ready" tools="1" />',
+        );
+        expect(gateway.requests[0]!.body).not.toContain(MCP_TOOL_NAME);
+
         expect(httpFixture.requests.map((entry) => entry.message.method))
           .toEqual(["server/discover", "tools/list", "tools/call"]);
         for (const entry of httpFixture.requests) {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -427,7 +427,11 @@ function occurrenceCount(text: string, needle: string): number {
   return text.split(needle).length - 1;
 }
 
-function writeMcpFixture(root: FixtureRoot) {
+function writeMcpFixture(
+  root: FixtureRoot,
+  options: { required?: boolean; toolCount?: number } = {},
+) {
+  const toolCount = options.toolCount ?? 1;
   const scriptPath = join(root.root, "mcp-fixture.js");
   const callLogPath = join(root.root, "mcp-calls.log");
   const pidPath = join(root.root, "mcp.pid");
@@ -466,19 +470,27 @@ function handle(message) {
     return;
   }
   if (message.method === "tools/list") {
+    const tools = Array.from({ length: ${toolCount} }, (_, index) => index === 0 ? {
+      name: "echo",
+      description: "Echo fixture input",
+      inputSchema: {
+        type: "object",
+        properties: { text: { type: "string", description: "EXACT_SCHEMA_QUERY_SENTINEL" } },
+        required: ["text"],
+      },
+    } : {
+      name: "network_tool_" + String(index).padStart(2, "0"),
+      description: "Inspect browser network use case " + index,
+      inputSchema: {
+        type: "object",
+        properties: { request: { type: "string" } },
+      },
+    });
     send({
       jsonrpc: "2.0",
       id: message.id,
       result: {
-        tools: [{
-          name: "echo",
-          description: "Echo fixture input",
-          inputSchema: {
-            type: "object",
-            properties: { text: { type: "string", description: "EXACT_SCHEMA_QUERY_SENTINEL" } },
-            required: ["text"],
-          },
-        }],
+        tools,
       },
     });
     writeFileSync(process.env.FX_MCP_READY_PATH, "ready\\n");
@@ -515,6 +527,7 @@ process.stdin.on("data", (chunk) => {
           type: "local",
           command: [process.execPath, scriptPath],
           enabled: true,
+          required: options.required ?? false,
           environment: {
             FX_MCP_CALL_LOG: callLogPath,
             FX_MCP_PID_PATH: pidPath,
@@ -3342,21 +3355,35 @@ describe("gateway stream lifecycle", () => {
   test("dynamic MCP search stays metadata-only and exact selection reveals instructions and schema", async () => {
     const root = createFixtureRoot("mcp-lazy-context");
     const tracePath = join(root.root, "trace.log");
-    const mcp = writeMcpFixture(root);
-    const searchCallId = "mcp_search_lazy_1";
+    const mcp = writeMcpFixture(root, { toolCount: 30 });
+    const searchCallId = "mcp_search_targeted_1";
+    const broadSearchCallId = "mcp_search_broad_1";
     const selectCallId = "mcp_select_lazy_1";
     const responses = [
       fakeGatewayToolCall(searchCallId, "mcp_search_tools", {
-        query: "SECRET_SERVER_INSTRUCTION_SENTINEL",
+        query: "fixture echo",
+      }),
+      fakeGatewayToolCall(broadSearchCallId, "mcp_search_tools", {
+        query: "fixture",
+        limit: 20,
       }),
       fakeGatewayToolCall(selectCallId, "mcp_select_tool", {
         name: DYNAMIC_MCP_TOOL_NAME,
       }),
+      fakeGatewayToolCall("mcp_call_lazy_1", DYNAMIC_MCP_TOOL_NAME, {
+        text: "lazy MCP proof",
+      }),
       fakeGatewayFinalText("MCP lazy context complete."),
     ];
-    const gateway = startGateway(() =>
-      responses.shift() ?? new Response("unexpected request", { status: 500 })
-    );
+    let requestIndex = 0;
+    const gateway = startDynamicFakeGateway(() => {
+      if (requestIndex === 0) expect(existsSync(mcp.pidPath)).toBe(false);
+      requestIndex += 1;
+      return responses.shift() ?? new Response("unexpected request", { status: 500 });
+    }, {
+      classifierDecision: "allow",
+      models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+    });
     try {
       const result = await runFx(
         ["ask", "--json", "--auto", "--no-save", "Discover the MCP fixture lazily."],
@@ -3371,10 +3398,17 @@ describe("gateway stream lifecycle", () => {
 
       expect(result.code).toBe(0);
       expect(json.output).toContain("MCP lazy context complete.");
-      expect(gateway.requestCount()).toBe(3);
+      expect(gateway.requestCount()).toBe(5);
+      const initialPrompt = promptText(gateway.requests[0]!.body);
+      const initialServer = initialPrompt.match(
+        /<server name="fixture" state="available_on_demand"[^>]*\/>/,
+      )?.[0];
+      expect(initialServer).toBeDefined();
+      expect(initialServer).not.toContain("tools=");
       expect(gateway.requests[0]!.body).not.toContain(DYNAMIC_MCP_TOOL_NAME);
       expect(gateway.requests[0]!.body).not.toContain("SECRET_SERVER_INSTRUCTION_SENTINEL");
       expect(gateway.requests[0]!.body).not.toContain("EXACT_SCHEMA_QUERY_SENTINEL");
+      expect(existsSync(mcp.readyPath)).toBe(true);
 
       const searchOutput = toolResultOutput(gateway.requests[1]!.body, searchCallId);
       const searchTools = JSON.stringify(JSON.parse(searchOutput).tools);
@@ -3383,7 +3417,13 @@ describe("gateway stream lifecycle", () => {
       expect(searchTools).not.toContain("SECRET_SERVER_INSTRUCTION_SENTINEL");
       expect(searchTools).not.toContain("EXACT_SCHEMA_QUERY_SENTINEL");
 
-      const selectedRequest = gatewayRequest(gateway.requests[2]!.body);
+      const broadSearchOutput = JSON.parse(
+        toolResultOutput(gateway.requests[2]!.body, broadSearchCallId),
+      );
+      expect(broadSearchOutput.count).toBe(20);
+      expect(broadSearchOutput.more_available).toBe(true);
+
+      const selectedRequest = gatewayRequest(gateway.requests[3]!.body);
       const selectedTool = selectedRequest.tools.find((tool) =>
         tool.name === DYNAMIC_MCP_TOOL_NAME
       );
@@ -3391,9 +3431,44 @@ describe("gateway stream lifecycle", () => {
       expect(selectedTool?.inputSchema.properties.text.description).toBe(
         "EXACT_SCHEMA_QUERY_SENTINEL",
       );
-      expect(gateway.requests[2]!.body).toContain(
+      expect(gateway.requests[3]!.body).toContain(
         "SECRET_SERVER_INSTRUCTION_SENTINEL",
       );
+      expect(toolResultOutput(gateway.requests[4]!.body, "mcp_call_lazy_1")).toContain(
+        "unexpected MCP call",
+      );
+      expect(readFileSync(mcp.callLogPath, "utf8").trim().split("\n")).toHaveLength(1);
+      await waitForProcessExit(pid);
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
+  test("required MCP server advertises only its ready count before lazy search", async () => {
+    const root = createFixtureRoot("mcp-ready-server-summary");
+    const tracePath = join(root.root, "trace.log");
+    const mcp = writeMcpFixture(root, { required: true, toolCount: 30 });
+    const gateway = startGateway(() => fakeGatewayFinalText("MCP ready summary complete."));
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Inspect configured MCP availability."],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          timeoutMs: 20_000,
+        },
+      );
+      const pid = Number.parseInt(readFileSync(mcp.pidPath, "utf8"), 10);
+      const initialPrompt = promptText(gateway.requests[0]!.body);
+
+      expect(result.code).toBe(0);
+      expect(initialPrompt).toContain(
+        '<server name="fixture" state="ready" tools="30" />',
+      );
+      expect(gateway.requests[0]!.body).not.toContain(DYNAMIC_MCP_TOOL_NAME);
+      expect(gateway.requests[0]!.body).not.toContain("SECRET_SERVER_INSTRUCTION_SENTINEL");
+      expect(gateway.requests[0]!.body).not.toContain("EXACT_SCHEMA_QUERY_SENTINEL");
       await waitForProcessExit(pid);
     } finally {
       gateway.stop();
@@ -3446,6 +3521,10 @@ describe("gateway stream lifecycle", () => {
         return parentCompletion;
       }
       if (body.includes(childPrompt)) {
+        expect(promptText(body)).toContain(
+          '<server name="fixture" state="ready" tools="1" />',
+        );
+        expect(body).not.toContain(DYNAMIC_MCP_TOOL_NAME);
         return fakeGatewayToolCall("child_mcp_select_1", "mcp_select_tool", {
           name: DYNAMIC_MCP_TOOL_NAME,
         });


### PR DESCRIPTION
## Summary

- Show each model turn the configured MCP server aliases, availability, and visible tool counts without loading tool metadata or schemas.
- Keep optional `fx ask` servers dormant until MCP search and report when capped searches have more matches.
- Restrict ACP and subagent summaries to their existing MCP authority and keep executable schemas behind exact tool selection.