### PR TITLE
Draft: Add --prompt-file flag to fx ask

### DIFF
--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -30,7 +30,7 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .ask,
         .token = "ask",
-        .usage = "ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>",
+        .usage = "ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--prompt-file PATH] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>",
         .summary = "Run one noninteractive request",
         .options = &.{
             .{ .flag = "--auto", .description = "Automatically review unresolved permission requests" },
@@ -40,6 +40,7 @@ pub const top_level_specs = [_]TopLevelSpec{
             .{ .flag = "--quiet", .description = "Suppress assistant output" },
             .{ .flag = "--prompt-permissions", .description = "Prompt for Y/N permission approval when stdin is a TTY" },
             .{ .flag = "--no-save", .description = "Do not save the session; incompatible with --resume and --resume-id" },
+            .{ .flag = "--prompt-file PATH", .description = "Read the prompt from a file instead of arguments or stdin" },
             .{ .flag = "--no-color", .description = "Render TTY output without colors or hyperlinks" },
             .{ .flag = "--resume <last|id>", .description = "Continue the last session or a session by id" },
             .{ .flag = "--resume-id <id>", .description = "Continue a session by exact id" },
@@ -47,7 +48,7 @@ pub const top_level_specs = [_]TopLevelSpec{
             .{ .flag = "--", .description = "Treat every following argument as prompt text" },
         },
         .details = &.{
-            "The prompt may be passed as arguments or piped on stdin when no prompt args are given.",
+            "The prompt may be passed as arguments, piped on stdin when no prompt args are given, or read from a file with --prompt-file.",
             "TTY stdout uses the Minimal transcript presentation; redirected stdout emits raw assistant Markdown.",
             "Operational progress and diagnostics are written to stderr. JSON output keeps raw Markdown in `output`.",
             "With --prompt-permissions, JSON and quiet requests may prompt on stderr only when stdin is a TTY.",

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -330,6 +330,7 @@ const AskOptions = struct {
     image_paths: std.ArrayList([]u8) = .empty,
     images: std.ArrayList(ImageAttachment) = .empty,
     system_prompt_override: ?[]u8 = null,
+    prompt_file_path: ?[]u8 = null,
     json_output: bool = false,
     prompt_permissions: bool = false,
     timeout_ms: ?usize = null,
@@ -346,6 +347,7 @@ const AskOptions = struct {
         for (self.images.items) |image| types.freeImageAttachment(alloc, image);
         self.images.deinit(alloc);
         if (self.system_prompt_override) |s| alloc.free(s);
+        if (self.prompt_file_path) |p| alloc.free(p);
     }
 };
 
@@ -1222,6 +1224,26 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
                 return 1;
             }
             try deps.write_stderr(deps.stderr_ctx, "fx ask: failed to read prompt from stdin\n");
+            return 1;
+        },
+        error.PromptFileNotFound => {
+            if (hasJsonFlag(args)) {
+                const json = try renderErrorJsonResult(alloc, @errorName(err));
+                defer alloc.free(json);
+                try deps.write_stdout(deps.stdout_ctx, json);
+                return 1;
+            }
+            try deps.write_stderr(deps.stderr_ctx, "fx ask: --prompt-file: file not found\n");
+            return 1;
+        },
+        error.PromptFileReadFailed => {
+            if (hasJsonFlag(args)) {
+                const json = try renderErrorJsonResult(alloc, @errorName(err));
+                defer alloc.free(json);
+                try deps.write_stdout(deps.stdout_ctx, json);
+                return 1;
+            }
+            try deps.write_stderr(deps.stderr_ctx, "fx ask: --prompt-file: failed to read file\n");
             return 1;
         },
         error.InvalidAskArgs => {
@@ -3370,6 +3392,11 @@ fn parseOptionsWithStdin(alloc: Allocator, args: []const [:0]const u8, stdin: St
             if (i >= args.len) return error.MissingPrompt;
             if (opts.system_prompt_override) |old| alloc.free(old);
             opts.system_prompt_override = try alloc.dupe(u8, args[i]);
+        } else if (std.mem.eql(u8, arg, "--prompt-file")) {
+            if (opts.prompt_file_path != null) return error.InvalidAskArgs;
+            i += 1;
+            if (i >= args.len) return error.MissingPrompt;
+            opts.prompt_file_path = try alloc.dupe(u8, args[i]);
         } else if (std.mem.eql(u8, arg, "--json")) {
             opts.json_output = true;
         } else if (std.mem.eql(u8, arg, "--prompt-permissions")) {
@@ -3398,11 +3425,15 @@ fn parseOptionsWithStdin(alloc: Allocator, args: []const [:0]const u8, stdin: St
 
     if (opts.continue_recovery) {
         if (opts.resume_target == null or opts.no_save or
-            prompt_parts.items.len != 0 or opts.image_paths.items.len != 0)
+            prompt_parts.items.len != 0 or opts.image_paths.items.len != 0 or
+            opts.prompt_file_path != null)
         {
             return error.InvalidAskArgs;
         }
         opts.prompt = try alloc.dupe(u8, "");
+    } else if (opts.prompt_file_path) |path| {
+        if (prompt_parts.items.len != 0) return error.InvalidAskArgs;
+        opts.prompt = try readPromptFromFile(alloc, path);
     } else if (prompt_parts.items.len > 0) {
         opts.prompt = try joinPromptSlices(alloc, prompt_parts.items);
     } else {
@@ -3472,6 +3503,31 @@ fn joinPromptSlices(alloc: Allocator, args: []const []const u8) ![]u8 {
 
 fn readPromptFromStdinSource(alloc: Allocator, stdin: StdinSource) ![]u8 {
     return readPromptFromStdinSourceWithLimit(alloc, stdin, stdin_prompt_resource_byte_limit);
+}
+
+fn readPromptFromFile(alloc: Allocator, path: []const u8) ![]u8 {
+    const zio = io_mod.getIo();
+    var file = std.Io.Dir.cwd().openFile(zio, path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return error.PromptFileNotFound,
+        else => return error.PromptFileReadFailed,
+    };
+    defer file.close(zio);
+
+    var read_buf: [8192]u8 = undefined;
+    var r = file.reader(zio, &read_buf);
+    const input = readPromptFromReader(alloc, &r.interface, stdin_prompt_resource_byte_limit) catch |err| switch (err) {
+        error.PromptInputReadFailed => return error.PromptFileReadFailed,
+        else => return err,
+    };
+    errdefer alloc.free(input);
+
+    const trimmed = std.mem.trim(u8, input, " \t\r\n");
+    if (trimmed.len == 0) return error.MissingPrompt;
+    if (trimmed.len == input.len) return input;
+
+    const owned = try alloc.dupe(u8, trimmed);
+    alloc.free(input);
+    return owned;
 }
 
 fn readPromptFromStdinSourceWithLimit(
@@ -5154,8 +5210,49 @@ test "parse options rejects unknown flags and accepts dash prompts after sentine
 test "parse options reports missing operands and empty tty input as missing prompt" {
     try std.testing.expectError(error.MissingPrompt, parseOptionsWithStdin(std.testing.allocator, &.{"--image"}, .tty));
     try std.testing.expectError(error.MissingPrompt, parseOptionsWithStdin(std.testing.allocator, &.{"--system"}, .tty));
+    try std.testing.expectError(error.MissingPrompt, parseOptionsWithStdin(std.testing.allocator, &.{"--prompt-file"}, .tty));
     try std.testing.expectError(error.MissingPrompt, parseOptionsWithStdin(std.testing.allocator, &.{"--timeout"}, .tty));
     try std.testing.expectError(error.MissingPrompt, parseOptionsWithStdin(std.testing.allocator, &.{}, .tty));
+}
+
+test "parse options reject a repeated --prompt-file and a --prompt-file combined with a positional prompt" {
+    try std.testing.expectError(
+        error.InvalidAskArgs,
+        parseOptionsWithStdin(std.testing.allocator, &.{ "--prompt-file", "a.txt", "--prompt-file", "b.txt" }, .tty),
+    );
+    try std.testing.expectError(
+        error.InvalidAskArgs,
+        parseOptionsWithStdin(std.testing.allocator, &.{ "--prompt-file", "a.txt", "also positional" }, .tty),
+    );
+}
+
+test "read prompt from file trims whitespace, rejects a whitespace-only file, and reports a missing file" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var file = try tmp.dir.createFile(io_mod.getIo(), "prompt.txt", .{ .read = true });
+    try file.writeStreamingAll(io_mod.getIo(), "  hello from a file  \n");
+    file.close(io_mod.getIo());
+    const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "prompt.txt");
+    defer alloc.free(path);
+
+    const prompt = try readPromptFromFile(alloc, path);
+    defer alloc.free(prompt);
+    try std.testing.expectEqualStrings("hello from a file", prompt);
+
+    var blank_file = try tmp.dir.createFile(io_mod.getIo(), "blank.txt", .{ .read = true });
+    try blank_file.writeStreamingAll(io_mod.getIo(), "   \n\t\n");
+    blank_file.close(io_mod.getIo());
+    const blank_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "blank.txt");
+    defer alloc.free(blank_path);
+    try std.testing.expectError(error.MissingPrompt, readPromptFromFile(alloc, blank_path));
+
+    const missing_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(missing_path);
+    const missing_file_path = try std.fs.path.join(alloc, &.{ missing_path, "does-not-exist.txt" });
+    defer alloc.free(missing_file_path);
+    try std.testing.expectError(error.PromptFileNotFound, readPromptFromFile(alloc, missing_file_path));
 }
 
 test "stdin prompt resource limit accepts exact bytes and rejects one over without a partial prompt" {
@@ -5237,6 +5334,37 @@ test "stdin read failure has distinct text and JSON output contracts" {
     );
     try std.testing.expectEqualStrings(
         "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
+        stdout_capture.bytes.items,
+    );
+    try std.testing.expectEqualStrings("", stderr_capture.bytes.items);
+}
+
+test "prompt-file missing file has distinct text and JSON output contracts" {
+    const alloc = std.testing.allocator;
+    var stdout_capture: TestCapture = .{};
+    defer stdout_capture.deinit(alloc);
+    var stderr_capture: TestCapture = .{};
+    defer stderr_capture.deinit(alloc);
+    const deps = testPromptRunDeps(&stdout_capture, &stderr_capture, testPresentKeyStartup);
+
+    try std.testing.expectEqual(
+        @as(u8, 1),
+        try runWithDeps(alloc, &.{ "--prompt-file", "/does/not/exist.txt" }, testConfig(), deps),
+    );
+    try std.testing.expectEqualStrings("", stdout_capture.bytes.items);
+    try std.testing.expectEqualStrings(
+        "fx ask: --prompt-file: file not found\n",
+        stderr_capture.bytes.items,
+    );
+
+    stdout_capture.bytes.clearRetainingCapacity();
+    stderr_capture.bytes.clearRetainingCapacity();
+    try std.testing.expectEqual(
+        @as(u8, 1),
+        try runWithDeps(alloc, &.{ "--json", "--prompt-file", "/does/not/exist.txt" }, testConfig(), deps),
+    );
+    try std.testing.expectEqualStrings(
+        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptFileNotFound\"}\n",
         stdout_capture.bytes.items,
     );
     try std.testing.expectEqualStrings("", stderr_capture.bytes.items);

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -310,7 +310,7 @@ describe("cli: help", () => {
 Run one noninteractive request
 
 Usage:
-  fx ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>
+  fx ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--prompt-file PATH] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>
 
 Options:
   --auto                Automatically review unresolved permission requests
@@ -320,13 +320,14 @@ Options:
   --quiet               Suppress assistant output
   --prompt-permissions  Prompt for Y/N permission approval when stdin is a TTY
   --no-save             Do not save the session; incompatible with --resume and --resume-id
+  --prompt-file PATH    Read the prompt from a file instead of arguments or stdin
   --no-color            Render TTY output without colors or hyperlinks
   --resume <last|id>    Continue the last session or a session by id
   --resume-id <id>      Continue a session by exact id
   --continue-recovery   Resume the paused model response in the selected session
   --                    Treat every following argument as prompt text
 
-The prompt may be passed as arguments or piped on stdin when no prompt args are given.
+The prompt may be passed as arguments, piped on stdin when no prompt args are given, or read from a file with --prompt-file.
 TTY stdout uses the Minimal transcript presentation; redirected stdout emits raw assistant Markdown.
 Operational progress and diagnostics are written to stderr. JSON output keeps raw Markdown in \`output\`.
 With --prompt-permissions, JSON and quiet requests may prompt on stderr only when stdin is a TTY.
@@ -4026,6 +4027,105 @@ describe("cli: ask success", () => {
       );
     },
     120_000,
+  );
+
+  test(
+    "fx ask --prompt-file reads prompt text from a file",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-ask-prompt-file-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const promptFile = join(root, "prompt.txt");
+      const gateway = startFakeGateway([fakeGatewayFinalText("from prompt file")]);
+      try {
+        mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+        mkdirSync(workspace);
+        writeFileSync(join(home, ".fx", "settings.json"), "{}\n");
+        writeFileSync(promptFile, "explain the changes in this repository\n");
+
+        const result = await runFx(
+          ["ask", "--json", "--auto", "--no-save", "--prompt-file", promptFile],
+          {
+            cwd: realpathSync(workspace),
+            env: {
+              HOME: home,
+              AI_GATEWAY_API_KEY: "fake-prompt-file-key",
+              VERCEL_OIDC_TOKEN: undefined,
+              FX_GATEWAY_BASE_URL: gateway.baseUrl,
+              FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+              FX_MODEL: FAKE_GATEWAY_MODEL,
+              FX_AUTO_UPGRADE: "0",
+            },
+            timeoutMs: TIMEOUT,
+          },
+        );
+
+        expect(result.code).toBe(0);
+        expect(JSON.parse(result.stdout).output.trim()).toBe("from prompt file");
+        const request = JSON.parse(gateway.requests[0]!.body) as {
+          prompt: Array<{ role: string; content: Array<{ type: string; text?: string }> }>;
+        };
+        const user = request.prompt.findLast((message) => message.role === "user");
+        expect(user?.content.find((part) => part.type === "text")?.text).toBe(
+          "explain the changes in this repository",
+        );
+      } finally {
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fx ask --prompt-file missing file has distinct text and JSON errors",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-ask-prompt-file-missing-"));
+      const missingPath = join(root, "does-not-exist.txt");
+      try {
+        const textResult = await runFx(
+          ["ask", "--auto", "--no-save", "--prompt-file", missingPath],
+          { env: { ...NO_GATEWAY_AUTH, FX_DISABLE_KEYCHAIN: "1" }, timeoutMs: TIMEOUT },
+        );
+        expect(textResult.code).toBe(1);
+        expect(textResult.stdout).toBe("");
+        expect(textResult.stderr).toBe("fx ask: --prompt-file: file not found\n");
+
+        const jsonResult = await runFx(
+          ["ask", "--json", "--auto", "--no-save", "--prompt-file", missingPath],
+          { env: { ...NO_GATEWAY_AUTH, FX_DISABLE_KEYCHAIN: "1" }, timeoutMs: TIMEOUT },
+        );
+        expect(jsonResult.code).toBe(1);
+        expect(jsonResult.stderr).toBe("");
+        expect(jsonResult.stdout).toBe(
+          '{"output":"","exit_code":1,"model":"","session_id":"","steps":0,"tool_calls":[],"error":"PromptFileNotFound"}\n',
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fx ask --prompt-file rejects a positional prompt given at the same time",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-ask-prompt-file-conflict-"));
+      const promptFile = join(root, "prompt.txt");
+      writeFileSync(promptFile, "file prompt\n");
+      try {
+        const result = await runFx(
+          ["ask", "--auto", "--no-save", "--prompt-file", promptFile, "also a positional prompt"],
+          { env: { ...NO_GATEWAY_AUTH, FX_DISABLE_KEYCHAIN: "1" }, timeoutMs: TIMEOUT },
+        );
+        expect(result.code).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toContain("usage: fx ask");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
   );
 
   test(


### PR DESCRIPTION
Lets prompts be read from a file instead of positional arguments or stdin, useful for CI pipelines and version-controlled prompts (#264).