### PR TITLE
Expose session resume in the session command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands.
 
+List saved sessions with `fx sessions`. Resume the latest session for the current workspace, or select an exact session ID, through the same command group:
+
+```bash
+fx session resume last
+fx session resume --id <id>
+```
+
 Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not create a diagnostic or change the clipboard.
 
 Run `/trace` to create a private Markdown diagnostic with logs, session context, runtime state, permissions, and recent activity. On macOS, fx copies the `.md` file to the clipboard; on other platforms, it saves the file and prints its path. Review and redact the trace before sharing it.

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -161,11 +161,12 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .session,
         .token = "session",
-        .usage = "session <last|id>|--id <id> [--json] | session migrate <id>|--id <id> [--allow-large] [--json] | session recover <id>|--id <id> [--json]",
-        .summary = "Inspect one saved session",
+        .usage = "session <last|id>|--id <id> [--json] | session resume [last|<id>] [--record] | session resume --id <id> [--record] | session migrate <id>|--id <id> [--allow-large] [--json] | session recover <id>|--id <id> [--json]",
+        .summary = "Inspect, resume, migrate, or recover saved sessions",
         .options = &.{
             .{ .flag = "last", .description = "Inspect the current workspace session" },
             .{ .flag = "--id <id>", .description = "Inspect a saved session by exact id" },
+            .{ .flag = "resume [last|<id>]", .description = "Resume the latest workspace session or a session by id" },
             .{ .flag = "migrate <id>", .description = "Migrate a saved session to the current format" },
             .{ .flag = "recover <id>", .description = "Copy a recoverable corrupt session into a new session" },
             .{ .flag = "--allow-large", .description = "Permit migrating an oversized session" },
@@ -189,7 +190,7 @@ pub const top_level_specs = [_]TopLevelSpec{
         .token = "resume",
         .aliases = &.{ "--resume", "--resume-last", "--continue", "-c", "-r" },
         .hidden_from_top_level_help = true,
-        .usage = "--resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>",
+        .usage = "session resume [last|<id>] [--record] | session resume --id <id> [--record] | --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>",
         .summary = "Continue a saved interactive session",
         .options = &.{
             .{ .flag = "-r", .description = "Choose the session to resume from a picker" },
@@ -276,6 +277,7 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
     .{ .entries = &.{
         .{ .kind = .sessions, .usage = "sessions" },
         .{ .kind = .session, .usage = "session <last|id>" },
+        .{ .usage = "session resume [last|id]", .summary = "Resume the latest workspace session or a session by id" },
         .{ .usage = "session migrate <id>", .summary = "Migrate a saved session to the current format" },
         .{ .usage = "session recover <id>", .summary = "Copy a recoverable corrupt session" },
         .{ .kind = .replay, .usage = "replay <tape>" },
@@ -350,7 +352,7 @@ pub const top_level_flags = [_]TopLevelFlag{
 pub const top_level_examples = [_]TopLevelExample{
     .{ .command = "fx", .description = "Start a fresh interactive session" },
     .{ .command = "fx ask \"Explain the changes in this repository\"", .description = "Run one request and exit" },
-    .{ .command = "fx --resume last", .description = "Continue the latest session for this workspace" },
+    .{ .command = "fx session resume last", .description = "Continue the latest session for this workspace" },
     .{ .command = "fx status --json", .description = "Inspect the current configuration as JSON" },
 };
 

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -153,6 +153,10 @@ pub fn recordRequested(args: []const [:0]const u8) error{RecordModifierRequiresI
     if (args.len >= 2 and
         (std.mem.eql(u8, args[0], "resume") or std.mem.eql(u8, args[0], "--resume")) and
         std.mem.eql(u8, args[args.len - 1], "--record")) return true;
+    if (args.len >= 3 and
+        std.mem.eql(u8, args[0], "session") and
+        std.mem.eql(u8, args[1], "resume") and
+        std.mem.eql(u8, args[args.len - 1], "--record")) return true;
     return error.RecordModifierRequiresInteractive;
 }
 
@@ -460,7 +464,12 @@ pub fn parse(command_catalog: CommandCatalog, args: []const [:0]const u8) Comman
             if (command_specs.matchesTopLevel(command_catalog, command, .setup)) return .{ .setup = args[1..] };
             if (command_specs.matchesTopLevel(command_catalog, command, .status)) return .{ .status = args[1..] };
             if (command_specs.matchesTopLevel(command_catalog, command, .sessions)) return .{ .sessions = args[1..] };
-            if (command_specs.matchesTopLevel(command_catalog, command, .session)) return .{ .session = args[1..] };
+            if (command_specs.matchesTopLevel(command_catalog, command, .session)) {
+                if (args.len > 1 and std.mem.eql(u8, args[1], "resume")) {
+                    return .{ .resume_session = .{ .args = args[2..] } };
+                }
+                return .{ .session = args[1..] };
+            }
         },
         't' => {
             if (command_specs.matchesTopLevel(command_catalog, command, .teams)) return .{ .teams = args[1..] };
@@ -517,6 +526,13 @@ pub fn parseInteractiveLaunch(
     }
 
     const command = parse(command_catalog, effective_args);
+    if (topLevelHelpRequest(command_catalog, effective_args) != null) {
+        return .{ .noninteractive = .{
+            .global_args = global_args,
+            .effective_args = effective_args,
+            .command = command,
+        } };
+    }
     switch (command) {
         .interactive => return .{ .interactive = .{
             .record_requested = record_requested,
@@ -3181,6 +3197,10 @@ test "parse recognizes every top-level command and preserves unknown commands" {
         .session => |rest| try std.testing.expectEqual(@as(usize, 1), rest.len),
         else => return error.TestExpectedEqual,
     }
+    switch (parse(command_catalog, &.{ @constCast("session"), @constCast("resume"), @constCast("last") })) {
+        .resume_session => |invocation| try std.testing.expectEqual(@as(usize, 1), invocation.args.len),
+        else => return error.TestExpectedEqual,
+    }
     switch (parse(command_catalog, &.{ @constCast("sessions"), @constCast("--json") })) {
         .sessions => |rest| try std.testing.expectEqual(@as(usize, 1), rest.len),
         else => return error.TestExpectedEqual,
@@ -3755,6 +3775,8 @@ test "parseInteractiveLaunch shares native resume grammar" {
         .{ .args = &.{@constCast("--resume")}, .expected_id = null },
         .{ .args = &.{ @constCast("--resume"), @constCast("last") }, .expected_id = null },
         .{ .args = &.{ @constCast("--resume"), @constCast("session-123") }, .expected_id = "session-123" },
+        .{ .args = &.{ @constCast("session"), @constCast("resume"), @constCast("last") }, .expected_id = null },
+        .{ .args = &.{ @constCast("session"), @constCast("resume"), @constCast("--id"), @constCast("session.v3") }, .expected_id = "session.v3" },
     };
     for (cases) |case| {
         const parsed = try parseInteractiveLaunch(alloc, case.args, command_catalog);
@@ -4104,6 +4126,25 @@ test "runIfRequested carries record intent through supported interactive launche
         },
         else => return error.TestExpectedInteractiveLaunch,
     }
+
+    const grouped = try runIfRequestedWithDeps(
+        std.testing.allocator,
+        &.{ @constCast("session"), @constCast("resume"), @constCast("session-123"), @constCast("--record") },
+        testConfig(),
+        capture.deps(),
+    );
+    switch (grouped) {
+        .interactive => |launch_value| {
+            var launch = launch_value;
+            defer launch.deinit(std.testing.allocator);
+            try std.testing.expect(launch.record_requested);
+            switch (launch.requested_resume.?) {
+                .id => |id| try std.testing.expectEqualStrings("session-123", id),
+                .pick, .last => return error.TestExpectedResumeId,
+            }
+        },
+        else => return error.TestExpectedInteractiveLaunch,
+    }
 }
 
 test "runIfRequested rejects record modifier before noninteractive handlers" {
@@ -4387,7 +4428,7 @@ test "runIfRequested rejects malformed resume aliases with canonical usage" {
         );
         try std.testing.expectEqual(RunResult.handled_failure, result);
         try std.testing.expectEqualStrings(
-            "usage: fx --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>\n",
+            "usage: fx session resume [last|<id>] [--record] | session resume --id <id> [--record] | --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>\n",
             capture.stderr.written(),
         );
     }
@@ -4418,7 +4459,7 @@ test "runIfRequested invalid resume writes usage" {
     const result = try runIfRequestedWithDeps(std.testing.allocator, &.{ @constCast("resume"), @constCast("a"), @constCast("b") }, testConfig(), capture.deps());
     try std.testing.expectEqual(RunResult.handled_failure, result);
     try std.testing.expectEqualStrings(
-        "usage: fx --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>\n",
+        "usage: fx session resume [last|<id>] [--record] | session resume --id <id> [--record] | --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>\n",
         capture.stderr.written(),
     );
 }

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1695,7 +1695,8 @@ test "rendered top-level help is a complete CLI navigation page" {
     try std.testing.expect(std.mem.find(u8, text, "Supported for interactive, resume, ask, ACP, PR, and issue launches") == null);
     try std.testing.expect(std.mem.find(u8, text, "Examples:") != null);
     try std.testing.expect(std.mem.find(u8, text, "fx ask \"Explain the changes in this repository\"") != null);
-    try std.testing.expect(std.mem.find(u8, text, "fx --resume last") != null);
+    try std.testing.expect(std.mem.find(u8, text, "fx session resume last") != null);
+    try std.testing.expect(std.mem.find(u8, text, "session resume [last|id]") != null);
     try std.testing.expect(std.mem.find(u8, text, "fx status --json") != null);
     try std.testing.expect(std.mem.find(u8, text, "Run `/help` inside an interactive session for slash commands.") != null);
     try std.testing.expect(std.mem.find(u8, text, "Learn more about 𝒇x:  https://fx.sh/docs") != null);
@@ -1780,7 +1781,7 @@ test "per-command help preserves long resume usage outside top-level index" {
     const text = try renderTopLevelCommandHelp(std.testing.allocator, testTopLevelRegistry(), .@"resume");
     defer std.testing.allocator.free(text);
 
-    try std.testing.expect(std.mem.find(u8, text, "Usage:\n  fx --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Usage:\n  fx session resume [last|<id>] [--record] | session resume --id <id> [--record] | --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>") != null);
     try std.testing.expect(std.mem.find(u8, text, "Options:") != null);
     try std.testing.expect(std.mem.find(u8, text, "--record") != null);
 }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -265,6 +265,7 @@ describe("cli: help", () => {
       expect(r.stdout).not.toContain("-c, -r, --continue");
       expect(r.stdout).toContain("--resume [last|<id>]");
       expect(r.stdout).toContain("--resume-last");
+      expect(r.stdout).toContain("session resume [last|id]");
       expect(r.stdout).toContain("-v, --version");
       expect(r.stdout).not.toContain("Must appear before the command");
       expect(r.stdout).toContain("Examples:\n");
@@ -332,6 +333,26 @@ Operational progress and diagnostics are written to stderr. JSON output keeps ra
         expect(result.code).toBe(0);
         expect(result.stderr).toBe("");
         expect(result.stdout).toBe(expected);
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fx session help documents inspect resume migrate and recover",
+    async () => {
+      for (const args of [
+        ["session", "--help"],
+        ["session", "resume", "--help"],
+      ]) {
+        const r = await runFx(args);
+        expect(r.code).toBe(0);
+        expect(r.stderr).toBe("");
+        expect(r.stdout).toContain("Inspect, resume, migrate, or recover saved sessions");
+        expect(r.stdout).toContain("session <last|id>|--id <id>");
+        expect(r.stdout).toContain("session resume [last|<id>]");
+        expect(r.stdout).toContain("session migrate <id>|--id <id>");
+        expect(r.stdout).toContain("session recover <id>|--id <id>");
       }
     },
     TIMEOUT,
@@ -3673,7 +3694,13 @@ describe("cli: interactive startup", () => {
   test(
     "interactive startup without TTY exits one",
     async () => {
-      const cases = [[], ["resume", "last"], ["--resume"]];
+      const cases = [
+        [],
+        ["resume", "last"],
+        ["--resume"],
+        ["session", "resume", "last"],
+        ["session", "resume", "--id", "session.v3"],
+      ];
 
       for (const args of cases) {
         const home = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-no-tty-")));

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -738,6 +738,90 @@ test("volatile status rows normalize before stable-grid comparison", () => {
   expect(normalizeVolatileStatusRows(["  0s (↑6 ↓5)"])).toEqual(["<status>"]);
 });
 
+test.skipIf(!tmuxAvailable())(
+  "session resume command group opens last and explicit session ids",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-session-resume-command-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const seedStderrPath = join(root, "seed-stderr.log");
+    const exactStderrPath = join(root, "exact-stderr.log");
+    const lastStderrPath = join(root, "last-stderr.log");
+    const title = "Save the grouped session resume fixture.";
+    const marker = "GROUPED_SESSION_RESUME_FIXTURE";
+    mkdirSync(home);
+    mkdirSync(workspace);
+    writeFileSync(seedStderrPath, "");
+    writeFileSync(exactStderrPath, "");
+    writeFileSync(lastStderrPath, "");
+
+    const seedGateway = startFakeGateway([fakeGatewayFinalText(marker)]);
+    const resumeGateway = startFakeGateway([]);
+    let active: TmuxSession | null = null;
+    try {
+      active = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: realpathSync(workspace),
+        env: gatewayEnv(home, seedGateway),
+        stderrPath: seedStderrPath,
+        width: 100,
+        height: 30,
+      });
+      await active.waitForComposer(TIMEOUT);
+      await active.sendText(title);
+      await active.waitForText(marker, TIMEOUT);
+      await active.sendText("/quit");
+      expect(await active.waitForSessionEnd(TIMEOUT)).toBe(true);
+      await active.kill();
+      active = null;
+
+      const sessionId = sessionIdFromHome(home);
+      const cases = [
+        {
+          command: `${FX_BIN} session resume --id ${sessionId}`,
+          stderrPath: exactStderrPath,
+        },
+        {
+          command: `${FX_BIN} session resume last`,
+          stderrPath: lastStderrPath,
+        },
+      ];
+      for (const resumeCase of cases) {
+        active = await TmuxSession.create({
+          cmd: resumeCase.command,
+          cwd: realpathSync(workspace),
+          env: gatewayEnv(home, resumeGateway),
+          stderrPath: resumeCase.stderrPath,
+          width: 100,
+          height: 30,
+        });
+        const resumed = await waitForScrollbackMarkers(
+          active,
+          [`● Session resumed: ${title}`, marker],
+          TIMEOUT,
+        );
+        expect(resumed).toContain(marker);
+        expect(active.isPaneAlive()).toBe(true);
+        expect(readFileSync(resumeCase.stderrPath, "utf8")).toBe("");
+        await active.sendText("/quit");
+        expect(await active.waitForSessionEnd(TIMEOUT)).toBe(true);
+        await active.kill();
+        active = null;
+      }
+
+      expect(seedGateway.requests).toHaveLength(1);
+      expect(resumeGateway.requests).toHaveLength(0);
+      expect(readFileSync(seedStderrPath, "utf8")).toBe("");
+    } finally {
+      if (active) await active.kill();
+      seedGateway.stop();
+      resumeGateway.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  TIMEOUT * 2,
+);
+
 function expectAltExitToPreserveNormalViewport(tapePath: string): void {
   const tape = readFileSync(tapePath);
   const leaveAlternate = Buffer.from("\x1b[?1049l");


### PR DESCRIPTION
## Summary

- Add `fx session resume [last|<id>]` and `fx session resume --id <id>` to the session command group.
- Route the grouped syntax through the existing interactive resume launch path, preserving legacy resume aliases and `--record`.
- Document inspect, resume, migrate, and recover consistently in CLI help and the README.
- Add CLI and real-TTY coverage for both latest-session and exact-ID resume paths.

## Testing

- `zig build`
- `zig build test`
- `env PYTHONDONTWRITEBYTECODE=1 python3 -m scripts.pgso.corpus --manifest scripts/pgso/corpus.json --list`
- `cd tests/e2e && bun test --max-concurrency 1 --test-name-pattern 'fx session help|interactive startup without TTY|fx help exits 0 and renders' ./cli.test.ts`
- `cd tests/e2e && bun test --max-concurrency 1 --test-name-pattern 'session resume command group' ./tui-resume.test.ts`
