### PR TITLE
Reduce macOS arm64 PGSO candidate size

### DIFF
--- a/scripts/pgso/pipeline.py
+++ b/scripts/pgso/pipeline.py
@@ -41,6 +41,10 @@ BENCHMARK_USE_FLAGS = (
     "-passes=default<O2>,mergefunc,iroutliner",
 )
 
+FX_MACHINE_OUTLINER_FLAGS = (
+    "-machine-outliner-reruns=1",
+)
+
 CANDIDATE_SIGNING_PAGE_SIZE = 16 * 1024
 
 PROFILE_SECTION_ALIGNMENTS = (
@@ -370,6 +374,24 @@ def candidate_link_argv(
         "-o",
         str(paths.candidate_binary),
         "-lc",
+    )
+
+
+def candidate_object_argv(
+    toolchain: Toolchain,
+    paths: PipelinePaths,
+) -> tuple[str, ...]:
+    # A second AArch64 outliner pass can fold sequences exposed by the first.
+    # Keep benchmark artifacts on their established code-generation contract.
+    outliner_flags = FX_MACHINE_OUTLINER_FLAGS if paths.selector == "fx" else ()
+    return (
+        str(toolchain.llc),
+        "-filetype=obj",
+        "-O=2",
+        *outliner_flags,
+        str(paths.profile_use_bitcode),
+        "-o",
+        str(paths.profile_use_object),
     )
 
 
@@ -777,14 +799,7 @@ def link_candidate(
         verify_release_safe_ir(paths.profile_use_ir)
 
     run_checked(
-        (
-            str(toolchain.llc),
-            "-filetype=obj",
-            "-O=2",
-            str(paths.profile_use_bitcode),
-            "-o",
-            str(paths.profile_use_object),
-        ),
+        candidate_object_argv(toolchain, paths),
         cwd=paths.root,
         env=os.environ.copy(),
         timeout_s=900,

--- a/scripts/pgso/tests/test_pipeline.py
+++ b/scripts/pgso/tests/test_pipeline.py
@@ -9,6 +9,7 @@ import unittest
 from scripts.pgso.model import PgsoError, sha256_file
 from scripts.pgso.pipeline import (
     BENCHMARK_USE_FLAGS,
+    FX_MACHINE_OUTLINER_FLAGS,
     GENERATION_FLAGS,
     PROFILE_SECTION_ALIGNMENTS,
     USE_FLAGS,
@@ -16,6 +17,7 @@ from scripts.pgso.pipeline import (
     CandidateMetadata,
     PipelinePaths,
     apply_profile,
+    candidate_object_argv,
     candidate_link_argv,
     instrumentation_argv,
     instrumented_run_argv,
@@ -118,6 +120,12 @@ class PgsoPipelineTests(unittest.TestCase):
                 "-passes=default<O2>,mergefunc,iroutliner",
             ),
             BENCHMARK_USE_FLAGS,
+        )
+        self.assertEqual(
+            (
+                "-machine-outliner-reruns=1",
+            ),
+            FX_MACHINE_OUTLINER_FLAGS,
         )
         self.assertEqual(
             (
@@ -251,6 +259,12 @@ class PgsoPipelineTests(unittest.TestCase):
             "13.0",
         )
         candidate = candidate_link_argv(self.toolchain, self.paths)
+        candidate_object = candidate_object_argv(self.toolchain, self.paths)
+        benchmark_paths = PipelinePaths.create(
+            self.root / "benchmark-run",
+            selector="file_index",
+        )
+        benchmark_object = candidate_object_argv(self.toolchain, benchmark_paths)
 
         for alignment in PROFILE_SECTION_ALIGNMENTS:
             self.assertIn(alignment, instrumented)
@@ -273,6 +287,9 @@ class PgsoPipelineTests(unittest.TestCase):
             ),
             candidate,
         )
+        for flag in FX_MACHINE_OUTLINER_FLAGS:
+            self.assertIn(flag, candidate_object)
+            self.assertNotIn(flag, benchmark_object)
 
     def test_candidate_object_and_signing_contract(self) -> None:
         actions = self.root / "candidate-actions.txt"
@@ -319,6 +336,7 @@ with pathlib.Path({str(actions)!r}).open('a') as stream:
                 f"{self.paths.profile_use_bitcode} -o "
                 f"{self.paths.profile_use_ir}",
                 "artifact -filetype=obj -O=2 "
+                "-machine-outliner-reruns=1 "
                 f"{self.paths.profile_use_bitcode} -o "
                 f"{self.paths.profile_use_object}",
                 "artifact cc -target aarch64-macos -O2 -Wl,-dead_strip -s "


### PR DESCRIPTION
## Summary

- Run one additional profile-aware AArch64 machine-outliner pass for production fx candidates.
- Keep benchmark artifacts on their existing code-generation path.