### PR TITLE
Name terminal tabs after the active session

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ fx session resume last
 fx session resume --id <id>
 ```
 
+Each session names its terminal tab. The title carries the session name once one exists, so parallel fx tabs stay distinguishable, and falls back to the active model before the first turn names the session. Renaming a session with `/rename` renames its tab.
+
 Run `/feedback` to open the feedback form at `fx.sh/feedback`. It does not create a diagnostic or change the clipboard.
 
 Run `/trace` to create a private Markdown diagnostic with logs, session context, runtime state, permissions, and recent activity. On macOS, fx copies the `.md` file to the clipboard; on other platforms, it saves the file and prints its path. Review and redact the trace before sharing it.

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -437,7 +437,7 @@ pub fn Runtime(comptime App: type) type {
             if (app.requested_resume == null) {
                 try deps.begin_fresh_persisted_session(app);
                 deps.enable_session_stores(app);
-                deps.terminal_title.setModel(app.selected_model.items);
+                deps.terminal_title.set(app.selected_model.items);
             }
 
             switch (staged_resume_view) {
@@ -629,7 +629,7 @@ fn testDeps() BootstrapDeps(TestApp) {
         .begin_fresh_persisted_session = beginFreshPersistedSessionForTest,
         .enable_session_stores = enableSessionStoresForTest,
         .terminal_title = .{
-            .set_model_fn = setTerminalTitleModelForTest,
+            .set_fn = setTerminalTitleLabelForTest,
             .clear_fn = clearTerminalTitleForTest,
         },
     };
@@ -802,10 +802,10 @@ fn enableSessionStoresForTest(_: *TestApp) void {
     capture.recordEvent("enable_stores");
 }
 
-fn setTerminalTitleModelForTest(_: ?*anyopaque, model: []const u8) void {
+fn setTerminalTitleLabelForTest(_: ?*anyopaque, label: []const u8) void {
     const capture = active_capture.?;
-    capture.title_len = @min(model.len, capture.title.len);
-    @memcpy(capture.title[0..capture.title_len], model[0..capture.title_len]);
+    capture.title_len = @min(label.len, capture.title.len);
+    @memcpy(capture.title[0..capture.title_len], label[0..capture.title_len]);
     capture.recordEvent("title");
 }
 

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const question_answer = @import("../agent/question_answer.zig");
 const config_runtime = @import("../config/config_runtime.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
@@ -6,6 +7,7 @@ const assistant_presentation = @import("../agent/assistant_presentation.zig");
 const tool_presentation = @import("../agent/runtime/tool_presentation.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const runtime_profile = @import("../hosts/runtime_profile.zig");
+const host_capability = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
 const diff = @import("../output/diff.zig");
 const diagnostics = @import("../workspace/diagnostics.zig");
@@ -2869,16 +2871,51 @@ pub fn Runtime(comptime App: type) type {
             return null;
         }
 
-        /// Replaces the cached footer title. App owns the copy.
+        /// Replaces the cached footer title. App owns the copy. Keeps the
+        /// terminal title in step because both surfaces read this cache.
         pub fn setCachedSessionTitle(app: *App, title: []const u8) !void {
             if (comptime !@hasField(App, "session_title")) return;
             app.session_title.clearRetainingCapacity();
-            try app.session_title.appendSlice(app.alloc, title);
+            try appendTitleWithoutControlBytes(app, title);
+            syncTerminalTitle(app);
         }
 
         pub fn clearCachedSessionTitle(app: *App) void {
             if (comptime !@hasField(App, "session_title")) return;
             app.session_title.clearRetainingCapacity();
+            syncTerminalTitle(app);
+        }
+
+        /// Drops C0 and DEL bytes. The cached title feeds the statusline and
+        /// the OSC 2 terminal title, where a stray BEL or ESC would close the
+        /// escape sequence early and hand the remaining bytes to the terminal
+        /// as commands. Derived titles come from prompt text and from the
+        /// display sidecar, so neither source is trusted here; `/rename` input
+        /// is already rejected by `validateSessionTitle`.
+        fn appendTitleWithoutControlBytes(app: *App, title: []const u8) !void {
+            var start: usize = 0;
+            for (title, 0..) |byte, index| {
+                if (byte >= 0x20 and byte != 0x7f) continue;
+                try app.session_title.appendSlice(app.alloc, title[start..index]);
+                start = index + 1;
+            }
+            try app.session_title.appendSlice(app.alloc, title[start..]);
+        }
+
+        fn terminalTitle(app: *App) host_capability.TerminalTitle {
+            if (comptime @hasDecl(App, "terminalTitle")) {
+                return app.terminalTitle();
+            }
+            if (comptime builtin.is_test) return host_capability.unavailable_terminal_title;
+            @compileError("interactive session runtime requires a terminal title host capability");
+        }
+
+        /// Terminal tabs carry the session name once one exists so several fx
+        /// tabs stay distinguishable, and fall back to the model before the
+        /// first turn names the session.
+        pub fn syncTerminalTitle(app: *App) void {
+            if (comptime !@hasField(App, "selected_model")) return;
+            terminalTitle(app).set(cachedSessionTitle(app) orelse app.selected_model.items);
         }
 
         pub fn cachedSessionTitle(app: *App) ?[]const u8 {
@@ -4994,6 +5031,8 @@ const TestApp = struct {
     session: session_runtime.SessionRuntime = .{ .max_history_turns = 8 },
     session_persistence: Persistence = .{},
     session_title: std.ArrayList(u8) = .empty,
+    terminal_title_label: [128]u8 = undefined,
+    terminal_title_label_len: usize = 0,
     input_runtime: core_input_runtime.Runtime = .{},
     terminal_input_runtime: ui_input.Runtime = .{},
     shell: transcript_runtime.TranscriptRuntime = .{},
@@ -5077,6 +5116,32 @@ const TestApp = struct {
             initialized += 1;
         }
         return names;
+    }
+
+    fn terminalTitle(self: *TestApp) host_capability.TerminalTitle {
+        return .{
+            .context = self,
+            .set_fn = setTerminalTitleLabelForTest,
+            .clear_fn = clearTerminalTitleForTest,
+        };
+    }
+
+    fn setTerminalTitleLabelForTest(raw: ?*anyopaque, label: []const u8) void {
+        const self: *TestApp = @ptrCast(@alignCast(raw.?));
+        self.terminal_title_label_len = @min(label.len, self.terminal_title_label.len);
+        @memcpy(
+            self.terminal_title_label[0..self.terminal_title_label_len],
+            label[0..self.terminal_title_label_len],
+        );
+    }
+
+    fn clearTerminalTitleForTest(raw: ?*anyopaque) void {
+        const self: *TestApp = @ptrCast(@alignCast(raw.?));
+        self.terminal_title_label_len = 0;
+    }
+
+    fn terminalTitleLabelText(self: *const TestApp) []const u8 {
+        return self.terminal_title_label[0..self.terminal_title_label_len];
     }
 
     fn deinit(self: *TestApp) void {
@@ -9564,6 +9629,9 @@ test "renameActiveSession persists the title to the sidecar and session index" {
         Runtime(TestApp).cachedSessionTitle(&app).?,
     );
 
+    // And carried to the terminal tab.
+    try std.testing.expectEqualStrings("deploy pipeline fix", app.terminalTitleLabelText());
+
     // Durable in the sidecar.
     const loaded = &app.session_persistence.writable.?;
     var display = try session_display_metadata.readSidecarOrFallback(alloc, &loaded.log.dir);
@@ -9615,4 +9683,72 @@ test "ensureCachedSessionTitle derives from the first prompt and then freezes" {
     // A fresh session clears it.
     Runtime(TestApp).clearCachedSessionTitle(&app);
     try std.testing.expect(Runtime(TestApp).cachedSessionTitle(&app) == null);
+}
+
+test "terminal title follows the session name and falls back to the model" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+
+    try app.selected_model.appendSlice(alloc, "zai/glm-5.2");
+
+    // Before the first turn names the session, tabs show the model.
+    Runtime(TestApp).syncTerminalTitle(&app);
+    try std.testing.expectEqualStrings("zai/glm-5.2", app.terminalTitleLabelText());
+
+    try app.session.appendHistoryEntry(alloc, .{ .assistant = .{
+        .user = .{ .text = @constCast("wire the release notes generator") },
+        .assistant = @constCast("ok"),
+        .execution = .{},
+    } });
+    try Runtime(TestApp).ensureCachedSessionTitle(&app);
+    try std.testing.expectEqualStrings(
+        "wire the release notes generator",
+        app.terminalTitleLabelText(),
+    );
+
+    // A model switch must not take the tab name back from the session.
+    app.selected_model.clearRetainingCapacity();
+    try app.selected_model.appendSlice(alloc, "anthropic/claude-opus-5");
+    Runtime(TestApp).syncTerminalTitle(&app);
+    try std.testing.expectEqualStrings(
+        "wire the release notes generator",
+        app.terminalTitleLabelText(),
+    );
+
+    // Starting over hands the tab back to the model.
+    Runtime(TestApp).clearCachedSessionTitle(&app);
+    try std.testing.expectEqualStrings("anthropic/claude-opus-5", app.terminalTitleLabelText());
+}
+
+test "cached session title drops control bytes before they reach the terminal" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+
+    // Derived titles come from prompt text and from the display sidecar, so a
+    // BEL could otherwise close the OSC 2 sequence and hand the rest of the
+    // title to the terminal as commands.
+    try Runtime(TestApp).setCachedSessionTitle(&app, "safe\x07\x1b]2;owned\x7ftail");
+    try std.testing.expectEqualStrings(
+        "safe]2;ownedtail",
+        Runtime(TestApp).cachedSessionTitle(&app).?,
+    );
+    try std.testing.expectEqualStrings("safe]2;ownedtail", app.terminalTitleLabelText());
 }

--- a/src/core/hosts/host.zig
+++ b/src/core/hosts/host.zig
@@ -55,13 +55,14 @@ fn unavailableUrlOpen(
 
 pub const TerminalTitle = struct {
     context: ?*anyopaque = null,
-    set_model_fn: *const fn (?*anyopaque, []const u8) void,
+    set_fn: *const fn (?*anyopaque, []const u8) void,
     clear_fn: *const fn (?*anyopaque) void,
 
-    /// Borrows `model` for this call. Terminal write failures are intentionally
+    /// Borrows `label` for this call. Callers resolve what the label says; the
+    /// provider only renders it. Terminal write failures are intentionally
     /// non-fatal because the title is presentation metadata.
-    pub fn setModel(self: TerminalTitle, model: []const u8) void {
-        self.set_model_fn(self.context, model);
+    pub fn set(self: TerminalTitle, label: []const u8) void {
+        self.set_fn(self.context, label);
     }
 
     pub fn clear(self: TerminalTitle) void {
@@ -70,11 +71,11 @@ pub const TerminalTitle = struct {
 };
 
 pub const unavailable_terminal_title: TerminalTitle = .{
-    .set_model_fn = ignoreTerminalTitleSetModel,
+    .set_fn = ignoreTerminalTitleSet,
     .clear_fn = ignoreTerminalTitleClear,
 };
 
-fn ignoreTerminalTitleSetModel(_: ?*anyopaque, _: []const u8) void {}
+fn ignoreTerminalTitleSet(_: ?*anyopaque, _: []const u8) void {}
 
 fn ignoreTerminalTitleClear(_: ?*anyopaque) void {}
 
@@ -268,16 +269,16 @@ pub fn operatingSystemText(alloc: std.mem.Allocator) std.mem.Allocator.Error![]u
     return std.fmt.allocPrint(alloc, "{s} {s}", .{ sysname, release });
 }
 
-test "terminal title forwards borrowed model bytes and clear" {
+test "terminal title forwards borrowed label bytes and clear" {
     const Capture = struct {
-        model: [64]u8 = undefined,
-        model_len: usize = 0,
+        label: [64]u8 = undefined,
+        label_len: usize = 0,
         clear_count: usize = 0,
 
-        fn setModel(raw: ?*anyopaque, model: []const u8) void {
+        fn set(raw: ?*anyopaque, label: []const u8) void {
             const self: *@This() = @ptrCast(@alignCast(raw.?));
-            self.model_len = @min(model.len, self.model.len);
-            @memcpy(self.model[0..self.model_len], model[0..self.model_len]);
+            self.label_len = @min(label.len, self.label.len);
+            @memcpy(self.label[0..self.label_len], label[0..self.label_len]);
         }
 
         fn clear(raw: ?*anyopaque) void {
@@ -285,27 +286,27 @@ test "terminal title forwards borrowed model bytes and clear" {
             self.clear_count += 1;
         }
 
-        fn model_text(self: *const @This()) []const u8 {
-            return self.model[0..self.model_len];
+        fn label_text(self: *const @This()) []const u8 {
+            return self.label[0..self.label_len];
         }
     };
 
     var capture = Capture{};
     const terminal_title = TerminalTitle{
         .context = &capture,
-        .set_model_fn = Capture.setModel,
+        .set_fn = Capture.set,
         .clear_fn = Capture.clear,
     };
 
-    terminal_title.setModel("provider/model");
+    terminal_title.set("session name");
     terminal_title.clear();
 
-    try std.testing.expectEqualStrings("provider/model", capture.model_text());
+    try std.testing.expectEqualStrings("session name", capture.label_text());
     try std.testing.expectEqual(@as(usize, 1), capture.clear_count);
 }
 
 test "unavailable terminal title accepts set and clear" {
-    unavailable_terminal_title.setModel("provider/model");
+    unavailable_terminal_title.set("provider/model");
     unavailable_terminal_title.clear();
 }
 

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const builtin = @import("builtin");
 const app_permission_runtime = @import("../app/app_permission_runtime.zig");
 const app_session_runtime = @import("../app/app_session_runtime.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
@@ -255,14 +254,6 @@ fn appendLegacyCleanup(writer: *std.Io.Writer, cleanup: config_runtime.LegacyCle
 
 pub fn Commands(comptime App: type) type {
     return struct {
-        fn terminalTitle(app: *App) host.TerminalTitle {
-            if (comptime @hasDecl(App, "terminalTitle")) {
-                return app.terminalTitle();
-            }
-            if (comptime builtin.is_test) return host.unavailable_terminal_title;
-            @compileError("interactive session commands require a terminal title host capability");
-        }
-
         fn update_channel_label(app: *App) []const u8 {
             if (comptime @hasField(App, "upgrader")) {
                 const Upgrader = @TypeOf(app.upgrader);
@@ -1131,7 +1122,8 @@ pub fn Commands(comptime App: type) type {
             const selected = app.selected_model.items;
             try app.worker.syncQueuedPromptModel(std.heap.c_allocator, selected);
             if (comptime @hasDecl(App, "persistAcceptedModel")) try app.persistAcceptedModel(selected);
-            terminalTitle(app).setModel(selected);
+            // A named session keeps its terminal title across model switches.
+            app_session_runtime.Runtime(App).syncTerminalTitle(app);
 
             if (announce) {
                 const active_response = if (comptime @hasField(App, "stream"))
@@ -1693,8 +1685,8 @@ const FakeApp = struct {
     permission_mode_preference_commit_count: usize = 0,
     last_preference_permission_mode: ?types.PermissionMode = null,
     semantic_write_count: usize = 0,
-    terminal_title_model: [128]u8 = undefined,
-    terminal_title_model_len: usize = 0,
+    terminal_title_label: [128]u8 = undefined,
+    terminal_title_label_len: usize = 0,
 
     fn init(alloc: std.mem.Allocator, workspace_root: []const u8, model: []const u8) !FakeApp {
         var app = FakeApp{
@@ -1745,30 +1737,32 @@ const FakeApp = struct {
         return self.tool_registry;
     }
 
-    fn terminalTitle(self: *FakeApp) host.TerminalTitle {
+    // Public so `@hasDecl` sees it from the session runtime, which is where
+    // the terminal title is now resolved.
+    pub fn terminalTitle(self: *FakeApp) host.TerminalTitle {
         return .{
             .context = self,
-            .set_model_fn = setTerminalTitleModelForTest,
+            .set_fn = setTerminalTitleLabelForTest,
             .clear_fn = clearTerminalTitleForTest,
         };
     }
 
-    fn setTerminalTitleModelForTest(raw: ?*anyopaque, model: []const u8) void {
+    fn setTerminalTitleLabelForTest(raw: ?*anyopaque, label: []const u8) void {
         const self: *FakeApp = @ptrCast(@alignCast(raw.?));
-        self.terminal_title_model_len = @min(model.len, self.terminal_title_model.len);
+        self.terminal_title_label_len = @min(label.len, self.terminal_title_label.len);
         @memcpy(
-            self.terminal_title_model[0..self.terminal_title_model_len],
-            model[0..self.terminal_title_model_len],
+            self.terminal_title_label[0..self.terminal_title_label_len],
+            label[0..self.terminal_title_label_len],
         );
     }
 
     fn clearTerminalTitleForTest(raw: ?*anyopaque) void {
         const self: *FakeApp = @ptrCast(@alignCast(raw.?));
-        self.terminal_title_model_len = 0;
+        self.terminal_title_label_len = 0;
     }
 
-    fn terminalTitleModelText(self: *const FakeApp) []const u8 {
-        return self.terminal_title_model[0..self.terminal_title_model_len];
+    fn terminalTitleLabelText(self: *const FakeApp) []const u8 {
+        return self.terminal_title_label[0..self.terminal_title_label_len];
     }
 
     fn snapshotCachedModelIds(self: *FakeApp, alloc: std.mem.Allocator) !?std.ArrayList([]u8) {
@@ -2199,7 +2193,7 @@ test "session_commands handleModel reports current model for empty query" {
 
     try std.testing.expectEqualStrings("● Model: anthropic/claude-opus-4.6\n", app.text());
     try std.testing.expect(app.worker.synced_model == null);
-    try std.testing.expectEqualStrings("", app.terminalTitleModelText());
+    try std.testing.expectEqualStrings("", app.terminalTitleLabelText());
 }
 
 test "session_commands handleModel resolves fuzzy cached model and syncs queued prompts" {
@@ -2216,7 +2210,7 @@ test "session_commands handleModel resolves fuzzy cached model and syncs queued 
 
     try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", app.selected_model.items);
     try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", app.worker.synced_model.?);
-    try std.testing.expectEqualStrings(app.selected_model.items, app.terminalTitleModelText());
+    try std.testing.expectEqualStrings(app.selected_model.items, app.terminalTitleLabelText());
     try expectTranscriptContains(&app, "● Switched to anthropic/claude-sonnet-4-20250514");
 }
 
@@ -2230,7 +2224,7 @@ test "session_commands handleModel falls back to raw query when model fetch fail
 
     try std.testing.expectEqualStrings("custom/provider-model", app.selected_model.items);
     try std.testing.expectEqualStrings("custom/provider-model", app.worker.synced_model.?);
-    try std.testing.expectEqualStrings(app.selected_model.items, app.terminalTitleModelText());
+    try std.testing.expectEqualStrings(app.selected_model.items, app.terminalTitleLabelText());
 }
 
 test "session_commands handlePermissions persists modes and reset clears session grants" {
@@ -2762,7 +2756,7 @@ test "session_commands model picker accepts the current selected model slice" {
     try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.selected_model.items);
     try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.worker.synced_model.?);
     try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.last_preference_model.items);
-    try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.terminalTitleModelText());
+    try std.testing.expectEqualStrings("anthropic/claude-opus-4.6", app.terminalTitleLabelText());
     try std.testing.expectEqual(types.ReasoningEffort.literal("high"), app.effort);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -459,8 +459,8 @@ const App = struct {
         return if (comptime host_profile.clipboard) native_host.clipboard else host.unavailable_clipboard;
     }
 
-    pub fn terminalTitle(_: *const Self) host.TerminalTitle {
-        return ui_render.terminal_title;
+    pub fn terminalTitle(self: *const Self) host.TerminalTitle {
+        return ui_render.terminalTitleFor(&self.shell.stdout_file);
     }
 
     alloc: Allocator,
@@ -602,7 +602,7 @@ const App = struct {
             .{
                 .load_mcp_runtime = if (comptime host_target.is_wasm) loadNoMcpRuntime else builtin_mcp.loadRuntime,
                 .skill_root_policy = if (comptime host_target.is_wasm) wasm_skill_root_policy else builtin_skills.root_policy,
-                .terminal_title = ui_render.terminal_title,
+                .terminal_title = app.terminalTitle(),
             },
         );
         errdefer app.deinit();
@@ -622,7 +622,7 @@ const App = struct {
                 } else {
                     try SessionAppRuntime.resumeRequestedSession(&app);
                 }
-                app.terminalTitle().setModel(app.selected_model.items);
+                SessionAppRuntime.syncTerminalTitle(&app);
             }
         }
         if (comptime host_profile.durable_sessions) {

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -523,21 +523,50 @@ test "render width zero emits no row bytes and first cursor column" {
     try std.testing.expectEqual(@as(u16, 1), view.cursor_col);
 }
 
-pub const terminal_title: host.TerminalTitle = .{
-    .set_model_fn = setTerminalTitleModel,
-    .clear_fn = clearTerminalTitleProvider,
-};
-
-fn setTerminalTitleModel(_: ?*anyopaque, model: []const u8) void {
-    const stdout = std.Io.File.stdout();
-    stdout.writeStreamingAll(io_mod.getIo(), "\x1b]2;fx · ") catch return;
-    stdout.writeStreamingAll(io_mod.getIo(), model) catch return;
-    stdout.writeStreamingAll(io_mod.getIo(), "\x07") catch return;
+/// Writes the title to the same file the transcript renders to, so a host
+/// that redirects its output keeps the escape sequence out of the real
+/// stdout. `out` must outlive every call.
+pub fn terminalTitleFor(out: *const std.Io.File) host.TerminalTitle {
+    return .{
+        .context = @constCast(out),
+        .set_fn = setTerminalTitleLabel,
+        .clear_fn = clearTerminalTitleProvider,
+    };
 }
 
-fn clearTerminalTitleProvider(_: ?*anyopaque) void {
-    const stdout = std.Io.File.stdout();
-    stdout.writeStreamingAll(io_mod.getIo(), "\x1b]2;\x07") catch return;
+fn titleOutput(raw: ?*anyopaque) std.Io.File {
+    const out: *const std.Io.File = @ptrCast(@alignCast(raw.?));
+    return out.*;
+}
+
+fn setTerminalTitleLabel(raw: ?*anyopaque, label: []const u8) void {
+    const out = titleOutput(raw);
+    out.writeStreamingAll(io_mod.getIo(), "\x1b]2;fx · ") catch return;
+    out.writeStreamingAll(io_mod.getIo(), label) catch return;
+    out.writeStreamingAll(io_mod.getIo(), "\x07") catch return;
+}
+
+fn clearTerminalTitleProvider(raw: ?*anyopaque) void {
+    const out = titleOutput(raw);
+    out.writeStreamingAll(io_mod.getIo(), "\x1b]2;\x07") catch return;
+}
+
+test "terminal title writes the label to the caller's output file" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var sink = try tmp.dir.createFile(std.testing.io, "terminal-title.log", .{});
+    defer sink.close(io_mod.getIo());
+
+    // A host that redirects its output keeps the escape sequence off the
+    // real stdout, which the Zig test runner owns as its protocol channel.
+    terminalTitleFor(&sink).set("release notes");
+
+    var written_file = try tmp.dir.openFile(io_mod.getIo(), "terminal-title.log", .{});
+    defer written_file.close(io_mod.getIo());
+    const written = try io_mod.readFileToEnd(alloc, &written_file, 128);
+    defer alloc.free(written);
+    try std.testing.expectEqualStrings("\x1b]2;fx · release notes\x07", written);
 }
 
 pub fn formatResumeHandoff(

--- a/tests/e2e/render-lab/audit-direct-writes.ts
+++ b/tests/e2e/render-lab/audit-direct-writes.ts
@@ -55,7 +55,7 @@ const allowlist: AllowRule[] = [
   rule("src/ui/ask_presentation.zig", "init", /stdio_acquisition/, "interactive_terminal_owner", "stored ask presenter stdout handle"),
   rule("src/ui/ask_presentation.zig", "refreshGeometry", /fixed_descriptor/, "terminal_probe", "ask stdout geometry refresh"),
   rule("src/ui/ask_presentation.zig", "writeTerminalBytes", /stdio_write/, "initialization_teardown", "ask terminal prepare and restore control"),
-  rule("src/ui/render.zig", "(?:setTerminalTitleModel|clearTerminalTitleProvider)", /stdio_(?:acquisition|write)/, "title_control", "terminal title control"),
+  rule("src/ui/render.zig", "(?:setTerminalTitleLabel|clearTerminalTitleProvider)", /stdio_(?:acquisition|write)/, "title_control", "terminal title control"),
   rule("src/acp/jsonrpc.zig", ".+", /stdio_(?:acquisition|write)/, "acp_protocol_transport", "ACP JSON-RPC transport"),
   rule("src/core/permissions/sandbox.zig", "(?:runForegroundSessionBootstrap|writeForegroundSessionReplaceFailure)", /stdio_acquisition_write/, "subprocess_protocol_transport", "foreground command bootstrap protocol"),
   rule("src/core/terminal/native_session.zig", "(?:acceptMarker|runLauncher)", /fixed_descriptor/, "subprocess_protocol_transport", "private native launcher PTY and control descriptors"),

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -869,6 +869,25 @@ export class TmuxSession {
   }
 
   /**
+   * Current pane title, which is what a terminal renders as the tab label.
+   * fx sets it through OSC 2, so this reads back what the user would see.
+   */
+  async paneTitle(): Promise<string> {
+    try {
+      return execFileSync(
+        "tmux",
+        this.tmuxArgs(["display-message", "-p", "-t", this.name, "#{pane_title}"]),
+        {
+          stdio: "pipe",
+          encoding: "utf-8",
+        },
+      ).trimEnd();
+    } catch {
+      return "";
+    }
+  }
+
+  /**
    * Resize the tmux window. Delivers a real SIGWINCH to fx, exercising the
    * resize pipeline end-to-end. Default post-resize sleep covers the 100 ms
    * debounce in src/main.zig.

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -83,11 +83,19 @@ function captureViewportEscapes(session: TmuxSession): string {
   });
 }
 
-function capturePaneTitle(session: TmuxSession): string {
-  return execFileSync("tmux", ["display-message", "-p", "-t", session.name, "#{pane_title}"], {
-    stdio: "pipe",
-    encoding: "utf-8",
-  }).trimEnd();
+async function waitForPaneTitle(
+  session: TmuxSession,
+  expected: string,
+  timeout: number,
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  let latest = "";
+  while (Date.now() < deadline) {
+    latest = await session.paneTitle();
+    if (latest === expected) return;
+    await Bun.sleep(50);
+  }
+  throw new Error(`pane title never became ${expected}; last saw ${latest}`);
 }
 
 async function waitForSkillsMenu(session: TmuxSession, count: number): Promise<string[]> {
@@ -649,6 +657,102 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendText("/quit");
       expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
       session = null;
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "terminal tab title follows the session name across rename and resume",
+    async () => {
+      const workDir = mkdtempSync(join(tmpdir(), "fx-title-rename-e2e-"));
+      workDirs.push(workDir);
+      const home = join(workDir, "home");
+      const workspace = join(workDir, "workspace");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ sandbox: "none", permission: {} }),
+      );
+
+      const stderrPath = join(workDir, "stderr.log");
+      const resumedStderrPath = join(workDir, "resumed-stderr.log");
+      const model = "openai/gpt-5";
+      gateway = startFakeGateway([fakeGatewayFinalText("TITLE_RENAME_COMPLETE")]);
+
+      const env = {
+        HOME: home,
+        AI_GATEWAY_API_KEY: "fake-title-rename-key",
+        VERCEL_OIDC_TOKEN: undefined,
+        FX_GATEWAY_BASE_URL: gateway.baseUrl,
+        FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+        FX_MODEL: model,
+        FX_AUTO_UPGRADE: "0",
+        NO_COLOR: "1",
+      };
+
+      session = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: workspace,
+        env,
+        stderrPath,
+        width: 120,
+        height: 32,
+        isolated: true,
+      });
+      await session.waitForComposer(10_000);
+
+      // An unnamed session still shows the model, so nothing regresses for
+      // users who never rename.
+      expect(await session.paneTitle()).toBe(`fx · ${model}`);
+
+      // The first prompt names the session, and the tab follows it.
+      await session.sendText("generate the release notes");
+      await session.waitForText("TITLE_RENAME_COMPLETE", 30_000);
+      await waitForPaneTitle(session, "fx · generate the release notes", 5_000);
+
+      await session.sendText("/rename deploy pipeline fix");
+      await session.waitForText("renamed: deploy pipeline fix", 10_000);
+      await waitForPaneTitle(session, "fx · deploy pipeline fix", 5_000);
+
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(10_000)).toBe(true);
+      await session.kill();
+      session = null;
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+      const sessionIds = readdirSync(join(home, ".fx", "sessions"), {
+        withFileTypes: true,
+      })
+        .filter((entry) => entry.name !== "latest" && entry.isDirectory())
+        .map((entry) => entry.name);
+      expect(sessionIds).toHaveLength(1);
+
+      // Resuming keeps the name the user chose instead of falling back to the
+      // model.
+      gateway.stop();
+      gateway = startFakeGateway([]);
+      session = await TmuxSession.create({
+        cmd: `${FX_BIN} resume ${sessionIds[0]}`,
+        cwd: workspace,
+        env: {
+          ...env,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+        },
+        stderrPath: resumedStderrPath,
+        width: 120,
+        height: 32,
+        isolated: true,
+      });
+      await session.waitForComposer(10_000);
+      await waitForPaneTitle(session, "fx · deploy pipeline fix", 5_000);
+
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(10_000)).toBe(true);
+      await session.kill();
+      session = null;
+      expect(readFileSync(resumedStderrPath, "utf8")).toBe("");
     },
     TEST_TIMEOUT,
   );
@@ -2569,7 +2673,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         height: 32,
       });
       await session.waitForComposer(10_000);
-      expect(capturePaneTitle(session)).toBe(`fx · ${currentModel}`);
+      expect(await session.paneTitle()).toBe(`fx · ${currentModel}`);
 
       await session.sendText("/models");
       let grid = await waitForModelsMenu(session, 4);
@@ -2629,7 +2733,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       const settings = JSON.parse(readFileSync(fixture.settingsPath, "utf8")) as { model?: string };
       expect(settings.model).toBe(selectedModel);
-      expect(capturePaneTitle(session)).toBe(`fx · ${selectedModel}`);
+      expect(await session.paneTitle()).toBe(`fx · ${selectedModel}`);
       expect(session.isAlive()).toBe(true);
 
       await session.sendText("/quit");
@@ -2743,7 +2847,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).not.toContain("Reasoning effort");
       expect(pane).not.toContain("default");
       expect(JSON.parse(readFileSync(fixture.settingsPath, "utf8")).model).toBe(selectedModel);
-      expect(capturePaneTitle(session)).toBe(`fx · ${selectedModel}`);
+      expect(await session.paneTitle()).toBe(`fx · ${selectedModel}`);
       expect(session.isAlive()).toBe(true);
       expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
 


### PR DESCRIPTION
Refs #158

## Problem

Every fx tab renders the same title, `fx · <model>`, so running several sessions in parallel gives no way to tell them apart at a glance.

## Behavior

The terminal title carries the session name once one exists, and falls back to the model before the first turn names the session:

| Moment | Title |
| --- | --- |
| Startup, no session name yet | `fx · openai/gpt-5` |
| After the first turn derives a name | `fx · generate the release notes` |
| After `/rename deploy pipeline fix` | `fx · deploy pipeline fix` |
| After a model switch on a named session | unchanged |
| After `/clear` or a new session | back to `fx · <model>` |
| `fx resume <id>` / `fx session resume <id>` | `fx · deploy pipeline fix` |
| Exit | restored to the terminal's own title |

`/rename` doubles as the manual override the issue asks for: renaming the session renames the tab. The right-click rename the issue mentions belongs to the terminal emulator and is outside what fx can drive.

## Implementation

`Runtime(App).syncTerminalTitle` is the single place that resolves "session name, else model", so every mutation point routes through it: the derived title, `/rename`, the resume path, session reset, and model switches.

Two correctness points came out of the work:

* The provider wrote to `std.Io.File.stdout()` directly. It now writes to the host's output file (`terminalTitleFor(&shell.stdout_file)`), so a host that redirects its output keeps the escape sequence out of the real stdout. This also unblocks `zig build test`, where stray stdout bytes deadlock the `--listen=-` protocol channel.
* Titles are sanitized of C0 and DEL bytes at the cache boundary. They are derived from prompt text and from the display sidecar, so neither source is trusted. Verified with a forged `display.json` title of `safe\x07\x1b]2;PWNED\x7ftail`, which renders as `fx · safe]2;PWNEDtail`.

The host capability was renamed from `setModel`/`set_model_fn` to `set`/`set_fn`, since the label is no longer model-specific.

## Tests

* `src/ui/render.zig`: the provider writes the label to the caller's output file.
* `src/core/app/app_session_runtime.zig`: the title follows the session name and falls back to the model; control bytes are dropped before reaching the terminal.
* `src/core/hosts/host.zig`: the capability forwards borrowed label bytes and clear.
* `tests/e2e/tui-slash-menu.test.ts`: `terminal tab title follows the session name across rename and resume` drives the real binary in tmux across startup, derived name, `/rename`, `/quit`, and resume.
* `TmuxSession.paneTitle()` replaces a local helper that ignored isolated tmux sockets.

## Docs

`README.md` gains one paragraph in the session block, since the behavior is user-facing.

## CI

Full CI triggers on `push` to a non-`main` branch, so it runs in the fork: https://github.com/arthjean/fx/actions?query=branch%3Aarthjean%2Fname-terminal-tabs-after-session

The `pull_request` workflows on this repository report `action_required` and need a maintainer to approve workflow runs for this fork PR.

## Label

Requires `type: improvement`. The tab title already existed and already showed the model; this changes what it displays rather than adding a new surface. I cannot apply labels on this repository, so the PR stays in draft until a maintainer applies one.
