### PR TITLE
Omit catalog maxOutputTokens when it copies the context window

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -304,6 +304,29 @@ test "agent request builder keeps default reasoning silent and emits output limi
     try std.testing.expect(std.mem.find(u8, body, "\"providerOptions\"") == null);
 }
 
+test "agent request builder omits output limit when catalog copies the context window" {
+    const messages = [_]shared_types.ChatMessage{.{ .role = .user, .content = "question" }};
+    const capabilities = model_capabilities.resolveCapabilities("meta/muse-spark-1.2-contributor", .{
+        .context_window = 1_048_576,
+        .max_output_tokens = 1_048_576,
+    });
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "meta/muse-spark-1.2-contributor",
+        .serialized_tools = "[]",
+        .messages = &messages,
+        .tool_choice = .auto,
+        .provider_options = model_capabilities.resolveProviderOptionsForCapabilities(
+            capabilities,
+            .auto,
+            false,
+        ),
+        .max_output_tokens = capabilities.max_output_tokens,
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"maxOutputTokens\"") == null);
+}
+
 test "agent request builder scopes the product user agent to GLM 5.2" {
     const alloc = std.testing.allocator;
     const messages = [_]shared_types.ChatMessage{.{ .role = .user, .content = "question" }};

--- a/src/core/config/model_capabilities.zig
+++ b/src/core/config/model_capabilities.zig
@@ -92,6 +92,18 @@ fn localCapabilitiesForModel(model: []const u8) Capabilities {
     return capabilities;
 }
 
+/// Catalog max_tokens is often a copy of the context window, not a real
+/// generation cap. Sending that value as maxOutputTokens is rejected by some
+/// providers, including Meta Muse Spark.
+pub fn usableMaxOutputTokens(context_window: ?u32, max_output_tokens: ?u32) ?u32 {
+    const tokens = max_output_tokens orelse return null;
+    if (tokens == 0) return null;
+    if (context_window) |window| {
+        if (window > 0 and tokens >= window) return null;
+    }
+    return tokens;
+}
+
 pub fn resolveCapabilities(model: []const u8, gateway_metadata: ?GatewayMetadata) Capabilities {
     var capabilities = localCapabilitiesForModel(model);
     if (gateway_metadata) |metadata| {
@@ -105,7 +117,10 @@ pub fn resolveCapabilities(model: []const u8, gateway_metadata: ?GatewayMetadata
         capabilities.supports_explicit_caching = metadata.supports_explicit_caching;
         capabilities.supports_implicit_caching = metadata.supports_implicit_caching;
         if (metadata.context_window) |window| capabilities.context_window = window;
-        if (metadata.max_output_tokens) |tokens| capabilities.max_output_tokens = tokens;
+        capabilities.max_output_tokens = usableMaxOutputTokens(
+            capabilities.context_window,
+            metadata.max_output_tokens,
+        );
     }
     return capabilities;
 }
@@ -250,6 +265,27 @@ test "resolveCapabilities preserves Gateway controls and unrelated local policy"
     try std.testing.expect(capabilities.prompt_caching);
     try std.testing.expectEqual(@as(?u32, 300_000), capabilities.context_window);
     try std.testing.expectEqual(@as(?u32, 32_000), capabilities.max_output_tokens);
+}
+
+test "resolveCapabilities omits catalog output limits that fill the context window" {
+    const muse = resolveCapabilities("meta/muse-spark-1.2-contributor", .{
+        .context_window = 1_048_576,
+        .max_output_tokens = 1_048_576,
+    });
+    try std.testing.expectEqual(@as(?u32, 1_048_576), muse.context_window);
+    try std.testing.expectEqual(@as(?u32, null), muse.max_output_tokens);
+
+    const over_window = resolveCapabilities("provider/model", .{
+        .context_window = 128_000,
+        .max_output_tokens = 256_000,
+    });
+    try std.testing.expectEqual(@as(?u32, null), over_window.max_output_tokens);
+
+    const real_cap = resolveCapabilities("provider/model", .{
+        .context_window = 256_000,
+        .max_output_tokens = 32_000,
+    });
+    try std.testing.expectEqual(@as(?u32, 32_000), real_cap.max_output_tokens);
 }
 
 test "reasoning effort picker helpers prepend default and preserve Gateway order" {

--- a/src/core/gateway/model_catalog_metadata.zig
+++ b/src/core/gateway/model_catalog_metadata.zig
@@ -19,7 +19,10 @@ pub fn fromCatalogEntry(entry: model_catalog.ModelCatalogEntry) model_capabiliti
         .supports_explicit_caching = entry.has_explicit_caching,
         .supports_implicit_caching = entry.has_implicit_caching,
         .context_window = optionalPositiveU32(entry.context_window),
-        .max_output_tokens = optionalPositiveU32(entry.max_tokens),
+        .max_output_tokens = model_capabilities.usableMaxOutputTokens(
+            optionalPositiveU32(entry.context_window),
+            optionalPositiveU32(entry.max_tokens),
+        ),
     };
 }
 
@@ -61,4 +64,23 @@ test "fromCatalogEntry preserves catalog capability metadata" {
     });
     try std.testing.expectEqual(@as(?u32, null), unknown_limits.context_window);
     try std.testing.expectEqual(@as(?u32, null), unknown_limits.max_output_tokens);
+}
+
+test "fromCatalogEntry keeps a real output cap and drops a full-window copy" {
+    const full_window = fromCatalogEntry(.{
+        .id = @constCast("meta/muse-spark-1.2-contributor"),
+        .model_type = @constCast("language"),
+        .context_window = 1_048_576,
+        .max_tokens = 1_048_576,
+    });
+    try std.testing.expectEqual(@as(?u32, 1_048_576), full_window.context_window);
+    try std.testing.expectEqual(@as(?u32, null), full_window.max_output_tokens);
+
+    const real_cap = fromCatalogEntry(.{
+        .id = @constCast("provider/model"),
+        .model_type = @constCast("language"),
+        .context_window = 256_000,
+        .max_tokens = 32_000,
+    });
+    try std.testing.expectEqual(@as(?u32, 32_000), real_cap.max_output_tokens);
 }


### PR DESCRIPTION
Fixes #106.

Interactive fx fails on `meta/muse-spark-1.2-contributor` with HTTP 400 `AI_APICallError: The request contains invalid parameters`. After the Gateway catalog loads, fx sends `maxOutputTokens: 1048576` because the catalog copies the 1M context window into `max_tokens`. Meta rejects that generation limit. Pi works on the same gateway because it does not send that field.

Treat a catalog output limit that is greater than or equal to the context window as unset, so Muse and similar models omit `maxOutputTokens` and keep using real caps such as 32k on a 256k window.

Required label: `type: bug`.