### PR TITLE
Run an allowlisted command as it was parsed

### DIFF
--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -590,8 +590,12 @@ pub fn executeCommandInEnvironmentResolving(
     const invocation = try shell_resolver.capturedInvocationResolving(scratch, environment, command, words);
     debug_trace.logf(
         "core",
-        "command runner explicit environment={s} shell={s}",
-        .{ @tagName(std.meta.activeTag(environment)), invocation.path },
+        "command runner explicit environment={s} shell={s} word_resolution={s}",
+        .{
+            @tagName(std.meta.activeTag(environment)),
+            invocation.path,
+            @tagName(words),
+        },
     );
     return executeRawInvocation(
         arena,

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -560,6 +560,20 @@ pub fn executeCommandInEnvironment(
     cwd: []const u8,
     environment: command_environment.Environment,
 ) !command_contract.RunCommandResult {
+    return executeCommandInEnvironmentResolving(cfg, arena, command, cwd, environment, .shell_defined);
+}
+
+/// `words` states whether the operator's shell may redefine the command before
+/// it runs. A command approved by parsing its text runs `as_parsed`, so the
+/// approval and the execution are about the same command.
+pub fn executeCommandInEnvironmentResolving(
+    cfg: Config,
+    arena: Allocator,
+    command: []const u8,
+    cwd: []const u8,
+    environment: command_environment.Environment,
+    words: shell_resolver.WordResolution,
+) !command_contract.RunCommandResult {
     switch (environment) {
         .legacy => return executeCommand(cfg, arena, command, cwd),
         .workspace_clean => return error.InvalidCommandEnvironment,
@@ -573,7 +587,7 @@ pub fn executeCommandInEnvironment(
     var effective_cfg = cfg;
     if (effective_cfg.timeout_started_ms == null) effective_cfg.timeout_started_ms = io_mod.milliTimestamp();
     try ExecutionControl.init(effective_cfg).check();
-    const invocation = try shell_resolver.capturedInvocation(scratch, environment, command);
+    const invocation = try shell_resolver.capturedInvocationResolving(scratch, environment, command, words);
     debug_trace.logf(
         "core",
         "command runner explicit environment={s} shell={s}",

--- a/src/core/execution/local_executor.zig
+++ b/src/core/execution/local_executor.zig
@@ -61,12 +61,18 @@ pub fn executePreparedCommand(
         },
         .approved_shell => |shell| .{
             .route = .approved_shell,
-            .result = try command_runner.executeCommandInEnvironment(
+            .result = try command_runner.executeCommandInEnvironmentResolving(
                 cfg,
                 alloc,
                 shell.command_ctx.command,
                 shell.command_ctx.resolved_cwd,
                 shell.command_ctx.environment,
+                // An auto-mode approval comes from parsing the command text, and
+                // nothing else looked at it. Run the words that were parsed.
+                switch (shell.source) {
+                    .auto_mode => .as_parsed,
+                    else => .shell_defined,
+                },
             ),
         },
     };

--- a/src/core/terminal/shell_resolver.zig
+++ b/src/core/terminal/shell_resolver.zig
@@ -197,20 +197,31 @@ pub fn capturedInvocationResolving(
                 .clean_start = true,
             } });
             removeInteractiveFlag(&invocation);
+            if (words == .as_parsed and shellKind(path).? == .bash) {
+                appendBashAsParsedProtection(&invocation);
+            }
             invocation.setCommand(command);
             return invocation;
         },
         .user => |path| {
+            if (words == .as_parsed) {
+                var invocation = try resolve(null, .{ .executable = .{
+                    .path = path,
+                    .clean_start = true,
+                } });
+                removeInteractiveFlag(&invocation);
+                if (shellKind(path).? == .bash) {
+                    appendBashAsParsedProtection(&invocation);
+                }
+                invocation.setCommand(command);
+                return invocation;
+            }
+
             var invocation = try resolve(path, .user_login);
             if (std.mem.eql(u8, std.fs.path.basename(path), "bash")) {
                 removeInteractiveFlag(&invocation);
-                // Alias expansion is what lets a login shell rewrite the command
-                // words. It stays on for a command a human or the reviewer looked
-                // at, and comes off for one approved by parsing the string.
-                if (words == .shell_defined) {
-                    invocation.append("-O");
-                    invocation.append("expand_aliases");
-                }
+                invocation.append("-O");
+                invocation.append("expand_aliases");
             }
             const effective_command = if (shellKind(path) == .zsh)
                 try std.mem.concat(alloc, u8, &.{ captured_zsh_user_prelude, command })
@@ -239,6 +250,13 @@ fn removeInteractiveFlag(invocation: *Invocation) void {
     std.debug.assert(invocation.len > 0);
     std.debug.assert(std.mem.eql(u8, invocation.values[invocation.len - 1], "-i"));
     invocation.len -= 1;
+}
+
+fn appendBashAsParsedProtection(invocation: *Invocation) void {
+    // Bash still reads BASH_ENV and imports exported functions in a
+    // non-interactive clean shell. Privileged mode suppresses those
+    // user-controlled command redefinition paths.
+    invocation.append("-p");
 }
 
 pub fn buildBootstrap(
@@ -441,6 +459,44 @@ test "captured profiles use exact non-PTY argv" {
     for (&expected_zsh_user, zsh_user.argv()) |expected, actual| {
         try std.testing.expectEqualStrings(expected, actual);
     }
+}
+
+test "as-parsed captured commands bypass Bash and zsh user definitions" {
+    const bash = try capturedInvocationResolving(
+        std.testing.allocator,
+        .{ .user = "/bin/bash" },
+        "git status",
+        .as_parsed,
+    );
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{ "/bin/bash", "--noprofile", "--norc", "-p", "-c", "git status" },
+        bash.argv(),
+    );
+
+    const zsh = try capturedInvocationResolving(
+        std.testing.allocator,
+        .{ .user = "/bin/zsh" },
+        "git status",
+        .as_parsed,
+    );
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{ "/bin/zsh", "-f", "-c", "git status" },
+        zsh.argv(),
+    );
+
+    const clean_bash = try capturedInvocationResolving(
+        std.testing.allocator,
+        .{ .clean = "/bin/bash" },
+        "npm install",
+        .as_parsed,
+    );
+    try std.testing.expectEqualSlices(
+        []const u8,
+        &.{ "/bin/bash", "--noprofile", "--norc", "-p", "-c", "npm install" },
+        clean_bash.argv(),
+    );
 }
 
 test "captured invocation provider projection shell-quotes every argv word" {

--- a/src/core/terminal/shell_resolver.zig
+++ b/src/core/terminal/shell_resolver.zig
@@ -169,10 +169,25 @@ pub fn profileShell(
 
 const captured_zsh_user_prelude = "\\builtin trap - TERM; ";
 
+/// Whether the operator's shell may redefine the command words before running
+/// them. An approval granted by reading the command string is only honest if the
+/// words that were read are the words that run, so a caller holding such an
+/// approval asks for `as_parsed`.
+pub const WordResolution = enum { shell_defined, as_parsed };
+
 pub fn capturedInvocation(
     alloc: Allocator,
     environment_value: Environment,
     command: []const u8,
+) (ResolveError || Allocator.Error)!Invocation {
+    return capturedInvocationResolving(alloc, environment_value, command, .shell_defined);
+}
+
+pub fn capturedInvocationResolving(
+    alloc: Allocator,
+    environment_value: Environment,
+    command: []const u8,
+    words: WordResolution,
 ) (ResolveError || Allocator.Error)!Invocation {
     switch (environment_value) {
         .legacy, .workspace_clean => return error.UnsupportedShell,
@@ -189,8 +204,13 @@ pub fn capturedInvocation(
             var invocation = try resolve(path, .user_login);
             if (std.mem.eql(u8, std.fs.path.basename(path), "bash")) {
                 removeInteractiveFlag(&invocation);
-                invocation.append("-O");
-                invocation.append("expand_aliases");
+                // Alias expansion is what lets a login shell rewrite the command
+                // words. It stays on for a command a human or the reviewer looked
+                // at, and comes off for one approved by parsing the string.
+                if (words == .shell_defined) {
+                    invocation.append("-O");
+                    invocation.append("expand_aliases");
+                }
             }
             const effective_command = if (shellKind(path) == .zsh)
                 try std.mem.concat(alloc, u8, &.{ captured_zsh_user_prelude, command })

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -11,7 +11,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, userInfo } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, runFx } from "../evals/eval-helpers";
 import {
@@ -27,6 +27,13 @@ import {
 const TIMEOUT = 30_000;
 const MODEL = "openai/gpt-5";
 const COMMAND_APPROVAL_PROMPT = "Would you like to run the following command?";
+const configuredLoginShell = userInfo().shell ?? "";
+const capturedUserShell =
+  configuredLoginShell.endsWith("/bash") || configuredLoginShell.endsWith("/zsh")
+    ? configuredLoginShell
+    : process.platform === "darwin"
+      ? "/bin/zsh"
+      : "/bin/bash";
 
 type IsolatedRoot = {
   root: string;
@@ -104,6 +111,26 @@ function cleanCommandCall(command: string, id: string) {
   });
 }
 
+function installUserCommandRedefinition(
+  root: IsolatedRoot,
+  command: string,
+): Record<string, string> {
+  if (capturedUserShell.endsWith("/bash")) {
+    const bashEnv = join(root.home, "bash_env");
+    writeFileSync(
+      bashEnv,
+      `${command}() { touch SHELL_DEFINITION_EXECUTED; }\n`,
+    );
+    return { SHELL: capturedUserShell, BASH_ENV: bashEnv };
+  }
+
+  writeFileSync(
+    join(root.home, ".zshrc"),
+    `alias ${command}='touch SHELL_DEFINITION_EXECUTED'\n`,
+  );
+  return { SHELL: capturedUserShell, ZDOTDIR: root.home };
+}
+
 function toolResultText(
   body: string,
   toolCallId: string,
@@ -171,7 +198,9 @@ async function waitForEither(
     if (expected.some((value) => scrollback.includes(value))) return scrollback;
     await Bun.sleep(25);
   }
-  throw new Error(`Timed out waiting for ${expected.map(JSON.stringify).join(" or ")}`);
+  throw new Error(
+    `Timed out waiting for ${expected.map((value) => JSON.stringify(value)).join(" or ")}`,
+  );
 }
 
 describe("lean auto mode reliability", () => {
@@ -179,7 +208,7 @@ describe("lean auto mode reliability", () => {
     "a reviewed command still runs under the operator's shell definitions",
     async () => {
       const root = createIsolatedRoot();
-      writeFileSync(join(root.home, ".bash_profile"), "alias deploy='touch ALIAS_EXECUTED'\n");
+      const shellEnv = installUserCommandRedefinition(root, "deploy");
       const gateway = startGateway(
         [commandCall("deploy", "reviewed_alias"), fakeGatewayFinalText("done")],
         [fakeGatewayPermissionDecision("clear", "reviewed and allowed")],
@@ -189,7 +218,10 @@ describe("lean auto mode reliability", () => {
         ["ask", "--quiet", "--json", "--no-save", "Deploy it."],
         {
           cwd: root.workspace,
-          env: { ...gatewayEnv(root, gateway), SHELL: "/bin/bash" },
+          env: {
+            ...gatewayEnv(root, gateway),
+            ...shellEnv,
+          },
           timeoutMs: TIMEOUT,
         },
       );
@@ -198,43 +230,59 @@ describe("lean auto mode reliability", () => {
       // This command is not on the allowlist, so the reviewer saw it. Approvals
       // that read the command keep the operator's own shell definitions.
       expect(gateway.classifierRequests.length).toBeGreaterThan(0);
-      expect(existsSync(join(root.workspace, "ALIAS_EXECUTED"))).toBe(true);
+      expect(
+        existsSync(join(root.workspace, "SHELL_DEFINITION_EXECUTED")),
+      ).toBe(true);
     },
     TIMEOUT,
   );
 
-
   test(
-    "an allowlisted command runs as parsed, not as the operator aliased it",
+    `an allowlisted command runs as parsed, not as the operator redefined it in ${capturedUserShell}`,
     async () => {
       const root = createIsolatedRoot();
-      // Auto mode approves `git status` from a parse of the command string. The
-      // operator's login shell would otherwise redefine that string, so the
-      // command that runs would not be the command that was approved.
-      writeFileSync(join(root.home, ".bash_profile"), "alias git='touch ALIAS_EXECUTED'\n");
+      // Auto mode approves `git status` from a parse of the command string. A
+      // user startup definition must not get a second chance to redefine it.
+      const shellEnv = installUserCommandRedefinition(root, "git");
       const gateway = startGateway(
-        [commandCall("git status", "alias_shadowed"), fakeGatewayFinalText("done")],
-        [fakeGatewayPermissionDecision("ask", "not consulted for an allowlisted command")],
+        [
+          commandCall("git status", "definition_shadowed"),
+          fakeGatewayFinalText("done"),
+        ],
+        [
+          fakeGatewayPermissionDecision(
+            "caution",
+            "not consulted for an allowlisted command",
+          ),
+        ],
       );
 
       const result = await runFx(
-        ["ask", "--quiet", "--json", "--no-save", "Check the repository status."],
+        [
+          "ask",
+          "--quiet",
+          "--json",
+          "--no-save",
+          "Check the repository status.",
+        ],
         {
           cwd: root.workspace,
-          env: { ...gatewayEnv(root, gateway), SHELL: "/bin/bash" },
+          env: { ...gatewayEnv(root, gateway), ...shellEnv },
           timeoutMs: TIMEOUT,
         },
       );
 
       expect(result.code).toBe(0);
       const call = JSON.parse(result.stdout).tool_calls?.[0];
+      expect(gateway.classifierRequests).toHaveLength(0);
       // git itself ran: the workspace is not a repository, so it fails that way.
       expect(call?.command_result?.exit_code).toBe(128);
-      expect(existsSync(join(root.workspace, "ALIAS_EXECUTED"))).toBe(false);
+      expect(
+        existsSync(join(root.workspace, "SHELL_DEFINITION_EXECUTED")),
+      ).toBe(false);
     },
     TIMEOUT,
   );
-
 
   test(
     "a configured safe command bypasses automatic review",

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -176,6 +176,67 @@ async function waitForEither(
 
 describe("lean auto mode reliability", () => {
   test(
+    "a reviewed command still runs under the operator's shell definitions",
+    async () => {
+      const root = createIsolatedRoot();
+      writeFileSync(join(root.home, ".bash_profile"), "alias deploy='touch ALIAS_EXECUTED'\n");
+      const gateway = startGateway(
+        [commandCall("deploy", "reviewed_alias"), fakeGatewayFinalText("done")],
+        [fakeGatewayPermissionDecision("clear", "reviewed and allowed")],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Deploy it."],
+        {
+          cwd: root.workspace,
+          env: { ...gatewayEnv(root, gateway), SHELL: "/bin/bash" },
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code).toBe(0);
+      // This command is not on the allowlist, so the reviewer saw it. Approvals
+      // that read the command keep the operator's own shell definitions.
+      expect(gateway.classifierRequests.length).toBeGreaterThan(0);
+      expect(existsSync(join(root.workspace, "ALIAS_EXECUTED"))).toBe(true);
+    },
+    TIMEOUT,
+  );
+
+
+  test(
+    "an allowlisted command runs as parsed, not as the operator aliased it",
+    async () => {
+      const root = createIsolatedRoot();
+      // Auto mode approves `git status` from a parse of the command string. The
+      // operator's login shell would otherwise redefine that string, so the
+      // command that runs would not be the command that was approved.
+      writeFileSync(join(root.home, ".bash_profile"), "alias git='touch ALIAS_EXECUTED'\n");
+      const gateway = startGateway(
+        [commandCall("git status", "alias_shadowed"), fakeGatewayFinalText("done")],
+        [fakeGatewayPermissionDecision("ask", "not consulted for an allowlisted command")],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Check the repository status."],
+        {
+          cwd: root.workspace,
+          env: { ...gatewayEnv(root, gateway), SHELL: "/bin/bash" },
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code).toBe(0);
+      const call = JSON.parse(result.stdout).tool_calls?.[0];
+      // git itself ran: the workspace is not a repository, so it fails that way.
+      expect(call?.command_result?.exit_code).toBe(128);
+      expect(existsSync(join(root.workspace, "ALIAS_EXECUTED"))).toBe(false);
+    },
+    TIMEOUT,
+  );
+
+
+  test(
     "a configured safe command bypasses automatic review",
     async () => {
       const root = createIsolatedRoot();


### PR DESCRIPTION
Fixes #258.

Auto-mode allowlist approvals now execute using the selected shell without allowing operator startup definitions to reinterpret the approved command. Bash uses `--noprofile --norc -p`; zsh uses `-f`.

Reviewed commands, configured rules, session grants, and interactive approvals retain the operator's normal shell definitions.

The contributor's original commit and attribution are preserved.

### Verification

- `zig build`
- focused Zig tests: 13 passed
- `auto-mode-reliability.test.ts`: 23 passed
- built-binary regression covers the captured login shell and confirms the automatic reviewer was not consulted

Full CI passed on exact commit `9abbb5d`: [run 32566855312](https://github.com/vercel-labs/fx/actions/runs/32566855312).
