### PR TITLE
Edit composer prompts in an external editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands.
 
+Press `Ctrl+T` to edit the current plain-text prompt with the command in `VISUAL`, falling back to `EDITOR`. Returning from the editor replaces the prompt and resets its edit history. Drafts containing pasted blocks, images, or skills stay unchanged in fx.
+
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands.
 
-Press `Ctrl+T` to edit the current prompt in the editor named by `VISUAL`, falling back to `EDITOR`; drafts containing pasted blocks, images, or skills are left unchanged.
+Press `Ctrl+T` to edit the current prompt with `VISUAL`, falling back to `EDITOR`, even while a response is streaming; drafts containing pasted blocks, images, or skills are left unchanged.
 
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands.
 
-Press `Ctrl+T` to edit the current plain-text prompt with the command in `VISUAL`, falling back to `EDITOR`. Returning from the editor replaces the prompt and resets its edit history. Drafts containing pasted blocks, images, or skills stay unchanged in fx.
+Press `Ctrl+T` to edit the current prompt in the editor named by `VISUAL`, falling back to `EDITOR`; drafts containing pasted blocks, images, or skills are left unchanged.
 
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 

--- a/src/core/app/app_external_editor_runtime.zig
+++ b/src/core/app/app_external_editor_runtime.zig
@@ -1,0 +1,217 @@
+const std = @import("std");
+const host = @import("../hosts/host.zig");
+const types = @import("../shared/types.zig");
+const input_runtime = @import("../input/runtime.zig");
+const render_request = @import("../../ui/render_request.zig");
+
+pub fn Runtime(comptime App: type) type {
+    return struct {
+        pub fn editComposer(
+            app: *App,
+            editor: host.ExternalEditor,
+            max_bytes: usize,
+        ) !bool {
+            if (structuredDraft(app)) {
+                try writeNotice(
+                    app,
+                    .warning,
+                    "external editing is unavailable while the draft contains pasted blocks, images, or skills",
+                );
+                return false;
+            }
+
+            const seed = app.input_runtime.edit_state.input.items;
+            var result = try app.runExternalInteractive(editor, seed, max_bytes);
+            defer result.deinit(app.alloc);
+            switch (result) {
+                .edited => |text| {
+                    const normalized = normalizeFinalNewline(seed, text);
+                    if (std.mem.eql(u8, seed, normalized)) return false;
+                    try app.input_runtime.textReplacementState().replace(app.alloc, normalized);
+                    app.shell.render_requests.request(.footer);
+                    return true;
+                },
+                .canceled => return false,
+                .failed => |failure| {
+                    try reportFailure(app, failure);
+                    return false;
+                },
+            }
+        }
+
+        fn structuredDraft(app: *const App) bool {
+            return app.input_runtime.entities.pasted_blocks.items.len > 0 or
+                app.input_runtime.entities.image_tokens.items.len > 0 or
+                app.input_runtime.entities.skill_tokens.items.len > 0 or
+                app.pending_images.items.len > 0;
+        }
+
+        fn reportFailure(app: *App, failure: host.ExternalEditor.Failure) !void {
+            const summary = switch (failure.reason) {
+                .unavailable => "external editing is unavailable on this host",
+                .missing_editor => "set VISUAL or EDITOR to use Ctrl+T",
+                .invalid_command => "VISUAL or EDITOR must name an executable and arguments without shell operators",
+                .editor_failed => "the external editor failed",
+                .output_invalid => "the external editor returned invalid text",
+                .output_too_large => "the external editor output exceeded the composer limit",
+            };
+            if (failure.kept_path) |path| {
+                const body = try std.fmt.allocPrint(
+                    app.alloc,
+                    "{s}; your saved draft is at {s}",
+                    .{ summary, path },
+                );
+                defer app.alloc.free(body);
+                try writeNotice(app, .@"error", body);
+                return;
+            }
+            try writeNotice(
+                app,
+                switch (failure.reason) {
+                    .unavailable, .missing_editor => .warning,
+                    else => .@"error",
+                },
+                summary,
+            );
+        }
+
+        fn writeNotice(app: *App, tone: types.NoticeTone, body: []const u8) !void {
+            try app.writeDomainNotice(.{
+                .topic = "editor",
+                .tone = tone,
+                .body = body,
+            }, true);
+            app.shell.render_requests.request(.footer);
+        }
+    };
+}
+
+fn normalizeFinalNewline(seed: []const u8, edited: []const u8) []const u8 {
+    if (!std.mem.endsWith(u8, seed, "\n") and std.mem.endsWith(u8, edited, "\n")) {
+        return edited[0 .. edited.len - 1];
+    }
+    return edited;
+}
+
+test "external editor normalization removes only an editor-added final newline" {
+    try std.testing.expectEqualStrings("edited", normalizeFinalNewline("seed", "edited\n"));
+    try std.testing.expectEqualStrings("edited\n", normalizeFinalNewline("seed\n", "edited\n"));
+    try std.testing.expectEqualStrings("edited\n\n", normalizeFinalNewline("seed\n", "edited\n\n"));
+}
+
+const TestResult = union(enum) {
+    edited: []const u8,
+    canceled,
+    failed: host.ExternalEditor.Failure,
+};
+
+const TestShell = struct {
+    render_requests: render_request.RenderRequestState = .{},
+};
+
+const TestApp = struct {
+    alloc: std.mem.Allocator,
+    input_runtime: input_runtime.Runtime = .{},
+    pending_images: std.ArrayList(u8) = .empty,
+    shell: TestShell = .{},
+    next_result: TestResult = .canceled,
+    run_count: usize = 0,
+    max_bytes_seen: usize = 0,
+    notice_body: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *TestApp) void {
+        self.input_runtime.deinit(self.alloc);
+        self.pending_images.deinit(self.alloc);
+        self.notice_body.deinit(self.alloc);
+    }
+
+    pub fn runExternalInteractive(
+        self: *TestApp,
+        _: host.ExternalEditor,
+        _: []const u8,
+        max_bytes: usize,
+    ) !host.ExternalEditor.EditResult {
+        self.run_count += 1;
+        self.max_bytes_seen = max_bytes;
+        return switch (self.next_result) {
+            .edited => |text| .{ .edited = try self.alloc.dupe(u8, text) },
+            .canceled => .canceled,
+            .failed => |failure| .{ .failed = .{
+                .reason = failure.reason,
+                .kept_path = if (failure.kept_path) |path|
+                    try self.alloc.dupe(u8, path)
+                else
+                    null,
+            } },
+        };
+    }
+
+    pub fn writeDomainNotice(self: *TestApp, notice: types.SemanticNotice, _: bool) !void {
+        self.notice_body.clearRetainingCapacity();
+        try self.notice_body.appendSlice(self.alloc, notice.body);
+    }
+};
+
+test "external editor replaces a plain draft and preserves a normalized no-op" {
+    const alloc = std.testing.allocator;
+    var app = TestApp{ .alloc = alloc, .next_result = .{ .edited = "edited\n" } };
+    defer app.deinit();
+    try app.input_runtime.edit_state.setText(alloc, "seed");
+
+    try std.testing.expect(try Runtime(TestApp).editComposer(
+        &app,
+        host.unavailable_external_editor,
+        1234,
+    ));
+    try std.testing.expectEqualStrings("edited", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(app.input_runtime.edit_state.input.items.len, app.input_runtime.edit_state.cursor);
+    try std.testing.expectEqual(@as(usize, 1234), app.max_bytes_seen);
+
+    _ = app.input_runtime.edit_state.setCursor(2);
+    app.next_result = .{ .edited = "edited\n" };
+    try std.testing.expect(!try Runtime(TestApp).editComposer(
+        &app,
+        host.unavailable_external_editor,
+        1234,
+    ));
+    try std.testing.expectEqual(@as(usize, 2), app.input_runtime.edit_state.cursor);
+}
+
+test "external editor refuses structured drafts before terminal handoff" {
+    const alloc = std.testing.allocator;
+    var app = TestApp{ .alloc = alloc, .next_result = .{ .edited = "changed" } };
+    defer app.deinit();
+    try app.input_runtime.edit_state.setText(alloc, "[Image #1]");
+    try app.input_runtime.entities.image_tokens.append(alloc, .{
+        .id = 1,
+        .span = .{ .raw_start = 0, .raw_end = "[Image #1]".len },
+    });
+
+    try std.testing.expect(!try Runtime(TestApp).editComposer(
+        &app,
+        host.unavailable_external_editor,
+        1234,
+    ));
+    try std.testing.expectEqual(@as(usize, 0), app.run_count);
+    try std.testing.expect(std.mem.find(u8, app.notice_body.items, "pasted blocks, images, or skills") != null);
+}
+
+test "external editor reports the recovery path for unusable output" {
+    const alloc = std.testing.allocator;
+    var app = TestApp{
+        .alloc = alloc,
+        .next_result = .{ .failed = .{
+            .reason = .output_too_large,
+            .kept_path = @constCast("/tmp/recovered.md"),
+        } },
+    };
+    defer app.deinit();
+
+    try std.testing.expect(!try Runtime(TestApp).editComposer(
+        &app,
+        host.unavailable_external_editor,
+        1234,
+    ));
+    try std.testing.expect(std.mem.find(u8, app.notice_body.items, "composer limit") != null);
+    try std.testing.expect(std.mem.find(u8, app.notice_body.items, "/tmp/recovered.md") != null);
+}

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1156,19 +1156,16 @@ pub fn Runtime(comptime App: type) type {
 
         fn routeExternalEditorShortcut(app: *App, byte: u8, max_input_len: usize) !bool {
             if (byte != ctrl_t_external_editor_byte) return false;
-            if (comptime @hasField(App, "stream")) {
-                if (app.stream.active) {
+            if (comptime @hasField(App, "terminal")) {
+                if (app.terminal.alternate_screen_owner != .none) {
                     try app.writeDomainNotice(.{
                         .topic = "editor",
                         .tone = .warning,
-                        .body = "external editing is unavailable until the response finishes",
+                        .body = "external editing is unavailable while another screen owns the terminal",
                     }, true);
                     app.shell.render_requests.request(.footer);
                     return true;
                 }
-            }
-            if (comptime @hasField(App, "terminal")) {
-                if (app.terminal.alternate_screen_owner != .none) return true;
             }
             dismissActiveMenusThenRedraw(app);
             if (comptime @hasDecl(App, "editComposerWithExternalEditor")) {
@@ -7291,29 +7288,27 @@ test "app_input_runtime ctrl+t invokes external editor without composer mutation
     try std.testing.expectEqual(@as(usize, 0), app.submitted_prompt_count);
 }
 
-test "app_input_runtime ctrl+t is denied while stream or alternate screen owns state" {
+test "app_input_runtime ctrl+t remains available while a response streams" {
     const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    app.stream.active = true;
 
-    {
-        var app = try RoutingFakeApp.init(alloc);
-        defer app.deinit();
-        app.stream.active = true;
+    try Runtime(RoutingFakeApp).handleByte(&app, ctrl_t_external_editor_byte, 4096, 100);
 
-        try Runtime(RoutingFakeApp).handleByte(&app, ctrl_t_external_editor_byte, 4096, 100);
+    try std.testing.expectEqual(@as(usize, 1), app.external_editor_count);
+}
 
-        try std.testing.expectEqual(@as(usize, 0), app.external_editor_count);
-        try std.testing.expect(std.mem.find(u8, app.notice_body.items, "response finishes") != null);
-    }
+test "app_input_runtime ctrl+t is denied while an alternate screen owns the terminal" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    app.terminal.alternate_screen_owner = .catalog_menu;
 
-    {
-        var app = try RoutingFakeApp.init(alloc);
-        defer app.deinit();
-        app.terminal.alternate_screen_owner = .catalog_menu;
+    try Runtime(RoutingFakeApp).handleByte(&app, ctrl_t_external_editor_byte, 4096, 100);
 
-        try Runtime(RoutingFakeApp).handleByte(&app, ctrl_t_external_editor_byte, 4096, 100);
-
-        try std.testing.expectEqual(@as(usize, 0), app.external_editor_count);
-    }
+    try std.testing.expectEqual(@as(usize, 0), app.external_editor_count);
+    try std.testing.expect(std.mem.find(u8, app.notice_body.items, "another screen") != null);
 }
 
 test "app_input_runtime immediate ctrl+t follows bare Escape" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -75,6 +75,7 @@ const ToolPermissionDecision = types.ToolPermissionDecision;
 
 pub const file_picker_completion_cap = input_completion_runtime.file_picker_completion_cap;
 const ctrl_g_upgrade_byte: u8 = 7;
+const ctrl_t_external_editor_byte: u8 = 20;
 const ctrl_x_manager_byte: u8 = 24;
 
 fn classifyResumeFailure(err: anyerror) session_catalog.ResumeFailure {
@@ -882,6 +883,7 @@ pub fn Runtime(comptime App: type) type {
             if (try full_transcript_rt.routeByte(app, byte)) return;
 
             if (try routeActiveModalInput(app, raw, input_limits.decision_bytes)) return;
+            if (try routeExternalEditorShortcut(app, byte, max_input_len)) return;
             if (byte >= 0x80) {
                 try handleTextByte(app, .composer, byte, max_input_len);
                 return;
@@ -1148,6 +1150,33 @@ pub fn Runtime(comptime App: type) type {
             if (byte != ctrl_g_upgrade_byte) return false;
             if (comptime @hasDecl(App, "applyReadyUpgradeShortcut")) {
                 try app.applyReadyUpgradeShortcut();
+            }
+            return true;
+        }
+
+        fn routeExternalEditorShortcut(app: *App, byte: u8, max_input_len: usize) !bool {
+            if (byte != ctrl_t_external_editor_byte) return false;
+            if (comptime @hasField(App, "stream")) {
+                if (app.stream.active) {
+                    try app.writeDomainNotice(.{
+                        .topic = "editor",
+                        .tone = .warning,
+                        .body = "external editing is unavailable until the response finishes",
+                    }, true);
+                    app.shell.render_requests.request(.footer);
+                    return true;
+                }
+            }
+            if (comptime @hasField(App, "terminal")) {
+                if (app.terminal.alternate_screen_owner != .none) return true;
+            }
+            dismissActiveMenusThenRedraw(app);
+            if (comptime @hasDecl(App, "editComposerWithExternalEditor")) {
+                if (try app.editComposerWithExternalEditor(max_input_len)) {
+                    if (comptime @hasField(App, "queued_prompt_review")) {
+                        queue_rt.markVisibleSelectionDirty(app);
+                    }
+                }
             }
             return true;
         }
@@ -3138,6 +3167,7 @@ const RoutingFakeApp = struct {
     selected_auth_team: ?usize = null,
     upgrade_apply_count: usize = 0,
     upgrade_denied_count: usize = 0,
+    external_editor_count: usize = 0,
     suspend_count: usize = 0,
     workspace_access: app_workspace_runtime.Access = .{},
 
@@ -3200,6 +3230,11 @@ const RoutingFakeApp = struct {
 
     pub fn suspendToJobControl(self: *RoutingFakeApp) !void {
         self.suspend_count += 1;
+    }
+
+    pub fn editComposerWithExternalEditor(self: *RoutingFakeApp, _: usize) !bool {
+        self.external_editor_count += 1;
+        return true;
     }
 
     pub fn modelCompletions(self: *RoutingFakeApp, query: []const u8, out: *[32][]const u8) usize {
@@ -7240,6 +7275,55 @@ test "app_input_runtime immediate ctrl+g follows bare Escape" {
 
     try std.testing.expectEqual(@as(usize, 1), app.upgrade_apply_count);
     try std.testing.expectEqual(@as(usize, 0), app.upgrade_denied_count);
+    try std.testing.expectEqual(@as(u8, 0), app.terminal_input_runtime.terminal_action_decoder.stage);
+}
+
+test "app_input_runtime ctrl+t invokes external editor without composer mutation" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    try app.input_runtime.textReplacementState().replace(alloc, "draft");
+
+    try Runtime(RoutingFakeApp).handleByte(&app, ctrl_t_external_editor_byte, 4096, 100);
+
+    try std.testing.expectEqual(@as(usize, 1), app.external_editor_count);
+    try std.testing.expectEqualStrings("draft", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 0), app.submitted_prompt_count);
+}
+
+test "app_input_runtime ctrl+t is denied while stream or alternate screen owns state" {
+    const alloc = std.testing.allocator;
+
+    {
+        var app = try RoutingFakeApp.init(alloc);
+        defer app.deinit();
+        app.stream.active = true;
+
+        try Runtime(RoutingFakeApp).handleByte(&app, ctrl_t_external_editor_byte, 4096, 100);
+
+        try std.testing.expectEqual(@as(usize, 0), app.external_editor_count);
+        try std.testing.expect(std.mem.find(u8, app.notice_body.items, "response finishes") != null);
+    }
+
+    {
+        var app = try RoutingFakeApp.init(alloc);
+        defer app.deinit();
+        app.terminal.alternate_screen_owner = .catalog_menu;
+
+        try Runtime(RoutingFakeApp).handleByte(&app, ctrl_t_external_editor_byte, 4096, 100);
+
+        try std.testing.expectEqual(@as(usize, 0), app.external_editor_count);
+    }
+}
+
+test "app_input_runtime immediate ctrl+t follows bare Escape" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+
+    try feedRoutingBytes(&app, "\x1b\x14");
+
+    try std.testing.expectEqual(@as(usize, 1), app.external_editor_count);
     try std.testing.expectEqual(@as(u8, 0), app.terminal_input_runtime.terminal_action_decoder.stage);
 }
 

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -62,7 +62,7 @@ pub const ExternalInteractiveSignalGuard = struct {
         const action: std.posix.Sigaction = .{
             .handler = .{ .handler = externalInteractiveSignalHandler },
             .mask = std.posix.sigemptyset(),
-            .flags = 0,
+            .flags = std.posix.SA.RESTART,
         };
         var guard: ExternalInteractiveSignalGuard = .{};
         var old_sigint: std.posix.Sigaction = undefined;
@@ -636,6 +636,16 @@ fn suspendTerminalForJobControl(
     metrics: *Metrics,
 ) void {
     leaveAlternateScreens(terminal, shell, metrics);
+    suspendForExternalInteractive(terminal, shell, metrics);
+}
+
+/// Restore cooked terminal state before inherited stdio belongs to a child.
+/// The caller must first ensure that no alternate screen remains owned.
+pub fn suspendForExternalInteractive(
+    terminal: *TerminalState,
+    shell: *TranscriptRuntime,
+    metrics: *Metrics,
+) void {
     _ = writeLifecycleTerminalBytes(shell, metrics, normalExitRestoreSequence(io_mod.getenv("TMUX"))) catch {};
     finishLeavingInteractiveMode(terminal, shell, metrics);
 }
@@ -687,6 +697,32 @@ fn resumeTerminalAfterJobControl(
     try enableInteractiveTerminalModes(shell, metrics);
     try shell.requestTerminalReset(metrics);
     shell.render_requests.request(.first_frame);
+}
+
+/// Re-arm interactive terminal state after a child handoff, then request a
+/// full repaint while still reporting the first restore failure.
+pub fn resumeAfterExternalInteractive(
+    terminal: *TerminalState,
+    shell: *TranscriptRuntime,
+    metrics: *Metrics,
+    footer_rows: u16,
+) !void {
+    var first_error: ?anyerror = null;
+    shell.layout = terminal.queryLayout(footer_rows) catch shell.layout;
+    terminal.captureOriginalTermios() catch |err| {
+        first_error = err;
+    };
+    terminal.enableRawMode() catch |err| {
+        if (first_error == null) first_error = err;
+    };
+    enableInteractiveTerminalModes(shell, metrics) catch |err| {
+        if (first_error == null) first_error = err;
+    };
+    shell.requestTerminalReset(metrics) catch |err| {
+        if (first_error == null) first_error = err;
+    };
+    shell.render_requests.request(.first_frame);
+    if (first_error) |err| return err;
 }
 
 fn enableInteractiveTerminalModes(shell: *TranscriptRuntime, metrics: *Metrics) !void {
@@ -1884,6 +1920,17 @@ test "terminal keyboard stack restore stays paired with enable policy" {
     try std.testing.expect(std.mem.find(u8, tmux_abnormal_exit_restore, "\x1b[<u") == null);
     try std.testing.expect(std.mem.find(u8, tmux_restore, "\x1b[?2004l") != null);
     try std.testing.expect(std.mem.find(u8, tmux_restore, "\x1b[>4;0m") != null);
+}
+
+test "external interactive signal guard restarts interrupted syscalls" {
+    if (!shell_runtime.supports_resize_signal) return error.SkipZigTest;
+
+    const guard = ExternalInteractiveSignalGuard.install();
+    defer guard.deinit();
+
+    var action: std.posix.Sigaction = undefined;
+    std.posix.sigaction(std.posix.SIG.INT, null, &action);
+    try std.testing.expect(action.flags & std.posix.SA.RESTART != 0);
 }
 
 test "launch scrollback push creates top-of-viewport space" {

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -48,6 +48,42 @@ const terminal_takeover_reset = "\x1b[?2026l\x1b[?1000l\x1b[?1002l\x1b[?1004l\x1
 var old_sigterm_action: ?std.posix.Sigaction = null;
 var old_sighup_action: ?std.posix.Sigaction = null;
 
+fn externalInteractiveSignalHandler(_: std.posix.SIG) callconv(.c) void {}
+
+/// Keeps terminal-generated interrupts from terminating fx while inherited
+/// stdio belongs to a child. Caught handlers reset to default across exec, so
+/// the editor still receives its normal SIGINT and SIGQUIT behavior.
+pub const ExternalInteractiveSignalGuard = struct {
+    old_sigint_action: ?std.posix.Sigaction = null,
+    old_sigquit_action: ?std.posix.Sigaction = null,
+
+    pub fn install() ExternalInteractiveSignalGuard {
+        if (!shell_runtime.supports_resize_signal) return .{};
+        const action: std.posix.Sigaction = .{
+            .handler = .{ .handler = externalInteractiveSignalHandler },
+            .mask = std.posix.sigemptyset(),
+            .flags = 0,
+        };
+        var guard: ExternalInteractiveSignalGuard = .{};
+        var old_sigint: std.posix.Sigaction = undefined;
+        std.posix.sigaction(std.posix.SIG.INT, &action, &old_sigint);
+        guard.old_sigint_action = old_sigint;
+        var old_sigquit: std.posix.Sigaction = undefined;
+        std.posix.sigaction(std.posix.SIG.QUIT, &action, &old_sigquit);
+        guard.old_sigquit_action = old_sigquit;
+        return guard;
+    }
+
+    pub fn deinit(self: ExternalInteractiveSignalGuard) void {
+        if (self.old_sigquit_action) |old| {
+            std.posix.sigaction(std.posix.SIG.QUIT, &old, null);
+        }
+        if (self.old_sigint_action) |old| {
+            std.posix.sigaction(std.posix.SIG.INT, &old, null);
+        }
+    }
+};
+
 /// Restores terminal state, installs the default disposition, and re-raises.
 /// Must remain async-signal-safe: only `write(2)`, `sigaction(2)`, and `raise(3)`.
 fn abnormalExitHandlerWithRestore(comptime restore: []const u8, sig: std.posix.SIG) void {

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -75,6 +75,7 @@ pub const ExternalInteractiveSignalGuard = struct {
     }
 
     pub fn deinit(self: ExternalInteractiveSignalGuard) void {
+        if (!shell_runtime.supports_resize_signal) return;
         if (self.old_sigquit_action) |old| {
             std.posix.sigaction(std.posix.SIG.QUIT, &old, null);
         }

--- a/src/core/hosts/host.zig
+++ b/src/core/hosts/host.zig
@@ -52,6 +52,72 @@ fn unavailableUrlOpen(
     return false;
 }
 
+pub const ExternalEditor = struct {
+    pub const FailureReason = enum {
+        unavailable,
+        missing_editor,
+        invalid_command,
+        editor_failed,
+        output_invalid,
+        output_too_large,
+    };
+
+    pub const Failure = struct {
+        reason: FailureReason,
+        kept_path: ?[]u8 = null,
+    };
+
+    pub const EditResult = union(enum) {
+        edited: []u8,
+        canceled,
+        failed: Failure,
+
+        pub fn deinit(self: *EditResult, alloc: std.mem.Allocator) void {
+            switch (self.*) {
+                .edited => |text| alloc.free(text),
+                .failed => |failure| if (failure.kept_path) |path| alloc.free(path),
+                .canceled => {},
+            }
+            self.* = .canceled;
+        }
+    };
+
+    context: ?*anyopaque = null,
+    edit_fn: *const fn (
+        ?*anyopaque,
+        std.mem.Allocator,
+        []const u8,
+        usize,
+    ) std.mem.Allocator.Error!EditResult,
+
+    /// Borrows `seed` for this call. The caller must quiesce terminal I/O, enter
+    /// cooked mode, and protect itself from terminal-generated signals while the
+    /// editor owns inherited stdio. Edited text is bounded, valid UTF-8 owned by
+    /// the caller, with temporary-file cleanup attempted on success. Release every
+    /// result with `EditResult.deinit`.
+    pub fn edit(
+        self: ExternalEditor,
+        alloc: std.mem.Allocator,
+        seed: []const u8,
+        max_bytes: usize,
+    ) std.mem.Allocator.Error!EditResult {
+        return self.edit_fn(self.context, alloc, seed, max_bytes);
+    }
+};
+
+pub const unavailable_external_editor: ExternalEditor = .{
+    .edit_fn = unavailableExternalEditorEdit,
+};
+
+fn unavailableExternalEditorEdit(
+    _: ?*anyopaque,
+    _: std.mem.Allocator,
+    _: []const u8,
+    _: usize,
+) std.mem.Allocator.Error!ExternalEditor.EditResult {
+    return .{ .failed = .{ .reason = .unavailable } };
+}
+
 pub const TerminalTitle = struct {
     context: ?*anyopaque = null,
     set_fn: *const fn (?*anyopaque, []const u8) void,

--- a/src/core/hosts/native_external_editor.zig
+++ b/src/core/hosts/native_external_editor.zig
@@ -1,0 +1,313 @@
+const std = @import("std");
+const command_lex = @import("../shell_command/command_lex.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
+const io_mod = @import("../shared/io.zig");
+const host = @import("host.zig");
+
+const Allocator = std.mem.Allocator;
+const EditResult = host.ExternalEditor.EditResult;
+const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+
+pub const external_editor: host.ExternalEditor = .{ .edit_fn = edit };
+
+fn edit(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    seed: []const u8,
+    max_bytes: usize,
+) Allocator.Error!EditResult {
+    const command = configuredEditorCommand() orelse {
+        return .{ .failed = .{ .reason = .missing_editor } };
+    };
+    return editWithCommand(alloc, command, temporaryRoot(), seed, max_bytes);
+}
+
+fn configuredEditorCommand() ?[]const u8 {
+    return selectEditorCommand(
+        io_mod.getenv("VISUAL"),
+        io_mod.getenv("EDITOR"),
+    );
+}
+
+fn selectEditorCommand(visual: ?[]const u8, editor: ?[]const u8) ?[]const u8 {
+    if (visual) |value| {
+        if (std.mem.trim(u8, value, " \t\r\n").len > 0) return value;
+    }
+    if (editor) |value| {
+        if (std.mem.trim(u8, value, " \t\r\n").len > 0) return value;
+    }
+    return null;
+}
+
+fn temporaryRoot() []const u8 {
+    const configured = io_mod.getenv("TMPDIR") orelse return "/tmp";
+    if (configured.len == 0 or !std.Io.Dir.path.isAbsolute(configured)) return "/tmp";
+    return configured;
+}
+
+fn editWithCommand(
+    alloc: Allocator,
+    command: []const u8,
+    temp_root: []const u8,
+    seed: []const u8,
+    max_bytes: usize,
+) Allocator.Error!EditResult {
+    if (command_lex.unsafe_compound_indicator(command)) {
+        return .{ .failed = .{ .reason = .invalid_command } };
+    }
+
+    var parsed = command_lex.tokenize_argv(alloc, command) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return .{ .failed = .{ .reason = .invalid_command } },
+    };
+    defer parsed.deinit(alloc);
+    if (parsed.tokens.len == 0) return .{ .failed = .{ .reason = .invalid_command } };
+    for (parsed.tokens) |token| {
+        if (std.mem.eql(u8, token.raw, token.value) and
+            (command_lex.redirection_kind(token.value) != null or
+                std.mem.eql(u8, token.value, "|")))
+        {
+            return .{ .failed = .{ .reason = .invalid_command } };
+        }
+    }
+
+    const zio = io_mod.getIo();
+    var temp_dir = std.Io.Dir.openDirAbsolute(zio, temp_root, .{}) catch |err| {
+        debug_trace.logf("input", "external editor temp directory failed err={s}", .{@errorName(err)});
+        return .{ .failed = .{ .reason = .editor_failed } };
+    };
+    defer temp_dir.close(zio);
+
+    var random_bytes: [16]u8 = undefined;
+    zio.random(&random_bytes);
+    const suffix = std.fmt.bytesToHex(random_bytes, .lower);
+    var name_buf: [64]u8 = undefined;
+    const temp_name = std.fmt.bufPrint(&name_buf, "fx-editor-{s}.md", .{suffix}) catch {
+        return .{ .failed = .{ .reason = .editor_failed } };
+    };
+    const temp_path = try std.Io.Dir.path.join(alloc, &.{ temp_root, temp_name });
+    var owns_temp_path = true;
+    defer if (owns_temp_path) alloc.free(temp_path);
+
+    var remove_temp = false;
+    defer if (remove_temp) {
+        temp_dir.deleteFile(zio, temp_name) catch |err| {
+            debug_trace.logf("input", "external editor temp cleanup failed err={s}", .{@errorName(err)});
+        };
+    };
+
+    {
+        var file = temp_dir.createFile(zio, temp_name, .{
+            .exclusive = true,
+            .permissions = private_file_permissions,
+        }) catch |err| {
+            debug_trace.logf("input", "external editor temp create failed err={s}", .{@errorName(err)});
+            return .{ .failed = .{ .reason = .editor_failed } };
+        };
+        remove_temp = true;
+        defer file.close(zio);
+        file.writeStreamingAll(zio, seed) catch |err| {
+            debug_trace.logf("input", "external editor seed write failed err={s}", .{@errorName(err)});
+            return .{ .failed = .{ .reason = .editor_failed } };
+        };
+    }
+
+    const argv = try alloc.alloc([]const u8, parsed.tokens.len + 1);
+    defer alloc.free(argv);
+    for (parsed.tokens, 0..) |token, index| argv[index] = token.value;
+    argv[parsed.tokens.len] = temp_path;
+
+    var child = std.process.spawn(zio, .{
+        .argv = argv,
+        .stdin = .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+    }) catch |err| {
+        debug_trace.logf("input", "external editor spawn failed err={s}", .{@errorName(err)});
+        return .{ .failed = .{ .reason = .editor_failed } };
+    };
+    defer child.kill(zio);
+    const term = child.wait(zio) catch |err| {
+        debug_trace.logf("input", "external editor wait failed err={s}", .{@errorName(err)});
+        return .{ .failed = .{ .reason = .editor_failed } };
+    };
+    switch (term) {
+        .exited => |code| {
+            if (code != 0) {
+                debug_trace.logf("input", "external editor canceled exit_code={d}", .{code});
+                return .canceled;
+            }
+        },
+        .signal => |signal| {
+            debug_trace.logf("input", "external editor failed signal={d}", .{@intFromEnum(signal)});
+            return .{ .failed = .{ .reason = .editor_failed } };
+        },
+        .stopped => |signal| {
+            debug_trace.logf("input", "external editor failed stopped={d}", .{@intFromEnum(signal)});
+            return .{ .failed = .{ .reason = .editor_failed } };
+        },
+        .unknown => |status| {
+            debug_trace.logf("input", "external editor failed status={d}", .{status});
+            return .{ .failed = .{ .reason = .editor_failed } };
+        },
+    }
+
+    var output_file = temp_dir.openFile(zio, temp_name, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+    }) catch |err| {
+        debug_trace.logf("input", "external editor output open failed err={s}", .{@errorName(err)});
+        return keepEditedFile(.editor_failed, temp_path, &owns_temp_path, &remove_temp);
+    };
+    defer output_file.close(zio);
+    const stat = output_file.stat(zio) catch |err| {
+        debug_trace.logf("input", "external editor output stat failed err={s}", .{@errorName(err)});
+        return keepEditedFile(.editor_failed, temp_path, &owns_temp_path, &remove_temp);
+    };
+    if (stat.kind != .file or stat.nlink != 1) {
+        debug_trace.logf("input", "external editor output rejected kind={s} nlink={d}", .{ @tagName(stat.kind), stat.nlink });
+        return keepEditedFile(.output_invalid, temp_path, &owns_temp_path, &remove_temp);
+    }
+
+    const output = io_mod.readFileToEnd(alloc, &output_file, max_bytes) catch |err| switch (err) {
+        error.StreamTooLong => return keepEditedFile(.output_too_large, temp_path, &owns_temp_path, &remove_temp),
+        else => {
+            debug_trace.logf("input", "external editor output read failed err={s}", .{@errorName(err)});
+            return keepEditedFile(.editor_failed, temp_path, &owns_temp_path, &remove_temp);
+        },
+    };
+    if (!std.unicode.utf8ValidateSlice(output) or std.mem.findScalar(u8, output, 0) != null) {
+        debug_trace.logf("input", "external editor output rejected reason=invalid_text", .{});
+        alloc.free(output);
+        return keepEditedFile(.output_invalid, temp_path, &owns_temp_path, &remove_temp);
+    }
+
+    temp_dir.deleteFile(zio, temp_name) catch |err| {
+        debug_trace.logf(
+            "input",
+            "external editor temp cleanup failed path={s} err={s}",
+            .{ temp_path, @errorName(err) },
+        );
+    };
+    remove_temp = false;
+    return .{ .edited = output };
+}
+
+fn keepEditedFile(
+    reason: host.ExternalEditor.FailureReason,
+    temp_path: []u8,
+    owns_temp_path: *bool,
+    remove_temp: *bool,
+) EditResult {
+    debug_trace.logf(
+        "input",
+        "external editor output kept reason={s} path={s}",
+        .{ @tagName(reason), temp_path },
+    );
+    owns_temp_path.* = false;
+    remove_temp.* = false;
+    return .{ .failed = .{ .reason = reason, .kept_path = temp_path } };
+}
+
+test "external editor command selection prefers VISUAL and skips empty values" {
+    try std.testing.expectEqualStrings("nvim -f", selectEditorCommand("nvim -f", "vi").?);
+    try std.testing.expectEqualStrings("vi", selectEditorCommand("  ", "vi").?);
+    try std.testing.expect(selectEditorCommand(null, "\t") == null);
+}
+
+test "external editor command parser accepts argv quoting and rejects shell syntax" {
+    const alloc = std.testing.allocator;
+    var parsed = try command_lex.tokenize_argv(alloc, "code --wait 'profile name'");
+    defer parsed.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 3), parsed.tokens.len);
+    try std.testing.expectEqualStrings("profile name", parsed.tokens[2].value);
+
+    const invalid_commands = [_][]const u8{
+        "vi && touch nope",
+        "vi > output",
+        "vi | cat",
+    };
+    for (invalid_commands) |command| {
+        var result = try editWithCommand(alloc, command, "/tmp", "seed", 1024);
+        defer result.deinit(alloc);
+        try std.testing.expectEqual(host.ExternalEditor.FailureReason.invalid_command, result.failed.reason);
+        try std.testing.expect(result.failed.kept_path == null);
+    }
+}
+
+test "external editor returns valid text and treats nonzero exit as cancellation" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+
+    var edited = try editWithCommand(
+        alloc,
+        "/bin/sh -c 'printf changed > \"$1\"' sh",
+        root,
+        "seed",
+        1024,
+    );
+    defer edited.deinit(alloc);
+    try std.testing.expectEqualStrings("changed", edited.edited);
+
+    var canceled = try editWithCommand(
+        alloc,
+        "/bin/sh -c 'exit 7' sh",
+        root,
+        "seed",
+        1024,
+    );
+    defer canceled.deinit(alloc);
+    try std.testing.expect(canceled == .canceled);
+
+    var check_dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), root, .{ .iterate = true });
+    defer check_dir.close(io_mod.getIo());
+    var iterator = check_dir.iterate();
+    try std.testing.expect(try iterator.next(io_mod.getIo()) == null);
+}
+
+test "external editor keeps oversized saved output for recovery" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+
+    var result = try editWithCommand(
+        alloc,
+        "/bin/sh -c 'printf too-long > \"$1\"' sh",
+        root,
+        "seed",
+        3,
+    );
+    defer result.deinit(alloc);
+    try std.testing.expectEqual(host.ExternalEditor.FailureReason.output_too_large, result.failed.reason);
+    const kept_path = result.failed.kept_path.?;
+    var kept = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), kept_path, .{});
+    defer kept.close(io_mod.getIo());
+    const contents = try io_mod.readFileToEnd(alloc, &kept, 64);
+    defer alloc.free(contents);
+    try std.testing.expectEqualStrings("too-long", contents);
+}
+
+test "external editor keeps invalid saved text for recovery" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+
+    var result = try editWithCommand(
+        alloc,
+        "/bin/sh -c 'printf \"bad\\000text\" > \"$1\"' sh",
+        root,
+        "seed",
+        64,
+    );
+    defer result.deinit(alloc);
+    try std.testing.expectEqual(host.ExternalEditor.FailureReason.output_invalid, result.failed.reason);
+    try std.testing.expect(result.failed.kept_path != null);
+}

--- a/src/core/hosts/runtime_profile.zig
+++ b/src/core/hosts/runtime_profile.zig
@@ -12,6 +12,7 @@ pub const Profile = struct {
     skills: bool,
     clipboard: bool,
     url_opening: bool,
+    external_editor: bool,
     web_search: bool,
     generation_usage: bool,
     tools: bool,
@@ -42,6 +43,7 @@ pub const native = Profile{
     .skills = true,
     .clipboard = true,
     .url_opening = true,
+    .external_editor = true,
     .web_search = true,
     .generation_usage = true,
     .tools = true,
@@ -65,6 +67,7 @@ pub const wasm = Profile{
     .skills = false,
     .clipboard = false,
     .url_opening = false,
+    .external_editor = false,
     .web_search = false,
     .generation_usage = false,
     .tools = false,
@@ -94,11 +97,13 @@ test "host profile capabilities are selected by field" {
 test "native and wasm profiles select distinct auth host effects" {
     try std.testing.expect(native.native_auth);
     try std.testing.expect(native.url_opening);
+    try std.testing.expect(native.external_editor);
     try std.testing.expect(!native.js_host_auth);
     try std.testing.expect(!native.js_host_url_open);
 
     try std.testing.expect(!wasm.native_auth);
     try std.testing.expect(!wasm.url_opening);
+    try std.testing.expect(!wasm.external_editor);
     try std.testing.expect(wasm.js_host_auth);
     try std.testing.expect(wasm.js_host_url_open);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -905,10 +905,19 @@ const App = struct {
 
         const signal_guard = app_lifecycle.ExternalInteractiveSignalGuard.install();
         defer signal_guard.deinit();
-        self.terminal.disableRawMode();
+        app_lifecycle.suspendForExternalInteractive(
+            &self.terminal,
+            &self.shell,
+            &self.metrics,
+        );
         var terminal_restored = false;
         defer if (!terminal_restored) {
-            self.restoreAfterExternalInteractive() catch |err| {
+            app_lifecycle.resumeAfterExternalInteractive(
+                &self.terminal,
+                &self.shell,
+                &self.metrics,
+                footer_rows,
+            ) catch |err| {
                 debug_trace.logf(
                     "input",
                     "external editor terminal restore failed err={s}",
@@ -917,32 +926,16 @@ const App = struct {
             };
         };
 
-        const io = io_mod.getIo();
-        try std.Io.File.stdout().writeStreamingAll(io, "\n");
         var result = try editor.edit(self.alloc, seed, max_bytes);
         errdefer result.deinit(self.alloc);
-        try self.restoreAfterExternalInteractive();
+        try app_lifecycle.resumeAfterExternalInteractive(
+            &self.terminal,
+            &self.shell,
+            &self.metrics,
+            footer_rows,
+        );
         terminal_restored = true;
         return result;
-    }
-
-    fn restoreAfterExternalInteractive(self: *App) !void {
-        var first_error: ?anyerror = null;
-        std.Io.File.stdout().writeStreamingAll(io_mod.getIo(), "\n") catch |err| {
-            first_error = err;
-        };
-        self.terminal.captureOriginalTermios() catch |err| {
-            if (first_error == null) first_error = err;
-        };
-        self.terminal.enableRawMode() catch |err| {
-            if (first_error == null) first_error = err;
-        };
-        self.shell.layout = self.terminal.queryLayout(footer_rows) catch self.shell.layout;
-        self.shell.requestTerminalReset(&self.metrics) catch |err| {
-            if (first_error == null) first_error = err;
-        };
-        self.shell.render_requests.request(.first_frame);
-        if (first_error) |err| return err;
     }
 
     pub fn flushBeforeBlockingExternalWork(self: *App) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,6 +15,7 @@ const credentials = @import("core/auth/credentials.zig");
 const secret = @import("core/auth/secret.zig");
 const model_cache_runtime = @import("core/app/model_cache_runtime.zig");
 const app_auth_runtime = @import("core/app/app_auth_runtime.zig");
+const app_external_editor_runtime = @import("core/app/app_external_editor_runtime.zig");
 const app_host_config_runtime = @import("core/app/app_host_config_runtime.zig");
 const app_entry_runtime = @import("core/app/app_entry_runtime.zig");
 const acp_runner = @import("core/cli/acp_runner.zig");
@@ -69,6 +70,7 @@ const js_host_url_opener = @import("core/hosts/js_host_url_opener.zig");
 const js_host_workspace = @import("core/hosts/js_host_workspace.zig");
 const host_target = @import("core/hosts/target.zig");
 const native_host = @import("core/hosts/native.zig");
+const native_external_editor = @import("core/hosts/native_external_editor.zig");
 const debug_trace = @import("core/shared/debug_trace.zig");
 const display_width = @import("core/shared/display_width.zig");
 const file_index_mod = @import("core/workspace/file_index.zig");
@@ -375,6 +377,7 @@ const App = struct {
     const Self = @This();
     const AgentAppRuntime = app_agent_runtime.Runtime(Self);
     const AuthAppRuntime = app_auth_runtime.Runtime(Self);
+    const ExternalEditorAppRuntime = app_external_editor_runtime.Runtime(Self);
     const HostConfigAppRuntime = app_host_config_runtime.Runtime(Self);
     const BootstrapAppRuntime = app_bootstrap_runtime.Runtime(Self);
     const InputAppRuntime = app_input_runtime.Runtime(Self);
@@ -426,6 +429,13 @@ const App = struct {
             js_host_url_opener.opener
         else
             host.unavailable_url_opener;
+    }
+
+    pub fn externalEditor(_: *const Self) host.ExternalEditor {
+        return if (comptime host_profile.external_editor)
+            native_external_editor.external_editor
+        else
+            host.unavailable_external_editor;
     }
 
     pub fn creditsProvider(_: *const Self) gateway_provider.CreditsProvider {
@@ -877,37 +887,62 @@ const App = struct {
         );
     }
 
-    pub fn runExternalInteractive(self: *App, argv: []const []const u8) !void {
+    pub fn editComposerWithExternalEditor(self: *App, max_bytes: usize) !bool {
+        return ExternalEditorAppRuntime.editComposer(
+            self,
+            self.externalEditor(),
+            max_bytes,
+        );
+    }
+
+    pub fn runExternalInteractive(
+        self: *App,
+        editor: host.ExternalEditor,
+        seed: []const u8,
+        max_bytes: usize,
+    ) !host.ExternalEditor.EditResult {
         try self.flushBeforeBlockingExternalWork();
 
+        const signal_guard = app_lifecycle.ExternalInteractiveSignalGuard.install();
+        defer signal_guard.deinit();
         self.terminal.disableRawMode();
-        var raw_restored = false;
-        defer if (!raw_restored) {
-            self.terminal.enableRawMode() catch {};
+        var terminal_restored = false;
+        defer if (!terminal_restored) {
+            self.restoreAfterExternalInteractive() catch |err| {
+                debug_trace.logf(
+                    "input",
+                    "external editor terminal restore failed err={s}",
+                    .{@errorName(err)},
+                );
+            };
         };
 
         const io = io_mod.getIo();
         try std.Io.File.stdout().writeStreamingAll(io, "\n");
-        var child = std.process.spawn(io, .{
-            .argv = argv,
-            .stdin = .inherit,
-            .stdout = .inherit,
-            .stderr = .inherit,
-        }) catch return error.ExternalInteractiveFailed;
-        const term = child.wait(io) catch return error.ExternalInteractiveFailed;
-        try std.Io.File.stdout().writeStreamingAll(io, "\n");
+        var result = try editor.edit(self.alloc, seed, max_bytes);
+        errdefer result.deinit(self.alloc);
+        try self.restoreAfterExternalInteractive();
+        terminal_restored = true;
+        return result;
+    }
 
-        try self.terminal.captureOriginalTermios();
-        try self.terminal.enableRawMode();
-        raw_restored = true;
+    fn restoreAfterExternalInteractive(self: *App) !void {
+        var first_error: ?anyerror = null;
+        std.Io.File.stdout().writeStreamingAll(io_mod.getIo(), "\n") catch |err| {
+            first_error = err;
+        };
+        self.terminal.captureOriginalTermios() catch |err| {
+            if (first_error == null) first_error = err;
+        };
+        self.terminal.enableRawMode() catch |err| {
+            if (first_error == null) first_error = err;
+        };
         self.shell.layout = self.terminal.queryLayout(footer_rows) catch self.shell.layout;
-        try self.shell.requestTerminalReset(&self.metrics);
+        self.shell.requestTerminalReset(&self.metrics) catch |err| {
+            if (first_error == null) first_error = err;
+        };
         self.shell.render_requests.request(.first_frame);
-
-        switch (term) {
-            .exited => |code| if (code != 0) return error.ExternalInteractiveFailed,
-            else => return error.ExternalInteractiveFailed,
-        }
+        if (first_error) |err| return err;
     }
 
     pub fn flushBeforeBlockingExternalWork(self: *App) !void {
@@ -3780,6 +3815,7 @@ test {
     _ = @import("core/app/app_callbacks.zig");
     _ = @import("core/app/app_commands.zig");
     _ = @import("core/app/app_entry_runtime.zig");
+    _ = @import("core/app/app_external_editor_runtime.zig");
     _ = @import("core/app/app_input_runtime.zig");
     _ = @import("core/app/app_lifecycle.zig");
     _ = @import("core/app/model_cache_runtime.zig");
@@ -3841,6 +3877,7 @@ test {
     _ = @import("core/github/github_publish.zig");
     _ = @import("core/github/github_workflows.zig");
     _ = @import("core/hosts/host.zig");
+    _ = @import("core/hosts/native_external_editor.zig");
     _ = @import("core/hooks/common.zig");
     _ = @import("core/hooks/definitions.zig");
     _ = @import("core/hooks/prompt.zig");

--- a/src/ui/input/shortcuts.zig
+++ b/src/ui/input/shortcuts.zig
@@ -111,6 +111,7 @@ test "composer shortcut table excludes app and terminal controls" {
         3,
         15,
         18,
+        20,
         22,
         24,
         '\r',
@@ -132,6 +133,7 @@ test "composer shortcut table excludes app and terminal controls" {
         .{ .remapped_byte = 3 },
         .{ .remapped_byte = 15 },
         .{ .remapped_byte = 18 },
+        .{ .remapped_byte = 20 },
         .{ .remapped_byte = 24 },
     };
     for (excluded_actions) |action| {

--- a/src/ui/input/terminal_action_decoder.zig
+++ b/src/ui/input/terminal_action_decoder.zig
@@ -239,7 +239,7 @@ fn appendAction(
 fn shouldReplayControlAfterBareEscape(byte: u8) bool {
     if (shortcuts.fromControlByte(byte) != null) return true;
     return switch (byte) {
-        3, 7, 12, 15, 22, 24 => true,
+        3, 7, 12, 15, 20, 22, 24 => true,
         else => false,
     };
 }
@@ -261,23 +261,26 @@ test "plain byte carries composer fallback without consuming product routing" {
 }
 
 test "bare Escape control replay preserves event order" {
-    var decoder = Decoder{};
-    _ = decoder.feed(0x1b, .{
-        .now_ms = 1,
-        .paste_active = false,
-        .cancel_pending = true,
-        .child_route_active = false,
-    });
-    const ingress = decoder.feed(3, .{
-        .now_ms = 2,
-        .paste_active = false,
-        .cancel_pending = true,
-        .child_route_active = false,
-    });
+    const app_controls = [_]u8{ 3, 7, 20, 24 };
+    for (app_controls) |byte| {
+        var decoder = Decoder{};
+        _ = decoder.feed(0x1b, .{
+            .now_ms = 1,
+            .paste_active = false,
+            .cancel_pending = true,
+            .child_route_active = false,
+        });
+        const ingress = decoder.feed(byte, .{
+            .now_ms = 2,
+            .paste_active = false,
+            .cancel_pending = true,
+            .child_route_active = false,
+        });
 
-    try std.testing.expectEqual(input_action.Action.escape, ingress.event.?.action.action);
-    try std.testing.expect(ingress.event.?.action.cancel_pending);
-    try std.testing.expectEqual(@as(?u8, 3), ingress.replay_byte_after_routing);
+        try std.testing.expectEqual(input_action.Action.escape, ingress.event.?.action.action);
+        try std.testing.expect(ingress.event.?.action.cancel_pending);
+        try std.testing.expectEqual(@as(?u8, byte), ingress.replay_byte_after_routing);
+    }
 }
 
 test "escape timeout emits one semantic action" {

--- a/tests/e2e/ci-shard-weights.json
+++ b/tests/e2e/ci-shard-weights.json
@@ -24,7 +24,7 @@
   { "file": "tui-agent.test.ts", "weight": 1 },
   { "file": "tui-auth-source-selection.test.ts", "weight": 49 },
   { "file": "tui-command-permissions.test.ts", "weight": 153 },
-  { "file": "tui-composer-edit-contracts.test.ts", "weight": 168 },
+  { "file": "tui-composer-edit-contracts.test.ts", "weight": 192 },
   { "file": "tui-cost.test.ts", "weight": 16 },
   { "file": "tui-decision-prompts.test.ts", "weight": 174 },
   { "file": "tui-direct-write-audit.test.ts", "weight": 2 },

--- a/tests/e2e/render-lab/audit-direct-writes.ts
+++ b/tests/e2e/render-lab/audit-direct-writes.ts
@@ -80,7 +80,7 @@ const allowlist: AllowRule[] = [
   rule("tests/json-schema/corpus_runner.zig", "printLine", /stdio_acquisition/, "noninteractive_output", "JSON Schema corpus report output"),
   rule("src/main.zig", "(?:writeStdoutFast|writeStderrFast)", /(?:stdio_acquisition_write|fixed_fd_write|raw_fd_write)/, "noninteractive_output", "top-level help and CLI validation output"),
   rule("src/main.zig", "(?:stdoutIsTerminal|stdoutTerminalColumns)", /fixed_descriptor/, "terminal_probe", "top-level help terminal capability probe"),
-  rule("src/main.zig", "runExternalInteractive", /stdio_acquisition_write/, "initialization_teardown", "external CLI handoff spacing"),
+  rule("src/main.zig", "(?:runExternalInteractive|restoreAfterExternalInteractive)", /stdio_acquisition_write/, "initialization_teardown", "external CLI handoff spacing"),
   rule("benchmarks/activity_progress.zig", "main", /stdio_acquisition/, "benchmark_output", "benchmark report output"),
   rule("src/core/shell_command/command_effect.zig", "(?:expectDirect|expectNativePrintfEquivalent)", /debug_print/, "tests", "test diagnostics"),
   rule("src/core/app/app_worker_runtime.zig", "(?:printModelTrace|printLifecycleDrainTrace)", /debug_print/, "tests", "test diagnostics"),

--- a/tests/e2e/render-lab/audit-direct-writes.ts
+++ b/tests/e2e/render-lab/audit-direct-writes.ts
@@ -80,7 +80,6 @@ const allowlist: AllowRule[] = [
   rule("tests/json-schema/corpus_runner.zig", "printLine", /stdio_acquisition/, "noninteractive_output", "JSON Schema corpus report output"),
   rule("src/main.zig", "(?:writeStdoutFast|writeStderrFast)", /(?:stdio_acquisition_write|fixed_fd_write|raw_fd_write)/, "noninteractive_output", "top-level help and CLI validation output"),
   rule("src/main.zig", "(?:stdoutIsTerminal|stdoutTerminalColumns)", /fixed_descriptor/, "terminal_probe", "top-level help terminal capability probe"),
-  rule("src/main.zig", "(?:runExternalInteractive|restoreAfterExternalInteractive)", /stdio_acquisition_write/, "initialization_teardown", "external CLI handoff spacing"),
   rule("benchmarks/activity_progress.zig", "main", /stdio_acquisition/, "benchmark_output", "benchmark report output"),
   rule("src/core/shell_command/command_effect.zig", "(?:expectDirect|expectNativePrintfEquivalent)", /debug_print/, "tests", "test diagnostics"),
   rule("src/core/app/app_worker_runtime.zig", "(?:printModelTrace|printLifecycleDrainTrace)", /debug_print/, "tests", "test diagnostics"),

--- a/tests/e2e/tui-composer-edit-contracts.test.ts
+++ b/tests/e2e/tui-composer-edit-contracts.test.ts
@@ -16,7 +16,10 @@ import { FX_BIN } from "../evals/eval-helpers";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  fakeGatewayToolCall,
+  heldFakeGatewayFinalText,
   startFakeGateway,
+  type FakeGatewayResponse,
   TmuxSession,
   tmuxAvailable,
 } from "./tmux-helpers";
@@ -32,6 +35,28 @@ const MANAGED_REVIEW_BODY = "GROUP_C_MANAGED_REVIEW_BODY";
 const WORKSPACE_REVIEW_BODY = "GROUP_C_WORKSPACE_REVIEW_BODY";
 const EXTERNAL_EDITOR_SCRIPT = `#!/bin/sh
 set -eu
+next_path="$1.next"
+printf 'externally edited: ' > "$next_path"
+cat "$1" >> "$next_path"
+mv "$next_path" "$1"
+`;
+const BLOCKING_EXTERNAL_EDITOR_SCRIPT = `#!/bin/sh
+set -eu
+opened_path="$0.open"
+release_path="$0.release"
+stty -a > "$0.stty"
+: > "$opened_path"
+while [ ! -f "$release_path" ]; do
+  sleep 0.05
+done
+next_path="$1.next"
+printf 'externally edited: ' > "$next_path"
+cat "$1" >> "$next_path"
+mv "$next_path" "$1"
+`;
+const RESETTING_EXTERNAL_EDITOR_SCRIPT = `#!/bin/sh
+set -eu
+printf '\x1b[?2004l\x1b[<u\x1b[?7h' > /dev/tty
 next_path="$1.next"
 printf 'externally edited: ' > "$next_path"
 cat "$1" >> "$next_path"
@@ -57,11 +82,23 @@ afterEach(async () => {
 
 async function startFx(
   withGateway: boolean,
-  responseCount = 1,
-  duplicateReview = false,
-  traceScopes?: string,
-  editorScript?: string,
+  options: {
+    responseCount?: number;
+    duplicateReview?: boolean;
+    traceScopes?: string;
+    editorScript?: string;
+    gatewayResponses?: FakeGatewayResponse[];
+    settings?: Record<string, unknown>;
+  } = {},
 ): Promise<TmuxSession> {
+  const {
+    responseCount = 1,
+    duplicateReview = false,
+    traceScopes,
+    editorScript,
+    gatewayResponses,
+    settings = {},
+  } = options;
   root = realpathSync(mkdtempSync(join(tmpdir(), "fx-edit-contracts-")));
   const home = join(root, "home");
   const workspace = join(root, "workspace");
@@ -69,7 +106,7 @@ async function startFx(
   mkdirSync(workspace);
   writeFileSync(
     join(home, ".fx", "settings.json"),
-    JSON.stringify({}),
+    JSON.stringify({ ...settings }),
   );
   stderrPath = join(root, "stderr.log");
   writeFileSync(stderrPath, "");
@@ -103,10 +140,11 @@ async function startFx(
 
   if (withGateway) {
     gateway = startFakeGateway(
-      Array.from(
-        { length: responseCount },
-        () => fakeGatewayFinalText("edit contract complete"),
-      ),
+      gatewayResponses ??
+        Array.from(
+          { length: responseCount },
+          () => fakeGatewayFinalText("edit contract complete"),
+        ),
       {
         models: [{
           id: FAKE_GATEWAY_MODEL,
@@ -175,6 +213,15 @@ async function waitForGatewayRequestWithin(
     await Bun.sleep(25);
   }
   throw new Error("Timed out waiting for fake Gateway request");
+}
+
+async function waitForPath(path: string): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < TIMEOUT) {
+    if (existsSync(path)) return;
+    await Bun.sleep(25);
+  }
+  throw new Error(`Timed out waiting for path: ${path}`);
 }
 
 async function waitForModelRequest(count = 1): Promise<void> {
@@ -273,13 +320,7 @@ async function selectReviewSkill(
 tmuxTest(
   "Ctrl+T round trips a plain-text draft through EDITOR",
   async () => {
-    const active = await startFx(
-      true,
-      1,
-      false,
-      undefined,
-      EXTERNAL_EDITOR_SCRIPT,
-    );
+    const active = await startFx(true, { editorScript: EXTERNAL_EDITOR_SCRIPT });
     const seed = "original editor draft";
     const edited = `externally edited: ${seed}`;
 
@@ -296,9 +337,192 @@ tmuxTest(
 );
 
 tmuxTest(
+  "Ctrl+T keeps the active turn running while the editor owns the terminal",
+  async () => {
+    const held = heldFakeGatewayFinalText();
+    const backgroundDone = "BACKGROUND_TURN_COMPLETED_DURING_EDITOR";
+    try {
+      const active = await startFx(true, {
+        traceScopes: "worker",
+        editorScript: BLOCKING_EXTERNAL_EDITOR_SCRIPT,
+        gatewayResponses: [held.response],
+      });
+
+      await active.sendLiteralText("hold the active response");
+      await active.sendKeys("Enter");
+      await waitForGatewayRequest();
+      await active.waitForText("Thinking", TIMEOUT);
+
+      const seed = "draft composed during the active turn";
+      const edited = `externally edited: ${seed}`;
+      await active.sendLiteralText(seed);
+      await active.sendHexBytes(["14"]);
+
+      const editorPath = join(root!, "editor.sh");
+      await waitForPath(`${editorPath}.open`);
+      expect(readFileSync(`${editorPath}.stty`, "utf8"))
+        .toMatch(/(?:^|[ ;])icanon(?:[ ;]|$)/m);
+      held.release(backgroundDone);
+      await waitForTraceOrExit(active, "finish processing queued=0");
+
+      expect(active.isAlive()).toBe(true);
+      expect(existsSync(`${editorPath}.release`)).toBe(false);
+      expect(await active.capturePane()).not.toContain(backgroundDone);
+
+      writeFileSync(`${editorPath}.release`, "release\n");
+      await active.waitForText(edited, TIMEOUT);
+      await active.waitForText(backgroundDone, TIMEOUT);
+      expectCleanRuntime(active);
+    } finally {
+      held.dispose();
+    }
+  },
+  TIMEOUT,
+);
+
+tmuxTest(
+  "an approval wait survives external editing during the active turn",
+  async () => {
+    let releaseToolResponse: (response: Response) => void = undefined!;
+    const toolResponse = new Promise<Response>((resolve) => {
+      releaseToolResponse = resolve;
+    });
+    const active = await startFx(true, {
+      traceScopes: "permission,worker",
+      editorScript: BLOCKING_EXTERNAL_EDITOR_SCRIPT,
+      gatewayResponses: [
+        () => toolResponse,
+        fakeGatewayFinalText("APPROVAL_AFTER_EDITOR_COMPLETE"),
+      ],
+      settings: { permission_mode: "ask", sandbox: "none" },
+    });
+
+    await active.sendLiteralText("prepare a file change");
+    await active.sendKeys("Enter");
+    await waitForGatewayRequest();
+    await active.waitForText("Thinking", TIMEOUT);
+
+    const seed = "draft preserved through approval";
+    const edited = `externally edited: ${seed}`;
+    await active.sendLiteralText(seed);
+    await active.sendHexBytes(["14"]);
+
+    const editorPath = join(root!, "editor.sh");
+    await waitForPath(`${editorPath}.open`);
+    releaseToolResponse(fakeGatewayToolCall(
+      "approval_during_editor",
+      "write_file",
+      { path: "approval.txt", content: "approved\n" },
+    ));
+    await waitForTraceOrExit(active, "event=permission_requested");
+
+    expect(active.isAlive()).toBe(true);
+    expect(await active.capturePane()).not.toContain("Apply this change?");
+
+    writeFileSync(`${editorPath}.release`, "release\n");
+    await active.waitForText("Apply this change?", TIMEOUT);
+    await active.sendKeys("Enter");
+    await active.waitForText("APPROVAL_AFTER_EDITOR_COMPLETE", TIMEOUT);
+    await active.waitForText(edited, TIMEOUT);
+
+    expect(readFileSync(join(root!, "workspace", "approval.txt"), "utf8"))
+      .toBe("approved\n");
+    expectCleanRuntime(active);
+  },
+  TIMEOUT,
+);
+
+tmuxTest(
+  "external editor terminal resets are repaired before the next paste",
+  async () => {
+    const active = await startFx(true, {
+      editorScript: RESETTING_EXTERNAL_EDITOR_SCRIPT,
+    });
+    const seed = "terminal mode seed";
+    const edited = `externally edited: ${seed}`;
+    const pasted = "PASTE_AFTER_EDITOR_A\nPASTE_AFTER_EDITOR_B";
+
+    await active.sendLiteralText(seed);
+    await active.sendHexBytes(["14"]);
+    await active.waitForText(edited, TIMEOUT);
+    await active.pasteText(pasted);
+    await active.waitForText("PASTE_AFTER_EDITOR_B", TIMEOUT);
+
+    expect(gateway!.requestCount()).toBe(0);
+    await active.sendKeys("Enter");
+    await waitForGatewayRequest();
+    expect(finalUserText()).toBe(edited + pasted);
+    expectCleanRuntime(active);
+  },
+  TIMEOUT,
+);
+
+tmuxTest(
+  "Ctrl+T streaming guards never launch an editor for owned draft or screen state",
+  async () => {
+    let releaseToolResponse: (response: Response) => void = undefined!;
+    const toolResponse = new Promise<Response>((resolve) => {
+      releaseToolResponse = resolve;
+    });
+    const held = heldFakeGatewayFinalText();
+    try {
+      const active = await startFx(true, {
+        traceScopes: "permission",
+        editorScript: BLOCKING_EXTERNAL_EDITOR_SCRIPT,
+        gatewayResponses: [() => toolResponse, held.response],
+        settings: { permission_mode: "ask", sandbox: "none" },
+      });
+      const editorPath = join(root!, "editor.sh");
+      const editorOpenPath = `${editorPath}.open`;
+
+      await active.sendLiteralText("exercise streaming editor guards");
+      await active.sendKeys("Enter");
+      await waitForGatewayRequest();
+      await active.waitForText("Thinking", TIMEOUT);
+
+      await pasteExact(active, "P".repeat(1001));
+      await active.waitForText("[Pasted text #1, 1 line]", TIMEOUT);
+      await active.sendHexBytes(["14"]);
+      await active.waitForText(
+        "external editing is unavailable while the draft contains pasted blocks, images, or skills",
+        TIMEOUT,
+      );
+      expect(existsSync(editorOpenPath)).toBe(false);
+
+      await active.sendHexBytes(["15"]);
+      releaseToolResponse(fakeGatewayToolCall(
+        "guard_approval",
+        "write_file",
+        { path: "guarded.txt", content: "guarded\n" },
+      ));
+      await active.waitForText("Apply this change?", TIMEOUT);
+      await active.sendHexBytes(["14"]);
+      expect(existsSync(editorOpenPath)).toBe(false);
+
+      await active.sendKeys("Enter");
+      await waitForGatewayRequest(2);
+      await active.waitForText("Thinking", TIMEOUT);
+      await active.sendKeys("C-o");
+      await active.waitForText("ctrl o close", TIMEOUT);
+      await active.sendHexBytes(["14"]);
+      expect(existsSync(editorOpenPath)).toBe(false);
+
+      await active.sendKeys("C-o");
+      held.release("STREAMING_GUARDS_COMPLETE");
+      await active.waitForText("STREAMING_GUARDS_COMPLETE", TIMEOUT);
+      expect(existsSync(editorOpenPath)).toBe(false);
+      expectCleanRuntime(active);
+    } finally {
+      held.dispose();
+    }
+  },
+  TIMEOUT,
+);
+
+tmuxTest(
   "composer shortcuts pressed immediately after Escape preserve input order",
   async () => {
-    const active = await startFx(true, 2);
+    const active = await startFx(true, { responseCount: 2 });
 
     await active.sendLiteralText("abc");
     await active.sendHexBytes(["1b", "01", "58"]);
@@ -335,7 +559,9 @@ tmuxTest(
 tmuxTest(
   "embedded paste terminator cannot execute its same-epoch suffix",
   async () => {
-    const active = await startFx(true, 1, false, "input,theme,resize,native_clear");
+    const active = await startFx(true, {
+      traceScopes: "input,theme,resize,native_clear",
+    });
     await active.sendLiteralText("PRESERVED_DRAFT");
 
     await active.sendHexBytes([
@@ -362,7 +588,9 @@ tmuxTest(
 tmuxTest(
   "active paste keeps a trailing escape sequence out of response parsers",
   async () => {
-    const active = await startFx(true, 1, false, "input,theme,resize,native_clear");
+    const active = await startFx(true, {
+      traceScopes: "input,theme,resize,native_clear",
+    });
     await active.sendLiteralText("ESCAPE_DRAFT");
 
     await active.sendHexBytes([
@@ -482,7 +710,7 @@ tmuxTest(
 tmuxTest(
   "multi-megabyte bracketed paste survives edits and resize byte-for-byte",
   async () => {
-    const active = await startFx(true, 1, false, "input");
+    const active = await startFx(true, { traceScopes: "input" });
     const prompt = `PASTE-BEGIN-${"x".repeat(4 * 1024 * 1024 + 1)}-PASTE-END`;
 
     await waitForModelRequest();
@@ -510,7 +738,7 @@ tmuxTest(
 tmuxTest(
   "expanded paste accepts the exact composer byte limit",
   async () => {
-    const active = await startFx(true, 1, false, "input");
+    const active = await startFx(true, { traceScopes: "input" });
     const rune = "🧪";
     const runeBytes = Buffer.byteLength(rune);
     const firstPasteBytes = COMPOSER_BYTE_LIMIT / 2 - runeBytes;
@@ -595,7 +823,7 @@ tmuxTest(
 tmuxTest(
   "Home End and control aliases stay on the current logical line",
   async () => {
-    const active = await startFx(true, 2);
+    const active = await startFx(true, { responseCount: 2 });
 
     await pasteExact(active, "FIRST\nSECOND\nTHIRD");
     await active.sendKeys("Up Home");
@@ -722,7 +950,7 @@ tmuxTest(
 tmuxTest(
   "Ctrl+U and Ctrl+Y preserve the selected duplicate skill source",
   async () => {
-    const active = await startFx(true, 1, true);
+    const active = await startFx(true, { duplicateReview: true });
 
     await selectReviewSkill(active, true);
     await active.sendLiteralText("inspect");
@@ -742,7 +970,7 @@ tmuxTest(
 tmuxTest(
   "history recall keeps an oversized paste compact and editable",
   async () => {
-    const active = await startFx(true, 2);
+    const active = await startFx(true, { responseCount: 2 });
     const pasted = "H".repeat(4138);
 
     await pasteExact(active, pasted);
@@ -773,7 +1001,7 @@ tmuxTest(
 tmuxTest(
   "history recall resubmits a real image under a fresh id",
   async () => {
-    const active = await startFx(true, 2);
+    const active = await startFx(true, { responseCount: 2 });
 
     await pasteExact(active, fixtureImagePath!);
     await active.waitForText("[Image 1]", TIMEOUT);
@@ -823,7 +1051,7 @@ for (
   tmuxTest(
     `history recall preserves the composer when an image snapshot is ${scenario.name}`,
     async () => {
-      const active = await startFx(true, 1, false, "prompt_history");
+      const active = await startFx(true, { traceScopes: "prompt_history" });
 
       await pasteExact(active, fixtureImagePath!);
       await active.waitForText("[Image 1]", TIMEOUT);
@@ -858,7 +1086,10 @@ for (
 tmuxTest(
   "history recall preserves the selected duplicate skill source",
   async () => {
-    const active = await startFx(true, 2, true);
+    const active = await startFx(true, {
+      responseCount: 2,
+      duplicateReview: true,
+    });
 
     await selectReviewSkill(active, true);
     await active.waitForText("review · workspace skills/", TIMEOUT);
@@ -981,7 +1212,7 @@ tmuxTest(
 tmuxTest(
   "skill entities survive file completion and stay atomic under word edits",
   async () => {
-    const active = await startFx(true, 4);
+    const active = await startFx(true, { responseCount: 4 });
 
     await selectReviewSkill(active);
     expect(await active.capturePane()).not.toContain("review ·");

--- a/tests/e2e/tui-composer-edit-contracts.test.ts
+++ b/tests/e2e/tui-composer-edit-contracts.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -29,6 +30,13 @@ const PASTE_START = ["1b", "5b", "32", "30", "30", "7e"] as const;
 const PASTE_END = ["1b", "5b", "32", "30", "31", "7e"] as const;
 const MANAGED_REVIEW_BODY = "GROUP_C_MANAGED_REVIEW_BODY";
 const WORKSPACE_REVIEW_BODY = "GROUP_C_WORKSPACE_REVIEW_BODY";
+const EXTERNAL_EDITOR_SCRIPT = `#!/bin/sh
+set -eu
+next_path="$1.next"
+printf 'externally edited: ' > "$next_path"
+cat "$1" >> "$next_path"
+mv "$next_path" "$1"
+`;
 
 let session: TmuxSession | null = null;
 let root: string | null = null;
@@ -52,6 +60,7 @@ async function startFx(
   responseCount = 1,
   duplicateReview = false,
   traceScopes?: string,
+  editorScript?: string,
 ): Promise<TmuxSession> {
   root = realpathSync(mkdtempSync(join(tmpdir(), "fx-edit-contracts-")));
   const home = join(root, "home");
@@ -66,6 +75,11 @@ async function startFx(
   writeFileSync(stderrPath, "");
   const tracePath = traceScopes ? join(root, "trace.log") : undefined;
   if (tracePath) writeFileSync(tracePath, "");
+  const editorPath = editorScript ? join(root, "editor.sh") : undefined;
+  if (editorPath) {
+    writeFileSync(editorPath, editorScript);
+    chmodSync(editorPath, 0o700);
+  }
   fixtureImagePath = join(workspace, "i.png");
   writeFileSync(
     fixtureImagePath,
@@ -121,6 +135,7 @@ async function startFx(
       FX_AUTO_UPGRADE: "0",
       FX_TRACE_LOG: tracePath,
       FX_TRACE_SCOPES: traceScopes,
+      ...(editorPath ? { VISUAL: undefined, EDITOR: editorPath } : {}),
     },
     width: 112,
     height: 32,
@@ -254,6 +269,31 @@ async function selectReviewSkill(
   if (selectWorkspace) await active.sendKeys("Down");
   await active.sendKeys("Enter");
 }
+
+tmuxTest(
+  "Ctrl+T round trips a plain-text draft through EDITOR",
+  async () => {
+    const active = await startFx(
+      true,
+      1,
+      false,
+      undefined,
+      EXTERNAL_EDITOR_SCRIPT,
+    );
+    const seed = "original editor draft";
+    const edited = `externally edited: ${seed}`;
+
+    await active.sendLiteralText(seed);
+    await active.sendHexBytes(["14"]);
+    await active.waitForText(edited, TIMEOUT);
+    await active.sendKeys("Enter");
+    await waitForGatewayRequest();
+
+    expect(finalUserText()).toBe(edited);
+    expectCleanRuntime(active);
+  },
+  TIMEOUT,
+);
 
 tmuxTest(
   "composer shortcuts pressed immediately after Escape preserve input order",


### PR DESCRIPTION
## Summary

- Add `Ctrl+T` to edit the current plain-text composer draft with `VISUAL`, falling back to `EDITOR`, including while a response continues in the background.
- Spawn the editor without a shell, limit and validate returned UTF-8 text, and retain a recovery file whenever a saved result cannot be used.
- Yield a clean cooked terminal to the child, protect in-flight worker syscalls from terminal interrupts, and restore raw mode, keyboard and paste modes, layout, and a full repaint on every return path.

## Scope and shortcut direction

`Ctrl+T` is provisional to avoid colliding with the existing `Ctrl+G` update/reload shortcut. `Ctrl+G` is a better fit for consistency with popular coding agents; a focused follow-up should move external editing to `Ctrl+G` and remove or relocate the current update binding.

This first version declines to open the editor while the draft contains pasted-block placeholders, image attachments, or skill tokens. That keeps structured entities intact without adding an offset-mapping subsystem. A successful external replacement resets composer undo history.

## Related work

PR #148 mentioned external-editor takeover as possible future work.

## Verification

- `zig fmt --check src/`
- `zig build`
- `zig build -Dwasm-surface=core -Doptimize=ReleaseSmall`
- `zig build -Dwasm-surface=term -Doptimize=ReleaseSmall`
- `zig build -Dnapi-surface=core -Doptimize=ReleaseSafe`
- clean-`ZDOTDIR` `zig build test --summary all`: 8,476 passed and 2 skipped, plus 1 benchmark test passed
- `tests/e2e/tui-composer-edit-contracts.test.ts`: 35 passed, including background worker progress while the editor is blocked, permission parking, terminal-mode restoration, and streaming guards
- direct-write audit and E2E shard-planner tests: 11 passed
- PGSO corpus validation passed; the new cases remain verification-only in the already classified composer contract file because editor handoff and recovery are important but uncommon behavior
- exercised the freshly built `./zig-out/bin/fx` in a real PTY while a held response completed behind a blocked editor; the answer and edited draft appeared after restore, fx stayed alive, and stderr remained empty

Required label: `type: feature`

Marked ready because Full CI passed for `0de69da` on our fork: https://github.com/possibilities/fx/actions/runs/32575054416
