### PR TITLE
Write the MCP config durably instead of truncating it in place

### DIFF
--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -173,7 +173,13 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
             return lineLiteral(alloc, "Usage: /mcp remove <name>", false);
         }
 
-        const removed = removeServerFromPath(alloc, config_path, name) catch false;
+        const removed = removeServerFromPath(alloc, config_path, name) catch |err| {
+            return lineParts(
+                alloc,
+                &.{ "Failed to remove MCP server '", name, "': ", @errorName(err), "." },
+                false,
+            );
+        };
         if (!removed) {
             return lineParts(alloc, &.{ "MCP server '", name, "' not found." }, false);
         }
@@ -191,8 +197,12 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
             return lineLiteral(alloc, "Usage: /mcp add <name> <command> [args...]", false);
         }
 
-        addOrReplaceLocalServer(alloc, config_path, tokens.items[0], tokens.items[1..]) catch {
-            return lineLiteral(alloc, "Failed to save MCP server config.", false);
+        addOrReplaceLocalServer(alloc, config_path, tokens.items[0], tokens.items[1..]) catch |err| {
+            return lineParts(
+                alloc,
+                &.{ "Failed to save MCP server config: ", @errorName(err), "." },
+                false,
+            );
         };
         return lineParts(alloc, &.{ "Saved MCP server '", tokens.items[0], "'." }, true);
     }
@@ -504,10 +514,13 @@ fn saveConfigsToPath(alloc: Allocator, path: []const u8, configs: []const McpSer
     defer alloc.free(json);
 
     const parent = std.fs.path.dirname(path) orelse return error.McpConfigPathInvalid;
-    ensureDir(parent);
-    var dir = io_mod.VerifiedDir{
-        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), parent, .{ .iterate = true }),
+    const grandparent = std.fs.path.dirname(parent) orelse return error.McpConfigPathInvalid;
+
+    var enclosing = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), grandparent, .{ .iterate = true }),
     };
+    defer enclosing.close();
+    var dir = try io_mod.openOrCreateVerifiedPrivateDir(&enclosing, std.fs.path.basename(parent));
     defer dir.close();
     try io_mod.durableReplaceVerified(alloc, &dir, std.fs.path.basename(path), json);
 }
@@ -1160,18 +1173,6 @@ fn isValidServerName(name: []const u8) bool {
     return true;
 }
 
-fn ensureDir(path: []const u8) void {
-    std.Io.Dir.createDirAbsolute(io_mod.getIo(), path, .default_dir) catch |err| switch (err) {
-        error.PathAlreadyExists => {},
-        else => {
-            if (std.fs.path.dirname(path)) |parent| {
-                ensureDir(parent);
-                std.Io.Dir.createDirAbsolute(io_mod.getIo(), path, .default_dir) catch {};
-            }
-        },
-    };
-}
-
 var stable_test_environ: ?*std.process.Environ.Map = null;
 
 fn stableEmptyTestEnviron() !*const std.process.Environ.Map {
@@ -1274,21 +1275,40 @@ test "saving MCP config replaces the file durably" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try writeTempFile(&tmp, "home/.fx/mcp.json", "{\"mcp\":{\"stale\":{\"command\":\"echo\"}}}");
+    const original = "{\"mcp\":{\"stale\":{\"command\":\"echo\"}}}";
+    try writeTempFile(&tmp, "home/.fx/mcp.json", original);
     const path = try tmpDirPath(alloc, tmp.dir, "home/.fx/mcp.json");
     defer alloc.free(path);
 
+    var fx_dir = try tmp.dir.openDir(io_mod.getIo(), "home/.fx", .{ .iterate = true });
+    defer fx_dir.close(io_mod.getIo());
+
+    // Seed a group-readable mode so the 0600 assertion below cannot pass just
+    // because the developer's umask already produced it.
+    {
+        var seed = try fx_dir.openFile(io_mod.getIo(), "mcp.json", .{ .mode = .read_write });
+        defer seed.close(io_mod.getIo());
+        try seed.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o644));
+    }
+
+    // Hold the pre-save file open. A rename-over leaves this descriptor on the
+    // old, unlinked inode; an in-place truncate would empty it instead, which
+    // is the failure this save must not have.
+    var held = try fx_dir.openFile(io_mod.getIo(), "mcp.json", .{});
+    defer held.close(io_mod.getIo());
+
     try saveConfigsToPath(alloc, path, &.{});
+
+    const held_stat = try held.stat(io_mod.getIo());
+    try std.testing.expectEqual(@as(u64, 0), held_stat.nlink);
+    const held_bytes = try io_mod.readFileToEnd(alloc, &held, 4096);
+    defer alloc.free(held_bytes);
+    try std.testing.expectEqualStrings(original, held_bytes);
 
     const written = try readFileForTest(alloc, path);
     defer alloc.free(written);
-    try std.testing.expect(std.mem.indexOf(u8, written, "stale") == null);
+    try std.testing.expect(std.mem.find(u8, written, "stale") == null);
 
-    // A durable replace renames a private temp file over the target, so the
-    // result is 0600 and no temp file is left behind. A plain truncating write
-    // leaves the mode the umask picked.
-    var fx_dir = try tmp.dir.openDir(io_mod.getIo(), "home/.fx", .{ .iterate = true });
-    defer fx_dir.close(io_mod.getIo());
     const stat = try fx_dir.statFile(io_mod.getIo(), "mcp.json", .{ .follow_symlinks = false });
     try std.testing.expectEqual(@as(u32, 0o600), stat.permissions.toMode() & 0o777);
 

--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -1705,6 +1705,74 @@ test "built-in MCP command mutates profile config and requests reload after save
     try expectLine(missing_result, "MCP server 'fs' not found.", false);
 }
 
+test "saving MCP config refuses a symlinked target" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const external = "{\"mcp\":{\"fs\":{\"command\":\"node\"}}}";
+    try writeTempFile(&tmp, "home/external.json", external);
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    const external_path = try tmpDirPath(alloc, tmp.dir, "home/external.json");
+    defer alloc.free(external_path);
+    try tmp.dir.symLink(io_mod.getIo(), external_path, "home/.fx/mcp.json", .{ .is_directory = false });
+
+    const path = try std.fs.path.join(alloc, &.{ std.fs.path.dirname(external_path).?, ".fx", "mcp.json" });
+    defer alloc.free(path);
+
+    // The durable helper refuses a target that is not a plain private file, so
+    // a symlinked config fails the save rather than writing through the link.
+    try std.testing.expectError(error.DurablePathUnsafe, saveConfigsToPath(alloc, path, &.{}));
+
+    const untouched = try readFileForTest(alloc, external_path);
+    defer alloc.free(untouched);
+    try std.testing.expectEqualStrings(external, untouched);
+}
+
+test "built-in MCP command reports a failed save instead of a missing server" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var fixture = ListFixture{ .text = "" };
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "home/external.json", "{\"mcp\":{\"fs\":{\"command\":\"node\"}}}");
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    const external_path = try tmpDirPath(alloc, tmp.dir, "home/external.json");
+    defer alloc.free(external_path);
+    try tmp.dir.symLink(io_mod.getIo(), external_path, "home/.fx/mcp.json", .{ .is_directory = false });
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+
+    // The server loads through the symlink, so this is a real entry whose
+    // removal cannot be persisted. It must not be reported as missing.
+    var result = try handleCommand(alloc, "remove fs", request(home, &fixture));
+    defer result.deinit(alloc);
+    try expectLine(result, "Failed to remove MCP server 'fs': DurablePathUnsafe.", false);
+}
+
+test "adding an MCP server creates the profile directory privately" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var fixture = ListFixture{ .text = "" };
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home");
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+
+    var result = try handleCommand(alloc, "add fs node server.js", request(home, &fixture));
+    defer result.deinit(alloc);
+    try expectLine(result, "Saved MCP server 'fs'.", true);
+
+    const dir_stat = try tmp.dir.statFile(io_mod.getIo(), "home/.fx", .{ .follow_symlinks = false });
+    try std.testing.expectEqual(@as(u32, 0o700), dir_stat.permissions.toMode() & 0o777);
+    const file_stat = try tmp.dir.statFile(io_mod.getIo(), "home/.fx/mcp.json", .{ .follow_symlinks = false });
+    try std.testing.expectEqual(@as(u32, 0o600), file_stat.permissions.toMode() & 0o777);
+}
+
 test "built-in MCP command preserves usage and missing-home notices" {
     const alloc = std.testing.allocator;
     var fixture = ListFixture{ .text = "" };

--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -503,10 +503,13 @@ fn saveConfigsToPath(alloc: Allocator, path: []const u8, configs: []const McpSer
     const json = try renderConfigJson(alloc, configs);
     defer alloc.free(json);
 
-    if (std.fs.path.dirname(path)) |parent| ensureDir(parent);
-    var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), path, .{ .truncate = true });
-    defer file.close(io_mod.getIo());
-    try file.writeStreamingAll(io_mod.getIo(), json);
+    const parent = std.fs.path.dirname(path) orelse return error.McpConfigPathInvalid;
+    ensureDir(parent);
+    var dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), parent, .{ .iterate = true }),
+    };
+    defer dir.close();
+    try io_mod.durableReplaceVerified(alloc, &dir, std.fs.path.basename(path), json);
 }
 
 fn freeConfigs(alloc: Allocator, configs: *std.ArrayList(McpServerConfig)) void {
@@ -1263,6 +1266,39 @@ fn tmpRoot(alloc: Allocator, tmp: std.testing.TmpDir) ![]u8 {
 
 fn tmpPath(alloc: Allocator, root: []const u8, name: []const u8) ![]u8 {
     return std.fs.path.join(alloc, &.{ root, name });
+}
+
+test "saving MCP config replaces the file durably" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "home/.fx/mcp.json", "{\"mcp\":{\"stale\":{\"command\":\"echo\"}}}");
+    const path = try tmpDirPath(alloc, tmp.dir, "home/.fx/mcp.json");
+    defer alloc.free(path);
+
+    try saveConfigsToPath(alloc, path, &.{});
+
+    const written = try readFileForTest(alloc, path);
+    defer alloc.free(written);
+    try std.testing.expect(std.mem.indexOf(u8, written, "stale") == null);
+
+    // A durable replace renames a private temp file over the target, so the
+    // result is 0600 and no temp file is left behind. A plain truncating write
+    // leaves the mode the umask picked.
+    var fx_dir = try tmp.dir.openDir(io_mod.getIo(), "home/.fx", .{ .iterate = true });
+    defer fx_dir.close(io_mod.getIo());
+    const stat = try fx_dir.statFile(io_mod.getIo(), "mcp.json", .{ .follow_symlinks = false });
+    try std.testing.expectEqual(@as(u32, 0o600), stat.permissions.toMode() & 0o777);
+
+    var it = fx_dir.iterate();
+    var entries: usize = 0;
+    while (try it.next(io_mod.getIo())) |entry| {
+        entries += 1;
+        try std.testing.expectEqualStrings("mcp.json", entry.name);
+    }
+    try std.testing.expectEqual(@as(usize, 1), entries);
 }
 
 fn tmpDirPath(alloc: Allocator, dir: std.Io.Dir, sub_path: []const u8) ![]u8 {


### PR DESCRIPTION
Fixes #163.

`saveConfigsToPath` truncated `~/.fx/mcp.json` before writing, so a crash or IO error mid-save left a zero-length or partial config and every configured server was gone. It now goes through `io_mod.durableReplaceVerified`, the helper the auth session file, settings store, session index and latest pointer, terminal host state, and session sidecars already use. The MCP config was the one config writer that did not.

Two follow-ups came out of reviewing that change, both in this PR:

`/mcp remove` collapsed every error from `removeServerFromPath` into `MCP server '<name>' not found.`. That was already misleading and got worse once the durable helper widened the error set, since a refused symlink or a permission failure would claim the server was missing while the entry sat on disk. It now reports the failure and keeps the not-found message for a genuine miss; `/mcp add` names its error the same way, matching `/mcp auth` and the resource surfaces.

The save opened the profile directory as a raw handle, so nothing verified `~/.fx` was a real private directory rather than a symlink. It now goes through `openOrCreateVerifiedPrivateDir`, which creates it at 0700, refuses a symlinked component, and fsyncs the parent on create. That also removed `ensureDir`, whose only remaining caller was itself.

## Two deliberate behavior changes

- **`mcp.json` becomes 0600 on its next save**, up from the umask default. It holds bearer tokens and OAuth client settings, and this matches how the auth session file is already treated.
- **A symlinked or hard-linked `mcp.json` now fails to save** instead of writing through the link, because the helper refuses a target that is not a plain single-linked file. That is the same posture the rest of the durable state already takes, and the failure is now legible rather than silent. If you would rather support that layout, the fix is to resolve the path before the split, and I am happy to change it.

## Verification

- The regression test holds the pre-save file open across the save and asserts that descriptor is unlinked and still holds the old bytes, the proof `io.zig:252` uses for the helper itself. Against a mutant that keeps the in-place truncate *and* chmods 0600, it fails on the inode check, so the mode assertion is not carrying the test. It also seeds a 0644 file first so the mode check cannot pass on a strict umask alone.
- Separately, capping `RLIMIT_FSIZE` so the write fails after the truncate destroys the config on the old code and leaves it byte-for-byte intact on this one. Not shipped as a test, since it manipulates a process-wide rlimit inside the shared test binary.
- Three tests cover the behavior changes: the symlink refusal with the linked file untouched, `/mcp remove` against that unsaveable config reporting the failure rather than a missing server, and a fresh profile coming out 0700 with the config at 0600.
- `zig build test` locally on linux-aarch64: no new failures against the same base without this branch. E2E `mcp-auth`, `mcp-stdio`, `mcp-legacy-remote`, and `cli` match a binary built from `origin/main` without this change.

Intended label: `type: bug`. I cannot set labels on this repo.

No new root `tests/e2e/*.test.ts` file, so `scripts/pgso/corpus.json` needs no entry.