### PR TITLE
Add direct provider OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,23 +40,38 @@ fx setup
 ```
 
 The native CLI and ACP server can also connect directly to subscription and
-vendor providers with a provider-qualified model ID:
+vendor providers. Sign in once with fx:
 
 ```bash
-# Reuse an existing Claude Code Max/Pro login, or set ANTHROPIC_OAUTH_TOKEN.
+fx login anthropic      # Claude Pro or Max, browser OAuth
+fx login anthropic --manual-code  # Paste the redirect when using SSH
+fx login openai-codex   # ChatGPT Plus or Pro, browser OAuth
+fx login openai-codex --device-code  # ChatGPT login on a headless machine
+fx login xai            # SuperGrok or X Premium, device OAuth
+```
+
+fx stores refreshable provider sessions in private files under `~/.fx/` and
+refreshes them before expiry or after an unauthorized response. Select a direct
+provider with a provider-qualified model ID:
+
+```bash
+# Use the fx-managed Anthropic login, an existing Claude Code login, or an API key.
 FX_MODEL=anthropic-max/claude-opus-4-8 fx
 
-# Reuse an existing Codex CLI ChatGPT Plus/Pro login, or set CODEX_ACCESS_TOKEN.
+# Use the fx-managed Codex login or an existing Codex CLI login.
 FX_MODEL=openai-codex/gpt-5.5 fx
 
-# Use xAI directly with XAI_API_KEY.
+# Use the fx-managed xAI login or XAI_API_KEY.
 FX_MODEL=xai-direct/grok-4.6 fx
 ```
 
-Anthropic API keys are also accepted through `ANTHROPIC_API_KEY`. Direct
-provider credentials are scoped to their route and are never sent to Vercel AI
-Gateway. Existing IDs such as `anthropic/...` and `xai/...` continue to use AI
-Gateway. Direct routes currently support text and function tools; the
+Managed sessions take precedence over environment variables and external CLI
+credential files. Anthropic API keys are accepted through `ANTHROPIC_API_KEY`;
+Codex accepts `CODEX_ACCESS_TOKEN`; xAI accepts `XAI_API_KEY`. Remove a managed
+session with `fx logout anthropic`, `fx logout openai-codex`, or `fx logout xai`.
+Direct-provider credentials are scoped to their route and are never sent to
+Vercel AI Gateway. Existing IDs such as `anthropic/...` and `xai/...` continue
+to use AI Gateway. Direct routes currently support text and function tools; the
 Gateway-backed vision helper is not advertised on those routes.
 
 Run fx from a project:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ Or add an AI Gateway API key:
 fx setup
 ```
 
+The native CLI and ACP server can also connect directly to subscription and
+vendor providers with a provider-qualified model ID:
+
+```bash
+# Reuse an existing Claude Code Max/Pro login, or set ANTHROPIC_OAUTH_TOKEN.
+FX_MODEL=anthropic-max/claude-opus-4-8 fx
+
+# Reuse an existing Codex CLI ChatGPT Plus/Pro login, or set CODEX_ACCESS_TOKEN.
+FX_MODEL=openai-codex/gpt-5.5 fx
+
+# Use xAI directly with XAI_API_KEY.
+FX_MODEL=xai-direct/grok-4.6 fx
+```
+
+Anthropic API keys are also accepted through `ANTHROPIC_API_KEY`. Direct
+provider credentials are scoped to their route and are never sent to Vercel AI
+Gateway. Existing IDs such as `anthropic/...` and `xai/...` continue to use AI
+Gateway. Direct routes currently support text and function tools; the
+Gateway-backed vision helper is not advertised on those routes.
+
 Run fx from a project:
 
 ```bash

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -89,14 +89,14 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .login,
         .token = "login",
-        .usage = "login",
-        .summary = "Sign in with Vercel",
+        .usage = "login [vercel|anthropic|openai-codex|xai] [--device-code|--manual-code]",
+        .summary = "Sign in to an inference provider",
     },
     .{
         .kind = .logout,
         .token = "logout",
-        .usage = "logout",
-        .summary = "Sign out of the current Vercel session",
+        .usage = "logout [vercel|anthropic|openai-codex|xai]",
+        .summary = "Sign out of an inference provider",
     },
     .{
         .kind = .setup,

--- a/src/builtins/direct_providers.zig
+++ b/src/builtins/direct_providers.zig
@@ -1,0 +1,910 @@
+const std = @import("std");
+
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const types = @import("../core/shared/types.zig");
+
+const Allocator = std.mem.Allocator;
+
+const anthropic_prefix = "anthropic-max/";
+const codex_prefix = "openai-codex/";
+const xai_prefix = "xai-direct/";
+
+const anthropic_url = "https://api.anthropic.com/v1/messages";
+const codex_url = "https://chatgpt.com/backend-api/codex/responses";
+const xai_url = "https://api.x.ai/v1/responses";
+
+const max_error_body_bytes = 1024 * 1024;
+const max_sse_line_bytes = 4 * 1024 * 1024;
+const claude_code_identity = "You are Claude Code, Anthropic's official CLI for Claude.";
+
+const Family = enum { anthropic, codex, xai };
+
+const DirectModel = struct {
+    family: Family,
+    wire_model: []const u8,
+    endpoint: []const u8,
+};
+
+pub const agent_stream_provider = stream_provider.Provider{
+    .build_fn = build,
+    .stream_fn = stream,
+};
+
+fn directModel(model: []const u8) ?DirectModel {
+    const cases = [_]struct { prefix: []const u8, family: Family, endpoint: []const u8 }{
+        .{ .prefix = anthropic_prefix, .family = .anthropic, .endpoint = anthropic_url },
+        .{ .prefix = codex_prefix, .family = .codex, .endpoint = codex_url },
+        .{ .prefix = xai_prefix, .family = .xai, .endpoint = xai_url },
+    };
+    for (cases) |case| {
+        if (std.mem.startsWith(u8, model, case.prefix) and model.len > case.prefix.len) {
+            return .{
+                .family = case.family,
+                .wire_model = model[case.prefix.len..],
+                .endpoint = case.endpoint,
+            };
+        }
+    }
+    return null;
+}
+
+fn build(_: ?*anyopaque, alloc: Allocator, request: stream_provider.BuildRequest) anyerror![]u8 {
+    const direct = directModel(request.model) orelse return error.AgentStreamProviderUnavailable;
+    try checkBuildBudget(request.budget);
+    if (request.verified_images != null or request.response_format != null) {
+        return error.DirectProviderUnsupportedRequest;
+    }
+    return switch (direct.family) {
+        .anthropic => buildAnthropicRequest(alloc, direct.wire_model, request),
+        .codex, .xai => buildResponsesRequest(alloc, direct, request),
+    };
+}
+
+fn checkBuildBudget(budget: ?stream_provider.BuildBudget) !void {
+    const active = budget orelse return;
+    if (active.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+    if (active.deadline) |deadline| {
+        const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+        if (now.raw.nanoseconds >= deadline.raw.nanoseconds) return error.TimedOut;
+    }
+}
+
+fn buildAnthropicRequest(alloc: Allocator, wire_model: []const u8, request: stream_provider.BuildRequest) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    const writer = &out.writer;
+
+    try writer.writeAll("{\"model\":");
+    try writeJson(writer, wire_model);
+    try writer.print(",\"max_tokens\":{d},\"stream\":true", .{request.max_output_tokens orelse 32_000});
+
+    try writer.writeAll(",\"system\":[{\"type\":\"text\",\"text\":");
+    try writeJson(writer, claude_code_identity);
+    try writer.writeByte('}');
+    for (request.messages) |message| if (message.role == .system and message.content != null) {
+        try writer.writeAll(", {\"type\":\"text\",\"text\":");
+        try writeJson(writer, message.content.?);
+        try writer.writeByte('}');
+    };
+    try writer.writeByte(']');
+
+    try writer.writeAll(",\"messages\":[");
+    var first = true;
+    for (request.messages) |message| {
+        if (message.role == .system) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try writeAnthropicMessage(writer, message);
+    }
+    try writer.writeByte(']');
+    try writeAnthropicTools(alloc, writer, request.serialized_tools, request.tool_choice);
+    if (request.provider_options.reasoning) |*effort| {
+        try writer.writeAll(",\"thinking\":{\"type\":\"adaptive\"},\"output_config\":{\"effort\":");
+        try writeJson(writer, effort.label());
+        try writer.writeByte('}');
+    }
+    try writer.writeByte('}');
+    try checkBuildBudget(request.budget);
+    return out.toOwnedSlice();
+}
+
+fn writeAnthropicMessage(writer: *std.Io.Writer, message: types.ChatMessage) !void {
+    if (message.role == .tool) {
+        try writer.writeAll("{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":");
+        try writeJson(writer, message.tool_call_id orelse "");
+        try writer.writeAll(",\"content\":");
+        try writeJson(writer, message.content orelse "");
+        if (message.tool_result_status) |status| if (status == .failure) try writer.writeAll(",\"is_error\":true");
+        try writer.writeAll("}]}");
+        return;
+    }
+
+    try writer.writeAll("{\"role\":");
+    try writeJson(writer, if (message.role == .assistant) "assistant" else "user");
+    if (message.tool_calls.len == 0) {
+        try writer.writeAll(",\"content\":");
+        try writeJson(writer, message.content orelse "");
+        try writer.writeByte('}');
+        return;
+    }
+
+    try writer.writeAll(",\"content\":[");
+    var first = true;
+    if (message.content) |content| if (content.len > 0) {
+        try writer.writeAll("{\"type\":\"text\",\"text\":");
+        try writeJson(writer, content);
+        try writer.writeByte('}');
+        first = false;
+    };
+    for (message.tool_calls) |call| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try writer.writeAll("{\"type\":\"tool_use\",\"id\":");
+        try writeJson(writer, call.id);
+        try writer.writeAll(",\"name\":");
+        try writeJson(writer, call.name);
+        try writer.writeAll(",\"input\":");
+        try writer.writeAll(if (call.arguments_json.len == 0) "{}" else call.arguments_json);
+        try writer.writeByte('}');
+    }
+    try writer.writeAll("]}");
+}
+
+fn writeAnthropicTools(alloc: Allocator, writer: *std.Io.Writer, tools_json: []const u8, choice: types.ToolChoice) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, tools_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array or parsed.value.array.items.len == 0) return;
+
+    var function_count: usize = 0;
+    for (parsed.value.array.items) |tool| {
+        if (!isUnsupportedDirectTool(tool)) function_count += 1;
+    }
+    if (function_count == 0) return;
+
+    try writer.writeAll(",\"tools\":[");
+    var first = true;
+    for (parsed.value.array.items) |tool| {
+        if (isUnsupportedDirectTool(tool)) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        const object = if (tool == .object) tool.object else return error.InvalidDirectToolSchema;
+        try writer.writeAll("{\"name\":");
+        try writeJsonValue(writer, object.get("name") orelse return error.InvalidDirectToolSchema);
+        if (object.get("description")) |description| {
+            try writer.writeAll(",\"description\":");
+            try writeJsonValue(writer, description);
+        }
+        try writer.writeAll(",\"input_schema\":");
+        try writeJsonValue(writer, object.get("inputSchema") orelse object.get("parameters") orelse return error.InvalidDirectToolSchema);
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
+    try writer.writeAll(if (choice == .none) ",\"tool_choice\":{\"type\":\"none\"}" else ",\"tool_choice\":{\"type\":\"auto\"}");
+}
+
+fn buildResponsesRequest(alloc: Allocator, direct: DirectModel, request: stream_provider.BuildRequest) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    const writer = &out.writer;
+
+    try writer.writeAll("{\"model\":");
+    try writeJson(writer, direct.wire_model);
+    try writer.writeAll(",\"stream\":true,\"store\":false");
+    if (direct.family != .codex) {
+        if (request.max_output_tokens) |limit| try writer.print(",\"max_output_tokens\":{d}", .{limit});
+    }
+
+    var has_system = false;
+    for (request.messages) |message| if (message.role == .system and message.content != null) {
+        if (!has_system) {
+            try writer.writeAll(",\"instructions\":");
+            var joined: std.Io.Writer.Allocating = .init(alloc);
+            defer joined.deinit();
+            for (request.messages) |system_message| if (system_message.role == .system) {
+                if (system_message.content) |content| {
+                    if (joined.writer.buffered().len > 0) try joined.writer.writeAll("\n\n");
+                    try joined.writer.writeAll(content);
+                }
+            };
+            try writeJson(writer, joined.writer.buffered());
+            has_system = true;
+        }
+    };
+
+    try writer.writeAll(",\"input\":[");
+    var first = true;
+    for (request.messages) |message| {
+        if (message.role == .system) continue;
+        if (message.role == .tool) {
+            if (!first) try writer.writeByte(',');
+            first = false;
+            try writer.writeAll("{\"type\":\"function_call_output\",\"call_id\":");
+            try writeJson(writer, message.tool_call_id orelse "");
+            try writer.writeAll(",\"output\":");
+            try writeJson(writer, message.content orelse "");
+            try writer.writeByte('}');
+            continue;
+        }
+        if (message.content) |content| {
+            if (!first) try writer.writeByte(',');
+            first = false;
+            try writer.writeAll("{\"role\":");
+            try writeJson(writer, if (message.role == .assistant) "assistant" else "user");
+            try writer.writeAll(",\"content\":");
+            try writeJson(writer, content);
+            try writer.writeByte('}');
+        }
+        for (message.tool_calls) |call| {
+            if (!first) try writer.writeByte(',');
+            first = false;
+            try writer.writeAll("{\"type\":\"function_call\",\"call_id\":");
+            try writeJson(writer, call.id);
+            try writer.writeAll(",\"name\":");
+            try writeJson(writer, call.name);
+            try writer.writeAll(",\"arguments\":");
+            try writeJson(writer, call.arguments_json);
+            try writer.writeByte('}');
+        }
+    }
+    try writer.writeByte(']');
+    const wrote_tool_choice = try writeResponsesTools(alloc, writer, request.serialized_tools, request.tool_choice);
+    if (direct.family == .codex) {
+        try writer.writeAll(",\"text\":{\"verbosity\":\"low\"},\"include\":[\"reasoning.encrypted_content\"]");
+        if (!wrote_tool_choice) {
+            try writer.writeAll(",\"tool_choice\":\"auto\"");
+        }
+        try writer.writeAll(",\"parallel_tool_calls\":true");
+    } else if (request.provider_options.parallel_tool_calls) |enabled| {
+        try writer.print(",\"parallel_tool_calls\":{}", .{enabled});
+    }
+    if (request.provider_options.reasoning) |*effort| {
+        try writer.writeAll(",\"reasoning\":{\"effort\":");
+        try writeJson(writer, effort.label());
+        try writer.writeAll(",\"summary\":\"auto\"}");
+        if (direct.family != .codex) try writer.writeAll(",\"include\":[\"reasoning.encrypted_content\"]");
+    }
+    try writer.writeByte('}');
+    try checkBuildBudget(request.budget);
+    return out.toOwnedSlice();
+}
+
+fn writeResponsesTools(alloc: Allocator, writer: *std.Io.Writer, tools_json: []const u8, choice: types.ToolChoice) !bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, tools_json, .{});
+    defer parsed.deinit();
+    if (parsed.value != .array or parsed.value.array.items.len == 0) return false;
+
+    var function_count: usize = 0;
+    for (parsed.value.array.items) |tool| {
+        if (!isUnsupportedDirectTool(tool)) function_count += 1;
+    }
+    if (function_count == 0) return false;
+
+    try writer.writeAll(",\"tools\":[");
+    var first = true;
+    for (parsed.value.array.items) |tool| {
+        if (isUnsupportedDirectTool(tool)) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        const object = if (tool == .object) tool.object else return error.InvalidDirectToolSchema;
+        try writer.writeAll("{\"type\":\"function\",\"name\":");
+        try writeJsonValue(writer, object.get("name") orelse return error.InvalidDirectToolSchema);
+        if (object.get("description")) |description| {
+            try writer.writeAll(",\"description\":");
+            try writeJsonValue(writer, description);
+        }
+        try writer.writeAll(",\"parameters\":");
+        try writeJsonValue(writer, object.get("inputSchema") orelse object.get("parameters") orelse return error.InvalidDirectToolSchema);
+        try writer.writeByte('}');
+    }
+    try writer.writeAll("],\"tool_choice\":");
+    try writeJson(writer, choice.label());
+    return true;
+}
+
+fn isUnsupportedDirectTool(tool: std.json.Value) bool {
+    if (jsonString(tool, "type")) |kind| {
+        if (std.mem.eql(u8, kind, "provider")) return true;
+    }
+    if (jsonString(tool, "name")) |name| {
+        if (std.mem.eql(u8, name, "vision")) return true;
+    }
+    return false;
+}
+
+fn writeJson(writer: *std.Io.Writer, value: []const u8) !void {
+    try std.json.Stringify.value(value, .{}, writer);
+}
+
+fn writeJsonValue(writer: *std.Io.Writer, value: std.json.Value) !void {
+    try std.json.Stringify.value(value, .{}, writer);
+}
+
+fn stream(_: ?*anyopaque, alloc: Allocator, request: stream_provider.Request) anyerror!stream_provider.Result {
+    const direct = directModel(request.model) orelse return error.AgentStreamProviderUnavailable;
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    const endpoint = if (direct.family == .anthropic and std.mem.startsWith(u8, request.api_key, "sk-ant-oat"))
+        anthropic_url ++ "?beta=true"
+    else
+        direct.endpoint;
+    const uri = try std.Uri.parse(endpoint);
+    var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
+    defer client.deinit();
+
+    const auth = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.api_key});
+    defer {
+        @memset(auth, 0);
+        alloc.free(auth);
+    }
+    var extra_headers_buf: [9]std.http.Header = undefined;
+    const extra_headers = try directHeaders(alloc, &extra_headers_buf, direct.family, request, auth);
+    defer if (direct.family == .codex and extra_headers.len > 0) {
+        const account_id = extra_headers[0].value;
+        @memset(@constCast(account_id), 0);
+        alloc.free(@constCast(account_id));
+    };
+
+    var req = try client.request(.POST, uri, .{
+        .headers = .{
+            .content_type = .{ .override = "application/json" },
+            .accept_encoding = .omit,
+            .authorization = if (direct.family == .anthropic and !std.mem.startsWith(u8, request.api_key, "sk-ant-oat")) .omit else .{ .override = auth },
+            .user_agent = .{ .override = if (direct.family == .anthropic) "claude-cli/2.1.76 (external, cli)" else "fx" },
+        },
+        .extra_headers = extra_headers,
+        .keep_alive = false,
+        .redirect_behavior = .unhandled,
+    });
+    defer req.deinit();
+
+    req.transfer_encoding = .{ .content_length = request.payload.len };
+    var send_buf: [8192]u8 = undefined;
+    request.delivery.markPossiblySent();
+    var body_writer = try req.sendBodyUnflushed(&send_buf);
+    try body_writer.writer.writeAll(request.payload);
+    try body_writer.end();
+    if (req.connection) |connection| try connection.flush();
+    var response = try req.receiveHead(&.{});
+
+    if (response.head.status != .ok) {
+        var transfer_buf: [4096]u8 = undefined;
+        const reader = response.reader(&transfer_buf);
+        const body = reader.allocRemaining(alloc, .limited(max_error_body_bytes)) catch null;
+        return .{ .status = response.head.status, .err_body = body, .ownership = .owned };
+    }
+
+    var transfer_buf: [16 * 1024]u8 = undefined;
+    const reader = response.reader(&transfer_buf);
+    const completion = try consumeDirectSse(
+        alloc,
+        reader,
+        direct.family,
+        request.callback_ctx,
+        request.on_content_chunk,
+        request.on_tool_start,
+        request.on_reasoning_chunk,
+        request.on_tool_input_chunk,
+        request.cancel_flag,
+        request.content_capture_limit,
+    );
+    return .{ .status = .ok, .completion = completion, .ownership = .owned };
+}
+
+fn directHeaders(
+    alloc: Allocator,
+    buf: []std.http.Header,
+    family: Family,
+    request: stream_provider.Request,
+    auth: []const u8,
+) ![]const std.http.Header {
+    var len: usize = 0;
+    if (request.session_id) |session_id| {
+        if (!validHeaderValue(session_id)) return error.InvalidDirectProviderHeader;
+    }
+    switch (family) {
+        .anthropic => {
+            buf[len] = .{ .name = "accept", .value = "text/event-stream" };
+            len += 1;
+            buf[len] = .{ .name = "anthropic-version", .value = "2023-06-01" };
+            len += 1;
+            buf[len] = .{ .name = "anthropic-dangerous-direct-browser-access", .value = "true" };
+            len += 1;
+            if (std.mem.startsWith(u8, request.api_key, "sk-ant-oat")) {
+                buf[len] = .{ .name = "anthropic-beta", .value = "claude-code-20250219,oauth-2025-04-20" };
+                len += 1;
+                buf[len] = .{ .name = "x-app", .value = "cli" };
+                len += 1;
+                if (request.session_id) |session_id| if (session_id.len > 0) {
+                    buf[len] = .{ .name = "X-Claude-Code-Session-Id", .value = session_id };
+                    len += 1;
+                };
+            } else {
+                buf[len] = .{ .name = "x-api-key", .value = request.api_key };
+                len += 1;
+            }
+        },
+        .codex => {
+            const account_id = try resolveCodexAccountId(alloc, request.api_key);
+            errdefer alloc.free(account_id);
+            buf[len] = .{ .name = "chatgpt-account-id", .value = account_id };
+            len += 1;
+            buf[len] = .{ .name = "originator", .value = "codex_cli_rs" };
+            len += 1;
+            buf[len] = .{ .name = "OpenAI-Beta", .value = "responses=experimental" };
+            len += 1;
+            buf[len] = .{ .name = "accept", .value = "text/event-stream" };
+            len += 1;
+            if (request.session_id) |session_id| if (session_id.len > 0) {
+                buf[len] = .{ .name = "session-id", .value = session_id };
+                len += 1;
+                buf[len] = .{ .name = "x-client-request-id", .value = session_id };
+                len += 1;
+            };
+        },
+        .xai => {
+            _ = auth;
+            buf[len] = .{ .name = "accept", .value = "text/event-stream" };
+            len += 1;
+        },
+    }
+    return buf[0..len];
+}
+
+fn resolveCodexAccountId(alloc: Allocator, token: []const u8) ![]u8 {
+    if (try codexAccountIdFromToken(alloc, token)) |account_id| return account_id;
+    if (io_mod.getenv("CODEX_ACCOUNT_ID")) |value| if (value.len > 0 and validHeaderValue(value)) return alloc.dupe(u8, value);
+    const home = io_mod.getenv("HOME") orelse return error.CodexAccountIdUnavailable;
+    const path = try std.fs.path.join(alloc, &.{ home, ".codex", "auth.json" });
+    defer alloc.free(path);
+    var file = std.Io.Dir.cwd().openFile(io_mod.getIo(), path, .{}) catch return error.CodexAccountIdUnavailable;
+    defer file.close(io_mod.getIo());
+    const bytes = io_mod.readFileToEnd(alloc, &file, 1024 * 1024) catch return error.CodexAccountIdUnavailable;
+    defer alloc.free(bytes);
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch return error.CodexAccountIdUnavailable;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.CodexAccountIdUnavailable;
+    const tokens = parsed.value.object.get("tokens") orelse return error.CodexAccountIdUnavailable;
+    if (tokens != .object) return error.CodexAccountIdUnavailable;
+    const account = tokens.object.get("account_id") orelse return error.CodexAccountIdUnavailable;
+    if (account != .string or account.string.len == 0 or !validHeaderValue(account.string)) return error.CodexAccountIdUnavailable;
+    return alloc.dupe(u8, account.string);
+}
+
+fn codexAccountIdFromToken(alloc: Allocator, token: []const u8) !?[]u8 {
+    const first_dot = std.mem.findScalar(u8, token, '.') orelse return null;
+    const payload_start = first_dot + 1;
+    const second_relative = std.mem.findScalar(u8, token[payload_start..], '.') orelse return null;
+    const payload = token[payload_start .. payload_start + second_relative];
+    if (payload.len == 0) return null;
+
+    const decoded_len = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(payload) catch return null;
+    const decoded = try alloc.alloc(u8, decoded_len);
+    defer alloc.free(decoded);
+    std.base64.url_safe_no_pad.Decoder.decode(decoded, payload) catch return null;
+
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, decoded, .{}) catch return null;
+    defer parsed.deinit();
+    const auth = jsonObject(parsed.value, "https://api.openai.com/auth") orelse return null;
+    const account_id = jsonString(auth, "chatgpt_account_id") orelse return null;
+    if (account_id.len == 0 or !validHeaderValue(account_id)) return null;
+    return @as(?[]u8, try alloc.dupe(u8, account_id));
+}
+
+fn validHeaderValue(value: []const u8) bool {
+    for (value) |byte| {
+        if (byte < 0x20 or byte == 0x7f or byte == ':') return false;
+    }
+    return true;
+}
+
+const ToolAccumulator = struct {
+    id: std.ArrayList(u8) = .empty,
+    item_id: std.ArrayList(u8) = .empty,
+    name: std.ArrayList(u8) = .empty,
+    arguments: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *@This(), alloc: Allocator) void {
+        self.id.deinit(alloc);
+        self.item_id.deinit(alloc);
+        self.name.deinit(alloc);
+        self.arguments.deinit(alloc);
+    }
+};
+
+fn consumeDirectSse(
+    alloc: Allocator,
+    reader: *std.Io.Reader,
+    family: Family,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    on_tool_input_chunk: ?stream_provider.StreamCallback,
+    cancel_flag: *std.atomic.Value(bool),
+    content_capture_limit: ?usize,
+) !types.GatewayCompletion {
+    var content: std.ArrayList(u8) = .empty;
+    defer content.deinit(alloc);
+    var tools: std.ArrayList(ToolAccumulator) = .empty;
+    defer {
+        for (tools.items) |*tool| tool.deinit(alloc);
+        tools.deinit(alloc);
+    }
+    var usage: types.Usage = .{};
+    var finish_reason: ?types.ProviderFinishReason = null;
+    var line_buf: std.ArrayList(u8) = .empty;
+    defer line_buf.deinit(alloc);
+
+    while (!cancel_flag.load(.seq_cst)) {
+        line_buf.clearRetainingCapacity();
+        const line = try readSseLine(alloc, reader, &line_buf) orelse break;
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (!std.mem.startsWith(u8, trimmed, "data:")) continue;
+        const data = std.mem.trimStart(u8, trimmed["data:".len..], " ");
+        if (std.mem.eql(u8, data, "[DONE]")) break;
+        var parsed = std.json.parseFromSlice(std.json.Value, alloc, data, .{}) catch continue;
+        defer parsed.deinit();
+        if (parsed.value != .object) continue;
+        switch (family) {
+            .anthropic => try consumeAnthropicEvent(alloc, parsed.value, &content, &tools, &usage, &finish_reason, callback_ctx, on_content_chunk, on_tool_start, on_reasoning_chunk, on_tool_input_chunk, content_capture_limit),
+            .codex, .xai => try consumeResponsesEvent(alloc, parsed.value, &content, &tools, &usage, &finish_reason, callback_ctx, on_content_chunk, on_tool_start, on_reasoning_chunk, on_tool_input_chunk, content_capture_limit),
+        }
+    }
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    var completion: types.GatewayCompletion = .{ .usage = usage, .finish_reason = finish_reason };
+    errdefer freeCompletion(alloc, &completion);
+    if (content.items.len > 0) completion.content = try alloc.dupe(u8, content.items);
+    const tool_calls = try alloc.alloc(types.ToolCall, tools.items.len);
+    var initialized: usize = 0;
+    errdefer {
+        for (tool_calls[0..initialized]) |call| {
+            alloc.free(@constCast(call.id));
+            alloc.free(@constCast(call.name));
+            alloc.free(@constCast(call.arguments_json));
+        }
+        alloc.free(tool_calls);
+    }
+    for (tools.items, 0..) |tool, index| {
+        const id = try alloc.dupe(u8, tool.id.items);
+        errdefer alloc.free(id);
+        const name = try alloc.dupe(u8, tool.name.items);
+        errdefer alloc.free(name);
+        const arguments = try alloc.dupe(u8, if (tool.arguments.items.len > 0) tool.arguments.items else "{}");
+        errdefer alloc.free(arguments);
+        tool_calls[index] = .{
+            .id = id,
+            .name = name,
+            .arguments_json = arguments,
+        };
+        initialized += 1;
+    }
+    completion.tool_calls = tool_calls;
+    if (completion.finish_reason == null and completion.tool_calls.len > 0) completion.finish_reason = .tool_calls;
+    return completion;
+}
+
+fn readSseLine(alloc: Allocator, reader: *std.Io.Reader, pending: *std.ArrayList(u8)) !?[]const u8 {
+    while (true) {
+        const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
+            error.StreamTooLong => {
+                const buffered = reader.buffered();
+                if (buffered.len == 0 or buffered.len > max_sse_line_bytes - pending.items.len) return error.DirectSseEventTooLarge;
+                try pending.appendSlice(alloc, buffered);
+                reader.tossBuffered();
+                continue;
+            },
+            else => return err,
+        } orelse return if (pending.items.len > 0) pending.items else null;
+        if (fragment.len > max_sse_line_bytes - pending.items.len) return error.DirectSseEventTooLarge;
+        if (pending.items.len == 0) return fragment;
+        try pending.appendSlice(alloc, fragment);
+        return pending.items;
+    }
+}
+
+fn consumeAnthropicEvent(
+    alloc: Allocator,
+    root: std.json.Value,
+    content: *std.ArrayList(u8),
+    tools: *std.ArrayList(ToolAccumulator),
+    usage: *types.Usage,
+    finish_reason: *?types.ProviderFinishReason,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    on_tool_input_chunk: ?stream_provider.StreamCallback,
+    content_capture_limit: ?usize,
+) !void {
+    const event_type = jsonString(root, "type") orelse return;
+    if (std.mem.eql(u8, event_type, "message_start")) {
+        if (jsonObject(root, "message")) |message| {
+            if (jsonObject(message, "usage")) |value| {
+                usage.input_tokens = jsonU64(value, "input_tokens");
+            }
+        }
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "content_block_start")) {
+        const block = jsonObject(root, "content_block") orelse return;
+        if (!std.mem.eql(u8, jsonString(block, "type") orelse "", "tool_use")) return;
+        var tool: ToolAccumulator = .{};
+        errdefer tool.deinit(alloc);
+        try tool.id.appendSlice(alloc, jsonString(block, "id") orelse "");
+        try tool.name.appendSlice(alloc, jsonString(block, "name") orelse "");
+        if (block.object.get("input")) |input| {
+            if (input == .object and input.object.count() > 0) try appendJsonValue(alloc, &tool.arguments, input);
+        }
+        try tools.append(alloc, tool);
+        if (on_tool_start) |callback| callback(callback_ctx, tool.id.items, tool.name.items, null);
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "content_block_delta")) {
+        const delta = jsonObject(root, "delta") orelse return;
+        const delta_type = jsonString(delta, "type") orelse return;
+        if (std.mem.eql(u8, delta_type, "text_delta")) {
+            if (jsonString(delta, "text")) |text| try emitContent(alloc, content, text, callback_ctx, on_content_chunk, content_capture_limit);
+        } else if (std.mem.eql(u8, delta_type, "thinking_delta")) {
+            if (on_reasoning_chunk) |callback| if (jsonString(delta, "thinking")) |thinking| callback(callback_ctx, thinking);
+        } else if (std.mem.eql(u8, delta_type, "input_json_delta") and tools.items.len > 0) {
+            if (jsonString(delta, "partial_json")) |partial| {
+                try tools.items[tools.items.len - 1].arguments.appendSlice(alloc, partial);
+                if (on_tool_input_chunk) |callback| callback(callback_ctx, partial);
+            }
+        }
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "message_delta")) {
+        if (jsonObject(root, "delta")) |delta| finish_reason.* = mapAnthropicFinish(jsonString(delta, "stop_reason"));
+        if (jsonObject(root, "usage")) |value| usage.output_tokens = jsonU64(value, "output_tokens");
+    }
+}
+
+fn consumeResponsesEvent(
+    alloc: Allocator,
+    root: std.json.Value,
+    content: *std.ArrayList(u8),
+    tools: *std.ArrayList(ToolAccumulator),
+    usage: *types.Usage,
+    finish_reason: *?types.ProviderFinishReason,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    on_tool_input_chunk: ?stream_provider.StreamCallback,
+    content_capture_limit: ?usize,
+) !void {
+    const event_type = jsonString(root, "type") orelse return;
+    if (std.mem.eql(u8, event_type, "response.output_text.delta")) {
+        if (jsonString(root, "delta")) |delta| try emitContent(alloc, content, delta, callback_ctx, on_content_chunk, content_capture_limit);
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "response.reasoning_summary_text.delta")) {
+        if (on_reasoning_chunk) |callback| if (jsonString(root, "delta")) |delta| callback(callback_ctx, delta);
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "response.output_item.added")) {
+        const item = jsonObject(root, "item") orelse return;
+        if (!std.mem.eql(u8, jsonString(item, "type") orelse "", "function_call")) return;
+        var tool: ToolAccumulator = .{};
+        errdefer tool.deinit(alloc);
+        try tool.id.appendSlice(alloc, jsonString(item, "call_id") orelse jsonString(item, "id") orelse "");
+        try tool.item_id.appendSlice(alloc, jsonString(item, "id") orelse "");
+        try tool.name.appendSlice(alloc, jsonString(item, "name") orelse "");
+        if (jsonString(item, "arguments")) |arguments| try tool.arguments.appendSlice(alloc, arguments);
+        try tools.append(alloc, tool);
+        if (on_tool_start) |callback| callback(callback_ctx, tool.id.items, tool.name.items, null);
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "response.function_call_arguments.delta")) {
+        const id = jsonString(root, "item_id") orelse jsonString(root, "call_id");
+        const delta = jsonString(root, "delta") orelse return;
+        if (findTool(tools.items, id)) |tool| {
+            try tool.arguments.appendSlice(alloc, delta);
+            if (on_tool_input_chunk) |callback| callback(callback_ctx, delta);
+        }
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "response.output_item.done")) {
+        const item = jsonObject(root, "item") orelse return;
+        if (!std.mem.eql(u8, jsonString(item, "type") orelse "", "function_call")) return;
+        const id = jsonString(item, "call_id") orelse jsonString(item, "id");
+        if (findTool(tools.items, id)) |tool| if (jsonString(item, "arguments")) |arguments| {
+            tool.arguments.clearRetainingCapacity();
+            try tool.arguments.appendSlice(alloc, arguments);
+        };
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "response.completed") or std.mem.eql(u8, event_type, "response.incomplete")) {
+        const response = jsonObject(root, "response") orelse root;
+        if (jsonObject(response, "usage")) |value| {
+            usage.input_tokens = jsonU64(value, "input_tokens");
+            usage.output_tokens = jsonU64(value, "output_tokens");
+        }
+        finish_reason.* = if (std.mem.eql(u8, event_type, "response.incomplete")) .length else if (tools.items.len > 0) .tool_calls else .stop;
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "response.failed")) finish_reason.* = .provider_error;
+}
+
+fn emitContent(alloc: Allocator, content: *std.ArrayList(u8), delta: []const u8, ctx: *anyopaque, callback: stream_provider.StreamCallback, limit: ?usize) !void {
+    const retained = if (limit) |max| delta[0..@min(delta.len, max -| content.items.len)] else delta;
+    try content.appendSlice(alloc, retained);
+    callback(ctx, delta);
+}
+
+fn findTool(tools: []ToolAccumulator, id: ?[]const u8) ?*ToolAccumulator {
+    if (id) |needle| for (tools) |*tool| {
+        if (std.mem.eql(u8, tool.id.items, needle) or std.mem.eql(u8, tool.item_id.items, needle)) return tool;
+    };
+    return null;
+}
+
+fn appendJsonValue(alloc: Allocator, out: *std.ArrayList(u8), value: std.json.Value) !void {
+    var writer: std.Io.Writer.Allocating = .init(alloc);
+    defer writer.deinit();
+    try std.json.Stringify.value(value, .{}, &writer.writer);
+    try out.appendSlice(alloc, writer.writer.buffered());
+}
+
+fn jsonString(value: std.json.Value, key: []const u8) ?[]const u8 {
+    if (value != .object) return null;
+    const child = value.object.get(key) orelse return null;
+    return if (child == .string) child.string else null;
+}
+
+fn jsonObject(value: std.json.Value, key: []const u8) ?std.json.Value {
+    if (value != .object) return null;
+    const child = value.object.get(key) orelse return null;
+    return if (child == .object) child else null;
+}
+
+fn jsonU64(value: std.json.Value, key: []const u8) ?u64 {
+    if (value != .object) return null;
+    const child = value.object.get(key) orelse return null;
+    return if (child == .integer and child.integer >= 0) @intCast(child.integer) else null;
+}
+
+fn mapAnthropicFinish(reason: ?[]const u8) ?types.ProviderFinishReason {
+    const value = reason orelse return null;
+    if (std.mem.eql(u8, value, "end_turn") or std.mem.eql(u8, value, "stop_sequence")) return .stop;
+    if (std.mem.eql(u8, value, "max_tokens")) return .length;
+    if (std.mem.eql(u8, value, "tool_use")) return .tool_calls;
+    if (std.mem.eql(u8, value, "refusal")) return .content_filter;
+    return .other;
+}
+
+fn freeCompletion(alloc: Allocator, completion: *types.GatewayCompletion) void {
+    if (completion.content) |content| alloc.free(@constCast(content));
+    types.freeToolCallSlice(alloc, @constCast(completion.tool_calls));
+    completion.* = .{};
+}
+
+const TestCapture = struct {
+    content: std.ArrayList(u8) = .empty,
+    reasoning: std.ArrayList(u8) = .empty,
+    tool_input: std.ArrayList(u8) = .empty,
+    tool_starts: usize = 0,
+
+    fn deinit(self: *@This(), alloc: Allocator) void {
+        self.content.deinit(alloc);
+        self.reasoning.deinit(alloc);
+        self.tool_input.deinit(alloc);
+    }
+
+    fn onContent(raw: *anyopaque, chunk: []const u8) void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        self.content.appendSlice(std.testing.allocator, chunk) catch unreachable;
+    }
+
+    fn onReasoning(raw: *anyopaque, chunk: []const u8) void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        self.reasoning.appendSlice(std.testing.allocator, chunk) catch unreachable;
+    }
+
+    fn onToolInput(raw: *anyopaque, chunk: []const u8) void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        self.tool_input.appendSlice(std.testing.allocator, chunk) catch unreachable;
+    }
+
+    fn onToolStart(raw: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8) void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        self.tool_starts += 1;
+    }
+};
+
+fn testBuildRequest(model: []const u8, messages: []const types.ChatMessage, tools: []const u8) stream_provider.BuildRequest {
+    return .{
+        .model = model,
+        .serialized_tools = tools,
+        .messages = messages,
+        .tool_choice = .auto,
+        .provider_options = .{},
+        .max_output_tokens = 4096,
+    };
+}
+
+test "direct request builders project native Anthropic and Responses shapes" {
+    const messages = [_]types.ChatMessage{
+        .{ .role = .system, .content = "Be precise." },
+        .{ .role = .user, .content = "Read it." },
+    };
+    const tools = "[{\"type\":\"provider\",\"id\":\"gateway.perplexity_search\",\"name\":\"perplexity_search\",\"args\":{}},{\"type\":\"function\",\"name\":\"vision\",\"description\":\"Inspect image\",\"inputSchema\":{\"type\":\"object\"}},{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read\",\"inputSchema\":{\"type\":\"object\"}}]";
+
+    const anthropic = try agent_stream_provider.build(std.testing.allocator, testBuildRequest("anthropic-max/claude-opus-4-1", &messages, tools));
+    defer std.testing.allocator.free(anthropic);
+    try std.testing.expect(std.mem.find(u8, anthropic, "\"model\":\"claude-opus-4-1\"") != null);
+    try std.testing.expect(std.mem.find(u8, anthropic, "\"input_schema\":{\"type\":\"object\"}") != null);
+    try std.testing.expect(std.mem.find(u8, anthropic, "gateway.perplexity_search") == null);
+    try std.testing.expect(std.mem.find(u8, anthropic, "\"name\":\"vision\"") == null);
+    try std.testing.expect(std.mem.find(u8, anthropic, claude_code_identity) != null);
+
+    const responses = try agent_stream_provider.build(std.testing.allocator, testBuildRequest("openai-codex/gpt-5.3-codex", &messages, tools));
+    defer std.testing.allocator.free(responses);
+    try std.testing.expect(std.mem.find(u8, responses, "\"model\":\"gpt-5.3-codex\"") != null);
+    try std.testing.expect(std.mem.find(u8, responses, "\"instructions\":\"Be precise.\"") != null);
+    try std.testing.expect(std.mem.find(u8, responses, "\"parameters\":{\"type\":\"object\"}") != null);
+    try std.testing.expect(std.mem.find(u8, responses, "gateway.perplexity_search") == null);
+    try std.testing.expect(std.mem.find(u8, responses, "\"name\":\"vision\"") == null);
+    try std.testing.expect(std.mem.find(u8, responses, "\"store\":false") != null);
+    try std.testing.expect(std.mem.find(u8, responses, "max_output_tokens") == null);
+
+    try std.testing.expectError(error.AgentStreamProviderUnavailable, agent_stream_provider.build(std.testing.allocator, testBuildRequest("anthropic/claude", &messages, tools)));
+}
+
+test "Anthropic SSE normalizes text reasoning tool calls usage and finish" {
+    const payload =
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":12}}}\n\n" ++
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"hmm\"}}\n\n" ++
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n" ++
+        "data: {\"type\":\"content_block_start\",\"content_block\":{\"type\":\"tool_use\",\"id\":\"tool_1\",\"name\":\"read_file\",\"input\":{}}}\n\n" ++
+        "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"a\\\"}\"}}\n\n" ++
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":9}}\n\n";
+    var reader = std.Io.Reader.fixed(payload);
+    var capture: TestCapture = .{};
+    defer capture.deinit(std.testing.allocator);
+    var cancelled = std.atomic.Value(bool).init(false);
+    var completion = try consumeDirectSse(std.testing.allocator, &reader, .anthropic, &capture, TestCapture.onContent, TestCapture.onToolStart, TestCapture.onReasoning, TestCapture.onToolInput, &cancelled, null);
+    defer freeCompletion(std.testing.allocator, &completion);
+
+    try std.testing.expectEqualStrings("hello", completion.content.?);
+    try std.testing.expectEqualStrings("hmm", capture.reasoning.items);
+    try std.testing.expectEqual(@as(usize, 1), capture.tool_starts);
+    try std.testing.expectEqualStrings("{\"path\":\"a\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(@as(?u64, 12), completion.usage.input_tokens);
+    try std.testing.expectEqual(@as(?u64, 9), completion.usage.output_tokens);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}
+
+test "Responses SSE normalizes text reasoning tool calls usage and finish" {
+    const payload =
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"plan\"}\n\n" ++
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"answer\"}\n\n" ++
+        "data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"id\":\"item_1\",\"call_id\":\"call_1\",\"name\":\"shell\",\"arguments\":\"\"}}\n\n" ++
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"item_1\",\"delta\":\"{\\\"cmd\\\":\\\"pwd\\\"}\"}\n\n" ++
+        "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":21,\"output_tokens\":8}}}\n\n" ++
+        "data: [DONE]\n\n";
+    var reader = std.Io.Reader.fixed(payload);
+    var capture: TestCapture = .{};
+    defer capture.deinit(std.testing.allocator);
+    var cancelled = std.atomic.Value(bool).init(false);
+    var completion = try consumeDirectSse(std.testing.allocator, &reader, .codex, &capture, TestCapture.onContent, TestCapture.onToolStart, TestCapture.onReasoning, TestCapture.onToolInput, &cancelled, null);
+    defer freeCompletion(std.testing.allocator, &completion);
+
+    try std.testing.expectEqualStrings("answer", completion.content.?);
+    try std.testing.expectEqualStrings("plan", capture.reasoning.items);
+    try std.testing.expectEqualStrings("{\"cmd\":\"pwd\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(@as(?u64, 21), completion.usage.input_tokens);
+    try std.testing.expectEqual(@as(?u64, 8), completion.usage.output_tokens);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}
+
+test "Codex account id is decoded from an access token" {
+    const token = "header.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF90ZXN0In19.signature";
+    const account_id = (try codexAccountIdFromToken(std.testing.allocator, token)).?;
+    defer std.testing.allocator.free(account_id);
+    try std.testing.expectEqualStrings("acct_test", account_id);
+    try std.testing.expect(!validHeaderValue("acct_test\r\nInjected: yes"));
+}

--- a/src/builtins/direct_providers.zig
+++ b/src/builtins/direct_providers.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 const stream_provider = @import("../core/agent/stream_provider.zig");
+const secret = @import("../core/auth/secret.zig");
 const io_mod = @import("../core/shared/io.zig");
 const types = @import("../core/shared/types.zig");
 
@@ -460,7 +461,7 @@ fn resolveCodexAccountId(alloc: Allocator, token: []const u8) ![]u8 {
     var file = std.Io.Dir.cwd().openFile(io_mod.getIo(), path, .{}) catch return error.CodexAccountIdUnavailable;
     defer file.close(io_mod.getIo());
     const bytes = io_mod.readFileToEnd(alloc, &file, 1024 * 1024) catch return error.CodexAccountIdUnavailable;
-    defer alloc.free(bytes);
+    defer secret.zeroAndFree(alloc, bytes);
     var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch return error.CodexAccountIdUnavailable;
     defer parsed.deinit();
     if (parsed.value != .object) return error.CodexAccountIdUnavailable;

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -605,21 +605,26 @@ const OAuthHttpOperation = struct {
         defer secret.zeroAndFree(self.alloc, response_buffer);
         var response_writer = std.Io.Writer.fixed(response_buffer);
 
+        const extra_headers = [_]std.http.Header{
+            .{ .name = "accept", .value = "application/json" },
+        };
         const result = client.fetch(.{
             .location = .{ .url = self.request.url },
             .method = switch (self.request.method) {
                 .get => .GET,
-                .post_form => .POST,
+                .post_form, .post_json => .POST,
             },
             .payload = self.request.payload,
             .headers = .{
-                .content_type = if (self.request.method == .post_form)
-                    .{ .override = "application/x-www-form-urlencoded" }
-                else
-                    .default,
+                .content_type = switch (self.request.method) {
+                    .get => .default,
+                    .post_form => .{ .override = "application/x-www-form-urlencoded" },
+                    .post_json => .{ .override = "application/json" },
+                },
                 .user_agent = .{ .override = gateway_client.user_agent },
                 .accept_encoding = .omit,
             },
+            .extra_headers = &extra_headers,
             .response_writer = &response_writer,
         }) catch |err| switch (err) {
             error.WriteFailed => return error.OAuthResponseTooLarge,
@@ -630,6 +635,7 @@ const OAuthHttpOperation = struct {
 
         return .{
             .disposition = if (result.status == .ok) .accepted else .rejected,
+            .status = @intFromEnum(result.status),
             .body = try self.alloc.dupe(u8, body),
         };
     }

--- a/src/builtins/providers.zig
+++ b/src/builtins/providers.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const inference_provider = @import("../core/gateway/inference_provider.zig");
+const builtin_gateway = @import("gateway.zig");
+const direct_providers = @import("direct_providers.zig");
+
+pub const agent_stream_provider = stream_provider.Provider{
+    .build_fn = build,
+    .stream_fn = stream,
+};
+
+pub const provider: gateway_provider.Provider = blk: {
+    var value = builtin_gateway.provider;
+    value.agent_stream = agent_stream_provider;
+    break :blk value;
+};
+
+fn build(_: ?*anyopaque, alloc: std.mem.Allocator, request: stream_provider.BuildRequest) anyerror![]u8 {
+    return switch (inference_provider.routeForModel(request.model).provider) {
+        .vercel_ai_gateway => builtin_gateway.agent_stream_provider.build(alloc, request),
+        .anthropic_max, .openai_codex, .xai_direct => direct_providers.agent_stream_provider.build(alloc, request),
+    };
+}
+
+fn stream(_: ?*anyopaque, alloc: std.mem.Allocator, request: stream_provider.Request) anyerror!stream_provider.Result {
+    return switch (inference_provider.routeForModel(request.model).provider) {
+        .vercel_ai_gateway => builtin_gateway.agent_stream_provider.stream(alloc, request),
+        .anthropic_max, .openai_codex, .xai_direct => direct_providers.agent_stream_provider.stream(alloc, request),
+    };
+}
+
+test "router preserves Gateway routes and selects direct adapters" {
+    const types = @import("../core/shared/types.zig");
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "hello" }};
+    const common = stream_provider.BuildRequest{
+        .model = "anthropic-max/claude-opus-4-1",
+        .serialized_tools = "[]",
+        .messages = &messages,
+        .tool_choice = .auto,
+        .provider_options = .{},
+    };
+    const direct = try agent_stream_provider.build(std.testing.allocator, common);
+    defer std.testing.allocator.free(direct);
+    try std.testing.expect(std.mem.find(u8, direct, "\"model\":\"claude-opus-4-1\"") != null);
+
+    var gateway_request = common;
+    gateway_request.model = "anthropic/claude-opus-4-1";
+    const gateway = try agent_stream_provider.build(std.testing.allocator, gateway_request);
+    defer std.testing.allocator.free(gateway);
+    try std.testing.expect(std.mem.find(u8, gateway, "\"prompt\"") != null);
+}

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const credentials = @import("../../auth/credentials.zig");
 const builtin = @import("builtin");
 const agent_steps = @import("../../config/agent_steps.zig");
 const model_capabilities = @import("../../config/model_capabilities.zig");
@@ -1419,7 +1420,7 @@ fn refreshGatewayCredentialForJob(
     trace_ctx: TraceContext,
 ) !bool {
     const source = job.credential_source orelse return false;
-    if (source != .fx_login) return false;
+    if (!credentials.sourceRefreshable(source)) return false;
     const refresh = deps.refresh_gateway_credential orelse return false;
 
     const refreshed = refresh(deps.ctx, alloc, source, mode) catch |err| {

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -363,7 +363,7 @@ pub fn Bindings(comptime App: type) type {
             mode: auth_runtime.CredentialRefreshMode,
         ) !?[]u8 {
             const app: *App = @ptrCast(@alignCast(raw_ctx));
-            return auth_runtime.refreshFxLoginToken(
+            return auth_runtime.refreshCredentialToken(
                 app.auth.oauthTransport(),
                 alloc,
                 source,

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -399,7 +399,14 @@ fn loadStartupStateFromOwnedWorkspace(
     state.prompt_history_enabled = settings.prompt_history_enabled orelse true;
     state.prompt_history_store_allowed = detailed.prompt_history_store_allowed;
     if (credential_mode) |mode| {
-        const resolution = try credentials.resolvePreferring(alloc, transport, secret_store, mode, settings.credential_source);
+        const resolution = try credentials.resolveForModel(
+            alloc,
+            transport,
+            secret_store,
+            mode,
+            state.selected_model,
+            settings.credential_source,
+        );
         state.credential = resolution.credential;
         state.stored_key_status = resolution.stored_key_status;
     }

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -23,6 +23,10 @@ const credential_source_order = [_]credentials.Source{
     .ai_gateway_api_key,
     .fx_login,
     .stored_key,
+    .anthropic_oauth_token,
+    .anthropic_api_key,
+    .codex_login,
+    .xai_api_key,
 };
 
 const SourceProbeFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!bool;
@@ -1118,6 +1122,21 @@ pub const Runtime = struct {
 
     pub fn selectSource(self: *Self, alloc: Allocator, source: credentials.Source) !?bool {
         return self.selectSourceWithLoader(alloc, source, self, loadRuntimeCredentialSource);
+    }
+
+    pub fn selectForModel(self: *Self, alloc: Allocator, model: []const u8) !bool {
+        const resolution = try credentials.resolveForModel(
+            alloc,
+            self.oauth_transport,
+            self.secret_store,
+            .refresh_if_needed,
+            model,
+            self.credentialSource(),
+        );
+        self.stored_key_status = resolution.stored_key_status;
+        var credential = resolution.credential orelse return false;
+        defer credential.deinit(alloc);
+        return self.adoptCredential(alloc, &credential);
     }
 
     pub fn refreshFxLoginIfNeeded(self: *Self, alloc: Allocator) !bool {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -4,6 +4,7 @@ const credentials = @import("credentials.zig");
 const host = @import("../hosts/host.zig");
 const login_flow = @import("login_flow.zig");
 const oauth_transport = @import("oauth_transport.zig");
+const provider_oauth = @import("provider_oauth.zig");
 const secret = @import("secret.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
@@ -23,9 +24,12 @@ const credential_source_order = [_]credentials.Source{
     .ai_gateway_api_key,
     .fx_login,
     .stored_key,
+    .anthropic_fx_login,
     .anthropic_oauth_token,
     .anthropic_api_key,
+    .codex_fx_login,
     .codex_login,
+    .xai_oauth_token,
     .xai_api_key,
 };
 
@@ -99,24 +103,29 @@ pub const FailureSnapshot = struct {
     }
 };
 
-/// Returns an owned token when the selected fx-login credential can be
+/// Returns an owned token when the selected managed OAuth credential can be
 /// refreshed. The caller must release it with `secret.zeroAndFree`.
-pub fn refreshFxLoginToken(
+pub fn refreshCredentialToken(
     transport: oauth_transport.Provider,
     alloc: Allocator,
     source: credentials.Source,
     mode: CredentialRefreshMode,
 ) !?[]u8 {
-    if (source != .fx_login) return null;
-
-    var credential = switch (mode) {
-        .if_needed => (try credentials.loadFxLoginCredential(alloc, transport)) orelse return null,
-        .force => (try credentials.refreshFxLoginCredential(alloc, transport)) orelse return null,
-    };
-    defer credential.deinit(alloc);
-
-    const token = credential.token;
-    credential.token = &.{};
+    if (source == .fx_login) {
+        var credential = switch (mode) {
+            .if_needed => (try credentials.loadFxLoginCredential(alloc, transport)) orelse return null,
+            .force => (try credentials.refreshFxLoginCredential(alloc, transport)) orelse return null,
+        };
+        defer credential.deinit(alloc);
+        const token = credential.token;
+        credential.token = &.{};
+        return token;
+    }
+    const provider = provider_oauth.Provider.fromCredentialSource(source) orelse return null;
+    var session = (try provider_oauth.refreshManagedSession(alloc, transport, provider, mode == .force)) orelse return null;
+    defer session.deinit(alloc);
+    const token = session.access_token;
+    session.access_token = &.{};
     return token;
 }
 
@@ -1456,7 +1465,7 @@ fn expectApiKeyAllocationCleared(
 
 test "auth runtime token refresher ignores non-refreshable credential sources" {
     for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .stored_key }) |source| {
-        try std.testing.expect((try refreshFxLoginToken(
+        try std.testing.expect((try refreshCredentialToken(
             oauth_transport.unavailable_provider,
             std.testing.allocator,
             source,

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -6,6 +6,7 @@ const io_mod = @import("../shared/io.zig");
 const oauth = @import("oauth.zig");
 const oauth_session = @import("oauth_session.zig");
 const oauth_transport = @import("oauth_transport.zig");
+const provider_oauth = @import("provider_oauth.zig");
 const secret = @import("secret.zig");
 const types = @import("../shared/types.zig");
 const inference_provider = @import("../gateway/inference_provider.zig");
@@ -134,9 +135,12 @@ pub fn catalogAccessForCredential(
         .vercel_oidc_token => .vercel_oidc_token,
         .ai_gateway_api_key => .ai_gateway_api_key,
         .stored_key => .stored_key,
+        .anthropic_fx_login,
         .anthropic_oauth_token,
         .anthropic_api_key,
+        .codex_fx_login,
         .codex_login,
+        .xai_oauth_token,
         .xai_api_key,
         => return .{ .public_only = .no_credential },
         .fx_login => blk: {
@@ -236,9 +240,9 @@ pub fn resolveForModel(
             mode,
             if (preferred) |source| if (sourceSupportsProvider(source, route.provider)) source else null else null,
         ),
-        .anthropic_max => .{ .credential = try loadAnthropicCredential(alloc) },
-        .openai_codex => .{ .credential = try loadCodexCredential(alloc) },
-        .xai_direct => .{ .credential = try loadEnvCredential(alloc, "XAI_API_KEY", .xai_api_key) },
+        .anthropic_max => .{ .credential = try loadAnthropicCredential(alloc, transport, mode) },
+        .openai_codex => .{ .credential = try loadCodexCredential(alloc, transport, mode) },
+        .xai_direct => .{ .credential = try loadXaiCredential(alloc, transport, mode) },
     };
 }
 
@@ -252,9 +256,9 @@ fn sourceSupportsProvider(source: Source, provider: inference_provider.ProviderI
             .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key => true,
             else => false,
         },
-        .anthropic_max => source == .anthropic_oauth_token or source == .anthropic_api_key,
-        .openai_codex => source == .codex_login,
-        .xai_direct => source == .xai_api_key,
+        .anthropic_max => source == .anthropic_fx_login or source == .anthropic_oauth_token or source == .anthropic_api_key,
+        .openai_codex => source == .codex_fx_login or source == .codex_login,
+        .xai_direct => source == .xai_oauth_token or source == .xai_api_key,
     };
 }
 
@@ -331,9 +335,12 @@ pub fn loadSource(
         .ai_gateway_api_key => loadEnvCredential(alloc, "AI_GATEWAY_API_KEY", source),
         .fx_login => loadFxLoginCredential(alloc, transport),
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
+        .anthropic_fx_login => loadManagedProviderCredential(alloc, transport, .anthropic, .refresh_if_needed),
         .anthropic_oauth_token => loadAnthropicOAuthCredential(alloc),
         .anthropic_api_key => loadEnvCredential(alloc, "ANTHROPIC_API_KEY", source),
-        .codex_login => loadCodexCredential(alloc),
+        .codex_fx_login => loadManagedProviderCredential(alloc, transport, .openai_codex, .refresh_if_needed),
+        .codex_login => loadCodexCredential(alloc, transport, .refresh_if_needed),
+        .xai_oauth_token => loadManagedProviderCredential(alloc, transport, .xai, .refresh_if_needed),
         .xai_api_key => loadEnvCredential(alloc, "XAI_API_KEY", source),
     };
 }
@@ -371,9 +378,15 @@ pub fn sourceExists(
             secret.zeroAndFree(alloc, value);
             break :blk true;
         },
+        .anthropic_fx_login => managedProviderExists(alloc, .anthropic),
         .anthropic_oauth_token => probeCredential(alloc, try loadAnthropicOAuthCredential(alloc)),
         .anthropic_api_key => nonEmptyEnvValue("ANTHROPIC_API_KEY") != null,
-        .codex_login => probeCredential(alloc, try loadCodexCredential(alloc)),
+        .codex_fx_login => managedProviderExists(alloc, .openai_codex),
+        .codex_login => blk: {
+            if (nonEmptyEnvValue("CODEX_ACCESS_TOKEN") != null) break :blk true;
+            break :blk try managedOrExternalSourceExists(alloc, .openai_codex, ".codex/auth.json", &.{ "tokens", "access_token" });
+        },
+        .xai_oauth_token => managedProviderExists(alloc, .xai),
         .xai_api_key => nonEmptyEnvValue("XAI_API_KEY") != null,
     };
 }
@@ -384,7 +397,8 @@ fn probeCredential(alloc: std.mem.Allocator, loaded: ?Credential) bool {
     return true;
 }
 
-fn loadAnthropicCredential(alloc: std.mem.Allocator) !?Credential {
+fn loadAnthropicCredential(alloc: std.mem.Allocator, transport: oauth_transport.Provider, mode: LoadMode) !?Credential {
+    if (try loadManagedProviderCredential(alloc, transport, .anthropic, mode)) |credential| return credential;
     if (try loadAnthropicOAuthCredential(alloc)) |credential| return credential;
     return loadEnvCredential(alloc, "ANTHROPIC_API_KEY", .anthropic_api_key);
 }
@@ -405,9 +419,48 @@ fn loadAnthropicOAuthCredential(alloc: std.mem.Allocator) !?Credential {
     return null;
 }
 
-fn loadCodexCredential(alloc: std.mem.Allocator) !?Credential {
+fn loadCodexCredential(alloc: std.mem.Allocator, transport: oauth_transport.Provider, mode: LoadMode) !?Credential {
+    if (try loadManagedProviderCredential(alloc, transport, .openai_codex, mode)) |credential| return credential;
     if (try loadEnvCredential(alloc, "CODEX_ACCESS_TOKEN", .codex_login)) |credential| return credential;
     return loadJsonCredential(alloc, ".codex/auth.json", &.{ "tokens", "access_token" }, .codex_login);
+}
+
+fn loadXaiCredential(alloc: std.mem.Allocator, transport: oauth_transport.Provider, mode: LoadMode) !?Credential {
+    if (try loadManagedProviderCredential(alloc, transport, .xai, mode)) |credential| return credential;
+    return loadEnvCredential(alloc, "XAI_API_KEY", .xai_api_key);
+}
+
+fn loadManagedProviderCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+    provider: provider_oauth.Provider,
+    mode: LoadMode,
+) !?Credential {
+    var session = (try provider_oauth.loadManagedSession(alloc, transport, provider, mode == .refresh_if_needed)) orelse return null;
+    defer session.deinit(alloc);
+    const token = session.access_token;
+    session.access_token = &.{};
+    return .{
+        .token = token,
+        .source = provider.credentialSource(),
+        .refresh_after_ms = oauth_session.refresh_deadline_ms(session.expires_at_ms),
+    };
+}
+
+fn managedProviderExists(alloc: std.mem.Allocator, provider: provider_oauth.Provider) !bool {
+    var session = (try oauth_session.loadNamed(alloc, provider.fileName(), @tagName(provider))) orelse return false;
+    session.deinit(alloc);
+    return true;
+}
+
+fn managedOrExternalSourceExists(
+    alloc: std.mem.Allocator,
+    provider: provider_oauth.Provider,
+    relative_path: []const u8,
+    keys: []const []const u8,
+) !bool {
+    if (try managedProviderExists(alloc, provider)) return true;
+    return probeCredential(alloc, try loadJsonCredential(alloc, relative_path, keys, provider.credentialSource()));
 }
 
 fn loadJsonCredential(
@@ -588,15 +641,18 @@ pub fn sourceLabel(source: Source) []const u8 {
         .ai_gateway_api_key => "AI_GATEWAY_API_KEY",
         .fx_login => "fx login",
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
+        .anthropic_fx_login => "fx Anthropic login",
         .anthropic_oauth_token => "Anthropic Max login",
         .anthropic_api_key => "ANTHROPIC_API_KEY",
+        .codex_fx_login => "fx Codex login",
         .codex_login => "ChatGPT/Codex login",
+        .xai_oauth_token => "xAI Grok/X login",
         .xai_api_key => "XAI_API_KEY",
     };
 }
 
 pub fn sourceRefreshable(source: Source) bool {
-    return source == .fx_login;
+    return source == .fx_login or provider_oauth.Provider.fromCredentialSource(source) != null;
 }
 
 test "stored key label discloses the backend that answered" {
@@ -874,9 +930,12 @@ test "provider-qualified models resolve only their provider credential" {
 
 test "direct provider credentials never authorize the Gateway catalog" {
     const direct_sources = [_]Source{
+        .anthropic_fx_login,
         .anthropic_oauth_token,
         .anthropic_api_key,
+        .codex_fx_login,
         .codex_login,
+        .xai_oauth_token,
         .xai_api_key,
     };
     for (direct_sources) |source| {
@@ -889,9 +948,12 @@ test "direct provider credentials never authorize the Gateway catalog" {
 test "credential sources are scoped to their model route" {
     try std.testing.expect(sourceSupportsModel(.fx_login, "anthropic/claude-opus"));
     try std.testing.expect(!sourceSupportsModel(.anthropic_oauth_token, "anthropic/claude-opus"));
+    try std.testing.expect(sourceSupportsModel(.anthropic_fx_login, "anthropic-max/claude-opus"));
     try std.testing.expect(sourceSupportsModel(.anthropic_oauth_token, "anthropic-max/claude-opus"));
     try std.testing.expect(!sourceSupportsModel(.ai_gateway_api_key, "anthropic-max/claude-opus"));
+    try std.testing.expect(sourceSupportsModel(.codex_fx_login, "openai-codex/gpt-5"));
     try std.testing.expect(sourceSupportsModel(.codex_login, "openai-codex/gpt-5"));
+    try std.testing.expect(sourceSupportsModel(.xai_oauth_token, "xai-direct/grok-4"));
     try std.testing.expect(sourceSupportsModel(.xai_api_key, "xai-direct/grok-4"));
 }
 

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -8,6 +8,7 @@ const oauth_session = @import("oauth_session.zig");
 const oauth_transport = @import("oauth_transport.zig");
 const secret = @import("secret.zig");
 const types = @import("../shared/types.zig");
+const inference_provider = @import("../gateway/inference_provider.zig");
 
 pub const Source = types.CredentialSource;
 
@@ -133,6 +134,11 @@ pub fn catalogAccessForCredential(
         .vercel_oidc_token => .vercel_oidc_token,
         .ai_gateway_api_key => .ai_gateway_api_key,
         .stored_key => .stored_key,
+        .anthropic_oauth_token,
+        .anthropic_api_key,
+        .codex_login,
+        .xai_api_key,
+        => return .{ .public_only = .no_credential },
         .fx_login => blk: {
             const team = team_context orelse
                 return .{ .public_only = .fx_login_team_required };
@@ -211,6 +217,47 @@ pub fn resolve(
     return resolvePreferring(alloc, transport, secret_store, mode, null);
 }
 
+/// Resolves credentials for the route encoded by `model`. Existing model IDs
+/// remain Vercel AI Gateway routes; direct routes use provider-owned sources.
+pub fn resolveForModel(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+    secret_store: host.SecretStore,
+    mode: LoadMode,
+    model: []const u8,
+    preferred: ?Source,
+) !Resolution {
+    const route = inference_provider.routeForModel(model);
+    return switch (route.provider) {
+        .vercel_ai_gateway => resolvePreferring(
+            alloc,
+            transport,
+            secret_store,
+            mode,
+            if (preferred) |source| if (sourceSupportsProvider(source, route.provider)) source else null else null,
+        ),
+        .anthropic_max => .{ .credential = try loadAnthropicCredential(alloc) },
+        .openai_codex => .{ .credential = try loadCodexCredential(alloc) },
+        .xai_direct => .{ .credential = try loadEnvCredential(alloc, "XAI_API_KEY", .xai_api_key) },
+    };
+}
+
+pub fn sourceSupportsModel(source: Source, model: []const u8) bool {
+    return sourceSupportsProvider(source, inference_provider.routeForModel(model).provider);
+}
+
+fn sourceSupportsProvider(source: Source, provider: inference_provider.ProviderId) bool {
+    return switch (provider) {
+        .vercel_ai_gateway => switch (source) {
+            .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key => true,
+            else => false,
+        },
+        .anthropic_max => source == .anthropic_oauth_token or source == .anthropic_api_key,
+        .openai_codex => source == .codex_login,
+        .xai_direct => source == .xai_api_key,
+    };
+}
+
 /// `preferred` is the source the user last chose in the hub. It wins over the
 /// precedence order below, including over the environment, because it is an
 /// explicit choice rather than a default. A preferred source that no longer
@@ -284,6 +331,10 @@ pub fn loadSource(
         .ai_gateway_api_key => loadEnvCredential(alloc, "AI_GATEWAY_API_KEY", source),
         .fx_login => loadFxLoginCredential(alloc, transport),
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
+        .anthropic_oauth_token => loadAnthropicOAuthCredential(alloc),
+        .anthropic_api_key => loadEnvCredential(alloc, "ANTHROPIC_API_KEY", source),
+        .codex_login => loadCodexCredential(alloc),
+        .xai_api_key => loadEnvCredential(alloc, "XAI_API_KEY", source),
     };
 }
 
@@ -320,7 +371,73 @@ pub fn sourceExists(
             secret.zeroAndFree(alloc, value);
             break :blk true;
         },
+        .anthropic_oauth_token => probeCredential(alloc, try loadAnthropicOAuthCredential(alloc)),
+        .anthropic_api_key => nonEmptyEnvValue("ANTHROPIC_API_KEY") != null,
+        .codex_login => probeCredential(alloc, try loadCodexCredential(alloc)),
+        .xai_api_key => nonEmptyEnvValue("XAI_API_KEY") != null,
     };
+}
+
+fn probeCredential(alloc: std.mem.Allocator, loaded: ?Credential) bool {
+    var credential = loaded orelse return false;
+    credential.deinit(alloc);
+    return true;
+}
+
+fn loadAnthropicCredential(alloc: std.mem.Allocator) !?Credential {
+    if (try loadAnthropicOAuthCredential(alloc)) |credential| return credential;
+    return loadEnvCredential(alloc, "ANTHROPIC_API_KEY", .anthropic_api_key);
+}
+
+fn loadAnthropicOAuthCredential(alloc: std.mem.Allocator) !?Credential {
+    inline for (&.{ "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_OAUTH_TOKEN" }) |name| {
+        if (try loadEnvCredential(alloc, name, .anthropic_oauth_token)) |credential| {
+            if (std.mem.startsWith(u8, credential.token, "sk-ant-oat")) return credential;
+            var rejected = credential;
+            rejected.deinit(alloc);
+        }
+    }
+    if (try loadJsonCredential(alloc, ".claude/.credentials.json", &.{ "claudeAiOauth", "accessToken" }, .anthropic_oauth_token)) |credential| {
+        if (std.mem.startsWith(u8, credential.token, "sk-ant-oat")) return credential;
+        var rejected = credential;
+        rejected.deinit(alloc);
+    }
+    return null;
+}
+
+fn loadCodexCredential(alloc: std.mem.Allocator) !?Credential {
+    if (try loadEnvCredential(alloc, "CODEX_ACCESS_TOKEN", .codex_login)) |credential| return credential;
+    return loadJsonCredential(alloc, ".codex/auth.json", &.{ "tokens", "access_token" }, .codex_login);
+}
+
+fn loadJsonCredential(
+    alloc: std.mem.Allocator,
+    relative_path: []const u8,
+    keys: []const []const u8,
+    source: Source,
+) !?Credential {
+    const home = io_mod.getenv("HOME") orelse return null;
+    const path = try std.fs.path.join(alloc, &.{ home, relative_path });
+    defer alloc.free(path);
+    var file = io_mod.openExistingRegularFile(std.Io.Dir.cwd(), path, .read_only) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer file.close(io_mod.getIo());
+    const stat = try file.stat(io_mod.getIo());
+    if (stat.kind != .file or stat.size > 1024 * 1024) return null;
+    const bytes = try io_mod.readFileToEnd(alloc, &file, 1024 * 1024 + 1);
+    defer secret.zeroAndFree(alloc, bytes);
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch return null;
+    defer parsed.deinit();
+    var value = parsed.value;
+    for (keys) |key| {
+        if (value != .object) return null;
+        value = value.object.get(key) orelse return null;
+    }
+    if (value != .string) return null;
+    const token = nonEmptyValue(value.string) orelse return null;
+    return .{ .token = try alloc.dupe(u8, token), .source = source };
 }
 
 fn loadEnvCredential(
@@ -471,6 +588,10 @@ pub fn sourceLabel(source: Source) []const u8 {
         .ai_gateway_api_key => "AI_GATEWAY_API_KEY",
         .fx_login => "fx login",
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
+        .anthropic_oauth_token => "Anthropic Max login",
+        .anthropic_api_key => "ANTHROPIC_API_KEY",
+        .codex_login => "ChatGPT/Codex login",
+        .xai_api_key => "XAI_API_KEY",
     };
 }
 
@@ -714,6 +835,64 @@ test "source-specific credential loading bypasses generic precedence" {
     try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .ai_gateway_api_key));
     try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .vercel_oidc_token));
     try std.testing.expect(!(try sourceExists(alloc, host.unavailable_secret_store, .stored_key)));
+}
+
+test "provider-qualified models resolve only their provider credential" {
+    const alloc = std.testing.allocator;
+    const env = try CredentialTestEnv.install(alloc, &.{
+        .{ "AI_GATEWAY_API_KEY", "gateway-key" },
+        .{ "ANTHROPIC_OAUTH_TOKEN", "sk-ant-oat-test" },
+        .{ "CODEX_ACCESS_TOKEN", "codex-token" },
+        .{ "XAI_API_KEY", "xai-key" },
+    });
+    defer env.deinit();
+
+    const cases = [_]struct {
+        model: []const u8,
+        source: Source,
+        token: []const u8,
+    }{
+        .{ .model = "anthropic-max/claude-opus", .source = .anthropic_oauth_token, .token = "sk-ant-oat-test" },
+        .{ .model = "openai-codex/gpt-5", .source = .codex_login, .token = "codex-token" },
+        .{ .model = "xai-direct/grok-4", .source = .xai_api_key, .token = "xai-key" },
+        .{ .model = "anthropic/claude-opus", .source = .ai_gateway_api_key, .token = "gateway-key" },
+    };
+    for (cases) |case| {
+        var resolution = try resolveForModel(
+            alloc,
+            oauth_transport.unavailable_provider,
+            host.unavailable_secret_store,
+            .stored,
+            case.model,
+            null,
+        );
+        defer if (resolution.credential) |*credential| credential.deinit(alloc);
+        try std.testing.expectEqual(case.source, resolution.credential.?.source);
+        try std.testing.expectEqualStrings(case.token, resolution.credential.?.token);
+    }
+}
+
+test "direct provider credentials never authorize the Gateway catalog" {
+    const direct_sources = [_]Source{
+        .anthropic_oauth_token,
+        .anthropic_api_key,
+        .codex_login,
+        .xai_api_key,
+    };
+    for (direct_sources) |source| {
+        const access = catalogAccessForCredential(source, "provider-secret", null);
+        try std.testing.expect(access.authorizationCredential() == null);
+        try std.testing.expect(access.teamContext() == null);
+    }
+}
+
+test "credential sources are scoped to their model route" {
+    try std.testing.expect(sourceSupportsModel(.fx_login, "anthropic/claude-opus"));
+    try std.testing.expect(!sourceSupportsModel(.anthropic_oauth_token, "anthropic/claude-opus"));
+    try std.testing.expect(sourceSupportsModel(.anthropic_oauth_token, "anthropic-max/claude-opus"));
+    try std.testing.expect(!sourceSupportsModel(.ai_gateway_api_key, "anthropic-max/claude-opus"));
+    try std.testing.expect(sourceSupportsModel(.codex_login, "openai-codex/gpt-5"));
+    try std.testing.expect(sourceSupportsModel(.xai_api_key, "xai-direct/grok-4"));
 }
 
 test "a remembered choice outranks the environment" {

--- a/src/core/auth/js_host_auth.zig
+++ b/src/core/auth/js_host_auth.zig
@@ -64,12 +64,16 @@ fn executeOAuthRequest(
             .name = "content-type",
             .value = "application/x-www-form-urlencoded",
         }},
+        .post_json => &.{.{
+            .name = "content-type",
+            .value = "application/json",
+        }},
     };
     var response = try executeRequest(
         alloc,
         switch (request.method) {
             .get => "GET",
-            .post_form => "POST",
+            .post_form, .post_json => "POST",
         },
         request.url,
         headers,
@@ -126,6 +130,7 @@ fn executeRequest(
     }
     return .{
         .disposition = if (status == 200) .accepted else .rejected,
+        .status = status,
         .body = try alloc.dupe(u8, response_buffer[0..@intCast(response_len)]),
     };
 }

--- a/src/core/auth/oauth_session.zig
+++ b/src/core/auth/oauth_session.zig
@@ -90,6 +90,8 @@ pub const Mutation = if (host_target.is_wasm) HostMutation else NativeMutation;
 const NativeMutation = struct {
     fx_dir: io_mod.VerifiedDir,
     lock: io_mod.TimedAdvisoryLock,
+    file_name: []const u8 = auth_file_name,
+    expected_issuer: ?[]const u8 = null,
 
     pub fn deinit(self: *Mutation) void {
         self.lock.release();
@@ -98,17 +100,17 @@ const NativeMutation = struct {
     }
 
     pub fn load(self: *Mutation, alloc: Allocator) !?Session {
-        return loadFromDir(alloc, &self.fx_dir.dir, .report_open_failure);
+        return loadFromDir(alloc, &self.fx_dir.dir, self.file_name, self.expected_issuer, .report_open_failure);
     }
 
     pub fn save(self: *Mutation, alloc: Allocator, session: Session) !void {
         const text = try stringify(alloc, session);
         defer secret.zeroAndFree(alloc, text);
-        try io_mod.durableReplaceVerified(alloc, &self.fx_dir, auth_file_name, text);
+        try io_mod.durableReplaceVerified(alloc, &self.fx_dir, self.file_name, text);
     }
 
     pub fn delete(self: *Mutation) !DeleteOutcome {
-        return deleteAuthFile(&self.fx_dir.dir, .{});
+        return deleteSessionFile(&self.fx_dir.dir, self.file_name, .{});
     }
 };
 
@@ -241,7 +243,20 @@ pub fn load(alloc: Allocator) !?Session {
     };
     defer fx_dir.close(io_mod.getIo());
 
-    return loadFromDir(alloc, &fx_dir, .tolerate_open_failure);
+    return loadFromDir(alloc, &fx_dir, auth_file_name, null, .tolerate_open_failure);
+}
+
+pub fn loadNamed(alloc: Allocator, file_name: []const u8, expected_issuer: []const u8) !?Session {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return null;
+    var home_dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch return null;
+    defer home_dir.close(io_mod.getIo());
+    var fx_dir = home_dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch return null;
+    defer fx_dir.close(io_mod.getIo());
+    return loadFromDir(alloc, &fx_dir, file_name, expected_issuer, .tolerate_open_failure);
 }
 
 fn loadFromHost(alloc: Allocator, store: js_host_auth.SessionStore) !?Session {
@@ -256,8 +271,8 @@ fn loadFromHost(alloc: Allocator, store: js_host_auth.SessionStore) !?Session {
     };
 }
 
-fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, mode: LoadMode) !?Session {
-    var file = fx_dir.openFile(io_mod.getIo(), auth_file_name, .{
+fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, file_name: []const u8, expected_issuer: ?[]const u8, mode: LoadMode) !?Session {
+    var file = fx_dir.openFile(io_mod.getIo(), file_name, .{
         .mode = .read_only,
         .allow_directory = false,
         .follow_symlinks = false,
@@ -279,7 +294,7 @@ fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, mode: LoadMode) !?Session 
 
     const bytes = try io_mod.readFileToEnd(alloc, &file, max_auth_file_bytes);
     defer secret.zeroAndFree(alloc, bytes);
-    return parse(alloc, bytes) catch |err| switch (err) {
+    return parseExpectedIssuer(alloc, bytes, expected_issuer) catch |err| switch (err) {
         error.OutOfMemory => return err,
         else => {
             debug_trace.logf("auth", "session load failed step=parse err={s}", .{@errorName(err)});
@@ -300,6 +315,18 @@ pub fn saveNewSession(alloc: Allocator, session: Session) !void {
     try mutation.save(alloc, session);
 }
 
+pub fn saveNamed(alloc: Allocator, file_name: []const u8, expected_issuer: []const u8, session: Session) !void {
+    var mutation = (try beginNamedMutation(file_name, expected_issuer)) orelse return error.ProviderOAuthUnsupported;
+    defer mutation.deinit();
+    try mutation.save(alloc, session);
+}
+
+pub fn deleteNamed(file_name: []const u8, expected_issuer: []const u8) !DeleteOutcome {
+    var mutation = (try beginNamedMutation(file_name, expected_issuer)) orelse return .missing;
+    defer mutation.deinit();
+    return mutation.delete();
+}
+
 pub fn beginExistingMutation() !?Mutation {
     if (comptime host_target.is_wasm) {
         return @as(?Mutation, HostMutation.init(js_host_auth.oauth_session_store));
@@ -314,7 +341,20 @@ pub fn beginExistingMutation() !?Mutation {
         error.FileNotFound => return null,
         else => return err,
     };
-    return @as(?Mutation, try lockMutation(fx_dir));
+    return @as(?Mutation, try lockMutation(fx_dir, auth_file_name));
+}
+
+pub fn beginNamedMutation(file_name: []const u8, expected_issuer: []const u8) !?Mutation {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+    const fx_dir = try io_mod.openOrCreateVerifiedPrivateDir(&home_dir, profile_paths.root_dir_name);
+    var mutation = try lockMutation(fx_dir, file_name);
+    mutation.expected_issuer = expected_issuer;
+    return @as(?Mutation, mutation);
 }
 
 fn beginMutation() !Mutation {
@@ -325,15 +365,17 @@ fn beginMutation() !Mutation {
     defer home_dir.close();
 
     const fx_dir = try io_mod.openOrCreateVerifiedPrivateDir(&home_dir, profile_paths.root_dir_name);
-    return lockMutation(fx_dir);
+    return lockMutation(fx_dir, auth_file_name);
 }
 
-fn lockMutation(open_fx_dir: io_mod.VerifiedDir) !Mutation {
+fn lockMutation(open_fx_dir: io_mod.VerifiedDir, file_name: []const u8) !Mutation {
     var probe = MutationLockProbe{ .fx_dir = open_fx_dir.dir };
-    return lockMutationWithOps(open_fx_dir, mutation_lock_deadline_ms, .{
+    var mutation = try lockMutationWithOps(open_fx_dir, mutation_lock_deadline_ms, .{
         .ctx = &probe,
         .try_lock = MutationLockProbe.tryLock,
     });
+    mutation.file_name = file_name;
+    return mutation;
 }
 
 fn lockMutationWithOps(
@@ -381,8 +423,8 @@ fn openExistingPrivateFxDir(home_dir: *io_mod.VerifiedDir) !io_mod.VerifiedDir {
     return .{ .dir = dir };
 }
 
-fn deleteAuthFile(fx_dir: *std.Io.Dir, ops: io_mod.DurableOps) !DeleteOutcome {
-    fx_dir.deleteFile(io_mod.getIo(), auth_file_name) catch |err| switch (err) {
+fn deleteSessionFile(fx_dir: *std.Io.Dir, file_name: []const u8, ops: io_mod.DurableOps) !DeleteOutcome {
+    fx_dir.deleteFile(io_mod.getIo(), file_name) catch |err| switch (err) {
         error.FileNotFound => return .missing,
         else => return err,
     };
@@ -391,6 +433,22 @@ fn deleteAuthFile(fx_dir: *std.Io.Dir, ops: io_mod.DurableOps) !DeleteOutcome {
 }
 
 pub fn parse(alloc: Allocator, bytes: []const u8) !Session {
+    return parseExpectedIssuer(alloc, bytes, null);
+}
+
+test "named sessions require their exact provider issuer" {
+    const bytes =
+        "{\"version\":1,\"issuer\":\"xai\",\"client_id\":\"client\",\"access_token\":\"access\",\"refresh_token\":\"refresh\",\"expires_at_ms\":4102444800000,\"scope\":\"openid\",\"token_type\":\"Bearer\"}";
+    var session = try parseExpectedIssuer(std.testing.allocator, bytes, "xai");
+    defer session.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("access", session.access_token);
+    try std.testing.expectError(
+        error.InvalidAuthSession,
+        parseExpectedIssuer(std.testing.allocator, bytes, "anthropic"),
+    );
+}
+
+fn parseExpectedIssuer(alloc: Allocator, bytes: []const u8, expected_issuer: ?[]const u8) !Session {
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidAuthSession;
@@ -398,9 +456,9 @@ pub fn parse(alloc: Allocator, bytes: []const u8) !Session {
     const version = object.get("version") orelse return error.InvalidAuthSession;
     if (version != .integer or version.integer != schema_version) return error.InvalidAuthSession;
     const saved_issuer = try requiredString(object, "issuer");
-    if (!std.mem.eql(u8, saved_issuer, issuer) and !isLoopbackE2EIssuer(saved_issuer)) {
-        return error.InvalidAuthSession;
-    }
+    if (expected_issuer) |expected| {
+        if (!std.mem.eql(u8, saved_issuer, expected)) return error.InvalidAuthSession;
+    } else if (!std.mem.eql(u8, saved_issuer, issuer) and !isLoopbackE2EIssuer(saved_issuer)) return error.InvalidAuthSession;
 
     const expires_at_ms = try requiredInteger(object, "expires_at_ms");
     const owned_issuer = try alloc.dupe(u8, saved_issuer);
@@ -551,7 +609,7 @@ fn check_parse_allocation_failures(alloc: Allocator) !void {
 }
 
 fn check_load_allocation_failures(alloc: Allocator, dir: *std.Io.Dir) !void {
-    var session = (try loadFromDir(alloc, dir, .report_open_failure)) orelse return error.TestUnexpectedMissingSession;
+    var session = (try loadFromDir(alloc, dir, auth_file_name, null, .report_open_failure)) orelse return error.TestUnexpectedMissingSession;
     defer session.deinit(alloc);
 }
 
@@ -651,10 +709,10 @@ test "OAuth mutation loads report auth file open failures" {
     defer tmp.cleanup();
     try tmp.dir.symLink(std.testing.io, "missing-auth-target", auth_file_name, .{ .is_directory = false });
 
-    try std.testing.expect((try loadFromDir(std.testing.allocator, &tmp.dir, .tolerate_open_failure)) == null);
+    try std.testing.expect((try loadFromDir(std.testing.allocator, &tmp.dir, auth_file_name, null, .tolerate_open_failure)) == null);
     try std.testing.expectError(
         error.SymLinkLoop,
-        loadFromDir(std.testing.allocator, &tmp.dir, .report_open_failure),
+        loadFromDir(std.testing.allocator, &tmp.dir, auth_file_name, null, .report_open_failure),
     );
 }
 
@@ -707,10 +765,10 @@ test "OAuth session deletion reports deleted and missing files" {
         .ctx = &probe,
         .sync_dir = DeleteSyncProbe.syncDir,
     };
-    const deleted = try deleteAuthFile(&tmp.dir, ops);
+    const deleted = try deleteSessionFile(&tmp.dir, auth_file_name, ops);
     try std.testing.expectEqual(DeleteOutcome.deleted, deleted);
     try std.testing.expectEqual(@as(usize, 1), probe.sync_count);
-    const missing = try deleteAuthFile(&tmp.dir, ops);
+    const missing = try deleteSessionFile(&tmp.dir, auth_file_name, ops);
     try std.testing.expectEqual(DeleteOutcome.missing, missing);
     try std.testing.expectEqual(@as(usize, 1), probe.sync_count);
 }
@@ -727,7 +785,7 @@ test "OAuth session deletion reports directory sync failure after unlink" {
         .ctx = &probe,
         .sync_dir = DeleteSyncProbe.syncDir,
     };
-    const outcome = try deleteAuthFile(&tmp.dir, ops);
+    const outcome = try deleteSessionFile(&tmp.dir, auth_file_name, ops);
     try std.testing.expectEqual(DeleteOutcome.deleted_not_durable, outcome);
     try std.testing.expectEqual(@as(usize, 1), probe.sync_count);
     try std.testing.expectError(
@@ -736,7 +794,7 @@ test "OAuth session deletion reports directory sync failure after unlink" {
     );
 
     probe.fail = false;
-    const missing = try deleteAuthFile(&tmp.dir, ops);
+    const missing = try deleteSessionFile(&tmp.dir, auth_file_name, ops);
     try std.testing.expectEqual(DeleteOutcome.missing, missing);
     try std.testing.expectEqual(@as(usize, 1), probe.sync_count);
 }

--- a/src/core/auth/oauth_transport.zig
+++ b/src/core/auth/oauth_transport.zig
@@ -6,6 +6,7 @@ const Allocator = std.mem.Allocator;
 pub const Method = enum {
     get,
     post_form,
+    post_json,
 };
 
 pub const Request = struct {
@@ -23,6 +24,7 @@ pub const Disposition = enum {
 
 pub const Response = struct {
     disposition: Disposition,
+    status: ?u16 = null,
     /// Owned bytes allocated with the allocator passed to `Provider.execute`.
     body: []u8,
 
@@ -30,6 +32,7 @@ pub const Response = struct {
         secret.zeroAndFree(alloc, self.body);
         self.* = .{
             .disposition = .rejected,
+            .status = null,
             .body = &.{},
         };
     }

--- a/src/core/auth/provider_oauth.zig
+++ b/src/core/auth/provider_oauth.zig
@@ -1,0 +1,1176 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const host = @import("../hosts/host.zig");
+const io_mod = @import("../shared/io.zig");
+const types = @import("../shared/types.zig");
+const oauth = @import("oauth.zig");
+const oauth_session = @import("oauth_session.zig");
+const oauth_transport = @import("oauth_transport.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+const callback_timeout_ms: i32 = 5 * 60 * 1000;
+const callback_poll_ms: i32 = 50;
+const refresh_skew_ms: i64 = 5 * std.time.ms_per_min;
+const max_poll_interval_seconds: i64 = 5 * 60;
+
+pub const Provider = enum {
+    anthropic,
+    openai_codex,
+    xai,
+
+    pub fn parse(value: []const u8) ?Provider {
+        if (std.ascii.eqlIgnoreCase(value, "anthropic") or std.ascii.eqlIgnoreCase(value, "anthropic-max")) return .anthropic;
+        if (std.ascii.eqlIgnoreCase(value, "openai-codex") or std.ascii.eqlIgnoreCase(value, "codex")) return .openai_codex;
+        if (std.ascii.eqlIgnoreCase(value, "xai") or std.ascii.eqlIgnoreCase(value, "xai-direct")) return .xai;
+        return null;
+    }
+
+    pub fn label(self: Provider) []const u8 {
+        return switch (self) {
+            .anthropic => "Anthropic Claude Pro/Max",
+            .openai_codex => "OpenAI Codex/ChatGPT",
+            .xai => "xAI Grok/X",
+        };
+    }
+
+    pub fn fileName(self: Provider) []const u8 {
+        return switch (self) {
+            .anthropic => "auth-anthropic.json",
+            .openai_codex => "auth-openai-codex.json",
+            .xai => "auth-xai.json",
+        };
+    }
+
+    pub fn credentialSource(self: Provider) types.CredentialSource {
+        return switch (self) {
+            .anthropic => .anthropic_fx_login,
+            .openai_codex => .codex_fx_login,
+            .xai => .xai_oauth_token,
+        };
+    }
+
+    pub fn fromCredentialSource(source: types.CredentialSource) ?Provider {
+        return switch (source) {
+            .anthropic_fx_login => .anthropic,
+            .codex_fx_login => .openai_codex,
+            .xai_oauth_token => .xai,
+            else => null,
+        };
+    }
+
+    fn validateAccessToken(self: Provider, alloc: Allocator, token: []const u8) !void {
+        switch (self) {
+            .anthropic => if (!std.mem.startsWith(u8, token, "sk-ant-oat")) return error.InvalidOAuthResponse,
+            .openai_codex => if (!try codexTokenHasAccountId(alloc, token)) return error.InvalidOAuthResponse,
+            .xai => {},
+        }
+    }
+
+    fn clientId(self: Provider) []const u8 {
+        return switch (self) {
+            .anthropic => "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+            .openai_codex => "app_EMoamEEZ73f0CkXaXp7hrann",
+            .xai => "b1a00492-073a-47ea-816f-4c329264a828",
+        };
+    }
+
+    fn tokenUrl(self: Provider) []const u8 {
+        return switch (self) {
+            .anthropic => "https://platform.claude.com/v1/oauth/token",
+            .openai_codex => "https://auth.openai.com/oauth/token",
+            .xai => "https://auth.x.ai/oauth2/token",
+        };
+    }
+
+    fn scope(self: Provider) []const u8 {
+        return switch (self) {
+            .anthropic => "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+            .openai_codex => "openid profile email offline_access",
+            .xai => "openid profile email offline_access grok-cli:access api:access",
+        };
+    }
+};
+
+pub const LoginMethod = enum { browser, device_code, manual_code };
+
+pub fn runLogin(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    url_opener: host.UrlOpener,
+    provider: Provider,
+    method: LoginMethod,
+) !void {
+    var session = switch (provider) {
+        .anthropic => if (method != .device_code)
+            try loginBrowser(alloc, transport, url_opener, provider, method)
+        else
+            return error.ProviderLoginMethodUnsupported,
+        .openai_codex => if (method == .device_code)
+            try loginCodexDevice(alloc, transport, url_opener)
+        else
+            try loginBrowser(alloc, transport, url_opener, provider, method),
+        .xai => if (method != .manual_code)
+            try loginXaiDevice(alloc, transport, url_opener)
+        else
+            return error.ProviderLoginMethodUnsupported,
+    };
+    defer session.deinit(alloc);
+    try oauth_session.saveNamed(alloc, provider.fileName(), @tagName(provider), session);
+    try writeStdoutFmt("Signed in to {s}.\n", .{provider.label()});
+}
+
+fn loginCodexDevice(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    url_opener: host.UrlOpener,
+) !oauth_session.Session {
+    const provider = Provider.openai_codex;
+    var request_body = std.Io.Writer.Allocating.init(alloc);
+    defer deinitSecretWriter(&request_body);
+    try request_body.writer.writeAll("{\"client_id\":");
+    try std.json.Stringify.value(provider.clientId(), .{}, &request_body.writer);
+    try request_body.writer.writeByte('}');
+    const bytes = try fetchAccepted(
+        alloc,
+        transport,
+        .post_json,
+        "https://auth.openai.com/api/accounts/deviceauth/usercode",
+        request_body.writer.buffered(),
+    );
+    defer secret.zeroAndFree(alloc, bytes);
+    var device = try parseCodexDeviceAuthorization(alloc, bytes);
+    defer device.deinit(alloc);
+    const verification_uri = "https://auth.openai.com/codex/device";
+    try writeStdoutFmt("Open {s}\nCode: {s}\n\n", .{ verification_uri, device.user_code });
+    _ = try url_opener.open(alloc, verification_uri);
+
+    var interval = device.interval;
+    const deadline = io_mod.milliTimestamp() +| 15 * std.time.ms_per_min;
+    while (io_mod.milliTimestamp() < deadline) {
+        try sleepPollInterval(interval);
+        var poll_body = std.Io.Writer.Allocating.init(alloc);
+        defer deinitSecretWriter(&poll_body);
+        try poll_body.writer.writeAll("{\"device_auth_id\":");
+        try std.json.Stringify.value(device.device_auth_id, .{}, &poll_body.writer);
+        try poll_body.writer.writeAll(",\"user_code\":");
+        try std.json.Stringify.value(device.user_code, .{}, &poll_body.writer);
+        try poll_body.writer.writeByte('}');
+        var response = try transport.execute(alloc, .{
+            .method = .post_json,
+            .url = "https://auth.openai.com/api/accounts/deviceauth/token",
+            .payload = poll_body.writer.buffered(),
+        });
+        defer response.deinit(alloc);
+        if (response.disposition == .accepted) {
+            var code = try parseCodexDeviceToken(alloc, response.body);
+            defer code.deinit(alloc);
+            return exchangeCodexAuthorizationCode(
+                alloc,
+                transport,
+                code.authorization_code,
+                code.code_verifier,
+                "https://auth.openai.com/deviceauth/callback",
+            );
+        }
+        if (response.status == 403 or response.status == 404) continue;
+        const oauth_error = parseError(alloc, response.body) orelse return error.OAuthRequestFailed;
+        if (oauth_error == .authorization_pending) continue;
+        if (oauth_error == .slow_down) {
+            interval +|= 5;
+            continue;
+        }
+        if (oauth_error == .access_denied) return error.AccessDenied;
+        if (oauth_error == .expired_token) return error.ExpiredToken;
+    }
+    return error.LoginTimedOut;
+}
+
+pub fn logout(provider: Provider) !oauth_session.DeleteOutcome {
+    return oauth_session.deleteNamed(provider.fileName(), @tagName(provider));
+}
+
+pub fn loadManagedSession(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    provider: Provider,
+    refresh_if_needed: bool,
+) !?oauth_session.Session {
+    var session = (try oauth_session.loadNamed(alloc, provider.fileName(), @tagName(provider))) orelse return null;
+    if (refresh_if_needed and session.expired(io_mod.milliTimestamp())) {
+        session.deinit(alloc);
+        return refreshManagedSession(alloc, transport, provider, false);
+    }
+    errdefer session.deinit(alloc);
+    return session;
+}
+
+pub fn refreshManagedSession(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    provider: Provider,
+    force: bool,
+) !?oauth_session.Session {
+    var mutation = (try oauth_session.beginNamedMutation(provider.fileName(), @tagName(provider))) orelse return null;
+    defer mutation.deinit();
+    var session = (try mutation.load(alloc)) orelse return null;
+    errdefer session.deinit(alloc);
+    if (!force and !session.expired(io_mod.milliTimestamp())) return session;
+
+    var body = std.Io.Writer.Allocating.init(alloc);
+    defer deinitSecretWriter(&body);
+    if (provider == .anthropic) {
+        try body.writer.writeAll("{\"grant_type\":\"refresh_token\",\"client_id\":");
+        try std.json.Stringify.value(provider.clientId(), .{}, &body.writer);
+        try body.writer.writeAll(",\"refresh_token\":");
+        try std.json.Stringify.value(session.refresh_token, .{}, &body.writer);
+        try body.writer.writeByte('}');
+    } else {
+        var form: FormBody = .{};
+        try form.append(&body.writer, "grant_type", "refresh_token");
+        try form.append(&body.writer, "client_id", provider.clientId());
+        try form.append(&body.writer, "refresh_token", session.refresh_token);
+    }
+    const bytes = try fetchAccepted(
+        alloc,
+        transport,
+        if (provider == .anthropic) .post_json else .post_form,
+        provider.tokenUrl(),
+        body.writer.buffered(),
+    );
+    defer secret.zeroAndFree(alloc, bytes);
+    var token = try parseToken(
+        alloc,
+        bytes,
+        if (provider == .xai) session.refresh_token else null,
+        true,
+        provider == .xai,
+    );
+    defer token.deinit(alloc);
+    try provider.validateAccessToken(alloc, token.access_token);
+    try replaceSessionTokens(alloc, &session, &token);
+    try mutation.save(alloc, session);
+    return session;
+}
+
+fn loginBrowser(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    url_opener: host.UrlOpener,
+    provider: Provider,
+    method: LoginMethod,
+) !oauth_session.Session {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return error.ProviderOAuthUnsupported;
+    const port: u16 = if (provider == .anthropic) 53692 else 1455;
+    const callback_path = if (provider == .anthropic) "/callback" else "/auth/callback";
+    const redirect_uri = if (provider == .anthropic)
+        "http://localhost:53692/callback"
+    else
+        "http://localhost:1455/auth/callback";
+    const authorize_url = if (provider == .anthropic)
+        "https://claude.ai/oauth/authorize"
+    else
+        "https://auth.openai.com/oauth/authorize";
+
+    var listener: ?std.Io.net.Server = null;
+    if (method == .browser) {
+        var address = try std.Io.net.IpAddress.parse("127.0.0.1", port);
+        listener = try address.listen(io_mod.getIo(), .{ .reuse_address = true });
+    }
+    defer if (listener) |*server| server.deinit(io_mod.getIo());
+
+    var verifier_entropy: [32]u8 = undefined;
+    try io_mod.getIo().randomSecure(&verifier_entropy);
+    var verifier_buf: [43]u8 = undefined;
+    const verifier = std.base64.url_safe_no_pad.Encoder.encode(&verifier_buf, &verifier_entropy);
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(verifier, &digest, .{});
+    var challenge_buf: [43]u8 = undefined;
+    const challenge = std.base64.url_safe_no_pad.Encoder.encode(&challenge_buf, &digest);
+    var state_entropy: [16]u8 = undefined;
+    try io_mod.getIo().randomSecure(&state_entropy);
+    var state_buf: [22]u8 = undefined;
+    const generated_state = std.base64.url_safe_no_pad.Encoder.encode(&state_buf, &state_entropy);
+    const stable_state = if (provider == .anthropic) verifier else generated_state;
+
+    var url = std.Io.Writer.Allocating.init(alloc);
+    defer deinitSecretWriter(&url);
+    try url.writer.print("{s}?", .{authorize_url});
+    var query: FormBody = .{};
+    if (provider == .anthropic) try query.append(&url.writer, "code", "true");
+    try query.append(&url.writer, "response_type", "code");
+    try query.append(&url.writer, "client_id", provider.clientId());
+    try query.append(&url.writer, "redirect_uri", redirect_uri);
+    try query.append(&url.writer, "scope", provider.scope());
+    try query.append(&url.writer, "code_challenge", challenge);
+    try query.append(&url.writer, "code_challenge_method", "S256");
+    try query.append(&url.writer, "state", stable_state);
+    if (provider == .openai_codex) {
+        try query.append(&url.writer, "id_token_add_organizations", "true");
+        try query.append(&url.writer, "codex_cli_simplified_flow", "true");
+        try query.append(&url.writer, "originator", "fx");
+    }
+    const authorization_url = url.writer.buffered();
+    try writeStdoutFmt("Open this URL to sign in to {s}:\n{s}\n\n", .{ provider.label(), authorization_url });
+    _ = try url_opener.open(alloc, authorization_url);
+
+    var callback = if (listener) |*server|
+        try waitForCallback(alloc, server, callback_path, stable_state)
+    else
+        try readManualCallback(alloc, stable_state);
+    defer callback.deinit(alloc);
+    if (!std.mem.eql(u8, callback.state, stable_state)) return error.OAuthStateMismatch;
+
+    var body = std.Io.Writer.Allocating.init(alloc);
+    defer deinitSecretWriter(&body);
+    const token_method: oauth_transport.Method = if (provider == .anthropic) .post_json else .post_form;
+    if (provider == .anthropic) {
+        try body.writer.writeAll("{\"grant_type\":\"authorization_code\",\"client_id\":");
+        try std.json.Stringify.value(provider.clientId(), .{}, &body.writer);
+        try body.writer.writeAll(",\"code\":");
+        try std.json.Stringify.value(callback.code, .{}, &body.writer);
+        try body.writer.writeAll(",\"state\":");
+        try std.json.Stringify.value(stable_state, .{}, &body.writer);
+        try body.writer.writeAll(",\"redirect_uri\":");
+        try std.json.Stringify.value(redirect_uri, .{}, &body.writer);
+        try body.writer.writeAll(",\"code_verifier\":");
+        try std.json.Stringify.value(verifier, .{}, &body.writer);
+        try body.writer.writeByte('}');
+    } else {
+        var form: FormBody = .{};
+        try form.append(&body.writer, "grant_type", "authorization_code");
+        try form.append(&body.writer, "client_id", provider.clientId());
+        try form.append(&body.writer, "code", callback.code);
+        try form.append(&body.writer, "code_verifier", verifier);
+        try form.append(&body.writer, "redirect_uri", redirect_uri);
+    }
+    const bytes = try fetchAccepted(alloc, transport, token_method, provider.tokenUrl(), body.writer.buffered());
+    defer secret.zeroAndFree(alloc, bytes);
+    var token = try parseToken(alloc, bytes, null, true, false);
+    defer token.deinit(alloc);
+    return takeSession(alloc, provider, &token);
+}
+
+fn readManualCallback(alloc: Allocator, expected_state: []const u8) !Callback {
+    try writeStdoutFmt("Paste the authorization code or final redirect URL, then press Enter:\n", .{});
+    var read_buffer: [16 * 1024]u8 = undefined;
+    var reader = std.Io.File.stdin().reader(io_mod.getIo(), &read_buffer);
+    const line = try reader.interface.takeDelimiter('\n') orelse return error.EndOfStream;
+    const input = std.mem.trim(u8, line, " \t\r\n");
+    return parseManualCallback(alloc, input, expected_state);
+}
+
+fn parseManualCallback(alloc: Allocator, input: []const u8, expected_state: []const u8) !Callback {
+    if (input.len == 0) return error.InvalidAuthorizationCallback;
+
+    var code_raw: []const u8 = input;
+    var state_raw: ?[]const u8 = null;
+    if (std.mem.findScalar(u8, input, '?')) |query_start| {
+        const fragment_start = std.mem.findScalarPos(u8, input, query_start + 1, '#') orelse input.len;
+        const query = input[query_start + 1 .. fragment_start];
+        code_raw = queryValue(query, "code") orelse return error.InvalidAuthorizationCallback;
+        state_raw = queryValue(query, "state");
+    } else if (std.mem.findScalar(u8, input, '#')) |separator| {
+        code_raw = input[0..separator];
+        state_raw = input[separator + 1 ..];
+    } else if (std.mem.startsWith(u8, input, "code=")) {
+        code_raw = queryValue(input, "code") orelse return error.InvalidAuthorizationCallback;
+        state_raw = queryValue(input, "state");
+    }
+    const state = if (state_raw) |value| try percentDecode(alloc, value) else try alloc.dupe(u8, expected_state);
+    errdefer secret.zeroAndFree(alloc, state);
+    if (!std.mem.eql(u8, state, expected_state)) return error.OAuthStateMismatch;
+    return .{ .code = try percentDecode(alloc, code_raw), .state = state };
+}
+
+const CodexDeviceAuthorization = struct {
+    device_auth_id: []u8,
+    user_code: []u8,
+    interval: i64,
+
+    fn deinit(self: *CodexDeviceAuthorization, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.device_auth_id);
+        alloc.free(self.user_code);
+        self.* = undefined;
+    }
+};
+
+fn parseCodexDeviceAuthorization(alloc: Allocator, bytes: []const u8) !CodexDeviceAuthorization {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidOAuthResponse;
+    const object = parsed.value.object;
+    const device_auth_id = try requiredStringDupe(alloc, object, "device_auth_id");
+    errdefer secret.zeroAndFree(alloc, device_auth_id);
+    const user_code = try requiredStringDupe(alloc, object, "user_code");
+    errdefer alloc.free(user_code);
+    const interval = if (object.get("interval")) |value| switch (value) {
+        .integer => |number| number,
+        .string => |text| std.fmt.parseInt(i64, std.mem.trim(u8, text, " \t\r\n"), 10) catch return error.InvalidOAuthResponse,
+        else => return error.InvalidOAuthResponse,
+    } else return error.InvalidOAuthResponse;
+    if (interval < 0 or interval > max_poll_interval_seconds) return error.InvalidOAuthResponse;
+    return .{ .device_auth_id = device_auth_id, .user_code = user_code, .interval = @max(interval, 1) };
+}
+
+const CodexDeviceToken = struct {
+    authorization_code: []u8,
+    code_verifier: []u8,
+
+    fn deinit(self: *CodexDeviceToken, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.authorization_code);
+        secret.zeroAndFree(alloc, self.code_verifier);
+        self.* = undefined;
+    }
+};
+
+fn parseCodexDeviceToken(alloc: Allocator, bytes: []const u8) !CodexDeviceToken {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidOAuthResponse;
+    const authorization_code = try requiredStringDupe(alloc, parsed.value.object, "authorization_code");
+    errdefer secret.zeroAndFree(alloc, authorization_code);
+    return .{
+        .authorization_code = authorization_code,
+        .code_verifier = try requiredStringDupe(alloc, parsed.value.object, "code_verifier"),
+    };
+}
+
+fn exchangeCodexAuthorizationCode(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    code: []const u8,
+    verifier: []const u8,
+    redirect_uri: []const u8,
+) !oauth_session.Session {
+    var body = std.Io.Writer.Allocating.init(alloc);
+    defer deinitSecretWriter(&body);
+    var form: FormBody = .{};
+    try form.append(&body.writer, "grant_type", "authorization_code");
+    try form.append(&body.writer, "client_id", Provider.openai_codex.clientId());
+    try form.append(&body.writer, "code", code);
+    try form.append(&body.writer, "code_verifier", verifier);
+    try form.append(&body.writer, "redirect_uri", redirect_uri);
+    const bytes = try fetchAccepted(
+        alloc,
+        transport,
+        .post_form,
+        Provider.openai_codex.tokenUrl(),
+        body.writer.buffered(),
+    );
+    defer secret.zeroAndFree(alloc, bytes);
+    var token = try parseToken(alloc, bytes, null, true, false);
+    defer token.deinit(alloc);
+    return takeSession(alloc, .openai_codex, &token);
+}
+
+fn loginXaiDevice(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    url_opener: host.UrlOpener,
+) !oauth_session.Session {
+    const provider = Provider.xai;
+    var request_body = std.Io.Writer.Allocating.init(alloc);
+    defer deinitSecretWriter(&request_body);
+    var form: FormBody = .{};
+    try form.append(&request_body.writer, "client_id", provider.clientId());
+    try form.append(&request_body.writer, "scope", provider.scope());
+    try form.append(&request_body.writer, "referrer", "pi");
+    const bytes = try fetchAccepted(
+        alloc,
+        transport,
+        .post_form,
+        "https://auth.x.ai/oauth2/device/code",
+        request_body.writer.buffered(),
+    );
+    defer secret.zeroAndFree(alloc, bytes);
+    var device = try parseXaiDeviceAuthorization(alloc, bytes);
+    defer device.deinit(alloc);
+    const display_url = device.verification_uri_complete orelse device.verification_uri;
+    try writeStdoutFmt("Open {s}\nCode: {s}\n\n", .{ display_url, device.user_code });
+    _ = try url_opener.open(alloc, display_url);
+
+    var interval: i64 = @max(device.interval, 1);
+    const deadline = io_mod.milliTimestamp() +| device.expires_in *| std.time.ms_per_s;
+    while (io_mod.milliTimestamp() < deadline) {
+        try sleepPollInterval(interval);
+        var poll_body = std.Io.Writer.Allocating.init(alloc);
+        defer deinitSecretWriter(&poll_body);
+        var poll_form: FormBody = .{};
+        try poll_form.append(&poll_body.writer, "grant_type", "urn:ietf:params:oauth:grant-type:device_code");
+        try poll_form.append(&poll_body.writer, "client_id", provider.clientId());
+        try poll_form.append(&poll_body.writer, "device_code", device.device_code);
+        var response = try transport.execute(alloc, .{
+            .method = .post_form,
+            .url = provider.tokenUrl(),
+            .payload = poll_body.writer.buffered(),
+        });
+        defer response.deinit(alloc);
+        if (response.disposition == .accepted) {
+            var token = try parseToken(alloc, response.body, null, true, true);
+            defer token.deinit(alloc);
+            return takeSession(alloc, provider, &token);
+        }
+        const oauth_error = parseError(alloc, response.body) orelse return error.OAuthRequestFailed;
+        if (oauth_error == .authorization_pending) continue;
+        if (oauth_error == .slow_down) {
+            interval = parsePollInterval(alloc, response.body) orelse @min(interval +| 5, max_poll_interval_seconds);
+            continue;
+        }
+        if (oauth_error == .access_denied) return error.AccessDenied;
+        if (oauth_error == .expired_token) return error.ExpiredToken;
+        return error.OAuthRequestFailed;
+    }
+    return error.LoginTimedOut;
+}
+
+const Callback = struct {
+    code: []u8,
+    state: []u8,
+
+    fn deinit(self: *Callback, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.code);
+        secret.zeroAndFree(alloc, self.state);
+        self.* = undefined;
+    }
+};
+
+fn waitForCallback(
+    alloc: Allocator,
+    listener: *std.Io.net.Server,
+    callback_path: []const u8,
+    expected_state: []const u8,
+) !Callback {
+    var remaining = callback_timeout_ms;
+    while (remaining > 0) {
+        var fds = [_]std.posix.pollfd{.{
+            .fd = listener.socket.handle,
+            .events = std.posix.POLL.IN,
+            .revents = 0,
+        }};
+        const wait_ms = @min(remaining, callback_poll_ms);
+        const ready = try std.posix.poll(&fds, wait_ms);
+        remaining -= wait_ms;
+        if (ready == 0) continue;
+
+        var stream = try listener.accept(io_mod.getIo());
+        defer stream.close(io_mod.getIo());
+        setSocketTimeouts(stream.socket.handle, 5);
+        var socket_buffer: [4096]u8 = undefined;
+        var reader = stream.reader(io_mod.getIo(), &socket_buffer);
+        var request_bytes: [16 * 1024]u8 = undefined;
+        var request_len: usize = 0;
+        while (request_len < request_bytes.len) {
+            request_bytes[request_len] = reader.interface.takeByte() catch break;
+            request_len += 1;
+            if (std.mem.endsWith(u8, request_bytes[0..request_len], "\r\n\r\n")) break;
+        }
+        var callback = parseCallbackRequest(alloc, request_bytes[0..request_len], callback_path) catch |err| {
+            writeCallbackResponse(&stream, .bad_request) catch {};
+            if (err == error.AccessDenied) return err;
+            continue;
+        };
+        if (!std.mem.eql(u8, callback.state, expected_state)) {
+            callback.deinit(alloc);
+            writeCallbackResponse(&stream, .bad_request) catch {};
+            continue;
+        }
+        try writeCallbackResponse(&stream, .ok);
+        return callback;
+    }
+    return error.LoginTimedOut;
+}
+
+fn parseCallbackRequest(alloc: Allocator, request_bytes: []const u8, callback_path: []const u8) !Callback {
+    if (request_bytes.len == 16 * 1024) return error.AuthorizationCallbackTooLarge;
+    const line_end = std.mem.find(u8, request_bytes, "\r\n") orelse return error.InvalidAuthorizationCallback;
+    const line = request_bytes[0..line_end];
+    if (!std.mem.startsWith(u8, line, "GET ")) return error.InvalidAuthorizationCallback;
+    const target_end = std.mem.findScalarPos(u8, line, 4, ' ') orelse return error.InvalidAuthorizationCallback;
+    const target = line[4..target_end];
+    if (!std.mem.startsWith(u8, target, callback_path) or target.len <= callback_path.len or target[callback_path.len] != '?') {
+        return error.InvalidAuthorizationCallback;
+    }
+    const query = target[callback_path.len + 1 ..];
+    if (queryValue(query, "error") != null) return error.AccessDenied;
+    const code_raw = queryValue(query, "code") orelse return error.InvalidAuthorizationCallback;
+    const state_raw = queryValue(query, "state") orelse return error.InvalidAuthorizationCallback;
+    const code = try percentDecode(alloc, code_raw);
+    errdefer secret.zeroAndFree(alloc, code);
+    return .{ .code = code, .state = try percentDecode(alloc, state_raw) };
+}
+
+const CallbackResponse = enum { ok, bad_request };
+
+fn writeCallbackResponse(stream: *std.Io.net.Stream, response: CallbackResponse) !void {
+    const body = switch (response) {
+        .ok => "Authorization received. You can return to fx now.",
+        .bad_request => "Invalid authorization callback. Return to fx and try again.",
+    };
+    var writer_buffer: [512]u8 = undefined;
+    var writer = stream.writer(io_mod.getIo(), &writer_buffer);
+    try writer.interface.print(
+        "HTTP/1.1 {s}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+        .{ if (response == .ok) "200 OK" else "400 Bad Request", body.len, body },
+    );
+    try writer.interface.flush();
+}
+
+fn queryValue(query: []const u8, key: []const u8) ?[]const u8 {
+    var fields = std.mem.splitScalar(u8, query, '&');
+    while (fields.next()) |field| {
+        const separator = std.mem.findScalar(u8, field, '=') orelse continue;
+        if (std.mem.eql(u8, field[0..separator], key)) return field[separator + 1 ..];
+    }
+    return null;
+}
+
+fn percentDecode(alloc: Allocator, value: []const u8) ![]u8 {
+    const result = try alloc.alloc(u8, value.len);
+    errdefer alloc.free(result);
+    var input: usize = 0;
+    var output: usize = 0;
+    while (input < value.len) {
+        if (value[input] == '%' and input + 2 < value.len) {
+            const high = std.fmt.charToDigit(value[input + 1], 16) catch return error.InvalidAuthorizationCallback;
+            const low = std.fmt.charToDigit(value[input + 2], 16) catch return error.InvalidAuthorizationCallback;
+            result[output] = (high << 4) | low;
+            input += 3;
+        } else {
+            result[output] = if (value[input] == '+') ' ' else value[input];
+            input += 1;
+        }
+        output += 1;
+    }
+    return alloc.realloc(result, output);
+}
+
+fn parseXaiDeviceAuthorization(alloc: Allocator, bytes: []const u8) !oauth.DeviceAuthorization {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidOAuthResponse;
+    const object = parsed.value.object;
+    const device_code = try requiredStringDupe(alloc, object, "device_code");
+    errdefer secret.zeroAndFree(alloc, device_code);
+    const user_code = try requiredStringDupe(alloc, object, "user_code");
+    errdefer alloc.free(user_code);
+    const verification_uri = try requiredHttpsUrlDupe(alloc, object, "verification_uri");
+    errdefer alloc.free(verification_uri);
+    const verification_uri_complete = if (object.get("verification_uri_complete")) |value| blk: {
+        if (value == .null) break :blk null;
+        if (value != .string or value.string.len == 0) return error.InvalidOAuthResponse;
+        break :blk try httpsUrlDupe(alloc, value.string);
+    } else null;
+    errdefer if (verification_uri_complete) |value| alloc.free(value);
+    const expires_in = try requiredPositiveInteger(object, "expires_in");
+    const interval = if (object.get("interval")) |value|
+        if (value == .integer and value.integer > 0 and value.integer <= max_poll_interval_seconds) value.integer else 5
+    else
+        5;
+    return .{
+        .device_code = device_code,
+        .user_code = user_code,
+        .verification_uri = verification_uri,
+        .verification_uri_complete = verification_uri_complete,
+        .expires_in = expires_in,
+        .interval = interval,
+    };
+}
+
+fn requiredHttpsUrlDupe(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
+    const value = object.get(key) orelse return error.InvalidOAuthResponse;
+    if (value != .string or value.string.len == 0) return error.InvalidOAuthResponse;
+    return httpsUrlDupe(alloc, value.string);
+}
+
+fn httpsUrlDupe(alloc: Allocator, value: []const u8) ![]u8 {
+    const uri = std.Uri.parse(value) catch return error.UntrustedVerificationUri;
+    if (!std.ascii.eqlIgnoreCase(uri.scheme, "https") or uri.host == null or uri.user != null or uri.password != null) {
+        return error.UntrustedVerificationUri;
+    }
+    return alloc.dupe(u8, value);
+}
+
+fn requiredPositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
+    const value = object.get(key) orelse return error.InvalidOAuthResponse;
+    if (value != .integer or value.integer <= 0) return error.InvalidOAuthResponse;
+    return value.integer;
+}
+
+fn takeSession(alloc: Allocator, provider: Provider, token: *oauth.TokenSet) !oauth_session.Session {
+    const refresh_token = token.refresh_token orelse return error.NoRefreshToken;
+    try provider.validateAccessToken(alloc, token.access_token);
+    const expires_at_ms = try oauth.expiry_timestamp_ms(io_mod.milliTimestamp(), token.expires_in);
+    const issuer = try alloc.dupe(u8, @tagName(provider));
+    errdefer alloc.free(issuer);
+    const client_id = try alloc.dupe(u8, provider.clientId());
+    errdefer alloc.free(client_id);
+    const session_scope = if (token.scope.len > 0) token.scope else try alloc.dupe(u8, provider.scope());
+    errdefer if (token.scope.len == 0) alloc.free(session_scope);
+    const session = oauth_session.Session{
+        .issuer = issuer,
+        .client_id = client_id,
+        .access_token = token.access_token,
+        .refresh_token = refresh_token,
+        .expires_at_ms = expires_at_ms -| (refresh_skew_ms - std.time.ms_per_min),
+        .scope = session_scope,
+        .token_type = token.token_type,
+    };
+    token.access_token = &.{};
+    token.refresh_token = null;
+    if (token.scope.len > 0) token.scope = &.{};
+    token.token_type = &.{};
+    return session;
+}
+
+fn codexTokenHasAccountId(alloc: Allocator, token: []const u8) !bool {
+    const first_dot = std.mem.findScalar(u8, token, '.') orelse return false;
+    const payload_start = first_dot + 1;
+    const second_relative = std.mem.findScalar(u8, token[payload_start..], '.') orelse return false;
+    const payload = token[payload_start .. payload_start + second_relative];
+    const decoded_len = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(payload) catch return false;
+    const decoded = try alloc.alloc(u8, decoded_len);
+    defer alloc.free(decoded);
+    std.base64.url_safe_no_pad.Decoder.decode(decoded, payload) catch return false;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, decoded, .{}) catch return false;
+    defer parsed.deinit();
+    if (parsed.value != .object) return false;
+    const auth = parsed.value.object.get("https://api.openai.com/auth") orelse return false;
+    if (auth != .object) return false;
+    const account = auth.object.get("chatgpt_account_id") orelse return false;
+    return account == .string and account.string.len > 0;
+}
+
+fn replaceSessionTokens(alloc: Allocator, session: *oauth_session.Session, token: *oauth.TokenSet) !void {
+    secret.zeroAndFree(alloc, session.access_token);
+    session.access_token = token.access_token;
+    token.access_token = &.{};
+    if (token.refresh_token) |refresh| {
+        secret.zeroAndFree(alloc, session.refresh_token);
+        session.refresh_token = refresh;
+        token.refresh_token = null;
+    }
+    if (token.scope.len > 0) {
+        alloc.free(session.scope);
+        session.scope = token.scope;
+        token.scope = &.{};
+    }
+    alloc.free(session.token_type);
+    session.token_type = token.token_type;
+    token.token_type = &.{};
+    session.expires_at_ms = (try oauth.expiry_timestamp_ms(io_mod.milliTimestamp(), token.expires_in)) -| (refresh_skew_ms - std.time.ms_per_min);
+}
+
+fn parseToken(
+    alloc: Allocator,
+    bytes: []const u8,
+    previous_refresh: ?[]const u8,
+    require_refresh: bool,
+    allow_missing_expiry: bool,
+) !oauth.TokenSet {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidOAuthResponse;
+    const object = parsed.value.object;
+    const access = try requiredStringDupe(alloc, object, "access_token");
+    errdefer secret.zeroAndFree(alloc, access);
+    const refresh = if (object.get("refresh_token")) |value|
+        if (value == .string and value.string.len > 0) try alloc.dupe(u8, value.string) else null
+    else if (previous_refresh) |value|
+        try alloc.dupe(u8, value)
+    else
+        null;
+    errdefer if (refresh) |value| secret.zeroAndFree(alloc, value);
+    if (require_refresh and refresh == null) return error.NoRefreshToken;
+    const expires_in = if (object.get("expires_in")) |value|
+        if (value == .integer and value.integer > 0) value.integer else return error.InvalidOAuthResponse
+    else if (allow_missing_expiry)
+        3600
+    else
+        return error.InvalidOAuthResponse;
+    const scope = if (object.get("scope")) |value|
+        if (value == .string) try alloc.dupe(u8, value.string) else try alloc.dupe(u8, "")
+    else
+        try alloc.dupe(u8, "");
+    errdefer alloc.free(scope);
+    const token_type = if (object.get("token_type")) |value|
+        if (value == .string and std.ascii.eqlIgnoreCase(value.string, "Bearer")) try alloc.dupe(u8, "Bearer") else return error.InvalidOAuthResponse
+    else
+        try alloc.dupe(u8, "Bearer");
+    return .{
+        .access_token = access,
+        .refresh_token = refresh,
+        .expires_in = expires_in,
+        .scope = scope,
+        .token_type = token_type,
+    };
+}
+
+fn requiredStringDupe(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
+    const value = object.get(key) orelse return error.InvalidOAuthResponse;
+    if (value != .string or value.string.len == 0) return error.InvalidOAuthResponse;
+    return alloc.dupe(u8, value.string);
+}
+
+fn fetchAccepted(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    method: oauth_transport.Method,
+    url: []const u8,
+    payload: []const u8,
+) ![]u8 {
+    var response = try transport.execute(alloc, .{ .method = method, .url = url, .payload = payload });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) {
+        if (parseError(alloc, response.body)) |value| {
+            if (value == .access_denied) return error.AccessDenied;
+            if (value == .expired_token) return error.ExpiredToken;
+        }
+        return error.OAuthRequestFailed;
+    }
+    return response.takeBody();
+}
+
+const ProviderError = enum { authorization_pending, slow_down, access_denied, expired_token };
+
+fn parseError(alloc: Allocator, bytes: []const u8) ?ProviderError {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const value = parsed.value.object.get("error") orelse return null;
+    const code = switch (value) {
+        .string => |text| text,
+        .object => |object| blk: {
+            const nested = object.get("code") orelse return null;
+            if (nested != .string) return null;
+            break :blk nested.string;
+        },
+        else => return null,
+    };
+    if (std.mem.eql(u8, code, "authorization_pending") or std.mem.eql(u8, code, "deviceauth_authorization_pending")) return .authorization_pending;
+    if (std.mem.eql(u8, code, "slow_down")) return .slow_down;
+    if (std.mem.eql(u8, code, "access_denied") or std.mem.eql(u8, code, "authorization_denied")) return .access_denied;
+    if (std.mem.eql(u8, code, "expired_token")) return .expired_token;
+    return null;
+}
+
+fn parsePollInterval(alloc: Allocator, bytes: []const u8) ?i64 {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const value = parsed.value.object.get("interval") orelse return null;
+    if (value != .integer or value.integer <= 0 or value.integer > max_poll_interval_seconds) return null;
+    return value.integer;
+}
+
+fn sleepPollInterval(interval_seconds: i64) !void {
+    if (interval_seconds <= 0 or interval_seconds > max_poll_interval_seconds) return error.InvalidOAuthResponse;
+    const nanoseconds = std.math.mul(
+        u64,
+        @intCast(interval_seconds),
+        std.time.ns_per_s,
+    ) catch return error.InvalidOAuthResponse;
+    io_mod.sleep(nanoseconds);
+}
+
+fn deinitSecretWriter(writer: *std.Io.Writer.Allocating) void {
+    @memset(@constCast(writer.writer.buffered()), 0);
+    writer.deinit();
+}
+
+const FormBody = struct {
+    first: bool = true,
+
+    fn append(self: *FormBody, writer: *std.Io.Writer, key: []const u8, value: []const u8) !void {
+        if (!self.first) try writer.writeByte('&');
+        self.first = false;
+        try percentEncode(writer, key);
+        try writer.writeByte('=');
+        try percentEncode(writer, value);
+    }
+};
+
+fn percentEncode(writer: *std.Io.Writer, value: []const u8) !void {
+    const hex = "0123456789ABCDEF";
+    for (value) |byte| {
+        if (std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_' or byte == '.' or byte == '~') {
+            try writer.writeByte(byte);
+        } else {
+            try writer.writeByte('%');
+            try writer.writeByte(hex[byte >> 4]);
+            try writer.writeByte(hex[byte & 0x0f]);
+        }
+    }
+}
+
+fn setSocketTimeouts(socket: std.posix.socket_t, seconds: i64) void {
+    const timeout = std.posix.timeval{ .sec = seconds, .usec = 0 };
+    const bytes = std.mem.asBytes(&timeout);
+    std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, bytes) catch {};
+    std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, bytes) catch {};
+}
+
+fn writeStdout(text: []const u8) !void {
+    try std.Io.File.stdout().writeStreamingAll(io_mod.getIo(), text);
+}
+
+fn writeStdoutFmt(comptime format: []const u8, args: anytype) !void {
+    var buffer: [4096]u8 = undefined;
+    var writer = std.Io.File.stdout().writer(io_mod.getIo(), &buffer);
+    try writer.interface.print(format, args);
+    try writer.interface.flush();
+}
+
+test "provider aliases parse to stable login identities" {
+    try std.testing.expectEqual(Provider.anthropic, Provider.parse("anthropic-max").?);
+    try std.testing.expectEqual(Provider.openai_codex, Provider.parse("codex").?);
+    try std.testing.expectEqual(Provider.xai, Provider.parse("xai-direct").?);
+    try std.testing.expect(Provider.parse("vercel") == null);
+}
+
+test "OAuth form encoding escapes provider scopes and callback URLs" {
+    var out = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer out.deinit();
+    var form: FormBody = .{};
+    try form.append(&out.writer, "scope", "openid offline_access");
+    try form.append(&out.writer, "redirect_uri", "http://localhost:1455/auth/callback");
+    try std.testing.expectEqualStrings(
+        "scope=openid%20offline_access&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback",
+        out.writer.buffered(),
+    );
+}
+
+test "callback query decoding rejects malformed escapes" {
+    const decoded = try percentDecode(std.testing.allocator, "code%2Bvalue");
+    defer std.testing.allocator.free(decoded);
+    try std.testing.expectEqualStrings("code+value", decoded);
+    try std.testing.expectError(error.InvalidAuthorizationCallback, percentDecode(std.testing.allocator, "%ZZ"));
+}
+
+test "manual callback accepts redirect URLs and code-state pairs" {
+    var redirect = try parseManualCallback(
+        std.testing.allocator,
+        "http://localhost:53692/callback?code=code%2Bvalue&state=expected",
+        "expected",
+    );
+    defer redirect.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("code+value", redirect.code);
+
+    var pair = try parseManualCallback(std.testing.allocator, "raw-code#expected", "expected");
+    defer pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("raw-code", pair.code);
+    try std.testing.expectError(
+        error.OAuthStateMismatch,
+        parseManualCallback(std.testing.allocator, "raw-code#wrong", "expected"),
+    );
+}
+
+test "provider token responses preserve refresh rotation and xAI fallback" {
+    var rotated = try parseToken(
+        std.testing.allocator,
+        "{\"access_token\":\"new-access\",\"refresh_token\":\"new-refresh\",\"expires_in\":3600,\"token_type\":\"Bearer\"}",
+        "old-refresh",
+        true,
+        false,
+    );
+    defer rotated.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("new-refresh", rotated.refresh_token.?);
+
+    var retained = try parseToken(
+        std.testing.allocator,
+        "{\"access_token\":\"new-access\",\"expires_in\":3600}",
+        "old-refresh",
+        false,
+        true,
+    );
+    defer retained.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("old-refresh", retained.refresh_token.?);
+    try std.testing.expectError(
+        error.InvalidOAuthResponse,
+        parseToken(
+            std.testing.allocator,
+            "{\"access_token\":\"access\",\"refresh_token\":\"refresh\"}",
+            null,
+            true,
+            false,
+        ),
+    );
+}
+
+test "xAI device authorization accepts only positive HTTPS responses" {
+    var valid = try parseXaiDeviceAuthorization(
+        std.testing.allocator,
+        "{\"device_code\":\"device\",\"user_code\":\"CODE\",\"verification_uri\":\"https://auth.x.ai/device\",\"expires_in\":600}",
+    );
+    defer valid.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("https://auth.x.ai/device", valid.verification_uri);
+    try std.testing.expectEqual(@as(i64, 5), valid.interval);
+
+    try std.testing.expectError(
+        error.UntrustedVerificationUri,
+        parseXaiDeviceAuthorization(
+            std.testing.allocator,
+            "{\"device_code\":\"device\",\"user_code\":\"CODE\",\"verification_uri\":\"file:///tmp/token\",\"expires_in\":600}",
+        ),
+    );
+    try std.testing.expectError(
+        error.InvalidOAuthResponse,
+        parseXaiDeviceAuthorization(
+            std.testing.allocator,
+            "{\"device_code\":\"device\",\"user_code\":\"CODE\",\"verification_uri\":\"https://auth.x.ai/device\",\"expires_in\":0}",
+        ),
+    );
+}
+
+test "Codex device responses accept string intervals and nested pending errors" {
+    var device = try parseCodexDeviceAuthorization(
+        std.testing.allocator,
+        "{\"device_auth_id\":\"device\",\"user_code\":\"CODE\",\"interval\":\"3\"}",
+    );
+    defer device.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(i64, 3), device.interval);
+    try std.testing.expectEqual(
+        ProviderError.authorization_pending,
+        parseError(std.testing.allocator, "{\"error\":{\"code\":\"deviceauth_authorization_pending\"}}").?,
+    );
+    try std.testing.expectEqual(
+        @as(i64, 17),
+        parsePollInterval(std.testing.allocator, "{\"error\":\"slow_down\",\"interval\":17}").?,
+    );
+}
+
+test "managed access token validation rejects provider mismatches" {
+    try std.testing.expectError(
+        error.InvalidOAuthResponse,
+        Provider.anthropic.validateAccessToken(std.testing.allocator, "not-an-anthropic-oauth-token"),
+    );
+    try Provider.openai_codex.validateAccessToken(
+        std.testing.allocator,
+        "header.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdC0xMjMifX0.signature",
+    );
+    try std.testing.expectError(
+        error.InvalidOAuthResponse,
+        Provider.openai_codex.validateAccessToken(std.testing.allocator, "header.e30.signature"),
+    );
+}
+
+var stable_provider_oauth_test_environ: ?*std.process.Environ.Map = null;
+
+fn stableProviderOauthTestEnviron() !*const std.process.Environ.Map {
+    if (stable_provider_oauth_test_environ) |map| return map;
+    const alloc = std.heap.page_allocator;
+    const map = try alloc.create(std.process.Environ.Map);
+    map.* = std.process.Environ.Map.init(alloc);
+    stable_provider_oauth_test_environ = map;
+    return map;
+}
+
+const ProviderOauthTestEnv = struct {
+    map: std.process.Environ.Map,
+
+    fn install(home: []const u8) !ProviderOauthTestEnv {
+        _ = try stableProviderOauthTestEnviron();
+        var self = ProviderOauthTestEnv{ .map = std.process.Environ.Map.init(std.testing.allocator) };
+        errdefer self.map.deinit();
+        try self.map.put("HOME", home);
+        return self;
+    }
+
+    fn deinit(self: *ProviderOauthTestEnv) void {
+        if (stable_provider_oauth_test_environ) |map| io_mod.setEnvironMap(map);
+        self.map.deinit();
+        self.* = undefined;
+    }
+};
+
+const RefreshTransportFixture = struct {
+    response: []const u8,
+    calls: usize = 0,
+
+    fn provider(self: *RefreshTransportFixture) oauth_transport.Provider {
+        return .{ .context = self, .execute_fn = execute };
+    }
+
+    fn execute(raw: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+        const self: *RefreshTransportFixture = @ptrCast(@alignCast(raw.?));
+        self.calls += 1;
+        try std.testing.expectEqual(oauth_transport.Method.post_json, request.method);
+        try std.testing.expectEqualStrings(Provider.anthropic.tokenUrl(), request.url);
+        return .{
+            .disposition = .accepted,
+            .status = 200,
+            .body = try alloc.dupe(u8, self.response),
+        };
+    }
+};
+
+test "managed provider sessions persist and refresh under the isolated profile" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(std.testing.io, "home", std.Io.File.Permissions.fromMode(0o700));
+    const home = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "home");
+    defer std.testing.allocator.free(home);
+    var env = try ProviderOauthTestEnv.install(home);
+    defer env.deinit();
+    io_mod.setEnvironMap(&env.map);
+
+    var original = oauth_session.Session{
+        .issuer = try std.testing.allocator.dupe(u8, @tagName(Provider.anthropic)),
+        .client_id = try std.testing.allocator.dupe(u8, Provider.anthropic.clientId()),
+        .access_token = try std.testing.allocator.dupe(u8, "sk-ant-oat-old"),
+        .refresh_token = try std.testing.allocator.dupe(u8, "old-refresh"),
+        .expires_at_ms = 1,
+        .scope = try std.testing.allocator.dupe(u8, Provider.anthropic.scope()),
+        .token_type = try std.testing.allocator.dupe(u8, "Bearer"),
+    };
+    defer original.deinit(std.testing.allocator);
+    try oauth_session.saveNamed(
+        std.testing.allocator,
+        Provider.anthropic.fileName(),
+        @tagName(Provider.anthropic),
+        original,
+    );
+    var saved = (try oauth_session.loadNamed(
+        std.testing.allocator,
+        Provider.anthropic.fileName(),
+        @tagName(Provider.anthropic),
+    )).?;
+    saved.deinit(std.testing.allocator);
+
+    var transport = RefreshTransportFixture{
+        .response = "{\"access_token\":\"sk-ant-oat-new\",\"refresh_token\":\"new-refresh\",\"expires_in\":3600}",
+    };
+    var refreshed = (try loadManagedSession(
+        std.testing.allocator,
+        transport.provider(),
+        .anthropic,
+        true,
+    )).?;
+    defer refreshed.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), transport.calls);
+    try std.testing.expectEqualStrings("sk-ant-oat-new", refreshed.access_token);
+
+    var persisted = (try oauth_session.loadNamed(
+        std.testing.allocator,
+        Provider.anthropic.fileName(),
+        @tagName(Provider.anthropic),
+    )).?;
+    defer persisted.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("new-refresh", persisted.refresh_token);
+    persisted.expires_at_ms = 1;
+    try oauth_session.saveNamed(
+        std.testing.allocator,
+        Provider.anthropic.fileName(),
+        @tagName(Provider.anthropic),
+        persisted,
+    );
+    try std.testing.expectError(
+        error.OAuthTransportUnavailable,
+        loadManagedSession(
+            std.testing.allocator,
+            oauth_transport.unavailable_provider,
+            .anthropic,
+            true,
+        ),
+    );
+}

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1791,7 +1791,7 @@ fn refreshGatewayCredential(
     mode: auth_runtime.CredentialRefreshMode,
 ) !?[]u8 {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
-    return auth_runtime.refreshFxLoginToken(
+    return auth_runtime.refreshCredentialToken(
         ctx.cfg.gateway_provider.oauth_transport,
         alloc,
         source,

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -21,6 +21,7 @@ const github_publish = @import("../github/github_publish.zig");
 const github_workflows = @import("../github/github_workflows.zig");
 const host = @import("../hosts/host.zig");
 const login_flow = @import("../auth/login_flow.zig");
+const provider_oauth = @import("../auth/provider_oauth.zig");
 const oauth_transport = @import("../auth/oauth_transport.zig");
 const secret = @import("../auth/secret.zig");
 const output_contracts = @import("../output/output_contracts.zig");
@@ -723,9 +724,37 @@ fn runNonInteractiveWithDeps(
         .pr => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .pull_request),
         .issue => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .issue),
         .login => |rest| {
-            if (rest.len != 0) {
-                try writeStderr(deps, "usage: fx login\n");
+            if (rest.len > 2) {
+                try writeStderr(deps, "usage: fx login [vercel|anthropic|openai-codex|xai] [--device-code|--manual-code]\n");
                 return .handled_failure;
+            }
+            if (rest.len >= 1 and !std.ascii.eqlIgnoreCase(rest[0], "vercel")) {
+                const provider = provider_oauth.Provider.parse(rest[0]) orelse {
+                    try writeStderr(deps, "fx login: unknown provider; use vercel, anthropic, openai-codex, or xai\n");
+                    return .handled_failure;
+                };
+                const method: provider_oauth.LoginMethod = if (rest.len == 2 and std.mem.eql(u8, rest[1], "--device-code"))
+                    .device_code
+                else if (rest.len == 2 and std.mem.eql(u8, rest[1], "--manual-code"))
+                    .manual_code
+                else if (rest.len == 1)
+                    .browser
+                else {
+                    try writeStderr(deps, "usage: fx login [vercel|anthropic|openai-codex|xai] [--device-code|--manual-code]\n");
+                    return .handled_failure;
+                };
+                provider_oauth.runLogin(alloc, cfg.gateway_provider.oauth_transport, cfg.url_opener, provider, method) catch |err| {
+                    const message = switch (err) {
+                        error.AccessDenied => "fx login: authorization denied\n",
+                        error.ExpiredToken, error.LoginTimedOut => "fx login: authorization expired; run fx login again\n",
+                        error.ProviderOAuthUnsupported => "fx login: provider OAuth is unavailable on this platform\n",
+                        error.ProviderLoginMethodUnsupported => "fx login: this provider does not support the selected login method\n",
+                        else => "fx login: failed to sign in to provider\n",
+                    };
+                    try writeStderr(deps, message);
+                    return .handled_failure;
+                };
+                return .handled_success;
             }
             login_flow.runLogin(
                 alloc,
@@ -744,9 +773,26 @@ fn runNonInteractiveWithDeps(
             return .handled_success;
         },
         .logout => |rest| {
-            if (rest.len != 0) {
-                try writeStderr(deps, "usage: fx logout\n");
+            if (rest.len > 1) {
+                try writeStderr(deps, "usage: fx logout [vercel|anthropic|openai-codex|xai]\n");
                 return .handled_failure;
+            }
+            if (rest.len == 1 and !std.ascii.eqlIgnoreCase(rest[0], "vercel")) {
+                const provider = provider_oauth.Provider.parse(rest[0]) orelse {
+                    try writeStderr(deps, "fx logout: unknown provider; use vercel, anthropic, openai-codex, or xai\n");
+                    return .handled_failure;
+                };
+                const outcome = provider_oauth.logout(provider) catch {
+                    try writeStderr(deps, "fx logout: failed to remove provider session\n");
+                    return .handled_failure;
+                };
+                const line = if (outcome == .missing)
+                    try std.fmt.allocPrint(alloc, "No {s} session found.\n", .{provider.label()})
+                else
+                    try std.fmt.allocPrint(alloc, "Signed out of {s}.\n", .{provider.label()});
+                defer alloc.free(line);
+                try writeStdout(deps, line);
+                return .handled_success;
             }
             const result = login_flow.logout(alloc, cfg.gateway_provider.oauth_transport) catch |err| switch (err) {
                 error.SessionDeleteFailed => {

--- a/src/core/config/model_capabilities.zig
+++ b/src/core/config/model_capabilities.zig
@@ -83,12 +83,48 @@ fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
 
 fn localCapabilitiesForModel(model: []const u8) Capabilities {
     var capabilities: Capabilities = .{};
-    if (std.mem.startsWith(u8, model, "anthropic/")) {
+    if (std.mem.startsWith(u8, model, "anthropic-max/")) {
+        capabilities.supports_reasoning = true;
+        capabilities.reasoning_efforts = .fromSlice(&.{
+            types.ReasoningEffort.literal("minimal"),
+            types.ReasoningEffort.literal("low"),
+            types.ReasoningEffort.literal("medium"),
+            types.ReasoningEffort.literal("high"),
+            types.ReasoningEffort.literal("max"),
+        });
+        capabilities.supports_tool_use = true;
+        capabilities.context_window = 200_000;
+        capabilities.max_output_tokens = 64_000;
+    } else if (std.mem.startsWith(u8, model, "openai-codex/")) {
+        capabilities.supports_reasoning = true;
+        capabilities.reasoning_efforts = .fromSlice(&.{
+            types.ReasoningEffort.literal("minimal"),
+            types.ReasoningEffort.literal("low"),
+            types.ReasoningEffort.literal("medium"),
+            types.ReasoningEffort.literal("high"),
+            types.ReasoningEffort.literal("xhigh"),
+        });
+        capabilities.supports_tool_use = true;
+        capabilities.parallel_tool_calls = true;
+        capabilities.context_window = 256_000;
+        capabilities.max_output_tokens = 128_000;
+    } else if (std.mem.startsWith(u8, model, "xai-direct/")) {
+        capabilities.supports_reasoning = true;
+        capabilities.reasoning_efforts = .fromSlice(&.{
+            types.ReasoningEffort.literal("low"),
+            types.ReasoningEffort.literal("medium"),
+            types.ReasoningEffort.literal("high"),
+        });
+        capabilities.supports_tool_use = true;
+        capabilities.parallel_tool_calls = true;
+        capabilities.context_window = 256_000;
+        capabilities.max_output_tokens = 64_000;
+    } else if (std.mem.startsWith(u8, model, "anthropic/")) {
         capabilities.prompt_caching = true;
     } else if (std.mem.startsWith(u8, model, "xai/")) {
         capabilities.parallel_tool_calls = true;
     }
-    capabilities.context_window = localContextWindowSize(model);
+    if (localContextWindowSize(model)) |window| capabilities.context_window = window;
     return capabilities;
 }
 
@@ -217,6 +253,22 @@ test "capabilities never infer reasoning or Fast controls from model IDs" {
         try std.testing.expectEqual(@as(usize, 0), capabilities.reasoning_efforts.len);
         try std.testing.expect(!capabilities.supports_fast_mode);
     }
+}
+
+test "direct provider routes expose their local runtime capabilities" {
+    const anthropic = capabilitiesForModel("anthropic-max/claude-opus-4-8");
+    try std.testing.expect(anthropic.supports_reasoning);
+    try std.testing.expect(anthropic.supports_tool_use);
+    try std.testing.expect(!anthropic.prompt_caching);
+
+    const codex = capabilitiesForModel("openai-codex/gpt-5.5");
+    try std.testing.expect(codex.supports_reasoning);
+    try std.testing.expect(codex.supports_tool_use);
+    try std.testing.expectEqual(@as(?bool, true), codex.parallel_tool_calls);
+
+    const xai = capabilitiesForModel("xai-direct/grok-4.6");
+    try std.testing.expect(xai.supports_reasoning);
+    try std.testing.expect(xai.supports_tool_use);
 }
 
 test "resolveCapabilities preserves Gateway controls and unrelated local policy" {

--- a/src/core/gateway/inference_provider.zig
+++ b/src/core/gateway/inference_provider.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+
+pub const ProviderId = enum {
+    vercel_ai_gateway,
+    anthropic_max,
+    openai_codex,
+    xai_direct,
+
+    pub fn metadata(self: ProviderId) Metadata {
+        return switch (self) {
+            .vercel_ai_gateway => .{
+                .label = "Vercel AI Gateway",
+                .credential_env_names = &.{ "VERCEL_OIDC_TOKEN", "AI_GATEWAY_API_KEY" },
+                .preferred_credential_env_name = "VERCEL_OIDC_TOKEN",
+            },
+            .anthropic_max => .{
+                .label = "Anthropic Max",
+                .credential_env_names = &.{ "CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY" },
+                .preferred_credential_env_name = "CLAUDE_CODE_OAUTH_TOKEN",
+            },
+            .openai_codex => .{
+                .label = "OpenAI Codex",
+                .credential_env_names = &.{"CODEX_ACCESS_TOKEN"},
+                .preferred_credential_env_name = "CODEX_ACCESS_TOKEN",
+            },
+            .xai_direct => .{
+                .label = "xAI",
+                .credential_env_names = &.{"XAI_API_KEY"},
+                .preferred_credential_env_name = "XAI_API_KEY",
+            },
+        };
+    }
+
+    pub fn label(self: ProviderId) []const u8 {
+        return self.metadata().label;
+    }
+};
+
+pub const Metadata = struct {
+    label: []const u8,
+    /// Ordered from most preferred to least preferred.
+    credential_env_names: []const []const u8,
+    preferred_credential_env_name: []const u8,
+};
+
+pub const Route = struct {
+    provider: ProviderId,
+    /// Borrowed from the model passed to `routeForModel`.
+    wire_model: []const u8,
+};
+
+pub fn routeForModel(model: []const u8) Route {
+    const qualified = [_]struct {
+        prefix: []const u8,
+        provider: ProviderId,
+    }{
+        .{ .prefix = "anthropic-max/", .provider = .anthropic_max },
+        .{ .prefix = "openai-codex/", .provider = .openai_codex },
+        .{ .prefix = "xai-direct/", .provider = .xai_direct },
+    };
+
+    for (qualified) |candidate| {
+        if (std.mem.startsWith(u8, model, candidate.prefix) and model.len > candidate.prefix.len) {
+            return .{
+                .provider = candidate.provider,
+                .wire_model = model[candidate.prefix.len..],
+            };
+        }
+    }
+
+    return .{ .provider = .vercel_ai_gateway, .wire_model = model };
+}
+
+test "provider-qualified models select direct inference routes" {
+    const cases = [_]struct {
+        model: []const u8,
+        provider: ProviderId,
+        wire_model: []const u8,
+    }{
+        .{ .model = "anthropic-max/claude-opus-4-1", .provider = .anthropic_max, .wire_model = "claude-opus-4-1" },
+        .{ .model = "openai-codex/gpt-5-codex", .provider = .openai_codex, .wire_model = "gpt-5-codex" },
+        .{ .model = "xai-direct/grok-4", .provider = .xai_direct, .wire_model = "grok-4" },
+    };
+
+    for (cases) |case| {
+        const route = routeForModel(case.model);
+        try std.testing.expectEqual(case.provider, route.provider);
+        try std.testing.expectEqualStrings(case.wire_model, route.wire_model);
+    }
+}
+
+test "unqualified and legacy provider models stay on Vercel AI Gateway" {
+    const models = [_][]const u8{
+        "anthropic/claude-opus-4-1",
+        "xai/grok-4",
+        "openai/gpt-5",
+        "custom-model",
+        "",
+        "anthropic-max/",
+        "openai-codex/",
+        "xai-direct/",
+    };
+
+    for (models) |model| {
+        const route = routeForModel(model);
+        try std.testing.expectEqual(ProviderId.vercel_ai_gateway, route.provider);
+        try std.testing.expectEqualStrings(model, route.wire_model);
+    }
+}
+
+test "provider metadata exposes labels and ordered credential preferences" {
+    const gateway = ProviderId.vercel_ai_gateway.metadata();
+    try std.testing.expectEqualStrings("Vercel AI Gateway", gateway.label);
+    try std.testing.expectEqualStrings("VERCEL_OIDC_TOKEN", gateway.preferred_credential_env_name);
+    try std.testing.expectEqualStrings(gateway.preferred_credential_env_name, gateway.credential_env_names[0]);
+
+    const anthropic = ProviderId.anthropic_max.metadata();
+    try std.testing.expectEqualStrings("Anthropic Max", ProviderId.anthropic_max.label());
+    try std.testing.expectEqualStrings("CLAUDE_CODE_OAUTH_TOKEN", anthropic.preferred_credential_env_name);
+    try std.testing.expectEqualStrings("ANTHROPIC_API_KEY", anthropic.credential_env_names[2]);
+
+    const codex = ProviderId.openai_codex.metadata();
+    try std.testing.expectEqualStrings("CODEX_ACCESS_TOKEN", codex.preferred_credential_env_name);
+    try std.testing.expectEqual(@as(usize, 1), codex.credential_env_names.len);
+
+    const xai = ProviderId.xai_direct.metadata();
+    try std.testing.expectEqualStrings("XAI_API_KEY", xai.preferred_credential_env_name);
+    try std.testing.expectEqual(@as(usize, 1), xai.credential_env_names.len);
+}

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -1120,6 +1120,9 @@ pub fn Commands(comptime App: type) type {
                 app.selected_model.appendSliceAssumeCapacity(stable);
             }
             const selected = app.selected_model.items;
+            if (comptime @hasDecl(App, "refreshCredentialForModel")) {
+                _ = try app.refreshCredentialForModel(selected);
+            }
             try app.worker.syncQueuedPromptModel(std.heap.c_allocator, selected);
             if (comptime @hasDecl(App, "persistAcceptedModel")) try app.persistAcceptedModel(selected);
             // Keep the session or workspace discriminator while updating the

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -92,6 +92,10 @@ pub const CredentialSource = enum {
     ai_gateway_api_key,
     fx_login,
     stored_key,
+    anthropic_oauth_token,
+    anthropic_api_key,
+    codex_login,
+    xai_api_key,
 };
 
 pub fn parseCredentialSource(text: []const u8) ?CredentialSource {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -92,9 +92,12 @@ pub const CredentialSource = enum {
     ai_gateway_api_key,
     fx_login,
     stored_key,
+    anthropic_fx_login,
     anthropic_oauth_token,
     anthropic_api_key,
+    codex_fx_login,
     codex_login,
+    xai_oauth_token,
     xai_api_key,
 };
 

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -994,7 +994,7 @@ fn executeVisionRequest(
 ) !ToolExecutionResult {
     if (state.runtime.credential_source) |source| switch (source) {
         .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key => {},
-        .anthropic_oauth_token, .anthropic_api_key, .codex_login, .xai_api_key => return error.VisionProviderCredentialUnavailable,
+        .anthropic_fx_login, .anthropic_oauth_token, .anthropic_api_key, .codex_fx_login, .codex_login, .xai_oauth_token, .xai_api_key => return error.VisionProviderCredentialUnavailable,
     };
     const config: vision_executor.Config = .{
         .stream_provider = state.runtime.agent_stream_provider,

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -992,6 +992,10 @@ fn executeVisionRequest(
     request: tool_contracts.vision.VisionRequest,
     authority: command_admission.ToolExecutionAuthority,
 ) !ToolExecutionResult {
+    if (state.runtime.credential_source) |source| switch (source) {
+        .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key => {},
+        .anthropic_oauth_token, .anthropic_api_key, .codex_login, .xai_api_key => return error.VisionProviderCredentialUnavailable,
+    };
     const config: vision_executor.Config = .{
         .stream_provider = state.runtime.agent_stream_provider,
         .api_key = state.runtime.api_key,

--- a/src/main.zig
+++ b/src/main.zig
@@ -50,6 +50,7 @@ const builtin_context = @import("builtins/context.zig");
 const builtin_devbox = @import("builtins/devbox.zig");
 const builtin_gateway = @import("builtins/gateway.zig");
 const gateway_provider = @import("core/gateway/gateway_provider.zig");
+const builtin_providers = @import("builtins/providers.zig");
 const generation_usage_provider = @import("core/session/generation_usage_provider.zig");
 const agent_stream_provider = @import("core/agent/stream_provider.zig");
 const builtin_hooks = @import("builtins/hooks.zig");
@@ -431,7 +432,7 @@ const App = struct {
         return if (comptime host_target.is_wasm)
             js_host_stream_provider.provider()
         else
-            builtin_gateway.agent_stream_provider;
+            builtin_providers.agent_stream_provider;
     }
 
     pub fn cooperativeTransportPulse(self: *Self) !void {
@@ -926,6 +927,10 @@ const App = struct {
         return AuthAppRuntime.selectCredentialSource(self, source);
     }
 
+    pub fn refreshCredentialForModel(self: *App, model: []const u8) !bool {
+        return self.auth.selectForModel(self.alloc, model);
+    }
+
     pub fn run(self: *App) !void {
         const callbacks = RenderAppRuntime.eventLoopCallbacks(self);
         while (true) {
@@ -1251,6 +1256,9 @@ const App = struct {
         errdefer std.heap.c_allocator.free(model_copy);
 
         const gateway_credential = self.auth.gatewayCredential() orelse return error.MissingApiKey;
+        if (!credentials.sourceSupportsModel(gateway_credential.source, self.selected_model.items)) {
+            return error.MissingProviderCredential;
+        }
         const api_key_copy = try std.heap.c_allocator.dupe(u8, gateway_credential.api_key);
         errdefer secret.zeroAndFree(std.heap.c_allocator, api_key_copy);
 
@@ -3200,7 +3208,7 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .models_path = builtin_gateway.models_path,
         .gateway_retry_count = builtin_gateway.retry_count,
         .gateway_chat_url = builtin_gateway.default_chat_url,
-        .gateway_provider = builtin_gateway.provider,
+        .gateway_provider = builtin_providers.provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3236,7 +3244,7 @@ fn localEntryConfig() app_entry_runtime.Config {
         .models_path = builtin_gateway.models_path,
         .gateway_retry_count = builtin_gateway.retry_count,
         .gateway_chat_url = builtin_gateway.default_chat_url,
-        .gateway_provider = builtin_gateway.provider,
+        .gateway_provider = builtin_providers.provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,


### PR DESCRIPTION
## Summary

- add direct Anthropic, OpenAI Codex, and xAI inference routes
- add first-class browser, manual redirect, and device-code OAuth login flows
- persist private provider sessions and refresh only fx-owned credentials
- keep external Claude Code, Codex CLI, and API-key credentials as fallbacks

## Validation

- `zig fmt --check src/`
- `zig build -Doptimize=ReleaseSafe`
- `zig build -Dwasm-surface=core`
- focused provider OAuth, persistence, refresh, routing, and credential tests
- live `./zig-out/bin/fx login openai-codex --device-code`
- live managed-session request through `openai-codex/gpt-5.4-mini`
- `zig build test`: 8,348 passed, 15 skipped, 1 pre-existing unrelated failure in `core.shared.io.test.writeFileAtomic preserves existing file permissions` (`expected 493, found 448`)
