### PR TITLE
Ignore unknown terminal escape sequences

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -638,16 +638,6 @@ pub fn Runtime(comptime App: type) type {
                             },
                         }
                     },
-                    .unrecognized_escape => |unrecognized| {
-                        if (unrecognized.cancel_pending) {
-                            // Dismiss approval with cancellation to avoid duplicate notices.
-                            if (app.approval_prompt.isActive()) {
-                                try approval_rt.cancelApprovalOperation(app);
-                            } else {
-                                try interrupt_rt.cancelActiveOperation(app);
-                            }
-                        }
-                    },
                 }
             }
             return replay_byte;
@@ -668,7 +658,7 @@ pub fn Runtime(comptime App: type) type {
                         disarmCtrlCExit(app, "semantic_action");
                         try resolveEscape(app, decoded.cancel_pending, now);
                     },
-                    .paste_byte, .raw, .unrecognized_escape => unreachable,
+                    .paste_byte, .raw => unreachable,
                 }
             }
         }
@@ -9894,7 +9884,7 @@ test "app_input_runtime pending Ctrl-C exits before repeating active cancellatio
     try std.testing.expectEqualStrings("", app.transcript.items);
 }
 
-test "app_input_runtime expired incomplete escape keeps approval cancellation behavior" {
+test "app_input_runtime expired incomplete control sequence preserves approval" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);
     defer app.deinit();
@@ -9908,9 +9898,23 @@ test "app_input_runtime expired incomplete escape keeps approval cancellation be
     try Runtime(RoutingFakeApp).flushPendingEscape(&app, 0);
 
     try std.testing.expectEqual(paste_framing.Owner.none, app.input_runtime.paste.owner);
-    try std.testing.expect(!app.approval_prompt.isActive());
-    try std.testing.expect(app.worker.cancel_requested);
+    try std.testing.expect(app.approval_prompt.isActive());
+    try std.testing.expect(!app.worker.cancel_requested);
     try std.testing.expect(app.worker.submitted_permission == null);
+}
+
+test "app_input_runtime complete unknown control sequence preserves active operation" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    app.stream.active = true;
+
+    try feedRoutingBytes(&app, "\x1b[>0q");
+
+    try std.testing.expect(app.stream.active);
+    try std.testing.expect(!app.worker.cancel_requested);
+    try std.testing.expectEqual(@as(u8, 0), app.terminal_input_runtime.terminal_action_decoder.stage);
+    try std.testing.expectEqualStrings("", app.input_runtime.edit_state.input.items);
 }
 
 test "app_input_runtime refreshes the pending escape deadline on decoder progress" {

--- a/src/core/input/input_action.zig
+++ b/src/core/input/input_action.zig
@@ -129,9 +129,6 @@ pub const TerminalInputEvent = union(enum) {
     paste_byte: u8,
     raw: RawTerminalInput,
     action: DecodedTerminalAction,
-    unrecognized_escape: struct {
-        cancel_pending: bool,
-    },
 };
 
 /// Core-owned facts sampled before UI advances its terminal decoder.

--- a/src/ui/input/escape_parser.zig
+++ b/src/ui/input/escape_parser.zig
@@ -31,9 +31,9 @@ const legacy_x10_column_stage: u8 = 11;
 const legacy_x10_row_stage: u8 = 12;
 const discarded_sgr_mouse_stage: u8 = 13;
 const discarded_x10_mouse_stage: u8 = 14;
-const csi_private_stage: u8 = 15;
+const control_sequence_discard_stage: u8 = 15;
 const sgr_mouse_max_bytes: u8 = 18;
-const csi_private_max_bytes: u16 = 32;
+const control_sequence_discard_max_bytes: u16 = 32;
 const kitty_up_key: u16 = 57352;
 const kitty_down_key: u16 = 57353;
 const shift_modifier: u16 = 0x01;
@@ -213,8 +213,12 @@ pub fn isMouseReportDiscardStage(stage: u8) bool {
     };
 }
 
-pub fn isPrivateCsiPayloadStage(stage: u8) bool {
-    return baseEscapeStage(stage) == csi_private_stage;
+pub fn isBareEscapeStage(stage: u8) bool {
+    return baseEscapeStage(stage) == 1;
+}
+
+pub fn isControlSequenceDiscardStage(stage: u8) bool {
+    return baseEscapeStage(stage) == control_sequence_discard_stage;
 }
 
 fn resetMouseEscapeDecode(stage: *u8, param: *u16, param2: *u16, mouse: *MouseInput) void {
@@ -222,6 +226,52 @@ fn resetMouseEscapeDecode(stage: *u8, param: *u16, param2: *u16, mouse: *MouseIn
     param.* = 0;
     param2.* = 0;
     mouse.reset();
+}
+
+fn beginControlSequenceDiscard(
+    stage: *u8,
+    param: *u16,
+    param2: *u16,
+    mouse: *MouseInput,
+    byte: u8,
+) ?InputEscapeAction {
+    if (byte >= 0x40 and byte <= 0x7e) {
+        resetMouseEscapeDecode(stage, param, param2, mouse);
+        return .ignore;
+    }
+    if (byte >= 0x20 and byte <= 0x3f) {
+        setBaseEscapeStage(stage, control_sequence_discard_stage);
+        param.* = 1;
+        param2.* = 0;
+        mouse.reset();
+        return null;
+    }
+    resetMouseEscapeDecode(stage, param, param2, mouse);
+    return .ignore;
+}
+
+fn consumeControlSequenceDiscardByte(
+    stage: *u8,
+    param: *u16,
+    param2: *u16,
+    mouse: *MouseInput,
+    byte: u8,
+) ?InputEscapeAction {
+    if (byte >= 0x40 and byte <= 0x7e) {
+        resetMouseEscapeDecode(stage, param, param2, mouse);
+        return .ignore;
+    }
+    if (byte < 0x20 or byte > 0x3f) {
+        resetMouseEscapeDecode(stage, param, param2, mouse);
+        return .ignore;
+    }
+
+    param.* = std.math.add(u16, param.*, 1) catch std.math.maxInt(u16);
+    if (param.* >= control_sequence_discard_max_bytes) {
+        resetMouseEscapeDecode(stage, param, param2, mouse);
+        return .ignore;
+    }
+    return null;
 }
 
 pub fn beginMouseReportDiscard(stage: *u8, param: *u16, param2: *u16, mouse: *MouseInput) bool {
@@ -395,7 +445,7 @@ pub fn consumeInputEscapeByteWithMouse(
             stage.* = 0;
             param.* = 0;
             param2.* = 0;
-            return null;
+            return .ignore;
         },
         2 => {
             const meta_prefixed = hasMetaPrefix(stage.*);
@@ -423,11 +473,7 @@ pub fn consumeInputEscapeByteWithMouse(
                     return null;
                 },
                 '?' => {
-                    param.* = 0;
-                    param2.* = 0;
-                    mouse.reset();
-                    setBaseEscapeStage(stage, csi_private_stage);
-                    return null;
+                    return beginControlSequenceDiscard(stage, param, param2, mouse, byte);
                 },
                 '0'...'9' => {
                     param.* = byte - '0';
@@ -435,29 +481,15 @@ pub fn consumeInputEscapeByteWithMouse(
                     setBaseEscapeStage(stage, 3);
                     return null;
                 },
-                else => null,
+                else => return beginControlSequenceDiscard(stage, param, param2, mouse, byte),
             };
             stage.* = 0;
             param.* = 0;
             param2.* = 0;
             return action;
         },
-        csi_private_stage => {
-            if (byte >= 0x40 and byte <= 0x7e) {
-                stage.* = 0;
-                param.* = 0;
-                param2.* = 0;
-                return .ignore;
-            }
-
-            param.* = std.math.add(u16, param.*, 1) catch std.math.maxInt(u16);
-            if (param.* >= csi_private_max_bytes) {
-                stage.* = 0;
-                param.* = 0;
-                param2.* = 0;
-                return .ignore;
-            }
-            return null;
+        control_sequence_discard_stage => {
+            return consumeControlSequenceDiscardByte(stage, param, param2, mouse, byte);
         },
         3 => {
             if (byte >= '0' and byte <= '9') {
@@ -473,18 +505,18 @@ pub fn consumeInputEscapeByteWithMouse(
                 return null;
             }
 
-            const meta_prefixed = hasMetaPrefix(stage.*);
-            const value = param.*;
-            const digit_count = param2.*;
-            stage.* = 0;
-            param.* = 0;
-            param2.* = 0;
             if (byte == 'u') {
+                const meta_prefixed = hasMetaPrefix(stage.*);
+                const value = param.*;
+                resetMouseEscapeDecode(stage, param, param2, mouse);
                 // Single-parameter CSI u: no `;`, so modifiers == 0.
                 return kittyUnicodeKeyAction(value, 0, meta_prefixed);
             }
-            if (byte != '~') return null;
+            if (byte != '~') return beginControlSequenceDiscard(stage, param, param2, mouse, byte);
 
+            const value = param.*;
+            const digit_count = param2.*;
+            resetMouseEscapeDecode(stage, param, param2, mouse);
             if (digit_count == 3 and value == 200) return .paste_start;
             if (digit_count == 3 and value == 201) return .paste_end;
 
@@ -499,12 +531,9 @@ pub fn consumeInputEscapeByteWithMouse(
         },
         4 => {
             const meta_prefixed = hasMetaPrefix(stage.*);
-            stage.* = 0;
-            param.* = 0;
-            param2.* = 0;
-            return switch (byte) {
+            const action: InputEscapeAction = switch (byte) {
                 'A', 'B', 'C', 'D' => if (meta_prefixed)
-                    modifiedArrowAction(byte, 0, true)
+                    modifiedArrowAction(byte, 0, true) orelse .ignore
                 else switch (byte) {
                     'A' => .cursor_up,
                     'B' => .cursor_down,
@@ -514,8 +543,10 @@ pub fn consumeInputEscapeByteWithMouse(
                 },
                 'H' => .home,
                 'F' => .end,
-                else => null,
+                else => return beginControlSequenceDiscard(stage, param, param2, mouse, byte),
             };
+            resetMouseEscapeDecode(stage, param, param2, mouse);
+            return action;
         },
         5 => {
             if (byte >= '0' and byte <= '9') {
@@ -531,18 +562,18 @@ pub fn consumeInputEscapeByteWithMouse(
                 return null;
             }
 
-            const meta_prefixed = hasMetaPrefix(stage.*);
-            const keycode = param2.*;
-            const modifiers = if (param.* > 0) param.* - 1 else 0;
-            stage.* = 0;
-            param.* = 0;
-            param2.* = 0;
-
             if (byte == 'u') {
+                const meta_prefixed = hasMetaPrefix(stage.*);
+                const keycode = param2.*;
+                const modifiers = if (param.* > 0) param.* - 1 else 0;
+                resetMouseEscapeDecode(stage, param, param2, mouse);
                 return kittyUnicodeKeyAction(keycode, modifiers, meta_prefixed);
             }
 
             if (byte == '~') {
+                const keycode = param2.*;
+                const modifiers = if (param.* > 0) param.* - 1 else 0;
+                resetMouseEscapeDecode(stage, param, param2, mouse);
                 if (keycode == 3 and (modifiers & 0x08) != 0) {
                     return .delete_to_line_end;
                 }
@@ -572,18 +603,28 @@ pub fn consumeInputEscapeByteWithMouse(
                 };
             }
 
-            if (byte == 'Z' and modifiers != 0) return .toggle_permission_mode;
-            if (modifiedArrowAction(byte, modifiers, meta_prefixed)) |action| return action;
+            const meta_prefixed = hasMetaPrefix(stage.*);
+            const modifiers = if (param.* > 0) param.* - 1 else 0;
+            if (byte == 'Z' and modifiers != 0) {
+                resetMouseEscapeDecode(stage, param, param2, mouse);
+                return .toggle_permission_mode;
+            }
+            if (modifiedArrowAction(byte, modifiers, meta_prefixed)) |action| {
+                resetMouseEscapeDecode(stage, param, param2, mouse);
+                return action;
+            }
 
-            return switch (byte) {
+            const action: InputEscapeAction = switch (byte) {
                 'A' => .cursor_up,
                 'B' => .cursor_down,
                 'C' => .cursor_right,
                 'D' => .cursor_left,
                 'H' => .home,
                 'F' => .end,
-                else => null,
+                else => return beginControlSequenceDiscard(stage, param, param2, mouse, byte),
             };
+            resetMouseEscapeDecode(stage, param, param2, mouse);
+            return action;
         },
         // Stage 6: third parameter (e.g. modifyOtherKeys: ESC[27;modifier;keycode~)
         6 => {
@@ -592,18 +633,15 @@ pub fn consumeInputEscapeByteWithMouse(
                 return null;
             }
 
-            const meta_prefixed = hasMetaPrefix(stage.*);
-            const keycode = param.*;
-            const modifiers = if (param2.* > 0) param2.* - 1 else 0;
-            stage.* = 0;
-            param.* = 0;
-            param2.* = 0;
-
             if (byte == '~') {
+                const meta_prefixed = hasMetaPrefix(stage.*);
+                const keycode = param.*;
+                const modifiers = if (param2.* > 0) param2.* - 1 else 0;
+                resetMouseEscapeDecode(stage, param, param2, mouse);
                 return kittyUnicodeKeyAction(keycode, modifiers, meta_prefixed);
             }
 
-            return null;
+            return beginControlSequenceDiscard(stage, param, param2, mouse, byte);
         },
         // SGR mouse: ESC [ < button ; column ; row M/m.
         sgr_mouse_stage => {

--- a/src/ui/input/runtime.zig
+++ b/src/ui/input/runtime.zig
@@ -132,7 +132,7 @@ fn withApprovalInput(
                 null,
             .cancel_pending = decoded.cancel_pending,
         } },
-        .paste_byte, .unrecognized_escape => event,
+        .paste_byte => event,
     };
     return typed;
 }
@@ -258,7 +258,7 @@ fn withQuestionInput(
             ),
             .cancel_pending = decoded.cancel_pending,
         } },
-        .paste_byte, .unrecognized_escape => event,
+        .paste_byte => event,
     };
     return typed;
 }
@@ -374,7 +374,7 @@ fn withSubagentInput(
             .subagent_action = subagentActionFromDecoded(decoded.action),
             .cancel_pending = decoded.cancel_pending,
         } },
-        .paste_byte, .unrecognized_escape => event,
+        .paste_byte => event,
     };
     return typed;
 }
@@ -1065,7 +1065,7 @@ pub const MouseReportDiscardResult = escape_parser.MouseReportDiscardResult;
 pub const isLegacyX10PayloadStage = escape_parser.isLegacyX10PayloadStage;
 pub const isMouseReportPayloadStage = escape_parser.isMouseReportPayloadStage;
 pub const isMouseReportDiscardStage = escape_parser.isMouseReportDiscardStage;
-pub const isPrivateCsiPayloadStage = escape_parser.isPrivateCsiPayloadStage;
+pub const isControlSequenceDiscardStage = escape_parser.isControlSequenceDiscardStage;
 pub const beginMouseReportDiscard = escape_parser.beginMouseReportDiscard;
 pub const consumeMouseReportDiscardByte = escape_parser.consumeMouseReportDiscardByte;
 pub const consumeInputEscapeByte = escape_parser.consumeInputEscapeByte;
@@ -2884,8 +2884,33 @@ test "input escape parser keeps private CSI digits in the escape sequence" {
     for ("[?12") |byte| {
         try std.testing.expectEqual(@as(?InputEscapeAction, null), consumeInputEscapeByte(&stage, &param, &param2, byte));
     }
-    try std.testing.expect(isPrivateCsiPayloadStage(stage));
+    try std.testing.expect(isControlSequenceDiscardStage(stage));
     try std.testing.expectEqual(@as(?InputEscapeAction, .ignore), consumeInputEscapeByte(&stage, &param, &param2, 'h'));
+    try std.testing.expectEqual(@as(u8, 0), stage);
+}
+
+test "input escape parser ignores complete unknown CSI and SS3 sequences" {
+    try expectEscapeAction("[I", .ignore);
+    try expectEscapeAction("[1;2R", .ignore);
+    try expectEscapeAction("[>0q", .ignore);
+    try expectEscapeAction("O1;2P", .ignore);
+}
+
+test "input escape parser keeps an unknown control sequence pending until its final byte" {
+    var stage: u8 = 1;
+    var param: u16 = 0;
+    var param2: u16 = 0;
+    for ("[>0") |byte| {
+        try std.testing.expectEqual(
+            @as(?InputEscapeAction, null),
+            consumeInputEscapeByte(&stage, &param, &param2, byte),
+        );
+    }
+    try std.testing.expect(isControlSequenceDiscardStage(stage));
+    try std.testing.expectEqual(
+        @as(?InputEscapeAction, .ignore),
+        consumeInputEscapeByte(&stage, &param, &param2, 'q'),
+    );
     try std.testing.expectEqual(@as(u8, 0), stage);
 }
 

--- a/src/ui/input/terminal_action_decoder.zig
+++ b/src/ui/input/terminal_action_decoder.zig
@@ -104,7 +104,7 @@ pub const Decoder = struct {
 
             if (prior_stage == 1 and
                 self.stage == 0 and
-                action == null and
+                (action == null or action.? == .ignore) and
                 shouldReplayControlAfterBareEscape(byte))
             {
                 const was_cancel_pending = self.takeCancelPending();
@@ -121,9 +121,8 @@ pub const Decoder = struct {
 
             if (self.stage != 0 or prior_stage != 0) {
                 if (self.stage == 0) {
-                    ingress.setEvent(.{ .unrecognized_escape = .{
-                        .cancel_pending = self.takeCancelPending(),
-                    } });
+                    _ = self.takeCancelPending();
+                    appendAction(&ingress, .ignore, false);
                 }
                 return ingress;
             }
@@ -157,8 +156,8 @@ pub const Decoder = struct {
             return ingress;
         }
 
-        if (escape_parser.isPrivateCsiPayloadStage(self.stage)) {
-            debug_trace.logf("input", "discard pending private csi reason=quiet_expiry", .{});
+        if (escape_parser.isControlSequenceDiscardStage(self.stage)) {
+            debug_trace.logf("input", "discard pending control sequence reason=quiet_expiry", .{});
             self.reset();
             return ingress;
         }
@@ -182,6 +181,12 @@ pub const Decoder = struct {
             } else {
                 self.started_ms = now_ms;
             }
+            return ingress;
+        }
+
+        if (!escape_parser.isBareEscapeStage(self.stage)) {
+            debug_trace.logf("input", "discard pending control sequence reason=quiet_expiry", .{});
+            self.reset();
             return ingress;
         }
 
@@ -334,7 +339,7 @@ test "active paste bypasses decoding and preserves pending text ownership" {
     try std.testing.expect(!decoder.hasPending());
 }
 
-test "unknown escape requests only the captured cancellation" {
+test "unknown escape resolves to ignore instead of Escape" {
     var decoder = Decoder{};
     _ = decoder.feed(0x1b, .{
         .now_ms = 1,
@@ -349,6 +354,44 @@ test "unknown escape requests only the captured cancellation" {
         .child_route_active = false,
     });
 
-    try std.testing.expect(ingress.event.?.unrecognized_escape.cancel_pending);
+    try std.testing.expectEqual(input_action.Action.ignore, ingress.event.?.action.action);
+    try std.testing.expect(ingress.event.?.action.cancel_pending);
+    try std.testing.expect(!decoder.hasPending());
+}
+
+test "unknown complete CSI stays pending until its final byte and resolves to ignore" {
+    var decoder = Decoder{};
+    const context: input_action.TerminalDecodeContext = .{
+        .now_ms = 1,
+        .paste_active = false,
+        .cancel_pending = true,
+        .child_route_active = false,
+    };
+
+    _ = decoder.feed(0x1b, context);
+    for ("[>0") |byte| {
+        const ingress = decoder.feed(byte, context);
+        try std.testing.expect(ingress.event == null);
+        try std.testing.expect(decoder.hasPending());
+    }
+    const ingress = decoder.feed('q', context);
+    try std.testing.expectEqual(input_action.Action.ignore, ingress.event.?.action.action);
+    try std.testing.expect(ingress.event.?.action.cancel_pending);
+    try std.testing.expect(!decoder.hasPending());
+}
+
+test "incomplete CSI expires without producing Escape" {
+    var decoder = Decoder{};
+    const context: input_action.TerminalDecodeContext = .{
+        .now_ms = 1,
+        .paste_active = false,
+        .cancel_pending = true,
+        .child_route_active = false,
+    };
+
+    _ = decoder.feed(0x1b, context);
+    _ = decoder.feed('[', context);
+    const ingress = decoder.flush(31, 30, false);
+    try std.testing.expect(ingress.event == null);
     try std.testing.expect(!decoder.hasPending());
 }

--- a/tests/e2e/tui-input-navigation.test.ts
+++ b/tests/e2e/tui-input-navigation.test.ts
@@ -332,6 +332,33 @@ tmuxTest(
 );
 
 tmuxTest(
+  "unknown terminal escape sequences leave the command catalog open",
+  async () => {
+    const active = await startFx(80, 24);
+    await active.sendText("/help");
+    await active.waitForPane(
+      (pane) =>
+        pane.includes("/help") &&
+        pane.includes("/quit") &&
+        !pane.includes("Run /help for commands"),
+      READY_TIMEOUT,
+    );
+
+    await active.sendHexBytes(hexSeq("\x1b[>0q"));
+    const afterUnknown = await active.capturePane();
+    expect(afterUnknown).toContain("/help");
+    expect(afterUnknown).toContain("/quit");
+    expect(afterUnknown).not.toContain("Run /help for commands");
+
+    await active.sendKeys("Escape");
+    await active.waitForText("Run /help for commands", READY_TIMEOUT);
+    expect(active.isAlive()).toBe(true);
+    expectCleanStderr();
+  },
+  TIMEOUT,
+);
+
+tmuxTest(
   "plain Up and Down move exactly one hard-newline visual row per press",
   async () => {
     const active = await startFx(60, 24);


### PR DESCRIPTION
## Summary

- Ignore completed unknown CSI and SS3 sequences without cancelling active work.
- Discard incomplete structured escape sequences when their timeout expires.
- Preserve recognized shortcuts and standalone Escape behavior.

## Root cause

Completed but unrecognized escape sequences produced an event carrying the cancellation state captured from the leading Escape byte. Core treated that event as a request to cancel the active operation.

## Validation

- `zig build test`
- `zig build`
- `zig fmt --check src/`
- Built binary in tmux: `ESC [ > 0 q` left Help open, standalone Escape closed it, and stderr remained empty.

Remote Devbox validation is still pending because no Devbox or SSH target is available locally.

Linear: [FXC-226](https://linear.app/vercel/issue/FXC-226)
