### PR TITLE
Support any OpenAI-compatible provider

### DIFF
--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -98,8 +98,13 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .setup,
         .token = "setup",
-        .usage = "setup",
-        .summary = "Configure an AI Gateway API key",
+        .usage = "setup [--base-url <url> [--no-key]] [--gateway]",
+        .summary = "Configure an API key, or a custom OpenAI-compatible endpoint",
+        .options = &.{
+            .{ .flag = "--base-url <url>", .description = "Use a custom OpenAI-compatible endpoint and store its key" },
+            .{ .flag = "--no-key", .description = "Configure the endpoint without a key, for a local server" },
+            .{ .flag = "--gateway", .description = "Clear the custom endpoint and use Vercel AI Gateway" },
+        },
     },
     .{
         .kind = .status,

--- a/src/builtins/openai_compat.zig
+++ b/src/builtins/openai_compat.zig
@@ -1,0 +1,486 @@
+//! Provider bundle for custom OpenAI-compatible endpoints.
+//!
+//! Setting FX_BASE_URL (for example `https://api.openai.com/v1` or
+//! `http://localhost:11434/v1`) routes inference to that endpoint using the
+//! OpenAI chat-completions protocol instead of Vercel AI Gateway. FX_API_KEY
+//! is the only credential ever sent to the custom endpoint; Vercel
+//! credentials resolved by the auth runtime never leave the process in this
+//! mode. Gateway-only features (credits, generation usage reconciliation,
+//! provider-executed web search) degrade to unavailable.
+
+const std = @import("std");
+
+const agent_stream_provider_contract = @import("../core/agent/stream_provider.zig");
+const oauth_transport = @import("../core/auth/oauth_transport.zig");
+const collections = @import("../core/shared/collections.zig");
+const debug_trace = @import("../core/shared/debug_trace.zig");
+const gateway_client = @import("../gateway/client.zig");
+const gateway_failure_diagnostics = @import("../core/gateway/gateway_failure_diagnostics.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const generation_usage_provider = @import("../core/session/generation_usage_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
+const custom_endpoint = @import("../core/config/custom_endpoint.zig");
+const credentials = @import("../core/auth/credentials.zig");
+const openai_json = @import("../core/gateway/openai_json.zig");
+const output_contracts = @import("../core/output/output_contracts.zig");
+const tool_advertisement = @import("../core/tooling/tool_advertisement.zig");
+const web_search_contract = @import("../core/tooling/web_search_contract.zig");
+const web_search_policy = @import("../core/tooling/web_search_policy.zig");
+const web_search_provider = @import("../core/tooling/web_search_provider.zig");
+const builtin_gateway = @import("gateway.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const base_url_env = custom_endpoint.base_url_env;
+pub const api_key_env = custom_endpoint.api_key_env;
+
+const chat_completions_path = "/chat/completions";
+const models_path = "/models";
+const max_endpoint_url_bytes = 2048;
+const models_response_max_bytes: usize = 4 * 1024 * 1024;
+
+/// A custom endpoint is active for this process when FX_BASE_URL holds an
+/// http(s) URL, or `fx setup --base-url` stored one in the user profile.
+pub fn isConfigured() bool {
+    return custom_endpoint.isConfigured();
+}
+
+fn baseUrl() ?[]const u8 {
+    return custom_endpoint.baseUrl();
+}
+
+/// The credential to send to the custom endpoint. FX_API_KEY wins; otherwise
+/// the resolved credential is used, which `credentials.loadSource` guarantees
+/// is endpoint-scoped whenever an endpoint is configured. The keyless
+/// placeholder maps back to sending no Authorization header at all.
+fn endpointCredential(resolved: []const u8) []const u8 {
+    const env_key = custom_endpoint.envApiKey();
+    if (env_key.len > 0) return env_key;
+    if (std.mem.eql(u8, resolved, credentials.custom_endpoint_keyless_placeholder)) return "";
+    return resolved;
+}
+
+var chat_url_buf: [max_endpoint_url_bytes]u8 = undefined;
+var models_url_buf: [max_endpoint_url_bytes]u8 = undefined;
+
+fn endpointUrl(buf: []u8, path: []const u8) ?[]const u8 {
+    const base = baseUrl() orelse return null;
+    @memcpy(buf[0..base.len], base);
+    @memcpy(buf[base.len..][0..path.len], path);
+    return buf[0 .. base.len + path.len];
+}
+
+pub fn chatUrl() ?[]const u8 {
+    return endpointUrl(&chat_url_buf, chat_completions_path);
+}
+
+fn modelsUrl() ?[]const u8 {
+    return endpointUrl(&models_url_buf, models_path);
+}
+
+fn resolveChatUrlForProvider(_: ?*anyopaque, fallback: []const u8) []const u8 {
+    return chatUrl() orelse fallback;
+}
+
+fn buildAgentRequest(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: agent_stream_provider_contract.BuildRequest,
+) anyerror![]u8 {
+    if (request.budget) |budget| {
+        if (budget.cancel_flag) |flag| {
+            if (flag.load(.seq_cst)) return error.Cancelled;
+        }
+    }
+    if (request.verified_images != null or request.response_format != null) {
+        return error.StructuredOutputUnsupportedForProvider;
+    }
+    if (request.vision_mode == .required) return error.VisionUnsupportedForProvider;
+
+    const tools_json = if (request.selected_dynamic_tool_schemas.len > 0)
+        try tool_advertisement.buildGatewayToolsJsonWithSelectedDynamicSchemas(
+            alloc,
+            request.serialized_tools,
+            request.selected_dynamic_tool_schemas,
+        )
+    else
+        request.serialized_tools;
+    defer if (request.selected_dynamic_tool_schemas.len > 0) alloc.free(@constCast(tools_json));
+
+    return openai_json.buildChatCompletionsBody(alloc, .{
+        .model = request.model,
+        .tools_json = tools_json,
+        .messages = request.messages,
+        .tool_choice = request.tool_choice,
+        .max_output_tokens = request.max_output_tokens,
+    });
+}
+
+fn streamAgentCompletion(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: agent_stream_provider_contract.Request,
+) anyerror!agent_stream_provider_contract.Result {
+    const chat_url = chatUrl() orelse return error.OpenAiEndpointUnconfigured;
+    const result = gateway_client.streamGatewayCompletion(
+        alloc,
+        .{
+            .api_key = endpointCredential(request.api_key),
+            .team = null,
+            .session_id = request.session_id,
+            .model = request.model,
+            .retry_count = request.retry_count,
+            .chat_url = chat_url,
+            .payload = request.payload,
+            .protocol = .openai_compat,
+            .trace_ctx = request.trace_ctx,
+            .content_capture_limit = request.content_capture_limit,
+            .delivery = request.delivery,
+            .on_reasoning_chunk = request.on_reasoning_chunk,
+            .on_tool_input_chunk = request.on_tool_input_chunk,
+            .provider_attempt_owner = switch (request.provider_attempt_owner) {
+                .transport => .transport,
+                .agent => .agent,
+            },
+        },
+        request.callback_ctx,
+        request.on_content_chunk,
+        request.on_tool_start,
+        request.cancel_flag,
+    ) catch |err| {
+        request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(
+            err,
+            request.delivery.load(),
+        );
+        return err;
+    };
+    const diagnostics = if (result.status == .ok)
+        gateway_failure_diagnostics.FailureDiagnostics{}
+    else
+        gateway_failure_diagnostics.collect(alloc, request.payload, result.err_body);
+    return .{
+        .status = result.status,
+        .completion = result.completion,
+        .err_body = result.err_body,
+        .generation_origin = "",
+        .reconcile_generation_usage = false,
+        .failure_schema = diagnostics.schema,
+        .failure_request_shape = diagnostics.request_shape,
+        .retry_after_seconds = result.retry_after_seconds,
+        .ownership = .owned,
+    };
+}
+
+fn catalogFailureForStatus(status: std.http.Status) model_catalog.Failure {
+    const code = @intFromEnum(status);
+    if (status == .unauthorized or status == .forbidden) {
+        return .{ .category = .authentication, .http_status = status };
+    }
+    if (status == .too_many_requests) {
+        return .{ .category = .rate_limited, .http_status = status, .retryable = true };
+    }
+    if (code >= 500) {
+        return .{ .category = .gateway_unavailable, .http_status = status, .retryable = true };
+    }
+    return .{ .category = .http_status, .http_status = status };
+}
+
+fn fetchCatalogForProvider(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    input: model_catalog.FetchInput,
+) Allocator.Error!model_catalog.ProviderResult {
+    if (input.cancel_flag) |flag| {
+        if (flag.load(.seq_cst)) return .{ .failure = .{ .category = .cancellation } };
+    }
+    const url = modelsUrl() orelse return .{ .failure = .{ .category = .transport } };
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
+    defer client.deinit();
+
+    var auth_header: ?[]u8 = null;
+    defer if (auth_header) |value| alloc.free(value);
+    var headers: std.http.Client.Request.Headers = .{};
+    headers.user_agent = .{ .override = gateway_client.user_agent };
+    const key = endpointCredential(input.access.authorizationCredential() orelse "");
+    if (key.len > 0) {
+        auth_header = std.fmt.allocPrint(alloc, "Bearer {s}", .{key}) catch |err| return err;
+        headers.authorization = .{ .override = auth_header.? };
+    }
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    const response = client.fetch(.{
+        .location = .{ .url = url },
+        .method = .GET,
+        .headers = headers,
+        .response_writer = &out.writer,
+        .redirect_behavior = .unhandled,
+    }) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        debug_trace.logf("gateway", "openai models fetch failed err={s}", .{@errorName(err)});
+        return .{ .failure = .{ .category = .transport, .retryable = true } };
+    };
+    if (response.status != .ok) return .{ .failure = catalogFailureForStatus(response.status) };
+    if (out.written().len > models_response_max_bytes) {
+        return .{ .failure = .{ .category = .malformed_response } };
+    }
+
+    return parseOpenAiModelCatalog(alloc, out.written());
+}
+
+/// Parses the OpenAI `GET /models` shape: `{"data":[{"id":"...",...}]}`.
+/// Every listed model is treated as a tool-capable language model; context
+/// window and vision support stay unknown and resolve through the local
+/// capability tables.
+fn parseOpenAiModelCatalog(
+    alloc: Allocator,
+    body: []const u8,
+) Allocator.Error!model_catalog.ProviderResult {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, body, .{}) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{ .category = .malformed_response } };
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return .{ .failure = .{ .category = .malformed_response } };
+    const data = parsed.value.object.get("data") orelse
+        return .{ .failure = .{ .category = .malformed_response } };
+    if (data != .array) return .{ .failure = .{ .category = .malformed_response } };
+
+    var entries: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    errdefer model_catalog.freeModelCatalog(alloc, &entries);
+    for (data.array.items) |item| {
+        if (item != .object) continue;
+        const id_value = item.object.get("id") orelse continue;
+        if (id_value != .string or id_value.string.len == 0) continue;
+
+        const id = try alloc.dupe(u8, id_value.string);
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        const released: i64 = if (item.object.get("created")) |created| switch (created) {
+            .integer => |value| value,
+            else => 0,
+        } else 0;
+        try entries.append(alloc, .{
+            .id = id,
+            .model_type = model_type,
+            .released = released,
+            .has_tool_use = true,
+        });
+    }
+    return .{ .catalog = entries };
+}
+
+pub const model_catalog_provider = model_catalog.Provider{
+    .fetch_fn = fetchCatalogForProvider,
+};
+
+fn fetchCliModelCatalog(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    input: gateway_provider.CliModelCatalogInput,
+) gateway_provider.CliModelCatalogResult {
+    const result = model_catalog.fetchWithPublicFallback(model_catalog_provider, alloc, .{
+        .access = input.access,
+        .endpoint = input.endpoint,
+        .cancel_flag = input.cancel_flag,
+        .view = .full,
+    });
+    return switch (result) {
+        .loaded => |loaded| project: {
+            var catalog = loaded.catalog;
+            defer model_catalog.freeModelCatalog(alloc, &catalog);
+            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
+                .access = loaded.provenance.access,
+                .anonymous_fallback_used = loaded.provenance.anonymous_fallback_used,
+                .failure = .{ .category = .resource_exhausted },
+            } };
+            break :project .{ .loaded = .{
+                .ids = ids,
+                .provenance = loaded.provenance,
+            } };
+        },
+        .failed => |failed| .{ .failure = failed },
+    };
+}
+
+fn fetchCredits(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    _: gateway_provider.CreditsLookupInput,
+) output_contracts.CreditsSnapshot {
+    return .{
+        .err_message = alloc.dupe(u8, "credits are not available for a custom FX_BASE_URL endpoint") catch null,
+    };
+}
+
+fn resolvePreferredWebSearchBackends(_: ?*anyopaque) !?[]const web_search_contract.SearchBackendId {
+    return &.{};
+}
+
+fn executeWebSearchProvider(
+    _: ?*anyopaque,
+    _: Allocator,
+    _: web_search_provider.Inputs,
+    _: web_search_contract.ProviderRequest,
+    _: ?web_search_contract.ProgressFn,
+    _: ?*anyopaque,
+) !web_search_contract.ProviderResponse {
+    return error.WebSearchUnsupportedForProvider;
+}
+
+const unavailable_web_search_provider = web_search_provider.Provider{
+    .policy = .{
+        .preferred_backends = &.{},
+        .backend_policies = &.{},
+    },
+    .preferred_backends_fn = resolvePreferredWebSearchBackends,
+    .execute_fn = executeWebSearchProvider,
+};
+
+pub const agent_stream_provider = agent_stream_provider_contract.Provider{
+    .build_fn = buildAgentRequest,
+    .stream_fn = streamAgentCompletion,
+};
+
+pub const chat_url_provider = gateway_provider.ChatUrlProvider{
+    .resolve_fn = resolveChatUrlForProvider,
+};
+
+pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
+    .fetch_fn = fetchCliModelCatalog,
+};
+
+pub const credits_provider = gateway_provider.CreditsProvider{
+    .fetch_fn = fetchCredits,
+};
+
+pub const provider = gateway_provider.Provider{
+    .agent_stream = agent_stream_provider,
+    // fx login continues to manage Vercel sessions even while inference is
+    // routed elsewhere; the OAuth transport never sees the custom endpoint.
+    .oauth_transport = builtin_gateway.oauth_transport_provider,
+    .chat_url = chat_url_provider,
+    .cli_model_catalog = cli_model_catalog_provider,
+    .credits = credits_provider,
+    .generation_usage = generation_usage_provider.unavailable_provider,
+    .web_search = unavailable_web_search_provider,
+    .model_catalog = model_catalog_provider,
+};
+
+var stable_empty_test_environ: ?*std.process.Environ.Map = null;
+
+fn stableEmptyTestEnviron() !*const std.process.Environ.Map {
+    if (stable_empty_test_environ) |map| return map;
+    const alloc = std.heap.page_allocator;
+    const map = try alloc.create(std.process.Environ.Map);
+    map.* = std.process.Environ.Map.init(alloc);
+    stable_empty_test_environ = map;
+    return map;
+}
+
+const EnvOverride = struct {
+    alloc: Allocator,
+    map: std.process.Environ.Map,
+
+    fn install(alloc: Allocator, entries: []const [2][]const u8) !*EnvOverride {
+        _ = try stableEmptyTestEnviron();
+        const self = try alloc.create(EnvOverride);
+        errdefer alloc.destroy(self);
+        self.* = .{ .alloc = alloc, .map = std.process.Environ.Map.init(alloc) };
+        errdefer self.map.deinit();
+        for (entries) |entry| try self.map.put(entry[0], entry[1]);
+        io_mod.setEnvironMap(&self.map);
+        return self;
+    }
+
+    fn deinit(self: *EnvOverride) void {
+        if (stable_empty_test_environ) |map| io_mod.setEnvironMap(map);
+        self.map.deinit();
+        const alloc = self.alloc;
+        alloc.destroy(self);
+    }
+};
+
+test "custom endpoint urls derive from FX_BASE_URL with trailing slash trimmed" {
+    const env = try EnvOverride.install(std.testing.allocator, &.{
+        .{ base_url_env, "http://localhost:11434/v1/" },
+    });
+    defer env.deinit();
+
+    try std.testing.expect(isConfigured());
+    try std.testing.expectEqualStrings("http://localhost:11434/v1/chat/completions", chatUrl().?);
+    try std.testing.expectEqualStrings("http://localhost:11434/v1/models", modelsUrl().?);
+    try std.testing.expectEqualStrings(
+        "http://localhost:11434/v1/chat/completions",
+        chat_url_provider.resolve("https://fallback.test/chat"),
+    );
+}
+
+test "non-http FX_BASE_URL values are rejected" {
+    const env = try EnvOverride.install(std.testing.allocator, &.{
+        .{ base_url_env, "file:///etc/passwd" },
+    });
+    defer env.deinit();
+
+    try std.testing.expect(!isConfigured());
+    try std.testing.expect(chatUrl() == null);
+    try std.testing.expectEqualStrings(
+        "https://fallback.test/chat",
+        chat_url_provider.resolve("https://fallback.test/chat"),
+    );
+}
+
+test "openai model catalog parses the OpenAI list shape" {
+    const body =
+        \\{"object":"list","data":[{"id":"gpt-5.2","object":"model","created":1700000000},{"id":"","object":"model"},{"id":"llama3.3","object":"model"}]}
+    ;
+    const result = try parseOpenAiModelCatalog(std.testing.allocator, body);
+    var entries = switch (result) {
+        .catalog => |catalog| catalog,
+        .failure => return error.TestUnexpectedResult,
+    };
+    defer model_catalog.freeModelCatalog(std.testing.allocator, &entries);
+
+    try std.testing.expectEqual(@as(usize, 2), entries.items.len);
+    try std.testing.expectEqualStrings("gpt-5.2", entries.items[0].id);
+    try std.testing.expect(entries.items[0].has_tool_use);
+    try std.testing.expectEqual(@as(i64, 1_700_000_000), entries.items[0].released);
+    try std.testing.expectEqualStrings("llama3.3", entries.items[1].id);
+}
+
+test "openai model catalog reports malformed and error responses as failures" {
+    const malformed = try parseOpenAiModelCatalog(std.testing.allocator, "not json");
+    try std.testing.expectEqual(
+        model_catalog.FailureCategory.malformed_response,
+        malformed.failure.category,
+    );
+
+    try std.testing.expectEqual(
+        model_catalog.FailureCategory.authentication,
+        catalogFailureForStatus(.unauthorized).category,
+    );
+    try std.testing.expect(catalogFailureForStatus(.internal_server_error).retryable);
+}
+
+test "agent request builder produces openai chat completion bodies" {
+    const shared_types = @import("../core/shared/types.zig");
+    const model_capabilities = @import("../core/config/model_capabilities.zig");
+    const messages = [_]shared_types.ChatMessage{.{ .role = .user, .content = "question" }};
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "llama3.3",
+        .serialized_tools = "[{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read\",\"inputSchema\":{\"type\":\"object\",\"properties\":{}}}]",
+        .messages = &messages,
+        .tool_choice = .auto,
+        .provider_options = model_capabilities.resolveProviderOptions("llama3.3", .auto, false),
+        .max_output_tokens = 2048,
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"llama3.3\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"max_tokens\":2048") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"parameters\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "inputSchema") == null);
+}

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -18,12 +18,22 @@ pub const CredentialRefreshMode = enum {
     force,
 };
 
+/// Must list every `credentials.Source`: the picker indexes selectable sources
+/// through this order while bounding on the full source set, so a missing entry
+/// makes those two disagree.
 const credential_source_order = [_]credentials.Source{
     .vercel_oidc_token,
     .ai_gateway_api_key,
     .fx_login,
     .stored_key,
+    .custom_endpoint,
 };
+
+comptime {
+    if (credential_source_order.len != @typeInfo(credentials.Source).@"enum".fields.len) {
+        @compileError("credential_source_order must list every credentials.Source");
+    }
+}
 
 const SourceProbeFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!bool;
 const CredentialLoaderFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!?credentials.Credential;

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -6,6 +6,7 @@ const io_mod = @import("../shared/io.zig");
 const oauth = @import("oauth.zig");
 const oauth_session = @import("oauth_session.zig");
 const oauth_transport = @import("oauth_transport.zig");
+const custom_endpoint = @import("../config/custom_endpoint.zig");
 const secret = @import("secret.zig");
 const types = @import("../shared/types.zig");
 
@@ -35,6 +36,7 @@ pub const CatalogAuthenticatedSource = enum {
     ai_gateway_api_key,
     fx_login,
     stored_key,
+    custom_endpoint,
 
     fn credentialSource(self: CatalogAuthenticatedSource) Source {
         return switch (self) {
@@ -42,6 +44,7 @@ pub const CatalogAuthenticatedSource = enum {
             .ai_gateway_api_key => .ai_gateway_api_key,
             .fx_login => .fx_login,
             .stored_key => .stored_key,
+            .custom_endpoint => .custom_endpoint,
         };
     }
 };
@@ -133,6 +136,7 @@ pub fn catalogAccessForCredential(
         .vercel_oidc_token => .vercel_oidc_token,
         .ai_gateway_api_key => .ai_gateway_api_key,
         .stored_key => .stored_key,
+        .custom_endpoint => .custom_endpoint,
         .fx_login => blk: {
             const team = team_context orelse
                 return .{ .public_only = .fx_login_team_required };
@@ -222,6 +226,13 @@ pub fn resolvePreferring(
     mode: LoadMode,
     preferred: ?Source,
 ) !Resolution {
+    // A configured endpoint owns resolution outright. Vercel sources are not
+    // consulted at all, so no later step can hand one of their tokens to a
+    // third-party endpoint, and a remembered Vercel preference cannot revive one.
+    if (custom_endpoint.isConfigured()) {
+        return .{ .credential = try loadCustomEndpointCredential(alloc, secret_store) };
+    }
+
     if (preferred) |source| {
         if (source != .stored_key or !secret_store.isDisabled()) {
             const chosen = loadPreferredSource(alloc, transport, secret_store, mode, source) catch |err| blk: {
@@ -279,11 +290,46 @@ pub fn loadSource(
     secret_store: host.SecretStore,
     source: Source,
 ) !?Credential {
+    if (custom_endpoint.isConfigured()) {
+        return loadCustomEndpointCredential(alloc, secret_store);
+    }
     return switch (source) {
         .vercel_oidc_token => loadEnvCredential(alloc, "VERCEL_OIDC_TOKEN", source),
         .ai_gateway_api_key => loadEnvCredential(alloc, "AI_GATEWAY_API_KEY", source),
         .fx_login => loadFxLoginCredential(alloc, transport),
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
+        .custom_endpoint => null,
+    };
+}
+
+/// Stands in for a keyless custom endpoint so a turn is not blocked for want of
+/// a credential. The transport maps it back to "send no Authorization header",
+/// so the value itself never leaves the process.
+pub const custom_endpoint_keyless_placeholder = "fx-custom-endpoint-keyless";
+
+/// A configured custom endpoint takes over credential resolution entirely: a
+/// Vercel token is meaningless to a third-party endpoint, and resolving one
+/// here would put it one layer away from being sent there. Only FX_API_KEY and
+/// the stored key — both of which the user set for this endpoint — can resolve.
+fn loadCustomEndpointCredential(
+    alloc: std.mem.Allocator,
+    secret_store: host.SecretStore,
+) !?Credential {
+    if (try loadEnvCredential(alloc, "FX_API_KEY", .custom_endpoint)) |credential| return credential;
+    if (!secret_store.isDisabled()) {
+        if (loadStoredKeyCredential(alloc, secret_store) catch |err| blk: {
+            if (err == error.OutOfMemory) return err;
+            debug_trace.logf("auth", "custom endpoint stored key load failed err={s}", .{@errorName(err)});
+            break :blk null;
+        }) |stored| {
+            var credential = stored;
+            credential.source = .custom_endpoint;
+            return credential;
+        }
+    }
+    return .{
+        .token = try alloc.dupe(u8, custom_endpoint_keyless_placeholder),
+        .source = .custom_endpoint,
     };
 }
 
@@ -293,8 +339,9 @@ pub fn sourceExists(
     source: Source,
 ) !bool {
     return switch (source) {
-        .vercel_oidc_token => nonEmptyEnvValue("VERCEL_OIDC_TOKEN") != null,
-        .ai_gateway_api_key => nonEmptyEnvValue("AI_GATEWAY_API_KEY") != null,
+        .custom_endpoint => custom_endpoint.isConfigured(),
+        .vercel_oidc_token => !custom_endpoint.isConfigured() and nonEmptyEnvValue("VERCEL_OIDC_TOKEN") != null,
+        .ai_gateway_api_key => !custom_endpoint.isConfigured() and nonEmptyEnvValue("AI_GATEWAY_API_KEY") != null,
         .fx_login => blk: {
             const loaded = oauth_session.load(alloc) catch |err| switch (err) {
                 error.OutOfMemory => return err,
@@ -471,6 +518,7 @@ pub fn sourceLabel(source: Source) []const u8 {
         .ai_gateway_api_key => "AI_GATEWAY_API_KEY",
         .fx_login => "fx login",
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
+        .custom_endpoint => "custom endpoint",
     };
 }
 
@@ -714,6 +762,68 @@ test "source-specific credential loading bypasses generic precedence" {
     try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .ai_gateway_api_key));
     try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .vercel_oidc_token));
     try std.testing.expect(!(try sourceExists(alloc, host.unavailable_secret_store, .stored_key)));
+}
+
+test "a custom endpoint satisfies the api key slot with or without FX_API_KEY" {
+    const alloc = std.testing.allocator;
+    {
+        const env = try CredentialTestEnv.install(alloc, &.{
+            .{ "FX_BASE_URL", "http://localhost:11434/v1" },
+            .{ "FX_API_KEY", "endpoint-key" },
+        });
+        defer env.deinit();
+
+        var credential = (try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .ai_gateway_api_key)).?;
+        defer credential.deinit(alloc);
+        try std.testing.expectEqualStrings("endpoint-key", credential.token);
+        try std.testing.expectEqual(Source.custom_endpoint, credential.source);
+        try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .custom_endpoint));
+    }
+    {
+        const env = try CredentialTestEnv.install(alloc, &.{
+            .{ "FX_BASE_URL", "http://localhost:11434/v1" },
+        });
+        defer env.deinit();
+
+        var keyless = (try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .ai_gateway_api_key)).?;
+        defer keyless.deinit(alloc);
+        try std.testing.expectEqualStrings(custom_endpoint_keyless_placeholder, keyless.token);
+    }
+    {
+        const env = try CredentialTestEnv.install(alloc, &.{
+            .{ "FX_API_KEY", "ignored-without-base-url" },
+        });
+        defer env.deinit();
+
+        try std.testing.expect((try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .ai_gateway_api_key)) == null);
+        try std.testing.expect(!(try sourceExists(alloc, host.unavailable_secret_store, .ai_gateway_api_key)));
+        try std.testing.expect(!(try sourceExists(alloc, host.unavailable_secret_store, .custom_endpoint)));
+    }
+}
+
+test "a configured endpoint keeps Vercel credentials out of resolution" {
+    const alloc = std.testing.allocator;
+    const env = try CredentialTestEnv.install(alloc, &.{
+        .{ "VERCEL_OIDC_TOKEN", "oidc-token" },
+        .{ "AI_GATEWAY_API_KEY", "gateway-key" },
+        .{ "FX_BASE_URL", "http://localhost:11434/v1" },
+        .{ "FX_API_KEY", "endpoint-key" },
+    });
+    defer env.deinit();
+
+    // Every source resolves to the endpoint credential, so no code path can
+    // hand a Vercel token to a third-party endpoint.
+    for ([_]Source{ .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key }) |source| {
+        var credential = (try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, source)).?;
+        defer credential.deinit(alloc);
+        try std.testing.expectEqualStrings("endpoint-key", credential.token);
+    }
+    try std.testing.expect(!(try sourceExists(alloc, host.unavailable_secret_store, .vercel_oidc_token)));
+
+    const resolution = try resolve(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .refresh_if_needed);
+    var selected = resolution.credential orelse return error.TestExpectedCredential;
+    defer selected.deinit(alloc);
+    try std.testing.expectEqualStrings("endpoint-key", selected.token);
 }
 
 test "a remembered choice outranks the environment" {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -10,6 +10,7 @@ const cli_replay = @import("cli_replay.zig");
 const command_specs = @import("../slash_commands/command_specs.zig");
 const collections = @import("../shared/collections.zig");
 const config_runtime = @import("../config/config_runtime.zig");
+const custom_endpoint = @import("../config/custom_endpoint.zig");
 const devbox_executor = @import("../execution/devbox_executor.zig");
 const doctor_runtime = @import("doctor_runtime.zig");
 const gateway_provider = @import("../gateway/gateway_provider.zig");
@@ -772,11 +773,11 @@ fn runNonInteractiveWithDeps(
             return .handled_success;
         },
         .setup => |rest| {
-            if (rest.len != 0) {
+            const opts = parseSetupArgs(rest) catch {
                 try writeTopLevelUsage(cfg.command_catalog, deps, .setup);
                 return .handled_failure;
-            }
-            return if (try runPasteSetup(alloc, cfg.secret_store, deps)) .handled_success else .handled_failure;
+            };
+            return if (try runSetup(alloc, cfg.secret_store, deps, opts)) .handled_success else .handled_failure;
         },
         .status => |rest| {
             const opts = parseLocalSurfaceArgs(rest) catch |err| {
@@ -1458,6 +1459,127 @@ fn writeStderr(deps: RunDeps, text: []const u8) !void {
     try deps.write_stderr(deps.stderr_ctx, text);
 }
 
+const SetupOptions = struct {
+    /// Endpoint to configure, or null to configure AI Gateway.
+    base_url: ?[]const u8 = null,
+    /// Removes a stored endpoint and returns inference to AI Gateway.
+    clear_base_url: bool = false,
+    /// Configures an endpoint that takes no credential, such as a local server.
+    no_key: bool = false,
+};
+
+fn parseSetupArgs(args: []const [:0]const u8) !SetupOptions {
+    var options = SetupOptions{};
+    var base_url_seen = false;
+    var no_key_seen = false;
+    var index: usize = 0;
+    while (index < args.len) : (index += 1) {
+        const arg = args[index];
+        if (std.mem.eql(u8, arg, "--no-key")) {
+            if (no_key_seen) return error.InvalidSetupArgs;
+            no_key_seen = true;
+            options.no_key = true;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--gateway")) {
+            if (base_url_seen) return error.InvalidSetupArgs;
+            base_url_seen = true;
+            options.clear_base_url = true;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--base-url")) {
+            if (base_url_seen or index + 1 >= args.len) return error.InvalidSetupArgs;
+            base_url_seen = true;
+            index += 1;
+            options.base_url = args[index];
+            continue;
+        }
+        if (std.mem.startsWith(u8, arg, "--base-url=")) {
+            if (base_url_seen) return error.InvalidSetupArgs;
+            base_url_seen = true;
+            options.base_url = arg["--base-url=".len..];
+            continue;
+        }
+        return error.InvalidSetupArgs;
+    }
+    if (options.no_key and options.base_url == null) return error.InvalidSetupArgs;
+    return options;
+}
+
+fn runSetup(
+    alloc: Allocator,
+    secret_store: host.SecretStore,
+    deps: RunDeps,
+    options: SetupOptions,
+) !bool {
+    if (options.clear_base_url) return runGatewayReset(alloc, deps);
+    if (options.base_url) |base_url| {
+        return runEndpointSetup(alloc, secret_store, deps, base_url, options.no_key);
+    }
+    return runPasteSetup(alloc, secret_store, deps);
+}
+
+fn runGatewayReset(alloc: Allocator, deps: RunDeps) !bool {
+    var cleared = config_runtime.setUserPreferences(alloc, .{ .clear_base_url = true }) catch {
+        try writeStderr(deps, "fx setup: could not update the stored endpoint\n");
+        return false;
+    };
+    cleared.deinit(alloc);
+    custom_endpoint.invalidateStored();
+    try writeStdout(deps, "Cleared the custom endpoint. Inference uses Vercel AI Gateway.\n");
+    return true;
+}
+
+/// Stores the endpoint in the user profile and its key in the secret store.
+/// The key is optional so a keyless local server (Ollama, LM Studio) can be
+/// configured in one step.
+fn runEndpointSetup(
+    alloc: Allocator,
+    secret_store: host.SecretStore,
+    deps: RunDeps,
+    raw_base_url: []const u8,
+    no_key: bool,
+) !bool {
+    const base_url = custom_endpoint.normalize(raw_base_url) orelse {
+        try writeStderr(deps, "fx setup: --base-url must be an http(s) URL without credentials, for example https://api.openai.com/v1\n");
+        return false;
+    };
+
+    var stored = config_runtime.setUserPreferences(alloc, .{ .base_url = base_url }) catch {
+        try writeStderr(deps, "fx setup: could not save the endpoint\n");
+        return false;
+    };
+    stored.deinit(alloc);
+    custom_endpoint.invalidateStored();
+
+    const saved = try std.fmt.allocPrint(alloc, "Saved endpoint {s}.\n", .{base_url});
+    defer alloc.free(saved);
+    try writeStdout(deps, saved);
+
+    if (no_key) {
+        try writeStdout(deps, "Requests to this endpoint are sent without an API key.\n");
+        return true;
+    }
+    if (custom_endpoint.envApiKey().len > 0) {
+        try writeStdout(deps, "Using the API key from FX_API_KEY.\n");
+        return true;
+    }
+    if (secret_store.isDisabled()) {
+        try writeStdout(deps, "Stored API keys are disabled by FX_DISABLE_KEYCHAIN; set FX_API_KEY for this endpoint.\n");
+        return true;
+    }
+    if (!deps.setup_terminal_available(deps.setup_ctx)) {
+        try writeStdout(deps, "Set FX_API_KEY for this endpoint, or run fx setup from a terminal to store its key.\n");
+        return true;
+    }
+    return storeApiKey(
+        alloc,
+        secret_store,
+        deps,
+        "Paste the API key for this endpoint (input hidden): ",
+    );
+}
+
 fn runPasteSetup(
     alloc: Allocator,
     secret_store: host.SecretStore,
@@ -1471,8 +1593,18 @@ fn runPasteSetup(
         try writeStderr(deps, "fx setup: an interactive terminal is required to paste an API key\n");
         return false;
     }
+    return storeApiKey(alloc, secret_store, deps, "Paste AI Gateway API key (input hidden): ");
+}
 
-    try writeStderr(deps, "Paste AI Gateway API key (input hidden): ");
+/// Prefers the platform's own secure prompt so plaintext never enters this
+/// process, falling back to a masked read where no such prompt exists.
+fn storeApiKey(
+    alloc: Allocator,
+    secret_store: host.SecretStore,
+    deps: RunDeps,
+    prompt: []const u8,
+) !bool {
+    try writeStderr(deps, prompt);
     const stored_interactively = secret_store.storeInteractive() catch {
         try writeStderr(deps, "\nfx setup: API key was not saved\n");
         return false;
@@ -1688,6 +1820,7 @@ fn statusSnapshotFromStartupWithBuild(
 ) output_contracts.StatusSnapshot {
     return .{
         .model = startup.selected_model,
+        .endpoint = custom_endpoint.baseUrl(),
         .auth = startup.auth,
         .auth_help = startup.auth.missingHelp(.cli),
         .permission_mode = permissionModeForSnapshot(startup.permission_mode),
@@ -3962,6 +4095,54 @@ test "setup delegates secure input to an interactive host store" {
     try std.testing.expectEqual(@as(usize, 1), capture.setup_store_calls);
     try std.testing.expectEqual(@as(usize, 0), capture.setup_read_calls);
     try std.testing.expect(!capture.setup_value_matched);
+}
+
+test "setup parses endpoint arguments and rejects conflicting ones" {
+    const endpoint = try parseSetupArgs(&.{ @constCast("--base-url"), @constCast("https://api.openai.com/v1") });
+    try std.testing.expectEqualStrings("https://api.openai.com/v1", endpoint.base_url.?);
+    try std.testing.expect(!endpoint.no_key);
+
+    const inline_form = try parseSetupArgs(&.{@constCast("--base-url=http://localhost:11434/v1")});
+    try std.testing.expectEqualStrings("http://localhost:11434/v1", inline_form.base_url.?);
+
+    const keyless = try parseSetupArgs(&.{
+        @constCast("--base-url"),
+        @constCast("http://localhost:11434/v1"),
+        @constCast("--no-key"),
+    });
+    try std.testing.expect(keyless.no_key);
+
+    const gateway = try parseSetupArgs(&.{@constCast("--gateway")});
+    try std.testing.expect(gateway.clear_base_url);
+    try std.testing.expect(gateway.base_url == null);
+
+    try std.testing.expectEqual(SetupOptions{}, try parseSetupArgs(&.{}));
+    try std.testing.expectError(error.InvalidSetupArgs, parseSetupArgs(&.{@constCast("--base-url")}));
+    try std.testing.expectError(error.InvalidSetupArgs, parseSetupArgs(&.{@constCast("--no-key")}));
+    try std.testing.expectError(error.InvalidSetupArgs, parseSetupArgs(&.{
+        @constCast("--gateway"),
+        @constCast("--base-url"),
+        @constCast("https://api.openai.com/v1"),
+    }));
+    try std.testing.expectError(error.InvalidSetupArgs, parseSetupArgs(&.{@constCast("--unknown")}));
+}
+
+test "setup rejects an endpoint url that is not a credential-free http origin" {
+    var capture = CaptureOutput.init(std.testing.allocator);
+    defer capture.deinit();
+    var cfg = testConfig();
+    cfg.secret_store = capture.secretStore();
+
+    const result = try runIfRequestedWithDeps(
+        std.testing.allocator,
+        &.{ @constCast("setup"), @constCast("--base-url"), @constCast("https://user:pass@api.openai.com/v1") },
+        cfg,
+        capture.deps(),
+    );
+
+    try std.testing.expectEqual(RunResult.handled_failure, result);
+    try std.testing.expectEqual(@as(usize, 0), capture.setup_store_calls);
+    try std.testing.expect(std.mem.find(u8, capture.stderr.written(), "--base-url must be an http(s) URL") != null);
 }
 
 test "setup preserves the disabled secret-store failure" {

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -37,6 +37,8 @@ pub const Paths = struct {
 
 pub const Settings = struct {
     model: ?[]u8 = null,
+    /// Base URL of a custom OpenAI-compatible endpoint, when configured.
+    base_url: ?[]u8 = null,
     permission_mode: ?types.PermissionMode = null,
     credential_source: ?types.CredentialSource = null,
     yolo_acknowledged: ?bool = null,
@@ -66,6 +68,7 @@ pub const Settings = struct {
 
     pub fn deinit(self: *Settings, alloc: Allocator) void {
         if (self.model) |value| alloc.free(value);
+        if (self.base_url) |value| alloc.free(value);
         if (self.input_appearance) |value| alloc.free(value);
         if (self.maxxing_mode) |value| alloc.free(value);
         if (self.sandbox) |value| alloc.free(value);
@@ -541,6 +544,7 @@ fn hasLegacyWorkspacePreferences(root: std.json.Value) bool {
 fn isProfileOnlySettingKey(key: []const u8) bool {
     inline for (&.{
         "model",
+        "base_url",
         "effort",
         "fast_mode",
         "input_appearance",
@@ -1321,6 +1325,13 @@ fn parseProfileOnlyFields(
             return error.InvalidCredentialSource;
     }
 
+    if (root.object.get("base_url")) |base_url_value| {
+        if (base_url_value != .string) return error.InvalidBaseUrlType;
+        settings_store.validateBaseUrl(base_url_value.string) catch return error.InvalidBaseUrl;
+        if (settings.base_url) |existing| alloc.free(existing);
+        settings.base_url = try alloc.dupe(u8, base_url_value.string);
+    }
+
     if (root.object.get("yolo_acknowledged")) |acknowledged_value| {
         if (acknowledged_value != .bool) return error.InvalidYoloAcknowledgedType;
         settings.yolo_acknowledged = acknowledged_value.bool;
@@ -1488,6 +1499,11 @@ fn mergeSettings(target: *Settings, incoming: *Settings, alloc: Allocator) void 
         if (target.model) |current| alloc.free(current);
         target.model = value;
         incoming.model = null;
+    }
+    if (incoming.base_url) |value| {
+        if (target.base_url) |current| alloc.free(current);
+        target.base_url = value;
+        incoming.base_url = null;
     }
     if (incoming.permission_mode) |value| target.permission_mode = value;
     if (incoming.credential_source) |value| target.credential_source = value;

--- a/src/core/config/custom_endpoint.zig
+++ b/src/core/config/custom_endpoint.zig
@@ -1,0 +1,115 @@
+//! Resolves the custom OpenAI-compatible endpoint configuration.
+//!
+//! The endpoint is ambient configuration shared by credential resolution and
+//! the provider transport, so it lives in core rather than in either caller.
+//! It comes from FX_BASE_URL, or from the `base_url` key that
+//! `fx setup --base-url` writes to the user profile.
+
+const std = @import("std");
+const io_mod = @import("../shared/io.zig");
+const settings_store = @import("settings_store.zig");
+
+pub const base_url_env = "FX_BASE_URL";
+pub const api_key_env = "FX_API_KEY";
+
+pub const max_base_url_bytes: usize = settings_store.base_url_max_bytes;
+/// Longest route the transport appends to the base URL.
+const max_appended_path_bytes: usize = "/chat/completions".len;
+
+var stored_base_url_buf: [max_base_url_bytes]u8 = undefined;
+var stored_base_url: ?[]const u8 = null;
+var stored_base_url_loaded = false;
+
+/// True when inference should use the custom endpoint instead of AI Gateway.
+pub fn isConfigured() bool {
+    return baseUrl() != null;
+}
+
+/// The normalized endpoint origin, without a trailing slash.
+///
+/// Reads the user profile, so it must not be called before process IO is
+/// installed. Callers that run during early startup use `envBaseUrl`.
+pub fn baseUrl() ?[]const u8 {
+    if (envBaseUrl()) |from_env| return from_env;
+    return storedBaseUrl();
+}
+
+/// The endpoint from the environment only. Safe at any point in startup
+/// because it performs no IO.
+pub fn envBaseUrl() ?[]const u8 {
+    const raw = io_mod.getenv(base_url_env) orelse return null;
+    return normalize(raw);
+}
+
+/// The endpoint credential from the environment. Empty means the caller should
+/// fall back to the stored key, or send no credential at all.
+pub fn envApiKey() []const u8 {
+    const raw = io_mod.getenv(api_key_env) orelse return "";
+    if (std.mem.trim(u8, raw, " \t\r\n").len == 0) return "";
+    return raw;
+}
+
+/// Drops the cached profile value so the next lookup re-reads it. Called after
+/// `fx setup` changes the endpoint.
+pub fn invalidateStored() void {
+    stored_base_url_loaded = false;
+    stored_base_url = null;
+}
+
+pub fn normalize(raw: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trimEnd(u8, std.mem.trim(u8, raw, " \t\r\n"), "/");
+    if (trimmed.len == 0) return null;
+    if (trimmed.len + max_appended_path_bytes > max_base_url_bytes) return null;
+    settings_store.validateBaseUrl(trimmed) catch return null;
+    return trimmed;
+}
+
+/// The profile is read directly rather than through the merged config runtime
+/// because both callers need this value before merged settings exist. Only
+/// this one key is consulted, and the result is cached for the process.
+fn storedBaseUrl() ?[]const u8 {
+    if (stored_base_url_loaded) return stored_base_url;
+    stored_base_url_loaded = true;
+    stored_base_url = null;
+
+    const alloc = std.heap.c_allocator;
+    const home = io_mod.getenv("HOME") orelse return null;
+    var store = settings_store.Store.initFromHome(alloc, home, .read_only) catch return null;
+    defer store.deinit(alloc);
+    var primary = store.loadPrimary(alloc) catch return null;
+    defer primary.deinit(alloc);
+    const bytes = switch (primary) {
+        .valid => |value| value,
+        else => return null,
+    };
+
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const value = parsed.value.object.get("base_url") orelse return null;
+    if (value != .string) return null;
+    const normalized = normalize(value.string) orelse return null;
+    @memcpy(stored_base_url_buf[0..normalized.len], normalized);
+    stored_base_url = stored_base_url_buf[0..normalized.len];
+    return stored_base_url;
+}
+
+test "normalize accepts http origins and trims trailing slashes" {
+    try std.testing.expectEqualStrings(
+        "http://localhost:11434/v1",
+        normalize("  http://localhost:11434/v1/  ").?,
+    );
+    try std.testing.expectEqualStrings(
+        "https://api.openai.com/v1",
+        normalize("https://api.openai.com/v1").?,
+    );
+}
+
+test "normalize rejects non-http, empty, and credential-bearing urls" {
+    try std.testing.expect(normalize("") == null);
+    try std.testing.expect(normalize("   ") == null);
+    try std.testing.expect(normalize("file:///etc/passwd") == null);
+    try std.testing.expect(normalize("api.openai.com/v1") == null);
+    try std.testing.expect(normalize("https://user:pass@api.openai.com/v1") == null);
+    try std.testing.expect(normalize("https://exa mple.com/v1") == null);
+}

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -88,6 +88,12 @@ pub const WorkspaceDirectoryMutation = struct {
 
 pub const UserSettingsPatch = struct {
     model: ?[]const u8 = null,
+    /// Base URL of a custom OpenAI-compatible endpoint. Routes inference away
+    /// from Vercel AI Gateway for every surface.
+    base_url: ?[]const u8 = null,
+    /// Removes the key entirely so inference returns to AI Gateway. Distinct
+    /// from a null `base_url`, which means "leave unchanged".
+    clear_base_url: bool = false,
     permission_mode: ?types.PermissionMode = null,
     credential_source: ?types.CredentialSource = null,
     /// Removes the key entirely so resolution returns to plain precedence.
@@ -109,6 +115,8 @@ pub const UserSettingsPatch = struct {
 
     fn isEmpty(self: UserSettingsPatch) bool {
         return self.model == null and
+            self.base_url == null and
+            !self.clear_base_url and
             self.permission_mode == null and
             self.credential_source == null and
             !self.clear_credential_source and
@@ -908,12 +916,72 @@ fn validAdditionalDirectoryPath(path: []const u8) bool {
         std.mem.findScalar(u8, path, 0) == null;
 }
 
+pub const base_url_max_bytes: usize = 2048;
+
+/// Accepts only an absolute http(s) origin with a path, which is what the
+/// OpenAI-compatible transport appends its routes to.
+pub fn validateBaseUrl(base_url: []const u8) !void {
+    if (base_url.len == 0 or base_url.len > base_url_max_bytes) return error.InvalidBaseUrl;
+    if (!std.mem.startsWith(u8, base_url, "https://") and
+        !std.mem.startsWith(u8, base_url, "http://")) return error.InvalidBaseUrl;
+    const scheme_end = (std.mem.find(u8, base_url, "://") orelse return error.InvalidBaseUrl) + 3;
+    if (scheme_end >= base_url.len) return error.InvalidBaseUrl;
+    for (base_url) |byte| {
+        if (byte <= ' ' or byte == 127) return error.InvalidBaseUrl;
+    }
+    if (std.mem.find(u8, base_url[scheme_end..], "@") != null) return error.InvalidBaseUrl;
+}
+
 pub fn validateInputAppearance(appearance: []const u8) !void {
     if (!input_appearance.InputAppearance.isPersistedLabel(appearance)) return error.InvalidDurableField;
 }
 
 pub fn validateMaxxingMode(mode: []const u8) !void {
     if (!presentation_mode.MaxxingMode.isPersistedLabel(mode)) return error.InvalidDurableField;
+}
+
+test "base_url round-trips through the user patch and clears to absent" {
+    const alloc = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+
+    var root = try std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), "{}", .{});
+    var application = try applyUserPatchToRoot(arena.allocator(), &root, .{
+        .base_url = "https://api.openai.com/v1",
+    });
+    try std.testing.expect(application.changed);
+    try std.testing.expectEqualStrings(
+        "https://api.openai.com/v1",
+        root.object.get("base_url").?.string,
+    );
+    try validateKnownSettingsObject(root.object, false);
+
+    application = try applyUserPatchToRoot(arena.allocator(), &root, .{ .clear_base_url = true });
+    try std.testing.expect(application.changed);
+    try std.testing.expect(!root.object.contains("base_url"));
+
+    application = try applyUserPatchToRoot(arena.allocator(), &root, .{ .clear_base_url = true });
+    try std.testing.expect(!application.changed);
+}
+
+test "settings validation rejects a base_url that is not a credential-free http origin" {
+    const alloc = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+
+    for ([_][]const u8{
+        "{\"base_url\":\"api.openai.com/v1\"}",
+        "{\"base_url\":\"file:///etc/passwd\"}",
+        "{\"base_url\":\"https://user:pass@api.openai.com/v1\"}",
+        "{\"base_url\":\"\"}",
+        "{\"base_url\":42}",
+    }) |text| {
+        const root = try std.json.parseFromSliceLeaky(std.json.Value, arena.allocator(), text, .{});
+        try std.testing.expectError(
+            error.InvalidSettingsFormat,
+            validateKnownSettingsObject(root.object, false),
+        );
+    }
 }
 
 test "clearing the credential choice removes the key rather than blanking it" {
@@ -977,6 +1045,11 @@ fn applyUserPatchToRoot(
 ) !PatchApplication {
     var application = PatchApplication{};
     if (patch.model) |value| application.changed = try putString(arena, &root.object, "model", value) or application.changed;
+    if (patch.base_url) |value| application.changed = try putString(arena, &root.object, "base_url", value) or application.changed;
+    if (patch.clear_base_url and root.object.contains("base_url")) {
+        _ = root.object.orderedRemove("base_url");
+        application.changed = true;
+    }
     if (patch.permission_mode) |value| application.changed = try putString(arena, &root.object, "permission_mode", @tagName(value)) or application.changed;
     if (patch.credential_source) |value| application.changed = try putString(arena, &root.object, "credential_source", @tagName(value)) or application.changed;
     if (patch.clear_credential_source and root.object.contains("credential_source")) {
@@ -1668,6 +1741,10 @@ fn validateKnownSettingsObject(
         if (value != .string or types.parseCredentialSource(value.string) == null) {
             return error.InvalidSettingsFormat;
         }
+    }
+    if (object.get("base_url")) |value| {
+        if (value != .string) return error.InvalidSettingsFormat;
+        validateBaseUrl(value.string) catch return error.InvalidSettingsFormat;
     }
     if (object.get("max_agent_steps")) |value| {
         if (value != .integer or value.integer < 0) return error.InvalidSettingsFormat;

--- a/src/core/gateway/openai_json.zig
+++ b/src/core/gateway/openai_json.zig
@@ -1,0 +1,229 @@
+//! Serializes agent requests into the OpenAI chat-completions wire format.
+//!
+//! This is the request-body sibling of `gateway_json.zig` for custom
+//! OpenAI-compatible endpoints. Tools arrive in the AI SDK flat schema
+//! (`{"type":"function","name",...,"inputSchema":...}`) and are re-emitted in
+//! the nested OpenAI envelope (`{"type":"function","function":{...}}`).
+
+const std = @import("std");
+const gateway_json = @import("gateway_json.zig");
+const types = @import("../shared/types.zig");
+
+const ChatMessage = types.ChatMessage;
+
+pub const BuildInput = struct {
+    model: []const u8,
+    /// AI SDK flat tools JSON array, as produced by tool advertisement.
+    tools_json: []const u8,
+    messages: []const ChatMessage,
+    tool_choice: types.ToolChoice,
+    max_output_tokens: ?u32 = null,
+};
+
+pub fn buildChatCompletionsBody(alloc: std.mem.Allocator, input: BuildInput) ![]u8 {
+    try gateway_json.validateToolMessageHistory(alloc, input.messages);
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+
+    try out.writer.writeAll("{\"model\":");
+    try std.json.Stringify.value(input.model, .{}, &out.writer);
+    try out.writer.writeAll(",\"stream\":true,\"stream_options\":{\"include_usage\":true},\"messages\":[");
+    for (input.messages, 0..) |message, i| {
+        if (i > 0) try out.writer.writeByte(',');
+        try writeChatMessageJson(&out.writer, message);
+    }
+    try out.writer.writeByte(']');
+
+    const tool_count = try writeTools(alloc, &out.writer, input.tools_json);
+    if (tool_count > 0) {
+        try out.writer.writeAll(",\"tool_choice\":");
+        try std.json.Stringify.value(input.tool_choice.label(), .{}, &out.writer);
+    }
+    if (input.max_output_tokens) |value| {
+        try out.writer.print(",\"max_tokens\":{d}", .{value});
+    }
+    try out.writer.writeByte('}');
+    return try out.toOwnedSlice();
+}
+
+fn writeChatMessageJson(writer: *std.Io.Writer, message: ChatMessage) !void {
+    if (message.images.len > 0) return error.ImageInputUnsupported;
+
+    try writer.writeAll("{\"role\":");
+    try std.json.Stringify.value(gateway_json.roleName(message.role), .{}, writer);
+    switch (message.role) {
+        .system, .user => {
+            try writer.writeAll(",\"content\":");
+            try std.json.Stringify.value(message.content orelse "", .{}, writer);
+        },
+        .assistant => {
+            try writer.writeAll(",\"content\":");
+            if (message.content) |content| {
+                try std.json.Stringify.value(content, .{}, writer);
+            } else if (message.tool_calls.len == 0) {
+                try writer.writeAll("\"\"");
+            } else {
+                try writer.writeAll("null");
+            }
+            if (message.tool_calls.len > 0) {
+                try writer.writeAll(",\"tool_calls\":[");
+                for (message.tool_calls, 0..) |tool_call, i| {
+                    if (i > 0) try writer.writeByte(',');
+                    try writer.writeAll("{\"id\":");
+                    try std.json.Stringify.value(tool_call.id, .{}, writer);
+                    try writer.writeAll(",\"type\":\"function\",\"function\":{\"name\":");
+                    try std.json.Stringify.value(tool_call.name, .{}, writer);
+                    // OpenAI carries function arguments as a JSON-encoded string.
+                    try writer.writeAll(",\"arguments\":");
+                    try std.json.Stringify.value(tool_call.arguments_json, .{}, writer);
+                    try writer.writeAll("}}");
+                }
+                try writer.writeByte(']');
+            }
+        },
+        .tool => {
+            try writer.writeAll(",\"tool_call_id\":");
+            try std.json.Stringify.value(message.tool_call_id orelse "", .{}, writer);
+            try writer.writeAll(",\"content\":");
+            try std.json.Stringify.value(message.content orelse "", .{}, writer);
+        },
+    }
+    try writer.writeByte('}');
+}
+
+/// Re-emits AI SDK flat function tools in the OpenAI nested envelope.
+/// Provider-executed tools have no OpenAI equivalent and are skipped.
+/// Returns the number of tools written; zero writes no "tools" key at all.
+fn writeTools(alloc: std.mem.Allocator, writer: *std.Io.Writer, tools_json: []const u8) !usize {
+    if (tools_json.len == 0) return 0;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, tools_json, .{}) catch {
+        return error.InvalidToolAdvertisement;
+    };
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidToolAdvertisement;
+
+    var written: usize = 0;
+    for (parsed.value.array.items) |tool| {
+        if (tool != .object) return error.InvalidToolAdvertisement;
+        const tool_type = tool.object.get("type") orelse return error.InvalidToolAdvertisement;
+        if (tool_type != .string) return error.InvalidToolAdvertisement;
+        if (!std.mem.eql(u8, tool_type.string, "function")) continue;
+        const name = tool.object.get("name") orelse return error.InvalidToolAdvertisement;
+        if (name != .string) return error.InvalidToolAdvertisement;
+
+        try writer.writeAll(if (written == 0) ",\"tools\":[" else ",");
+        try writer.writeAll("{\"type\":\"function\",\"function\":{\"name\":");
+        try std.json.Stringify.value(name.string, .{}, writer);
+        if (tool.object.get("description")) |description| {
+            if (description == .string) {
+                try writer.writeAll(",\"description\":");
+                try std.json.Stringify.value(description.string, .{}, writer);
+            }
+        }
+        if (tool.object.get("inputSchema")) |schema| {
+            try writer.writeAll(",\"parameters\":");
+            try std.json.Stringify.value(schema, .{}, writer);
+        }
+        try writer.writeAll("}}");
+        written += 1;
+    }
+    if (written > 0) try writer.writeByte(']');
+    return written;
+}
+
+test "openai body carries model, messages, and translated tools" {
+    const messages = [_]ChatMessage{
+        .{ .role = .system, .content = "be brief" },
+        .{ .role = .user, .content = "hi" },
+    };
+    const tools_json =
+        \\[{"type":"function","name":"read_file","description":"Read","inputSchema":{"type":"object","properties":{"path":{"type":"string"}}}},{"type":"provider","id":"gateway.perplexity_search","name":"perplexity_search","args":{}}]
+    ;
+    const body = try buildChatCompletionsBody(std.testing.allocator, .{
+        .model = "gpt-5.2",
+        .tools_json = tools_json,
+        .messages = &messages,
+        .tool_choice = .auto,
+        .max_output_tokens = 4096,
+    });
+    defer std.testing.allocator.free(body);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+
+    try std.testing.expectEqualStrings("gpt-5.2", root.get("model").?.string);
+    try std.testing.expect(root.get("stream").?.bool);
+    try std.testing.expectEqual(@as(usize, 2), root.get("messages").?.array.items.len);
+    const tools = root.get("tools").?.array;
+    try std.testing.expectEqual(@as(usize, 1), tools.items.len);
+    const function = tools.items[0].object.get("function").?.object;
+    try std.testing.expectEqualStrings("read_file", function.get("name").?.string);
+    try std.testing.expect(function.get("parameters").?.object.get("properties") != null);
+    try std.testing.expectEqualStrings("auto", root.get("tool_choice").?.string);
+    try std.testing.expectEqual(@as(i64, 4096), root.get("max_tokens").?.integer);
+}
+
+test "openai body round-trips assistant tool calls and tool results" {
+    const calls = [_]types.ToolCall{.{
+        .id = "call_1",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"a.txt\"}",
+    }};
+    const messages = [_]ChatMessage{
+        .{ .role = .user, .content = "read a.txt" },
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = "call_1", .tool_name = "read_file", .content = "contents" },
+    };
+    const body = try buildChatCompletionsBody(std.testing.allocator, .{
+        .model = "llama3.3",
+        .tools_json = "[]",
+        .messages = &messages,
+        .tool_choice = .auto,
+    });
+    defer std.testing.allocator.free(body);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try std.testing.expect(root.get("tools") == null);
+    try std.testing.expect(root.get("tool_choice") == null);
+    try std.testing.expect(root.get("max_tokens") == null);
+
+    const message_items = root.get("messages").?.array.items;
+    const assistant = message_items[1].object;
+    try std.testing.expect(assistant.get("content").? == .null);
+    const tool_call = assistant.get("tool_calls").?.array.items[0].object;
+    try std.testing.expectEqualStrings("call_1", tool_call.get("id").?.string);
+    try std.testing.expectEqualStrings(
+        "{\"path\":\"a.txt\"}",
+        tool_call.get("function").?.object.get("arguments").?.string,
+    );
+    const tool_result = message_items[2].object;
+    try std.testing.expectEqualStrings("tool", tool_result.get("role").?.string);
+    try std.testing.expectEqualStrings("call_1", tool_result.get("tool_call_id").?.string);
+    try std.testing.expectEqualStrings("contents", tool_result.get("content").?.string);
+}
+
+test "openai body rejects image attachments" {
+    var path_buf = "img.png".*;
+    var media_type_buf = "image/png".*;
+    const attachment_messages = [_]ChatMessage{.{
+        .role = .user,
+        .content = "look",
+        .images = &[_]types.ImageAttachment{.{
+            .path = &path_buf,
+            .media_type = &media_type_buf,
+        }},
+    }};
+    try std.testing.expectError(error.ImageInputUnsupported, buildChatCompletionsBody(
+        std.testing.allocator,
+        .{
+            .model = "gpt-5.2",
+            .tools_json = "[]",
+            .messages = &attachment_messages,
+            .tool_choice = .auto,
+        },
+    ));
+}

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -362,6 +362,9 @@ fn writeTerminalSafe(writer: *std.Io.Writer, alloc: Allocator, raw: []const u8) 
 
 pub const StatusSnapshot = struct {
     model: []const u8,
+    /// Custom OpenAI-compatible endpoint, when one is configured. Absent means
+    /// inference uses Vercel AI Gateway.
+    endpoint: ?[]const u8 = null,
     update_channel: []const u8 = "stable",
     build_channel: []const u8 = "stable",
     build_revision: []const u8 = "",
@@ -387,6 +390,9 @@ pub const StatusSnapshot = struct {
         defer out.deinit();
 
         try out.writer.print("[status] model={s}\n", .{self.model});
+        if (self.endpoint) |endpoint| {
+            try out.writer.print("[status] endpoint={s}\n", .{endpoint});
+        }
         try out.writer.print("[status] update_channel={s}\n", .{self.update_channel});
         try out.writer.print("[status] build_channel={s}\n", .{self.build_channel});
         if (self.build_revision.len > 0) {
@@ -418,6 +424,7 @@ pub const StatusSnapshot = struct {
         defer out.deinit();
 
         try out.writer.print("model={s}\n", .{self.model});
+        if (self.endpoint) |endpoint| try out.writer.print("endpoint={s}\n", .{endpoint});
         try out.writer.print("update_channel={s}\n", .{self.update_channel});
         try out.writer.print("build_channel={s}\n", .{self.build_channel});
         if (self.build_revision.len > 0) {
@@ -448,6 +455,10 @@ pub const StatusSnapshot = struct {
     pub fn writeJson(self: StatusSnapshot, writer: *std.Io.Writer) !void {
         try writer.writeAll("{\"kind\":\"status\",\"model\":");
         try std.json.Stringify.value(self.model, .{}, writer);
+        if (self.endpoint) |endpoint| {
+            try writer.writeAll(",\"endpoint\":");
+            try std.json.Stringify.value(endpoint, .{}, writer);
+        }
         try writer.writeAll(",\"update_channel\":");
         try std.json.Stringify.value(self.update_channel, .{}, writer);
         try writer.writeAll(",\"build_channel\":");
@@ -1788,6 +1799,37 @@ test "core status snapshot text and json stay stable" {
         "{\"kind\":\"status\",\"model\":\"alpha\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":3,\"session_permission_grants\":1,\"agent_step_limit\":24}",
         json,
     );
+}
+
+test "core status snapshot reports a configured custom endpoint" {
+    const snapshot = StatusSnapshot{
+        .model = "llama3.3",
+        .endpoint = "http://localhost:11434/v1",
+        .permission_mode = .ask,
+        .workspace_root = "/tmp/fx",
+        .history_turns = 0,
+        .session_permission_grants = 0,
+        .agent_step_limit = 24,
+    };
+
+    const text = try snapshot.renderText(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.find(u8, text, "[status] endpoint=http://localhost:11434/v1\n") != null);
+
+    const interactive = try snapshot.renderInteractiveBody(std.testing.allocator);
+    defer std.testing.allocator.free(interactive);
+    try std.testing.expect(std.mem.find(u8, interactive, "endpoint=http://localhost:11434/v1\n") != null);
+
+    const json = try snapshot.renderJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.find(u8, json, "\"endpoint\":\"http://localhost:11434/v1\"") != null);
+
+    // A gateway session must not gain the field at all.
+    var gateway = snapshot;
+    gateway.endpoint = null;
+    const gateway_json = try gateway.renderJson(std.testing.allocator);
+    defer std.testing.allocator.free(gateway_json);
+    try std.testing.expect(std.mem.find(u8, gateway_json, "endpoint") == null);
 }
 
 test "core status snapshot includes selected team when present" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -92,6 +92,9 @@ pub const CredentialSource = enum {
     ai_gateway_api_key,
     fx_login,
     stored_key,
+    /// Credential for a custom OpenAI-compatible endpoint. Never valid against
+    /// Vercel AI Gateway.
+    custom_endpoint,
 };
 
 pub fn parseCredentialSource(text: []const u8) ?CredentialSource {

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -5,6 +5,7 @@ const secret = @import("../core/auth/secret.zig");
 const agent_stream_provider = @import("../core/agent/stream_provider.zig");
 const debug_trace = @import("../core/shared/debug_trace.zig");
 const io_mod = @import("../core/shared/io.zig");
+const openai_sse = @import("openai_sse.zig");
 const types = @import("../core/shared/types.zig");
 
 pub fn isRetryableGatewayError(err: anyerror) bool {
@@ -185,7 +186,7 @@ const provider_failure_detail_max_bytes: usize = 600;
 const generation_response_max_bytes: usize = 128 * 1024;
 const generation_lookup_timeout_ms: i64 = 30_000;
 // Covers a 4 MiB string at worst-case JSON escaping plus SSE framing.
-const max_sse_event_line_bytes: usize = 32 * 1024 * 1024;
+pub const max_sse_event_line_bytes: usize = 32 * 1024 * 1024;
 const e2e_gateway_chat_url_env = "FX_E2E_GATEWAY_CHAT_URL";
 const e2e_gateway_models_url_env = "FX_E2E_GATEWAY_MODELS_URL";
 const e2e_gateway_credits_url_env = "FX_E2E_GATEWAY_CREDITS_URL";
@@ -988,12 +989,23 @@ test "connection setup policy bounds retry by deadline attempts and delivery" {
     }
 }
 
+/// Wire protocol spoken at `chat_url`. `.gateway` is the Vercel AI SDK
+/// LanguageModelV2 protocol; `.openai_compat` is the OpenAI chat-completions
+/// protocol used by custom endpoints (see `builtins/openai_compat.zig`).
+pub const WireProtocol = enum {
+    gateway,
+    openai_compat,
+};
+
 pub const StreamRequest = struct {
+    /// Empty means the request is sent without an Authorization header
+    /// (supported for `.openai_compat` local servers only).
     api_key: []const u8,
     model: []const u8,
     retry_count: usize,
     chat_url: []const u8,
     payload: []const u8,
+    protocol: WireProtocol = .gateway,
     team: ?[]const u8 = null,
     /// Borrowed until `streamGatewayCompletion` returns.
     session_id: ?[]const u8 = null,
@@ -1174,16 +1186,29 @@ fn streamGatewayCompletionCoreWithOptions(
     const request_url = try resolveE2eGatewayUrl(e2e_gateway_chat_url_env, request.chat_url);
     const uri = try std.Uri.parse(request_url);
 
-    const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.api_key});
-    defer alloc.free(auth_header);
+    const auth_header: ?[]u8 = if (request.api_key.len > 0)
+        try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.api_key})
+    else
+        null;
+    defer if (auth_header) |header| alloc.free(header);
+    const authorization: std.http.Client.Request.Headers.Value = if (auth_header) |header|
+        .{ .override = header }
+    else
+        .omit;
 
     var extra_headers_buf: [9]std.http.Header = undefined;
-    const extra_headers = gatewayExtraHeaders(
-        &extra_headers_buf,
-        model,
-        request.team,
-        request.session_id,
-    );
+    const extra_headers = switch (request.protocol) {
+        .gateway => gatewayExtraHeaders(
+            &extra_headers_buf,
+            model,
+            request.team,
+            request.session_id,
+        ),
+        .openai_compat => blk: {
+            extra_headers_buf[0] = .{ .name = "accept", .value = "text/event-stream" };
+            break :blk extra_headers_buf[0..1];
+        },
+    };
 
     var attempt: usize = 0;
     var delivery_ambiguous = false;
@@ -1210,7 +1235,7 @@ fn streamGatewayCompletionCoreWithOptions(
         var req = openGatewayRequestBounded(&client, uri, .{
             .headers = .{
                 .content_type = .{ .override = "application/json" },
-                .authorization = .{ .override = auth_header },
+                .authorization = authorization,
                 .accept_encoding = .omit,
                 .user_agent = .{ .override = user_agent },
             },
@@ -1387,19 +1412,32 @@ fn streamGatewayCompletionCoreWithOptions(
         var transfer_buf: [gateway_transfer_buffer_bytes]u8 = undefined;
         const body_reader = response.reader(&transfer_buf);
         debug_trace.eventf("gateway", "before_sse_consume", trace_ctx, "attempt={d}", .{attempt + 1});
-        var completion = consumeSseStreamTraced(
-            alloc,
-            body_reader,
-            callback_ctx,
-            on_content_chunk,
-            on_tool_start,
-            request.on_reasoning_chunk,
-            request.on_tool_input_chunk,
-            cancel_flag,
-            .{ .requested_model = model, .ctx = trace_ctx },
-            expected_provider_tool_name,
-            request.content_capture_limit,
-        ) catch |err| {
+        var completion = switch (request.protocol) {
+            .gateway => consumeSseStreamTraced(
+                alloc,
+                body_reader,
+                callback_ctx,
+                on_content_chunk,
+                on_tool_start,
+                request.on_reasoning_chunk,
+                request.on_tool_input_chunk,
+                cancel_flag,
+                .{ .requested_model = model, .ctx = trace_ctx },
+                expected_provider_tool_name,
+                request.content_capture_limit,
+            ),
+            .openai_compat => openai_sse.consumeOpenAiSseStream(
+                alloc,
+                body_reader,
+                callback_ctx,
+                on_content_chunk,
+                on_tool_start,
+                request.on_reasoning_chunk,
+                request.on_tool_input_chunk,
+                cancel_flag,
+                request.content_capture_limit,
+            ),
+        } catch |err| {
             debug_trace.eventf("gateway", "sse_consume_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
             return @as(anyerror!StreamResult, connectedIoFailure(
                 cancel_flag.load(.seq_cst),
@@ -2608,7 +2646,7 @@ const SseLineRead = union(enum) {
     eof,
 };
 
-const SseEventRead = union(enum) {
+pub const SseEventRead = union(enum) {
     data: []const u8,
     done,
     ignored,
@@ -2616,19 +2654,20 @@ const SseEventRead = union(enum) {
     eof,
 };
 
-const SseEventReader = struct {
+/// Shared by the AI Gateway and OpenAI-compatible SSE consumers.
+pub const SseEventReader = struct {
     pending_line: std.ArrayList(u8) = .empty,
     max_line_bytes: usize,
 
-    fn deinit(self: *@This(), alloc: std.mem.Allocator) void {
+    pub fn deinit(self: *@This(), alloc: std.mem.Allocator) void {
         self.pending_line.deinit(alloc);
     }
 
-    fn releaseLine(self: *@This()) void {
+    pub fn releaseLine(self: *@This()) void {
         self.pending_line.clearRetainingCapacity();
     }
 
-    fn next(self: *@This(), alloc: std.mem.Allocator, reader: anytype) !SseEventRead {
+    pub fn next(self: *@This(), alloc: std.mem.Allocator, reader: anytype) !SseEventRead {
         const line = switch (try self.readLine(alloc, reader)) {
             .line => |line| line,
             .read_failed => return .read_failed,

--- a/src/gateway/openai_sse.zig
+++ b/src/gateway/openai_sse.zig
@@ -1,0 +1,414 @@
+//! Decodes an OpenAI chat-completions SSE response stream.
+//!
+//! This is the wire-protocol sibling of the AI Gateway consumer in
+//! `client.zig`: transports own status and headers, this module owns the
+//! `choices[].delta` event grammar shared by OpenAI-compatible servers
+//! (OpenAI, Ollama, vLLM, LM Studio, OpenRouter, Groq, and similar).
+
+const std = @import("std");
+const gateway_client = @import("client.zig");
+const types = @import("../core/shared/types.zig");
+
+const provider_failure_detail_max_bytes: usize = 600;
+
+const ToolCallAccumulator = struct {
+    index: u32,
+    id: std.ArrayList(u8) = .empty,
+    name: std.ArrayList(u8) = .empty,
+    arguments: std.ArrayList(u8) = .empty,
+    start_reported: bool = false,
+
+    fn deinit(self: *ToolCallAccumulator, alloc: std.mem.Allocator) void {
+        self.id.deinit(alloc);
+        self.name.deinit(alloc);
+        self.arguments.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+/// Consumes an OpenAI chat-completions SSE body from a transport-owned reader.
+/// The returned completion and every populated child buffer are owned by
+/// `alloc`. Cancellation returns the partial completion; the transport
+/// discards it after observing the cancel flag.
+pub fn consumeOpenAiSseStream(
+    alloc: std.mem.Allocator,
+    reader: anytype,
+    callback_ctx: *anyopaque,
+    on_content_chunk: gateway_client.StreamCallback,
+    on_tool_start: ?gateway_client.ToolStartCallback,
+    on_reasoning_chunk: ?gateway_client.StreamCallback,
+    on_tool_input_chunk: ?gateway_client.StreamCallback,
+    cancel_flag: *std.atomic.Value(bool),
+    content_capture_limit: ?usize,
+) !types.GatewayCompletion {
+    var content_buf: std.ArrayList(u8) = .empty;
+    defer content_buf.deinit(alloc);
+
+    var accumulators: std.ArrayList(ToolCallAccumulator) = .empty;
+    defer {
+        for (accumulators.items) |*acc| acc.deinit(alloc);
+        accumulators.deinit(alloc);
+    }
+
+    var finish_reason: ?types.ProviderFinishReason = null;
+    var usage: types.Usage = .{};
+    var provider_failure_detail: ?[]u8 = null;
+    defer if (provider_failure_detail) |detail| alloc.free(detail);
+
+    var event_reader = gateway_client.SseEventReader{
+        .max_line_bytes = gateway_client.max_sse_event_line_bytes,
+    };
+    defer event_reader.deinit(alloc);
+
+    while (true) {
+        if (cancel_flag.load(.seq_cst)) break;
+        const event = try event_reader.next(alloc, reader);
+        switch (event) {
+            .done, .eof, .read_failed => break,
+            .ignored => continue,
+            .data => |json_text| {
+                var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch {
+                    event_reader.releaseLine();
+                    continue;
+                };
+                defer parsed.deinit();
+                defer event_reader.releaseLine();
+                if (parsed.value != .object) continue;
+                const root = parsed.value.object;
+
+                if (root.get("error")) |failure| {
+                    try captureFailureDetail(alloc, &provider_failure_detail, failure);
+                    if (finish_reason == null) finish_reason = .provider_error;
+                }
+
+                if (root.get("usage")) |usage_value| {
+                    if (usage_value == .object) {
+                        if (parseTokenCount(usage_value.object.get("prompt_tokens"))) |tokens| {
+                            usage.input_tokens = tokens;
+                        }
+                        if (parseTokenCount(usage_value.object.get("completion_tokens"))) |tokens| {
+                            usage.output_tokens = tokens;
+                        }
+                    }
+                }
+
+                const choices = root.get("choices") orelse continue;
+                if (choices != .array or choices.array.items.len == 0) continue;
+                const choice = choices.array.items[0];
+                if (choice != .object) continue;
+
+                if (choice.object.get("finish_reason")) |reason| {
+                    if (reason == .string) {
+                        if (types.ProviderFinishReason.parse_legacy(reason.string)) |parsed_reason| {
+                            finish_reason = parsed_reason;
+                        }
+                    }
+                }
+
+                const delta = choice.object.get("delta") orelse continue;
+                if (delta != .object) continue;
+
+                if (jsonString(delta.object.get("content"))) |text| {
+                    if (text.len > 0) {
+                        on_content_chunk(callback_ctx, text);
+                        try appendCapped(alloc, &content_buf, text, content_capture_limit);
+                    }
+                }
+                // "reasoning_content" is the DeepSeek/vLLM field; "reasoning"
+                // is used by OpenRouter and several local servers.
+                if (jsonString(delta.object.get("reasoning_content")) orelse
+                    jsonString(delta.object.get("reasoning"))) |text|
+                {
+                    if (text.len > 0) {
+                        if (on_reasoning_chunk) |cb| cb(callback_ctx, text);
+                    }
+                }
+
+                if (delta.object.get("tool_calls")) |tool_calls| {
+                    if (tool_calls == .array) {
+                        for (tool_calls.array.items) |fragment| {
+                            try accumulateToolCallFragment(
+                                alloc,
+                                &accumulators,
+                                fragment,
+                                callback_ctx,
+                                on_tool_start,
+                                on_tool_input_chunk,
+                            );
+                        }
+                    }
+                }
+            },
+        }
+    }
+
+    var completion = types.GatewayCompletion{
+        .finish_reason = finish_reason,
+        .usage = usage,
+    };
+    if (content_buf.items.len > 0) {
+        completion.content = try alloc.dupe(u8, content_buf.items);
+    }
+    errdefer if (completion.content) |content| alloc.free(@constCast(content));
+    if (provider_failure_detail) |detail| {
+        completion.provider_failure_detail = try alloc.dupe(u8, detail);
+    }
+    errdefer if (completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
+    completion.tool_calls = try materializeToolCalls(alloc, accumulators.items);
+    return completion;
+}
+
+fn accumulateToolCallFragment(
+    alloc: std.mem.Allocator,
+    accumulators: *std.ArrayList(ToolCallAccumulator),
+    fragment: std.json.Value,
+    callback_ctx: *anyopaque,
+    on_tool_start: ?gateway_client.ToolStartCallback,
+    on_tool_input_chunk: ?gateway_client.StreamCallback,
+) !void {
+    if (fragment != .object) return;
+    const index: u32 = if (fragment.object.get("index")) |value| switch (value) {
+        .integer => |raw| if (raw >= 0 and raw <= std.math.maxInt(u32)) @intCast(raw) else return,
+        else => return,
+    } else 0;
+
+    const acc = find: {
+        for (accumulators.items) |*candidate| {
+            if (candidate.index == index) break :find candidate;
+        }
+        try accumulators.append(alloc, .{ .index = index });
+        break :find &accumulators.items[accumulators.items.len - 1];
+    };
+
+    if (jsonString(fragment.object.get("id"))) |id| {
+        try acc.id.appendSlice(alloc, id);
+    }
+    if (fragment.object.get("function")) |function| {
+        if (function == .object) {
+            if (jsonString(function.object.get("name"))) |name| {
+                try acc.name.appendSlice(alloc, name);
+            }
+            if (jsonString(function.object.get("arguments"))) |arguments| {
+                if (arguments.len > 0) {
+                    try acc.arguments.appendSlice(alloc, arguments);
+                    if (on_tool_input_chunk) |cb| cb(callback_ctx, arguments);
+                }
+            }
+        }
+    }
+    if (!acc.start_reported and acc.id.items.len > 0 and acc.name.items.len > 0) {
+        acc.start_reported = true;
+        if (on_tool_start) |cb| cb(callback_ctx, acc.id.items, acc.name.items, null);
+    }
+}
+
+fn materializeToolCalls(
+    alloc: std.mem.Allocator,
+    accumulators: []const ToolCallAccumulator,
+) ![]const types.ToolCall {
+    if (accumulators.len == 0) return &.{};
+
+    const calls = try alloc.alloc(types.ToolCall, accumulators.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (calls[0..initialized]) |call| {
+            alloc.free(call.id);
+            alloc.free(call.name);
+            alloc.free(call.arguments_json);
+        }
+        alloc.free(calls);
+    }
+
+    for (accumulators, 0..) |acc, i| {
+        const id = try alloc.dupe(u8, acc.id.items);
+        errdefer alloc.free(id);
+        const name = try alloc.dupe(u8, acc.name.items);
+        errdefer alloc.free(name);
+        const raw_arguments: []const u8 = if (acc.arguments.items.len > 0) acc.arguments.items else "{}";
+        const arguments = try alloc.dupe(u8, raw_arguments);
+        errdefer alloc.free(arguments);
+
+        calls[i] = .{
+            .id = id,
+            .name = name,
+            .arguments_json = arguments,
+            .argument_integrity = try types.ToolArgumentIntegrity.classifySerialized(alloc, arguments),
+        };
+        initialized += 1;
+    }
+
+    return calls;
+}
+
+fn captureFailureDetail(
+    alloc: std.mem.Allocator,
+    current: *?[]u8,
+    failure: std.json.Value,
+) !void {
+    if (current.* != null) return;
+    const text = switch (failure) {
+        .string => |value| value,
+        .object => |obj| jsonString(obj.get("message")) orelse return,
+        else => return,
+    };
+    if (text.len == 0) return;
+    const clipped = text[0..@min(text.len, provider_failure_detail_max_bytes)];
+    current.* = try alloc.dupe(u8, clipped);
+}
+
+fn appendCapped(
+    alloc: std.mem.Allocator,
+    buf: *std.ArrayList(u8),
+    text: []const u8,
+    limit: ?usize,
+) !void {
+    const max = limit orelse {
+        try buf.appendSlice(alloc, text);
+        return;
+    };
+    if (buf.items.len >= max) return;
+    const remaining = max - buf.items.len;
+    try buf.appendSlice(alloc, text[0..@min(text.len, remaining)]);
+}
+
+fn parseTokenCount(value: ?std.json.Value) ?u64 {
+    const raw = value orelse return null;
+    return switch (raw) {
+        .integer => |number| if (number >= 0) @intCast(number) else null,
+        else => null,
+    };
+}
+
+fn jsonString(value: ?std.json.Value) ?[]const u8 {
+    const raw = value orelse return null;
+    return switch (raw) {
+        .string => |text| text,
+        else => null,
+    };
+}
+
+const TestCapture = struct {
+    content: std.ArrayList(u8) = .empty,
+    reasoning: std.ArrayList(u8) = .empty,
+    tool_input: std.ArrayList(u8) = .empty,
+    tool_starts: usize = 0,
+    failed: bool = false,
+
+    fn deinit(self: *TestCapture) void {
+        self.content.deinit(std.testing.allocator);
+        self.reasoning.deinit(std.testing.allocator);
+        self.tool_input.deinit(std.testing.allocator);
+    }
+
+    fn onContent(raw: *anyopaque, chunk: []const u8) void {
+        const self: *TestCapture = @ptrCast(@alignCast(raw));
+        self.content.appendSlice(std.testing.allocator, chunk) catch {
+            self.failed = true;
+        };
+    }
+
+    fn onReasoning(raw: *anyopaque, chunk: []const u8) void {
+        const self: *TestCapture = @ptrCast(@alignCast(raw));
+        self.reasoning.appendSlice(std.testing.allocator, chunk) catch {
+            self.failed = true;
+        };
+    }
+
+    fn onToolInput(raw: *anyopaque, chunk: []const u8) void {
+        const self: *TestCapture = @ptrCast(@alignCast(raw));
+        self.tool_input.appendSlice(std.testing.allocator, chunk) catch {
+            self.failed = true;
+        };
+    }
+
+    fn onToolStart(raw: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8) void {
+        const self: *TestCapture = @ptrCast(@alignCast(raw));
+        self.tool_starts += 1;
+    }
+};
+
+fn consumeTestStream(sse_body: []const u8, capture: *TestCapture) !types.GatewayCompletion {
+    var reader: std.Io.Reader = .fixed(sse_body);
+    var cancelled = std.atomic.Value(bool).init(false);
+    return consumeOpenAiSseStream(
+        std.testing.allocator,
+        &reader,
+        capture,
+        TestCapture.onContent,
+        TestCapture.onToolStart,
+        TestCapture.onReasoning,
+        TestCapture.onToolInput,
+        &cancelled,
+        null,
+    );
+}
+
+fn freeTestCompletion(completion: *types.GatewayCompletion) void {
+    const alloc = std.testing.allocator;
+    if (completion.content) |content| alloc.free(@constCast(content));
+    if (completion.provider_failure_detail) |detail| alloc.free(@constCast(detail));
+    types.freeToolCallSlice(alloc, @constCast(completion.tool_calls));
+}
+
+test "openai sse stream accumulates content, reasoning, and usage" {
+    const body =
+        "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hel\"}}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"content\":\"lo\",\"reasoning_content\":\"think\"}}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n" ++
+        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":7}}\n\n" ++
+        "data: [DONE]\n";
+
+    var capture = TestCapture{};
+    defer capture.deinit();
+    var completion = try consumeTestStream(body, &capture);
+    defer freeTestCompletion(&completion);
+
+    try std.testing.expect(!capture.failed);
+    try std.testing.expectEqualStrings("Hello", capture.content.items);
+    try std.testing.expectEqualStrings("think", capture.reasoning.items);
+    try std.testing.expectEqualStrings("Hello", completion.content.?);
+    try std.testing.expectEqual(types.ProviderFinishReason.stop, completion.finish_reason.?);
+    try std.testing.expectEqual(@as(?u64, 12), completion.usage.input_tokens);
+    try std.testing.expectEqual(@as(?u64, 7), completion.usage.output_tokens);
+}
+
+test "openai sse stream assembles index-keyed tool call fragments" {
+    const body =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read_file\",\"arguments\":\"\"}}]}}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\"}}]}}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"a.txt\\\"}\"}},{\"index\":1,\"id\":\"call_2\",\"function\":{\"name\":\"list_dir\",\"arguments\":\"{}\"}}]}}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n" ++
+        "data: [DONE]\n";
+
+    var capture = TestCapture{};
+    defer capture.deinit();
+    var completion = try consumeTestStream(body, &capture);
+    defer freeTestCompletion(&completion);
+
+    try std.testing.expect(!capture.failed);
+    try std.testing.expectEqual(@as(usize, 2), capture.tool_starts);
+    try std.testing.expectEqual(@as(usize, 2), completion.tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", completion.tool_calls[0].id);
+    try std.testing.expectEqualStrings("read_file", completion.tool_calls[0].name);
+    try std.testing.expectEqualStrings("{\"path\":\"a.txt\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(types.ToolArgumentIntegrity.valid, completion.tool_calls[0].argument_integrity);
+    try std.testing.expectEqualStrings("call_2", completion.tool_calls[1].id);
+    try std.testing.expectEqualStrings("list_dir", completion.tool_calls[1].name);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}
+
+test "openai sse stream captures provider errors and malformed arguments" {
+    const body =
+        "data: {\"error\":{\"message\":\"model overloaded\",\"type\":\"server_error\"}}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_x\",\"function\":{\"name\":\"run\",\"arguments\":\"{not json\"}}]}}]}\n\n" ++
+        "data: [DONE]\n";
+
+    var capture = TestCapture{};
+    defer capture.deinit();
+    var completion = try consumeTestStream(body, &capture);
+    defer freeTestCompletion(&completion);
+
+    try std.testing.expectEqualStrings("model overloaded", completion.provider_failure_detail.?);
+    try std.testing.expectEqual(types.ProviderFinishReason.provider_error, completion.finish_reason.?);
+    try std.testing.expectEqual(types.ToolArgumentIntegrity.malformed_json, completion.tool_calls[0].argument_integrity);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,8 +48,11 @@ const command_specs = @import("core/slash_commands/command_specs.zig");
 const builtin_context = @import("builtins/context.zig");
 const builtin_devbox = @import("builtins/devbox.zig");
 const builtin_gateway = @import("builtins/gateway.zig");
+const builtin_openai_compat = @import("builtins/openai_compat.zig");
 const gateway_provider = @import("core/gateway/gateway_provider.zig");
 const generation_usage_provider = @import("core/session/generation_usage_provider.zig");
+const core_model_catalog = @import("core/gateway/model_catalog.zig");
+const web_search_provider = @import("core/tooling/web_search_provider.zig");
 const agent_stream_provider = @import("core/agent/stream_provider.zig");
 const builtin_hooks = @import("builtins/hooks.zig");
 const builtin_mcp = @import("builtins/mcp.zig");
@@ -423,14 +426,14 @@ const App = struct {
     }
 
     pub fn creditsProvider(_: *const Self) gateway_provider.CreditsProvider {
-        return builtin_gateway.credits_provider;
+        return selectedCreditsProvider();
     }
 
     pub fn agentStreamProvider(_: *const Self) agent_stream_provider.Provider {
         return if (comptime host_target.is_wasm)
             js_host_stream_provider.provider()
         else
-            builtin_gateway.agent_stream_provider;
+            selectedAgentStreamProvider();
     }
 
     pub fn cooperativeTransportPulse(self: *Self) !void {
@@ -569,6 +572,14 @@ const App = struct {
                 background_process_provider.unavailable_provider
             else
                 background_process.provider),
+            // Provider-dependent runtimes are selected here rather than in the
+            // field defaults because FX_BASE_URL is only known at runtime.
+            .web_search_runtime = web_search_runtime.Runtime.init(.{
+                .provider = selectedWebSearchProvider(),
+            }),
+            .web_search_models_path = selectedModelsPath(),
+            .model_cache = model_cache_runtime.Runtime.init(std.heap.c_allocator, selectedModelsPath()),
+            .session = SessionRuntime.init(max_history_turns, selectedGenerationUsageProvider()),
         };
         if (comptime host_profile.js_host_workspace) {
             app.workspace_host = js_host_workspace.Runtime.init(alloc) catch |err| blk: {
@@ -1520,7 +1531,7 @@ const App = struct {
         self: *App,
         admission: subagent_domain.AdmissionSnapshot,
     ) tool_runtime.Context {
-        return AgentAppRuntime.toolContextForSubagent(self, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl(), admission);
+        return AgentAppRuntime.toolContextForSubagent(self, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl(), admission);
     }
 
     pub fn runSubagentChild(
@@ -1550,7 +1561,7 @@ const App = struct {
     }
 
     pub fn describeToolAction(self: *App, arena: Allocator, call: ToolCall, file_display_path: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
-        return AgentAppRuntime.describeToolAction(self, arena, call, file_display_path, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.describeToolAction(self, arena, call, file_display_path, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn describeToolActionWithAdvertised(self: *App, arena: Allocator, call: ToolCall, file_display_path: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
@@ -1558,7 +1569,7 @@ const App = struct {
     }
 
     pub fn describeToolActionCompleted(self: *App, arena: Allocator, call: ToolCall, file_display_path: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
-        return AgentAppRuntime.describeToolActionCompleted(self, arena, call, file_display_path, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.describeToolActionCompleted(self, arena, call, file_display_path, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn describeToolActionCompletedWithAdvertised(self: *App, arena: Allocator, call: ToolCall, file_display_path: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
@@ -1566,7 +1577,7 @@ const App = struct {
     }
 
     pub fn describeToolActionDenied(self: *App, arena: Allocator, call: ToolCall, file_display_path: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
-        return AgentAppRuntime.describeToolActionDenied(self, arena, call, file_display_path, label, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.describeToolActionDenied(self, arena, call, file_display_path, label, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn describeToolActionDeniedWithAdvertised(self: *App, arena: Allocator, call: ToolCall, file_display_path: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
@@ -1574,7 +1585,7 @@ const App = struct {
     }
 
     pub fn requestToolPermissionSync(self: *App, arena: Allocator, call: ToolCall, review_turn: permission_auto_classifier.ReviewTurnContext, permission_mode: PermissionMode, local_grants: []const PermissionGrant, live_authority: ?agent_runtime.LiveToolAuthority, revalidation: ?agent_runtime.LivePermissionRevalidation, advertised_dynamic_tool_names: []const []const u8) !command_admission.PermissionOutcome {
-        return AgentAppRuntime.requestToolPermissionSync(self, arena, call, review_turn, permission_mode, local_grants, live_authority, revalidation, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.requestToolPermissionSync(self, arena, call, review_turn, permission_mode, local_grants, live_authority, revalidation, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn requestToolPermissionSyncWithAdvertised(self: *App, arena: Allocator, call: ToolCall, review_turn: permission_auto_classifier.ReviewTurnContext, permission_mode: PermissionMode, local_grants: []const PermissionGrant, live_authority: ?agent_runtime.LiveToolAuthority, revalidation: ?agent_runtime.LivePermissionRevalidation, advertised_dynamic_tool_names: []const []const u8) !command_admission.PermissionOutcome {
@@ -1582,7 +1593,7 @@ const App = struct {
     }
 
     pub fn requestPreparedFileMutationPermissionSyncWithAdvertised(self: *App, arena: Allocator, call: ToolCall, prepared: *tool_admission.PreparedFileMutationCall, review_turn: permission_auto_classifier.ReviewTurnContext, permission_mode: PermissionMode, local_grants: []const PermissionGrant, live_authority: ?agent_runtime.LiveToolAuthority, advertised_dynamic_tool_names: []const []const u8) !command_admission.PermissionOutcome {
-        return AgentAppRuntime.requestPreparedFileMutationPermissionSync(self, arena, call, prepared, review_turn, permission_mode, local_grants, live_authority, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.requestPreparedFileMutationPermissionSync(self, arena, call, prepared, review_turn, permission_mode, local_grants, live_authority, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn requestSandboxWideningSyncWithAdvertised(
@@ -1613,20 +1624,20 @@ const App = struct {
             max_read_file_line_len,
             max_command_output_bytes,
             builtin_gateway.retry_count,
-            builtin_gateway.defaultChatUrl(),
+            selectedChatUrl(),
         );
     }
 
     pub fn validateToolCall(self: *App, arena: Allocator, call: ToolCall) !agent_runtime.ToolCallValidationResult {
-        return AgentAppRuntime.validateToolCall(self, arena, call, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.validateToolCall(self, arena, call, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn checkToolAvailability(self: *App, arena: Allocator, call: ToolCall) !?[]const u8 {
-        return AgentAppRuntime.checkToolAvailability(self, arena, call, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.checkToolAvailability(self, arena, call, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn permissionTargetForCall(self: *App, arena: Allocator, call: ToolCall, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
-        return AgentAppRuntime.permissionTargetForCall(self, arena, call, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.permissionTargetForCall(self, arena, call, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn permissionTargetForCallWithAdvertised(self: *App, arena: Allocator, call: ToolCall, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
@@ -1647,7 +1658,7 @@ const App = struct {
             max_read_file_line_len,
             max_command_output_bytes,
             builtin_gateway.retry_count,
-            builtin_gateway.defaultChatUrl(),
+            selectedChatUrl(),
         );
         return tool_admission.preparePermissionStateAction(
             ctx.admissionInput(),
@@ -1681,8 +1692,8 @@ const App = struct {
     pub fn fetchModelIds(self: *App) !std.ArrayList([]u8) {
         return AgentAppRuntime.fetchModelIds(
             self,
-            if (comptime host_target.is_wasm) js_host_model_catalog.provider else builtin_gateway.model_catalog_provider,
-            builtin_gateway.models_path,
+            if (comptime host_target.is_wasm) js_host_model_catalog.provider else selectedModelCatalogProvider(),
+            selectedModelsPath(),
         );
     }
 
@@ -1698,7 +1709,7 @@ const App = struct {
             );
         } else {
             self.model_cache.startWarmup(
-                builtin_gateway.model_catalog_provider,
+                selectedModelCatalogProvider(),
                 self.auth.modelCatalogAccess(),
             );
         }
@@ -1816,7 +1827,7 @@ const App = struct {
             self,
             job,
             builtin_gateway.retry_count,
-            builtin_gateway.defaultChatUrl(),
+            selectedChatUrl(),
         ) catch |err| {
             if (err == error.TurnFinalizationDeliveryFailed) return;
             return err;
@@ -1832,7 +1843,7 @@ const App = struct {
                 return agent_runtime.unavailableHostToolResult(request.result_allocator);
             }
         }
-        return AgentAppRuntime.executeToolCall(self, request, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        return AgentAppRuntime.executeToolCall(self, request, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn executeToolCallWithAdvertised(self: *App, request: agent_runtime.ToolExecutionRequest) !ToolExecutionResult {
@@ -1845,11 +1856,11 @@ const App = struct {
     }
 
     pub fn appendRuntimeContextMessage(self: *App, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {
-        try AgentAppRuntime.appendTransientRuntimeContextMessage(self, arena, messages, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        try AgentAppRuntime.appendTransientRuntimeContextMessage(self, arena, messages, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     pub fn appendStaticContextMessage(self: *App, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {
-        try AgentAppRuntime.appendStaticContextMessage(self, arena, messages, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+        try AgentAppRuntime.appendStaticContextMessage(self, arena, messages, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, selectedChatUrl());
     }
 
     fn runtimeContextSnapshot(self: *App, alloc: Allocator) !RuntimeContextSnapshot {
@@ -3184,6 +3195,63 @@ test "native app preserves the built-in tool set without workspace metadata" {
     try std.testing.expectEqual(builtin_tools.advertisement_set.order.len, advertised.order.len);
 }
 
+/// FX_BASE_URL routes inference to a custom OpenAI-compatible endpoint;
+/// otherwise the Vercel AI Gateway bundle is used. Every surface
+/// (interactive, ask, ACP) resolves its providers through these selectors so
+/// one process never mixes the two wire protocols.
+fn customEndpointActive() bool {
+    if (comptime host_target.is_wasm) return false;
+    return builtin_openai_compat.isConfigured();
+}
+
+fn selectedGatewayProvider() gateway_provider.Provider {
+    if (customEndpointActive()) return builtin_openai_compat.provider;
+    return builtin_gateway.provider;
+}
+
+fn selectedChatUrl() []const u8 {
+    if (customEndpointActive()) {
+        if (builtin_openai_compat.chatUrl()) |url| return url;
+    }
+    return builtin_gateway.defaultChatUrl();
+}
+
+/// The custom endpoint serves its catalog from `<FX_BASE_URL>/models`; the
+/// Gateway uses its coding-agent route.
+fn selectedModelsPath() []const u8 {
+    if (customEndpointActive()) return "/models";
+    return builtin_gateway.models_path;
+}
+
+fn selectedAgentStreamProvider() agent_stream_provider.Provider {
+    if (customEndpointActive()) return builtin_openai_compat.agent_stream_provider;
+    return builtin_gateway.agent_stream_provider;
+}
+
+fn selectedCreditsProvider() gateway_provider.CreditsProvider {
+    if (customEndpointActive()) return builtin_openai_compat.credits_provider;
+    return builtin_gateway.credits_provider;
+}
+
+fn selectedModelCatalogProvider() core_model_catalog.Provider {
+    if (customEndpointActive()) return builtin_openai_compat.model_catalog_provider;
+    return builtin_gateway.model_catalog_provider;
+}
+
+/// The custom endpoint has no provider-executed search, and its models path is
+/// the endpoint's own `/models` route rather than the Gateway coding-agent one.
+fn selectedWebSearchProvider() ?web_search_provider.Provider {
+    if (comptime !App.host_profile.web_search) return null;
+    if (customEndpointActive()) return null;
+    return builtin_gateway.default_web_search_provider;
+}
+
+fn selectedGenerationUsageProvider() generation_usage_provider.Provider {
+    if (comptime !App.host_profile.generation_usage) return generation_usage_provider.unavailable_provider;
+    if (customEndpointActive()) return generation_usage_provider.unavailable_provider;
+    return builtin_gateway.generation_usage_provider;
+}
+
 fn fullEntryConfig() app_entry_runtime.Config {
     return .{
         .version = version,
@@ -3194,8 +3262,8 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .default_agent_step_limit = default_max_agent_steps,
         .models_path = builtin_gateway.models_path,
         .gateway_retry_count = builtin_gateway.retry_count,
-        .gateway_chat_url = builtin_gateway.default_chat_url,
-        .gateway_provider = builtin_gateway.provider,
+        .gateway_chat_url = selectedChatUrl(),
+        .gateway_provider = selectedGatewayProvider(),
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3230,8 +3298,8 @@ fn localEntryConfig() app_entry_runtime.Config {
         .default_agent_step_limit = default_max_agent_steps,
         .models_path = builtin_gateway.models_path,
         .gateway_retry_count = builtin_gateway.retry_count,
-        .gateway_chat_url = builtin_gateway.default_chat_url,
-        .gateway_provider = builtin_gateway.provider,
+        .gateway_chat_url = selectedChatUrl(),
+        .gateway_provider = selectedGatewayProvider(),
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3266,7 +3334,7 @@ fn emptyEntryConfig() app_entry_runtime.Config {
         .models_path = "",
         .gateway_retry_count = 0,
         .gateway_chat_url = "",
-        .gateway_provider = builtin_gateway.provider,
+        .gateway_provider = selectedGatewayProvider(),
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3759,6 +3827,10 @@ test {
     _ = @import("ui/settings_screen.zig");
     _ = @import("builtins/context.zig");
     _ = @import("builtins/gateway.zig");
+    _ = @import("builtins/openai_compat.zig");
+    _ = @import("core/config/custom_endpoint.zig");
+    _ = @import("gateway/openai_sse.zig");
+    _ = @import("core/gateway/openai_json.zig");
     _ = @import("core/shared/debug_trace.zig");
     _ = @import("core/output/diff.zig");
     _ = @import("core/shared/display_width.zig");


### PR DESCRIPTION
## What

Adds the OpenAI chat-completions protocol alongside the existing AI SDK `LanguageModelV2` protocol, so fx can run against OpenAI, Ollama, vLLM, LM Studio, OpenRouter, or any endpoint serving that API.

```bash
fx setup --base-url https://api.openai.com/v1
fx setup --base-url http://localhost:11434/v1 --no-key   # keyless local server
fx setup --gateway                                        # back to AI Gateway
```

With no endpoint configured nothing changes: AI Gateway remains the default on every surface.

## Why

fx describes itself as model-agnostic and suitable for local inference, but inference is currently reachable only through AI Gateway. This closes that gap without disturbing the Gateway path.

## Design

Transport keeps a single seam. `StreamRequest` gains a `protocol` field selecting the wire format, so HTTP, retry, cancellation, and delivery-certainty logic stay shared:

| Module | Role |
| --- | --- |
| `src/gateway/openai_sse.zig` | Decodes the chat-completions event grammar: index-keyed tool-call fragment accumulation, reasoning deltas, usage, provider errors |
| `src/core/gateway/openai_json.zig` | Builds request bodies, translating the flat AI SDK tool schema into OpenAI's nested function envelope |
| `src/builtins/openai_compat.zig` | Assembles the provider behind the existing `gateway_provider.Provider` interface |
| `src/core/config/custom_endpoint.zig` | Resolves the endpoint from `FX_BASE_URL` or the `base_url` profile key |

Gateway-only surfaces degrade rather than fail a turn: credits, generation usage, and provider-executed web search report unavailable.

## Credential boundary

A configured endpoint takes over credential resolution entirely, so no code path can hand a Vercel token to a third party. Only `FX_API_KEY` or the stored key resolve; a keyless placeholder maps back to omitting the `Authorization` header. `fx status` reports a new `custom_endpoint` source instead of mislabeling the key as `AI_GATEWAY_API_KEY`.

## Contracts

- Settings: new profile-owned `base_url` key, validated as a credential-free http(s) origin, ignored from project `.fx.json` like other profile keys.
- Output: `fx status` gains `endpoint` in both text and JSON, rendered from the same snapshot.
- Command: `fx setup` gains `--base-url`, `--no-key`, and `--gateway`, wired through `cli_surface.zig` with the spec in `commands.zig`.

## Tests

19 unit tests covering SSE decoding (streaming content, index-keyed tool-call assembly, malformed arguments, provider errors), request-body translation, endpoint URL normalization and rejection, credential resolution and the Vercel-exclusion guarantee, settings round-trip and validation, and the status snapshot. No new `tests/e2e/*.test.ts` files, so `scripts/pgso/corpus.json` is unchanged.

Verified by hand against a live vLLM-backed OpenAI-compatible endpoint using `./zig-out/bin/fx`: interactive session, `fx ask`, and a full tool round-trip, plus a keyless local server and confirmation the Gateway path is untouched.

## Not included

Vision and structured output return explicit errors on this path; both depend on Gateway-side behavior with no chat-completions equivalent. Worth a follow-up if there's interest.
