### PR TITLE
Retire completed one-off subagent sessions

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -1118,12 +1118,16 @@ fn acknowledgeParentTurnContext(
 ) void {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     const subagent_host = ctx.state.subagent_host orelse return;
-    parent_delivery_projector.acknowledge(
+    const retirement_ready = parent_delivery_projector
+        .acknowledgeWithRetirementSignal(
         arena,
         subagent_host.sessions,
         subagent_host.manager.options.child_store,
         acknowledgements,
     );
+    if (retirement_ready) {
+        subagent_host.requestRetirementSweep(io_mod.milliTimestamp());
+    }
 }
 
 fn appendStaticContext(raw_ctx: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -579,12 +579,16 @@ pub fn Bindings(comptime App: type) type {
             const app: *App = @ptrCast(@alignCast(ctx));
             if (comptime @hasField(App, "session_persistence")) {
                 const host = app_session_runtime.Runtime(App).subagentHost(app) orelse return;
-                parent_delivery_projector.acknowledge(
+                const retirement_ready = parent_delivery_projector
+                    .acknowledgeWithRetirementSignal(
                     arena,
                     host.sessions,
                     host.manager.options.child_store,
                     acknowledgements,
                 );
+                if (retirement_ready) {
+                    host.requestRetirementSweep(io_mod.milliTimestamp());
+                }
             }
         }
 

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -368,6 +368,7 @@ pub const SessionPicker = struct {
     has_more: bool = false,
     loading_more: bool = false,
     summaries: std.ArrayList(session_store.SessionSummary) = .empty,
+    continuation: ?subagent_resume_admission.ActionableContinuation = null,
     selected: usize = 0,
     window_start: usize = 0,
     scope: SessionPickerScope = .current_workspace,
@@ -378,6 +379,7 @@ pub const SessionPicker = struct {
     pub fn deinit(self: *SessionPicker, alloc: Allocator) void {
         for (self.summaries.items) |*summary| summary.deinit(alloc);
         self.summaries.deinit(alloc);
+        if (self.continuation) |*continuation| continuation.deinit(alloc);
         self.* = .{};
     }
 
@@ -491,7 +493,7 @@ const SessionPickerPageCache = struct {
     active_id: ?[]u8 = null,
     limit: usize = 0,
     loaded_at_ns: i128 = 0,
-    page: session_store.ResumableSessionPage = .{},
+    page: subagent_resume_admission.ActionableSessionPage = .{},
 
     fn deinit(self: *SessionPickerPageCache) void {
         const alloc = std.heap.c_allocator;
@@ -515,19 +517,32 @@ const SessionPickerPageCache = struct {
 
     fn install(
         self: *SessionPickerPageCache,
-        source: *const session_store.ResumableSessionPage,
+        source: *const subagent_resume_admission.ActionableSessionPage,
         active_id: ?[]const u8,
         limit: usize,
         loaded_at_ns: i128,
     ) !void {
         const alloc = std.heap.c_allocator;
+        var owned_active_id = if (active_id) |id| try alloc.dupe(u8, id) else null;
+        errdefer if (owned_active_id) |id| alloc.free(id);
+        var owned_continuation: ?subagent_resume_admission.ActionableContinuation =
+            if (source.continuation) |continuation| .{
+                .updated_at_ms = continuation.updated_at_ms,
+                .id = try alloc.dupe(u8, continuation.id),
+            } else null;
+        errdefer if (owned_continuation) |*continuation| continuation.deinit(alloc);
         var replacement: SessionPickerPageCache = .{
             .ready = true,
-            .active_id = if (active_id) |id| try alloc.dupe(u8, id) else null,
+            .active_id = owned_active_id,
             .limit = limit,
             .loaded_at_ns = loaded_at_ns,
-            .page = .{ .has_more = source.has_more },
+            .page = .{
+                .has_more = source.has_more,
+                .continuation = owned_continuation,
+            },
         };
+        owned_active_id = null;
+        owned_continuation = null;
         errdefer replacement.deinit();
         for (source.summaries.items) |summary| {
             var copied = try session_summary_codec.cloneSessionSummary(alloc, summary);
@@ -559,7 +574,7 @@ fn sessionPickerCacheForScope(
 fn replaceSessionPickerPage(
     picker: *SessionPicker,
     alloc: Allocator,
-    source: *const session_store.ResumableSessionPage,
+    source: *const subagent_resume_admission.ActionableSessionPage,
 ) !void {
     var replacement: std.ArrayList(session_store.SessionSummary) = .empty;
     errdefer {
@@ -648,7 +663,7 @@ const SessionPickerLoad = struct {
         home_dir: []u8,
         workspace_root: []u8,
         request: PageRequest,
-        page: ?session_store.ResumableSessionPage = null,
+        page: ?subagent_resume_admission.ActionableSessionPage = null,
         failure: ?anyerror = null,
 
         fn deinit(self: *Task) void {
@@ -923,13 +938,18 @@ fn tryListResumableIndexPageForScope(
     active_id: ?[]const u8,
     continuation: ?session_store.ResumableSessionContinuation,
     limit: usize,
-) !?session_store.ResumableSessionPage {
-    var scoped = store;
-    scoped.resume_page_limit = limit;
-    return switch (scope) {
-        .current_workspace => try scoped.tryListResumableWorkspaceIndexPage(alloc, active_id, continuation),
-        .all_workspaces => try scoped.tryListResumableIndexPage(alloc, active_id, continuation),
-    };
+) !?subagent_resume_admission.ActionableSessionPage {
+    return subagent_resume_admission.tryListActionableIndexPage(
+        store,
+        alloc,
+        switch (scope) {
+            .current_workspace => .current_workspace,
+            .all_workspaces => .all_workspaces,
+        },
+        active_id,
+        continuation,
+        limit,
+    );
 }
 
 fn listResumablePageForScope(
@@ -939,13 +959,18 @@ fn listResumablePageForScope(
     active_id: ?[]const u8,
     continuation: ?session_store.ResumableSessionContinuation,
     limit: usize,
-) !session_store.ResumableSessionPage {
-    var scoped = store;
-    scoped.resume_page_limit = limit;
-    return switch (scope) {
-        .current_workspace => try scoped.listResumableWorkspacePage(alloc, active_id, continuation),
-        .all_workspaces => try scoped.listResumablePage(alloc, active_id, continuation),
-    };
+) !subagent_resume_admission.ActionableSessionPage {
+    return subagent_resume_admission.listActionablePage(
+        store,
+        alloc,
+        switch (scope) {
+            .current_workspace => .current_workspace,
+            .all_workspaces => .all_workspaces,
+        },
+        active_id,
+        continuation,
+        limit,
+    );
 }
 
 const default_cancelled_command_replay_inline_limit: usize = 64 * 1024;
@@ -1996,6 +2021,13 @@ pub fn Runtime(comptime App: type) type {
             const now_ns = io_mod.nanoTimestamp();
             if (cache.matches(active_id, limit)) {
                 try replaceSessionPickerPage(picker, app.alloc, &cache.page);
+                const continuation: ?subagent_resume_admission.ActionableContinuation =
+                    if (cache.page.continuation) |value| .{
+                        .updated_at_ms = value.updated_at_ms,
+                        .id = try app.alloc.dupe(u8, value.id),
+                    } else null;
+                if (picker.continuation) |*prior| prior.deinit(app.alloc);
+                picker.continuation = continuation;
                 picker.has_more = cache.page.has_more;
                 picker.load_state = .ready;
                 cache_visible = true;
@@ -2184,8 +2216,17 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             picker: *SessionPicker,
             task: *const SessionPickerLoad.Task,
-            page: *const session_store.ResumableSessionPage,
+            page: *const subagent_resume_admission.ActionableSessionPage,
         ) !void {
+            var continuation: ?subagent_resume_admission.ActionableContinuation =
+                if (page.continuation) |value| .{
+                    .updated_at_ms = value.updated_at_ms,
+                    .id = try app.alloc.dupe(u8, value.id),
+                } else null;
+            errdefer if (continuation) |value| {
+                var owned = value;
+                owned.deinit(app.alloc);
+            };
             const selected_load_more = task.request.continuation != null and
                 picker.selected == picker.filteredItemCount();
             const previous_filtered_count = picker.filteredItemCount();
@@ -2194,6 +2235,9 @@ pub fn Runtime(comptime App: type) type {
             } else {
                 try picker.appendPage(app.alloc, page.summaries.items);
             }
+            if (picker.continuation) |*prior| prior.deinit(app.alloc);
+            picker.continuation = continuation;
+            continuation = null;
             picker.has_more = page.has_more;
             picker.loading_more = false;
             picker.load_state = .ready;
@@ -2221,7 +2265,8 @@ pub fn Runtime(comptime App: type) type {
                 value
             else
                 return error.SessionStoreUnavailable;
-            const last = picker.summaries.items[picker.summaries.items.len - 1];
+            const continuation = picker.continuation orelse
+                return error.SessionStoreUnavailable;
             const active_id = if (app.session_persistence.writable) |*loaded|
                 loaded.active_id
             else
@@ -2234,10 +2279,7 @@ pub fn Runtime(comptime App: type) type {
                 picker.generation,
                 picker.scope,
                 active_id,
-                .{
-                    .updated_at_ms = last.updated_at_ms,
-                    .id = last.id,
-                },
+                continuation.view(),
                 limit,
             );
 
@@ -9045,8 +9087,8 @@ test "session picker rejects a load more completion after switching to a fresh c
     try Runtime(TestApp).initializePersistence(&app, true);
     try Runtime(TestApp).beginFreshPersistedSession(&app);
 
-    const current_page: session_store.ResumableSessionPage = .{};
-    var all_page: session_store.ResumableSessionPage = .{ .has_more = true };
+    const current_page: subagent_resume_admission.ActionableSessionPage = .{};
+    var all_page: subagent_resume_admission.ActionableSessionPage = .{ .has_more = true };
     defer all_page.deinit(alloc);
     try all_page.summaries.append(alloc, .{
         .id = try alloc.dupe(u8, "foreign-session"),
@@ -9472,7 +9514,7 @@ test "session picker keeps stale cached rows ready when refresh fails" {
     try Runtime(TestApp).initializePersistence(&app, true);
     try Runtime(TestApp).beginFreshPersistedSession(&app);
 
-    var cached_page: session_store.ResumableSessionPage = .{};
+    var cached_page: subagent_resume_admission.ActionableSessionPage = .{};
     defer cached_page.deinit(alloc);
     try cached_page.summaries.append(alloc, .{
         .id = try alloc.dupe(u8, "cached-session"),

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1969,12 +1969,16 @@ fn acknowledgeParentTurnContext(
 ) void {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
     const subagent_host = ctx.subagent_host orelse return;
-    parent_delivery_projector.acknowledge(
+    const retirement_ready = parent_delivery_projector
+        .acknowledgeWithRetirementSignal(
         arena,
         subagent_host.sessions,
         subagent_host.manager.options.child_store,
         acknowledgements,
     );
+    if (retirement_ready) {
+        subagent_host.requestRetirementSweep(io_mod.milliTimestamp());
+    }
 }
 
 fn appendStaticContext(raw_ctx: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -853,15 +853,50 @@ pub const Store = struct {
         alloc: Allocator,
         loaded: *LoadedWritableSession,
     ) PristineDiscardDisposition {
-        defer loaded.deinit(alloc);
-        if (self.canonical_root.mode != .writable or
-            !std.mem.eql(u8, self.workspace_root, loaded.state.workspace_root) or
-            !isPristineStartedSession(loaded))
-        {
+        if (!isPristineStartedSession(loaded)) {
+            loaded.deinit(alloc);
             debug_trace.logf(
                 "session",
                 "event=pristine_session_discard disposition=retained reason=guard_failed",
                 .{},
+            );
+            return .retained;
+        }
+        return self.deleteWriterOwnedSession(
+            alloc,
+            loaded,
+            "pristine_session_discard",
+        );
+    }
+
+    /// Consumes an exact writable session on every return. Policy checks such
+    /// as terminal one-off admission remain with the caller that owns them.
+    pub fn deleteCommittedSession(
+        self: Store,
+        alloc: Allocator,
+        loaded: *LoadedWritableSession,
+    ) PristineDiscardDisposition {
+        return self.deleteWriterOwnedSession(
+            alloc,
+            loaded,
+            "committed_session_delete",
+        );
+    }
+
+    fn deleteWriterOwnedSession(
+        self: Store,
+        alloc: Allocator,
+        loaded: *LoadedWritableSession,
+        event_name: []const u8,
+    ) PristineDiscardDisposition {
+        defer loaded.deinit(alloc);
+        if (self.canonical_root.mode != .writable or
+            !std.mem.eql(u8, self.workspace_root, loaded.state.workspace_root))
+        {
+            debug_trace.logf(
+                "session",
+                "event={s} disposition=retained reason=guard_failed",
+                .{event_name},
             );
             return .retained;
         }
@@ -872,32 +907,32 @@ pub const Store = struct {
         ) catch |err| {
             debug_trace.logf(
                 "session",
-                "event=pristine_session_discard disposition=retained reason=store_root_unverified err={s}",
-                .{@errorName(err)},
+                "event={s} disposition=retained reason=store_root_unverified err={s}",
+                .{ event_name, @errorName(err) },
             );
             return .retained;
         };
         if (!writer_belongs_to_store) {
             debug_trace.logf(
                 "session",
-                "event=pristine_session_discard disposition=retained reason=store_root_mismatch",
-                .{},
+                "event={s} disposition=retained reason=store_root_mismatch",
+                .{event_name},
             );
             return .retained;
         }
         const lifecycle = if (loaded.commit_lifecycle) |*value| value else {
             debug_trace.logf(
                 "session",
-                "event=pristine_session_discard disposition=retained reason=cache_lifecycle_unavailable",
-                .{},
+                "event={s} disposition=retained reason=cache_lifecycle_unavailable",
+                .{event_name},
             );
             return .retained;
         };
         const sessions = &(self.canonical_root.sessions orelse {
             debug_trace.logf(
                 "session",
-                "event=pristine_session_discard disposition=indeterminate stage=sessions_root",
-                .{},
+                "event={s} disposition=indeterminate stage=sessions_root",
+                .{event_name},
             );
             return .indeterminate;
         });
@@ -911,24 +946,24 @@ pub const Store = struct {
         ) catch |err| {
             debug_trace.logf(
                 "session",
-                "event=pristine_session_discard disposition=indeterminate stage=cache_pending err={s}",
-                .{@errorName(err)},
+                "event={s} disposition=indeterminate stage=cache_pending err={s}",
+                .{ event_name, @errorName(err) },
             );
             return .indeterminate;
         };
         sessions.dir.deleteTree(io_mod.getIo(), loaded.active_id) catch |err| {
             debug_trace.logf(
                 "session",
-                "event=pristine_session_discard disposition=indeterminate stage=delete err={s}",
-                .{@errorName(err)},
+                "event={s} disposition=indeterminate stage=delete err={s}",
+                .{ event_name, @errorName(err) },
             );
             return .indeterminate;
         };
         io_mod.syncVerifiedDir(sessions.dir) catch |err| {
             debug_trace.logf(
                 "session",
-                "event=pristine_session_discard disposition=indeterminate stage=sync err={s}",
-                .{@errorName(err)},
+                "event={s} disposition=indeterminate stage=sync err={s}",
+                .{ event_name, @errorName(err) },
             );
             return .indeterminate;
         };
@@ -938,15 +973,15 @@ pub const Store = struct {
         ) catch |err| {
             debug_trace.logf(
                 "session",
-                "event=pristine_session_discard disposition=indeterminate stage=deferred_token_cleanup err={s}",
-                .{@errorName(err)},
+                "event={s} disposition=indeterminate stage=deferred_token_cleanup err={s}",
+                .{ event_name, @errorName(err) },
             );
             return .indeterminate;
         };
         debug_trace.logf(
             "session",
-            "event=pristine_session_discard disposition=discarded",
-            .{},
+            "event={s} disposition=discarded",
+            .{event_name},
         );
         return .discarded;
     }
@@ -6379,6 +6414,34 @@ test "pristine discard refuses resumed and committed writers" {
         return error.TestExpectedEqual;
     defer latest.deinit(alloc);
     try std.testing.expectEqualStrings(committed_state.id, latest.session_id);
+}
+
+test "committed session deletion consumes its exact writer" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    var state = try testDurableState(alloc, "delete-committed", ctx.workspace);
+    defer state.deinit(alloc);
+    var writable = try ctx.store.startWritableSession(alloc, state);
+    _ = try writable.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        20,
+        .retry_expected_tail,
+        .{},
+    );
+
+    try std.testing.expectEqual(
+        PristineDiscardDisposition.discarded,
+        ctx.store.deleteCommittedSession(alloc, &writable),
+    );
+    try std.testing.expectError(
+        error.SessionNotFound,
+        ctx.store.loadReadOnly(alloc, state.id),
+    );
 }
 
 test "pristine discard refuses a writer from a different Store root" {

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -285,12 +285,16 @@ fn acknowledgeParentTurnContext(
     acknowledgements: []const agent_runtime.ParentTurnDeliveryAck,
 ) void {
     const context: *Context = @ptrCast(@alignCast(raw));
-    parent_delivery_projector.acknowledge(
+    const retirement_ready = parent_delivery_projector
+        .acknowledgeWithRetirementSignal(
         arena,
         context.config.host.sessions,
         context.config.host.manager.options.child_store,
         acknowledgements,
     );
+    if (retirement_ready) {
+        context.config.host.requestRetirementSweep(io_mod.milliTimestamp());
+    }
 }
 
 fn appendRuntimeContext(raw: *anyopaque, arena: Allocator, messages: *std.ArrayList(types.ChatMessage)) !void {

--- a/src/core/subagent/communication.zig
+++ b/src/core/subagent/communication.zig
@@ -3409,6 +3409,64 @@ pub fn retentionGapThrough(
     return 0;
 }
 
+pub fn parentTurnDeliveryFullyAcknowledged(
+    ledger: Ledger,
+    consumer_id: []const u8,
+    target_id: []const u8,
+    delivery_id: []const u8,
+) bool {
+    const cursor = findCursor(
+        ledger.cursors,
+        consumer_id,
+        target_id,
+        .parent_turn,
+    ) orelse return false;
+    if (cursor.stale or cursor.partial_message_sequence != 0 or
+        retentionGapThrough(ledger, target_id, .parent_turn) != 0)
+    {
+        return false;
+    }
+    for (ledger.deliveries) |delivery| {
+        if (!std.mem.eql(u8, delivery.id, delivery_id) or
+            !std.mem.eql(u8, delivery.target_id, target_id) or
+            delivery.payload != .message)
+        {
+            continue;
+        }
+        return cursor.acknowledged_sequence >= delivery.sequence;
+    }
+    return false;
+}
+
+pub fn stableFinalResultFullyAcknowledged(
+    ledger: Ledger,
+    consumer_id: []const u8,
+    target_id: []const u8,
+    delivery_id: []const u8,
+) bool {
+    for (ledger.deliveries) |delivery| {
+        if (!std.mem.eql(u8, delivery.id, delivery_id) or
+            delivery.payload != .message)
+        {
+            continue;
+        }
+        const work_id = delivery.work_id orelse return false;
+        const stable_id = stableDeliveryId(
+            delivery.source_id,
+            work_id,
+            "final-result",
+        );
+        if (!std.mem.eql(u8, &stable_id, delivery.id)) return false;
+        return parentTurnDeliveryFullyAcknowledged(
+            ledger,
+            consumer_id,
+            target_id,
+            delivery_id,
+        );
+    }
+    return false;
+}
+
 const DeliveryOperationIdentity = union(enum) {
     none,
     legacy,

--- a/src/core/subagent/communication_manager.zig
+++ b/src/core/subagent/communication_manager.zig
@@ -313,6 +313,23 @@ pub const Manager = struct {
         target_session_id: []const u8,
         acknowledgement: communication.ParentAcknowledgement,
     ) Error!void {
+        _ = try self.acknowledgeParentBoundaryWithFinalResultSignal(
+            alloc,
+            owner_session_id,
+            consumer_id,
+            target_session_id,
+            acknowledgement,
+        );
+    }
+
+    pub fn acknowledgeParentBoundaryWithFinalResultSignal(
+        self: *Manager,
+        alloc: Allocator,
+        owner_session_id: []const u8,
+        consumer_id: []const u8,
+        target_session_id: []const u8,
+        acknowledgement: communication.ParentAcknowledgement,
+    ) Error!bool {
         var locked = try AuthorizedLocks.acquire(
             alloc,
             self.sessions,
@@ -337,6 +354,12 @@ pub const Manager = struct {
             acknowledgement,
         ) catch |err| return mapMutation(err);
         if (ledger.generation != prior_generation) try save(store, alloc, ledger);
+        return communication.stableFinalResultFullyAcknowledged(
+            ledger,
+            consumer_id,
+            target_session_id,
+            acknowledgement.delivery_id,
+        );
     }
 
     fn acknowledgeProjection(
@@ -828,6 +851,47 @@ pub fn reconcileTerminalsLocked(
         );
     }
     return repaired;
+}
+
+pub const FinalResultInput = struct {
+    child_id: []const u8,
+    parent_id: []const u8,
+    work_id: []const u8,
+    timestamp_ms: i64,
+    content: []const u8,
+};
+
+/// Appends the mandatory one-off result through the existing message ledger.
+/// The stable ID makes normal completion, restart recovery, and retries
+/// idempotent. The caller retains ownership of every input slice.
+pub fn reconcileFinalResultLocked(
+    alloc: Allocator,
+    store: communication_store.Store,
+    input: FinalResultInput,
+) Error!bool {
+    var ledger = try loadOrInit(alloc, store, input.child_id);
+    defer ledger.deinit(alloc);
+    const id = communication.stableDeliveryId(
+        input.child_id,
+        input.work_id,
+        "final-result",
+    );
+    const appended = communication.appendDelivery(alloc, &ledger, .{
+        .id = &id,
+        .source_id = input.child_id,
+        .target_id = input.parent_id,
+        .work_id = input.work_id,
+        .timestamp_ms = input.timestamp_ms,
+        .payload = .{ .message = @constCast(input.content) },
+    }) catch |err| return mapMutation(err);
+    if (appended == .duplicate) return false;
+    try save(store, alloc, ledger);
+    debug_trace.logf(
+        "subagent",
+        "final result reconciliation committed child_id={s} work_id={s} outcome=ok",
+        .{ input.child_id, input.work_id },
+    );
+    return true;
 }
 
 /// Reconciles unresolved tool approvals from canonical work state. This is

--- a/src/core/subagent/execution.zig
+++ b/src/core/subagent/execution.zig
@@ -1361,6 +1361,12 @@ pub const Owner = struct {
     approval_registry: ?*approval_registry_mod.Registry = null,
     notification_clock: ?NotificationClock = null,
     notification_poller: ?NotificationPoller = null,
+    /// Borrowed from the host and valid until `deinit` joins the reaper.
+    retirement_root_id: ?[]const u8 = null,
+    retirement_cursor: ?[]u8 = null,
+    retirement_scan_pending: bool = false,
+    retirement_due_ms: ?i64 = null,
+    retirement_retry_after_scan: bool = false,
     max_history_turns: usize = 8,
     mutex: std.Io.Mutex = .init,
     reaper_cond: std.Io.Condition = .init,
@@ -1453,6 +1459,18 @@ pub const Owner = struct {
             self.mutex.unlock(io_mod.getIo());
             return result;
         }
+    }
+
+    pub fn requestRetirementSweep(
+        self: *Owner,
+        timestamp_ms: i64,
+    ) StartError!void {
+        self.mutex.lockUncancelable(io_mod.getIo());
+        defer self.mutex.unlock(io_mod.getIo());
+        if (self.closed) return error.OwnerClosed;
+        if (self.retirement_root_id == null) return;
+        try self.ensureReaperLocked();
+        self.scheduleRetirementSweepLocked(timestamp_ms);
     }
 
     /// Returns the latest in-memory execution outcome without consuming it.
@@ -1726,6 +1744,12 @@ pub const Owner = struct {
 
     pub fn deinit(self: *Owner) void {
         self.mutex.lockUncancelable(io_mod.getIo());
+        if (self.retirement_scan_pending and self.retirement_root_id != null) {
+            self.retirement_due_ms = reaperNowMs(self);
+            self.mutex.unlock(io_mod.getIo());
+            self.runRetirementSweep(reaperNowMs(self));
+            self.mutex.lockUncancelable(io_mod.getIo());
+        }
         self.closed = true;
         for (self.slots.items) |slot| {
             slot.shutdown.store(true, .seq_cst);
@@ -1786,6 +1810,7 @@ pub const Owner = struct {
             schedule.deinit(self.alloc);
         }
         self.notification_schedules.deinit(self.alloc);
+        if (self.retirement_cursor) |cursor| self.alloc.free(cursor);
         self.slots.deinit(self.alloc);
         self.* = undefined;
     }
@@ -1898,6 +1923,15 @@ pub const Owner = struct {
         if (self.reaper_thread != null) return;
         self.reaper_thread = std.Thread.spawn(.{}, reaperMain, .{self}) catch
             return error.ThreadSpawnFailed;
+    }
+
+    fn scheduleRetirementSweepLocked(self: *Owner, due_ms: i64) void {
+        self.retirement_scan_pending = true;
+        self.retirement_due_ms = if (self.retirement_due_ms) |current|
+            @min(current, due_ms)
+        else
+            due_ms;
+        self.reaper_wake.set(io_mod.getIo());
     }
 
     fn registerNotificationSchedule(
@@ -2237,6 +2271,16 @@ pub const Owner = struct {
             "terminal reconciliation deferred child_id={s} outcome={s}",
             .{ child_id, @errorName(err) },
         );
+        _ = reconcileOneOffFinalResultLocked(
+            self.alloc,
+            communication_state,
+            record,
+            &.{},
+        ) catch |err| debug_trace.logf(
+            "subagent",
+            "final result reconciliation deferred child_id={s} outcome={s}",
+            .{ child_id, @errorName(err) },
+        );
         return count;
     }
 
@@ -2350,6 +2394,12 @@ pub const Owner = struct {
             communication_state,
             record,
         ) catch return error.ControlStoreFailed;
+        _ = reconcileOneOffFinalResultLocked(
+            self.alloc,
+            communication_state,
+            record,
+            loaded.state.history,
+        ) catch return error.ControlStoreFailed;
         return changed;
     }
 
@@ -2379,7 +2429,353 @@ pub const Owner = struct {
         report.work_interrupted += changed.interrupted;
         report.work_completed += changed.completed;
     }
+
+    fn runRetirementSweep(self: *Owner, now_ms: i64) void {
+        self.mutex.lockUncancelable(io_mod.getIo());
+        if (!self.retirement_scan_pending or
+            (self.retirement_due_ms orelse now_ms) > now_ms)
+        {
+            self.mutex.unlock(io_mod.getIo());
+            return;
+        }
+        self.retirement_scan_pending = false;
+        self.retirement_due_ms = null;
+        const root_id = self.retirement_root_id orelse {
+            self.mutex.unlock(io_mod.getIo());
+            return;
+        };
+        const owned_root = self.alloc.dupe(u8, root_id) catch {
+            self.scheduleRetirementSweepLocked(now_ms + retirement_retry_delay_ms);
+            self.mutex.unlock(io_mod.getIo());
+            return;
+        };
+        const cursor = self.retirement_cursor;
+        self.retirement_cursor = null;
+        self.mutex.unlock(io_mod.getIo());
+        defer self.alloc.free(owned_root);
+        defer if (cursor) |value| self.alloc.free(value);
+
+        var result = self.manager.snapshot(self.alloc, .{
+            .root_id = owned_root,
+            .cursor = cursor,
+            .limit = domain.default_page_limit,
+        }) catch |err| {
+            debug_trace.logf(
+                "subagent",
+                "retirement sweep deferred root_id={s} outcome={s}",
+                .{ owned_root, @errorName(err) },
+            );
+            self.finishRetirementSweep(null, true, now_ms);
+            return;
+        };
+        defer result.deinit(self.alloc);
+        const snapshot = switch (result) {
+            .failure => |failure| {
+                const retry = failure.code == .store_failure or
+                    failure.code == .graph_changed;
+                debug_trace.logf(
+                    "subagent",
+                    "retirement sweep retained root_id={s} reason={s} retryable={}",
+                    .{ owned_root, @tagName(failure.code), retry },
+                );
+                self.finishRetirementSweep(null, retry, now_ms);
+                return;
+            },
+            .snapshot => |*value| value,
+        };
+        if (snapshot.restart_required) {
+            self.finishRetirementSweep(null, true, now_ms);
+            return;
+        }
+
+        var retry = false;
+        for (snapshot.nodes) |node| {
+            if (!isTerminalOneOff(node.mode, node.state)) continue;
+            retry = self.tryRetireOneOff(node.child_id) or retry;
+        }
+        for (snapshot.diagnostics) |diagnostic| {
+            if (diagnostic.code != .session_unavailable) continue;
+            const parent_id = diagnostic.parent_id orelse continue;
+            _ = relationship_index.removeChild(
+                self.alloc,
+                self.sessions,
+                parent_id,
+                diagnostic.session_id,
+                self.child_store_options,
+            ) catch |err| {
+                traceRetirementRetain(
+                    diagnostic.session_id,
+                    "stale_relationship_remove",
+                    err,
+                );
+                retry = shouldScheduleRetirementRetry(err) or retry;
+            };
+        }
+        const next_cursor = if (snapshot.next_cursor) |next|
+            self.alloc.dupe(u8, next) catch {
+                self.finishRetirementSweep(null, true, now_ms);
+                return;
+            }
+        else
+            null;
+        self.finishRetirementSweep(next_cursor, retry, now_ms);
+    }
+
+    fn finishRetirementSweep(
+        self: *Owner,
+        next_cursor: ?[]u8,
+        retry: bool,
+        now_ms: i64,
+    ) void {
+        self.mutex.lockUncancelable(io_mod.getIo());
+        defer self.mutex.unlock(io_mod.getIo());
+        if (self.closed) {
+            if (next_cursor) |cursor| self.alloc.free(cursor);
+            return;
+        }
+        if (self.retirement_scan_pending) {
+            self.retirement_retry_after_scan =
+                self.retirement_retry_after_scan or retry;
+            if (next_cursor) |cursor| self.alloc.free(cursor);
+            return;
+        }
+        if (self.retirement_cursor) |cursor| self.alloc.free(cursor);
+        self.retirement_cursor = next_cursor;
+        if (next_cursor != null) {
+            self.retirement_retry_after_scan =
+                self.retirement_retry_after_scan or retry;
+            self.scheduleRetirementSweepLocked(now_ms);
+        } else {
+            const should_retry = retry or self.retirement_retry_after_scan;
+            self.retirement_retry_after_scan = false;
+            if (should_retry) {
+                self.scheduleRetirementSweepLocked(
+                    now_ms + retirement_retry_delay_ms,
+                );
+            }
+        }
+    }
+
+    /// Returns true only when another automatic bounded attempt is warranted.
+    fn tryRetireOneOff(self: *Owner, child_id: []const u8) bool {
+        _ = relationship_index.migrateLegacyPage(
+            self.alloc,
+            self.sessions,
+            child_id,
+            self.child_store_options,
+        ) catch |err| {
+            if (err == error.StoreUnavailable) {
+                var page = self.sessions.listResumablePage(
+                    self.alloc,
+                    null,
+                    null,
+                ) catch |backfill_err| {
+                    traceRetirementRetain(
+                        child_id,
+                        "migration_backfill",
+                        backfill_err,
+                    );
+                    return shouldScheduleRetirementRetry(backfill_err);
+                };
+                page.deinit(self.alloc);
+                return true;
+            }
+            traceRetirementRetain(child_id, "migration", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+
+        var loaded = self.sessions.resumeTargetForWrite(
+            self.alloc,
+            .{ .id = child_id },
+            self.sessions.workspace_root,
+            self.session_resume_options,
+        ) catch |err| {
+            traceRetirementRetain(child_id, "writer", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+        var loaded_consumed = false;
+        defer if (!loaded_consumed) loaded.deinit(self.alloc);
+
+        var capability = self.sessions.openSubagentControlCapabilityWritable(
+            self.alloc,
+            child_id,
+            self.child_store_options,
+        ) catch |err| {
+            traceRetirementRetain(child_id, "control_open", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+        defer capability.deinit();
+        const control = control_store.Store{
+            .capability = &capability,
+            .expected_child_id = child_id,
+        };
+        var lock = control.acquireLock() catch |err| {
+            traceRetirementRetain(child_id, "control_lock", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+        defer lock.release();
+        var record = control.load(self.alloc) catch |err| {
+            traceRetirementRetain(child_id, "control_load", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+        defer record.deinit(self.alloc);
+        if (!isTerminalOneOff(record.mode, record.state)) return false;
+        const parent_id = record.parent_id orelse return false;
+
+        var communication_capability = self.sessions.openSubagentControlCapabilityWritable(
+            self.alloc,
+            child_id,
+            self.communication_store_options,
+        ) catch |err| {
+            traceRetirementRetain(child_id, "communication_open", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+        defer communication_capability.deinit();
+        const communication_state = communication_store.Store{
+            .capability = &communication_capability,
+            .expected_session_id = child_id,
+        };
+        _ = reconcileOneOffFinalResultLocked(
+            self.alloc,
+            communication_state,
+            record,
+            loaded.state.history,
+        ) catch |err| {
+            traceRetirementRetain(child_id, "result_reconcile", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+        var ledger = communication_state.loadOptional(self.alloc) catch |err| {
+            traceRetirementRetain(child_id, "communication_load", err);
+            return shouldScheduleRetirementRetry(err);
+        } orelse return true;
+        defer ledger.deinit(self.alloc);
+        const work_id = terminalOneOffWorkId(record) orelse return false;
+        const delivery_id = communication.stableDeliveryId(
+            child_id,
+            work_id,
+            "final-result",
+        );
+        const result_acknowledged = communication.parentTurnDeliveryFullyAcknowledged(
+            ledger,
+            "parent-model",
+            parent_id,
+            &delivery_id,
+        );
+        if (!result_acknowledged) return false;
+
+        const active_count = relationship_index.activeCountIfMigrationComplete(
+            self.alloc,
+            self.sessions,
+            child_id,
+            self.child_store_options,
+        ) catch |err| {
+            traceRetirementRetain(child_id, "descendant_proof", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+        const facts = OneOffRetirementFacts{
+            .mode = record.mode,
+            .state = record.state,
+            .result_acknowledged = result_acknowledged,
+            .migration_complete = active_count != null,
+            .active_count = active_count,
+        };
+        if (!canRetireOneOff(facts)) return active_count == null;
+
+        const disposition = self.sessions.deleteCommittedSession(
+            self.alloc,
+            &loaded,
+        );
+        loaded_consumed = true;
+        switch (disposition) {
+            .retained => return false,
+            .indeterminate => return true,
+            .discarded => {},
+        }
+        _ = relationship_index.removeChild(
+            self.alloc,
+            self.sessions,
+            parent_id,
+            child_id,
+            self.child_store_options,
+        ) catch |err| {
+            traceRetirementRetain(child_id, "relationship_remove", err);
+            return shouldScheduleRetirementRetry(err);
+        };
+        debug_trace.logf(
+            "subagent",
+            "one-off retirement committed child_id={s} parent_id={s}",
+            .{ child_id, parent_id },
+        );
+        return false;
+    }
 };
+
+const retirement_retry_delay_ms: i64 = 100;
+
+fn isTerminalOneOff(mode: domain.Mode, state: domain.State) bool {
+    if (mode != .one_off) return false;
+    return switch (state) {
+        .completed, .failed, .cancelled => true,
+        else => false,
+    };
+}
+
+const OneOffRetirementFacts = struct {
+    mode: domain.Mode,
+    state: domain.State,
+    result_acknowledged: bool,
+    migration_complete: bool,
+    active_count: ?u64,
+};
+
+fn canRetireOneOff(facts: OneOffRetirementFacts) bool {
+    return isTerminalOneOff(facts.mode, facts.state) and
+        facts.result_acknowledged and
+        facts.migration_complete and
+        facts.active_count != null and
+        facts.active_count.? == 0;
+}
+
+fn terminalOneOffWorkId(record: control_store.Record) ?[]const u8 {
+    var index = record.queue.len;
+    while (index > 0) {
+        index -= 1;
+        switch (record.queue[index].status) {
+            .completed, .failed, .cancelled => return record.queue[index].id,
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn shouldScheduleRetirementRetry(err: anyerror) bool {
+    return switch (err) {
+        error.SessionBusy,
+        error.ExternalBusy,
+        error.ControlLockBusy,
+        error.LockBusy,
+        error.SessionStoreUnavailable,
+        error.StoreUnavailable,
+        error.CommitIndeterminate,
+        error.RecoveryRequired,
+        error.StaleCursor,
+        error.OutOfMemory,
+        => true,
+        else => false,
+    };
+}
+
+fn traceRetirementRetain(
+    child_id: []const u8,
+    stage: []const u8,
+    err: anyerror,
+) void {
+    debug_trace.logf(
+        "subagent",
+        "one-off retirement retained child_id={s} stage={s} outcome={s} retryable={}",
+        .{ child_id, stage, @errorName(err), shouldScheduleRetirementRetry(err) },
+    );
+}
 
 fn isRetryableNotificationPollError(err: communication_manager.Error) bool {
     return switch (err) {
@@ -2416,11 +2812,23 @@ fn reaperMain(owner: *Owner) void {
             break;
         }
         const slot = selected orelse {
-            const next_check_ms = owner.nextNotificationCheckLocked();
-            const now_ms = if (owner.notification_clock) |clock|
-                clock.now_ms()
+            const now_ms = reaperNowMs(owner);
+            if (owner.retirement_scan_pending and
+                (owner.retirement_due_ms orelse now_ms) <= now_ms)
+            {
+                owner.mutex.unlock(io_mod.getIo());
+                owner.runRetirementSweep(now_ms);
+                owner.mutex.lockUncancelable(io_mod.getIo());
+                continue;
+            }
+            const notification_check_ms = owner.nextNotificationCheckLocked();
+            const next_check_ms = if (owner.retirement_scan_pending)
+                if (notification_check_ms) |notification_due|
+                    @min(notification_due, owner.retirement_due_ms orelse now_ms)
+                else
+                    owner.retirement_due_ms
             else
-                0;
+                notification_check_ms;
             if (next_check_ms != null and next_check_ms.? <= now_ms) {
                 owner.mutex.unlock(io_mod.getIo());
                 _ = owner.pollNotifications() catch |err| {
@@ -2459,12 +2867,22 @@ fn reaperMain(owner: *Owner) void {
         }
         owner.removeSlotLocked(slot);
         owner.cacheCompletionLocked(slot.child_id, slot.result);
+        if (owner.retirement_root_id != null) {
+            owner.scheduleRetirementSweepLocked(reaperNowMs(owner));
+        }
         owner.reaper_cond.broadcast(io_mod.getIo());
         owner.mutex.unlock(io_mod.getIo());
         slot.live.deinit(owner.alloc);
         owner.alloc.destroy(slot);
         owner.mutex.lockUncancelable(io_mod.getIo());
     }
+}
+
+fn reaperNowMs(owner: *const Owner) i64 {
+    return if (owner.notification_clock) |clock|
+        clock.now_ms()
+    else
+        io_mod.milliTimestamp();
 }
 
 fn appendSlotLiveText(raw: *anyopaque, value: []const u8) void {
@@ -2755,6 +3173,12 @@ fn runOne(slot: *Slot) OneResult {
         communication_state,
         record,
     ) catch return .control_failed;
+    _ = reconcileOneOffFinalResultLocked(
+        owner.alloc,
+        communication_state,
+        record,
+        loaded.state.history,
+    ) catch return .control_failed;
     const index = nextRunnableIndex(record.queue, slot.retry_interrupted) orelse
         return if (record.mode == .one_off and record.state == .completed)
             .completed
@@ -2896,6 +3320,15 @@ fn runOne(slot: *Slot) OneResult {
         owner.wakeNotificationSchedules(slot.child_id, completed_at_ms);
         return .control_failed;
     };
+    _ = reconcileOneOffFinalResultLocked(
+        owner.alloc,
+        communication_state,
+        current,
+        loaded.state.history,
+    ) catch {
+        owner.wakeNotificationSchedules(slot.child_id, completed_at_ms);
+        return .control_failed;
+    };
     owner.wakeNotificationSchedules(slot.child_id, completed_at_ms);
     if (outcome == .failed) return .failed;
     if (current.mode == .one_off) return .completed;
@@ -2986,6 +3419,158 @@ fn completedWorkIdForRecovery(
     return work_id;
 }
 
+const TerminalTransition = struct {
+    timestamp_ms: i64,
+    reason: ?[]const u8,
+};
+
+fn terminalTransitionForWork(
+    events: []const domain.Event,
+    work_id: []const u8,
+    status: domain.QueueStatus,
+) ?TerminalTransition {
+    var index = events.len;
+    while (index > 0) {
+        index -= 1;
+        const transition = switch (events[index].kind) {
+            .work_transition => |value| value,
+            else => continue,
+        };
+        if (transition.current != status or
+            !std.mem.eql(u8, transition.work_item_id, work_id))
+        {
+            continue;
+        }
+        return .{
+            .timestamp_ms = events[index].timestamp_ms,
+            .reason = transition.reason,
+        };
+    }
+    return null;
+}
+
+fn assistantTextForWork(
+    history: []const types.HistoryTurn,
+    work_id: []const u8,
+) ?[]const u8 {
+    var index = history.len;
+    while (index > 0) {
+        index -= 1;
+        const candidate = history[index];
+        const candidate_work_id = session.historyTurnWorkId(candidate) orelse continue;
+        if (!std.mem.eql(u8, candidate_work_id, work_id)) continue;
+        return switch (candidate) {
+            .assistant => |value| value.assistant,
+            .background_command => |value| value.assistant orelse "",
+            .interrupted => |value| value.assistant orelse "",
+            .compacted_summary => null,
+        };
+    }
+    return null;
+}
+
+fn boundedFinalResultAlloc(
+    alloc: Allocator,
+    content: []const u8,
+) Allocator.Error![]u8 {
+    if (content.len <= communication.max_delivery_content_bytes) {
+        return alloc.dupe(u8, content);
+    }
+    const suffix = try std.fmt.allocPrint(
+        alloc,
+        "\n\n[truncated; original_bytes={d}]",
+        .{content.len},
+    );
+    defer alloc.free(suffix);
+    std.debug.assert(suffix.len < communication.max_delivery_content_bytes);
+    const prefix = text_utils.utf8PrefixByBytes(
+        content,
+        communication.max_delivery_content_bytes - suffix.len,
+    );
+    return std.fmt.allocPrint(alloc, "{s}{s}", .{ prefix, suffix });
+}
+
+fn oneOffFinalResultAlloc(
+    alloc: Allocator,
+    work: domain.QueuedMessage,
+    transition: TerminalTransition,
+    history: []const types.HistoryTurn,
+) (Allocator.Error || error{InvalidRecord})![]u8 {
+    const fallback_completed = "One-off subagent completed without a final text response.";
+    var formatted: ?[]u8 = null;
+    defer if (formatted) |value| alloc.free(value);
+    const raw = switch (work.status) {
+        .completed => blk: {
+            const assistant = assistantTextForWork(history, work.id) orelse
+                fallback_completed;
+            break :blk if (assistant.len != 0 and text_utils.isModelSafeText(assistant))
+                assistant
+            else
+                fallback_completed;
+        },
+        .failed => blk: {
+            formatted = try std.fmt.allocPrint(
+                alloc,
+                "One-off subagent failed: {s}",
+                .{transition.reason orelse "unknown failure"},
+            );
+            break :blk formatted.?;
+        },
+        .cancelled => blk: {
+            formatted = try std.fmt.allocPrint(
+                alloc,
+                "One-off subagent cancelled: {s}",
+                .{work.cancellation_reason orelse transition.reason orelse "cancelled"},
+            );
+            break :blk formatted.?;
+        },
+        .pending, .running, .awaiting_approval, .interrupted => return error.InvalidRecord,
+    };
+    return boundedFinalResultAlloc(alloc, raw);
+}
+
+fn reconcileOneOffFinalResultLocked(
+    alloc: Allocator,
+    store: communication_store.Store,
+    record: control_store.Record,
+    history: []const types.HistoryTurn,
+) communication_manager.Error!bool {
+    if (record.mode != .one_off) return false;
+    var index = record.queue.len;
+    while (index > 0) {
+        index -= 1;
+        const work = record.queue[index];
+        switch (work.status) {
+            .completed, .failed, .cancelled => {},
+            else => continue,
+        }
+        const parent_id = record.parent_id orelse return error.InvalidRecord;
+        const transition = terminalTransitionForWork(
+            record.events,
+            work.id,
+            work.status,
+        ) orelse return error.InvalidRecord;
+        const content = oneOffFinalResultAlloc(
+            alloc,
+            work,
+            transition,
+            history,
+        ) catch |err| return switch (err) {
+            error.OutOfMemory => error.OutOfMemory,
+            error.InvalidRecord => error.InvalidRecord,
+        };
+        defer alloc.free(content);
+        return communication_manager.reconcileFinalResultLocked(alloc, store, .{
+            .child_id = record.child_id,
+            .parent_id = parent_id,
+            .work_id = work.id,
+            .timestamp_ms = transition.timestamp_ms,
+            .content = content,
+        });
+    }
+    return false;
+}
+
 fn findDeliveryById(
     deliveries: []const communication.Delivery,
     id: []const u8,
@@ -3027,6 +3612,104 @@ fn serviceFailureReason(err: ServiceError) []const u8 {
         error.ProviderFailed => "provider_failed",
         error.Cancelled => "cancelled",
     };
+}
+
+test "one off terminal results and retry classification stay bounded" {
+    const alloc = std.testing.allocator;
+    const transition = TerminalTransition{ .timestamp_ms = 2, .reason = "provider_failed" };
+    const failed = domain.QueuedMessage{
+        .id = @constCast("failed-work"),
+        .source_id = @constCast("parent"),
+        .content = @constCast("work"),
+        .status = .failed,
+        .created_at_ms = 1,
+    };
+    const failed_result = try oneOffFinalResultAlloc(alloc, failed, transition, &.{});
+    defer alloc.free(failed_result);
+    try std.testing.expectEqualStrings(
+        "One-off subagent failed: provider_failed",
+        failed_result,
+    );
+
+    const cancelled = domain.QueuedMessage{
+        .id = @constCast("cancelled-work"),
+        .source_id = @constCast("parent"),
+        .content = @constCast("work"),
+        .status = .cancelled,
+        .cancellation_reason = @constCast("user cancelled"),
+        .created_at_ms = 1,
+    };
+    const cancelled_result = try oneOffFinalResultAlloc(
+        alloc,
+        cancelled,
+        .{ .timestamp_ms = 2, .reason = "user cancelled" },
+        &.{},
+    );
+    defer alloc.free(cancelled_result);
+    try std.testing.expectEqualStrings(
+        "One-off subagent cancelled: user cancelled",
+        cancelled_result,
+    );
+
+    const oversized = try alloc.alloc(u8, communication.max_delivery_content_bytes + 100);
+    defer alloc.free(oversized);
+    @memset(oversized, 'a');
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("work"), .work_id = @constCast("completed-work") },
+        .assistant = oversized,
+    } }};
+    const completed = domain.QueuedMessage{
+        .id = @constCast("completed-work"),
+        .source_id = @constCast("parent"),
+        .content = @constCast("work"),
+        .status = .completed,
+        .created_at_ms = 1,
+    };
+    const completed_result = try oneOffFinalResultAlloc(
+        alloc,
+        completed,
+        .{ .timestamp_ms = 2, .reason = null },
+        &history,
+    );
+    defer alloc.free(completed_result);
+    try std.testing.expectEqual(
+        communication.max_delivery_content_bytes,
+        completed_result.len,
+    );
+    try std.testing.expect(std.mem.endsWith(u8, completed_result, "]"));
+
+    try std.testing.expect(shouldScheduleRetirementRetry(error.LockBusy));
+    try std.testing.expect(shouldScheduleRetirementRetry(error.CommitIndeterminate));
+    try std.testing.expect(!shouldScheduleRetirementRetry(error.LockUnsupported));
+    try std.testing.expect(!shouldScheduleRetirementRetry(error.PathUnsafe));
+    try std.testing.expect(!shouldScheduleRetirementRetry(error.InvalidRecord));
+
+    const eligible = OneOffRetirementFacts{
+        .mode = .one_off,
+        .state = .completed,
+        .result_acknowledged = true,
+        .migration_complete = true,
+        .active_count = 0,
+    };
+    try std.testing.expect(canRetireOneOff(eligible));
+    var rejected = eligible;
+    rejected.mode = .persistent;
+    try std.testing.expect(!canRetireOneOff(rejected));
+    rejected = eligible;
+    rejected.state = .running;
+    try std.testing.expect(!canRetireOneOff(rejected));
+    rejected = eligible;
+    rejected.result_acknowledged = false;
+    try std.testing.expect(!canRetireOneOff(rejected));
+    rejected = eligible;
+    rejected.migration_complete = false;
+    try std.testing.expect(!canRetireOneOff(rejected));
+    rejected = eligible;
+    rejected.active_count = null;
+    try std.testing.expect(!canRetireOneOff(rejected));
+    rejected = eligible;
+    rejected.active_count = 1;
+    try std.testing.expect(!canRetireOneOff(rejected));
 }
 
 fn mapOpenControlError(err: session_store.OpenSubagentControlError) ControlError {
@@ -8580,6 +9263,181 @@ test "session-backed owner executes through deterministic gateway and normal age
         else => {},
     };
     try std.testing.expect(saw_pending and saw_running and saw_completed);
+}
+
+test "completed one off reconciles one stable final result message" {
+    const alloc = std.testing.allocator;
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, "parent");
+    try env.createSession(alloc, "one-off-child");
+    try env.installControl(
+        alloc,
+        "one-off-child",
+        .one_off,
+        "anthropic/claude-opus-4.6",
+        types.ReasoningEffort.literal("high"),
+        &.{"one-off-work"},
+    );
+    _ = try relationship_index.ensureChild(
+        alloc,
+        &env.store,
+        "parent",
+        "one-off-child",
+        .{},
+    );
+    var gateway_execution: GatewayExecution = .{};
+    var manager = manager_mod.Manager{ .sessions = &env.store };
+    var live_authority = authority_mod.Resolver{
+        .sessions = &env.store,
+        .host = .{ .resolve_fn = GatewayExecution.resolveHostAuthority },
+    };
+    var owner = Owner{
+        .alloc = alloc,
+        .sessions = &env.store,
+        .manager = &manager,
+        .services = gateway_execution.services(),
+        .live_authority = &live_authority,
+        .retirement_root_id = "parent",
+    };
+    defer owner.deinit();
+    try std.testing.expectEqual(StartResult.started, try owner.start("one-off-child", false));
+    try std.testing.expectEqual(ChildResult.completed, try owner.join("one-off-child"));
+    var indexed = try env.store.listResumablePage(alloc, null, null);
+    indexed.deinit(alloc);
+
+    var communication_query = communication_manager.Manager{ .sessions = &env.store };
+    var page = try communication_query.page(
+        alloc,
+        "one-off-child",
+        "parent-model",
+        "parent",
+        null,
+        16,
+    );
+    defer page.deinit(alloc);
+    var result_count: usize = 0;
+    for (page.deliveries) |delivery| switch (delivery.payload) {
+        .message => |message| {
+            result_count += 1;
+            try std.testing.expectEqualStrings("gateway child reply", message);
+            try std.testing.expectEqualStrings("one-off-work", delivery.work_id.?);
+        },
+        else => {},
+    };
+    try std.testing.expectEqual(@as(usize, 1), result_count);
+
+    _ = try owner.recover(20);
+    var repeated = try communication_query.page(
+        alloc,
+        "one-off-child",
+        "parent-model",
+        "parent",
+        null,
+        16,
+    );
+    defer repeated.deinit(alloc);
+    var repeated_count: usize = 0;
+    for (repeated.deliveries) |delivery| {
+        if (delivery.payload == .message) repeated_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), repeated_count);
+
+    while (true) {
+        var pending = try communication_query.prepareParentBoundary(
+            alloc,
+            "one-off-child",
+            "parent-model",
+            "parent",
+            .turn_boundary,
+            null,
+        );
+        defer pending.deinit(alloc);
+        if (pending == .wait) break;
+        try communication_query.acknowledgeParentBoundary(
+            alloc,
+            "one-off-child",
+            "parent-model",
+            "parent",
+            .{
+                .sequence = pending.inject.through_sequence,
+                .delivery_id = pending.inject.delivery_id,
+                .start_offset = pending.inject.start_offset,
+                .end_offset = pending.inject.end_offset,
+                .total_bytes = pending.inject.total_bytes,
+            },
+        );
+    }
+    var canonical = try manager.snapshot(alloc, .{ .root_id = "parent" });
+    defer canonical.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), canonical.snapshot.nodes.len);
+    var communication_capability = try env.store.openSubagentControlCapabilityReadOnly(
+        alloc,
+        "one-off-child",
+        .{},
+    );
+    defer communication_capability.deinit();
+    const communication_state = communication_store.Store{
+        .capability = &communication_capability,
+        .expected_session_id = "one-off-child",
+    };
+    var acknowledged = try communication_state.load(alloc);
+    defer acknowledged.deinit(alloc);
+    const result_id = communication.stableDeliveryId(
+        "one-off-child",
+        "one-off-work",
+        "final-result",
+    );
+    try std.testing.expect(communication.parentTurnDeliveryFullyAcknowledged(
+        acknowledged,
+        "parent-model",
+        "parent",
+        &result_id,
+    ));
+    try std.testing.expectEqual(
+        @as(?u64, 0),
+        try relationship_index.activeCountIfMigrationComplete(
+            alloc,
+            &env.store,
+            "one-off-child",
+            .{},
+        ),
+    );
+    try owner.requestRetirementSweep(21);
+    const deadline = io_mod.milliTimestamp() + 30_000;
+    while (true) {
+        var retained = env.store.loadReadOnly(alloc, "one-off-child") catch |err| switch (err) {
+            error.SessionNotFound => break,
+            error.FileNotFound => {
+                if (io_mod.milliTimestamp() >= deadline) return error.TestUnexpectedResult;
+                std.Thread.yield() catch std.atomic.spinLoopHint();
+                continue;
+            },
+            else => return err,
+        };
+        retained.deinit(alloc);
+        if (io_mod.milliTimestamp() >= deadline) return error.TestUnexpectedResult;
+        std.Thread.yield() catch std.atomic.spinLoopHint();
+    }
+    while (true) {
+        const lookup = relationship_index.lookupSlot(
+            alloc,
+            &env.store,
+            "parent",
+            "one-off-child",
+            .{},
+        ) catch |err| switch (err) {
+            error.CommitIndeterminate, error.RecoveryRequired => {
+                if (io_mod.milliTimestamp() >= deadline) return error.TestUnexpectedResult;
+                std.Thread.yield() catch std.atomic.spinLoopHint();
+                continue;
+            },
+            else => return err,
+        };
+        if (lookup == null) break;
+        if (io_mod.milliTimestamp() >= deadline) return error.TestUnexpectedResult;
+        std.Thread.yield() catch std.atomic.spinLoopHint();
+    }
 }
 
 fn checkAdmissionAllocationFailures(alloc: Allocator) !void {

--- a/src/core/subagent/execution.zig
+++ b/src/core/subagent/execution.zig
@@ -9371,29 +9371,31 @@ test "completed one off reconciles one stable final result message" {
     var canonical = try manager.snapshot(alloc, .{ .root_id = "parent" });
     defer canonical.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 1), canonical.snapshot.nodes.len);
-    var communication_capability = try env.store.openSubagentControlCapabilityReadOnly(
-        alloc,
-        "one-off-child",
-        .{},
-    );
-    defer communication_capability.deinit();
-    const communication_state = communication_store.Store{
-        .capability = &communication_capability,
-        .expected_session_id = "one-off-child",
-    };
-    var acknowledged = try communication_state.load(alloc);
-    defer acknowledged.deinit(alloc);
-    const result_id = communication.stableDeliveryId(
-        "one-off-child",
-        "one-off-work",
-        "final-result",
-    );
-    try std.testing.expect(communication.parentTurnDeliveryFullyAcknowledged(
-        acknowledged,
-        "parent-model",
-        "parent",
-        &result_id,
-    ));
+    {
+        var communication_capability = try env.store.openSubagentControlCapabilityReadOnly(
+            alloc,
+            "one-off-child",
+            .{},
+        );
+        defer communication_capability.deinit();
+        const communication_state = communication_store.Store{
+            .capability = &communication_capability,
+            .expected_session_id = "one-off-child",
+        };
+        var acknowledged = try communication_state.load(alloc);
+        defer acknowledged.deinit(alloc);
+        const result_id = communication.stableDeliveryId(
+            "one-off-child",
+            "one-off-work",
+            "final-result",
+        );
+        try std.testing.expect(communication.parentTurnDeliveryFullyAcknowledged(
+            acknowledged,
+            "parent-model",
+            "parent",
+            &result_id,
+        ));
+    }
     try std.testing.expectEqual(
         @as(?u64, 0),
         try relationship_index.activeCountIfMigrationComplete(
@@ -9403,41 +9405,18 @@ test "completed one off reconciles one stable final result message" {
             .{},
         ),
     );
-    try owner.requestRetirementSweep(21);
-    const deadline = io_mod.milliTimestamp() + 30_000;
-    while (true) {
-        var retained = env.store.loadReadOnly(alloc, "one-off-child") catch |err| switch (err) {
-            error.SessionNotFound => break,
-            error.FileNotFound => {
-                if (io_mod.milliTimestamp() >= deadline) return error.TestUnexpectedResult;
-                std.Thread.yield() catch std.atomic.spinLoopHint();
-                continue;
-            },
-            else => return err,
-        };
-        retained.deinit(alloc);
-        if (io_mod.milliTimestamp() >= deadline) return error.TestUnexpectedResult;
-        std.Thread.yield() catch std.atomic.spinLoopHint();
-    }
-    while (true) {
-        const lookup = relationship_index.lookupSlot(
-            alloc,
-            &env.store,
-            "parent",
-            "one-off-child",
-            .{},
-        ) catch |err| switch (err) {
-            error.CommitIndeterminate, error.RecoveryRequired => {
-                if (io_mod.milliTimestamp() >= deadline) return error.TestUnexpectedResult;
-                std.Thread.yield() catch std.atomic.spinLoopHint();
-                continue;
-            },
-            else => return err,
-        };
-        if (lookup == null) break;
-        if (io_mod.milliTimestamp() >= deadline) return error.TestUnexpectedResult;
-        std.Thread.yield() catch std.atomic.spinLoopHint();
-    }
+    try std.testing.expect(!owner.tryRetireOneOff("one-off-child"));
+    try std.testing.expectError(
+        error.SessionNotFound,
+        env.store.loadReadOnly(alloc, "one-off-child"),
+    );
+    try std.testing.expect((try relationship_index.lookupSlot(
+        alloc,
+        &env.store,
+        "parent",
+        "one-off-child",
+        .{},
+    )) == null);
 }
 
 fn checkAdmissionAllocationFailures(alloc: Allocator) !void {

--- a/src/core/subagent/manager.zig
+++ b/src/core/subagent/manager.zig
@@ -279,10 +279,12 @@ pub const TreeDiagnosticCode = enum {
 
 pub const TreeDiagnostic = struct {
     session_id: []u8,
+    parent_id: ?[]u8 = null,
     code: TreeDiagnosticCode,
 
     pub fn deinit(self: *TreeDiagnostic, alloc: Allocator) void {
         alloc.free(self.session_id);
+        if (self.parent_id) |parent_id| alloc.free(parent_id);
         self.* = undefined;
     }
 };
@@ -292,6 +294,7 @@ pub const TreeQuery = struct {
     cursor: ?[]const u8 = null,
     anchor_id: ?[]const u8 = null,
     limit: usize = domain.default_page_limit,
+    hide_terminal_one_off: bool = false,
 };
 
 pub const TreeNode = struct {
@@ -666,6 +669,7 @@ pub const Manager = struct {
             var record = self.loadIndexedTreeRecord(
                 alloc,
                 candidate.child_id,
+                traversal.frames.items[frame_index].parent_id,
                 &diagnostics,
                 &diagnostics_truncated,
             ) catch |err| return switch (err) {
@@ -680,11 +684,15 @@ pub const Manager = struct {
                 traversal.frames.items[frame_index].parent_id,
             )) continue;
 
-            var node = try treeNodeFromRecord(alloc, value, depth);
-            var node_appended = false;
-            errdefer if (!node_appended) node.deinit(alloc);
-            try nodes.append(alloc, node);
-            node_appended = true;
+            if (!query.hide_terminal_one_off or
+                !isTerminalOneOff(value.mode, value.state))
+            {
+                var node = try treeNodeFromRecord(alloc, value, depth);
+                var node_appended = false;
+                errdefer if (!node_appended) node.deinit(alloc);
+                try nodes.append(alloc, node);
+                node_appended = true;
+            }
 
             if (migration_pages < max_snapshot_migration_pages) {
                 relationship_index.recoverForQuery(
@@ -1050,6 +1058,7 @@ pub const Manager = struct {
         self: *Manager,
         alloc: Allocator,
         child_id: []const u8,
+        parent_id: []const u8,
         diagnostics: *std.ArrayList(TreeDiagnostic),
         diagnostics_truncated: *bool,
     ) error{OutOfMemory}!?control_store.Record {
@@ -1073,6 +1082,7 @@ pub const Manager = struct {
                 diagnostics,
                 diagnostics_truncated,
                 child_id,
+                if (err == error.SessionNotFound) parent_id else null,
                 code,
             );
             return null;
@@ -1099,6 +1109,7 @@ pub const Manager = struct {
                 diagnostics,
                 diagnostics_truncated,
                 child_id,
+                null,
                 code,
             );
             return null;
@@ -3519,6 +3530,9 @@ fn reduceRelationship(
         );
     };
     defer if (next) |*record| record.deinit(alloc);
+    if (!canMutateRelationship(next.?.mode, command.action)) {
+        return .{ .reject = .invalid_state };
+    }
     for (next.?.queue) |work| switch (work.status) {
         .running, .awaiting_approval => return .{ .reject = .invalid_state },
         else => {},
@@ -3562,6 +3576,28 @@ fn reduceRelationship(
         event_kind,
         context.timestamp_ms,
     );
+}
+
+fn canMutateRelationship(
+    target_mode: domain.Mode,
+    action: domain.RelationshipAction,
+) bool {
+    return target_mode != .one_off or
+        (action != .detach and action != .reparent);
+}
+
+fn isTerminalOneOff(mode: domain.Mode, state: domain.State) bool {
+    if (mode != .one_off) return false;
+    return switch (state) {
+        .completed, .failed, .cancelled => true,
+        .idle,
+        .queued,
+        .running,
+        .awaiting_approval,
+        .interrupted,
+        .archived,
+        => false,
+    };
 }
 
 fn reduceConfigure(
@@ -4595,6 +4631,7 @@ fn appendTreeDiagnostic(
     diagnostics: *std.ArrayList(TreeDiagnostic),
     truncated: *bool,
     session_id: []const u8,
+    parent_id: ?[]const u8,
     code: TreeDiagnosticCode,
 ) Allocator.Error!void {
     if (diagnostics.items.len == max_snapshot_diagnostics) {
@@ -4603,8 +4640,11 @@ fn appendTreeDiagnostic(
     }
     const owned_id = try alloc.dupe(u8, session_id);
     errdefer alloc.free(owned_id);
+    const owned_parent = if (parent_id) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (owned_parent) |value| alloc.free(value);
     try diagnostics.append(alloc, .{
         .session_id = owned_id,
+        .parent_id = owned_parent,
         .code = code,
     });
 }
@@ -6386,6 +6426,76 @@ test "detach and reparent reject running or approval-blocked work" {
     try std.testing.expectEqual(FailureCode.invalid_state, approval_rejected.failure.code);
 }
 
+test "detach and reparent reject canonical one off targets" {
+    const alloc = std.testing.allocator;
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, "parent-a");
+    try env.createSession(alloc, "parent-b");
+    try env.createSession(alloc, "child-id");
+    var manager = Manager{ .sessions = &env.store };
+    var create = try domain.validateCommand(alloc, .{ .create = .{
+        .name = "temporary worker",
+        .mode = .one_off,
+        .prompt = "temporary work",
+    } });
+    defer create.deinit(alloc);
+    var created = try manager.execute(alloc, create, .{
+        .actor_id = "parent-a",
+        .operation_id = "create-one-off",
+        .created_child_id = "child-id",
+        .timestamp_ms = 1,
+    });
+    defer created.deinit(alloc);
+    try std.testing.expect(created == .receipt);
+
+    for ([_]struct {
+        action: domain.RelationshipAction,
+        operation_id: []const u8,
+        parent_id: ?[]const u8,
+    }{
+        .{ .action = .detach, .operation_id = "detach-one-off", .parent_id = null },
+        .{ .action = .reparent, .operation_id = "reparent-one-off", .parent_id = "parent-b" },
+    }) |case| {
+        var command = try domain.validateCommand(alloc, .{ .relationship = .{
+            .action = case.action,
+            .id = "child-id",
+            .parent_id = case.parent_id,
+        } });
+        defer command.deinit(alloc);
+        var rejected = try manager.execute(alloc, command, .{
+            .actor_id = "parent-a",
+            .operation_id = case.operation_id,
+            .relationship_authorization = if (case.action == .detach) .none else .direct,
+            .timestamp_ms = 2,
+        });
+        defer rejected.deinit(alloc);
+        try std.testing.expect(rejected == .failure);
+        try std.testing.expectEqual(FailureCode.invalid_state, rejected.failure.code);
+    }
+
+    var capability = try env.store.openSubagentControlCapabilityReadOnly(
+        alloc,
+        "child-id",
+        .{},
+    );
+    defer capability.deinit();
+    const store = control_store.Store{
+        .capability = &capability,
+        .expected_child_id = "child-id",
+    };
+    var record = try store.load(alloc);
+    defer record.deinit(alloc);
+    try std.testing.expectEqualStrings("parent-a", record.parent_id.?);
+    try std.testing.expect((try relationship_index.lookupSlot(
+        alloc,
+        &env.store,
+        "parent-a",
+        "child-id",
+        .{},
+    )) != null);
+}
+
 test "stored snapshot polling uses fake clock coalesces ticks and stops without model work" {
     const alloc = std.testing.allocator;
     var env = try TestEnvironment.init(alloc);
@@ -8140,6 +8250,142 @@ test "manager snapshot migrates legacy control edges without global discovery" {
         relationship_index.max_candidate_reads +
             session_store.relationship_migration_candidate_limit *
                 (max_snapshot_migration_pages - 1));
+}
+
+test "descendant count remains unknown until legacy migration completes" {
+    const alloc = std.testing.allocator;
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, "root-id");
+    try env.createSession(alloc, "legacy-child");
+    var manager = Manager{ .sessions = &env.store };
+    try executeRelationshipForTest(
+        alloc,
+        &manager,
+        "root-id",
+        "legacy-attach",
+        .attach,
+        "legacy-child",
+        "root-id",
+    );
+    try env.commitSession(alloc, "legacy-child", 2);
+    try std.testing.expect(try relationship_index.removeChild(
+        alloc,
+        &env.store,
+        "root-id",
+        "legacy-child",
+        .{},
+    ));
+
+    for (0..session_store.relationship_migration_candidate_limit + 1) |index| {
+        var id_buffer: [32]u8 = undefined;
+        const id = try std.fmt.bufPrint(&id_buffer, "newer-{d:0>3}", .{index});
+        try env.createSession(alloc, id);
+        try env.commitSession(alloc, id, @intCast(100 + index));
+    }
+
+    try std.testing.expect((try relationship_index.activeCountIfMigrationComplete(
+        alloc,
+        &env.store,
+        "root-id",
+        .{},
+    )) == null);
+    _ = try relationship_index.migrateLegacyPage(alloc, &env.store, "root-id", .{});
+    try std.testing.expect((try relationship_index.activeCountIfMigrationComplete(
+        alloc,
+        &env.store,
+        "root-id",
+        .{},
+    )) == null);
+
+    var active_count: ?u64 = null;
+    for (0..8) |_| {
+        _ = try relationship_index.migrateLegacyPage(alloc, &env.store, "root-id", .{});
+        active_count = try relationship_index.activeCountIfMigrationComplete(
+            alloc,
+            &env.store,
+            "root-id",
+            .{},
+        );
+        if (active_count != null) break;
+    }
+    try std.testing.expectEqual(@as(?u64, 1), active_count);
+}
+
+test "legacy migration participates in the parent control lock boundary" {
+    const alloc = std.testing.allocator;
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, "root-id");
+    try env.indexSession(alloc, "root-id");
+    var capability = try env.store.openSubagentControlCapabilityWritable(
+        alloc,
+        "root-id",
+        .{},
+    );
+    defer capability.deinit();
+    const store = control_store.Store{
+        .capability = &capability,
+        .expected_child_id = "root-id",
+    };
+    var lock = try store.acquireLock();
+    defer lock.release();
+
+    try std.testing.expectError(
+        error.LockBusy,
+        relationship_index.migrateLegacyPage(
+            alloc,
+            &env.store,
+            "root-id",
+            .{},
+        ),
+    );
+}
+
+test "missing child diagnostic retains the exact stale parent edge" {
+    const alloc = std.testing.allocator;
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, "root-id");
+    try env.createSession(alloc, "missing-child");
+    var manager = Manager{ .sessions = &env.store };
+    try executeRelationshipForTest(
+        alloc,
+        &manager,
+        "root-id",
+        "attach-missing",
+        .attach,
+        "missing-child",
+        "root-id",
+    );
+    var writer = try env.store.resumeForWrite(alloc, "missing-child");
+    try std.testing.expectEqual(
+        session_store.PristineDiscardDisposition.discarded,
+        env.store.deleteCommittedSession(alloc, &writer),
+    );
+
+    var snapshot = try manager.snapshot(alloc, .{ .root_id = "root-id" });
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.snapshot.nodes.len);
+    try std.testing.expectEqual(@as(usize, 1), snapshot.snapshot.diagnostics.len);
+    const diagnostic = snapshot.snapshot.diagnostics[0];
+    try std.testing.expectEqual(TreeDiagnosticCode.session_unavailable, diagnostic.code);
+    try std.testing.expectEqualStrings("missing-child", diagnostic.session_id);
+    try std.testing.expectEqualStrings("root-id", diagnostic.parent_id.?);
+    try std.testing.expect(try relationship_index.removeChild(
+        alloc,
+        &env.store,
+        diagnostic.parent_id.?,
+        diagnostic.session_id,
+        .{},
+    ));
+    try std.testing.expect((try relationship_index.lookupSlot(
+        alloc,
+        &env.store,
+        "root-id",
+        "missing-child",
+        .{},
+    )) == null);
 }
 
 test "manager snapshot recovers every pending free boundary without exposing the edge" {

--- a/src/core/subagent/parent_delivery_projector.zig
+++ b/src/core/subagent/parent_delivery_projector.zig
@@ -269,6 +269,20 @@ pub fn acknowledge(
     child_store_options: session_child_store.Options,
     acknowledgements: []const runtime_deps.ParentTurnDeliveryAck,
 ) void {
+    _ = acknowledgeWithRetirementSignal(
+        alloc,
+        sessions,
+        child_store_options,
+        acknowledgements,
+    );
+}
+
+pub fn acknowledgeWithRetirementSignal(
+    alloc: Allocator,
+    sessions: *session_store.Store,
+    child_store_options: session_child_store.Options,
+    acknowledgements: []const runtime_deps.ParentTurnDeliveryAck,
+) bool {
     var delivery_manager = communication_manager.Manager{
         .sessions = sessions,
         .child_store_options = child_store_options,
@@ -277,8 +291,10 @@ pub fn acknowledge(
     var discovery_start_offset: ?u64 = null;
     var discovery_next_offset: ?u64 = null;
     var all_acknowledged = true;
+    var final_result_acknowledged = false;
     for (acknowledgements) |ack| {
-        delivery_manager.acknowledgeParentBoundary(
+        const signals_retirement = delivery_manager
+            .acknowledgeParentBoundaryWithFinalResultSignal(
             alloc,
             ack.child_id,
             consumer_id,
@@ -297,7 +313,16 @@ pub fn acknowledge(
                 "parent delivery acknowledgement failed child_id={s} parent_id={s} sequence={d} outcome={s}",
                 .{ ack.child_id, ack.target_session_id, ack.through_sequence, @errorName(err) },
             );
+            continue;
         };
+        final_result_acknowledged = signals_retirement or final_result_acknowledged;
+        if (signals_retirement) {
+            debug_trace.logf(
+                "subagent",
+                "final result acknowledgement committed child_id={s} parent_id={s}",
+                .{ ack.child_id, ack.target_session_id },
+            );
+        }
         const start = ack.discovery_start_offset orelse {
             all_acknowledged = false;
             continue;
@@ -323,15 +348,16 @@ pub fn acknowledge(
         relationship_index.advanceDelivery(
             alloc,
             sessions,
-            discovery_parent_id orelse return,
+            discovery_parent_id orelse return final_result_acknowledged,
             child_store_options,
-            discovery_start_offset orelse return,
-            discovery_next_offset orelse return,
+            discovery_start_offset orelse return final_result_acknowledged,
+            discovery_next_offset orelse return final_result_acknowledged,
         ) catch |err| traceDiscoveryAdvanceFailure(
-            discovery_parent_id orelse return,
+            discovery_parent_id orelse return final_result_acknowledged,
             err,
         );
     }
+    return final_result_acknowledged;
 }
 
 pub fn deinitPrepared(
@@ -694,6 +720,45 @@ test "parent delivery projector prepares one trusted envelope and acknowledges a
     var loaded_parent = try env.store.loadReadOnly(alloc, "parent");
     defer loaded_parent.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 0), loaded_parent.history.len);
+}
+
+test "parent delivery acknowledgement reports stable final result" {
+    const alloc = std.testing.allocator;
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, "parent");
+    try preparePersistentChild(alloc, &env, "parent", "child", "child");
+    var capability = try env.store.openSubagentControlCapabilityWritable(
+        alloc,
+        "child",
+        .{},
+    );
+    defer capability.deinit();
+    const communication_state = communication_store.Store{
+        .capability = &capability,
+        .expected_session_id = "child",
+    };
+    try std.testing.expect(try communication_manager.reconcileFinalResultLocked(
+        alloc,
+        communication_state,
+        .{
+            .child_id = "child",
+            .parent_id = "parent",
+            .work_id = "work",
+            .timestamp_ms = 2,
+            .content = "final result",
+        },
+    ));
+
+    var prepared = (try prepare(alloc, &env.store, "parent", .{})).?;
+    defer deinitPrepared(alloc, &prepared);
+    try std.testing.expect(acknowledgeWithRetirementSignal(
+        alloc,
+        &env.store,
+        .{},
+        prepared.acknowledgements,
+    ));
+    try expectNoPrepared(alloc, &env, "parent");
 }
 
 test "parent delivery projector acknowledges bounded approval before later delivery" {

--- a/src/core/subagent/relationship_index.zig
+++ b/src/core/subagent/relationship_index.zig
@@ -459,6 +459,33 @@ pub fn migrateLegacyPage(
     parent_id: []const u8,
     options: session_child_store.Options,
 ) Error!MigrationStats {
+    var parent_capability = sessions.openSubagentControlCapabilityWritable(
+        alloc,
+        parent_id,
+        options,
+    ) catch |err| return switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        error.InvalidSessionId, error.SessionNotFound => error.SessionNotFound,
+        error.SessionPathUnsafe,
+        error.PrivateStatePermissionsUnsupported,
+        => error.PathUnsafe,
+        else => error.StoreUnavailable,
+    };
+    defer parent_capability.deinit();
+    const parent_store = control_store.Store{
+        .capability = &parent_capability,
+        .expected_child_id = parent_id,
+    };
+    var parent_lock = parent_store.acquireLock() catch |err| return switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        error.ControlLockBusy => error.LockBusy,
+        error.ControlLockUnsupported => error.LockUnsupported,
+        error.ControlPathUnsafe,
+        error.PrivateStatePermissionsUnsupported,
+        => error.PathUnsafe,
+        error.ControlStoreFailed => error.StoreUnavailable,
+    };
+    defer parent_lock.release();
     const continuation = try migrationCursor(
         alloc,
         sessions,
@@ -518,6 +545,46 @@ pub fn migrateLegacyPage(
         migration_page.cursor,
     );
     return stats;
+}
+
+/// Returns the indexed child count only when the existing migration cursor
+/// proves that the current session-index snapshot has been exhausted. The
+/// caller must separately serialize relationship writers through the parent
+/// control lock when using this as a destructive leaf proof.
+pub fn activeCountIfMigrationComplete(
+    alloc: Allocator,
+    sessions: *session_store.Store,
+    parent_id: []const u8,
+    options: session_child_store.Options,
+) Error!?u64 {
+    var opened = try Opened.initReadOnly(alloc, sessions, parent_id, options);
+    defer opened.deinit();
+    const header = try opened.loadStableHeader();
+    const continuation = session_store.RelationshipMigrationCursor{
+        .inode = header.migration_inode,
+        .size = header.migration_size,
+        .mtime_ns = header.migration_mtime_ns,
+        .offset = header.migration_offset,
+    };
+    var migration_page = sessions.listRelationshipMigrationCandidates(
+        alloc,
+        continuation,
+    ) catch |err| return switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        error.SessionStoreUnavailable => error.StoreUnavailable,
+    };
+    defer migration_page.deinit(alloc);
+    try opened.verifyStableHeader(header);
+    if (!header.active_count_known or migration_page.has_more or
+        migration_page.ids.items.len != 0 or
+        migration_page.cursor.inode != continuation.inode or
+        migration_page.cursor.size != continuation.size or
+        migration_page.cursor.mtime_ns != continuation.mtime_ns or
+        migration_page.cursor.offset != continuation.offset)
+    {
+        return null;
+    }
+    return header.active_count;
 }
 
 pub fn deliveryPage(

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -4,11 +4,185 @@ const session = @import("../session/session.zig");
 const session_codec = @import("../session/session_codec.zig");
 const session_log = @import("../session/session_log.zig");
 const session_store = @import("../session/session_store.zig");
+const session_summary_codec = @import("../session/session_summary_codec.zig");
 const control_store = @import("control_store.zig");
 const domain = @import("domain.zig");
 const manager_mod = @import("manager.zig");
 
 const Allocator = std.mem.Allocator;
+
+pub const ActionableContinuation = struct {
+    updated_at_ms: i64,
+    id: []u8,
+
+    pub fn deinit(self: *ActionableContinuation, alloc: Allocator) void {
+        alloc.free(self.id);
+        self.* = undefined;
+    }
+
+    pub fn view(self: ActionableContinuation) session_store.ResumableSessionContinuation {
+        return .{ .updated_at_ms = self.updated_at_ms, .id = self.id };
+    }
+};
+
+pub const ActionableSessionPage = struct {
+    summaries: std.ArrayList(session_store.SessionSummary) = .empty,
+    has_more: bool = false,
+    continuation: ?ActionableContinuation = null,
+
+    pub fn deinit(self: *ActionableSessionPage, alloc: Allocator) void {
+        for (self.summaries.items) |*summary| summary.deinit(alloc);
+        self.summaries.deinit(alloc);
+        if (self.continuation) |*continuation| continuation.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+pub fn listActionablePage(
+    store: session_store.Store,
+    alloc: Allocator,
+    scope: session_store.SessionListScope,
+    active_id: ?[]const u8,
+    continuation: ?session_store.ResumableSessionContinuation,
+    limit: usize,
+) !ActionableSessionPage {
+    return (try listActionablePageInternal(
+        store,
+        alloc,
+        scope,
+        active_id,
+        continuation,
+        limit,
+        false,
+    )).?;
+}
+
+pub fn tryListActionableIndexPage(
+    store: session_store.Store,
+    alloc: Allocator,
+    scope: session_store.SessionListScope,
+    active_id: ?[]const u8,
+    continuation: ?session_store.ResumableSessionContinuation,
+    limit: usize,
+) !?ActionableSessionPage {
+    return listActionablePageInternal(
+        store,
+        alloc,
+        scope,
+        active_id,
+        continuation,
+        limit,
+        true,
+    );
+}
+
+fn listActionablePageInternal(
+    store: session_store.Store,
+    alloc: Allocator,
+    scope: session_store.SessionListScope,
+    active_id: ?[]const u8,
+    continuation: ?session_store.ResumableSessionContinuation,
+    limit: usize,
+    index_only: bool,
+) !?ActionableSessionPage {
+    if (limit == 0 or limit > domain.max_page_limit) {
+        return error.InvalidSessionListLimit;
+    }
+    var result: ActionableSessionPage = .{};
+    errdefer result.deinit(alloc);
+    var owned_continuation: ?ActionableContinuation = if (continuation) |value| .{
+        .updated_at_ms = value.updated_at_ms,
+        .id = try alloc.dupe(u8, value.id),
+    } else null;
+    defer if (owned_continuation) |*value| value.deinit(alloc);
+    var scanned: usize = 0;
+
+    while (result.summaries.items.len < limit and scanned < domain.max_page_limit) {
+        var scoped = store;
+        scoped.resume_page_limit = @min(
+            limit - result.summaries.items.len,
+            domain.max_page_limit - scanned,
+        );
+        const position = if (owned_continuation) |value| value.view() else null;
+        const maybe_page = if (index_only) switch (scope) {
+            .current_workspace => try scoped.tryListResumableWorkspaceIndexPage(
+                alloc,
+                active_id,
+                position,
+            ),
+            .all_workspaces => try scoped.tryListResumableIndexPage(
+                alloc,
+                active_id,
+                position,
+            ),
+        } else switch (scope) {
+            .current_workspace => try scoped.listResumableWorkspacePage(
+                alloc,
+                active_id,
+                position,
+            ),
+            .all_workspaces => try scoped.listResumablePage(
+                alloc,
+                active_id,
+                position,
+            ),
+        };
+        var page = maybe_page orelse {
+            result.deinit(alloc);
+            return null;
+        };
+        defer page.deinit(alloc);
+        result.has_more = page.has_more;
+        if (page.summaries.items.len == 0) break;
+
+        for (page.summaries.items) |summary| {
+            scanned += 1;
+            if (owned_continuation) |*value| value.deinit(alloc);
+            owned_continuation = .{
+                .updated_at_ms = summary.updated_at_ms,
+                .id = try alloc.dupe(u8, summary.id),
+            };
+            if (!try summaryIsActionable(store, alloc, summary.id)) continue;
+            var cloned = try session_summary_codec.cloneSessionSummary(alloc, summary);
+            result.summaries.append(alloc, cloned) catch |err| {
+                cloned.deinit(alloc);
+                return err;
+            };
+        }
+        if (!page.has_more) break;
+    }
+    if (owned_continuation) |value| {
+        result.continuation = value;
+        owned_continuation = null;
+    }
+    return result;
+}
+
+fn summaryIsActionable(
+    store: session_store.Store,
+    alloc: Allocator,
+    session_id: []const u8,
+) error{OutOfMemory}!bool {
+    var capability = store.openSubagentControlCapabilityReadOnly(
+        alloc,
+        session_id,
+        .{},
+    ) catch |err| return switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => false,
+    };
+    defer capability.deinit();
+    const controls = control_store.Store{
+        .capability = &capability,
+        .expected_child_id = session_id,
+    };
+    var record = (controls.loadOptional(alloc) catch |err| return switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => false,
+    }) orelse return true;
+    defer record.deinit(alloc);
+    return record.mode == .persistent;
+}
 
 /// Resumes a session for a user-authored prompt while preserving the canonical
 /// one-off child lifecycle. Internal child execution uses the mode-neutral
@@ -242,6 +416,48 @@ test "external prompt resume rejects a canonical one-off child" {
         }
         return error.TestExpectedResumeViewAdmissionError;
     } else |err| try std.testing.expectEqual(error.OneOffSessionNotResumable, err);
+}
+
+test "actionable catalog advances across a bounded hidden-only page" {
+    const alloc = std.testing.allocator;
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, "parent");
+    try env.createVisibleSession(alloc, "ordinary");
+    for (0..domain.max_page_limit + 1) |index| {
+        var id_buffer: [32]u8 = undefined;
+        const id = try std.fmt.bufPrint(&id_buffer, "one-off-{d:0>2}", .{index});
+        try env.createVisibleSession(alloc, id);
+        try env.createControl(alloc, id, .one_off);
+    }
+
+    var hidden_page = try listActionablePage(
+        env.store,
+        alloc,
+        .all_workspaces,
+        "parent",
+        null,
+        1,
+    );
+    defer hidden_page.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), hidden_page.summaries.items.len);
+    try std.testing.expect(hidden_page.has_more);
+    const continuation = hidden_page.continuation orelse
+        return error.TestUnexpectedResult;
+
+    var visible_page = try listActionablePage(
+        env.store,
+        alloc,
+        .all_workspaces,
+        "parent",
+        continuation.view(),
+        1,
+    );
+    defer visible_page.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), visible_page.summaries.items.len);
+    try std.testing.expectEqualStrings("ordinary", visible_page.summaries.items[0].id);
+    try std.testing.expect(!visible_page.has_more);
+    try std.testing.expectEqualStrings("ordinary", visible_page.continuation.?.id);
 }
 
 test "external prompt resume keeps ordinary sessions writable" {
@@ -501,6 +717,26 @@ const TestEnvironment = struct {
         state.created_at_ms = self.next_timestamp_ms;
         state.updated_at_ms = self.next_timestamp_ms;
         self.next_timestamp_ms += 1;
+        var loaded = try self.store.startWritableSession(alloc, state);
+        loaded.deinit(alloc);
+    }
+
+    fn createVisibleSession(
+        self: *TestEnvironment,
+        alloc: Allocator,
+        id: []const u8,
+    ) !void {
+        var state = try testSessionState(alloc, id, self.workspace);
+        defer state.deinit(alloc);
+        state.created_at_ms = self.next_timestamp_ms;
+        state.updated_at_ms = self.next_timestamp_ms;
+        self.next_timestamp_ms += 1;
+        const history = try alloc.alloc(session.HistoryTurn, 1);
+        history[0] = session.makeAssistantTurn(alloc, "prompt", "response") catch |err| {
+            alloc.free(history);
+            return err;
+        };
+        state.history = history;
         var loaded = try self.store.startWritableSession(alloc, state);
         loaded.deinit(alloc);
     }

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -169,6 +169,7 @@ fn summaryIsActionable(
         .{},
     ) catch |err| return switch (err) {
         error.OutOfMemory => error.OutOfMemory,
+        error.SessionNotFound => true,
         else => false,
     };
     defer capability.deinit();

--- a/src/core/subagent/tool_host.zig
+++ b/src/core/subagent/tool_host.zig
@@ -341,6 +341,7 @@ pub const Runtime = struct {
             },
             .live_authority = &self.authority_resolver,
             .approval_registry = &self.approvals,
+            .retirement_root_id = self.root_id,
             .notification_clock = .{
                 .now_fn = notificationNow,
             },
@@ -379,6 +380,18 @@ pub const Runtime = struct {
     ) ![]u8 {
         if (command.* == .inspect) {
             return self.executeModelInspection(alloc, command.*, options);
+        }
+        if (command.* == .create and
+            !try self.callerMayCreate(alloc, options.caller_id))
+        {
+            return boundedFailureAlloc(
+                alloc,
+                options.invocation_id,
+                null,
+                "invalid_state",
+                false,
+                options.max_result_bytes,
+            );
         }
         if (!try self.admitModelCommand(
             alloc,
@@ -735,6 +748,33 @@ pub const Runtime = struct {
             command.create.configuration.permission_mode = admitted;
         }
         return true;
+    }
+
+    fn callerMayCreate(
+        self: *Runtime,
+        alloc: Allocator,
+        caller_id: []const u8,
+    ) error{OutOfMemory}!bool {
+        if (std.mem.eql(u8, caller_id, self.root_id)) return true;
+        var capability = self.sessions.openSubagentControlCapabilityReadOnly(
+            alloc,
+            caller_id,
+            self.manager.options.child_store,
+        ) catch |err| return switch (err) {
+            error.OutOfMemory => error.OutOfMemory,
+            else => false,
+        };
+        defer capability.deinit();
+        const store = control_store.Store{
+            .capability = &capability,
+            .expected_child_id = caller_id,
+        };
+        var record = (store.loadOptional(alloc) catch |err| return switch (err) {
+            error.OutOfMemory => error.OutOfMemory,
+            else => false,
+        }) orelse return false;
+        defer record.deinit(alloc);
+        return record.mode != .one_off;
     }
 
     /// Typed human adapter for the same canonical command/effect path used by
@@ -1225,9 +1265,11 @@ pub const Runtime = struct {
             self.root_id,
             timestamp_ms,
         ) catch |err| {
+            self.requestRetirementSweep(timestamp_ms);
             self.finishRecoveryLocked(.failed);
             return err;
         };
+        self.requestRetirementSweep(timestamp_ms);
         self.finishRecoveryLocked(if (report.fullyReconciled())
             .fully_reconciled
         else
@@ -1279,6 +1321,22 @@ pub const Runtime = struct {
 
     pub fn recoveryState(self: *const Runtime) RecoveryState {
         return self.recovery_state.load(.acquire);
+    }
+
+    pub fn requestRetirementSweep(self: *Runtime, timestamp_ms: i64) void {
+        self.owner.requestRetirementSweep(timestamp_ms) catch |err| {
+            debug_trace.logf(
+                "subagent",
+                "retirement sweep wake failed root_id={s} outcome={s}",
+                .{ self.root_id, @errorName(err) },
+            );
+            return;
+        };
+        debug_trace.logf(
+            "subagent",
+            "retirement sweep requested root_id={s}",
+            .{self.root_id},
+        );
     }
 
     fn backgroundRecoveryMain(self: *Runtime, timestamp_ms: i64) void {
@@ -1463,7 +1521,8 @@ pub const Runtime = struct {
                 ),
                 .close => {},
             },
-            .inspect, .relationship, .configure => {},
+            .relationship => self.requestRetirementSweep(context.timestamp_ms),
+            .inspect, .configure => {},
         };
         return result;
     }
@@ -2933,6 +2992,71 @@ fn testHumanOptions(invocation_id: []const u8) HumanCommandOptions {
         },
         .timestamp_ms = 10,
     };
+}
+
+test "one off caller cannot create before identity or child allocation" {
+    const alloc = std.testing.allocator;
+    const root_id = "01J00000000000000000000000";
+    const caller_id = "01J00000000000000000000001";
+    var env = try TestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    try env.createSession(alloc, root_id);
+    try env.createSession(alloc, caller_id);
+    var test_authority = TestAuthority{ .root_id = root_id };
+    const host = try Runtime.create(
+        alloc,
+        &env.store,
+        root_id,
+        test_authority.resolver(),
+        .{},
+    );
+    defer host.deinit();
+
+    var caller_create = try domain.validateCommand(alloc, .{ .create = .{
+        .name = "temporary caller",
+        .mode = .one_off,
+        .prompt = "temporary work",
+    } });
+    defer caller_create.deinit(alloc);
+    var caller_created = try host.manager.execute(alloc, caller_create, .{
+        .actor_id = root_id,
+        .operation_id = "create-one-off-caller",
+        .created_child_id = caller_id,
+        .timestamp_ms = 1,
+    });
+    defer caller_created.deinit(alloc);
+    try std.testing.expect(caller_created == .receipt);
+
+    var nested_create = try domain.validateCommand(alloc, .{ .create = .{
+        .name = "must not exist",
+        .mode = .persistent,
+    } });
+    defer nested_create.deinit(alloc);
+    const rejected = try host.execute(
+        alloc,
+        &nested_create,
+        testOptions(caller_id, "one-off-nested-create"),
+    );
+    defer alloc.free(rejected);
+    try std.testing.expect(std.mem.find(u8, rejected, "invalid_state") != null);
+
+    var root_capability = try env.store.openSubagentControlCapabilityReadOnly(
+        alloc,
+        root_id,
+        .{},
+    );
+    defer root_capability.deinit();
+    const operations = create_store.Store{
+        .capability = &root_capability,
+        .expected_root_id = root_id,
+    };
+    try std.testing.expect((try operations.loadOptional(alloc)) == null);
+
+    var nested = try host.manager.snapshot(alloc, .{
+        .root_id = caller_id,
+    });
+    defer nested.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), nested.snapshot.nodes.len);
 }
 
 test "model child permissions inherit and reject elevation before persistence" {

--- a/src/core/subagent/tool_host.zig
+++ b/src/core/subagent/tool_host.zig
@@ -1324,6 +1324,7 @@ pub const Runtime = struct {
     }
 
     pub fn requestRetirementSweep(self: *Runtime, timestamp_ms: i64) void {
+        if (comptime builtin.single_threaded) return;
         self.owner.requestRetirementSweep(timestamp_ms) catch |err| {
             debug_trace.logf(
                 "subagent",

--- a/src/core/subagent/ui_projection.zig
+++ b/src/core/subagent/ui_projection.zig
@@ -8,6 +8,7 @@ const control_store = @import("control_store.zig");
 const domain = @import("domain.zig");
 const execution = @import("execution.zig");
 const manager_mod = @import("manager.zig");
+const resume_admission = @import("resume_admission.zig");
 const tool_result = @import("tool_result.zig");
 const activity_runtime = @import("../output/activity_runtime.zig");
 const io_mod = @import("../shared/io.zig");
@@ -236,10 +237,12 @@ pub const AttachCandidate = struct {
 pub const AttachPage = struct {
     candidates: []AttachCandidate,
     has_more: bool,
+    continuation: ?resume_admission.ActionableContinuation = null,
 
     pub fn deinit(self: *AttachPage, alloc: Allocator) void {
         for (self.candidates) |*candidate| candidate.deinit(alloc);
         alloc.free(self.candidates);
+        if (self.continuation) |*continuation| continuation.deinit(alloc);
         self.* = undefined;
     }
 };
@@ -252,10 +255,13 @@ pub fn loadAttachPage(
     source: Source,
     continuation: ?session_store.ResumableSessionContinuation,
 ) !AttachPage {
-    var page = try source.sessions.listResumablePage(
+    var page = try resume_admission.listActionablePage(
+        source.sessions.*,
         alloc,
+        .all_workspaces,
         source.root_id,
         continuation,
+        session_store.default_resume_page_limit,
     );
     defer page.deinit(alloc);
 
@@ -269,7 +275,13 @@ pub fn loadAttachPage(
         candidates[built] = try projectAttachCandidate(alloc, source, summary);
         built += 1;
     }
-    return .{ .candidates = candidates, .has_more = page.has_more };
+    const next_continuation = page.continuation;
+    page.continuation = null;
+    return .{
+        .candidates = candidates,
+        .has_more = page.has_more,
+        .continuation = next_continuation,
+    };
 }
 
 fn projectAttachCandidate(
@@ -743,6 +755,7 @@ fn loadPageWithTreeLimit(
         .root_id = source.root_id,
         .cursor = cursor,
         .limit = tree_limit,
+        .hide_terminal_one_off = true,
     });
     var restarted = false;
 
@@ -758,6 +771,7 @@ fn loadPageWithTreeLimit(
                 .root_id = source.root_id,
                 .anchor_id = anchor_id,
                 .limit = tree_limit,
+                .hide_terminal_one_off = true,
             });
         },
     }
@@ -1552,8 +1566,16 @@ fn cloneDiagnostics(
         alloc.free(out);
     }
     for (diagnostics) |diagnostic| {
+        const session_id = try alloc.dupe(u8, diagnostic.session_id);
+        errdefer alloc.free(session_id);
+        const parent_id = if (diagnostic.parent_id) |value|
+            try alloc.dupe(u8, value)
+        else
+            null;
+        errdefer if (parent_id) |value| alloc.free(value);
         out[built] = .{
-            .session_id = try alloc.dupe(u8, diagnostic.session_id),
+            .session_id = session_id,
+            .parent_id = parent_id,
             .code = diagnostic.code,
         };
         built += 1;
@@ -1657,6 +1679,7 @@ fn snapshotContentHash(
     }
     for (tree.diagnostics) |diagnostic| {
         hash.update(diagnostic.session_id);
+        if (diagnostic.parent_id) |parent_id| hash.update(parent_id);
         hashValue(&hash, diagnostic.code);
     }
     hashValue(&hash, tree.diagnostics_truncated);
@@ -2015,6 +2038,82 @@ test "authoritative bounded pages relocate a later configured child after a stal
     try std.testing.expect(missing.snapshot.restart_required);
     try std.testing.expect(missing.snapshot.page_cursor == null);
     try std.testing.expectEqual(tree_limit, missing.snapshot.nodes.len);
+}
+
+test "visible manager hides terminal one offs without removing canonical descendants" {
+    const alloc = std.testing.allocator;
+    var env = try ProjectionTestEnvironment.init(alloc);
+    defer env.deinit(alloc);
+    for ([_][]const u8{ "root-id", "one-off", "descendant", "persistent" }) |id| {
+        try env.createSession(alloc, id);
+    }
+    var manager = manager_mod.Manager{ .sessions = &env.store };
+
+    var one_off = try domain.validateCommand(alloc, .{ .create = .{
+        .name = "temporary",
+        .mode = .one_off,
+        .prompt = "temporary work",
+    } });
+    defer one_off.deinit(alloc);
+    var created_one_off = try manager.execute(alloc, one_off, .{
+        .actor_id = "root-id",
+        .operation_id = "create-one-off",
+        .created_child_id = "one-off",
+        .timestamp_ms = 1,
+    });
+    defer created_one_off.deinit(alloc);
+
+    for ([_]struct {
+        actor_id: []const u8,
+        child_id: []const u8,
+        operation_id: []const u8,
+    }{
+        .{ .actor_id = "one-off", .child_id = "descendant", .operation_id = "create-descendant" },
+        .{ .actor_id = "root-id", .child_id = "persistent", .operation_id = "create-persistent" },
+    }) |entry| {
+        var create = try domain.validateCommand(alloc, .{ .create = .{
+            .name = entry.child_id,
+            .mode = .persistent,
+        } });
+        defer create.deinit(alloc);
+        var created = try manager.execute(alloc, create, .{
+            .actor_id = entry.actor_id,
+            .operation_id = entry.operation_id,
+            .created_child_id = entry.child_id,
+            .timestamp_ms = 2,
+        });
+        defer created.deinit(alloc);
+        try std.testing.expect(created == .receipt);
+    }
+
+    var cancel = try domain.validateCommand(alloc, .{ .lifecycle = .{
+        .id = "one-off",
+        .action = .cancel,
+    } });
+    defer cancel.deinit(alloc);
+    var cancelled = try manager.execute(alloc, cancel, .{
+        .actor_id = "root-id",
+        .operation_id = "cancel-one-off",
+        .timestamp_ms = 3,
+    });
+    defer cancelled.deinit(alloc);
+    try std.testing.expect(cancelled == .receipt);
+
+    const source = Source{
+        .root_id = "root-id",
+        .manager = &manager,
+        .sessions = &env.store,
+    };
+    var visible = try loadPageWithTreeLimit(alloc, source, null, null, 2);
+    defer visible.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), visible.snapshot.nodes.len);
+    try std.testing.expectEqualStrings("descendant", visible.snapshot.nodes[0].child_id);
+    try std.testing.expectEqualStrings("persistent", visible.snapshot.nodes[1].child_id);
+
+    var canonical = try manager.snapshot(alloc, .{ .root_id = "root-id", .limit = 3 });
+    defer canonical.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 3), canonical.snapshot.nodes.len);
+    try std.testing.expectEqualStrings("one-off", canonical.snapshot.nodes[0].child_id);
 }
 
 test "pending approval pages reach beyond eight independently of the bounded tree page" {

--- a/src/ui/subagent/runtime.zig
+++ b/src/ui/subagent/runtime.zig
@@ -12,6 +12,7 @@ const io_mod = @import("../../core/shared/io.zig");
 const manager_mod = @import("../../core/subagent/manager.zig");
 const permission_request = @import("../../core/permissions/permission_request.zig");
 const projection = @import("../../core/subagent/ui_projection.zig");
+const resume_admission = @import("../../core/subagent/resume_admission.zig");
 const terminal_projection = @import("../../core/terminal/ui_projection.zig");
 const skill_contract = @import("../../core/skills/skill_contract.zig");
 const input_action = @import("../../core/input/input_action.zig");
@@ -342,6 +343,7 @@ const AttachState = struct {
     candidates: std.ArrayList(projection.AttachCandidate) = .empty,
     selected: usize = 0,
     has_more: bool = false,
+    continuation: ?resume_admission.ActionableContinuation = null,
     loading: bool = false,
     selection_stale: bool = false,
     attempt: MutationAttempt = .{},
@@ -355,6 +357,8 @@ const AttachState = struct {
     fn clear(self: *AttachState, alloc: Allocator) void {
         for (self.candidates.items) |*candidate| candidate.deinit(alloc);
         self.candidates.clearRetainingCapacity();
+        if (self.continuation) |*continuation| continuation.deinit(alloc);
+        self.continuation = null;
         self.attempt.deinit(alloc);
         self.selected = 0;
         self.has_more = false;
@@ -2203,6 +2207,12 @@ pub const Runtime = struct {
         var page = page_value;
         errdefer page.deinit(alloc);
         const has_more = page.has_more;
+        const continuation = page.continuation;
+        page.continuation = null;
+        errdefer if (continuation) |value| {
+            var owned = value;
+            owned.deinit(alloc);
+        };
         if (!append) {
             const prior_selected = self.attach.selectedCandidate();
             var next_candidates: std.ArrayList(projection.AttachCandidate) = .empty;
@@ -2237,6 +2247,8 @@ pub const Runtime = struct {
         }
         alloc.free(page.candidates);
         page = undefined;
+        if (self.attach.continuation) |*prior| prior.deinit(alloc);
+        self.attach.continuation = continuation;
         self.attach.has_more = has_more;
         self.attach.loading = false;
         if (self.attach.candidates.items.len == 0) self.attach.selected = 0 else {
@@ -2253,9 +2265,9 @@ pub const Runtime = struct {
     }
 
     pub fn attachContinuation(self: Runtime) ?@import("../../core/session/session_store.zig").ResumableSessionContinuation {
-        if (!self.attach.has_more or self.attach.candidates.items.len == 0) return null;
-        const last = self.attach.candidates.items[self.attach.candidates.items.len - 1];
-        return .{ .updated_at_ms = last.updated_at_ms, .id = last.session_id };
+        if (!self.attach.has_more) return null;
+        const continuation = self.attach.continuation orelse return null;
+        return continuation.view();
     }
 
     pub fn prepareManagerMutation(

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -6169,26 +6169,29 @@ describe("acp: model-independent", () => {
   }
 
   test(
-    "session/load rejects a completed one-off child without changing its control",
+    "session/load denies pending one-off then returns not found after retirement",
     async () => {
       const root = createIsolatedRoot("fx-acp-one-off-load-");
       const childName = "acp-readonly-child";
       const childPrompt = "ACP_ONE_OFF_LOAD_CHILD";
-      const routeChildAndParent = (body: string) =>
-        body.includes(childPrompt)
-          ? finalText("ACP_ONE_OFF_LOAD_CHILD_DONE")
-          : finalText("ACP_ONE_OFF_LOAD_PARENT_DONE");
-      const gateway = startFakeGateway([
-        fakeGatewayToolCall("acp_one_off_load_create", "subagent", {
+      const gateway = startDynamicFakeGateway((body) => {
+        if (body.includes("Acknowledge the completed one-off result.")) {
+          return finalText("ACP_ONE_OFF_RETIREMENT_ACK_DONE");
+        }
+        if (body.includes('"toolCallId":"acp_one_off_load_create"')) {
+          return finalText("ACP_ONE_OFF_LOAD_PARENT_DONE");
+        }
+        if (body.includes(childPrompt)) {
+          return finalText("ACP_ONE_OFF_LOAD_CHILD_DONE");
+        }
+        return fakeGatewayToolCall("acp_one_off_load_create", "subagent", {
           command: { create: {
             name: childName,
             mode: "one_off",
             prompt: childPrompt,
           } },
-        }),
-        routeChildAndParent,
-        routeChildAndParent,
-      ]);
+        });
+      });
       try {
         client = await AcpClient.create({
           cwd: root.workspace,
@@ -6201,25 +6204,32 @@ describe("acp: model-independent", () => {
           TIMEOUT,
         );
         expect(result.promptResult.result.stopReason).toBe("end_turn");
+        const sessionsDir = join(root.home, ".fx", "sessions");
+        let control: { id: string; path: string } | undefined;
         await waitForCondition(
           "ACP one-off child completion",
-          () => gateway.requests.length === 3,
+          () => {
+            if (gateway.requests.length !== 3) return false;
+            control = readdirSync(sessionsDir)
+              .map((id) => ({
+                id,
+                path: join(sessionsDir, id, "subagent", "control.json"),
+              }))
+              .filter((entry) => existsSync(entry.path))
+              .find((entry) => {
+                const record = JSON.parse(readFileSync(entry.path, "utf8")) as {
+                  state: string;
+                  configuration: { name: string };
+                };
+                return record.configuration.name === childName &&
+                  record.state === "completed";
+              });
+            return control !== undefined;
+          },
+          TIMEOUT,
         );
         await client.close();
 
-        const sessionsDir = join(root.home, ".fx", "sessions");
-        const control = readdirSync(sessionsDir)
-          .map((id) => ({
-            id,
-            path: join(sessionsDir, id, "subagent", "control.json"),
-          }))
-          .filter((entry) => existsSync(entry.path))
-          .find((entry) => {
-            const record = JSON.parse(readFileSync(entry.path, "utf8")) as {
-              configuration: { name: string };
-            };
-            return record.configuration.name === childName;
-          });
         if (!control) throw new Error("ACP one-off control was not persisted");
         const controlBefore = readFileSync(control.path, "utf8");
 
@@ -6249,6 +6259,44 @@ describe("acp: model-independent", () => {
         const parent = await readResponse(client, 12);
         expect(parent.error).toBeUndefined();
         expect(Array.isArray(parent.result?.configOptions)).toBe(true);
+
+        await client.close();
+        client = null;
+        const acknowledged = await runFx([
+          "ask",
+          "--json",
+          "--auto",
+          "--resume-id",
+          parentId,
+          "Acknowledge the completed one-off result.",
+        ], {
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        });
+        expect(acknowledged.code).toBe(0);
+        expect(gateway.requests.at(-1)?.body).toContain(
+          "ACP_ONE_OFF_LOAD_CHILD_DONE",
+        );
+        await waitForCondition(
+          "ACP one-off child retirement",
+          () => !existsSync(control.path),
+        );
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 20);
+        const retired = await client.request(
+          "session/load",
+          { sessionId: control.id, mcpServers: [] },
+          21,
+        ) as any;
+        expect(retired.error).toEqual({
+          code: -32602,
+          message: "Session not found",
+        });
+        expect(gateway.requests).toHaveLength(4);
         expect(client.stderr).toBe("");
       } finally {
         await client?.close();
@@ -6256,7 +6304,7 @@ describe("acp: model-independent", () => {
         rmSync(root.root, { recursive: true, force: true });
       }
     },
-    TIMEOUT,
+    LIVE_TIMEOUT,
   );
 
   test(

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -141,12 +141,16 @@ function classifierTrustContext(body: string): string {
   return evidence.slice(start, end);
 }
 
-function subagentCreateCall(toolCallId: string, prompt: string) {
+function subagentCreateCall(
+  toolCallId: string,
+  prompt: string,
+  mode: "one_off" | "persistent" = "one_off",
+) {
   return gatewayToolCall("subagent", {
     command: {
       create: {
         name: "bounded-child",
-        mode: "one_off",
+        mode,
         prompt,
       },
     },
@@ -4372,7 +4376,7 @@ describe("effect-aware command permissions", () => {
         }, "nested_create_1");
       };
       const gateway = startFakeGateway([
-        subagentCreateCall("root_create_1", childPrompt),
+        subagentCreateCall("root_create_1", childPrompt, "persistent"),
         route,
         route,
         route,
@@ -5073,7 +5077,7 @@ describe("effect-aware command permissions", () => {
             command: {
               create: {
                 name: "interactive-approval-child",
-                mode: "one_off",
+                mode: "persistent",
                 prompt: childPrompt,
                 permission_mode: "ask",
               },
@@ -5124,11 +5128,11 @@ describe("effect-aware command permissions", () => {
       );
       expect(existsSync(markerPath)).toBe(false);
       const childDeadline = Date.now() + TIMEOUT;
-      while (subagentState(root, childId) !== "completed" &&
+      while (subagentState(root, childId) !== "idle" &&
              Date.now() < childDeadline) {
         await Bun.sleep(20);
       }
-      expect(subagentState(root, childId)).toBe("completed");
+      expect(subagentState(root, childId)).toBe("idle");
       const stored = JSON.parse(readFileSync(
         join(root.home, ".fx", "sessions", childId, "subagent", "communication.json"),
         "utf8",

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -4114,31 +4114,6 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         await active.sendKeys("C-x");
         await active.waitForComposer(TIMEOUT);
 
-        await active.sendText("/resume");
-        let resumePane = await active.waitForPane(
-          (pane) => pane.includes("Sessions"),
-          TIMEOUT,
-        );
-        const resumeContainsPersistent = (pane: string) => {
-          const sessionsStart = pane.indexOf("Sessions");
-          return sessionsStart >= 0 &&
-            pane.slice(sessionsStart).includes(persistentInitial);
-        };
-        if (!resumeContainsPersistent(resumePane)) {
-          await active.sendKeys("Escape");
-          await active.waitForComposer(TIMEOUT);
-          await Bun.sleep(5_100);
-          await active.sendText("/resume");
-          resumePane = await active.waitForPane(
-            (pane) => resumeContainsPersistent(pane) && !pane.includes(childName),
-            TIMEOUT,
-          );
-        }
-        expect(resumeContainsPersistent(resumePane)).toBe(true);
-        expect(resumePane).not.toContain(childName);
-        await active.sendKeys("Escape");
-        await active.waitForComposer(TIMEOUT);
-
         await active.sendText(parentAck);
         await active.waitForText(parentAckDone, TIMEOUT);
         expect(

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -4115,10 +4115,26 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         await active.waitForComposer(TIMEOUT);
 
         await active.sendText("/resume");
-        const resumePane = await active.waitForPane(
-          (pane) => pane.includes(persistentInitial) && !pane.includes(childName),
+        let resumePane = await active.waitForPane(
+          (pane) => pane.includes("Sessions"),
           TIMEOUT,
         );
+        const resumeContainsPersistent = (pane: string) => {
+          const sessionsStart = pane.indexOf("Sessions");
+          return sessionsStart >= 0 &&
+            pane.slice(sessionsStart).includes(persistentInitial);
+        };
+        if (!resumeContainsPersistent(resumePane)) {
+          await active.sendKeys("Escape");
+          await active.waitForComposer(TIMEOUT);
+          await Bun.sleep(5_100);
+          await active.sendText("/resume");
+          resumePane = await active.waitForPane(
+            (pane) => resumeContainsPersistent(pane) && !pane.includes(childName),
+            TIMEOUT,
+          );
+        }
+        expect(resumeContainsPersistent(resumePane)).toBe(true);
         expect(resumePane).not.toContain(childName);
         await active.sendKeys("Escape");
         await active.waitForComposer(TIMEOUT);
@@ -5860,7 +5876,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
   );
 
   test(
-    "assembled TTY tree shows model persistent, one-off, nested, and notification config",
+    "assembled TTY tree keeps persistent configuration and hides settled one-offs",
     async () => {
       const fixture = createFixture();
       const persistentPrompt = "CHECKPOINT3_PERSISTENT_CREATES_NESTED";
@@ -5946,45 +5962,14 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         const tree = await active.waitForPane(
           (pane) =>
             pane.includes("assembled-persistent") &&
-            pane.includes("assembled-one-off") &&
             pane.includes("idle") &&
-            pane.includes("completed"),
+            !pane.includes("assembled-one-off") &&
+            !pane.includes("assembled-nested"),
           TIMEOUT,
         );
         expect(tree).toContain("Agents & processes");
-        const assembledNames = [
-          "assembled-persistent",
-          "assembled-nested",
-          "assembled-one-off",
-        ];
-        const selectedAssembledName = (pane: string) => {
-          const selectedLine = pane.split("\n").find((line) =>
-            line.startsWith("› ")
-          );
-          return assembledNames.find((name) => selectedLine?.includes(name)) ?? null;
-        };
-        let nestedTree = await active.waitForPane(
-          (pane) => assembledNames.every((name) => pane.includes(name)),
-          TIMEOUT,
-        );
-        expect(nestedTree).toContain("assembled-persistent");
-        expect(nestedTree).toContain("assembled-one-off");
-        for (let moves = 0; moves < assembledNames.length; moves += 1) {
-          const selected = selectedAssembledName(nestedTree);
-          if (selected === "assembled-persistent") break;
-          if (!selected) {
-            throw new Error("assembled tree did not expose a deterministic selection");
-          }
-          await active.sendLiteralText("k");
-          nestedTree = await active.waitForPane(
-            (pane) => {
-              const next = selectedAssembledName(pane);
-              return next !== null && next !== selected;
-            },
-            TIMEOUT,
-          );
-        }
-        expect(selectedAssembledName(nestedTree)).toBe("assembled-persistent");
+        expect(tree).not.toContain("assembled-one-off");
+        expect(tree).not.toContain("assembled-nested");
 
         type Control = {
           child_id: string;
@@ -6002,36 +5987,19 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
           .map((id) => join(sessionsDir, id, "subagent", "control.json"))
           .filter((path) => existsSync(path))
           .map((path) => JSON.parse(readFileSync(path, "utf8")) as Control);
-        let controls = readControls();
+        let persistent: Control | undefined;
         const controlsDeadline = Date.now() + TIMEOUT;
         while (Date.now() < controlsDeadline) {
-          const states = new Map(
-            controls.map((control) => [control.configuration.name, control.state]),
+          persistent = readControls().find(
+            (control) => control.configuration.name === "assembled-persistent" &&
+              control.state === "idle",
           );
-          if (states.get("assembled-persistent") === "idle" &&
-              states.get("assembled-nested") === "completed" &&
-              states.get("assembled-one-off") === "completed") break;
+          if (persistent) break;
           await Bun.sleep(25);
-          controls = readControls();
         }
-        const byName = new Map(
-          controls.map((control) => [control.configuration.name, control]),
-        );
-        const persistent = byName.get("assembled-persistent");
-        const nested = byName.get("assembled-nested");
-        const oneOff = byName.get("assembled-one-off");
-        expect(persistent).toBeDefined();
-        expect(nested).toBeDefined();
-        expect(oneOff).toBeDefined();
+        if (!persistent) throw new Error("assembled persistent control did not settle");
         expect(persistent!.mode).toBe("persistent");
         expect(persistent!.state).toBe("idle");
-        expect(nested).toMatchObject({
-          parent_id: persistent!.child_id,
-          mode: "one_off",
-          state: "completed",
-        });
-        expect(oneOff).toMatchObject({ mode: "one_off", state: "completed" });
-        expect(oneOff!.parent_id).toBe(persistent!.parent_id);
         expect(persistent!.configuration.notifications).toMatchObject({
           milestones: ["assembled-checkpoint"],
           stop_conditions: ["terminal", "duration_elapsed"],

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -3962,80 +3962,77 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
   );
 
   test(
-    "completed one-off child stays read-only across direct resume and restart",
+    "terminal one-off delivers once retires and leaves persistent controls intact",
     async () => {
       const fixture = createFixture();
-      const childName = "readonly-history";
-      const persistentName = "resume-control";
-      const persistentInitial = "PERSISTENT_RESUME_CONTROL_INITIAL";
-      const persistentReady = "PERSISTENT_RESUME_CONTROL_READY";
-      const persistentResume = "PERSISTENT_RESUME_CONTROL_SECOND";
-      const persistentResumed = "PERSISTENT_RESUME_CONTROL_RESUMED";
-      const ordinaryResume = "ORDINARY_RESUME_CONTROL_SECOND";
-      const ordinaryResumed = "ORDINARY_RESUME_CONTROL_RESUMED";
-      const illegalResume = "ONEOFF_ILLEGAL_SECOND_TURN";
-      const mainPrompt = "ONEOFF_READONLY_HISTORY_MAIN";
-      const childPrompt = "ONEOFF_READONLY_HISTORY_CHILD";
-      const childDone = "ONEOFF_READONLY_HISTORY_DONE";
-      const markdown = [
-        "# Read-only history",
-        "",
-        "| a | b |",
-        "| --- | --- |",
-        "| one | two |",
-        "",
-        "```diff",
-        "- before",
-        "+ after",
-        "```",
-        "",
-        ...Array.from(
-          { length: 48 },
-          (_, index) => `history-${String(index + 1).padStart(2, "0")}`,
-        ),
-        "",
-        childDone,
-      ].join("\n");
-      const visibleHistoryRows = (pane: string) =>
-        pane.match(/history-\d{2}/g)?.join("|") ?? "";
+      const childName = "temporary-result";
+      const persistentName = "persistent-control";
+      const persistentInitial = "PERSISTENT_CONTROL_INITIAL";
+      const persistentReady = "PERSISTENT_CONTROL_READY";
+      const persistentResume = "PERSISTENT_CONTROL_SECOND";
+      const persistentResumed = "PERSISTENT_CONTROL_RESUMED";
+      const mainPrompt = "ONEOFF_RETIREMENT_MAIN";
+      const childPrompt = "ONEOFF_RETIREMENT_CHILD";
+      const childDone = "ONEOFF_RETIREMENT_RESULT";
+      const parentAck = "ONEOFF_RETIREMENT_ACK";
+      const parentAckDone = "ONEOFF_RETIREMENT_ACK_DONE";
+      const childStream = controlledTextResponse("ONEOFF_RETIREMENT_STREAM_");
       const gateway = startDynamicFakeGateway((body) => {
-        if (body.includes(persistentResume)) {
-          return fakeGatewayFinalText(persistentResumed);
+        if (body.includes(persistentResume)) return fakeGatewayFinalText(persistentResumed);
+        if (body.includes(parentAck) && body.includes(childDone)) {
+          return fakeGatewayFinalText(parentAckDone);
         }
-        if (body.includes(ordinaryResume)) {
-          return fakeGatewayFinalText(ordinaryResumed);
+        if (body.includes(persistentInitial)) return fakeGatewayFinalText(persistentReady);
+        if (body.includes('"toolCallId":"create_temporary_result"')) {
+          return fakeGatewayFinalText("ONEOFF_RETIREMENT_MAIN_DONE");
         }
-        if (body.includes(persistentInitial)) {
-          return fakeGatewayFinalText(persistentReady);
-        }
-        if (body.includes('"toolCallId":"create_readonly_history"')) {
-          return fakeGatewayFinalText("ONEOFF_READONLY_HISTORY_MAIN_DONE");
-        }
-        if (body.includes(childPrompt)) return fakeGatewayFinalText(markdown);
+        if (body.includes(childPrompt)) return childStream.response;
         if (body.includes(mainPrompt)) {
-          return fakeGatewayToolCall(
-            "create_readonly_history",
-            "subagent",
-            {
-              command: {
-                create: {
-                  name: childName,
-                  mode: "one_off",
-                  prompt: childPrompt,
-                },
+          return fakeGatewayToolCall("create_temporary_result", "subagent", {
+            command: {
+              create: {
+                name: childName,
+                mode: "one_off",
+                prompt: childPrompt,
               },
             },
-          );
+          });
         }
-        return fakeGatewayFinalText("unexpected one-off history request");
+        return fakeGatewayFinalText("unexpected retirement request");
       }, {
         models: [{ id: FAKE_GATEWAY_MODEL, type: "language", tags: ["tool-use"] }],
       });
-      const env = relationshipTestEnv(
-        fixture,
-        gateway,
-        "oneoff-readonly-history",
-      );
+      const env = relationshipTestEnv(fixture, gateway, "oneoff-retirement");
+
+      type ResumeControl = {
+        child_id: string;
+        parent_id: string;
+        mode: "persistent" | "one_off";
+        state: string;
+        configuration: { name: string };
+      };
+      const sessionsDir = join(fixture.home, ".fx", "sessions");
+      const readControls = () =>
+        readdirSync(sessionsDir)
+          .map((id) => join(sessionsDir, id, "subagent", "control.json"))
+          .filter((path) => existsSync(path))
+          .map((path) => ({
+            path,
+            value: JSON.parse(readFileSync(path, "utf8")) as ResumeControl,
+          }));
+
+      async function waitForControl(name: string, state: string) {
+        const deadline = Date.now() + TIMEOUT;
+        while (Date.now() < deadline) {
+          const found = readControls().find((entry) =>
+            entry.value.configuration.name === name &&
+            entry.value.state === state
+          );
+          if (found) return found;
+          await Bun.sleep(25);
+        }
+        throw new Error(`control did not reach ${name}:${state}`);
+      }
 
       async function runAsk(args: string[]) {
         const child = Bun.spawn([FX_BIN, "ask", ...args], {
@@ -4052,50 +4049,14 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         return { stdout, stderr, exitCode };
       }
 
-      async function selectManagerChild(
-        active: TmuxSession,
-        managerPane: string,
-        name: string,
-      ) {
-        const visibleChildren = managerPane
-          .split("\n")
-          .filter((line) =>
-            line.includes(childName) || line.includes(persistentName)
-          );
-        const selectedIndex = visibleChildren.findIndex((line) =>
-          line.startsWith("› ")
-        );
-        const targetIndex = visibleChildren.findIndex((line) =>
-          line.includes(name)
-        );
-        if (selectedIndex < 0 || targetIndex < 0) {
-          throw new Error("manager did not expose deterministic child selection");
-        }
-        const direction = selectedIndex < targetIndex ? "j" : "k";
-        for (
-          let index = 0;
-          index < Math.abs(targetIndex - selectedIndex);
-          index += 1
-        ) {
-          await active.sendLiteralText(direction);
-        }
-        await active.waitForPane(
-          (pane) => pane.split("\n").some((line) =>
-            line.startsWith("› ") && line.includes(name)
-          ),
-          TIMEOUT,
-        );
-      }
-
       try {
         session = await TmuxSession.create({
           cmd: FX_BIN,
           cwd: fixture.workspace,
           env,
-          width: 60,
-          height: 12,
+          width: 80,
+          height: 24,
           stderrPath: fixture.stderrPath,
-          minimumHistoryLines: 100_000,
         });
         const active = session;
         await active.waitForComposer(TIMEOUT);
@@ -4109,175 +4070,91 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         await pasteVisibleText(active, persistentInitial);
         await active.sendKeys("Enter");
         await active.waitForPane(
-          (pane) =>
-            pane.includes(persistentReady) && pane.includes("status: idle"),
+          (pane) => pane.includes(persistentReady) && pane.includes("status: idle"),
           TIMEOUT,
         );
         await active.sendKeys("Escape");
         await active.waitForText("Agents & processes", TIMEOUT);
         await active.sendKeys("C-x");
         await active.waitForComposer(TIMEOUT);
+
         await active.sendText(mainPrompt);
         await active.waitForPane(
-          (pane) =>
-            pane.includes("ONEOFF_READONLY_HISTORY_MAIN_DONE") &&
-            !pane.includes("Streaming ("),
+          (pane) => pane.includes("ONEOFF_RETIREMENT_MAIN_DONE") && !pane.includes("Streaming ("),
           TIMEOUT,
         );
-        const mainGrid = await active.capturePaneGrid();
-        const mainCursor = active.cursorPosition();
-
-        await active.sendKeys("C-x");
-        const manager = await active.waitForPane(
-          (pane) => pane.includes(childName) && pane.includes(persistentName),
-          TIMEOUT,
-        );
-        await selectManagerChild(active, manager, childName);
-        await active.sendKeys("Enter");
-        const tail = await active.waitForText(childDone, TIMEOUT);
-        expect(tail).toContain("Read-only child");
-        expect(tail).not.toContain("Enter Send");
-        const tailGrid = await active.capturePaneGrid();
-
-        await active.pasteText("SHOULD_NOT_ROUTE");
-        await active.sendKeys("Enter");
-
-        let compactGrid = tailGrid;
-        const compactInitial = compactGrid.join("\n");
-        let compactIdentity = compactInitial.includes(childName);
-        let compactProvenance = compactInitial.includes("Parent agent");
-        let compactHeading = compactInitial.includes("Read-only history");
-        for (
-          let page = 0;
-          page < 12 &&
-          !(compactIdentity && compactProvenance && compactHeading);
-          page += 1
+        const childStartedDeadline = Date.now() + TIMEOUT;
+        while (
+          !gateway.requests.some((request) => request.body.includes(childPrompt)) &&
+          Date.now() < childStartedDeadline
         ) {
-          const before = compactGrid.join("\n");
-          const beforeHistoryRows = visibleHistoryRows(before);
-          await active.sendKeys("PageUp");
-          const pane = await active.waitForPane(
-            (value) =>
-              value.includes("Read-only history") ||
-              visibleHistoryRows(value) !== beforeHistoryRows,
-            TIMEOUT,
-          );
-          compactGrid = await active.capturePaneGrid();
-          compactIdentity ||= pane.includes(childName);
-          compactProvenance ||= pane.includes("Parent agent");
-          compactHeading ||= pane.includes("Read-only history");
+          await Bun.sleep(25);
         }
-        expect(compactGrid).not.toEqual(tailGrid);
-        expect(compactIdentity).toBe(true);
-        expect(compactProvenance).toBe(true);
-        expect(compactHeading).toBe(true);
-
-        await active.sendKeys("C-o");
+        expect(gateway.requests.some((request) => request.body.includes(childPrompt))).toBe(true);
+        await active.sendKeys("C-x");
         await active.waitForPane(
           (pane) =>
-            pane.includes("Read-only child") &&
-            pane !== compactGrid.join("\n"),
+            pane.includes(childName) &&
+            pane.includes("running") &&
+            pane.includes(persistentName),
           TIMEOUT,
         );
-        await active.sendKeys("Right");
-        await active.waitForText("Full detail · ←/→ switch · ctrl o close", TIMEOUT);
-        let fullGrid = await active.capturePaneGrid();
-        const fullInitial = fullGrid.join("\n");
-        let fullIdentity = fullInitial.includes(childName);
-        let fullProvenance = fullInitial.includes("Parent agent");
-        let fullHeading = fullInitial.includes("Read-only history");
-        for (
-          let page = 0;
-          page < 12 && !(fullIdentity && fullProvenance && fullHeading);
-          page += 1
-        ) {
-          const before = fullGrid.join("\n");
-          const beforeHistoryRows = visibleHistoryRows(before);
-          await active.sendKeys("PageUp");
-          const pane = await active.waitForPane(
-            (value) =>
-              value.includes("Read-only history") ||
-              visibleHistoryRows(value) !== beforeHistoryRows,
-            TIMEOUT,
-          );
-          fullGrid = await active.capturePaneGrid();
-          fullIdentity ||= pane.includes(childName);
-          fullProvenance ||= pane.includes("Parent agent");
-          fullHeading ||= pane.includes("Read-only history");
-        }
-        expect(fullIdentity).toBe(true);
-        expect(fullProvenance).toBe(true);
-        expect(fullHeading).toBe(true);
-
-        await active.sendKeys("C-o");
-        await active.waitForText("Read-only child", TIMEOUT);
-        await active.sendKeys("Escape");
-        await active.waitForText("Agents & processes", TIMEOUT);
         await active.sendKeys("C-x");
-        await active.waitForText("ONEOFF_READONLY_HISTORY_MAIN_DONE", TIMEOUT);
-        const restoredMainGrid = await active.capturePaneGrid();
-        expect(normalizeVolatileTokenRows(restoredMainGrid.slice(0, -1))).toEqual(
-          normalizeVolatileTokenRows(mainGrid.slice(0, -1)),
-        );
-        expect(restoredMainGrid.at(-1)).not.toContain("ctrl+x manager");
-        expect(active.cursorPosition()).toEqual(mainCursor);
-        expect(gateway.requests).toHaveLength(4);
-        expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+        await active.waitForComposer(TIMEOUT);
+        childStream.release(childDone);
+        const oneOff = await waitForControl(childName, "completed");
+        const persistent = await waitForControl(persistentName, "idle");
 
-        type ResumeControl = {
-          child_id: string;
-          parent_id: string;
-          mode: "persistent" | "one_off";
-          state: string;
-          configuration: { name: string };
-        };
-        const sessionsDir = join(fixture.home, ".fx", "sessions");
-        const controls = readdirSync(sessionsDir)
-          .map((id) => join(sessionsDir, id, "subagent", "control.json"))
-          .filter((path) => existsSync(path))
-          .map((path) => ({
-            path,
-            value: JSON.parse(readFileSync(path, "utf8")) as ResumeControl,
-          }));
-        const oneOff = controls.find((entry) =>
-          entry.value.configuration.name === childName
+        await active.sendKeys("C-x");
+        const managerPane = await active.waitForPane(
+          (pane) => pane.includes(persistentName) && !pane.includes(childName),
+          TIMEOUT,
         );
-        const persistent = controls.find((entry) =>
-          entry.value.configuration.name === persistentName
+        expect(managerPane).not.toContain(childName);
+        await active.sendKeys("C-x");
+        await active.waitForComposer(TIMEOUT);
+
+        await active.sendText("/resume");
+        const resumePane = await active.waitForPane(
+          (pane) => pane.includes(persistentInitial) && !pane.includes(childName),
+          TIMEOUT,
         );
-        if (!oneOff || !persistent) {
-          throw new Error("resume controls were not persisted");
+        expect(resumePane).not.toContain(childName);
+        await active.sendKeys("Escape");
+        await active.waitForComposer(TIMEOUT);
+
+        await active.sendText(parentAck);
+        await active.waitForText(parentAckDone, TIMEOUT);
+        expect(
+          gateway.requests.some((request) =>
+            request.body.includes(parentAck) && request.body.includes(childDone)
+          ),
+        ).toBe(true);
+
+        const childDir = join(sessionsDir, oneOff.value.child_id);
+        const retirementDeadline = Date.now() + TIMEOUT;
+        while (existsSync(childDir) && Date.now() < retirementDeadline) {
+          await Bun.sleep(25);
         }
-        expect(oneOff.value).toMatchObject({
-          mode: "one_off",
-          state: "completed",
-        });
-        expect(persistent.value).toMatchObject({
-          mode: "persistent",
-          state: "idle",
-        });
-        const controlBefore = readFileSync(oneOff.path, "utf8");
-        const requestsBeforeDenial = gateway.requests.length;
+        expect(existsSync(childDir)).toBe(false);
 
         await active.sendText("/quit");
         expect(await active.waitForSessionEnd(TIMEOUT)).toBe(true);
         session = null;
 
-        const denied = await runAsk([
+        const retired = await runAsk([
           "--json",
           "--auto",
           "--resume-id",
           oneOff.value.child_id,
-          illegalResume,
+          "must not resume",
         ]);
-        expect(denied.exitCode).toBe(1);
-        expect(denied.stderr).toBe("");
-        expect(JSON.parse(denied.stdout)).toMatchObject({
+        expect(retired.exitCode).toBe(1);
+        expect(retired.stderr).toBe("");
+        expect(JSON.parse(retired.stdout)).toMatchObject({
           exit_code: 1,
-          error: "OneOffSessionNotResumable",
+          error: "SessionNotFound",
         });
-        expect(gateway.requests).toHaveLength(requestsBeforeDenial);
-        expect(readFileSync(oneOff.path, "utf8")).toBe(controlBefore);
 
         const persistentControl = await runAsk([
           "--json",
@@ -4292,80 +4169,18 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
           exit_code: 0,
           output: persistentResumed,
         });
-
-        const ordinaryControl = await runAsk([
-          "--json",
-          "--auto",
-          "--resume-id",
-          oneOff.value.parent_id,
-          ordinaryResume,
-        ]);
-        expect(ordinaryControl.exitCode).toBe(0);
-        expect(ordinaryControl.stderr).toBe("");
-        expect(JSON.parse(ordinaryControl.stdout)).toMatchObject({
-          exit_code: 0,
-          output: ordinaryResumed,
-        });
-        expect(gateway.requests).toHaveLength(requestsBeforeDenial + 2);
-        expect(readFileSync(oneOff.path, "utf8")).toBe(controlBefore);
-        expect(
-          gateway.requests.some((request) => request.body.includes(illegalResume)),
-        ).toBe(false);
-
-        const deniedStderr = join(root!, "one-off-interactive-denied.stderr");
-        writeFileSync(deniedStderr, "");
-        session = await TmuxSession.create({
-          cmd: `${FX_BIN} resume --id ${oneOff.value.child_id}`,
-          cwd: fixture.workspace,
-          env,
-          width: 80,
-          height: 20,
-          stderrPath: deniedStderr,
-          remainOnExit: true,
-        });
-        await session.waitForPane(() => session!.paneStatus().dead, TIMEOUT);
-        expect(paneExitMatches(session.paneStatus(), 1)).toBe(true);
-        expect(readFileSync(deniedStderr, "utf8")).toBe(
-          "fx: one-off child sessions cannot accept additional prompts; create a persistent child to continue the conversation\n",
-        );
-        await session.kill();
-        session = null;
-        expect(gateway.requests).toHaveLength(requestsBeforeDenial + 2);
-        expect(readFileSync(oneOff.path, "utf8")).toBe(controlBefore);
-
-        session = await TmuxSession.create({
-          cmd: `${FX_BIN} resume --id ${oneOff.value.parent_id}`,
-          cwd: fixture.workspace,
-          env,
-          width: 80,
-          height: 20,
-          stderrPath: fixture.stderrPath,
-        });
-        const restarted = session;
-        await restarted.waitForComposer(TIMEOUT);
-        await restarted.sendKeys("C-x");
-        const restartedManager = await restarted.waitForPane(
-          (pane) =>
-            pane.includes(childName) &&
-            pane.includes(persistentName) &&
-            pane.includes("completed") &&
-            pane.includes("idle"),
-          TIMEOUT,
-        );
-        await selectManagerChild(restarted, restartedManager, childName);
-        await restarted.sendKeys("Enter");
-        const restartedChild = await restarted.waitForText(childDone, TIMEOUT);
-        expect(restartedChild).toContain("Read-only child");
-        expect(restartedChild).not.toContain(illegalResume);
-        expect(readFileSync(oneOff.path, "utf8")).toBe(controlBefore);
         expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
       } finally {
+        if (!childStream.released()) {
+          try {
+            childStream.release("CLEANUP");
+          } catch {}
+        }
         gateway.stop();
       }
     },
     60_000,
   );
-
   test(
     "persistent child quit exits locally without sending a model turn",
     async () => {


### PR DESCRIPTION
## Summary

- Keep active one-off subagents visible in the manager, then hide them from manager, resume, and attach lists after they finish.
- Deliver one automatic final result to the parent for each terminal one-off.
- Delete acknowledged one-off sessions and return the standard not-found response for retired IDs.
- Reject child creation from one-off subagents and reject detach or reparent operations against one-off targets.
- Keep persistent subagents visible, resumable, and reusable.