### PR TITLE
Preserve retained transcript scrollback

### DIFF
--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -3331,12 +3331,11 @@ test "structured command-output rewrite materializes committed transcript scroll
         .images = &.{},
     });
 
-    var live_entry_ids: [18]u32 = undefined;
     for (0..18) |index| {
         var line: [48]u8 = undefined;
         const text = try std.fmt.bufPrint(&line, "SYSTEM OUTPUT {d:0>2}\\n", .{index + 1});
         const bytes = try h.alloc.dupe(u8, text);
-        live_entry_ids[index] = try h.shell.appendRawBytesEntryClassified(
+        _ = try h.shell.appendRawBytesEntryClassified(
             h.alloc,
             bytes,
             .unknown_raw,
@@ -3359,43 +3358,63 @@ test "structured command-output rewrite materializes committed transcript scroll
     try h.flush();
     try std.testing.expectEqual(transcript_runtime.TranscriptCommitDiagnosticState.stable, h.shell.transcriptCommitDiagnostic().state);
 
-    try removeRawEntriesForResizeTest(&h.shell, h.alloc, &live_entry_ids);
-    const compact_bytes = try h.alloc.dupe(
-        u8,
-        "SYSTEM OUTPUT 01\n... 16 command lines folded\nSYSTEM OUTPUT 18\n",
-    );
-    _ = try h.shell.appendRawBytesEntryClassified(
-        h.alloc,
-        compact_bytes,
-        .unknown_raw,
-    );
-    try h.shell.rebuildTranscriptCacheAfterStructuredRewrite(
-        h.alloc,
-        "command output consolidation",
-    );
-
-    const second_assistant_id = try h.shell.appendAssistantTurnEntry(h.alloc);
-    const second_assistant = h.shell.lookupAssistantSegments(second_assistant_id) orelse
-        return error.TestExpectedAssistantSegments;
+    var follow_up: std.Io.Writer.Allocating = .init(h.alloc);
+    defer follow_up.deinit();
     for (0..60) |index| {
-        var line: [40]u8 = undefined;
-        const text = try std.fmt.bufPrint(&line, "follow-up table row {d}\n", .{index + 1});
-        try second_assistant.text.appendSlice(h.alloc, text);
+        try follow_up.writer.print("follow-up retained row {d}\n", .{index + 1});
     }
+    const retained_before = h.shell.retainedStructuredBytesForCommandOutput();
+    h.shell.max_retained_transcript_bytes = retained_before + follow_up.written().len / 2;
+    {
+        var block = assistant_presentation.CodeBlockPayload{
+            .language = try h.alloc.dupe(u8, "zig"),
+            .code = try h.alloc.dupe(u8, "const retained_boundary = true;\n"),
+        };
+        errdefer block.deinit(h.alloc);
+        _ = try h.shell.appendAssistantCodeBlockOwned(h.alloc, block);
+    }
+    _ = try h.shell.streamAssistantChunk(h.alloc, &h.metrics, follow_up.written());
+    try std.testing.expect(
+        h.shell.retainedStructuredBytesForCommandOutput() <=
+            h.shell.max_retained_transcript_bytes,
+    );
+    var retained_source = try h.shell.prepareTranscriptSource(h.alloc, null);
+    defer retained_source.deinit(h.alloc);
+    try std.testing.expect(std.mem.find(
+        u8,
+        retained_source.bytes,
+        "SYSTEM OUTPUT 02",
+    ) == null);
 
     try h.renderTranscriptFrame();
     try h.flush();
-    // The structured rewrite is byte-incompatible with the committed
-    // anchor: this frame re-anchors in place with zero release.
+    // The retention rewrite is byte-incompatible with the committed anchor.
+    // This frame re-anchors in place and records same-epoch recovery debt.
     try std.testing.expectEqual(@as(u16, 0), h.last_frame.planned_scroll_rows);
     try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
+    const held_diagnostic = h.shell.transcriptCommitDiagnostic();
+    try std.testing.expectEqual(
+        transcript_runtime.TranscriptCommitDiagnosticState.stable,
+        held_diagnostic.state,
+    );
+    switch (h.shell.transcript_commit_state) {
+        .stable => |anchor| try std.testing.expect(anchor.normal_buffer_recovery_pending),
+        .invalid, .recovering => return error.TestExpectedStableTranscript,
+    }
 
     // The following compatible frame settles the held rows with final bytes.
     try h.renderTranscriptFrame();
     try h.flush();
     try std.testing.expect(h.last_frame.planned_scroll_rows > 0);
-    try std.testing.expect(h.last_frame.committed_scroll_rows > 0);
-    try expectGridContains(&h, "follow-up table row 60");
+    try std.testing.expectEqual(
+        h.last_frame.planned_scroll_rows,
+        h.last_frame.committed_scroll_rows,
+    );
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
+    switch (h.shell.transcript_commit_state) {
+        .stable => |anchor| try std.testing.expect(!anchor.normal_buffer_recovery_pending),
+        .invalid, .recovering => return error.TestExpectedStableTranscript,
+    }
 }
 
 fn applyCompletedReadForGroupFinalityResizeTest(
@@ -7592,24 +7611,6 @@ fn commandOutputAnsiStyles() transcript_runtime.Styles {
         .dim_style = "\x1b[2m",
         .red_style = "\x1b[31m",
     };
-}
-
-fn removeRawEntriesForResizeTest(
-    runtime: *TranscriptRuntime,
-    alloc: Allocator,
-    ids: []const u32,
-) !void {
-    for (ids) |id| {
-        var index: usize = 0;
-        while (index < runtime.entries.items.len) : (index += 1) {
-            const entry = runtime.entries.items[index];
-            if (entry == .raw_bytes and entry.raw_bytes.id == id) {
-                var removed = runtime.entries.orderedRemove(index);
-                removed.deinit(alloc);
-                break;
-            }
-        } else return error.TestExpectedRawEntry;
-    }
 }
 
 fn expectGridOccurrenceCount(h: *Harness, needle: []const u8, expected: usize) !void {

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -217,6 +217,29 @@ fn installStableAnchorForTest(
     );
 }
 
+fn stableHistoryVisualOffsetForTest(runtime: *const TranscriptRuntime) !u32 {
+    return switch (runtime.transcript_commit_state) {
+        .stable => |anchor| anchor.history_visual_offset,
+        .invalid, .recovering => error.TestExpectedStableTranscript,
+    };
+}
+
+fn expectStableNormalBufferRecoveryForTest(
+    runtime: *const TranscriptRuntime,
+    expected_history_visual_offset: u32,
+) !void {
+    switch (runtime.transcript_commit_state) {
+        .stable => |anchor| {
+            try std.testing.expect(anchor.normal_buffer_recovery_pending);
+            try std.testing.expectEqual(
+                expected_history_visual_offset,
+                anchor.history_visual_offset,
+            );
+        },
+        .invalid, .recovering => return error.TestExpectedStableTranscript,
+    }
+}
+
 fn testPaintPlan(
     runtime: *const TranscriptRuntime,
     selection: viewport_selection.ViewportSelection,
@@ -10305,7 +10328,7 @@ test "streamAssistantChunk extends the trailing assistant_turn on subsequent chu
     try std.testing.expectEqualStrings("alpha beta", runtime.entries.items[0].assistant_turn.segments.text.items);
 }
 
-test "recorded assistant stream slow path preserves a capped canonical anchor without pruning" {
+test "recorded assistant stream slow path preserves a canonical anchor when retention rewrites its source" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{
         .layout = transcriptTestLayout(48, 12, 8),
@@ -10315,6 +10338,12 @@ test "recorded assistant stream slow path preserves a capped canonical anchor wi
     defer runtime.deinit(alloc);
     try runtime.enableShadowVt(alloc);
 
+    const old_prefix = "old retained prefix\n";
+    _ = try runtime.appendRawTranscriptEntryClassified(
+        alloc,
+        old_prefix,
+        .subagent_status,
+    );
     const long_prompt = try makeLongPastePrompt(alloc, 40);
     defer alloc.free(long_prompt);
     var metrics: Metrics = .{};
@@ -10346,35 +10375,38 @@ test "recorded assistant stream slow path preserves a capped canonical anchor wi
         committed_prepared.cursor.cursor_col,
         1,
     );
-    const committed_diagnostic = runtime.transcriptCommitDiagnostic();
+    const committed_history_visual_offset = try stableHistoryVisualOffsetForTest(&runtime);
 
     const chunk = "trimmed assistant tail";
-    const retained_before = transcript_store.retainedStructuredBytes(&runtime);
-    runtime.max_retained_transcript_bytes = retained_before + chunk.len - 1;
-    try std.testing.expect(
-        chunk.len > runtime.max_retained_transcript_bytes - retained_before,
-    );
+    runtime.max_retained_transcript_bytes =
+        transcript_store.retainedStructuredBytes(&runtime) + chunk.len - old_prefix.len;
     const assistant_id = try runtime.streamAssistantChunk(alloc, &metrics, chunk);
 
-    try std.testing.expectEqualDeep(
-        committed_diagnostic,
-        runtime.transcriptCommitDiagnostic(),
+    try expectStableNormalBufferRecoveryForTest(
+        &runtime,
+        committed_history_visual_offset,
     );
-    try std.testing.expectEqual(@as(usize, 2), runtime.entries.items.len);
-    try std.testing.expectEqual(user_id, runtime.entries.items[0].id());
-    try std.testing.expect(runtime.entries.items[0] == .user_turn);
-    try std.testing.expectEqual(assistant_id, runtime.entries.items[1].id());
-    try std.testing.expectEqualStrings(
-        chunk[1..],
-        runtime.lookupAssistantSegments(assistant_id).?.text.items,
+    try std.testing.expect(
+        transcript_store.retainedStructuredBytes(&runtime) <=
+            runtime.max_retained_transcript_bytes,
     );
+    try std.testing.expect(runtime.lookupAssistantSegments(assistant_id) != null);
     var appended_source = try runtime.prepareTranscriptSource(alloc, null);
     defer appended_source.deinit(alloc);
-    try std.testing.expect(std.mem.startsWith(
+    try std.testing.expect(!std.mem.startsWith(
         u8,
         appended_source.bytes,
         committed_source.bytes,
     ));
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        std.mem.count(u8, appended_source.bytes, old_prefix),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, appended_source.bytes, "LONG_PASTE_LAST_MARKER"),
+    );
+    try std.testing.expect(runtime.entries.items[0].id() == user_id);
 }
 
 const AssistantStreamFastPathCase = enum {
@@ -11158,7 +11190,7 @@ test "recorded user prompt card preserves a committed anchor after a non-prefix 
     );
 }
 
-test "recorded user prompt card invalidates an anchor when retention prunes its source" {
+test "recorded user prompt card preserves an anchor when retention prunes its source" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{
         .layout = transcriptTestLayout(40, 8, 4),
@@ -11184,6 +11216,7 @@ test "recorded user prompt card invalidates an anchor when retention prunes its 
         1,
         1,
     );
+    const committed_history_visual_offset = try stableHistoryVisualOffsetForTest(&runtime);
 
     const prompt = "retained prompt";
     runtime.max_retained_transcript_bytes = prompt.len;
@@ -11196,9 +11229,9 @@ test "recorded user prompt card invalidates an anchor when retention prunes its 
         &.{},
     );
 
-    try std.testing.expectEqual(
-        transcript_runtime.TranscriptCommitDiagnosticState.invalid,
-        runtime.transcriptCommitDiagnostic().state,
+    try expectStableNormalBufferRecoveryForTest(
+        &runtime,
+        committed_history_visual_offset,
     );
     var retained_source = try runtime.prepareTranscriptSource(alloc, null);
     defer retained_source.deinit(alloc);
@@ -11558,7 +11591,7 @@ test "theme retint is atomic across allocation failures" {
     );
 }
 
-test "recorded transcript append invalidates an anchor when retention prunes its source" {
+test "recorded transcript append preserves an anchor when retention prunes its source" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{
         .layout = transcriptTestLayout(40, 8, 4),
@@ -11584,6 +11617,7 @@ test "recorded transcript append invalidates an anchor when retention prunes its
         1,
         1,
     );
+    const committed_history_visual_offset = try stableHistoryVisualOffsetForTest(&runtime);
 
     const notice = "permission accepted\n";
     runtime.max_retained_transcript_bytes = notice.len;
@@ -11596,9 +11630,9 @@ test "recorded transcript append invalidates an anchor when retention prunes its
         .subagent_status,
     );
 
-    try std.testing.expectEqual(
-        transcript_runtime.TranscriptCommitDiagnosticState.invalid,
-        runtime.transcriptCommitDiagnostic().state,
+    try expectStableNormalBufferRecoveryForTest(
+        &runtime,
+        committed_history_visual_offset,
     );
     var retained_source = try runtime.prepareTranscriptSource(alloc, null);
     defer retained_source.deinit(alloc);
@@ -13006,7 +13040,7 @@ test "recorded command output completion does not allocate without a matching bl
     try std.testing.expectEqual(display_before.open_command_block, runtime.command_output_display.open_command_block);
 }
 
-test "recorded command output consolidation uses strict anchor mode when retention changes" {
+test "recorded command output consolidation preserves its anchor when retention changes" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{ .layout = transcriptTestLayout(80, 12, 8) };
     defer runtime.deinit(alloc);
@@ -13049,6 +13083,7 @@ test "recorded command output consolidation uses strict anchor mode when retenti
         transcript_runtime.TranscriptCommitDiagnosticState.stable,
         runtime.transcriptCommitDiagnostic().state,
     );
+    const committed_history_visual_offset = try stableHistoryVisualOffsetForTest(&runtime);
 
     try runtime.flushCommandOutputSummaryForLifecycle(
         alloc,
@@ -13060,9 +13095,9 @@ test "recorded command output consolidation uses strict anchor mode when retenti
 
     try std.testing.expect(transcript_store.retainedStructuredBytes(&runtime) <= runtime.max_retained_transcript_bytes);
     try std.testing.expect(runtime.command_output_blocks.items[0].lines.items.len < 2);
-    try std.testing.expectEqual(
-        transcript_runtime.TranscriptCommitDiagnosticState.invalid,
-        runtime.transcriptCommitDiagnostic().state,
+    try expectStableNormalBufferRecoveryForTest(
+        &runtime,
+        committed_history_visual_offset,
     );
 }
 
@@ -13715,27 +13750,30 @@ test "preserving batch lifecycle rewrite keeps a capped canonical anchor" {
     ) != null);
 }
 
-test "turn finished anchor preservation falls back for retention strict mode and geometry blockers" {
+test "turn finished anchor preservation keeps a same-epoch retention rewrite" {
     const alloc = std.testing.allocator;
 
-    {
-        var runtime = TranscriptRuntime{
-            .layout = transcriptTestLayout(40, 8, 4),
-            .owned_top_row = 1,
-        };
-        defer runtime.deinit(alloc);
-        try prepareTurnFinishedAnchor(&runtime, alloc);
-        runtime.max_retained_transcript_bytes = 0;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(40, 8, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+    try prepareTurnFinishedAnchor(&runtime, alloc);
+    const committed_history_visual_offset = try stableHistoryVisualOffsetForTest(&runtime);
+    runtime.max_retained_transcript_bytes = 0;
 
-        _ = try runtime.applyToolLifecyclePreservingNormalBufferAnchor(alloc, .{
-            .turn_finished = .{ .turn_id = 1, .outcome = .interrupted },
-        });
+    _ = try runtime.applyToolLifecyclePreservingNormalBufferAnchor(alloc, .{
+        .turn_finished = .{ .turn_id = 1, .outcome = .interrupted },
+    });
 
-        try std.testing.expectEqual(
-            transcript_runtime.TranscriptCommitDiagnosticState.invalid,
-            runtime.transcriptCommitDiagnostic().state,
-        );
-    }
+    try expectStableNormalBufferRecoveryForTest(
+        &runtime,
+        committed_history_visual_offset,
+    );
+}
+
+test "turn finished anchor preservation falls back for strict mode or geometry blocker" {
+    const alloc = std.testing.allocator;
 
     {
         var runtime = TranscriptRuntime{
@@ -13998,7 +14036,7 @@ test "pinned status admission preserves an authoritative committed anchor" {
     );
 }
 
-test "pinned status admission invalidates an anchor when retention prunes its source" {
+test "pinned status admission preserves an anchor when retention prunes its source" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{
         .layout = transcriptTestLayout(40, 8, 4),
@@ -14025,6 +14063,7 @@ test "pinned status admission invalidates an anchor when retention prunes its so
         1,
         1,
     );
+    const committed_history_visual_offset = try stableHistoryVisualOffsetForTest(&runtime);
     runtime.max_retained_transcript_bytes = "pending\n".len;
 
     _ = try transcript_store.appendPinnedToolStatusAtomic(
@@ -14033,9 +14072,9 @@ test "pinned status admission invalidates an anchor when retention prunes its so
         "pending\n",
     );
 
-    try std.testing.expectEqual(
-        transcript_runtime.TranscriptCommitDiagnosticState.invalid,
-        runtime.transcriptCommitDiagnostic().state,
+    try expectStableNormalBufferRecoveryForTest(
+        &runtime,
+        committed_history_visual_offset,
     );
     var retained_source = try runtime.prepareTranscriptSource(alloc, null);
     defer retained_source.deinit(alloc);
@@ -14479,7 +14518,7 @@ test "coalesced approval lifecycle reposition preserves an authoritative committ
     try std.testing.expectEqual(committed_offset, facts.source_visual_offset);
 }
 
-test "coalesced approval lifecycle reposition invalidates when retention prunes its source" {
+test "coalesced approval lifecycle reposition preserves its anchor when retention prunes its source" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{
         .layout = transcriptTestLayout(48, 12, 8),
@@ -14507,6 +14546,7 @@ test "coalesced approval lifecycle reposition invalidates when retention prunes 
         1,
         1,
     );
+    const committed_history_visual_offset = try stableHistoryVisualOffsetForTest(&runtime);
 
     const id = lifecycleId(92, "retained-command");
     _ = try runtime.applyToolLifecycle(alloc, .{ .provisional = .{
@@ -14532,9 +14572,9 @@ test "coalesced approval lifecycle reposition invalidates when retention prunes 
         .place_after_current_transcript = true,
     } });
 
-    try std.testing.expectEqual(
-        transcript_runtime.TranscriptCommitDiagnosticState.invalid,
-        runtime.transcriptCommitDiagnostic().state,
+    try expectStableNormalBufferRecoveryForTest(
+        &runtime,
+        committed_history_visual_offset,
     );
     var retained_source = try runtime.prepareTranscriptSource(alloc, null);
     defer retained_source.deinit(alloc);
@@ -14962,7 +15002,7 @@ test "lifecycle pin cleanup preserves a capped canonical anchor without pruning"
     try std.testing.expectEqualStrings(committed_source.bytes, cleaned_source.bytes);
 }
 
-test "lifecycle pin cleanup invalidates a canonical anchor when retention prunes" {
+test "lifecycle pin cleanup preserves a canonical anchor when retention prunes" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{
         .layout = transcriptTestLayout(48, 12, 8),
@@ -15000,14 +15040,15 @@ test "lifecycle pin cleanup invalidates a canonical anchor when retention prunes
         1,
         1,
     );
+    const committed_history_visual_offset = try stableHistoryVisualOffsetForTest(&runtime);
     runtime.max_retained_transcript_bytes =
         transcript_store.retainedStructuredBytes(&runtime) - anchored.len;
 
     try runtime.finishLifecycleBatch(alloc);
 
-    try std.testing.expectEqual(
-        transcript_runtime.TranscriptCommitDiagnosticState.invalid,
-        runtime.transcriptCommitDiagnostic().state,
+    try expectStableNormalBufferRecoveryForTest(
+        &runtime,
+        committed_history_visual_offset,
     );
     try std.testing.expectEqual(@as(usize, 0), runtime.lifecyclePinCount());
     try std.testing.expectEqual(@as(usize, 0), runtime.toolActivityRecordCount());

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -888,7 +888,7 @@ pub fn enforceStructuredRetentionAndReport(
         self.pruneToolDetailsForRetainedEntries(alloc, &entry_ids);
     }
     try self.refreshFoldedCommandSummaryIndices(alloc);
-    try rebuildTranscriptCacheFromEntries(self, alloc, "structured retention");
+    try rebuildTranscriptCacheAfterStructuredRewrite(self, alloc, "structured retention");
     requestTranscriptPaint(self);
     return true;
 }
@@ -1043,7 +1043,7 @@ pub fn appendPinnedToolStatusAtomic(
     const entry_index = rawEntryIndex(&shadow, entry_id) orelse
         return error.MissingLifecycleTranscriptEntry;
     shadow.entries.items[entry_index].raw_bytes.lifecycle_pinned = true;
-    const retention_changed = try enforceStructuredRetentionAndReport(
+    try enforceStructuredRetention(
         &shadow,
         alloc,
         entry_id,
@@ -1061,7 +1061,7 @@ pub fn appendPinnedToolStatusAtomic(
         &shadow,
         alloc,
         "atomic_pinned_tool_status_append",
-        if (retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
     );
     return entry_id;
 }
@@ -1127,7 +1127,7 @@ fn appendSemanticNoticeAtomicPinned(
         notice,
         pending_replacement,
     );
-    const retention_changed = try enforceStructuredRetentionAndReport(
+    try enforceStructuredRetention(
         &shadow,
         alloc,
         entry_id,
@@ -1145,7 +1145,7 @@ fn appendSemanticNoticeAtomicPinned(
         &shadow,
         alloc,
         "atomic_semantic_notice_append",
-        if (retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
     );
     return entry_id;
 }
@@ -1192,7 +1192,7 @@ pub fn replaceSemanticNoticeAtomic(
     handed_off = true;
     previous.deinit(alloc);
 
-    const retention_changed = try enforceStructuredRetentionAndReport(
+    try enforceStructuredRetention(
         &shadow,
         alloc,
         entry_id,
@@ -1209,7 +1209,7 @@ pub fn replaceSemanticNoticeAtomic(
         &shadow,
         alloc,
         "atomic_semantic_notice_replacement",
-        if (retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
     );
     return true;
 }
@@ -1238,7 +1238,7 @@ pub fn writeRecordedTranscriptClassifiedAtomic(
         class,
     );
     handed_off = true;
-    const retention_changed = try enforceStructuredRetentionAndReport(
+    try enforceStructuredRetention(
         &shadow,
         alloc,
         entry_id,
@@ -1249,7 +1249,7 @@ pub fn writeRecordedTranscriptClassifiedAtomic(
         &shadow,
         alloc,
         "atomic_recorded_transcript_append",
-        if (retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
     );
     return entry_id;
 }
@@ -1329,7 +1329,7 @@ pub fn writeRecordedCommandOutputChunkAtomic(
         &shadow,
         alloc,
         "atomic_recorded_command_output_append",
-        if (retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
         if (retention_changed) null else dirty_entry_id,
     );
     return entry_id;
@@ -1380,7 +1380,7 @@ pub fn flushRecordedCommandOutputSummaryAtomic(
         &shadow,
         alloc,
         "command output consolidation",
-        if (retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
         if (retention_changed) null else dirty_entry_id,
     );
 }
@@ -1524,7 +1524,7 @@ fn replacePinnedToolStatusAtomicInternal(
         &shadow,
         alloc,
         if (reposition) "lifecycle_status_reposition" else "lifecycle_status_replacement",
-        if (retention_changed) .strict else rewrite_mode,
+        rewrite_mode,
         if (retention_changed or reposition) null else entry_id,
     );
     return true;
@@ -1615,7 +1615,7 @@ fn replacePinnedToolStatusesAtomicWithRewriteMode(
         &shadow,
         alloc,
         "lifecycle_statuses_replacement",
-        if (retention_changed) .strict else rewrite_mode,
+        rewrite_mode,
         if (retention_changed) null else dirty_entry_id,
     );
 }
@@ -1666,7 +1666,7 @@ pub fn clearLifecyclePinsAtomic(
         &shadow,
         alloc,
         "lifecycle_pin_cleanup",
-        if (retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
         if (retention_changed) null else dirty_entry_id,
     );
 }
@@ -2480,7 +2480,7 @@ pub fn writeUserPromptCard(
         &shadow,
         alloc,
         "atomic_user_prompt_append",
-        if (admission.retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
         if (admission.retention_changed) null else admission.entry_id,
     );
     self.forgetShimmer();
@@ -2800,7 +2800,7 @@ pub fn streamAssistantChunk(
             &shadow,
             alloc,
             "atomic_assistant_stream_append",
-            .strict,
+            .preserve_same_epoch,
             if (staged.retention_changed) null else staged.entry_id,
         );
         self.forgetShimmer();
@@ -2848,7 +2848,7 @@ pub fn retintEntriesForTheme(
         }
     }
 
-    const retention_changed = try enforceStructuredRetentionAndReport(
+    try enforceStructuredRetention(
         &shadow,
         alloc,
         null,
@@ -2861,7 +2861,7 @@ pub fn retintEntriesForTheme(
         &shadow,
         alloc,
         "theme retint",
-        if (retention_changed) .strict else .preserve_same_epoch,
+        .preserve_same_epoch,
     );
 }
 

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -20,6 +20,7 @@ import { FX_BIN } from "../evals/eval-helpers";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  fakeGatewaySse,
   fakeGatewayToolCall,
   hasEmptyComposer,
   paneExitMatches,
@@ -1704,6 +1705,137 @@ describe.skipIf(SKIP)("tui: resize", () => {
       expect(session.isPaneAlive()).toBe(true);
     },
     TIMEOUT,
+  );
+
+  test(
+    "structured retention keeps native scrollback complete before resize",
+    async () => {
+      const root = realpathSync(
+        mkdtempSync(join(tmpdir(), "fx-retention-native-scrollback-")),
+      );
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      tempDirs.push(root);
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ sandbox: "none", permission_mode: "auto", permission: {} }),
+      );
+      writeFileSync(stderrPath, "");
+
+      const begin = "RETENTION_SCROLLBACK_BEGIN";
+      const end = "RETENTION_SCROLLBACK_END";
+      const beforeMarkers = Array.from(
+        { length: 120 },
+        (_, index) => `RETENTION_A_${String(index).padStart(3, "0")}`,
+      );
+      const afterMarkers = Array.from(
+        { length: 120 },
+        (_, index) => `RETENTION_B_${String(index).padStart(3, "0")}`,
+      );
+      const markers = [
+        begin,
+        ...beforeMarkers,
+        ...afterMarkers,
+        end,
+      ];
+      const response = fakeGatewaySse([
+        {
+          type: "text-delta",
+          id: "retention-text-a",
+          delta: `${begin}\n${beforeMarkers.map((marker) =>
+            `${marker} retained before semantic code block`
+          ).join("\n")}\n`,
+        },
+        {
+          type: "text-delta",
+          id: "retention-code",
+          delta: "```zig\nconst retained_scrollback = true;\n```\n",
+        },
+        {
+          type: "text-delta",
+          id: "retention-text-b",
+          delta: `${afterMarkers.map((marker) =>
+            `${marker} retained after semantic code block`
+          ).join("\n")}\n`,
+        },
+        {
+          type: "text-delta",
+          id: "retention-tail",
+          delta:
+            "| phase | state |\n| --- | --- |\n| middle | retained |\n\n---\n" +
+            `${end}\n`,
+        },
+        {
+          type: "finish",
+          finishReason: { unified: "stop", raw: "stop" },
+          usage: {
+            inputTokens: { total: 3 },
+            outputTokens: { total: 5_000 },
+          },
+        },
+      ]);
+      const command =
+        `awk 'BEGIN { for (i = 0; i < 13500; i++) printf "RETENTION_SEED_%05d alpha beta gamma delta epsilon zeta eta theta iota kappa lambda\\n", i }'`;
+      const gateway = startFakeGateway([
+        fakeGatewayToolCall("retention-seed", "terminal", { action: "exec", command }),
+        response,
+      ]);
+      gateways.push(gateway);
+
+      session = await createResizeSession({
+        cmd: FX_BIN,
+        cwd: workspace,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-retention-scrollback-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_MAX_AGENT_STEPS: "4",
+          FX_AUTO_UPGRADE: "0",
+          NO_COLOR: "1",
+        },
+        width: 120,
+        height: 40,
+        stderrPath,
+        minimumHistoryLines: MINIMUM_RESIZE_HISTORY_LINES,
+      });
+      await session.waitForComposer(10_000);
+      await session.sendText("exercise structured retention scrollback");
+      await waitForLiveScrollbackText(session, end, 60_000);
+      await waitForGatewayRequestCount(gateway, 2, 60_000);
+      await session.waitForPane(
+        (pane) => pane.includes(end) && hasEmptyComposer(pane),
+        60_000,
+      );
+
+      const assertMarkersExactlyOnce = (scrollback: string) => {
+        for (const marker of markers) {
+          expect(countOccurrences(scrollback, marker)).toBe(1);
+        }
+      };
+      const beforeResize = await session.captureFullScrollback();
+      assertMarkersExactlyOnce(beforeResize);
+
+      await session.resizeWindow(72, 24, 700);
+      await waitForSettledFooter(session);
+      assertMarkersExactlyOnce(await session.captureFullScrollback());
+
+      await session.resizeWindow(120, 40, 700);
+      const grid = await waitForSettledFooter(session);
+      assertMarkersExactlyOnce(await session.captureFullScrollback());
+      expect(grid.filter(isInputRow)).toHaveLength(1);
+      expect(findFooter(grid)).not.toBeNull();
+      expect(gateway.requests).toHaveLength(2);
+      expect(session.isPaneAlive()).toBe(true);
+      expectEmptyStderr(stderrPath);
+    },
+    LARGE_SKILL_TIMEOUT,
   );
 
   test(


### PR DESCRIPTION
## Summary

- Keep retained transcript rows in native scrollback when structured retention prunes older entries.
- Preserve the same retained scrollback content across terminal resize and reflow.
