### PR TITLE
Make settings model updates alias-safe

### DIFF
--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -1121,11 +1121,17 @@ pub fn Commands(comptime App: type) type {
         }
 
         fn setResolvedModelRuntime(app: *App, resolved: []const u8, announce: bool) !void {
-            app.selected_model.clearRetainingCapacity();
-            try app.selected_model.appendSlice(app.alloc, resolved);
-            try app.worker.syncQueuedPromptModel(std.heap.c_allocator, resolved);
-            if (comptime @hasDecl(App, "persistAcceptedModel")) try app.persistAcceptedModel(resolved);
-            terminalTitle(app).setModel(resolved);
+            if (!std.mem.eql(u8, app.selected_model.items, resolved)) {
+                const stable = try app.alloc.dupe(u8, resolved);
+                defer app.alloc.free(stable);
+                try app.selected_model.ensureTotalCapacity(app.alloc, stable.len);
+                app.selected_model.clearRetainingCapacity();
+                app.selected_model.appendSliceAssumeCapacity(stable);
+            }
+            const selected = app.selected_model.items;
+            try app.worker.syncQueuedPromptModel(std.heap.c_allocator, selected);
+            if (comptime @hasDecl(App, "persistAcceptedModel")) try app.persistAcceptedModel(selected);
+            terminalTitle(app).setModel(selected);
 
             if (announce) {
                 const active_response = if (comptime @hasField(App, "stream"))
@@ -1133,7 +1139,7 @@ pub fn Commands(comptime App: type) type {
                 else
                     false;
                 const prefix: []const u8 = if (active_response) "Next turn will use " else "Switched to ";
-                const line = try std.fmt.allocPrint(app.alloc, "{s}{s}", .{ prefix, resolved });
+                const line = try std.fmt.allocPrint(app.alloc, "{s}{s}", .{ prefix, selected });
                 defer app.alloc.free(line);
                 try app.writeDomainNotice(.{ .topic = "", .tone = .neutral, .body = line }, true);
                 if (comptime @hasDecl(App, "playInteractionSound")) app.playInteractionSound();
@@ -2754,6 +2760,9 @@ test "session_commands model picker accepts the current selected model slice" {
     );
 
     try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.selected_model.items);
+    try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.worker.synced_model.?);
+    try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.last_preference_model.items);
+    try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.terminalTitleModelText());
     try std.testing.expectEqual(types.ReasoningEffort.literal("high"), app.effort);
 }
 

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -2739,6 +2739,24 @@ test "session_commands selectModelFromPicker skips effort changes for models wit
     try std.testing.expect(!app.fast_mode);
 }
 
+test "session_commands model picker accepts the current selected model slice" {
+    const alloc = std.testing.allocator;
+    var app = try FakeApp.init(alloc, "/tmp/workspace", "anthropic/claude-opus-4.6");
+    defer app.deinit();
+    const efforts = [_]types.ReasoningEffort{types.ReasoningEffort.literal("high")};
+    app.setGatewayControls("anthropic/claude-opus-4.6", &efforts, true);
+
+    try Commands(FakeApp).selectModelFromPicker(
+        &app,
+        app.selected_model.items,
+        types.ReasoningEffort.literal("high"),
+        false,
+    );
+
+    try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.selected_model.items);
+    try std.testing.expectEqual(types.ReasoningEffort.literal("high"), app.effort);
+}
+
 test "session_commands selectModelFromPicker persists portable Gateway reasoning effort" {
     const alloc = std.testing.allocator;
     var app = try FakeApp.init(alloc, "/tmp/workspace", "anthropic/claude-opus-4.6");

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -744,6 +744,78 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
   );
 
   test(
+    "settings reasoning effort changes without mutating the selected model",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-settings-effort-"));
+      const gateway = startFakeGateway([], {
+        models: [{
+          id: "zai/glm-5.2",
+          type: "language",
+          released: 1,
+          tags: ["reasoning", "tool-use"],
+          reasoning_options: [{ type: "effort", values: ["low", "medium"] }],
+        }],
+      });
+      try {
+        const home = join(root, "home");
+        const workspace = join(root, "workspace");
+        const stderrPath = join(root, "stderr.log");
+        const settingsPath = join(home, ".fx", "settings.json");
+        mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+        mkdirSync(workspace);
+        writeFileSync(
+          settingsPath,
+          JSON.stringify({ model: "zai/glm-5.2", effort: "low" }) + "\n",
+          { mode: 0o600 },
+        );
+
+        session = await TmuxSession.create({
+          cwd: realpathSync(workspace),
+          env: {
+            ...NO_AUTH,
+            HOME: home,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+          },
+          stderrPath,
+        });
+        await session.waitForText("Run /help", TIMEOUT);
+        await session.sendText("/settings");
+        await session.waitForText("←→ Change", TIMEOUT);
+        await session.sendLiteral("reason");
+        const effortSetting = await session.waitForText("Reasoning effort", TIMEOUT);
+        expect(effortSetting).toContain("low");
+        await session.sendKeys("Right");
+
+        let stored = JSON.parse(readFileSync(settingsPath, "utf8"));
+        const persistenceDeadline = Date.now() + TIMEOUT;
+        while (stored.effort !== "medium" && Date.now() < persistenceDeadline) {
+          await Bun.sleep(25);
+          stored = JSON.parse(readFileSync(settingsPath, "utf8"));
+        }
+        expect(stored).toMatchObject({
+          model: "zai/glm-5.2",
+          effort: "medium",
+        });
+        expect(session.paneStatus()).toEqual({ dead: false, status: null });
+        expect(await session.capturePane()).toContain("medium");
+
+        await session.sendKeys("Escape");
+        await session.waitForComposer(TIMEOUT);
+        await session.sendText("/quit");
+        await session.waitForSessionEnd(TIMEOUT);
+        session = null;
+
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+        expect(gateway.requests).toHaveLength(0);
+      } finally {
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  test(
     "Opus 4.8 Fast pricing drives picker request and persistence",
     async () => {
       const root = mkdtempSync(join(tmpdir(), "fx-anthropic-capabilities-"));


### PR DESCRIPTION
## Summary

- Make selected-model replacement safe when its input aliases the current model buffer.
- Exercise the Settings reasoning-effort flow from `low` to `medium`.
- Verify the selected model is preserved and downstream runtime state remains synchronized.

## Why

Changing reasoning effort can reuse the current selected-model buffer. The model update path cleared that buffer before copying from it, causing a deterministic `@memcpy arguments alias` panic.

## Impact

Changing Reasoning effort in Settings remains safe, persists the new effort, and does not mutate the active model or terminate fx.

## Testing

- Focused selected-model alias regression
- `zig build test -Doptimize=Debug`
- `zig build test -Doptimize=ReleaseSafe`
- Settings reasoning-effort E2E
- `./zig-out/bin/fx --version`
- `zig fmt --check src/`
- `git diff --check`
