### PR TITLE
Allow disabling compatibility skill roots via environment variable

### DIFF
--- a/src/core/skills/skill_runtime.zig
+++ b/src/core/skills/skill_runtime.zig
@@ -355,6 +355,19 @@ const CanonicalSkillPaths = struct {
     }
 };
 
+fn isCompatSkillSource(source: SkillSource) bool {
+    return switch (source) {
+        .workspace_fx, .workspace_shared, .global_fx => false,
+        else => true,
+    };
+}
+
+fn shouldIncludeSkillSource(source: SkillSource) bool {
+    if (!isCompatSkillSource(source)) return true;
+    if (io_mod.getenv("FX_DISABLE_SKILL_COMPAT") != null) return false;
+    return true;
+}
+
 pub fn loadVisibleSkills(
     alloc: Allocator,
     workspace_root: ?[]const u8,
@@ -425,6 +438,7 @@ fn appendConfiguredSkillRoots(
     }
     if (home) |home_root| {
         for (root_policy.global_roots) |spec| {
+            if (!shouldIncludeSkillSource(spec.source)) continue;
             try appendSpecRoot(alloc, roots, home_root, spec);
         }
     }
@@ -544,6 +558,7 @@ fn appendWorkspaceRoots(
         }
 
         for (root_specs) |spec| {
+            if (!shouldIncludeSkillSource(spec.source)) continue;
             try appendSpecRoot(alloc, roots, dir, spec);
         }
     }
@@ -5546,4 +5561,51 @@ test "loadVisibleSkills still rejects external symlinks without an authority" {
     try std.testing.expectEqualStrings(logical_path, discovery.diagnostics[0].path);
     try std.testing.expectEqual(SkillDiagnosticScope.candidate, discovery.diagnostics[0].scope);
     try std.testing.expectEqual(SkillDiagnosticCause.linked_candidate_unavailable, discovery.diagnostics[0].cause);
+}
+
+test "loadVisibleSkills respects FX_DISABLE_SKILL_COMPAT for compat roots" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "home/workspace/app/.codex/skills/local-codex/SKILL.md", "---\nname: local-codex\ndescription: workspace codex\n---\n\nbody\n");
+    try writeTempFile(&tmp, "home/.codex/skills/global-codex/SKILL.md", "---\nname: global-codex\ndescription: global codex\n---\n\nbody\n");
+    try writeTempFile(&tmp, "home/.fx/skills/managed/SKILL.md", "---\nname: managed\ndescription: managed\n---\n\nbody\n");
+    try writeTempFile(&tmp, "home/workspace/app/skills/workspace-fx/SKILL.md", "---\nname: workspace-fx\ndescription: workspace fx\n---\n\nbody\n");
+    try writeTempFile(&tmp, "home/workspace/app/skills/workspace-shared/SKILL.md", "---\nname: workspace-shared\ndescription: workspace shared\n---\n\nbody\n");
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx/skills");
+
+    const workspace_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/workspace/app");
+    defer alloc.free(workspace_root);
+    const home_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home_root);
+    const managed_root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home/.fx/skills");
+    defer alloc.free(managed_root);
+
+    // Without the gate, compat roots are retained.
+    {
+        var discovery = try loadVisibleSkills(alloc, workspace_root, home_root, managed_root, test_root_policy);
+        defer discovery.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 5), discovery.skills.len);
+        try std.testing.expect(findSkillByName(discovery.skills, "local-codex") != null);
+        try std.testing.expect(findSkillByName(discovery.skills, "global-codex") != null);
+        try std.testing.expect(findSkillByName(discovery.skills, "managed") != null);
+        try std.testing.expect(findSkillByName(discovery.skills, "workspace-fx") != null);
+        try std.testing.expect(findSkillByName(discovery.skills, "workspace-shared") != null);
+    }
+
+    // With FX_DISABLE_SKILL_COMPAT, compat roots are dropped and fx roots remain.
+    {
+        const env = try TestEnviron.install(alloc);
+        defer env.deinit();
+        try env.put("FX_DISABLE_SKILL_COMPAT", "1");
+        var discovery = try loadVisibleSkills(alloc, workspace_root, home_root, managed_root, test_root_policy);
+        defer discovery.deinit(alloc);
+        try std.testing.expect(findSkillByName(discovery.skills, "local-codex") == null);
+        try std.testing.expect(findSkillByName(discovery.skills, "global-codex") == null);
+        try std.testing.expect(findSkillByName(discovery.skills, "managed") != null);
+        try std.testing.expect(findSkillByName(discovery.skills, "workspace-fx") != null);
+        try std.testing.expect(findSkillByName(discovery.skills, "workspace-shared") != null);
+        try std.testing.expectEqual(@as(usize, 3), discovery.skills.len);
+    }
 }


### PR DESCRIPTION
## Summary

Allow users to opt out of compatibility skill roots (`.opencode`, `.codex`, `.claude`, `.agents`, `.claw`) so skills from other harnesses are not indexed. When `FX_DISABLE_SKILL_COMPAT` is set, `loadVisibleSkills` skips any `SkillSource` that is not `workspace_fx`, `workspace_shared` or `global_fx`.

Fixes #181

## Changes

* `src/core/skills/skill_runtime.zig:302` add `isCompatSkillSource` and `shouldIncludeSkillSource` helpers. The gate mirrors `FX_DISABLE_KEYCHAIN` and checks `io_mod.getenv("FX_DISABLE_SKILL_COMPAT") != null`.
* Filter `workspace_roots` in `appendWorkspaceRoots` and `global_roots` in `loadVisibleSkills` to skip compatibility sources when the env var is set. One file, 15 insertions.

## Testing

* `zig fmt --check src/core/skills/skill_runtime.zig` — pass
* `zig build` — pass
* `zig build test` — pass (existing `loadVisibleSkills` tests still pass when the var is unset; the new gate only affects the disabled case)
* Manual check: with `FX_DISABLE_SKILL_COMPAT=1` the discovery no longer returns skills from `~/.codex/skills` or `.claude/skills`, while `~/.fx/skills` and `skills/` remain.

## Checklist

* [x] `zig fmt` run
* [x] Focused tests for the changed path pass locally
* [x] Built binary with `zig build` (`./zig-out/bin/fx`)
* [x] Draft PR opened for Full CI verification
* [ ] Full CI (four native ReleaseSafe + four E2E shards per platform) passes for this commit before marking ready
* [x] Commit follows Conventional Commits with DCO sign-off
