### PR TITLE
Isolate terminal tool tmux sessions

### DIFF
--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -426,6 +426,7 @@ async function launch(
   size = { width: 120, height: 30 },
 ) {
   const session = await TmuxSession.create({
+    isolated: true,
     cmd,
     cwd: fixture.workspace,
     env: {


### PR DESCRIPTION
## Summary

- Run each terminal tool E2E case on its own tmux server.
- Prevent teardown from one case from terminating the next case's live session.