### PR TITLE
Fix active libfx session transitions

### DIFF
--- a/sdk/browser-test-terminal.html
+++ b/sdk/browser-test-terminal.html
@@ -36,13 +36,40 @@
     let runtime;
     let inputTaskRan = false;
     let inputTaskChunkCount;
+    let fetchCount = 0;
+    let activeClearFetchAborted = false;
+    let activeClearFollowupCompleted = false;
     let signalFetchStarted;
     let releaseBufferedStream;
     let finishBufferedStream;
     const fetchStarted = new Promise((resolve) => { signalFetchStarted = resolve; });
     const bufferedStreamReleased = new Promise((resolve) => { releaseBufferedStream = resolve; });
     const bufferedStreamFinished = new Promise((resolve) => { finishBufferedStream = resolve; });
-    const mockFetch = async () => {
+    const completedResponse = (text) => {
+      let sent = false;
+      return new Response(new ReadableStream({
+        pull(controller) {
+          if (sent) return;
+          sent = true;
+          controller.enqueue(encoded.encode(`data: ${JSON.stringify({ type: "text-delta", id: "browser_followup_1", delta: text })}\n\n`));
+          controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\n'));
+          controller.enqueue(encoded.encode("data: [DONE]\n\n"));
+          controller.close();
+          activeClearFollowupCompleted = true;
+        },
+      }), { status: 200, headers: { "content-type": "text/event-stream" } });
+    };
+    const mockFetch = async (_url, init) => {
+      fetchCount += 1;
+      if (fetchCount === 2) {
+        return new Promise((_, reject) => {
+          init.signal.addEventListener("abort", () => {
+            activeClearFetchAborted = true;
+            reject(new DOMException("aborted", "AbortError"));
+          }, { once: true });
+        });
+      }
+      if (fetchCount > 2) return completedResponse("BROWSER_FOLLOWUP_OK");
       signalFetchStarted();
       return new Response(new ReadableStream({
         async pull(controller) {
@@ -106,6 +133,25 @@
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
     runtime.write("\x7f".repeat(liveDraft.length));
+    testState.stage = "starting-active-clear";
+    runtime.write("clear active turn\r");
+    const activeDeadline = performance.now() + 10000;
+    while (fetchCount < 2 || !output.includes("Thinking")) {
+      if (performance.now() >= activeDeadline) throw new Error("active clear prompt did not start");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    testState.stage = "clearing-active-turn";
+    runtime.write("/clear\r");
+    while (!activeClearFetchAborted) {
+      if (performance.now() >= activeDeadline) throw new Error("active clear did not abort browser fetch");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    testState.stage = "running-followup";
+    runtime.write("follow-up prompt\r");
+    while (fetchCount < 3 || !activeClearFollowupCompleted) {
+      if (performance.now() >= activeDeadline) throw new Error("browser follow-up did not complete after active clear");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
     runtime.write("/exit\r");
     const code = await runtime.exited;
     window.__fxBrowserTerminalTest = {
@@ -114,6 +160,8 @@
       output,
       inputTaskRanDuringStream,
       draftRenderedDuringStream,
+      activeClearFetchAborted,
+      activeClearFollowupCompleted,
       dataListeners: dataListeners.size,
       resizeListeners: resizeListeners.size,
     };

--- a/sdk/browser-test-terminal.html
+++ b/sdk/browser-test-terminal.html
@@ -38,7 +38,8 @@
     let inputTaskChunkCount;
     let fetchCount = 0;
     let activeClearFetchAborted = false;
-    let activeClearFollowupCompleted = false;
+    let activeClearSessionRendered = false;
+    let activeClearFollowupFresh = false;
     let signalFetchStarted;
     let releaseBufferedStream;
     let finishBufferedStream;
@@ -55,12 +56,12 @@
           controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\n'));
           controller.enqueue(encoded.encode("data: [DONE]\n\n"));
           controller.close();
-          activeClearFollowupCompleted = true;
         },
       }), { status: 200, headers: { "content-type": "text/event-stream" } });
     };
     const mockFetch = async (_url, init) => {
       fetchCount += 1;
+      const requestBody = new TextDecoder().decode(init.body);
       if (fetchCount === 2) {
         return new Promise((_, reject) => {
           init.signal.addEventListener("abort", () => {
@@ -69,7 +70,12 @@
           }, { once: true });
         });
       }
-      if (fetchCount > 2) return completedResponse("BROWSER_FOLLOWUP_OK");
+      if (fetchCount > 2) {
+        activeClearFollowupFresh = requestBody.includes("follow-up prompt") &&
+          !requestBody.includes("clear active turn") &&
+          !requestBody.includes("STREAM_STARTED");
+        return completedResponse("BROWSER_FOLLOWUP_OK");
+      }
       signalFetchStarted();
       return new Response(new ReadableStream({
         async pull(controller) {
@@ -133,6 +139,7 @@
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
     runtime.write("\x7f".repeat(liveDraft.length));
+    const freshWelcomeOffset = output.length;
     testState.stage = "starting-active-clear";
     runtime.write("clear active turn\r");
     const activeDeadline = performance.now() + 10000;
@@ -146,10 +153,15 @@
       if (performance.now() >= activeDeadline) throw new Error("active clear did not abort browser fetch");
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
+    while (!output.slice(freshWelcomeOffset).includes("Run /help for commands")) {
+      if (performance.now() >= activeDeadline) throw new Error("active clear did not render a fresh session");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    activeClearSessionRendered = true;
     testState.stage = "running-followup";
     runtime.write("follow-up prompt\r");
-    while (fetchCount < 3 || !activeClearFollowupCompleted) {
-      if (performance.now() >= activeDeadline) throw new Error("browser follow-up did not complete after active clear");
+    while (fetchCount < 3 || !activeClearFollowupFresh) {
+      if (performance.now() >= activeDeadline) throw new Error("browser follow-up did not start with fresh session history");
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
     runtime.write("/exit\r");
@@ -161,7 +173,8 @@
       inputTaskRanDuringStream,
       draftRenderedDuringStream,
       activeClearFetchAborted,
-      activeClearFollowupCompleted,
+      activeClearSessionRendered,
+      activeClearFollowupFresh,
       dataListeners: dataListeners.size,
       resizeListeners: resizeListeners.size,
     };

--- a/sdk/node/test-term-lifecycle.mjs
+++ b/sdk/node/test-term-lifecycle.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,6 +34,14 @@ function terminalGrid(terminal) {
     lines.push(terminal.buffer.active.getLine(row)?.translateToString(true) ?? "");
   }
   return lines.join("\n");
+}
+
+const activeTransitionChildIndex = process.argv.indexOf("--active-transition-child");
+if (activeTransitionChildIndex >= 0) {
+  const scenario = process.argv[activeTransitionChildIndex + 1];
+  const command = process.argv[activeTransitionChildIndex + 2];
+  await runActiveTransitionChild(scenario, command);
+  process.exit(0);
 }
 
 const terminal = new Terminal({ cols: 80, rows: 24, allowProposedApi: true, scrollback: 1000 });
@@ -157,4 +166,155 @@ if (await abortRuntime.exited !== 130) throw new Error("aborted terminal did not
 if (abortDisposals.data !== 1 || abortDisposals.resize !== 1) {
   throw new Error(`aborted terminal subscriptions were not released exactly once: data=${abortDisposals.data}, resize=${abortDisposals.resize}`);
 }
-console.log("headless lifecycle passed: theme retinted, resize propagated, and Ctrl-C cancelled stalled fetch");
+
+await runActiveTransitionScenario("stalled", "/clear");
+await runActiveTransitionScenario("streaming", "/clear");
+await runActiveTransitionScenario("stalled", "/new");
+await runActiveTransitionScenario("stalled", "/reset");
+
+console.log("headless lifecycle passed: active session transitions recovered and Ctrl-C cancelled stalled fetch");
+
+async function runActiveTransitionScenario(scenario, command) {
+  const child = spawn(process.execPath, [
+    "--experimental-wasm-jspi",
+    fileURLToPath(import.meta.url),
+    wasmPath,
+    "--active-transition-child",
+    scenario,
+    command,
+  ], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+
+  const result = await new Promise((resolveResult) => {
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, 15000);
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolveResult({ code, signal, timedOut });
+    });
+  });
+
+  if (result.timedOut) {
+    throw new Error(`active ${command} timed out during ${scenario}; child output:\n${stdout}`);
+  }
+  if (result.code !== 0) {
+    throw new Error(`active ${command} failed during ${scenario}: code=${result.code} signal=${result.signal}\n${stderr}\n${stdout}`);
+  }
+  if (!stdout.includes("followup_completed")) {
+    throw new Error(`active ${command} did not complete a follow-up prompt during ${scenario}:\n${stdout}`);
+  }
+  if (stderr !== "") throw new Error(`active ${command} wrote stderr during ${scenario}:\n${stderr}`);
+}
+
+async function runActiveTransitionChild(scenario, command) {
+  if (!scenario || !command) throw new Error("active transition child requires scenario and command");
+
+  const childTerminal = new Terminal({ cols: 80, rows: 24, allowProposedApi: true, scrollback: 1000 });
+  const childDisposals = { data: 0, resize: 0 };
+  let childOutput = "";
+  let fetchCount = 0;
+  let firstFetchAborted = false;
+  let streamStarted = false;
+  const childDecoder = new TextDecoder();
+  const childHost = instrumentTerminal(childTerminal, childDisposals, (bytes) => {
+    childOutput += childDecoder.decode(bytes, { stream: true });
+  });
+  const encoder = new TextEncoder();
+
+  const completedResponse = (text) => new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "text-delta", id: "followup_1", delta: text })}\n\n`));
+      controller.enqueue(encoder.encode('data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"},"usage":{"inputTokens":{"total":1},"outputTokens":{"total":1}}}\n\n'));
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  }), { status: 200, headers: { "content-type": "text/event-stream" } });
+
+  const childFetch = async (_url, init) => {
+    fetchCount += 1;
+    process.stdout.write(`fetch_started:${fetchCount}\n`);
+    if (fetchCount > 1) return completedResponse("FOLLOWUP_OK");
+    if (scenario === "stalled") {
+      return new Promise((_, reject) => {
+        init.signal.addEventListener("abort", () => {
+          firstFetchAborted = true;
+          process.stdout.write("fetch_aborted\n");
+          reject(new DOMException("aborted", "AbortError"));
+        }, { once: true });
+      });
+    }
+    let sent = false;
+    return new Response(new ReadableStream({
+      pull(controller) {
+        if (sent) return;
+        sent = true;
+        controller.enqueue(encoder.encode('data: {"type":"text-delta","id":"stream_1","delta":"STREAM_STARTED"}\n\n'));
+        streamStarted = true;
+        init.signal.addEventListener("abort", () => {
+          firstFetchAborted = true;
+          process.stdout.write("fetch_aborted\n");
+          controller.error(new DOMException("aborted", "AbortError"));
+        }, { once: true });
+      },
+    }), { status: 200, headers: { "content-type": "text/event-stream" } });
+  };
+
+  const childRuntime = await createFxTerminal({
+    backend: "wasm",
+    wasm: await readFile(wasmPath),
+    terminal: childHost,
+    env: { AI_GATEWAY_API_KEY: "term-active-transition-key" },
+    fetch: childFetch,
+  });
+  const childFlush = () => new Promise((resolveFlush) => childTerminal.write("", resolveFlush));
+  const waitForChild = async (predicate, label, timeoutMs = 5000) => {
+    const deadline = performance.now() + timeoutMs;
+    while (!predicate()) {
+      await childFlush();
+      if (performance.now() >= deadline) {
+        throw new Error(`timed out waiting for ${label}; output:\n${childOutput}`);
+      }
+      await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+    }
+  };
+
+  await childRuntime.interactive;
+  await waitForChild(() => childOutput.includes("Run /help for commands"), "child startup");
+  process.stdout.write("runtime_interactive\n");
+  childRuntime.write("first prompt\r");
+  await waitForChild(() => fetchCount === 1, "first fetch");
+  if (scenario === "streaming") {
+    await waitForChild(() => streamStarted, "stream start");
+  } else {
+    await waitForChild(() => childOutput.includes("Thinking"), "thinking state");
+  }
+
+  process.stdout.write("transition_write\n");
+  childRuntime.write(`${command}\r`);
+  process.stdout.write("transition_returned\n");
+  await waitForChild(() => firstFetchAborted, "first fetch abort");
+  process.stdout.write("transition_settled\n");
+  childRuntime.write("second prompt\r");
+  await waitForChild(
+    () => fetchCount === 2 && terminalGrid(childTerminal).includes("FOLLOWUP_OK"),
+    "follow-up completion",
+  );
+  process.stdout.write("followup_completed\n");
+  childRuntime.write("/exit\r");
+  const childExit = await childRuntime.exited;
+  if (childExit !== 0) throw new Error(`child runtime exited with ${childExit}`);
+  if (childDisposals.data !== 1 || childDisposals.resize !== 1) {
+    throw new Error(`child subscriptions were not released exactly once: data=${childDisposals.data}, resize=${childDisposals.resize}`);
+  }
+}

--- a/sdk/node/test-term-lifecycle.mjs
+++ b/sdk/node/test-term-lifecycle.mjs
@@ -224,6 +224,7 @@ async function runActiveTransitionChild(scenario, command) {
   const childDisposals = { data: 0, resize: 0 };
   let childOutput = "";
   let fetchCount = 0;
+  const requestBodies = [];
   let firstFetchAborted = false;
   let streamStarted = false;
   const childDecoder = new TextDecoder();
@@ -243,6 +244,7 @@ async function runActiveTransitionChild(scenario, command) {
 
   const childFetch = async (_url, init) => {
     fetchCount += 1;
+    requestBodies.push(new TextDecoder().decode(init.body));
     process.stdout.write(`fetch_started:${fetchCount}\n`);
     if (fetchCount > 1) return completedResponse("FOLLOWUP_OK");
     if (scenario === "stalled") {
@@ -310,6 +312,13 @@ async function runActiveTransitionChild(scenario, command) {
     () => fetchCount === 2 && terminalGrid(childTerminal).includes("FOLLOWUP_OK"),
     "follow-up completion",
   );
+  const followupRequest = requestBodies[1] ?? "";
+  if (!followupRequest.includes("second prompt")) {
+    throw new Error(`follow-up request omitted the new prompt: ${followupRequest}`);
+  }
+  if (followupRequest.includes("first prompt") || followupRequest.includes("STREAM_STARTED")) {
+    throw new Error(`follow-up request retained cancelled session history: ${followupRequest}`);
+  }
   process.stdout.write("followup_completed\n");
   childRuntime.write("/exit\r");
   const childExit = await childRuntime.exited;

--- a/sdk/tests/test-core-browser.mjs
+++ b/sdk/tests/test-core-browser.mjs
@@ -163,6 +163,15 @@ async function runCase(name, query, verify) {
 function expect(condition, message) {
   if (!condition) throw new Error(message);
 }
+function withTimeout(promise, message, timeoutMs) {
+  let timer;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
 
 try {
   await runCase("incremental stream", "transport=mock&autorun=say%20hello&chunk-delay=75&model=sdk%2Fchrome-model&mode=code", (result) => {
@@ -192,12 +201,18 @@ try {
     await command("Runtime.enable", {}, sessionId);
     await command("Page.enable", {}, sessionId);
     await command("Page.navigate", { url: `http://127.0.0.1:${port}/sdk/browser-test-terminal.html` }, sessionId);
-    const result = await waitFor("window.__fxBrowserTerminalTest && ['completed', 'failed'].includes(window.__fxBrowserTerminalTest.state) && window.__fxBrowserTerminalTest", sessionId);
+    const result = await withTimeout(
+      waitFor("window.__fxBrowserTerminalTest && ['completed', 'failed'].includes(window.__fxBrowserTerminalTest.state) && window.__fxBrowserTerminalTest", sessionId),
+      "browser terminal case timed out",
+      15000,
+    );
     expect(result.state === "completed", result.error || `unexpected terminal state ${result.state}`);
     expect(result.code === 0, `unexpected terminal exit code ${result.code}`);
     expect(result.output.includes("Run /help for commands"), "browser terminal startup output missing");
     expect(result.inputTaskRanDuringStream, "browser terminal input task was blocked until the buffered stream finished");
     expect(result.draftRenderedDuringStream, "browser terminal input rendered only after the stream source closed");
+    expect(result.activeClearFetchAborted, "active /clear did not abort the browser fetch");
+    expect(result.activeClearFollowupCompleted, "browser terminal did not complete a follow-up prompt after active /clear");
     expect(result.dataListeners === 0, `browser terminal leaked ${result.dataListeners} data listener(s)`);
     expect(result.resizeListeners === 0, `browser terminal leaked ${result.resizeListeners} resize listener(s)`);
     console.log("browser terminal startup and shutdown passed");

--- a/sdk/tests/test-core-browser.mjs
+++ b/sdk/tests/test-core-browser.mjs
@@ -212,7 +212,8 @@ try {
     expect(result.inputTaskRanDuringStream, "browser terminal input task was blocked until the buffered stream finished");
     expect(result.draftRenderedDuringStream, "browser terminal input rendered only after the stream source closed");
     expect(result.activeClearFetchAborted, "active /clear did not abort the browser fetch");
-    expect(result.activeClearFollowupCompleted, "browser terminal did not complete a follow-up prompt after active /clear");
+    expect(result.activeClearSessionRendered, "active /clear did not render a fresh browser session");
+    expect(result.activeClearFollowupFresh, "browser follow-up retained cancelled session history");
     expect(result.dataListeners === 0, `browser terminal leaked ${result.dataListeners} data listener(s)`);
     expect(result.resizeListeners === 0, `browser terminal leaked ${result.resizeListeners} resize listener(s)`);
     console.log("browser terminal startup and shutdown passed");

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -1070,6 +1070,12 @@ pub const WorkerRuntime = struct {
         }
     }
 
+    pub fn isProcessing(self: *WorkerRuntime) bool {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        return self.worker_processing;
+    }
+
     pub fn snapshotState(
         self: *WorkerRuntime,
         alloc: std.mem.Allocator,

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -53,6 +53,156 @@ const BackgroundSessionPolicy = enum {
     stop_forget,
 };
 
+const LiveSessionTransitionEvent = union(enum) {
+    request: BackgroundSessionPolicy,
+    settle,
+};
+
+const LiveSessionTransitionAction = union(enum) {
+    apply_now: BackgroundSessionPolicy,
+    cancel_and_defer,
+    apply_pending: BackgroundSessionPolicy,
+    none,
+};
+
+const LiveSessionTransitionDecision = struct {
+    pending_policy: ?BackgroundSessionPolicy,
+    action: LiveSessionTransitionAction,
+};
+
+fn decideLiveSessionTransition(
+    cooperative: bool,
+    processing: bool,
+    pending_policy: ?BackgroundSessionPolicy,
+    event: LiveSessionTransitionEvent,
+) LiveSessionTransitionDecision {
+    return switch (event) {
+        .request => |policy| if (!cooperative or !processing)
+            .{
+                .pending_policy = null,
+                .action = .{ .apply_now = policy },
+            }
+        else if (pending_policy == null)
+            .{
+                .pending_policy = policy,
+                .action = .cancel_and_defer,
+            }
+        else
+            .{
+                .pending_policy = policy,
+                .action = .none,
+            },
+        .settle => if (processing)
+            .{
+                .pending_policy = pending_policy,
+                .action = .none,
+            }
+        else if (pending_policy) |policy|
+            .{
+                .pending_policy = null,
+                .action = .{ .apply_pending = policy },
+            }
+        else
+            .{
+                .pending_policy = null,
+                .action = .none,
+            },
+    };
+}
+
+test "live session transition decision defers only active cooperative requests" {
+    const cases = [_]struct {
+        cooperative: bool,
+        processing: bool,
+        pending: ?BackgroundSessionPolicy,
+        event: LiveSessionTransitionEvent,
+        expected: LiveSessionTransitionDecision,
+    }{
+        .{
+            .cooperative = false,
+            .processing = true,
+            .pending = null,
+            .event = .{ .request = .carry_forward },
+            .expected = .{
+                .pending_policy = null,
+                .action = .{ .apply_now = .carry_forward },
+            },
+        },
+        .{
+            .cooperative = true,
+            .processing = false,
+            .pending = null,
+            .event = .{ .request = .stop_forget },
+            .expected = .{
+                .pending_policy = null,
+                .action = .{ .apply_now = .stop_forget },
+            },
+        },
+        .{
+            .cooperative = true,
+            .processing = true,
+            .pending = null,
+            .event = .{ .request = .carry_forward },
+            .expected = .{
+                .pending_policy = .carry_forward,
+                .action = .cancel_and_defer,
+            },
+        },
+        .{
+            .cooperative = true,
+            .processing = true,
+            .pending = .carry_forward,
+            .event = .{ .request = .stop_forget },
+            .expected = .{
+                .pending_policy = .stop_forget,
+                .action = .none,
+            },
+        },
+        .{
+            .cooperative = true,
+            .processing = true,
+            .pending = .stop_forget,
+            .event = .settle,
+            .expected = .{
+                .pending_policy = .stop_forget,
+                .action = .none,
+            },
+        },
+        .{
+            .cooperative = true,
+            .processing = false,
+            .pending = .stop_forget,
+            .event = .settle,
+            .expected = .{
+                .pending_policy = null,
+                .action = .{ .apply_pending = .stop_forget },
+            },
+        },
+        .{
+            .cooperative = true,
+            .processing = false,
+            .pending = null,
+            .event = .settle,
+            .expected = .{
+                .pending_policy = null,
+                .action = .none,
+            },
+        },
+    };
+
+    for (cases) |case| {
+        try std.testing.expectEqualDeep(
+            case.expected,
+            decideLiveSessionTransition(
+                case.cooperative,
+                case.processing,
+                case.pending,
+                case.event,
+            ),
+        );
+    }
+}
+
 fn nextImageIdForResumedHistory(
     alloc: Allocator,
     history: []const types.HistoryTurn,
@@ -941,8 +1091,16 @@ pub const Persistence = struct {
     image_snapshot_temp_dir: ?[]u8 = null,
     resume_view_admission: ?session_store.ResumeViewAdmission = null,
     resume_handoff_intent: ResumeHandoffIntent = .none,
+    pending_live_session_policy: ?BackgroundSessionPolicy = null,
 
     pub fn deinit(self: *Persistence, alloc: Allocator) void {
+        if (self.pending_live_session_policy) |policy| {
+            debug_trace.logf(
+                "session",
+                "event=live_session_transition_discard reason=deinit policy={s}",
+                .{@tagName(policy)},
+            );
+        }
         if (self.pending_cancelled_command) |*pending| pending.discard(alloc);
         if (self.resume_view_admission) |*admission| admission.deinit(alloc);
         if (self.image_snapshot_temp_dir) |path| {
@@ -1285,8 +1443,60 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             background_policy: BackgroundSessionPolicy,
         ) !void {
-            clearCachedSessionTitle(app);
+            const previous_policy = app.session_persistence.pending_live_session_policy;
+            const decision = decideLiveSessionTransition(
+                runtime_profile.allows(App, .cooperative_agent),
+                app.worker.isProcessing(),
+                previous_policy,
+                .{ .request = background_policy },
+            );
+            if (previous_policy) |previous| {
+                if (decision.pending_policy) |next| {
+                    if (previous != next) {
+                        debug_trace.logf(
+                            "session",
+                            "event=live_session_transition_coalesced previous={s} next={s}",
+                            .{ @tagName(previous), @tagName(next) },
+                        );
+                    }
+                }
+            }
+            app.session_persistence.pending_live_session_policy = decision.pending_policy;
+            switch (decision.action) {
+                .apply_now => |policy| try applyLiveSessionTransition(app, policy),
+                .cancel_and_defer => beginLiveSessionCancellation(app),
+                .none => {},
+                .apply_pending => unreachable,
+            }
+        }
+
+        pub fn settlePendingLiveSessionTransition(app: *App) !void {
+            const decision = decideLiveSessionTransition(
+                runtime_profile.allows(App, .cooperative_agent),
+                app.worker.isProcessing(),
+                app.session_persistence.pending_live_session_policy,
+                .settle,
+            );
+            app.session_persistence.pending_live_session_policy = decision.pending_policy;
+            switch (decision.action) {
+                .apply_pending => |policy| {
+                    applyIdleLiveSessionTransition(app, policy, .{});
+                    try installFreshLiveSession(app);
+                },
+                .none => {},
+                .apply_now, .cancel_and_defer => unreachable,
+            }
+        }
+
+        fn applyLiveSessionTransition(
+            app: *App,
+            background_policy: BackgroundSessionPolicy,
+        ) !void {
             try prepareLiveSessionTransition(app, background_policy, .{});
+            try installFreshLiveSession(app);
+        }
+
+        fn installFreshLiveSession(app: *App) !void {
             try beginFreshPersistedSession(app);
             enableSessionStores(app);
             refreshSubagentProjectionAfterSessionInstall(app);
@@ -1310,6 +1520,12 @@ pub fn Runtime(comptime App: type) type {
             background_policy: BackgroundSessionPolicy,
             log_options: session_log.Options,
         ) !void {
+            beginLiveSessionCancellation(app);
+            app.worker.waitUntilIdle();
+            applyIdleLiveSessionTransition(app, background_policy, log_options);
+        }
+
+        fn beginLiveSessionCancellation(app: *App) void {
             app.worker.requestCancel();
             app.pacer.clear(app.alloc);
             if (comptime @hasField(App, "queued_prompt_review")) {
@@ -1317,7 +1533,14 @@ pub fn Runtime(comptime App: type) type {
             }
             app.shell.render_requests.finishSubmittedPromptTransition();
             app.worker.clearQueuedPrompts(std.heap.c_allocator, &.{});
-            app.worker.waitUntilIdle();
+        }
+
+        fn applyIdleLiveSessionTransition(
+            app: *App,
+            background_policy: BackgroundSessionPolicy,
+            log_options: session_log.Options,
+        ) void {
+            clearCachedSessionTitle(app);
             app.worker.discardEvents(std.heap.c_allocator);
 
             if (comptime @hasField(App, "subagents") and

--- a/src/main.zig
+++ b/src/main.zig
@@ -966,6 +966,7 @@ const App = struct {
             app_callbacks.Bindings(App).workerEventHandlers(self),
             flushRequestedFrame,
         );
+        try SessionAppRuntime.settlePendingLiveSessionTransition(self);
     }
 
     fn flushRequestedFrame(self: *App) !void {

--- a/tests/e2e/tui-slash-extra.test.ts
+++ b/tests/e2e/tui-slash-extra.test.ts
@@ -234,6 +234,62 @@ describe.skipIf(!tmuxAvailable() || CLIPBOARD_PROGRAM === null)("tui: clipboard 
   );
 });
 
+describe.skipIf(!tmuxAvailable())("tui: active session transitions", () => {
+  test(
+    "active /clear cancels a fake Gateway turn and accepts a follow-up prompt",
+    async () => {
+      const workDir = mkdtempSync(join(tmpdir(), "fx-active-clear-"));
+      const homeDir = mkdtempSync(join(tmpdir(), "fx-active-clear-home-"));
+      const stderrPath = join(workDir, "stderr.log");
+      let requestCount = 0;
+      const gateway = startDynamicFakeGateway(() => {
+        requestCount += 1;
+        if (requestCount > 1) return fakeGatewayFinalText("NATIVE_FOLLOWUP_OK");
+        return new Promise<Response>(() => {});
+      });
+
+      try {
+        session = await TmuxSession.create({
+          cwd: workDir,
+          stderrPath,
+          env: {
+            HOME: homeDir,
+            AI_GATEWAY_API_KEY: "active-clear-fake-key",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_MODEL: FAKE_GATEWAY_MODEL,
+          },
+          width: 120,
+          height: 40,
+        });
+        await session.waitForComposer(10_000);
+
+        await session.sendText("start an active turn");
+        await session.waitForText("Thinking", 10_000);
+        await session.sendText("/clear");
+        await session.waitForComposer(10_000);
+
+        await session.sendText("complete the follow-up");
+        await session.waitForText("NATIVE_FOLLOWUP_OK", 10_000);
+        expect(gateway.requests).toHaveLength(2);
+        expect(session.isAlive()).toBe(true);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+      } finally {
+        if (session) {
+          await session.kill();
+          session = null;
+        }
+        gateway.stop();
+        rmSync(workDir, { recursive: true, force: true });
+        rmSync(homeDir, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+});
+
 describe.skipIf(SKIP)("tui: extra slash commands", () => {
   test(
     "/clear clears the screen",

--- a/tests/e2e/tui-slash-extra.test.ts
+++ b/tests/e2e/tui-slash-extra.test.ts
@@ -274,6 +274,8 @@ describe.skipIf(!tmuxAvailable())("tui: active session transitions", () => {
         await session.sendText("complete the follow-up");
         await session.waitForText("NATIVE_FOLLOWUP_OK", 10_000);
         expect(gateway.requests).toHaveLength(2);
+        expect(gateway.requests[1].body).toContain("complete the follow-up");
+        expect(gateway.requests[1].body).not.toContain("start an active turn");
         expect(session.isAlive()).toBe(true);
         expect(readFileSync(stderrPath, "utf8")).toBe("");
       } finally {


### PR DESCRIPTION
## Summary

- Cancel active libfx session commands after cooperative worker completion so the terminal stays responsive for the next prompt
- Start the next prompt in a fresh session without retaining the cancelled turn
