### PR TITLE
Classify memory list as read-only

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -748,6 +748,7 @@ pub const memory = ToolSpec{
     .completed_action_label = "Remembered",
     .label_arg_kind = .action,
     .label_arg_default = "memory",
+    .presentation_fn = memory_impl.presentation,
     .permission_target_kind = .none,
     .decode = memory_impl.decode,
     .validate = memory_impl.validate,
@@ -2013,11 +2014,40 @@ test "built-in memory owns product metadata schema and callbacks" {
     try std.testing.expectEqual(tool_dispatch.PermissionTargetKind.none, memory.permission_target_kind);
     try std.testing.expectEqualStrings("Remembering", memory.action_label);
     try std.testing.expectEqualStrings("Remembered", memory.completed_action_label);
+    try std.testing.expect(memory.presentation_fn.? == memory_impl.presentation);
     try std.testing.expect(memory.decode == memory_impl.decode);
     try std.testing.expect(memory.validate.? == memory_impl.validate);
     try std.testing.expect(memory.call == memory_impl.call);
     try std.testing.expect(memory.reads_only_fn == memory_impl.readsOnly);
     try std.testing.expect(memory.irreversible_fn == memory_impl.isIrreversible);
+
+    const list_call = types.ToolCall{
+        .id = "memory_list",
+        .name = "memory",
+        .arguments_json = "{\"action\":\"list\"}",
+    };
+    const save_call = types.ToolCall{
+        .id = "memory_save",
+        .name = "memory",
+        .arguments_json = "{\"action\":\"save\",\"fact\":\"test\"}",
+    };
+    const clear_call = types.ToolCall{
+        .id = "memory_clear",
+        .name = "memory",
+        .arguments_json = "{\"action\":\"clear\"}",
+    };
+    try std.testing.expectEqual(
+        types.ToolActivityKind.read,
+        tool_dispatch.toolActivityKindForCall(std.testing.allocator, registry, list_call),
+    );
+    try std.testing.expectEqual(
+        types.ToolActivityKind.write,
+        tool_dispatch.toolActivityKindForCall(std.testing.allocator, registry, save_call),
+    );
+    try std.testing.expectEqual(
+        types.ToolActivityKind.write,
+        tool_dispatch.toolActivityKindForCall(std.testing.allocator, registry, clear_call),
+    );
 }
 
 test "built-in semantic_search owns product metadata schema and callbacks" {

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3868,7 +3868,7 @@ fn processQueuedPromptLoop(
         }
         var step_has_visible_tool_calls = false;
         for (completion.tool_calls) |call| {
-            if (runtime_tool_presentation.activityKind(deps.tool_registry, call.name) == .ask) continue;
+            if (runtime_tool_presentation.activityKindForCall(arena, deps.tool_registry, call) == .ask) continue;
             step_has_visible_tool_calls = true;
             break;
         }
@@ -4471,7 +4471,7 @@ fn processQueuedPromptLoop(
         const step_has_content = !terminal_provider_completion and completion.content != null and completion.content.?.len > 0;
         if (step_has_content) {
             const first_tool_is_ask = effective_tool_calls.len > 0 and
-                runtime_tool_presentation.activityKind(deps.tool_registry, effective_tool_calls[0].name) == .ask;
+                runtime_tool_presentation.activityKindForCall(arena, deps.tool_registry, effective_tool_calls[0]) == .ask;
             if (!first_tool_is_ask) try deps.push_text(deps.ctx, .{ .assistant_rendered = "\n" });
             silent_tool_steps = 0;
         } else {
@@ -6098,7 +6098,7 @@ fn processQueuedPromptLoop(
                 };
             }
             const execution_lifecycle_id = types.ToolLifecycleId{ .turn_id = turn_id, .call_id = execution_call.id };
-            const execution_is_command = runtime_tool_presentation.activityKind(deps.tool_registry, tool_call.name) == .command;
+            const execution_is_command = runtime_tool_presentation.activityKindForCall(arena, deps.tool_registry, tool_call) == .command;
             var sandbox_widening_feedback: ?[]const u8 = null;
             var sandbox_widening_required: ?runtime_tool_contracts.SandboxScopeRequired = null;
             var sandbox_widening_retry_started = false;

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -472,7 +472,7 @@ pub fn appendOrdinaryExecutedResult(
     memory: types.ToolResultMemory,
     execution: ToolExecutionResult,
 ) !void {
-    const activity = runtime_tool_presentation.activityKind(tool_registry, tool_call.name);
+    const activity = runtime_tool_presentation.activityKindForCall(arena, tool_registry, tool_call);
     try appendToolResultContent(
         arena,
         within_turn_suffix,

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -669,6 +669,15 @@ pub fn activityKind(registry: tool_dispatch.Registry, tool_name: []const u8) typ
     return tool_dispatch.toolActivityKind(registry, tool_name);
 }
 
+pub fn activityKindForCall(
+    alloc: Allocator,
+    registry: tool_dispatch.Registry,
+    call: ToolCall,
+) types.ToolActivityKind {
+    if (tooling_presentation.isProviderSearchAlias(call.name)) return .read;
+    return tool_dispatch.toolActivityKindForCall(alloc, registry, call);
+}
+
 fn formatProvisionalProgressLabel(
     buf: []u8,
     tool_name: []const u8,
@@ -717,7 +726,7 @@ pub noinline fn startToolVisibleLifecycle(
     file_display_path: ?[]const u8,
     advertised_dynamic_tool_names: []const []const u8,
 ) !bool {
-    const activity_kind = activityKind(hooks.tool_registry, call.name);
+    const activity_kind = activityKindForCall(arena, hooks.tool_registry, call);
     if (activity_kind == .ask) return false;
     const redacted_arguments = try text_utils.maskSecrets(arena, call.arguments_json);
     const activity_line = try hooks.describe_tool_action(
@@ -842,7 +851,7 @@ fn finishDeniedToolStatusInternal(
         label,
         advertised_dynamic_tool_names,
     );
-    const command_artifact_handle = if (activityKind(hooks.tool_registry, call.name) == .command)
+    const command_artifact_handle = if (activityKindForCall(arena, hooks.tool_registry, call) == .command)
         try commandArtifactHandle(arena, command_result_json)
     else
         null;
@@ -884,7 +893,7 @@ pub fn finishCancelledToolStatus(
         "Cancelled",
         advertised_dynamic_tool_names,
     );
-    const command_artifact_handle = if (activityKind(hooks.tool_registry, call.name) == .command)
+    const command_artifact_handle = if (activityKindForCall(arena, hooks.tool_registry, call) == .command)
         commandArtifactHandle(arena, result.command_result_json) catch |err| blk: {
             debug_trace.logf("tool", "cancelled command artifact handle omitted err={s}", .{@errorName(err)});
             break :blk null;
@@ -915,7 +924,7 @@ pub fn finishExecutedToolStatus(
     advertised_dynamic_tool_names: []const []const u8,
 ) !void {
     if (!status_started) return;
-    const activity_kind = activityKind(hooks.tool_registry, call.name);
+    const activity_kind = activityKindForCall(arena, hooks.tool_registry, call);
     const command_process_ran = activity_kind == .command and
         result_memory.command_process_presentation != null;
     const base_line = switch (if (command_process_ran) .success else result.status) {
@@ -1414,6 +1423,41 @@ test "tool lifecycle uses activity metadata from the supplied registry" {
         &.{},
     ));
     try std.testing.expectEqual(types.ToolActivityKind.open, capture.events.items[0].authoritative_started.activity_kind);
+}
+
+test "memory list authoritative lifecycle is classified as a read" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var capture = ProvisionalStatusTestCapture{
+        .alloc = alloc,
+        .tool_registry = .{ .tools = &.{test_builtin_tools.memory} },
+    };
+    defer capture.deinit();
+    const hooks = capture.hooks();
+
+    try std.testing.expect(try startToolVisibleLifecycle(
+        &hooks,
+        arena,
+        1,
+        null,
+        .{
+            .id = "memory_list",
+            .name = "memory",
+            .arguments_json = "{\"action\":\"list\"}",
+        },
+        null,
+        &.{},
+    ));
+
+    switch (capture.events.items[0]) {
+        .authoritative_started => |event| try std.testing.expectEqual(
+            types.ToolActivityKind.read,
+            event.activity_kind,
+        ),
+        else => return error.TestExpectedEqual,
+    }
 }
 
 test "presentation grouping spans silent tool steps and splits on visible prose" {

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1177,8 +1177,9 @@ fn formatToolAction(
         return formatInvalidArgsToolAction(arena, state, denied_label, call.name);
     };
 
-    const value = tool_dispatch.toolLabelValue(spec.*, args) orelse spec.label_arg_default;
-    return formatToolActionValue(arena, specLabel(spec, state, denied_label), value);
+    const presentation = tool_dispatch.presentationForArgs(spec.*, args);
+    const value = tool_dispatch.presentationLabelValue(presentation, args) orelse presentation.label_arg_default;
+    return formatToolActionValue(arena, presentationLabel(presentation, state, denied_label), value);
 }
 
 fn formatWebSearchAction(arena: Allocator, call: ToolCall, state: ToolActionState, denied_label: ?[]const u8) ![]const u8 {
@@ -1216,6 +1217,14 @@ fn specLabel(spec: *const tool_dispatch.Tool, state: ToolActionState, denied_lab
     return switch (state) {
         .active => spec.action_label,
         .completed => spec.completed_action_label,
+        .denied => denied_label.?,
+    };
+}
+
+fn presentationLabel(presentation: tool_dispatch.CallPresentation, state: ToolActionState, denied_label: ?[]const u8) []const u8 {
+    return switch (state) {
+        .active => presentation.action_label,
+        .completed => presentation.completed_action_label,
         .denied => denied_label.?,
     };
 }
@@ -2098,6 +2107,19 @@ test "tool labels preserve memory action value and invalid argument fallback" {
     const completed = try app.describeToolActionCompleted(arena, memory_call);
     try std.testing.expect(std.mem.find(u8, completed, "Remembered") != null);
     try std.testing.expect(std.mem.find(u8, completed, "save") != null);
+
+    const list_call: ToolCall = .{
+        .id = "memory_list",
+        .name = "memory",
+        .arguments_json = "{\"action\":\"list\"}",
+    };
+    const list_active = try app.describeToolAction(arena, list_call);
+    try std.testing.expect(std.mem.find(u8, list_active, "Listing") != null);
+    try std.testing.expect(std.mem.find(u8, list_active, "memories") != null);
+
+    const list_completed = try app.describeToolActionCompleted(arena, list_call);
+    try std.testing.expect(std.mem.find(u8, list_completed, "Listed") != null);
+    try std.testing.expect(std.mem.find(u8, list_completed, "memories") != null);
 
     const invalid_call: ToolCall = .{
         .id = "memory_invalid",

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -3125,8 +3125,8 @@ pub fn Runtime(comptime App: type) type {
 
                 const Self = @This();
 
-                fn activityKind(self: *Self, tool_name: []const u8) types.ToolActivityKind {
-                    return self.app.historicalToolActivityKind(tool_name);
+                fn activityKind(self: *Self, call: types.ToolCall) types.ToolActivityKind {
+                    return self.app.historicalToolActivityKind(call);
                 }
 
                 fn appendNotice(self: *Self, notice: types.SemanticNotice) !void {
@@ -3170,7 +3170,7 @@ pub fn Runtime(comptime App: type) type {
                     try self.projection.attachHistoricalToolDetail(
                         entry_id,
                         call,
-                        self.activityKind(call.name),
+                        self.activityKind(call),
                         result,
                     );
                 }
@@ -3185,7 +3185,7 @@ pub fn Runtime(comptime App: type) type {
                     try self.projection.attachHistoricalToolDetailWithLifecycle(
                         entry_id,
                         call,
-                        self.activityKind(call.name),
+                        self.activityKind(call),
                         result,
                         lifecycle_id,
                     );
@@ -3200,7 +3200,7 @@ pub fn Runtime(comptime App: type) type {
                     try self.projection.attachHistoricalToolDetailAfterCommandOutput(
                         entry_id,
                         call,
-                        self.activityKind(call.name),
+                        self.activityKind(call),
                         result,
                     );
                 }

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -29,6 +29,7 @@ const context_limits = @import("../config/context_limits.zig");
 const workspace_access = @import("../workspace/workspace_access.zig");
 const terminal_client_runtime = @import("../terminal/client.zig");
 const terminal_contracts = @import("../terminal/contracts.zig");
+const tool_args = @import("tool_args.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -406,6 +407,18 @@ pub const RuntimeProviderKind = enum {
 
 pub const CapturedCommandFn = *const fn (ToolInput) bool;
 
+pub const CallPresentation = struct {
+    activity_kind: core_types.ToolActivityKind,
+    action_label: []const u8,
+    completed_action_label: []const u8,
+    label_arg_kind: LabelArgKind,
+    label_arg_default: []const u8,
+};
+
+/// Optional call-aware presentation override. Returned strings must outlive the
+/// parsed arguments supplied to the callback.
+pub const PresentationFn = *const fn (std.json.ObjectMap) ?CallPresentation;
+
 /// Descriptor for a core tool's model-facing metadata and runtime callbacks.
 pub const Tool = struct {
     name: []const u8,
@@ -424,6 +437,7 @@ pub const Tool = struct {
     completed_action_label: []const u8 = "Completed",
     label_arg_kind: LabelArgKind = .none,
     label_arg_default: []const u8 = "",
+    presentation_fn: ?PresentationFn = null,
     permission_target_kind: PermissionTargetKind = .none,
     decode: DecodeFn,
     validate: ?ValidateFn = null,
@@ -506,8 +520,58 @@ pub fn toolActivityKind(registry: Registry, tool_name: []const u8) core_types.To
     return if (registry.lookup(tool_name)) |tool| tool.activity_kind else .command;
 }
 
+pub fn staticPresentation(tool: Tool) CallPresentation {
+    return .{
+        .activity_kind = tool.activity_kind,
+        .action_label = tool.action_label,
+        .completed_action_label = tool.completed_action_label,
+        .label_arg_kind = tool.label_arg_kind,
+        .label_arg_default = tool.label_arg_default,
+    };
+}
+
+pub fn presentationForArgs(tool: Tool, args: std.json.ObjectMap) CallPresentation {
+    if (tool.presentation_fn) |resolve| {
+        if (resolve(args)) |presentation| return presentation;
+    }
+    return staticPresentation(tool);
+}
+
+pub fn toolCallPresentation(
+    alloc: Allocator,
+    registry: Registry,
+    call: core_types.ToolCall,
+) ?CallPresentation {
+    const tool = registry.lookup(call.name) orelse return null;
+    var scratch_state = std.heap.ArenaAllocator.init(alloc);
+    defer scratch_state.deinit();
+    const args = tool_args.parseToolArgsObject(
+        scratch_state.allocator(),
+        call.arguments_json,
+    ) catch return staticPresentation(tool.*);
+    return presentationForArgs(tool.*, args);
+}
+
+pub fn toolActivityKindForCall(
+    alloc: Allocator,
+    registry: Registry,
+    call: core_types.ToolCall,
+) core_types.ToolActivityKind {
+    const presentation = toolCallPresentation(alloc, registry, call) orelse
+        return .command;
+    return presentation.activity_kind;
+}
+
 pub fn toolLabelValue(tool: Tool, args: std.json.ObjectMap) ?[]const u8 {
-    return switch (tool.label_arg_kind) {
+    return labelValueForKind(tool.label_arg_kind, args);
+}
+
+pub fn presentationLabelValue(presentation: CallPresentation, args: std.json.ObjectMap) ?[]const u8 {
+    return labelValueForKind(presentation.label_arg_kind, args);
+}
+
+fn labelValueForKind(kind: LabelArgKind, args: std.json.ObjectMap) ?[]const u8 {
+    return switch (kind) {
         .none => null,
         .name => optionalStringArg(args, "name"),
         .path => optionalStringArg(args, "path"),

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -211,14 +211,15 @@ pub fn formatPlainAction(alloc: Allocator, input: ToolActionInput) ![]const u8 {
         return std.fmt.allocPrint(alloc, "Working: {s}", .{call.name});
     };
 
+    const presentation = tool_dispatch.presentationForArgs(spec.*, args);
     if (spec.executor_kind == .web_search) {
-        return std.fmt.allocPrint(alloc, "{s} {s}", .{ spec.action_label, try formatWebSearchActionDetail(scratch, args) });
+        return std.fmt.allocPrint(alloc, "{s} {s}", .{ presentation.action_label, try formatWebSearchActionDetail(scratch, args) });
     }
     if (try copyRenameLabel(scratch, call.name, args)) |value| {
-        return std.fmt.allocPrint(alloc, "{s} {s}", .{ spec.action_label, value });
+        return std.fmt.allocPrint(alloc, "{s} {s}", .{ presentation.action_label, value });
     }
-    const value = tool_dispatch.toolLabelValue(spec.*, args) orelse spec.label_arg_default;
-    return std.fmt.allocPrint(alloc, "{s} {s}", .{ spec.action_label, value });
+    const value = tool_dispatch.presentationLabelValue(presentation, args) orelse presentation.label_arg_default;
+    return std.fmt.allocPrint(alloc, "{s} {s}", .{ presentation.action_label, value });
 }
 
 /// The caller owns the returned allocation and must free it with `alloc`.

--- a/src/main.zig
+++ b/src/main.zig
@@ -1178,9 +1178,9 @@ const App = struct {
 
     pub fn historicalToolActivityKind(
         self: *App,
-        tool_name: []const u8,
+        call: types.ToolCall,
     ) types.ToolActivityKind {
-        return tool_dispatch.toolActivityKind(self.toolRegistry(), tool_name);
+        return tool_dispatch.toolActivityKindForCall(self.alloc, self.toolRegistry(), call);
     }
 
     pub fn commitStartupResumeReplayAnchor(self: *App) !void {
@@ -1894,7 +1894,7 @@ const App = struct {
         call: types.ToolCall,
         result: types.PersistedToolResult,
     ) !void {
-        const activity_kind = tool_dispatch.toolActivityKind(self.toolRegistry(), call.name);
+        const activity_kind = tool_dispatch.toolActivityKindForCall(self.alloc, self.toolRegistry(), call);
         try self.shell.attachHistoricalToolDetail(self.alloc, entry_id, call, activity_kind, result);
     }
 
@@ -1905,7 +1905,7 @@ const App = struct {
         result: types.PersistedToolResult,
         lifecycle_id: types.ToolLifecycleId,
     ) !void {
-        const activity_kind = tool_dispatch.toolActivityKind(self.toolRegistry(), call.name);
+        const activity_kind = tool_dispatch.toolActivityKindForCall(self.alloc, self.toolRegistry(), call);
         try self.shell.attachHistoricalToolDetailWithLifecycle(
             self.alloc,
             entry_id,
@@ -1922,7 +1922,7 @@ const App = struct {
         call: types.ToolCall,
         result: types.PersistedToolResult,
     ) !void {
-        const activity_kind = tool_dispatch.toolActivityKind(self.toolRegistry(), call.name);
+        const activity_kind = tool_dispatch.toolActivityKindForCall(self.alloc, self.toolRegistry(), call);
         try self.shell.attachHistoricalToolDetailAfterCommandOutput(
             self.alloc,
             entry_id,

--- a/src/tools/memory/memory.zig
+++ b/src/tools/memory/memory.zig
@@ -191,6 +191,18 @@ pub fn readsOnly(erased: tool_dispatch.ToolInput) bool {
     return std.mem.eql(u8, erased.as(Input).action, "list");
 }
 
+pub fn presentation(args: std.json.ObjectMap) ?tool_dispatch.CallPresentation {
+    const action = tool_args.optionalStringArg(args, "action") orelse return null;
+    if (!std.mem.eql(u8, action, "list")) return null;
+    return .{
+        .activity_kind = .read,
+        .action_label = "Listing",
+        .completed_action_label = "Listed",
+        .label_arg_kind = .none,
+        .label_arg_default = "memories",
+    };
+}
+
 pub fn isIrreversible(erased: tool_dispatch.ToolInput) bool {
     return std.mem.eql(u8, erased.as(Input).action, "clear");
 }

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -390,6 +390,45 @@ describe("fx ask presentation", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
+    "memory list is presented as a read-only tool call",
+    async () => {
+      const root = createRoot();
+      const stderrPath = join(root.root, "stderr.log");
+      writeFileSync(stderrPath, "");
+      const gateway = startFakeGateway([
+        fakeGatewayToolCall("memory_list", "memory", { action: "list" }),
+        fakeGatewayFinalText("Memory list complete.\n"),
+      ]);
+      gateways.push(gateway);
+
+      const session = await TmuxSession.create({
+        cmd: terminalCommand([
+          "ask",
+          "--auto",
+          "--no-save",
+          "List saved memories.",
+        ]),
+        cwd: root.workspace,
+        env: { ...gatewayEnv(root.home, gateway), NO_COLOR: undefined },
+        width: 120,
+        height: 40,
+        remainOnExit: true,
+        stderrPath,
+      });
+      sessions.push(session);
+
+      await session.waitForText("__FX_EXIT_0__", TIMEOUT);
+      const pane = await session.captureFullScrollback();
+      expect(pane).toContain("● 1 tool call · 1 read");
+      expect(pane).toContain("Listing memories");
+      expect(pane).not.toContain("1 write");
+      expect(pane).not.toContain("Remembered list");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
     "--no-color keeps the TTY layout without Fx styles or hyperlinks",
     async () => {
       const root = createRoot();


### PR DESCRIPTION
## What changed

- Added call-aware presentation metadata for tools whose activity varies by action.
- Classified `memory` with `action: "list"` as a read and presented it as `Listing memories` / `Listed memories`.
- Preserved write classification and existing presentation for `save` and `clear`.
- Added unit, lifecycle, and TTY regression coverage.

## Why

The memory tool advertised one static write activity and one `Remembered` label for every action. Although execution already treated `list` as read-only, the TUI consumed the static metadata and reported a read-only list as `1 write · Remembered list`.

Users now see a truthful read count and memory-list action, while mutating memory actions remain writes.

## Validation

- `zig build test --summary all` — 8,260 passed, 1 skipped
- `zig build -Doptimize=ReleaseSafe`
- `bun test tests/e2e/ask-presentation.test.ts` — 11 passed
- Fresh Debug and ReleaseSafe binaries both passed the focused memory-list TTY regression with empty stderr