### PR TITLE
Reduce macOS arm64 release binary size

### DIFF
--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -45,7 +45,7 @@ BENCHMARK_RELINK_USE_FLAGS = (
     "--disable-vp",
     "-pgo-kind=pgo-instr-use-pipeline",
     "-pgo-cold-func-opt=minsize",
-    "-profile-summary-cutoff-cold=995000",
+    "-profile-summary-cutoff-cold=996000",
     "-passes=default<O2>",
 )
 

--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -29,7 +29,15 @@ USE_FLAGS = (
     "--disable-vp",
     "-pgo-kind=pgo-instr-use-pipeline",
     "-pgo-cold-func-opt=minsize",
-    "-profile-summary-cutoff-cold=700000",
+    "-profile-summary-cutoff-cold=600000",
+    "-passes=default<O2>",
+)
+
+BENCHMARK_USE_FLAGS = (
+    "--disable-vp",
+    "-pgo-kind=pgo-instr-use-pipeline",
+    "-pgo-cold-func-opt=minsize",
+    "-profile-summary-cutoff-cold=990000",
     "-passes=default<O2>",
 )
 
@@ -304,9 +312,10 @@ def profile_use_argv(
     profile_path: pathlib.Path | None = None,
 ) -> tuple[str, ...]:
     profile = profile_path or paths.merged_profile
+    flags = USE_FLAGS if paths.selector == "fx" else BENCHMARK_USE_FLAGS
     return (
         str(toolchain.opt),
-        *USE_FLAGS,
+        *flags,
         f"-profile-file={profile}",
         str(paths.bitcode),
         "-o",

--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -41,14 +41,6 @@ BENCHMARK_USE_FLAGS = (
     "-passes=default<O2>",
 )
 
-BENCHMARK_RELINK_USE_FLAGS = (
-    "--disable-vp",
-    "-pgo-kind=pgo-instr-use-pipeline",
-    "-pgo-cold-func-opt=minsize",
-    "-profile-summary-cutoff-cold=996000",
-    "-passes=default<O2>",
-)
-
 CANDIDATE_SIGNING_PAGE_SIZE = 16 * 1024
 
 PROFILE_SECTION_ALIGNMENTS = (
@@ -318,16 +310,9 @@ def profile_use_argv(
     toolchain: Toolchain,
     paths: PipelinePaths,
     profile_path: pathlib.Path | None = None,
-    *,
-    benchmark_relink: bool = False,
 ) -> tuple[str, ...]:
     profile = profile_path or paths.merged_profile
-    if benchmark_relink:
-        if paths.selector == "fx":
-            raise PgsoError("benchmark relink requires a benchmark artifact")
-        flags = BENCHMARK_RELINK_USE_FLAGS
-    else:
-        flags = USE_FLAGS if paths.selector == "fx" else BENCHMARK_USE_FLAGS
+    flags = USE_FLAGS if paths.selector == "fx" else BENCHMARK_USE_FLAGS
     return (
         str(toolchain.opt),
         *flags,
@@ -727,18 +712,12 @@ def apply_profile(
     expected_bitcode_sha256: str,
     *,
     profile_path: pathlib.Path | None = None,
-    benchmark_relink: bool = False,
 ) -> pathlib.Path:
     validate_bitcode_hash(paths.bitcode, expected_bitcode_sha256)
     profile = profile_path or paths.merged_profile
     _require_nonempty_file(profile, "merged profile")
     run_checked(
-        profile_use_argv(
-            toolchain,
-            paths,
-            profile,
-            benchmark_relink=benchmark_relink,
-        ),
+        profile_use_argv(toolchain, paths, profile),
         cwd=paths.root,
         env=os.environ.copy(),
         timeout_s=900,

--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -29,7 +29,7 @@ USE_FLAGS = (
     "--disable-vp",
     "-pgo-kind=pgo-instr-use-pipeline",
     "-pgo-cold-func-opt=minsize",
-    "-profile-summary-cutoff-cold=990000",
+    "-profile-summary-cutoff-cold=700000",
     "-passes=default<O2>",
 )
 

--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -41,6 +41,14 @@ BENCHMARK_USE_FLAGS = (
     "-passes=default<O2>",
 )
 
+BENCHMARK_RELINK_USE_FLAGS = (
+    "--disable-vp",
+    "-pgo-kind=pgo-instr-use-pipeline",
+    "-pgo-cold-func-opt=minsize",
+    "-profile-summary-cutoff-cold=995000",
+    "-passes=default<O2>",
+)
+
 CANDIDATE_SIGNING_PAGE_SIZE = 16 * 1024
 
 PROFILE_SECTION_ALIGNMENTS = (
@@ -310,9 +318,16 @@ def profile_use_argv(
     toolchain: Toolchain,
     paths: PipelinePaths,
     profile_path: pathlib.Path | None = None,
+    *,
+    benchmark_relink: bool = False,
 ) -> tuple[str, ...]:
     profile = profile_path or paths.merged_profile
-    flags = USE_FLAGS if paths.selector == "fx" else BENCHMARK_USE_FLAGS
+    if benchmark_relink:
+        if paths.selector == "fx":
+            raise PgsoError("benchmark relink requires a benchmark artifact")
+        flags = BENCHMARK_RELINK_USE_FLAGS
+    else:
+        flags = USE_FLAGS if paths.selector == "fx" else BENCHMARK_USE_FLAGS
     return (
         str(toolchain.opt),
         *flags,
@@ -712,12 +727,18 @@ def apply_profile(
     expected_bitcode_sha256: str,
     *,
     profile_path: pathlib.Path | None = None,
+    benchmark_relink: bool = False,
 ) -> pathlib.Path:
     validate_bitcode_hash(paths.bitcode, expected_bitcode_sha256)
     profile = profile_path or paths.merged_profile
     _require_nonempty_file(profile, "merged profile")
     run_checked(
-        profile_use_argv(toolchain, paths, profile),
+        profile_use_argv(
+            toolchain,
+            paths,
+            profile,
+            benchmark_relink=benchmark_relink,
+        ),
         cwd=paths.root,
         env=os.environ.copy(),
         timeout_s=900,

--- a/scripts/pgso/profile_supplement.py
+++ b/scripts/pgso/profile_supplement.py
@@ -14,8 +14,8 @@ from scripts.pgso.runner import run_checked
 from scripts.pgso.toolchain import Toolchain
 
 
-PROFILE_SUMMARY_CUTOFF_COLD = 990_000
-SUPPLEMENT_COLD_THRESHOLD_MULTIPLIER = 8
+PROFILE_SUMMARY_CUTOFF_COLD = 600_000
+SUPPLEMENT_COLD_THRESHOLD_MULTIPLIER = 2
 
 
 @dataclasses.dataclass(frozen=True)

--- a/scripts/pgso/profile_supplement.py
+++ b/scripts/pgso/profile_supplement.py
@@ -15,7 +15,7 @@ from scripts.pgso.toolchain import Toolchain
 
 
 PROFILE_SUMMARY_CUTOFF_COLD = 990_000
-SUPPLEMENT_COLD_THRESHOLD_MULTIPLIER = 9
+SUPPLEMENT_COLD_THRESHOLD_MULTIPLIER = 8
 
 
 @dataclasses.dataclass(frozen=True)

--- a/scripts/pgso/profile_supplement.py
+++ b/scripts/pgso/profile_supplement.py
@@ -15,7 +15,7 @@ from scripts.pgso.toolchain import Toolchain
 
 
 PROFILE_SUMMARY_CUTOFF_COLD = 990_000
-SUPPLEMENT_COLD_THRESHOLD_MULTIPLIER = 8
+SUPPLEMENT_COLD_THRESHOLD_MULTIPLIER = 9
 
 
 @dataclasses.dataclass(frozen=True)

--- a/scripts/pgso/qualify.py
+++ b/scripts/pgso/qualify.py
@@ -760,6 +760,7 @@ def relink_profile_linked_benchmarks(
             pair_paths,
             pair.bitcode_sha256,
             profile_path=mapped_profile_path,
+            benchmark_relink=True,
         )
         candidate = link_candidate(
             toolchain,

--- a/scripts/pgso/qualify.py
+++ b/scripts/pgso/qualify.py
@@ -760,7 +760,6 @@ def relink_profile_linked_benchmarks(
             pair_paths,
             pair.bitcode_sha256,
             profile_path=mapped_profile_path,
-            benchmark_relink=True,
         )
         candidate = link_candidate(
             toolchain,

--- a/scripts/pgso/tests/test_pipeline.py
+++ b/scripts/pgso/tests/test_pipeline.py
@@ -8,7 +8,6 @@ import unittest
 
 from scripts.pgso.model import PgsoError, sha256_file
 from scripts.pgso.pipeline import (
-    BENCHMARK_RELINK_USE_FLAGS,
     BENCHMARK_USE_FLAGS,
     GENERATION_FLAGS,
     PROFILE_SECTION_ALIGNMENTS,
@@ -122,16 +121,6 @@ class PgsoPipelineTests(unittest.TestCase):
         )
         self.assertEqual(
             (
-                "--disable-vp",
-                "-pgo-kind=pgo-instr-use-pipeline",
-                "-pgo-cold-func-opt=minsize",
-                "-profile-summary-cutoff-cold=996000",
-                "-passes=default<O2>",
-            ),
-            BENCHMARK_RELINK_USE_FLAGS,
-        )
-        self.assertEqual(
-            (
                 str(self.toolchain.opt),
                 *GENERATION_FLAGS,
                 f"-profile-file={self.paths.raw_profile_pattern}",
@@ -167,30 +156,6 @@ class PgsoPipelineTests(unittest.TestCase):
             ),
             profile_use_argv(self.toolchain, benchmark_paths),
         )
-        self.assertEqual(
-            (
-                str(self.toolchain.opt),
-                *BENCHMARK_RELINK_USE_FLAGS,
-                f"-profile-file={benchmark_paths.merged_profile}",
-                str(benchmark_paths.bitcode),
-                "-o",
-                str(benchmark_paths.profile_use_bitcode),
-            ),
-            profile_use_argv(
-                self.toolchain,
-                benchmark_paths,
-                benchmark_relink=True,
-            ),
-        )
-        with self.assertRaisesRegex(
-            PgsoError,
-            "benchmark relink requires a benchmark artifact",
-        ):
-            profile_use_argv(
-                self.toolchain,
-                self.paths,
-                benchmark_relink=True,
-            )
         mapped_profile = self.paths.profiles / "production.profdata"
         self.assertEqual(
             f"-profile-file={mapped_profile}",

--- a/scripts/pgso/tests/test_pipeline.py
+++ b/scripts/pgso/tests/test_pipeline.py
@@ -8,6 +8,7 @@ import unittest
 
 from scripts.pgso.model import PgsoError, sha256_file
 from scripts.pgso.pipeline import (
+    BENCHMARK_RELINK_USE_FLAGS,
     BENCHMARK_USE_FLAGS,
     GENERATION_FLAGS,
     PROFILE_SECTION_ALIGNMENTS,
@@ -121,6 +122,16 @@ class PgsoPipelineTests(unittest.TestCase):
         )
         self.assertEqual(
             (
+                "--disable-vp",
+                "-pgo-kind=pgo-instr-use-pipeline",
+                "-pgo-cold-func-opt=minsize",
+                "-profile-summary-cutoff-cold=995000",
+                "-passes=default<O2>",
+            ),
+            BENCHMARK_RELINK_USE_FLAGS,
+        )
+        self.assertEqual(
+            (
                 str(self.toolchain.opt),
                 *GENERATION_FLAGS,
                 f"-profile-file={self.paths.raw_profile_pattern}",
@@ -156,6 +167,30 @@ class PgsoPipelineTests(unittest.TestCase):
             ),
             profile_use_argv(self.toolchain, benchmark_paths),
         )
+        self.assertEqual(
+            (
+                str(self.toolchain.opt),
+                *BENCHMARK_RELINK_USE_FLAGS,
+                f"-profile-file={benchmark_paths.merged_profile}",
+                str(benchmark_paths.bitcode),
+                "-o",
+                str(benchmark_paths.profile_use_bitcode),
+            ),
+            profile_use_argv(
+                self.toolchain,
+                benchmark_paths,
+                benchmark_relink=True,
+            ),
+        )
+        with self.assertRaisesRegex(
+            PgsoError,
+            "benchmark relink requires a benchmark artifact",
+        ):
+            profile_use_argv(
+                self.toolchain,
+                self.paths,
+                benchmark_relink=True,
+            )
         mapped_profile = self.paths.profiles / "production.profdata"
         self.assertEqual(
             f"-profile-file={mapped_profile}",

--- a/scripts/pgso/tests/test_pipeline.py
+++ b/scripts/pgso/tests/test_pipeline.py
@@ -103,7 +103,7 @@ class PgsoPipelineTests(unittest.TestCase):
                 "--disable-vp",
                 "-pgo-kind=pgo-instr-use-pipeline",
                 "-pgo-cold-func-opt=minsize",
-                "-profile-summary-cutoff-cold=990000",
+                "-profile-summary-cutoff-cold=700000",
                 "-passes=default<O2>",
             ),
             USE_FLAGS,

--- a/scripts/pgso/tests/test_pipeline.py
+++ b/scripts/pgso/tests/test_pipeline.py
@@ -8,6 +8,7 @@ import unittest
 
 from scripts.pgso.model import PgsoError, sha256_file
 from scripts.pgso.pipeline import (
+    BENCHMARK_USE_FLAGS,
     GENERATION_FLAGS,
     PROFILE_SECTION_ALIGNMENTS,
     USE_FLAGS,
@@ -103,10 +104,20 @@ class PgsoPipelineTests(unittest.TestCase):
                 "--disable-vp",
                 "-pgo-kind=pgo-instr-use-pipeline",
                 "-pgo-cold-func-opt=minsize",
-                "-profile-summary-cutoff-cold=700000",
+                "-profile-summary-cutoff-cold=600000",
                 "-passes=default<O2>",
             ),
             USE_FLAGS,
+        )
+        self.assertEqual(
+            (
+                "--disable-vp",
+                "-pgo-kind=pgo-instr-use-pipeline",
+                "-pgo-cold-func-opt=minsize",
+                "-profile-summary-cutoff-cold=990000",
+                "-passes=default<O2>",
+            ),
+            BENCHMARK_USE_FLAGS,
         )
         self.assertEqual(
             (
@@ -129,6 +140,21 @@ class PgsoPipelineTests(unittest.TestCase):
                 str(self.paths.profile_use_bitcode),
             ),
             profile_use_argv(self.toolchain, self.paths),
+        )
+        benchmark_paths = PipelinePaths.create(
+            self.root / "benchmark-run",
+            selector="ui_activity",
+        )
+        self.assertEqual(
+            (
+                str(self.toolchain.opt),
+                *BENCHMARK_USE_FLAGS,
+                f"-profile-file={benchmark_paths.merged_profile}",
+                str(benchmark_paths.bitcode),
+                "-o",
+                str(benchmark_paths.profile_use_bitcode),
+            ),
+            profile_use_argv(self.toolchain, benchmark_paths),
         )
         mapped_profile = self.paths.profiles / "production.profdata"
         self.assertEqual(

--- a/scripts/pgso/tests/test_pipeline.py
+++ b/scripts/pgso/tests/test_pipeline.py
@@ -125,7 +125,7 @@ class PgsoPipelineTests(unittest.TestCase):
                 "--disable-vp",
                 "-pgo-kind=pgo-instr-use-pipeline",
                 "-pgo-cold-func-opt=minsize",
-                "-profile-summary-cutoff-cold=995000",
+                "-profile-summary-cutoff-cold=996000",
                 "-passes=default<O2>",
             ),
             BENCHMARK_RELINK_USE_FLAGS,

--- a/scripts/pgso/tests/test_profile_supplement.py
+++ b/scripts/pgso/tests/test_profile_supplement.py
@@ -4,6 +4,8 @@ import unittest
 
 from scripts.pgso.model import PgsoError
 from scripts.pgso.profile_supplement import (
+    PROFILE_SUMMARY_CUTOFF_COLD,
+    SUPPLEMENT_COLD_THRESHOLD_MULTIPLIER,
     extract_compatible_profile,
     map_production_profile,
     speed_shaped_functions,
@@ -28,6 +30,10 @@ def profile_text(*records: tuple[str, int, tuple[int, ...]]) -> str:
 
 
 class ProfileSupplementTests(unittest.TestCase):
+    def test_supplements_follow_the_production_cold_cutoff(self) -> None:
+        self.assertEqual(600_000, PROFILE_SUMMARY_CUTOFF_COLD)
+        self.assertEqual(2, SUPPLEMENT_COLD_THRESHOLD_MULTIPLIER)
+
     def test_reads_speed_shaped_functions_from_profile_use_ir(self) -> None:
         ir = """
 define internal void @core.output.diff.hot() #3 {
@@ -119,7 +125,7 @@ attributes #4 = { cold minsize nounwind }
             ("fx;core.workspace.file_index.scoreAsciiRange",),
             supplement.function_names,
         )
-        self.assertEqual(10, supplement.total_counter_value)
+        self.assertEqual(3, supplement.total_counter_value)
         self.assertIn(
             "fx;core.workspace.file_index.scoreAsciiRange",
             supplement.text,
@@ -179,8 +185,8 @@ attributes #4 = { cold minsize nounwind }
             speed_functions=("core.output.diff.compute",),
         )
 
-        self.assertIn("\n200\n100\n0\n50\n", supplement.text)
-        self.assertEqual(350, supplement.total_counter_value)
+        self.assertIn("\n100\n50\n0\n25\n", supplement.text)
+        self.assertEqual(175, supplement.total_counter_value)
 
     def test_raises_a_low_workload_count_above_the_production_cold_cutoff(self) -> None:
         production = profile_text(
@@ -199,8 +205,8 @@ attributes #4 = { cold minsize nounwind }
             speed_functions=("core.output.diff.compute",),
         )
 
-        self.assertIn("\n200\n100\n0\n20\n", supplement.text)
-        self.assertEqual(320, supplement.total_counter_value)
+        self.assertIn("\n100\n50\n0\n10\n", supplement.text)
+        self.assertEqual(160, supplement.total_counter_value)
 
     def test_rejects_malformed_counter_count(self) -> None:
         production = profile_text(("fx;core.output.diff.compute", 7, (1,)))

--- a/scripts/pgso/tests/test_profile_supplement.py
+++ b/scripts/pgso/tests/test_profile_supplement.py
@@ -119,7 +119,7 @@ attributes #4 = { cold minsize nounwind }
             ("fx;core.workspace.file_index.scoreAsciiRange",),
             supplement.function_names,
         )
-        self.assertEqual(11, supplement.total_counter_value)
+        self.assertEqual(10, supplement.total_counter_value)
         self.assertIn(
             "fx;core.workspace.file_index.scoreAsciiRange",
             supplement.text,
@@ -179,8 +179,8 @@ attributes #4 = { cold minsize nounwind }
             speed_functions=("core.output.diff.compute",),
         )
 
-        self.assertIn("\n225\n112\n0\n56\n", supplement.text)
-        self.assertEqual(393, supplement.total_counter_value)
+        self.assertIn("\n200\n100\n0\n50\n", supplement.text)
+        self.assertEqual(350, supplement.total_counter_value)
 
     def test_raises_a_low_workload_count_above_the_production_cold_cutoff(self) -> None:
         production = profile_text(
@@ -199,8 +199,8 @@ attributes #4 = { cold minsize nounwind }
             speed_functions=("core.output.diff.compute",),
         )
 
-        self.assertIn("\n225\n112\n0\n22\n", supplement.text)
-        self.assertEqual(359, supplement.total_counter_value)
+        self.assertIn("\n200\n100\n0\n20\n", supplement.text)
+        self.assertEqual(320, supplement.total_counter_value)
 
     def test_rejects_malformed_counter_count(self) -> None:
         production = profile_text(("fx;core.output.diff.compute", 7, (1,)))

--- a/scripts/pgso/tests/test_profile_supplement.py
+++ b/scripts/pgso/tests/test_profile_supplement.py
@@ -119,7 +119,7 @@ attributes #4 = { cold minsize nounwind }
             ("fx;core.workspace.file_index.scoreAsciiRange",),
             supplement.function_names,
         )
-        self.assertEqual(10, supplement.total_counter_value)
+        self.assertEqual(11, supplement.total_counter_value)
         self.assertIn(
             "fx;core.workspace.file_index.scoreAsciiRange",
             supplement.text,
@@ -179,8 +179,8 @@ attributes #4 = { cold minsize nounwind }
             speed_functions=("core.output.diff.compute",),
         )
 
-        self.assertIn("\n200\n100\n0\n50\n", supplement.text)
-        self.assertEqual(350, supplement.total_counter_value)
+        self.assertIn("\n225\n112\n0\n56\n", supplement.text)
+        self.assertEqual(393, supplement.total_counter_value)
 
     def test_raises_a_low_workload_count_above_the_production_cold_cutoff(self) -> None:
         production = profile_text(
@@ -199,8 +199,8 @@ attributes #4 = { cold minsize nounwind }
             speed_functions=("core.output.diff.compute",),
         )
 
-        self.assertIn("\n200\n100\n0\n20\n", supplement.text)
-        self.assertEqual(320, supplement.total_counter_value)
+        self.assertIn("\n225\n112\n0\n22\n", supplement.text)
+        self.assertEqual(359, supplement.total_counter_value)
 
     def test_rejects_malformed_counter_count(self) -> None:
         production = profile_text(("fx;core.output.diff.compute", 7, (1,)))

--- a/src/core/workspace/unicode_simple_fold.zig
+++ b/src/core/workspace/unicode_simple_fold.zig
@@ -1530,7 +1530,116 @@ const mappings = [_]Mapping{
     .{ .from = 0x1E921, .to = 0x1E943 },
 };
 
+const CompactMapping = packed struct(u64) {
+    first: u21,
+    last: u21,
+    delta: i17,
+    step_two: bool,
+    padding: u4 = 0,
+};
+
+const Run = struct {
+    len: usize,
+    step_two: bool,
+};
+
+fn run_length(start: usize, step: u2) usize {
+    const first = mappings[start];
+    const delta = @as(i22, @intCast(first.to)) -
+        @as(i22, @intCast(first.from));
+    var len: usize = 1;
+    while (start + len < mappings.len) : (len += 1) {
+        const prior = mappings[start + len - 1];
+        const next = mappings[start + len];
+        if (next.from != prior.from + step) break;
+        if (next.to != prior.to + step) break;
+        const next_delta = @as(i22, @intCast(next.to)) -
+            @as(i22, @intCast(next.from));
+        if (next_delta != delta) break;
+    }
+    return len;
+}
+
+fn best_run(start: usize) Run {
+    const step_one = run_length(start, 1);
+    const step_two = run_length(start, 2);
+    if (step_two > step_one) return .{ .len = step_two, .step_two = true };
+    return .{ .len = step_one, .step_two = false };
+}
+
+const compact_mapping_count: usize = blk: {
+    @setEvalBranchQuota(2_000_000);
+    var count: usize = 0;
+    var index: usize = 0;
+    while (index < mappings.len) {
+        if (mappings[index].from < 0x80) {
+            index += 1;
+            continue;
+        }
+        const run = best_run(index);
+        index += if (run.len >= 3) run.len else 1;
+        count += 1;
+    }
+    break :blk count;
+};
+
+const compact_mappings: [compact_mapping_count]CompactMapping = blk: {
+    @setEvalBranchQuota(2_000_000);
+    var result: [compact_mapping_count]CompactMapping = undefined;
+    var result_index: usize = 0;
+    var index: usize = 0;
+    while (index < mappings.len) {
+        const first = mappings[index];
+        if (first.from < 0x80) {
+            index += 1;
+            continue;
+        }
+        const run = best_run(index);
+        const len = if (run.len >= 3) run.len else 1;
+        const last = mappings[index + len - 1];
+        const delta = @as(i22, @intCast(first.to)) -
+            @as(i22, @intCast(first.from));
+        result[result_index] = .{
+            .first = first.from,
+            .last = last.from,
+            .delta = @intCast(delta),
+            .step_two = run.step_two and len >= 3,
+        };
+        result_index += 1;
+        index += len;
+    }
+    if (result_index != compact_mapping_count) {
+        @compileError("Unicode fold mapping compression count mismatch");
+    }
+    break :blk result;
+};
+
+const runtime_mapping_bytes = @sizeOf(@TypeOf(compact_mappings));
+
 pub fn fold(codepoint: u21) u21 {
+    if (codepoint >= 'A' and codepoint <= 'Z') return codepoint + ('a' - 'A');
+    if (codepoint < 0x80) return codepoint;
+
+    var low: usize = 0;
+    var high: usize = compact_mappings.len;
+    while (low < high) {
+        const mid = low + (high - low) / 2;
+        if (codepoint < compact_mappings[mid].first) {
+            high = mid;
+        } else {
+            low = mid + 1;
+        }
+    }
+    if (low == 0) return codepoint;
+    const mapping = compact_mappings[low - 1];
+    if (codepoint > mapping.last) return codepoint;
+    const step: u21 = if (mapping.step_two) 2 else 1;
+    if ((codepoint - mapping.first) % step != 0) return codepoint;
+    const mapped = @as(i22, @intCast(codepoint)) + mapping.delta;
+    return @intCast(mapped);
+}
+
+fn reference_fold(codepoint: u21) u21 {
     if (codepoint >= 'A' and codepoint <= 'Z') return codepoint + ('a' - 'A');
     if (codepoint < 0x80) return codepoint;
 
@@ -1548,6 +1657,18 @@ pub fn fold(codepoint: u21) u21 {
         }
     }
     return codepoint;
+}
+
+test "Unicode simple fold matches the reference for every codepoint" {
+    var value: u32 = 0;
+    while (value <= 0x10FFFF) : (value += 1) {
+        const codepoint: u21 = @intCast(value);
+        try std.testing.expectEqual(reference_fold(codepoint), fold(codepoint));
+    }
+}
+
+test "Unicode simple fold runtime data stays within budget" {
+    try std.testing.expect(runtime_mapping_bytes <= 1_840);
 }
 
 test "Unicode simple fold covers representative C and S mappings" {


### PR DESCRIPTION
## Summary

- Reduce the macOS arm64 release binary by compacting Unicode case-fold data and profile-proven cold code.
- Preserve Unicode file search, ReleaseSafe checks, and hot-path code generation.