### PR TITLE
Fix stale assistant tail test API

### DIFF
--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -5268,7 +5268,7 @@ test "slash picker dismissal resolves transcript extent before layout convergenc
         .images = &.{},
     });
     _ = try h.shell.streamAssistantChunk(alloc, &h.metrics, transcript.items);
-    h.shell.setAssistantTailWritable(false);
+    h.shell.transcript_release = h.shell.transcript_release.with_assistant_tail_writable(false);
     try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
     try h.flush();
     try std.testing.expectEqual(@as(u16, 70), h.shell.last_visible_transcript_last_row);


### PR DESCRIPTION
## Summary

- migrate one resize test from the removed `setAssistantTailWritable` helper
- use the current immutable `transcript_release.with_assistant_tail_writable(false)` API
- restore compilation of the full Zig test target

## Why

`origin/main` retained one call to the removed mutable helper after the transcript-release API migration. That stale test-only call caused `zig build test` to fail during compilation across CI and Full CI before any tests could run.

## Impact

The test now uses the same current API pattern as neighboring resize and transcript tests. Production behavior is unchanged.

## Testing

- `zig build test -Doptimize=Debug`
- `zig build test -Doptimize=ReleaseSafe`
- `zig build`
- `zig fmt --check src/`
- `git diff --check`
- `./zig-out/bin/fx --version`

Unblocks [PR #123](https://github.com/vercel-labs/fx/pull/123).