### PR TITLE
Preserve corrupt memory stores

### DIFF
--- a/src/tools/memory/memory.zig
+++ b/src/tools/memory/memory.zig
@@ -5,6 +5,14 @@ const tool_args = @import("../../core/tooling/tool_args.zig");
 const tool_dispatch = @import("../../core/tooling/tool_dispatch.zig");
 
 const Allocator = std.mem.Allocator;
+const max_memory_store_bytes: usize = 1024 * 1024;
+
+const MemoryStoreError = error{
+    OutOfMemory,
+    MemoryStoreMalformed,
+    MemoryStoreTooLarge,
+    MemoryStoreUnreadable,
+};
 
 pub const Input = struct {
     action: []u8,
@@ -69,6 +77,18 @@ pub fn call(ctx: tool_dispatch.DispatchContext, erased: tool_dispatch.ToolInput)
     const input = erased.as(Input);
     const output = runMemory(ctx.allocator, input.action, input.fact) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
+        error.MemoryStoreMalformed => return .{ .failure = try ctx.allocator.dupe(
+            u8,
+            "memory store is malformed; ~/.fx/memories.json was not modified. Repair or remove the file, then retry",
+        ) },
+        error.MemoryStoreTooLarge => return .{ .failure = try ctx.allocator.dupe(
+            u8,
+            "memory store exceeds the 1 MiB limit; ~/.fx/memories.json was not modified. Reduce or remove the file, then retry",
+        ) },
+        error.MemoryStoreUnreadable => return .{ .failure = try ctx.allocator.dupe(
+            u8,
+            "memory store could not be read; ~/.fx/memories.json was not modified. Check the file type and permissions, then retry",
+        ) },
         error.MemoryClearFailed => return .{ .failure = try ctx.allocator.dupe(
             u8,
             "memory clear failed: saved memories were not removed; ensure ~/.fx/memories.json is a removable file and retry",
@@ -94,7 +114,7 @@ fn runMemory(alloc: Allocator, action: []const u8, fact: ?[]const u8) ![]u8 {
 
     if (std.mem.eql(u8, action, "save")) {
         const fact_value = fact orelse return std.fmt.allocPrint(alloc, "no fact provided", .{});
-        var existing = loadMemories(alloc, memories_path);
+        var existing = try loadMemories(alloc, memories_path);
         defer freeMemories(alloc, &existing);
 
         for (existing.items) |memory| {
@@ -107,7 +127,7 @@ fn runMemory(alloc: Allocator, action: []const u8, fact: ?[]const u8) ![]u8 {
     }
 
     if (std.mem.eql(u8, action, "list")) {
-        var existing = loadMemories(alloc, memories_path);
+        var existing = try loadMemories(alloc, memories_path);
         defer freeMemories(alloc, &existing);
 
         if (existing.items.len == 0) return std.fmt.allocPrint(alloc, "No saved memories", .{});
@@ -137,20 +157,36 @@ fn isSupportedAction(action: []const u8) bool {
         std.mem.eql(u8, action, "clear");
 }
 
-fn loadMemories(alloc: Allocator, path: []const u8) std.ArrayList([]u8) {
+fn loadMemories(alloc: Allocator, path: []const u8) MemoryStoreError!std.ArrayList([]u8) {
     var list: std.ArrayList([]u8) = .empty;
-    var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{}) catch return list;
+    errdefer freeMemories(alloc, &list);
+
+    var file = io_mod.openExistingRegularFile(std.Io.Dir.cwd(), path, .read_only) catch |err| switch (err) {
+        error.FileNotFound => return list,
+        else => return error.MemoryStoreUnreadable,
+    };
     defer file.close(io_mod.getIo());
-    const content = io_mod.readFileToEnd(alloc, &file, 1024 * 1024) catch return list;
+    const content = io_mod.readFileToEnd(alloc, &file, max_memory_store_bytes) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.StreamTooLong => return error.MemoryStoreTooLarge,
+        else => return error.MemoryStoreUnreadable,
+    };
     defer alloc.free(content);
 
-    const parsed = std.json.parseFromSlice(std.json.Value, alloc, content, .{}) catch return list;
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, content, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.MemoryStoreMalformed,
+    };
     defer parsed.deinit();
 
-    if (parsed.value != .array) return list;
+    if (parsed.value != .array) return error.MemoryStoreMalformed;
     for (parsed.value.array.items) |item| {
-        if (item != .string) continue;
-        list.append(alloc, alloc.dupe(u8, item.string) catch continue) catch continue;
+        if (item != .string) return error.MemoryStoreMalformed;
+        const owned = try alloc.dupe(u8, item.string);
+        list.append(alloc, owned) catch |err| {
+            alloc.free(owned);
+            return err;
+        };
     }
     return list;
 }
@@ -180,11 +216,7 @@ fn saveMemories(alloc: Allocator, path: []const u8, memories: []const []u8) !voi
     const json = try out.toOwnedSlice();
     defer alloc.free(json);
 
-    io_mod.writeFileAtomic(alloc, path, json) catch {
-        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), path, .{ .truncate = true });
-        defer file.close(io_mod.getIo());
-        try file.writeStreamingAll(io_mod.getIo(), json);
-    };
+    try io_mod.writeFileAtomic(alloc, path, json);
 }
 
 pub fn readsOnly(erased: tool_dispatch.ToolInput) bool {
@@ -311,6 +343,76 @@ test "memory clear fails closed when state cannot be deleted" {
         .{},
     );
     survivor.close(io_mod.getIo());
+}
+
+test "memory corrupt store fails closed and preserves original bytes" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    const corrupt_store = "[\"recoverable prior memory\",\n";
+    try tmp.dir.writeFile(io_mod.getIo(), .{
+        .sub_path = "home/.fx/memories.json",
+        .data = corrupt_store,
+    });
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    try setTestHome(home);
+    defer setTestHome(null) catch {};
+
+    var list_arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer list_arena_state.deinit();
+    try std.testing.expectError(
+        error.MemoryStoreMalformed,
+        execute(list_arena_state.allocator(), "{\"action\":\"list\"}"),
+    );
+
+    var save_arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer save_arena_state.deinit();
+    try std.testing.expectError(
+        error.MemoryStoreMalformed,
+        execute(save_arena_state.allocator(), "{\"action\":\"save\",\"fact\":\"replacement\"}"),
+    );
+
+    var file = try tmp.dir.openFile(io_mod.getIo(), "home/.fx/memories.json", .{});
+    defer file.close(io_mod.getIo());
+    const after = try io_mod.readFileToEnd(alloc, &file, 4096);
+    defer alloc.free(after);
+    try std.testing.expectEqualStrings(corrupt_store, after);
+}
+
+test "memory loader distinguishes missing oversized and unreadable stores" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    const memories_path = try profile_paths.memoriesPath(alloc, home);
+    defer alloc.free(memories_path);
+
+    var missing = try loadMemories(alloc, memories_path);
+    defer freeMemories(alloc, &missing);
+    try std.testing.expectEqual(@as(usize, 0), missing.items.len);
+
+    {
+        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), memories_path, .{});
+        defer file.close(io_mod.getIo());
+        try file.setLength(io_mod.getIo(), max_memory_store_bytes + 1);
+    }
+    try std.testing.expectError(
+        error.MemoryStoreTooLarge,
+        loadMemories(alloc, memories_path),
+    );
+
+    try std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), memories_path);
+    try std.Io.Dir.createDirAbsolute(io_mod.getIo(), memories_path, .default_dir);
+    try std.testing.expectError(
+        error.MemoryStoreUnreadable,
+        loadMemories(alloc, memories_path),
+    );
 }
 
 test "memory owner preserves active output behavior" {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -806,6 +806,55 @@ describe("gateway stream lifecycle", () => {
     }
   }, 30_000);
 
+  test("memory save rejects a corrupt store without replacing it", async () => {
+    const root = createFixtureRoot("memory-corrupt-save");
+    const tracePath = join(root.root, "trace.log");
+    const memoriesPath = join(root.home, ".fx", "memories.json");
+    const corruptStore = '["recoverable prior memory",\n';
+    writeFileSync(memoriesPath, corruptStore);
+
+    const callId = "memory_corrupt_save_1";
+    const responses = [
+      fakeGatewayToolCall(callId, "memory", {
+        action: "save",
+        fact: "replacement memory",
+      }),
+      fakeGatewayFinalText("Corrupt memory store handled."),
+    ];
+    const gateway = startGateway(() =>
+      responses.shift() ?? new Response("unexpected request", { status: 500 })
+    );
+
+    try {
+      const result = await runFx(
+        ["ask", "--auto", "--json", "--no-save", "Save a memory."],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          timeoutMs: 15_000,
+        },
+      );
+      const json = parseAskJson(result.stdout);
+
+      expect(result.code).toBe(0);
+      expect(json.exit_code).toBe(0);
+      expect(json.error).toBeUndefined();
+      expect(json.output).toContain("Corrupt memory store handled.");
+      expect(json.tool_calls).toContainEqual({
+        name: "memory",
+        status: "error",
+      });
+      expect(gateway.requestCount()).toBe(2);
+      expect(toolResultOutput(gateway.requests[1]!.body, callId)).toContain(
+        "memory store is malformed; ~/.fx/memories.json was not modified",
+      );
+      expect(readFileSync(memoriesPath, "utf8")).toBe(corruptStore);
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test("ask keeps the GLM default model identity without enabling fast mode", async () => {
     const root = createFixtureRoot("default-model");
     const tracePath = join(root.root, "trace.log");


### PR DESCRIPTION
## Summary

- Treat only a missing memory store as empty; report malformed, oversized, and unreadable stores.
- Fail memory listing and saving closed while preserving the original bytes.
- Remove the non-atomic truncation fallback from memory saves.
- Add unit and built-binary regression coverage.

## Testing

- `zig fmt --check src/`
- `zig build`
- `zig build test`
- Focused corrupt-memory-store E2E regression
