### PR TITLE
Support native Fish execution in the terminal tool

### DIFF
--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -3397,6 +3397,7 @@ const Session = struct {
         const command_path = if (request.command != null) paths.command else null;
         const bootstrap = try shell_resolver.buildBootstrap(
             self.alloc,
+            invocation.kind,
             executable,
             paths.marker_socket,
             &nonce,
@@ -3744,6 +3745,7 @@ const Session = struct {
         defer self.alloc.free(executable);
         const bootstrap = try shell_resolver.buildBootstrap(
             self.alloc,
+            invocation.kind,
             executable,
             control_path,
             &nonce,

--- a/src/core/terminal/shell_resolver.zig
+++ b/src/core/terminal/shell_resolver.zig
@@ -14,12 +14,13 @@ pub const ResolveError = error{
 pub const Profile = command_environment.Profile;
 pub const Environment = command_environment.Environment;
 
-const ShellKind = enum { bash, zsh };
+pub const ShellKind = enum { bash, zsh, fish };
 
 fn shellKind(path: []const u8) ?ShellKind {
     const basename = std.fs.path.basename(path);
     if (std.mem.eql(u8, basename, "bash")) return .bash;
     if (std.mem.eql(u8, basename, "zsh")) return .zsh;
+    if (std.mem.eql(u8, basename, "fish")) return .fish;
     return null;
 }
 
@@ -36,6 +37,7 @@ fn supportedLoginShell(configured_login_shell: ?[]const u8) ResolveError![]const
 
 pub const Invocation = struct {
     path: []const u8,
+    kind: ShellKind,
     values: [6][]const u8 = @splat(""),
     len: usize = 0,
 
@@ -78,7 +80,7 @@ pub fn resolve(
 
     const kind = shellKind(selection.path) orelse return error.UnsupportedShell;
 
-    var result = Invocation{ .path = selection.path };
+    var result = Invocation{ .path = selection.path, .kind = kind };
     result.append(selection.path);
     switch (kind) {
         .bash => {
@@ -93,6 +95,14 @@ pub fn resolve(
         .zsh => {
             if (selection.clean_start) {
                 result.append("-f");
+            } else {
+                result.append("-l");
+            }
+            result.append("-i");
+        },
+        .fish => {
+            if (selection.clean_start) {
+                result.append("--no-config");
             } else {
                 result.append("-l");
             }
@@ -181,10 +191,16 @@ pub fn capturedInvocation(environment_value: Environment, command: []const u8) R
         },
         .user => |path| {
             var invocation = try resolve(path, .user_login);
-            if (std.mem.eql(u8, std.fs.path.basename(path), "bash")) {
-                removeInteractiveFlag(&invocation);
-                invocation.append("-O");
-                invocation.append("expand_aliases");
+            switch (invocation.kind) {
+                .bash => {
+                    removeInteractiveFlag(&invocation);
+                    invocation.append("-O");
+                    invocation.append("expand_aliases");
+                },
+                // Fish loads functions from configuration without -i, and a
+                // forced interactive capture would leak greeting output.
+                .fish => removeInteractiveFlag(&invocation),
+                .zsh => {},
             }
             invocation.setCommand(command);
             return invocation;
@@ -213,6 +229,7 @@ fn removeInteractiveFlag(invocation: *Invocation) void {
 
 pub fn buildBootstrap(
     alloc: Allocator,
+    kind: ShellKind,
     executable: []const u8,
     control_path: []const u8,
     nonce: []const u8,
@@ -221,11 +238,24 @@ pub fn buildBootstrap(
     var output: std.ArrayList(u8) = .empty;
     errdefer output.deinit(alloc);
 
-    try output.appendSlice(alloc, "set +x; ");
+    switch (kind) {
+        // Disable tracing so user configuration cannot leak the control nonce.
+        .bash, .zsh => try output.appendSlice(alloc, "set +x; "),
+        .fish => try output.appendSlice(alloc, "set -e fish_trace; "),
+    }
     if (command_path) |path| {
-        try output.appendSlice(alloc, "fx_terminal_command=$(< ");
-        try appendShellWord(&output, alloc, path);
-        try output.appendSlice(alloc, ") || exit 125; ");
+        switch (kind) {
+            .bash, .zsh => {
+                try output.appendSlice(alloc, "fx_terminal_command=$(< ");
+                try appendShellWord(&output, alloc, path);
+                try output.appendSlice(alloc, ") || exit 125; ");
+            },
+            .fish => {
+                try output.appendSlice(alloc, "set fx_terminal_command (string collect < ");
+                try appendShellWord(&output, alloc, path);
+                try output.appendSlice(alloc, ") || exit 125; ");
+            },
+        }
     }
     try appendMarker(&output, alloc, executable, control_path, nonce, "shell-ready");
     if (command_path) |_| {
@@ -238,11 +268,18 @@ pub fn buildBootstrap(
             nonce,
             "command-started",
         );
-        try output.appendSlice(
-            alloc,
-            " || exit 125; builtin eval -- \"$fx_terminal_command\"; " ++
-                "fx_terminal_status=$?; exit \"$fx_terminal_status\"\n",
-        );
+        switch (kind) {
+            .bash, .zsh => try output.appendSlice(
+                alloc,
+                " || exit 125; builtin eval -- \"$fx_terminal_command\"; " ++
+                    "fx_terminal_status=$?; exit \"$fx_terminal_status\"\n",
+            ),
+            .fish => try output.appendSlice(
+                alloc,
+                " || exit 125; eval $fx_terminal_command; " ++
+                    "set fx_terminal_status $status; exit $fx_terminal_status\n",
+            ),
+        }
     } else {
         try output.appendSlice(alloc, " || exit 125\n");
     }
@@ -349,12 +386,32 @@ test "resolver rejects missing relative and unsupported shells" {
     );
     try std.testing.expectError(
         error.UnsupportedShell,
-        resolve(null, .{ .executable = .{ .path = "/bin/fish" } }),
+        resolve(null, .{ .executable = .{ .path = "/usr/local/bin/nu" } }),
+    );
+}
+
+test "resolver builds fish interactive argv" {
+    const user = try resolve("/opt/homebrew/bin/fish", .user_login);
+    try std.testing.expectEqual(ShellKind.fish, user.kind);
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{ "/opt/homebrew/bin/fish", "-l", "-i" },
+        user.argv(),
+    );
+
+    const clean = try resolve(
+        null,
+        .{ .executable = .{ .path = "/usr/bin/fish", .clean_start = true } },
+    );
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{ "/usr/bin/fish", "--no-config", "-i" },
+        clean.argv(),
     );
 }
 
 test "login shell resolution falls back without accepting explicit unsupported shells" {
-    const fallback = try resolve("/opt/homebrew/bin/fish", .user_login);
+    const fallback = try resolve("/usr/local/bin/nu", .user_login);
     try std.testing.expectEqualStrings(fallbackLoginShell(), fallback.path);
     if (builtin.os.tag == .macos) {
         try std.testing.expectEqualSlices(
@@ -372,7 +429,7 @@ test "login shell resolution falls back without accepting explicit unsupported s
 
     try std.testing.expectError(
         error.UnsupportedShell,
-        resolve(null, .{ .executable = .{ .path = "/opt/homebrew/bin/fish" } }),
+        resolve(null, .{ .executable = .{ .path = "/usr/local/bin/nu" } }),
     );
 }
 
@@ -400,6 +457,18 @@ test "captured profiles use exact non-PTY argv" {
         []const u8,
         &.{ "/bin/zsh", "-l", "-i", "-c", "printf user" },
         zsh_user.argv(),
+    );
+    const fish_clean = try capturedInvocation(.{ .clean = "/usr/bin/fish" }, "printf clean");
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{ "/usr/bin/fish", "--no-config", "-c", "printf clean" },
+        fish_clean.argv(),
+    );
+    const fish_user = try capturedInvocation(.{ .user = "/usr/bin/fish" }, "printf user");
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{ "/usr/bin/fish", "-l", "-c", "printf user" },
+        fish_user.argv(),
     );
 }
 
@@ -434,8 +503,8 @@ test "unsupported login shell profiles fall back for captured and persistent exe
     const arena = arena_state.allocator();
 
     const fallback = fallbackLoginShell();
-    const user_environment = try environment(arena, "/opt/homebrew/bin/fish", .user);
-    const clean_environment = try environment(arena, "/opt/homebrew/bin/fish", .clean);
+    const user_environment = try environment(arena, "/usr/local/bin/nu", .user);
+    const clean_environment = try environment(arena, "/usr/local/bin/nu", .clean);
     try std.testing.expect(user_environment.eql(.{ .user = fallback }));
     try std.testing.expect(clean_environment.eql(.{ .clean = fallback }));
 
@@ -446,17 +515,36 @@ test "unsupported login shell profiles fall back for captured and persistent exe
 
     try std.testing.expectEqualStrings(
         fallback,
-        (try profileShell(arena, "/opt/homebrew/bin/fish", .user)).executable.path,
+        (try profileShell(arena, "/usr/local/bin/nu", .user)).executable.path,
     );
     try std.testing.expectEqualStrings(
         fallback,
-        (try profileShell(arena, "/opt/homebrew/bin/fish", .clean)).executable.path,
+        (try profileShell(arena, "/usr/local/bin/nu", .clean)).executable.path,
+    );
+}
+
+test "fish login shell profiles resolve natively for captured and persistent execution" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const fish = "/opt/homebrew/bin/fish";
+    try std.testing.expect((try environment(arena, fish, .user)).eql(.{ .user = fish }));
+    try std.testing.expect((try environment(arena, fish, .clean)).eql(.{ .clean = fish }));
+    try std.testing.expectEqual(
+        contracts.ShellSpec.user_login,
+        try profileShell(arena, fish, .user),
+    );
+    try std.testing.expectEqualStrings(
+        fish,
+        (try profileShell(arena, fish, .clean)).executable.path,
     );
 }
 
 test "bootstrap quotes private paths and separates command completion" {
     const commandless = try buildBootstrap(
         std.testing.allocator,
+        .zsh,
         "/tmp/fx'bin",
         "/tmp/control",
         "nonce",
@@ -471,6 +559,7 @@ test "bootstrap quotes private paths and separates command completion" {
 
     const command = try buildBootstrap(
         std.testing.allocator,
+        .bash,
         "/tmp/fx",
         "/tmp/control",
         "nonce",
@@ -498,15 +587,53 @@ test "bootstrap quotes private paths and separates command completion" {
     );
 }
 
-fn checkBootstrapAllocationFailures(alloc: Allocator) !void {
-    const bootstrap = try buildBootstrap(
-        alloc,
+test "fish bootstrap uses fish dialect for capture eval and status" {
+    const commandless = try buildBootstrap(
+        std.testing.allocator,
+        .fish,
+        "/tmp/fx'bin",
+        "/tmp/control",
+        "nonce",
+        null,
+    );
+    defer std.testing.allocator.free(commandless);
+    try std.testing.expectEqualStrings(
+        "set -e fish_trace; '/tmp/fx'\"'\"'bin' '--fx-internal-terminal-control' " ++
+            "'/tmp/control' 'nonce' 'shell-ready' || exit 125\n",
+        commandless,
+    );
+
+    const command = try buildBootstrap(
+        std.testing.allocator,
+        .fish,
         "/tmp/fx",
         "/tmp/control",
         "nonce",
         "/tmp/command",
     );
-    defer alloc.free(bootstrap);
+    defer std.testing.allocator.free(command);
+    try std.testing.expectEqualStrings(
+        "set -e fish_trace; " ++
+            "set fx_terminal_command (string collect < '/tmp/command') || exit 125; " ++
+            "'/tmp/fx' '--fx-internal-terminal-control' '/tmp/control' 'nonce' 'shell-ready' || exit 125; " ++
+            "'/tmp/fx' '--fx-internal-terminal-control' '/tmp/control' 'nonce' 'command-started' || exit 125; " ++
+            "eval $fx_terminal_command; set fx_terminal_status $status; exit $fx_terminal_status\n",
+        command,
+    );
+}
+
+fn checkBootstrapAllocationFailures(alloc: Allocator) !void {
+    inline for (.{ ShellKind.bash, ShellKind.fish }) |kind| {
+        const bootstrap = try buildBootstrap(
+            alloc,
+            kind,
+            "/tmp/fx",
+            "/tmp/control",
+            "nonce",
+            "/tmp/command",
+        );
+        defer alloc.free(bootstrap);
+    }
     const source = try buildSourceCommand(alloc, "/tmp/bootstrap");
     defer alloc.free(source);
 }

--- a/tests/e2e/terminal-host.test.ts
+++ b/tests/e2e/terminal-host.test.ts
@@ -7387,7 +7387,7 @@ test("Bash and zsh preserve trusted normal startup and controlled clean startup"
     {
       cwd: home,
       shell: {
-        executable: { path: "/bin/fish", clean_start: true },
+        executable: { path: "/bin/nu", clean_start: true },
       },
       backend: "native",
       return_when: { started: {} },


### PR DESCRIPTION
Closes #118.

Fish login shells previously fell back to zsh or bash (#111, #121). Commands ran, but not in the user's shell: config.fish never loaded, fish functions and fish_add_path entries were missing, and an explicit fish executable was rejected with UnsupportedShell.

## What changed

- `shell_resolver` recognizes fish as a supported shell. `Invocation` now carries its resolved `ShellKind`, so downstream consumers stop guessing from basenames.
- PTY argv: `fish -l -i` for the user profile, `fish --no-config -i` for clean starts. `--no-config` requires fish 3.2 (March 2021) or newer.
- Captured runs: `fish --no-config -c` (clean) and `fish -l -c` (user). Fish loads functions without `-i`, and a forced interactive capture would leak greeting output, so the user capture drops `-i`.
- `buildBootstrap` takes a `ShellKind` and emits a fish dialect: `set -e fish_trace` guards tracing, `set fx_terminal_command (string collect < path)` preserves multi-line commands, and `eval` plus `$status` propagate the exit code. `buildSourceCommand` is unchanged; fish accepts `.` for `source`.
- Both `native_session` bootstrap call sites pass `invocation.kind`.
- The captured user-profile special case now switches on `invocation.kind` instead of the raw basename. This also fixes a latent edge where a fallback-to-bash invocation missed `-O expand_aliases`.

## Tests

- The three tests that locked in fish rejection now use nushell as the unsupported shell, preserving fallback coverage.
- New tests: fish argv (user and clean), fish captured invocations, fish-native profile resolution, and byte-exact fish bootstrap output for the commandless and command forms.
- `zig build test`: 8265/8266 pass, 1 pre-existing skip.

## Verification

On macOS arm64 with fish 4.7.1:

- Ran the exact generated fish bootstrap (asserted byte for byte in the unit test) through `fish --no-config -i -c ". 'path'"`. The command ran, exit code 7 propagated, a missing command file and a failed marker both returned 125, and multi-line commands survived `string collect`.
- Drove `./zig-out/bin/fx` end to end: `terminal start` with shell executable `/opt/homebrew/bin/fish` opened a session and fx read the fish prompt through the PTY. The same request fails with UnsupportedShell on the released v0.0.3.

## Known gaps

- No Bun E2E coverage yet. CI runners would need fish installed. Happy to add the suite if that works for you.
- Command generation is not told the session dialect, so agent-authored POSIX one-liners can still misfire inside fish sessions. That is the "make the active shell semantics clear to command generation" item from #118 and needs its own change.

Nushell, Elvish, and Xonsh remain out of scope per the issue.
