### PR TITLE
Fix the post-write review reminder lifecycle and add a lifecycle-boundary eval

### DIFF
--- a/src/core/agent/runtime/config.zig
+++ b/src/core/agent/runtime/config.zig
@@ -44,7 +44,10 @@ pub const Config = struct {
     max_tool_result_bytes: usize = tool_result_limits.default_max_tool_result_bytes,
     step_limit_notice: []const u8 = default_step_limit_notice,
     cancel_flag: *std.atomic.Value(bool),
-    review_enabled: bool = false,
+    /// Inject one bounded verification reminder after an observed file mutation.
+    /// Off by default: a 32-coordinate paired comparison showed no
+    /// statistically supported quality lift and measurable token overhead.
+    final_verification_enabled: bool = false,
     fast_mode: bool = false,
     effort: ReasoningEffort = .auto,
     first_call_tool_choice: types.ToolChoice = .auto,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2725,6 +2725,7 @@ fn processQueuedPromptLoop(
     defer interrupted_persisted_ptr.* = interrupted_persisted;
     var silent_tool_steps: usize = 0;
     var continuation_injected = false;
+    var final_verification_state: runtime_tool_batch.FinalVerificationState = .{};
     var last_step_ctx = finish_trace.ctx;
     var current_step_index: usize = 0;
     var last_tool_call_name: []const u8 = "none";
@@ -2822,7 +2823,13 @@ fn processQueuedPromptLoop(
             overlay_arena,
             &ephemeral_overlay,
         );
-        var gateway_messages = try runtime_prompt_context.buildGatewayMessages(overlay_arena, stable_prefix.items, ephemeral_overlay.items, history_messages.items, current_user_effective, within_turn_suffix.items);
+        const request_suffix = try runtime_tool_batch.finalVerificationRequestSuffix(
+            overlay_arena,
+            &final_verification_state,
+            step_ctx,
+            within_turn_suffix.items,
+        );
+        var gateway_messages = try runtime_prompt_context.buildGatewayMessages(overlay_arena, stable_prefix.items, ephemeral_overlay.items, history_messages.items, current_user_effective, request_suffix);
         last_gateway_message_count = gateway_messages.items.len;
         const history_start_index = stable_prefix.items.len + ephemeral_overlay.items.len;
         const current_user_message_index = history_start_index + history_messages.items.len;
@@ -2986,13 +2993,21 @@ fn processQueuedPromptLoop(
                     step_ctx,
                 );
             }
+            // Recompute from the live suffix: recovery paths append preserved
+            // tool evidence between builds, and the initial capture goes stale.
+            const retry_request_suffix = try runtime_tool_batch.finalVerificationRequestSuffix(
+                overlay_arena,
+                &final_verification_state,
+                step_ctx,
+                within_turn_suffix.items,
+            );
             gateway_messages = try runtime_prompt_context.buildGatewayMessages(
                 overlay_arena,
                 stable_prefix.items,
                 ephemeral_overlay.items,
                 history_messages.items,
                 current_user_effective,
-                within_turn_suffix.items,
+                retry_request_suffix,
             );
             debug_trace.eventf("agent", "before_provider_preflight", step_ctx, "model={s} messages={d}", .{ gateway_model, gateway_messages.items.len });
             var vision_route: runtime_vision_contracts.VisionRoute = .native_images;
@@ -4086,6 +4101,10 @@ fn processQueuedPromptLoop(
             if (vision_mode != .required) configured_first_tool_choice_pending = false;
             break;
         }
+        runtime_tool_batch.consumeFinalVerification(
+            &final_verification_state,
+            step_ctx,
+        );
         defer if (stream_result_set) stream_result.deinit(arena);
 
         var completion = streamCompletion(stream_result);
@@ -6985,10 +7004,10 @@ fn processQueuedPromptLoop(
             );
             pending_image_ids = transition.pending_ids;
         }
-        try runtime_tool_batch.appendReviewContinuationSuffix(
-            config.review_enabled,
-            arena,
-            &within_turn_suffix,
+        runtime_tool_batch.scheduleFinalVerification(
+            config.final_verification_enabled,
+            &final_verification_state,
+            step_ctx,
             &step_batch,
         );
         if (malformed_arguments_retry.finishBatch()) {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -5963,6 +5963,45 @@ test "processQueuedPrompt injects final verification only into the completion af
     try expectBodyNotContains(&gateway, 2, "Before finalizing, verify");
 }
 
+test "processQueuedPrompt retains final verification across physical recovery" {
+    const alloc = std.testing.allocator;
+    const mutation_calls = [_]ToolCall{toolCall("call_write", "write_file", "{\"path\":\"a\",\"content\":\"x\"}")};
+    const interrupted_starts = [_]ToolCall{toolCall("call_read_interrupted", "read_file", "{}")};
+    const recovered_calls = [_]ToolCall{toolCall("call_read_recovered", "read_file", "{\"path\":\"a\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &mutation_calls },
+        .{
+            .streamed_tool_starts = &interrupted_starts,
+            .stream_error_after_tool_starts = error.ReadFailed,
+        },
+        .{
+            .streamed_tool_starts = &recovered_calls,
+            .tool_calls = &recovered_calls,
+        },
+        .{ .content = "Finished" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.final_verification_enabled = true;
+    config.gateway_retry_count = 3;
+    config.max_provider_attempts = 3;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 4), gateway.request_bodies.items.len);
+    try expectBodyNotContains(&gateway, 0, "Before finalizing, verify");
+    try expectBodyContains(&gateway, 1, "Before finalizing, verify");
+    try expectBodyContains(&gateway, 2, "Before finalizing, verify");
+    try expectBodyContains(&gateway, 2, "did not execute the incomplete tool call");
+    try expectBodyNotContains(&gateway, 3, "Before finalizing, verify");
+    try expectBodyContains(&gateway, 3, "call_read_recovered");
+    try expectBodyContains(&gateway, 3, "\"output\":{\"type\":\"text\",\"value\":\"ok\"}");
+}
+
 test "processQueuedPrompt excludes successful non-file executors from final verification" {
     const alloc = std.testing.allocator;
     const cases = [_]struct {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -5936,12 +5936,14 @@ test "processQueuedPrompt no-tool length preserves completed presentation with l
     );
 }
 
-test "processQueuedPrompt review continuation appends active review prompt after write tool" {
+test "processQueuedPrompt injects final verification only into the completion after mutation" {
     const alloc = std.testing.allocator;
-    const calls = [_]ToolCall{toolCall("call_1", "write_file", "{\"path\":\"a\",\"content\":\"x\"}")};
+    const mutation_calls = [_]ToolCall{toolCall("call_1", "write_file", "{\"path\":\"a\",\"content\":\"x\"}")};
+    const continuation_calls = [_]ToolCall{toolCall("call_2", "read_file", "{\"path\":\"a\"}")};
     const completions = [_]FakeCompletion{
-        .{ .tool_calls = &calls },
-        .{ .content = "Reviewed" },
+        .{ .tool_calls = &mutation_calls },
+        .{ .tool_calls = &continuation_calls },
+        .{ .content = "Verified" },
     };
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
@@ -5949,11 +5951,186 @@ test "processQueuedPrompt review continuation appends active review prompt after
     defer hooks.deinit();
     var fixture = PromptFixture{};
     var config = fixture.config();
-    config.review_enabled = true;
+    config.final_verification_enabled = true;
 
     try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
-    try expectBodyContains(&gateway, 1, "Review the changes you just made. Re-read any modified files and briefly note any issues (syntax errors, missing imports, logic bugs). If everything looks correct, say so.");
+    try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
+    try expectBodyNotContains(&gateway, 0, "Before finalizing, verify");
+    try expectBodyContains(&gateway, 1, "Before finalizing, verify the completed change against the user's request.");
+    try expectBodyContains(&gateway, 1, "exercise at least one combined transition");
+    try expectBodyContains(&gateway, 1, "effects completed rather than merely began");
+    try expectBodyNotContains(&gateway, 2, "Before finalizing, verify");
+}
+
+test "processQueuedPrompt excludes successful non-file executors from final verification" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        tool_name: []const u8,
+        arguments_json: []const u8,
+    }{
+        .{ .tool_name = "memory", .arguments_json = "{}" },
+        .{ .tool_name = "install_skill", .arguments_json = "{}" },
+        .{ .tool_name = "terminal", .arguments_json = "{\"action\":\"exec\",\"command\":\"pwd\"}" },
+    };
+    for (cases) |case| {
+        const calls = [_]ToolCall{toolCall("call_non_file_write", case.tool_name, case.arguments_json)};
+        const completions = [_]FakeCompletion{
+            .{ .tool_calls = &calls },
+            .{ .content = "Completed" },
+        };
+        var gateway = FakeGateway.init(alloc, &completions);
+        defer gateway.deinit();
+        var hooks = FakeAgentRuntimeDeps.init(alloc);
+        defer hooks.deinit();
+        var fixture = PromptFixture{};
+        var config = fixture.config();
+        config.final_verification_enabled = true;
+
+        var job = fixture.job();
+        if (std.mem.eql(u8, case.tool_name, "terminal")) {
+            hooks.permission_decisions = &.{.once};
+            job.permission_mode = .auto;
+        }
+        try runFakePrompt(&gateway, &hooks, config, job);
+
+        try expectBodyNotContains(&gateway, 1, "Before finalizing, verify");
+    }
+}
+
+test "processQueuedPrompt injects once for mixed batches with a filesystem mutation" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{
+        toolCall("call_memory", "memory", "{}"),
+        toolCall("call_create", "create_folder", "{}"),
+        toolCall("call_read", "read_file", "{}"),
+    };
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Verified" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.final_verification_enabled = true;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        countNeedle(gateway.request_bodies.items[1], "Before finalizing, verify"),
+    );
+}
+
+test "processQueuedPrompt does not append final verification after a read-only batch" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{toolCall("call_read", "read_file", "{\"path\":\"a\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Read" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.final_verification_enabled = true;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try expectBodyNotContains(&gateway, 1, "Before finalizing, verify");
+}
+
+test "processQueuedPrompt does not retrigger final verification for repair mutations" {
+    const alloc = std.testing.allocator;
+    const first_calls = [_]ToolCall{toolCall("call_1", "write_file", "{\"path\":\"a\",\"content\":\"x\"}")};
+    const repair_calls = [_]ToolCall{toolCall("call_2", "write_file", "{\"path\":\"a\",\"content\":\"y\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &first_calls },
+        .{ .tool_calls = &repair_calls },
+        .{ .content = "Verified after repair" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.final_verification_enabled = true;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    const prompt_prefix = "Before finalizing, verify";
+    try std.testing.expectEqual(@as(usize, 1), countNeedle(gateway.request_bodies.items[1], prompt_prefix));
+    try std.testing.expectEqual(@as(usize, 0), countNeedle(gateway.request_bodies.items[2], prompt_prefix));
+}
+
+test "processQueuedPrompt excludes failed write results from final verification" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{toolCall("call_1", "write_file", "{\"path\":\"a\",\"content\":\"x\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Write failed" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.exec_plans = &.{.{ .result = .{
+        .status = .failure,
+        .model_output = "write failed",
+    } }};
+    var fixture = PromptFixture{};
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    try expectBodyNotContains(&gateway, 1, "Before finalizing, verify");
+}
+
+test "processQueuedPrompt excludes canonical tool error output from final verification" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{toolCall("call_1", "create_folder", "{}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Create failed" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    hooks.exec_plans = &.{.{ .result = .{
+        .status = .success,
+        .model_output = "Tool create_folder failed: permission denied",
+    } }};
+    var fixture = PromptFixture{};
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    try expectBodyNotContains(&gateway, 1, "Before finalizing, verify");
+}
+
+test "processQueuedPrompt honors disabled final verification after mutation" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{toolCall("call_1", "write_file", "{\"path\":\"a\",\"content\":\"x\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Written" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.final_verification_enabled = false;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try expectBodyNotContains(&gateway, 1, "Before finalizing, verify");
 }
 
 test "processQueuedPrompt trace records history shape returned tool calls and waits" {
@@ -5988,7 +6165,9 @@ test "processQueuedPrompt trace records history shape returned tool calls and wa
     var job = fixture.job();
     job.history = history[0..];
 
-    try runFakePrompt(&gateway, &hooks, fixture.config(), job);
+    var config = fixture.config();
+    config.final_verification_enabled = true;
+    try runFakePrompt(&gateway, &hooks, config, job);
     debug_trace.shutdown();
 
     const trace = try readTraceFile(alloc, trace_path, 131072);
@@ -6006,6 +6185,7 @@ test "processQueuedPrompt trace records history shape returned tool calls and wa
     try std.testing.expect(std.mem.find(u8, trace, "event=after_permission_decision") != null);
     try std.testing.expect(std.mem.find(u8, trace, "event=before_tool_execution") != null);
     try std.testing.expect(std.mem.find(u8, trace, "event=after_tool_execution") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "event=final_verification_injected") != null);
     try std.testing.expect(std.mem.find(u8, trace, "\"path\"") == null);
     try std.testing.expect(std.mem.find(u8, trace, "\"content\"") == null);
     try std.testing.expect(std.mem.find(u8, trace, "\"metadata\"") == null);

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -21,11 +21,22 @@ const ToolCall = types.ToolCall;
 const TraceContext = debug_trace.TraceContext;
 const AgentRuntimeDeps = runtime_deps.AgentRuntimeDeps;
 const ToolExecutionResult = runtime_tool_contracts.ToolExecutionResult;
+const final_verification_prompt =
+    "Before finalizing, verify the completed change against the user's request. " ++
+    "Re-read the changed contract and modified files. If correctness depends on " ++
+    "interacting states or events, exercise at least one combined transition. " ++
+    "Confirm promised effects completed rather than merely began. Fix any " ++
+    "discrepancy, then report concrete verification evidence.";
+
+pub const FinalVerificationState = struct {
+    scheduled: bool = false,
+    pending: bool = false,
+};
 
 pub const StepBatchState = struct {
     step_error_count: usize = 0,
     step_total_count: usize = 0,
-    step_had_writes: bool = false,
+    step_had_mutation: bool = false,
     pending_user_suffix: std.ArrayList(ChatMessage) = .empty,
 
     pub fn allToolResultsFailed(self: StepBatchState) bool {
@@ -37,7 +48,7 @@ pub const ToolResultAccounting = struct {
     increment_total: bool = true,
     increment_error: bool = false,
     record_completion: bool = false,
-    mark_write: bool = false,
+    mark_mutation: bool = false,
     status: ?types.PersistedToolStatus = null,
 };
 
@@ -68,7 +79,7 @@ pub fn appendToolResultContent(
 ) !void {
     if (accounting.increment_total) batch.step_total_count += 1;
     if (accounting.increment_error) batch.step_error_count += 1;
-    if (accounting.mark_write) batch.step_had_writes = true;
+    if (accounting.mark_mutation) batch.step_had_mutation = true;
     try within_turn_suffix.append(arena, .{
         .role = .tool,
         .content = model_output,
@@ -463,8 +474,42 @@ pub fn processCommittedFileResult(
         .{ tool_call.id, tool_call.name, execution.model_output.len },
     );
     batch.step_total_count += 1;
-    batch.step_had_writes = true;
+    batch.step_had_mutation = true;
     completed_tool_names.appendAssumeCapacity(committed_file_tool_name);
+}
+
+fn executorMutatesWorkspaceFiles(kind: tool_dispatch.ExecutorKind) bool {
+    return switch (kind) {
+        .write_file,
+        .edit_file,
+        .delete_file,
+        .rename_file,
+        .copy_file,
+        .create_folder,
+        => true,
+        .list_files,
+        .glob_files,
+        .grep_files,
+        .read_file,
+        .read_tool_result,
+        .file_info,
+        .memory,
+        .semantic_search,
+        .open_file,
+        .web_fetch,
+        .web_search,
+        .run_command,
+        .terminal,
+        .skill,
+        .install_skill,
+        .subagent,
+        .mcp_search_tools,
+        .mcp_select_tool,
+        .mcp_features,
+        .ask_user_question,
+        .vision,
+        => false,
+    };
 }
 
 pub fn appendOrdinaryExecutedResult(
@@ -478,7 +523,10 @@ pub fn appendOrdinaryExecutedResult(
     memory: types.ToolResultMemory,
     execution: ToolExecutionResult,
 ) !void {
-    const activity = runtime_tool_presentation.activityKindForCall(arena, tool_registry, tool_call);
+    const mutates_workspace_files = if (tool_registry.lookup(tool_call.name)) |tool|
+        executorMutatesWorkspaceFiles(tool.executor_kind)
+    else
+        false;
     try appendToolResultContent(
         arena,
         within_turn_suffix,
@@ -490,7 +538,9 @@ pub fn appendOrdinaryExecutedResult(
         .{
             .increment_error = execution.status == .failure or tool_result_errors.isToolOutputError(model_output),
             .record_completion = true,
-            .mark_write = activity == .write or activity == .edit,
+            .mark_mutation = mutates_workspace_files and
+                execution.status == .success and
+                !tool_result_errors.isToolOutputError(model_output),
             .status = runtime_execution_memory.persistedStatusForCurrentFxLocalResult(
                 execution.status,
                 model_output,
@@ -499,16 +549,64 @@ pub fn appendOrdinaryExecutedResult(
     );
 }
 
-pub fn appendReviewContinuationSuffix(
-    review_enabled: bool,
-    arena: Allocator,
-    within_turn_suffix: *std.ArrayList(ChatMessage),
+pub fn scheduleFinalVerification(
+    enabled: bool,
+    state: *FinalVerificationState,
+    step_ctx: TraceContext,
     batch: *const StepBatchState,
-) !void {
-    if (review_enabled and batch.step_had_writes) {
-        const review_prompt = "Review the changes you just made. Re-read any modified files and briefly note any issues (syntax errors, missing imports, logic bugs). If everything looks correct, say so.";
-        try within_turn_suffix.append(arena, .{ .role = .user, .content = review_prompt });
-    }
+) void {
+    if (!enabled or state.scheduled or !batch.step_had_mutation) return;
+
+    state.scheduled = true;
+    state.pending = true;
+    debug_trace.eventf(
+        "agent",
+        "final_verification_scheduled",
+        step_ctx,
+        "trigger=file_mutation",
+        .{},
+    );
+}
+
+pub fn finalVerificationRequestSuffix(
+    arena: Allocator,
+    state: *const FinalVerificationState,
+    step_ctx: TraceContext,
+    within_turn_suffix: []const ChatMessage,
+) ![]const ChatMessage {
+    if (!state.pending) return within_turn_suffix;
+
+    const request_suffix = try arena.alloc(ChatMessage, within_turn_suffix.len + 1);
+    @memcpy(request_suffix[0..within_turn_suffix.len], within_turn_suffix);
+    request_suffix[within_turn_suffix.len] = .{
+        .role = .user,
+        .content = final_verification_prompt,
+        .cache_policy = .no_cache,
+    };
+    debug_trace.eventf(
+        "agent",
+        "final_verification_injected",
+        step_ctx,
+        "trigger=file_mutation",
+        .{},
+    );
+    return request_suffix;
+}
+
+pub fn consumeFinalVerification(
+    state: *FinalVerificationState,
+    step_ctx: TraceContext,
+) void {
+    if (!state.pending) return;
+
+    state.pending = false;
+    debug_trace.eventf(
+        "agent",
+        "final_verification_consumed",
+        step_ctx,
+        "scope=next_completion",
+        .{},
+    );
 }
 
 test "appendPermissionFeedback marks typed approval feedback" {
@@ -591,4 +689,47 @@ test "drained batch feedback follows all tool results and keeps its source call"
     try std.testing.expectEqual(.user, suffix.items[3].role);
     try std.testing.expectEqualStrings("call_first", suffix.items[3].tool_call_id.?);
     try std.testing.expect(suffix.items[3].permission_feedback);
+}
+
+test "filesystem mutation executor classification includes every file mutator" {
+    const kinds = [_]tool_dispatch.ExecutorKind{
+        .write_file,
+        .edit_file,
+        .delete_file,
+        .rename_file,
+        .copy_file,
+        .create_folder,
+    };
+    for (kinds) |kind| {
+        try std.testing.expect(executorMutatesWorkspaceFiles(kind));
+    }
+}
+
+test "filesystem mutation executor classification excludes every non-file executor" {
+    const kinds = [_]tool_dispatch.ExecutorKind{
+        .list_files,
+        .glob_files,
+        .grep_files,
+        .read_file,
+        .read_tool_result,
+        .file_info,
+        .memory,
+        .semantic_search,
+        .open_file,
+        .web_fetch,
+        .web_search,
+        .run_command,
+        .terminal,
+        .skill,
+        .install_skill,
+        .subagent,
+        .mcp_search_tools,
+        .mcp_select_tool,
+        .mcp_features,
+        .ask_user_question,
+        .vision,
+    };
+    for (kinds) |kind| {
+        try std.testing.expect(!executorMutatesWorkspaceFiles(kind));
+    }
 }

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1104,7 +1104,7 @@ pub fn Runtime(comptime App: type) type {
                 .agent_step_limit = app.agent_step_limit,
                 .max_tool_result_bytes = job.agent_settings.max_tool_result_bytes,
                 .cancel_flag = &app.worker.worker_cancel_requested,
-                .review_enabled = false,
+                .final_verification_enabled = false,
                 .fast_mode = job.agent_settings.fast_mode,
                 .effort = job.agent_settings.effort,
                 .first_call_tool_choice = job.agent_settings.first_call_tool_choice,

--- a/tests/evals/composed-lifecycle-eval.test.ts
+++ b/tests/evals/composed-lifecycle-eval.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  LIFECYCLE_TASK_PROMPT,
+  prepareHeldOutLifecycleWorkspace,
+  runBunTestFile,
+  writeHeldOutLifecycleVerifier,
+  writeLifecycleFixture,
+} from "./composed-lifecycle-eval";
+
+
+describe("composed lifecycle fixture", () => {
+  test("frozen flaw passes visible tests and fails the held-out transition", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "fx-lifecycle-flawed-"));
+    try {
+      writeLifecycleFixture(dir, "flawed");
+      expect(existsSync(join(dir, "held-out-lifecycle.test.ts"))).toBe(false);
+      expect(statSync(dir).mode & 0o777).toBe(0o700);
+
+      const visible = await runBunTestFile(dir, "pool.test.ts");
+      expect(visible.code).toBe(0);
+
+      writeHeldOutLifecycleVerifier(dir);
+      const heldOut = await runBunTestFile(dir, "held-out-lifecycle.test.ts");
+      expect(heldOut.code).not.toBe(0);
+      expect(heldOut.stdout + heldOut.stderr).toContain("cleanupCompleted");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("known-correct implementation passes the held-out transition", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "fx-lifecycle-correct-"));
+    try {
+      writeLifecycleFixture(dir, "correct");
+      const visible = await runBunTestFile(dir, "pool.test.ts");
+      expect(visible.code).toBe(0);
+
+      writeHeldOutLifecycleVerifier(dir);
+      const heldOut = await runBunTestFile(dir, "held-out-lifecycle.test.ts");
+      expect(heldOut.code).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("held-out verifier ignores agent-controlled Bun configuration", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "fx-lifecycle-agent-"));
+    const verifierDir = mkdtempSync(join(tmpdir(), "fx-lifecycle-verifier-"));
+    try {
+      writeLifecycleFixture(agentDir, "flawed");
+      writeFileSync(join(agentDir, "bunfig.toml"), "[test]\npreload = [\"./preload.ts\"]\n");
+      writeFileSync(join(agentDir, "preload.ts"), "throw new Error(\"agent preload ran\");\n");
+
+      prepareHeldOutLifecycleWorkspace(agentDir, verifierDir);
+
+      expect(existsSync(join(verifierDir, "bunfig.toml"))).toBe(false);
+      const heldOut = await runBunTestFile(
+        verifierDir,
+        "held-out-lifecycle.test.ts",
+      );
+      expect(heldOut.code).not.toBe(0);
+      expect(heldOut.stdout + heldOut.stderr).not.toContain("agent preload ran");
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true });
+      rmSync(verifierDir, { recursive: true, force: true });
+    }
+  });
+
+  test("held-out verifier rejects symlinked agent source", () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "fx-lifecycle-agent-"));
+    const verifierDir = mkdtempSync(join(tmpdir(), "fx-lifecycle-verifier-"));
+    try {
+      writeLifecycleFixture(agentDir, "flawed");
+      const externalPath = join(agentDir, "external.ts");
+      writeFileSync(externalPath, "export const exposed = true;\n");
+      rmSync(join(agentDir, "pool.ts"));
+      symlinkSync(externalPath, join(agentDir, "pool.ts"));
+
+      expect(() =>
+        prepareHeldOutLifecycleWorkspace(agentDir, verifierDir)
+      ).toThrow(/regular file/);
+    } finally {
+      rmSync(agentDir, { recursive: true, force: true });
+      rmSync(verifierDir, { recursive: true, force: true });
+    }
+  });
+
+  test("agent prompt stays generic and does not expose the held-out implementation", () => {
+    expect(LIFECYCLE_TASK_PROMPT).toContain("asynchronous cleanup has settled");
+    expect(LIFECYCLE_TASK_PROMPT).not.toMatch(/asyncio|python|semaphore|sigint/i);
+    expect(LIFECYCLE_TASK_PROMPT).not.toContain("held-out-lifecycle.test.ts");
+  });
+});

--- a/tests/evals/composed-lifecycle-eval.ts
+++ b/tests/evals/composed-lifecycle-eval.ts
@@ -1,0 +1,404 @@
+/**
+ * Deterministic synthetic fixture for composed lifecycle verification.
+ *
+ * Run with:
+ *   bun test composed-lifecycle-eval.test.ts
+ */
+import { spawn as nodeSpawn } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+export const LIFECYCLE_TASK_PROMPT = `Repair the bounded task pool in this workspace.
+
+Its public contract is:
+- no more than the configured number of jobs run concurrently;
+- aborting prevents jobs that have not started from starting;
+- the pool rejects with the abort reason only after asynchronous cleanup has settled for every job that did start;
+- successful results preserve input order.
+
+Inspect pool.ts and pool.test.ts. Fix the implementation, add a regression test for any missing interaction you find, and run the focused tests. Do not look for or create hidden tests.`;
+
+const MAX_LIFECYCLE_SOURCE_BYTES = 256 * 1024;
+
+export type FixtureImplementation = "flawed" | "correct";
+
+export interface ProcessResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+}
+
+export const FLAWED_POOL_SOURCE = `export interface PoolJob<T> {
+  run(signal: AbortSignal): Promise<T>;
+  cleanup(): Promise<void>;
+}
+
+
+export async function runBounded<T>(
+  jobs: readonly PoolJob<T>[],
+  limit: number,
+  signal: AbortSignal,
+): Promise<T[]> {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new RangeError("limit must be a positive integer");
+  }
+
+  const results = new Array<T>(jobs.length);
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      if (signal.aborted) {
+        throw signal.reason ?? new DOMException("Aborted", "AbortError");
+      }
+      const index = nextIndex;
+      if (index >= jobs.length) return;
+      nextIndex += 1;
+
+      const job = jobs[index]!;
+      try {
+        results[index] = await job.run(signal);
+      } finally {
+        await job.cleanup();
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, jobs.length) }, () => worker()),
+  );
+  return results;
+}
+`;
+
+export const CORRECT_POOL_SOURCE = `export interface PoolJob<T> {
+  run(signal: AbortSignal): Promise<T>;
+  cleanup(): Promise<void>;
+}
+
+
+export async function runBounded<T>(
+  jobs: readonly PoolJob<T>[],
+  limit: number,
+  signal: AbortSignal,
+): Promise<T[]> {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new RangeError("limit must be a positive integer");
+  }
+
+  const results = new Array<T>(jobs.length);
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      if (signal.aborted) {
+        throw signal.reason ?? new DOMException("Aborted", "AbortError");
+      }
+      const index = nextIndex;
+      if (index >= jobs.length) return;
+      nextIndex += 1;
+
+      const job = jobs[index]!;
+      try {
+        results[index] = await job.run(signal);
+      } finally {
+        await job.cleanup();
+      }
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(limit, jobs.length) },
+    () => worker(),
+  );
+  const outcomes = await Promise.allSettled(workers);
+  const failure = outcomes.find(
+    (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+  );
+  if (failure) throw failure.reason;
+  return results;
+}
+`;
+
+export const VISIBLE_TEST_SOURCE = `import { describe, expect, test } from "bun:test";
+import { runBounded, type PoolJob } from "./pool";
+
+function waitForAbort(signal: AbortSignal): Promise<never> {
+  const { promise, reject } = Promise.withResolvers<never>();
+  const rejectAbort = () => reject(signal.reason);
+  if (signal.aborted) {
+    rejectAbort();
+  } else {
+    signal.addEventListener("abort", rejectAbort, { once: true });
+  }
+  return promise;
+}
+
+describe("runBounded", () => {
+  test("limits concurrency and preserves result order", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const jobs: PoolJob<number>[] = Array.from({ length: 5 }, (_, index) => ({
+      async run() {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await Bun.sleep(5 + (4 - index));
+        active -= 1;
+        return index;
+      },
+      async cleanup() {},
+    }));
+
+    const results = await runBounded(jobs, 2, new AbortController().signal);
+
+    expect(maxActive).toBe(2);
+    expect(results).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  test("abort prevents queued work from starting", async () => {
+    const controller = new AbortController();
+    const reason = new Error("stop");
+    const started: number[] = [];
+    const { promise: firstStarted, resolve: announceStarted } =
+      Promise.withResolvers<void>();
+    const jobs: PoolJob<number>[] = [0, 1].map((index) => ({
+      async run(signal) {
+        started.push(index);
+        if (index === 0) announceStarted();
+        return waitForAbort(signal);
+      },
+      async cleanup() {},
+    }));
+
+    const running = runBounded(jobs, 1, controller.signal);
+    await firstStarted;
+    controller.abort(reason);
+
+    await expect(running).rejects.toBe(reason);
+    expect(started).toEqual([0]);
+  });
+
+  test("normal completion awaits asynchronous cleanup", async () => {
+    let cleanupComplete = false;
+    const jobs: PoolJob<number>[] = [{
+      async run() {
+        return 42;
+      },
+      async cleanup() {
+        await Bun.sleep(10);
+        cleanupComplete = true;
+      },
+    }];
+
+    await expect(
+      runBounded(jobs, 1, new AbortController().signal),
+    ).resolves.toEqual([42]);
+    expect(cleanupComplete).toBe(true);
+  });
+});
+`;
+
+export const HELD_OUT_TEST_SOURCE = `import { expect, test } from "bun:test";
+import { runBounded, type PoolJob } from "./pool";
+
+function waitForAbort(signal: AbortSignal): Promise<never> {
+  const { promise, reject } = Promise.withResolvers<never>();
+  const rejectAbort = () => reject(signal.reason);
+  if (signal.aborted) {
+    rejectAbort();
+  } else {
+    signal.addEventListener("abort", rejectAbort, { once: true });
+  }
+  return promise;
+}
+
+test("queued abort settles cleanup for every started job before rejection", async () => {
+  const controller = new AbortController();
+  const reason = new Error("interrupt");
+  const started: number[] = [];
+  const cleanupCompleted: number[] = [];
+  const { promise: bothStarted, resolve: announceBothStarted } =
+    Promise.withResolvers<void>();
+
+  const jobs: PoolJob<number>[] = [0, 1, 2].map((index) => ({
+    async run(signal) {
+      started.push(index);
+      if (started.length === 2) announceBothStarted();
+      return waitForAbort(signal);
+    },
+    async cleanup() {
+      if (index < 2) await Bun.sleep(index === 0 ? 5 : 80);
+      cleanupCompleted.push(index);
+    },
+  }));
+
+  const running = runBounded(jobs, 2, controller.signal);
+  await Promise.race([
+    bothStarted,
+    Bun.sleep(1_000).then(() => {
+      throw new Error("timed out waiting for two started jobs");
+    }),
+  ]);
+  controller.abort(reason);
+
+  await expect(running).rejects.toBe(reason);
+  expect(started.sort()).toEqual([0, 1]);
+  expect(cleanupCompleted.sort()).toEqual([0, 1]);
+});
+`;
+
+export function writeLifecycleFixture(
+  dir: string,
+  implementation: FixtureImplementation,
+): void {
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  chmodSync(dir, 0o700);
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ private: true, type: "module" }, null, 2) + "\n",
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    join(dir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          target: "ESNext",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          types: ["bun"],
+          noEmit: true,
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    join(dir, "pool.ts"),
+    implementation === "flawed" ? FLAWED_POOL_SOURCE : CORRECT_POOL_SOURCE,
+    { mode: 0o600 },
+  );
+  writeFileSync(join(dir, "pool.test.ts"), VISIBLE_TEST_SOURCE, {
+    mode: 0o600,
+  });
+}
+
+export function writeHeldOutLifecycleVerifier(dir: string): string {
+  const path = join(dir, "held-out-lifecycle.test.ts");
+  if (existsSync(path)) {
+    throw new Error(`held-out verifier already exists: ${path}`);
+  }
+  writeFileSync(path, HELD_OUT_TEST_SOURCE, { mode: 0o600 });
+  return path;
+}
+
+export function prepareHeldOutLifecycleWorkspace(
+  agentWorkspace: string,
+  verifierWorkspace: string,
+): string {
+  rmSync(verifierWorkspace, { recursive: true, force: true });
+  writeLifecycleFixture(verifierWorkspace, "flawed");
+  const agentPoolPath = join(agentWorkspace, "pool.ts");
+  let agentPoolFd: number;
+  try {
+    agentPoolFd = openSync(
+      agentPoolPath,
+      constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
+  } catch (error) {
+    throw new Error("agent pool.ts must be a regular file", { cause: error });
+  }
+  const verifierPoolPath = join(verifierWorkspace, "pool.ts");
+  try {
+    const sourceStat = fstatSync(agentPoolFd);
+    if (!sourceStat.isFile()) {
+      throw new Error("agent pool.ts must be a regular file");
+    }
+    if (sourceStat.size > MAX_LIFECYCLE_SOURCE_BYTES) {
+      throw new Error(
+        `agent pool.ts exceeds ${MAX_LIFECYCLE_SOURCE_BYTES}-byte verifier limit`,
+      );
+    }
+    const source = readFileSync(agentPoolFd);
+    if (source.byteLength > MAX_LIFECYCLE_SOURCE_BYTES) {
+      throw new Error(
+        `agent pool.ts exceeds ${MAX_LIFECYCLE_SOURCE_BYTES}-byte verifier limit`,
+      );
+    }
+    writeFileSync(verifierPoolPath, source, { mode: 0o600 });
+  } finally {
+    closeSync(agentPoolFd);
+  }
+  chmodSync(verifierPoolPath, 0o600);
+  return writeHeldOutLifecycleVerifier(verifierWorkspace);
+}
+
+export async function runBunTestFile(
+  dir: string,
+  file: string,
+  timeoutMs = 30_000,
+): Promise<ProcessResult> {
+  return runProcess("bun", ["test", file], { cwd: dir, timeoutMs });
+}
+
+async function runProcess(
+  command: string,
+  args: string[],
+  opts: {
+    cwd: string;
+    timeoutMs: number;
+    env?: NodeJS.ProcessEnv;
+  },
+): Promise<ProcessResult> {
+  const { promise, resolve } = Promise.withResolvers<ProcessResult>();
+  const child = nodeSpawn(command, args, {
+    cwd: opts.cwd,
+    env: opts.env ?? process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  let timedOut = false;
+  let settled = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGKILL");
+  }, opts.timeoutMs);
+  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+
+  const finish = (code: number | null, signal: NodeJS.Signals | null) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    resolve({
+      stdout: Buffer.concat(stdout).toString(),
+      stderr: Buffer.concat(stderr).toString(),
+      code,
+      signal,
+      timedOut,
+    });
+  };
+  child.on("error", (error) => {
+    stderr.push(Buffer.from(error.message));
+    finish(null, null);
+  });
+  child.on("close", finish);
+  return promise;
+}


### PR DESCRIPTION
## Summary

- make the dormant post-write verification reminder transient to the next successful completion instead of replaying throughout the turn
- trigger it only from successful typed filesystem mutators
- rebuild the request-only suffix from live recovery state, preserving recovered tool evidence
- keep the mechanism disabled by default because the frozen 32-coordinate comparison found no supported quality lift and measurable token overhead
- add a generic held-out lifecycle-boundary eval for bounded work, interruption with queued work, and cleanup completion

## Contract

When explicitly enabled, the first successful file mutation schedules one no-cache reminder. Physical retries retain it; the next successful completion consumes it; later reads, terminal calls, failed mutations, and repair writes do not retrigger it. The shipped default remains off.

The eval contains no benchmark-private task, verifier, hidden assertion, or reference solution. Investigation receipts and the final 24-run disposition remain on #233.

## Verification

Exact head: `a4c3a3a73b9f3af8ae891f84514d603aca9b1151`  
Base: `v0.0.6` (`79666393e5f613c85f2f0b4b65475f1addd55379`)

- `zig fmt --check src/`: passed
- `scripts/check-public-surface.sh`: passed
- final-verification focused Zig tests: 20 passed
- filesystem-mutation focused Zig tests: 16 passed
- physical-recovery regression: 14 passed; recovered tool evidence survives retry, the reminder remains until a successful completion, and is then consumed once
- `composed-lifecycle-eval.test.ts`: 5 passed
- native build: passed
- built `./zig-out/bin/fx` fake-Gateway smoke: `write_file` succeeded, `smoke.txt` contained `smoke-ok`, two requests completed, default-off follow-up omitted the reminder, exit 0, and stderr matched the expected progress output exactly
- current `origin/main` merge simulation: clean

Full CI passed all four platform aggregates on the exact head: https://github.com/alphastorm/fx/actions/runs/32898862052

Final ship gate: SHIP for `a4c3a3a73b9f3af8ae891f84514d603aca9b1151`.

Addresses #233.