### PR TITLE
Own interactive transcript scrollback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Config precedence (highest wins):
 4. `<workspace>/.fx.json` (committed project defaults)
 5. Built-in defaults
 
-Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `permission_mode`, `credential_source`, and `permission` are ignored from project config before their values are parsed.
+Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `fullscreen`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `permission_mode`, `credential_source`, and `permission` are ignored from project config before their values are parsed.
 
 Runtime state lives under `~/.fx/sessions/<session-id>/` (`session.json`, `background/`, `subagent/`, `logs/`). Sessions are global and portable across workspaces — each session tracks its `workspace_root` which updates when resumed in a different workspace. A subagent child is an ordinary session with its own directory; `subagent/` holds create-operation identities on a parent and the control record on a child.
 
@@ -279,7 +279,7 @@ A Full CI result is valid only when it belongs to the exact current commit and a
 
 ## Reproducing Render Bugs
 
-fx's rendering is inline by default and deliberately emits a small ANSI subset. Five owner classes are the narrow exceptions, and each takes the alternate buffer exclusively through `AlternateScreenOwner` in `src/ui/shell_runtime.zig`: interactive permission review, the full-transcript screen, catalog menus, the ctrl+x subagent manager, and a hosted child-terminal takeover. The terminal-session owner is entered only by an explicit manager handoff after the host grants the human write lease; it renders the shared terminal-engine grid without permanent Fx chrome and releases that lease on detach. Only one class may own the buffer at a time, and each must leave it and restore the main grid, composer, cursor, paste, mouse, focus, and keyboard modes when it closes. Transcript rendering, question prompts, and command-output expansion remain inline. Three tools exist for reproducing and regression-proofing render bugs:
+fx starts with its scrollable transcript in the alternate buffer and retains inline rendering as a profile-controlled fallback. Five owner classes take the alternate buffer exclusively through `AlternateScreenOwner` in `src/ui/shell_runtime.zig`: interactive permission review, the full-transcript screen, catalog menus, the ctrl+x subagent manager, and a hosted child-terminal takeover. The terminal-session owner is entered only by an explicit manager handoff after the host grants the human write lease; it renders the shared terminal-engine grid without permanent Fx chrome and releases that lease on detach. Only one class may own the buffer at a time, and each must leave it or explicitly hand ownership off, restoring the main grid, composer, cursor, paste, mouse, focus, and keyboard modes when it closes. Question prompts and command-output expansion remain inline. Three tools exist for reproducing and regression-proofing render bugs:
 
 ### tmux (live TTY repros)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ Config precedence (highest wins):
 4. `<workspace>/.fx.json` (committed project defaults)
 5. Built-in defaults
 
-Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `update_channel`, `permission_mode`, and `permission` are ignored from project config before their values are parsed.
+Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `fullscreen`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `update_channel`, `permission_mode`, and `permission` are ignored from project config before their values are parsed.
 
 Runtime state lives under `~/.fx/`:
 
@@ -255,7 +255,7 @@ Do not add new sensitive tool behavior without integrating it into `src/core/per
 
 ## Writing a Resize Test
 
-Render bugs that appear during window resize are hard to reason about because the footer is inline (hugs the transcript) rather than pinned to the terminal bottom, and the 100 ms debounce can mask ordering mistakes. The testing rig covers three layers. Pick the lowest layer that can catch the bug.
+Render bugs that appear during window resize are hard to reason about because fullscreen mode pins the footer while the inline fallback hugs the transcript, and the 100 ms debounce can mask ordering mistakes. The testing rig covers three layers. Pick the lowest layer that can catch the bug.
 
 ### Zig unit test (fastest, runs in `zig build test`)
 
@@ -317,7 +317,7 @@ Check in the golden file and wire a regression test that re-runs `fx replay` in 
 
 * Do not commit generated state from `.fx/`, `.zig-cache/`, or `zig-out/`
 
-* Do not add a general alternate-screen (`\x1b[?1049h/l`) render path. fx is inline by design except for the five exclusive owner classes represented by `AlternateScreenOwner`: interactive tool-approval review, the full-transcript screen, catalog menus, the ctrl+x subagent manager, and the hosted child-terminal takeover. The terminal-session owner is entered only from the manager after `TerminalHost` grants the human write lease, has no permanent fx chrome, and must release the lease on detach. Every owner must leave or explicitly hand off the alternate buffer and restore the main grid, composer, cursor, paste, mouse, focus, and keyboard modes before resolving, cancelling, or shutting down
+* Do not add a general alternate-screen (`\x1b[?1049h/l`) render path. Fullscreen transcript presentation uses the existing full-transcript owner and inline mode remains the fallback. The five exclusive owner classes represented by `AlternateScreenOwner` are interactive tool-approval review, the full-transcript screen, catalog menus, the ctrl+x subagent manager, and the hosted child-terminal takeover. The terminal-session owner is entered only from the manager after `TerminalHost` grants the human write lease, has no permanent fx chrome, and must release the lease on detach. Every owner must leave or explicitly hand off the alternate buffer and restore the main grid, composer, cursor, paste, mouse, focus, and keyboard modes before resolving, cancelling, or shutting down
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands.
 
+Interactive fx starts in fullscreen mode. fx owns the scrollback viewport while the composer and status area stay docked, so the mouse wheel and Page Up/Page Down can move through the transcript without replaying it into terminal history. Press Ctrl+O or Escape to return to inline mode for the current run. To keep inline mode across launches, run `/settings fullscreen off`, set `"fullscreen": false` in `~/.fx/settings.json`, or launch once with `FX_FULLSCREEN=0`.
+
 List saved sessions with `fx sessions`. Resume the latest session for the current workspace, or select an exact session ID, through the same command group:
 
 ```bash

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -435,7 +435,7 @@ pub const slash_specs = [_]SlashSpec{
     .{ .kind = .feedback, .command = "/feedback", .help_entry = "/feedback", .completion_description = "open the fx feedback form", .presentation_category = .product, .show_in_welcome = true },
     .{ .kind = .trace, .command = "/trace", .help_entry = "/trace", .completion_description = "copy a private diagnostic trace", .presentation_category = .product },
     .{ .kind = .compact, .command = "/compact", .help_entry = "/compact", .completion_description = "compact older conversation turns", .presentation_category = .session },
-    .{ .kind = .settings, .command = "/settings", .help_entry = "/settings [startup-scrollback [on|off]]", .completion_description = "browse and update settings", .presentation_category = .appearance, .has_args = true, .accepts_payload = true },
+    .{ .kind = .settings, .command = "/settings", .help_entry = "/settings [fullscreen|startup-scrollback [on|off]]", .completion_description = "browse and update settings", .presentation_category = .appearance, .has_args = true, .accepts_payload = true },
     .{ .kind = .alias, .command = "/alias", .aliases = &.{}, .help_entry = "/alias [name] [command]", .completion_description = "show alias availability", .presentation_category = .extensions, .has_args = true, .accepts_payload = true },
     .{ .kind = .credits, .command = "/credits", .aliases = &.{"/balance"}, .help_entry = "/credits (/balance)", .completion_description = "show gateway credits balance", .presentation_category = .account, .requires_prompt_credential = true },
     .{ .kind = .paste, .command = "/paste", .help_entry = "/paste", .completion_description = "attach an image from the clipboard when supported", .presentation_category = .media },
@@ -585,6 +585,14 @@ test "built-in slash registry resolves primary commands and aliases" {
     try std.testing.expect(!models.requires_prompt_credential);
 
     try std.testing.expect(command_specs.matchedSlashPrefix(slash_registry, "/model\nmodel-id", .model) == null);
+}
+
+test "built-in settings help documents fullscreen preference" {
+    const settings = slash_registry.lookup("/settings") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings(
+        "/settings [fullscreen|startup-scrollback [on|off]]",
+        settings.help_entry.?,
+    );
 }
 
 test "exact slash command matching includes hidden completion aliases" {

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -272,6 +272,9 @@ pub fn Runtime(comptime App: type) type {
             app.worker.agent_turn_settings.effort = startup.effort;
             app.context_enabled = startup.context_enabled;
             app.fast_mode = startup.fast_mode;
+            if (comptime @hasField(App, "fullscreen_enabled")) {
+                app.fullscreen_enabled = startup.fullscreen;
+            }
             app.input_runtime.input_appearance = startup.input_appearance;
             app.input_runtime.slash_menu_categories = startup.slash_menu_categories;
             app.shell.maxxing_mode = startup.maxxing_mode;
@@ -444,6 +447,14 @@ pub fn Runtime(comptime App: type) type {
                 .none => {},
                 .ready => |entry_id| try deps.publish_staged_resume_view(app, entry_id),
             }
+            if (startup.fullscreen) {
+                try app_lifecycle.openFullTranscript(
+                    app.alloc,
+                    &app.terminal,
+                    &app.shell,
+                    &app.metrics,
+                );
+            }
             app.shell.render_requests.request(.first_frame);
         }
     };
@@ -536,6 +547,7 @@ const TestApp = struct {
     terminal_input_runtime: ui_input.Runtime = .{},
     context_enabled: bool = true,
     fast_mode: bool = false,
+    fullscreen_enabled: bool = false,
     auto_upgrade_enabled: bool = true,
     upgrader: auto_upgrade.AutoUpgrade = .{},
     effort: types.ReasoningEffort = .auto,
@@ -665,6 +677,7 @@ var active_app_for_pointer_check: ?*TestApp = null;
 
 fn makeStartupState(alloc: Allocator) !app_lifecycle.StartupState {
     var state = app_lifecycle.StartupState{ .agent_step_limit = 19 };
+    state.fullscreen = false;
     state.max_tool_result_bytes = 131072;
     state.first_call_tool_choice = .none;
     state.workspace_root = try alloc.dupe(u8, "/workspace");

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -1579,7 +1579,8 @@ pub fn Handlers(comptime App: type) type {
                 if (comptime @hasField(App, "model_cache")) app.model_cache.closeMenu();
                 closeHelpMenuIfPresent(app);
                 closeInlineCommandMenusIfPresent(app);
-                app.input_runtime.settings_menu.openWithStartupScrollback(
+                app.input_runtime.settings_menu.openWithPreferences(
+                    settings.fullscreen orelse true,
                     settings.startup_scrollback orelse true,
                 );
                 app.shell.render_requests.request(.footer);
@@ -3337,6 +3338,7 @@ pub fn settingsCatalogSnapshot(app: anytype) settings_catalog.Snapshot {
     if (comptime @hasField(App, "permission_engine")) snapshot.permission_mode = @tagName(app.permission_engine.mode);
     if (comptime @hasField(App, "input_runtime")) {
         snapshot.input_appearance = app.input_runtime.input_appearance.label();
+        snapshot.fullscreen = app.input_runtime.settings_menu.fullscreen;
         snapshot.startup_scrollback = app.input_runtime.settings_menu.startup_scrollback;
         if (comptime @hasField(@TypeOf(app.input_runtime), "slash_menu_categories")) {
             snapshot.slash_menu_categories = app.input_runtime.slash_menu_categories;
@@ -3497,6 +3499,14 @@ pub fn applySettingsCatalogChange(app: anytype, change: settings_catalog.Change)
                 .{ .slash_menu_categories = enabled },
                 runtime_changed,
             );
+        },
+        .fullscreen => {
+            const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;
+            try session_commands.Commands(@TypeOf(app.*)).handleSettings(
+                app,
+                if (enabled) "fullscreen on" else "fullscreen off",
+            );
+            app.input_runtime.settings_menu.fullscreen = enabled;
         },
         .effort => {
             const effort = types.ReasoningEffort.parseDisplayLabel(change.value) orelse

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -137,6 +137,7 @@ pub const StartupState = struct {
     slash_menu_categories: bool = true,
     auto_upgrade: bool = true,
     update_channel: update_target.Channel = .stable,
+    fullscreen: bool = true,
     startup_scrollback: bool = true,
     prompt_history_enabled: bool = true,
     prompt_history_store_allowed: bool = true,
@@ -416,6 +417,7 @@ fn loadStartupStateFromOwnedWorkspace(
     state.slash_menu_categories = settings.slash_menu_categories orelse true;
     state.auto_upgrade = settings.auto_upgrade orelse true;
     state.update_channel = settings.update_channel orelse .stable;
+    state.fullscreen = loadFullscreen(settings.fullscreen);
     state.startup_scrollback = settings.startup_scrollback orelse true;
     state.effort = settings.effort orelse .auto;
     state.first_call_tool_choice = settings.first_call_tool_choice orelse .auto;
@@ -1083,6 +1085,26 @@ fn loadPermissionMode(configured: ?PermissionMode) PermissionMode {
     const fallback = configured orelse default_permission_mode;
     const mode = io_mod.getenv("FX_PERMISSION_MODE") orelse return fallback;
     return config_runtime.parsePermissionMode(mode) orelse fallback;
+}
+
+fn loadFullscreen(configured: ?bool) bool {
+    return resolveFullscreen(configured, io_mod.getenv("FX_FULLSCREEN"));
+}
+
+fn resolveFullscreen(configured: ?bool, override: ?[]const u8) bool {
+    const fallback = configured orelse true;
+    const raw = override orelse return fallback;
+    if (std.mem.eql(u8, raw, "1") or std.ascii.eqlIgnoreCase(raw, "true")) return true;
+    if (std.mem.eql(u8, raw, "0") or std.ascii.eqlIgnoreCase(raw, "false")) return false;
+    return fallback;
+}
+
+test "fullscreen environment override accepts both directions" {
+    try std.testing.expect(resolveFullscreen(false, "1"));
+    try std.testing.expect(resolveFullscreen(false, "true"));
+    try std.testing.expect(!resolveFullscreen(true, "0"));
+    try std.testing.expect(!resolveFullscreen(true, "false"));
+    try std.testing.expect(resolveFullscreen(true, "invalid"));
 }
 
 fn loadAgentStepLimit(fallback: usize, configured: ?usize) usize {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1577,9 +1577,29 @@ pub fn Runtime(comptime App: type) type {
                 try requestNormalViewportRecovery(app);
             }
 
+            if (!question_active and approval == null and
+                fullscreenEnabled(app) and
+                app.terminal.alternate_screen_owner == .none and
+                !app.shell.fullTranscriptActive())
+            {
+                try app_lifecycle.openFullTranscript(
+                    app.alloc,
+                    &app.terminal,
+                    &app.shell,
+                    &app.metrics,
+                );
+            }
+
             return .{ .inline_render = .{
                 .alternate_screen_owns_rendering = app.terminal.alternate_screen_owner != .none,
             } };
+        }
+
+        fn fullscreenEnabled(app: *const App) bool {
+            if (comptime @hasField(App, "fullscreen_enabled")) {
+                return app.fullscreen_enabled;
+            }
+            return false;
         }
 
         fn renderFrameAttempt(app: *App, snapshot: render_request.AttemptSnapshot) !FrameAttemptResult {
@@ -4538,6 +4558,7 @@ const CoordinatorTestApp = struct {
     model_cache: model_cache_runtime.Runtime = model_cache_runtime.Runtime.init(std.testing.allocator, "/v1/models"),
     stream: types.StreamState = .{},
     fast_mode: bool = false,
+    fullscreen_enabled: bool = false,
     effort: types.ReasoningEffort = .auto,
     statusline_sandbox: bool = false,
     statusline_context: bool = false,
@@ -4634,6 +4655,58 @@ fn initCoordinatorProjectionTestApp(
     try app.shell.initBacking(alloc);
     try app.shell.enableShadowVt(alloc);
     return app;
+}
+
+test "core.app_render_runtime fullscreen resumes after a catalog surface yields ownership" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile(std.testing.io, "fullscreen-resume.log", .{ .read = true });
+    defer file.close(io_mod.getIo());
+
+    var app = try initCoordinatorProjectionTestApp(alloc, file);
+    defer app.deinit();
+    app.fullscreen_enabled = true;
+
+    _ = try Runtime(CoordinatorTestApp).reconcileBeforeFrameRender(&app, 0);
+    try std.testing.expect(app.terminal.fullTranscriptScreenActive());
+    try std.testing.expect(app.shell.fullTranscriptActive());
+
+    app.input_runtime.settings_menu.open();
+    _ = try Runtime(CoordinatorTestApp).reconcileBeforeFrameRender(&app, 0);
+    try std.testing.expect(!app.terminal.fullTranscriptScreenActive());
+    try std.testing.expect(!app.shell.fullTranscriptActive());
+
+    app.input_runtime.settings_menu.close();
+    _ = try Runtime(CoordinatorTestApp).reconcileBeforeFrameRender(&app, 0);
+    try std.testing.expect(app.terminal.fullTranscriptScreenActive());
+    try std.testing.expect(app.shell.fullTranscriptActive());
+}
+
+test "core.app_render_runtime fullscreen yields to inline approval and resumes after it clears" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile(std.testing.io, "fullscreen-approval-resume.log", .{ .read = true });
+    defer file.close(io_mod.getIo());
+
+    var app = try initCoordinatorProjectionTestApp(alloc, file);
+    defer app.deinit();
+    app.fullscreen_enabled = true;
+    try app_lifecycle.openFullTranscript(app.alloc, &app.terminal, &app.shell, &app.metrics);
+    try std.testing.expect(try app.approval_prompt.syncRequest(alloc, .{
+        .id = 42,
+        .label = "terminal.exec printf approval",
+    }));
+
+    _ = try Runtime(CoordinatorTestApp).reconcileBeforeFrameRender(&app, 0);
+    try std.testing.expect(!app.terminal.fullTranscriptScreenActive());
+    try std.testing.expect(!app.shell.fullTranscriptActive());
+
+    app.approval_prompt.clear(alloc);
+    _ = try Runtime(CoordinatorTestApp).reconcileBeforeFrameRender(&app, 0);
+    try std.testing.expect(app.terminal.fullTranscriptScreenActive());
+    try std.testing.expect(app.shell.fullTranscriptActive());
 }
 
 test "core.app_render_runtime keeps final token progress during paced response tail" {

--- a/src/core/app/input_full_transcript_runtime.zig
+++ b/src/core/app/input_full_transcript_runtime.zig
@@ -124,8 +124,10 @@ pub fn Runtime(comptime App: type) type {
                     &app.shell,
                     &app.metrics,
                 );
+                setFullscreenEnabled(app, true);
                 requestActiveSurfaceFrame(app);
             } else if (to == .inline_mode) {
+                if (event == .toggle) setFullscreenEnabled(app, false);
                 try app_lifecycle.closeFullTranscript(
                     app.alloc,
                     &app.terminal,
@@ -172,6 +174,7 @@ pub fn Runtime(comptime App: type) type {
             if (comptime !@hasField(App, "terminal")) return;
             const from = app.shell.transcriptPresentationDepth();
             if (!from.active()) return;
+            setFullscreenEnabled(app, false);
             try app_lifecycle.closeFullTranscript(
                 app.alloc,
                 &app.terminal,
@@ -347,6 +350,12 @@ pub fn Runtime(comptime App: type) type {
                 .full => "full",
             };
         }
+
+        fn setFullscreenEnabled(app: *App, enabled: bool) void {
+            if (comptime @hasField(App, "fullscreen_enabled")) {
+                app.fullscreen_enabled = enabled;
+            }
+        }
     };
 }
 
@@ -403,6 +412,7 @@ const ApprovalRoutingApp = struct {
     terminal: shell_runtime.TerminalState = .{
         .alternate_screen_owner = .full_transcript,
     },
+    fullscreen_enabled: bool = false,
 
     fn deinit(self: *ApprovalRoutingApp) void {
         self.approval_prompt.deinit(self.alloc);
@@ -436,6 +446,16 @@ test "full transcript owns raw semantic and remapped ctrl-l" {
         transcript_presentation.Depth.review,
         app.subagents.depth,
     );
+}
+
+test "full transcript preference tracks the owned scrollback surface" {
+    var app = ApprovalRoutingApp{ .alloc = std.testing.allocator };
+    defer app.deinit();
+
+    Runtime(ApprovalRoutingApp).setFullscreenEnabled(&app, true);
+    try std.testing.expect(app.fullscreen_enabled);
+    Runtime(ApprovalRoutingApp).setFullscreenEnabled(&app, false);
+    try std.testing.expect(!app.fullscreen_enabled);
 }
 
 test "selected child approval owns ctrl-o ahead of transcript depth" {

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -51,6 +51,7 @@ pub const Settings = struct {
     slash_menu_categories: ?bool = null,
     auto_upgrade: ?bool = null,
     update_channel: ?update_target.Channel = null,
+    fullscreen: ?bool = null,
     startup_scrollback: ?bool = null,
     prompt_history_enabled: ?bool = null,
     effort: ?types.ReasoningEffort = null,
@@ -110,6 +111,7 @@ pub const ConfigSources = struct {
     input_appearance: ConfigSource = .compiled_default,
     maxxing_mode: ConfigSource = .compiled_default,
     slash_menu_categories: ConfigSource = .compiled_default,
+    fullscreen: ConfigSource = .compiled_default,
     startup_scrollback: ConfigSource = .compiled_default,
     prompt_history_enabled: ConfigSource = .compiled_default,
     statusline_sandbox: ConfigSource = .compiled_default,
@@ -518,6 +520,7 @@ fn hasLegacyWorkspacePreferences(root: std.json.Value) bool {
             "input_appearance",
             "maxxing_mode",
             "slash_menu_categories",
+            "fullscreen",
             "startup_scrollback",
         }) |key| {
             if (workspace.contains(key)) return true;
@@ -546,6 +549,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "input_appearance",
         "maxxing_mode",
         "slash_menu_categories",
+        "fullscreen",
         "startup_scrollback",
         "prompt_history",
         "statusLine",
@@ -591,6 +595,7 @@ fn updateConfigSources(sources: *ConfigSources, settings: Settings, source: Conf
     if (settings.input_appearance != null) sources.input_appearance = source;
     if (settings.maxxing_mode != null) sources.maxxing_mode = source;
     if (settings.slash_menu_categories != null) sources.slash_menu_categories = source;
+    if (settings.fullscreen != null) sources.fullscreen = source;
     if (settings.startup_scrollback != null) sources.startup_scrollback = source;
     if (settings.prompt_history_enabled != null) sources.prompt_history_enabled = source;
     if (settings.statusline_sandbox != null) sources.statusline_sandbox = source;
@@ -1380,6 +1385,11 @@ fn parseProfileOnlyFields(
             return error.InvalidUpdateChannelValue;
     }
 
+    if (root.object.get("fullscreen")) |fullscreen_value| {
+        if (fullscreen_value != .bool) return error.InvalidFullscreenType;
+        settings.fullscreen = fullscreen_value.bool;
+    }
+
     if (root.object.get("startup_scrollback")) |startup_scrollback_value| {
         const value = startup_scrollback_value;
         if (value != .bool) return error.InvalidStartupScrollbackType;
@@ -1511,6 +1521,7 @@ fn mergeSettings(target: *Settings, incoming: *Settings, alloc: Allocator) void 
     if (incoming.slash_menu_categories) |value| target.slash_menu_categories = value;
     if (incoming.auto_upgrade) |value| target.auto_upgrade = value;
     if (incoming.update_channel) |value| target.update_channel = value;
+    if (incoming.fullscreen) |value| target.fullscreen = value;
     if (incoming.startup_scrollback) |value| target.startup_scrollback = value;
     if (incoming.prompt_history_enabled) |value| target.prompt_history_enabled = value;
     if (incoming.effort) |value| target.effort = value;
@@ -2100,6 +2111,30 @@ test "startup_scrollback parses merges rejects invalid type and round trips" {
     const json = try serializeJsonObject(std.testing.allocator, parsed.value);
     defer std.testing.allocator.free(json);
     try std.testing.expect(std.mem.find(u8, json, "\"startup_scrollback\":false") != null);
+}
+
+test "fullscreen is a profile-only boolean preference" {
+    var enabled = try parseSettingsJson(std.testing.allocator, "{\"fullscreen\":true}");
+    defer enabled.deinit(std.testing.allocator);
+    try std.testing.expectEqual(true, enabled.fullscreen.?);
+
+    var disabled = try parseSettingsJson(std.testing.allocator, "{\"fullscreen\":false}");
+    defer disabled.deinit(std.testing.allocator);
+    mergeSettings(&enabled, &disabled, std.testing.allocator);
+    try std.testing.expectEqual(false, enabled.fullscreen.?);
+
+    try std.testing.expectError(
+        error.InvalidFullscreenType,
+        parseSettingsJson(std.testing.allocator, "{\"fullscreen\":\"off\"}"),
+    );
+
+    var project = try parseSettingsJsonForLayer(
+        std.testing.allocator,
+        "{\"fullscreen\":false}",
+        .project,
+    );
+    defer project.deinit(std.testing.allocator);
+    try std.testing.expect(project.fullscreen == null);
 }
 
 test "slash menu categories parses merges and rejects invalid types" {

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -30,6 +30,7 @@ pub const SettingId = enum {
     statusline_context,
     statusline_session,
     slash_menu_categories,
+    fullscreen,
     model,
     effort,
     fast_mode,
@@ -60,6 +61,7 @@ pub const Snapshot = struct {
     statusline_context: bool = false,
     statusline_session: bool = false,
     slash_menu_categories: bool = true,
+    fullscreen: bool = true,
     startup_scrollback: bool = true,
     prompt_history: bool = true,
     sound_level: []const u8 = "on",
@@ -77,6 +79,7 @@ pub const Snapshot = struct {
             .statusline_context => onOff(self.statusline_context),
             .statusline_session => onOff(self.statusline_session),
             .slash_menu_categories => onOff(self.slash_menu_categories),
+            .fullscreen => onOff(self.fullscreen),
             .startup_scrollback => onOff(self.startup_scrollback),
             .prompt_history => onOff(self.prompt_history),
             .sound_level => self.sound_level,
@@ -363,14 +366,23 @@ pub const Menu = struct {
     category: Category = .all,
     selected_index: usize = 0,
     window_start: usize = 0,
+    fullscreen: bool = true,
     startup_scrollback: bool = true,
 
     pub fn open(self: *Menu) void {
         self.* = .{ .active = true };
     }
 
-    pub fn openWithStartupScrollback(self: *Menu, enabled: bool) void {
-        self.* = .{ .active = true, .startup_scrollback = enabled };
+    pub fn openWithPreferences(
+        self: *Menu,
+        fullscreen: bool,
+        startup_scrollback: bool,
+    ) void {
+        self.* = .{
+            .active = true,
+            .fullscreen = fullscreen,
+            .startup_scrollback = startup_scrollback,
+        };
     }
 
     pub fn close(self: *Menu) void {
@@ -437,6 +449,7 @@ const specs = [_]Spec{
     .{ .id = .statusline_context, .category = .interface, .label = "Status line context", .description = "Show context usage in the status line" },
     .{ .id = .statusline_session, .category = .interface, .label = "Status line session", .description = "Show the session title in the status line" },
     .{ .id = .slash_menu_categories, .category = .interface, .label = "Slash menu categories", .description = "Show categories and skill sources in slash-command results" },
+    .{ .id = .fullscreen, .category = .interface, .label = "Fullscreen", .description = "Own transcript scrolling in the alternate screen" },
     .{ .id = .model, .category = .agent, .label = "Model", .description = "Choose the model used for new turns" },
     .{ .id = .effort, .category = .agent, .label = "Reasoning effort", .description = "Control how much reasoning the model applies" },
     .{ .id = .fast_mode, .category = .agent, .label = "Fast mode", .description = "Use faster inference when the model supports it" },
@@ -558,6 +571,7 @@ fn staticOptionsFor(id: SettingId) []const []const u8 {
         .statusline_context,
         .statusline_session,
         .slash_menu_categories,
+        .fullscreen,
         .startup_scrollback,
         .prompt_history,
         => &on_off_options,
@@ -622,8 +636,8 @@ test "settings catalog projects grouped searchable preferences" {
         .sandbox = "os",
     };
 
-    try std.testing.expectEqual(@as(usize, 14), filteredCount(snapshot, .all, ""));
-    try std.testing.expectEqual(@as(usize, 6), filteredCount(snapshot, .interface, ""));
+    try std.testing.expectEqual(@as(usize, 15), filteredCount(snapshot, .all, ""));
+    try std.testing.expectEqual(@as(usize, 7), filteredCount(snapshot, .interface, ""));
     try std.testing.expectEqual(@as(usize, 4), filteredCount(snapshot, .agent, ""));
     try std.testing.expectEqual(@as(usize, 1), filteredCount(snapshot, .notifications, ""));
     try std.testing.expectEqual(@as(usize, 3), filteredCount(snapshot, .advanced, ""));
@@ -694,6 +708,19 @@ test "settings catalog exposes slash menu categories as an interface toggle" {
     try std.testing.expectEqualStrings("off", hide.value);
 }
 
+test "settings catalog exposes fullscreen as an interface toggle" {
+    const snapshot: Snapshot = .{ .fullscreen = true };
+    try std.testing.expectEqual(@as(usize, 15), filteredCount(snapshot, .all, ""));
+    try std.testing.expectEqual(@as(usize, 7), filteredCount(snapshot, .interface, ""));
+    const item = itemAt(snapshot, .interface, "fullscreen", 0).?;
+    try std.testing.expectEqual(SettingId.fullscreen, item.id);
+    try std.testing.expectEqualStrings("on", item.value);
+
+    const disabled = changeAt(&snapshot, .fullscreen, 0).?;
+    try std.testing.expectEqual(SettingId.fullscreen, disabled.setting);
+    try std.testing.expectEqualStrings("off", disabled.value);
+}
+
 test "settings menu navigates rows and changes selected values inline" {
     const snapshot: Snapshot = .{
         .model = "zai/glm-5.2",
@@ -731,7 +758,7 @@ test "settings menu navigates rows and changes selected values inline" {
     menu.selected_index = 0;
     try std.testing.expect(menu.changeSelectedOption(&snapshot, "", 1) == null);
 
-    menu.openWithStartupScrollback(false);
+    menu.openWithPreferences(true, false);
     try std.testing.expect(!menu.startup_scrollback);
 }
 

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -100,6 +100,7 @@ pub const UserSettingsPatch = struct {
     maxxing_mode: ?[]const u8 = null,
     slash_menu_categories: ?bool = null,
     update_channel: ?update_target.Channel = null,
+    fullscreen: ?bool = null,
     startup_scrollback: ?bool = null,
     prompt_history_enabled: ?bool = null,
     statusline_item: ?StatuslineItemPatch = null,
@@ -119,6 +120,7 @@ pub const UserSettingsPatch = struct {
             self.maxxing_mode == null and
             self.slash_menu_categories == null and
             self.update_channel == null and
+            self.fullscreen == null and
             self.startup_scrollback == null and
             self.prompt_history_enabled == null and
             self.statusline_item == null and
@@ -214,6 +216,7 @@ const UserPreferenceField = enum(u4) {
     maxxing_mode,
     slash_menu_categories,
     update_channel,
+    fullscreen,
     startup_scrollback,
     prompt_history_enabled,
     statusline_sandbox,
@@ -234,6 +237,7 @@ const UserPreferenceField = enum(u4) {
             .maxxing_mode => "settings.json.preference-migration.maxxing_mode.json",
             .slash_menu_categories => "settings.json.preference-migration.slash_menu_categories.json",
             .update_channel => "settings.json.preference-migration.update_channel.json",
+            .fullscreen => "settings.json.preference-migration.fullscreen.json",
             .startup_scrollback => "settings.json.preference-migration.startup_scrollback.json",
             .prompt_history_enabled => "settings.json.preference-migration.prompt_history_enabled.json",
             .statusline_sandbox => "settings.json.preference-migration.statusline_sandbox.json",
@@ -252,6 +256,7 @@ const user_preference_fields = [_]UserPreferenceField{
     .maxxing_mode,
     .slash_menu_categories,
     .update_channel,
+    .fullscreen,
     .startup_scrollback,
     .prompt_history_enabled,
     .statusline_sandbox,
@@ -990,6 +995,7 @@ fn applyUserPatchToRoot(
     if (patch.maxxing_mode) |value| application.changed = try putString(arena, &root.object, "maxxing_mode", value) or application.changed;
     if (patch.slash_menu_categories) |value| application.changed = try putBool(arena, &root.object, "slash_menu_categories", value) or application.changed;
     if (patch.update_channel) |value| application.changed = try putString(arena, &root.object, "update_channel", value.label()) or application.changed;
+    if (patch.fullscreen) |value| application.changed = try putBool(arena, &root.object, "fullscreen", value) or application.changed;
     if (patch.startup_scrollback) |value| application.changed = try putBool(arena, &root.object, "startup_scrollback", value) or application.changed;
 
     if (patch.prompt_history_enabled) |enabled| {
@@ -1109,6 +1115,13 @@ fn cleanupLegacyWorkspacePreferences(
             "update_channel",
             .update_channel,
             patch.update_channel != null,
+            application,
+        );
+        removeLegacyLeaf(
+            &entry.value_ptr.object,
+            "fullscreen",
+            .fullscreen,
+            patch.fullscreen != null,
             application,
         );
         removeLegacyLeaf(
@@ -1683,7 +1696,7 @@ fn validateKnownSettingsObject(
     if (object.get("context_limits")) |value| {
         _ = context_limits.parseJsonObject(value) catch return error.InvalidSettingsFormat;
     }
-    inline for (&.{ "context", "fast_mode", "auto_upgrade", "slash_menu_categories", "startup_scrollback", "yolo_acknowledged" }) |key| {
+    inline for (&.{ "context", "fast_mode", "auto_upgrade", "slash_menu_categories", "fullscreen", "startup_scrollback", "yolo_acknowledged" }) |key| {
         if (object.get(key)) |value| {
             if (value != .bool) return error.InvalidSettingsFormat;
         }
@@ -1945,6 +1958,26 @@ test "user patch writes user preferences at top level" {
     try std.testing.expect(std.mem.find(u8, bytes, "\"notifications\":{\"turn_end\":true,\"attention_required\":false}") != null);
     try std.testing.expect(std.mem.find(u8, bytes, "\"future\":{\"nested\":7}") != null);
     try std.testing.expect(std.mem.find(u8, bytes, "\"workspaces\"") == null);
+}
+
+test "fullscreen user preference writes at top level" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    var store = try Store.initFromHome(alloc, home, .writable);
+    defer store.deinit(alloc);
+
+    var outcome = try store.applyUserPatch(alloc, .{ .fullscreen = false });
+    defer outcome.deinit(alloc);
+    try std.testing.expect(outcome == .committed);
+
+    const bytes = try store.readPrimaryForTest(alloc);
+    defer alloc.free(bytes);
+    try std.testing.expect(std.mem.find(u8, bytes, "\"fullscreen\":false") != null);
 }
 
 test "notification user patch preserves sibling fields and valid workspace overrides" {

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -172,6 +172,7 @@ fn appendShadowedUserSources(
     try appendShadowedUserSource(writer, "permission_mode", patch.permission_mode != null, sources.permission_mode, &wrote_header);
     try appendShadowedUserSource(writer, "effort", patch.effort != null, sources.effort, &wrote_header);
     try appendShadowedUserSource(writer, "fast_mode", patch.fast_mode != null, sources.fast_mode, &wrote_header);
+    try appendShadowedUserSource(writer, "fullscreen", patch.fullscreen != null, sources.fullscreen, &wrote_header);
     try appendShadowedUserSource(writer, "startup_scrollback", patch.startup_scrollback != null, sources.startup_scrollback, &wrote_header);
     try appendShadowedUserSource(writer, "input_appearance", patch.input_appearance != null, sources.input_appearance, &wrote_header);
     try appendShadowedUserSource(writer, "prompt_history", patch.prompt_history_enabled != null, sources.prompt_history_enabled, &wrote_header);
@@ -298,10 +299,14 @@ pub fn Commands(comptime App: type) type {
                 try writeSettingsUsage(app);
                 return;
             };
-            if (!std.ascii.eqlIgnoreCase(first.word, "startup-scrollback")) {
+            const setting: enum { fullscreen, startup_scrollback } = if (std.ascii.eqlIgnoreCase(first.word, "fullscreen"))
+                .fullscreen
+            else if (std.ascii.eqlIgnoreCase(first.word, "startup-scrollback"))
+                .startup_scrollback
+            else {
                 try writeSettingsUsage(app);
                 return;
-            }
+            };
 
             const value_split = splitFirstWord(first.rest);
             if (value_split) |split| {
@@ -310,11 +315,17 @@ pub fn Commands(comptime App: type) type {
                     return;
                 }
                 if (std.ascii.eqlIgnoreCase(split.word, "on")) {
-                    try saveStartupScrollbackSetting(app, true);
+                    switch (setting) {
+                        .fullscreen => try saveFullscreenSetting(app, true),
+                        .startup_scrollback => try saveStartupScrollbackSetting(app, true),
+                    }
                     return;
                 }
                 if (std.ascii.eqlIgnoreCase(split.word, "off")) {
-                    try saveStartupScrollbackSetting(app, false);
+                    switch (setting) {
+                        .fullscreen => try saveFullscreenSetting(app, false),
+                        .startup_scrollback => try saveStartupScrollbackSetting(app, false),
+                    }
                     return;
                 }
                 try writeSettingsUsage(app);
@@ -327,7 +338,10 @@ pub fn Commands(comptime App: type) type {
             };
             defer settings.deinit(app.alloc);
 
-            try saveStartupScrollbackSetting(app, !(settings.startup_scrollback orelse true));
+            switch (setting) {
+                .fullscreen => try saveFullscreenSetting(app, !(settings.fullscreen orelse true)),
+                .startup_scrollback => try saveStartupScrollbackSetting(app, !(settings.startup_scrollback orelse true)),
+            }
         }
 
         pub fn handleModel(app: *App, query: []const u8) !void {
@@ -923,13 +937,15 @@ pub fn Commands(comptime App: type) type {
             defer detailed.deinit(app.alloc);
             const settings = &detailed.settings;
 
+            const fullscreen_label = if (settings.fullscreen orelse true) "on" else "off";
             const startup_scrollback_label = if (settings.startup_scrollback orelse true) "on" else "off";
-            const msg = try std.fmt.allocPrint(app.alloc, "model: {s}\nmodel_config_source: {s}\npermission_mode: {s}\nworkspace: {s}\nstep_limit: {d}\nstartup_scrollback: {s}", .{
+            const msg = try std.fmt.allocPrint(app.alloc, "model: {s}\nmodel_config_source: {s}\npermission_mode: {s}\nworkspace: {s}\nstep_limit: {d}\nfullscreen: {s}\nstartup_scrollback: {s}", .{
                 app.selected_model.items,
                 @tagName(detailed.sources.model),
                 permissions.permissionModeLabel(app.permission_engine.mode),
                 app.workspace_root,
                 app.agent_step_limit,
+                fullscreen_label,
                 startup_scrollback_label,
             });
             defer app.alloc.free(msg);
@@ -989,11 +1005,56 @@ pub fn Commands(comptime App: type) type {
             }
         }
 
+        fn saveFullscreenSetting(app: *App, enabled: bool) !void {
+            var attempt = config_runtime.attemptUserPreferences(
+                app.alloc,
+                .{ .fullscreen = enabled },
+            );
+            defer attempt.deinit(app.alloc);
+            switch (attempt) {
+                .failure => |failure| try reportUserSettingsFailure(
+                    app,
+                    "fullscreen",
+                    failure.err,
+                    failure.cleanup,
+                    false,
+                ),
+                .outcome => |outcome| {
+                    const sources = try reportUserSettingsCommit(
+                        app,
+                        "fullscreen",
+                        .{ .fullscreen = enabled },
+                        outcome,
+                        null,
+                        false,
+                    );
+                    const label = if (enabled) "on" else "off";
+                    var out: std.Io.Writer.Allocating = .init(app.alloc);
+                    defer out.deinit();
+                    try out.writer.print("fullscreen: {s} ", .{label});
+                    if (sources) |resolved| {
+                        switch (resolved.fullscreen) {
+                            .user_global => try out.writer.writeAll("(applies on next launch)"),
+                            else => try out.writer.print(
+                                "(saved user default; current source={s})",
+                                .{@tagName(resolved.fullscreen)},
+                            ),
+                        }
+                    } else {
+                        try out.writer.writeAll("(saved user default; next-launch source unknown)");
+                    }
+                    const msg = try out.toOwnedSlice();
+                    defer app.alloc.free(msg);
+                    try app.writeDomainNotice(.{ .topic = "settings", .tone = .neutral, .body = msg }, true);
+                },
+            }
+        }
+
         fn writeSettingsUsage(app: *App) !void {
             try app.writeDomainNotice(.{
                 .topic = "settings",
                 .tone = .@"error",
-                .body = "usage: /settings [startup-scrollback [on|off]]",
+                .body = "usage: /settings [fullscreen|startup-scrollback [on|off]]",
             }, true);
         }
 
@@ -2069,6 +2130,31 @@ test "session_commands handleSettings toggles and persists startup scrollback" {
     try std.testing.expectEqual(false, disabled.startup_scrollback.?);
 }
 
+test "session_commands fullscreen setting persists the next-launch preference" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io_mod.getIo(), "home");
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+    const home_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home_root);
+    const workspace_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(workspace_root);
+
+    const home = try SessionCommandTestHome.install(alloc, home_root);
+    defer home.deinit();
+    var app = try FakeApp.init(alloc, workspace_root, "anthropic/test-model");
+    defer app.deinit();
+
+    try Commands(FakeApp).handleSettings(&app, "fullscreen off");
+    try expectTranscriptContains(&app, "fullscreen: off (applies on next launch)");
+
+    var settings = try config_runtime.loadMergedSettings(alloc, workspace_root);
+    defer settings.deinit(alloc);
+    try std.testing.expectEqual(false, settings.fullscreen.?);
+}
+
 test "session_commands startup scrollback ignores project profile-only shadowing" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -2173,11 +2259,11 @@ test "session_commands handleSettings reports usage and save failures" {
     defer app.deinit();
 
     try Commands(FakeApp).handleSettings(&app, "bogus");
-    try expectTranscriptContains(&app, "usage: /settings [startup-scrollback [on|off]]");
+    try expectTranscriptContains(&app, "usage: /settings [fullscreen|startup-scrollback [on|off]]");
 
     app.clearTranscript();
     try Commands(FakeApp).handleSettings(&app, "startup-scrollback off extra");
-    try expectTranscriptContains(&app, "usage: /settings [startup-scrollback [on|off]]");
+    try expectTranscriptContains(&app, "usage: /settings [fullscreen|startup-scrollback [on|off]]");
 
     app.clearTranscript();
     try Commands(FakeApp).handleSettings(&app, "startup-scrollback off");

--- a/src/main.zig
+++ b/src/main.zig
@@ -535,6 +535,7 @@ const App = struct {
     context_enabled: bool = true,
     context_limits: config_runtime.context_limits.Values = .{},
     fast_mode: bool = false,
+    fullscreen_enabled: bool = true,
     auto_upgrade_enabled: bool = true,
     effort: ReasoningEffort = .auto,
     diff_entries: std.ArrayList(@import("core/output/diff.zig").DiffEntry) = .empty,

--- a/src/ui/footer/settings_menu_presentation.zig
+++ b/src/ui/footer/settings_menu_presentation.zig
@@ -369,6 +369,7 @@ const test_snapshot: settings_catalog.Snapshot = .{
     .statusline_sandbox = false,
     .statusline_context = true,
     .statusline_session = false,
+    .fullscreen = true,
     .startup_scrollback = true,
     .prompt_history = true,
     .sound_level = "on",
@@ -382,7 +383,7 @@ test "settings menu renders each setting on one row at wide and narrow widths" {
         .snapshot = test_snapshot,
     };
     const wide_rows = menuRowCount(projection, 100, 40);
-    try std.testing.expectEqual(@as(u16, 23), wide_rows);
+    try std.testing.expectEqual(@as(u16, 24), wide_rows);
 
     var header = try composeSettingsMenuRow(alloc, projection, 0, 100, wide_rows);
     defer header.deinit(alloc);
@@ -407,11 +408,28 @@ test "settings menu renders each setting on one row at wide and narrow widths" {
     try std.testing.expect(std.mem.find(u8, compact_item.items, "tint") != null);
 
     const narrow_rows = menuRowCount(projection, 24, 40);
-    try std.testing.expectEqual(@as(u16, 23), narrow_rows);
+    try std.testing.expectEqual(@as(u16, 24), narrow_rows);
     var narrow_item = try composeSettingsMenuRow(alloc, projection, 3, 24, narrow_rows);
     defer narrow_item.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow_item.items, "Input appeara") != null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(narrow_item.items) <= 24);
+}
+
+test "fullscreen preference occupies one settings menu row" {
+    const alloc = std.testing.allocator;
+    const projection: render_input.SettingsMenuProjection = .{
+        .active = true,
+        .snapshot = test_snapshot,
+    };
+    const rows = menuRowCount(projection, 100, 40);
+    try std.testing.expectEqual(@as(u16, 24), rows);
+    var found = false;
+    for (0..rows) |row| {
+        var rendered = try composeSettingsMenuRow(alloc, projection, @intCast(row), 100, rows);
+        defer rendered.deinit(alloc);
+        found = found or std.mem.find(u8, rendered.items, "Fullscreen") != null;
+    }
+    try std.testing.expect(found);
 }
 
 test "settings menu values form a centered left aligned block" {
@@ -424,7 +442,7 @@ test "settings menu values form a centered left aligned block" {
 
     var short = try composeSettingsMenuRow(alloc, projection, 3, 100, rows);
     defer short.deinit(alloc);
-    var long = try composeSettingsMenuRow(alloc, projection, 11, 100, rows);
+    var long = try composeSettingsMenuRow(alloc, projection, 12, 100, rows);
     defer long.deinit(alloc);
 
     const short_start = std.mem.find(u8, short.items, "lines").?;

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -492,6 +492,7 @@ export class TmuxSession {
     );
     const defaultArgs = [
       ["FX_DISABLE_KEYCHAIN", "1"],
+      ["FX_FULLSCREEN", "0"],
       ["FX_SKIP_ONBOARDING", "1"],
       ["FX_SOUND", "0"],
     ].flatMap(([key, value]) =>

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -1162,6 +1162,66 @@ async function runStress(config: StressConfig): Promise<StressRoot> {
 }
 
 test.skipIf(!tmuxAvailable())(
+  "fullscreen owns transcript scrollback from startup",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-fullscreen-owned-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const stderrPath = join(root, "stderr.log");
+    const tapePath = join(root, "fullscreen.fxtape");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(workspace, { recursive: true });
+
+    const lines = Array.from(
+      { length: 80 },
+      (_, index) => `OWNED_SCROLLBACK_${pad(index, 3)}`,
+    ).join("\n");
+    const gateway = startFakeGateway([fakeGatewayFinalText(lines)]);
+    let session: TmuxSession | null = null;
+    try {
+      session = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: workspace,
+        env: {
+          ...gatewayEnv(home, gateway),
+          FX_FULLSCREEN: undefined,
+          FX_RECORD: tapePath,
+        },
+        stderrPath,
+        width: 88,
+        height: 24,
+      });
+      await session.waitForText(REVIEW_FOOTER, TIMEOUT);
+      await session.sendText("Write the owned scrollback fixture.");
+      await session.waitForText("OWNED_SCROLLBACK_079", TIMEOUT);
+
+      await session.sendHexBytes(PAGE_UP);
+      await session.waitForText("OWNED_SCROLLBACK_050", TIMEOUT);
+      const viewport = await session.capturePane();
+      expect(viewport).toContain("OWNED_SCROLLBACK_050");
+      expect(viewport).not.toContain("OWNED_SCROLLBACK_079");
+
+      await session.sendHexBytes(CTRL_O);
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+      const alternate = alternateScreenStats(readFileSync(tapePath));
+      expect(alternate.enters).toBe(1);
+      expect(alternate.leaves).toBe(1);
+      expect(alternate.maximumDepth).toBe(1);
+      expect(alternate.depth).toBe(0);
+    } finally {
+      if (session) await session.kill();
+      gateway.stop();
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+  60_000,
+);
+
+test.skipIf(!tmuxAvailable())(
   "Ctrl-O repeatedly survives mixed long chats, dense tool batches, live output, resize storms, and resume",
   async () => {
     await runStress({


### PR DESCRIPTION
## Summary

- start interactive fx in the existing full-transcript alternate-screen owner by default
- preserve app-owned scroll position and follow state while docking the composer and status area
- yield alternate-buffer ownership to approvals, questions, menus, subagents, and terminal takeovers, then resume fullscreen safely
- retain inline mode through Ctrl+O, Escape, the fullscreen profile preference, and FX_FULLSCREEN
- cover startup scrolling and clean terminal teardown through the built binary in tmux

## Local validation

- `mise exec zig@0.16.0 -- zig fmt --check src/`
- focused Zig tests matching `fullscreen`
- `mise exec zig@0.16.0 -- zig build`
- `bun test tui-full-transcript-brutal.test.ts -t "fullscreen owns transcript scrollback from startup"`
- exercised `./zig-out/bin/fx` through prompt, Page Up, Ctrl+O, and quit with empty stderr