### PR TITLE
Complete terminal signal delivery

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -174,10 +174,10 @@ const terminal_write_schema = gateway_schema.ObjectSchema{
 };
 
 const terminal_properties = [_]gateway_schema.Property{
-    .{ .name = "session_id", .json_type = .string, .description = "Required for session-targeted actions. Omit for start and list; owner-catalog authority is private." },
+    .{ .name = "session_id", .json_type = .string, .description = "Required for session-targeted actions. Set null for start and list; owner-catalog authority is private." },
     .{ .name = "cwd", .json_type = .string, .description = "Working directory for exec or start; defaults to the workspace." },
     .{ .name = "command", .json_type = .string, .max_length = terminal_contracts.max_command_bytes, .description = "Command for exec, or optional command for start; omit on start for an interactive shell." },
-    .{ .name = "profile", .json_type = .string, .enum_values = &.{ "clean", "user" }, .description = "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile." },
+    .{ .name = "profile", .json_type = .string, .enum_values = &.{ "clean", "user" }, .description = "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile." },
     .{ .name = "shell", .json_type = .object, .object_schema = &terminal_shell_schema },
     .{ .name = "backend", .json_type = .string, .enum_values = &.{ "native", "tmux" }, .description = "Start backend or optional list filter." },
     .{ .name = "return_when", .json_type = .object, .object_schema = &terminal_return_schema, .description = "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only." },
@@ -1336,8 +1336,12 @@ test "terminal tool schema exposes one nullable object backed by the terminal ac
         schemaProperty(input_schema, "wait_ceiling_ms").?.description,
     );
     try std.testing.expectEqualStrings(
-        "Required for session-targeted actions. Omit for start and list; owner-catalog authority is private.",
+        "Required for session-targeted actions. Set null for start and list; owner-catalog authority is private.",
         schemaProperty(input_schema, "session_id").?.description,
+    );
+    try std.testing.expectEqualStrings(
+        "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile.",
+        schemaProperty(input_schema, "profile").?.description,
     );
     try std.testing.expectEqualStrings(
         "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only. Set null when the selected action does not use this field.",

--- a/src/core/execution/process_tree.zig
+++ b/src/core/execution/process_tree.zig
@@ -33,6 +33,31 @@ const ProcessSnapshot = struct {
     parent_unique_id: ?u64 = null,
 };
 
+pub const DeliverySummary = struct {
+    delivered: usize = 0,
+    incomplete: bool = false,
+};
+
+const ProcessGroupState = union(enum) {
+    found: std.posix.pid_t,
+    vanished,
+    unavailable,
+};
+
+const SystemSignalEffects = struct {
+    fn capture(alloc: Allocator, pid: std.posix.pid_t) !ProcessSnapshot {
+        return captureSnapshot(alloc, pid);
+    }
+
+    fn processGroup(pid: std.posix.pid_t) ProcessGroupState {
+        return inspectProcessGroup(pid);
+    }
+
+    fn send(pid: std.posix.pid_t, signal: std.posix.SIG) std.posix.KillError!void {
+        return std.posix.kill(pid, signal);
+    }
+};
+
 /// Tracks a command root and descendants across new sessions or process
 /// groups. Identity checks guard both traversal and signaling against PID
 /// reuse.
@@ -157,7 +182,7 @@ pub const Tracker = struct {
     }
 
     pub fn signalAll(self: *Tracker, signal: std.posix.SIG) usize {
-        return self.signalProcesses(signal, null);
+        return self.signalProcessesChecked(signal, null).delivered;
     }
 
     pub fn signalOutsideProcessGroup(
@@ -165,42 +190,89 @@ pub const Tracker = struct {
         signal: std.posix.SIG,
         preserved_group: std.posix.pid_t,
     ) usize {
-        return self.signalProcesses(signal, preserved_group);
+        return self.signalProcessesChecked(signal, preserved_group).delivered;
     }
 
-    fn signalProcesses(
+    pub fn signalOutsideProcessGroupChecked(
+        self: *Tracker,
+        signal: std.posix.SIG,
+        preserved_group: std.posix.pid_t,
+    ) DeliverySummary {
+        return self.signalProcessesChecked(signal, preserved_group);
+    }
+
+    fn signalProcessesChecked(
         self: *Tracker,
         signal: std.posix.SIG,
         preserved_group: ?std.posix.pid_t,
-    ) usize {
-        var signaled: usize = 0;
+    ) DeliverySummary {
+        return self.signalProcessesWith(
+            signal,
+            preserved_group,
+            SystemSignalEffects,
+        );
+    }
+
+    fn signalProcessesWith(
+        self: *Tracker,
+        signal: std.posix.SIG,
+        preserved_group: ?std.posix.pid_t,
+        comptime Effects: type,
+    ) DeliverySummary {
+        var summary: DeliverySummary = .{};
         var index = self.processes.items.len;
         while (index > 0) {
             index -= 1;
-            const process = self.processes.items[index];
-            const actual = captureSnapshot(self.alloc, process.pid) catch continue;
-            if (!process.identity.eql(actual.identity)) continue;
-            if (!shouldSignalProcess(
-                processGroupId(process.pid),
+            self.signalTrackedProcessWith(
+                self.processes.items[index],
+                signal,
                 preserved_group,
-            )) continue;
-            std.posix.kill(process.pid, signal) catch |err| switch (err) {
-                error.ProcessNotFound => continue,
-                else => continue,
-            };
-            signaled += 1;
+                &summary,
+                Effects,
+            );
         }
         if (self.root) |root| {
-            const actual = captureSnapshot(self.alloc, root.pid) catch return signaled;
-            if (root.identity.eql(actual.identity) and shouldSignalProcess(
-                processGroupId(root.pid),
+            self.signalTrackedProcessWith(
+                root,
+                signal,
                 preserved_group,
-            )) {
-                std.posix.kill(root.pid, signal) catch return signaled;
-                signaled += 1;
-            }
+                &summary,
+                Effects,
+            );
         }
-        return signaled;
+        return summary;
+    }
+
+    fn signalTrackedProcessWith(
+        self: *Tracker,
+        process: TrackedProcess,
+        signal: std.posix.SIG,
+        preserved_group: ?std.posix.pid_t,
+        summary: *DeliverySummary,
+        comptime Effects: type,
+    ) void {
+        const actual = Effects.capture(self.alloc, process.pid) catch |err| {
+            if (err != error.ProcessNotFound) summary.incomplete = true;
+            return;
+        };
+        if (!process.identity.eql(actual.identity)) return;
+        const process_group = switch (Effects.processGroup(process.pid)) {
+            .found => |value| value,
+            .vanished => return,
+            .unavailable => {
+                summary.incomplete = true;
+                return;
+            },
+        };
+        if (!shouldSignalProcess(process_group, preserved_group)) return;
+        Effects.send(process.pid, signal) catch |err| switch (err) {
+            error.ProcessNotFound => return,
+            else => {
+                summary.incomplete = true;
+                return;
+            },
+        };
+        summary.delivered += 1;
     }
 
     pub fn anyAlive(self: *Tracker) bool {
@@ -234,10 +306,42 @@ pub const Tracker = struct {
     ) !void {
         if (comptime builtin.os.tag != .linux) return error.ProcessTreeUnsupported;
         if (!try self.parentIdentityMatches(parent)) return;
+        const task_path = try std.fmt.allocPrint(
+            self.alloc,
+            "/proc/{d}/task",
+            .{parent.pid},
+        );
+        defer self.alloc.free(task_path);
+        var task_dir = std.Io.Dir.openDirAbsolute(
+            io_mod.getIo(),
+            task_path,
+            .{ .iterate = true },
+        ) catch |err| switch (err) {
+            error.FileNotFound => return,
+            else => return err,
+        };
+        defer task_dir.close(io_mod.getIo());
+        var tasks = task_dir.iterate();
+        while (try tasks.next(io_mod.getIo())) |entry| {
+            const tid = std.fmt.parseInt(
+                std.posix.pid_t,
+                entry.name,
+                10,
+            ) catch continue;
+            if (tid <= 0) continue;
+            try self.appendLinuxTaskChildren(parent, tid);
+        }
+    }
+
+    fn appendLinuxTaskChildren(
+        self: *Tracker,
+        parent: TrackedProcess,
+        tid: std.posix.pid_t,
+    ) !void {
         const path = try std.fmt.allocPrint(
             self.alloc,
             "/proc/{d}/task/{d}/children",
-            .{ parent.pid, parent.pid },
+            .{ parent.pid, tid },
         );
         defer self.alloc.free(path);
         var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{}) catch |err| switch (err) {
@@ -370,10 +474,16 @@ fn shouldSignalProcess(
     return actual != preserved;
 }
 
-fn processGroupId(pid: std.posix.pid_t) ?std.posix.pid_t {
-    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return null;
+fn inspectProcessGroup(pid: std.posix.pid_t) ProcessGroupState {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return .unavailable;
+    }
     const process_group = getpgid(pid);
-    return if (process_group >= 0) process_group else null;
+    if (process_group >= 0) return .{ .found = process_group };
+    return switch (std.c.errno(process_group)) {
+        .SRCH => .vanished,
+        else => .unavailable,
+    };
 }
 
 extern "c" fn getpgid(pid: std.posix.pid_t) std.posix.pid_t;
@@ -435,6 +545,99 @@ test "macOS lineage identity matches only the same unique process" {
         .{ .linux_start_ticks = 42 },
         42,
     ));
+}
+
+test "checked signal delivery distinguishes vanished stale and failed targets" {
+    const FakeEffects = struct {
+        fn capture(_: Allocator, pid: std.posix.pid_t) !ProcessSnapshot {
+            return switch (pid) {
+                11 => error.ProcessNotFound,
+                12 => error.ProcessIdentityUnavailable,
+                13 => .{
+                    .identity = .{ .linux_start_ticks = 113 },
+                    .parent_pid = 1,
+                },
+                else => .{
+                    .identity = .{ .linux_start_ticks = @intCast(pid) },
+                    .parent_pid = 1,
+                },
+            };
+        }
+
+        fn processGroup(pid: std.posix.pid_t) ProcessGroupState {
+            return switch (pid) {
+                14 => .vanished,
+                15 => .unavailable,
+                16 => .{ .found = 41 },
+                else => .{ .found = pid + 100 },
+            };
+        }
+
+        fn send(pid: std.posix.pid_t, _: std.posix.SIG) std.posix.KillError!void {
+            return switch (pid) {
+                17 => error.PermissionDenied,
+                18 => error.ProcessNotFound,
+                else => {},
+            };
+        }
+    };
+
+    var tracker = Tracker{ .alloc = std.testing.allocator };
+    defer tracker.deinit();
+    for (10..19) |pid| {
+        try tracker.processes.append(std.testing.allocator, .{
+            .pid = @intCast(pid),
+            .identity = .{ .linux_start_ticks = pid },
+        });
+    }
+
+    const summary = tracker.signalProcessesWith(
+        std.posix.SIG.TERM,
+        41,
+        FakeEffects,
+    );
+    try std.testing.expectEqual(@as(usize, 1), summary.delivered);
+    try std.testing.expect(summary.incomplete);
+}
+
+test "checked signal delivery keeps vanished stale and excluded targets complete" {
+    const FakeEffects = struct {
+        fn capture(_: Allocator, pid: std.posix.pid_t) !ProcessSnapshot {
+            if (pid == 21) return error.ProcessNotFound;
+            return .{
+                .identity = .{ .linux_start_ticks = if (pid == 22) 122 else @as(u64, @intCast(pid)) },
+                .parent_pid = 1,
+            };
+        }
+
+        fn processGroup(pid: std.posix.pid_t) ProcessGroupState {
+            return switch (pid) {
+                23 => .vanished,
+                else => .{ .found = 41 },
+            };
+        }
+
+        fn send(_: std.posix.pid_t, _: std.posix.SIG) std.posix.KillError!void {
+            return;
+        }
+    };
+
+    var tracker = Tracker{ .alloc = std.testing.allocator };
+    defer tracker.deinit();
+    for (21..25) |pid| {
+        try tracker.processes.append(std.testing.allocator, .{
+            .pid = @intCast(pid),
+            .identity = .{ .linux_start_ticks = pid },
+        });
+    }
+
+    const summary = tracker.signalProcessesWith(
+        std.posix.SIG.TERM,
+        41,
+        FakeEffects,
+    );
+    try std.testing.expectEqual(@as(usize, 0), summary.delivered);
+    try std.testing.expect(!summary.incomplete);
 }
 
 fn captureSnapshot(alloc: Allocator, pid: std.posix.pid_t) !ProcessSnapshot {

--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -4143,9 +4143,12 @@ const Session = struct {
     fn signalTerminalProcesses(
         self: *Session,
         signal: contracts.Signal,
-    ) !bool {
-        const target = self.signalTarget() orelse return false;
+    ) !?bool {
+        const target = self.signalTarget() orelse return null;
         if (!self.matchesSignalTarget(target)) return false;
+        if (failSignalStageForTest("refresh")) {
+            return error.ProcessIdentityUnavailable;
+        }
 
         var descendants = try process_tree.Tracker.init(self.alloc);
         defer descendants.deinit();
@@ -4155,16 +4158,22 @@ const Session = struct {
         };
         if (!self.matchesSignalTarget(target)) return false;
 
-        const delivered = descendants.signalOutsideProcessGroup(
+        var descendants_delivery = descendants.signalOutsideProcessGroupChecked(
             signalValue(signal),
             target.pid,
         );
+        if (failSignalStageForTest("outside_group")) {
+            descendants_delivery.incomplete = true;
+        }
         debug_trace.logf(
             "terminal_host",
-            "session signal reached outside-group descendants id={s} count={d}",
-            .{ self.id, delivered },
+            "session signal reached outside-group descendants id={s} count={d} incomplete={any}",
+            .{ self.id, descendants_delivery.delivered, descendants_delivery.incomplete },
         );
-        return self.signalProcess(signal);
+        return terminalSignalCompleted(
+            descendants_delivery,
+            !failSignalStageForTest("shell_group") and self.signalProcess(signal),
+        );
     }
 
     fn signalNative(self: *Session, signal: std.c.SIG) bool {
@@ -5489,7 +5498,7 @@ fn signalAction(
         request.authority.?,
         .signal,
     );
-    if (!try session.signalTerminalProcesses(request.signal)) {
+    if (!(try session.signalTerminalProcesses(request.signal) orelse false)) {
         return error.ProcessIdentityUnavailable;
     }
     session.mutex.lockUncancelable(zio);
@@ -5501,6 +5510,23 @@ fn signalAction(
             .signal = request.signal,
         } } },
     ) catch return error.OutOfMemory;
+}
+
+fn terminalSignalCompleted(
+    descendants: process_tree.DeliverySummary,
+    shell_group_delivered: bool,
+) bool {
+    return !descendants.incomplete and shell_group_delivered;
+}
+
+fn failSignalStageForTest(stage: []const u8) bool {
+    const requested = io_mod.getenv("FX_TERMINAL_TEST_FAIL_SIGNAL_STAGE") orelse
+        return false;
+    return std.mem.eql(u8, requested, stage);
+}
+
+fn forceCloseSignalIncomplete(tree_complete: ?bool) bool {
+    return tree_complete == null or !tree_complete.?;
 }
 
 fn closeAction(
@@ -5543,18 +5569,26 @@ fn closeAction(
     var still_live = session.lifecycle == .starting or
         session.lifecycle == .running;
     session.mutex.unlock(zio);
+    var force_signal_attempted = false;
+    var force_tree_complete: ?bool = null;
     if (still_live) {
-        const delivered = if (request.policy == .force)
-            session.signalTerminalProcesses(.kill) catch |err| blk: {
+        const delivered = if (request.policy == .force) blk: {
+            const tree_complete = session.signalTerminalProcesses(.kill) catch |err| {
+                force_signal_attempted = true;
                 debug_trace.logf(
                     "terminal_host",
                     "force close tree signal failed id={s} err={s}; falling back to shell group",
                     .{ session.id, @errorName(err) },
                 );
                 break :blk session.signalProcess(.kill);
+            };
+            if (tree_complete) |complete| {
+                force_signal_attempted = true;
+                force_tree_complete = complete;
+                break :blk complete;
             }
-        else
-            session.signalProcess(.terminate);
+            break :blk false;
+        } else session.signalProcess(.terminate);
         if (!delivered) session.markLost();
     }
     if (request.policy == .graceful and still_live) {
@@ -5595,6 +5629,16 @@ fn closeAction(
         try backend.cleanupChecked(session.durable.profile.process_provider);
     }
     try session.durable.finish_close(io_mod.milliTimestamp());
+    if (force_signal_attempted and forceCloseSignalIncomplete(force_tree_complete)) {
+        return contracts.OwnedResult.init(
+            session.alloc,
+            .{ .failure = .{
+                .action = .close,
+                .code = .session_lost,
+                .session_id = session.id,
+            } },
+        ) catch return error.OutOfMemory;
+    }
     var facts = session.durable.facts();
     facts.next_actions = .{};
     return contracts.OwnedResult.init(
@@ -6219,6 +6263,21 @@ test "terminal outcomes preserve exact exit and signal status" {
     );
     try std.testing.expect(signalFromInt(0) == null);
     try std.testing.expect(signalFromInt(256) == null);
+}
+
+test "terminal signal completion requires checked descendants and shell group" {
+    try std.testing.expect(terminalSignalCompleted(.{}, true));
+    try std.testing.expect(!terminalSignalCompleted(.{
+        .delivered = 1,
+        .incomplete = true,
+    }, true));
+    try std.testing.expect(!terminalSignalCompleted(.{}, false));
+}
+
+test "force close fallback does not erase an incomplete tree operation" {
+    try std.testing.expect(!forceCloseSignalIncomplete(true));
+    try std.testing.expect(forceCloseSignalIncomplete(false));
+    try std.testing.expect(forceCloseSignalIncomplete(null));
 }
 
 fn ignoreWorkUpdate(_: ?*anyopaque, _: bool) void {}

--- a/src/main.zig
+++ b/src/main.zig
@@ -3761,6 +3761,7 @@ test {
     _ = @import("core/permissions/permission_gate.zig");
     _ = @import("core/permissions/permissions.zig");
     _ = @import("core/background/process_supervisor.zig");
+    _ = @import("core/execution/process_tree.zig");
     _ = @import("core/config/prompt_policy.zig");
     _ = @import("core/workspace/record_tape.zig");
     _ = @import("core/session/session.zig");

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -155,9 +155,12 @@ describe("fx ask presentation", () => {
     } else {
       writeFileSync(
         join(root.home, ".bash_profile"),
-        "export FX_PROFILE_LOGIN=login\nexport FX_PROFILE_RC=rc\n" +
-          "export PATH=\"$HOME/profile-bin:$PATH\"\n" +
-          "alias fx_profile_alias='printf alias-user'\n" +
+        "export FX_PROFILE_LOGIN=login\nexport PATH=\"$HOME/profile-bin:$PATH\"\n" +
+          "source \"$HOME/.bashrc\"\n",
+      );
+      writeFileSync(
+        join(root.home, ".bashrc"),
+        "export FX_PROFILE_RC=rc\nalias fx_profile_alias='printf alias-user'\n" +
           "fx_profile_function() { printf function-user; }\n",
       );
     }
@@ -223,6 +226,12 @@ describe("fx ask presentation", () => {
     );
     expect(gateway.requests[0]!.body).toContain(
       "omission defaults to user, while clean skips user startup files",
+    );
+    expect(gateway.requests[0]!.body).toContain(
+      "User-profile execution supports the configured Bash or zsh login shell",
+    );
+    expect(gateway.requests[0]!.body).toContain(
+      ".bashrc is available only when sourced by the login profile",
     );
     expect(gateway.requests[0]!.body).not.toContain(
       "omission preserves legacy command behavior",

--- a/tests/e2e/terminal-host.test.ts
+++ b/tests/e2e/terminal-host.test.ts
@@ -81,6 +81,7 @@ const children: ChildProcessWithoutNullStreams[] = [];
 const hostPids: number[] = [];
 const fixtureArtifacts: string[] = [];
 let currentClientFixtureBinary: string | null = null;
+let currentThreadForkFixtureBinary: string | null = null;
 
 function loginShellProfile(): string | null {
   const shell = userInfo().shell;
@@ -476,6 +477,95 @@ function buildCurrentClientFixture(): string {
     { cwd: repoRoot, stdio: "pipe", timeout: 120_000 },
   );
   currentClientFixtureBinary = binary;
+  return binary;
+}
+
+function buildThreadForkFixture(): string {
+  if (currentThreadForkFixtureBinary !== null) {
+    return currentThreadForkFixtureBinary;
+  }
+  const repoRoot = join(import.meta.dir, "../..");
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "fx-terminal-thread-fork-"));
+  const source = join(fixtureRoot, "thread-fork.c");
+  const binary = join(fixtureRoot, "thread-fork");
+  fixtureArtifacts.push(fixtureRoot);
+  writeFileSync(
+    source,
+    String.raw`#define _GNU_SOURCE
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static const char *proof_path;
+static const char *term_path;
+
+static void on_term(int signal_number) {
+    (void)signal_number;
+    int fd = open(term_path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd >= 0) {
+        (void)write(fd, "term", 4);
+        (void)close(fd);
+    }
+    _exit(0);
+}
+
+static void *fork_child(void *unused) {
+    (void)unused;
+    int ready[2];
+    if (pipe(ready) != 0) _exit(69);
+    pid_t worker_tid = (pid_t)syscall(SYS_gettid);
+    pid_t child_pid = fork();
+    if (child_pid < 0) _exit(70);
+    if (child_pid == 0) {
+        close(ready[0]);
+        if (setpgid(0, 0) != 0) _exit(71);
+        struct sigaction action = {0};
+        action.sa_handler = on_term;
+        sigemptyset(&action.sa_mask);
+        if (sigaction(SIGTERM, &action, NULL) != 0) _exit(72);
+        (void)write(ready[1], "1", 1);
+        close(ready[1]);
+        for (;;) pause();
+    }
+
+    close(ready[1]);
+    char ready_byte = 0;
+    if (read(ready[0], &ready_byte, 1) != 1) _exit(74);
+    close(ready[0]);
+
+    int fd = open(proof_path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) _exit(73);
+    dprintf(fd, "%d %d %d\n", getpid(), worker_tid, child_pid);
+    close(fd);
+    (void)write(STDOUT_FILENO, "thread-fork-ready\n", 18);
+    int status = 0;
+    (void)waitpid(child_pid, &status, 0);
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3) return 64;
+    proof_path = argv[1];
+    term_path = argv[2];
+    pthread_t worker;
+    if (pthread_create(&worker, NULL, fork_child, NULL) != 0) return 65;
+    if (pthread_join(worker, NULL) != 0) return 66;
+    return 0;
+}
+`,
+  );
+  execFileSync(
+    "zig",
+    ["cc", "-O2", "-pthread", source, "-o", binary],
+    { cwd: repoRoot, stdio: "pipe", timeout: 120_000 },
+  );
+  currentThreadForkFixtureBinary = binary;
   return binary;
 }
 
@@ -7551,6 +7641,175 @@ test("writes resize waits cancellation signals and close remain session-scoped",
   expect(existsSync(paths.socket)).toBe(false);
 }, NATIVE_STARTUP_OBSERVATION_BUDGET_MS * 8 + 60_000);
 
+test.skipIf(process.platform !== "linux")(
+  "signal reaches a child forked by a non-leader thread",
+  async () => {
+    if (!existsSync("/bin/zsh")) return;
+    const home = makeHome();
+    const paths = hostPaths(home);
+    const proofPath = join(home, "thread-fork.proof");
+    const termPath = join(home, "thread-fork.term");
+    const fixture = buildThreadForkFixture();
+    const host = startHost(home, undefined, 200);
+    await waitFor(() => existsSync(paths.socket));
+    const control = await handshake(paths.socket, { minimum: 4, current: 5 });
+    let rootPid = 0;
+    let childPid = 0;
+
+    try {
+      const started = await startNativeCommandFixture(
+        control.client,
+        control.revision!,
+        312_900,
+        {
+          cwd: home,
+          command:
+            `exec ${JSON.stringify(fixture)} ${JSON.stringify(proofPath)} ` +
+            JSON.stringify(termPath),
+          shell: { executable: { path: "/bin/zsh", clean_start: true } },
+          returnWhen: { match: "thread-fork-ready" },
+        },
+      );
+      const sessionId = (started.session as { session_id: string }).session_id;
+      await waitFor(() => existsSync(proofPath));
+      const [rootText, workerText, childText] = readFileSync(proofPath, "utf8")
+        .trim()
+        .split(/\s+/);
+      rootPid = Number(rootText);
+      const workerTid = Number(workerText);
+      childPid = Number(childText);
+      const shellPid = Number(durableTerminalRecordFor(home, sessionId).pid);
+      expect(rootPid).toBe(shellPid);
+      expect(workerTid).toBeGreaterThan(0);
+      expect(workerTid).not.toBe(rootPid);
+      expect(childPid).toBeGreaterThan(0);
+      const workerChildren = readFileSync(
+        `/proc/${rootPid}/task/${workerTid}/children`,
+        "utf8",
+      ).trim().split(/\s+/).filter(Boolean).map(Number);
+      const leaderChildren = readFileSync(
+        `/proc/${rootPid}/task/${rootPid}/children`,
+        "utf8",
+      ).trim().split(/\s+/).filter(Boolean).map(Number);
+      expect(workerChildren).toContain(childPid);
+      expect(leaderChildren).not.toContain(childPid);
+      expect(processGroupId(childPid)).not.toBe(processGroupId(rootPid));
+
+      const signaled = await requestAction(
+        control.client,
+        control.revision!,
+        312_901,
+        "signal",
+        { session_id: sessionId, signal: "terminate" },
+      );
+      expect(success(signaled, "signal").signal).toBe("terminate");
+      await waitFor(
+        () => existsSync(termPath) && readFileSync(termPath, "utf8") === "term",
+        2_000,
+      );
+      await waitFor(() => !processExists(childPid), 5_000);
+      const waited = await requestAction(
+        control.client,
+        control.revision!,
+        312_902,
+        "wait",
+        {
+          session_id: sessionId,
+          return_when: { exit: {} },
+          safety_ceiling_ms: 5_000,
+        },
+      );
+      success(waited, "wait");
+      const closed = await requestAction(
+        control.client,
+        control.revision!,
+        312_903,
+        "close",
+        { session_id: sessionId, policy: "force" },
+      );
+      expect(success(closed, "close").session).toMatchObject({
+        lifecycle: "closed",
+      });
+    } finally {
+      for (const pid of [childPid, rootPid]) {
+        if (pid <= 0 || !processExists(pid)) continue;
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {}
+      }
+      control.client.close();
+      if (host.exitCode === null) await waitForExit(host);
+    }
+  },
+  NATIVE_STARTUP_OBSERVATION_BUDGET_MS * 3 + 30_000,
+);
+
+test("force close reports incomplete refresh descendant and shell delivery", async () => {
+  if (!existsSync("/bin/zsh")) return;
+  const stages = ["refresh", "outside_group", "shell_group"] as const;
+  for (const [index, stage] of stages.entries()) {
+    const home = makeHome();
+    const paths = hostPaths(home);
+    const host = startHost(home, undefined, 200, {
+      FX_TERMINAL_TEST_FAIL_SIGNAL_STAGE: stage,
+    });
+    await waitFor(() => existsSync(paths.socket));
+    const control = await handshake(paths.socket, { minimum: 4, current: 5 });
+    let shellPid = 0;
+
+    try {
+      const started = await startNativeCommandFixture(
+        control.client,
+        control.revision!,
+        312_910 + index * 10,
+        {
+          cwd: home,
+          command:
+            `printf 'force-close-${stage}-ready\\n'; ` +
+            "while :; do sleep 0.05; done",
+          shell: { executable: { path: "/bin/zsh", clean_start: true } },
+          returnWhen: { match: `force-close-${stage}-ready` },
+        },
+      );
+      const sessionId = (started.session as { session_id: string }).session_id;
+      shellPid = Number(durableTerminalRecordFor(home, sessionId).pid);
+      const closed = await requestAction(
+        control.client,
+        control.revision!,
+        312_911 + index * 10,
+        "close",
+        { session_id: sessionId, policy: "force" },
+      );
+      expect(failure(closed)).toMatchObject({
+        action: "close",
+        code: "session_lost",
+        session_id: sessionId,
+        retryable: false,
+      });
+      expect(durableTerminalRecordFor(home, sessionId)).toMatchObject({
+        authority_revoked: true,
+        lifecycle: "closed",
+      });
+      const inspect = await requestAction(
+        control.client,
+        control.revision!,
+        312_912 + index * 10,
+        "inspect",
+        { session_id: sessionId },
+      );
+      expect(failure(inspect).code).toBe("authority_denied");
+    } finally {
+      if (shellPid > 0 && processExists(shellPid)) {
+        try {
+          process.kill(shellPid, "SIGKILL");
+        } catch {}
+      }
+      control.client.close();
+      if (host.exitCode === null) await waitForExit(host);
+    }
+  }
+}, NATIVE_STARTUP_OBSERVATION_BUDGET_MS * 8 + 60_000);
+
 test("signal reaches a background job outside the shell process group", async () => {
   if (!existsSync("/bin/zsh")) return;
   const home = makeHome();
@@ -7879,13 +8138,14 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
-  "checked live tmux close retains cleanup intent until recovery retries",
+  "checked cleanup failure wins over incomplete delivery and retains recovery intent",
   async () => {
     if (!existsSync("/bin/zsh")) return;
     const home = makeHome();
     const paths = hostPaths(home);
     const firstHost = startHost(home, undefined, 30_000, {
       FX_TERMINAL_TEST_FAIL_TMUX_CLOSE_CLEANUP: "1",
+      FX_TERMINAL_TEST_FAIL_SIGNAL_STAGE: "outside_group",
     });
     const firstStdout = streamText(firstHost.stdout);
     const firstStderr = streamText(firstHost.stderr);


### PR DESCRIPTION
## Summary

- Discover terminal descendants forked by any Linux thread before signaling.
- Preserve best-effort process cleanup for sandbox callers while reporting incomplete terminal delivery.
- Return non-retryable `session_lost` when force-close cannot fully inspect or signal known terminal processes.
- Keep checked backend cleanup failures authoritative and recoverable.
- Tell terminal callers to set `session_id` to null for start and list, and document Bash/zsh profile behavior.