### PR TITLE
Forward raw Markdown through ACP

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -1903,8 +1903,8 @@ fn pushRouteRecoveryStatus(
 fn pushText(raw_ctx: *anyopaque, emission: agent_runtime.TextEmission) !void {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     const text = switch (emission) {
-        .assistant_source => return,
-        .assistant_rendered => |text| text,
+        .assistant_source => |text| text,
+        .assistant_rendered => return,
         .operational => |text| text,
     };
     if (text.len == 0) return;
@@ -3079,19 +3079,25 @@ test "ACP tool notifications preserve UTF-8 for clipped and unsafe output" {
     }
 }
 
-test "ACP stream adapter strips ANSI from agent chunks and suppresses writer failure" {
+test "ACP stream adapter forwards raw Markdown and suppresses rendered duplicates and writer failure" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const alloc = arena_state.allocator();
-    const spans = [_][]const u8{
-        "\x1b[1mbold\x1b[22m and \x1b[3mitalic\x1b[23m\n",
-        "\x1b]8;id=fx-1;https://example.com\x1b\\docs\x1b]8;;\x1b\\\n",
-        "\x1b[2m\xe2\x94\x82 \x1b[22mconst x = **literal**;\n",
+    const source_spans = [_][]const u8{
+        "# Heading\n\n- **bold** item\n",
+        "| A | B |\n| - | - |\n| 1 | 2 |\n",
+        "```zig\nconst x = 1;\n```\n",
+    };
+    const rendered_spans = [_][]const u8{
+        "Heading\n\nbold item\n",
+        "A  B\n1  2\n",
+        "\xe2\x94\x82 const x = 1;\n",
     };
     const expected_spans = [_][]const u8{
-        "bold and italic\n",
-        "[docs](https://example.com)\n",
-        "\xe2\x94\x82 const x = **literal**;\n",
+        source_spans[0],
+        source_spans[1],
+        source_spans[2],
+        "status\n",
     };
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -3113,8 +3119,12 @@ test "ACP stream adapter strips ANSI from agent chunks and suppresses writer fai
         };
         const deps = agentRuntimeDeps(&ctx);
 
-        for (spans) |span| try deps.push_text(deps.ctx, .{ .assistant_rendered = span });
-        try deps.push_text(deps.ctx, .{ .assistant_rendered = "" });
+        for (source_spans, rendered_spans) |source, rendered| {
+            try deps.push_text(deps.ctx, .{ .assistant_source = source });
+            try deps.push_text(deps.ctx, .{ .assistant_rendered = rendered });
+        }
+        try deps.push_text(deps.ctx, .{ .assistant_source = "" });
+        try deps.push_text(deps.ctx, .{ .operational = "status\n" });
         try capture.sync(io_mod.getIo());
     }
 
@@ -3143,7 +3153,7 @@ test "ACP stream adapter strips ANSI from agent chunks and suppresses writer fai
 
         notification_count += 1;
     }
-    try std.testing.expectEqual(spans.len, notification_count);
+    try std.testing.expectEqual(expected_spans.len, notification_count);
 
     var failed_output = try tmp.dir.createFile(io_mod.getIo(), "acp-stream-failure.jsonl", .{});
     failed_output.close(io_mod.getIo());
@@ -3163,7 +3173,7 @@ test "ACP stream adapter strips ANSI from agent chunks and suppresses writer fai
     try std.testing.expect(writer_failed);
 
     const failed_deps = agentRuntimeDeps(&failed_ctx);
-    try failed_deps.push_text(failed_deps.ctx, .{ .assistant_rendered = "writer failure remains suppressed" });
+    try failed_deps.push_text(failed_deps.ctx, .{ .assistant_source = "writer failure remains suppressed" });
 }
 
 test "ACP auth failure emits a valid detail-free JSON-RPC notification" {

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -3097,8 +3097,11 @@ test "ACP stream adapter forwards raw Markdown and suppresses rendered duplicate
         source_spans[0],
         source_spans[1],
         source_spans[2],
-        "status\n",
+        "status\n[docs](https://example.com)\n",
     };
+    const operational_span =
+        "\x1b[1mstatus\x1b[22m\n" ++
+        "\x1b]8;id=fx-1;https://example.com\x1b\\docs\x1b]8;;\x1b\\\n";
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -3124,7 +3127,7 @@ test "ACP stream adapter forwards raw Markdown and suppresses rendered duplicate
             try deps.push_text(deps.ctx, .{ .assistant_rendered = rendered });
         }
         try deps.push_text(deps.ctx, .{ .assistant_source = "" });
-        try deps.push_text(deps.ctx, .{ .operational = "status\n" });
+        try deps.push_text(deps.ctx, .{ .operational = operational_span });
         try capture.sync(io_mod.getIo());
     }
 

--- a/src/core/agent/runtime/assistant_stream.zig
+++ b/src/core/agent/runtime/assistant_stream.zig
@@ -153,7 +153,6 @@ pub const StreamChunkContext = struct {
         source: []const u8,
     ) !void {
         try self.raw_text.appendSlice(self.alloc, source);
-        try self.hooks.push_text(self.hooks.ctx, .{ .assistant_source = source });
 
         var start: usize = 0;
         while (start < source.len and isTrimmedAssistantPrefixByte(source[start])) : (start += 1) {
@@ -1087,7 +1086,7 @@ test "presented recovery source seeds continuation without rendering twice" {
     try stream_ctx.restoreRecoverySource("Partial output before EOF.", true);
 
     try std.testing.expectEqualStrings("Partial output before EOF.", stream_ctx.raw_text.items);
-    try std.testing.expectEqual(@as(usize, 1), capture.source_spans.items.len);
+    try std.testing.expectEqual(@as(usize, 0), capture.source_spans.items.len);
     try std.testing.expectEqual(@as(usize, 0), capture.text_spans.items.len);
 
     stream_ctx.beginRecoveryAttempt();
@@ -1097,8 +1096,8 @@ test "presented recovery source seeds continuation without rendering twice" {
         "Partial output before EOF.Recovered final output once.",
         stream_ctx.raw_text.items,
     );
-    try std.testing.expectEqual(@as(usize, 2), capture.source_spans.items.len);
-    try std.testing.expectEqualStrings("Recovered final output once.", capture.source_spans.items[1]);
+    try std.testing.expectEqual(@as(usize, 1), capture.source_spans.items.len);
+    try std.testing.expectEqualStrings("Recovered final output once.", capture.source_spans.items[0]);
     try std.testing.expectEqual(@as(usize, 1), capture.text_spans.items.len);
     try std.testing.expectEqualStrings("Recovered final output once.", capture.text_spans.items[0]);
 }
@@ -1129,8 +1128,8 @@ test "presented recovery source preserves an unfinished semantic code fence" {
         prefix ++ " 1;\n```\nAfter code.\n",
         stream_ctx.raw_text.items,
     );
-    try std.testing.expectEqual(@as(usize, 2), capture.source_spans.items.len);
-    try std.testing.expectEqualStrings(" 1;\n```\nAfter code.\n", capture.source_spans.items[1]);
+    try std.testing.expectEqual(@as(usize, 1), capture.source_spans.items.len);
+    try std.testing.expectEqualStrings(" 1;\n```\nAfter code.\n", capture.source_spans.items[0]);
     try std.testing.expectEqual(@as(usize, 1), capture.code_blocks.items.len);
     try std.testing.expectEqualStrings("zig", capture.code_blocks.items[0].language);
     try std.testing.expectEqualStrings(" 1;\n", capture.code_blocks.items[0].code);

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -1490,6 +1490,60 @@ describe("acp: model-independent", () => {
   );
 
   test(
+    "ACP forwards exact Markdown source without rendered duplicates",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-markdown-source-");
+      const markdown = [
+        "# Heading\n\n- **bold** item\n\n",
+        "| A | B |\n| - | - |\n| 1 | 2 |\n\n",
+        "```zig\nconst x = 1;\n```\n",
+      ];
+      const gateway = startFakeGateway([
+        fakeGatewaySse([
+          ...markdown.map((delta) => ({
+            type: "text-delta",
+            id: "answer_1",
+            delta,
+          })),
+          {
+            type: "finish",
+            finishReason: { unified: "stop", raw: "stop" },
+            usage: {
+              inputTokens: { total: 3 },
+              outputTokens: { total: 5 },
+            },
+          },
+        ]),
+      ]);
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await startCodeSession(client);
+
+        const result = await runPrompt(client, "Return the Markdown fixture.", TIMEOUT);
+        expect(result.promptResult.result.stopReason).toBe("end_turn");
+        const responseText = result.messages
+          .filter((message) =>
+            message.method === "session/update" &&
+            message.params?.update?.sessionUpdate === "agent_message_chunk"
+          )
+          .map((message) => message.params.update.content.text)
+          .join("");
+        expect(responseText).toBe(markdown.join(""));
+        expect(responseText).not.toContain("\u001b");
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "ACP reload replays pending execution once and clears recovery after completion",
     async () => {
       const root = createIsolatedRoot("fx-acp-reload-model-recovery-");


### PR DESCRIPTION
## Summary

- Forward raw assistant Markdown to ACP clients instead of terminal-rendered text.
- Preserve operational updates through the existing sanitized ACP writer.
- Resume paused ACP responses without repeating partial text the client already received.

Fixes #207.