### PR TITLE
Keep the MCP session id alive until in-flight requests drain

### DIFF
--- a/src/core/mcp/legacy_streamable_http.zig
+++ b/src/core/mcp/legacy_streamable_http.zig
@@ -110,6 +110,7 @@ pub const Client = struct {
     lifecycle_cond: std.Io.Condition = .init,
     active_users: usize = 0,
     retiring: bool = false,
+    session_retired: std.atomic.Value(bool) = .init(false),
     auth_mutex: std.Io.Mutex = .init,
     auth_challenge: ?[]u8 = null,
 
@@ -144,12 +145,13 @@ pub const Client = struct {
         self.lifecycle_mutex.unlock(io_mod.getIo());
     }
 
+    /// Stops new work and records that the server rejected this session id.
+    /// The id stays owned by the client because requests already in flight are
+    /// still sending it as a header, so only `deinit` may free it: it drains
+    /// `active_users` and runs after the subscription listener is joined.
     pub fn retireExpiredSession(self: *Client) void {
+        self.session_retired.store(true, .release);
         self.stopping.store(true, .release);
-        if (self.session_id) |value| {
-            self.owner_allocator.free(value);
-            self.session_id = null;
-        }
     }
 
     pub fn request(self: *Client, alloc: Allocator, options: RequestOptions) ![]u8 {
@@ -248,8 +250,18 @@ pub const Client = struct {
         self.auth_challenge = replacement;
     }
 
+    /// Whether teardown should still send the session DELETE. Split out so a
+    /// test can assert both directions; `terminateSession` swallows every
+    /// transport error, so the skip is otherwise unobservable.
+    fn shouldTerminateSession(self: *const Client) bool {
+        if (self.session_id == null) return false;
+        // The server answered 404 for this session id, so a DELETE would very
+        // likely 404 as well. Skip it rather than spend a request.
+        return !self.session_retired.load(.acquire);
+    }
+
     fn terminateSession(self: *Client) void {
-        if (self.session_id == null) return;
+        if (!self.shouldTerminateSession()) return;
         const deadline = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake)
             .addDuration(.{
             .clock = .awake,
@@ -1409,4 +1421,50 @@ test "legacy Streamable HTTP rejects unsafe resumption header values" {
             .control = undefined,
         }, false),
     );
+}
+
+fn testClientWithSession(alloc: Allocator, session_id: []const u8) !*Client {
+    const client = try alloc.create(Client);
+    errdefer alloc.destroy(client);
+    client.* = .{
+        .owner_allocator = alloc,
+        .url = "http://127.0.0.1:1/mcp",
+        .static_headers = &.{},
+        .version = .v2025_03_26,
+        .session_id = try alloc.dupe(u8, session_id),
+    };
+    return client;
+}
+
+test "retiring an expired session keeps the id alive for in-flight requests" {
+    const alloc = std.testing.allocator;
+    const client = try testClientWithSession(alloc, "session-abc");
+
+    // Stand in for a request that is already past `acquireUse` and is using
+    // session_id as an outgoing header.
+    try std.testing.expect(client.acquireUse());
+    const in_flight = client.session_id.?;
+
+    client.retireExpiredSession();
+
+    try std.testing.expect(client.session_id != null);
+    try std.testing.expectEqualStrings("session-abc", in_flight);
+
+    client.releaseUse();
+    // deinit drains active_users before freeing, so it owns the free.
+    client.deinit();
+}
+
+test "a retired session refuses new leases and skips the delete on teardown" {
+    const alloc = std.testing.allocator;
+    const client = try testClientWithSession(alloc, "session-xyz");
+
+    // A live session is still deleted on teardown; only retirement skips it.
+    try std.testing.expect(client.shouldTerminateSession());
+
+    client.retireExpiredSession();
+
+    try std.testing.expect(!client.acquireUse());
+    try std.testing.expect(!client.shouldTerminateSession());
+    client.deinit();
 }

--- a/src/core/mcp/legacy_streamable_http.zig
+++ b/src/core/mcp/legacy_streamable_http.zig
@@ -1455,6 +1455,59 @@ test "retiring an expired session keeps the id alive for in-flight requests" {
     client.deinit();
 }
 
+/// Stands in for a request that is already in flight: it holds a use lease and
+/// keeps reading `session_id` as an outgoing header would, then releases.
+const LeaseProbe = struct {
+    client: *Client,
+    entered: *std.atomic.Value(bool),
+    released: *std.atomic.Value(bool),
+    id_stayed_valid: *std.atomic.Value(bool),
+
+    fn run(self: LeaseProbe) void {
+        self.entered.store(true, .release);
+        var i: usize = 0;
+        while (i < 200_000) : (i += 1) {
+            const id = self.client.session_id orelse {
+                self.id_stayed_valid.store(false, .release);
+                break;
+            };
+            if (!std.mem.eql(u8, id, "session-drain")) {
+                self.id_stayed_valid.store(false, .release);
+                break;
+            }
+        }
+        self.released.store(true, .release);
+        self.client.releaseUse();
+    }
+};
+
+test "deinit waits for an in-flight lease before it frees the session id" {
+    const alloc = std.testing.allocator;
+    const client = try testClientWithSession(alloc, "session-drain");
+
+    var entered: std.atomic.Value(bool) = .init(false);
+    var released: std.atomic.Value(bool) = .init(false);
+    var id_stayed_valid: std.atomic.Value(bool) = .init(true);
+
+    try std.testing.expect(client.acquireUse());
+    const probe = try std.Thread.spawn(.{}, LeaseProbe.run, .{LeaseProbe{
+        .client = client,
+        .entered = &entered,
+        .released = &released,
+        .id_stayed_valid = &id_stayed_valid,
+    }});
+    while (!entered.load(.acquire)) {}
+
+    client.retireExpiredSession();
+    client.deinit();
+
+    // deinit must not have returned until the probe gave the lease back, and
+    // the id it was reading must have stayed valid for that whole window.
+    try std.testing.expect(released.load(.acquire));
+    try std.testing.expect(id_stayed_valid.load(.acquire));
+    probe.join();
+}
+
 test "a retired session refuses new leases and skips the delete on teardown" {
     const alloc = std.testing.allocator;
     const client = try testClientWithSession(alloc, "session-xyz");


### PR DESCRIPTION
Fixes #128.

`retireExpiredSession` freed `Client.session_id` the moment a server answered 404 for it. Requests that had already taken an `acquireUse` lease were still passing that slice as their `Mcp-Session-Id` header, and `callToolLegacyHttp` releases `server.connection_lock` before its HTTP call, so a concurrent tool call on the same connection can be mid-flight when recovery frees the buffer. `deinit` already drains `active_users` before freeing the same field; retire waited for nothing.

Retire now records `session_retired`, stops new work, and leaves the free to `deinit`. That makes `session_id` write-once: `initialize` sets it, `deinit` frees it after the drain, and nothing in between mutates it, so the race is gone rather than guarded and no new lock is needed. In-flight requests keep sending the expired id, which the server rejects the same way it already did, instead of sending freed memory.

`terminateSession` keeps skipping its DELETE for a retired session, which previously fell out of the id being nulled. That skip lives in a `shouldTerminateSession` predicate rather than inline, because `terminateSession` swallows every transport error: with the guard inline, deleting it changed nothing any test could observe.

## Verification

- New test drives the ordering the fix rests on: a second thread holds a lease and reads `session_id` while the main thread retires and calls `deinit`. It asserts `deinit` did not return until the lease came back and the id stayed valid throughout. Reverting retire to the pre-fix free turns both new tests red, so they cover the original defect rather than the shape of the new code.
- `shouldTerminateSession` is asserted in both directions, and replacing its `session_retired` term with `return true` turns the teardown test red.
- `bun test mcp-legacy-remote.test.ts`: 37 pass, 0 fail against the built binary, including the expired-session reinitialization test that drives this path end to end.
- `zig build test` locally on linux-aarch64: no new failures against the same base without this branch.

One caveat worth stating plainly: the concurrency test is a genuine two-thread test, so it is a race reproduction rather than a deterministic one. It failed reliably against the pre-fix code in my runs, but it is timing-shaped by nature.


Intended label: `type: security` (memory safety with a server-controlled trigger); `type: bug` if you would rather scope it that way. I cannot set labels on this repo.

No new root `tests/e2e/*.test.ts` file, so `scripts/pgso/corpus.json` needs no entry.
