### PR TITLE
Preserve session writes during cache contention

### DIFF
--- a/src/core/session/session_latest_pointer.zig
+++ b/src/core/session/session_latest_pointer.zig
@@ -13,7 +13,7 @@ const validateSessionId = paths.validateSessionId;
 const SessionSummary = store_types.SessionSummary;
 const summaryFromState = discovery.summaryFromState;
 const freeSummaries = summary_codec.freeSummaries;
-const readSessionIndex = summary_codec.readSessionIndex;
+const readSessionIndexForRepair = summary_codec.readSessionIndexForRepair;
 const removeSessionIndexMarker = summary_codec.removeSessionIndexMarker;
 const replaceIndexedSummary = summary_codec.replaceIndexedSummary;
 const writeSessionIndex = summary_codec.writeSessionIndex;
@@ -128,7 +128,8 @@ pub const LatestCache = struct {
                 latest_sessions_lock_file,
                 commit_lock_deadline_ms,
             ) catch |err| return switch (err) {
-                error.LockBusy, error.LockUnsupported => error.SessionCommitBoundaryUnavailable,
+                error.LockBusy => error.LatestCacheLockBusy,
+                error.LockUnsupported => error.SessionCommitBoundaryUnavailable,
                 else => err,
             };
         }
@@ -165,7 +166,7 @@ pub const LatestCache = struct {
             .preserve => {},
             .maintain, .replace_latest_if_current => {
                 if (self.prior_index == null) {
-                    self.prior_index = readSessionIndex(alloc, &self.sessions) catch |err| switch (err) {
+                    self.prior_index = readSessionIndexForRepair(alloc, &self.sessions) catch |err| switch (err) {
                         error.OutOfMemory => return error.OutOfMemory,
                         else => null,
                     };
@@ -181,10 +182,45 @@ pub const LatestCache = struct {
         try self.test_controls.boundary(.after_latest_cache_pending);
     }
 
+    pub fn writeDeferredToken(
+        self: *LatestCache,
+        alloc: Allocator,
+        session_id: []const u8,
+        workspace_root: []const u8,
+        position: session_log.CommitPosition,
+    ) !void {
+        try validateSessionId(session_id);
+        const encoded = try summary_codec.encodeDeferredCacheToken(
+            alloc,
+            session_id,
+            workspace_root,
+            position,
+        );
+        defer alloc.free(encoded);
+
+        var latest = try io_mod.openOrCreateVerifiedPrivateDir(
+            &self.sessions,
+            latest_sessions_dir,
+        );
+        defer latest.close();
+        var deferred = try io_mod.openOrCreateVerifiedPrivateDir(
+            &latest,
+            deferred_cache_dir,
+        );
+        defer deferred.close();
+        try io_mod.durableReplaceVerified(
+            alloc,
+            &deferred,
+            session_id,
+            encoded,
+        );
+    }
+
     pub fn publish(
         self: *LatestCache,
         alloc: Allocator,
         state: session_codec.DurableSessionState,
+        position: session_log.CommitPosition,
     ) !void {
         defer self.releaseLock();
         defer self.clearPreparedState(alloc);
@@ -261,6 +297,27 @@ pub const LatestCache = struct {
             try writeSessionIndex(alloc, &self.sessions, index.items);
             try removeSessionIndexMarker(&self.sessions);
         }
+        try self.clearDeferredTokenIfCovered(
+            alloc,
+            state.id,
+            position,
+        );
+    }
+
+    fn clearDeferredTokenIfCovered(
+        self: *LatestCache,
+        alloc: Allocator,
+        session_id: []const u8,
+        position: session_log.CommitPosition,
+    ) !void {
+        var token = (try summary_codec.readDeferredCacheToken(
+            alloc,
+            &self.sessions,
+            session_id,
+        )) orelse return;
+        defer token.deinit(alloc);
+        if (!commitPositionCovers(position, token.position)) return;
+        try removeDeferredToken(&self.sessions, session_id);
     }
 
     fn abort(self: *LatestCache) void {
@@ -313,6 +370,8 @@ pub const LatestCache = struct {
 };
 
 pub const latest_sessions_dir = "latest";
+
+pub const deferred_cache_dir = summary_codec.deferred_cache_dir;
 
 pub const latest_sessions_lock_file = "latest.lock";
 
@@ -384,6 +443,105 @@ fn latestCandidateNewer(
     return std.mem.order(u8, left.session_id, right.session_id) == .gt;
 }
 
+pub fn commitPositionCovers(
+    current: session_log.CommitPosition,
+    target: session_log.CommitPosition,
+) bool {
+    if (!std.mem.eql(u8, &current.log_generation, &target.log_generation)) {
+        return true;
+    }
+    if (current.through_seq != target.through_seq) {
+        return current.through_seq > target.through_seq;
+    }
+    return std.mem.eql(
+        u8,
+        &current.through_event_id,
+        &target.through_event_id,
+    ) and current.through_event_log_bytes >= target.through_event_log_bytes;
+}
+
+fn deferredTokensEqual(
+    left: summary_codec.DeferredCacheToken,
+    right: summary_codec.DeferredCacheToken,
+) bool {
+    return std.mem.eql(u8, left.session_id, right.session_id) and
+        std.mem.eql(u8, left.workspace_root, right.workspace_root) and
+        std.meta.eql(left.position, right.position);
+}
+
+pub fn removeDeferredToken(
+    sessions: *const io_mod.VerifiedDir,
+    session_id: []const u8,
+) !void {
+    try validateSessionId(session_id);
+    var latest = sessions.dir.openDir(io_mod.getIo(), latest_sessions_dir, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return,
+        error.NotDir, error.SymLinkLoop => return error.InvalidSessionIndex,
+        else => return err,
+    };
+    defer latest.close(io_mod.getIo());
+    var deferred = latest.openDir(io_mod.getIo(), deferred_cache_dir, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return,
+        error.NotDir, error.SymLinkLoop => return error.InvalidSessionIndex,
+        else => return err,
+    };
+    defer deferred.close(io_mod.getIo());
+    deferred.deleteFile(io_mod.getIo(), session_id) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => return err,
+    };
+    try io_mod.syncVerifiedDir(deferred);
+}
+
+pub fn clearObservedDeferredToken(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+    expected: summary_codec.DeferredCacheToken,
+) !void {
+    var session_dir = sessions.dir.openDir(io_mod.getIo(), expected.session_id, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| switch (err) {
+        error.FileNotFound => {
+            var current = (try summary_codec.readDeferredCacheToken(
+                alloc,
+                sessions,
+                expected.session_id,
+            )) orelse return;
+            defer current.deinit(alloc);
+            if (deferredTokensEqual(expected, current)) {
+                try removeDeferredToken(sessions, expected.session_id);
+            }
+            return;
+        },
+        error.NotDir, error.SymLinkLoop => return,
+        else => return err,
+    };
+    defer session_dir.close(io_mod.getIo());
+    var verified = io_mod.VerifiedDir{ .dir = session_dir };
+    var session_lock = io_mod.acquireTimedAdvisoryLock(
+        &verified,
+        "session.lock",
+        0,
+    ) catch return;
+    defer session_lock.release();
+
+    var current = (try summary_codec.readDeferredCacheToken(
+        alloc,
+        sessions,
+        expected.session_id,
+    )) orelse return;
+    defer current.deinit(alloc);
+    if (!deferredTokensEqual(expected, current)) return;
+    try removeDeferredToken(sessions, expected.session_id);
+}
+
 /// Commit-lifecycle `prepare` thunk: recovers the `LatestCache` from the opaque
 /// context and begins the pending phase for the previous/next workspace roots.
 pub fn latestCachePrepare(
@@ -404,14 +562,33 @@ pub fn latestCachePrepare(
     );
 }
 
+/// Commit-lifecycle deferred-publication thunk: persists the proposed
+/// canonical boundary before the watermark can advance.
+pub fn latestCacheWriteDeferred(
+    raw: ?*anyopaque,
+    alloc: Allocator,
+    session_id: []const u8,
+    workspace_root: []const u8,
+    position: session_log.CommitPosition,
+) !void {
+    const cache: *LatestCache = @ptrCast(@alignCast(raw orelse return error.SessionStoreUnavailable));
+    try cache.writeDeferredToken(
+        alloc,
+        session_id,
+        workspace_root,
+        position,
+    );
+}
+
 /// Commit-lifecycle `publish` thunk: writes the ready pointer for the committed state.
 pub fn latestCachePublish(
     raw: ?*anyopaque,
     alloc: Allocator,
     state: session_codec.DurableSessionState,
+    position: session_log.CommitPosition,
 ) !void {
     const cache: *LatestCache = @ptrCast(@alignCast(raw orelse return error.SessionStoreUnavailable));
-    try cache.publish(alloc, state);
+    try cache.publish(alloc, state, position);
 }
 
 /// Commit-lifecycle `abort` thunk: releases the cache lock without publishing.

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -423,6 +423,14 @@ pub const CommitLifecycle = struct {
         ?*anyopaque,
         Allocator,
         session_codec.DurableSessionState,
+        CommitPosition,
+    ) anyerror!void = null,
+    write_deferred_fn: ?*const fn (
+        ?*anyopaque,
+        Allocator,
+        []const u8,
+        []const u8,
+        CommitPosition,
     ) anyerror!void = null,
     abort_fn: ?*const fn (?*anyopaque) void = null,
     deinit_fn: ?*const fn (?*anyopaque, Allocator) void = null,
@@ -436,13 +444,57 @@ pub const CommitLifecycle = struct {
         commit_lock_deadline_ms: u64,
     ) !void {
         if (self.prepare_fn) |callback| {
-            try callback(
+            callback(
                 self.context,
                 alloc,
                 session_id,
                 previous_workspace_root,
                 next_workspace_root,
                 commit_lock_deadline_ms,
+            ) catch |err| return switch (err) {
+                error.LatestCacheLockBusy => error.SessionCommitBoundaryUnavailable,
+                else => err,
+            };
+        }
+    }
+
+    fn prepareOpportunistic(
+        self: *CommitLifecycle,
+        alloc: Allocator,
+        session_id: []const u8,
+        workspace_root: []const u8,
+        commit_lock_deadline_ms: u64,
+    ) !bool {
+        if (self.prepare_fn) |callback| {
+            callback(
+                self.context,
+                alloc,
+                session_id,
+                workspace_root,
+                workspace_root,
+                commit_lock_deadline_ms,
+            ) catch |err| return switch (err) {
+                error.LatestCacheLockBusy => true,
+                else => err,
+            };
+        }
+        return false;
+    }
+
+    fn writeDeferred(
+        self: *CommitLifecycle,
+        alloc: Allocator,
+        session_id: []const u8,
+        workspace_root: []const u8,
+        position: CommitPosition,
+    ) !void {
+        if (self.write_deferred_fn) |callback| {
+            try callback(
+                self.context,
+                alloc,
+                session_id,
+                workspace_root,
+                position,
             );
         }
     }
@@ -451,8 +503,11 @@ pub const CommitLifecycle = struct {
         self: *CommitLifecycle,
         alloc: Allocator,
         state: session_codec.DurableSessionState,
+        position: CommitPosition,
     ) !void {
-        if (self.publish_fn) |callback| try callback(self.context, alloc, state);
+        if (self.publish_fn) |callback| {
+            try callback(self.context, alloc, state, position);
+        }
     }
 
     pub fn abort(self: *CommitLifecycle) void {
@@ -591,7 +646,13 @@ pub const LoadedWritableSession = struct {
         };
         defer if (usage_sidecar_bytes) |bytes| alloc.free(bytes);
         self.state_replacement_pending = true;
-        try self.prepareCommitLifecycle(alloc, next_workspace_root, options);
+        const cache_deferred = switch (event) {
+            .workspace_rebound => blk: {
+                try self.prepareCommitLifecycle(alloc, next_workspace_root, options);
+                break :blk false;
+            },
+            else => try self.prepareCommitLifecycleOpportunistic(alloc, options),
+        };
         _ = appendEventImpl(
             self,
             alloc,
@@ -601,12 +662,13 @@ pub const LoadedWritableSession = struct {
             options,
             usage_sidecar_bytes,
             write_usage_sidecar,
+            cache_deferred,
         ) catch |err| {
             self.abortCommitLifecycle();
             return err;
         };
         if (!preserves_pristine_start) self.freshly_started = false;
-        const lifecycle_published = self.publishCommitLifecycle(alloc);
+        const lifecycle_published = !cache_deferred and self.publishCommitLifecycle(alloc);
         maintainCanonicalLogAfterCommit(self, alloc, options) catch |err| {
             self.state_replacement_pending = true;
             return err;
@@ -638,7 +700,21 @@ pub const LoadedWritableSession = struct {
             null;
         defer if (usage_sidecar_bytes) |bytes| alloc.free(bytes);
         self.state_replacement_pending = true;
-        try self.prepareCommitLifecycle(alloc, state.workspace_root, options);
+        const same_workspace = std.mem.eql(
+            u8,
+            self.state.workspace_root,
+            state.workspace_root,
+        );
+        const may_defer_cache = same_workspace and switch (reason) {
+            .compaction, .log_compaction => true,
+            .migration, .recovery => false,
+        };
+        const cache_deferred = if (may_defer_cache)
+            try self.prepareCommitLifecycleOpportunistic(alloc, options)
+        else blk: {
+            try self.prepareCommitLifecycle(alloc, state.workspace_root, options);
+            break :blk false;
+        };
         _ = commitStateReplacementImpl(
             self,
             alloc,
@@ -648,12 +724,13 @@ pub const LoadedWritableSession = struct {
             options,
             usage_sidecar_bytes,
             true,
+            cache_deferred,
         ) catch |err| {
             self.abortCommitLifecycle();
             return err;
         };
         self.freshly_started = false;
-        const lifecycle_published = self.publishCommitLifecycle(alloc);
+        const lifecycle_published = !cache_deferred and self.publishCommitLifecycle(alloc);
         maintainCanonicalLogAfterCommit(self, alloc, options) catch |err| {
             self.state_replacement_pending = true;
             return err;
@@ -683,9 +760,40 @@ pub const LoadedWritableSession = struct {
         }
     }
 
+    fn prepareCommitLifecycleOpportunistic(
+        self: *LoadedWritableSession,
+        alloc: Allocator,
+        options: Options,
+    ) !bool {
+        if (self.commit_lifecycle) |*lifecycle| {
+            return lifecycle.prepareOpportunistic(
+                alloc,
+                self.active_id,
+                self.state.workspace_root,
+                options.commit_lock_deadline_ms,
+            );
+        }
+        return false;
+    }
+
+    fn writeDeferredCommitLifecycle(
+        self: *LoadedWritableSession,
+        alloc: Allocator,
+        position: CommitPosition,
+    ) !void {
+        if (self.commit_lifecycle) |*lifecycle| {
+            try lifecycle.writeDeferred(
+                alloc,
+                self.active_id,
+                self.state.workspace_root,
+                position,
+            );
+        }
+    }
+
     pub fn publishCommitLifecycle(self: *LoadedWritableSession, alloc: Allocator) bool {
         if (self.commit_lifecycle) |*lifecycle| {
-            lifecycle.publish(alloc, self.state) catch |err| {
+            lifecycle.publish(alloc, self.state, self.position) catch |err| {
                 debug_trace.logf(
                     "session",
                     "event=latest_cache_publish_failed err={s}",
@@ -2905,6 +3013,7 @@ fn appendEventImpl(
     options: Options,
     usage_sidecar_bytes: ?[]const u8,
     write_usage_sidecar: bool,
+    cache_deferred: bool,
 ) !CommitPosition {
     try prepareCanonicalWrite(loaded, alloc, options);
     const envelope = session_event.Envelope{
@@ -2924,6 +3033,15 @@ fn appendEventImpl(
         envelope.event_id,
         .{ .event = envelope.event_id },
     );
+    if (cache_deferred) {
+        loaded.writeDeferredCommitLifecycle(
+            alloc,
+            prepared.proposed,
+        ) catch |err| {
+            prepared.deinit(alloc);
+            return err;
+        };
+    }
     return publishPreparedTail(
         loaded,
         alloc,
@@ -2960,6 +3078,7 @@ fn commitStateReplacementImpl(
     options: Options,
     usage_sidecar_bytes: ?[]const u8,
     write_usage_sidecar: bool,
+    cache_deferred: bool,
 ) !CommitPosition {
     try prepareCanonicalWrite(loaded, alloc, options);
     const timestamp_ms = state.updated_at_ms;
@@ -2992,6 +3111,15 @@ fn commitStateReplacementImpl(
             .final_event_id = summary.last_event_id,
         } },
     );
+    if (cache_deferred) {
+        loaded.writeDeferredCommitLifecycle(
+            alloc,
+            prepared.proposed,
+        ) catch |err| {
+            prepared.deinit(alloc);
+            return err;
+        };
+    }
     return publishPreparedTail(
         loaded,
         alloc,

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -65,6 +65,7 @@ const latestCacheAbort = latest_pointer.latestCacheAbort;
 const latestCacheDeinit = latest_pointer.latestCacheDeinit;
 const latestCachePrepare = latest_pointer.latestCachePrepare;
 const latestCachePublish = latest_pointer.latestCachePublish;
+const latestCacheWriteDeferred = latest_pointer.latestCacheWriteDeferred;
 const latest_sessions_lock_file = latest_pointer.latest_sessions_lock_file;
 const latest_sessions_dir = latest_pointer.latest_sessions_dir;
 const recovery_staging_dir = "recovery+staging";
@@ -843,6 +844,17 @@ pub const Store = struct {
             );
             return .indeterminate;
         };
+        latest_pointer.removeDeferredToken(
+            sessions,
+            loaded.active_id,
+        ) catch |err| {
+            debug_trace.logf(
+                "session",
+                "event=pristine_session_discard disposition=indeterminate stage=deferred_token_cleanup err={s}",
+                .{@errorName(err)},
+            );
+            return .indeterminate;
+        };
         debug_trace.logf(
             "session",
             "event=pristine_session_discard disposition=discarded",
@@ -875,6 +887,14 @@ pub const Store = struct {
         return switch (target) {
             .id => |id| try root.admitResumeView(alloc, id),
             .last => blk: {
+                if (self.deferredCacheInvalidatesReads()) {
+                    var latest = try self.latestReadOnlyWorkspaceSummary(alloc);
+                    defer latest.deinit(alloc);
+                    break :blk try root.admitResumeView(
+                        alloc,
+                        latest.id,
+                    );
+                }
                 var latest = (try readLatestPointer(self, alloc, self.workspace_root)) orelse
                     return null;
                 defer latest.deinit(alloc);
@@ -988,6 +1008,13 @@ pub const Store = struct {
         workspace_root: []const u8,
         options: ResumeOptions,
     ) !LoadedWritableSession {
+        if (self.deferredCacheInvalidatesReads()) {
+            return self.resumeLatestDiscoveryAfterBarrier(
+                alloc,
+                workspace_root,
+                options,
+            );
+        }
         const cached = readLatestPointer(self, alloc, workspace_root) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             else => null,
@@ -1147,7 +1174,12 @@ pub const Store = struct {
             options,
         );
         errdefer loaded.deinit(alloc);
-        self.repairLatestPointer(alloc, loaded.state, options.log) catch |err| {
+        self.repairLatestPointer(
+            alloc,
+            loaded.state,
+            loaded.position,
+            options.log,
+        ) catch |err| {
             debug_trace.logf(
                 "session",
                 "event=latest_cache_repair_failed err={s}",
@@ -1523,6 +1555,7 @@ pub const Store = struct {
             .context = cache,
             .prepare_fn = latestCachePrepare,
             .publish_fn = latestCachePublish,
+            .write_deferred_fn = latestCacheWriteDeferred,
             .abort_fn = latestCacheAbort,
             .deinit_fn = latestCacheDeinit,
         };
@@ -1547,11 +1580,13 @@ pub const Store = struct {
         self: Store,
         alloc: Allocator,
         state: session_codec.DurableSessionState,
+        position: session_log.CommitPosition,
         options: session_log.Options,
     ) !void {
         try self.publishLatestPointer(
             alloc,
             state,
+            position,
             options,
             .maintain,
         );
@@ -1561,6 +1596,7 @@ pub const Store = struct {
         self: Store,
         alloc: Allocator,
         state: session_codec.DurableSessionState,
+        position: session_log.CommitPosition,
         source_session_id: []const u8,
         options: session_log.Options,
     ) !void {
@@ -1586,6 +1622,7 @@ pub const Store = struct {
             self.publishLatestPointer(
                 alloc,
                 state,
+                position,
                 options,
                 .{ .replace_latest_if_current = .{
                     .expected_current_id = source_session_id,
@@ -1608,6 +1645,7 @@ pub const Store = struct {
         self: Store,
         alloc: Allocator,
         state: session_codec.DurableSessionState,
+        position: session_log.CommitPosition,
         options: session_log.Options,
         effect: InitialIndexEffect,
     ) !void {
@@ -1626,7 +1664,7 @@ pub const Store = struct {
             state.workspace_root,
             options.commit_lock_deadline_ms,
         );
-        try cache.publish(alloc, state);
+        try cache.publish(alloc, state, position);
     }
 
     /// Loads a session's summary, state, and storage format read-only, handling
@@ -1673,6 +1711,11 @@ pub const Store = struct {
     /// Lists all readable sessions newest-first. Caller frees each item and the list.
     pub fn list(self: Store, alloc: Allocator) anyerror!std.ArrayList(SessionSummary) {
         return self.scanSessionSummaries(alloc, .read_only_list);
+    }
+
+    fn deferredCacheInvalidatesReads(self: Store) bool {
+        const sessions = &(self.canonical_root.sessions orelse return false);
+        return summary_codec.deferredCachePresent(sessions) catch true;
     }
 
     /// Invalidates the derived resume catalog after managed child ownership
@@ -1723,6 +1766,15 @@ pub const Store = struct {
         alloc: Allocator,
         continuation: RelationshipMigrationCursor,
     ) ListSubagentControlIdsError!RelationshipMigrationCandidatePage {
+        if (self.deferredCacheInvalidatesReads()) {
+            return self.listRelationshipMigrationCandidatesFromCanonical(
+                alloc,
+                continuation,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                else => error.SessionStoreUnavailable,
+            };
+        }
         var sessions = self.canonical_root.sessions orelse
             return error.SessionStoreUnavailable;
         if (self.canonical_root.mode == .read_only) {
@@ -1768,6 +1820,40 @@ pub const Store = struct {
                 };
             },
         };
+    }
+
+    fn listRelationshipMigrationCandidatesFromCanonical(
+        self: Store,
+        alloc: Allocator,
+        continuation: RelationshipMigrationCursor,
+    ) !RelationshipMigrationCandidatePage {
+        var summaries = try self.scanSessionSummaries(alloc, .read_only_list);
+        defer freeSummaries(alloc, &summaries);
+        const total = std.math.cast(u64, summaries.items.len) orelse
+            return error.SessionStoreUnavailable;
+        const same_snapshot = continuation.inode == 0 and
+            continuation.mtime_ns == 0 and
+            continuation.size == total and
+            continuation.offset <= total;
+        const start = if (same_snapshot) continuation.offset else 0;
+        const remaining = total - start;
+        const count = @min(
+            remaining,
+            summary_codec.relationship_migration_candidate_limit,
+        );
+        const end = start + count;
+        var page = RelationshipMigrationCandidatePage{
+            .cursor = .{
+                .size = total,
+                .offset = end,
+            },
+            .has_more = end < total,
+        };
+        errdefer page.deinit(alloc);
+        for (summaries.items[@intCast(start)..@intCast(end)]) |summary| {
+            try page.ids.append(alloc, try alloc.dupe(u8, summary.id));
+        }
+        return page;
     }
 
     /// Persists the unresolved marker before its matching session checkpoint.
@@ -2188,29 +2274,83 @@ pub const Store = struct {
         continuation: ?ResumableSessionContinuation,
     ) !ResumableSessionPage {
         var sessions = self.canonical_root.sessions orelse return error.SessionStoreUnavailable;
-        var cache_lock = try io_mod.acquireTimedAdvisoryLock(
-            &sessions,
-            latest_sessions_lock_file,
-            2000,
-        );
-        defer cache_lock.release();
-
-        if (try self.tryListResumableIndexPageForScope(alloc, scope, active_id, continuation)) |page| {
-            return page;
-        }
-
         var summaries = try self.scanSessionSummaries(alloc, .read_only_list);
         defer freeSummaries(alloc, &summaries);
         try self.refreshMissingDisplayMetadata(alloc, &summaries);
-        try writeSessionIndex(alloc, &sessions, summaries.items);
-        try removeSessionIndexMarker(&sessions);
-        return try self.resumablePageFromSummariesForScope(
+        var page = try self.resumablePageFromSummariesForScope(
             alloc,
             scope,
             summaries.items,
             active_id,
             continuation,
         );
+        errdefer page.deinit(alloc);
+
+        var cache_lock = io_mod.acquireTimedAdvisoryLock(
+            &sessions,
+            latest_sessions_lock_file,
+            0,
+        ) catch return page;
+        var cache_lock_held = true;
+        defer if (cache_lock_held) cache_lock.release();
+
+        if (try self.tryListResumableIndexPageForScope(alloc, scope, active_id, continuation)) |indexed| {
+            page.deinit(alloc);
+            return indexed;
+        }
+        var observed = summary_codec.readDeferredCacheTokens(
+            alloc,
+            &sessions,
+        ) catch return page;
+        defer summary_codec.freeDeferredCacheTokens(alloc, &observed);
+        var repair_summaries = try self.scanSessionSummaries(alloc, .read_only_list);
+        defer freeSummaries(alloc, &repair_summaries);
+        try self.refreshMissingDisplayMetadata(alloc, &repair_summaries);
+        try writeSessionIndex(alloc, &sessions, repair_summaries.items);
+        try removeSessionIndexMarker(&sessions);
+        cache_lock.release();
+        cache_lock_held = false;
+        for (observed.items) |token| {
+            var root = self.canonical_root;
+            var boundary = root.captureReadBoundary(
+                alloc,
+                token.session_id,
+                .{ .commit_lock_deadline_ms = 0 },
+            ) catch |err| switch (err) {
+                error.SessionNotFound => {
+                    latest_pointer.clearObservedDeferredToken(
+                        alloc,
+                        &sessions,
+                        token,
+                    ) catch |clear_err| {
+                        debug_trace.logf(
+                            "session",
+                            "event=deferred_cache_orphan_clear_failed err={s}",
+                            .{@errorName(clear_err)},
+                        );
+                    };
+                    continue;
+                },
+                else => continue,
+            };
+            defer boundary.deinit();
+            if (!latest_pointer.commitPositionCovers(
+                boundary.position,
+                token.position,
+            )) continue;
+            latest_pointer.clearObservedDeferredToken(
+                alloc,
+                &sessions,
+                token,
+            ) catch |err| {
+                debug_trace.logf(
+                    "session",
+                    "event=deferred_cache_token_clear_failed err={s}",
+                    .{@errorName(err)},
+                );
+            };
+        }
+        return page;
     }
 
     fn listResumablePageFromDiscoveryForScope(
@@ -2457,6 +2597,7 @@ pub const Store = struct {
     ) !SessionSummaryScan {
         var scan = SessionSummaryScan{};
         errdefer scan.deinit(alloc);
+        const replay_schema_v3 = self.deferredCacheInvalidatesReads();
         var metadata: std.ArrayList(DiscoveryCandidateMetadata) = .empty;
         defer metadata.deinit(alloc);
         if (self.canonical_root.sessions == null) return scan;
@@ -2491,6 +2632,32 @@ pub const Store = struct {
                 },
             };
             session_dir.close();
+            if (replay_schema_v3 and candidate.storage == .schema_v3) {
+                var detail = self.loadReadOnlyDetail(
+                    alloc,
+                    entry.name,
+                    .{},
+                ) catch |err| {
+                    candidate.deinit(alloc);
+                    switch (err) {
+                        error.OutOfMemory => return error.OutOfMemory,
+                        else => {
+                            logDiscoveryError(mode, entry.name, null, null, err);
+                            scan.skipped_invalid += 1;
+                            continue;
+                        },
+                    }
+                };
+                candidate.deinit(alloc);
+                candidate = .{
+                    .summary = detail.summary,
+                    .storage = .schema_v3,
+                    .projection_state = .current,
+                };
+                detail.summary = undefined;
+                detail.state.deinit(alloc);
+                detail = undefined;
+            }
             candidate.summary.has_managed_children =
                 self.sessionHasManagedChildren(alloc, entry.name) catch |err| switch (err) {
                     error.OutOfMemory => {
@@ -2922,6 +3089,7 @@ pub const Store = struct {
     ) !?[]u8 {
         try validateWorkspaceRoot(workspace_root);
         if (self.canonical_root.sessions == null) return null;
+        const replay_schema_v3 = self.deferredCacheInvalidatesReads();
 
         var selected: ?WritableCandidate = null;
         defer if (selected) |*candidate| candidate.deinit(alloc);
@@ -2953,6 +3121,27 @@ pub const Store = struct {
                     return err;
                 },
             };
+            if (replay_schema_v3 and candidate.storage == .schema_v3) {
+                var root = self.canonical_root;
+                var state = root.loadReadOnly(
+                    alloc,
+                    entry.name,
+                    options.log,
+                ) catch |err| {
+                    candidate.deinit(alloc);
+                    return mapReplayError(err);
+                };
+                defer state.deinit(alloc);
+                candidate.deinit(alloc);
+                candidate = try dupeWritableCandidate(
+                    alloc,
+                    state.id,
+                    state.workspace_root,
+                    state.updated_at_ms,
+                    .schema_v3,
+                    .current,
+                );
+            }
             if (!std.mem.eql(u8, candidate.workspace_root, workspace_root)) {
                 logDiscovery(
                     .workspace_writable_last,
@@ -3711,6 +3900,7 @@ pub const Store = struct {
         self.publishRecoveredLatestPointer(
             alloc,
             recovered,
+            target.position,
             source_id,
             options,
         ) catch |err| {
@@ -4572,6 +4762,9 @@ fn readLatestPointer(
     workspace_root: []const u8,
 ) !?LatestPointer {
     const sessions = self.canonical_root.sessions orelse return null;
+    if (try summary_codec.deferredCachePresent(&sessions)) {
+        return error.InvalidSessionIndex;
+    }
     return readLatestPointerFromSessions(&sessions, alloc, workspace_root);
 }
 
@@ -4663,6 +4856,22 @@ fn testDurableState(
         .total_input_tokens = 0,
         .total_output_tokens = 0,
     };
+}
+
+fn expectDeferredCacheTokenMissing(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+    session_id: []const u8,
+) !void {
+    if (try summary_codec.readDeferredCacheToken(
+        alloc,
+        sessions,
+        session_id,
+    )) |token_value| {
+        var token = token_value;
+        defer token.deinit(alloc);
+        return error.TestExpectedEqual;
+    }
 }
 
 fn testIndexedSessionSummary(
@@ -7041,7 +7250,7 @@ test "workspace rebind honors an immediate latest cache lock deadline" {
     try std.testing.expect(io_mod.milliTimestamp() - started_at_ms < 1000);
 }
 
-test "existing session lifecycle honors a per-operation latest cache deadline" {
+test "same-workspace append defers latest cache contention and marks cache dirty" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -7060,9 +7269,88 @@ test "existing session lifecycle honors a per-operation latest cache deadline" {
     );
     defer latest_lock.release();
 
+    const prior = loaded.position;
     const started_at_ms = io_mod.milliTimestamp();
+    const committed = try loaded.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        20,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    try std.testing.expect(io_mod.milliTimestamp() - started_at_ms < 1000);
+    try std.testing.expect(committed.through_seq > prior.through_seq);
+    try std.testing.expectEqual(@as(?bool, true), loaded.state.preferences.fast_mode);
+
+    var latest = try sessions.dir.openDir(io_mod.getIo(), latest_sessions_dir, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer latest.close(io_mod.getIo());
+    var deferred = try latest.openDir(io_mod.getIo(), "deferred", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer deferred.close(io_mod.getIo());
+    var token = try deferred.openFile(io_mod.getIo(), state.id, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    });
+    defer token.close(io_mod.getIo());
+    const token_stat = try token.stat(io_mod.getIo());
+    try std.testing.expectEqual(std.Io.File.Kind.file, token_stat.kind);
+    try std.testing.expectEqual(@as(u32, 0o600), token_stat.permissions.toMode() & 0o777);
+    const token_bytes = try io_mod.readFileToEnd(
+        alloc,
+        &token,
+        summary_codec.max_deferred_cache_token_bytes,
+    );
+    defer alloc.free(token_bytes);
+    var decoded = try summary_codec.decodeDeferredCacheToken(alloc, token_bytes);
+    defer decoded.deinit(alloc);
+    try std.testing.expectEqualStrings(state.id, decoded.session_id);
+    try std.testing.expectEqualStrings(ctx.workspace, decoded.workspace_root);
+    try std.testing.expectEqualDeep(committed, decoded.position);
+}
+
+test "deferred token failure prevents a same-workspace canonical commit" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "deferred-token-failure", ctx.workspace);
+    defer state.deinit(alloc);
+    var loaded = try ctx.store.startWritableSession(alloc, state);
+    defer loaded.deinit(alloc);
+
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest = try sessions.dir.openDir(io_mod.getIo(), latest_sessions_dir, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer latest.close(io_mod.getIo());
+    var obstacle = try latest.createFile(io_mod.getIo(), "deferred", .{
+        .read = true,
+        .truncate = false,
+        .exclusive = true,
+        .permissions = std.Io.File.Permissions.fromMode(0o600),
+        .resolve_beneath = true,
+    });
+    obstacle.close(io_mod.getIo());
+
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    defer latest_lock.release();
+    const prior = loaded.position;
+    const prior_fast_mode = loaded.state.preferences.fast_mode;
     try std.testing.expectError(
-        error.SessionCommitBoundaryUnavailable,
+        error.DurablePathUnsafe,
         loaded.appendEvent(
             alloc,
             .{ .preferences_changed = .{ .fast_mode = true } },
@@ -7071,7 +7359,584 @@ test "existing session lifecycle honors a per-operation latest cache deadline" {
             .{ .commit_lock_deadline_ms = 0 },
         ),
     );
-    try std.testing.expect(io_mod.milliTimestamp() - started_at_ms < 1000);
+    try std.testing.expectEqualDeep(prior, loaded.position);
+    try std.testing.expectEqual(prior_fast_mode, loaded.state.preferences.fast_mode);
+}
+
+test "same-workspace compaction replacement defers latest cache contention" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "deferred-replacement", ctx.workspace);
+    defer state.deinit(alloc);
+    var loaded = try ctx.store.startWritableSession(alloc, state);
+    defer loaded.deinit(alloc);
+    var replacement = try loaded.state.dupe(alloc);
+    defer replacement.deinit(alloc);
+    replacement.updated_at_ms = 30;
+
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    defer latest_lock.release();
+    const committed = try loaded.commitStateReplacement(
+        alloc,
+        replacement,
+        .compaction,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    try std.testing.expectEqual(@as(i64, 30), loaded.state.updated_at_ms);
+
+    var latest = try sessions.dir.openDir(io_mod.getIo(), latest_sessions_dir, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer latest.close(io_mod.getIo());
+    var deferred = try latest.openDir(io_mod.getIo(), "deferred", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer deferred.close(io_mod.getIo());
+    var token = try deferred.openFile(io_mod.getIo(), state.id, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    });
+    defer token.close(io_mod.getIo());
+    const token_bytes = try io_mod.readFileToEnd(
+        alloc,
+        &token,
+        summary_codec.max_deferred_cache_token_bytes,
+    );
+    defer alloc.free(token_bytes);
+    var decoded = try summary_codec.decodeDeferredCacheToken(alloc, token_bytes);
+    defer decoded.deinit(alloc);
+    try std.testing.expectEqualDeep(committed, decoded.position);
+}
+
+test "migration and recovery replacements keep latest cache contention strict" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "strict-replacement-cache-lock", ctx.workspace);
+    defer state.deinit(alloc);
+    var loaded = try ctx.store.startWritableSession(alloc, state);
+    defer loaded.deinit(alloc);
+    var replacement = try loaded.state.dupe(alloc);
+    defer replacement.deinit(alloc);
+    replacement.updated_at_ms = 30;
+
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    defer latest_lock.release();
+    const prior = loaded.position;
+    for ([_]session_event.ReplacementReason{ .migration, .recovery }) |reason| {
+        try std.testing.expectError(
+            error.SessionCommitBoundaryUnavailable,
+            loaded.commitStateReplacement(
+                alloc,
+                replacement,
+                reason,
+                .retry_expected_tail,
+                .{ .commit_lock_deadline_ms = 0 },
+            ),
+        );
+        try std.testing.expectEqualDeep(prior, loaded.position);
+    }
+}
+
+test "session creation keeps latest cache contention strict" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "strict-creation-cache-lock", ctx.workspace);
+    defer state.deinit(alloc);
+
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    defer latest_lock.release();
+    try std.testing.expectError(
+        error.SessionCommitBoundaryUnavailable,
+        ctx.store.startWritableSessionWithOptions(
+            alloc,
+            state,
+            .{ .commit_lock_deadline_ms = 0 },
+        ),
+    );
+    try std.testing.expectError(
+        error.SessionNotFound,
+        ctx.store.openSessionDir(state.id),
+    );
+}
+
+test "read-only session page replays canonical state for a deferred token" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "dirty-read-only-page", ctx.workspace);
+    defer state.deinit(alloc);
+    var loaded = try ctx.store.startWritableSession(alloc, state);
+    defer loaded.deinit(alloc);
+
+    var warm = try ctx.store.listResumablePage(alloc, null, null);
+    warm.deinit(alloc);
+    var session_dir = try ctx.store.openSessionDir(state.id);
+    defer session_dir.close();
+    var manifest_file = try session_dir.dir.openFile(io_mod.getIo(), "session.json", .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    });
+    const stale_manifest = try io_mod.readFileToEnd(
+        alloc,
+        &manifest_file,
+        session_projection.manifest_max_bytes + 1,
+    );
+    manifest_file.close(io_mod.getIo());
+    defer alloc.free(stale_manifest);
+
+    var replacement = try loaded.state.dupe(alloc);
+    defer replacement.deinit(alloc);
+    replacement.updated_at_ms = 30;
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    defer latest_lock.release();
+    _ = try loaded.commitStateReplacement(
+        alloc,
+        replacement,
+        .compaction,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    try io_mod.durableReplaceVerified(
+        alloc,
+        &session_dir,
+        "session.json",
+        stale_manifest,
+    );
+
+    var read_only = try Store.initReadOnlyFromHome(alloc, ctx.home, ctx.workspace);
+    defer read_only.deinit(alloc);
+    var page = try read_only.listSessionPage(
+        alloc,
+        .all_workspaces,
+        null,
+        session_list_default_limit,
+    );
+    defer page.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), page.summaries.items.len);
+    try std.testing.expectEqual(@as(i64, 30), page.summaries.items[0].updated_at_ms);
+}
+
+test "writable picker returns canonical results while deferred repair is busy" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "dirty-writable-picker",
+        ctx.workspace,
+        20,
+        "picker prompt",
+    );
+    var warm = try ctx.store.listResumablePage(alloc, null, null);
+    warm.deinit(alloc);
+    var writer = try ctx.store.resumeTargetForWrite(
+        alloc,
+        .{ .id = "dirty-writable-picker" },
+        ctx.workspace,
+        .{},
+    );
+
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    _ = try writer.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        30,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    writer.deinit(alloc);
+
+    var page = try ctx.store.listResumablePage(alloc, null, null);
+    defer page.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), page.summaries.items.len);
+    try std.testing.expectEqual(@as(i64, 30), page.summaries.items[0].updated_at_ms);
+
+    var latest = try sessions.dir.openDir(io_mod.getIo(), latest_sessions_dir, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer latest.close(io_mod.getIo());
+    var deferred = try latest.openDir(io_mod.getIo(), "deferred", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer deferred.close(io_mod.getIo());
+    var token = try deferred.openFile(io_mod.getIo(), "dirty-writable-picker", .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    });
+    token.close(io_mod.getIo());
+
+    latest_lock.release();
+    var repaired = try ctx.store.listResumablePage(alloc, null, null);
+    repaired.deinit(alloc);
+    try std.testing.expectError(
+        error.FileNotFound,
+        deferred.openFile(io_mod.getIo(), "dirty-writable-picker", .{
+            .mode = .read_only,
+            .allow_directory = false,
+            .follow_symlinks = false,
+            .resolve_beneath = true,
+        }),
+    );
+}
+
+test "writable resume last selects canonically while deferred repair is busy" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "dirty-resume-a",
+        ctx.workspace,
+        20,
+        "first prompt",
+    );
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "dirty-resume-b",
+        ctx.workspace,
+        25,
+        "second prompt",
+    );
+    var writer = try ctx.store.resumeTargetForWrite(
+        alloc,
+        .{ .id = "dirty-resume-a" },
+        ctx.workspace,
+        .{},
+    );
+
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    defer latest_lock.release();
+    _ = try writer.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        30,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    writer.deinit(alloc);
+
+    var admission = (try ctx.store.admitResumeView(alloc, .last)) orelse
+        return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings("dirty-resume-a", admission.sessionId());
+    admission.deinit(alloc);
+
+    var resumed = try ctx.store.resumeTargetForWrite(
+        alloc,
+        .last,
+        ctx.workspace,
+        .{ .log = .{ .commit_lock_deadline_ms = 0 } },
+    );
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("dirty-resume-a", resumed.active_id);
+    try std.testing.expectEqual(@as(i64, 30), resumed.state.updated_at_ms);
+}
+
+test "incremental cache publication clears a stable deferred token" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "incremental-clears-deferred",
+        ctx.workspace,
+        20,
+        "incremental prompt",
+    );
+    var warm = try ctx.store.listResumablePage(alloc, null, null);
+    warm.deinit(alloc);
+    var writer = try ctx.store.resumeTargetForWrite(
+        alloc,
+        .{ .id = "incremental-clears-deferred" },
+        ctx.workspace,
+        .{},
+    );
+    defer writer.deinit(alloc);
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    _ = try writer.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        30,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    latest_lock.release();
+    _ = try writer.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = false } },
+        40,
+        .retry_expected_tail,
+        .{},
+    );
+    try expectDeferredCacheTokenMissing(alloc, &sessions, writer.active_id);
+}
+
+test "deferred token compare-before-clear retains a newer token" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "newer-deferred-token", ctx.workspace);
+    defer state.deinit(alloc);
+    var writer = try ctx.store.startWritableSession(alloc, state);
+    var writer_open = true;
+    defer if (writer_open) writer.deinit(alloc);
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    _ = try writer.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        30,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+    latest_lock.release();
+    var observed = try summary_codec.readDeferredCacheTokens(alloc, &sessions);
+    defer summary_codec.freeDeferredCacheTokens(alloc, &observed);
+    try std.testing.expectEqual(@as(usize, 1), observed.items.len);
+    writer.deinit(alloc);
+    writer_open = false;
+
+    var newer = observed.items[0].position;
+    newer.through_seq += 1;
+    newer.through_event_id = [_]u8{0xcd} ** 16;
+    newer.through_event_log_bytes += 1;
+    const cache = try LatestCache.init(alloc, &sessions, .{}, .maintain);
+    defer cache.deinit(alloc);
+    try cache.writeDeferredToken(
+        alloc,
+        state.id,
+        ctx.workspace,
+        newer,
+    );
+    try latest_pointer.clearObservedDeferredToken(
+        alloc,
+        &sessions,
+        observed.items[0],
+    );
+    var current = (try summary_codec.readDeferredCacheToken(
+        alloc,
+        &sessions,
+        state.id,
+    )) orelse return error.TestExpectedEqual;
+    defer current.deinit(alloc);
+    try std.testing.expectEqualDeep(newer, current.position);
+}
+
+test "failed canonical publication retains a safe false-positive deferred token" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "false-positive-deferred", ctx.workspace);
+    defer state.deinit(alloc);
+    var writer = try ctx.store.startWritableSession(alloc, state);
+    defer writer.deinit(alloc);
+    const prior = writer.position;
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    var failure = MigrationBoundaryFailure{ .target = .after_event_sync };
+    var options = failure.options().log;
+    options.commit_lock_deadline_ms = 0;
+    try std.testing.expectError(
+        error.SessionPersistenceDegraded,
+        writer.appendEvent(
+            alloc,
+            .{ .preferences_changed = .{ .fast_mode = true } },
+            30,
+            .retry_expected_tail,
+            options,
+        ),
+    );
+    latest_lock.release();
+    try std.testing.expectEqualDeep(prior, writer.position);
+
+    var page = try ctx.store.listResumablePage(alloc, null, null);
+    page.deinit(alloc);
+    var token = (try summary_codec.readDeferredCacheToken(
+        alloc,
+        &sessions,
+        state.id,
+    )) orelse return error.TestExpectedEqual;
+    defer token.deinit(alloc);
+    try std.testing.expect(token.position.through_seq > prior.through_seq);
+}
+
+test "dirty relationship and managed-child candidates use canonical summaries" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "dirty-candidate-summary", ctx.workspace);
+    defer state.deinit(alloc);
+    var writer = try ctx.store.startWritableSession(alloc, state);
+    defer writer.deinit(alloc);
+    var replacement = try writer.state.dupe(alloc);
+    defer replacement.deinit(alloc);
+    replacement.updated_at_ms = 30;
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    var latest_lock = try io_mod.acquireTimedAdvisoryLock(
+        &sessions,
+        latest_sessions_lock_file,
+        2000,
+    );
+    defer latest_lock.release();
+    _ = try writer.commitStateReplacement(
+        alloc,
+        replacement,
+        .compaction,
+        .retry_expected_tail,
+        .{ .commit_lock_deadline_ms = 0 },
+    );
+
+    var managed = try ctx.store.listManagedChildCandidatesForWorkspace(alloc);
+    defer freeSummaries(alloc, &managed);
+    try std.testing.expectEqual(@as(usize, 1), managed.items.len);
+    try std.testing.expectEqual(@as(i64, 30), managed.items[0].updated_at_ms);
+
+    var relationship = try ctx.store.listRelationshipMigrationCandidates(
+        alloc,
+        .{},
+    );
+    defer relationship.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), relationship.ids.items.len);
+    try std.testing.expectEqualStrings(
+        "dirty-candidate-summary",
+        relationship.ids.items[0],
+    );
+}
+
+test "writable repair removes a stable orphan deferred token" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    const cache = try LatestCache.init(alloc, &sessions, .{}, .maintain);
+    defer cache.deinit(alloc);
+    try cache.writeDeferredToken(
+        alloc,
+        "orphan-deferred-token",
+        ctx.workspace,
+        .{
+            .log_generation = [_]u8{0x12} ** 16,
+            .through_seq = 1,
+            .through_event_id = [_]u8{0xab} ** 16,
+            .through_event_log_bytes = 100,
+        },
+    );
+
+    var page = try ctx.store.listResumablePage(alloc, null, null);
+    page.deinit(alloc);
+    try expectDeferredCacheTokenMissing(
+        alloc,
+        &sessions,
+        "orphan-deferred-token",
+    );
+}
+
+test "pristine discard removes its deferred token" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+    var state = try testDurableState(alloc, "discard-deferred-token", ctx.workspace);
+    defer state.deinit(alloc);
+    var loaded = try ctx.store.startWritableSession(alloc, state);
+    var sessions = ctx.store.canonical_root.sessions orelse return error.TestExpectedEqual;
+    const cache = try LatestCache.init(alloc, &sessions, .{}, .maintain);
+    defer cache.deinit(alloc);
+    try cache.writeDeferredToken(
+        alloc,
+        loaded.active_id,
+        loaded.state.workspace_root,
+        loaded.position,
+    );
+
+    try std.testing.expectEqual(
+        PristineDiscardDisposition.discarded,
+        ctx.store.discardPristineStartedSession(alloc, &loaded),
+    );
+    try expectDeferredCacheTokenMissing(alloc, &sessions, state.id);
 }
 
 test "degraded-tail recovery republishes the workspace latest pointer" {

--- a/src/core/session/session_summary_codec.zig
+++ b/src/core/session/session_summary_codec.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const io_mod = @import("../shared/io.zig");
 const session = @import("session.zig");
+const session_replay = @import("session_replay.zig");
 const Allocator = std.mem.Allocator;
 
 const paths = @import("session_store_paths.zig");
@@ -45,10 +46,263 @@ const session_index_marker_contents = "pending\n";
 const relationship_migration_snapshot_file = "relationship-migration-index.json";
 pub const max_session_index_bytes: usize = 16 * 1024 * 1024;
 const session_index_schema_version: i64 = 3;
+const deferred_cache_token_schema_version: i64 = 1;
+pub const max_deferred_cache_token_bytes: usize = 4 * 1024;
+const max_deferred_cache_token_count: usize = 4096;
+pub const deferred_cache_dir = "deferred";
 pub const relationship_migration_candidate_limit: usize = 16;
 const relationship_migration_read_bytes: usize = 64 * 1024;
 const relationship_migration_overlap_bytes: u64 = 512;
 const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+const private_dir_permissions = std.Io.File.Permissions.fromMode(0o700);
+
+const DeferredCachePositionJson = struct {
+    log_generation: []const u8,
+    through_seq: u64,
+    through_event_id: []const u8,
+    through_event_log_bytes: u64,
+};
+
+const DeferredCacheTokenJson = struct {
+    schema_version: i64,
+    session_id: []const u8,
+    workspace_root: []const u8,
+    position: DeferredCachePositionJson,
+};
+
+pub const DeferredCacheToken = struct {
+    session_id: []u8,
+    workspace_root: []u8,
+    position: session_replay.CommitPosition,
+
+    pub fn deinit(self: *DeferredCacheToken, alloc: Allocator) void {
+        alloc.free(self.session_id);
+        alloc.free(self.workspace_root);
+        self.* = undefined;
+    }
+};
+
+pub fn encodeDeferredCacheToken(
+    alloc: Allocator,
+    session_id: []const u8,
+    workspace_root: []const u8,
+    position: session_replay.CommitPosition,
+) ![]u8 {
+    try validateSessionId(session_id);
+    try paths.validateWorkspaceRoot(workspace_root);
+
+    const generation = std.fmt.bytesToHex(position.log_generation, .lower);
+    const event_id = std.fmt.bytesToHex(position.through_event_id, .lower);
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try out.writer.print("{{\"schema_version\":{d},\"session_id\":", .{deferred_cache_token_schema_version});
+    try std.json.Stringify.value(session_id, .{}, &out.writer);
+    try out.writer.writeAll(",\"workspace_root\":");
+    try std.json.Stringify.value(workspace_root, .{}, &out.writer);
+    try out.writer.writeAll(",\"position\":{\"log_generation\":");
+    try std.json.Stringify.value(&generation, .{}, &out.writer);
+    try out.writer.print(",\"through_seq\":{d},\"through_event_id\":", .{position.through_seq});
+    try std.json.Stringify.value(&event_id, .{}, &out.writer);
+    try out.writer.print(",\"through_event_log_bytes\":{d}}}}}", .{position.through_event_log_bytes});
+    const encoded = try out.toOwnedSlice();
+    if (encoded.len > max_deferred_cache_token_bytes) {
+        alloc.free(encoded);
+        return error.InvalidSessionIndex;
+    }
+    return encoded;
+}
+
+pub fn decodeDeferredCacheToken(
+    alloc: Allocator,
+    bytes: []const u8,
+) !DeferredCacheToken {
+    if (bytes.len == 0 or bytes.len > max_deferred_cache_token_bytes) {
+        return error.InvalidSessionIndex;
+    }
+    var parsed = std.json.parseFromSlice(
+        DeferredCacheTokenJson,
+        alloc,
+        bytes,
+        .{ .allocate = .alloc_always },
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidSessionIndex,
+    };
+    defer parsed.deinit();
+
+    if (parsed.value.schema_version != deferred_cache_token_schema_version) {
+        return error.InvalidSessionIndex;
+    }
+    validateSessionId(parsed.value.session_id) catch
+        return error.InvalidSessionIndex;
+    paths.validateWorkspaceRoot(parsed.value.workspace_root) catch
+        return error.InvalidSessionIndex;
+
+    const session_id = try alloc.dupe(u8, parsed.value.session_id);
+    errdefer alloc.free(session_id);
+    const workspace_root = try alloc.dupe(u8, parsed.value.workspace_root);
+    errdefer alloc.free(workspace_root);
+    return .{
+        .session_id = session_id,
+        .workspace_root = workspace_root,
+        .position = .{
+            .log_generation = try parseDeferredTokenIdentifier(
+                parsed.value.position.log_generation,
+            ),
+            .through_seq = parsed.value.position.through_seq,
+            .through_event_id = try parseDeferredTokenIdentifier(
+                parsed.value.position.through_event_id,
+            ),
+            .through_event_log_bytes = parsed.value.position.through_event_log_bytes,
+        },
+    };
+}
+
+fn parseDeferredTokenIdentifier(raw: []const u8) ![16]u8 {
+    if (raw.len != 32) return error.InvalidSessionIndex;
+    var result: [16]u8 = undefined;
+    _ = std.fmt.hexToBytes(&result, raw) catch return error.InvalidSessionIndex;
+    const canonical = std.fmt.bytesToHex(result, .lower);
+    if (!std.mem.eql(u8, &canonical, raw)) return error.InvalidSessionIndex;
+    return result;
+}
+
+pub fn deferredCachePresent(
+    sessions: *const io_mod.VerifiedDir,
+) !bool {
+    var deferred = (try openDeferredCacheDirectory(sessions)) orelse return false;
+    defer deferred.close();
+    var iter = deferred.dir.iterate();
+    return (try iter.next(io_mod.getIo())) != null;
+}
+
+fn openDeferredCacheDirectory(
+    sessions: *const io_mod.VerifiedDir,
+) !?io_mod.VerifiedDir {
+    var latest = sessions.dir.openDir(io_mod.getIo(), "latest", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        error.NotDir, error.SymLinkLoop => return error.InvalidSessionIndex,
+        else => return err,
+    };
+    defer latest.close(io_mod.getIo());
+
+    var deferred = latest.openDir(io_mod.getIo(), deferred_cache_dir, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        error.NotDir, error.SymLinkLoop => return error.InvalidSessionIndex,
+        else => return err,
+    };
+    errdefer deferred.close(io_mod.getIo());
+    try requirePrivateCacheDirectory(latest);
+    try requirePrivateCacheDirectory(deferred);
+    return .{ .dir = deferred };
+}
+
+fn requirePrivateCacheDirectory(dir: std.Io.Dir) !void {
+    const stat = try dir.stat(io_mod.getIo());
+    if (stat.kind != .directory or
+        stat.permissions.toMode() & 0o777 != private_dir_permissions.toMode())
+    {
+        return error.InvalidSessionIndex;
+    }
+}
+
+pub fn readDeferredCacheTokens(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+) !std.ArrayList(DeferredCacheToken) {
+    var tokens: std.ArrayList(DeferredCacheToken) = .empty;
+    errdefer freeDeferredCacheTokens(alloc, &tokens);
+    var deferred = (try openDeferredCacheDirectory(sessions)) orelse return tokens;
+    defer deferred.close();
+
+    var iter = deferred.dir.iterate();
+    while (try iter.next(io_mod.getIo())) |entry| {
+        if (tokens.items.len >= max_deferred_cache_token_count) {
+            return error.InvalidSessionIndex;
+        }
+        if (entry.kind != .file) return error.InvalidSessionIndex;
+        try validateSessionId(entry.name);
+        var token = try readDeferredCacheTokenFromDirectory(
+            alloc,
+            &deferred,
+            entry.name,
+        );
+        errdefer token.deinit(alloc);
+        if (!std.mem.eql(u8, entry.name, token.session_id)) {
+            return error.InvalidSessionIndex;
+        }
+        try tokens.append(alloc, token);
+    }
+    return tokens;
+}
+
+pub fn readDeferredCacheToken(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+    session_id: []const u8,
+) !?DeferredCacheToken {
+    try validateSessionId(session_id);
+    var deferred = (try openDeferredCacheDirectory(sessions)) orelse return null;
+    defer deferred.close();
+    return readDeferredCacheTokenFromDirectory(
+        alloc,
+        &deferred,
+        session_id,
+    ) catch |err| switch (err) {
+        error.FileNotFound => null,
+        else => return err,
+    };
+}
+
+fn readDeferredCacheTokenFromDirectory(
+    alloc: Allocator,
+    deferred: *const io_mod.VerifiedDir,
+    session_id: []const u8,
+) !DeferredCacheToken {
+    var file = deferred.dir.openFile(io_mod.getIo(), session_id, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    }) catch |err| switch (err) {
+        error.NotDir, error.SymLinkLoop, error.IsDir => {
+            return error.InvalidSessionIndex;
+        },
+        else => return err,
+    };
+    defer file.close(io_mod.getIo());
+    const stat = try file.stat(io_mod.getIo());
+    if (stat.kind != .file or stat.nlink != 1 or
+        stat.permissions.toMode() & 0o777 != private_file_permissions.toMode() or
+        stat.size == 0 or stat.size > max_deferred_cache_token_bytes)
+    {
+        return error.InvalidSessionIndex;
+    }
+    const bytes = io_mod.readFileToEnd(
+        alloc,
+        &file,
+        max_deferred_cache_token_bytes + 1,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidSessionIndex,
+    };
+    defer alloc.free(bytes);
+    return decodeDeferredCacheToken(alloc, bytes);
+}
+
+pub fn freeDeferredCacheTokens(
+    alloc: Allocator,
+    tokens: *std.ArrayList(DeferredCacheToken),
+) void {
+    for (tokens.items) |*token| token.deinit(alloc);
+    tokens.deinit(alloc);
+}
 
 pub const RelationshipMigrationCursor = struct {
     inode: u64 = 0,
@@ -1060,6 +1314,14 @@ pub fn readSessionIndex(
     alloc: Allocator,
     sessions: *const io_mod.VerifiedDir,
 ) !std.ArrayList(SessionSummary) {
+    if (try deferredCachePresent(sessions)) return error.InvalidSessionIndex;
+    return readSessionIndexForRepair(alloc, sessions);
+}
+
+pub fn readSessionIndexForRepair(
+    alloc: Allocator,
+    sessions: *const io_mod.VerifiedDir,
+) !std.ArrayList(SessionSummary) {
     if (try sessionIndexMarkerPresent(sessions)) return error.InvalidSessionIndex;
     var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
     defer file.close(io_mod.getIo());
@@ -1076,6 +1338,7 @@ pub fn readSessionIndexPage(
     sessions: *const io_mod.VerifiedDir,
     options: SessionIndexPageOptions,
 ) !ResumableSessionPage {
+    if (try deferredCachePresent(sessions)) return error.InvalidSessionIndex;
     if (try sessionIndexMarkerPresent(sessions)) return error.InvalidSessionIndex;
     var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
     defer file.close(io_mod.getIo());
@@ -1098,6 +1361,7 @@ pub fn readSessionIndexWorkspaceCandidates(
     sessions: *const io_mod.VerifiedDir,
     workspace_root: []const u8,
 ) !std.ArrayList(SessionSummary) {
+    if (try deferredCachePresent(sessions)) return error.InvalidSessionIndex;
     var file = try openVerifiedSessionIndexFile(sessions, session_index_file);
     defer file.close(io_mod.getIo());
     const bytes = io_mod.readFileToEnd(
@@ -1120,6 +1384,7 @@ pub fn readRelationshipMigrationCandidatePage(
     sessions: *const io_mod.VerifiedDir,
     continuation: RelationshipMigrationCursor,
 ) !RelationshipMigrationCandidatePage {
+    if (try deferredCachePresent(sessions)) return error.InvalidSessionIndex;
     var file = try openVerifiedSessionIndexFile(
         sessions,
         relationship_migration_snapshot_file,
@@ -1949,4 +2214,128 @@ test "state summary fast parser reads generated cache shape" {
 
     try std.testing.expectEqual(@as(usize, 2), summary.count);
     try std.testing.expectEqualStrings("session-2", summary.latest_id.?);
+}
+
+test "deferred cache token round trips an exact commit position" {
+    const alloc = std.testing.allocator;
+    const position = session_replay.CommitPosition{
+        .log_generation = [_]u8{0x12} ** 16,
+        .through_seq = 42,
+        .through_event_id = [_]u8{0xab} ** 16,
+        .through_event_log_bytes = 4096,
+    };
+    const encoded = try encodeDeferredCacheToken(
+        alloc,
+        "deferred-token-round-trip",
+        "/tmp/workspace",
+        position,
+    );
+    defer alloc.free(encoded);
+
+    var decoded = try decodeDeferredCacheToken(alloc, encoded);
+    defer decoded.deinit(alloc);
+    try std.testing.expectEqualStrings("deferred-token-round-trip", decoded.session_id);
+    try std.testing.expectEqualStrings("/tmp/workspace", decoded.workspace_root);
+    try std.testing.expectEqualDeep(position, decoded.position);
+}
+
+test "deferred cache token rejects malformed and noncanonical input" {
+    const invalid = [_][]const u8{
+        "",
+        "{}",
+        "{\"schema_version\":2,\"session_id\":\"session\",\"workspace_root\":\"/tmp/workspace\",\"position\":{\"log_generation\":\"12121212121212121212121212121212\",\"through_seq\":1,\"through_event_id\":\"abababababababababababababababab\",\"through_event_log_bytes\":1}}",
+        "{\"schema_version\":1,\"session_id\":\"../session\",\"workspace_root\":\"/tmp/workspace\",\"position\":{\"log_generation\":\"12121212121212121212121212121212\",\"through_seq\":1,\"through_event_id\":\"abababababababababababababababab\",\"through_event_log_bytes\":1}}",
+        "{\"schema_version\":1,\"session_id\":\"session\",\"workspace_root\":\"relative\",\"position\":{\"log_generation\":\"12121212121212121212121212121212\",\"through_seq\":1,\"through_event_id\":\"abababababababababababababababab\",\"through_event_log_bytes\":1}}",
+        "{\"schema_version\":1,\"session_id\":\"session\",\"workspace_root\":\"/tmp/workspace\",\"position\":{\"log_generation\":\"1212121212121212121212121212121A\",\"through_seq\":1,\"through_event_id\":\"abababababababababababababababab\",\"through_event_log_bytes\":1}}",
+    };
+    for (invalid) |bytes| {
+        try std.testing.expectError(
+            error.InvalidSessionIndex,
+            decodeDeferredCacheToken(std.testing.allocator, bytes),
+        );
+    }
+
+    var oversized: [max_deferred_cache_token_bytes + 1]u8 = undefined;
+    @memset(&oversized, 'x');
+    try std.testing.expectError(
+        error.InvalidSessionIndex,
+        decodeDeferredCacheToken(std.testing.allocator, &oversized),
+    );
+}
+
+test "deferred cache token reader rejects non-private files" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        std.testing.io,
+        "sessions",
+        private_dir_permissions,
+    );
+    var sessions_dir = try tmp.dir.openDir(std.testing.io, "sessions", .{
+        .iterate = true,
+    });
+    defer sessions_dir.close(std.testing.io);
+    var sessions = io_mod.VerifiedDir{ .dir = sessions_dir };
+    var latest = try io_mod.openOrCreateVerifiedPrivateDir(&sessions, "latest");
+    defer latest.close();
+    var deferred = try io_mod.openOrCreateVerifiedPrivateDir(
+        &latest,
+        deferred_cache_dir,
+    );
+    defer deferred.close();
+    const encoded = try encodeDeferredCacheToken(
+        alloc,
+        "non-private-token",
+        "/tmp/workspace",
+        .{
+            .log_generation = [_]u8{0x12} ** 16,
+            .through_seq = 1,
+            .through_event_id = [_]u8{0xab} ** 16,
+            .through_event_log_bytes = 100,
+        },
+    );
+    defer alloc.free(encoded);
+    try io_mod.durableReplaceVerified(
+        alloc,
+        &deferred,
+        "non-private-token",
+        encoded,
+    );
+    var file = try deferred.dir.openFile(std.testing.io, "non-private-token", .{
+        .mode = .read_write,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    });
+    try file.setPermissions(
+        std.testing.io,
+        std.Io.File.Permissions.fromMode(0o644),
+    );
+    file.close(std.testing.io);
+
+    try std.testing.expect(try deferredCachePresent(&sessions));
+    try std.testing.expectError(
+        error.InvalidSessionIndex,
+        readDeferredCacheTokens(alloc, &sessions),
+    );
+}
+
+test "deferred cache token parser handles fuzzed bytes" {
+    try std.testing.fuzz({}, fuzzDeferredCacheToken, .{
+        .corpus = &.{
+            "",
+            "{}",
+            "{\"schema_version\":1}",
+        },
+    });
+}
+
+fn fuzzDeferredCacheToken(_: void, smith: *std.testing.Smith) !void {
+    var buffer: [max_deferred_cache_token_bytes + 1]u8 = undefined;
+    const len: usize = @intCast(smith.slice(&buffer));
+    var decoded = decodeDeferredCacheToken(
+        std.testing.allocator,
+        buffer[0..len],
+    ) catch return;
+    decoded.deinit(std.testing.allocator);
 }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -4143,6 +4143,147 @@ describe("cli: ask success", () => {
     180_000,
   );
 
+  test(
+    "saved ask survives session cache contention and repairs after release",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-session-cache-contention-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const lockReady = join(root, "latest-lock-ready");
+      const gateway = startFakeGateway([
+        fakeGatewayFinalText("first saved turn"),
+        fakeGatewayFinalText("contended exact turn"),
+        fakeGatewayFinalText("contended latest turn"),
+        fakeGatewayFinalText("repairing turn"),
+      ]);
+      let lockHolder: ReturnType<typeof Bun.spawn> | null = null;
+      try {
+        mkdirSync(home);
+        mkdirSync(workspace);
+        const workspaceRoot = realpathSync(workspace);
+        const env = {
+          HOME: realpathSync(home),
+          AI_GATEWAY_API_KEY: "fake-session-cache-contention-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_AUTO_UPGRADE: "0",
+        };
+
+        const first = await runFx(
+          ["ask", "--json", "--auto", "Reply with the first saved turn."],
+          { cwd: workspaceRoot, env, timeoutMs: 60_000 },
+        );
+        expect(first.code).toBe(0);
+        expect(first.stderr).toBe("");
+        const sessionId = JSON.parse(first.stdout).session_id as string;
+        const lockPath = join(home, ".fx", "sessions", "latest.lock");
+        lockHolder = Bun.spawn(
+          [
+            "python3",
+            "-c",
+            [
+              "import fcntl, os, sys, time",
+              "fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o600)",
+              "fcntl.flock(fd, fcntl.LOCK_EX)",
+              "open(sys.argv[2], 'w').close()",
+              "time.sleep(300)",
+            ].join("\n"),
+            lockPath,
+            lockReady,
+          ],
+          { stdout: "ignore", stderr: "pipe" },
+        );
+        for (let attempt = 0; attempt < 250 && !existsSync(lockReady); attempt += 1) {
+          await Bun.sleep(20);
+        }
+        expect(existsSync(lockReady)).toBe(true);
+
+        const exact = await runFx(
+          [
+            "ask",
+            "--json",
+            "--auto",
+            "--resume-id",
+            sessionId,
+            "Reply with the contended exact turn.",
+          ],
+          { cwd: workspaceRoot, env, timeoutMs: 60_000 },
+        );
+        expect(exact.code).toBe(0);
+        expect(exact.stderr).toBe("");
+        expect(JSON.parse(exact.stdout).output.trim()).toBe("contended exact turn");
+        const tokenPath = join(
+          home,
+          ".fx",
+          "sessions",
+          "latest",
+          "deferred",
+          sessionId,
+        );
+        expect(existsSync(tokenPath)).toBe(true);
+
+        const listed = await runFx(["sessions", "--json"], {
+          cwd: workspaceRoot,
+          env: { HOME: home, ...NO_GATEWAY_AUTH },
+          timeoutMs: 60_000,
+        });
+        expect(listed.code).toBe(0);
+        expect(listed.stderr).toBe("");
+        expect(JSON.parse(listed.stdout).sessions[0]).toMatchObject({
+          id: sessionId,
+          history_len: 2,
+        });
+
+        const latest = await runFx(
+          [
+            "ask",
+            "--json",
+            "--auto",
+            "--resume",
+            "last",
+            "Reply with the contended latest turn.",
+          ],
+          { cwd: workspaceRoot, env, timeoutMs: 60_000 },
+        );
+        expect(latest.code).toBe(0);
+        expect(latest.stderr).toBe("");
+        expect(JSON.parse(latest.stdout).session_id).toBe(sessionId);
+        expect(JSON.parse(latest.stdout).output.trim()).toBe("contended latest turn");
+
+        lockHolder.kill();
+        await lockHolder.exited;
+        lockHolder = null;
+        const repaired = await runFx(
+          [
+            "ask",
+            "--json",
+            "--auto",
+            "--resume-id",
+            sessionId,
+            "Reply with the repairing turn.",
+          ],
+          { cwd: workspaceRoot, env, timeoutMs: 60_000 },
+        );
+        expect(repaired.code).toBe(0);
+        expect(repaired.stderr).toBe("");
+        expect(JSON.parse(repaired.stdout).output.trim()).toBe("repairing turn");
+        expect(existsSync(tokenPath)).toBe(false);
+        expect(gateway.requests).toHaveLength(4);
+      } finally {
+        if (lockHolder) {
+          lockHolder.kill();
+          await lockHolder.exited;
+        }
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    300_000,
+  );
+
   test.skipIf(!HAS_API_KEY)(
     "fx ask --json --no-save --auto returns valid JSON with output",
     async () => {


### PR DESCRIPTION
## Summary

- Continue same-workspace saved-session turns when another process holds the latest cache lock.
- Keep session listings and latest-session resume current while cache publication is deferred.
- Repair derived cache state without clearing newer invalidations.
- Preserve strict failures for creation, workspace changes, migration, recovery publication, and canonical commit locks.