### PR TITLE
Cover reasoning models without effort tiers

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -2683,6 +2683,7 @@ test "gateway catalog retains broad capability metadata" {
     try std.testing.expectEqualStrings("language", catalog.items[0].model_type);
     try std.testing.expect(catalog.items[0].has_tool_use);
     try std.testing.expect(catalog.items[0].has_reasoning);
+    try std.testing.expectEqual(@as(usize, 0), catalog.items[0].reasoning_efforts.items.len);
     try std.testing.expect(catalog.items[0].has_vision);
     try std.testing.expect(catalog.items[0].has_file_input);
     try std.testing.expect(catalog.items[0].has_web_search);

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -6676,6 +6676,33 @@ test "app_input_runtime model picker commits a model without options directly" {
     try std.testing.expectEqualStrings("", app.input_runtime.edit_state.input.items);
 }
 
+test "app_input_runtime model picker skips effort stage for reasoning model without tiers" {
+    const alloc = std.testing.allocator;
+    const model = "deepseek/deepseek-v4-pro-0813";
+    const completions = [_][]const u8{model};
+
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    app.model_completion_values = &completions;
+    app.gateway_metadata_model = model;
+    app.gateway_metadata = .{ .supports_reasoning = true };
+    try app.input_runtime.textReplacementState().replace(alloc, "/model ");
+
+    const capabilities = app.resolvedModelCapabilities(model);
+    try std.testing.expect(capabilities.supports_reasoning);
+    try std.testing.expectEqual(@as(usize, 0), capabilities.reasoning_efforts.len);
+
+    try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
+
+    try std.testing.expectEqual(@as(usize, 1), app.preference_commit_count);
+    try std.testing.expectEqualStrings(model, app.selected_model.items);
+    try std.testing.expectEqual(ModelPickerStage.model, app.input_runtime.picker.model_picker_stage);
+    try std.testing.expect(!app.input_runtime.picker.hasPendingModelPickerSelection());
+    try std.testing.expect(app.last_preference_effort == null);
+    try std.testing.expect(app.last_preference_fast_mode == null);
+    try std.testing.expectEqualStrings("", app.input_runtime.edit_state.input.items);
+}
+
 test "app_input_runtime model picker exposes opaque Gateway reasoning effort" {
     const alloc = std.testing.allocator;
     const completions = [_][]const u8{"provider/new-reasoning-model"};

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -2682,6 +2682,62 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
   );
 
   test(
+    "model picker skips effort stage for reasoning models without declared tiers",
+    async () => {
+      const fixture = createModelsMenuFixture();
+      const selectedModel = "deepseek/deepseek-v4-pro-0813";
+      gateway = startFakeGateway([], {
+        models: [
+          {
+            id: selectedModel,
+            type: "language",
+            released: 100,
+            tags: ["reasoning", "tool-use"],
+            context_window: 128_000,
+          },
+        ],
+      });
+      session = await TmuxSession.create({
+        cwd: fixture.workspace,
+        stderrPath: fixture.stderrPath,
+        env: {
+          HOME: fixture.home,
+          AI_GATEWAY_API_KEY: "fake-model-picker-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+          FX_MODEL: "openai/gpt-4o",
+          FX_AUTO_UPGRADE: "0",
+        },
+        width: 120,
+        height: 32,
+      });
+      await session.waitForComposer(10_000);
+
+      await session.sendLiteralText("/model ");
+      await session.waitForText(selectedModel, 10_000);
+      await session.sendLiteralText(selectedModel);
+      await session.sendKeys("Enter");
+      await session.waitForText(`● Switched to ${selectedModel}`, 5_000);
+
+      const pane = (await session.capturePaneGrid()).join("\n");
+      expect(hasEmptyComposer(pane)).toBe(true);
+      expect(pane).not.toContain("Reasoning effort");
+      expect(pane).not.toContain("default");
+      expect(JSON.parse(readFileSync(fixture.settingsPath, "utf8")).model).toBe(selectedModel);
+      expect(capturePaneTitle(session)).toBe(`fx · ${selectedModel}`);
+      expect(session.isAlive()).toBe(true);
+      expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      session = null;
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
     "skills catalog retains input ownership for global view shortcuts",
     async () => {
       const fixture = createSkillsMenuFixture();


### PR DESCRIPTION
## Summary
- assert that reasoning-tagged catalog entries can declare zero effort tiers
- verify the model picker selects those models directly without opening an effort stage
- add a deterministic tmux regression using DeepSeek-shaped catalog metadata

## Why
FXC-214 / #114 reported a dead `default`-only reasoning-effort stage. Current `main` already contains the correct zero-tier guard, but lacked explicit coverage connecting catalog parsing to the live picker flow. These tests prevent the behavior from regressing.

## Validation
- `zig build`
- `zig build test`
- focused catalog and picker Zig tests
- focused tmux end-to-end test

Closes #114
