### PR TITLE
Recover canonical sessions past zero-turn entries (FXC-227)

### DIFF
--- a/benchmarks/session_list_fixture.py
+++ b/benchmarks/session_list_fixture.py
@@ -39,6 +39,7 @@ def generate(home: Path, workspace: Path, count: int, log_size: int, deny_event_
         session_id = f"benchmark-session-{index:02d}"
         authority_id = f"{index + 1:032x}"
         generation = f"{index + 101:032x}"
+        event_seq = max(2, index + 1)
         session_dir = sessions_root / session_id
         session_dir.mkdir(mode=0o700)
 
@@ -69,7 +70,7 @@ def generate(home: Path, workspace: Path, count: int, log_size: int, deny_event_
                 "schema_version": 1,
                 "session_id": session_id,
                 "log_generation": generation,
-                "through_seq": 1,
+                "through_seq": event_seq,
                 "through_event_id": f"{index + 201:032x}",
                 "through_event_log_bytes": log_size,
             },
@@ -92,7 +93,7 @@ def generate(home: Path, workspace: Path, count: int, log_size: int, deny_event_
                 "history_len": index,
                 "total_input_tokens": 0,
                 "total_output_tokens": 0,
-                "last_event_seq": 1,
+                "last_event_seq": event_seq,
                 "event_log_bytes": log_size,
                 "event_log_stat_fingerprint": stat_fingerprint(event_log, log_size),
                 "generation_base_seq": 1,

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -398,8 +398,6 @@ pub const SessionPicker = struct {
         alloc: Allocator,
         source: *const session_store.SessionSummary,
     ) !void {
-        if (source.history_len == 0 and !source.has_managed_children) return;
-
         var summary = try session_summary_codec.cloneSessionSummary(alloc, source.*);
         errdefer summary.deinit(alloc);
         try self.summaries.append(alloc, summary);
@@ -592,7 +590,6 @@ fn replaceSessionPickerPage(
         replacement.deinit(alloc);
     }
     for (source.summaries.items) |*summary| {
-        if (summary.history_len == 0 and !summary.has_managed_children) continue;
         var copied = try session_summary_codec.cloneSessionSummary(alloc, summary.*);
         replacement.append(alloc, copied) catch |err| {
             copied.deinit(alloc);
@@ -1151,13 +1148,6 @@ pub fn Runtime(comptime App: type) type {
                     .{@tagName(admission.view)},
                 ),
                 .exact, .older => |view| {
-                    switch (requested) {
-                        .last => app.requested_resume = .{ .id = app.alloc.dupe(u8, view.session_id) catch |err| {
-                            traceResumeViewUnavailable(err);
-                            return .none;
-                        } },
-                        .pick, .id => {},
-                    }
                     const freshness = std.meta.activeTag(admission.view);
                     const paint_safe = freshness == .exact and view.capture.canPaintAt(
                         app.shell.layout.rows,
@@ -1627,17 +1617,13 @@ pub fn Runtime(comptime App: type) type {
                 var admission = saved;
                 app.session_persistence.resume_view_admission = null;
                 defer admission.deinit(app.alloc);
-                const session_id = switch (resume_target) {
-                    .id => |id| id,
-                    .last => return error.SessionTargetChanged,
-                };
                 const store = app.session_persistence.store orelse
                     return error.SessionStoreUnavailable;
                 break :admitted try subagent_resume_admission.resumeAdmittedForExternalPrompt(
                     store,
                     app.alloc,
                     &admission,
-                    session_id,
+                    resume_target,
                     app.workspace_root,
                     .{ .seed_preferences = app.session_persistence.workspace_preferences },
                 );
@@ -4371,11 +4357,12 @@ pub fn Runtime(comptime App: type) type {
                     .{ loaded.active_id, @errorName(err) },
                 );
             };
+            const pristine = session_store.isPristineStartedSession(loaded);
             const should_create_handoff = resume_boundary_valid and
                 shouldCreateResumeHandoff(.{
                     .intent = handoff_intent,
                     .has_writable_session = true,
-                    .is_pristine = session_store.isPristineStartedSession(loaded),
+                    .is_pristine = pristine,
                     .has_unresolved_degraded_tail = loaded.degradedTail() != null,
                 });
             const handoff: ?ResumeHandoff = if (should_create_handoff) blk: {
@@ -4404,6 +4391,13 @@ pub fn Runtime(comptime App: type) type {
                 app.session.clearWebFetchArtifacts();
             }
             disableSubagentHost(app);
+            if (pristine) {
+                if (app.session_persistence.store) |store| {
+                    _ = store.discardPristineStartedSession(app.alloc, loaded);
+                    app.session_persistence.writable = null;
+                    return handoff;
+                }
+            }
             loaded.deinit(app.alloc);
             app.session_persistence.writable = null;
             return handoff;
@@ -7251,7 +7245,7 @@ test "execution replay keeps failed and unpaired persisted results visible witho
     );
 }
 
-test "safe last resume view paints and pins authoritative resume to its session id" {
+test "safe last resume view paints and retains authoritative last admission" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -7296,8 +7290,8 @@ test "safe last resume view paints and pins authoritative resume to its session 
 
     try std.testing.expectEqualStrings("cached transcript\n", app.shell.transcript.items);
     switch (app.requested_resume.?) {
-        .id => |session_id| try std.testing.expectEqualStrings("cached-session", session_id),
-        .pick, .last => return error.TestExpectedPinnedResumeSession,
+        .last => {},
+        .pick, .id => return error.TestExpectedPinnedResumeSession,
     }
     try std.testing.expectError(
         error.SessionBusy,
@@ -9041,6 +9035,14 @@ test "session picker owns non-current session summaries" {
         &history,
         0,
     );
+    const eventful_id = "eventful-zero-history";
+    try writeSessionFixture(
+        alloc,
+        app.session_persistence.store.?,
+        eventful_id,
+        &.{},
+        0,
+    );
     try Runtime(TestApp).beginFreshPersistedSession(&app);
     const active_id = app.session_persistence.writable.?.active_id;
 
@@ -9050,11 +9052,16 @@ test "session picker owns non-current session summaries" {
 
     const picker = &app.session_persistence.session_picker;
     try std.testing.expect(picker.active);
-    try std.testing.expectEqual(@as(usize, 1), picker.summaries.items.len);
+    try std.testing.expectEqual(@as(usize, 2), picker.summaries.items.len);
     try std.testing.expectEqualStrings(prior_id, picker.selectedId().?);
     try std.testing.expect(!std.mem.eql(u8, picker.selectedId().?, active_id));
     try std.testing.expectEqualStrings("saved prompt", picker.summaries.items[0].title.?);
     try std.testing.expectEqualStrings(paths.workspace, picker.summaries.items[0].workspace_root.?);
+    var found_eventful = false;
+    for (picker.summaries.items) |summary| {
+        if (std.mem.eql(u8, summary.id, eventful_id)) found_eventful = true;
+    }
+    try std.testing.expect(found_eventful);
 
     Runtime(TestApp).cancelSessionPicker(&app);
     try std.testing.expect(!picker.active);
@@ -9303,25 +9310,6 @@ test "session picker current mode filters workspace and all mode includes every 
     }
     try std.testing.expect(found_workspace_a);
     try std.testing.expect(found_workspace_b);
-}
-
-test "session picker excludes empty sessions and reports loading" {
-    const alloc = std.testing.allocator;
-    var picker: SessionPicker = .{ .active = true, .load_state = .loading };
-    defer picker.deinit(alloc);
-
-    try std.testing.expect(picker.isLoading());
-    var empty_summary = session_store.SessionSummary{
-        .id = try alloc.dupe(u8, "empty-session"),
-        .created_at_ms = 0,
-        .updated_at_ms = 0,
-        .conversation_language = session_runtime.ConversationLanguage.literal("en"),
-        .history_len = 0,
-    };
-    defer empty_summary.deinit(alloc);
-    try picker.appendSummary(alloc, &empty_summary);
-
-    try std.testing.expectEqual(@as(usize, 0), picker.summaries.items.len);
 }
 
 test "session picker navigation clamps at both ends instead of wrapping" {

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -1442,7 +1442,7 @@ fn runNonInteractiveWithDeps(
 
             switch (target) {
                 .last => {
-                    var summary = store.latestReadOnlyWorkspaceSummary(alloc) catch |err| {
+                    var summary = store.latestResumableWorkspaceSummary(alloc) catch |err| {
                         try writeLookupFailure(alloc, deps, "session", err, opts.format);
                         return .handled_failure;
                     };

--- a/src/core/session/session_discovery.zig
+++ b/src/core/session/session_discovery.zig
@@ -50,12 +50,6 @@ const DiscoveryOutcome = enum {
     skipped,
 };
 
-pub const DiscoveryCandidateMetadata = struct {
-    id: []const u8,
-    storage: CandidateStorage,
-    projection_state: ProjectionState,
-};
-
 pub const ReadOnlyCandidate = struct {
     summary: SessionSummary,
     storage: CandidateStorage,
@@ -71,8 +65,29 @@ pub const WritableCandidate = struct {
     id: []u8,
     workspace_root: []u8,
     updated_at_ms: i64,
+    history_len: usize,
+    is_resume_candidate: bool,
     storage: CandidateStorage,
     projection_state: ProjectionState,
+
+    pub fn isResumable(self: WritableCandidate) bool {
+        return self.history_len != 0 or self.is_resume_candidate;
+    }
+
+    pub fn resumeRank(
+        self: WritableCandidate,
+        preferred_id: ?[]const u8,
+    ) ResumeCandidateRank {
+        return .{
+            .id = self.id,
+            .updated_at_ms = self.updated_at_ms,
+            .resumable = self.isResumable(),
+            .preferred_pointer = if (preferred_id) |id|
+                std.mem.eql(u8, self.id, id)
+            else
+                false,
+        };
+    }
 
     pub fn deinit(self: *WritableCandidate, alloc: Allocator) void {
         alloc.free(self.id);
@@ -91,6 +106,10 @@ const LegacyCandidateSummary = struct {
     schema_version: session_json.LegacySchemaVersion = .v1,
 
     fn intoSessionSummary(self: *LegacyCandidateSummary) SessionSummary {
+        // Legacy snapshots cannot distinguish a pristine start from a
+        // zero-history session with durable activity. Preserve zero-history
+        // legacy sessions conservatively; schema-v3 projections can prove the
+        // pristine case from their event sequence.
         const summary = SessionSummary{
             .id = self.id,
             .workspace_root = self.workspace_root,
@@ -98,6 +117,7 @@ const LegacyCandidateSummary = struct {
             .updated_at_ms = self.updated_at_ms,
             .conversation_language = self.conversation_language,
             .history_len = self.history_len,
+            .has_durable_activity = self.history_len == 0,
         };
         self.id = undefined;
         self.workspace_root = null;
@@ -110,6 +130,22 @@ const LegacyCandidateSummary = struct {
         self.* = undefined;
     }
 };
+
+test "legacy zero-history summaries remain conservatively resumable" {
+    const alloc = std.testing.allocator;
+    var legacy = LegacyCandidateSummary{
+        .id = try alloc.dupe(u8, "legacy-zero-history"),
+        .workspace_root = try alloc.dupe(u8, "/tmp/workspace"),
+        .created_at_ms = 1,
+        .updated_at_ms = 2,
+        .conversation_language = session.ConversationLanguage.literal("en"),
+        .history_len = 0,
+    };
+    var summary = legacy.intoSessionSummary();
+    defer summary.deinit(alloc);
+
+    try std.testing.expect(summary.has_durable_activity);
+}
 
 /// Frees every diagnostic in the list and the list itself. Call once on the
 /// slice returned by `Store.inspectForDoctor`.
@@ -602,6 +638,7 @@ pub fn classifySchemaV3Candidate(
             .updated_at_ms = manifest.updated_at_ms,
             .conversation_language = manifest.conversation_language,
             .history_len = history_len,
+            .has_durable_activity = manifest.last_event_seq > 1,
         },
         .storage = .schema_v3,
         .projection_state = projection_state,
@@ -682,6 +719,8 @@ pub fn dupeWritableCandidate(
     id_source: []const u8,
     workspace_source: []const u8,
     updated_at_ms: i64,
+    history_len: usize,
+    is_resume_candidate: bool,
     storage: CandidateStorage,
     projection_state: ProjectionState,
 ) !WritableCandidate {
@@ -692,6 +731,8 @@ pub fn dupeWritableCandidate(
         .id = id,
         .workspace_root = workspace_root,
         .updated_at_ms = updated_at_ms,
+        .history_len = history_len,
+        .is_resume_candidate = is_resume_candidate,
         .storage = storage,
         .projection_state = projection_state,
     };
@@ -716,14 +757,31 @@ pub fn storageFormatForLegacy(
     };
 }
 
-/// Orders writable candidates: newer `updated_at_ms` wins, ties broken by
-/// descending id. Used to select the most recent writable session.
-pub fn writableCandidateNewer(
-    candidate: WritableCandidate,
-    current: WritableCandidate,
+pub const ResumeCandidateRank = struct {
+    id: []const u8,
+    updated_at_ms: i64,
+    resumable: bool,
+    preferred_pointer: bool,
+};
+
+/// Orders `last` candidates. Resumable sessions outrank pristine sessions;
+/// recency wins within that class, with the latest pointer breaking ties. The
+/// pointer remains authoritative when every candidate is pristine.
+pub fn resumeCandidateOutranks(
+    candidate: ResumeCandidateRank,
+    current: ResumeCandidateRank,
 ) bool {
+    if (candidate.resumable != current.resumable) return candidate.resumable;
+    if (!candidate.resumable and
+        candidate.preferred_pointer != current.preferred_pointer)
+    {
+        return candidate.preferred_pointer;
+    }
     if (candidate.updated_at_ms != current.updated_at_ms) {
         return candidate.updated_at_ms > current.updated_at_ms;
+    }
+    if (candidate.preferred_pointer != current.preferred_pointer) {
+        return candidate.preferred_pointer;
     }
     return std.mem.order(u8, candidate.id, current.id) == .gt;
 }

--- a/src/core/session/session_latest_pointer.zig
+++ b/src/core/session/session_latest_pointer.zig
@@ -289,6 +289,7 @@ pub const LatestCache = struct {
         }
         if (self.prior_index) |*index| {
             var summary = try summaryFromState(alloc, state);
+            summary.has_durable_activity = position.through_seq > 1;
             var summary_owned = true;
             errdefer if (summary_owned) summary.deinit(alloc);
             try summary_codec.preserveIndexedDisplayMetadata(alloc, index.items, &summary);

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -43,9 +43,9 @@ const readExactLegacyFile = authority_module.readExactLegacyFile;
 const requireAuthorityFenceAbsent = authority_module.requireAuthorityFenceAbsent;
 const requireAuthorityTransitionSession = authority_module.requireAuthorityTransitionSession;
 const restoreLegacyAuthority = authority_module.restoreLegacyAuthority;
-const DiscoveryCandidateMetadata = discovery.DiscoveryCandidateMetadata;
 const DiscoveryMode = discovery.DiscoveryMode;
 const ReadOnlyCandidate = discovery.ReadOnlyCandidate;
+const ResumeCandidateRank = discovery.ResumeCandidateRank;
 const WritableCandidate = discovery.WritableCandidate;
 const appendDoctorDiagnostic = discovery.appendDoctorDiagnostic;
 const classifyLegacyCandidate = discovery.classifyLegacyCandidate;
@@ -56,9 +56,9 @@ const freeDoctorDiagnostics = discovery.freeDoctorDiagnostics;
 const inspectDoctorSession = discovery.inspectDoctorSession;
 const logDiscovery = discovery.logDiscovery;
 const logDiscoveryError = discovery.logDiscoveryError;
+const resumeCandidateOutranks = discovery.resumeCandidateOutranks;
 const storageFormatForLegacy = discovery.storageFormatForLegacy;
 const summaryFromState = discovery.summaryFromState;
-const writableCandidateNewer = discovery.writableCandidateNewer;
 const InitialIndexEffect = latest_pointer.InitialIndexEffect;
 const LatestCache = latest_pointer.LatestCache;
 const LatestPointer = latest_pointer.LatestPointer;
@@ -314,6 +314,7 @@ const removeSessionIndexMarker = summary_codec.removeSessionIndexMarker;
 const resumablePageFromSummaries = summary_codec.resumablePageFromSummaries;
 const sessionListPageFromSummaries = summary_codec.sessionListPageFromSummaries;
 const sortSummariesNewestFirst = summary_codec.sortSummariesNewestFirst;
+const summaryIsResumable = summary_codec.summaryIsResumable;
 const writeSessionIndex = summary_codec.writeSessionIndex;
 
 const SessionSummaryScan = struct {
@@ -456,6 +457,21 @@ fn summaryNeedsDisplayMetadata(summary: SessionSummary) bool {
     if (summary.history_len == 0) return false;
     if (!summary.display_metadata_present) return true;
     return summary.title == null;
+}
+
+fn resumeRankForSummary(
+    summary: SessionSummary,
+    preferred_id: ?[]const u8,
+) ResumeCandidateRank {
+    return .{
+        .id = summary.id,
+        .updated_at_ms = summary.updated_at_ms,
+        .resumable = summaryIsResumable(summary),
+        .preferred_pointer = if (preferred_id) |id|
+            std.mem.eql(u8, summary.id, id)
+        else
+            false,
+    };
 }
 
 fn initialIndexEffect(state: session_codec.DurableSessionState) InitialIndexEffect {
@@ -863,6 +879,27 @@ pub const Store = struct {
             );
             return .retained;
         }
+        const has_managed_children = self.sessionHasManagedChildrenConservative(
+            alloc,
+            loaded.active_id,
+        ) catch |err| {
+            loaded.deinit(alloc);
+            debug_trace.logf(
+                "session",
+                "event=pristine_session_discard disposition=retained reason=child_probe_failed err={s}",
+                .{@errorName(err)},
+            );
+            return .retained;
+        };
+        if (has_managed_children) {
+            loaded.deinit(alloc);
+            debug_trace.logf(
+                "session",
+                "event=pristine_session_discard disposition=retained reason=managed_children",
+                .{},
+            );
+            return .retained;
+        }
         return self.deleteWriterOwnedSession(
             alloc,
             loaded,
@@ -1011,21 +1048,12 @@ pub const Store = struct {
         return switch (target) {
             .id => |id| try root.admitResumeView(alloc, id),
             .last => blk: {
-                if (self.deferredCacheInvalidatesReads()) {
-                    var latest = try self.latestReadOnlyWorkspaceSummary(alloc);
-                    defer latest.deinit(alloc);
-                    break :blk try root.admitResumeView(
-                        alloc,
-                        latest.id,
-                    );
-                }
-                var latest = (try readLatestPointer(self, alloc, self.workspace_root)) orelse
-                    return null;
+                var latest = self.latestResumableWorkspaceSummary(alloc) catch |err| switch (err) {
+                    error.NoSavedSessions => return null,
+                    else => return err,
+                };
                 defer latest.deinit(alloc);
-                break :blk try root.admitResumeView(
-                    alloc,
-                    latest.session_id,
-                );
+                break :blk try root.admitResumeView(alloc, latest.id);
             },
         };
     }
@@ -1058,14 +1086,20 @@ pub const Store = struct {
         self: Store,
         alloc: Allocator,
         admission: *ResumeViewAdmission,
-        expected_session_id: []const u8,
+        target: ResumeTarget,
         workspace_root: []const u8,
         options: ResumeOptions,
     ) !LoadedWritableSession {
         try validateWorkspaceRoot(workspace_root);
-        if (!std.mem.eql(u8, admission.sessionId(), expected_session_id)) {
-            return error.SessionTargetChanged;
-        }
+        const repair_latest = switch (target) {
+            .id => |expected_session_id| blk: {
+                if (!std.mem.eql(u8, admission.sessionId(), expected_session_id)) {
+                    return error.SessionTargetChanged;
+                }
+                break :blk false;
+            },
+            .last => true,
+        };
         const loaded = try admission.resumeForWrite(alloc, options.log);
         const rebound = try self.finishWorkspaceResume(
             alloc,
@@ -1074,7 +1108,23 @@ pub const Store = struct {
             true,
             options,
         );
-        return self.finishResumedForWrite(alloc, rebound, options);
+        var finished = try self.finishResumedForWrite(alloc, rebound, options);
+        errdefer finished.deinit(alloc);
+        if (repair_latest) {
+            self.repairSelectedLatestPointer(
+                alloc,
+                finished.state,
+                finished.position,
+                options.log,
+            ) catch |err| {
+                debug_trace.logf(
+                    "session",
+                    "event=admitted_resume_latest_repair_failed err={s}",
+                    .{@errorName(err)},
+                );
+            };
+        }
+        return finished;
     }
 
     fn finishResumedForWrite(
@@ -1191,7 +1241,41 @@ pub const Store = struct {
                     loaded.deinit(alloc);
                     return err;
                 };
-                if (still_matches) return loaded;
+                if (still_matches) {
+                    var preferred = self.latestResumableWorkspaceSummaryFor(
+                        alloc,
+                        workspace_root,
+                    ) catch |err| {
+                        loaded.deinit(alloc);
+                        return err;
+                    };
+                    defer preferred.deinit(alloc);
+                    if (std.mem.eql(u8, preferred.id, loaded.active_id)) {
+                        return loaded;
+                    }
+                    loaded.deinit(alloc);
+                    var recovered = try self.resumeExactForWrite(
+                        alloc,
+                        preferred.id,
+                        workspace_root,
+                        false,
+                        options,
+                    );
+                    errdefer recovered.deinit(alloc);
+                    self.repairSelectedLatestPointer(
+                        alloc,
+                        recovered.state,
+                        recovered.position,
+                        options.log,
+                    ) catch |err| {
+                        debug_trace.logf(
+                            "session",
+                            "event=latest_cache_repair_failed err={s}",
+                            .{@errorName(err)},
+                        );
+                    };
+                    return recovered;
+                }
             }
             loaded.deinit(alloc);
         }
@@ -1311,7 +1395,7 @@ pub const Store = struct {
             options,
         );
         errdefer loaded.deinit(alloc);
-        self.repairLatestPointer(
+        self.repairSelectedLatestPointer(
             alloc,
             loaded.state,
             loaded.position,
@@ -1729,6 +1813,65 @@ pub const Store = struct {
         );
     }
 
+    fn repairSelectedLatestPointer(
+        self: Store,
+        alloc: Allocator,
+        state: session_codec.DurableSessionState,
+        position: session_log.CommitPosition,
+        options: session_log.Options,
+    ) !void {
+        var current = (readLatestPointer(
+            self,
+            alloc,
+            state.workspace_root,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return self.repairLatestPointer(
+                alloc,
+                state,
+                position,
+                options,
+            ),
+        }) orelse return self.repairLatestPointer(
+            alloc,
+            state,
+            position,
+            options,
+        );
+        defer current.deinit(alloc);
+        if (std.mem.eql(u8, current.session_id, state.id)) {
+            return self.repairLatestPointer(
+                alloc,
+                state,
+                position,
+                options,
+            );
+        }
+        const current_resumable = self.sessionIdIsResumable(
+            alloc,
+            current.session_id,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => false,
+        };
+        if (current_resumable) {
+            return self.repairLatestPointer(
+                alloc,
+                state,
+                position,
+                options,
+            );
+        }
+        return self.publishRecoveredLatestPointer(
+            alloc,
+            state,
+            position,
+            current.session_id,
+            options,
+            true,
+        );
+    }
+
     fn publishRecoveredLatestPointer(
         self: Store,
         alloc: Allocator,
@@ -1736,6 +1879,7 @@ pub const Store = struct {
         position: session_log.CommitPosition,
         source_session_id: []const u8,
         options: session_log.Options,
+        resumable_baseline_only: bool,
     ) !void {
         const sessions = &(self.canonical_root.sessions orelse
             return error.SessionStoreUnavailable);
@@ -1747,14 +1891,19 @@ pub const Store = struct {
             try options.test_controls.boundary(
                 .after_recovery_latest_snapshot,
             );
-            var discovered_latest: ?SessionSummary =
+            var discovered_latest: ?SessionSummary = (if (resumable_baseline_only)
+                self.latestResumableWorkspaceSummaryFor(
+                    alloc,
+                    state.workspace_root,
+                )
+            else
                 self.latestReadOnlyWorkspaceSummaryFor(
                     alloc,
                     state.workspace_root,
-                ) catch |err| switch (err) {
-                    error.NoSavedSessions => null,
-                    else => return err,
-                };
+                )) catch |err| switch (err) {
+                error.NoSavedSessions => null,
+                else => return err,
+            };
             defer if (discovered_latest) |*summary| summary.deinit(alloc);
             self.publishLatestPointer(
                 alloc,
@@ -1829,8 +1978,18 @@ pub const Store = struct {
                     self.sessions_dir,
                     session_id,
                 );
+                var summary = try summaryFromState(alloc, state);
+                errdefer summary.deinit(alloc);
+                summary.has_durable_activity = if (state.history.len != 0)
+                    true
+                else
+                    try self.sessionHasDurableActivityConservative(
+                        alloc,
+                        session_id,
+                        options.log,
+                    );
                 return .{
-                    .summary = try summaryFromState(alloc, state),
+                    .summary = summary,
                     .state = state,
                     .storage_format = .schema_v3,
                 };
@@ -2254,7 +2413,7 @@ pub const Store = struct {
                 .workspace_root = workspace_root,
                 .continuation = continuation,
                 .limit = limit,
-                .resumable_only = false,
+                .resumable_only = true,
             }) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 else => null,
@@ -2273,7 +2432,7 @@ pub const Store = struct {
             }
         }
 
-        var scan = self.scanSessionSummariesWithDiagnostics(alloc, .read_only_list, false) catch |err| switch (err) {
+        var scan = self.scanSessionSummariesWithDiagnostics(alloc, .read_only_list, true) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             else => return error.SessionStoreUnavailable,
         };
@@ -2695,6 +2854,15 @@ pub const Store = struct {
         if (summaries.items.len == 0) return error.NoSavedSessions;
         const latest = summaries.orderedRemove(0);
         for (summaries.items) |*summary| summary.deinit(alloc);
+        logDiscovery(
+            .global_read_only_last,
+            latest.id,
+            null,
+            null,
+            .listable,
+            .selected,
+            null,
+        );
         return latest;
     }
 
@@ -2710,25 +2878,87 @@ pub const Store = struct {
         );
     }
 
+    pub fn latestResumableWorkspaceSummary(
+        self: Store,
+        alloc: Allocator,
+    ) !SessionSummary {
+        return self.latestResumableWorkspaceSummaryFor(
+            alloc,
+            self.workspace_root,
+        );
+    }
+
     fn latestReadOnlyWorkspaceSummaryFor(
         self: Store,
         alloc: Allocator,
         workspace_root: []const u8,
+    ) !SessionSummary {
+        return self.latestWorkspaceSummaryFor(alloc, workspace_root, false);
+    }
+
+    fn latestResumableWorkspaceSummaryFor(
+        self: Store,
+        alloc: Allocator,
+        workspace_root: []const u8,
+    ) !SessionSummary {
+        return self.latestWorkspaceSummaryFor(alloc, workspace_root, true);
+    }
+
+    fn latestWorkspaceSummaryFor(
+        self: Store,
+        alloc: Allocator,
+        workspace_root: []const u8,
+        resumable_only: bool,
     ) !SessionSummary {
         var scan = try self.scanSessionSummariesWithDiagnostics(
             alloc,
             .global_read_only_last,
             true,
         );
-        defer scan.summaries.deinit(alloc);
+        defer scan.deinit(alloc);
         retainWorkspaceSummaries(alloc, &scan.summaries, workspace_root);
         if (scan.summaries.items.len == 0) {
             if (scan.skipped_invalid > 0) return error.NoReadableSessions;
             return error.NoSavedSessions;
         }
-        const latest = scan.summaries.orderedRemove(0);
-        for (scan.summaries.items) |*summary| summary.deinit(alloc);
-        return latest;
+        var selected_index: usize = 0;
+        if (resumable_only) {
+            var pointer = readLatestPointer(
+                self,
+                alloc,
+                workspace_root,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => null,
+            };
+            defer if (pointer) |*value| value.deinit(alloc);
+
+            const preferred_id = if (pointer) |value| value.session_id else null;
+            var selected_rank = resumeRankForSummary(
+                scan.summaries.items[0],
+                preferred_id,
+            );
+            for (scan.summaries.items[1..], 1..) |summary, index| {
+                const candidate_rank = resumeRankForSummary(
+                    summary,
+                    preferred_id,
+                );
+                if (!resumeCandidateOutranks(candidate_rank, selected_rank)) continue;
+                selected_index = index;
+                selected_rank = candidate_rank;
+            }
+        }
+        const selected = scan.summaries.orderedRemove(selected_index);
+        logDiscovery(
+            .global_read_only_last,
+            selected.id,
+            null,
+            null,
+            .listable,
+            .selected,
+            null,
+        );
+        return selected;
     }
 
     fn scanSessionSummaries(
@@ -2755,8 +2985,6 @@ pub const Store = struct {
         errdefer scan.deinit(alloc);
         var replay_scope = self.loadDeferredReplayScope(alloc);
         defer replay_scope.deinit(alloc);
-        var metadata: std.ArrayList(DiscoveryCandidateMetadata) = .empty;
-        defer metadata.deinit(alloc);
         if (self.canonical_root.sessions == null) return scan;
         var iter = self.canonical_root.sessions.?.dir.iterate();
         while (try iter.next(io_mod.getIo())) |entry| {
@@ -2828,7 +3056,11 @@ pub const Store = struct {
                             candidate.deinit(alloc);
                             return error.OutOfMemory;
                         },
-                        else => false,
+                        error.FileNotFound => false,
+                        // Legacy fixtures and snapshots predate the private
+                        // managed-child layout. Preserve their historical
+                        // history-based classification on capability errors.
+                        else => candidate.storage == .schema_v3,
                     };
             }
             logDiscovery(
@@ -2840,14 +3072,6 @@ pub const Store = struct {
                 .retained,
                 null,
             );
-            metadata.append(alloc, .{
-                .id = candidate.summary.id,
-                .storage = candidate.storage,
-                .projection_state = candidate.projection_state,
-            }) catch |err| {
-                candidate.deinit(alloc);
-                return err;
-            };
             scan.summaries.append(alloc, candidate.summary) catch |err| {
                 candidate.deinit(alloc);
                 return err;
@@ -2855,23 +3079,6 @@ pub const Store = struct {
             candidate.summary = undefined;
         }
         sortSummariesNewestFirst(scan.summaries.items);
-        if (mode == .global_read_only_last and scan.summaries.items.len > 0) {
-            for (metadata.items) |candidate| {
-                if (!std.mem.eql(u8, candidate.id, scan.summaries.items[0].id)) {
-                    continue;
-                }
-                logDiscovery(
-                    mode,
-                    candidate.id,
-                    candidate.storage,
-                    candidate.projection_state,
-                    .listable,
-                    .selected,
-                    null,
-                );
-                break;
-            }
-        }
         return scan;
     }
 
@@ -3248,6 +3455,116 @@ pub const Store = struct {
         return loaded;
     }
 
+    fn sessionHasManagedChildrenConservative(
+        self: Store,
+        alloc: Allocator,
+        session_id: []const u8,
+    ) !bool {
+        return self.sessionHasManagedChildren(alloc, session_id) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.FileNotFound => false,
+            // An unreadable child index cannot prove that a zero-turn parent is
+            // disposable. Retain it until doctor can classify the payload.
+            else => true,
+        };
+    }
+
+    fn sessionHasDurableActivityConservative(
+        self: Store,
+        alloc: Allocator,
+        session_id: []const u8,
+        options: session_log.Options,
+    ) !bool {
+        var root = self.canonical_root;
+        var boundary = root.captureReadBoundary(
+            alloc,
+            session_id,
+            options,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            // A boundary that cannot be classified is not safe to hide as an
+            // empty orphan. The normal resume path will surface its error.
+            else => return true,
+        };
+        defer boundary.deinit();
+        return boundary.position.through_seq > 1;
+    }
+
+    fn candidateHasManagedChildren(
+        self: Store,
+        alloc: Allocator,
+        session_id: []const u8,
+        history_len: usize,
+        storage: CandidateStorage,
+    ) !bool {
+        if (history_len != 0) return false;
+        if (storage != .schema_v3) {
+            return self.sessionHasManagedChildren(alloc, session_id) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => false,
+            };
+        }
+        return self.sessionHasManagedChildrenConservative(alloc, session_id);
+    }
+
+    fn sessionIdIsResumable(
+        self: Store,
+        alloc: Allocator,
+        session_id: []const u8,
+    ) !bool {
+        var session_dir = try self.openSessionDir(session_id);
+        defer session_dir.close();
+        var candidate = try classifyReadOnlyCandidate(
+            alloc,
+            &session_dir,
+            session_id,
+        );
+        defer candidate.deinit(alloc);
+        if (summaryIsResumable(candidate.summary)) return true;
+        if (candidate.projection_state == .stale) {
+            var detail = try self.loadReadOnlyDetail(alloc, session_id, .{});
+            defer detail.deinit(alloc);
+            if (summaryIsResumable(detail.summary)) return true;
+        }
+        return self.sessionHasManagedChildrenConservative(alloc, session_id);
+    }
+
+    fn summaryHasResumeEvidence(
+        self: Store,
+        alloc: Allocator,
+        summary: SessionSummary,
+        storage: CandidateStorage,
+    ) !bool {
+        if (summary.history_len != 0) return false;
+        if (summary.has_durable_activity) return true;
+        return self.candidateHasManagedChildren(
+            alloc,
+            summary.id,
+            summary.history_len,
+            storage,
+        );
+    }
+
+    fn stateHasResumeEvidence(
+        self: Store,
+        alloc: Allocator,
+        state: *const session_codec.DurableSessionState,
+        options: session_log.Options,
+    ) !bool {
+        if (state.history.len != 0) return false;
+        if (try self.sessionHasDurableActivityConservative(
+            alloc,
+            state.id,
+            options,
+        )) return true;
+        return self.candidateHasManagedChildren(
+            alloc,
+            state.id,
+            state.history.len,
+            .schema_v3,
+        );
+    }
+
     fn selectWritableLastId(
         self: Store,
         alloc: Allocator,
@@ -3258,6 +3575,16 @@ pub const Store = struct {
         if (self.canonical_root.sessions == null) return null;
         var replay_scope = self.loadDeferredReplayScope(alloc);
         defer replay_scope.deinit(alloc);
+        var pointer = readLatestPointer(
+            self,
+            alloc,
+            workspace_root,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => null,
+        };
+        defer if (pointer) |*value| value.deinit(alloc);
+        const preferred_id = if (pointer) |value| value.session_id else null;
 
         var selected: ?WritableCandidate = null;
         defer if (selected) |*candidate| candidate.deinit(alloc);
@@ -3309,6 +3636,8 @@ pub const Store = struct {
                     state.id,
                     state.workspace_root,
                     state.updated_at_ms,
+                    state.history.len,
+                    try self.stateHasResumeEvidence(alloc, &state, options.log),
                     .schema_v3,
                     .current,
                 );
@@ -3326,16 +3655,21 @@ pub const Store = struct {
                 candidate.deinit(alloc);
                 continue;
             }
+            const resumable = candidate.isResumable();
             logDiscovery(
                 .workspace_writable_last,
                 candidate.id,
                 candidate.storage,
                 candidate.projection_state,
-                .listable,
+                if (resumable) .listable else .empty_session,
                 .retained,
                 null,
             );
-            if (selected == null or writableCandidateNewer(candidate, selected.?)) {
+            const outranks_selected = if (selected) |current| resumeCandidateOutranks(
+                candidate.resumeRank(preferred_id),
+                current.resumeRank(preferred_id),
+            ) else true;
+            if (outranks_selected) {
                 if (selected) |*old| old.deinit(alloc);
                 selected = candidate;
             } else {
@@ -3348,7 +3682,7 @@ pub const Store = struct {
                 candidate.id,
                 candidate.storage,
                 candidate.projection_state,
-                .listable,
+                if (candidate.isResumable()) .listable else .empty_session,
                 .selected,
                 null,
             );
@@ -3379,6 +3713,12 @@ pub const Store = struct {
                     candidate.summary.id,
                     candidate.summary.workspace_root orelse self.workspace_root,
                     candidate.summary.updated_at_ms,
+                    candidate.summary.history_len,
+                    try self.summaryHasResumeEvidence(
+                        alloc,
+                        candidate.summary,
+                        candidate.storage,
+                    ),
                     candidate.storage,
                     .current,
                 );
@@ -3399,6 +3739,12 @@ pub const Store = struct {
                             candidate.summary.id,
                             candidate.summary.workspace_root.?,
                             candidate.summary.updated_at_ms,
+                            candidate.summary.history_len,
+                            try self.summaryHasResumeEvidence(
+                                alloc,
+                                candidate.summary,
+                                .schema_v3,
+                            ),
                             .schema_v3,
                             .current,
                         );
@@ -3430,6 +3776,12 @@ pub const Store = struct {
                         candidate.summary.id,
                         candidate.summary.workspace_root.?,
                         candidate.summary.updated_at_ms,
+                        candidate.summary.history_len,
+                        try self.summaryHasResumeEvidence(
+                            alloc,
+                            candidate.summary,
+                            .schema_v3,
+                        ),
                         .schema_v3,
                         .stale,
                     );
@@ -3440,6 +3792,8 @@ pub const Store = struct {
                     state.id,
                     state.workspace_root,
                     state.updated_at_ms,
+                    state.history.len,
+                    try self.stateHasResumeEvidence(alloc, &state, options.log),
                     .schema_v3,
                     .stale,
                 );
@@ -4122,6 +4476,7 @@ pub const Store = struct {
             target.position,
             source_id,
             options,
+            false,
         ) catch |err| {
             debug_trace.logf(
                 "session",
@@ -5282,6 +5637,28 @@ fn writeSummaryFixture(
     alloc.free(path);
 }
 
+fn writePristineSummaryFixture(
+    alloc: Allocator,
+    store: Store,
+    id: []const u8,
+    workspace_root: []const u8,
+    updated_at_ms: i64,
+) !void {
+    var state = try testDurableState(alloc, id, workspace_root);
+    defer state.deinit(alloc);
+    state.updated_at_ms = updated_at_ms;
+    var writer = try store.startWritableSession(alloc, state);
+    writer.deinit(alloc);
+}
+
+fn checkLatestResumableSummaryAllocationFailures(
+    alloc: Allocator,
+    store: Store,
+) !void {
+    var summary = try store.latestResumableWorkspaceSummary(alloc);
+    summary.deinit(alloc);
+}
+
 fn writeWritableHistoryFixture(
     alloc: Allocator,
     store: Store,
@@ -6363,6 +6740,42 @@ test "discarding a pristine started session permits usage checkpoints" {
     );
 }
 
+test "pristine discard retains a zero-turn parent with managed children" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    var state = try testDurableState(alloc, "managed-parent", ctx.workspace);
+    defer state.deinit(alloc);
+    var writable = try ctx.store.startWritableSession(alloc, state);
+    {
+        const header_bytes = try relationship_index_codec.encodeHeader(alloc, .{
+            .high_watermark = 1,
+            .active_count = 1,
+        });
+        defer alloc.free(header_bytes);
+        var capability = try writable.childCapability();
+        var header_file = try capability.createExclusiveFile(
+            alloc,
+            .subagent_control,
+            session_child_store.subagent_relationship_index_file,
+        );
+        defer header_file.deinit();
+        try header_file.writeAll(header_bytes);
+        try header_file.sync();
+    }
+
+    try std.testing.expectEqual(
+        PristineDiscardDisposition.retained,
+        ctx.store.discardPristineStartedSession(alloc, &writable),
+    );
+    var retained = try ctx.store.loadReadOnly(alloc, state.id);
+    defer retained.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), retained.history.len);
+}
+
 test "pristine discard retains active recovery and permits cleared recovery" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -6467,6 +6880,218 @@ test "pristine discard repairs latest and index to the completed predecessor" {
     defer freeSummaries(alloc, &rebuilt_index);
     try std.testing.expectEqual(@as(usize, 1), rebuilt_index.items.len);
     try std.testing.expectEqualStrings("discard-predecessor", rebuilt_index.items[0].id);
+}
+
+test "resume last reranks a stale pointer that names older history" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "stale-history-pointer",
+        ctx.workspace,
+        20,
+        "saved prompt",
+    );
+    var activity_state = try testDurableState(
+        alloc,
+        "newer-activity-candidate",
+        ctx.workspace,
+    );
+    defer activity_state.deinit(alloc);
+    activity_state.updated_at_ms = 30;
+    var activity = try ctx.store.startWritableSession(alloc, activity_state);
+    _ = try activity.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = true } },
+        30,
+        .retry_expected_tail,
+        .{},
+    );
+    activity.deinit(alloc);
+
+    var older = try ctx.store.resumeExactForWrite(
+        alloc,
+        "stale-history-pointer",
+        ctx.workspace,
+        false,
+        .{},
+    );
+    try ctx.store.publishRecoveredLatestPointer(
+        alloc,
+        older.state,
+        older.position,
+        activity_state.id,
+        .{},
+        false,
+    );
+    older.deinit(alloc);
+
+    var stale = try readLatestPointer(ctx.store, alloc, ctx.workspace) orelse
+        return error.TestExpectedEqual;
+    defer stale.deinit(alloc);
+    try std.testing.expectEqualStrings("stale-history-pointer", stale.session_id);
+
+    var latest = try ctx.store.latestResumableWorkspaceSummary(alloc);
+    defer latest.deinit(alloc);
+    try std.testing.expectEqualStrings("newer-activity-candidate", latest.id);
+
+    var resumed = try ctx.store.resumeTargetForWrite(
+        alloc,
+        .last,
+        ctx.workspace,
+        .{},
+    );
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("newer-activity-candidate", resumed.active_id);
+
+    var repaired = try readLatestPointer(ctx.store, alloc, ctx.workspace) orelse
+        return error.TestExpectedEqual;
+    defer repaired.deinit(alloc);
+    try std.testing.expectEqualStrings("newer-activity-candidate", repaired.session_id);
+}
+
+test "admitted exact resume preserves an unrelated latest pointer" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "exact-resume-target",
+        ctx.workspace,
+        20,
+        "saved prompt",
+    );
+    try writePristineSummaryFixture(
+        alloc,
+        ctx.store,
+        "unrelated-pristine-latest",
+        ctx.workspace,
+        30,
+    );
+
+    var admission = (try ctx.store.admitResumeView(
+        alloc,
+        .{ .id = "exact-resume-target" },
+    )) orelse return error.TestExpectedEqual;
+    defer admission.deinit(alloc);
+    var resumed = try ctx.store.resumeAdmittedForWrite(
+        alloc,
+        &admission,
+        .{ .id = "exact-resume-target" },
+        ctx.workspace,
+        .{},
+    );
+    defer resumed.deinit(alloc);
+
+    var latest = try readLatestPointer(ctx.store, alloc, ctx.workspace) orelse
+        return error.TestExpectedEqual;
+    defer latest.deinit(alloc);
+    try std.testing.expectEqualStrings("unrelated-pristine-latest", latest.session_id);
+}
+
+test "latest resumable summary frees ownership across allocation failures" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    try writePristineSummaryFixture(
+        alloc,
+        ctx.store,
+        "allocation-summary",
+        ctx.workspace,
+        20,
+    );
+    try std.testing.checkAllAllocationFailures(
+        alloc,
+        checkLatestResumableSummaryAllocationFailures,
+        .{ctx.store},
+    );
+}
+
+test "resume last skips a newer zero-turn orphan and repairs the canonical pointer" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "canonical-predecessor",
+        ctx.workspace,
+        20,
+        "saved prompt",
+    );
+    var empty_state = try testDurableState(
+        alloc,
+        "newer-zero-turn-orphan",
+        ctx.workspace,
+    );
+    defer empty_state.deinit(alloc);
+    empty_state.updated_at_ms = 30;
+    var empty = try ctx.store.startWritableSession(alloc, empty_state);
+    empty.deinit(alloc);
+
+    var stale_latest = try readLatestPointer(ctx.store, alloc, ctx.workspace) orelse
+        return error.TestExpectedEqual;
+    defer stale_latest.deinit(alloc);
+    try std.testing.expectEqualStrings(empty_state.id, stale_latest.session_id);
+
+    const trace_path = try std.fs.path.join(alloc, &.{ ctx.home, "selection-trace.log" });
+    defer alloc.free(trace_path);
+    debug_trace.resetForTest();
+    try debug_trace.configureForTest(alloc, trace_path);
+    defer debug_trace.resetForTest();
+
+    var visible = try ctx.store.listWorkspacePage(alloc, null, 10);
+    defer visible.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), visible.summaries.items.len);
+    try std.testing.expectEqualStrings(
+        "canonical-predecessor",
+        visible.summaries.items[0].id,
+    );
+
+    var resumed = try ctx.store.resumeTargetForWrite(
+        alloc,
+        .last,
+        ctx.workspace,
+        .{},
+    );
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("canonical-predecessor", resumed.state.id);
+
+    var repaired = try readLatestPointer(ctx.store, alloc, ctx.workspace) orelse
+        return error.TestExpectedEqual;
+    defer repaired.deinit(alloc);
+    try std.testing.expectEqualStrings("canonical-predecessor", repaired.session_id);
+
+    debug_trace.shutdown();
+    var trace_file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), trace_path, .{});
+    defer trace_file.close(io_mod.getIo());
+    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 8192);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "validated_candidate_id=canonical-predecessor outcome=selected",
+    ) != null);
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace,
+        "validated_candidate_id=newer-zero-turn-orphan outcome=selected",
+    ) == null);
 }
 
 test "pristine discard refuses resumed and committed writers" {
@@ -11147,7 +11772,7 @@ test "workspace latest ignores newer sessions from other workspaces" {
     try std.testing.expectEqualStrings("workspace-b-newest", latest_b.id);
 }
 
-test "workspace session pages prefer the bounded index and include empty sessions" {
+test "workspace session pages prefer the bounded index and exclude empty sessions" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -11155,7 +11780,8 @@ test "workspace session pages prefer the bounded index and include empty session
     defer ctx.deinit(alloc);
 
     const other_workspace = "/tmp/other-workspace";
-    const summaries = [_]SessionSummary{
+    var summaries = [_]SessionSummary{
+        testIndexedSessionSummary("session-006-empty", ctx.workspace, 60),
         testIndexedSessionSummary("session-005", ctx.workspace, 50),
         testIndexedSessionSummary("other-004", other_workspace, 45),
         testIndexedSessionSummary("session-004", ctx.workspace, 40),
@@ -11163,6 +11789,7 @@ test "workspace session pages prefer the bounded index and include empty session
         testIndexedSessionSummary("session-002", ctx.workspace, 20),
         testIndexedSessionSummary("session-001", ctx.workspace, 10),
     };
+    for (summaries[1..]) |*summary| summary.history_len = 1;
     var sessions = ctx.store.canonical_root.sessions orelse
         return error.TestExpectedEqual;
     try summary_codec.writeSessionIndex(alloc, &sessions, &summaries);
@@ -11173,7 +11800,7 @@ test "workspace session pages prefer the bounded index and include empty session
     try std.testing.expect(first.has_more);
     try std.testing.expectEqualStrings("session-005", first.summaries.items[0].id);
     try std.testing.expectEqualStrings("session-004", first.summaries.items[1].id);
-    try std.testing.expectEqual(@as(usize, 0), first.summaries.items[0].history_len);
+    try std.testing.expectEqual(@as(usize, 1), first.summaries.items[0].history_len);
 
     var profile = try ctx.store.listSessionPage(alloc, .all_workspaces, null, 3);
     defer profile.deinit(alloc);
@@ -11245,7 +11872,6 @@ test "resumable session pages filter before paging and preserve continuation ord
         .{ "tie-a", 1000, 1 },
         .{ "tie-b", 1000, 1 },
         .{ "current", 2000, 1 },
-        .{ "empty", 1500, 0 },
     }) |fixture| {
         const body = try std.fmt.allocPrint(
             alloc,
@@ -11256,6 +11882,7 @@ test "resumable session pages filter before paging and preserve continuation ord
         const path = try writeSessionFixture(alloc, ctx.store, fixture[0], body);
         defer alloc.free(path);
     }
+    try writePristineSummaryFixture(alloc, ctx.store, "empty", "/tmp/ws", 1500);
 
     var first = try ctx.store.listResumablePage(alloc, "current", null);
     defer first.deinit(alloc);
@@ -11312,7 +11939,7 @@ test "workspace resumable pages filter workspace before paging and preserve cont
         try writeSummaryFixture(alloc, ctx.store, id, ctx.workspace, 100 + @as(i64, @intCast(index)), 1);
     }
     try writeSummaryFixture(alloc, ctx.store, "workspace-a-current", ctx.workspace, 2000, 1);
-    try writeSummaryFixture(alloc, ctx.store, "workspace-a-empty", ctx.workspace, 1500, 0);
+    try writePristineSummaryFixture(alloc, ctx.store, "workspace-a-empty", ctx.workspace, 1500);
     try writeSummaryFixture(alloc, ctx.store, "missing-workspace", null, 1600, 1);
 
     var first = try ctx.store.listResumableWorkspacePage(alloc, "workspace-a-current", null);
@@ -11407,6 +12034,50 @@ test "read-only resumable index hydrates missing display metadata for the page" 
     try std.testing.expectEqual(@as(usize, 1), page.summaries.items.len);
     try std.testing.expect(page.summaries.items[0].display_metadata_present);
     try std.testing.expectEqualStrings("stale index prompt", page.summaries.items[0].title.?);
+
+    var latest = try read_only.latestResumableWorkspaceSummary(alloc);
+    defer latest.deinit(alloc);
+    try std.testing.expect(latest.display_metadata_present);
+    try std.testing.expectEqualStrings("stale index prompt", latest.title.?);
+}
+
+test "latest resumable summary ignores deleted index rows" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var ctx = try initTempStore(alloc, &tmp);
+    defer ctx.deinit(alloc);
+
+    try writeWritableHistoryFixture(
+        alloc,
+        ctx.store,
+        "surviving-canonical-session",
+        ctx.workspace,
+        20,
+        "surviving prompt",
+    );
+    var summaries = [_]SessionSummary{
+        testIndexedSessionSummary("deleted-index-session", ctx.workspace, 30),
+        testIndexedSessionSummary("surviving-canonical-session", ctx.workspace, 20),
+    };
+    for (&summaries) |*summary| summary.history_len = 1;
+    const sessions = &(ctx.store.canonical_root.sessions orelse
+        return error.TestExpectedEqual);
+    try summary_codec.writeSessionIndex(alloc, sessions, &summaries);
+    try removeSessionIndexMarker(sessions);
+
+    var latest = try ctx.store.latestResumableWorkspaceSummary(alloc);
+    defer latest.deinit(alloc);
+    try std.testing.expectEqualStrings("surviving-canonical-session", latest.id);
+
+    var resumed = try ctx.store.resumeTargetForWrite(
+        alloc,
+        .last,
+        ctx.workspace,
+        .{},
+    );
+    defer resumed.deinit(alloc);
+    try std.testing.expectEqualStrings("surviving-canonical-session", resumed.active_id);
 }
 
 test "resume page does not replay a large history to repair missing display metadata" {
@@ -11925,7 +12596,7 @@ test "invalid/corrupt record skipping" {
     inline for (.{
         .{ "broken", "{\"schema_version\":1," },
         .{ "unsupported", "{\"schema_version\":99,\"id\":\"unsupported\",\"created_at_ms\":1,\"updated_at_ms\":8,\"workspace_root\":\"/tmp/ws\",\"conversation_language\":\"en\",\"history_len\":0,\"history\":[]}" },
-        .{ "valid", "{\"schema_version\":1,\"id\":\"valid\",\"created_at_ms\":3,\"updated_at_ms\":9,\"workspace_root\":\"/tmp/ws\",\"conversation_language\":\"es\",\"history_len\":0,\"history\":[]}" },
+        .{ "valid", "{\"schema_version\":1,\"id\":\"valid\",\"created_at_ms\":3,\"updated_at_ms\":9,\"workspace_root\":\"/tmp/ws\",\"conversation_language\":\"es\",\"history_len\":1,\"history\":[{\"role\":\"user\",\"content\":\"saved\"}]}" },
     }) |fixture| {
         const path = try writeSessionFixture(alloc, ctx.store, fixture[0], fixture[1]);
         alloc.free(path);
@@ -11955,7 +12626,7 @@ test "invalid/corrupt record skipping" {
     try std.testing.expect(std.mem.find(
         u8,
         trace,
-        "session discovery mode=global_read_only_last cause=listable storage_format=legacy_v1 projection_state=current validated_candidate_id=valid outcome=selected error=none",
+        "validated_candidate_id=valid outcome=selected",
     ) != null);
     try std.testing.expect(std.mem.find(u8, trace, "{\"schema_version\":1,") == null);
     try std.testing.expect(std.mem.find(u8, trace, ctx.home) == null);

--- a/src/core/session/session_store_types.zig
+++ b/src/core/session/session_store_types.zig
@@ -40,6 +40,7 @@ pub const ProjectionState = enum {
 /// only for structured tracing.
 pub const DiscoveryCause = enum {
     listable,
+    empty_session,
     workspace_mismatch,
     authority_transition,
     missing_authority,
@@ -64,6 +65,10 @@ pub const SessionSummary = struct {
     updated_at_ms: i64,
     conversation_language: session.ConversationLanguage,
     history_len: usize,
+    /// True when the canonical log contains an event after `session_started`.
+    /// This distinguishes a genuinely pristine zero-turn entry from a valid
+    /// session whose durable activity has not produced chat history yet.
+    has_durable_activity: bool = false,
     has_managed_children: bool = false,
 
     /// Frees owned summary strings and poisons the value.

--- a/src/core/session/session_summary_codec.zig
+++ b/src/core/session/session_summary_codec.zig
@@ -924,6 +924,7 @@ fn parseIndexedSummary(alloc: Allocator, value: std.json.Value) !SessionSummary 
     const preview = try indexedOptionalStringDup(alloc, root.get("preview"));
     errdefer if (preview) |preview_text| alloc.free(preview_text);
     const language = session.ConversationLanguage.fromSlice(try indexedString(root.get("conversation_language"))) catch return error.InvalidSessionIndex;
+    const history_len = try indexedUsize(root.get("history_len"));
 
     return .{
         .id = id,
@@ -935,7 +936,9 @@ fn parseIndexedSummary(alloc: Allocator, value: std.json.Value) !SessionSummary 
         .created_at_ms = try indexedI64(root.get("created_at_ms")),
         .updated_at_ms = try indexedI64(root.get("updated_at_ms")),
         .conversation_language = language,
-        .history_len = try indexedUsize(root.get("history_len")),
+        .history_len = history_len,
+        .has_durable_activity = (try indexedOptionalBool(root.get("has_durable_activity"))) orelse
+            (history_len == 0),
         .has_managed_children = (try indexedOptionalBool(root.get("has_managed_children"))) orelse false,
     };
 }
@@ -959,6 +962,7 @@ const IndexedSummaryView = struct {
     updated_at_ms: i64,
     conversation_language: session.ConversationLanguage,
     history_len: usize,
+    has_durable_activity: bool = false,
     has_managed_children: bool = false,
 
     fn deinit(self: *IndexedSummaryView, alloc: Allocator) void {
@@ -998,6 +1002,7 @@ const IndexedSummaryView = struct {
             .updated_at_ms = self.updated_at_ms,
             .conversation_language = self.conversation_language,
             .history_len = self.history_len,
+            .has_durable_activity = self.has_durable_activity,
             .has_managed_children = self.has_managed_children,
         };
     }
@@ -1125,6 +1130,7 @@ fn readIndexedSummaryView(
     var updated_at_ms: ?i64 = null;
     var conversation_language: ?session.ConversationLanguage = null;
     var history_len: ?usize = null;
+    var has_durable_activity: ?bool = null;
     var has_managed_children: bool = false;
 
     while (true) {
@@ -1157,6 +1163,8 @@ fn readIndexedSummaryView(
                         return error.InvalidSessionIndex;
                 } else if (std.mem.eql(u8, key.text, "history_len")) {
                     history_len = try readJsonUsize(scanner);
+                } else if (std.mem.eql(u8, key.text, "has_durable_activity")) {
+                    has_durable_activity = try readJsonBool(scanner);
                 } else if (std.mem.eql(u8, key.text, "has_managed_children")) {
                     has_managed_children = try readJsonBool(scanner);
                 } else {
@@ -1188,6 +1196,7 @@ fn readIndexedSummaryView(
         .updated_at_ms = parsed_updated_at_ms,
         .conversation_language = parsed_conversation_language,
         .history_len = parsed_history_len,
+        .has_durable_activity = has_durable_activity orelse (parsed_history_len == 0),
         .has_managed_children = has_managed_children,
     };
     id = null;
@@ -1254,6 +1263,7 @@ fn indexedSummaryMatches(
     }
     if (options.resumable_only and
         summary.history_len == 0 and
+        !summary.has_durable_activity and
         !summary.has_managed_children)
     {
         return false;
@@ -1677,8 +1687,9 @@ fn writeIndexedSummaryJson(writer: *std.Io.Writer, summary: SessionSummary) !voi
     }
     try writer.writeAll(",\"conversation_language\":");
     try std.json.Stringify.value(summary.conversation_language.view(), .{}, writer);
-    try writer.print(",\"history_len\":{d},\"has_managed_children\":{s},\"display_metadata_present\":{s},\"title\":", .{
+    try writer.print(",\"history_len\":{d},\"has_durable_activity\":{s},\"has_managed_children\":{s},\"display_metadata_present\":{s},\"title\":", .{
         summary.history_len,
+        if (summary.has_durable_activity) "true" else "false",
         if (summary.has_managed_children) "true" else "false",
         if (summary.display_metadata_present) "true" else "false",
     });
@@ -1724,6 +1735,7 @@ pub fn cloneSessionSummary(alloc: Allocator, source: SessionSummary) !SessionSum
         .updated_at_ms = source.updated_at_ms,
         .conversation_language = source.conversation_language,
         .history_len = source.history_len,
+        .has_durable_activity = source.has_durable_activity,
         .has_managed_children = source.has_managed_children,
     };
 }
@@ -1786,7 +1798,7 @@ pub fn resumablePageFromSummaries(
             const summary_workspace = summary.workspace_root orelse continue;
             if (!std.mem.eql(u8, summary_workspace, root)) continue;
         }
-        if (summary.history_len == 0 and !summary.has_managed_children) continue;
+        if (!summaryIsResumable(summary)) continue;
         if (active_id) |id| {
             if (std.mem.eql(u8, summary.id, id)) continue;
         }
@@ -1817,6 +1829,7 @@ pub fn sessionListPageFromSummaries(
     var page: types.SessionListPage = .{};
     errdefer page.deinit(alloc);
     for (summaries) |summary| {
+        if (!summaryIsResumable(summary)) continue;
         if (workspace_root) |root| {
             const summary_workspace = summary.workspace_root orelse continue;
             if (!std.mem.eql(u8, summary_workspace, root)) continue;
@@ -1836,6 +1849,12 @@ pub fn sessionListPageFromSummaries(
         };
     }
     return page;
+}
+
+pub fn summaryIsResumable(summary: SessionSummary) bool {
+    return summary.history_len != 0 or
+        summary.has_durable_activity or
+        summary.has_managed_children;
 }
 
 fn summaryFollowsContinuation(
@@ -1979,7 +1998,7 @@ test "bounded resumable index page preserves filters and newest-first order" {
         "{\"schema_version\":3,\"sessions\":[" ++
         "{\"id\":\"older\",\"created_at_ms\":1,\"updated_at_ms\":10,\"workspace_root\":\"/tmp/ws\",\"origin_workspace_root\":null,\"conversation_language\":\"en\",\"history_len\":1,\"display_metadata_present\":true,\"title\":\"Older\",\"preview\":\"Older\"}," ++
         "{\"id\":\"other-workspace\",\"created_at_ms\":1,\"updated_at_ms\":100,\"workspace_root\":\"/tmp/other\",\"origin_workspace_root\":null,\"conversation_language\":\"ja\",\"history_len\":1,\"display_metadata_present\":true,\"title\":\"Other\",\"preview\":\"Other\"}," ++
-        "{\"id\":\"empty\",\"created_at_ms\":1,\"updated_at_ms\":90,\"workspace_root\":\"/tmp/ws\",\"origin_workspace_root\":null,\"conversation_language\":\"en\",\"history_len\":0,\"display_metadata_present\":true,\"title\":\"Empty\",\"preview\":\"Empty\"}," ++
+        "{\"id\":\"empty\",\"created_at_ms\":1,\"updated_at_ms\":90,\"workspace_root\":\"/tmp/ws\",\"origin_workspace_root\":null,\"conversation_language\":\"en\",\"history_len\":0,\"has_durable_activity\":false,\"display_metadata_present\":true,\"title\":\"Empty\",\"preview\":\"Empty\"}," ++
         "{\"id\":\"newest\",\"created_at_ms\":1,\"updated_at_ms\":40,\"workspace_root\":\"/tmp/ws\",\"origin_workspace_root\":null,\"conversation_language\":\"fr\",\"history_len\":2,\"display_metadata_present\":true,\"title\":\"Newest 🚀\",\"preview\":\"مرحبا\"}," ++
         "{\"id\":\"active\",\"created_at_ms\":1,\"updated_at_ms\":80,\"workspace_root\":\"/tmp/ws\",\"origin_workspace_root\":null,\"conversation_language\":\"en\",\"history_len\":1,\"display_metadata_present\":true,\"title\":\"Active\",\"preview\":\"Active\"}," ++
         "{\"id\":\"middle-b\",\"created_at_ms\":1,\"updated_at_ms\":30,\"workspace_root\":\"/tmp/ws\",\"origin_workspace_root\":null,\"conversation_language\":\"en\",\"history_len\":1,\"display_metadata_present\":true,\"title\":\"Middle B\",\"preview\":\"Middle B\"}," ++
@@ -2015,6 +2034,23 @@ test "bounded resumable index page preserves filters and newest-first order" {
     try std.testing.expect(!second.has_more);
     try std.testing.expectEqualStrings("middle-a", second.summaries.items[0].id);
     try std.testing.expectEqualStrings("older", second.summaries.items[1].id);
+}
+
+test "bounded resumable index keeps zero-history rows from older indexes" {
+    const alloc = std.testing.allocator;
+    var page = try parseSessionIndexPage(
+        alloc,
+        "{\"schema_version\":3,\"sessions\":[{\"id\":\"eventful-zero-turn\",\"created_at_ms\":1,\"updated_at_ms\":2,\"workspace_root\":\"/tmp/ws\",\"conversation_language\":\"en\",\"history_len\":0}]}",
+        .{
+            .workspace_root = "/tmp/ws",
+            .limit = 10,
+            .resumable_only = true,
+        },
+    );
+    defer page.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), page.summaries.items.len);
+    try std.testing.expect(page.summaries.items[0].has_durable_activity);
 }
 
 test "managed child ownership keeps a zero-turn session resumable" {

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -232,15 +232,19 @@ pub fn resumeAdmittedForExternalPrompt(
     store: session_store.Store,
     alloc: Allocator,
     admission: *session_store.ResumeViewAdmission,
-    session_id: []const u8,
+    target: session_store.ResumeTarget,
     workspace_root: []const u8,
     options: session_store.ResumeOptions,
 ) !session_store.LoadedWritableSession {
+    const session_id = switch (target) {
+        .id => |id| id,
+        .last => admission.sessionId(),
+    };
     try ensureExternalPromptAllowed(store, alloc, session_id, true);
     var loaded = try store.resumeAdmittedForWrite(
         alloc,
         admission,
-        session_id,
+        target,
         workspace_root,
         options,
     );
@@ -562,7 +566,7 @@ test "persistent child with missing root evidence stays incomplete after externa
     );
 }
 
-test "external prompt last target rechecks the selected one-off child" {
+test "external prompt last skips a one-off child for its resumable parent" {
     const alloc = std.testing.allocator;
     var env = try TestEnvironment.init(alloc);
     defer env.deinit(alloc);
@@ -570,13 +574,15 @@ test "external prompt last target rechecks the selected one-off child" {
     try env.createSession(alloc, "latest-one-off");
     try env.createControl(alloc, "latest-one-off", .one_off);
 
-    try expectResumeError(alloc, error.OneOffSessionNotResumable, resumeForExternalPrompt(
+    var loaded = try resumeForExternalPrompt(
         env.store,
         alloc,
         .last,
         env.workspace,
         .{},
-    ));
+    );
+    defer loaded.deinit(alloc);
+    try std.testing.expectEqualStrings("parent", loaded.active_id);
 }
 
 test "exact one-off denial does not rebind its workspace" {
@@ -772,7 +778,7 @@ const TestEnvironment = struct {
             self.store,
             alloc,
             &admission,
-            session_id,
+            .{ .id = session_id },
             self.workspace,
             .{},
         ));

--- a/tests/e2e/session-recovery.test.ts
+++ b/tests/e2e/session-recovery.test.ts
@@ -97,7 +97,11 @@ async function waitForPath(path: string, timeoutMs = 3_000): Promise<void> {
   throw new Error(`timed out waiting for ${path}`);
 }
 
-async function createSession(cwd: string, home: string): Promise<string> {
+async function createSession(
+  cwd: string,
+  home: string,
+  options: { durableActivity?: boolean } = {},
+): Promise<string> {
   const client = startAcp(cwd, home);
   try {
     client.send({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: 1 } });
@@ -105,6 +109,16 @@ async function createSession(cwd: string, home: string): Promise<string> {
     client.send({ jsonrpc: "2.0", id: 2, method: "session/new", params: { mcpServers: [] } });
     const response = await client.read();
     expect(response.result?.sessionId).toBeDefined();
+    if (options.durableActivity) {
+      await client.read(); // consume session/update notification
+      client.send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "session/set_config_option",
+        params: { configId: "model", value: "o4-mini" },
+      });
+      expect((await client.read()).result).toBeDefined();
+    }
     return response.result.sessionId;
   } finally {
     client.kill();
@@ -119,6 +133,98 @@ function sessionIdsFromHome(home: string): string[] {
 }
 
 describe("session recovery", () => {
+  test(
+    "resume last skips existing zero-turn entries across repeated persistence cycles",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-session-zero-turn-recovery-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      mkdirSync(home);
+      mkdirSync(workspace);
+      const workspaceRoot = realpathSync(workspace);
+      const gateway = startFakeGateway([
+        fakeGatewayFinalText("CANONICAL_SESSION_SEEDED"),
+        fakeGatewayFinalText("CANONICAL_SESSION_RESUMED_ONCE"),
+        fakeGatewayFinalText("CANONICAL_SESSION_RESUMED_TWICE"),
+      ]);
+      const env = {
+        HOME: home,
+        AI_GATEWAY_API_KEY: "e2e-placeholder",
+        VERCEL_OIDC_TOKEN: "",
+        FX_AUTO_UPGRADE: "0",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl,
+        FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+      };
+
+      try {
+        const eventfulId = await createSession(workspaceRoot, home, {
+          durableActivity: true,
+        });
+        const eventfulManifest = JSON.parse(readFileSync(
+          join(home, ".fx", "sessions", eventfulId, "session.json"),
+          "utf8",
+        ));
+        expect(eventfulManifest.history_len).toBe(0);
+        expect(eventfulManifest.last_event_seq).toBeGreaterThan(1);
+
+        const seeded = await runFx(
+          ["ask", "--json", "--auto", "Create the canonical saved session."],
+          { cwd: workspaceRoot, env },
+        );
+        expect(seeded.code).toBe(0);
+        expect(seeded.stderr).toBe("");
+        const canonicalId = JSON.parse(seeded.stdout).session_id as string;
+
+        const emptyId = await createSession(workspaceRoot, home);
+        expect(emptyId).not.toBe(canonicalId);
+        expect(sessionIdsFromHome(home).sort()).toEqual(
+          [canonicalId, emptyId, eventfulId].sort(),
+        );
+
+        const latest = await runFx(["session", "last", "--json"], {
+          cwd: workspaceRoot,
+          env: { HOME: home },
+        });
+        expect(latest.code).toBe(0);
+        expect(JSON.parse(latest.stdout).id).toBe(canonicalId);
+
+        for (const expected of [
+          "CANONICAL_SESSION_RESUMED_ONCE",
+          "CANONICAL_SESSION_RESUMED_TWICE",
+        ]) {
+          const resumed = await runFx(
+            ["ask", "--json", "--auto", "--resume", "last", expected],
+            { cwd: workspaceRoot, env },
+          );
+          expect(resumed.code).toBe(0);
+          expect(resumed.stderr).toBe("");
+          expect(JSON.parse(resumed.stdout).session_id).toBe(canonicalId);
+          expect(sessionIdsFromHome(home).sort()).toEqual(
+            [canonicalId, emptyId, eventfulId].sort(),
+          );
+        }
+
+        const listed = await runFx(["sessions", "--json"], {
+          cwd: workspaceRoot,
+          env: { HOME: home },
+        });
+        expect(listed.code).toBe(0);
+        const listedJson = JSON.parse(listed.stdout);
+        expect(listedJson.count).toBe(2);
+        expect(listedJson.sessions.map((summary: { id: string }) => summary.id).sort()).toEqual(
+          [canonicalId, eventfulId].sort(),
+        );
+        expect(listedJson.sessions.find(
+          (summary: { id: string }) => summary.id === eventfulId,
+        )?.history_len).toBe(0);
+      } finally {
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
   for (const boundary of [
     "after_event_append",
     "after_event_sync",
@@ -405,9 +511,13 @@ describe("session recovery", () => {
 
       const sourceId = await createSession(workspaceARoot, home);
       await Bun.sleep(10);
-      const healthyAId = await createSession(workspaceARoot, home);
+      const healthyAId = await createSession(workspaceARoot, home, {
+        durableActivity: true,
+      });
       await Bun.sleep(10);
-      const newestBId = await createSession(workspaceBRoot, home);
+      const newestBId = await createSession(workspaceBRoot, home, {
+        durableActivity: true,
+      });
 
       const sourceDir = join(home, ".fx", "sessions", sourceId);
       const watermarkName = readdirSync(sourceDir).find(

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -49,20 +50,59 @@ describe.skipIf(SKIP)("tui: startup and exit", () => {
     TIMEOUT,
   );
 
-  test(
-    "/quit exits cleanly",
-    async () => {
-      session = await TmuxSession.create();
-      await session.waitForComposer(10_000);
-      await session.sendText("/quit");
-      const exited = await session.waitForSessionEnd(5_000);
-      expect(exited).toBe(true);
-    },
-    TIMEOUT,
-  );
 });
 
 describe.skipIf(SKIP_TMUX)("tui: fresh-session commands", () => {
+  test(
+    "a clean exit discards the pristine zero-turn session",
+    async () => {
+      const root = realpathSync(
+        mkdtempSync(join(tmpdir(), "fx-e2e-pristine-session-exit-")),
+      );
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      mkdirSync(home);
+      mkdirSync(workspace);
+      writeFileSync(stderrPath, "");
+
+      try {
+        session = await TmuxSession.create({
+          isolated: true,
+          cwd: realpathSync(workspace),
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: undefined,
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_AUTO_UPGRADE: "0",
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_SKIP_ONBOARDING: "1",
+          },
+          stderrPath,
+        });
+        await session.waitForComposer(10_000);
+        await session.sendText("/quit");
+        expect(await session.waitForSessionEnd(5_000)).toBe(true);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+        const durableSessionIds = readdirSync(
+          join(home, ".fx", "sessions"),
+          { withFileTypes: true },
+        )
+          .filter((entry) => entry.isDirectory() && entry.name !== "latest")
+          .map((entry) => entry.name);
+        expect(durableSessionIds).toEqual([]);
+      } finally {
+        if (session) {
+          await session.kill();
+          session = null;
+        }
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
   test(
     "statusline hides the workspace identity by default",
     async () => {


### PR DESCRIPTION
## Summary

- Discard pristine interactive sessions after a clean exit.
- Skip pristine zero-turn orphans when `last` has a resumable session.
- Preserve eventful zero-history, managed-child, legacy, and last-resort recovery paths.
- Ignore stale index rows and preserve canonical display metadata when resolving `last`.
- Keep session listings and the picker aligned with resumable session policy.
- Repair stale latest pointers without changing exact-ID resume authority.

Linear: [FXC-227](https://linear.app/vercel/issue/FXC-227)