### PR TITLE
[DNM] Add ChatGPT subscription provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,24 @@ curl -fsSL https://fx.sh/setup.sh | bash
 
 ## Run fx
 
-To get started, sign in with Vercel:
+Sign in with Vercel AI Gateway:
 
 ```bash
 fx login
 ```
 
-Or add an AI Gateway API key:
+Or use an eligible ChatGPT subscription through OpenAI Codex OAuth:
+
+```bash
+fx login openai-codex
+fx
+```
+
+Inside fx, `/login` offers both providers and `/model` lists available `openai-codex/` models after ChatGPT sign-in. No model environment variable is required. Use `/logout chatgpt` to remove the ChatGPT session without affecting Vercel access.
+
+The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed.
+
+To use an AI Gateway API key instead:
 
 ```bash
 fx setup

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fx
 
 Inside fx, `/login` offers both providers and `/model` lists available `openai-codex/` models after ChatGPT sign-in. No model environment variable is required. Use `/logout chatgpt` to remove the ChatGPT session without affecting Vercel access.
 
-The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed.
+The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed. On supported Codex models, `/fast` requests OpenAI's priority service tier and consumes ChatGPT credits at the higher Fast mode rate.
 
 To use an AI Gateway API key instead:
 

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -3,6 +3,7 @@ const std_builtin = @import("builtin");
 const command_admission = @import("../core/permissions/command_admission.zig");
 const auth_runtime = @import("../core/auth/auth_runtime.zig");
 const credentials = @import("../core/auth/credentials.zig");
+const model_provider = @import("../core/config/model_provider.zig");
 const host = @import("../core/hosts/host.zig");
 const host_target = @import("../core/hosts/target.zig");
 const io_mod = @import("../core/shared/io.zig");
@@ -204,15 +205,18 @@ const AcpContext = struct {
 
     fn toolContext(self: *AcpContext) tool_runtime.Context {
         const session = if (self.state.active_session) |*active| active else unreachable;
-        self.state.web_search_runtime.configure(.{
-            .api_key = session.api_key,
-            .gateway_team = self.state.gateway_team,
-            .worker_model = session.model,
-            .gateway_retry_count = self.state.cfg.gateway_retry_count,
-            .gateway_chat_url = self.state.cfg.gateway_chat_url,
-            .usage = &session.session_rt.usage,
-            .usage_allocator = self.state.alloc,
-        });
+        const gateway_features_allowed = session.credential_source != .chatgpt_subscription;
+        if (gateway_features_allowed) {
+            self.state.web_search_runtime.configure(.{
+                .api_key = session.api_key,
+                .gateway_team = self.state.gateway_team,
+                .worker_model = session.model,
+                .gateway_retry_count = self.state.cfg.gateway_retry_count,
+                .gateway_chat_url = self.state.cfg.gateway_chat_url,
+                .usage = &session.session_rt.usage,
+                .usage_allocator = self.state.alloc,
+            });
+        }
         var tc: tool_runtime.Context = .{
             .workspace_root = self.state.workspace_root,
             .access_scope = self.state.workspace_access.scope(self.state.workspace_root),
@@ -227,6 +231,7 @@ const AcpContext = struct {
             .agent_stream_provider = self.state.cfg.gateway_provider.agent_stream,
             .credential_source = session.credential_source,
             .oauth_transport = self.state.cfg.gateway_provider.oauth_transport,
+            .secret_store = self.state.cfg.secret_store,
             .gateway_team = self.state.gateway_team,
             .model = session.model,
             .gateway_retry_count = self.state.cfg.gateway_retry_count,
@@ -240,8 +245,8 @@ const AcpContext = struct {
             .permission_grants = session.session_grants,
             .permission_rules = session.permission_rules,
             .tool_registry = self.toolRegistry(),
-            .permission_reviewer_provider = self.state.cfg.permission_reviewer_provider,
-            .auto_classifier = self.auto_classifier,
+            .permission_reviewer_provider = if (gateway_features_allowed) self.state.cfg.permission_reviewer_provider else null,
+            .auto_classifier = if (gateway_features_allowed) self.auto_classifier else permission_auto_classifier.Classifier.disabled(),
             .subagent_host = self.state.subagent_host,
             .subagent_caller_id = session.session_id,
             .worker = &self.state.worker,
@@ -275,7 +280,7 @@ const AcpContext = struct {
             .web_fetch_artifact_store = session.session_rt.webFetchArtifactStore(),
             .web_fetch_artifact_error = session.session_rt.webFetchArtifactError(),
             .web_search_runtime_ready = false,
-            .web_search_backend = self.state.web_search_runtime.dispatchBackend(),
+            .web_search_backend = if (gateway_features_allowed) self.state.web_search_runtime.dispatchBackend() else null,
             .model_capability_resolver = .{
                 .ctx = @ptrCast(self),
                 .resolve_fn = resolveModelCapabilities,
@@ -435,6 +440,15 @@ pub fn handlePrompt(
     const session = if (state.active_session) |*active| active else return .{
         .rpc_error = no_active_session_rpc_error,
     };
+    if (!try server.selectCredentialForModel(state, session.model)) {
+        return .{ .rpc_error = .{
+            .code = ErrorCode.invalid_request,
+            .message = if (model_provider.isChatGptSubscriptionModel(session.model))
+                credentials.missing_chatgpt_credential_message
+            else
+                credentials.missing_credential_message,
+        } };
+    }
 
     const params = msg.params_raw orelse return .{
         .rpc_error = .{
@@ -981,6 +995,7 @@ fn agentRuntimeDeps(ctx: *AcpContext) agent_runtime.AgentRuntimeDeps {
         .push_context_notice = pushContextNotice,
         .push_command_output_complete = pushCommandOutputComplete,
         .push_http_error = pushHttpError,
+        .refresh_gateway_credential = refreshGatewayCredential,
         .available_model_capabilities = availableModelCapabilities,
         .resolve_model_capabilities = resolveModelCapabilities,
         .format_tool_execution_error = formatToolExecutionError,
@@ -988,6 +1003,16 @@ fn agentRuntimeDeps(ctx: *AcpContext) agent_runtime.AgentRuntimeDeps {
         .usage = &session.session_rt.usage,
         .usage_allocator = ctx.state.alloc,
     };
+}
+
+fn refreshGatewayCredential(
+    raw: *anyopaque,
+    alloc: Allocator,
+    source: types.CredentialSource,
+    mode: auth_runtime.CredentialRefreshMode,
+) !?[]u8 {
+    const ctx: *AcpContext = @ptrCast(@alignCast(raw));
+    return server.refreshModelCredential(@ptrCast(ctx.state), alloc, source, mode);
 }
 
 fn persistUsageCheckpoint(
@@ -3861,6 +3886,20 @@ test "ACP prompt projection configures web search then blocks native execution" 
     try std.testing.expectEqualStrings(state.cfg.gateway_chat_url, state.web_search_runtime.gateway_chat_url);
     try std.testing.expectEqual(.failure, execution.status);
     try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
+}
+
+test "ACP ChatGPT route removes Gateway-backed auxiliary capabilities" {
+    const alloc = std.testing.allocator;
+    var state = try initTestAcpState(alloc, "/tmp/workspace", .auto);
+    defer state.deinit();
+    state.active_session.?.credential_source = .chatgpt_subscription;
+    state.active_session.?.api_key = "chatgpt-secret";
+    var ctx = AcpContext{ .alloc = alloc, .state = &state, .session_id = "session_1" };
+
+    const tool_ctx = ctx.toolContext();
+    try std.testing.expect(tool_ctx.web_search_backend == null);
+    try std.testing.expect(tool_ctx.permission_reviewer_provider == null);
+    try std.testing.expect(!tool_ctx.auto_classifier.enabled());
 }
 
 test "ACP default user commands require configured authority or review" {

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -14,6 +14,9 @@ const app_runtime_setup = @import("../core/app/app_runtime_setup.zig");
 const builtin_skills = @import("../builtins/skills.zig");
 const builtin_tools = @import("../builtins/tools.zig");
 const credentials = @import("../core/auth/credentials.zig");
+const secret = @import("../core/auth/secret.zig");
+const auth_runtime = @import("../core/auth/auth_runtime.zig");
+const model_provider = @import("../core/config/model_provider.zig");
 const debug_trace = @import("../core/shared/debug_trace.zig");
 const gateway_provider = @import("../core/gateway/gateway_provider.zig");
 const hooks = @import("../core/hooks/hooks.zig");
@@ -263,7 +266,7 @@ pub const ServerState = struct {
         };
         self.workspace_access.deinit(self.alloc);
         if (self.workspace_root.len > 0) self.alloc.free(self.workspace_root);
-        if (self.api_key.len > 0) self.alloc.free(self.api_key);
+        if (self.api_key.len > 0) secret.zeroAndFree(self.alloc, self.api_key);
         if (self.gateway_team) |team| self.alloc.free(team);
         if (self.selected_model.len > 0) self.alloc.free(self.selected_model);
         if (self.configured_model.len > 0) self.alloc.free(self.configured_model);
@@ -286,6 +289,77 @@ pub const ServerState = struct {
     }
 };
 
+fn credentialMatchesModel(source: ?types.CredentialSource, model: []const u8) bool {
+    return model_provider.isChatGptSubscriptionModel(model) ==
+        (source == .chatgpt_subscription);
+}
+
+fn adoptServerCredential(state: *ServerState, credential: *credentials.Credential) void {
+    if (state.active_session) |*active| active.api_key = &.{};
+    if (state.api_key.len > 0) secret.zeroAndFree(state.alloc, state.api_key);
+    if (state.gateway_team) |team| state.alloc.free(team);
+
+    state.api_key = credential.token;
+    credential.token = &.{};
+    state.credential_source = credential.source;
+    state.gateway_team = if (credential.team_id) |team| team else credential.team_slug;
+    if (credential.team_id != null) {
+        credential.team_id = null;
+        if (credential.team_slug) |slug| state.alloc.free(slug);
+        credential.team_slug = null;
+    } else {
+        credential.team_slug = null;
+    }
+    if (state.active_session) |*active| {
+        active.api_key = state.api_key;
+        active.credential_source = state.credential_source;
+    }
+}
+
+/// Ensures the process and active ACP session use a credential authorized for
+/// the final model route. Returns false when that route has no credential.
+pub fn selectCredentialForModel(state: *ServerState, model: []const u8) !bool {
+    if (state.active_session) |active| {
+        if (credentialMatchesModel(active.credential_source, model)) return true;
+    }
+    if (credentialMatchesModel(state.credential_source, model) and state.api_key.len > 0) return true;
+
+    var credential = if (!model_provider.isChatGptSubscriptionModel(model) and state.cfg.credential_override != null)
+        credentials.Credential{
+            .token = try state.alloc.dupe(u8, state.cfg.credential_override.?),
+            .source = .ai_gateway_api_key,
+        }
+    else blk: {
+        const resolution = try credentials.resolveForModel(
+            state.alloc,
+            state.cfg.gateway_provider.oauth_transport,
+            state.cfg.secret_store,
+            .refresh_if_needed,
+            model,
+            state.credential_source,
+        );
+        break :blk resolution.credential orelse return false;
+    };
+    defer credential.deinit(state.alloc);
+    adoptServerCredential(state, &credential);
+    return true;
+}
+
+pub fn refreshModelCredential(
+    raw: *anyopaque,
+    alloc: Allocator,
+    source: types.CredentialSource,
+    mode: auth_runtime.CredentialRefreshMode,
+) !?[]u8 {
+    const state: *ServerState = @ptrCast(@alignCast(raw));
+    return auth_runtime.refreshCredentialToken(
+        state.cfg.gateway_provider.oauth_transport,
+        alloc,
+        source,
+        mode,
+    );
+}
+
 pub fn releaseActiveSession(state: *ServerState) !void {
     clearPendingLegacyUrls(state);
     const active = if (state.active_session) |*session| session else return;
@@ -294,10 +368,14 @@ pub fn releaseActiveSession(state: *ServerState) !void {
         active.session_rt.usage.cancelReconciliation();
         active.session_rt.usage.finishProfilePublicationsBeforeShutdown();
         flushActiveSessionUsage(state) catch |err| {
-            active.session_rt.usage.startReconciliation(
-                state.alloc,
-                state.api_key,
-            );
+            if (state.credential_source == .chatgpt_subscription) {
+                active.session_rt.usage.clearReconciliationCredential();
+            } else {
+                active.session_rt.usage.startReconciliation(
+                    state.alloc,
+                    state.api_key,
+                );
+            }
             return err;
         };
         active.session_rt.usage.configurePublicationSink(null);
@@ -1194,32 +1272,6 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
 
     state.workspace_root = startup.takeWorkspaceRoot();
     state.workspace_access = startup.takeWorkspaceAccess();
-    var credential = if (state.cfg.credential_override) |override| credentials.Credential{
-        .token = try alloc.dupe(u8, override),
-        .source = .ai_gateway_api_key,
-    } else startup.takeCredential() orelse {
-        return state.writer.writeError(alloc, msg.id, .{
-            .code = ErrorCode.invalid_request,
-            .message = credentials.missing_credential_message,
-        });
-    };
-    defer credential.deinit(alloc);
-    if (credential.token.len == 0) {
-        return state.writer.writeError(alloc, msg.id, .{
-            .code = ErrorCode.invalid_request,
-            .message = credentials.missing_credential_message,
-        });
-    }
-    state.credential_source = credential.source;
-    state.api_key = credential.token;
-    credential.token = &.{};
-    if (credential.team_id) |team| {
-        state.gateway_team = team;
-        credential.team_id = null;
-    } else if (credential.team_slug) |team| {
-        state.gateway_team = team;
-        credential.team_slug = null;
-    }
 
     if (state.cfg.model_override) |override| {
         state.selected_model = try alloc.dupe(u8, override);
@@ -1230,6 +1282,55 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
         state.process_model_override = startup.model_source == .process_override;
     }
     state.configured_model = try alloc.dupe(u8, startup.configured_model);
+
+    var startup_credential = startup.takeCredential();
+    defer if (startup_credential) |*credential| credential.deinit(alloc);
+    var routed_credential: ?credentials.Credential = null;
+    defer if (routed_credential) |*credential| credential.deinit(alloc);
+    const startup_matches_model = if (startup_credential) |credential|
+        credentialMatchesModel(credential.source, state.selected_model)
+    else
+        false;
+    const credential: *credentials.Credential = if (!model_provider.isChatGptSubscriptionModel(state.selected_model) and state.cfg.credential_override != null) override: {
+        routed_credential = .{
+            .token = try alloc.dupe(u8, state.cfg.credential_override.?),
+            .source = .ai_gateway_api_key,
+        };
+        break :override &routed_credential.?;
+    } else if (startup_matches_model)
+        &startup_credential.?
+    else routed: {
+        const preferred = if (startup_credential) |value| value.source else null;
+        const resolution = try credentials.resolveForModel(
+            alloc,
+            state.cfg.gateway_provider.oauth_transport,
+            state.cfg.secret_store,
+            .refresh_if_needed,
+            state.selected_model,
+            preferred,
+        );
+        routed_credential = resolution.credential;
+        if (routed_credential == null) {
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_request,
+                .message = if (model_provider.isChatGptSubscriptionModel(state.selected_model))
+                    credentials.missing_chatgpt_credential_message
+                else
+                    credentials.missing_credential_message,
+            });
+        }
+        break :routed &routed_credential.?;
+    };
+    if (credential.token.len == 0) {
+        return state.writer.writeError(alloc, msg.id, .{
+            .code = ErrorCode.invalid_request,
+            .message = if (model_provider.isChatGptSubscriptionModel(state.selected_model))
+                credentials.missing_chatgpt_credential_message
+            else
+                credentials.missing_credential_message,
+        });
+    }
+    adoptServerCredential(state, credential);
 
     state.permission_mode = startup.permission_mode;
     state.permission_rules = startup.takePermissionRules();
@@ -1373,6 +1474,15 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                 .code = ErrorCode.invalid_params,
                 .message = "Invalid session model",
             });
+        if (!try selectCredentialForModel(state, value)) {
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_request,
+                .message = if (model_provider.isChatGptSubscriptionModel(value))
+                    credentials.missing_chatgpt_credential_message
+                else
+                    credentials.missing_credential_message,
+            });
+        }
         if (host_target.is_wasm and session.writable == null) {
             const next_model = alloc.dupe(u8, value) catch
                 return state.writer.writeError(alloc, msg.id, .{

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -14,6 +14,8 @@ const session_runtime = @import("../core/session/session.zig");
 const mcp_runtime = @import("../core/mcp/mcp_runtime.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
 const host = @import("../core/hosts/host.zig");
+const credentials = @import("../core/auth/credentials.zig");
+const model_provider = @import("../core/config/model_provider.zig");
 const mode_registry = @import("../core/modes/mode_registry.zig");
 const subagent_resume_admission = @import("../core/subagent/resume_admission.zig");
 const types = @import("../core/shared/types.zig");
@@ -301,6 +303,12 @@ pub fn handleLoadWasmSession(state: *server.ServerState, alloc: Allocator, msg: 
     const sid_copy = try alloc.dupe(u8, loaded.state.id);
     var sid_owned = true;
     defer if (sid_owned) alloc.free(sid_copy);
+    if (model_provider.isChatGptSubscriptionModel(loaded.state.preferences.model)) {
+        return state.writer.writeError(alloc, msg.id, .{
+            .code = ErrorCode.invalid_request,
+            .message = "ChatGPT subscription models are unavailable in this WASM runtime",
+        });
+    }
     const model_copy = try alloc.dupe(u8, loaded.state.preferences.model);
     var model_owned = true;
     defer if (model_owned) alloc.free(model_copy);
@@ -537,6 +545,15 @@ fn handleRestoreSession(
         state.selected_model
     else
         writable.state.preferences.model;
+    if (!try server.selectCredentialForModel(state, effective_model)) {
+        return state.writer.writeError(alloc, msg.id, .{
+            .code = ErrorCode.invalid_request,
+            .message = if (model_provider.isChatGptSubscriptionModel(effective_model))
+                credentials.missing_chatgpt_credential_message
+            else
+                credentials.missing_credential_message,
+        });
+    }
     const model_copy = try alloc.dupe(u8, effective_model);
     var model_owned = true;
     defer if (model_owned) alloc.free(model_copy);
@@ -754,10 +771,14 @@ fn activateSession(
     };
     server.enableSubagentHost(state);
     state.active_session.?.session_rt.attachProfileUsagePublisher(state.alloc);
-    state.active_session.?.session_rt.usage.startReconciliation(
-        state.alloc,
-        state.api_key,
-    );
+    if (state.credential_source == .chatgpt_subscription) {
+        state.active_session.?.session_rt.usage.clearReconciliationCredential();
+    } else {
+        state.active_session.?.session_rt.usage.startReconciliation(
+            state.alloc,
+            state.api_key,
+        );
+    }
     activateManagedBackground(state, store);
 }
 

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -86,14 +86,14 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .login,
         .token = "login",
-        .usage = "login",
-        .summary = "Sign in with Vercel",
+        .usage = "login [vercel|openai-codex]",
+        .summary = "Sign in to Vercel or a selected provider",
     },
     .{
         .kind = .logout,
         .token = "logout",
-        .usage = "logout",
-        .summary = "Sign out of the current Vercel session",
+        .usage = "logout [vercel|openai-codex]",
+        .summary = "Sign out of Vercel or a selected provider session",
     },
     .{
         .kind = .setup,
@@ -281,8 +281,8 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
         .{ .kind = .replay, .usage = "replay <tape>" },
     } },
     .{ .entries = &.{
-        .{ .kind = .login, .usage = "login" },
-        .{ .kind = .logout, .usage = "logout" },
+        .{ .kind = .login, .usage = "login [vercel|openai-codex]" },
+        .{ .kind = .logout, .usage = "logout [vercel|openai-codex]" },
         .{ .kind = .setup, .usage = "setup" },
         .{ .kind = .teams, .usage = "teams" },
         .{ .kind = .credits, .usage = "credits|balance" },
@@ -407,9 +407,9 @@ pub const slash_specs = [_]SlashSpec{
     .{ .kind = .resume_session, .command = "/resume", .help_entry = "/resume", .completion_description = "resume a saved session", .presentation_category = .session },
     .{ .kind = .continue_recovery, .command = "/continue", .help_entry = "/continue", .completion_description = "continue a paused model response", .presentation_category = .session, .requires_prompt_credential = true },
     .{ .kind = .rename_session, .command = "/rename", .help_entry = "/rename <title>", .completion_description = "rename the current session", .presentation_category = .session, .has_args = true, .accepts_payload = true },
-    .{ .kind = .login, .command = "/login", .help_entry = "/login", .completion_description = "sign in with Vercel", .presentation_category = .account },
-    .{ .kind = .logout, .command = "/logout", .help_entry = "/logout", .completion_description = "sign out of fx login", .presentation_category = .account },
-    .{ .kind = .setup, .command = "/setup", .help_entry = "/setup", .completion_description = "set up AI Gateway access", .presentation_category = .account },
+    .{ .kind = .login, .command = "/login", .help_entry = "/login", .completion_description = "choose Vercel or ChatGPT sign-in", .presentation_category = .account },
+    .{ .kind = .logout, .command = "/logout", .help_entry = "/logout [vercel|chatgpt]", .completion_description = "sign out of a provider session", .presentation_category = .account, .has_args = true, .accepts_payload = true },
+    .{ .kind = .setup, .command = "/setup", .help_entry = "/setup", .completion_description = "manage accounts and AI Gateway access", .presentation_category = .account },
     .{ .kind = .stats, .command = "/stats", .help_entry = "/stats", .completion_description = "show token and turn statistics", .presentation_category = .account },
     .{ .kind = .usage, .command = "/usage", .aliases = &.{"/cost"}, .help_entry = "/usage (/cost)", .completion_description = "show local fx tokens, models, and spend", .presentation_category = .account },
     .{ .kind = .status, .command = "/status", .help_entry = "/status", .completion_description = "show runtime configuration", .presentation_category = .general, .show_in_welcome = true },
@@ -419,7 +419,7 @@ pub const slash_specs = [_]SlashSpec{
     .{ .kind = .background_logs, .command = "/background logs", .accepts_payload = true },
     .{ .kind = .image, .command = "/image", .aliases = &.{"/img"}, .help_entry = "/image <path> (/img)", .completion_description = "attach an image by path", .presentation_category = .media, .has_args = true, .accepts_payload = true },
     .{ .kind = .images, .command = "/images", .help_entry = "/images [clear]", .completion_description = "manage pending image attachments", .presentation_category = .media, .has_args = true, .accepts_payload = true },
-    .{ .kind = .model, .command = "/model", .help_entry = "/model <id-or-query>", .completion_description = "choose what model and reasoning effort to use", .presentation_category = .model, .has_args = true, .accepts_payload = true, .requires_prompt_credential = true },
+    .{ .kind = .model, .command = "/model", .help_entry = "/model <id-or-query>", .completion_description = "choose what model and reasoning effort to use", .presentation_category = .model, .has_args = true, .accepts_payload = true },
     .{ .kind = .models, .command = "/models", .help_entry = "/models", .completion_description = "browse available models", .presentation_category = .model },
     .{ .kind = .permissions, .command = "/permissions", .help_entry = "/permissions [ask|auto|yolo|reset]", .completion_description = "choose what fx is allowed to do", .presentation_category = .security, .show_in_welcome = true, .has_args = true, .accepts_payload = true },
     .{ .kind = .allowlist, .command = "/allowlist", .help_entry = "/allowlist [view [effective|local|user]|[local|user] add|remove|reset ...]", .completion_description = "manage trusted commands, tools, and URLs", .presentation_category = .security, .show_in_welcome = true, .has_args = true, .accepts_payload = true },
@@ -571,13 +571,13 @@ test "built-in slash registry resolves primary commands and aliases" {
     const model = command_specs.matchedSlashPrefix(slash_registry, "/model\tmodel-id", .model) orelse return error.TestExpectedEqual;
     try std.testing.expectEqualStrings("/model", model);
 
-    for ([_][]const u8{ "/model", "/credits" }) |command| {
-        const credential_backed = slash_registry.lookup(command) orelse return error.TestExpectedEqual;
-        try std.testing.expect(credential_backed.requires_prompt_credential);
-    }
+    const credits = slash_registry.lookup("/credits") orelse return error.TestExpectedEqual;
+    try std.testing.expect(credits.requires_prompt_credential);
 
-    const models = slash_registry.lookup("/models") orelse return error.TestExpectedEqual;
-    try std.testing.expect(!models.requires_prompt_credential);
+    for ([_][]const u8{ "/model", "/models" }) |command| {
+        const catalog_command = slash_registry.lookup(command) orelse return error.TestExpectedEqual;
+        try std.testing.expect(!catalog_command.requires_prompt_credential);
+    }
 
     try std.testing.expect(command_specs.matchedSlashPrefix(slash_registry, "/model\nmodel-id", .model) == null);
 }

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -5,6 +5,7 @@ pub const permission_reviewer = @import("gateway/permission_reviewer.zig");
 
 const api_key_validator_contract = @import("../core/auth/api_key_validator.zig");
 const agent_stream_provider_contract = @import("../core/agent/stream_provider.zig");
+const chatgpt_oauth = @import("../core/auth/chatgpt_oauth.zig");
 const credentials = @import("../core/auth/credentials.zig");
 const oauth_transport = @import("../core/auth/oauth_transport.zig");
 const secret = @import("../core/auth/secret.zig");
@@ -15,6 +16,7 @@ const gateway_client = @import("../gateway/client.zig");
 const gateway_failure_diagnostics = @import("../core/gateway/gateway_failure_diagnostics.zig");
 const gateway_json = @import("../core/gateway/gateway_json.zig");
 const io_mod = @import("../core/shared/io.zig");
+const openai_codex_models = @import("../gateway/openai_codex_models.zig");
 const gateway_generation_usage = @import("../gateway/generation_usage.zig");
 const gateway_provider = @import("../core/gateway/gateway_provider.zig");
 const model_capabilities = @import("../core/config/model_capabilities.zig");
@@ -478,6 +480,9 @@ fn fetchCredits(
     alloc: Allocator,
     input: gateway_provider.CreditsLookupInput,
 ) output_contracts.CreditsSnapshot {
+    if (input.credential_source == .chatgpt_subscription) {
+        return creditsErrorSnapshot(alloc, "AI Gateway credits are unavailable for a ChatGPT subscription.");
+    }
     return fetchCreditsWithFetch(
         alloc,
         input.credential,
@@ -609,14 +614,15 @@ const OAuthHttpOperation = struct {
             .location = .{ .url = self.request.url },
             .method = switch (self.request.method) {
                 .get => .GET,
-                .post_form => .POST,
+                .post_form, .post_json => .POST,
             },
             .payload = self.request.payload,
             .headers = .{
-                .content_type = if (self.request.method == .post_form)
-                    .{ .override = "application/x-www-form-urlencoded" }
-                else
-                    .default,
+                .content_type = switch (self.request.method) {
+                    .get => .default,
+                    .post_form => .{ .override = "application/x-www-form-urlencoded" },
+                    .post_json => .{ .override = "application/json" },
+                },
                 .user_agent = .{ .override = gateway_client.user_agent },
                 .accept_encoding = .omit,
             },
@@ -1710,6 +1716,19 @@ fn stubFetchForbiddenCredits(
     };
 }
 
+test "built-in credits provider rejects ChatGPT credentials before Gateway I/O" {
+    var snapshot = fetchCredits(null, std.testing.allocator, .{
+        .credential = "chatgpt-secret",
+        .credential_source = .chatgpt_subscription,
+        .tenant = null,
+    });
+    defer snapshot.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings(
+        "AI Gateway credits are unavailable for a ChatGPT subscription.",
+        snapshot.err_message.?,
+    );
+}
+
 test "built-in credits provider names the team query only when valid" {
     const cases = [_]struct { team: ?[]const u8, want: []const u8 }{
         .{ .team = null, .want = "/coding-agent/v1/credits" },
@@ -2012,24 +2031,50 @@ fn fetchCatalogForProvider(
     alloc: std.mem.Allocator,
     input: model_catalog.FetchInput,
 ) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    const chatgpt_available = input.access.credentialSource() == .chatgpt_subscription or
+        (chatgpt_oauth.sourceExists(alloc) catch false);
     const response = fetchModelCatalogResponse(
         alloc,
         input.access,
         input.endpoint,
         input.cancel_flag,
-    ) catch |err| return .{ .failure = catalogRequestFailure(err) };
+    ) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        if (chatgpt_available and err != error.Cancelled) return localChatGptCatalog(alloc);
+        return .{ .failure = catalogRequestFailure(err) };
+    };
     const json_text = switch (response) {
         .success => |body| body,
-        .http_status => |status| return .{ .failure = model_catalog.failureForHttpStatus(status) },
+        .http_status => |status| {
+            const failure = model_catalog.failureForHttpStatus(status);
+            // Preserve the shared authenticated-to-public retry before falling
+            // back to the independent local ChatGPT catalog.
+            if (failure.allowsPublicFallback()) return .{ .failure = failure };
+            if (chatgpt_available) return localChatGptCatalog(alloc);
+            return .{ .failure = failure };
+        },
     };
     defer alloc.free(json_text);
 
-    const catalog = parseModelCatalogForView(alloc, json_text, input.view) catch |err| return .{
-        .failure = .{
-            .category = if (err == error.OutOfMemory) .resource_exhausted else .malformed_response,
-            .http_status = .ok,
-        },
+    var catalog = parseModelCatalogForView(alloc, json_text, input.view) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        if (chatgpt_available) return localChatGptCatalog(alloc);
+        return .{ .failure = .{ .category = .malformed_response, .http_status = .ok } };
     };
+    if (chatgpt_available) {
+        openai_codex_models.append(alloc, &catalog) catch {
+            freeModelCatalog(alloc, &catalog);
+            return .{ .failure = .{ .category = .resource_exhausted } };
+        };
+        std.mem.sort(ModelCatalogEntry, catalog.items, {}, model_catalog.compareModelCatalogEntries);
+    }
+    return .{ .catalog = catalog };
+}
+
+fn localChatGptCatalog(alloc: std.mem.Allocator) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    var catalog: std.ArrayList(ModelCatalogEntry) = .empty;
+    errdefer freeModelCatalog(alloc, &catalog);
+    try openai_codex_models.append(alloc, &catalog);
     return .{ .catalog = catalog };
 }
 
@@ -2060,7 +2105,18 @@ fn fetchModelCatalogForView(
     };
     defer alloc.free(json_text);
 
-    return parseModelCatalogForView(alloc, json_text, view);
+    var catalog = try parseModelCatalogForView(alloc, json_text, view);
+    errdefer freeModelCatalog(alloc, &catalog);
+
+    // The model-id completion path must expose ChatGPT subscription models too;
+    // otherwise users can authenticate successfully but still have to set
+    // FX_MODEL manually to reach the Codex route.
+    const chatgpt_available = (chatgpt_oauth.sourceExists(alloc) catch false);
+    if (chatgpt_available) {
+        openai_codex_models.append(alloc, &catalog) catch return error.OutOfMemory;
+        std.mem.sort(ModelCatalogEntry, catalog.items, {}, model_catalog.compareModelCatalogEntries);
+    }
+    return catalog;
 }
 
 fn fetchModelCatalogResponse(

--- a/src/builtins/providers.zig
+++ b/src/builtins/providers.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const credentials = @import("../core/auth/credentials.zig");
+const model_provider = @import("../core/config/model_provider.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const gateway = @import("gateway.zig");
+const openai_codex = @import("../gateway/openai_codex.zig");
+
+const Route = enum {
+    gateway,
+    openai_codex,
+};
+
+pub const agent_stream_provider = stream_provider.Provider{
+    .build_fn = build,
+    .stream_fn = stream,
+};
+
+fn routeForModel(model: []const u8) Route {
+    return if (model_provider.isChatGptSubscriptionModel(model)) .openai_codex else .gateway;
+}
+
+fn authorizedRoute(model: []const u8, source: ?credentials.Source) !Route {
+    return switch (routeForModel(model)) {
+        .openai_codex => if (source == .chatgpt_subscription)
+            .openai_codex
+        else
+            error.ChatGptSubscriptionCredentialRequired,
+        .gateway => if (source == .chatgpt_subscription)
+            error.ChatGptCredentialCannotAuthorizeGateway
+        else
+            .gateway,
+    };
+}
+
+fn build(_: ?*anyopaque, alloc: std.mem.Allocator, request: stream_provider.BuildRequest) ![]u8 {
+    const provider = switch (routeForModel(request.model)) {
+        .gateway => gateway.agent_stream_provider,
+        .openai_codex => openai_codex.agent_stream_provider,
+    };
+    return provider.build(alloc, request);
+}
+
+fn stream(_: ?*anyopaque, alloc: std.mem.Allocator, request: stream_provider.Request) !stream_provider.Result {
+    const provider = switch (try authorizedRoute(request.model, request.credential_source)) {
+        .gateway => gateway.agent_stream_provider,
+        .openai_codex => openai_codex.agent_stream_provider,
+    };
+    return provider.stream(alloc, request);
+}
+
+test "provider router keeps ChatGPT and Gateway credentials on their own origins" {
+    try std.testing.expectEqual(Route.openai_codex, try authorizedRoute(
+        "openai-codex/gpt-5.4",
+        .chatgpt_subscription,
+    ));
+    try std.testing.expectEqual(Route.gateway, try authorizedRoute(
+        "openai/gpt-5.4",
+        .ai_gateway_api_key,
+    ));
+    try std.testing.expectError(
+        error.ChatGptSubscriptionCredentialRequired,
+        authorizedRoute("openai-codex/gpt-5.4", .fx_login),
+    );
+    try std.testing.expectError(
+        error.ChatGptCredentialCannotAuthorizeGateway,
+        authorizedRoute("openai/gpt-5.4", .chatgpt_subscription),
+    );
+}

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -28,6 +28,7 @@ pub fn streamGatewayCompletion(
     provider: agent_stream_provider.Provider,
     alloc: Allocator,
     api_key: []const u8,
+    credential_source: ?types.CredentialSource,
     team: ?[]const u8,
     session_id: ?[]const u8,
     model: []const u8,
@@ -55,6 +56,7 @@ pub fn streamGatewayCompletion(
     attempt_evidence.provider_admitted = true;
     var result = provider.stream(alloc, .{
         .api_key = api_key,
+        .credential_source = credential_source,
         .team = team,
         .session_id = session_id,
         .model = model,
@@ -103,7 +105,11 @@ pub fn streamGatewayCompletion(
     if (comptime @import("builtin").os.tag != .wasi) {
         if (result.reconcile_generation_usage) {
             if (usage) |ledger| {
-                ledger.startReconciliation(usage_allocator, api_key);
+                if (credential_source == .chatgpt_subscription) {
+                    ledger.clearReconciliationCredential();
+                } else {
+                    ledger.startReconciliation(usage_allocator, api_key);
+                }
             }
         }
     }
@@ -125,6 +131,8 @@ pub fn streamGatewayCompletion(
     errdefer if (generation_id) |owned| alloc.free(owned);
     const provider_failure_detail = if (result.completion.provider_failure_detail) |detail| try alloc.dupe(u8, detail) else null;
     errdefer if (provider_failure_detail) |owned| alloc.free(owned);
+    const provider_state_json = if (result.completion.provider_state_json) |state| try alloc.dupe(u8, state) else null;
+    errdefer if (provider_state_json) |owned| alloc.free(owned);
     const err_body = if (result.err_body) |body| try alloc.dupe(u8, body) else null;
     errdefer if (err_body) |owned| alloc.free(owned);
 
@@ -145,6 +153,7 @@ pub fn streamGatewayCompletion(
             .delivery_ambiguous = delivery_ambiguous,
             .provider_result_identity_failure = provider_result_identity_failure,
             .provider_failure_detail = provider_failure_detail,
+            .provider_state_json = provider_state_json,
             .finish_reason = finish_reason,
             .usage = completion_usage,
         },
@@ -165,6 +174,7 @@ fn recordGatewayResultMetric(
 ) void {
     var response_bytes: u64 = 0;
     if (completion.content) |content| response_bytes += content.len;
+    if (completion.provider_state_json) |state| response_bytes += state.len;
     for (completion.tool_calls) |call| {
         response_bytes += call.id.len + call.name.len + call.arguments_json.len;
         if (call.provider_result) |pr| response_bytes += pr.len;
@@ -346,6 +356,7 @@ test "pre-send gateway failure settles usage as unbilled" {
         "test-key",
         null,
         null,
+        null,
         "test/model",
         1,
         "not a valid URL",
@@ -401,6 +412,7 @@ test "possibly sent gateway failure marks billing incomplete" {
         .{ .stream_fn = Gateway.stream },
         alloc,
         "test-key",
+        null,
         null,
         null,
         "test/model",

--- a/src/core/agent/runtime/image_provider.zig
+++ b/src/core/agent/runtime/image_provider.zig
@@ -15,6 +15,7 @@ const model = "google/gemini-2.5-flash";
 pub const Request = struct {
     stream_provider: agent_stream_provider.Provider,
     api_key: []const u8,
+    credential_source: ?types.CredentialSource = null,
     gateway_team: ?[]const u8,
     session_id: ?[]const u8 = null,
     retry_count: usize,
@@ -76,6 +77,7 @@ pub fn inspect(
         request.stream_provider,
         alloc,
         request.api_key,
+        request.credential_source,
         request.gateway_team,
         request.session_id,
         model,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -14,6 +14,7 @@ const file_mutation_contract = @import("../../tooling/file_mutation_contract.zig
 const io_mod = @import("../../shared/io.zig");
 const host_target = @import("../../hosts/target.zig");
 const secret = @import("../../auth/secret.zig");
+const credentials = @import("../../auth/credentials.zig");
 const tool_dispatch = @import("../../tooling/tool_dispatch.zig");
 const tool_result_errors = @import("../../tooling/tool_result_errors.zig");
 const tooling_tool_admission = @import("../../tooling/tool_admission.zig");
@@ -634,6 +635,7 @@ fn materializeConfirmedProviderTools(
         within_turn_suffix,
         null,
         novel_calls,
+        completion.provider_state_json,
     );
     var batch: runtime_tool_batch.StepBatchState = .{};
     for (novel_calls) |call| {
@@ -1400,7 +1402,7 @@ fn refreshGatewayCredentialForJob(
     trace_ctx: TraceContext,
 ) !bool {
     const source = job.credential_source orelse return false;
-    if (source != .fx_login) return false;
+    if (!credentials.sourceRefreshable(source)) return false;
     const refresh = deps.refresh_gateway_credential orelse return false;
 
     const refreshed = refresh(deps.ctx, alloc, source, mode) catch |err| {
@@ -1417,11 +1419,15 @@ fn refreshGatewayCredentialForJob(
     const previous_api_key = active_api_key.*;
     if (comptime !host_target.is_wasm) {
         if (deps.usage) |usage| {
-            usage.refreshReconciliationCredential(
-                deps.usage_allocator,
-                previous_api_key,
-                refreshed,
-            );
+            if (source == .chatgpt_subscription) {
+                usage.clearReconciliationCredential();
+            } else {
+                usage.refreshReconciliationCredential(
+                    deps.usage_allocator,
+                    previous_api_key,
+                    refreshed,
+                );
+            }
         }
     }
     if (owned_api_key.*) |old| secret.zeroAndFree(alloc, old);
@@ -2687,6 +2693,7 @@ fn processQueuedPromptLoop(
                 deps.agent_stream_provider,
                 arena,
                 active_api_key,
+                job.credential_source,
                 job.gateway_team,
                 lifecycle.scope.session_id,
                 gateway_model,
@@ -4211,6 +4218,7 @@ fn processQueuedPromptLoop(
             else
                 partial_assistant,
             .tool_calls = effective_tool_calls,
+            .provider_state_json = completion.provider_state_json,
         };
 
         var preparation_batch = tool_preparation.ReadyCallBatch.init(
@@ -4442,6 +4450,7 @@ fn processQueuedPromptLoop(
             &within_turn_suffix,
             if (terminal_provider_completion) null else completion.content,
             effective_tool_calls,
+            completion.provider_state_json,
         );
 
         const step_has_content = !terminal_provider_completion and completion.content != null and completion.content.?.len > 0;

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -46,8 +46,14 @@ pub fn appendAssistantToolCallStep(
     within_turn_suffix: *std.ArrayList(ChatMessage),
     content: ?[]const u8,
     tool_calls: []const ToolCall,
+    provider_state_json: ?[]const u8,
 ) !void {
-    try within_turn_suffix.append(arena, .{ .role = .assistant, .content = content, .tool_calls = tool_calls });
+    try within_turn_suffix.append(arena, .{
+        .role = .assistant,
+        .content = content,
+        .tool_calls = tool_calls,
+        .provider_state_json = provider_state_json,
+    });
 }
 
 pub fn appendToolResultContent(
@@ -549,7 +555,7 @@ test "drained batch feedback follows all tool results and keeps its source call"
         .{ .id = "call_second", .name = "run_command", .arguments_json = "{}" },
     };
 
-    try appendAssistantToolCallStep(alloc, &suffix, null, &calls);
+    try appendAssistantToolCallStep(alloc, &suffix, null, &calls, null);
     try appendToolResultContent(
         alloc,
         &suffix,

--- a/src/core/agent/runtime/vision_executor.zig
+++ b/src/core/agent/runtime/vision_executor.zig
@@ -28,6 +28,7 @@ const system_prompt =
 pub const Config = struct {
     stream_provider: agent_stream_provider.Provider,
     api_key: []const u8,
+    credential_source: ?types.CredentialSource = null,
     gateway_team: ?[]const u8,
     session_id: ?[]const u8 = null,
     retry_count: usize,
@@ -280,6 +281,7 @@ fn runBatchAttempt(
         .{
             .stream_provider = config.stream_provider,
             .api_key = config.api_key,
+            .credential_source = config.credential_source,
             .gateway_team = config.gateway_team,
             .session_id = config.session_id,
             .retry_count = config.retry_count,

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -107,6 +107,7 @@ pub const BuildRequest = struct {
 
 pub const Request = struct {
     api_key: []const u8,
+    credential_source: ?types.CredentialSource = null,
     team: ?[]const u8,
     /// Borrowed for the duration of `Provider.stream`.
     session_id: ?[]const u8 = null,
@@ -155,6 +156,7 @@ pub const Result = struct {
             if (self.completion.billing) |billing| alloc.free(@constCast(billing.model));
             types.freeToolCallSlice(alloc, @constCast(self.completion.tool_calls));
             if (self.completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
+            if (self.completion.provider_state_json) |state| alloc.free(@constCast(state));
             if (self.failure_schema) |schema| alloc.free(schema);
             if (self.failure_request_shape) |shape| alloc.free(shape);
         }

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -5,6 +5,7 @@ const command_admission = @import("../permissions/command_admission.zig");
 const permission_auto_classifier = @import("../permissions/auto_classifier.zig");
 const app_callbacks = @import("app_callbacks.zig");
 const runtime_profile = @import("../hosts/runtime_profile.zig");
+const host = @import("../hosts/host.zig");
 const app_permission_runtime = @import("app_permission_runtime.zig");
 const app_session_runtime = @import("app_session_runtime.zig");
 const app_worker_runtime = @import("app_worker_runtime.zig");
@@ -215,6 +216,10 @@ pub fn Runtime(comptime App: type) type {
                 .gateway_team = app.auth.gatewayTeam(),
                 .credential_source = app.auth.credentialSource(),
                 .oauth_transport = app.auth.oauthTransport(),
+                .secret_store = if (comptime @hasDecl(@TypeOf(app.auth), "secretStore"))
+                    app.auth.secretStore()
+                else
+                    host.unavailable_secret_store,
                 .model = app.selected_model.items,
                 .gateway_retry_count = gateway_retry_count,
                 .gateway_chat_url = gateway_chat_url,
@@ -261,7 +266,7 @@ pub fn Runtime(comptime App: type) type {
                     .allow_sandboxed => .allow_sandboxed,
                     .prompt => .prompt,
                 } else .none,
-                .permission_reviewer_provider = if (comptime @hasDecl(App, "permissionReviewerProvider")) app.permissionReviewerProvider() else null,
+                .permission_reviewer_provider = if (app.auth.credentialSource() != .chatgpt_subscription and comptime @hasDecl(App, "permissionReviewerProvider")) app.permissionReviewerProvider() else null,
                 .tracker = &app.change_tracker,
                 .mcp_ctx = @ptrCast(app),
                 .mcp_has_tool = if (comptime runtime_profile.allows(App, .mcp)) mcpHasTool else null,
@@ -283,17 +288,19 @@ pub fn Runtime(comptime App: type) type {
                 ctx.on_web_fetch_progress = app_callbacks.Bindings(App).onWebFetchProgress;
             }
             if (comptime @hasField(App, "web_search_runtime")) {
-                app.web_search_runtime.configure(.{
-                    .api_key = app.auth.apiKey() orelse "",
-                    .gateway_team = app.auth.gatewayTeam(),
-                    .worker_model = app.selected_model.items,
-                    .gateway_retry_count = gateway_retry_count,
-                    .gateway_chat_url = gateway_chat_url,
-                    .usage = &app.session.usage,
-                    .usage_allocator = app.alloc,
-                });
+                if (app.auth.credentialSource() != .chatgpt_subscription) {
+                    app.web_search_runtime.configure(.{
+                        .api_key = app.auth.apiKey() orelse "",
+                        .gateway_team = app.auth.gatewayTeam(),
+                        .worker_model = app.selected_model.items,
+                        .gateway_retry_count = gateway_retry_count,
+                        .gateway_chat_url = gateway_chat_url,
+                        .usage = &app.session.usage,
+                        .usage_allocator = app.alloc,
+                    });
+                    ctx.web_search_backend = app.web_search_runtime.dispatchBackend();
+                }
                 ctx.web_search_runtime_ready = false;
-                ctx.web_search_backend = app.web_search_runtime.dispatchBackend();
                 ctx.web_search_progress_ctx = @ptrCast(app);
                 ctx.on_web_search_progress = app_callbacks.Bindings(App).onWebSearchProgress;
             }
@@ -1920,6 +1927,32 @@ test "app prompt projection configures web search then blocks native execution" 
     try std.testing.expectEqualStrings(test_gateway_chat_url, app.web_search_runtime.gateway_chat_url);
     try std.testing.expectEqual(.failure, execution.status);
     try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
+}
+
+test "app ChatGPT route removes Gateway-backed auxiliary capabilities" {
+    const alloc = std.testing.allocator;
+    var app = try FakeApp.init(alloc);
+    defer app.deinit();
+    var credential = credentials.Credential{
+        .token = try alloc.dupe(u8, "chatgpt-secret"),
+        .source = .chatgpt_subscription,
+    };
+    defer credential.deinit(alloc);
+    _ = app.auth.adoptCredential(alloc, &credential);
+
+    const ctx = Runtime(FakeApp).toolContext(
+        &app,
+        &test_ignored_list_entries,
+        100,
+        1024,
+        40,
+        120,
+        2048,
+        2,
+        test_gateway_chat_url,
+    );
+    try std.testing.expect(ctx.web_search_backend == null);
+    try std.testing.expect(ctx.permission_reviewer_provider == null);
 }
 
 test "app agent runtime tool context prefers active queued turn settings" {

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -7,6 +7,9 @@ const io_mod = @import("../shared/io.zig");
 const credentials = @import("../auth/credentials.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
 const login_flow = @import("../auth/login_flow.zig");
+const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
+const provider_catalog = @import("../auth/provider_catalog.zig");
+const model_provider = @import("../config/model_provider.zig");
 const types = @import("../shared/types.zig");
 
 fn oauthAuthEnabled(comptime App: type) bool {
@@ -17,6 +20,32 @@ fn oauthAuthEnabled(comptime App: type) bool {
 pub fn Runtime(comptime App: type) type {
     return struct {
         fn ensurePromptCredential(app: *App) !bool {
+            if (comptime @hasField(App, "selected_model") and
+                @hasDecl(@TypeOf(app.auth), "selectForModel"))
+            {
+                const model = app.selected_model.items;
+                const required_source: credentials.Source = if (model_provider.isChatGptSubscriptionModel(model))
+                    .chatgpt_subscription
+                else
+                    app.auth.credentialSource() orelse .fx_login;
+                const route_change = app.auth.selectForModel(app.alloc, model) catch |err| switch (err) {
+                    error.OutOfMemory => return err,
+                    else => return recoverCredentialFailure(app, required_source, err),
+                };
+                if (route_change) |changed| {
+                    applyCredentialChange(app, changed);
+                } else if (model_provider.isChatGptSubscriptionModel(model) and
+                    app.auth.credentialSource() != .chatgpt_subscription)
+                {
+                    try app.writeDomainNotice(.{
+                        .topic = "auth",
+                        .tone = .warning,
+                        .body = credentials.missing_chatgpt_interactive_credential_message,
+                    }, true);
+                    app.shell.render_requests.request(.footer);
+                    return false;
+                }
+            }
             if (app.auth.credentialSource() != null) return true;
 
             const auth_view = app.auth.view();
@@ -43,10 +72,12 @@ pub fn Runtime(comptime App: type) type {
                 }, true);
                 return;
             }
-            try beginSignIn(app, false);
+            try app.auth.refreshSourceInventory(app.alloc);
+            app.auth.openPicker(app.alloc);
+            app.shell.render_requests.request(.footer);
         }
 
-        pub fn runLogoutCommand(app: *App) !void {
+        pub fn runLogoutCommand(app: *App, target: []const u8) !void {
             if (comptime !oauthAuthEnabled(App)) {
                 try app.writeDomainNotice(.{
                     .topic = "auth",
@@ -55,7 +86,55 @@ pub fn Runtime(comptime App: type) type {
                 }, true);
                 return;
             }
+            const requested_provider = if (std.mem.trim(u8, target, " \t\r\n").len == 0)
+                null
+            else
+                provider_catalog.parse(std.mem.trim(u8, target, " \t\r\n")) orelse {
+                    try writeAuthNotice(app, .{
+                        .topic = "auth",
+                        .tone = .warning,
+                        .body = "Usage: /logout [vercel|chatgpt]",
+                    });
+                    return;
+                };
             try app.flushBeforeBlockingExternalWork();
+            const selected_model_uses_chatgpt = if (comptime @hasField(App, "selected_model"))
+                model_provider.isChatGptSubscriptionModel(app.selected_model.items)
+            else
+                false;
+            const provider_inventory = if (comptime @hasDecl(@TypeOf(app.auth), "pickerView")) inventory: {
+                try app.auth.refreshSourceInventory(app.alloc);
+                break :inventory app.auth.pickerView().available_sources;
+            } else @as(auth_runtime.SourceSet, .empty);
+            const chatgpt_is_only_logout_session = provider_inventory.contains(.chatgpt_subscription) and
+                !provider_inventory.contains(.fx_login);
+            const logout_chatgpt = if (requested_provider) |provider|
+                provider == .openai_codex
+            else
+                selected_model_uses_chatgpt or
+                    app.auth.credentialSource() == .chatgpt_subscription or
+                    chatgpt_is_only_logout_session;
+            if (logout_chatgpt) {
+                const outcome = chatgpt_oauth.logout() catch {
+                    try writeAuthNotice(app, .{
+                        .topic = "auth",
+                        .tone = .@"error",
+                        .body = "Could not durably sign out of ChatGPT. The current source is unchanged.",
+                    });
+                    return;
+                };
+                const changed = if (comptime @hasDecl(@TypeOf(app.auth), "reconcileAfterChatGptLogout"))
+                    try app.auth.reconcileAfterChatGptLogout(app.alloc)
+                else
+                    false;
+                applyCredentialChange(app, changed);
+                try writeAuthNotice(app, switch (outcome) {
+                    .deleted => .{ .topic = "auth", .tone = .neutral, .body = "Signed out of ChatGPT." },
+                    .missing => .{ .topic = "auth", .tone = .neutral, .body = "No ChatGPT login session found." },
+                    .deleted_not_durable => .{ .topic = "auth", .tone = .warning, .body = "Signed out of ChatGPT, but could not confirm the profile directory update." },
+                });
+                return;
+            }
             const result = login_flow.logout(app.alloc, app.auth.oauthTransport()) catch |err| switch (err) {
                 error.SessionDeleteFailed => {
                     try writeAuthNotice(app, .{
@@ -131,6 +210,7 @@ pub fn Runtime(comptime App: type) type {
                 .source => |source| try applySourceChoice(app, source),
                 .action => |action| switch (action) {
                     .login => try beginSignIn(app, true),
+                    .chatgpt_login => try beginChatGptSignIn(app),
                     .setup => {
                         if (comptime !runtime_profile.allows(App, .native_auth)) {
                             try app.writeDomainNotice(.{
@@ -192,40 +272,75 @@ pub fn Runtime(comptime App: type) type {
 
         pub fn collectSignInFacts(app: *App) !void {
             if (comptime !oauthAuthEnabled(App)) return;
+            const sign_in_source: credentials.Source = if (comptime @hasDecl(@TypeOf(app.auth), "pickerView"))
+                app.auth.pickerView().sign_in_source
+            else
+                .fx_login;
             app.auth.pulseSignIn(app.alloc);
             switch (app.auth.pollSignInTransition(app.alloc)) {
                 .none => {},
                 .cancelled => app.shell.render_requests.request(.footer),
                 .failed => |err| {
-                    debug_trace.logf("auth", "login failed err={s}", .{@errorName(err)});
+                    debug_trace.logf("auth", "login failed source={t} err={s}", .{ sign_in_source, @errorName(err) });
                     _ = app.auth.popPickerStage(app.alloc);
-                    try writeLoginError(app, err);
+                    try writeLoginError(app, sign_in_source, err);
                 },
                 .succeeded => |completed| {
-                    var selection = completed;
-                    defer selection.deinit(app.alloc);
+                    var owned = completed;
+                    defer owned.deinit(app.alloc);
+                    switch (owned) {
+                        .vercel => |*selection| {
+                            if (!try selectCredentialSource(app, .fx_login)) {
+                                _ = app.auth.popPickerStage(app.alloc);
+                                try writeAuthNotice(app, .{
+                                    .topic = "auth",
+                                    .tone = .@"error",
+                                    .body = "Signed in, but the fx login credential could not be loaded.",
+                                });
+                                return;
+                            }
+                            rememberCredentialSource(app, .fx_login);
 
-                    if (!try selectCredentialSource(app, .fx_login)) {
-                        _ = app.auth.popPickerStage(app.alloc);
-                        try writeAuthNotice(app, .{
-                            .topic = "auth",
-                            .tone = .@"error",
-                            .body = "Signed in, but the fx login credential could not be loaded.",
-                        });
-                        return;
+                            if (selection.teams.items.len > 0) {
+                                app.auth.openTeamPicker(app.alloc, selection);
+                            } else {
+                                app.auth.closePicker(app.alloc);
+                            }
+                            try writeAuthNotice(app, .{
+                                .topic = "auth",
+                                .tone = .neutral,
+                                .body = "Signed in to Vercel.",
+                            });
+                        },
+                        .chatgpt => {
+                            try app.auth.refreshSourceInventory(app.alloc);
+                            const selected_model_uses_chatgpt = if (comptime @hasField(App, "selected_model"))
+                                model_provider.isChatGptSubscriptionModel(app.selected_model.items)
+                            else
+                                false;
+                            if (selected_model_uses_chatgpt and
+                                !try selectCredentialSource(app, .chatgpt_subscription))
+                            {
+                                _ = app.auth.popPickerStage(app.alloc);
+                                try writeAuthNotice(app, .{
+                                    .topic = "auth",
+                                    .tone = .@"error",
+                                    .body = "Signed in, but the ChatGPT subscription credential could not be loaded.",
+                                });
+                                return;
+                            }
+                            if (!selected_model_uses_chatgpt) {
+                                app.model_cache.reset();
+                                if (comptime @hasDecl(App, "startModelCacheWarmup")) app.startModelCacheWarmup();
+                            }
+                            app.auth.closePicker(app.alloc);
+                            try writeAuthNotice(app, .{
+                                .topic = "auth",
+                                .tone = .neutral,
+                                .body = "Signed in with ChatGPT.",
+                            });
+                        },
                     }
-                    rememberCredentialSource(app, .fx_login);
-
-                    if (selection.teams.items.len > 0) {
-                        app.auth.openTeamPicker(app.alloc, &selection);
-                    } else {
-                        _ = app.auth.popPickerStage(app.alloc);
-                    }
-                    try writeAuthNotice(app, .{
-                        .topic = "auth",
-                        .tone = .neutral,
-                        .body = "Signed in to Vercel.",
-                    });
                 },
             }
         }
@@ -371,6 +486,9 @@ pub fn Runtime(comptime App: type) type {
         /// leaves the source active for this run rather than refusing a working
         /// credential the user already selected.
         fn rememberCredentialSource(app: *App, source: credentials.Source) void {
+            // ChatGPT is selected by model route, not as a global Gateway
+            // credential preference. Its saved session coexists independently.
+            if (source == .chatgpt_subscription) return;
             if (comptime @hasDecl(App, "persistCredentialSourcePreference")) {
                 app.persistCredentialSourcePreference(source);
                 return;
@@ -388,6 +506,19 @@ pub fn Runtime(comptime App: type) type {
                     "credential choice not persisted source={t} err={s}",
                     .{ source, @errorName(failure.err) },
                 ),
+            }
+        }
+
+        fn beginChatGptSignIn(app: *App) !void {
+            try app.flushBeforeBlockingExternalWork();
+            const started = app.auth.openChatGptSignInPickerFromRoot(app.alloc);
+            if (started catch |err| {
+                debug_trace.logf("auth", "ChatGPT login failed err={s}", .{@errorName(err)});
+                try writeLoginError(app, .chatgpt_subscription, err);
+                return;
+            }) {
+                app.shell.render_requests.request(.footer);
+                if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) try openSignInBrowser(app);
             }
         }
 
@@ -468,7 +599,7 @@ pub fn Runtime(comptime App: type) type {
                 app.auth.openSignInPicker(app.alloc);
             if (started catch |err| {
                 debug_trace.logf("auth", "login failed err={s}", .{@errorName(err)});
-                try writeLoginError(app, err);
+                try writeLoginError(app, .fx_login, err);
                 return;
             }) {
                 app.shell.render_requests.request(.footer);
@@ -529,12 +660,21 @@ pub fn Runtime(comptime App: type) type {
         }
 
         fn recoverPromptCredentialRefreshFailure(app: *App, err: anyerror) !bool {
-            debug_trace.logf("auth", "prompt credential refresh failed source=fx_login err={s}", .{@errorName(err)});
-            app.auth.recordCredentialRefreshFailure(.fx_login);
+            const active_source = app.auth.credentialSource();
+            const source = if (active_source) |active|
+                if (credentials.sourceRefreshable(active)) active else .fx_login
+            else
+                .fx_login;
+            return recoverCredentialFailure(app, source, err);
+        }
+
+        fn recoverCredentialFailure(app: *App, source: credentials.Source, err: anyerror) !bool {
+            debug_trace.logf("auth", "prompt credential refresh failed source={t} err={s}", .{ source, @errorName(err) });
+            if (app.auth.credentialSource() == source) app.auth.recordCredentialRefreshFailure(source);
             try app.auth.refreshSourceInventory(app.alloc);
             app.auth.openPicker(app.alloc);
             const failure = auth_runtime.FailureSnapshot{
-                .source = .fx_login,
+                .source = source,
                 .reason = .credential_refresh_failed,
             };
             const failure_text = try failure.renderText(app.alloc);
@@ -569,18 +709,32 @@ pub fn Runtime(comptime App: type) type {
                 @hasField(@TypeOf(app.session), "usage"))
             {
                 if (app.auth.gatewayCredential()) |credential| {
-                    app.session.usage.replaceReconciliationCredential(
-                        app.alloc,
-                        credential.api_key,
-                    );
+                    const chatgpt_subscription = if (comptime @hasField(@TypeOf(credential), "source"))
+                        credential.source == .chatgpt_subscription
+                    else
+                        false;
+                    if (chatgpt_subscription) {
+                        app.session.usage.clearReconciliationCredential();
+                    } else {
+                        app.session.usage.replaceReconciliationCredential(
+                            app.alloc,
+                            credential.api_key,
+                        );
+                    }
                 } else {
                     app.session.usage.clearReconciliationCredential();
                 }
             }
         }
 
-        fn writeLoginError(app: *App, err: anyerror) !void {
-            const notice: types.SemanticNotice = switch (err) {
+        fn writeLoginError(app: *App, source: credentials.Source, err: anyerror) !void {
+            const notice: types.SemanticNotice = if (source == .chatgpt_subscription)
+                switch (err) {
+                    error.ChatGptAuthorizationFailed => .{ .topic = "auth", .tone = .@"error", .body = "ChatGPT sign-in was denied. The current credential is unchanged." },
+                    error.ChatGptLoginTimedOut, error.LoginTimedOut => .{ .topic = "auth", .tone = .warning, .body = "The ChatGPT sign-in code expired. The current credential is unchanged; run /login to try again." },
+                    else => .{ .topic = "auth", .tone = .@"error", .body = "ChatGPT sign-in failed. The current credential is unchanged." },
+                }
+            else switch (err) {
                 error.ClientIdMissing => .{ .topic = "auth", .tone = .@"error", .body = "fx login is not configured yet. The current credential is unchanged." },
                 error.AccessDenied => .{ .topic = "auth", .tone = .@"error", .body = "Vercel sign-in was denied. The current credential is unchanged." },
                 error.ExpiredToken, error.LoginTimedOut => .{ .topic = "auth", .tone = .warning, .body = "The Vercel sign-in code expired. The current credential is unchanged; run /login to try again." },
@@ -1011,7 +1165,7 @@ test "successful direct login remembers fx login after activation" {
     var app: TestApp = .{};
     defer app.deinit();
     app.auth.select_result = true;
-    app.auth.sign_in_transition = .{ .succeeded = .{} };
+    app.auth.sign_in_transition = .{ .succeeded = .{ .vercel = .{} } };
 
     try Runtime(TestApp).collectSignInFacts(&app);
 
@@ -1025,7 +1179,7 @@ test "direct login source load failure leaves the environment preference unchang
     var app: TestApp = .{};
     defer app.deinit();
     app.auth.select_result = null;
-    app.auth.sign_in_transition = .{ .succeeded = .{} };
+    app.auth.sign_in_transition = .{ .succeeded = .{ .vercel = .{} } };
 
     try Runtime(TestApp).collectSignInFacts(&app);
 
@@ -1039,7 +1193,7 @@ test "failed preference persistence keeps a successful direct login active" {
     var app: TestApp = .{};
     defer app.deinit();
     app.auth.select_result = true;
-    app.auth.sign_in_transition = .{ .succeeded = .{} };
+    app.auth.sign_in_transition = .{ .succeeded = .{ .vercel = .{} } };
     app.preference_write_succeeds = false;
 
     try Runtime(TestApp).collectSignInFacts(&app);
@@ -1176,7 +1330,7 @@ test "prompt credential refresh failure is recoverable and detail-free" {
     try std.testing.expect(std.mem.find(u8, app.transcript.items, "OAuthRequestFailed") == null);
     try std.testing.expect(app.shell.render_requests.footer_requested);
     try std.testing.expectEqual(@as(usize, 1), app.auth.source_inventory_refresh_count);
-    try std.testing.expectEqual(credentials.Source.fx_login, app.auth.refresh_failure_source.?);
+    try std.testing.expect(app.auth.refresh_failure_source == null);
     try std.testing.expect(app.auth.picker_opened);
     try std.testing.expectEqual(@as(usize, 0), app.model_cache.reset_count);
 }

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -215,9 +215,17 @@ pub fn Runtime(comptime App: type) type {
                 startup.stored_key_status,
                 startup.credential_onboarding_skipped,
             );
+            if (comptime @hasDecl(@TypeOf(app.auth), "refreshChatGptSourceInventory")) {
+                app.auth.refreshChatGptSourceInventory(app.alloc) catch |err| {
+                    debug_trace.logf("auth", "startup ChatGPT inventory refresh failed err={s}", .{@errorName(err)});
+                };
+            } else {
+                app.auth.refreshSourceInventory(app.alloc) catch |err| {
+                    debug_trace.logf("auth", "startup source inventory refresh failed err={s}", .{@errorName(err)});
+                };
+            }
             const startup_auth_view = app.auth.view();
             if (startup_auth_view.active_source == null and !startup_auth_view.onboarding_skipped) {
-                try app.auth.refreshSourceInventory(app.alloc);
                 app.auth.openOnboardingPicker(app.alloc);
             }
             if (comptime @hasField(App, "terminal_input_runtime") and @hasField(App, "terminal")) {

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -363,7 +363,7 @@ pub fn Bindings(comptime App: type) type {
             mode: auth_runtime.CredentialRefreshMode,
         ) !?[]u8 {
             const app: *App = @ptrCast(@alignCast(raw_ctx));
-            return auth_runtime.refreshFxLoginToken(
+            return auth_runtime.refreshCredentialToken(
                 app.auth.oauthTransport(),
                 alloc,
                 source,

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -505,10 +505,10 @@ pub fn Handlers(comptime App: type) type {
             }
         }
 
-        fn commandLogout(ctx: *anyopaque) !void {
+        fn commandLogout(ctx: *anyopaque, rest: []const u8) !void {
             const app: *App = @ptrCast(@alignCast(ctx));
             if (comptime @hasDecl(App, "runLogoutCommand")) {
-                try app.runLogoutCommand();
+                try app.runLogoutCommand(rest);
             } else {
                 try app.writeDomainNotice(.{
                     .topic = "auth",
@@ -1541,6 +1541,10 @@ pub fn Handlers(comptime App: type) type {
             const app: *App = @ptrCast(@alignCast(ctx));
             var snapshot = app.creditsProvider().fetch(app.alloc, .{
                 .credential = app.auth.apiKey(),
+                .credential_source = if (comptime @hasDecl(@TypeOf(app.auth), "credentialSource"))
+                    app.auth.credentialSource()
+                else
+                    null,
                 .tenant = app.auth.gatewayTeam(),
             });
             defer snapshot.deinit(app.alloc);

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -3875,7 +3875,7 @@ test "app_input_runtime routes auth picker navigation before composer history" {
 
     try Runtime(RoutingFakeApp).routeModifiedHistory(&app, .down, 1);
 
-    try std.testing.expect((auth_runtime.Choice{ .action = .setup }).eql(app.auth.pickerView().selected_choice.?));
+    try std.testing.expect((auth_runtime.Choice{ .action = .chatgpt_login }).eql(app.auth.pickerView().selected_choice.?));
     try std.testing.expectEqual(@as(?usize, null), app.input_runtime.composer_history.activeIndex());
 }
 
@@ -3888,7 +3888,7 @@ test "app_input_runtime Tab cycles the active auth picker" {
 
     try Runtime(RoutingFakeApp).handleByte(&app, '\t', 4096, 100);
 
-    try std.testing.expect((auth_runtime.Choice{ .action = .setup }).eql(app.auth.pickerView().selected_choice.?));
+    try std.testing.expect((auth_runtime.Choice{ .action = .chatgpt_login }).eql(app.auth.pickerView().selected_choice.?));
 }
 
 test "app_input_runtime Tab leaves a dismissed slash query unchanged" {
@@ -4027,7 +4027,7 @@ test "app_input_runtime auth stage Escape pops before closing the picker" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..3) |_| _ = app.auth.movePicker(1);
+    for (0..4) |_| _ = app.auth.movePicker(1);
     try std.testing.expect((auth_runtime.Choice{ .action = .switch_credential }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -4055,7 +4055,7 @@ test "app_input_runtime disabled change team action stays silent" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..2) |_| _ = app.auth.movePicker(1);
+    for (0..3) |_| _ = app.auth.movePicker(1);
     try std.testing.expect((auth_runtime.Choice{ .action = .change_team }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -7663,7 +7663,7 @@ fn openRoutingAuthPicker(app: *RoutingFakeApp) !void {
     app.auth.source_inventory.insert(.ai_gateway_api_key);
     app.auth.openPicker(app.alloc);
     try std.testing.expect(app.auth.movePicker(1));
-    try std.testing.expectEqual(@as(usize, 4), app.auth.pickerView().choiceCount());
+    try std.testing.expectEqual(@as(usize, 5), app.auth.pickerView().choiceCount());
     try std.testing.expectEqual(@as(usize, 1), app.auth.pickerView().selectedIndex());
 }
 

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -320,7 +320,12 @@ pub fn loadStartupStatus(
     const selected_model = try loadStartupStatusModel(alloc, default_model, settings.model);
     errdefer if (selected_model.owned) |model| alloc.free(model);
 
-    var auth_status = try auth_runtime.loadStatusSnapshot(alloc, secret_store, settings.credential_source);
+    var auth_status = try auth_runtime.loadStatusSnapshotForModel(
+        alloc,
+        secret_store,
+        selected_model.value,
+        settings.credential_source,
+    );
     errdefer auth_status.deinit(alloc);
 
     const result = StartupStatus{
@@ -399,7 +404,14 @@ fn loadStartupStateFromOwnedWorkspace(
     state.prompt_history_enabled = settings.prompt_history_enabled orelse true;
     state.prompt_history_store_allowed = detailed.prompt_history_store_allowed;
     if (credential_mode) |mode| {
-        const resolution = try credentials.resolvePreferring(alloc, transport, secret_store, mode, settings.credential_source);
+        const resolution = try credentials.resolveForModel(
+            alloc,
+            transport,
+            secret_store,
+            mode,
+            state.selected_model,
+            settings.credential_source,
+        );
         state.credential = resolution.credential;
         state.stored_key_status = resolution.stored_key_status;
     }

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1561,6 +1561,12 @@ pub fn Runtime(comptime App: type) type {
 
         pub fn startResumedSessionReconciliation(app: *App) void {
             if (comptime @hasField(App, "auth")) {
+                if (comptime @hasDecl(@TypeOf(app.auth), "credentialSource")) {
+                    if (app.auth.credentialSource() == .chatgpt_subscription) {
+                        app.session.usage.clearReconciliationCredential();
+                        return;
+                    }
+                }
                 if (app.auth.apiKey()) |api_key| {
                     app.session.usage.startReconciliation(
                         app.alloc,
@@ -9347,6 +9353,53 @@ test "renameActiveSession persists the title to the sidecar and session index" {
     defer display.deinit(alloc);
     try std.testing.expect(display.present);
     try std.testing.expectEqualStrings("deploy pipeline fix", display.title);
+}
+
+const ReconciliationOriginUsage = struct {
+    started: usize = 0,
+    cleared: usize = 0,
+
+    fn startReconciliation(self: *@This(), _: Allocator, _: []const u8) void {
+        self.started += 1;
+    }
+
+    fn clearReconciliationCredential(self: *@This()) void {
+        self.cleared += 1;
+    }
+};
+
+const ReconciliationOriginAuth = struct {
+    source: types.CredentialSource,
+
+    fn credentialSource(self: *const @This()) ?types.CredentialSource {
+        return self.source;
+    }
+
+    fn apiKey(_: *const @This()) ?[]const u8 {
+        return "origin-bound-token";
+    }
+};
+
+const ReconciliationOriginApp = struct {
+    alloc: Allocator = std.testing.allocator,
+    auth: ReconciliationOriginAuth,
+    session: struct { usage: ReconciliationOriginUsage = .{} } = .{},
+};
+
+test "resumed ChatGPT sessions never start Gateway usage reconciliation" {
+    var chatgpt = ReconciliationOriginApp{
+        .auth = .{ .source = .chatgpt_subscription },
+    };
+    Runtime(ReconciliationOriginApp).startResumedSessionReconciliation(&chatgpt);
+    try std.testing.expectEqual(@as(usize, 0), chatgpt.session.usage.started);
+    try std.testing.expectEqual(@as(usize, 1), chatgpt.session.usage.cleared);
+
+    var gateway = ReconciliationOriginApp{
+        .auth = .{ .source = .ai_gateway_api_key },
+    };
+    Runtime(ReconciliationOriginApp).startResumedSessionReconciliation(&gateway);
+    try std.testing.expectEqual(@as(usize, 1), gateway.session.usage.started);
+    try std.testing.expectEqual(@as(usize, 0), gateway.session.usage.cleared);
 }
 
 test "ensureCachedSessionTitle derives from the first prompt and then freezes" {

--- a/src/core/app/model_cache_runtime.zig
+++ b/src/core/app/model_cache_runtime.zig
@@ -83,6 +83,7 @@ pub const ModelMenuLoadState = enum {
 
 pub const ModelMenuCatalogState = struct {
     access_level: ?model_catalog.AccessLevel = null,
+    source: ?credentials.Source = null,
     public_only_reason: ?credentials.CatalogPublicOnlyReason = null,
     private_models_hidden: bool = false,
     failure: ?Failure = null,
@@ -244,7 +245,8 @@ fn modelMenuItemMatches(
 fn providerMatchesFilter(provider: []const u8, filter: ModelProviderFilter) bool {
     const known_filter: ?ModelProviderFilter = if (std.ascii.eqlIgnoreCase(provider, "anthropic"))
         .anthropic
-    else if (std.ascii.eqlIgnoreCase(provider, "openai"))
+    else if (std.ascii.eqlIgnoreCase(provider, "openai") or
+        std.ascii.eqlIgnoreCase(provider, "openai-codex"))
         .openai
     else if (std.ascii.eqlIgnoreCase(provider, "xai"))
         .xai
@@ -688,6 +690,7 @@ fn modelMenuCatalogState(outcome: CatalogOutcome) ModelMenuCatalogState {
         null;
     return .{
         .access_level = access.level,
+        .source = access.source,
         .public_only_reason = access.public_only_reason,
         .private_models_hidden = access.private_models_may_be_hidden,
         .failure = if (failure) |failed| .{
@@ -1320,6 +1323,11 @@ test "model menu owns resolved catalog state and filters without changing catalo
     const selected = (try runtime.menu.selectedModelAlloc(alloc)).?;
     defer alloc.free(selected);
     try std.testing.expectEqualStrings("standalone", selected);
+}
+
+test "OpenAI provider tab includes ChatGPT subscription models" {
+    try std.testing.expect(providerMatchesFilter("openai-codex", .openai));
+    try std.testing.expect(!providerMatchesFilter("openai-codex", .others));
 }
 
 test "model menu snapshot construction cleans every allocation failure" {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1,8 +1,11 @@
 const std = @import("std");
 const api_key_validator = @import("api_key_validator.zig");
 const credentials = @import("credentials.zig");
+const chatgpt_oauth = @import("chatgpt_oauth.zig");
 const host = @import("../hosts/host.zig");
+const host_target = @import("../hosts/target.zig");
 const login_flow = @import("login_flow.zig");
+const model_provider = @import("../config/model_provider.zig");
 const oauth_transport = @import("oauth_transport.zig");
 const secret = @import("secret.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
@@ -23,6 +26,7 @@ const credential_source_order = [_]credentials.Source{
     .ai_gateway_api_key,
     .fx_login,
     .stored_key,
+    .chatgpt_subscription,
 };
 
 const SourceProbeFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!bool;
@@ -95,19 +99,26 @@ pub const FailureSnapshot = struct {
     }
 };
 
-/// Returns an owned token when the selected fx-login credential can be
-/// refreshed. The caller must release it with `secret.zeroAndFree`.
-pub fn refreshFxLoginToken(
+/// Returns an owned token when the selected provider credential can refresh.
+/// The caller must release it with `secret.zeroAndFree`.
+pub fn refreshCredentialToken(
     transport: oauth_transport.Provider,
     alloc: Allocator,
     source: credentials.Source,
     mode: CredentialRefreshMode,
 ) !?[]u8 {
-    if (source != .fx_login) return null;
+    if (!credentials.sourceRefreshable(source)) return null;
 
-    var credential = switch (mode) {
-        .if_needed => (try credentials.loadFxLoginCredential(alloc, transport)) orelse return null,
-        .force => (try credentials.refreshFxLoginCredential(alloc, transport)) orelse return null,
+    var credential = switch (source) {
+        .fx_login => switch (mode) {
+            .if_needed => (try credentials.loadFxLoginCredential(alloc, transport)) orelse return null,
+            .force => (try credentials.refreshFxLoginCredential(alloc, transport)) orelse return null,
+        },
+        .chatgpt_subscription => switch (mode) {
+            .if_needed => (try credentials.loadSource(alloc, transport, host.unavailable_secret_store, source)) orelse return null,
+            .force => (try credentials.refreshChatGptCredential(alloc, transport)) orelse return null,
+        },
+        else => unreachable,
     };
     defer credential.deinit(alloc);
 
@@ -118,6 +129,7 @@ pub fn refreshFxLoginToken(
 
 pub const AcquisitionAction = enum {
     login,
+    chatgpt_login,
     setup,
     change_team,
     switch_credential,
@@ -336,6 +348,7 @@ pub const PickerView = struct {
     current_team: ?[]const u8 = null,
     team_query: []const u8 = &.{},
     sign_in: login_flow.SignInSnapshot = .{},
+    sign_in_source: credentials.Source = .fx_login,
     api_key_mask_count: usize = 0,
 
     pub fn activeSourceLabel(self: PickerView) []const u8 {
@@ -344,7 +357,12 @@ pub const PickerView = struct {
 
     pub fn choiceCount(self: PickerView) usize {
         return switch (self.stage) {
-            .root => if (self.include_skip) 2 else 4,
+            .root => if (self.include_skip)
+                if (comptime host_target.is_wasm) 2 else 3
+            else if (comptime host_target.is_wasm)
+                4
+            else
+                5,
             .sign_in, .api_key => 0,
             .change_team => blk: {
                 var count: usize = 0;
@@ -353,23 +371,39 @@ pub const PickerView = struct {
                 }
                 break :blk count;
             },
-            .switch_credential => self.available_sources.count() + 1,
+            .switch_credential => gatewaySourceCount(self.available_sources) + 1,
         };
     }
 
     pub fn choiceAt(self: PickerView, index: usize) ?Choice {
         return switch (self.stage) {
             .root => if (self.include_skip)
+                if (comptime host_target.is_wasm)
+                    switch (index) {
+                        0 => .{ .action = .login },
+                        1 => .{ .action = .setup },
+                        else => null,
+                    }
+                else switch (index) {
+                    0 => .{ .action = .login },
+                    1 => .{ .action = .chatgpt_login },
+                    2 => .{ .action = .setup },
+                    else => null,
+                }
+            else if (comptime host_target.is_wasm)
                 switch (index) {
                     0 => .{ .action = .login },
                     1 => .{ .action = .setup },
+                    2 => .{ .action = .change_team },
+                    3 => .{ .action = .switch_credential },
                     else => null,
                 }
             else switch (index) {
                 0 => .{ .action = .login },
-                1 => .{ .action = .setup },
-                2 => .{ .action = .change_team },
-                3 => .{ .action = .switch_credential },
+                1 => .{ .action = .chatgpt_login },
+                2 => .{ .action = .setup },
+                3 => .{ .action = .change_team },
+                4 => .{ .action = .switch_credential },
                 else => null,
             },
             .sign_in, .api_key => null,
@@ -382,9 +416,9 @@ pub const PickerView = struct {
                 }
                 break :blk null;
             },
-            .switch_credential => if (index < self.available_sources.count())
-                .{ .source = sourceAtIndex(self.available_sources, index).? }
-            else if (index == self.available_sources.count())
+            .switch_credential => if (index < gatewaySourceCount(self.available_sources))
+                .{ .source = gatewaySourceAtIndex(self.available_sources, index).? }
+            else if (index == gatewaySourceCount(self.available_sources))
                 .{ .action = .automatic }
             else
                 null,
@@ -410,6 +444,7 @@ pub const PickerView = struct {
             .source => |source| credentials.sourceLabel(source),
             .action => |action| switch (action) {
                 .login => "Sign in with Vercel",
+                .chatgpt_login => "Sign in with ChatGPT",
                 .setup => if (self.include_skip) "Add an API key" else "API key",
                 .change_team => "Change team",
                 .switch_credential => "Switch credential",
@@ -423,7 +458,9 @@ pub const PickerView = struct {
         return switch (choice) {
             .source => |source| if (self.active_source == source) "current" else "available",
             .action => |action| switch (action) {
-                .login, .setup, .switch_credential => "",
+                .login => if (self.fx_login_session_available) "connected" else "",
+                .chatgpt_login => if (self.available_sources.contains(.chatgpt_subscription)) "connected" else "",
+                .setup, .switch_credential => "",
                 .automatic => "use normal precedence",
                 .change_team => if (self.fx_login_session_available) "choose a team" else "sign in first",
             },
@@ -433,7 +470,8 @@ pub const PickerView = struct {
 
     pub fn choiceEnabled(self: PickerView, choice: Choice) bool {
         return switch (choice) {
-            .action => |action| action != .change_team or self.fx_login_session_available,
+            .action => |action| (action != .change_team or self.fx_login_session_available) and
+                (action != .chatgpt_login or !host_target.is_wasm),
             .source, .team => true,
         };
     }
@@ -472,9 +510,12 @@ pub const MissingHelpSurface = enum {
 
 pub const StatusSnapshot = struct {
     active_source: ?credentials.Source = null,
+    required_source: ?credentials.Source = null,
     team: ?[]const u8 = null,
     owned_team: ?[]u8 = null,
     stored_key_status: credentials.StoredKeyReadStatus = .not_attempted,
+    gateway_connected: bool = false,
+    chatgpt_connected: bool = false,
     /// The active credential is past its refresh deadline. Distinct from `refreshable`,
     /// which answers whether this source type can refresh at all.
     expired: bool = false,
@@ -496,6 +537,12 @@ pub const StatusSnapshot = struct {
     pub fn missingHelp(self: StatusSnapshot, surface: MissingHelpSurface) ?[]const u8 {
         if (self.active_source != null) return null;
         if (self.stored_key_status == .unavailable) return credentials.unreadable_store_message;
+        if (self.required_source == .chatgpt_subscription) {
+            return switch (surface) {
+                .cli => credentials.missing_chatgpt_credential_message,
+                .interactive => credentials.missing_chatgpt_interactive_credential_message,
+            };
+        }
         return switch (surface) {
             .cli => credentials.missing_credential_message,
             .interactive => credentials.missing_interactive_credential_message,
@@ -522,16 +569,43 @@ pub fn loadStatusSnapshot(
     secret_store: host.SecretStore,
     preferred: ?credentials.Source,
 ) !StatusSnapshot {
+    return loadStatusSnapshotForModel(alloc, secret_store, null, preferred);
+}
+
+pub fn loadStatusSnapshotForModel(
+    alloc: Allocator,
+    secret_store: host.SecretStore,
+    model: ?[]const u8,
+    preferred: ?credentials.Source,
+) !StatusSnapshot {
+    const chatgpt_connected = credentials.sourceExists(
+        alloc,
+        secret_store,
+        .chatgpt_subscription,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => false,
+    };
     // Resolves in `.stored` mode: a diagnostic must not refresh, because refreshing
     // rewrites the session file and performs network I/O. It reports the expired state
     // instead of repairing it.
-    const resolution = credentials.resolvePreferring(
-        alloc,
-        oauth_transport.unavailable_provider,
-        secret_store,
-        .stored,
-        preferred,
-    ) catch |err| switch (err) {
+    const resolution = (if (model) |selected_model|
+        credentials.resolveForModel(
+            alloc,
+            oauth_transport.unavailable_provider,
+            secret_store,
+            .stored,
+            selected_model,
+            preferred,
+        )
+    else
+        credentials.resolvePreferring(
+            alloc,
+            oauth_transport.unavailable_provider,
+            secret_store,
+            .stored,
+            preferred,
+        )) catch |err| switch (err) {
         error.OutOfMemory => return err,
         // The store could not be interrogated, so its contents are unknown rather than absent.
         else => blk: {
@@ -539,6 +613,21 @@ pub fn loadStatusSnapshot(
             break :blk credentials.Resolution{ .stored_key_status = .unavailable };
         },
     };
+    const resolved_source = if (resolution.credential) |credential| credential.source else null;
+    var gateway_connected = resolved_source != null and resolved_source != .chatgpt_subscription;
+    const gateway_probe_required = (model != null and model_provider.isChatGptSubscriptionModel(model.?)) or
+        resolved_source == .chatgpt_subscription;
+    if (gateway_probe_required) {
+        for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key }) |source| {
+            if (credentials.sourceExists(alloc, secret_store, source) catch |err| switch (err) {
+                error.OutOfMemory => return err,
+                else => false,
+            }) {
+                gateway_connected = true;
+                break;
+            }
+        }
+    }
     if (resolution.credential) |loaded| {
         var credential = loaded;
         defer credential.deinit(alloc);
@@ -549,10 +638,20 @@ pub fn loadStatusSnapshot(
             .team = owned_team,
             .owned_team = owned_team,
             .stored_key_status = resolution.stored_key_status,
+            .gateway_connected = gateway_connected,
+            .chatgpt_connected = chatgpt_connected,
             .expired = expired,
         };
     }
-    return .{ .stored_key_status = resolution.stored_key_status };
+    return .{
+        .required_source = if (model) |selected_model|
+            if (model_provider.isChatGptSubscriptionModel(selected_model)) .chatgpt_subscription else null
+        else
+            null,
+        .stored_key_status = resolution.stored_key_status,
+        .gateway_connected = gateway_connected,
+        .chatgpt_connected = chatgpt_connected,
+    };
 }
 
 pub const View = struct {
@@ -598,6 +697,7 @@ pub const Runtime = struct {
     team_selection: ?login_flow.TeamSelection = null,
     team_query: std.ArrayList(u8) = .empty,
     sign_in_flow: login_flow.SignInRuntime = .{},
+    sign_in_source: credentials.Source = .fx_login,
     sign_in_returns_to_root: bool = false,
     api_key_input: std.ArrayList(u8) = .empty,
     api_key_returns_to_root: bool = false,
@@ -649,6 +749,10 @@ pub const Runtime = struct {
         return self.oauth_transport;
     }
 
+    pub fn secretStore(self: *const Self) host.SecretStore {
+        return self.secret_store;
+    }
+
     pub fn modelCatalogAccess(self: *const Self) credentials.CatalogAccess {
         if (self.credential_refresh_failure_source) |source| {
             return credentials.catalogAccessAfterRefreshFailure(source);
@@ -685,10 +789,20 @@ pub const Runtime = struct {
     }
 
     fn statusSnapshotAt(self: *const Self, now_ms: i64) StatusSnapshot {
-        const credential = self.selected_credential orelse return .{};
+        const gateway_connected = self.source_inventory.contains(.vercel_oidc_token) or
+            self.source_inventory.contains(.ai_gateway_api_key) or
+            self.source_inventory.contains(.fx_login) or
+            self.source_inventory.contains(.stored_key);
+        const chatgpt_connected = self.source_inventory.contains(.chatgpt_subscription);
+        const credential = self.selected_credential orelse return .{
+            .gateway_connected = gateway_connected,
+            .chatgpt_connected = chatgpt_connected,
+        };
         return .{
             .active_source = credential.source,
             .team = displayTeam(credential),
+            .gateway_connected = gateway_connected,
+            .chatgpt_connected = chatgpt_connected,
             .expired = credential.needsRefreshAt(now_ms),
         };
     }
@@ -723,6 +837,14 @@ pub const Runtime = struct {
 
     pub fn refreshSourceInventory(self: *Self, alloc: Allocator) !void {
         try self.refreshSourceInventoryWithProbe(alloc, self, probeCredentialSource);
+    }
+
+    pub fn refreshChatGptSourceInventory(self: *Self, alloc: Allocator) !void {
+        if (try credentials.sourceExists(alloc, self.secret_store, .chatgpt_subscription)) {
+            self.source_inventory.insert(.chatgpt_subscription);
+        } else if (self.credentialSource() != .chatgpt_subscription) {
+            self.source_inventory.remove(.chatgpt_subscription);
+        }
     }
 
     fn refreshSourceInventoryWithProbe(
@@ -771,6 +893,7 @@ pub const Runtime = struct {
             .current_team = if (self.team_selection) |*selection| selection.currentTeam() else null,
             .team_query = self.team_query.items,
             .sign_in = self.sign_in_flow.snapshot(),
+            .sign_in_source = self.sign_in_source,
             .api_key_mask_count = @min(self.api_key_input.items.len, max_api_key_mask_glyphs),
         };
     }
@@ -833,7 +956,10 @@ pub const Runtime = struct {
         self.picker_stage = .switch_credential;
         const active_source = self.credentialSource();
         self.picker_selection = if (active_source) |source|
-            .{ .source = source }
+            if (source != .chatgpt_subscription and self.source_inventory.contains(source))
+                .{ .source = source }
+            else
+                self.pickerView().choiceAt(0)
         else
             self.pickerView().choiceAt(0);
     }
@@ -857,21 +983,37 @@ pub const Runtime = struct {
     }
 
     pub fn openSignInPicker(self: *Self, alloc: Allocator) !bool {
-        return self.openSignInPickerWithParent(alloc, false);
+        return self.openSignInPickerWithParent(alloc, false, .fx_login);
     }
 
     pub fn openSignInPickerFromRoot(self: *Self, alloc: Allocator) !bool {
-        return self.openSignInPickerWithParent(alloc, true);
+        return self.openSignInPickerWithParent(alloc, true, .fx_login);
     }
 
-    fn openSignInPickerWithParent(self: *Self, alloc: Allocator, returns_to_root: bool) !bool {
+    pub fn openChatGptSignInPickerFromRoot(self: *Self, alloc: Allocator) !bool {
+        if (comptime host_target.is_wasm) return error.ChatGptOAuthUnavailable;
+        return self.openSignInPickerWithParent(alloc, true, .chatgpt_subscription);
+    }
+
+    fn openSignInPickerWithParent(
+        self: *Self,
+        alloc: Allocator,
+        returns_to_root: bool,
+        source: credentials.Source,
+    ) !bool {
         self.exitSignInStage(alloc);
-        if (!try self.sign_in_flow.start(alloc, self.oauth_transport)) return false;
+        const started = switch (source) {
+            .fx_login => try self.sign_in_flow.start(alloc, self.oauth_transport),
+            .chatgpt_subscription => try chatgpt_oauth.startSignIn(&self.sign_in_flow, alloc, self.oauth_transport),
+            else => return error.InvalidSignInSource,
+        };
+        if (!started) return false;
         self.exitApiKeyStage(alloc, .screen_replacement);
         self.clearTeamSelection(alloc);
         self.picker_active = true;
         self.picker_stage = .sign_in;
         self.picker_selection = null;
+        self.sign_in_source = source;
         self.sign_in_returns_to_root = returns_to_root;
         return true;
     }
@@ -999,7 +1141,7 @@ pub const Runtime = struct {
         self.picker_stage = .root;
         self.picker_selection = .{ .action = switch (stage) {
             .root => unreachable,
-            .sign_in => .login,
+            .sign_in => if (self.sign_in_source == .chatgpt_subscription) .chatgpt_login else .login,
             .api_key => .setup,
             .change_team => .change_team,
             .switch_credential => .switch_credential,
@@ -1035,7 +1177,7 @@ pub const Runtime = struct {
                     .setup => {},
                     // Only reachable from the switch screen, never the root.
                     .automatic => unreachable,
-                    .login => self.closePicker(alloc),
+                    .login, .chatgpt_login => self.closePicker(alloc),
                 },
                 .team => unreachable,
             },
@@ -1120,11 +1262,39 @@ pub const Runtime = struct {
         return self.selectSourceWithLoader(alloc, source, self, loadRuntimeCredentialSource);
     }
 
+    /// Keeps the active credential on the same provider route as the model.
+    /// Returns null when the required route has no saved credential.
+    pub fn selectForModel(self: *Self, alloc: Allocator, model: []const u8) !?bool {
+        return self.selectForModelWithDeps(
+            alloc,
+            model,
+            self,
+            probeCredentialSource,
+            loadRuntimeCredentialSource,
+        );
+    }
+
+    fn selectForModelWithDeps(
+        self: *Self,
+        alloc: Allocator,
+        model: []const u8,
+        ctx: ?*anyopaque,
+        probe: SourceProbeFn,
+        loader: CredentialLoaderFn,
+    ) !?bool {
+        if (model_provider.isChatGptSubscriptionModel(model)) {
+            if (self.credentialSource() == .chatgpt_subscription) return false;
+            return self.selectSourceWithLoader(alloc, .chatgpt_subscription, ctx, loader);
+        }
+        if (self.credentialSource() != .chatgpt_subscription) return false;
+        return @as(?bool, try self.reselectByPrecedenceWithDeps(alloc, ctx, probe, loader));
+    }
+
     pub fn refreshFxLoginIfNeeded(self: *Self, alloc: Allocator) !bool {
         const source = self.credentialSource() orelse return false;
-        if (source != .fx_login) return false;
+        if (!credentials.sourceRefreshable(source)) return false;
 
-        const loaded = (try credentials.loadFxLoginCredential(alloc, self.oauth_transport)) orelse {
+        const loaded = (try credentials.loadSource(alloc, self.oauth_transport, self.secret_store, source)) orelse {
             if (self.credentialNeedsRefresh()) return error.CredentialRefreshUnavailable;
             return false;
         };
@@ -1153,6 +1323,7 @@ pub const Runtime = struct {
 
         try self.refreshSourceInventoryWithProbe(alloc, ctx, probe);
         for (credential_source_order) |source| {
+            if (source == .chatgpt_subscription) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) {
                 return self.credentialSource() != previous;
@@ -1161,6 +1332,18 @@ pub const Runtime = struct {
         }
         self.onboarding_skipped = false;
         return previous != null;
+    }
+
+    pub fn reconcileAfterChatGptLogout(self: *Self, alloc: Allocator) !bool {
+        const was_available = self.source_inventory.contains(.chatgpt_subscription);
+        const was_active = self.credentialSource() == .chatgpt_subscription;
+        if (was_active) {
+            if (self.selected_credential) |*credential| credential.deinit(alloc);
+            self.selected_credential = null;
+            self.credential_refresh_failure_source = null;
+        }
+        try self.refreshSourceInventory(alloc);
+        return was_active or was_available;
     }
 
     pub fn reconcileAfterFxLoginLogout(self: *Self, alloc: Allocator) !bool {
@@ -1190,6 +1373,7 @@ pub const Runtime = struct {
         if (!login_was_active) return false;
 
         for (credential_source_order) |source| {
+            if (source == .chatgpt_subscription) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) return true;
             self.source_inventory.remove(source);
@@ -1282,10 +1466,19 @@ fn takeDisplayTeam(alloc: Allocator, credential: *credentials.Credential) ?[]u8 
     return team;
 }
 
-fn sourceAtIndex(sources: SourceSet, wanted_index: usize) ?credentials.Source {
+fn gatewaySourceCount(sources: SourceSet) usize {
+    var count: usize = 0;
+    for (credential_source_order) |source| {
+        if (source == .chatgpt_subscription or !sources.contains(source)) continue;
+        count += 1;
+    }
+    return count;
+}
+
+fn gatewaySourceAtIndex(sources: SourceSet, wanted_index: usize) ?credentials.Source {
     var index: usize = 0;
     for (credential_source_order) |source| {
-        if (!sources.contains(source)) continue;
+        if (source == .chatgpt_subscription or !sources.contains(source)) continue;
         if (index == wanted_index) return source;
         index += 1;
     }
@@ -1437,7 +1630,7 @@ fn expectApiKeyAllocationCleared(
 
 test "auth runtime token refresher ignores non-refreshable credential sources" {
     for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .stored_key }) |source| {
-        try std.testing.expect((try refreshFxLoginToken(
+        try std.testing.expect((try refreshCredentialToken(
             oauth_transport.unavailable_provider,
             std.testing.allocator,
             source,
@@ -1834,6 +2027,38 @@ const LogoutFixture = struct {
     }
 };
 
+test "model routing switches between independent ChatGPT and Gateway credentials" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    var gateway = try makeTestCredential(alloc, "gateway", .ai_gateway_api_key, null, null);
+    defer gateway.deinit(alloc);
+    _ = runtime.adoptCredential(alloc, &gateway);
+
+    var fixture = LogoutFixture{
+        .existing = SourceSet.initMany(&.{ .ai_gateway_api_key, .chatgpt_subscription }),
+    };
+    try std.testing.expect((try runtime.selectForModelWithDeps(
+        alloc,
+        "openai-codex/gpt-5.4",
+        &fixture,
+        LogoutFixture.probe,
+        LogoutFixture.load,
+    )).?);
+    try std.testing.expectEqual(credentials.Source.chatgpt_subscription, runtime.credentialSource().?);
+    try std.testing.expectEqualStrings("chatgpt_subscription", runtime.apiKey().?);
+
+    try std.testing.expect((try runtime.selectForModelWithDeps(
+        alloc,
+        "anthropic/claude-sonnet-4.6",
+        &fixture,
+        LogoutFixture.probe,
+        LogoutFixture.load,
+    )).?);
+    try std.testing.expectEqual(credentials.Source.ai_gateway_api_key, runtime.credentialSource().?);
+    try std.testing.expectEqualStrings("ai_gateway_api_key", runtime.apiKey().?);
+}
+
 test "logout replaces an active fx login with the next available source" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
@@ -1945,16 +2170,32 @@ test "auth picker root starts on sign in and keeps sources in the switch stage" 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.active);
     try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
-    try std.testing.expectEqual(@as(usize, 4), picker.choiceCount());
-    try std.testing.expect(picker.choiceAt(4) == null);
+    try std.testing.expectEqual(@as(usize, 5), picker.choiceCount());
+    try std.testing.expect(picker.choiceAt(5) == null);
 }
 
-test "auth picker navigation wraps across the four hub actions" {
+test "credential switcher excludes provider-routed ChatGPT sessions" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .chatgpt_subscription });
+    runtime.openPicker(alloc);
+    runtime.openSwitchCredentialPicker(alloc);
+
+    const picker = runtime.pickerView();
+    try std.testing.expectEqual(@as(usize, 2), picker.choiceCount());
+    try std.testing.expect((Choice{ .source = .ai_gateway_api_key }).eql(picker.choiceAt(0).?));
+    try std.testing.expect((Choice{ .action = .automatic }).eql(picker.choiceAt(1).?));
+}
+
+test "auth picker navigation wraps across the five hub actions" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .fx_login });
     runtime.openPicker(alloc);
 
+    try std.testing.expect(runtime.movePicker(1));
+    try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expect((Choice{ .action = .setup }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
@@ -1988,23 +2229,24 @@ test "auth picker without credentials exposes acquisition actions" {
     try std.testing.expect(picker.active_source == null);
     try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
     try std.testing.expectEqual(@as(usize, 0), picker.available_sources.count());
-    try std.testing.expectEqual(@as(usize, 4), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 5), picker.choiceCount());
     try std.testing.expect(!picker.choiceEnabled(.{ .action = .change_team }));
     try std.testing.expectEqualStrings("missing", picker.activeSourceLabel());
 }
 
-test "auth onboarding picker exposes only the two setup paths" {
+test "auth onboarding picker exposes the setup paths" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     runtime.openOnboardingPicker(alloc);
 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.include_skip);
-    try std.testing.expectEqual(@as(usize, 2), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 3), picker.choiceCount());
     try std.testing.expect((Choice{ .action = .login }).eql(picker.choiceAt(0).?));
-    try std.testing.expect((Choice{ .action = .setup }).eql(picker.choiceAt(1).?));
-    try std.testing.expectEqualStrings("Add an API key", picker.choiceLabel(picker.choiceAt(1).?));
-    try std.testing.expect(picker.choiceAt(2) == null);
+    try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(picker.choiceAt(1).?));
+    try std.testing.expect((Choice{ .action = .setup }).eql(picker.choiceAt(2).?));
+    try std.testing.expectEqualStrings("Add an API key", picker.choiceLabel(picker.choiceAt(2).?));
+    try std.testing.expect(picker.choiceAt(3) == null);
 }
 
 test "clearing a remembered choice re-resolves even when no login was active" {

--- a/src/core/auth/chatgpt_oauth.zig
+++ b/src/core/auth/chatgpt_oauth.zig
@@ -1,0 +1,922 @@
+const std = @import("std");
+const chatgpt_session = @import("chatgpt_session.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
+const host = @import("../hosts/host.zig");
+const io_mod = @import("../shared/io.zig");
+const login_flow = @import("login_flow.zig");
+const oauth = @import("oauth.zig");
+const oauth_transport = @import("oauth_transport.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const client_id = "app_EMoamEEZ73f0CkXaXp7hrann";
+pub const token_url = "https://auth.openai.com/oauth/token";
+pub const device_user_code_url = "https://auth.openai.com/api/accounts/deviceauth/usercode";
+pub const device_token_url = "https://auth.openai.com/api/accounts/deviceauth/token";
+pub const device_verification_uri = "https://auth.openai.com/codex/device";
+pub const device_redirect_uri = "https://auth.openai.com/deviceauth/callback";
+pub const device_code_timeout_seconds: i64 = 15 * 60;
+const e2e_device_user_code_url_env = "FX_E2E_CHATGPT_DEVICE_USER_CODE_URL";
+const e2e_device_token_url_env = "FX_E2E_CHATGPT_DEVICE_TOKEN_URL";
+const e2e_token_url_env = "FX_E2E_CHATGPT_TOKEN_URL";
+const jwt_auth_claim = "https://api.openai.com/auth";
+
+pub const RefreshMode = enum {
+    if_needed,
+    force,
+    stored,
+};
+
+pub const Access = struct {
+    access_token: []u8,
+    account_id: []u8,
+    refresh_after_ms: i64,
+
+    pub fn deinit(self: *Access, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.access_token);
+        alloc.free(self.account_id);
+        self.* = undefined;
+    }
+};
+
+const DeviceAuthorization = struct {
+    device_auth_id: []u8,
+    user_code: []u8,
+    interval_seconds: i64,
+
+    fn deinit(self: *DeviceAuthorization, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.device_auth_id);
+        alloc.free(self.user_code);
+        self.* = undefined;
+    }
+};
+
+const DeviceToken = struct {
+    authorization_code: []u8,
+    code_verifier: []u8,
+
+    fn deinit(self: *DeviceToken, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.authorization_code);
+        secret.zeroAndFree(alloc, self.code_verifier);
+        self.* = undefined;
+    }
+};
+
+const TokenSet = struct {
+    access_token: []u8,
+    refresh_token: []u8,
+    expires_in: i64,
+
+    fn deinit(self: *TokenSet, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.access_token);
+        secret.zeroAndFree(alloc, self.refresh_token);
+        self.* = undefined;
+    }
+};
+
+pub fn startSignIn(
+    runtime: *login_flow.SignInRuntime,
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+) !bool {
+    return runtime.startPrepared(
+        alloc,
+        try prepareSignIn(alloc, transport),
+        .{
+            .oauth_transport = transport,
+            .poll = .{ .poll_device_token = pollSignInDeviceToken },
+            .complete = completeSignIn,
+            .save = saveSignIn,
+        },
+    );
+}
+
+fn prepareSignIn(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+) !login_flow.PreparedLogin {
+    const user_code_endpoint = try configuredEndpoint(alloc, e2e_device_user_code_url_env, device_user_code_url);
+    defer alloc.free(user_code_endpoint);
+    const device_token_endpoint = try configuredEndpoint(alloc, e2e_device_token_url_env, device_token_url);
+    errdefer alloc.free(device_token_endpoint);
+    const configured_token_endpoint = try configuredEndpoint(alloc, e2e_token_url_env, token_url);
+    errdefer alloc.free(configured_token_endpoint);
+    var device = try requestDeviceAuthorizationAt(alloc, transport, user_code_endpoint);
+    defer device.deinit(alloc);
+
+    var poll_payload: std.Io.Writer.Allocating = .init(alloc);
+    defer poll_payload.deinit();
+    try poll_payload.writer.writeAll("{\"device_auth_id\":");
+    try std.json.Stringify.value(device.device_auth_id, .{}, &poll_payload.writer);
+    try poll_payload.writer.writeAll(",\"user_code\":");
+    try std.json.Stringify.value(device.user_code, .{}, &poll_payload.writer);
+    try poll_payload.writer.writeByte('}');
+
+    const issuer = try alloc.dupe(u8, "https://auth.openai.com");
+    errdefer alloc.free(issuer);
+    const device_endpoint = device_token_endpoint;
+    const owned_token_url = configured_token_endpoint;
+    const device_code = try poll_payload.toOwnedSlice();
+    errdefer secret.zeroAndFree(alloc, device_code);
+    const user_code = device.user_code;
+    device.user_code = &.{};
+    errdefer alloc.free(user_code);
+    const verification_uri = try alloc.dupe(u8, device_verification_uri);
+    errdefer alloc.free(verification_uri);
+    const owned_client_id = try alloc.dupe(u8, client_id);
+    errdefer alloc.free(owned_client_id);
+
+    return .{
+        .metadata = .{
+            .issuer = issuer,
+            .device_authorization_endpoint = device_endpoint,
+            .token_endpoint = owned_token_url,
+        },
+        .device = .{
+            .device_code = device_code,
+            .user_code = user_code,
+            .verification_uri = verification_uri,
+            .expires_in = device_code_timeout_seconds,
+            .interval = device.interval_seconds,
+        },
+        .client_id = owned_client_id,
+    };
+}
+
+fn pollSignInDeviceToken(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    metadata: oauth.Metadata,
+    _: []const u8,
+    poll_payload: []const u8,
+    cancel_flag: *std.atomic.Value(bool),
+    deadline: std.Io.Clock.Timestamp,
+) !oauth.PollResult {
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    var response = try transport.execute(alloc, .{
+        .method = .post_json,
+        .url = metadata.device_authorization_endpoint,
+        .payload = poll_payload,
+        .cancel_flag = cancel_flag,
+        .deadline = deadline,
+    });
+    defer response.deinit(alloc);
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (response.disposition != .accepted) {
+        return switch (devicePollDisposition(alloc, response.body)) {
+            .pending => .pending,
+            .slow_down => .slow_down,
+            .failed => error.ChatGptAuthorizationFailed,
+        };
+    }
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, response.body, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidChatGptOAuthResponse;
+    const authorization_code = try dupeRequiredString(alloc, parsed.value.object, "authorization_code");
+    defer secret.zeroAndFree(alloc, authorization_code);
+    const code_verifier = try dupeRequiredString(alloc, parsed.value.object, "code_verifier");
+    defer secret.zeroAndFree(alloc, code_verifier);
+    var token = try exchangeAuthorizationCodeBounded(
+        alloc,
+        transport,
+        metadata.token_endpoint,
+        authorization_code,
+        code_verifier,
+        cancel_flag,
+        deadline,
+    );
+    errdefer token.deinit(alloc);
+    const scope = try alloc.dupe(u8, "");
+    errdefer alloc.free(scope);
+    const token_type = try alloc.dupe(u8, "Bearer");
+    errdefer alloc.free(token_type);
+    const access_token = token.access_token;
+    token.access_token = &.{};
+    const refresh_token = token.refresh_token;
+    token.refresh_token = &.{};
+    return .{ .success = .{
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+        .expires_in = token.expires_in,
+        .scope = scope,
+        .token_type = token_type,
+    } };
+}
+
+fn completeSignIn(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    _: []const u8,
+    _: []const u8,
+    token: *oauth.TokenSet,
+) !login_flow.SignInCompletion {
+    const refresh_token = token.refresh_token orelse return error.ChatGptRefreshTokenMissing;
+    const account_id = try extractAccountId(alloc, token.access_token);
+    errdefer alloc.free(account_id);
+    const duration_ms = std.math.mul(i64, token.expires_in, std.time.ms_per_s) catch
+        return error.InvalidChatGptOAuthResponse;
+    const expires_at_ms = std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
+        return error.InvalidChatGptOAuthResponse;
+    const completion: login_flow.SignInCompletion = .{ .chatgpt = .{
+        .access_token = token.access_token,
+        .refresh_token = refresh_token,
+        .expires_at_ms = expires_at_ms,
+        .account_id = account_id,
+    } };
+    token.access_token = &.{};
+    token.refresh_token = null;
+    return completion;
+}
+
+fn saveSignIn(_: ?*anyopaque, alloc: Allocator, completion: login_flow.SignInCompletion) !void {
+    const session = switch (completion) {
+        .chatgpt => |session| session,
+        .vercel => return error.InvalidSignInCompletion,
+    };
+    try chatgpt_session.saveNewSession(alloc, session);
+}
+
+pub fn runLogin(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    url_opener: host.UrlOpener,
+) !void {
+    const user_code_endpoint = try configuredEndpoint(alloc, e2e_device_user_code_url_env, device_user_code_url);
+    defer alloc.free(user_code_endpoint);
+    const configured_device_token_endpoint = try configuredEndpoint(alloc, e2e_device_token_url_env, device_token_url);
+    defer alloc.free(configured_device_token_endpoint);
+    const configured_token_endpoint = try configuredEndpoint(alloc, e2e_token_url_env, token_url);
+    defer alloc.free(configured_token_endpoint);
+    var device = try requestDeviceAuthorizationAt(alloc, transport, user_code_endpoint);
+    defer device.deinit(alloc);
+
+    try writeStdout("Open ");
+    try writeStdout(device_verification_uri);
+    try writeStdout("\nCode: ");
+    try writeStdout(device.user_code);
+    try writeStdout("\n\nWaiting for ChatGPT authorization...\n");
+    if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) {
+        _ = url_opener.open(alloc, device_verification_uri) catch false;
+    }
+
+    var device_token = try pollDeviceAuthorizationAt(
+        alloc,
+        transport,
+        configured_device_token_endpoint,
+        device,
+    );
+    defer device_token.deinit(alloc);
+    var token = try exchangeAuthorizationCodeAt(
+        alloc,
+        transport,
+        configured_token_endpoint,
+        device_token.authorization_code,
+        device_token.code_verifier,
+    );
+    defer token.deinit(alloc);
+
+    var session = try sessionFromToken(alloc, &token, io_mod.milliTimestamp());
+    defer session.deinit(alloc);
+    try chatgpt_session.saveNewSession(alloc, session);
+    try writeStdout("Signed in with ChatGPT.\n");
+}
+
+pub fn logout() !chatgpt_session.DeleteOutcome {
+    var mutation = (try chatgpt_session.beginExistingMutation()) orelse return .missing;
+    defer mutation.deinit();
+    return mutation.delete();
+}
+
+pub fn sourceExists(alloc: Allocator) !bool {
+    var session = (try chatgpt_session.load(alloc)) orelse return false;
+    defer session.deinit(alloc);
+    return true;
+}
+
+pub fn loadAccess(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    mode: RefreshMode,
+) !?Access {
+    if (mode == .stored) {
+        var session = (try chatgpt_session.load(alloc)) orelse return null;
+        defer session.deinit(alloc);
+        return takeAccess(&session);
+    }
+
+    var mutation = (try chatgpt_session.beginExistingMutation()) orelse return null;
+    defer mutation.deinit();
+    var session = (try mutation.load(alloc)) orelse return null;
+    defer session.deinit(alloc);
+
+    if (mode == .force or session.expired(io_mod.milliTimestamp())) {
+        try refreshSession(alloc, transport, &mutation, &session);
+    }
+    return takeAccess(&session);
+}
+
+fn takeAccess(session: *chatgpt_session.Session) Access {
+    const access_token = session.access_token;
+    session.access_token = &.{};
+    const account_id = session.account_id;
+    session.account_id = &.{};
+    return .{
+        .access_token = access_token,
+        .account_id = account_id,
+        .refresh_after_ms = chatgpt_session.refreshDeadlineMs(session.expires_at_ms),
+    };
+}
+
+fn refreshSession(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    mutation: *chatgpt_session.Mutation,
+    session: *chatgpt_session.Session,
+) !void {
+    var form: FormBody = .{};
+    var body: std.Io.Writer.Allocating = .init(alloc);
+    defer body.deinit();
+    try form.append(&body.writer, "grant_type", "refresh_token");
+    try form.append(&body.writer, "refresh_token", session.refresh_token);
+    try form.append(&body.writer, "client_id", client_id);
+    var token = try requestToken(alloc, transport, body.written());
+    defer token.deinit(alloc);
+
+    var replacement = try sessionFromToken(alloc, &token, io_mod.milliTimestamp());
+    errdefer replacement.deinit(alloc);
+    try mutation.save(alloc, replacement);
+
+    session.deinit(alloc);
+    session.* = replacement;
+    replacement.access_token = &.{};
+    replacement.refresh_token = &.{};
+    replacement.account_id = &.{};
+}
+
+fn requestDeviceAuthorization(alloc: Allocator, transport: oauth_transport.Provider) !DeviceAuthorization {
+    return requestDeviceAuthorizationAt(alloc, transport, device_user_code_url);
+}
+
+fn requestDeviceAuthorizationAt(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    endpoint_url: []const u8,
+) !DeviceAuthorization {
+    var payload: std.Io.Writer.Allocating = .init(alloc);
+    defer payload.deinit();
+    try payload.writer.writeAll("{\"client_id\":");
+    try std.json.Stringify.value(client_id, .{}, &payload.writer);
+    try payload.writer.writeByte('}');
+
+    const bytes = try requestAccepted(alloc, transport, .post_json, endpoint_url, payload.written());
+    defer secret.zeroAndFree(alloc, bytes);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidChatGptOAuthResponse;
+    const object = parsed.value.object;
+    const device_auth_id = try dupeRequiredString(alloc, object, "device_auth_id");
+    errdefer secret.zeroAndFree(alloc, device_auth_id);
+    const user_code = try dupeRequiredString(alloc, object, "user_code");
+    errdefer alloc.free(user_code);
+    return .{
+        .device_auth_id = device_auth_id,
+        .user_code = user_code,
+        .interval_seconds = try flexiblePositiveInteger(object, "interval"),
+    };
+}
+
+fn pollDeviceAuthorization(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    device: DeviceAuthorization,
+) !DeviceToken {
+    return pollDeviceAuthorizationAt(alloc, transport, device_token_url, device);
+}
+
+fn pollDeviceAuthorizationAt(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    endpoint_url: []const u8,
+    device: DeviceAuthorization,
+) !DeviceToken {
+    const started_ms = io_mod.milliTimestamp();
+    const timeout_ms = device_code_timeout_seconds * std.time.ms_per_s;
+    var interval_seconds = @max(device.interval_seconds, 1);
+    while (io_mod.milliTimestamp() - started_ms < timeout_ms) {
+        var payload: std.Io.Writer.Allocating = .init(alloc);
+        defer payload.deinit();
+        try payload.writer.writeAll("{\"device_auth_id\":");
+        try std.json.Stringify.value(device.device_auth_id, .{}, &payload.writer);
+        try payload.writer.writeAll(",\"user_code\":");
+        try std.json.Stringify.value(device.user_code, .{}, &payload.writer);
+        try payload.writer.writeByte('}');
+
+        var response = try transport.execute(alloc, .{
+            .method = .post_json,
+            .url = endpoint_url,
+            .payload = payload.written(),
+        });
+        defer response.deinit(alloc);
+        if (response.disposition == .accepted) {
+            var parsed = try std.json.parseFromSlice(std.json.Value, alloc, response.body, .{});
+            defer parsed.deinit();
+            if (parsed.value != .object) return error.InvalidChatGptOAuthResponse;
+            const authorization_code = try dupeRequiredString(alloc, parsed.value.object, "authorization_code");
+            errdefer secret.zeroAndFree(alloc, authorization_code);
+            return .{
+                .authorization_code = authorization_code,
+                .code_verifier = try dupeRequiredString(alloc, parsed.value.object, "code_verifier"),
+            };
+        }
+        switch (devicePollDisposition(alloc, response.body)) {
+            .pending => {},
+            .slow_down => interval_seconds += 5,
+            .failed => return error.ChatGptAuthorizationFailed,
+        }
+        io_mod.sleep(@as(u64, @intCast(interval_seconds)) * std.time.ns_per_s);
+    }
+    return error.ChatGptLoginTimedOut;
+}
+
+const PollDisposition = enum { pending, slow_down, failed };
+
+fn devicePollDisposition(alloc: Allocator, bytes: []const u8) PollDisposition {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch return .pending;
+    defer parsed.deinit();
+    if (parsed.value != .object) return .pending;
+    const value = parsed.value.object.get("error") orelse return .pending;
+    const code = switch (value) {
+        .string => value.string,
+        .object => object: {
+            const nested = value.object.get("code") orelse return .failed;
+            if (nested != .string) return .failed;
+            break :object nested.string;
+        },
+        else => return .failed,
+    };
+    if (std.mem.eql(u8, code, "deviceauth_authorization_pending") or
+        std.mem.eql(u8, code, "authorization_pending")) return .pending;
+    if (std.mem.eql(u8, code, "slow_down")) return .slow_down;
+    return .failed;
+}
+
+fn exchangeAuthorizationCode(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    authorization_code: []const u8,
+    code_verifier: []const u8,
+) !TokenSet {
+    return exchangeAuthorizationCodeAt(
+        alloc,
+        transport,
+        token_url,
+        authorization_code,
+        code_verifier,
+    );
+}
+
+fn exchangeAuthorizationCodeAt(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    endpoint_url: []const u8,
+    authorization_code: []const u8,
+    code_verifier: []const u8,
+) !TokenSet {
+    return exchangeAuthorizationCodeWithBounds(
+        alloc,
+        transport,
+        endpoint_url,
+        authorization_code,
+        code_verifier,
+        null,
+        null,
+    );
+}
+
+fn exchangeAuthorizationCodeBounded(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    endpoint_url: []const u8,
+    authorization_code: []const u8,
+    code_verifier: []const u8,
+    cancel_flag: *std.atomic.Value(bool),
+    deadline: std.Io.Clock.Timestamp,
+) !TokenSet {
+    return exchangeAuthorizationCodeWithBounds(
+        alloc,
+        transport,
+        endpoint_url,
+        authorization_code,
+        code_verifier,
+        cancel_flag,
+        deadline,
+    );
+}
+
+fn exchangeAuthorizationCodeWithBounds(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    endpoint_url: []const u8,
+    authorization_code: []const u8,
+    code_verifier: []const u8,
+    cancel_flag: ?*std.atomic.Value(bool),
+    deadline: ?std.Io.Clock.Timestamp,
+) !TokenSet {
+    var form: FormBody = .{};
+    var body: std.Io.Writer.Allocating = .init(alloc);
+    defer body.deinit();
+    try form.append(&body.writer, "grant_type", "authorization_code");
+    try form.append(&body.writer, "client_id", client_id);
+    try form.append(&body.writer, "code", authorization_code);
+    try form.append(&body.writer, "code_verifier", code_verifier);
+    try form.append(&body.writer, "redirect_uri", device_redirect_uri);
+    return requestTokenAtWithBounds(alloc, transport, endpoint_url, body.written(), cancel_flag, deadline);
+}
+
+fn requestToken(alloc: Allocator, transport: oauth_transport.Provider, payload: []const u8) !TokenSet {
+    const endpoint_url = try configuredEndpoint(alloc, e2e_token_url_env, token_url);
+    defer alloc.free(endpoint_url);
+    return requestTokenAtWithBounds(alloc, transport, endpoint_url, payload, null, null);
+}
+
+fn requestTokenAtWithBounds(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    endpoint_url: []const u8,
+    payload: []const u8,
+    cancel_flag: ?*std.atomic.Value(bool),
+    deadline: ?std.Io.Clock.Timestamp,
+) !TokenSet {
+    const bytes = try requestAcceptedWithBounds(
+        alloc,
+        transport,
+        .post_form,
+        endpoint_url,
+        payload,
+        cancel_flag,
+        deadline,
+    );
+    defer secret.zeroAndFree(alloc, bytes);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidChatGptOAuthResponse;
+    const object = parsed.value.object;
+    const access_token = try dupeRequiredString(alloc, object, "access_token");
+    errdefer secret.zeroAndFree(alloc, access_token);
+    const refresh_token = try dupeRequiredString(alloc, object, "refresh_token");
+    errdefer secret.zeroAndFree(alloc, refresh_token);
+    return .{
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+        .expires_in = try requiredPositiveInteger(object, "expires_in"),
+    };
+}
+
+fn configuredEndpoint(alloc: Allocator, env_name: []const u8, default_url: []const u8) ![]u8 {
+    const candidate = io_mod.getenv(env_name) orelse default_url;
+    if (io_mod.getenv(env_name) != null and !isLoopbackHttpUrl(candidate)) {
+        return error.InvalidE2EChatGptEndpoint;
+    }
+    return alloc.dupe(u8, candidate);
+}
+
+fn isLoopbackHttpUrl(url: []const u8) bool {
+    const uri = std.Uri.parse(url) catch return false;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "http") or
+        uri.user != null or
+        uri.password != null or
+        uri.port == null)
+    {
+        return false;
+    }
+    const host_component = uri.host orelse return false;
+    var host_buf: [std.Io.net.HostName.max_len]u8 = undefined;
+    const host_name = host_component.toRaw(&host_buf) catch return false;
+    return std.mem.eql(u8, host_name, "127.0.0.1") or
+        std.ascii.eqlIgnoreCase(host_name, "localhost") or
+        std.mem.eql(u8, host_name, "[::1]");
+}
+
+fn requestAccepted(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    method: oauth_transport.Method,
+    url: []const u8,
+    payload: []const u8,
+) ![]u8 {
+    return requestAcceptedWithBounds(alloc, transport, method, url, payload, null, null);
+}
+
+fn requestAcceptedWithBounds(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    method: oauth_transport.Method,
+    url: []const u8,
+    payload: []const u8,
+    cancel_flag: ?*std.atomic.Value(bool),
+    deadline: ?std.Io.Clock.Timestamp,
+) ![]u8 {
+    if (cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+    var response = try transport.execute(alloc, .{
+        .method = method,
+        .url = url,
+        .payload = payload,
+        .cancel_flag = cancel_flag,
+        .deadline = deadline,
+    });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) {
+        debug_trace.logf("auth", "ChatGPT OAuth request rejected url={s}", .{url});
+        return error.ChatGptOAuthRequestFailed;
+    }
+    return response.takeBody();
+}
+
+fn sessionFromToken(alloc: Allocator, token: *TokenSet, now_ms: i64) !chatgpt_session.Session {
+    const account_id = try extractAccountId(alloc, token.access_token);
+    errdefer alloc.free(account_id);
+    const duration_ms = std.math.mul(i64, token.expires_in, std.time.ms_per_s) catch
+        return error.InvalidChatGptOAuthResponse;
+    const expires_at_ms = std.math.add(i64, now_ms, duration_ms) catch
+        return error.InvalidChatGptOAuthResponse;
+    const session = chatgpt_session.Session{
+        .access_token = token.access_token,
+        .refresh_token = token.refresh_token,
+        .expires_at_ms = expires_at_ms,
+        .account_id = account_id,
+    };
+    token.access_token = &.{};
+    token.refresh_token = &.{};
+    return session;
+}
+
+pub fn extractAccountId(alloc: Allocator, token: []const u8) ![]u8 {
+    var parts = std.mem.splitScalar(u8, token, '.');
+    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
+    const payload = parts.next() orelse return error.InvalidChatGptAccessToken;
+    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
+    if (parts.next() != null) return error.InvalidChatGptAccessToken;
+
+    const decoded_len = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(payload) catch
+        return error.InvalidChatGptAccessToken;
+    const decoded = try alloc.alloc(u8, decoded_len);
+    defer alloc.free(decoded);
+    std.base64.url_safe_no_pad.Decoder.decode(decoded, payload) catch
+        return error.InvalidChatGptAccessToken;
+
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, decoded, .{}) catch
+        return error.InvalidChatGptAccessToken;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidChatGptAccessToken;
+    const claim = parsed.value.object.get(jwt_auth_claim) orelse return error.InvalidChatGptAccessToken;
+    if (claim != .object) return error.InvalidChatGptAccessToken;
+    return dupeRequiredString(alloc, claim.object, "chatgpt_account_id") catch
+        return error.InvalidChatGptAccessToken;
+}
+
+fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
+    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
+    if (value != .string or value.string.len == 0) return error.InvalidChatGptOAuthResponse;
+    return alloc.dupe(u8, value.string);
+}
+
+fn requiredPositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
+    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
+    if (value != .integer or value.integer <= 0) return error.InvalidChatGptOAuthResponse;
+    return value.integer;
+}
+
+fn flexiblePositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
+    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
+    const result = switch (value) {
+        .integer => value.integer,
+        .string => std.fmt.parseInt(i64, std.mem.trim(u8, value.string, " \t\r\n"), 10) catch
+            return error.InvalidChatGptOAuthResponse,
+        else => return error.InvalidChatGptOAuthResponse,
+    };
+    if (result < 0) return error.InvalidChatGptOAuthResponse;
+    return result;
+}
+
+const FormBody = struct {
+    first: bool = true,
+
+    fn append(self: *FormBody, writer: *std.Io.Writer, key: []const u8, value: []const u8) !void {
+        if (!self.first) try writer.writeByte('&');
+        self.first = false;
+        try percentEncode(writer, key);
+        try writer.writeByte('=');
+        try percentEncode(writer, value);
+    }
+};
+
+fn percentEncode(writer: *std.Io.Writer, value: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (value) |byte| {
+        const safe = std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_' or byte == '.' or byte == '~';
+        if (safe) {
+            try writer.writeByte(byte);
+        } else {
+            try writer.writeByte('%');
+            try writer.writeByte(hex[byte >> 4]);
+            try writer.writeByte(hex[byte & 0x0f]);
+        }
+    }
+}
+
+fn writeStdout(text: []const u8) !void {
+    var buffer: [1024]u8 = undefined;
+    var writer = std.Io.File.stdout().writer(io_mod.getIo(), &buffer);
+    try writer.interface.writeAll(text);
+    try writer.interface.flush();
+}
+
+test "ChatGPT E2E OAuth endpoint overrides accept only loopback HTTP" {
+    try std.testing.expect(isLoopbackHttpUrl("http://127.0.0.1:1234/token"));
+    try std.testing.expect(isLoopbackHttpUrl("http://localhost:1234/token"));
+    try std.testing.expect(!isLoopbackHttpUrl("https://127.0.0.1:1234/token"));
+    try std.testing.expect(!isLoopbackHttpUrl("http://example.com:1234/token"));
+}
+
+test "ChatGPT account id is extracted from the namespaced JWT claim" {
+    const alloc = std.testing.allocator;
+    const payload =
+        \\{"https://api.openai.com/auth":{"chatgpt_account_id":"acct_test"}}
+    ;
+    const encoded_len = std.base64.url_safe_no_pad.Encoder.calcSize(payload.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(encoded, payload);
+    const token = try std.fmt.allocPrint(alloc, "header.{s}.signature", .{encoded});
+    defer alloc.free(token);
+
+    const account_id = try extractAccountId(alloc, token);
+    defer alloc.free(account_id);
+    try std.testing.expectEqualStrings("acct_test", account_id);
+}
+
+test "ChatGPT device polling recognizes pending and slow down errors" {
+    try std.testing.expectEqual(PollDisposition.pending, devicePollDisposition(
+        std.testing.allocator,
+        "{\"error\":{\"code\":\"deviceauth_authorization_pending\"}}",
+    ));
+    try std.testing.expectEqual(PollDisposition.slow_down, devicePollDisposition(
+        std.testing.allocator,
+        "{\"error\":\"slow_down\"}",
+    ));
+    try std.testing.expectEqual(PollDisposition.failed, devicePollDisposition(
+        std.testing.allocator,
+        "{\"error\":\"access_denied\"}",
+    ));
+}
+
+const SignInTestMode = enum { success, block_until_cancel };
+
+const SignInTestState = struct {
+    mode: SignInTestMode,
+    poll_started: std.atomic.Value(bool) = .init(false),
+    save_count: std.atomic.Value(usize) = .init(0),
+
+    fn provider(self: *@This()) oauth_transport.Provider {
+        return .{ .context = self, .execute_fn = execute };
+    }
+
+    fn execute(
+        raw: ?*anyopaque,
+        alloc: Allocator,
+        request: oauth_transport.Request,
+    ) !oauth_transport.Response {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        if (std.mem.eql(u8, request.url, device_user_code_url)) {
+            return .{
+                .disposition = .accepted,
+                .body = try alloc.dupe(u8, "{\"device_auth_id\":\"device-id\",\"user_code\":\"CHAT-CODE\",\"interval\":0}"),
+            };
+        }
+        if (std.mem.eql(u8, request.url, device_token_url)) {
+            self.poll_started.store(true, .seq_cst);
+            if (self.mode == .block_until_cancel) {
+                const cancel = request.cancel_flag orelse return error.TestExpectedCancelFlag;
+                while (!cancel.load(.seq_cst)) io_mod.sleep(std.time.ns_per_ms);
+                return error.Cancelled;
+            }
+            return .{
+                .disposition = .accepted,
+                .body = try alloc.dupe(u8, "{\"authorization_code\":\"code\",\"code_verifier\":\"verifier\"}"),
+            };
+        }
+        if (std.mem.eql(u8, request.url, token_url)) {
+            const token = try testAccessToken(alloc, "acct_runtime");
+            defer alloc.free(token);
+            return .{
+                .disposition = .accepted,
+                .body = try std.fmt.allocPrint(
+                    alloc,
+                    "{{\"access_token\":\"{s}\",\"refresh_token\":\"refresh\",\"expires_in\":3600}}",
+                    .{token},
+                ),
+            };
+        }
+        return error.TestUnexpectedEndpoint;
+    }
+
+    fn save(raw: ?*anyopaque, _: Allocator, completion: login_flow.SignInCompletion) !void {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        switch (completion) {
+            .chatgpt => {},
+            .vercel => return error.TestUnexpectedCompletion,
+        }
+        _ = self.save_count.fetchAdd(1, .seq_cst);
+    }
+};
+
+fn testAccessToken(alloc: Allocator, account_id: []const u8) ![]u8 {
+    const payload = try std.fmt.allocPrint(
+        alloc,
+        "{{\"https://api.openai.com/auth\":{{\"chatgpt_account_id\":\"{s}\"}}}}",
+        .{account_id},
+    );
+    defer alloc.free(payload);
+    const encoded = try alloc.alloc(u8, std.base64.url_safe_no_pad.Encoder.calcSize(payload.len));
+    defer alloc.free(encoded);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(encoded, payload);
+    return std.fmt.allocPrint(alloc, "header.{s}.signature", .{encoded});
+}
+
+fn waitForSignIn(
+    runtime: *login_flow.SignInRuntime,
+    alloc: Allocator,
+    timeout_ms: usize,
+) login_flow.SignInTransition {
+    for (0..timeout_ms) |_| {
+        const transition = runtime.pollTransition(alloc);
+        if (transition != .none) return transition;
+        io_mod.sleep(std.time.ns_per_ms);
+    }
+    return .none;
+}
+
+test "ChatGPT sign-in uses the shared rendered runtime and publishes a saved completion" {
+    const alloc = std.testing.allocator;
+    var state = SignInTestState{ .mode = .success };
+    var runtime: login_flow.SignInRuntime = .{};
+    defer runtime.deinit(alloc);
+    const transport = state.provider();
+    try std.testing.expect(try runtime.startPrepared(
+        alloc,
+        try prepareSignIn(alloc, transport),
+        .{
+            .ctx = &state,
+            .oauth_transport = transport,
+            .poll = .{ .poll_device_token = pollSignInDeviceToken },
+            .complete = completeSignIn,
+            .save = SignInTestState.save,
+        },
+    ));
+
+    const snapshot = runtime.snapshot();
+    try std.testing.expectEqualStrings(device_verification_uri, snapshot.verification_uri);
+    try std.testing.expectEqualStrings("CHAT-CODE", snapshot.user_code);
+    var transition = waitForSignIn(&runtime, alloc, 1000);
+    switch (transition) {
+        .succeeded => |*completion| {
+            switch (completion.*) {
+                .chatgpt => |session| try std.testing.expectEqualStrings("acct_runtime", session.account_id),
+                .vercel => return error.TestUnexpectedCompletion,
+            }
+            completion.deinit(alloc);
+        },
+        else => return error.TestExpectedSuccessfulSignIn,
+    }
+    try std.testing.expectEqual(@as(usize, 1), state.save_count.load(.seq_cst));
+}
+
+test "ChatGPT shared sign-in cancellation saves no session" {
+    const alloc = std.testing.allocator;
+    var state = SignInTestState{ .mode = .block_until_cancel };
+    var runtime: login_flow.SignInRuntime = .{};
+    defer runtime.deinit(alloc);
+    const transport = state.provider();
+    try std.testing.expect(try runtime.startPrepared(
+        alloc,
+        try prepareSignIn(alloc, transport),
+        .{
+            .ctx = &state,
+            .oauth_transport = transport,
+            .poll = .{ .poll_device_token = pollSignInDeviceToken },
+            .complete = completeSignIn,
+            .save = SignInTestState.save,
+        },
+    ));
+    for (0..500) |_| {
+        if (state.poll_started.load(.seq_cst)) break;
+        io_mod.sleep(std.time.ns_per_ms);
+    }
+    try std.testing.expect(state.poll_started.load(.seq_cst));
+    try std.testing.expect(runtime.cancel(alloc));
+    try std.testing.expectEqual(login_flow.SignInTransition.cancelled, runtime.pollTransition(alloc));
+    try std.testing.expectEqual(@as(usize, 0), state.save_count.load(.seq_cst));
+}

--- a/src/core/auth/chatgpt_session.zig
+++ b/src/core/auth/chatgpt_session.zig
@@ -1,0 +1,269 @@
+const std = @import("std");
+const debug_trace = @import("../shared/debug_trace.zig");
+const host_target = @import("../hosts/target.zig");
+const io_mod = @import("../shared/io.zig");
+const profile_paths = @import("../shared/profile_paths.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+const schema_version: i64 = 1;
+const max_auth_file_bytes: usize = 64 * 1024;
+const expiry_skew_ms: i64 = 60 * 1000;
+const mutation_lock_file_name = "chatgpt-auth.lock";
+const mutation_lock_deadline_ms: u64 = 2000;
+
+pub const issuer = "https://auth.openai.com";
+pub const auth_file_name = profile_paths.chatgpt_auth_file_name;
+
+pub fn refreshDeadlineMs(expires_at_ms: i64) i64 {
+    return @max(expires_at_ms - expiry_skew_ms, 0);
+}
+
+pub const Session = struct {
+    access_token: []u8,
+    refresh_token: []u8,
+    expires_at_ms: i64,
+    account_id: []u8,
+
+    pub fn deinit(self: *Session, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.access_token);
+        secret.zeroAndFree(alloc, self.refresh_token);
+        alloc.free(self.account_id);
+        self.* = undefined;
+    }
+
+    pub fn expired(self: Session, now_ms: i64) bool {
+        return refreshDeadlineMs(self.expires_at_ms) <= now_ms;
+    }
+};
+
+pub const DeleteOutcome = enum {
+    deleted,
+    missing,
+    deleted_not_durable,
+};
+
+pub const Mutation = struct {
+    fx_dir: io_mod.VerifiedDir,
+    lock: io_mod.TimedAdvisoryLock,
+
+    pub fn deinit(self: *Mutation) void {
+        self.lock.release();
+        self.fx_dir.close();
+        self.* = undefined;
+    }
+
+    pub fn load(self: *Mutation, alloc: Allocator) !?Session {
+        return loadFromDir(alloc, &self.fx_dir.dir, true);
+    }
+
+    pub fn save(self: *Mutation, alloc: Allocator, session: Session) !void {
+        const text = try stringify(alloc, session);
+        defer secret.zeroAndFree(alloc, text);
+        try io_mod.durableReplaceVerified(alloc, &self.fx_dir, auth_file_name, text);
+    }
+
+    pub fn delete(self: *Mutation) !DeleteOutcome {
+        self.fx_dir.dir.deleteFile(io_mod.getIo(), auth_file_name) catch |err| switch (err) {
+            error.FileNotFound => return .missing,
+            else => return err,
+        };
+        const durable: io_mod.DurableOps = .{};
+        durable.sync_dir(durable.ctx, self.fx_dir.dir) catch return .deleted_not_durable;
+        return .deleted;
+    }
+};
+
+pub fn load(alloc: Allocator) !?Session {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return null;
+    var home_dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch |err| {
+        debug_trace.logf("auth", "ChatGPT session load failed step=open_home err={s}", .{@errorName(err)});
+        return null;
+    };
+    defer home_dir.close(io_mod.getIo());
+
+    var fx_dir = home_dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| {
+        if (err != error.FileNotFound) {
+            debug_trace.logf("auth", "ChatGPT session load failed step=open_profile err={s}", .{@errorName(err)});
+        }
+        return null;
+    };
+    defer fx_dir.close(io_mod.getIo());
+    return loadFromDir(alloc, &fx_dir, false);
+}
+
+fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, report_open_failure: bool) !?Session {
+    var file = fx_dir.openFile(io_mod.getIo(), auth_file_name, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => {
+            debug_trace.logf("auth", "ChatGPT session load failed step=open_file err={s}", .{@errorName(err)});
+            if (report_open_failure) return err;
+            return null;
+        },
+    };
+    defer file.close(io_mod.getIo());
+
+    const stat = try file.stat(io_mod.getIo());
+    if (stat.kind != .file or stat.permissions.toMode() & 0o077 != 0) {
+        debug_trace.logf("auth", "ChatGPT session load failed step=permissions err=InsecureAuthFile", .{});
+        return null;
+    }
+
+    const bytes = try io_mod.readFileToEnd(alloc, &file, max_auth_file_bytes);
+    defer secret.zeroAndFree(alloc, bytes);
+    return parse(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "ChatGPT session load failed step=parse err={s}", .{@errorName(err)});
+            return null;
+        },
+    };
+}
+
+pub fn saveNewSession(alloc: Allocator, session: Session) !void {
+    if (comptime host_target.is_wasm) return error.ChatGptOAuthUnavailable;
+    var mutation = try beginMutation();
+    defer mutation.deinit();
+    try mutation.save(alloc, session);
+}
+
+pub fn beginExistingMutation() !?Mutation {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+
+    const fx_dir = openExistingPrivateFxDir(&home_dir) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    return try lockMutation(fx_dir);
+}
+
+fn beginMutation() !Mutation {
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+
+    const fx_dir = try io_mod.openOrCreateVerifiedPrivateDir(&home_dir, profile_paths.root_dir_name);
+    return lockMutation(fx_dir);
+}
+
+fn lockMutation(open_fx_dir: io_mod.VerifiedDir) !Mutation {
+    var fx_dir = open_fx_dir;
+    errdefer fx_dir.close();
+    var lock = try io_mod.acquireTimedAdvisoryLock(
+        &fx_dir,
+        mutation_lock_file_name,
+        mutation_lock_deadline_ms,
+    );
+    errdefer lock.release();
+    return .{ .fx_dir = fx_dir, .lock = lock };
+}
+
+fn openExistingPrivateFxDir(home_dir: *io_mod.VerifiedDir) !io_mod.VerifiedDir {
+    var dir = try home_dir.dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    errdefer dir.close(io_mod.getIo());
+
+    const initial_stat = try dir.stat(io_mod.getIo());
+    if (initial_stat.kind != .directory) return error.DurablePathUnsafe;
+    if (initial_stat.permissions.toMode() & 0o200 == 0) return error.PrivateStatePermissionsUnsupported;
+    dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {
+        return error.PrivateStatePermissionsUnsupported;
+    };
+    const stat = try dir.stat(io_mod.getIo());
+    if (stat.kind != .directory or stat.permissions.toMode() & 0o777 != 0o700) {
+        return error.PrivateStatePermissionsUnsupported;
+    }
+    return .{ .dir = dir };
+}
+
+pub fn parse(alloc: Allocator, bytes: []const u8) !Session {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidChatGptAuthSession;
+    const object = parsed.value.object;
+    const version = object.get("version") orelse return error.InvalidChatGptAuthSession;
+    if (version != .integer or version.integer != schema_version) return error.InvalidChatGptAuthSession;
+
+    const access_token = try dupeRequiredString(alloc, object, "access_token");
+    errdefer secret.zeroAndFree(alloc, access_token);
+    const refresh_token = try dupeRequiredString(alloc, object, "refresh_token");
+    errdefer secret.zeroAndFree(alloc, refresh_token);
+    const account_id = try dupeRequiredString(alloc, object, "account_id");
+    errdefer alloc.free(account_id);
+    const expires_at_ms = try requiredInteger(object, "expires_at_ms");
+    return .{
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+        .expires_at_ms = expires_at_ms,
+        .account_id = account_id,
+    };
+}
+
+pub fn stringify(alloc: Allocator, session: Session) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"version\":1,\"access_token\":");
+    try std.json.Stringify.value(session.access_token, .{}, &out.writer);
+    try out.writer.writeAll(",\"refresh_token\":");
+    try std.json.Stringify.value(session.refresh_token, .{}, &out.writer);
+    try out.writer.print(",\"expires_at_ms\":{d},\"account_id\":", .{session.expires_at_ms});
+    try std.json.Stringify.value(session.account_id, .{}, &out.writer);
+    try out.writer.writeAll("}\n");
+    return out.toOwnedSlice();
+}
+
+fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
+    const value = object.get(key) orelse return error.InvalidChatGptAuthSession;
+    if (value != .string or value.string.len == 0) return error.InvalidChatGptAuthSession;
+    return alloc.dupe(u8, value.string);
+}
+
+fn requiredInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
+    const value = object.get(key) orelse return error.InvalidChatGptAuthSession;
+    if (value != .integer) return error.InvalidChatGptAuthSession;
+    return value.integer;
+}
+
+test "ChatGPT auth session round trips without exposing token fields to structure" {
+    const alloc = std.testing.allocator;
+    var session = Session{
+        .access_token = try alloc.dupe(u8, "header.payload.signature"),
+        .refresh_token = try alloc.dupe(u8, "refresh"),
+        .expires_at_ms = 1234,
+        .account_id = try alloc.dupe(u8, "acct_123"),
+    };
+    defer session.deinit(alloc);
+
+    const encoded = try stringify(alloc, session);
+    defer secret.zeroAndFree(alloc, encoded);
+    var decoded = try parse(alloc, encoded);
+    defer decoded.deinit(alloc);
+
+    try std.testing.expectEqualStrings(session.access_token, decoded.access_token);
+    try std.testing.expectEqualStrings(session.refresh_token, decoded.refresh_token);
+    try std.testing.expectEqualStrings(session.account_id, decoded.account_id);
+    try std.testing.expectEqual(session.expires_at_ms, decoded.expires_at_ms);
+}
+
+test "ChatGPT session refresh deadline keeps a one minute safety margin" {
+    try std.testing.expectEqual(@as(i64, 40_000), refreshDeadlineMs(100_000));
+    try std.testing.expectEqual(@as(i64, 0), refreshDeadlineMs(10_000));
+}

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -1,8 +1,10 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const chatgpt_oauth = @import("chatgpt_oauth.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const io_mod = @import("../shared/io.zig");
+const model_provider = @import("../config/model_provider.zig");
 const oauth = @import("oauth.zig");
 const oauth_session = @import("oauth_session.zig");
 const oauth_transport = @import("oauth_transport.zig");
@@ -17,6 +19,7 @@ pub const CatalogPublicOnly = union(enum) {
     fx_login_refresh_required,
     credential_refresh_failed: Source,
     authenticated_credential_rejected: Source,
+    chatgpt_subscription,
 
     fn credentialSource(self: CatalogPublicOnly) ?Source {
         return switch (self) {
@@ -24,6 +27,7 @@ pub const CatalogPublicOnly = union(enum) {
             .fx_login_team_required, .fx_login_refresh_required => .fx_login,
             .credential_refresh_failed => |source| source,
             .authenticated_credential_rejected => |source| source,
+            .chatgpt_subscription => .chatgpt_subscription,
         };
     }
 };
@@ -133,6 +137,7 @@ pub fn catalogAccessForCredential(
         .vercel_oidc_token => .vercel_oidc_token,
         .ai_gateway_api_key => .ai_gateway_api_key,
         .stored_key => .stored_key,
+        .chatgpt_subscription => return .{ .public_only = .chatgpt_subscription },
         .fx_login => blk: {
             const team = team_context orelse
                 return .{ .public_only = .fx_login_team_required };
@@ -162,6 +167,8 @@ const FxLoginRefreshMode = enum { if_needed, force };
 
 pub const missing_credential_message = "Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.";
 pub const missing_interactive_credential_message = "Fx needs access to Vercel AI Gateway. Run /login to sign in, /setup to use an API key, or set AI_GATEWAY_API_KEY.";
+pub const missing_chatgpt_credential_message = "Fx needs a ChatGPT subscription login for this model. Run fx login openai-codex.";
+pub const missing_chatgpt_interactive_credential_message = "This model needs a ChatGPT subscription login. Run /login and choose Sign in with ChatGPT.";
 pub const unreadable_store_message = "Fx could not read the stored API key from " ++ stored_key_backend_label ++ ". A key may be saved but unreadable. Set FX_TRACE_LOG for the failing step, or set AI_GATEWAY_API_KEY.";
 
 pub const Credential = struct {
@@ -209,6 +216,33 @@ pub fn resolve(
     mode: LoadMode,
 ) !Resolution {
     return resolvePreferring(alloc, transport, secret_store, mode, null);
+}
+
+/// Resolves the credential for the selected provider route. ChatGPT OAuth
+/// tokens are never considered for a Vercel AI Gateway model, and Gateway
+/// credentials are never considered for an `openai-codex/` model.
+pub fn resolveForModel(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+    secret_store: host.SecretStore,
+    mode: LoadMode,
+    model: []const u8,
+    preferred: ?Source,
+) !Resolution {
+    if (model_provider.isChatGptSubscriptionModel(model)) {
+        const credential = switch (mode) {
+            .stored => try loadStoredChatGptCredential(alloc),
+            .refresh_if_needed => try loadChatGptCredential(alloc, transport, .if_needed),
+        };
+        return .{ .credential = credential };
+    }
+    return resolvePreferring(
+        alloc,
+        transport,
+        secret_store,
+        mode,
+        if (preferred == .chatgpt_subscription) null else preferred,
+    );
 }
 
 /// `preferred` is the source the user last chose in the hub. It wins over the
@@ -266,10 +300,16 @@ fn loadPreferredSource(
     mode: LoadMode,
     source: Source,
 ) !?Credential {
-    if (source != .fx_login) return loadSource(alloc, transport, secret_store, source);
-    return switch (mode) {
-        .stored => loadStoredFxLoginCredential(alloc),
-        .refresh_if_needed => loadFxLoginCredential(alloc, transport),
+    return switch (source) {
+        .fx_login => switch (mode) {
+            .stored => loadStoredFxLoginCredential(alloc),
+            .refresh_if_needed => loadFxLoginCredential(alloc, transport),
+        },
+        .chatgpt_subscription => switch (mode) {
+            .stored => loadStoredChatGptCredential(alloc),
+            .refresh_if_needed => loadChatGptCredential(alloc, transport, .if_needed),
+        },
+        else => loadSource(alloc, transport, secret_store, source),
     };
 }
 
@@ -284,6 +324,7 @@ pub fn loadSource(
         .ai_gateway_api_key => loadEnvCredential(alloc, "AI_GATEWAY_API_KEY", source),
         .fx_login => loadFxLoginCredential(alloc, transport),
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
+        .chatgpt_subscription => loadChatGptCredential(alloc, transport, .if_needed),
     };
 }
 
@@ -307,6 +348,7 @@ pub fn sourceExists(
             defer session.deinit(alloc);
             break :blk true;
         },
+        .chatgpt_subscription => chatgpt_oauth.sourceExists(alloc),
         .stored_key => blk: {
             if (secret_store.isDisabled()) break :blk false;
             const stored = secret_store.load(alloc) catch |err| switch (err) {
@@ -344,6 +386,26 @@ fn loadStoredKeyCredential(
     return .{ .token = value, .source = .stored_key };
 }
 
+fn loadChatGptCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+    mode: chatgpt_oauth.RefreshMode,
+) !?Credential {
+    var access = (try chatgpt_oauth.loadAccess(alloc, transport, mode)) orelse return null;
+    defer access.deinit(alloc);
+    const token = access.access_token;
+    access.access_token = &.{};
+    return .{
+        .token = token,
+        .source = .chatgpt_subscription,
+        .refresh_after_ms = access.refresh_after_ms,
+    };
+}
+
+fn loadStoredChatGptCredential(alloc: std.mem.Allocator) !?Credential {
+    return loadChatGptCredential(alloc, oauth_transport.unavailable_provider, .stored);
+}
+
 fn nonEmptyEnvValue(name: []const u8) ?[]const u8 {
     return nonEmptyValue(io_mod.getenv(name));
 }
@@ -379,6 +441,13 @@ pub fn refreshFxLoginCredential(
     transport: oauth_transport.Provider,
 ) !?Credential {
     return refreshFxLoginCredentialLocked(alloc, transport, .force);
+}
+
+pub fn refreshChatGptCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+) !?Credential {
+    return loadChatGptCredential(alloc, transport, .force);
 }
 
 fn refreshFxLoginCredentialLocked(
@@ -471,11 +540,12 @@ pub fn sourceLabel(source: Source) []const u8 {
         .ai_gateway_api_key => "AI_GATEWAY_API_KEY",
         .fx_login => "fx login",
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
+        .chatgpt_subscription => "ChatGPT subscription",
     };
 }
 
 pub fn sourceRefreshable(source: Source) bool {
-    return source == .fx_login;
+    return source == .fx_login or source == .chatgpt_subscription;
 }
 
 test "stored key label discloses the backend that answered" {
@@ -524,6 +594,15 @@ test "public-only catalog access never permits authorization or team context" {
     const refresh_failed = catalogAccessAfterRefreshFailure(.fx_login);
     try std.testing.expectEqual(CatalogPublicOnlyReason.credential_refresh_failed, refresh_failed.publicOnlyReason().?);
     try std.testing.expectEqual(Source.fx_login, refresh_failed.credentialSource().?);
+
+    const chatgpt = catalogAccessForCredential(
+        .chatgpt_subscription,
+        "chatgpt-secret",
+        "chatgpt-account",
+    );
+    try std.testing.expectEqual(CatalogPublicOnlyReason.chatgpt_subscription, chatgpt.publicOnlyReason().?);
+    try std.testing.expect(chatgpt.authorizationCredential() == null);
+    try std.testing.expect(chatgpt.teamContext() == null);
 
     const rejected: CatalogAccess = .{ .public_only = .{ .authenticated_credential_rejected = .stored_key } };
     try std.testing.expectEqual(CatalogPublicOnlyReason.authenticated_credential_rejected, rejected.publicOnlyReason().?);

--- a/src/core/auth/js_host_auth.zig
+++ b/src/core/auth/js_host_auth.zig
@@ -64,12 +64,16 @@ fn executeOAuthRequest(
             .name = "content-type",
             .value = "application/x-www-form-urlencoded",
         }},
+        .post_json => &.{.{
+            .name = "content-type",
+            .value = "application/json",
+        }},
     };
     var response = try executeRequest(
         alloc,
         switch (request.method) {
             .get => "GET",
-            .post_form => "POST",
+            .post_form, .post_json => "POST",
         },
         request.url,
         headers,

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const credentials = @import("credentials.zig");
+const chatgpt_session = @import("chatgpt_session.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
@@ -132,19 +133,38 @@ pub const SignInSnapshot = struct {
     user_code: []const u8 = "",
 };
 
+pub const SignInCompletion = union(enum) {
+    vercel: TeamSelection,
+    chatgpt: chatgpt_session.Session,
+
+    pub fn deinit(self: *SignInCompletion, alloc: Allocator) void {
+        switch (self.*) {
+            .vercel => |*selection| selection.deinit(alloc),
+            .chatgpt => |*session| session.deinit(alloc),
+        }
+        self.* = .{ .vercel = .{} };
+    }
+
+    pub fn take(self: *SignInCompletion) SignInCompletion {
+        const completion = self.*;
+        self.* = .{ .vercel = .{} };
+        return completion;
+    }
+};
+
 pub const SignInTransition = union(enum) {
     none,
-    succeeded: TeamSelection,
+    succeeded: SignInCompletion,
     failed: anyerror,
     cancelled,
 };
 
-const PreparedLogin = struct {
+pub const PreparedLogin = struct {
     metadata: oauth.Metadata,
     device: oauth.DeviceAuthorization,
     client_id: []u8,
 
-    fn deinit(self: *PreparedLogin, alloc: Allocator) void {
+    pub fn deinit(self: *PreparedLogin, alloc: Allocator) void {
         self.metadata.deinit(alloc);
         self.device.deinit(alloc);
         alloc.free(self.client_id);
@@ -152,16 +172,16 @@ const PreparedLogin = struct {
     }
 };
 
-const CompleteSignInFn = *const fn (
+pub const CompleteSignInFn = *const fn (
     ?*anyopaque,
     Allocator,
     []const u8,
     []const u8,
     *oauth.TokenSet,
-) anyerror!TeamSelection;
-const SaveSignInFn = *const fn (?*anyopaque, Allocator, oauth_session.Session) anyerror!void;
+) anyerror!SignInCompletion;
+pub const SaveSignInFn = *const fn (?*anyopaque, Allocator, SignInCompletion) anyerror!void;
 
-const SignInRuntimeDeps = struct {
+pub const SignInRuntimeDeps = struct {
     ctx: ?*anyopaque = null,
     oauth_transport: oauth_transport.Provider = oauth_transport.unavailable_provider,
     poll: LoginPollDeps = .{},
@@ -177,7 +197,7 @@ pub const SignInRuntime = struct {
     cancel_requested: std.atomic.Value(bool) = .init(false),
     state: SignInState = .idle,
     flow: ?PreparedLogin = null,
-    completion: ?TeamSelection = null,
+    completion: ?SignInCompletion = null,
     failure: ?anyerror = null,
     poll_state: ?LoginPollState = null,
     deps: SignInRuntimeDeps = .{},
@@ -193,7 +213,7 @@ pub const SignInRuntime = struct {
         });
     }
 
-    fn startPrepared(
+    pub fn startPrepared(
         self: *Self,
         alloc: Allocator,
         prepared: PreparedLogin,
@@ -415,12 +435,7 @@ pub const SignInRuntime = struct {
             debug_trace.logf("auth", "sign-in discarded session after cancel state={t}", .{self.state});
             return;
         }
-        const session = completion.session orelse {
-            self.failure = LoginError.NoSession;
-            self.state = .failed;
-            return;
-        };
-        self.deps.save(self.deps.ctx, alloc, session) catch |err| {
+        self.deps.save(self.deps.ctx, alloc, completion) catch |err| {
             debug_trace.logf("auth", "sign-in session save failed err={s}", .{@errorName(err)});
             self.failure = err;
             self.state = .failed;
@@ -491,18 +506,22 @@ fn completeSignIn(
     issuer_url: []const u8,
     client_id: []const u8,
     token: *oauth.TokenSet,
-) !TeamSelection {
+) !SignInCompletion {
     var teams = fetchTeams(alloc, token.access_token, issuer_url) catch std.ArrayList(Team).empty;
     errdefer freeTeams(alloc, &teams);
     const now_ms = io_mod.milliTimestamp();
     const session = try take_login_session(alloc, issuer_url, client_id, token, null, now_ms);
-    return .{
+    return .{ .vercel = .{
         .session = session,
         .teams = teams,
-    };
+    } };
 }
 
-fn saveSignIn(_: ?*anyopaque, alloc: Allocator, session: oauth_session.Session) !void {
+fn saveSignIn(_: ?*anyopaque, alloc: Allocator, completion: SignInCompletion) !void {
+    const session = switch (completion) {
+        .vercel => |selection| selection.session orelse return LoginError.NoSession,
+        .chatgpt => return error.InvalidSignInCompletion,
+    };
     try oauth_session.saveNewSession(alloc, session);
 }
 
@@ -727,7 +746,7 @@ fn pollForTokenWithPrompt(
     });
 }
 
-const LoginPollDeps = struct {
+pub const LoginPollDeps = struct {
     ctx: ?*anyopaque = null,
     now_ms: *const fn (?*anyopaque) i64 = realNowMs,
     poll_device_token: *const fn (
@@ -1584,10 +1603,10 @@ const SignInTestState = struct {
         issuer_url: []const u8,
         client_id: []const u8,
         token: *oauth.TokenSet,
-    ) !TeamSelection {
+    ) !SignInCompletion {
         const self = state(raw);
         _ = self.complete_count.fetchAdd(1, .seq_cst);
-        return .{
+        return .{ .vercel = .{
             .session = try take_login_session(
                 alloc,
                 issuer_url,
@@ -1596,10 +1615,10 @@ const SignInTestState = struct {
                 null,
                 0,
             ),
-        };
+        } };
     }
 
-    fn save(raw: ?*anyopaque, _: Allocator, _: oauth_session.Session) !void {
+    fn save(raw: ?*anyopaque, _: Allocator, _: SignInCompletion) !void {
         const self = state(raw);
         _ = self.save_count.fetchAdd(1, .seq_cst);
     }
@@ -1638,20 +1657,20 @@ const CooperativeSignInTestState = struct {
         issuer_url: []const u8,
         client_id: []const u8,
         token: *oauth.TokenSet,
-    ) !TeamSelection {
+    ) !SignInCompletion {
         const self = state(raw);
         self.complete_count += 1;
-        return .{ .session = try take_login_session(
+        return .{ .vercel = .{ .session = try take_login_session(
             alloc,
             issuer_url,
             client_id,
             token,
             null,
             0,
-        ) };
+        ) } };
     }
 
-    fn save(raw: ?*anyopaque, _: Allocator, _: oauth_session.Session) !void {
+    fn save(raw: ?*anyopaque, _: Allocator, _: SignInCompletion) !void {
         const self = state(raw);
         self.save_count += 1;
         if (self.fail_save) return error.TestStoreCommitFailed;

--- a/src/core/auth/oauth_transport.zig
+++ b/src/core/auth/oauth_transport.zig
@@ -6,6 +6,7 @@ const Allocator = std.mem.Allocator;
 pub const Method = enum {
     get,
     post_form,
+    post_json,
 };
 
 pub const Request = struct {

--- a/src/core/auth/provider_catalog.zig
+++ b/src/core/auth/provider_catalog.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+
+pub const Id = enum {
+    vercel,
+    openai_codex,
+
+    pub fn slug(self: Id) []const u8 {
+        return switch (self) {
+            .vercel => "vercel",
+            .openai_codex => "openai-codex",
+        };
+    }
+};
+
+pub const Entry = struct {
+    id: Id,
+    name: []const u8,
+    description: []const u8,
+    subscription: bool,
+};
+
+pub const entries = [_]Entry{
+    .{
+        .id = .vercel,
+        .name = "Vercel AI Gateway",
+        .description = "Vercel account or AI Gateway billing",
+        .subscription = false,
+    },
+    .{
+        .id = .openai_codex,
+        .name = "OpenAI Codex",
+        .description = "ChatGPT Plus, Pro, Business, Enterprise, or Edu subscription",
+        .subscription = true,
+    },
+};
+
+pub fn parse(value: []const u8) ?Id {
+    if (std.ascii.eqlIgnoreCase(value, "vercel") or
+        std.ascii.eqlIgnoreCase(value, "ai-gateway")) return .vercel;
+    if (std.ascii.eqlIgnoreCase(value, "openai-codex") or
+        std.ascii.eqlIgnoreCase(value, "chatgpt")) return .openai_codex;
+    return null;
+}
+
+pub fn find(id: Id) *const Entry {
+    for (&entries) |*entry| if (entry.id == id) return entry;
+    unreachable;
+}
+
+test "auth provider catalog parses stable slugs and compatibility aliases" {
+    try std.testing.expectEqual(Id.vercel, parse("vercel").?);
+    try std.testing.expectEqual(Id.openai_codex, parse("openai-codex").?);
+    try std.testing.expectEqual(Id.openai_codex, parse("chatgpt").?);
+    try std.testing.expect(parse("unknown") == null);
+    try std.testing.expect(find(.openai_codex).subscription);
+}

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -30,6 +30,7 @@ const notification_sound = @import("../notifications/sound.zig");
 const io_mod = @import("../shared/io.zig");
 const config_runtime = @import("../config/config_runtime.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
+const model_provider = @import("../config/model_provider.zig");
 const mcp_elicitation_interaction = @import("../mcp/elicitation_interaction.zig");
 const mcp_elicitation = @import("../mcp/elicitation.zig");
 const mcp_access_policy = @import("../mcp/access_policy.zig");
@@ -843,15 +844,18 @@ const AskContext = struct {
     }
 
     fn toolContext(self: *AskContext) tool_runtime.Context {
-        self.web_search_runtime.configure(.{
-            .api_key = self.api_key,
-            .gateway_team = self.gateway_team,
-            .worker_model = self.model,
-            .gateway_retry_count = self.cfg.gateway_retry_count,
-            .gateway_chat_url = self.cfg.gateway_chat_url,
-            .usage = &self.session.usage,
-            .usage_allocator = self.alloc,
-        });
+        const gateway_features_allowed = self.credential_source != .chatgpt_subscription;
+        if (gateway_features_allowed) {
+            self.web_search_runtime.configure(.{
+                .api_key = self.api_key,
+                .gateway_team = self.gateway_team,
+                .worker_model = self.model,
+                .gateway_retry_count = self.cfg.gateway_retry_count,
+                .gateway_chat_url = self.cfg.gateway_chat_url,
+                .usage = &self.session.usage,
+                .usage_allocator = self.alloc,
+            });
+        }
         var tc: tool_runtime.Context = .{
             .workspace_root = self.workspace_root,
             .access_scope = self.workspace_access.scope(self.workspace_root),
@@ -867,6 +871,7 @@ const AskContext = struct {
             .gateway_team = self.gateway_team,
             .credential_source = self.credential_source,
             .oauth_transport = self.cfg.gateway_provider.oauth_transport,
+            .secret_store = self.cfg.secret_store,
             .model = self.model,
             .gateway_retry_count = self.cfg.gateway_retry_count,
             .gateway_chat_url = self.cfg.gateway_chat_url,
@@ -910,7 +915,7 @@ const AskContext = struct {
             .web_fetch_progress_ctx = @ptrCast(self),
             .on_web_fetch_progress = onWebFetchProgress,
             .web_search_runtime_ready = false,
-            .web_search_backend = self.web_search_runtime.dispatchBackend(),
+            .web_search_backend = if (gateway_features_allowed) self.web_search_runtime.dispatchBackend() else null,
             .web_search_progress_ctx = @ptrCast(self),
             .on_web_search_progress = onWebSearchProgress,
             .model_capability_resolver = .{
@@ -951,6 +956,7 @@ const AskContext = struct {
     }
 
     fn admissionAutoClassifier(self: *AskContext) permission_auto_classifier.Classifier {
+        if (self.credential_source == .chatgpt_subscription) return permission_auto_classifier.Classifier.disabled();
         if (self.auto_classifier.enabled()) return self.auto_classifier;
         const provider = self.cfg.permission_reviewer_provider orelse
             return permission_auto_classifier.Classifier.disabled();
@@ -1261,8 +1267,14 @@ pub fn runPromptCapture(alloc: Allocator, prompt: []const u8, auto_permission: b
     });
 }
 
-fn missingCredentialResult(alloc: Allocator, options: RunOptions) !PromptRunResult {
-    try options.deps.write_stderr(options.deps.stderr_ctx, "fx ask: " ++ credentials.missing_credential_message ++ "\n");
+fn missingCredentialResult(alloc: Allocator, options: RunOptions, model: []const u8) !PromptRunResult {
+    const message = if (model_provider.isChatGptSubscriptionModel(model))
+        credentials.missing_chatgpt_credential_message
+    else
+        credentials.missing_credential_message;
+    try options.deps.write_stderr(options.deps.stderr_ctx, "fx ask: ");
+    try options.deps.write_stderr(options.deps.stderr_ctx, message);
+    try options.deps.write_stderr(options.deps.stderr_ctx, "\n");
     return .{
         .exit_code = 1,
         .assistant_output = try alloc.dupe(u8, ""),
@@ -1315,8 +1327,8 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     );
     try checkHeadlessCancellation(options.deps);
 
-    if (!options.continue_recovery and startup.credential == null) {
-        return missingCredentialResult(alloc, options);
+    if (!options.continue_recovery and options.resume_target == null and startup.credential == null) {
+        return missingCredentialResult(alloc, options, startup.selected_model);
     }
 
     var owned_resumed_model: ?[]u8 = null;
@@ -1395,8 +1407,31 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         ctx.session.setConversationLanguageFromUserMessage(owned_prompt);
     }
 
-    const credential = startup.credential orelse
-        return missingCredentialResult(alloc, options);
+    var routed_credential: ?credentials.Credential = null;
+    defer if (routed_credential) |*credential| credential.deinit(alloc);
+    const startup_matches_final_model = if (startup.credential) |credential|
+        model_provider.isChatGptSubscriptionModel(ctx.model) ==
+            (credential.source == .chatgpt_subscription)
+    else
+        false;
+    const credential: *const credentials.Credential = if (startup_matches_final_model)
+        &startup.credential.?
+    else routed: {
+        const preferred = if (startup.credential) |value| value.source else null;
+        const resolution = try credentials.resolveForModel(
+            alloc,
+            cfg.gateway_provider.oauth_transport,
+            cfg.secret_store,
+            .refresh_if_needed,
+            ctx.model,
+            preferred,
+        );
+        routed_credential = resolution.credential;
+        if (routed_credential == null) {
+            return missingCredentialResult(alloc, options, ctx.model);
+        }
+        break :routed &routed_credential.?;
+    };
     const api_key = credential.token;
     ctx.api_key = api_key;
     ctx.gateway_team = credential.gatewayTeam();
@@ -1761,7 +1796,7 @@ fn refreshGatewayCredential(
     mode: auth_runtime.CredentialRefreshMode,
 ) !?[]u8 {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
-    return auth_runtime.refreshFxLoginToken(
+    return auth_runtime.refreshCredentialToken(
         ctx.cfg.gateway_provider.oauth_transport,
         alloc,
         source,
@@ -4512,6 +4547,29 @@ test "CLI prompt projection configures web search then blocks native execution" 
     try std.testing.expectEqualStrings(ctx.cfg.gateway_chat_url, ctx.web_search_runtime.gateway_chat_url);
     try std.testing.expectEqual(.failure, execution.status);
     try std.testing.expectEqual(@as(usize, 0), provider_state.calls);
+}
+
+test "fx ask ChatGPT route disables Gateway-backed auxiliary providers" {
+    const alloc = std.testing.allocator;
+    var stdout_capture = TestCapture{};
+    defer stdout_capture.deinit(alloc);
+    var stderr_capture = TestCapture{};
+    defer stderr_capture.deinit(alloc);
+    var ctx = AskContext.init(
+        alloc,
+        testConfig(),
+        testPromptRunDeps(&stdout_capture, &stderr_capture, testPresentKeyStartup),
+        "/tmp/workspace",
+    );
+    defer ctx.deinit();
+    ctx.api_key = "chatgpt-secret";
+    ctx.credential_source = .chatgpt_subscription;
+    ctx.model = "openai-codex/gpt-5.4";
+
+    const tool_ctx = ctx.toolContext();
+    try std.testing.expect(tool_ctx.web_search_backend == null);
+    try std.testing.expect(!tool_ctx.auto_classifier.enabled());
+    try std.testing.expect(tool_ctx.permission_reviewer_provider == null);
 }
 
 test "fx ask finalization fails every failed turn" {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -4,6 +4,7 @@ const io_mod = @import("../shared/io.zig");
 const app_lifecycle = @import("../app/app_lifecycle.zig");
 const background_record_liveness = @import("../background/background_record_liveness.zig");
 const background_store = @import("../background/background_store.zig");
+const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
 const acp_runner = @import("acp_runner.zig");
 const cli_ask = @import("cli_ask.zig");
 const cli_replay = @import("cli_replay.zig");
@@ -22,6 +23,7 @@ const github_workflows = @import("../github/github_workflows.zig");
 const host = @import("../hosts/host.zig");
 const login_flow = @import("../auth/login_flow.zig");
 const oauth_transport = @import("../auth/oauth_transport.zig");
+const provider_catalog = @import("../auth/provider_catalog.zig");
 const secret = @import("../auth/secret.zig");
 const output_contracts = @import("../output/output_contracts.zig");
 const permission_auto_classifier = @import("../permissions/auto_classifier.zig");
@@ -194,6 +196,12 @@ pub const Config = struct {
 const LocalSurfaceOptions = struct {
     format: output_contracts.OutputFormat = .text,
 };
+
+fn parseLoginProvider(rest: []const [:0]const u8) !?provider_catalog.Id {
+    if (rest.len == 0) return null;
+    if (rest.len != 1) return error.InvalidLoginProviderArgs;
+    return provider_catalog.parse(rest[0]) orelse error.InvalidLoginProviderArgs;
+}
 
 const UpgradeOptions = struct {
     format: output_contracts.OutputFormat = .text,
@@ -707,30 +715,69 @@ fn runNonInteractiveWithDeps(
         .pr => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .pull_request),
         .issue => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .issue),
         .login => |rest| {
-            if (rest.len != 0) {
-                try writeStderr(deps, "usage: fx login\n");
-                return .handled_failure;
-            }
-            login_flow.runLogin(
-                alloc,
-                cfg.gateway_provider.oauth_transport,
-                cfg.url_opener,
-            ) catch |err| {
-                const message = switch (err) {
-                    error.ClientIdMissing => "fx login: missing FX_OAUTH_CLIENT_ID; configure the fx Vercel App client id first\n",
-                    error.AccessDenied => "fx login: authorization denied\n",
-                    error.ExpiredToken, error.LoginTimedOut => "fx login: authorization expired; run fx login again\n",
-                    else => "fx login: failed to sign in\n",
-                };
-                try writeStderr(deps, message);
+            const maybe_login_provider = parseLoginProvider(rest) catch {
+                try writeStderr(deps, "usage: fx login [vercel|openai-codex]\n");
                 return .handled_failure;
             };
+            // Preserve the original `fx login` behavior for scripts and users.
+            const login_provider = maybe_login_provider orelse .vercel;
+            switch (login_provider) {
+                .vercel => login_flow.runLogin(
+                    alloc,
+                    cfg.gateway_provider.oauth_transport,
+                    cfg.url_opener,
+                ) catch |err| {
+                    const message = switch (err) {
+                        error.ClientIdMissing => "fx login: missing FX_OAUTH_CLIENT_ID; configure the fx Vercel App client id first\n",
+                        error.AccessDenied => "fx login: authorization denied\n",
+                        error.ExpiredToken, error.LoginTimedOut => "fx login: authorization expired; run fx login again\n",
+                        else => "fx login: failed to sign in\n",
+                    };
+                    try writeStderr(deps, message);
+                    return .handled_failure;
+                },
+                .openai_codex => chatgpt_oauth.runLogin(
+                    alloc,
+                    cfg.gateway_provider.oauth_transport,
+                    cfg.url_opener,
+                ) catch |err| {
+                    const message = switch (err) {
+                        error.ChatGptLoginTimedOut => "fx login: ChatGPT authorization expired; run fx login openai-codex again\n",
+                        error.ChatGptAuthorizationFailed => "fx login: ChatGPT authorization denied\n",
+                        else => "fx login: failed to sign in with ChatGPT\n",
+                    };
+                    try writeStderr(deps, message);
+                    return .handled_failure;
+                },
+            }
             return .handled_success;
         },
         .logout => |rest| {
-            if (rest.len != 0) {
-                try writeStderr(deps, "usage: fx logout\n");
+            const maybe_login_provider = parseLoginProvider(rest) catch {
+                try writeStderr(deps, "usage: fx logout [vercel|openai-codex]\n");
                 return .handled_failure;
+            };
+            // Preserve the original `fx logout` behavior for scripts and users.
+            const login_provider = maybe_login_provider orelse .vercel;
+            if (login_provider == .openai_codex) {
+                const outcome = chatgpt_oauth.logout() catch {
+                    try writeStderr(deps, "fx logout: failed to durably remove saved ChatGPT login\n");
+                    return .handled_failure;
+                };
+                return switch (outcome) {
+                    .deleted => result: {
+                        try writeStdout(deps, "Signed out of ChatGPT.\n");
+                        break :result .handled_success;
+                    },
+                    .missing => result: {
+                        try writeStdout(deps, "No ChatGPT login session found.\n");
+                        break :result .handled_success;
+                    },
+                    .deleted_not_durable => result: {
+                        try writeStderr(deps, "fx logout: failed to durably remove saved ChatGPT login\n");
+                        break :result .handled_failure;
+                    },
+                };
             }
             const result = login_flow.logout(alloc, cfg.gateway_provider.oauth_transport) catch |err| switch (err) {
                 error.SessionDeleteFailed => {
@@ -1250,6 +1297,7 @@ fn runNonInteractiveWithDeps(
 
             var snapshot = cfg.gateway_provider.credits.fetch(alloc, .{
                 .credential = startup.apiKey(),
+                .credential_source = if (startup.credential) |credential| credential.source else null,
                 .tenant = startup.gatewayTeam(),
             });
             defer snapshot.deinit(alloc);
@@ -4520,7 +4568,7 @@ test "runIfRequested models passes startup team to fetch seam" {
     try std.testing.expectEqual(RunResult.handled_success, result);
     try std.testing.expect(probe.called);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[\"private/blue-hornbill\"]}\n",
+        "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[\"private/blue-hornbill\"],\"models\":[{\"id\":\"private/blue-hornbill\",\"source\":\"Vercel AI Gateway\"}]}\n",
         capture.stdout.written(),
     );
 }
@@ -4599,7 +4647,7 @@ test "runIfRequested local json success appends exactly one newline" {
     const result = try runIfRequestedWithDeps(std.testing.allocator, &.{ @constCast("status"), @constCast("--json") }, testConfig(), deps);
     try std.testing.expectEqual(RunResult.handled_success, result);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"status\",\"model\":\"test-model\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"auto\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":42}\n",
+        "{\"kind\":\"status\",\"model\":\"test-model\",\"model_source\":\"Vercel AI Gateway\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"connected_providers\":[],\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"auto\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":42}\n",
         capture.stdout.written(),
     );
     try std.testing.expect(!std.mem.endsWith(u8, capture.stdout.written(), "\n\n"));
@@ -4692,7 +4740,7 @@ test "writeRenderedJsonLine falls back to heap and appends exactly one newline" 
     );
 
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"status\",\"model\":\"test-model\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":42}\n",
+        "{\"kind\":\"status\",\"model\":\"test-model\",\"model_source\":\"Vercel AI Gateway\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"connected_providers\":[],\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":42}\n",
         capture.stdout.written(),
     );
 }
@@ -4738,7 +4786,7 @@ test "writeRenderedJsonLine renders doctor json through output contract" {
     );
 
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"doctor\",\"ok_count\":1,\"warn_count\":1,\"fail_count\":0,\"workspace\":\"/tmp/fx\",\"model\":\"test-model\",\"auth\":\"AI_GATEWAY_API_KEY\",\"auth_refreshable\":false,\"permission_mode\":\"auto\",\"agent_step_limit\":42,\"checks\":[{\"name\":\"auth\",\"status\":\"ok\",\"detail\":\"AI_GATEWAY_API_KEY is configured\"},{\"name\":\"gh\",\"status\":\"warn\",\"detail\":\"GitHub CLI not found in PATH\"}]}\n",
+        "{\"kind\":\"doctor\",\"ok_count\":1,\"warn_count\":1,\"fail_count\":0,\"workspace\":\"/tmp/fx\",\"model\":\"test-model\",\"model_source\":\"Vercel AI Gateway\",\"auth\":\"AI_GATEWAY_API_KEY\",\"auth_refreshable\":false,\"permission_mode\":\"auto\",\"agent_step_limit\":42,\"checks\":[{\"name\":\"auth\",\"status\":\"ok\",\"detail\":\"AI_GATEWAY_API_KEY is configured\"},{\"name\":\"gh\",\"status\":\"warn\",\"detail\":\"GitHub CLI not found in PATH\"}]}\n",
         capture.stdout.written(),
     );
 }

--- a/src/core/config/model_provider.zig
+++ b/src/core/config/model_provider.zig
@@ -1,0 +1,31 @@
+const std = @import("std");
+
+pub const chatgpt_subscription_prefix = "openai-codex/";
+pub const default_chatgpt_subscription_model = chatgpt_subscription_prefix ++ "gpt-5.4";
+
+pub fn isChatGptSubscriptionModel(model: []const u8) bool {
+    return std.mem.startsWith(u8, model, chatgpt_subscription_prefix) and
+        model.len > chatgpt_subscription_prefix.len;
+}
+
+pub fn upstreamModel(model: []const u8) ?[]const u8 {
+    if (!isChatGptSubscriptionModel(model)) return null;
+    return model[chatgpt_subscription_prefix.len..];
+}
+
+pub fn sourceLabel(model: []const u8) []const u8 {
+    return if (isChatGptSubscriptionModel(model))
+        "ChatGPT subscription"
+    else
+        "Vercel AI Gateway";
+}
+
+test "ChatGPT subscription model routing requires a non-empty upstream model" {
+    try std.testing.expect(isChatGptSubscriptionModel("openai-codex/gpt-5.4"));
+    try std.testing.expectEqualStrings("gpt-5.4", upstreamModel("openai-codex/gpt-5.4").?);
+    try std.testing.expect(!isChatGptSubscriptionModel("openai-codex/"));
+    try std.testing.expect(!isChatGptSubscriptionModel("openai/gpt-5.4"));
+    try std.testing.expect(upstreamModel("openai/gpt-5.4") == null);
+    try std.testing.expectEqualStrings("ChatGPT subscription", sourceLabel("openai-codex/gpt-5.4"));
+    try std.testing.expectEqualStrings("Vercel AI Gateway", sourceLabel("openai/gpt-5.4"));
+}

--- a/src/core/config/model_provider.zig
+++ b/src/core/config/model_provider.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
 pub const chatgpt_subscription_prefix = "openai-codex/";
-pub const default_chatgpt_subscription_model = chatgpt_subscription_prefix ++ "gpt-5.4";
+pub const default_chatgpt_subscription_model = chatgpt_subscription_prefix ++ "gpt-5.6-sol";
 
 pub fn isChatGptSubscriptionModel(model: []const u8) bool {
     return std.mem.startsWith(u8, model, chatgpt_subscription_prefix) and
@@ -21,8 +21,9 @@ pub fn sourceLabel(model: []const u8) []const u8 {
 }
 
 test "ChatGPT subscription model routing requires a non-empty upstream model" {
-    try std.testing.expect(isChatGptSubscriptionModel("openai-codex/gpt-5.4"));
-    try std.testing.expectEqualStrings("gpt-5.4", upstreamModel("openai-codex/gpt-5.4").?);
+    try std.testing.expectEqualStrings("openai-codex/gpt-5.6-sol", default_chatgpt_subscription_model);
+    try std.testing.expect(isChatGptSubscriptionModel("openai-codex/gpt-5.6-sol"));
+    try std.testing.expectEqualStrings("gpt-5.6-sol", upstreamModel("openai-codex/gpt-5.6-sol").?);
     try std.testing.expect(!isChatGptSubscriptionModel("openai-codex/"));
     try std.testing.expect(!isChatGptSubscriptionModel("openai/gpt-5.4"));
     try std.testing.expect(upstreamModel("openai/gpt-5.4") == null);

--- a/src/core/gateway/gateway_json.zig
+++ b/src/core/gateway/gateway_json.zig
@@ -849,6 +849,7 @@ pub fn freeGatewayCompletion(alloc: std.mem.Allocator, completion: GatewayComple
         alloc.free(tool_call.arguments_json);
     }
     if (completion.tool_calls.len > 0) alloc.free(completion.tool_calls);
+    if (completion.provider_state_json) |state| alloc.free(state);
 }
 
 fn checkParseGatewayCompletionAllocFailures(alloc: std.mem.Allocator) !void {

--- a/src/core/gateway/gateway_provider.zig
+++ b/src/core/gateway/gateway_provider.zig
@@ -61,6 +61,7 @@ pub const CliModelCatalogProvider = struct {
 
 pub const CreditsLookupInput = struct {
     credential: ?[]const u8,
+    credential_source: ?credentials.Source = null,
     tenant: ?[]const u8,
 };
 

--- a/src/core/gateway/model_catalog.zig
+++ b/src/core/gateway/model_catalog.zig
@@ -373,7 +373,8 @@ pub fn compareModelCatalogEntries(_: void, a: ModelCatalogEntry, b: ModelCatalog
 
 fn modelProviderRank(id: []const u8) u8 {
     if (std.mem.startsWith(u8, id, "anthropic/")) return 0;
-    if (std.mem.startsWith(u8, id, "openai/")) return 1;
+    if (std.mem.startsWith(u8, id, "openai/") or
+        std.mem.startsWith(u8, id, "openai-codex/")) return 1;
     if (std.mem.startsWith(u8, id, "google/")) return 2;
     if (std.mem.startsWith(u8, id, "xai/")) return 3;
     if (std.mem.startsWith(u8, id, "deepseek/")) return 4;
@@ -414,6 +415,7 @@ const FeaturedPickerFamily = struct {
 const featured_picker_families = [_]FeaturedPickerFamily{
     .{ .family = "anthropic/claude-fable", .count = 1 },
     .{ .family = "openai/gpt", .count = 1 },
+    .{ .family = "openai-codex/gpt", .count = 1 },
     .{ .family = "xai/grok-build", .count = 1 },
     .{ .family = "anthropic/claude-opus", .count = 1 },
     .{ .family = "zai/glm", .count = 1 },
@@ -545,7 +547,10 @@ fn modelPickerProvider(id: []const u8) []const u8 {
 }
 
 fn pickerProviderLimit(provider: []const u8) usize {
-    if (std.mem.eql(u8, provider, "anthropic") or std.mem.eql(u8, provider, "openai")) {
+    if (std.mem.eql(u8, provider, "anthropic") or
+        std.mem.eql(u8, provider, "openai") or
+        std.mem.eql(u8, provider, "openai-codex"))
+    {
         return extended_picker_provider_limit;
     }
     return picker_provider_limit;
@@ -851,6 +856,21 @@ test "catalog order prefers tool use, tier, provider, then recency" {
     try std.testing.expectEqualStrings("xai/grok-flash", entries[3].id);
     try std.testing.expectEqualStrings("anthropic/claude-haiku-4.5", entries[4].id);
     try std.testing.expectEqualStrings("mistral/large-x", entries[5].id);
+}
+
+test "picker preserves equivalent Gateway and ChatGPT model routes" {
+    const candidates = [_]ModelCatalogEntry{
+        .{ .id = @constCast("openai/gpt-5.6-sol"), .model_type = @constCast("language"), .released = 200, .has_tool_use = true },
+        .{ .id = @constCast("openai-codex/gpt-5.6-sol"), .model_type = @constCast("language"), .released = 200, .has_tool_use = true },
+        .{ .id = @constCast("openai-codex/gpt-5.6-terra"), .model_type = @constCast("language"), .released = 200, .has_tool_use = true },
+    };
+
+    var curated = try projectPickerModelCatalog(std.testing.allocator, &candidates);
+    defer freeModelCatalog(std.testing.allocator, &curated);
+
+    try std.testing.expectEqual(@as(usize, 3), curated.items.len);
+    try std.testing.expect(pickerCatalogContains(curated.items, "openai/gpt-5.6-sol"));
+    try std.testing.expect(pickerCatalogContains(curated.items, "openai-codex/gpt-5.6-sol"));
 }
 
 test "featured deepseek slot prefers the pro variant at equal recency" {

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -3,6 +3,7 @@ const auth_runtime = @import("../auth/auth_runtime.zig");
 const credentials = @import("../auth/credentials.zig");
 const background_store = @import("../background/background_store.zig");
 const doctor_runtime = @import("../cli/doctor_runtime.zig");
+const model_provider = @import("../config/model_provider.zig");
 const permissions = @import("../permissions/permissions.zig");
 const sandbox = @import("../permissions/sandbox.zig");
 const session_display_metadata = @import("../session/session_display_metadata.zig");
@@ -360,6 +361,29 @@ fn writeTerminalSafe(writer: *std.Io.Writer, alloc: Allocator, raw: []const u8) 
     try writer.writeAll(encoded.bytes);
 }
 
+fn gatewayProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
+    const source = auth.active_source orelse return auth.gateway_connected;
+    return auth.gateway_connected or source != .chatgpt_subscription;
+}
+
+fn chatGptProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
+    return auth.chatgpt_connected or auth.active_source == .chatgpt_subscription;
+}
+
+fn writeConnectedProvidersText(writer: *std.Io.Writer, auth: auth_runtime.StatusSnapshot) !void {
+    var wrote_provider = false;
+    if (gatewayProviderConnected(auth)) {
+        try writer.writeAll("Vercel AI Gateway");
+        wrote_provider = true;
+    }
+    if (chatGptProviderConnected(auth)) {
+        if (wrote_provider) try writer.writeAll(", ChatGPT");
+        if (!wrote_provider) try writer.writeAll("ChatGPT");
+        wrote_provider = true;
+    }
+    if (!wrote_provider) try writer.writeAll("none");
+}
+
 pub const StatusSnapshot = struct {
     model: []const u8,
     update_channel: []const u8 = "stable",
@@ -387,6 +411,7 @@ pub const StatusSnapshot = struct {
         defer out.deinit();
 
         try out.writer.print("[status] model={s}\n", .{self.model});
+        try out.writer.print("[status] model_source={s}\n", .{model_provider.sourceLabel(self.model)});
         try out.writer.print("[status] update_channel={s}\n", .{self.update_channel});
         try out.writer.print("[status] build_channel={s}\n", .{self.build_channel});
         if (self.build_revision.len > 0) {
@@ -396,6 +421,9 @@ pub const StatusSnapshot = struct {
             try out.writer.print("[status] mcp_config_error={s}\n", .{error_name});
         }
         try out.writer.print("[status] auth={s}\n", .{self.auth.activeSourceLabel()});
+        try out.writer.writeAll("[status] connected_providers=");
+        try writeConnectedProvidersText(&out.writer, self.auth);
+        try out.writer.writeByte('\n');
         try out.writer.print("[status] auth_refreshable={}\n", .{self.auth.refreshable()});
         if (self.auth.expired) try out.writer.writeAll("[status] auth_expired=true\n");
         if (self.auth_help) |help| {
@@ -418,12 +446,16 @@ pub const StatusSnapshot = struct {
         defer out.deinit();
 
         try out.writer.print("model={s}\n", .{self.model});
+        try out.writer.print("model_source={s}\n", .{model_provider.sourceLabel(self.model)});
         try out.writer.print("update_channel={s}\n", .{self.update_channel});
         try out.writer.print("build_channel={s}\n", .{self.build_channel});
         if (self.build_revision.len > 0) {
             try out.writer.print("build_revision={s}\n", .{self.build_revision});
         }
         try out.writer.print("auth={s}\n", .{self.auth.activeSourceLabel()});
+        try out.writer.writeAll("connected_providers=");
+        try writeConnectedProvidersText(&out.writer, self.auth);
+        try out.writer.writeByte('\n');
         try out.writer.print("auth_refreshable={}\n", .{self.auth.refreshable()});
         if (self.auth.expired) try out.writer.writeAll("auth_expired=true\n");
         if (self.auth_help) |help| try out.writer.print("auth_help={s}\n", .{help});
@@ -448,6 +480,8 @@ pub const StatusSnapshot = struct {
     pub fn writeJson(self: StatusSnapshot, writer: *std.Io.Writer) !void {
         try writer.writeAll("{\"kind\":\"status\",\"model\":");
         try std.json.Stringify.value(self.model, .{}, writer);
+        try writer.writeAll(",\"model_source\":");
+        try std.json.Stringify.value(model_provider.sourceLabel(self.model), .{}, writer);
         try writer.writeAll(",\"update_channel\":");
         try std.json.Stringify.value(self.update_channel, .{}, writer);
         try writer.writeAll(",\"build_channel\":");
@@ -460,6 +494,17 @@ pub const StatusSnapshot = struct {
         }
         try writer.writeAll(",\"auth\":");
         try std.json.Stringify.value(self.auth.activeSourceLabel(), .{}, writer);
+        try writer.writeAll(",\"connected_providers\":[");
+        var wrote_provider = false;
+        if (gatewayProviderConnected(self.auth)) {
+            try std.json.Stringify.value("vercel-ai-gateway", .{}, writer);
+            wrote_provider = true;
+        }
+        if (chatGptProviderConnected(self.auth)) {
+            if (wrote_provider) try writer.writeByte(',');
+            try std.json.Stringify.value("chatgpt", .{}, writer);
+        }
+        try writer.writeByte(']');
         try writer.print(",\"auth_refreshable\":{}", .{self.auth.refreshable()});
         if (self.auth.expired) try writer.writeAll(",\"auth_expired\":true");
         if (self.auth_help) |help| {
@@ -606,7 +651,7 @@ pub const ModelListSnapshot = struct {
 
         const shown = self.shownCount();
         for (self.ids[0..shown]) |id| {
-            try out.writer.print(" - {s}\n", .{id});
+            try out.writer.print(" - {s} · {s}\n", .{ id, model_provider.sourceLabel(id) });
         }
         if (self.ids.len > shown) {
             try out.writer.print(" ... and {d} more\n", .{self.ids.len - shown});
@@ -628,7 +673,7 @@ pub const ModelListSnapshot = struct {
         defer out.deinit();
         try out.writer.print("{d} available", .{self.ids.len});
         const shown = self.shownCount();
-        for (self.ids[0..shown]) |id| try out.writer.print("\n - {s}", .{id});
+        for (self.ids[0..shown]) |id| try out.writer.print("\n - {s} · {s}", .{ id, model_provider.sourceLabel(id) });
         if (self.ids.len > shown) try out.writer.print("\n ... and {d} more", .{self.ids.len - shown});
         if (self.catalogExplanation()) |explanation| try out.writer.print("\n{s}", .{explanation});
         return try out.toOwnedSlice();
@@ -647,6 +692,15 @@ pub const ModelListSnapshot = struct {
             if (i > 0) try out.writer.writeByte(',');
             try std.json.Stringify.value(id, .{}, &out.writer);
         }
+        try out.writer.writeAll("],\"models\":[");
+        for (self.ids[0..shown], 0..) |id, i| {
+            if (i > 0) try out.writer.writeByte(',');
+            try out.writer.writeAll("{\"id\":");
+            try std.json.Stringify.value(id, .{}, &out.writer);
+            try out.writer.writeAll(",\"source\":");
+            try std.json.Stringify.value(model_provider.sourceLabel(id), .{}, &out.writer);
+            try out.writer.writeByte('}');
+        }
         try out.writer.writeAll("]}");
         return try out.toOwnedSlice();
     }
@@ -664,6 +718,7 @@ pub const ModelListSnapshot = struct {
             .fx_login_refresh_required => "Vercel sign-in must refresh before team-private models can load.",
             .credential_refresh_failed => "Vercel sign-in refresh failed; using the public model catalog.",
             .authenticated_credential_rejected => "Your Gateway credential was rejected; using the public model catalog.",
+            .chatgpt_subscription => "ChatGPT subscription models are available alongside the public Gateway catalog.",
         };
     }
 };
@@ -1043,6 +1098,7 @@ pub const DoctorSnapshot = struct {
         );
         try out.writer.print("[doctor] workspace={s}\n", .{self.workspace_root});
         try out.writer.print("[doctor] model={s}\n", .{self.model});
+        try out.writer.print("[doctor] model_source={s}\n", .{model_provider.sourceLabel(self.model)});
         try out.writer.print("[doctor] auth={s}\n", .{self.auth.activeSourceLabel()});
         try out.writer.print("[doctor] auth_refreshable={}\n", .{self.auth.refreshable()});
         if (self.auth.expired) try out.writer.writeAll("[doctor] auth_expired=true\n");
@@ -1077,6 +1133,8 @@ pub const DoctorSnapshot = struct {
         try std.json.Stringify.value(self.workspace_root, .{}, writer);
         try writer.writeAll(",\"model\":");
         try std.json.Stringify.value(self.model, .{}, writer);
+        try writer.writeAll(",\"model_source\":");
+        try std.json.Stringify.value(model_provider.sourceLabel(self.model), .{}, writer);
         try writer.writeAll(",\"auth\":");
         try std.json.Stringify.value(self.auth.activeSourceLabel(), .{}, writer);
         try writer.print(",\"auth_refreshable\":{}", .{self.auth.refreshable()});
@@ -1778,14 +1836,14 @@ test "core status snapshot text and json stay stable" {
     const text = try snapshot.renderText(std.testing.allocator);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings(
-        "[status] model=alpha\n[status] update_channel=stable\n[status] build_channel=stable\n[status] auth=missing\n[status] auth_refreshable=false\n[status] auth_help=Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\n[status] permission_mode=ask\n[status] sandbox=none\n[status] workspace=/tmp/fx\n[status] history_turns=3\n[status] session_permission_grants=1\n[status] agent_step_limit=24\n",
+        "[status] model=alpha\n[status] model_source=Vercel AI Gateway\n[status] update_channel=stable\n[status] build_channel=stable\n[status] auth=missing\n[status] connected_providers=none\n[status] auth_refreshable=false\n[status] auth_help=Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\n[status] permission_mode=ask\n[status] sandbox=none\n[status] workspace=/tmp/fx\n[status] history_turns=3\n[status] session_permission_grants=1\n[status] agent_step_limit=24\n",
         text,
     );
 
     const json = try snapshot.renderJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"status\",\"model\":\"alpha\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":3,\"session_permission_grants\":1,\"agent_step_limit\":24}",
+        "{\"kind\":\"status\",\"model\":\"alpha\",\"model_source\":\"Vercel AI Gateway\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"connected_providers\":[],\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":3,\"session_permission_grants\":1,\"agent_step_limit\":24}",
         json,
     );
 }
@@ -1804,16 +1862,41 @@ test "core status snapshot includes selected team when present" {
     const text = try snapshot.renderText(std.testing.allocator);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings(
-        "[status] model=alpha\n[status] update_channel=stable\n[status] build_channel=stable\n[status] auth=fx login\n[status] auth_refreshable=true\n[status] team=example-team\n[status] permission_mode=ask\n[status] sandbox=none\n[status] workspace=/tmp/fx\n[status] history_turns=0\n[status] session_permission_grants=0\n[status] agent_step_limit=24\n",
+        "[status] model=alpha\n[status] model_source=Vercel AI Gateway\n[status] update_channel=stable\n[status] build_channel=stable\n[status] auth=fx login\n[status] connected_providers=Vercel AI Gateway\n[status] auth_refreshable=true\n[status] team=example-team\n[status] permission_mode=ask\n[status] sandbox=none\n[status] workspace=/tmp/fx\n[status] history_turns=0\n[status] session_permission_grants=0\n[status] agent_step_limit=24\n",
         text,
     );
 
     const json = try snapshot.renderJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"status\",\"model\":\"alpha\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"fx login\",\"auth_refreshable\":true,\"team\":\"example-team\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":24}",
+        "{\"kind\":\"status\",\"model\":\"alpha\",\"model_source\":\"Vercel AI Gateway\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"fx login\",\"connected_providers\":[\"vercel-ai-gateway\"],\"auth_refreshable\":true,\"team\":\"example-team\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":24}",
         json,
     );
+}
+
+test "status distinguishes the selected model route from connected providers" {
+    const snapshot = StatusSnapshot{
+        .model = "openai-codex/gpt-5.4",
+        .auth = .{
+            .active_source = .chatgpt_subscription,
+            .gateway_connected = true,
+            .chatgpt_connected = true,
+        },
+        .permission_mode = .auto,
+        .workspace_root = "/tmp/fx",
+        .history_turns = 0,
+        .session_permission_grants = 0,
+        .agent_step_limit = 24,
+    };
+    const text = try snapshot.renderText(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.find(u8, text, "model_source=ChatGPT subscription") != null);
+    try std.testing.expect(std.mem.find(u8, text, "connected_providers=Vercel AI Gateway, ChatGPT") != null);
+
+    const json = try snapshot.renderJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.find(u8, json, "\"model_source\":\"ChatGPT subscription\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"connected_providers\":[\"vercel-ai-gateway\",\"chatgpt\"]") != null);
 }
 
 test "MCP config diagnostic renders in status text and JSON but not interactive body" {
@@ -1891,13 +1974,13 @@ test "model list explains public-only and rejected-credential catalogs" {
     }{
         .{
             .snapshot = .{ .ids = &ids, .private_models_hidden = true, .public_only_reason = .no_credential },
-            .text = "[models] 1 available\n - alpha\n[models] Using the public model catalog; sign in with Vercel or use an AI Gateway API key for team-private models.\n",
-            .body = "1 available\n - alpha\nUsing the public model catalog; sign in with Vercel or use an AI Gateway API key for team-private models.",
+            .text = "[models] 1 available\n - alpha · Vercel AI Gateway\n[models] Using the public model catalog; sign in with Vercel or use an AI Gateway API key for team-private models.\n",
+            .body = "1 available\n - alpha · Vercel AI Gateway\nUsing the public model catalog; sign in with Vercel or use an AI Gateway API key for team-private models.",
         },
         .{
             .snapshot = rejected,
-            .text = "[models] 1 available\n - alpha\n[models] Your Gateway credential was rejected; using the public model catalog.\n",
-            .body = "1 available\n - alpha\nYour Gateway credential was rejected; using the public model catalog.",
+            .text = "[models] 1 available\n - alpha · Vercel AI Gateway\n[models] Your Gateway credential was rejected; using the public model catalog.\n",
+            .body = "1 available\n - alpha · Vercel AI Gateway\nYour Gateway credential was rejected; using the public model catalog.",
         },
         .{
             .snapshot = .{ .ids = &.{}, .private_models_hidden = true, .public_only_reason = .no_credential },
@@ -1924,7 +2007,7 @@ test "model list explains public-only and rejected-credential catalogs" {
     const json = try rejected.renderJson(alloc);
     defer alloc.free(json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":true,\"ids\":[\"alpha\"]}",
+        "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":true,\"ids\":[\"alpha\"],\"models\":[{\"id\":\"alpha\",\"source\":\"Vercel AI Gateway\"}]}",
         json,
     );
 
@@ -1943,21 +2026,21 @@ test "core model list snapshot handles limits and empty lists" {
     const all_text = try (ModelListSnapshot{ .ids = &ids }).renderText(std.testing.allocator);
     defer std.testing.allocator.free(all_text);
     try std.testing.expectEqualStrings(
-        "[models] 3 available\n - alpha\n - beta\n - gamma\n",
+        "[models] 3 available\n - alpha · Vercel AI Gateway\n - beta · Vercel AI Gateway\n - gamma · Vercel AI Gateway\n",
         all_text,
     );
 
     const limit_text = try (ModelListSnapshot{ .ids = &ids, .limit = 2 }).renderText(std.testing.allocator);
     defer std.testing.allocator.free(limit_text);
     try std.testing.expectEqualStrings(
-        "[models] 3 available\n - alpha\n - beta\n ... and 1 more\n",
+        "[models] 3 available\n - alpha · Vercel AI Gateway\n - beta · Vercel AI Gateway\n ... and 1 more\n",
         limit_text,
     );
 
     const limit_json = try (ModelListSnapshot{ .ids = &ids, .limit = 2 }).renderJson(std.testing.allocator);
     defer std.testing.allocator.free(limit_json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"models\",\"count\":3,\"shown_count\":2,\"more_count\":1,\"private_models_hidden\":false,\"ids\":[\"alpha\",\"beta\"]}",
+        "{\"kind\":\"models\",\"count\":3,\"shown_count\":2,\"more_count\":1,\"private_models_hidden\":false,\"ids\":[\"alpha\",\"beta\"],\"models\":[{\"id\":\"alpha\",\"source\":\"Vercel AI Gateway\"},{\"id\":\"beta\",\"source\":\"Vercel AI Gateway\"}]}",
         limit_json,
     );
 
@@ -1968,7 +2051,7 @@ test "core model list snapshot handles limits and empty lists" {
     const empty_json = try (ModelListSnapshot{ .ids = &.{} }).renderJson(std.testing.allocator);
     defer std.testing.allocator.free(empty_json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"models\",\"count\":0,\"shown_count\":0,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[]}",
+        "{\"kind\":\"models\",\"count\":0,\"shown_count\":0,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[],\"models\":[]}",
         empty_json,
     );
 }
@@ -2401,14 +2484,14 @@ test "core doctor snapshot text and json stay stable" {
     const text = try snapshot.renderText(std.testing.allocator);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings(
-        "[doctor] ok=1 warn=1 fail=0\n[doctor] workspace=/tmp/fx\n[doctor] model=alpha\n[doctor] auth=AI_GATEWAY_API_KEY\n[doctor] auth_refreshable=false\n[doctor] permission_mode=ask\n[doctor] agent_step_limit=24\n[ok] auth: AI_GATEWAY_API_KEY is configured\n[warn] gh: GitHub CLI not found in PATH\n",
+        "[doctor] ok=1 warn=1 fail=0\n[doctor] workspace=/tmp/fx\n[doctor] model=alpha\n[doctor] model_source=Vercel AI Gateway\n[doctor] auth=AI_GATEWAY_API_KEY\n[doctor] auth_refreshable=false\n[doctor] permission_mode=ask\n[doctor] agent_step_limit=24\n[ok] auth: AI_GATEWAY_API_KEY is configured\n[warn] gh: GitHub CLI not found in PATH\n",
         text,
     );
 
     const json = try snapshot.renderJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"doctor\",\"ok_count\":1,\"warn_count\":1,\"fail_count\":0,\"workspace\":\"/tmp/fx\",\"model\":\"alpha\",\"auth\":\"AI_GATEWAY_API_KEY\",\"auth_refreshable\":false,\"permission_mode\":\"ask\",\"agent_step_limit\":24,\"checks\":[{\"name\":\"auth\",\"status\":\"ok\",\"detail\":\"AI_GATEWAY_API_KEY is configured\"},{\"name\":\"gh\",\"status\":\"warn\",\"detail\":\"GitHub CLI not found in PATH\"}]}",
+        "{\"kind\":\"doctor\",\"ok_count\":1,\"warn_count\":1,\"fail_count\":0,\"workspace\":\"/tmp/fx\",\"model\":\"alpha\",\"model_source\":\"Vercel AI Gateway\",\"auth\":\"AI_GATEWAY_API_KEY\",\"auth_refreshable\":false,\"permission_mode\":\"ask\",\"agent_step_limit\":24,\"checks\":[{\"name\":\"auth\",\"status\":\"ok\",\"detail\":\"AI_GATEWAY_API_KEY is configured\"},{\"name\":\"gh\",\"status\":\"warn\",\"detail\":\"GitHub CLI not found in PATH\"}]}",
         json,
     );
 }

--- a/src/core/shared/profile_paths.zig
+++ b/src/core/shared/profile_paths.zig
@@ -4,6 +4,7 @@ const Allocator = std.mem.Allocator;
 
 pub const root_dir_name = ".fx";
 pub const auth_file_name = "auth.json";
+pub const chatgpt_auth_file_name = "chatgpt-auth.json";
 pub const api_key_file_name = "api-key";
 pub const sessions_dir_name = "sessions";
 pub const prompt_history_file_name = "history.jsonl";
@@ -52,6 +53,10 @@ pub fn managedSkillsDir(alloc: Allocator, home: []const u8) ![]u8 {
 
 pub fn authPath(alloc: Allocator, home: []const u8) ![]u8 {
     return std.fs.path.join(alloc, &.{ home, root_dir_name, auth_file_name });
+}
+
+pub fn chatgptAuthPath(alloc: Allocator, home: []const u8) ![]u8 {
+    return std.fs.path.join(alloc, &.{ home, root_dir_name, chatgpt_auth_file_name });
 }
 
 pub fn apiKeyPath(alloc: Allocator, home: []const u8) ![]u8 {
@@ -122,6 +127,10 @@ test "profile path helpers preserve current default locations" {
     const auth = try authPath(alloc, "/tmp/fake-home");
     defer alloc.free(auth);
     try std.testing.expectEqualStrings("/tmp/fake-home/.fx/auth.json", auth);
+
+    const chatgpt_auth = try chatgptAuthPath(alloc, "/tmp/fake-home");
+    defer alloc.free(chatgpt_auth);
+    try std.testing.expectEqualStrings("/tmp/fake-home/.fx/chatgpt-auth.json", chatgpt_auth);
 
     const api_key = try apiKeyPath(alloc, "/tmp/fake-home");
     defer alloc.free(api_key);

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -92,6 +92,7 @@ pub const CredentialSource = enum {
     ai_gateway_api_key,
     fx_login,
     stored_key,
+    chatgpt_subscription,
 };
 
 pub fn parseCredentialSource(text: []const u8) ?CredentialSource {
@@ -866,6 +867,9 @@ pub const ChatMessage = struct {
     tool_call_id: ?[]const u8 = null,
     tool_name: ?[]const u8 = null,
     tool_calls: []const ToolCall = &.{},
+    /// Provider-owned opaque response items needed only for stateless within-turn continuation.
+    /// The value is a validated JSON array and is never sent across provider routes.
+    provider_state_json: ?[]const u8 = null,
     tool_result_status: ?PersistedToolStatus = null,
     tool_result_memory: ?ToolResultMemory = null,
     permission_feedback: bool = false,
@@ -959,6 +963,8 @@ pub const GatewayCompletion = struct {
     delivery_ambiguous: bool = false,
     provider_result_identity_failure: ?ProviderResultIdentityFailure = null,
     provider_failure_detail: ?[]const u8 = null,
+    /// Provider-owned opaque response items for the next stateless request in this turn.
+    provider_state_json: ?[]const u8 = null,
     finish_reason: ?ProviderFinishReason = null,
     usage: Usage = .{},
 };

--- a/src/core/slash_commands/command_router.zig
+++ b/src/core/slash_commands/command_router.zig
@@ -14,7 +14,7 @@ pub const ParsedCommand = union(enum) {
     rename_session: []const u8,
     help,
     login,
-    logout,
+    logout: []const u8,
     setup,
     status,
     background,
@@ -60,7 +60,7 @@ pub const CommandHandlers = struct {
     continue_recovery: *const fn (ctx: *anyopaque) anyerror!void,
     show_help: *const fn (ctx: *anyopaque) anyerror!void,
     login: *const fn (ctx: *anyopaque) anyerror!void,
-    logout: *const fn (ctx: *anyopaque) anyerror!void,
+    logout: *const fn (ctx: *anyopaque, rest: []const u8) anyerror!void,
     setup: *const fn (ctx: *anyopaque) anyerror!void,
     show_status: *const fn (ctx: *anyopaque) anyerror!void,
     show_background: *const fn (ctx: *anyopaque) anyerror!void,
@@ -112,7 +112,7 @@ fn parsedCommand(kind: SlashKind, payload: []const u8) ParsedCommand {
         .rename_session => .{ .rename_session = payload },
         .help => .help,
         .login => .login,
-        .logout => .logout,
+        .logout => .{ .logout = payload },
         .setup => .setup,
         .status => .status,
         .background => .background,
@@ -172,7 +172,7 @@ pub fn route(registry: SlashRegistry, handlers: *const CommandHandlers, cmd: []c
         .rename_session => |rest| try handlers.rename_session(handlers.ctx, rest),
         .help => try handlers.show_help(handlers.ctx),
         .login => try handlers.login(handlers.ctx),
-        .logout => try handlers.logout(handlers.ctx),
+        .logout => |rest| try handlers.logout(handlers.ctx, rest),
         .setup => try handlers.setup(handlers.ctx),
         .status => try handlers.show_status(handlers.ctx),
         .background => try handlers.show_background(handlers.ctx),
@@ -219,6 +219,13 @@ test "parse extracts model command payload" {
     switch (parsed) {
         .model => |query| try std.testing.expectEqualStrings("claude-opus", query),
         else => return error.TestExpectedEqual,
+    }
+}
+
+test "parse extracts an optional logout provider" {
+    switch (parse(testSlashRegistry(), "/logout chatgpt")) {
+        .logout => |provider| try std.testing.expectEqualStrings("chatgpt", provider),
+        else => return error.TestExpectedLogoutCommand,
     }
 }
 
@@ -554,7 +561,7 @@ fn testHandlers(ctx: *TestContext) CommandHandlers {
         .continue_recovery = unexpectedNoPayload,
         .show_help = unexpectedNoPayload,
         .login = unexpectedNoPayload,
-        .logout = unexpectedNoPayload,
+        .logout = unexpectedPayload,
         .setup = unexpectedNoPayload,
         .show_status = unexpectedNoPayload,
         .show_background = unexpectedNoPayload,

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 const agent_runtime = @import("../agent/agent_runtime.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
+const auth_runtime = @import("../auth/auth_runtime.zig");
+const credentials = @import("../auth/credentials.zig");
+const model_provider = @import("../config/model_provider.zig");
 const auto_classifier = @import("../permissions/auto_classifier.zig");
 const command_admission = @import("../permissions/command_admission.zig");
 const command_output_content = @import("../tooling/command_output_content.zig");
@@ -120,8 +123,44 @@ pub fn run(
     var arena_state = std.heap.ArenaAllocator.init(turn.alloc);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
+    var routed_credential: ?credentials.Credential = null;
+    defer if (routed_credential) |*credential| credential.deinit(turn.alloc);
+    var routed_config = config;
+    const chatgpt_model = model_provider.isChatGptSubscriptionModel(admission.model);
+    const chatgpt_credential = config.tool_context.credential_source == .chatgpt_subscription;
+    if (chatgpt_model != chatgpt_credential) {
+        const resolution = credentials.resolveForModel(
+            turn.alloc,
+            config.tool_context.oauth_transport,
+            config.tool_context.secret_store,
+            .refresh_if_needed,
+            admission.model,
+            config.tool_context.credential_source,
+        ) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            turn.setFailureDiagnostic("model_credential_resolution_failed", @errorName(err)) catch
+                return error.OutOfMemory;
+            return error.ProviderFailed;
+        };
+        routed_credential = resolution.credential;
+        const credential = if (routed_credential) |*value| value else {
+            turn.setFailureDiagnostic("model_credential_missing", admission.model) catch
+                return error.OutOfMemory;
+            return error.ProviderFailed;
+        };
+        routed_config.tool_context.api_key = credential.token;
+        routed_config.tool_context.gateway_team = credential.gatewayTeam();
+        routed_config.tool_context.credential_source = credential.source;
+    }
+    routed_config.tool_context.model = admission.model;
+    if (routed_config.tool_context.credential_source == .chatgpt_subscription) {
+        routed_config.tool_context.permission_reviewer_provider = null;
+        routed_config.tool_context.auto_classifier = auto_classifier.Classifier.disabled();
+        routed_config.tool_context.web_search_backend = null;
+        routed_config.tool_context.web_search_runtime_ready = false;
+    }
     var context = Context{
-        .config = config,
+        .config = routed_config,
         .turn = turn,
         .admission = admission,
         .cancel = cancel,
@@ -248,11 +287,27 @@ fn runtimeDeps(context: *Context) agent_runtime.AgentRuntimeDeps {
         .push_route_recovery_status = pushLiveRouteRecoveryStatus,
         .push_command_output_complete = pushLiveCommandOutputComplete,
         .push_http_error = captureHttpError,
+        .refresh_gateway_credential = refreshGatewayCredential,
         .format_tool_execution_error = formatToolExecutionError,
         .report_usage = reportUsage,
         .usage = &context.turn.sessionRuntime().usage,
         .usage_allocator = context.turn.alloc,
     };
+}
+
+fn refreshGatewayCredential(
+    raw: *anyopaque,
+    alloc: Allocator,
+    source: types.CredentialSource,
+    mode: auth_runtime.CredentialRefreshMode,
+) !?[]u8 {
+    const context: *Context = @ptrCast(@alignCast(raw));
+    return auth_runtime.refreshCredentialToken(
+        context.config.tool_context.oauth_transport,
+        alloc,
+        source,
+        mode,
+    );
 }
 
 fn finalizeTurn(

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const agent_stream_provider = @import("../agent/stream_provider.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
 const oauth_transport = @import("../auth/oauth_transport.zig");
+const host_mod = @import("../hosts/host.zig");
 const command_contract = @import("../execution/command_contract.zig");
 const command_environment = @import("../execution/command_environment.zig");
 const background_process_provider = @import(
@@ -136,6 +137,7 @@ pub const Context = struct {
     gateway_team: ?[]const u8 = null,
     credential_source: ?types.CredentialSource = null,
     oauth_transport: oauth_transport.Provider = oauth_transport.unavailable_provider,
+    secret_store: host_mod.SecretStore = host_mod.unavailable_secret_store,
     model: []const u8,
     permission_review_turn: ?permission_auto_classifier.ReviewTurnContext = null,
     root_user_intent_context: []const u8 = "",
@@ -995,6 +997,7 @@ fn executeVisionRequest(
     const config: vision_executor.Config = .{
         .stream_provider = state.runtime.agent_stream_provider,
         .api_key = state.runtime.api_key,
+        .credential_source = state.runtime.credential_source,
         .gateway_team = state.runtime.gateway_team,
         .session_id = state.runtime.lifecycle_scope.session_id,
         .retry_count = state.runtime.gateway_retry_count,

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -1738,6 +1738,14 @@ fn suspendGapDetected(previous: SuspendClockSample, current: SuspendClockSample)
     return boot_elapsed - awake_elapsed > suspend_gap_tolerance_ns;
 }
 
+pub fn spawnHttpCancelWatcher(
+    done: *std.atomic.Value(bool),
+    cancel_flag: *std.atomic.Value(bool),
+    stream: std.Io.net.Stream,
+) !std.Thread {
+    return spawn_gateway_cancel_watcher(done, cancel_flag, null, stream);
+}
+
 fn spawn_gateway_cancel_watcher(
     done: *std.atomic.Value(bool),
     cancel_flag: *std.atomic.Value(bool),

--- a/src/gateway/js_host_model_catalog.zig
+++ b/src/gateway/js_host_model_catalog.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
+const model_provider = @import("../core/config/model_provider.zig");
 const builtin_gateway = @import("../builtins/gateway.zig");
 
 const Allocator = std.mem.Allocator;
@@ -78,7 +79,7 @@ fn fetch(
         return .{ .failure = model_catalog.failureForHttpStatus(@enumFromInt(status)) };
     }
 
-    const catalog = builtin_gateway.parseModelCatalogForView(
+    var catalog = builtin_gateway.parseModelCatalogForView(
         alloc,
         response[0..@intCast(response_len)],
         input.view,
@@ -86,5 +87,13 @@ fn fetch(
         .category = if (err == error.OutOfMemory) .resource_exhausted else .malformed_response,
         .http_status = .ok,
     } };
+    var index: usize = 0;
+    while (index < catalog.items.len) {
+        if (!model_provider.isChatGptSubscriptionModel(catalog.items[index].id)) {
+            index += 1;
+            continue;
+        }
+        model_catalog.freeModelCatalogEntry(alloc, catalog.orderedRemove(index));
+    }
     return .{ .catalog = catalog };
 }

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -1,0 +1,810 @@
+const std = @import("std");
+const chatgpt_oauth = @import("../core/auth/chatgpt_oauth.zig");
+const image_attachments = @import("../core/images/image_attachments.zig");
+const model_provider = @import("../core/config/model_provider.zig");
+const secret = @import("../core/auth/secret.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+
+const Allocator = std.mem.Allocator;
+const endpoint = "https://chatgpt.com/backend-api/codex/responses";
+const e2e_endpoint_env = "FX_E2E_OPENAI_CODEX_RESPONSES_URL";
+const max_error_body_bytes: usize = 1024 * 1024;
+const max_sse_line_bytes: usize = 32 * 1024 * 1024;
+const transfer_buffer_bytes: usize = 256 * 1024;
+const connect_timeout_ms: i64 = 30_000;
+
+pub const agent_stream_provider = stream_provider.Provider{
+    .build_fn = buildRequest,
+    .stream_fn = streamCompletion,
+};
+
+pub fn buildRequest(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.BuildRequest,
+) ![]u8 {
+    _ = model_provider.upstreamModel(request.model) orelse return error.InvalidOpenAICodexModel;
+    if (request.budget) |budget| {
+        if (budget.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+        _ = budget.deadline;
+    }
+
+    var instructions: std.Io.Writer.Allocating = .init(alloc);
+    defer instructions.deinit();
+    for (request.messages) |message| {
+        if (message.role != .system) continue;
+        const text = message.content orelse continue;
+        if (text.len == 0) continue;
+        if (instructions.written().len > 0) try instructions.writer.writeAll("\n\n");
+        try instructions.writer.writeAll(text);
+    }
+    if (instructions.written().len == 0) try instructions.writer.writeAll("You are a helpful assistant.");
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll("{\"model\":");
+    try std.json.Stringify.value(model_provider.upstreamModel(request.model).?, .{}, writer);
+    try writer.writeAll(",\"store\":false,\"stream\":true,\"instructions\":");
+    try std.json.Stringify.value(instructions.written(), .{}, writer);
+    try writer.writeAll(",\"input\":[");
+    try writeInput(writer, alloc, request.messages, request.verified_images);
+    try writer.writeByte(']');
+
+    const tool_count = try writeTools(writer, alloc, request.serialized_tools, request.selected_dynamic_tool_schemas);
+    try writer.writeAll(",\"tool_choice\":");
+    try std.json.Stringify.value(request.tool_choice.label(), .{}, writer);
+    try writer.writeAll(",\"parallel_tool_calls\":true,\"include\":[\"reasoning.encrypted_content\"]");
+
+    try writer.writeAll(",\"text\":{\"verbosity\":\"low\"");
+    if (request.response_format) |format| {
+        var schema = try std.json.parseFromSlice(std.json.Value, alloc, format.schema_json, .{});
+        defer schema.deinit();
+        if (schema.value != .object) return error.InvalidStructuredResponseSchema;
+        try writer.writeAll(",\"format\":{\"type\":\"json_schema\",\"name\":");
+        try std.json.Stringify.value(format.name, .{}, writer);
+        try writer.writeAll(",\"description\":");
+        try std.json.Stringify.value(format.description, .{}, writer);
+        try writer.writeAll(",\"schema\":");
+        try std.json.Stringify.value(schema.value, .{}, writer);
+        try writer.writeAll(",\"strict\":true}");
+    }
+    try writer.writeByte('}');
+
+    if (request.provider_options.reasoning) |effort| {
+        const label = if (std.mem.eql(u8, effort.label(), "minimal")) "low" else effort.label();
+        try writer.writeAll(",\"reasoning\":{\"effort\":");
+        try std.json.Stringify.value(label, .{}, writer);
+        try writer.writeAll(",\"summary\":\"auto\"}");
+    }
+    if (request.max_output_tokens) |limit| try writer.print(",\"max_output_tokens\":{d}", .{limit});
+    if (tool_count == 0 and request.tool_choice == .none) {
+        // Explicitly keeping the empty tool set out of the request avoids a
+        // backend validation difference between no tools and `tools: []`.
+    }
+    try writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn writeInput(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    messages: []const types.ChatMessage,
+    verified_images: ?[]const image_attachments.VerifiedSnapshot,
+) !void {
+    var first = true;
+    for (messages, 0..) |message, message_index| {
+        switch (message.role) {
+            .system => continue,
+            .user => {
+                try writeComma(writer, &first);
+                try writer.writeAll("{\"role\":\"user\",\"content\":[");
+                var first_part = true;
+                if (message.content) |content| if (content.len > 0) {
+                    try writer.writeAll("{\"type\":\"input_text\",\"text\":");
+                    try std.json.Stringify.value(content, .{}, writer);
+                    try writer.writeByte('}');
+                    first_part = false;
+                };
+                if (verified_images) |images| {
+                    if (message_index == messages.len - 1) {
+                        for (images) |image| {
+                            if (!first_part) try writer.writeByte(',');
+                            try writeInputImage(writer, alloc, image);
+                            first_part = false;
+                        }
+                    }
+                }
+                try writer.writeAll("]}");
+            },
+            .assistant => {
+                if (message.provider_state_json) |state_json| {
+                    var state = std.json.parseFromSlice(std.json.Value, alloc, state_json, .{}) catch
+                        return error.InvalidOpenAICodexProviderState;
+                    defer state.deinit();
+                    if (state.value != .array) return error.InvalidOpenAICodexProviderState;
+                    for (state.value.array.items) |item| {
+                        if (item != .object) return error.InvalidOpenAICodexProviderState;
+                        try writeComma(writer, &first);
+                        try std.json.Stringify.value(item, .{}, writer);
+                    }
+                }
+                if (message.content) |content| if (content.len > 0) {
+                    try writeComma(writer, &first);
+                    try writer.writeAll("{\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":");
+                    try std.json.Stringify.value(content, .{}, writer);
+                    try writer.writeAll(",\"annotations\":[]}]}");
+                };
+                for (message.tool_calls) |call| {
+                    try writeComma(writer, &first);
+                    try writer.writeAll("{\"type\":\"function_call\",\"call_id\":");
+                    try std.json.Stringify.value(call.id, .{}, writer);
+                    try writer.writeAll(",\"name\":");
+                    try std.json.Stringify.value(call.name, .{}, writer);
+                    try writer.writeAll(",\"arguments\":");
+                    try std.json.Stringify.value(call.arguments_json, .{}, writer);
+                    try writer.writeByte('}');
+                }
+            },
+            .tool => {
+                try writeComma(writer, &first);
+                try writer.writeAll("{\"type\":\"function_call_output\",\"call_id\":");
+                try std.json.Stringify.value(message.tool_call_id orelse "", .{}, writer);
+                try writer.writeAll(",\"output\":");
+                try std.json.Stringify.value(message.content orelse "", .{}, writer);
+                try writer.writeByte('}');
+            },
+        }
+    }
+}
+
+fn writeInputImage(writer: *std.Io.Writer, alloc: Allocator, image: image_attachments.VerifiedSnapshot) !void {
+    const encoded_len = std.base64.standard.Encoder.calcSize(image.bytes.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = std.base64.standard.Encoder.encode(encoded, image.bytes);
+    try writer.writeAll("{\"type\":\"input_image\",\"detail\":\"auto\",\"image_url\":\"data:");
+    try writer.writeAll(image.media_type);
+    try writer.writeAll(";base64,");
+    try writer.writeAll(encoded);
+    try writer.writeAll("\"}");
+}
+
+fn writeTools(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    serialized_tools: []const u8,
+    selected_dynamic_schemas: []const []const u8,
+) !usize {
+    var count: usize = 0;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, serialized_tools, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidToolSchema,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidToolSchema;
+
+    var tools_out: std.Io.Writer.Allocating = .init(alloc);
+    defer tools_out.deinit();
+    try tools_out.writer.writeAll(",\"tools\":[");
+    for (parsed.value.array.items) |tool| {
+        if (try writeFunctionTool(&tools_out.writer, tool, count != 0)) count += 1;
+    }
+    for (selected_dynamic_schemas) |schema_json| {
+        var selected = std.json.parseFromSlice(std.json.Value, alloc, schema_json, .{}) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.InvalidToolSchema,
+        };
+        defer selected.deinit();
+        if (try writeFunctionTool(&tools_out.writer, selected.value, count != 0)) count += 1;
+    }
+    try tools_out.writer.writeByte(']');
+    if (count > 0) try writer.writeAll(tools_out.written());
+    return count;
+}
+
+fn writeFunctionTool(writer: *std.Io.Writer, value: std.json.Value, comma: bool) !bool {
+    if (value != .object) return false;
+    const kind = value.object.get("type") orelse return false;
+    if (kind != .string or !std.mem.eql(u8, kind.string, "function")) return false;
+    const name = value.object.get("name") orelse return false;
+    if (name != .string or name.string.len == 0) return false;
+    const parameters = value.object.get("inputSchema") orelse value.object.get("parameters") orelse return false;
+    if (parameters != .object) return false;
+    if (comma) try writer.writeByte(',');
+    try writer.writeAll("{\"type\":\"function\",\"name\":");
+    try std.json.Stringify.value(name.string, .{}, writer);
+    if (value.object.get("description")) |description| if (description == .string) {
+        try writer.writeAll(",\"description\":");
+        try std.json.Stringify.value(description.string, .{}, writer);
+    };
+    try writer.writeAll(",\"parameters\":");
+    try std.json.Stringify.value(parameters, .{}, writer);
+    try writer.writeAll(",\"strict\":false}");
+    return true;
+}
+
+fn writeComma(writer: *std.Io.Writer, first: *bool) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+}
+
+fn streamCompletion(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.Request,
+) !stream_provider.Result {
+    return streamCompletionCore(alloc, request) catch |err| {
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(err, request.delivery.load());
+        return err;
+    };
+}
+
+const OpenedRequest = struct {
+    request: ?std.http.Client.Request,
+
+    pub fn deinit(self: *OpenedRequest, _: Allocator) void {
+        if (self.request) |*request| request.deinit();
+        self.request = null;
+    }
+
+    pub fn take(self: *OpenedRequest) std.http.Client.Request {
+        const request = self.request.?;
+        self.request = null;
+        return request;
+    }
+};
+
+const OpenRequestOperation = struct {
+    client: *std.http.Client,
+    uri: std.Uri,
+    auth_header: []const u8,
+    extra_headers: []const std.http.Header,
+
+    pub fn run(self: *@This()) !OpenedRequest {
+        return .{ .request = try self.client.request(.POST, self.uri, .{
+            .headers = .{
+                .content_type = .{ .override = "application/json" },
+                .authorization = .{ .override = self.auth_header },
+                .accept_encoding = .omit,
+                .user_agent = .{ .override = gateway_client.user_agent },
+            },
+            .extra_headers = self.extra_headers,
+            .keep_alive = false,
+            .redirect_behavior = .unhandled,
+        }) };
+    }
+};
+
+fn streamCompletionCore(alloc: Allocator, request: stream_provider.Request) !stream_provider.Result {
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    _ = model_provider.upstreamModel(request.model) orelse return error.InvalidOpenAICodexModel;
+    const account_id = try chatgpt_oauth.extractAccountId(alloc, request.api_key);
+    defer alloc.free(account_id);
+    const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.api_key});
+    defer secret.zeroAndFree(alloc, auth_header);
+    const request_endpoint = if (io_mod.getenv(e2e_endpoint_env)) |override| endpoint: {
+        if (!gateway_client.isLoopbackHttpUrl(override)) return error.InvalidE2EOpenAICodexEndpoint;
+        break :endpoint override;
+    } else endpoint;
+    const uri = try std.Uri.parse(request_endpoint);
+
+    var extra_headers_buf: [7]std.http.Header = undefined;
+    var extra_count: usize = 0;
+    extra_headers_buf[extra_count] = .{ .name = "chatgpt-account-id", .value = account_id };
+    extra_count += 1;
+    extra_headers_buf[extra_count] = .{ .name = "originator", .value = "fx" };
+    extra_count += 1;
+    extra_headers_buf[extra_count] = .{ .name = "OpenAI-Beta", .value = "responses=experimental" };
+    extra_count += 1;
+    extra_headers_buf[extra_count] = .{ .name = "accept", .value = "text/event-stream" };
+    extra_count += 1;
+    if (request.session_id) |session_id| if (session_id.len > 0) {
+        extra_headers_buf[extra_count] = .{ .name = "session-id", .value = session_id };
+        extra_count += 1;
+        extra_headers_buf[extra_count] = .{ .name = "x-client-request-id", .value = session_id };
+        extra_count += 1;
+    };
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
+    defer client.deinit();
+    var open_operation = OpenRequestOperation{
+        .client = &client,
+        .uri = uri,
+        .auth_header = auth_header,
+        .extra_headers = extra_headers_buf[0..extra_count],
+    };
+    const connect_deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+        .clock = .awake,
+        .raw = .fromMilliseconds(connect_timeout_ms),
+    });
+    var opened = try gateway_client.runBoundedHttpOperation(
+        OpenedRequest,
+        alloc,
+        request.cancel_flag,
+        connect_deadline,
+        &open_operation,
+    );
+    var http_request = opened.take();
+    defer http_request.deinit();
+    var cancel_watch_done = std.atomic.Value(bool).init(false);
+    const cancel_watcher = if (http_request.connection) |connection|
+        try gateway_client.spawnHttpCancelWatcher(
+            &cancel_watch_done,
+            request.cancel_flag,
+            connection.stream_writer.stream,
+        )
+    else
+        null;
+    defer {
+        cancel_watch_done.store(true, .seq_cst);
+        if (cancel_watcher) |thread| thread.join();
+    }
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    http_request.transfer_encoding = .{ .content_length = request.payload.len };
+    var send_buffer: [8192]u8 = undefined;
+    request.delivery.markPossiblySent();
+    var body_writer = try http_request.sendBodyUnflushed(&send_buffer);
+    try body_writer.writer.writeAll(request.payload);
+    try body_writer.end();
+    if (http_request.connection) |connection| try connection.flush();
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    var response = try http_request.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        var transfer: [16 * 1024]u8 = undefined;
+        const reader = response.reader(&transfer);
+        const body = reader.allocRemaining(alloc, .limited(max_error_body_bytes)) catch |err| switch (err) {
+            error.StreamTooLong => try alloc.dupe(u8, "OpenAI Codex error response exceeded the local limit"),
+            else => return err,
+        };
+        return .{
+            .status = response.head.status,
+            .err_body = body,
+            .ownership = .owned,
+        };
+    }
+
+    var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
+    const reader = response.reader(&transfer_buffer);
+    const completion = try consumeSse(
+        alloc,
+        reader,
+        request.callback_ctx,
+        request.on_content_chunk,
+        request.on_tool_start,
+        request.on_reasoning_chunk,
+        request.on_tool_input_chunk,
+        request.cancel_flag,
+        request.content_capture_limit,
+    );
+    return .{
+        .status = .ok,
+        .completion = completion,
+        .ownership = .owned,
+    };
+}
+
+const ToolAccumulator = struct {
+    output_index: i64,
+    id: []u8,
+    name: []u8,
+    arguments: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *ToolAccumulator, alloc: Allocator) void {
+        alloc.free(self.id);
+        alloc.free(self.name);
+        self.arguments.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+const SseReader = struct {
+    pending_line: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *SseReader, alloc: Allocator) void {
+        self.pending_line.deinit(alloc);
+    }
+
+    fn release(self: *SseReader) void {
+        self.pending_line.clearRetainingCapacity();
+    }
+
+    fn next(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
+        while (true) {
+            const line = try self.readLine(alloc, reader) orelse return null;
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (trimmed.len == 0 or trimmed[0] == ':') {
+                self.release();
+                continue;
+            }
+            if (!std.mem.startsWith(u8, trimmed, "data:")) {
+                self.release();
+                continue;
+            }
+            const data = std.mem.trim(u8, trimmed["data:".len..], " \t");
+            if (std.mem.eql(u8, data, "[DONE]")) return null;
+            return data;
+        }
+    }
+
+    fn readLine(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
+        while (true) {
+            const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
+                error.StreamTooLong => {
+                    const buffered = reader.buffered();
+                    if (buffered.len == 0) return error.OpenAICodexSseReadStalled;
+                    if (buffered.len > max_sse_line_bytes - self.pending_line.items.len) {
+                        return error.OpenAICodexSseEventTooLarge;
+                    }
+                    try self.pending_line.appendSlice(alloc, buffered);
+                    reader.tossBuffered();
+                    continue;
+                },
+                error.ReadFailed => return error.ReadFailed,
+            } orelse {
+                if (self.pending_line.items.len > 0) return self.pending_line.items;
+                return null;
+            };
+            if (fragment.len > max_sse_line_bytes - self.pending_line.items.len) {
+                return error.OpenAICodexSseEventTooLarge;
+            }
+            if (self.pending_line.items.len == 0) return fragment;
+            try self.pending_line.appendSlice(alloc, fragment);
+            return self.pending_line.items;
+        }
+    }
+};
+
+fn consumeSse(
+    alloc: Allocator,
+    reader: anytype,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    on_tool_input_chunk: ?stream_provider.StreamCallback,
+    cancel_flag: *std.atomic.Value(bool),
+    content_capture_limit: ?usize,
+) !types.GatewayCompletion {
+    var content: std.ArrayList(u8) = .empty;
+    errdefer content.deinit(alloc);
+    var provider_state: std.Io.Writer.Allocating = .init(alloc);
+    defer provider_state.deinit();
+    var provider_state_count: usize = 0;
+    var tools: std.ArrayList(ToolAccumulator) = .empty;
+    defer {
+        for (tools.items) |*tool| tool.deinit(alloc);
+        tools.deinit(alloc);
+    }
+    var sse: SseReader = .{};
+    defer sse.deinit(alloc);
+    var finish_reason: ?types.ProviderFinishReason = null;
+    var usage: types.Usage = .{};
+    var terminal_seen = false;
+    var saw_content_delta = false;
+
+    while (try sse.next(alloc, reader)) |json_text| {
+        defer sse.release();
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch
+            return error.InvalidOpenAICodexSseEvent;
+        defer parsed.deinit();
+        if (parsed.value != .object) continue;
+        const event_type = stringField(parsed.value.object, "type") orelse continue;
+
+        if (std.mem.eql(u8, event_type, "response.output_item.added")) {
+            const output_index = integerField(parsed.value.object, "output_index") orelse continue;
+            const item = parsed.value.object.get("item") orelse continue;
+            if (item != .object) continue;
+            const item_type = stringField(item.object, "type") orelse continue;
+            if (std.mem.eql(u8, item_type, "function_call")) {
+                const call_id = stringField(item.object, "call_id") orelse continue;
+                const name = stringField(item.object, "name") orelse continue;
+                if (findTool(tools.items, output_index) == null) {
+                    try appendTool(alloc, &tools, output_index, call_id, name);
+                    if (on_tool_start) |callback| callback(callback_ctx, call_id, name, null);
+                }
+            }
+        } else if (std.mem.eql(u8, event_type, "response.output_text.delta") or
+            std.mem.eql(u8, event_type, "response.refusal.delta"))
+        {
+            const delta = stringField(parsed.value.object, "delta") orelse continue;
+            saw_content_delta = true;
+            on_content_chunk(callback_ctx, delta);
+            try appendCaptured(alloc, &content, delta, content_capture_limit);
+        } else if (std.mem.eql(u8, event_type, "response.reasoning_summary_text.delta") or
+            std.mem.eql(u8, event_type, "response.reasoning_text.delta"))
+        {
+            const delta = stringField(parsed.value.object, "delta") orelse continue;
+            if (on_reasoning_chunk) |callback| callback(callback_ctx, delta);
+        } else if (std.mem.eql(u8, event_type, "response.reasoning_summary_part.done")) {
+            if (on_reasoning_chunk) |callback| callback(callback_ctx, "\n\n");
+        } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.delta")) {
+            const output_index = integerField(parsed.value.object, "output_index") orelse continue;
+            const delta = stringField(parsed.value.object, "delta") orelse continue;
+            const index = findTool(tools.items, output_index) orelse continue;
+            try tools.items[index].arguments.appendSlice(alloc, delta);
+            if (on_tool_input_chunk) |callback| callback(callback_ctx, delta);
+        } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.done")) {
+            const output_index = integerField(parsed.value.object, "output_index") orelse continue;
+            const arguments = stringField(parsed.value.object, "arguments") orelse continue;
+            const index = findTool(tools.items, output_index) orelse continue;
+            const previous_len = tools.items[index].arguments.items.len;
+            if (std.mem.startsWith(u8, arguments, tools.items[index].arguments.items)) {
+                const suffix = arguments[previous_len..];
+                try tools.items[index].arguments.appendSlice(alloc, suffix);
+                if (suffix.len > 0) if (on_tool_input_chunk) |callback| callback(callback_ctx, suffix);
+            } else {
+                tools.items[index].arguments.clearRetainingCapacity();
+                try tools.items[index].arguments.appendSlice(alloc, arguments);
+            }
+        } else if (std.mem.eql(u8, event_type, "response.output_item.done")) {
+            const output_index = integerField(parsed.value.object, "output_index") orelse continue;
+            const item = parsed.value.object.get("item") orelse continue;
+            if (item != .object) continue;
+            const item_type = stringField(item.object, "type") orelse continue;
+            if (std.mem.eql(u8, item_type, "function_call")) {
+                if (findTool(tools.items, output_index)) |index| {
+                    if (stringField(item.object, "arguments")) |arguments| {
+                        if (tools.items[index].arguments.items.len == 0) {
+                            try tools.items[index].arguments.appendSlice(alloc, arguments);
+                        }
+                    }
+                }
+            } else if (std.mem.eql(u8, item_type, "reasoning") and
+                stringField(item.object, "encrypted_content") != null)
+            {
+                if (provider_state_count == 0) {
+                    try provider_state.writer.writeByte('[');
+                } else {
+                    try provider_state.writer.writeByte(',');
+                }
+                try std.json.Stringify.value(item, .{}, &provider_state.writer);
+                provider_state_count += 1;
+            } else if (std.mem.eql(u8, item_type, "message") and !saw_content_delta) {
+                if (item.object.get("content")) |parts| if (parts == .array) {
+                    for (parts.array.items) |part| {
+                        if (part != .object) continue;
+                        const text = stringField(part.object, "text") orelse stringField(part.object, "refusal") orelse continue;
+                        on_content_chunk(callback_ctx, text);
+                        try appendCaptured(alloc, &content, text, content_capture_limit);
+                    }
+                };
+            }
+        } else if (std.mem.eql(u8, event_type, "response.completed") or
+            std.mem.eql(u8, event_type, "response.done") or
+            std.mem.eql(u8, event_type, "response.incomplete"))
+        {
+            const response_value = parsed.value.object.get("response") orelse continue;
+            if (response_value != .object) continue;
+            terminal_seen = true;
+            const status = stringField(response_value.object, "status");
+            finish_reason = finishReason(status, response_value.object, tools.items.len > 0);
+            usage = parseUsage(response_value.object);
+            break;
+        } else if (std.mem.eql(u8, event_type, "response.failed") or
+            std.mem.eql(u8, event_type, "error"))
+        {
+            return error.OpenAICodexResponseFailed;
+        }
+    }
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (!terminal_seen) return error.OpenAICodexStreamIncomplete;
+
+    const owned_content = if (content.items.len > 0) try content.toOwnedSlice(alloc) else null;
+    if (owned_content != null) content = .empty;
+    errdefer if (owned_content) |value| alloc.free(value);
+    const owned_provider_state = if (provider_state_count > 0) state: {
+        try provider_state.writer.writeByte(']');
+        break :state try provider_state.toOwnedSlice();
+    } else null;
+    errdefer if (owned_provider_state) |value| alloc.free(value);
+    const owned_tools: []types.ToolCall = if (tools.items.len > 0)
+        try alloc.alloc(types.ToolCall, tools.items.len)
+    else
+        &.{};
+    errdefer if (owned_tools.len > 0) alloc.free(owned_tools);
+    var initialized: usize = 0;
+    errdefer for (owned_tools[0..initialized]) |call| {
+        alloc.free(call.id);
+        alloc.free(call.name);
+        alloc.free(call.arguments_json);
+    };
+    for (tools.items, 0..) |*tool, index| {
+        const arguments = if (tool.arguments.items.len > 0)
+            try tool.arguments.toOwnedSlice(alloc)
+        else
+            try alloc.dupe(u8, "{}");
+        tool.arguments = .empty;
+        owned_tools[index] = .{
+            .id = tool.id,
+            .name = tool.name,
+            .arguments_json = arguments,
+        };
+        tool.id = &.{};
+        tool.name = &.{};
+        initialized += 1;
+    }
+    return .{
+        .content = owned_content,
+        .tool_calls = owned_tools,
+        .provider_state_json = owned_provider_state,
+        .finish_reason = finish_reason orelse if (owned_tools.len > 0) .tool_calls else .stop,
+        .usage = usage,
+    };
+}
+
+fn appendTool(
+    alloc: Allocator,
+    tools: *std.ArrayList(ToolAccumulator),
+    output_index: i64,
+    call_id: []const u8,
+    name: []const u8,
+) !void {
+    const id = try alloc.dupe(u8, call_id);
+    errdefer alloc.free(id);
+    const owned_name = try alloc.dupe(u8, name);
+    errdefer alloc.free(owned_name);
+    try tools.append(alloc, .{
+        .output_index = output_index,
+        .id = id,
+        .name = owned_name,
+    });
+}
+
+fn appendCaptured(
+    alloc: Allocator,
+    content: *std.ArrayList(u8),
+    delta: []const u8,
+    limit: ?usize,
+) !void {
+    const remaining = if (limit) |maximum| maximum -| @min(maximum, content.items.len) else delta.len;
+    try content.appendSlice(alloc, delta[0..@min(delta.len, remaining)]);
+}
+
+fn findTool(tools: []const ToolAccumulator, output_index: i64) ?usize {
+    for (tools, 0..) |tool, index| if (tool.output_index == output_index) return index;
+    return null;
+}
+
+fn finishReason(
+    status: ?[]const u8,
+    response: std.json.ObjectMap,
+    has_tools: bool,
+) types.ProviderFinishReason {
+    const value = status orelse return if (has_tools) .tool_calls else .stop;
+    if (std.mem.eql(u8, value, "completed")) return if (has_tools) .tool_calls else .stop;
+    if (std.mem.eql(u8, value, "incomplete")) {
+        if (response.get("incomplete_details")) |details| if (details == .object) {
+            if (stringField(details.object, "reason")) |reason| {
+                if (std.mem.eql(u8, reason, "max_output_tokens")) return .length;
+                if (std.mem.eql(u8, reason, "content_filter")) return .content_filter;
+            }
+        };
+        return .provider_error;
+    }
+    if (std.mem.eql(u8, value, "failed") or std.mem.eql(u8, value, "cancelled")) return .provider_error;
+    return if (has_tools) .tool_calls else .other;
+}
+
+fn parseUsage(response: std.json.ObjectMap) types.Usage {
+    const value = response.get("usage") orelse return .{};
+    if (value != .object) return .{};
+    return .{
+        .input_tokens = unsignedField(value.object, "input_tokens"),
+        .output_tokens = unsignedField(value.object, "output_tokens"),
+    };
+}
+
+fn stringField(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    if (value != .string) return null;
+    return value.string;
+}
+
+fn integerField(object: std.json.ObjectMap, key: []const u8) ?i64 {
+    const value = object.get(key) orelse return null;
+    if (value != .integer) return null;
+    return value.integer;
+}
+
+fn unsignedField(object: std.json.ObjectMap, key: []const u8) ?u64 {
+    const value = integerField(object, key) orelse return null;
+    if (value < 0) return null;
+    return @intCast(value);
+}
+
+test "OpenAI Codex request uses Responses input and converts AI SDK tool schemas" {
+    const messages = [_]types.ChatMessage{
+        .{ .role = .system, .content = "Be concise." },
+        .{ .role = .user, .content = "Read it." },
+        .{
+            .role = .assistant,
+            .tool_calls = &.{.{ .id = "call_1", .name = "read_file", .arguments_json = "{\"path\":\"README.md\"}" }},
+            .provider_state_json = "[{\"id\":\"rs_1\",\"type\":\"reasoning\",\"encrypted_content\":\"opaque\"}]",
+        },
+        .{ .role = .tool, .tool_call_id = "call_1", .tool_name = "read_file", .content = "contents" },
+    };
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "openai-codex/gpt-5.4",
+        .serialized_tools = "[{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read\",\"inputSchema\":{\"type\":\"object\"}}]",
+        .messages = &messages,
+        .tool_choice = .auto,
+        .provider_options = .{ .reasoning = types.ReasoningEffort.literal("high") },
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"gpt-5.4\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"instructions\":\"Be concise.\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"type\":\"function_call_output\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"encrypted_content\":\"opaque\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"parameters\":{\"type\":\"object\"}") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"reasoning\":{\"effort\":\"high\"") != null);
+}
+
+test "OpenAI Codex SSE maps text reasoning tools and usage" {
+    const sse_text =
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\"}}\n\n" ++
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"thinking\"}\n\n" ++
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n" ++
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\"}}\n\n" ++
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"hello\"}\n\n" ++
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":2,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"read_file\"}}\n\n" ++
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":2,\"delta\":\"{\\\"path\\\":\\\"README.md\\\"}\"}\n\n" ++
+        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4}}}\n\n";
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    const Capture = struct {
+        content: std.ArrayList(u8) = .empty,
+        reasoning: std.ArrayList(u8) = .empty,
+        saw_read_file: bool = false,
+
+        fn contentChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.content.appendSlice(std.testing.allocator, chunk) catch unreachable;
+        }
+        fn reasoningChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.reasoning.appendSlice(std.testing.allocator, chunk) catch unreachable;
+        }
+        fn toolStart(raw: *anyopaque, _: []const u8, name: []const u8, _: ?[]const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.saw_read_file = std.mem.eql(u8, name, "read_file");
+        }
+    };
+    var capture: Capture = .{};
+    defer capture.content.deinit(std.testing.allocator);
+    defer capture.reasoning.deinit(std.testing.allocator);
+    const completion = try consumeSse(
+        std.testing.allocator,
+        &reader,
+        &capture,
+        Capture.contentChunk,
+        Capture.toolStart,
+        Capture.reasoningChunk,
+        null,
+        &cancelled,
+        null,
+    );
+    defer {
+        if (completion.content) |value| std.testing.allocator.free(@constCast(value));
+        types.freeToolCallSlice(std.testing.allocator, @constCast(completion.tool_calls));
+        if (completion.provider_state_json) |value| std.testing.allocator.free(@constCast(value));
+    }
+    try std.testing.expectEqualStrings("hello", capture.content.items);
+    try std.testing.expectEqualStrings("thinking", capture.reasoning.items);
+    try std.testing.expect(capture.saw_read_file);
+    try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", completion.tool_calls[0].id);
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(@as(?u64, 10), completion.usage.input_tokens);
+    try std.testing.expect(completion.provider_state_json != null);
+    try std.testing.expect(std.mem.find(u8, completion.provider_state_json.?, "\"encrypted_content\":\"opaque\"") != null);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -58,6 +58,9 @@ pub fn buildRequest(
     try writer.writeAll(",\"tool_choice\":");
     try std.json.Stringify.value(request.tool_choice.label(), .{}, writer);
     try writer.writeAll(",\"parallel_tool_calls\":true,\"include\":[\"reasoning.encrypted_content\"]");
+    // Codex exposes Fast mode as its priority service tier for supported
+    // ChatGPT subscription models.
+    if (request.provider_options.fast) try writer.writeAll(",\"service_tier\":\"priority\"");
 
     try writer.writeAll(",\"text\":{\"verbosity\":\"low\"");
     if (request.response_format) |format| {
@@ -80,7 +83,8 @@ pub fn buildRequest(
         try std.json.Stringify.value(label, .{}, writer);
         try writer.writeAll(",\"summary\":\"auto\"}");
     }
-    if (request.max_output_tokens) |limit| try writer.print(",\"max_output_tokens\":{d}", .{limit});
+    // The ChatGPT Codex endpoint chooses the model's output limit and rejects
+    // the public Responses API max_output_tokens parameter.
     if (tool_count == 0 and request.tool_choice == .none) {
         // Explicitly keeping the empty tool set out of the request avoids a
         // backend validation difference between no tools and `tools: []`.
@@ -736,7 +740,7 @@ test "OpenAI Codex request uses Responses input and converts AI SDK tool schemas
         .serialized_tools = "[{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read\",\"inputSchema\":{\"type\":\"object\"}}]",
         .messages = &messages,
         .tool_choice = .auto,
-        .provider_options = .{ .reasoning = types.ReasoningEffort.literal("high") },
+        .provider_options = .{ .reasoning = types.ReasoningEffort.literal("high"), .fast = true },
     });
     defer std.testing.allocator.free(body);
 
@@ -746,6 +750,22 @@ test "OpenAI Codex request uses Responses input and converts AI SDK tool schemas
     try std.testing.expect(std.mem.find(u8, body, "\"encrypted_content\":\"opaque\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"parameters\":{\"type\":\"object\"}") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"reasoning\":{\"effort\":\"high\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"service_tier\":\"priority\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"max_output_tokens\"") == null);
+}
+
+test "OpenAI Codex standard requests omit the priority service tier" {
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "Hello." }};
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "openai-codex/gpt-5.6-sol",
+        .serialized_tools = "[]",
+        .messages = &messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"service_tier\"") == null);
 }
 
 test "OpenAI Codex SSE maps text reasoning tools and usage" {

--- a/src/gateway/openai_codex_models.zig
+++ b/src/gateway/openai_codex_models.zig
@@ -8,6 +8,7 @@ const Model = struct {
     context_window: u32,
     vision: bool,
     supports_max_effort: bool = false,
+    supports_fast_mode: bool = false,
 };
 
 // OpenAI does not expose a stable unauthenticated model catalog for the Codex
@@ -15,12 +16,12 @@ const Model = struct {
 // openai-codex-responses catalog. Provider-qualified IDs intentionally remain
 // distinct from otherwise equivalent openai/* Gateway entries.
 const models = [_]Model{
-    .{ .id = "openai-codex/gpt-5.6-sol", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true },
-    .{ .id = "openai-codex/gpt-5.6-terra", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true },
-    .{ .id = "openai-codex/gpt-5.6-luna", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true },
-    .{ .id = "openai-codex/gpt-5.5", .released = 1_776_988_800, .context_window = 272_000, .vision = true },
+    .{ .id = "openai-codex/gpt-5.6-sol", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true, .supports_fast_mode = true },
+    .{ .id = "openai-codex/gpt-5.6-terra", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true, .supports_fast_mode = true },
+    .{ .id = "openai-codex/gpt-5.6-luna", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true, .supports_fast_mode = true },
+    .{ .id = "openai-codex/gpt-5.5", .released = 1_776_988_800, .context_window = 272_000, .vision = true, .supports_fast_mode = true },
     .{ .id = "openai-codex/gpt-5.4-mini", .released = 1_773_705_600, .context_window = 272_000, .vision = true },
-    .{ .id = "openai-codex/gpt-5.4", .released = 1_772_668_800, .context_window = 272_000, .vision = true },
+    .{ .id = "openai-codex/gpt-5.4", .released = 1_772_668_800, .context_window = 272_000, .vision = true, .supports_fast_mode = true },
     .{ .id = "openai-codex/gpt-5.3-codex-spark", .released = 0, .context_window = 128_000, .vision = false },
 };
 
@@ -55,6 +56,7 @@ pub fn append(alloc: std.mem.Allocator, catalog: *std.ArrayList(model_catalog.Mo
             .has_tool_use = true,
             .has_reasoning = true,
             .reasoning_efforts = efforts,
+            .supports_fast_mode = model.supports_fast_mode,
             .has_vision = model.vision,
             .has_file_input = model.vision,
             .has_implicit_caching = true,
@@ -79,9 +81,11 @@ test "ChatGPT subscription models append once with tool and reasoning metadata" 
     try std.testing.expectEqual(models.len, catalog.items.len);
     try std.testing.expect(catalog.items[0].has_tool_use);
     try std.testing.expect(catalog.items[0].has_reasoning);
+    try std.testing.expect(catalog.items[0].supports_fast_mode);
     try std.testing.expectEqual(@as(usize, 5), catalog.items[0].reasoning_efforts.items.len);
     try std.testing.expectEqualStrings("max", catalog.items[0].reasoning_efforts.items[4].label());
     try std.testing.expectEqual(@as(usize, 4), catalog.items[3].reasoning_efforts.items.len);
+    try std.testing.expect(!catalog.items[4].supports_fast_mode);
 }
 
 test "Gateway and ChatGPT versions of the same model remain distinct" {

--- a/src/gateway/openai_codex_models.zig
+++ b/src/gateway/openai_codex_models.zig
@@ -4,21 +4,35 @@ const types = @import("../core/shared/types.zig");
 
 const Model = struct {
     id: []const u8,
+    released: i64,
     context_window: u32,
     vision: bool,
+    supports_max_effort: bool = false,
 };
 
+// OpenAI does not expose a stable unauthenticated model catalog for the Codex
+// subscription route. Keep this list aligned with the verified
+// openai-codex-responses catalog. Provider-qualified IDs intentionally remain
+// distinct from otherwise equivalent openai/* Gateway entries.
 const models = [_]Model{
-    .{ .id = "openai-codex/gpt-5.4", .context_window = 272_000, .vision = true },
-    .{ .id = "openai-codex/gpt-5.4-mini", .context_window = 272_000, .vision = true },
-    .{ .id = "openai-codex/gpt-5.3-codex-spark", .context_window = 128_000, .vision = false },
+    .{ .id = "openai-codex/gpt-5.6-sol", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true },
+    .{ .id = "openai-codex/gpt-5.6-terra", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true },
+    .{ .id = "openai-codex/gpt-5.6-luna", .released = 1_783_555_200, .context_window = 272_000, .vision = true, .supports_max_effort = true },
+    .{ .id = "openai-codex/gpt-5.5", .released = 1_776_988_800, .context_window = 272_000, .vision = true },
+    .{ .id = "openai-codex/gpt-5.4-mini", .released = 1_773_705_600, .context_window = 272_000, .vision = true },
+    .{ .id = "openai-codex/gpt-5.4", .released = 1_772_668_800, .context_window = 272_000, .vision = true },
+    .{ .id = "openai-codex/gpt-5.3-codex-spark", .released = 0, .context_window = 128_000, .vision = false },
 };
 
-const reasoning_efforts = [_]types.ReasoningEffort{
+const standard_reasoning_efforts = [_]types.ReasoningEffort{
     types.ReasoningEffort.literal("low"),
     types.ReasoningEffort.literal("medium"),
     types.ReasoningEffort.literal("high"),
     types.ReasoningEffort.literal("xhigh"),
+};
+
+const max_reasoning_efforts = standard_reasoning_efforts ++ [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("max"),
 };
 
 pub fn append(alloc: std.mem.Allocator, catalog: *std.ArrayList(model_catalog.ModelCatalogEntry)) !void {
@@ -30,10 +44,14 @@ pub fn append(alloc: std.mem.Allocator, catalog: *std.ArrayList(model_catalog.Mo
         errdefer alloc.free(model_type);
         var efforts: std.ArrayList(types.ReasoningEffort) = .empty;
         errdefer efforts.deinit(alloc);
-        try efforts.appendSlice(alloc, &reasoning_efforts);
+        try efforts.appendSlice(alloc, if (model.supports_max_effort)
+            &max_reasoning_efforts
+        else
+            &standard_reasoning_efforts);
         try catalog.append(alloc, .{
             .id = id,
             .model_type = model_type,
+            .released = model.released,
             .has_tool_use = true,
             .has_reasoning = true,
             .reasoning_efforts = efforts,
@@ -61,5 +79,29 @@ test "ChatGPT subscription models append once with tool and reasoning metadata" 
     try std.testing.expectEqual(models.len, catalog.items.len);
     try std.testing.expect(catalog.items[0].has_tool_use);
     try std.testing.expect(catalog.items[0].has_reasoning);
-    try std.testing.expectEqual(@as(usize, 4), catalog.items[0].reasoning_efforts.items.len);
+    try std.testing.expectEqual(@as(usize, 5), catalog.items[0].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("max", catalog.items[0].reasoning_efforts.items[4].label());
+    try std.testing.expectEqual(@as(usize, 4), catalog.items[3].reasoning_efforts.items.len);
+}
+
+test "Gateway and ChatGPT versions of the same model remain distinct" {
+    const alloc = std.testing.allocator;
+    var catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    defer model_catalog.freeModelCatalog(alloc, &catalog);
+    const gateway_id = try alloc.dupe(u8, "openai/gpt-5.6-sol");
+    const model_type = alloc.dupe(u8, "language") catch |err| {
+        alloc.free(gateway_id);
+        return err;
+    };
+    catalog.append(alloc, .{ .id = gateway_id, .model_type = model_type }) catch |err| {
+        alloc.free(model_type);
+        alloc.free(gateway_id);
+        return err;
+    };
+
+    try append(alloc, &catalog);
+
+    try std.testing.expect(contains(catalog.items, "openai/gpt-5.6-sol"));
+    try std.testing.expect(contains(catalog.items, "openai-codex/gpt-5.6-sol"));
+    try std.testing.expectEqual(models.len + 1, catalog.items.len);
 }

--- a/src/gateway/openai_codex_models.zig
+++ b/src/gateway/openai_codex_models.zig
@@ -1,0 +1,65 @@
+const std = @import("std");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
+const types = @import("../core/shared/types.zig");
+
+const Model = struct {
+    id: []const u8,
+    context_window: u32,
+    vision: bool,
+};
+
+const models = [_]Model{
+    .{ .id = "openai-codex/gpt-5.4", .context_window = 272_000, .vision = true },
+    .{ .id = "openai-codex/gpt-5.4-mini", .context_window = 272_000, .vision = true },
+    .{ .id = "openai-codex/gpt-5.3-codex-spark", .context_window = 128_000, .vision = false },
+};
+
+const reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("xhigh"),
+};
+
+pub fn append(alloc: std.mem.Allocator, catalog: *std.ArrayList(model_catalog.ModelCatalogEntry)) !void {
+    for (models) |model| {
+        if (contains(catalog.items, model.id)) continue;
+        const id = try alloc.dupe(u8, model.id);
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        var efforts: std.ArrayList(types.ReasoningEffort) = .empty;
+        errdefer efforts.deinit(alloc);
+        try efforts.appendSlice(alloc, &reasoning_efforts);
+        try catalog.append(alloc, .{
+            .id = id,
+            .model_type = model_type,
+            .has_tool_use = true,
+            .has_reasoning = true,
+            .reasoning_efforts = efforts,
+            .has_vision = model.vision,
+            .has_file_input = model.vision,
+            .has_implicit_caching = true,
+            .context_window = model.context_window,
+            .max_tokens = 128_000,
+        });
+    }
+}
+
+fn contains(catalog: []const model_catalog.ModelCatalogEntry, id: []const u8) bool {
+    for (catalog) |entry| if (std.mem.eql(u8, entry.id, id)) return true;
+    return false;
+}
+
+test "ChatGPT subscription models append once with tool and reasoning metadata" {
+    const alloc = std.testing.allocator;
+    var catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    defer model_catalog.freeModelCatalog(alloc, &catalog);
+    try append(alloc, &catalog);
+    try append(alloc, &catalog);
+
+    try std.testing.expectEqual(models.len, catalog.items.len);
+    try std.testing.expect(catalog.items[0].has_tool_use);
+    try std.testing.expect(catalog.items[0].has_reasoning);
+    try std.testing.expectEqual(@as(usize, 4), catalog.items[0].reasoning_efforts.items.len);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,6 +48,7 @@ const command_specs = @import("core/slash_commands/command_specs.zig");
 const builtin_context = @import("builtins/context.zig");
 const builtin_devbox = @import("builtins/devbox.zig");
 const builtin_gateway = @import("builtins/gateway.zig");
+const builtin_providers = @import("builtins/providers.zig");
 const gateway_provider = @import("core/gateway/gateway_provider.zig");
 const generation_usage_provider = @import("core/session/generation_usage_provider.zig");
 const agent_stream_provider = @import("core/agent/stream_provider.zig");
@@ -179,6 +180,11 @@ const idle_wasm_poll_timeout_ms: i32 = 16;
 const resize_debounce_ms: i64 = 100;
 const max_transcript_bytes: usize = 256 * 1024;
 const default_max_agent_steps: usize = agent_steps.default_max_agent_steps;
+const native_gateway_provider: gateway_provider.Provider = provider: {
+    var value = builtin_gateway.provider;
+    value.agent_stream = builtin_providers.agent_stream_provider;
+    break :provider value;
+};
 const max_history_turns: usize = 8;
 const max_list_entries: usize = 100;
 const max_read_file_bytes: usize = 50 * 1024;
@@ -430,7 +436,7 @@ const App = struct {
         return if (comptime host_target.is_wasm)
             js_host_stream_provider.provider()
         else
-            builtin_gateway.agent_stream_provider;
+            builtin_providers.agent_stream_provider;
     }
 
     pub fn cooperativeTransportPulse(self: *Self) !void {
@@ -910,8 +916,8 @@ const App = struct {
         try AuthAppRuntime.runLoginCommand(self);
     }
 
-    pub fn runLogoutCommand(self: *App) !void {
-        try AuthAppRuntime.runLogoutCommand(self);
+    pub fn runLogoutCommand(self: *App, target: []const u8) !void {
+        try AuthAppRuntime.runLogoutCommand(self, target);
     }
 
     pub fn applyAuthPickerChoice(self: *App, choice: auth_runtime.Choice) !void {
@@ -3195,7 +3201,7 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .models_path = builtin_gateway.models_path,
         .gateway_retry_count = builtin_gateway.retry_count,
         .gateway_chat_url = builtin_gateway.default_chat_url,
-        .gateway_provider = builtin_gateway.provider,
+        .gateway_provider = native_gateway_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3231,7 +3237,7 @@ fn localEntryConfig() app_entry_runtime.Config {
         .models_path = builtin_gateway.models_path,
         .gateway_retry_count = builtin_gateway.retry_count,
         .gateway_chat_url = builtin_gateway.default_chat_url,
-        .gateway_provider = builtin_gateway.provider,
+        .gateway_provider = native_gateway_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3266,7 +3272,7 @@ fn emptyEntryConfig() app_entry_runtime.Config {
         .models_path = "",
         .gateway_retry_count = 0,
         .gateway_chat_url = "",
-        .gateway_provider = builtin_gateway.provider,
+        .gateway_provider = native_gateway_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,

--- a/src/ui/footer/model_menu_presentation.zig
+++ b/src/ui/footer/model_menu_presentation.zig
@@ -3,6 +3,7 @@ const display_width = @import("../../core/shared/display_width.zig");
 const list_window = @import("../../core/shared/list_window.zig");
 const model_cache_runtime = @import("../../core/app/model_cache_runtime.zig");
 const model_capabilities = @import("../../core/config/model_capabilities.zig");
+const model_provider = @import("../../core/config/model_provider.zig");
 const ui_render = @import("../render.zig");
 const render_input = @import("render_input.zig");
 const row_text = @import("row_text.zig");
@@ -231,7 +232,7 @@ fn modelFactsColumn(projection: ModelMenuProjection, width: u16) ?usize {
     const content_width: usize = width;
     var facts_width: usize = 0;
     for (projection.items) |item| {
-        facts_width = @max(facts_width, compactFactsWidth(item.capabilities));
+        facts_width = @max(facts_width, compactFactsWidth(item.id, item.capabilities));
     }
     if (facts_width == 0 or content_width < indent_width + 8 + 2 + facts_width) return null;
     return content_width - facts_width;
@@ -252,7 +253,7 @@ fn composeTitleRow(
 
     var facts: std.ArrayList(u8) = .empty;
     defer facts.deinit(alloc);
-    try appendCompactFacts(alloc, &facts, item.capabilities);
+    try appendCompactFacts(alloc, &facts, item.id, item.capabilities);
 
     const prefix_width = display_width.visibleWidthIgnoringAnsi(row.items);
     const content_width = @as(usize, width);
@@ -274,16 +275,21 @@ fn composeTitleRow(
 fn appendCompactFacts(
     alloc: Allocator,
     facts: *std.ArrayList(u8),
+    model: []const u8,
     capabilities: model_capabilities.Capabilities,
 ) !void {
+    try appendMetadataFact(alloc, facts, model_provider.sourceLabel(model));
     if (capabilities.context_window) |tokens| try appendTokenFact(alloc, facts, tokens, "context");
     if (capabilities.max_output_tokens) |tokens| try appendTokenFact(alloc, facts, tokens, "output");
     if (capabilities.supports_fast_mode) try appendMetadataFact(alloc, facts, "Fast");
 }
 
-fn compactFactsWidth(capabilities: model_capabilities.Capabilities) usize {
-    var width: usize = 0;
-    if (capabilities.context_window) |tokens| width += tokenFactWidth(tokens, "context");
+fn compactFactsWidth(model: []const u8, capabilities: model_capabilities.Capabilities) usize {
+    var width: usize = display_width.visibleWidth(model_provider.sourceLabel(model));
+    if (capabilities.context_window) |tokens| {
+        if (width > 0) width += display_width.visibleWidth(" · ");
+        width += tokenFactWidth(tokens, "context");
+    }
     if (capabilities.max_output_tokens) |tokens| {
         if (width > 0) width += display_width.visibleWidth(" · ");
         width += tokenFactWidth(tokens, "output");
@@ -341,6 +347,17 @@ fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]
             .fx_login_refresh_required => "Vercel sign-in must refresh before team-private models can load.",
             .credential_refresh_failed => "Vercel sign-in refresh failed; using the public model catalog.",
             .authenticated_credential_rejected => "Your Gateway credential was rejected; using the public model catalog.",
+            .chatgpt_subscription => "ChatGPT subscription models are available with the public Gateway catalog.",
+        };
+    }
+    if (state.access_level == .authenticated) {
+        const source = state.source orelse return "Using an authenticated AI Gateway catalog.";
+        return switch (source) {
+            .fx_login => "Gateway catalog: authenticated with fx login.",
+            .ai_gateway_api_key => "Gateway catalog: authenticated with an API key.",
+            .vercel_oidc_token => "Gateway catalog: authenticated with the Vercel session.",
+            .stored_key => "Gateway catalog: authenticated with the stored API key.",
+            .chatgpt_subscription => "ChatGPT subscription models are available.",
         };
     }
     return null;
@@ -477,6 +494,19 @@ test "model menu keeps shared-prefix model ids distinguishable when narrow" {
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(beta_row.items) <= 40);
 }
 
+test "full model menu renders per-model account provenance" {
+    const alloc = std.testing.allocator;
+    const item: model_cache_runtime.ModelMenuItem = .{
+        .id = @constCast("openai-codex/gpt-5.4"),
+        .provider = "openai-codex",
+        .capabilities = .{},
+    };
+    var row = try composeTitleRow(alloc, item, true, 55, 80);
+    defer row.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, row.items, "openai-codex/gpt-5.4") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "ChatGPT subscription") != null);
+}
+
 test "model menu states and navigation budget stay bounded" {
     const alloc = std.testing.allocator;
     const loading: ModelMenuProjection = .{ .active = true, .load_state = .loading };
@@ -506,7 +536,10 @@ test "model menu states and navigation budget stay bounded" {
 }
 
 test "model menu status follows provenance and retryable failure precedence" {
-    try std.testing.expect(loadedCatalogStatusText(.{ .access_level = .authenticated }) == null);
+    try std.testing.expectEqualStrings(
+        "Gateway catalog: authenticated with fx login.",
+        loadedCatalogStatusText(.{ .access_level = .authenticated, .source = .fx_login }).?,
+    );
 
     const cases = [_]struct {
         state: model_cache_runtime.ModelMenuCatalogState,

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const model_provider = @import("../../core/config/model_provider.zig");
 const auth_runtime = @import("../../core/auth/auth_runtime.zig");
 const credentials = @import("../../core/auth/credentials.zig");
 const login_flow = @import("../../core/auth/login_flow.zig");
@@ -67,7 +68,7 @@ pub noinline fn composeAuthPickerRow(
     width: u16,
 ) !std.ArrayList(u8) {
     if (view.stage == .sign_in) {
-        return composeSignInPickerRow(alloc, view.sign_in, row_index, width);
+        return composeSignInPickerRow(alloc, view.sign_in, view.sign_in_source, row_index, width);
     }
     if (view.stage == .api_key) {
         return composeApiKeyPickerRow(alloc, view.api_key_mask_count, row_index, width);
@@ -159,7 +160,7 @@ fn onboardingProjectedRowIndex(view: auth_runtime.PickerView, row_index: u16, ro
 
     const selected_row: u16 = if (view.selectedIndex() == 0) 8 else 9;
     const other_row: u16 = if (selected_row == 8) 9 else 8;
-    const priority = [_]u16{ selected_row, other_row, 14, 7, 11, 5, 0, 2, 3, 6, 10, 12, 13, 1, 4, 15, 16 };
+    const priority = [_]u16{ selected_row, other_row, 10, 14, 7, 11, 5, 0, 2, 3, 6, 12, 13, 1, 4, 15, 16 };
 
     var projected_index: u16 = 0;
     for (0..17) |source_row| {
@@ -188,6 +189,7 @@ fn composeOnboardingPickerRow(
     const maybe_choice_index: ?usize = switch (source_row_index) {
         8 => 0,
         9 => 1,
+        10 => 2,
         else => null,
     };
     if (maybe_choice_index) |choice_index| {
@@ -231,6 +233,7 @@ fn composeOnboardingPickerRow(
 fn composeSignInPickerRow(
     alloc: Allocator,
     snapshot: login_flow.SignInSnapshot,
+    source: credentials.Source,
     row_index: u16,
     width: u16,
 ) !std.ArrayList(u8) {
@@ -247,13 +250,16 @@ fn composeSignInPickerRow(
     );
     var label_buf: [512]u8 = undefined;
     const label = switch (row_index) {
-        0 => "   Sign in with Vercel",
+        0 => if (source == .chatgpt_subscription) "   Sign in with ChatGPT" else "   Sign in with Vercel",
         1, 4 => "",
         2 => std.fmt.bufPrint(
             &label_buf,
             "   Open   {s}",
             .{snapshot.verification_uri},
-        ) catch "   Open the Vercel device authorization page",
+        ) catch if (source == .chatgpt_subscription)
+            "   Open the ChatGPT device authorization page"
+        else
+            "   Open the Vercel device authorization page",
         3 => std.fmt.bufPrint(
             &label_buf,
             "   Code   {s}",
@@ -433,7 +439,16 @@ pub noinline fn composePickerOptionRow(
     try row.appendSlice(alloc, if (selected) selected_style else ui_render.dim_style);
 
     const label_width: u16 = @intCast(width_usize - @as(usize, start_col - 1));
-    try row_text.appendClipped(alloc, &row, item, label_width);
+    if (kind == .model_stage and std.mem.findScalar(u8, item, '/') != null) {
+        var labeled: std.ArrayList(u8) = .empty;
+        defer labeled.deinit(alloc);
+        try labeled.appendSlice(alloc, item);
+        try labeled.appendSlice(alloc, "  · ");
+        try labeled.appendSlice(alloc, model_provider.sourceLabel(item));
+        try row_text.appendClipped(alloc, &row, labeled.items, label_width);
+    } else {
+        try row_text.appendClipped(alloc, &row, item, label_width);
+    }
     try row.appendSlice(alloc, ui_render.reset_style);
     return row;
 }
@@ -1502,6 +1517,16 @@ test "typed file picker tiny directory row retains kind identity" {
     try std.testing.expect(std.mem.find(u8, row.items, "/") != null);
 }
 
+test "compose model picker rows disclose the per-model provider source" {
+    var chatgpt = try composePickerOptionRow(std.testing.allocator, .model_stage, 1, "openai-codex/gpt-5.4", true, 80);
+    defer chatgpt.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.find(u8, chatgpt.items, "ChatGPT subscription") != null);
+
+    var gateway = try composePickerOptionRow(std.testing.allocator, .model_stage, 1, "anthropic/claude-sonnet-4.6", false, 80);
+    defer gateway.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.find(u8, gateway.items, "Vercel AI Gateway") != null);
+}
+
 test "compose model picker status row aligns to active token" {
     var row = try composePickerStatusRow(std.testing.allocator, .model_stage, .fast, false, false, 23, 48);
     defer row.deinit(std.testing.allocator);
@@ -1551,7 +1576,11 @@ test "auth onboarding composes the welcome copy and setup choices" {
     defer selected_row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, selected_row.items, "› Sign in with Vercel") != null);
 
-    var unselected_row = try composeAuthPickerRow(alloc, view, 9, authPickerRowCount(view), 100);
+    var chatgpt_row = try composeAuthPickerRow(alloc, view, 9, authPickerRowCount(view), 100);
+    defer chatgpt_row.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, chatgpt_row.items, "Sign in with ChatGPT") != null);
+
+    var unselected_row = try composeAuthPickerRow(alloc, view, 10, authPickerRowCount(view), 100);
     defer unselected_row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, unselected_row.items, "Add an API key") != null);
 
@@ -1569,7 +1598,7 @@ test "auth onboarding composes the welcome copy and setup choices" {
     }
     try std.testing.expect(std.mem.find(u8, compact_screen.items, "Sign in with Vercel") != null);
     try std.testing.expect(std.mem.find(u8, compact_screen.items, "Add an API key") != null);
-    try std.testing.expect(std.mem.find(u8, compact_screen.items, "Esc to set up later") != null);
+    try std.testing.expect(std.mem.find(u8, compact_screen.items, "Sign in with ChatGPT") != null);
 }
 
 test "auth picker composes only detected credential sources" {
@@ -1582,7 +1611,7 @@ test "auth picker composes only detected credential sources" {
         .include_skip = false,
     };
     const row_count = authPickerRowCount(view);
-    try std.testing.expectEqual(@as(u16, 5), row_count);
+    try std.testing.expectEqual(@as(u16, 6), row_count);
 
     var header = try composeAuthPickerRow(alloc, view, 0, row_count, 80);
     defer header.deinit(alloc);
@@ -1592,16 +1621,20 @@ test "auth picker composes only detected credential sources" {
     defer sign_in.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, sign_in.items, "Sign in with Vercel") != null);
 
-    var setup = try composeAuthPickerRow(alloc, view, 2, row_count, 80);
+    var chatgpt = try composeAuthPickerRow(alloc, view, 2, row_count, 80);
+    defer chatgpt.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, chatgpt.items, "Sign in with ChatGPT") != null);
+
+    var setup = try composeAuthPickerRow(alloc, view, 3, row_count, 80);
     defer setup.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, setup.items, "API key") != null);
 
-    var change_team = try composeAuthPickerRow(alloc, view, 3, row_count, 80);
+    var change_team = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
     defer change_team.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, change_team.items, "Change team") != null);
     try std.testing.expect(std.mem.find(u8, change_team.items, "sign in first") != null);
 
-    var switch_credential = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
+    var switch_credential = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
     defer switch_credential.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, switch_credential.items, "Switch credential") != null);
 }

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -519,6 +519,52 @@ function writeSeededFxAuth(home: string, teamId?: string): void {
   chmodSync(authPath, 0o600);
 }
 
+function acpChatGptAccessToken(accountId = "acct_acp_e2e"): string {
+  const payload = Buffer.from(JSON.stringify({
+    "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+  })).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+function writeSeededAcpChatGptLogin(home: string, accessToken: string): void {
+  const fxDir = join(home, ".fx");
+  mkdirSync(fxDir, { recursive: true, mode: 0o700 });
+  chmodSync(fxDir, 0o700);
+  const authPath = join(fxDir, "chatgpt-auth.json");
+  writeFileSync(authPath, JSON.stringify({
+    version: 1,
+    access_token: accessToken,
+    refresh_token: "chatgpt-refresh",
+    expires_at_ms: Date.now() + 60 * 60 * 1000,
+    account_id: "acct_acp_e2e",
+  }) + "\n", { mode: 0o600 });
+  chmodSync(authPath, 0o600);
+}
+
+function startAcpFakeCodex() {
+  const accessToken = acpChatGptAccessToken();
+  const requests: Array<{ path: string; authorization: string | null }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const path = new URL(request.url).pathname;
+      requests.push({ path, authorization: request.headers.get("authorization") });
+      return new Response(
+        'data: {"type":"response.output_text.delta","delta":"ACP_CHATGPT_RESPONSE"}\n\n' +
+          'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":2}}}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  });
+  return {
+    accessToken,
+    requests,
+    responsesUrl: `http://127.0.0.1:${server.port}/responses`,
+    stop() { server.stop(true); },
+  };
+}
+
 class AcpReadTimeoutError extends Error {
   constructor() {
     super("ACP readLine timeout");
@@ -7022,6 +7068,50 @@ describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {
         expect(modelOpt.currentValue).toBe("o4-mini");
       } finally {
         await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "session model changes re-resolve ChatGPT credentials without crossing origins",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-chatgpt-route-");
+      const gateway = startFakeGateway([]);
+      const codex = startAcpFakeCodex();
+      writeSeededAcpChatGptLogin(root.home, codex.accessToken);
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            ...fakeGatewayEnv(root, gateway),
+            FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
+          },
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+        await client.request("session/new", { mcpServers: [] }, 2);
+        await client.readLine(); // consume session/update notification
+
+        const changed = await client.request("session/set_config_option", {
+          configId: "model",
+          value: "openai-codex/gpt-5.4",
+        }, 3) as any;
+        expect(changed.result.configOptions.find((option: any) => option.id === "model").currentValue)
+          .toBe("openai-codex/gpt-5.4");
+
+        const prompt = await runPrompt(client, "Answer directly.", TIMEOUT);
+        expect(prompt.promptResult.result.stopReason).toBe("end_turn");
+        expect(JSON.stringify(prompt.messages)).toContain("ACP_CHATGPT_RESPONSE");
+        expect(codex.requests).toHaveLength(1);
+        expect(codex.requests[0]!.authorization).toBe(`Bearer ${codex.accessToken}`);
+        for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+          expect(request.headers.get("authorization")).not.toBe(`Bearer ${codex.accessToken}`);
+        }
+      } finally {
+        await client?.close();
+        codex.stop();
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });
       }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -3118,6 +3118,7 @@ describe("cli: models", () => {
             more_count: 0,
             private_models_hidden: true,
             ids: ["public/fallback"],
+            models: [{ id: "public/fallback", source: "Vercel AI Gateway" }],
           });
 
           expect(gateway.modelRequests).toHaveLength(2);
@@ -3287,6 +3288,7 @@ describe("cli: models", () => {
   test(
     "fx models rejects E2E gateway redirects without contacting the target",
     async () => {
+      const home = createIsolatedTestHome();
       const captureRequests: string[] = [];
       const captureServer = Bun.serve({
         hostname: "127.0.0.1",
@@ -3309,6 +3311,8 @@ describe("cli: models", () => {
       try {
         const r = await runFx(["models", "--json"], {
           env: {
+            HOME: home,
+            FX_DISABLE_KEYCHAIN: "1",
             AI_GATEWAY_API_KEY: "redirect-proof-key",
             VERCEL_OIDC_TOKEN: undefined,
             FX_E2E_GATEWAY_MODELS_URL: `http://127.0.0.1:${redirectServer.port}/v1/models`,
@@ -3326,6 +3330,7 @@ describe("cli: models", () => {
       } finally {
         redirectServer.stop(true);
         captureServer.stop(true);
+        cleanupIsolatedTestHome(home);
       }
     },
     TIMEOUT,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -339,16 +339,21 @@ function startFakeChatGptOAuth(
     method: string;
     path: string;
     authorization: string | null;
+    body: string | null;
   }> = [];
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     async fetch(request) {
       const url = new URL(request.url);
+      const body = url.pathname === "/chatgpt/responses"
+        ? await request.text()
+        : null;
       requests.push({
         method: request.method,
         path: url.pathname,
         authorization: request.headers.get("authorization"),
+        body,
       });
       if (url.pathname === "/chatgpt/device") {
         return Response.json({
@@ -527,7 +532,11 @@ tmuxTest(
     home = mkdtempSync(join(tmpdir(), "fx-tui-chatgpt-success-"));
     stderrPath = join(home, "stderr.log");
     writeFileSync(stderrPath, "");
-    gateway = startFakeGateway([]);
+    gateway = startFakeGateway([], {
+      models() {
+        return [{ id: "openai/gpt-5.6-sol", type: "language", tags: ["tool-use"] }];
+      },
+    });
     chatgptOauth = startFakeChatGptOAuth({ tokenDelayMs: 500 });
 
     session = await startFx(
@@ -562,7 +571,7 @@ tmuxTest(
     await session.sendText("/model");
     const picker = await session.waitForPane(
       (pane) =>
-        pane.includes("openai-codex/gpt-5.4") &&
+        pane.includes("openai-codex/gpt-5.6-sol") &&
         pane.includes("ChatGPT subscription"),
       TIMEOUT,
     );
@@ -570,17 +579,18 @@ tmuxTest(
     await session.sendKeys("Escape");
     await session.sendKeys("C-c");
     await session.waitForComposer(TIMEOUT);
-    await session.sendLiteralText("/model openai-codex/gpt-5.4");
+    await session.sendLiteralText("/model openai-codex/gpt-5.6-sol");
     await session.sendKeys("Space");
     await session.sendLiteralText("auto");
     await session.sendKeys("Enter");
-    await session.waitForText("Switched to openai-codex/gpt-5.4", TIMEOUT);
+    await session.waitForText("Switched to openai-codex/gpt-5.6-sol", TIMEOUT);
     await session.sendText("Use the ChatGPT subscription directly.");
     await session.waitForText("CHATGPT_DIRECT_RESPONSE", TIMEOUT);
     const directRequest = chatgptOauth.requests.find(
       (request) => request.path === "/chatgpt/responses",
     );
     expect(directRequest?.authorization).toBe(`Bearer ${chatgptOauth.accessToken}`);
+    expect(JSON.parse(directRequest?.body ?? "{}").model).toBe("gpt-5.6-sol");
     for (const request of [...gateway.requests, ...gateway.modelRequests]) {
       expect(request.headers.get("authorization")).not.toBe(
         `Bearer ${chatgptOauth.accessToken}`,
@@ -588,7 +598,11 @@ tmuxTest(
     }
     await session.sendText("/models");
     await session.waitForPane(
-      (pane) => pane.includes("Models") && pane.includes("ChatGPT subscription"),
+      (pane) =>
+        pane.includes("Models") &&
+        pane.includes("openai/gpt-5.6-sol") &&
+        pane.includes("openai-codex/gpt-5.6-sol") &&
+        pane.includes("ChatGPT subscription"),
       TIMEOUT,
     );
     await session.sendKeys("Escape");
@@ -1310,7 +1324,11 @@ test(
   "ChatGPT CLI login survives restart and exposes sourced models without FX_MODEL",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-chatgpt-cli-login-"));
-    gateway = startFakeGateway([]);
+    gateway = startFakeGateway([], {
+      models() {
+        return [{ id: "openai/gpt-5.6-sol", type: "language", tags: ["tool-use"] }];
+      },
+    });
     chatgptOauth = startFakeChatGptOAuth({ unauthorizedResponses: 1 });
     const env = {
       HOME: home,
@@ -1352,7 +1370,11 @@ test(
       models: Array<{ id: string; source: string }>;
     };
     expect(modelsJson.models).toContainEqual({
-      id: "openai-codex/gpt-5.4",
+      id: "openai/gpt-5.6-sol",
+      source: "Vercel AI Gateway",
+    });
+    expect(modelsJson.models).toContainEqual({
+      id: "openai-codex/gpt-5.6-sol",
       source: "ChatGPT subscription",
     });
 
@@ -1370,12 +1392,12 @@ test(
     ).toBe(0);
     expect(
       (JSON.parse(offlineModels.stdout) as { models: Array<{ id: string }> }).models
-        .some((model) => model.id === "openai-codex/gpt-5.4"),
+        .some((model) => model.id === "openai-codex/gpt-5.6-sol"),
     ).toBe(true);
 
     writeFileSync(
       join(home, ".fx", "settings.json"),
-      JSON.stringify({ model: "openai-codex/gpt-5.4" }) + "\n",
+      JSON.stringify({ model: "openai-codex/gpt-5.6-sol" }) + "\n",
       { mode: 0o600 },
     );
     const ask = await runFx(

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -45,6 +45,7 @@ let home: string | null = null;
 let stderrPath: string | null = null;
 let gateway: ReturnType<typeof startFakeGateway> | null = null;
 let oauth: ReturnType<typeof startFakeOAuth> | null = null;
+let chatgptOauth: ReturnType<typeof startFakeChatGptOAuth> | null = null;
 let creditsGateway: ReturnType<typeof startFakeCreditsGateway> | null = null;
 let catcher: ReturnType<typeof startRequestCatcher> | null = null;
 
@@ -55,6 +56,8 @@ afterEach(async () => {
   gateway = null;
   oauth?.stop();
   oauth = null;
+  chatgptOauth?.stop();
+  chatgptOauth = null;
   creditsGateway?.stop();
   creditsGateway = null;
   catcher?.stop();
@@ -63,6 +66,21 @@ afterEach(async () => {
   home = null;
   stderrPath = null;
 });
+
+function writeSeededChatGptLogin(testHome: string, accessToken = chatgptAccessToken()): void {
+  const fxDir = join(testHome, ".fx");
+  mkdirSync(fxDir, { recursive: true, mode: 0o700 });
+  chmodSync(fxDir, 0o700);
+  const authPath = join(fxDir, "chatgpt-auth.json");
+  writeFileSync(authPath, JSON.stringify({
+    version: 1,
+    access_token: accessToken,
+    refresh_token: "chatgpt-refresh",
+    expires_at_ms: Date.now() + 60 * 60 * 1000,
+    account_id: "acct_e2e",
+  }) + "\n", { mode: 0o600 });
+  chmodSync(authPath, 0o600);
+}
 
 function writeSeededFxLogin(
   testHome: string,
@@ -301,6 +319,125 @@ function startFakeOAuth(
   };
 }
 
+function chatgptAccessToken(accountId = "acct_e2e"): string {
+  const payload = Buffer.from(JSON.stringify({
+    "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+  })).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+function startFakeChatGptOAuth(
+  options: {
+    tokenDelayMs?: number;
+    responseDelayMs?: number;
+    unauthorizedResponses?: number;
+  } = {},
+) {
+  const accessToken = chatgptAccessToken();
+  let responseCount = 0;
+  const requests: Array<{
+    method: string;
+    path: string;
+    authorization: string | null;
+  }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      requests.push({
+        method: request.method,
+        path: url.pathname,
+        authorization: request.headers.get("authorization"),
+      });
+      if (url.pathname === "/chatgpt/device") {
+        return Response.json({
+          device_auth_id: "chatgpt-device-id",
+          user_code: "CHAT-CODE",
+          interval: 0,
+        });
+      }
+      if (url.pathname === "/chatgpt/poll") {
+        if (options.tokenDelayMs) await Bun.sleep(options.tokenDelayMs);
+        return Response.json({
+          authorization_code: "chatgpt-code",
+          code_verifier: "chatgpt-verifier",
+        });
+      }
+      if (url.pathname === "/chatgpt/token") {
+        return Response.json({
+          access_token: accessToken,
+          refresh_token: "chatgpt-refresh",
+          expires_in: 3600,
+        });
+      }
+      if (url.pathname === "/chatgpt/responses") {
+        responseCount += 1;
+        if (responseCount <= (options.unauthorizedResponses ?? 0)) {
+          return Response.json(
+            { error: { message: "expired ChatGPT token" } },
+            { status: 401 },
+          );
+        }
+        if (options.responseDelayMs) await Bun.sleep(options.responseDelayMs);
+        return new Response(
+          'data: {"type":"response.output_text.delta","delta":"CHATGPT_DIRECT_RESPONSE"}\n\n' +
+            'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":2}}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const baseUrl = `http://127.0.0.1:${server.port}`;
+  return {
+    accessToken,
+    requests,
+    env: {
+      FX_E2E_CHATGPT_DEVICE_USER_CODE_URL: `${baseUrl}/chatgpt/device`,
+      FX_E2E_CHATGPT_DEVICE_TOKEN_URL: `${baseUrl}/chatgpt/poll`,
+      FX_E2E_CHATGPT_TOKEN_URL: `${baseUrl}/chatgpt/token`,
+      FX_E2E_OPENAI_CODEX_RESPONSES_URL: `${baseUrl}/chatgpt/responses`,
+    },
+    stop() {
+      server.stop(true);
+    },
+  };
+}
+
+function startFakeCodexToolLoop() {
+  const bodies: string[] = [];
+  const accessToken = chatgptAccessToken("acct_tool_loop");
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      bodies.push(await request.text());
+      if (bodies.length === 1) {
+        return new Response(
+          'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}\n\n' +
+            'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_tool","type":"reasoning","summary":[],"encrypted_content":"opaque-tool-loop"}}\n\n' +
+            'data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","call_id":"call_read","name":"read_file"}}\n\n' +
+            'data: {"type":"response.function_call_arguments.done","output_index":1,"arguments":"{\\"path\\":\\"README.md\\"}"}\n\n' +
+            'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(
+        'data: {"type":"response.output_text.delta","delta":"CODEX_TOOL_LOOP_OK"}\n\n' +
+          'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":7,"output_tokens":3}}}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  });
+  return {
+    accessToken,
+    bodies,
+    responsesUrl: `http://127.0.0.1:${server.port}/responses`,
+    stop() { server.stop(true); },
+  };
+}
+
 tmuxTest(
   "inline sign-in renders the device flow and Ctrl+C cancels without a session",
   async () => {
@@ -315,6 +452,8 @@ tmuxTest(
     session = await startFx(home, stderrPath, gateway, oauth.issuerUrl);
     await session.waitForComposer(TIMEOUT);
     await session.sendText("/login");
+    await session.waitForText("Sign in with ChatGPT", TIMEOUT);
+    await session.sendKeys("Enter");
     const signInScreen = await session.waitForPane(
       (pane) =>
         pane.includes("Sign in with Vercel") &&
@@ -332,6 +471,173 @@ tmuxTest(
     expect(session.isAlive()).toBe(true);
     expect(existsSync(join(home, ".fx", "auth.json"))).toBe(false);
     expect(await session.captureFullScrollback()).not.toContain("Signed in to Vercel.");
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
+  "ChatGPT sign-in uses the rendered device flow and Ctrl+C cancels without a session",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-chatgpt-cancel-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    chatgptOauth = startFakeChatGptOAuth({ tokenDelayMs: 5_000 });
+
+    session = await startFx(
+      home,
+      stderrPath,
+      gateway,
+      undefined,
+      undefined,
+      chatgptOauth.env,
+    );
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/login");
+    await session.waitForText("Sign in with ChatGPT", TIMEOUT);
+    await session.sendKeys("Down");
+    await session.sendKeys("Enter");
+    const signInScreen = await session.waitForPane(
+      (pane) =>
+        pane.includes("Sign in with ChatGPT") &&
+        pane.includes("CHAT-CODE") &&
+        pane.includes("auth.openai.com/codex/device") &&
+        pane.includes("Waiting for authorization") &&
+        pane.includes("Enter reopens browser · Esc cancels"),
+      TIMEOUT,
+    );
+    await session.resizeWindow(72, 10);
+    await session.waitForText("CHAT-CODE", TIMEOUT);
+    await session.resizeWindow(100, 30);
+    await session.sendKeys("C-c");
+    await session.waitForComposer(TIMEOUT);
+
+    expect(session.isAlive()).toBe(true);
+    expect(existsSync(join(home, ".fx", "chatgpt-auth.json"))).toBe(false);
+    expect(await session.captureFullScrollback()).not.toContain("Signed in with ChatGPT.");
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
+  "ChatGPT sign-in refreshes the model picker without FX_MODEL",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-chatgpt-success-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    chatgptOauth = startFakeChatGptOAuth({ tokenDelayMs: 500 });
+
+    session = await startFx(
+      home,
+      stderrPath,
+      gateway,
+      undefined,
+      undefined,
+      {
+        ...chatgptOauth.env,
+        AI_GATEWAY_API_KEY: undefined,
+        FX_MODEL: undefined,
+      },
+    );
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/login");
+    await session.waitForText("Sign in with ChatGPT", TIMEOUT);
+    await session.sendKeys("Down");
+    await session.sendKeys("Enter");
+    await session.waitForText("CHAT-CODE", TIMEOUT);
+    await session.waitForText("Signed in with ChatGPT.", TIMEOUT);
+
+    const authPath = join(home, ".fx", "chatgpt-auth.json");
+    expect(existsSync(authPath)).toBe(true);
+    expect(statSync(authPath).mode & 0o077).toBe(0);
+
+    await session.sendText("/status");
+    await session.waitForText(
+      "connected_providers=ChatGPT",
+      TIMEOUT,
+    );
+    await session.sendText("/model");
+    const picker = await session.waitForPane(
+      (pane) =>
+        pane.includes("openai-codex/gpt-5.4") &&
+        pane.includes("ChatGPT subscription"),
+      TIMEOUT,
+    );
+    expect(picker).toContain("Vercel AI Gateway");
+    await session.sendKeys("Escape");
+    await session.sendKeys("C-c");
+    await session.waitForComposer(TIMEOUT);
+    await session.sendLiteralText("/model openai-codex/gpt-5.4");
+    await session.sendKeys("Space");
+    await session.sendLiteralText("auto");
+    await session.sendKeys("Enter");
+    await session.waitForText("Switched to openai-codex/gpt-5.4", TIMEOUT);
+    await session.sendText("Use the ChatGPT subscription directly.");
+    await session.waitForText("CHATGPT_DIRECT_RESPONSE", TIMEOUT);
+    const directRequest = chatgptOauth.requests.find(
+      (request) => request.path === "/chatgpt/responses",
+    );
+    expect(directRequest?.authorization).toBe(`Bearer ${chatgptOauth.accessToken}`);
+    for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+      expect(request.headers.get("authorization")).not.toBe(
+        `Bearer ${chatgptOauth.accessToken}`,
+      );
+    }
+    await session.sendText("/models");
+    await session.waitForPane(
+      (pane) => pane.includes("Models") && pane.includes("ChatGPT subscription"),
+      TIMEOUT,
+    );
+    await session.sendKeys("Escape");
+    await session.waitForPane((pane) => !pane.includes("Esc Close"), TIMEOUT);
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/logout chatgpt");
+    await session.waitForText("Signed out of ChatGPT.", TIMEOUT);
+    expect(existsSync(authPath)).toBe(false);
+    await session.sendText("/model");
+    const afterLogoutPicker = await session.waitForText("Vercel AI Gateway", TIMEOUT);
+    expect(afterLogoutPicker).not.toMatch(/^\s+openai-codex\//m);
+    await session.sendKeys("C-c");
+
+    expect(session.isAlive()).toBe(true);
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
+  "ChatGPT response transport cancels blocked HTTP without stopping the shell",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-chatgpt-response-cancel-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    chatgptOauth = startFakeChatGptOAuth({ responseDelayMs: 10_000 });
+    writeSeededChatGptLogin(home, chatgptOauth.accessToken);
+
+    session = await startFx(
+      home,
+      stderrPath,
+      gateway,
+      undefined,
+      undefined,
+      {
+        ...chatgptOauth.env,
+        FX_MODEL: "openai-codex/gpt-5.4",
+      },
+    );
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("Cancel the blocked ChatGPT response.");
+    await Bun.sleep(300);
+    const cancelStarted = Date.now();
+    await session.sendKeys("C-c");
+    await session.waitForText("System: cancelled", TIMEOUT);
+    await session.waitForComposer(TIMEOUT);
+    expect(Date.now() - cancelStarted).toBeLessThan(3_000);
+    expect(session.isAlive()).toBe(true);
     expect(readFileSync(stderrPath, "utf8")).toBe("");
   },
   60_000,
@@ -356,6 +662,7 @@ tmuxTest(
       (pane) =>
         pane.includes("Setup") &&
         pane.includes("Sign in with Vercel") &&
+        pane.includes("Sign in with ChatGPT") &&
         pane.includes("API key") &&
         pane.includes("Change team") &&
         pane.includes("Switch credential"),
@@ -369,6 +676,7 @@ tmuxTest(
     await session.sendKeys("Escape");
     await session.waitForText("Switch credential", TIMEOUT);
 
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
     const apiKey = await session.waitForText("Paste your AI Gateway API key", TIMEOUT);
@@ -450,7 +758,7 @@ async function waitForTrace(tracePath: string, needle: string): Promise<void> {
 }
 
 async function enterSwitchCredential(pickerSession: TmuxSession): Promise<void> {
-  for (let index = 0; index < 3; index += 1) {
+  for (let index = 0; index < 4; index += 1) {
     await pickerSession.sendKeys("Down");
   }
   await pickerSession.sendKeys("Enter");
@@ -487,6 +795,7 @@ profileStoredKeyTmuxTest(
 
     await session.sendText("/setup");
     await session.waitForText("API key", TIMEOUT);
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
     await session.waitForText("Paste your AI Gateway API key", TIMEOUT);
@@ -538,6 +847,8 @@ tmuxTest(
     await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
 
     await session.sendText("/login");
+    await session.waitForText("Sign in with ChatGPT", TIMEOUT);
+    await session.sendKeys("Enter");
     await session.waitForText("Signed in to Vercel", TIMEOUT);
     await session.sendText("/status");
     await session.waitForText("auth=fx login", TIMEOUT);
@@ -606,6 +917,7 @@ tmuxTest(
 
     await session.sendText("/setup");
     await session.waitForText("Change team", TIMEOUT);
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
@@ -703,6 +1015,8 @@ tmuxTest(
     expect(gateway.requests[2].headers.get("authorization")).toBe(`Bearer ${LOGIN_TOKEN}`);
 
     await session.sendText("/login");
+    await session.waitForText("Sign in with ChatGPT", TIMEOUT);
+    await session.sendKeys("Enter");
     const loginCompleted = await session.waitForText("Signed in to Vercel", TIMEOUT);
     expect(loginCompleted).not.toContain("Setup");
     expect(oauth.requests.map((request) => `${request.method} ${request.path}`)).toEqual([
@@ -824,6 +1138,8 @@ tmuxTest(
     expect(gateway.modelRequests[0].headers.get("authorization")).toBeNull();
 
     await session.sendText("/login");
+    await session.waitForText("Sign in with ChatGPT", TIMEOUT);
+    await session.sendKeys("Enter");
     await session.waitForText("Choose a Vercel team", TIMEOUT);
     await session.resizeWindow(80, 5);
     await session.sendLiteralText("example");
@@ -986,6 +1302,182 @@ test(
     expect(result.stdout.match(/Code: TEST-CODE/g) ?? []).toHaveLength(1);
     expect(result.stdout).not.toContain(oauth.providerDetail);
     expect(result.stderr).toBe("");
+  },
+  60_000,
+);
+
+test(
+  "ChatGPT CLI login survives restart and exposes sourced models without FX_MODEL",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-chatgpt-cli-login-"));
+    gateway = startFakeGateway([]);
+    chatgptOauth = startFakeChatGptOAuth({ unauthorizedResponses: 1 });
+    const env = {
+      HOME: home,
+      AI_GATEWAY_API_KEY: undefined,
+      VERCEL_OIDC_TOKEN: undefined,
+      FX_DISABLE_KEYCHAIN: "1",
+      FX_SKIP_ONBOARDING: "1",
+      FX_AUTO_UPGRADE: "0",
+      FX_NO_OPEN_BROWSER: "1",
+      FX_GATEWAY_BASE_URL: gateway.baseUrl,
+      FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+      ...chatgptOauth.env,
+    };
+
+    const login = await runFx(["login", "openai-codex"], {
+      env,
+      timeoutMs: TIMEOUT,
+    });
+    expect(login.code, `stdout: ${login.stdout}\nstderr: ${login.stderr}`).toBe(0);
+    expect(login.stdout).toContain("Signed in with ChatGPT.");
+    expect(login.stderr).toBe("");
+
+    const authPath = join(home, ".fx", "chatgpt-auth.json");
+    expect(existsSync(authPath)).toBe(true);
+    expect(statSync(authPath).mode & 0o077).toBe(0);
+
+    const status = await runFx(["status", "--json"], { env, timeoutMs: TIMEOUT });
+    expect(status.code).toBe(0);
+    const statusJson = JSON.parse(status.stdout) as {
+      connected_providers: string[];
+      model_source: string;
+    };
+    expect(statusJson.connected_providers).toContain("chatgpt");
+    expect(statusJson.model_source).toBe("Vercel AI Gateway");
+
+    const models = await runFx(["models", "--json"], { env, timeoutMs: TIMEOUT });
+    expect(models.code, `stdout: ${models.stdout}\nstderr: ${models.stderr}`).toBe(0);
+    const modelsJson = JSON.parse(models.stdout) as {
+      models: Array<{ id: string; source: string }>;
+    };
+    expect(modelsJson.models).toContainEqual({
+      id: "openai-codex/gpt-5.4",
+      source: "ChatGPT subscription",
+    });
+
+    const offlineModels = await runFx(["models", "--json"], {
+      env: {
+        ...env,
+        FX_GATEWAY_BASE_URL: "http://127.0.0.1:1",
+        FX_E2E_GATEWAY_MODELS_URL: "http://127.0.0.1:1/coding-agent/v1/models",
+      },
+      timeoutMs: TIMEOUT,
+    });
+    expect(
+      offlineModels.code,
+      `stdout: ${offlineModels.stdout}\nstderr: ${offlineModels.stderr}`,
+    ).toBe(0);
+    expect(
+      (JSON.parse(offlineModels.stdout) as { models: Array<{ id: string }> }).models
+        .some((model) => model.id === "openai-codex/gpt-5.4"),
+    ).toBe(true);
+
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ model: "openai-codex/gpt-5.4" }) + "\n",
+      { mode: 0o600 },
+    );
+    const ask = await runFx(
+      ["ask", "--json", "--auto", "Answer directly."],
+      {
+        env,
+        timeoutMs: TIMEOUT,
+      },
+    );
+    expect(ask.code, `stdout: ${ask.stdout}\nstderr: ${ask.stderr}`).toBe(0);
+    expect(ask.stdout).toContain("CHATGPT_DIRECT_RESPONSE");
+    const responseRequest = chatgptOauth.requests.find(
+      (request) => request.path === "/chatgpt/responses",
+    );
+    expect(responseRequest?.authorization).toBe(`Bearer ${chatgptOauth.accessToken}`);
+    expect(
+      chatgptOauth.requests.filter((request) => request.path === "/chatgpt/responses"),
+    ).toHaveLength(2);
+    expect(
+      chatgptOauth.requests.filter((request) => request.path === "/chatgpt/token"),
+    ).toHaveLength(2);
+    for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+      expect(request.headers.get("authorization")).not.toBe(
+        `Bearer ${chatgptOauth.accessToken}`,
+      );
+    }
+
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ model: "zai/glm-5.2" }) + "\n",
+      { mode: 0o600 },
+    );
+    const resumed = await runFx(
+      ["ask", "--json", "--auto", "--resume", "last", "Continue directly."],
+      {
+        env: {
+          ...env,
+          AI_GATEWAY_API_KEY: "gateway-resume-sentinel",
+          FX_MODEL: undefined,
+        },
+        timeoutMs: TIMEOUT,
+      },
+    );
+    expect(resumed.code, `stdout: ${resumed.stdout}\nstderr: ${resumed.stderr}`).toBe(0);
+    expect(resumed.stdout).toContain("CHATGPT_DIRECT_RESPONSE");
+    expect(
+      chatgptOauth.requests.filter((request) => request.path === "/chatgpt/responses"),
+    ).toHaveLength(3);
+    for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+      expect(request.headers.get("authorization")).not.toBe(
+        `Bearer ${chatgptOauth.accessToken}`,
+      );
+    }
+
+    const logout = await runFx(["logout", "openai-codex"], { env, timeoutMs: TIMEOUT });
+    expect(logout.code).toBe(0);
+    expect(logout.stdout).toContain("Signed out of ChatGPT.");
+    expect(existsSync(authPath)).toBe(false);
+  },
+  60_000,
+);
+
+test(
+  "ChatGPT tool loops round-trip encrypted reasoning without Gateway leakage",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-chatgpt-tool-loop-"));
+    gateway = startFakeGateway([]);
+    const codex = startFakeCodexToolLoop();
+    try {
+      writeSeededChatGptLogin(home, codex.accessToken);
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ model: "openai-codex/gpt-5.4" }) + "\n",
+        { mode: 0o600 },
+      );
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Read the README, then finish."],
+        {
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: "gateway-tool-loop-sentinel",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_AUTO_UPGRADE: "0",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+            FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("CODEX_TOOL_LOOP_OK");
+      expect(codex.bodies).toHaveLength(2);
+      expect(codex.bodies[1]).toContain('"encrypted_content":"opaque-tool-loop"');
+      expect(codex.bodies[1]).toContain('"type":"function_call_output"');
+      for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+        expect(request.headers.get("authorization")).not.toBe(`Bearer ${codex.accessToken}`);
+      }
+    } finally {
+      codex.stop();
+    }
   },
   60_000,
 );

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -581,16 +581,31 @@ tmuxTest(
     await session.waitForComposer(TIMEOUT);
     await session.sendLiteralText("/model openai-codex/gpt-5.6-sol");
     await session.sendKeys("Space");
-    await session.sendLiteralText("auto");
+    await session.sendLiteralText("max");
+    await session.sendKeys("Space");
+    await session.sendLiteralText("fast");
     await session.sendKeys("Enter");
     await session.waitForText("Switched to openai-codex/gpt-5.6-sol", TIMEOUT);
+    await session.sendText("/fast");
+    await session.waitForText("Fast: off", TIMEOUT);
+    await session.sendText("/fast");
+    await session.waitForText("Fast: on", TIMEOUT);
     await session.sendText("Use the ChatGPT subscription directly.");
     await session.waitForText("CHATGPT_DIRECT_RESPONSE", TIMEOUT);
     const directRequest = chatgptOauth.requests.find(
       (request) => request.path === "/chatgpt/responses",
     );
     expect(directRequest?.authorization).toBe(`Bearer ${chatgptOauth.accessToken}`);
-    expect(JSON.parse(directRequest?.body ?? "{}").model).toBe("gpt-5.6-sol");
+    const directBody = JSON.parse(directRequest?.body ?? "{}") as {
+      model?: string;
+      service_tier?: string;
+      max_output_tokens?: number;
+      reasoning?: { effort?: string };
+    };
+    expect(directBody.model).toBe("gpt-5.6-sol");
+    expect(directBody.service_tier).toBe("priority");
+    expect(directBody.max_output_tokens).toBeUndefined();
+    expect(directBody.reasoning?.effort).toBe("max");
     for (const request of [...gateway.requests, ...gateway.modelRequests]) {
       expect(request.headers.get("authorization")).not.toBe(
         `Bearer ${chatgptOauth.accessToken}`,


### PR DESCRIPTION
## Summary
- add ChatGPT subscription OAuth and direct OpenAI Codex model routing alongside Vercel AI Gateway
- isolate credentials by provider origin across TUI, CLI, ACP, subagents, auxiliary tools, and usage reconciliation
- add cancellable rendered login, provider-aware model/status output, independent catalog fallback, refresh, logout, and stateless reasoning continuation

## Local validation
- `zig fmt --check src/`
- `zig build`
- `zig build test`
- `zig build -Dwasm-surface=core`
- `zig build -Dwasm-surface=term`
- `cd tests/e2e && bun test cli.test.ts`
- `cd tests/e2e && bun test tui-auth-source-selection.test.ts`
- `cd tests/e2e && AI_GATEWAY_API_KEY=dummy bun test acp.test.ts --test-name-pattern 'session model changes re-resolve ChatGPT'`
- exercised ChatGPT login, model selection, direct response, model provenance, and logout with `./zig-out/bin/fx` in cmux

## Pending
- Full CI and the final ship gate for commit `df5d29f`
