### PR TITLE
Rank substring slash command matches

### DIFF
--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -460,12 +460,61 @@ pub fn firstSlashCompletion(registry: SlashRegistry, prefix: []const u8) ?[]cons
     return null;
 }
 
-pub fn matchedCompletionCommand(spec: SlashSpec, prefix: []const u8) ?[]const u8 {
-    if (prefix.len <= 1) return spec.command;
-    if (std.mem.startsWith(u8, spec.command, prefix)) return spec.command;
+const slash_completion_match_rank_count: usize = 3;
+
+const SlashCompletionCommandMatch = struct {
+    command: []const u8,
+    rank: usize,
+};
+
+const SlashCompletionMatch = struct {
+    spec: *const SlashSpec,
+    command: []const u8,
+};
+
+fn completionCommandMatchRank(command: []const u8, prefix: []const u8) ?usize {
+    if (std.mem.eql(u8, command, prefix)) return 0;
+    if (std.mem.startsWith(u8, command, prefix)) return 1;
+    if (prefix.len <= 1 or command.len <= 1) return null;
+    if (std.mem.find(u8, command[1..], prefix[1..]) != null) return 2;
+    return null;
+}
+
+fn bestCompletionCommandMatch(spec: SlashSpec, prefix: []const u8) ?SlashCompletionCommandMatch {
+    var best: ?SlashCompletionCommandMatch = if (completionCommandMatchRank(spec.command, prefix)) |rank|
+        .{ .command = spec.command, .rank = rank }
+    else
+        null;
+
     if (spec.show_aliases_in_completion) {
         for (spec.aliases) |alias| {
-            if (std.mem.startsWith(u8, alias, prefix)) return alias;
+            const rank = completionCommandMatchRank(alias, prefix) orelse continue;
+            if (best == null or rank < best.?.rank) {
+                best = .{ .command = alias, .rank = rank };
+            }
+        }
+    }
+    return best;
+}
+
+pub fn matchedCompletionCommand(spec: SlashSpec, prefix: []const u8) ?[]const u8 {
+    return (bestCompletionCommandMatch(spec, prefix) orelse return null).command;
+}
+
+fn nthSlashCommandCompletionMatch(registry: SlashRegistry, prefix: []const u8, n: usize) ?SlashCompletionMatch {
+    var idx: usize = 0;
+    for (0..slash_completion_match_rank_count) |rank| {
+        for (registry.commands) |*spec| {
+            if (spec.help_entry == null) continue;
+            const match = bestCompletionCommandMatch(spec.*, prefix) orelse continue;
+            if (match.rank != rank) continue;
+            if (idx == n) {
+                return .{
+                    .spec = spec,
+                    .command = match.command,
+                };
+            }
+            idx += 1;
         }
     }
     return null;
@@ -547,15 +596,7 @@ pub fn nthSlashCompletion(registry: SlashRegistry, prefix: []const u8, n: usize)
         return nthWorkspaceArgCompletion(query, n);
     }
     if (prefix.len == 0 or prefix[0] != '/') return null;
-    var idx: usize = 0;
-    for (registry.commands) |spec| {
-        if (spec.help_entry == null) continue;
-        if (matchedCompletionCommand(spec, prefix)) |cmd| {
-            if (idx == n) return cmd;
-            idx += 1;
-        }
-    }
-    return null;
+    return (nthSlashCommandCompletionMatch(registry, prefix, n) orelse return null).command;
 }
 
 /// Returns the byte offset where the argument portion begins for
@@ -620,31 +661,13 @@ pub fn nthSlashCompletionDescription(registry: SlashRegistry, prefix: []const u8
     if (maxxingArgCompletionPrefix(prefix) != null) return null;
     if (workspaceArgCompletionPrefix(prefix) != null) return null;
     if (prefix.len == 0 or prefix[0] != '/') return null;
-
-    var idx: usize = 0;
-    for (registry.commands) |spec| {
-        if (spec.help_entry == null) continue;
-        if (matchedCompletionCommand(spec, prefix) != null) {
-            if (idx == n) return spec.completion_description;
-            idx += 1;
-        }
-    }
-    return null;
+    return (nthSlashCommandCompletionMatch(registry, prefix, n) orelse return null).spec.completion_description;
 }
 
 pub fn nthSlashCompletionCategory(registry: SlashRegistry, prefix: []const u8, n: usize) ?SlashPresentationCategory {
     if (argCompletionAnchor(prefix) != 0) return null;
     if (prefix.len == 0 or prefix[0] != '/') return null;
-
-    var idx: usize = 0;
-    for (registry.commands) |spec| {
-        if (spec.help_entry == null) continue;
-        if (matchedCompletionCommand(spec, prefix) != null) {
-            if (idx == n) return spec.presentation_category;
-            idx += 1;
-        }
-    }
-    return null;
+    return (nthSlashCommandCompletionMatch(registry, prefix, n) orelse return null).spec.presentation_category;
 }
 
 pub fn slashCompletionHasArgs(registry: SlashRegistry, command: []const u8) bool {
@@ -1821,6 +1844,31 @@ test "slash completion matches prefix and aliases" {
     try std.testing.expect(firstSlashCompletion(testSlashRegistry(), "") == null);
 }
 
+test "slash completion ranks exact prefix and substring command matches" {
+    const specs = [_]SlashSpec{
+        .{ .kind = .models, .command = "/models", .help_entry = "/models", .completion_description = "browse models", .presentation_category = .model },
+        .{ .kind = .rename_session, .command = "/rename", .help_entry = "/rename <title>", .completion_description = "rename session", .presentation_category = .session },
+        .{ .kind = .model, .command = "/model", .help_entry = "/model <id>", .completion_description = "choose model", .presentation_category = .model },
+    };
+    const registry = SlashRegistry{ .commands = specs[0..] };
+
+    try std.testing.expectEqual(@as(usize, 2), slashCompletionCount(registry, "/model"));
+    try std.testing.expectEqualStrings("/model", nthSlashCompletion(registry, "/model", 0).?);
+    try std.testing.expectEqualStrings("choose model", nthSlashCompletionDescription(registry, "/model", 0).?);
+    try std.testing.expectEqualStrings("/models", nthSlashCompletion(registry, "/model", 1).?);
+
+    try std.testing.expectEqual(@as(usize, 2), slashCompletionCount(registry, "/mo"));
+    try std.testing.expectEqualStrings("/models", nthSlashCompletion(registry, "/mo", 0).?);
+    try std.testing.expectEqualStrings("/model", nthSlashCompletion(registry, "/mo", 1).?);
+
+    try std.testing.expectEqual(@as(usize, 1), slashCompletionCount(registry, "/name"));
+    try std.testing.expectEqualStrings("/rename", nthSlashCompletion(registry, "/name", 0).?);
+    try std.testing.expectEqual(SlashPresentationCategory.session, nthSlashCompletionCategory(registry, "/name", 0).?);
+
+    try std.testing.expectEqual(@as(usize, 0), slashCompletionCount(registry, "/missing"));
+    try std.testing.expect(nthSlashCompletion(registry, "/missing", 0) == null);
+}
+
 test "slash completion exposes interactive resume" {
     try std.testing.expectEqualStrings("/resume", nthSlashCompletion(testSlashRegistry(), "/resume", 0).?);
 }
@@ -2220,11 +2268,12 @@ test "slash completion descriptions follow completion matches" {
     try std.testing.expectEqualStrings("toggle Fast mode when supported", nthSlashCompletionDescription(testSlashRegistry(), "/fa", 0).?);
 }
 
-test "slash completion aliases participate in registry order" {
+test "slash completion aliases participate in ranked order" {
     try std.testing.expectEqualStrings("/background", firstSlashCompletion(testSlashRegistry(), "/ba").?);
-    try std.testing.expectEqual(@as(usize, 2), slashCompletionCount(testSlashRegistry(), "/ba"));
+    try std.testing.expectEqual(@as(usize, 3), slashCompletionCount(testSlashRegistry(), "/ba"));
     try std.testing.expectEqualStrings("/background", nthSlashCompletion(testSlashRegistry(), "/ba", 0).?);
     try std.testing.expectEqualStrings("/balance", nthSlashCompletion(testSlashRegistry(), "/ba", 1).?);
+    try std.testing.expectEqualStrings("/feedback", nthSlashCompletion(testSlashRegistry(), "/ba", 2).?);
     try std.testing.expectEqualStrings("/balance", firstSlashCompletion(testSlashRegistry(), "/bal").?);
 }
 

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -1196,6 +1196,27 @@ test "mixed slash completion uses skill relevance order" {
     );
 }
 
+test "mixed slash completion ranks substring commands before skill metadata" {
+    const specs = [_]command_specs.SlashSpec{
+        .{ .kind = .rename_session, .command = "/rename", .help_entry = "/rename <title>", .completion_description = "rename session", .presentation_category = .session },
+    };
+    const registry = command_specs.SlashRegistry{ .commands = specs[0..] };
+    const skills = [_]skill_runtime.Skill{.{
+        .name = "workflow-helper",
+        .description = "manage named workflows",
+        .path = "/tmp/.codex/skills/workflow-helper",
+        .source = .global_codex,
+    }};
+
+    try std.testing.expectEqual(@as(usize, 2), mixedSlashCompletionCount(registry, "/name", &skills));
+    try std.testing.expectEqualStrings("/rename", nthMixedSlashCompletionText(registry, "/name", &skills, 0).?);
+    try std.testing.expect(nthMixedSlashCompletionSkill(registry, "/name", &skills, 0) == null);
+    try std.testing.expectEqualStrings(
+        "workflow-helper",
+        nthMixedSlashCompletionSkill(registry, "/name", &skills, 1).?.name,
+    );
+}
+
 test "registry-aware mixed slash completion maps skills after injected commands" {
     const specs = [_]command_specs.SlashSpec{
         .{ .kind = .help, .command = "/alpha", .help_entry = "/alpha" },

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -944,7 +944,10 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.waitForComposer(10_000);
 
       await session.sendKeys("-l '/m'");
-      await session.waitForText("Commands 3", 5_000);
+      await session.waitForPane(
+        (pane) => pane.includes("Commands ") && pane.includes("/model"),
+        5_000,
+      );
 
       const initialGrid = await session.capturePaneGrid();
       const modelRow = initialGrid.find((line) =>
@@ -1021,7 +1024,10 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
       await session.sendLiteralText("/m");
-      await session.waitForText("Results 7", 5_000);
+      await session.waitForPane(
+        (pane) => pane.includes("Results ") && pane.includes("/model"),
+        5_000,
+      );
       grid = await session.capturePaneGrid();
       const modelRow = grid.find((line) => line.includes("/model"));
       const mcpRow = grid.find((line) => line.includes("/mcp"));
@@ -1046,7 +1052,10 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       session = await launch();
       await session.waitForComposer(10_000);
       await session.sendLiteralText("/m");
-      await session.waitForText("Results 7", 5_000);
+      await session.waitForPane(
+        (pane) => pane.includes("Results ") && pane.includes("/model"),
+        5_000,
+      );
       grid = await session.capturePaneGrid();
       const restartedModelRow = grid.find((line) => line.includes("/model"));
       const restartedMcpRow = grid.find((line) => line.includes("/mcp"));
@@ -1135,7 +1144,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       mkdirSync(workspace, { recursive: true });
       writeFileSync(
         join(skillDir, "SKILL.md"),
-        "---\nname: resume-helper\ndescription: resume a saved workflow\n---\n\nResume helper body\n",
+        "---\nname: resume-helper\ndescription: resume a named saved workflow\n---\n\nResume helper body\n",
       );
 
       session = await TmuxSession.create({
@@ -1165,6 +1174,14 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           !current.includes("no matching slash commands"),
         5_000,
       );
+
+      await session.sendKeys("C-u");
+      await session.sendLiteralText("/name");
+      pane = await session.waitForPane(
+        (current) => current.includes("/rename") && current.includes("resume-helper"),
+        5_000,
+      );
+      expect(pane.indexOf("/rename")).toBeLessThan(pane.indexOf("resume-helper"));
 
       await session.sendKeys("C-u");
       await session.pasteText("\n   ");


### PR DESCRIPTION
## What changed

- Rank slash-command results as exact, prefix, then substring matches.
- Keep command matches ahead of skill-description matches.
- Preserve prefix-only inline completion and argument-completion behavior.
- Add unit and TUI coverage for `/name` discovering `/rename`.

## Why

Slash-command discovery only considered prefixes, so memorable fragments such as `/name` could not surface `/rename`.

## Impact

Commands are easier to discover without changing command execution or allowing lower-relevance matches to outrank exact and prefix results.

## Validation

- Debug build
- 61 focused Zig slash-completion tests
- Full slash-menu TUI end-to-end file: 36 passed
- Fresh built-binary interaction with clean stderr