### PR TITLE
Add Nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ It's open source (Apache-2.0), model-agnostic, and suitable for both local and c
 curl -fsSL https://fx.sh/setup.sh | bash
 ```
 
+With Nix: `nix profile add github:vercel-labs/fx`
+
 ## Run fx
 
 To get started, sign in with Vercel:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786920013,
+        "narHash": "sha256-tlbRqzZ3suDUO3vyR0QFBk0TrxJiRP50t7VWfHhtVrw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "33da5f36e599b50aa7dbbfacb718254423b18354",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,12 @@
               in
               pkgs.lib.removeSuffix "\";" (pkgs.lib.removePrefix "pub const version = \"" line);
             src = ./.;
+            # Build/install phases come from the nixpkgs zig setup hook, which
+            # runs `zig build` / `zig build install` when build.zig is present.
             nativeBuildInputs = [ pkgs.makeBinaryWrapper pkgs.zig ];
+            doInstallCheck = true;
+            nativeInstallCheckInputs = [ pkgs.versionCheckHook ];
+            versionCheckProgramArg = "--version";
             postInstall = ''
               install -Dm444 LICENSE "$out/share/licenses/fx/LICENSE"
               install -Dm444 THIRD_PARTY_NOTICES.md "$out/share/licenses/fx/THIRD_PARTY_NOTICES.md"

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,13 @@
         in
         {
           default = pkgs.stdenv.mkDerivation {
-            name = "fx";
+            pname = "fx";
+            version =
+              let
+                line = pkgs.lib.findFirst (pkgs.lib.hasPrefix "pub const version = ") null
+                  (pkgs.lib.splitString "\n" (builtins.readFile ./src/main.zig));
+              in
+              pkgs.lib.removeSuffix "\";" (pkgs.lib.removePrefix "pub const version = \"" line);
             src = ./.;
             nativeBuildInputs = [ pkgs.makeBinaryWrapper pkgs.zig ];
             postInstall = ''

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
               install -Dm444 LICENSE "$out/share/licenses/fx/LICENSE"
               install -Dm444 THIRD_PARTY_NOTICES.md "$out/share/licenses/fx/THIRD_PARTY_NOTICES.md"
             '';
-            postFixup = "wrapProgram $out/bin/fx --set FX_AUTO_UPGRADE 0";
+            postFixup = "wrapProgram $out/bin/fx --set-default FX_AUTO_UPGRADE 0";
             meta = {
               license = pkgs.lib.licenses.asl20;
               mainProgram = "fx";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
+      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = eachSystem (pkgs: {
+        default = pkgs.stdenv.mkDerivation {
+          name = "fx";
+          src = ./.;
+          nativeBuildInputs = [ pkgs.makeBinaryWrapper pkgs.zig_0_16 ];
+          postFixup = "wrapProgram $out/bin/fx --set FX_AUTO_UPGRADE 0";
+          meta.mainProgram = "fx";
+        };
+      });
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell { packages = [ pkgs.zig_0_16 ]; };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,23 +1,28 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
 
-  outputs = { nixpkgs, ... }:
-    let
-      systems = [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
-      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
-    in
-    {
-      packages = eachSystem (pkgs: {
-        default = pkgs.stdenv.mkDerivation {
-          name = "fx";
-          src = ./.;
-          nativeBuildInputs = [ pkgs.makeBinaryWrapper pkgs.zig_0_16 ];
-          postFixup = "wrapProgram $out/bin/fx --set FX_AUTO_UPGRADE 0";
-          meta.mainProgram = "fx";
-        };
-      });
-      devShells = eachSystem (pkgs: {
-        default = pkgs.mkShell { packages = [ pkgs.zig_0_16 ]; };
-      });
-    };
+  outputs = { nixpkgs, ... }: {
+    packages = nixpkgs.lib.genAttrs
+      [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ]
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.stdenv.mkDerivation {
+            name = "fx";
+            src = ./.;
+            nativeBuildInputs = [ pkgs.makeBinaryWrapper pkgs.zig ];
+            postInstall = ''
+              install -Dm444 LICENSE "$out/share/licenses/fx/LICENSE"
+              install -Dm444 THIRD_PARTY_NOTICES.md "$out/share/licenses/fx/THIRD_PARTY_NOTICES.md"
+            '';
+            postFixup = "wrapProgram $out/bin/fx --set FX_AUTO_UPGRADE 0";
+            meta = {
+              license = pkgs.lib.licenses.asl20;
+              mainProgram = "fx";
+            };
+          };
+        });
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,11 @@
             '';
             postFixup = "wrapProgram $out/bin/fx --set-default FX_AUTO_UPGRADE 0";
             meta = {
+              description = "Tiny, open, embeddable, native coding agent";
+              homepage = "https://fx.sh";
               license = pkgs.lib.licenses.asl20;
               mainProgram = "fx";
+              platforms = [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
             };
           };
         });


### PR DESCRIPTION
## Why

Let Nix users install fx through Nix.

## What changed

- Adds a package-only flake for Linux and macOS on x86_64 and ARM64.
- Disables automatic updates because Nix owns the installed files.
- Documents `nix profile add github:vercel-labs/fx`.

## Pin choice

The lock uses the final nixpkgs branch supporting Intel macOS, matching fx's platform support without another package source.
