### PR TITLE
Harden runtime security boundaries

### DIFF
--- a/scripts/pgso/README.md
+++ b/scripts/pgso/README.md
@@ -58,12 +58,12 @@ GitHub Actions matrices. The remaining distributed subcommands are workflow
 phase interfaces: `train-shard`, `candidate`, `behavior-shard`, `measure`, and
 `aggregate`. They reject a source, corpus, toolchain, bitcode, instrumented
 binary, candidate, assignment, or shard identity mismatch. The aggregate
-command requires all 36 training scenarios, all 51 behavior scenarios, and all
+command requires all 36 training scenarios, all 53 behavior scenarios, and all
 12 performance gates exactly once before it emits `eligible: true`.
 
 ## Corpus
 
-[`corpus.json`](corpus.json) references existing test owners instead of copying their behavior. Training contains six direct CLI commands and thirty deterministic E2E files covering CLI, configuration, tools, Gateway lifecycle, fake web and vision routes, ACP, modern and legacy MCP, sessions, terminal hosting, TUI startup, resizing, rendering, permissions, interruption, subagents, and recovery. Sixteen additional deterministic E2E files verify the final candidate without influencing LLVM's hot and cold classification.
+[`corpus.json`](corpus.json) references existing test owners instead of copying their behavior. Training contains six direct CLI commands and thirty deterministic E2E files covering CLI, configuration, tools, Gateway lifecycle, fake web and vision routes, ACP, modern and legacy MCP, sessions, terminal hosting, TUI startup, resizing, rendering, permissions, interruption, subagents, and recovery. A bounded `profile_runs` count can weight a direct training command without duplicating manifest entries or final behavior checks. Seventeen additional deterministic E2E files verify the final candidate without influencing LLVM's hot and cold classification.
 
 Every root `tests/e2e/*.test.ts` file must be classified as training, verification-only, or intentionally excluded. The corpus loader fails on missing, duplicate, stale, or unclassified files, so a new E2E owner cannot silently bypass release qualification. New tests added to an already classified file inherit that file's classification.
 

--- a/scripts/pgso/corpus.json
+++ b/scripts/pgso/corpus.json
@@ -110,6 +110,7 @@
   ],
   "verification_scenarios": [
     {"name": "verify-auto-mode-reliability", "argv": ["bun", "test", "--max-concurrency", "1", "./auto-mode-reliability.test.ts"], "test_file": "auto-mode-reliability.test.ts"},
+    {"name": "verify-oauth-keychain-migration", "argv": ["bun", "test", "--max-concurrency", "1", "./oauth-keychain-migration.test.ts"], "test_file": "oauth-keychain-migration.test.ts", "allow_keychain": true},
     {"name": "verify-tui-auth-source-selection", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-auth-source-selection.test.ts"], "test_file": "tui-auth-source-selection.test.ts"},
     {"name": "verify-tui-composer-edit-contracts", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-composer-edit-contracts.test.ts"], "test_file": "tui-composer-edit-contracts.test.ts"},
     {"name": "verify-tui-cost", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-cost.test.ts"], "test_file": "tui-cost.test.ts"},

--- a/scripts/pgso/corpus.json
+++ b/scripts/pgso/corpus.json
@@ -74,6 +74,7 @@
       "argv": ["{binary}", "sessions", "--json"],
       "cwd": ".",
       "env_set": {"FX_SKIP_ONBOARDING": "1"},
+      "profile_runs": 100,
       "timeout_seconds": 60,
       "requires_tmux": false
     },

--- a/scripts/pgso/corpus.py
+++ b/scripts/pgso/corpus.py
@@ -26,6 +26,7 @@ REQUIRED_DIRECT_COMMANDS = (
     ("doctor", "--json"),
     ("sessions", "--json"),
 )
+MAX_PROFILE_RUNS = 100
 
 REQUIRED_EXCLUSIONS = (
     "notifications.test.ts",
@@ -56,6 +57,7 @@ class Scenario:
     requires_tmux: bool
     allow_keychain: bool
     test_file: str | None
+    profile_runs: int = 1
 
 
 @dataclasses.dataclass(frozen=True)
@@ -224,6 +226,16 @@ def _parse_scenario(
     allow_keychain = values.get("allow_keychain", False)
     if not isinstance(allow_keychain, bool):
         raise PgsoError(f"scenario {name} allow_keychain must be a boolean")
+    profile_runs = values.get("profile_runs", 1)
+    if (
+        isinstance(profile_runs, bool)
+        or not isinstance(profile_runs, int)
+        or not 1 <= profile_runs <= MAX_PROFILE_RUNS
+    ):
+        raise PgsoError(
+            f"scenario {name} profile_runs must be an integer from 1 to "
+            f"{MAX_PROFILE_RUNS}"
+        )
 
     test_file = values.get("test_file")
     if test_file is not None:
@@ -243,6 +255,16 @@ def _parse_scenario(
         expected_test = repo_root / "tests" / "e2e" / test_file
         if not expected_test.is_file():
             raise PgsoError(f"test file does not exist: {test_file}")
+    if profile_runs != 1 and (
+        argv[0] != "{binary}"
+        or test_file is not None
+        or requires_tmux
+        or allow_keychain
+    ):
+        raise PgsoError(
+            f"scenario {name} profile_runs is only supported for "
+            "noninteractive direct training commands without Keychain access"
+        )
 
     if "skip_reason" in defaults or "skip_reason" in scenario_raw:
         raise PgsoError(f"scenario {name} cannot be skipped")
@@ -257,6 +279,7 @@ def _parse_scenario(
         requires_tmux=requires_tmux,
         allow_keychain=allow_keychain,
         test_file=test_file,
+        profile_runs=profile_runs,
     )
 
 
@@ -527,6 +550,8 @@ def _execute_scenario(
     log_dir: pathlib.Path,
     environment: dict[str, str],
     command_runner: Callable[..., CommandResult],
+    run_index: int = 0,
+    run_count: int = 1,
 ) -> CommandResult:
     scenario_home = runtime_home / scenario.name
     _prepare_runtime_home(scenario_home, allow_keychain=scenario.allow_keychain)
@@ -543,12 +568,17 @@ def _execute_scenario(
 
     primary_error: BaseException | None = None
     try:
+        log_name = (
+            scenario.name
+            if run_count == 1
+            else f"{scenario.name}-run-{run_index + 1:03d}"
+        )
         return command_runner(
             _scenario_argv(scenario, canonical, bun),
             cwd=_resolve_cwd(corpus.repo_root, scenario.cwd),
             env=environment,
             timeout_s=scenario.timeout_seconds,
-            log_path=log_dir / f"{scenario.name}.json",
+            log_path=log_dir / f"{log_name}.json",
         )
     except BaseException as error:
         primary_error = error
@@ -574,25 +604,33 @@ def _run_scenarios(
     finish: Callable[[Scenario, CommandResult, object], int],
     failure_label: str,
     command_runner: Callable[..., CommandResult],
+    repeat_profile_runs: bool = False,
 ) -> CorpusResult:
     results: list[ScenarioResult] = []
     merged_raw_profiles = 0
     with _installed_training_binary(corpus, binary) as canonical:
         for scenario in scenarios:
             command_result: CommandResult | None = None
+            elapsed_seconds = 0.0
             try:
                 environment: dict[str, str] = {}
                 state = prepare(scenario, environment)
-                command_result = _execute_scenario(
-                    corpus,
-                    scenario,
-                    canonical,
-                    bun,
-                    runtime_home,
-                    log_dir,
-                    environment,
-                    command_runner,
-                )
+                run_count = scenario.profile_runs if repeat_profile_runs else 1
+                for run_index in range(run_count):
+                    command_result = _execute_scenario(
+                        corpus,
+                        scenario,
+                        canonical,
+                        bun,
+                        runtime_home,
+                        log_dir,
+                        environment,
+                        command_runner,
+                        run_index,
+                        run_count,
+                    )
+                    elapsed_seconds += command_result.elapsed_seconds
+                assert command_result is not None
                 raw_profiles = finish(scenario, command_result, state)
                 merged_raw_profiles += raw_profiles
             except Exception as error:
@@ -601,7 +639,7 @@ def _run_scenarios(
                         name=scenario.name,
                         status="failed",
                         elapsed_seconds=(
-                            0 if command_result is None else command_result.elapsed_seconds
+                            elapsed_seconds
                         ),
                         raw_profiles=0,
                         error=str(error),
@@ -617,7 +655,7 @@ def _run_scenarios(
                 ScenarioResult(
                     name=scenario.name,
                     status="passed",
-                    elapsed_seconds=command_result.elapsed_seconds,
+                    elapsed_seconds=elapsed_seconds,
                     raw_profiles=raw_profiles,
                 )
             )
@@ -681,6 +719,7 @@ def run_corpus(
         finish=finish,
         failure_label="training corpus",
         command_runner=command_runner,
+        repeat_profile_runs=True,
     )
 
 

--- a/scripts/pgso/tests/test_corpus.py
+++ b/scripts/pgso/tests/test_corpus.py
@@ -54,6 +54,7 @@ TRAINING_E2E_TESTS = (
 
 VERIFICATION_E2E_TESTS = (
     "auto-mode-reliability.test.ts",
+    "oauth-keychain-migration.test.ts",
     "tui-auth-source-selection.test.ts",
     "tui-composer-edit-contracts.test.ts",
     "tui-cost.test.ts",
@@ -341,12 +342,20 @@ class PgsoCorpusTests(unittest.TestCase):
             tuple(test_file for test_file, _ in corpus.intentional_exclusions),
         )
         self.assertEqual(36, len(corpus.scenarios))
-        self.assertEqual(52, len(corpus.candidate_scenarios))
+        self.assertEqual(53, len(corpus.candidate_scenarios))
         self.assertEqual(
             ("e2e-cli", "e2e-mcp-auth"),
             tuple(
                 scenario.name
                 for scenario in corpus.scenarios
+                if scenario.allow_keychain
+            ),
+        )
+        self.assertEqual(
+            ("verify-oauth-keychain-migration",),
+            tuple(
+                scenario.name
+                for scenario in corpus.verification_scenarios
                 if scenario.allow_keychain
             ),
         )

--- a/scripts/pgso/tests/test_corpus.py
+++ b/scripts/pgso/tests/test_corpus.py
@@ -276,6 +276,29 @@ class PgsoCorpusTests(unittest.TestCase):
                 with self.assertRaises(PgsoError):
                     load_corpus(self.write_manifest(payload), repo_root=self.root)
 
+    def test_load_rejects_invalid_profile_runs(self) -> None:
+        for value in (True, 0, 101, 1.5):
+            with self.subTest(value=value):
+                payload = self.manifest()
+                scenarios = payload["scenarios"]
+                assert isinstance(scenarios, list)
+                scenarios[-1]["profile_runs"] = value
+                with self.assertRaisesRegex(PgsoError, "profile_runs"):
+                    load_corpus(self.write_manifest(payload), repo_root=self.root)
+
+    def test_load_rejects_profile_runs_for_e2e_scenarios(self) -> None:
+        test_file = "profile-repeat.test.ts"
+        (self.root / "tests" / "e2e" / test_file).write_text("test")
+        payload = self.manifest()
+        scenarios = payload["scenarios"]
+        assert isinstance(scenarios, list)
+        scenario = self.e2e_scenario(test_file)
+        scenario["profile_runs"] = 2
+        scenarios.append(scenario)
+
+        with self.assertRaisesRegex(PgsoError, "profile_runs"):
+            load_corpus(self.write_manifest(payload), repo_root=self.root)
+
     def test_load_rejects_sound_and_nondeterministic_test_files(self) -> None:
         for test_file in (
             "notifications.test.ts",
@@ -343,6 +366,14 @@ class PgsoCorpusTests(unittest.TestCase):
         )
         self.assertEqual(36, len(corpus.scenarios))
         self.assertEqual(53, len(corpus.candidate_scenarios))
+        self.assertEqual(
+            100,
+            next(
+                scenario.profile_runs
+                for scenario in corpus.scenarios
+                if scenario.name == "direct-sessions"
+            ),
+        )
         self.assertEqual(
             ("e2e-cli", "e2e-mcp-auth"),
             tuple(
@@ -494,7 +525,7 @@ class PgsoCorpusTests(unittest.TestCase):
                 pattern = environment["LLVM_PROFILE_FILE"]
                 raw = pathlib.Path(
                     pattern.replace("%m", "module")
-                    .replace("%p", "123")
+                    .replace("%p", str(len(calls)))
                     .replace("%c", "")
                 )
                 raw.write_bytes(scenario_name.encode())
@@ -576,8 +607,62 @@ class PgsoCorpusTests(unittest.TestCase):
         patterns = [call["env"]["LLVM_PROFILE_FILE"] for call in calls]
         self.assertNotEqual(patterns[0], patterns[1])
         self.assertTrue(all("%m-%p-%c.profraw" in pattern for pattern in patterns))
-        self.assertEqual(("first-module-123-.profraw",), merges[0])
-        self.assertEqual(("second-module-123-.profraw",), merges[1])
+        self.assertEqual(("first-module-1-.profraw",), merges[0])
+        self.assertEqual(("second-module-2-.profraw",), merges[1])
+
+    def test_training_profile_runs_repeat_one_direct_scenario(self) -> None:
+        payload = self.manifest()
+        scenarios = payload["scenarios"]
+        assert isinstance(scenarios, list)
+        scenarios[-1]["profile_runs"] = 3
+        loaded = load_corpus(self.write_manifest(payload), repo_root=self.root)
+        corpus = self.make_corpus(loaded.scenarios[-1])
+
+        result, calls, merges, _, _ = self.run_fixture(corpus)
+
+        self.assertEqual(1, result.passed)
+        self.assertEqual(0.75, result.results[0].elapsed_seconds)
+        self.assertEqual(3, result.merged_raw_profiles)
+        self.assertEqual(3, len(calls))
+        self.assertEqual(
+            (
+                "direct-sessions-module-1-.profraw",
+                "direct-sessions-module-2-.profraw",
+                "direct-sessions-module-3-.profraw",
+            ),
+            merges[0],
+        )
+
+    def test_behavior_corpus_ignores_training_profile_runs(self) -> None:
+        payload = self.manifest()
+        scenarios = payload["scenarios"]
+        assert isinstance(scenarios, list)
+        scenarios[-1]["profile_runs"] = 3
+        loaded = load_corpus(self.write_manifest(payload), repo_root=self.root)
+        corpus = self.make_corpus(loaded.scenarios[-1])
+        binary = self.root / "candidate-fx"
+        binary.write_bytes(b"candidate")
+        calls: list[tuple[str, ...]] = []
+
+        def command_runner(argv, **kwargs):
+            calls.append(tuple(argv))
+            return CommandResult(
+                argv=tuple(argv),
+                returncode=0,
+                stdout="ok\n",
+                stderr="",
+                elapsed_seconds=0.2,
+            )
+
+        result = run_behavior_corpus(
+            corpus,
+            binary,
+            self.root / "behavior-output",
+            command_runner=command_runner,
+        )
+
+        self.assertEqual(1, result.passed)
+        self.assertEqual(1, len(calls))
 
     def test_run_cleans_the_isolated_tmux_server(self) -> None:
         marker = self.root / "tmux-cleaned"

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -1281,6 +1281,10 @@ fn requestAcpPermission(
     _: ?*const diff_mod.FileReview,
     _: ?[]const PermissionGrant,
 ) anyerror!permission_request.OwnedPermissionResponse {
+    var validated_arguments: std.Io.Writer.Allocating = .init(alloc);
+    defer validated_arguments.deinit();
+    try writeValidatedToolArguments(alloc, &validated_arguments.writer, call.arguments_json);
+
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     const request_id = server.beginPermissionRequest(ctx.state) orelse return error.PermissionRequestAlreadyPending;
     errdefer {
@@ -1303,7 +1307,7 @@ fn requestAcpPermission(
     try params.writer.writeAll(",\"kind\":");
     try jsonrpc.writeJsonStr(mapToolKind(call.name).jsonString(), &params.writer);
     try params.writer.writeAll(",\"status\":\"pending\",\"rawInput\":");
-    try params.writer.writeAll(call.arguments_json);
+    try params.writer.writeAll(validated_arguments.written());
     try params.writer.writeAll("},\"options\":[");
     try writePermissionOption(&params.writer, "allow_once", "Allow once", "allow_once");
     try params.writer.writeByte(',');
@@ -1320,6 +1324,13 @@ fn requestAcpPermission(
     );
     const decision = server.awaitPermissionDecision(ctx.state, request_id);
     return permission_request.OwnedPermissionResponse.init(alloc, decision, null);
+}
+
+fn writeValidatedToolArguments(alloc: Allocator, writer: *std.Io.Writer, arguments_json: []const u8) !void {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch
+        return error.InvalidToolArgumentsJson;
+    defer parsed.deinit();
+    try std.json.Stringify.value(parsed.value, .{}, writer);
 }
 
 fn writePermissionOption(
@@ -2916,6 +2927,23 @@ test "mapToolKind maps all file tools" {
     try std.testing.expectEqual(acp_types.ToolCallKind.other, mapToolKind("memory"));
     try std.testing.expectEqual(acp_types.ToolCallKind.other, mapToolKind("skill"));
     try std.testing.expectEqual(acp_types.ToolCallKind.other, mapToolKind("install_skill"));
+}
+
+test "ACP permission arguments are validated and reserialized before emission" {
+    const alloc = std.testing.allocator;
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+
+    try writeValidatedToolArguments(alloc, &out.writer, " { \"path\" : \"README.md\" } ");
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", out.written());
+
+    var malformed: std.Io.Writer.Allocating = .init(alloc);
+    defer malformed.deinit();
+    try std.testing.expectError(
+        error.InvalidToolArgumentsJson,
+        writeValidatedToolArguments(alloc, &malformed.writer, "{\"path\":}"),
+    );
+    try std.testing.expectEqual(@as(usize, 0), malformed.written().len);
 }
 
 test "acp exposes web_search progress updates" {

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -1979,7 +1979,7 @@ test "loadStartupState applies core env overrides" {
     try std.testing.expectEqual(credentials.Source.ai_gateway_api_key, state.credential.?.source);
     try std.testing.expectEqual(PermissionMode.auto, state.permission_mode);
     try std.testing.expectEqual(@as(usize, 37), state.agent_step_limit);
-    try std.testing.expectEqual(sandbox.BackendKind.none, state.sandbox_backend);
+    try std.testing.expectEqual(sandbox.BackendKind.auto, state.sandbox_backend);
 }
 
 test "loadStartupState defaults fast mode off and preserves explicit preferences" {

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -656,7 +656,7 @@ pub fn logout(
     var session: ?oauth_session.Session = null;
     var session_load_failed = false;
     defer if (session) |*loaded| loaded.deinit(alloc);
-    const delete_outcome = blk: {
+    const delete_result = blk: {
         var mutation = (oauth_session.beginExistingMutation() catch {
             return LogoutError.SessionDeleteFailed;
         }) orelse return .{};
@@ -665,12 +665,11 @@ pub fn logout(
             session_load_failed = true;
             break :load null;
         };
-        break :blk mutation.delete() catch return LogoutError.SessionDeleteFailed;
+        break :blk mutation.delete(alloc) catch .{ .local_cleanup_failed = true };
     };
 
-    const local_durability_failed = delete_outcome == .deleted_not_durable;
-    var remote_revocation_failed = session_load_failed or local_durability_failed;
-    if (!local_durability_failed and session != null) {
+    var remote_revocation_failed = session_load_failed;
+    if (session != null) {
         const loaded = session.?;
         revokeLogoutSession(alloc, transport, loaded) catch {
             remote_revocation_failed = true;
@@ -678,8 +677,8 @@ pub fn logout(
     }
 
     return .{
-        .session_deleted = delete_outcome != .missing,
-        .local_durability_failed = local_durability_failed,
+        .session_deleted = delete_result.session_deleted,
+        .local_durability_failed = delete_result.local_cleanup_failed,
         .remote_revocation_failed = remote_revocation_failed,
     };
 }

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -665,7 +665,9 @@ pub fn logout(
             session_load_failed = true;
             break :load null;
         };
-        break :blk mutation.delete(alloc) catch .{ .local_cleanup_failed = true };
+        break :blk mutation.delete(alloc) catch oauth_session.DeleteResult{
+            .local_cleanup_failed = true,
+        };
     };
 
     var remote_revocation_failed = session_load_failed;

--- a/src/core/auth/oauth_session.zig
+++ b/src/core/auth/oauth_session.zig
@@ -135,7 +135,7 @@ const DeleteOutcome = enum {
     deleted_not_durable,
 };
 
-const DeleteResult = struct {
+pub const DeleteResult = struct {
     session_deleted: bool = false,
     local_cleanup_failed: bool = false,
 };

--- a/src/core/auth/oauth_session.zig
+++ b/src/core/auth/oauth_session.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host_target = @import("../hosts/target.zig");
+const native_keychain = @import("../hosts/native_keychain.zig");
 const io_mod = @import("../shared/io.zig");
 const profile_paths = @import("../shared/profile_paths.zig");
 const js_host_auth = @import("js_host_auth.zig");
@@ -20,6 +22,82 @@ const mutation_lock_file_name = "auth.lock";
 const mutation_lock_deadline_ms: u64 = 2000;
 const e2e_lock_contention_file_name = "auth-lock-contention";
 const LoadMode = enum { tolerate_open_failure, report_open_failure };
+
+const StorageBackend = enum {
+    profile_file,
+    macos_keychain,
+};
+
+const FileState = enum { absent, valid, unusable };
+const KeychainState = enum { absent, valid, invalid, unavailable };
+const Resolution = enum {
+    missing,
+    file_migrate,
+    file_defer_migration,
+    keychain,
+    storage_error,
+};
+
+const Authority = enum { unresolved, missing, profile_file, keychain };
+
+const KeychainError = Allocator.Error || native_keychain.Error;
+
+const KeychainBackend = struct {
+    context: ?*anyopaque = null,
+    load_fn: *const fn (?*anyopaque, Allocator) KeychainError!?[]u8,
+    store_fn: *const fn (?*anyopaque, []const u8) KeychainError!void,
+    delete_fn: *const fn (?*anyopaque, Allocator) KeychainError!bool,
+
+    fn load(self: KeychainBackend, alloc: Allocator) KeychainError!?[]u8 {
+        return self.load_fn(self.context, alloc);
+    }
+
+    fn store(self: KeychainBackend, value: []const u8) KeychainError!void {
+        return self.store_fn(self.context, value);
+    }
+
+    fn delete(self: KeychainBackend, alloc: Allocator) KeychainError!bool {
+        return self.delete_fn(self.context, alloc);
+    }
+};
+
+const native_keychain_backend: KeychainBackend = .{
+    .load_fn = nativeKeychainLoad,
+    .store_fn = nativeKeychainStore,
+    .delete_fn = nativeKeychainDelete,
+};
+
+fn nativeKeychainLoad(_: ?*anyopaque, alloc: Allocator) KeychainError!?[]u8 {
+    return native_keychain.loadOAuthSession(alloc);
+}
+
+fn nativeKeychainStore(_: ?*anyopaque, value: []const u8) KeychainError!void {
+    return native_keychain.storeOAuthSession(value);
+}
+
+fn nativeKeychainDelete(_: ?*anyopaque, alloc: Allocator) KeychainError!bool {
+    return native_keychain.deleteOAuthSession(alloc);
+}
+
+fn selectStorageBackend(os_tag: std.Target.Os.Tag, keychain_disabled: bool) StorageBackend {
+    if (os_tag == .macos and !keychain_disabled) return .macos_keychain;
+    return .profile_file;
+}
+
+fn storageBackend() StorageBackend {
+    return selectStorageBackend(builtin.os.tag, native_keychain.isDisabled());
+}
+
+fn selectResolution(file: FileState, keychain: KeychainState) Resolution {
+    return switch (file) {
+        .valid => if (keychain == .unavailable) .file_defer_migration else .file_migrate,
+        .absent, .unusable => switch (keychain) {
+            .absent => .missing,
+            .valid => .keychain,
+            .invalid, .unavailable => .storage_error,
+        },
+    };
+}
 
 pub fn refresh_deadline_ms(expires_at_ms: i64) i64 {
     return expires_at_ms -| expiry_skew_ms;
@@ -51,10 +129,15 @@ fn signalE2ELockContention(fx_dir: std.Io.Dir) void {
     file.writeStreamingAll(io_mod.getIo(), "contended\n") catch {};
 }
 
-pub const DeleteOutcome = enum {
+const DeleteOutcome = enum {
     deleted,
     missing,
     deleted_not_durable,
+};
+
+const DeleteResult = struct {
+    session_deleted: bool = false,
+    local_cleanup_failed: bool = false,
 };
 
 pub const Session = struct {
@@ -85,11 +168,169 @@ pub const Session = struct {
     }
 };
 
+const FileObservation = union(enum) {
+    absent,
+    valid: Session,
+    unusable,
+
+    fn state(self: FileObservation) FileState {
+        return switch (self) {
+            .absent => .absent,
+            .valid => .valid,
+            .unusable => .unusable,
+        };
+    }
+
+    fn takeSession(self: *FileObservation) ?Session {
+        return switch (self.*) {
+            .valid => |session| blk: {
+                self.* = .absent;
+                break :blk session;
+            },
+            else => null,
+        };
+    }
+
+    fn deinit(self: *FileObservation, alloc: Allocator) void {
+        switch (self.*) {
+            .valid => |*session| session.deinit(alloc),
+            else => {},
+        }
+        self.* = .absent;
+    }
+};
+
+const KeychainObservation = union(enum) {
+    absent,
+    valid: Session,
+    invalid,
+    unavailable: KeychainError,
+
+    fn state(self: KeychainObservation) KeychainState {
+        return switch (self) {
+            .absent => .absent,
+            .valid => .valid,
+            .invalid => .invalid,
+            .unavailable => .unavailable,
+        };
+    }
+
+    fn takeSession(self: *KeychainObservation) ?Session {
+        return switch (self.*) {
+            .valid => |session| blk: {
+                self.* = .absent;
+                break :blk session;
+            },
+            else => null,
+        };
+    }
+
+    fn storageError(self: KeychainObservation) (KeychainError || error{
+        InvalidOAuthKeychainSession,
+        InvalidOAuthStorageState,
+    }) {
+        return switch (self) {
+            .invalid => error.InvalidOAuthKeychainSession,
+            .unavailable => |err| err,
+            else => error.InvalidOAuthStorageState,
+        };
+    }
+
+    fn deinit(self: *KeychainObservation, alloc: Allocator) void {
+        switch (self.*) {
+            .valid => |*session| session.deinit(alloc),
+            else => {},
+        }
+        self.* = .absent;
+    }
+};
+
+fn observeAuthFile(alloc: Allocator, fx_dir: *std.Io.Dir) !FileObservation {
+    var file = fx_dir.openFile(io_mod.getIo(), auth_file_name, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return .absent,
+        else => {
+            debug_trace.logf("auth", "session load failed source=file step=open err={s}", .{@errorName(err)});
+            return .unusable;
+        },
+    };
+    defer file.close(io_mod.getIo());
+
+    const stat = file.stat(io_mod.getIo()) catch |err| {
+        debug_trace.logf("auth", "session load failed source=file step=stat err={s}", .{@errorName(err)});
+        return .unusable;
+    };
+    if (stat.kind != .file or stat.nlink != 1 or stat.permissions.toMode() & 0o077 != 0) {
+        debug_trace.logf("auth", "session load failed source=file step=permissions err=InsecureAuthFile", .{});
+        return .unusable;
+    }
+
+    const bytes = io_mod.readFileToEnd(alloc, &file, max_auth_file_bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "session load failed source=file step=read err={s}", .{@errorName(err)});
+            return .unusable;
+        },
+    };
+    defer secret.zeroAndFree(alloc, bytes);
+    const session = parse(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "session load failed source=file step=parse err={s}", .{@errorName(err)});
+            return .unusable;
+        },
+    };
+    return .{ .valid = session };
+}
+
+fn observeKeychain(alloc: Allocator, keychain: KeychainBackend) !KeychainObservation {
+    const maybe_bytes = keychain.load(alloc) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        error.KeychainItemNotFound => return .absent,
+        else => return .{ .unavailable = err },
+    };
+    const bytes = maybe_bytes orelse return .absent;
+    defer secret.zeroAndFree(alloc, bytes);
+    if (bytes.len > max_auth_file_bytes) return .invalid;
+    const session = parse(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return .invalid,
+    };
+    return .{ .valid = session };
+}
+
+fn publishAndVerifyKeychain(alloc: Allocator, keychain: KeychainBackend, session: Session) !void {
+    const bytes = try stringify(alloc, session);
+    defer secret.zeroAndFree(alloc, bytes);
+    try keychain.store(bytes);
+    const persisted = keychain.load(alloc) catch |err| switch (err) {
+        error.KeychainItemNotFound => return error.OAuthSessionKeychainWriteMismatch,
+        else => return err,
+    } orelse return error.OAuthSessionKeychainWriteMismatch;
+    defer secret.zeroAndFree(alloc, persisted);
+    if (!std.mem.eql(u8, bytes, persisted)) return error.OAuthSessionKeychainWriteMismatch;
+}
+
+fn authFileExists(fx_dir: *std.Io.Dir) !bool {
+    _ = fx_dir.statFile(io_mod.getIo(), auth_file_name, .{}) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    return true;
+}
+
 pub const Mutation = if (host_target.is_wasm) HostMutation else NativeMutation;
 
 const NativeMutation = struct {
     fx_dir: io_mod.VerifiedDir,
     lock: io_mod.TimedAdvisoryLock,
+    backend: StorageBackend,
+    keychain: KeychainBackend,
+    authority: Authority = .unresolved,
 
     pub fn deinit(self: *Mutation) void {
         self.lock.release();
@@ -98,17 +339,125 @@ const NativeMutation = struct {
     }
 
     pub fn load(self: *Mutation, alloc: Allocator) !?Session {
-        return loadFromDir(alloc, &self.fx_dir.dir, .report_open_failure);
+        if (self.backend == .profile_file) {
+            self.authority = .profile_file;
+            return loadFromDir(alloc, &self.fx_dir.dir, .report_open_failure);
+        }
+        return self.loadKeychainResolved(alloc);
     }
 
     pub fn save(self: *Mutation, alloc: Allocator, session: Session) !void {
+        if (self.backend == .macos_keychain) {
+            return self.saveKeychainResolved(alloc, session);
+        }
+        self.authority = .profile_file;
+        return self.saveFile(alloc, session);
+    }
+
+    fn saveFile(self: *Mutation, alloc: Allocator, session: Session) !void {
         const text = try stringify(alloc, session);
         defer secret.zeroAndFree(alloc, text);
         try io_mod.durableReplaceVerified(alloc, &self.fx_dir, auth_file_name, text);
     }
 
-    pub fn delete(self: *Mutation) !DeleteOutcome {
-        return deleteAuthFile(&self.fx_dir.dir, .{});
+    pub fn delete(self: *Mutation, alloc: Allocator) !DeleteResult {
+        var result: DeleteResult = .{};
+        if (self.backend == .macos_keychain) {
+            const deleted = self.keychain.delete(alloc) catch blk: {
+                result.local_cleanup_failed = true;
+                break :blk false;
+            };
+            result.session_deleted = result.session_deleted or deleted;
+        }
+
+        const file_outcome = deleteAuthFile(&self.fx_dir.dir, .{}) catch {
+            result.local_cleanup_failed = true;
+            return result;
+        };
+        switch (file_outcome) {
+            .missing => {},
+            .deleted => result.session_deleted = true,
+            .deleted_not_durable => {
+                result.session_deleted = true;
+                result.local_cleanup_failed = true;
+            },
+        }
+        self.authority = .missing;
+        return result;
+    }
+
+    fn loadKeychainResolved(self: *Mutation, alloc: Allocator) !?Session {
+        var file = try observeAuthFile(alloc, &self.fx_dir.dir);
+        defer file.deinit(alloc);
+        var keychain = try observeKeychain(alloc, self.keychain);
+        defer keychain.deinit(alloc);
+
+        switch (selectResolution(file.state(), keychain.state())) {
+            .missing => {
+                self.authority = .missing;
+                return null;
+            },
+            .keychain => {
+                self.authority = .keychain;
+                return keychain.takeSession().?;
+            },
+            .file_defer_migration => {
+                self.authority = .profile_file;
+                return file.takeSession().?;
+            },
+            .file_migrate => {
+                var session = file.takeSession().?;
+                errdefer session.deinit(alloc);
+                const migrated = try self.publishAndCleanup(alloc, session);
+                self.authority = if (migrated) .keychain else .profile_file;
+                return session;
+            },
+            .storage_error => return keychain.storageError(),
+        }
+    }
+
+    fn saveKeychainResolved(self: *Mutation, alloc: Allocator, session: Session) !void {
+        if (self.authority == .unresolved) {
+            self.authority = if (try authFileExists(&self.fx_dir.dir)) .profile_file else .keychain;
+        }
+
+        switch (self.authority) {
+            .profile_file => {
+                try self.saveFile(alloc, session);
+                const migrated = try self.publishAndCleanup(alloc, session);
+                if (migrated) self.authority = .keychain;
+            },
+            .keychain, .missing => {
+                try publishAndVerifyKeychain(alloc, self.keychain, session);
+                self.authority = .keychain;
+            },
+            .unresolved => unreachable,
+        }
+    }
+
+    fn publishAndCleanup(self: *Mutation, alloc: Allocator, session: Session) !bool {
+        publishAndVerifyKeychain(alloc, self.keychain, session) catch |err| {
+            debug_trace.logf("auth", "session migration deferred step=publish err={s}", .{@errorName(err)});
+            return false;
+        };
+
+        const outcome = deleteAuthFile(&self.fx_dir.dir, .{}) catch |err| {
+            const stat = self.fx_dir.dir.statFile(io_mod.getIo(), auth_file_name, .{}) catch |stat_err| switch (stat_err) {
+                error.FileNotFound => return error.OAuthSessionCleanupUncertain,
+                else => return stat_err,
+            };
+            if (stat.kind != .file) return error.OAuthSessionCleanupUncertain;
+            debug_trace.logf("auth", "session migration deferred step=delete err={s}", .{@errorName(err)});
+            return false;
+        };
+        return switch (outcome) {
+            .deleted => true,
+            .missing => blk: {
+                try io_mod.syncVerifiedDir(self.fx_dir.dir);
+                break :blk true;
+            },
+            .deleted_not_durable => error.OAuthSessionCleanupUncertain,
+        };
     }
 };
 
@@ -147,11 +496,11 @@ const HostMutation = struct {
         try self.captureStoredRevision(revision);
     }
 
-    pub fn delete(self: *HostMutation) !DeleteOutcome {
+    pub fn delete(self: *HostMutation, _: Allocator) !DeleteResult {
         const expected = if (self.exists) self.revision[0..self.revision_len] else null;
         return switch (try self.store.remove(expected)) {
-            .deleted => .deleted,
-            .missing => .missing,
+            .deleted => .{ .session_deleted = true },
+            .missing => .{},
         };
     }
 
@@ -226,6 +575,14 @@ pub fn load(alloc: Allocator) !?Session {
         debug_trace.logf("auth", "session load skipped step=home err=HomeNotSet", .{});
         return null;
     };
+    if (storageBackend() == .macos_keychain) {
+        if (try beginExistingNativeMutation()) |existing| {
+            var mutation = existing;
+            defer mutation.deinit();
+            return mutation.load(alloc);
+        }
+        return loadKeychainWithoutProfile(alloc);
+    }
     var home_dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch |err| {
         debug_trace.logf("auth", "session load failed step=open_home err={s}", .{@errorName(err)});
         return null;
@@ -304,6 +661,13 @@ pub fn beginExistingMutation() !?Mutation {
     if (comptime host_target.is_wasm) {
         return @as(?Mutation, HostMutation.init(js_host_auth.oauth_session_store));
     }
+    if (storageBackend() == .macos_keychain) {
+        return @as(?Mutation, try beginMutation());
+    }
+    return beginExistingNativeMutation();
+}
+
+fn beginExistingNativeMutation() !?Mutation {
     const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
@@ -315,6 +679,24 @@ pub fn beginExistingMutation() !?Mutation {
         else => return err,
     };
     return @as(?Mutation, try lockMutation(fx_dir));
+}
+
+fn loadKeychainWithoutProfile(alloc: Allocator) !?Session {
+    var keychain = try observeKeychain(alloc, native_keychain_backend);
+    defer keychain.deinit(alloc);
+
+    if (try beginExistingNativeMutation()) |existing| {
+        var mutation = existing;
+        defer mutation.deinit();
+        return mutation.load(alloc);
+    }
+
+    return switch (selectResolution(.absent, keychain.state())) {
+        .missing => null,
+        .keychain => keychain.takeSession().?,
+        .storage_error => keychain.storageError(),
+        .file_migrate, .file_defer_migration => unreachable,
+    };
 }
 
 fn beginMutation() !Mutation {
@@ -341,6 +723,22 @@ fn lockMutationWithOps(
     deadline_ms: u64,
     ops: io_mod.LockOps,
 ) !Mutation {
+    return lockMutationWithBackend(
+        open_fx_dir,
+        deadline_ms,
+        ops,
+        storageBackend(),
+        native_keychain_backend,
+    );
+}
+
+fn lockMutationWithBackend(
+    open_fx_dir: io_mod.VerifiedDir,
+    deadline_ms: u64,
+    ops: io_mod.LockOps,
+    backend: StorageBackend,
+    keychain: KeychainBackend,
+) !Mutation {
     var fx_dir = open_fx_dir;
     errdefer fx_dir.close();
 
@@ -355,6 +753,8 @@ fn lockMutationWithOps(
     return .{
         .fx_dir = fx_dir,
         .lock = lock,
+        .backend = backend,
+        .keychain = keychain,
     };
 }
 
@@ -580,6 +980,250 @@ test "oauth session stringifies and parses" {
     try std.testing.expectEqualStrings("team_123", parsed.team_id.?);
 }
 
+test "OAuth storage backend selection is platform scoped and explicitly disableable" {
+    try std.testing.expectEqual(StorageBackend.macos_keychain, selectStorageBackend(.macos, false));
+    try std.testing.expectEqual(StorageBackend.profile_file, selectStorageBackend(.macos, true));
+    try std.testing.expectEqual(StorageBackend.profile_file, selectStorageBackend(.linux, false));
+    try std.testing.expectEqual(StorageBackend.profile_file, selectStorageBackend(.windows, false));
+}
+
+test "OAuth source resolution covers every file and Keychain state" {
+    const cases = [_]struct {
+        file: FileState,
+        keychain: KeychainState,
+        expected: Resolution,
+    }{
+        .{ .file = .absent, .keychain = .absent, .expected = .missing },
+        .{ .file = .absent, .keychain = .valid, .expected = .keychain },
+        .{ .file = .absent, .keychain = .invalid, .expected = .storage_error },
+        .{ .file = .absent, .keychain = .unavailable, .expected = .storage_error },
+        .{ .file = .valid, .keychain = .absent, .expected = .file_migrate },
+        .{ .file = .valid, .keychain = .valid, .expected = .file_migrate },
+        .{ .file = .valid, .keychain = .invalid, .expected = .file_migrate },
+        .{ .file = .valid, .keychain = .unavailable, .expected = .file_defer_migration },
+        .{ .file = .unusable, .keychain = .valid, .expected = .keychain },
+        .{ .file = .unusable, .keychain = .absent, .expected = .missing },
+        .{ .file = .unusable, .keychain = .invalid, .expected = .storage_error },
+        .{ .file = .unusable, .keychain = .unavailable, .expected = .storage_error },
+    };
+
+    for (cases) |case| {
+        try std.testing.expectEqual(case.expected, selectResolution(case.file, case.keychain));
+    }
+}
+
+const alternate_test_session_json = "{\"version\":1,\"issuer\":\"https://vercel.com\",\"client_id\":\"client\",\"access_token\":\"keychain-access\",\"refresh_token\":\"keychain-refresh\",\"expires_at_ms\":2,\"scope\":\"openid offline_access\",\"token_type\":\"Bearer\"}";
+
+const FakeOAuthKeychain = struct {
+    alloc: Allocator,
+    value: ?[]u8 = null,
+    store_calls: usize = 0,
+    delete_calls: usize = 0,
+    fail_store: bool = false,
+    fail_delete: bool = false,
+
+    fn deinit(self: *FakeOAuthKeychain) void {
+        if (self.value) |value| secret.zeroAndFree(self.alloc, value);
+        self.* = undefined;
+    }
+
+    fn backend(self: *FakeOAuthKeychain) KeychainBackend {
+        return .{
+            .context = self,
+            .load_fn = loadCallback,
+            .store_fn = storeCallback,
+            .delete_fn = deleteCallback,
+        };
+    }
+
+    fn loadCallback(raw: ?*anyopaque, alloc: Allocator) KeychainError!?[]u8 {
+        const self: *FakeOAuthKeychain = @ptrCast(@alignCast(raw.?));
+        const value = self.value orelse return null;
+        return try alloc.dupe(u8, value);
+    }
+
+    fn storeCallback(raw: ?*anyopaque, value: []const u8) KeychainError!void {
+        const self: *FakeOAuthKeychain = @ptrCast(@alignCast(raw.?));
+        self.store_calls += 1;
+        if (self.fail_store) return error.KeychainWriteFailed;
+        const replacement = try self.alloc.dupe(u8, value);
+        if (self.value) |previous| secret.zeroAndFree(self.alloc, previous);
+        self.value = replacement;
+    }
+
+    fn deleteCallback(raw: ?*anyopaque, _: Allocator) KeychainError!bool {
+        const self: *FakeOAuthKeychain = @ptrCast(@alignCast(raw.?));
+        self.delete_calls += 1;
+        if (self.fail_delete) return error.KeychainDeleteFailed;
+        const previous = self.value orelse return false;
+        secret.zeroAndFree(self.alloc, previous);
+        self.value = null;
+        return true;
+    }
+};
+
+fn writeTestAuthFile(dir: std.Io.Dir, contents: []const u8) !void {
+    var file = try dir.createFile(std.testing.io, auth_file_name, .{
+        .truncate = true,
+        .permissions = std.Io.File.Permissions.fromMode(0o600),
+    });
+    defer file.close(std.testing.io);
+    try file.writeStreamingAll(std.testing.io, contents);
+}
+
+fn testKeychainMutation(dir: std.Io.Dir, keychain: KeychainBackend) !Mutation {
+    return lockMutationWithBackend(
+        .{ .dir = try dir.openDir(std.testing.io, ".", .{ .iterate = true }) },
+        0,
+        .{},
+        .macos_keychain,
+        keychain,
+    );
+}
+
+test "OAuth migration keeps a valid file authoritative until verified cleanup" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestAuthFile(tmp.dir, test_session_json);
+
+    var fake = FakeOAuthKeychain{
+        .alloc = alloc,
+        .value = try alloc.dupe(u8, alternate_test_session_json),
+    };
+    defer fake.deinit();
+    var mutation = try testKeychainMutation(tmp.dir, fake.backend());
+    defer mutation.deinit();
+
+    var loaded = (try mutation.load(alloc)).?;
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqualStrings("access", loaded.access_token);
+    try std.testing.expectEqual(@as(usize, 1), fake.store_calls);
+    try std.testing.expectEqual(Authority.keychain, mutation.authority);
+    try std.testing.expectError(
+        error.FileNotFound,
+        tmp.dir.statFile(std.testing.io, auth_file_name, .{}),
+    );
+
+    var persisted = try parse(alloc, fake.value.?);
+    defer persisted.deinit(alloc);
+    try std.testing.expectEqualStrings("access", persisted.access_token);
+
+    secret.zeroAndFree(alloc, loaded.access_token);
+    loaded.access_token = try alloc.dupe(u8, "keychain-only-update");
+    try mutation.save(alloc, loaded);
+    try std.testing.expectError(
+        error.FileNotFound,
+        tmp.dir.statFile(std.testing.io, auth_file_name, .{}),
+    );
+    var updated = try parse(alloc, fake.value.?);
+    defer updated.deinit(alloc);
+    try std.testing.expectEqualStrings("keychain-only-update", updated.access_token);
+}
+
+test "new OAuth login replaces an existing file before deferred migration" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestAuthFile(tmp.dir, test_session_json);
+
+    var fake = FakeOAuthKeychain{ .alloc = alloc, .fail_store = true };
+    defer fake.deinit();
+    var mutation = try testKeychainMutation(tmp.dir, fake.backend());
+    defer mutation.deinit();
+    var replacement = try parse(alloc, alternate_test_session_json);
+    defer replacement.deinit(alloc);
+
+    try mutation.save(alloc, replacement);
+    var persisted = (try loadFromDir(alloc, &tmp.dir, .report_open_failure)).?;
+    defer persisted.deinit(alloc);
+    try std.testing.expectEqualStrings("keychain-access", persisted.access_token);
+    try std.testing.expectEqual(Authority.profile_file, mutation.authority);
+}
+
+test "OAuth migration preserves and updates the file when Keychain publication fails" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestAuthFile(tmp.dir, test_session_json);
+
+    var fake = FakeOAuthKeychain{ .alloc = alloc, .fail_store = true };
+    defer fake.deinit();
+    var mutation = try testKeychainMutation(tmp.dir, fake.backend());
+    defer mutation.deinit();
+
+    var loaded = (try mutation.load(alloc)).?;
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqual(Authority.profile_file, mutation.authority);
+    secret.zeroAndFree(alloc, loaded.access_token);
+    loaded.access_token = try alloc.dupe(u8, "updated-access");
+    try mutation.save(alloc, loaded);
+
+    var persisted = (try loadFromDir(alloc, &tmp.dir, .report_open_failure)).?;
+    defer persisted.deinit(alloc);
+    try std.testing.expectEqualStrings("updated-access", persisted.access_token);
+    try std.testing.expectEqual(@as(usize, 2), fake.store_calls);
+}
+
+test "OAuth resolver uses valid Keychain state without deleting an unusable file" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestAuthFile(tmp.dir, "not-json");
+
+    var fake = FakeOAuthKeychain{
+        .alloc = alloc,
+        .value = try alloc.dupe(u8, alternate_test_session_json),
+    };
+    defer fake.deinit();
+    var mutation = try testKeychainMutation(tmp.dir, fake.backend());
+    defer mutation.deinit();
+
+    var loaded = (try mutation.load(alloc)).?;
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqualStrings("keychain-access", loaded.access_token);
+    _ = try tmp.dir.statFile(std.testing.io, auth_file_name, .{});
+}
+
+test "OAuth resolver reports invalid Keychain state when no valid file exists" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var fake = FakeOAuthKeychain{
+        .alloc = alloc,
+        .value = try alloc.dupe(u8, "not-json"),
+    };
+    defer fake.deinit();
+    var mutation = try testKeychainMutation(tmp.dir, fake.backend());
+    defer mutation.deinit();
+
+    try std.testing.expectError(error.InvalidOAuthKeychainSession, mutation.load(alloc));
+}
+
+test "OAuth logout deletion attempts Keychain and file cleanup independently" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestAuthFile(tmp.dir, test_session_json);
+    var fake = FakeOAuthKeychain{
+        .alloc = alloc,
+        .value = try alloc.dupe(u8, alternate_test_session_json),
+        .fail_delete = true,
+    };
+    defer fake.deinit();
+    var mutation = try testKeychainMutation(tmp.dir, fake.backend());
+    defer mutation.deinit();
+
+    const result = try mutation.delete(alloc);
+    try std.testing.expect(result.session_deleted);
+    try std.testing.expect(result.local_cleanup_failed);
+    try std.testing.expectEqual(@as(usize, 1), fake.delete_calls);
+    try std.testing.expectError(
+        error.FileNotFound,
+        tmp.dir.statFile(std.testing.io, auth_file_name, .{}),
+    );
+}
+
 test "JS host OAuth session load commit and remove preserve the native format and revision" {
     var state: HostStoreTestState = .{};
     var loaded = (try loadFromHost(std.testing.allocator, state.provider())).?;
@@ -595,7 +1239,9 @@ test "JS host OAuth session load commit and remove preserve the native format an
     try std.testing.expect(state.expected_revision_matched);
     try std.testing.expect(state.committed_format_matched);
 
-    try std.testing.expectEqual(DeleteOutcome.deleted, try mutation.delete());
+    const deleted = try mutation.delete(std.testing.allocator);
+    try std.testing.expect(deleted.session_deleted);
+    try std.testing.expect(!deleted.local_cleanup_failed);
     try std.testing.expectEqual(@as(usize, 1), state.remove_count);
     try std.testing.expect(state.expected_revision_matched);
 }

--- a/src/core/hosts/native_keychain.zig
+++ b/src/core/hosts/native_keychain.zig
@@ -6,12 +6,14 @@ const secret = @import("../auth/secret.zig");
 
 pub const service_name = "FX_AI_GATEWAY_API_KEY";
 const mcp_credentials_service_name = "FX_MCP_OAUTH_CREDENTIALS_V1";
+pub const oauth_session_service_name = "FX_OAUTH_SESSION_V1";
 
 /// Backing store for a resolved account name. Must outlive any argv built from it.
 pub const AccountBuffer = [256]u8;
 
 const passwd_scratch_bytes = 2048;
 const max_mcp_credentials_bytes: usize = 1024 * 1024;
+const max_oauth_session_bytes: usize = 64 * 1024;
 const keychain_process_timeout: std.Io.Timeout = .{
     .duration = .{
         .raw = .{ .nanoseconds = 10 * std.time.ns_per_s },
@@ -82,6 +84,10 @@ pub fn load(alloc: std.mem.Allocator) !?[]u8 {
 
 pub fn loadMcpCredentials(alloc: std.mem.Allocator) !?[]u8 {
     return loadMcpValueMacControlled(alloc, mcp_credentials_service_name, null);
+}
+
+pub fn loadOAuthSession(alloc: std.mem.Allocator) !?[]u8 {
+    return loadMcpValueMacControlled(alloc, oauth_session_service_name, null);
 }
 
 pub fn loadMcpCredentialsCancellable(
@@ -259,6 +265,14 @@ pub fn storeMcpCredentials(value: []const u8) Error!void {
     return storeMcpCredentialsControlled(value, null);
 }
 
+pub fn storeOAuthSession(value: []const u8) Error!void {
+    if (!isAvailable()) return error.UnsupportedPlatform;
+    if (value.len == 0 or value.len > max_oauth_session_bytes) {
+        return error.KeychainWriteFailed;
+    }
+    return storeMcpValueMac(oauth_session_service_name, value);
+}
+
 pub fn storeMcpCredentialsCancellable(
     value: []const u8,
     cancel_flag: *const std.atomic.Value(bool),
@@ -287,6 +301,10 @@ fn storeMcpCredentialsControlled(
 
 pub fn deleteMcpCredentials(alloc: std.mem.Allocator) Error!bool {
     return deleteMcpValueMac(alloc, mcp_credentials_service_name);
+}
+
+pub fn deleteOAuthSession(alloc: std.mem.Allocator) Error!bool {
+    return deleteMcpValueMac(alloc, oauth_session_service_name);
 }
 
 fn writeFailed(step: []const u8, err: anyerror) Error {

--- a/src/core/permissions/permissions.zig
+++ b/src/core/permissions/permissions.zig
@@ -1622,12 +1622,13 @@ fn evaluateRulesetForTool(rules: []const types.PermissionRule, permission: []con
     var matched: ?RuleDecision = null;
     for (rules) |rule| {
         if (!ruleMatchesPermission(rule.permission, permission, tool_name)) continue;
-        if (!permissionPatternMatchesTarget(rule.pattern, pattern)) continue;
-        matched = switch (rule.action) {
+        const action: RuleDecision = switch (rule.action) {
             .allow => .allow,
             .ask => .ask,
             .deny => .deny,
         };
+        if (!ruleTargetMatches(permission, action, rule.pattern, pattern)) continue;
+        matched = action;
     }
     return matched;
 }
@@ -1675,6 +1676,116 @@ fn permissionPatternMatchesTarget(pattern: []const u8, candidate: []const u8) bo
     return wildcardMatch(pattern, candidate);
 }
 
+fn ruleTargetMatches(permission: []const u8, action: RuleDecision, pattern: []const u8, candidate: []const u8) bool {
+    if (action != .allow or
+        (!std.mem.eql(u8, permission, "bash") and !std.mem.eql(u8, permission, "sandbox")))
+    {
+        return permissionPatternMatchesTarget(pattern, candidate);
+    }
+
+    if (!containsWildcard(pattern)) return std.mem.eql(u8, pattern, candidate);
+    if (!isStaticCommand(pattern, true) or !isStaticCommand(candidate, false)) return false;
+    return staticCommandWildcardMatch(pattern, candidate);
+}
+
+fn containsWildcard(pattern: []const u8) bool {
+    return std.mem.findScalar(u8, pattern, '*') != null or
+        std.mem.findScalar(u8, pattern, '?') != null;
+}
+
+fn isStaticCommand(command: []const u8, allow_wildcards: bool) bool {
+    if (command.len == 0) return false;
+    if (firstWordIsAssignment(command)) return false;
+
+    var index: usize = 0;
+    var in_word = false;
+    while (index < command.len) {
+        const char = command[index];
+        if (char == ' ' or char == '\t') {
+            if (!in_word) return false;
+            while (index < command.len and (command[index] == ' ' or command[index] == '\t')) : (index += 1) {}
+            if (index == command.len) return false;
+            in_word = false;
+            continue;
+        }
+
+        if (char == '\'') {
+            const literal_start = index + 1;
+            const literal_end = std.mem.findScalarPos(u8, command, literal_start, '\'') orelse return false;
+            const literal = command[literal_start..literal_end];
+            if (!std.unicode.utf8ValidateSlice(literal)) return false;
+            if (std.mem.findScalar(u8, literal, 0) != null or
+                std.mem.findScalar(u8, literal, '\r') != null or
+                std.mem.findScalar(u8, literal, '\n') != null)
+            {
+                return false;
+            }
+            in_word = true;
+            index = literal_end + 1;
+            continue;
+        }
+
+        if (!isStaticUnquotedByte(char) and !(allow_wildcards and (char == '*' or char == '?'))) return false;
+        in_word = true;
+        index += 1;
+    }
+    return in_word;
+}
+
+fn firstWordIsAssignment(command: []const u8) bool {
+    const first_word_end = std.mem.findAny(u8, command, " \t") orelse command.len;
+    const first_word = command[0..first_word_end];
+    const equals = std.mem.findScalar(u8, first_word, '=') orelse return false;
+    const name = first_word[0..equals];
+    if (name.len == 0 or (!std.ascii.isAlphabetic(name[0]) and name[0] != '_')) return false;
+    for (name[1..]) |char| {
+        if (!std.ascii.isAlphanumeric(char) and char != '_') return false;
+    }
+    return true;
+}
+
+fn isStaticUnquotedByte(char: u8) bool {
+    return std.ascii.isAlphanumeric(char) or switch (char) {
+        '_', '.', '/', ',', ':', '+', '=', '%', '@', '-' => true,
+        else => false,
+    };
+}
+
+fn staticCommandWildcardMatch(pattern: []const u8, candidate: []const u8) bool {
+    var pattern_index: usize = 0;
+    var candidate_index: usize = 0;
+    var in_single_quote = false;
+    var star_index: ?usize = null;
+    var star_candidate_index: usize = 0;
+
+    while (candidate_index < candidate.len) {
+        if (pattern_index < pattern.len) {
+            const char = pattern[pattern_index];
+            if (!in_single_quote and char == '*') {
+                star_index = pattern_index;
+                pattern_index += 1;
+                star_candidate_index = candidate_index;
+                continue;
+            }
+            if ((!in_single_quote and char == '?') or char == candidate[candidate_index]) {
+                if (char == '\'') in_single_quote = !in_single_quote;
+                pattern_index += 1;
+                candidate_index += 1;
+                continue;
+            }
+        }
+
+        const star = star_index orelse return false;
+        star_candidate_index += 1;
+        candidate_index = star_candidate_index;
+        pattern_index = star + 1;
+        in_single_quote = false;
+    }
+
+    while (pattern_index < pattern.len and !in_single_quote and pattern[pattern_index] == '*') : (pattern_index += 1) {}
+    return pattern_index == pattern.len;
+}
+
 fn directoryTreePatternMatches(pattern: []const u8, candidate: []const u8) bool {
     if (!std.mem.endsWith(u8, pattern, "/**")) return false;
     if (std.mem.eql(u8, pattern, "/**")) return std.mem.startsWith(u8, candidate, "/");
@@ -1687,18 +1798,34 @@ fn directoryTreePatternMatches(pattern: []const u8, candidate: []const u8) bool 
 }
 
 fn wildcardMatch(pattern: []const u8, candidate: []const u8) bool {
-    if (pattern.len == 0) return candidate.len == 0;
-    if (pattern[0] == '*') {
-        if (wildcardMatch(pattern[1..], candidate)) return true;
-        if (candidate.len == 0) return false;
-        return wildcardMatch(pattern, candidate[1..]);
+    var pattern_index: usize = 0;
+    var candidate_index: usize = 0;
+    var star_index: ?usize = null;
+    var star_candidate_index: usize = 0;
+
+    while (candidate_index < candidate.len) {
+        if (pattern_index < pattern.len and
+            (pattern[pattern_index] == '?' or pattern[pattern_index] == candidate[candidate_index]))
+        {
+            pattern_index += 1;
+            candidate_index += 1;
+            continue;
+        }
+        if (pattern_index < pattern.len and pattern[pattern_index] == '*') {
+            star_index = pattern_index;
+            pattern_index += 1;
+            star_candidate_index = candidate_index;
+            continue;
+        }
+
+        const star = star_index orelse return false;
+        star_candidate_index += 1;
+        candidate_index = star_candidate_index;
+        pattern_index = star + 1;
     }
-    if (pattern[0] == '?') {
-        if (candidate.len == 0) return false;
-        return wildcardMatch(pattern[1..], candidate[1..]);
-    }
-    if (candidate.len == 0 or pattern[0] != candidate[0]) return false;
-    return wildcardMatch(pattern[1..], candidate[1..]);
+
+    while (pattern_index < pattern.len and pattern[pattern_index] == '*') : (pattern_index += 1) {}
+    return pattern_index == pattern.len;
 }
 
 fn isGlobalTargetPattern(pattern: []const u8) bool {
@@ -2497,6 +2624,95 @@ test "ruleDecisionForPermissionPattern matches direct inputs and fallback" {
     try std.testing.expectEqual(RuleDecision.ask, ruleDecisionForPermissionPattern(rules, "edit", "src/main.zig", .none));
     try std.testing.expectEqual(RuleDecision.none, ruleDecisionForPermissionPattern(rules, "read", "README.md", .none));
     try std.testing.expectEqual(RuleDecision.ask, ruleDecisionForPermissionPattern(rules, "read", "README.md", .ask));
+}
+
+test "configured wildcard command allows only static command grammar" {
+    var rules_buf = [_]types.PermissionRule{
+        .{ .permission = @constCast("*"), .pattern = @constCast("printf *"), .action = .allow },
+    };
+    const rules: types.PermissionRuleSet = .{ .rules = &rules_buf };
+
+    try std.testing.expectEqual(RuleDecision.allow, ruleDecisionForPermissionPattern(rules, "bash", "printf safe", .none));
+    try std.testing.expectEqual(RuleDecision.allow, ruleDecisionForPermissionPattern(rules, "bash", "printf 'safe value'", .none));
+    try std.testing.expectEqual(RuleDecision.none, ruleDecisionForPermissionPattern(rules, "bash", "printf safe && touch /tmp/fx-marker", .none));
+    try std.testing.expectEqual(RuleDecision.none, ruleDecisionForPermissionPattern(rules, "bash", "printf \"$(touch /tmp/fx-marker)\"", .none));
+    try std.testing.expectEqual(RuleDecision.none, ruleDecisionForPermissionPattern(rules, "sandbox", "printf safe | sh", .none));
+}
+
+test "configured command rules require exact matching outside static grammar" {
+    var exact_rules_buf = [_]types.PermissionRule{
+        .{ .permission = @constCast("bash"), .pattern = @constCast("printf \"$(date)\""), .action = .allow },
+    };
+    const exact_rules: types.PermissionRuleSet = .{ .rules = &exact_rules_buf };
+
+    try std.testing.expectEqual(RuleDecision.allow, ruleDecisionForPermissionPattern(exact_rules, "bash", "printf \"$(date)\"", .none));
+    try std.testing.expectEqual(RuleDecision.none, ruleDecisionForPermissionPattern(exact_rules, "bash", "printf \"$(touch /tmp/fx-marker)\"", .none));
+
+    var dynamic_pattern_rules_buf = [_]types.PermissionRule{
+        .{ .permission = @constCast("bash"), .pattern = @constCast("printf \"*\""), .action = .allow },
+    };
+    try std.testing.expectEqual(
+        RuleDecision.none,
+        ruleDecisionForPermissionPattern(.{ .rules = &dynamic_pattern_rules_buf }, "bash", "printf \"safe\"", .none),
+    );
+}
+
+test "configured command deny and ask retain generic wildcard matching" {
+    var rules_buf = [_]types.PermissionRule{
+        .{ .permission = @constCast("bash"), .pattern = @constCast("printf *"), .action = .deny },
+        .{ .permission = @constCast("sandbox"), .pattern = @constCast("printf *"), .action = .ask },
+    };
+    const rules: types.PermissionRuleSet = .{ .rules = &rules_buf };
+
+    try std.testing.expectEqual(RuleDecision.deny, ruleDecisionForPermissionPattern(rules, "bash", "printf safe && touch /tmp/fx-marker", .none));
+    try std.testing.expectEqual(RuleDecision.ask, ruleDecisionForPermissionPattern(rules, "sandbox", "printf \"$(touch /tmp/fx-marker)\"", .none));
+}
+
+test "static command grammar is an explicit allowlist" {
+    for ([_][]const u8{
+        "git status --short",
+        "printf 'safe value'",
+        "printf ''",
+        "tool foo/bar:baz,+qux=value%@host",
+        "printf 'Grüße'",
+    }) |command| {
+        try std.testing.expect(isStaticCommand(command, false));
+    }
+
+    for ([_][]const u8{
+        "",
+        " leading",
+        "trailing ",
+        "FOO=bar command",
+        "FOO='bar' command",
+        "echo \"dynamic\"",
+        "echo $HOME",
+        "echo `pwd`",
+        "echo ~",
+        "echo [ab]",
+        "echo #comment",
+        "echo foo\\bar",
+        "echo one && echo two",
+        "echo one | cat",
+        "echo one > out",
+        "(echo one)",
+        "echo one\necho two",
+        "echo 'unterminated",
+    }) |command| {
+        try std.testing.expect(!isStaticCommand(command, false));
+    }
+
+    try std.testing.expect(isStaticCommand("git * --?", true));
+    try std.testing.expect(!isStaticCommand("git * --?", false));
+    try std.testing.expect(isStaticCommand("printf '*'", false));
+}
+
+test "generic wildcard matching remains total for maximum command-sized input" {
+    const candidate = try std.testing.allocator.alloc(u8, 64 * 1024);
+    defer std.testing.allocator.free(candidate);
+    @memset(candidate, 'x');
+    try std.testing.expect(wildcardMatch("*", candidate));
+    try std.testing.expect(!wildcardMatch("?", candidate));
 }
 
 test "rulesDenyAllTargetsForPermission honors last matching overrides" {

--- a/src/core/permissions/sandbox.zig
+++ b/src/core/permissions/sandbox.zig
@@ -68,10 +68,10 @@ pub fn effectiveBackend(
 }
 
 /// Converts the already-validated merged sandbox value into process-local
-/// backend state. An absent setting always means no sandbox; the permission
-/// mode never influences the backend.
+/// backend state. An absent setting selects automatic host resolution; the
+/// permission mode never influences the configured backend.
 pub fn backendFromConfig(configured: ?[]const u8) BackendKind {
-    const raw = configured orelse return .none;
+    const raw = configured orelse return .auto;
     return switch (parseConfigMode(raw)) {
         .mode => |mode| backendForPublicMode(mode),
         .invalid, .retired, .unsupported_os => .auto,
@@ -2934,8 +2934,8 @@ test "config sandbox parse accepts canonical and compatibility values" {
     try std.testing.expectEqual(ConfigModeParseResult.invalid, parseConfigModeForOs("bogus", .macos));
 }
 
-test "absent sandbox config always means no sandbox" {
-    try std.testing.expectEqual(BackendKind.none, backendFromConfig(null));
+test "absent sandbox config selects automatic host resolution" {
+    try std.testing.expectEqual(BackendKind.auto, backendFromConfig(null));
     try std.testing.expectEqual(BackendKind.none, backendFromConfig("none"));
     try std.testing.expectEqual(BackendKind.auto, backendFromConfig("bogus"));
 }

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -5285,6 +5285,24 @@ test "configured command authority skips automatic review" {
     );
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
     try std.testing.expectEqual(@as(usize, 0), recording.calls);
+
+    const compound = try requestPermissionOutcome(
+        input,
+        arena_state.allocator(),
+        .{
+            .id = "compound",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"touch configured.txt && printf bypass\"}",
+        },
+        .auto,
+        &.{},
+    );
+    try std.testing.expectEqual(
+        command_admission.ShellAuthorizationSource.interactive_once,
+        compound.execution_authority.?.run_command.shell_allowed.source,
+    );
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+    try std.testing.expectEqual(@as(usize, 1), recording.calls);
 }
 
 test "known reversible auto commands bypass the reviewer" {

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -4781,6 +4781,11 @@ describe("acp: model-independent", () => {
         expect(JSON.stringify(result.messages)).toContain("ACP needs one detail.");
         expect(JSON.stringify(result.messages)).toContain("ACP recovered normally.");
         expect(JSON.stringify(result.messages)).not.toContain("internal_error");
+        expect(
+          result.messages.some(
+            (message: any) => message.method === "session/request_permission",
+          ),
+        ).toBe(false);
         expect(gateway.requests).toHaveLength(2);
         expect(gateway.requests[1].body).toContain(`"toolCallId":"${malformedCallId}"`);
         expect(gateway.requests[1].body).toContain('"input":{}');

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -153,6 +153,67 @@ describe("lean auto mode reliability", () => {
   );
 
   test(
+    "configured wildcard commands cannot absorb shell operators or substitutions",
+    async () => {
+      const root = createIsolatedRoot();
+      const operatorMarker = join(root.workspace, "operator-bypass-must-not-run");
+      const substitutionMarker = join(
+        root.workspace,
+        "substitution-bypass-must-not-run",
+      );
+      writeFileSync(
+        join(root.home, ".fx", "settings.json"),
+        JSON.stringify({
+          sandbox: "none",
+          permission: { "*": { "printf *": "allow" } },
+          maxxing_mode: "legacy",
+        }),
+      );
+      const gateway = startGateway(
+        [
+          commandCall(
+            `printf safe && touch ${JSON.stringify(operatorMarker)}`,
+            "operator_bypass",
+          ),
+          (body) => {
+            expect(body).toContain("auto_denied");
+            return commandCall(
+              `printf "$(touch ${substitutionMarker})"`,
+              "substitution_bypass",
+            );
+          },
+          (body) => {
+            expect(body).toContain("auto_denied");
+            return commandCall("printf safe", "static_command");
+          },
+          fakeGatewayFinalText("static command complete"),
+        ],
+        [
+          fakeGatewayPermissionDecision("ask", "operator_requires_review"),
+          fakeGatewayPermissionDecision("ask", "substitution_requires_review"),
+        ],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Exercise configured commands safely."],
+        {
+          cwd: root.workspace,
+          env: gatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(existsSync(operatorMarker)).toBe(false);
+      expect(existsSync(substitutionMarker)).toBe(false);
+      expect(gateway.classifierRequests).toHaveLength(2);
+      expect(gateway.requests).toHaveLength(4);
+      expect(result.stdout).toContain("static command complete");
+    },
+    TIMEOUT,
+  );
+
+  test(
     "an exact read-only git status bypasses automatic review",
     async () => {
       const root = createIsolatedRoot();

--- a/tests/e2e/ci-shard-weights.json
+++ b/tests/e2e/ci-shard-weights.json
@@ -15,6 +15,7 @@
   { "file": "mcp-legacy-remote.test.ts", "weight": 19 },
   { "file": "mcp-stdio.test.ts", "weight": 84 },
   { "file": "notifications.test.ts", "weight": 9 },
+  { "file": "oauth-keychain-migration.test.ts", "weight": 30 },
   { "file": "permission-errors.test.ts", "weight": 1 },
   { "file": "prompt-history.test.ts", "weight": 14 },
   { "file": "session-recovery.test.ts", "weight": 13 },

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -568,6 +568,7 @@ describe("cli: status", () => {
           auth: "missing",
           auth_refreshable: false,
           auth_help: MISSING_AUTH_MESSAGE,
+          sandbox: platform() === "darwin" ? "os" : "none",
         });
         expect(doctorJson).toMatchObject({
           auth: "missing",

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -285,7 +285,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.sendText("/fast");
         await session.waitForText("● Fast: on", TIMEOUT);
         await session.sendText("/sandbox none");
-        await session.waitForText("● Sandbox: already set to none", TIMEOUT);
+        await session.waitForText("● Sandbox: switched to none", TIMEOUT);
         await session.sendText("/statusline sandbox");
         await session.waitForText("● Statusline: sandbox:", TIMEOUT);
         await session.sendText("/statusline context");
@@ -441,7 +441,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         });
         await session.waitForText("Run /help", TIMEOUT);
         await session.sendText("/sandbox none");
-        await session.waitForText("● Sandbox: already set to none", TIMEOUT);
+        await session.waitForText("● Sandbox: switched to none", TIMEOUT);
         await session.sendText('/allowlist add command "local-a *"');
         await session.waitForText("(scope=local)", TIMEOUT);
         await session.sendText('/allowlist user add command "user *"');

--- a/tests/e2e/file-tool-paths.test.ts
+++ b/tests/e2e/file-tool-paths.test.ts
@@ -751,6 +751,10 @@ describe("filesystem path handling", () => {
     async () => {
       const root = createIsolatedRoot();
       try {
+        writeFileSync(
+          join(root.home, ".fx", "settings.json"),
+          JSON.stringify({ sandbox: "none" }),
+        );
         const cases = [
           { id: "cwd_absolute", cwd: root.external, canonical: root.external },
           { id: "cwd_relative", cwd: "../external", canonical: root.external },

--- a/tests/e2e/oauth-keychain-migration.test.ts
+++ b/tests/e2e/oauth-keychain-migration.test.ts
@@ -1,0 +1,314 @@
+import { expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir, userInfo } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { runFx } from "../evals/eval-helpers";
+import {
+  FAKE_GATEWAY_MODEL,
+  fakeGatewayFinalText,
+  startFakeGateway,
+} from "./tmux-helpers";
+
+const TIMEOUT = 30_000;
+const OAUTH_SERVICE = "FX_OAUTH_SESSION_V1";
+const TEST_ACCOUNT_PREFIX = "fx-e2e-oauth-";
+const activeCleanups = new Set<() => void>();
+const KEYCHAIN_PROBE_SCRIPT = `
+ObjC.import("Security");
+ObjC.import("Foundation");
+const object = (value) => ObjC.castRefToObject(value);
+function run(argv) {
+  const query = $.NSMutableDictionary.alloc.init;
+  query.setObjectForKey(object($.kSecClassGenericPassword), object($.kSecClass));
+  query.setObjectForKey($(argv[0]), object($.kSecAttrAccount));
+  query.setObjectForKey($(argv[1]), object($.kSecAttrService));
+  query.setObjectForKey($.NSNumber.numberWithBool(true), object($.kSecReturnData));
+  query.setObjectForKey(object($.kSecMatchLimitOne), object($.kSecMatchLimit));
+  const result = Ref();
+  const status = $.SecItemCopyMatching(query, result);
+  if (status !== 0) throw new Error("keychain status=" + status);
+  $.NSFileHandle.fileHandleWithStandardOutput.writeData(
+    ObjC.castRefToObject(result[0]),
+  );
+}
+`;
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    for (const cleanup of activeCleanups) {
+      try {
+        cleanup();
+      } catch {}
+    }
+    process.removeAllListeners(signal);
+    process.kill(process.pid, signal);
+  });
+}
+
+function isolatedAccount(): string {
+  const account = `${TEST_ACCOUNT_PREFIX}${process.pid}-${randomUUID()}`;
+  if (!account.startsWith(TEST_ACCOUNT_PREFIX) || account.length > 200) {
+    throw new Error("failed to establish an isolated OAuth Keychain account");
+  }
+  return account;
+}
+
+function deleteKeychainItem(account: string): void {
+  if (!account.startsWith(TEST_ACCOUNT_PREFIX)) {
+    throw new Error("refusing to delete a non-test OAuth Keychain account");
+  }
+  const result = spawnSync(
+    "/usr/bin/security",
+    ["delete-generic-password", "-a", account, "-s", OAUTH_SERVICE],
+    { encoding: "utf8" },
+  );
+  if (result.status === 0 || result.stderr.includes("could not be found")) return;
+  throw new Error(`isolated OAuth Keychain cleanup failed: ${result.stderr.trim()}`);
+}
+
+function loadKeychainItem(account: string, home: string): string | null {
+  if (!account.startsWith(TEST_ACCOUNT_PREFIX)) {
+    throw new Error("refusing to read a non-test OAuth Keychain account");
+  }
+  const result = spawnSync(
+    "/usr/bin/osascript",
+    ["-l", "JavaScript", "-e", KEYCHAIN_PROBE_SCRIPT, account, OAUTH_SERVICE],
+    {
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, USER: account },
+    },
+  );
+  if (result.status === 0) return result.stdout.trim();
+  if (result.stderr.includes("keychain status=-25300")) return null;
+  throw new Error(`isolated OAuth Keychain lookup failed: ${result.stderr.trim()}`);
+}
+
+function productionMetadata(): string | null {
+  const result = spawnSync(
+    "/usr/bin/security",
+    ["find-generic-password", "-a", userInfo().username, "-s", OAUTH_SERVICE],
+    { encoding: "utf8" },
+  );
+  if (result.status === 0) return `${result.stdout}\n${result.stderr}`;
+  if (result.stderr.includes("could not be found")) return null;
+  throw new Error(`production OAuth Keychain metadata lookup failed: ${result.stderr.trim()}`);
+}
+
+function startOAuthIssuer() {
+  const requests: Array<{ method: string; path: string }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      requests.push({ method: request.method, path: url.pathname });
+      const issuer = `http://127.0.0.1:${server.port}`;
+      if (url.pathname === "/.well-known/openid-configuration") {
+        return Response.json({
+          issuer,
+          device_authorization_endpoint: `${issuer}/oauth/device`,
+          token_endpoint: `${issuer}/oauth/token`,
+          revocation_endpoint: `${issuer}/oauth/revoke`,
+        });
+      }
+      if (url.pathname === "/oauth/token") {
+        return Response.json({
+          access_token: "keychain-refreshed-access",
+          refresh_token: "keychain-rotated-refresh",
+          expires_in: 3600,
+          scope: "openid offline_access",
+          token_type: "Bearer",
+        });
+      }
+      if (url.pathname === "/oauth/revoke") return Response.json({ revoked: true });
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return {
+    issuer: `http://127.0.0.1:${server.port}`,
+    requests,
+    stop: () => server.stop(true),
+  };
+}
+
+function writeLogin(home: string, issuer: string, tokenSuffix: string): void {
+  const fxDir = join(home, ".fx");
+  mkdirSync(fxDir, { recursive: true, mode: 0o700 });
+  chmodSync(fxDir, 0o700);
+  const authPath = join(fxDir, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      version: 1,
+      issuer,
+      client_id: "keychain-e2e-client",
+      access_token: `keychain-access-${tokenSuffix}`,
+      refresh_token: `keychain-refresh-${tokenSuffix}`,
+      expires_at_ms: Date.now() - 60_000,
+      scope: "openid offline_access",
+      token_type: "Bearer",
+    }) + "\n",
+    { mode: 0o600 },
+  );
+  chmodSync(authPath, 0o600);
+}
+
+function attachSystemKeychain(home: string): void {
+  mkdirSync(join(home, "Library"), { recursive: true });
+  symlinkSync(
+    join(homedir(), "Library", "Keychains"),
+    join(home, "Library", "Keychains"),
+    "dir",
+  );
+}
+
+function keychainEnv(home: string, account: string, issuer: string) {
+  if (!account.startsWith(TEST_ACCOUNT_PREFIX)) {
+    throw new Error("OAuth Keychain E2E requires a unique test USER");
+  }
+  return {
+    HOME: home,
+    USER: account,
+    AI_GATEWAY_API_KEY: undefined,
+    VERCEL_OIDC_TOKEN: undefined,
+    FX_DISABLE_KEYCHAIN: undefined,
+    FX_SKIP_ONBOARDING: "1",
+    FX_AUTO_UPGRADE: "0",
+    FX_E2E_OAUTH_ISSUER_URL: issuer,
+    FX_TRACE_LOG: join(home, "oauth-keychain-trace.log"),
+    FX_TRACE_SCOPES: "auth,keychain",
+  };
+}
+
+const keychainTest = test.skipIf(process.platform !== "darwin");
+
+keychainTest(
+  "OAuth file migration survives restart and logout in an isolated Keychain account",
+  async () => {
+    const account = isolatedAccount();
+    const before = productionMetadata();
+    const home = mkdtempSync(join(tmpdir(), "fx-oauth-keychain-migration-"));
+    attachSystemKeychain(home);
+    const issuer = startOAuthIssuer();
+    const gateway = startFakeGateway([
+      fakeGatewayFinalText("Keychain refresh complete"),
+    ]);
+    const cleanup = () => deleteKeychainItem(account);
+    activeCleanups.add(cleanup);
+    cleanup();
+    writeLogin(home, issuer.issuer, account);
+    const env = {
+      ...keychainEnv(home, account, issuer.issuer),
+      FX_GATEWAY_BASE_URL: gateway.baseUrl,
+      FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+      FX_MODEL: FAKE_GATEWAY_MODEL,
+    };
+
+    try {
+      const first = await runFx(["status", "--json"], { env, timeoutMs: TIMEOUT });
+      expect(first.code, `stdout: ${first.stdout}\nstderr: ${first.stderr}`).toBe(0);
+      expect(JSON.parse(first.stdout).auth).toBe("fx login");
+      expect(
+        existsSync(join(home, ".fx", "auth.json")),
+        readFileSync(join(home, "oauth-keychain-trace.log"), "utf8"),
+      ).toBe(false);
+
+      const stored = loadKeychainItem(account, home);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!).access_token).toBe(`keychain-access-${account}`);
+
+      const refreshed = await runFx(
+        ["ask", "--json", "--no-save", "Refresh the saved login."],
+        { env, timeoutMs: TIMEOUT },
+      );
+      expect(
+        refreshed.code,
+        `stdout: ${refreshed.stdout}\nstderr: ${refreshed.stderr}`,
+      ).toBe(0);
+      expect(JSON.parse(refreshed.stdout).output).toContain(
+        "Keychain refresh complete",
+      );
+      expect(existsSync(join(home, ".fx", "auth.json"))).toBe(false);
+      expect(JSON.parse(loadKeychainItem(account, home)!).access_token).toBe(
+        "keychain-refreshed-access",
+      );
+      expect(
+        issuer.requests.filter((request) => request.path === "/oauth/token"),
+      ).toHaveLength(1);
+
+      rmSync(join(home, ".fx"), { recursive: true, force: true });
+      const restarted = await runFx(["status", "--json"], { env, timeoutMs: TIMEOUT });
+      expect(restarted.code).toBe(0);
+      expect(JSON.parse(restarted.stdout).auth).toBe("fx login");
+      expect(existsSync(join(home, ".fx"))).toBe(false);
+
+      const logout = await runFx(["logout"], { env, timeoutMs: TIMEOUT });
+      expect(logout.code, `stdout: ${logout.stdout}\nstderr: ${logout.stderr}`).toBe(0);
+      expect(logout.stdout).toBe("Signed out of fx.\n");
+      expect(loadKeychainItem(account, home)).toBeNull();
+      expect(issuer.requests.filter((request) => request.path === "/oauth/revoke")).toHaveLength(2);
+    } finally {
+      cleanup();
+      activeCleanups.delete(cleanup);
+      gateway.stop();
+      issuer.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+
+    expect(productionMetadata()).toBe(before);
+  },
+  TIMEOUT,
+);
+
+keychainTest(
+  "OAuth Keychain cleanup survives a failure after migration",
+  async () => {
+    const account = isolatedAccount();
+    const before = productionMetadata();
+    const home = mkdtempSync(join(tmpdir(), "fx-oauth-keychain-failure-"));
+    attachSystemKeychain(home);
+    const issuer = startOAuthIssuer();
+    const cleanup = () => deleteKeychainItem(account);
+    activeCleanups.add(cleanup);
+    cleanup();
+    writeLogin(home, issuer.issuer, account);
+
+    let injectedFailureObserved = false;
+    try {
+      const status = await runFx(["status", "--json"], {
+        env: keychainEnv(home, account, issuer.issuer),
+        timeoutMs: TIMEOUT,
+      });
+      expect(status.code).toBe(0);
+      expect(loadKeychainItem(account, home)).not.toBeNull();
+      throw new Error("injected failure after OAuth Keychain seeding");
+    } catch (error) {
+      expect((error as Error).message).toBe("injected failure after OAuth Keychain seeding");
+      injectedFailureObserved = true;
+    } finally {
+      cleanup();
+      activeCleanups.delete(cleanup);
+      issuer.stop();
+    }
+
+    try {
+      expect(injectedFailureObserved).toBe(true);
+      expect(loadKeychainItem(account, home)).toBeNull();
+      expect(productionMetadata()).toBe(before);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT,
+);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1275,7 +1275,7 @@ tmuxTest(
 );
 
 tmuxTest(
-  "logout keeps the active fx login when its saved session cannot be deleted",
+  "logout recalculates auth when local cleanup cannot be completed",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-logout-delete-failure-"));
     stderrPath = join(home, "stderr.log");
@@ -1295,18 +1295,18 @@ tmuxTest(
 
     await session.sendText("/logout");
     const failed = await session.waitForText(
-      "Could not complete fx logout. The current source is unchanged.",
+      "Could not confirm durable fx logout. The active source was recalculated.",
       TIMEOUT,
     );
     expect(failed).not.toContain("Signed out of fx.");
+    expect(failed).toContain(
+      "Warning: signed out locally, but the remote session could not be revoked.",
+    );
     expect(existsSync(authPath)).toBe(true);
 
     await session.sendText("/status");
-    await session.waitForText("auth=fx login", TIMEOUT);
-    await session.sendText("prove fx login remains active");
-    await session.waitForText(LOGIN_RESPONSE, TIMEOUT);
-    expect(gateway.requests).toHaveLength(1);
-    expect(gateway.requests[0].headers.get("authorization")).toBe(`Bearer ${LOGIN_TOKEN}`);
+    await session.waitForText("auth=missing", TIMEOUT);
+    expect(gateway.requests).toHaveLength(0);
     expect(oauth.requests).toEqual([]);
     expect(readFileSync(stderrPath, "utf8")).toBe("");
   },

--- a/tests/e2e/tui-decision-prompts.test.ts
+++ b/tests/e2e/tui-decision-prompts.test.ts
@@ -174,6 +174,9 @@ function outerCommandCall() {
 
 const PROJECTION_READY = ".projection-change-ready";
 const PROJECTION_RELEASE = ".projection-change-release";
+const PROJECTION_CHANGING_COMMAND =
+  `i=1; while [ "$i" -le 5000 ]; do printf 'PROJECTION_FIXTURE_%04d\\n' "$i"; i=$((i + 1)); done; ` +
+  `: > ${PROJECTION_READY}; while [ ! -e ${PROJECTION_RELEASE} ]; do sleep 0.01; done`;
 
 function outerProjectionChangingCommandCall() {
   return outerToolCalls([
@@ -182,9 +185,7 @@ function outerProjectionChangingCommandCall() {
       name: "terminal",
       input: {
         action: "exec",
-        command:
-          `i=1; while [ "$i" -le 5000 ]; do printf 'PROJECTION_FIXTURE_%04d\\n' "$i"; i=$((i + 1)); done; ` +
-          `: > ${PROJECTION_READY}; while [ ! -e ${PROJECTION_RELEASE} ]; do sleep 0.01; done`,
+        command: PROJECTION_CHANGING_COMMAND,
       },
     },
   ]);
@@ -1496,7 +1497,7 @@ describe.skipIf(SKIP)("tui: decision prompt input isolation", () => {
         },
         "ask",
         () => "allow",
-        { bash: { "i=1; while *": "allow" } },
+        { bash: { [PROJECTION_CHANGING_COMMAND]: "allow" } },
       );
       await ctx.session.resizeWindow(120, 36);
 

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -69,7 +69,7 @@ async function startFx(
   mkdirSync(join(testHome, ".fx"), { recursive: true });
   writeFileSync(
     join(testHome, ".fx", "settings.json"),
-    JSON.stringify({ maxxing_mode: "legacy" }),
+    JSON.stringify({ maxxing_mode: "legacy", sandbox: "none" }),
   );
   if (withGateway) {
     gateway = startFakeGateway(

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -2608,7 +2608,10 @@ describe.skipIf(SKIP)("tui: resize", () => {
         await active.sendText("/statusline");
         await active.waitForText("Status line", TIMEOUT);
         await active.sendKeys("Right");
-        await active.waitForText("sandbox:os", TIMEOUT);
+        await active.waitForText(
+          process.platform === "darwin" ? "sandbox:os" : "sandbox:none",
+          TIMEOUT,
+        );
         await active.sendKeys("Down");
         await active.sendKeys("Right");
       },

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -2608,7 +2608,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
         await active.sendText("/statusline");
         await active.waitForText("Status line", TIMEOUT);
         await active.sendKeys("Right");
-        await active.waitForText("sandbox:none", TIMEOUT);
+        await active.waitForText("sandbox:os", TIMEOUT);
         await active.sendKeys("Down");
         await active.sendKeys("Right");
       },

--- a/tests/e2e/tui-slash-commands.test.ts
+++ b/tests/e2e/tui-slash-commands.test.ts
@@ -142,7 +142,7 @@ describe.skipIf(TMUX_SKIP)("tui: no-key slash commands", () => {
         "Run /help for commands",
         "auth_refreshable=",
         "permission_mode=auto",
-        "sandbox=none",
+        process.platform === "darwin" ? "sandbox=os" : "sandbox=none",
       ]) {
         expect(scrollback.split(field)).toHaveLength(2);
       }


### PR DESCRIPTION
## Summary

- Restrict wildcard command allows to static shell words while preserving exact command rules.
- Default unset sandbox configuration to the supported OS sandbox while preserving explicit opt-outs.
- Store native macOS fx login sessions in Keychain with verified migration, refresh, restart, and logout behavior.
- Report partial OAuth cleanup and remote revocation failures without skipping either operation.
- Validate ACP permission input before writing JSON-RPC frames.