### PR TITLE
Keep browser terminal input responsive during buffered streams

### DIFF
--- a/sdk/browser-test-terminal.html
+++ b/sdk/browser-test-terminal.html
@@ -5,14 +5,18 @@
   import { createFxTerminal, supportsJspi } from "./browser.js";
 
   const decoder = new TextDecoder();
+  const liveDraft = "INPUT_DURING_STREAM";
   let output = "";
+  let streamSourceClosed = false;
+  let streamChunkCount = 0;
   const dataListeners = new Set();
   const resizeListeners = new Set();
   const terminal = {
     cols: 80,
     rows: 24,
     write(value) {
-      output += typeof value === "string" ? value : decoder.decode(value, { stream: true });
+      const text = typeof value === "string" ? value : decoder.decode(value, { stream: true });
+      output += text;
     },
     drain() {},
     onData(callback) {
@@ -25,26 +29,91 @@
     },
   };
 
-  window.__fxBrowserTerminalTest = { state: "starting" };
+  const testState = window.__fxBrowserTerminalTest = { state: "starting", stage: "boot" };
   try {
     if (!supportsJspi()) throw new Error("JSPI unavailable");
-    const runtime = await createFxTerminal({
+    const encoded = new TextEncoder();
+    let runtime;
+    let inputTaskRan = false;
+    let inputTaskChunkCount;
+    let signalFetchStarted;
+    let releaseBufferedStream;
+    let finishBufferedStream;
+    const fetchStarted = new Promise((resolve) => { signalFetchStarted = resolve; });
+    const bufferedStreamReleased = new Promise((resolve) => { releaseBufferedStream = resolve; });
+    const bufferedStreamFinished = new Promise((resolve) => { finishBufferedStream = resolve; });
+    const mockFetch = async () => {
+      signalFetchStarted();
+      return new Response(new ReadableStream({
+        async pull(controller) {
+          await bufferedStreamReleased;
+          streamChunkCount += 1;
+          testState.chunks = streamChunkCount;
+          if (streamChunkCount === 1) {
+            controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"STREAM_STARTED"}\n'));
+            return;
+          }
+          if (streamChunkCount <= 128) {
+            controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"."}\n'));
+            return;
+          }
+          await bufferedStreamFinished;
+          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"STREAM_FINISHED"}\n'));
+          controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
+          controller.enqueue(encoded.encode("data: [DONE]\n"));
+          controller.close();
+          streamSourceClosed = true;
+        },
+      }), { status: 200, headers: { "content-type": "text/event-stream" } });
+    };
+    testState.stage = "creating-runtime";
+    runtime = await createFxTerminal({
       wasm: "../zig-out/bin/fx-term.wasm",
       terminal,
       env: { AI_GATEWAY_API_KEY: "browser-terminal-test-key" },
+      fetch: mockFetch,
     });
+    testState.stage = "waiting-interactive";
     await runtime.interactive;
-    const deadline = performance.now() + 5000;
+    testState.stage = "waiting-startup";
+    const deadline = performance.now() + 10000;
     while (!output.includes("Run /help for commands")) {
       if (performance.now() >= deadline) throw new Error("startup output missing");
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
+    testState.stage = "starting-stream";
+    runtime.write("stream please\r");
+    await fetchStarted;
+    testState.stage = "releasing-stream";
+    setTimeout(() => {
+      inputTaskRan = true;
+      inputTaskChunkCount = streamChunkCount;
+      runtime.write(liveDraft);
+    }, 0);
+    releaseBufferedStream();
+    testState.stage = "waiting-live-input";
+    while (!inputTaskRan || !output.includes(liveDraft)) {
+      if (streamSourceClosed) throw new Error("terminal rendered browser input only after the stream source closed");
+      if (performance.now() >= deadline) throw new Error("browser input did not render during the stream");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const inputTaskRanDuringStream = inputTaskChunkCount < 128;
+    const draftRenderedDuringStream = !streamSourceClosed;
+    finishBufferedStream();
+    testState.stage = "waiting-stream-finish";
+    while (!streamSourceClosed) {
+      if (performance.now() >= deadline) throw new Error("stream source did not finish");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    runtime.write("\x7f".repeat(liveDraft.length));
     runtime.write("/exit\r");
     const code = await runtime.exited;
     window.__fxBrowserTerminalTest = {
       state: "completed",
       code,
       output,
+      inputTaskRanDuringStream,
+      draftRenderedDuringStream,
       dataListeners: dataListeners.size,
       resizeListeners: resizeListeners.size,
     };

--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -4,6 +4,7 @@ const strictDecoder = new TextDecoder("utf-8", { fatal: true });
 const workspaceInfoLimit = 4 * 1024;
 const workspaceCommandLimit = 64 * 1024;
 const workspaceOutputLimit = 64 * 1024;
+const streamReadsPerTaskYield = 32;
 
 function validWorkspacePath(path) {
   if (typeof path !== "string" || !path.startsWith("/") || path.includes("\0")) return false;
@@ -205,6 +206,13 @@ function raceWithTimeout(promise, timeoutMs, timeoutValue) {
   });
 }
 
+function yieldToHostTask() {
+  if (typeof globalThis.setImmediate === "function") {
+    return new Promise((resolve) => globalThis.setImmediate(resolve));
+  }
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 function createRuntime(options) {
   const stdin = new ByteQueue();
   const streams = new Map();
@@ -356,6 +364,7 @@ function createRuntime(options) {
       pendingRead: null,
       readResult: null,
       readError: null,
+      readsSinceTaskYield: 0,
     };
     streams.set(handle, state);
     state.responseSettled = Promise.resolve().then(() => options.fetch(text(urlPtr, urlLen), {
@@ -390,6 +399,13 @@ function createRuntime(options) {
   function streamNext(handle, outPtr, outCap) {
     const state = streams.get(handle);
     if (!state) return -1;
+    const yieldAfterReadyResult = (result) => {
+      if (result <= 0) return result;
+      state.readsSinceTaskYield += 1;
+      if (state.readsSinceTaskYield < streamReadsPerTaskYield) return result;
+      state.readsSinceTaskYield = 0;
+      return yieldToHostTask().then(() => result);
+    };
     const copy = (chunk) => {
       const written = chunk.subarray(0, outCap);
       bytes(outPtr, written.length).set(written);
@@ -407,7 +423,7 @@ function createRuntime(options) {
       return copy(value);
     };
     const immediate = consume();
-    if (immediate !== null) return immediate;
+    if (immediate !== null) return yieldAfterReadyResult(immediate);
     if (!state.reader) return 0;
     if (!state.pendingRead) {
       state.pendingRead = state.reader.read().then((result) => {
@@ -421,7 +437,7 @@ function createRuntime(options) {
     return raceWithTimeout(state.pendingRead.then(() => true), 50, false).then((ready) => {
       if (!ready) return -3;
       const result = consume();
-      return result === null ? -3 : result;
+      return result === null ? -3 : yieldAfterReadyResult(result);
     });
   }
 

--- a/sdk/tests/test-core-browser.mjs
+++ b/sdk/tests/test-core-browser.mjs
@@ -121,7 +121,14 @@ async function waitFor(expression, sessionId, timeoutMs = 10000) {
     if (result.result.value) return result.result.value;
     await new Promise((resolveWait) => setTimeout(resolveWait, 25));
   }
-  throw new Error(`timed out waiting for ${expression}`);
+  let diagnostic;
+  try {
+    diagnostic = await command("Runtime.evaluate", {
+      expression: "window.__fxBrowserTerminalTest || null",
+      returnByValue: true,
+    }, sessionId);
+  } catch {}
+  throw new Error(`timed out waiting for ${expression}; last value=${JSON.stringify(diagnostic?.result?.value)}`);
 }
 async function runCase(name, query, verify) {
   const { targetId } = await command("Target.createTarget", { url: "about:blank" });
@@ -182,6 +189,8 @@ try {
     expect(result.state === "completed", result.error || `unexpected terminal state ${result.state}`);
     expect(result.code === 0, `unexpected terminal exit code ${result.code}`);
     expect(result.output.includes("Run /help for commands"), "browser terminal startup output missing");
+    expect(result.inputTaskRanDuringStream, "browser terminal input task was blocked until the buffered stream finished");
+    expect(result.draftRenderedDuringStream, "browser terminal input rendered only after the stream source closed");
     expect(result.dataListeners === 0, `browser terminal leaked ${result.dataListeners} data listener(s)`);
     expect(result.resizeListeners === 0, `browser terminal leaked ${result.resizeListeners} resize listener(s)`);
     console.log("browser terminal startup and shutdown passed");

--- a/sdk/tests/test-term.mjs
+++ b/sdk/tests/test-term.mjs
@@ -17,7 +17,9 @@ const output = [];
 const streamedDecoder = new TextDecoder();
 let streamedText = "";
 const liveDraft = "queued draft";
+const queuedAnswer = "§";
 let draftVisibleAt;
+let queuedVisibleAt;
 const originalSetTimeout = globalThis.setTimeout;
 let observeZeroTimeouts = false;
 let zeroTimeoutCount = 0;
@@ -37,6 +39,7 @@ const terminal = {
     output.push(chunk);
     streamedText += streamedDecoder.decode(chunk, { stream: true });
     if (draftVisibleAt === undefined && streamedText.includes(liveDraft)) draftVisibleAt = performance.now();
+    if (queuedVisibleAt === undefined && streamedText.includes("queued 1")) queuedVisibleAt = performance.now();
     process.stdout.write(chunk);
   },
   async drain() {
@@ -63,26 +66,42 @@ const encoded = new TextEncoder();
 let requestedModel;
 let streamStartedAt;
 let streamFinishedAt;
+let releaseFirstStream;
+const firstStreamRelease = new Promise((resolve) => {
+  releaseFirstStream = resolve;
+});
+let secondRequestAt;
+let secondRequestBody;
+let requestCount = 0;
 const mockFetch = async (_url, init) => {
   requestedModel = new Headers(init.headers).get("ai-language-model-id");
-  return new Response(new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n'));
-      streamStartedAt = performance.now();
-      let emitted = 0;
-      const interval = setInterval(() => {
-        emitted += 1;
-        if (emitted < 30) {
-          controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"."}\n'));
-          return;
-        }
-        clearInterval(interval);
-        streamFinishedAt = performance.now();
-        controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n'));
+  requestCount += 1;
+  if (requestCount === 2) {
+    secondRequestAt = performance.now();
+    secondRequestBody = JSON.parse(new TextDecoder().decode(init.body));
+    return new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoded.encode(`data: {"type":"text-delta","delta":"${queuedAnswer}"}\n`));
         controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
         controller.enqueue(encoded.encode("data: [DONE]\n"));
         controller.close();
+      },
+    }), { status: 200, headers: { "content-type": "text/event-stream" } });
+  }
+  return new Response(new ReadableStream({
+    async start(controller) {
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n'));
+      streamStartedAt = performance.now();
+      const interval = setInterval(() => {
+        controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"."}\n'));
       }, 20);
+      await firstStreamRelease;
+      clearInterval(interval);
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n'));
+      controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":2}}}\n'));
+      controller.enqueue(encoded.encode("data: [DONE]\n"));
+      controller.close();
+      streamFinishedAt = performance.now();
     },
   }), { status: 200, headers: { "content-type": "text/event-stream" } });
 };
@@ -127,13 +146,24 @@ while (draftVisibleAt === undefined) {
   if (performance.now() >= deadline) throw new Error("timed out waiting for live follow-up input");
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
+runtime.write("\r");
+while (queuedVisibleAt === undefined) {
+  if (streamFinishedAt !== undefined) throw new Error("terminal did not queue follow-up input while the response was active");
+  if (performance.now() >= deadline) throw new Error("timed out waiting for queued follow-up input");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
 observeZeroTimeouts = false;
+if (secondRequestAt !== undefined) throw new Error("queued follow-up started before the active response finished");
+releaseFirstStream();
 while (streamFinishedAt === undefined) {
   if (performance.now() >= deadline) throw new Error("timed out waiting for streamed fx-term response");
   await new Promise((resolve) => setTimeout(resolve, 10));
 }
-await new Promise((resolve) => setTimeout(resolve, 100));
-runtime.write("\x7f".repeat(liveDraft.length));
+const queuedDeadline = performance.now() + 5000;
+while (secondRequestAt === undefined || !streamedText.includes(queuedAnswer)) {
+  if (performance.now() >= queuedDeadline) throw new Error("timed out waiting for queued fx-term response");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
 runtime.write("/exit\r");
 const exitCode = await Promise.race([
   runtime.exited,
@@ -148,6 +178,14 @@ if (!text.includes("Run /help for commands")) throw new Error("shared Fx welcome
 if (requestedModel !== "sdk/term-model") throw new Error(`terminal prompt did not use the host-restored model: ${requestedModel}`);
 if (!(streamStartedAt < streamFinishedAt)) throw new Error("terminal fetch did not remain active for continuous streaming");
 if (!(draftVisibleAt < streamFinishedAt)) throw new Error("terminal rendered follow-up input only after continuous streaming finished");
+if (!(queuedVisibleAt < streamFinishedAt)) throw new Error("terminal queued follow-up input only after continuous streaming finished");
+if (!(secondRequestAt >= streamFinishedAt)) throw new Error("terminal started queued follow-up before continuous streaming finished");
+const queuedUser = secondRequestBody.prompt?.filter((message) => message.role === "user").at(-1);
+const queuedText = queuedUser?.content?.filter((part) => part.type === "text").map((part) => part.text);
+if (queuedText?.length !== 1 || queuedText[0] !== liveDraft) {
+  throw new Error(`queued follow-up request changed the submitted draft: ${JSON.stringify(queuedText)}`);
+}
+if (requestCount !== 2) throw new Error(`terminal sent ${requestCount} requests instead of the active and queued turns`);
 if (zeroTimeoutCount !== 0) throw new Error(`terminal allocated ${zeroTimeoutCount} zero-timeout poll timer(s)`);
 if (!events.some((event) => event.type === "config.restore" && event.configId === "model")) throw new Error("terminal model restore event was not emitted");
 if (!events.some((event) => event.type === "config.restore" && event.configId === "mode")) throw new Error("terminal mode restore event was not emitted");


### PR DESCRIPTION
## Summary

- Keep browser terminal input responsive while buffered Gateway chunks stream.
- Queue submitted follow-ups without starting them before the active stream completes.
- Preserve submitted prompt text in the next Gateway request.