### PR TITLE
Route Codex CLI images natively

### DIFF
--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -15,6 +15,7 @@ const process_supervisor = @import("../background/process_supervisor.zig");
 const context_contract = @import("../workspace/context_contract.zig");
 const devbox_executor = @import("../execution/devbox_executor.zig");
 const gateway_provider = @import("../gateway/gateway_provider.zig");
+const model_catalog = @import("../gateway/model_catalog.zig");
 const background_process_provider = @import(
     "../execution/background_process_provider.zig",
 );
@@ -224,6 +225,7 @@ pub const Config = struct {
     gateway_models_path: []const u8,
     gateway_provider: gateway_provider.Provider,
     codex_agent_stream: ?agent_stream_provider.Provider = null,
+    codex_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     secret_store: host.SecretStore,
@@ -1979,9 +1981,14 @@ fn reportUsage(raw_ctx: *anyopaque, usage: types.Usage) void {
 
 fn resolveModelCapabilities(raw_ctx: *anyopaque, _: Allocator, model: []const u8) model_capabilities.ResolveError!model_capabilities.Capabilities {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    const catalog = selectModelCatalog(
+        ctx.provider,
+        ctx.cfg.gateway_provider.model_catalog,
+        ctx.cfg.codex_model_catalog,
+    ) orelse return model_capabilities.capabilitiesForModel(model);
     return ctx.capability_resolver.resolve(
         ctx.alloc,
-        ctx.cfg.gateway_provider.model_catalog,
+        catalog,
         .{
             .access = ctx.model_catalog_access,
             .endpoint = ctx.cfg.gateway_models_path,
@@ -1991,9 +1998,48 @@ fn resolveModelCapabilities(raw_ctx: *anyopaque, _: Allocator, model: []const u8
     );
 }
 
+fn selectModelCatalog(
+    provider: model_provider.ProviderId,
+    gateway: model_catalog.Provider,
+    codex: ?model_catalog.Provider,
+) ?model_catalog.Provider {
+    return switch (provider) {
+        .gateway => gateway,
+        .codex => codex,
+    };
+}
+
 fn availableModelCapabilities(raw_ctx: *anyopaque, model: []const u8) model_capabilities.Capabilities {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
     return ctx.capability_resolver.available(model);
+}
+
+test "provider catalog selection never falls back across origins" {
+    var gateway_tag: u8 = 0;
+    var codex_tag: u8 = 0;
+    var gateway = test_builtin_gateway.model_catalog_provider;
+    gateway.context = &gateway_tag;
+    var codex = test_builtin_gateway.model_catalog_provider;
+    codex.context = &codex_tag;
+    const cases = [_]struct {
+        provider: model_provider.ProviderId,
+        codex: ?model_catalog.Provider,
+        expected_context: ?*anyopaque,
+    }{
+        .{ .provider = .gateway, .codex = codex, .expected_context = &gateway_tag },
+        .{ .provider = .codex, .codex = codex, .expected_context = &codex_tag },
+        .{ .provider = .codex, .codex = null, .expected_context = null },
+    };
+
+    for (cases) |case| {
+        const selected = selectModelCatalog(case.provider, gateway, case.codex);
+        if (case.expected_context) |expected| {
+            try std.testing.expect(selected != null);
+            try std.testing.expect(selected.?.context.? == expected);
+        } else {
+            try std.testing.expect(selected == null);
+        }
+    }
 }
 
 fn finalizeTurn(raw_ctx: *anyopaque, turn_id: u64, outcome: types.TurnPresentationOutcome, disposition: ?types.ProviderCompletionDisposition) !void {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -2857,6 +2857,7 @@ fn workflowConfig(cfg: Config) @import("cli_ask.zig").Config {
         .gateway_models_path = cfg.models_path,
         .gateway_provider = cfg.gateway_provider,
         .codex_agent_stream = cfg.codex_agent_stream,
+        .codex_model_catalog = cfg.codex_model_catalog,
         .background_process_provider = cfg.background_process_provider,
         .secret_store = cfg.secret_store,
         .prompt_policy = cfg.prompt_policy,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1560,6 +1560,33 @@ test(
       expect(request.headers.get("authorization")).not.toBe(`Bearer ${chatgptOauth.accessToken}`);
     }
 
+    const gatewayRequestsBeforeImage = gateway.requests.length;
+    const gatewayModelRequestsBeforeImage = gateway.modelRequests.length;
+    const imageAsk = await runFx([
+      "ask",
+      "--json",
+      "--auto",
+      "--no-save",
+      "--image",
+      join(REPO_ROOT, "tests/e2e/fixtures/favicon.png"),
+      "Read the attached image directly.",
+    ], {
+      env,
+      timeoutMs: TIMEOUT,
+    });
+    expect(imageAsk.code, `stdout: ${imageAsk.stdout}\nstderr: ${imageAsk.stderr}`).toBe(0);
+    expect(imageAsk.stdout).toContain("CHATGPT_DIRECT_RESPONSE");
+    const imageResponses = chatgptOauth.requests.filter(
+      (request) => request.path === "/chatgpt/responses",
+    );
+    expect(imageResponses).toHaveLength(3);
+    const imageBody = imageResponses[2]!.body ?? "";
+    expect(imageBody.match(/"type":"input_image"/g)).toHaveLength(1);
+    expect(imageBody).toContain("data:image/png;base64,");
+    expect(imageBody).not.toContain('"name":"vision"');
+    expect(gateway.requests).toHaveLength(gatewayRequestsBeforeImage);
+    expect(gateway.modelRequests).toHaveLength(gatewayModelRequestsBeforeImage);
+
     const tokenRequestsBeforeRoundTrip = chatgptOauth.requests.filter(
       (request) => request.path === "/chatgpt/token",
     ).length;


### PR DESCRIPTION
## Summary

- Resolve one-shot image capabilities through the selected provider catalog.
- Send verified fx ask images to Codex as native input_image parts without contacting Gateway.
- Preserve the existing Gateway vision fallback and CLI behavior.

Follow-up to #226.