### PR TITLE
Treat textual null placeholders as absent terminal fields

### DIFF
--- a/src/core/permissions/permissions.zig
+++ b/src/core/permissions/permissions.zig
@@ -244,7 +244,7 @@ fn resolveCommandCwdFromArgs(
     workspace_root: []const u8,
     args: std.json.ObjectMap,
 ) ![]const u8 {
-    const cwd_input = tool_args.optionalStringArg(args, "cwd") orelse ".";
+    const cwd_input = tool_args.nullablePlaceholderStringArg(args, "cwd") orelse ".";
     if (std.mem.eql(u8, cwd_input, ".")) return arena.dupe(u8, workspace_root);
     return pathing.resolveWorkspaceOrExternalPath(arena, workspace_root, cwd_input);
 }
@@ -254,7 +254,7 @@ fn resolveCommandCwdFromArgsInScope(
     scope: workspace_access.AccessScope,
     args: std.json.ObjectMap,
 ) ![]const u8 {
-    const cwd_input = tool_args.optionalStringArg(args, "cwd") orelse ".";
+    const cwd_input = tool_args.nullablePlaceholderStringArg(args, "cwd") orelse ".";
     if (std.mem.eql(u8, cwd_input, ".")) return arena.dupe(u8, scope.primary_directory);
     return pathing.resolveWorkspaceOrExternalPath(arena, scope.primary_directory, cwd_input);
 }
@@ -2516,6 +2516,20 @@ test "rulesDenyAllTargetsForPermission honors last matching overrides" {
         .{ .permission = @constCast("edit"), .pattern = @constCast("src/*"), .action = .deny },
     };
     try std.testing.expect(!rulesDenyAllTargetsForPermission(.{ .rules = &target_deny_rules }, "edit"));
+}
+
+test "command permission target treats a textual null cwd as absent" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const target = try permissionTargetForCall(arena, "/tmp/workspace", .{
+        .id = "terminal",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"ls\",\"cwd\":\" NULL \"}",
+    }, .command_cwd);
+
+    try std.testing.expectEqualStrings("/tmp/workspace::ls", target);
 }
 
 test "web_fetch permission target is canonical domain rather than full url" {

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -2267,7 +2267,7 @@ pub fn runCommandContext(
     const cwd = switch (tool.captured_command_host) {
         .workspace_clean => try arena.dupe(u8, input.workspace_root),
         .native => blk: {
-            const cwd_arg = tool_args.optionalStringArg(args, "cwd") orelse ".";
+            const cwd_arg = tool_args.nullablePlaceholderStringArg(args, "cwd") orelse ".";
             break :blk if (std.mem.eql(u8, cwd_arg, "."))
                 try arena.dupe(u8, input.workspace_root)
             else
@@ -2277,7 +2277,7 @@ pub fn runCommandContext(
     const environment_value: command_environment.Environment = switch (tool.captured_command_host) {
         .workspace_clean => .workspace_clean,
         .native => blk: {
-            const profile_raw = tool_args.optionalStringArg(args, "profile");
+            const profile_raw = tool_args.nullablePlaceholderStringArg(args, "profile");
             const profile: ?command_environment.Profile = if (profile_raw) |raw|
                 std.meta.stringToEnum(command_environment.Profile, raw) orelse
                     return error.InvalidCommandProfile

--- a/src/core/tooling/tool_args.zig
+++ b/src/core/tooling/tool_args.zig
@@ -20,6 +20,21 @@ pub fn optionalStringArg(args: std.json.ObjectMap, key: []const u8) ?[]const u8 
     return value.string;
 }
 
+/// Tool schemas that require every field tell the model to send null for the
+/// fields its selected action does not use. Models routinely serialize that null
+/// as the literal text "null", so readers treat it as the absence it expresses.
+pub fn isNullPlaceholderText(text: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(std.mem.trim(u8, text, &std.ascii.whitespace), "null");
+}
+
+/// Reads an optional string argument from a schema whose unused fields arrive as
+/// nulls, so textual null placeholders read as absent instead of as a value.
+pub fn nullablePlaceholderStringArg(args: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const text = optionalStringArg(args, key) orelse return null;
+    if (isNullPlaceholderText(text)) return null;
+    return text;
+}
+
 pub fn optionalBoolArg(args: std.json.ObjectMap, key: []const u8) ?bool {
     const value = args.get(key) orelse return null;
     if (value != .bool) return null;
@@ -80,4 +95,23 @@ test "optional typed args return payloads only for matching tags" {
     try std.testing.expectEqual(@as(i64, 3), optionalIntArg(args, "count").?);
     try std.testing.expect(optionalIntArg(args, "missing") == null);
     try std.testing.expect(optionalIntArg(args, "other") == null);
+}
+
+test "null placeholder reads treat textual nulls as absent" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const args = try parseToolArgsObject(
+        arena,
+        "{\"cwd\":\"null\",\"profile\":\" NULL \",\"shell\":null,\"command\":\"echo null\",\"dir\":\"nullify\"}",
+    );
+
+    try std.testing.expect(nullablePlaceholderStringArg(args, "cwd") == null);
+    try std.testing.expect(nullablePlaceholderStringArg(args, "profile") == null);
+    try std.testing.expect(nullablePlaceholderStringArg(args, "shell") == null);
+    try std.testing.expect(nullablePlaceholderStringArg(args, "missing") == null);
+    try std.testing.expectEqualStrings("echo null", nullablePlaceholderStringArg(args, "command").?);
+    try std.testing.expectEqualStrings("nullify", nullablePlaceholderStringArg(args, "dir").?);
+    try std.testing.expectEqualStrings("null", optionalStringArg(args, "cwd").?);
 }

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -9,6 +9,7 @@ const command_environment = @import("../../core/execution/command_environment.zi
 const io_mod = @import("../../core/shared/io.zig");
 const pathing = @import("../../core/workspace/pathing.zig");
 const tool_dispatch = @import("../../core/tooling/tool_dispatch.zig");
+const tool_args = @import("../../core/tooling/tool_args.zig");
 const tool_result_errors = @import("../../core/tooling/tool_result_errors.zig");
 const workspace_access = @import("../../core/workspace/workspace_access.zig");
 const shell_resolver = @import("../../core/terminal/shell_resolver.zig");
@@ -251,10 +252,22 @@ fn fieldNameLessThan(_: void, left: []const u8, right: []const u8) bool {
     return std.mem.order(u8, left, right) == .lt;
 }
 
+/// The advertised schema requires every public field and tells the model to
+/// send null for the ones the selected action does not use. Models routinely
+/// serialize that null as the literal text "null", so the decoder treats it as
+/// the absence it was meant to express.
+fn isNullPlaceholder(value: std.json.Value) bool {
+    return switch (value) {
+        .null => true,
+        .string => |text| tool_args.isNullPlaceholderText(text),
+        else => false,
+    };
+}
+
 fn elideKnownNullFields(object: *std.json.ObjectMap) void {
     for (public_field_names[1..]) |field_name| {
         const value = object.get(field_name) orelse continue;
-        if (value != .null) continue;
+        if (!isNullPlaceholder(value)) continue;
         _ = object.orderedRemove(field_name);
     }
 }
@@ -1382,6 +1395,105 @@ test "terminal decoder elides known null placeholders but structures unknown nul
             const invalid_fields = correction.get("invalid_fields").?.array.items;
             try std.testing.expectEqual(@as(usize, 1), invalid_fields.len);
             try std.testing.expectEqualStrings("unknown", invalid_fields[0].string);
+        },
+        .input => |input| {
+            input.deinit(alloc);
+            return error.TestUnexpectedResult;
+        },
+    }
+}
+
+test "terminal decoder elides textual null placeholders like real nulls" {
+    const alloc = std.testing.allocator;
+    const exec_call = try decode(
+        .{ .allocator = alloc },
+        "{\"action\":\"exec\",\"command\":\"echo ONE\",\"cwd\":\".\",\"profile\":\"NULL\"," ++
+            "\"session_id\":\"null\",\"task_id\":\"null\",\"workspace_root\":\" null \"," ++
+            "\"shell\":null,\"backend\":\"null\",\"return_when\":\"null\",\"lease\":\"null\"}",
+    );
+    switch (exec_call) {
+        .failure => |message| {
+            defer alloc.free(message);
+            return error.TestUnexpectedResult;
+        },
+        .input => |input| {
+            defer input.deinit(alloc);
+            const value = input.as(OwnedInput).parsed.value;
+            try std.testing.expectEqual(Action.exec, value.action);
+            try std.testing.expectEqualStrings("echo ONE", value.command.?);
+            try std.testing.expectEqualStrings(".", value.cwd.?);
+            try std.testing.expect(value.profile == null);
+            try std.testing.expect(value.session_id == null);
+            try std.testing.expect(value.task_id == null);
+            try std.testing.expect(value.workspace_root == null);
+            try std.testing.expectEqual(contracts.WriteLeaseIntent.use, value.lease);
+        },
+    }
+
+    const start_call = try decode(
+        .{ .allocator = alloc },
+        "{\"action\":\"start\",\"shell\":\"null\",\"initial_monitors\":\"null\",\"write\":\"null\"}",
+    );
+    switch (start_call) {
+        .failure => |message| {
+            defer alloc.free(message);
+            return error.TestUnexpectedResult;
+        },
+        .input => |input| {
+            defer input.deinit(alloc);
+            const value = input.as(OwnedInput).parsed.value;
+            try std.testing.expectEqual(Action.start, value.action);
+            try std.testing.expect(value.shell == null);
+            try std.testing.expect(value.write == null);
+            try std.testing.expectEqual(@as(usize, 0), value.initial_monitors.len);
+        },
+    }
+}
+
+test "terminal decoder keeps command text that merely contains a null placeholder" {
+    const alloc = std.testing.allocator;
+    const accepted = try decode(
+        .{ .allocator = alloc },
+        "{\"action\":\"exec\",\"command\":\"echo null\"}",
+    );
+    switch (accepted) {
+        .failure => |message| {
+            defer alloc.free(message);
+            return error.TestUnexpectedResult;
+        },
+        .input => |input| {
+            defer input.deinit(alloc);
+            try std.testing.expectEqualStrings(
+                "echo null",
+                input.as(OwnedInput).parsed.value.command.?,
+            );
+        },
+    }
+}
+
+test "terminal decoder reports a textual null placeholder on a required field as missing" {
+    const alloc = std.testing.allocator;
+    const rejected = try decode(
+        .{ .allocator = alloc },
+        "{\"action\":\"exec\",\"command\":\"null\"}",
+    );
+    switch (rejected) {
+        .failure => |message| {
+            defer alloc.free(message);
+            var parsed = try std.json.parseFromSlice(std.json.Value, alloc, message, .{});
+            defer parsed.deinit();
+            const correction = parsed.value.object.get("error").?.object;
+            try std.testing.expectEqualStrings(
+                "invalid_action_fields",
+                correction.get("code").?.string,
+            );
+            try std.testing.expectEqual(
+                @as(usize, 0),
+                correction.get("invalid_fields").?.array.items.len,
+            );
+            const missing_fields = correction.get("missing_fields").?.array.items;
+            try std.testing.expectEqual(@as(usize, 1), missing_fields.len);
+            try std.testing.expectEqualStrings("command", missing_fields[0].string);
         },
         .input => |input| {
             input.deinit(alloc);

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -1474,6 +1474,61 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "terminal exec treats textual null placeholders as absent fields",
+  async () => {
+    const fixture = createFixture("fx-tui-terminal-null-placeholder-");
+    const marker = join(fixture.workspace, "null-placeholder-ran");
+    const gateway = startFakeGateway([
+      fakeGatewayToolCall("terminal_null_placeholder_exec", "terminal", {
+        action: "exec",
+        command: `printf NULL_PLACEHOLDER_OK > ${JSON.stringify(marker)}`,
+        cwd: "null",
+        profile: "null",
+        session_id: "null",
+        shell: "null",
+        backend: "null",
+        return_when: "null",
+        wait_ceiling_ms: "null",
+        dimensions: "null",
+        initial_monitors: "null",
+        cursor_segment: "null",
+        cursor_offset: "null",
+        after_event_id: "null",
+        acknowledge_event_id: "null",
+        max_events: "null",
+        write: "null",
+        lease: "null",
+        monitor: "null",
+        task_id: "NULL",
+        workspace_root: " null ",
+        rows: "null",
+        columns: "null",
+        signal: "null",
+        close_policy: "null",
+      }),
+      (body) => {
+        const result = toolResultText(body, "terminal_null_placeholder_exec");
+        expect(result).not.toContain("invalid_action_fields");
+        expect(readFileSync(marker, "utf8")).toBe("NULL_PLACEHOLDER_OK");
+        return fakeGatewayFinalText("Terminal null placeholders verified");
+      },
+    ]);
+    gateways.push(gateway);
+    const active = await launch(fixture, gateway);
+
+    await active.sendText("Run the fixture command exactly once.");
+    await active.waitForText("Terminal null placeholders verified", TIMEOUT);
+    expect(gateway.requests).toHaveLength(2);
+
+    const scrollback = await active.captureFullScrollback();
+    expect(countOccurrences(scrollback, "Ran printf NULL_PLACEHOLDER_OK")).toBe(1);
+    expect(scrollback).not.toContain("invalid field");
+    expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
   "terminal repeated unknown correction with a valid neighbor stops without request three",
   async () => {
     const fixture = createFixture("fx-tui-terminal-correction-loop-");


### PR DESCRIPTION
### Problem

Reported in #167. The terminal schema exposes 25 fields, all required, and every non-`action` field carries `Set null when the selected action does not use this field.` Models routinely serialize that null as the string `"null"`. The decoder only elided real JSON nulls, so `session_id: "null"` was read as a value and the call came back as `invalid_action_fields`.

The issue documents the consequence: the model retries with identical arguments, then explains the failure with a fabricated reason. In the reported example it claimed it had refused an `rm -rf` on safety grounds, when no permission gate had been evaluated and the call had simply failed on the shape of its arguments.

### What changes

A shared predicate, `tool_args.isNullPlaceholderText`, recognizes the string `"null"` case-insensitively and whitespace-trimmed.

Two independent readers parse the raw arguments and have to agree:

- the tool decoder, in `elideKnownNullFields`, which now elides textual placeholders alongside real nulls;
- the permission admission path, in `runCommandContext` and `resolveCommandCwdFromArgs`, where `cwd` and `profile` go through `nullablePlaceholderStringArg`.

Fixing only the decoder is not enough. The call then passed validation and failed later with `Permission target resolution failed for terminal: FileNotFound`, because `cwd: "null"` resolved to `<workspace>/null`.

### What is not covered

Only the string `"null"` is recognized, not `"undefined"`, `"None"`, or the empty string. That is the case observed in the issue, and widening it would be guesswork.

Points 2 and 3 of the issue are out of scope here. Point 2 proposes a per-action schema; the flat schema is a deliberate choice from `c51b710` "Fix terminal schema correction loops", and reversing it is a design decision rather than a bug fix. Point 3 is partly in place already: the TUI renders `Failed exec · N invalid fields` through `tool_presentation.zig`.

An out-of-contract field carrying a real value, for example `wait_ceiling_ms: 5000` on `exec`, is still rejected by `actionFieldCorrection`. The advertised schema makes that unlikely, since it explicitly asks for null on unused fields, but point 2 is what would rule it out for good.

### Tests

- `tool_args`: textual placeholder reads, with `"echo null"` and `"nullify"` preserved.
- `terminal`: `exec` and `start` accepted with textual placeholders, command text containing `null` preserved, a textual placeholder on a required field reported as missing.
- `permissions`: `permissionTargetForCall` with `cwd: " NULL "` resolves against the workspace root.
- E2E `tui-terminal-tool.test.ts`: an `exec` whose 24 unused fields are textual placeholders runs exactly once, with no correction and no extra gateway request.

`zig fmt --check src/` and `zig build` are clean. Full CI runs on the fork branch.

Refs #167
