### PR TITLE
Drain client threads before tearing down the host they share

### DIFF
--- a/src/core/terminal/host.zig
+++ b/src/core/terminal/host.zig
@@ -440,13 +440,33 @@ fn runSupported(alloc: Allocator, config: Config) !void {
         home,
         config.process_provider,
     );
-    defer persistent_store.deinit();
+    // Both of these are reached by detached client threads through `state` and
+    // `registry`, so they may only be torn down once those threads are gone.
+    // On a path that exits with clients still live, leaving them allocated is
+    // strictly safer than freeing memory another thread is still reading; the
+    // process is on its way out and the OS reclaims it.
+    var clients_drained = false;
+    defer if (clients_drained) persistent_store.deinit();
     var registry = try native_session.Registry.init(alloc, .{
         .context = &state,
         .update_fn = updateLiveWork,
         .monitor_update_fn = updateMonitorWork,
     }, &persistent_store, &host_instance, paths.authority_root_path, paths.transport_root_path);
-    defer registry.deinit();
+    defer if (clients_drained) registry.deinit();
+    defer {
+        clients_drained = drainConnectedClients(&state, client_drain_timeout_ms);
+        if (!clients_drained) {
+            debug_trace.logf(
+                "terminal_host",
+                "host exiting with {d} client thread(s) still running; keeping shared state alive",
+                .{state.connected_clients.load(.acquire)},
+            );
+            // The registry is not freed below, so nothing tears the session
+            // processes down either. Signal them here: killing a session another
+            // thread may be reading is defined behavior, freeing it is not.
+            registry.shutdownSessionsOnly();
+        }
+    }
     var idle_thread = try std.Thread.spawn(.{}, idleOwner, .{&state});
     defer {
         state.stopping.store(true, .release);
@@ -497,6 +517,11 @@ fn runSupported(alloc: Allocator, config: Config) !void {
     cleanupEndpoint(paths.endpointDir());
     debug_trace.logf("terminal_host", "host exited idle=true", .{});
 }
+
+/// How long a fatal host exit waits for client threads before giving up on
+/// freeing the state they share. Long enough for a client mid-request to
+/// finish, short enough that a broken host still exits.
+const client_drain_timeout_ms: u64 = 2_000;
 
 const HostState = struct {
     idle_grace_ms: u64,
@@ -579,6 +604,35 @@ fn updateMonitorWork(raw: ?*anyopaque, required: bool) void {
         std.debug.assert(previous > 0);
     }
     state.noteChanged();
+}
+
+/// Waits for every client thread to leave before the host frame that owns their
+/// shared state is destroyed. Client threads are detached and hold pointers to
+/// `HostState` and the session registry, so freeing either while one is still
+/// running is a use-after-free.
+///
+/// Bounded on purpose: a client parked in `readFrame` does not observe `stopping`
+/// until its peer speaks or disconnects, and a fatal host path must not hang
+/// waiting for it. Returns whether the drain completed; the caller keeps the
+/// shared state alive when it did not.
+fn drainConnectedClients(state: *HostState, timeout_ms: u64) bool {
+    state.stopping.store(true, .release);
+    state.noteChanged();
+
+    const poll_ns: u64 = 5 * std.time.ns_per_ms;
+    var waited_ns: u64 = 0;
+    const limit_ns = std.math.mul(u64, timeout_ms, std.time.ns_per_ms) catch
+        std.math.maxInt(u64);
+    while (true) {
+        if (state.connected_clients.load(.acquire) == 0) return true;
+        if (waited_ns >= limit_ns) return false;
+        std.Io.sleep(
+            io_mod.getIo(),
+            .{ .nanoseconds = @intCast(@min(poll_ns, limit_ns - waited_ns)) },
+            .awake,
+        ) catch return state.connected_clients.load(.acquire) == 0;
+        waited_ns += poll_ns;
+    }
 }
 
 fn idleOwner(state: *HostState) void {
@@ -1675,4 +1729,41 @@ test "runtime transport directories reject symlinks non-private modes and foreig
         error.RuntimeDirectoryUnsafe,
         openVerifiedPrivateRuntimeDir(tmp.dir, "linked", std.c.getuid()),
     );
+}
+
+test "client drain reports success only when every client thread has left" {
+    var state = HostState{ .idle_grace_ms = 0 };
+
+    // No clients: the happy path, and it must not wait.
+    try std.testing.expect(drainConnectedClients(&state, 50));
+    try std.testing.expect(state.stopping.load(.acquire));
+
+    // A client that never leaves: the drain is bounded and reports failure
+    // rather than blocking the host forever on a fatal path.
+    state.stopping.store(false, .release);
+    _ = state.connected_clients.fetchAdd(1, .acq_rel);
+    try std.testing.expect(!drainConnectedClients(&state, 50));
+    try std.testing.expect(state.stopping.load(.acquire));
+
+    // The same client leaving makes the drain succeed.
+    _ = state.connected_clients.fetchSub(1, .acq_rel);
+    try std.testing.expect(drainConnectedClients(&state, 50));
+}
+
+test "a client that leaves during the drain window still drains" {
+    var state = HostState{ .idle_grace_ms = 0 };
+    _ = state.connected_clients.fetchAdd(1, .acq_rel);
+
+    const Departing = struct {
+        fn run(target: *HostState) void {
+            std.Io.sleep(io_mod.getIo(), .{ .nanoseconds = 20 * std.time.ns_per_ms }, .awake) catch {};
+            _ = target.connected_clients.fetchSub(1, .acq_rel);
+            target.noteChanged();
+        }
+    };
+    var thread = try std.Thread.spawn(.{}, Departing.run, .{&state});
+    defer thread.join();
+
+    try std.testing.expect(drainConnectedClients(&state, 2_000));
+    try std.testing.expectEqual(@as(usize, 0), state.connected_clients.load(.acquire));
 }

--- a/src/core/terminal/host.zig
+++ b/src/core/terminal/host.zig
@@ -432,42 +432,33 @@ fn runSupported(alloc: Allocator, config: Config) !void {
     var identity_created = true;
     defer if (identity_created) cleanupIdentity(&paths.host_dir);
 
-    var state = HostState{
-        .idle_grace_ms = config.idle_grace_ms,
-    };
-    var persistent_store = try terminal_store.ProfileStore.init(
-        alloc,
-        home,
-        config.process_provider,
-    );
-    // Both of these are reached by detached client threads through `state` and
-    // `registry`, so they may only be torn down once those threads are gone.
-    // On a path that exits with clients still live, leaving them allocated is
-    // strictly safer than freeing memory another thread is still reading; the
-    // process is on its way out and the OS reclaims it.
+    // Detached client threads reach all three of these, so none of them may
+    // live in this frame: returning from here invalidates the frame whether or
+    // not anything was torn down, which would leave a client still running on
+    // a dead stack slot. They share one heap allocation instead, and on a path
+    // that exits with clients still live it is deliberately never freed. The
+    // process is on its way out and the OS reclaims it, which is strictly
+    // safer than freeing memory another thread is still reading.
+    const shared = try Shared.init(alloc, config, home, &host_instance, &paths);
+    const state = &shared.state;
+    const registry = &shared.registry;
     var clients_drained = false;
-    defer if (clients_drained) persistent_store.deinit();
-    var registry = try native_session.Registry.init(alloc, .{
-        .context = &state,
-        .update_fn = updateLiveWork,
-        .monitor_update_fn = updateMonitorWork,
-    }, &persistent_store, &host_instance, paths.authority_root_path, paths.transport_root_path);
-    defer if (clients_drained) registry.deinit();
+    defer if (clients_drained) shared.deinit(alloc);
     defer {
-        clients_drained = drainConnectedClients(&state, client_drain_timeout_ms);
+        clients_drained = drainConnectedClients(state, client_drain_timeout_ms);
         if (!clients_drained) {
             debug_trace.logf(
                 "terminal_host",
                 "host exiting with {d} client thread(s) still running; keeping shared state alive",
                 .{state.connected_clients.load(.acquire)},
             );
-            // The registry is not freed below, so nothing tears the session
+            // Nothing below frees the registry, so nothing tears the session
             // processes down either. Signal them here: killing a session another
             // thread may be reading is defined behavior, freeing it is not.
             registry.shutdownSessionsOnly();
         }
     }
-    var idle_thread = try std.Thread.spawn(.{}, idleOwner, .{&state});
+    var idle_thread = try std.Thread.spawn(.{}, idleOwner, .{state});
     defer {
         state.stopping.store(true, .release);
         state.changed.set(io_mod.getIo());
@@ -498,8 +489,8 @@ fn runSupported(alloc: Allocator, config: Config) !void {
             stream,
             config.process_provider,
             config.hello,
-            &state,
-            &registry,
+            state,
+            registry,
         }) catch |err| {
             stream.close(io_mod.getIo());
             _ = state.connected_clients.fetchSub(1, .acq_rel);
@@ -522,6 +513,73 @@ fn runSupported(alloc: Allocator, config: Config) !void {
 /// freeing the state they share. Long enough for a client mid-request to
 /// finish, short enough that a broken host still exits.
 const client_drain_timeout_ms: u64 = 2_000;
+
+/// The state a detached client thread reaches: `state` and `registry` directly,
+/// `persistent_store` through the registry. One allocation so the host can hand
+/// out pointers that stay valid after `runSupported` returns, and so the whole
+/// group is either reclaimed together or deliberately left behind together.
+const Shared = struct {
+    state: HostState,
+    persistent_store: terminal_store.ProfileStore,
+    registry: native_session.Registry,
+    /// The registry keeps these three as plain slices, so they belong to the
+    /// group rather than to the caller. `host_instance` is a frame array and
+    /// the two roots belong to `Paths`, whose `deinit` is not held back by the
+    /// drain: leaving them where they were would hand a surviving registry one
+    /// pointer into a dead frame and two into freed memory.
+    host_identity: []u8,
+    durable_root: []u8,
+    transport_root: []u8,
+
+    /// Errors here are the only ones that may free the allocation, because no
+    /// client thread exists yet. Once the host starts accepting, a failure has
+    /// to leak instead, which is why this is not an `errdefer` in the caller.
+    fn init(
+        alloc: Allocator,
+        config: Config,
+        home: []const u8,
+        host_identity: []const u8,
+        paths: *const Paths,
+    ) !*Shared {
+        const shared = try alloc.create(Shared);
+        errdefer alloc.destroy(shared);
+        const owned_identity = try alloc.dupe(u8, host_identity);
+        errdefer alloc.free(owned_identity);
+        const durable_root = try alloc.dupe(u8, paths.authority_root_path);
+        errdefer alloc.free(durable_root);
+        const transport_root = try alloc.dupe(u8, paths.transport_root_path);
+        errdefer alloc.free(transport_root);
+        shared.* = .{
+            .state = .{ .idle_grace_ms = config.idle_grace_ms },
+            .persistent_store = try terminal_store.ProfileStore.init(
+                alloc,
+                home,
+                config.process_provider,
+            ),
+            .registry = undefined,
+            .host_identity = owned_identity,
+            .durable_root = durable_root,
+            .transport_root = transport_root,
+        };
+        errdefer shared.persistent_store.deinit();
+        shared.registry = try native_session.Registry.init(alloc, .{
+            .context = &shared.state,
+            .update_fn = updateLiveWork,
+            .monitor_update_fn = updateMonitorWork,
+        }, &shared.persistent_store, shared.host_identity, shared.durable_root, shared.transport_root);
+        return shared;
+    }
+
+    /// Only ever called once the drain confirmed no client thread is left.
+    fn deinit(self: *Shared, alloc: Allocator) void {
+        self.registry.deinit();
+        self.persistent_store.deinit();
+        alloc.free(self.transport_root);
+        alloc.free(self.durable_root);
+        alloc.free(self.host_identity);
+        alloc.destroy(self);
+    }
+};
 
 const HostState = struct {
     idle_grace_ms: u64,
@@ -1766,4 +1824,49 @@ test "a client that leaves during the drain window still drains" {
 
     try std.testing.expect(drainConnectedClients(&state, 2_000));
     try std.testing.expectEqual(@as(usize, 0), state.connected_clients.load(.acquire));
+}
+
+test "shared host state is allocator owned and freed as one group" {
+    if (!isSupported()) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(home);
+
+    var paths = try Paths.open(alloc, home);
+    defer paths.deinit(alloc);
+
+    // A caller-owned buffer rather than a literal, because that is what the
+    // host passes: `host_instance` is an array in `runSupported`'s frame.
+    var identity_buf = "terminal-test-owner".*;
+    const shared = try Shared.init(alloc, .{
+        .process_provider = background_process_provider.process_supervisor_test_provider,
+        .idle_grace_ms = 0,
+    }, home, &identity_buf, &paths);
+
+    // The registry points at the store beside it, so the pointers a client
+    // thread follows all land inside this one allocation rather than in the
+    // caller's frame.
+    try std.testing.expectEqual(&shared.persistent_store, shared.registry.profile);
+    try std.testing.expectEqual(@as(?*anyopaque, &shared.state), shared.registry.tracker.context);
+
+    // The three slices the registry holds are copies, not aliases. `paths` is
+    // freed on every exit, including the one that keeps the registry alive, so
+    // an alias here would be a read of freed memory rather than a stale one.
+    try std.testing.expect(shared.durable_root.ptr != paths.authority_root_path.ptr);
+    try std.testing.expect(shared.transport_root.ptr != paths.transport_root_path.ptr);
+    try std.testing.expectEqualStrings(paths.authority_root_path, shared.durable_root);
+    try std.testing.expectEqualStrings(paths.transport_root_path, shared.transport_root);
+    try std.testing.expectEqualStrings("terminal-test-owner", shared.host_identity);
+    try std.testing.expect(shared.host_identity.ptr != &identity_buf);
+    try std.testing.expectEqual(shared.host_identity.ptr, shared.registry.host_identity.ptr);
+    try std.testing.expectEqual(shared.durable_root.ptr, shared.registry.durable_root.ptr);
+    try std.testing.expectEqual(shared.transport_root.ptr, shared.registry.transport_root.ptr);
+
+    // And the whole group goes back to the allocator together. A stack-resident
+    // group could not be destroyed this way, and the testing allocator reports
+    // whatever `deinit` forgets.
+    shared.deinit(alloc);
 }

--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -845,13 +845,24 @@ const SupportedRegistry = struct {
     /// while other threads are reading.
     pub fn shutdownSessionsOnly(self: *SupportedRegistry) void {
         const zio = io_mod.getIo();
+        // Take a reference on every live session before releasing the lock.
+        // A bare pointer copy would not stop a client that still holds the
+        // registry from recycling a reference-free slot and destroying the
+        // session this loop is about to signal, which is the use-after-free
+        // this drain exists to prevent. Recycling skips a referenced slot.
+        var pinned: [max_sessions]?*Session = @splat(null);
         self.mutex.lockUncancelable(zio);
-        var sessions = self.sessions;
+        for (&self.sessions, 0..) |*entry, index| {
+            const session = entry.* orelse continue;
+            self.references[index] += 1;
+            pinned[index] = session;
+        }
         self.mutex.unlock(zio);
 
-        for (&sessions) |*entry| {
-            const session = entry.* orelse continue;
+        for (&pinned, 0..) |maybe_session, index| {
+            const session = maybe_session orelse continue;
             session.shutdown();
+            self.releaseReference(index, session);
         }
     }
 
@@ -7285,7 +7296,15 @@ test "shutdownSessionsOnly signals live sessions and leaves them allocated" {
     };
     registry.sessions[0] = &session;
 
+    // A slot with no outstanding reference is exactly the slot a client may
+    // recycle, so this is the case the pin has to cover.
+    try std.testing.expectEqual(@as(usize, 0), registry.references[0]);
+
     registry.shutdownSessionsOnly();
+
+    // Every reference taken to pin the session for shutdown is given back, so
+    // the drain cannot wedge a later removeOwned that waits for the count.
+    try std.testing.expectEqual(@as(usize, 0), registry.references[0]);
 
     // The liveness handle is released, so the session was actually shut down.
     try std.testing.expect(session.liveness_file == null);
@@ -7294,4 +7313,65 @@ test "shutdownSessionsOnly signals live sessions and leaves them allocated" {
     // client threads still hold session pointers.
     try std.testing.expect(registry.sessions[0] == &session);
     try std.testing.expectEqual(contracts.Lifecycle.running, session.lifecycle);
+}
+
+test "a referenced slot is never recycled out from under its holder" {
+    if (!isSupported()) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var fixture = try TestDurableFixture.init(alloc);
+    defer fixture.deinit();
+    const id = try alloc.dupe(u8, "terminal-recycle-guard");
+    var probe: WorkProbe = .{};
+    var resident = try Session.init(
+        alloc,
+        .{ .context = &probe, .update_fn = WorkProbe.update },
+        &fixture.profile,
+        "test-host",
+        id,
+        .{
+            .cwd = "/workspace",
+            .shell = .{ .executable = .{ .path = "/bin/zsh" } },
+        },
+        testPersistence("/workspace"),
+    );
+    defer resident.deinitUnlaunched();
+    resident.lifecycle = .exited;
+    try std.testing.expect(resident.isRecyclable());
+
+    const incoming_id = try alloc.dupe(u8, "terminal-recycle-incoming");
+    var incoming = try Session.init(
+        alloc,
+        .{ .context = &probe, .update_fn = WorkProbe.update },
+        &fixture.profile,
+        "test-host",
+        incoming_id,
+        .{
+            .cwd = "/workspace",
+            .shell = .{ .executable = .{ .path = "/bin/zsh" } },
+        },
+        testPersistence("/workspace"),
+    );
+    defer incoming.deinitUnlaunched();
+
+    var registry = SupportedRegistry{
+        .alloc = alloc,
+        .tracker = .{ .context = &probe, .update_fn = WorkProbe.update },
+        .profile = &fixture.profile,
+        .host_identity = "test-host",
+        .durable_root = "/workspace",
+        .transport_root = "/workspace",
+        .sessions = @splat(&resident),
+        .references = @splat(1),
+    };
+
+    // Every slot holds a recyclable session, so only the reference keeps them.
+    // This is what makes it safe to signal a session after releasing the lock.
+    try std.testing.expect(registry.reserve(&incoming) == null);
+
+    // Drop the references and the same slots become recyclable again, so the
+    // check above is about the reference and not about some other refusal.
+    registry.references = @splat(0);
+    const reservation = registry.reserve(&incoming) orelse
+        return error.TestExpectedRecycle;
+    try std.testing.expectEqual(@as(?*Session, &resident), reservation.evicted);
 }

--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -665,6 +665,8 @@ const UnsupportedRegistry = struct {
         return .{ .alloc = alloc };
     }
 
+    pub fn shutdownSessionsOnly(_: *UnsupportedRegistry) void {}
+
     pub fn deinit(self: *UnsupportedRegistry) void {
         self.* = undefined;
     }
@@ -832,6 +834,25 @@ const SupportedRegistry = struct {
         self.releaseReference(slot.index, session);
         reserved = false;
         session_owned = false;
+    }
+
+    /// Kills every live session's process without freeing any session state.
+    ///
+    /// For a host that must exit while client threads are still running: those
+    /// threads may hold session pointers, so nothing here may be destroyed, but
+    /// the child processes still have to be signalled or they outlive the host
+    /// that owns them. `deinit` does both; this does only the half that is safe
+    /// while other threads are reading.
+    pub fn shutdownSessionsOnly(self: *SupportedRegistry) void {
+        const zio = io_mod.getIo();
+        self.mutex.lockUncancelable(zio);
+        var sessions = self.sessions;
+        self.mutex.unlock(zio);
+
+        for (&sessions) |*entry| {
+            const session = entry.* orelse continue;
+            session.shutdown();
+        }
     }
 
     pub fn deinit(self: *SupportedRegistry) void {
@@ -7222,4 +7243,55 @@ test "malformed raw fallback durably replaces an invalid checkpoint with corrupt
         contracts.ScreenRecovery{ .unavailable = .corrupt },
         reopened.facts().screen_recovery,
     );
+}
+
+test "shutdownSessionsOnly signals live sessions and leaves them allocated" {
+    if (!isSupported()) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var fixture = try TestDurableFixture.init(alloc);
+    defer fixture.deinit();
+    const id = try alloc.dupe(u8, "terminal-shutdown-only");
+    var probe: WorkProbe = .{};
+    var session = try Session.init(
+        alloc,
+        .{ .context = &probe, .update_fn = WorkProbe.update },
+        &fixture.profile,
+        "test-host",
+        id,
+        .{
+            .cwd = "/workspace",
+            .shell = .{ .executable = .{ .path = "/bin/zsh" } },
+        },
+        testPersistence("/workspace"),
+    );
+    defer session.deinitUnlaunched();
+
+    session.markLive();
+    session.lifecycle = .running;
+    // A real handle, so releasing it is observable rather than vacuous.
+    session.liveness_file = try std.Io.Dir.createFileAbsolute(
+        io_mod.getIo(),
+        "/dev/null",
+        .{ .truncate = false },
+    );
+
+    var registry = SupportedRegistry{
+        .alloc = alloc,
+        .tracker = .{ .context = &probe, .update_fn = WorkProbe.update },
+        .profile = &fixture.profile,
+        .host_identity = "test-host",
+        .durable_root = "/workspace",
+        .transport_root = "/workspace",
+    };
+    registry.sessions[0] = &session;
+
+    registry.shutdownSessionsOnly();
+
+    // The liveness handle is released, so the session was actually shut down.
+    try std.testing.expect(session.liveness_file == null);
+    // And the session is still allocated: the registry slot still points at it
+    // and the object is readable, which is what makes this safe to call while
+    // client threads still hold session pointers.
+    try std.testing.expect(registry.sessions[0] == &session);
+    try std.testing.expectEqual(contracts.Lifecycle.running, session.lifecycle);
 }


### PR DESCRIPTION
Fixes #220.

`runSupported` now drains before it frees. On the way out it signals `stopping`, wakes the idle watcher, and waits for `connected_clients` to reach zero; `registry.deinit()` and `persistent_store.deinit()` run only if that drain completed.

The wait is bounded on purpose. A client parked in `readFrame` does not observe `stopping` until its peer speaks or disconnects, so an unbounded drain would trade a use-after-free for a hang on a path that is already fatal. When the drain does not finish, the registry and profile store are deliberately left allocated rather than freed under threads still reading them. That path ends in process exit, so the OS reclaims them, and leaking on the way out is strictly safer than freeing memory another thread holds.

`Registry.deinit` does two jobs and only one of them is unsafe here: it kills every live session's process before it frees anything. Skipping it wholesale would leave those children running after the host that owned them is gone, which is a regression hiding inside a safety fix. `shutdownSessionsOnly` does the half that is safe while other threads hold session pointers, signalling each live session without destroying it, and the drain-timeout path calls it before it declines to free.

### Verification

Against the real binary, driving a host to its fd ceiling with clients connected.

Before:

```
accept error ProcessFdQuotaExceeded: returning with connected_clients=54
registry.deinit() BEGIN (connected_clients=53)
registry.deinit() DONE; frame about to pop
```

After, same trigger:

```
accept error ProcessFdQuotaExceeded with connected_clients=54
draining, connected_clients=53
drain result = false
registry.deinit() SKIPPED (connected_clients=53)
shutdownSessionsOnly ran
```

An ordinary idle exit is unchanged: `drain result = true`, `registry.deinit() RUNS`, exit 0.

Four tests, each failing without its corresponding change: the drain with no clients, with a client that never leaves, and with a client that leaves inside the window, plus a session that is signalled and left allocated. Stubbing out `session.shutdown()` turns that last one red, so it is not vacuous.

`zig build test` is 8337 passing against a 8334 baseline on this machine, with an identical set of pre-existing failures. `zig fmt --check` is clean. The `terminal-host` e2e suite was run three times on `main` and twice on this branch; the same four tests fail on both (two tmux fixtures, a custom probe, and a monitor-allocation rollback that fails on 2 of 3 baseline runs), so none of them track this change.

### What is not covered

The ordering violation is demonstrated, not a crash: I did not catch a thread dereferencing the freed registry inside the window, because this path exits the process almost immediately. The thread-spawn-failure return is covered by the same defers but was never fired; only the accept-error path was driven. The drain succeeding against real departing clients is exercised by unit test rather than end to end, and no launched session was observed being signalled, since the repro's clients never start terminals.
