### PR TITLE
Fall back from unsupported login shells

### DIFF
--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -1102,10 +1102,14 @@ const SupportedRegistry = struct {
             );
             return self.failure(
                 .start,
-                if (err == error.CapacityExceeded)
-                    .capacity_exceeded
-                else
-                    .authority_denied,
+                switch (err) {
+                    error.CapacityExceeded => .capacity_exceeded,
+                    error.MissingLoginShell => .shell_unavailable,
+                    error.RelativeShellPath,
+                    error.UnsupportedShell,
+                    => .invalid_request,
+                    else => .authority_denied,
+                },
                 null,
             );
         };
@@ -3193,11 +3197,9 @@ const Session = struct {
         persistence: contracts.StartPersistence,
     ) !Session {
         var login_shell_buffer: [4096]u8 = undefined;
-        const shell_path = switch (request.shell) {
-            .user_login => shell_resolver.configuredLoginShellInto(&login_shell_buffer) orelse "",
-            .executable => |value| value.path,
-        };
-        const shell = try alloc.dupe(u8, shell_path);
+        const configured = shell_resolver.configuredLoginShellInto(&login_shell_buffer);
+        const invocation = try shell_resolver.resolve(configured, request.shell);
+        const shell = try alloc.dupe(u8, invocation.path);
         errdefer alloc.free(shell);
         const cwd = try alloc.dupe(u8, request.cwd);
         errdefer alloc.free(cwd);
@@ -3372,13 +3374,10 @@ const Session = struct {
         durable_root: []const u8,
         transport_root: []const u8,
     ) !void {
-        var login_shell_buffer: [4096]u8 = undefined;
-        const configured = shell_resolver.configuredLoginShellInto(&login_shell_buffer);
-        var invocation = try shell_resolver.resolve(configured, request.shell);
-        if (!std.mem.eql(u8, self.shell, invocation.path)) {
-            self.alloc.free(self.shell);
-            self.shell = try self.alloc.dupe(u8, invocation.path);
-        }
+        var invocation = try shell_resolver.resolve(
+            null,
+            pinnedShell(request.shell, self.shell),
+        );
 
         const executable = try std.process.executablePathAlloc(
             io_mod.getIo(),
@@ -3705,16 +3704,10 @@ const Session = struct {
     }
 
     fn launchNative(self: *Session, request: contracts.StartRequest) !void {
-        var login_shell_buffer: [4096]u8 = undefined;
-        const configured = shell_resolver.configuredLoginShellInto(&login_shell_buffer);
         var invocation = try shell_resolver.resolve(
-            configured,
-            request.shell,
+            null,
+            pinnedShell(request.shell, self.shell),
         );
-        if (!std.mem.eql(u8, self.shell, invocation.path)) {
-            self.alloc.free(self.shell);
-            self.shell = try self.alloc.dupe(u8, invocation.path);
-        }
 
         var nonce_bytes: [16]u8 = undefined;
         io_mod.getIo().random(&nonce_bytes);
@@ -4724,6 +4717,19 @@ const Session = struct {
         return true;
     }
 };
+
+fn pinnedShell(
+    requested: contracts.ShellSpec,
+    resolved_path: []const u8,
+) contracts.ShellSpec {
+    return .{ .executable = .{
+        .path = resolved_path,
+        .clean_start = switch (requested) {
+            .user_login => false,
+            .executable => |value| value.clean_start,
+        },
+    } };
+}
 
 fn screenAction(
     session: *Session,

--- a/src/core/terminal/shell_resolver.zig
+++ b/src/core/terminal/shell_resolver.zig
@@ -14,6 +14,26 @@ pub const ResolveError = error{
 pub const Profile = command_environment.Profile;
 pub const Environment = command_environment.Environment;
 
+const ShellKind = enum { bash, zsh };
+
+fn shellKind(path: []const u8) ?ShellKind {
+    const basename = std.fs.path.basename(path);
+    if (std.mem.eql(u8, basename, "bash")) return .bash;
+    if (std.mem.eql(u8, basename, "zsh")) return .zsh;
+    return null;
+}
+
+fn fallbackLoginShell() []const u8 {
+    return if (builtin.os.tag == .macos) "/bin/zsh" else "/bin/bash";
+}
+
+fn supportedLoginShell(configured_login_shell: ?[]const u8) ResolveError![]const u8 {
+    const path = configured_login_shell orelse return error.MissingLoginShell;
+    if (!std.fs.path.isAbsolute(path)) return error.RelativeShellPath;
+    if (shellKind(path) != null) return path;
+    return fallbackLoginShell();
+}
+
 pub const Invocation = struct {
     path: []const u8,
     values: [6][]const u8 = @splat(""),
@@ -44,7 +64,7 @@ pub fn resolve(
     };
     const selection: Selection = switch (shell) {
         .user_login => .{
-            .path = configured_login_shell orelse return error.MissingLoginShell,
+            .path = try supportedLoginShell(configured_login_shell),
             .clean_start = false,
         },
         .executable => |value| .{
@@ -56,13 +76,7 @@ pub fn resolve(
         return error.RelativeShellPath;
     }
 
-    const kind: enum { bash, zsh } =
-        if (std.mem.eql(u8, std.fs.path.basename(selection.path), "bash"))
-            .bash
-        else if (std.mem.eql(u8, std.fs.path.basename(selection.path), "zsh"))
-            .zsh
-        else
-            return error.UnsupportedShell;
+    const kind = shellKind(selection.path) orelse return error.UnsupportedShell;
 
     var result = Invocation{ .path = selection.path };
     result.append(selection.path);
@@ -116,10 +130,10 @@ pub fn environment(
     profile: ?Profile,
 ) (ResolveError || Allocator.Error)!Environment {
     const selected = profile orelse .user;
-    const path = configured_login_shell orelse return error.MissingLoginShell;
-    _ = try resolve(path, switch (selected) {
+    const path = try supportedLoginShell(configured_login_shell);
+    _ = try resolve(null, switch (selected) {
         .clean => .{ .executable = .{ .path = path, .clean_start = true } },
-        .user => .user_login,
+        .user => .{ .executable = .{ .path = path } },
     });
     return switch (selected) {
         .clean => .{ .clean = try alloc.dupe(u8, path) },
@@ -134,14 +148,22 @@ pub fn profileShell(
 ) (ResolveError || Allocator.Error)!contracts.ShellSpec {
     return switch (profile) {
         .clean => blk: {
-            const path = configured_login_shell orelse return error.MissingLoginShell;
-            _ = try resolve(path, .{ .executable = .{ .path = path, .clean_start = true } });
+            const path = try supportedLoginShell(configured_login_shell);
+            _ = try resolve(null, .{ .executable = .{ .path = path, .clean_start = true } });
             break :blk .{ .executable = .{
                 .path = try alloc.dupe(u8, path),
                 .clean_start = true,
             } };
         },
-        .user => .user_login,
+        .user => blk: {
+            const configured = configured_login_shell orelse
+                break :blk .user_login;
+            const path = try supportedLoginShell(configured);
+            if (std.mem.eql(u8, path, configured)) break :blk .user_login;
+            break :blk .{ .executable = .{
+                .path = try alloc.dupe(u8, path),
+            } };
+        },
     };
 }
 
@@ -331,6 +353,29 @@ test "resolver rejects missing relative and unsupported shells" {
     );
 }
 
+test "login shell resolution falls back without accepting explicit unsupported shells" {
+    const fallback = try resolve("/opt/homebrew/bin/fish", .user_login);
+    try std.testing.expectEqualStrings(fallbackLoginShell(), fallback.path);
+    if (builtin.os.tag == .macos) {
+        try std.testing.expectEqualSlices(
+            []const u8,
+            &.{ "/bin/zsh", "-l", "-i" },
+            fallback.argv(),
+        );
+    } else {
+        try std.testing.expectEqualSlices(
+            []const u8,
+            &.{ "/bin/bash", "--login", "-i" },
+            fallback.argv(),
+        );
+    }
+
+    try std.testing.expectError(
+        error.UnsupportedShell,
+        resolve(null, .{ .executable = .{ .path = "/opt/homebrew/bin/fish" } }),
+    );
+}
+
 test "captured profiles use exact non-PTY argv" {
     const bash_clean = try capturedInvocation(.{ .clean = "/bin/bash" }, "printf clean");
     try std.testing.expectEqualSlices(
@@ -380,6 +425,32 @@ test "profile normalization defaults captured and persistent execution to user" 
     try std.testing.expectEqualStrings(
         "/bin/zsh",
         (try profileShell(arena, "/bin/zsh", .clean)).executable.path,
+    );
+}
+
+test "unsupported login shell profiles fall back for captured and persistent execution" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const fallback = fallbackLoginShell();
+    const user_environment = try environment(arena, "/opt/homebrew/bin/fish", .user);
+    const clean_environment = try environment(arena, "/opt/homebrew/bin/fish", .clean);
+    try std.testing.expect(user_environment.eql(.{ .user = fallback }));
+    try std.testing.expect(clean_environment.eql(.{ .clean = fallback }));
+
+    const user_invocation = try capturedInvocation(user_environment, "printf user");
+    const clean_invocation = try capturedInvocation(clean_environment, "printf clean");
+    try std.testing.expectEqualStrings(fallback, user_invocation.path);
+    try std.testing.expectEqualStrings(fallback, clean_invocation.path);
+
+    try std.testing.expectEqualStrings(
+        fallback,
+        (try profileShell(arena, "/opt/homebrew/bin/fish", .user)).executable.path,
+    );
+    try std.testing.expectEqualStrings(
+        fallback,
+        (try profileShell(arena, "/opt/homebrew/bin/fish", .clean)).executable.path,
     );
 }
 


### PR DESCRIPTION
## What changed

- Fall back to `/bin/zsh` on macOS and `/bin/bash` elsewhere when the configured login shell is unsupported.
- Apply the fallback consistently to user/clean commands and durable terminal sessions.
- Persist the resolved shell while continuing to reject explicitly requested unsupported executables.

## Why

fx only supports Bash and Zsh invocation semantics. Users whose account login shell is Fish currently receive `UnsupportedShell` before terminal actions can run.

## Impact

Fish users can use the terminal through a supported compatibility shell. Native Fish execution remains separately tracked in #118.

## Validation

- `zig build test -Doptimize=ReleaseSafe`
- Isolated rerun of the single Debug timeout flake passed
- Forced-Fish binary smoke covering user/clean exec and durable start
- `zig fmt --check`
- `git diff --check`

Fixes #111
