### PR TITLE
Reject terminal payloads on lease transitions

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -189,8 +189,8 @@ const terminal_properties = [_]gateway_schema.Property{
     .{ .name = "after_event_id", .json_type = .integer },
     .{ .name = "acknowledge_event_id", .json_type = .integer, .minimum = 1 },
     .{ .name = "max_events", .json_type = .integer, .minimum = 1, .maximum = 256 },
-    .{ .name = "write", .json_type = .object, .object_schema = &terminal_write_schema },
-    .{ .name = "lease", .json_type = .string, .enum_values = &.{ "acquire", "use", "release", "revoke" } },
+    .{ .name = "write", .json_type = .object, .object_schema = &terminal_write_schema, .description = "Payload is valid only with lease=use. Set null for acquire, release, and revoke." },
+    .{ .name = "lease", .json_type = .string, .enum_values = &.{ "acquire", "use", "release", "revoke" }, .description = "Use lease=acquire without write, then send a second call with lease=use and the payload. Release and revoke also require write=null." },
     .{ .name = "monitor", .json_type = .object, .object_schema = &terminal_monitor_operation_schema },
     .{ .name = "task_id", .json_type = .string },
     .{ .name = "workspace_root", .json_type = .string },
@@ -1338,6 +1338,14 @@ test "terminal tool schema exposes one nullable object backed by the terminal ac
     try std.testing.expectEqualStrings(
         "Required for session-targeted actions. Set null for start and list; owner-catalog authority is private.",
         schemaProperty(input_schema, "session_id").?.description,
+    );
+    try std.testing.expectEqualStrings(
+        "Payload is valid only with lease=use. Set null for acquire, release, and revoke.",
+        schemaProperty(input_schema, "write").?.description,
+    );
+    try std.testing.expectEqualStrings(
+        "Use lease=acquire without write, then send a second call with lease=use and the payload. Release and revoke also require write=null.",
+        schemaProperty(input_schema, "lease").?.description,
     );
     try std.testing.expectEqualStrings(
         "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile.",

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -820,9 +820,8 @@ fn buildAuthorizedRequest(
         } },
         .write => .{ .write = .{
             .session_id = session_id,
-            .payload = if (input.lease == .use)
-                try buildWritePayload(arena, input.write orelse
-                    return error.InvalidWritePayload)
+            .payload = if (input.write) |write|
+                try buildWritePayload(arena, write)
             else
                 null,
             .lease = input.lease,
@@ -1757,6 +1756,7 @@ test "registered terminal validation enforces action-specific input before execu
         "{\"action\":\"read\",\"session_id\":\"terminal-a\",\"cursor_segment\":1}",
         "{\"action\":\"screen\",\"session_id\":\"terminal-a\"}",
         "{\"action\":\"write\",\"session_id\":\"terminal-a\",\"lease\":\"acquire\"}",
+        "{\"action\":\"write\",\"session_id\":\"terminal-a\",\"lease\":\"use\",\"write\":{\"kind\":\"text\",\"text\":\"input\\n\"}}",
         "{\"action\":\"wait\",\"session_id\":\"terminal-a\",\"return_when\":{\"kind\":\"exit\"},\"wait_ceiling_ms\":1000}",
         "{\"action\":\"monitor\",\"session_id\":\"terminal-a\",\"monitor\":{\"kind\":\"remove\",\"monitor_id\":\"monitor-a\"}}",
         "{\"action\":\"inspect\",\"session_id\":\"terminal-a\"}",
@@ -1775,6 +1775,32 @@ test "registered terminal validation enforces action-specific input before execu
             else => {},
         };
         try std.testing.expectEqual(.valid, accepted);
+    }
+
+    inline for (&.{
+        "{\"action\":\"write\",\"session_id\":\"terminal-a\",\"lease\":\"acquire\",\"write\":{\"kind\":\"text\",\"text\":\"input\\n\"}}",
+        "{\"action\":\"write\",\"session_id\":\"terminal-a\",\"lease\":\"release\",\"write\":{\"kind\":\"text\",\"text\":\"input\\n\"}}",
+        "{\"action\":\"write\",\"session_id\":\"terminal-a\",\"lease\":\"revoke\",\"write\":{\"kind\":\"text\",\"text\":\"input\\n\"}}",
+    }) |arguments_json| {
+        const rejected_lease_payload = try tool_dispatch.validateRegisteredToolCall(
+            ctx,
+            registry,
+            .{
+                .id = "terminal-invalid-lease-payload",
+                .name = "terminal",
+                .arguments_json = arguments_json,
+            },
+        );
+        defer switch (rejected_lease_payload) {
+            .failure => |reason| std.testing.allocator.free(reason),
+            else => {},
+        };
+        switch (rejected_lease_payload) {
+            .failure => |reason| try std.testing.expect(
+                std.mem.find(u8, reason, "InvalidWritePayload") != null,
+            ),
+            else => return error.TestUnexpectedResult,
+        }
     }
 
     const mixed = try tool_dispatch.validateRegisteredToolCall(ctx, registry, .{

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -1819,6 +1819,141 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "TUI terminal write lease payload contract rejects combined acquire and delivers after valid acquisition",
+  async () => {
+    const fixture = createFixture("fx-tui-terminal-lease-payload-");
+    const payload = "LEASE_PAYLOAD_INPUT\n";
+    let terminalSessionId = "";
+    const gateway = startFakeGateway([
+      fakeGatewayToolCall("tui_terminal_lease_start", "terminal", {
+        action: "start",
+        cwd: fixture.workspace,
+        command:
+          "printf 'TUI_PUBLIC_LEASE_PAYLOAD_READY\\n'; " +
+          "while IFS= read -r line; do " +
+          "printf 'TUI_PUBLIC_LEASE_PAYLOAD_ECHO:%s\\n' \"$line\"; done",
+        shell: {
+          kind: "executable",
+          path: TERMINAL_FIXTURE_SHELL,
+          clean_start: true,
+        },
+        backend: "native",
+        return_when: {
+          kind: "match",
+          pattern: "TUI_PUBLIC_LEASE_PAYLOAD_READY",
+        },
+        wait_ceiling_ms: 20_000,
+        dimensions: { rows: 24, columns: 80 },
+      }),
+      (body) => {
+        const result = JSON.parse(
+          toolResultText(body, "tui_terminal_lease_start"),
+        ) as {
+          success: { start: { session: { session_id: string } } };
+        };
+        terminalSessionId = result.success.start.session.session_id;
+        return fakeGatewayToolCall(
+          "tui_terminal_lease_invalid_acquire",
+          "terminal",
+          {
+            action: "write",
+            session_id: terminalSessionId,
+            lease: "acquire",
+            write: { kind: "text", text: payload },
+          },
+        );
+      },
+      (body) => {
+        expect(
+          toolResultText(body, "tui_terminal_lease_invalid_acquire"),
+        ).toContain("InvalidWritePayload");
+        return fakeGatewayToolCall(
+          "tui_terminal_lease_premature_use",
+          "terminal",
+          {
+            action: "write",
+            session_id: terminalSessionId,
+            lease: "use",
+            write: { kind: "text", text: payload },
+          },
+        );
+      },
+      (body) => {
+        expect(toolResultText(body, "tui_terminal_lease_premature_use"))
+          .toContain('"code":"lease_conflict"');
+        return fakeGatewayToolCall("tui_terminal_lease_read_before", "terminal", {
+          action: "read",
+          session_id: terminalSessionId,
+          cursor_segment: 1,
+          cursor_offset: 0,
+        });
+      },
+      (body) => {
+        const output = toolResultText(body, "tui_terminal_lease_read_before");
+        expect(output).toContain("TUI_PUBLIC_LEASE_PAYLOAD_READY");
+        expect(output).not.toContain("TUI_PUBLIC_LEASE_PAYLOAD_ECHO");
+        return fakeGatewayToolCall("tui_terminal_lease_acquire", "terminal", {
+          action: "write",
+          session_id: terminalSessionId,
+          lease: "acquire",
+        });
+      },
+      (body) => {
+        const acquired = toolResultText(body, "tui_terminal_lease_acquire");
+        expect(acquired).toContain('"write_lease":"agent"');
+        expect(acquired).toContain('"accepted_bytes":0');
+        return fakeGatewayToolCall("tui_terminal_lease_use", "terminal", {
+          action: "write",
+          session_id: terminalSessionId,
+          lease: "use",
+          write: { kind: "text", text: payload },
+        });
+      },
+      (body) => {
+        expect(toolResultText(body, "tui_terminal_lease_use"))
+          .toContain('"accepted_bytes":20');
+        return fakeGatewayToolCall("tui_terminal_lease_wait", "terminal", {
+          action: "wait",
+          session_id: terminalSessionId,
+          return_when: {
+            kind: "match",
+            pattern: "TUI_PUBLIC_LEASE_PAYLOAD_ECHO:LEASE_PAYLOAD_INPUT",
+          },
+          wait_ceiling_ms: 20_000,
+        });
+      },
+      (body) => {
+        expect(toolResultText(body, "tui_terminal_lease_wait"))
+          .toContain('"outcome":{"condition_met":{}}');
+        return fakeGatewayToolCall("tui_terminal_lease_close", "terminal", {
+          action: "close",
+          session_id: terminalSessionId,
+          close_policy: "force",
+        });
+      },
+      (body) => {
+        expect(toolResultText(body, "tui_terminal_lease_close"))
+          .toContain('"lifecycle":"closed"');
+        return fakeGatewayFinalText("TUI terminal lease payload complete");
+      },
+    ]);
+    gateways.push(gateway);
+    const active = await launch(fixture, gateway);
+
+    await active.sendText("Exercise terminal lease and payload validation.");
+    const pane = await active.waitForText(
+      "TUI terminal lease payload complete",
+      TIMEOUT,
+    );
+    expect(pane).toContain("Failed write");
+    expect(pane).toContain("Used terminal write");
+    expect(gateway.requests).toHaveLength(9);
+    expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
   "TUI public terminal controls reject encoded bytes and deliver key designators",
   async () => {
     const fixture = createFixture("fx-tui-terminal-public-controls-");


### PR DESCRIPTION
## Summary

- Reject payloads attached to terminal lease acquisition, release, or revocation before they can change session state.
- Keep acquire-then-use input delivery unchanged and document the two-call contract in the terminal schema.