### PR TITLE
Route exhausted auto reviews to human approval

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ Security is permission-first.
 
 * the main agent may pass that exact request ID through `ask_user_question` to open the existing permission screen; generic question text cannot authorize an action, and the resulting once or always approval is revalidated and consumed only by the exact bound action
 
-* after three consecutive all-blocked response groups, fx either makes one final tools-disabled model request when step budget remains or emits a fixed local fallback when it does not; any completed successful tool in a group resets that recovery count
+* after three consecutive all-blocked response groups, the next unresolved sensitive action skips another automatic review and uses the existing human approval path; any completed successful tool resets that recovery count, and configured and saved-session rules remain authoritative
 
 * the sandbox backend is configured independently; yolo uses an effective backend of `none` without rewriting the saved sandbox setting
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ fx ask "explain the changes in this repository"
 
 fx starts in `auto` permission mode. Routine understood development actions run directly; unresolved sensitive actions receive one bounded automatic review. A blocked action may return an exact approval request that the agent can send to fx's real permission screen. Ordinary question text never grants permission. See [Permissions](https://fx.sh/docs/configure-fx/permissions) for other modes and persistent rules.
 
+JSON and quiet requests stay noninteractive by default. Add `--prompt-permissions` to allow the existing Y/N approval prompt when stdin is a TTY. Prompt text is written to stderr, so JSON stdout stays parseable and quiet stdout stays empty. Piped or redirected stdin remains noninteractive and fails instead of waiting for approval.
+
 Inside a saved session, `/permissions remember <allow|deny> <tool-name> <arguments-json>` stores an exact confirmed rule without running the action. `/permissions` lists stable rule IDs, and `/permissions revoke <rule-id>` removes a stored rule even when its original workspace or file state has changed.
 
 ## Embed fx

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -30,13 +30,15 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .ask,
         .token = "ask",
-        .usage = "ask [--auto|--yolo] [--image PATH] [--json] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>",
+        .usage = "ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>",
         .summary = "Run one noninteractive request",
         .options = &.{
             .{ .flag = "--auto", .description = "Automatically review unresolved permission requests" },
             .{ .flag = "--yolo", .description = "Disable permission checks and command sandboxing" },
             .{ .flag = "--image PATH", .description = "Attach an image file; repeat for multiple images" },
             json_option,
+            .{ .flag = "--quiet", .description = "Suppress assistant output" },
+            .{ .flag = "--prompt-permissions", .description = "Prompt for Y/N permission approval when stdin is a TTY" },
             .{ .flag = "--no-save", .description = "Do not save the session; incompatible with --resume and --resume-id" },
             .{ .flag = "--no-color", .description = "Render TTY output without colors or hyperlinks" },
             .{ .flag = "--resume <last|id>", .description = "Continue the last session or a session by id" },
@@ -48,6 +50,7 @@ pub const top_level_specs = [_]TopLevelSpec{
             "The prompt may be passed as arguments or piped on stdin when no prompt args are given.",
             "TTY stdout uses the Minimal transcript presentation; redirected stdout emits raw assistant Markdown.",
             "Operational progress and diagnostics are written to stderr. JSON output keeps raw Markdown in `output`.",
+            "With --prompt-permissions, JSON and quiet requests may prompt on stderr only when stdin is a TTY.",
         },
     },
     .{

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -5800,7 +5800,8 @@ fn processQueuedPromptLoop(
             const approved_revalidation = turn_permission_recovery.takeApproval(
                 execution_call,
             );
-            const preserved_automatic_denial = if (approved_revalidation == null)
+            const preserved_automatic_denial = if (approved_revalidation == null and
+                auto_permission_phase == .automatic_review)
                 try turn_permission_recovery.preservedOutcome(
                     call_allocator,
                     config.workspace_root,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2010,6 +2010,7 @@ fn buildReviewTurnContext(
     root_user_intent_context: []const u8,
     pending_assistant: ChatMessage,
     target_call_id: []const u8,
+    auto_permission_phase: permission_auto_classifier.AutoPermissionPhase,
 ) permission_auto_classifier.ReviewTurnContext {
     const current_root_request = currentRootRequest(
         config,
@@ -2025,6 +2026,7 @@ fn buildReviewTurnContext(
             .subagent => .subagent,
         },
         .current_root_request = current_root_request,
+        .auto_permission_phase = auto_permission_phase,
     };
 }
 
@@ -2056,11 +2058,9 @@ fn currentRootRequest(
         "";
 }
 
-const max_automatic_non_allow_response_groups: usize = 3;
-const permission_recovery_fallback = "The blocked action was not run. No safe alternative completed within the configured agent step limit. Provide direction to continue.";
-const permission_recovery_final_guidance = "Permission recovery reached its action limit. Do not call tools. Explain that the blocked action did not run, then ask the user for direction or finish honestly.";
+const max_automatic_denial_response_groups: usize = 3;
 
-fn automaticRecoveryExhausted(messages: []const ChatMessage) bool {
+fn automaticPermissionPhase(messages: []const ChatMessage) permission_auto_classifier.AutoPermissionPhase {
     var blocked_groups: usize = 0;
     var index: usize = 0;
     while (index < messages.len) : (index += 1) {
@@ -2074,24 +2074,30 @@ fn automaticRecoveryExhausted(messages: []const ChatMessage) bool {
             index = group_end -| 1;
             continue;
         }
-        var has_permission_denial = false;
+        var has_auto_denial = false;
+        var resets_auto_recovery = false;
         var has_success = false;
         for (messages[index + 1 .. group_end]) |message| {
             if (message.role != .tool) continue;
             if (message.tool_result_status == .success) has_success = true;
             const output = message.content orelse continue;
-            if (tool_result_errors.toolPermissionDenialReason(output) != null) {
-                has_permission_denial = true;
-            }
+            const reason = tool_result_errors.toolPermissionDenialReason(output) orelse continue;
+            if (reason == .auto_denied)
+                has_auto_denial = true
+            else
+                resets_auto_recovery = true;
         }
-        if (has_success) {
+        if (has_success or resets_auto_recovery) {
             blocked_groups = 0;
-        } else if (has_permission_denial) {
+        } else if (has_auto_denial) {
             blocked_groups +|= 1;
         }
         index = group_end -| 1;
     }
-    return blocked_groups >= max_automatic_non_allow_response_groups;
+    return if (blocked_groups >= max_automatic_denial_response_groups)
+        .human_approval
+    else
+        .automatic_review;
 }
 
 fn responseGroupComplete(
@@ -2114,24 +2120,6 @@ fn responseGroupComplete(
     return true;
 }
 
-const PermissionRecoveryPlan = enum {
-    continue_with_tools,
-    final_model_response,
-    local_fallback,
-};
-
-fn permissionRecoveryPlan(
-    messages: []const ChatMessage,
-    step_limit: usize,
-    completed_steps: usize,
-) PermissionRecoveryPlan {
-    if (!automaticRecoveryExhausted(messages)) return .continue_with_tools;
-    if (agent_steps.allowsStep(step_limit, completed_steps)) {
-        return .final_model_response;
-    }
-    return .local_fallback;
-}
-
 test "automatic recovery counts completed response groups and resets after success" {
     const denied = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"auto_denied\"}}";
     const blocked_group = [_]ChatMessage{
@@ -2143,7 +2131,10 @@ test "automatic recovery counts completed response groups and resets after succe
     @memcpy(three_then_current[2..4], &blocked_group);
     @memcpy(three_then_current[4..6], &blocked_group);
     three_then_current[6] = .{ .role = .assistant, .tool_calls = &.{.{ .id = "current", .name = "run_command", .arguments_json = "{}" }} };
-    try std.testing.expect(automaticRecoveryExhausted(&three_then_current));
+    try std.testing.expectEqual(
+        permission_auto_classifier.AutoPermissionPhase.human_approval,
+        automaticPermissionPhase(&three_then_current),
+    );
 
     const success = ChatMessage{
         .role = .tool,
@@ -2157,7 +2148,36 @@ test "automatic recovery counts completed response groups and resets after succe
     reset[7] = success;
     reset[8] = blocked_group[0];
     reset[9] = blocked_group[1];
-    try std.testing.expect(!automaticRecoveryExhausted(&reset));
+    try std.testing.expectEqual(
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(&reset),
+    );
+}
+
+test "automatic recovery resets after non automatic permission denials" {
+    const auto_denied = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"auto_denied\"}}";
+    const user_denied = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"user_denied\"}}";
+    const policy_denied = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"policy_denied\"}}";
+    const permission_required = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"permission_required\"}}";
+    const messages = [_]ChatMessage{
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-1", .name = "run_command", .arguments_json = "{}" }} },
+        .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-1", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-2", .name = "run_command", .arguments_json = "{}" }} },
+        .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-2", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-3", .name = "run_command", .arguments_json = "{}" }} },
+        .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-3", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "user", .name = "run_command", .arguments_json = "{}" }} },
+        .{ .role = .tool, .content = user_denied, .tool_call_id = "user", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "policy", .name = "run_command", .arguments_json = "{}" }} },
+        .{ .role = .tool, .content = policy_denied, .tool_call_id = "policy", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "headless", .name = "run_command", .arguments_json = "{}" }} },
+        .{ .role = .tool, .content = permission_required, .tool_call_id = "headless", .tool_result_status = .failure },
+    };
+
+    try std.testing.expectEqual(
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(&messages),
+    );
 }
 
 test "parallel automatic denials count as one response group" {
@@ -2172,7 +2192,10 @@ test "parallel automatic denials count as one response group" {
         .{ .role = .tool, .content = denied, .tool_call_id = "two", .tool_result_status = .failure },
         .{ .role = .assistant, .tool_calls = &calls },
     };
-    try std.testing.expect(!automaticRecoveryExhausted(&messages));
+    try std.testing.expectEqual(
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(&messages),
+    );
 }
 
 test "a mixed parallel response group resets recovery regardless result order" {
@@ -2198,11 +2221,17 @@ test "a mixed parallel response group resets recovery regardless result order" {
     }
     success_first[9] = current;
     denial_first[9] = current;
-    try std.testing.expect(!automaticRecoveryExhausted(&success_first));
-    try std.testing.expect(!automaticRecoveryExhausted(&denial_first));
+    try std.testing.expectEqual(
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(&success_first),
+    );
+    try std.testing.expectEqual(
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(&denial_first),
+    );
 }
 
-test "permission recovery plan respects the ordinary step budget" {
+test "automatic permission phase depends only on completed response groups" {
     const denied = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"auto_denied\"}}";
     const messages = [_]ChatMessage{
         .{ .role = .assistant, .tool_calls = &.{.{ .id = "one", .name = "run_command", .arguments_json = "{}" }} },
@@ -2214,16 +2243,42 @@ test "permission recovery plan respects the ordinary step budget" {
     };
 
     try std.testing.expectEqual(
-        PermissionRecoveryPlan.final_model_response,
-        permissionRecoveryPlan(&messages, 0, 3),
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(&.{}),
     );
     try std.testing.expectEqual(
-        PermissionRecoveryPlan.final_model_response,
-        permissionRecoveryPlan(&messages, 4, 3),
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(messages[0..2]),
     );
     try std.testing.expectEqual(
-        PermissionRecoveryPlan.local_fallback,
-        permissionRecoveryPlan(&messages, 3, 3),
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(messages[0..4]),
+    );
+    try std.testing.expectEqual(
+        permission_auto_classifier.AutoPermissionPhase.human_approval,
+        automaticPermissionPhase(&messages),
+    );
+}
+
+test "incomplete parallel response groups do not advance automatic recovery" {
+    const denied = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"auto_denied\"}}";
+    const parallel_calls = [_]ToolCall{
+        .{ .id = "incomplete-1", .name = "run_command", .arguments_json = "{}" },
+        .{ .id = "incomplete-2", .name = "run_command", .arguments_json = "{}" },
+    };
+    const messages = [_]ChatMessage{
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "one", .name = "run_command", .arguments_json = "{}" }} },
+        .{ .role = .tool, .content = denied, .tool_call_id = "one", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "two", .name = "run_command", .arguments_json = "{}" }} },
+        .{ .role = .tool, .content = denied, .tool_call_id = "two", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &parallel_calls },
+        .{ .role = .tool, .content = denied, .tool_call_id = "incomplete-1", .tool_result_status = .failure },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "current", .name = "run_command", .arguments_json = "{}" }} },
+    };
+
+    try std.testing.expectEqual(
+        permission_auto_classifier.AutoPermissionPhase.automatic_review,
+        automaticPermissionPhase(&messages),
     );
 }
 
@@ -2535,14 +2590,7 @@ fn processQueuedPromptLoop(
     var restore_recovery_source = job.recovery_checkpoint != null;
     var step: usize = 0;
     while (agent_steps.allowsStep(config.agent_step_limit, step)) : (step += 1) {
-        const permission_recovery_plan = permissionRecoveryPlan(
-            within_turn_suffix.items,
-            config.agent_step_limit,
-            step,
-        );
-        std.debug.assert(permission_recovery_plan != .local_fallback);
-        const final_permission_response =
-            permission_recovery_plan == .final_model_response;
+        const auto_permission_phase = automaticPermissionPhase(within_turn_suffix.items);
         current_step_index = step + 1;
         const step_ctx: TraceContext = .{ .turn_id = turn_id, .step_id = debug_trace.nextStepId(), .subagent_id = config.subagent_id };
         const presentation_group_id = runtime_tool_presentation.presentationGroupForStep(
@@ -2562,12 +2610,6 @@ fn processQueuedPromptLoop(
         var ephemeral_overlay: std.ArrayList(ChatMessage) = .empty;
         if (config.explicit_skills_prompt_section.len > 0) {
             try ephemeral_overlay.append(overlay_arena, .{ .role = .system, .content = config.explicit_skills_prompt_section });
-        }
-        if (final_permission_response) {
-            try ephemeral_overlay.append(overlay_arena, .{
-                .role = .system,
-                .content = permission_recovery_final_guidance,
-            });
         }
         try deps.append_runtime_context(deps.ctx, overlay_arena, &ephemeral_overlay);
         var parent_turn_delivery = try appendPreparedParentTurnContext(
@@ -2748,9 +2790,7 @@ fn processQueuedPromptLoop(
             );
             debug_trace.eventf("gateway", "before_payload_build", step_ctx, "model={s} gateway_messages={d}", .{ gateway_model, gateway_messages.items.len });
             var vision_route: runtime_vision_contracts.VisionRoute = .native_images;
-            var vision_mode: runtime_gateway_step.VisionToolMode = if (final_permission_response)
-                .unavailable
-            else if (deps.tool_registry.lookup("vision") != null)
+            var vision_mode: runtime_gateway_step.VisionToolMode = if (deps.tool_registry.lookup("vision") != null)
                 .optional
             else
                 .unavailable;
@@ -2791,9 +2831,7 @@ fn processQueuedPromptLoop(
             last_gateway_message_count = request_messages.len;
             const provider_opts = model_capabilities.resolveProviderOptionsForCapabilities(request_capabilities, config.effort, route_fast_mode);
             runtime_telemetry.traceGatewayProviderOptions(step_ctx, gateway_model, route_fast_mode, config.effort, provider_opts);
-            const tool_choice: types.ToolChoice = if (final_permission_response)
-                .none
-            else if (recovery_strategy == .reconcile_tool)
+            const tool_choice: types.ToolChoice = if (recovery_strategy == .reconcile_tool)
                 .none
             else if (configured_first_tool_choice_pending and vision_mode != .required)
                 config.first_call_tool_choice
@@ -2803,20 +2841,11 @@ fn processQueuedPromptLoop(
                 overlay_arena,
                 .{
                     .model = gateway_model,
-                    .tool_registry = if (final_permission_response)
-                        .{ .tools = &.{} }
-                    else
-                        deps.tool_registry,
-                    .serialized_tools = if (final_permission_response)
-                        "[]"
-                    else
-                        config.gateway_tools_json,
+                    .tool_registry = deps.tool_registry,
+                    .serialized_tools = config.gateway_tools_json,
                     .messages = request_messages,
                     .tool_choice = tool_choice,
-                    .selected_dynamic_tool_schemas = if (final_permission_response)
-                        &.{}
-                    else
-                        selected_dynamic_tool_schemas.items,
+                    .selected_dynamic_tool_schemas = selected_dynamic_tool_schemas.items,
                     .vision_mode = vision_mode,
                     .provider_options = provider_opts,
                     .max_output_tokens = request_max_output_tokens(request_capabilities),
@@ -2854,7 +2883,7 @@ fn processQueuedPromptLoop(
                 gateway_model,
                 request_payload.len,
                 request_messages.len,
-                if (final_permission_response) "[]" else config.gateway_tools_json,
+                config.gateway_tools_json,
             );
             try persistRecoveryCheckpoint(
                 deps,
@@ -3969,36 +3998,6 @@ fn processQueuedPromptLoop(
             }
         }
 
-        if (final_permission_response and completion.tool_calls.len > 0) {
-            try stream_ctx.provisional_statuses.finishRejectedCompletions(
-                deps,
-                arena,
-                turn_id,
-                completion.tool_calls,
-                advertised_dynamic_tool_names,
-            );
-            debug_trace.eventf(
-                "permission",
-                "permission_recovery_final_tool_rejected",
-                step_ctx,
-                "tool_call_count={d}",
-                .{completion.tool_calls.len},
-            );
-            try finishFailedTurnWithNotice(
-                deps,
-                finalization,
-                arena,
-                job,
-                within_turn_suffix.items,
-                &summary_accumulator,
-                stop_state,
-                &finish_trace,
-                permission_recovery_fallback,
-                "permission_recovery_fallback",
-            );
-            return;
-        }
-
         if (disposition == .completed and completion.tool_calls.len > 0) {
             const admission = types.authoritativeToolAdmission(completion);
             switch (admission) {
@@ -4152,21 +4151,6 @@ fn processQueuedPromptLoop(
         if (completion.tool_calls.len == 0) {
             const has_content =
                 std.mem.trim(u8, partial_assistant, " \t\r\n").len > 0;
-            if (final_permission_response and !has_content) {
-                try finishFailedTurnWithNotice(
-                    deps,
-                    finalization,
-                    arena,
-                    job,
-                    within_turn_suffix.items,
-                    &summary_accumulator,
-                    stop_state,
-                    &finish_trace,
-                    permission_recovery_fallback,
-                    "permission_recovery_fallback",
-                );
-                return;
-            }
             const needs_continuation =
                 disposition == .completed and
                 !continuation_injected and
@@ -4813,6 +4797,7 @@ fn processQueuedPromptLoop(
                         root_user_intent_context,
                         pending_assistant,
                         parallel_call.id,
+                        auto_permission_phase,
                     );
                     const maybe_parallel_permission: ?command_admission.PermissionOutcome = runtime_tool_admission.requestToolPermissionTraced(deps, arena, parallel_call, parallel_review_context, job.permission_mode, local_grants.items, null, null, advertised_dynamic_tool_names, config.workspace_root, step_ctx) catch |err| blk: {
                         if (err != error.Cancelled or !config.cancel_flag.load(.seq_cst)) return err;
@@ -5798,6 +5783,7 @@ fn processQueuedPromptLoop(
                 root_user_intent_context,
                 pending_assistant,
                 execution_call.id,
+                auto_permission_phase,
             );
             const tool_execution_root_user_context = try buildToolExecutionRootUserContext(
                 call_allocator,
@@ -7355,15 +7341,6 @@ fn processQueuedPromptLoop(
         }
     }
 
-    const exhausted_recovery_plan = permissionRecoveryPlan(
-        within_turn_suffix.items,
-        config.agent_step_limit,
-        step,
-    );
-    const final_notice = if (exhausted_recovery_plan == .local_fallback)
-        permission_recovery_fallback
-    else
-        config.step_limit_notice;
     runtime_telemetry.traceStepLimitReached(.{
         .ctx = last_step_ctx,
         .step_index = current_step_index,
@@ -7382,11 +7359,8 @@ fn processQueuedPromptLoop(
         &summary_accumulator,
         stop_state,
         &finish_trace,
-        final_notice,
-        if (exhausted_recovery_plan == .local_fallback)
-            "permission_recovery_fallback"
-        else
-            "step_limit",
+        config.step_limit_notice,
+        "step_limit",
     );
 }
 

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2159,25 +2159,23 @@ test "automatic recovery resets after non automatic permission denials" {
     const user_denied = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"user_denied\"}}";
     const policy_denied = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"policy_denied\"}}";
     const permission_required = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"permission_required\"}}";
-    const messages = [_]ChatMessage{
-        .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-1", .name = "run_command", .arguments_json = "{}" }} },
-        .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-1", .tool_result_status = .failure },
-        .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-2", .name = "run_command", .arguments_json = "{}" }} },
-        .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-2", .tool_result_status = .failure },
-        .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-3", .name = "run_command", .arguments_json = "{}" }} },
-        .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-3", .tool_result_status = .failure },
-        .{ .role = .assistant, .tool_calls = &.{.{ .id = "user", .name = "run_command", .arguments_json = "{}" }} },
-        .{ .role = .tool, .content = user_denied, .tool_call_id = "user", .tool_result_status = .failure },
-        .{ .role = .assistant, .tool_calls = &.{.{ .id = "policy", .name = "run_command", .arguments_json = "{}" }} },
-        .{ .role = .tool, .content = policy_denied, .tool_call_id = "policy", .tool_result_status = .failure },
-        .{ .role = .assistant, .tool_calls = &.{.{ .id = "headless", .name = "run_command", .arguments_json = "{}" }} },
-        .{ .role = .tool, .content = permission_required, .tool_call_id = "headless", .tool_result_status = .failure },
-    };
+    for ([_][]const u8{ user_denied, policy_denied, permission_required }) |reset_result| {
+        const messages = [_]ChatMessage{
+            .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-1", .name = "run_command", .arguments_json = "{}" }} },
+            .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-1", .tool_result_status = .failure },
+            .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-2", .name = "run_command", .arguments_json = "{}" }} },
+            .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-2", .tool_result_status = .failure },
+            .{ .role = .assistant, .tool_calls = &.{.{ .id = "auto-3", .name = "run_command", .arguments_json = "{}" }} },
+            .{ .role = .tool, .content = auto_denied, .tool_call_id = "auto-3", .tool_result_status = .failure },
+            .{ .role = .assistant, .tool_calls = &.{.{ .id = "reset", .name = "run_command", .arguments_json = "{}" }} },
+            .{ .role = .tool, .content = reset_result, .tool_call_id = "reset", .tool_result_status = .failure },
+        };
 
-    try std.testing.expectEqual(
-        permission_auto_classifier.AutoPermissionPhase.automatic_review,
-        automaticPermissionPhase(&messages),
-    );
+        try std.testing.expectEqual(
+            permission_auto_classifier.AutoPermissionPhase.automatic_review,
+            automaticPermissionPhase(&messages),
+        );
+    }
 }
 
 test "parallel automatic denials count as one response group" {

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -467,6 +467,7 @@ pub const FakeAgentRuntimeDeps = struct {
     permission_review_models: std.ArrayList([]u8) = .empty,
     permission_review_target_call_ids: std.ArrayList([]u8) = .empty,
     permission_review_origins: std.ArrayList(permission_auto_classifier.ReviewOrigin) = .empty,
+    permission_review_phases: std.ArrayList(permission_auto_classifier.AutoPermissionPhase) = .empty,
     permission_review_root_authority_counts: std.ArrayList(usize) = .empty,
     permission_review_feedback_counts: std.ArrayList(usize) = .empty,
     permission_review_pending_call_counts: std.ArrayList(usize) = .empty,
@@ -647,6 +648,7 @@ pub const FakeAgentRuntimeDeps = struct {
         freeStringList(self.alloc, &self.permission_review_models);
         freeStringList(self.alloc, &self.permission_review_target_call_ids);
         self.permission_review_origins.deinit(self.alloc);
+        self.permission_review_phases.deinit(self.alloc);
         self.permission_review_root_authority_counts.deinit(self.alloc);
         self.permission_review_feedback_counts.deinit(self.alloc);
         self.permission_review_pending_call_counts.deinit(self.alloc);
@@ -982,6 +984,10 @@ pub const FakeAgentRuntimeDeps = struct {
             try self.alloc.dupe(u8, review_turn.target_call_id),
         );
         try self.permission_review_origins.append(self.alloc, review_turn.origin);
+        try self.permission_review_phases.append(
+            self.alloc,
+            review_turn.auto_permission_phase,
+        );
         try self.permission_review_root_authority_counts.append(
             self.alloc,
             @intFromBool(review_turn.current_root_request.len > 0),

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -63,6 +63,9 @@ const toolCall = test_support.toolCall;
 const vision_agent_test_tools = test_support.vision_agent_test_tools;
 const VisionAgentToolRuntime = test_support.VisionAgentToolRuntime;
 
+const fixture_tools_json =
+    "[{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read a file\",\"inputSchema\":{\"type\":\"object\",\"properties\":{}}}]";
+
 fn makeOwnedVisionCatalog(
     alloc: std.mem.Allocator,
     dir: std.Io.Dir,
@@ -4520,7 +4523,53 @@ test "processQueuedPrompt auto permission denial labels lifecycle source" {
     try expectPermissionDeniedToolResult(&gateway, 1, "write_file", .auto_denied);
 }
 
-test "three permission blocks use one tools-disabled final model step when budget remains" {
+test "three automatic permission blocks route the next action through approval" {
+    const alloc = std.testing.allocator;
+    const first = [_]ToolCall{toolCall("blocked-1", "run_command", "{\"command\":\"touch one\"}")};
+    const second = [_]ToolCall{toolCall("blocked-2", "run_command", "{\"command\":\"touch two\"}")};
+    const third = [_]ToolCall{toolCall("blocked-3", "run_command", "{\"command\":\"touch three\"}")};
+    const approved = [_]ToolCall{toolCall("approved-4", "run_command", "{\"command\":\"touch approved\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &first },
+        .{ .tool_calls = &second },
+        .{ .tool_calls = &third },
+        .{ .tool_calls = &approved },
+        .{ .content = "Approved action completed." },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.permission_decisions = &.{ .deny, .deny, .deny, .once };
+    hooks.permission_denial_reasons = &.{ .auto_denied, .auto_denied, .auto_denied };
+    hooks.permission_human_approvals = &.{ .none, .none, .none, .once };
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.agent_step_limit = 5;
+    config.gateway_tools_json = fixture_tools_json;
+    var job = fixture.job();
+    job.permission_mode = .auto;
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 5), gateway.request_bodies.items.len);
+    try expectBodyNotContains(&gateway, 3, "\"toolChoice\":{\"type\":\"none\"}");
+    try expectBodyNotContains(&gateway, 3, "\"tools\":[]");
+    try std.testing.expectEqualStrings(
+        "Approved action completed.",
+        hooks.history_assistant_text.?,
+    );
+    try std.testing.expectEqual(@as(usize, 4), hooks.permission_names.items.len);
+    try std.testing.expectEqualSlices(
+        permission_auto_classifier.AutoPermissionPhase,
+        &.{ .automatic_review, .automatic_review, .automatic_review, .human_approval },
+        hooks.permission_review_phases.items,
+    );
+    try std.testing.expectEqual(@as(usize, 1), hooks.executed_names.items.len);
+    try std.testing.expectEqualStrings("run_command", hooks.executed_names.items[0]);
+}
+
+test "human approval phase permits a normal text completion" {
     const alloc = std.testing.allocator;
     const first = [_]ToolCall{toolCall("blocked-1", "run_command", "{\"command\":\"touch one\"}")};
     const second = [_]ToolCall{toolCall("blocked-2", "run_command", "{\"command\":\"touch two\"}")};
@@ -4529,7 +4578,7 @@ test "three permission blocks use one tools-disabled final model step when budge
         .{ .tool_calls = &first },
         .{ .tool_calls = &second },
         .{ .tool_calls = &third },
-        .{ .content = "Which safe alternative should I use?" },
+        .{ .content = "No further action is needed." },
     };
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
@@ -4540,20 +4589,67 @@ test "three permission blocks use one tools-disabled final model step when budge
     var fixture = PromptFixture{};
     var config = fixture.config();
     config.agent_step_limit = 4;
+    var job = fixture.job();
+    job.permission_mode = .auto;
 
-    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+    try runFakePrompt(&gateway, &hooks, config, job);
 
     try std.testing.expectEqual(@as(usize, 4), gateway.request_bodies.items.len);
-    try expectBodyContains(&gateway, 3, "\"toolChoice\":{\"type\":\"none\"}");
-    try expectBodyContains(&gateway, 3, "\"tools\":[]");
+    try std.testing.expectEqual(@as(usize, 3), hooks.permission_names.items.len);
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqualStrings(
-        "Which safe alternative should I use?",
+        "No further action is needed.",
         hooks.history_assistant_text.?,
     );
-    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
 }
 
-test "three permission blocks use local fallback when step budget is exhausted" {
+test "human approval phase reaches every call in a parallel response group" {
+    const alloc = std.testing.allocator;
+    const first = [_]ToolCall{toolCall("blocked-1", "run_command", "{\"command\":\"touch one\"}")};
+    const second = [_]ToolCall{toolCall("blocked-2", "run_command", "{\"command\":\"touch two\"}")};
+    const third = [_]ToolCall{toolCall("blocked-3", "run_command", "{\"command\":\"touch three\"}")};
+    const parallel = [_]ToolCall{
+        toolCall("approved-4a", "run_command", "{\"command\":\"touch approved-a\"}"),
+        toolCall("approved-4b", "run_command", "{\"command\":\"touch approved-b\"}"),
+    };
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &first },
+        .{ .tool_calls = &second },
+        .{ .tool_calls = &third },
+        .{ .tool_calls = &parallel },
+        .{ .content = "Parallel approved actions completed." },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.permission_decisions = &.{ .deny, .deny, .deny, .once, .once };
+    hooks.permission_denial_reasons = &.{ .auto_denied, .auto_denied, .auto_denied };
+    hooks.permission_human_approvals = &.{ .none, .none, .none, .once, .once };
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.agent_step_limit = 5;
+    var job = fixture.job();
+    job.permission_mode = .auto;
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 5), hooks.permission_names.items.len);
+    try std.testing.expectEqualSlices(
+        permission_auto_classifier.AutoPermissionPhase,
+        &.{
+            .automatic_review,
+            .automatic_review,
+            .automatic_review,
+            .human_approval,
+            .human_approval,
+        },
+        hooks.permission_review_phases.items,
+    );
+    try std.testing.expectEqual(@as(usize, 2), hooks.executed_names.items.len);
+}
+
+test "three automatic permission blocks preserve an exhausted positive step cap" {
     const alloc = std.testing.allocator;
     const first = [_]ToolCall{toolCall("blocked-1", "run_command", "{\"command\":\"touch one\"}")};
     const second = [_]ToolCall{toolCall("blocked-2", "run_command", "{\"command\":\"touch two\"}")};
@@ -4578,7 +4674,7 @@ test "three permission blocks use local fallback when step budget is exhausted" 
 
     try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
     try std.testing.expectEqualStrings(
-        "The blocked action was not run. No safe alternative completed within the configured agent step limit. Provide direction to continue.",
+        runtime_config.Config.default_step_limit_notice,
         hooks.history_assistant_text.?,
     );
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -311,6 +311,7 @@ const AskOptions = struct {
     images: std.ArrayList(ImageAttachment) = .empty,
     system_prompt_override: ?[]u8 = null,
     json_output: bool = false,
+    prompt_permissions: bool = false,
     timeout_ms: ?usize = null,
     quiet: bool = false,
     verbose: bool = false,
@@ -422,14 +423,11 @@ const OutputMode = enum {
     fn capturesJson(self: OutputMode) bool {
         return self == .json;
     }
-
-    fn permitsPermissionPrompt(self: OutputMode) bool {
-        return self == .raw or self.isTerminal();
-    }
 };
 
 const RunOptions = struct {
     output_mode: OutputMode,
+    prompt_permissions: bool = false,
     images: []const ImageAttachment = &.{},
     command_timeout_ms: ?usize = null,
     save_session: bool = true,
@@ -494,6 +492,7 @@ const AskContext = struct {
     typed_error_code: ?[]const u8 = null,
     auth_failure: ?auth_runtime.FailureSnapshot = null,
     output_mode: OutputMode = .raw,
+    prompt_permissions: bool = false,
     presenter: ?*ask_presentation.Runtime = null,
     pending_tool_progress: std.ArrayList(PendingToolProgress) = .empty,
     deferred_tool_progress: std.ArrayList([]u8) = .empty,
@@ -1177,6 +1176,7 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
     );
     const result = runPromptInternal(alloc, options.prompt, options.permission_override, effective_cfg, .{
         .output_mode = output_mode,
+        .prompt_permissions = options.prompt_permissions,
         .images = if (options.images.items.len > 0) options.images.items else &.{},
         .command_timeout_ms = options.timeout_ms,
         .save_session = !options.no_save,
@@ -1359,6 +1359,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     var worker_events_drained = false;
     ctx.workspace_access = startup.takeWorkspaceAccess();
     ctx.output_mode = options.output_mode;
+    ctx.prompt_permissions = options.prompt_permissions;
     ctx.mcp_elicitation_capabilities = askElicitationCapabilities(
         options.output_mode,
         options.deps.stdin_is_tty(options.deps.stdin_ctx),
@@ -1961,7 +1962,7 @@ fn cliAdmissionContext(
         advertised_dynamic_tool_names,
     );
     tool_ctx.permission_review_turn = review_turn;
-    if (cliPermissionPromptAllowed(ctx)) {
+    if (cliContextPermissionPromptAllowed(ctx)) {
         tool_ctx.permission_prompter = .{
             .context = @ptrCast(ctx),
             .request_fn = requestCliPermission,
@@ -2179,7 +2180,7 @@ fn promptCliPermissionApproval(
     ctx: *AskContext,
     label: []const u8,
 ) !PermissionApprovalPromptResult {
-    if (!cliPermissionPromptAllowed(ctx)) return .unavailable;
+    if (!cliContextPermissionPromptAllowed(ctx)) return .unavailable;
     return try ctx.deps.permission_approval_prompt(
         ctx.deps.permission_approval_prompt_ctx,
         ctx.deps.stderr_ctx,
@@ -2207,8 +2208,23 @@ fn emitAskNotificationBell(raw: *anyopaque) void {
     };
 }
 
-fn cliPermissionPromptAllowed(ctx: *const AskContext) bool {
-    return ctx.output_mode.permitsPermissionPrompt();
+fn cliPermissionPromptAllowed(
+    output_mode: OutputMode,
+    prompt_permissions: bool,
+    stdin_is_tty: bool,
+) bool {
+    return switch (output_mode) {
+        .raw, .terminal, .terminal_no_color => true,
+        .json, .quiet => prompt_permissions and stdin_is_tty,
+    };
+}
+
+fn cliContextPermissionPromptAllowed(ctx: *const AskContext) bool {
+    return cliPermissionPromptAllowed(
+        ctx.output_mode,
+        ctx.prompt_permissions,
+        ctx.deps.stdin_is_tty(ctx.deps.stdin_ctx),
+    );
 }
 
 fn describeToolAction(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, file_display_path: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
@@ -3197,6 +3213,8 @@ fn parseOptionsWithStdin(alloc: Allocator, args: []const [:0]const u8, stdin: St
             opts.system_prompt_override = try alloc.dupe(u8, args[i]);
         } else if (std.mem.eql(u8, arg, "--json")) {
             opts.json_output = true;
+        } else if (std.mem.eql(u8, arg, "--prompt-permissions")) {
+            opts.prompt_permissions = true;
         } else if (std.mem.eql(u8, arg, "--timeout")) {
             i += 1;
             if (i >= args.len) return error.MissingPrompt;
@@ -3673,7 +3691,7 @@ fn testModelPromptOverlay(model: []const u8) ?[]const u8 {
 
 fn testConfig() Config {
     return .{
-        .command_usage = "ask [--auto|--yolo] [--image PATH] [--json] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--] <prompt>",
+        .command_usage = "ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--] <prompt>",
         .default_model = "model",
         .default_agent_step_limit = 4,
         .gateway_retry_count = 1,
@@ -4597,6 +4615,7 @@ test "parse options preserves active ask flags and operands" {
         "--system",
         "second",
         "--json",
+        "--prompt-permissions",
         "--quiet",
         "--verbose",
         "--no-save",
@@ -4610,6 +4629,7 @@ test "parse options preserves active ask flags and operands" {
 
     try std.testing.expectEqual(@as(?PermissionMode, .auto), options.permission_override);
     try std.testing.expect(options.json_output);
+    try std.testing.expect(options.prompt_permissions);
     try std.testing.expect(options.quiet);
     try std.testing.expect(options.verbose);
     try std.testing.expect(options.no_save);
@@ -5928,6 +5948,85 @@ test "fx ask captured and quiet permission paths bypass terminal prompt" {
     }, .ask, &.{}, &.{}));
     try std.testing.expectEqual(@as(usize, 0), prompt.calls);
     try std.testing.expect(std.mem.find(u8, stderr_capture.bytes.items, "noninteractive_permission_prompt_unavailable") != null);
+}
+
+test "fx ask permission prompt policy requires explicit captured-mode opt in and TTY stdin" {
+    const Case = struct {
+        output_mode: OutputMode,
+        prompt_permissions: bool,
+        stdin_is_tty: bool,
+        expected: bool,
+    };
+    const cases = [_]Case{
+        .{ .output_mode = .raw, .prompt_permissions = false, .stdin_is_tty = false, .expected = true },
+        .{ .output_mode = .terminal, .prompt_permissions = false, .stdin_is_tty = false, .expected = true },
+        .{ .output_mode = .terminal_no_color, .prompt_permissions = false, .stdin_is_tty = false, .expected = true },
+        .{ .output_mode = .json, .prompt_permissions = false, .stdin_is_tty = true, .expected = false },
+        .{ .output_mode = .quiet, .prompt_permissions = false, .stdin_is_tty = true, .expected = false },
+        .{ .output_mode = .json, .prompt_permissions = true, .stdin_is_tty = false, .expected = false },
+        .{ .output_mode = .quiet, .prompt_permissions = true, .stdin_is_tty = false, .expected = false },
+        .{ .output_mode = .json, .prompt_permissions = true, .stdin_is_tty = true, .expected = true },
+        .{ .output_mode = .quiet, .prompt_permissions = true, .stdin_is_tty = true, .expected = true },
+    };
+
+    for (cases) |case| {
+        try std.testing.expectEqual(
+            case.expected,
+            cliPermissionPromptAllowed(
+                case.output_mode,
+                case.prompt_permissions,
+                case.stdin_is_tty,
+            ),
+        );
+    }
+}
+
+test "fx ask captured permission prompt opt in uses the existing prompter" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var stdout_capture: TestCapture = .{};
+    defer stdout_capture.deinit(alloc);
+    var stderr_capture: TestCapture = .{};
+    defer stderr_capture.deinit(alloc);
+    var prompt = TestPermissionPrompt{ .result = .approve };
+    var deps = testPromptRunDeps(&stdout_capture, &stderr_capture, testPresentKeyStartup);
+    deps.permission_approval_prompt_ctx = @ptrCast(&prompt);
+    deps.permission_approval_prompt = TestPermissionPrompt.prompt;
+    deps.stdin_is_tty = TestTty.yes;
+    var ctx = AskContext.init(alloc, testConfig(), deps, "/tmp/workspace");
+    defer ctx.deinit();
+    ctx.prompt_permissions = true;
+
+    ctx.output_mode = .json;
+    const approved = try requestToolPermissionOutcome(&ctx, arena, .{
+        .id = "captured-approved",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"touch captured-approved.txt\"}",
+    }, .ask, &.{}, &.{});
+    try std.testing.expectEqual(ToolPermissionDecision.once, approved.decision);
+    try std.testing.expectEqual(@as(usize, 1), prompt.calls);
+    try std.testing.expect(std.mem.find(u8, stderr_capture.bytes.items, "Approve? [y/N]") != null);
+    try std.testing.expectEqualStrings("", stdout_capture.bytes.items);
+
+    prompt.result = .deny;
+    ctx.output_mode = .quiet;
+    const denied = try requestToolPermissionOutcome(&ctx, arena, .{
+        .id = "quiet-denied",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"touch quiet-denied.txt\"}",
+    }, .ask, &.{}, &.{});
+    try std.testing.expectEqual(ToolPermissionDecision.deny, denied.decision);
+    try std.testing.expectEqual(@as(usize, 2), prompt.calls);
+
+    ctx.deps.stdin_is_tty = TestTty.no;
+    try std.testing.expectError(error.NonInteractivePermissionRequired, requestToolPermissionOutcome(&ctx, arena, .{
+        .id = "quiet-non-tty",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"touch quiet-non-tty.txt\"}",
+    }, .ask, &.{}, &.{}));
+    try std.testing.expectEqual(@as(usize, 2), prompt.calls);
 }
 
 test "fx ask terminal permission prompt propagates prompt hook errors" {

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -120,6 +120,11 @@ pub const ReviewOrigin = enum {
     subagent,
 };
 
+pub const AutoPermissionPhase = enum {
+    automatic_review,
+    human_approval,
+};
+
 /// Borrowed view of the successful model turn. Every referenced slice must
 /// remain valid until `Reviewer.review` returns.
 pub const ReviewTurnContext = struct {
@@ -130,6 +135,7 @@ pub const ReviewTurnContext = struct {
     /// Bounded canonical root-user requests for the active turn. Assistant,
     /// tool, feedback, repository, and attachment text never become authority.
     current_root_request: []const u8 = "",
+    auto_permission_phase: AutoPermissionPhase = .automatic_review,
 };
 
 pub const ReviewRequest = struct {

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -861,6 +861,11 @@ fn nonAllowAutoReviewOutcome(
     };
 }
 
+fn isHumanApprovalPhase(input: Input) bool {
+    const review_turn = input.permission_review_turn orelse return false;
+    return review_turn.auto_permission_phase == .human_approval;
+}
+
 fn automaticReviewOutcome(
     input: Input,
     arena: Allocator,
@@ -869,6 +874,10 @@ fn automaticReviewOutcome(
     is_dynamic_tool: bool,
     file_authorization: ?file_mutation_contract.FileExecutionAuthorization,
 ) !command_admission.PermissionOutcome {
+    if (isHumanApprovalPhase(input)) return .{
+        .decision = .permission_required,
+        .denial_reason = .permission_required,
+    };
     if (!input.auto_classifier.enabled()) return reviewerUnavailableOutcome(call);
     if (input.permission_review_turn == null) return reviewerUnavailableOutcome(call);
 
@@ -1782,7 +1791,7 @@ fn requestSandboxWideningOutcomeInternal(
         );
     }
 
-    if (permission_mode == .auto) {
+    if (permission_mode == .auto and !isHumanApprovalPhase(input)) {
         if (!input.auto_classifier.enabled() or input.permission_review_turn == null) {
             return reviewerUnavailableOutcome(call);
         }
@@ -5161,7 +5170,7 @@ test "invalid automatic review returns a recoverable denial without a prompter" 
     try std.testing.expect(outcome.auto_review_result == null);
 }
 
-test "exhausted automatic recovery remains a recoverable review denial" {
+test "human approval phase bypasses automatic review" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var worker: WorkerRuntime = .{};
@@ -5178,7 +5187,9 @@ test "exhausted automatic recovery remains a recoverable review denial" {
             FakeAutoClassifier.classify,
         ),
     );
-    input.permission_review_turn = testReviewTurn();
+    var review_turn = testReviewTurn();
+    review_turn.auto_permission_phase = .human_approval;
+    input.permission_review_turn = review_turn;
     input.permission_prompter = recording.prompter();
     const call = ToolCall{
         .id = "exhausted",
@@ -5186,17 +5197,17 @@ test "exhausted automatic recovery remains a recoverable review denial" {
         .arguments_json = "{\"action\":\"exec\",\"command\":\"touch exhausted.txt\"}",
     };
 
-    const reviewed = try requestPermissionOutcome(
+    const approved = try requestPermissionOutcome(
         input,
         arena_state.allocator(),
         call,
         .auto,
         &.{},
     );
-    try std.testing.expectEqual(ToolPermissionDecision.deny, reviewed.decision);
-    try std.testing.expectEqual(types.ToolPermissionDenialReason.auto_denied, reviewed.denial_reason.?);
-    try std.testing.expectEqual(@as(usize, 1), fake.calls);
-    try std.testing.expectEqual(@as(usize, 0), recording.calls);
+    try std.testing.expectEqual(ToolPermissionDecision.once, approved.decision);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+    try std.testing.expectEqual(@as(usize, 1), recording.calls);
+    try std.testing.expectEqualStrings(call.id, recording.last_call_id.?);
 
     input.permission_prompter = null;
     const headless = try requestPermissionOutcome(
@@ -5206,10 +5217,10 @@ test "exhausted automatic recovery remains a recoverable review denial" {
         .auto,
         &.{},
     );
-    try std.testing.expectEqual(ToolPermissionDecision.deny, headless.decision);
-    try std.testing.expectEqual(types.ToolPermissionDenialReason.auto_denied, headless.denial_reason.?);
-    try std.testing.expectEqual(@as(usize, 2), fake.calls);
-    try std.testing.expectEqual(@as(usize, 0), recording.calls);
+    try std.testing.expectEqual(ToolPermissionDecision.permission_required, headless.decision);
+    try std.testing.expectEqual(types.ToolPermissionDenialReason.permission_required, headless.denial_reason.?);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+    try std.testing.expectEqual(@as(usize, 1), recording.calls);
 }
 
 test "configured command authority skips automatic review" {
@@ -5220,6 +5231,7 @@ test "configured command authority skips automatic review" {
     var background: BackgroundRuntime = .{};
     defer background.deinit(std.testing.allocator);
     var fake = FakeAutoClassifier{};
+    var recording = RecordingPrompter{};
     var input = testInputWithClassifier(
         &worker,
         &background,
@@ -5252,6 +5264,10 @@ test "configured command authority skips automatic review" {
         .action = .allow,
     }};
     input.permission_rules = .{ .rules = &rules };
+    var review_turn = testReviewTurn();
+    review_turn.auto_permission_phase = .human_approval;
+    input.permission_review_turn = review_turn;
+    input.permission_prompter = recording.prompter();
     const configured = try requestPermissionOutcome(
         input,
         arena_state.allocator(),
@@ -5268,6 +5284,7 @@ test "configured command authority skips automatic review" {
         configured.execution_authority.?.run_command.shell_allowed.source,
     );
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
+    try std.testing.expectEqual(@as(usize, 0), recording.calls);
 }
 
 test "known reversible auto commands bypass the reviewer" {
@@ -5329,6 +5346,11 @@ test "session deny narrows configured command allow" {
         &background,
         permission_auto_classifier.Classifier.disabled(),
     );
+    var recording = RecordingPrompter{};
+    var review_turn = testReviewTurn();
+    review_turn.auto_permission_phase = .human_approval;
+    input.permission_review_turn = review_turn;
+    input.permission_prompter = recording.prompter();
     var rules = [_]types.PermissionRule{.{
         .permission = @constCast("bash"),
         .pattern = @constCast("touch *"),
@@ -5362,6 +5384,7 @@ test "session deny narrows configured command allow" {
     );
     try std.testing.expectEqual(ToolPermissionDecision.policy_denied, denied.decision);
     try std.testing.expect(denied.execution_authority == null);
+    try std.testing.expectEqual(@as(usize, 0), recording.calls);
 }
 
 test "prepared session deny blocks local file mutation without setup effects" {
@@ -5574,6 +5597,55 @@ test "sandbox widening review carries the full broader command context" {
     );
     const authority = outcome.execution_authority.?.run_command.shell_allowed;
     try std.testing.expectEqual(permission_auto_classifier.SandboxScope.broader, authority.fingerprint.scope);
+}
+
+test "human approval phase routes sandbox widening through the prompter" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(std.testing.allocator);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(std.testing.allocator);
+    var fake = FakeAutoClassifier{};
+    var recording = RecordingPrompter{};
+    var input = testInputWithClassifier(
+        &worker,
+        &background,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+    var review_turn = testReviewTurn();
+    review_turn.auto_permission_phase = .human_approval;
+    input.permission_review_turn = review_turn;
+    input.permission_prompter = recording.prompter();
+    input.sandbox_backend = .macos;
+
+    const call = ToolCall{
+        .id = "sandbox-human-approval",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"npm install left-pad\"}",
+    };
+    const restricted_fingerprint = command_admission.AdmissionFingerprint.init(
+        try runCommandContext(input, arena_state.allocator(), call),
+    );
+    const outcome = try requestSandboxWideningOutcome(
+        input,
+        arena_state.allocator(),
+        call,
+        .auto,
+        &.{},
+        .{
+            .phase = .preflight,
+            .restricted_fingerprint = restricted_fingerprint,
+        },
+    );
+
+    try std.testing.expectEqual(ToolPermissionDecision.once, outcome.decision);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+    try std.testing.expectEqual(@as(usize, 1), recording.calls);
+    try std.testing.expectEqualStrings(call.id, recording.last_call_id.?);
 }
 
 test "unavailable sandbox reviewer always returns to the agent" {
@@ -6047,6 +6119,75 @@ test "external prepared file review carries frozen path and diff authority" {
         target_path,
         authorization.input.path(),
     );
+}
+
+test "human approval phase routes prepared file mutation through the prompter" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+    try tmp.dir.createDirPath(io_mod.getIo(), "external");
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(workspace);
+    const external = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "external");
+    defer alloc.free(external);
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(alloc);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(alloc);
+    var fake = FakeAutoClassifier{};
+    var recording = RecordingPrompter{};
+    var input = testInputWithClassifier(
+        &worker,
+        &background,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+    var review_turn = testReviewTurn();
+    review_turn.auto_permission_phase = .human_approval;
+    input.permission_review_turn = review_turn;
+    input.permission_prompter = recording.prompter();
+    input.workspace_root = workspace;
+
+    const target_path = try std.fs.path.join(arena, &.{ external, "prepared.txt" });
+    const arguments_json = try std.fmt.allocPrint(
+        arena,
+        "{{\"path\":\"{s}\",\"content\":\"hello\\n\"}}",
+        .{target_path},
+    );
+    const call: ToolCall = .{
+        .id = "prepared-human-approval",
+        .name = "write_file",
+        .arguments_json = arguments_json,
+    };
+    var prepared = switch (try prepareFileMutationCall(arena, call, .{
+        .tool_registry = test_admission_registry,
+        .workspace_root = workspace,
+    })) {
+        .tool_failure => return error.TestExpectedPreparedFileMutation,
+        .prepared => |value| value,
+    };
+    defer prepared.deinit(arena);
+
+    const outcome = try requestPreparedFileMutationPermissionOutcome(
+        input,
+        arena,
+        call,
+        &prepared,
+        .auto,
+        &.{},
+    );
+
+    try std.testing.expectEqual(ToolPermissionDecision.once, outcome.decision);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+    try std.testing.expectEqual(@as(usize, 1), recording.calls);
+    try std.testing.expectEqualStrings(call.id, recording.last_call_id.?);
 }
 
 test "automatic workspace write uses reversible admission without reviewer" {

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -6131,6 +6131,15 @@ test "human approval phase routes prepared file mutation through the prompter" {
     defer alloc.free(workspace);
     const external = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "external");
     defer alloc.free(external);
+    {
+        var existing = try tmp.dir.createFile(
+            io_mod.getIo(),
+            "external/prepared.txt",
+            .{ .truncate = true },
+        );
+        defer existing.close(io_mod.getIo());
+        try existing.writeStreamingAll(io_mod.getIo(), "before\n");
+    }
 
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -4291,6 +4291,76 @@ describe("acp: model-independent", () => {
   );
 
   test(
+    "ACP routes the post-threshold action through session/request_permission",
+    async () => {
+      const cases = [
+        { suffix: "allow", optionId: "allow_once" as const, executes: true },
+        { suffix: "reject", optionId: "reject_once" as const, executes: false },
+      ];
+
+      for (const testCase of cases) {
+        const root = createIsolatedRoot(`fx-acp-auto-threshold-${testCase.suffix}-`);
+        const target = join(root.external, `threshold-${testCase.suffix}.txt`);
+        const fourthCallId = `${testCase.suffix}_threshold_call_4`;
+        const gateway = startFakeGateway([
+          ...Array.from({ length: 4 }, (_, index) => (body: string) => {
+            if (index > 0) expect(body).toContain("auto_denied");
+            if (index === 3) {
+              expect(body).not.toContain('"tools":[]');
+              expect(body).not.toContain('"toolChoice":{"type":"none"}');
+            }
+            return fileToolCall(
+              index === 3 ? fourthCallId : `${testCase.suffix}_threshold_call_${index + 1}`,
+              target,
+              `ACP_THRESHOLD_${testCase.suffix.toUpperCase()}`,
+            );
+          }),
+          finalText(`ACP threshold ${testCase.suffix} complete`),
+        ], { classifierDecision: "ask" });
+
+        try {
+          client = await AcpClient.create({
+            cwd: root.workspace,
+            env: fakeGatewayEnv(root, gateway),
+          });
+          client.setPermissionOption(testCase.optionId);
+          await startCodeSession(client);
+          const result = await runPrompt(
+            client,
+            `Write the ACP threshold ${testCase.suffix} fixture.`,
+            TIMEOUT,
+          );
+
+          const permissions = result.messages.filter(
+            (message: any) => message.method === "session/request_permission",
+          );
+          expect(permissions).toHaveLength(1);
+          expect(permissions[0]!.params.toolCall.toolCallId).toBe(fourthCallId);
+          expect(gateway.classifierRequests).toHaveLength(3);
+          expect(gateway.requests).toHaveLength(5);
+          expect(existsSync(target)).toBe(testCase.executes);
+          if (testCase.executes) {
+            expect(readFileSync(target, "utf8")).toBe("ACP_THRESHOLD_ALLOW");
+            expect(acpToolResultText(gateway.requests[4]!.body, fourthCallId)).not.toContain(
+              "tool_permission_denied",
+            );
+          } else {
+            expect(acpToolResultText(gateway.requests[4]!.body, fourthCallId)).toContain(
+              "user_denied",
+            );
+          }
+          expect(client.stderr).toBe("");
+        } finally {
+          await client?.close();
+          gateway.stop();
+          rmSync(root.root, { recursive: true, force: true });
+        }
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "terminal prompt response admits immediate session/list before worker exit",
     async () => {
       const root = createIsolatedRoot("fx-acp-terminal-list-");

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -4301,6 +4301,7 @@ describe("acp: model-independent", () => {
       for (const testCase of cases) {
         const root = createIsolatedRoot(`fx-acp-auto-threshold-${testCase.suffix}-`);
         const target = join(root.external, `threshold-${testCase.suffix}.txt`);
+        writeFileSync(target, "before");
         const fourthCallId = `${testCase.suffix}_threshold_call_4`;
         const postRejectCallId = "reject_after_human_denial";
         const postDecisionResponses = testCase.executes
@@ -4348,15 +4349,16 @@ describe("acp: model-independent", () => {
           );
           expect(permissions).toHaveLength(1);
           expect(permissions[0]!.params.toolCall.toolCallId).toBe(fourthCallId);
-          expect(gateway.classifierRequests).toHaveLength(testCase.executes ? 3 : 4);
+          expect(gateway.classifierRequests).toHaveLength(testCase.executes ? 1 : 2);
           expect(gateway.requests).toHaveLength(testCase.executes ? 5 : 6);
-          expect(existsSync(target)).toBe(testCase.executes);
+          expect(existsSync(target)).toBe(true);
           if (testCase.executes) {
             expect(readFileSync(target, "utf8")).toBe("ACP_THRESHOLD_ALLOW");
             expect(acpToolResultText(gateway.requests[4]!.body, fourthCallId)).not.toContain(
               "tool_permission_denied",
             );
           } else {
+            expect(readFileSync(target, "utf8")).toBe("before");
             expect(acpToolResultText(gateway.requests[4]!.body, fourthCallId)).toContain(
               "user_denied",
             );

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -4302,6 +4302,17 @@ describe("acp: model-independent", () => {
         const root = createIsolatedRoot(`fx-acp-auto-threshold-${testCase.suffix}-`);
         const target = join(root.external, `threshold-${testCase.suffix}.txt`);
         const fourthCallId = `${testCase.suffix}_threshold_call_4`;
+        const postRejectCallId = "reject_after_human_denial";
+        const postDecisionResponses = testCase.executes
+          ? []
+          : [(body: string) => {
+            expect(acpToolResultText(body, fourthCallId)).toContain("user_denied");
+            return fileToolCall(
+              postRejectCallId,
+              target,
+              "ACP_THRESHOLD_REJECTED_RETRY",
+            );
+          }];
         const gateway = startFakeGateway([
           ...Array.from({ length: 4 }, (_, index) => (body: string) => {
             if (index > 0) expect(body).toContain("auto_denied");
@@ -4315,6 +4326,7 @@ describe("acp: model-independent", () => {
               `ACP_THRESHOLD_${testCase.suffix.toUpperCase()}`,
             );
           }),
+          ...postDecisionResponses,
           finalText(`ACP threshold ${testCase.suffix} complete`),
         ], { classifierDecision: "ask" });
 
@@ -4336,8 +4348,8 @@ describe("acp: model-independent", () => {
           );
           expect(permissions).toHaveLength(1);
           expect(permissions[0]!.params.toolCall.toolCallId).toBe(fourthCallId);
-          expect(gateway.classifierRequests).toHaveLength(3);
-          expect(gateway.requests).toHaveLength(5);
+          expect(gateway.classifierRequests).toHaveLength(testCase.executes ? 3 : 4);
+          expect(gateway.requests).toHaveLength(testCase.executes ? 5 : 6);
           expect(existsSync(target)).toBe(testCase.executes);
           if (testCase.executes) {
             expect(readFileSync(target, "utf8")).toBe("ACP_THRESHOLD_ALLOW");
@@ -4347,6 +4359,9 @@ describe("acp: model-independent", () => {
           } else {
             expect(acpToolResultText(gateway.requests[4]!.body, fourthCallId)).toContain(
               "user_denied",
+            );
+            expect(acpToolResultText(gateway.requests[5]!.body, postRejectCallId)).toContain(
+              "auto_denied",
             );
           }
           expect(client.stderr).toBe("");

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -316,24 +316,23 @@ describe("lean auto mode reliability", () => {
   );
 
   test(
-    "three blocked responses end with one tools-disabled agent response",
+    "headless auto mode requires approval for the next action after three blocks",
     async () => {
       const root = createIsolatedRoot();
       const markers = Array.from(
-        { length: 3 },
+        { length: 4 },
         (_, index) => join(root.workspace, `blocked-action-${index + 1}-must-not-run`),
       );
       const gateway = startGateway(
         [
           ...markers.map((marker, index) => (body?: string) => {
-          if (index > 0) expect(body).toContain("auto_denied");
-          return commandCall(`touch ${JSON.stringify(marker)}`, `blocked_action_${index + 1}`);
+            if (index > 0) expect(body).toContain("auto_denied");
+            if (index === 3) {
+              expect(body).not.toContain('"tools":[]');
+              expect(body).not.toContain('"toolChoice":{"type":"none"}');
+            }
+            return commandCall(`touch ${JSON.stringify(marker)}`, `blocked_action_${index + 1}`);
           }),
-          (body?: string) => {
-            expect(body).toContain('"tools":[]');
-            expect(body).toContain('"toolChoice":{"type":"none"}');
-            return fakeGatewayFinalText("Which safe alternative should I use?");
-          },
         ],
         Array.from(
           { length: 3 },
@@ -350,9 +349,9 @@ describe("lean auto mode reliability", () => {
         },
       );
 
-      expect(result.code).toBe(0);
-      expect(result.stdout).not.toContain("NonInteractivePermissionRequired");
-      expect(result.stdout).toContain("Which safe alternative should I use?");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("permission required");
+      expect(result.stderr).toContain("noninteractive_permission_prompt_unavailable");
       expect(gateway.requests).toHaveLength(4);
       expect(gateway.classifierRequests).toHaveLength(3);
       for (const marker of markers) expect(existsSync(marker)).toBe(false);
@@ -470,7 +469,7 @@ describe("lean auto mode reliability", () => {
   );
 
   test.skipIf(process.platform !== "darwin")(
-    "headless sandbox widening uses a tools-disabled response after three blocks",
+    "headless sandbox widening requires approval after three blocks",
     async () => {
       const root = createIsolatedRoot("/Users/Shared");
       const marker = join(root.workspace, "sandbox-widening-must-not-run");
@@ -485,14 +484,11 @@ describe("lean auto mode reliability", () => {
       );
       const gateway = startGateway(
         [
-          ...Array.from({ length: 3 }, (_, index) => (body?: string) => {
-          if (index > 0) expect(body).toContain("auto_denied");
-          return commandCall(command, `sandbox_widening_${index + 1}`);
+          ...Array.from({ length: 4 }, (_, index) => (body?: string) => {
+            if (index > 0) expect(body).toContain("auto_denied");
+            if (index === 3) expect(body).not.toContain('"tools":[]');
+            return commandCall(command, `sandbox_widening_${index + 1}`);
           }),
-          (body?: string) => {
-            expect(body).toContain('"tools":[]');
-            return fakeGatewayFinalText("Sandbox widening needs user direction.");
-          },
         ],
         [
           fakeGatewayPermissionDecision("ask", "sandbox_review_1"),
@@ -510,9 +506,9 @@ describe("lean auto mode reliability", () => {
         },
       );
 
-      expect(result.code).toBe(0);
-      expect(result.stdout).not.toContain("NonInteractivePermissionRequired");
-      expect(result.stdout).toContain("Sandbox widening needs user direction.");
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("permission required");
+      expect(result.stderr).toContain("noninteractive_permission_prompt_unavailable");
       expect(gateway.requests).toHaveLength(4);
       expect(gateway.classifierRequests).toHaveLength(3);
       for (const request of gateway.classifierRequests) {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -308,23 +308,26 @@ describe("cli: help", () => {
 Run one noninteractive request
 
 Usage:
-  fx ask [--auto|--yolo] [--image PATH] [--json] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>
+  fx ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>
 
 Options:
-  --auto               Automatically review unresolved permission requests
-  --yolo               Disable permission checks and command sandboxing
-  --image PATH         Attach an image file; repeat for multiple images
-  --json               Emit machine-readable JSON instead of text
-  --no-save            Do not save the session; incompatible with --resume and --resume-id
-  --no-color           Render TTY output without colors or hyperlinks
-  --resume <last|id>   Continue the last session or a session by id
-  --resume-id <id>     Continue a session by exact id
-  --continue-recovery  Resume the paused model response in the selected session
-  --                   Treat every following argument as prompt text
+  --auto                Automatically review unresolved permission requests
+  --yolo                Disable permission checks and command sandboxing
+  --image PATH          Attach an image file; repeat for multiple images
+  --json                Emit machine-readable JSON instead of text
+  --quiet               Suppress assistant output
+  --prompt-permissions  Prompt for Y/N permission approval when stdin is a TTY
+  --no-save             Do not save the session; incompatible with --resume and --resume-id
+  --no-color            Render TTY output without colors or hyperlinks
+  --resume <last|id>    Continue the last session or a session by id
+  --resume-id <id>      Continue a session by exact id
+  --continue-recovery   Resume the paused model response in the selected session
+  --                    Treat every following argument as prompt text
 
 The prompt may be passed as arguments or piped on stdin when no prompt args are given.
 TTY stdout uses the Minimal transcript presentation; redirected stdout emits raw assistant Markdown.
 Operational progress and diagnostics are written to stderr. JSON output keeps raw Markdown in \`output\`.
+With --prompt-permissions, JSON and quiet requests may prompt on stderr only when stdin is a TTY.
 `;
 
       for (const alias of ["--help", "-h"]) {
@@ -4418,7 +4421,7 @@ describe("cli: error handling", () => {
             "fx ask: --no-save cannot be used with --resume or --resume-id",
           );
           expect(rejected.stderr).toContain(
-            "usage: fx ask [--auto|--yolo] [--image PATH] [--json] [--no-save]",
+            "usage: fx ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save]",
           );
         }
         expect(gateway.requests).toHaveLength(0);

--- a/tests/e2e/permission-errors.test.ts
+++ b/tests/e2e/permission-errors.test.ts
@@ -3,18 +3,22 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runFx } from "../evals/eval-helpers";
+import { FX_BIN, runFx } from "../evals/eval-helpers";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  fakeGatewayPermissionDecision,
   fakeGatewayToolCall,
   startFakeGateway,
+  TmuxSession,
+  tmuxAvailable,
 } from "./tmux-helpers";
 
 const TIMEOUT = 120_000;
@@ -62,6 +66,99 @@ function toolResultText(body: string, toolCallId: string): string {
   expect(output.type).toBe("text");
   expect(typeof output.value).toBe("string");
   return output.value as string;
+}
+
+function permissionEnv(
+  home: string,
+  gateway: ReturnType<typeof startFakeGateway>,
+) {
+  return {
+    HOME: home,
+    AI_GATEWAY_API_KEY: "permission-error-fake-key",
+    VERCEL_OIDC_TOKEN: undefined,
+    FX_GATEWAY_BASE_URL: gateway.baseUrl,
+    FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+    FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+    FX_MODEL: FAKE_GATEWAY_MODEL,
+    FX_AUTO_UPGRADE: "0",
+    NO_COLOR: "1",
+  };
+}
+
+async function waitForPaneExit(
+  session: TmuxSession,
+  expectedStatus: number,
+) {
+  const deadline = Date.now() + TIMEOUT;
+  while (Date.now() < deadline) {
+    const status = session.paneStatus();
+    if (status.dead) {
+      expect(status.status).toBe(expectedStatus);
+      return;
+    }
+    await Bun.sleep(25);
+  }
+  throw new Error(
+    `Timed out waiting for fx ask to exit.\n${await session.captureFullScrollback()}`,
+  );
+}
+
+async function runTtyPromptPermissionsCase(
+  outputMode: "json" | "quiet",
+  decision: "approve" | "deny",
+) {
+  const root = createIsolatedRoot(
+    `fx-${outputMode}-prompt-permissions-${decision}-`,
+  );
+  const marker = join(root.workspace, `${decision}-marker.txt`);
+  const stdoutPath = join(root.root, `${decision}.stdout`);
+  writeFileSync(
+    join(root.home, ".fx", "settings.json"),
+    JSON.stringify({ permission_mode: "ask", sandbox: "none" }),
+  );
+  writeFileSync(stdoutPath, "");
+  const gateway = startFakeGateway([
+    fakeGatewayToolCall(`${decision}_${outputMode}_call`, "terminal", {
+      action: "exec",
+      command: `touch ${JSON.stringify(marker)}`,
+    }),
+    fakeGatewayFinalText(`${decision} ${outputMode} complete`),
+  ]);
+  let session: TmuxSession | null = null;
+  try {
+    session = await TmuxSession.create({
+      cmd: `${JSON.stringify(FX_BIN)} ask --${outputMode} --prompt-permissions --no-save "Run the exact ${outputMode} fixture." > ${JSON.stringify(stdoutPath)}`,
+      cwd: root.workspace,
+      env: permissionEnv(root.home, gateway),
+      remainOnExit: true,
+    });
+    const prompt = await session.waitForText("Approve? [y/N]", TIMEOUT);
+    expect(prompt).toContain("fx wants to run:");
+    expect(existsSync(marker)).toBe(false);
+    await session.sendText(decision === "approve" ? "y" : "n");
+    await waitForPaneExit(session, 0);
+
+    const stdout = readFileSync(stdoutPath, "utf8");
+    expect(stdout).not.toContain("Approve? [y/N]");
+    if (outputMode === "json") {
+      const json = JSON.parse(stdout) as FxJson;
+      expect(json.exit_code).toBe(0);
+      expect(json.tool_calls).toContainEqual(
+        expect.objectContaining({
+          name: "terminal",
+          status: decision === "approve" ? "success" : "error",
+        }),
+      );
+    } else {
+      expect(stdout).toBe("");
+    }
+    expect(existsSync(marker)).toBe(decision === "approve");
+    expect(gateway.requests).toHaveLength(2);
+  } finally {
+    if (session) await session.kill();
+    gateway.stop();
+    rmSync(root.root, { recursive: true, force: true });
+  }
 }
 
 describe("generic permission typed errors", () => {
@@ -125,6 +222,159 @@ describe("generic permission typed errors", () => {
       } finally {
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "JSON prompt-permissions approval and denial preserve stdout and exact execution",
+    async () => {
+      for (const decision of ["approve", "deny"] as const) {
+        await runTtyPromptPermissionsCase("json", decision);
+      }
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "JSON prompt-permissions reaches approval after three automatic review denials",
+    async () => {
+      const root = createIsolatedRoot("fx-json-auto-prompt-permissions-");
+      const markers = Array.from(
+        { length: 4 },
+        (_, index) => join(root.workspace, `auto-marker-${index + 1}.txt`),
+      );
+      const stdoutPath = join(root.root, "auto.stdout");
+      writeFileSync(
+        join(root.home, ".fx", "settings.json"),
+        JSON.stringify({ permission_mode: "auto", sandbox: "none" }),
+      );
+      writeFileSync(stdoutPath, "");
+      const gateway = startFakeGateway(
+        [
+          ...markers.map((marker, index) => (body?: string) => {
+            if (index > 0) expect(body).toContain("auto_denied");
+            return fakeGatewayToolCall(`auto_call_${index + 1}`, "terminal", {
+              action: "exec",
+              command: `touch ${JSON.stringify(marker)}`,
+            });
+          }),
+          fakeGatewayFinalText("automatic threshold approval complete"),
+        ],
+        {
+          classifierResponses: Array.from(
+            { length: 3 },
+            (_, index) => fakeGatewayPermissionDecision(
+              "ask",
+              `auto_review_${index + 1}`,
+            ),
+          ),
+        },
+      );
+      let session: TmuxSession | null = null;
+      try {
+        session = await TmuxSession.create({
+          cmd: `${JSON.stringify(FX_BIN)} ask --auto --json --prompt-permissions --no-save "Run the automatic threshold fixture." > ${JSON.stringify(stdoutPath)}`,
+          cwd: root.workspace,
+          env: permissionEnv(root.home, gateway),
+          remainOnExit: true,
+        });
+        await session.waitForText("Approve? [y/N]", TIMEOUT);
+        for (const marker of markers) expect(existsSync(marker)).toBe(false);
+        expect(gateway.classifierRequests).toHaveLength(3);
+        await session.sendText("y");
+        await waitForPaneExit(session, 0);
+
+        const stdout = readFileSync(stdoutPath, "utf8");
+        expect(stdout).not.toContain("Approve? [y/N]");
+        const json = JSON.parse(stdout) as FxJson;
+        expect(json.output).toContain("automatic threshold approval complete");
+        expect(json.tool_calls.filter((call) => call.status === "error")).toHaveLength(3);
+        expect(json.tool_calls.filter((call) => call.status === "success")).toHaveLength(1);
+        for (const marker of markers.slice(0, 3)) {
+          expect(existsSync(marker)).toBe(false);
+        }
+        expect(existsSync(markers[3]!)).toBe(true);
+        expect(gateway.requests).toHaveLength(5);
+        expect(gateway.classifierRequests).toHaveLength(3);
+      } finally {
+        if (session) await session.kill();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "quiet prompt-permissions approval and denial keep stdout empty",
+    async () => {
+      for (const decision of ["approve", "deny"] as const) {
+        await runTtyPromptPermissionsCase("quiet", decision);
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "JSON and quiet permission prompting remain fail-closed without a TTY or explicit opt in",
+    async () => {
+      const cases = [
+        { mode: "json", args: ["--json"], optIn: false },
+        { mode: "json", args: ["--json", "--prompt-permissions"], optIn: true },
+        { mode: "quiet", args: ["--quiet"], optIn: false },
+        { mode: "quiet", args: ["--quiet", "--prompt-permissions"], optIn: true },
+      ] as const;
+
+      for (const testCase of cases) {
+        const root = createIsolatedRoot(
+          `fx-${testCase.mode}-${testCase.optIn ? "opt-in" : "default"}-non-tty-`,
+        );
+        const marker = join(root.workspace, "must-not-run.txt");
+        writeFileSync(
+          join(root.home, ".fx", "settings.json"),
+          JSON.stringify({ permission_mode: "ask", sandbox: "none" }),
+        );
+        const gateway = startFakeGateway([
+          fakeGatewayToolCall("non_tty_call", "terminal", {
+            action: "exec",
+            command: `touch ${JSON.stringify(marker)}`,
+          }),
+        ]);
+        try {
+          const result = await runFx(
+            [
+              "ask",
+              ...testCase.args,
+              "--no-save",
+              "Run the non-TTY fixture.",
+            ],
+            {
+              cwd: root.workspace,
+              env: permissionEnv(root.home, gateway),
+              timeoutMs: TIMEOUT,
+            },
+          );
+
+          expect(result.timedOut).toBe(false);
+          expect(result.code).toBe(1);
+          expect(result.stderr).toContain("noninteractive_permission_prompt_unavailable");
+          expect(result.stderr).not.toContain("Approve? [y/N]");
+          if (testCase.mode === "json") {
+            const json = JSON.parse(result.stdout) as FxJson & {
+              error: string;
+            };
+            expect(json.error).toBe("NonInteractivePermissionRequired");
+          } else {
+            expect(result.stdout).toBe("");
+          }
+          expect(gateway.requests).toHaveLength(1);
+          expect(existsSync(marker)).toBe(false);
+        } finally {
+          gateway.stop();
+          rmSync(root.root, { recursive: true, force: true });
+        }
       }
     },
     TIMEOUT,

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -5226,7 +5226,6 @@ describe("effect-aware command permissions", () => {
       });
       await activeSession.waitForComposer(TIMEOUT);
       await activeSession.sendText(rootPrompt);
-      await activeSession.waitForText("INTERACTIVE_AUTO_APPROVAL_PARENT_CREATED", TIMEOUT);
       const approvalPane = await activeSession.waitForText(COMMAND_APPROVAL_PROMPT, TIMEOUT);
 
       expect(approvalPane).toContain(

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -2682,7 +2682,7 @@ describe("effect-aware command permissions", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
-    "TUI auto mode reuses one invalid review through three blocked responses",
+    "TUI auto mode reuses one invalid review before human escalation",
     async () => {
       const root = createIsolatedRoot();
       const marker = join(root.workspace, "classifier-fallback-approved.txt");
@@ -2693,10 +2693,11 @@ describe("effect-aware command permissions", () => {
           toolCall(command, {}, "invalid_review_2"),
           toolCall(command, {}, "invalid_review_3"),
           (body) => {
-            expect(body).toContain('"tools":[]');
-            expect(body).toContain('"toolChoice":{"type":"none"}');
-            return finalText("Which safe alternative should I use?");
+            expect(body).not.toContain('"tools":[]');
+            expect(body).not.toContain('"toolChoice":{"type":"none"}');
+            return toolCall(command, {}, "human_approval_4");
           },
+          finalText("post-threshold approval complete"),
         ],
         {
           classifierResponses: [finalText("accept")],
@@ -2721,14 +2722,18 @@ describe("effect-aware command permissions", () => {
       });
       await activeSession.waitForComposer(TIMEOUT);
       await activeSession.sendText("Run the reviewer fallback fixture.");
-      const pane = await activeSession.waitForText(
-        "Which safe alternative should I use?",
-        TIMEOUT,
-      );
+      const pane = await activeSession.waitForText(COMMAND_APPROVAL_PROMPT, TIMEOUT);
 
-      expect(pane).not.toContain(COMMAND_APPROVAL_PROMPT);
+      expect(pane).toContain("classifier-fallback-approved.txt");
       expect(existsSync(marker)).toBe(false);
       expect(gateway.requests).toHaveLength(4);
+      expect(gateway.classifierRequests).toHaveLength(1);
+      await activeSession.sendKeys("1");
+      await activeSession.sendKeys("Enter");
+      await activeSession.waitForText("post-threshold approval complete", TIMEOUT);
+
+      expect(existsSync(marker)).toBe(true);
+      expect(gateway.requests).toHaveLength(5);
       expect(gateway.classifierRequests).toHaveLength(1);
       const trace = readFileSync(tracePath, "utf8");
       expect(trace.match(/denial_reason=auto_denied/g)).toHaveLength(1);
@@ -5143,6 +5148,110 @@ describe("effect-aware command permissions", () => {
         "<subagent_deliveries",
         approval!.label,
       ]);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      expectNoHostileExecutables(root);
+      expectNoCommandArtifacts(root);
+    },
+    60_000,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "interactive fx routes a child's post-threshold action to parent approval",
+    async () => {
+      const root = createIsolatedRoot();
+      const stderrPath = join(root.root, "interactive-child-auto-approval-stderr.log");
+      const markerPath = join(root.workspace, "child-auto-approved.txt");
+      const rootPrompt = "INTERACTIVE_CREATE_AUTO_APPROVAL_CHILD";
+      const childPrompt = "INTERACTIVE_AUTO_APPROVAL_CHILD";
+      const rootCreateCallId = "interactive_auto_approval_create";
+      let childId = "";
+      let childRequestCount = 0;
+      writeFileSync(stderrPath, "");
+
+      const route = (body: string): Response => {
+        const userText = currentUserText(body);
+        if (userText.includes(childPrompt)) {
+          childRequestCount += 1;
+          if (childRequestCount <= 4) {
+            if (childRequestCount > 1) expect(body).toContain("auto_denied");
+            return gatewayToolCall("terminal", {
+              action: "exec",
+              command: `/usr/bin/touch ${shellQuote(markerPath)}`,
+            }, `child_auto_command_${childRequestCount}`);
+          }
+          expect(toolResultText(body, "child_auto_command_4")).not.toContain(
+            "tool_permission_denied",
+          );
+          return finalText("INTERACTIVE_AUTO_APPROVAL_CHILD_COMPLETE");
+        }
+        if (body.includes(`\"toolCallId\":\"${rootCreateCallId}\"`) &&
+            body.includes('"type":"tool-result"')) {
+          const created = JSON.parse(toolResultText(body, rootCreateCallId)) as {
+            child_id: string;
+            status: string;
+          };
+          expect(created.status).toBe("created");
+          childId = created.child_id;
+          return finalText("INTERACTIVE_AUTO_APPROVAL_PARENT_CREATED");
+        }
+        if (userText.includes(rootPrompt)) {
+          return gatewayToolCall("subagent", {
+            command: {
+              create: {
+                name: "interactive-auto-approval-child",
+                mode: "one_off",
+                prompt: childPrompt,
+                permission_mode: "auto",
+              },
+            },
+          }, rootCreateCallId);
+        }
+        throw new Error(`Unexpected child auto approval request: ${body}`);
+      };
+      const gateway = startDynamicFakeGateway(route, {
+        classifierDecision: "ask",
+      });
+      gateways.push(gateway);
+
+      activeSession = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: root.workspace,
+        env: gatewayEnv(root, gateway, {
+          FX_PERMISSION_MODE: "auto",
+          PATH: hostilePath(root),
+        }),
+        stderrPath,
+        width: 120,
+        height: 40,
+      });
+      await activeSession.waitForComposer(TIMEOUT);
+      await activeSession.sendText(rootPrompt);
+      await activeSession.waitForText("INTERACTIVE_AUTO_APPROVAL_PARENT_CREATED", TIMEOUT);
+      const approvalPane = await activeSession.waitForText(COMMAND_APPROVAL_PROMPT, TIMEOUT);
+
+      expect(approvalPane).toContain(
+        "Subagent interactive-auto-approval-child needs permission",
+      );
+      expect(approvalPane).toContain("/usr/bin/touch");
+      expect(childId).not.toBe("");
+      expect(subagentState(root, childId)).toBe("awaiting_approval");
+      expect(existsSync(markerPath)).toBe(false);
+      expect(gateway.classifierRequests).toHaveLength(3);
+      await activeSession.sendKeys("1");
+      await activeSession.sendKeys("Enter");
+
+      const deadline = Date.now() + TIMEOUT;
+      while (subagentState(root, childId) !== "completed" && Date.now() < deadline) {
+        await Bun.sleep(20);
+      }
+      expect(subagentState(root, childId)).toBe("completed");
+      expect(childRequestCount).toBe(5);
+      expect(gateway.classifierRequests).toHaveLength(3);
+      expect(existsSync(markerPath)).toBe(true);
+
+      await activeSession.sendText("/quit");
+      expect(await activeSession.waitForSessionEnd(5_000)).toBe(true);
+      activeSession = null;
       expect(readFileSync(stderrPath, "utf8")).toBe("");
       expectNoHostileExecutables(root);
       expectNoCommandArtifacts(root);

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -5235,7 +5235,7 @@ describe("effect-aware command permissions", () => {
       expect(childId).not.toBe("");
       expect(subagentState(root, childId)).toBe("awaiting_approval");
       expect(existsSync(markerPath)).toBe(false);
-      expect(gateway.classifierRequests).toHaveLength(3);
+      expect(gateway.classifierRequests).toHaveLength(1);
       await activeSession.sendKeys("1");
       await activeSession.sendKeys("Enter");
 
@@ -5245,7 +5245,7 @@ describe("effect-aware command permissions", () => {
       }
       expect(subagentState(root, childId)).toBe("completed");
       expect(childRequestCount).toBe(5);
-      expect(gateway.classifierRequests).toHaveLength(3);
+      expect(gateway.classifierRequests).toHaveLength(1);
       expect(existsSync(markerPath)).toBe(true);
 
       await activeSession.sendText("/quit");


### PR DESCRIPTION
## Summary

- Ask for human approval on the next unresolved sensitive action after three automatic review denials.
- Keep tools available and skip a fourth automatic review at the threshold.
- Return to automatic review after a human denial instead of prompting again immediately.
- Use the existing root, child, and ACP approval paths while headless runs return the existing `permission_required` error.
- Allow JSON and quiet `fx ask` runs to opt into the existing Y/N approval prompt with `--prompt-permissions` when stdin is a TTY.
- Keep permission prompts on stderr so JSON stdout stays parseable and quiet stdout stays empty.
- Keep JSON and quiet runs noninteractive without the flag or a TTY and return the existing permission-required error.
- Preserve configured rules, session decisions, safe paths, sandbox policy, and step limits.