### PR TITLE
Show active working directory and Git branch

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -25,6 +25,7 @@ const types = @import("../shared/types.zig");
 const subagent_domain = @import("../subagent/domain.zig");
 const subagent_projection = @import("../subagent/ui_projection.zig");
 const file_index = @import("../workspace/file_index.zig");
+const statusline_identity = @import("../workspace/statusline_identity.zig");
 const activity_runtime = @import("../output/activity_runtime.zig");
 const transcript_presentation = @import("../output/transcript_presentation.zig");
 const event_loop = @import("../../ui/event_loop.zig");
@@ -1129,6 +1130,8 @@ pub fn Runtime(comptime App: type) type {
             ctx.esc_clear_armed = view.editor.gestures.escapeClearArmed();
             ctx.question = null;
             ctx.statusline = .{
+                .workspace_label = base.statusline.workspace_label,
+                .git_branch = base.statusline.git_branch,
                 .sandbox_label = base.statusline.sandbox_label,
             };
             const worker_status_projection = if (app.subagents.childConversationRuntime()) |child_runtime|
@@ -1215,6 +1218,16 @@ pub fn Runtime(comptime App: type) type {
             visible_model: []const u8,
         ) ui_render.StatuslineItems {
             var items: ui_render.StatuslineItems = .{};
+            if (comptime @hasField(App, "workspace_identity") and
+                @hasField(App, "workspace_root"))
+            {
+                const identity = app.workspace_identity.refresh(
+                    app.alloc,
+                    app.workspace_root,
+                ) catch app.workspace_identity.snapshot();
+                items.workspace_label = identity.workspace_label;
+                items.git_branch = identity.git_branch;
+            }
             if (app.statusline_sandbox) {
                 const permission_mode: types.PermissionMode = if (comptime @hasField(App, "permission_engine"))
                     app.permission_engine.mode
@@ -4516,6 +4529,8 @@ const CoordinatorTestApp = struct {
     worker: CoordinatorTestWorker = .{},
     subagents: ui_subagents.Controller = .{},
     selected_model: std.ArrayList(u8) = .empty,
+    workspace_root: []const u8 = "",
+    workspace_identity: statusline_identity.Runtime = .{},
     pacer: CoordinatorTestPacer = .{},
     auth: auth_runtime.Runtime = .{},
     pending_images: std.ArrayList(types.ImageAttachment) = .empty,
@@ -4545,6 +4560,7 @@ const CoordinatorTestApp = struct {
         self.question_prompt.deinit(self.alloc);
         self.subagents.deinit(self.alloc);
         self.selected_model.deinit(self.alloc);
+        self.workspace_identity.deinit(self.alloc);
         self.pending_images.deinit(self.alloc);
         self.model_cache.deinit();
     }

--- a/src/core/workspace/statusline_identity.zig
+++ b/src/core/workspace/statusline_identity.zig
@@ -1,0 +1,405 @@
+const std = @import("std");
+const io_mod = @import("../shared/io.zig");
+const text_utils = @import("../shared/text_utils.zig");
+
+const max_git_metadata_bytes: usize = 4096;
+const max_encoded_workspace_bytes: usize = std.fs.max_path_bytes * 4;
+const max_encoded_branch_bytes: usize = 512;
+
+pub const Snapshot = struct {
+    workspace_label: []const u8 = "",
+    git_branch: ?[]const u8 = null,
+};
+
+const HeadSignature = struct {
+    inode: u64,
+    mtime_ns: i128,
+    size: u64,
+
+    fn eql(a: HeadSignature, b: HeadSignature) bool {
+        return a.inode == b.inode and
+            a.mtime_ns == b.mtime_ns and
+            a.size == b.size;
+    }
+};
+
+const ParsedHead = union(enum) {
+    branch: []const u8,
+    detached: []const u8,
+};
+
+const HeadPathResolution = union(enum) {
+    missing,
+    invalid,
+    found: []u8,
+};
+
+/// Owns the filesystem-derived state used by the footer. The UI only receives
+/// terminal-safe strings, and repeated renders stat HEAD without rereading it
+/// unless its metadata changes.
+pub const Runtime = struct {
+    workspace_root: []u8 = &.{},
+    workspace_label: []u8 = &.{},
+    head_path: []u8 = &.{},
+    branch_label: []u8 = &.{},
+    head_signature: ?HeadSignature = null,
+
+    pub fn deinit(self: *Runtime, alloc: std.mem.Allocator) void {
+        freeOwned(alloc, &self.workspace_root);
+        freeOwned(alloc, &self.workspace_label);
+        freeOwned(alloc, &self.head_path);
+        freeOwned(alloc, &self.branch_label);
+        self.* = .{};
+    }
+
+    pub fn snapshot(self: *const Runtime) Snapshot {
+        return .{
+            .workspace_label = self.workspace_label,
+            .git_branch = if (self.branch_label.len > 0) self.branch_label else null,
+        };
+    }
+
+    pub fn refresh(
+        self: *Runtime,
+        alloc: std.mem.Allocator,
+        workspace_root: []const u8,
+    ) !Snapshot {
+        if (!std.mem.eql(u8, self.workspace_root, workspace_root)) {
+            try self.rebuildWorkspace(alloc, workspace_root);
+        }
+        try self.refreshBranch(alloc);
+        return self.snapshot();
+    }
+
+    fn rebuildWorkspace(
+        self: *Runtime,
+        alloc: std.mem.Allocator,
+        workspace_root: []const u8,
+    ) !void {
+        if (workspace_root.len == 0) {
+            self.deinit(alloc);
+            return;
+        }
+
+        const next_root = try alloc.dupe(u8, workspace_root);
+        errdefer alloc.free(next_root);
+
+        const encoded_path = try encodeWorkspacePath(alloc, workspace_root);
+        errdefer alloc.free(encoded_path);
+
+        const next_head_path = try resolveHeadPath(alloc, workspace_root);
+        errdefer if (next_head_path) |path| alloc.free(path);
+
+        freeOwned(alloc, &self.workspace_root);
+        freeOwned(alloc, &self.workspace_label);
+        freeOwned(alloc, &self.head_path);
+        freeOwned(alloc, &self.branch_label);
+
+        self.workspace_root = next_root;
+        self.workspace_label = encoded_path;
+        self.head_path = next_head_path orelse &.{};
+        self.head_signature = null;
+    }
+
+    fn refreshBranch(self: *Runtime, alloc: std.mem.Allocator) !void {
+        if (self.head_path.len == 0) return;
+
+        const stat = std.Io.Dir.cwd().statFile(
+            io_mod.getIo(),
+            self.head_path,
+            .{ .follow_symlinks = false },
+        ) catch {
+            freeOwned(alloc, &self.branch_label);
+            self.head_signature = null;
+            return;
+        };
+        if (stat.kind != .file) {
+            freeOwned(alloc, &self.branch_label);
+            self.head_signature = null;
+            return;
+        }
+
+        const signature = HeadSignature{
+            .inode = @intCast(stat.inode),
+            .mtime_ns = stat.mtime.nanoseconds,
+            .size = stat.size,
+        };
+        if (self.head_signature) |previous| {
+            if (previous.eql(signature)) return;
+        }
+
+        const head = readSmallFile(alloc, self.head_path, max_git_metadata_bytes) catch {
+            freeOwned(alloc, &self.branch_label);
+            self.head_signature = signature;
+            return;
+        };
+        defer alloc.free(head);
+
+        const parsed = parseHead(head);
+        if (parsed) |value| {
+            var detached_buf: [32]u8 = undefined;
+            const raw = switch (value) {
+                .branch => |branch| branch,
+                .detached => |sha| std.fmt.bufPrint(
+                    &detached_buf,
+                    "detached:{s}",
+                    .{sha},
+                ) catch sha,
+            };
+            var encoded = try text_utils.encodeTerminalSafe(
+                alloc,
+                raw,
+                max_encoded_branch_bytes,
+            );
+            freeOwned(alloc, &self.branch_label);
+            self.branch_label = encoded.bytes;
+            encoded.bytes = &.{};
+        } else {
+            freeOwned(alloc, &self.branch_label);
+        }
+        self.head_signature = signature;
+    }
+};
+
+fn freeOwned(alloc: std.mem.Allocator, bytes: *[]u8) void {
+    if (bytes.*.len > 0) alloc.free(bytes.*);
+    bytes.* = &.{};
+}
+
+fn encodeWorkspacePath(
+    alloc: std.mem.Allocator,
+    workspace_root: []const u8,
+) ![]u8 {
+    const encoded = text_utils.encodeTerminalSafePathTail(
+        alloc,
+        workspace_root,
+        max_encoded_workspace_bytes,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.PathBasenameTooLong => {
+            const fallback = try text_utils.encodeTerminalSafe(
+                alloc,
+                workspace_root,
+                max_encoded_workspace_bytes,
+            );
+            return fallback.bytes;
+        },
+    };
+    return encoded.bytes;
+}
+
+fn resolveHeadPath(
+    alloc: std.mem.Allocator,
+    workspace_root: []const u8,
+) !?[]u8 {
+    var candidate = workspace_root;
+    while (true) {
+        switch (try resolveHeadPathAt(alloc, candidate)) {
+            .found => |head_path| return head_path,
+            .invalid => return null,
+            .missing => {},
+        }
+        const parent = std.fs.path.dirname(candidate) orelse return null;
+        if (std.mem.eql(u8, parent, candidate)) return null;
+        candidate = parent;
+    }
+}
+
+fn resolveHeadPathAt(
+    alloc: std.mem.Allocator,
+    candidate_root: []const u8,
+) !HeadPathResolution {
+    const dot_git = try std.fs.path.join(alloc, &.{ candidate_root, ".git" });
+    defer alloc.free(dot_git);
+
+    const stat = std.Io.Dir.cwd().statFile(
+        io_mod.getIo(),
+        dot_git,
+        .{ .follow_symlinks = false },
+    ) catch |err| return switch (err) {
+        error.FileNotFound, error.NotDir => .missing,
+        else => .invalid,
+    };
+
+    if (stat.kind == .directory) {
+        return .{ .found = try std.fs.path.join(alloc, &.{ dot_git, "HEAD" }) };
+    }
+    if (stat.kind != .file) return .invalid;
+
+    const content = readSmallFile(alloc, dot_git, max_git_metadata_bytes) catch return .invalid;
+    defer alloc.free(content);
+    const trimmed = std.mem.trim(u8, content, " \t\r\n");
+    const prefix = "gitdir:";
+    if (!std.mem.startsWith(u8, trimmed, prefix)) return .invalid;
+
+    const raw = std.mem.trim(u8, trimmed[prefix.len..], " \t\r\n");
+    if (raw.len == 0) return .invalid;
+    const git_dir = if (std.fs.path.isAbsolute(raw))
+        try alloc.dupe(u8, raw)
+    else
+        try std.fs.path.resolve(alloc, &.{ candidate_root, raw });
+    defer alloc.free(git_dir);
+    return .{ .found = try std.fs.path.join(alloc, &.{ git_dir, "HEAD" }) };
+}
+
+fn readSmallFile(
+    alloc: std.mem.Allocator,
+    path: []const u8,
+    max_bytes: usize,
+) ![]u8 {
+    var file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{});
+    defer file.close(io_mod.getIo());
+    return io_mod.readFileToEnd(alloc, &file, max_bytes);
+}
+
+fn parseHead(head: []const u8) ?ParsedHead {
+    const trimmed = std.mem.trim(u8, head, " \t\r\n");
+    if (trimmed.len == 0) return null;
+
+    const ref_prefix = "ref:";
+    if (std.mem.startsWith(u8, trimmed, ref_prefix)) {
+        const ref = std.mem.trim(u8, trimmed[ref_prefix.len..], " \t\r\n");
+        if (ref.len == 0) return null;
+        const heads_prefix = "refs/heads/";
+        const branch = if (std.mem.startsWith(u8, ref, heads_prefix))
+            ref[heads_prefix.len..]
+        else
+            ref;
+        if (branch.len == 0) return null;
+        return .{ .branch = branch };
+    }
+
+    if (trimmed.len < 7) return null;
+    for (trimmed) |byte| {
+        if (!std.ascii.isHex(byte)) return null;
+    }
+    return .{ .detached = trimmed[0..@min(trimmed.len, 12)] };
+}
+
+fn writeTestFile(
+    dir: std.Io.Dir,
+    path: []const u8,
+    content: []const u8,
+) !void {
+    if (std.fs.path.dirname(path)) |parent| {
+        try dir.createDirPath(io_mod.getIo(), parent);
+    }
+    var file = try dir.createFile(io_mod.getIo(), path, .{ .truncate = true });
+    defer file.close(io_mod.getIo());
+    try file.writeStreamingAll(io_mod.getIo(), content);
+}
+
+test "workspace statusline identity refreshes branch and detached HEAD" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(tmp.dir, "workspace/.git/HEAD", "ref: refs/heads/main\n");
+
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(root);
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+
+    var snapshot = try runtime.refresh(alloc, root);
+    try std.testing.expectEqualStrings(root, snapshot.workspace_label);
+    try std.testing.expectEqualStrings("main", snapshot.git_branch.?);
+
+    try writeTestFile(tmp.dir, "workspace/.git/HEAD", "ref: refs/heads/refreshed-branch\n");
+    snapshot = try runtime.refresh(alloc, root);
+    try std.testing.expectEqualStrings("refreshed-branch", snapshot.git_branch.?);
+
+    try writeTestFile(tmp.dir, "workspace/.git/HEAD", "0123456789abcdef0123456789abcdef01234567\n");
+    snapshot = try runtime.refresh(alloc, root);
+    try std.testing.expectEqualStrings("detached:0123456789ab", snapshot.git_branch.?);
+}
+
+test "workspace statusline identity resolves worktree gitdir files" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(
+        tmp.dir,
+        "workspace/.git",
+        "gitdir: ../git-data/worktrees/active\n",
+    );
+    try writeTestFile(
+        tmp.dir,
+        "git-data/worktrees/active/HEAD",
+        "ref: refs/heads/worktree-branch\n",
+    );
+
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(root);
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+
+    const snapshot = try runtime.refresh(alloc, root);
+    try std.testing.expectEqualStrings("worktree-branch", snapshot.git_branch.?);
+}
+
+test "workspace statusline identity finds a repository above the working directory" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(tmp.dir, "repo/.git/HEAD", "ref: refs/heads/parent-repo\n");
+    try tmp.dir.createDirPath(io_mod.getIo(), "repo/packages/app");
+
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "repo/packages/app");
+    defer alloc.free(root);
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+
+    const snapshot = try runtime.refresh(alloc, root);
+    try std.testing.expectEqualStrings(root, snapshot.workspace_label);
+    try std.testing.expectEqualStrings("parent-repo", snapshot.git_branch.?);
+}
+
+test "workspace statusline identity handles non-git and hostile paths" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "unsafe-\x1b[31m-workspace");
+    try writeTestFile(
+        tmp.dir,
+        "unsafe-\x1b[31m-workspace/.git",
+        "not a Git directory\n",
+    );
+
+    const root = try io_mod.dirRealpathAlloc(
+        alloc,
+        tmp.dir,
+        "unsafe-\x1b[31m-workspace",
+    );
+    defer alloc.free(root);
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+
+    const snapshot = try runtime.refresh(alloc, root);
+    try std.testing.expect(snapshot.git_branch == null);
+    try std.testing.expect(std.mem.findScalar(u8, snapshot.workspace_label, 0x1b) == null);
+    try std.testing.expect(std.mem.find(u8, snapshot.workspace_label, "\\x1b") != null);
+}
+
+test "workspace statusline identity rejects malformed detached HEAD" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(tmp.dir, "workspace/.git/HEAD", "not-a-commit\x1b[31m\n");
+
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(root);
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+
+    const snapshot = try runtime.refresh(alloc, root);
+    try std.testing.expect(snapshot.git_branch == null);
+}
+
+test "workspace statusline identity represents the filesystem root" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+
+    const snapshot = try runtime.refresh(alloc, std.fs.path.sep_str);
+    try std.testing.expectEqualStrings(std.fs.path.sep_str, snapshot.workspace_label);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -37,6 +37,7 @@ const app_callbacks = @import("core/app/app_callbacks.zig");
 const app_commands = @import("core/app/app_commands.zig");
 const change_tracker_mod = @import("core/workspace/change_tracker.zig");
 const context_contract = @import("core/workspace/context_contract.zig");
+const statusline_identity = @import("core/workspace/statusline_identity.zig");
 const collections = @import("core/shared/collections.zig");
 const agent_steps = @import("core/config/agent_steps.zig");
 const config_runtime = @import("core/config/config_runtime.zig");
@@ -479,6 +480,7 @@ const App = struct {
     selected_model: std.ArrayList(u8) = .empty,
     model_cache: model_cache_runtime.Runtime = model_cache_runtime.Runtime.init(std.heap.c_allocator, builtin_gateway.models_path),
     workspace_root: []u8 = &.{},
+    workspace_identity: statusline_identity.Runtime = .{},
     workspace_host: WorkspaceHostRuntime = .{},
     workspace: app_workspace_runtime.State = .{},
     permission_engine: PermissionEngine = .{},
@@ -842,6 +844,7 @@ const App = struct {
 
         self.auth.deinit(self.alloc);
         WorkspaceAppRuntime.deinit(self);
+        self.workspace_identity.deinit(self.alloc);
         if (self.workspace_root.len > 0) self.alloc.free(self.workspace_root);
         return resume_handoff;
     }

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -350,13 +350,7 @@ pub fn composeHintRow(
     else
         base_hint_line;
 
-    var row: std.ArrayList(u8) = .empty;
-    try row.appendSlice(alloc, if (question_hint != null) ui_render.dim_style else ui_render.statusline_style);
-    try row_text.appendClipped(alloc, &row, hint_line, width);
-    try row.appendSlice(alloc, ui_render.reset_style);
-
     const width_usize: usize = width;
-    const hint_width = display_width.visibleWidthIgnoringAnsi(hint_line);
     const danger_text = dangerStatusText(approval_active, ctx, width);
     // The armed clear indicator outranks the question suppression: a
     // freeform draft mid-question uses the same double-Esc contract as the
@@ -371,6 +365,20 @@ pub fn composeHintRow(
         ctx.upgrade_status;
     const right_width = display_width.visibleWidth(right_text);
     const danger_visible = danger_text.len > 0 and right_text.ptr == danger_text.ptr;
+    const left_width: u16 = if (!danger_visible and right_width > 0 and width_usize > right_width)
+        @intCast(width_usize - right_width - 1)
+    else
+        width;
+
+    var row: std.ArrayList(u8) = .empty;
+    try row.appendSlice(alloc, if (question_hint != null) ui_render.dim_style else ui_render.statusline_style);
+    try row_text.appendClipped(alloc, &row, hint_line, left_width);
+    try row.appendSlice(alloc, ui_render.reset_style);
+
+    const hint_width = @min(
+        display_width.visibleWidthIgnoringAnsi(hint_line),
+        @as(usize, left_width),
+    );
     if (right_text.len > 0 and right_width > 0 and
         ((danger_visible and width_usize >= right_width) or
             (!danger_visible and width_usize > hint_width + right_width)))
@@ -1607,6 +1615,9 @@ test "compose hint row right-aligns upgrade status" {
         .selected_subagent_label = null,
         .selected_subagent_status = null,
         .upgrade_status = "Update installed: ctrl+g to reload",
+        .statusline = .{
+            .workspace_label = "/a/long/workspace/path/that/uses/the/statusline-tail",
+        },
         .input = &input,
     };
 

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const io_mod = @import("../core/shared/io.zig");
 const host = @import("../core/hosts/host.zig");
 const display_width = @import("../core/shared/display_width.zig");
+const text_utils = @import("../core/shared/text_utils.zig");
 const types = @import("../core/shared/types.zig");
 const image_attachments = @import("../core/images/image_attachments.zig");
 const assistant_presentation = @import("../core/agent/assistant_presentation.zig");
@@ -178,6 +179,8 @@ pub fn welcomeMessage(alloc: std.mem.Allocator) ![]u8 {
 }
 
 pub const StatuslineItems = struct {
+    workspace_label: []const u8 = "",
+    git_branch: ?[]const u8 = null,
     sandbox_label: ?[]const u8 = null,
     context_used: u64 = 0,
     context_total: ?u32 = null,
@@ -236,9 +239,159 @@ fn appendStatusSegment(out: []u8, end: *usize, segment: []const u8) void {
     end.* += segment.len;
 }
 
-fn leadingPermissionModeFits(limit: usize, permission_label: []const u8, model_label: []const u8) bool {
+const statusline_separator = " · ";
+const max_workspace_reserve_cells: usize = 24;
+
+fn workspaceIdentityWidth(statusline: StatuslineItems) usize {
+    if (statusline.workspace_label.len == 0) return 0;
+    var width = display_width.visibleWidth(statusline.workspace_label);
+    if (statusline.git_branch) |branch| {
+        if (branch.len > 0) {
+            width +|= display_width.visibleWidth(" (") +
+                display_width.visibleWidth(branch) +
+                display_width.visibleWidth(")");
+        }
+    }
+    return width;
+}
+
+fn requiredCoreWidth(
+    model_label: []const u8,
+    statusline: StatuslineItems,
+) usize {
+    var width = display_width.visibleWidth(model_label);
+    const workspace_width = workspaceIdentityWidth(statusline);
+    if (workspace_width > 0) {
+        width +|= display_width.visibleWidth(statusline_separator) +
+            @min(workspace_width, max_workspace_reserve_cells);
+    }
+    return width;
+}
+
+fn leadingPermissionModeFits(
+    limit: usize,
+    current: []const u8,
+    permission_label: []const u8,
+    core_width: usize,
+) bool {
     if (limit == 0) return false;
-    return display_width.visibleWidthIgnoringAnsi(permission_label) + display_width.visibleWidth(" · ") + display_width.visibleWidth(model_label) <= limit;
+    var needed = display_width.visibleWidthIgnoringAnsi(current);
+    if (current.len > 0) needed +|= display_width.visibleWidth(statusline_separator);
+    needed +|= display_width.visibleWidthIgnoringAnsi(permission_label) +
+        display_width.visibleWidth(statusline_separator) +
+        core_width;
+    return needed <= limit;
+}
+
+const ClippedSegment = struct {
+    bytes: []const u8,
+    marker_before: bool = false,
+    marker_after: bool = false,
+};
+
+fn clippedWorkspaceSuffix(encoded: []const u8, max_width: usize) ClippedSegment {
+    if (display_width.visibleWidth(encoded) <= max_width) return .{ .bytes = encoded };
+    if (max_width <= 1) return .{ .bytes = "", .marker_before = max_width == 1 };
+    return .{
+        .bytes = text_utils.suffixTerminalSafeByWidth(encoded, max_width - 1),
+        .marker_before = true,
+    };
+}
+
+fn clippedBranchPrefix(encoded: []const u8, max_width: usize) ClippedSegment {
+    if (display_width.visibleWidth(encoded) <= max_width) return .{ .bytes = encoded };
+    if (max_width <= 1) return .{ .bytes = "", .marker_after = max_width == 1 };
+    return .{
+        .bytes = text_utils.prefixTerminalSafeByWidth(encoded, max_width - 1),
+        .marker_after = true,
+    };
+}
+
+fn appendIdentityBytes(out: []u8, end: *usize, bytes: []const u8) bool {
+    if (end.* + bytes.len > out.len) return false;
+    @memcpy(out[end.* .. end.* + bytes.len], bytes);
+    end.* += bytes.len;
+    return true;
+}
+
+fn appendClippedIdentityPart(
+    out: []u8,
+    end: *usize,
+    clipped: ClippedSegment,
+) bool {
+    if (clipped.marker_before and !appendIdentityBytes(out, end, "…")) return false;
+    if (!appendIdentityBytes(out, end, clipped.bytes)) return false;
+    if (clipped.marker_after and !appendIdentityBytes(out, end, "…")) return false;
+    return true;
+}
+
+fn composeWorkspaceIdentity(
+    statusline: StatuslineItems,
+    max_width: usize,
+    out: []u8,
+) ?[]const u8 {
+    if (statusline.workspace_label.len == 0 or max_width == 0) return null;
+
+    var width_budget = @min(max_width, out.len);
+    while (width_budget > 0) : (width_budget -= 1) {
+        var end: usize = 0;
+        if (statusline.git_branch) |branch| {
+            if (branch.len > 0) {
+                // Below seven cells, showing fragments of both values is less
+                // useful than retaining the working-directory tail alone.
+                if (width_budget >= 7) {
+                    const branch_width = display_width.visibleWidth(branch);
+                    const max_branch_width = width_budget - 4;
+                    const branch_budget = @min(
+                        branch_width,
+                        @min(max_branch_width, @max(@as(usize, 4), width_budget / 2)),
+                    );
+                    const path_budget = width_budget - 3 - branch_budget;
+                    const path = clippedWorkspaceSuffix(statusline.workspace_label, path_budget);
+                    const branch_label = clippedBranchPrefix(branch, branch_budget);
+                    if (appendClippedIdentityPart(out, &end, path) and
+                        appendIdentityBytes(out, &end, " (") and
+                        appendClippedIdentityPart(out, &end, branch_label) and
+                        appendIdentityBytes(out, &end, ")"))
+                    {
+                        return out[0..end];
+                    }
+                    continue;
+                }
+            }
+        }
+
+        const path = clippedWorkspaceSuffix(statusline.workspace_label, width_budget);
+        if (appendClippedIdentityPart(out, &end, path)) return out[0..end];
+    }
+    return null;
+}
+
+fn appendWorkspaceIdentity(
+    out: []u8,
+    end: *usize,
+    status_limit: usize,
+    statusline: StatuslineItems,
+) void {
+    if (statusline.workspace_label.len == 0) return;
+    const used_width = display_width.visibleWidthIgnoringAnsi(out[0..end.*]);
+    const separator_width = if (end.* > 0)
+        display_width.visibleWidth(statusline_separator)
+    else
+        0;
+    if (used_width + separator_width >= status_limit) return;
+
+    const separator_bytes = if (end.* > 0) statusline_separator.len else 0;
+    if (end.* + separator_bytes >= out.len) return;
+    const available_width = status_limit - used_width - separator_width;
+    const available_bytes = out.len - end.* - separator_bytes;
+    var identity_buf: [512]u8 = undefined;
+    const identity = composeWorkspaceIdentity(
+        statusline,
+        available_width,
+        identity_buf[0..@min(identity_buf.len, available_bytes)],
+    ) orelse return;
+    appendStatusSegment(out, end, identity);
 }
 
 pub fn buildHintLine(
@@ -274,14 +427,18 @@ pub fn buildHintLine(
         appendStatusSegment(out, &end, std.fmt.bufPrint(&queued_buf, "queued {d}", .{queued_count}) catch "");
     }
     const status_limit = @min(@as(usize, width), out.len);
-    if (leadingPermissionModeFits(status_limit, permission_label, model_label)) {
+    const show_effort = model_supports_effort and !effort.isDefault();
+    const show_fast = model_supports_fast and fast_mode;
+    const core_width = requiredCoreWidth(model_label, statusline);
+    if (leadingPermissionModeFits(status_limit, out[0..end], permission_label, core_width)) {
         appendStatusSegment(out, &end, permission_label);
     }
     appendStatusSegment(out, &end, model_label);
-    if (model_supports_effort and !effort.isDefault()) {
+    appendWorkspaceIdentity(out, &end, status_limit, statusline);
+    if (show_effort) {
         appendStatusSegment(out, &end, effort.displayLabel());
     }
-    if (model_supports_fast and fast_mode) {
+    if (show_fast) {
         appendStatusSegment(out, &end, "⚡︎");
     }
 
@@ -716,6 +873,54 @@ test "buildHintLine omits the session segment when no title is cached" {
         .session_title = null,
     }, 80, &buf);
     try std.testing.expectEqualStrings("ask · gpt-5", line);
+}
+
+test "buildHintLine shows the workspace and Git branch" {
+    var buf: [256]u8 = undefined;
+    const line = buildHintLine(false, false, true, "openai/gpt-5", .ask, 0, null, false, false, .auto, false, .{
+        .workspace_label = "/Users/mike/code/fx",
+        .git_branch = "feature/statusline",
+    }, 100, &buf);
+    try std.testing.expectEqualStrings(
+        "ask · gpt-5 · /Users/mike/code/fx (feature/statusline)",
+        line,
+    );
+}
+
+test "buildHintLine keeps workspace and branch readable at narrow widths" {
+    var buf: [256]u8 = undefined;
+    const line = buildHintLine(false, false, true, "openai/gpt-5", .ask, 0, null, false, false, .auto, false, .{
+        .workspace_label = "/a/very/long/path/to/fx-repo",
+        .git_branch = "feature/statusline",
+    }, 32, &buf);
+    try std.testing.expectEqual(@as(usize, 32), display_width.visibleWidthIgnoringAnsi(line));
+    try std.testing.expect(std.mem.startsWith(u8, line, "gpt-5 · "));
+    try std.testing.expect(std.mem.find(u8, line, "fx-repo") != null);
+    try std.testing.expect(std.mem.find(u8, line, "feature/") != null);
+    try std.testing.expect(std.mem.endsWith(u8, line, "…)"));
+}
+
+test "buildHintLine shows a non-Git workspace without branch punctuation" {
+    var buf: [128]u8 = undefined;
+    const line = buildHintLine(false, false, true, "openai/gpt-5", .ask, 0, null, false, false, .auto, false, .{
+        .workspace_label = "/tmp/plain-workspace",
+    }, 80, &buf);
+    try std.testing.expectEqualStrings(
+        "ask · gpt-5 · /tmp/plain-workspace",
+        line,
+    );
+}
+
+test "buildHintLine labels detached HEAD" {
+    var buf: [128]u8 = undefined;
+    const line = buildHintLine(false, false, true, "openai/gpt-5", .ask, 0, null, false, false, .auto, false, .{
+        .workspace_label = "/tmp/fx",
+        .git_branch = "detached:0123456789ab",
+    }, 80, &buf);
+    try std.testing.expectEqualStrings(
+        "ask · gpt-5 · /tmp/fx (detached:0123456789ab)",
+        line,
+    );
 }
 
 test "buildHintLine keeps system labels and dot separators" {

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -240,47 +240,16 @@ fn appendStatusSegment(out: []u8, end: *usize, segment: []const u8) void {
 }
 
 const statusline_separator = " · ";
-const max_workspace_reserve_cells: usize = 24;
-
-fn workspaceIdentityWidth(statusline: StatuslineItems) usize {
-    if (statusline.workspace_label.len == 0) return 0;
-    var width = display_width.visibleWidth(statusline.workspace_label);
-    if (statusline.git_branch) |branch| {
-        if (branch.len > 0) {
-            width +|= display_width.visibleWidth(" (") +
-                display_width.visibleWidth(branch) +
-                display_width.visibleWidth(")");
-        }
-    }
-    return width;
-}
-
-fn requiredCoreWidth(
-    model_label: []const u8,
-    statusline: StatuslineItems,
-) usize {
-    var width = display_width.visibleWidth(model_label);
-    const workspace_width = workspaceIdentityWidth(statusline);
-    if (workspace_width > 0) {
-        width +|= display_width.visibleWidth(statusline_separator) +
-            @min(workspace_width, max_workspace_reserve_cells);
-    }
-    return width;
-}
 
 fn leadingPermissionModeFits(
     limit: usize,
-    current: []const u8,
     permission_label: []const u8,
-    core_width: usize,
+    model_label: []const u8,
 ) bool {
     if (limit == 0) return false;
-    var needed = display_width.visibleWidthIgnoringAnsi(current);
-    if (current.len > 0) needed +|= display_width.visibleWidth(statusline_separator);
-    needed +|= display_width.visibleWidthIgnoringAnsi(permission_label) +
+    return display_width.visibleWidthIgnoringAnsi(permission_label) +
         display_width.visibleWidth(statusline_separator) +
-        core_width;
-    return needed <= limit;
+        display_width.visibleWidth(model_label) <= limit;
 }
 
 const ClippedSegment = struct {
@@ -429,12 +398,10 @@ pub fn buildHintLine(
     const status_limit = @min(@as(usize, width), out.len);
     const show_effort = model_supports_effort and !effort.isDefault();
     const show_fast = model_supports_fast and fast_mode;
-    const core_width = requiredCoreWidth(model_label, statusline);
-    if (leadingPermissionModeFits(status_limit, out[0..end], permission_label, core_width)) {
+    if (leadingPermissionModeFits(status_limit, permission_label, model_label)) {
         appendStatusSegment(out, &end, permission_label);
     }
     appendStatusSegment(out, &end, model_label);
-    appendWorkspaceIdentity(out, &end, status_limit, statusline);
     if (show_effort) {
         appendStatusSegment(out, &end, effort.displayLabel());
     }
@@ -464,6 +431,7 @@ pub fn buildHintLine(
             appendStatusSegment(out, &end, std.fmt.bufPrint(&ctx_buf, "Context: {d}k", .{used_k}) catch "");
         }
     }
+    appendWorkspaceIdentity(out, &end, status_limit, statusline);
 
     const width_usize: usize = width;
     if (width_usize == 0) return "";
@@ -892,12 +860,25 @@ test "buildHintLine keeps workspace and branch readable at narrow widths" {
     const line = buildHintLine(false, false, true, "openai/gpt-5", .ask, 0, null, false, false, .auto, false, .{
         .workspace_label = "/a/very/long/path/to/fx-repo",
         .git_branch = "feature/statusline",
-    }, 32, &buf);
-    try std.testing.expectEqual(@as(usize, 32), display_width.visibleWidthIgnoringAnsi(line));
-    try std.testing.expect(std.mem.startsWith(u8, line, "gpt-5 · "));
+    }, 36, &buf);
+    try std.testing.expectEqual(@as(usize, 36), display_width.visibleWidthIgnoringAnsi(line));
+    try std.testing.expect(std.mem.startsWith(u8, line, "ask · gpt-5 · "));
     try std.testing.expect(std.mem.find(u8, line, "fx-repo") != null);
     try std.testing.expect(std.mem.find(u8, line, "feature/") != null);
     try std.testing.expect(std.mem.endsWith(u8, line, "…)"));
+}
+
+test "buildHintLine workspace identity does not displace existing status segments" {
+    var buf: [256]u8 = undefined;
+    const line = buildHintLine(false, false, true, "anthropic/claude-opus-4.8", .auto, 0, null, true, true, types.ReasoningEffort.literal("xhigh"), true, .{
+        .workspace_label = "/a/very/long/path/to/the/active/workspace",
+        .git_branch = "feature/statusline",
+        .context_used = 1_000,
+        .context_total = 100_000,
+    }, 60, &buf);
+    try std.testing.expect(std.mem.find(u8, line, "xhigh") != null);
+    try std.testing.expect(std.mem.find(u8, line, "⚡︎") != null);
+    try std.testing.expect(std.mem.find(u8, line, "Context: 1k/100k 1%") != null);
 }
 
 test "buildHintLine shows a non-Git workspace without branch punctuation" {

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -878,11 +878,11 @@ test "buildHintLine omits the session segment when no title is cached" {
 test "buildHintLine shows the workspace and Git branch" {
     var buf: [256]u8 = undefined;
     const line = buildHintLine(false, false, true, "openai/gpt-5", .ask, 0, null, false, false, .auto, false, .{
-        .workspace_label = "/Users/mike/code/fx",
+        .workspace_label = "/workspace/code/fx",
         .git_branch = "feature/statusline",
     }, 100, &buf);
     try std.testing.expectEqualStrings(
-        "ask · gpt-5 · /Users/mike/code/fx (feature/statusline)",
+        "ask · gpt-5 · /workspace/code/fx (feature/statusline)",
         line,
     );
 }

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -3924,6 +3924,7 @@ describe("modern MCP stdio compatibility", () => {
         "retry_attempt=0",
         "discovery=completed",
       ]) expect(pane).toContain(expected);
+      expect(pane).toContain(root.workspace);
       for (const forbidden of [
         "captured_at_ms=",
         "runtime_generation=",
@@ -3932,7 +3933,6 @@ describe("modern MCP stdio compatibility", () => {
         "HEALTH_SECRET_SENTINEL",
         "S11_SECRET_ENV",
         MODERN_FIXTURE,
-        root.root,
         "fake-mcp-stdio-key",
       ]) expect(pane).not.toContain(forbidden);
       expect(activeGateway.requests).toHaveLength(0);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -5851,6 +5851,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         FX_TRACE_LOG: tracePath,
         FX_TRACE_SCOPES: "tool",
       };
+      const withoutWorkspaceStatusline = (text: string): string =>
+        text.split("\n").filter((line) =>
+          !(line.includes(workspace) && line.includes(" · "))
+        ).join("\n");
 
       session = await TmuxSession.create({
         cwd: workspace,
@@ -5869,7 +5873,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(compact).toContain(
         "Ran cd ./vercel/packages/cli/test/fixtures/unit/commands/git/connect/unlink && pwd",
       );
-      expect(compact).not.toContain(workspace);
+      expect(withoutWorkspaceStatusline(compact)).not.toContain(workspace);
       expect(countOccurrences(compact, `Ran ${firstDisplayCommand}`)).toBe(1);
       expect(compact).not.toContain(`Ran ${firstCommand}`);
       expect(countOccurrences(compact, `Ran ${thirdCommand}`)).toBe(1);
@@ -5884,7 +5888,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(review).toContain(`├ Ran ${firstDisplayCommand}`);
       expect(review).not.toContain(`Ran ${firstCommand}`);
       expect(review).toContain("● 3 tool calls · 3 commands");
-      expect(review).not.toContain(workspace);
+      expect(withoutWorkspaceStatusline(review)).not.toContain(workspace);
 
       await session.sendKeys("Right");
       const full = await session.waitForText("Full detail · ←/→ switch · ctrl o close", TIMEOUT);
@@ -5892,7 +5896,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendKeys("PPage");
       const fullAtSummary = await session.waitForText("● 3 tool calls · 3 commands", TIMEOUT);
       expect(fullAtSummary).toContain("● 3 tool calls · 3 commands");
-      expect(fullAtSummary).not.toContain(workspace);
+      expect(withoutWorkspaceStatusline(fullAtSummary)).not.toContain(workspace);
 
       const trace = readFileSync(tracePath, "utf8");
       for (const callId of [
@@ -5933,7 +5937,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       );
       expect(resumed).toContain(`Ran ${firstDisplayCommand}`);
       expect(resumed).not.toContain(`Ran ${firstCommand}`);
-      expect(resumed).not.toContain(workspace);
+      expect(withoutWorkspaceStatusline(resumed)).not.toContain(workspace);
       expect(summaryGateway.requests).toHaveLength(2);
       expect(readFileSync(resumedStderrPath, "utf8")).toBe("");
     },

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -1960,12 +1960,14 @@ test.skipIf(!tmuxAvailable())(
     };
     const expectInlineOrder = (scrollback: string): void => {
       expect(countOccurrences(scrollback, statusLine)).toBe(1);
-      expect(countOccurrences(scrollback, outputLine)).toBe(1);
 
       const statusIndex = scrollback.indexOf(statusLine);
-      const outputIndex = scrollback.indexOf(outputLine);
       const doneIndex = scrollback.lastIndexOf(finalMarker);
       expect(statusIndex).toBeGreaterThanOrEqual(0);
+      expect(doneIndex).toBeGreaterThan(statusIndex);
+      const transcriptRegion = scrollback.slice(statusIndex, doneIndex);
+      expect(countOccurrences(transcriptRegion, outputLine)).toBe(1);
+      const outputIndex = scrollback.indexOf(outputLine, statusIndex);
       expect(outputIndex).toBeGreaterThan(statusIndex);
       expect(doneIndex).toBeGreaterThan(outputIndex);
     };

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -168,7 +168,7 @@ describe.skipIf(SKIP_TMUX)("tui: fresh-session commands", () => {
 
         await session.resizeWindow(50, 30);
         const narrow = await session.waitForPane(
-          (pane) => pane.includes("tus-root") && pane.includes("detached:"),
+          (pane) => pane.includes("s-root") && pane.includes("detached:"),
           5_000,
         );
         expect(narrow).not.toContain("initial-branch");

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -120,6 +120,75 @@ describe.skipIf(SKIP_TMUX)("tui: fresh-session commands", () => {
   );
 
   test(
+    "statusline refreshes the working directory and Git branch",
+    async () => {
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-statusline-")));
+      const home = join(root, "home");
+      const repository = join(root, "repository");
+      const workspace = join(repository, "packages", "status-root");
+      const headPath = join(repository, ".git", "HEAD");
+      const stderrPath = join(root, "stderr.log");
+      mkdirSync(home, { recursive: true });
+      mkdirSync(join(repository, ".git"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(headPath, "ref: refs/heads/initial-branch\n");
+      writeFileSync(stderrPath, "");
+
+      try {
+        session = await TmuxSession.create({
+          cwd: workspace,
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: undefined,
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_AUTO_UPGRADE: "0",
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_SKIP_ONBOARDING: "1",
+          },
+          stderrPath,
+          width: 100,
+          height: 30,
+        });
+
+        await session.waitForPane(
+          (pane) => pane.includes("status-root") && pane.includes("initial-branch"),
+          10_000,
+        );
+
+        writeFileSync(headPath, "ref: refs/heads/refreshed-branch\n");
+        await session.resizeWindow(101, 30);
+        await session.waitForPane(
+          (pane) => pane.includes("status-root") && pane.includes("refreshed-branch"),
+          5_000,
+        );
+
+        writeFileSync(headPath, "0123456789abcdef0123456789abcdef01234567\n");
+        await session.resizeWindow(100, 30);
+        await session.waitForText("detached:0123456789ab", 5_000);
+
+        await session.resizeWindow(50, 30);
+        const narrow = await session.waitForPane(
+          (pane) => pane.includes("tus-root") && pane.includes("detached:"),
+          5_000,
+        );
+        expect(narrow).not.toContain("initial-branch");
+        expect(session.isAlive()).toBe(true);
+
+        await session.sendText("/quit");
+        expect(await session.waitForSessionEnd(5_000)).toBe(true);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+      } finally {
+        if (session) {
+          await session.kill();
+          session = null;
+        }
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "restore the launch header without retaining prior output",
     async () => {
       const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-fresh-session-")));

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -6982,8 +6982,12 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         await active.waitForText("MANAGER_HUMAN_TWO_LIVE_", TIMEOUT);
         await Bun.sleep(1_500);
         const idleReopenFrames = stdoutFrames(tapePath).slice(idleReopenFrameStart);
+        const identityFrameAllowance = Buffer.byteLength(fixture.workspace) +
+          Buffer.byteLength(" · ");
         expect(
-          idleReopenFrames.filter((frame) => frame.payload.length >= 1_024),
+          idleReopenFrames.filter(
+            (frame) => frame.payload.length >= 1_024 + identityFrameAllowance,
+          ),
         ).toHaveLength(0);
         expect(
           idleReopenFrames.reduce((total, frame) => total + frame.payload.length, 0),


### PR DESCRIPTION
## Summary

- show the active working directory and Git branch persistently in the footer
- discover repositories above nested working directories and support worktree `.git` files, detached HEAD, and non-Git directories
- preserve useful path and branch fragments on narrow terminals while keeping terminal-hostile filesystem text escaped
- refresh branch state when `.git/HEAD` changes without spawning `git` on every render

## Why

The footer previously projected model, permission, and optional session data, but it had no workspace identity. That made it difficult to verify which directory and branch an `fx` session would operate on. The new core-owned runtime supplies terminal-safe workspace and Git state to the renderer and caches HEAD contents by filesystem identity and modification metadata.

## User impact

Users can verify the active directory and branch at a glance. Long paths and branch names remain readable in narrow terminals, and detached or non-Git states degrade safely.

## Validation

- `zig build test -Doptimize=Debug`
- `bun test --max-concurrency 1 ./tui-startup.test.ts --test-name-pattern "statusline refreshes the working directory and Git branch"`
- manual built-binary tmux exercise covering a live branch switch and 50-column resize, with empty stderr

Linear: [FXC-220](https://linear.app/vercel/issue/FXC-220)
