### PR TITLE
Keep help descriptions close on wide terminals

### DIFF
--- a/src/ui/footer/help_menu_presentation.zig
+++ b/src/ui/footer/help_menu_presentation.zig
@@ -9,6 +9,8 @@ const Allocator = std.mem.Allocator;
 const HelpMenuProjection = render_input.HelpMenuProjection;
 
 const roomy_header_rows: u16 = 2;
+// Keep command names and descriptions visually associated on wide terminals.
+const maximum_description_column: usize = 48;
 
 fn commandRowCount(_: u16) u16 {
     return 1;
@@ -64,7 +66,7 @@ pub fn composeHelpMenuRow(
     }
     if (layout.match_count == 0) return composeEmptyRow(alloc, width);
 
-    const description_col = centeredDescriptionColumn(projection, width);
+    const description_col = descriptionColumn(projection, width);
     return switch (bodyRowAt(projection, width, layout, row_index - layout.body_start_row)) {
         .none => empty,
         .category => |category| composeCategoryRow(alloc, category, width),
@@ -249,7 +251,7 @@ fn composeCommandRow(
     return row;
 }
 
-fn centeredDescriptionColumn(projection: HelpMenuProjection, width: u16) usize {
+fn descriptionColumn(projection: HelpMenuProjection, width: u16) usize {
     const total_width: usize = width;
     const right_column_start = total_width * 2 / 3;
     const right_column_width = total_width - right_column_start;
@@ -262,7 +264,8 @@ fn centeredDescriptionColumn(projection: HelpMenuProjection, width: u16) usize {
         );
     }
     const description_block_width = @min(widest_description_width, right_column_width);
-    return right_column_start + (right_column_width - description_block_width) / 2;
+    const centered_column = right_column_start + (right_column_width - description_block_width) / 2;
+    return @min(centered_column, maximum_description_column);
 }
 
 fn composeEmptyRow(alloc: Allocator, width: u16) !std.ArrayList(u8) {
@@ -281,24 +284,24 @@ const help_menu_test_specs = [_]command_specs.SlashSpec{
 };
 const help_menu_test_registry = command_specs.SlashRegistry{ .commands = help_menu_test_specs[0..] };
 
-test "help menu renders each command on one linear row at wide and narrow widths" {
+test "help menu keeps descriptions close at wide widths without changing narrow layout" {
     const alloc = std.testing.allocator;
     const projection: render_input.HelpMenuProjection = .{
         .active = true,
         .registry = help_menu_test_registry,
         .selected_index = 0,
     };
-    const rows = menuRowCount(projection, 100, 20);
+    const rows = menuRowCount(projection, 160, 20);
 
-    var header = try composeHelpMenuRow(alloc, projection, 0, 100, rows);
+    var header = try composeHelpMenuRow(alloc, projection, 0, 160, rows);
     defer header.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, header.items, "Commands 3") != null);
 
-    var category = try composeHelpMenuRow(alloc, projection, 2, 100, rows);
+    var category = try composeHelpMenuRow(alloc, projection, 2, 160, rows);
     defer category.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, category.items, "General") != null);
 
-    var selected = try composeHelpMenuRow(alloc, projection, 3, 100, rows);
+    var selected = try composeHelpMenuRow(alloc, projection, 3, 160, rows);
     defer selected.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, selected.items, "/help") != null);
     try std.testing.expect(std.mem.find(u8, selected.items, "●") == null);
@@ -310,10 +313,14 @@ test "help menu renders each command on one linear row at wide and narrow widths
         ui_render.selected_completion_style,
         selected.items[selected_style_start..description_start],
     );
-    try std.testing.expect(display_width.visibleWidthIgnoringAnsi(selected.items[0..description_start]) >= 100 * 2 / 3);
+    try std.testing.expectEqual(
+        maximum_description_column,
+        display_width.visibleWidthIgnoringAnsi(selected.items[0..description_start]),
+    );
 
     const narrow_rows = menuRowCount(projection, 22, 20);
     try std.testing.expectEqual(rows, narrow_rows);
+    try std.testing.expectEqual(@as(usize, 14), descriptionColumn(projection, 22));
     var narrow = try composeHelpMenuRow(alloc, projection, 3, 22, narrow_rows);
     defer narrow.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow.items, "/help") != null);
@@ -330,13 +337,13 @@ test "help menu keeps a gutter between long commands and descriptions" {
         .active = true,
         .registry = .{ .commands = long_specs[0..] },
     };
-    const rows = menuRowCount(projection, 100, 12);
-    var item = try composeHelpMenuRow(alloc, projection, 3, 100, rows);
+    const rows = menuRowCount(projection, 160, 12);
+    var item = try composeHelpMenuRow(alloc, projection, 3, 160, rows);
     defer item.deinit(alloc);
 
     const description_start = std.mem.find(u8, item.items, "choose presentation").?;
     const description_col = display_width.visibleWidthIgnoringAnsi(item.items[0..description_start]);
-    try std.testing.expect(description_col >= 100 * 2 / 3);
+    try std.testing.expectEqual(maximum_description_column, description_col);
     try std.testing.expect(std.mem.find(u8, item.items[0..description_start], "…") != null);
 }
 

--- a/src/ui/help_screen.zig
+++ b/src/ui/help_screen.zig
@@ -202,3 +202,44 @@ test "help screen keeps a selectable command visible at six rows" {
     try std.testing.expect(std.mem.find(u8, row.items, "/help") != null);
     try std.testing.expect(std.mem.find(u8, row.items, "●") == null);
 }
+
+test "help screen keeps command descriptions associated at narrow and wide widths" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        cols: u16,
+        description_col: usize,
+    }{
+        .{ .cols = 60, .description_col = 40 },
+        .{ .cols = 160, .description_col = 48 },
+    };
+
+    for (cases) |case| {
+        var screen = try paint(alloc, .{
+            .rows = 16,
+            .cols = case.cols,
+            .help = .{
+                .active = true,
+                .registry = help_screen_test_registry,
+            },
+            .composer = .{
+                .input = "",
+                .cursor = 0,
+                .appearance = .lines,
+                .prefix_style = input_presentation.ComposerPrefixStyle.rail,
+            },
+            .clear_display = true,
+        });
+        defer screen.deinit(alloc);
+
+        var grid = try vt_emulator.Grid.init(alloc, case.cols, 16);
+        defer grid.deinit();
+        try grid.feed(screen.bytes);
+
+        var row: std.ArrayList(u8) = .empty;
+        defer row.deinit(alloc);
+        try grid.rowTextTrimmed(6, &row);
+        try std.testing.expect(std.mem.find(u8, row.items, "/help") != null);
+        const description_start = std.mem.find(u8, row.items, "show available").?;
+        try std.testing.expectEqual(case.description_col, description_start);
+    }
+}

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -63,6 +63,63 @@ describe.skipIf(SKIP)("tui: startup and exit", () => {
 
 describe.skipIf(SKIP_TMUX)("tui: fresh-session commands", () => {
   test(
+    "/help keeps command descriptions close after a wide-to-narrow resize",
+    async () => {
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-help-columns-")));
+      const home = join(root, "home");
+      const stderrPath = join(root, "stderr.log");
+      mkdirSync(home, { recursive: true });
+      writeFileSync(stderrPath, "");
+
+      try {
+        session = await TmuxSession.create({
+          cwd: root,
+          env: {
+            HOME: home,
+            FX_AUTO_UPGRADE: "0",
+          },
+          stderrPath,
+          width: 160,
+          height: 40,
+        });
+
+        await session.waitForComposer(10_000);
+        await session.sendText("/help");
+        const wide = await session.waitForPane(
+          (pane) => pane.includes("/help") && pane.includes("show available slash commands"),
+          5_000,
+        );
+        const wideHelp = wide.split("\n").find(
+          (line) => line.includes("/help") && line.includes("show available slash commands"),
+        );
+        expect(wideHelp).toBeDefined();
+        expect(wideHelp!.indexOf("show available slash commands")).toBe(48);
+
+        await session.resizeWindow(60, 40);
+        const narrow = await session.waitForPane(
+          (pane) => pane.split("\n").some(
+            (line) => line.includes("/help") && line.includes("show available"),
+          ),
+          5_000,
+        );
+        const narrowHelp = narrow.split("\n").find(
+          (line) => line.includes("/help") && line.includes("show available"),
+        );
+        expect(narrowHelp).toBeDefined();
+        expect(narrowHelp!.indexOf("show available")).toBe(40);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+      } finally {
+        if (session) {
+          await session.kill();
+          session = null;
+        }
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "restore the launch header without retaining prior output",
     async () => {
       const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-fresh-session-")));


### PR DESCRIPTION
## Summary

- Cap the `/help` description column at 48 so commands and descriptions remain visually associated on wide terminals.
- Preserve the existing description placement at narrow terminal widths.
- Add renderer coverage at 60 and 160 columns plus a tmux resize regression test.

## Testing

- `zig build`
- `zig build test`
- `python3 -m scripts.pgso.corpus --manifest scripts/pgso/corpus.json --list`
- `cd tests/e2e && bun test --max-concurrency 1 --test-name-pattern 'help keeps command descriptions' ./tui-startup.test.ts`
