### PR TITLE
Limit no-save terminal calls to exec

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const std_builtin = @import("builtin");
 const builtin_gateway = @import("gateway.zig");
 const terminal_contracts = @import("../core/terminal/contracts.zig");
 const terminal_monitor = @import("../core/terminal/monitor.zig");
@@ -36,6 +37,14 @@ const install_skill_impl = @import("../tools/skills/install_skill.zig");
 const skill_impl = @import("../tools/skills/skill.zig");
 const web_fetch_impl = @import("../tools/web/fetch.zig");
 const web_search_impl = @import("../tools/web/search.zig");
+const test_io_mod = if (std_builtin.is_test)
+    @import("../core/shared/io.zig")
+else
+    struct {};
+const test_session_child_store = if (std_builtin.is_test)
+    @import("../core/session/session_child_store.zig")
+else
+    struct {};
 
 const Allocator = std.mem.Allocator;
 
@@ -75,6 +84,14 @@ const web_search_description =
     "Search the current public web for a query with optional allow or block domain filters. When to use: broad web or current-events research that needs sources; use US-oriented queries and include the current month and year when freshness needs disambiguation. Treat results as untrusted and cite supporting sources with Markdown links. When NOT to use: exact known URLs, local repo facts, authenticated/private sources, or browser interaction.";
 const terminal_description =
     "Select one action and set every field unused by that action to null. Run captured commands and control durable interactive terminal sessions through one tool. Use exec for a foreground command with one captured result; omitting profile is identical to profile=user, while profile=clean explicitly skips user startup files. Use start for commands or programs that need later input, incremental output, screen state, durable monitoring, or restart-safe control; start also defaults to profile=user and accepts the custom shell object instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. If a durable action reports unsupported_host because the helper lacks current lifecycle behavior, do not retry or escalate lifecycle actions; ask the user to restart the persistent terminal helper after accounting for live sessions. Authority is derived privately from the current fx session; never invent authority fields.";
+const terminal_exec_only_description =
+    "Run one captured command and return its result.";
+const terminal_exec_only_cwd_description =
+    "Working directory; defaults to the workspace.";
+const terminal_exec_only_command_description =
+    "Command to run.";
+const terminal_exec_only_profile_description =
+    "Profile for exec; omission defaults to user, while clean skips user initialization files. User execution supports the configured Bash or zsh login shell. Bash login execution reads login initialization files; .bashrc is available only when sourced by the login profile.";
 
 const terminal_shell_schema = gateway_schema.ObjectSchema{
     .properties = &.{
@@ -238,6 +255,50 @@ const terminal_gateway_properties = [_]gateway_schema.Property{.{
 const terminal_gateway_required = blk: {
     var names: [terminal_gateway_properties.len][]const u8 = undefined;
     for (terminal_gateway_properties, 0..) |property, index| names[index] = property.name;
+    break :blk names;
+};
+
+fn terminalPropertyNamed(comptime name: []const u8) gateway_schema.Property {
+    inline for (terminal_properties) |property| {
+        if (std.mem.eql(u8, property.name, name)) return property;
+    }
+    @compileError("terminal exec field is missing shared property metadata: " ++ name);
+}
+
+fn terminalExecOnlyProperty(comptime name: []const u8) gateway_schema.Property {
+    var property = terminalPropertyNamed(name);
+    property.description = if (std.mem.eql(u8, name, "cwd"))
+        terminal_exec_only_cwd_description
+    else if (std.mem.eql(u8, name, "command"))
+        terminal_exec_only_command_description
+    else if (std.mem.eql(u8, name, "profile"))
+        terminal_exec_only_profile_description
+    else
+        @compileError("terminal exec field is missing focused model guidance: " ++ name);
+    return terminalNullableProperty(property);
+}
+
+const terminal_exec_only_actions = [_][]const u8{"exec"};
+const terminal_exec_contract = terminal_impl.actionFieldContract(.exec);
+const terminal_exec_only_gateway_properties = blk: {
+    var properties: [terminal_exec_contract.allowed.len]gateway_schema.Property = undefined;
+    for (terminal_exec_contract.allowed, 0..) |field_name, index| {
+        properties[index] = if (std.mem.eql(u8, field_name, "action"))
+            .{
+                .name = "action",
+                .json_type = .string,
+                .shape = &.{ .enum_values = &terminal_exec_only_actions },
+            }
+        else
+            terminalExecOnlyProperty(field_name);
+    }
+    break :blk properties;
+};
+const terminal_exec_only_gateway_required = blk: {
+    var names: [terminal_exec_only_gateway_properties.len][]const u8 = undefined;
+    for (terminal_exec_only_gateway_properties, 0..) |property, index| {
+        names[index] = property.name;
+    }
     break :blk names;
 };
 const skill_description =
@@ -926,6 +987,25 @@ pub const terminal = ToolSpec{
     .irreversible_fn = terminal_impl.isIrreversible,
 };
 
+const terminal_exec_only = blk: {
+    var spec = terminal;
+    spec.description = terminal_exec_only_description;
+    spec.gateway_schema = .{
+        .name = "terminal",
+        .description = terminal_exec_only_description,
+        .input_schema = .{
+            .properties = &terminal_exec_only_gateway_properties,
+            .required = &terminal_exec_only_gateway_required,
+            .additional_properties = false,
+        },
+    };
+    break :blk spec;
+};
+
+pub fn terminalExecOnlySpec() ToolSpec {
+    return terminal_exec_only;
+}
+
 pub const skill = ToolSpec{
     .name = "skill",
     .description = skill_description,
@@ -1401,6 +1481,39 @@ test "terminal tool schema exposes one nullable object backed by the terminal ac
     );
 }
 
+test "terminal exec-only schema reuses exec structure with focused descriptions" {
+    const spec = terminalExecOnlySpec();
+    const input_schema = spec.gateway_schema.input_schema;
+    try std.testing.expectEqualStrings(
+        terminal_exec_only_description,
+        spec.description,
+    );
+    try std.testing.expectEqual(
+        terminal_exec_contract.allowed.len,
+        input_schema.properties.len,
+    );
+    for (terminal_exec_contract.allowed, input_schema.properties) |field_name, property| {
+        try std.testing.expectEqualStrings(field_name, property.name);
+    }
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &terminal_exec_only_actions,
+        schemaEnumValues(schemaProperty(input_schema, "action").?),
+    );
+    try std.testing.expectEqualStrings(
+        terminal_exec_only_command_description,
+        schemaProperty(input_schema, "command").?.description,
+    );
+    try std.testing.expectEqualStrings(
+        terminal_exec_only_cwd_description,
+        schemaProperty(input_schema, "cwd").?.description,
+    );
+    try std.testing.expectEqualStrings(
+        terminal_exec_only_profile_description,
+        schemaProperty(input_schema, "profile").?.description,
+    );
+}
+
 test "terminal gateway advertisement projects a provider-compatible object schema" {
     const alloc = std.testing.allocator;
     var projection = try tool_advertisement.buildGatewayToolProjectionForSet(
@@ -1478,6 +1591,29 @@ fn denyTerminalTool(
 
 test "terminal dispatch is permission gated and fails closed when unavailable" {
     const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        test_io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(test_io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(test_io_mod.getIo());
+    const session_path = try test_io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(session_path);
+    var capability = try test_session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        session_path,
+        .read_only,
+        .{},
+    );
+    defer capability.deinit();
+
     const call = types.ToolCall{
         .id = "terminal-test",
         .name = "terminal",
@@ -1497,10 +1633,92 @@ test "terminal dispatch is permission gated and fails closed when unavailable" {
         .terminal = .supported,
     };
 
+    const exec_available = try tool_dispatch.localToolAvailabilityFailureForCall(
+        .{
+            .allocator = alloc,
+            .workspace_root = "/tmp",
+            .tool_capabilities = capabilities,
+        },
+        registry,
+        .{
+            .id = "terminal-exec-no-capability",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"printf ok\"}",
+        },
+    );
+    try std.testing.expect(exec_available == null);
+
+    const missing_capability = try tool_dispatch.dispatchToolCall(
+        .{
+            .allocator = alloc,
+            .workspace_root = "/tmp",
+            .permission_decider = allowTerminalTool,
+            .tool_capabilities = capabilities,
+        },
+        registry,
+        .{
+            .id = "terminal-start-no-capability",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"start\",\"command\":\"printf nope\"}",
+        },
+    );
+    defer missing_capability.deinit(alloc);
+    try std.testing.expectEqual(.failure, missing_capability.status);
+    var parsed_missing_capability = try std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        missing_capability.body,
+        .{},
+    );
+    defer parsed_missing_capability.deinit();
+    const missing_error = parsed_missing_capability.value.object.get("error").?.object;
+    try std.testing.expectEqualStrings("tool_execution_failed", missing_error.get("type").?.string);
+    try std.testing.expectEqualStrings("terminal", missing_error.get("tool_name").?.string);
+    try std.testing.expectEqualStrings(
+        "Durable terminal actions require a saved fx session.",
+        missing_error.get("message").?.string,
+    );
+    try std.testing.expectEqualStrings(
+        "Use terminal.exec, or rerun without --no-save.",
+        missing_error.get("suggestion").?.string,
+    );
+
+    const start_available = try tool_dispatch.localToolAvailabilityFailureForCall(
+        .{
+            .allocator = alloc,
+            .workspace_root = "/tmp",
+            .tool_capabilities = capabilities,
+            .session_child_capability = &capability,
+        },
+        registry,
+        .{
+            .id = "terminal-start-with-capability",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"start\",\"command\":\"printf ok\"}",
+        },
+    );
+    try std.testing.expect(start_available == null);
+
+    const unsupported_start = try tool_dispatch.localToolAvailabilityFailureForCall(
+        .{ .allocator = alloc, .workspace_root = "/tmp" },
+        registry,
+        .{
+            .id = "terminal-start-unsupported",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"start\",\"command\":\"printf nope\"}",
+        },
+    );
+    defer alloc.free(unsupported_start.?);
+    try std.testing.expectEqualStrings(
+        tool_dispatch.terminal_unavailable_message,
+        unsupported_start.?,
+    );
+
     const ordinary_inspect = try tool_dispatch.dispatchToolCall(
         .{
             .allocator = alloc,
             .tool_capabilities = capabilities,
+            .session_child_capability = &capability,
         },
         registry,
         .{
@@ -1517,6 +1735,7 @@ test "terminal dispatch is permission gated and fails closed when unavailable" {
         .{
             .allocator = alloc,
             .tool_capabilities = capabilities,
+            .session_child_capability = &capability,
         },
         registry,
         .{
@@ -1535,6 +1754,7 @@ test "terminal dispatch is permission gated and fails closed when unavailable" {
             .allocator = alloc,
             .permission_decider = denyTerminalTool,
             .tool_capabilities = capabilities,
+            .session_child_capability = &capability,
         },
         registry,
         call,
@@ -1549,6 +1769,7 @@ test "terminal dispatch is permission gated and fails closed when unavailable" {
             .allocator = alloc,
             .permission_decider = allowTerminalTool,
             .tool_capabilities = capabilities,
+            .session_child_capability = &capability,
         },
         registry,
         call,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -63,7 +63,7 @@ const test_builtin_gateway = if (std_builtin.is_test)
     @import("../../builtins/gateway.zig")
 else
     struct {};
-const test_builtin_tools = @import("../../builtins/tools.zig");
+const builtin_tools = @import("../../builtins/tools.zig");
 const tool_advertisement = @import("../tooling/tool_advertisement.zig");
 const tool_admission = @import("../tooling/tool_admission.zig");
 const tool_args = @import("../tooling/tool_args.zig");
@@ -436,6 +436,56 @@ const RunOptions = struct {
     continue_recovery: bool = false,
     deps: RunDeps,
 };
+
+fn buildAskGatewayToolProjection(
+    alloc: Allocator,
+    registry: mode_registry.Registry,
+    tool_set: tool_set_contract.ToolSet,
+    mode_id: []const u8,
+    options: tool_advertisement.Options,
+    has_child_capability: bool,
+) !tool_advertisement.EffectiveToolProjection {
+    if (has_child_capability) {
+        return registry.buildGatewayToolProjection(
+            alloc,
+            tool_set,
+            mode_id,
+            options,
+        );
+    }
+
+    const terminal_index = for (tool_set.registry.tools, 0..) |tool, index| {
+        if (tool.executor_kind == .terminal and
+            std.mem.eql(u8, tool.name, "terminal"))
+        {
+            break index;
+        }
+    } else {
+        return registry.buildGatewayToolProjection(
+            alloc,
+            tool_set,
+            mode_id,
+            options,
+        );
+    };
+
+    const projected_tools = try alloc.dupe(
+        tool_dispatch.Tool,
+        tool_set.registry.tools,
+    );
+    defer alloc.free(projected_tools);
+    projected_tools[terminal_index] = builtin_tools.terminalExecOnlySpec();
+    return registry.buildGatewayToolProjection(
+        alloc,
+        .{
+            .registry = .{ .tools = projected_tools },
+            .order = tool_set.order,
+            .read_only_tool_names = tool_set.read_only_tool_names,
+        },
+        mode_id,
+        options,
+    );
+}
 
 const StdinSource = union(enum) {
     real,
@@ -1504,12 +1554,16 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
             return error.McpRequiredServerUnavailable;
         }
     }
-    var tool_projection = try ctx.cfg.mode_registry.buildGatewayToolProjection(alloc, options.deps.tool_set, ctx.mode_id, .{
+    const session_child_capability = if (ctx.writable) |*writable|
+        writable.childCapability() catch null
+    else
+        null;
+    var tool_projection = try buildAskGatewayToolProjection(alloc, ctx.cfg.mode_registry, options.deps.tool_set, ctx.mode_id, .{
         .permission_mode = ctx.permission_mode,
         .permission_rules = ctx.permission_rules,
         .mcp_runtime = ctx.mcp,
         .subagent_available = ctx.subagent_host != null,
-    });
+    }, session_child_capability != null);
     defer tool_projection.deinit(alloc);
 
     const skills_view = skill_runtime.Runtime{
@@ -1603,10 +1657,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         else
             false,
         .context_limits = ctx.context_limits,
-        .session_child_capability = if (ctx.writable) |*writable|
-            writable.childCapability() catch null
-        else
-            null,
+        .session_child_capability = session_child_capability,
     }, job) catch |err| switch (err) {
         error.NonInteractivePermissionRequired => {
             const assistant_output = try alloc.dupe(u8, ctx.assistant_output.items);
@@ -3841,18 +3892,30 @@ fn testProcessQueuedPromptChecksTimeout(deps: *const agent_runtime.AgentRuntimeD
     try testPushAssistantText(deps, "assistant text");
 }
 
-fn testProcessQueuedPromptChecksRealTools(deps: *const agent_runtime.AgentRuntimeDeps, semantic_presentation: ?agent_runtime.SemanticPresentationSink, _: agent_runtime.LifecycleContext, cfg: agent_runtime.Config, _: worker_runtime.QueuedPrompt) !void {
+fn testProcessQueuedPromptChecksExecOnlyTerminal(deps: *const agent_runtime.AgentRuntimeDeps, semantic_presentation: ?agent_runtime.SemanticPresentationSink, _: agent_runtime.LifecycleContext, cfg: agent_runtime.Config, _: worker_runtime.QueuedPrompt) !void {
     try std.testing.expect(semantic_presentation == null);
+    try std.testing.expect(cfg.session_child_capability == null);
     const ctx: *AskContext = @ptrCast(@alignCast(deps.ctx));
     try std.testing.expectEqualStrings("inspect", ctx.mode_id);
-    try std.testing.expect(!std.mem.eql(u8, cfg.gateway_tools_json, "[]"));
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "\"name\":\"read_file\"") != null);
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "\"name\":\"terminal\"") != null);
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "\"name\":\"run_command\"") == null);
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "\"name\":\"web_search\"") == null);
     try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "gateway.perplexity_search") != null);
-    try std.testing.expectEqualStrings(test_builtin_tools.web_search.description, cfg.custom_tool_guidance);
+    try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "Run one captured command and return its result.") != null);
+    try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "Use start for commands") == null);
+    try std.testing.expectEqualStrings(builtin_tools.web_search.description, cfg.custom_tool_guidance);
     try std.testing.expectEqualStrings("test model overlay", cfg.model_prompt_overlay.?);
+    const runtime_terminal = deps.tool_registry.lookup("terminal") orelse
+        return error.TestExpectedEqual;
+    try std.testing.expect(std.mem.find(u8, runtime_terminal.description, "Use start") != null);
+    try testPushAssistantText(deps, "assistant text");
+}
+
+fn testProcessQueuedPromptChecksFullTerminal(deps: *const agent_runtime.AgentRuntimeDeps, semantic_presentation: ?agent_runtime.SemanticPresentationSink, _: agent_runtime.LifecycleContext, cfg: agent_runtime.Config, _: worker_runtime.QueuedPrompt) !void {
+    try std.testing.expect(semantic_presentation == null);
+    try std.testing.expect(cfg.session_child_capability != null);
+    try std.testing.expect(std.mem.find(u8, cfg.gateway_tools_json, "Use start for commands") != null);
     try testPushAssistantText(deps, "assistant text");
 }
 
@@ -4247,7 +4310,7 @@ fn testPromptRunDeps(stdout_capture: *TestCapture, stderr_capture: *TestCapture,
         .initialize_session_stores = testSkipSessionStores,
         .load_skills = testLoadNoSkills,
         .context_registry = test_no_context_registry,
-        .tool_set = test_builtin_tools.advertisement_set,
+        .tool_set = builtin_tools.advertisement_set,
         .load_mcp_runtime = testNoMcpRuntime,
         .process_queued_prompt = testProcessQueuedPrompt,
     };
@@ -4335,18 +4398,18 @@ test "CLI lifecycle action preserves dynamic MCP availability boundaries" {
     const advertised = [_][]const u8{"mcp_lookup"};
     var fixture = Fixture{};
 
-    const missing = dynamicMcpToolAvailable(test_builtin_tools.registry, "mcp_lookup", &advertised, @ptrCast(&fixture), Fixture.hasTool, .unrestricted);
+    const missing = dynamicMcpToolAvailable(builtin_tools.registry, "mcp_lookup", &advertised, @ptrCast(&fixture), Fixture.hasTool, .unrestricted);
     try std.testing.expect(!missing);
     try std.testing.expectEqual(@as(usize, 1), fixture.calls);
     const missing_label = try tool_presentation.formatPlainAction(alloc, .{
-        .tool_registry = test_builtin_tools.registry,
+        .tool_registry = builtin_tools.registry,
         .call = .{ .id = "missing", .name = "mcp_lookup", .arguments_json = "{}" },
         .is_available_dynamic_mcp_tool = missing,
     });
     defer alloc.free(missing_label);
     try std.testing.expectEqualStrings("Working: mcp_lookup", missing_label);
 
-    const builtin = dynamicMcpToolAvailable(test_builtin_tools.registry, "terminal", &.{"terminal"}, @ptrCast(&fixture), Fixture.hasTool, .unrestricted);
+    const builtin = dynamicMcpToolAvailable(builtin_tools.registry, "terminal", &.{"terminal"}, @ptrCast(&fixture), Fixture.hasTool, .unrestricted);
     try std.testing.expect(!builtin);
     try std.testing.expectEqual(@as(usize, 1), fixture.calls);
 }
@@ -6590,7 +6653,7 @@ test "CLI ask auto mode requires review when only one copy or rename target is c
     }
 }
 
-test "runWithDeps builds real gateway tools after startup" {
+test "runWithDeps projects exec-only terminal when saved setup has no capability" {
     const alloc = std.testing.allocator;
     var stdout_capture: TestCapture = .{};
     defer stdout_capture.deinit(alloc);
@@ -6601,7 +6664,7 @@ test "runWithDeps builds real gateway tools after startup" {
         alloc,
         &.{"hello"},
         testConfig(),
-        testPromptRunDepsWithProcess(&stdout_capture, &stderr_capture, testProcessQueuedPromptChecksRealTools),
+        testPromptRunDepsWithProcess(&stdout_capture, &stderr_capture, testProcessQueuedPromptChecksExecOnlyTerminal),
     );
 
     try std.testing.expectEqual(@as(u8, 0), exit_code);
@@ -6610,7 +6673,7 @@ test "runWithDeps builds real gateway tools after startup" {
 
 test "runWithDeps uses the supplied tool set for advertisement and runtime" {
     const alloc = std.testing.allocator;
-    const tools = [_]tool_dispatch.Tool{test_builtin_tools.read_file};
+    const tools = [_]tool_dispatch.Tool{builtin_tools.read_file};
     const names = [_][]const u8{"read_file"};
     const tool_set: tool_set_contract.ToolSet = .{
         .registry = .{ .tools = tools[0..] },
@@ -6673,7 +6736,7 @@ test "runWithDeps honors no-save by skipping ask session stores" {
     defer stderr_capture.deinit(alloc);
 
     test_initialize_session_store_calls = 0;
-    var deps = testPromptRunDepsWithProcess(&stdout_capture, &stderr_capture, testProcessQueuedPrompt);
+    var deps = testPromptRunDepsWithProcess(&stdout_capture, &stderr_capture, testProcessQueuedPromptChecksExecOnlyTerminal);
     deps.initialize_session_stores = testCountSessionStores;
 
     const exit_code = try runWithDeps(
@@ -6685,6 +6748,52 @@ test "runWithDeps honors no-save by skipping ask session stores" {
 
     try std.testing.expectEqual(@as(u8, 0), exit_code);
     try std.testing.expectEqual(@as(usize, 0), test_initialize_session_store_calls);
+}
+
+test "runWithDeps retains full terminal projection with saved capability" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home");
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    const test_home = try TestAskHome.install(alloc, home);
+    defer test_home.deinit();
+
+    var stdout_capture: TestCapture = .{};
+    defer stdout_capture.deinit(alloc);
+    var stderr_capture: TestCapture = .{};
+    defer stderr_capture.deinit(alloc);
+    var deps = testPromptRunDeps(
+        &stdout_capture,
+        &stderr_capture,
+        testPresentKeySavedStartup,
+    );
+    deps.initialize_session_stores = initializeSessionStoresDefault;
+    deps.process_queued_prompt = testProcessQueuedPromptChecksFullTerminal;
+
+    const exit_code = try runWithDeps(alloc, &.{"hello"}, testConfig(), deps);
+
+    try std.testing.expectEqual(@as(u8, 0), exit_code);
+    try std.testing.expectEqualStrings("assistant text", stdout_capture.bytes.items);
+}
+
+test "exec-only terminal projection propagates view allocation failure" {
+    var failing = std.testing.FailingAllocator.init(
+        std.testing.allocator,
+        .{ .fail_index = 0 },
+    );
+    try std.testing.expectError(
+        error.OutOfMemory,
+        buildAskGatewayToolProjection(
+            failing.allocator(),
+            test_mode_registry,
+            builtin_tools.advertisement_set,
+            "inspect",
+            .{},
+            false,
+        ),
+    );
 }
 
 const TestAskHome = struct {
@@ -8265,7 +8374,7 @@ test "fx ask JSON permission-denied capture is best effort under allocation fail
         testConfig(),
         .{
             .context_registry = test_no_context_registry,
-            .tool_set = test_builtin_tools.advertisement_set,
+            .tool_set = builtin_tools.advertisement_set,
             .load_mcp_runtime = testNoMcpRuntime,
         },
         "/tmp/workspace",
@@ -8447,7 +8556,7 @@ test "fx ask JSON captures parallel tool results without corrupting records" {
 fn checkAskJsonCaptureAllocationFailures(alloc: Allocator) !void {
     var ctx = AskContext.init(alloc, testConfig(), .{
         .context_registry = test_no_context_registry,
-        .tool_set = test_builtin_tools.advertisement_set,
+        .tool_set = builtin_tools.advertisement_set,
         .load_mcp_runtime = testNoMcpRuntime,
     }, "/tmp/workspace");
     defer ctx.deinit();
@@ -8534,7 +8643,7 @@ test "fx ask JSON clips ask_user_question text at a UTF-8 boundary" {
 
     var ctx = AskContext.init(alloc, testConfig(), .{
         .context_registry = test_no_context_registry,
-        .tool_set = test_builtin_tools.advertisement_set,
+        .tool_set = builtin_tools.advertisement_set,
         .load_mcp_runtime = testNoMcpRuntime,
     }, "/tmp/workspace");
     defer ctx.deinit();

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -52,6 +52,10 @@ pub const web_search_unavailable_message = "web_search is unavailable: no local 
 pub const web_fetch_unavailable_message = "web_fetch is unavailable: no local WebFetch runtime is installed";
 pub const terminal_unavailable_message =
     "{\"error\":{\"tool\":\"terminal\",\"code\":\"unsupported_host\",\"retryable\":false}}";
+const terminal_saved_session_required_message =
+    "Durable terminal actions require a saved fx session.";
+const terminal_saved_session_required_suggestion =
+    "Use terminal.exec, or rerun without --no-save.";
 
 pub const ToolCapabilities = struct {
     web_search_runtime_ready: bool = false,
@@ -937,10 +941,16 @@ pub fn localToolAvailabilityFailure(
             try ctx.allocator.dupe(u8, web_search_unavailable_message),
         .terminal => if (tool.captured_command_fn != null and tool.captured_command_fn.?(input))
             null
-        else if (ctx.tool_capabilities.terminalAvailable())
+        else if (!ctx.tool_capabilities.terminalAvailable())
+            try ctx.allocator.dupe(u8, terminal_unavailable_message)
+        else if (ctx.session_child_capability != null)
             null
         else
-            try ctx.allocator.dupe(u8, terminal_unavailable_message),
+            try tool_result_errors.toolExecutionFailureJson(ctx.allocator, .{
+                .tool_name = tool.name,
+                .message = terminal_saved_session_required_message,
+                .suggestion = terminal_saved_session_required_suggestion,
+            }),
         else => null,
     };
 }

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -179,7 +179,7 @@ describe("fx ask presentation", () => {
     expect(JSON.parse(result.stdout).output).toBe("Commands complete.\n");
   }, TIMEOUT);
 
-  test("fresh binary defaults terminal exec and start to the user profile", async () => {
+  test("no-save advertises exec only and preserves terminal exec profiles", async () => {
     const configuredShell = userInfo().shell;
     if (!configuredShell.endsWith("/bash") && !configuredShell.endsWith("/zsh")) return;
 
@@ -227,27 +227,17 @@ describe("fx ask presentation", () => {
         command: profileCommand,
         profile: "user",
       }),
-      fakeGatewayToolCall("terminal-start-omitted", "terminal", {
+      fakeGatewayToolCall("terminal-stale-start", "terminal", {
         action: "start",
-        command: profileCommand,
+        command: "printf should-not-start",
         return_when: { kind: "exit" },
         wait_ceiling_ms: 8_000,
       }),
-      fakeGatewayToolCall("terminal-start-clean", "terminal", {
-        action: "start",
-        command: profileCommand,
-        profile: "clean",
-        return_when: { kind: "exit" },
-        wait_ceiling_ms: 8_000,
+      fakeGatewayToolCall("terminal-neighbor-exec", "terminal", {
+        action: "exec",
+        command: "printf neighbor-exec",
       }),
-      fakeGatewayToolCall("terminal-start-user", "terminal", {
-        action: "start",
-        command: profileCommand,
-        profile: "user",
-        return_when: { kind: "exit" },
-        wait_ceiling_ms: 8_000,
-      }),
-      fakeGatewayFinalText("Terminal exec profiles verified.\n"),
+      fakeGatewayFinalText("Terminal no-save profiles verified.\n"),
     ]);
     gateways.push(gateway);
 
@@ -261,31 +251,81 @@ describe("fx ask presentation", () => {
     );
 
     expect(result.code).toBe(0);
-    expect(JSON.parse(result.stdout).output).toBe("Terminal exec profiles verified.\n");
-    expect(gateway.requests).toHaveLength(7);
-    expect(gateway.requests[0]!.body).toContain(
-      "omitting profile is identical to profile=user",
+    const output = JSON.parse(result.stdout) as {
+      output: string;
+      tool_calls: Array<{ name: string; status: string }>;
+    };
+    expect(output.output).toBe("Terminal no-save profiles verified.\n");
+    expect(output.tool_calls.map(({ name, status }) => ({ name, status }))).toEqual([
+      { name: "terminal", status: "success" },
+      { name: "terminal", status: "success" },
+      { name: "terminal", status: "success" },
+      { name: "terminal", status: "error" },
+      { name: "terminal", status: "success" },
+    ]);
+    expect(gateway.requests).toHaveLength(6);
+
+    const firstRequest = JSON.parse(gateway.requests[0]!.body) as {
+      tools: Array<{
+        name?: string;
+        description?: string;
+        inputSchema?: {
+          properties?: Record<string, {
+            enum?: string[];
+            description?: string;
+          }>;
+          required?: string[];
+          additionalProperties?: boolean;
+        };
+      }>;
+    };
+    const terminalTool = firstRequest.tools.find(({ name }) => name === "terminal");
+    expect(terminalTool?.description).toBe(
+      "Run one captured command and return its result.",
     );
-    expect(gateway.requests[0]!.body).toContain(
-      "omission defaults to user, while clean skips user startup files",
+    const terminalSchema = terminalTool?.inputSchema;
+    expect(terminalSchema?.properties?.action?.enum).toEqual(["exec"]);
+    expect(Object.keys(terminalSchema?.properties ?? {})).toEqual([
+      "action",
+      "command",
+      "cwd",
+      "profile",
+    ]);
+    expect(terminalSchema?.required).toEqual(["action", "command", "cwd", "profile"]);
+    expect(terminalSchema?.additionalProperties).toBe(false);
+    expect(terminalSchema?.properties?.command?.description).toBe(
+      "Command to run. Set null when the selected action does not use this field.",
     );
-    expect(gateway.requests[0]!.body).toContain(
-      "User-profile execution supports the configured Bash or zsh login shell",
+    expect(terminalSchema?.properties?.cwd?.description).toBe(
+      "Working directory; defaults to the workspace. Set null when the selected action does not use this field.",
     );
-    expect(gateway.requests[0]!.body).toContain(
-      ".bashrc is available only when sourced by the login profile",
+    expect(terminalSchema?.properties?.profile?.description).toBe(
+      "Profile for exec; omission defaults to user, while clean skips user initialization files. User execution supports the configured Bash or zsh login shell. Bash login execution reads login initialization files; .bashrc is available only when sourced by the login profile. Set null when the selected action does not use this field.",
     );
-    expect(gateway.requests[0]!.body).not.toContain(
-      "omission preserves legacy command behavior",
-    );
-    for (const requestIndex of [1, 3, 4, 6]) {
+    const serializedTerminalTool = JSON.stringify(terminalTool);
+    expect(serializedTerminalTool).not.toContain("Use start");
+    expect(serializedTerminalTool).not.toContain("Other actions");
+    expect(serializedTerminalTool).not.toContain("durable");
+
+    for (const requestIndex of [1, 3]) {
       expect(gateway.requests[requestIndex]!.body).toContain("mode=login:rc:path-user:");
       expect(gateway.requests[requestIndex]!.body).toContain("alias-user:function-user");
     }
-    for (const requestIndex of [2, 5]) {
-      expect(gateway.requests[requestIndex]!.body).toContain("mode=unset:unset:path-clean:");
-      expect(gateway.requests[requestIndex]!.body).toContain("no-alias:no-function");
-    }
+    expect(gateway.requests[2]!.body).toContain("mode=unset:unset:path-clean:");
+    expect(gateway.requests[2]!.body).toContain("no-alias:no-function");
+    expect(gateway.requests[4]!.body).toContain("tool_execution_failed");
+    expect(gateway.requests[4]!.body).toContain(
+      "Durable terminal actions require a saved fx session.",
+    );
+    expect(gateway.requests[4]!.body).toContain(
+      "Use terminal.exec, or rerun without --no-save.",
+    );
+    expect(gateway.requests[4]!.body).not.toContain("authority_denied");
+    expect(gateway.requests[4]!.body).not.toContain("tool_permission_denied");
+    expect(gateway.requests[5]!.body).toContain("neighbor-exec");
+    expect(
+      existsSync(join(root.home, ".fx", "terminal-host", "host.json")),
+    ).toBe(false);
   }, TIMEOUT);
 
   test.skipIf(!tmuxAvailable())(

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -703,7 +703,7 @@ describe("gateway stream lifecycle", () => {
     })).toEqual([]);
   });
 
-  test("ask sends status text normally with the full tool surface", async () => {
+  test("no-save ask sends status text with the exec-only terminal surface", async () => {
     const root = createFixtureRoot("status-text-ask");
     const tracePath = join(root.root, "trace.log");
     const gateway = startGateway(() => fakeGatewayFinalText("STATUS_TEXT_ASK_COMPLETE"));
@@ -738,8 +738,8 @@ describe("gateway stream lifecycle", () => {
       expect(request.prompt[0]?.role).toBe("system");
       expect(request.prompt[1]?.role).toBe("system");
       expect(contentText(request.prompt[1]?.content)).toBe(WEB_SEARCH_GUIDANCE);
-      expect(toolByName(oracleRequest, "terminal")?.description).toContain(
-        "Use exec for a foreground command",
+      expect(toolByName(oracleRequest, "terminal")?.description).toBe(
+        "Run one captured command and return its result.",
       );
       expect(toolByName(oracleRequest, "skill")?.description).toContain(
         "the task clearly matches one",


### PR DESCRIPTION
## Summary

- Advertise only `terminal.exec` when an ask lacks saved-session authority, while saved asks retain the full terminal surface.
- Reject stale durable terminal calls before permission with guidance to use `terminal.exec` or save the session.
- Remove durable-action instructions from the exec-only schema while preserving exec profile behavior.