### PR TITLE
Add Codex OAuth login and a native mod API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Requirements:
 
 * interactive terminal for manual shell testing
 
-* a Vercel OAuth session via `fx login` for model-backed flows. macOS Keychain API keys (via `fx setup`), `AI_GATEWAY_API_KEY`, and `VERCEL_OIDC_TOKEN` are also supported
+* a Vercel OAuth session via `fx login` for model-backed flows. macOS Keychain API keys (via `fx setup`), `AI_GATEWAY_API_KEY`, and `VERCEL_OIDC_TOKEN` are also supported. Existing Codex or Nanocodex ChatGPT login at `~/.codex/auth.json` is also accepted and talks to OpenAI Codex.
 
 Common commands:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ fx setup
 
 If you already signed in with Codex or Nanocodex, fx also uses the ChatGPT tokens in `~/.codex/auth.json` and talks to OpenAI Codex. Switch credentials from the hub if more than one source is available.
 
+To create that login from fx:
+
+```bash
+fx login --codex
+```
+
 Run fx from a project:
 
 ```bash
@@ -87,7 +93,7 @@ The WebAssembly SDK is experimental. See the [WebAssembly SDK](sdk/README.md) an
 
 ## Extend fx
 
-Add reusable instructions with [skills](https://fx.sh/docs/capabilities/skills), connect external tools through [MCP](https://fx.sh/docs/capabilities/mcp), or delegate independent work to [subagents](https://fx.sh/docs/capabilities/subagents). Project instruction files may link within their scope, and read-only workspace or compatibility skill directories may link within their owning workspace or home; managed skills, `SKILL.md` files, resources, and escaping links remain no-follow. `fx status` and `fx doctor` report an invalid trusted MCP profile without starting its servers.
+Add reusable instructions with [skills](https://fx.sh/docs/capabilities/skills), connect external tools through [MCP](https://fx.sh/docs/capabilities/mcp), or delegate independent work to [subagents](https://fx.sh/docs/capabilities/subagents). Zig distributions can also compile tools, native slash commands, and typed lifecycle hooks through the [native mod API](docs/native-mods.md). Project instruction files may link within their scope, and read-only workspace or compatibility skill directories may link within their owning workspace or home; managed skills, `SKILL.md` files, resources, and escaping links remain no-follow. `fx status` and `fx doctor` report an invalid trusted MCP profile without starting its servers.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Or add an AI Gateway API key:
 fx setup
 ```
 
+If you already signed in with Codex or Nanocodex, fx also uses the ChatGPT tokens in `~/.codex/auth.json` and talks to OpenAI Codex. Switch credentials from the hub if more than one source is available.
+
 Run fx from a project:
 
 ```bash

--- a/build.zig
+++ b/build.zig
@@ -66,6 +66,19 @@ pub fn build(b: *std.Build) void {
     });
     exe.root_module.addImport("build_options", build_options.createModule());
 
+    _ = b.addModule("fx_mod", .{
+        .root_source_file = b.path("src/mod_api.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+    _ = b.addModule("fx_default_distribution", .{
+        .root_source_file = b.path("src/default_distribution.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);

--- a/docs/native-mods.md
+++ b/docs/native-mods.md
@@ -1,0 +1,83 @@
+# Native Zig mods
+
+fx exposes a compile-time mod API as the `fx_mod` Zig module. Native mods are ordinary Zig packages linked into a custom fx distribution. They are type checked with the application and add no runtime interpreter or dynamic-library ABI.
+
+## Contract
+
+A mod is a namespace with a manifest and contribution:
+
+```zig
+const fx = @import("fx_mod");
+
+pub const manifest: fx.ModManifest = .{
+    .name = "acme.deploy",
+    .version = "1.0.0",
+    .description = "Deployment tools",
+    .capabilities = .{
+        .workspace_read = true,
+        .terminal = true,
+        .network = true,
+    },
+};
+
+pub const contribution: fx.ModContribution = .{
+    .tools = tools[0..],
+    .commands = commands[0..],
+    .hooks = .{
+        .post_turn_end = post_turn_end_hooks[0..],
+    },
+};
+```
+
+Tools use fx's existing `Tool` descriptor and therefore retain normal argument validation, permission admission, cancellation, result limits, and transcript behavior.
+
+Native slash commands use the open command contract:
+
+```zig
+fn deploy(context: fx.NativeCommandContext, payload: []const u8) !void {
+    _ = context;
+    _ = payload;
+}
+
+const commands = [_]fx.NativeCommand{.{
+    .name = "deploy",
+    .description = "Deploy the current workspace",
+    .handler = deploy,
+}};
+```
+
+The built-in slash router remains a closed typed enum. A custom distribution should try its `NativeCommandRegistry` before delegating to the built-in command router.
+
+## Composition
+
+Compose mods at compile time:
+
+```zig
+const fx = @import("fx_mod");
+const builtins = @import("fx_builtins");
+const deploy = @import("deploy_mod");
+
+const Distribution = fx.Catalog(.{ builtins, deploy });
+
+pub const tool_set = Distribution.tool_set;
+pub const command_registry = Distribution.command_registry;
+```
+
+`Catalog` validates the manifest contract and rejects duplicate tool or native-command names at compile time. It also aggregates the four current typed lifecycle hooks:
+
+- `pre_tool_use`
+- `stop`
+- `post_turn_end`
+- `attention_required`
+
+Call `Distribution.registerHooks(&runtime)` before freezing the lifecycle runtime.
+
+## State and ownership
+
+A stateful mod declares `State`, `init`, and `deinit` together. The distribution owns initialization order and must deinitialize in reverse order. Allocators remain explicit, and data crossing erased tool or hook boundaries follows the ownership rules in those existing contracts.
+
+Capability declarations document the ambient authority a compiled mod expects. They do not bypass fx's runtime permission system. Tool effects must continue to use the normal dispatch and capability paths.
+
+## Runtime-installed extensions
+
+Native mods deliberately require rebuilding the distribution. Runtime-installed portable extensions should use a separate byte-oriented WebAssembly ABI rather than Zig shared libraries. Zig does not promise a stable ABI for arbitrary Zig types across compiler versions and separately built dynamic libraries.

--- a/examples/native-mod/mod.zig
+++ b/examples/native-mod/mod.zig
@@ -1,0 +1,22 @@
+const fx = @import("fx_mod");
+
+fn hello(context: fx.NativeCommandContext, payload: []const u8) !void {
+    _ = context;
+    _ = payload;
+}
+
+const commands = [_]fx.NativeCommand{.{
+    .name = "hello",
+    .description = "Run a native fx mod command",
+    .handler = hello,
+}};
+
+pub const manifest: fx.ModManifest = .{
+    .name = "example.hello",
+    .version = "1.0.0",
+    .description = "Minimal native fx mod",
+};
+
+pub const contribution: fx.ModContribution = .{
+    .commands = commands[0..],
+};

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -3,6 +3,7 @@ const std_builtin = @import("builtin");
 const command_admission = @import("../core/permissions/command_admission.zig");
 const auth_runtime = @import("../core/auth/auth_runtime.zig");
 const credentials = @import("../core/auth/credentials.zig");
+const codex_protocol = @import("../core/gateway/codex_protocol.zig");
 const host = @import("../core/hosts/host.zig");
 const host_target = @import("../core/hosts/target.zig");
 const io_mod = @import("../core/shared/io.zig");
@@ -728,7 +729,7 @@ fn buildAgentConfig(state: *server.ServerState, session: *server.ActiveSessionSt
         .skills_prompt_section = sections.skills_prompt_section,
         .explicit_skills_prompt_section = sections.explicit_skills_prompt_section,
         .gateway_retry_count = state.cfg.gateway_retry_count,
-        .gateway_chat_url = state.cfg.gateway_chat_url,
+        .gateway_chat_url = codex_protocol.effectiveChatUrl(session.credential_source, state.cfg.gateway_chat_url),
         .gateway_tools_json = sections.gateway_tools_json,
         .custom_tool_guidance = sections.custom_tool_guidance,
         .agent_step_limit = session.agent_step_limit,

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -98,8 +98,11 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .logout,
         .token = "logout",
-        .usage = "logout",
-        .summary = "Sign out of the current Vercel session",
+        .usage = "logout [--codex]",
+        .summary = "Sign out of Vercel, or of ChatGPT Codex",
+        .options = &.{
+            .{ .flag = "--codex", .description = "Sign out of ChatGPT Codex and revoke its tokens" },
+        },
     },
     .{
         .kind = .setup,
@@ -290,7 +293,7 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
     } },
     .{ .entries = &.{
         .{ .kind = .login, .usage = "login [--codex]" },
-        .{ .kind = .logout, .usage = "logout" },
+        .{ .kind = .logout, .usage = "logout [--codex]" },
         .{ .kind = .setup, .usage = "setup" },
         .{ .kind = .teams, .usage = "teams" },
         .{ .kind = .credits, .usage = "credits|balance" },

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -89,8 +89,11 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .login,
         .token = "login",
-        .usage = "login",
-        .summary = "Sign in with Vercel",
+        .usage = "login [--codex]",
+        .summary = "Sign in with Vercel, or with ChatGPT Codex via a device code",
+        .options = &.{
+            .{ .flag = "--codex", .description = "Sign in with ChatGPT Codex using a device code" },
+        },
     },
     .{
         .kind = .logout,
@@ -286,7 +289,7 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
         .{ .kind = .replay, .usage = "replay <tape>" },
     } },
     .{ .entries = &.{
-        .{ .kind = .login, .usage = "login" },
+        .{ .kind = .login, .usage = "login [--codex]" },
         .{ .kind = .logout, .usage = "logout" },
         .{ .kind = .setup, .usage = "setup" },
         .{ .kind = .teams, .usage = "teams" },

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -17,6 +17,7 @@ const gateway_json = @import("../core/gateway/gateway_json.zig");
 const io_mod = @import("../core/shared/io.zig");
 const gateway_generation_usage = @import("../gateway/generation_usage.zig");
 const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const codex_protocol = @import("../core/gateway/codex_protocol.zig");
 const model_capabilities = @import("../core/config/model_capabilities.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
 const output_contracts = @import("../core/output/output_contracts.zig");
@@ -460,12 +461,13 @@ fn streamAgentCompletion(
         gateway_failure_diagnostics.FailureDiagnostics{}
     else
         gateway_failure_diagnostics.collect(alloc, request.payload, result.err_body);
+    const openai_codex = codex_protocol.isCodexChatUrl(request.chat_url);
     return .{
         .status = result.status,
         .completion = result.completion,
         .err_body = result.err_body,
         .generation_origin = gateway_client.generationBaseUrl(),
-        .reconcile_generation_usage = true,
+        .reconcile_generation_usage = !openai_codex,
         .failure_schema = diagnostics.schema,
         .failure_request_shape = diagnostics.request_shape,
         .retry_after_seconds = result.retry_after_seconds,
@@ -609,14 +611,15 @@ const OAuthHttpOperation = struct {
             .location = .{ .url = self.request.url },
             .method = switch (self.request.method) {
                 .get => .GET,
-                .post_form => .POST,
+                .post_form, .post_json => .POST,
             },
             .payload = self.request.payload,
             .headers = .{
-                .content_type = if (self.request.method == .post_form)
-                    .{ .override = "application/x-www-form-urlencoded" }
-                else
-                    .default,
+                .content_type = switch (self.request.method) {
+                    .post_form => .{ .override = "application/x-www-form-urlencoded" },
+                    .post_json => .{ .override = "application/json" },
+                    .get => .default,
+                },
                 .user_agent = .{ .override = gateway_client.user_agent },
                 .accept_encoding = .omit,
             },
@@ -2007,11 +2010,42 @@ fn parseSortedModelIds(alloc: std.mem.Allocator, json_text: []const u8) !std.Arr
 
 const ModelCatalogView = model_catalog.View;
 
+fn buildCodexCatalog(alloc: std.mem.Allocator) std.mem.Allocator.Error!std.ArrayList(ModelCatalogEntry) {
+    var catalog: std.ArrayList(ModelCatalogEntry) = .empty;
+    errdefer freeModelCatalog(alloc, &catalog);
+    try catalog.ensureTotalCapacity(alloc, codex_protocol.catalog_models.len);
+    for (codex_protocol.catalog_models) |model| {
+        const id = try alloc.dupe(u8, model.id);
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        catalog.appendAssumeCapacity(.{
+            .id = id,
+            .model_type = model_type,
+            .released = 90,
+            .has_tool_use = true,
+            .has_reasoning = true,
+            .supports_fast_mode = false,
+            .context_window = model.context_window,
+            .max_tokens = model.max_tokens,
+        });
+    }
+    return catalog;
+}
+
 fn fetchCatalogForProvider(
     _: ?*anyopaque,
     alloc: std.mem.Allocator,
     input: model_catalog.FetchInput,
 ) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    if (input.access.credentialSource() == .codex_oauth) {
+        const catalog = buildCodexCatalog(alloc) catch |err| return .{
+            .failure = .{
+                .category = if (err == error.OutOfMemory) .resource_exhausted else .runtime,
+            },
+        };
+        return .{ .catalog = catalog };
+    }
     const response = fetchModelCatalogResponse(
         alloc,
         input.access,
@@ -2053,6 +2087,9 @@ fn fetchModelCatalogForView(
     cancel_flag: ?*std.atomic.Value(bool),
     view: ModelCatalogView,
 ) !std.ArrayList(ModelCatalogEntry) {
+    if (access.credentialSource() == .codex_oauth) {
+        return buildCodexCatalog(alloc);
+    }
     const response = try fetchModelCatalogResponse(alloc, access, path, cancel_flag);
     const json_text = switch (response) {
         .success => |body| body,

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -634,6 +634,7 @@ const OAuthHttpOperation = struct {
         return .{
             .disposition = if (result.status == .ok) .accepted else .rejected,
             .body = try self.alloc.dupe(u8, body),
+            .status = result.status,
         };
     }
 };

--- a/src/builtins/mod.zig
+++ b/src/builtins/mod.zig
@@ -1,0 +1,22 @@
+const builtin_tools = @import("tools.zig");
+const mod_api = @import("../mod_api.zig");
+
+pub const manifest: mod_api.ModManifest = .{
+    .name = "fx.builtins",
+    .version = "1.0.0",
+    .description = "First-party fx capabilities",
+    .capabilities = .{
+        .workspace_read = true,
+        .workspace_write = true,
+        .terminal = true,
+        .network = true,
+        .secrets = true,
+        .clipboard = true,
+    },
+};
+
+pub const contribution: mod_api.ModContribution = .{
+    .tools = builtin_tools.all[0..],
+    .advertised_tool_names = builtin_tools.advertisement_order[0..],
+    .read_only_tool_names = builtin_tools.read_only_tool_names[0..],
+};

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1401,7 +1401,7 @@ fn refreshGatewayCredentialForJob(
     trace_ctx: TraceContext,
 ) !bool {
     const source = job.credential_source orelse return false;
-    if (source != .fx_login) return false;
+    if (source != .fx_login and source != .codex_oauth) return false;
     const refresh = deps.refresh_gateway_credential orelse return false;
 
     const refreshed = refresh(deps.ctx, alloc, source, mode) catch |err| {

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -36,6 +36,7 @@ const tool_dispatch = @import("../tooling/tool_dispatch.zig");
 const tool_mcp_runtime = @import("../tooling/tool_mcp_runtime.zig");
 const context_contract = @import("../workspace/context_contract.zig");
 const model_catalog = @import("../gateway/model_catalog.zig");
+const codex_protocol = @import("../gateway/codex_protocol.zig");
 const test_builtin_gateway = if (@import("builtin").is_test)
     @import("../../builtins/gateway.zig")
 else
@@ -1093,7 +1094,7 @@ pub fn Runtime(comptime App: type) type {
                     &app.worker.worker_recovery_pause_requested
                 else
                     null,
-                .gateway_chat_url = gateway_chat_url,
+                .gateway_chat_url = codex_protocol.effectiveChatUrl(job.credential_source, gateway_chat_url),
                 .gateway_tools_json = tool_projection.tools_json,
                 .custom_tool_guidance = tool_projection.custom_guidance,
                 .agent_step_limit = app.agent_step_limit,

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -18,6 +18,7 @@ const sandbox = @import("../permissions/sandbox.zig");
 const skill_contract = @import("../skills/skill_contract.zig");
 const skill_runtime = @import("../skills/skill_runtime.zig");
 const types = @import("../shared/types.zig");
+const codex_protocol = @import("../gateway/codex_protocol.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
 const auto_upgrade = @import("../upgrade/auto_upgrade.zig");
 const update_target = @import("../upgrade/update_target.zig");
@@ -253,7 +254,8 @@ pub fn Runtime(comptime App: type) type {
 
             const selected_model = startup.takeSelectedModel();
             defer if (selected_model.len > 0) app.alloc.free(selected_model);
-            try app.selected_model.appendSlice(app.alloc, selected_model);
+            const session_model = codex_protocol.resolvedModel(app.auth.credentialSource(), selected_model);
+            try app.selected_model.appendSlice(app.alloc, session_model);
             try deps.configure_session_preferences(
                 app,
                 startup.configured_model,

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -22,6 +22,7 @@ const credential_source_order = [_]credentials.Source{
     .vercel_oidc_token,
     .ai_gateway_api_key,
     .fx_login,
+    .codex_oauth,
     .stored_key,
 };
 
@@ -103,11 +104,16 @@ pub fn refreshFxLoginToken(
     source: credentials.Source,
     mode: CredentialRefreshMode,
 ) !?[]u8 {
-    if (source != .fx_login) return null;
-
-    var credential = switch (mode) {
-        .if_needed => (try credentials.loadFxLoginCredential(alloc, transport)) orelse return null,
-        .force => (try credentials.refreshFxLoginCredential(alloc, transport)) orelse return null,
+    var credential = switch (source) {
+        .fx_login => switch (mode) {
+            .if_needed => (try credentials.loadFxLoginCredential(alloc, transport)) orelse return null,
+            .force => (try credentials.refreshFxLoginCredential(alloc, transport)) orelse return null,
+        },
+        .codex_oauth => switch (mode) {
+            .if_needed => (try credentials.loadCodexCredential(alloc, transport)) orelse return null,
+            .force => (try credentials.refreshCodexCredential(alloc, transport)) orelse return null,
+        },
+        else => return null,
     };
     defer credential.deinit(alloc);
 
@@ -1122,9 +1128,14 @@ pub const Runtime = struct {
 
     pub fn refreshFxLoginIfNeeded(self: *Self, alloc: Allocator) !bool {
         const source = self.credentialSource() orelse return false;
-        if (source != .fx_login) return false;
+        if (!credentials.sourceRefreshable(source)) return false;
 
-        const loaded = (try credentials.loadFxLoginCredential(alloc, self.oauth_transport)) orelse {
+        const loaded = (try credentials.loadSource(
+            alloc,
+            self.oauth_transport,
+            self.secret_store,
+            source,
+        )) orelse {
             if (self.credentialNeedsRefresh()) return error.CredentialRefreshUnavailable;
             return false;
         };
@@ -1451,6 +1462,7 @@ test "auth failure snapshot names every selected source without exposing styling
         .vercel_oidc_token,
         .ai_gateway_api_key,
         .fx_login,
+        .codex_oauth,
         .stored_key,
     };
     for (sources) |source| {
@@ -1626,6 +1638,7 @@ test "auth status snapshot labels every credential source without exposing token
         .vercel_oidc_token,
         .ai_gateway_api_key,
         .fx_login,
+        .codex_oauth,
         .stored_key,
     };
 

--- a/src/core/auth/codex_login.zig
+++ b/src/core/auth/codex_login.zig
@@ -277,6 +277,22 @@ pub fn runLogin(
     try writeStdout("Signed in to ChatGPT Codex.\n");
 }
 
+pub fn runLogout(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+) !codex_oauth.LogoutResult {
+    var remote_revocation_failed = false;
+    if (try codex_oauth.loadStoredRefreshToken(alloc)) |refresh_token| {
+        defer secret.zeroAndFree(alloc, refresh_token);
+        codex_oauth.revokeRefreshToken(alloc, transport, refresh_token) catch {
+            remote_revocation_failed = true;
+        };
+    }
+    var result = try codex_oauth.clearStoredTokens(alloc);
+    result.remote_revocation_failed = remote_revocation_failed;
+    return result;
+}
+
 fn isPendingStatus(status: ?std.http.Status) bool {
     return status == .forbidden or status == .not_found;
 }

--- a/src/core/auth/codex_login.zig
+++ b/src/core/auth/codex_login.zig
@@ -1,0 +1,625 @@
+const std = @import("std");
+const codex_oauth = @import("codex_oauth.zig");
+const host = @import("../hosts/host.zig");
+const io_mod = @import("../shared/io.zig");
+const oauth_transport = @import("oauth_transport.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const login_timeout_ns: u64 = 15 * std.time.ns_per_min;
+const poll_slice_ms: u64 = 100;
+
+pub const Error = error{
+    DeviceCodeUnavailable,
+    InvalidDeviceCodeResponse,
+    InvalidAuthorizationGrant,
+    InvalidTokenExchange,
+    LoginTimedOut,
+    AccessDenied,
+    HomeNotSet,
+};
+
+pub const DeviceCode = struct {
+    verification_url: []u8,
+    user_code: []u8,
+    device_auth_id: []u8,
+    interval_ns: u64,
+
+    pub fn deinit(self: *DeviceCode, alloc: Allocator) void {
+        alloc.free(self.verification_url);
+        alloc.free(self.user_code);
+        secret.zeroAndFree(alloc, self.device_auth_id);
+        self.* = undefined;
+    }
+};
+
+pub const AuthorizationGrant = struct {
+    authorization_code: []u8,
+    code_verifier: []u8,
+    code_challenge: []u8,
+
+    pub fn deinit(self: *AuthorizationGrant, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.authorization_code);
+        secret.zeroAndFree(alloc, self.code_verifier);
+        alloc.free(self.code_challenge);
+        self.* = undefined;
+    }
+};
+
+pub const PollResult = union(enum) {
+    pending,
+    success: AuthorizationGrant,
+};
+
+pub fn requestDeviceCode(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+) !DeviceCode {
+    const client_id = codex_oauth.oauth_client_id;
+    const url = try std.fmt.allocPrint(alloc, "{s}/api/accounts/deviceauth/usercode", .{codex_oauth.issuer()});
+    defer alloc.free(url);
+
+    var payload: std.Io.Writer.Allocating = .init(alloc);
+    defer payload.deinit();
+    try payload.writer.writeAll("{\"client_id\":");
+    try std.json.Stringify.value(client_id, .{}, &payload.writer);
+    try payload.writer.writeByte('}');
+
+    var response = try transport.execute(alloc, .{
+        .method = .post_json,
+        .url = url,
+        .payload = payload.written(),
+    });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) {
+        if (response.status == .not_found) return Error.DeviceCodeUnavailable;
+        return Error.InvalidDeviceCodeResponse;
+    }
+    return parseDeviceCode(alloc, response.body);
+}
+
+pub fn parseDeviceCode(alloc: Allocator, bytes: []const u8) !DeviceCode {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return Error.InvalidDeviceCodeResponse,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return Error.InvalidDeviceCodeResponse;
+    const object = parsed.value.object;
+    const device_auth_id = objectString(object, "device_auth_id") orelse
+        return Error.InvalidDeviceCodeResponse;
+    const user_code = objectString(object, "user_code") orelse
+        objectString(object, "usercode") orelse
+        return Error.InvalidDeviceCodeResponse;
+    if (device_auth_id.len == 0 or user_code.len == 0) return Error.InvalidDeviceCodeResponse;
+    const interval_s = objectIntervalSeconds(object);
+
+    const verification_url = try std.fmt.allocPrint(alloc, "{s}/codex/device", .{codex_oauth.issuer()});
+    errdefer alloc.free(verification_url);
+    return .{
+        .verification_url = verification_url,
+        .user_code = try alloc.dupe(u8, user_code),
+        .device_auth_id = try alloc.dupe(u8, device_auth_id),
+        .interval_ns = interval_s * std.time.ns_per_s,
+    };
+}
+
+pub fn pollAuthorizationGrant(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    device: DeviceCode,
+    cancel_flag: ?*std.atomic.Value(bool),
+) !PollResult {
+    const url = try std.fmt.allocPrint(alloc, "{s}/api/accounts/deviceauth/token", .{codex_oauth.issuer()});
+    defer alloc.free(url);
+
+    var payload: std.Io.Writer.Allocating = .init(alloc);
+    defer payload.deinit();
+    try payload.writer.writeAll("{\"device_auth_id\":");
+    try std.json.Stringify.value(device.device_auth_id, .{}, &payload.writer);
+    try payload.writer.writeAll(",\"user_code\":");
+    try std.json.Stringify.value(device.user_code, .{}, &payload.writer);
+    try payload.writer.writeByte('}');
+
+    var response = try transport.execute(alloc, .{
+        .method = .post_json,
+        .url = url,
+        .payload = payload.written(),
+        .cancel_flag = cancel_flag,
+    });
+    defer response.deinit(alloc);
+    if (response.disposition == .accepted) {
+        return .{ .success = try parseAuthorizationGrant(alloc, response.body) };
+    }
+    if (isPendingStatus(response.status)) return .pending;
+    if (response.status == .unauthorized) return Error.AccessDenied;
+    return Error.InvalidAuthorizationGrant;
+}
+
+pub fn parseAuthorizationGrant(alloc: Allocator, bytes: []const u8) !AuthorizationGrant {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return Error.InvalidAuthorizationGrant,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return Error.InvalidAuthorizationGrant;
+    const object = parsed.value.object;
+    const authorization_code = objectString(object, "authorization_code") orelse
+        return Error.InvalidAuthorizationGrant;
+    const code_verifier = objectString(object, "code_verifier") orelse
+        return Error.InvalidAuthorizationGrant;
+    const code_challenge = objectString(object, "code_challenge") orelse "";
+    if (authorization_code.len == 0 or code_verifier.len == 0) return Error.InvalidAuthorizationGrant;
+    return .{
+        .authorization_code = try alloc.dupe(u8, authorization_code),
+        .code_verifier = try alloc.dupe(u8, code_verifier),
+        .code_challenge = try alloc.dupe(u8, code_challenge),
+    };
+}
+
+pub fn exchangeAuthorizationGrant(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    grant: AuthorizationGrant,
+) !codex_oauth.StoredTokens {
+    const redirect_uri = try std.fmt.allocPrint(
+        alloc,
+        "{s}/deviceauth/callback",
+        .{codex_oauth.issuer()},
+    );
+    defer alloc.free(redirect_uri);
+
+    var form: FormBody = .{};
+    var writer: std.Io.Writer.Allocating = .init(alloc);
+    defer writer.deinit();
+    try form.append(&writer.writer, "grant_type", "authorization_code");
+    try form.append(&writer.writer, "code", grant.authorization_code);
+    try form.append(&writer.writer, "redirect_uri", redirect_uri);
+    try form.append(&writer.writer, "client_id", codex_oauth.oauth_client_id);
+    try form.append(&writer.writer, "code_verifier", grant.code_verifier);
+
+    var response = try transport.execute(alloc, .{
+        .method = .post_form,
+        .url = codex_oauth.tokenUrl(),
+        .payload = writer.written(),
+    });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) return Error.InvalidTokenExchange;
+    return parseExchangedTokens(alloc, response.body);
+}
+
+pub fn parseExchangedTokens(alloc: Allocator, bytes: []const u8) !codex_oauth.StoredTokens {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return Error.InvalidTokenExchange,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return Error.InvalidTokenExchange;
+    const object = parsed.value.object;
+    const id_token = objectString(object, "id_token") orelse return Error.InvalidTokenExchange;
+    const access_token = objectString(object, "access_token") orelse return Error.InvalidTokenExchange;
+    const refresh_token = objectString(object, "refresh_token") orelse return Error.InvalidTokenExchange;
+    if (id_token.len == 0 or access_token.len == 0 or refresh_token.len == 0) {
+        return Error.InvalidTokenExchange;
+    }
+
+    var account_buf: [256]u8 = undefined;
+    const account_id = objectString(object, "account_id") orelse
+        codex_oauth.copyAccountId(id_token, &account_buf) orelse
+        return Error.InvalidTokenExchange;
+
+    return .{
+        .id_token = try alloc.dupe(u8, id_token),
+        .access_token = try alloc.dupe(u8, access_token),
+        .refresh_token = try alloc.dupe(u8, refresh_token),
+        .account_id = try alloc.dupe(u8, account_id),
+    };
+}
+
+pub fn completeLogin(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    device: DeviceCode,
+    cancel_flag: ?*std.atomic.Value(bool),
+) !void {
+    const started = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+    const deadline_ns = started.raw.nanoseconds + login_timeout_ns;
+    while (true) {
+        if (cancel_flag) |flag| {
+            if (flag.load(.seq_cst)) return error.Cancelled;
+        }
+        const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+        if (now.raw.nanoseconds >= deadline_ns) return Error.LoginTimedOut;
+
+        switch (try pollAuthorizationGrant(alloc, transport, device, cancel_flag)) {
+            .pending => {},
+            .success => |grant_value| {
+                var grant = grant_value;
+                defer grant.deinit(alloc);
+                const tokens = try exchangeAuthorizationGrant(alloc, transport, grant);
+                defer {
+                    secret.zeroAndFree(alloc, @constCast(tokens.id_token));
+                    secret.zeroAndFree(alloc, @constCast(tokens.access_token));
+                    secret.zeroAndFree(alloc, @constCast(tokens.refresh_token));
+                    alloc.free(tokens.account_id);
+                }
+                try codex_oauth.persistTokens(alloc, tokens);
+                return;
+            },
+        }
+
+        const now_ns = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake).raw.nanoseconds;
+        if (now_ns >= deadline_ns) return Error.LoginTimedOut;
+        const remaining_ns: u64 = @intCast(deadline_ns - now_ns);
+        const wait_ns: u64 = if (device.interval_ns == 0) 0 else @min(device.interval_ns, remaining_ns);
+        try sleepCancellable(wait_ns, cancel_flag);
+    }
+}
+
+pub fn runLogin(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    url_opener: host.UrlOpener,
+) !void {
+    var device = try requestDeviceCode(alloc, transport);
+    defer device.deinit(alloc);
+
+    try writeStdout("Open ");
+    try writeStdout(device.verification_url);
+    try writeStdout("\nCode: ");
+    try writeStdout(device.user_code);
+    try writeStdout("\n\nThe code expires in 15 minutes. Continue only if you started this login in fx.\n\n");
+
+    _ = url_opener.open(alloc, device.verification_url) catch false;
+    try writeStdout("Waiting for authorization...\n");
+    try completeLogin(alloc, transport, device, null);
+    try writeStdout("Signed in to ChatGPT Codex.\n");
+}
+
+fn isPendingStatus(status: ?std.http.Status) bool {
+    return status == .forbidden or status == .not_found;
+}
+
+fn objectString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    return switch (value) {
+        .string => |text| if (text.len == 0) null else text,
+        else => null,
+    };
+}
+
+fn objectIntervalSeconds(object: std.json.ObjectMap) u64 {
+    const value = object.get("interval") orelse return 5;
+    return switch (value) {
+        .integer => |integer| if (integer < 0) 0 else @intCast(integer),
+        .string => |text| std.fmt.parseInt(u64, std.mem.trim(u8, text, " \t"), 10) catch 5,
+        else => 5,
+    };
+}
+
+const FormBody = struct {
+    first: bool = true,
+
+    fn append(self: *FormBody, writer: *std.Io.Writer, key: []const u8, value: []const u8) !void {
+        if (!self.first) try writer.writeAll("&");
+        self.first = false;
+        try percentEncode(writer, key);
+        try writer.writeAll("=");
+        try percentEncode(writer, value);
+    }
+};
+
+fn percentEncode(writer: *std.Io.Writer, value: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (value) |byte| {
+        const safe = std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_' or byte == '.' or byte == '~';
+        if (safe) {
+            try writer.writeByte(byte);
+        } else {
+            try writer.writeByte('%');
+            try writer.writeByte(hex[byte >> 4]);
+            try writer.writeByte(hex[byte & 0x0f]);
+        }
+    }
+}
+
+fn sleepCancellable(wait_ns: u64, cancel_flag: ?*std.atomic.Value(bool)) !void {
+    if (wait_ns == 0) return;
+    var remaining = wait_ns;
+    const slice_ns = poll_slice_ms * std.time.ns_per_ms;
+    while (remaining > 0) {
+        if (cancel_flag) |flag| {
+            if (flag.load(.seq_cst)) return error.Cancelled;
+        }
+        const slice = @min(remaining, slice_ns);
+        io_mod.sleep(slice);
+        remaining -= slice;
+    }
+}
+
+fn writeStdout(text: []const u8) !void {
+    try std.Io.File.stdout().writeStreamingAll(io_mod.getIo(), text);
+}
+
+const ScriptedTransport = struct {
+    responses: []const ScriptedResponse,
+    index: usize = 0,
+    last_url: []const u8 = "",
+    last_payload: []const u8 = "",
+    last_method: ?oauth_transport.Method = null,
+
+    const ScriptedResponse = struct {
+        disposition: oauth_transport.Disposition,
+        status: std.http.Status,
+        body: []const u8,
+    };
+
+    fn execute(raw: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        self.last_url = request.url;
+        self.last_payload = request.payload orelse "";
+        self.last_method = request.method;
+        if (self.index >= self.responses.len) return error.UnexpectedOAuthRequest;
+        const next = self.responses[self.index];
+        self.index += 1;
+        return .{
+            .disposition = next.disposition,
+            .status = next.status,
+            .body = try alloc.dupe(u8, next.body),
+        };
+    }
+
+    fn provider(self: *@This()) oauth_transport.Provider {
+        return .{
+            .context = self,
+            .execute_fn = execute,
+        };
+    }
+};
+
+test "parseDeviceCode accepts string intervals and usercode aliases" {
+    const alloc = std.testing.allocator;
+    var device = try parseDeviceCode(
+        alloc,
+        "{\"device_auth_id\":\"auth-1\",\"usercode\":\"ABCD-1234\",\"interval\":\"2\"}",
+    );
+    defer device.deinit(alloc);
+    try std.testing.expectEqualStrings("auth-1", device.device_auth_id);
+    try std.testing.expectEqualStrings("ABCD-1234", device.user_code);
+    try std.testing.expectEqual(@as(u64, 2 * std.time.ns_per_s), device.interval_ns);
+    try std.testing.expect(std.mem.endsWith(u8, device.verification_url, "/codex/device"));
+}
+
+test "device-code poll treats 403 as pending then exchanges the grant" {
+    const alloc = std.testing.allocator;
+    var pending = ScriptedTransport{
+        .responses = &.{
+            .{ .disposition = .rejected, .status = .forbidden, .body = "pending" },
+        },
+    };
+    var device = try parseDeviceCode(
+        alloc,
+        "{\"device_auth_id\":\"auth-1\",\"user_code\":\"CODE\",\"interval\":0}",
+    );
+    defer device.deinit(alloc);
+    try std.testing.expectEqual(
+        std.meta.Tag(PollResult).pending,
+        std.meta.activeTag(try pollAuthorizationGrant(
+            alloc,
+            pending.provider(),
+            device,
+            null,
+        )),
+    );
+
+    var ready = ScriptedTransport{
+        .responses = &.{
+            .{
+                .disposition = .accepted,
+                .status = .ok,
+                .body = "{\"authorization_code\":\"abc\",\"code_verifier\":\"verifier\",\"code_challenge\":\"challenge\"}",
+            },
+        },
+    };
+    var grant = switch (try pollAuthorizationGrant(alloc, ready.provider(), device, null)) {
+        .pending => return error.TestExpectedGrant,
+        .success => |value| value,
+    };
+    defer grant.deinit(alloc);
+    try std.testing.expectEqualStrings("abc", grant.authorization_code);
+    try std.testing.expectEqualStrings("verifier", grant.code_verifier);
+}
+
+test "parseExchangedTokens extracts account id from a realistic ChatGPT JWT" {
+    const alloc = std.testing.allocator;
+    const jwt = try encodePaddedJwt(alloc, "acct_login_real", 900);
+    defer alloc.free(jwt);
+    const token_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"id_token\":\"{s}\",\"access_token\":\"{s}\",\"refresh_token\":\"refresh-login\"}}",
+        .{ jwt, jwt },
+    );
+    defer alloc.free(token_json);
+
+    const tokens = try parseExchangedTokens(alloc, token_json);
+    defer {
+        secret.zeroAndFree(alloc, @constCast(tokens.id_token));
+        secret.zeroAndFree(alloc, @constCast(tokens.access_token));
+        secret.zeroAndFree(alloc, @constCast(tokens.refresh_token));
+        alloc.free(tokens.account_id);
+    }
+    try std.testing.expectEqualStrings("acct_login_real", tokens.account_id);
+}
+
+test "token exchange posts the Codex device-callback form and persists ChatGPT tokens" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const auth_path = try std.fs.path.join(alloc, &.{ root, "auth.json" });
+    defer alloc.free(auth_path);
+
+    const encoder = std.base64.url_safe_no_pad.Encoder;
+    const payload = "{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_login\"}}";
+    const encoded_len = encoder.calcSize(payload.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = encoder.encode(encoded, payload);
+    const jwt = try std.fmt.allocPrint(alloc, "e30.{s}.sig", .{encoded});
+    defer alloc.free(jwt);
+    const token_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"id_token\":\"{s}\",\"access_token\":\"{s}\",\"refresh_token\":\"refresh-login\"}}",
+        .{ jwt, jwt },
+    );
+    defer alloc.free(token_json);
+
+    var env = try TestEnv.install(alloc, &.{
+        .{ codex_oauth.auth_file_env, auth_path },
+        .{ codex_oauth.issuer_env, "https://auth.openai.com" },
+    });
+    defer env.deinit();
+
+    var grant = AuthorizationGrant{
+        .authorization_code = try alloc.dupe(u8, "abc"),
+        .code_verifier = try alloc.dupe(u8, "verifier"),
+        .code_challenge = try alloc.dupe(u8, "challenge"),
+    };
+    defer grant.deinit(alloc);
+
+    var transport = ScriptedTransport{
+        .responses = &.{
+            .{ .disposition = .accepted, .status = .ok, .body = token_json },
+        },
+    };
+    const tokens = try exchangeAuthorizationGrant(alloc, transport.provider(), grant);
+    defer {
+        secret.zeroAndFree(alloc, @constCast(tokens.id_token));
+        secret.zeroAndFree(alloc, @constCast(tokens.access_token));
+        secret.zeroAndFree(alloc, @constCast(tokens.refresh_token));
+        alloc.free(tokens.account_id);
+    }
+    try std.testing.expectEqualStrings("acct_login", tokens.account_id);
+    try std.testing.expect(transport.last_method == .post_form);
+    try std.testing.expect(std.mem.find(u8, transport.last_payload, "grant_type=authorization_code") != null);
+    try std.testing.expect(std.mem.find(u8, transport.last_payload, "redirect_uri=https%3A%2F%2Fauth.openai.com%2Fdeviceauth%2Fcallback") != null);
+
+    try codex_oauth.persistTokens(alloc, tokens);
+    var loaded = (try codex_oauth.loadStored(alloc)).?;
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqualStrings("acct_login", loaded.account_id.?);
+    try std.testing.expectEqualStrings(jwt, loaded.access_token);
+}
+
+test "completeLogin walks pending poll then token exchange" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const auth_path = try std.fs.path.join(alloc, &.{ root, "auth.json" });
+    defer alloc.free(auth_path);
+
+    const encoder = std.base64.url_safe_no_pad.Encoder;
+    const payload = "{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_done\"}}";
+    const encoded_len = encoder.calcSize(payload.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = encoder.encode(encoded, payload);
+    const jwt = try std.fmt.allocPrint(alloc, "e30.{s}.sig", .{encoded});
+    defer alloc.free(jwt);
+    const token_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"id_token\":\"{s}\",\"access_token\":\"{s}\",\"refresh_token\":\"refresh-done\"}}",
+        .{ jwt, jwt },
+    );
+    defer alloc.free(token_json);
+
+    var env = try TestEnv.install(alloc, &.{
+        .{ codex_oauth.auth_file_env, auth_path },
+    });
+    defer env.deinit();
+
+    var device = try parseDeviceCode(
+        alloc,
+        "{\"device_auth_id\":\"auth-1\",\"user_code\":\"CODE\",\"interval\":0}",
+    );
+    defer device.deinit(alloc);
+
+    var transport = ScriptedTransport{
+        .responses = &.{
+            .{ .disposition = .rejected, .status = .forbidden, .body = "wait" },
+            .{
+                .disposition = .accepted,
+                .status = .ok,
+                .body = "{\"authorization_code\":\"abc\",\"code_verifier\":\"verifier\",\"code_challenge\":\"challenge\"}",
+            },
+            .{ .disposition = .accepted, .status = .ok, .body = token_json },
+        },
+    };
+    try completeLogin(alloc, transport.provider(), device, null);
+    try std.testing.expectEqual(@as(usize, 3), transport.index);
+    var loaded = (try codex_oauth.loadStored(alloc)).?;
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqualStrings("acct_done", loaded.account_id.?);
+}
+
+var stable_login_test_environ: ?*std.process.Environ.Map = null;
+
+fn stableLoginTestEnviron() !*const std.process.Environ.Map {
+    if (stable_login_test_environ) |map| return map;
+    const alloc = std.heap.page_allocator;
+    const map = try alloc.create(std.process.Environ.Map);
+    map.* = std.process.Environ.Map.init(alloc);
+    stable_login_test_environ = map;
+    return map;
+}
+
+fn encodeJwt(alloc: Allocator, payload: []const u8) ![]u8 {
+    const encoder = std.base64.url_safe_no_pad.Encoder;
+    const encoded_len = encoder.calcSize(payload.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = encoder.encode(encoded, payload);
+    return std.fmt.allocPrint(alloc, "e30.{s}.sig", .{encoded});
+}
+
+fn encodePaddedJwt(alloc: Allocator, account_id: []const u8, pad_len: usize) ![]u8 {
+    var payload: std.Io.Writer.Allocating = .init(alloc);
+    defer payload.deinit();
+    try payload.writer.writeAll("{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":");
+    try std.json.Stringify.value(account_id, .{}, &payload.writer);
+    try payload.writer.writeAll("},\"pad\":\"");
+    var index: usize = 0;
+    while (index < pad_len) : (index += 1) try payload.writer.writeByte('x');
+    try payload.writer.writeAll("\"}");
+    return encodeJwt(alloc, payload.written());
+}
+
+const TestEnv = struct {
+    alloc: Allocator,
+    map: std.process.Environ.Map,
+
+    fn install(alloc: Allocator, entries: []const [2][]const u8) !*TestEnv {
+        _ = try stableLoginTestEnviron();
+        const self = try alloc.create(TestEnv);
+        errdefer alloc.destroy(self);
+        self.* = .{
+            .alloc = alloc,
+            .map = std.process.Environ.Map.init(alloc),
+        };
+        errdefer self.map.deinit();
+        for (entries) |entry| try self.map.put(entry[0], entry[1]);
+        io_mod.setEnvironMap(&self.map);
+        return self;
+    }
+
+    fn deinit(self: *TestEnv) void {
+        if (stable_login_test_environ) |map| io_mod.setEnvironMap(map);
+        self.map.deinit();
+        const alloc = self.alloc;
+        alloc.destroy(self);
+    }
+};

--- a/src/core/auth/codex_oauth.zig
+++ b/src/core/auth/codex_oauth.zig
@@ -1,0 +1,625 @@
+const std = @import("std");
+const debug_trace = @import("../shared/debug_trace.zig");
+const host_target = @import("../hosts/target.zig");
+const io_mod = @import("../shared/io.zig");
+const oauth_transport = @import("oauth_transport.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const auth_file_env = "FX_CODEX_AUTH_FILE";
+pub const token_url_env = "FX_CODEX_TOKEN_URL";
+pub const oauth_client_id = "app_EMoamEEZ73f0CkXaXp7hrann";
+pub const default_token_url = "https://auth.openai.com/oauth/token";
+pub const refresh_early_seconds: i64 = 5 * 60;
+const max_auth_file_bytes: usize = 256 * 1024;
+const personal_access_token_prefix = "at-";
+const jwt_payload_max_bytes: usize = 8 * 1024;
+
+pub const Loaded = struct {
+    access_token: []u8,
+    account_id: ?[]u8 = null,
+    refresh_after_ms: ?i64 = null,
+    refreshable: bool = true,
+
+    pub fn deinit(self: *Loaded, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.access_token);
+        if (self.account_id) |account_id| alloc.free(account_id);
+        self.* = undefined;
+    }
+};
+
+pub const StoredTokens = struct {
+    id_token: []const u8,
+    access_token: []const u8,
+    refresh_token: []const u8,
+    account_id: []const u8,
+};
+
+pub fn sourceExists(alloc: Allocator) !bool {
+    if (comptime host_target.is_wasm) return false;
+    var loaded = (try loadStored(alloc)) orelse return false;
+    loaded.deinit(alloc);
+    return true;
+}
+
+pub fn loadStored(alloc: Allocator) !?Loaded {
+    if (comptime host_target.is_wasm) return null;
+    const path = (try resolveAuthFilePath(alloc)) orelse return null;
+    defer alloc.free(path);
+    return loadFromPath(alloc, path);
+}
+
+pub fn load(alloc: Allocator, transport: oauth_transport.Provider) !?Loaded {
+    if (comptime host_target.is_wasm) return null;
+    const path = (try resolveAuthFilePath(alloc)) orelse return null;
+    defer alloc.free(path);
+    var loaded = (try loadFromPath(alloc, path)) orelse return null;
+    errdefer loaded.deinit(alloc);
+    if (!loaded.refreshable) return loaded;
+    if (!needsRefresh(loaded.refresh_after_ms, io_mod.milliTimestamp())) return loaded;
+    loaded.deinit(alloc);
+    return refreshAtPath(alloc, transport, path);
+}
+
+pub fn refresh(alloc: Allocator, transport: oauth_transport.Provider) !?Loaded {
+    if (comptime host_target.is_wasm) return null;
+    const path = (try resolveAuthFilePath(alloc)) orelse return null;
+    defer alloc.free(path);
+    return refreshAtPath(alloc, transport, path);
+}
+
+pub fn resolveAuthFilePath(alloc: Allocator) !?[]u8 {
+    if (nonEmptyEnv(auth_file_env)) |path| return try alloc.dupe(u8, path);
+    if (nonEmptyEnv("CODEX_HOME")) |home| {
+        return try std.fs.path.join(alloc, &.{ home, "auth.json" });
+    }
+    const home = nonEmptyEnv("HOME") orelse nonEmptyEnv("USERPROFILE") orelse return null;
+    return try std.fs.path.join(alloc, &.{ home, ".codex", "auth.json" });
+}
+
+pub fn tokenUrl() []const u8 {
+    return nonEmptyEnv(token_url_env) orelse default_token_url;
+}
+
+pub fn parseLoaded(alloc: Allocator, bytes: []const u8) !?Loaded {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidCodexAuthFile,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidCodexAuthFile;
+    return loadedFromDocument(alloc, parsed.value.object);
+}
+
+pub fn applyRefreshResponse(current: StoredTokens, response: std.json.ObjectMap) !StoredTokens {
+    const access = objectString(response, "access_token") orelse current.access_token;
+    const refresh_token = objectString(response, "refresh_token") orelse current.refresh_token;
+    const id_token = objectString(response, "id_token") orelse current.id_token;
+    if (access.len == 0 or refresh_token.len == 0) return error.InvalidCodexRefreshResponse;
+
+    var jwt_buf: [jwt_payload_max_bytes]u8 = undefined;
+    if (jwtAccountId(id_token, &jwt_buf)) |next_account| {
+        if (next_account.len > 0 and current.account_id.len > 0 and
+            !std.mem.eql(u8, current.account_id, next_account))
+        {
+            return error.CodexAccountChanged;
+        }
+    }
+
+    return .{
+        .id_token = id_token,
+        .access_token = access,
+        .refresh_token = refresh_token,
+        .account_id = current.account_id,
+    };
+}
+
+pub fn jwtExpirationUnix(jwt: []const u8) ?i64 {
+    var buf: [jwt_payload_max_bytes]u8 = undefined;
+    const payload = decodeJwtPayload(jwt, &buf) orelse return null;
+    var parsed = std.json.parseFromSlice(std.json.Value, std.heap.page_allocator, payload, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const exp = parsed.value.object.get("exp") orelse return null;
+    return switch (exp) {
+        .integer => |value| value,
+        else => null,
+    };
+}
+
+fn loadFromPath(alloc: Allocator, path: []const u8) !?Loaded {
+    const bytes = readAuthFile(alloc, path) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        error.OutOfMemory => return error.OutOfMemory,
+        else => {
+            debug_trace.logf("auth", "codex auth load failed step=read err={s}", .{@errorName(err)});
+            return null;
+        },
+    };
+    defer secret.zeroAndFree(alloc, bytes);
+
+    return parseLoaded(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => {
+            debug_trace.logf("auth", "codex auth load failed step=parse err={s}", .{@errorName(err)});
+            return null;
+        },
+    };
+}
+
+fn refreshAtPath(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    path: []const u8,
+) !?Loaded {
+    const bytes = readAuthFile(alloc, path) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer secret.zeroAndFree(alloc, bytes);
+
+    var document = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidCodexAuthFile,
+    };
+    defer document.deinit();
+    if (document.value != .object) return error.InvalidCodexAuthFile;
+
+    const current = storedTokensFromDocument(document.value.object) orelse return error.InvalidCodexAuthFile;
+    if (current.refresh_token.len == 0) return error.CodexRefreshUnavailable;
+
+    var request_body: std.Io.Writer.Allocating = .init(alloc);
+    defer request_body.deinit();
+    try request_body.writer.writeAll("{\"client_id\":");
+    try std.json.Stringify.value(oauth_client_id, .{}, &request_body.writer);
+    try request_body.writer.writeAll(",\"grant_type\":\"refresh_token\",\"refresh_token\":");
+    try std.json.Stringify.value(current.refresh_token, .{}, &request_body.writer);
+    try request_body.writer.writeByte('}');
+
+    var response = try transport.execute(alloc, .{
+        .method = .post_json,
+        .url = tokenUrl(),
+        .payload = request_body.written(),
+    });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) return error.CodexRefreshRejected;
+
+    var refreshed_json = std.json.parseFromSlice(std.json.Value, alloc, response.body, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidCodexRefreshResponse,
+    };
+    defer refreshed_json.deinit();
+    if (refreshed_json.value != .object) return error.InvalidCodexRefreshResponse;
+
+    const refreshed = try applyRefreshResponse(current, refreshed_json.value.object);
+    try writeRefreshedDocument(alloc, path, bytes, refreshed);
+    return try takeLoaded(alloc, refreshed.access_token, refreshed.account_id, true);
+}
+
+fn loadedFromDocument(alloc: Allocator, object: std.json.ObjectMap) !?Loaded {
+    if (personalAccessToken(object)) |token| {
+        if (!std.mem.startsWith(u8, token, personal_access_token_prefix)) return error.InvalidCodexAuthFile;
+        return try takeLoaded(alloc, token, objectString(object, "account_id"), false);
+    }
+
+    var jwt_buf: [jwt_payload_max_bytes]u8 = undefined;
+    const tokens = storedTokensFromDocumentWithJwt(object, &jwt_buf) orelse return null;
+    return try takeLoaded(alloc, tokens.access_token, tokens.account_id, true);
+}
+
+fn storedTokensFromDocument(object: std.json.ObjectMap) ?StoredTokens {
+    if (objectString(object, "auth_mode")) |mode| {
+        if (!std.ascii.eqlIgnoreCase(mode, "chatgpt")) return null;
+    }
+    const tokens_value = object.get("tokens") orelse return null;
+    if (tokens_value != .object) return null;
+    const tokens = tokens_value.object;
+    const access = objectString(tokens, "access_token") orelse return null;
+    const refresh_token = objectString(tokens, "refresh_token") orelse return null;
+    const id_token = objectString(tokens, "id_token") orelse "";
+    const account_id = objectString(tokens, "account_id") orelse return null;
+    if (access.len == 0 or refresh_token.len == 0 or account_id.len == 0) return null;
+    return .{
+        .id_token = id_token,
+        .access_token = access,
+        .refresh_token = refresh_token,
+        .account_id = account_id,
+    };
+}
+
+fn storedTokensFromDocumentWithJwt(object: std.json.ObjectMap, jwt_buf: []u8) ?StoredTokens {
+    if (objectString(object, "auth_mode")) |mode| {
+        if (!std.ascii.eqlIgnoreCase(mode, "chatgpt")) return null;
+    }
+    const tokens_value = object.get("tokens") orelse return null;
+    if (tokens_value != .object) return null;
+    const tokens = tokens_value.object;
+    const access = objectString(tokens, "access_token") orelse return null;
+    const refresh_token = objectString(tokens, "refresh_token") orelse return null;
+    const id_token = objectString(tokens, "id_token") orelse "";
+    if (access.len == 0 or refresh_token.len == 0) return null;
+
+    const account_id = objectString(tokens, "account_id") orelse jwtAccountId(id_token, jwt_buf) orelse "";
+    if (account_id.len == 0) return null;
+    return .{
+        .id_token = id_token,
+        .access_token = access,
+        .refresh_token = refresh_token,
+        .account_id = account_id,
+    };
+}
+
+fn personalAccessToken(object: std.json.ObjectMap) ?[]const u8 {
+    const selected = if (objectString(object, "auth_mode")) |mode|
+        std.mem.eql(u8, mode, "personalAccessToken")
+    else
+        object.get("personal_access_token") != null;
+    if (!selected) return null;
+    return objectString(object, "personal_access_token");
+}
+
+fn takeLoaded(
+    alloc: Allocator,
+    access_token: []const u8,
+    account_id: ?[]const u8,
+    refreshable: bool,
+) !Loaded {
+    const token = try alloc.dupe(u8, access_token);
+    errdefer secret.zeroAndFree(alloc, token);
+    const owned_account = if (account_id) |value|
+        if (value.len > 0) try alloc.dupe(u8, value) else null
+    else
+        null;
+    const refresh_after_ms = if (refreshable)
+        if (jwtExpirationUnix(access_token)) |exp|
+            (exp - refresh_early_seconds) * std.time.ms_per_s
+        else
+            io_mod.milliTimestamp()
+    else
+        null;
+    return .{
+        .access_token = token,
+        .account_id = owned_account,
+        .refresh_after_ms = refresh_after_ms,
+        .refreshable = refreshable,
+    };
+}
+
+fn needsRefresh(refresh_after_ms: ?i64, now_ms: i64) bool {
+    const deadline = refresh_after_ms orelse return false;
+    return deadline <= now_ms;
+}
+
+fn writeRefreshedDocument(
+    alloc: Allocator,
+    path: []const u8,
+    original_bytes: []const u8,
+    tokens: StoredTokens,
+) !void {
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var root = std.json.parseFromSliceLeaky(
+        std.json.Value,
+        arena_alloc,
+        original_bytes,
+        .{ .allocate = .alloc_always },
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidCodexAuthFile,
+    };
+    if (root != .object) return error.InvalidCodexAuthFile;
+
+    try root.object.put(arena_alloc, try arena_alloc.dupe(u8, "auth_mode"), .{
+        .string = try arena_alloc.dupe(u8, "chatgpt"),
+    });
+    const stamp = try rfc3339UtcAlloc(arena_alloc, @divFloor(io_mod.milliTimestamp(), 1000));
+    try root.object.put(arena_alloc, try arena_alloc.dupe(u8, "last_refresh"), .{
+        .string = stamp,
+    });
+
+    var token_object: std.json.ObjectMap = if (root.object.get("tokens")) |value|
+        if (value == .object) value.object else .empty
+    else
+        .empty;
+    try token_object.put(arena_alloc, try arena_alloc.dupe(u8, "id_token"), .{
+        .string = try arena_alloc.dupe(u8, tokens.id_token),
+    });
+    try token_object.put(arena_alloc, try arena_alloc.dupe(u8, "access_token"), .{
+        .string = try arena_alloc.dupe(u8, tokens.access_token),
+    });
+    try token_object.put(arena_alloc, try arena_alloc.dupe(u8, "refresh_token"), .{
+        .string = try arena_alloc.dupe(u8, tokens.refresh_token),
+    });
+    try token_object.put(arena_alloc, try arena_alloc.dupe(u8, "account_id"), .{
+        .string = try arena_alloc.dupe(u8, tokens.account_id),
+    });
+    try root.object.put(arena_alloc, try arena_alloc.dupe(u8, "tokens"), .{ .object = token_object });
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try std.json.Stringify.value(root, .{ .whitespace = .indent_2 }, &out.writer);
+    try io_mod.writeFileAtomic(alloc, path, out.written());
+}
+
+fn readAuthFile(alloc: Allocator, path: []const u8) ![]u8 {
+    var file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{
+        .mode = .read_only,
+    });
+    defer file.close(io_mod.getIo());
+    return io_mod.readFileToEnd(alloc, &file, max_auth_file_bytes);
+}
+
+fn objectString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    return switch (value) {
+        .string => |text| if (text.len == 0) null else text,
+        else => null,
+    };
+}
+
+fn jwtAccountId(jwt: []const u8, buf: []u8) ?[]const u8 {
+    const payload = decodeJwtPayload(jwt, buf) orelse return null;
+    var parsed = std.json.parseFromSlice(std.json.Value, std.heap.page_allocator, payload, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const nested = parsed.value.object.get("https://api.openai.com/auth") orelse return null;
+    if (nested != .object) return null;
+    const account = objectString(nested.object, "chatgpt_account_id") orelse return null;
+    if (account.len == 0 or account.len > buf.len) return null;
+    var copy: [256]u8 = undefined;
+    if (account.len > copy.len) return null;
+    @memcpy(copy[0..account.len], account);
+    @memcpy(buf[0..account.len], copy[0..account.len]);
+    return buf[0..account.len];
+}
+
+fn decodeJwtPayload(jwt: []const u8, buf: []u8) ?[]const u8 {
+    var parts = std.mem.splitScalar(u8, jwt, '.');
+    _ = parts.next() orelse return null;
+    const payload = parts.next() orelse return null;
+    if (payload.len == 0 or parts.next() == null or parts.next() != null) return null;
+
+    const decoder = std.base64.url_safe_no_pad.Decoder;
+    const size = decoder.calcSizeForSlice(payload) catch return null;
+    if (size > buf.len) return null;
+    decoder.decode(buf[0..size], payload) catch return null;
+    return buf[0..size];
+}
+
+fn rfc3339UtcAlloc(alloc: Allocator, timestamp_s: i64) ![]u8 {
+    const days = @divFloor(timestamp_s, 86_400);
+    var seconds = @mod(timestamp_s, 86_400);
+    if (seconds < 0) seconds += 86_400;
+    const hour: u6 = @intCast(@divFloor(seconds, 3_600));
+    const minute: u6 = @intCast(@divFloor(@mod(seconds, 3_600), 60));
+    const second: u6 = @intCast(@mod(seconds, 60));
+    const civil = civilFromDays(days);
+    return std.fmt.allocPrint(alloc, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}Z", .{
+        civil.year,
+        civil.month,
+        civil.day,
+        hour,
+        minute,
+        second,
+    });
+}
+
+const CivilDate = struct { year: i64, month: u8, day: u8 };
+
+fn civilFromDays(days: i64) CivilDate {
+    const shifted = days + 719_468;
+    const era = @divFloor(shifted, 146_097);
+    const day_of_era = shifted - era * 146_097;
+    const year_of_era = @divFloor(day_of_era - @divFloor(day_of_era, 1460) + @divFloor(day_of_era, 36524) - @divFloor(day_of_era, 146096), 365);
+    var year = year_of_era + era * 400;
+    const day_of_year = day_of_era - (365 * year_of_era + @divFloor(year_of_era, 4) - @divFloor(year_of_era, 100));
+    const month_prime = @divFloor(5 * day_of_year + 2, 153);
+    const day: u8 = @intCast(day_of_year - @divFloor(153 * month_prime + 2, 5) + 1);
+    const month: u8 = @intCast(if (month_prime < 10) month_prime + 3 else month_prime - 9);
+    if (month <= 2) year += 1;
+    return .{ .year = year, .month = month, .day = day };
+}
+
+fn nonEmptyEnv(name: []const u8) ?[]const u8 {
+    const raw = io_mod.getenv(name) orelse return null;
+    if (std.mem.trim(u8, raw, " \t\r\n").len == 0) return null;
+    return raw;
+}
+
+var stable_codex_test_environ: ?*std.process.Environ.Map = null;
+
+fn stableCodexTestEnviron() !*const std.process.Environ.Map {
+    if (stable_codex_test_environ) |map| return map;
+    const alloc = std.heap.page_allocator;
+    const map = try alloc.create(std.process.Environ.Map);
+    map.* = std.process.Environ.Map.init(alloc);
+    stable_codex_test_environ = map;
+    return map;
+}
+
+const TestEnv = struct {
+    alloc: Allocator,
+    map: std.process.Environ.Map,
+
+    fn install(alloc: Allocator, entries: []const [2][]const u8) !*TestEnv {
+        _ = try stableCodexTestEnviron();
+        const self = try alloc.create(TestEnv);
+        errdefer alloc.destroy(self);
+        self.* = .{
+            .alloc = alloc,
+            .map = std.process.Environ.Map.init(alloc),
+        };
+        errdefer self.map.deinit();
+        for (entries) |entry| try self.map.put(entry[0], entry[1]);
+        io_mod.setEnvironMap(&self.map);
+        return self;
+    }
+
+    fn deinit(self: *TestEnv) void {
+        if (stable_codex_test_environ) |map| io_mod.setEnvironMap(map);
+        self.map.deinit();
+        const alloc = self.alloc;
+        alloc.destroy(self);
+    }
+};
+
+fn encodeJwt(alloc: Allocator, payload: []const u8) ![]u8 {
+    const encoder = std.base64.url_safe_no_pad.Encoder;
+    const encoded_len = encoder.calcSize(payload.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = encoder.encode(encoded, payload);
+    return std.fmt.allocPrint(alloc, "e30.{s}.sig", .{encoded});
+}
+
+const FakeTransportState = struct {
+    body: []const u8,
+    disposition: oauth_transport.Disposition,
+    calls: usize = 0,
+
+    fn execute(raw: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+        const self: *@This() = @ptrCast(@alignCast(raw.?));
+        self.calls += 1;
+        _ = request;
+        return .{
+            .disposition = self.disposition,
+            .body = try alloc.dupe(u8, self.body),
+        };
+    }
+};
+
+test "auth file path prefers FX_CODEX_AUTH_FILE then CODEX_HOME then ~/.codex" {
+    const alloc = std.testing.allocator;
+
+    var explicit = try TestEnv.install(alloc, &.{
+        .{ auth_file_env, "/tmp/custom-auth.json" },
+        .{ "CODEX_HOME", "/tmp/codex-home" },
+        .{ "HOME", "/tmp/home" },
+    });
+    defer explicit.deinit();
+    const explicit_path = (try resolveAuthFilePath(alloc)).?;
+    defer alloc.free(explicit_path);
+    try std.testing.expectEqualStrings("/tmp/custom-auth.json", explicit_path);
+
+    var home = try TestEnv.install(alloc, &.{
+        .{ "CODEX_HOME", "/tmp/codex-home" },
+        .{ "HOME", "/tmp/home" },
+    });
+    defer home.deinit();
+    const home_path = (try resolveAuthFilePath(alloc)).?;
+    defer alloc.free(home_path);
+    try std.testing.expectEqualStrings("/tmp/codex-home/auth.json", home_path);
+
+    var fallback = try TestEnv.install(alloc, &.{.{ "HOME", "/tmp/home" }});
+    defer fallback.deinit();
+    const fallback_path = (try resolveAuthFilePath(alloc)).?;
+    defer alloc.free(fallback_path);
+    try std.testing.expectEqualStrings("/tmp/home/.codex/auth.json", fallback_path);
+}
+
+test "parseLoaded reads ChatGPT tokens and JWT expiry" {
+    const alloc = std.testing.allocator;
+    const jwt = try encodeJwt(alloc, "{\"exp\":1700000000,\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_1\"}}");
+    defer alloc.free(jwt);
+    const document = try std.fmt.allocPrint(alloc,
+        \\{{"auth_mode":"chatgpt","tokens":{{"id_token":"{s}","access_token":"{s}","refresh_token":"refresh","account_id":"acct_1"}}}}
+    , .{ jwt, jwt });
+    defer alloc.free(document);
+
+    var loaded = (try parseLoaded(alloc, document)).?;
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqualStrings(jwt, loaded.access_token);
+    try std.testing.expectEqualStrings("acct_1", loaded.account_id.?);
+    try std.testing.expect(loaded.refreshable);
+    try std.testing.expectEqual(@as(i64, (1_700_000_000 - refresh_early_seconds) * 1000), loaded.refresh_after_ms.?);
+}
+
+test "applyRefreshResponse rotates tokens and rejects account changes" {
+    const alloc = std.testing.allocator;
+    const next = try encodeJwt(alloc, "{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_1\"}}");
+    defer alloc.free(next);
+    const changed = try encodeJwt(alloc, "{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_2\"}}");
+    defer alloc.free(changed);
+
+    const current = StoredTokens{
+        .id_token = "old-id",
+        .access_token = "old-access",
+        .refresh_token = "old-refresh",
+        .account_id = "acct_1",
+    };
+
+    const rotated_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"access_token\":\"{s}\",\"refresh_token\":\"new-refresh\",\"id_token\":\"{s}\"}}",
+        .{ next, next },
+    );
+    defer alloc.free(rotated_json);
+    var rotated = try std.json.parseFromSlice(std.json.Value, alloc, rotated_json, .{});
+    defer rotated.deinit();
+    const applied = try applyRefreshResponse(current, rotated.value.object);
+    try std.testing.expectEqualStrings(next, applied.access_token);
+    try std.testing.expectEqualStrings("new-refresh", applied.refresh_token);
+    try std.testing.expectEqualStrings("acct_1", applied.account_id);
+
+    const swapped_json = try std.fmt.allocPrint(
+        alloc,
+        "{{\"access_token\":\"{s}\",\"id_token\":\"{s}\"}}",
+        .{ changed, changed },
+    );
+    defer alloc.free(swapped_json);
+    var swapped = try std.json.parseFromSlice(std.json.Value, alloc, swapped_json, .{});
+    defer swapped.deinit();
+    try std.testing.expectError(error.CodexAccountChanged, applyRefreshResponse(current, swapped.value.object));
+}
+
+test "load refreshes an expired ChatGPT auth.json through the OAuth transport" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const auth_path = try std.fs.path.join(alloc, &.{ root, "auth.json" });
+    defer alloc.free(auth_path);
+
+    const expired = try encodeJwt(alloc, "{\"exp\":1,\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_1\"}}");
+    defer alloc.free(expired);
+    const fresh = try encodeJwt(alloc, "{\"exp\":4000000000,\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"acct_1\"}}");
+    defer alloc.free(fresh);
+    const seed = try std.fmt.allocPrint(alloc,
+        \\{{"auth_mode":"chatgpt","extra":1,"tokens":{{"id_token":"{s}","access_token":"{s}","refresh_token":"refresh-1","account_id":"acct_1"}}}}
+    , .{ expired, expired });
+    defer alloc.free(seed);
+    try tmp.dir.writeFile(io_mod.getIo(), .{ .sub_path = "auth.json", .data = seed });
+
+    var env = try TestEnv.install(alloc, &.{.{ auth_file_env, auth_path }});
+    defer env.deinit();
+
+    const response = try std.fmt.allocPrint(
+        alloc,
+        "{{\"access_token\":\"{s}\",\"refresh_token\":\"refresh-2\",\"id_token\":\"{s}\"}}",
+        .{ fresh, fresh },
+    );
+    defer alloc.free(response);
+    var transport_state = FakeTransportState{ .body = response, .disposition = .accepted };
+    const transport = oauth_transport.Provider{
+        .context = &transport_state,
+        .execute_fn = FakeTransportState.execute,
+    };
+
+    var loaded = (try load(alloc, transport)).?;
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqualStrings(fresh, loaded.access_token);
+    try std.testing.expectEqualStrings("acct_1", loaded.account_id.?);
+    try std.testing.expectEqual(@as(usize, 1), transport_state.calls);
+
+    var rewritten_file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), auth_path, .{ .mode = .read_only });
+    defer rewritten_file.close(io_mod.getIo());
+    const rewritten = try io_mod.readFileToEnd(alloc, &rewritten_file, max_auth_file_bytes);
+    defer alloc.free(rewritten);
+    try std.testing.expect(std.mem.find(u8, rewritten, "refresh-2") != null);
+    try std.testing.expect(std.mem.find(u8, rewritten, "\"extra\": 1") != null or std.mem.find(u8, rewritten, "\"extra\":1") != null);
+    try std.testing.expect(std.mem.find(u8, rewritten, "\"auth_mode\": \"chatgpt\"") != null or std.mem.find(u8, rewritten, "\"auth_mode\":\"chatgpt\"") != null);
+}

--- a/src/core/auth/codex_oauth.zig
+++ b/src/core/auth/codex_oauth.zig
@@ -11,6 +11,8 @@ pub const auth_file_env = "FX_CODEX_AUTH_FILE";
 pub const token_url_env = "FX_CODEX_TOKEN_URL";
 pub const oauth_client_id = "app_EMoamEEZ73f0CkXaXp7hrann";
 pub const default_token_url = "https://auth.openai.com/oauth/token";
+pub const issuer_env = "FX_CODEX_ISSUER";
+pub const default_issuer = "https://auth.openai.com";
 pub const refresh_early_seconds: i64 = 5 * 60;
 const max_auth_file_bytes: usize = 256 * 1024;
 const personal_access_token_prefix = "at-";
@@ -80,6 +82,28 @@ pub fn resolveAuthFilePath(alloc: Allocator) !?[]u8 {
 
 pub fn tokenUrl() []const u8 {
     return nonEmptyEnv(token_url_env) orelse default_token_url;
+}
+
+pub fn issuer() []const u8 {
+    const value = nonEmptyEnv(issuer_env) orelse return default_issuer;
+    return std.mem.trimEnd(u8, value, "/");
+}
+
+pub fn persistTokens(alloc: Allocator, tokens: StoredTokens) !void {
+    if (comptime host_target.is_wasm) return error.CodexAuthUnavailable;
+    const path = (try resolveAuthFilePath(alloc)) orelse return error.HomeNotSet;
+    defer alloc.free(path);
+    try ensureAuthFileParent(path);
+    const existing = readAuthFile(alloc, path) catch |err| switch (err) {
+        error.FileNotFound => null,
+        else => return err,
+    };
+    defer if (existing) |bytes| secret.zeroAndFree(alloc, bytes);
+    try writeRefreshedDocument(alloc, path, existing orelse "{}", tokens);
+}
+
+pub fn copyAccountId(id_token: []const u8, buf: []u8) ?[]const u8 {
+    return jwtAccountId(id_token, buf);
 }
 
 pub fn parseLoaded(alloc: Allocator, bytes: []const u8) !?Loaded {
@@ -344,6 +368,21 @@ fn writeRefreshedDocument(
     try io_mod.writeFileAtomic(alloc, path, out.written());
 }
 
+fn ensureAuthFileParent(path: []const u8) !void {
+    const parent = std.fs.path.dirname(path) orelse return error.InvalidCodexAuthPath;
+    if (std.Io.Dir.openDirAbsolute(io_mod.getIo(), parent, .{})) |*dir| {
+        dir.close(io_mod.getIo());
+        return;
+    } else |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    }
+    std.Io.Dir.createDirAbsolute(io_mod.getIo(), parent, .default_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+}
+
 fn readAuthFile(alloc: Allocator, path: []const u8) ![]u8 {
     var file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{
         .mode = .read_only,
@@ -361,7 +400,9 @@ fn objectString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
 }
 
 fn jwtAccountId(jwt: []const u8, buf: []u8) ?[]const u8 {
-    const payload = decodeJwtPayload(jwt, buf) orelse return null;
+    // ChatGPT id_token payloads are ~1KiB. `buf` is only the account-id output.
+    var payload_buf: [jwt_payload_max_bytes]u8 = undefined;
+    const payload = decodeJwtPayload(jwt, &payload_buf) orelse return null;
     var parsed = std.json.parseFromSlice(std.json.Value, std.heap.page_allocator, payload, .{}) catch return null;
     defer parsed.deinit();
     if (parsed.value != .object) return null;
@@ -369,10 +410,7 @@ fn jwtAccountId(jwt: []const u8, buf: []u8) ?[]const u8 {
     if (nested != .object) return null;
     const account = objectString(nested.object, "chatgpt_account_id") orelse return null;
     if (account.len == 0 or account.len > buf.len) return null;
-    var copy: [256]u8 = undefined;
-    if (account.len > copy.len) return null;
-    @memcpy(copy[0..account.len], account);
-    @memcpy(buf[0..account.len], copy[0..account.len]);
+    @memcpy(buf[0..account.len], account);
     return buf[0..account.len];
 }
 
@@ -475,6 +513,18 @@ fn encodeJwt(alloc: Allocator, payload: []const u8) ![]u8 {
     return std.fmt.allocPrint(alloc, "e30.{s}.sig", .{encoded});
 }
 
+fn encodePaddedJwt(alloc: Allocator, account_id: []const u8, pad_len: usize) ![]u8 {
+    var payload: std.Io.Writer.Allocating = .init(alloc);
+    defer payload.deinit();
+    try payload.writer.writeAll("{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":");
+    try std.json.Stringify.value(account_id, .{}, &payload.writer);
+    try payload.writer.writeAll("},\"pad\":\"");
+    var index: usize = 0;
+    while (index < pad_len) : (index += 1) try payload.writer.writeByte('x');
+    try payload.writer.writeAll("\"}");
+    return encodeJwt(alloc, payload.written());
+}
+
 const FakeTransportState = struct {
     body: []const u8,
     disposition: oauth_transport.Disposition,
@@ -518,6 +568,16 @@ test "auth file path prefers FX_CODEX_AUTH_FILE then CODEX_HOME then ~/.codex" {
     const fallback_path = (try resolveAuthFilePath(alloc)).?;
     defer alloc.free(fallback_path);
     try std.testing.expectEqualStrings("/tmp/home/.codex/auth.json", fallback_path);
+}
+
+test "copyAccountId extracts chatgpt_account_id from a ChatGPT JWT larger than 256 bytes" {
+    const alloc = std.testing.allocator;
+    const jwt = try encodePaddedJwt(alloc, "acct_real", 900);
+    defer alloc.free(jwt);
+
+    var tiny: [256]u8 = undefined;
+    const account = copyAccountId(jwt, &tiny) orelse return error.TestExpectedAccountId;
+    try std.testing.expectEqualStrings("acct_real", account);
 }
 
 test "parseLoaded reads ChatGPT tokens and JWT expiry" {

--- a/src/core/auth/codex_oauth.zig
+++ b/src/core/auth/codex_oauth.zig
@@ -106,6 +106,82 @@ pub fn copyAccountId(id_token: []const u8, buf: []u8) ?[]const u8 {
     return jwtAccountId(id_token, buf);
 }
 
+pub const LogoutResult = struct {
+    session_deleted: bool = false,
+    local_durability_failed: bool = false,
+    remote_revocation_failed: bool = false,
+};
+
+pub fn revokeRefreshToken(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    refresh_token: []const u8,
+) !void {
+    var request_body: std.Io.Writer.Allocating = .init(alloc);
+    defer request_body.deinit();
+    try request_body.writer.writeAll("{\"client_id\":");
+    try std.json.Stringify.value(oauth_client_id, .{}, &request_body.writer);
+    try request_body.writer.writeAll(",\"token\":");
+    try std.json.Stringify.value(refresh_token, .{}, &request_body.writer);
+    try request_body.writer.writeAll(",\"token_type_hint\":\"refresh_token\"}");
+
+    var response = transport.execute(alloc, .{
+        .method = .post_json,
+        .url = tokenUrl(),
+        .payload = request_body.written(),
+    }) catch return;
+    defer response.deinit(alloc);
+}
+
+pub fn clearStoredTokens(alloc: Allocator) !LogoutResult {
+    if (comptime host_target.is_wasm) return error.CodexAuthUnavailable;
+    const path = (try resolveAuthFilePath(alloc)) orelse return error.HomeNotSet;
+    defer alloc.free(path);
+
+    const existing = readAuthFile(alloc, path) catch |err| switch (err) {
+        error.FileNotFound => return .{},
+        else => return err,
+    };
+    defer secret.zeroAndFree(alloc, existing);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, existing, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidCodexAuthFile,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidCodexAuthFile;
+    if (parsed.value.object.get("tokens") == null) return .{};
+
+    _ = parsed.value.object.orderedRemove("tokens");
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try std.json.Stringify.value(parsed.value, .{ .whitespace = .indent_2 }, &out.writer);
+    io_mod.writeFileAtomic(alloc, path, out.written()) catch return .{
+        .local_durability_failed = true,
+    };
+    return .{ .session_deleted = true };
+}
+
+pub fn loadStoredRefreshToken(alloc: Allocator) !?[]u8 {
+    if (comptime host_target.is_wasm) return null;
+    const path = (try resolveAuthFilePath(alloc)) orelse return null;
+    defer alloc.free(path);
+    const bytes = readAuthFile(alloc, path) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
+    defer secret.zeroAndFree(alloc, bytes);
+
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const tokens = storedTokensFromDocument(parsed.value.object) orelse return null;
+    if (tokens.refresh_token.len == 0) return null;
+    return try alloc.dupe(u8, tokens.refresh_token);
+}
+
 pub fn parseLoaded(alloc: Allocator, bytes: []const u8) !?Loaded {
     var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -6,6 +6,7 @@ const io_mod = @import("../shared/io.zig");
 const oauth = @import("oauth.zig");
 const oauth_session = @import("oauth_session.zig");
 const oauth_transport = @import("oauth_transport.zig");
+const codex_oauth = @import("codex_oauth.zig");
 const secret = @import("secret.zig");
 const types = @import("../shared/types.zig");
 
@@ -35,6 +36,7 @@ pub const CatalogAuthenticatedSource = enum {
     ai_gateway_api_key,
     fx_login,
     stored_key,
+    codex_oauth,
 
     fn credentialSource(self: CatalogAuthenticatedSource) Source {
         return switch (self) {
@@ -42,6 +44,7 @@ pub const CatalogAuthenticatedSource = enum {
             .ai_gateway_api_key => .ai_gateway_api_key,
             .fx_login => .fx_login,
             .stored_key => .stored_key,
+            .codex_oauth => .codex_oauth,
         };
     }
 };
@@ -133,6 +136,7 @@ pub fn catalogAccessForCredential(
         .vercel_oidc_token => .vercel_oidc_token,
         .ai_gateway_api_key => .ai_gateway_api_key,
         .stored_key => .stored_key,
+        .codex_oauth => .codex_oauth,
         .fx_login => blk: {
             const team = team_context orelse
                 return .{ .public_only = .fx_login_team_required };
@@ -243,6 +247,12 @@ pub fn resolvePreferring(
     };
     if (fx_login) |credential| return .{ .credential = credential };
 
+    const codex = switch (mode) {
+        .stored => try loadStoredCodexCredential(alloc),
+        .refresh_if_needed => try loadCodexCredential(alloc, transport),
+    };
+    if (codex) |credential| return .{ .credential = credential };
+
     if (secret_store.isDisabled()) return .{};
 
     var status: StoredKeyReadStatus = .not_found;
@@ -266,11 +276,19 @@ fn loadPreferredSource(
     mode: LoadMode,
     source: Source,
 ) !?Credential {
-    if (source != .fx_login) return loadSource(alloc, transport, secret_store, source);
-    return switch (mode) {
-        .stored => loadStoredFxLoginCredential(alloc),
-        .refresh_if_needed => loadFxLoginCredential(alloc, transport),
-    };
+    if (source == .fx_login) {
+        return switch (mode) {
+            .stored => loadStoredFxLoginCredential(alloc),
+            .refresh_if_needed => loadFxLoginCredential(alloc, transport),
+        };
+    }
+    if (source == .codex_oauth) {
+        return switch (mode) {
+            .stored => loadStoredCodexCredential(alloc),
+            .refresh_if_needed => loadCodexCredential(alloc, transport),
+        };
+    }
+    return loadSource(alloc, transport, secret_store, source);
 }
 
 pub fn loadSource(
@@ -284,6 +302,7 @@ pub fn loadSource(
         .ai_gateway_api_key => loadEnvCredential(alloc, "AI_GATEWAY_API_KEY", source),
         .fx_login => loadFxLoginCredential(alloc, transport),
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
+        .codex_oauth => loadCodexCredential(alloc, transport),
     };
 }
 
@@ -320,6 +339,7 @@ pub fn sourceExists(
             secret.zeroAndFree(alloc, value);
             break :blk true;
         },
+        .codex_oauth => try codex_oauth.sourceExists(alloc),
     };
 }
 
@@ -372,6 +392,40 @@ fn loadStoredFxLoginCredential(alloc: std.mem.Allocator) !?Credential {
     var session = (try oauth_session.load(alloc)) orelse return null;
     defer session.deinit(alloc);
     return takeCredentialFromSession(&session, null);
+}
+
+pub fn loadCodexCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+) !?Credential {
+    var loaded = (try codex_oauth.load(alloc, transport)) orelse return null;
+    return takeCredentialFromCodex(&loaded);
+}
+
+fn loadStoredCodexCredential(alloc: std.mem.Allocator) !?Credential {
+    var loaded = (try codex_oauth.loadStored(alloc)) orelse return null;
+    return takeCredentialFromCodex(&loaded);
+}
+
+pub fn refreshCodexCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+) !?Credential {
+    var loaded = (try codex_oauth.refresh(alloc, transport)) orelse return null;
+    return takeCredentialFromCodex(&loaded);
+}
+
+fn takeCredentialFromCodex(loaded: *codex_oauth.Loaded) Credential {
+    const token = loaded.access_token;
+    loaded.access_token = &.{};
+    const account_id = loaded.account_id;
+    loaded.account_id = null;
+    return .{
+        .token = token,
+        .source = .codex_oauth,
+        .team_id = account_id,
+        .refresh_after_ms = loaded.refresh_after_ms,
+    };
 }
 
 pub fn refreshFxLoginCredential(
@@ -471,11 +525,12 @@ pub fn sourceLabel(source: Source) []const u8 {
         .ai_gateway_api_key => "AI_GATEWAY_API_KEY",
         .fx_login => "fx login",
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
+        .codex_oauth => "Codex OAuth (~/.codex)",
     };
 }
 
 pub fn sourceRefreshable(source: Source) bool {
-    return source == .fx_login;
+    return source == .fx_login or source == .codex_oauth;
 }
 
 test "stored key label discloses the backend that answered" {
@@ -568,7 +623,7 @@ test "fx login catalog access requires a fresh credential and selected team" {
 }
 
 test "authenticated catalog access carries source and permitted request context" {
-    for ([_]Source{ .vercel_oidc_token, .ai_gateway_api_key, .stored_key }) |source| {
+    for ([_]Source{ .vercel_oidc_token, .ai_gateway_api_key, .stored_key, .codex_oauth }) |source| {
         var credential = Credential{
             .token = try std.testing.allocator.dupe(u8, "token"),
             .source = source,
@@ -686,6 +741,58 @@ const SecretStoreFixture = struct {
         return false;
     }
 };
+
+test "Codex OAuth loads from FX_CODEX_AUTH_FILE behind Vercel environment keys" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const auth_path = try std.fs.path.join(alloc, &.{ root, "auth.json" });
+    defer alloc.free(auth_path);
+
+    const encoder = std.base64.url_safe_no_pad.Encoder;
+    const payload = "{\"exp\":4000000000}";
+    var encoded: [64]u8 = undefined;
+    const encoded_len = encoder.calcSize(payload.len);
+    _ = encoder.encode(encoded[0..encoded_len], payload);
+    const jwt = try std.fmt.allocPrint(alloc, "e30.{s}.sig", .{encoded[0..encoded_len]});
+    defer alloc.free(jwt);
+    const document = try std.fmt.allocPrint(alloc,
+        \\{{"auth_mode":"chatgpt","tokens":{{"id_token":"{s}","access_token":"{s}","refresh_token":"refresh","account_id":"acct_1"}}}}
+    , .{ jwt, jwt });
+    defer alloc.free(document);
+    try tmp.dir.writeFile(io_mod.getIo(), .{ .sub_path = "auth.json", .data = document });
+
+    const env = try CredentialTestEnv.install(alloc, &.{
+        .{ "AI_GATEWAY_API_KEY", "api-key" },
+        .{ "FX_CODEX_AUTH_FILE", auth_path },
+    });
+    defer env.deinit();
+
+    try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .codex_oauth));
+    var preferred = (try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .codex_oauth)).?;
+    defer preferred.deinit(alloc);
+    try std.testing.expectEqual(Source.codex_oauth, preferred.source);
+    try std.testing.expectEqualStrings(jwt, preferred.token);
+    try std.testing.expectEqualStrings("acct_1", preferred.team_id.?);
+
+    const resolution = try resolve(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .refresh_if_needed);
+    var startup = resolution.credential orelse return error.TestExpectedCredential;
+    defer startup.deinit(alloc);
+    try std.testing.expectEqual(Source.ai_gateway_api_key, startup.source);
+
+    const remembered = try resolvePreferring(
+        alloc,
+        oauth_transport.unavailable_provider,
+        host.unavailable_secret_store,
+        .refresh_if_needed,
+        .codex_oauth,
+    );
+    var chosen = remembered.credential orelse return error.TestExpectedCredential;
+    defer chosen.deinit(alloc);
+    try std.testing.expectEqual(Source.codex_oauth, chosen.source);
+}
 
 test "source-specific credential loading bypasses generic precedence" {
     const alloc = std.testing.allocator;

--- a/src/core/auth/js_host_auth.zig
+++ b/src/core/auth/js_host_auth.zig
@@ -64,12 +64,16 @@ fn executeOAuthRequest(
             .name = "content-type",
             .value = "application/x-www-form-urlencoded",
         }},
+        .post_json => &.{.{
+            .name = "content-type",
+            .value = "application/json",
+        }},
     };
     var response = try executeRequest(
         alloc,
         switch (request.method) {
             .get => "GET",
-            .post_form => "POST",
+            .post_form, .post_json => "POST",
         },
         request.url,
         headers,

--- a/src/core/auth/js_host_auth.zig
+++ b/src/core/auth/js_host_auth.zig
@@ -131,6 +131,7 @@ fn executeRequest(
     return .{
         .disposition = if (status == 200) .accepted else .rejected,
         .body = try alloc.dupe(u8, response_buffer[0..@intCast(response_len)]),
+        .status = @enumFromInt(status),
     };
 }
 

--- a/src/core/auth/oauth_transport.zig
+++ b/src/core/auth/oauth_transport.zig
@@ -6,6 +6,7 @@ const Allocator = std.mem.Allocator;
 pub const Method = enum {
     get,
     post_form,
+    post_json,
 };
 
 pub const Request = struct {

--- a/src/core/auth/oauth_transport.zig
+++ b/src/core/auth/oauth_transport.zig
@@ -26,6 +26,7 @@ pub const Response = struct {
     disposition: Disposition,
     /// Owned bytes allocated with the allocator passed to `Provider.execute`.
     body: []u8,
+    status: ?std.http.Status = null,
 
     pub fn deinit(self: *Response, alloc: Allocator) void {
         secret.zeroAndFree(alloc, self.body);

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -14,6 +14,7 @@ const process_supervisor = @import("../background/process_supervisor.zig");
 const context_contract = @import("../workspace/context_contract.zig");
 const devbox_executor = @import("../execution/devbox_executor.zig");
 const gateway_provider = @import("../gateway/gateway_provider.zig");
+const codex_protocol = @import("../gateway/codex_protocol.zig");
 const background_process_provider = @import(
     "../execution/background_process_provider.zig",
 );
@@ -1432,6 +1433,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     ctx.gateway_team = credential.gatewayTeam();
     ctx.credential_source = credential.source;
     ctx.model_catalog_access = credentials.catalogAccessForCredential(credential.source, api_key, credential.gatewayTeam());
+    ctx.model = codex_protocol.resolvedModel(credential.source, ctx.model);
 
     const restored_image_catalog = try ctx.session.snapshotImageCatalog(alloc, &.{});
     defer types.freeImageAttachmentSlice(alloc, restored_image_catalog);
@@ -1575,7 +1577,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         .skills_prompt_section = skills_section,
         .explicit_skills_prompt_section = explicit_skills.text,
         .gateway_retry_count = cfg.gateway_retry_count,
-        .gateway_chat_url = cfg.gateway_chat_url,
+        .gateway_chat_url = codex_protocol.effectiveChatUrl(credential.source, cfg.gateway_chat_url),
         .gateway_tools_json = tool_projection.tools_json,
         .custom_tool_guidance = tool_projection.custom_guidance,
         .agent_step_limit = startup.agent_step_limit,

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -765,29 +765,57 @@ fn runNonInteractiveWithDeps(
             return .handled_success;
         },
         .logout => |rest| {
-            if (rest.len != 0) {
-                try writeStderr(deps, "usage: fx logout\n");
+            const provider = parseLoginProvider(rest) catch {
+                try writeStderr(deps, "usage: fx logout [--codex]\n");
                 return .handled_failure;
-            }
-            const result = login_flow.logout(alloc, cfg.gateway_provider.oauth_transport) catch |err| switch (err) {
-                error.SessionDeleteFailed => {
-                    try writeStderr(deps, "fx logout: failed to durably remove saved Fx login\n");
-                    return .handled_failure;
-                },
             };
-            if (result.local_durability_failed) {
-                try writeStderr(deps, "fx logout: failed to durably remove saved Fx login\n");
-            } else {
-                try writeStdout(
-                    deps,
-                    if (result.session_deleted) "Signed out of fx.\n" else "No fx login session found.\n",
-                );
+            switch (provider) {
+                .vercel => {
+                    const result = login_flow.logout(alloc, cfg.gateway_provider.oauth_transport) catch |err| switch (err) {
+                        error.SessionDeleteFailed => {
+                            try writeStderr(deps, "fx logout: failed to durably remove saved Fx login\n");
+                            return .handled_failure;
+                        },
+                    };
+                    if (result.local_durability_failed) {
+                        try writeStderr(deps, "fx logout: failed to durably remove saved Fx login\n");
+                    } else {
+                        try writeStdout(
+                            deps,
+                            if (result.session_deleted) "Signed out of fx.\n" else "No fx login session found.\n",
+                        );
+                    }
+                    if (result.remote_revocation_failed) {
+                        try writeStderr(deps, login_flow.remote_revocation_warning);
+                        try writeStderr(deps, "\n");
+                    }
+                    return if (result.local_durability_failed) .handled_failure else .handled_success;
+                },
+                .codex => {
+                    const result = codex_login.runLogout(alloc, cfg.gateway_provider.oauth_transport) catch |err| switch (err) {
+                        error.HomeNotSet => {
+                            try writeStderr(deps, "fx logout: home directory is unavailable; set HOME or FX_CODEX_AUTH_FILE\n");
+                            return .handled_failure;
+                        },
+                        else => {
+                            try writeStderr(deps, "fx logout: failed to sign out of Codex\n");
+                            return .handled_failure;
+                        },
+                    };
+                    if (result.local_durability_failed) {
+                        try writeStderr(deps, "fx logout: failed to durably remove saved Codex login\n");
+                    } else {
+                        try writeStdout(
+                            deps,
+                            if (result.session_deleted) "Signed out of Codex.\n" else "No Codex login session found.\n",
+                        );
+                    }
+                    if (result.remote_revocation_failed) {
+                        try writeStderr(deps, "fx logout: Codex token revocation failed; the local session was removed\n");
+                    }
+                    return if (result.local_durability_failed) .handled_failure else .handled_success;
+                },
             }
-            if (result.remote_revocation_failed) {
-                try writeStderr(deps, login_flow.remote_revocation_warning);
-                try writeStderr(deps, "\n");
-            }
-            return if (result.local_durability_failed) .handled_failure else .handled_success;
         },
         .teams => |rest| {
             if (rest.len != 0) {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -21,6 +21,7 @@ const github_publish = @import("../github/github_publish.zig");
 const github_workflows = @import("../github/github_workflows.zig");
 const host = @import("../hosts/host.zig");
 const login_flow = @import("../auth/login_flow.zig");
+const codex_login = @import("../auth/codex_login.zig");
 const oauth_transport = @import("../auth/oauth_transport.zig");
 const secret = @import("../auth/secret.zig");
 const output_contracts = @import("../output/output_contracts.zig");
@@ -723,24 +724,44 @@ fn runNonInteractiveWithDeps(
         .pr => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .pull_request),
         .issue => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .issue),
         .login => |rest| {
-            if (rest.len != 0) {
-                try writeStderr(deps, "usage: fx login\n");
-                return .handled_failure;
-            }
-            login_flow.runLogin(
-                alloc,
-                cfg.gateway_provider.oauth_transport,
-                cfg.url_opener,
-            ) catch |err| {
-                const message = switch (err) {
-                    error.ClientIdMissing => "fx login: missing FX_OAUTH_CLIENT_ID; configure the fx Vercel App client id first\n",
-                    error.AccessDenied => "fx login: authorization denied\n",
-                    error.ExpiredToken, error.LoginTimedOut => "fx login: authorization expired; run fx login again\n",
-                    else => "fx login: failed to sign in\n",
-                };
-                try writeStderr(deps, message);
+            const provider = parseLoginProvider(rest) catch {
+                try writeStderr(deps, "usage: fx login [--codex]\n");
                 return .handled_failure;
             };
+            switch (provider) {
+                .vercel => login_flow.runLogin(
+                    alloc,
+                    cfg.gateway_provider.oauth_transport,
+                    cfg.url_opener,
+                ) catch |err| {
+                    const message = switch (err) {
+                        error.ClientIdMissing => "fx login: missing FX_OAUTH_CLIENT_ID; configure the fx Vercel App client id first\n",
+                        error.AccessDenied => "fx login: authorization denied\n",
+                        error.ExpiredToken, error.LoginTimedOut => "fx login: authorization expired; run fx login again\n",
+                        else => "fx login: failed to sign in\n",
+                    };
+                    try writeStderr(deps, message);
+                    return .handled_failure;
+                },
+                .codex => codex_login.runLogin(
+                    alloc,
+                    cfg.gateway_provider.oauth_transport,
+                    cfg.url_opener,
+                ) catch |err| {
+                    const message = switch (err) {
+                        error.DeviceCodeUnavailable => "fx login: Codex device-code login is not available\n",
+                        error.InvalidDeviceCodeResponse => "fx login: Codex device-code response was invalid\n",
+                        error.InvalidAuthorizationGrant => "fx login: Codex authorization grant was invalid\n",
+                        error.InvalidTokenExchange => "fx login: Codex token exchange failed\n",
+                        error.AccessDenied => "fx login: Codex authorization denied\n",
+                        error.LoginTimedOut => "fx login: Codex authorization expired; run fx login --codex again\n",
+                        error.HomeNotSet => "fx login: home directory is unavailable; set HOME or FX_CODEX_AUTH_FILE\n",
+                        else => "fx login: failed to sign in to Codex\n",
+                    };
+                    try writeStderr(deps, message);
+                    return .handled_failure;
+                },
+            }
             return .handled_success;
         },
         .logout => |rest| {
@@ -2724,6 +2745,16 @@ fn globalLaunchErrorMessage(err: anyerror) ?[]const u8 {
     };
 }
 
+const LoginProvider = enum { vercel, codex };
+
+fn parseLoginProvider(args: []const [:0]const u8) !LoginProvider {
+    if (args.len == 0) return .vercel;
+    if (args.len == 1 and (std.mem.eql(u8, args[0], "--codex") or std.mem.eql(u8, args[0], "codex"))) {
+        return .codex;
+    }
+    return error.InvalidLoginUsage;
+}
+
 fn parseAcpArgs(args: []const [:0]const u8) !AcpOptions {
     var opts = AcpOptions{};
     var i: usize = 0;
@@ -3146,6 +3177,13 @@ fn isVersionFlag(arg: []const u8) bool {
 fn testCommandCatalog() CommandCatalog {
     const builtin_commands = @import("../../builtins/commands.zig");
     return builtin_commands.top_level_registry;
+}
+
+test "login accepts an optional Codex device-code provider" {
+    try std.testing.expectEqual(LoginProvider.vercel, try parseLoginProvider(&.{}));
+    try std.testing.expectEqual(LoginProvider.codex, try parseLoginProvider(&.{@constCast("--codex")}));
+    try std.testing.expectEqual(LoginProvider.codex, try parseLoginProvider(&.{@constCast("codex")}));
+    try std.testing.expectError(error.InvalidLoginUsage, parseLoginProvider(&.{@constCast("--json")}));
 }
 
 test "parse recognizes every top-level command and preserves unknown commands" {

--- a/src/core/gateway/codex_protocol.zig
+++ b/src/core/gateway/codex_protocol.zig
@@ -211,12 +211,6 @@ pub fn translateGatewayPayload(
     try out.writer.writeAll(",\"tool_choice\":");
     try std.json.Stringify.value(tool_choice, .{}, &out.writer);
 
-    if (parsed.value.object.get("maxOutputTokens")) |max_tokens| {
-        if (max_tokens == .integer and max_tokens.integer > 0) {
-            try out.writer.print(",\"max_output_tokens\":{d}", .{max_tokens.integer});
-        }
-    }
-
     try out.writer.writeAll(",\"reasoning\":{\"summary\":\"auto\",\"context\":\"all_turns\"");
     if (objectString(parsed.value.object, "reasoning")) |effort| {
         if (!std.mem.eql(u8, effort, "auto")) {
@@ -554,6 +548,7 @@ test "gateway payload translates into a Responses request" {
     try std.testing.expect(std.mem.find(u8, body, "\"prompt_cache_key\":\"session-1\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"effort\":\"medium\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"context\":\"all_turns\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "max_output_tokens") == null);
 }
 
 test "Responses SSE events project onto the Gateway stream contract" {

--- a/src/core/gateway/codex_protocol.zig
+++ b/src/core/gateway/codex_protocol.zig
@@ -1,0 +1,598 @@
+const std = @import("std");
+const types = @import("../shared/types.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const responses_url = "https://chatgpt.com/backend-api/codex/responses";
+pub const default_model = "openai/gpt-5.6-sol";
+pub const account_header = "ChatGPT-Account-ID";
+
+const openai_prefix = "openai/";
+
+pub fn isCodexChatUrl(url: []const u8) bool {
+    return std.mem.find(u8, url, "/backend-api/codex") != null or
+        std.mem.find(u8, url, "/codex/responses") != null;
+}
+
+pub fn isLoopbackHttpUrl(url: []const u8) bool {
+    const uri = std.Uri.parse(url) catch return false;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "http") or
+        uri.user != null or
+        uri.password != null or
+        uri.port == null)
+    {
+        return false;
+    }
+    const host_component = uri.host orelse return false;
+    var host_buf: [std.Io.net.HostName.max_len]u8 = undefined;
+    const host = host_component.toRaw(&host_buf) catch return false;
+    return std.mem.eql(u8, host, "127.0.0.1") or
+        std.ascii.eqlIgnoreCase(host, "localhost") or
+        std.mem.eql(u8, host, "[::1]");
+}
+
+pub fn effectiveChatUrl(source: ?types.CredentialSource, fallback: []const u8) []const u8 {
+    if (source != .codex_oauth) return fallback;
+    if (isLoopbackHttpUrl(fallback)) return fallback;
+    return responses_url;
+}
+
+pub fn wireModelId(model: []const u8) []const u8 {
+    const trimmed = if (std.mem.startsWith(u8, model, openai_prefix))
+        model[openai_prefix.len..]
+    else
+        model;
+    if (std.mem.startsWith(u8, trimmed, "gpt-")) return trimmed;
+    return "gpt-5.6-sol";
+}
+
+pub fn resolvedModel(source: ?types.CredentialSource, model: []const u8) []const u8 {
+    if (source != .codex_oauth) return model;
+    if (std.mem.startsWith(u8, model, openai_prefix) or std.mem.startsWith(u8, model, "gpt-")) {
+        return model;
+    }
+    return default_model;
+}
+
+pub const CatalogModel = struct {
+    id: []const u8,
+    context_window: u32,
+    max_tokens: u32,
+};
+
+pub const catalog_models = [_]CatalogModel{
+    .{ .id = "openai/gpt-5.6-sol", .context_window = 272_000, .max_tokens = 128_000 },
+    .{ .id = "openai/gpt-5.6-terra", .context_window = 272_000, .max_tokens = 128_000 },
+    .{ .id = "openai/gpt-5.6-luna", .context_window = 272_000, .max_tokens = 128_000 },
+    .{ .id = "openai/gpt-5.3-codex", .context_window = 272_000, .max_tokens = 128_000 },
+    .{ .id = "openai/gpt-5.2-codex", .context_window = 272_000, .max_tokens = 128_000 },
+};
+
+pub const TranslateState = struct {
+    saw_tool_call: bool = false,
+    calls: std.ArrayList(OpenCall) = .empty,
+
+    const OpenCall = struct {
+        item_id: []u8,
+        call_id: []u8,
+        name: []u8,
+
+        fn deinit(self: *@This(), alloc: Allocator) void {
+            alloc.free(self.item_id);
+            alloc.free(self.call_id);
+            alloc.free(self.name);
+        }
+    };
+
+    pub fn deinit(self: *TranslateState, alloc: Allocator) void {
+        for (self.calls.items) |*call| call.deinit(alloc);
+        self.calls.deinit(alloc);
+        self.* = undefined;
+    }
+
+    fn upsert(self: *TranslateState, alloc: Allocator, item_id: []const u8, call_id: []const u8, name: []const u8) !void {
+        if (self.find(item_id) != null) return;
+        try self.calls.append(alloc, .{
+            .item_id = try alloc.dupe(u8, item_id),
+            .call_id = try alloc.dupe(u8, call_id),
+            .name = try alloc.dupe(u8, name),
+        });
+    }
+
+    fn find(self: TranslateState, item_id: []const u8) ?*OpenCall {
+        for (self.calls.items) |*call| {
+            if (std.mem.eql(u8, call.item_id, item_id)) return call;
+        }
+        return null;
+    }
+
+    fn findByCallId(self: TranslateState, call_id: []const u8) ?*OpenCall {
+        for (self.calls.items) |*call| {
+            if (std.mem.eql(u8, call.call_id, call_id)) return call;
+        }
+        return null;
+    }
+};
+
+pub fn translateGatewayPayload(
+    alloc: Allocator,
+    model: []const u8,
+    payload: []const u8,
+    session_id: ?[]const u8,
+) ![]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, payload, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidGatewayRequestBody,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidGatewayRequestBody;
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"model\":");
+    try std.json.Stringify.value(wireModelId(model), .{}, &out.writer);
+    try out.writer.writeAll(",\"store\":false,\"stream\":true,\"parallel_tool_calls\":false");
+    try out.writer.writeAll(",\"include\":[\"reasoning.encrypted_content\"]");
+
+    if (session_id) |id| {
+        if (id.len > 0) {
+            try out.writer.writeAll(",\"prompt_cache_key\":");
+            try std.json.Stringify.value(id, .{}, &out.writer);
+        }
+    }
+
+    var instructions: std.Io.Writer.Allocating = .init(alloc);
+    defer instructions.deinit();
+    try out.writer.writeAll(",\"input\":[");
+    var wrote_input = false;
+    if (parsed.value.object.get("prompt")) |prompt| {
+        if (prompt == .array) {
+            for (prompt.array.items) |message| {
+                if (message != .object) continue;
+                const role = objectString(message.object, "role") orelse continue;
+                if (std.mem.eql(u8, role, "system")) {
+                    if (messageText(message.object)) |text| {
+                        if (instructions.written().len > 0) try instructions.writer.writeAll("\n\n");
+                        try instructions.writer.writeAll(text);
+                    }
+                    continue;
+                }
+                if (wrote_input) try out.writer.writeByte(',');
+                try writeResponsesInputMessage(alloc, &out.writer, role, message.object);
+                wrote_input = true;
+            }
+        }
+    }
+    try out.writer.writeByte(']');
+
+    if (instructions.written().len > 0) {
+        try out.writer.writeAll(",\"instructions\":");
+        try std.json.Stringify.value(instructions.written(), .{}, &out.writer);
+    }
+
+    if (parsed.value.object.get("tools")) |tools| {
+        if (tools == .array) {
+            try out.writer.writeAll(",\"tools\":[");
+            var wrote_tool = false;
+            for (tools.array.items) |tool| {
+                if (tool != .object) continue;
+                const tool_type = objectString(tool.object, "type") orelse continue;
+                if (!std.mem.eql(u8, tool_type, "function")) continue;
+                const name = objectString(tool.object, "name") orelse continue;
+                if (wrote_tool) try out.writer.writeByte(',');
+                try out.writer.writeAll("{\"type\":\"function\",\"strict\":false,\"name\":");
+                try std.json.Stringify.value(name, .{}, &out.writer);
+                if (objectString(tool.object, "description")) |description| {
+                    try out.writer.writeAll(",\"description\":");
+                    try std.json.Stringify.value(description, .{}, &out.writer);
+                }
+                try out.writer.writeAll(",\"parameters\":");
+                if (tool.object.get("inputSchema")) |schema| {
+                    try std.json.Stringify.value(schema, .{}, &out.writer);
+                } else {
+                    try out.writer.writeAll("{\"type\":\"object\",\"properties\":{}}");
+                }
+                try out.writer.writeByte('}');
+                wrote_tool = true;
+            }
+            try out.writer.writeByte(']');
+        }
+    }
+
+    var tool_choice: []const u8 = "auto";
+    if (parsed.value.object.get("toolChoice")) |choice| {
+        if (choice == .object) {
+            if (objectString(choice.object, "type")) |kind| {
+                if (std.mem.eql(u8, kind, "none")) tool_choice = "none";
+                if (std.mem.eql(u8, kind, "required")) tool_choice = "required";
+            }
+        }
+    }
+    try out.writer.writeAll(",\"tool_choice\":");
+    try std.json.Stringify.value(tool_choice, .{}, &out.writer);
+
+    if (parsed.value.object.get("maxOutputTokens")) |max_tokens| {
+        if (max_tokens == .integer and max_tokens.integer > 0) {
+            try out.writer.print(",\"max_output_tokens\":{d}", .{max_tokens.integer});
+        }
+    }
+
+    try out.writer.writeAll(",\"reasoning\":{\"summary\":\"auto\",\"context\":\"all_turns\"");
+    if (objectString(parsed.value.object, "reasoning")) |effort| {
+        if (!std.mem.eql(u8, effort, "auto")) {
+            try out.writer.writeAll(",\"effort\":");
+            try std.json.Stringify.value(effort, .{}, &out.writer);
+        }
+    }
+    try out.writer.writeByte('}');
+
+    try out.writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+pub fn translateResponsesSseData(
+    alloc: Allocator,
+    json_text: []const u8,
+    state: *TranslateState,
+) !?[]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const event_type = objectString(parsed.value.object, "type") orelse return null;
+
+    if (std.mem.eql(u8, event_type, "response.output_text.delta")) {
+        const delta = objectString(parsed.value.object, "delta") orelse return null;
+        return try writeObject(alloc, &.{
+            .{ "type", .{ .string = "text-delta" } },
+            .{ "delta", .{ .string = delta } },
+        });
+    }
+    if (std.mem.eql(u8, event_type, "response.reasoning_summary_text.delta") or
+        std.mem.eql(u8, event_type, "response.reasoning_text.delta") or
+        std.mem.eql(u8, event_type, "response.reasoning_summary.delta"))
+    {
+        const delta = objectString(parsed.value.object, "delta") orelse return null;
+        return try writeObject(alloc, &.{
+            .{ "type", .{ .string = "reasoning-delta" } },
+            .{ "delta", .{ .string = delta } },
+        });
+    }
+    if (std.mem.eql(u8, event_type, "response.output_item.added")) {
+        const item = parsed.value.object.get("item") orelse return null;
+        if (item != .object) return null;
+        const item_type = objectString(item.object, "type") orelse return null;
+        if (!std.mem.eql(u8, item_type, "function_call")) return null;
+        const call_id = objectString(item.object, "call_id") orelse return null;
+        const name = objectString(item.object, "name") orelse "";
+        const item_id = objectString(item.object, "id") orelse call_id;
+        try state.upsert(alloc, item_id, call_id, name);
+        state.saw_tool_call = true;
+        return try writeToolInputStart(alloc, call_id, name);
+    }
+    if (std.mem.eql(u8, event_type, "response.function_call_arguments.delta")) {
+        const delta = objectString(parsed.value.object, "delta") orelse return null;
+        const call_id = try resolveCallId(parsed.value.object, state) orelse return null;
+        return try writeObject(alloc, &.{
+            .{ "type", .{ .string = "tool-input-delta" } },
+            .{ "toolCallId", .{ .string = call_id } },
+            .{ "delta", .{ .string = delta } },
+        });
+    }
+    if (std.mem.eql(u8, event_type, "response.function_call_arguments.done")) {
+        const call_id = try resolveCallId(parsed.value.object, state) orelse return null;
+        return try writeObject(alloc, &.{
+            .{ "type", .{ .string = "tool-input-end" } },
+            .{ "toolCallId", .{ .string = call_id } },
+        });
+    }
+    if (std.mem.eql(u8, event_type, "response.output_item.done")) {
+        const item = parsed.value.object.get("item") orelse return null;
+        if (item != .object) return null;
+        const item_type = objectString(item.object, "type") orelse return null;
+        if (!std.mem.eql(u8, item_type, "function_call")) return null;
+        const call_id = objectString(item.object, "call_id") orelse return null;
+        const name = objectString(item.object, "name") orelse "";
+        const arguments = objectString(item.object, "arguments") orelse "{}";
+        state.saw_tool_call = true;
+        return try writeToolCall(alloc, call_id, name, arguments);
+    }
+    if (std.mem.eql(u8, event_type, "response.completed")) {
+        const finish: []const u8 = if (state.saw_tool_call) "tool-calls" else "stop";
+        return try writeFinish(alloc, parsed.value.object.get("response"), finish);
+    }
+    if (std.mem.eql(u8, event_type, "response.incomplete")) {
+        return try writeFinish(alloc, parsed.value.object.get("response"), "length");
+    }
+    if (std.mem.eql(u8, event_type, "response.failed") or std.mem.eql(u8, event_type, "error")) {
+        return try alloc.dupe(u8, "{\"type\":\"finish\",\"finishReason\":{\"unified\":\"error\"}}");
+    }
+    return null;
+}
+
+fn writeResponsesInputMessage(alloc: Allocator, writer: *std.Io.Writer, role: []const u8, object: std.json.ObjectMap) !void {
+    if (std.mem.eql(u8, role, "tool")) {
+        const call_id = objectString(object, "toolCallId") orelse
+            firstToolResultId(object) orelse
+            "";
+        const output = toolResultText(object) orelse "";
+        try writer.writeAll("{\"type\":\"function_call_output\",\"call_id\":");
+        try std.json.Stringify.value(call_id, .{}, writer);
+        try writer.writeAll(",\"output\":");
+        try std.json.Stringify.value(output, .{}, writer);
+        try writer.writeByte('}');
+        return;
+    }
+
+    if (std.mem.eql(u8, role, "assistant")) {
+        if (object.get("content")) |content| {
+            if (content == .array) {
+                var wrote = false;
+                for (content.array.items) |part| {
+                    if (part != .object) continue;
+                    const part_type = objectString(part.object, "type") orelse continue;
+                    if (std.mem.eql(u8, part_type, "tool-call")) {
+                        if (wrote) try writer.writeByte(',');
+                        try writer.writeAll("{\"type\":\"function_call\",\"call_id\":");
+                        try std.json.Stringify.value(objectString(part.object, "toolCallId") orelse "", .{}, writer);
+                        try writer.writeAll(",\"name\":");
+                        try std.json.Stringify.value(objectString(part.object, "toolName") orelse "", .{}, writer);
+                        try writer.writeAll(",\"arguments\":");
+                        if (part.object.get("input")) |input| {
+                            if (input == .string) {
+                                try std.json.Stringify.value(input.string, .{}, writer);
+                            } else {
+                                var args: std.Io.Writer.Allocating = .init(alloc);
+                                defer args.deinit();
+                                try std.json.Stringify.value(input, .{}, &args.writer);
+                                try std.json.Stringify.value(args.written(), .{}, writer);
+                            }
+                        } else {
+                            try writer.writeAll("\"{}\"");
+                        }
+                        try writer.writeByte('}');
+                        wrote = true;
+                        continue;
+                    }
+                    if (std.mem.eql(u8, part_type, "text")) {
+                        if (wrote) try writer.writeByte(',');
+                        try writer.writeAll("{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":");
+                        try std.json.Stringify.value(objectString(part.object, "text") orelse "", .{}, writer);
+                        try writer.writeAll("}]}");
+                        wrote = true;
+                    }
+                }
+                if (wrote) return;
+            }
+        }
+    }
+
+    const text = messageText(object) orelse "";
+    const content_type: []const u8 = if (std.mem.eql(u8, role, "assistant")) "output_text" else "input_text";
+    const responses_role: []const u8 = if (std.mem.eql(u8, role, "assistant")) "assistant" else "user";
+    try writer.writeAll("{\"type\":\"message\",\"role\":");
+    try std.json.Stringify.value(responses_role, .{}, writer);
+    try writer.writeAll(",\"content\":[{\"type\":");
+    try std.json.Stringify.value(content_type, .{}, writer);
+    try writer.writeAll(",\"text\":");
+    try std.json.Stringify.value(text, .{}, writer);
+    try writer.writeAll("}]}");
+}
+
+fn messageText(object: std.json.ObjectMap) ?[]const u8 {
+    if (object.get("content")) |content| {
+        switch (content) {
+            .string => |text| return text,
+            .array => |parts| {
+                for (parts.items) |part| {
+                    if (part != .object) continue;
+                    const part_type = objectString(part.object, "type") orelse continue;
+                    if (std.mem.eql(u8, part_type, "text")) {
+                        return objectString(part.object, "text");
+                    }
+                    if (std.mem.eql(u8, part_type, "tool-result")) {
+                        if (part.object.get("output")) |output| {
+                            if (output == .object) return objectString(output.object, "value");
+                            if (output == .string) return output.string;
+                        }
+                    }
+                }
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn firstToolResultId(object: std.json.ObjectMap) ?[]const u8 {
+    const content = object.get("content") orelse return null;
+    if (content != .array) return null;
+    for (content.array.items) |part| {
+        if (part != .object) continue;
+        if (objectString(part.object, "toolCallId")) |id| return id;
+    }
+    return null;
+}
+
+fn toolResultText(object: std.json.ObjectMap) ?[]const u8 {
+    if (messageText(object)) |text| return text;
+    return objectString(object, "content");
+}
+
+fn resolveCallId(object: std.json.ObjectMap, state: *TranslateState) !?[]const u8 {
+    if (objectString(object, "call_id")) |call_id| return call_id;
+    if (objectString(object, "item_id")) |item_id| {
+        if (state.find(item_id)) |call| return call.call_id;
+        return item_id;
+    }
+    return null;
+}
+
+const JsonField = struct {
+    []const u8,
+    union(enum) { string: []const u8 },
+};
+
+fn writeObject(alloc: Allocator, fields: []const JsonField) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeByte('{');
+    for (fields, 0..) |field, i| {
+        if (i > 0) try out.writer.writeByte(',');
+        try std.json.Stringify.value(field[0], .{}, &out.writer);
+        try out.writer.writeByte(':');
+        try std.json.Stringify.value(field[1].string, .{}, &out.writer);
+    }
+    try out.writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn writeToolInputStart(alloc: Allocator, call_id: []const u8, name: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"type\":\"tool-input-start\",\"toolCallId\":");
+    try std.json.Stringify.value(call_id, .{}, &out.writer);
+    try out.writer.writeAll(",\"toolName\":");
+    try std.json.Stringify.value(name, .{}, &out.writer);
+    try out.writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn writeToolCall(alloc: Allocator, call_id: []const u8, name: []const u8, arguments: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"type\":\"tool-call\",\"toolCallId\":");
+    try std.json.Stringify.value(call_id, .{}, &out.writer);
+    try out.writer.writeAll(",\"toolName\":");
+    try std.json.Stringify.value(name, .{}, &out.writer);
+    try out.writer.writeAll(",\"input\":");
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments, .{}) catch {
+        try std.json.Stringify.value(arguments, .{}, &out.writer);
+        try out.writer.writeByte('}');
+        return out.toOwnedSlice();
+    };
+    defer parsed.deinit();
+    try std.json.Stringify.value(parsed.value, .{}, &out.writer);
+    try out.writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn writeFinish(alloc: Allocator, response: ?std.json.Value, reason: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"type\":\"finish\",\"finishReason\":{\"unified\":");
+    try std.json.Stringify.value(reason, .{}, &out.writer);
+    try out.writer.writeByte('}');
+    if (response) |value| {
+        if (value == .object) {
+            if (value.object.get("usage")) |usage| {
+                if (usage == .object) {
+                    try out.writer.writeAll(",\"usage\":{\"inputTokens\":{\"total\":");
+                    try writeTokenTotal(&out.writer, usage.object.get("input_tokens"));
+                    try out.writer.writeAll("},\"outputTokens\":{\"total\":");
+                    try writeTokenTotal(&out.writer, usage.object.get("output_tokens"));
+                    try out.writer.writeAll("}}");
+                }
+            }
+        }
+    }
+    try out.writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn writeTokenTotal(writer: *std.Io.Writer, value: ?std.json.Value) !void {
+    const total: i64 = if (value) |actual|
+        switch (actual) {
+            .integer => |integer| integer,
+            else => 0,
+        }
+    else
+        0;
+    try writer.print("{d}", .{if (total < 0) 0 else total});
+}
+
+fn objectString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    return switch (value) {
+        .string => |text| text,
+        else => null,
+    };
+}
+
+test "Codex chat URLs and model ids" {
+    try std.testing.expect(isCodexChatUrl(responses_url));
+    try std.testing.expect(isCodexChatUrl("http://127.0.0.1:9/codex/responses"));
+    try std.testing.expect(!isCodexChatUrl("https://ai-gateway.vercel.sh/v3/ai/language-model"));
+    try std.testing.expectEqualStrings(responses_url, effectiveChatUrl(.codex_oauth, "https://ai-gateway.vercel.sh/v3/ai/language-model"));
+    try std.testing.expectEqualStrings(
+        "http://127.0.0.1:9/codex/responses",
+        effectiveChatUrl(.codex_oauth, "http://127.0.0.1:9/codex/responses"),
+    );
+    try std.testing.expectEqualStrings("gpt-5.6-sol", wireModelId("openai/gpt-5.6-sol"));
+    try std.testing.expectEqualStrings("gpt-5.3-codex", wireModelId("gpt-5.3-codex"));
+    try std.testing.expectEqualStrings("gpt-5.6-sol", wireModelId("zai/glm-5.2"));
+    try std.testing.expectEqualStrings(default_model, resolvedModel(.codex_oauth, "zai/glm-5.2"));
+    try std.testing.expectEqualStrings("openai/gpt-5.3-codex", resolvedModel(.codex_oauth, "openai/gpt-5.3-codex"));
+    try std.testing.expectEqualStrings("zai/glm-5.2", resolvedModel(.ai_gateway_api_key, "zai/glm-5.2"));
+}
+
+test "gateway payload translates into a Responses request" {
+    const alloc = std.testing.allocator;
+    const payload =
+        \\{"prompt":[{"role":"system","content":"Be brief."},{"role":"user","content":[{"type":"text","text":"Hi"}]}],"tools":[{"type":"function","name":"read_file","description":"Read","inputSchema":{"type":"object","properties":{"path":{"type":"string"}}}}],"toolChoice":{"type":"auto"},"maxOutputTokens":32,"reasoning":"medium"}
+    ;
+    const body = try translateGatewayPayload(alloc, "openai/gpt-5.6-sol", payload, "session-1");
+    defer alloc.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"gpt-5.6-sol\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"instructions\":\"Be brief.\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"type\":\"input_text\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"parameters\":{\"type\":\"object\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"store\":false") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"prompt_cache_key\":\"session-1\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"effort\":\"medium\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"context\":\"all_turns\"") != null);
+}
+
+test "Responses SSE events project onto the Gateway stream contract" {
+    const alloc = std.testing.allocator;
+    var state: TranslateState = .{};
+    defer state.deinit(alloc);
+
+    const text = (try translateResponsesSseData(
+        alloc,
+        "{\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}",
+        &state,
+    )).?;
+    defer alloc.free(text);
+    try std.testing.expectEqualStrings("{\"type\":\"text-delta\",\"delta\":\"Hello\"}", text);
+
+    const start = (try translateResponsesSseData(
+        alloc,
+        "{\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"id\":\"item_1\",\"call_id\":\"call_1\",\"name\":\"read_file\"}}",
+        &state,
+    )).?;
+    defer alloc.free(start);
+    try std.testing.expect(std.mem.find(u8, start, "\"type\":\"tool-input-start\"") != null);
+    try std.testing.expect(std.mem.find(u8, start, "\"toolCallId\":\"call_1\"") != null);
+
+    const done = (try translateResponsesSseData(
+        alloc,
+        "{\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"a.txt\\\"}\"}}",
+        &state,
+    )).?;
+    defer alloc.free(done);
+    try std.testing.expect(std.mem.find(u8, done, "\"type\":\"tool-call\"") != null);
+    try std.testing.expect(std.mem.find(u8, done, "\"path\":\"a.txt\"") != null);
+
+    const finish = (try translateResponsesSseData(
+        alloc,
+        "{\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":9,\"output_tokens\":4}}}",
+        &state,
+    )).?;
+    defer alloc.free(finish);
+    try std.testing.expect(std.mem.find(u8, finish, "\"unified\":\"tool-calls\"") != null);
+    try std.testing.expect(std.mem.find(u8, finish, "\"total\":9") != null);
+}

--- a/src/core/mods/catalog.zig
+++ b/src/core/mods/catalog.zig
@@ -1,0 +1,332 @@
+const std = @import("std");
+const hooks = @import("../hooks/hooks.zig");
+const command = @import("command.zig");
+const manifest_mod = @import("manifest.zig");
+const tool_dispatch = @import("../tooling/tool_dispatch.zig");
+const tool_set_contract = @import("../tooling/tool_set.zig");
+
+pub const HookRegistration = struct {
+    pre_tool_use: []const hooks.PreToolUseHandler = &.{},
+    stop: []const hooks.StopHandler = &.{},
+    post_turn_end: []const hooks.PostTurnEndHandler = &.{},
+    attention_required: []const hooks.AttentionRequiredHandler = &.{},
+};
+
+pub const Contribution = struct {
+    tools: []const tool_dispatch.Tool = &.{},
+    advertised_tool_names: []const []const u8 = &.{},
+    read_only_tool_names: []const []const u8 = &.{},
+    commands: []const command.Command = &.{},
+    hooks: HookRegistration = .{},
+};
+
+pub const InitContext = struct {
+    allocator: std.mem.Allocator,
+    workspace_root: []const u8,
+};
+
+pub fn validateMod(comptime Mod: type) void {
+    if (!@hasDecl(Mod, "manifest")) {
+        @compileError("fx mod must declare `pub const manifest: fx.ModManifest`");
+    }
+    if (@TypeOf(Mod.manifest) != manifest_mod.Manifest) {
+        @compileError("fx mod `manifest` must have type fx.ModManifest");
+    }
+    manifest_mod.validate(Mod.manifest);
+
+    if (!@hasDecl(Mod, "contribution")) {
+        @compileError("fx mod must declare `pub const contribution: fx.ModContribution`");
+    }
+    if (@TypeOf(Mod.contribution) != Contribution) {
+        @compileError("fx mod `contribution` must have type fx.ModContribution");
+    }
+
+    if (@hasDecl(Mod, "State") != @hasDecl(Mod, "init")) {
+        @compileError("stateful fx mods must declare both `State` and `init`");
+    }
+    if (@hasDecl(Mod, "State") != @hasDecl(Mod, "deinit")) {
+        @compileError("stateful fx mods must declare `State`, `init`, and `deinit`");
+    }
+    if (@hasDecl(Mod, "State")) {
+        const init_info = @typeInfo(@TypeOf(Mod.init)).@"fn";
+        if (init_info.params.len != 1 or init_info.params[0].type == null or
+            init_info.params[0].type.? != InitContext or init_info.return_type == null)
+        {
+            @compileError("fx mod `init` must accept one fx.InitContext parameter and return its State (optionally through an error union)");
+        }
+        const init_return = init_info.return_type.?;
+        const init_payload = switch (@typeInfo(init_return)) {
+            .error_union => |error_union| error_union.payload,
+            else => init_return,
+        };
+        if (init_payload != Mod.State) {
+            @compileError("fx mod `init` must return its State or an error union containing its State");
+        }
+        const deinit_info = @typeInfo(@TypeOf(Mod.deinit)).@"fn";
+        if (deinit_info.params.len != 1 or deinit_info.params[0].type == null or
+            deinit_info.params[0].type.? != *Mod.State or deinit_info.return_type == null or
+            deinit_info.return_type.? != void)
+        {
+            @compileError("fx mod `deinit` must have signature fn (*State) void");
+        }
+    }
+}
+
+pub fn Catalog(comptime Mods: anytype) type {
+    comptime {
+        for (Mods) |Mod| validateMod(Mod);
+        validateUniqueNames(Mods);
+        validateContributions(Mods);
+    }
+
+    return struct {
+        pub const mods = Mods;
+        pub const tool_count = totalTools(Mods);
+        pub const advertised_tool_count = totalAdvertisedTools(Mods);
+        pub const read_only_tool_count = totalReadOnlyTools(Mods);
+        pub const command_count = totalCommands(Mods);
+
+        pub const tools = collectTools(Mods, tool_count);
+        pub const advertised_tool_names = collectNames(Mods, "advertised_tool_names", advertised_tool_count);
+        pub const read_only_tool_names = collectNames(Mods, "read_only_tool_names", read_only_tool_count);
+        pub const commands = collectCommands(Mods, command_count);
+
+        pub const registry = tool_dispatch.Registry{ .tools = tools[0..] };
+        pub const tool_set = tool_set_contract.ToolSet{
+            .registry = registry,
+            .order = advertised_tool_names[0..],
+            .read_only_tool_names = read_only_tool_names[0..],
+        };
+        pub const command_registry = command.Registry{ .commands = commands[0..] };
+
+        pub fn registerHooks(runtime: *hooks.Runtime) !void {
+            inline for (Mods) |Mod| {
+                inline for (Mod.contribution.hooks.pre_tool_use) |handler| try runtime.registerPreToolUse(handler);
+                inline for (Mod.contribution.hooks.stop) |handler| try runtime.registerStop(handler);
+                inline for (Mod.contribution.hooks.post_turn_end) |handler| try runtime.registerPostTurnEnd(handler);
+                inline for (Mod.contribution.hooks.attention_required) |handler| try runtime.registerAttentionRequired(handler);
+            }
+        }
+
+        pub fn States() type {
+            return StateTuple(Mods);
+        }
+
+        pub fn init(init_context: InitContext) !States() {
+            var states: States() = undefined;
+            var initialized: usize = 0;
+            errdefer deinitPrefix(&states, initialized);
+            inline for (Mods, 0..) |Mod, index| {
+                if (@hasDecl(Mod, "State")) {
+                    states[index] = try initOne(Mod, init_context);
+                } else {
+                    states[index] = {};
+                }
+                initialized = index + 1;
+            }
+            return states;
+        }
+
+        pub fn deinit(states: *States()) void {
+            deinitPrefix(states, Mods.len);
+        }
+
+        fn deinitPrefix(states: *States(), count: usize) void {
+            inline for (Mods, 0..) |Mod, index| {
+                if (@hasDecl(Mod, "State")) {
+                    if (index < count) Mod.deinit(&states[index]);
+                }
+            }
+        }
+    };
+}
+
+fn initOne(comptime Mod: type, init_context: InitContext) !Mod.State {
+    const result = Mod.init(init_context);
+    return switch (@typeInfo(@TypeOf(result))) {
+        .error_union => try result,
+        else => result,
+    };
+}
+
+fn StateTuple(comptime Mods: anytype) type {
+    var fields: [Mods.len]type = undefined;
+    inline for (Mods, 0..) |Mod, index| {
+        fields[index] = if (@hasDecl(Mod, "State")) Mod.State else void;
+    }
+    return std.meta.Tuple(&fields);
+}
+
+fn totalTools(comptime Mods: anytype) usize {
+    var count: usize = 0;
+    inline for (Mods) |Mod| count += Mod.contribution.tools.len;
+    return count;
+}
+
+fn totalAdvertisedTools(comptime Mods: anytype) usize {
+    var count: usize = 0;
+    inline for (Mods) |Mod| count += Mod.contribution.advertised_tool_names.len;
+    return count;
+}
+
+fn totalReadOnlyTools(comptime Mods: anytype) usize {
+    var count: usize = 0;
+    inline for (Mods) |Mod| count += Mod.contribution.read_only_tool_names.len;
+    return count;
+}
+
+fn totalCommands(comptime Mods: anytype) usize {
+    var count: usize = 0;
+    inline for (Mods) |Mod| count += Mod.contribution.commands.len;
+    return count;
+}
+
+fn collectTools(comptime Mods: anytype, comptime count: usize) [count]tool_dispatch.Tool {
+    var result: [count]tool_dispatch.Tool = undefined;
+    var index: usize = 0;
+    inline for (Mods) |Mod| {
+        inline for (Mod.contribution.tools) |tool| {
+            result[index] = tool;
+            index += 1;
+        }
+    }
+    return result;
+}
+
+fn collectCommands(comptime Mods: anytype, comptime count: usize) [count]command.Command {
+    var result: [count]command.Command = undefined;
+    var index: usize = 0;
+    inline for (Mods) |Mod| {
+        inline for (Mod.contribution.commands) |entry| {
+            result[index] = entry;
+            index += 1;
+        }
+    }
+    return result;
+}
+
+fn collectNames(comptime Mods: anytype, comptime field_name: []const u8, comptime count: usize) [count][]const u8 {
+    var result: [count][]const u8 = undefined;
+    var index: usize = 0;
+    inline for (Mods) |Mod| {
+        const values = @field(Mod.contribution, field_name);
+        inline for (values) |value| {
+            result[index] = value;
+            index += 1;
+        }
+    }
+    return result;
+}
+
+fn validateContributions(comptime Mods: anytype) void {
+    inline for (Mods) |Mod| {
+        inline for (Mod.contribution.advertised_tool_names) |name| {
+            if (!contributionHasTool(Mod.contribution, name)) {
+                @compileError(std.fmt.comptimePrint(
+                    "fx mod '{s}' advertises unknown tool '{s}'",
+                    .{ Mod.manifest.name, name },
+                ));
+            }
+        }
+        inline for (Mod.contribution.read_only_tool_names) |name| {
+            if (!contributionHasTool(Mod.contribution, name)) {
+                @compileError(std.fmt.comptimePrint(
+                    "fx mod '{s}' marks unknown tool '{s}' read-only",
+                    .{ Mod.manifest.name, name },
+                ));
+            }
+        }
+    }
+}
+
+fn contributionHasTool(comptime contribution: Contribution, comptime name: []const u8) bool {
+    inline for (contribution.tools) |tool| {
+        if (std.mem.eql(u8, tool.name, name)) return true;
+    }
+    return false;
+}
+
+fn validateUniqueNames(comptime Mods: anytype) void {
+    @setEvalBranchQuota(20000);
+    inline for (Mods, 0..) |Left, left_mod_index| {
+        inline for (Left.contribution.tools, 0..) |left, left_index| {
+            inline for (Mods, 0..) |Right, right_mod_index| {
+                inline for (Right.contribution.tools, 0..) |right, right_index| {
+                    if (right_mod_index < left_mod_index or
+                        (right_mod_index == left_mod_index and right_index <= left_index)) continue;
+                    if (std.mem.eql(u8, left.name, right.name)) {
+                        @compileError(std.fmt.comptimePrint(
+                            "duplicate fx tool name '{s}' in mods '{s}' and '{s}'",
+                            .{ left.name, Left.manifest.name, Right.manifest.name },
+                        ));
+                    }
+                }
+            }
+        }
+        inline for (Left.contribution.commands, 0..) |left, left_index| {
+            inline for (Mods, 0..) |Right, right_mod_index| {
+                inline for (Right.contribution.commands, 0..) |right, right_index| {
+                    if (right_mod_index < left_mod_index or
+                        (right_mod_index == left_mod_index and right_index <= left_index)) continue;
+                    if (std.mem.eql(u8, left.name, right.name)) {
+                        @compileError(std.fmt.comptimePrint(
+                            "duplicate fx command name '{s}' in mods '{s}' and '{s}'",
+                            .{ left.name, Left.manifest.name, Right.manifest.name },
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+const EmptyMod = struct {
+    pub const manifest: manifest_mod.Manifest = .{ .name = "empty", .version = "1.0.0" };
+    pub const contribution: Contribution = .{};
+};
+
+const CommandMod = struct {
+    fn run(_: command.Context, _: []const u8) !void {}
+
+    const commands = [_]command.Command{.{
+        .name = "fixture",
+        .description = "Fixture command",
+        .handler = run,
+    }};
+
+    pub const manifest: manifest_mod.Manifest = .{ .name = "commands", .version = "1.0.0" };
+    pub const contribution: Contribution = .{ .commands = &commands };
+};
+
+const StatefulMod = struct {
+    pub const State = struct { initialized: bool };
+
+    pub fn init(_: InitContext) !State {
+        return .{ .initialized = true };
+    }
+
+    pub fn deinit(state: *State) void {
+        state.initialized = false;
+    }
+
+    pub const manifest: manifest_mod.Manifest = .{ .name = "stateful", .version = "1.0.0" };
+    pub const contribution: Contribution = .{};
+};
+
+test "catalog composes native mod commands at comptime" {
+    const TestCatalog = Catalog(.{ EmptyMod, CommandMod });
+    try std.testing.expectEqual(@as(usize, 1), TestCatalog.command_count);
+    try std.testing.expectEqualStrings("fixture", TestCatalog.commands[0].name);
+    try std.testing.expectEqual(@as(usize, 0), TestCatalog.tool_count);
+}
+
+test "catalog initializes and deinitializes stateful mods" {
+    const TestCatalog = Catalog(.{ EmptyMod, StatefulMod });
+    var states = try TestCatalog.init(.{
+        .allocator = std.testing.allocator,
+        .workspace_root = "/tmp/workspace",
+    });
+    try std.testing.expect(states[1].initialized);
+    TestCatalog.deinit(&states);
+    try std.testing.expect(!states[1].initialized);
+}

--- a/src/core/mods/command.zig
+++ b/src/core/mods/command.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+
+pub const Context = struct {
+    allocator: std.mem.Allocator,
+    app: *anyopaque,
+};
+
+pub const Handler = *const fn (Context, []const u8) anyerror!void;
+
+pub const Command = struct {
+    name: []const u8,
+    description: []const u8,
+    handler: Handler,
+    accepts_payload: bool = true,
+};
+
+pub const Registry = struct {
+    commands: []const Command = &.{},
+
+    pub const Match = struct {
+        command: *const Command,
+        payload: []const u8,
+    };
+
+    pub fn match(self: Registry, input: []const u8) ?Match {
+        const trimmed = std.mem.trim(u8, input, " \t\r\n");
+        if (trimmed.len < 2 or trimmed[0] != '/') return null;
+
+        const token_end = std.mem.indexOfAny(u8, trimmed, " \t\r\n") orelse trimmed.len;
+        const token = trimmed[1..token_end];
+        const payload = std.mem.trim(u8, trimmed[token_end..], " \t\r\n");
+
+        for (self.commands) |*command| {
+            if (!std.mem.eql(u8, command.name, token)) continue;
+            if (!command.accepts_payload and payload.len != 0) return null;
+            return .{ .command = command, .payload = payload };
+        }
+        return null;
+    }
+
+    pub fn dispatch(self: Registry, context: Context, input: []const u8) !bool {
+        const matched = self.match(input) orelse return false;
+        try matched.command.handler(context, matched.payload);
+        return true;
+    }
+};
+
+fn fixtureHandler(_: Context, payload: []const u8) !void {
+    try std.testing.expectEqualStrings("production", payload);
+}
+
+test "native command registry matches and dispatches open slash commands" {
+    const commands = [_]Command{.{
+        .name = "deploy",
+        .description = "Deploy a workspace",
+        .handler = fixtureHandler,
+    }};
+    const registry = Registry{ .commands = &commands };
+    const matched = registry.match("/deploy production") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings("deploy", matched.command.name);
+    try std.testing.expectEqualStrings("production", matched.payload);
+    var marker: u8 = 0;
+    try std.testing.expect(try registry.dispatch(.{
+        .allocator = std.testing.allocator,
+        .app = @ptrCast(&marker),
+    }, "/deploy production"));
+    try std.testing.expect(!try registry.dispatch(.{
+        .allocator = std.testing.allocator,
+        .app = @ptrCast(&marker),
+    }, "/missing"));
+}

--- a/src/core/mods/manifest.zig
+++ b/src/core/mods/manifest.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+
+pub const current_api_version: u32 = 1;
+
+pub const Capabilities = packed struct {
+    workspace_read: bool = false,
+    workspace_write: bool = false,
+    terminal: bool = false,
+    network: bool = false,
+    secrets: bool = false,
+    clipboard: bool = false,
+    _reserved: u10 = 0,
+};
+
+pub const Manifest = struct {
+    name: []const u8,
+    version: []const u8,
+    description: []const u8 = "",
+    api_version: u32 = current_api_version,
+    capabilities: Capabilities = .{},
+};
+
+pub fn validate(comptime manifest: Manifest) void {
+    if (manifest.api_version != current_api_version) {
+        @compileError(std.fmt.comptimePrint(
+            "fx mod '{s}' targets API version {d}, but this fx build supports {d}",
+            .{ manifest.name, manifest.api_version, current_api_version },
+        ));
+    }
+    validateToken("mod name", manifest.name);
+    if (manifest.version.len == 0) @compileError("fx mod version must not be empty");
+}
+
+fn validateToken(comptime label: []const u8, comptime value: []const u8) void {
+    if (value.len == 0) @compileError(label ++ " must not be empty");
+    for (value) |byte| {
+        const valid = std.ascii.isAlphanumeric(byte) or byte == '.' or byte == '_' or byte == '-';
+        if (!valid) {
+            @compileError(std.fmt.comptimePrint(
+                "{s} '{s}' contains invalid byte 0x{x}",
+                .{ label, value, byte },
+            ));
+        }
+    }
+}
+
+test "manifest capabilities default to no ambient authority" {
+    const manifest = Manifest{ .name = "fixture", .version = "1.0.0" };
+    try std.testing.expect(!manifest.capabilities.workspace_read);
+    try std.testing.expect(!manifest.capabilities.workspace_write);
+    try std.testing.expect(!manifest.capabilities.terminal);
+    try std.testing.expect(!manifest.capabilities.network);
+    try std.testing.expect(!manifest.capabilities.secrets);
+    try std.testing.expect(!manifest.capabilities.clipboard);
+}

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -92,6 +92,7 @@ pub const CredentialSource = enum {
     ai_gateway_api_key,
     fx_login,
     stored_key,
+    codex_oauth,
 };
 
 pub fn parseCredentialSource(text: []const u8) ?CredentialSource {

--- a/src/default_distribution.zig
+++ b/src/default_distribution.zig
@@ -1,0 +1,9 @@
+const mod_api = @import("mod_api.zig");
+const builtin_mod = @import("builtins/mod.zig");
+
+pub const mods = .{builtin_mod};
+pub const Catalog = mod_api.Catalog(mods);
+
+pub const tool_registry = Catalog.registry;
+pub const tool_set = Catalog.tool_set;
+pub const native_command_registry = Catalog.command_registry;

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -6,6 +6,7 @@ const agent_stream_provider = @import("../core/agent/stream_provider.zig");
 const debug_trace = @import("../core/shared/debug_trace.zig");
 const io_mod = @import("../core/shared/io.zig");
 const types = @import("../core/shared/types.zig");
+const codex_protocol = @import("../core/gateway/codex_protocol.zig");
 
 pub fn isRetryableGatewayError(err: anyerror) bool {
     return err == error.HttpConnectionClosing or
@@ -1165,25 +1166,34 @@ fn streamGatewayCompletionCoreWithOptions(
     core_options: StreamCoreOptions,
 ) !StreamResult {
     const model = request.model;
-    const payload = request.payload;
     const retry_count = switch (request.provider_attempt_owner) {
         .agent => 1,
         .transport => request.retry_count,
     };
     const trace_ctx = request.trace_ctx;
     const request_url = try resolveE2eGatewayUrl(e2e_gateway_chat_url_env, request.chat_url);
+    const openai_codex = codex_protocol.isCodexChatUrl(request_url);
+    var owned_payload: ?[]u8 = null;
+    defer if (owned_payload) |bytes| alloc.free(bytes);
+    const payload = if (openai_codex) blk: {
+        owned_payload = try codex_protocol.translateGatewayPayload(
+            alloc,
+            model,
+            request.payload,
+            request.session_id,
+        );
+        break :blk owned_payload.?;
+    } else request.payload;
     const uri = try std.Uri.parse(request_url);
 
     const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.api_key});
     defer alloc.free(auth_header);
 
-    var extra_headers_buf: [9]std.http.Header = undefined;
-    const extra_headers = gatewayExtraHeaders(
-        &extra_headers_buf,
-        model,
-        request.team,
-        request.session_id,
-    );
+    var extra_headers_buf: [12]std.http.Header = undefined;
+    const extra_headers = if (openai_codex)
+        codexExtraHeaders(&extra_headers_buf, request.team, request.session_id)
+    else
+        gatewayExtraHeaders(extra_headers_buf[0..9], model, request.team, request.session_id);
 
     var attempt: usize = 0;
     var delivery_ambiguous = false;
@@ -1399,6 +1409,7 @@ fn streamGatewayCompletionCoreWithOptions(
             .{ .requested_model = model, .ctx = trace_ctx },
             expected_provider_tool_name,
             request.content_capture_limit,
+            openai_codex,
         ) catch |err| {
             debug_trace.eventf("gateway", "sse_consume_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
             return @as(anyerror!StreamResult, connectedIoFailure(
@@ -1487,6 +1498,34 @@ fn gatewayExtraHeaders(
             buf[len] = .{ .name = "x-session-id", .value = id };
             len += 1;
             buf[len] = .{ .name = "x-session-affinity", .value = id };
+            len += 1;
+        }
+    }
+    return buf[0..len];
+}
+
+fn codexExtraHeaders(
+    buf: []std.http.Header,
+    account_id: ?[]const u8,
+    session_id: ?[]const u8,
+) []const std.http.Header {
+    std.debug.assert(buf.len >= 5);
+    var len: usize = 0;
+    buf[len] = .{ .name = "Accept", .value = "text/event-stream" };
+    len += 1;
+    if (account_id) |account| {
+        if (account.len > 0) {
+            buf[len] = .{ .name = codex_protocol.account_header, .value = account };
+            len += 1;
+        }
+    }
+    if (session_id) |id| {
+        if (id.len > 0) {
+            buf[len] = .{ .name = "session-id", .value = id };
+            len += 1;
+            buf[len] = .{ .name = "thread-id", .value = id };
+            len += 1;
+            buf[len] = .{ .name = "x-client-request-id", .value = id };
             len += 1;
         }
     }
@@ -2715,7 +2754,7 @@ fn consumeSseStream(
     on_tool_start: ?ToolStartCallback,
     cancel_flag: *std.atomic.Value(bool),
 ) !types.GatewayCompletion {
-    return consumeSseStreamTraced(alloc, reader, callback_ctx, on_content_chunk, on_tool_start, null, null, cancel_flag, null, null, null);
+    return consumeSseStreamTraced(alloc, reader, callback_ctx, on_content_chunk, on_tool_start, null, null, cancel_flag, null, null, null, false);
 }
 
 /// Decodes an AI Gateway SSE response from a transport-owned reader.
@@ -2745,6 +2784,7 @@ pub fn consumeGatewaySseStream(
         null,
         null,
         content_capture_limit,
+        false,
     );
 }
 
@@ -2760,6 +2800,7 @@ fn consumeSseStreamTraced(
     resolved_model_trace: ?ResolvedModelTrace,
     expected_provider_tool_name: ?[]const u8,
     content_capture_limit: ?usize,
+    openai_codex: bool,
 ) !types.GatewayCompletion {
     var content_buf: std.ArrayList(u8) = .empty;
     defer content_buf.deinit(alloc);
@@ -2794,8 +2835,13 @@ fn consumeSseStreamTraced(
 
     var event_reader = SseEventReader{ .max_line_bytes = max_sse_event_line_bytes };
     defer event_reader.deinit(alloc);
+    var translate_state: ?codex_protocol.TranslateState = if (openai_codex) .{} else null;
+    defer if (translate_state) |*state| state.deinit(alloc);
 
     while (true) {
+        var owned_json: ?[]u8 = null;
+        defer if (owned_json) |bytes| alloc.free(bytes);
+
         if (cancel_flag.load(.seq_cst)) {
             traceSseTermination(resolved_model_trace, "cancellation", finish_reason_holder);
             break;
@@ -2805,7 +2851,14 @@ fn consumeSseStreamTraced(
         defer event_reader.releaseLine();
 
         const json_text = switch (event) {
-            .data => |json_text| json_text,
+            .data => |raw| blk: {
+                if (translate_state) |*state| {
+                    const translated = (try codex_protocol.translateResponsesSseData(alloc, raw, state)) orelse continue;
+                    owned_json = translated;
+                    break :blk translated;
+                }
+                break :blk raw;
+            },
             .done => {
                 traceSseTermination(resolved_model_trace, "done_without_finish", finish_reason_holder);
                 break;

--- a/src/main.zig
+++ b/src/main.zig
@@ -3767,6 +3767,8 @@ test {
     _ = @import("core/auth/login_flow.zig");
     _ = @import("core/auth/oauth.zig");
     _ = @import("core/auth/oauth_session.zig");
+    _ = @import("core/auth/codex_oauth.zig");
+    _ = @import("core/gateway/codex_protocol.zig");
     _ = @import("core/workspace/file_index.zig");
     _ = @import("core/gateway/gateway_json.zig");
     _ = @import("core/github/git_context.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -107,7 +107,7 @@ const session_runtime = @import("core/session/session.zig");
 const session_codec = @import("core/session/session_codec.zig");
 const session_child_store = @import("core/session/session_child_store.zig");
 const session_log = @import("core/session/session_log.zig");
-const builtin_tools = @import("builtins/tools.zig");
+const default_distribution = @import("default_distribution.zig");
 const browser_workspace_tools = @import("builtins/browser_workspace_tools.zig");
 const tool_admission = @import("core/tooling/tool_admission.zig");
 const tool_advertisement = @import("core/tooling/tool_advertisement.zig");
@@ -649,8 +649,9 @@ const App = struct {
     }
 
     pub fn configureNotifications(self: *App) !void {
-        // Register herdr hooks before NotificationAppRuntime.configure freezes
-        // the lifecycle runtime (its call to freeze() is the sole freeze site).
+        // Register distribution and first-party hooks before
+        // NotificationAppRuntime.configure freezes the lifecycle runtime.
+        try default_distribution.Catalog.registerHooks(&self.lifecycle_runtime);
         try HerdrAppRuntime.configure(self, SessionAppRuntime.activeSessionId(self));
         try NotificationAppRuntime.configure(self);
     }
@@ -974,6 +975,10 @@ const App = struct {
     }
 
     pub fn handleCommand(self: *App, cmd: []const u8) !void {
+        if (try default_distribution.native_command_registry.dispatch(.{
+            .allocator = self.alloc,
+            .app = self,
+        }, cmd)) return;
         try app_commands.Handlers(App).route(self, cmd);
     }
 
@@ -1399,7 +1404,7 @@ const App = struct {
 
     fn effectiveToolSet(self: *const App) tool_set_contract.ToolSet {
         if (comptime host_profile.tools) {
-            return builtin_tools.advertisement_set;
+            return default_distribution.tool_set;
         }
         return browser_workspace_tools.selectToolSet(
             false,
@@ -3177,12 +3182,12 @@ test "native app preserves the built-in tool set without workspace metadata" {
     try std.testing.expect(app.workspaceHostInfo() == null);
 
     const registry = app.toolRegistry();
-    try std.testing.expect(registry.tools.ptr == builtin_tools.registry.tools.ptr);
-    try std.testing.expectEqual(builtin_tools.registry.tools.len, registry.tools.len);
+    try std.testing.expect(registry.tools.ptr == default_distribution.tool_registry.tools.ptr);
+    try std.testing.expectEqual(default_distribution.tool_registry.tools.len, registry.tools.len);
 
     const advertised = app.toolAdvertisementSet();
-    try std.testing.expect(advertised.order.ptr == builtin_tools.advertisement_set.order.ptr);
-    try std.testing.expectEqual(builtin_tools.advertisement_set.order.len, advertised.order.len);
+    try std.testing.expect(advertised.order.ptr == default_distribution.tool_set.order.ptr);
+    try std.testing.expectEqual(default_distribution.tool_set.order.len, advertised.order.len);
 }
 
 fn fullEntryConfig() app_entry_runtime.Config {
@@ -3212,7 +3217,7 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .max_history_turns = max_history_turns,
         .context_registry = default_context_registry,
         .mode_registry = builtin_modes.registry,
-        .tool_set = builtin_tools.advertisement_set,
+        .tool_set = default_distribution.tool_set,
         .inspect_mcp_profile_config = builtin_mcp.inspectProfileConfig,
         .load_mcp_runtime = builtin_mcp.loadRuntime,
         .acp_runner = .{ .run_fn = runAcpServer },
@@ -3248,7 +3253,7 @@ fn localEntryConfig() app_entry_runtime.Config {
         .max_history_turns = 0,
         .context_registry = default_context_registry,
         .mode_registry = builtin_modes.registry,
-        .tool_set = builtin_tools.advertisement_set,
+        .tool_set = default_distribution.tool_set,
         .inspect_mcp_profile_config = builtin_mcp.inspectProfileConfig,
         .load_mcp_runtime = builtin_mcp.loadRuntime,
         .acp_runner = .{ .run_fn = runAcpServer },
@@ -3283,7 +3288,7 @@ fn emptyEntryConfig() app_entry_runtime.Config {
         .max_history_turns = 0,
         .context_registry = default_context_registry,
         .mode_registry = builtin_modes.registry,
-        .tool_set = builtin_tools.advertisement_set,
+        .tool_set = default_distribution.tool_set,
         .inspect_mcp_profile_config = builtin_mcp.inspectProfileConfig,
         .load_mcp_runtime = builtin_mcp.loadRuntime,
         .acp_runner = .{ .run_fn = runAcpServer },
@@ -3753,6 +3758,9 @@ test {
     _ = @import("core/shared/collections.zig");
     _ = @import("core/slash_commands/command_router.zig");
     _ = @import("core/slash_commands/command_specs.zig");
+    _ = @import("core/mods/catalog.zig");
+    _ = @import("core/mods/command.zig");
+    _ = @import("core/mods/manifest.zig");
     _ = @import("core/config/config_runtime.zig");
     _ = @import("ui/footer/appearance_menu_presentation.zig");
     _ = @import("ui/footer/compact_command_menu_presentation.zig");
@@ -3768,6 +3776,7 @@ test {
     _ = @import("core/auth/oauth.zig");
     _ = @import("core/auth/oauth_session.zig");
     _ = @import("core/auth/codex_oauth.zig");
+    _ = @import("core/auth/codex_login.zig");
     _ = @import("core/gateway/codex_protocol.zig");
     _ = @import("core/workspace/file_index.zig");
     _ = @import("core/gateway/gateway_json.zig");

--- a/src/mod_api.zig
+++ b/src/mod_api.zig
@@ -1,0 +1,22 @@
+pub const manifest = @import("core/mods/manifest.zig");
+pub const command = @import("core/mods/command.zig");
+pub const catalog = @import("core/mods/catalog.zig");
+pub const hooks = @import("core/hooks/hooks.zig");
+pub const tooling = @import("core/tooling/tool_dispatch.zig");
+
+pub const api_version = manifest.current_api_version;
+pub const Capabilities = manifest.Capabilities;
+pub const ModManifest = manifest.Manifest;
+pub const ModContribution = catalog.Contribution;
+pub const HookRegistration = catalog.HookRegistration;
+pub const InitContext = catalog.InitContext;
+pub const NativeCommand = command.Command;
+pub const NativeCommandContext = command.Context;
+pub const NativeCommandRegistry = command.Registry;
+pub const Tool = tooling.Tool;
+pub const ToolResult = tooling.ToolResult;
+pub const ToolInput = tooling.ToolInput;
+pub const ToolContext = tooling.DispatchContext;
+
+pub const Catalog = catalog.Catalog;
+pub const validateMod = catalog.validateMod;

--- a/src/mod_api/mod.zig
+++ b/src/mod_api/mod.zig
@@ -1,0 +1,22 @@
+pub const manifest = @import("../core/mods/manifest.zig");
+pub const command = @import("../core/mods/command.zig");
+pub const catalog = @import("../core/mods/catalog.zig");
+pub const hooks = @import("../core/hooks/hooks.zig");
+pub const tooling = @import("../core/tooling/tool_dispatch.zig");
+
+pub const api_version = manifest.current_api_version;
+pub const Capabilities = manifest.Capabilities;
+pub const ModManifest = manifest.Manifest;
+pub const ModContribution = catalog.Contribution;
+pub const HookRegistration = catalog.HookRegistration;
+pub const InitContext = catalog.InitContext;
+pub const NativeCommand = command.Command;
+pub const NativeCommandContext = command.Context;
+pub const NativeCommandRegistry = command.Registry;
+pub const Tool = tooling.Tool;
+pub const ToolResult = tooling.ToolResult;
+pub const ToolInput = tooling.ToolInput;
+pub const ToolContext = tooling.DispatchContext;
+
+pub const Catalog = catalog.Catalog;
+pub const validateMod = catalog.validateMod;

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -1814,7 +1814,8 @@ test "partially visible auth picker shows a source window without duplicates" {
     scrolled_view.selected_choice = .{ .source = .stored_key };
     var scrolled_first = try composeAuthPickerRow(alloc, scrolled_view, 1, 3, 80);
     defer scrolled_first.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, scrolled_first.items, "fx login") != null);
+    try std.testing.expect(std.mem.find(u8, scrolled_first.items, credentials.sourceLabel(.codex_oauth)) != null);
+    try std.testing.expect(std.mem.find(u8, scrolled_first.items, "fx login") == null);
 
     var scrolled_selected = try composeAuthPickerRow(alloc, scrolled_view, 2, 3, 80);
     defer scrolled_selected.deinit(alloc);


### PR DESCRIPTION
## Summary

- Load ChatGPT OAuth from the shared Codex `~/.codex/auth.json` (or `CODEX_HOME` / `FX_CODEX_AUTH_FILE`), including refresh against `auth.openai.com`.
- When that credential is selected, send Responses requests to `https://chatgpt.com/backend-api/codex/responses` instead of the Vercel AI Gateway.
- Add `fx login --codex` to sign in with ChatGPT Codex through a device code and write the resulting tokens to `~/.codex/auth.json`, so fx can reach OpenAI Codex without a pre-existing Codex login. `fx login` keeps its Vercel default.
- Add `fx logout --codex` to sign out of ChatGPT Codex. It revokes the stored refresh token against `auth.openai.com` (best-effort) and removes the `tokens` object from `~/.codex/auth.json`, preserving the surrounding auth file. `fx logout` keeps its Vercel default.
- Add a native mod API so Zig distributions can contribute tools, native slash commands, and typed lifecycle hooks at compile time. The default distribution now registers the first-party builtin tools and commands through this catalog; `handleCommand` routes to native commands and `configureNotifications` registers their hooks.
- Keep Vercel credentials first in precedence; pick Codex from the credential hub when more than one source is present.

## Test plan

- [x] `zig build test`
- [x] `zig fmt --check src/`
- [x] `./zig-out/bin/fx doctor` reports `auth=Codex OAuth (~/.codex)`
- [x] `./zig-out/bin/fx ask --no-save --json -- "Reply with exactly the word pong and nothing else."` returns `pong` via `openai/gpt-5.6-sol`
- [x] `./zig-out/bin/fx login --help` shows the `login [--codex]` usage and `--codex` option
- [x] `./zig-out/bin/fx logout --help` shows the `logout [--codex]` usage and `--codex` option
- [x] `./zig-out/bin/fx login --codex` issues a device code against auth.openai.com and polls for authorization
- [x] `./zig-out/bin/fx logout --codex` removes tokens from `~/.codex/auth.json` and preserves surrounding fields
- [ ] Full CI on this commit