### PR TITLE
Omit full-window output limits from agent requests

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1708,6 +1708,30 @@ fn requiresResolvedRequestCapabilities(
         (fast_mode and !available.supports_fast_mode);
 }
 
+fn request_max_output_tokens(capabilities: model_capabilities.Capabilities) ?u32 {
+    const max_output_tokens = capabilities.max_output_tokens orelse return null;
+    const context_window = capabilities.context_window orelse return max_output_tokens;
+    if (max_output_tokens >= context_window) return null;
+    return max_output_tokens;
+}
+
+test "request output limit follows capability bounds" {
+    const cases = [_]struct {
+        capabilities: model_capabilities.Capabilities,
+        expected: ?u32,
+    }{
+        .{ .capabilities = .{}, .expected = null },
+        .{ .capabilities = .{ .max_output_tokens = 32_000 }, .expected = 32_000 },
+        .{ .capabilities = .{ .context_window = 256_000 }, .expected = null },
+        .{ .capabilities = .{ .context_window = 256_000, .max_output_tokens = 32_000 }, .expected = 32_000 },
+        .{ .capabilities = .{ .context_window = 1_048_576, .max_output_tokens = 1_048_576 }, .expected = null },
+        .{ .capabilities = .{ .context_window = 128_000, .max_output_tokens = 256_000 }, .expected = null },
+    };
+    for (cases) |case| {
+        try std.testing.expectEqual(case.expected, request_max_output_tokens(case.capabilities));
+    }
+}
+
 fn processQueuedPromptInner(
     deps: *const AgentRuntimeDeps,
     semantic_presentation: ?runtime_assistant_stream.SemanticPresentationSink,
@@ -2621,7 +2645,7 @@ fn processQueuedPromptLoop(
                         selected_dynamic_tool_schemas.items,
                     .vision_mode = vision_mode,
                     .provider_options = provider_opts,
-                    .max_output_tokens = request_capabilities.max_output_tokens,
+                    .max_output_tokens = request_max_output_tokens(request_capabilities),
                     .budget = .{ .cancel_flag = config.cancel_flag },
                 },
             ) catch |err| {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -2539,6 +2539,48 @@ test "processQueuedPrompt uses one available capability snapshot for history and
     try expectBodyContains(&gateway, 0, "\"maxOutputTokens\":16000");
 }
 
+test "processQueuedPrompt projects bounded output limits into gateway requests" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        context_window: ?u32,
+        max_output_tokens: ?u32,
+        expected_json: ?[]const u8,
+    }{
+        .{ .context_window = 256_000, .max_output_tokens = 32_000, .expected_json = "\"maxOutputTokens\":32000" },
+        .{ .context_window = 1_048_576, .max_output_tokens = 1_048_576, .expected_json = null },
+    };
+
+    for (cases) |case| {
+        const available_overrides = [_]ModelCapabilityOverride{.{
+            .model = "provider/model",
+            .capabilities = .{
+                .context_window = case.context_window,
+                .max_output_tokens = case.max_output_tokens,
+            },
+        }};
+        const completions = [_]FakeCompletion{.{ .content = "Done" }};
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        hooks.available_capability_overrides = &available_overrides;
+        defer hooks.deinit();
+        var fixture = PromptFixture{};
+        var job = fixture.job();
+        job.model = @constCast("provider/model");
+
+        try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+
+        try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
+        if (case.expected_json) |expected| {
+            try expectBodyContains(&gateway, 0, expected);
+        } else {
+            try expectBodyNotContains(&gateway, 0, "\"maxOutputTokens\"");
+        }
+        try std.testing.expectEqual(case.context_window, available_overrides[0].capabilities.context_window);
+        try std.testing.expectEqual(case.max_output_tokens, available_overrides[0].capabilities.max_output_tokens);
+    }
+}
+
 test "processQueuedPrompt resolves catalog capabilities for opaque effort" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -1401,6 +1401,51 @@ async function launchRouteRecoveryTui(
 
 describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
   test(
+    "full-window output limit is omitted from the agent request",
+    async () => {
+      const model = "meta/muse-spark-1.2-contributor";
+      const finalText = "Full-window output limit omitted.";
+      const { queuedGateway, stderrPath } = await launchRouteRecoveryTui(
+        "fx-tui-full-window-output-limit-",
+        [fakeGatewayFinalText(finalText)],
+        {
+          model,
+          models: [{
+            id: model,
+            type: "language",
+            tags: ["reasoning", "tool-use", "implicit-caching", "file-input", "vision"],
+            context_window: 1_048_576,
+            max_tokens: 1_048_576,
+          }],
+          settings: { model },
+        },
+      );
+      await waitForCondition(
+        () => queuedGateway.modelRequests.length === 1,
+        "full-window model catalog",
+      );
+
+      await session!.sendText("hi");
+      await session!.waitForText(finalText, TIMEOUT);
+      await session!.waitForComposer(TIMEOUT);
+
+      expect(queuedGateway.modelRequests).toHaveLength(1);
+      expect(queuedGateway.requests).toHaveLength(1);
+      expect(JSON.parse(queuedGateway.requests[0]!.body)).not.toHaveProperty(
+        "maxOutputTokens",
+      );
+      expect(session!.isAlive()).toBe(true);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+      await session!.sendText("/quit");
+      expect(await session!.waitForSessionEnd(TIMEOUT)).toBe(true);
+      await session!.kill();
+      session = null;
+    },
+    TIMEOUT * 2,
+  );
+
+  test(
     "live token counter includes submitted input, reasoning, and streamed text",
     async () => {
       const hold: TokenProgressHoldState = { started: false, cancelled: false };


### PR DESCRIPTION
## Summary

- Omit output limits that consume a model's full context window from agent requests.
- Preserve smaller output limits and catalog metadata used by history, diagnostics, and model menus.

## Context

- Resolves #106.
- Supersedes #107. Thanks @Chinteyley for the report, diagnosis, and initial patch.