### PR TITLE
Make workspace status line opt in

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands.
 
+The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "workspace": true
+  }
+}
+```
+
 List saved sessions with `fx sessions`. Resume the latest session for the current workspace, or select an exact session ID, through the same command group:
 
 ```bash

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -442,7 +442,7 @@ pub const slash_specs = [_]SlashSpec{
     .{ .kind = .fast, .command = "/fast", .help_entry = "/fast", .completion_description = "toggle Fast mode when supported", .presentation_category = .model },
     .{ .kind = .appearance, .command = "/appearance", .aliases = &.{ "/input", "/maxxing" }, .show_aliases_in_completion = false, .help_entry = "/appearance [input lines|tint|presentation normal|minimal]", .completion_description = "choose input and transcript presentation", .presentation_category = .appearance, .has_args = true, .accepts_payload = true },
     .{ .kind = .sandbox, .command = "/sandbox", .help_entry = "/sandbox [os|none]", .completion_description = "choose command sandbox behavior", .presentation_category = .security, .has_args = true, .accepts_payload = true },
-    .{ .kind = .statusline, .command = "/statusline", .help_entry = "/statusline [sandbox|context|session]", .completion_description = "toggle status line segments", .presentation_category = .appearance, .has_args = true, .accepts_payload = true },
+    .{ .kind = .statusline, .command = "/statusline", .help_entry = "/statusline [sandbox|context|session|workspace]", .completion_description = "toggle status line segments", .presentation_category = .appearance, .has_args = true, .accepts_payload = true },
     .{ .kind = .notifications, .command = "/sound", .help_entry = "/sound [on|off|max]", .completion_description = "toggle sounds and terminal bells", .presentation_category = .appearance, .has_args = true, .accepts_payload = true },
     .{ .kind = .workspace, .command = "/workspace", .help_entry = "/workspace [list|add PATH|remove PATH|clear]", .completion_description = "manage additional workspace directories", .presentation_category = .workspace, .show_in_welcome = true, .has_args = true, .accepts_payload = true },
     .{ .kind = .version, .command = "/version", .help_entry = "/version", .completion_description = "show the fx version", .presentation_category = .general },
@@ -601,4 +601,17 @@ test "built-in paste completion describes clipboard image attachment" {
 
     const description = nthSlashCompletionDescription("/pas", 0) orelse return error.TestExpectedEqual;
     try std.testing.expectEqualStrings("attach an image from the clipboard when supported", description);
+}
+
+test "built-in statusline help and completion include workspace" {
+    const help = try renderSlashHelp(std.testing.allocator);
+    defer std.testing.allocator.free(help);
+    try std.testing.expect(
+        std.mem.find(u8, help, "/statusline [sandbox|context|session|workspace]") != null,
+    );
+
+    try std.testing.expectEqualStrings(
+        "/statusline workspace",
+        nthSlashCompletion("/statusline w", 0).?,
+    );
 }

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -11,6 +11,7 @@ const config_runtime = @import("../config/config_runtime.zig");
 const host = @import("../hosts/host.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const record_tape = @import("../workspace/record_tape.zig");
+const statusline_identity = @import("../workspace/statusline_identity.zig");
 const shared_io = @import("../shared/io.zig");
 const mcp_runtime = @import("../mcp/mcp_runtime.zig");
 const permissions = @import("../permissions/permissions.zig");
@@ -287,6 +288,9 @@ pub fn Runtime(comptime App: type) type {
             app.statusline_sandbox = startup.statusline_sandbox;
             app.statusline_context = startup.statusline_context;
             app.statusline_session = startup.statusline_session;
+            if (comptime @hasField(App, "workspace_identity")) {
+                app.workspace_identity.enabled = startup.statusline_workspace;
+            }
             if (comptime @hasDecl(App, "setNotificationPreferences")) {
                 app.setNotificationPreferences(
                     startup.notification_turn_end,
@@ -543,6 +547,7 @@ const TestApp = struct {
     statusline_sandbox: bool = false,
     statusline_context: bool = false,
     statusline_session: bool = false,
+    workspace_identity: statusline_identity.Runtime = .{},
     requested_resume: ?u8 = null,
     mcp_runtime: ?*mcp_runtime.McpRuntime = null,
     skills: skill_runtime.Runtime = .{},
@@ -562,6 +567,7 @@ const TestApp = struct {
             self.workspace_root = &.{};
         }
         self.auth.deinit(self.alloc);
+        self.workspace_identity.deinit(self.alloc);
         self.selected_model.deinit(self.alloc);
         self.permission_engine.deinit(self.alloc);
         self.worker.deinit(std.heap.c_allocator);
@@ -695,6 +701,7 @@ fn makeStartupState(alloc: Allocator) !app_lifecycle.StartupState {
     state.update_channel = .dev;
     state.effort = types.ReasoningEffort.literal("high");
     state.sandbox_backend = .none;
+    state.statusline_workspace = true;
     if (active_capture.?.emit_config_diagnostics) {
         const diagnostics = try alloc.alloc(config_runtime.ConfigDiagnostic, 2);
         errdefer alloc.free(diagnostics);
@@ -918,6 +925,7 @@ test "app_bootstrap_runtime transfers startup state and starts a fresh session" 
     try std.testing.expect(!app.auto_upgrade_enabled);
     try std.testing.expectEqual(types.ReasoningEffort.literal("high"), app.effort);
     try std.testing.expectEqual(sandbox.BackendKind.none, app.permission_state.sandbox_backend);
+    try std.testing.expect(app.workspace_identity.enabled);
     try std.testing.expectEqualStrings("/skills", app.skills.dir);
     try std.testing.expectEqualStrings("welcome\n", app.transcript.items);
     try std.testing.expect(app.transcript_recorded);

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -3165,74 +3165,89 @@ fn handleRenameCommand(app: anytype, rest: []const u8) !void {
     try app.writeDomainNotice(.{ .topic = "session", .tone = .neutral, .body = msg }, true);
 }
 
-fn handleStatuslineCommand(app: anytype, rest: []const u8) !void {
-    const trimmed = std.mem.trim(u8, rest, " \t");
+const StatuslineFeedback = enum { announce, silent };
 
-    if (std.mem.eql(u8, trimmed, "sandbox")) {
-        app.statusline_sandbox = !app.statusline_sandbox;
-        const label: []const u8 = if (app.statusline_sandbox) "on" else "off";
-        persistStatuslineSetting(app, "sandbox", app.statusline_sandbox) catch |err| {
-            const notice = try std.fmt.allocPrint(
-                app.alloc,
-                "sandbox active for this process but not saved to user settings ({s})",
-                .{@errorName(err)},
-            );
-            defer app.alloc.free(notice);
-            try app.writeDomainNotice(.{ .topic = "statusline", .tone = .warning, .body = notice }, true);
-        };
-        const msg = try std.fmt.allocPrint(app.alloc, "sandbox: {s}", .{label});
-        defer app.alloc.free(msg);
-        try app.writeDomainNotice(.{ .topic = "statusline", .tone = .neutral, .body = msg }, true);
-        return;
+fn parseStatuslineItem(raw: []const u8) ?config_runtime.StatuslineItem {
+    const trimmed = std.mem.trim(u8, raw, " \t");
+    inline for (std.meta.fields(config_runtime.StatuslineItem)) |field| {
+        if (std.mem.eql(u8, trimmed, field.name)) return @enumFromInt(field.value);
     }
-
-    if (std.mem.eql(u8, trimmed, "context")) {
-        app.statusline_context = !app.statusline_context;
-        const label: []const u8 = if (app.statusline_context) "on" else "off";
-        persistStatuslineSetting(app, "context", app.statusline_context) catch |err| {
-            const notice = try std.fmt.allocPrint(
-                app.alloc,
-                "context active for this process but not saved to user settings ({s})",
-                .{@errorName(err)},
-            );
-            defer app.alloc.free(notice);
-            try app.writeDomainNotice(.{ .topic = "statusline", .tone = .warning, .body = notice }, true);
-        };
-        const msg = try std.fmt.allocPrint(app.alloc, "context: {s}", .{label});
-        defer app.alloc.free(msg);
-        try app.writeDomainNotice(.{ .topic = "statusline", .tone = .neutral, .body = msg }, true);
-        return;
-    }
-
-    if (std.mem.eql(u8, trimmed, "session")) {
-        app.statusline_session = !app.statusline_session;
-        const label: []const u8 = if (app.statusline_session) "on" else "off";
-        persistStatuslineSetting(app, "session", app.statusline_session) catch |err| {
-            const notice = try std.fmt.allocPrint(
-                app.alloc,
-                "session active for this process but not saved to user settings ({s})",
-                .{@errorName(err)},
-            );
-            defer app.alloc.free(notice);
-            try app.writeDomainNotice(.{ .topic = "statusline", .tone = .warning, .body = notice }, true);
-        };
-        const msg = try std.fmt.allocPrint(app.alloc, "session: {s}", .{label});
-        defer app.alloc.free(msg);
-        try app.writeDomainNotice(.{ .topic = "statusline", .tone = .neutral, .body = msg }, true);
-        return;
-    }
-
-    try app.writeDomainNotice(.{ .topic = "statusline", .tone = .@"error", .body = "Use: sandbox, context, session" }, true);
+    return null;
 }
 
-fn persistStatuslineSetting(app: anytype, key: []const u8, value: bool) !void {
-    const item: config_runtime.UserSettingsPatch = if (std.mem.eql(u8, key, "sandbox"))
-        .{ .statusline_item = .{ .item = .sandbox, .enabled = value } }
-    else if (std.mem.eql(u8, key, "session"))
-        .{ .statusline_item = .{ .item = .session, .enabled = value } }
-    else
-        .{ .statusline_item = .{ .item = .context, .enabled = value } };
-    try persistUserPreferences(app, "statusline", item, true);
+fn statuslineItemForSetting(setting: settings_catalog.SettingId) ?config_runtime.StatuslineItem {
+    return switch (setting) {
+        .statusline_sandbox => .sandbox,
+        .statusline_context => .context,
+        .statusline_session => .session,
+        .statusline_workspace => .workspace,
+        else => null,
+    };
+}
+
+fn statuslineItemEnabled(app: anytype, item: config_runtime.StatuslineItem) bool {
+    const App = @TypeOf(app.*);
+    return switch (item) {
+        .sandbox => app.statusline_sandbox,
+        .context => app.statusline_context,
+        .session => app.statusline_session,
+        .workspace => if (comptime @hasField(App, "workspace_identity"))
+            app.workspace_identity.enabled
+        else
+            false,
+    };
+}
+
+fn assignStatuslineItem(app: anytype, item: config_runtime.StatuslineItem, enabled: bool) bool {
+    const App = @TypeOf(app.*);
+    const current = statuslineItemEnabled(app, item);
+    switch (item) {
+        .sandbox => app.statusline_sandbox = enabled,
+        .context => app.statusline_context = enabled,
+        .session => app.statusline_session = enabled,
+        .workspace => if (comptime @hasField(App, "workspace_identity")) {
+            app.workspace_identity.enabled = enabled;
+        },
+    }
+    return current != enabled;
+}
+
+fn applyStatuslineItem(
+    app: anytype,
+    item: config_runtime.StatuslineItem,
+    enabled: bool,
+    feedback: StatuslineFeedback,
+) !void {
+    const runtime_changed = assignStatuslineItem(app, item, enabled);
+    const patch: config_runtime.UserSettingsPatch = .{
+        .statusline_item = .{ .item = item, .enabled = enabled },
+    };
+    switch (feedback) {
+        .announce => {
+            try persistUserPreferences(app, "statusline", patch, runtime_changed);
+            const message = try std.fmt.allocPrint(
+                app.alloc,
+                "{s}: {s}",
+                .{ @tagName(item), if (enabled) "on" else "off" },
+            );
+            defer app.alloc.free(message);
+            try app.writeDomainNotice(.{ .topic = "statusline", .tone = .neutral, .body = message }, true);
+        },
+        .silent => try persistUserPreferencesSilently(app, "statusline", patch, runtime_changed),
+    }
+    app.shell.render_requests.request(.footer);
+}
+
+fn handleStatuslineCommand(app: anytype, rest: []const u8) !void {
+    const item = parseStatuslineItem(rest) orelse {
+        try app.writeDomainNotice(.{
+            .topic = "statusline",
+            .tone = .@"error",
+            .body = "Use: sandbox, context, session, workspace",
+        }, true);
+        return;
+    };
+    try applyStatuslineItem(app, item, !statuslineItemEnabled(app, item), .announce);
 }
 
 const SoundLevel = enum {
@@ -3350,6 +3365,7 @@ pub fn settingsCatalogSnapshot(app: anytype) settings_catalog.Snapshot {
     if (comptime @hasField(App, "statusline_sandbox")) snapshot.statusline_sandbox = app.statusline_sandbox;
     if (comptime @hasField(App, "statusline_context")) snapshot.statusline_context = app.statusline_context;
     if (comptime @hasField(App, "statusline_session")) snapshot.statusline_session = app.statusline_session;
+    if (comptime @hasField(App, "workspace_identity")) snapshot.statusline_workspace = app.workspace_identity.enabled;
     if (comptime @hasField(App, "prompt_history")) snapshot.prompt_history = app.prompt_history.enabled;
     if (comptime @hasDecl(App, "notificationPreferences")) {
         const notifications = app.notificationPreferences();
@@ -3394,33 +3410,14 @@ pub fn applySettingsCatalogMenuChange(app: anytype, change: settings_catalog.Cha
                 runtime_changed,
             );
         },
-        .statusline_sandbox, .statusline_context, .statusline_session => {
+        .statusline_sandbox, .statusline_context, .statusline_session, .statusline_workspace => {
             const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;
-            const runtime_changed = switch (change.setting) {
-                .statusline_sandbox => blk: {
-                    const changed = enabled != app.statusline_sandbox;
-                    app.statusline_sandbox = enabled;
-                    break :blk changed;
-                },
-                .statusline_context => blk: {
-                    const changed = enabled != app.statusline_context;
-                    app.statusline_context = enabled;
-                    break :blk changed;
-                },
-                .statusline_session => blk: {
-                    const changed = enabled != app.statusline_session;
-                    app.statusline_session = enabled;
-                    break :blk changed;
-                },
-                else => unreachable,
-            };
-            const item: config_runtime.UserSettingsPatch = switch (change.setting) {
-                .statusline_sandbox => .{ .statusline_item = .{ .item = .sandbox, .enabled = enabled } },
-                .statusline_context => .{ .statusline_item = .{ .item = .context, .enabled = enabled } },
-                .statusline_session => .{ .statusline_item = .{ .item = .session, .enabled = enabled } },
-                else => unreachable,
-            };
-            try persistUserPreferencesSilently(app, "statusline", item, runtime_changed);
+            try applyStatuslineItem(
+                app,
+                statuslineItemForSetting(change.setting).?,
+                enabled,
+                .silent,
+            );
         },
         .sandbox => {
             const mode = sandbox.PublicMode.parse(change.value) orelse return error.InvalidSettingsCatalogValue;
@@ -3472,17 +3469,12 @@ pub fn applySettingsCatalogChange(app: anytype, change: settings_catalog.Change)
         .model => unreachable,
         .input_appearance => try handleInputAppearanceCommand(app, change.value),
         .maxxing_mode => try handleMaxxingCommand(app, change.value),
-        .statusline_sandbox => {
+        .statusline_sandbox, .statusline_context, .statusline_session, .statusline_workspace => {
             const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;
-            if (enabled != app.statusline_sandbox) try handleStatuslineCommand(app, "sandbox");
-        },
-        .statusline_context => {
-            const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;
-            if (enabled != app.statusline_context) try handleStatuslineCommand(app, "context");
-        },
-        .statusline_session => {
-            const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;
-            if (enabled != app.statusline_session) try handleStatuslineCommand(app, "session");
+            const item = statuslineItemForSetting(change.setting).?;
+            if (enabled != statuslineItemEnabled(app, item)) {
+                try applyStatuslineItem(app, item, enabled, .announce);
+            }
         },
         .slash_menu_categories => {
             const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -147,6 +147,7 @@ pub const StartupState = struct {
     statusline_sandbox: bool = false,
     statusline_context: bool = false,
     statusline_session: bool = false,
+    statusline_workspace: bool = false,
     notification_turn_end: bool = false,
     notification_attention_required: bool = false,
     notification_max: bool = false,
@@ -423,6 +424,7 @@ fn loadStartupStateFromOwnedWorkspace(
     state.statusline_sandbox = settings.statusline_sandbox orelse false;
     state.statusline_context = settings.statusline_context orelse false;
     state.statusline_session = settings.statusline_session orelse false;
+    state.statusline_workspace = settings.statusline_workspace orelse false;
     const sound_override = soundEnvOverride();
     const sound_on_override: ?bool = if (sound_override) |level| level != .off else null;
     const max_override: ?bool = if (sound_override) |level| level == .max else null;

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -58,6 +58,7 @@ pub const Settings = struct {
     statusline_sandbox: ?bool = null,
     statusline_context: ?bool = null,
     statusline_session: ?bool = null,
+    statusline_workspace: ?bool = null,
     notification_turn_end: ?bool = null,
     notification_attention_required: ?bool = null,
     notification_max: ?bool = null,
@@ -626,7 +627,13 @@ fn mergeDetailedSettingsLayer(
     source: ConfigSource,
     permission_source: DetailedPermissionSource,
 ) !void {
-    if (parseSettingsValueForLayer(alloc, value, settings_layer, tolerate_non_object_user_containers)) |layer_settings| {
+    if (parseSettingsValueForLayer(
+        alloc,
+        value,
+        settings_layer,
+        tolerate_non_object_user_containers,
+        source != .user_workspace,
+    )) |layer_settings| {
         var incoming = layer_settings;
         defer incoming.deinit(alloc);
         incoming.context_limits.retag(switch (source) {
@@ -634,7 +641,9 @@ fn mergeDetailedSettingsLayer(
             .user_workspace => .user_workspace,
             else => .compiled_default,
         });
-        if (source == .user_workspace) incoming.update_channel = null;
+        if (source == .user_workspace) {
+            incoming.update_channel = null;
+        }
         updateConfigSources(state.sources, incoming, source);
         if (incoming.has_permission_rules) {
             switch (permission_source) {
@@ -742,6 +751,7 @@ pub fn userSettingsPath(alloc: Allocator) !?[]u8 {
 pub const AllowlistResetScope = settings_store.AllowlistResetScope;
 pub const PermissionMutation = settings_store.PermissionMutation;
 pub const PermissionScope = settings_store.PermissionScope;
+pub const StatuslineItem = settings_store.StatuslineItem;
 pub const UserSettingsPatch = settings_store.UserSettingsPatch;
 pub const WorkspaceDirectoryMutation = settings_store.WorkspaceDirectoryMutation;
 pub const WorkspaceSettingsPatch = settings_store.WorkspaceSettingsPatch;
@@ -929,7 +939,7 @@ pub fn loadMergedSettingsFromPaths(alloc: Allocator, paths: Paths) !Settings {
 
         try mergeSettingsFile(&settings, alloc, paths.workspace_settings);
 
-        var user_settings = try parseSettingsValueForLayer(alloc, parsed.value, .profile, false);
+        var user_settings = try parseSettingsValueForLayer(alloc, parsed.value, .profile, false, true);
         defer user_settings.deinit(alloc);
         user_settings.context_limits.retag(.user_global);
         mergeSettings(&settings, &user_settings, alloc);
@@ -1036,7 +1046,7 @@ fn mergeWorkspaceOverridesFromValue(target: *Settings, alloc: Allocator, root_va
     const override_val = workspaces_val.object.get(workspace_root) orelse return;
     if (override_val != .object) return;
 
-    var override_settings = try parseSettingsValueForLayer(alloc, override_val, .profile, true);
+    var override_settings = try parseSettingsValueForLayer(alloc, override_val, .profile, true, false);
     defer override_settings.deinit(alloc);
     override_settings.update_channel = null;
     override_settings.context_limits.retag(.user_workspace);
@@ -1075,7 +1085,7 @@ fn parseSettingsJson(alloc: Allocator, json_text: []const u8) !Settings {
 fn parseSettingsJsonForLayer(alloc: Allocator, json_text: []const u8, layer: SettingsLayer) !Settings {
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json_text, .{});
     defer parsed.deinit();
-    return parseSettingsValueForLayer(alloc, parsed.value, layer, false);
+    return parseSettingsValueForLayer(alloc, parsed.value, layer, false, true);
 }
 
 const JsonStringToken = struct {
@@ -1283,13 +1293,20 @@ fn parseSettingsValueForLayer(
     root: std.json.Value,
     layer: SettingsLayer,
     tolerate_non_object_user_containers: bool,
+    parse_workspace_statusline: bool,
 ) !Settings {
     if (root != .object) return error.InvalidSettingsShape;
 
     var settings = Settings{};
     errdefer settings.deinit(alloc);
 
-    if (layer == .profile) try parseProfileOnlyFields(&settings, alloc, root, tolerate_non_object_user_containers);
+    if (layer == .profile) try parseProfileOnlyFields(
+        &settings,
+        alloc,
+        root,
+        tolerate_non_object_user_containers,
+        parse_workspace_statusline,
+    );
     try parseProjectSafeFields(&settings, alloc, root);
 
     return settings;
@@ -1300,6 +1317,7 @@ fn parseProfileOnlyFields(
     alloc: Allocator,
     root: std.json.Value,
     tolerate_non_object_user_containers: bool,
+    parse_workspace_statusline: bool,
 ) !void {
     if (root.object.contains("skill_match_fuzzy")) return error.RetiredSkillMatchFuzzy;
     if (root.object.get("model")) |model_value| {
@@ -1420,6 +1438,12 @@ fn parseProfileOnlyFields(
                 if (v != .bool) return error.InvalidStatusLineSessionType;
                 settings.statusline_session = v.bool;
             }
+            if (parse_workspace_statusline) {
+                if (value.object.get("workspace")) |v| {
+                    if (v != .bool) return error.InvalidStatusLineWorkspaceType;
+                    settings.statusline_workspace = v.bool;
+                }
+            }
         }
     }
 
@@ -1518,6 +1542,7 @@ fn mergeSettings(target: *Settings, incoming: *Settings, alloc: Allocator) void 
     if (incoming.statusline_sandbox) |value| target.statusline_sandbox = value;
     if (incoming.statusline_context) |value| target.statusline_context = value;
     if (incoming.statusline_session) |value| target.statusline_session = value;
+    if (incoming.statusline_workspace) |value| target.statusline_workspace = value;
     if (incoming.notification_turn_end) |value| target.notification_turn_end = value;
     if (incoming.notification_attention_required) |value| target.notification_attention_required = value;
     if (incoming.notification_max) |value| target.notification_max = value;
@@ -3100,12 +3125,12 @@ test "malformed project profile-only settings are ignored before value parsing" 
 test "global statusline fields parse and merge independently" {
     var target = try parseSettingsJson(
         std.testing.allocator,
-        "{\"statusLine\":{\"sandbox\":false,\"context\":true,\"session\":false}}",
+        "{\"statusLine\":{\"sandbox\":false,\"context\":true,\"session\":false,\"workspace\":false}}",
     );
     defer target.deinit(std.testing.allocator);
     var incoming = try parseSettingsJson(
         std.testing.allocator,
-        "{\"statusLine\":{\"session\":true}}",
+        "{\"statusLine\":{\"session\":true,\"workspace\":true}}",
     );
     defer incoming.deinit(std.testing.allocator);
 
@@ -3114,6 +3139,7 @@ test "global statusline fields parse and merge independently" {
     try std.testing.expectEqual(false, target.statusline_sandbox.?);
     try std.testing.expectEqual(true, target.statusline_context.?);
     try std.testing.expectEqual(true, target.statusline_session.?);
+    try std.testing.expectEqual(true, target.statusline_workspace.?);
 }
 
 test "global statusline rejects malformed containers and fields" {
@@ -3142,6 +3168,42 @@ test "global statusline rejects malformed containers and fields" {
             "{\"statusLine\":{\"session\":1}}",
         ),
     );
+    try std.testing.expectError(
+        error.InvalidStatusLineWorkspaceType,
+        parseSettingsJson(
+            std.testing.allocator,
+            "{\"statusLine\":{\"workspace\":1}}",
+        ),
+    );
+}
+
+test "workspace statusline is global only in ordinary and detailed loads" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+
+    const home_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "home");
+    defer std.testing.allocator.free(home_root);
+    const workspace_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "workspace");
+    defer std.testing.allocator.free(workspace_root);
+
+    const user_settings = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"statusLine\":{{\"workspace\":true}},\"workspaces\":{{\"{s}\":{{\"statusLine\":{{\"workspace\":\"ignored\"}}}}}}}}\n",
+        .{workspace_root},
+    );
+    defer std.testing.allocator.free(user_settings);
+    try writeFixtureFile(tmp.dir, "home/.fx/settings.json", user_settings);
+
+    var ordinary = try loadMergedSettingsFromHome(std.testing.allocator, home_root, workspace_root);
+    defer ordinary.deinit(std.testing.allocator);
+    try std.testing.expectEqual(true, ordinary.statusline_workspace.?);
+
+    var detailed = try loadMergedSettingsDetailedFromHome(std.testing.allocator, home_root, workspace_root);
+    defer detailed.deinit(std.testing.allocator);
+    try std.testing.expectEqual(true, detailed.settings.statusline_workspace.?);
+    try std.testing.expectEqual(@as(usize, 0), detailed.diagnostics.len);
 }
 
 test "ordinary and detailed loads agree on workspace overrides with legacy statusline containers" {

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -29,6 +29,7 @@ pub const SettingId = enum {
     statusline_sandbox,
     statusline_context,
     statusline_session,
+    statusline_workspace,
     slash_menu_categories,
     model,
     effort,
@@ -59,6 +60,7 @@ pub const Snapshot = struct {
     statusline_sandbox: bool = false,
     statusline_context: bool = false,
     statusline_session: bool = false,
+    statusline_workspace: bool = false,
     slash_menu_categories: bool = true,
     startup_scrollback: bool = true,
     prompt_history: bool = true,
@@ -76,6 +78,7 @@ pub const Snapshot = struct {
             .statusline_sandbox => onOff(self.statusline_sandbox),
             .statusline_context => onOff(self.statusline_context),
             .statusline_session => onOff(self.statusline_session),
+            .statusline_workspace => onOff(self.statusline_workspace),
             .slash_menu_categories => onOff(self.slash_menu_categories),
             .startup_scrollback => onOff(self.startup_scrollback),
             .prompt_history => onOff(self.prompt_history),
@@ -237,6 +240,11 @@ const statusline_choices = [_]StatuslineChoice{
         .label = "Session",
         .description = "Show the current session title",
         .setting = .statusline_session,
+    },
+    .{
+        .label = "Workspace",
+        .description = "Show the workspace path and Git branch",
+        .setting = .statusline_workspace,
     },
 };
 
@@ -436,6 +444,7 @@ const specs = [_]Spec{
     .{ .id = .statusline_sandbox, .category = .interface, .label = "Status line sandbox", .description = "Show the active sandbox in the status line" },
     .{ .id = .statusline_context, .category = .interface, .label = "Status line context", .description = "Show context usage in the status line" },
     .{ .id = .statusline_session, .category = .interface, .label = "Status line session", .description = "Show the session title in the status line" },
+    .{ .id = .statusline_workspace, .category = .interface, .label = "Status line workspace", .description = "Show the workspace path and Git branch in the status line" },
     .{ .id = .slash_menu_categories, .category = .interface, .label = "Slash menu categories", .description = "Show categories and skill sources in slash-command results" },
     .{ .id = .model, .category = .agent, .label = "Model", .description = "Choose the model used for new turns" },
     .{ .id = .effort, .category = .agent, .label = "Reasoning effort", .description = "Control how much reasoning the model applies" },
@@ -557,6 +566,7 @@ fn staticOptionsFor(id: SettingId) []const []const u8 {
         .statusline_sandbox,
         .statusline_context,
         .statusline_session,
+        .statusline_workspace,
         .slash_menu_categories,
         .startup_scrollback,
         .prompt_history,
@@ -616,14 +626,15 @@ test "settings catalog projects grouped searchable preferences" {
         .maxxing_mode = "minimal",
         .statusline_sandbox = false,
         .statusline_context = true,
+        .statusline_workspace = false,
         .startup_scrollback = true,
         .prompt_history = true,
         .sound_level = "on",
         .sandbox = "os",
     };
 
-    try std.testing.expectEqual(@as(usize, 14), filteredCount(snapshot, .all, ""));
-    try std.testing.expectEqual(@as(usize, 6), filteredCount(snapshot, .interface, ""));
+    try std.testing.expectEqual(@as(usize, 15), filteredCount(snapshot, .all, ""));
+    try std.testing.expectEqual(@as(usize, 7), filteredCount(snapshot, .interface, ""));
     try std.testing.expectEqual(@as(usize, 4), filteredCount(snapshot, .agent, ""));
     try std.testing.expectEqual(@as(usize, 1), filteredCount(snapshot, .notifications, ""));
     try std.testing.expectEqual(@as(usize, 3), filteredCount(snapshot, .advanced, ""));
@@ -789,6 +800,7 @@ test "status line menu describes toggle changes without performing effects" {
     const disabled: Snapshot = .{
         .statusline_sandbox = false,
         .statusline_context = false,
+        .statusline_workspace = false,
     };
     const enable_sandbox = menu.selectedChange(disabled).?;
     try std.testing.expectEqual(SettingId.statusline_sandbox, enable_sandbox.setting);
@@ -804,6 +816,11 @@ test "status line menu describes toggle changes without performing effects" {
     const enable_context = menu.selectedChange(enabled).?;
     try std.testing.expectEqual(SettingId.statusline_context, enable_context.setting);
     try std.testing.expectEqualStrings("on", enable_context.value);
+
+    try std.testing.expect(menu.move(2));
+    const enable_workspace = menu.selectedChange(enabled).?;
+    try std.testing.expectEqual(SettingId.statusline_workspace, enable_workspace.setting);
+    try std.testing.expectEqualStrings("on", enable_workspace.value);
 
     menu.close();
     try std.testing.expect(menu.selectedChange(enabled) == null);

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -34,6 +34,7 @@ pub const StatuslineItem = enum {
     sandbox,
     context,
     session,
+    workspace,
 };
 
 pub const StatuslineItemPatch = struct {
@@ -1127,18 +1128,22 @@ fn cleanupLegacyWorkspacePreferences(
             application,
         );
         if (patch.statusline_item) |item_patch| {
-            removeLegacyNestedLeaf(
-                &entry.value_ptr.object,
-                "statusLine",
-                @tagName(item_patch.item),
-                switch (item_patch.item) {
-                    .sandbox => .statusline_sandbox,
-                    .context => .statusline_context,
-                    .session => .statusline_session,
-                },
-                true,
-                application,
-            );
+            const legacy_field: ?UserPreferenceField = switch (item_patch.item) {
+                .sandbox => .statusline_sandbox,
+                .context => .statusline_context,
+                .session => .statusline_session,
+                .workspace => null,
+            };
+            if (legacy_field) |field| {
+                removeLegacyNestedLeaf(
+                    &entry.value_ptr.object,
+                    "statusLine",
+                    @tagName(item_patch.item),
+                    field,
+                    true,
+                    application,
+                );
+            }
         }
         if (application.legacy_fields_removed != removed_before) {
             application.legacy_workspaces_changed += 1;
@@ -1742,6 +1747,11 @@ fn validateKnownSettingsObject(
                     if (enabled != .bool) return error.InvalidSettingsFormat;
                 }
             }
+            if (!tolerate_non_object_user_containers) {
+                if (value.object.get("workspace")) |enabled| {
+                    if (enabled != .bool) return error.InvalidSettingsFormat;
+                }
+            }
         } else if (!tolerate_non_object_user_containers) {
             return error.InvalidSettingsFormat;
         }
@@ -1945,6 +1955,101 @@ test "user patch writes user preferences at top level" {
     try std.testing.expect(std.mem.find(u8, bytes, "\"notifications\":{\"turn_end\":true,\"attention_required\":false}") != null);
     try std.testing.expect(std.mem.find(u8, bytes, "\"future\":{\"nested\":7}") != null);
     try std.testing.expect(std.mem.find(u8, bytes, "\"workspaces\"") == null);
+}
+
+test "workspace statusline patch writes globally and preserves nested leaf" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try writeStoreFixture(
+        tmp.dir,
+        "home/.fx/settings.json",
+        "{\"statusLine\":{\"future\":7},\"workspaces\":{\"/workspace\":{\"statusLine\":{\"workspace\":false,\"future\":8}}}}\n",
+    );
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    var store = try Store.initFromHome(alloc, home, .writable);
+    defer store.deinit(alloc);
+
+    var outcome = try store.applyUserPatch(alloc, .{
+        .statusline_item = .{ .item = .workspace, .enabled = true },
+    });
+    defer outcome.deinit(alloc);
+
+    try std.testing.expect(outcome == .committed);
+    try std.testing.expectEqual(@as(usize, 0), outcome.committed.cleanup.fields_removed);
+    try std.testing.expectEqual(@as(usize, 0), outcome.committed.cleanup.recovery_paths.len);
+
+    const bytes = try store.readPrimaryForTest(alloc);
+    defer alloc.free(bytes);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+
+    const root_statusline = parsed.value.object.get("statusLine").?.object;
+    try std.testing.expectEqual(true, root_statusline.get("workspace").?.bool);
+    try std.testing.expectEqual(@as(i64, 7), root_statusline.get("future").?.integer);
+
+    const nested_statusline = parsed.value.object.get("workspaces").?.object
+        .get("/workspace").?.object.get("statusLine").?.object;
+    try std.testing.expectEqual(false, nested_statusline.get("workspace").?.bool);
+    try std.testing.expectEqual(@as(i64, 8), nested_statusline.get("future").?.integer);
+}
+
+test "durable validation rejects malformed workspace statusline" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try writeStoreFixture(
+        tmp.dir,
+        "home/.fx/settings.json",
+        "{\"statusLine\":{\"workspace\":\"yes\"}}\n",
+    );
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    var store = try Store.initFromHome(alloc, home, .writable);
+    defer store.deinit(alloc);
+
+    try std.testing.expectError(
+        error.InvalidSettingsFormat,
+        store.applyUserPatch(alloc, .{ .startup_scrollback = false }),
+    );
+}
+
+test "workspace patch ignores malformed nested workspace statusline" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try writeStoreFixture(
+        tmp.dir,
+        "home/.fx/settings.json",
+        "{\"workspaces\":{\"/workspace\":{\"statusLine\":{\"workspace\":\"ignored\"},\"future\":7}}}\n",
+    );
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    var store = try Store.initFromHome(alloc, home, .writable);
+    defer store.deinit(alloc);
+
+    var outcome = try store.applyWorkspacePatch(alloc, "/workspace", .{ .sandbox = "none" });
+    defer outcome.deinit(alloc);
+    try std.testing.expect(outcome == .committed);
+
+    const bytes = try store.readPrimaryForTest(alloc);
+    defer alloc.free(bytes);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    const workspace = parsed.value.object.get("workspaces").?.object.get("/workspace").?.object;
+    try std.testing.expectEqualStrings(
+        "ignored",
+        workspace.get("statusLine").?.object.get("workspace").?.string,
+    );
+    try std.testing.expectEqual(@as(i64, 7), workspace.get("future").?.integer);
+    try std.testing.expectEqualStrings("none", workspace.get("sandbox").?.string);
 }
 
 test "notification user patch preserves sibling fields and valid workspace overrides" {

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -176,17 +176,21 @@ fn appendShadowedUserSources(
     try appendShadowedUserSource(writer, "input_appearance", patch.input_appearance != null, sources.input_appearance, &wrote_header);
     try appendShadowedUserSource(writer, "prompt_history", patch.prompt_history_enabled != null, sources.prompt_history_enabled, &wrote_header);
     if (patch.statusline_item) |item| {
-        const source = switch (item.item) {
+        const source: ?config_runtime.ConfigSource = switch (item.item) {
             .sandbox => sources.statusline_sandbox,
             .context => sources.statusline_context,
             .session => sources.statusline_session,
+            .workspace => null,
         };
-        const field = switch (item.item) {
-            .sandbox => "statusLine.sandbox",
-            .context => "statusLine.context",
-            .session => "statusLine.session",
-        };
-        try appendShadowedUserSource(writer, field, true, source, &wrote_header);
+        if (source) |resolved| {
+            const field = switch (item.item) {
+                .sandbox => "statusLine.sandbox",
+                .context => "statusLine.context",
+                .session => "statusLine.session",
+                .workspace => unreachable,
+            };
+            try appendShadowedUserSource(writer, field, true, resolved, &wrote_header);
+        }
     }
     try appendShadowedUserSource(
         writer,

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -737,6 +737,7 @@ const statusline_arg_completions = [_][]const u8{
     "/statusline sandbox",
     "/statusline context",
     "/statusline session",
+    "/statusline workspace",
 };
 
 const notifications_arg_completions = [_][]const u8{

--- a/src/core/workspace/statusline_identity.zig
+++ b/src/core/workspace/statusline_identity.zig
@@ -38,6 +38,7 @@ const HeadPathResolution = union(enum) {
 /// terminal-safe strings, and repeated renders stat HEAD without rereading it
 /// unless its metadata changes.
 pub const Runtime = struct {
+    enabled: bool = false,
     workspace_root: []u8 = &.{},
     workspace_label: []u8 = &.{},
     head_path: []u8 = &.{},
@@ -64,6 +65,7 @@ pub const Runtime = struct {
         alloc: std.mem.Allocator,
         workspace_root: []const u8,
     ) !Snapshot {
+        if (!self.enabled) return .{};
         if (!std.mem.eql(u8, self.workspace_root, workspace_root)) {
             try self.rebuildWorkspace(alloc, workspace_root);
         }
@@ -297,7 +299,7 @@ test "workspace statusline identity refreshes branch and detached HEAD" {
 
     const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
     defer alloc.free(root);
-    var runtime: Runtime = .{};
+    var runtime: Runtime = .{ .enabled = true };
     defer runtime.deinit(alloc);
 
     var snapshot = try runtime.refresh(alloc, root);
@@ -330,7 +332,7 @@ test "workspace statusline identity resolves worktree gitdir files" {
 
     const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
     defer alloc.free(root);
-    var runtime: Runtime = .{};
+    var runtime: Runtime = .{ .enabled = true };
     defer runtime.deinit(alloc);
 
     const snapshot = try runtime.refresh(alloc, root);
@@ -346,7 +348,7 @@ test "workspace statusline identity finds a repository above the working directo
 
     const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "repo/packages/app");
     defer alloc.free(root);
-    var runtime: Runtime = .{};
+    var runtime: Runtime = .{ .enabled = true };
     defer runtime.deinit(alloc);
 
     const snapshot = try runtime.refresh(alloc, root);
@@ -371,7 +373,7 @@ test "workspace statusline identity handles non-git and hostile paths" {
         "unsafe-\x1b[31m-workspace",
     );
     defer alloc.free(root);
-    var runtime: Runtime = .{};
+    var runtime: Runtime = .{ .enabled = true };
     defer runtime.deinit(alloc);
 
     const snapshot = try runtime.refresh(alloc, root);
@@ -388,7 +390,7 @@ test "workspace statusline identity rejects malformed detached HEAD" {
 
     const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
     defer alloc.free(root);
-    var runtime: Runtime = .{};
+    var runtime: Runtime = .{ .enabled = true };
     defer runtime.deinit(alloc);
 
     const snapshot = try runtime.refresh(alloc, root);
@@ -397,9 +399,36 @@ test "workspace statusline identity rejects malformed detached HEAD" {
 
 test "workspace statusline identity represents the filesystem root" {
     const alloc = std.testing.allocator;
-    var runtime: Runtime = .{};
+    var runtime: Runtime = .{ .enabled = true };
     defer runtime.deinit(alloc);
 
     const snapshot = try runtime.refresh(alloc, std.fs.path.sep_str);
     try std.testing.expectEqualStrings(std.fs.path.sep_str, snapshot.workspace_label);
+}
+
+test "workspace statusline disabled refresh preserves cached identity" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestFile(tmp.dir, "workspace/.git/HEAD", "ref: refs/heads/main\n");
+
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(root);
+    var runtime: Runtime = .{ .enabled = true };
+    defer runtime.deinit(alloc);
+
+    const initial = try runtime.refresh(alloc, root);
+    try std.testing.expectEqualStrings("main", initial.git_branch.?);
+
+    runtime.enabled = false;
+    try writeTestFile(tmp.dir, "workspace/.git/HEAD", "ref: refs/heads/changed-while-disabled\n");
+    const disabled = try runtime.refresh(alloc, root);
+    try std.testing.expectEqualStrings("", disabled.workspace_label);
+    try std.testing.expect(disabled.git_branch == null);
+    try std.testing.expectEqualStrings(root, runtime.workspace_root);
+    try std.testing.expectEqualStrings("main", runtime.branch_label);
+
+    runtime.enabled = true;
+    const reenabled = try runtime.refresh(alloc, root);
+    try std.testing.expectEqualStrings("changed-while-disabled", reenabled.git_branch.?);
 }

--- a/src/ui/footer/compact_command_menu_presentation.zig
+++ b/src/ui/footer/compact_command_menu_presentation.zig
@@ -818,6 +818,7 @@ test "compact status line menu renders toggled items without choose copy" {
             .statusline_sandbox = true,
             .statusline_context = false,
             .statusline_session = true,
+            .statusline_workspace = false,
         },
     } };
 
@@ -838,6 +839,11 @@ test "compact status line menu renders toggled items without choose copy" {
     try std.testing.expect(std.mem.find(u8, sandbox.items, "Sandbox") != null);
     try std.testing.expect(std.mem.find(u8, sandbox.items, "on") != null);
     try std.testing.expect(std.mem.find(u8, sandbox.items, "❯") == null);
+
+    var workspace = try composeCompactCommandMenuRow(std.testing.allocator, projection, 5, rows, 80);
+    defer workspace.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.find(u8, workspace.items, "Workspace") != null);
+    try std.testing.expect(std.mem.find(u8, workspace.items, "off") != null);
 
     var context = try composeCompactCommandMenuRow(std.testing.allocator, projection, 3, rows, 80);
     defer context.deinit(std.testing.allocator);

--- a/src/ui/footer/settings_menu_presentation.zig
+++ b/src/ui/footer/settings_menu_presentation.zig
@@ -369,6 +369,7 @@ const test_snapshot: settings_catalog.Snapshot = .{
     .statusline_sandbox = false,
     .statusline_context = true,
     .statusline_session = false,
+    .statusline_workspace = false,
     .startup_scrollback = true,
     .prompt_history = true,
     .sound_level = "on",
@@ -382,7 +383,7 @@ test "settings menu renders each setting on one row at wide and narrow widths" {
         .snapshot = test_snapshot,
     };
     const wide_rows = menuRowCount(projection, 100, 40);
-    try std.testing.expectEqual(@as(u16, 23), wide_rows);
+    try std.testing.expectEqual(@as(u16, 24), wide_rows);
 
     var header = try composeSettingsMenuRow(alloc, projection, 0, 100, wide_rows);
     defer header.deinit(alloc);
@@ -407,7 +408,7 @@ test "settings menu renders each setting on one row at wide and narrow widths" {
     try std.testing.expect(std.mem.find(u8, compact_item.items, "tint") != null);
 
     const narrow_rows = menuRowCount(projection, 24, 40);
-    try std.testing.expectEqual(@as(u16, 23), narrow_rows);
+    try std.testing.expectEqual(@as(u16, 24), narrow_rows);
     var narrow_item = try composeSettingsMenuRow(alloc, projection, 3, 24, narrow_rows);
     defer narrow_item.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow_item.items, "Input appeara") != null);
@@ -424,7 +425,7 @@ test "settings menu values form a centered left aligned block" {
 
     var short = try composeSettingsMenuRow(alloc, projection, 3, 100, rows);
     defer short.deinit(alloc);
-    var long = try composeSettingsMenuRow(alloc, projection, 11, 100, rows);
+    var long = try composeSettingsMenuRow(alloc, projection, 12, 100, rows);
     defer long.deinit(alloc);
 
     const short_start = std.mem.find(u8, short.items, "lines").?;

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -64,7 +64,7 @@ async function disablePromptHistory(
 ): Promise<void> {
   await session.sendText("/settings");
   await session.waitForText("←→ Change", TIMEOUT);
-  for (let index = 0; index < 13; index += 1) {
+  for (let index = 0; index < 14; index += 1) {
     await session.sendKeys("Down");
   }
   await session.sendKeys("Left");
@@ -238,6 +238,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
                   sandbox: false,
                   context: false,
                   session: false,
+                  workspace: false,
                   future: "keep-a-status",
                 },
                 future_workspace: { nested: "a" },
@@ -253,6 +254,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
                   sandbox: false,
                   context: false,
                   session: false,
+                  workspace: false,
                   future: "keep-b-status",
                 },
                 future_workspace: { nested: "b" },
@@ -292,6 +294,8 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         await session.waitForText("● Statusline: context:", TIMEOUT);
         await session.sendText("/statusline session");
         await session.waitForText("● Statusline: session:", TIMEOUT);
+        await session.sendText("/statusline workspace");
+        await session.waitForText("● Statusline: workspace:", TIMEOUT);
         await session.sendText("/settings startup-scrollback off");
         await session.waitForText("startup_scrollback: off", TIMEOUT);
         await disablePromptHistory(session, join(home, ".fx", "settings.json"));
@@ -310,6 +314,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
           sandbox: true,
           context: true,
           session: true,
+          workspace: true,
         });
         expect(stored.future_global).toEqual({ nested: "preserve-me" });
         for (const [workspaceRoot, futureWorkspace, historyFuture, statusFuture] of [
@@ -323,7 +328,7 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
           expect(override).not.toHaveProperty("fast_mode");
           expect(override).not.toHaveProperty("startup_scrollback");
           expect(override.prompt_history).toEqual({ future: historyFuture });
-          expect(override.statusLine).toEqual({ future: statusFuture });
+          expect(override.statusLine).toEqual({ workspace: false, future: statusFuture });
           expect(override.future_workspace).toEqual({ nested: futureWorkspace });
         }
         expect(readFileSync(join(workspaceA, ".fx.json"), "utf8")).toBe(projectABytes);
@@ -1408,6 +1413,50 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
         expect(statSync(join(home, ".fx", "history.lock")).mode & 0o777).toBe(0o600);
         expect(statSync(join(home, ".fx", "settings.json")).mode & 0o777).toBe(0o600);
         expect(statSync(join(home, ".fx", "settings.lock")).mode & 0o777).toBe(0o600);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
+
+  serialTest(
+    "workspace statusline stays active when user settings cannot be saved",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-statusline-write-failure-"));
+      try {
+        const home = join(root, "home");
+        const workspace = join(root, "workspace-write-failure-visible");
+        const settingsPath = join(home, ".fx", "settings.json");
+        const externalSettings = join(root, "external-settings.json");
+        const stderrPath = join(root, "stderr.log");
+        mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+        mkdirSync(workspace);
+        writeFileSync(settingsPath, '{"statusLine":{"workspace":false}}\n', { mode: 0o600 });
+        writeFileSync(externalSettings, '{"statusLine":{"workspace":false}}\n', { mode: 0o600 });
+
+        session = await TmuxSession.create({
+          cwd: realpathSync(workspace),
+          env: { ...NO_AUTH, HOME: home },
+          stderrPath,
+        });
+        await session.waitForText("Run /help", TIMEOUT);
+        expect(await session.capturePane()).not.toContain("workspace-write-failure-visible");
+
+        rmSync(settingsPath);
+        symlinkSync(externalSettings, settingsPath);
+        await session.sendText("/statusline workspace");
+        await session.waitForText("active for this process but not saved to user settings", TIMEOUT);
+        await session.waitForPane(
+          (pane) => pane.includes("workspace-write-failure-visible"),
+          TIMEOUT,
+        );
+        expect(JSON.parse(readFileSync(externalSettings, "utf8")).statusLine.workspace).toBe(false);
+
+        await session.sendText("/quit");
+        await session.waitForSessionEnd(TIMEOUT);
+        session = null;
         expect(readFileSync(stderrPath, "utf8")).toBe("");
       } finally {
         rmSync(root, { recursive: true, force: true });

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -3924,7 +3924,7 @@ describe("modern MCP stdio compatibility", () => {
         "retry_attempt=0",
         "discovery=completed",
       ]) expect(pane).toContain(expected);
-      expect(pane).toContain(root.workspace);
+      expect(pane).not.toContain(root.workspace);
       for (const forbidden of [
         "captured_at_ms=",
         "runtime_generation=",

--- a/tests/e2e/prompt-history.test.ts
+++ b/tests/e2e/prompt-history.test.ts
@@ -52,7 +52,7 @@ async function disablePromptHistory(
 ): Promise<void> {
   await session.sendText("/settings");
   await session.waitForText("←→ Change", TIMEOUT);
-  for (let index = 0; index < 13; index += 1) {
+  for (let index = 0; index < 14; index += 1) {
     await session.sendKeys("Down");
   }
   await session.sendKeys("Left");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -162,6 +162,25 @@ async function waitForSettingValue(
   );
 }
 
+async function waitForStatuslineValue(
+  settingsPath: string,
+  key: string,
+  expected: boolean,
+): Promise<void> {
+  const deadline = Date.now() + TIMEOUT;
+  let latest: unknown;
+  while (Date.now() < deadline) {
+    if (existsSync(settingsPath)) {
+      latest = JSON.parse(readFileSync(settingsPath, "utf8")).statusLine?.[key];
+      if (latest === expected) return;
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(
+    `Timed out waiting for statusLine.${key}=${expected}; last=${JSON.stringify(latest)}`,
+  );
+}
+
 async function waitForAppearanceMenu(
   session: TmuxSession,
   expectedSelection?: string,
@@ -1113,7 +1132,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       let grid = await waitForSettingsMenu(session);
       expect(grid.join("\n")).toContain("Slash menu categories");
 
-      for (let index = 0; index < 5; index += 1) {
+      for (let index = 0; index < 6; index += 1) {
         await session.sendKeys("Down");
       }
       await session.sendKeys("Left");
@@ -1444,11 +1463,17 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-settings-menu-")));
       workDirs.push(root);
       const home = join(root, "home");
-      const workspace = join(root, "workspace");
+      const workspace = join(root, "workspace-statusline-visible");
       const settingsPath = join(home, ".fx", "settings.json");
       mkdirSync(join(home, ".fx"), { recursive: true });
       mkdirSync(workspace, { recursive: true });
-      writeFileSync(settingsPath, `${JSON.stringify({ input_appearance: "tint" })}\n`);
+      writeFileSync(
+        settingsPath,
+        `${JSON.stringify({
+          input_appearance: "tint",
+          statusLine: { workspace: false },
+        })}\n`,
+      );
 
       session = await TmuxSession.create({
         cwd: workspace,
@@ -1488,11 +1513,17 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("Left");
       await waitForSettingValue(settingsPath, "maxxing_mode", "legacy");
 
+      for (let index = 0; index < 4; index += 1) await session.sendKeys("Down");
+      await session.waitForText(/Status line workspace\s+off/, 5_000);
+      await session.sendKeys("Right");
+      await waitForStatuslineValue(settingsPath, "workspace", true);
+
       await session.sendKeys("Escape");
-      await session.waitForPane(
+      pane = await session.waitForPane(
         (current) =>
           hasEmptyComposer(current) &&
           current.includes("𝒇x") &&
+          current.includes("workspace-statusline-visible") &&
           !current.includes("←→ Change"),
         5_000,
       );
@@ -1655,14 +1686,14 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-statusline-menu-")));
       workDirs.push(root);
       const home = join(root, "home");
-      const workspace = join(root, "workspace");
+      const workspace = join(root, "compact-statusline-workspace");
       const settingsPath = join(home, ".fx", "settings.json");
       mkdirSync(join(home, ".fx"), { recursive: true });
       mkdirSync(workspace, { recursive: true });
       writeFileSync(
         settingsPath,
         `${JSON.stringify({
-          statusLine: { sandbox: false, context: false },
+          statusLine: { sandbox: false, context: false, workspace: false },
         })}\n`,
       );
 
@@ -1684,6 +1715,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       let pane = grid.join("\n");
       expect(pane).toContain("Sandbox");
       expect(pane).toContain("Context");
+      expect(pane).toContain("Workspace");
       expect(pane).toContain("off  on");
       expect(pane).not.toContain("❯");
       expect(pane).not.toContain("Choose what appears");
@@ -1703,15 +1735,32 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       expect(pane).not.toContain("● Statusline:");
       expect(JSON.parse(readFileSync(settingsPath, "utf8")).statusLine.context).toBe(true);
 
+      await session.sendKeys("Down");
+      await session.sendKeys("Down");
+      await session.sendKeys("Right");
+      grid = await waitForStatuslineMenu(session, "Workspace");
+      pane = grid.join("\n");
+      expect(pane).not.toContain("saved to user settings");
+      await waitForStatuslineValue(settingsPath, "workspace", true);
+
       await session.sendKeys("Escape");
       await session.waitForPane(
         (current) =>
           hasEmptyComposer(current) &&
           current.includes("𝒇x") &&
+          current.includes("compact-statusline-workspace") &&
           !current.includes("←→ Change"),
         5_000,
       );
       expect(session.isAlive()).toBe(true);
+
+      await session.sendText("/statusline workspace");
+      await session.waitForText("● Statusline: workspace: off", 5_000);
+      await waitForStatuslineValue(settingsPath, "workspace", false);
+      await session.waitForPane(
+        (current) => hasEmptyComposer(current) && !current.includes("compact-statusline-workspace"),
+        5_000,
+      );
 
       await session.sendText("/quit");
       expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -63,6 +63,49 @@ describe.skipIf(SKIP)("tui: startup and exit", () => {
 
 describe.skipIf(SKIP_TMUX)("tui: fresh-session commands", () => {
   test(
+    "statusline hides the workspace identity by default",
+    async () => {
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-statusline-default-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace-default-hidden");
+      const stderrPath = join(root, "stderr.log");
+      mkdirSync(home, { recursive: true });
+      mkdirSync(join(workspace, ".git"), { recursive: true });
+      writeFileSync(join(workspace, ".git", "HEAD"), "ref: refs/heads/default-hidden-branch\n");
+      writeFileSync(stderrPath, "");
+
+      try {
+        session = await TmuxSession.create({
+          cwd: workspace,
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: undefined,
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_AUTO_UPGRADE: "0",
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_SKIP_ONBOARDING: "1",
+          },
+          stderrPath,
+          width: 100,
+          height: 30,
+        });
+
+        const pane = await session.waitForComposer(10_000);
+        expect(pane).not.toContain("workspace-default-hidden");
+        expect(pane).not.toContain("default-hidden-branch");
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+      } finally {
+        if (session) {
+          await session.kill();
+          session = null;
+        }
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "/help keeps command descriptions close after a wide-to-narrow resize",
     async () => {
       const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-help-columns-")));
@@ -128,10 +171,14 @@ describe.skipIf(SKIP_TMUX)("tui: fresh-session commands", () => {
       const workspace = join(repository, "packages", "status-root");
       const headPath = join(repository, ".git", "HEAD");
       const stderrPath = join(root, "stderr.log");
-      mkdirSync(home, { recursive: true });
+      mkdirSync(join(home, ".fx"), { recursive: true });
       mkdirSync(join(repository, ".git"), { recursive: true });
       mkdirSync(workspace, { recursive: true });
       writeFileSync(headPath, "ref: refs/heads/initial-branch\n");
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        `${JSON.stringify({ statusLine: { workspace: true } })}\n`,
+      );
       writeFileSync(stderrPath, "");
 
       try {


### PR DESCRIPTION
## Summary

- Hide the workspace path and Git branch from the status line by default.
- Let users enable workspace identity from `/settings`, `/statusline workspace`, or `statusLine.workspace`.
- Keep workspace-scoped copies of the new setting inert without deleting them.