### PR TITLE
Fix process lifecycle CI flakes

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -144,14 +144,34 @@ jobs:
 
       - name: Install E2E system dependencies
         shell: bash
+        timeout-minutes: 12
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             missing=()
             command -v tmux >/dev/null 2>&1 || missing+=(tmux)
             command -v zsh >/dev/null 2>&1 || missing+=(zsh)
             if [ "${#missing[@]}" -gt 0 ]; then
-              sudo apt-get update
-              sudo apt-get install -y "${missing[@]}"
+              retry() {
+                local attempt
+                for attempt in 1 2; do
+                  if "$@"; then
+                    return 0
+                  fi
+                  if [ "$attempt" -lt 2 ]; then
+                    printf 'Dependency install attempt %s failed; retrying in 5s\n' "$attempt" >&2
+                    sleep 5
+                  fi
+                done
+                return 1
+              }
+              retry sudo timeout --kill-after=15s 2m apt-get \
+                -o Acquire::Retries=3 \
+                -o Acquire::http::Timeout=30 \
+                -o Acquire::https::Timeout=30 \
+                update
+              retry sudo timeout --kill-after=15s 3m apt-get \
+                -o Dpkg::Use-Pty=0 \
+                install -y "${missing[@]}"
             fi
           elif ! command -v tmux >/dev/null 2>&1; then
             brew install tmux

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install E2E system dependencies
         shell: bash
-        timeout-minutes: 12
+        timeout-minutes: 17
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             missing=()
@@ -164,7 +164,9 @@ jobs:
                 done
                 return 1
               }
-              retry sudo timeout --kill-after=15s 2m apt-get \
+              # GitHub's Azure mirror can make forward progress for more than
+              # two minutes before falling back to archive.ubuntu.com.
+              retry sudo timeout --kill-after=15s 4m apt-get \
                 -o Acquire::Retries=3 \
                 -o Acquire::http::Timeout=30 \
                 -o Acquire::https::Timeout=30 \

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -164,8 +164,14 @@ jobs:
                 done
                 return 1
               }
-              # GitHub's Azure mirror can make forward progress for more than
-              # two minutes before falling back to archive.ubuntu.com.
+              # The Azure mirror can stall after APT has already fetched release
+              # metadata from the direct Ubuntu fallback. Prefer that fallback
+              # for the whole update when the runner's mirror list provides it.
+              if [ -f /etc/apt/apt-mirrors.txt ] &&
+                grep -Eq '^https?://(archive|ports)\.ubuntu\.com/' /etc/apt/apt-mirrors.txt
+              then
+                sudo sed -i '/:\/\/azure\..*ubuntu\.com\//d' /etc/apt/apt-mirrors.txt
+              fi
               retry sudo timeout --kill-after=15s 4m apt-get \
                 -o Acquire::Retries=3 \
                 -o Acquire::http::Timeout=30 \

--- a/sdk/tests/test-core-browser.mjs
+++ b/sdk/tests/test-core-browser.mjs
@@ -15,6 +15,13 @@ const chromeCandidates = [
   "google-chrome",
   "chromium",
 ].filter(Boolean);
+const chromeStartTimeoutMs = 15_000;
+
+async function stopChrome(process) {
+  if (process.exitCode !== null || process.signalCode !== null) return;
+  process.kill();
+  await new Promise((resolveExit) => process.once("exit", resolveExit));
+}
 
 const contentTypes = {
   ".html": "text/html; charset=utf-8",
@@ -60,7 +67,7 @@ for (const candidate of chromeCandidates) {
       };
       const timeout = setTimeout(() => fail(new Error(
         `timed out starting ${candidate}${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
-      )), 5000);
+      )), chromeStartTimeoutMs);
       chrome.once("error", fail);
       chrome.once("exit", (code, signal) => fail(new Error(
         `${candidate} exited before DevTools started (${signal || code})${stderr.trim() ? `: ${stderr.trim()}` : ""}`,
@@ -78,7 +85,7 @@ for (const candidate of chromeCandidates) {
     break;
   } catch (error) {
     chromeLaunchError = error;
-    chrome?.kill();
+    if (chrome) await stopChrome(chrome);
     chrome = null;
   }
 }
@@ -199,6 +206,6 @@ try {
   }
 } finally {
   socket.close();
-  chrome.kill();
+  await stopChrome(chrome);
   server.close();
 }

--- a/src/core/background/background_runtime.zig
+++ b/src/core/background/background_runtime.zig
@@ -2758,7 +2758,6 @@ fn spawnBlockedBackgroundHandshakeForTest(
         child.stdin = null;
         child.stderr = null;
         child.kill(io_mod.getIo());
-        _ = child.wait(io_mod.getIo()) catch {};
     }
 
     var ready: [1]u8 = undefined;

--- a/src/core/execution/process_tree.zig
+++ b/src/core/execution/process_tree.zig
@@ -312,14 +312,7 @@ pub const Tracker = struct {
             .{parent.pid},
         );
         defer self.alloc.free(task_path);
-        var task_dir = std.Io.Dir.openDirAbsolute(
-            io_mod.getIo(),
-            task_path,
-            .{ .iterate = true },
-        ) catch |err| switch (err) {
-            error.FileNotFound => return,
-            else => return err,
-        };
+        var task_dir = (try openLinuxProcDir(task_path)) orelse return;
         defer task_dir.close(io_mod.getIo());
         var tasks = task_dir.iterate();
         while (try tasks.next(io_mod.getIo())) |entry| {
@@ -344,10 +337,7 @@ pub const Tracker = struct {
             .{ parent.pid, tid },
         );
         defer self.alloc.free(path);
-        var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{}) catch |err| switch (err) {
-            error.FileNotFound => return,
-            else => return err,
-        };
+        var file = (try openLinuxProcFile(path)) orelse return;
         defer file.close(io_mod.getIo());
         var buffer: [64 * 1024]u8 = undefined;
         const read_len = readLinuxChildrenFile(file, &buffer) catch |err| switch (err) {
@@ -501,6 +491,49 @@ fn readLinuxChildrenFile(file: std.Io.File, buffer: []u8) !usize {
     }
 }
 
+fn openLinuxProcDir(path: []const u8) !?std.Io.Dir {
+    if (comptime builtin.os.tag != .linux) return error.ProcessTreeUnsupported;
+    // A process can disappear between identity validation and opening its
+    // procfs entry. The POSIX wrapper maps Linux's ESRCH to FileNotFound;
+    // std.Io currently treats ESRCH from directory opens as unexpected.
+    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{
+        .ACCMODE = .RDONLY,
+        .NOFOLLOW = true,
+        .DIRECTORY = true,
+        .CLOEXEC = true,
+    }, 0) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    return .{ .handle = fd };
+}
+
+fn openLinuxProcFile(path: []const u8) !?std.Io.File {
+    if (comptime builtin.os.tag != .linux) return error.ProcessTreeUnsupported;
+    const fd = std.posix.openat(std.posix.AT.FDCWD, path, .{
+        .ACCMODE = .RDONLY,
+        .NOFOLLOW = true,
+        .CLOEXEC = true,
+    }, 0) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    return .{
+        .handle = fd,
+        .flags = .{ .nonblocking = false },
+    };
+}
+
+test "Linux proc helpers treat missing process data as vanished" {
+    if (builtin.os.tag != .linux) return error.SkipZigTest;
+    try std.testing.expect(
+        (try openLinuxProcDir("/proc/self/fx-process-tree-missing")) == null,
+    );
+    try std.testing.expect(
+        (try openLinuxProcFile("/proc/self/fx-process-tree-missing")) == null,
+    );
+}
+
 test "process-group exclusion preserves the captured command grace" {
     try std.testing.expect(shouldSignalProcess(41, null));
     try std.testing.expect(!shouldSignalProcess(41, 41));
@@ -652,10 +685,7 @@ fn captureLinuxSnapshot(alloc: Allocator, pid: std.posix.pid_t) !ProcessSnapshot
     if (comptime builtin.os.tag != .linux) return error.ProcessTreeUnsupported;
     const path = try std.fmt.allocPrint(alloc, "/proc/{d}/stat", .{pid});
     defer alloc.free(path);
-    var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{}) catch |err| switch (err) {
-        error.FileNotFound => return error.ProcessNotFound,
-        else => return err,
-    };
+    var file = (try openLinuxProcFile(path)) orelse return error.ProcessNotFound;
     defer file.close(io_mod.getIo());
     var buffer: [4096]u8 = undefined;
     const read_len = try readLinuxProcFile(file, &buffer);

--- a/src/core/permissions/sandbox.zig
+++ b/src/core/permissions/sandbox.zig
@@ -267,7 +267,6 @@ pub fn runForegroundSessionBootstrap(args: []const [:0]const u8) !void {
     };
     const term = waitForForegroundTarget(&target) catch |err| {
         target.kill(zio);
-        _ = target.wait(zio) catch {};
         writeForegroundSessionReplaceFailure(args[1], err);
         std.process.exit(foreground_session_replace_failure_exit_code);
     };
@@ -2741,9 +2740,6 @@ fn cleanupChild(child: *std.process.Child) void {
     }
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
         child.kill(io_mod.getIo());
-        _ = child.wait(io_mod.getIo()) catch |err| {
-            debug_trace.logf("core", "command cleanup wait failed err={s}", .{@errorName(err)});
-        };
         return;
     }
     const pid = child.id orelse return;

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -585,6 +585,13 @@ export class TmuxSession {
       : [
         ";",
         "set-option",
+        "-w",
+        "-t",
+        `${name}:0`,
+        "history-limit",
+        String(Math.max(serverHistoryLines!, minimumHistoryLines)),
+        ";",
+        "set-option",
         "-g",
         "history-limit",
         String(serverHistoryLines!),


### PR DESCRIPTION
## Summary

- Treat disappearing Linux procfs entries as completed process-tree traversal instead of surfacing an unexpected error.
- Remove redundant waits after `Child.kill()`, which already waits and clears the child ID in Zig 0.16.
- Preserve each tmux test window's requested history limit when restoring the server-global setting.
- Bound and retry Linux E2E dependency installation so a stalled package manager cannot consume the full two-hour job timeout.

## Root cause

Short-lived process exits could race procfs inspection and return `ESRCH`. The generic I/O path surfaced that as unexpected, and foreground-session cleanup then called `wait()` after `kill()` had already reaped the child, triggering an assertion. Separately, tmux history-limit restoration was version-sensitive, and the E2E dependency step had no inner timeout.

## Validation

- `zig fmt --check src/`
- `zig build test -Doptimize=Debug`
- macOS Debug build and clean `fx help` / `fx status --json` smoke tests
- Linux x86_64 Debug and ReleaseSafe cross-builds
- Linux aarch64 Debug cross-build
- 10 tmux-helper tests
- 17 terminal-host lifecycle tests
- 2 slash-menu tests
- the previously failing resume test

Refs FXC-219
