### PR TITLE
Retire public version reset bridge

### DIFF
--- a/src/core/upgrade/update_target.zig
+++ b/src/core/upgrade/update_target.zig
@@ -134,8 +134,7 @@ pub const Target = union(Channel) {
     pub fn shouldInstall(self: Target, current: CurrentBuild) bool {
         if (self.channel() != current.channel) return true;
         return switch (self) {
-            .stable => |stable| compareVersions(stable.version, current.version) == .gt or
-                isPublicResetBridge(current.version, stable.version),
+            .stable => |stable| compareVersions(stable.version, current.version) == .gt,
             .dev => |dev| !revisionsEqual(dev.revision, current.revision),
         };
     }
@@ -151,10 +150,6 @@ pub const Target = union(Channel) {
 pub fn normalizeVersion(raw: []const u8) []const u8 {
     if (raw.len > 0 and raw[0] == 'v') return raw[1..];
     return raw;
-}
-
-pub fn versionsEqual(a: []const u8, b: []const u8) bool {
-    return std.mem.eql(u8, normalizeVersion(a), normalizeVersion(b));
 }
 
 pub fn compareVersions(a: []const u8, b: []const u8) std.math.Order {
@@ -205,10 +200,6 @@ fn shortRevision(revision: []const u8) []const u8 {
     return revision[0..@min(revision.len, 12)];
 }
 
-fn isPublicResetBridge(current: []const u8, target: []const u8) bool {
-    return versionsEqual(current, "0.4.5") and versionsEqual(target, "0.0.1");
-}
-
 test "channel parsing accepts only stable and dev" {
     try std.testing.expectEqual(Channel.stable, Channel.parse("stable").?);
     try std.testing.expectEqual(Channel.dev, Channel.parse("DEV").?);
@@ -249,30 +240,6 @@ test "dev manifest rejects malformed and oversized external data" {
     );
 }
 
-test "stable ordering permits only the exact public reset from the bridge" {
-    const alloc = std.testing.allocator;
-    var reset = try Target.initStable(alloc, "v0.0.1");
-    defer reset.deinit(alloc);
-    var other_reset = try Target.initStable(alloc, "v0.0.2");
-    defer other_reset.deinit(alloc);
-
-    try std.testing.expect(reset.shouldInstall(.{
-        .channel = .stable,
-        .version = "0.4.5",
-        .revision = "0123456789ab",
-    }));
-    try std.testing.expect(!reset.shouldInstall(.{
-        .channel = .stable,
-        .version = "0.4.4",
-        .revision = "0123456789ab",
-    }));
-    try std.testing.expect(!other_reset.shouldInstall(.{
-        .channel = .stable,
-        .version = "0.4.5",
-        .revision = "0123456789ab",
-    }));
-}
-
 test "stable release ordering rejects older targets and preserves channel switching" {
     const alloc = std.testing.allocator;
     var older = try Target.initStable(alloc, "v0.0.1");
@@ -284,6 +251,11 @@ test "stable release ordering rejects older targets and preserves channel switch
     };
 
     try std.testing.expect(!older.shouldInstall(newer_current));
+    try std.testing.expect(!older.shouldInstall(.{
+        .channel = .stable,
+        .version = "0.4.5",
+        .revision = "0123456789ab",
+    }));
     try std.testing.expect(older.shouldInstall(.{
         .channel = .dev,
         .version = "0.0.2",

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -54,7 +54,6 @@ function shellQuote(value: string): string {
 function startUpgradeServer(
   root: string,
   argvLogPath: string,
-  version = "v9.9.9",
 ): { baseUrl: string; stop: () => void } {
   const artifactDir = join(root, "release-artifact");
   const wrapperPath = join(artifactDir, "fx");
@@ -78,13 +77,13 @@ exec ${shellQuote(FX_BIN)} "$@"
   const archive = readFileSync(archivePath);
   const checksum = createHash("sha256").update(archive).digest("hex");
   const platform = `${process.platform === "darwin" ? "macos" : "linux"}-${process.arch === "arm64" ? "aarch64" : "x86_64"}`;
-  const archiveRoute = `/${version}/fx-${platform}.tar.gz`;
+  const archiveRoute = `/v9.9.9/fx-${platform}.tar.gz`;
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     fetch(request) {
       const path = new URL(request.url).pathname;
-      if (path === "/latest.txt") return new Response(`${version}\n`);
+      if (path === "/latest.txt") return new Response("v9.9.9\n");
       if (path === archiveRoute) return new Response(archive);
       if (path === `${archiveRoute}.sha256`) return new Response(`${checksum}\n`);
       return new Response("not found", { status: 404 });


### PR DESCRIPTION
## Summary

- Restore stable upgrades to normal forward-only version ordering.
- Remove the retired public-reset exception and unused version override from upgrade tests.
- Keep manual, automatic, and Ctrl+G handoffs on the shared target policy.
