### PR TITLE
Reduce macOS arm64 binary size

### DIFF
--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -33,6 +33,8 @@ USE_FLAGS = (
     "-passes=default<O2>",
 )
 
+CANDIDATE_SIGNING_PAGE_SIZE = 16 * 1024
+
 PROFILE_SECTION_ALIGNMENTS = (
     "-Wl,-sectalign,__DATA,__llvm_prf_cnts,0x4000",
     "-Wl,-sectalign,__DATA,__llvm_prf_data,0x4000",
@@ -804,6 +806,25 @@ def link_candidate(
         require_empty_stderr=True,
     )
     _require_nonempty_file(paths.candidate_binary, "stripped candidate executable")
+    run_checked(
+        (
+            str(toolchain.codesign),
+            "--force",
+            "--sign",
+            "-",
+            "--options",
+            "linker-signed",
+            "--pagesize",
+            str(CANDIDATE_SIGNING_PAGE_SIZE),
+            str(paths.candidate_binary),
+        ),
+        cwd=paths.root,
+        env=os.environ.copy(),
+        timeout_s=120,
+        log_path=paths.logs / "resign-candidate.json",
+        require_empty_stderr=False,
+    )
+    _require_nonempty_file(paths.candidate_binary, "re-signed candidate executable")
     return paths.candidate_binary
 
 

--- a/scripts/pgso/tests/test_pipeline.py
+++ b/scripts/pgso/tests/test_pipeline.py
@@ -19,6 +19,7 @@ from scripts.pgso.pipeline import (
     instrumentation_argv,
     instrumented_run_argv,
     instrumented_link_argv,
+    link_candidate,
     merge_profile_batch,
     parse_compiler_runtime,
     profile_use_argv,
@@ -245,6 +246,52 @@ class PgsoPipelineTests(unittest.TestCase):
                 "-lc",
             ),
             candidate,
+        )
+
+    def test_candidate_is_resigned_with_16k_pages_after_strip(self) -> None:
+        actions = self.root / "candidate-actions.txt"
+        artifact_tool = self.write_executable(
+            "artifact-tool",
+            """import pathlib,sys
+output = pathlib.Path(sys.argv[sys.argv.index('-o') + 1])
+output.parent.mkdir(parents=True, exist_ok=True)
+output.write_bytes(b'artifact')""",
+        )
+        strip = self.write_executable(
+            "strip-tool",
+            f"""import pathlib,sys
+with pathlib.Path({str(actions)!r}).open('a') as stream:
+    stream.write('strip ' + ' '.join(sys.argv[1:]) + '\\n')""",
+        )
+        codesign = self.write_executable(
+            "codesign-tool",
+            f"""import pathlib,sys
+with pathlib.Path({str(actions)!r}).open('a') as stream:
+    stream.write('codesign ' + ' '.join(sys.argv[1:]) + '\\n')""",
+        )
+        toolchain = dataclasses.replace(
+            self.toolchain,
+            zig=artifact_tool,
+            opt=artifact_tool,
+            llc=artifact_tool,
+            strip=strip,
+            codesign=codesign,
+        )
+        self.paths.profile_use_bitcode.write_bytes(b'profile-use bitcode')
+
+        link_candidate(
+            toolchain,
+            self.paths,
+            require_release_safe_evidence=False,
+        )
+
+        self.assertEqual(
+            [
+                f"strip -S -x {self.paths.candidate_binary}",
+                "codesign --force --sign - --options linker-signed "
+                f"--pagesize 16384 {self.paths.candidate_binary}",
+            ],
+            actions.read_text().splitlines(),
         )
 
     def test_bitcode_hash_must_match_the_original(self) -> None:

--- a/src/builtins/browser_workspace_tools.zig
+++ b/src/builtins/browser_workspace_tools.zig
@@ -17,7 +17,7 @@ fn buildTerminalSpec() tool_dispatch.Tool {
         .description = terminal_description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "action", .json_type = .string, .enum_values = &.{"exec"} },
+                .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{"exec"} } },
                 .{
                     .name = "command",
                     .json_type = .string,

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -78,7 +78,7 @@ const terminal_description =
 
 const terminal_shell_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "kind", .json_type = .string, .enum_values = &.{ "user_login", "executable" } },
+        .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "user_login", "executable" } } },
         .{ .name = "path", .json_type = .string, .description = "Required for executable." },
         .{ .name = "clean_start", .json_type = .boolean },
     },
@@ -87,7 +87,7 @@ const terminal_shell_schema = gateway_schema.ObjectSchema{
 
 const terminal_return_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "kind", .json_type = .string, .enum_values = &.{ "started", "exit", "quiet", "match" }, .description = "started is for start readiness; exit waits for session exit; quiet requires duration_ms; match requires pattern. output_contains is a monitor condition, not a return kind." },
+        .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "started", "exit", "quiet", "match" } }, .description = "started is for start readiness; exit waits for session exit; quiet requires duration_ms; match requires pattern. output_contains is a monitor condition, not a return kind." },
         .{ .name = "duration_ms", .json_type = .integer, .minimum = 1, .description = "Required for quiet." },
         .{ .name = "pattern", .json_type = .string, .description = "Required for match." },
     },
@@ -106,11 +106,11 @@ const terminal_dimensions_schema = gateway_schema.ObjectSchema{
 
 const terminal_monitor_condition_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "kind", .json_type = .string, .enum_values = &.{ "process_exit", "exit_code", "signal", "output_contains", "output_matches", "output_quiet", "screen_matches", "tcp_ready", "http_ready", "path_exists", "path_changed", "path_size", "custom_probe" } },
+        .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "process_exit", "exit_code", "signal", "output_contains", "output_matches", "output_quiet", "screen_matches", "tcp_ready", "http_ready", "path_exists", "path_changed", "path_size", "custom_probe" } } },
         .{ .name = "pattern", .json_type = .string, .description = "Output/screen pattern or HTTP URL, according to kind." },
         .{ .name = "duration_ms", .json_type = .integer, .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms), .description = "Required for output_quiet." },
         .{ .name = "exit_code", .json_type = .integer },
-        .{ .name = "signal", .json_type = .string, .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } },
+        .{ .name = "signal", .json_type = .string, .shape = &.{ .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } } },
         .{ .name = "host", .json_type = .string },
         .{ .name = "port", .json_type = .integer, .minimum = 1, .maximum = 65535 },
         .{ .name = "path", .json_type = .string, .description = "Required for path conditions. The path must resolve within the terminal workspace; external paths are rejected." },
@@ -124,7 +124,7 @@ const terminal_monitor_condition_schema = gateway_schema.ObjectSchema{
 
 const terminal_monitor_notify_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "kind", .json_type = .string, .enum_values = &.{ "on_match", "on_state_change", "on_exit", "every_check", "every_n_checks", "interval" } },
+        .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "on_match", "on_state_change", "on_exit", "every_check", "every_n_checks", "interval" } } },
         .{ .name = "count", .json_type = .integer, .minimum = 1 },
         .{ .name = "interval_ms", .json_type = .integer, .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms) },
     },
@@ -134,7 +134,7 @@ const terminal_monitor_notify_schema = gateway_schema.ObjectSchema{
 
 const terminal_monitor_lifetime_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "kind", .json_type = .string, .enum_values = &.{ "until_match", "until_session_end", "duration" } },
+        .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "until_match", "until_session_end", "duration" } } },
         .{ .name = "duration_ms", .json_type = .integer, .minimum = 1, .maximum = @intCast(terminal_monitor.maximum_lifetime_ms) },
     },
     .required = &.{"kind"},
@@ -143,10 +143,10 @@ const terminal_monitor_lifetime_schema = gateway_schema.ObjectSchema{
 
 const terminal_monitor_definition_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "condition", .json_type = .object, .object_schema = &terminal_monitor_condition_schema },
+        .{ .name = "condition", .json_type = .object, .shape = &.{ .object = &terminal_monitor_condition_schema } },
         .{ .name = "check_interval_ms", .json_type = .integer, .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms), .description = "Required for polling conditions tcp_ready, http_ready, path_exists, path_changed, path_size, and custom_probe. Event-driven conditions process_exit, exit_code, signal, output_contains, output_matches, output_quiet, and screen_matches omit it; materialized values are ignored." },
-        .{ .name = "notify", .json_type = .object, .object_schema = &terminal_monitor_notify_schema },
-        .{ .name = "lifetime", .json_type = .object, .object_schema = &terminal_monitor_lifetime_schema },
+        .{ .name = "notify", .json_type = .object, .shape = &.{ .object = &terminal_monitor_notify_schema } },
+        .{ .name = "lifetime", .json_type = .object, .shape = &.{ .object = &terminal_monitor_lifetime_schema } },
     },
     .required = &.{ "condition", "notify", "lifetime" },
     .additional_properties = false,
@@ -154,9 +154,9 @@ const terminal_monitor_definition_schema = gateway_schema.ObjectSchema{
 
 const terminal_monitor_operation_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "kind", .json_type = .string, .enum_values = &.{ "add", "update", "pause", "resume", "remove" } },
+        .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "add", "update", "pause", "resume", "remove" } } },
         .{ .name = "monitor_id", .json_type = .string },
-        .{ .name = "definition", .json_type = .object, .object_schema = &terminal_monitor_definition_schema },
+        .{ .name = "definition", .json_type = .object, .shape = &.{ .object = &terminal_monitor_definition_schema } },
     },
     .required = &.{"kind"},
     .additional_properties = false,
@@ -164,10 +164,10 @@ const terminal_monitor_operation_schema = gateway_schema.ObjectSchema{
 
 const terminal_write_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "kind", .json_type = .string, .enum_values = &.{ "text", "keys", "controls", "paste" } },
+        .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "text", "keys", "controls", "paste" } } },
         .{ .name = "text", .json_type = .string, .description = "Required for text or paste." },
-        .{ .name = "keys", .json_type = .array, .item_json_type = .string, .item_enum_values = &.{ "enter", "tab", "escape", "backspace", "delete", "insert", "arrow_up", "arrow_down", "arrow_left", "arrow_right", "home", "end", "page_up", "page_down" } },
-        .{ .name = "controls", .json_type = .array, .item_json_type = .integer, .description = "ASCII code of the printable key designator used with Ctrl; for example, 108 (`l`) for Ctrl+L. Send the printable key code, not the resulting control byte." },
+        .{ .name = "keys", .json_type = .array, .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "enter", "tab", "escape", "backspace", "delete", "insert", "arrow_up", "arrow_down", "arrow_left", "arrow_right", "home", "end", "page_up", "page_down" } } } },
+        .{ .name = "controls", .json_type = .array, .shape = &.{ .array_values = .{ .json_type = .integer } }, .description = "ASCII code of the printable key designator used with Ctrl; for example, 108 (`l`) for Ctrl+L. Send the printable key code, not the resulting control byte." },
     },
     .required = &.{"kind"},
     .additional_properties = false,
@@ -177,27 +177,27 @@ const terminal_properties = [_]gateway_schema.Property{
     .{ .name = "session_id", .json_type = .string, .description = "Required for session-targeted actions. Set null for start and list; owner-catalog authority is private." },
     .{ .name = "cwd", .json_type = .string, .description = "Working directory for exec or start; defaults to the workspace." },
     .{ .name = "command", .json_type = .string, .max_length = terminal_contracts.max_command_bytes, .description = "Command for exec, or optional command for start; omit on start for an interactive shell." },
-    .{ .name = "profile", .json_type = .string, .enum_values = &.{ "clean", "user" }, .description = "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile." },
-    .{ .name = "shell", .json_type = .object, .object_schema = &terminal_shell_schema },
-    .{ .name = "backend", .json_type = .string, .enum_values = &.{ "native", "tmux" }, .description = "Start backend or optional list filter." },
-    .{ .name = "return_when", .json_type = .object, .object_schema = &terminal_return_schema, .description = "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only." },
+    .{ .name = "profile", .json_type = .string, .shape = &.{ .enum_values = &.{ "clean", "user" } }, .description = "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile." },
+    .{ .name = "shell", .json_type = .object, .shape = &.{ .object = &terminal_shell_schema } },
+    .{ .name = "backend", .json_type = .string, .shape = &.{ .enum_values = &.{ "native", "tmux" } }, .description = "Start backend or optional list filter." },
+    .{ .name = "return_when", .json_type = .object, .shape = &.{ .object = &terminal_return_schema }, .description = "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only." },
     .{ .name = "wait_ceiling_ms", .json_type = .integer, .minimum = 1, .description = "Required for wait; required for start when return_when is non-immediate; maximum blocking time in milliseconds." },
-    .{ .name = "dimensions", .json_type = .object, .object_schema = &terminal_dimensions_schema },
-    .{ .name = "initial_monitors", .json_type = .array, .max_items = 32, .items = &terminal_monitor_definition_schema },
+    .{ .name = "dimensions", .json_type = .object, .shape = &.{ .object = &terminal_dimensions_schema } },
+    .{ .name = "initial_monitors", .json_type = .array, .max_items = 32, .shape = &.{ .array_objects = &terminal_monitor_definition_schema } },
     .{ .name = "cursor_segment", .json_type = .integer, .minimum = 1, .description = "Only for read and required for every read. For a new session's first read, use segment 1 with cursor_offset 0; otherwise use unread_range.start or raw_gap.available_from from the latest session facts. Continue from the previous raw_range.end." },
     .{ .name = "cursor_offset", .json_type = .integer, .description = "Only for read. Use 0 with segment 1 for a new session's first read, then continue from the previous raw_range.end offset." },
     .{ .name = "after_event_id", .json_type = .integer },
     .{ .name = "acknowledge_event_id", .json_type = .integer, .minimum = 1 },
     .{ .name = "max_events", .json_type = .integer, .minimum = 1, .maximum = 256 },
-    .{ .name = "write", .json_type = .object, .object_schema = &terminal_write_schema, .description = "Payload is valid only with lease=use. Set null for acquire, release, and revoke." },
-    .{ .name = "lease", .json_type = .string, .enum_values = &.{ "acquire", "use", "release", "revoke" }, .description = "Use lease=acquire without write, then send a second call with lease=use and the payload. Release and revoke also require write=null." },
-    .{ .name = "monitor", .json_type = .object, .object_schema = &terminal_monitor_operation_schema },
+    .{ .name = "write", .json_type = .object, .shape = &.{ .object = &terminal_write_schema }, .description = "Payload is valid only with lease=use. Set null for acquire, release, and revoke." },
+    .{ .name = "lease", .json_type = .string, .shape = &.{ .enum_values = &.{ "acquire", "use", "release", "revoke" } }, .description = "Use lease=acquire without write, then send a second call with lease=use and the payload. Release and revoke also require write=null." },
+    .{ .name = "monitor", .json_type = .object, .shape = &.{ .object = &terminal_monitor_operation_schema } },
     .{ .name = "task_id", .json_type = .string },
     .{ .name = "workspace_root", .json_type = .string },
     .{ .name = "rows", .json_type = .integer, .minimum = 1, .maximum = 4096 },
     .{ .name = "columns", .json_type = .integer, .minimum = 1, .maximum = 4096 },
-    .{ .name = "signal", .json_type = .string, .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } },
-    .{ .name = "close_policy", .json_type = .string, .enum_values = &.{ "graceful", "force" }, .description = "Only for close and required for close. Close is final; read or inspect all needed output before closing." },
+    .{ .name = "signal", .json_type = .string, .shape = &.{ .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } } },
+    .{ .name = "close_policy", .json_type = .string, .shape = &.{ .enum_values = &.{ "graceful", "force" } }, .description = "Only for close and required for close. Close is final; read or inspect all needed output before closing." },
 };
 
 const terminal_actions = blk: {
@@ -232,7 +232,7 @@ const terminal_nullable_properties = blk: {
 const terminal_gateway_properties = [_]gateway_schema.Property{.{
     .name = "action",
     .json_type = .string,
-    .enum_values = &terminal_actions,
+    .shape = &.{ .enum_values = &terminal_actions },
 }} ++ terminal_nullable_properties;
 
 const terminal_gateway_required = blk: {
@@ -262,7 +262,7 @@ const ask_user_question_option_schema = gateway_schema.ObjectSchema{
 const ask_user_question_question_schema = gateway_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "question", .json_type = .string, .description = "Specific blocking decision shown to the user; do not ask for facts tools can inspect." },
-        .{ .name = "options", .json_type = .array, .min_items = 2, .max_items = 6, .items = &ask_user_question_option_schema },
+        .{ .name = "options", .json_type = .array, .min_items = 2, .max_items = 6, .shape = &.{ .array_objects = &ask_user_question_option_schema } },
     },
     .required = &.{ "question", "options" },
 };
@@ -281,11 +281,11 @@ const subagent_terminal_schema = gateway_schema.ObjectSchema{
 
 const subagent_notifications_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "terminal", .json_type = .object, .object_schema = &subagent_terminal_schema },
-        .{ .name = "milestones", .json_type = .array, .max_items = subagent_domain.max_milestones, .item_json_type = .string },
+        .{ .name = "terminal", .json_type = .object, .shape = &.{ .object = &subagent_terminal_schema } },
+        .{ .name = "milestones", .json_type = .array, .max_items = subagent_domain.max_milestones, .shape = &.{ .array_values = .{ .json_type = .string } } },
         .{ .name = "report_interval_ms", .json_type = .integer, .minimum = 1 },
         .{ .name = "report_duration_ms", .json_type = .integer, .minimum = 1 },
-        .{ .name = "stop_conditions", .json_type = .array, .max_items = subagent_domain.max_stop_conditions, .item_json_type = .string, .item_enum_values = &.{ "terminal", "duration_elapsed" } },
+        .{ .name = "stop_conditions", .json_type = .array, .max_items = subagent_domain.max_stop_conditions, .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "terminal", "duration_elapsed" } } } },
     },
     .additional_properties = false,
 };
@@ -293,12 +293,12 @@ const subagent_notifications_schema = gateway_schema.ObjectSchema{
 const subagent_create_schema = gateway_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "name", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_name_bytes },
-        .{ .name = "mode", .json_type = .string, .enum_values = &.{ "one_off", "persistent" } },
+        .{ .name = "mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "one_off", "persistent" } } },
         .{ .name = "prompt", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_prompt_bytes },
         .{ .name = "model", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_model_bytes },
         .{ .name = "effort", .json_type = .string, .min_length = 1, .max_length = types.ReasoningEffort.max_name_bytes },
-        .{ .name = "permission_mode", .json_type = .string, .enum_values = &.{ "ask", "auto", "yolo" }, .description = "Child permission mode. Inherits the caller when omitted and cannot exceed it." },
-        .{ .name = "notifications", .json_type = .object, .object_schema = &subagent_notifications_schema },
+        .{ .name = "permission_mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "ask", "auto", "yolo" } }, .description = "Child permission mode. Inherits the caller when omitted and cannot exceed it." },
+        .{ .name = "notifications", .json_type = .object, .shape = &.{ .object = &subagent_notifications_schema } },
     },
     .required = &.{ "name", "mode" },
     .additional_properties = false,
@@ -306,7 +306,7 @@ const subagent_create_schema = gateway_schema.ObjectSchema{
 
 const subagent_inspect_wait_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "until", .json_type = .string, .enum_values = &.{"settled"}, .description = "Wait until a persistent child is idle or the child reaches another non-running terminal/recovery state." },
+        .{ .name = "until", .json_type = .string, .shape = &.{ .enum_values = &.{"settled"} }, .description = "Wait until a persistent child is idle or the child reaches another non-running terminal/recovery state." },
         .{ .name = "after_generation", .json_type = .integer, .minimum = 0, .description = "Optional durable generation that must be exceeded before the wait can complete." },
         .{ .name = "timeout_ms", .json_type = .integer, .minimum = 1, .maximum = subagent_domain.max_inspect_wait_ms, .description = "Bounded wait deadline in milliseconds. A timeout returns the latest inspection with status wait_timed_out." },
     },
@@ -317,10 +317,10 @@ const subagent_inspect_wait_schema = gateway_schema.ObjectSchema{
 const subagent_inspect_schema = gateway_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "id", .json_type = .string, .min_length = 1 },
-        .{ .name = "sections", .json_type = .array, .min_items = 1, .max_items = 6, .item_json_type = .string, .item_enum_values = &.{ "status", "messages", "tool_activity", "events", "configuration", "relationship" } },
+        .{ .name = "sections", .json_type = .array, .min_items = 1, .max_items = 6, .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "status", "messages", "tool_activity", "events", "configuration", "relationship" } } } },
         .{ .name = "cursor", .json_type = .string, .min_length = 1 },
         .{ .name = "limit", .json_type = .integer, .minimum = 1, .maximum = subagent_domain.max_page_limit },
-        .{ .name = "wait", .json_type = .object, .object_schema = &subagent_inspect_wait_schema, .description = "Optional condition-driven same-turn wait. Requires the status section and cannot be combined with a cursor." },
+        .{ .name = "wait", .json_type = .object, .shape = &.{ .object = &subagent_inspect_wait_schema }, .description = "Optional condition-driven same-turn wait. Requires the status section and cannot be combined with a cursor." },
     },
     .required = &.{ "id", "sections" },
     .additional_properties = false,
@@ -343,8 +343,8 @@ const subagent_milestone_schema = gateway_schema.ObjectSchema{
 
 const subagent_message_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "send", .json_type = .object, .object_schema = &subagent_send_schema },
-        .{ .name = "milestone", .json_type = .object, .object_schema = &subagent_milestone_schema },
+        .{ .name = "send", .json_type = .object, .shape = &.{ .object = &subagent_send_schema } },
+        .{ .name = "milestone", .json_type = .object, .shape = &.{ .object = &subagent_milestone_schema } },
     },
     .additional_properties = false,
     .min_properties = 1,
@@ -353,7 +353,7 @@ const subagent_message_schema = gateway_schema.ObjectSchema{
 
 const subagent_relationship_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "action", .json_type = .string, .enum_values = &.{ "attach", "detach", "reparent" } },
+        .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{ "attach", "detach", "reparent" } } },
         .{ .name = "id", .json_type = .string, .min_length = 1 },
         .{ .name = "parent_id", .json_type = .string, .min_length = 1 },
     },
@@ -367,8 +367,8 @@ const subagent_configure_schema = gateway_schema.ObjectSchema{
         .{ .name = "name", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_name_bytes },
         .{ .name = "model", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_model_bytes },
         .{ .name = "effort", .json_type = .string, .min_length = 1, .max_length = types.ReasoningEffort.max_name_bytes },
-        .{ .name = "permission_mode", .json_type = .string, .enum_values = &.{ "ask", "auto", "yolo" }, .description = "New child permission mode. Cannot exceed the caller's current mode." },
-        .{ .name = "notifications", .json_type = .object, .object_schema = &subagent_notifications_schema },
+        .{ .name = "permission_mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "ask", "auto", "yolo" } }, .description = "New child permission mode. Cannot exceed the caller's current mode." },
+        .{ .name = "notifications", .json_type = .object, .shape = &.{ .object = &subagent_notifications_schema } },
     },
     .required = &.{"id"},
     .additional_properties = false,
@@ -377,7 +377,7 @@ const subagent_configure_schema = gateway_schema.ObjectSchema{
 const subagent_lifecycle_schema = gateway_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "id", .json_type = .string, .min_length = 1 },
-        .{ .name = "action", .json_type = .string, .enum_values = &.{ "cancel", "resume", "close", "reopen" } },
+        .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{ "cancel", "resume", "close", "reopen" } } },
     },
     .required = &.{ "id", "action" },
     .additional_properties = false,
@@ -385,12 +385,12 @@ const subagent_lifecycle_schema = gateway_schema.ObjectSchema{
 
 const subagent_command_schema = gateway_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "create", .json_type = .object, .object_schema = &subagent_create_schema },
-        .{ .name = "inspect", .json_type = .object, .object_schema = &subagent_inspect_schema },
-        .{ .name = "message", .json_type = .object, .object_schema = &subagent_message_schema },
-        .{ .name = "relationship", .json_type = .object, .object_schema = &subagent_relationship_schema },
-        .{ .name = "configure", .json_type = .object, .object_schema = &subagent_configure_schema },
-        .{ .name = "lifecycle", .json_type = .object, .object_schema = &subagent_lifecycle_schema },
+        .{ .name = "create", .json_type = .object, .shape = &.{ .object = &subagent_create_schema } },
+        .{ .name = "inspect", .json_type = .object, .shape = &.{ .object = &subagent_inspect_schema } },
+        .{ .name = "message", .json_type = .object, .shape = &.{ .object = &subagent_message_schema } },
+        .{ .name = "relationship", .json_type = .object, .shape = &.{ .object = &subagent_relationship_schema } },
+        .{ .name = "configure", .json_type = .object, .shape = &.{ .object = &subagent_configure_schema } },
+        .{ .name = "lifecycle", .json_type = .object, .shape = &.{ .object = &subagent_lifecycle_schema } },
     },
     .additional_properties = false,
     .min_properties = 1,
@@ -436,7 +436,7 @@ pub const glob_files = ToolSpec{
             .properties = &.{
                 .{ .name = "pattern", .json_type = .string, .description = "Glob pattern to match, such as src/**/*.zig or *.md." },
                 .{ .name = "path", .json_type = .string, .description = "Optional search root relative to the workspace root, or an external path using an absolute path, ~/..., or a relative workspace escape such as ../...; external access is subject to permission policy. Defaults to current directory; narrow it when possible." },
-                .{ .name = "mode", .json_type = .string, .enum_values = &.{ "matches", "count" }, .description = "Use matches to return sample paths, or count to return an exact matching path count without listing entries." },
+                .{ .name = "mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "matches", "count" } }, .description = "Use matches to return sample paths, or count to return an exact matching path count without listing entries." },
             },
             .required = &.{"pattern"},
         },
@@ -468,7 +468,7 @@ pub const grep_files = ToolSpec{
                 .{ .name = "path", .json_type = .string, .description = "Optional search root relative to the workspace root, or an external path using an absolute path, ~/..., or a relative workspace escape such as ../...; external access is subject to permission policy. Defaults to current directory; narrow it when possible." },
                 .{ .name = "include", .json_type = .string, .description = "Optional glob pattern applied to candidate file paths before reading files, such as *.zig or src/**/*.ts." },
                 .{ .name = "case_insensitive", .json_type = .boolean, .description = "Search case-insensitively when true." },
-                .{ .name = "mode", .json_type = .string, .enum_values = &.{ "matches", "files_with_matches", "count" }, .description = "Use matches for line matches, files_with_matches for unique matching paths, or count for exact matching-line and matching-file counts." },
+                .{ .name = "mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "matches", "files_with_matches", "count" } }, .description = "Use matches for line matches, files_with_matches for unique matching paths, or count for exact matching-line and matching-file counts." },
                 .{ .name = "head_limit", .json_type = .integer, .description = "Optional positive maximum results to return for matches or files_with_matches. Defaults to the normal output cap." },
                 .{ .name = "offset", .json_type = .integer, .description = "Optional zero-based result offset for matches or files_with_matches pagination. Defaults to 0." },
                 .{ .name = "context_lines", .json_type = .integer, .description = "Optional non-negative number of lines before and after each emitted match in matches mode. Bounded by the tool." },
@@ -735,7 +735,7 @@ pub const memory = ToolSpec{
         .description = memory_description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "action", .json_type = .string, .enum_values = &.{ "save", "list", "clear" }, .description = "Action to perform." },
+                .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{ "save", "list", "clear" } }, .description = "Action to perform." },
                 .{ .name = "fact", .json_type = .string, .description = "Fact to save (required for save action)." },
             },
             .required = &.{"action"},
@@ -871,8 +871,8 @@ pub const web_search = ToolSpec{
         .input_schema = .{
             .properties = &.{
                 .{ .name = "query", .json_type = .string, .min_length = 2 },
-                .{ .name = "allowed_domains", .json_type = .array, .item_json_type = .string },
-                .{ .name = "blocked_domains", .json_type = .array, .item_json_type = .string },
+                .{ .name = "allowed_domains", .json_type = .array, .shape = &.{ .array_values = .{ .json_type = .string } } },
+                .{ .name = "blocked_domains", .json_type = .array, .shape = &.{ .array_values = .{ .json_type = .string } } },
             },
             .required = &.{"query"},
             .additional_properties = false,
@@ -997,7 +997,7 @@ pub const subagent = ToolSpec{
         .name = "subagent",
         .description = subagent_description,
         .input_schema = .{
-            .properties = &.{.{ .name = "command", .json_type = .object, .object_schema = &subagent_command_schema }},
+            .properties = &.{.{ .name = "command", .json_type = .object, .shape = &.{ .object = &subagent_command_schema } }},
             .required = &.{"command"},
             .additional_properties = false,
         },
@@ -1083,7 +1083,7 @@ pub const mcp_features = ToolSpec{
         .description = mcp_features_description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "action", .json_type = .string, .enum_values = &.{ "resource_list", "resource_templates", "resource_read", "prompt_list", "prompt_get", "prompt_complete", "resource_complete" }, .description = "Exact MCP feature operation." },
+                .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{ "resource_list", "resource_templates", "resource_read", "prompt_list", "prompt_get", "prompt_complete", "resource_complete" } }, .description = "Exact MCP feature operation." },
                 .{ .name = "server", .json_type = .string, .description = "Exact configured MCP server name." },
                 .{ .name = "uri", .json_type = .string, .description = "Exact discovered resource URI for resource_read." },
                 .{ .name = "uri_template", .json_type = .string, .description = "Exact discovered resource template for resource_complete." },
@@ -1119,7 +1119,7 @@ pub const ask_user_question = ToolSpec{
         .description = ask_user_question_description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "questions", .json_type = .array, .min_items = 1, .max_items = 4, .items = &ask_user_question_question_schema },
+                .{ .name = "questions", .json_type = .array, .min_items = 1, .max_items = 4, .shape = &.{ .array_objects = &ask_user_question_question_schema } },
                 .{ .name = "permission_request_id", .json_type = .string, .min_length = ask_user_question_impl.permission_request_id_hex_bytes, .max_length = ask_user_question_impl.permission_request_id_hex_bytes, .description = "Exact opaque ID from an auto_denied tool result. Omit for ordinary questions." },
             },
             .required = &.{"questions"},
@@ -1154,14 +1154,14 @@ pub const vision = ToolSpec{
                     .json_type = .array,
                     .description = "Ordered unique IDs of user-authorized images to inspect.",
                     .min_items = 1,
-                    .item_json_type = .integer,
+                    .shape = &.{ .array_values = .{ .json_type = .integer } },
                 },
                 .{
                     .name = "paths",
                     .json_type = .array,
                     .description = "Ordered unique local image paths supplied by the user. Relative paths resolve from the workspace; ~/ resolves from the user's home directory.",
                     .min_items = 1,
-                    .item_json_type = .string,
+                    .shape = &.{ .array_values = .{ .json_type = .string } },
                 },
                 .{
                     .name = "focus",
@@ -1280,6 +1280,14 @@ fn schemaProperty(schema: gateway_schema.ObjectSchema, name: []const u8) ?gatewa
     return null;
 }
 
+fn schemaEnumValues(property: gateway_schema.Property) []const []const u8 {
+    const shape = property.shape orelse return &.{};
+    return switch (shape.*) {
+        .enum_values => |values| values,
+        else => &.{},
+    };
+}
+
 fn nameInSet(names: []const []const u8, wanted: []const u8) bool {
     for (names) |name| {
         if (std.mem.eql(u8, name, wanted)) return true;
@@ -1307,7 +1315,7 @@ test "terminal tool schema exposes one nullable object backed by the terminal ac
     try std.testing.expectEqualSlices(
         []const u8,
         &terminal_actions,
-        schemaProperty(input_schema, "action").?.enum_values,
+        schemaEnumValues(schemaProperty(input_schema, "action").?),
     );
 
     var covered_fields: [terminal_impl.public_field_names.len]bool = @splat(false);
@@ -1331,7 +1339,7 @@ test "terminal tool schema exposes one nullable object backed by the terminal ac
     try std.testing.expectEqualSlices(
         []const u8,
         &.{ "native", "tmux" },
-        schemaProperty(input_schema, "backend").?.enum_values,
+        schemaEnumValues(schemaProperty(input_schema, "backend").?),
     );
     try std.testing.expectEqualStrings(
         "Required for wait; required for start when return_when is non-immediate; maximum blocking time in milliseconds.",

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -828,19 +828,19 @@ const schema_properties = [_]gateway_schema.Property{
     .{
         .name = "risk",
         .json_type = .string,
-        .enum_values = risk_values[0..],
+        .shape = &.{ .enum_values = risk_values[0..] },
         .description = "Risk of the exact action being reviewed.",
     },
     .{
         .name = "authorization",
         .json_type = .string,
-        .enum_values = authorization_values[0..],
+        .shape = &.{ .enum_values = authorization_values[0..] },
         .description = "Strength of authorization from proven user-authored instructions.",
     },
     .{
         .name = "decision",
         .json_type = .string,
-        .enum_values = decision_values[0..],
+        .shape = &.{ .enum_values = decision_values[0..] },
         .description = "Allow this action, or ask the user.",
     },
     .{

--- a/src/core/shared/display_width.zig
+++ b/src/core/shared/display_width.zig
@@ -1,6 +1,80 @@
 const std = @import("std");
 const unicode_data = @import("unicode_display_data.zig");
 
+const RgiNode = packed struct(u32) {
+    edge_start: u13,
+    edge_len: u8,
+    terminal: bool,
+    padding: u10 = 0,
+};
+
+const rgi_codepoint_count: usize = blk: {
+    @setEvalBranchQuota(2_000_000);
+    var unique: [unicode_data.rgi_trie_edges.len]u21 = undefined;
+    var count: usize = 0;
+    for (unicode_data.rgi_trie_edges) |edge| {
+        var seen = false;
+        for (unique[0..count]) |codepoint| {
+            if (codepoint == edge.codepoint) {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen) {
+            unique[count] = edge.codepoint;
+            count += 1;
+        }
+    }
+    break :blk count;
+};
+
+const RgiData = struct {
+    nodes: [unicode_data.rgi_trie_nodes.len]RgiNode,
+    edge_codepoint_ids: [unicode_data.rgi_trie_edges.len]u8,
+    codepoints: [rgi_codepoint_count]u21,
+};
+
+const rgi_data: RgiData = blk: {
+    @setEvalBranchQuota(2_000_000);
+    if (rgi_codepoint_count > std.math.maxInt(u8) + 1) {
+        @compileError("RGI trie edge alphabet no longer fits in u8");
+    }
+
+    var data: RgiData = undefined;
+    var codepoint_count: usize = 0;
+    for (unicode_data.rgi_trie_edges, 0..) |edge, edge_index| {
+        if (edge.child != edge_index + 1) {
+            @compileError("RGI trie child numbering is no longer implicit");
+        }
+
+        var codepoint_id: ?u8 = null;
+        for (data.codepoints[0..codepoint_count], 0..) |codepoint, index| {
+            if (codepoint == edge.codepoint) {
+                codepoint_id = @intCast(index);
+                break;
+            }
+        }
+        if (codepoint_id == null) {
+            codepoint_id = @intCast(codepoint_count);
+            data.codepoints[codepoint_count] = edge.codepoint;
+            codepoint_count += 1;
+        }
+        data.edge_codepoint_ids[edge_index] = codepoint_id.?;
+    }
+    if (codepoint_count != rgi_codepoint_count) {
+        @compileError("RGI trie edge alphabet count mismatch");
+    }
+
+    for (unicode_data.rgi_trie_nodes, 0..) |node, index| {
+        data.nodes[index] = .{
+            .edge_start = @intCast(node.edge_start),
+            .edge_len = @intCast(node.edge_len),
+            .terminal = node.terminal,
+        };
+    }
+    break :blk data;
+};
+
 pub const DecodedRune = struct {
     len: usize,
     codepoint: u21,
@@ -314,7 +388,7 @@ fn matchRgiSequence(text: []const u8, index: usize) usize {
         const rune = decodeNextRune(text, cursor);
         node_index = findTrieChild(node_index, rune.codepoint) orelse break;
         cursor += rune.len;
-        const node = unicode_data.rgi_trie_nodes[node_index];
+        const node = rgi_data.nodes[node_index];
         if (node.terminal) longest = cursor - index;
     }
 
@@ -322,22 +396,26 @@ fn matchRgiSequence(text: []const u8, index: usize) usize {
 }
 
 fn findTrieChild(node_index: u32, codepoint: u21) ?u32 {
-    const node = unicode_data.rgi_trie_nodes[node_index];
+    const node = rgi_data.nodes[node_index];
     const edge_start: usize = node.edge_start;
     var low = edge_start;
     var high = edge_start + node.edge_len;
     while (low < high) {
         const middle = low + (high - low) / 2;
-        const edge = unicode_data.rgi_trie_edges[middle];
-        if (codepoint < edge.codepoint) {
+        const edge_codepoint = rgi_data.codepoints[rgi_data.edge_codepoint_ids[middle]];
+        if (codepoint < edge_codepoint) {
             high = middle;
-        } else if (codepoint > edge.codepoint) {
+        } else if (codepoint > edge_codepoint) {
             low = middle + 1;
         } else {
-            return edge.child;
+            return @intCast(middle + 1);
         }
     }
     return null;
+}
+
+test "RGI runtime lookup data stays within the measured size budget" {
+    try std.testing.expect(@sizeOf(RgiData) <= 22_272);
 }
 
 test "prefixByWidth avoids cutting emoji bytes" {

--- a/src/core/tooling/gateway_schema.zig
+++ b/src/core/tooling/gateway_schema.zig
@@ -11,31 +11,40 @@ pub const JsonType = enum {
     array,
 };
 
+const no_u32_bound = std.math.maxInt(u32);
+const no_u64_bound = std.math.maxInt(u64);
+
+const PropertyShape = union(enum) {
+    enum_values: []const []const u8,
+    object: *const ObjectSchema,
+    array_values: struct {
+        json_type: JsonType,
+        enum_values: []const []const u8 = &.{},
+    },
+    array_objects: *const ObjectSchema,
+};
+
 pub const Property = struct {
     name: []const u8,
     json_type: JsonType,
     description: []const u8 = "",
     nullable: bool = false,
     nullable_description: []const u8 = "",
-    enum_values: []const []const u8 = &.{},
-    min_length: ?usize = null,
-    max_length: ?usize = null,
-    minimum: ?u64 = null,
-    maximum: ?u64 = null,
-    min_items: ?usize = null,
-    max_items: ?usize = null,
-    item_json_type: ?JsonType = null,
-    item_enum_values: []const []const u8 = &.{},
-    items: ?*const ObjectSchema = null,
-    object_schema: ?*const ObjectSchema = null,
+    shape: ?*const PropertyShape = null,
+    min_length: u32 = no_u32_bound,
+    max_length: u32 = no_u32_bound,
+    minimum: u64 = no_u64_bound,
+    maximum: u64 = no_u64_bound,
+    min_items: u32 = no_u32_bound,
+    max_items: u32 = no_u32_bound,
 };
 
 pub const ObjectSchema = struct {
     properties: []const Property = &.{},
     required: []const []const u8 = &.{},
     additional_properties: ?bool = null,
-    min_properties: ?usize = null,
-    max_properties: ?usize = null,
+    min_properties: u32 = no_u32_bound,
+    max_properties: u32 = no_u32_bound,
     one_of: []const ObjectSchema = &.{},
 };
 
@@ -44,6 +53,10 @@ pub const FunctionSchema = struct {
     description: []const u8,
     input_schema: ObjectSchema = .{},
 };
+
+test "static property representation stays within the measured size budget" {
+    try std.testing.expect(@sizeOf(Property) <= 96);
+}
 
 fn cappedDescriptionAlloc(alloc: std.mem.Allocator, text: []const u8) ![]u8 {
     if (text.len <= description_max_bytes) return alloc.dupe(u8, text);
@@ -123,8 +136,8 @@ fn writeObjectSchema(
         if (schema.properties.len > 0 or
             schema.required.len > 0 or
             schema.additional_properties != null or
-            schema.min_properties != null or
-            schema.max_properties != null)
+            schema.min_properties != no_u32_bound or
+            schema.max_properties != no_u32_bound)
         {
             return error.InvalidObjectSchema;
         }
@@ -149,8 +162,8 @@ fn writeObjectSchema(
         try writer.writeAll(",\"additionalProperties\":");
         try writer.writeAll(if (value) "true" else "false");
     }
-    if (schema.min_properties) |value| try writer.print(",\"minProperties\":{d}", .{value});
-    if (schema.max_properties) |value| try writer.print(",\"maxProperties\":{d}", .{value});
+    if (schema.min_properties != no_u32_bound) try writer.print(",\"minProperties\":{d}", .{schema.min_properties});
+    if (schema.max_properties != no_u32_bound) try writer.print(",\"maxProperties\":{d}", .{schema.max_properties});
     if (schema.required.len > 0) {
         try writer.writeAll(",\"required\":[");
         for (schema.required, 0..) |name, index| {
@@ -185,45 +198,61 @@ fn writePropertySchema(
         try writer.writeByte('}');
         return;
     }
-    if (property.object_schema) |object_schema| {
-        try writeObjectSchema(alloc, writer, object_schema.*);
-        return;
+    if (property.shape) |shape| {
+        switch (shape.*) {
+            .object => |object_schema| {
+                try writeObjectSchema(alloc, writer, object_schema.*);
+                return;
+            },
+            else => {},
+        }
     }
     try writer.writeAll("{\"type\":");
     try std.json.Stringify.value(@tagName(property.json_type), .{}, writer);
-    if (property.enum_values.len > 0) {
-        try writer.writeAll(",\"enum\":[");
-        for (property.enum_values, 0..) |value, index| {
-            if (index > 0) try writer.writeByte(',');
-            try std.json.Stringify.value(value, .{}, writer);
+    if (property.shape) |shape| {
+        switch (shape.*) {
+            .enum_values => |values| {
+                try writer.writeAll(",\"enum\":[");
+                for (values, 0..) |value, index| {
+                    if (index > 0) try writer.writeByte(',');
+                    try std.json.Stringify.value(value, .{}, writer);
+                }
+                try writer.writeByte(']');
+            },
+            else => {},
         }
-        try writer.writeByte(']');
     }
-    if (property.min_length) |value| try writer.print(",\"minLength\":{d}", .{value});
-    if (property.max_length) |value| try writer.print(",\"maxLength\":{d}", .{value});
-    if (property.minimum) |value| try writer.print(",\"minimum\":{d}", .{value});
-    if (property.maximum) |value| try writer.print(",\"maximum\":{d}", .{value});
+    if (property.min_length != no_u32_bound) try writer.print(",\"minLength\":{d}", .{property.min_length});
+    if (property.max_length != no_u32_bound) try writer.print(",\"maxLength\":{d}", .{property.max_length});
+    if (property.minimum != no_u64_bound) try writer.print(",\"minimum\":{d}", .{property.minimum});
+    if (property.maximum != no_u64_bound) try writer.print(",\"maximum\":{d}", .{property.maximum});
     if (property.description.len > 0) {
         try writer.writeAll(",\"description\":");
         try writeCappedDescriptionJsonString(alloc, writer, property.description);
     }
-    if (property.min_items) |value| try writer.print(",\"minItems\":{d}", .{value});
-    if (property.max_items) |value| try writer.print(",\"maxItems\":{d}", .{value});
-    if (property.item_json_type) |item_json_type| {
-        try writer.writeAll(",\"items\":{\"type\":");
-        try std.json.Stringify.value(@tagName(item_json_type), .{}, writer);
-        if (property.item_enum_values.len > 0) {
-            try writer.writeAll(",\"enum\":[");
-            for (property.item_enum_values, 0..) |value, index| {
-                if (index > 0) try writer.writeByte(',');
-                try std.json.Stringify.value(value, .{}, writer);
-            }
-            try writer.writeByte(']');
+    if (property.min_items != no_u32_bound) try writer.print(",\"minItems\":{d}", .{property.min_items});
+    if (property.max_items != no_u32_bound) try writer.print(",\"maxItems\":{d}", .{property.max_items});
+    if (property.shape) |shape| {
+        switch (shape.*) {
+            .array_values => |values| {
+                try writer.writeAll(",\"items\":{\"type\":");
+                try std.json.Stringify.value(@tagName(values.json_type), .{}, writer);
+                if (values.enum_values.len > 0) {
+                    try writer.writeAll(",\"enum\":[");
+                    for (values.enum_values, 0..) |value, index| {
+                        if (index > 0) try writer.writeByte(',');
+                        try std.json.Stringify.value(value, .{}, writer);
+                    }
+                    try writer.writeByte(']');
+                }
+                try writer.writeByte('}');
+            },
+            .array_objects => |items| {
+                try writer.writeAll(",\"items\":");
+                try writeObjectSchema(alloc, writer, items.*);
+            },
+            else => {},
         }
-        try writer.writeByte('}');
-    } else if (property.items) |items| {
-        try writer.writeAll(",\"items\":");
-        try writeObjectSchema(alloc, writer, items.*);
     }
     try writer.writeByte('}');
 }
@@ -246,14 +275,14 @@ test "nullable properties preserve concrete constraints and add one null branch"
                     .description = "Concrete choice.",
                     .nullable = true,
                     .nullable_description = "Concrete choice. Set null when unused.",
-                    .enum_values = &.{ "one", "two" },
+                    .shape = &.{ .enum_values = &.{ "one", "two" } },
                 },
                 .{
                     .name = "config",
                     .json_type = .object,
                     .nullable = true,
                     .nullable_description = "Set null when unused.",
-                    .object_schema = &object_value_schema,
+                    .shape = &.{ .object = &object_value_schema },
                 },
             },
             .required = &.{ "choice", "config" },
@@ -286,11 +315,11 @@ test "nullable properties preserve concrete constraints and add one null branch"
 test "nested object schema serializes exact property bounds" {
     const alloc = std.testing.allocator;
     const nested = ObjectSchema{
-        .properties = &.{.{ .name = "create", .json_type = .object, .object_schema = &.{
+        .properties = &.{.{ .name = "create", .json_type = .object, .shape = &.{ .object = &.{
             .properties = &.{.{ .name = "name", .json_type = .string }},
             .required = &.{"name"},
             .additional_properties = false,
-        } }},
+        } } }},
         .additional_properties = false,
         .min_properties = 1,
         .max_properties = 1,
@@ -315,7 +344,7 @@ test "object alternatives serialize as exclusive object branches" {
     const alternatives = [_]ObjectSchema{
         .{
             .properties = &.{
-                .{ .name = "action", .json_type = .string, .enum_values = &.{"read"} },
+                .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{"read"} } },
                 .{ .name = "path", .json_type = .string },
             },
             .required = &.{ "action", "path" },
@@ -323,7 +352,7 @@ test "object alternatives serialize as exclusive object branches" {
         },
         .{
             .properties = &.{
-                .{ .name = "action", .json_type = .string, .enum_values = &.{"list"} },
+                .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{"list"} } },
             },
             .required = &.{"action"},
             .additional_properties = false,
@@ -431,22 +460,21 @@ test "builtinFunctionSchemaJsonAlloc serializes every supported property shape" 
                     .name = "text",
                     .json_type = .string,
                     .description = "bounded choice",
-                    .enum_values = &.{ "alpha", "beta" },
+                    .shape = &.{ .enum_values = &.{ "alpha", "beta" } },
                     .min_length = 1,
                     .max_length = 8,
                 },
                 .{ .name = "count", .json_type = .integer, .minimum = 2, .maximum = 9 },
                 .{ .name = "enabled", .json_type = .boolean },
-                .{ .name = "config", .json_type = .object, .object_schema = &object_value_schema },
+                .{ .name = "config", .json_type = .object, .shape = &.{ .object = &object_value_schema } },
                 .{
                     .name = "tags",
                     .json_type = .array,
                     .min_items = 1,
                     .max_items = 3,
-                    .item_json_type = .string,
-                    .item_enum_values = &.{ "red", "blue" },
+                    .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "red", "blue" } } },
                 },
-                .{ .name = "records", .json_type = .array, .items = &array_item_schema },
+                .{ .name = "records", .json_type = .array, .shape = &.{ .array_objects = &array_item_schema } },
             },
             .required = &.{ "text", "count", "enabled", "config", "tags", "records" },
             .additional_properties = false,

--- a/src/core/tooling/tool_advertisement.zig
+++ b/src/core/tooling/tool_advertisement.zig
@@ -138,7 +138,7 @@ const test_memory = blk: {
         .description = spec.description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "action", .json_type = .string, .enum_values = &.{ "save", "list", "clear" } },
+                .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{ "save", "list", "clear" } } },
                 .{ .name = "fact", .json_type = .string },
             },
             .required = &.{"action"},
@@ -457,7 +457,7 @@ const test_terminal = blk: {
         .description = spec.description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "action", .json_type = .string, .enum_values = &.{"exec"} },
+                .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{"exec"} } },
                 .{ .name = "command", .json_type = .string },
             },
             .required = &.{ "action", "command" },

--- a/src/main.zig
+++ b/src/main.zig
@@ -562,6 +562,7 @@ const App = struct {
     pub fn init(alloc: Allocator, launch: *cli_surface.InteractiveLaunch) !Self {
         var app = Self{
             .alloc = alloc,
+            .subagents = ui_subagents.Controller.init(),
             .lifecycle_runtime = hooks.Runtime.init(alloc),
             .background = BackgroundRuntime.init(if (comptime host_target.is_wasm)
                 background_process_provider.unavailable_provider

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -5,6 +5,7 @@ const identity = @import("../../core/terminal/identity.zig");
 const operation = @import("../../core/terminal/operation.zig");
 const store = @import("../../core/terminal/store.zig");
 const debug_trace = @import("../../core/shared/debug_trace.zig");
+const sort_utils = @import("../../core/shared/sort_utils.zig");
 const command_environment = @import("../../core/execution/command_environment.zig");
 const io_mod = @import("../../core/shared/io.zig");
 const pathing = @import("../../core/workspace/pathing.zig");
@@ -296,7 +297,7 @@ fn actionFieldCorrection(
         if (isPublicField(entry.key_ptr.*)) continue;
         scratch.invalid_fields.appendAssumeCapacity(entry.key_ptr.*);
     }
-    std.mem.sort(
+    sort_utils.sort(
         []const u8,
         scratch.invalid_fields.items[unknown_start..],
         {},

--- a/src/ui/subagent/controller.zig
+++ b/src/ui/subagent/controller.zig
@@ -26,6 +26,10 @@ pub const Controller = struct {
     view_active: bool = false,
     last_refresh_ms: i64 = 0,
 
+    pub noinline fn init() Controller {
+        return .{ .runtime = subagent_runtime.Runtime.init() };
+    }
+
     pub fn deinit(self: *Controller, alloc: Allocator) void {
         self.runtime.deinit(alloc);
         self.view_active = false;

--- a/src/ui/subagent/runtime.zig
+++ b/src/ui/subagent/runtime.zig
@@ -261,10 +261,16 @@ const FormState = struct {
     paste_rejection: ?FormValidationFailure = null,
     attempt: MutationAttempt = .{},
 
+    noinline fn init() FormState {
+        var result: FormState = .{ .editors = undefined };
+        for (&result.editors) |*editor| editor.* = .{};
+        return result;
+    }
+
     fn deinit(self: *FormState, alloc: Allocator) void {
         self.clear(alloc);
         for (&self.editors) |*editor| editor.deinit(alloc);
-        self.* = .{};
+        self.* = undefined;
     }
 
     fn clear(self: *FormState, alloc: Allocator) void {
@@ -738,7 +744,7 @@ pub const ChildRouteState = struct {
         self.clear(alloc);
         self.pages.deinit(alloc);
         self.editor.deinit(alloc);
-        self.* = .{};
+        self.* = undefined;
     }
 
     fn clear(self: *ChildRouteState, alloc: Allocator) void {
@@ -872,6 +878,12 @@ pub const Runtime = struct {
     physical_surface: PhysicalSurface = .manager,
     count_projection: usize = 0,
 
+    pub noinline fn init() Runtime {
+        var result: Runtime = .{ .form = undefined };
+        result.form = FormState.init();
+        return result;
+    }
+
     pub fn deinit(self: *Runtime, alloc: Allocator) void {
         self.clearProjection(alloc);
         self.clearTerminalProjection(alloc);
@@ -886,7 +898,7 @@ pub const Runtime = struct {
         self.attach.deinit(alloc);
         self.lifecycle_attempt.deinit(alloc);
         if (self.main_approval_card) |*card| card.deinit(alloc);
-        self.* = .{};
+        self.* = undefined;
     }
 
     pub fn resetForOpen(self: *Runtime, alloc: Allocator) void {
@@ -3872,6 +3884,16 @@ pub const Runtime = struct {
         self.terminal_scroll = @min(self.terminal_scroll, max_scroll);
     }
 };
+
+test "repeated editor defaults are initialized through one runtime path" {
+    const runtime = Runtime.init();
+    try std.testing.expect(runtime.loading);
+    try std.testing.expect(runtime.preserve_page_anchor);
+    try std.testing.expectEqual(FormKind.none, runtime.form.kind);
+    for (runtime.form.editors) |editor| {
+        try std.testing.expect(editor.slash_menu_categories);
+    }
+}
 
 pub fn paint(
     alloc: Allocator,


### PR DESCRIPTION
## Summary

- Reduce the published macOS arm64 PGSO binary to 6.337 MiB.
- Preserve built-in tool schema JSON and Unicode terminal-width behavior.
- Keep startup and heavy-workload performance within the existing gates.