### PR TITLE
Reduce native release binary size

### DIFF
--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -30,7 +30,7 @@ USE_FLAGS = (
     "-pgo-kind=pgo-instr-use-pipeline",
     "-pgo-cold-func-opt=minsize",
     "-profile-summary-cutoff-cold=600000",
-    "-passes=default<O2>",
+    "-passes=default<O2>,mergefunc,iroutliner",
 )
 
 BENCHMARK_USE_FLAGS = (
@@ -38,7 +38,7 @@ BENCHMARK_USE_FLAGS = (
     "-pgo-kind=pgo-instr-use-pipeline",
     "-pgo-cold-func-opt=minsize",
     "-profile-summary-cutoff-cold=990000",
-    "-passes=default<O2>",
+    "-passes=default<O2>,mergefunc,iroutliner",
 )
 
 CANDIDATE_SIGNING_PAGE_SIZE = 16 * 1024

--- a/scripts/pgso/tests/test_pipeline.py
+++ b/scripts/pgso/tests/test_pipeline.py
@@ -105,7 +105,7 @@ class PgsoPipelineTests(unittest.TestCase):
                 "-pgo-kind=pgo-instr-use-pipeline",
                 "-pgo-cold-func-opt=minsize",
                 "-profile-summary-cutoff-cold=600000",
-                "-passes=default<O2>",
+                "-passes=default<O2>,mergefunc,iroutliner",
             ),
             USE_FLAGS,
         )
@@ -115,7 +115,7 @@ class PgsoPipelineTests(unittest.TestCase):
                 "-pgo-kind=pgo-instr-use-pipeline",
                 "-pgo-cold-func-opt=minsize",
                 "-profile-summary-cutoff-cold=990000",
-                "-passes=default<O2>",
+                "-passes=default<O2>,mergefunc,iroutliner",
             ),
             BENCHMARK_USE_FLAGS,
         )
@@ -274,11 +274,13 @@ class PgsoPipelineTests(unittest.TestCase):
             candidate,
         )
 
-    def test_candidate_is_resigned_with_16k_pages_after_strip(self) -> None:
+    def test_candidate_object_and_signing_contract(self) -> None:
         actions = self.root / "candidate-actions.txt"
         artifact_tool = self.write_executable(
             "artifact-tool",
-            """import pathlib,sys
+            f"""import pathlib,sys
+with pathlib.Path({str(actions)!r}).open('a') as stream:
+    stream.write('artifact ' + ' '.join(sys.argv[1:]) + '\\n')
 output = pathlib.Path(sys.argv[sys.argv.index('-o') + 1])
 output.parent.mkdir(parents=True, exist_ok=True)
 output.write_bytes(b'artifact')""",
@@ -313,6 +315,15 @@ with pathlib.Path({str(actions)!r}).open('a') as stream:
 
         self.assertEqual(
             [
+                "artifact -S "
+                f"{self.paths.profile_use_bitcode} -o "
+                f"{self.paths.profile_use_ir}",
+                "artifact -filetype=obj -O=2 "
+                f"{self.paths.profile_use_bitcode} -o "
+                f"{self.paths.profile_use_object}",
+                "artifact cc -target aarch64-macos -O2 -Wl,-dead_strip -s "
+                f"{self.paths.profile_use_object} -o "
+                f"{self.paths.candidate_binary} -lc",
                 f"strip -S -x {self.paths.candidate_binary}",
                 "codesign --force --sign - --options linker-signed "
                 f"--pagesize 16384 {self.paths.candidate_binary}",

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -691,6 +691,43 @@ pub fn parseAuthorizationRedirect(
     return .{ .code = code, .state = state, .issuer = issuer };
 }
 
+fn encodeBase64UrlNoPad(output: []u8, input: []const u8) []const u8 {
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    const complete_groups = input.len / 3;
+    const remainder = input.len % 3;
+    const tail_len: usize = switch (remainder) {
+        0 => 0,
+        1 => 2,
+        2 => 3,
+        else => unreachable,
+    };
+    const encoded_len = complete_groups * 4 + tail_len;
+    std.debug.assert(output.len >= encoded_len);
+
+    var input_index: usize = 0;
+    var output_index: usize = 0;
+    while (input_index + 3 <= input.len) : (input_index += 3) {
+        const value = (@as(u24, input[input_index]) << 16) |
+            (@as(u24, input[input_index + 1]) << 8) |
+            input[input_index + 2];
+        output[output_index] = alphabet[(value >> 18) & 0x3f];
+        output[output_index + 1] = alphabet[(value >> 12) & 0x3f];
+        output[output_index + 2] = alphabet[(value >> 6) & 0x3f];
+        output[output_index + 3] = alphabet[value & 0x3f];
+        output_index += 4;
+    }
+    if (remainder != 0) {
+        const value = @as(u24, input[input_index]) << 16 |
+            (if (remainder == 2) @as(u24, input[input_index + 1]) << 8 else 0);
+        output[output_index] = alphabet[(value >> 18) & 0x3f];
+        output[output_index + 1] = alphabet[(value >> 12) & 0x3f];
+        if (remainder == 2) {
+            output[output_index + 2] = alphabet[(value >> 6) & 0x3f];
+        }
+    }
+    return output[0..encoded_len];
+}
+
 pub fn generatePkce(
     verifier_buf: *[64]u8,
     challenge_buf: *[43]u8,
@@ -698,11 +735,28 @@ pub fn generatePkce(
 ) struct { verifier: []const u8, challenge: []const u8 } {
     var entropy: [48]u8 = undefined;
     random.bytes(&entropy);
-    const verifier = std.base64.url_safe_no_pad.Encoder.encode(verifier_buf, &entropy);
+    const verifier = encodeBase64UrlNoPad(verifier_buf, &entropy);
     var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(verifier, &digest, .{});
-    const challenge = std.base64.url_safe_no_pad.Encoder.encode(challenge_buf, &digest);
+    const challenge = encodeBase64UrlNoPad(challenge_buf, &digest);
     return .{ .verifier = verifier, .challenge = challenge };
+}
+
+test "PKCE base64url encoding covers complete and partial groups" {
+    const cases = .{
+        .{ "", "" },
+        .{ "f", "Zg" },
+        .{ "fo", "Zm8" },
+        .{ "foo", "Zm9v" },
+        .{ &[_]u8{ 0xfb, 0xef, 0xff }, "--__" },
+    };
+    inline for (cases) |case| {
+        var output: [64]u8 = undefined;
+        try std.testing.expectEqualStrings(
+            case[1],
+            encodeBase64UrlNoPad(&output, case[0]),
+        );
+    }
 }
 
 pub fn bearerHeaderAlloc(alloc: Allocator, access_token: []const u8) ![]u8 {
@@ -1044,21 +1098,21 @@ fn authorizeWithRedirect(
     var verifier_entropy: [48]u8 = undefined;
     try io_mod.getIo().randomSecure(&verifier_entropy);
     var verifier_buf: [64]u8 = undefined;
-    const verifier = std.base64.url_safe_no_pad.Encoder.encode(
+    const verifier = encodeBase64UrlNoPad(
         &verifier_buf,
         &verifier_entropy,
     );
     var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(verifier, &digest, .{});
     var challenge_buf: [43]u8 = undefined;
-    const code_challenge = std.base64.url_safe_no_pad.Encoder.encode(
+    const code_challenge = encodeBase64UrlNoPad(
         &challenge_buf,
         &digest,
     );
     var state_entropy: [32]u8 = undefined;
     try io_mod.getIo().randomSecure(&state_entropy);
     var state_buf: [43]u8 = undefined;
-    const state = std.base64.url_safe_no_pad.Encoder.encode(
+    const state = encodeBase64UrlNoPad(
         &state_buf,
         &state_entropy,
     );

--- a/src/ui/subagent/runtime.zig
+++ b/src/ui/subagent/runtime.zig
@@ -744,6 +744,16 @@ pub const ChildRouteState = struct {
     presentation_diffs: std.ArrayList(diff_mod.DiffEntry) = .empty,
     presented_through_sequence: u64 = 0,
 
+    noinline fn init() ChildRouteState {
+        var result: ChildRouteState = .{
+            .editor = undefined,
+            .presentation = undefined,
+        };
+        result.editor = .{};
+        result.presentation = null;
+        return result;
+    }
+
     fn deinit(self: *ChildRouteState, alloc: Allocator) void {
         self.clear(alloc);
         self.pages.deinit(alloc);
@@ -883,7 +893,11 @@ pub const Runtime = struct {
     count_projection: usize = 0,
 
     pub noinline fn init() Runtime {
-        var result: Runtime = .{ .form = undefined };
+        var result: Runtime = .{
+            .child = undefined,
+            .form = undefined,
+        };
+        result.child = ChildRouteState.init();
         result.form = FormState.init();
         return result;
     }
@@ -3905,6 +3919,36 @@ test "repeated editor defaults are initialized through one runtime path" {
     for (runtime.form.editors) |editor| {
         try std.testing.expect(editor.slash_menu_categories);
     }
+}
+
+test "child route initializer preserves every runtime default" {
+    var child = ChildRouteState.init();
+    defer child.deinit(std.testing.allocator);
+
+    try std.testing.expect(child.chat == null);
+    try std.testing.expect(child.unavailable == null);
+    try std.testing.expectEqual(@as(usize, 0), child.pages.pages.items.len);
+    try std.testing.expect(child.editor.slash_menu_categories);
+    try std.testing.expectEqual(@as(usize, 0), child.scroll_from_bottom);
+    try std.testing.expectEqual(@as(usize, 0), child.max_scroll);
+    try std.testing.expect(child.invocation_id == null);
+    try std.testing.expectEqual(@as(u64, 0), child.identity_epoch);
+    try std.testing.expect(child.submission_failure == null);
+    try std.testing.expect(child.input_failure == null);
+    try std.testing.expect(child.paste_rejection == null);
+    try std.testing.expectEqual(@as(u64, 0), child.operation_counter);
+    try std.testing.expect(child.rendered_chat_rows == null);
+    try std.testing.expectEqual(ViewportMutation.none, child.viewport_mutation);
+    try std.testing.expect(child.presentation == null);
+    try std.testing.expectEqual(
+        transcript_presentation.Depth.inline_mode,
+        child.presentation_transcript_depth,
+    );
+    try std.testing.expect(child.presentation_live_work_id == null);
+    try std.testing.expectEqual(@as(usize, 0), child.presentation_live_event_count);
+    try std.testing.expectEqual(@as(u32, 1), child.presentation_next_diff_id);
+    try std.testing.expectEqual(@as(usize, 0), child.presentation_diffs.items.len);
+    try std.testing.expectEqual(@as(u64, 0), child.presented_through_sequence);
 }
 
 pub fn paint(


### PR DESCRIPTION
## Summary

- Apply profile-guided function merging and outlining to production and benchmark binaries.
- Encode fixed-size PKCE values without pulling generic Base64 machinery into the native executable.
- Initialize subagent route defaults through one shared runtime path.