### PR TITLE
Handle SIGTERM during headless tool execution

### DIFF
--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -105,22 +105,38 @@ const supports_headless_interrupt = switch (std_builtin.os.tag) {
 
 const HeadlessInterruptInstallError = error{HeadlessInterruptBusy};
 const headless_interrupt_exit_code: u8 = 130;
+const headless_termination_exit_code: u8 = 143;
 
 const headless_interrupt = if (supports_headless_interrupt) struct {
     var coordinator_mutex: std.Io.Mutex = .init;
     var coordinator_active = false;
     var cancel_requested = std.atomic.Value(bool).init(false);
+    var requested_signal = std.atomic.Value(u8).init(0);
     var test_after_reset_before_install: if (std_builtin.is_test) ?*const fn () void else void =
         if (std_builtin.is_test) null else {};
     var test_after_restore: if (std_builtin.is_test) ?*const fn () void else void =
         if (std_builtin.is_test) null else {};
 
-    fn handle(_: std.posix.SIG) callconv(.c) void {
+    fn handle(signal: std.posix.SIG) callconv(.c) void {
+        _ = requested_signal.cmpxchgStrong(
+            0,
+            @intCast(@intFromEnum(signal)),
+            .seq_cst,
+            .seq_cst,
+        );
         cancel_requested.store(true, .seq_cst);
     }
 
+    fn exitCode() u8 {
+        return switch (@as(std.posix.SIG, @enumFromInt(requested_signal.load(.seq_cst)))) {
+            std.posix.SIG.TERM => headless_termination_exit_code,
+            else => headless_interrupt_exit_code,
+        };
+    }
+
     const Scope = struct {
-        old_action: std.posix.Sigaction = undefined,
+        old_sigint_action: std.posix.Sigaction = undefined,
+        old_sigterm_action: std.posix.Sigaction = undefined,
         installed: bool = false,
 
         fn install(enabled: bool) HeadlessInterruptInstallError!Scope {
@@ -135,11 +151,13 @@ const headless_interrupt = if (supports_headless_interrupt) struct {
                 .flags = 0,
             };
             var scope = Scope{};
+            requested_signal.store(0, .seq_cst);
             cancel_requested.store(false, .seq_cst);
             if (std_builtin.is_test) {
                 if (test_after_reset_before_install) |hook| hook();
             }
-            std.posix.sigaction(std.posix.SIG.INT, &action, &scope.old_action);
+            std.posix.sigaction(std.posix.SIG.INT, &action, &scope.old_sigint_action);
+            std.posix.sigaction(std.posix.SIG.TERM, &action, &scope.old_sigterm_action);
             coordinator_active = true;
             scope.installed = true;
             return scope;
@@ -150,12 +168,14 @@ const headless_interrupt = if (supports_headless_interrupt) struct {
             coordinator_mutex.lockUncancelable(io_mod.getIo());
             defer coordinator_mutex.unlock(io_mod.getIo());
             std.debug.assert(coordinator_active);
-            std.posix.sigaction(std.posix.SIG.INT, &self.old_action, null);
+            std.posix.sigaction(std.posix.SIG.INT, &self.old_sigint_action, null);
+            std.posix.sigaction(std.posix.SIG.TERM, &self.old_sigterm_action, null);
             if (std_builtin.is_test) {
                 if (test_after_restore) |hook| hook();
             }
             if (redeliver and cancel_requested.load(.seq_cst)) {
-                _ = std.c.raise(std.posix.SIG.INT);
+                const signal: std.posix.SIG = @enumFromInt(requested_signal.load(.seq_cst));
+                _ = std.c.raise(signal);
             }
             coordinator_active = false;
             self.installed = false;
@@ -174,6 +194,10 @@ const headless_interrupt = if (supports_headless_interrupt) struct {
         }
     };
 } else struct {
+    fn exitCode() u8 {
+        return headless_interrupt_exit_code;
+    }
+
     const Scope = struct {
         fn install(_: bool) HeadlessInterruptInstallError!Scope {
             return .{};
@@ -883,6 +907,7 @@ const AskContext = struct {
             .subagent_caller_id = if (self.writable) |*writable| writable.active_id else null,
             .auto_classifier = self.admissionAutoClassifier(),
             .worker = &self.worker,
+            .cancel_flag = self.cancelFlag(),
             .background = &self.background,
             .session = &self.session,
             .session_allocator = self.alloc,
@@ -1131,13 +1156,13 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
     };
     defer options.deinit(alloc);
 
-    if (interrupt_scope.requested()) return headless_interrupt_exit_code;
+    if (interrupt_scope.requested()) return headless_interrupt.exitCode();
     if (options.image_paths.items.len > 0) {
         const workspace_root = try io_mod.realpathAlloc(alloc, ".");
         defer alloc.free(workspace_root);
         if (!try preflightAskImages(alloc, workspace_root, &options, deps)) return 1;
     }
-    if (interrupt_scope.requested()) return headless_interrupt_exit_code;
+    if (interrupt_scope.requested()) return headless_interrupt.exitCode();
 
     var effective_cfg = cfg;
     if (options.system_prompt_override) |sp| {
@@ -1160,7 +1185,7 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
         .continue_recovery = options.continue_recovery,
         .deps = deps,
     }) catch |err| {
-        if (interrupt_scope.requested()) return headless_interrupt_exit_code;
+        if (interrupt_scope.requested()) return headless_interrupt.exitCode();
         if (err == error.OutOfMemory) return err;
         if (err == error.OneOffSessionNotResumable and !options.json_output) {
             try deps.write_stderr(
@@ -1178,18 +1203,18 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
     defer result.deinit(alloc);
 
     if (result.interrupted or interrupt_scope.requested()) {
-        return headless_interrupt_exit_code;
+        return headless_interrupt.exitCode();
     }
 
     if (options.json_output) {
         const json = try renderFinalJsonResult(alloc, result);
         defer alloc.free(json);
-        if (interrupt_scope.requested()) return headless_interrupt_exit_code;
+        if (interrupt_scope.requested()) return headless_interrupt.exitCode();
         try deps.write_stdout(deps.stdout_ctx, json);
     }
 
     return if (interrupt_scope.requested())
-        headless_interrupt_exit_code
+        headless_interrupt.exitCode()
     else
         result.exit_code;
 }

--- a/src/core/permissions/sandbox.zig
+++ b/src/core/permissions/sandbox.zig
@@ -470,12 +470,14 @@ fn exitForegroundSessionSupervisor(term: std.process.Child.Term) noreturn {
     switch (term) {
         .exited => |code| std.process.exit(code),
         .signal => |signal| {
-            const default_action: std.posix.Sigaction = .{
-                .handler = .{ .handler = std.posix.SIG.DFL },
-                .mask = std.posix.sigemptyset(),
-                .flags = 0,
-            };
-            std.posix.sigaction(signal, &default_action, null);
+            if (signal != std.posix.SIG.KILL and signal != std.posix.SIG.STOP) {
+                const default_action: std.posix.Sigaction = .{
+                    .handler = .{ .handler = std.posix.SIG.DFL },
+                    .mask = std.posix.sigemptyset(),
+                    .flags = 0,
+                };
+                std.posix.sigaction(signal, &default_action, null);
+            }
             var signal_mask = std.posix.sigemptyset();
             std.posix.sigaddset(&signal_mask, signal);
             std.posix.sigprocmask(std.posix.SIG.UNBLOCK, &signal_mask, null);

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2635,6 +2635,86 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test("SIGTERM drains an active headless terminal command without panic or survivors", async () => {
+    const root = createFixtureRoot("headless-sigterm");
+    const tracePath = join(root.root, "trace.log");
+    const pidPath = join(root.workspace, "active-command.pid");
+    const command = [
+      'trap "" TERM',
+      `printf "%s %s" "$$" "$PPID" > ${JSON.stringify(pidPath)}`,
+      "while :; do sleep 1; done",
+    ].join("; ");
+    const gateway = startGateway(() =>
+      fakeGatewayToolCall("headless_sigterm_1", "terminal", {
+        action: "exec",
+        command,
+      })
+    );
+    const proc = Bun.spawn([
+      FX_BIN,
+      "ask",
+      "--json",
+      "--yolo",
+      "--no-save",
+      "Run the active command fixture.",
+    ], {
+      cwd: root.workspace,
+      env: {
+        ...process.env,
+        ...fixtureEnv(root, gateway, tracePath),
+        FX_AUTO_UPGRADE: "0",
+      },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    let targetPid: number | null = null;
+    let helperPid: number | null = null;
+    try {
+      const startDeadline = Date.now() + 10_000;
+      while (!existsSync(pidPath)) {
+        if (Date.now() >= startDeadline) {
+          throw new Error("active terminal command did not start");
+        }
+        await Bun.sleep(10);
+      }
+      const pids = readFileSync(pidPath, "utf8").trim().split(/\s+/).map(Number);
+      expect(pids).toHaveLength(2);
+      [targetPid, helperPid] = pids;
+      expect(Number.isSafeInteger(targetPid) && targetPid > 0).toBe(true);
+      expect(Number.isSafeInteger(helperPid) && helperPid > 0).toBe(true);
+
+      const signalAt = Date.now();
+      proc.kill("SIGTERM");
+      const exitCode = await proc.exited;
+      const elapsedMs = Date.now() - signalAt;
+
+      await waitForProcessExit(targetPid, 3_000);
+      await waitForProcessExit(helperPid, 3_000);
+      const stderr = await new Response(proc.stderr).text();
+
+      expect(exitCode).toBe(143);
+      expect(proc.signalCode).toBe("SIGTERM");
+      expect(elapsedMs).toBeLessThan(3_000);
+      expect(stderr).not.toContain("panic: reached unreachable code");
+    } finally {
+      proc.kill("SIGKILL");
+      if (helperPid !== null && isProcessAlive(helperPid)) {
+        try {
+          process.kill(-helperPid, "SIGKILL");
+        } catch {}
+      }
+      if (targetPid !== null && isProcessAlive(targetPid)) {
+        try {
+          process.kill(targetPid, "SIGKILL");
+        } catch {}
+      }
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   test(
     "nine saved turns stay canonical while the next request uses bounded context",
     async () => {


### PR DESCRIPTION
## Summary

- Cancel and reap active headless terminal commands before fx exits on SIGTERM.
- Preserve SIGINT and SIGTERM process status after cleanup.
- Handle forced child termination without panicking.