### PR TITLE
Keep destructive actions out of automatic review

### DIFF
--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -494,7 +494,7 @@ fn expectPermissionDeniedToolResult(gateway: *const FakeGateway, index: usize, t
 fn expectedPermissionDeniedMessage(reason: types.ToolPermissionDenialReason) ?[]const u8 {
     return switch (reason) {
         .user_denied => "Permission denied by user",
-        .auto_denied => "Permission denied by auto mode classifier",
+        .auto_denied => "Blocked by automatic safety policy",
         .policy_denied, .permission_required => null,
     };
 }

--- a/src/core/tooling/command_policy.zig
+++ b/src/core/tooling/command_policy.zig
@@ -87,6 +87,7 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
     var in_double = false;
     var escaped = false;
     var in_comment = false;
+    var word_active = false;
     var segment_start: usize = 0;
     var i: usize = 0;
     while (i < command.len) : (i += 1) {
@@ -94,11 +95,13 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
         if (in_comment) {
             if (ch != '\n') continue;
             in_comment = false;
+            word_active = false;
             segment_start = i + 1;
             continue;
         }
         if (escaped) {
             escaped = false;
+            if (ch != '\n') word_active = true;
             continue;
         }
         if (ch == '\\' and !in_single) {
@@ -107,19 +110,25 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
         }
         if (ch == '\'' and !in_double) {
             in_single = !in_single;
+            word_active = true;
             continue;
         }
         if (ch == '"' and !in_single) {
             in_double = !in_double;
+            word_active = true;
             continue;
         }
         if (!in_single and (ch == '$' or ch == '`')) return null;
         if (in_single or in_double) continue;
-        if (ch == '#' and starts_shell_comment(command, i)) {
+        if (ch == '#' and !word_active) {
             if (effect == null) {
                 effect = warning_at_command_position(command[segment_start..i]);
             }
             in_comment = true;
+            continue;
+        }
+        if (ch == ' ' or ch == '\t' or ch == '\r') {
+            word_active = false;
             continue;
         }
         if (ch == '<' or ch == '>' or ch == '(' or ch == ')' or
@@ -141,11 +150,15 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
                 }
                 break :blk i + 1;
             },
-            else => continue,
+            else => {
+                word_active = true;
+                continue;
+            },
         };
         if (effect == null) {
             effect = warning_at_command_position(command[segment_start..boundary_start]);
         }
+        word_active = false;
         segment_start = boundary_end;
     }
     if (in_single or in_double or escaped) return null;
@@ -153,14 +166,6 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
         effect = warning_at_command_position(command[segment_start..]);
     }
     return effect;
-}
-
-fn starts_shell_comment(command: []const u8, index: usize) bool {
-    if (index == 0) return true;
-    return switch (command[index - 1]) {
-        ' ', '\t', '\r', '\n', ';', '|', '&', '(', ')' => true,
-        else => false,
-    };
 }
 
 fn warning_at_command_position(command: []const u8) ?DestructiveEffect {
@@ -322,6 +327,9 @@ fn git_effect_args(subcommand: []const u8, rest: []const u8) GitEffectArgs {
                 if (std.mem.findScalar(u8, token.text[1..exclude_index], 'n') != null) {
                     args.dry_run = true;
                 }
+                if (std.mem.findScalar(u8, token.text[1..exclude_index], 'h') != null) {
+                    args.help_or_version = true;
+                }
                 if (exclude_index + 1 == token.text.len) {
                     const pattern = command_classification.next_token(rest, offset) orelse {
                         args.supported = false;
@@ -354,7 +362,8 @@ fn git_effect_args(subcommand: []const u8, rest: []const u8) GitEffectArgs {
         }
         if (std.mem.eql(u8, token.text, "--help") or
             std.mem.eql(u8, token.text, "--version") or
-            std.mem.eql(u8, token.text, "-h")) args.help_or_version = true;
+            std.mem.eql(u8, token.text, "-h") or
+            short_option_contains(token.text, 'h')) args.help_or_version = true;
         if (std.mem.eql(u8, token.text, "--hard")) args.hard_reset = true;
         if (std.mem.eql(u8, token.text, "--dry-run") or
             std.mem.eql(u8, token.text, "-n") or
@@ -609,8 +618,12 @@ test "command risk note detects direct destructive effects only" {
     try std.testing.expect(command_risk_note_for("git rm --help") == null);
     try std.testing.expect(command_risk_note_for("git clean --help") == null);
     try std.testing.expect(command_risk_note_for("git clean -h") == null);
+    try std.testing.expect(command_risk_note_for("git clean -hf") == null);
+    try std.testing.expect(command_risk_note_for("git clean -fh") == null);
     try std.testing.expect(command_risk_note_for("git rm -h tracked.txt") == null);
+    try std.testing.expect(command_risk_note_for("git rm -hf tracked.txt") == null);
     try std.testing.expect(command_risk_note_for("git reset -h --hard") == null);
+    try std.testing.expect(command_risk_note_for("git reset -hq --hard") == null);
     try std.testing.expect(command_risk_note_for("git -C clean status") == null);
     try std.testing.expect(command_risk_note_for("git --unknown clean -fd") == null);
     try std.testing.expect(command_risk_note_for("rtk rm -rf generated") == null);
@@ -628,6 +641,8 @@ test "command risk note detects direct destructive effects only" {
         "git clean -f -e-n",
         "git clean -fe-n",
         "git clean -f --exclude=--dry-run",
+        "git clean -f -ehelp",
+        "git clean -f -fehelp",
     }) |command| {
         try std.testing.expectEqual(
             DestructiveEffect.remove_files,
@@ -675,6 +690,21 @@ test "command destructive effect leaves unsupported and targetless removal unres
     try std.testing.expectEqual(
         DestructiveEffect.remove_files,
         destructive_effect_for("printf ok # ignored; rm first\nrm second").?,
+    );
+    try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("printf foo\\ #bar; rm victim").?,
+    );
+    try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("printf foo\\;#bar; rm victim").?,
+    );
+    try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("printf foo\\" ++ "\n#bar; rm victim").?,
+    );
+    try std.testing.expect(
+        destructive_effect_for("printf \\" ++ "\n# comment; rm ignored") == null,
     );
     try std.testing.expectEqual(
         DestructiveEffect.discard_version_control_state,

--- a/src/core/tooling/command_policy.zig
+++ b/src/core/tooling/command_policy.zig
@@ -82,21 +82,19 @@ pub fn semantic_exit_annotation(command_text: []const u8, exit_code: i64, stderr
 }
 
 fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
-    var effect = warning_at_command_position(command);
-
+    var effect: ?DestructiveEffect = null;
     var in_single = false;
     var in_double = false;
     var escaped = false;
     var in_comment = false;
+    var segment_start: usize = 0;
     var i: usize = 0;
     while (i < command.len) : (i += 1) {
         const ch = command[i];
         if (in_comment) {
             if (ch != '\n') continue;
             in_comment = false;
-            if (effect == null) {
-                effect = warning_at_command_position(command[i + 1 ..]);
-            }
+            segment_start = i + 1;
             continue;
         }
         if (escaped) {
@@ -115,15 +113,19 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
             in_double = !in_double;
             continue;
         }
+        if (!in_single and (ch == '$' or ch == '`')) return null;
         if (in_single or in_double) continue;
         if (ch == '#' and starts_shell_comment(command, i)) {
+            if (effect == null) {
+                effect = warning_at_command_position(command[segment_start..i]);
+            }
             in_comment = true;
             continue;
         }
-        if (ch == '<' and i + 1 < command.len and command[i + 1] == '<') {
-            return null;
-        }
+        if (ch == '<' or ch == '>' or ch == '(' or ch == ')' or
+            ch == '{' or ch == '}') return null;
 
+        const boundary_start = i;
         const boundary_end = switch (ch) {
             ';', '\n', '&' => blk: {
                 if (ch == '&' and i + 1 < command.len and command[i + 1] == '&') {
@@ -142,10 +144,14 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
             else => continue,
         };
         if (effect == null) {
-            effect = warning_at_command_position(command[boundary_end..]);
+            effect = warning_at_command_position(command[segment_start..boundary_start]);
         }
+        segment_start = boundary_end;
     }
     if (in_single or in_double or escaped) return null;
+    if (!in_comment and effect == null) {
+        effect = warning_at_command_position(command[segment_start..]);
+    }
     return effect;
 }
 
@@ -270,9 +276,9 @@ fn git_destructive_effect(command_name: []const u8, rest: []const u8) ?Destructi
     if (!std.mem.eql(u8, std.fs.path.basename(command_name), "git")) return null;
 
     const sub = git_subcommand(rest) orelse return null;
-    const args = git_effect_args(rest[sub.end..]);
+    const args = git_effect_args(sub.text, rest[sub.end..]);
 
-    if (args.help_or_version) return null;
+    if (!args.supported or args.help_or_version) return null;
     if (std.mem.eql(u8, sub.text, "reset") and args.hard_reset) {
         return .discard_version_control_state;
     }
@@ -289,13 +295,14 @@ fn git_destructive_effect(command_name: []const u8, rest: []const u8) ?Destructi
 }
 
 const GitEffectArgs = struct {
+    supported: bool = true,
     dry_run: bool = false,
     help_or_version: bool = false,
     hard_reset: bool = false,
     has_operand: bool = false,
 };
 
-fn git_effect_args(rest: []const u8) GitEffectArgs {
+fn git_effect_args(subcommand: []const u8, rest: []const u8) GitEffectArgs {
     var args: GitEffectArgs = .{};
     var options = true;
     var offset: usize = 0;
@@ -310,20 +317,59 @@ fn git_effect_args(rest: []const u8) GitEffectArgs {
             args.has_operand = true;
             continue;
         }
+        if (std.mem.eql(u8, subcommand, "clean")) {
+            if (clean_exclude_short_index(token.text)) |exclude_index| {
+                if (std.mem.findScalar(u8, token.text[1..exclude_index], 'n') != null) {
+                    args.dry_run = true;
+                }
+                if (exclude_index + 1 == token.text.len) {
+                    const pattern = command_classification.next_token(rest, offset) orelse {
+                        args.supported = false;
+                        break;
+                    };
+                    if (token_starts_shell_comment(pattern.text)) {
+                        args.supported = false;
+                        break;
+                    }
+                    offset = pattern.end;
+                }
+                continue;
+            }
+            if (std.mem.eql(u8, token.text, "--exclude")) {
+                const pattern = command_classification.next_token(rest, offset) orelse {
+                    args.supported = false;
+                    break;
+                };
+                if (token_starts_shell_comment(pattern.text)) {
+                    args.supported = false;
+                    break;
+                }
+                offset = pattern.end;
+                continue;
+            }
+            if (std.mem.startsWith(u8, token.text, "--exclude=")) {
+                if (token.text.len == "--exclude=".len) args.supported = false;
+                continue;
+            }
+        }
         if (std.mem.eql(u8, token.text, "--help") or
-            std.mem.eql(u8, token.text, "--version")) args.help_or_version = true;
+            std.mem.eql(u8, token.text, "--version") or
+            std.mem.eql(u8, token.text, "-h")) args.help_or_version = true;
         if (std.mem.eql(u8, token.text, "--hard")) args.hard_reset = true;
         if (std.mem.eql(u8, token.text, "--dry-run") or
             std.mem.eql(u8, token.text, "-n") or
             short_option_contains(token.text, 'n')) args.dry_run = true;
-        if (std.mem.eql(u8, token.text, "--pathspec-from-file")) {
+        if (std.mem.eql(u8, token.text, "--pathspec-from-file") and
+            !std.mem.eql(u8, subcommand, "clean"))
+        {
             const path = command_classification.next_token(rest, offset) orelse break;
             if (token_starts_shell_comment(path.text)) break;
             args.has_operand = true;
             offset = path.end;
             continue;
         }
-        if (std.mem.startsWith(u8, token.text, "--pathspec-from-file=") and
+        if (!std.mem.eql(u8, subcommand, "clean") and
+            std.mem.startsWith(u8, token.text, "--pathspec-from-file=") and
             token.text.len > "--pathspec-from-file=".len)
         {
             args.has_operand = true;
@@ -332,6 +378,12 @@ fn git_effect_args(rest: []const u8) GitEffectArgs {
         if (!std.mem.startsWith(u8, token.text, "-")) args.has_operand = true;
     }
     return args;
+}
+
+fn clean_exclude_short_index(option: []const u8) ?usize {
+    if (option.len < 2 or option[0] != '-' or option[1] == '-') return null;
+    const relative = std.mem.findScalar(u8, option[1..], 'e') orelse return null;
+    return relative + 1;
 }
 
 fn short_option_contains(option: []const u8, needle: u8) bool {
@@ -550,11 +602,15 @@ test "command risk note detects direct destructive effects only" {
 
     try std.testing.expect(command_risk_note_for("git clean --dry-run") == null);
     try std.testing.expect(command_risk_note_for("git clean -nd") == null);
+    try std.testing.expect(command_risk_note_for("git clean -nfeignored") == null);
     try std.testing.expect(command_risk_note_for("git -C nested clean --dry-run") == null);
     try std.testing.expect(command_risk_note_for("git rm --dry-run tracked.txt") == null);
     try std.testing.expect(command_risk_note_for("git rm -n -- tracked.txt") == null);
     try std.testing.expect(command_risk_note_for("git rm --help") == null);
     try std.testing.expect(command_risk_note_for("git clean --help") == null);
+    try std.testing.expect(command_risk_note_for("git clean -h") == null);
+    try std.testing.expect(command_risk_note_for("git rm -h tracked.txt") == null);
+    try std.testing.expect(command_risk_note_for("git reset -h --hard") == null);
     try std.testing.expect(command_risk_note_for("git -C clean status") == null);
     try std.testing.expect(command_risk_note_for("git --unknown clean -fd") == null);
     try std.testing.expect(command_risk_note_for("rtk rm -rf generated") == null);
@@ -566,6 +622,18 @@ test "command risk note detects direct destructive effects only" {
         DestructiveEffect.remove_files,
         destructive_effect_for("git clean -f -- -n").?,
     );
+    for ([_][]const u8{
+        "git clean -f -e --dry-run",
+        "git clean -f --exclude --dry-run",
+        "git clean -f -e-n",
+        "git clean -fe-n",
+        "git clean -f --exclude=--dry-run",
+    }) |command| {
+        try std.testing.expectEqual(
+            DestructiveEffect.remove_files,
+            destructive_effect_for(command).?,
+        );
+    }
     try std.testing.expectEqual(
         DestructiveEffect.discard_version_control_state,
         destructive_effect_for("git reset --hard HEAD~1").?,
@@ -586,6 +654,10 @@ test "command destructive effect leaves unsupported and targetless removal unres
         "git rm # no target",
         "git rm -- # no target",
         "git reset # --hard",
+        "rm -f; printf ok",
+        "git rm --dry-run; printf ok",
+        "rm -f < input.txt",
+        "rm victim > output.txt",
         "printf ok # harmless; rm victim",
         "cat <<EOF\nrm victim\nEOF",
     }) |command| {
@@ -603,6 +675,14 @@ test "command destructive effect leaves unsupported and targetless removal unres
     try std.testing.expectEqual(
         DestructiveEffect.remove_files,
         destructive_effect_for("printf ok # ignored; rm first\nrm second").?,
+    );
+    try std.testing.expectEqual(
+        DestructiveEffect.discard_version_control_state,
+        destructive_effect_for("git reset --hard; printf ok").?,
+    );
+    try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("rm victim; printf ok").?,
     );
 }
 

--- a/src/core/tooling/command_policy.zig
+++ b/src/core/tooling/command_policy.zig
@@ -82,14 +82,23 @@ pub fn semantic_exit_annotation(command_text: []const u8, exit_code: i64, stderr
 }
 
 fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
-    if (warning_at_command_position(command)) |risk| return risk;
+    var effect = warning_at_command_position(command);
 
     var in_single = false;
     var in_double = false;
     var escaped = false;
+    var in_comment = false;
     var i: usize = 0;
     while (i < command.len) : (i += 1) {
         const ch = command[i];
+        if (in_comment) {
+            if (ch != '\n') continue;
+            in_comment = false;
+            if (effect == null) {
+                effect = warning_at_command_position(command[i + 1 ..]);
+            }
+            continue;
+        }
         if (escaped) {
             escaped = false;
             continue;
@@ -107,6 +116,13 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
             continue;
         }
         if (in_single or in_double) continue;
+        if (ch == '#' and starts_shell_comment(command, i)) {
+            in_comment = true;
+            continue;
+        }
+        if (ch == '<' and i + 1 < command.len and command[i + 1] == '<') {
+            return null;
+        }
 
         const boundary_end = switch (ch) {
             ';', '\n', '&' => blk: {
@@ -125,9 +141,20 @@ fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
             },
             else => continue,
         };
-        if (warning_at_command_position(command[boundary_end..])) |risk| return risk;
+        if (effect == null) {
+            effect = warning_at_command_position(command[boundary_end..]);
+        }
     }
-    return null;
+    if (in_single or in_double or escaped) return null;
+    return effect;
+}
+
+fn starts_shell_comment(command: []const u8, index: usize) bool {
+    if (index == 0) return true;
+    return switch (command[index - 1]) {
+        ' ', '\t', '\r', '\n', ';', '|', '&', '(', ')' => true,
+        else => false,
+    };
 }
 
 fn warning_at_command_position(command: []const u8) ?DestructiveEffect {
@@ -144,7 +171,7 @@ fn warning_at_command_position(command: []const u8) ?DestructiveEffect {
 
     const rest = command[first.end..];
     if (git_destructive_effect(first.text, rest)) |risk| return risk;
-    if (file_removal_effect(first.text)) |risk| return risk;
+    if (file_removal_effect(first.text, rest)) |risk| return risk;
     return null;
 }
 
@@ -243,29 +270,89 @@ fn git_destructive_effect(command_name: []const u8, rest: []const u8) ?Destructi
     if (!std.mem.eql(u8, std.fs.path.basename(command_name), "git")) return null;
 
     const sub = git_subcommand(rest) orelse return null;
-    const args = rest[sub.end..];
+    const args = git_effect_args(rest[sub.end..]);
 
-    if (std.mem.eql(u8, sub.text, "reset") and has_token(args, "--hard")) {
+    if (args.help_or_version) return null;
+    if (std.mem.eql(u8, sub.text, "reset") and args.hard_reset) {
         return .discard_version_control_state;
     }
-    if ((std.mem.eql(u8, sub.text, "clean") or
-        std.mem.eql(u8, sub.text, "rm")) and
-        !has_dry_run_flag(args))
+    if (std.mem.eql(u8, sub.text, "clean") and !args.dry_run) {
+        return .remove_files;
+    }
+    if (std.mem.eql(u8, sub.text, "rm") and
+        !args.dry_run and
+        args.has_operand)
     {
         return .remove_files;
     }
     return null;
 }
 
+const GitEffectArgs = struct {
+    dry_run: bool = false,
+    help_or_version: bool = false,
+    hard_reset: bool = false,
+    has_operand: bool = false,
+};
+
+fn git_effect_args(rest: []const u8) GitEffectArgs {
+    var args: GitEffectArgs = .{};
+    var options = true;
+    var offset: usize = 0;
+    while (command_classification.next_token(rest, offset)) |token| {
+        offset = token.end;
+        if (token_starts_shell_comment(token.text)) break;
+        if (options and std.mem.eql(u8, token.text, "--")) {
+            options = false;
+            continue;
+        }
+        if (!options) {
+            args.has_operand = true;
+            continue;
+        }
+        if (std.mem.eql(u8, token.text, "--help") or
+            std.mem.eql(u8, token.text, "--version")) args.help_or_version = true;
+        if (std.mem.eql(u8, token.text, "--hard")) args.hard_reset = true;
+        if (std.mem.eql(u8, token.text, "--dry-run") or
+            std.mem.eql(u8, token.text, "-n") or
+            short_option_contains(token.text, 'n')) args.dry_run = true;
+        if (std.mem.eql(u8, token.text, "--pathspec-from-file")) {
+            const path = command_classification.next_token(rest, offset) orelse break;
+            if (token_starts_shell_comment(path.text)) break;
+            args.has_operand = true;
+            offset = path.end;
+            continue;
+        }
+        if (std.mem.startsWith(u8, token.text, "--pathspec-from-file=") and
+            token.text.len > "--pathspec-from-file=".len)
+        {
+            args.has_operand = true;
+            continue;
+        }
+        if (!std.mem.startsWith(u8, token.text, "-")) args.has_operand = true;
+    }
+    return args;
+}
+
+fn short_option_contains(option: []const u8, needle: u8) bool {
+    return option.len > 2 and
+        option[0] == '-' and
+        option[1] != '-' and
+        std.mem.findScalar(u8, option[1..], needle) != null;
+}
+
 fn git_subcommand(rest: []const u8) ?command_classification.Token {
     var offset: usize = 0;
     while (command_classification.next_token(rest, offset)) |token| {
+        if (token_starts_shell_comment(token.text)) return null;
         if (std.mem.eql(u8, token.text, "--")) {
-            return command_classification.next_token(rest, token.end);
+            const subcommand = command_classification.next_token(rest, token.end) orelse return null;
+            return if (token_starts_shell_comment(subcommand.text)) null else subcommand;
         }
         if (!std.mem.startsWith(u8, token.text, "-")) return token;
         if (git_global_option_takes_value(token.text)) {
             const value = command_classification.next_token(rest, token.end) orelse return null;
+            if (token_starts_shell_comment(value.text)) return null;
             offset = value.end;
             continue;
         }
@@ -319,28 +406,50 @@ fn git_global_flag(option: []const u8) bool {
         std.mem.eql(u8, option, "-P");
 }
 
-fn file_removal_effect(command_name: []const u8) ?DestructiveEffect {
+fn file_removal_effect(command_name: []const u8, rest: []const u8) ?DestructiveEffect {
     const executable = std.fs.path.basename(command_name);
-    return if (std.mem.eql(u8, executable, "rm") or
+    if (!(std.mem.eql(u8, executable, "rm") or
         std.mem.eql(u8, executable, "rmdir") or
         std.mem.eql(u8, executable, "unlink") or
-        std.mem.eql(u8, executable, "shred"))
-        .remove_files
-    else
-        null;
+        std.mem.eql(u8, executable, "shred"))) return null;
+    return if (removal_has_operand(executable, rest)) .remove_files else null;
 }
 
-fn has_dry_run_flag(rest: []const u8) bool {
-    var cursor: usize = 0;
-    while (command_classification.next_token(rest, cursor)) |token| {
-        cursor = token.end;
-        if (std.mem.eql(u8, token.text, "--dry-run") or
-            std.mem.eql(u8, token.text, "-n")) return true;
-        if (token.text.len > 2 and token.text[0] == '-' and token.text[1] != '-') {
-            if (std.mem.findScalar(u8, token.text[1..], 'n') != null) return true;
+fn removal_has_operand(executable: []const u8, rest: []const u8) bool {
+    var offset: usize = 0;
+    while (command_classification.next_token(rest, offset)) |token| {
+        offset = token.end;
+        if (token_starts_shell_comment(token.text)) return false;
+        if (std.mem.eql(u8, token.text, "--help") or
+            std.mem.eql(u8, token.text, "--version")) return false;
+        if (std.mem.eql(u8, token.text, "--")) {
+            const operand = command_classification.next_token(rest, offset) orelse return false;
+            return !token_starts_shell_comment(operand.text);
         }
+        if (std.mem.eql(u8, executable, "shred") and
+            shred_option_takes_value(token.text))
+        {
+            const value = command_classification.next_token(rest, offset) orelse return false;
+            if (token_starts_shell_comment(value.text)) return false;
+            offset = value.end;
+            continue;
+        }
+        if (std.mem.eql(u8, token.text, "-") or
+            !std.mem.startsWith(u8, token.text, "-")) return true;
     }
     return false;
+}
+
+fn shred_option_takes_value(option: []const u8) bool {
+    return std.mem.eql(u8, option, "-n") or
+        std.mem.eql(u8, option, "-s") or
+        std.mem.eql(u8, option, "--iterations") or
+        std.mem.eql(u8, option, "--size") or
+        std.mem.eql(u8, option, "--random-source");
+}
+
+fn token_starts_shell_comment(token: []const u8) bool {
+    return token.len > 0 and token[0] == '#';
 }
 
 fn is_pattern_matcher(command: []const u8) bool {
@@ -354,15 +463,6 @@ fn is_pattern_matcher(command: []const u8) bool {
 fn looks_like_find_access_issue(stderr_text: []const u8) bool {
     return contains_ascii_ignore_case(stderr_text, "permission denied") or
         contains_ascii_ignore_case(stderr_text, "operation not permitted");
-}
-
-fn has_token(rest: []const u8, needle: []const u8) bool {
-    var cursor: usize = 0;
-    while (command_classification.next_token(rest, cursor)) |token| {
-        cursor = token.end;
-        if (std.mem.eql(u8, token.text, needle)) return true;
-    }
-    return false;
 }
 
 fn contains_ascii_ignore_case(haystack: []const u8, needle: []const u8) bool {
@@ -452,12 +552,57 @@ test "command risk note detects direct destructive effects only" {
     try std.testing.expect(command_risk_note_for("git clean -nd") == null);
     try std.testing.expect(command_risk_note_for("git -C nested clean --dry-run") == null);
     try std.testing.expect(command_risk_note_for("git rm --dry-run tracked.txt") == null);
+    try std.testing.expect(command_risk_note_for("git rm -n -- tracked.txt") == null);
+    try std.testing.expect(command_risk_note_for("git rm --help") == null);
+    try std.testing.expect(command_risk_note_for("git clean --help") == null);
     try std.testing.expect(command_risk_note_for("git -C clean status") == null);
     try std.testing.expect(command_risk_note_for("git --unknown clean -fd") == null);
     try std.testing.expect(command_risk_note_for("rtk rm -rf generated") == null);
     try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("git rm -- -n").?,
+    );
+    try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("git clean -f -- -n").?,
+    );
+    try std.testing.expectEqual(
         DestructiveEffect.discard_version_control_state,
         destructive_effect_for("git reset --hard HEAD~1").?,
+    );
+}
+
+test "command destructive effect leaves unsupported and targetless removal unresolved" {
+    for ([_][]const u8{
+        "rm",
+        "rm -f",
+        "rm --help",
+        "rm --version",
+        "rm # no target",
+        "rm -- # no target",
+        "rmdir --verbose",
+        "unlink --help",
+        "shred -n 3",
+        "git rm # no target",
+        "git rm -- # no target",
+        "git reset # --hard",
+        "printf ok # harmless; rm victim",
+        "cat <<EOF\nrm victim\nEOF",
+    }) |command| {
+        try std.testing.expect(command_risk_note_for(command) == null);
+    }
+
+    try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("rm -- -n").?,
+    );
+    try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("git clean -f # --dry-run").?,
+    );
+    try std.testing.expectEqual(
+        DestructiveEffect.remove_files,
+        destructive_effect_for("printf ok # ignored; rm first\nrm second").?,
     );
 }
 

--- a/src/core/tooling/command_policy.zig
+++ b/src/core/tooling/command_policy.zig
@@ -1,22 +1,28 @@
 const std = @import("std");
 const command_classification = @import("../shell_command/command_classification.zig");
 
-const RiskKind = enum {
+pub const DestructiveEffect = enum {
     discard_version_control_state,
-    forceful_file_removal,
+    remove_files,
 };
+
+/// Returns a destructive effect only when it appears at an executed command
+/// position. Unknown wrappers and quoted or argument text remain unresolved.
+pub fn destructive_effect_for(command: []const u8) ?DestructiveEffect {
+    const analysis = command_classification.analysis_command_tail(command);
+    return destructive_effect_in_analysis(analysis);
+}
 
 /// Returns a short policy note for command text with a high-risk shape.
 pub fn command_risk_note_for(command: []const u8) ?[]const u8 {
-    const analysis = command_classification.analysis_command_tail(command);
-    const risk = risk_kind_in_analysis(analysis) orelse return null;
+    const risk = destructive_effect_for(command) orelse return null;
     return risk_note_for(risk);
 }
 
 /// Returns a narrow alternative when the command text has an unambiguous safer path.
 pub fn command_safer_alternative_for(command: []const u8) ?[]const u8 {
     const analysis = command_classification.analysis_command_tail(command);
-    if (risk_kind_in_analysis(analysis)) |risk| {
+    if (destructive_effect_in_analysis(analysis)) |risk| {
         return safer_alternative_for_risk(risk);
     }
 
@@ -37,17 +43,17 @@ pub fn command_safer_alternative_for(command: []const u8) ?[]const u8 {
     return null;
 }
 
-fn risk_note_for(risk: RiskKind) []const u8 {
+fn risk_note_for(risk: DestructiveEffect) []const u8 {
     return switch (risk) {
         .discard_version_control_state => "note: command may discard version-control state",
-        .forceful_file_removal => "note: command may remove files forcefully",
+        .remove_files => "note: command may remove files forcefully",
     };
 }
 
-fn safer_alternative_for_risk(risk: RiskKind) []const u8 {
+fn safer_alternative_for_risk(risk: DestructiveEffect) []const u8 {
     return switch (risk) {
         .discard_version_control_state => "safer: inspect git status first and revert only the intended files",
-        .forceful_file_removal => "safer: inspect targets first or use delete_file for explicit files",
+        .remove_files => "safer: inspect targets first or use delete_file for explicit files",
     };
 }
 
@@ -75,7 +81,7 @@ pub fn semantic_exit_annotation(command_text: []const u8, exit_code: i64, stderr
     return null;
 }
 
-fn risk_kind_in_analysis(command: []const u8) ?RiskKind {
+fn destructive_effect_in_analysis(command: []const u8) ?DestructiveEffect {
     if (warning_at_command_position(command)) |risk| return risk;
 
     var in_single = false;
@@ -124,7 +130,7 @@ fn risk_kind_in_analysis(command: []const u8) ?RiskKind {
     return null;
 }
 
-fn warning_at_command_position(command: []const u8) ?RiskKind {
+fn warning_at_command_position(command: []const u8) ?DestructiveEffect {
     var cursor = command_classification.skip_whitespace(command, 0);
     while (command_classification.next_token(command, cursor)) |token| {
         if (!command_classification.is_env_assignment(token.text)) break;
@@ -137,8 +143,8 @@ fn warning_at_command_position(command: []const u8) ?RiskKind {
     }
 
     const rest = command[first.end..];
-    if (git_hard_reset(first.text, rest)) |risk| return risk;
-    if (forceful_file_removal(first.text, rest)) |risk| return risk;
+    if (git_destructive_effect(first.text, rest)) |risk| return risk;
+    if (file_removal_effect(first.text)) |risk| return risk;
     return null;
 }
 
@@ -233,37 +239,108 @@ fn parse_su_command_argument(command: []const u8, start: usize) ?[]const u8 {
     return token.text;
 }
 
-fn git_hard_reset(command_name: []const u8, rest: []const u8) ?RiskKind {
-    if (!std.mem.eql(u8, command_name, "git")) return null;
+fn git_destructive_effect(command_name: []const u8, rest: []const u8) ?DestructiveEffect {
+    if (!std.mem.eql(u8, std.fs.path.basename(command_name), "git")) return null;
 
-    const sub = command_classification.next_token(rest, 0) orelse return null;
+    const sub = git_subcommand(rest) orelse return null;
     const args = rest[sub.end..];
 
     if (std.mem.eql(u8, sub.text, "reset") and has_token(args, "--hard")) {
         return .discard_version_control_state;
     }
+    if ((std.mem.eql(u8, sub.text, "clean") or
+        std.mem.eql(u8, sub.text, "rm")) and
+        !has_dry_run_flag(args))
+    {
+        return .remove_files;
+    }
     return null;
 }
 
-fn forceful_file_removal(command_name: []const u8, rest: []const u8) ?RiskKind {
-    if (!std.mem.eql(u8, command_name, "rm")) return null;
+fn git_subcommand(rest: []const u8) ?command_classification.Token {
+    var offset: usize = 0;
+    while (command_classification.next_token(rest, offset)) |token| {
+        if (std.mem.eql(u8, token.text, "--")) {
+            return command_classification.next_token(rest, token.end);
+        }
+        if (!std.mem.startsWith(u8, token.text, "-")) return token;
+        if (git_global_option_takes_value(token.text)) {
+            const value = command_classification.next_token(rest, token.end) orelse return null;
+            offset = value.end;
+            continue;
+        }
+        if (git_global_option_has_inline_value(token.text) or
+            git_global_flag(token.text))
+        {
+            offset = token.end;
+            continue;
+        }
+        return null;
+    }
+    return null;
+}
 
-    var has_recursive = false;
-    var has_force = false;
+fn git_global_option_takes_value(option: []const u8) bool {
+    return std.mem.eql(u8, option, "-C") or
+        std.mem.eql(u8, option, "-c") or
+        std.mem.eql(u8, option, "--git-dir") or
+        std.mem.eql(u8, option, "--work-tree") or
+        std.mem.eql(u8, option, "--namespace") or
+        std.mem.eql(u8, option, "--config-env");
+}
+
+fn git_global_option_has_inline_value(option: []const u8) bool {
+    if (std.mem.startsWith(u8, option, "-C") and option.len > 2) return true;
+    if (std.mem.startsWith(u8, option, "-c") and option.len > 2) return true;
+    for ([_][]const u8{
+        "--git-dir=",
+        "--work-tree=",
+        "--namespace=",
+        "--config-env=",
+    }) |prefix| {
+        if (std.mem.startsWith(u8, option, prefix) and option.len > prefix.len) {
+            return true;
+        }
+    }
+    return false;
+}
+
+fn git_global_flag(option: []const u8) bool {
+    return std.mem.eql(u8, option, "--bare") or
+        std.mem.eql(u8, option, "--no-replace-objects") or
+        std.mem.eql(u8, option, "--literal-pathspecs") or
+        std.mem.eql(u8, option, "--glob-pathspecs") or
+        std.mem.eql(u8, option, "--noglob-pathspecs") or
+        std.mem.eql(u8, option, "--icase-pathspecs") or
+        std.mem.eql(u8, option, "--no-optional-locks") or
+        std.mem.eql(u8, option, "--no-pager") or
+        std.mem.eql(u8, option, "--paginate") or
+        std.mem.eql(u8, option, "-p") or
+        std.mem.eql(u8, option, "-P");
+}
+
+fn file_removal_effect(command_name: []const u8) ?DestructiveEffect {
+    const executable = std.fs.path.basename(command_name);
+    return if (std.mem.eql(u8, executable, "rm") or
+        std.mem.eql(u8, executable, "rmdir") or
+        std.mem.eql(u8, executable, "unlink") or
+        std.mem.eql(u8, executable, "shred"))
+        .remove_files
+    else
+        null;
+}
+
+fn has_dry_run_flag(rest: []const u8) bool {
     var cursor: usize = 0;
     while (command_classification.next_token(rest, cursor)) |token| {
         cursor = token.end;
-        if (!std.mem.startsWith(u8, token.text, "-")) continue;
-        if (std.mem.eql(u8, token.text, "--recursive") or std.mem.eql(u8, token.text, "-r") or std.mem.eql(u8, token.text, "-R")) has_recursive = true;
-        if (std.mem.eql(u8, token.text, "--force") or std.mem.eql(u8, token.text, "-f")) has_force = true;
-        if (token.text.len > 1 and token.text[1] != '-') {
-            for (token.text[1..]) |ch| {
-                if (ch == 'r' or ch == 'R') has_recursive = true;
-                if (ch == 'f') has_force = true;
-            }
+        if (std.mem.eql(u8, token.text, "--dry-run") or
+            std.mem.eql(u8, token.text, "-n")) return true;
+        if (token.text.len > 2 and token.text[0] == '-' and token.text[1] != '-') {
+            if (std.mem.findScalar(u8, token.text[1..], 'n') != null) return true;
         }
     }
-    return if (has_recursive or has_force) .forceful_file_removal else null;
+    return false;
 }
 
 fn is_pattern_matcher(command: []const u8) bool {
@@ -346,6 +423,42 @@ test "command risk note stays narrow for ordinary git operations" {
 
 test "command risk note detects forceful removal" {
     try std.testing.expectEqualStrings("note: command may remove files forcefully", command_risk_note_for("rm -rf /tmp/x").?);
+}
+
+test "command risk note detects direct destructive effects only" {
+    for ([_][]const u8{
+        "rm scratch.txt",
+        "rmdir generated",
+        "unlink stale-link",
+        "shred secret.txt",
+        "git clean -fd",
+        "git rm tracked.txt",
+        "/bin/rm scratch.txt",
+        "/usr/bin/git clean -fd",
+        "git -C nested clean -fd",
+        "git --git-dir=.git rm tracked.txt",
+    }) |command| {
+        try std.testing.expectEqual(
+            DestructiveEffect.remove_files,
+            destructive_effect_for(command).?,
+        );
+        try std.testing.expectEqualStrings(
+            "note: command may remove files forcefully",
+            command_risk_note_for(command).?,
+        );
+    }
+
+    try std.testing.expect(command_risk_note_for("git clean --dry-run") == null);
+    try std.testing.expect(command_risk_note_for("git clean -nd") == null);
+    try std.testing.expect(command_risk_note_for("git -C nested clean --dry-run") == null);
+    try std.testing.expect(command_risk_note_for("git rm --dry-run tracked.txt") == null);
+    try std.testing.expect(command_risk_note_for("git -C clean status") == null);
+    try std.testing.expect(command_risk_note_for("git --unknown clean -fd") == null);
+    try std.testing.expect(command_risk_note_for("rtk rm -rf generated") == null);
+    try std.testing.expectEqual(
+        DestructiveEffect.discard_version_control_state,
+        destructive_effect_for("git reset --hard HEAD~1").?,
+    );
 }
 
 test "command risk note detects privilege-wrapped removal" {

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -5155,6 +5155,9 @@ test "delegated command effects remain reviewer owned" {
         "cat <<EOF\nrm victim\nEOF",
         "rm --help",
         "rm",
+        "rm -f; printf ok",
+        "git rm --dry-run; printf ok",
+        "rm -f < input.txt",
     }) |command| {
         const arguments_json = try std.fmt.allocPrint(
             arena_state.allocator(),
@@ -5175,7 +5178,7 @@ test "delegated command effects remain reviewer owned" {
         try std.testing.expectEqual(ToolPermissionDecision.deny, outcome.decision);
         try std.testing.expect(outcome.auto_review_result != null);
     }
-    try std.testing.expectEqual(@as(usize, 8), fake.calls);
+    try std.testing.expectEqual(@as(usize, 11), fake.calls);
 }
 
 test "automatic delete replans before reviewer" {

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -5158,6 +5158,9 @@ test "delegated command effects remain reviewer owned" {
         "rm -f; printf ok",
         "git rm --dry-run; printf ok",
         "rm -f < input.txt",
+        "git clean -hf",
+        "git rm -hf tracked.txt",
+        "git reset -hq --hard",
     }) |command| {
         const arguments_json = try std.fmt.allocPrint(
             arena_state.allocator(),
@@ -5178,7 +5181,7 @@ test "delegated command effects remain reviewer owned" {
         try std.testing.expectEqual(ToolPermissionDecision.deny, outcome.decision);
         try std.testing.expect(outcome.auto_review_result != null);
     }
-    try std.testing.expectEqual(@as(usize, 11), fake.calls);
+    try std.testing.expectEqual(@as(usize, 14), fake.calls);
 }
 
 test "automatic delete replans before reviewer" {

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -6,6 +6,7 @@ const vision_contracts = @import("../agent/runtime/vision_contracts.zig");
 const command_admission = @import("../permissions/command_admission.zig");
 const command_environment = @import("../execution/command_environment.zig");
 const command_effect = @import("../shell_command/command_effect.zig");
+const command_policy = @import("command_policy.zig");
 const file_mutation = @import("file_mutation.zig");
 const file_mutation_contract = @import("file_mutation_contract.zig");
 const image_attachments = @import("../images/image_attachments.zig");
@@ -840,6 +841,34 @@ fn reviewerUnavailableOutcome(call: ToolCall) command_admission.PermissionOutcom
     };
 }
 
+const UnresolvedAutoDisposition = enum {
+    replan,
+    review,
+};
+
+fn unresolved_command_disposition(command: []const u8) UnresolvedAutoDisposition {
+    return if (command_policy.destructive_effect_for(command) != null)
+        .replan
+    else
+        .review;
+}
+
+fn unresolved_tool_disposition(kind: tool_dispatch.ExecutorKind) UnresolvedAutoDisposition {
+    return if (kind == .delete_file) .replan else .review;
+}
+
+fn deterministic_auto_replan_outcome(call: ToolCall) command_admission.PermissionOutcome {
+    debug_trace.logf(
+        "permission",
+        "event=deterministic_auto_disposition tool_name={s} source=deterministic_policy disposition=replan reviewer_transport=false call_id={s}",
+        .{ call.name, call.id },
+    );
+    return .{
+        .decision = .deny,
+        .denial_reason = .auto_denied,
+    };
+}
+
 /// Maps every non-allow automatic review to one recoverable denial. A
 /// separately selected human-approval phase bypasses automatic review below.
 fn nonAllowAutoReviewOutcome(
@@ -988,6 +1017,11 @@ fn resolveOrdinaryPermissionOutcome(
                     .once,
                     .auto_mode,
                 );
+            }
+            if (!isHumanApprovalPhase(input) and
+                unresolved_command_disposition(command.command) == .replan)
+            {
+                return deterministic_auto_replan_outcome(call);
             }
         }
         return automaticReviewOutcome(
@@ -1291,6 +1325,13 @@ fn requestPermissionOutcomeResolved(
         try reversibleStructuredToolMayBypassAutoReview(input, arena, call))
     {
         return ordinaryPermissionOutcome(.once);
+    }
+    if (permission_mode == .auto and !isHumanApprovalPhase(input)) {
+        if (registeredTool(input, call.name)) |tool| {
+            if (unresolved_tool_disposition(tool.executor_kind) == .replan) {
+                return deterministic_auto_replan_outcome(call);
+            }
+        }
     }
     if (input.host_sandbox_default == .allow_sandboxed and
         try isRunCommandCall(input, arena, call))
@@ -5001,7 +5042,7 @@ test "automatic review receives exact command and mints matching one-call author
     }
 }
 
-test "automatic ask returns to the agent before using a human prompter" {
+test "automatic destructive command replans before reviewer or human prompter" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var worker: WorkerRuntime = .{};
@@ -5037,18 +5078,163 @@ test "automatic ask returns to the agent before using a human prompter" {
         &.{},
     );
 
-    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
     try std.testing.expectEqual(@as(usize, 0), recording.calls);
     try std.testing.expectEqual(ToolPermissionDecision.deny, outcome.decision);
     try std.testing.expectEqual(types.ToolPermissionDenialReason.auto_denied, outcome.denial_reason.?);
     try std.testing.expect(outcome.execution_authority == null);
-    try std.testing.expectEqualStrings(
-        "The command exceeds the user's request.",
-        outcome.auto_review_result.?.rationale,
-    );
+    try std.testing.expect(outcome.auto_review_result == null);
 }
 
-test "automatic ask returns a recoverable denial without a prompter" {
+test "configured allow remains authoritative for a destructive command" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(std.testing.allocator);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(std.testing.allocator);
+    var fake = FakeAutoClassifier{};
+    var input = testInputWithClassifier(
+        &worker,
+        &background,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+    var rules = [_]types.PermissionRule{.{
+        .permission = @constCast("bash"),
+        .pattern = @constCast("rm -rf public"),
+        .action = .allow,
+    }};
+    input.permission_rules = .{ .rules = &rules };
+
+    const outcome = try requestPermissionOutcome(
+        input,
+        arena_state.allocator(),
+        .{
+            .id = "configured-destructive",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"rm -rf public\"}",
+        },
+        .auto,
+        &.{},
+    );
+
+    try std.testing.expectEqual(ToolPermissionDecision.once, outcome.decision);
+    try std.testing.expectEqual(
+        command_admission.ShellAuthorizationSource.configured_rule,
+        outcome.execution_authority.?.run_command.shell_allowed.source,
+    );
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+}
+
+test "delegated command effects remain reviewer owned" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(std.testing.allocator);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(std.testing.allocator);
+    var fake = FakeAutoClassifier{ .decision = .ask };
+    const input = testInputWithClassifier(
+        &worker,
+        &background,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+
+    for ([_][]const u8{
+        "git checkout feature/repro",
+        "git switch feature/repro",
+        "git pull --ff-only",
+        "rtk rm -rf generated",
+    }) |command| {
+        const arguments_json = try std.fmt.allocPrint(
+            arena_state.allocator(),
+            "{{\"action\":\"exec\",\"command\":{f}}}",
+            .{std.json.fmt(command, .{})},
+        );
+        const outcome = try requestPermissionOutcome(
+            input,
+            arena_state.allocator(),
+            .{
+                .id = command,
+                .name = "terminal",
+                .arguments_json = arguments_json,
+            },
+            .auto,
+            &.{},
+        );
+        try std.testing.expectEqual(ToolPermissionDecision.deny, outcome.decision);
+        try std.testing.expect(outcome.auto_review_result != null);
+    }
+    try std.testing.expectEqual(@as(usize, 4), fake.calls);
+}
+
+test "automatic delete replans before reviewer" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "workspace");
+    var victim = try tmp.dir.createFile(
+        std.testing.io,
+        "workspace/victim.txt",
+        .{ .truncate = true },
+    );
+    defer victim.close(std.testing.io);
+    try victim.writeStreamingAll(std.testing.io, "keep\n");
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(workspace);
+    const target = try std.fs.path.join(alloc, &.{ workspace, "victim.txt" });
+    defer alloc.free(target);
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(alloc);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(alloc);
+    var fake = FakeAutoClassifier{};
+    var input = testInputWithClassifier(
+        &worker,
+        &background,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+    input.workspace_root = workspace;
+    const arguments_json = try std.fmt.allocPrint(
+        arena_state.allocator(),
+        "{{\"path\":{f}}}",
+        .{std.json.fmt(target, .{})},
+    );
+
+    const outcome = try requestPermissionOutcome(
+        input,
+        arena_state.allocator(),
+        .{
+            .id = "delete-victim",
+            .name = "delete_file",
+            .arguments_json = arguments_json,
+        },
+        .auto,
+        &.{},
+    );
+
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+    try std.testing.expectEqual(ToolPermissionDecision.deny, outcome.decision);
+    try std.testing.expectEqual(
+        types.ToolPermissionDenialReason.auto_denied,
+        outcome.denial_reason.?,
+    );
+    try std.testing.expect(outcome.execution_authority == null);
+}
+
+test "automatic reviewer ask returns a recoverable denial without a prompter" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     var worker: WorkerRuntime = .{};
@@ -5076,7 +5262,7 @@ test "automatic ask returns a recoverable denial without a prompter" {
         .{
             .id = "asked",
             .name = "terminal",
-            .arguments_json = "{\"action\":\"exec\",\"command\":\"rm -rf public\"}",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"touch public\"}",
         },
         .auto,
         &.{},
@@ -5219,6 +5405,45 @@ test "human approval phase bypasses automatic review" {
     );
     try std.testing.expectEqual(ToolPermissionDecision.permission_required, headless.decision);
     try std.testing.expectEqual(types.ToolPermissionDenialReason.permission_required, headless.denial_reason.?);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+    try std.testing.expectEqual(@as(usize, 1), recording.calls);
+}
+
+test "human approval phase bypasses deterministic destructive replan" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(std.testing.allocator);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(std.testing.allocator);
+    var fake = FakeAutoClassifier{ .decision = .ask };
+    var recording = RecordingPrompter{};
+    var input = testInputWithClassifier(
+        &worker,
+        &background,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+    var review_turn = testReviewTurn();
+    review_turn.auto_permission_phase = .human_approval;
+    input.permission_review_turn = review_turn;
+    input.permission_prompter = recording.prompter();
+
+    const approved = try requestPermissionOutcome(
+        input,
+        arena_state.allocator(),
+        .{
+            .id = "destructive-human-approval",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"rm -rf disposable-dir\"}",
+        },
+        .auto,
+        &.{},
+    );
+
+    try std.testing.expectEqual(ToolPermissionDecision.once, approved.decision);
     try std.testing.expectEqual(@as(usize, 0), fake.calls);
     try std.testing.expectEqual(@as(usize, 1), recording.calls);
 }

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -5151,6 +5151,10 @@ test "delegated command effects remain reviewer owned" {
         "git switch feature/repro",
         "git pull --ff-only",
         "rtk rm -rf generated",
+        "printf ok # harmless; rm victim",
+        "cat <<EOF\nrm victim\nEOF",
+        "rm --help",
+        "rm",
     }) |command| {
         const arguments_json = try std.fmt.allocPrint(
             arena_state.allocator(),
@@ -5171,7 +5175,7 @@ test "delegated command effects remain reviewer owned" {
         try std.testing.expectEqual(ToolPermissionDecision.deny, outcome.decision);
         try std.testing.expect(outcome.auto_review_result != null);
     }
-    try std.testing.expectEqual(@as(usize, 4), fake.calls);
+    try std.testing.expectEqual(@as(usize, 8), fake.calls);
 }
 
 test "automatic delete replans before reviewer" {

--- a/src/core/tooling/tool_result_errors.zig
+++ b/src/core/tooling/tool_result_errors.zig
@@ -173,7 +173,7 @@ fn toolPermissionDeniedJsonOptionalRequest(
 fn permissionDeniedMessage(tool_name: []const u8, reason: types.ToolPermissionDenialReason) []const u8 {
     return switch (reason) {
         .user_denied => "Permission denied by user",
-        .auto_denied => "Permission denied by auto mode classifier",
+        .auto_denied => "Blocked by automatic safety policy",
         .policy_denied => if (is_network_tool(tool_name))
             "Network or browser access was denied by configured policy"
         else
@@ -197,7 +197,7 @@ fn permissionDeniedSuggestion(
         .auto_denied => if (action_bound_request_available)
             "The tool did not run. Do not retry it unchanged. Use a materially different safe action, or ask the user through ask_user_question with the exact approval_request_id. Generic question text cannot authorize the action."
         else
-            "The tool did not run. Do not retry unchanged or ask the user for approval. Replan autonomously with a materially different safe action or an existing deterministic safe tool; fx will use its human approval channel after bounded recovery.",
+            "The tool did not run. Do not retry unchanged. Replan autonomously with a materially different safe action or explain the blocker and stop.",
         .policy_denied => "The tool did not run. Do not retry unchanged; explain the configured policy blocker or use an allowed alternative.",
         .permission_required => "The tool did not run. Noninteractive mode cannot show an approval prompt. Rerun interactively to approve, or configure a narrow permission rule before retrying.",
     };
@@ -478,10 +478,10 @@ test "tool permission denied JSON explains policy and headless blockers" {
     defer web_search.deinit();
 
     const auto_error = auto_denied.value.object.get("error").?.object;
-    try std.testing.expectEqualStrings("Permission denied by auto mode classifier", auto_error.get("message").?.string);
+    try std.testing.expectEqualStrings("Blocked by automatic safety policy", auto_error.get("message").?.string);
     try std.testing.expectEqualStrings("auto_denied", auto_error.get("reason").?.string);
     try std.testing.expectEqualStrings(
-        "The tool did not run. Do not retry unchanged or ask the user for approval. Replan autonomously with a materially different safe action or an existing deterministic safe tool; fx will use its human approval channel after bounded recovery.",
+        "The tool did not run. Do not retry unchanged. Replan autonomously with a materially different safe action or explain the blocker and stop.",
         auto_error.get("suggestion").?.string,
     );
     try std.testing.expectEqual(

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -85,6 +85,39 @@ function commandCall(command: string, id: string) {
   return fakeGatewayToolCall(id, "terminal", { action: "exec", command });
 }
 
+function cleanCommandCall(command: string, id: string) {
+  return fakeGatewayToolCall(id, "terminal", {
+    action: "exec",
+    command,
+    profile: "clean",
+  });
+}
+
+function installRecorder(root: IsolatedRoot, name: string, marker: string) {
+  const bin = join(root.root, "bin");
+  mkdirSync(bin, { recursive: true });
+  const executable = join(bin, name);
+  writeFileSync(
+    executable,
+    `#!/bin/sh\nprintf '%s:%s\\n' ${JSON.stringify(name)} "$*" >> ${JSON.stringify(marker)}\n`,
+  );
+  chmodSync(executable, 0o755);
+  return bin;
+}
+
+function runGit(cwd: string, args: string[]) {
+  const result = Bun.spawnSync(["/usr/bin/git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(
+    result.exitCode,
+    `git ${args.join(" ")} failed: ${result.stderr.toString()}`,
+  ).toBe(0);
+  return result.stdout.toString();
+}
+
 function startGateway(
   responses: Parameters<typeof startFakeGateway>[0],
   classifierResponses: NonNullable<
@@ -247,6 +280,331 @@ describe("lean auto mode reliability", () => {
       expect(json.tool_calls).toContainEqual(
         expect.objectContaining({ name: "terminal", status: "success" }),
       );
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "direct destructive commands replan before reviewer allow",
+    async () => {
+      for (const [name, command] of [
+        ["rm", "rm disposable.txt"],
+        ["rmdir", "rmdir disposable-dir"],
+        ["unlink", "unlink disposable-link"],
+        ["shred", "shred disposable.txt"],
+        ["git_clean", "git clean -fd"],
+        ["git_rm", "git rm tracked.txt"],
+        ["git_reset", "git reset --hard HEAD~1"],
+        ["compound_rm", "pwd && rm compound.txt"],
+      ] as const) {
+        const root = createIsolatedRoot();
+        const marker = join(root.root, `${name}-must-not-run`);
+        let bin = installRecorder(root, "rm", marker);
+        for (const executable of ["rmdir", "unlink", "shred", "git"]) {
+          bin = installRecorder(root, executable, marker);
+        }
+        const gateway = startGateway(
+          [
+            cleanCommandCall(command, `deterministic_${name}`),
+            (body) => {
+              expect(body).toContain("auto_denied");
+              return fakeGatewayFinalText(`${name} replanned`);
+            },
+          ],
+          [fakeGatewayPermissionDecision("allow", `must_not_review_${name}`)],
+        );
+
+        const result = await runFx(
+          ["ask", "--quiet", "--json", "--no-save", `Exercise ${name} safely.`],
+          {
+            cwd: root.workspace,
+            env: {
+              ...gatewayEnv(root, gateway),
+              PATH: `${bin}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+            },
+            timeoutMs: TIMEOUT,
+          },
+        );
+
+        expect(
+          result.code,
+          `command: ${command}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+        ).toBe(0);
+        expect(result.stdout).toContain(`${name} replanned`);
+        expect(gateway.classifierRequests).toHaveLength(0);
+        expect(gateway.requests).toHaveLength(2);
+        expect(existsSync(marker)).toBe(false);
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "delete_file replans before reviewer allow and preserves the file",
+    async () => {
+      const root = createIsolatedRoot();
+      const target = join(root.workspace, "keep.txt");
+      writeFileSync(target, "keep\n");
+      const gateway = startGateway(
+        [
+          fakeGatewayToolCall("deterministic_delete", "delete_file", {
+            path: target,
+          }),
+          (body) => {
+            expect(body).toContain("auto_denied");
+            return fakeGatewayFinalText("delete replanned");
+          },
+        ],
+        [fakeGatewayPermissionDecision("allow", "must_not_review_delete")],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Keep the file intact."],
+        {
+          cwd: root.workspace,
+          env: gatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("delete replanned");
+      expect(gateway.classifierRequests).toHaveLength(0);
+      expect(readFileSync(target, "utf8")).toBe("keep\n");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "git checkout hooks remain reviewer owned",
+    async () => {
+      for (const hookMode of ["default", "configured"] as const) {
+        const root = createIsolatedRoot();
+        runGit(root.workspace, ["init", "--quiet", "--initial-branch=main"]);
+        runGit(root.workspace, ["config", "user.name", "Fixture"]);
+        runGit(root.workspace, ["config", "user.email", "fixture@example.com"]);
+        writeFileSync(join(root.workspace, "tracked.txt"), "main\n");
+        runGit(root.workspace, ["add", "tracked.txt"]);
+        runGit(root.workspace, ["commit", "--quiet", "-m", "initial"]);
+        runGit(root.workspace, ["branch", "feature/repro"]);
+
+        const marker = join(root.root, `${hookMode}-checkout-hook-must-not-run`);
+        const hooks = hookMode === "default"
+          ? join(root.workspace, ".git", "hooks")
+          : join(root.root, "configured-hooks");
+        mkdirSync(hooks, { recursive: true });
+        if (hookMode === "configured") {
+          runGit(root.workspace, ["config", "core.hooksPath", hooks]);
+        }
+        const hook = join(hooks, "post-checkout");
+        writeFileSync(
+          hook,
+          `#!/bin/sh\nprintf hook > ${JSON.stringify(marker)}\n`,
+        );
+        chmodSync(hook, 0o755);
+
+        const gateway = startGateway(
+          [
+            cleanCommandCall("git checkout feature/repro", `${hookMode}_checkout`),
+            (body) => {
+              expect(body).toContain("auto_denied");
+              return fakeGatewayFinalText("checkout remained blocked");
+            },
+          ],
+          [fakeGatewayPermissionDecision("ask", `${hookMode}_checkout_review`)],
+        );
+        const result = await runFx(
+          ["ask", "--quiet", "--json", "--no-save", "Do not run repository hooks."],
+          {
+            cwd: root.workspace,
+            env: gatewayEnv(root, gateway),
+            timeoutMs: TIMEOUT,
+          },
+        );
+
+        expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+        expect(gateway.classifierRequests).toHaveLength(1);
+        expect(existsSync(marker)).toBe(false);
+        expect(runGit(root.workspace, ["branch", "--show-current"]).trim()).toBe("main");
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "git pull post-merge hook remains reviewer owned",
+    async () => {
+      const root = createIsolatedRoot();
+      const remote = join(root.root, "remote.git");
+      const seed = join(root.root, "seed");
+      const probe = join(root.root, "probe");
+      mkdirSync(seed);
+      runGit(root.root, ["init", "--quiet", "--bare", remote]);
+      runGit(seed, ["init", "--quiet", "--initial-branch=main"]);
+      runGit(seed, ["config", "user.name", "Fixture"]);
+      runGit(seed, ["config", "user.email", "fixture@example.com"]);
+      writeFileSync(join(seed, "tracked.txt"), "initial\n");
+      runGit(seed, ["add", "tracked.txt"]);
+      runGit(seed, ["commit", "--quiet", "-m", "initial"]);
+      runGit(seed, ["remote", "add", "origin", remote]);
+      runGit(seed, ["push", "--quiet", "-u", "origin", "main"]);
+      runGit(root.root, [
+        `--git-dir=${remote}`,
+        "symbolic-ref",
+        "HEAD",
+        "refs/heads/main",
+      ]);
+      runGit(root.root, ["clone", "--quiet", remote, root.workspace]);
+      runGit(root.root, ["clone", "--quiet", remote, probe]);
+
+      const blockedMarker = join(root.root, "pull-hook-must-not-run");
+      const probeMarker = join(root.root, "pull-hook-qualification-ran");
+      for (const [repository, marker] of [
+        [root.workspace, blockedMarker],
+        [probe, probeMarker],
+      ] as const) {
+        const hook = join(repository, ".git", "hooks", "post-merge");
+        writeFileSync(
+          hook,
+          `#!/bin/sh\nprintf hook > ${JSON.stringify(marker)}\n`,
+        );
+        chmodSync(hook, 0o755);
+      }
+
+      writeFileSync(join(seed, "tracked.txt"), "updated\n");
+      runGit(seed, ["add", "tracked.txt"]);
+      runGit(seed, ["commit", "--quiet", "-m", "update"]);
+      runGit(seed, ["push", "--quiet", "origin", "main"]);
+      runGit(probe, ["pull", "--quiet", "--ff-only"]);
+      expect(existsSync(probeMarker)).toBe(true);
+
+      const gateway = startGateway(
+        [
+          cleanCommandCall("git pull --ff-only", "pull_with_hook"),
+          (body) => {
+            expect(body).toContain("auto_denied");
+            return fakeGatewayFinalText("pull remained blocked");
+          },
+        ],
+        [fakeGatewayPermissionDecision("ask", "pull_hook_review")],
+      );
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Do not run pull hooks."],
+        {
+          cwd: root.workspace,
+          env: gatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(gateway.classifierRequests).toHaveLength(1);
+      expect(existsSync(blockedMarker)).toBe(false);
+      expect(readFileSync(join(root.workspace, "tracked.txt"), "utf8")).toBe(
+        "initial\n",
+      );
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "rtk remains reviewer owned as an unresolved executable boundary",
+    async () => {
+      const root = createIsolatedRoot();
+      const marker = join(root.root, "rtk-must-not-run");
+      const bin = installRecorder(root, "rtk", marker);
+      const gateway = startGateway(
+        [
+          cleanCommandCall("rtk git status --short", "review_rtk"),
+          (body) => {
+            expect(body).toContain("auto_denied");
+            return fakeGatewayFinalText("rtk remained blocked");
+          },
+        ],
+        [fakeGatewayPermissionDecision("ask", "rtk_review")],
+      );
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Do not run unresolved wrappers."],
+        {
+          cwd: root.workspace,
+          env: {
+            ...gatewayEnv(root, gateway),
+            PATH: `${bin}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(gateway.classifierRequests).toHaveLength(1);
+      expect(existsSync(marker)).toBe(false);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "existing replacement and startup targets remain reviewer owned",
+    async () => {
+      const root = createIsolatedRoot();
+      const copySource = join(root.root, "copy-source.txt");
+      const copyDestination = join(root.root, "copy-destination.txt");
+      const renameSource = join(root.root, "rename-source.txt");
+      const renameDestination = join(root.root, "rename-destination.txt");
+      const startup = join(root.home, ".zshrc");
+      writeFileSync(copySource, "copy source\n");
+      writeFileSync(copyDestination, "copy destination\n");
+      writeFileSync(renameSource, "rename source\n");
+      writeFileSync(renameDestination, "rename destination\n");
+      writeFileSync(startup, "startup before\n");
+
+      const gateway = startGateway(
+        [
+          fakeGatewayToolCall("review_copy", "copy_file", {
+            source: copySource,
+            destination: copyDestination,
+          }),
+          (body) => {
+            expect(body).toContain("auto_denied");
+            return fakeGatewayToolCall("review_rename", "rename_file", {
+              old_path: renameSource,
+              new_path: renameDestination,
+            });
+          },
+          (body) => {
+            expect(body).toContain("auto_denied");
+            return fakeGatewayToolCall("review_startup", "write_file", {
+              path: startup,
+              content: "startup after\n",
+            });
+          },
+          (body) => {
+            expect(body).toContain("auto_denied");
+            return fakeGatewayFinalText("replacement effects stayed blocked");
+          },
+        ],
+        [
+          fakeGatewayPermissionDecision("ask", "copy_review"),
+          fakeGatewayPermissionDecision("ask", "rename_review"),
+          fakeGatewayPermissionDecision("ask", "startup_review"),
+        ],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Preserve every existing target."],
+        {
+          cwd: root.workspace,
+          env: gatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(gateway.classifierRequests).toHaveLength(3);
+      expect(readFileSync(copySource, "utf8")).toBe("copy source\n");
+      expect(readFileSync(copyDestination, "utf8")).toBe("copy destination\n");
+      expect(readFileSync(renameSource, "utf8")).toBe("rename source\n");
+      expect(readFileSync(renameDestination, "utf8")).toBe("rename destination\n");
+      expect(readFileSync(startup, "utf8")).toBe("startup before\n");
     },
     TIMEOUT,
   );

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -294,6 +294,8 @@ describe("lean auto mode reliability", () => {
         ["shred", "shred disposable.txt"],
         ["git_clean", "git clean -fd"],
         ["git_rm", "git rm tracked.txt"],
+        ["git_rm_separator", "git rm -- -n"],
+        ["git_clean_separator", "git clean -f -- -n"],
         ["git_reset", "git reset --hard HEAD~1"],
         ["compound_rm", "pwd && rm compound.txt"],
       ] as const) {

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -296,8 +296,12 @@ describe("lean auto mode reliability", () => {
         ["git_rm", "git rm tracked.txt"],
         ["git_rm_separator", "git rm -- -n"],
         ["git_clean_separator", "git clean -f -- -n"],
+        ["git_clean_exclude_short", "git clean -f -e --dry-run"],
+        ["git_clean_exclude_long", "git clean -f --exclude --dry-run"],
         ["git_reset", "git reset --hard HEAD~1"],
+        ["git_reset_boundary", "git reset --hard; printf ok"],
         ["compound_rm", "pwd && rm compound.txt"],
+        ["rm_boundary", "rm victim; printf ok"],
       ] as const) {
         const root = createIsolatedRoot();
         const marker = join(root.root, `${name}-must-not-run`);

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -302,6 +302,7 @@ describe("lean auto mode reliability", () => {
         ["git_reset_boundary", "git reset --hard; printf ok"],
         ["compound_rm", "pwd && rm compound.txt"],
         ["rm_boundary", "rm victim; printf ok"],
+        ["escaped_space_rm", "printf foo\\ #bar; rm victim"],
       ] as const) {
         const root = createIsolatedRoot();
         const marker = join(root.root, `${name}-must-not-run`);

--- a/tests/e2e/file-tool-paths.test.ts
+++ b/tests/e2e/file-tool-paths.test.ts
@@ -970,7 +970,7 @@ describe("filesystem path handling", () => {
         (body) => {
           const resultOutput = toolResultOutput(body, "write_large_review");
           expect(resultOutput).toContain('"reason":"auto_denied"');
-          expect(resultOutput).toContain("Permission denied by auto mode classifier");
+          expect(resultOutput).toContain("Blocked by automatic safety policy");
           return finalText("large reviewed write blocked");
         },
       ], { classifierDecision: "ask" });
@@ -1483,7 +1483,7 @@ describe("filesystem path handling", () => {
   );
 
   test(
-    "external delete_file review receives exact action and canonical target",
+    "external delete_file replans before review and preserves the target",
     async () => {
       const root = createIsolatedRoot();
       try {
@@ -1491,17 +1491,23 @@ describe("filesystem path handling", () => {
         mkdirSync(desktop, { recursive: true });
         const target = join(desktop, "test.txt");
         writeFileSync(target, "delete\n");
-        const gateway = startFakeGateway(firstCallToolResponses({
-          id: "delete_external_1",
-          name: "delete_file",
-          input: {
-            path: target,
+        const gateway = startFakeGateway([
+          (body) => {
+            expect(body).toContain("Execute the requested file tool once.");
+            expect(existsSync(target)).toBe(true);
+            return toolCall("delete_external_1", "delete_file", {
+              path: target,
+            });
           },
-          expectedResultRequest: [target],
-          expectedResultOutput: [target],
-          finalMessage: "classified external delete complete",
-          beforeToolCall: () => expect(existsSync(target)).toBe(true),
-        }));
+          (body) => {
+            const resultOutput = toolResultOutput(body, "delete_external_1");
+            expect(body).toContain(target);
+            expect(resultOutput).toContain("auto_denied");
+            expect(resultOutput).toContain("Blocked by automatic safety policy");
+            expect(existsSync(target)).toBe(true);
+            return finalText("external delete replanned");
+          },
+        ], { classifierDecision: "allow" });
         try {
           const result = await runFx(
             [
@@ -1519,28 +1525,12 @@ describe("filesystem path handling", () => {
           );
           const json = parseFxJson(result);
           expect(gateway.requests).toHaveLength(2);
-          expect(gateway.classifierRequests).toHaveLength(1);
+          expect(gateway.classifierRequests).toHaveLength(0);
           expect(gateway.remainingResponseCount()).toBe(0);
-          expect(gateway.classifierRequests[0]!.body).toContain(
-            "Execute the requested file tool once.",
-          );
-          expect(gateway.classifierRequests[0]!.body).toContain(
-            "action: tool",
-          );
-          expect(gateway.classifierRequests[0]!.body).toContain(
-            "tool: delete_file",
-          );
-          expect(gateway.classifierRequests[0]!.body).toContain(
-            `target[target]: ${target}`,
-          );
-          expect(gateway.classifierRequests[0]!.body).toContain(
-            `arguments_json: {\\\"path\\\":\\\"${target}`,
-          );
           expect(json.tool_calls).toEqual([
-            { name: "delete_file", status: "success" },
+            { name: "delete_file", status: "error" },
           ]);
-          expect(occurrenceCount(result.stderr, `Deleting ${target}\n`)).toBe(1);
-          expect(existsSync(target)).toBe(false);
+          expect(readFileSync(target, "utf8")).toBe("delete\n");
         } finally {
           gateway.stop();
         }

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -1438,6 +1438,88 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
   );
 
   test(
+    "persistent auto child replans a direct delete before review",
+    async () => {
+      const fixture = createFixture();
+      writeFileSync(
+        join(fixture.home, ".fx", "settings.json"),
+        JSON.stringify({ sandbox: "none", permission_mode: "auto", permission: {} }),
+      );
+      const childPrompt = "AUTO_DELETE_CHILD_PROMPT";
+      const marker = join(fixture.workspace, "auto-child-keep.txt");
+      writeFileSync(marker, "keep\n");
+      const gateway = startDynamicFakeGateway((body) => {
+        if (body.includes('"toolCallId":"auto_delete_create"')) {
+          return fakeGatewayFinalText("AUTO_DELETE_PARENT_READY");
+        }
+        if (body.includes('"toolCallId":"auto_delete_file"')) {
+          return fakeGatewayFinalText("AUTO_DELETE_CHILD_COMPLETE");
+        }
+        if (body.includes(childPrompt)) {
+          return fakeGatewayToolCall("auto_delete_file", "delete_file", {
+            path: marker,
+          });
+        }
+        return fakeGatewayToolCall("auto_delete_create", "subagent", {
+          command: {
+            create: {
+              name: "auto-delete-child",
+              mode: "persistent",
+              prompt: childPrompt,
+              permission_mode: "auto",
+            },
+          },
+        });
+      }, {
+        classifierDecision: "allow",
+        models: [{ id: FAKE_GATEWAY_MODEL, type: "language", tags: ["tool-use"] }],
+      });
+      try {
+        session = await TmuxSession.create({
+          cmd: FX_BIN,
+          cwd: fixture.workspace,
+          env: {
+            HOME: fixture.home,
+            AI_GATEWAY_API_KEY: "auto-delete-child-key",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_MODEL: FAKE_GATEWAY_MODEL,
+            FX_AUTO_UPGRADE: "0",
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_SKIP_ONBOARDING: "1",
+            FX_SOUND: "0",
+            NO_COLOR: "1",
+          },
+          width: 112,
+          height: 32,
+          stderrPath: fixture.stderrPath,
+        });
+        const active = session;
+        await active.waitForComposer(TIMEOUT);
+        await active.sendText("Create the auto-delete child.");
+        await active.waitForText("AUTO_DELETE_PARENT_READY", TIMEOUT);
+        const denialDeadline = Date.now() + TIMEOUT;
+        while (
+          !gateway.requests.some((request) => request.body.includes("auto_denied")) &&
+          Date.now() < denialDeadline
+        ) {
+          await Bun.sleep(25);
+        }
+        expect(gateway.requests.some((request) =>
+          request.body.includes("auto_denied")
+        )).toBe(true);
+        expect(readFileSync(marker, "utf8")).toBe("keep\n");
+        expect(gateway.classifierRequests).toHaveLength(0);
+        expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+      } finally {
+        gateway.stop();
+      }
+    },
+    60_000,
+  );
+
+  test(
     "child file always approval reuses canonical scope and keeps external writes governed",
     async () => {
       const fixture = createFixture();


### PR DESCRIPTION
## Summary

- Return direct file deletion and destructive shell commands to the agent for replanning without invoking the automatic reviewer.
- Preserve configured rules, session decisions, local grants, sandbox authority, and exact human approval.
- Keep Git checkout, switch, pull, unresolved wrappers, and existing file replacements under automatic review.
- Leave current automatic allows for known reversible commands and new nonsensitive files unchanged.
- Describe automatic denials as safety-policy blocks instead of classifier-specific failures.
