### PR TITLE
Add persistent Git workspace contract

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -73,6 +73,15 @@ The staging script includes `zig-out/lib/libfx.node` by default for local testin
 
 The npm `latest` dist-tag is the stable channel. The `dev` dist-tag tracks successful builds from `main` and uses immutable prerelease versions. Publishing runs through `.github/workflows/publish-libfx.yml` with npm trusted publishing and provenance. Configure the npm trusted publisher for the `vercel-labs/fx` repository, workflow filename `publish-libfx.yml`, and GitHub environment `npm`. Because npm requires a package to exist before trusted publishing can be configured, the first `libfx` version must be published once by a maintainer before enabling that relationship.
 
-JavaScript hosts can provide configuration, prompt history, session persistence, device login, URL opening, and a foreground workspace. The optional workspace adapter exposes only `terminal` with `{ action: "exec", command }`; command execution is delegated to the host in a clean, root-fixed environment.
+JavaScript hosts can provide configuration, prompt history, session persistence, device login, URL opening, and a foreground workspace. The optional workspace adapter exposes only `terminal` with `{ action: "exec", command }`; command execution is delegated to the host with the workspace's validated current directory.
+
+The workspace metadata contract has two exact versions:
+
+| Version | Git | Storage | Current directory |
+| --- | --- | --- | --- |
+| 1 | unavailable | ephemeral | must equal `root` |
+| 2 | available | persistent | `root` or a directory beneath it |
+
+Both versions require normalized absolute `root`, `cwd`, and `home` paths plus a permission of `allow-sandboxed` or `prompt`. Hosts own workspace provisioning, persistence, source synchronization, and cleanup; FX keeps provider lifecycle code and dependencies outside the SDK. Command execution remains bounded to 64 KiB of input and output, a 30-second maximum deadline, and host `AbortSignal` cancellation.
 
 WebAssembly builds do not include native processes, OS sandboxing, native MCP, subagents, skills, auto-upgrade, clipboard integration, arbitrary WASI filesystem access, or web search.

--- a/sdk/fx-sdk.js
+++ b/sdk/fx-sdk.js
@@ -14,25 +14,32 @@ function validWorkspacePath(path) {
   return path.slice(1).split("/").every((part) => part && part !== "." && part !== "..");
 }
 
+function workspacePathContains(root, path) {
+  return path === root || root === "/" || path.startsWith(`${root}/`);
+}
+
 function prepareWorkspaceAdapter(workspace) {
   if (workspace == null) return { present: false, valid: false };
   try {
     const info = workspace.info;
     const permission = workspace.permission;
-    if (!info || typeof workspace.exec !== "function" || info.version !== 1 ||
+    const validV1 = info?.version === 1 && info.cwd === info.root &&
+      info.gitAvailable === false && info.ephemeral === true;
+    const validV2 = info?.version === 2 && workspacePathContains(info.root, info.cwd) &&
+      info.gitAvailable === true && info.ephemeral === false;
+    if (!info || typeof workspace.exec !== "function" || (!validV1 && !validV2) ||
       !validWorkspacePath(info.root) || !validWorkspacePath(info.cwd) ||
-      !validWorkspacePath(info.home) || info.cwd !== info.root ||
-      info.gitAvailable !== false || info.ephemeral !== true ||
+      !validWorkspacePath(info.home) ||
       (permission !== "allow-sandboxed" && permission !== "prompt")) {
       return { present: true, valid: false };
     }
     const value = {
-      version: 1,
+      version: info.version,
       root: info.root,
       cwd: info.cwd,
       home: info.home,
-      git: false,
-      ephemeral: true,
+      git: info.gitAvailable,
+      ephemeral: info.ephemeral,
       permission,
     };
     const encoded = encoder.encode(JSON.stringify(value));

--- a/sdk/node/test-term-workspace.mjs
+++ b/sdk/node/test-term-workspace.mjs
@@ -23,22 +23,23 @@ const execCalls = [];
 let abortStarted = false;
 let abortObserved = false;
 let checkedToolProjection = false;
+let checkedWorkspaceContext = false;
 const truncatedOutput = `start\n${"🙂".repeat(17_000)}\nend\n`;
 const truncatedBytes = encoder.encode(truncatedOutput).length;
 
 const workspace = {
   info: {
-    version: 1,
+    version: 2,
     root: "/workspace",
-    cwd: "/workspace",
+    cwd: "/workspace/src",
     home: "/home/visitor",
-    gitAvailable: false,
-    ephemeral: true,
+    gitAvailable: true,
+    ephemeral: false,
   },
   permission: "allow-sandboxed",
   exec({ command, cwd, signal, timeoutMs, outputLimitBytes }) {
     execCalls.push(command);
-    if (cwd !== "/workspace" || timeoutMs !== 30_000 || outputLimitBytes !== 65_536) {
+    if (cwd !== "/workspace/src" || timeoutMs !== 30_000 || outputLimitBytes !== 65_536) {
       throw new Error(`unexpected workspace exec contract: cwd=${cwd} timeout=${timeoutMs} outputLimit=${outputLimitBytes}`);
     }
     if (command === "printf adapter-success") {
@@ -164,6 +165,19 @@ const fetch = async (_url, init = {}) => {
     }
     checkedToolProjection = true;
   }
+  if (!checkedWorkspaceContext) {
+    const prompt = JSON.stringify(body.prompt || []);
+    for (const expected of [
+      "workspace_root: /workspace",
+      "current_directory: /workspace/src",
+      "workspace_ephemeral: false",
+      "git_available: true",
+      "git_worktree: unknown",
+    ]) {
+      if (!prompt.includes(expected)) throw new Error(`workspace context omitted ${expected}: ${prompt}`);
+    }
+    checkedWorkspaceContext = true;
+  }
   if (toolResult(body, "workspace-success")) {
     requireResult(body, "workspace-success", ["adapter-success", "exit_code=0"]);
     return textResponse("success record checked");
@@ -258,7 +272,8 @@ const exitCode = await Promise.race([
 ]);
 if (exitCode !== 0) throw new Error(`fx-term exited with ${exitCode}`);
 if (!checkedToolProjection) throw new Error("workspace tool projection was not checked");
+if (!checkedWorkspaceContext) throw new Error("workspace metadata projection was not checked");
 if (execCalls.join(",") !== "printf adapter-success,generate-truncated-output,timeout-command,hold-command") {
   throw new Error(`unexpected workspace exec calls: ${execCalls.join(",")}`);
 }
-console.log("headless workspace passed: success, truncation, timeout, Ctrl-C abort, and strict invalid boundaries mapped through the host adapter");
+console.log("headless v2 workspace passed: nested cwd, persistent git metadata, success, truncation, timeout, Ctrl-C abort, and strict invalid boundaries mapped through the host adapter");

--- a/src/builtins/context.zig
+++ b/src/builtins/context.zig
@@ -2032,11 +2032,20 @@ fn buildTurnContextFragmentForHost(
     try model_context_encoding.writeScalar(&out.writer, workspace.cwd);
     try out.writer.print("\noperating_system: {s}\nshell_path: just-bash\ndate_utc: {s}\nhome_directory: ", .{ os_text, date_text });
     try model_context_encoding.writeScalar(&out.writer, workspace.home);
-    try out.writer.writeAll(
-        "\ngit_available: false\n" ++
-            "git_worktree: unavailable\n" ++
-            "</fx-turn-context>",
-    );
+    if (workspace.git_available and !workspace.ephemeral) {
+        try out.writer.writeAll(
+            "\nworkspace_ephemeral: false\n" ++
+                "git_available: true\n" ++
+                "git_worktree: unknown\n" ++
+                "</fx-turn-context>",
+        );
+    } else {
+        try out.writer.writeAll(
+            "\ngit_available: false\n" ++
+                "git_worktree: unavailable\n" ++
+                "</fx-turn-context>",
+        );
+    }
     return try out.toOwnedSlice();
 }
 
@@ -2721,15 +2730,39 @@ test "turn context uses explicit browser workspace and git unavailable state" {
             .root = "/workspace",
             .cwd = "/workspace/src",
             .home = "/home/visitor",
+            .git_available = false,
+            .ephemeral = true,
         },
     );
     try expectContains(fragment, "workspace_root: /workspace\n");
     try expectContains(fragment, "current_directory: /workspace/src\n");
     try expectContains(fragment, "shell_path: just-bash\n");
     try expectContains(fragment, "home_directory: /home/visitor\n");
+    try expectNotContains(fragment, "workspace_ephemeral:");
     try expectContains(fragment, "git_available: false\n");
     try expectContains(fragment, "git_worktree: unavailable\n");
     try expectNotContains(fragment, "/native/path");
+    try expectNotContains(fragment, "git_branch:");
+}
+
+test "turn context reports persistent host git without inventing repository state" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    const fragment = try buildTurnContextFragmentForHost(
+        arena_state.allocator(),
+        "/native/path",
+        context_contract.HostWorkspaceContext{
+            .root = "/workspace",
+            .cwd = "/workspace/src",
+            .home = "/home/visitor",
+            .git_available = true,
+            .ephemeral = false,
+        },
+    );
+    try expectContains(fragment, "workspace_ephemeral: false\n");
+    try expectContains(fragment, "git_available: true\n");
+    try expectContains(fragment, "git_worktree: unknown\n");
     try expectNotContains(fragment, "git_branch:");
 }
 

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -817,6 +817,8 @@ pub fn Runtime(comptime App: type) type {
                     .root = info.root(),
                     .cwd = info.cwd(),
                     .home = info.home(),
+                    .git_available = info.git_available,
+                    .ephemeral = info.ephemeral,
                 } else null,
                 .access_scope = if (host_workspace != null)
                     workspace_access.AccessScope.primaryOnly(workspace_root)

--- a/src/core/hosts/js_host_workspace.zig
+++ b/src/core/hosts/js_host_workspace.zig
@@ -104,6 +104,7 @@ const PathSpan = struct {
 
 pub const Info = struct {
     storage: [max_info_bytes]u8 = undefined,
+    version: u32,
     root_span: PathSpan,
     cwd_span: PathSpan,
     home_span: PathSpan,
@@ -181,11 +182,15 @@ pub fn Adapter(comptime Host: type) type {
             };
             defer parsed.deinit();
             const value = parsed.value;
-            if (value.version != 1 or value.git or !value.ephemeral) return error.InvalidContract;
             if (!validAbsolutePath(value.root) or
                 !validAbsolutePath(value.cwd) or
-                !validAbsolutePath(value.home) or
-                !std.mem.eql(u8, value.root, value.cwd)) return error.InvalidContract;
+                !validAbsolutePath(value.home)) return error.InvalidContract;
+            const valid_contract = switch (value.version) {
+                1 => !value.git and value.ephemeral and std.mem.eql(u8, value.root, value.cwd),
+                2 => value.git and !value.ephemeral and pathContains(value.root, value.cwd),
+                else => false,
+            };
+            if (!valid_contract) return error.InvalidContract;
             const permission: Permission = if (std.mem.eql(u8, value.permission, "allow-sandboxed"))
                 .allow_sandboxed
             else if (std.mem.eql(u8, value.permission, "prompt"))
@@ -194,11 +199,12 @@ pub fn Adapter(comptime Host: type) type {
                 return error.InvalidContract;
 
             var info = Info{
+                .version = value.version,
                 .root_span = undefined,
                 .cwd_span = undefined,
                 .home_span = undefined,
-                .git_available = false,
-                .ephemeral = true,
+                .git_available = value.git,
+                .ephemeral = value.ephemeral,
                 .permission = permission,
             };
             var offset: usize = 0;
@@ -358,6 +364,13 @@ fn validAbsolutePath(path: []const u8) bool {
     return true;
 }
 
+fn pathContains(root: []const u8, path: []const u8) bool {
+    if (std.mem.eql(u8, root, path) or std.mem.eql(u8, root, "/")) return true;
+    return path.len > root.len and
+        std.mem.startsWith(u8, path, root) and
+        path[root.len] == '/';
+}
+
 const valid_info_json =
     "{\"version\":1,\"root\":\"/workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":false,\"ephemeral\":true,\"permission\":\"allow-sandboxed\"}";
 
@@ -401,12 +414,28 @@ test "workspace info is unavailable when the host adapter is absent" {
 
 test "workspace info accepts the bounded v1 browser contract" {
     const info = try Adapter(FakeInfoHost).loadInfo(std.testing.allocator);
+    try std.testing.expectEqual(@as(u32, 1), info.version);
     try std.testing.expectEqualStrings("/workspace", info.root());
     try std.testing.expectEqualStrings("/workspace", info.cwd());
     try std.testing.expectEqualStrings("/home/visitor", info.home());
     try std.testing.expect(!info.git_available);
     try std.testing.expect(info.ephemeral);
     try std.testing.expectEqual(Permission.allow_sandboxed, info.permission);
+}
+
+test "workspace info accepts a persistent v2 git workspace with nested cwd" {
+    FakeInfoHost.info_json =
+        "{\"version\":2,\"root\":\"/workspace\",\"cwd\":\"/workspace/src\",\"home\":\"/home/visitor\",\"git\":true,\"ephemeral\":false,\"permission\":\"prompt\"}";
+    defer FakeInfoHost.info_json = valid_info_json;
+
+    const info = try Adapter(FakeInfoHost).loadInfo(std.testing.allocator);
+    try std.testing.expectEqual(@as(u32, 2), info.version);
+    try std.testing.expectEqualStrings("/workspace", info.root());
+    try std.testing.expectEqualStrings("/workspace/src", info.cwd());
+    try std.testing.expectEqualStrings("/home/visitor", info.home());
+    try std.testing.expect(info.git_available);
+    try std.testing.expect(!info.ephemeral);
+    try std.testing.expectEqual(Permission.prompt, info.permission);
 }
 
 test "workspace runtime keeps one validated metadata and executor snapshot" {
@@ -427,7 +456,7 @@ test "workspace info rejects invalid host contracts and stable error codes" {
         FakeInfoHost.info_json = valid_info_json;
     }
     const invalid = [_][]const u8{
-        "{\"version\":2,\"root\":\"/workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":false,\"ephemeral\":true,\"permission\":\"prompt\"}",
+        "{\"version\":3,\"root\":\"/workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":true,\"ephemeral\":false,\"permission\":\"prompt\"}",
         "{\"version\":1,\"root\":\"workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":false,\"ephemeral\":true,\"permission\":\"prompt\"}",
         "{\"version\":1,\"root\":\"/workspace/./src\",\"cwd\":\"/workspace/src\",\"home\":\"/home/visitor\",\"git\":false,\"ephemeral\":true,\"permission\":\"prompt\"}",
         "{\"version\":1,\"root\":\"/workspace\",\"cwd\":\"/workspace/src\",\"home\":\"/home/visitor\",\"git\":false,\"ephemeral\":true,\"permission\":\"prompt\"}",
@@ -436,6 +465,9 @@ test "workspace info rejects invalid host contracts and stable error codes" {
         "{\"version\":1,\"root\":\"/workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":true,\"ephemeral\":true,\"permission\":\"prompt\"}",
         "{\"version\":1,\"root\":\"/workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":false,\"ephemeral\":false,\"permission\":\"prompt\"}",
         "{\"version\":1,\"root\":\"/workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":false,\"ephemeral\":true,\"permission\":\"allow\"}",
+        "{\"version\":2,\"root\":\"/workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":false,\"ephemeral\":false,\"permission\":\"prompt\"}",
+        "{\"version\":2,\"root\":\"/workspace\",\"cwd\":\"/workspace\",\"home\":\"/home/visitor\",\"git\":true,\"ephemeral\":true,\"permission\":\"prompt\"}",
+        "{\"version\":2,\"root\":\"/workspace\",\"cwd\":\"/workspace-other\",\"home\":\"/home/visitor\",\"git\":true,\"ephemeral\":false,\"permission\":\"prompt\"}",
     };
     for (invalid) |payload| {
         FakeInfoHost.info_json = payload;

--- a/src/core/workspace/context_contract.zig
+++ b/src/core/workspace/context_contract.zig
@@ -245,6 +245,8 @@ pub const HostWorkspaceContext = struct {
     root: []const u8,
     cwd: []const u8,
     home: []const u8,
+    git_available: bool,
+    ephemeral: bool,
 };
 
 pub const TransientContextInput = struct {


### PR DESCRIPTION
## Summary

- add a versioned persistent Git workspace contract to the WebAssembly host boundary
- allow validated nested working directories while preserving the v1 ephemeral contract
- propagate persistence, Git availability, and root/current-directory metadata into turn context
- keep sandbox provisioning, source synchronization, persistence, execution, and cleanup in the external host adapter

## Why

Blaxel-backed FX hosts need a persistent repository workspace and a nested execution directory. FX must validate that capability without importing provider dependencies or taking ownership of provider lifecycle.

## Compatibility and safety

- v1 remains ephemeral, Git-unavailable, and root-fixed
- v2 requires Git, persistence, normalized absolute paths, and a root or descendant current directory
- sibling-prefix escapes, traversal, malformed paths, unknown versions, and invalid capability combinations are rejected before execution
- existing permission admission, 64 KiB command/output bounds, 30-second deadline, and AbortSignal cancellation remain unchanged

## Validation

- Node 24 terminal suite, including the new v2 workspace exercise: passed
- terminal WebAssembly build: passed
- freshly built `./zig-out/bin/fx --version`: passed
- `zig fmt --check src/` and `git diff --check`: passed
- local full Zig suite: 8240/8258 passed; 17 pre-existing image-path/render failures remain environment-specific and unrelated to this change

Closes ENG-4965
