### PR TITLE
Forward raw Markdown to ACP instead of terminal rendering

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -1896,8 +1896,8 @@ fn pushRouteRecoveryStatus(
 fn pushText(raw_ctx: *anyopaque, emission: agent_runtime.TextEmission) !void {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     const text = switch (emission) {
-        .assistant_source => return,
-        .assistant_rendered => |text| text,
+        .assistant_source => |text| text,
+        .assistant_rendered => return,
         .operational => |text| text,
     };
     if (text.len == 0) return;


### PR DESCRIPTION
## Summary

Forward raw Markdown to ACP `agent_message_chunk` instead of terminal-rendered text. The agent runtime publishes both `assistant_source` (raw Markdown) and `assistant_rendered` (terminal projection) and the ACP callback was forwarding the rendered text, so headings, lists, tables and emphasis were lost before the client could render them.

Fixes #207

## Changes

* `src/acp/prompt.zig:1896` `pushText`: change `switch` to forward `assistant_source` and return on `assistant_rendered`, preserving `operational` forwarding. The diff is two lines and matches the proposed fix in the issue.

## Testing

* `zig fmt --check src/acp/prompt.zig` — pass
* `zig build` — pass (no output, exit 0)
* `zig build test` — pass (exit 0)
* Existing test `ACP stream adapter strips ANSI from agent chunks and suppresses writer failure` still covers the ANSI stripping path; the Markdown preservation will be verified by the Full CI deterministic E2E shards.

## Checklist

* [x] `zig fmt` run
* [x] Focused tests for the changed path pass locally
* [x] Built binary with `zig build` (`./zig-out/bin/fx`)
* [x] Draft PR opened for Full CI verification
* [ ] Full CI (four native ReleaseSafe + four E2E shards per platform) passes for this commit before marking ready
* [x] Commit follows Conventional Commits with DCO sign-off
