### PR TITLE
Bound Codex streamed response accumulation

### DIFF
--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -13,8 +13,23 @@ const generation_origin = "https://chatgpt.com/backend-api/codex";
 const e2e_endpoint_env = "FX_E2E_OPENAI_CODEX_RESPONSES_URL";
 const max_error_body_bytes: usize = 1024 * 1024;
 const max_sse_line_bytes: usize = 32 * 1024 * 1024;
+const max_sse_aggregate_bytes: usize = 64 * 1024 * 1024;
+const max_sse_events: usize = 100_000;
+const max_tool_calls: usize = 128;
+const max_tool_identity_bytes: usize = 1024;
+const max_tool_arguments_bytes: usize = 4 * 1024 * 1024;
+const max_provider_state_bytes: usize = 4 * 1024 * 1024;
 const transfer_buffer_bytes: usize = 256 * 1024;
 const connect_timeout_ms: i64 = 30_000;
+
+const StreamLimits = struct {
+    aggregate_bytes: usize = max_sse_aggregate_bytes,
+    events: usize = max_sse_events,
+    tool_calls: usize = max_tool_calls,
+    tool_identity_bytes: usize = max_tool_identity_bytes,
+    tool_arguments_bytes: usize = max_tool_arguments_bytes,
+    provider_state_bytes: usize = max_provider_state_bytes,
+};
 
 pub const agent_stream_provider = stream_provider.Provider{
     .build_fn = buildRequest,
@@ -392,6 +407,7 @@ fn streamCompletionCore(alloc: Allocator, request: stream_provider.Request) !str
         request.on_tool_input_chunk,
         request.cancel_flag,
         request.content_capture_limit,
+        .{},
     );
     return .{
         .status = .ok,
@@ -482,6 +498,7 @@ fn consumeSse(
     on_tool_input_chunk: ?stream_provider.StreamCallback,
     cancel_flag: *std.atomic.Value(bool),
     content_capture_limit: ?usize,
+    limits: StreamLimits,
 ) !types.GatewayCompletion {
     var content: std.ArrayList(u8) = .empty;
     errdefer content.deinit(alloc);
@@ -501,10 +518,14 @@ fn consumeSse(
     errdefer if (generation_id) |id| alloc.free(id);
     var terminal_seen = false;
     var saw_content_delta = false;
+    var event_count: usize = 0;
+    var aggregate_bytes: usize = 0;
 
     while (try sse.next(alloc, reader)) |json_text| {
         defer sse.release();
         if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        event_count = try checkedAccumulatedSize(event_count, 1, limits.events);
+        aggregate_bytes = try checkedAccumulatedSize(aggregate_bytes, json_text.len, limits.aggregate_bytes);
         var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch
             return error.InvalidOpenAICodexSseEvent;
         defer parsed.deinit();
@@ -520,7 +541,7 @@ fn consumeSse(
                 const call_id = stringField(item.object, "call_id") orelse continue;
                 const name = stringField(item.object, "name") orelse continue;
                 if (findTool(tools.items, output_index) == null) {
-                    try appendTool(alloc, &tools, output_index, call_id, name);
+                    try appendTool(alloc, &tools, output_index, call_id, name, limits);
                     if (on_tool_start) |callback| callback(callback_ctx, call_id, name, null);
                 }
             }
@@ -542,7 +563,7 @@ fn consumeSse(
             const output_index = integerField(parsed.value.object, "output_index") orelse continue;
             const delta = stringField(parsed.value.object, "delta") orelse continue;
             const index = findTool(tools.items, output_index) orelse continue;
-            try tools.items[index].arguments.appendSlice(alloc, delta);
+            try appendToolArguments(alloc, &tools.items[index].arguments, delta, limits.tool_arguments_bytes);
             if (on_tool_input_chunk) |callback| callback(callback_ctx, delta);
         } else if (std.mem.eql(u8, event_type, "response.function_call_arguments.done")) {
             const output_index = integerField(parsed.value.object, "output_index") orelse continue;
@@ -551,11 +572,11 @@ fn consumeSse(
             const previous_len = tools.items[index].arguments.items.len;
             if (std.mem.startsWith(u8, arguments, tools.items[index].arguments.items)) {
                 const suffix = arguments[previous_len..];
-                try tools.items[index].arguments.appendSlice(alloc, suffix);
+                try appendToolArguments(alloc, &tools.items[index].arguments, suffix, limits.tool_arguments_bytes);
                 if (suffix.len > 0) if (on_tool_input_chunk) |callback| callback(callback_ctx, suffix);
             } else {
                 tools.items[index].arguments.clearRetainingCapacity();
-                try tools.items[index].arguments.appendSlice(alloc, arguments);
+                try appendToolArguments(alloc, &tools.items[index].arguments, arguments, limits.tool_arguments_bytes);
             }
         } else if (std.mem.eql(u8, event_type, "response.output_item.done")) {
             const output_index = integerField(parsed.value.object, "output_index") orelse continue;
@@ -566,19 +587,24 @@ fn consumeSse(
                 if (findTool(tools.items, output_index)) |index| {
                     if (stringField(item.object, "arguments")) |arguments| {
                         if (tools.items[index].arguments.items.len == 0) {
-                            try tools.items[index].arguments.appendSlice(alloc, arguments);
+                            try appendToolArguments(alloc, &tools.items[index].arguments, arguments, limits.tool_arguments_bytes);
                         }
                     }
                 }
             } else if (std.mem.eql(u8, item_type, "reasoning") and
                 stringField(item.object, "encrypted_content") != null)
             {
+                var encoded: std.Io.Writer.Allocating = .init(alloc);
+                defer encoded.deinit();
+                try std.json.Stringify.value(item, .{}, &encoded.writer);
+                const framed_size = try checkedAccumulatedSize(encoded.written().len, 2, limits.provider_state_bytes);
+                _ = try checkedAccumulatedSize(provider_state.written().len, framed_size, limits.provider_state_bytes);
                 if (provider_state_count == 0) {
                     try provider_state.writer.writeByte('[');
                 } else {
                     try provider_state.writer.writeByte(',');
                 }
-                try std.json.Stringify.value(item, .{}, &provider_state.writer);
+                try provider_state.writer.writeAll(encoded.written());
                 provider_state_count += 1;
             } else if (std.mem.eql(u8, item_type, "message") and !saw_content_delta) {
                 if (item.object.get("content")) |parts| if (parts == .array) {
@@ -663,7 +689,13 @@ fn appendTool(
     output_index: i64,
     call_id: []const u8,
     name: []const u8,
+    limits: StreamLimits,
 ) !void {
+    if (tools.items.len >= limits.tool_calls or call_id.len == 0 or call_id.len > limits.tool_identity_bytes or
+        name.len == 0 or name.len > limits.tool_identity_bytes)
+    {
+        return error.OpenAICodexToolCallLimitExceeded;
+    }
     const id = try alloc.dupe(u8, call_id);
     errdefer alloc.free(id);
     const owned_name = try alloc.dupe(u8, name);
@@ -673,6 +705,24 @@ fn appendTool(
         .id = id,
         .name = owned_name,
     });
+}
+
+fn appendToolArguments(
+    alloc: Allocator,
+    arguments: *std.ArrayList(u8),
+    delta: []const u8,
+    maximum: usize,
+) !void {
+    _ = checkedAccumulatedSize(arguments.items.len, delta.len, maximum) catch
+        return error.OpenAICodexToolArgumentsTooLarge;
+    try arguments.appendSlice(alloc, delta);
+}
+
+fn checkedAccumulatedSize(current: usize, additional: usize, maximum: usize) !usize {
+    const next = std.math.add(usize, current, additional) catch
+        return error.OpenAICodexResourceLimitExceeded;
+    if (next > maximum) return error.OpenAICodexResourceLimitExceeded;
+    return next;
 }
 
 fn appendCaptured(
@@ -877,6 +927,7 @@ test "OpenAI Codex SSE maps text reasoning tools and usage" {
         null,
         &cancelled,
         null,
+        .{},
     );
     defer {
         if (completion.content) |value| std.testing.allocator.free(@constCast(value));
@@ -893,4 +944,149 @@ test "OpenAI Codex SSE maps text reasoning tools and usage" {
     try std.testing.expect(completion.provider_state_json != null);
     try std.testing.expect(std.mem.find(u8, completion.provider_state_json.?, "\"encrypted_content\":\"opaque\"") != null);
     try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}
+
+fn consumeOpenAICodexTestSse(sse_text: []const u8, limits: StreamLimits) !types.GatewayCompletion {
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    var callback_context: u8 = 0;
+    return consumeSse(
+        std.testing.allocator,
+        &reader,
+        &callback_context,
+        struct {
+            fn ignore(_: *anyopaque, _: []const u8) void {}
+        }.ignore,
+        null,
+        null,
+        null,
+        &cancelled,
+        null,
+        limits,
+    );
+}
+
+fn freeOpenAICodexTestCompletion(completion: types.GatewayCompletion) void {
+    if (completion.content) |value| std.testing.allocator.free(@constCast(value));
+    types.freeToolCallSlice(std.testing.allocator, @constCast(completion.tool_calls));
+    if (completion.generation_id) |value| std.testing.allocator.free(@constCast(value));
+    if (completion.provider_state_json) |value| std.testing.allocator.free(@constCast(value));
+}
+
+fn expectOpenAICodexSseError(expected: anyerror, sse_text: []const u8, limits: StreamLimits) !void {
+    const result = consumeOpenAICodexTestSse(sse_text, limits);
+    if (result) |completion| {
+        freeOpenAICodexTestCompletion(completion);
+        return error.TestExpectedOpenAICodexSseError;
+    } else |err| {
+        try std.testing.expectEqual(expected, err);
+    }
+}
+
+test "OpenAI Codex checked stream sizes accept the bound and reject overflow" {
+    try std.testing.expectEqual(@as(usize, 7), try checkedAccumulatedSize(6, 1, 7));
+    try std.testing.expectError(
+        error.OpenAICodexResourceLimitExceeded,
+        checkedAccumulatedSize(std.math.maxInt(usize), 1, std.math.maxInt(usize)),
+    );
+}
+
+test "OpenAI Codex rejects cumulative event and byte limits" {
+    const terminal_json = "{\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}";
+    const terminal_event = "data: " ++ terminal_json ++ "\n\n";
+    const completion = try consumeOpenAICodexTestSse(
+        terminal_event,
+        .{ .events = 1, .aggregate_bytes = terminal_json.len },
+    );
+    defer freeOpenAICodexTestCompletion(completion);
+
+    const event = "data: {\"type\":\"response.reasoning_summary_part.done\"}\n\n";
+    try expectOpenAICodexSseError(
+        error.OpenAICodexResourceLimitExceeded,
+        event ++ event,
+        .{ .events = 1 },
+    );
+    try expectOpenAICodexSseError(
+        error.OpenAICodexResourceLimitExceeded,
+        terminal_event,
+        .{ .aggregate_bytes = terminal_json.len - 1 },
+    );
+}
+
+test "OpenAI Codex rejects oversized streamed tool identities" {
+    try expectOpenAICodexSseError(
+        error.OpenAICodexToolCallLimitExceeded,
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call\",\"name\":\"ok\"}}\n\n",
+        .{ .tool_identity_bytes = 3 },
+    );
+    try expectOpenAICodexSseError(
+        error.OpenAICodexToolCallLimitExceeded,
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"ok\",\"name\":\"read\"}}\n\n",
+        .{ .tool_identity_bytes = 3 },
+    );
+}
+
+test "OpenAI Codex bounds every streamed argument representation and cleans staged state" {
+    const prefix =
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"read\"}}\n\n" ++
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"opaque\"}}\n\n";
+    const cases = [_][]const u8{
+        prefix ++ "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"four\"}\n\n",
+        prefix ++ "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"arguments\":\"four\"}\n\n",
+        prefix ++ "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"arguments\":\"four\"}}\n\n",
+    };
+    for (cases) |sse_text| {
+        try expectOpenAICodexSseError(
+            error.OpenAICodexToolArgumentsTooLarge,
+            sse_text,
+            .{ .tool_arguments_bytes = 3 },
+        );
+    }
+}
+
+test "OpenAI Codex rejects oversized encrypted provider state" {
+    try expectOpenAICodexSseError(
+        error.OpenAICodexResourceLimitExceeded,
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"opaque\"}}\n\n",
+        .{ .provider_state_bytes = 16 },
+    );
+}
+
+test "OpenAI Codex provider state accepts the exact framed limit" {
+    const expected_state = "[{\"type\":\"reasoning\",\"encrypted_content\":\"a\"},{\"type\":\"reasoning\",\"encrypted_content\":\"b\"}]";
+    const sse_text =
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"a\"}}\n\n" ++
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"type\":\"reasoning\",\"encrypted_content\":\"b\"}}\n\n" ++
+        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n";
+    const completion = try consumeOpenAICodexTestSse(
+        sse_text,
+        .{ .provider_state_bytes = expected_state.len },
+    );
+    defer freeOpenAICodexTestCompletion(completion);
+    try std.testing.expectEqualStrings(expected_state, completion.provider_state_json.?);
+    try expectOpenAICodexSseError(
+        error.OpenAICodexResourceLimitExceeded,
+        sse_text,
+        .{ .provider_state_bytes = expected_state.len - 1 },
+    );
+}
+
+test "OpenAI Codex rejects a 129th streamed tool call" {
+    var stream: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer stream.deinit();
+    for (0..129) |index| {
+        try stream.writer.print(
+            "data: {{\"type\":\"response.output_item.added\",\"output_index\":{d},\"item\":{{\"type\":\"function_call\",\"call_id\":\"call_{d}\",\"name\":\"read_file\"}}}}\n\n",
+            .{ index, index },
+        );
+    }
+    try stream.writer.writeAll("data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n");
+
+    const result = consumeOpenAICodexTestSse(stream.written(), .{});
+    if (result) |completion| {
+        freeOpenAICodexTestCompletion(completion);
+        return error.TestExpectedToolCallLimit;
+    } else |err| {
+        try std.testing.expectEqual(error.OpenAICodexToolCallLimitExceeded, err);
+    }
 }

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -22,7 +22,7 @@ const max_provider_state_bytes: usize = 4 * 1024 * 1024;
 const transfer_buffer_bytes: usize = 256 * 1024;
 const connect_timeout_ms: i64 = 30_000;
 
-const StreamLimits = struct {
+const CodexLimits = struct {
     aggregate_bytes: usize = max_sse_aggregate_bytes,
     events: usize = max_sse_events,
     tool_calls: usize = max_tool_calls,
@@ -40,6 +40,23 @@ fn validateModel(model: []const u8) !void {
     if (model.len == 0 or model.len > 1024) return error.InvalidOpenAICodexModel;
     for (model) |byte| {
         if (byte <= 0x20 or byte == 0x7f) return error.InvalidOpenAICodexModel;
+    }
+}
+
+fn validateReplayMessage(message: types.ChatMessage, limits: CodexLimits) !void {
+    if (message.provider_state_json) |state_json| {
+        if (state_json.len > limits.provider_state_bytes) return error.OpenAICodexProviderStateTooLarge;
+    }
+    if (message.tool_calls.len > limits.tool_calls) return error.OpenAICodexToolCallLimitExceeded;
+    for (message.tool_calls) |call| {
+        if (call.id.len == 0 or call.id.len > limits.tool_identity_bytes or
+            call.name.len == 0 or call.name.len > limits.tool_identity_bytes)
+        {
+            return error.OpenAICodexToolCallLimitExceeded;
+        }
+        if (call.arguments_json.len > limits.tool_arguments_bytes) {
+            return error.OpenAICodexToolArgumentsTooLarge;
+        }
     }
 }
 
@@ -143,6 +160,7 @@ fn writeInput(
                 try writer.writeAll("]}");
             },
             .assistant => {
+                try validateReplayMessage(message, .{});
                 if (message.provider_state_json) |state_json| {
                     var state = std.json.parseFromSlice(std.json.Value, alloc, state_json, .{}) catch
                         return error.InvalidOpenAICodexProviderState;
@@ -498,7 +516,7 @@ fn consumeSse(
     on_tool_input_chunk: ?stream_provider.StreamCallback,
     cancel_flag: *std.atomic.Value(bool),
     content_capture_limit: ?usize,
-    limits: StreamLimits,
+    limits: CodexLimits,
 ) !types.GatewayCompletion {
     var content: std.ArrayList(u8) = .empty;
     errdefer content.deinit(alloc);
@@ -689,7 +707,7 @@ fn appendTool(
     output_index: i64,
     call_id: []const u8,
     name: []const u8,
-    limits: StreamLimits,
+    limits: CodexLimits,
 ) !void {
     if (tools.items.len >= limits.tool_calls or call_id.len == 0 or call_id.len > limits.tool_identity_bytes or
         name.len == 0 or name.len > limits.tool_identity_bytes)
@@ -815,6 +833,119 @@ test "OpenAI Codex request uses Responses input and converts AI SDK tool schemas
     try std.testing.expect(std.mem.find(u8, body, "\"reasoning\":{\"effort\":\"high\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"service_tier\":\"priority\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"max_output_tokens\"") == null);
+}
+
+fn makeSizedProviderState(alloc: Allocator, size: usize) ![]u8 {
+    const prefix = "[{\"type\":\"reasoning\",\"encrypted_content\":\"";
+    const suffix = "\"}]";
+    if (size < prefix.len + suffix.len) return error.TestProviderStateSizeTooSmall;
+    const state = try alloc.alloc(u8, size);
+    @memcpy(state[0..prefix.len], prefix);
+    @memset(state[prefix.len .. size - suffix.len], 'x');
+    @memcpy(state[size - suffix.len ..], suffix);
+    return state;
+}
+
+fn makeSizedToolArguments(alloc: Allocator, size: usize) ![]u8 {
+    const prefix = "{\"value\":\"";
+    const suffix = "\"}";
+    if (size < prefix.len + suffix.len) return error.TestToolArgumentsSizeTooSmall;
+    const arguments = try alloc.alloc(u8, size);
+    @memcpy(arguments[0..prefix.len], prefix);
+    @memset(arguments[prefix.len .. size - suffix.len], 'x');
+    @memcpy(arguments[size - suffix.len ..], suffix);
+    return arguments;
+}
+
+fn buildOpenAICodexReplay(messages: []const types.ChatMessage) ![]u8 {
+    return agent_stream_provider.build(std.testing.allocator, .{
+        .model = "gpt-5.6-sol",
+        .serialized_tools = "[]",
+        .messages = messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+    });
+}
+
+fn expectOpenAICodexReplaySuccess(messages: []const types.ChatMessage) !void {
+    const body = try buildOpenAICodexReplay(messages);
+    std.testing.allocator.free(body);
+}
+
+fn expectOpenAICodexReplayError(expected: anyerror, messages: []const types.ChatMessage) !void {
+    const result = buildOpenAICodexReplay(messages);
+    if (result) |body| {
+        std.testing.allocator.free(body);
+        return error.TestExpectedOpenAICodexReplayError;
+    } else |err| {
+        try std.testing.expectEqual(expected, err);
+    }
+}
+
+test "OpenAI Codex replay provider state accepts the limit and rejects one byte beyond" {
+    {
+        const provider_state = try makeSizedProviderState(std.testing.allocator, max_provider_state_bytes);
+        defer std.testing.allocator.free(provider_state);
+        const messages = [_]types.ChatMessage{.{
+            .role = .assistant,
+            .provider_state_json = provider_state,
+        }};
+        try expectOpenAICodexReplaySuccess(&messages);
+    }
+    {
+        const provider_state = try makeSizedProviderState(std.testing.allocator, max_provider_state_bytes + 1);
+        defer std.testing.allocator.free(provider_state);
+        const messages = [_]types.ChatMessage{.{
+            .role = .assistant,
+            .provider_state_json = provider_state,
+        }};
+        try expectOpenAICodexReplayError(error.OpenAICodexProviderStateTooLarge, &messages);
+    }
+}
+
+test "OpenAI Codex replay tool count accepts the limit and rejects one call beyond" {
+    var calls: [max_tool_calls + 1]types.ToolCall = undefined;
+    for (&calls) |*call| call.* = .{ .id = "call", .name = "read_file", .arguments_json = "{}" };
+    var message: types.ChatMessage = .{ .role = .assistant, .tool_calls = calls[0..max_tool_calls] };
+    try expectOpenAICodexReplaySuccess(&.{message});
+    message.tool_calls = &calls;
+    try expectOpenAICodexReplayError(error.OpenAICodexToolCallLimitExceeded, &.{message});
+}
+
+test "OpenAI Codex replay tool identities accept the limit and reject one byte beyond" {
+    const identity = try std.testing.allocator.alloc(u8, max_tool_identity_bytes + 1);
+    defer std.testing.allocator.free(identity);
+    @memset(identity, 'i');
+    var call: types.ToolCall = .{ .id = identity[0..max_tool_identity_bytes], .name = "read", .arguments_json = "{}" };
+    var message: types.ChatMessage = .{ .role = .assistant, .tool_calls = &.{call} };
+    try expectOpenAICodexReplaySuccess(&.{message});
+    call.id = identity;
+    message.tool_calls = &.{call};
+    try expectOpenAICodexReplayError(error.OpenAICodexToolCallLimitExceeded, &.{message});
+
+    call = .{ .id = "call", .name = identity[0..max_tool_identity_bytes], .arguments_json = "{}" };
+    message.tool_calls = &.{call};
+    try expectOpenAICodexReplaySuccess(&.{message});
+    call.name = identity;
+    message.tool_calls = &.{call};
+    try expectOpenAICodexReplayError(error.OpenAICodexToolCallLimitExceeded, &.{message});
+}
+
+test "OpenAI Codex replay tool arguments accept the limit and reject one byte beyond" {
+    {
+        const arguments = try makeSizedToolArguments(std.testing.allocator, max_tool_arguments_bytes);
+        defer std.testing.allocator.free(arguments);
+        const calls = [_]types.ToolCall{.{ .id = "call", .name = "read", .arguments_json = arguments }};
+        const messages = [_]types.ChatMessage{.{ .role = .assistant, .tool_calls = &calls }};
+        try expectOpenAICodexReplaySuccess(&messages);
+    }
+    {
+        const arguments = try makeSizedToolArguments(std.testing.allocator, max_tool_arguments_bytes + 1);
+        defer std.testing.allocator.free(arguments);
+        const calls = [_]types.ToolCall{.{ .id = "call", .name = "read", .arguments_json = arguments }};
+        const messages = [_]types.ChatMessage{.{ .role = .assistant, .tool_calls = &calls }};
+        try expectOpenAICodexReplayError(error.OpenAICodexToolArgumentsTooLarge, &messages);
+    }
 }
 
 test "OpenAI Codex standard requests omit the priority service tier" {
@@ -946,7 +1077,7 @@ test "OpenAI Codex SSE maps text reasoning tools and usage" {
     try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
 }
 
-fn consumeOpenAICodexTestSse(sse_text: []const u8, limits: StreamLimits) !types.GatewayCompletion {
+fn consumeOpenAICodexTestSse(sse_text: []const u8, limits: CodexLimits) !types.GatewayCompletion {
     var reader: std.Io.Reader = .fixed(sse_text);
     var cancelled = std.atomic.Value(bool).init(false);
     var callback_context: u8 = 0;
@@ -973,7 +1104,7 @@ fn freeOpenAICodexTestCompletion(completion: types.GatewayCompletion) void {
     if (completion.provider_state_json) |value| std.testing.allocator.free(@constCast(value));
 }
 
-fn expectOpenAICodexSseError(expected: anyerror, sse_text: []const u8, limits: StreamLimits) !void {
+fn expectOpenAICodexSseError(expected: anyerror, sse_text: []const u8, limits: CodexLimits) !void {
     const result = consumeOpenAICodexTestSse(sse_text, limits);
     if (result) |completion| {
         freeOpenAICodexTestCompletion(completion);


### PR DESCRIPTION
## Summary

- Bound cumulative Codex SSE event count and response bytes.
- Cap streamed tools, tool identities, arguments, and encrypted provider state before persistent allocation grows further.
- Validate the same provider state and tool metadata limits before replaying saved history into a new request.
- Reject over-limit responses and history while releasing staged buffers and preserving ordinary Codex streams.

Follow-up to #216.