### PR TITLE
Show saved session names in fx sessions

### DIFF
--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -696,8 +696,14 @@ pub const SessionListSnapshot = struct {
             try out.writer.print("[sessions] {d} saved\n", .{self.sessions.len});
             for (self.sessions) |entry| {
                 try out.writer.print(
-                    " - {s} turns={d} language={s} updated_at_ms={d}\n",
-                    .{ entry.id, entry.history_len, entry.conversation_language.view(), entry.updated_at_ms },
+                    " - {s}\n   id={s} turns={d} language={s} updated_at_ms={d}\n",
+                    .{
+                        entry.title orelse session_display_metadata.fallback_title,
+                        entry.id,
+                        entry.history_len,
+                        entry.conversation_language.view(),
+                        entry.updated_at_ms,
+                    },
                 );
             }
         }
@@ -1992,7 +1998,7 @@ test "core session list snapshot text and json stay stable" {
     const text = try (SessionListSnapshot{ .sessions = &sessions }).renderText(std.testing.allocator);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings(
-        "[sessions] 1 saved\n - abc turns=3 language=es updated_at_ms=2\n",
+        "[sessions] 1 saved\n - Session title\n   id=abc turns=3 language=es updated_at_ms=2\n",
         text,
     );
 
@@ -2010,7 +2016,7 @@ test "core session list snapshot text and json stay stable" {
     }).renderText(std.testing.allocator);
     defer std.testing.allocator.free(paged_text);
     try std.testing.expectEqualStrings(
-        "[sessions] 1 saved\n - abc turns=3 language=es updated_at_ms=2\n" ++
+        "[sessions] 1 saved\n - Session title\n   id=abc turns=3 language=es updated_at_ms=2\n" ++
             "[sessions] more saved sessions; continue with `fx sessions --cursor v1:2:abc`\n",
         paged_text,
     );
@@ -2025,6 +2031,30 @@ test "core session list snapshot text and json stay stable" {
         "{\"kind\":\"sessions\",\"count\":1,\"has_more\":true,\"next_cursor\":\"v1:2:abc\",\"sessions\":[{\"id\":\"abc\",\"title\":\"Session title\",\"preview\":\"Session title\\npreview line\",\"workspace_root\":\"/tmp/workspace\",\"origin_workspace_root\":\"/tmp/origin\",\"created_at_ms\":1,\"updated_at_ms\":2,\"history_len\":3,\"conversation_language\":\"es\"}]}",
         paged_json,
     );
+
+    const fallback_sessions = [_]session_store.SessionSummary{
+        .{
+            .id = @constCast("legacy"),
+            .created_at_ms = 1,
+            .updated_at_ms = 2,
+            .conversation_language = types.ConversationLanguage.default(),
+            .history_len = 0,
+        },
+    };
+    const fallback_text = try (SessionListSnapshot{ .sessions = &fallback_sessions }).renderText(std.testing.allocator);
+    defer std.testing.allocator.free(fallback_text);
+    try std.testing.expectEqualStrings(
+        "[sessions] 1 saved\n - Untitled session\n   id=legacy turns=0 language=und updated_at_ms=2\n",
+        fallback_text,
+    );
+
+    const long_title = "a" ** session_display_metadata.max_title_bytes;
+    var long_session = sessions[0];
+    long_session.title = @constCast(long_title);
+    const long_text = try (SessionListSnapshot{ .sessions = @as(*const [1]session_store.SessionSummary, &long_session) }).renderText(std.testing.allocator);
+    defer std.testing.allocator.free(long_text);
+    try std.testing.expect(std.mem.startsWith(u8, long_text, "[sessions] 1 saved\n - " ++ long_title ++ "\n"));
+    try std.testing.expect(std.mem.find(u8, long_text, "\n   id=abc turns=3") != null);
 
     const warning_text = try (SessionListSnapshot{
         .sessions = &sessions,

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -695,10 +695,15 @@ pub const SessionListSnapshot = struct {
         } else {
             try out.writer.print("[sessions] {d} saved\n", .{self.sessions.len});
             for (self.sessions) |entry| {
+                try out.writer.writeAll(" - ");
+                try writeTerminalSafe(
+                    &out.writer,
+                    alloc,
+                    entry.title orelse session_display_metadata.fallback_title,
+                );
                 try out.writer.print(
-                    " - {s}\n   id={s} turns={d} language={s} updated_at_ms={d}\n",
+                    "\n   id={s} turns={d} language={s} updated_at_ms={d}\n",
                     .{
-                        entry.title orelse session_display_metadata.fallback_title,
                         entry.id,
                         entry.history_len,
                         entry.conversation_language.view(),
@@ -2071,6 +2076,27 @@ test "core session list snapshot text and json stay stable" {
     try std.testing.expectEqualStrings(
         "{\"kind\":\"sessions\",\"count\":0,\"skipped_invalid\":2,\"sessions\":[]}",
         warning_json,
+    );
+}
+
+test "core session list text visibly escapes terminal controls in titles" {
+    const sessions = [_]session_store.SessionSummary{
+        .{
+            .id = @constCast("hostile-title"),
+            .title = @constCast("\x1b[2Jbreak\nnext"),
+            .created_at_ms = 1,
+            .updated_at_ms = 2,
+            .conversation_language = types.ConversationLanguage.default(),
+            .history_len = 0,
+        },
+    };
+
+    const text = try (SessionListSnapshot{ .sessions = &sessions }).renderText(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+    try std.testing.expectEqualStrings(
+        "[sessions] 1 saved\n - \\x1b[2Jbreak\\x0anext\n" ++
+            "   id=hostile-title turns=0 language=und updated_at_ms=2\n",
+        text,
     );
 }
 

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -2268,6 +2268,86 @@ describe("cli: sessions", () => {
   );
 
   test(
+    "fx sessions text shows named, unnamed, and renamed sessions",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-session-names-"));
+      try {
+        const home = join(root, "home");
+        const workspace = join(root, "workspace");
+        const sessionsDir = join(home, ".fx", "sessions");
+        mkdirSync(sessionsDir, { recursive: true, mode: 0o700 });
+        mkdirSync(workspace);
+        chmodSync(join(home, ".fx"), 0o700);
+        chmodSync(sessionsDir, 0o700);
+        const workspaceRoot = realpathSync(workspace);
+        const named = {
+          id: "named-session",
+          workspace_root: workspaceRoot,
+          origin_workspace_root: workspaceRoot,
+          title: "Investigate cache misses",
+          preview: null,
+          display_metadata_present: true,
+          created_at_ms: 1,
+          updated_at_ms: 3,
+          conversation_language: "en",
+          history_len: 2,
+        };
+        const unnamed = {
+          ...named,
+          id: "unnamed-session",
+          title: null,
+          display_metadata_present: false,
+          updated_at_ms: 2,
+          history_len: 0,
+        };
+        const indexPath = join(sessionsDir, "index.json");
+        writeFileSync(
+          indexPath,
+          JSON.stringify({ schema_version: 3, sessions: [named, unnamed] }),
+          { mode: 0o600 },
+        );
+
+        const first = await runFx(["sessions"], {
+          cwd: workspaceRoot,
+          env: { HOME: home, ...NO_GATEWAY_AUTH },
+          timeoutMs: TIMEOUT,
+        });
+        expect(first.code).toBe(0);
+        expect(first.stderr).toBe("");
+        expect(first.stdout).toContain(
+          " - Investigate cache misses\n   id=named-session turns=2",
+        );
+        expect(first.stdout).toContain(
+          " - Untitled session\n   id=unnamed-session turns=0",
+        );
+
+        writeFileSync(
+          indexPath,
+          JSON.stringify({
+            schema_version: 3,
+            sessions: [{ ...named, title: "Investigate cache hits" }, unnamed],
+          }),
+          { mode: 0o600 },
+        );
+        const renamed = await runFx(["sessions"], {
+          cwd: workspaceRoot,
+          env: { HOME: home, ...NO_GATEWAY_AUTH },
+          timeoutMs: TIMEOUT,
+        });
+        expect(renamed.code).toBe(0);
+        expect(renamed.stderr).toBe("");
+        expect(renamed.stdout).toContain(
+          " - Investigate cache hits\n   id=named-session turns=2",
+        );
+        expect(renamed.stdout).not.toContain("Investigate cache misses");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "session listing pages a 9001-entry index without scanning session directories",
     async () => {
       const root = mkdtempSync(join(tmpdir(), "fx-e2e-session-pages-"));


### PR DESCRIPTION
## What changed

- Show each persisted session title in the default `fx sessions` output.
- Keep the stable session ID and metadata on a separate line so long titles wrap cleanly.
- Use `Untitled session` for legacy sessions without display metadata.
- Cover named, unnamed, renamed, and maximum-length titles.

## Why

The session index already persisted titles, but the default text view only exposed opaque IDs.

## Impact

Saved sessions are easier to identify without changing the structured JSON contract.

## Validation

- Debug and ReleaseSafe builds
- Focused Zig output-contract tests
- Focused CLI end-to-end coverage
- Built-binary session-list smoke test with clean stderr
