### PR TITLE
Harden Codex provider boundaries

### DIFF
--- a/sdk/tests/test-core-browser.mjs
+++ b/sdk/tests/test-core-browser.mjs
@@ -176,10 +176,7 @@ function withTimeout(promise, message, timeoutMs) {
 try {
   await runCase("incremental stream", "transport=mock&autorun=say%20hello&chunk-delay=75&model=sdk%2Fchrome-model&mode=code", (result) => {
     const modelChunks = result.chunks.filter((chunk) => !chunk.startsWith("[context]"));
-    expect(
-      result.stopReason === "end_turn",
-      `unexpected stop reason ${result.stopReason}; state=${result.state}; error=${result.error}`,
-    );
+    expect(result.stopReason === "end_turn", `unexpected stop reason ${result.stopReason}`);
     expect(modelChunks.join("").trimEnd() === "hello world", `unexpected chunks ${JSON.stringify(result.chunks)}`);
     expect(modelChunks.filter((chunk) => chunk.trim()).length >= 2, "browser stream was buffered");
     expect(result.fetchCalls === 1, `expected one prompt fetch, got ${result.fetchCalls}`);

--- a/sdk/tests/test-core.mjs
+++ b/sdk/tests/test-core.mjs
@@ -109,6 +109,7 @@ checkpoint("agent initialized");
 const session = await agent.createSession();
 checkpoint("session created");
 if (!session.id) throw new Error("session/new did not return a session id");
+if (session.configOptions?.some((option) => option.id === "provider")) throw new Error("WASM session/new advertised unsupported provider switching");
 if (!session.modes?.currentModeId) throw new Error("session/new did not return a mode snapshot");
 const modeOption = session.configOptions?.find((option) => option.id === "mode");
 if (modeOption?.options.find((option) => option.value === "code")?.permissionMode !== "auto") throw new Error("code mode did not advertise auto permission mode");
@@ -121,6 +122,7 @@ for (const model of catalogModels) {
 if (modelOption.currentValue !== "sdk/catalog-alpha") throw new Error(`stored model was not restored through ACP: ${modelOption.currentValue}`);
 if (session.modes.currentModeId !== "code") throw new Error(`stored mode was not restored through ACP: ${session.modes.currentModeId}`);
 await session.setModel("sdk/browser-test-model");
+if (session.configOptions.some((option) => option.id === "provider")) throw new Error("WASM model update advertised unsupported provider switching");
 if (session.configOptions.find((option) => option.id === "model")?.currentValue !== "sdk/browser-test-model") throw new Error("model option did not update");
 if (persistedConfig.get("model") !== "sdk/browser-test-model") throw new Error("accepted model was not persisted");
 failNextCommit = true;
@@ -174,6 +176,7 @@ const sessions = await agent.listSessions();
 if (!sessions.some((entry) => entry.sessionId === session.id)) throw new Error("persisted session was not listed");
 const restored = await agent.openSession(session.id);
 if (restored.id !== session.id) throw new Error("opened session id did not match");
+if (restored.configOptions?.some((option) => option.id === "provider")) throw new Error("WASM session/load advertised unsupported provider switching");
 if (!restored.history.some((update) => update.sessionUpdate === "agent_message_chunk" && update.content.text.includes("hello world"))) {
   throw new Error("restored session did not replay prior assistant history");
 }

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -699,6 +699,16 @@ pub fn runSubagentChild(
     return subagent_agent_adapter.run(.{
         .host = subagent_host,
         .tool_context = ctx.toolContext(),
+        .provider_routes = .{
+            .gateway = .{
+                .agent_stream_provider = server.streamProviderFor(state, .gateway),
+                .permission_reviewer_provider = state.cfg.permission_reviewer_provider,
+            },
+            .codex = .{
+                .agent_stream_provider = server.streamProviderFor(state, .codex),
+                .permission_reviewer_provider = state.cfg.codex_permission_reviewer_provider,
+            },
+        },
         .system_prompt = state.cfg.prompt_policy.system_prompt,
         .model_prompt_overlay = state.cfg.prompt_policy.modelPromptOverlay(admission.model),
         .skills_prompt_section = bounded_skills.text,

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -394,13 +394,42 @@ pub fn refreshModelCredential(
     expected_account_id: ?[]const u8,
 ) !?[]u8 {
     const state: *ServerState = @ptrCast(@alignCast(raw));
-    return auth_runtime.refreshCredentialTokenForAccount(
+    const refreshed = try auth_runtime.refreshCredentialTokenForAccount(
         state.cfg.gateway_provider.oauth_transport,
         alloc,
         source,
         mode,
         expected_account_id,
-    );
+    ) orelse return null;
+    errdefer secret.zeroAndFree(alloc, refreshed);
+    if (source == .chatgpt_subscription) {
+        try publishRefreshedChatGptToken(state, refreshed, expected_account_id);
+    }
+    return refreshed;
+}
+
+fn publishRefreshedChatGptToken(
+    state: *ServerState,
+    refreshed: []const u8,
+    expected_account_id: ?[]const u8,
+) !void {
+    const expected = expected_account_id orelse return error.ChatGptAccountChanged;
+    const state_account = state.account_id orelse return error.ChatGptAccountChanged;
+    if (!std.mem.eql(u8, expected, state_account)) return error.ChatGptAccountChanged;
+    if (state.active_session) |active| {
+        const active_account = active.account_id orelse return error.ChatGptAccountChanged;
+        if (!std.mem.eql(u8, expected, active_account)) return error.ChatGptAccountChanged;
+    }
+
+    const owned = try state.alloc.dupe(u8, refreshed);
+    if (state.active_session) |*active| active.api_key = &.{};
+    if (state.api_key.len > 0) secret.zeroAndFree(state.alloc, state.api_key);
+    state.api_key = owned;
+    state.credential_source = .chatgpt_subscription;
+    if (state.active_session) |*active| {
+        active.api_key = state.api_key;
+        active.credential_source = .chatgpt_subscription;
+    }
 }
 
 pub fn releaseActiveSession(state: *ServerState) !void {
@@ -1717,11 +1746,13 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
     try out.writer.writeAll("{\"configOptions\":[");
-    try sessions.writeProviderConfigOption(
-        &out.writer,
-        if (state.active_session) |session| session.provider else state.provider,
-    );
-    try out.writer.writeAll(",");
+    if (comptime !host_target.is_wasm) {
+        try sessions.writeProviderConfigOption(
+            &out.writer,
+            if (state.active_session) |session| session.provider else state.provider,
+        );
+        try out.writer.writeAll(",");
+    }
     try sessions.writeModelConfigOption(
         &out.writer,
         current_model,
@@ -2442,6 +2473,51 @@ test "ACP model commits honor the active session write boundary" {
         error.SessionPersistenceUnavailable,
         worker.failure.?,
     );
+}
+
+test "ACP publishes an account-bound refreshed Codex token for later prompts" {
+    const alloc = std.testing.allocator;
+    var state: ServerState = undefined;
+    state.alloc = alloc;
+    state.api_key = try alloc.dupe(u8, "stale-token");
+    state.account_id = try alloc.dupe(u8, "acct-1");
+    state.credential_source = .chatgpt_subscription;
+    var active: ActiveSessionState = undefined;
+    active.api_key = state.api_key;
+    active.account_id = state.account_id;
+    active.credential_source = .chatgpt_subscription;
+    state.active_session = active;
+    defer {
+        secret.zeroAndFree(alloc, state.api_key);
+        alloc.free(state.account_id.?);
+    }
+
+    try publishRefreshedChatGptToken(&state, "fresh-token", "acct-1");
+
+    try std.testing.expectEqualStrings("fresh-token", state.api_key);
+    try std.testing.expectEqualStrings("fresh-token", state.active_session.?.api_key);
+    try std.testing.expectEqualStrings("acct-1", state.account_id.?);
+    try std.testing.expectEqualStrings("acct-1", state.active_session.?.account_id.?);
+}
+
+test "ACP rejects refreshed Codex tokens for another account" {
+    const alloc = std.testing.allocator;
+    var state: ServerState = undefined;
+    state.alloc = alloc;
+    state.api_key = try alloc.dupe(u8, "stale-token");
+    state.account_id = try alloc.dupe(u8, "acct-1");
+    state.credential_source = .chatgpt_subscription;
+    state.active_session = null;
+    defer {
+        secret.zeroAndFree(alloc, state.api_key);
+        alloc.free(state.account_id.?);
+    }
+
+    try std.testing.expectError(
+        error.ChatGptAccountChanged,
+        publishRefreshedChatGptToken(&state, "wrong-token", "acct-2"),
+    );
+    try std.testing.expectEqualStrings("stale-token", state.api_key);
 }
 
 test "ACP usage flush preserves snapshot ownership on allocation failure" {

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -14,6 +14,7 @@ const session_runtime = @import("../core/session/session.zig");
 const mcp_runtime = @import("../core/mcp/mcp_runtime.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
 const host = @import("../core/hosts/host.zig");
+const host_target = @import("../core/hosts/target.zig");
 const credentials = @import("../core/auth/credentials.zig");
 const model_provider = @import("../core/config/model_provider.zig");
 const mode_registry = @import("../core/modes/mode_registry.zig");
@@ -252,8 +253,10 @@ fn writeNewSessionResponse(
     try out.writer.writeAll("{\"sessionId\":");
     try writeJsonStr(session_id, &out.writer);
     try out.writer.writeAll(",\"configOptions\":[");
-    try writeProviderConfigOption(&out.writer, state.active_session.?.provider);
-    try out.writer.writeAll(",");
+    if (comptime !host_target.is_wasm) {
+        try writeProviderConfigOption(&out.writer, state.active_session.?.provider);
+        try out.writer.writeAll(",");
+    }
     try writeModelConfigOption(
         &out.writer,
         state.active_session.?.model,
@@ -692,8 +695,10 @@ fn writeLoadSessionResponse(
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
     try out.writer.writeAll("{\"configOptions\":[");
-    try writeProviderConfigOption(&out.writer, state.active_session.?.provider);
-    try out.writer.writeAll(",");
+    if (comptime !host_target.is_wasm) {
+        try writeProviderConfigOption(&out.writer, state.active_session.?.provider);
+        try out.writer.writeAll(",");
+    }
     try writeModelConfigOption(
         &out.writer,
         model,

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -2043,10 +2043,8 @@ fn fetchCatalogForProvider(
     };
     const json_text = switch (response) {
         .success => |body| body,
-        .http_status => |status| {
-            const failure = model_catalog.failureForHttpStatus(status);
-            if (failure.allowsPublicFallback()) return .{ .failure = failure };
-            return .{ .failure = failure };
+        .http_status => |status| return .{
+            .failure = model_catalog.failureForHttpStatus(status),
         },
     };
     defer alloc.free(json_text);
@@ -2085,10 +2083,7 @@ fn fetchModelCatalogForView(
     };
     defer alloc.free(json_text);
 
-    var catalog = try parseModelCatalogForView(alloc, json_text, view);
-    errdefer freeModelCatalog(alloc, &catalog);
-
-    return catalog;
+    return parseModelCatalogForView(alloc, json_text, view);
 }
 
 fn fetchModelCatalogResponse(

--- a/src/core/agent/runtime/image_provider.zig
+++ b/src/core/agent/runtime/image_provider.zig
@@ -10,10 +10,9 @@ const runtime_gateway_step = @import("gateway_step.zig");
 const Allocator = std.mem.Allocator;
 const ChatMessage = types.ChatMessage;
 
-pub const default_model = "google/gemini-2.5-flash";
+const model = "google/gemini-2.5-flash";
 
 pub const Request = struct {
-    model: []const u8 = default_model,
     stream_provider: agent_stream_provider.Provider,
     api_key: []const u8,
     credential_source: ?types.CredentialSource = null,
@@ -51,11 +50,11 @@ pub fn inspect(
         .{ .role = .system, .content = system_prompt },
         .{ .role = .user, .content = user_prompt },
     };
-    const provider_opts = model_capabilities.resolveProviderOptions(request.model, .auto, false);
+    const provider_opts = model_capabilities.resolveProviderOptions(model, .auto, false);
     const payload = try request.stream_provider.build(
         alloc,
         .{
-            .model = request.model,
+            .model = model,
             .serialized_tools = "[]",
             .messages = &messages,
             .tool_choice = .none,
@@ -81,7 +80,7 @@ pub fn inspect(
         request.credential_source,
         request.gateway_team,
         request.session_id,
-        request.model,
+        model,
         request.retry_count,
         request.chat_url,
         payload,

--- a/src/core/agent/runtime/image_provider.zig
+++ b/src/core/agent/runtime/image_provider.zig
@@ -10,9 +10,10 @@ const runtime_gateway_step = @import("gateway_step.zig");
 const Allocator = std.mem.Allocator;
 const ChatMessage = types.ChatMessage;
 
-const model = "google/gemini-2.5-flash";
+pub const default_model = "google/gemini-2.5-flash";
 
 pub const Request = struct {
+    model: []const u8 = default_model,
     stream_provider: agent_stream_provider.Provider,
     api_key: []const u8,
     credential_source: ?types.CredentialSource = null,
@@ -50,11 +51,11 @@ pub fn inspect(
         .{ .role = .system, .content = system_prompt },
         .{ .role = .user, .content = user_prompt },
     };
-    const provider_opts = model_capabilities.resolveProviderOptions(model, .auto, false);
+    const provider_opts = model_capabilities.resolveProviderOptions(request.model, .auto, false);
     const payload = try request.stream_provider.build(
         alloc,
         .{
-            .model = model,
+            .model = request.model,
             .serialized_tools = "[]",
             .messages = &messages,
             .tool_choice = .none,
@@ -80,7 +81,7 @@ pub fn inspect(
         request.credential_source,
         request.gateway_team,
         request.session_id,
-        model,
+        request.model,
         request.retry_count,
         request.chat_url,
         payload,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2517,6 +2517,31 @@ fn executeActionBoundPermissionRequest(
     };
 }
 
+fn visionFallbackMode(
+    provider: model_provider.ProviderId,
+    tool_registered: bool,
+) runtime_gateway_step.VisionToolMode {
+    if (!model_provider.usesGatewayAuxiliaries(provider) or !tool_registered) {
+        return .unavailable;
+    }
+    return .optional;
+}
+
+test "vision fallback is available only through Gateway" {
+    try std.testing.expectEqual(
+        runtime_gateway_step.VisionToolMode.optional,
+        visionFallbackMode(.gateway, true),
+    );
+    try std.testing.expectEqual(
+        runtime_gateway_step.VisionToolMode.unavailable,
+        visionFallbackMode(.gateway, false),
+    );
+    try std.testing.expectEqual(
+        runtime_gateway_step.VisionToolMode.unavailable,
+        visionFallbackMode(.codex, true),
+    );
+}
+
 fn processQueuedPromptLoop(
     deps: *const AgentRuntimeDeps,
     semantic_presentation: ?runtime_assistant_stream.SemanticPresentationSink,
@@ -2859,10 +2884,10 @@ fn processQueuedPromptLoop(
             );
             debug_trace.eventf("gateway", "before_payload_build", step_ctx, "model={s} gateway_messages={d}", .{ gateway_model, gateway_messages.items.len });
             var vision_route: runtime_vision_contracts.VisionRoute = .native_images;
-            var vision_mode: runtime_gateway_step.VisionToolMode = if (deps.tool_registry.lookup("vision") != null)
-                .optional
-            else
-                .unavailable;
+            var vision_mode = visionFallbackMode(
+                job.provider,
+                deps.tool_registry.lookup("vision") != null,
+            );
             const recovery_source_messages = try appendReadFailureRecoveryContext(
                 overlay_arena,
                 gateway_messages.items,
@@ -2883,6 +2908,9 @@ fn processQueuedPromptLoop(
                         recovery_source_messages,
                         current_user_message_index,
                     );
+                }
+                if (!model_provider.usesGatewayAuxiliaries(job.provider)) {
+                    return error.CodexNativeImageUnavailable;
                 }
                 if (job.authorized_image_catalog.len == 0) {
                     return error.MissingAuthorizedImageCatalog;

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -2277,6 +2277,40 @@ test "processQueuedPrompt keeps native image parts for vision route model" {
     try std.testing.expectEqualStrings("Native image answer", hooks.finish_assistant_text.?);
 }
 
+test "processQueuedPrompt never uses the vision fallback for Codex" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const image_path = try writeTestImagePath(alloc, &tmp);
+    defer alloc.free(image_path);
+    const image = try testCapturedImage(alloc, &tmp, image_path, 1);
+    defer types.freeImageAttachment(alloc, image);
+    var images = [_]types.ImageAttachment{image};
+    const capability_overrides = [_]ModelCapabilityOverride{.{
+        .model = "gpt-5.6-sol",
+        .capabilities = .{},
+    }};
+    var gateway = FakeGateway.init(alloc, &.{});
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.capability_overrides = &capability_overrides;
+    hooks.tool_registry = .{ .tools = test_support.vision_agent_test_tools[0..] };
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var job = fixture.job();
+    job.provider = .codex;
+    job.model = @constCast("gpt-5.6-sol");
+    job.prompt = @constCast("Describe the attached image.");
+    job.images = &images;
+    job.authorized_image_catalog = &images;
+
+    try std.testing.expectError(
+        error.CodexNativeImageUnavailable,
+        runFakePrompt(&gateway, &hooks, fixture.config(), job),
+    );
+    try std.testing.expectEqual(@as(usize, 0), gateway.request_bodies.items.len);
+}
+
 test "processQueuedPrompt routes images natively only when vision and file input are both supported" {
     const alloc = std.testing.allocator;
     const cases = [_]struct {

--- a/src/core/agent/runtime/vision_executor.zig
+++ b/src/core/agent/runtime/vision_executor.zig
@@ -26,6 +26,7 @@ const system_prompt =
     "Extract exactly one record for every requested image ID, in requested order.";
 
 pub const Config = struct {
+    model: []const u8 = image_provider.default_model,
     stream_provider: agent_stream_provider.Provider,
     api_key: []const u8,
     credential_source: ?types.CredentialSource = null,
@@ -279,6 +280,7 @@ fn runBatchAttempt(
         user_prompt,
         verified_images,
         .{
+            .model = config.model,
             .stream_provider = config.stream_provider,
             .api_key = config.api_key,
             .credential_source = config.credential_source,

--- a/src/core/agent/runtime/vision_executor.zig
+++ b/src/core/agent/runtime/vision_executor.zig
@@ -26,7 +26,6 @@ const system_prompt =
     "Extract exactly one record for every requested image ID, in requested order.";
 
 pub const Config = struct {
-    model: []const u8 = image_provider.default_model,
     stream_provider: agent_stream_provider.Provider,
     api_key: []const u8,
     credential_source: ?types.CredentialSource = null,
@@ -280,7 +279,6 @@ fn runBatchAttempt(
         user_prompt,
         verified_images,
         .{
-            .model = config.model,
             .stream_provider = config.stream_provider,
             .api_key = config.api_key,
             .credential_source = config.credential_source,

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1052,10 +1052,25 @@ pub fn Runtime(comptime App: type) type {
             ) catch return error.OutOfMemory;
             defer explicit_skills.deinit(alloc);
             const prompt_policy = app.promptPolicy();
+            const tool_context = childToolContext(app.subagentToolContextForAdmission(admission));
+            const provider_routes = if (comptime @hasDecl(App, "subagentProviderRoutes"))
+                app.subagentProviderRoutes()
+            else
+                subagent_agent_adapter.ProviderRoutes{
+                    .gateway = .{
+                        .agent_stream_provider = tool_context.agent_stream_provider,
+                        .permission_reviewer_provider = tool_context.permission_reviewer_provider,
+                    },
+                    .codex = .{
+                        .agent_stream_provider = tool_context.agent_stream_provider,
+                        .permission_reviewer_provider = tool_context.permission_reviewer_provider,
+                    },
+                };
             return subagent_agent_adapter.run(.{
                 .host = app_session_runtime.Runtime(App).subagentHost(app) orelse
                     return error.ProviderFailed,
-                .tool_context = childToolContext(app.subagentToolContextForAdmission(admission)),
+                .tool_context = tool_context,
+                .provider_routes = provider_routes,
                 .system_prompt = prompt_policy.system_prompt,
                 .model_prompt_overlay = prompt_policy.modelPromptOverlay(admission.model),
                 .skills_prompt_section = bounded_skills.text,

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -3179,6 +3179,7 @@ pub fn Runtime(comptime App: type) type {
             var result = host.executeHumanCommand(app.alloc, &mutation.command, .{
                 .invocation_id = mutation.invocation_id,
                 .defaults = .{
+                    .provider = provider_runtime.provider(app),
                     .model = provider_runtime.model(app),
                     .effort = app.effort,
                     .fast_mode = if (comptime @hasField(App, "fast_mode")) app.fast_mode else false,

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -342,7 +342,7 @@ pub const SessionPreferencePatch = struct {
     effort: ?types.ReasoningEffort = null,
     fast_mode: ?bool = null,
 
-    fn userSettingsPatch(self: SessionPreferencePatch) config_runtime.UserSettingsPatch {
+    pub fn userSettingsPatch(self: SessionPreferencePatch) config_runtime.UserSettingsPatch {
         var patch = config_runtime.UserSettingsPatch{
             .provider = self.provider,
             .effort = self.effort,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -270,6 +270,16 @@ fn runAskChild(
     return subagent_agent_adapter.run(.{
         .host = ctx.subagent_host orelse return error.ProviderFailed,
         .tool_context = ctx.toolContext(),
+        .provider_routes = .{
+            .gateway = .{
+                .agent_stream_provider = ctx.cfg.gateway_provider.agent_stream,
+                .permission_reviewer_provider = ctx.cfg.permission_reviewer_provider,
+            },
+            .codex = .{
+                .agent_stream_provider = ctx.cfg.codex_agent_stream orelse agent_stream_provider.unavailable_provider,
+                .permission_reviewer_provider = ctx.cfg.codex_permission_reviewer_provider,
+            },
+        },
         .system_prompt = ctx.cfg.prompt_policy.system_prompt,
         .model_prompt_overlay = ctx.cfg.prompt_policy.modelPromptOverlay(admission.model),
         .skills_prompt_section = ctx.subagent_skills_prompt,

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -4747,7 +4747,7 @@ test "runIfRequested models passes startup team to fetch seam" {
     try std.testing.expectEqual(RunResult.handled_success, result);
     try std.testing.expect(probe.called);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[\"private/blue-hornbill\"],\"models\":[{\"id\":\"private/blue-hornbill\",\"source\":\"Vercel AI Gateway\"}]}\n",
+        "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[\"private/blue-hornbill\"]}\n",
         capture.stdout.written(),
     );
 }
@@ -4826,7 +4826,7 @@ test "runIfRequested local json success appends exactly one newline" {
     const result = try runIfRequestedWithDeps(std.testing.allocator, &.{ @constCast("status"), @constCast("--json") }, testConfig(), deps);
     try std.testing.expectEqual(RunResult.handled_success, result);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"status\",\"model\":\"test-model\",\"model_source\":\"Vercel AI Gateway\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"connected_providers\":[],\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"auto\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":42}\n",
+        "{\"kind\":\"status\",\"model\":\"test-model\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"auto\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":42}\n",
         capture.stdout.written(),
     );
     try std.testing.expect(!std.mem.endsWith(u8, capture.stdout.written(), "\n\n"));
@@ -4919,7 +4919,7 @@ test "writeRenderedJsonLine falls back to heap and appends exactly one newline" 
     );
 
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"status\",\"model\":\"test-model\",\"model_source\":\"Vercel AI Gateway\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"connected_providers\":[],\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":42}\n",
+        "{\"kind\":\"status\",\"model\":\"test-model\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":42}\n",
         capture.stdout.written(),
     );
 }
@@ -4965,7 +4965,7 @@ test "writeRenderedJsonLine renders doctor json through output contract" {
     );
 
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"doctor\",\"ok_count\":1,\"warn_count\":1,\"fail_count\":0,\"workspace\":\"/tmp/fx\",\"model\":\"test-model\",\"model_source\":\"Vercel AI Gateway\",\"auth\":\"AI_GATEWAY_API_KEY\",\"auth_refreshable\":false,\"permission_mode\":\"auto\",\"agent_step_limit\":42,\"checks\":[{\"name\":\"auth\",\"status\":\"ok\",\"detail\":\"AI_GATEWAY_API_KEY is configured\"},{\"name\":\"gh\",\"status\":\"warn\",\"detail\":\"GitHub CLI not found in PATH\"}]}\n",
+        "{\"kind\":\"doctor\",\"ok_count\":1,\"warn_count\":1,\"fail_count\":0,\"workspace\":\"/tmp/fx\",\"model\":\"test-model\",\"auth\":\"AI_GATEWAY_API_KEY\",\"auth_refreshable\":false,\"permission_mode\":\"auto\",\"agent_step_limit\":42,\"checks\":[{\"name\":\"auth\",\"status\":\"ok\",\"detail\":\"AI_GATEWAY_API_KEY is configured\"},{\"name\":\"gh\",\"status\":\"warn\",\"detail\":\"GitHub CLI not found in PATH\"}]}\n",
         capture.stdout.written(),
     );
 }

--- a/src/core/gateway/model_catalog.zig
+++ b/src/core/gateway/model_catalog.zig
@@ -545,9 +545,7 @@ fn modelPickerProvider(id: []const u8) []const u8 {
 }
 
 fn pickerProviderLimit(provider: []const u8) usize {
-    if (std.mem.eql(u8, provider, "anthropic") or
-        std.mem.eql(u8, provider, "openai"))
-    {
+    if (std.mem.eql(u8, provider, "anthropic") or std.mem.eql(u8, provider, "openai")) {
         return extended_picker_provider_limit;
     }
     return picker_provider_limit;

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -412,7 +412,9 @@ pub const StatusSnapshot = struct {
         defer out.deinit();
 
         try out.writer.print("[status] model={s}\n", .{self.model});
-        try out.writer.print("[status] model_source={s}\n", .{model_provider.label(self.provider)});
+        if (self.provider == .codex) {
+            try out.writer.print("[status] model_source={s}\n", .{model_provider.label(self.provider)});
+        }
         try out.writer.print("[status] update_channel={s}\n", .{self.update_channel});
         try out.writer.print("[status] build_channel={s}\n", .{self.build_channel});
         if (self.build_revision.len > 0) {
@@ -422,9 +424,11 @@ pub const StatusSnapshot = struct {
             try out.writer.print("[status] mcp_config_error={s}\n", .{error_name});
         }
         try out.writer.print("[status] auth={s}\n", .{self.auth.activeSourceLabel()});
-        try out.writer.writeAll("[status] connected_providers=");
-        try writeConnectedProvidersText(&out.writer, self.auth);
-        try out.writer.writeByte('\n');
+        if (self.provider == .codex) {
+            try out.writer.writeAll("[status] connected_providers=");
+            try writeConnectedProvidersText(&out.writer, self.auth);
+            try out.writer.writeByte('\n');
+        }
         try out.writer.print("[status] auth_refreshable={}\n", .{self.auth.refreshable()});
         if (self.auth.expired) try out.writer.writeAll("[status] auth_expired=true\n");
         if (self.auth_help) |help| {
@@ -447,16 +451,20 @@ pub const StatusSnapshot = struct {
         defer out.deinit();
 
         try out.writer.print("model={s}\n", .{self.model});
-        try out.writer.print("model_source={s}\n", .{model_provider.label(self.provider)});
+        if (self.provider == .codex) {
+            try out.writer.print("model_source={s}\n", .{model_provider.label(self.provider)});
+        }
         try out.writer.print("update_channel={s}\n", .{self.update_channel});
         try out.writer.print("build_channel={s}\n", .{self.build_channel});
         if (self.build_revision.len > 0) {
             try out.writer.print("build_revision={s}\n", .{self.build_revision});
         }
         try out.writer.print("auth={s}\n", .{self.auth.activeSourceLabel()});
-        try out.writer.writeAll("connected_providers=");
-        try writeConnectedProvidersText(&out.writer, self.auth);
-        try out.writer.writeByte('\n');
+        if (self.provider == .codex) {
+            try out.writer.writeAll("connected_providers=");
+            try writeConnectedProvidersText(&out.writer, self.auth);
+            try out.writer.writeByte('\n');
+        }
         try out.writer.print("auth_refreshable={}\n", .{self.auth.refreshable()});
         if (self.auth.expired) try out.writer.writeAll("auth_expired=true\n");
         if (self.auth_help) |help| try out.writer.print("auth_help={s}\n", .{help});
@@ -481,8 +489,10 @@ pub const StatusSnapshot = struct {
     pub fn writeJson(self: StatusSnapshot, writer: *std.Io.Writer) !void {
         try writer.writeAll("{\"kind\":\"status\",\"model\":");
         try std.json.Stringify.value(self.model, .{}, writer);
-        try writer.writeAll(",\"model_source\":");
-        try std.json.Stringify.value(model_provider.label(self.provider), .{}, writer);
+        if (self.provider == .codex) {
+            try writer.writeAll(",\"model_source\":");
+            try std.json.Stringify.value(model_provider.label(self.provider), .{}, writer);
+        }
         try writer.writeAll(",\"update_channel\":");
         try std.json.Stringify.value(self.update_channel, .{}, writer);
         try writer.writeAll(",\"build_channel\":");
@@ -495,17 +505,19 @@ pub const StatusSnapshot = struct {
         }
         try writer.writeAll(",\"auth\":");
         try std.json.Stringify.value(self.auth.activeSourceLabel(), .{}, writer);
-        try writer.writeAll(",\"connected_providers\":[");
-        var wrote_provider = false;
-        if (gatewayProviderConnected(self.auth)) {
-            try std.json.Stringify.value("vercel-ai-gateway", .{}, writer);
-            wrote_provider = true;
+        if (self.provider == .codex) {
+            try writer.writeAll(",\"connected_providers\":[");
+            var wrote_provider = false;
+            if (gatewayProviderConnected(self.auth)) {
+                try std.json.Stringify.value("vercel-ai-gateway", .{}, writer);
+                wrote_provider = true;
+            }
+            if (chatGptProviderConnected(self.auth)) {
+                if (wrote_provider) try writer.writeByte(',');
+                try std.json.Stringify.value("codex", .{}, writer);
+            }
+            try writer.writeByte(']');
         }
-        if (chatGptProviderConnected(self.auth)) {
-            if (wrote_provider) try writer.writeByte(',');
-            try std.json.Stringify.value("codex", .{}, writer);
-        }
-        try writer.writeByte(']');
         try writer.print(",\"auth_refreshable\":{}", .{self.auth.refreshable()});
         if (self.auth.expired) try writer.writeAll(",\"auth_expired\":true");
         if (self.auth_help) |help| {
@@ -654,7 +666,11 @@ pub const ModelListSnapshot = struct {
 
         const shown = self.shownCount();
         for (self.ids[0..shown]) |id| {
-            try out.writer.print(" - {s} · {s}\n", .{ id, model_provider.label(self.provider) });
+            if (self.provider == .codex) {
+                try out.writer.print(" - {s} · {s}\n", .{ id, model_provider.label(self.provider) });
+            } else {
+                try out.writer.print(" - {s}\n", .{id});
+            }
         }
         if (self.ids.len > shown) {
             try out.writer.print(" ... and {d} more\n", .{self.ids.len - shown});
@@ -677,7 +693,13 @@ pub const ModelListSnapshot = struct {
         defer out.deinit();
         try out.writer.print("{d} available", .{self.ids.len});
         const shown = self.shownCount();
-        for (self.ids[0..shown]) |id| try out.writer.print("\n - {s} · {s}", .{ id, model_provider.label(self.provider) });
+        for (self.ids[0..shown]) |id| {
+            if (self.provider == .codex) {
+                try out.writer.print("\n - {s} · {s}", .{ id, model_provider.label(self.provider) });
+            } else {
+                try out.writer.print("\n - {s}", .{id});
+            }
+        }
         if (self.ids.len > shown) try out.writer.print("\n ... and {d} more", .{self.ids.len - shown});
         if (self.catalogExplanation()) |explanation| try out.writer.print("\n{s}", .{explanation});
         return try out.toOwnedSlice();
@@ -696,14 +718,16 @@ pub const ModelListSnapshot = struct {
             if (i > 0) try out.writer.writeByte(',');
             try std.json.Stringify.value(id, .{}, &out.writer);
         }
-        try out.writer.writeAll("],\"models\":[");
-        for (self.ids[0..shown], 0..) |id, i| {
-            if (i > 0) try out.writer.writeByte(',');
-            try out.writer.writeAll("{\"id\":");
-            try std.json.Stringify.value(id, .{}, &out.writer);
-            try out.writer.writeAll(",\"source\":");
-            try std.json.Stringify.value(model_provider.label(self.provider), .{}, &out.writer);
-            try out.writer.writeByte('}');
+        if (self.provider == .codex) {
+            try out.writer.writeAll("],\"models\":[");
+            for (self.ids[0..shown], 0..) |id, i| {
+                if (i > 0) try out.writer.writeByte(',');
+                try out.writer.writeAll("{\"id\":");
+                try std.json.Stringify.value(id, .{}, &out.writer);
+                try out.writer.writeAll(",\"source\":");
+                try std.json.Stringify.value(model_provider.label(self.provider), .{}, &out.writer);
+                try out.writer.writeByte('}');
+            }
         }
         try out.writer.writeAll("]}");
         return try out.toOwnedSlice();
@@ -1193,7 +1217,9 @@ pub const DoctorSnapshot = struct {
         );
         try out.writer.print("[doctor] workspace={s}\n", .{self.workspace_root});
         try out.writer.print("[doctor] model={s}\n", .{self.model});
-        try out.writer.print("[doctor] model_source={s}\n", .{model_provider.label(self.provider)});
+        if (self.provider == .codex) {
+            try out.writer.print("[doctor] model_source={s}\n", .{model_provider.label(self.provider)});
+        }
         try out.writer.print("[doctor] auth={s}\n", .{self.auth.activeSourceLabel()});
         try out.writer.print("[doctor] auth_refreshable={}\n", .{self.auth.refreshable()});
         if (self.auth.expired) try out.writer.writeAll("[doctor] auth_expired=true\n");
@@ -1228,8 +1254,10 @@ pub const DoctorSnapshot = struct {
         try std.json.Stringify.value(self.workspace_root, .{}, writer);
         try writer.writeAll(",\"model\":");
         try std.json.Stringify.value(self.model, .{}, writer);
-        try writer.writeAll(",\"model_source\":");
-        try std.json.Stringify.value(model_provider.label(self.provider), .{}, writer);
+        if (self.provider == .codex) {
+            try writer.writeAll(",\"model_source\":");
+            try std.json.Stringify.value(model_provider.label(self.provider), .{}, writer);
+        }
         try writer.writeAll(",\"auth\":");
         try std.json.Stringify.value(self.auth.activeSourceLabel(), .{}, writer);
         try writer.print(",\"auth_refreshable\":{}", .{self.auth.refreshable()});
@@ -1931,14 +1959,14 @@ test "core status snapshot text and json stay stable" {
     const text = try snapshot.renderText(std.testing.allocator);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings(
-        "[status] model=alpha\n[status] model_source=Vercel AI Gateway\n[status] update_channel=stable\n[status] build_channel=stable\n[status] auth=missing\n[status] connected_providers=none\n[status] auth_refreshable=false\n[status] auth_help=Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\n[status] permission_mode=ask\n[status] sandbox=none\n[status] workspace=/tmp/fx\n[status] history_turns=3\n[status] session_permission_grants=1\n[status] agent_step_limit=24\n",
+        "[status] model=alpha\n[status] update_channel=stable\n[status] build_channel=stable\n[status] auth=missing\n[status] auth_refreshable=false\n[status] auth_help=Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\n[status] permission_mode=ask\n[status] sandbox=none\n[status] workspace=/tmp/fx\n[status] history_turns=3\n[status] session_permission_grants=1\n[status] agent_step_limit=24\n",
         text,
     );
 
     const json = try snapshot.renderJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"status\",\"model\":\"alpha\",\"model_source\":\"Vercel AI Gateway\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"connected_providers\":[],\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":3,\"session_permission_grants\":1,\"agent_step_limit\":24}",
+        "{\"kind\":\"status\",\"model\":\"alpha\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"missing\",\"auth_refreshable\":false,\"auth_help\":\"Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":3,\"session_permission_grants\":1,\"agent_step_limit\":24}",
         json,
     );
 }
@@ -1957,14 +1985,14 @@ test "core status snapshot includes selected team when present" {
     const text = try snapshot.renderText(std.testing.allocator);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings(
-        "[status] model=alpha\n[status] model_source=Vercel AI Gateway\n[status] update_channel=stable\n[status] build_channel=stable\n[status] auth=fx login\n[status] connected_providers=Vercel AI Gateway\n[status] auth_refreshable=true\n[status] team=example-team\n[status] permission_mode=ask\n[status] sandbox=none\n[status] workspace=/tmp/fx\n[status] history_turns=0\n[status] session_permission_grants=0\n[status] agent_step_limit=24\n",
+        "[status] model=alpha\n[status] update_channel=stable\n[status] build_channel=stable\n[status] auth=fx login\n[status] auth_refreshable=true\n[status] team=example-team\n[status] permission_mode=ask\n[status] sandbox=none\n[status] workspace=/tmp/fx\n[status] history_turns=0\n[status] session_permission_grants=0\n[status] agent_step_limit=24\n",
         text,
     );
 
     const json = try snapshot.renderJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"status\",\"model\":\"alpha\",\"model_source\":\"Vercel AI Gateway\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"fx login\",\"connected_providers\":[\"vercel-ai-gateway\"],\"auth_refreshable\":true,\"team\":\"example-team\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":24}",
+        "{\"kind\":\"status\",\"model\":\"alpha\",\"update_channel\":\"stable\",\"build_channel\":\"stable\",\"build_revision\":\"\",\"auth\":\"fx login\",\"auth_refreshable\":true,\"team\":\"example-team\",\"permission_mode\":\"ask\",\"sandbox\":\"none\",\"workspace\":\"/tmp/fx\",\"history_turns\":0,\"session_permission_grants\":0,\"agent_step_limit\":24}",
         json,
     );
 }
@@ -2070,13 +2098,13 @@ test "model list explains public-only and rejected-credential catalogs" {
     }{
         .{
             .snapshot = .{ .ids = &ids, .private_models_hidden = true, .public_only_reason = .no_credential },
-            .text = "[models] 1 available\n - alpha · Vercel AI Gateway\n[models] Using the public model catalog; sign in with Vercel or use an AI Gateway API key for team-private models.\n",
-            .body = "1 available\n - alpha · Vercel AI Gateway\nUsing the public model catalog; sign in with Vercel or use an AI Gateway API key for team-private models.",
+            .text = "[models] 1 available\n - alpha\n[models] Using the public model catalog; sign in with Vercel or use an AI Gateway API key for team-private models.\n",
+            .body = "1 available\n - alpha\nUsing the public model catalog; sign in with Vercel or use an AI Gateway API key for team-private models.",
         },
         .{
             .snapshot = rejected,
-            .text = "[models] 1 available\n - alpha · Vercel AI Gateway\n[models] Your Gateway credential was rejected; using the public model catalog.\n",
-            .body = "1 available\n - alpha · Vercel AI Gateway\nYour Gateway credential was rejected; using the public model catalog.",
+            .text = "[models] 1 available\n - alpha\n[models] Your Gateway credential was rejected; using the public model catalog.\n",
+            .body = "1 available\n - alpha\nYour Gateway credential was rejected; using the public model catalog.",
         },
         .{
             .snapshot = .{ .ids = &.{}, .private_models_hidden = true, .public_only_reason = .no_credential },
@@ -2108,7 +2136,7 @@ test "model list explains public-only and rejected-credential catalogs" {
     const json = try rejected.renderJson(alloc);
     defer alloc.free(json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":true,\"ids\":[\"alpha\"],\"models\":[{\"id\":\"alpha\",\"source\":\"Vercel AI Gateway\"}]}",
+        "{\"kind\":\"models\",\"count\":1,\"shown_count\":1,\"more_count\":0,\"private_models_hidden\":true,\"ids\":[\"alpha\"]}",
         json,
     );
 
@@ -2127,21 +2155,21 @@ test "core model list snapshot handles limits and empty lists" {
     const all_text = try (ModelListSnapshot{ .ids = &ids }).renderText(std.testing.allocator);
     defer std.testing.allocator.free(all_text);
     try std.testing.expectEqualStrings(
-        "[models] 3 available\n - alpha · Vercel AI Gateway\n - beta · Vercel AI Gateway\n - gamma · Vercel AI Gateway\n",
+        "[models] 3 available\n - alpha\n - beta\n - gamma\n",
         all_text,
     );
 
     const limit_text = try (ModelListSnapshot{ .ids = &ids, .limit = 2 }).renderText(std.testing.allocator);
     defer std.testing.allocator.free(limit_text);
     try std.testing.expectEqualStrings(
-        "[models] 3 available\n - alpha · Vercel AI Gateway\n - beta · Vercel AI Gateway\n ... and 1 more\n",
+        "[models] 3 available\n - alpha\n - beta\n ... and 1 more\n",
         limit_text,
     );
 
     const limit_json = try (ModelListSnapshot{ .ids = &ids, .limit = 2 }).renderJson(std.testing.allocator);
     defer std.testing.allocator.free(limit_json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"models\",\"count\":3,\"shown_count\":2,\"more_count\":1,\"private_models_hidden\":false,\"ids\":[\"alpha\",\"beta\"],\"models\":[{\"id\":\"alpha\",\"source\":\"Vercel AI Gateway\"},{\"id\":\"beta\",\"source\":\"Vercel AI Gateway\"}]}",
+        "{\"kind\":\"models\",\"count\":3,\"shown_count\":2,\"more_count\":1,\"private_models_hidden\":false,\"ids\":[\"alpha\",\"beta\"]}",
         limit_json,
     );
 
@@ -2152,7 +2180,7 @@ test "core model list snapshot handles limits and empty lists" {
     const empty_json = try (ModelListSnapshot{ .ids = &.{} }).renderJson(std.testing.allocator);
     defer std.testing.allocator.free(empty_json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"models\",\"count\":0,\"shown_count\":0,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[],\"models\":[]}",
+        "{\"kind\":\"models\",\"count\":0,\"shown_count\":0,\"more_count\":0,\"private_models_hidden\":false,\"ids\":[]}",
         empty_json,
     );
 }
@@ -2660,14 +2688,14 @@ test "core doctor snapshot text and json stay stable" {
     const text = try snapshot.renderText(std.testing.allocator);
     defer std.testing.allocator.free(text);
     try std.testing.expectEqualStrings(
-        "[doctor] ok=1 warn=1 fail=0\n[doctor] workspace=/tmp/fx\n[doctor] model=alpha\n[doctor] model_source=Vercel AI Gateway\n[doctor] auth=AI_GATEWAY_API_KEY\n[doctor] auth_refreshable=false\n[doctor] permission_mode=ask\n[doctor] agent_step_limit=24\n[ok] auth: AI_GATEWAY_API_KEY is configured\n[warn] gh: GitHub CLI not found in PATH\n",
+        "[doctor] ok=1 warn=1 fail=0\n[doctor] workspace=/tmp/fx\n[doctor] model=alpha\n[doctor] auth=AI_GATEWAY_API_KEY\n[doctor] auth_refreshable=false\n[doctor] permission_mode=ask\n[doctor] agent_step_limit=24\n[ok] auth: AI_GATEWAY_API_KEY is configured\n[warn] gh: GitHub CLI not found in PATH\n",
         text,
     );
 
     const json = try snapshot.renderJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
     try std.testing.expectEqualStrings(
-        "{\"kind\":\"doctor\",\"ok_count\":1,\"warn_count\":1,\"fail_count\":0,\"workspace\":\"/tmp/fx\",\"model\":\"alpha\",\"model_source\":\"Vercel AI Gateway\",\"auth\":\"AI_GATEWAY_API_KEY\",\"auth_refreshable\":false,\"permission_mode\":\"ask\",\"agent_step_limit\":24,\"checks\":[{\"name\":\"auth\",\"status\":\"ok\",\"detail\":\"AI_GATEWAY_API_KEY is configured\"},{\"name\":\"gh\",\"status\":\"warn\",\"detail\":\"GitHub CLI not found in PATH\"}]}",
+        "{\"kind\":\"doctor\",\"ok_count\":1,\"warn_count\":1,\"fail_count\":0,\"workspace\":\"/tmp/fx\",\"model\":\"alpha\",\"auth\":\"AI_GATEWAY_API_KEY\",\"auth_refreshable\":false,\"permission_mode\":\"ask\",\"agent_step_limit\":24,\"checks\":[{\"name\":\"auth\",\"status\":\"ok\",\"detail\":\"AI_GATEWAY_API_KEY is configured\"},{\"name\":\"gh\",\"status\":\"warn\",\"detail\":\"GitHub CLI not found in PATH\"}]}",
         json,
     );
 }

--- a/src/core/permissions/sandbox.zig
+++ b/src/core/permissions/sandbox.zig
@@ -4393,7 +4393,7 @@ test "timeout remains dominant when its output callback fails" {
         .max_command_output_bytes = 1024,
         .output_chunk_ctx = @ptrCast(&trigger),
         .on_output_chunk = FailOutput.onChunk,
-        .timeout_ms = 500,
+        .timeout_ms = 120,
     }, std.testing.allocator, "trap 'echo TIMEOUT-FAIL; exit 0' TERM; while :; do :; done", "/tmp"));
     try std.testing.expect(trigger.seen);
 }

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -8,6 +8,7 @@ const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const io_mod = @import("../shared/io.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
+const model_provider = @import("../config/model_provider.zig");
 const output_contracts = @import("../output/output_contracts.zig");
 const permissions = @import("../permissions/permissions.zig");
 const sandbox = @import("../permissions/sandbox.zig");
@@ -765,7 +766,10 @@ pub fn Commands(comptime App: type) type {
 
         pub fn selectModelFromPicker(app: *App, model: []const u8, effort: types.ReasoningEffort, fast_mode: bool) !void {
             try setResolvedModelRuntime(app, model, true);
-            var patch = app_session_runtime.SessionPreferencePatch{ .model = model };
+            var patch = app_session_runtime.SessionPreferencePatch{
+                .provider = provider_runtime.provider(app),
+                .model = model,
+            };
             const capabilities = model_capabilities.resolveForApp(App, app, model);
             if (capabilities.reasoning_efforts.len == 0) {
                 if (capabilities.supports_fast_mode) {
@@ -1038,7 +1042,10 @@ pub fn Commands(comptime App: type) type {
             try setResolvedModelRuntime(app, resolved, announce);
             try persistPreferenceTargets(
                 app,
-                .{ .model = resolved },
+                .{
+                    .provider = provider_runtime.provider(app),
+                    .model = resolved,
+                },
                 "model",
                 !announce,
             );
@@ -1057,11 +1064,7 @@ pub fn Commands(comptime App: type) type {
                 var committed = app_session_runtime.PreferenceCommitResult{};
                 const attempt = config_runtime.attemptUserPreferences(
                     app.alloc,
-                    .{
-                        .model = patch.model,
-                        .effort = patch.effort,
-                        .fast_mode = patch.fast_mode,
-                    },
+                    patch.userSettingsPatch(),
                 );
                 switch (attempt) {
                     .outcome => |outcome| committed.settings_outcome = outcome,
@@ -1091,11 +1094,7 @@ pub fn Commands(comptime App: type) type {
                 _ = try reportUserSettingsCommit(
                     app,
                     label,
-                    .{
-                        .model = patch.model,
-                        .effort = patch.effort,
-                        .fast_mode = patch.fast_mode,
-                    },
+                    patch.userSettingsPatch(),
                     outcome,
                     result.session_error,
                     announce_commit,
@@ -1657,6 +1656,7 @@ const FakeApp = struct {
     workspace_root: []u8,
     tool_registry: tool_dispatch.Registry = .{},
     selected_model: std.ArrayList(u8) = .empty,
+    selected_provider: model_provider.ProviderId = .gateway,
     auth: auth_runtime.Runtime = .{},
     permission_engine: permissions.PermissionEngine = .{},
     permission_state: app_permission_runtime.State = .{},
@@ -1677,6 +1677,7 @@ const FakeApp = struct {
     last_tone: ?types.NoticeTone = null,
     preference_commit_count: usize = 0,
     last_preference_model: std.ArrayList(u8) = .empty,
+    last_preference_provider: ?model_provider.ProviderId = null,
     last_preference_effort: ?types.ReasoningEffort = null,
     last_preference_fast_mode: ?bool = null,
     preference_settings_error: ?anyerror = null,
@@ -1824,6 +1825,7 @@ const FakeApp = struct {
         patch: app_session_runtime.SessionPreferencePatch,
     ) app_session_runtime.PreferenceCommitResult {
         self.preference_commit_count += 1;
+        self.last_preference_provider = patch.provider;
         self.last_preference_model.clearRetainingCapacity();
         if (patch.model) |model| {
             self.last_preference_model.appendSlice(self.alloc, model) catch
@@ -1834,11 +1836,7 @@ const FakeApp = struct {
         if (self.preference_settings_error == null) {
             const attempt = config_runtime.attemptUserPreferences(
                 self.alloc,
-                .{
-                    .model = patch.model,
-                    .effort = patch.effort,
-                    .fast_mode = patch.fast_mode,
-                },
+                patch.userSettingsPatch(),
             );
             return switch (attempt) {
                 .outcome => |outcome| .{
@@ -2208,11 +2206,13 @@ test "session_commands handleModel resolves fuzzy cached model and syncs queued 
     var app = try FakeApp.init(alloc, "/tmp/workspace", "openai/gpt-4o");
     defer app.deinit();
     app.cached_ids = &ids;
+    app.selected_provider = .codex;
 
     try Commands(FakeApp).handleModel(&app, "claude sonnet");
 
     try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", app.selected_model.items);
     try std.testing.expectEqualStrings("anthropic/claude-sonnet-4-20250514", app.worker.synced_model.?);
+    try std.testing.expectEqual(model_provider.ProviderId.codex, app.last_preference_provider.?);
     try std.testing.expectEqualStrings(
         "workspace · anthropic/claude-sonnet-4-20250514",
         app.terminalTitleLabelText(),
@@ -2844,6 +2844,7 @@ test "session_commands model picker emits one combined preference transaction" {
         "anthropic/claude-opus-4.7",
     );
     defer app.deinit();
+    app.selected_provider = .codex;
     const efforts = [_]types.ReasoningEffort{types.ReasoningEffort.literal("high")};
     app.setGatewayControls("anthropic/claude-opus-4.7", &efforts, true);
 
@@ -2855,6 +2856,7 @@ test "session_commands model picker emits one combined preference transaction" {
     );
 
     try std.testing.expectEqual(@as(usize, 1), app.preference_commit_count);
+    try std.testing.expectEqual(model_provider.ProviderId.codex, app.last_preference_provider.?);
     try std.testing.expectEqualStrings(
         "anthropic/claude-opus-4.7",
         app.last_preference_model.items,

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1552,6 +1552,7 @@ pub const BackendKind = enum {
 pub const ToolChoice = enum {
     auto,
     none,
+    required,
 
     pub fn label(self: ToolChoice) []const u8 {
         return @tagName(self);

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const agent_runtime = @import("../agent/agent_runtime.zig");
+const stream_provider = @import("../agent/stream_provider.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
 const credentials = @import("../auth/credentials.zig");
@@ -30,9 +31,57 @@ const tool_host = @import("tool_host.zig");
 
 const Allocator = std.mem.Allocator;
 
+pub const ProviderRoute = struct {
+    agent_stream_provider: stream_provider.Provider,
+    permission_reviewer_provider: ?auto_classifier.Provider,
+};
+
+pub const ProviderRoutes = struct {
+    gateway: ProviderRoute,
+    codex: ProviderRoute,
+
+    pub fn select(self: ProviderRoutes, provider: model_provider.ProviderId) ProviderRoute {
+        return switch (provider) {
+            .gateway => self.gateway,
+            .codex => self.codex,
+        };
+    }
+};
+
+test "provider routes select independent streams and reviewers" {
+    var gateway_tag: u8 = 0;
+    var codex_tag: u8 = 0;
+    var gateway_stream = stream_provider.unavailable_provider;
+    gateway_stream.context = &gateway_tag;
+    var codex_stream = stream_provider.unavailable_provider;
+    codex_stream.context = &codex_tag;
+    const Reviewer = struct {
+        fn review(
+            _: ?*anyopaque,
+            _: Allocator,
+            _: auto_classifier.ProviderInput,
+            _: auto_classifier.ReviewRequest,
+        ) anyerror!auto_classifier.ParseOutcome {
+            return .invalid;
+        }
+    };
+    const gateway_reviewer = auto_classifier.Provider{ .context = &gateway_tag, .review_fn = Reviewer.review };
+    const codex_reviewer = auto_classifier.Provider{ .context = &codex_tag, .review_fn = Reviewer.review };
+    const routes = ProviderRoutes{
+        .gateway = .{ .agent_stream_provider = gateway_stream, .permission_reviewer_provider = gateway_reviewer },
+        .codex = .{ .agent_stream_provider = codex_stream, .permission_reviewer_provider = codex_reviewer },
+    };
+
+    try std.testing.expect(routes.select(.gateway).agent_stream_provider.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
+    try std.testing.expect(routes.select(.gateway).permission_reviewer_provider.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
+    try std.testing.expect(routes.select(.codex).agent_stream_provider.context.? == @as(*anyopaque, @ptrCast(&codex_tag)));
+    try std.testing.expect(routes.select(.codex).permission_reviewer_provider.?.context.? == @as(*anyopaque, @ptrCast(&codex_tag)));
+}
+
 pub const Config = struct {
     host: *tool_host.Runtime,
     tool_context: tool_runtime.Context,
+    provider_routes: ProviderRoutes,
     system_prompt: []const u8,
     model_prompt_overlay: ?[]const u8 = null,
     skills_prompt_section: []const u8 = "",
@@ -126,6 +175,10 @@ pub fn run(
     var routed_credential: ?credentials.Credential = null;
     defer if (routed_credential) |*credential| credential.deinit(turn.alloc);
     var routed_config = config;
+    const route = config.provider_routes.select(admission.provider);
+    routed_config.tool_context.agent_stream_provider = route.agent_stream_provider;
+    routed_config.tool_context.permission_reviewer_provider = route.permission_reviewer_provider;
+    routed_config.tool_context.auto_classifier = auto_classifier.Classifier.disabled();
     if (!model_provider.authorizesCredential(
         admission.provider,
         config.tool_context.credential_source,
@@ -157,8 +210,6 @@ pub fn run(
     routed_config.tool_context.model = admission.model;
     routed_config.tool_context.provider = admission.provider;
     if (!model_provider.usesGatewayAuxiliaries(admission.provider)) {
-        routed_config.tool_context.permission_reviewer_provider = null;
-        routed_config.tool_context.auto_classifier = auto_classifier.Classifier.disabled();
         routed_config.tool_context.web_search_backend = null;
         routed_config.tool_context.web_search_runtime_ready = false;
     }

--- a/src/core/subagent/execution.zig
+++ b/src/core/subagent/execution.zig
@@ -67,6 +67,26 @@ pub fn resolveTurnPreferences(
     };
 }
 
+test "turn preference overrides preserve the persisted provider" {
+    var command = try domain.validateCommand(std.testing.allocator, .{ .create = .{
+        .name = "child",
+        .mode = .persistent,
+        .model = "gpt-5.4-mini",
+    } });
+    defer command.deinit(std.testing.allocator);
+    const preferences = resolveTurnPreferences(
+        command.create.configuration,
+        .{
+            .provider = .codex,
+            .model = @constCast("gpt-5.6-sol"),
+            .effort = types.ReasoningEffort.literal("high"),
+            .fast_mode = false,
+        },
+    );
+    try std.testing.expectEqual(model_provider.ProviderId.codex, preferences.provider);
+    try std.testing.expectEqualStrings("gpt-5.4-mini", preferences.model);
+}
+
 pub const WorkOutcome = enum {
     completed,
     failed,
@@ -2781,7 +2801,8 @@ fn runOne(slot: *Slot) OneResult {
         return .admission_failed;
     };
     defer admission.deinit(owner.alloc);
-    if (admission.permission_mode != record.configuration.permission_mode or
+    if (admission.provider != preferences.provider or
+        admission.permission_mode != record.configuration.permission_mode or
         !std.mem.eql(u8, admission.parent_id, parent_id) or
         !std.mem.eql(u8, admission.source_id, record.queue[index].source_id) or
         !std.mem.eql(u8, admission.model, preferences.model) or

--- a/src/core/subagent/tool_host.zig
+++ b/src/core/subagent/tool_host.zig
@@ -21,6 +21,7 @@ const session_codec = @import("../session/session_codec.zig");
 const session_store = @import("../session/session_store.zig");
 const mcp_access = @import("../mcp/access_policy.zig");
 const mode_registry = @import("../modes/mode_registry.zig");
+const model_provider = @import("../config/model_provider.zig");
 const permissions = @import("../permissions/permissions.zig");
 const session_permission_state = @import("../permissions/session_permission_state.zig");
 const tool_dispatch = @import("../tooling/tool_dispatch.zig");
@@ -103,6 +104,7 @@ fn recoveryStateAfterFinish(outcome: RecoveryFinishOutcome) RecoveryState {
 pub const BackgroundRecoveryError = error{ThreadSpawnFailed};
 
 pub const Defaults = struct {
+    provider: model_provider.ProviderId,
     model: []const u8,
     effort: types.ReasoningEffort,
     fast_mode: bool = false,
@@ -2175,6 +2177,7 @@ fn freshChildState(
         .updated_at_ms = now,
         .conversation_language = defaults.conversation_language,
         .preferences = .{
+            .provider = defaults.provider,
             .model = model,
             .effort = create.configuration.effort orelse defaults.effort,
             .fast_mode = defaults.fast_mode,
@@ -2183,6 +2186,31 @@ fn freshChildState(
         .total_input_tokens = 0,
         .total_output_tokens = 0,
     };
+}
+
+test "fresh child state persists its provider with the model" {
+    const alloc = std.testing.allocator;
+    var command = try domain.validateCommand(alloc, .{ .create = .{
+        .name = "codex-child",
+        .mode = .persistent,
+    } });
+    defer command.deinit(alloc);
+    var state = try freshChildState(
+        alloc,
+        "01J00000000000000000000000",
+        "/tmp/workspace",
+        command.create,
+        .{
+            .provider = .codex,
+            .model = "gpt-5.6-sol",
+            .effort = types.ReasoningEffort.literal("high"),
+            .conversation_language = session.ConversationLanguage.literal("en"),
+        },
+    );
+    defer state.deinit(alloc);
+
+    try std.testing.expectEqual(model_provider.ProviderId.codex, state.preferences.provider);
+    try std.testing.expectEqualStrings("gpt-5.6-sol", state.preferences.model);
 }
 
 fn reservationWasCommitted(
@@ -2915,6 +2943,7 @@ fn testOptions(caller_id: []const u8, invocation_id: []const u8) ExecuteOptions 
         .caller_id = caller_id,
         .invocation_id = invocation_id,
         .defaults = .{
+            .provider = .gateway,
             .model = "test/model",
             .effort = types.ReasoningEffort.literal("high"),
             .conversation_language = session.ConversationLanguage.literal("en"),
@@ -2928,6 +2957,7 @@ fn testHumanOptions(invocation_id: []const u8) HumanCommandOptions {
     return .{
         .invocation_id = invocation_id,
         .defaults = .{
+            .provider = .gateway,
             .model = "test/model",
             .effort = types.ReasoningEffort.literal("high"),
             .conversation_language = session.ConversationLanguage.literal("en"),

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -15,7 +15,6 @@ const image_attachments = @import("../images/image_attachments.zig");
 const io_mod = @import("../shared/io.zig");
 const tool_contracts = @import("../agent/runtime/tool_contracts.zig");
 const vision_executor = @import("../agent/runtime/vision_executor.zig");
-const image_provider = @import("../agent/runtime/image_provider.zig");
 const background_runtime = @import("../background/background_runtime.zig");
 const background_launch_identity = @import("../background/background_launch_identity.zig");
 const process_supervisor = @import("../background/process_supervisor.zig");
@@ -304,7 +303,15 @@ fn registeredToolSpec(ctx: Context, name: []const u8) ?*const tool_specs.ToolSpe
     return ctx.tool_registry.lookup(name);
 }
 
+fn providerDisablesTool(provider: model_provider.ProviderId, name: []const u8) bool {
+    return std.mem.eql(u8, name, "vision") and
+        !model_provider.usesGatewayAuxiliaries(provider);
+}
+
 pub fn validateToolCall(ctx: Context, arena: Allocator, call: ToolCall) !tool_contracts.ToolCallValidationResult {
+    if (providerDisablesTool(ctx.provider, call.name)) {
+        return .{ .failure = try arena.dupe(u8, "Unsupported tool: vision") };
+    }
     const spec = registeredToolSpec(ctx, call.name) orelse {
         return switch (try tool_mcp_runtime.validateAdvertisedDynamicTool(.{
             .is_registered_tool = false,
@@ -334,6 +341,9 @@ pub fn validateToolCall(ctx: Context, arena: Allocator, call: ToolCall) !tool_co
 }
 
 pub fn checkToolAvailability(ctx: Context, arena: Allocator, call: ToolCall) !?[]const u8 {
+    if (providerDisablesTool(ctx.provider, call.name)) {
+        return try arena.dupe(u8, "Unsupported tool: vision");
+    }
     return tool_dispatch.localToolAvailabilityFailureForCall(
         typedDispatchContext(ctx, arena),
         ctx.tool_registry,
@@ -999,7 +1009,6 @@ fn executeVisionRequest(
     authority: command_admission.ToolExecutionAuthority,
 ) !ToolExecutionResult {
     const config: vision_executor.Config = .{
-        .model = imageAdapterModel(state.runtime.provider, state.runtime.model),
         .stream_provider = state.runtime.agent_stream_provider,
         .api_key = state.runtime.api_key,
         .credential_source = state.runtime.credential_source,
@@ -1030,24 +1039,6 @@ fn executeVisionRequest(
     const raw_paths = request.paths() orelse return error.InvalidVisionExecutionAuthority;
     if (raw_paths.len != approved_targets.len) return error.InvalidVisionExecutionAuthority;
     return executeVisionPathRequest(state, alloc, request, approved_targets, config);
-}
-
-fn imageAdapterModel(provider: model_provider.ProviderId, active_model: []const u8) []const u8 {
-    return switch (provider) {
-        .gateway => image_provider.default_model,
-        .codex => active_model,
-    };
-}
-
-test "Codex vision fallback stays on the admitted Codex model" {
-    try std.testing.expectEqualStrings(
-        "gpt-5.4-mini",
-        imageAdapterModel(.codex, "gpt-5.4-mini"),
-    );
-    try std.testing.expectEqualStrings(
-        image_provider.default_model,
-        imageAdapterModel(.gateway, "zai/glm-5.2"),
-    );
 }
 
 fn executeVisionPathRequest(
@@ -2145,6 +2136,7 @@ const TestRuntime = struct {
     max_command_output_bytes: usize = 64 * 1024,
     max_tool_result_bytes: usize = 64 * 1024,
     api_key: []const u8 = "",
+    provider: model_provider.ProviderId = .gateway,
     gateway_team: ?[]const u8 = null,
     gateway_retry_count: usize = 0,
     gateway_chat_url: []const u8 = "",
@@ -2194,6 +2186,7 @@ const TestRuntime = struct {
             .api_key = self.api_key,
             .agent_stream_provider = self.agent_stream_provider,
             .gateway_team = self.gateway_team,
+            .provider = self.provider,
             .model = self.model,
             .gateway_retry_count = self.gateway_retry_count,
             .gateway_chat_url = self.gateway_chat_url,
@@ -8548,6 +8541,35 @@ fn executeVisionPathTargetsForTest(
         .advertised_dynamic_tool_names = &.{},
         .max_tool_result_bytes = rt.max_tool_result_bytes,
     });
+}
+
+test "Codex vision calls fail before provider access" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const catalog = try makeVisionCatalog(alloc, tmp.dir, 1);
+    defer types.freeImageAttachmentSlice(alloc, catalog);
+    const provider_json = try visionProviderSuccess(alloc, &.{1});
+    defer alloc.free(provider_json);
+    const responses = [_]VisionGatewayResponse{.{ .content = provider_json }};
+    var fixture = VisionGatewayFixture{ .alloc = alloc, .responses = &responses };
+    defer fixture.deinit();
+    var rt = TestRuntime{
+        .provider = .codex,
+        .agent_stream_provider = fixture.provider(),
+        .tool_registry = .{ .tools = vision_test_registry_tools[0..] },
+        .session_allocator = alloc,
+    };
+    defer rt.deinit(alloc);
+    const args = try visionArgs(alloc, &.{1}, "Read the image");
+    defer alloc.free(args);
+
+    const result = try executeVisionForTest(&rt, alloc, args, catalog);
+    defer alloc.free(@constCast(result.model_output));
+
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
+    try std.testing.expectEqualStrings("Unsupported tool: vision", result.model_output);
+    try std.testing.expectEqual(@as(usize, 0), fixture.call_count);
 }
 
 fn visionRequestAllocationCount(args_json: []const u8) !usize {

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -15,6 +15,7 @@ const image_attachments = @import("../images/image_attachments.zig");
 const io_mod = @import("../shared/io.zig");
 const tool_contracts = @import("../agent/runtime/tool_contracts.zig");
 const vision_executor = @import("../agent/runtime/vision_executor.zig");
+const image_provider = @import("../agent/runtime/image_provider.zig");
 const background_runtime = @import("../background/background_runtime.zig");
 const background_launch_identity = @import("../background/background_launch_identity.zig");
 const process_supervisor = @import("../background/process_supervisor.zig");
@@ -998,6 +999,7 @@ fn executeVisionRequest(
     authority: command_admission.ToolExecutionAuthority,
 ) !ToolExecutionResult {
     const config: vision_executor.Config = .{
+        .model = imageAdapterModel(state.runtime.provider, state.runtime.model),
         .stream_provider = state.runtime.agent_stream_provider,
         .api_key = state.runtime.api_key,
         .credential_source = state.runtime.credential_source,
@@ -1028,6 +1030,24 @@ fn executeVisionRequest(
     const raw_paths = request.paths() orelse return error.InvalidVisionExecutionAuthority;
     if (raw_paths.len != approved_targets.len) return error.InvalidVisionExecutionAuthority;
     return executeVisionPathRequest(state, alloc, request, approved_targets, config);
+}
+
+fn imageAdapterModel(provider: model_provider.ProviderId, active_model: []const u8) []const u8 {
+    return switch (provider) {
+        .gateway => image_provider.default_model,
+        .codex => active_model,
+    };
+}
+
+test "Codex vision fallback stays on the admitted Codex model" {
+    try std.testing.expectEqualStrings(
+        "gpt-5.4-mini",
+        imageAdapterModel(.codex, "gpt-5.4-mini"),
+    );
+    try std.testing.expectEqualStrings(
+        image_provider.default_model,
+        imageAdapterModel(.gateway, "zai/glm-5.2"),
+    );
 }
 
 fn executeVisionPathRequest(
@@ -1739,6 +1759,7 @@ fn executeSubagentProvider(
         .root_user_messages = ctx.root_user_messages,
         .root_user_evidence_complete = ctx.root_user_evidence_complete,
         .defaults = .{
+            .provider = ctx.provider,
             .model = ctx.model,
             .effort = ctx.effort,
             .fast_mode = ctx.fast_mode,

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -61,7 +61,7 @@ pub fn buildRequest(
     try writeInput(writer, alloc, request.messages, request.verified_images);
     try writer.writeByte(']');
 
-    const tool_count = try writeTools(writer, alloc, request.serialized_tools, request.selected_dynamic_tool_schemas);
+    _ = try writeTools(writer, alloc, request.serialized_tools, request.selected_dynamic_tool_schemas);
     try writer.writeAll(",\"tool_choice\":");
     try std.json.Stringify.value(request.tool_choice.label(), .{}, writer);
     try writer.writeAll(",\"parallel_tool_calls\":true,\"include\":[\"reasoning.encrypted_content\"]");
@@ -92,10 +92,6 @@ pub fn buildRequest(
     }
     // The ChatGPT Codex endpoint chooses the model's output limit and rejects
     // the public Responses API max_output_tokens parameter.
-    if (tool_count == 0 and request.tool_choice == .none) {
-        // Explicitly keeping the empty tool set out of the request avoids a
-        // backend validation difference between no tools and `tools: []`.
-    }
     try writer.writeByte('}');
     return out.toOwnedSlice();
 }

--- a/src/gateway/openai_codex_permission_reviewer.zig
+++ b/src/gateway/openai_codex_permission_reviewer.zig
@@ -67,7 +67,7 @@ fn buildReviewPayload(
         .model = model,
         .serialized_tools = tools_json,
         .messages = expanded,
-        .tool_choice = .auto,
+        .tool_choice = .required,
         .provider_options = .{},
         .max_output_tokens = 2048,
         .budget = .{ .deadline = deadline, .cancel_flag = cancel_flag },
@@ -199,6 +199,7 @@ test "Codex reviewer builds a direct Responses request with gpt-5.4-mini" {
     defer std.testing.allocator.free(body);
 
     try std.testing.expect(std.mem.find(u8, body, "\"model\":\"gpt-5.4-mini\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_choice\":\"required\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"type\":\"function_call_output\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "ai-gateway") == null);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -83,6 +83,7 @@ const hooks = @import("core/hooks/hooks.zig");
 const github_publish = @import("core/github/github_publish.zig");
 const subagent_domain = @import("core/subagent/domain.zig");
 const subagent_execution = @import("core/subagent/execution.zig");
+const subagent_agent_adapter = @import("core/subagent/agent_adapter.zig");
 const types = @import("core/shared/types.zig");
 const image_attachments = @import("core/images/image_attachments.zig");
 const permissions = @import("core/permissions/permissions.zig");
@@ -435,10 +436,9 @@ const App = struct {
     }
 
     pub fn agentStreamProvider(self: *const Self) agent_stream_provider.Provider {
-        return if (comptime host_target.is_wasm)
-            js_host_stream_provider.provider()
-        else
-            builtin_providers.agentStream(self.provider_selection.selection().provider);
+        return self.subagentProviderRoutes()
+            .select(self.provider_selection.selection().provider)
+            .agent_stream_provider;
     }
 
     pub fn fetchProviderCatalog(
@@ -1583,10 +1583,33 @@ const App = struct {
     }
 
     pub fn permissionReviewerProvider(self: *const App) ?permission_auto_classifier.Provider {
-        if (comptime !host_profile.tools) return null;
-        return switch (self.provider_selection.selection().provider) {
-            .gateway => builtin_gateway.permission_reviewer.provider,
-            .codex => openai_codex_permission_reviewer.provider,
+        return self.subagentProviderRoutes()
+            .select(self.provider_selection.selection().provider)
+            .permission_reviewer_provider;
+    }
+
+    pub fn subagentProviderRoutes(_: *const App) subagent_agent_adapter.ProviderRoutes {
+        return .{
+            .gateway = .{
+                .agent_stream_provider = if (comptime host_target.is_wasm)
+                    js_host_stream_provider.provider()
+                else
+                    builtin_providers.agentStream(.gateway),
+                .permission_reviewer_provider = if (comptime host_profile.tools)
+                    builtin_gateway.permission_reviewer.provider
+                else
+                    null,
+            },
+            .codex = .{
+                .agent_stream_provider = if (comptime host_target.is_wasm)
+                    agent_stream_provider.unavailable_provider
+                else
+                    builtin_providers.agentStream(.codex),
+                .permission_reviewer_provider = if (comptime host_profile.tools and !host_target.is_wasm)
+                    openai_codex_permission_reviewer.provider
+                else
+                    null,
+            },
         };
     }
 

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -519,11 +519,14 @@ function writeSeededFxAuth(home: string, teamId?: string): void {
   chmodSync(authPath, 0o600);
 }
 
-function acpChatGptAccessToken(accountId = "acct_acp_e2e"): string {
+function acpChatGptAccessToken(
+  accountId = "acct_acp_e2e",
+  signature = "signature",
+): string {
   const payload = Buffer.from(JSON.stringify({
     "https://api.openai.com/auth": { chatgpt_account_id: accountId },
   })).toString("base64url");
-  return `header.${payload}.signature`;
+  return `header.${payload}.${signature}`;
 }
 
 function writeSeededAcpChatGptLogin(home: string, accessToken: string): void {
@@ -541,14 +544,50 @@ function writeSeededAcpChatGptLogin(home: string, accessToken: string): void {
   chmodSync(authPath, 0o600);
 }
 
-function startAcpFakeCodex() {
-  const accessToken = acpChatGptAccessToken();
-  const requests: Array<{ path: string; authorization: string | null }> = [];
+function codexFinalText(text: string): string {
+  return `data: ${JSON.stringify({ type: "response.output_text.delta", delta: text })}\n\n` +
+    'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":2}}}\n\n';
+}
+
+function codexToolCall(callId: string, name: string, args: object): string {
+  return `data: ${JSON.stringify({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { type: "function_call", call_id: callId, name },
+  })}\n\n` +
+    `data: ${JSON.stringify({
+      type: "response.function_call_arguments.done",
+      output_index: 0,
+      arguments: JSON.stringify(args),
+    })}\n\n` +
+    'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":2}}}\n\n';
+}
+
+function codexLatestToolResult(body: string): { callId: string; output: string } | null {
+  const request = JSON.parse(body) as {
+    input?: Array<{ type?: string; call_id?: string; output?: string }>;
+  };
+  const result = request.input?.at(-1);
+  if (result?.type !== "function_call_output" || !result.call_id || !result.output) {
+    return null;
+  }
+  return { callId: result.call_id, output: result.output };
+}
+
+function startAcpFakeCodex(options: {
+  unauthorizedResponses?: number;
+  route?: (body: string) => string | Promise<string>;
+} = {}) {
+  const accessToken = acpChatGptAccessToken("acct_acp_e2e", "stale");
+  const refreshedAccessToken = acpChatGptAccessToken("acct_acp_e2e", "fresh");
+  const requests: Array<{ path: string; authorization: string | null; body: string }> = [];
   const modelRequests: Array<{ path: string; authorization: string | null }> = [];
+  const tokenRequests: Array<{ path: string; authorization: string | null }> = [];
+  let unauthorizedResponses = options.unauthorizedResponses ?? 0;
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
-    fetch(request) {
+    async fetch(request) {
       const path = new URL(request.url).pathname;
       const recorded = { path, authorization: request.headers.get("authorization") };
       if (path === "/models") {
@@ -558,20 +597,35 @@ function startAcpFakeCodex() {
           { slug: "gpt-5.4-mini", visibility: "list", supported_in_api: true, supported_reasoning_levels: [{ effort: "low" }], additional_speed_tiers: [], input_modalities: ["text"], context_window: 128000 },
         ] });
       }
-      requests.push(recorded);
+      if (path === "/token") {
+        tokenRequests.push(recorded);
+        return Response.json({
+          access_token: refreshedAccessToken,
+          refresh_token: "chatgpt-refresh-next",
+          expires_in: 3600,
+        });
+      }
+      const body = await request.text();
+      requests.push({ ...recorded, body });
+      if (unauthorizedResponses > 0) {
+        unauthorizedResponses -= 1;
+        return Response.json({ error: { message: "expired" } }, { status: 401 });
+      }
       return new Response(
-        'data: {"type":"response.output_text.delta","delta":"ACP_CHATGPT_RESPONSE"}\n\n' +
-          'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":2}}}\n\n',
+        options.route ? await options.route(body) : codexFinalText("ACP_CHATGPT_RESPONSE"),
         { headers: { "content-type": "text/event-stream" } },
       );
     },
   });
   return {
     accessToken,
+    refreshedAccessToken,
     requests,
     modelRequests,
+    tokenRequests,
     responsesUrl: `http://127.0.0.1:${server.port}/responses`,
     modelsUrl: `http://127.0.0.1:${server.port}/models`,
+    tokenUrl: `http://127.0.0.1:${server.port}/token`,
     stop() { server.stop(true); },
   };
 }
@@ -6790,6 +6844,140 @@ describe("acp: model-independent", () => {
 
 
   test(
+    "ACP persistent Codex children retain their provider across messages",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-codex-subagent-");
+      const gateway = startFakeGateway([]);
+      const childFirstPrompt = "CODEX_CHILD_FIRST_TURN";
+      const childSecondPrompt = "CODEX_CHILD_SECOND_TURN";
+      let childId = "";
+      const codex = startAcpFakeCodex({
+        route(body) {
+          const toolResult = codexLatestToolResult(body);
+          if (toolResult?.callId === "codex_child_resume") {
+            return codexFinalText("CODEX_PARENT_RESUMED_CHILD");
+          }
+          if (toolResult?.callId === "codex_child_message") {
+            if (!childId) throw new Error("Codex child id was not captured");
+            return codexToolCall("codex_child_resume", "subagent", {
+              command: {
+                lifecycle: { id: childId, action: "resume" },
+              },
+            });
+          }
+          if (toolResult?.callId === "codex_child_create") {
+            const created = JSON.parse(toolResult.output) as {
+              child_id: string;
+              status: string;
+            };
+            expect(created.status).toBe("created");
+            childId = created.child_id;
+            return codexFinalText("CODEX_PARENT_CREATED_CHILD");
+          }
+          if (body.includes("Send the persistent Codex child another message.")) {
+            if (!childId) throw new Error("Codex child id was not captured");
+            return codexToolCall("codex_child_message", "subagent", {
+              command: {
+                message: {
+                  send: { id: childId, content: childSecondPrompt },
+                },
+              },
+            });
+          }
+          if (body.includes(childSecondPrompt)) {
+            return codexFinalText("CODEX_CHILD_SECOND_DONE");
+          }
+          if (body.includes(childFirstPrompt)) {
+            return codexFinalText("CODEX_CHILD_FIRST_DONE");
+          }
+          return codexToolCall("codex_child_create", "subagent", {
+            command: { create: {
+              name: "codex-persistent-child",
+              mode: "persistent",
+              prompt: childFirstPrompt,
+            } },
+          });
+        },
+      });
+      writeSeededAcpChatGptLogin(root.home, codex.accessToken);
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            ...fakeGatewayEnv(root, gateway),
+            FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
+            FX_E2E_OPENAI_CODEX_MODELS_URL: codex.modelsUrl,
+          },
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+        await client.request("session/new", { mcpServers: [] }, 2);
+        await client.readLine();
+        await client.request("session/set_mode", { modeId: "code" }, 3);
+        const changed = await client.request("session/set_config_option", {
+          configId: "provider",
+          value: "codex",
+        }, 4) as any;
+        expect(changed.result.configOptions.find((option: any) => option.id === "provider").currentValue)
+          .toBe("codex");
+
+        const first = await runPrompt(client, "Create a persistent Codex child.", TIMEOUT);
+        expect(first.promptResult.result.stopReason).toBe("end_turn");
+        await waitForCondition(
+          "first Codex child turn",
+          () => childId.length > 0 &&
+            codex.requests.some((request) => request.body.includes(childFirstPrompt)),
+          TIMEOUT,
+        );
+        await waitForCondition(
+          "first Codex child idle state",
+          () => acpSubagentState(root, childId) === "idle",
+          TIMEOUT,
+        );
+        const childState = JSON.parse(
+          readFileSync(
+            join(root.home, ".fx", "sessions", childId, "session.json"),
+            "utf8",
+          ),
+        ) as { preferences: { provider: string; model: string } };
+        expect(childState.preferences.provider).toBe("codex");
+        expect(childState.preferences.model).toBe("gpt-5.6-sol");
+
+        const second = await runPrompt(
+          client,
+          "Send the persistent Codex child another message.",
+          TIMEOUT,
+        );
+        expect(second.promptResult.result.stopReason).toBe("end_turn");
+        await waitForCondition(
+          "second Codex child turn",
+          () => codex.requests.some((request) => request.body.includes(childSecondPrompt)),
+          TIMEOUT,
+        );
+        await waitForCondition(
+          "second Codex child idle state",
+          () => acpSubagentState(root, childId) === "idle",
+          TIMEOUT,
+        );
+        expect(codex.requests.length).toBeGreaterThanOrEqual(7);
+        for (const request of codex.requests) {
+          expect(request.authorization).toBe(`Bearer ${codex.accessToken}`);
+          expect(JSON.parse(request.body).model).toBe("gpt-5.6-sol");
+        }
+        for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+          expect(request.headers.get("authorization")).not.toBe(`Bearer ${codex.accessToken}`);
+        }
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        codex.stop();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "stdin shutdown cancels a pending permission request",
     async () => {
       const root = createIsolatedRoot("fx-acp-permission-shutdown-");
@@ -7154,7 +7342,7 @@ describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {
     async () => {
       const root = createIsolatedRoot("fx-acp-chatgpt-route-");
       const gateway = startFakeGateway([]);
-      const codex = startAcpFakeCodex();
+      const codex = startAcpFakeCodex({ unauthorizedResponses: 1 });
       writeSeededAcpChatGptLogin(root.home, codex.accessToken);
       try {
         client = await AcpClient.create({
@@ -7163,6 +7351,7 @@ describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {
             ...fakeGatewayEnv(root, gateway),
             FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
             FX_E2E_OPENAI_CODEX_MODELS_URL: codex.modelsUrl,
+            FX_E2E_CHATGPT_TOKEN_URL: codex.tokenUrl,
           },
         });
         await client.request("initialize", { protocolVersion: 1 }, 1);
@@ -7181,9 +7370,14 @@ describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {
         const prompt = await runPrompt(client, "Answer directly.", TIMEOUT);
         expect(prompt.promptResult.result.stopReason).toBe("end_turn");
         expect(JSON.stringify(prompt.messages)).toContain("ACP_CHATGPT_RESPONSE");
-        expect(codex.requests).toHaveLength(1);
+        const secondPrompt = await runPrompt(client, "Answer again.", TIMEOUT);
+        expect(secondPrompt.promptResult.result.stopReason).toBe("end_turn");
+        expect(codex.requests).toHaveLength(3);
         expect(codex.modelRequests).toHaveLength(1);
         expect(codex.requests[0]!.authorization).toBe(`Bearer ${codex.accessToken}`);
+        expect(codex.requests[1]!.authorization).toBe(`Bearer ${codex.refreshedAccessToken}`);
+        expect(codex.requests[2]!.authorization).toBe(`Bearer ${codex.refreshedAccessToken}`);
+        expect(codex.tokenRequests).toHaveLength(1);
         for (const request of [...gateway.requests, ...gateway.modelRequests]) {
           expect(request.headers.get("authorization")).not.toBe(`Bearer ${codex.accessToken}`);
         }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -3257,7 +3257,6 @@ describe("cli: models", () => {
             more_count: 0,
             private_models_hidden: true,
             ids: ["public/fallback"],
-            models: [{ id: "public/fallback", source: "Vercel AI Gateway" }],
           });
 
           expect(gateway.modelRequests).toHaveLength(2);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -665,6 +665,8 @@ tmuxTest(
       },
     );
     await session.waitForComposer(TIMEOUT);
+    await session.sendText("/model openai/gpt-5.6-sol");
+    await session.waitForText("Switched to openai/gpt-5.6-sol", TIMEOUT);
     await session.sendText("/provider");
     await session.waitForText("Switch provider", TIMEOUT);
     await session.sendKeys("Down");
@@ -740,10 +742,45 @@ tmuxTest(
     const authorizeRequestsBeforeRoundTrip = chatgptOauth.requests.filter(
       (request) => request.path === "/oauth/authorize",
     ).length;
+    const settingsPath = join(home, ".fx", "settings.json");
+    const gatewayModelBefore = JSON.parse(readFileSync(settingsPath, "utf8")).model;
+    expect(typeof gatewayModelBefore).toBe("string");
+    await session.sendLiteralText("/model gpt-5.4-mini low");
+    await session.sendKeys("Enter");
+    await session.waitForText("Switched to gpt-5.4-mini", TIMEOUT);
+    const savedCodex = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(savedCodex.model).toBe(gatewayModelBefore);
+    expect(savedCodex.codex_model).toBe("gpt-5.4-mini");
+    await session.sendText("/quit");
+    await session.waitForSessionEnd(TIMEOUT);
+    session = null;
+
+    session = await startFx(
+      home,
+      stderrPath,
+      gateway,
+      undefined,
+      undefined,
+      {
+        ...chatgptOauth.env,
+        FX_MODEL: undefined,
+      },
+    );
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/status");
+    await session.waitForText("model=gpt-5.4-mini", TIMEOUT);
     await session.sendText("/provider gateway");
     await session.waitForText("Switched to Vercel AI Gateway", TIMEOUT);
+    const savedGateway = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(savedGateway.provider).toBe("gateway");
+    expect(savedGateway.model).toBe(gatewayModelBefore);
+    expect(savedGateway.codex_model).toBe("gpt-5.4-mini");
     await session.sendText("/provider codex");
     await session.waitForText("Switched to Codex subscription", TIMEOUT);
+    const restoredCodex = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(restoredCodex.provider).toBe("codex");
+    expect(restoredCodex.model).toBe(gatewayModelBefore);
+    expect(restoredCodex.codex_model).toBe("gpt-5.4-mini");
     expect(chatgptOauth.requests.filter((request) => request.path === "/oauth/authorize"))
       .toHaveLength(authorizeRequestsBeforeRoundTrip);
     await session.sendText("/logout codex");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -469,9 +469,16 @@ async function runCodexLoginWithBrowser(
   return { code, stdout, stderr };
 }
 
-function startFakeCodexToolLoop() {
+function startFakeCodexToolLoop(options: {
+  toolName?: string;
+  toolArguments?: object;
+  finalText?: string;
+} = {}) {
   const bodies: string[] = [];
   const accessToken = chatgptAccessToken("acct_tool_loop");
+  const toolName = options.toolName ?? "read_file";
+  const toolArguments = options.toolArguments ?? { path: "README.md" };
+  const finalText = options.finalText ?? "CODEX_TOOL_LOOP_OK";
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
@@ -487,14 +494,14 @@ function startFakeCodexToolLoop() {
         return new Response(
           'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}\n\n' +
             'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_tool","type":"reasoning","summary":[],"encrypted_content":"opaque-tool-loop"}}\n\n' +
-            'data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","call_id":"call_read","name":"read_file"}}\n\n' +
-            'data: {"type":"response.function_call_arguments.done","output_index":1,"arguments":"{\\"path\\":\\"README.md\\"}"}\n\n' +
+            `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 1, item: { type: "function_call", call_id: "call_tool", name: toolName } })}\n\n` +
+            `data: ${JSON.stringify({ type: "response.function_call_arguments.done", output_index: 1, arguments: JSON.stringify(toolArguments) })}\n\n` +
             'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}\n\n',
           { headers: { "content-type": "text/event-stream" } },
         );
       }
       return new Response(
-        'data: {"type":"response.output_text.delta","delta":"CODEX_TOOL_LOOP_OK"}\n\n' +
+        `data: ${JSON.stringify({ type: "response.output_text.delta", delta: finalText })}\n\n` +
           'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":7,"output_tokens":3}}}\n\n',
         { headers: { "content-type": "text/event-stream" } },
       );
@@ -1604,6 +1611,62 @@ test(
       expect(codex.bodies).toHaveLength(2);
       expect(codex.bodies[1]).toContain('"encrypted_content":"opaque-tool-loop"');
       expect(codex.bodies[1]).toContain('"type":"function_call_output"');
+      for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+        expect(request.headers.get("authorization")).not.toBe(`Bearer ${codex.accessToken}`);
+      }
+    } finally {
+      codex.stop();
+    }
+  },
+  60_000,
+);
+
+test(
+  "Codex rejects the vision fallback without another provider request",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-codex-vision-disabled-"));
+    gateway = startFakeGateway([]);
+    const codex = startFakeCodexToolLoop({
+      toolName: "vision",
+      toolArguments: { image_ids: [1], focus: "Inspect the image." },
+      finalText: "CODEX_VISION_DISABLED_OK",
+    });
+    try {
+      writeSeededChatGptLogin(home, codex.accessToken);
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ provider: "codex", codex_model: "gpt-5.6-sol" }) + "\n",
+        { mode: 0o600 },
+      );
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Answer without using a vision fallback."],
+        {
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: "gateway-vision-sentinel",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_AUTO_UPGRADE: "0",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+            FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
+            FX_E2E_OPENAI_CODEX_MODELS_URL: codex.modelsUrl,
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("CODEX_VISION_DISABLED_OK");
+      expect(codex.bodies).toHaveLength(2);
+      expect(codex.bodies[0]).not.toContain('"name":"vision"');
+      const continuation = JSON.parse(codex.bodies[1]) as {
+        input: Array<{ type?: string; output?: string }>;
+      };
+      const toolResult = continuation.input.find(
+        (item) => item.type === "function_call_output",
+      );
+      expect(toolResult?.output).toContain("Vision is unavailable for this request.");
+      expect(toolResult?.output).toContain("native image input");
       for (const request of [...gateway.requests, ...gateway.modelRequests]) {
         expect(request.headers.get("authorization")).not.toBe(`Bearer ${codex.accessToken}`);
       }


### PR DESCRIPTION
## Summary

- Preserve existing Gateway status, doctor, model-list, and automatic-review behavior.
- Keep Codex provider selection out of unsupported WASM and JS-host ACP surfaces.
- Persist models under the selected provider and keep persistent Codex subagents on Codex credentials, streams, and review across resumed work.
- Keep Codex image handling native and disable its separate vision fallback while preserving the Gateway adapter.
- Require structured permission decisions for Codex automatic review.
- Publish account-bound refreshed Codex tokens to live ACP sessions for subsequent prompts.
- Remove unrelated sandbox, SDK diagnostic, and catalog formatting changes introduced with #216.

Follow-up to #216.