### PR TITLE
Skip unavailable WASM project-instruction probes

### DIFF
--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -59,6 +59,7 @@ Core validation from the repository root:
 zig build -Dwasm-surface=core
 node --experimental-wasm-jspi sdk/tests/test-core.mjs
 node --experimental-wasm-jspi sdk/tests/test-core-cancel.mjs
+node --experimental-wasm-jspi sdk/tests/test-core-home-unavailable.mjs
 node sdk/tests/test-core-browser.mjs
 ```
 

--- a/sdk/tests/test-core-home-unavailable.mjs
+++ b/sdk/tests/test-core-home-unavailable.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createFxAgent, supportsJspi } from "../node.js";
+
+const scriptDir = fileURLToPath(new URL(".", import.meta.url));
+const defaultWasm = resolve(scriptDir, "../../zig-out/bin/fx-core.wasm");
+const wasmPath = resolve(process.argv[2] || defaultWasm);
+
+if (!supportsJspi()) {
+  console.error("Node JSPI is disabled. Run with: node --experimental-wasm-jspi sdk/tests/test-core-home-unavailable.mjs");
+  process.exit(2);
+}
+
+const encoded = new TextEncoder();
+const catalogModels = [
+  { id: "sdk/catalog-alpha", type: "language", released: 2, tags: ["tool-use"] },
+];
+let fetchCalls = 0;
+let workspaceExecs = 0;
+const mockFetch = async (url, init) => {
+  if (init.method === "GET" && String(url).endsWith("/v1/models")) {
+    return Response.json({ object: "list", data: catalogModels });
+  }
+  fetchCalls++;
+  if (init.method !== "POST") throw new Error(`unexpected method ${init.method}`);
+  const requestBody = JSON.parse(new TextDecoder().decode(init.body));
+  if (!Array.isArray(requestBody.prompt) && !Array.isArray(requestBody.messages)) {
+    throw new Error("gateway request did not contain prompt messages");
+  }
+  return new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":"hello"}\n'));
+      controller.enqueue(encoded.encode('data: {"type":"text-delta","delta":" world"}\n'));
+      controller.enqueue(encoded.encode('data: {"type":"finish","finishReason":{"unified":"stop"},"usage":{"inputTokens":{"total":3},"outputTokens":{"total":2}}}\n'));
+      controller.enqueue(encoded.encode("data: [DONE]\n"));
+      controller.close();
+    },
+  }), { status: 200, headers: { "content-type": "text/event-stream" } });
+};
+
+const timeout = (label, ms = 8000) => {
+  let timer;
+  const promise = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), ms);
+  });
+  return { promise, cancel() { clearTimeout(timer); } };
+};
+
+const initializeTimeout = timeout("fx-core initialize");
+const agent = await Promise.race([
+  createFxAgent({
+    backend: "wasm",
+    wasm: await readFile(wasmPath),
+    fetch: mockFetch,
+    env: {
+      AI_GATEWAY_API_KEY: "sdk-test-key",
+      HOME: "/repo",
+    },
+    workspace: {
+      info: {
+        version: 1,
+        root: "/repo",
+        cwd: "/repo",
+        home: "/repo",
+        gitAvailable: false,
+        ephemeral: true,
+      },
+      permission: "allow-sandboxed",
+      async exec() {
+        workspaceExecs += 1;
+        throw new Error("workspace.exec should not run during a text-only prompt");
+      },
+    },
+  }),
+  initializeTimeout.promise,
+]).finally(() => initializeTimeout.cancel());
+
+const session = await agent.createSession();
+const turn = session.prompt("say hello");
+const chunks = [];
+const notices = [];
+for await (const update of turn) {
+  if (update.sessionUpdate !== "agent_message_chunk") continue;
+  const text = update.content.text;
+  if (text.startsWith("[context]")) notices.push(text);
+  else chunks.push(text);
+}
+const resultTimeout = timeout("prompt result");
+const result = await Promise.race([turn.result, resultTimeout.promise]).finally(() => resultTimeout.cancel());
+const streamedText = chunks.join("").trimEnd();
+if (notices.some((notice) => notice.includes("home unavailable"))) {
+  throw new Error(`home unavailable notice replaced the turn: ${JSON.stringify(notices)}`);
+}
+if (streamedText !== "hello world") throw new Error(`unexpected streamed text: ${JSON.stringify(chunks)}`);
+if (result.stopReason !== "end_turn") throw new Error(`unexpected stop reason: ${result.stopReason}`);
+if (fetchCalls !== 1) throw new Error(`expected one gateway fetch, got ${fetchCalls}`);
+if (workspaceExecs !== 0) throw new Error(`workspace.exec ran ${workspaceExecs} time(s)`);
+
+await agent.close();
+console.log("core SDK HOME=/repo unavailable filesystem passed: prompt reached the model");

--- a/sdk/tests/test-node-wasm.mjs
+++ b/sdk/tests/test-node-wasm.mjs
@@ -6,6 +6,7 @@ const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const commands = [
   [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-core.mjs", import.meta.url))]],
   [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-core-cancel.mjs", import.meta.url))]],
+  [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-core-home-unavailable.mjs", import.meta.url))]],
   [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-term.mjs", import.meta.url))]],
   [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-term-session-resume.mjs", import.meta.url))]],
   [process.execPath, ["--experimental-wasm-jspi", fileURLToPath(new URL("test-term-login.mjs", import.meta.url))]],

--- a/sdk/tests/test-sdk.mjs
+++ b/sdk/tests/test-sdk.mjs
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-const scripts = ["test-term.mjs", "test-core.mjs", "test-core-cancel.mjs"];
+const scripts = ["test-term.mjs", "test-core.mjs", "test-core-cancel.mjs", "test-core-home-unavailable.mjs"];
 for (const script of scripts) {
   const path = fileURLToPath(new URL(script, import.meta.url));
   const result = spawnSync(process.execPath, ["--experimental-wasm-jspi", path], {

--- a/src/builtins/context.zig
+++ b/src/builtins/context.zig
@@ -3,6 +3,7 @@ const background_runtime = @import("../core/background/background_runtime.zig");
 const change_tracker = @import("../core/workspace/change_tracker.zig");
 const debug_trace = @import("../core/shared/debug_trace.zig");
 const host = @import("../core/hosts/host.zig");
+const host_target = @import("../core/hosts/target.zig");
 const io_mod = @import("../core/shared/io.zig");
 const model_context_encoding = @import("../core/shared/model_context_encoding.zig");
 const pathing = @import("../core/workspace/pathing.zig");
@@ -180,6 +181,7 @@ const SelectionOptions = struct {
     initial_omission_summary: ?context_contract.ContextOmissionSummary = null,
     home: ?[]const u8 = null,
     initial: bool,
+    load_project_instruction_files: bool = true,
     context_limits: context_limits.Values = .{},
 };
 
@@ -242,6 +244,10 @@ const SelectionScratch = struct {
     }
 };
 
+fn loadsProjectInstructionFiles() bool {
+    return !host_target.is_wasm;
+}
+
 fn gatherProjectContext(alloc: Allocator, input: InitialContextInput) context_contract.ProviderError!ProviderContext {
     return gatherProjectContextWithHome(alloc, input, io_mod.getenv("HOME"));
 }
@@ -258,6 +264,7 @@ fn gatherProjectContextWithHome(
         .initial_omission_summary = input.omission_summary,
         .home = home,
         .initial = true,
+        .load_project_instruction_files = loadsProjectInstructionFiles(),
         .context_limits = input.context_limits,
     });
 }
@@ -269,6 +276,7 @@ fn selectApplicableProjectContext(alloc: Allocator, input: LaterContextInput) co
         .delivered_sources = input.delivered_sources,
         .evaluated_endpoints = input.evaluated_endpoints,
         .initial = false,
+        .load_project_instruction_files = loadsProjectInstructionFiles(),
         .context_limits = input.context_limits,
     });
 }
@@ -291,40 +299,44 @@ fn selectProjectContext(alloc: Allocator, options: SelectionOptions) context_con
     if (options.initial) {
         try scratch.addEvaluated(options.workspace_root);
         try scratch.addRankingEndpoint(options.workspace_root);
-
-        if (options.home) |home| {
-            const canonical_home: ?[]u8 = io_mod.realpathAlloc(arena, home) catch |err| blk: {
-                if (err == error.OutOfMemory) return error.OutOfMemory;
-                try scratch.addOmission(home, .home_unavailable);
-                break :blk null;
-            };
-            if (canonical_home) |home_root| {
-                global_source_path = try std.fs.path.join(arena, &.{ home_root, ".fx", "AGENTS.md" });
-                global_rule = try loadRuleForSelection(arena, &scratch, global_source_path.?, options.context_limits.project_instruction_file_bytes);
-                if (pathing.pathInside(home_root, options.workspace_root)) {
-                    try collectLaunchAncestorCandidates(arena, &scratch, home_root, options.workspace_root, options.delivered_sources);
-                } else {
-                    try scratch.addOmission(options.workspace_root, .home_outside_workspace);
-                }
-            }
-        } else {
-            try scratch.addOmission("HOME", .home_unavailable);
-        }
-
-        if (std.fs.path.isAbsolute(options.workspace_root)) {
-            const project_source = try std.fs.path.join(arena, &.{ options.workspace_root, "AGENTS.md" });
-            if (global_source_path == null or
-                !std.mem.eql(u8, global_source_path.?, project_source))
-            {
-                project_rule = try loadRuleForSelection(arena, &scratch, project_source, options.context_limits.project_instruction_file_bytes);
-            }
-        } else {
-            try scratch.addOmission(options.workspace_root, .unsafe_target);
-        }
     }
 
-    for (options.targets) |target| {
-        try collectTargetCandidates(arena, &scratch, options, target);
+    if (options.load_project_instruction_files) {
+        if (options.initial) {
+            if (options.home) |home| {
+                const canonical_home: ?[]u8 = io_mod.realpathAlloc(arena, home) catch |err| blk: {
+                    if (err == error.OutOfMemory) return error.OutOfMemory;
+                    try scratch.addOmission(home, .home_unavailable);
+                    break :blk null;
+                };
+                if (canonical_home) |home_root| {
+                    global_source_path = try std.fs.path.join(arena, &.{ home_root, ".fx", "AGENTS.md" });
+                    global_rule = try loadRuleForSelection(arena, &scratch, global_source_path.?, options.context_limits.project_instruction_file_bytes);
+                    if (pathing.pathInside(home_root, options.workspace_root)) {
+                        try collectLaunchAncestorCandidates(arena, &scratch, home_root, options.workspace_root, options.delivered_sources);
+                    } else {
+                        try scratch.addOmission(options.workspace_root, .home_outside_workspace);
+                    }
+                }
+            } else {
+                try scratch.addOmission("HOME", .home_unavailable);
+            }
+
+            if (std.fs.path.isAbsolute(options.workspace_root)) {
+                const project_source = try std.fs.path.join(arena, &.{ options.workspace_root, "AGENTS.md" });
+                if (global_source_path == null or
+                    !std.mem.eql(u8, global_source_path.?, project_source))
+                {
+                    project_rule = try loadRuleForSelection(arena, &scratch, project_source, options.context_limits.project_instruction_file_bytes);
+                }
+            } else {
+                try scratch.addOmission(options.workspace_root, .unsafe_target);
+            }
+        }
+
+        for (options.targets) |target| {
+            try collectTargetCandidates(arena, &scratch, options, target);
+        }
     }
 
     var usable: std.ArrayList(*RuleCandidate) = .empty;
@@ -1632,6 +1644,36 @@ test "later added-root targets are evaluated without loading added instructions"
     try std.testing.expectEqual(@as(usize, 0), context.notices.len);
     try std.testing.expect(std.mem.find(u8, context.modelVisibleBytes(), "ADDED_ROOT_SENTINEL") == null);
     try std.testing.expect(std.mem.find(u8, context.modelVisibleBytes(), "target outside workspace") == null);
+}
+
+test "native hosts still load project instruction files" {
+    try std.testing.expect(loadsProjectInstructionFiles());
+}
+
+test "hosts without instruction files keep client omissions and skip home probes" {
+    const alloc = std.testing.allocator;
+    var context = try selectProjectContext(alloc, .{
+        .workspace_root = "/repo",
+        .targets = &.{},
+        .initial_omissions = &.{.{
+            .source = "https://example.test/context.txt",
+            .reason = .unsafe_target,
+        }},
+        .home = "/repo",
+        .initial = true,
+        .load_project_instruction_files = false,
+    });
+    defer context.deinit(alloc);
+
+    try std.testing.expect(std.mem.find(u8, context.modelVisibleBytes(), "reason=\"home unavailable\"") == null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        context.modelVisibleBytes(),
+        "<project-rules-omitted from=\"https://example.test/context.txt\" reason=\"unsafe target\" />",
+    ) != null);
+    try std.testing.expectEqual(@as(usize, 1), context.notices.len);
+    try std.testing.expect(std.mem.find(u8, context.notices[0], "home unavailable") == null);
+    try std.testing.expect(std.mem.find(u8, context.notices[0], "unsafe target") != null);
 }
 
 test "HOME availability failures and non-ancestor diagnostics stay explicit" {


### PR DESCRIPTION
Supersedes #161. Maintainers cannot rewrite the contributor fork’s commit history, so this PR carries the same implementation as one clean commit. Efe Baran Durmaz remains the commit author.

Fixes #134

## Summary

- Published `libfx@0.0.3` already reaches the model; the reported turn abort was not reproduced.
- Browser/WASM hosts have no readable WASI filesystem, so `AGENTS.md` and `$HOME` disk probes are skipped there.
- Host-supplied context omissions remain preserved.
- Native project-instruction loading is unchanged.

## Verification

- `zig fmt --check src/builtins/context.zig`
- `zig build -Dwasm-surface=core`
- Core HOME-unavailable SDK regression under Node 24
- Standard core SDK stream test under Node 24
- `zig build test`
