### PR TITLE
Recover from post-Vision prefill rejection

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -59,6 +59,8 @@ const AgentRuntimeDeps = runtime_deps.AgentRuntimeDeps;
 const CredentialRefreshMode = runtime_deps.CredentialRefreshMode;
 
 const http_error_detail_max_bytes: usize = 4096;
+const assistant_prefill_recovery_prompt =
+    "Continue from the preceding tool result.";
 const repeated_terminal_validation_notice =
     "Repeated terminal validation failures stopped the tool loop. The invalid terminal calls were not executed and produced no terminal effect.";
 const Config = runtime_config.Config;
@@ -1264,6 +1266,22 @@ fn isRetryableModelStatus(status: std.http.Status) bool {
         => true,
         else => false,
     };
+}
+
+fn isPostVisionAssistantPrefillRejection(
+    status: std.http.Status,
+    detail: []const u8,
+    messages: []const ChatMessage,
+) bool {
+    if (status != .bad_request or messages.len == 0) return false;
+    const tail = messages[messages.len - 1];
+    if (tail.role != .tool or
+        !std.mem.eql(u8, tail.tool_name orelse return false, "vision"))
+    {
+        return false;
+    }
+    return std.mem.find(u8, detail, "does not support assistant message prefill") != null and
+        std.mem.find(u8, detail, "must end with a user message") != null;
 }
 
 fn waitForRecoveryDelay(
@@ -2657,6 +2675,7 @@ fn processQueuedPromptLoop(
         var successful_vision_mode: runtime_gateway_step.VisionToolMode = .unavailable;
         var reset_stream_for_next_attempt = false;
         var auth_retry_used = false;
+        var assistant_prefill_recovery_used = false;
         var skip_next_preflight_refresh = false;
         var recovery_has_unexecuted_tool_start = false;
         var successful_recovery_strategy: ?model_response_recovery.Strategy = null;
@@ -3380,6 +3399,37 @@ fn processQueuedPromptLoop(
             }
             const gateway_wait_finished_ms = io_mod.milliTimestamp();
             summary_accumulator.addThinkingWait(gateway_wait_started_ms, stream_ctx.first_model_output_at_ms orelse gateway_wait_finished_ms);
+
+            if (!assistant_prefill_recovery_used and
+                semantic_attempt + 1 < semantic_limit and
+                streamReplaySafe(&stream_ctx) and
+                isPostVisionAssistantPrefillRejection(
+                    stream_result.status,
+                    stream_result.err_body orelse "",
+                    request_messages,
+                ))
+            {
+                try within_turn_suffix.append(arena, .{
+                    .role = .user,
+                    .content = assistant_prefill_recovery_prompt,
+                    .cache_policy = .no_cache,
+                });
+                debug_trace.eventf(
+                    "gateway",
+                    "assistant_prefill_recovery",
+                    step_ctx,
+                    "tool_name=vision provider_attempt={d}/{d}",
+                    .{ semantic_attempt + 1, semantic_limit },
+                );
+                if (stream_result.err_body) |body| mem_utils.free(arena, body);
+                stream_result.err_body = null;
+                stream_result_set = false;
+                assistant_prefill_recovery_used = true;
+                semantic_attempt += 1;
+                retry_pacing = .idle;
+                reset_stream_for_next_attempt = true;
+                continue;
+            }
 
             if (isRetryableModelStatus(stream_result.status)) {
                 const cause: model_response_recovery.FailureCause = if (stream_result.status == .too_many_requests)

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -210,6 +210,33 @@ fn expectGatewayPromptRoles(gateway: *const FakeGateway, index: usize, expected_
     }
 }
 
+fn expectGatewayPromptTailText(
+    gateway: *const FakeGateway,
+    index: usize,
+    expected_role: types.ChatRole,
+    expected_text: []const u8,
+) !void {
+    const alloc = std.testing.allocator;
+    try std.testing.expect(index < gateway.request_bodies.items.len);
+
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        gateway.request_bodies.items[index],
+        .{},
+    );
+    defer parsed.deinit();
+
+    const prompt = parsed.value.object.get("prompt").?.array.items;
+    try std.testing.expect(prompt.len > 0);
+    const tail = prompt[prompt.len - 1];
+    try expectPromptEntryRole(tail, expected_role);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countPromptEntryText(tail, expected_text),
+    );
+}
+
 fn expectRootFieldAbsent(gateway: *const FakeGateway, index: usize, field: []const u8) !void {
     const alloc = std.testing.allocator;
     try std.testing.expect(index < gateway.request_bodies.items.len);
@@ -524,6 +551,64 @@ test "processQueuedPrompt gates text-only images through the real Vision runtime
     try expectBodyContains(&gateway, 2, "FX LOGO");
     try expectBodyNotContains(&gateway, 2, image_path);
     try std.testing.expectEqualStrings("Final selected-model answer", hooks.finish_assistant_text.?);
+}
+
+test "processQueuedPrompt recovers when a model rejects post-Vision assistant prefill" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const image_path = try writeTestImagePath(alloc, &tmp);
+    defer alloc.free(image_path);
+    const image = try testCapturedImage(alloc, &tmp, image_path, 1);
+    defer types.freeImageAttachment(alloc, image);
+    var images = [_]types.ImageAttachment{image};
+
+    const calls = [_]ToolCall{toolCall(
+        "call_vision_prefill_recovery",
+        "vision",
+        "{\"image_ids\":[1],\"focus\":\"describe the image\"}",
+    )};
+    const prefill_rejection =
+        "{\"error\":{\"message\":\"AI_APICallError: This model does not support " ++
+        "assistant message prefill. The conversation must end with a user message.\"}}";
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "{\"images\":[{\"image_id\":1,\"status\":\"ok\",\"summary\":\"FX logo\",\"visible_text\":[],\"details\":[]}] }" },
+        .{ .status = .bad_request, .err_body = prefill_rejection },
+        .{ .content = "Recovered final answer" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.tool_registry = .{ .tools = test_support.vision_agent_test_tools[0..] };
+    defer hooks.deinit();
+    var vision_runtime = VisionAgentToolRuntime{ .alloc = alloc };
+    defer vision_runtime.deinit();
+    hooks.execute_delegate = vision_runtime.delegate();
+    var fixture = PromptFixture{};
+    var job = fixture.job();
+    job.model = @constCast("anthropic/claude-fable-5");
+    job.prompt = @constCast("Describe the attached image.");
+    job.images = &images;
+    job.authorized_image_catalog = &images;
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+
+    try std.testing.expectEqual(@as(usize, 4), gateway.request_bodies.items.len);
+    try expectGatewayPromptTailText(
+        &gateway,
+        2,
+        .tool,
+        "FX logo",
+    );
+    try expectGatewayPromptTailText(
+        &gateway,
+        3,
+        .user,
+        "Continue from the preceding tool result.",
+    );
+    try std.testing.expectEqual(@as(?std.http.Status, null), hooks.http_status);
+    try std.testing.expectEqualStrings("Recovered final answer", hooks.finish_assistant_text.?);
 }
 
 test "text-only Vision keeps later permission restriction trusted across model steps" {

--- a/tests/e2e/vision-route-fake-gateway.test.ts
+++ b/tests/e2e/vision-route-fake-gateway.test.ts
@@ -707,6 +707,70 @@ describe("Vision route fake Gateway", () => {
   );
 
   test(
+    "fx ask recovers when the model rejects the post-Vision prompt as assistant prefill",
+    async () => {
+      const root = createIsolatedRoot();
+      const fixture = createScopedImageFixture(root);
+      const prefillRejection = new Response(
+        JSON.stringify({
+          error: {
+            message:
+              "AI_APICallError: This model does not support assistant message prefill. " +
+              "The conversation must end with a user message.",
+          },
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      );
+      const gateway = startImageGateway([
+        sseToolCall(
+          "vision",
+          { image_ids: [1], focus: "describe the image" },
+          "vision_prefill_recovery",
+        ),
+        sseText(VISION_RESULT),
+        prefillRejection,
+        sseText("Recovered final image answer"),
+      ]);
+      try {
+        const result = await runFx(
+          [
+            "ask",
+            "--json",
+            "--no-save",
+            "--no-color",
+            "--image",
+            fixture.imagePath,
+            "Describe the attached image.",
+          ],
+          {
+            cwd: root.workspace,
+            env: fakeGatewayEnv(root, gateway, GLM_MODEL),
+            timeoutMs: TIMEOUT,
+          },
+        );
+
+        const json = parseFxJson(result);
+        expect(json.exit_code).toBe(0);
+        expect(json.output).toContain("Recovered final image answer");
+        expect(gateway.chatRequests).toHaveLength(4);
+
+        const rejectedPrompt = JSON.parse(gateway.chatRequests[2].body).prompt;
+        expect(rejectedPrompt.at(-1)).toMatchObject({ role: "tool" });
+        const retryPrompt = JSON.parse(gateway.chatRequests[3].body).prompt;
+        expect(retryPrompt.at(-1)).toMatchObject({ role: "user" });
+        expect(JSON.stringify(retryPrompt.at(-1))).toContain(
+          "Continue from the preceding tool result.",
+        );
+        expect(result.stderr).toBe("Inspecting images\n");
+      } finally {
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "fx ask executes path-source Vision and cleans transient snapshots without failure telemetry",
     async () => {
       const root = createIsolatedRoot();


### PR DESCRIPTION
## Summary

- Recover when a replay-safe post-Vision request receives the assistant-prefill HTTP 400.
- Append a non-cacheable user continuation and retry once per model step.
- Add runtime and built-binary regression coverage while preserving missing and corrupt-image recovery.

## Root cause

The supplied trace showed Vision completing successfully before `anthropic/claude-fable-5` rejected the next request because it interpreted the prompt as ending with an assistant prefill. The fx process remained alive, but the turn finalized as failed and appeared to crash.

## Validation

- `zig fmt --check src/`
- `zig build`
- `zig build test`
- Built-binary screenshot recovery regression
- Missing and corrupt-image recovery tests

Linear: https://linear.app/vercel/issue/FXC-224
