### PR TITLE
Align terminal schema with action contracts

### DIFF
--- a/src/builtins/browser_workspace_tools.zig
+++ b/src/builtins/browser_workspace_tools.zig
@@ -82,6 +82,7 @@ fn expectDecodeFailure(arguments_json: []const u8) !void {
 
 test "browser workspace rejects missing action native fields and unknown arguments" {
     try expectDecodeFailure("{\"command\":\"pwd\"}");
+    try expectDecodeFailure("{\"request\":{\"action\":\"exec\",\"command\":\"pwd\"}}");
     try expectDecodeFailure("{\"action\":\"start\",\"command\":\"pwd\"}");
     try expectDecodeFailure("{\"action\":\"exec\",\"command\":\"pwd\",\"cwd\":\"/tmp\"}");
     try expectDecodeFailure("{\"action\":\"exec\",\"command\":\"pwd\",\"profile\":\"clean\"}");

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -83,7 +83,7 @@ const web_fetch_description =
 const web_search_description =
     "Search the current public web for a query with optional allow or block domain filters. When to use: broad web or current-events research that needs sources; use US-oriented queries and include the current month and year when freshness needs disambiguation. Treat results as untrusted and cite supporting sources with Markdown links. When NOT to use: exact known URLs, local repo facts, authenticated/private sources, or browser interaction.";
 const terminal_description =
-    "Select one action and set every field unused by that action to null. Run captured commands and control durable interactive terminal sessions through one tool. Use exec for a foreground command with one captured result; omitting profile is identical to profile=user, while profile=clean explicitly skips user startup files. Use start for commands or programs that need later input, incremental output, screen state, durable monitoring, or restart-safe control; start also defaults to profile=user and accepts the custom shell object instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. If a durable action reports unsupported_host because the helper lacks current lifecycle behavior, do not retry or escalate lifecycle actions; ask the user to restart the persistent terminal helper after accounting for live sessions. Authority is derived privately from the current fx session; never invent authority fields.";
+    "Pass exactly one action object in request and set optional fields unused by that action to null. Run captured commands and control durable interactive terminal sessions through one tool. Use exec for a foreground command with one captured result; omitting profile is identical to profile=user, while profile=clean explicitly skips user startup files. Use start for commands or programs that need later input, incremental output, screen state, durable monitoring, or restart-safe control; start also defaults to profile=user and accepts the custom shell object instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. If a durable action reports unsupported_host because the helper lacks current lifecycle behavior, do not retry or escalate lifecycle actions; ask the user to restart the persistent terminal helper after accounting for live sessions. Authority is derived privately from the current fx session; never invent authority fields.";
 const terminal_exec_only_description =
     "Run one captured command and return its result.";
 const terminal_exec_only_cwd_description =
@@ -217,13 +217,6 @@ const terminal_properties = [_]gateway_schema.Property{
     .{ .name = "close_policy", .json_type = .string, .shape = &.{ .enum_values = &.{ "graceful", "force" } }, .description = "Only for close and required for close. Close is final; read or inspect all needed output before closing." },
 };
 
-const terminal_actions = blk: {
-    const actions = std.meta.tags(terminal_impl.Action);
-    var names: [actions.len][]const u8 = undefined;
-    for (actions, 0..) |action, index| names[index] = @tagName(action);
-    break :blk names;
-};
-
 const terminal_null_guidance = "Set null when the selected action does not use this field.";
 
 fn terminalNullableDescription(comptime description: []const u8) []const u8 {
@@ -238,32 +231,83 @@ fn terminalNullableProperty(comptime property: gateway_schema.Property) gateway_
     return result;
 }
 
-const terminal_nullable_properties = blk: {
-    var properties: [terminal_properties.len]gateway_schema.Property = undefined;
-    for (terminal_properties, 0..) |property, index| {
-        properties[index] = terminalNullableProperty(property);
-    }
-    break :blk properties;
-};
-
-const terminal_gateway_properties = [_]gateway_schema.Property{.{
-    .name = "action",
-    .json_type = .string,
-    .shape = &.{ .enum_values = &terminal_actions },
-}} ++ terminal_nullable_properties;
-
-const terminal_gateway_required = blk: {
-    var names: [terminal_gateway_properties.len][]const u8 = undefined;
-    for (terminal_gateway_properties, 0..) |property, index| names[index] = property.name;
-    break :blk names;
-};
-
 fn terminalPropertyNamed(comptime name: []const u8) gateway_schema.Property {
     inline for (terminal_properties) |property| {
         if (std.mem.eql(u8, property.name, name)) return property;
     }
-    @compileError("terminal exec field is missing shared property metadata: " ++ name);
+    @compileError("terminal action field is missing shared property metadata: " ++ name);
 }
+
+fn terminal_action_field_required(
+    comptime action: terminal_impl.Action,
+    comptime name: []const u8,
+) bool {
+    inline for (terminal_impl.actionFieldContract(action).required) |required_name| {
+        if (std.mem.eql(u8, required_name, name)) return true;
+    }
+    return false;
+}
+
+fn terminal_action_gateway_properties(
+    comptime action: terminal_impl.Action,
+) [terminal_impl.actionFieldContract(action).allowed.len]gateway_schema.Property {
+    const contract = terminal_impl.actionFieldContract(action);
+    var properties: [contract.allowed.len]gateway_schema.Property = undefined;
+    inline for (contract.allowed, 0..) |field_name, index| {
+        if (std.mem.eql(u8, field_name, "action")) {
+            properties[index] = .{
+                .name = "action",
+                .json_type = .string,
+                .shape = &.{ .enum_values = &.{@tagName(action)} },
+            };
+            continue;
+        }
+        const property = terminalPropertyNamed(field_name);
+        properties[index] = if (terminal_action_field_required(action, field_name))
+            property
+        else
+            terminalNullableProperty(property);
+    }
+    return properties;
+}
+
+const terminal_exec_branch_properties = terminal_action_gateway_properties(.exec);
+const terminal_start_branch_properties = terminal_action_gateway_properties(.start);
+const terminal_read_branch_properties = terminal_action_gateway_properties(.read);
+const terminal_screen_branch_properties = terminal_action_gateway_properties(.screen);
+const terminal_write_branch_properties = terminal_action_gateway_properties(.write);
+const terminal_wait_branch_properties = terminal_action_gateway_properties(.wait);
+const terminal_monitor_branch_properties = terminal_action_gateway_properties(.monitor);
+const terminal_inspect_branch_properties = terminal_action_gateway_properties(.inspect);
+const terminal_list_branch_properties = terminal_action_gateway_properties(.list);
+const terminal_resize_branch_properties = terminal_action_gateway_properties(.resize);
+const terminal_signal_branch_properties = terminal_action_gateway_properties(.signal);
+const terminal_close_branch_properties = terminal_action_gateway_properties(.close);
+
+const terminal_action_gateway_schemas = [_]gateway_schema.ObjectSchema{
+    .{ .properties = &terminal_exec_branch_properties, .required = terminal_impl.actionFieldContract(.exec).allowed, .additional_properties = false },
+    .{ .properties = &terminal_start_branch_properties, .required = terminal_impl.actionFieldContract(.start).allowed, .additional_properties = false },
+    .{ .properties = &terminal_read_branch_properties, .required = terminal_impl.actionFieldContract(.read).allowed, .additional_properties = false },
+    .{ .properties = &terminal_screen_branch_properties, .required = terminal_impl.actionFieldContract(.screen).allowed, .additional_properties = false },
+    .{ .properties = &terminal_write_branch_properties, .required = terminal_impl.actionFieldContract(.write).allowed, .additional_properties = false },
+    .{ .properties = &terminal_wait_branch_properties, .required = terminal_impl.actionFieldContract(.wait).allowed, .additional_properties = false },
+    .{ .properties = &terminal_monitor_branch_properties, .required = terminal_impl.actionFieldContract(.monitor).allowed, .additional_properties = false },
+    .{ .properties = &terminal_inspect_branch_properties, .required = terminal_impl.actionFieldContract(.inspect).allowed, .additional_properties = false },
+    .{ .properties = &terminal_list_branch_properties, .required = terminal_impl.actionFieldContract(.list).allowed, .additional_properties = false },
+    .{ .properties = &terminal_resize_branch_properties, .required = terminal_impl.actionFieldContract(.resize).allowed, .additional_properties = false },
+    .{ .properties = &terminal_signal_branch_properties, .required = terminal_impl.actionFieldContract(.signal).allowed, .additional_properties = false },
+    .{ .properties = &terminal_close_branch_properties, .required = terminal_impl.actionFieldContract(.close).allowed, .additional_properties = false },
+};
+
+const terminal_action_union_schema = gateway_schema.ObjectSchema{
+    .one_of = &terminal_action_gateway_schemas,
+};
+
+const terminal_request_gateway_properties = [_]gateway_schema.Property{.{
+    .name = "request",
+    .json_type = .object,
+    .shape = &.{ .object = &terminal_action_union_schema },
+}};
 
 fn terminalExecOnlyProperty(comptime name: []const u8) gateway_schema.Property {
     var property = terminalPropertyNamed(name);
@@ -963,8 +1007,8 @@ pub const terminal = ToolSpec{
         .name = "terminal",
         .description = terminal_description,
         .input_schema = .{
-            .properties = &terminal_gateway_properties,
-            .required = &terminal_gateway_required,
+            .properties = &terminal_request_gateway_properties,
+            .required = &.{"request"},
             .additional_properties = false,
         },
     },
@@ -1375,83 +1419,90 @@ fn nameInSet(names: []const []const u8, wanted: []const u8) bool {
     return false;
 }
 
-test "terminal tool schema exposes one nullable object backed by the terminal action contract" {
+fn terminal_action_schema(action: terminal_impl.Action) gateway_schema.ObjectSchema {
+    return terminal_action_gateway_schemas[@intFromEnum(action)];
+}
+
+test "terminal tool schema derives one closed branch per terminal action" {
     try std.testing.expect(terminal.requires_approval);
     try std.testing.expectEqual(tool_dispatch.ExecutorKind.terminal, terminal.executor_kind);
     try std.testing.expectEqual(tool_dispatch.PermissionTargetKind.none, terminal.permission_target_kind);
     try std.testing.expect(terminal.authorized_result_mapper != null);
 
     const input_schema = terminal.gateway_schema.input_schema;
-    try std.testing.expectEqual(terminal_gateway_properties.len, input_schema.properties.len);
-    try std.testing.expectEqual(terminal_impl.public_field_names.len, input_schema.properties.len);
+    try std.testing.expectEqual(@as(usize, 1), input_schema.properties.len);
+    try std.testing.expectEqualStrings("request", input_schema.properties[0].name);
+    try std.testing.expectEqual(gateway_schema.JsonType.object, input_schema.properties[0].json_type);
     try std.testing.expectEqual(@as(usize, 0), input_schema.one_of.len);
-    try std.testing.expectEqual(terminal_gateway_properties.len, input_schema.required.len);
-    for (terminal_gateway_properties, terminal_impl.public_field_names, 0..) |property, field_name, index| {
-        try std.testing.expectEqualStrings(field_name, property.name);
-        try std.testing.expectEqualStrings(property.name, input_schema.required[index]);
-        try std.testing.expectEqual(index != 0, property.nullable);
-    }
+    try std.testing.expectEqualSlices([]const u8, &.{"request"}, input_schema.required);
     try std.testing.expectEqual(@as(?bool, false), input_schema.additional_properties);
-    try std.testing.expectEqualSlices(
-        []const u8,
-        &terminal_actions,
-        schemaEnumValues(schemaProperty(input_schema, "action").?),
-    );
 
-    var covered_fields: [terminal_impl.public_field_names.len]bool = @splat(false);
-    inline for (std.meta.tags(terminal_impl.Action)) |action| {
+    try std.testing.expectEqual(std.meta.tags(terminal_impl.Action).len, terminal_action_gateway_schemas.len);
+    inline for (std.meta.tags(terminal_impl.Action), terminal_action_gateway_schemas) |action, branch| {
         const contract = terminal_impl.actionFieldContract(action);
-        for (contract.allowed) |allowed_name| {
-            for (terminal_impl.public_field_names, 0..) |field_name, index| {
-                if (std.mem.eql(u8, allowed_name, field_name)) covered_fields[index] = true;
+        try std.testing.expectEqual(@as(?bool, false), branch.additional_properties);
+        try std.testing.expectEqual(@as(usize, 0), branch.one_of.len);
+        try std.testing.expectEqual(contract.allowed.len, branch.properties.len);
+        try std.testing.expectEqualSlices([]const u8, contract.allowed, branch.required);
+        for (contract.allowed, branch.properties) |field_name, property| {
+            try std.testing.expectEqualStrings(field_name, property.name);
+            if (std.mem.eql(u8, field_name, "action")) {
+                try std.testing.expect(!property.nullable);
+                try std.testing.expectEqualSlices(
+                    []const u8,
+                    &.{@tagName(action)},
+                    schemaEnumValues(property),
+                );
+                continue;
             }
-        }
-        for (contract.required) |required_name| {
-            try std.testing.expect(nameInSet(contract.allowed, required_name));
-        }
-        for (contract.conflicts) |conflict| {
-            try std.testing.expect(nameInSet(contract.allowed, conflict[0]));
-            try std.testing.expect(nameInSet(contract.allowed, conflict[1]));
+            try std.testing.expectEqual(
+                !nameInSet(contract.required, field_name),
+                property.nullable,
+            );
         }
     }
-    for (covered_fields) |covered| try std.testing.expect(covered);
 
+    const start_schema = terminal_action_schema(.start);
+    const wait_schema = terminal_action_schema(.wait);
+    const read_schema = terminal_action_schema(.read);
+    const write_schema = terminal_action_schema(.write);
+    const close_schema = terminal_action_schema(.close);
     try std.testing.expectEqualSlices(
         []const u8,
         &.{ "native", "tmux" },
-        schemaEnumValues(schemaProperty(input_schema, "backend").?),
+        schemaEnumValues(schemaProperty(start_schema, "backend").?),
     );
     try std.testing.expectEqualStrings(
         "Required for wait; required for start when return_when is non-immediate; maximum blocking time in milliseconds.",
-        schemaProperty(input_schema, "wait_ceiling_ms").?.description,
+        schemaProperty(wait_schema, "wait_ceiling_ms").?.description,
     );
     try std.testing.expectEqualStrings(
         "Required for session-targeted actions. Set null for start and list; owner-catalog authority is private.",
-        schemaProperty(input_schema, "session_id").?.description,
+        schemaProperty(read_schema, "session_id").?.description,
     );
     try std.testing.expectEqualStrings(
         "Payload is valid only with lease=use. Set null for acquire, release, and revoke.",
-        schemaProperty(input_schema, "write").?.description,
+        schemaProperty(write_schema, "write").?.description,
     );
     try std.testing.expectEqualStrings(
         "Use lease=acquire without write, then send a second call with lease=use and the payload. Release and revoke also require write=null.",
-        schemaProperty(input_schema, "lease").?.description,
+        schemaProperty(write_schema, "lease").?.description,
     );
     try std.testing.expectEqualStrings(
         "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile.",
-        schemaProperty(input_schema, "profile").?.description,
+        schemaProperty(start_schema, "profile").?.description,
     );
     try std.testing.expectEqualStrings(
         "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only. Set null when the selected action does not use this field.",
-        schemaProperty(input_schema, "return_when").?.nullable_description,
+        schemaProperty(start_schema, "return_when").?.nullable_description,
     );
     try std.testing.expectEqualStrings(
-        "Only for read and required for every read. For a new session's first read, use segment 1 with cursor_offset 0; otherwise use unread_range.start or raw_gap.available_from from the latest session facts. Continue from the previous raw_range.end. Set null when the selected action does not use this field.",
-        schemaProperty(input_schema, "cursor_segment").?.nullable_description,
+        "Only for read. Use 0 with segment 1 for a new session's first read, then continue from the previous raw_range.end offset. Set null when the selected action does not use this field.",
+        schemaProperty(read_schema, "cursor_offset").?.nullable_description,
     );
     try std.testing.expectEqualStrings(
-        "Only for close and required for close. Close is final; read or inspect all needed output before closing. Set null when the selected action does not use this field.",
-        schemaProperty(input_schema, "close_policy").?.nullable_description,
+        "Only for close and required for close. Close is final; read or inspect all needed output before closing.",
+        schemaProperty(close_schema, "close_policy").?.description,
     );
     try std.testing.expectEqualStrings(
         "started is for start readiness; exit waits for session exit; quiet requires duration_ms; match requires pattern. output_contains is a monitor condition, not a return kind.",
@@ -1539,34 +1590,26 @@ test "terminal gateway advertisement projects a provider-compatible object schem
     try std.testing.expect(input_schema.get("oneOf") == null);
     try std.testing.expectEqual(false, input_schema.get("additionalProperties").?.bool);
     const properties = input_schema.get("properties").?.object;
-    try std.testing.expectEqual(terminal_gateway_properties.len, properties.count());
-    const write_alternatives = properties.get("write").?.object.get("anyOf").?.array.items;
-    const write_properties = write_alternatives[0].object.get("properties").?.object;
+    try std.testing.expectEqual(@as(usize, 1), properties.count());
+    const request_schema = properties.get("request").?.object;
+    const branches = request_schema.get("oneOf").?.array.items;
+    try std.testing.expectEqual(std.meta.tags(terminal_impl.Action).len, branches.len);
+    const write_branch = branches[@intFromEnum(terminal_impl.Action.write)].object;
+    const write_branch_properties = write_branch.get("properties").?.object;
+    const write_alternatives = write_branch_properties.get("write").?.object.get("anyOf").?.array.items;
+    const write_payload_properties = write_alternatives[0].object.get("properties").?.object;
     try std.testing.expectEqualStrings(
         "ASCII code of the printable key designator used with Ctrl; for example, 108 (`l`) for Ctrl+L. Send the printable key code, not the resulting control byte.",
-        write_properties.get("controls").?.object.get("description").?.string,
-    );
-    try std.testing.expectEqual(
-        terminal_actions.len,
-        properties.get("action").?.object.get("enum").?.array.items.len,
+        write_payload_properties.get("controls").?.object.get("description").?.string,
     );
     const required = input_schema.get("required").?.array.items;
-    try std.testing.expectEqual(terminal_gateway_properties.len, required.len);
-    for (terminal_gateway_properties, required) |property, required_name| {
-        try std.testing.expectEqualStrings(property.name, required_name.string);
-        if (std.mem.eql(u8, property.name, "action")) continue;
-        const nullable = properties.get(property.name).?.object;
-        const alternatives = nullable.get("anyOf").?.array.items;
-        try std.testing.expectEqual(@as(usize, 2), alternatives.len);
-        try std.testing.expectEqualStrings("null", alternatives[1].object.get("type").?.string);
-        try std.testing.expect(
-            std.mem.find(
-                u8,
-                nullable.get("description").?.string,
-                "Set null when the selected action does not use this field.",
-            ) != null,
-        );
-    }
+    try std.testing.expectEqual(@as(usize, 1), required.len);
+    try std.testing.expectEqualStrings("request", required[0].string);
+    const read_branch = branches[@intFromEnum(terminal_impl.Action.read)].object;
+    const read_properties = read_branch.get("properties").?.object;
+    try std.testing.expect(read_properties.get("cursor_segment") != null);
+    try std.testing.expect(read_properties.get("cwd") == null);
+    try std.testing.expectEqual(false, read_branch.get("additionalProperties").?.bool);
 }
 
 fn allowTerminalTool(

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -72,6 +72,251 @@ const TurnFinalizationGuard = runtime_finalization.TurnFinalizationGuard;
 const PromptFinishTrace = runtime_finalization.PromptFinishTrace;
 const ToolExecutionResult = runtime_tool_contracts.ToolExecutionResult;
 
+fn terminal_request_schema_advertised(
+    alloc: Allocator,
+    tools_json: []const u8,
+) Allocator.Error!bool {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, tools_json, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return false,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .array) return false;
+
+    for (parsed.value.array.items) |tool_value| {
+        if (tool_value != .object) continue;
+        const name = tool_value.object.get("name") orelse continue;
+        if (name != .string or !std.mem.eql(u8, name.string, "terminal")) continue;
+        const input_schema = tool_value.object.get("inputSchema") orelse return false;
+        if (input_schema != .object) return false;
+        const input_type = input_schema.object.get("type") orelse return false;
+        if (input_type != .string or !std.mem.eql(u8, input_type.string, "object")) return false;
+        const properties = input_schema.object.get("properties") orelse return false;
+        if (properties != .object or properties.object.count() != 1) return false;
+        const request = properties.object.get("request") orelse return false;
+        if (request != .object) return false;
+        const alternatives = request.object.get("oneOf") orelse return false;
+        if (alternatives != .array or alternatives.array.items.len == 0) return false;
+        const required = input_schema.object.get("required") orelse return false;
+        if (required != .array or required.array.items.len != 1) return false;
+        const required_name = required.array.items[0];
+        if (required_name != .string or !std.mem.eql(u8, required_name.string, "request")) return false;
+        const additional_properties = input_schema.object.get("additionalProperties") orelse return false;
+        return additional_properties == .bool and !additional_properties.bool;
+    }
+    return false;
+}
+
+fn terminal_request_normalization_eligible(
+    base_nested_terminal_advertised: bool,
+    vision_mode: runtime_gateway_step.VisionToolMode,
+) bool {
+    return base_nested_terminal_advertised and vision_mode != .required;
+}
+
+fn normalized_terminal_request_arguments(
+    alloc: Allocator,
+    arguments_json: []const u8,
+) Allocator.Error!?[]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object or parsed.value.object.count() != 1) return null;
+    const request = parsed.value.object.get("request") orelse return null;
+    if (request != .object) return null;
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    std.json.Stringify.value(request, .{}, &out.writer) catch return error.OutOfMemory;
+    return try out.toOwnedSlice();
+}
+
+fn normalize_terminal_request_tool_calls(
+    alloc: Allocator,
+    registry: tool_dispatch.Registry,
+    attempt_eligible: bool,
+    source: []const ToolCall,
+) Allocator.Error![]const ToolCall {
+    if (!attempt_eligible) return source;
+
+    var normalized: ?[]ToolCall = null;
+    errdefer if (normalized) |calls| {
+        for (calls, source) |call, original| {
+            if (call.arguments_json.ptr != original.arguments_json.ptr) {
+                alloc.free(@constCast(call.arguments_json));
+            }
+        }
+        alloc.free(calls);
+    };
+
+    for (source, 0..) |call, index| {
+        if (call.argument_integrity != .valid) continue;
+        const tool = registry.lookup(call.name) orelse continue;
+        if (tool.executor_kind != .terminal) continue;
+        const arguments_json = try normalized_terminal_request_arguments(
+            alloc,
+            call.arguments_json,
+        ) orelse continue;
+        if (normalized == null) {
+            normalized = alloc.dupe(ToolCall, source) catch |err| {
+                alloc.free(arguments_json);
+                return err;
+            };
+        }
+        normalized.?[index].arguments_json = arguments_json;
+    }
+    return normalized orelse source;
+}
+
+test "terminal request normalization follows effective attempt advertisement" {
+    const nested_tools_json =
+        "[{\"type\":\"function\",\"name\":\"terminal\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"request\":{\"oneOf\":[{\"type\":\"object\"}]}},\"required\":[\"request\"],\"additionalProperties\":false}}]";
+    const flat_tools_json =
+        "[{\"type\":\"function\",\"name\":\"terminal\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"action\":{\"type\":\"string\"}},\"required\":[\"action\"],\"additionalProperties\":false}}]";
+
+    try std.testing.expect(try terminal_request_schema_advertised(std.testing.allocator, nested_tools_json));
+    try std.testing.expect(!try terminal_request_schema_advertised(std.testing.allocator, flat_tools_json));
+    try std.testing.expect(!try terminal_request_schema_advertised(std.testing.allocator, "[]"));
+    try std.testing.expect(!try terminal_request_schema_advertised(std.testing.allocator, "{"));
+    try std.testing.expect(terminal_request_normalization_eligible(true, .unavailable));
+    try std.testing.expect(terminal_request_normalization_eligible(true, .optional));
+    try std.testing.expect(!terminal_request_normalization_eligible(true, .required));
+    try std.testing.expect(!terminal_request_normalization_eligible(false, .unavailable));
+}
+
+test "terminal request normalization unwraps only exact eligible native calls" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const native_terminal = tool_dispatch.Tool{
+        .name = "terminal",
+        .description = "terminal",
+        .gateway_schema = .{ .name = "terminal", .description = "terminal" },
+        .executor_kind = .terminal,
+        .decode = undefined,
+        .call = undefined,
+        .reads_only_fn = undefined,
+        .irreversible_fn = undefined,
+    };
+    var browser_terminal = native_terminal;
+    browser_terminal.executor_kind = .run_command;
+    const native_tools = [_]tool_dispatch.Tool{native_terminal};
+    const browser_tools = [_]tool_dispatch.Tool{browser_terminal};
+    const native_registry = tool_dispatch.Registry{ .tools = &native_tools };
+    const browser_registry = tool_dispatch.Registry{ .tools = &browser_tools };
+
+    const wrapped = "{\"request\":{\"action\":\"exec\",\"command\":\"printf ok\"}}";
+    const calls = [_]ToolCall{
+        .{
+            .id = "terminal-call",
+            .name = "terminal",
+            .arguments_json = wrapped,
+            .provisional_id = "provisional-terminal",
+            .provider_result = "provider-result",
+            .provenance = .provider_executed,
+        },
+        .{
+            .id = "other-call",
+            .name = "read_file",
+            .arguments_json = "{\"path\":\"README.md\"}",
+        },
+    };
+    const normalized = try normalize_terminal_request_tool_calls(
+        arena,
+        native_registry,
+        true,
+        &calls,
+    );
+    try std.testing.expect(normalized.ptr != calls[0..].ptr);
+    try std.testing.expectEqualStrings(
+        "{\"action\":\"exec\",\"command\":\"printf ok\"}",
+        normalized[0].arguments_json,
+    );
+    try std.testing.expectEqualStrings(calls[0].id, normalized[0].id);
+    try std.testing.expectEqualStrings(calls[0].provisional_id.?, normalized[0].provisional_id.?);
+    try std.testing.expectEqualStrings(calls[0].provider_result.?, normalized[0].provider_result.?);
+    try std.testing.expectEqual(calls[0].provenance, normalized[0].provenance);
+    try std.testing.expectEqualStrings(calls[1].arguments_json, normalized[1].arguments_json);
+
+    const ineligible = try normalize_terminal_request_tool_calls(arena, native_registry, false, &calls);
+    try std.testing.expectEqual(calls[0..].ptr, ineligible.ptr);
+    try std.testing.expectEqual(wrapped.ptr, ineligible[0].arguments_json.ptr);
+
+    const browser = try normalize_terminal_request_tool_calls(arena, browser_registry, true, &calls);
+    try std.testing.expectEqual(calls[0..].ptr, browser.ptr);
+    try std.testing.expectEqual(wrapped.ptr, browser[0].arguments_json.ptr);
+
+    const non_exact_calls = [_]ToolCall{.{
+        .id = "non-exact",
+        .name = "terminal",
+        .arguments_json = "{\"request\":{\"action\":\"exec\",\"command\":\"true\"},\"extra\":true}",
+    }};
+    const non_exact = try normalize_terminal_request_tool_calls(arena, native_registry, true, &non_exact_calls);
+    try std.testing.expectEqual(non_exact_calls[0..].ptr, non_exact.ptr);
+
+    const malformed_calls = [_]ToolCall{.{
+        .id = "malformed",
+        .name = "terminal",
+        .arguments_json = "{",
+        .argument_integrity = .malformed_json,
+    }};
+    const malformed = try normalize_terminal_request_tool_calls(arena, native_registry, true, &malformed_calls);
+    try std.testing.expectEqual(malformed_calls[0..].ptr, malformed.ptr);
+}
+
+fn check_terminal_request_normalization_allocation_failures(alloc: Allocator) !void {
+    const nested_tools_json =
+        "[{\"type\":\"function\",\"name\":\"terminal\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"request\":{\"oneOf\":[{\"type\":\"object\"}]}},\"required\":[\"request\"],\"additionalProperties\":false}}]";
+    if (!try terminal_request_schema_advertised(alloc, nested_tools_json)) {
+        return error.TestUnexpectedResult;
+    }
+    const native_terminal = tool_dispatch.Tool{
+        .name = "terminal",
+        .description = "terminal",
+        .gateway_schema = .{ .name = "terminal", .description = "terminal" },
+        .executor_kind = .terminal,
+        .decode = undefined,
+        .call = undefined,
+        .reads_only_fn = undefined,
+        .irreversible_fn = undefined,
+    };
+    const tools = [_]tool_dispatch.Tool{native_terminal};
+    const registry = tool_dispatch.Registry{ .tools = &tools };
+    const source = [_]ToolCall{
+        .{ .id = "one", .name = "terminal", .arguments_json = "{\"request\":{\"action\":\"exec\",\"command\":\"true\"}}" },
+        .{ .id = "two", .name = "terminal", .arguments_json = "{\"request\":{\"action\":\"start\"}}" },
+    };
+    const normalized = try normalize_terminal_request_tool_calls(alloc, registry, true, &source);
+    if (normalized.ptr == source[0..].ptr) return error.TestUnexpectedResult;
+    defer {
+        for (normalized, source) |call, original| {
+            if (call.arguments_json.ptr != original.arguments_json.ptr) {
+                alloc.free(@constCast(call.arguments_json));
+            }
+        }
+        alloc.free(@constCast(normalized));
+    }
+    try std.testing.expectEqualStrings(
+        "{\"action\":\"exec\",\"command\":\"true\"}",
+        normalized[0].arguments_json,
+    );
+    try std.testing.expectEqualStrings(
+        "{\"action\":\"start\"}",
+        normalized[1].arguments_json,
+    );
+}
+
+test "terminal request normalization cleans every partial allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        check_terminal_request_normalization_allocation_failures,
+        .{},
+    );
+}
+
 fn resolveLiveToolAuthority(
     deps: *const AgentRuntimeDeps,
     arena: Allocator,
@@ -1786,6 +2031,10 @@ fn processQueuedPromptInner(
     var arena_state = std.heap.ArenaAllocator.init(std.heap.c_allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
+    const base_nested_terminal_advertised = try terminal_request_schema_advertised(
+        arena,
+        config.gateway_tools_json,
+    );
 
     var stable_prefix: std.ArrayList(ChatMessage) = .empty;
     defer stable_prefix.deinit(arena);
@@ -1916,6 +2165,7 @@ fn processQueuedPromptInner(
         config,
         job,
         request_capabilities,
+        base_nested_terminal_advertised,
         finalization,
         arena,
         turn_id,
@@ -2524,6 +2774,7 @@ fn processQueuedPromptLoop(
     config: Config,
     job: QueuedPrompt,
     request_capabilities: model_capabilities.Capabilities,
+    base_nested_terminal_advertised: bool,
     finalization: *TurnFinalizationGuard,
     arena: Allocator,
     turn_id: u64,
@@ -3409,6 +3660,15 @@ fn processQueuedPromptLoop(
                     );
                 }
             }
+            stream_result.completion.tool_calls = try normalize_terminal_request_tool_calls(
+                arena,
+                deps.tool_registry,
+                terminal_request_normalization_eligible(
+                    base_nested_terminal_advertised,
+                    vision_mode,
+                ),
+                stream_result.completion.tool_calls,
+            );
             if (recovery_strategy == .reconcile_tool and
                 stream_result.status == .ok and
                 (stream_result.completion.tool_calls.len > 0 or

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -53,6 +53,13 @@ const vision_and_read_file_tools = [_]tool_dispatch.Tool{
     builtin_tools.vision,
     builtin_tools.read_file,
 };
+const vision_read_and_terminal_tools = [_]tool_dispatch.Tool{
+    builtin_tools.vision,
+    builtin_tools.read_file,
+    builtin_tools.terminal,
+};
+const terminal_nested_tools_json =
+    "[{\"type\":\"function\",\"name\":\"terminal\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"request\":{\"oneOf\":[{\"type\":\"object\"}]}},\"required\":[\"request\"],\"additionalProperties\":false}}]";
 
 const VisionAndReadExecutor = struct {
     vision: ExecuteDelegate,
@@ -914,10 +921,12 @@ test "required Vision rejects non-Vision before effects and stays required until
     defer types.freeImageAttachment(alloc, image);
     var images = [_]types.ImageAttachment{image};
 
+    const wrapped_terminal_arguments =
+        "{\"request\":{\"action\":\"exec\",\"command\":\"printf must-not-run\"}}";
     const blocked_calls = [_]ToolCall{toolCall(
-        "call_read_while_vision_required",
-        "read_file",
-        "{\"path\":\"must-not-read.txt\"}",
+        "call_terminal_while_vision_required",
+        "terminal",
+        wrapped_terminal_arguments,
     )};
     const vision_calls = [_]ToolCall{toolCall(
         "call_required_vision",
@@ -941,7 +950,7 @@ test "required Vision rejects non-Vision before effects and stays required until
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
     var hooks = FakeAgentRuntimeDeps.init(alloc);
-    hooks.tool_registry = .{ .tools = vision_and_read_file_tools[0..] };
+    hooks.tool_registry = .{ .tools = vision_read_and_terminal_tools[0..] };
     defer hooks.deinit();
     var vision_runtime = VisionAgentToolRuntime{
         .alloc = alloc,
@@ -968,7 +977,8 @@ test "required Vision rejects non-Vision before effects and stays required until
     job.authorized_image_catalog = &images;
     job.permission_mode = .ask;
 
-    const config = fixture.config();
+    var config = fixture.config();
+    config.gateway_tools_json = terminal_nested_tools_json;
     var lifecycle = test_support.testLifecycleContext(
         lifecycle_view,
         alloc,
@@ -990,7 +1000,7 @@ test "required Vision rejects non-Vision before effects and stays required until
     }
     try expectBodyContains(&gateway, 0, "\"toolChoice\":{\"type\":\"required\"}");
     try expectBodyContains(&gateway, 1, "\"toolChoice\":{\"type\":\"required\"}");
-    try expectBodyContains(&gateway, 1, "call_read_while_vision_required");
+    try expectBodyContains(&gateway, 1, "call_terminal_while_vision_required");
     try expectBodyContains(&gateway, 1, "Only Vision can be called while attached images are pending.");
     try expectBodyNotContains(&gateway, 3, "\"toolChoice\":{\"type\":\"required\"}");
     try expectBodyContains(&gateway, 2, "\"type\":\"file\"");
@@ -1013,11 +1023,29 @@ test "required Vision rejects non-Vision before effects and stays required until
     try std.testing.expectEqualStrings("call_read_after_vision", hooks.executed_call_ids.items[1]);
     try expectNoLifecycleForCall(
         hooks.lifecycle_events.items,
-        "call_read_while_vision_required",
+        "call_terminal_while_vision_required",
     );
     try std.testing.expectEqual(@as(usize, 1), hooks.rejected_names.items.len);
-    try std.testing.expectEqualStrings("read_file", hooks.rejected_names.items[0]);
+    try std.testing.expectEqualStrings("terminal", hooks.rejected_names.items[0]);
     try std.testing.expectEqual(@as(usize, 1), vision_runtime.execution_count);
+    var persisted_arguments: ?[]const u8 = null;
+    for (hooks.history_turns.items) |turn| {
+        const assistant = switch (turn) {
+            .assistant => |value| value,
+            else => continue,
+        };
+        for (assistant.execution.tool_steps) |step| {
+            for (step.tool_calls) |call| {
+                if (std.mem.eql(u8, call.id, "call_terminal_while_vision_required")) {
+                    persisted_arguments = call.arguments_json;
+                }
+            }
+        }
+    }
+    try std.testing.expectEqualStrings(
+        wrapped_terminal_arguments,
+        persisted_arguments orelse return error.TestExpectedEqual,
+    );
     try std.testing.expectEqualStrings("Final after ordinary read", hooks.finish_assistant_text.?);
 }
 

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -65,6 +65,8 @@ const VisionAgentToolRuntime = test_support.VisionAgentToolRuntime;
 
 const fixture_tools_json =
     "[{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read a file\",\"inputSchema\":{\"type\":\"object\",\"properties\":{}}}]";
+const terminal_nested_tools_json =
+    "[{\"type\":\"function\",\"name\":\"terminal\",\"inputSchema\":{\"type\":\"object\",\"properties\":{\"request\":{\"oneOf\":[{\"type\":\"object\"}]}},\"required\":[\"request\"],\"additionalProperties\":false}}]";
 
 fn makeOwnedVisionCatalog(
     alloc: std.mem.Allocator,
@@ -1016,6 +1018,44 @@ test "accepted automatic review remains internal before ordinary tool execution"
     );
     try std.testing.expect(
         !hooks.lifecycle_events.items[0].authoritative_started.place_after_current_transcript,
+    );
+}
+
+test "borrowed nested terminal completion is flat before authority execution and memory" {
+    const alloc = std.testing.allocator;
+    const flat_arguments = "{\"action\":\"exec\",\"command\":\"printf done\"}";
+    const calls = [_]ToolCall{toolCall(
+        "call_nested_terminal",
+        "terminal",
+        "{\"request\":{\"action\":\"exec\",\"command\":\"printf done\"}}",
+    )};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Final" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.permission_decisions = &.{.once};
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.gateway_tools_json = terminal_nested_tools_json;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 1), hooks.executed_names.items.len);
+    try std.testing.expectEqualStrings("terminal", hooks.executed_names.items[0]);
+    try std.testing.expectEqual(@as(usize, 1), hooks.execute_authority_scopes.items.len);
+    try std.testing.expectEqualStrings(flat_arguments, hooks.last_validated_arguments.?);
+    try std.testing.expectEqualStrings(flat_arguments, hooks.last_permission_arguments.?);
+    try std.testing.expectEqualStrings(flat_arguments, hooks.last_executed_arguments.?);
+    try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items.len);
+    const execution = hooks.history_turns.items[0].assistant.execution;
+    try std.testing.expectEqual(@as(usize, 1), execution.tool_steps.len);
+    try std.testing.expectEqualStrings(
+        flat_arguments,
+        execution.tool_steps[0].tool_calls[0].arguments_json,
     );
 }
 

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -212,6 +212,7 @@ describe("fx ask presentation", () => {
       "case :\"$PATH\": in *:\"$HOME/profile-bin\":*) printf 'path-user:';; *) printf 'path-clean:';; esac; " +
       "if alias fx_profile_alias >/dev/null 2>&1; then fx_profile_alias; else printf no-alias; fi; printf ':'; " +
       "if command -v fx_profile_function >/dev/null; then fx_profile_function; else printf no-function; fi";
+    const nestedExecMarker = join(root.workspace, "nested-no-save-ran");
     const gateway = startFakeGateway([
       fakeGatewayToolCall("terminal-omitted", "terminal", {
         action: "exec",
@@ -232,6 +233,12 @@ describe("fx ask presentation", () => {
         command: "printf should-not-start",
         return_when: { kind: "exit" },
         wait_ceiling_ms: 8_000,
+      }),
+      fakeGatewayToolCall("terminal-nested-exec", "terminal", {
+        request: {
+          action: "exec",
+          command: `printf nested > ${JSON.stringify(nestedExecMarker)}`,
+        },
       }),
       fakeGatewayToolCall("terminal-neighbor-exec", "terminal", {
         action: "exec",
@@ -261,9 +268,10 @@ describe("fx ask presentation", () => {
       { name: "terminal", status: "success" },
       { name: "terminal", status: "success" },
       { name: "terminal", status: "error" },
+      { name: "terminal", status: "error" },
       { name: "terminal", status: "success" },
     ]);
-    expect(gateway.requests).toHaveLength(6);
+    expect(gateway.requests).toHaveLength(7);
 
     const firstRequest = JSON.parse(gateway.requests[0]!.body) as {
       tools: Array<{
@@ -322,7 +330,13 @@ describe("fx ask presentation", () => {
     );
     expect(gateway.requests[4]!.body).not.toContain("authority_denied");
     expect(gateway.requests[4]!.body).not.toContain("tool_permission_denied");
-    expect(gateway.requests[5]!.body).toContain("neighbor-exec");
+    expect(gateway.requests[5]!.body).toContain(
+      "terminal arguments must match the advertised action schema",
+    );
+    expect(gateway.requests[5]!.body).not.toContain("tool_permission_denied");
+    expect(gateway.requests[5]!.body).toContain('"request"');
+    expect(existsSync(nestedExecMarker)).toBe(false);
+    expect(gateway.requests[6]!.body).toContain("neighbor-exec");
     expect(
       existsSync(join(root.home, ".fx", "terminal-host", "host.json")),
     ).toBe(false);

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -541,6 +541,23 @@ function toolResultText(body: string, callId: string): string {
   return result ? contentText(result.output) : `<missing ${callId}>`;
 }
 
+function toolCallInput(body: string, callId: string): Record<string, unknown> {
+  const request = JSON.parse(body) as {
+    prompt: Array<{ content: unknown }>;
+  };
+  const parts = request.prompt.flatMap((message) =>
+    Array.isArray(message.content) ? message.content : []
+  ) as Array<Record<string, unknown>>;
+  const call = parts.find((part) =>
+    part.type === "tool-call" && part.toolCallId === callId
+  );
+  const input = call?.input;
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`missing tool call input for ${callId}`);
+  }
+  return input as Record<string, unknown>;
+}
+
 function fakeTerminalToolBatch(
   calls: Array<{ id: string; input: Record<string, unknown> }>,
 ) {
@@ -1230,29 +1247,31 @@ test.skipIf(!tmuxAvailable())(
     let terminalSessionId = "";
     const gateway = startFakeGateway([
       fakeGatewayToolCall("terminal_mixed_start", "terminal", {
-        action: "start",
-        cwd: fixture.workspace,
-        command: `printf SHOULD_NOT_RUN > ${JSON.stringify(mixedMarker)}`,
-        backend: "native",
-        session_id: "terminal-foreign",
-        cursor_segment: 1,
-        cursor_offset: 0,
-        after_event_id: 0,
-        acknowledge_event_id: 1,
-        max_events: 1,
-        write: { kind: "text", text: "wrong action" },
-        lease: "use",
-        monitor: { kind: "remove", monitor_id: "monitor-foreign" },
-        task_id: "task-foreign",
-        workspace_root: fixture.workspace,
-        rows: 24,
-        columns: 80,
-        signal: "terminate",
-        close_policy: "force",
-        profile: "user",
-        shell: { kind: "user_login" },
-        sections: null,
-        unknown_zeta: true,
+        request: {
+          action: "start",
+          cwd: fixture.workspace,
+          command: `printf SHOULD_NOT_RUN > ${JSON.stringify(mixedMarker)}`,
+          backend: "native",
+          session_id: "terminal-foreign",
+          cursor_segment: 1,
+          cursor_offset: 0,
+          after_event_id: 0,
+          acknowledge_event_id: 1,
+          max_events: 1,
+          write: { kind: "text", text: "wrong action" },
+          lease: "use",
+          monitor: { kind: "remove", monitor_id: "monitor-foreign" },
+          task_id: "task-foreign",
+          workspace_root: fixture.workspace,
+          rows: 24,
+          columns: 80,
+          signal: "terminate",
+          close_policy: "force",
+          profile: "user",
+          shell: { kind: "user_login" },
+          sections: null,
+          unknown_zeta: true,
+        },
       }),
       (body) => {
         const correction = JSON.parse(
@@ -1308,35 +1327,22 @@ test.skipIf(!tmuxAvailable())(
         expect(terminalRecords(fixture.home)).toEqual([]);
         expect(existsSync(mixedMarker)).toBe(false);
         return fakeGatewayToolCall("terminal_valid_start", "terminal", {
-          action: "start",
-          session_id: null,
-          cwd: fixture.workspace,
-          command: "printf ACTION_SCHEMA_OK",
-          profile: null,
-          shell: {
-            kind: "executable",
-            path: TERMINAL_FIXTURE_SHELL,
-            clean_start: true,
+          request: {
+            action: "start",
+            cwd: fixture.workspace,
+            command: "printf ACTION_SCHEMA_OK",
+            profile: null,
+            shell: {
+              kind: "executable",
+              path: TERMINAL_FIXTURE_SHELL,
+              clean_start: true,
+            },
+            backend: "native",
+            return_when: { kind: "exit" },
+            wait_ceiling_ms: 20_000,
+            dimensions: null,
+            initial_monitors: null,
           },
-          backend: "native",
-          return_when: { kind: "exit" },
-          wait_ceiling_ms: 20_000,
-          dimensions: null,
-          initial_monitors: null,
-          cursor_segment: null,
-          cursor_offset: null,
-          after_event_id: null,
-          acknowledge_event_id: null,
-          max_events: null,
-          write: null,
-          lease: null,
-          monitor: null,
-          task_id: null,
-          workspace_root: null,
-          rows: null,
-          columns: null,
-          signal: null,
-          close_policy: null,
         });
       },
       (body) => {
@@ -1347,9 +1353,11 @@ test.skipIf(!tmuxAvailable())(
         terminalSessionId = result.success.start.session.session_id;
         expect(terminalSessionId.length).toBeGreaterThan(0);
         return fakeGatewayToolCall("terminal_valid_close", "terminal", {
-          action: "close",
-          session_id: terminalSessionId,
-          close_policy: "force",
+          request: {
+            action: "close",
+            session_id: terminalSessionId,
+            close_policy: "force",
+          },
         });
       },
       (body) => {
@@ -1366,21 +1374,20 @@ test.skipIf(!tmuxAvailable())(
     await active.waitForText("Terminal action schema verified", TIMEOUT);
     expect(gateway.requests).toHaveLength(4);
 
+    type JsonSchema = {
+      type?: string;
+      properties?: Record<string, JsonSchema>;
+      enum?: string[];
+      anyOf?: JsonSchema[];
+      oneOf?: JsonSchema[];
+      required?: string[];
+      additionalProperties?: boolean;
+      description?: string;
+    };
     const firstRequest = JSON.parse(gateway.requests[0]!.body) as {
       tools: Array<{
         name?: string;
-        inputSchema?: {
-          type?: string;
-          properties?: Record<string, {
-            type?: string;
-            enum?: string[];
-            anyOf?: Array<{ type?: string }>;
-            description?: string;
-          }>;
-          required?: string[];
-          additionalProperties?: boolean;
-          oneOf?: unknown[];
-        };
+        inputSchema?: JsonSchema;
       }>;
     };
     const terminalSchema = firstRequest.tools.find(
@@ -1391,63 +1398,69 @@ test.skipIf(!tmuxAvailable())(
     expect(terminalSchema!.oneOf).toBeUndefined();
     expect(terminalSchema!.additionalProperties).toBe(false);
     const properties = terminalSchema!.properties ?? {};
-    const propertyNames = [
-      "action",
-      "session_id",
-      "cwd",
-      "command",
-      "profile",
-      "shell",
-      "backend",
-      "return_when",
-      "wait_ceiling_ms",
-      "dimensions",
-      "initial_monitors",
-      "cursor_segment",
-      "cursor_offset",
-      "after_event_id",
-      "acknowledge_event_id",
-      "max_events",
-      "write",
-      "lease",
-      "monitor",
-      "task_id",
-      "workspace_root",
-      "rows",
-      "columns",
-      "signal",
-      "close_policy",
-    ];
-    expect(Object.keys(properties)).toEqual(propertyNames);
-    expect(terminalSchema!.required).toEqual(propertyNames);
-    expect(properties.action!.enum).toEqual([
+    expect(Object.keys(properties)).toEqual(["request"]);
+    expect(terminalSchema!.required).toEqual(["request"]);
+    const branches = properties.request!.oneOf ?? [];
+    expect(branches).toHaveLength(12);
+    const branchByAction = new Map(branches.map((branch) => [
+      branch.properties?.action?.enum?.[0],
+      branch,
+    ]));
+    expect([...branchByAction.keys()]).toEqual([
       "exec", "start", "read", "screen", "write", "wait",
       "monitor", "inspect", "list", "resize", "signal", "close",
     ]);
-    expect(properties.action!.type).toBe("string");
-    for (const name of propertyNames.slice(1)) {
-      expect(properties[name]!.anyOf).toHaveLength(2);
-      expect(properties[name]!.anyOf![1]!.type).toBe("null");
-      expect(properties[name]!.description).toContain(
-        "Set null when the selected action does not use this field.",
-      );
+    for (const branch of branches) {
+      expect(branch.type).toBe("object");
+      expect(branch.additionalProperties).toBe(false);
     }
-    expect(properties.wait_ceiling_ms!.anyOf![0]!.type).toBe("integer");
-    expect(properties.shell!.anyOf![0]!.type).toBe("object");
-    expect(properties.initial_monitors!.anyOf![0]!.type).toBe("array");
-    expect(properties.return_when!.description).toContain(
+    const startProperties = branchByAction.get("start")!.properties!;
+    expect(startProperties.wait_ceiling_ms!.anyOf![0]!.type).toBe("integer");
+    expect(startProperties.shell!.anyOf![0]!.type).toBe("object");
+    expect(startProperties.initial_monitors!.anyOf![0]!.type).toBe("array");
+    expect(startProperties.return_when!.description).toContain(
       "required for every wait",
     );
-    expect(properties.return_when!.description).toContain(
+    expect(startProperties.return_when!.description).toContain(
       "output_contains is monitor-only",
     );
-    expect(properties.cursor_segment!.description).toContain(
+    const readProperties = branchByAction.get("read")!.properties!;
+    expect(Object.keys(readProperties)).toEqual([
+      "action", "session_id", "cursor_segment", "cursor_offset",
+    ]);
+    expect(readProperties.cwd).toBeUndefined();
+    expect(readProperties.cursor_segment!.description).toContain(
       "required for every read",
     );
-    expect(properties.cursor_segment!.description).toContain(
+    expect(readProperties.cursor_segment!.description).toContain(
       "raw_gap.available_from",
     );
-    expect(properties.close_policy!.description).toContain("Close is final");
+    const closeProperties = branchByAction.get("close")!.properties!;
+    expect(closeProperties.close_policy!.type).toBe("string");
+    expect(closeProperties.close_policy!.description).toContain("Close is final");
+
+    const mixedInput = toolCallInput(
+      gateway.requests[1]!.body,
+      "terminal_mixed_start",
+    );
+    expect(mixedInput.request).toBeUndefined();
+    expect(mixedInput.action).toBe("start");
+    expect(mixedInput.session_id).toBe("terminal-foreign");
+    const validStartInput = toolCallInput(
+      gateway.requests[2]!.body,
+      "terminal_valid_start",
+    );
+    expect(validStartInput.request).toBeUndefined();
+    expect(validStartInput.action).toBe("start");
+    const validCloseInput = toolCallInput(
+      gateway.requests[3]!.body,
+      "terminal_valid_close",
+    );
+    expect(validCloseInput).toEqual({
+      action: "close",
+      session_id: terminalSessionId,
+      close_policy: "force",
+    });
 
     const scrollback = await active.captureFullScrollback();
     expect(scrollback).toContain("Failed start · 17 invalid fields");

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -2305,16 +2305,18 @@ test.skipIf(!tmuxAvailable())(
     await active.sendText("Exercise the public terminal wait contract.");
     await active.waitForText("TUI public terminal wait complete", TIMEOUT);
     expect(gateway.requests).toHaveLength(6);
+    type WaitSchema = {
+      type?: string;
+      properties?: Record<string, WaitSchema>;
+      enum?: string[];
+      oneOf?: WaitSchema[];
+      required?: string[];
+      additionalProperties?: boolean;
+    };
     const request = JSON.parse(gateway.requests[0]!.body) as {
       tools: Array<{
         name?: string;
-        inputSchema?: {
-          type?: string;
-          properties?: Record<string, { enum?: string[] }>;
-          required?: string[];
-          additionalProperties?: boolean;
-          oneOf?: unknown[];
-        };
+        inputSchema?: WaitSchema;
       }>;
     };
     const terminalSchema = request.tools.find(
@@ -2324,16 +2326,20 @@ test.skipIf(!tmuxAvailable())(
     expect(terminalSchema!.type).toBe("object");
     expect(terminalSchema!.oneOf).toBeUndefined();
     expect(terminalSchema!.additionalProperties).toBe(false);
-    expect(terminalSchema!.properties?.action?.enum).toContain("wait");
-    const terminalProperties = Object.keys(terminalSchema!.properties ?? {});
-    expect(terminalProperties).toHaveLength(25);
-    expect(terminalSchema!.required).toEqual(terminalProperties);
-    expect(
-      terminalProperties.filter((name) => name === "wait_ceiling_ms"),
-    ).toHaveLength(1);
-    expect(terminalProperties).not.toContain("safety_ceiling_ms");
-    expect(terminalProperties).not.toContain("authority");
-    expect(terminalProperties).not.toContain("proof");
+    expect(terminalSchema!.required).toEqual(["request"]);
+    const branches = terminalSchema!.properties?.request?.oneOf ?? [];
+    const waitBranch = branches.find((branch) =>
+      branch.properties?.action?.enum?.[0] === "wait"
+    );
+    expect(waitBranch).toBeDefined();
+    const waitProperties = Object.keys(waitBranch!.properties ?? {});
+    expect(waitProperties).toEqual([
+      "action", "session_id", "return_when", "wait_ceiling_ms",
+    ]);
+    expect(waitBranch!.required).toEqual(waitProperties);
+    expect(waitProperties).not.toContain("safety_ceiling_ms");
+    expect(waitProperties).not.toContain("authority");
+    expect(waitProperties).not.toContain("proof");
     expect(gateway.requests[4]!.body).toContain('"wait_ceiling_ms":20000');
     expect(gateway.requests[4]!.body).not.toContain("safety_ceiling_ms");
     expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");


### PR DESCRIPTION
## Summary

- Advertise the full terminal tool as one request with fields limited to the selected action.
- Normalize those requests before existing validation, permission, execution, and persistence.
- Keep no-save, browser, and required-Vision terminal calls on their existing input contracts.