### PR TITLE
Add Grok subscription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,18 @@ fx login codex
 fx
 ```
 
-Inside fx, `/provider` switches between Gateway and Codex, and `/model` lists the active provider's fetched models. Codex model IDs are the raw IDs returned by its authenticated catalog. Use `/logout codex` to remove the Codex session without affecting Vercel access.
+Or use an eligible Grok subscription through xAI OAuth:
+
+```bash
+fx login grok
+fx
+```
+
+Inside fx, `/provider` switches between Gateway, Codex, and Grok, and `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Use `/logout codex` or `/logout grok` to remove that subscription session without affecting other providers.
 
 The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed. On supported Codex models, `/fast` requests OpenAI's priority service tier and consumes ChatGPT credits at the higher Fast mode rate.
+
+The Grok route uses subscription access directly at xAI and never sends its OAuth token to Vercel AI Gateway or OpenAI. Its session is stored privately at `~/.fx/grok-auth.json`, refreshed when needed, and used only with the authenticated xAI catalog and Responses API.
 
 To use an AI Gateway API key instead:
 

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -250,6 +250,7 @@ const AcpContext = struct {
             .permission_reviewer_provider = switch (session.provider) {
                 .gateway => self.state.cfg.permission_reviewer_provider,
                 .codex => self.state.cfg.codex_permission_reviewer_provider,
+                .grok => self.state.cfg.grok_permission_reviewer_provider,
             },
             .auto_classifier = self.auto_classifier,
             .subagent_host = self.state.subagent_host,
@@ -450,6 +451,8 @@ pub fn handlePrompt(
             .code = ErrorCode.invalid_request,
             .message = if (session.provider == .codex)
                 credentials.missing_chatgpt_credential_message
+            else if (session.provider == .grok)
+                credentials.missing_grok_credential_message
             else
                 credentials.missing_credential_message,
         } };
@@ -707,6 +710,10 @@ pub fn runSubagentChild(
             .codex = .{
                 .agent_stream_provider = server.streamProviderFor(state, .codex),
                 .permission_reviewer_provider = state.cfg.codex_permission_reviewer_provider,
+            },
+            .grok = .{
+                .agent_stream_provider = server.streamProviderFor(state, .grok),
+                .permission_reviewer_provider = state.cfg.grok_permission_reviewer_provider,
             },
         },
         .system_prompt = state.cfg.prompt_policy.system_prompt,

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -326,7 +326,7 @@ fn adoptServerCredential(state: *ServerState, credential: *credentials.Credentia
         active.credential_source = state.credential_source;
         active.account_id = state.account_id;
         if (comptime !host_target.is_wasm) {
-            if (state.credential_source == .chatgpt_subscription) {
+            if (state.credential_source == .chatgpt_subscription or state.credential_source == .grok_subscription) {
                 active.session_rt.usage.clearReconciliationCredential();
             }
         }
@@ -373,6 +373,8 @@ pub fn streamProviderFor(
         .gateway => state.cfg.gateway_provider.agent_stream,
         .codex => state.cfg.codex_agent_stream orelse
             @import("../core/agent/stream_provider.zig").unavailable_provider,
+        .grok => state.cfg.grok_agent_stream orelse
+            @import("../core/agent/stream_provider.zig").unavailable_provider,
     };
 }
 
@@ -383,6 +385,7 @@ pub fn catalogProviderFor(
     return switch (provider) {
         .gateway => state.cfg.gateway_provider.model_catalog,
         .codex => state.cfg.codex_model_catalog,
+        .grok => state.cfg.grok_model_catalog,
     };
 }
 
@@ -402,15 +405,16 @@ pub fn refreshModelCredential(
         expected_account_id,
     ) orelse return null;
     errdefer secret.zeroAndFree(alloc, refreshed);
-    if (source == .chatgpt_subscription) {
-        try publishRefreshedChatGptToken(state, refreshed, expected_account_id);
+    if (source == .chatgpt_subscription or source == .grok_subscription) {
+        try publishRefreshedSubscriptionToken(state, refreshed, source, expected_account_id);
     }
     return refreshed;
 }
 
-fn publishRefreshedChatGptToken(
+fn publishRefreshedSubscriptionToken(
     state: *ServerState,
     refreshed: []const u8,
+    source: types.CredentialSource,
     expected_account_id: ?[]const u8,
 ) !void {
     const expected = expected_account_id orelse return error.ChatGptAccountChanged;
@@ -425,10 +429,10 @@ fn publishRefreshedChatGptToken(
     if (state.active_session) |*active| active.api_key = &.{};
     if (state.api_key.len > 0) secret.zeroAndFree(state.alloc, state.api_key);
     state.api_key = owned;
-    state.credential_source = .chatgpt_subscription;
+    state.credential_source = source;
     if (state.active_session) |*active| {
         active.api_key = state.api_key;
-        active.credential_source = .chatgpt_subscription;
+        active.credential_source = source;
     }
 }
 
@@ -440,7 +444,7 @@ pub fn releaseActiveSession(state: *ServerState) !void {
         active.session_rt.usage.cancelReconciliation();
         active.session_rt.usage.finishProfilePublicationsBeforeShutdown();
         flushActiveSessionUsage(state) catch |err| {
-            if (state.credential_source == .chatgpt_subscription) {
+            if (state.credential_source == .chatgpt_subscription or state.credential_source == .grok_subscription) {
                 active.session_rt.usage.clearReconciliationCredential();
             } else {
                 active.session_rt.usage.startReconciliation(
@@ -1388,6 +1392,8 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
                 .code = ErrorCode.invalid_request,
                 .message = if (state.provider == .codex)
                     credentials.missing_chatgpt_credential_message
+                else if (state.provider == .grok)
+                    credentials.missing_grok_credential_message
                 else
                     credentials.missing_credential_message,
             });
@@ -1399,6 +1405,8 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
             .code = ErrorCode.invalid_request,
             .message = if (state.provider == .codex)
                 credentials.missing_chatgpt_credential_message
+            else if (state.provider == .grok)
+                credentials.missing_grok_credential_message
             else
                 credentials.missing_credential_message,
         });
@@ -1553,7 +1561,7 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                 .message = "Invalid session model",
             });
         if (comptime !host_target.is_wasm) {
-            if (session.provider == .codex) {
+            if (session.provider != .gateway) {
                 var model_available = false;
                 if (state.capability_resolver.catalogEntries()) |entries| {
                     for (entries) |entry| {
@@ -1569,10 +1577,13 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                         .message = "Model is not available for the active provider",
                     });
                 }
-                if (!try selectCredentialForProvider(state, .codex)) {
+                if (!try selectCredentialForProvider(state, session.provider)) {
                     return state.writer.writeError(alloc, msg.id, .{
                         .code = ErrorCode.invalid_request,
-                        .message = credentials.missing_chatgpt_credential_message,
+                        .message = if (session.provider == .codex)
+                            credentials.missing_chatgpt_credential_message
+                        else
+                            credentials.missing_grok_credential_message,
                     });
                 }
             }
@@ -1633,7 +1644,7 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
             if (host_target.is_wasm) {
                 return state.writer.writeError(alloc, msg.id, .{
                     .code = ErrorCode.invalid_request,
-                    .message = "Codex provider switching is unavailable in this WASM runtime",
+                    .message = "Subscription provider switching is unavailable in this WASM runtime",
                 });
             }
             var staged_credential = if (target == .gateway and state.cfg.credential_override != null)
@@ -1655,6 +1666,8 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                         .code = ErrorCode.invalid_request,
                         .message = if (target == .codex)
                             credentials.missing_chatgpt_credential_message
+                        else if (target == .grok)
+                            credentials.missing_grok_credential_message
                         else
                             credentials.missing_credential_message,
                     });
@@ -1704,6 +1717,7 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
             const saved_model = switch (target) {
                 .gateway => settings.model,
                 .codex => settings.codex_model,
+                .grok => settings.grok_model,
             };
             var selected_model = catalog.items[0].id;
             if (saved_model) |saved| {
@@ -2492,7 +2506,7 @@ test "ACP publishes an account-bound refreshed Codex token for later prompts" {
         alloc.free(state.account_id.?);
     }
 
-    try publishRefreshedChatGptToken(&state, "fresh-token", "acct-1");
+    try publishRefreshedSubscriptionToken(&state, "fresh-token", .chatgpt_subscription, "acct-1");
 
     try std.testing.expectEqualStrings("fresh-token", state.api_key);
     try std.testing.expectEqualStrings("fresh-token", state.active_session.?.api_key);
@@ -2515,7 +2529,7 @@ test "ACP rejects refreshed Codex tokens for another account" {
 
     try std.testing.expectError(
         error.ChatGptAccountChanged,
-        publishRefreshedChatGptToken(&state, "wrong-token", "acct-2"),
+        publishRefreshedSubscriptionToken(&state, "wrong-token", .chatgpt_subscription, "acct-2"),
     );
     try std.testing.expectEqualStrings("stale-token", state.api_key);
 }

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -312,10 +312,10 @@ pub fn handleLoadWasmSession(state: *server.ServerState, alloc: Allocator, msg: 
     const sid_copy = try alloc.dupe(u8, loaded.state.id);
     var sid_owned = true;
     defer if (sid_owned) alloc.free(sid_copy);
-    if (loaded.state.preferences.provider == .codex) {
+    if (loaded.state.preferences.provider != .gateway) {
         return state.writer.writeError(alloc, msg.id, .{
             .code = ErrorCode.invalid_request,
-            .message = "Codex subscription models are unavailable in this WASM runtime",
+            .message = "Subscription models are unavailable in this WASM runtime",
         });
     }
     const model_copy = try alloc.dupe(u8, loaded.state.preferences.model);
@@ -566,6 +566,8 @@ fn handleRestoreSession(
             .code = ErrorCode.invalid_request,
             .message = if (effective_provider == .codex)
                 credentials.missing_chatgpt_credential_message
+            else if (effective_provider == .grok)
+                credentials.missing_grok_credential_message
             else
                 credentials.missing_credential_message,
         });
@@ -796,7 +798,7 @@ fn activateSession(
     };
     server.enableSubagentHost(state);
     state.active_session.?.session_rt.attachProfileUsagePublisher(state.alloc);
-    if (state.credential_source == .chatgpt_subscription) {
+    if (state.credential_source == .chatgpt_subscription or state.credential_source == .grok_subscription) {
         state.active_session.?.session_rt.usage.clearReconciliationCredential();
     } else {
         state.active_session.?.session_rt.usage.startReconciliation(
@@ -1111,7 +1113,11 @@ pub fn writeProviderConfigOption(
 ) !void {
     try w.writeAll("{\"id\":\"provider\",\"name\":\"Provider\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":");
     try writeJsonStr(@tagName(current), w);
-    try w.writeAll(",\"options\":[{\"value\":\"gateway\",\"name\":\"Vercel AI Gateway\"},{\"value\":\"codex\",\"name\":\"Codex subscription\"}]}");
+    try w.writeAll(",\"options\":[{\"value\":\"gateway\",\"name\":\"Vercel AI Gateway\"},{\"value\":\"codex\",\"name\":\"Codex subscription\"}");
+    if (comptime !host_target.is_wasm) {
+        try w.writeAll(",{\"value\":\"grok\",\"name\":\"Grok subscription\"}");
+    }
+    try w.writeAll("]}");
 }
 
 pub fn writeModeConfigOption(

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -89,13 +89,13 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .login,
         .token = "login",
-        .usage = "login [vercel|codex]",
+        .usage = "login [vercel|codex|grok]",
         .summary = "Sign in to Vercel or a selected provider",
     },
     .{
         .kind = .logout,
         .token = "logout",
-        .usage = "logout [vercel|codex]",
+        .usage = "logout [vercel|codex|grok]",
         .summary = "Sign out of Vercel or a selected provider session",
     },
     .{
@@ -137,7 +137,7 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .provider,
         .token = "provider",
-        .usage = "provider <gateway|codex>",
+        .usage = "provider <gateway|codex|grok>",
         .summary = "Choose the model provider used by fx",
     },
     .{
@@ -292,9 +292,9 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
         .{ .kind = .replay, .usage = "replay <tape>" },
     } },
     .{ .entries = &.{
-        .{ .kind = .login, .usage = "login [vercel|codex]" },
-        .{ .kind = .logout, .usage = "logout [vercel|codex]" },
-        .{ .kind = .provider, .usage = "provider <gateway|codex>" },
+        .{ .kind = .login, .usage = "login [vercel|codex|grok]" },
+        .{ .kind = .logout, .usage = "logout [vercel|codex|grok]" },
+        .{ .kind = .provider, .usage = "provider <gateway|codex|grok>" },
         .{ .kind = .setup, .usage = "setup" },
         .{ .kind = .teams, .usage = "teams" },
         .{ .kind = .credits, .usage = "credits|balance" },
@@ -420,7 +420,7 @@ pub const slash_specs = [_]SlashSpec{
     .{ .kind = .continue_recovery, .command = "/continue", .help_entry = "/continue", .completion_description = "continue a paused model response", .presentation_category = .session, .requires_prompt_credential = true },
     .{ .kind = .rename_session, .command = "/rename", .help_entry = "/rename <title>", .completion_description = "rename the current session", .presentation_category = .session, .has_args = true, .accepts_payload = true },
     .{ .kind = .login, .command = "/login", .help_entry = "/login", .completion_description = "choose Vercel or Codex sign-in", .presentation_category = .account },
-    .{ .kind = .logout, .command = "/logout", .help_entry = "/logout [vercel|codex]", .completion_description = "sign out of a provider session", .presentation_category = .account, .has_args = true, .accepts_payload = true },
+    .{ .kind = .logout, .command = "/logout", .help_entry = "/logout [vercel|codex|grok]", .completion_description = "sign out of a provider session", .presentation_category = .account, .has_args = true, .accepts_payload = true },
     .{ .kind = .setup, .command = "/setup", .help_entry = "/setup", .completion_description = "manage accounts and AI Gateway access", .presentation_category = .account },
     .{ .kind = .stats, .command = "/stats", .help_entry = "/stats", .completion_description = "show token and turn statistics", .presentation_category = .account },
     .{ .kind = .usage, .command = "/usage", .aliases = &.{"/cost"}, .help_entry = "/usage (/cost)", .completion_description = "show local fx tokens, models, and spend", .presentation_category = .account },
@@ -433,7 +433,7 @@ pub const slash_specs = [_]SlashSpec{
     .{ .kind = .images, .command = "/images", .help_entry = "/images [clear]", .completion_description = "manage pending image attachments", .presentation_category = .media, .has_args = true, .accepts_payload = true },
     .{ .kind = .model, .command = "/model", .help_entry = "/model <id-or-query>", .completion_description = "choose what model and reasoning effort to use", .presentation_category = .model, .has_args = true, .accepts_payload = true },
     .{ .kind = .models, .command = "/models", .help_entry = "/models", .completion_description = "browse available models", .presentation_category = .model },
-    .{ .kind = .provider, .command = "/provider", .help_entry = "/provider [gateway|codex]", .completion_description = "choose Gateway or Codex", .presentation_category = .model, .has_args = true, .accepts_payload = true },
+    .{ .kind = .provider, .command = "/provider", .help_entry = "/provider [gateway|codex|grok]", .completion_description = "choose a model provider", .presentation_category = .model, .has_args = true, .accepts_payload = true },
     .{ .kind = .permissions, .command = "/permissions", .help_entry = "/permissions [ask|auto|yolo|reset]", .completion_description = "choose what fx is allowed to do", .presentation_category = .security, .show_in_welcome = true, .has_args = true, .accepts_payload = true },
     .{ .kind = .allowlist, .command = "/allowlist", .help_entry = "/allowlist [view [effective|local|user]|[local|user] add|remove|reset ...]", .completion_description = "manage trusted commands, tools, and URLs", .presentation_category = .security, .show_in_welcome = true, .has_args = true, .accepts_payload = true },
     .{ .kind = .undo, .command = "/undo", .help_entry = "/undo", .completion_description = "undo the latest tracked file operation", .presentation_category = .session },

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -425,8 +425,8 @@ fn streamAgentCompletion(
     alloc: Allocator,
     request: agent_stream_provider_contract.Request,
 ) anyerror!agent_stream_provider_contract.Result {
-    if (request.credential_source == .chatgpt_subscription) {
-        return error.CodexCredentialCannotAuthorizeGateway;
+    if (request.credential_source == .chatgpt_subscription or request.credential_source == .grok_subscription) {
+        return error.SubscriptionCredentialCannotAuthorizeGateway;
     }
     const result = gateway_client.streamGatewayCompletion(
         alloc,
@@ -483,6 +483,9 @@ fn fetchCredits(
 ) output_contracts.CreditsSnapshot {
     if (input.credential_source == .chatgpt_subscription) {
         return creditsErrorSnapshot(alloc, "AI Gateway credits are unavailable for a ChatGPT subscription.");
+    }
+    if (input.credential_source == .grok_subscription) {
+        return creditsErrorSnapshot(alloc, "AI Gateway credits are unavailable for a Grok subscription.");
     }
     return fetchCreditsWithFetch(
         alloc,
@@ -626,7 +629,12 @@ const OAuthHttpOperation = struct {
                 },
                 .user_agent = .{ .override = gateway_client.user_agent },
                 .accept_encoding = .omit,
+                .authorization = if (self.request.authorization) |value|
+                    .{ .override = value }
+                else
+                    .default,
             },
+            .redirect_behavior = .unhandled,
             .response_writer = &response_writer,
         }) catch |err| switch (err) {
             error.WriteFailed => return error.OAuthResponseTooLarge,

--- a/src/builtins/providers.zig
+++ b/src/builtins/providers.zig
@@ -4,11 +4,14 @@ const stream_provider = @import("../core/agent/stream_provider.zig");
 const gateway = @import("gateway.zig");
 const openai_codex = @import("../gateway/openai_codex.zig");
 const openai_codex_models = @import("../gateway/openai_codex_models.zig");
+const xai_grok = @import("../gateway/xai_grok.zig");
+const xai_grok_models = @import("../gateway/xai_grok_models.zig");
 
 pub fn agentStream(provider: model_provider.ProviderId) stream_provider.Provider {
     return switch (provider) {
         .gateway => gateway.agent_stream_provider,
         .codex => openai_codex.agent_stream_provider,
+        .grok => xai_grok.agent_stream_provider,
     };
 }
 
@@ -16,5 +19,6 @@ pub fn modelCatalog(provider: model_provider.ProviderId) model_catalog.Provider 
     return switch (provider) {
         .gateway => gateway.model_catalog_provider,
         .codex => openai_codex_models.model_catalog_provider,
+        .grok => xai_grok_models.model_catalog_provider,
     };
 }

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -105,7 +105,7 @@ pub fn streamGatewayCompletion(
     if (comptime @import("builtin").os.tag != .wasi) {
         if (result.reconcile_generation_usage) {
             if (usage) |ledger| {
-                if (credential_source == .chatgpt_subscription) {
+                if (credential_source == .chatgpt_subscription or credential_source == .grok_subscription) {
                     ledger.clearReconciliationCredential();
                 } else {
                     ledger.startReconciliation(usage_allocator, api_key);

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1688,7 +1688,7 @@ fn refreshGatewayCredentialForJob(
     const previous_api_key = active_api_key.*;
     if (comptime !host_target.is_wasm) {
         if (deps.usage) |usage| {
-            if (source == .chatgpt_subscription) {
+            if (source == .chatgpt_subscription or source == .grok_subscription) {
                 usage.clearReconciliationCredential();
             } else {
                 usage.refreshReconciliationCredential(
@@ -3164,7 +3164,7 @@ fn processQueuedPromptLoop(
                     );
                 }
                 if (!model_provider.usesGatewayAuxiliaries(job.provider)) {
-                    return error.CodexNativeImageUnavailable;
+                    return error.SubscriptionNativeImageUnavailable;
                 }
                 if (job.authorized_image_catalog.len == 0) {
                     return error.MissingAuthorizedImageCatalog;
@@ -3189,7 +3189,7 @@ fn processQueuedPromptLoop(
             else
                 .auto;
             var verified_images: std.ArrayList(image_attachments.VerifiedSnapshot) = .empty;
-            if (job.provider == .codex and job.images.len > 0 and
+            if (job.provider != .gateway and job.images.len > 0 and
                 request_capabilities.supports_vision and request_capabilities.supports_file_input)
             {
                 try verified_images.ensureTotalCapacity(overlay_arena, job.images.len);
@@ -3253,7 +3253,7 @@ fn processQueuedPromptLoop(
                 request_messages.len,
                 config.gateway_tools_json,
             );
-            if (job.provider != .codex) {
+            if (job.provider == .gateway) {
                 try persistRecoveryCheckpoint(
                     deps,
                     arena,
@@ -3629,7 +3629,7 @@ fn processQueuedPromptLoop(
                 gateway_delivery.load(),
             );
             stream_result_set = true;
-            if (job.provider == .codex and
+            if (job.provider != .gateway and
                 stream_result.status == .unauthorized and
                 !auth_retry_used and
                 stream_ctx.raw_text.items.len == 0 and
@@ -3684,7 +3684,7 @@ fn processQueuedPromptLoop(
                     );
                     debug_trace.eventf(
                         "auth",
-                        "codex_request_replayed",
+                        "subscription_request_replayed",
                         step_ctx,
                         "payload_bytes={d} semantic_attempt={d}",
                         .{ request_payload.len, semantic_attempt + 1 },
@@ -3768,7 +3768,7 @@ fn processQueuedPromptLoop(
                 );
             }
             const settled_attempts = semantic_attempt + 1;
-            if (job.provider != .codex or stream_result.status != .unauthorized) {
+            if (job.provider == .gateway or stream_result.status != .unauthorized) {
                 try persistRecoveryCheckpoint(
                     deps,
                     arena,
@@ -3799,7 +3799,7 @@ fn processQueuedPromptLoop(
                 debug_trace.logf("agent", "token progress publication failed source=gateway_usage err={s}", .{@errorName(progress_err)});
             };
             if (stream_result.status == .unauthorized and
-                job.provider != .codex and
+                job.provider == .gateway and
                 !auth_retry_used and
                 semantic_attempt + 1 < semantic_limit)
             {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -2333,7 +2333,7 @@ test "processQueuedPrompt never uses the vision fallback for Codex" {
     job.authorized_image_catalog = &images;
 
     try std.testing.expectError(
-        error.CodexNativeImageUnavailable,
+        error.SubscriptionNativeImageUnavailable,
         runFakePrompt(&gateway, &hooks, fixture.config(), job),
     );
     try std.testing.expectEqual(@as(usize, 0), gateway.request_bodies.items.len);

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1088,6 +1088,10 @@ pub fn Runtime(comptime App: type) type {
                         .agent_stream_provider = tool_context.agent_stream_provider,
                         .permission_reviewer_provider = tool_context.permission_reviewer_provider,
                     },
+                    .grok = .{
+                        .agent_stream_provider = tool_context.agent_stream_provider,
+                        .permission_reviewer_provider = tool_context.permission_reviewer_provider,
+                    },
                 };
             return subagent_agent_adapter.run(.{
                 .host = app_session_runtime.Runtime(App).subagentHost(app) orelse

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -9,6 +9,7 @@ const credentials = @import("../auth/credentials.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
 const login_flow = @import("../auth/login_flow.zig");
 const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
+const grok_oauth = @import("../auth/grok_oauth.zig");
 const provider_catalog = @import("../auth/provider_catalog.zig");
 const model_provider = @import("../config/model_provider.zig");
 const model_catalog = @import("../gateway/model_catalog.zig");
@@ -44,23 +45,27 @@ pub fn Runtime(comptime App: type) type {
                 @hasDecl(@TypeOf(app.auth), "selectForProvider"))
             {
                 const provider = provider_runtime.provider(app);
-                const required_source: credentials.Source = if (provider == .codex)
-                    .chatgpt_subscription
-                else
-                    app.auth.credentialSource() orelse .fx_login;
+                const required_source: credentials.Source = switch (provider) {
+                    .codex => .chatgpt_subscription,
+                    .grok => .grok_subscription,
+                    .gateway => app.auth.credentialSource() orelse .fx_login,
+                };
                 const route_change = app.auth.selectForProvider(app.alloc, provider) catch |err| switch (err) {
                     error.OutOfMemory => return err,
                     else => return recoverCredentialFailure(app, required_source, err),
                 };
                 if (route_change) |changed| {
                     applyCredentialChange(app, changed);
-                } else if (provider == .codex and
-                    app.auth.credentialSource() != .chatgpt_subscription)
-                {
+                } else if (!model_provider.authorizesCredential(provider, app.auth.credentialSource())) {
                     try app.writeDomainNotice(.{
                         .topic = "auth",
                         .tone = .warning,
-                        .body = credentials.missing_chatgpt_interactive_credential_message,
+                        .body = if (provider == .grok)
+                            credentials.missing_grok_interactive_credential_message
+                        else if (provider == .codex)
+                            credentials.missing_chatgpt_interactive_credential_message
+                        else
+                            credentials.missing_interactive_credential_message,
                     }, true);
                     app.shell.render_requests.request(.footer);
                     return false;
@@ -120,7 +125,7 @@ pub fn Runtime(comptime App: type) type {
                 try app.writeDomainNotice(.{
                     .topic = "provider",
                     .tone = .warning,
-                    .body = "Usage: /provider [gateway|codex]",
+                    .body = "Usage: /provider [gateway|codex|grok]",
                 }, true);
                 return;
             };
@@ -143,7 +148,7 @@ pub fn Runtime(comptime App: type) type {
                     try writeAuthNotice(app, .{
                         .topic = "auth",
                         .tone = .warning,
-                        .body = "Usage: /logout [vercel|codex]",
+                        .body = "Usage: /logout [vercel|codex|grok]",
                     });
                     return;
                 };
@@ -152,12 +157,54 @@ pub fn Runtime(comptime App: type) type {
                 provider_runtime.provider(app) == .codex
             else
                 false;
+            const selected_model_uses_grok = if (comptime provider_runtime.supported(App))
+                provider_runtime.provider(app) == .grok
+            else
+                false;
             const provider_inventory = if (comptime @hasDecl(@TypeOf(app.auth), "pickerView")) inventory: {
                 try app.auth.refreshSourceInventory(app.alloc);
                 break :inventory app.auth.pickerView().available_sources;
             } else @as(auth_runtime.SourceSet, .empty);
             const chatgpt_is_only_logout_session = provider_inventory.contains(.chatgpt_subscription) and
-                !provider_inventory.contains(.fx_login);
+                !provider_inventory.contains(.fx_login) and
+                !provider_inventory.contains(.grok_subscription);
+            const grok_is_only_logout_session = provider_inventory.contains(.grok_subscription) and
+                !provider_inventory.contains(.fx_login) and
+                !provider_inventory.contains(.chatgpt_subscription);
+            const logout_grok = if (requested_provider) |provider|
+                provider == .grok
+            else
+                selected_model_uses_grok or
+                    app.auth.credentialSource() == .grok_subscription or
+                    grok_is_only_logout_session;
+            if (logout_grok) {
+                const outcome = grok_oauth.logout(app.alloc, app.auth.oauthTransport()) catch {
+                    try writeAuthNotice(app, .{
+                        .topic = "auth",
+                        .tone = .@"error",
+                        .body = "Could not durably sign out of Grok. The current source is unchanged.",
+                    });
+                    return;
+                };
+                const changed = if (comptime @hasDecl(@TypeOf(app.auth), "reconcileAfterGrokLogout"))
+                    try app.auth.reconcileAfterGrokLogout(app.alloc)
+                else
+                    false;
+                applyCredentialChange(app, changed);
+                try writeAuthNotice(app, switch (outcome.deletion) {
+                    .deleted => .{ .topic = "auth", .tone = .neutral, .body = "Signed out of Grok." },
+                    .missing => .{ .topic = "auth", .tone = .neutral, .body = "No Grok login session found." },
+                    .deleted_not_durable => .{ .topic = "auth", .tone = .warning, .body = "Signed out of Grok, but could not confirm the profile directory update." },
+                });
+                if (outcome.revocation_failed) {
+                    try writeAuthNotice(app, .{
+                        .topic = "auth",
+                        .tone = .warning,
+                        .body = "The local Grok session was removed, but remote revocation could not be confirmed.",
+                    });
+                }
+                return;
+            }
             const logout_chatgpt = if (requested_provider) |provider|
                 provider == .codex
             else
@@ -262,6 +309,7 @@ pub fn Runtime(comptime App: type) type {
                 .action => |action| switch (action) {
                     .login => try beginSignIn(app, true),
                     .chatgpt_login => try beginChatGptSignIn(app),
+                    .grok_login => try beginGrokSignIn(app),
                     .setup => {
                         if (comptime !runtime_profile.allows(App, .native_auth)) {
                             try app.writeDomainNotice(.{
@@ -328,7 +376,8 @@ pub fn Runtime(comptime App: type) type {
             else
                 .fx_login;
             const completes_provider_switch = if (comptime @hasDecl(@TypeOf(app.auth), "signInReturnsToRoot"))
-                sign_in_source == .chatgpt_subscription and !app.auth.signInReturnsToRoot()
+                (sign_in_source == .chatgpt_subscription or sign_in_source == .grok_subscription) and
+                    !app.auth.signInReturnsToRoot()
             else
                 false;
             app.auth.pulseSignIn(app.alloc);
@@ -398,6 +447,39 @@ pub fn Runtime(comptime App: type) type {
                                 .topic = "auth",
                                 .tone = .neutral,
                                 .body = "Signed in with Codex.",
+                            });
+                        },
+                        .grok => {
+                            try app.auth.refreshSourceInventory(app.alloc);
+                            if (completes_provider_switch and comptime provider_runtime.supported(App)) {
+                                app.auth.closePicker(app.alloc);
+                                try switchProvider(app, .grok, false);
+                                return;
+                            }
+                            const selected_model_uses_grok = if (comptime provider_runtime.supported(App))
+                                provider_runtime.provider(app) == .grok
+                            else
+                                false;
+                            if (selected_model_uses_grok and
+                                !try selectCredentialSource(app, .grok_subscription))
+                            {
+                                _ = app.auth.popPickerStage(app.alloc);
+                                try writeAuthNotice(app, .{
+                                    .topic = "auth",
+                                    .tone = .@"error",
+                                    .body = "Signed in, but the Grok subscription credential could not be loaded.",
+                                });
+                                return;
+                            }
+                            if (!selected_model_uses_grok) {
+                                app.model_cache.reset();
+                                if (comptime @hasDecl(App, "startModelCacheWarmup")) app.startModelCacheWarmup();
+                            }
+                            app.auth.closePicker(app.alloc);
+                            try writeAuthNotice(app, .{
+                                .topic = "auth",
+                                .tone = .neutral,
+                                .body = "Signed in with Grok.",
                             });
                         },
                     }
@@ -548,7 +630,7 @@ pub fn Runtime(comptime App: type) type {
         fn rememberCredentialSource(app: *App, source: credentials.Source) void {
             // ChatGPT is selected by model route, not as a global Gateway
             // credential preference. Its saved session coexists independently.
-            if (source == .chatgpt_subscription) return;
+            if (source == .chatgpt_subscription or source == .grok_subscription) return;
             if (comptime @hasDecl(App, "persistCredentialSourcePreference")) {
                 app.persistCredentialSourcePreference(source);
                 return;
@@ -582,12 +664,38 @@ pub fn Runtime(comptime App: type) type {
             }
         }
 
+        fn beginGrokSignIn(app: *App) !void {
+            try app.flushBeforeBlockingExternalWork();
+            const started = app.auth.openGrokSignInPickerFromRoot(app.alloc);
+            if (started catch |err| {
+                debug_trace.logf("auth", "Grok login failed err={s}", .{@errorName(err)});
+                try writeLoginError(app, .grok_subscription, err);
+                return;
+            }) {
+                app.shell.render_requests.request(.footer);
+                if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) try openSignInBrowser(app);
+            }
+        }
+
         fn beginCodexSignInForProviderSwitch(app: *App) !void {
             try app.flushBeforeBlockingExternalWork();
             const started = app.auth.openChatGptSignInPickerForProviderSwitch(app.alloc);
             if (started catch |err| {
                 debug_trace.logf("auth", "Codex login failed err={s}", .{@errorName(err)});
                 try writeLoginError(app, .chatgpt_subscription, err);
+                return;
+            }) {
+                app.shell.render_requests.request(.footer);
+                if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) try openSignInBrowser(app);
+            }
+        }
+
+        fn beginGrokSignInForProviderSwitch(app: *App) !void {
+            try app.flushBeforeBlockingExternalWork();
+            const started = app.auth.openGrokSignInPickerForProviderSwitch(app.alloc);
+            if (started catch |err| {
+                debug_trace.logf("auth", "Grok login failed err={s}", .{@errorName(err)});
+                try writeLoginError(app, .grok_subscription, err);
                 return;
             }) {
                 app.shell.render_requests.request(.footer);
@@ -615,7 +723,7 @@ pub fn Runtime(comptime App: type) type {
                 try app.writeDomainNotice(.{
                     .topic = "provider",
                     .tone = .warning,
-                    .body = "Codex provider switching is unavailable in this WASM session.",
+                    .body = "Subscription provider switching is unavailable in this WASM session.",
                 }, true);
                 return;
             }
@@ -670,11 +778,17 @@ pub fn Runtime(comptime App: type) type {
                     try beginCodexSignInForProviderSwitch(app);
                     return;
                 }
+                if (target == .grok and allow_login) {
+                    try beginGrokSignInForProviderSwitch(app);
+                    return;
+                }
                 try app.writeDomainNotice(.{
                     .topic = "provider",
                     .tone = .warning,
                     .body = if (target == .codex)
                         "Run fx login codex, then try switching again."
+                    else if (target == .grok)
+                        "Run fx login grok, then try switching again."
                     else
                         credentials.missing_interactive_credential_message,
                 }, true);
@@ -739,6 +853,7 @@ pub fn Runtime(comptime App: type) type {
             const saved_model = switch (target) {
                 .gateway => settings.model,
                 .codex => settings.codex_model,
+                .grok => settings.grok_model,
             };
             const requested_model = io_mod.getenv("FX_MODEL") orelse saved_model;
             var selected: ?[]const u8 = null;
@@ -792,6 +907,7 @@ pub fn Runtime(comptime App: type) type {
                 var persistence = config_runtime.attemptUserPreferences(app.alloc, switch (target) {
                     .gateway => .{ .provider = .gateway, .model = provider_runtime.model(app) },
                     .codex => .{ .provider = .codex, .codex_model = provider_runtime.model(app) },
+                    .grok => .{ .provider = .grok, .grok_model = provider_runtime.model(app) },
                 });
                 defer persistence.deinit(app.alloc);
                 switch (persistence) {
@@ -996,11 +1112,11 @@ pub fn Runtime(comptime App: type) type {
                 @hasField(@TypeOf(app.session), "usage"))
             {
                 if (app.auth.gatewayCredential()) |credential| {
-                    const chatgpt_subscription = if (comptime @hasField(@TypeOf(credential), "source"))
-                        credential.source == .chatgpt_subscription
+                    const subscription = if (comptime @hasField(@TypeOf(credential), "source"))
+                        credential.source == .chatgpt_subscription or credential.source == .grok_subscription
                     else
                         false;
-                    if (chatgpt_subscription) {
+                    if (subscription) {
                         app.session.usage.clearReconciliationCredential();
                     } else {
                         app.session.usage.replaceReconciliationCredential(
@@ -1020,6 +1136,12 @@ pub fn Runtime(comptime App: type) type {
                     error.ChatGptAuthorizationFailed => .{ .topic = "auth", .tone = .@"error", .body = "Codex sign-in was denied. The current credential is unchanged." },
                     error.ChatGptLoginTimedOut, error.LoginTimedOut => .{ .topic = "auth", .tone = .warning, .body = "Codex sign-in expired. The current credential is unchanged; run /login to try again." },
                     else => .{ .topic = "auth", .tone = .@"error", .body = "Codex sign-in failed. The current credential is unchanged." },
+                }
+            else if (source == .grok_subscription)
+                switch (err) {
+                    error.GrokAuthorizationFailed => .{ .topic = "auth", .tone = .@"error", .body = "Grok sign-in was denied. The current credential is unchanged." },
+                    error.GrokLoginTimedOut, error.LoginTimedOut => .{ .topic = "auth", .tone = .warning, .body = "Grok sign-in expired. The current credential is unchanged; run /login to try again." },
+                    else => .{ .topic = "auth", .tone = .@"error", .body = "Grok sign-in failed. The current credential is unchanged." },
                 }
             else switch (err) {
                 error.ClientIdMissing => .{ .topic = "auth", .tone = .@"error", .body = "fx login is not configured yet. The current credential is unchanged." },

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -51,6 +51,9 @@ pub const Config = struct {
     codex_agent_stream: ?agent_stream_provider.Provider = null,
     codex_cli_model_catalog: ?gateway_provider.CliModelCatalogProvider = null,
     codex_model_catalog: ?model_catalog.Provider = null,
+    grok_agent_stream: ?agent_stream_provider.Provider = null,
+    grok_cli_model_catalog: ?gateway_provider.CliModelCatalogProvider = null,
+    grok_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     url_opener: host.UrlOpener,
@@ -74,6 +77,7 @@ pub const Config = struct {
     devbox_provider: ?devbox_executor.Provider = null,
     permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     codex_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
+    grok_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
 };
 
 pub fn run(comptime App: type, alloc: Allocator, args: []const [:0]const u8, cfg: Config) !void {
@@ -402,6 +406,9 @@ fn cliSurfaceConfig(cfg: Config) cli_surface.Config {
         .codex_agent_stream = cfg.codex_agent_stream,
         .codex_cli_model_catalog = cfg.codex_cli_model_catalog,
         .codex_model_catalog = cfg.codex_model_catalog,
+        .grok_agent_stream = cfg.grok_agent_stream,
+        .grok_cli_model_catalog = cfg.grok_cli_model_catalog,
+        .grok_model_catalog = cfg.grok_model_catalog,
         .background_process_provider = cfg.background_process_provider,
         .url_opener = cfg.url_opener,
         .secret_store = cfg.secret_store,
@@ -424,6 +431,7 @@ fn cliSurfaceConfig(cfg: Config) cli_surface.Config {
         .devbox_provider = cfg.devbox_provider,
         .permission_reviewer_provider = cfg.permission_reviewer_provider,
         .codex_permission_reviewer_provider = cfg.codex_permission_reviewer_provider,
+        .grok_permission_reviewer_provider = cfg.grok_permission_reviewer_provider,
     };
 }
 

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -4018,7 +4018,7 @@ test "app_input_runtime auth stage Escape pops before closing the picker" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..4) |_| _ = app.auth.movePicker(1);
+    for (0..5) |_| _ = app.auth.movePicker(1);
     try std.testing.expect((auth_runtime.Choice{ .action = .switch_credential }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -4046,7 +4046,7 @@ test "app_input_runtime disabled change team action stays silent" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..3) |_| _ = app.auth.movePicker(1);
+    for (0..4) |_| _ = app.auth.movePicker(1);
     try std.testing.expect((auth_runtime.Choice{ .action = .change_team }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -7711,7 +7711,7 @@ fn openRoutingAuthPicker(app: *RoutingFakeApp) !void {
     app.auth.source_inventory.insert(.ai_gateway_api_key);
     app.auth.openPicker(app.alloc);
     try std.testing.expect(app.auth.movePicker(1));
-    try std.testing.expectEqual(@as(usize, 5), app.auth.pickerView().choiceCount());
+    try std.testing.expectEqual(@as(usize, 6), app.auth.pickerView().choiceCount());
     try std.testing.expectEqual(@as(usize, 1), app.auth.pickerView().selectedIndex());
 }
 

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -1122,6 +1122,7 @@ fn configuredProviderSelection(
     const model = switch (provider) {
         .gateway => settings.model orelse default_model,
         .codex => settings.codex_model orelse return error.CodexModelNotSelected,
+        .grok => settings.grok_model orelse return error.GrokModelNotSelected,
     };
     return .{ .provider = provider, .model = model };
 }
@@ -1156,6 +1157,14 @@ test "startup provider chooses only its provider-scoped model" {
         error.CodexModelNotSelected,
         configuredProviderSelection("default/model", &missing_codex),
     );
+
+    const grok_settings = config_runtime.Settings{
+        .provider = .grok,
+        .grok_model = @constCast("grok-model"),
+    };
+    const grok = try configuredProviderSelection("default/model", &grok_settings);
+    try std.testing.expectEqual(model_provider.ProviderId.grok, grok.provider);
+    try std.testing.expectEqualStrings("grok-model", grok.model);
 }
 
 fn loadInitialModel(alloc: Allocator, default_model: []const u8, configured: ?[]const u8) ![]u8 {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -352,6 +352,7 @@ pub const SessionPreferencePatch = struct {
             switch (provider) {
                 .gateway => patch.model = self.model,
                 .codex => patch.codex_model = self.model,
+                .grok => patch.grok_model = self.model,
             }
         } else {
             patch.model = self.model;
@@ -1827,7 +1828,7 @@ pub fn Runtime(comptime App: type) type {
         pub fn startResumedSessionReconciliation(app: *App) void {
             if (comptime @hasField(App, "auth")) {
                 if (comptime @hasDecl(@TypeOf(app.auth), "credentialSource")) {
-                    if (app.auth.credentialSource() == .chatgpt_subscription) {
+                    if (app.auth.credentialSource() == .chatgpt_subscription or app.auth.credentialSource() == .grok_subscription) {
                         app.session.usage.clearReconciliationCredential();
                         return;
                     }

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const api_key_validator = @import("api_key_validator.zig");
 const credentials = @import("credentials.zig");
 const chatgpt_oauth = @import("chatgpt_oauth.zig");
+const grok_oauth = @import("grok_oauth.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
 const login_flow = @import("login_flow.zig");
@@ -27,6 +28,7 @@ const credential_source_order = [_]credentials.Source{
     .fx_login,
     .stored_key,
     .chatgpt_subscription,
+    .grok_subscription,
 };
 
 const SourceProbeFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!bool;
@@ -128,6 +130,10 @@ pub fn refreshCredentialTokenForAccount(
             .if_needed => (try credentials.loadSource(alloc, transport, host.unavailable_secret_store, source)) orelse return null,
             .force => (try credentials.refreshChatGptCredential(alloc, transport)) orelse return null,
         },
+        .grok_subscription => switch (mode) {
+            .if_needed => (try credentials.loadSource(alloc, transport, host.unavailable_secret_store, source)) orelse return null,
+            .force => (try credentials.refreshGrokCredential(alloc, transport)) orelse return null,
+        },
         else => unreachable,
     };
     defer credential.deinit(alloc);
@@ -144,6 +150,7 @@ pub fn refreshCredentialTokenForAccount(
 pub const AcquisitionAction = enum {
     login,
     chatgpt_login,
+    grok_login,
     setup,
     change_team,
     switch_credential,
@@ -379,12 +386,12 @@ pub const PickerView = struct {
     pub fn choiceCount(self: PickerView) usize {
         return switch (self.stage) {
             .root => if (self.include_skip)
-                if (comptime host_target.is_wasm) 2 else 3
+                if (comptime host_target.is_wasm) 2 else 4
             else if (comptime host_target.is_wasm)
                 4
             else
-                5,
-            .provider => 2,
+                6,
+            .provider => if (comptime host_target.is_wasm) 2 else 3,
             .sign_in, .api_key => 0,
             .change_team => blk: {
                 var count: usize = 0;
@@ -409,7 +416,8 @@ pub const PickerView = struct {
                 else switch (index) {
                     0 => .{ .action = .login },
                     1 => .{ .action = .chatgpt_login },
-                    2 => .{ .action = .setup },
+                    2 => .{ .action = .grok_login },
+                    3 => .{ .action = .setup },
                     else => null,
                 }
             else if (comptime host_target.is_wasm)
@@ -423,14 +431,16 @@ pub const PickerView = struct {
             else switch (index) {
                 0 => .{ .action = .login },
                 1 => .{ .action = .chatgpt_login },
-                2 => .{ .action = .setup },
-                3 => .{ .action = .change_team },
-                4 => .{ .action = .switch_credential },
+                2 => .{ .action = .grok_login },
+                3 => .{ .action = .setup },
+                4 => .{ .action = .change_team },
+                5 => .{ .action = .switch_credential },
                 else => null,
             },
             .provider => switch (index) {
                 0 => .{ .provider = .gateway },
                 1 => .{ .provider = .codex },
+                2 => if (comptime host_target.is_wasm) null else .{ .provider = .grok },
                 else => null,
             },
             .sign_in, .api_key => null,
@@ -473,6 +483,7 @@ pub const PickerView = struct {
             .action => |action| switch (action) {
                 .login => "Sign in with Vercel",
                 .chatgpt_login => "Sign in with Codex",
+                .grok_login => "Sign in with Grok",
                 .setup => if (self.include_skip) "Add an API key" else "API key",
                 .change_team => "Change team",
                 .switch_credential => "Switch credential",
@@ -489,6 +500,7 @@ pub const PickerView = struct {
             .action => |action| switch (action) {
                 .login => if (self.fx_login_session_available) "connected" else "",
                 .chatgpt_login => if (self.available_sources.contains(.chatgpt_subscription)) "connected" else "",
+                .grok_login => if (self.available_sources.contains(.grok_subscription)) "connected" else "",
                 .setup, .switch_credential => "",
                 .automatic => "use normal precedence",
                 .change_team => if (self.fx_login_session_available) "choose a team" else "sign in first",
@@ -500,7 +512,8 @@ pub const PickerView = struct {
     pub fn choiceEnabled(self: PickerView, choice: Choice) bool {
         return switch (choice) {
             .action => |action| (action != .change_team or self.fx_login_session_available) and
-                (action != .chatgpt_login or !host_target.is_wasm),
+                (action != .chatgpt_login or !host_target.is_wasm) and
+                (action != .grok_login or !host_target.is_wasm),
             .provider, .source, .team => true,
         };
     }
@@ -545,6 +558,7 @@ pub const StatusSnapshot = struct {
     stored_key_status: credentials.StoredKeyReadStatus = .not_attempted,
     gateway_connected: bool = false,
     chatgpt_connected: bool = false,
+    grok_connected: bool = false,
     /// The active credential is past its refresh deadline. Distinct from `refreshable`,
     /// which answers whether this source type can refresh at all.
     expired: bool = false,
@@ -570,6 +584,12 @@ pub const StatusSnapshot = struct {
             return switch (surface) {
                 .cli => credentials.missing_chatgpt_credential_message,
                 .interactive => credentials.missing_chatgpt_interactive_credential_message,
+            };
+        }
+        if (self.required_source == .grok_subscription) {
+            return switch (surface) {
+                .cli => credentials.missing_grok_credential_message,
+                .interactive => credentials.missing_grok_interactive_credential_message,
             };
         }
         return switch (surface) {
@@ -615,6 +635,14 @@ pub fn loadStatusSnapshotForProvider(
         error.OutOfMemory => return err,
         else => false,
     };
+    const grok_connected = credentials.sourceExists(
+        alloc,
+        secret_store,
+        .grok_subscription,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => false,
+    };
     // Resolves in `.stored` mode: a diagnostic must not refresh, because refreshing
     // rewrites the session file and performs network I/O. It reports the expired state
     // instead of repairing it.
@@ -643,9 +671,9 @@ pub fn loadStatusSnapshotForProvider(
         },
     };
     const resolved_source = if (resolution.credential) |credential| credential.source else null;
-    var gateway_connected = resolved_source != null and resolved_source != .chatgpt_subscription;
-    const gateway_probe_required = provider == .codex or
-        resolved_source == .chatgpt_subscription;
+    var gateway_connected = resolved_source != null and resolved_source != .chatgpt_subscription and resolved_source != .grok_subscription;
+    const gateway_probe_required = provider == .codex or provider == .grok or
+        resolved_source == .chatgpt_subscription or resolved_source == .grok_subscription;
     if (gateway_probe_required) {
         for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key }) |source| {
             if (credentials.sourceExists(alloc, secret_store, source) catch |err| switch (err) {
@@ -669,14 +697,21 @@ pub fn loadStatusSnapshotForProvider(
             .stored_key_status = resolution.stored_key_status,
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
+            .grok_connected = grok_connected,
             .expired = expired,
         };
     }
     return .{
-        .required_source = if (provider == .codex) .chatgpt_subscription else null,
+        .required_source = if (provider == .codex)
+            .chatgpt_subscription
+        else if (provider == .grok)
+            .grok_subscription
+        else
+            null,
         .stored_key_status = resolution.stored_key_status,
         .gateway_connected = gateway_connected,
         .chatgpt_connected = chatgpt_connected,
+        .grok_connected = grok_connected,
     };
 }
 
@@ -826,15 +861,18 @@ pub const Runtime = struct {
             self.source_inventory.contains(.fx_login) or
             self.source_inventory.contains(.stored_key);
         const chatgpt_connected = self.source_inventory.contains(.chatgpt_subscription);
+        const grok_connected = self.source_inventory.contains(.grok_subscription);
         const credential = self.selected_credential orelse return .{
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
+            .grok_connected = grok_connected,
         };
         return .{
             .active_source = credential.source,
             .team = displayTeam(credential),
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
+            .grok_connected = grok_connected,
             .expired = credential.needsRefreshAt(now_ms),
         };
     }
@@ -876,6 +914,14 @@ pub const Runtime = struct {
             self.source_inventory.insert(.chatgpt_subscription);
         } else if (self.credentialSource() != .chatgpt_subscription) {
             self.source_inventory.remove(.chatgpt_subscription);
+        }
+    }
+
+    pub fn refreshGrokSourceInventory(self: *Self, alloc: Allocator) !void {
+        if (try credentials.sourceExists(alloc, self.secret_store, .grok_subscription)) {
+            self.source_inventory.insert(.grok_subscription);
+        } else if (self.credentialSource() != .grok_subscription) {
+            self.source_inventory.remove(.grok_subscription);
         }
     }
 
@@ -1004,7 +1050,7 @@ pub const Runtime = struct {
         self.picker_stage = .switch_credential;
         const active_source = self.credentialSource();
         self.picker_selection = if (active_source) |source|
-            if (source != .chatgpt_subscription and self.source_inventory.contains(source))
+            if (source != .chatgpt_subscription and source != .grok_subscription and self.source_inventory.contains(source))
                 .{ .source = source }
             else
                 self.pickerView().choiceAt(0)
@@ -1048,6 +1094,16 @@ pub const Runtime = struct {
         return self.openSignInPickerWithParent(alloc, false, .chatgpt_subscription);
     }
 
+    pub fn openGrokSignInPickerFromRoot(self: *Self, alloc: Allocator) !bool {
+        if (comptime host_target.is_wasm) return error.GrokOAuthUnavailable;
+        return self.openSignInPickerWithParent(alloc, true, .grok_subscription);
+    }
+
+    pub fn openGrokSignInPickerForProviderSwitch(self: *Self, alloc: Allocator) !bool {
+        if (comptime host_target.is_wasm) return error.GrokOAuthUnavailable;
+        return self.openSignInPickerWithParent(alloc, false, .grok_subscription);
+    }
+
     fn openSignInPickerWithParent(
         self: *Self,
         alloc: Allocator,
@@ -1058,6 +1114,7 @@ pub const Runtime = struct {
         const started = switch (source) {
             .fx_login => try self.sign_in_flow.start(alloc, self.oauth_transport),
             .chatgpt_subscription => try chatgpt_oauth.startSignIn(&self.sign_in_flow, alloc, self.oauth_transport),
+            .grok_subscription => try grok_oauth.startSignIn(&self.sign_in_flow, alloc, self.oauth_transport),
             else => return error.InvalidSignInSource,
         };
         if (!started) return false;
@@ -1203,7 +1260,12 @@ pub const Runtime = struct {
         self.picker_selection = .{ .action = switch (stage) {
             .root => unreachable,
             .provider => unreachable,
-            .sign_in => if (self.sign_in_source == .chatgpt_subscription) .chatgpt_login else .login,
+            .sign_in => if (self.sign_in_source == .chatgpt_subscription)
+                .chatgpt_login
+            else if (self.sign_in_source == .grok_subscription)
+                .grok_login
+            else
+                .login,
             .api_key => .setup,
             .change_team => .change_team,
             .switch_credential => .switch_credential,
@@ -1244,7 +1306,7 @@ pub const Runtime = struct {
                     .setup => {},
                     // Only reachable from the switch screen, never the root.
                     .automatic => unreachable,
-                    .login, .chatgpt_login => self.closePicker(alloc),
+                    .login, .chatgpt_login, .grok_login => self.closePicker(alloc),
                 },
                 .team => unreachable,
             },
@@ -1346,7 +1408,16 @@ pub const Runtime = struct {
                     self,
                     loadRuntimeCredentialSource,
                 ),
-            .gateway => if (self.credentialSource() != .chatgpt_subscription)
+            .grok => if (self.credentialSource() == .grok_subscription)
+                false
+            else
+                self.selectSourceWithLoader(
+                    alloc,
+                    .grok_subscription,
+                    self,
+                    loadRuntimeCredentialSource,
+                ),
+            .gateway => if (self.credentialSource() != .chatgpt_subscription and self.credentialSource() != .grok_subscription)
                 false
             else
                 @as(?bool, try self.reselectByPrecedenceWithDeps(
@@ -1391,7 +1462,7 @@ pub const Runtime = struct {
 
         try self.refreshSourceInventoryWithProbe(alloc, ctx, probe);
         for (credential_source_order) |source| {
-            if (source == .chatgpt_subscription) continue;
+            if (source == .chatgpt_subscription or source == .grok_subscription) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) {
                 return self.credentialSource() != previous;
@@ -1405,6 +1476,18 @@ pub const Runtime = struct {
     pub fn reconcileAfterChatGptLogout(self: *Self, alloc: Allocator) !bool {
         const was_available = self.source_inventory.contains(.chatgpt_subscription);
         const was_active = self.credentialSource() == .chatgpt_subscription;
+        if (was_active) {
+            if (self.selected_credential) |*credential| credential.deinit(alloc);
+            self.selected_credential = null;
+            self.credential_refresh_failure_source = null;
+        }
+        try self.refreshSourceInventory(alloc);
+        return was_active or was_available;
+    }
+
+    pub fn reconcileAfterGrokLogout(self: *Self, alloc: Allocator) !bool {
+        const was_available = self.source_inventory.contains(.grok_subscription);
+        const was_active = self.credentialSource() == .grok_subscription;
         if (was_active) {
             if (self.selected_credential) |*credential| credential.deinit(alloc);
             self.selected_credential = null;
@@ -1441,7 +1524,7 @@ pub const Runtime = struct {
         if (!login_was_active) return false;
 
         for (credential_source_order) |source| {
-            if (source == .chatgpt_subscription) continue;
+            if (source == .chatgpt_subscription or source == .grok_subscription) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) return true;
             self.source_inventory.remove(source);
@@ -1537,7 +1620,7 @@ fn takeDisplayTeam(alloc: Allocator, credential: *credentials.Credential) ?[]u8 
 fn gatewaySourceCount(sources: SourceSet) usize {
     var count: usize = 0;
     for (credential_source_order) |source| {
-        if (source == .chatgpt_subscription or !sources.contains(source)) continue;
+        if (source == .chatgpt_subscription or source == .grok_subscription or !sources.contains(source)) continue;
         count += 1;
     }
     return count;
@@ -1546,7 +1629,7 @@ fn gatewaySourceCount(sources: SourceSet) usize {
 fn gatewaySourceAtIndex(sources: SourceSet, wanted_index: usize) ?credentials.Source {
     var index: usize = 0;
     for (credential_source_order) |source| {
-        if (source == .chatgpt_subscription or !sources.contains(source)) continue;
+        if (source == .chatgpt_subscription or source == .grok_subscription or !sources.contains(source)) continue;
         if (index == wanted_index) return source;
         index += 1;
     }
@@ -2206,15 +2289,15 @@ test "auth picker root starts on sign in and keeps sources in the switch stage" 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.active);
     try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
-    try std.testing.expectEqual(@as(usize, 5), picker.choiceCount());
-    try std.testing.expect(picker.choiceAt(5) == null);
+    try std.testing.expectEqual(@as(usize, 6), picker.choiceCount());
+    try std.testing.expect(picker.choiceAt(6) == null);
 }
 
-test "credential switcher excludes provider-routed ChatGPT sessions" {
+test "credential switcher excludes provider-routed subscription sessions" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     defer runtime.deinit(alloc);
-    runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .chatgpt_subscription });
+    runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .chatgpt_subscription, .grok_subscription });
     runtime.openPicker(alloc);
     runtime.openSwitchCredentialPicker(alloc);
 
@@ -2224,7 +2307,7 @@ test "credential switcher excludes provider-routed ChatGPT sessions" {
     try std.testing.expect((Choice{ .action = .automatic }).eql(picker.choiceAt(1).?));
 }
 
-test "auth picker navigation wraps across the five hub actions" {
+test "auth picker navigation wraps across the six hub actions" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .fx_login });
@@ -2232,6 +2315,8 @@ test "auth picker navigation wraps across the five hub actions" {
 
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(runtime.pickerView().selected_choice.?));
+    try std.testing.expect(runtime.movePicker(1));
+    try std.testing.expect((Choice{ .action = .grok_login }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expect((Choice{ .action = .setup }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
@@ -2265,7 +2350,7 @@ test "auth picker without credentials exposes acquisition actions" {
     try std.testing.expect(picker.active_source == null);
     try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
     try std.testing.expectEqual(@as(usize, 0), picker.available_sources.count());
-    try std.testing.expectEqual(@as(usize, 5), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 6), picker.choiceCount());
     try std.testing.expect(!picker.choiceEnabled(.{ .action = .change_team }));
     try std.testing.expectEqualStrings("missing", picker.activeSourceLabel());
 }
@@ -2277,12 +2362,13 @@ test "auth onboarding picker exposes the setup paths" {
 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.include_skip);
-    try std.testing.expectEqual(@as(usize, 3), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 4), picker.choiceCount());
     try std.testing.expect((Choice{ .action = .login }).eql(picker.choiceAt(0).?));
     try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(picker.choiceAt(1).?));
-    try std.testing.expect((Choice{ .action = .setup }).eql(picker.choiceAt(2).?));
-    try std.testing.expectEqualStrings("Add an API key", picker.choiceLabel(picker.choiceAt(2).?));
-    try std.testing.expect(picker.choiceAt(3) == null);
+    try std.testing.expect((Choice{ .action = .grok_login }).eql(picker.choiceAt(2).?));
+    try std.testing.expect((Choice{ .action = .setup }).eql(picker.choiceAt(3).?));
+    try std.testing.expectEqualStrings("Add an API key", picker.choiceLabel(picker.choiceAt(3).?));
+    try std.testing.expect(picker.choiceAt(4) == null);
 }
 
 test "clearing a remembered choice re-resolves even when no login was active" {

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const chatgpt_oauth = @import("chatgpt_oauth.zig");
+const grok_oauth = @import("grok_oauth.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const io_mod = @import("../shared/io.zig");
@@ -20,6 +21,7 @@ pub const CatalogPublicOnly = union(enum) {
     credential_refresh_failed: Source,
     authenticated_credential_rejected: Source,
     chatgpt_subscription,
+    grok_subscription,
 
     fn credentialSource(self: CatalogPublicOnly) ?Source {
         return switch (self) {
@@ -28,6 +30,7 @@ pub const CatalogPublicOnly = union(enum) {
             .credential_refresh_failed => |source| source,
             .authenticated_credential_rejected => |source| source,
             .chatgpt_subscription => .chatgpt_subscription,
+            .grok_subscription => .grok_subscription,
         };
     }
 };
@@ -40,6 +43,7 @@ pub const CatalogAuthenticatedSource = enum {
     fx_login,
     stored_key,
     chatgpt_subscription,
+    grok_subscription,
 
     fn credentialSource(self: CatalogAuthenticatedSource) Source {
         return switch (self) {
@@ -48,6 +52,7 @@ pub const CatalogAuthenticatedSource = enum {
             .fx_login => .fx_login,
             .stored_key => .stored_key,
             .chatgpt_subscription => .chatgpt_subscription,
+            .grok_subscription => .grok_subscription,
         };
     }
 };
@@ -85,7 +90,7 @@ pub const CatalogAccess = union(enum) {
     pub fn publicFallbackAfterRejection(self: CatalogAccess) ?CatalogAccess {
         return switch (self) {
             .public_only => null,
-            .authenticated => |access| if (access.source == .chatgpt_subscription)
+            .authenticated => |access| if (access.source == .chatgpt_subscription or access.source == .grok_subscription)
                 null
             else
                 .{
@@ -143,6 +148,7 @@ pub fn catalogAccessForCredential(
         .ai_gateway_api_key => .ai_gateway_api_key,
         .stored_key => .stored_key,
         .chatgpt_subscription => .chatgpt_subscription,
+        .grok_subscription => .grok_subscription,
         .fx_login => blk: {
             const team = team_context orelse
                 return .{ .public_only = .fx_login_team_required };
@@ -155,7 +161,7 @@ pub fn catalogAccessForCredential(
         .authenticated = .{
             .source = authenticated_source,
             .credential = credential,
-            .team_context = if (authenticated_source == .chatgpt_subscription) null else team_context,
+            .team_context = if (authenticated_source == .chatgpt_subscription or authenticated_source == .grok_subscription) null else team_context,
         },
     };
 }
@@ -174,6 +180,8 @@ pub const missing_credential_message = "Fx needs access to Vercel AI Gateway. Ru
 pub const missing_interactive_credential_message = "Fx needs access to Vercel AI Gateway. Run /login to sign in, /setup to use an API key, or set AI_GATEWAY_API_KEY.";
 pub const missing_chatgpt_credential_message = "fx needs a Codex subscription login for this model. Run fx login codex.";
 pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login and choose Sign in with Codex.";
+pub const missing_grok_credential_message = "fx needs a Grok subscription login for this model. Run fx login grok.";
+pub const missing_grok_interactive_credential_message = "Grok needs a subscription login. Run /login and choose Sign in with Grok.";
 pub const unreadable_store_message = "Fx could not read the stored API key from " ++ stored_key_backend_label ++ ". A key may be saved but unreadable. Set FX_TRACE_LOG for the failing step, or set AI_GATEWAY_API_KEY.";
 
 pub const Credential = struct {
@@ -248,19 +256,29 @@ pub fn resolveForProvider(
     provider: model_provider.ProviderId,
     preferred: ?Source,
 ) !Resolution {
-    if (provider == .codex) {
-        const credential = switch (mode) {
-            .stored => try loadStoredChatGptCredential(alloc),
-            .refresh_if_needed => try loadChatGptCredential(alloc, transport, .if_needed),
-        };
-        return .{ .credential = credential };
+    switch (provider) {
+        .codex => {
+            const credential = switch (mode) {
+                .stored => try loadStoredChatGptCredential(alloc),
+                .refresh_if_needed => try loadChatGptCredential(alloc, transport, .if_needed),
+            };
+            return .{ .credential = credential };
+        },
+        .grok => {
+            const credential = switch (mode) {
+                .stored => try loadStoredGrokCredential(alloc),
+                .refresh_if_needed => try loadGrokCredential(alloc, transport, .if_needed),
+            };
+            return .{ .credential = credential };
+        },
+        .gateway => {},
     }
     return resolvePreferring(
         alloc,
         transport,
         secret_store,
         mode,
-        if (preferred == .chatgpt_subscription) null else preferred,
+        if (preferred == .chatgpt_subscription or preferred == .grok_subscription) null else preferred,
     );
 }
 
@@ -346,6 +364,10 @@ fn loadPreferredSource(
             .stored => loadStoredChatGptCredential(alloc),
             .refresh_if_needed => loadChatGptCredential(alloc, transport, .if_needed),
         },
+        .grok_subscription => switch (mode) {
+            .stored => loadStoredGrokCredential(alloc),
+            .refresh_if_needed => loadGrokCredential(alloc, transport, .if_needed),
+        },
         else => loadSource(alloc, transport, secret_store, source),
     };
 }
@@ -362,6 +384,7 @@ pub fn loadSource(
         .fx_login => loadFxLoginCredential(alloc, transport),
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
         .chatgpt_subscription => loadChatGptCredential(alloc, transport, .if_needed),
+        .grok_subscription => loadGrokCredential(alloc, transport, .if_needed),
     };
 }
 
@@ -386,6 +409,7 @@ pub fn sourceExists(
             break :blk true;
         },
         .chatgpt_subscription => chatgpt_oauth.sourceExists(alloc),
+        .grok_subscription => grok_oauth.sourceExists(alloc),
         .stored_key => blk: {
             if (secret_store.isDisabled()) break :blk false;
             const stored = secret_store.load(alloc) catch |err| switch (err) {
@@ -446,6 +470,29 @@ fn loadStoredChatGptCredential(alloc: std.mem.Allocator) !?Credential {
     return loadChatGptCredential(alloc, oauth_transport.unavailable_provider, .stored);
 }
 
+fn loadGrokCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+    mode: grok_oauth.RefreshMode,
+) !?Credential {
+    var access = (try grok_oauth.loadAccess(alloc, transport, mode)) orelse return null;
+    defer access.deinit(alloc);
+    const token = access.access_token;
+    access.access_token = &.{};
+    const account_id = access.account_id;
+    access.account_id = &.{};
+    return .{
+        .token = token,
+        .source = .grok_subscription,
+        .account_id = account_id,
+        .refresh_after_ms = access.refresh_after_ms,
+    };
+}
+
+fn loadStoredGrokCredential(alloc: std.mem.Allocator) !?Credential {
+    return loadGrokCredential(alloc, oauth_transport.unavailable_provider, .stored);
+}
+
 fn nonEmptyEnvValue(name: []const u8) ?[]const u8 {
     return nonEmptyValue(io_mod.getenv(name));
 }
@@ -488,6 +535,13 @@ pub fn refreshChatGptCredential(
     transport: oauth_transport.Provider,
 ) !?Credential {
     return loadChatGptCredential(alloc, transport, .force);
+}
+
+pub fn refreshGrokCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+) !?Credential {
+    return loadGrokCredential(alloc, transport, .force);
 }
 
 fn refreshFxLoginCredentialLocked(
@@ -581,11 +635,12 @@ pub fn sourceLabel(source: Source) []const u8 {
         .fx_login => "fx login",
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
         .chatgpt_subscription => "Codex subscription",
+        .grok_subscription => "Grok subscription",
     };
 }
 
 pub fn sourceRefreshable(source: Source) bool {
-    return source == .fx_login or source == .chatgpt_subscription;
+    return source == .fx_login or source == .chatgpt_subscription or source == .grok_subscription;
 }
 
 test "stored key label discloses the backend that answered" {

--- a/src/core/auth/grok_oauth.zig
+++ b/src/core/auth/grok_oauth.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const chatgpt_session = @import("chatgpt_session.zig");
+const grok_session = @import("grok_session.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
@@ -11,14 +11,16 @@ const secret = @import("secret.zig");
 
 const Allocator = std.mem.Allocator;
 
-pub const client_id = "app_EMoamEEZ73f0CkXaXp7hrann";
-pub const token_url = "https://auth.openai.com/oauth/token";
-pub const issuer_url = "https://auth.openai.com";
-const e2e_token_url_env = "FX_E2E_CHATGPT_TOKEN_URL";
-const e2e_issuer_url_env = "FX_E2E_CHATGPT_ISSUER_URL";
-const jwt_auth_claim = "https://api.openai.com/auth";
-const browser_scope = "openid profile email offline_access api.connectors.read api.connectors.invoke";
-const browser_callback_ports = [_]u16{ 1455, 1457 };
+const client_id = "b1a00492-073a-47ea-816f-4c329264a828";
+const token_url = "https://auth.x.ai/oauth2/token";
+const issuer_url = "https://auth.x.ai";
+const userinfo_url = "https://auth.x.ai/oauth2/userinfo";
+const revoke_url = "https://auth.x.ai/oauth2/revoke";
+const e2e_token_url_env = "FX_E2E_GROK_TOKEN_URL";
+const e2e_issuer_url_env = "FX_E2E_GROK_ISSUER_URL";
+const e2e_userinfo_url_env = "FX_E2E_GROK_USERINFO_URL";
+const e2e_revoke_url_env = "FX_E2E_GROK_REVOKE_URL";
+const browser_scope = "openid profile email offline_access grok-cli:access api:access";
 const browser_login_timeout_seconds: i64 = 5 * 60;
 const browser_callback_poll_ms: i32 = 100;
 const browser_callback_io_timeout_seconds: i64 = 30;
@@ -58,6 +60,7 @@ const BrowserLoginContext = struct {
     redirect_uri: []u8,
     code_verifier: []u8,
     state: []u8,
+    transport: oauth_transport.Provider,
 
     fn deinit(self: *BrowserLoginContext, alloc: Allocator) void {
         self.listener.deinit(io_mod.getIo());
@@ -78,7 +81,7 @@ pub fn startSignIn(
     alloc: Allocator,
     transport: oauth_transport.Provider,
 ) !bool {
-    const browser = try prepareBrowserSignIn(alloc);
+    const browser = try prepareBrowserSignIn(alloc, transport);
     return runtime.startPrepared(
         alloc,
         browser.prepared,
@@ -96,19 +99,19 @@ pub fn startSignIn(
     );
 }
 
-fn prepareBrowserSignIn(alloc: Allocator) !PreparedBrowserLogin {
+fn prepareBrowserSignIn(alloc: Allocator, transport: oauth_transport.Provider) !PreparedBrowserLogin {
     const configured_issuer = try configuredEndpoint(alloc, e2e_issuer_url_env, issuer_url);
     defer alloc.free(configured_issuer);
     const configured_token_endpoint = try configuredEndpoint(alloc, e2e_token_url_env, token_url);
     errdefer alloc.free(configured_token_endpoint);
 
-    var listener = try bindBrowserCallback(io_mod.getenv(e2e_issuer_url_env) != null);
+    var listener = try bindBrowserCallback();
     var listener_owned = true;
     errdefer if (listener_owned) listener.deinit(io_mod.getIo());
     const callback_port = listener.socket.address.getPort();
     const redirect_uri = try std.fmt.allocPrint(
         alloc,
-        "http://localhost:{d}/auth/callback",
+        "http://127.0.0.1:{d}/callback",
         .{callback_port},
     );
     errdefer alloc.free(redirect_uri);
@@ -134,6 +137,7 @@ fn prepareBrowserSignIn(alloc: Allocator) !PreparedBrowserLogin {
         .redirect_uri = redirect_uri,
         .code_verifier = code_verifier,
         .state = state,
+        .transport = transport,
     };
     listener_owned = false;
 
@@ -141,7 +145,7 @@ fn prepareBrowserSignIn(alloc: Allocator) !PreparedBrowserLogin {
     errdefer alloc.free(owned_issuer);
     const authorization_endpoint = try std.fmt.allocPrint(
         alloc,
-        "{s}/oauth/authorize",
+        "{s}/oauth2/authorize",
         .{std.mem.trimEnd(u8, configured_issuer, "/")},
     );
     errdefer alloc.free(authorization_endpoint);
@@ -178,19 +182,9 @@ fn deinitBrowserLoginContext(raw: ?*anyopaque, alloc: Allocator) void {
     alloc.destroy(context);
 }
 
-fn bindBrowserCallback(e2e: bool) !std.Io.net.Server {
-    if (e2e) {
-        var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
-        return address.listen(io_mod.getIo(), .{ .reuse_address = true });
-    }
-    for (browser_callback_ports) |port| {
-        var address = try std.Io.net.IpAddress.parse("127.0.0.1", port);
-        return address.listen(io_mod.getIo(), .{ .reuse_address = true }) catch |err| switch (err) {
-            error.AddressInUse => continue,
-            else => return err,
-        };
-    }
-    return error.ChatGptOAuthCallbackPortUnavailable;
+fn bindBrowserCallback() !std.Io.net.Server {
+    var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    return address.listen(io_mod.getIo(), .{ .reuse_address = true });
 }
 
 fn randomUrlSafeSecret(alloc: Allocator) ![]u8 {
@@ -221,7 +215,7 @@ fn pollBrowserToken(
     cancel_flag: *std.atomic.Value(bool),
     deadline: std.Io.Clock.Timestamp,
 ) !oauth.PollResult {
-    if (comptime host_target.is_wasm) return error.ChatGptOAuthUnavailable;
+    if (comptime host_target.is_wasm) return error.GrokOAuthUnavailable;
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     const context: *BrowserLoginContext = @ptrCast(@alignCast(raw.?));
     if (!try browserCallbackReady(&context.listener, cancel_flag)) return .pending;
@@ -284,7 +278,7 @@ fn browserCallbackReady(
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     if (ready == 0) return false;
     if ((fds[0].revents & std.posix.POLL.IN) == 0) {
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidGrokOAuthCallback;
     }
     return true;
 }
@@ -296,21 +290,21 @@ fn readBrowserCallbackTarget(alloc: Allocator, stream: std.Io.net.Stream) ![]u8 
     var request_len: usize = 0;
     while (request_len < request_bytes.len) {
         request_bytes[request_len] = reader.interface.takeByte() catch |err| switch (err) {
-            error.EndOfStream => return error.InvalidChatGptOAuthCallback,
+            error.EndOfStream => return error.InvalidGrokOAuthCallback,
             else => return err,
         };
         request_len += 1;
         if (std.mem.endsWith(u8, request_bytes[0..request_len], "\r\n\r\n")) break;
     }
-    if (request_len == request_bytes.len) return error.ChatGptOAuthCallbackTooLarge;
+    if (request_len == request_bytes.len) return error.GrokOAuthCallbackTooLarge;
     const line_end = std.mem.find(u8, request_bytes[0..request_len], "\r\n") orelse
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidGrokOAuthCallback;
     const request_line = request_bytes[0..line_end];
     if (!std.mem.startsWith(u8, request_line, "GET ")) {
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidGrokOAuthCallback;
     }
     const target_end = std.mem.findScalarPos(u8, request_line, 4, ' ') orelse
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidGrokOAuthCallback;
     return alloc.dupe(u8, request_line[4..target_end]);
 }
 
@@ -332,28 +326,29 @@ fn setBrowserSocketTimeouts(socket: std.posix.socket_t) void {
     const timeout = std.posix.timeval{ .sec = browser_callback_io_timeout_seconds, .usec = 0 };
     const bytes = std.mem.asBytes(&timeout);
     std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, bytes) catch |err| {
-        debug_trace.logf("auth", "ChatGPT callback receive timeout setup failed err={s}", .{@errorName(err)});
+        debug_trace.logf("auth", "Grok callback receive timeout setup failed err={s}", .{@errorName(err)});
     };
     std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, bytes) catch |err| {
-        debug_trace.logf("auth", "ChatGPT callback send timeout setup failed err={s}", .{@errorName(err)});
+        debug_trace.logf("auth", "Grok callback send timeout setup failed err={s}", .{@errorName(err)});
     };
 }
 
 fn completeSignIn(
-    _: ?*anyopaque,
+    raw: ?*anyopaque,
     alloc: Allocator,
     _: []const u8,
     _: []const u8,
     token: *oauth.TokenSet,
 ) !login_flow.SignInCompletion {
-    const refresh_token = token.refresh_token orelse return error.ChatGptRefreshTokenMissing;
-    const account_id = try extractAccountId(alloc, token.access_token);
+    const context: *BrowserLoginContext = @ptrCast(@alignCast(raw.?));
+    const refresh_token = token.refresh_token orelse return error.GrokRefreshTokenMissing;
+    const account_id = try fetchAccountId(alloc, context.transport, token.access_token);
     errdefer alloc.free(account_id);
     const duration_ms = std.math.mul(i64, token.expires_in, std.time.ms_per_s) catch
-        return error.InvalidChatGptOAuthResponse;
+        return error.InvalidGrokOAuthResponse;
     const expires_at_ms = std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
-        return error.InvalidChatGptOAuthResponse;
-    const completion: login_flow.SignInCompletion = .{ .chatgpt = .{
+        return error.InvalidGrokOAuthResponse;
+    const completion: login_flow.SignInCompletion = .{ .grok = .{
         .access_token = token.access_token,
         .refresh_token = refresh_token,
         .expires_at_ms = expires_at_ms,
@@ -366,10 +361,10 @@ fn completeSignIn(
 
 fn saveSignIn(_: ?*anyopaque, alloc: Allocator, completion: login_flow.SignInCompletion) !void {
     const session = switch (completion) {
-        .chatgpt => |session| session,
-        .vercel, .grok => return error.InvalidSignInCompletion,
+        .grok => |session| session,
+        .vercel, .chatgpt => return error.InvalidSignInCompletion,
     };
-    try chatgpt_session.saveNewSession(alloc, session);
+    try grok_session.saveNewSession(alloc, session);
 }
 
 pub fn runLogin(
@@ -379,12 +374,12 @@ pub fn runLogin(
 ) !void {
     var runtime: login_flow.SignInRuntime = .{};
     defer runtime.deinit(alloc);
-    if (!try startSignIn(&runtime, alloc, transport)) return error.ChatGptLoginBusy;
+    if (!try startSignIn(&runtime, alloc, transport)) return error.GrokLoginBusy;
 
     const authorization_url = (try runtime.browserUrlAlloc(alloc)) orelse
-        return error.ChatGptAuthorizationUrlMissing;
+        return error.GrokAuthorizationUrlMissing;
     defer alloc.free(authorization_url);
-    try writeStdout("Open this URL to sign in with Codex:\n");
+    try writeStdout("Open this URL to sign in with Grok:\n");
     try writeStdout(authorization_url);
     try writeStdout("\n\nWaiting for browser authorization...\n");
     if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) {
@@ -397,7 +392,7 @@ pub fn runLogin(
             .succeeded => |completion| {
                 var owned = completion;
                 defer owned.deinit(alloc);
-                try writeStdout("Signed in with Codex.\n");
+                try writeStdout("Signed in with Grok.\n");
                 return;
             },
             .failed => |err| return err,
@@ -406,14 +401,33 @@ pub fn runLogin(
     }
 }
 
-pub fn logout() !chatgpt_session.DeleteOutcome {
-    var mutation = (try chatgpt_session.beginExistingMutation()) orelse return .missing;
+pub const LogoutResult = struct {
+    deletion: grok_session.DeleteOutcome,
+    revocation_failed: bool,
+};
+
+pub fn logout(alloc: Allocator, transport: oauth_transport.Provider) !LogoutResult {
+    var mutation = (try grok_session.beginExistingMutation()) orelse return .{
+        .deletion = .missing,
+        .revocation_failed = false,
+    };
     defer mutation.deinit();
-    return mutation.delete();
+    var revocation_failed = false;
+    if (try mutation.load(alloc)) |loaded| {
+        var session = loaded;
+        defer session.deinit(alloc);
+        revokeToken(alloc, transport, session.refresh_token) catch {
+            revocation_failed = true;
+        };
+    }
+    return .{
+        .deletion = try mutation.delete(),
+        .revocation_failed = revocation_failed,
+    };
 }
 
 pub fn sourceExists(alloc: Allocator) !bool {
-    var session = (try chatgpt_session.load(alloc)) orelse return false;
+    var session = (try grok_session.load(alloc)) orelse return false;
     defer session.deinit(alloc);
     return true;
 }
@@ -424,12 +438,12 @@ pub fn loadAccess(
     mode: RefreshMode,
 ) !?Access {
     if (mode == .stored) {
-        var session = (try chatgpt_session.load(alloc)) orelse return null;
+        var session = (try grok_session.load(alloc)) orelse return null;
         defer session.deinit(alloc);
         return takeAccess(&session);
     }
 
-    var mutation = (try chatgpt_session.beginExistingMutation()) orelse return null;
+    var mutation = (try grok_session.beginExistingMutation()) orelse return null;
     defer mutation.deinit();
     var session = (try mutation.load(alloc)) orelse return null;
     defer session.deinit(alloc);
@@ -440,7 +454,7 @@ pub fn loadAccess(
     return takeAccess(&session);
 }
 
-fn takeAccess(session: *chatgpt_session.Session) Access {
+fn takeAccess(session: *grok_session.Session) Access {
     const access_token = session.access_token;
     session.access_token = &.{};
     const account_id = session.account_id;
@@ -448,41 +462,40 @@ fn takeAccess(session: *chatgpt_session.Session) Access {
     return .{
         .access_token = access_token,
         .account_id = account_id,
-        .refresh_after_ms = chatgpt_session.refreshDeadlineMs(session.expires_at_ms),
+        .refresh_after_ms = grok_session.refreshDeadlineMs(session.expires_at_ms),
     };
 }
 
 fn refreshSession(
     alloc: Allocator,
     transport: oauth_transport.Provider,
-    mutation: *chatgpt_session.Mutation,
-    session: *chatgpt_session.Session,
+    mutation: *grok_session.Mutation,
+    session: *grok_session.Session,
 ) !void {
     var body: std.Io.Writer.Allocating = .init(alloc);
     defer body.deinit();
-    try body.writer.writeAll("{\"client_id\":");
-    try std.json.Stringify.value(client_id, .{}, &body.writer);
-    try body.writer.writeAll(",\"grant_type\":\"refresh_token\",\"refresh_token\":");
-    try std.json.Stringify.value(session.refresh_token, .{}, &body.writer);
-    try body.writer.writeByte('}');
+    var form: FormBody = .{};
+    try form.append(&body.writer, "grant_type", "refresh_token");
+    try form.append(&body.writer, "client_id", client_id);
+    try form.append(&body.writer, "refresh_token", session.refresh_token);
     var token = try requestRefreshToken(alloc, transport, body.written());
     defer token.deinit(alloc);
 
-    const account_id = try extractAccountId(alloc, token.access_token);
+    const account_id = try fetchAccountId(alloc, transport, token.access_token);
     errdefer alloc.free(account_id);
     if (!std.mem.eql(u8, account_id, session.account_id)) {
-        return error.ChatGptAccountChanged;
+        return error.GrokAccountChanged;
     }
     const refresh_token = if (token.refresh_token) |rotated| rotated else try alloc.dupe(u8, session.refresh_token);
     if (token.refresh_token != null) token.refresh_token = null;
     errdefer secret.zeroAndFree(alloc, refresh_token);
     const expires_at_ms = if (token.expires_in) |expires_in| blk: {
         const duration_ms = std.math.mul(i64, expires_in, std.time.ms_per_s) catch
-            return error.InvalidChatGptOAuthResponse;
+            return error.InvalidGrokOAuthResponse;
         break :blk std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
-            return error.InvalidChatGptOAuthResponse;
-    } else try accessTokenExpiresAtMs(alloc, token.access_token);
-    var replacement = chatgpt_session.Session{
+            return error.InvalidGrokOAuthResponse;
+    } else return error.InvalidGrokOAuthResponse;
+    var replacement = grok_session.Session{
         .access_token = token.access_token,
         .refresh_token = refresh_token,
         .expires_at_ms = expires_at_ms,
@@ -521,24 +534,24 @@ fn requestRefreshToken(
     const bytes = try requestAccepted(
         alloc,
         transport,
-        .post_json,
+        .post_form,
         endpoint_url,
         payload,
     );
     defer secret.zeroAndFree(alloc, bytes);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidChatGptOAuthResponse;
+    if (parsed.value != .object) return error.InvalidGrokOAuthResponse;
     const object = parsed.value.object;
     const access_token = try dupeRequiredString(alloc, object, "access_token");
     errdefer secret.zeroAndFree(alloc, access_token);
     const refresh_token = if (object.get("refresh_token")) |value| blk: {
-        if (value != .string or value.string.len == 0) return error.InvalidChatGptOAuthResponse;
+        if (value != .string or value.string.len == 0) return error.InvalidGrokOAuthResponse;
         break :blk try alloc.dupe(u8, value.string);
     } else null;
     errdefer if (refresh_token) |token| secret.zeroAndFree(alloc, token);
     const expires_in = if (object.get("expires_in")) |value| blk: {
-        if (value != .integer or value.integer <= 0) return error.InvalidChatGptOAuthResponse;
+        if (value != .integer or value.integer <= 0) return error.InvalidGrokOAuthResponse;
         break :blk value.integer;
     } else null;
     return .{
@@ -546,28 +559,6 @@ fn requestRefreshToken(
         .refresh_token = refresh_token,
         .expires_in = expires_in,
     };
-}
-
-fn accessTokenExpiresAtMs(alloc: Allocator, token: []const u8) !i64 {
-    var parts = std.mem.splitScalar(u8, token, '.');
-    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
-    const payload = parts.next() orelse return error.InvalidChatGptAccessToken;
-    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
-    if (parts.next() != null) return error.InvalidChatGptAccessToken;
-    const decoded_len = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(payload) catch
-        return error.InvalidChatGptAccessToken;
-    const decoded = try alloc.alloc(u8, decoded_len);
-    defer alloc.free(decoded);
-    std.base64.url_safe_no_pad.Decoder.decode(decoded, payload) catch
-        return error.InvalidChatGptAccessToken;
-    var parsed = std.json.parseFromSlice(std.json.Value, alloc, decoded, .{}) catch
-        return error.InvalidChatGptAccessToken;
-    defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidChatGptAccessToken;
-    const exp = parsed.value.object.get("exp") orelse return error.InvalidChatGptOAuthResponse;
-    if (exp != .integer or exp.integer <= 0) return error.InvalidChatGptOAuthResponse;
-    return std.math.mul(i64, exp.integer, std.time.ms_per_s) catch
-        return error.InvalidChatGptOAuthResponse;
 }
 
 fn exchangeAuthorizationCodeForRedirectWithBounds(
@@ -611,7 +602,7 @@ fn requestTokenAtWithBounds(
     defer secret.zeroAndFree(alloc, bytes);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidChatGptOAuthResponse;
+    if (parsed.value != .object) return error.InvalidGrokOAuthResponse;
     const object = parsed.value.object;
     const access_token = try dupeRequiredString(alloc, object, "access_token");
     errdefer secret.zeroAndFree(alloc, access_token);
@@ -627,7 +618,7 @@ fn requestTokenAtWithBounds(
 fn configuredEndpoint(alloc: Allocator, env_name: []const u8, default_url: []const u8) ![]u8 {
     const candidate = io_mod.getenv(env_name) orelse default_url;
     if (io_mod.getenv(env_name) != null and !isLoopbackHttpUrl(candidate)) {
-        return error.InvalidE2EChatGptEndpoint;
+        return error.InvalidE2EGrokEndpoint;
     }
     return alloc.dupe(u8, candidate);
 }
@@ -659,6 +650,46 @@ fn requestAccepted(
     return requestAcceptedWithBounds(alloc, transport, method, url, payload, null, null);
 }
 
+fn fetchAccountId(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    access_token: []const u8,
+) ![]u8 {
+    const endpoint_url = try configuredEndpoint(alloc, e2e_userinfo_url_env, userinfo_url);
+    defer alloc.free(endpoint_url);
+    const authorization = try std.fmt.allocPrint(alloc, "Bearer {s}", .{access_token});
+    defer secret.zeroAndFree(alloc, authorization);
+    var response = try transport.execute(alloc, .{
+        .method = .get,
+        .url = endpoint_url,
+        .authorization = authorization,
+    });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) return error.GrokUserInfoRequestFailed;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, response.body, .{}) catch
+        return error.InvalidGrokUserInfoResponse;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidGrokUserInfoResponse;
+    return dupeRequiredString(alloc, parsed.value.object, "sub") catch
+        return error.InvalidGrokUserInfoResponse;
+}
+
+fn revokeToken(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    token: []const u8,
+) !void {
+    const endpoint_url = try configuredEndpoint(alloc, e2e_revoke_url_env, revoke_url);
+    defer alloc.free(endpoint_url);
+    var body: std.Io.Writer.Allocating = .init(alloc);
+    defer body.deinit();
+    var form: FormBody = .{};
+    try form.append(&body.writer, "token", token);
+    try form.append(&body.writer, "client_id", client_id);
+    const bytes = try requestAccepted(alloc, transport, .post_form, endpoint_url, body.written());
+    secret.zeroAndFree(alloc, bytes);
+}
+
 fn requestAcceptedWithBounds(
     alloc: Allocator,
     transport: oauth_transport.Provider,
@@ -678,76 +709,22 @@ fn requestAcceptedWithBounds(
     });
     defer response.deinit(alloc);
     if (response.disposition != .accepted) {
-        debug_trace.logf("auth", "ChatGPT OAuth request rejected url={s}", .{url});
-        return error.ChatGptOAuthRequestFailed;
+        debug_trace.logf("auth", "Grok OAuth request rejected url={s}", .{url});
+        return error.GrokOAuthRequestFailed;
     }
     return response.takeBody();
 }
 
-fn sessionFromToken(alloc: Allocator, token: *TokenSet, now_ms: i64) !chatgpt_session.Session {
-    const account_id = try extractAccountId(alloc, token.access_token);
-    errdefer alloc.free(account_id);
-    const duration_ms = std.math.mul(i64, token.expires_in, std.time.ms_per_s) catch
-        return error.InvalidChatGptOAuthResponse;
-    const expires_at_ms = std.math.add(i64, now_ms, duration_ms) catch
-        return error.InvalidChatGptOAuthResponse;
-    const session = chatgpt_session.Session{
-        .access_token = token.access_token,
-        .refresh_token = token.refresh_token,
-        .expires_at_ms = expires_at_ms,
-        .account_id = account_id,
-    };
-    token.access_token = &.{};
-    token.refresh_token = &.{};
-    return session;
-}
-
-pub fn extractAccountId(alloc: Allocator, token: []const u8) ![]u8 {
-    var parts = std.mem.splitScalar(u8, token, '.');
-    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
-    const payload = parts.next() orelse return error.InvalidChatGptAccessToken;
-    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
-    if (parts.next() != null) return error.InvalidChatGptAccessToken;
-
-    const decoded_len = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(payload) catch
-        return error.InvalidChatGptAccessToken;
-    const decoded = try alloc.alloc(u8, decoded_len);
-    defer alloc.free(decoded);
-    std.base64.url_safe_no_pad.Decoder.decode(decoded, payload) catch
-        return error.InvalidChatGptAccessToken;
-
-    var parsed = std.json.parseFromSlice(std.json.Value, alloc, decoded, .{}) catch
-        return error.InvalidChatGptAccessToken;
-    defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidChatGptAccessToken;
-    const claim = parsed.value.object.get(jwt_auth_claim) orelse return error.InvalidChatGptAccessToken;
-    if (claim != .object) return error.InvalidChatGptAccessToken;
-    return dupeRequiredString(alloc, claim.object, "chatgpt_account_id") catch
-        return error.InvalidChatGptAccessToken;
-}
-
 fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
-    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
-    if (value != .string or value.string.len == 0) return error.InvalidChatGptOAuthResponse;
+    const value = object.get(key) orelse return error.InvalidGrokOAuthResponse;
+    if (value != .string or value.string.len == 0) return error.InvalidGrokOAuthResponse;
     return alloc.dupe(u8, value.string);
 }
 
 fn requiredPositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
-    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
-    if (value != .integer or value.integer <= 0) return error.InvalidChatGptOAuthResponse;
+    const value = object.get(key) orelse return error.InvalidGrokOAuthResponse;
+    if (value != .integer or value.integer <= 0) return error.InvalidGrokOAuthResponse;
     return value.integer;
-}
-
-fn flexiblePositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
-    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
-    const result = switch (value) {
-        .integer => value.integer,
-        .string => std.fmt.parseInt(i64, std.mem.trim(u8, value.string, " \t\r\n"), 10) catch
-            return error.InvalidChatGptOAuthResponse,
-        else => return error.InvalidChatGptOAuthResponse,
-    };
-    if (result < 0) return error.InvalidChatGptOAuthResponse;
-    return result;
 }
 
 const BrowserCallback = struct {
@@ -768,7 +745,7 @@ fn buildBrowserAuthorizationUrl(
 ) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
-    try out.writer.print("{s}/oauth/authorize?", .{std.mem.trimEnd(u8, issuer, "/")});
+    try out.writer.print("{s}/oauth2/authorize?", .{std.mem.trimEnd(u8, issuer, "/")});
     var form: FormBody = .{};
     try form.append(&out.writer, "response_type", "code");
     try form.append(&out.writer, "client_id", client_id);
@@ -776,10 +753,8 @@ fn buildBrowserAuthorizationUrl(
     try form.append(&out.writer, "scope", browser_scope);
     try form.append(&out.writer, "code_challenge", code_challenge);
     try form.append(&out.writer, "code_challenge_method", "S256");
-    try form.append(&out.writer, "id_token_add_organizations", "true");
-    try form.append(&out.writer, "codex_cli_simplified_flow", "true");
     try form.append(&out.writer, "state", state);
-    try form.append(&out.writer, "originator", "fx");
+    try form.append(&out.writer, "referrer", "fx");
     return out.toOwnedSlice();
 }
 
@@ -788,16 +763,16 @@ fn parseBrowserCallbackTarget(
     target: []const u8,
     expected_state: []const u8,
 ) !BrowserCallback {
-    const prefix = "/auth/callback?";
+    const prefix = "/callback?";
     if (!std.mem.startsWith(u8, target, prefix) or std.mem.findScalar(u8, target, '#') != null) {
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidGrokOAuthCallback;
     }
     const query = target[prefix.len..];
     const code = try queryValueAlloc(alloc, query, "code");
     errdefer secret.zeroAndFree(alloc, code);
     const state = try queryValueAlloc(alloc, query, "state");
     defer secret.zeroAndFree(alloc, state);
-    if (!std.mem.eql(u8, state, expected_state)) return error.ChatGptOAuthStateMismatch;
+    if (!std.mem.eql(u8, state, expected_state)) return error.GrokOAuthStateMismatch;
     return .{ .code = code };
 }
 
@@ -808,7 +783,7 @@ fn queryValueAlloc(alloc: Allocator, query: []const u8, key: []const u8) ![]u8 {
         if (!std.mem.eql(u8, pair[0..equals], key)) continue;
         return percentDecodeAlloc(alloc, pair[equals + 1 ..]);
     }
-    return error.InvalidChatGptOAuthCallback;
+    return error.InvalidGrokOAuthCallback;
 }
 
 fn percentDecodeAlloc(alloc: Allocator, value: []const u8) ![]u8 {
@@ -818,11 +793,11 @@ fn percentDecodeAlloc(alloc: Allocator, value: []const u8) ![]u8 {
     var write_index: usize = 0;
     while (read_index < value.len) {
         if (value[read_index] == '%') {
-            if (read_index + 2 >= value.len) return error.InvalidChatGptOAuthCallback;
+            if (read_index + 2 >= value.len) return error.InvalidGrokOAuthCallback;
             const high = std.fmt.charToDigit(value[read_index + 1], 16) catch
-                return error.InvalidChatGptOAuthCallback;
+                return error.InvalidGrokOAuthCallback;
             const low = std.fmt.charToDigit(value[read_index + 2], 16) catch
-                return error.InvalidChatGptOAuthCallback;
+                return error.InvalidGrokOAuthCallback;
             out[write_index] = @as(u8, @intCast(high * 16 + low));
             read_index += 3;
         } else {
@@ -831,7 +806,7 @@ fn percentDecodeAlloc(alloc: Allocator, value: []const u8) ![]u8 {
         }
         write_index += 1;
     }
-    if (write_index == 0) return error.InvalidChatGptOAuthCallback;
+    if (write_index == 0) return error.InvalidGrokOAuthCallback;
     return alloc.realloc(out, write_index);
 }
 
@@ -865,31 +840,35 @@ fn writeStdout(text: []const u8) !void {
     try std.Io.File.stdout().writeStreamingAll(io_mod.getIo(), text);
 }
 
-test "ChatGPT E2E OAuth endpoint overrides accept only loopback HTTP" {
+test "Grok E2E OAuth endpoint overrides accept only loopback HTTP" {
     try std.testing.expect(isLoopbackHttpUrl("http://127.0.0.1:1234/token"));
     try std.testing.expect(isLoopbackHttpUrl("http://localhost:1234/token"));
     try std.testing.expect(!isLoopbackHttpUrl("https://127.0.0.1:1234/token"));
     try std.testing.expect(!isLoopbackHttpUrl("http://example.com:1234/token"));
 }
 
-test "ChatGPT account id is extracted from the namespaced JWT claim" {
-    const alloc = std.testing.allocator;
-    const payload =
-        \\{"https://api.openai.com/auth":{"chatgpt_account_id":"acct_test"}}
-    ;
-    const encoded_len = std.base64.url_safe_no_pad.Encoder.calcSize(payload.len);
-    const encoded = try alloc.alloc(u8, encoded_len);
-    defer alloc.free(encoded);
-    _ = std.base64.url_safe_no_pad.Encoder.encode(encoded, payload);
-    const token = try std.fmt.allocPrint(alloc, "header.{s}.signature", .{encoded});
-    defer alloc.free(token);
+test "Grok account identity comes from authenticated userinfo" {
+    const State = struct {
+        authorization_seen: bool = false,
 
-    const account_id = try extractAccountId(alloc, token);
-    defer alloc.free(account_id);
+        fn execute(raw: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.authorization_seen = std.mem.eql(u8, request.authorization orelse "", "Bearer access-token");
+            return .{ .disposition = .accepted, .body = try alloc.dupe(u8, "{\"sub\":\"acct_test\"}") };
+        }
+    };
+    var state = State{};
+    const account_id = try fetchAccountId(
+        std.testing.allocator,
+        .{ .context = &state, .execute_fn = State.execute },
+        "access-token",
+    );
+    defer std.testing.allocator.free(account_id);
+    try std.testing.expect(state.authorization_seen);
     try std.testing.expectEqualStrings("acct_test", account_id);
 }
 
-test "Codex refresh uses JSON and accepts omitted token rotation and lifetime" {
+test "Grok refresh uses form encoding and accepts omitted token rotation" {
     const State = struct {
         method: ?oauth_transport.Method = null,
         payload: [512]u8 = undefined,
@@ -907,7 +886,7 @@ test "Codex refresh uses JSON and accepts omitted token rotation and lifetime" {
             @memcpy(self.payload[0..self.payload_len], payload[0..self.payload_len]);
             return .{
                 .disposition = .accepted,
-                .body = try alloc.dupe(u8, "{\"access_token\":\"header.payload.signature\"}"),
+                .body = try alloc.dupe(u8, "{\"access_token\":\"new-access\",\"expires_in\":3600}"),
             };
         }
     };
@@ -915,54 +894,55 @@ test "Codex refresh uses JSON and accepts omitted token rotation and lifetime" {
     var response = try requestRefreshToken(
         std.testing.allocator,
         .{ .context = &state, .execute_fn = State.execute },
-        "{\"client_id\":\"client\",\"grant_type\":\"refresh_token\",\"refresh_token\":\"refresh\"}",
+        "client_id=client&grant_type=refresh_token&refresh_token=refresh",
     );
     defer response.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(oauth_transport.Method.post_json, state.method.?);
-    try std.testing.expect(std.mem.find(u8, state.payload[0..state.payload_len], "\"grant_type\":\"refresh_token\"") != null);
+    try std.testing.expectEqual(oauth_transport.Method.post_form, state.method.?);
+    try std.testing.expect(std.mem.find(u8, state.payload[0..state.payload_len], "grant_type=refresh_token") != null);
     try std.testing.expect(response.refresh_token == null);
-    try std.testing.expect(response.expires_in == null);
+    try std.testing.expectEqual(@as(?i64, 3600), response.expires_in);
 }
 
-test "ChatGPT browser authorization URL uses PKCE without device authentication" {
+test "Grok browser authorization URL uses PKCE without device authentication" {
     const url = try buildBrowserAuthorizationUrl(
         std.testing.allocator,
-        "https://auth.openai.com",
-        "http://localhost:1455/auth/callback",
+        "https://auth.x.ai",
+        "http://127.0.0.1:1455/callback",
         "challenge-value",
         "state-value",
     );
     defer std.testing.allocator.free(url);
 
-    try std.testing.expect(std.mem.startsWith(u8, url, "https://auth.openai.com/oauth/authorize?"));
+    try std.testing.expect(std.mem.startsWith(u8, url, "https://auth.x.ai/oauth2/authorize?"));
     try std.testing.expect(std.mem.find(u8, url, "response_type=code") != null);
     try std.testing.expect(std.mem.find(u8, url, "code_challenge=challenge-value") != null);
     try std.testing.expect(std.mem.find(u8, url, "code_challenge_method=S256") != null);
     try std.testing.expect(std.mem.find(u8, url, "state=state-value") != null);
-    try std.testing.expect(std.mem.find(u8, url, "originator=fx") != null);
+    try std.testing.expect(std.mem.find(u8, url, "referrer=fx") != null);
+    try std.testing.expect(std.mem.find(u8, url, "nonce") == null);
     try std.testing.expect(std.mem.find(u8, url, "device") == null);
 }
 
-test "ChatGPT browser callback requires the exact path and state" {
+test "Grok browser callback requires the exact path and state" {
     var callback = try parseBrowserCallbackTarget(
         std.testing.allocator,
-        "/auth/callback?code=auth%20code&state=expected",
+        "/callback?code=auth%20code&state=expected",
         "expected",
     );
     defer callback.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("auth code", callback.code);
 
     try std.testing.expectError(
-        error.ChatGptOAuthStateMismatch,
+        error.GrokOAuthStateMismatch,
         parseBrowserCallbackTarget(
             std.testing.allocator,
-            "/auth/callback?code=auth&state=other",
+            "/callback?code=auth&state=other",
             "expected",
         ),
     );
     try std.testing.expectError(
-        error.InvalidChatGptOAuthCallback,
+        error.InvalidGrokOAuthCallback,
         parseBrowserCallbackTarget(
             std.testing.allocator,
             "/other?code=auth&state=expected",

--- a/src/core/auth/grok_session.zig
+++ b/src/core/auth/grok_session.zig
@@ -1,0 +1,268 @@
+const std = @import("std");
+const debug_trace = @import("../shared/debug_trace.zig");
+const host_target = @import("../hosts/target.zig");
+const io_mod = @import("../shared/io.zig");
+const profile_paths = @import("../shared/profile_paths.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+const schema_version: i64 = 1;
+const max_auth_file_bytes: usize = 64 * 1024;
+const expiry_skew_ms: i64 = 60 * 1000;
+const mutation_lock_file_name = "grok-auth.lock";
+const mutation_lock_deadline_ms: u64 = 2000;
+
+const auth_file_name = profile_paths.grok_auth_file_name;
+
+pub fn refreshDeadlineMs(expires_at_ms: i64) i64 {
+    return @max(expires_at_ms - expiry_skew_ms, 0);
+}
+
+pub const Session = struct {
+    access_token: []u8,
+    refresh_token: []u8,
+    expires_at_ms: i64,
+    account_id: []u8,
+
+    pub fn deinit(self: *Session, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.access_token);
+        secret.zeroAndFree(alloc, self.refresh_token);
+        alloc.free(self.account_id);
+        self.* = undefined;
+    }
+
+    pub fn expired(self: Session, now_ms: i64) bool {
+        return refreshDeadlineMs(self.expires_at_ms) <= now_ms;
+    }
+};
+
+pub const DeleteOutcome = enum {
+    deleted,
+    missing,
+    deleted_not_durable,
+};
+
+pub const Mutation = struct {
+    fx_dir: io_mod.VerifiedDir,
+    lock: io_mod.TimedAdvisoryLock,
+
+    pub fn deinit(self: *Mutation) void {
+        self.lock.release();
+        self.fx_dir.close();
+        self.* = undefined;
+    }
+
+    pub fn load(self: *Mutation, alloc: Allocator) !?Session {
+        return loadFromDir(alloc, &self.fx_dir.dir, true);
+    }
+
+    pub fn save(self: *Mutation, alloc: Allocator, session: Session) !void {
+        const text = try stringify(alloc, session);
+        defer secret.zeroAndFree(alloc, text);
+        try io_mod.durableReplaceVerified(alloc, &self.fx_dir, auth_file_name, text);
+    }
+
+    pub fn delete(self: *Mutation) !DeleteOutcome {
+        self.fx_dir.dir.deleteFile(io_mod.getIo(), auth_file_name) catch |err| switch (err) {
+            error.FileNotFound => return .missing,
+            else => return err,
+        };
+        const durable: io_mod.DurableOps = .{};
+        durable.sync_dir(durable.ctx, self.fx_dir.dir) catch return .deleted_not_durable;
+        return .deleted;
+    }
+};
+
+pub fn load(alloc: Allocator) !?Session {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return null;
+    var home_dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch |err| {
+        debug_trace.logf("auth", "Grok session load failed step=open_home err={s}", .{@errorName(err)});
+        return null;
+    };
+    defer home_dir.close(io_mod.getIo());
+
+    var fx_dir = home_dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| {
+        if (err != error.FileNotFound) {
+            debug_trace.logf("auth", "Grok session load failed step=open_profile err={s}", .{@errorName(err)});
+        }
+        return null;
+    };
+    defer fx_dir.close(io_mod.getIo());
+    return loadFromDir(alloc, &fx_dir, false);
+}
+
+fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, report_open_failure: bool) !?Session {
+    var file = fx_dir.openFile(io_mod.getIo(), auth_file_name, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => {
+            debug_trace.logf("auth", "Grok session load failed step=open_file err={s}", .{@errorName(err)});
+            if (report_open_failure) return err;
+            return null;
+        },
+    };
+    defer file.close(io_mod.getIo());
+
+    const stat = try file.stat(io_mod.getIo());
+    if (stat.kind != .file or stat.permissions.toMode() & 0o077 != 0) {
+        debug_trace.logf("auth", "Grok session load failed step=permissions err=InsecureAuthFile", .{});
+        return null;
+    }
+
+    const bytes = try io_mod.readFileToEnd(alloc, &file, max_auth_file_bytes);
+    defer secret.zeroAndFree(alloc, bytes);
+    return parse(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "Grok session load failed step=parse err={s}", .{@errorName(err)});
+            return null;
+        },
+    };
+}
+
+pub fn saveNewSession(alloc: Allocator, session: Session) !void {
+    if (comptime host_target.is_wasm) return error.GrokOAuthUnavailable;
+    var mutation = try beginMutation();
+    defer mutation.deinit();
+    try mutation.save(alloc, session);
+}
+
+pub fn beginExistingMutation() !?Mutation {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+
+    const fx_dir = openExistingPrivateFxDir(&home_dir) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    return try lockMutation(fx_dir);
+}
+
+fn beginMutation() !Mutation {
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+
+    const fx_dir = try io_mod.openOrCreateVerifiedPrivateDir(&home_dir, profile_paths.root_dir_name);
+    return lockMutation(fx_dir);
+}
+
+fn lockMutation(open_fx_dir: io_mod.VerifiedDir) !Mutation {
+    var fx_dir = open_fx_dir;
+    errdefer fx_dir.close();
+    var lock = try io_mod.acquireTimedAdvisoryLock(
+        &fx_dir,
+        mutation_lock_file_name,
+        mutation_lock_deadline_ms,
+    );
+    errdefer lock.release();
+    return .{ .fx_dir = fx_dir, .lock = lock };
+}
+
+fn openExistingPrivateFxDir(home_dir: *io_mod.VerifiedDir) !io_mod.VerifiedDir {
+    var dir = try home_dir.dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    errdefer dir.close(io_mod.getIo());
+
+    const initial_stat = try dir.stat(io_mod.getIo());
+    if (initial_stat.kind != .directory) return error.DurablePathUnsafe;
+    if (initial_stat.permissions.toMode() & 0o200 == 0) return error.PrivateStatePermissionsUnsupported;
+    dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {
+        return error.PrivateStatePermissionsUnsupported;
+    };
+    const stat = try dir.stat(io_mod.getIo());
+    if (stat.kind != .directory or stat.permissions.toMode() & 0o777 != 0o700) {
+        return error.PrivateStatePermissionsUnsupported;
+    }
+    return .{ .dir = dir };
+}
+
+pub fn parse(alloc: Allocator, bytes: []const u8) !Session {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidGrokAuthSession;
+    const object = parsed.value.object;
+    const version = object.get("version") orelse return error.InvalidGrokAuthSession;
+    if (version != .integer or version.integer != schema_version) return error.InvalidGrokAuthSession;
+
+    const access_token = try dupeRequiredString(alloc, object, "access_token");
+    errdefer secret.zeroAndFree(alloc, access_token);
+    const refresh_token = try dupeRequiredString(alloc, object, "refresh_token");
+    errdefer secret.zeroAndFree(alloc, refresh_token);
+    const account_id = try dupeRequiredString(alloc, object, "account_id");
+    errdefer alloc.free(account_id);
+    const expires_at_ms = try requiredInteger(object, "expires_at_ms");
+    return .{
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+        .expires_at_ms = expires_at_ms,
+        .account_id = account_id,
+    };
+}
+
+pub fn stringify(alloc: Allocator, session: Session) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"version\":1,\"access_token\":");
+    try std.json.Stringify.value(session.access_token, .{}, &out.writer);
+    try out.writer.writeAll(",\"refresh_token\":");
+    try std.json.Stringify.value(session.refresh_token, .{}, &out.writer);
+    try out.writer.print(",\"expires_at_ms\":{d},\"account_id\":", .{session.expires_at_ms});
+    try std.json.Stringify.value(session.account_id, .{}, &out.writer);
+    try out.writer.writeAll("}\n");
+    return out.toOwnedSlice();
+}
+
+fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
+    const value = object.get(key) orelse return error.InvalidGrokAuthSession;
+    if (value != .string or value.string.len == 0) return error.InvalidGrokAuthSession;
+    return alloc.dupe(u8, value.string);
+}
+
+fn requiredInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
+    const value = object.get(key) orelse return error.InvalidGrokAuthSession;
+    if (value != .integer) return error.InvalidGrokAuthSession;
+    return value.integer;
+}
+
+test "Grok auth session round trips without exposing token fields to structure" {
+    const alloc = std.testing.allocator;
+    var session = Session{
+        .access_token = try alloc.dupe(u8, "header.payload.signature"),
+        .refresh_token = try alloc.dupe(u8, "refresh"),
+        .expires_at_ms = 1234,
+        .account_id = try alloc.dupe(u8, "acct_123"),
+    };
+    defer session.deinit(alloc);
+
+    const encoded = try stringify(alloc, session);
+    defer secret.zeroAndFree(alloc, encoded);
+    var decoded = try parse(alloc, encoded);
+    defer decoded.deinit(alloc);
+
+    try std.testing.expectEqualStrings(session.access_token, decoded.access_token);
+    try std.testing.expectEqualStrings(session.refresh_token, decoded.refresh_token);
+    try std.testing.expectEqualStrings(session.account_id, decoded.account_id);
+    try std.testing.expectEqual(session.expires_at_ms, decoded.expires_at_ms);
+}
+
+test "Grok session refresh deadline keeps a one minute safety margin" {
+    try std.testing.expectEqual(@as(i64, 40_000), refreshDeadlineMs(100_000));
+    try std.testing.expectEqual(@as(i64, 0), refreshDeadlineMs(10_000));
+}

--- a/src/core/auth/js_host_auth.zig
+++ b/src/core/auth/js_host_auth.zig
@@ -58,17 +58,23 @@ fn executeOAuthRequest(
 ) !oauth_transport.Response {
     try checkRequestBounds(request);
     const Header = struct { name: []const u8, value: []const u8 };
-    const headers: []const Header = switch (request.method) {
-        .get => &.{},
-        .post_form => &.{.{
-            .name = "content-type",
-            .value = "application/x-www-form-urlencoded",
-        }},
-        .post_json => &.{.{
-            .name = "content-type",
-            .value = "application/json",
-        }},
-    };
+    var header_buf: [2]Header = undefined;
+    var header_count: usize = 0;
+    switch (request.method) {
+        .get => {},
+        .post_form => {
+            header_buf[header_count] = .{ .name = "content-type", .value = "application/x-www-form-urlencoded" };
+            header_count += 1;
+        },
+        .post_json => {
+            header_buf[header_count] = .{ .name = "content-type", .value = "application/json" };
+            header_count += 1;
+        },
+    }
+    if (request.authorization) |value| {
+        header_buf[header_count] = .{ .name = "authorization", .value = value };
+        header_count += 1;
+    }
     var response = try executeRequest(
         alloc,
         switch (request.method) {
@@ -76,7 +82,7 @@ fn executeOAuthRequest(
             .post_form, .post_json => "POST",
         },
         request.url,
-        headers,
+        header_buf[0..header_count],
         request.payload orelse "",
     );
     errdefer response.deinit(alloc);

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const credentials = @import("credentials.zig");
 const chatgpt_session = @import("chatgpt_session.zig");
+const grok_session = @import("grok_session.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
@@ -136,11 +137,13 @@ pub const SignInSnapshot = struct {
 pub const SignInCompletion = union(enum) {
     vercel: TeamSelection,
     chatgpt: chatgpt_session.Session,
+    grok: grok_session.Session,
 
     pub fn deinit(self: *SignInCompletion, alloc: Allocator) void {
         switch (self.*) {
             .vercel => |*selection| selection.deinit(alloc),
             .chatgpt => |*session| session.deinit(alloc),
+            .grok => |*session| session.deinit(alloc),
         }
         self.* = .{ .vercel = .{} };
     }
@@ -527,7 +530,7 @@ fn completeSignIn(
 fn saveSignIn(_: ?*anyopaque, alloc: Allocator, completion: SignInCompletion) !void {
     const session = switch (completion) {
         .vercel => |selection| selection.session orelse return LoginError.NoSession,
-        .chatgpt => return error.InvalidSignInCompletion,
+        .chatgpt, .grok => return error.InvalidSignInCompletion,
     };
     try oauth_session.saveNewSession(alloc, session);
 }

--- a/src/core/auth/oauth_transport.zig
+++ b/src/core/auth/oauth_transport.zig
@@ -13,6 +13,8 @@ pub const Request = struct {
     method: Method,
     url: []const u8,
     payload: ?[]const u8 = null,
+    /// Optional preformatted Authorization value, borrowed for this request.
+    authorization: ?[]const u8 = null,
     cancel_flag: ?*std.atomic.Value(bool) = null,
     deadline: ?std.Io.Clock.Timestamp = null,
 };

--- a/src/core/auth/provider_catalog.zig
+++ b/src/core/auth/provider_catalog.zig
@@ -3,11 +3,13 @@ const std = @import("std");
 pub const Id = enum {
     vercel,
     codex,
+    grok,
 
     pub fn slug(self: Id) []const u8 {
         return switch (self) {
             .vercel => "vercel",
             .codex => "codex",
+            .grok => "grok",
         };
     }
 };
@@ -32,12 +34,19 @@ pub const entries = [_]Entry{
         .description = "ChatGPT Plus, Pro, Business, Enterprise, or Edu subscription",
         .subscription = true,
     },
+    .{
+        .id = .grok,
+        .name = "Grok",
+        .description = "SuperGrok or X Premium subscription",
+        .subscription = true,
+    },
 };
 
 pub fn parse(value: []const u8) ?Id {
     if (std.ascii.eqlIgnoreCase(value, "vercel") or
         std.ascii.eqlIgnoreCase(value, "ai-gateway")) return .vercel;
     if (std.ascii.eqlIgnoreCase(value, "codex")) return .codex;
+    if (std.ascii.eqlIgnoreCase(value, "grok")) return .grok;
     return null;
 }
 
@@ -46,11 +55,13 @@ pub fn find(id: Id) *const Entry {
     unreachable;
 }
 
-test "auth provider catalog exposes codex without unreleased aliases" {
+test "auth provider catalog exposes subscription providers without aliases" {
     try std.testing.expectEqual(Id.vercel, parse("vercel").?);
     try std.testing.expectEqual(Id.codex, parse("codex").?);
+    try std.testing.expectEqual(Id.grok, parse("grok").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("chatgpt") == null);
     try std.testing.expect(parse("unknown") == null);
     try std.testing.expect(find(.codex).subscription);
+    try std.testing.expect(find(.grok).subscription);
 }

--- a/src/core/cli/acp_runner.zig
+++ b/src/core/cli/acp_runner.zig
@@ -24,6 +24,8 @@ pub const Config = struct {
     gateway_provider: gateway_provider.Provider,
     codex_agent_stream: ?agent_stream_provider.Provider = null,
     codex_model_catalog: ?model_catalog.Provider = null,
+    grok_agent_stream: ?agent_stream_provider.Provider = null,
+    grok_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     secret_store: host.SecretStore,
@@ -41,6 +43,7 @@ pub const Config = struct {
     devbox_provider: ?devbox_executor.Provider = null,
     permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     codex_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
+    grok_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     model_override: ?[]const u8 = null,
     credential_override: ?[]const u8 = null,
     home_override: ?[]const u8 = null,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -226,6 +226,8 @@ pub const Config = struct {
     gateway_provider: gateway_provider.Provider,
     codex_agent_stream: ?agent_stream_provider.Provider = null,
     codex_model_catalog: ?model_catalog.Provider = null,
+    grok_agent_stream: ?agent_stream_provider.Provider = null,
+    grok_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     secret_store: host.SecretStore,
@@ -244,6 +246,7 @@ pub const Config = struct {
     devbox_provider: ?devbox_executor.Provider = null,
     permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     codex_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
+    grok_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     context_limit_overrides: []const config_runtime.context_limits.Override = &.{},
     additional_directories: []const []const u8 = &.{},
     saved_directories_suppressed: bool = false,
@@ -280,6 +283,10 @@ fn runAskChild(
             .codex = .{
                 .agent_stream_provider = ctx.cfg.codex_agent_stream orelse agent_stream_provider.unavailable_provider,
                 .permission_reviewer_provider = ctx.cfg.codex_permission_reviewer_provider,
+            },
+            .grok = .{
+                .agent_stream_provider = ctx.cfg.grok_agent_stream orelse agent_stream_provider.unavailable_provider,
+                .permission_reviewer_provider = ctx.cfg.grok_permission_reviewer_provider,
             },
         },
         .system_prompt = ctx.cfg.prompt_policy.system_prompt,
@@ -1059,6 +1066,7 @@ const AskContext = struct {
         const provider = switch (self.provider) {
             .gateway => self.cfg.permission_reviewer_provider,
             .codex => self.cfg.codex_permission_reviewer_provider,
+            .grok => self.cfg.grok_permission_reviewer_provider,
         } orelse
             return permission_auto_classifier.Classifier.disabled();
         return permission_auto_classifier.Classifier.withProvider(provider, .{
@@ -1075,6 +1083,7 @@ const AskContext = struct {
         return switch (self.provider) {
             .gateway => self.cfg.gateway_provider.agent_stream,
             .codex => self.cfg.codex_agent_stream orelse agent_stream_provider.unavailable_provider,
+            .grok => self.cfg.grok_agent_stream orelse agent_stream_provider.unavailable_provider,
         };
     }
 
@@ -1383,6 +1392,8 @@ fn missingCredentialResult(
 ) !PromptRunResult {
     const message = if (provider == .codex)
         credentials.missing_chatgpt_credential_message
+    else if (provider == .grok)
+        credentials.missing_grok_credential_message
     else
         credentials.missing_credential_message;
     try options.deps.write_stderr(options.deps.stderr_ctx, "fx ask: ");
@@ -1986,6 +1997,7 @@ fn resolveModelCapabilities(raw_ctx: *anyopaque, _: Allocator, model: []const u8
         ctx.provider,
         ctx.cfg.gateway_provider.model_catalog,
         ctx.cfg.codex_model_catalog,
+        ctx.cfg.grok_model_catalog,
     ) orelse return model_capabilities.capabilitiesForModel(model);
     return ctx.capability_resolver.resolve(
         ctx.alloc,
@@ -2003,10 +2015,12 @@ fn selectModelCatalog(
     provider: model_provider.ProviderId,
     gateway: model_catalog.Provider,
     codex: ?model_catalog.Provider,
+    grok: ?model_catalog.Provider,
 ) ?model_catalog.Provider {
     return switch (provider) {
         .gateway => gateway,
         .codex => codex,
+        .grok => grok,
     };
 }
 
@@ -2022,18 +2036,24 @@ test "provider catalog selection never falls back across origins" {
     gateway.context = &gateway_tag;
     var codex = test_builtin_gateway.model_catalog_provider;
     codex.context = &codex_tag;
+    var grok_tag: u8 = 0;
+    var grok = test_builtin_gateway.model_catalog_provider;
+    grok.context = &grok_tag;
     const cases = [_]struct {
         provider: model_provider.ProviderId,
         codex: ?model_catalog.Provider,
+        grok: ?model_catalog.Provider,
         expected_context: ?*anyopaque,
     }{
-        .{ .provider = .gateway, .codex = codex, .expected_context = &gateway_tag },
-        .{ .provider = .codex, .codex = codex, .expected_context = &codex_tag },
-        .{ .provider = .codex, .codex = null, .expected_context = null },
+        .{ .provider = .gateway, .codex = codex, .grok = grok, .expected_context = &gateway_tag },
+        .{ .provider = .codex, .codex = codex, .grok = grok, .expected_context = &codex_tag },
+        .{ .provider = .codex, .codex = null, .grok = grok, .expected_context = null },
+        .{ .provider = .grok, .codex = codex, .grok = grok, .expected_context = &grok_tag },
+        .{ .provider = .grok, .codex = codex, .grok = null, .expected_context = null },
     };
 
     for (cases) |case| {
-        const selected = selectModelCatalog(case.provider, gateway, case.codex);
+        const selected = selectModelCatalog(case.provider, gateway, case.codex, case.grok);
         if (case.expected_context) |expected| {
             try std.testing.expect(selected != null);
             try std.testing.expect(selected.?.context.? == expected);

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -5,6 +5,7 @@ const app_lifecycle = @import("../app/app_lifecycle.zig");
 const background_record_liveness = @import("../background/background_record_liveness.zig");
 const background_store = @import("../background/background_store.zig");
 const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
+const grok_oauth = @import("../auth/grok_oauth.zig");
 const acp_runner = @import("acp_runner.zig");
 const cli_ask = @import("cli_ask.zig");
 const cli_replay = @import("cli_replay.zig");
@@ -181,6 +182,9 @@ pub const Config = struct {
     codex_agent_stream: ?agent_stream_provider.Provider = null,
     codex_cli_model_catalog: ?gateway_provider.CliModelCatalogProvider = null,
     codex_model_catalog: ?model_catalog.Provider = null,
+    grok_agent_stream: ?agent_stream_provider.Provider = null,
+    grok_cli_model_catalog: ?gateway_provider.CliModelCatalogProvider = null,
+    grok_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     url_opener: host.UrlOpener,
@@ -204,6 +208,7 @@ pub const Config = struct {
     devbox_provider: ?devbox_executor.Provider = null,
     permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     codex_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
+    grok_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
 };
 
 const LocalSurfaceOptions = struct {
@@ -729,6 +734,8 @@ fn runNonInteractiveWithDeps(
                 .gateway_provider = cfg.gateway_provider,
                 .codex_agent_stream = cfg.codex_agent_stream,
                 .codex_model_catalog = cfg.codex_model_catalog,
+                .grok_agent_stream = cfg.grok_agent_stream,
+                .grok_model_catalog = cfg.grok_model_catalog,
                 .background_process_provider = cfg.background_process_provider,
                 .secret_store = cfg.secret_store,
                 .prompt_policy = cfg.prompt_policy,
@@ -745,6 +752,7 @@ fn runNonInteractiveWithDeps(
                 .devbox_provider = cfg.devbox_provider,
                 .permission_reviewer_provider = cfg.permission_reviewer_provider,
                 .codex_permission_reviewer_provider = cfg.codex_permission_reviewer_provider,
+                .grok_permission_reviewer_provider = cfg.grok_permission_reviewer_provider,
                 .context_limit_overrides = global_args.modifiers.context_limit_overrides,
                 .additional_directories = global_args.modifiers.additional_directories,
                 .saved_directories_suppressed = global_args.modifiers.saved_directories_suppressed,
@@ -757,7 +765,7 @@ fn runNonInteractiveWithDeps(
         .issue => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .issue),
         .login => |rest| {
             const maybe_login_provider = parseLoginProvider(rest) catch {
-                try writeStderr(deps, "usage: fx login [vercel|codex]\n");
+                try writeStderr(deps, "usage: fx login [vercel|codex|grok]\n");
                 return .handled_failure;
             };
             // Preserve the original `fx login` behavior for scripts and users.
@@ -790,12 +798,21 @@ fn runNonInteractiveWithDeps(
                     try writeStderr(deps, message);
                     return .handled_failure;
                 },
+                .grok => grok_oauth.runLogin(
+                    alloc,
+                    cfg.gateway_provider.oauth_transport,
+                    cfg.url_opener,
+                ) catch |err| {
+                    debug_trace.logf("auth", "Grok login failed err={s}", .{@errorName(err)});
+                    try writeStderr(deps, "fx login: failed to sign in with Grok\n");
+                    return .handled_failure;
+                },
             }
             return .handled_success;
         },
         .logout => |rest| {
             const maybe_login_provider = parseLoginProvider(rest) catch {
-                try writeStderr(deps, "usage: fx logout [vercel|codex]\n");
+                try writeStderr(deps, "usage: fx logout [vercel|codex|grok]\n");
                 return .handled_failure;
             };
             // Preserve the original `fx logout` behavior for scripts and users.
@@ -816,6 +833,29 @@ fn runNonInteractiveWithDeps(
                     },
                     .deleted_not_durable => result: {
                         try writeStderr(deps, "fx logout: failed to durably remove saved Codex login\n");
+                        break :result .handled_failure;
+                    },
+                };
+            }
+            if (login_provider == .grok) {
+                const outcome = grok_oauth.logout(alloc, cfg.gateway_provider.oauth_transport) catch {
+                    try writeStderr(deps, "fx logout: failed to durably remove saved Grok login\n");
+                    return .handled_failure;
+                };
+                if (outcome.revocation_failed) {
+                    try writeStderr(deps, "fx logout: local Grok session removed, but remote revocation could not be confirmed\n");
+                }
+                return switch (outcome.deletion) {
+                    .deleted => result: {
+                        try writeStdout(deps, "Signed out of Grok.\n");
+                        break :result .handled_success;
+                    },
+                    .missing => result: {
+                        try writeStdout(deps, "No Grok login session found.\n");
+                        break :result .handled_success;
+                    },
+                    .deleted_not_durable => result: {
+                        try writeStderr(deps, "fx logout: failed to durably remove saved Grok login\n");
                         break :result .handled_failure;
                     },
                 };
@@ -861,11 +901,11 @@ fn runNonInteractiveWithDeps(
         },
         .provider => |rest| {
             if (rest.len != 1) {
-                try writeStderr(deps, "usage: fx provider <gateway|codex>\n");
+                try writeStderr(deps, "usage: fx provider <gateway|codex|grok>\n");
                 return .handled_failure;
             }
             const target = model_provider.parse(rest[0]) orelse {
-                try writeStderr(deps, "fx provider: expected gateway or codex\n");
+                try writeStderr(deps, "fx provider: expected gateway, codex, or grok\n");
                 return .handled_failure;
             };
             const workspace_root = try io_mod.realpathAlloc(alloc, ".");
@@ -877,7 +917,12 @@ fn runNonInteractiveWithDeps(
             };
             defer settings.deinit(alloc);
             if ((settings.provider orelse .gateway) == target) {
-                try writeStdout(deps, if (target == .codex) "Codex is already selected.\n" else "Gateway is already selected.\n");
+                const message = switch (target) {
+                    .gateway => "Gateway is already selected.\n",
+                    .codex => "Codex is already selected.\n",
+                    .grok => "Grok is already selected.\n",
+                };
+                try writeStdout(deps, message);
                 return .handled_success;
             }
 
@@ -905,20 +950,41 @@ fn runNonInteractiveWithDeps(
                     settings.credential_source,
                 );
             }
+            if (resolution.credential == null and target == .grok) {
+                grok_oauth.runLogin(alloc, cfg.gateway_provider.oauth_transport, cfg.url_opener) catch |err| {
+                    debug_trace.logf("auth", "provider selection Grok login failed err={s}", .{@errorName(err)});
+                    try writeStderr(deps, "fx provider: Grok login failed\n");
+                    return .handled_failure;
+                };
+                resolution = try credentials.resolveForProvider(
+                    alloc,
+                    cfg.gateway_provider.oauth_transport,
+                    cfg.secret_store,
+                    .refresh_if_needed,
+                    target,
+                    settings.credential_source,
+                );
+            }
             const credential = if (resolution.credential) |*value| value else {
                 try writeStderr(deps, if (target == .codex)
                     "fx provider: run fx login codex first\n"
+                else if (target == .grok)
+                    "fx provider: run fx login grok first\n"
                 else
                     "fx provider: configure a Gateway credential first\n");
                 return .handled_failure;
             };
-            const catalog_provider = if (target == .codex)
-                cfg.codex_model_catalog orelse {
+            const catalog_provider = switch (target) {
+                .codex => cfg.codex_model_catalog orelse {
                     try writeStderr(deps, "fx provider: Codex model catalog is unavailable\n");
                     return .handled_failure;
-                }
-            else
-                cfg.gateway_provider.model_catalog;
+                },
+                .grok => cfg.grok_model_catalog orelse {
+                    try writeStderr(deps, "fx provider: Grok model catalog is unavailable\n");
+                    return .handled_failure;
+                },
+                .gateway => cfg.gateway_provider.model_catalog,
+            };
             const fetch_result = model_catalog.fetchWithPublicFallback(catalog_provider, alloc, .{
                 .access = credentials.catalogAccessAt(credential.*, io_mod.milliTimestamp()),
                 .endpoint = cfg.models_path,
@@ -939,15 +1005,20 @@ fn runNonInteractiveWithDeps(
                 },
             };
             defer model_catalog.freeModelCatalog(alloc, &loaded.catalog);
-            const saved_model = if (target == .codex) settings.codex_model else settings.model;
+            const saved_model = switch (target) {
+                .gateway => settings.model,
+                .codex => settings.codex_model,
+                .grok => settings.grok_model,
+            };
             const selected_model = selectCatalogModel(loaded.catalog.items, saved_model) orelse {
                 try writeStderr(deps, "fx provider: target model catalog is empty\n");
                 return .handled_failure;
             };
-            var attempt = config_runtime.attemptUserPreferences(alloc, if (target == .codex)
-                .{ .provider = target, .codex_model = selected_model }
-            else
-                .{ .provider = target, .model = selected_model });
+            var attempt = config_runtime.attemptUserPreferences(alloc, switch (target) {
+                .gateway => .{ .provider = target, .model = selected_model },
+                .codex => .{ .provider = target, .codex_model = selected_model },
+                .grok => .{ .provider = target, .grok_model = selected_model },
+            });
             defer attempt.deinit(alloc);
             switch (attempt) {
                 .failure => |failure| {
@@ -957,7 +1028,11 @@ fn runNonInteractiveWithDeps(
                 },
                 .outcome => {},
             }
-            try writeStdout(deps, if (target == .codex) "Provider set to Codex.\n" else "Provider set to Gateway.\n");
+            try writeStdout(deps, switch (target) {
+                .gateway => "Provider set to Gateway.\n",
+                .codex => "Provider set to Codex.\n",
+                .grok => "Provider set to Grok.\n",
+            });
             return .handled_success;
         },
         .setup => |rest| {
@@ -1035,13 +1110,17 @@ fn runNonInteractiveWithDeps(
             try writeConfigDiagnostics(alloc, deps, startup.config_diagnostics);
 
             const catalog_access = startup.modelCatalogAccess();
-            const catalog_provider = if (startup.provider == .codex)
-                cfg.codex_cli_model_catalog orelse {
+            const catalog_provider = switch (startup.provider) {
+                .codex => cfg.codex_cli_model_catalog orelse {
                     try writeStderr(deps, "fx models: Codex model catalog is unavailable\n");
                     return .handled_failure;
-                }
-            else
-                cfg.gateway_provider.cli_model_catalog;
+                },
+                .grok => cfg.grok_cli_model_catalog orelse {
+                    try writeStderr(deps, "fx models: Grok model catalog is unavailable\n");
+                    return .handled_failure;
+                },
+                .gateway => cfg.gateway_provider.cli_model_catalog,
+            };
             const loaded = switch (catalog_provider.fetch(alloc, .{
                 .access = catalog_access,
                 .endpoint = cfg.models_path,
@@ -2858,6 +2937,8 @@ fn workflowConfig(cfg: Config) @import("cli_ask.zig").Config {
         .gateway_provider = cfg.gateway_provider,
         .codex_agent_stream = cfg.codex_agent_stream,
         .codex_model_catalog = cfg.codex_model_catalog,
+        .grok_agent_stream = cfg.grok_agent_stream,
+        .grok_model_catalog = cfg.grok_model_catalog,
         .background_process_provider = cfg.background_process_provider,
         .secret_store = cfg.secret_store,
         .prompt_policy = cfg.prompt_policy,
@@ -2875,6 +2956,7 @@ fn workflowConfig(cfg: Config) @import("cli_ask.zig").Config {
         .devbox_provider = cfg.devbox_provider,
         .permission_reviewer_provider = cfg.permission_reviewer_provider,
         .codex_permission_reviewer_provider = cfg.codex_permission_reviewer_provider,
+        .grok_permission_reviewer_provider = cfg.grok_permission_reviewer_provider,
     };
 }
 

--- a/src/core/cli/doctor_runtime.zig
+++ b/src/core/cli/doctor_runtime.zig
@@ -127,6 +127,7 @@ pub fn collect(
         .model = switch (snapshot.provider) {
             .gateway => detailed.settings.model,
             .codex => detailed.settings.codex_model,
+            .grok => detailed.settings.grok_model,
         },
         .permission_mode = detailed.settings.permission_mode,
         .max_agent_steps = detailed.settings.max_agent_steps,

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -40,6 +40,7 @@ pub const Settings = struct {
     model: ?[]u8 = null,
     provider: ?model_provider.ProviderId = null,
     codex_model: ?[]u8 = null,
+    grok_model: ?[]u8 = null,
     permission_mode: ?types.PermissionMode = null,
     credential_source: ?types.CredentialSource = null,
     yolo_acknowledged: ?bool = null,
@@ -71,6 +72,7 @@ pub const Settings = struct {
     pub fn deinit(self: *Settings, alloc: Allocator) void {
         if (self.model) |value| alloc.free(value);
         if (self.codex_model) |value| alloc.free(value);
+        if (self.grok_model) |value| alloc.free(value);
         if (self.input_appearance) |value| alloc.free(value);
         if (self.maxxing_mode) |value| alloc.free(value);
         if (self.sandbox) |value| alloc.free(value);
@@ -111,6 +113,7 @@ pub const ConfigSources = struct {
     model: ConfigSource = .compiled_default,
     provider: ConfigSource = .compiled_default,
     codex_model: ConfigSource = .compiled_default,
+    grok_model: ConfigSource = .compiled_default,
     permission_mode: ConfigSource = .compiled_default,
     effort: ConfigSource = .compiled_default,
     fast_mode: ConfigSource = .compiled_default,
@@ -550,6 +553,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "model",
         "provider",
         "codex_model",
+        "grok_model",
         "effort",
         "fast_mode",
         "input_appearance",
@@ -596,6 +600,7 @@ fn updateConfigSources(sources: *ConfigSources, settings: Settings, source: Conf
     if (settings.model != null) sources.model = source;
     if (settings.provider != null) sources.provider = source;
     if (settings.codex_model != null) sources.codex_model = source;
+    if (settings.grok_model != null) sources.grok_model = source;
     if (settings.permission_mode != null) sources.permission_mode = source;
     if (settings.effort != null) sources.effort = source;
     if (settings.fast_mode != null) sources.fast_mode = source;
@@ -1349,6 +1354,12 @@ fn parseProfileOnlyFields(
         settings.codex_model = try alloc.dupe(u8, model_value.string);
     }
 
+    if (root.object.get("grok_model")) |model_value| {
+        if (model_value != .string) return error.InvalidGrokModelType;
+        settings_store.validateModel(model_value.string) catch return error.InvalidGrokModelValue;
+        settings.grok_model = try alloc.dupe(u8, model_value.string);
+    }
+
     if (root.object.get("permission_mode")) |permission_mode_value| {
         const value = permission_mode_value;
         if (value != .string) return error.InvalidPermissionModeType;
@@ -1540,6 +1551,11 @@ fn mergeSettings(target: *Settings, incoming: *Settings, alloc: Allocator) void 
         if (target.codex_model) |current| alloc.free(current);
         target.codex_model = value;
         incoming.codex_model = null;
+    }
+    if (incoming.grok_model) |value| {
+        if (target.grok_model) |current| alloc.free(current);
+        target.grok_model = value;
+        incoming.grok_model = null;
     }
     if (incoming.permission_mode) |value| target.permission_mode = value;
     if (incoming.credential_source) |value| target.credential_source = value;
@@ -2083,15 +2099,16 @@ test "max_agent_steps absence and explicit values resolve distinctly" {
     try std.testing.expectEqual(@as(usize, 50), agent_steps.resolveMaxAgentSteps(positive.max_agent_steps, 25));
 }
 
-test "provider settings keep independent Gateway and Codex models" {
+test "provider settings keep independent provider models" {
     var settings = try parseSettingsJson(
         std.testing.allocator,
-        "{\"provider\":\"codex\",\"model\":\"gateway/model\",\"codex_model\":\"gpt-5.4-mini\"}",
+        "{\"provider\":\"grok\",\"model\":\"gateway/model\",\"codex_model\":\"gpt-5.4-mini\",\"grok_model\":\"grok-4.20-0309-non-reasoning\"}",
     );
     defer settings.deinit(std.testing.allocator);
-    try std.testing.expectEqual(model_provider.ProviderId.codex, settings.provider.?);
+    try std.testing.expectEqual(model_provider.ProviderId.grok, settings.provider.?);
     try std.testing.expectEqualStrings("gateway/model", settings.model.?);
     try std.testing.expectEqualStrings("gpt-5.4-mini", settings.codex_model.?);
+    try std.testing.expectEqualStrings("grok-4.20-0309-non-reasoning", settings.grok_model.?);
 }
 
 test "max_agent_steps explicit zero survives serialization round trip" {

--- a/src/core/config/model_provider.zig
+++ b/src/core/config/model_provider.zig
@@ -4,6 +4,7 @@ const types = @import("../shared/types.zig");
 pub const ProviderId = enum {
     gateway,
     codex,
+    grok,
 };
 
 pub const ProviderSelection = struct {
@@ -14,6 +15,7 @@ pub const ProviderSelection = struct {
 pub fn parse(value: []const u8) ?ProviderId {
     if (std.ascii.eqlIgnoreCase(value, "gateway")) return .gateway;
     if (std.ascii.eqlIgnoreCase(value, "codex")) return .codex;
+    if (std.ascii.eqlIgnoreCase(value, "grok")) return .grok;
     return null;
 }
 
@@ -21,14 +23,16 @@ pub fn label(provider: ProviderId) []const u8 {
     return switch (provider) {
         .gateway => "Vercel AI Gateway",
         .codex => "Codex subscription",
+        .grok => "Grok subscription",
     };
 }
 
 pub fn authorizesCredential(provider: ProviderId, source: ?types.CredentialSource) bool {
     const selected = source orelse return false;
     return switch (provider) {
-        .gateway => selected != .chatgpt_subscription,
+        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription,
         .codex => selected == .chatgpt_subscription,
+        .grok => selected == .grok_subscription,
     };
 }
 
@@ -43,11 +47,15 @@ test "explicit providers authorize only their own credential origins" {
     try std.testing.expect(authorizesCredential(.codex, .chatgpt_subscription));
     try std.testing.expect(!authorizesCredential(.codex, .ai_gateway_api_key));
     try std.testing.expect(!authorizesCredential(.codex, null));
+    try std.testing.expect(authorizesCredential(.grok, .grok_subscription));
+    try std.testing.expect(!authorizesCredential(.grok, .chatgpt_subscription));
+    try std.testing.expect(!authorizesCredential(.gateway, .grok_subscription));
 }
 
-test "provider parsing exposes only gateway and codex" {
+test "provider parsing exposes gateway codex and grok" {
     try std.testing.expectEqual(ProviderId.gateway, parse("gateway").?);
     try std.testing.expectEqual(ProviderId.codex, parse("CODEX").?);
+    try std.testing.expectEqual(ProviderId.grok, parse("GROK").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("") == null);
 }

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -92,6 +92,7 @@ pub const UserSettingsPatch = struct {
     model: ?[]const u8 = null,
     provider: ?model_provider.ProviderId = null,
     codex_model: ?[]const u8 = null,
+    grok_model: ?[]const u8 = null,
     permission_mode: ?types.PermissionMode = null,
     credential_source: ?types.CredentialSource = null,
     /// Removes the key entirely so resolution returns to plain precedence.
@@ -115,6 +116,7 @@ pub const UserSettingsPatch = struct {
         return self.model == null and
             self.provider == null and
             self.codex_model == null and
+            self.grok_model == null and
             self.permission_mode == null and
             self.credential_source == null and
             !self.clear_credential_source and
@@ -942,7 +944,7 @@ test "clearing the credential choice removes the key rather than blanking it" {
     try std.testing.expect(!application.changed);
 }
 
-test "provider patch keeps independent Gateway and Codex models" {
+test "provider patch keeps independent provider models" {
     const alloc = std.testing.allocator;
     var arena = std.heap.ArenaAllocator.init(alloc);
     defer arena.deinit();
@@ -956,11 +958,13 @@ test "provider patch keeps independent Gateway and Codex models" {
     const application = try applyUserPatchToRoot(arena.allocator(), &root, .{
         .provider = .codex,
         .codex_model = "gpt-5.4-mini",
+        .grok_model = "grok-4.20-0309-non-reasoning",
     });
     try std.testing.expect(application.changed);
     try std.testing.expectEqualStrings("gateway/model", root.object.get("model").?.string);
     try std.testing.expectEqualStrings("codex", root.object.get("provider").?.string);
     try std.testing.expectEqualStrings("gpt-5.4-mini", root.object.get("codex_model").?.string);
+    try std.testing.expectEqualStrings("grok-4.20-0309-non-reasoning", root.object.get("grok_model").?.string);
     try std.testing.expectEqual(model_provider.ProviderId.codex, model_provider.parse(root.object.get("provider").?.string).?);
 }
 
@@ -1007,6 +1011,7 @@ fn applyUserPatchToRoot(
     if (patch.model) |value| application.changed = try putString(arena, &root.object, "model", value) or application.changed;
     if (patch.provider) |value| application.changed = try putString(arena, &root.object, "provider", @tagName(value)) or application.changed;
     if (patch.codex_model) |value| application.changed = try putString(arena, &root.object, "codex_model", value) or application.changed;
+    if (patch.grok_model) |value| application.changed = try putString(arena, &root.object, "grok_model", value) or application.changed;
     if (patch.permission_mode) |value| application.changed = try putString(arena, &root.object, "permission_mode", @tagName(value)) or application.changed;
     if (patch.credential_source) |value| application.changed = try putString(arena, &root.object, "credential_source", @tagName(value)) or application.changed;
     if (patch.clear_credential_source and root.object.contains("credential_source")) {
@@ -1695,6 +1700,10 @@ fn validateKnownSettingsObject(
         }
     }
     if (object.get("codex_model")) |value| {
+        if (value != .string) return error.InvalidSettingsFormat;
+        try validateModel(value.string);
+    }
+    if (object.get("grok_model")) |value| {
         if (value != .string) return error.InvalidSettingsFormat;
         try validateModel(value.string);
     }

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -363,11 +363,15 @@ fn writeTerminalSafe(writer: *std.Io.Writer, alloc: Allocator, raw: []const u8) 
 
 fn gatewayProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
     const source = auth.active_source orelse return auth.gateway_connected;
-    return auth.gateway_connected or source != .chatgpt_subscription;
+    return auth.gateway_connected or (source != .chatgpt_subscription and source != .grok_subscription);
 }
 
 fn chatGptProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
     return auth.chatgpt_connected or auth.active_source == .chatgpt_subscription;
+}
+
+fn grokProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
+    return auth.grok_connected or auth.active_source == .grok_subscription;
 }
 
 fn writeConnectedProvidersText(writer: *std.Io.Writer, auth: auth_runtime.StatusSnapshot) !void {
@@ -379,6 +383,11 @@ fn writeConnectedProvidersText(writer: *std.Io.Writer, auth: auth_runtime.Status
     if (chatGptProviderConnected(auth)) {
         if (wrote_provider) try writer.writeAll(", Codex");
         if (!wrote_provider) try writer.writeAll("Codex");
+        wrote_provider = true;
+    }
+    if (grokProviderConnected(auth)) {
+        if (wrote_provider) try writer.writeAll(", Grok");
+        if (!wrote_provider) try writer.writeAll("Grok");
         wrote_provider = true;
     }
     if (!wrote_provider) try writer.writeAll("none");
@@ -412,7 +421,7 @@ pub const StatusSnapshot = struct {
         defer out.deinit();
 
         try out.writer.print("[status] model={s}\n", .{self.model});
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try out.writer.print("[status] model_source={s}\n", .{model_provider.label(self.provider)});
         }
         try out.writer.print("[status] update_channel={s}\n", .{self.update_channel});
@@ -424,7 +433,7 @@ pub const StatusSnapshot = struct {
             try out.writer.print("[status] mcp_config_error={s}\n", .{error_name});
         }
         try out.writer.print("[status] auth={s}\n", .{self.auth.activeSourceLabel()});
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try out.writer.writeAll("[status] connected_providers=");
             try writeConnectedProvidersText(&out.writer, self.auth);
             try out.writer.writeByte('\n');
@@ -451,7 +460,7 @@ pub const StatusSnapshot = struct {
         defer out.deinit();
 
         try out.writer.print("model={s}\n", .{self.model});
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try out.writer.print("model_source={s}\n", .{model_provider.label(self.provider)});
         }
         try out.writer.print("update_channel={s}\n", .{self.update_channel});
@@ -460,7 +469,7 @@ pub const StatusSnapshot = struct {
             try out.writer.print("build_revision={s}\n", .{self.build_revision});
         }
         try out.writer.print("auth={s}\n", .{self.auth.activeSourceLabel()});
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try out.writer.writeAll("connected_providers=");
             try writeConnectedProvidersText(&out.writer, self.auth);
             try out.writer.writeByte('\n');
@@ -489,7 +498,7 @@ pub const StatusSnapshot = struct {
     pub fn writeJson(self: StatusSnapshot, writer: *std.Io.Writer) !void {
         try writer.writeAll("{\"kind\":\"status\",\"model\":");
         try std.json.Stringify.value(self.model, .{}, writer);
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try writer.writeAll(",\"model_source\":");
             try std.json.Stringify.value(model_provider.label(self.provider), .{}, writer);
         }
@@ -505,7 +514,7 @@ pub const StatusSnapshot = struct {
         }
         try writer.writeAll(",\"auth\":");
         try std.json.Stringify.value(self.auth.activeSourceLabel(), .{}, writer);
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try writer.writeAll(",\"connected_providers\":[");
             var wrote_provider = false;
             if (gatewayProviderConnected(self.auth)) {
@@ -515,6 +524,11 @@ pub const StatusSnapshot = struct {
             if (chatGptProviderConnected(self.auth)) {
                 if (wrote_provider) try writer.writeByte(',');
                 try std.json.Stringify.value("codex", .{}, writer);
+                wrote_provider = true;
+            }
+            if (grokProviderConnected(self.auth)) {
+                if (wrote_provider) try writer.writeByte(',');
+                try std.json.Stringify.value("grok", .{}, writer);
             }
             try writer.writeByte(']');
         }
@@ -666,7 +680,7 @@ pub const ModelListSnapshot = struct {
 
         const shown = self.shownCount();
         for (self.ids[0..shown]) |id| {
-            if (self.provider == .codex) {
+            if (self.provider != .gateway) {
                 try out.writer.print(" - {s} · {s}\n", .{ id, model_provider.label(self.provider) });
             } else {
                 try out.writer.print(" - {s}\n", .{id});
@@ -694,7 +708,7 @@ pub const ModelListSnapshot = struct {
         try out.writer.print("{d} available", .{self.ids.len});
         const shown = self.shownCount();
         for (self.ids[0..shown]) |id| {
-            if (self.provider == .codex) {
+            if (self.provider != .gateway) {
                 try out.writer.print("\n - {s} · {s}", .{ id, model_provider.label(self.provider) });
             } else {
                 try out.writer.print("\n - {s}", .{id});
@@ -718,7 +732,7 @@ pub const ModelListSnapshot = struct {
             if (i > 0) try out.writer.writeByte(',');
             try std.json.Stringify.value(id, .{}, &out.writer);
         }
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try out.writer.writeAll("],\"models\":[");
             for (self.ids[0..shown], 0..) |id, i| {
                 if (i > 0) try out.writer.writeByte(',');
@@ -741,6 +755,7 @@ pub const ModelListSnapshot = struct {
         return switch (self.provider) {
             .gateway => "gateway",
             .codex => model_provider.label(.codex),
+            .grok => model_provider.label(.grok),
         };
     }
 
@@ -754,6 +769,7 @@ pub const ModelListSnapshot = struct {
             .credential_refresh_failed => "Vercel sign-in refresh failed; using the public model catalog.",
             .authenticated_credential_rejected => "Your Gateway credential was rejected; using the public model catalog.",
             .chatgpt_subscription => "Codex models require an authenticated Codex catalog.",
+            .grok_subscription => "Grok models require an authenticated Grok catalog.",
         };
     }
 };
@@ -1217,7 +1233,7 @@ pub const DoctorSnapshot = struct {
         );
         try out.writer.print("[doctor] workspace={s}\n", .{self.workspace_root});
         try out.writer.print("[doctor] model={s}\n", .{self.model});
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try out.writer.print("[doctor] model_source={s}\n", .{model_provider.label(self.provider)});
         }
         try out.writer.print("[doctor] auth={s}\n", .{self.auth.activeSourceLabel()});
@@ -1254,7 +1270,7 @@ pub const DoctorSnapshot = struct {
         try std.json.Stringify.value(self.workspace_root, .{}, writer);
         try writer.writeAll(",\"model\":");
         try std.json.Stringify.value(self.model, .{}, writer);
-        if (self.provider == .codex) {
+        if (self.provider != .gateway) {
             try writer.writeAll(",\"model_source\":");
             try std.json.Stringify.value(model_provider.label(self.provider), .{}, writer);
         }

--- a/src/core/shared/profile_paths.zig
+++ b/src/core/shared/profile_paths.zig
@@ -5,6 +5,7 @@ const Allocator = std.mem.Allocator;
 pub const root_dir_name = ".fx";
 pub const auth_file_name = "auth.json";
 pub const chatgpt_auth_file_name = "chatgpt-auth.json";
+pub const grok_auth_file_name = "grok-auth.json";
 pub const api_key_file_name = "api-key";
 pub const sessions_dir_name = "sessions";
 pub const prompt_history_file_name = "history.jsonl";
@@ -57,6 +58,10 @@ pub fn authPath(alloc: Allocator, home: []const u8) ![]u8 {
 
 pub fn chatgptAuthPath(alloc: Allocator, home: []const u8) ![]u8 {
     return std.fs.path.join(alloc, &.{ home, root_dir_name, chatgpt_auth_file_name });
+}
+
+pub fn grokAuthPath(alloc: Allocator, home: []const u8) ![]u8 {
+    return std.fs.path.join(alloc, &.{ home, root_dir_name, grok_auth_file_name });
 }
 
 pub fn apiKeyPath(alloc: Allocator, home: []const u8) ![]u8 {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -93,6 +93,7 @@ pub const CredentialSource = enum {
     fx_login,
     stored_key,
     chatgpt_subscription,
+    grok_subscription,
 };
 
 pub fn parseCredentialSource(text: []const u8) ?CredentialSource {

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -39,11 +39,13 @@ pub const ProviderRoute = struct {
 pub const ProviderRoutes = struct {
     gateway: ProviderRoute,
     codex: ProviderRoute,
+    grok: ProviderRoute,
 
     pub fn select(self: ProviderRoutes, provider: model_provider.ProviderId) ProviderRoute {
         return switch (provider) {
             .gateway => self.gateway,
             .codex => self.codex,
+            .grok => self.grok,
         };
     }
 };
@@ -51,10 +53,13 @@ pub const ProviderRoutes = struct {
 test "provider routes select independent streams and reviewers" {
     var gateway_tag: u8 = 0;
     var codex_tag: u8 = 0;
+    var grok_tag: u8 = 0;
     var gateway_stream = stream_provider.unavailable_provider;
     gateway_stream.context = &gateway_tag;
     var codex_stream = stream_provider.unavailable_provider;
     codex_stream.context = &codex_tag;
+    var grok_stream = stream_provider.unavailable_provider;
+    grok_stream.context = &grok_tag;
     const Reviewer = struct {
         fn review(
             _: ?*anyopaque,
@@ -67,15 +72,19 @@ test "provider routes select independent streams and reviewers" {
     };
     const gateway_reviewer = auto_classifier.Provider{ .context = &gateway_tag, .review_fn = Reviewer.review };
     const codex_reviewer = auto_classifier.Provider{ .context = &codex_tag, .review_fn = Reviewer.review };
+    const grok_reviewer = auto_classifier.Provider{ .context = &grok_tag, .review_fn = Reviewer.review };
     const routes = ProviderRoutes{
         .gateway = .{ .agent_stream_provider = gateway_stream, .permission_reviewer_provider = gateway_reviewer },
         .codex = .{ .agent_stream_provider = codex_stream, .permission_reviewer_provider = codex_reviewer },
+        .grok = .{ .agent_stream_provider = grok_stream, .permission_reviewer_provider = grok_reviewer },
     };
 
     try std.testing.expect(routes.select(.gateway).agent_stream_provider.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(routes.select(.gateway).permission_reviewer_provider.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(routes.select(.codex).agent_stream_provider.context.? == @as(*anyopaque, @ptrCast(&codex_tag)));
     try std.testing.expect(routes.select(.codex).permission_reviewer_provider.?.context.? == @as(*anyopaque, @ptrCast(&codex_tag)));
+    try std.testing.expect(routes.select(.grok).agent_stream_provider.context.? == @as(*anyopaque, @ptrCast(&grok_tag)));
+    try std.testing.expect(routes.select(.grok).permission_reviewer_provider.?.context.? == @as(*anyopaque, @ptrCast(&grok_tag)));
 }
 
 pub const Config = struct {

--- a/src/gateway/xai_grok.zig
+++ b/src/gateway/xai_grok.zig
@@ -1,0 +1,948 @@
+const std = @import("std");
+const image_attachments = @import("../core/images/image_attachments.zig");
+const secret = @import("../core/auth/secret.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+
+const Allocator = std.mem.Allocator;
+const endpoint = "https://api.x.ai/v1/responses";
+const generation_origin = "https://api.x.ai/v1";
+const e2e_endpoint_env = "FX_E2E_XAI_GROK_RESPONSES_URL";
+const max_error_body_bytes: usize = 256 * 1024;
+const max_sse_line_bytes: usize = 1024 * 1024;
+const max_sse_aggregate_bytes: usize = 64 * 1024 * 1024;
+const max_sse_events: usize = 100_000;
+const max_tool_calls: usize = 128;
+const max_tool_identity_bytes: usize = 1024;
+const max_tool_arguments_bytes: usize = 4 * 1024 * 1024;
+const max_provider_state_bytes: usize = 4 * 1024 * 1024;
+const transfer_buffer_bytes: usize = 256 * 1024;
+const connect_timeout_ms: i64 = 30_000;
+
+pub const agent_stream_provider = stream_provider.Provider{
+    .build_fn = buildRequest,
+    .stream_fn = streamCompletion,
+};
+
+fn validateModel(model: []const u8) !void {
+    if (model.len == 0 or model.len > 256) return error.InvalidXaiGrokModel;
+    for (model) |byte| {
+        if (byte <= 0x20 or byte == 0x7f) return error.InvalidXaiGrokModel;
+    }
+}
+
+fn buildRequest(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.BuildRequest,
+) ![]u8 {
+    try validateModel(request.model);
+    if (request.budget) |budget| {
+        if (budget.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+        _ = budget.deadline;
+    }
+
+    var instructions: std.Io.Writer.Allocating = .init(alloc);
+    defer instructions.deinit();
+    for (request.messages) |message| {
+        if (message.role != .system) continue;
+        const text = message.content orelse continue;
+        if (text.len == 0) continue;
+        if (instructions.written().len > 0) try instructions.writer.writeAll("\n\n");
+        try instructions.writer.writeAll(text);
+    }
+    if (instructions.written().len == 0) try instructions.writer.writeAll("You are a helpful assistant.");
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll("{\"model\":");
+    try std.json.Stringify.value(request.model, .{}, writer);
+    try writer.writeAll(",\"store\":false,\"stream\":true,\"instructions\":");
+    try std.json.Stringify.value(instructions.written(), .{}, writer);
+    try writer.writeAll(",\"input\":[");
+    try writeInput(writer, alloc, request.messages, request.verified_images);
+    try writer.writeByte(']');
+
+    _ = try writeTools(writer, alloc, request.serialized_tools, request.selected_dynamic_tool_schemas);
+    try writer.writeAll(",\"tool_choice\":");
+    try std.json.Stringify.value(request.tool_choice.label(), .{}, writer);
+    try writer.writeAll(",\"parallel_tool_calls\":true,\"include\":[\"reasoning.encrypted_content\"]");
+    try writer.writeAll(",\"text\":{\"verbosity\":\"low\"");
+    if (request.response_format) |format| {
+        var schema = try std.json.parseFromSlice(std.json.Value, alloc, format.schema_json, .{});
+        defer schema.deinit();
+        if (schema.value != .object) return error.InvalidStructuredResponseSchema;
+        try writer.writeAll(",\"format\":{\"type\":\"json_schema\",\"name\":");
+        try std.json.Stringify.value(format.name, .{}, writer);
+        try writer.writeAll(",\"description\":");
+        try std.json.Stringify.value(format.description, .{}, writer);
+        try writer.writeAll(",\"schema\":");
+        try std.json.Stringify.value(schema.value, .{}, writer);
+        try writer.writeAll(",\"strict\":true}");
+    }
+    try writer.writeByte('}');
+
+    if (request.provider_options.reasoning) |effort| {
+        try writer.writeAll(",\"reasoning\":{\"effort\":");
+        try std.json.Stringify.value(effort.label(), .{}, writer);
+        try writer.writeAll(",\"summary\":\"auto\"}");
+    }
+    if (request.max_output_tokens) |limit| try writer.print(",\"max_output_tokens\":{d}", .{limit});
+    try writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn writeInput(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    messages: []const types.ChatMessage,
+    verified_images: ?[]const image_attachments.VerifiedSnapshot,
+) !void {
+    var first = true;
+    for (messages, 0..) |message, message_index| {
+        switch (message.role) {
+            .system => continue,
+            .user => {
+                try writeComma(writer, &first);
+                try writer.writeAll("{\"role\":\"user\",\"content\":[");
+                var first_part = true;
+                if (message.content) |content| if (content.len > 0) {
+                    try writer.writeAll("{\"type\":\"input_text\",\"text\":");
+                    try std.json.Stringify.value(content, .{}, writer);
+                    try writer.writeByte('}');
+                    first_part = false;
+                };
+                if (verified_images) |images| {
+                    if (message_index == messages.len - 1) {
+                        for (images) |image| {
+                            if (!first_part) try writer.writeByte(',');
+                            try writeInputImage(writer, alloc, image);
+                            first_part = false;
+                        }
+                    }
+                }
+                try writer.writeAll("]}");
+            },
+            .assistant => {
+                if (message.provider_state_json) |state_json| {
+                    if (state_json.len > max_provider_state_bytes) return error.XaiGrokProviderStateTooLarge;
+                    var state = std.json.parseFromSlice(std.json.Value, alloc, state_json, .{}) catch
+                        return error.InvalidXaiGrokProviderState;
+                    defer state.deinit();
+                    if (state.value != .array) return error.InvalidXaiGrokProviderState;
+                    for (state.value.array.items) |item| {
+                        if (item != .object) return error.InvalidXaiGrokProviderState;
+                        try writeComma(writer, &first);
+                        try std.json.Stringify.value(item, .{}, writer);
+                    }
+                }
+                if (message.content) |content| if (content.len > 0) {
+                    try writeComma(writer, &first);
+                    try writer.writeAll("{\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":");
+                    try std.json.Stringify.value(content, .{}, writer);
+                    try writer.writeAll(",\"annotations\":[]}]}");
+                };
+                for (message.tool_calls) |call| {
+                    if (call.id.len == 0 or call.id.len > max_tool_identity_bytes or
+                        call.name.len == 0 or call.name.len > max_tool_identity_bytes or
+                        call.arguments_json.len > max_tool_arguments_bytes)
+                    {
+                        return error.XaiGrokToolCallLimitExceeded;
+                    }
+                    try writeComma(writer, &first);
+                    try writer.writeAll("{\"type\":\"function_call\",\"call_id\":");
+                    try std.json.Stringify.value(call.id, .{}, writer);
+                    try writer.writeAll(",\"name\":");
+                    try std.json.Stringify.value(call.name, .{}, writer);
+                    try writer.writeAll(",\"arguments\":");
+                    try std.json.Stringify.value(call.arguments_json, .{}, writer);
+                    try writer.writeByte('}');
+                }
+            },
+            .tool => {
+                try writeComma(writer, &first);
+                try writer.writeAll("{\"type\":\"function_call_output\",\"call_id\":");
+                try std.json.Stringify.value(message.tool_call_id orelse "", .{}, writer);
+                try writer.writeAll(",\"output\":");
+                try std.json.Stringify.value(message.content orelse "", .{}, writer);
+                try writer.writeByte('}');
+            },
+        }
+    }
+}
+
+fn writeInputImage(writer: *std.Io.Writer, alloc: Allocator, image: image_attachments.VerifiedSnapshot) !void {
+    const encoded_len = std.base64.standard.Encoder.calcSize(image.bytes.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = std.base64.standard.Encoder.encode(encoded, image.bytes);
+    try writer.writeAll("{\"type\":\"input_image\",\"detail\":\"auto\",\"image_url\":\"data:");
+    try writer.writeAll(image.media_type);
+    try writer.writeAll(";base64,");
+    try writer.writeAll(encoded);
+    try writer.writeAll("\"}");
+}
+
+fn writeTools(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    serialized_tools: []const u8,
+    selected_dynamic_schemas: []const []const u8,
+) !usize {
+    var count: usize = 0;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, serialized_tools, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidToolSchema,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidToolSchema;
+
+    var tools_out: std.Io.Writer.Allocating = .init(alloc);
+    defer tools_out.deinit();
+    try tools_out.writer.writeAll(",\"tools\":[");
+    for (parsed.value.array.items) |tool| {
+        if (try writeFunctionTool(&tools_out.writer, tool, count != 0)) count += 1;
+    }
+    for (selected_dynamic_schemas) |schema_json| {
+        var selected = std.json.parseFromSlice(std.json.Value, alloc, schema_json, .{}) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.InvalidToolSchema,
+        };
+        defer selected.deinit();
+        if (try writeFunctionTool(&tools_out.writer, selected.value, count != 0)) count += 1;
+    }
+    try tools_out.writer.writeByte(']');
+    if (count > 0) try writer.writeAll(tools_out.written());
+    return count;
+}
+
+fn writeFunctionTool(writer: *std.Io.Writer, value: std.json.Value, comma: bool) !bool {
+    if (value != .object) return false;
+    const kind = value.object.get("type") orelse return false;
+    if (kind != .string or !std.mem.eql(u8, kind.string, "function")) return false;
+    const name = value.object.get("name") orelse return false;
+    if (name != .string or name.string.len == 0) return false;
+    const parameters = value.object.get("inputSchema") orelse value.object.get("parameters") orelse return false;
+    if (parameters != .object) return false;
+    if (comma) try writer.writeByte(',');
+    try writer.writeAll("{\"type\":\"function\",\"name\":");
+    try std.json.Stringify.value(name.string, .{}, writer);
+    if (value.object.get("description")) |description| if (description == .string) {
+        try writer.writeAll(",\"description\":");
+        try std.json.Stringify.value(description.string, .{}, writer);
+    };
+    try writer.writeAll(",\"parameters\":");
+    try std.json.Stringify.value(parameters, .{}, writer);
+    try writer.writeAll(",\"strict\":false}");
+    return true;
+}
+
+fn writeComma(writer: *std.Io.Writer, first: *bool) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+}
+
+fn streamCompletion(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.Request,
+) !stream_provider.Result {
+    return streamCompletionCore(alloc, request) catch |err| {
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(err, request.delivery.load());
+        return err;
+    };
+}
+
+const OpenedRequest = struct {
+    request: ?std.http.Client.Request,
+
+    pub fn deinit(self: *OpenedRequest, _: Allocator) void {
+        if (self.request) |*request| request.deinit();
+        self.request = null;
+    }
+
+    pub fn take(self: *OpenedRequest) std.http.Client.Request {
+        const request = self.request.?;
+        self.request = null;
+        return request;
+    }
+};
+
+const OpenRequestOperation = struct {
+    client: *std.http.Client,
+    uri: std.Uri,
+    auth_header: []const u8,
+    extra_headers: []const std.http.Header,
+
+    pub fn run(self: *@This()) !OpenedRequest {
+        return .{ .request = try self.client.request(.POST, self.uri, .{
+            .headers = .{
+                .content_type = .{ .override = "application/json" },
+                .authorization = .{ .override = self.auth_header },
+                .accept_encoding = .omit,
+                .user_agent = .{ .override = gateway_client.user_agent },
+            },
+            .extra_headers = self.extra_headers,
+            .keep_alive = false,
+            .redirect_behavior = .unhandled,
+        }) };
+    }
+};
+
+fn streamCompletionCore(alloc: Allocator, request: stream_provider.Request) !stream_provider.Result {
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.credential_source != .grok_subscription) {
+        return error.GrokSubscriptionCredentialRequired;
+    }
+    try validateModel(request.model);
+    const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.api_key});
+    defer secret.zeroAndFree(alloc, auth_header);
+    const request_endpoint = if (io_mod.getenv(e2e_endpoint_env)) |override| endpoint: {
+        if (!gateway_client.isLoopbackHttpUrl(override)) return error.InvalidE2EXaiGrokEndpoint;
+        break :endpoint override;
+    } else endpoint;
+    const uri = try std.Uri.parse(request_endpoint);
+
+    var extra_headers_buf: [2]std.http.Header = undefined;
+    var extra_count: usize = 0;
+    extra_headers_buf[extra_count] = .{ .name = "accept", .value = "text/event-stream" };
+    extra_count += 1;
+    if (request.session_id) |session_id| if (session_id.len > 0) {
+        extra_headers_buf[extra_count] = .{ .name = "x-grok-conv-id", .value = session_id };
+        extra_count += 1;
+    };
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
+    defer client.deinit();
+    var open_operation = OpenRequestOperation{
+        .client = &client,
+        .uri = uri,
+        .auth_header = auth_header,
+        .extra_headers = extra_headers_buf[0..extra_count],
+    };
+    const connect_deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+        .clock = .awake,
+        .raw = .fromMilliseconds(connect_timeout_ms),
+    });
+    var opened = try gateway_client.runBoundedHttpOperation(
+        OpenedRequest,
+        alloc,
+        request.cancel_flag,
+        connect_deadline,
+        &open_operation,
+    );
+    var http_request = opened.take();
+    defer http_request.deinit();
+    var cancel_watch_done = std.atomic.Value(bool).init(false);
+    const cancel_watcher = if (http_request.connection) |connection|
+        try gateway_client.spawnHttpCancelWatcher(
+            &cancel_watch_done,
+            request.cancel_flag,
+            connection.stream_writer.stream,
+        )
+    else
+        null;
+    defer {
+        cancel_watch_done.store(true, .seq_cst);
+        if (cancel_watcher) |thread| thread.join();
+    }
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    http_request.transfer_encoding = .{ .content_length = request.payload.len };
+    var send_buffer: [8192]u8 = undefined;
+    request.delivery.markPossiblySent();
+    var body_writer = try http_request.sendBodyUnflushed(&send_buffer);
+    try body_writer.writer.writeAll(request.payload);
+    try body_writer.end();
+    if (http_request.connection) |connection| try connection.flush();
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    var response = try http_request.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        var transfer: [16 * 1024]u8 = undefined;
+        const reader = response.reader(&transfer);
+        const body = reader.allocRemaining(alloc, .limited(max_error_body_bytes)) catch |err| switch (err) {
+            error.StreamTooLong => try alloc.dupe(u8, "xAI Grok error response exceeded the local limit"),
+            else => return err,
+        };
+        return .{
+            .status = response.head.status,
+            .err_body = body,
+            .ownership = .owned,
+        };
+    }
+
+    var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
+    const reader = response.reader(&transfer_buffer);
+    const completion = try consumeSse(
+        alloc,
+        reader,
+        request.callback_ctx,
+        request.on_content_chunk,
+        request.on_tool_start,
+        request.on_reasoning_chunk,
+        request.on_tool_input_chunk,
+        request.cancel_flag,
+        request.content_capture_limit,
+    );
+    return .{
+        .status = .ok,
+        .completion = completion,
+        .generation_origin = generation_origin,
+        .ownership = .owned,
+    };
+}
+
+const ToolAccumulator = struct {
+    output_index: i64,
+    id: []u8,
+    name: []u8,
+    arguments: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *ToolAccumulator, alloc: Allocator) void {
+        alloc.free(self.id);
+        alloc.free(self.name);
+        self.arguments.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+const SseReader = struct {
+    pending_line: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *SseReader, alloc: Allocator) void {
+        self.pending_line.deinit(alloc);
+    }
+
+    fn release(self: *SseReader) void {
+        self.pending_line.clearRetainingCapacity();
+    }
+
+    fn next(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
+        while (true) {
+            const line = try self.readLine(alloc, reader) orelse return null;
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (trimmed.len == 0 or trimmed[0] == ':') {
+                self.release();
+                continue;
+            }
+            if (!std.mem.startsWith(u8, trimmed, "data:")) {
+                self.release();
+                continue;
+            }
+            const data = std.mem.trim(u8, trimmed["data:".len..], " \t");
+            if (std.mem.eql(u8, data, "[DONE]")) return null;
+            return data;
+        }
+    }
+
+    fn readLine(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
+        while (true) {
+            const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
+                error.StreamTooLong => {
+                    const buffered = reader.buffered();
+                    if (buffered.len == 0) return error.XaiGrokSseReadStalled;
+                    if (buffered.len > max_sse_line_bytes - self.pending_line.items.len) {
+                        return error.XaiGrokSseEventTooLarge;
+                    }
+                    try self.pending_line.appendSlice(alloc, buffered);
+                    reader.tossBuffered();
+                    continue;
+                },
+                error.ReadFailed => return error.ReadFailed,
+            } orelse {
+                if (self.pending_line.items.len > 0) return self.pending_line.items;
+                return null;
+            };
+            if (fragment.len > max_sse_line_bytes - self.pending_line.items.len) {
+                return error.XaiGrokSseEventTooLarge;
+            }
+            if (self.pending_line.items.len == 0) return fragment;
+            try self.pending_line.appendSlice(alloc, fragment);
+            return self.pending_line.items;
+        }
+    }
+};
+
+fn consumeSse(
+    alloc: Allocator,
+    reader: anytype,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    on_tool_input_chunk: ?stream_provider.StreamCallback,
+    cancel_flag: *std.atomic.Value(bool),
+    content_capture_limit: ?usize,
+) !types.GatewayCompletion {
+    var content: std.ArrayList(u8) = .empty;
+    errdefer content.deinit(alloc);
+    var provider_state: std.Io.Writer.Allocating = .init(alloc);
+    defer provider_state.deinit();
+    var provider_state_count: usize = 0;
+    var tools: std.ArrayList(ToolAccumulator) = .empty;
+    defer {
+        for (tools.items) |*tool| tool.deinit(alloc);
+        tools.deinit(alloc);
+    }
+    var sse: SseReader = .{};
+    defer sse.deinit(alloc);
+    var finish_reason: ?types.ProviderFinishReason = null;
+    var usage: types.Usage = .{};
+    var generation_id: ?[]u8 = null;
+    errdefer if (generation_id) |id| alloc.free(id);
+    var terminal_seen = false;
+    var saw_content_delta = false;
+    var event_count: usize = 0;
+    var aggregate_bytes: usize = 0;
+
+    while (try sse.next(alloc, reader)) |json_text| {
+        defer sse.release();
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        event_count = try checkedAccumulatedSize(event_count, 1, max_sse_events);
+        aggregate_bytes = try checkedAccumulatedSize(aggregate_bytes, json_text.len, max_sse_aggregate_bytes);
+        var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch
+            return error.InvalidXaiGrokSseEvent;
+        defer parsed.deinit();
+        if (parsed.value != .object) continue;
+        const event_type = stringField(parsed.value.object, "type") orelse continue;
+
+        if (std.mem.eql(u8, event_type, "response.output_item.added")) {
+            const output_index = integerField(parsed.value.object, "output_index") orelse continue;
+            const item = parsed.value.object.get("item") orelse continue;
+            if (item != .object) continue;
+            const item_type = stringField(item.object, "type") orelse continue;
+            if (std.mem.eql(u8, item_type, "function_call")) {
+                const call_id = stringField(item.object, "call_id") orelse continue;
+                const name = stringField(item.object, "name") orelse continue;
+                if (findTool(tools.items, output_index) == null) {
+                    try appendTool(alloc, &tools, output_index, call_id, name);
+                    if (on_tool_start) |callback| callback(callback_ctx, call_id, name, null);
+                }
+            }
+        } else if (std.mem.eql(u8, event_type, "response.output_text.delta") or
+            std.mem.eql(u8, event_type, "response.refusal.delta"))
+        {
+            const delta = stringField(parsed.value.object, "delta") orelse continue;
+            saw_content_delta = true;
+            on_content_chunk(callback_ctx, delta);
+            try appendCaptured(alloc, &content, delta, content_capture_limit);
+        } else if (std.mem.eql(u8, event_type, "response.reasoning_summary_text.delta") or
+            std.mem.eql(u8, event_type, "response.reasoning_text.delta"))
+        {
+            const delta = stringField(parsed.value.object, "delta") orelse continue;
+            if (on_reasoning_chunk) |callback| callback(callback_ctx, delta);
+        } else if (std.mem.eql(u8, event_type, "response.reasoning_summary_part.done")) {
+            if (on_reasoning_chunk) |callback| callback(callback_ctx, "\n\n");
+        } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.delta")) {
+            const output_index = integerField(parsed.value.object, "output_index") orelse continue;
+            const delta = stringField(parsed.value.object, "delta") orelse continue;
+            const index = findTool(tools.items, output_index) orelse continue;
+            try appendToolArguments(alloc, &tools.items[index].arguments, delta);
+            if (on_tool_input_chunk) |callback| callback(callback_ctx, delta);
+        } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.done")) {
+            const output_index = integerField(parsed.value.object, "output_index") orelse continue;
+            const arguments = stringField(parsed.value.object, "arguments") orelse continue;
+            const index = findTool(tools.items, output_index) orelse continue;
+            const previous_len = tools.items[index].arguments.items.len;
+            if (std.mem.startsWith(u8, arguments, tools.items[index].arguments.items)) {
+                const suffix = arguments[previous_len..];
+                try appendToolArguments(alloc, &tools.items[index].arguments, suffix);
+                if (suffix.len > 0) if (on_tool_input_chunk) |callback| callback(callback_ctx, suffix);
+            } else {
+                tools.items[index].arguments.clearRetainingCapacity();
+                try appendToolArguments(alloc, &tools.items[index].arguments, arguments);
+            }
+        } else if (std.mem.eql(u8, event_type, "response.output_item.done")) {
+            const output_index = integerField(parsed.value.object, "output_index") orelse continue;
+            const item = parsed.value.object.get("item") orelse continue;
+            if (item != .object) continue;
+            const item_type = stringField(item.object, "type") orelse continue;
+            if (std.mem.eql(u8, item_type, "function_call")) {
+                if (findTool(tools.items, output_index)) |index| {
+                    if (stringField(item.object, "arguments")) |arguments| {
+                        if (tools.items[index].arguments.items.len == 0) {
+                            try appendToolArguments(alloc, &tools.items[index].arguments, arguments);
+                        }
+                    }
+                }
+            } else if (std.mem.eql(u8, item_type, "reasoning") and
+                stringField(item.object, "encrypted_content") != null)
+            {
+                var encoded: std.Io.Writer.Allocating = .init(alloc);
+                defer encoded.deinit();
+                try std.json.Stringify.value(item, .{}, &encoded.writer);
+                const separators: usize = if (provider_state_count == 0) 2 else 1;
+                const encoded_size = try checkedAccumulatedSize(encoded.written().len, separators, max_provider_state_bytes);
+                _ = try checkedAccumulatedSize(provider_state.written().len, encoded_size, max_provider_state_bytes);
+                if (provider_state_count == 0) {
+                    try provider_state.writer.writeByte('[');
+                } else {
+                    try provider_state.writer.writeByte(',');
+                }
+                try provider_state.writer.writeAll(encoded.written());
+                provider_state_count += 1;
+            } else if (std.mem.eql(u8, item_type, "message") and !saw_content_delta) {
+                if (item.object.get("content")) |parts| if (parts == .array) {
+                    for (parts.array.items) |part| {
+                        if (part != .object) continue;
+                        const text = stringField(part.object, "text") orelse stringField(part.object, "refusal") orelse continue;
+                        on_content_chunk(callback_ctx, text);
+                        try appendCaptured(alloc, &content, text, content_capture_limit);
+                    }
+                };
+            }
+        } else if (std.mem.eql(u8, event_type, "response.completed") or
+            std.mem.eql(u8, event_type, "response.done") or
+            std.mem.eql(u8, event_type, "response.incomplete"))
+        {
+            const response_value = parsed.value.object.get("response") orelse continue;
+            if (response_value != .object) continue;
+            terminal_seen = true;
+            const status = stringField(response_value.object, "status");
+            finish_reason = finishReason(status, response_value.object, tools.items.len > 0);
+            usage = parseUsage(response_value.object);
+            if (stringField(response_value.object, "id")) |id| {
+                generation_id = try alloc.dupe(u8, id);
+            }
+            break;
+        } else if (std.mem.eql(u8, event_type, "response.failed") or
+            std.mem.eql(u8, event_type, "error"))
+        {
+            return error.XaiGrokResponseFailed;
+        }
+    }
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (!terminal_seen) return error.XaiGrokStreamIncomplete;
+
+    const owned_content = if (content.items.len > 0) try content.toOwnedSlice(alloc) else null;
+    if (owned_content != null) content = .empty;
+    errdefer if (owned_content) |value| alloc.free(value);
+    const owned_provider_state = if (provider_state_count > 0) state: {
+        try provider_state.writer.writeByte(']');
+        break :state try provider_state.toOwnedSlice();
+    } else null;
+    errdefer if (owned_provider_state) |value| alloc.free(value);
+    const owned_tools: []types.ToolCall = if (tools.items.len > 0)
+        try alloc.alloc(types.ToolCall, tools.items.len)
+    else
+        &.{};
+    errdefer if (owned_tools.len > 0) alloc.free(owned_tools);
+    var initialized: usize = 0;
+    errdefer for (owned_tools[0..initialized]) |call| {
+        alloc.free(call.id);
+        alloc.free(call.name);
+        alloc.free(call.arguments_json);
+    };
+    for (tools.items, 0..) |*tool, index| {
+        const arguments = if (tool.arguments.items.len > 0)
+            try tool.arguments.toOwnedSlice(alloc)
+        else
+            try alloc.dupe(u8, "{}");
+        tool.arguments = .empty;
+        owned_tools[index] = .{
+            .id = tool.id,
+            .name = tool.name,
+            .arguments_json = arguments,
+        };
+        tool.id = &.{};
+        tool.name = &.{};
+        initialized += 1;
+    }
+    return .{
+        .content = owned_content,
+        .tool_calls = owned_tools,
+        .generation_id = generation_id,
+        .provider_state_json = owned_provider_state,
+        .finish_reason = finish_reason orelse if (owned_tools.len > 0) .tool_calls else .stop,
+        .usage = usage,
+    };
+}
+
+fn appendTool(
+    alloc: Allocator,
+    tools: *std.ArrayList(ToolAccumulator),
+    output_index: i64,
+    call_id: []const u8,
+    name: []const u8,
+) !void {
+    if (tools.items.len >= max_tool_calls or call_id.len == 0 or call_id.len > max_tool_identity_bytes or
+        name.len == 0 or name.len > max_tool_identity_bytes)
+    {
+        return error.XaiGrokToolCallLimitExceeded;
+    }
+    const id = try alloc.dupe(u8, call_id);
+    errdefer alloc.free(id);
+    const owned_name = try alloc.dupe(u8, name);
+    errdefer alloc.free(owned_name);
+    try tools.append(alloc, .{
+        .output_index = output_index,
+        .id = id,
+        .name = owned_name,
+    });
+}
+
+fn appendToolArguments(
+    alloc: Allocator,
+    arguments: *std.ArrayList(u8),
+    delta: []const u8,
+) !void {
+    _ = checkedAccumulatedSize(arguments.items.len, delta.len, max_tool_arguments_bytes) catch
+        return error.XaiGrokToolArgumentsTooLarge;
+    try arguments.appendSlice(alloc, delta);
+}
+
+fn checkedAccumulatedSize(current: usize, additional: usize, maximum: usize) !usize {
+    const next = std.math.add(usize, current, additional) catch
+        return error.XaiGrokResourceLimitExceeded;
+    if (next > maximum) return error.XaiGrokResourceLimitExceeded;
+    return next;
+}
+
+fn appendCaptured(
+    alloc: Allocator,
+    content: *std.ArrayList(u8),
+    delta: []const u8,
+    limit: ?usize,
+) !void {
+    const remaining = if (limit) |maximum| maximum -| @min(maximum, content.items.len) else delta.len;
+    try content.appendSlice(alloc, delta[0..@min(delta.len, remaining)]);
+}
+
+fn findTool(tools: []const ToolAccumulator, output_index: i64) ?usize {
+    for (tools, 0..) |tool, index| if (tool.output_index == output_index) return index;
+    return null;
+}
+
+fn finishReason(
+    status: ?[]const u8,
+    response: std.json.ObjectMap,
+    has_tools: bool,
+) types.ProviderFinishReason {
+    const value = status orelse return if (has_tools) .tool_calls else .stop;
+    if (std.mem.eql(u8, value, "completed")) return if (has_tools) .tool_calls else .stop;
+    if (std.mem.eql(u8, value, "incomplete")) {
+        if (response.get("incomplete_details")) |details| if (details == .object) {
+            if (stringField(details.object, "reason")) |reason| {
+                if (std.mem.eql(u8, reason, "max_output_tokens")) return .length;
+                if (std.mem.eql(u8, reason, "content_filter")) return .content_filter;
+            }
+        };
+        return .provider_error;
+    }
+    if (std.mem.eql(u8, value, "failed") or std.mem.eql(u8, value, "cancelled")) return .provider_error;
+    return if (has_tools) .tool_calls else .other;
+}
+
+fn parseUsage(response: std.json.ObjectMap) types.Usage {
+    const value = response.get("usage") orelse return .{};
+    if (value != .object) return .{};
+    return .{
+        .input_tokens = unsignedField(value.object, "input_tokens"),
+        .output_tokens = unsignedField(value.object, "output_tokens"),
+    };
+}
+
+fn stringField(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    if (value != .string) return null;
+    return value.string;
+}
+
+fn integerField(object: std.json.ObjectMap, key: []const u8) ?i64 {
+    const value = object.get(key) orelse return null;
+    if (value != .integer) return null;
+    return value.integer;
+}
+
+fn unsignedField(object: std.json.ObjectMap, key: []const u8) ?u64 {
+    const value = integerField(object, key) orelse return null;
+    if (value < 0) return null;
+    return @intCast(value);
+}
+
+test "xAI Grok request uses Responses input and converts AI SDK tool schemas" {
+    const messages = [_]types.ChatMessage{
+        .{ .role = .system, .content = "Be concise." },
+        .{ .role = .user, .content = "Read it." },
+        .{
+            .role = .assistant,
+            .tool_calls = &.{.{ .id = "call_1", .name = "read_file", .arguments_json = "{\"path\":\"README.md\"}" }},
+            .provider_state_json = "[{\"id\":\"rs_1\",\"type\":\"reasoning\",\"encrypted_content\":\"opaque\"}]",
+        },
+        .{ .role = .tool, .tool_call_id = "call_1", .tool_name = "read_file", .content = "contents" },
+    };
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "grok-4.20",
+        .serialized_tools = "[{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read\",\"inputSchema\":{\"type\":\"object\"}}]",
+        .messages = &messages,
+        .tool_choice = .auto,
+        .provider_options = .{ .reasoning = types.ReasoningEffort.literal("high"), .fast = true },
+        .max_output_tokens = 4096,
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"grok-4.20\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"instructions\":\"Be concise.\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"type\":\"function_call_output\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"encrypted_content\":\"opaque\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"parameters\":{\"type\":\"object\"}") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"reasoning\":{\"effort\":\"high\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"service_tier\"") == null);
+    try std.testing.expect(std.mem.find(u8, body, "\"max_output_tokens\":4096") != null);
+}
+
+test "xAI Grok standard requests omit the priority service tier" {
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "Hello." }};
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "grok-4.20",
+        .serialized_tools = "[]",
+        .messages = &messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"service_tier\"") == null);
+}
+
+test "xAI Grok serializes each verified image directly once" {
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "Describe it." }};
+    const images = [_]image_attachments.VerifiedSnapshot{.{
+        .bytes = @constCast(&[_]u8{ 1, 2, 3, 4 }),
+        .media_type = "image/png",
+    }};
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "grok-4.20",
+        .serialized_tools = "[]",
+        .messages = &messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+        .verified_images = &images,
+    });
+    defer std.testing.allocator.free(body);
+
+    const marker = "\"type\":\"input_image\"";
+    const first = std.mem.find(u8, body, marker) orelse return error.TestExpectedImage;
+    try std.testing.expect(std.mem.findPos(u8, body, first + marker.len, marker) == null);
+    try std.testing.expect(std.mem.find(u8, body, "data:image/png;base64,AQIDBA==") != null);
+}
+
+test "xAI Grok rejects a wrong-origin credential before network I/O" {
+    var cancelled = std.atomic.Value(bool).init(false);
+    var delivery = stream_provider.DeliveryCertainty.init();
+    var evidence: stream_provider.AttemptEvidence = .{};
+    var callback_context: u8 = 0;
+    try std.testing.expectError(
+        error.GrokSubscriptionCredentialRequired,
+        agent_stream_provider.stream(std.testing.allocator, .{
+            .api_key = "gateway-key",
+            .credential_source = .ai_gateway_api_key,
+            .team = null,
+            .model = "grok-4.20",
+            .retry_count = 1,
+            .chat_url = "",
+            .payload = "{}",
+            .trace_ctx = .{},
+            .content_capture_limit = null,
+            .delivery = &delivery,
+            .attempt_evidence = &evidence,
+            .callback_ctx = @ptrCast(&callback_context),
+            .on_content_chunk = struct {
+                fn ignore(_: *anyopaque, _: []const u8) void {}
+            }.ignore,
+            .on_tool_start = null,
+            .on_reasoning_chunk = null,
+            .cancel_flag = &cancelled,
+        }),
+    );
+    try std.testing.expectEqual(stream_provider.DeliveryCertainty.State.definitely_unsent, delivery.load());
+}
+
+test "xAI Grok SSE maps text reasoning tools and usage" {
+    const sse_text =
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"reasoning\"}}\n\n" ++
+        "data: {\"type\":\"response.reasoning_summary_text.delta\",\"output_index\":0,\"delta\":\"thinking\"}\n\n" ++
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n" ++
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\"}}\n\n" ++
+        "data: {\"type\":\"response.output_text.delta\",\"output_index\":1,\"delta\":\"hello\"}\n\n" ++
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":2,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"read_file\"}}\n\n" ++
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":2,\"delta\":\"{\\\"path\\\":\\\"README.md\\\"}\"}\n\n" ++
+        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"output_tokens\":4}}}\n\n";
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    const Capture = struct {
+        content: std.ArrayList(u8) = .empty,
+        reasoning: std.ArrayList(u8) = .empty,
+        saw_read_file: bool = false,
+
+        fn contentChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.content.appendSlice(std.testing.allocator, chunk) catch unreachable;
+        }
+        fn reasoningChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.reasoning.appendSlice(std.testing.allocator, chunk) catch unreachable;
+        }
+        fn toolStart(raw: *anyopaque, _: []const u8, name: []const u8, _: ?[]const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.saw_read_file = std.mem.eql(u8, name, "read_file");
+        }
+    };
+    var capture: Capture = .{};
+    defer capture.content.deinit(std.testing.allocator);
+    defer capture.reasoning.deinit(std.testing.allocator);
+    const completion = try consumeSse(
+        std.testing.allocator,
+        &reader,
+        &capture,
+        Capture.contentChunk,
+        Capture.toolStart,
+        Capture.reasoningChunk,
+        null,
+        &cancelled,
+        null,
+    );
+    defer {
+        if (completion.content) |value| std.testing.allocator.free(@constCast(value));
+        types.freeToolCallSlice(std.testing.allocator, @constCast(completion.tool_calls));
+        if (completion.provider_state_json) |value| std.testing.allocator.free(@constCast(value));
+    }
+    try std.testing.expectEqualStrings("hello", capture.content.items);
+    try std.testing.expectEqualStrings("thinking", capture.reasoning.items);
+    try std.testing.expect(capture.saw_read_file);
+    try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+    try std.testing.expectEqualStrings("call_1", completion.tool_calls[0].id);
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(@as(?u64, 10), completion.usage.input_tokens);
+    try std.testing.expect(completion.provider_state_json != null);
+    try std.testing.expect(std.mem.find(u8, completion.provider_state_json.?, "\"encrypted_content\":\"opaque\"") != null);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}
+
+test "xAI Grok resource limits accept the exact bound and reject one beyond" {
+    try std.testing.expectEqual(
+        max_sse_line_bytes,
+        try checkedAccumulatedSize(0, max_sse_line_bytes, max_sse_line_bytes),
+    );
+    try std.testing.expectError(
+        error.XaiGrokResourceLimitExceeded,
+        checkedAccumulatedSize(0, max_sse_line_bytes + 1, max_sse_line_bytes),
+    );
+    try std.testing.expectEqual(
+        max_tool_arguments_bytes,
+        try checkedAccumulatedSize(max_tool_arguments_bytes - 1, 1, max_tool_arguments_bytes),
+    );
+    try std.testing.expectError(
+        error.XaiGrokResourceLimitExceeded,
+        checkedAccumulatedSize(max_provider_state_bytes, 1, max_provider_state_bytes),
+    );
+    try std.testing.expectError(
+        error.XaiGrokResourceLimitExceeded,
+        checkedAccumulatedSize(max_sse_events, 1, max_sse_events),
+    );
+}

--- a/src/gateway/xai_grok_models.zig
+++ b/src/gateway/xai_grok_models.zig
@@ -1,0 +1,323 @@
+const std = @import("std");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const secret = @import("../core/auth/secret.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+
+const max_catalog_models: usize = 128;
+const max_model_id_bytes: usize = 256;
+const max_catalog_bytes: usize = 1024 * 1024;
+const fetch_timeout_ms: i64 = 30_000;
+const default_models_endpoint = "https://api.x.ai/v1/language-models";
+const e2e_models_endpoint_env = "FX_E2E_XAI_GROK_MODELS_URL";
+const grok_4_6_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("xhigh"),
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("low"),
+};
+const grok_4_5_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("low"),
+};
+
+pub const model_catalog_provider = model_catalog.Provider{
+    .fetch_fn = fetchCatalogForProvider,
+};
+
+pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
+    .fetch_fn = fetchCliModelCatalog,
+};
+
+fn fetchCliModelCatalog(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: gateway_provider.CliModelCatalogInput,
+) gateway_provider.CliModelCatalogResult {
+    return switch (model_catalog.fetchWithPublicFallback(model_catalog_provider, alloc, .{
+        .access = input.access,
+        .endpoint = input.endpoint,
+        .cancel_flag = input.cancel_flag,
+        .view = .full,
+    })) {
+        .loaded => |loaded| blk: {
+            var catalog = loaded.catalog;
+            defer model_catalog.freeModelCatalog(alloc, &catalog);
+            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
+                .access = loaded.provenance.access,
+                .anonymous_fallback_used = false,
+                .failure = .{ .category = .resource_exhausted },
+            } };
+            break :blk .{ .loaded = .{
+                .ids = ids,
+                .provenance = loaded.provenance,
+            } };
+        },
+        .failed => |failure| .{ .failure = failure },
+    };
+}
+
+fn fetchCatalogForProvider(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: model_catalog.FetchInput,
+) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    if (input.access.credentialSource() != .grok_subscription) {
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    }
+    const credential = input.access.authorizationCredential() orelse
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    const request_url = modelsUrl(alloc) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{ .category = .runtime } };
+    };
+    defer alloc.free(request_url);
+
+    var fallback_cancel = std.atomic.Value(bool).init(false);
+    const cancel_flag = input.cancel_flag orelse &fallback_cancel;
+    var operation = FetchOperation{
+        .alloc = alloc,
+        .url = request_url,
+        .credential = credential,
+    };
+    var response = gateway_client.runBoundedHttpOperation(
+        FetchResponse,
+        alloc,
+        cancel_flag,
+        std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+            .clock = .awake,
+            .raw = .fromMilliseconds(fetch_timeout_ms),
+        }),
+        &operation,
+    ) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{
+            .category = if (err == error.Cancelled) .cancellation else .transport,
+            .retryable = err != error.Cancelled,
+        } };
+    };
+    defer response.deinit(alloc);
+    if (response.status != .ok) {
+        return .{ .failure = model_catalog.failureForHttpStatus(response.status) };
+    }
+    const catalog = parseCatalog(alloc, response.body) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{ .category = .malformed_response, .http_status = .ok } };
+    };
+    return .{ .catalog = catalog };
+}
+
+const FetchResponse = struct {
+    status: std.http.Status,
+    body: []u8,
+
+    pub fn deinit(self: *FetchResponse, alloc: std.mem.Allocator) void {
+        secret.zeroAndFree(alloc, self.body);
+        self.* = undefined;
+    }
+};
+
+const FetchOperation = struct {
+    alloc: std.mem.Allocator,
+    url: []const u8,
+    credential: []const u8,
+
+    pub fn run(self: *@This()) !FetchResponse {
+        var client: std.http.Client = .{ .allocator = self.alloc, .io = io_mod.getIo() };
+        defer client.deinit();
+        const auth_header = try std.fmt.allocPrint(self.alloc, "Bearer {s}", .{self.credential});
+        defer secret.zeroAndFree(self.alloc, auth_header);
+        const body_buffer = try self.alloc.alloc(u8, max_catalog_bytes + 1);
+        defer secret.zeroAndFree(self.alloc, body_buffer);
+        var response_writer = std.Io.Writer.fixed(body_buffer);
+        const result = client.fetch(.{
+            .location = .{ .url = self.url },
+            .method = .GET,
+            .headers = .{
+                .authorization = .{ .override = auth_header },
+                .user_agent = .{ .override = gateway_client.user_agent },
+                .accept_encoding = .omit,
+            },
+            .extra_headers = &.{
+                .{ .name = "accept", .value = "application/json" },
+            },
+            .response_writer = &response_writer,
+            .redirect_behavior = .unhandled,
+        }) catch |err| switch (err) {
+            error.WriteFailed => return error.GrokModelCatalogTooLarge,
+            else => return err,
+        };
+        const body = response_writer.buffered();
+        try validateCatalogBodySize(body.len);
+        return .{
+            .status = result.status,
+            .body = try self.alloc.dupe(u8, body),
+        };
+    }
+};
+
+fn modelsUrl(alloc: std.mem.Allocator) ![]u8 {
+    const base = io_mod.getenv(e2e_models_endpoint_env) orelse default_models_endpoint;
+    if (io_mod.getenv(e2e_models_endpoint_env) != null and !gateway_client.isLoopbackHttpUrl(base)) {
+        return error.InvalidE2EGrokModelsEndpoint;
+    }
+    return alloc.dupe(u8, base);
+}
+
+fn parseCatalog(
+    alloc: std.mem.Allocator,
+    json_text: []const u8,
+) !std.ArrayList(model_catalog.ModelCatalogEntry) {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json_text, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidGrokModelCatalog;
+    const models_value = parsed.value.object.get("models") orelse
+        return error.InvalidGrokModelCatalog;
+    if (models_value != .array) {
+        return error.InvalidGrokModelCatalog;
+    }
+    try validateCatalogModelCount(models_value.array.items.len);
+
+    var catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    errdefer model_catalog.freeModelCatalog(alloc, &catalog);
+    for (models_value.array.items) |value| {
+        if (value != .object) return error.InvalidGrokModelCatalog;
+        const object = value.object;
+        if (!try stringArrayContains(object, "output_modalities", "text")) continue;
+        const raw_id = try requiredString(object, "id");
+        try validateModelId(raw_id);
+        const id = try alloc.dupe(u8, raw_id);
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        var reasoning_efforts: std.ArrayList(types.ReasoningEffort) = .empty;
+        errdefer reasoning_efforts.deinit(alloc);
+        try appendKnownReasoningEfforts(alloc, &reasoning_efforts, raw_id);
+        const has_vision = try stringArrayContains(object, "input_modalities", "image");
+
+        try catalog.append(alloc, .{
+            .id = id,
+            .model_type = model_type,
+            .has_tool_use = true,
+            .has_reasoning = reasoning_efforts.items.len > 0,
+            .reasoning_efforts = reasoning_efforts,
+            .has_vision = has_vision,
+            .has_file_input = has_vision,
+            .has_implicit_caching = true,
+        });
+    }
+    return catalog;
+}
+
+fn appendKnownReasoningEfforts(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayList(types.ReasoningEffort),
+    model_id: []const u8,
+) !void {
+    const efforts = if (std.mem.eql(u8, model_id, "grok-4.6"))
+        &grok_4_6_reasoning_efforts
+    else if (std.mem.eql(u8, model_id, "grok-4.5"))
+        &grok_4_5_reasoning_efforts
+    else
+        return;
+    try out.appendSlice(alloc, efforts);
+}
+
+fn stringArrayContains(
+    object: std.json.ObjectMap,
+    key: []const u8,
+    expected: []const u8,
+) !bool {
+    const value = object.get(key) orelse return false;
+    if (value != .array or value.array.items.len > 32) return error.InvalidGrokModelCatalog;
+    for (value.array.items) |entry| {
+        if (entry != .string) return error.InvalidGrokModelCatalog;
+        if (std.mem.eql(u8, entry.string, expected)) return true;
+    }
+    return false;
+}
+
+fn requiredString(object: std.json.ObjectMap, key: []const u8) ![]const u8 {
+    const value = object.get(key) orelse return error.InvalidGrokModelCatalog;
+    if (value != .string or value.string.len == 0) return error.InvalidGrokModelCatalog;
+    return value.string;
+}
+
+fn validateModelId(id: []const u8) !void {
+    if (id.len == 0 or id.len > max_model_id_bytes) return error.InvalidGrokModelCatalog;
+    for (id) |byte| {
+        if (byte <= 0x20 or byte == 0x7f) return error.InvalidGrokModelCatalog;
+    }
+}
+
+fn validateCatalogBodySize(size: usize) !void {
+    if (size > max_catalog_bytes) return error.GrokModelCatalogTooLarge;
+}
+
+fn validateCatalogModelCount(count: usize) !void {
+    if (count > max_catalog_models) return error.InvalidGrokModelCatalog;
+}
+
+test "Grok catalog parser keeps text models and live modalities" {
+    const alloc = std.testing.allocator;
+    const json =
+        \\{"models":[
+        \\  {"id":"grok-4.20","object":"model","input_modalities":["text","image"],"output_modalities":["text"]},
+        \\  {"id":"grok-4.6","object":"model","input_modalities":["text","image"],"output_modalities":["text"]},
+        \\  {"id":"grok-4.5","object":"model","input_modalities":["text","image"],"output_modalities":["text"]},
+        \\  {"id":"grok-image","object":"model","input_modalities":["text"],"output_modalities":["image"]}
+        \\]}
+    ;
+    var catalog = try parseCatalog(alloc, json);
+    defer model_catalog.freeModelCatalog(alloc, &catalog);
+
+    try std.testing.expectEqual(@as(usize, 3), catalog.items.len);
+    const model = catalog.items[0];
+    try std.testing.expectEqualStrings("grok-4.20", model.id);
+    try std.testing.expect(model.has_tool_use);
+    try std.testing.expect(!model.has_reasoning);
+    try std.testing.expectEqual(@as(usize, 0), model.reasoning_efforts.items.len);
+    try std.testing.expect(!model.supports_fast_mode);
+    try std.testing.expect(model.has_vision);
+    try std.testing.expect(model.has_file_input);
+    try std.testing.expectEqual(@as(u32, 0), model.context_window);
+    const grok_4_6 = catalog.items[1];
+    try std.testing.expectEqualStrings("grok-4.6", grok_4_6.id);
+    try std.testing.expect(grok_4_6.has_reasoning);
+    try std.testing.expectEqual(@as(usize, 4), grok_4_6.reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("xhigh", grok_4_6.reasoning_efforts.items[0].label());
+    try std.testing.expectEqualStrings("low", grok_4_6.reasoning_efforts.items[3].label());
+    const grok_4_5 = catalog.items[2];
+    try std.testing.expectEqualStrings("grok-4.5", grok_4_5.id);
+    try std.testing.expectEqual(@as(usize, 3), grok_4_5.reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("high", grok_4_5.reasoning_efforts.items[0].label());
+}
+
+test "Grok catalog URL is the live-validated direct endpoint" {
+    const url = try modelsUrl(std.testing.allocator);
+    defer std.testing.allocator.free(url);
+    try std.testing.expectEqualStrings(default_models_endpoint, url);
+}
+
+test "Grok model ids enforce the exact provider-local bound" {
+    var accepted: [max_model_id_bytes]u8 = @splat('a');
+    try validateModelId(&accepted);
+    var rejected: [max_model_id_bytes + 1]u8 = @splat('a');
+    try std.testing.expectError(error.InvalidGrokModelCatalog, validateModelId(&rejected));
+}
+
+test "Grok catalog resource limits accept exact values and reject one beyond" {
+    try validateCatalogBodySize(max_catalog_bytes);
+    try std.testing.expectError(
+        error.GrokModelCatalogTooLarge,
+        validateCatalogBodySize(max_catalog_bytes + 1),
+    );
+    try validateCatalogModelCount(max_catalog_models);
+    try std.testing.expectError(
+        error.InvalidGrokModelCatalog,
+        validateCatalogModelCount(max_catalog_models + 1),
+    );
+}

--- a/src/gateway/xai_grok_permission_reviewer.zig
+++ b/src/gateway/xai_grok_permission_reviewer.zig
@@ -1,0 +1,200 @@
+const std = @import("std");
+const permission_auto_classifier = @import("../core/permissions/auto_classifier.zig");
+const gateway_json = @import("../core/gateway/gateway_json.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const types = @import("../core/shared/types.zig");
+const session_usage = @import("../core/session/session_usage.zig");
+const xai_grok = @import("xai_grok.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const provider = permission_auto_classifier.Provider{
+    .review_fn = reviewGrok,
+};
+
+const ReviewConfig = struct {
+    credential: []const u8,
+    cancel_flag: ?*std.atomic.Value(bool),
+    usage: ?*session_usage.Usage,
+    usage_allocator: Allocator,
+};
+
+fn reviewGrok(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    input: permission_auto_classifier.ProviderInput,
+    request: permission_auto_classifier.ReviewRequest,
+) anyerror!permission_auto_classifier.ParseOutcome {
+    if (input.credential.len == 0) return .invalid;
+    var config = ReviewConfig{
+        .credential = input.credential,
+        .cancel_flag = input.cancel_flag,
+        .usage = input.usage,
+        .usage_allocator = input.usage_allocator,
+    };
+    return permission_auto_classifier.Reviewer.withTransportModel(
+        .{
+            .context = @ptrCast(&config),
+            .build_fn = buildReviewPayload,
+            .send_fn = sendReview,
+        },
+        config.cancel_flag,
+        permission_auto_classifier.Reviewer.default_timeout_ms,
+        request.review_turn.model,
+    ).review(alloc, request);
+}
+
+fn buildReviewPayload(
+    _: *anyopaque,
+    alloc: Allocator,
+    model: []const u8,
+    tools_json: []const u8,
+    messages: []const types.ChatMessage,
+    target_call_id: []const u8,
+    deadline: std.Io.Clock.Timestamp,
+    cancel_flag: *std.atomic.Value(bool),
+) ![]u8 {
+    const expanded = try gateway_json.expandPendingToolReviewMessages(
+        alloc,
+        messages,
+        target_call_id,
+        deadline,
+        cancel_flag,
+    );
+    defer alloc.free(expanded);
+    return xai_grok.agent_stream_provider.build(alloc, .{
+        .model = model,
+        .serialized_tools = tools_json,
+        .messages = expanded,
+        .tool_choice = .required,
+        .provider_options = .{},
+        .max_output_tokens = 2048,
+        .budget = .{ .deadline = deadline, .cancel_flag = cancel_flag },
+    });
+}
+
+const OwnedResult = struct {
+    result: stream_provider.Result,
+};
+
+fn deinitOwnedResult(raw: *anyopaque, alloc: Allocator) void {
+    const owned: *OwnedResult = @ptrCast(@alignCast(raw));
+    owned.result.deinit(alloc);
+    alloc.destroy(owned);
+}
+
+fn ignoreChunk(_: *anyopaque, _: []const u8) void {}
+
+fn sendReview(
+    raw: *anyopaque,
+    alloc: Allocator,
+    model: []const u8,
+    payload: []const u8,
+    deadline: std.Io.Clock.Timestamp,
+    cancel_flag: *std.atomic.Value(bool),
+) !permission_auto_classifier.TransportOutcome {
+    const config: *ReviewConfig = @ptrCast(@alignCast(raw));
+    if (cancel_flag.load(.seq_cst)) return .cancelled;
+    if (std.Io.Clock.Timestamp.now(@import("../core/shared/io.zig").getIo(), .awake).raw.nanoseconds >=
+        deadline.raw.nanoseconds)
+    {
+        return .timed_out;
+    }
+    var delivery = stream_provider.DeliveryCertainty.init();
+    var evidence: stream_provider.AttemptEvidence = .{};
+    var callback_context: u8 = 0;
+    const usage_observation = try session_usage.GatewayObservation.begin(config.usage);
+    var result = xai_grok.agent_stream_provider.stream(alloc, .{
+        .api_key = config.credential,
+        .credential_source = .grok_subscription,
+        .team = null,
+        .model = model,
+        .retry_count = 1,
+        .chat_url = "",
+        .payload = payload,
+        .trace_ctx = .{},
+        .content_capture_limit = 16 * 1024,
+        .delivery = &delivery,
+        .attempt_evidence = &evidence,
+        .callback_ctx = @ptrCast(&callback_context),
+        .on_content_chunk = ignoreChunk,
+        .on_tool_start = null,
+        .on_reasoning_chunk = null,
+        .cancel_flag = cancel_flag,
+        .provider_attempt_owner = .transport,
+    }) catch |err| {
+        usage_observation.fail(if (delivery.load() == .possibly_sent)
+            .ambiguous_delivery
+        else
+            .unbilled) catch return .permanent_failure;
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        if (err == error.Cancelled or cancel_flag.load(.seq_cst)) return .cancelled;
+        return .transient_failure;
+    };
+    var result_owned = true;
+    defer if (result_owned) result.deinit(alloc);
+    usage_observation.complete(
+        config.usage_allocator,
+        result.status,
+        result.completion,
+        "https://api.x.ai/v1",
+        null,
+    ) catch return .permanent_failure;
+    if (cancel_flag.load(.seq_cst)) return .cancelled;
+    if (result.status != .ok) {
+        const code: u16 = @intFromEnum(result.status);
+        return if (code == 408 or code == 425 or code == 429 or code >= 500)
+            .transient_failure
+        else
+            .permanent_failure;
+    }
+    if (result.completion.finish_reason) |reason| switch (reason) {
+        .provider_error => return .transient_failure,
+        .content_filter => return .permanent_failure,
+        .stop, .length, .tool_calls, .other => {},
+    };
+    const owned = try alloc.create(OwnedResult);
+    owned.* = .{ .result = result };
+    result_owned = false;
+    return .{ .completion = .{
+        .completion = owned.result.completion,
+        .context = @ptrCast(owned),
+        .deinit_fn = deinitOwnedResult,
+    } };
+}
+
+test "Grok reviewer builds a direct Responses request with the admitted model" {
+    const messages = [_]types.ChatMessage{
+        .{ .role = .user, .content = "User requested the change." },
+        .{
+            .role = .assistant,
+            .tool_calls = &.{.{
+                .id = "call_review",
+                .name = "write_file",
+                .arguments_json = "{\"path\":\"a.txt\"}",
+            }},
+        },
+        .{ .role = .system, .content = "Review the pending action." },
+    };
+    var cancelled = std.atomic.Value(bool).init(false);
+    var context: u8 = 0;
+    const body = try buildReviewPayload(
+        @ptrCast(&context),
+        std.testing.allocator,
+        "grok-4.20",
+        "[{\"type\":\"function\",\"name\":\"permission_decision\",\"parameters\":{\"type\":\"object\"}}]",
+        &messages,
+        "call_review",
+        std.Io.Clock.Timestamp.fromNow(@import("../core/shared/io.zig").getIo(), .{
+            .clock = .awake,
+            .raw = .fromSeconds(5),
+        }),
+        &cancelled,
+    );
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"grok-4.20\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_choice\":\"required\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"type\":\"function_call_output\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "ai-gateway") == null);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -54,6 +54,8 @@ const builtin_gateway = @import("builtins/gateway.zig");
 const builtin_providers = @import("builtins/providers.zig");
 const openai_codex_models = @import("gateway/openai_codex_models.zig");
 const openai_codex_permission_reviewer = @import("gateway/openai_codex_permission_reviewer.zig");
+const xai_grok_models = @import("gateway/xai_grok_models.zig");
+const xai_grok_permission_reviewer = @import("gateway/xai_grok_permission_reviewer.zig");
 const gateway_provider = @import("core/gateway/gateway_provider.zig");
 const model_catalog = @import("core/gateway/model_catalog.zig");
 const generation_usage_provider = @import("core/session/generation_usage_provider.zig");
@@ -1607,6 +1609,16 @@ const App = struct {
                     builtin_providers.agentStream(.codex),
                 .permission_reviewer_provider = if (comptime host_profile.tools and !host_target.is_wasm)
                     openai_codex_permission_reviewer.provider
+                else
+                    null,
+            },
+            .grok = .{
+                .agent_stream_provider = if (comptime host_target.is_wasm)
+                    agent_stream_provider.unavailable_provider
+                else
+                    builtin_providers.agentStream(.grok),
+                .permission_reviewer_provider = if (comptime host_profile.tools and !host_target.is_wasm)
+                    xai_grok_permission_reviewer.provider
                 else
                     null,
             },
@@ -3272,6 +3284,9 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .codex_agent_stream = builtin_providers.agentStream(.codex),
         .codex_cli_model_catalog = openai_codex_models.cli_model_catalog_provider,
         .codex_model_catalog = openai_codex_models.model_catalog_provider,
+        .grok_agent_stream = builtin_providers.agentStream(.grok),
+        .grok_cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
+        .grok_model_catalog = xai_grok_models.model_catalog_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3294,6 +3309,7 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .devbox_provider = builtin_devbox.provider,
         .permission_reviewer_provider = builtin_gateway.permission_reviewer.provider,
         .codex_permission_reviewer_provider = openai_codex_permission_reviewer.provider,
+        .grok_permission_reviewer_provider = xai_grok_permission_reviewer.provider,
     };
 }
 
@@ -3312,6 +3328,9 @@ fn localEntryConfig() app_entry_runtime.Config {
         .codex_agent_stream = builtin_providers.agentStream(.codex),
         .codex_cli_model_catalog = openai_codex_models.cli_model_catalog_provider,
         .codex_model_catalog = openai_codex_models.model_catalog_provider,
+        .grok_agent_stream = builtin_providers.agentStream(.grok),
+        .grok_cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
+        .grok_model_catalog = xai_grok_models.model_catalog_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3350,6 +3369,9 @@ fn emptyEntryConfig() app_entry_runtime.Config {
         .codex_agent_stream = builtin_providers.agentStream(.codex),
         .codex_cli_model_catalog = openai_codex_models.cli_model_catalog_provider,
         .codex_model_catalog = openai_codex_models.model_catalog_provider,
+        .grok_agent_stream = builtin_providers.agentStream(.grok),
+        .grok_cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
+        .grok_model_catalog = xai_grok_models.model_catalog_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3855,6 +3877,11 @@ test {
     _ = @import("gateway/openai_codex_models.zig");
     _ = @import("gateway/openai_codex.zig");
     _ = @import("gateway/openai_codex_permission_reviewer.zig");
+    _ = @import("core/auth/grok_session.zig");
+    _ = @import("core/auth/grok_oauth.zig");
+    _ = @import("gateway/xai_grok_models.zig");
+    _ = @import("gateway/xai_grok.zig");
+    _ = @import("gateway/xai_grok_permission_reviewer.zig");
     _ = credentials;
     _ = @import("core/auth/oauth.zig");
     _ = @import("core/auth/oauth_session.zig");

--- a/src/ui/footer/model_menu_presentation.zig
+++ b/src/ui/footer/model_menu_presentation.zig
@@ -345,6 +345,7 @@ fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]
             .credential_refresh_failed => "Vercel sign-in refresh failed; using the public model catalog.",
             .authenticated_credential_rejected => "Your Gateway credential was rejected; using the public model catalog.",
             .chatgpt_subscription => "Codex models require an authenticated Codex catalog.",
+            .grok_subscription => "Grok models require an authenticated Grok catalog.",
         };
     }
     if (state.access_level == .authenticated) {
@@ -355,6 +356,7 @@ fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]
             .vercel_oidc_token => "Gateway catalog: authenticated with the Vercel session.",
             .stored_key => "Gateway catalog: authenticated with the stored API key.",
             .chatgpt_subscription => "Codex catalog: authenticated with a subscription.",
+            .grok_subscription => "Grok catalog: authenticated with a subscription.",
         };
     }
     return null;

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -55,7 +55,7 @@ fn teamQueryProjection(query: []const u8, width: u16) TeamQueryProjection {
 pub fn authPickerRowCount(view: auth_runtime.PickerView) u16 {
     if (view.stage == .sign_in) return 7;
     if (view.stage == .api_key) return 4;
-    if (view.stage == .root and view.include_skip) return 17;
+    if (view.stage == .root and view.include_skip) return 18;
     return @intCast(1 + @max(view.choiceCount(), 1));
 }
 
@@ -157,14 +157,13 @@ const onboarding_note = "   ⚠︎ Note: fx is experimental and defaults to auto
 const onboarding_note_link = onboarding_note ++ " \x1b]8;id=fx-onboarding;https://fx.sh/docs/stability\x1b\\\x1b[4mLearn more\x1b[24m\x1b]8;;\x1b\\";
 
 fn onboardingProjectedRowIndex(view: auth_runtime.PickerView, row_index: u16, row_count: u16) u16 {
-    if (row_count >= 17) return row_index;
+    if (row_count >= 18) return row_index;
 
-    const selected_row: u16 = if (view.selectedIndex() == 0) 8 else 9;
-    const other_row: u16 = if (selected_row == 8) 9 else 8;
-    const priority = [_]u16{ selected_row, other_row, 10, 14, 7, 11, 5, 0, 2, 3, 6, 12, 13, 1, 4, 15, 16 };
+    const selected_row: u16 = 8 + @as(u16, @intCast(view.selectedIndex()));
+    const priority = [_]u16{ selected_row, 11, 9, 10, 8, 15, 7, 12, 5, 0, 2, 3, 6, 13, 14, 1, 4, 16, 17 };
 
     var projected_index: u16 = 0;
-    for (0..17) |source_row| {
+    for (0..18) |source_row| {
         for (priority[0..@min(row_count, priority.len)]) |included_row| {
             if (source_row != included_row) continue;
             if (projected_index == row_index) return @intCast(source_row);
@@ -172,7 +171,7 @@ fn onboardingProjectedRowIndex(view: auth_runtime.PickerView, row_index: u16, ro
             break;
         }
     }
-    return 16;
+    return 17;
 }
 
 fn composeOnboardingPickerRow(
@@ -191,6 +190,7 @@ fn composeOnboardingPickerRow(
         8 => 0,
         9 => 1,
         10 => 2,
+        11 => 3,
         else => null,
     };
     if (maybe_choice_index) |choice_index| {
@@ -218,12 +218,10 @@ fn composeOnboardingPickerRow(
         5 => "   You can change this anytime with /setup.",
         6 => "",
         7 => "   Get started",
-        10 => "",
-        11 => if (display_width.visibleWidthIgnoringAnsi(onboarding_note_link) <= width) onboarding_note_link else onboarding_note,
-        12 => "",
-        13 => "",
-        14 => "   Esc to set up later · Explore all commands with /help",
-        15, 16 => "",
+        12 => if (display_width.visibleWidthIgnoringAnsi(onboarding_note_link) <= width) onboarding_note_link else onboarding_note,
+        13, 14 => "",
+        15 => "   Esc to set up later · Explore all commands with /help",
+        16, 17 => "",
         else => "",
     };
     try row_text.appendClipped(alloc, &row, label, width);
@@ -251,7 +249,12 @@ fn composeSignInPickerRow(
     );
     var label_buf: [512]u8 = undefined;
     const label = switch (row_index) {
-        0 => if (source == .chatgpt_subscription) "   Sign in with Codex" else "   Sign in with Vercel",
+        0 => if (source == .chatgpt_subscription)
+            "   Sign in with Codex"
+        else if (source == .grok_subscription)
+            "   Sign in with Grok"
+        else
+            "   Sign in with Vercel",
         1, 4 => "",
         2 => std.fmt.bufPrint(
             &label_buf,
@@ -259,6 +262,8 @@ fn composeSignInPickerRow(
             .{snapshot.verification_uri},
         ) catch if (source == .chatgpt_subscription)
             "   Open the Codex authorization page"
+        else if (source == .grok_subscription)
+            "   Open the Grok authorization page"
         else
             "   Open the Vercel device authorization page",
         3 => if (snapshot.user_code.len == 0)
@@ -1561,7 +1566,7 @@ test "auth onboarding composes the welcome copy and setup choices" {
         .include_skip = true,
     };
 
-    try std.testing.expectEqual(@as(u16, 17), authPickerRowCount(view));
+    try std.testing.expectEqual(@as(u16, 18), authPickerRowCount(view));
     var screen: std.ArrayList(u8) = .empty;
     defer screen.deinit(alloc);
     for (0..authPickerRowCount(view)) |row_index| {
@@ -1596,11 +1601,15 @@ test "auth onboarding composes the welcome copy and setup choices" {
     defer chatgpt_row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, chatgpt_row.items, "Sign in with Codex") != null);
 
-    var unselected_row = try composeAuthPickerRow(alloc, view, 10, authPickerRowCount(view), 100);
+    var grok_row = try composeAuthPickerRow(alloc, view, 10, authPickerRowCount(view), 100);
+    defer grok_row.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, grok_row.items, "Sign in with Grok") != null);
+
+    var unselected_row = try composeAuthPickerRow(alloc, view, 11, authPickerRowCount(view), 100);
     defer unselected_row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, unselected_row.items, "Add an API key") != null);
 
-    var narrow_note = try composeAuthPickerRow(alloc, view, 11, authPickerRowCount(view), 58);
+    var narrow_note = try composeAuthPickerRow(alloc, view, 12, authPickerRowCount(view), 58);
     defer narrow_note.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow_note.items, "https://fx.sh/docs/stability") == null);
 
@@ -1615,6 +1624,7 @@ test "auth onboarding composes the welcome copy and setup choices" {
     try std.testing.expect(std.mem.find(u8, compact_screen.items, "Sign in with Vercel") != null);
     try std.testing.expect(std.mem.find(u8, compact_screen.items, "Add an API key") != null);
     try std.testing.expect(std.mem.find(u8, compact_screen.items, "Sign in with Codex") != null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Sign in with Grok") != null);
 }
 
 test "auth picker composes only detected credential sources" {
@@ -1627,7 +1637,7 @@ test "auth picker composes only detected credential sources" {
         .include_skip = false,
     };
     const row_count = authPickerRowCount(view);
-    try std.testing.expectEqual(@as(u16, 6), row_count);
+    try std.testing.expectEqual(@as(u16, 7), row_count);
 
     var header = try composeAuthPickerRow(alloc, view, 0, row_count, 80);
     defer header.deinit(alloc);
@@ -1641,16 +1651,20 @@ test "auth picker composes only detected credential sources" {
     defer chatgpt.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, chatgpt.items, "Sign in with Codex") != null);
 
-    var setup = try composeAuthPickerRow(alloc, view, 3, row_count, 80);
+    var grok = try composeAuthPickerRow(alloc, view, 3, row_count, 80);
+    defer grok.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, grok.items, "Sign in with Grok") != null);
+
+    var setup = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
     defer setup.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, setup.items, "API key") != null);
 
-    var change_team = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
+    var change_team = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
     defer change_team.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, change_team.items, "Change team") != null);
     try std.testing.expect(std.mem.find(u8, change_team.items, "sign in first") != null);
 
-    var switch_credential = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
+    var switch_credential = try composeAuthPickerRow(alloc, view, 6, row_count, 80);
     defer switch_credential.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, switch_credential.items, "Switch credential") != null);
 }

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -630,6 +630,89 @@ function startAcpFakeCodex(options: {
   };
 }
 
+function writeSeededAcpGrokLogin(home: string, accessToken: string): void {
+  const fxDir = join(home, ".fx");
+  mkdirSync(fxDir, { recursive: true, mode: 0o700 });
+  chmodSync(fxDir, 0o700);
+  const authPath = join(fxDir, "grok-auth.json");
+  writeFileSync(authPath, JSON.stringify({
+    version: 1,
+    access_token: accessToken,
+    refresh_token: "grok-refresh",
+    expires_at_ms: Date.now() + 60 * 60 * 1000,
+    account_id: "acct_grok_acp",
+  }) + "\n", { mode: 0o600 });
+  chmodSync(authPath, 0o600);
+}
+
+function startAcpFakeGrok(options: {
+  unauthorizedResponses?: number;
+  route?: (body: string) => string | Promise<string>;
+} = {}) {
+  const accessToken = "grok-acp-stale";
+  const refreshedAccessToken = "grok-acp-fresh";
+  const requests: Array<{ path: string; authorization: string | null; body: string; conversationId: string | null }> = [];
+  const modelRequests: Array<{ path: string; authorization: string | null }> = [];
+  const tokenRequests: Array<{ path: string; authorization: string | null; body: string }> = [];
+  const userinfoRequests: Array<{ path: string; authorization: string | null }> = [];
+  let unauthorizedResponses = options.unauthorizedResponses ?? 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const path = new URL(request.url).pathname;
+      const authorization = request.headers.get("authorization");
+      if (path === "/models") {
+        modelRequests.push({ path, authorization });
+        return Response.json({ models: [
+          { id: "grok-4.20", object: "model", input_modalities: ["text", "image"], output_modalities: ["text"] },
+        ] });
+      }
+      if (path === "/token") {
+        const body = await request.text();
+        tokenRequests.push({ path, authorization, body });
+        return Response.json({
+          access_token: refreshedAccessToken,
+          refresh_token: "grok-refresh-next",
+          expires_in: 3600,
+        });
+      }
+      if (path === "/userinfo") {
+        userinfoRequests.push({ path, authorization });
+        return Response.json({ sub: "acct_grok_acp" });
+      }
+      const body = await request.text();
+      requests.push({
+        path,
+        authorization,
+        body,
+        conversationId: request.headers.get("x-grok-conv-id"),
+      });
+      if (unauthorizedResponses > 0) {
+        unauthorizedResponses -= 1;
+        return Response.json({ error: { message: "expired" } }, { status: 401 });
+      }
+      return new Response(options.route ? await options.route(body) : codexFinalText("ACP_GROK_RESPONSE"), {
+        headers: { "content-type": "text/event-stream" },
+      });
+    },
+  });
+  const base = `http://127.0.0.1:${server.port}`;
+  return {
+    accessToken,
+    refreshedAccessToken,
+    requests,
+    modelRequests,
+    tokenRequests,
+    userinfoRequests,
+    responsesUrl: `${base}/responses`,
+    modelsUrl: `${base}/models`,
+    tokenUrl: `${base}/token`,
+    userinfoUrl: `${base}/userinfo`,
+    stop() { server.stop(true); },
+  };
+}
+
 class AcpReadTimeoutError extends Error {
   constructor() {
     super("ACP readLine timeout");
@@ -7070,6 +7153,111 @@ describe("acp: model-independent", () => {
   );
 
   test(
+    "ACP persistent Grok children retain their provider across messages",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-grok-subagent-");
+      const gateway = startFakeGateway([]);
+      const childFirstPrompt = "GROK_CHILD_FIRST_TURN";
+      const childSecondPrompt = "GROK_CHILD_SECOND_TURN";
+      let childId = "";
+      const grok = startAcpFakeGrok({
+        route(body) {
+          const toolResult = codexLatestToolResult(body);
+          if (toolResult?.callId === "grok_child_resume") {
+            return codexFinalText("GROK_PARENT_RESUMED_CHILD");
+          }
+          if (toolResult?.callId === "grok_child_message") {
+            if (!childId) throw new Error("Grok child id was not captured");
+            return codexToolCall("grok_child_resume", "subagent", {
+              command: { lifecycle: { id: childId, action: "resume" } },
+            });
+          }
+          if (toolResult?.callId === "grok_child_create") {
+            const created = JSON.parse(toolResult.output) as { child_id: string; status: string };
+            expect(created.status).toBe("created");
+            childId = created.child_id;
+            return codexFinalText("GROK_PARENT_CREATED_CHILD");
+          }
+          if (body.includes("Send the persistent Grok child another message.")) {
+            if (!childId) throw new Error("Grok child id was not captured");
+            return codexToolCall("grok_child_message", "subagent", {
+              command: { message: { send: { id: childId, content: childSecondPrompt } } },
+            });
+          }
+          if (body.includes(childSecondPrompt)) return codexFinalText("GROK_CHILD_SECOND_DONE");
+          if (body.includes(childFirstPrompt)) return codexFinalText("GROK_CHILD_FIRST_DONE");
+          return codexToolCall("grok_child_create", "subagent", {
+            command: { create: {
+              name: "grok-persistent-child",
+              mode: "persistent",
+              prompt: childFirstPrompt,
+            } },
+          });
+        },
+      });
+      writeSeededAcpGrokLogin(root.home, grok.accessToken);
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            ...fakeGatewayEnv(root, gateway),
+            FX_E2E_XAI_GROK_RESPONSES_URL: grok.responsesUrl,
+            FX_E2E_XAI_GROK_MODELS_URL: grok.modelsUrl,
+          },
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+        await client.request("session/new", { mcpServers: [] }, 2);
+        await client.readLine();
+        await client.request("session/set_mode", { modeId: "code" }, 3);
+        const changed = await client.request("session/set_config_option", {
+          configId: "provider",
+          value: "grok",
+        }, 4) as any;
+        expect(changed.result.configOptions.find((option: any) => option.id === "provider").currentValue)
+          .toBe("grok");
+
+        const first = await runPrompt(client, "Create a persistent Grok child.", TIMEOUT);
+        expect(first.promptResult.result.stopReason).toBe("end_turn");
+        await waitForCondition(
+          "first Grok child turn",
+          () => childId.length > 0 && grok.requests.some((request) => request.body.includes(childFirstPrompt)),
+          TIMEOUT,
+        );
+        await waitForCondition("first Grok child idle state", () => acpSubagentState(root, childId) === "idle", TIMEOUT);
+        const childState = JSON.parse(
+          readFileSync(join(root.home, ".fx", "sessions", childId, "session.json"), "utf8"),
+        ) as { preferences: { provider: string; model: string } };
+        expect(childState.preferences.provider).toBe("grok");
+        expect(childState.preferences.model).toBe("grok-4.20");
+
+        const second = await runPrompt(client, "Send the persistent Grok child another message.", TIMEOUT);
+        expect(second.promptResult.result.stopReason).toBe("end_turn");
+        await waitForCondition(
+          "second Grok child turn",
+          () => grok.requests.some((request) => request.body.includes(childSecondPrompt)),
+          TIMEOUT,
+        );
+        await waitForCondition("second Grok child idle state", () => acpSubagentState(root, childId) === "idle", TIMEOUT);
+        expect(grok.requests.length).toBeGreaterThanOrEqual(7);
+        for (const request of grok.requests) {
+          expect(request.authorization).toBe(`Bearer ${grok.accessToken}`);
+          expect(JSON.parse(request.body).model).toBe("grok-4.20");
+        }
+        for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+          expect(request.headers.get("authorization")).not.toContain("grok-acp-");
+        }
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        grok.stop();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "stdin shutdown cancels a pending permission request",
     async () => {
       const root = createIsolatedRoot("fx-acp-permission-shutdown-");
@@ -7476,6 +7664,68 @@ describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {
       } finally {
         await client?.close();
         codex.stop();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "session provider changes use Grok credentials with byte-identical account-stable replay",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-grok-route-");
+      const gateway = startFakeGateway([]);
+      const grok = startAcpFakeGrok({ unauthorizedResponses: 1 });
+      writeSeededAcpGrokLogin(root.home, grok.accessToken);
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            ...fakeGatewayEnv(root, gateway),
+            FX_E2E_XAI_GROK_RESPONSES_URL: grok.responsesUrl,
+            FX_E2E_XAI_GROK_MODELS_URL: grok.modelsUrl,
+            FX_E2E_GROK_TOKEN_URL: grok.tokenUrl,
+            FX_E2E_GROK_USERINFO_URL: grok.userinfoUrl,
+          },
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+        await client.request("session/new", { mcpServers: [] }, 2);
+        await client.readLine();
+
+        const changed = await client.request("session/set_config_option", {
+          configId: "provider",
+          value: "grok",
+        }, 3) as any;
+        expect(changed.result.configOptions.find((option: any) => option.id === "provider").currentValue)
+          .toBe("grok");
+        expect(changed.result.configOptions.find((option: any) => option.id === "model").currentValue)
+          .toBe("grok-4.20");
+
+        const prompt = await runPrompt(client, "Answer directly.", TIMEOUT);
+        expect(prompt.promptResult.result.stopReason).toBe("end_turn");
+        expect(JSON.stringify(prompt.messages)).toContain("ACP_GROK_RESPONSE");
+        const secondPrompt = await runPrompt(client, "Answer again.", TIMEOUT);
+        expect(secondPrompt.promptResult.result.stopReason).toBe("end_turn");
+
+        expect(grok.requests).toHaveLength(3);
+        expect(grok.requests[0]!.body).toBe(grok.requests[1]!.body);
+        expect(grok.requests[0]!.conversationId).toBeTruthy();
+        expect(grok.requests[0]!.conversationId).toBe(grok.requests[1]!.conversationId);
+        expect(grok.modelRequests).toHaveLength(1);
+        expect(grok.requests[0]!.authorization).toBe(`Bearer ${grok.accessToken}`);
+        expect(grok.requests[1]!.authorization).toBe(`Bearer ${grok.refreshedAccessToken}`);
+        expect(grok.requests[2]!.authorization).toBe(`Bearer ${grok.refreshedAccessToken}`);
+        expect(grok.tokenRequests).toHaveLength(1);
+        expect(grok.tokenRequests[0]!.body).toContain("grant_type=refresh_token");
+        expect(grok.userinfoRequests).toHaveLength(1);
+        expect(grok.userinfoRequests[0]!.authorization).toBe(`Bearer ${grok.refreshedAccessToken}`);
+        for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+          expect(request.headers.get("authorization")).not.toContain("grok-acp-");
+        }
+      } finally {
+        await client?.close();
+        grok.stop();
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });
       }

--- a/tests/e2e/render-lab/audit-direct-writes.ts
+++ b/tests/e2e/render-lab/audit-direct-writes.ts
@@ -75,6 +75,7 @@ const allowlist: AllowRule[] = [
   rule("src/core/auth/login_flow.zig", "(?:canUseInteractiveTeamPicker|enable)", /fixed_descriptor/, "terminal_probe", "auth login team-picker TTY probe"),
   rule("src/core/auth/login_flow.zig", "writeStdout", /stdio_acquisition_write/, "noninteractive_output", "CLI auth login output"),
   rule("src/core/auth/chatgpt_oauth.zig", "writeStdout", /stdio_acquisition_write/, "noninteractive_output", "Codex CLI login output"),
+  rule("src/core/auth/grok_oauth.zig", "writeStdout", /stdio_acquisition_write/, "noninteractive_output", "Grok CLI login output"),
   rule("src/core/shared/debug_trace.zig", "(?:writeLine|writeNoninteractiveStderr)", /debug_print/, "noninteractive_output", "opt-in tracing"),
   rule("tests/json-schema/corpus_runner.zig", "printLine", /stdio_acquisition/, "noninteractive_output", "JSON Schema corpus report output"),
   rule("src/main.zig", "(?:writeStdoutFast|writeStderrFast)", /(?:stdio_acquisition_write|fixed_fd_write|raw_fd_write)/, "noninteractive_output", "top-level help and CLI validation output"),

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -83,6 +83,21 @@ function writeSeededChatGptLogin(testHome: string, accessToken = chatgptAccessTo
   chmodSync(authPath, 0o600);
 }
 
+function writeSeededGrokLogin(testHome: string, accessToken: string, accountId = "acct_grok_e2e"): void {
+  const fxDir = join(testHome, ".fx");
+  mkdirSync(fxDir, { recursive: true, mode: 0o700 });
+  chmodSync(fxDir, 0o700);
+  const authPath = join(fxDir, "grok-auth.json");
+  writeFileSync(authPath, JSON.stringify({
+    version: 1,
+    access_token: accessToken,
+    refresh_token: "grok-refresh",
+    expires_at_ms: Date.now() + 60 * 60 * 1000,
+    account_id: accountId,
+  }) + "\n", { mode: 0o600 });
+  chmodSync(authPath, 0o600);
+}
+
 function writeSeededFxLogin(
   testHome: string,
   expiresAtMs = Date.now() + 60 * 60 * 1000,
@@ -414,6 +429,171 @@ function startFakeChatGptOAuth(
   };
 }
 
+function startFakeGrokOAuth(options: {
+  unauthorizedResponses?: number;
+  revokeStatus?: number;
+  userinfoSub?: string;
+} = {}) {
+  const initialAccessToken = "grok-initial-access-token";
+  const refreshedAccessToken = "grok-refreshed-access-token";
+  const requests: Array<{
+    method: string;
+    path: string;
+    authorization: string | null;
+    body: string | null;
+    conversationId: string | null;
+    query: string;
+  }> = [];
+  let tokenCalls = 0;
+  let responseCalls = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const body = request.method === "POST" ? await request.text() : null;
+      requests.push({
+        method: request.method,
+        path: url.pathname,
+        authorization: request.headers.get("authorization"),
+        body,
+        conversationId: request.headers.get("x-grok-conv-id"),
+        query: url.search,
+      });
+      if (url.pathname === "/oauth2/authorize") {
+        const redirectUri = url.searchParams.get("redirect_uri");
+        const state = url.searchParams.get("state");
+        if (!redirectUri || !state || url.searchParams.get("nonce")) {
+          return new Response("invalid authorize request", { status: 400 });
+        }
+        if (url.searchParams.get("referrer") !== "fx") {
+          return new Response("missing fx referrer", { status: 400 });
+        }
+        const callback = new URL(redirectUri);
+        callback.searchParams.set("code", "grok-code");
+        callback.searchParams.set("state", state);
+        return Response.redirect(callback.toString(), 302);
+      }
+      if (url.pathname === "/oauth2/token") {
+        tokenCalls += 1;
+        const form = new URLSearchParams(body ?? "");
+        const refresh = form.get("grant_type") === "refresh_token";
+        return Response.json({
+          access_token: refresh ? refreshedAccessToken : initialAccessToken,
+          refresh_token: refresh ? "grok-refresh-next" : "grok-refresh",
+          expires_in: 3600,
+        });
+      }
+      if (url.pathname === "/oauth2/userinfo") {
+        if (!request.headers.get("authorization")?.startsWith("Bearer grok-")) {
+          return Response.json({ error: "unauthorized" }, { status: 401 });
+        }
+        return Response.json({ sub: options.userinfoSub ?? "acct_grok_e2e" });
+      }
+      if (url.pathname === "/oauth2/revoke") {
+        const form = new URLSearchParams(body ?? "");
+        const valid = form.get("client_id") === "b1a00492-073a-47ea-816f-4c329264a828" &&
+          (form.get("token") === "grok-refresh-next" || form.get("token") === "grok-refresh");
+        if (valid && options.revokeStatus && options.revokeStatus !== 200) {
+          return Response.json({ error: "revocation unavailable" }, { status: options.revokeStatus });
+        }
+        return Response.json(valid ? { revoked: true } : { error: "invalid" }, {
+          status: valid ? 200 : 400,
+        });
+      }
+      if (url.pathname === "/v1/language-models") {
+        return Response.json({ models: [
+          { id: "grok-4.20", object: "model", input_modalities: ["text", "image"], output_modalities: ["text"] },
+          { id: "grok-4.6", object: "model", input_modalities: ["text", "image"], output_modalities: ["text"] },
+          { id: "grok-image-only", object: "model", input_modalities: ["text"], output_modalities: ["image"] },
+        ] });
+      }
+      if (url.pathname === "/v1/responses") {
+        responseCalls += 1;
+        if (responseCalls <= (options.unauthorizedResponses ?? 0)) {
+          return Response.json({ error: { message: "expired" } }, { status: 401 });
+        }
+        return new Response(
+          'data: {"type":"response.output_text.delta","delta":"GROK_DIRECT_RESPONSE"}\n\n' +
+            'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":4,"output_tokens":2}}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const baseUrl = `http://127.0.0.1:${server.port}`;
+  return {
+    initialAccessToken,
+    refreshedAccessToken,
+    requests,
+    tokenCalls: () => tokenCalls,
+    baseUrl,
+    env: {
+      FX_E2E_GROK_ISSUER_URL: baseUrl,
+      FX_E2E_GROK_TOKEN_URL: `${baseUrl}/oauth2/token`,
+      FX_E2E_GROK_USERINFO_URL: `${baseUrl}/oauth2/userinfo`,
+      FX_E2E_GROK_REVOKE_URL: `${baseUrl}/oauth2/revoke`,
+      FX_E2E_XAI_GROK_MODELS_URL: `${baseUrl}/v1/language-models`,
+      FX_E2E_XAI_GROK_RESPONSES_URL: `${baseUrl}/v1/responses`,
+    },
+    stop() { server.stop(true); },
+  };
+}
+
+async function runGrokLoginWithBrowser(env: Record<string, string | undefined>) {
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete childEnv[key];
+    else childEnv[key] = value;
+  }
+  const proc = nodeSpawn(FX_BIN, ["login", "grok"], {
+    cwd: REPO_ROOT,
+    env: childEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  proc.stdout!.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+  proc.stderr!.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+  const deadline = Date.now() + TIMEOUT;
+  let authorizationUrl: string | undefined;
+  while (Date.now() < deadline) {
+    authorizationUrl = stdout.match(/http:\/\/127\.0\.0\.1:\d+\/oauth2\/authorize\?\S+/)?.[0];
+    if (authorizationUrl) break;
+    await Bun.sleep(20);
+  }
+  if (!authorizationUrl) {
+    proc.kill("SIGTERM");
+    throw new Error(`Grok login did not print an authorization URL: ${stdout}\n${stderr}`);
+  }
+  const response = await fetch(authorizationUrl, { redirect: "follow" });
+  expect(response.status).toBe(200);
+  const code = await new Promise<number>((resolve, reject) => {
+    proc.once("error", reject);
+    proc.once("close", (value) => resolve(value ?? 1));
+  });
+  return { code, stdout, stderr };
+}
+
+async function completeDisplayedGrokLogin(
+  activeSession: TmuxSession,
+  fixture: ReturnType<typeof startFakeGrokOAuth>,
+) {
+  await activeSession.resizeWindow(500, 20);
+  const pane = await activeSession.waitForPane(
+    (value) => value.includes(`${fixture.baseUrl}/oauth2/authorize?`),
+    TIMEOUT,
+  );
+  const authorizationUrl = pane
+    .split(/\s+/)
+    .find((value) => value.startsWith(`${fixture.baseUrl}/oauth2/authorize?`));
+  if (!authorizationUrl) throw new Error("Grok authorization URL was not rendered");
+  const response = await fetch(authorizationUrl, { redirect: "follow" });
+  expect(response.status).toBe(200);
+  await activeSession.resizeWindow(100, 30);
+}
+
 async function completeDisplayedCodexLogin(
   activeSession: TmuxSession,
   fixture: ReturnType<typeof startFakeChatGptOAuth>,
@@ -516,6 +696,52 @@ function startFakeCodexToolLoop(options: {
   };
 }
 
+function startFakeGrokToolLoop(options: {
+  toolName?: string;
+  toolArguments?: object;
+  finalText?: string;
+} = {}) {
+  const bodies: string[] = [];
+  const accessToken = "grok-tool-loop-token";
+  const toolName = options.toolName ?? "read_file";
+  const toolArguments = options.toolArguments ?? { path: "README.md" };
+  const finalText = options.finalText ?? "GROK_TOOL_LOOP_OK";
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      if (new URL(request.url).pathname === "/models") {
+        return Response.json({ models: [
+          { id: "grok-4.20", object: "model", input_modalities: ["text", "image"], output_modalities: ["text"] },
+        ] });
+      }
+      bodies.push(await request.text());
+      if (bodies.length === 1) {
+        return new Response(
+          'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}\n\n' +
+            'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_tool","type":"reasoning","summary":[],"encrypted_content":"opaque-grok-tool-loop"}}\n\n' +
+            `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 1, item: { type: "function_call", call_id: "call_tool", name: toolName } })}\n\n` +
+            `data: ${JSON.stringify({ type: "response.function_call_arguments.done", output_index: 1, arguments: JSON.stringify(toolArguments) })}\n\n` +
+            'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(
+        `data: ${JSON.stringify({ type: "response.output_text.delta", delta: finalText })}\n\n` +
+          'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":7,"output_tokens":3}}}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  });
+  return {
+    accessToken,
+    bodies,
+    responsesUrl: `http://127.0.0.1:${server.port}/responses`,
+    modelsUrl: `http://127.0.0.1:${server.port}/models`,
+    stop() { server.stop(true); },
+  };
+}
+
 function startFakeCodexAutoReview() {
   const bodies: string[] = [];
   const accessToken = chatgptAccessToken("acct_auto_review");
@@ -553,6 +779,55 @@ function startFakeCodexAutoReview() {
       }
       return new Response(
         'data: {"type":"response.output_text.delta","delta":"CODEX_AUTO_REVIEW_OK"}\n\n' +
+          'data: {"type":"response.completed","response":{"id":"gen_main_2","status":"completed","usage":{"input_tokens":7,"output_tokens":3}}}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  });
+  return {
+    accessToken,
+    bodies,
+    responsesUrl: `http://127.0.0.1:${server.port}/responses`,
+    modelsUrl: `http://127.0.0.1:${server.port}/models`,
+    stop() { server.stop(true); },
+  };
+}
+
+function startFakeGrokAutoReview() {
+  const bodies: string[] = [];
+  const accessToken = "grok-auto-review-token";
+  let mainRequests = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const path = new URL(request.url).pathname;
+      if (path === "/models") {
+        return Response.json({ models: [
+          { id: "grok-4.20", object: "model", input_modalities: ["text"], output_modalities: ["text"] },
+        ] });
+      }
+      const body = await request.text();
+      bodies.push(body);
+      if (body.includes('"name":"permission_decision"')) {
+        return new Response(
+          'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_permission","name":"permission_decision"}}\n\n' +
+            'data: {"type":"response.function_call_arguments.done","output_index":0,"arguments":"{\\"risk\\":\\"low\\",\\"authorization\\":\\"high\\",\\"decision\\":\\"allow\\",\\"rationale\\":\\"The user requested this harmless command.\\"}"}\n\n' +
+            'data: {"type":"response.completed","response":{"id":"gen_review","status":"completed","usage":{"input_tokens":8,"output_tokens":3}}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      mainRequests += 1;
+      if (mainRequests === 1) {
+        return new Response(
+          'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_terminal","name":"terminal"}}\n\n' +
+            'data: {"type":"response.function_call_arguments.done","output_index":0,"arguments":"{\\"action\\":\\"exec\\",\\"command\\":\\"pwd\\"}"}\n\n' +
+            'data: {"type":"response.completed","response":{"id":"gen_main_1","status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}\n\n',
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(
+        'data: {"type":"response.output_text.delta","delta":"GROK_AUTO_REVIEW_OK"}\n\n' +
           'data: {"type":"response.completed","response":{"id":"gen_main_2","status":"completed","usage":{"input_tokens":7,"output_tokens":3}}}\n\n',
         { headers: { "content-type": "text/event-stream" } },
       );
@@ -857,15 +1132,16 @@ tmuxTest(
 
     session = await startFx(home, stderrPath, gateway, oauth.issuerUrl);
     await session.waitForComposer(TIMEOUT);
+    await session.resizeWindow(100, 36);
     await session.sendText("/setup");
     const root = await session.waitForPane(
       (pane) =>
         pane.includes("Setup") &&
         pane.includes("Sign in with Vercel") &&
         pane.includes("Sign in with Codex") &&
+        pane.includes("Sign in with Grok") &&
         pane.includes("API key") &&
-        pane.includes("Change team") &&
-        pane.includes("Switch credential"),
+        pane.includes("Change team"),
       TIMEOUT,
     );
     expect(root).not.toContain("AI_GATEWAY_API_KEY");
@@ -874,8 +1150,9 @@ tmuxTest(
     await session.sendKeys("Enter");
     await session.waitForText("Enter reopens browser · Esc cancels", TIMEOUT);
     await session.sendKeys("Escape");
-    await session.waitForText("Switch credential", TIMEOUT);
+    await session.waitForText("Sign in with Grok", TIMEOUT);
 
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
@@ -958,7 +1235,7 @@ async function waitForTrace(tracePath: string, needle: string): Promise<void> {
 }
 
 async function enterSwitchCredential(pickerSession: TmuxSession): Promise<void> {
-  for (let index = 0; index < 4; index += 1) {
+  for (let index = 0; index < 5; index += 1) {
     await pickerSession.sendKeys("Down");
   }
   await pickerSession.sendKeys("Enter");
@@ -967,7 +1244,7 @@ async function enterSwitchCredential(pickerSession: TmuxSession): Promise<void> 
 
 async function openSwitchCredential(pickerSession: TmuxSession): Promise<void> {
   await pickerSession.sendText("/setup");
-  await pickerSession.waitForText("Switch credential", TIMEOUT);
+  await pickerSession.waitForText("Sign in with Grok", TIMEOUT);
   await enterSwitchCredential(pickerSession);
 }
 
@@ -995,6 +1272,7 @@ profileStoredKeyTmuxTest(
 
     await session.sendText("/setup");
     await session.waitForText("API key", TIMEOUT);
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
@@ -1117,6 +1395,7 @@ tmuxTest(
 
     await session.sendText("/setup");
     await session.waitForText("Change team", TIMEOUT);
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
@@ -1604,6 +1883,293 @@ test(
 );
 
 test(
+  "Grok CLI browser login fetches subscription models and replays one account-stable 401",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-grok-cli-login-"));
+    gateway = startFakeGateway([]);
+    const grok = startFakeGrokOAuth({ unauthorizedResponses: 1 });
+    try {
+      const env = {
+        HOME: home,
+        AI_GATEWAY_API_KEY: ENV_TOKEN,
+        VERCEL_OIDC_TOKEN: undefined,
+        FX_DISABLE_KEYCHAIN: "1",
+        FX_SKIP_ONBOARDING: "1",
+        FX_AUTO_UPGRADE: "0",
+        FX_NO_OPEN_BROWSER: "1",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl,
+        FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+        ...grok.env,
+      };
+
+      const login = await runGrokLoginWithBrowser(env);
+      expect(login.code, `stdout: ${login.stdout}\nstderr: ${login.stderr}`).toBe(0);
+      expect(login.stdout).toContain("Signed in with Grok.");
+      expect(login.stderr).toBe("");
+
+      const authPath = join(home, ".fx", "grok-auth.json");
+      expect(existsSync(authPath)).toBe(true);
+      expect(statSync(authPath).mode & 0o077).toBe(0);
+
+      const selected = await runFx(["provider", "grok"], { env, timeoutMs: TIMEOUT });
+      expect(selected.code, `stdout: ${selected.stdout}\nstderr: ${selected.stderr}`).toBe(0);
+      expect(selected.stdout).toContain("Provider set to Grok.");
+
+      const models = await runFx(["models", "--json"], { env, timeoutMs: TIMEOUT });
+      const modelIds = (JSON.parse(models.stdout) as { models: Array<{ id: string }> }).models
+        .map((model) => model.id);
+      expect(modelIds).toEqual(["grok-4.20", "grok-4.6"]);
+
+      const ask = await runFx(["ask", "--json", "--auto", "Answer directly."], {
+        env,
+        timeoutMs: TIMEOUT,
+      });
+      expect(ask.code, `stdout: ${ask.stdout}\nstderr: ${ask.stderr}`).toBe(0);
+      expect(ask.stdout).toContain("GROK_DIRECT_RESPONSE");
+      const responses = grok.requests.filter((request) => request.path === "/v1/responses");
+      expect(responses).toHaveLength(2);
+      expect(responses[0]!.body).toBe(responses[1]!.body);
+      expect(responses[0]!.conversationId).toBeTruthy();
+      expect(responses[0]!.conversationId).toBe(responses[1]!.conversationId);
+      expect(responses[0]!.authorization).toBe(`Bearer ${grok.initialAccessToken}`);
+      expect(responses[1]!.authorization).toBe(`Bearer ${grok.refreshedAccessToken}`);
+      expect(grok.tokenCalls()).toBe(2);
+      const userinfo = grok.requests.filter((request) => request.path === "/oauth2/userinfo");
+      expect(userinfo).toHaveLength(2);
+      for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+        expect(request.headers.get("authorization")).not.toContain("grok-");
+      }
+
+      expect((await runFx(["provider", "gateway"], { env, timeoutMs: TIMEOUT })).code).toBe(0);
+      expect((await runFx(["provider", "grok"], { env, timeoutMs: TIMEOUT })).code).toBe(0);
+      expect(grok.tokenCalls()).toBe(2);
+
+      const logout = await runFx(["logout", "grok"], { env, timeoutMs: TIMEOUT });
+      expect(logout.code, `stdout: ${logout.stdout}\nstderr: ${logout.stderr}`).toBe(0);
+      expect(logout.stdout).toContain("Signed out of Grok.");
+      expect(grok.requests.some((request) => request.path === "/oauth2/revoke")).toBe(true);
+      expect(existsSync(authPath)).toBe(false);
+    } finally {
+      grok.stop();
+    }
+  },
+  60_000,
+);
+
+test("Grok logout removes local credentials when remote revocation fails", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-grok-logout-revoke-failure-"));
+  const grok = startFakeGrokOAuth({ revokeStatus: 503 });
+  try {
+    writeSeededGrokLogin(home, grok.initialAccessToken);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+      { mode: 0o600 },
+    );
+    const authPath = join(home, ".fx", "grok-auth.json");
+    const result = await runFx(["logout", "grok"], {
+      env: {
+        HOME: home,
+        FX_DISABLE_KEYCHAIN: "1",
+        FX_AUTO_UPGRADE: "0",
+        FX_E2E_GROK_REVOKE_URL: grok.env.FX_E2E_GROK_REVOKE_URL,
+      },
+      timeoutMs: TIMEOUT,
+    });
+    expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("Signed out of Grok.");
+    expect(result.stderr).toContain("remote revocation could not be confirmed");
+    expect(existsSync(authPath)).toBe(false);
+    expect(JSON.parse(readFileSync(join(home, ".fx", "settings.json"), "utf8")).provider)
+      .toBe("grok");
+    const ask = await runFx(["ask", "--json", "--no-save", "Still Grok?"], {
+      env: { HOME: home, FX_DISABLE_KEYCHAIN: "1", FX_AUTO_UPGRADE: "0" },
+      timeoutMs: TIMEOUT,
+    });
+    expect(ask.code).toBe(1);
+    expect(ask.stderr).toContain("fx login grok");
+  } finally {
+    grok.stop();
+  }
+});
+
+test("Grok 401 replay refuses a different account before the second provider send", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-grok-account-mismatch-"));
+  gateway = startFakeGateway([]);
+  const grok = startFakeGrokOAuth({ unauthorizedResponses: 1, userinfoSub: "acct_other" });
+  try {
+    writeSeededGrokLogin(home, grok.initialAccessToken);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+      { mode: 0o600 },
+    );
+    const env = {
+      HOME: home,
+      AI_GATEWAY_API_KEY: ENV_TOKEN,
+      VERCEL_OIDC_TOKEN: undefined,
+      FX_DISABLE_KEYCHAIN: "1",
+      FX_AUTO_UPGRADE: "0",
+      FX_GATEWAY_BASE_URL: gateway.baseUrl,
+      FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+      ...grok.env,
+    };
+    const ask = await runFx(["ask", "--json", "--auto", "--no-save", "Answer."], {
+      env,
+      timeoutMs: TIMEOUT,
+    });
+    expect(ask.code).toBe(1);
+    expect(grok.requests.filter((request) => request.path === "/v1/responses")).toHaveLength(1);
+    const saved = JSON.parse(readFileSync(join(home, ".fx", "grok-auth.json"), "utf8")) as {
+      access_token: string;
+      account_id: string;
+    };
+    expect(saved.access_token).toBe(grok.initialAccessToken);
+    expect(saved.account_id).toBe("acct_grok_e2e");
+    for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+      expect(request.headers.get("authorization")).not.toContain("grok-");
+    }
+  } finally {
+    grok.stop();
+  }
+});
+
+test("Grok CLI sends verified images directly without advertising the vision fallback", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-grok-native-image-"));
+  gateway = startFakeGateway([]);
+  const grok = startFakeGrokOAuth();
+  try {
+    writeSeededGrokLogin(home, grok.initialAccessToken);
+    writeFileSync(
+      join(home, ".fx", "settings.json"),
+      JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+      { mode: 0o600 },
+    );
+    const imagePath = join(home, "attachment.png");
+    writeFileSync(imagePath, Buffer.from("89504e470d0a1a0a72657374", "hex"));
+    const ask = await runFx([
+      "ask",
+      "--json",
+      "--auto",
+      "--no-save",
+      "--image",
+      imagePath,
+      "Describe the image.",
+    ], {
+      env: {
+        HOME: home,
+        AI_GATEWAY_API_KEY: ENV_TOKEN,
+        VERCEL_OIDC_TOKEN: undefined,
+        FX_DISABLE_KEYCHAIN: "1",
+        FX_AUTO_UPGRADE: "0",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl,
+        FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+        ...grok.env,
+      },
+      timeoutMs: TIMEOUT,
+    });
+    expect(ask.code, `stdout: ${ask.stdout}\nstderr: ${ask.stderr}`).toBe(0);
+    const responses = grok.requests.filter((request) => request.path === "/v1/responses");
+    expect(responses).toHaveLength(1);
+    expect(responses[0]!.body).toContain('"type":"input_image"');
+    expect(responses[0]!.body).not.toContain('"name":"vision"');
+    expect(gateway.requests).toHaveLength(0);
+  } finally {
+    grok.stop();
+  }
+});
+
+tmuxTest(
+  "interactive provider switch completes Grok OAuth and round-trips without reauthentication",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-grok-tui-switch-"));
+    stderrPath = join(home, "stderr.log");
+    gateway = startFakeGateway([fakeGatewayFinalText("GATEWAY_AFTER_GROK")]);
+    const grok = startFakeGrokOAuth();
+    try {
+      session = await startFx(home, stderrPath, gateway, undefined, undefined, {
+        FX_MODEL: undefined,
+        ...grok.env,
+      });
+      await session.waitForText("auto ·", TIMEOUT);
+
+      await session.sendText("/provider grok");
+      await completeDisplayedGrokLogin(session, grok);
+      await session.waitForText("Switched to Grok subscription with grok-4.20.", TIMEOUT);
+      await session.sendText("Answer from Grok.");
+      await session.waitForText("GROK_DIRECT_RESPONSE", TIMEOUT);
+
+      const tokenCallsAfterLogin = grok.tokenCalls();
+      await session.sendText("/provider gateway");
+      await session.waitForText("Switched to Vercel AI Gateway", TIMEOUT);
+      await session.sendText("/provider grok");
+      await session.waitForText("Switched to Grok subscription with grok-4.20.", TIMEOUT);
+      expect(grok.tokenCalls()).toBe(tokenCallsAfterLogin);
+
+      const saved = JSON.parse(readFileSync(join(home, ".fx", "settings.json"), "utf8")) as {
+        provider: string;
+        grok_model: string;
+      };
+      expect(saved.provider).toBe("grok");
+      expect(saved.grok_model).toBe("grok-4.20");
+      const responses = grok.requests.filter((request) => request.path === "/v1/responses");
+      expect(responses).toHaveLength(1);
+      expect(responses[0]!.conversationId).toBeTruthy();
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    } finally {
+      grok.stop();
+    }
+  },
+  60_000,
+);
+
+tmuxTest(
+  "Grok model selection accepts proven effort levels and sends the selected effort",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-grok-effort-selection-"));
+    stderrPath = join(home, "stderr.log");
+    gateway = startFakeGateway([]);
+    const grok = startFakeGrokOAuth();
+    try {
+      writeSeededGrokLogin(home, grok.initialAccessToken);
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+        { mode: 0o600 },
+      );
+      session = await startFx(home, stderrPath, gateway, undefined, undefined, {
+        FX_MODEL: undefined,
+        ...grok.env,
+      });
+      await session.waitForComposer(TIMEOUT);
+      const catalogDeadline = Date.now() + TIMEOUT;
+      while (!grok.requests.some((request) => request.path === "/v1/language-models")) {
+        if (Date.now() >= catalogDeadline) throw new Error("Grok catalog did not load");
+        await Bun.sleep(25);
+      }
+      await session.sendText("/model grok-4.6 xhigh");
+      await session.waitForText("Switched to grok-4.6", TIMEOUT);
+      await session.sendText("Use the selected effort.");
+      await session.waitForText("GROK_DIRECT_RESPONSE", TIMEOUT);
+
+      const response = grok.requests.find((request) => request.path === "/v1/responses");
+      expect(response).toBeDefined();
+      const body = JSON.parse(response!.body ?? "{}") as {
+        model?: string;
+        reasoning?: { effort?: string };
+      };
+      expect(body.model).toBe("grok-4.6");
+      expect(body.reasoning?.effort).toBe("xhigh");
+      expect(readFileSync(join(home, ".fx", "settings.json"), "utf8")).toContain('"effort":"xhigh"');
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    } finally {
+      grok.stop();
+    }
+  },
+  60_000,
+);
+
+test(
   "ChatGPT tool loops round-trip encrypted reasoning without Gateway leakage",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-chatgpt-tool-loop-"));
@@ -1643,6 +2209,51 @@ test(
       }
     } finally {
       codex.stop();
+    }
+  },
+  60_000,
+);
+
+test(
+  "Grok tool loops round-trip encrypted reasoning without Gateway leakage",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-grok-tool-loop-"));
+    gateway = startFakeGateway([]);
+    const grok = startFakeGrokToolLoop();
+    try {
+      writeSeededGrokLogin(home, grok.accessToken, "acct_tool_loop");
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+        { mode: 0o600 },
+      );
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Read the README, then finish."],
+        {
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: "gateway-grok-tool-loop-sentinel",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_AUTO_UPGRADE: "0",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+            FX_E2E_XAI_GROK_RESPONSES_URL: grok.responsesUrl,
+            FX_E2E_XAI_GROK_MODELS_URL: grok.modelsUrl,
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("GROK_TOOL_LOOP_OK");
+      expect(grok.bodies).toHaveLength(2);
+      expect(grok.bodies[1]).toContain('"encrypted_content":"opaque-grok-tool-loop"');
+      expect(grok.bodies[1]).toContain('"type":"function_call_output"');
+      for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+        expect(request.headers.get("authorization")).not.toContain("grok-tool-loop-token");
+      }
+    } finally {
+      grok.stop();
     }
   },
   60_000,
@@ -1705,6 +2316,57 @@ test(
 );
 
 test(
+  "Grok rejects the vision fallback because native image input owns OCR",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-grok-vision-disabled-"));
+    gateway = startFakeGateway([]);
+    const grok = startFakeGrokToolLoop({
+      toolName: "vision",
+      toolArguments: { image_ids: [1], focus: "Inspect the image." },
+      finalText: "GROK_VISION_DISABLED_OK",
+    });
+    try {
+      writeSeededGrokLogin(home, grok.accessToken, "acct_vision");
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+        { mode: 0o600 },
+      );
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Answer without a vision fallback."],
+        {
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: "gateway-grok-vision-sentinel",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_AUTO_UPGRADE: "0",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+            FX_E2E_XAI_GROK_RESPONSES_URL: grok.responsesUrl,
+            FX_E2E_XAI_GROK_MODELS_URL: grok.modelsUrl,
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("GROK_VISION_DISABLED_OK");
+      expect(grok.bodies).toHaveLength(2);
+      expect(grok.bodies[0]).not.toContain('"name":"vision"');
+      const continuation = JSON.parse(grok.bodies[1]) as {
+        input: Array<{ type?: string; output?: string }>;
+      };
+      const toolResult = continuation.input.find((item) => item.type === "function_call_output");
+      expect(toolResult?.output).toContain("Vision is unavailable for this request.");
+      expect(gateway.requests).toHaveLength(0);
+    } finally {
+      grok.stop();
+    }
+  },
+  60_000,
+);
+
+test(
   "Codex automatic review uses gpt-5.4-mini while Gateway review stays untouched",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-codex-auto-review-"));
@@ -1744,6 +2406,51 @@ test(
       }
     } finally {
       codex.stop();
+    }
+  },
+  60_000,
+);
+
+test(
+  "Grok automatic review reuses the admitted Grok model and never reaches Gateway",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-grok-auto-review-"));
+    gateway = startFakeGateway([]);
+    const grok = startFakeGrokAutoReview();
+    try {
+      writeSeededGrokLogin(home, grok.accessToken, "acct_auto_review");
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ provider: "grok", grok_model: "grok-4.20" }) + "\n",
+        { mode: 0o600 },
+      );
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Run pwd, then finish."],
+        {
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: "gateway-grok-auto-review-sentinel",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_AUTO_UPGRADE: "0",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+            FX_E2E_XAI_GROK_RESPONSES_URL: grok.responsesUrl,
+            FX_E2E_XAI_GROK_MODELS_URL: grok.modelsUrl,
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("GROK_AUTO_REVIEW_OK");
+      expect(grok.bodies.map((body) => (JSON.parse(body) as { model: string }).model))
+        .toEqual(["grok-4.20", "grok-4.20", "grok-4.20"]);
+      expect(grok.bodies[1]).toContain('"name":"permission_decision"');
+      for (const request of gateway.requests) {
+        expect(request.body).not.toContain("permission_decision");
+      }
+    } finally {
+      grok.stop();
     }
   },
   60_000,
@@ -2097,14 +2804,14 @@ tmuxTest(
       (pane) =>
         pane.includes("Setup") &&
         pane.includes("Sign in with Vercel") &&
-        pane.includes("API key") &&
-        pane.includes("Switch credential"),
+        pane.includes("Sign in with Grok") &&
+        pane.includes("API key"),
       TIMEOUT,
     );
     expect(inventory).not.toMatch(/^\s+fx login\s+/m);
     await session.sendKeys("Escape");
     await session.waitForPane(
-      (pane) => !pane.includes("Switch credential"),
+      (pane) => !pane.includes("   Setup"),
       TIMEOUT,
     );
 
@@ -2196,7 +2903,7 @@ tmuxTest(
         pane.includes("fx login credential refresh failed.") &&
         pane.includes("Choose another source below") &&
         pane.includes("Setup") &&
-        pane.includes("Switch credential"),
+        pane.includes("Sign in with Grok"),
       TIMEOUT,
     );
     expect(failed).toContain(`${promptHead}${promptTail}`);
@@ -2430,14 +3137,14 @@ tmuxTest(
       (pane) =>
         pane.includes(blockedPrompt) &&
         pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Switch credential"),
+        pane.includes("Sign in with Grok"),
       TIMEOUT,
     );
     expect(gateway.requests).toHaveLength(0);
 
     await session.sendKeys("Escape");
     await session.waitForPane(
-      (pane) => pane.includes(blockedPrompt) && !pane.includes("Switch credential"),
+      (pane) => pane.includes(blockedPrompt) && !pane.includes("   Setup"),
       TIMEOUT,
     );
     await session.sendKeys("C-u");
@@ -2502,7 +3209,7 @@ tmuxTest(
       (pane) =>
         pane.includes(firstPrompt) &&
         pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Switch credential"),
+        pane.includes("Sign in with Grok"),
       TIMEOUT,
     );
     expect(firstFailure).toContain("Choose another source below.");
@@ -2515,7 +3222,7 @@ tmuxTest(
 
     await session.sendKeys("Escape");
     await session.waitForPane(
-      (pane) => pane.includes(firstPrompt) && !pane.includes("Switch credential"),
+      (pane) => pane.includes(firstPrompt) && !pane.includes("   Setup"),
       TIMEOUT,
     );
     await session.sendKeys("C-u");
@@ -2537,7 +3244,7 @@ tmuxTest(
       (pane) =>
         pane.includes(secondPrompt) &&
         pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Switch credential"),
+        pane.includes("Sign in with Grok"),
       TIMEOUT,
     );
     expect(gateway.requests).toHaveLength(0);

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -367,7 +367,7 @@ describe.skipIf(SKIP_TMUX)("tui: MCP startup", () => {
 
 describe.skipIf(SKIP_TMUX)("tui: credential onboarding", () => {
   test(
-    "/setup opens the four-action setup hub without source rows",
+    "/setup opens the provider-aware setup hub without source rows",
     async () => {
       const home = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-direct-setup-")));
       session = await TmuxSession.create({
@@ -387,9 +387,10 @@ describe.skipIf(SKIP_TMUX)("tui: credential onboarding", () => {
         (pane) =>
           pane.includes("Setup") &&
           pane.includes("Sign in with Vercel") &&
+          pane.includes("Sign in with Codex") &&
+          pane.includes("Sign in with Grok") &&
           pane.includes("API key") &&
-          pane.includes("Change team") &&
-          pane.includes("Switch credential"),
+          pane.includes("Change team"),
         TIMEOUT,
       );
       expect(setup).not.toContain("AI_GATEWAY_API_KEY");


### PR DESCRIPTION
## Summary

- Sign in with eligible Grok subscriptions through browser OAuth and keep Grok credentials separate from Gateway and Codex.
- Switch to Grok in interactive fx, `fx ask`, and native ACP with provider-scoped models and persistent sessions.
- Load models from the authenticated xAI catalog and run direct Responses requests with local tools, native images, usage, and provider-owned automatic review.
- Expose the effort levels published for `grok-4.6` and `grok-4.5` through `/model`.
- Refresh and replay one clean 401 for the admitted account, and remove the local session even when remote revocation cannot be confirmed.
- Keep Grok unavailable on WASM without changing Gateway or Codex routing.
