### PR TITLE
Report turn usage totals in ask --json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ fx ask "explain the changes in this repository"
 
 Foreground terminal commands run with an explicit finite deadline. fx uses durable terminal sessions for services, watchers, GUI applications, and other long-lived work, and keeps captured foreground output available through an opaque bounded-read handle for the active session or `--no-save` process.
 
+Use `--json` for a structured result. Every result includes main-agent usage:
+
+```json
+{
+  "usage": { "requests": 1, "input_tokens": 1200, "output_tokens": 450 }
+}
+```
+
+`requests` counts settled main-agent completions, including responses without token totals. Input and output tokens sum the totals reported for each completion. All three values are zero when no completion settles. These fields do not include subagent or model-powered tool usage, or asynchronously reconciled spend.
+
 fx starts in `auto` permission mode. Routine understood development actions run directly. Each unresolved action receives one narrow safety review based on the current user request and the exact pending action. A clear result authorizes only that action. A caution or unavailable review holds the action and returns advice to the agent without opening a permission prompt or ending the turn. See [Permissions](https://fx.sh/docs/configure-fx/permissions) for other modes and persistent rules.
 
 JSON and quiet requests stay noninteractive by default. Add `--prompt-permissions` to allow configured approval prompts when stdin is a TTY. Automatic safety review never opens that prompt. Prompt text is written to stderr, so JSON stdout stays parseable and quiet stdout stays empty. Piped or redirected stdin remains noninteractive and fails instead of waiting for approval.

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -4286,9 +4286,7 @@ fn processQueuedPromptLoop(
         preserved_tool_evidence = .none;
 
         if (deps.report_usage) |report_fn| {
-            if (completion.usage.input_tokens != null or completion.usage.output_tokens != null) {
-                report_fn(deps.ctx, completion.usage);
-            }
+            report_fn(deps.ctx, completion.usage);
         }
 
         if (disposition == .completed and completion.tool_calls.len > 0) {

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3136,6 +3136,22 @@ test "processQueuedPrompt emits submitted prompt token update before streamed ou
     try std.testing.expect(input_idx.? < text_idx.?);
 }
 
+test "processQueuedPrompt reports a settled completion without provider token usage" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{.{ .content = "done" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 1), hooks.usage_reports.items.len);
+    try std.testing.expect(hooks.usage_reports.items[0].input_tokens == null);
+    try std.testing.expect(hooks.usage_reports.items[0].output_tokens == null);
+}
+
 test "processQueuedPrompt excludes assistant-authored subagent prompts from input progress" {
     const alloc = std.testing.allocator;
     const completions = [_]FakeCompletion{.{

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -490,6 +490,7 @@ pub const FakeAgentRuntimeDeps = struct {
     executed_names: std.ArrayList([]u8) = .empty,
     executed_call_ids: std.ArrayList([]u8) = .empty,
     rejected_names: std.ArrayList([]u8) = .empty,
+    usage_reports: std.ArrayList(types.Usage) = .empty,
     inner_usage_names: std.ArrayList([]u8) = .empty,
     inner_usages: std.ArrayList(types.ToolUsage) = .empty,
     validated_names: std.ArrayList([]u8) = .empty,
@@ -668,6 +669,7 @@ pub const FakeAgentRuntimeDeps = struct {
         freeStringList(self.alloc, &self.executed_names);
         freeStringList(self.alloc, &self.executed_call_ids);
         freeStringList(self.alloc, &self.rejected_names);
+        self.usage_reports.deinit(self.alloc);
         freeStringList(self.alloc, &self.inner_usage_names);
         self.inner_usages.deinit(self.alloc);
         freeStringList(self.alloc, &self.validated_names);
@@ -753,6 +755,7 @@ pub const FakeAgentRuntimeDeps = struct {
             .resolve_model_capabilities = resolveModelCapabilities,
             .format_tool_execution_error = formatError,
             .record_tool_call_rejected = recordRejected,
+            .report_usage = reportUsage,
             .report_inner_tool_usage = reportCapturedInnerToolUsage,
         };
     }
@@ -1451,6 +1454,11 @@ pub const FakeAgentRuntimeDeps = struct {
         const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
         self.inner_usage_names.append(self.alloc, self.alloc.dupe(u8, tool_name) catch return) catch return;
         self.inner_usages.append(self.alloc, usage) catch return;
+    }
+
+    fn reportUsage(raw: *anyopaque, usage: types.Usage) void {
+        const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
+        self.usage_reports.append(self.alloc, usage) catch return;
     }
 
     fn recordRejected(raw: *anyopaque, _: Allocator, call: ToolCall, _: []const u8, _: ?[]const u8) !void {

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -7427,10 +7427,11 @@ test "headless ask tracks turn usage while preserving latest session usage" {
     const report_fn = deps.report_usage orelse return error.TestExpectedEqual;
     report_fn(deps.ctx, .{ .input_tokens = 100, .output_tokens = 20 });
     report_fn(deps.ctx, .{ .input_tokens = 107, .output_tokens = 23 });
+    report_fn(deps.ctx, .{});
 
     try std.testing.expectEqual(@as(u64, 107), ctx.writable.?.state.total_input_tokens);
     try std.testing.expectEqual(@as(u64, 23), ctx.writable.?.state.total_output_tokens);
-    try std.testing.expectEqual(@as(u64, 2), ctx.usage_requests);
+    try std.testing.expectEqual(@as(u64, 3), ctx.usage_requests);
     try std.testing.expectEqual(@as(u64, 207), ctx.usage_input_tokens);
     try std.testing.expectEqual(@as(u64, 43), ctx.usage_output_tokens);
     var failed = try takeFailedPromptRunResult(
@@ -7444,7 +7445,7 @@ test "headless ask tracks turn usage while preserving latest session usage" {
         "NonInteractivePermissionRequired",
         failed.error_code.?,
     );
-    try std.testing.expectEqual(@as(u64, 2), failed.usage_requests);
+    try std.testing.expectEqual(@as(u64, 3), failed.usage_requests);
     try std.testing.expectEqual(@as(u64, 207), failed.usage_input_tokens);
     try std.testing.expectEqual(@as(u64, 43), failed.usage_output_tokens);
 }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -3610,13 +3610,11 @@ fn renderFinalJsonResult(alloc: Allocator, result: PromptRunResult) ![]u8 {
 }
 
 fn renderErrorJsonResult(alloc: Allocator, err_name: []const u8) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    errdefer out.deinit();
-
-    try out.writer.writeAll("{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":");
-    try std.json.Stringify.value(err_name, .{}, &out.writer);
-    try out.writer.writeAll("}\n");
-    return try out.toOwnedSlice();
+    return renderFinalJsonResult(alloc, .{
+        .exit_code = 1,
+        .assistant_output = &.{},
+        .error_code = err_name,
+    });
 }
 
 fn toCoreReasoningEffort(effort: types.ReasoningEffort) types.ReasoningEffort {
@@ -5205,14 +5203,14 @@ test "stdin prompt errors keep exact structured names" {
     const overflow = try renderErrorJsonResult(alloc, "PromptResourceLimitExceeded");
     defer alloc.free(overflow);
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptResourceLimitExceeded\"}\n",
+        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[],\"error\":\"PromptResourceLimitExceeded\"}\n",
         overflow,
     );
 
     const read_failure = try renderErrorJsonResult(alloc, "PromptInputReadFailed");
     defer alloc.free(read_failure);
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
+        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
         read_failure,
     );
 }
@@ -5229,7 +5227,7 @@ test "image preparation failure has stable text and JSON contracts" {
     const json = try renderErrorJsonResult(alloc, @errorName(error.ImagePreparationFailed));
     defer alloc.free(json);
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"ImagePreparationFailed\"}\n",
+        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[],\"error\":\"ImagePreparationFailed\"}\n",
         json,
     );
 }
@@ -5260,7 +5258,7 @@ test "stdin read failure has distinct text and JSON output contracts" {
         try runWithDeps(alloc, &.{"--json"}, testConfig(), deps),
     );
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
+        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
         stdout_capture.bytes.items,
     );
     try std.testing.expectEqualStrings("", stderr_capture.bytes.items);
@@ -7448,6 +7446,14 @@ test "headless ask tracks turn usage while preserving latest session usage" {
     try std.testing.expectEqual(@as(u64, 3), failed.usage_requests);
     try std.testing.expectEqual(@as(u64, 207), failed.usage_input_tokens);
     try std.testing.expectEqual(@as(u64, 43), failed.usage_output_tokens);
+
+    ctx.usage_requests = std.math.maxInt(u64);
+    ctx.usage_input_tokens = std.math.maxInt(u64);
+    ctx.usage_output_tokens = std.math.maxInt(u64);
+    report_fn(deps.ctx, .{ .input_tokens = 1, .output_tokens = 1 });
+    try std.testing.expectEqual(std.math.maxInt(u64), ctx.usage_requests);
+    try std.testing.expectEqual(std.math.maxInt(u64), ctx.usage_input_tokens);
+    try std.testing.expectEqual(std.math.maxInt(u64), ctx.usage_output_tokens);
 }
 
 test "saved ask settles profile publication before persistence teardown" {
@@ -8914,8 +8920,8 @@ test "default fx ask preserves project context gathering error mappings" {
         json: ?[]const u8,
     }{
         .{ .err = error.OutOfMemory, .json = null },
-        .{ .err = error.NoSpaceLeft, .json = "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"NoSpaceLeft\"}\n" },
-        .{ .err = error.WriteFailed, .json = "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"WriteFailed\"}\n" },
+        .{ .err = error.NoSpaceLeft, .json = "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[],\"error\":\"NoSpaceLeft\"}\n" },
+        .{ .err = error.WriteFailed, .json = "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[],\"error\":\"WriteFailed\"}\n" },
     };
 
     for (cases) |case| {

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -292,6 +292,9 @@ pub const PromptRunResult = struct {
     session_id: []u8 = &.{},
     tool_calls: []ToolCallRecord = &.{},
     step_count: usize = 0,
+    usage_requests: u64 = 0,
+    usage_input_tokens: u64 = 0,
+    usage_output_tokens: u64 = 0,
     error_code: ?[]const u8 = null,
     auth_failure: ?auth_runtime.FailureSnapshot = null,
     recovery: ?types.RouteRecoveryStatus = null,
@@ -536,6 +539,11 @@ const AskContext = struct {
     store: ?session_store.Store = null,
     writable: ?session_store.LoadedWritableSession = null,
     session_write_mutex: std.Io.Mutex = .init,
+    /// Cumulative provider-settled usage across this turn's model requests.
+    /// Inputs sum each request's full prompt, matching per-request billing.
+    usage_requests: u64 = 0,
+    usage_input_tokens: u64 = 0,
+    usage_output_tokens: u64 = 0,
     requested_resume: ?ResumeTarget = null,
     seed_model: []const u8 = "",
     command_timeout_ms: ?usize = null,
@@ -1753,24 +1761,14 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         else
             null,
     }, job) catch |err| switch (err) {
-        error.NonInteractivePermissionRequired => {
-            const assistant_output = try alloc.dupe(u8, ctx.assistant_output.items);
-            errdefer alloc.free(assistant_output);
-            const tool_calls = try takeToolCallRecords(&ctx, alloc);
-            return .{
-                .exit_code = 1,
-                .assistant_output = assistant_output,
-                .interrupted = ctx.processInterruptRequested(),
-                .tool_calls = tool_calls,
-                .error_code = "NonInteractivePermissionRequired",
-            };
-        },
+        error.NonInteractivePermissionRequired => return takeFailedPromptRunResult(
+            &ctx,
+            alloc,
+            "NonInteractivePermissionRequired",
+        ),
         else => {
             if (!options.output_mode.capturesJson()) return err;
-            var failed_result = try takePromptRunResult(&ctx, alloc);
-            failed_result.exit_code = 1;
-            failed_result.error_code = @errorName(err);
-            return failed_result;
+            return takeFailedPromptRunResult(&ctx, alloc, @errorName(err));
         },
     };
     worker_events_drained = true;
@@ -1802,11 +1800,24 @@ fn takePromptRunResult(ctx: *AskContext, alloc: Allocator) !PromptRunResult {
         .session_id = session_id,
         .tool_calls = tool_calls,
         .step_count = ctx.step_count,
+        .usage_requests = ctx.usage_requests,
+        .usage_input_tokens = ctx.usage_input_tokens,
+        .usage_output_tokens = ctx.usage_output_tokens,
         .error_code = ctx.typed_error_code,
         .auth_failure = ctx.auth_failure,
         .recovery = ctx.last_recovery_status,
         .recovery_durable = ctx.writable != null,
     };
+}
+fn takeFailedPromptRunResult(
+    ctx: *AskContext,
+    alloc: Allocator,
+    error_code: []const u8,
+) !PromptRunResult {
+    var result = try takePromptRunResult(ctx, alloc);
+    result.exit_code = 1;
+    result.error_code = error_code;
+    return result;
 }
 
 fn takeToolCallRecords(ctx: *AskContext, alloc: Allocator) ![]ToolCallRecord {
@@ -1989,13 +2000,17 @@ fn persistUsageCheckpoint(
     );
 }
 
-/// Overwrite session totals with the latest completion usage (same semantics as
-/// interactive `agentReportUsage`). Gateway `input_tokens` is full-prompt
-/// occupancy, not a delta, so overwrite rather than accumulate.
+/// Session totals are overwritten with the latest completion usage (same
+/// semantics as interactive `agentReportUsage`): gateway `input_tokens` is
+/// full-prompt occupancy, not a delta. The turn accumulators sum every
+/// settled request instead, matching how per-request billing adds up.
 fn reportUsage(raw_ctx: *anyopaque, usage: types.Usage) void {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
     ctx.session_write_mutex.lockUncancelable(io_mod.getIo());
     defer ctx.session_write_mutex.unlock(io_mod.getIo());
+    ctx.usage_requests +|= 1;
+    if (usage.input_tokens) |input| ctx.usage_input_tokens +|= input;
+    if (usage.output_tokens) |output| ctx.usage_output_tokens +|= output;
     const writable = if (ctx.writable) |*value| value else return;
     if (usage.input_tokens) |input| writable.state.total_input_tokens = input;
     if (usage.output_tokens) |output| writable.state.total_output_tokens = output;
@@ -3515,6 +3530,10 @@ fn renderFinalJsonResult(alloc: Allocator, result: PromptRunResult) ![]u8 {
     try out.writer.writeAll(",\"session_id\":");
     try std.json.Stringify.value(result.session_id, .{}, &out.writer);
     try out.writer.print(",\"steps\":{d}", .{result.step_count});
+    try out.writer.print(
+        ",\"usage\":{{\"requests\":{d},\"input_tokens\":{d},\"output_tokens\":{d}}}",
+        .{ result.usage_requests, result.usage_input_tokens, result.usage_output_tokens },
+    );
     try out.writer.writeAll(",\"tool_calls\":[");
     for (result.tool_calls, 0..) |tc, i| {
         if (i > 0) try out.writer.writeAll(",");
@@ -7379,7 +7398,7 @@ test "saved ask initializes subagent host and background persistence" {
     try std.testing.expectEqualStrings(workspace, sessions.items[0].workspace_root.?);
 }
 
-test "headless ask overwrites session usage from latest completion" {
+test "headless ask tracks turn usage while preserving latest session usage" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -7411,6 +7430,23 @@ test "headless ask overwrites session usage from latest completion" {
 
     try std.testing.expectEqual(@as(u64, 107), ctx.writable.?.state.total_input_tokens);
     try std.testing.expectEqual(@as(u64, 23), ctx.writable.?.state.total_output_tokens);
+    try std.testing.expectEqual(@as(u64, 2), ctx.usage_requests);
+    try std.testing.expectEqual(@as(u64, 207), ctx.usage_input_tokens);
+    try std.testing.expectEqual(@as(u64, 43), ctx.usage_output_tokens);
+    var failed = try takeFailedPromptRunResult(
+        &ctx,
+        alloc,
+        "NonInteractivePermissionRequired",
+    );
+    defer failed.deinit(alloc);
+    try std.testing.expectEqual(@as(u8, 1), failed.exit_code);
+    try std.testing.expectEqualStrings(
+        "NonInteractivePermissionRequired",
+        failed.error_code.?,
+    );
+    try std.testing.expectEqual(@as(u64, 2), failed.usage_requests);
+    try std.testing.expectEqual(@as(u64, 207), failed.usage_input_tokens);
+    try std.testing.expectEqual(@as(u64, 43), failed.usage_output_tokens);
 }
 
 test "saved ask settles profile publication before persistence teardown" {
@@ -7915,6 +7951,9 @@ test "render final JSON preserves shape escaping order and newline" {
         .session_id = try alloc.dupe(u8, "123"),
         .tool_calls = tool_calls,
         .step_count = 2,
+        .usage_requests = 3,
+        .usage_input_tokens = 1200,
+        .usage_output_tokens = 450,
     };
     defer result.deinit(alloc);
 
@@ -7922,7 +7961,7 @@ test "render final JSON preserves shape escaping order and newline" {
     defer alloc.free(json);
 
     try std.testing.expectEqualStrings(
-        "{\"output\":\"hello \\\"zig\\\"\\n\",\"exit_code\":0,\"model\":\"model-x\",\"session_id\":\"123\",\"steps\":2,\"tool_calls\":[{\"name\":\"read_file\",\"status\":\"success\"}]}\n",
+        "{\"output\":\"hello \\\"zig\\\"\\n\",\"exit_code\":0,\"model\":\"model-x\",\"session_id\":\"123\",\"steps\":2,\"usage\":{\"requests\":3,\"input_tokens\":1200,\"output_tokens\":450},\"tool_calls\":[{\"name\":\"read_file\",\"status\":\"success\"}]}\n",
         json,
     );
 }
@@ -7939,7 +7978,7 @@ test "render final JSON emits empty tool call array" {
     defer alloc.free(json);
 
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[]}\n",
+        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[]}\n",
         json,
     );
 }
@@ -8666,7 +8705,7 @@ test "json run with missing API key prints diagnostic then final object" {
     try std.testing.expectEqual(@as(u8, 1), exit_code);
     try std.testing.expectEqualStrings("fx ask: " ++ credentials.missing_credential_message ++ "\n", stderr_capture.bytes.items);
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"MissingCredentials\"}\n",
+        "{\"output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[],\"error\":\"MissingCredentials\"}\n",
         stdout_capture.bytes.items,
     );
 }
@@ -8929,7 +8968,7 @@ test "quiet suppresses streaming while quiet json captures final output" {
     const json_exit = try runWithDeps(alloc, &.{ "--quiet", "--json", "hello" }, testConfig(), testPromptRunDeps(&stdout_capture, &stderr_capture, testPresentKeyStartup));
     try std.testing.expectEqual(@as(u8, 0), json_exit);
     try std.testing.expect(std.mem.startsWith(u8, stdout_capture.bytes.items, "{\"output\":\"assistant text\",\"exit_code\":0,\"model\":\"model\",\"session_id\":\""));
-    try std.testing.expect(std.mem.endsWith(u8, stdout_capture.bytes.items, "\",\"steps\":0,\"tool_calls\":[]}\n"));
+    try std.testing.expect(std.mem.endsWith(u8, stdout_capture.bytes.items, "\",\"steps\":0,\"usage\":{\"requests\":0,\"input_tokens\":0,\"output_tokens\":0},\"tool_calls\":[]}\n"));
     try std.testing.expectEqualStrings("", stderr_capture.bytes.items);
 }
 

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -3924,9 +3924,15 @@ describe("cli: ask success", () => {
 
         expect(result.code).toBe(0);
         expect(result.stderr).toBe("");
-        expect(JSON.parse(result.stdout).output.trim()).toBe(
+        const json = JSON.parse(result.stdout);
+        expect(json.output.trim()).toBe(
           "explicit skill ask complete",
         );
+        expect(json.usage).toEqual({
+          requests: 1,
+          input_tokens: 3,
+          output_tokens: 5,
+        });
         expect(gateway.requests).toHaveLength(1);
         expect(gateway.modelRequests).toHaveLength(0);
         expect(gateway.requests[0]!.body).toContain(
@@ -4022,7 +4028,7 @@ describe("cli: ask success", () => {
       expect(jsonResult.code).toBe(1);
       expect(jsonResult.stderr).toBe("");
       expect(jsonResult.stdout).toBe(
-        '{"output":"","exit_code":1,"model":"","session_id":"","steps":0,"tool_calls":[],"error":"PromptResourceLimitExceeded"}\n',
+        '{"output":"","exit_code":1,"model":"","session_id":"","steps":0,"usage":{"requests":0,"input_tokens":0,"output_tokens":0},"tool_calls":[],"error":"PromptResourceLimitExceeded"}\n',
       );
     },
     120_000,

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -141,6 +141,14 @@ function sse(body: string): Response {
   });
 }
 
+function successfulResponseWithoutUsage(text: string): Response {
+  return sse(
+    `data: ${JSON.stringify({ type: "text-delta", id: "answer", delta: text })}\n\n` +
+      'data: {"type":"finish","finishReason":{"unified":"stop","raw":"stop"}}\n\n' +
+      "data: [DONE]\n\n",
+  );
+}
+
 function startGateway(
   response: () => Response,
   classifierDecision: "clear" | "caution" = "clear",
@@ -278,6 +286,11 @@ function parseAskJson(stdout: string): {
   exit_code: number;
   error?: string;
   session_id: string;
+  usage: {
+    requests: number;
+    input_tokens: number;
+    output_tokens: number;
+  };
   tool_calls: Array<{ name: string; status: string }>;
   recovery?: {
     state: string;
@@ -755,6 +768,39 @@ describe("gateway stream lifecycle", () => {
       expect(gateway.requests[0]!.body).not.toContain(
         "Continue from the latest meaningful state",
       );
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("no-save ask counts a settled response without provider token usage", async () => {
+    const root = createFixtureRoot("ask-null-usage");
+    const tracePath = join(root.root, "trace.log");
+    const gateway = startGateway(() =>
+      successfulResponseWithoutUsage("NULL_USAGE_ASK_COMPLETE")
+    );
+
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Return the fixture response."],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          timeoutMs: 30_000,
+        },
+      );
+      const json = parseAskJson(result.stdout);
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(json.output).toContain("NULL_USAGE_ASK_COMPLETE");
+      expect(json.usage).toEqual({
+        requests: 1,
+        input_tokens: 0,
+        output_tokens: 0,
+      });
+      expect(gateway.requests).toHaveLength(1);
     } finally {
       gateway.stop();
       rmSync(root.root, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

`fx ask --json` drops completion token usage. With `--no-save`, that information cannot be recovered later.

## Change

- add a stable `usage` object to final JSON results: `requests`, `input_tokens`, and `output_tokens`
- sum every settled main-agent completion in the turn; input tokens remain full-prompt occupancy per request, matching provider billing
- count settled completions without token totals as one request with zero tokens
- preserve the existing saved-session behavior, which records the latest completion in session state
- carry settled totals through typed error results, including non-interactive permission failures
- render preflight and startup errors through the same result schema with zero usage

Scope is intentionally narrow: nested tool/provider usage and asynchronously reconciled spend are not represented by these fields. This PR exposes the completion usage already available on the main agent loop and leaves #279 open for those residuals.

## Verification

Exact head: `3fd1f978609a82090ef6091e5685828570a5a574`  
Base: `v0.0.6` (`79666393e5f613c85f2f0b4b65475f1addd55379`)

- `zig fmt --check src/`: passed
- `scripts/check-public-surface.sh`: passed
- cumulative/latest/error/saturation focused Zig tests: 16 passed
- settled completion without token usage focused Zig tests: 14 passed
- final JSON and preflight-error schema focused Zig tests: 13 passed each
- focused CLI and lifecycle E2E cases: 3 passed; covered nonzero usage, null token totals, zero-usage preflight errors, and empty stderr
- native build: passed
- built `./zig-out/bin/fx ask --json --no-save` fake-Gateway smoke: exact `usage` was `{ "requests": 1, "input_tokens": 3, "output_tokens": 5 }`, exit 0, stderr empty
- current `origin/main` merge simulation: clean

Addresses #279.

Full CI passed all four platform aggregates on the exact head: https://github.com/alphastorm/fx/actions/runs/32898616967

Final ship gate: SHIP for `3fd1f978609a82090ef6091e5685828570a5a574`.