### PR TITLE
Stop repeated malformed tool argument loops

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -65,6 +65,8 @@ const assistant_prefill_recovery_prompt =
     "Continue from the preceding tool result.";
 const repeated_terminal_validation_notice =
     "Repeated terminal validation failures stopped the tool loop. The invalid terminal calls were not executed and produced no terminal effect.";
+const repeated_malformed_arguments_notice =
+    "Repeated malformed tool arguments stopped the agent loop. The invalid calls were not executed. Continue with a follow-up prompt if needed.";
 const Config = runtime_config.Config;
 const LifecycleContext = runtime_lifecycle.LifecycleContext;
 const PreparedToolCall = runtime_lifecycle.PreparedToolCall;
@@ -2828,6 +2830,7 @@ fn processQueuedPromptLoop(
     defer turn_permission_recovery.deinit(arena);
     var terminal_validation_retry: runtime_tool_admission.TerminalValidationRetryState = .{};
     defer terminal_validation_retry.deinit(arena);
+    var malformed_arguments_retry: runtime_tool_admission.MalformedArgumentsRetryState = .{};
     var completed_tool_names = completed_tool_names_ptr.*;
     defer completed_tool_names_ptr.* = completed_tool_names;
     var context_delivery_state: context_contract.DeliveryState = if (deps.context_enabled)
@@ -5113,6 +5116,10 @@ fn processQueuedPromptLoop(
 
         var step_batch = runtime_tool_batch.StepBatchState{};
         terminal_validation_retry.beginBatch();
+        malformed_arguments_retry.beginBatch();
+        for (effective_tool_calls) |tool_call| {
+            malformed_arguments_retry.observe(tool_call);
+        }
         var settled_vision_ids: std.ArrayList(usize) = .empty;
         defer mem_utils.deinitList(arena, &settled_vision_ids);
         var parallel_skip_until: usize = 0;
@@ -7679,6 +7686,28 @@ fn processQueuedPromptLoop(
             &within_turn_suffix,
             &step_batch,
         );
+        if (malformed_arguments_retry.finishBatch()) {
+            debug_trace.eventf(
+                "agent",
+                "repeated_malformed_tool_arguments",
+                step_ctx,
+                "tool_call_count={d}",
+                .{effective_tool_calls.len},
+            );
+            try finishFailedTurnWithNotice(
+                deps,
+                finalization,
+                arena,
+                job,
+                within_turn_suffix.items,
+                &summary_accumulator,
+                stop_state,
+                &finish_trace,
+                repeated_malformed_arguments_notice,
+                "repeated_malformed_tool_arguments",
+            );
+            return;
+        }
         if (terminal_validation_retry.finishBatch()) {
             try deps.push_system_notice(
                 deps.ctx,

--- a/src/core/agent/runtime/tests/finalization_flow.zig
+++ b/src/core/agent/runtime/tests/finalization_flow.zig
@@ -268,7 +268,7 @@ test "processQueuedPrompt returns a final response after repeated tool failures"
     try std.testing.expectEqual(@as(usize, 3), hooks.executed_names.items.len);
 }
 
-test "processQueuedPrompt returns a final response after repeated malformed calls" {
+test "processQueuedPrompt stops repeated malformed calls before another provider request" {
     const alloc = std.testing.allocator;
     const call_one = [_]ToolCall{.{
         .id = "call_1",
@@ -292,23 +292,27 @@ test "processQueuedPrompt returns a final response after repeated malformed call
         .{ .tool_calls = &call_one },
         .{ .tool_calls = &call_two },
         .{ .tool_calls = &call_three },
-        .{ .content = "Recovered after malformed arguments." },
+        .{ .content = "must not be requested" },
     };
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
     var hooks = FakeAgentRuntimeDeps.init(alloc);
     defer hooks.deinit();
     var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.agent_step_limit = 0;
 
-    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
-    try std.testing.expect(!textContains(&hooks, "Agent stopped: 3 consecutive steps with all-error tool calls."));
+    const notice = "Repeated malformed tool arguments stopped the agent loop. The invalid calls were not executed. Continue with a follow-up prompt if needed.";
+    try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
+    try std.testing.expect(textContains(&hooks, notice));
     try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items.len);
     try std.testing.expectEqual(@as(usize, 1), hooks.finalization_count);
     try std.testing.expectEqual(@as(usize, 1), hooks.finish_event_count);
-    try std.testing.expectEqual(types.TurnPresentationOutcome.completed, hooks.finalized_outcome.?);
-    try std.testing.expectEqualStrings("Recovered after malformed arguments.", hooks.history_assistant_text.?);
-    try std.testing.expectEqualStrings("Recovered after malformed arguments.", hooks.finish_assistant_text.?);
+    try std.testing.expectEqual(types.TurnPresentationOutcome.failed, hooks.finalized_outcome.?);
+    try std.testing.expectEqualStrings(notice, hooks.history_assistant_text.?);
+    try std.testing.expectEqualStrings(notice, hooks.finish_assistant_text.?);
     try std.testing.expect(
         logIndex(&hooks, "event:turn_finished").? <
             logIndex(&hooks, "event:finish_prompt").?,

--- a/src/core/agent/runtime/tool_admission.zig
+++ b/src/core/agent/runtime/tool_admission.zig
@@ -31,6 +31,7 @@ const ToolExecutionResult = runtime_tool_contracts.ToolExecutionResult;
 const TerminalValidationDigest = [std.crypto.hash.sha2.Sha256.digest_length]u8;
 pub const PermissionActionId = [std.crypto.hash.sha2.Sha256.digest_length]u8;
 const max_turn_permission_denials: usize = 64;
+const max_consecutive_malformed_argument_batches: usize = 3;
 
 const ApprovedAction = struct {
     authority: command_admission.ToolExecutionAuthority,
@@ -344,6 +345,86 @@ pub const TerminalValidationRetryState = struct {
         return false;
     }
 };
+
+pub const MalformedArgumentsRetryState = struct {
+    consecutive_malformed_batches: usize = 0,
+    current_call_count: usize = 0,
+    current_malformed_count: usize = 0,
+
+    pub fn beginBatch(self: *MalformedArgumentsRetryState) void {
+        self.current_call_count = 0;
+        self.current_malformed_count = 0;
+    }
+
+    pub fn observe(self: *MalformedArgumentsRetryState, call: ToolCall) void {
+        self.current_call_count += 1;
+        if (call.argument_integrity != .malformed_json) return;
+        self.current_malformed_count += 1;
+    }
+
+    pub fn finishBatch(self: *MalformedArgumentsRetryState) bool {
+        const all_malformed = self.current_call_count > 0 and
+            self.current_call_count == self.current_malformed_count;
+        if (!all_malformed) {
+            self.consecutive_malformed_batches = 0;
+            return false;
+        }
+        if (self.consecutive_malformed_batches < max_consecutive_malformed_argument_batches) {
+            self.consecutive_malformed_batches += 1;
+        }
+        return self.consecutive_malformed_batches == max_consecutive_malformed_argument_batches;
+    }
+};
+
+test "malformed arguments retry state stops consecutive all-malformed batches" {
+    const malformed_read: ToolCall = .{
+        .id = "read-1",
+        .name = "read_file",
+        .arguments_json = "{}",
+        .argument_integrity = .malformed_json,
+    };
+    const malformed_fetch: ToolCall = .{
+        .id = "fetch-1",
+        .name = "web_fetch",
+        .arguments_json = "{}",
+        .argument_integrity = .malformed_json,
+    };
+    const valid_read: ToolCall = .{
+        .id = "read-valid",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"README.md\"}",
+    };
+
+    var state: MalformedArgumentsRetryState = .{};
+    state.beginBatch();
+    state.observe(malformed_read);
+    try std.testing.expect(!state.finishBatch());
+
+    state.beginBatch();
+    state.observe(malformed_fetch);
+    try std.testing.expect(!state.finishBatch());
+
+    state.beginBatch();
+    state.observe(malformed_fetch);
+    try std.testing.expect(state.finishBatch());
+
+    state.beginBatch();
+    state.observe(malformed_fetch);
+    state.observe(valid_read);
+    try std.testing.expect(!state.finishBatch());
+
+    state.beginBatch();
+    state.observe(malformed_read);
+    try std.testing.expect(!state.finishBatch());
+
+    state.beginBatch();
+    state.observe(malformed_read);
+    try std.testing.expect(!state.finishBatch());
+
+    state.beginBatch();
+    state.observe(malformed_read);
+    try std.testing.expect(state.finishBatch());
+}
 
 test "terminal validation retry state retains independent batch corrections" {
     const alloc = std.testing.allocator;

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2048,6 +2048,80 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test("default ask stops a consecutive malformed argument loop", async () => {
+    const root = createFixtureRoot("repeated-malformed-arguments");
+    const tracePath = join(root.root, "trace.log");
+    const alternateMalformedArguments = '{"path":"README.md",}';
+    const responses = [
+      fakeGatewaySerializedToolCall(
+        "malformed_repeat_1",
+        MALFORMED_TOOL_NAME,
+        MALFORMED_ARGUMENTS,
+      ),
+      fakeGatewaySerializedToolCall(
+        "malformed_repeat_2",
+        MALFORMED_TOOL_NAME,
+        MALFORMED_ARGUMENTS,
+      ),
+      fakeGatewaySerializedToolCall(
+        "malformed_repeat_3",
+        "read_file",
+        alternateMalformedArguments,
+      ),
+    ];
+    const gateway = startGateway(() =>
+      responses.shift() ?? new Response("unexpected request", { status: 500 })
+    );
+    try {
+      const result = await runFx(
+        [
+          "ask",
+          "--json",
+          "--auto",
+          "--no-save",
+          "Run the repeated malformed argument fixture.",
+        ],
+        {
+          cwd: root.workspace,
+          env: {
+            ...fixtureEnv(root, gateway, tracePath),
+            FX_MAX_AGENT_STEPS: undefined,
+          },
+          timeoutMs: 15_000,
+        },
+      );
+      const json = parseAskJson(result.stdout);
+      const trace = readFileSync(tracePath, "utf8");
+      const notice =
+        "Repeated malformed tool arguments stopped the agent loop. The invalid calls were not executed. Continue with a follow-up prompt if needed.";
+
+      expect(result.code).toBe(1);
+      expect(json.exit_code).toBe(1);
+      expect(json.error).toBeUndefined();
+      expect(result.stderr).toContain(notice);
+      expect(gateway.requestCount()).toBe(3);
+      expect(
+        json.tool_calls.filter(
+          (call) => call.name === MALFORMED_TOOL_NAME && call.status === "error",
+        ),
+      ).toHaveLength(2);
+      expect(json.tool_calls).toContainEqual({
+        name: "read_file",
+        status: "error",
+      });
+      expect(result.stdout).not.toContain(MALFORMED_ARGUMENTS);
+      expect(result.stderr).not.toContain(MALFORMED_ARGUMENTS);
+      expect(trace).toContain("event=repeated_malformed_tool_arguments");
+      expect(trace).not.toContain(MALFORMED_ARGUMENTS);
+      expect(result.stdout).not.toContain(alternateMalformedArguments);
+      expect(result.stderr).not.toContain(alternateMalformedArguments);
+      expect(trace).not.toContain(alternateMalformedArguments);
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("text and JSON ask defer a newly scoped build target until rules are visible", async () => {
     const variants = [
       { name: "text", json: false },


### PR DESCRIPTION
## Summary

- Stop an agent turn after three consecutive response batches contain only malformed tool arguments.
- Reset the breaker when a valid or mixed batch arrives, preserving one-off recovery.
- Keep malformed calls fail-closed, emit a dedicated trace event, and provide follow-up guidance.
- Add unit, finalization, and deterministic built-binary regression coverage.

## Testing

- `zig fmt --check src/`
- `zig build test`
- Focused malformed-loop and recovery E2E tests
