### PR TITLE
Route clean reads through direct admission

### DIFF
--- a/src/core/permissions/command_admission.zig
+++ b/src/core/permissions/command_admission.zig
@@ -128,8 +128,14 @@ pub const DefaultApproval = union(enum) {
 pub fn defaultForRunCommand(
     alloc: std.mem.Allocator,
     command_ctx: CommandContext,
+    permission_mode: types.PermissionMode,
 ) DefaultApproval {
-    if (command_ctx.environment.requiresShellRoute()) {
+    const requires_shell_authority = switch (command_ctx.environment) {
+        .user => true,
+        .clean => permission_mode != .auto,
+        .legacy, .workspace_clean => false,
+    };
+    if (requires_shell_authority) {
         return .{ .approval_required = .dynamic_shell };
     }
     var admission = command_effect.plan(
@@ -156,7 +162,7 @@ test "normalized default emits direct-only only for a direct plan" {
         .resolved_backend = .none,
         .target_os = .macos,
     };
-    const direct = defaultForRunCommand(std.testing.allocator, direct_ctx);
+    const direct = defaultForRunCommand(std.testing.allocator, direct_ctx, .ask);
     switch (direct) {
         .direct_only => |fingerprint| try std.testing.expect(fingerprint.matches(direct_ctx)),
         .approval_required => return error.TestExpectedDirectOnly,
@@ -171,7 +177,7 @@ test "normalized default emits direct-only only for a direct plan" {
     };
     try std.testing.expectEqual(
         command_effect.ApprovalReason.filesystem_write,
-        defaultForRunCommand(std.testing.allocator, write_ctx).approval_required,
+        defaultForRunCommand(std.testing.allocator, write_ctx, .ask).approval_required,
     );
 }
 
@@ -184,8 +190,36 @@ test "explicit user environment always requires shell authority" {
         .target_os = .macos,
         .environment = .{ .user = "/bin/zsh" },
     };
+    for ([_]types.PermissionMode{ .auto, .ask }) |permission_mode| {
+        try std.testing.expectEqual(
+            command_effect.ApprovalReason.dynamic_shell,
+            defaultForRunCommand(std.testing.allocator, user_ctx, permission_mode).approval_required,
+        );
+    }
+}
+
+test "explicit clean environment is direct only in automatic mode" {
+    const clean_ctx = CommandContext{
+        .command = "pwd",
+        .resolved_cwd = "/workspace",
+        .background = false,
+        .resolved_backend = .none,
+        .target_os = .macos,
+        .environment = .{ .clean = "/bin/zsh" },
+    };
+    const automatic = defaultForRunCommand(std.testing.allocator, clean_ctx, .auto);
+    switch (automatic) {
+        .direct_only => |fingerprint| try std.testing.expect(fingerprint.matches(clean_ctx)),
+        .approval_required => return error.TestExpectedDirectOnly,
+    }
     try std.testing.expectEqual(
         command_effect.ApprovalReason.dynamic_shell,
-        defaultForRunCommand(std.testing.allocator, user_ctx).approval_required,
+        defaultForRunCommand(std.testing.allocator, clean_ctx, .ask).approval_required,
+    );
+    var write_ctx = clean_ctx;
+    write_ctx.command = "touch created.txt";
+    try std.testing.expectEqual(
+        command_effect.ApprovalReason.filesystem_write,
+        defaultForRunCommand(std.testing.allocator, write_ctx, .auto).approval_required,
     );
 }

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -984,7 +984,12 @@ fn resolveOrdinaryPermissionOutcome(
 ) !command_admission.PermissionOutcome {
     const command_call = try isRunCommandCall(input, arena, call);
     if (command_call) {
-        const default_outcome = defaultRunCommandPermissionOutcome(input, arena, call);
+        const default_outcome = defaultRunCommandPermissionOutcome(
+            input,
+            arena,
+            call,
+            permission_mode,
+        );
         if (default_outcome.execution_authority != null) return default_outcome;
     }
     if (toolApprovalPolicy(input, call.name) == .ask_only) {
@@ -2283,11 +2288,16 @@ fn defaultRunCommandPermissionOutcome(
     input: Input,
     arena: Allocator,
     call: ToolCall,
+    permission_mode: PermissionMode,
 ) command_admission.PermissionOutcome {
     const command_ctx = runCommandContext(input, arena, call) catch {
         return .{ .decision = .permission_required };
     };
-    return switch (command_admission.defaultForRunCommand(arena, command_ctx)) {
+    return switch (command_admission.defaultForRunCommand(
+        arena,
+        command_ctx,
+        permission_mode,
+    )) {
         .direct_only => |fingerprint| .{
             .decision = .once,
             .execution_authority = .{ .run_command = .{ .direct_only = fingerprint } },
@@ -5538,6 +5548,50 @@ test "configured command authority skips automatic review" {
     );
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
     try std.testing.expectEqual(@as(usize, 1), recording.calls);
+}
+
+test "automatic clean direct command bypasses the reviewer" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(std.testing.allocator);
+    var background: BackgroundRuntime = .{};
+    defer background.deinit(std.testing.allocator);
+    var fake = FakeAutoClassifier{ .decision = .ask };
+    const input = testInputWithClassifier(
+        &worker,
+        &background,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+
+    const outcome = requestPermissionOutcome(
+        input,
+        arena_state.allocator(),
+        .{
+            .id = "clean-direct",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"pwd\",\"profile\":\"clean\"}",
+        },
+        .auto,
+        &.{},
+    ) catch |err| switch (err) {
+        error.MissingLoginShell, error.UnsupportedShell => return error.SkipZigTest,
+        else => return err,
+    };
+
+    try std.testing.expectEqual(ToolPermissionDecision.once, outcome.decision);
+    try std.testing.expectEqual(@as(usize, 0), fake.calls);
+    const authority = outcome.execution_authority orelse return error.TestExpectedEqual;
+    switch (authority.run_command) {
+        .direct_only => |fingerprint| try std.testing.expectEqual(
+            std.meta.Tag(command_environment.Environment).clean,
+            std.meta.activeTag(fingerprint.environment),
+        ),
+        .shell_allowed => return error.TestExpectedDirectOnly,
+    }
 }
 
 test "known reversible auto commands bypass the reviewer" {

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -93,6 +93,20 @@ function cleanCommandCall(command: string, id: string) {
   });
 }
 
+function toolResultText(body: string, toolCallId: string): string {
+  const request = JSON.parse(body) as {
+    prompt?: Array<{ content?: Array<Record<string, unknown>> }>;
+  };
+  const result = (request.prompt ?? [])
+    .flatMap((message) => message.content ?? [])
+    .find((part) => part.type === "tool-result" && part.toolCallId === toolCallId);
+  expect(result).toBeDefined();
+  const output = result!.output as Record<string, unknown>;
+  expect(output.type).toBe("text");
+  expect(typeof output.value).toBe("string");
+  return output.value as string;
+}
+
 function installRecorder(root: IsolatedRoot, name: string, marker: string) {
   const bin = join(root.root, "bin");
   mkdirSync(bin, { recursive: true });
@@ -325,7 +339,12 @@ describe("lean auto mode reliability", () => {
               finishReason: { unified: "tool-calls", raw: "tool-calls" },
             },
           ]),
-          fakeGatewayFinalText("Clean command group complete."),
+          (body) => {
+            expect(toolResultText(body, "clean_direct_pwd")).toContain("exit_code=0");
+            expect(toolResultText(body, "clean_direct_git_status")).toContain("exit_code=0");
+            expect(toolResultText(body, "clean_blocked_reset")).toContain("auto_denied");
+            return fakeGatewayFinalText("Clean command group complete.");
+          },
         ],
         [fakeGatewayPermissionDecision("ask", "must_not_review_clean_reads")],
       );

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -285,6 +285,86 @@ describe("lean auto mode reliability", () => {
   );
 
   test(
+    "clean direct reads bypass review and PATH while destructive commands stay blocked",
+    async () => {
+      const root = createIsolatedRoot();
+      runGit(root.workspace, ["init", "--quiet"]);
+      const shadowMarker = join(root.root, "shadow-git-must-not-run");
+      const shadowBin = installRecorder(root, "git", shadowMarker);
+      const gateway = startGateway(
+        [
+          fakeGatewaySse([
+            {
+              type: "tool-call",
+              toolCallId: "clean_direct_pwd",
+              toolName: "terminal",
+              input: { action: "exec", command: "pwd", profile: "clean" },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "clean_direct_git_status",
+              toolName: "terminal",
+              input: {
+                action: "exec",
+                command: "git status --short",
+                profile: "clean",
+              },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "clean_blocked_reset",
+              toolName: "terminal",
+              input: {
+                action: "exec",
+                command: "git reset --hard",
+                profile: "clean",
+              },
+            },
+            {
+              type: "finish",
+              finishReason: { unified: "tool-calls", raw: "tool-calls" },
+            },
+          ]),
+          fakeGatewayFinalText("Clean command group complete."),
+        ],
+        [fakeGatewayPermissionDecision("ask", "must_not_review_clean_reads")],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Run the mixed clean command group."],
+        {
+          cwd: root.workspace,
+          env: {
+            ...gatewayEnv(root, gateway),
+            PATH: `${shadowBin}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(
+        result.code,
+        `stdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      ).toBe(0);
+      expect(result.stderr).not.toContain("panic");
+      expect(result.stderr).not.toContain("error:");
+      expect(gateway.requests).toHaveLength(2);
+      expect(gateway.classifierRequests).toHaveLength(0);
+      expect(existsSync(shadowMarker)).toBe(false);
+      const json = JSON.parse(result.stdout.trim()) as {
+        tool_calls: Array<{ name: string; status: string }>;
+      };
+      const terminalStatuses = json.tool_calls
+        .filter(({ name }) => name === "terminal")
+        .map(({ status }) => status);
+      expect(terminalStatuses.filter((status) => status === "success")).toHaveLength(2);
+      expect(terminalStatuses.filter((status) => status === "error")).toHaveLength(1);
+      expect(result.stdout).toContain("Clean command group complete.");
+    },
+    TIMEOUT,
+  );
+
+  test(
     "direct destructive commands replan before reviewer allow",
     async () => {
       for (const [name, command] of [


### PR DESCRIPTION
## Summary

- Run planner-proven clean-profile commands directly in auto mode instead of sending them to the automatic reviewer.
- Use the hardened direct Git route for clean-profile read-only inspection instead of shell PATH resolution.
- Keep ask mode, user profiles, and destructive command handling unchanged.
