### PR TITLE
Reject non-regular read_file targets

### DIFF
--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -208,6 +208,57 @@ pub fn openExistingRegularFile(
     return file;
 }
 
+/// Opens an existing read-only regular file without following the final
+/// symlink or blocking if a special file races the metadata check. Hard-linked
+/// regular files remain valid. The caller owns the returned file.
+pub fn openExistingReadOnlyRegularFile(
+    dir: std.Io.Dir,
+    sub_path: []const u8,
+) !std.Io.File {
+    const initial = try dir.statFile(getIo(), sub_path, .{
+        .follow_symlinks = false,
+    });
+    if (initial.kind != .file) return error.NotRegularFile;
+
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        var file = dir.openFile(getIo(), sub_path, .{
+            .mode = .read_only,
+            .allow_directory = false,
+            .follow_symlinks = false,
+        }) catch |err| switch (err) {
+            error.IsDir, error.SymLinkLoop, error.NotDir => return error.NotRegularFile,
+            else => return err,
+        };
+        errdefer file.close(getIo());
+        const stat = try file.stat(getIo());
+        if (stat.kind != .file) return error.NotRegularFile;
+        return file;
+    }
+
+    var flags: std.posix.O = .{
+        .ACCMODE = .RDONLY,
+        .NOFOLLOW = true,
+        .NONBLOCK = true,
+    };
+    if (@hasField(std.posix.O, "CLOEXEC")) flags.CLOEXEC = true;
+    if (@hasField(std.posix.O, "LARGEFILE")) flags.LARGEFILE = true;
+    if (@hasField(std.posix.O, "NOCTTY")) flags.NOCTTY = true;
+
+    const fd = std.posix.openat(dir.handle, sub_path, flags, 0) catch |err| switch (err) {
+        error.NoDevice, error.SymLinkLoop, error.NotDir => return error.NotRegularFile,
+        else => return err,
+    };
+    var file = std.Io.File{
+        .handle = fd,
+        .flags = .{ .nonblocking = true },
+    };
+    errdefer file.close(getIo());
+    const stat = try file.stat(getIo());
+    if (stat.kind != .file) return error.NotRegularFile;
+    try makeFileBlocking(&file);
+    return file;
+}
+
 pub fn verifyOpenedRegularFile(
     stat: std.Io.File.Stat,
     mode: std.Io.Dir.OpenFileOptions.Mode,

--- a/src/tools/filesystem/read_file.zig
+++ b/src/tools/filesystem/read_file.zig
@@ -129,7 +129,7 @@ pub fn call(ctx: tool_dispatch.DispatchContext, erased: tool_dispatch.ToolInput)
     };
 
     const zio = io_mod.getIo();
-    var file = std.Io.Dir.openFileAbsolute(zio, target, .{}) catch |err| {
+    var file = io_mod.openExistingReadOnlyRegularFile(std.Io.Dir.cwd(), target) catch |err| {
         return readFileFailure(ctx.allocator, err, target);
     };
     defer file.close(zio);
@@ -178,6 +178,19 @@ pub fn call(ctx: tool_dispatch.DispatchContext, erased: tool_dispatch.ToolInput)
 fn readFileFailure(alloc: Allocator, err: anyerror, path: []const u8) tool_dispatch.DispatchError!tool_dispatch.ToolResult {
     if (tool_result_errors.isFilesystemAccessDenied(err)) {
         return .{ .failure = try tool_result_errors.filesystemAccessDeniedJson(alloc, "read_file", path, err) };
+    }
+    if (err == error.NotRegularFile) {
+        const details = [_]tool_result_errors.Detail{
+            .{ .name = "field", .value = .{ .string = "path" } },
+            .{ .name = "path", .value = .{ .string = path } },
+            .{ .name = "error", .value = .{ .string = @errorName(err) } },
+        };
+        return .{ .failure = try tool_result_errors.toolExecutionFailureJson(alloc, .{
+            .tool_name = "read_file",
+            .message = "read_file requires a regular file",
+            .details = &details,
+            .suggestion = "Run file_info to inspect the path, then choose a regular file.",
+        }) };
     }
     const details = [_]tool_result_errors.Detail{
         .{ .name = "field", .value = .{ .string = "path" } },
@@ -594,6 +607,24 @@ test "read_file access denial returns structured recovery" {
             try std.testing.expect(std.mem.find(u8, body, "/tmp/blocked/read.txt") != null);
             try std.testing.expect(std.mem.find(u8, body, "AccessDenied") != null);
             try std.testing.expect(std.mem.find(u8, body, "symlink") != null);
+        },
+        .success => |body| {
+            defer alloc.free(body);
+            try std.testing.expect(false);
+        },
+    }
+}
+
+test "read_file non-regular paths return structured recovery" {
+    const alloc = std.testing.allocator;
+    const result = try readFileFailure(alloc, error.NotRegularFile, "/tmp/search-pipe");
+    switch (result) {
+        .failure => |body| {
+            defer alloc.free(body);
+            try std.testing.expect(tool_result_errors.isToolExecutionFailedOutput(body));
+            try std.testing.expect(std.mem.find(u8, body, "read_file requires a regular file") != null);
+            try std.testing.expect(std.mem.find(u8, body, "NotRegularFile") != null);
+            try std.testing.expect(std.mem.find(u8, body, "file_info") != null);
         },
         .success => |body| {
             defer alloc.free(body);

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -1324,6 +1324,50 @@ describe("acp: model-independent", () => {
   );
 
   test(
+    "read_file rejects a FIFO without waiting for a writer",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-read-file-fifo-");
+      const fifoPath = join(root.workspace, "search-pipe");
+      const fifo = Bun.spawnSync(["mkfifo", fifoPath]);
+      expect(fifo.exitCode).toBe(0);
+      const gateway = startFakeGateway([
+        fakeGatewayToolCall("fifo_read_1", "read_file", {
+          path: "search-pipe",
+        }),
+        finalText("FIFO rejection handled."),
+      ]);
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await startCodeSession(client);
+
+        const result = await runPrompt(
+          client,
+          "Try to read the FIFO fixture.",
+          3_000,
+        );
+
+        expect(result.promptResult.result.stopReason).toBe("end_turn");
+        expect(gateway.requests).toHaveLength(2);
+        const toolResult = acpToolResultText(
+          gateway.requests[1]!.body,
+          "fifo_read_1",
+        );
+        expect(toolResult).toContain("NotRegularFile");
+        expect(toolResult).toContain("regular file");
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "ACP reload replays pending execution once and clears recovery after completion",
     async () => {
       const root = createIsolatedRoot("fx-acp-reload-model-recovery-");


### PR DESCRIPTION
## Summary

- Reject FIFOs and other non-regular paths before `read_file` can block opening them.
- Open regular read targets nonblocking, verify the descriptor, then restore normal blocking reads.
- Return a structured recovery message and add built-binary ACP coverage.

## Testing

- `zig fmt --check src/`
- `zig build`
- `zig build test`
- Focused ACP FIFO regression
