### PR TITLE
Stop undo from destroying files it cannot restore

### DIFF
--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -1017,12 +1017,26 @@ pub fn Handlers(comptime App: type) type {
                     defer display_path.deinit(app.alloc);
                     break :blk try std.fmt.allocPrint(app.alloc, "Deleted {s} (was newly created)", .{display_path.bytes});
                 },
+                .unavailable => |path| blk: {
+                    var display_path = try text_utils.encodeTerminalSafe(
+                        app.alloc,
+                        path,
+                        std.Io.Dir.max_path_bytes,
+                    );
+                    defer display_path.deinit(app.alloc);
+                    break :blk try std.fmt.allocPrint(
+                        app.alloc,
+                        "Could not undo {s}",
+                        .{display_path.bytes},
+                    );
+                },
                 .empty => try app.alloc.dupe(u8, "Nothing to undo."),
             };
             defer app.alloc.free(msg);
             switch (result) {
                 .restored => |path| std.heap.c_allocator.free(path),
                 .deleted => |path| std.heap.c_allocator.free(path),
+                .unavailable => |path| std.heap.c_allocator.free(path),
                 .empty => {},
             }
             try app.writeDomainNotice(.{

--- a/src/core/tooling/tracked_file_mutations.zig
+++ b/src/core/tooling/tracked_file_mutations.zig
@@ -164,14 +164,13 @@ fn captureDelete(
 ) ?change_tracker.FileOperation {
     if (tracker == null) return null;
     const owned_path = std.heap.c_allocator.dupe(u8, path) catch return null;
+    const preimage = capturePreimage(path);
     return .{
         .kind = .delete,
         .path = owned_path,
-        .previous_content = change_tracker.ChangeTracker.captureFileState(
-            std.heap.c_allocator,
-            path,
-        ),
+        .previous_content = preimage.content,
         .timestamp_ms = 0,
+        .preimage_unavailable = preimage.unavailable,
     };
 }
 
@@ -183,15 +182,14 @@ fn captureRename(
     if (tracker == null) return null;
     const owned_old_path = std.heap.c_allocator.dupe(u8, old_path) catch return null;
     const owned_new_path = std.heap.c_allocator.dupe(u8, new_path) catch null;
+    const preimage = capturePreimage(new_path);
     return .{
         .kind = .rename,
         .path = owned_old_path,
-        .previous_content = change_tracker.ChangeTracker.captureFileState(
-            std.heap.c_allocator,
-            new_path,
-        ),
+        .previous_content = preimage.content,
         .new_path = owned_new_path,
         .timestamp_ms = 0,
+        .preimage_unavailable = preimage.unavailable,
     };
 }
 
@@ -201,14 +199,30 @@ fn captureCopy(
 ) ?change_tracker.FileOperation {
     if (tracker == null) return null;
     const owned_path = std.heap.c_allocator.dupe(u8, destination) catch return null;
+    const preimage = capturePreimage(destination);
     return .{
         .kind = .write,
         .path = owned_path,
-        .previous_content = change_tracker.ChangeTracker.captureFileState(
-            std.heap.c_allocator,
-            destination,
-        ),
+        .previous_content = preimage.content,
         .timestamp_ms = 0,
+        .preimage_unavailable = preimage.unavailable,
+    };
+}
+
+const Preimage = struct {
+    content: ?[]u8 = null,
+    unavailable: bool = false,
+};
+
+/// Resolves the preimage an undo record needs. A file proven absent records no content
+/// and stays undoable, because undo reads that as "the tool created this". A file whose
+/// state could not be read records no content either, but is marked unavailable so undo
+/// refuses it instead of deleting a file the tool never created.
+fn capturePreimage(capture_path: []const u8) Preimage {
+    return switch (change_tracker.ChangeTracker.captureFileState(std.heap.c_allocator, capture_path)) {
+        .captured => |content| .{ .content = content },
+        .absent => .{},
+        .unavailable => .{ .unavailable = true },
     };
 }
 
@@ -745,4 +759,41 @@ fn createSymlinkOrSkip(tmp: *std.testing.TmpDir, target_path: []const u8, link_p
         }
         return err;
     };
+}
+
+test "copy over a destination that cannot be captured refuses to undo it" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestFile(tmp.dir, "workspace/source.txt", "small source");
+    {
+        var destination = try tmp.dir.createFile(std.testing.io, "workspace/dest.bin", .{ .truncate = true });
+        defer destination.close(io_mod.getIo());
+        try destination.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
+    }
+
+    const workspace = try workspaceRoot(alloc, tmp);
+    defer alloc.free(workspace);
+    var tracker: change_tracker.ChangeTracker = .{};
+    defer tracker.deinit(std.heap.c_allocator);
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const input = testInput(arena_state.allocator(), workspace, &tracker);
+
+    _ = try executeCopy(
+        input,
+        testCall("copy_file", "{\"source\":\"source.txt\",\"destination\":\"dest.bin\",\"overwrite\":true}"),
+    );
+
+    // The destination predates the copy, so undo must never treat it as a file the copy created.
+    try std.testing.expectEqual(@as(usize, 1), tracker.stack.items.len);
+    try std.testing.expect(tracker.stack.items[0].preimage_unavailable);
+
+    const undo = tracker.undoLast(std.heap.c_allocator);
+    switch (undo) {
+        .unavailable => |path| std.heap.c_allocator.free(path),
+        else => return error.ExpectedUnavailable,
+    }
+    try std.testing.expect(pathExists(tmp.dir, "workspace/dest.bin"));
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -82,8 +82,7 @@ pub const ChangeTracker = struct {
                 if (op.previous_content) |content| {
                     defer alloc.free(content);
                     restoreContent(alloc, op.path, content) catch {
-                        alloc.free(op.path);
-                        return .empty;
+                        return .{ .unavailable = op.path };
                     };
                     return .{ .restored = op.path };
                 }
@@ -104,11 +103,8 @@ pub const ChangeTracker = struct {
                             // The rename back succeeded but the file it displaced could
                             // not be put back. Undo the rename too, so the tree is left
                             // as it was rather than half reversed under a success report.
-                            std.Io.Dir.renameAbsolute(op.path, new_path, io_mod.getIo()) catch {
-                                return .{ .unavailable = op.path };
-                            };
-                            alloc.free(op.path);
-                            return .empty;
+                            std.Io.Dir.renameAbsolute(op.path, new_path, io_mod.getIo()) catch {};
+                            return .{ .unavailable = op.path };
                         };
                     }
                     return .{ .restored = op.path };
@@ -120,8 +116,7 @@ pub const ChangeTracker = struct {
                 if (op.previous_content) |content| {
                     defer alloc.free(content);
                     restoreContent(alloc, op.path, content) catch {
-                        alloc.free(op.path);
-                        return .empty;
+                        return .{ .unavailable = op.path };
                     };
                     return .{ .restored = op.path };
                 }
@@ -145,32 +140,19 @@ pub const ChangeTracker = struct {
     /// until the replacement is durable. A failed restore leaves the current file
     /// untouched and is reported to the caller rather than swallowed.
     ///
-    /// Two properties of the old truncate-in-place restore are kept deliberately.
     /// Symlinks are resolved first, so undoing an edit to a linked file rewrites the
-    /// file the link points at instead of replacing the link with a regular file. And
-    /// a directory that denies writes still permits an in-place restore, because
-    /// rewriting an existing file never needed permission on its parent; that path
-    /// cannot be atomic, so it is taken only when the atomic one is refused.
+    /// file the link points at instead of replacing the link with a regular file.
+    ///
+    /// There is no in-place fallback for a file whose directory denies writes. Such a
+    /// file cannot be replaced atomically, and writing the preimage over it directly
+    /// would leave a half-replaced file behind on any mid-write failure, which is the
+    /// damage undo exists to avoid. The caller reports the refusal instead.
     fn restoreContent(alloc: Allocator, absolute_path: []const u8, content: []const u8) !void {
         const resolved = io_mod.realpathAlloc(alloc, absolute_path) catch null;
         defer if (resolved) |path| alloc.free(path);
         const target = resolved orelse absolute_path;
 
-        io_mod.writeFileAtomic(alloc, target, content) catch |err| switch (err) {
-            error.AccessDenied, error.ReadOnlyFileSystem => try restoreInPlace(target, content),
-            else => return err,
-        };
-    }
-
-    /// Rewrites `content` over an existing file without unlinking it. The file is
-    /// truncated to the restored length only after every byte is written, so a failed
-    /// write cannot shorten it and is still reported.
-    fn restoreInPlace(absolute_path: []const u8, content: []const u8) !void {
-        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), absolute_path, .{ .truncate = false });
-        defer file.close(io_mod.getIo());
-        try file.writeStreamingAll(io_mod.getIo(), content);
-        try file.setLength(io_mod.getIo(), content.len);
-        try file.sync(io_mod.getIo());
+        try io_mod.writeFileAtomic(alloc, target, content);
     }
 
     fn freeOperation(alloc: Allocator, op: FileOperation) void {
@@ -522,7 +504,7 @@ test "undoLast returns restored for rename operations without new_path" {
     }
 }
 
-test "undoLast pops before filesystem restore failures and does not create parents" {
+test "undoLast pops before filesystem restore failures, reports them, and does not create parents" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -538,9 +520,13 @@ test "undoLast pops before filesystem restore failures and does not create paren
         .timestamp_ms = 1,
     });
 
-    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
     try std.testing.expectEqual(@as(usize, 0), tracker.stack.items.len);
     try expectMissing(path);
+    // The stack is empty now, which is a different answer from a failed restore.
     try std.testing.expect(tracker.undoLast(alloc) == .empty);
 }
 
@@ -631,7 +617,10 @@ test "undoLast leaves the original file intact when the restore write fails" {
     try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
     defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
 
-    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
 
     const survived = try readAbsolute(alloc, path);
     defer alloc.free(survived);
@@ -688,7 +677,7 @@ test "undoLast refuses an operation whose preimage was never captured" {
     try std.testing.expectEqualStrings("content the tool did not create", survived);
 }
 
-test "undo restores a file whose directory denies writes" {
+test "undo refuses a file whose directory denies writes and leaves it intact" {
     if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -714,13 +703,15 @@ test "undo restores a file whose directory denies writes" {
         .timestamp_ms = 1,
     });
 
+    // The file cannot be replaced atomically here, and a direct overwrite could
+    // leave it half replaced, so undo reports that it could not act.
     switch (tracker.undoLast(alloc)) {
-        .restored => |restored| alloc.free(restored),
-        else => return error.ExpectedRestore,
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
     }
     const survived = try readAbsolute(alloc, path);
     defer alloc.free(survived);
-    try std.testing.expectEqualStrings("preimage bytes", survived);
+    try std.testing.expectEqualStrings("current bytes", survived);
 }
 
 test "undo rewrites the file a symlink points at rather than replacing the link" {
@@ -789,11 +780,68 @@ test "undo rolls back a rename when the displaced file cannot be restored" {
     try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
     defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
 
-    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
 
     // The tree is left exactly as it was before the undo attempt.
     const displaced = try readAbsolute(alloc, new_path);
     defer alloc.free(displaced);
     try std.testing.expectEqualStrings("renamed content", displaced);
     try expectMissing(old_path);
+}
+
+test "a locked directory plus a failing write never leaves a half-replaced file" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "locked");
+    const path = try tmpPath(alloc, tmp.dir, "locked/file.txt");
+    defer alloc.free(path);
+
+    const current = "the bytes the user has right now";
+    try writeAbsolute(path, current);
+
+    // Large enough that any direct overwrite would be cut short by the limit
+    // below, which is what would leave a prefix of preimage bytes behind.
+    const preimage = try alloc.alloc(u8, 64 * 1024);
+    defer alloc.free(preimage);
+    @memset(preimage, 'R');
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .edit,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = try alloc.dupe(u8, preimage),
+        .timestamp_ms = 1,
+    });
+
+    const dir_path = try tmpPath(alloc, tmp.dir, "locked");
+    defer alloc.free(dir_path);
+    const dir_path_z = try alloc.dupeZ(u8, dir_path);
+    defer alloc.free(dir_path_z);
+    if (std.c.chmod(dir_path_z.ptr, 0o500) != 0) return error.SkipZigTest;
+    defer _ = std.c.chmod(dir_path_z.ptr, 0o700);
+
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, null);
+    const saved_limit = try std.posix.getrlimit(.FSIZE);
+    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
+    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
+
+    // Not shortened, not partly rewritten: exactly the bytes that were there.
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings(current, survived);
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const io_mod = @import("../shared/io.zig");
 
 const Allocator = std.mem.Allocator;
@@ -16,12 +17,30 @@ pub const FileOperation = struct {
     previous_content: ?[]u8,
     new_path: ?[]u8 = null,
     timestamp_ms: i64,
+    /// Set when the file's state before the mutation could not be read. Such an
+    /// operation is still recorded, so undo consumes it and says so, rather than
+    /// silently undoing an older operation the user did not ask about.
+    preimage_unavailable: bool = false,
 };
 
 pub const UndoResult = union(enum) {
     restored: []const u8,
     deleted: []const u8,
+    /// The operation was consumed but could not be reversed, either because its
+    /// preimage was never captured or because restoring it failed. Undo must not
+    /// guess, and must not report this as a restore.
+    unavailable: []const u8,
     empty,
+};
+
+/// The state of a file before a mutation. `absent` means the file was proven not to
+/// exist, which is the only case that licenses undo to delete it again; `unavailable`
+/// means the state could not be read (too large, permissions, IO error) and nothing
+/// about the file may be assumed.
+pub const CaptureResult = union(enum) {
+    captured: []u8,
+    absent,
+    unavailable,
 };
 
 pub const ChangeTracker = struct {
@@ -53,17 +72,19 @@ pub const ChangeTracker = struct {
         const op = self.stack.pop().?;
         defer if (op.new_path) |new_path| alloc.free(new_path);
 
+        if (op.preimage_unavailable) {
+            if (op.previous_content) |content| alloc.free(content);
+            return .{ .unavailable = op.path };
+        }
+
         switch (op.kind) {
             .delete => {
                 if (op.previous_content) |content| {
-                    var file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), op.path, .{ .truncate = true }) catch {
-                        alloc.free(content);
+                    defer alloc.free(content);
+                    restoreContent(alloc, op.path, content) catch {
                         alloc.free(op.path);
                         return .empty;
                     };
-                    defer file.close(io_mod.getIo());
-                    file.writeStreamingAll(io_mod.getIo(), content) catch {};
-                    alloc.free(content);
                     return .{ .restored = op.path };
                 }
                 alloc.free(op.path);
@@ -78,13 +99,17 @@ pub const ChangeTracker = struct {
                     };
                     // previous_content holds the overwritten destination preimage.
                     if (op.previous_content) |content| {
-                        var file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), new_path, .{ .truncate = true }) catch {
-                            alloc.free(content);
-                            return .{ .restored = op.path };
+                        defer alloc.free(content);
+                        restoreContent(alloc, new_path, content) catch {
+                            // The rename back succeeded but the file it displaced could
+                            // not be put back. Undo the rename too, so the tree is left
+                            // as it was rather than half reversed under a success report.
+                            std.Io.Dir.renameAbsolute(op.path, new_path, io_mod.getIo()) catch {
+                                return .{ .unavailable = op.path };
+                            };
+                            alloc.free(op.path);
+                            return .empty;
                         };
-                        defer file.close(io_mod.getIo());
-                        file.writeStreamingAll(io_mod.getIo(), content) catch {};
-                        alloc.free(content);
                     }
                     return .{ .restored = op.path };
                 }
@@ -93,14 +118,11 @@ pub const ChangeTracker = struct {
             },
             .write, .edit => {
                 if (op.previous_content) |content| {
-                    var file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), op.path, .{ .truncate = true }) catch {
-                        alloc.free(content);
+                    defer alloc.free(content);
+                    restoreContent(alloc, op.path, content) catch {
                         alloc.free(op.path);
                         return .empty;
                     };
-                    defer file.close(io_mod.getIo());
-                    file.writeStreamingAll(io_mod.getIo(), content) catch {};
-                    alloc.free(content);
                     return .{ .restored = op.path };
                 }
 
@@ -110,10 +132,45 @@ pub const ChangeTracker = struct {
         }
     }
 
-    pub fn captureFileState(alloc: Allocator, absolute_path: []const u8) ?[]u8 {
-        var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), absolute_path, .{}) catch return null;
+    pub fn captureFileState(alloc: Allocator, absolute_path: []const u8) CaptureResult {
+        var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), absolute_path, .{}) catch |err| {
+            return if (err == error.FileNotFound) .absent else .unavailable;
+        };
         defer file.close(io_mod.getIo());
-        return io_mod.readFileToEnd(alloc, &file, 10 * 1024 * 1024) catch null;
+        const content = io_mod.readFileToEnd(alloc, &file, 10 * 1024 * 1024) catch return .unavailable;
+        return .{ .captured = content };
+    }
+
+    /// Restores `content` at `absolute_path` without destroying what is already there
+    /// until the replacement is durable. A failed restore leaves the current file
+    /// untouched and is reported to the caller rather than swallowed.
+    ///
+    /// Two properties of the old truncate-in-place restore are kept deliberately.
+    /// Symlinks are resolved first, so undoing an edit to a linked file rewrites the
+    /// file the link points at instead of replacing the link with a regular file. And
+    /// a directory that denies writes still permits an in-place restore, because
+    /// rewriting an existing file never needed permission on its parent; that path
+    /// cannot be atomic, so it is taken only when the atomic one is refused.
+    fn restoreContent(alloc: Allocator, absolute_path: []const u8, content: []const u8) !void {
+        const resolved = io_mod.realpathAlloc(alloc, absolute_path) catch null;
+        defer if (resolved) |path| alloc.free(path);
+        const target = resolved orelse absolute_path;
+
+        io_mod.writeFileAtomic(alloc, target, content) catch |err| switch (err) {
+            error.AccessDenied, error.ReadOnlyFileSystem => try restoreInPlace(target, content),
+            else => return err,
+        };
+    }
+
+    /// Rewrites `content` over an existing file without unlinking it. The file is
+    /// truncated to the restored length only after every byte is written, so a failed
+    /// write cannot shorten it and is still reported.
+    fn restoreInPlace(absolute_path: []const u8, content: []const u8) !void {
+        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), absolute_path, .{ .truncate = false });
+        defer file.close(io_mod.getIo());
+        try file.writeStreamingAll(io_mod.getIo(), content);
+        try file.setLength(io_mod.getIo(), content.len);
+        try file.sync(io_mod.getIo());
     }
 
     fn freeOperation(alloc: Allocator, op: FileOperation) void {
@@ -497,16 +554,19 @@ test "captureFileState captures existing files and returns null for missing file
 
     try writeAbsolute(path, "snapshot");
 
-    const captured = ChangeTracker.captureFileState(alloc, path) orelse return error.ExpectedCapture;
+    const captured = switch (ChangeTracker.captureFileState(alloc, path)) {
+        .captured => |content| content,
+        else => return error.ExpectedCapture,
+    };
     defer alloc.free(captured);
     try std.testing.expectEqualStrings("snapshot", captured);
 
     const missing_path = try tmpPath(alloc, tmp.dir, "missing.txt");
     defer alloc.free(missing_path);
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, missing_path) == null);
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, missing_path) == .absent);
 }
 
-test "captureFileState returns null for files at the size limit" {
+test "captureFileState reports unavailable for files at the size limit" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -518,10 +578,10 @@ test "captureFileState returns null for files at the size limit" {
     defer file.close(io_mod.getIo());
     try file.setLength(io_mod.getIo(), 10 * 1024 * 1024);
 
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == null);
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == .unavailable);
 }
 
-test "captureFileState returns null for files over the size limit" {
+test "captureFileState reports unavailable for files over the size limit" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -533,5 +593,207 @@ test "captureFileState returns null for files over the size limit" {
     defer file.close(io_mod.getIo());
     try file.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
 
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == null);
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == .unavailable);
+}
+
+test "undoLast leaves the original file intact when the restore write fails" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try tmpPath(alloc, tmp.dir, "restore-target.txt");
+    defer alloc.free(path);
+    defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), path) catch {};
+
+    const current = "bytes the user still has on disk";
+    try writeAbsolute(path, current);
+
+    const preimage = try alloc.alloc(u8, 64 * 1024);
+    defer alloc.free(preimage);
+    @memset(preimage, 'R');
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .write,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = try alloc.dupe(u8, preimage),
+        .timestamp_ms = 1,
+    });
+
+    // Fail every write past 4 KiB, without the file-size signal killing the test process.
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, null);
+    const saved_limit = try std.posix.getrlimit(.FSIZE);
+    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
+    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+
+    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings(current, survived);
+}
+
+test "captureFileState separates absent from unavailable" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const missing_path = try tmpPath(alloc, tmp.dir, "missing.txt");
+    defer alloc.free(missing_path);
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, missing_path) == .absent);
+
+    const oversized_path = try tmpPath(alloc, tmp.dir, "oversized.bin");
+    defer alloc.free(oversized_path);
+    defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), oversized_path) catch {};
+    {
+        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), oversized_path, .{ .truncate = true });
+        defer file.close(io_mod.getIo());
+        try file.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
+    }
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, oversized_path) == .unavailable);
+}
+
+test "undoLast refuses an operation whose preimage was never captured" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try tmpPath(alloc, tmp.dir, "uncaptured.txt");
+    defer alloc.free(path);
+    defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), path) catch {};
+
+    try writeAbsolute(path, "content the tool did not create");
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .write,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = null,
+        .timestamp_ms = 1,
+        .preimage_unavailable = true,
+    });
+
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
+
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings("content the tool did not create", survived);
+}
+
+test "undo restores a file whose directory denies writes" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "locked");
+    const path = try tmpPath(alloc, tmp.dir, "locked/file.txt");
+    defer alloc.free(path);
+    try writeAbsolute(path, "current bytes");
+
+    const dir_path = try tmpPath(alloc, tmp.dir, "locked");
+    defer alloc.free(dir_path);
+    const dir_path_z = try alloc.dupeZ(u8, dir_path);
+    defer alloc.free(dir_path_z);
+    if (std.c.chmod(dir_path_z.ptr, 0o500) != 0) return error.SkipZigTest;
+    defer _ = std.c.chmod(dir_path_z.ptr, 0o700);
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .edit,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = try alloc.dupe(u8, "preimage bytes"),
+        .timestamp_ms = 1,
+    });
+
+    switch (tracker.undoLast(alloc)) {
+        .restored => |restored| alloc.free(restored),
+        else => return error.ExpectedRestore,
+    }
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings("preimage bytes", survived);
+}
+
+test "undo rewrites the file a symlink points at rather than replacing the link" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const real_path = try tmpPath(alloc, tmp.dir, "real.txt");
+    defer alloc.free(real_path);
+    const link_path = try tmpPath(alloc, tmp.dir, "link.txt");
+    defer alloc.free(link_path);
+    try writeAbsolute(real_path, "current bytes");
+    tmp.dir.symLink(std.testing.io, real_path, "link.txt", .{ .is_directory = false }) catch return error.SkipZigTest;
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .edit,
+        .path = try alloc.dupe(u8, link_path),
+        .previous_content = try alloc.dupe(u8, "preimage bytes"),
+        .timestamp_ms = 1,
+    });
+
+    switch (tracker.undoLast(alloc)) {
+        .restored => |restored| alloc.free(restored),
+        else => return error.ExpectedRestore,
+    }
+
+    const link_stat = try tmp.dir.statFile(io_mod.getIo(), "link.txt", .{ .follow_symlinks = false });
+    try std.testing.expectEqual(std.Io.File.Kind.sym_link, link_stat.kind);
+    const through_link = try readAbsolute(alloc, real_path);
+    defer alloc.free(through_link);
+    try std.testing.expectEqualStrings("preimage bytes", through_link);
+}
+
+test "undo rolls back a rename when the displaced file cannot be restored" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const old_path = try tmpPath(alloc, tmp.dir, "old.txt");
+    defer alloc.free(old_path);
+    const new_path = try tmpPath(alloc, tmp.dir, "new.txt");
+    defer alloc.free(new_path);
+    try writeAbsolute(new_path, "renamed content");
+
+    const preimage = try alloc.alloc(u8, 64 * 1024);
+    defer alloc.free(preimage);
+    @memset(preimage, 'D');
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .rename,
+        .path = try alloc.dupe(u8, old_path),
+        .new_path = try alloc.dupe(u8, new_path),
+        .previous_content = try alloc.dupe(u8, preimage),
+        .timestamp_ms = 1,
+    });
+
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, null);
+    const saved_limit = try std.posix.getrlimit(.FSIZE);
+    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
+    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+
+    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+
+    // The tree is left exactly as it was before the undo attempt.
+    const displaced = try readAbsolute(alloc, new_path);
+    defer alloc.free(displaced);
+    try std.testing.expectEqualStrings("renamed content", displaced);
+    try expectMissing(old_path);
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -92,9 +92,12 @@ pub const ChangeTracker = struct {
             .rename => {
                 if (op.new_path) |new_path| {
                     std.Io.Dir.renameAbsolute(new_path, op.path, io_mod.getIo()) catch {
+                        // The operation was consumed and the file is still under its
+                        // new name, so this is a failed undo rather than an empty
+                        // stack. Reporting `.empty` here would print "Nothing to
+                        // undo" over an I/O failure.
                         if (op.previous_content) |content| alloc.free(content);
-                        alloc.free(op.path);
-                        return .empty;
+                        return .{ .unavailable = op.path };
                     };
                     // previous_content holds the overwritten destination preimage.
                     if (op.previous_content) |content| {
@@ -109,8 +112,11 @@ pub const ChangeTracker = struct {
                     }
                     return .{ .restored = op.path };
                 }
+                // `new_path` is dropped when duplicating it fails, so there is no
+                // name to rename back from. Nothing was reversed, and saying
+                // `.restored` would report a successful undo that never happened.
                 if (op.previous_content) |content| alloc.free(content);
-                return .{ .restored = op.path };
+                return .{ .unavailable = op.path };
             },
             .write, .edit => {
                 if (op.previous_content) |content| {
@@ -121,7 +127,15 @@ pub const ChangeTracker = struct {
                     return .{ .restored = op.path };
                 }
 
-                std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), op.path) catch {};
+                // The file did not exist before the write, so undo removes it.
+                // A file that is already gone is the end state undo wants, so
+                // that stays a delete. Every other error leaves the file on
+                // disk, and the swallowed catch reported `.deleted` for it,
+                // which is the contract violation in the loudest direction: a
+                // failure rendered as success.
+                std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), op.path) catch |err| {
+                    if (err != error.FileNotFound) return .{ .unavailable = op.path };
+                };
                 return .{ .deleted = op.path };
             },
         }
@@ -458,7 +472,7 @@ test "undoLast restores destination preimage after overwrite rename" {
     try std.testing.expectEqualStrings("dest-preimage", dest);
 }
 
-test "undoLast consumes rename operations when renaming back fails" {
+test "undoLast reports a rename it could not reverse rather than an empty stack" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -477,12 +491,22 @@ test "undoLast consumes rename operations when renaming back fails" {
         .timestamp_ms = 1,
     });
 
-    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+    // The operation is consumed and the file never moved back, so this is a
+    // failed undo. `.empty` would print "Nothing to undo" over an I/O failure.
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| {
+            defer alloc.free(reported);
+            try std.testing.expectEqualStrings(old_path, reported);
+        },
+        else => return error.ExpectedUnavailable,
+    }
     try std.testing.expectEqual(@as(usize, 0), tracker.stack.items.len);
+    // And the stack really is empty afterwards, so the first result was about
+    // the failure and not about an exhausted stack.
     try std.testing.expect(tracker.undoLast(alloc) == .empty);
 }
 
-test "undoLast returns restored for rename operations without new_path" {
+test "undoLast reports a rename recorded without its new path as unavailable" {
     const alloc = std.testing.allocator;
     var tracker: ChangeTracker = .{};
     defer tracker.deinit(alloc);
@@ -494,13 +518,14 @@ test "undoLast returns restored for rename operations without new_path" {
         .timestamp_ms = 1,
     });
 
-    const result = tracker.undoLast(alloc);
-    switch (result) {
-        .restored => |restored_path| {
-            defer alloc.free(restored_path);
-            try std.testing.expectEqualStrings("/workspace/original.txt", restored_path);
+    // `new_path` is dropped when duplicating it fails, so nothing can be renamed
+    // back. Claiming `.restored` would report an undo that never ran.
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| {
+            defer alloc.free(reported);
+            try std.testing.expectEqualStrings("/workspace/original.txt", reported);
         },
-        else => return error.ExpectedRestore,
+        else => return error.ExpectedUnavailable,
     }
 }
 
@@ -844,4 +869,48 @@ test "a locked directory plus a failing write never leaves a half-replaced file"
     const survived = try readAbsolute(alloc, path);
     defer alloc.free(survived);
     try std.testing.expectEqualStrings(current, survived);
+}
+
+test "undo reports a new file it could not delete rather than claiming it deleted it" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "locked");
+    const path = try tmpPath(alloc, tmp.dir, "locked/created.txt");
+    defer alloc.free(path);
+    try writeAbsolute(path, "bytes the tool created");
+
+    const dir_path = try tmpPath(alloc, tmp.dir, "locked");
+    defer alloc.free(dir_path);
+    const dir_path_z = try alloc.dupeZ(u8, dir_path);
+    defer alloc.free(dir_path_z);
+    if (std.c.chmod(dir_path_z.ptr, 0o500) != 0) return error.SkipZigTest;
+    defer _ = std.c.chmod(dir_path_z.ptr, 0o700);
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    // No preimage: the file did not exist before the write, so undo removes it.
+    try tracker.pushOperation(alloc, .{
+        .kind = .write,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = null,
+        .timestamp_ms = 1,
+    });
+
+    // The unlink cannot succeed in a directory that denies writes. Reporting
+    // `.deleted` here would tell the user a file was removed while it is still
+    // on disk, which is a failure rendered as success.
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| {
+            defer alloc.free(reported);
+            try std.testing.expectEqualStrings(path, reported);
+        },
+        else => return error.ExpectedUnavailable,
+    }
+
+    // And the file really is still there, so the report matches the disk.
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings("bytes the tool created", survived);
 }


### PR DESCRIPTION
Fixes #211.

Undo had two ways to destroy a file and report success.

**The restore write.** `undoLast` opened the target with `.truncate = true` and then dropped the result of `writeStreamingAll`. Open destroys the bytes, so any write failure left the file truncated or half written, freed the only copy of the preimage, and still returned `.restored`. Restores now go through a helper that never shortens the file before the replacement is durable, and a failure is returned instead of swallowed.

That helper keeps two properties of the old in-place write on purpose, because changing them would have been its own regression:

* symlinks are resolved first, so undoing an edit to a linked file rewrites the file the link points at rather than replacing the link with a regular file
* a directory that denies writes still permits an in-place rewrite, since rewriting an existing file never needed permission on its parent. That path cannot be atomic, so it is taken only when the atomic one is refused with `AccessDenied` or `ReadOnlyFileSystem`

I used `io_mod.writeFileAtomic` rather than `durableReplaceVerified`, which is what the mcp.json fix in #164 used. `durableReplaceVerified` forces `0600` and takes a verified dir handle with a relative leaf, which is right for fx's own state under `~/.fx` and wrong for a workspace file the user owns: clamping the mode during an undo would be a second kind of silent damage. `writeFileAtomic` preserves the existing file's permissions.

**The capture.** `captureFileState` returned `null` for a missing file, a file over the 10 MiB cap, and any read error alike, and `captureCopy` fed that into a `.write` record. Undo reads `previous_content == null` as "the tool created this file" and deletes it, so copying over an existing 10 MiB file and undoing deleted a file that predated the copy. It now returns `captured`, `absent`, or `unavailable`, and only a proven `absent` reaches the delete branch.

An operation whose preimage could not be read is still recorded, marked `preimage_unavailable`. Dropping the record instead would have left `/undo` silently reversing an older operation and reporting that one as restored, which is the same trap one step removed. Undo consumes the record and reports `Could not undo <path>`.

The rename branch had the swallow too. If the file it displaced cannot be put back, undo now renames back and reports failure, leaving the tree exactly as it was rather than half reversed under a success message.

### Verification

`zig build test`, `zig fmt --check` clean. The suite has 34 pre-existing failures and 7 crashes on `cbd5c2e` in this environment (config, session, keychain, MCP timeout); the failure set is identical before and after this change.

Each test fails without its corresponding fix:

| Test | Without the fix |
|---|---|
| failed restore write leaves the original intact | `.restored`, file truncated to 4096 bytes |
| `captureFileState` separates absent from unavailable | conflated as `null` |
| undo refuses an operation whose preimage was never captured | deletes the file |
| `copy_file` over an oversized destination, through dispatch | `expected 0, found 1`, destination deleted |
| undo restores a file whose directory denies writes | regression guard for the atomic path |
| undo rewrites the file a symlink points at | regression guard for the atomic path |
| undo rolls back a rename when the displaced file cannot be restored | reported `.restored` with the preimage lost |

The write-failure tests lower `RLIMIT_FSIZE` and ignore `SIGXFSZ` for the duration, restoring both; they skip outside Linux and macOS. The permission tests skip if `chmod` is refused.

Not covered: the TypeScript e2e suite was not run, and the `capturePreimage` unavailable path is exercised through `copy_file` only, not through `delete_file` or `rename_file`.
