### PR TITLE
Prevent Codex usage reservation exhaustion

### DIFF
--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -139,6 +139,7 @@ pub fn streamGatewayCompletion(
     const status = result.status;
     const finish_reason = result.completion.finish_reason;
     const completion_usage = result.completion.usage;
+    const gateway_generation_expected = result.completion.gateway_generation_expected;
     const delivery_ambiguous = result.completion.delivery_ambiguous;
     const generation_metadata_invalid = result.completion.generation_metadata_invalid;
     const provider_result_identity_failure = result.completion.provider_result_identity_failure;
@@ -148,6 +149,7 @@ pub fn streamGatewayCompletion(
         .completion = .{
             .content = content,
             .tool_calls = tool_calls,
+            .gateway_generation_expected = gateway_generation_expected,
             .generation_id = generation_id,
             .generation_metadata_invalid = generation_metadata_invalid,
             .delivery_ambiguous = delivery_ambiguous,

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -112,11 +112,16 @@ pub const GatewayObservation = struct {
         team: ?[]const u8,
     ) !void {
         const ledger = self.usage orelse return;
-        const generation_id = completion.generation_id;
+        const generation_id = if (completion.gateway_generation_expected)
+            completion.generation_id
+        else
+            null;
         const delivery: DeliveryOutcome = if (completion.delivery_ambiguous)
             .ambiguous_delivery
         else if (status == .ok)
-            if (!completion.generation_metadata_invalid and generation_id != null)
+            if (!completion.gateway_generation_expected)
+                .unbilled
+            else if (!completion.generation_metadata_invalid and generation_id != null)
                 .observed_generation
             else
                 .possibly_billed_without_identity
@@ -492,7 +497,12 @@ pub const Usage = struct {
             origin,
             team,
         ) catch |err| {
-            self.markBillingIncomplete();
+            const settled = self.finishInvocationWithResult(
+                sequence,
+                duration_ms,
+                .possibly_billed_without_identity,
+            );
+            if (!settled) self.markBillingIncomplete();
             _ = self.persistCheckpointBestEffortLocked();
             debug_trace.logf(
                 "session",
@@ -546,9 +556,18 @@ pub const Usage = struct {
         duration_ms: u64,
         outcome: DeliveryOutcome,
     ) void {
+        _ = self.finishInvocationWithResult(sequence, duration_ms, outcome);
+    }
+
+    fn finishInvocationWithResult(
+        self: *Usage,
+        sequence: u64,
+        duration_ms: u64,
+        outcome: DeliveryOutcome,
+    ) bool {
         self.mutex.lockUncancelable(io_mod.getIo());
         defer self.mutex.unlock(io_mod.getIo());
-        _ = self.finishInvocationUnlocked(sequence, duration_ms, outcome);
+        return self.finishInvocationUnlocked(sequence, duration_ms, outcome);
     }
 
     pub fn finishObservedInvocation(
@@ -3751,6 +3770,29 @@ test "successful response without generation identity marks billing incomplete" 
     try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
 }
 
+test "successful response without Gateway generation tracking settles unbilled" {
+    const alloc = std.testing.allocator;
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+
+    const observation = try GatewayObservation.begin(&usage);
+    try observation.complete(
+        alloc,
+        .ok,
+        .{ .gateway_generation_expected = false },
+        "https://chatgpt.com/backend-api/codex",
+        null,
+    );
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(Availability.complete, snapshot.billing);
+    try std.testing.expect(snapshot.api_duration_complete);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.incidents.len);
+}
+
 const TestGenerationUsageProvider = struct {
     outcome: enum {
         found,
@@ -4661,6 +4703,38 @@ test "gateway observation checkpoints active and terminal usage states" {
     try std.testing.expectEqual(Availability.pending, capture.billing[1]);
     try std.testing.expect(capture.api_duration_complete[1]);
     try std.testing.expectEqual(@as(usize, 1), capture.pending_count[1]);
+}
+
+test "invalid generation metadata does not exhaust gateway observations" {
+    const alloc = std.testing.allocator;
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+
+    for (0..max_active_invocations + 1) |index| {
+        const observation = try GatewayObservation.begin(&usage);
+        try observation.complete(
+            alloc,
+            .ok,
+            .{ .generation_id = "resp_not-a-gateway-generation" },
+            "https://chatgpt.com/backend-api/codex",
+            null,
+        );
+        if (index == 0) {
+            var first = try usage.snapshot(alloc);
+            defer first.deinit(alloc);
+            try std.testing.expectEqual(@as(usize, 1), first.incidents.len);
+        }
+    }
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(Availability.incomplete, snapshot.billing);
+    try std.testing.expect(snapshot.api_duration_complete);
+    try std.testing.expectEqual(
+        @as(u64, max_active_invocations + 1),
+        snapshot.settled_through_sequence,
+    );
+    try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
 }
 
 test "gateway observation does not proceed when active checkpoint fails" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -955,6 +955,8 @@ pub const ProviderFinishReason = enum {
 pub const GatewayCompletion = struct {
     content: ?[]const u8 = null,
     tool_calls: []const ToolCall = &.{},
+    /// Whether successful delivery should produce a Gateway generation.
+    gateway_generation_expected: bool = true,
     generation_id: ?[]const u8 = null,
     billing: ?GatewayBilling = null,
     /// Gateway generation or resolved-model metadata was malformed or conflicting.

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -497,8 +497,6 @@ fn consumeSse(
     defer sse.deinit(alloc);
     var finish_reason: ?types.ProviderFinishReason = null;
     var usage: types.Usage = .{};
-    var generation_id: ?[]u8 = null;
-    errdefer if (generation_id) |id| alloc.free(id);
     var terminal_seen = false;
     var saw_content_delta = false;
 
@@ -600,9 +598,6 @@ fn consumeSse(
             const status = stringField(response_value.object, "status");
             finish_reason = finishReason(status, response_value.object, tools.items.len > 0);
             usage = parseUsage(response_value.object);
-            if (stringField(response_value.object, "id")) |id| {
-                generation_id = try alloc.dupe(u8, id);
-            }
             break;
         } else if (std.mem.eql(u8, event_type, "response.failed") or
             std.mem.eql(u8, event_type, "error"))
@@ -650,7 +645,7 @@ fn consumeSse(
     return .{
         .content = owned_content,
         .tool_calls = owned_tools,
-        .generation_id = generation_id,
+        .gateway_generation_expected = false,
         .provider_state_json = owned_provider_state,
         .finish_reason = finish_reason orelse if (owned_tools.len > 0) .tool_calls else .stop,
         .usage = usage,
@@ -843,7 +838,7 @@ test "OpenAI Codex SSE maps text reasoning tools and usage" {
         "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"hello\"}\n\n" ++
         "data: {\"type\":\"response.output_item.added\",\"output_index\":2,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"read_file\"}}\n\n" ++
         "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":2,\"delta\":\"{\\\"path\\\":\\\"README.md\\\"}\"}\n\n" ++
-        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4}}}\n\n";
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_123\",\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4}}}\n\n";
     var reader: std.Io.Reader = .fixed(sse_text);
     var cancelled = std.atomic.Value(bool).init(false);
     const Capture = struct {
@@ -890,6 +885,8 @@ test "OpenAI Codex SSE maps text reasoning tools and usage" {
     try std.testing.expectEqualStrings("call_1", completion.tool_calls[0].id);
     try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", completion.tool_calls[0].arguments_json);
     try std.testing.expectEqual(@as(?u64, 10), completion.usage.input_tokens);
+    try std.testing.expect(!completion.gateway_generation_expected);
+    try std.testing.expectEqual(@as(?[]const u8, null), completion.generation_id);
     try std.testing.expect(completion.provider_state_json != null);
     try std.testing.expect(std.mem.find(u8, completion.provider_state_json.?, "\"encrypted_content\":\"opaque\"") != null);
     try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);


### PR DESCRIPTION
## Summary

- Distinguish direct Codex completions that do not produce Gateway generation identities
- Settle usage reservations when generation observation fails, without recording duplicate incidents
- Add regressions for direct Codex `resp_*` identities and more than 64 consecutive completions

## Root cause

Direct Codex responses expose `resp_*` response IDs, but `GatewayCompletion.generation_id` accepts only Gateway `gen_*` identities. The rejected identity marked billing incomplete without releasing its active reservation, so the 65th successful response failed with `UsageCapacityExceeded`.

## Testing

- `zig fmt --check src/`
- focused session-usage and direct-Codex tests
- all Codex-focused tests
- `zig build -Doptimize=ReleaseSafe`
- exercised the built binary against a mock Codex endpoint for 66 responses without `UsageCapacityExceeded`

Required label: `type: bug`
