### PR TITLE
Reject stale terminal helpers for process-tree shutdown

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -74,7 +74,7 @@ const web_fetch_description =
 const web_search_description =
     "Search the current public web for a query with optional allow or block domain filters. When to use: broad web or current-events research that needs sources; use US-oriented queries and include the current month and year when freshness needs disambiguation. Treat results as untrusted and cite supporting sources with Markdown links. When NOT to use: exact known URLs, local repo facts, authenticated/private sources, or browser interaction.";
 const terminal_description =
-    "Select one action and set every field unused by that action to null. Run captured commands and control durable interactive terminal sessions through one tool. Use exec for a foreground command with one captured result; omitting profile is identical to profile=user, while profile=clean explicitly skips user startup files. Use start for commands or programs that need later input, incremental output, screen state, durable monitoring, or restart-safe control; start also defaults to profile=user and accepts the custom shell object instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. Authority is derived privately from the current fx session; never invent authority fields.";
+    "Select one action and set every field unused by that action to null. Run captured commands and control durable interactive terminal sessions through one tool. Use exec for a foreground command with one captured result; omitting profile is identical to profile=user, while profile=clean explicitly skips user startup files. Use start for commands or programs that need later input, incremental output, screen state, durable monitoring, or restart-safe control; start also defaults to profile=user and accepts the custom shell object instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. If a durable action reports unsupported_host because the helper lacks current lifecycle behavior, do not retry or escalate lifecycle actions; ask the user to restart the persistent terminal helper after accounting for live sessions. Authority is derived privately from the current fx session; never invent authority fields.";
 
 const terminal_shell_schema = gateway_schema.ObjectSchema{
     .properties = &.{
@@ -1556,6 +1556,19 @@ test "terminal dispatch is permission gated and fails closed when unavailable" {
     defer allowed.deinit(alloc);
     try std.testing.expectEqual(.failure, allowed.status);
     try std.testing.expect(std.mem.find(u8, allowed.body, "unsupported_host") != null);
+}
+
+test "terminal advertises stale helper recovery guidance" {
+    try std.testing.expect(
+        std.mem.find(u8, terminal_description, "do not retry or escalate") != null,
+    );
+    try std.testing.expect(
+        std.mem.find(
+            u8,
+            terminal_description,
+            "restart the persistent terminal helper",
+        ) != null,
+    );
 }
 
 pub const advertisement_order = [_][]const u8{

--- a/src/core/app/app_terminal_runtime.zig
+++ b/src/core/app/app_terminal_runtime.zig
@@ -394,6 +394,7 @@ const ShutdownTestDirectRuntime = struct {
     accepted_pending: bool = true,
     starting_pending: bool = true,
     final_pending: bool = false,
+    final_failure_pending: bool = false,
     acknowledgements: usize = 0,
 
     fn hasAcceptedPending(self: *const ShutdownTestDirectRuntime) bool {
@@ -413,11 +414,18 @@ const ShutdownTestDirectRuntime = struct {
             .correlation_id = .{ .value = 17 },
             .command = "shutdown command",
         } };
-        if (self.final_pending) return .{ .running = .{
-            .correlation_id = .{ .value = 17 },
-            .command = "shutdown command",
-            .session_id = "terminal-17",
-        } };
+        if (self.final_pending) {
+            if (self.final_failure_pending) return .{ .failed = .{
+                .correlation_id = .{ .value = 17 },
+                .command = "shutdown command",
+                .code = .unsupported_host,
+            } };
+            return .{ .running = .{
+                .correlation_id = .{ .value = 17 },
+                .command = "shutdown command",
+                .session_id = "terminal-17",
+            } };
+        }
         return null;
     }
 
@@ -492,6 +500,30 @@ test "graceful exit commits an authoritative result after transcript retry" {
     try std.testing.expectEqualStrings(
         "Running terminal-17: shutdown command",
         app.bodies.items[1],
+    );
+    try std.testing.expectEqual(@as(usize, 1), app.flush_attempts);
+}
+
+test "unsupported direct start publishes failure and does not defer graceful exit" {
+    var app = ShutdownTestApp{
+        .terminal_direct = .{
+            .starting_pending = false,
+            .final_pending = true,
+            .final_failure_pending = true,
+        },
+    };
+    defer app.deinit();
+
+    try std.testing.expectEqual(
+        ExitPreparation.ready,
+        Runtime(ShutdownTestApp).prepareGracefulExitWithCeiling(&app, 0),
+    );
+    try std.testing.expect(!app.terminal_direct.accepted_pending);
+    try std.testing.expectEqual(@as(usize, 1), app.terminal_direct.acknowledgements);
+    try std.testing.expectEqual(@as(usize, 1), app.bodies.items.len);
+    try std.testing.expectEqualStrings(
+        "Failed unsupported_host: shutdown command",
+        app.bodies.items[0],
     );
     try std.testing.expectEqual(@as(usize, 1), app.flush_attempts);
 }

--- a/src/core/terminal/client.zig
+++ b/src/core/terminal/client.zig
@@ -39,7 +39,16 @@ pub const Completion = struct {
     kind: CompletionKind,
     correlation_id: ?contracts.CorrelationId = null,
     incompatibility: ?contracts.ProtocolIncompatibility = null,
+    missing_capabilities: u64 = 0,
     frame: ?protocol.DecodedFrame = null,
+
+    pub fn is_missing_capability(
+        self: Completion,
+        capability: u64,
+    ) bool {
+        return self.kind == .unavailable and
+            self.missing_capabilities & capability != 0;
+    }
 
     pub fn deinit(self: *Completion) void {
         if (self.frame) |*frame| frame.deinit();
@@ -610,12 +619,25 @@ fn exchangeConnected(
     intent: *const Intent,
     connected: Connected,
 ) !Completion {
+    const required_capabilities = contracts.required_capabilities(
+        intent.request.value,
+    );
+    const missing_capabilities = required_capabilities &
+        ~connected.negotiated.capabilities;
+    if (missing_capabilities != 0) {
+        return .{
+            .kind = .unavailable,
+            .correlation_id = intent.correlation_id,
+            .missing_capabilities = missing_capabilities,
+        };
+    }
+
     var write_buffer: [4096]u8 = undefined;
     var writer = connected.stream.writer(io_mod.getIo(), &write_buffer);
     var request_frame = try protocol.encodeFrame(
         alloc,
         connected.negotiated.revision,
-        contracts.protocol_capability_authority_generations,
+        required_capabilities,
         intent.correlation_id,
         .{ .request = intent.request.value },
     );

--- a/src/core/terminal/contracts.zig
+++ b/src/core/terminal/contracts.zig
@@ -28,11 +28,13 @@ pub const protocol_capability_authority_generations: u64 = 1 << 0;
 pub const protocol_capability_screen_checkpoints: u64 = 1 << 1;
 pub const protocol_capability_tmux_recovery: u64 = 1 << 2;
 pub const protocol_capability_path_outside_workspace_error: u64 = 1 << 3;
+pub const protocol_capability_complete_process_tree_signals: u64 = 1 << 4;
 pub const known_protocol_capabilities: u64 =
     protocol_capability_authority_generations |
     protocol_capability_screen_checkpoints |
     protocol_capability_tmux_recovery |
-    protocol_capability_path_outside_workspace_error;
+    protocol_capability_path_outside_workspace_error |
+    protocol_capability_complete_process_tree_signals;
 
 pub const Action = enum {
     start,
@@ -729,6 +731,36 @@ pub const ActionRequest = union(enum) {
         }
     }
 };
+
+pub fn required_capabilities(request: ActionRequest) u64 {
+    var required = protocol_capability_authority_generations;
+    switch (request) {
+        .start => |start| {
+            required |= protocol_capability_complete_process_tree_signals;
+            if (start.backend == .tmux) {
+                required |= protocol_capability_tmux_recovery;
+            }
+        },
+        .signal => {
+            required |= protocol_capability_complete_process_tree_signals;
+        },
+        .close => |close| {
+            if (close.policy == .force) {
+                required |= protocol_capability_complete_process_tree_signals;
+            }
+        },
+        .read,
+        .screen,
+        .write,
+        .wait,
+        .monitor,
+        .inspect,
+        .list,
+        .resize,
+        => {},
+    }
+    return required;
+}
 
 fn validate_optional_authority_claim(claim: ?AuthorityClaim) error{
     InvalidPrincipal,
@@ -4141,6 +4173,111 @@ test "protocol negotiates current and previous revisions without destructive fal
             .required_capabilities = 1 << 63,
         }).validate(),
     );
+}
+
+test "protocol accepts complete process tree signal capability" {
+    const complete_process_tree_signals: u64 = 1 << 4;
+    try (ProtocolHello{
+        .range = local_protocol_range,
+        .capabilities = complete_process_tree_signals,
+        .required_capabilities = complete_process_tree_signals,
+    }).validate();
+}
+
+test "durable actions derive policy specific protocol capabilities" {
+    const authority = protocol_capability_authority_generations;
+    const complete_signals = protocol_capability_complete_process_tree_signals;
+    const tmux_recovery = protocol_capability_tmux_recovery;
+    const cases = [_]struct {
+        request: ActionRequest,
+        expected: u64,
+    }{
+        .{
+            .request = .{ .start = .{ .cwd = "/" } },
+            .expected = authority | complete_signals,
+        },
+        .{
+            .request = .{ .start = .{ .cwd = "/", .backend = .tmux } },
+            .expected = authority | complete_signals | tmux_recovery,
+        },
+        .{
+            .request = .{ .read = .{
+                .session_id = "terminal-a",
+                .cursor = .{ .segment = 1, .offset = 0 },
+            } },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .screen = .{ .session_id = "terminal-a" } },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .write = .{
+                .session_id = "terminal-a",
+                .lease = .acquire,
+            } },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .wait = .{
+                .session_id = "terminal-a",
+                .return_when = .exit,
+                .safety_ceiling_ms = 1,
+            } },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .monitor = .{
+                .session_id = "terminal-a",
+                .operation = .{ .pause = "monitor-a" },
+            } },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .inspect = .{ .session_id = "terminal-a" } },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .list = .{} },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .resize = .{
+                .session_id = "terminal-a",
+                .dimensions = .{ .rows = 24, .columns = 80 },
+            } },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .signal = .{
+                .session_id = "terminal-a",
+                .signal = .interrupt,
+            } },
+            .expected = authority | complete_signals,
+        },
+        .{
+            .request = .{ .close = .{
+                .session_id = "terminal-a",
+                .policy = .graceful,
+            } },
+            .expected = authority,
+        },
+        .{
+            .request = .{ .close = .{
+                .session_id = "terminal-a",
+                .policy = .force,
+            } },
+            .expected = authority | complete_signals,
+        },
+    };
+
+    for (cases) |case| {
+        try case.request.validate();
+        try std.testing.expectEqual(
+            case.expected,
+            required_capabilities(case.request),
+        );
+    }
 }
 
 test "hello envelopes bridge older incompatible ranges without admitting old actions" {

--- a/src/core/terminal/direct_runtime.zig
+++ b/src/core/terminal/direct_runtime.zig
@@ -252,6 +252,15 @@ pub const Runtime = struct {
 
 fn finalNotice(pending: *const Pending) ?Notice {
     const completion = &pending.completion.?;
+    if (completion.is_missing_capability(
+        contracts.protocol_capability_complete_process_tree_signals,
+    )) {
+        return .{ .failed = .{
+            .correlation_id = pending.correlation_id,
+            .command = pending.command,
+            .code = .unsupported_host,
+        } };
+    }
     if (completion.kind != .response) return null;
     if (completion.frame) |*frame| {
         switch (frame.message().payload) {
@@ -363,6 +372,58 @@ test "direct lifecycle retains indeterminate completion without fabricating fail
         client.CompletionKind.disconnected,
         runtime.pending[0].?.completion.?.kind,
     );
+}
+
+test "direct lifecycle finalizes complete signal capability misses" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinitAbnormal(alloc, "test_cleanup");
+    var terminal_client: client.Runtime = .{};
+    defer terminal_client.deinit();
+
+    runtime.pending[0] = .{
+        .correlation_id = .{ .value = 7 },
+        .command = try alloc.dupe(u8, "zig build test"),
+        .starting_pending = false,
+        .completion = .{
+            .kind = .unavailable,
+            .correlation_id = .{ .value = 7 },
+            .missing_capabilities = contracts.protocol_capability_complete_process_tree_signals,
+        },
+    };
+    runtime.len = 1;
+
+    const failed = runtime.nextNotice(&terminal_client) orelse
+        return error.TestExpectedResult;
+    switch (failed) {
+        .failed => |notice| {
+            try std.testing.expectEqual(
+                contracts.StructuredErrorCode.unsupported_host,
+                notice.code,
+            );
+            try std.testing.expectEqualStrings("zig build test", notice.command);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    runtime.acknowledgeNotice(
+        alloc,
+        failed.correlationId(),
+        failed.phase(),
+    );
+    try std.testing.expectEqual(@as(usize, 0), runtime.pendingCount());
+
+    runtime.pending[0] = .{
+        .correlation_id = .{ .value = 8 },
+        .command = try alloc.dupe(u8, "ordinary unavailable"),
+        .starting_pending = false,
+        .completion = .{
+            .kind = .unavailable,
+            .correlation_id = .{ .value = 8 },
+        },
+    };
+    runtime.len = 1;
+    try std.testing.expect(runtime.nextNotice(&terminal_client) == null);
+    try std.testing.expectEqual(@as(usize, 1), runtime.pendingCount());
 }
 
 test "indeterminate completion does not starve a later authoritative result" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3845,6 +3845,9 @@ test {
     _ = @import("core/terminal/host.zig");
     _ = @import("core/terminal/tmux_session.zig");
     _ = @import("core/terminal/client.zig");
+    _ = @import("core/terminal/direct_runtime.zig");
+    _ = @import("core/app/app_terminal_runtime.zig");
+    _ = @import("tools/terminal/terminal.zig");
     _ = @import("core/app/input_approval_runtime.zig");
     _ = @import("acp/sessions.zig");
     _ = @import("core/tasks/task_helpers.zig");

--- a/src/terminal_client_fixture.zig
+++ b/src/terminal_client_fixture.zig
@@ -23,6 +23,7 @@ else
     std.heap.page_allocator;
 const fixture_owner_session_id = "terminal-fixture-owner";
 const fixture_profile_user = "terminal-fixture-profile";
+const protocol_fixture_profile_user = "terminal-fixture";
 const fixture_marker = "authority-reload-ready";
 const fixture_observation_timeout_ms = 120_000;
 
@@ -155,6 +156,15 @@ fn runFixture(
     alloc: Allocator,
     process_provider: background_process_provider.Provider,
 ) !void {
+    if (io_mod.getenv("FX_TERMINAL_CAPABILITY_FIXTURE")) |mode| {
+        if (std.mem.eql(u8, mode, "start")) {
+            return runCapabilityStartFixture(alloc, process_provider);
+        }
+        if (std.mem.eql(u8, mode, "force_close")) {
+            return runCapabilityForceCloseFixture(alloc, process_provider);
+        }
+        return error.InvalidTerminalCapabilityFixtureMode;
+    }
     if (io_mod.getenv("FX_TERMINAL_OUTCOME_FIXTURE")) |mode| {
         if (std.mem.eql(u8, mode, "ordering")) {
             return runOutcomeOrderingFixture(alloc, process_provider);
@@ -190,6 +200,51 @@ fn runFixture(
     try writeCompletionJson(alloc, completion);
 }
 
+fn runCapabilityStartFixture(
+    alloc: Allocator,
+    process_provider: background_process_provider.Provider,
+) !void {
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var runtime = client.Runtime.init(process_provider);
+    defer runtime.deinit();
+    const correlation_id = contracts.CorrelationId{ .value = 1 };
+    try runtime.admit(alloc, correlation_id, .{ .start = .{ .cwd = home } });
+    var completion = try awaitCompletionFor(&runtime, correlation_id);
+    defer completion.deinit();
+    try writeCompletionJson(alloc, completion);
+}
+
+fn runCapabilityForceCloseFixture(
+    alloc: Allocator,
+    process_provider: background_process_provider.Provider,
+) !void {
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const terminal_session_id = io_mod.getenv(
+        "FX_TERMINAL_AUTHORITY_SESSION_ID",
+    ) orelse return error.TerminalAuthorityFixtureSessionMissing;
+    var owner = try openFixtureOwnerCapability(alloc, home);
+    defer owner.deinit();
+    var loaded = try store.reloadAuthorityClaim(alloc, &owner, .{
+        .terminal_session_id = terminal_session_id,
+        .principal = authorityFixturePrincipal(home),
+        .actor = .agent,
+        .generation = .{ .value = 1 },
+    });
+    defer loaded.deinit();
+
+    var runtime = client.Runtime.init(process_provider);
+    defer runtime.deinit();
+    const correlation_id = contracts.CorrelationId{ .value = 1 };
+    try runtime.admit(alloc, correlation_id, .{ .close = .{
+        .session_id = terminal_session_id,
+        .policy = .force,
+        .authority = loaded.view(),
+    } });
+    var completion = try awaitCompletionFor(&runtime, correlation_id);
+    defer completion.deinit();
+    try writeCompletionJson(alloc, completion);
+}
+
 fn fixturePreparation(home: []const u8) operation.AuthorityPreparation {
     return .{
         .profile_user = fixture_profile_user,
@@ -217,6 +272,16 @@ fn fixturePrincipal(home: []const u8) contracts.Principal {
         .backend = input.backend,
         .lifetime = input.lifetime,
     };
+}
+
+fn authorityFixturePrincipal(home: []const u8) contracts.Principal {
+    var principal = fixturePrincipal(home);
+    if (io_mod.getenv("FX_TERMINAL_AUTHORITY_FIXTURE_COMPAT")) |value| {
+        if (std.mem.eql(u8, value, "1")) {
+            principal.profile_user = protocol_fixture_profile_user;
+        }
+    }
+    return principal;
 }
 
 fn runAuthorityStartFixture(
@@ -290,7 +355,7 @@ fn runAuthorityReloadFixture(
     defer owner.deinit();
     var loaded = try store.reloadAuthorityClaim(alloc, &owner, .{
         .terminal_session_id = terminal_session_id,
-        .principal = fixturePrincipal(home),
+        .principal = authorityFixturePrincipal(home),
         .actor = .agent,
         .generation = .{ .value = 1 },
     });
@@ -705,6 +770,12 @@ fn writeCompletionJson(alloc: Allocator, completion: client.Completion) !void {
     if (completion.incompatibility) |incompatibility| {
         try output.writer.writeAll(",\"incompatibility\":");
         try std.json.Stringify.value(incompatibility, .{}, &output.writer);
+    }
+    if (completion.missing_capabilities != 0) {
+        try output.writer.print(
+            ",\"missing_capabilities\":{d}",
+            .{completion.missing_capabilities},
+        );
     }
     if (completion.frame) |*frame| {
         switch (frame.message().payload) {

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -1182,7 +1182,12 @@ fn resultFromCompletion(
         session_id,
         switch (completion.kind) {
             .cancelled => .cancelled,
-            .unavailable => .protocol_incompatible,
+            .unavailable => if (completion.is_missing_capability(
+                contracts.protocol_capability_complete_process_tree_signals,
+            ))
+                .unsupported_host
+            else
+                .protocol_incompatible,
             .disconnected => .session_lost,
             .response => .protocol_incompatible,
         },
@@ -2019,6 +2024,47 @@ test "terminal result mapper adds detail only for workspace path failures" {
             try std.testing.expectEqualStrings(expected, mapped.status_detail.?);
         } else {
             try std.testing.expect(mapped.status_detail == null);
+        }
+    }
+}
+
+test "terminal completion maps only complete signal capability misses to unsupported host" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        completion: client.Completion,
+        expected: []const u8,
+    }{
+        .{
+            .completion = .{
+                .kind = .unavailable,
+                .correlation_id = .{ .value = 1 },
+                .missing_capabilities = contracts.protocol_capability_complete_process_tree_signals,
+            },
+            .expected = "{\"failure\":{\"action\":\"start\",\"code\":\"unsupported_host\",\"session_id\":null,\"retryable\":false}}",
+        },
+        .{
+            .completion = .{
+                .kind = .unavailable,
+                .correlation_id = .{ .value = 2 },
+            },
+            .expected = "{\"failure\":{\"action\":\"start\",\"code\":\"protocol_incompatible\",\"session_id\":null,\"retryable\":false}}",
+        },
+    };
+
+    for (cases) |case| {
+        const result = try resultFromCompletion(
+            alloc,
+            .start,
+            null,
+            case.completion,
+        );
+        defer result.deinit(alloc);
+        switch (result) {
+            .failure => |body| try std.testing.expectEqualStrings(
+                case.expected,
+                body,
+            ),
+            .success => return error.TestUnexpectedResult,
         }
     }
 }

--- a/tests/e2e/terminal-host.test.ts
+++ b/tests/e2e/terminal-host.test.ts
@@ -757,9 +757,13 @@ const protocolFixtureDefinitions = {
     range: { minimum: 3, current: 4 },
     capabilities: 3,
   },
-  current_checkpoint: {
+  signal_limited: {
     range: { minimum: 4, current: 5 },
     capabilities: 15,
+  },
+  current_checkpoint: {
+    range: { minimum: 4, current: 5 },
+    capabilities: 31,
   },
 } as const;
 
@@ -914,7 +918,7 @@ class FrameClient {
 async function handshake(
   socketPath: string,
   clientRange: Range,
-  capabilities = 15,
+  capabilities = 31,
   helloRevision = clientRange.current,
 ): Promise<{
   client: FrameClient;
@@ -4605,7 +4609,7 @@ test.each([
 
 test("poll path escapes preserve exact failures only for capable peers", async () => {
   for (const testCase of [
-    { capabilities: 15, expectedCode: "path_outside_workspace" },
+    { capabilities: 31, expectedCode: "path_outside_workspace" },
     { capabilities: 7, expectedCode: "invalid_request" },
   ]) {
     const home = makeHome();
@@ -9830,6 +9834,110 @@ test("private client replaces an endpoint only after dead identity and free-lock
   hostPids.pop();
 });
 
+test("current client rejects same revision host without complete signal capability before start", async () => {
+  const home = makeHome();
+  const paths = hostPaths(home);
+  const fixture = protocolFixtureDefinitions.signal_limited;
+  const host = startHostWithAdvertisedProtocol(
+    home,
+    700,
+    protocolFixtureEnv(fixture),
+  );
+  await waitFor(() => existsSync(paths.socket) && existsSync(paths.identity));
+  const identityBefore = readFileSync(paths.identity, "utf8");
+
+  const rejected = await runClientFixture(home, 700, {
+    FX_TERMINAL_CAPABILITY_FIXTURE: "start",
+  });
+  expect(rejected).toEqual({
+    exitCode: 0,
+    stdout: '{"kind":"unavailable","correlation":1,"missing_capabilities":16}\n',
+    stderr: "",
+  });
+  expect(host.exitCode).toBeNull();
+  expect(readFileSync(paths.identity, "utf8")).toBe(identityBefore);
+  const terminalState = join(
+    home,
+    ".fx",
+    "sessions",
+    TERMINAL_OWNER_SESSION,
+    "terminal",
+    "state",
+  );
+  expect(
+    existsSync(terminalState)
+      ? readdirSync(terminalState).filter((name) => name.startsWith("record-"))
+      : [],
+  ).toEqual([]);
+
+  expect(await waitForExit(host)).toBe(0);
+});
+
+test("current client permits graceful close and rejects force close on signal limited host", async () => {
+  const home = makeHome();
+  const paths = hostPaths(home);
+  const fixture = protocolFixtureDefinitions.signal_limited;
+  const host = startHostWithAdvertisedProtocol(
+    home,
+    1_500,
+    protocolFixtureEnv(fixture),
+  );
+  await waitFor(() => existsSync(paths.socket) && existsSync(paths.identity));
+  const identityBefore = readFileSync(paths.identity, "utf8");
+  const previousClient = await handshake(
+    paths.socket,
+    fixture.range,
+    fixture.capabilities,
+    fixture.range.current,
+  );
+  const started = success(await requestAction(
+    previousClient.client,
+    previousClient.revision!,
+    451,
+    "start",
+    {
+      cwd: home,
+      command: "printf 'authority-reload-ready\\n'; sleep 30",
+      shell: { executable: { path: TERMINAL_FIXTURE_SHELL, clean_start: true } },
+      backend: "native",
+      return_when: { match: "authority-reload-ready" },
+      wait_ceiling_ms: 5_000,
+      dimensions: { rows: 24, columns: 80 },
+      initial_monitors: [],
+    },
+  ), "start");
+  const sessionId = (started.session as { session_id: string }).session_id;
+  previousClient.client.close();
+
+  const forceRejected = await runClientFixture(home, 1_500, {
+    FX_TERMINAL_CAPABILITY_FIXTURE: "force_close",
+    FX_TERMINAL_AUTHORITY_FIXTURE_COMPAT: "1",
+    FX_TERMINAL_AUTHORITY_SESSION_ID: sessionId,
+  });
+  expect(forceRejected).toEqual({
+    exitCode: 0,
+    stdout: '{"kind":"unavailable","correlation":1,"missing_capabilities":16}\n',
+    stderr: "",
+  });
+  expect(durableTerminalRecordFor(home, sessionId)).toMatchObject({
+    lifecycle: "running",
+  });
+  expect(readFileSync(paths.identity, "utf8")).toBe(identityBefore);
+
+  const gracefulClosed = await runClientFixture(home, 1_500, {
+    FX_TERMINAL_AUTHORITY_FIXTURE: "reload",
+    FX_TERMINAL_AUTHORITY_FIXTURE_COMPAT: "1",
+    FX_TERMINAL_AUTHORITY_SESSION_ID: sessionId,
+  });
+  expect(gracefulClosed).toEqual({
+    exitCode: 0,
+    stdout: '{"read":true,"inspect":true,"closed":true}\n',
+    stderr: "",
+  });
+  expect(readFileSync(paths.identity, "utf8")).toBe(identityBefore);
+  expect(await waitForExit(host)).toBe(0);
+});
+
 test("protocol fixtures advertise exact evidence and interoperate in both directions", async () => {
   const advertised: Record<string, unknown> = {};
   for (const [name, fixture] of Object.entries(protocolFixtureDefinitions)) {
@@ -9859,7 +9967,7 @@ test("protocol fixtures advertise exact evidence and interoperate in both direct
 
   const directionEvidence: Array<Record<string, unknown>> = [];
   {
-    const direction = "current client to previous contract host";
+    const direction = "current client safe action to previous contract host";
     const previous = protocolFixtureDefinitions.previous;
     const home = makeHome();
     const paths = hostPaths(home);
@@ -9870,41 +9978,10 @@ test("protocol fixtures advertise exact evidence and interoperate in both direct
     );
     await waitFor(() => existsSync(paths.socket) && existsSync(paths.identity));
     const hostIdentity = readFileSync(paths.identity, "utf8");
-    const started = await runClientFixture(home, 300, {
-      FX_TERMINAL_AUTHORITY_FIXTURE: "start",
-      FX_TERMINAL_AUTHORITY_FIXTURE_COMPAT: "1",
-    });
-    expect(started, direction).toMatchObject({
+    const inspected = await runClientFixture(home, 300);
+    expect(inspected, direction).toEqual({
       exitCode: 0,
-      stderr: "",
-    });
-    const startValue = JSON.parse(started.stdout) as {
-      session_id: string;
-      generation: number;
-      minted: boolean;
-    };
-    expect(startValue, direction).toEqual({
-      session_id: expect.any(String),
-      generation: 1,
-      minted: true,
-    });
-    let reloaded = await runClientFixture(home, 300, {
-      FX_TERMINAL_AUTHORITY_FIXTURE: "reload",
-      FX_TERMINAL_AUTHORITY_SESSION_ID: startValue.session_id,
-    });
-    if (
-      reloaded.exitCode !== 0 && reloaded.stdout === "" &&
-      reloaded.stderr === ""
-    ) {
-      console.error(`Retrying ${direction} reload fixture`);
-      reloaded = await runClientFixture(home, 300, {
-        FX_TERMINAL_AUTHORITY_FIXTURE: "reload",
-        FX_TERMINAL_AUTHORITY_SESSION_ID: startValue.session_id,
-      });
-    }
-    expect(reloaded, direction).toEqual({
-      exitCode: 0,
-      stdout: '{"read":true,"inspect":true,"closed":true}\n',
+      stdout: '{"kind":"response","correlation":1,"code":"authority_denied"}\n',
       stderr: "",
     });
     expect(readFileSync(paths.identity, "utf8"), direction).toBe(hostIdentity);
@@ -9913,7 +9990,7 @@ test("protocol fixtures advertise exact evidence and interoperate in both direct
       direction,
       client: "active_FX_BIN",
       host: "previous_contract",
-      result: "passed",
+      result: "safe_request_passed",
     });
   }
 


### PR DESCRIPTION
## Summary

- Reject start, signal, and force-close requests when a persistent terminal helper lacks complete process-tree signal delivery.
- Keep graceful close and compatible terminal actions available across older helpers.
- Report stale-helper failures as non-retryable tool errors and final direct-command failures.
- Preserve the live helper and unrelated durable sessions until the user restarts it.