### PR TITLE
Tell the auto reviewer which shell will run the command

### DIFF
--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -7,6 +7,7 @@ const io_mod = @import("../shared/io.zig");
 const permissions = @import("permissions.zig");
 const session_usage = @import("../session/session_usage.zig");
 const text_utils = @import("../shared/text_utils.zig");
+const command_environment = @import("../execution/command_environment.zig");
 const types = @import("../shared/types.zig");
 
 pub const tool_name = "permission_decision";
@@ -70,6 +71,12 @@ pub const CommandAction = struct {
     resolved_cwd: []const u8,
     background: bool,
     target_os: std.Target.Os.Tag,
+    /// The interpreter the approved string will actually run under. A user
+    /// shell re-reads the command through the operator's aliases, functions and
+    /// rc files, so a reviewer that never sees this is judging a different
+    /// command than the one that executes. Deliberately has no default: a caller
+    /// must state the environment rather than inherit a benign-looking one.
+    environment: command_environment.Environment,
 };
 
 pub const FileMutationAction = struct {
@@ -471,6 +478,30 @@ const SerializedEvidence = struct {
     }
 };
 
+/// Names the interpreter in the evidence, and marks the evidence incomplete when
+/// a shell-routed environment cannot say which shell. Incomplete action evidence
+/// already fails closed to `.invalid`, so an unnameable interpreter cannot be
+/// auto-approved.
+fn writeEnvironment(
+    writer: *std.Io.Writer,
+    alloc: std.mem.Allocator,
+    environment: command_environment.Environment,
+    action_complete: *bool,
+) !void {
+    try writer.print("environment: {s}\n", .{@tagName(std.meta.activeTag(environment))});
+    switch (environment) {
+        .legacy, .workspace_clean => {},
+        .clean, .user => |shell_path| {
+            if (shell_path.len == 0) {
+                action_complete.* = false;
+                try writer.writeAll("environment_shell: <unknown>\n");
+                return;
+            }
+            try writeBoundedField(writer, alloc, "environment_shell", shell_path, max_action_field_bytes, action_complete);
+        },
+    }
+}
+
 fn serializeEvidence(
     alloc: std.mem.Allocator,
     request: ReviewRequest,
@@ -502,6 +533,7 @@ fn serializeEvidence(
                 "background: {}\ntarget_os: {s}\n",
                 .{ command.background, @tagName(command.target_os) },
             );
+            try writeEnvironment(&out.writer, alloc, command.environment, &action_complete);
         },
         .file_mutation => |file| {
             try out.writer.writeAll("action: prepared_file_mutation\n");
@@ -1132,6 +1164,7 @@ test "automatic review does not send redacted action evidence" {
             .resolved_cwd = "/tmp/workspace",
             .background = false,
             .target_os = .linux,
+            .environment = .legacy,
         } },
         .escalation_reason = "command_requires_approval",
     });
@@ -1326,6 +1359,7 @@ test "automatic review serializes the pending call structurally" {
             .resolved_cwd = "/tmp/workspace",
             .background = false,
             .target_os = .linux,
+            .environment = .legacy,
         } },
         .escalation_reason = "command_requires_approval",
     });
@@ -1401,6 +1435,7 @@ test "subagent automatic review sends only the current root request" {
             .resolved_cwd = "/tmp/workspace",
             .background = false,
             .target_os = .linux,
+            .environment = .legacy,
         } },
         .escalation_reason = "command_requires_approval",
     });
@@ -1454,6 +1489,7 @@ test "automatic review rejects an oversized complete packet without sending" {
             .resolved_cwd = "/tmp/workspace",
             .background = false,
             .target_os = .linux,
+            .environment = .legacy,
         } },
         .escalation_reason = "command_requires_approval",
     });
@@ -1590,6 +1626,7 @@ test "automatic review excludes assistant preamble and images" {
             .resolved_cwd = "/tmp/workspace",
             .background = false,
             .target_os = .linux,
+            .environment = .legacy,
         } },
         .escalation_reason = "command_requires_approval",
     });
@@ -1644,6 +1681,7 @@ test "automatic review ignores legacy authority completeness" {
             .resolved_cwd = "/tmp/workspace",
             .background = false,
             .target_os = .linux,
+            .environment = .legacy,
         } },
         .escalation_reason = "command_requires_approval",
     });
@@ -1669,6 +1707,7 @@ test "automatic review ignores legacy authority completeness" {
             .resolved_cwd = "/tmp/workspace",
             .background = false,
             .target_os = .linux,
+            .environment = .legacy,
         } },
         .escalation_reason = "command_requires_approval",
     });
@@ -1783,10 +1822,146 @@ test "expired review budget fails closed before transport" {
             .resolved_cwd = "/tmp/workspace",
             .background = false,
             .target_os = .linux,
+            .environment = .legacy,
         } },
         .escalation_reason = "command_requires_approval",
     });
 
     try std.testing.expectEqual(std.meta.Tag(ParseOutcome).invalid, std.meta.activeTag(outcome));
     try std.testing.expectEqual(@as(usize, 0), fake.calls);
+}
+
+test "command evidence names the shell that will interpret the command" {
+    const Capture = struct {
+        payload: [8192]u8 = undefined,
+        len: usize = 0,
+
+        fn send(
+            raw_ctx: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+            payload: []const u8,
+            _: std.Io.Clock.Timestamp,
+            _: *std.atomic.Value(bool),
+        ) anyerror!TransportOutcome {
+            const self: *@This() = @ptrCast(@alignCast(raw_ctx));
+            const n = @min(payload.len, self.payload.len);
+            @memcpy(self.payload[0..n], payload[0..n]);
+            self.len = n;
+            return .{ .completion = .{ .completion = .{
+                .tool_calls = &.{.{
+                    .id = "review",
+                    .name = tool_name,
+                    .arguments_json = "{\"risk\":\"low\",\"authorization\":\"medium\",\"decision\":\"allow\",\"rationale\":\"safe\"}",
+                }},
+            } } };
+        }
+    };
+
+    var capture = Capture{};
+    const reviewer = Reviewer.withTransport(.{
+        .context = @ptrCast(&capture),
+        .send_fn = Capture.send,
+    }, null, 1000);
+
+    const pending_assistant = types.ChatMessage{
+        .role = .assistant,
+        .content = "checking the repository",
+        .tool_calls = &.{.{
+            .id = "call_git",
+            .name = "run_command",
+            .arguments_json = "{\"command\":\"git status\"}",
+        }},
+    };
+
+    // A user shell re-reads this command through the operator's aliases, so the
+    // reviewer must be told which interpreter runs it.
+    var outcome = try reviewer.review(std.testing.allocator, .{
+        .workspace_root = "/tmp/workspace",
+        .review_turn = .{
+            .model = "openai/gpt-5",
+            .pending_assistant = pending_assistant,
+            .target_call_id = "call_git",
+            .origin = .root,
+            .current_root_request = "Check the repo status.",
+        },
+        .targets = &.{},
+        .action = .{ .command = .{
+            .command = "git status",
+            .resolved_cwd = "/tmp/workspace",
+            .background = false,
+            .backend = .none,
+            .target_os = .linux,
+            .environment = .{ .user = "/bin/bash" },
+        } },
+        .escalation_reason = "command_requires_approval",
+    });
+    defer outcome.deinit(std.testing.allocator);
+
+    const payload = capture.payload[0..capture.len];
+    try std.testing.expect(std.mem.find(u8, payload, "environment: user") != null);
+    try std.testing.expect(std.mem.find(u8, payload, "/bin/bash") != null);
+}
+
+test "a shell-routed command whose shell is unnamed cannot be auto-approved" {
+    const AlwaysAllow = struct {
+        fn send(
+            _: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+            _: []const u8,
+            _: std.Io.Clock.Timestamp,
+            _: *std.atomic.Value(bool),
+        ) anyerror!TransportOutcome {
+            return .{ .completion = .{ .completion = .{
+                .tool_calls = &.{.{
+                    .id = "review",
+                    .name = tool_name,
+                    .arguments_json = "{\"risk\":\"low\",\"authorization\":\"medium\",\"decision\":\"allow\",\"rationale\":\"safe\"}",
+                }},
+            } } };
+        }
+    };
+
+    var ctx: usize = 0;
+    const reviewer = Reviewer.withTransport(.{
+        .context = @ptrCast(&ctx),
+        .send_fn = AlwaysAllow.send,
+    }, null, 1000);
+
+    const pending_assistant = types.ChatMessage{
+        .role = .assistant,
+        .content = "checking the repository",
+        .tool_calls = &.{.{
+            .id = "call_git",
+            .name = "run_command",
+            .arguments_json = "{\"command\":\"git status\"}",
+        }},
+    };
+
+    // Even with the model saying allow, evidence that cannot name the interpreter
+    // is incomplete, and incomplete action evidence goes to a human.
+    var outcome = try reviewer.review(std.testing.allocator, .{
+        .workspace_root = "/tmp/workspace",
+        .review_turn = .{
+            .model = "openai/gpt-5",
+            .pending_assistant = pending_assistant,
+            .target_call_id = "call_git",
+            .origin = .root,
+            .current_root_request = "Check the repo status.",
+        },
+        .targets = &.{},
+        .action = .{ .command = .{
+            .command = "git status",
+            .resolved_cwd = "/tmp/workspace",
+            .background = false,
+            .backend = .none,
+            .target_os = .linux,
+            .environment = .{ .user = "" },
+        } },
+        .escalation_reason = "command_requires_approval",
+    });
+    defer outcome.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(std.meta.Tag(ParseOutcome).invalid, std.meta.activeTag(outcome));
 }

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -8,6 +8,7 @@ const permissions = @import("permissions.zig");
 const session_usage = @import("../session/session_usage.zig");
 const text_utils = @import("../shared/text_utils.zig");
 const command_environment = @import("../execution/command_environment.zig");
+const shell_resolver = @import("../terminal/shell_resolver.zig");
 const types = @import("../shared/types.zig");
 
 pub const tool_name = "permission_decision";
@@ -498,6 +499,22 @@ fn writeEnvironment(
                 return;
             }
             try writeBoundedField(writer, alloc, "environment_shell", shell_path, max_action_field_bytes, action_complete);
+
+            // The path alone reads like an ordinary `bash -c`, where aliases do
+            // not apply. What fx runs is a login shell with alias expansion, and
+            // that is the difference that decides what the command means, so the
+            // reviewer gets the startup words themselves.
+            var invocation = shell_resolver.capturedInvocation(environment, "") catch {
+                action_complete.* = false;
+                try writer.writeAll("environment_invocation: <unknown>\n");
+                return;
+            };
+            // `setCommand` appended the placeholder; the words before it are the
+            // startup semantics, and the command is already its own field.
+            if (invocation.len > 0) invocation.len -= 1;
+            const startup = try shell_resolver.formatInvocationCommand(alloc, &invocation);
+            defer alloc.free(startup);
+            try writeBoundedField(writer, alloc, "environment_invocation", startup, max_action_field_bytes, action_complete);
         },
     }
 }
@@ -1890,7 +1907,6 @@ test "command evidence names the shell that will interpret the command" {
             .command = "git status",
             .resolved_cwd = "/tmp/workspace",
             .background = false,
-            .backend = .none,
             .target_os = .linux,
             .environment = .{ .user = "/bin/bash" },
         } },
@@ -1901,6 +1917,15 @@ test "command evidence names the shell that will interpret the command" {
     const payload = capture.payload[0..capture.len];
     try std.testing.expect(std.mem.find(u8, payload, "environment: user") != null);
     try std.testing.expect(std.mem.find(u8, payload, "/bin/bash") != null);
+
+    // The startup words are what separate this from an ordinary `bash -c`, where
+    // the operator's aliases would not apply at all.
+    const invocation_line = std.mem.find(u8, payload, "environment_invocation:") orelse
+        return error.TestExpectedInvocation;
+    const rest = payload[invocation_line..];
+    const line_end = std.mem.findScalar(u8, rest, '\n') orelse rest.len;
+    const invocation = rest[0..line_end];
+    try std.testing.expect(std.mem.find(u8, invocation, "expand_aliases") != null);
 }
 
 test "a shell-routed command whose shell is unnamed cannot be auto-approved" {
@@ -1955,7 +1980,6 @@ test "a shell-routed command whose shell is unnamed cannot be auto-approved" {
             .command = "git status",
             .resolved_cwd = "/tmp/workspace",
             .background = false,
-            .backend = .none,
             .target_os = .linux,
             .environment = .{ .user = "" },
         } },

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -788,6 +788,7 @@ fn reviewRequestForCall(
                 .resolved_cwd = command.resolved_cwd,
                 .background = command.background,
                 .target_os = command.target_os,
+                .environment = command.environment,
             } };
         } else blk: {
             break :blk .{ .tool = .{
@@ -5897,5 +5898,38 @@ test "automatic trusted-root folder creation bypasses reviewer while external do
             command_admission.ToolExecutionAuthority.ordinary,
             outcome.execution_authority.?,
         );
+    }
+}
+
+test "the review request carries the shell a profiled command will run under" {
+    // The evidence serializer can only report an environment that this function
+    // hands it, so pin the wiring here: a command asking for the user profile
+    // must reach the reviewer described as a user shell, not as legacy.
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(std.testing.allocator);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(std.testing.allocator);
+    var input = testInputWithClassifier(&worker, &background, .{});
+    input.permission_review_turn = testReviewTurn();
+
+    const request = try reviewRequestForCall(input, arena, .{
+        .id = "test-environment",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"git status\",\"profile\":\"user\"}",
+    }, &.{}, false, null);
+
+    switch (request.action) {
+        .command => |command| switch (command.environment) {
+            .user => |shell_path| try std.testing.expect(shell_path.len > 0),
+            else => |other| {
+                std.debug.print("\n[WIRE] reviewer was told environment={s}, expected user\n", .{@tagName(std.meta.activeTag(command.environment))});
+                _ = other;
+                return error.TestExpectedUserEnvironment;
+            },
+        },
+        else => return error.TestExpectedCommandAction,
     }
 }


### PR DESCRIPTION
Fixes #237.

`CommandAction` and `SandboxWideningAction` now carry the command environment, and `serializeEvidence` writes the tag plus, for the shell routes, the shell path. A shell-routed environment that cannot name its shell marks the action evidence incomplete, which already fails closed to `.invalid`, so an unnameable interpreter reaches a human instead of an automatic approval.

The field deliberately has no default. A caller has to state the environment rather than inherit a benign-looking one, and that is what surfaced every stale construction site instead of leaving them silently `legacy`. Both production sites take it from the `CommandContext` they were already copying every other field from. Execution and fingerprint matching are untouched.

### Verification

Three tests, each run against the mutation it exists to catch:

| Test | Mutation | Result |
|---|---|---|
| packet carries `environment: user` and the shell path | stub the environment writer | fails |
| a shell-routed command with no shell named cannot be auto-approved, even when the model answers allow | stub the environment writer | fails |
| the review request built for a user-profile command describes a user shell | hardcode the wired value to `legacy` | fails |

That third one is the reason it exists. The required field makes the wiring impossible to delete but not impossible to fill in wrongly, and before the test existed, hardcoding `legacy` passed the entire suite.

`zig build test` is 8410 passing against an 8407 baseline on `195b73f`, with an identical set of pre-existing failures. `zig fmt --check` clean.

### Scope

This hardens reviews that happen. It does not change which commands reach the reviewer, and the auto-approve fast path is out of scope here.

Two smaller gaps I did not close: the `.clean` environment and the widening branch have no dedicated tests, though both share the writer that the mutations above cover, and the alias behaviour was demonstrated with bash only, since zsh is not installed on this machine.
