### PR TITLE
Treat Thai combining marks as zero-width cells

### DIFF
--- a/src/core/input/text_boundaries.zig
+++ b/src/core/input/text_boundaries.zig
@@ -199,6 +199,29 @@ test "character boundaries group terminal character continuations" {
     try std.testing.expectEqual(@as(usize, 1), previousCharacterStart(family, 1 + "👨‍👩‍👧‍👦".len));
 }
 
+test "character boundaries group Thai base characters with their marks" {
+    // Base consonant + above-vowel + tone mark forms one editing character.
+    const cluster = "\u{0E01}\u{0E31}\u{0E49}";
+    try std.testing.expectEqual(cluster.len, nextCharacterEnd(cluster, 0));
+    try std.testing.expectEqual(@as(usize, 0), previousCharacterStart(cluster, cluster.len));
+
+    // Stacked marks chain onto the same base (SARA U + MAI EK).
+    const stacked = "\u{0E19}\u{0E38}\u{0E49}\u{0E01}";
+    try std.testing.expectEqual("\u{0E19}\u{0E38}\u{0E49}".len, nextCharacterEnd(stacked, 0));
+    try std.testing.expectEqual(@as(usize, 0), previousCharacterStart(stacked, "\u{0E19}\u{0E38}\u{0E49}".len));
+
+    // SARA AM is spacing, so it starts a new editing character even after a
+    // tone mark; the tone mark stays grouped with the base.
+    const sara_am = "\u{0E19}\u{0E49}\u{0E33}";
+    try std.testing.expectEqual("\u{0E19}\u{0E49}".len, nextCharacterEnd(sara_am, 0));
+    try std.testing.expectEqual("\u{0E19}\u{0E49}".len, previousCharacterStart(sara_am, sara_am.len));
+
+    // Spacing characters do not absorb a following mark.
+    const spaced = "\u{0E01}\u{0E02}";
+    try std.testing.expectEqual(@as(usize, 3), nextCharacterEnd(spaced, 0));
+    try std.testing.expectEqual(@as(usize, 6), nextCharacterEnd(spaced, 3));
+}
+
 test "character boundaries preserve ascii and precomposed utf8" {
     const text = "AéB";
     try std.testing.expectEqual(@as(usize, 1), nextCharacterEnd(text, 0));

--- a/src/core/shared/display_width.zig
+++ b/src/core/shared/display_width.zig
@@ -345,7 +345,8 @@ fn isCombining(codepoint: u21) bool {
         (codepoint >= 0x1dc0 and codepoint <= 0x1dff) or
         (codepoint >= 0x20d0 and codepoint <= 0x20ff) or
         (codepoint >= 0xfe20 and codepoint <= 0xfe2f) or
-        (codepoint >= 0xfe00 and codepoint <= 0xfe0f);
+        (codepoint >= 0xfe00 and codepoint <= 0xfe0f) or
+        isInRanges(codepoint, unicode_data.combining_ranges[0..]);
 }
 
 fn isZeroWidthContinuation(codepoint: u21) bool {
@@ -519,6 +520,46 @@ test "runeWidth preserves current width table semantics" {
     try std.testing.expectEqual(@as(usize, 1), runeWidth('a'));
     try std.testing.expectEqual(@as(usize, 1), runeWidth(' '));
     try std.testing.expectEqual(@as(usize, 0), runeWidth(0x09));
+}
+
+test "runeWidth treats Thai combining marks as zero-width" {
+    // Mn/Me marks composite onto the preceding cell.
+    try std.testing.expectEqual(@as(usize, 0), runeWidth(0x0E31));
+    try std.testing.expectEqual(@as(usize, 0), runeWidth(0x0E34));
+    try std.testing.expectEqual(@as(usize, 0), runeWidth(0x0E3A));
+    try std.testing.expectEqual(@as(usize, 0), runeWidth(0x0E47));
+    try std.testing.expectEqual(@as(usize, 0), runeWidth(0x0E4E));
+    // Spacing Thai characters still occupy a cell.
+    try std.testing.expectEqual(@as(usize, 1), runeWidth(0x0E01));
+    try std.testing.expectEqual(@as(usize, 1), runeWidth(0x0E30));
+    try std.testing.expectEqual(@as(usize, 1), runeWidth(0x0E33));
+    try std.testing.expectEqual(@as(usize, 1), runeWidth(0x0E40));
+}
+
+test "visibleWidth counts Thai clusters as single cells" {
+    // Base + above-vowel + tone mark: one cell per cluster, not per codepoint.
+    try std.testing.expectEqual(@as(usize, 1), visibleWidth("\u{0E01}\u{0E31}\u{0E49}"));
+    try std.testing.expectEqual(@as(usize, 1), visibleWidth("\u{0E17}\u{0E35}\u{0E48}"));
+    // SARA AM is spacing, so it costs its own cell even after a tone mark.
+    try std.testing.expectEqual(@as(usize, 2), visibleWidth("\u{0E19}\u{0E49}\u{0E33}"));
+    // Marks without a base still cost no cells.
+    try std.testing.expectEqual(@as(usize, 0), visibleWidth("\u{0E49}"));
+}
+
+test "display unit scanner keeps Thai marks as zero-width units" {
+    const cluster = "\u{0E01}\u{0E31}\u{0E49}";
+    try std.testing.expectEqual(
+        DisplayUnit{ .byte_len = 3, .cell_width = 1 },
+        displayUnitAt(cluster, 0),
+    );
+    try std.testing.expectEqual(
+        DisplayUnit{ .byte_len = 3, .cell_width = 0 },
+        displayUnitAt(cluster, 3),
+    );
+    try std.testing.expectEqual(
+        DisplayUnit{ .byte_len = 3, .cell_width = 0 },
+        displayUnitAt(cluster, 6),
+    );
 }
 
 test "decodeNextRune preserves boundary and invalid-byte behavior" {

--- a/src/core/shared/unicode_display_data.zig
+++ b/src/core/shared/unicode_display_data.zig
@@ -251,6 +251,20 @@ pub const emoji_modifier_ranges = [_]Range{
     .{ .first = 0x1F3FB, .last = 0x1F3FF },
 };
 
+// Combining marks that terminals composite onto the preceding cell without
+// advancing the cursor. Currently covers the Thai block subset of general
+// categories Mn/Me: U+0E31, U+0E34-U+0E3A, U+0E47-U+0E4E. Spacing Thai
+// characters (consonants, lead vowels, and U+0E33 SARA AM) are intentionally
+// excluded because they occupy a cell. Intended to grow toward the full Mn/Me
+// set, script by script, each addition verified against the terminal
+// composition behavior. Sourced from:
+// https://www.unicode.org/Public/17.0.0/ucd/extracted/DerivedGeneralCategory.txt
+pub const combining_ranges = [_]Range{
+    .{ .first = 0x0E31, .last = 0x0E31 },
+    .{ .first = 0x0E34, .last = 0x0E3A },
+    .{ .first = 0x0E47, .last = 0x0E4E },
+};
+
 pub const variation_bases = [_]Range{
     .{ .first = 0x0023, .last = 0x0023 },
     .{ .first = 0x002A, .last = 0x002A },


### PR DESCRIPTION
## Problem

Typing Thai in the composer makes tone marks and above/below vowels disappear. Thai combining marks (U+0E31, U+0E34-U+0E3A, U+0E47-U+0E4E) were classified as width-1 cells, but terminals composite them onto the preceding cell without advancing the cursor. Every column computation (cursor math, incremental repaint addressing, soft-wrap, row clipping) therefore desyncs from the physical terminal: later glyphs get written into the wrong cells, and a wrap that splits a base character from its mark leaves the mark compositing onto the row-prefix space, where it is invisible.

## Fix

Add a `combining_ranges` table to `unicode_display_data.zig` covering the Thai block Mn/Me subset and consult it from `isCombining()` in `display_width.zig`. This single change propagates through the whole stack: width accounting, grapheme grouping in `text_boundaries.zig`, soft-wrap (no break between base and mark), the VT engine's combining-suffix path, cursor columns, and clipping budgets.

The table is named generically because it is intended to grow toward the full Mn/Me set script by script; this PR deliberately scopes to Thai to keep the blast radius reviewable (three Mn codepoints currently classified wide — U+302A-302D, U+3099-309A, U+16FE4 — are left for a follow-up).

## Commits

1. Add combining mark ranges for the Thai block (data)
2. Treat Thai combining marks as zero-width cells (policy + width tests)
3. Group Thai combining marks into single editing characters (boundary tests)

## Tests

Six new tests covering runeWidth, visibleWidth (e.g. กั้ง = 1 cell, น้ำ = 2 cells since SARA AM is spacing), displayUnitAt zero-width units, stacked-mark grouping (นุ้), SARA AM cluster splitting, and spacing-character non-absorption. All 42 existing width/boundary tests plus the fuzz invariants pass.