### PR TITLE
Read skills from .fx/skills workspace folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,9 @@ If you cannot manage labels, a maintainer or repository agent will apply the lab
 
 * `src/gateway/`: AI Gateway client transport
 
-* `skills/`: optional workspace-level skill root if the project wants one
+* `.fx/skills/`: optional fx-native workspace-level skill root
+
+* `skills/`: optional shared workspace-level skill root
 
 ## Collaboration Rules
 
@@ -143,13 +145,13 @@ Subagent children are ordinary sessions with their own `~/.fx/sessions/<child-id
 
 There are two distinct skill categories in `fx`:
 
-* `fx` roots that belong to the product itself: `skills/`, `~/.fx/skills`
+* `fx` roots that belong to the product itself: `.fx/skills`, `skills/`, `~/.fx/skills`
 
 * compatibility roots discovered for other agent installs: `.opencode/skills`, `.codex/skills`, `.claude/skills`, `.agents/skills`, `.claw/skills`, plus their global equivalents
 
 `/skills list` should make that distinction visible to the user.
 
-`/skills add` and `/skills install` install full skill directories into the profile-owned `~/.fx/skills` managed root, not just `SKILL.md`. Workspace `skills/` remains discoverable project-local instructions, not a managed install target.
+`/skills add` and `/skills install` install full skill directories into the profile-owned `~/.fx/skills` managed root, not just `SKILL.md`. Workspace `.fx/skills` and `skills/` remain discoverable project-local instructions, not managed install targets.
 
 The interactive agent can also install skills via the `install_skill` tool when the user asks to install one in conversation, including pasted `npx skills add ...` syntax.
 

--- a/src/builtins/skills.zig
+++ b/src/builtins/skills.zig
@@ -108,7 +108,14 @@ fn executeCommand(alloc: Allocator, command: Command, request: CommandRequest) !
         .install => |install| installCommandResult(alloc, request.skills_dir, install),
         .create => |name| createCommandResult(alloc, request.skills_dir, name),
         .remove => |name| removeCommandResult(alloc, request, name),
-        .path => noticeFmt(alloc, "fx managed install root: {s}\ncompatibility roots are auto-discovered from workspace and home (.opencode/.codex/.claude/.agents/.claw).", .{request.skills_dir}, false),
+        .path => noticeFmt(
+            alloc,
+            "fx workspace roots are auto-discovered from .fx/skills and skills/.\n" ++
+                "fx managed install root: {s}\n" ++
+                "compatibility roots are auto-discovered from workspace and home (.opencode/.codex/.claude/.agents/.claw).",
+            .{request.skills_dir},
+            false,
+        ),
         .usage => noticeLiteral(alloc, "Usage: /skills [list|add|install|show|create|remove|path] [name|url|path]", false),
     };
 }
@@ -1937,6 +1944,23 @@ test "built-in skills command parses install aliases and filters" {
             try std.testing.expectEqualStrings("vercel-labs/agent-skills", install.source);
             try std.testing.expectEqualStrings("workflow", install.filter.?);
         },
+        else => return error.TestExpectedEqual,
+    }
+}
+
+test "built-in skills path reports native workspace roots" {
+    const alloc = std.testing.allocator;
+    var static_ctx = StaticSkillCtx{ .skills = &.{} };
+    var result = try executeCommand(alloc, parseCommand("path"), staticCommandRequest("/tmp/skills", &static_ctx));
+    defer result.deinit(alloc);
+
+    switch (result) {
+        .notice => |notice| try std.testing.expectEqualStrings(
+            "fx workspace roots are auto-discovered from .fx/skills and skills/.\n" ++
+                "fx managed install root: /tmp/skills\n" ++
+                "compatibility roots are auto-discovered from workspace and home (.opencode/.codex/.claude/.agents/.claw).",
+            notice.text,
+        ),
         else => return error.TestExpectedEqual,
     }
 }

--- a/src/builtins/skills.zig
+++ b/src/builtins/skills.zig
@@ -10,9 +10,10 @@ const Allocator = std.mem.Allocator;
 const RootSpec = skill_contract.RootSpec;
 
 /// Roots scanned at the workspace root and each ancestor directory below
-/// home, in precedence order. `skills/` belongs to the product; the rest are
-/// compatibility roots for other agent installs.
+/// home, in precedence order. `.fx/skills` and `skills/` belong to the product;
+/// the rest are compatibility roots for other agent installs.
 const workspace_roots = [_]RootSpec{
+    .{ .source = .workspace_fx, .path = ".fx/skills" },
     .{ .source = .workspace_shared, .path = "skills" },
     .{ .source = .workspace_opencode, .path = ".opencode/skills" },
     .{ .source = .workspace_codex, .path = ".codex/skills" },
@@ -1142,6 +1143,7 @@ test "copySkillDir preserves the installed skill across allocation failures" {
 
 test "workspace skill roots scan the product root before compatibility roots" {
     const expected = [_]RootSpec{
+        .{ .source = .workspace_fx, .path = ".fx/skills" },
         .{ .source = .workspace_shared, .path = "skills" },
         .{ .source = .workspace_opencode, .path = ".opencode/skills" },
         .{ .source = .workspace_codex, .path = ".codex/skills" },

--- a/src/core/skills/skill_contract.zig
+++ b/src/core/skills/skill_contract.zig
@@ -6,6 +6,7 @@ pub const max_name_bytes: usize = 256;
 pub const max_description_bytes: usize = 4 * 1024;
 
 pub const SkillSource = enum {
+    workspace_fx,
     workspace_shared,
     workspace_opencode,
     workspace_codex,

--- a/src/core/skills/skill_runtime.zig
+++ b/src/core/skills/skill_runtime.zig
@@ -739,6 +739,7 @@ pub fn isManagedInstallSkill(skill: Skill) bool {
 pub fn skillGroupLabel(source: SkillSource) []const u8 {
     return switch (source) {
         .global_fx => "Managed installs",
+        .workspace_fx => "Workspace skills",
         .workspace_shared => "Workspace skills",
         .workspace_opencode,
         .workspace_codex,
@@ -757,6 +758,7 @@ pub fn skillGroupLabel(source: SkillSource) []const u8 {
 pub fn skillGroupRank(source: SkillSource) usize {
     return switch (source) {
         .global_fx => 0,
+        .workspace_fx => 1,
         .workspace_shared => 1,
         .workspace_opencode,
         .workspace_codex,
@@ -776,6 +778,7 @@ const skill_group_count: usize = 3;
 
 pub fn skillSourceLabel(source: SkillSource) []const u8 {
     return switch (source) {
+        .workspace_fx => "workspace .fx/skills",
         .workspace_shared => "workspace skills/",
         .workspace_opencode => "workspace .opencode/skills",
         .workspace_codex => "workspace .codex/skills",
@@ -793,6 +796,7 @@ pub fn skillSourceLabel(source: SkillSource) []const u8 {
 
 pub fn skillSourceShortLabel(source: SkillSource) []const u8 {
     return switch (source) {
+        .workspace_fx => "workspace .fx",
         .workspace_shared => "workspace skills/",
         .workspace_opencode => "workspace .opencode",
         .workspace_codex => "workspace .codex",
@@ -824,6 +828,7 @@ pub fn skillMenuFilterLabel(filter: SkillMenuSourceFilter) []const u8 {
 pub fn skillMenuFilterForSource(source: SkillSource) SkillMenuSourceFilter {
     return switch (source) {
         .global_fx => .fx,
+        .workspace_fx => .fx,
         .workspace_shared => .workspace,
         .workspace_opencode, .global_opencode => .opencode,
         .workspace_codex, .global_codex => .codex,

--- a/src/ui/footer/skills_menu_presentation.zig
+++ b/src/ui/footer/skills_menu_presentation.zig
@@ -331,6 +331,7 @@ fn composeEmptyRow(
 fn skillSourceScopeLabel(source: skill_runtime.SkillSource) []const u8 {
     return switch (source) {
         .global_fx => "Fx · Global",
+        .workspace_fx => "Fx · Workspace",
         .workspace_shared => "Fx · Workspace",
         .workspace_opencode => "OpenCode · Workspace",
         .global_opencode => "OpenCode · Global",

--- a/src/ui/footer/skills_menu_presentation.zig
+++ b/src/ui/footer/skills_menu_presentation.zig
@@ -331,7 +331,7 @@ fn composeEmptyRow(
 fn skillSourceScopeLabel(source: skill_runtime.SkillSource) []const u8 {
     return switch (source) {
         .global_fx => "Fx · Global",
-        .workspace_fx => "Fx · Workspace",
+        .workspace_fx => "fx · Workspace",
         .workspace_shared => "Fx · Workspace",
         .workspace_opencode => "OpenCode · Workspace",
         .global_opencode => "OpenCode · Global",
@@ -356,6 +356,10 @@ fn cloneClippedRow(alloc: Allocator, text: []const u8, width: u16) !std.ArrayLis
 
 fn visibleSkillCount(projection: SkillsMenuProjection) usize {
     return skill_runtime.skillMenuFilterQueryCount(projection.items, projection.source_filter, projection.query);
+}
+
+test "skills menu labels native workspace skills with lowercase product name" {
+    try std.testing.expectEqualStrings("fx · Workspace", skillSourceScopeLabel(.workspace_fx));
 }
 
 test "skills menu renders source tabs and single-line results" {


### PR DESCRIPTION
## Summary

Add `.fx/skills` as a workspace skill root so repos can ship fx-native skills in a `.fx` folder alongside their source. This is the fx-native equivalent of the existing compatibility roots for `.claude/skills`, `.codex/skills`, and other agent harnesses.

A new `workspace_fx` `SkillSource` variant places `.fx/skills` at the highest workspace precedence, before the existing `skills/` root and all compatibility roots. The existing ancestor-walk, dedup, menu filtering, and `/skills` list all pick it up with no new logic.

## Files changed

- `src/core/skills/skill_contract.zig` — added `workspace_fx` to the `SkillSource` enum
- `src/builtins/skills.zig` — added `.fx/skills` as the first entry in `workspace_roots`, updated the doc comment, and updated the test expectations
- `src/core/skills/skill_runtime.zig` — added `workspace_fx` to all five exhaustive switches (`skillGroupLabel`, `skillGroupRank`, `skillSourceLabel`, `skillSourceShortLabel`, `skillMenuFilterForSource`)
- `src/ui/footer/skills_menu_presentation.zig` — added `workspace_fx` to the `skillSourceScopeLabel` switch

## Verification

- `zig fmt --check src/` passes
- `zig build` succeeds
- `zig build test` — 8315/8322 tests pass. The 5 failures are pre-existing environment issues (Ghostty shell integration escape sequences in captured shell output), unrelated to this change
- Confirmed via `FX_BENCH=1 ./zig-out/bin/fx ask --json` that the loader scans `.fx/skills` at the workspace root alongside `~/.fx/skills`

Closes #182