### PR TITLE
Add code block copy to Ctrl-O

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands.
 
+Press `Ctrl-O` to review the transcript. Completed code blocks with boxed headers show `Copy` in the top-right; click it to copy the code and return to the inline view.
+
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 
 ```json

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -89,6 +89,39 @@ const FrameAttemptResult = struct {
     }
 };
 
+fn publishCodeCopyFrameForAttempt(
+    alloc: std.mem.Allocator,
+    runtime: *transcript_runtime.TranscriptRuntime,
+    candidate: *full_transcript_screen.CodeCopyInteractionFrame,
+    committed: bool,
+) void {
+    if (!committed) return;
+    runtime.commitCodeCopyFrame(alloc, candidate);
+}
+
+test "code copy targets publish only for a committed frame" {
+    const alloc = std.testing.allocator;
+    var runtime = transcript_runtime.TranscriptRuntime{};
+    defer runtime.deinit(alloc);
+
+    var candidate = full_transcript_screen.CodeCopyInteractionFrame{};
+    defer candidate.deinit(alloc);
+    try candidate.targets.append(alloc, .{
+        .entry_id = 41,
+        .row = 3,
+        .first_col = 72,
+        .last_col = 75,
+    });
+
+    publishCodeCopyFrameForAttempt(alloc, &runtime, &candidate, false);
+    try std.testing.expectEqual(@as(?u32, null), runtime.codeCopyHit(3, 72));
+    try std.testing.expectEqual(@as(usize, 1), candidate.targets.items.len);
+
+    publishCodeCopyFrameForAttempt(alloc, &runtime, &candidate, true);
+    try std.testing.expectEqual(@as(?u32, 41), runtime.codeCopyHit(3, 72));
+    try std.testing.expectEqual(@as(usize, 0), candidate.targets.items.len);
+}
+
 const InlineRenderReconciliation = struct {
     alternate_screen_owns_rendering: bool = false,
     terminal_transition: render_engine.terminal_diff.FrameTerminalTransition = .none,
@@ -1689,6 +1722,8 @@ pub fn Runtime(comptime App: type) type {
             defer if (owned_transcript_source) |*source| source.deinit(app.alloc);
             var transcript_source: ?*transcript_runtime.TranscriptPreparationSource = null;
             var full_transcript_projection: ?*full_transcript_screen.Projection = null;
+            var staged_code_copy_frame: ?full_transcript_screen.CodeCopyInteractionFrame = null;
+            defer if (staged_code_copy_frame) |*frame| frame.deinit(app.alloc);
             var transcript_transition: ?transcript_runtime.TranscriptTransition = null;
             defer if (transcript_transition) |*transition| transition.deinit(app.alloc);
             var footer_measurement: ?surface_frame.SurfaceFooterMeasurement = null;
@@ -1976,7 +2011,7 @@ pub fn Runtime(comptime App: type) type {
                             app.fullTranscriptSidecarCapability()
                         else
                             null;
-                        const staged = try presentation_shell.prepareFullTranscriptSurfacePaintInterruptible(
+                        var staged = try presentation_shell.prepareFullTranscriptSurfacePaintInterruptible(
                             app.alloc,
                             &app.metrics,
                             projection,
@@ -1987,6 +2022,8 @@ pub fn Runtime(comptime App: type) type {
                         owned_transcript_source = staged.source;
                         transcript_source = &owned_transcript_source.?;
                         prepared_transcript = staged.prepared;
+                        staged_code_copy_frame = staged.code_copy_frame;
+                        staged.code_copy_frame = .{};
                         footer_frame.paint.viewport = prepared_transcript.?.selection;
                         try validatePreparedTranscriptFitsPlan(&prepared_transcript.?, footer_frame.paint);
                     }
@@ -2180,6 +2217,14 @@ pub fn Runtime(comptime App: type) type {
                 if (!render_requests.hasReason(.external_damage)) {
                     presentation_shell.footer_viewport.clearExternalInvalidation();
                 }
+            }
+            if (staged_code_copy_frame) |*candidate| {
+                publishCodeCopyFrameForAttempt(
+                    app.alloc,
+                    presentation_shell,
+                    candidate,
+                    result.is_committed(),
+                );
             }
             if (result.is_committed() and child_view != null) {
                 if (presentation_shell.resolvedTailViewport()) |viewport| {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -99,29 +99,6 @@ fn publishCodeCopyFrameForAttempt(
     runtime.commitCodeCopyFrame(alloc, candidate);
 }
 
-test "code copy targets publish only for a committed frame" {
-    const alloc = std.testing.allocator;
-    var runtime = transcript_runtime.TranscriptRuntime{};
-    defer runtime.deinit(alloc);
-
-    var candidate = full_transcript_screen.CodeCopyInteractionFrame{};
-    defer candidate.deinit(alloc);
-    try candidate.targets.append(alloc, .{
-        .entry_id = 41,
-        .row = 3,
-        .first_col = 72,
-        .last_col = 75,
-    });
-
-    publishCodeCopyFrameForAttempt(alloc, &runtime, &candidate, false);
-    try std.testing.expectEqual(@as(?u32, null), runtime.codeCopyHit(3, 72));
-    try std.testing.expectEqual(@as(usize, 1), candidate.targets.items.len);
-
-    publishCodeCopyFrameForAttempt(alloc, &runtime, &candidate, true);
-    try std.testing.expectEqual(@as(?u32, 41), runtime.codeCopyHit(3, 72));
-    try std.testing.expectEqual(@as(usize, 0), candidate.targets.items.len);
-}
-
 const InlineRenderReconciliation = struct {
     alternate_screen_owns_rendering: bool = false,
     terminal_transition: render_engine.terminal_diff.FrameTerminalTransition = .none,
@@ -3672,6 +3649,29 @@ fn solveFixedPointForTest(
         FixedPointTestContext.prepareCandidate,
         FixedPointTestContext.resolveCandidate,
     );
+}
+
+test "code copy targets publish only for a committed frame" {
+    const alloc = std.testing.allocator;
+    var runtime = transcript_runtime.TranscriptRuntime{};
+    defer runtime.deinit(alloc);
+
+    var candidate = full_transcript_screen.CodeCopyInteractionFrame{};
+    defer candidate.deinit(alloc);
+    try candidate.targets.append(alloc, .{
+        .entry_id = 41,
+        .row = 3,
+        .first_col = 72,
+        .last_col = 75,
+    });
+
+    publishCodeCopyFrameForAttempt(alloc, &runtime, &candidate, false);
+    try std.testing.expectEqual(@as(?u32, null), runtime.codeCopyHit(3, 72));
+    try std.testing.expectEqual(@as(usize, 1), candidate.targets.items.len);
+
+    publishCodeCopyFrameForAttempt(alloc, &runtime, &candidate, true);
+    try std.testing.expectEqual(@as(?u32, 41), runtime.codeCopyHit(3, 72));
+    try std.testing.expectEqual(@as(usize, 0), candidate.targets.items.len);
 }
 
 test "assistant tail writability changes remain traceable" {

--- a/src/core/app/input_full_transcript_runtime.zig
+++ b/src/core/app/input_full_transcript_runtime.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const host = @import("../hosts/host.zig");
 const runtime_profile = @import("../hosts/runtime_profile.zig");
 const app_lifecycle = @import("app_lifecycle.zig");
 const app_render_runtime = @import("app_render_runtime.zig");
@@ -10,6 +11,8 @@ const interaction_state = @import("../../ui/footer/interaction_state.zig");
 const approval_prompt = @import("../permissions/approval_prompt.zig");
 const subagent_runtime = @import("../../ui/subagent/runtime.zig");
 const shell_runtime = @import("../../ui/shell_runtime.zig");
+const full_transcript_screen = @import("../../ui/full_transcript_screen.zig");
+const render_request = @import("../../ui/render_request.zig");
 const transcript_runtime = @import("../../ui/transcript/runtime.zig");
 
 pub fn Runtime(comptime App: type) type {
@@ -23,6 +26,7 @@ pub fn Runtime(comptime App: type) type {
             redraw,
             wheel_scroll: input_action.MouseWheel,
             page_scroll: input_action.MouseWheel,
+            pointer: input_action.MousePointer,
         };
 
         fn requestActiveSurfaceFrame(app: *App) void {
@@ -197,6 +201,7 @@ pub fn Runtime(comptime App: type) type {
                 .cursor_right => .{ .navigate = .right },
                 .escape => .close,
                 .mouse_wheel => |direction| .{ .wheel_scroll = direction },
+                .mouse_pointer => |pointer| .{ .pointer = pointer },
                 .page_up => .{ .page_scroll = .up },
                 .page_down => .{ .page_scroll = .down },
                 .composer_shortcut => |shortcut| switch (shortcut) {
@@ -247,7 +252,63 @@ pub fn Runtime(comptime App: type) type {
                     }
                     requestActiveSurfaceFrame(app);
                 },
+                .pointer => |pointer| try routeCodeCopyPointer(app, pointer),
             }
+        }
+
+        fn routeCodeCopyPointer(
+            app: *App,
+            pointer: input_action.MousePointer,
+        ) !void {
+            if (pointer.kind != .press or pointer.shift or pointer.alt or pointer.ctrl) return;
+            if (childRouteActive(app)) {
+                const child = childPresentationShell(app) orelse return;
+                return activateCodeCopyPointer(app, child, pointer);
+            }
+            if (comptime @hasDecl(@TypeOf(app.shell), "codeCopyHit") and
+                @hasDecl(@TypeOf(app.shell), "assistantCodeBlockSource"))
+            {
+                return activateCodeCopyPointer(app, &app.shell, pointer);
+            }
+        }
+
+        fn activateCodeCopyPointer(
+            app: *App,
+            active_shell: anytype,
+            pointer: input_action.MousePointer,
+        ) !void {
+            const entry_id = active_shell.codeCopyHit(
+                pointer.row,
+                pointer.column,
+            ) orelse return;
+            const code = active_shell.assistantCodeBlockSource(entry_id) orelse {
+                debug_trace.logf(
+                    "full_transcript",
+                    "code_copy_target_stale entry_id={d}",
+                    .{entry_id},
+                );
+                return;
+            };
+            const copied = if (comptime @hasDecl(App, "clipboard"))
+                app.clipboard().copy(code) catch |err| failed: {
+                    debug_trace.logf(
+                        "full_transcript",
+                        "code_copy_failed entry_id={d} err={s}",
+                        .{ entry_id, @errorName(err) },
+                    );
+                    break :failed false;
+                }
+            else
+                false;
+
+            try closeScreen(app, .code_copy);
+            if (copied) return;
+            _ = try active_shell.appendSemanticNotice(app.alloc, .{
+                .topic = "clipboard",
+                .tone = .@"error",
+                .body = "Failed to copy code block to clipboard.",
+            });
+            requestActiveSurfaceFrame(app);
         }
 
         fn childPresentationShell(
@@ -315,7 +376,7 @@ pub fn Runtime(comptime App: type) type {
         }
 
         const TransitionRoute = enum { root, child };
-        const TransitionTrigger = enum { ctrl_o, left, right, escape, ctrl_c };
+        const TransitionTrigger = enum { ctrl_o, left, right, escape, ctrl_c, code_copy };
 
         fn triggerForEvent(
             event: transcript_presentation.Event,
@@ -473,4 +534,269 @@ test "approval for another child does not steal selected child transcript input"
 
     app.subagents.approval_child_id = "child-one";
     try std.testing.expect(Runtime(ApprovalRoutingApp).approvalOwnsCurrentSurface(&app));
+}
+
+const CodeCopyTestClipboard = struct {
+    succeed: bool = true,
+    copied: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *CodeCopyTestClipboard, alloc: std.mem.Allocator) void {
+        self.copied.deinit(alloc);
+    }
+
+    fn clipboard(self: *CodeCopyTestClipboard) host.Clipboard {
+        return .{ .context = self, .copy_fn = copy };
+    }
+
+    fn copy(raw_context: ?*anyopaque, bytes: []const u8) host.ClipboardError!bool {
+        const self: *CodeCopyTestClipboard = @ptrCast(@alignCast(raw_context.?));
+        self.copied.clearRetainingCapacity();
+        self.copied.appendSlice(std.testing.allocator, bytes) catch return error.CopyFailed;
+        return self.succeed;
+    }
+};
+
+const CodeCopyRoutingSubagents = struct {
+    active: bool = false,
+    child: transcript_runtime.TranscriptRuntime = .{},
+
+    fn deinit(self: *CodeCopyRoutingSubagents, alloc: std.mem.Allocator) void {
+        self.child.deinit(alloc);
+    }
+
+    pub fn isViewActive(self: *const CodeCopyRoutingSubagents) bool {
+        return self.active;
+    }
+
+    pub fn childRouteId(self: *const CodeCopyRoutingSubagents) ?[]const u8 {
+        return if (self.active) "child-one" else null;
+    }
+
+    pub fn childConversationRuntime(
+        self: *CodeCopyRoutingSubagents,
+    ) ?*transcript_runtime.TranscriptRuntime {
+        return if (self.active) &self.child else null;
+    }
+
+    pub fn childFullTranscriptRequested(self: *const CodeCopyRoutingSubagents) bool {
+        return self.active and self.child.fullTranscriptActive();
+    }
+
+    pub fn childTranscriptPresentationDepth(
+        self: *const CodeCopyRoutingSubagents,
+    ) transcript_presentation.Depth {
+        return if (self.active)
+            self.child.transcriptPresentationDepth()
+        else
+            .inline_mode;
+    }
+
+    pub fn closeChildTranscriptPresentation(
+        self: *CodeCopyRoutingSubagents,
+        alloc: std.mem.Allocator,
+    ) !bool {
+        if (!self.active) return false;
+        return self.child.setTranscriptPresentationDepth(alloc, .inline_mode);
+    }
+
+    pub fn activeRenderRequests(
+        self: *CodeCopyRoutingSubagents,
+    ) *render_request.RenderRequestState {
+        return &self.child.render_requests;
+    }
+};
+
+const CodeCopyRoutingApp = struct {
+    alloc: std.mem.Allocator,
+    metrics: types.Metrics = .{},
+    approval_prompt: approval_prompt.ApprovalPrompt = .{},
+    terminal: shell_runtime.TerminalState = .{},
+    shell: transcript_runtime.TranscriptRuntime = .{},
+    subagents: CodeCopyRoutingSubagents = .{},
+    clipboard_state: CodeCopyTestClipboard = .{},
+
+    fn deinit(self: *CodeCopyRoutingApp) void {
+        self.clipboard_state.deinit(self.alloc);
+        self.subagents.deinit(self.alloc);
+        self.shell.deinit(self.alloc);
+        self.approval_prompt.deinit(self.alloc);
+    }
+
+    pub fn clipboard(self: *CodeCopyRoutingApp) host.Clipboard {
+        return self.clipboard_state.clipboard();
+    }
+};
+
+fn prepareCodeCopyRoute(
+    alloc: std.mem.Allocator,
+    runtime: *transcript_runtime.TranscriptRuntime,
+) !void {
+    runtime.layout = .{
+        .rows = 12,
+        .cols = 80,
+        .content_bottom = 8,
+        .divider_top_row = 9,
+        .input_row = 10,
+        .divider_bottom_row = 11,
+        .hint_row = 12,
+    };
+    runtime.owned_top_row = 1;
+    runtime.viewport_top_row = 1;
+    const language = try alloc.dupe(u8, "zig");
+    var owns_language = true;
+    errdefer if (owns_language) alloc.free(language);
+    const code = try alloc.dupe(u8, "const copied = true;\n");
+    var owns_code = true;
+    errdefer if (owns_code) alloc.free(code);
+    const entry_id = try runtime.appendAssistantCodeBlockOwned(alloc, .{
+        .language = language,
+        .code = code,
+    });
+    owns_language = false;
+    owns_code = false;
+    runtime.full_transcript = .{ .depth = .review };
+
+    var frame: full_transcript_screen.CodeCopyInteractionFrame = .{};
+    defer frame.deinit(alloc);
+    try frame.targets.append(alloc, .{
+        .entry_id = entry_id,
+        .row = 4,
+        .first_col = 70,
+        .last_col = 73,
+    });
+    runtime.commitCodeCopyFrame(alloc, &frame);
+}
+
+fn semanticNoticeCount(runtime: *const transcript_runtime.TranscriptRuntime) usize {
+    var count: usize = 0;
+    for (runtime.entries.items) |entry| {
+        if (entry == .semantic_notice) count += 1;
+    }
+    return count;
+}
+
+test "code copy closes and reports on the active transcript route" {
+    const alloc = std.testing.allocator;
+    const Route = enum { root, child };
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    for ([_]Route{ .root, .child }) |route| {
+        for ([_]bool{ true, false }) |copy_succeeds| {
+            const out_file = try tmp.dir.createFile(
+                @import("../shared/io.zig").getIo(),
+                "code-copy-route.out",
+                .{ .truncate = true },
+            );
+            var app = CodeCopyRoutingApp{ .alloc = alloc };
+            defer app.deinit();
+            app.shell.stdout_file = out_file;
+            defer app.shell.stdout_file.close(@import("../shared/io.zig").getIo());
+            app.clipboard_state.succeed = copy_succeeds;
+
+            const active = switch (route) {
+                .root => &app.shell,
+                .child => blk: {
+                    app.subagents.active = true;
+                    break :blk &app.subagents.child;
+                },
+            };
+            try prepareCodeCopyRoute(alloc, active);
+            if (route == .root) {
+                app.terminal.alternate_screen_owner = .full_transcript;
+            }
+
+            try std.testing.expect(try Runtime(CodeCopyRoutingApp).routeAction(
+                &app,
+                .{ .mouse_pointer = .{
+                    .kind = .press,
+                    .column = 71,
+                    .row = 4,
+                } },
+            ));
+
+            try std.testing.expectEqualStrings(
+                "const copied = true;\n",
+                app.clipboard_state.copied.items,
+            );
+            try std.testing.expectEqual(
+                transcript_presentation.Depth.inline_mode,
+                active.transcriptPresentationDepth(),
+            );
+            try std.testing.expectEqual(
+                @as(usize, @intFromBool(!copy_succeeds)),
+                semanticNoticeCount(active),
+            );
+            if (!copy_succeeds) {
+                const notice = active.entries.items[active.entries.items.len - 1].semantic_notice;
+                try std.testing.expectEqualStrings(
+                    "Failed to copy code block to clipboard.",
+                    notice.body,
+                );
+            }
+
+            const inactive = switch (route) {
+                .root => &app.subagents.child,
+                .child => &app.shell,
+            };
+            try std.testing.expectEqual(
+                transcript_presentation.Depth.inline_mode,
+                inactive.transcriptPresentationDepth(),
+            );
+            try std.testing.expectEqual(@as(usize, 0), semanticNoticeCount(inactive));
+        }
+    }
+}
+
+test "code copy ignores non-target and modified pointer actions" {
+    const alloc = std.testing.allocator;
+    var app = CodeCopyRoutingApp{ .alloc = alloc };
+    defer app.deinit();
+    app.subagents.active = true;
+    try prepareCodeCopyRoute(alloc, &app.subagents.child);
+
+    const pointers = [_]input_action.MousePointer{
+        .{ .kind = .press, .column = 69, .row = 4 },
+        .{ .kind = .press, .column = 74, .row = 4 },
+        .{ .kind = .press, .column = 71, .row = 5 },
+        .{ .kind = .drag, .column = 71, .row = 4 },
+        .{ .kind = .release, .column = 71, .row = 4 },
+        .{ .kind = .press, .column = 71, .row = 4, .shift = true },
+        .{ .kind = .press, .column = 71, .row = 4, .alt = true },
+        .{ .kind = .press, .column = 71, .row = 4, .ctrl = true },
+    };
+    for (pointers) |pointer| {
+        try std.testing.expect(try Runtime(CodeCopyRoutingApp).routeAction(
+            &app,
+            .{ .mouse_pointer = pointer },
+        ));
+        try std.testing.expectEqual(
+            transcript_presentation.Depth.review,
+            app.subagents.child.transcriptPresentationDepth(),
+        );
+        try std.testing.expectEqual(@as(usize, 0), app.clipboard_state.copied.items.len);
+    }
+
+    var stale_frame: full_transcript_screen.CodeCopyInteractionFrame = .{};
+    defer stale_frame.deinit(alloc);
+    try stale_frame.targets.append(alloc, .{
+        .entry_id = 999,
+        .row = 4,
+        .first_col = 70,
+        .last_col = 73,
+    });
+    app.subagents.child.commitCodeCopyFrame(alloc, &stale_frame);
+    try std.testing.expect(try Runtime(CodeCopyRoutingApp).routeAction(
+        &app,
+        .{ .mouse_pointer = .{
+            .kind = .press,
+            .column = 71,
+            .row = 4,
+        } },
+    ));
+    try std.testing.expectEqual(
+        transcript_presentation.Depth.review,
+        app.subagents.child.transcriptPresentationDepth(),
+    );
+    try std.testing.expectEqual(@as(usize, 0), app.clipboard_state.copied.items.len);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3911,6 +3911,7 @@ test {
     _ = @import("core/app/app_terminal_runtime.zig");
     _ = @import("tools/terminal/terminal.zig");
     _ = @import("core/app/input_approval_runtime.zig");
+    _ = @import("core/app/input_full_transcript_runtime.zig");
     _ = @import("acp/sessions.zig");
     _ = @import("core/tasks/task_helpers.zig");
     _ = @import("core/shared/text_utils.zig");

--- a/src/ui/full_transcript_screen.zig
+++ b/src/ui/full_transcript_screen.zig
@@ -561,6 +561,7 @@ pub const Projection = struct {
             self.item_boundaries.appendAssumeCapacity(.{
                 .entry_id = boundary.entry_id,
                 .segment_index = first_segment + boundary.segment_index,
+                .code_copy_span = boundary.code_copy_span,
             });
         }
         suffix.item_boundaries.items.len = 0;
@@ -580,7 +581,79 @@ pub const Projection = struct {
 const ItemBoundary = struct {
     entry_id: u32,
     segment_index: usize,
+    code_copy_span: ?transcript_blocks.CodeBlockActionSpan = null,
 };
+
+test "full projection boundary stores final code copy columns" {
+    const alloc = std.testing.allocator;
+    const language = try alloc.dupe(u8, "zig");
+    defer alloc.free(language);
+    const code = try alloc.dupe(u8, "const value = 1;");
+    defer alloc.free(code);
+    const entries = [_]transcript_blocks.TranscriptEntry{.{ .assistant_code_block = .{
+        .id = 7,
+        .block = .{ .language = language, .code = code },
+    } }};
+    var projection = try buildProjection(alloc, &entries, &.{}, &.{}, .{}, 80, null);
+    defer projection.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), projection.item_boundaries.items.len);
+    if (comptime @hasField(ItemBoundary, "code_copy_span")) {
+        const span = projection.item_boundaries.items[0].code_copy_span orelse
+            return error.TestUnexpectedResult;
+        const source = try renderProjectionViewportSource(alloc, &projection, null, 80, 8, 0);
+        defer alloc.free(source);
+        const copy_byte = std.mem.find(u8, source, "Copy") orelse
+            return error.TestUnexpectedResult;
+        const expected_first: u16 = @intCast(
+            display_width.visibleWidthIgnoringAnsi(source[0..copy_byte]) + 1,
+        );
+        try std.testing.expectEqual(expected_first, span.first_col);
+        try std.testing.expectEqual(expected_first + 3, span.last_col);
+
+        var suffix = try buildProjection(alloc, &entries, &.{}, &.{}, .{}, 80, null);
+        defer suffix.deinit(alloc);
+        try std.testing.expect(try projection.replaceFromEntry(alloc, 7, &suffix));
+        try std.testing.expect(projection.item_boundaries.items[0].code_copy_span != null);
+    } else {
+        return error.TestUnexpectedResult;
+    }
+}
+
+test "code copy targets project visible rows and exact columns" {
+    const alloc = std.testing.allocator;
+    const language = try alloc.dupe(u8, "zig");
+    defer alloc.free(language);
+    const code = try alloc.dupe(u8, "const value = 1;");
+    defer alloc.free(code);
+    const entries = [_]transcript_blocks.TranscriptEntry{.{ .assistant_code_block = .{
+        .id = 9,
+        .block = .{ .language = language, .code = code },
+    } }};
+    var projection = try buildProjection(alloc, &entries, &.{}, &.{}, .{}, 80, null);
+    defer projection.deinit(alloc);
+    _ = try measureProjectionInterruptible(alloc, &projection, null, 80, null);
+
+    if (comptime @hasDecl(@This(), "codeCopyTargetsForWindow")) {
+        const collect = @field(@This(), "codeCopyTargetsForWindow");
+        var frame = try collect(alloc, &projection, 0, 4, 8);
+        defer frame.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 1), frame.targets.items.len);
+        const target = frame.targets.items[0];
+        try std.testing.expectEqual(@as(u32, 9), target.entry_id);
+        try std.testing.expectEqual(@as(u16, 4), target.row);
+        try std.testing.expectEqual(@as(?u32, 9), frame.hitTest(target.row, target.first_col));
+        try std.testing.expectEqual(@as(?u32, 9), frame.hitTest(target.row, target.last_col));
+        try std.testing.expectEqual(@as(?u32, null), frame.hitTest(target.row, target.first_col - 1));
+        try std.testing.expectEqual(@as(?u32, null), frame.hitTest(target.row + 1, target.first_col));
+
+        var hidden = try collect(alloc, &projection, 1, 4, 8);
+        defer hidden.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 0), hidden.targets.items.len);
+    } else {
+        return error.TestUnexpectedResult;
+    }
+}
 
 test "projection finds a repositioned entry by transcript order" {
     const alloc = std.testing.allocator;
@@ -634,6 +707,67 @@ pub const ProjectionMeasurement = struct {
     item_rows: []const transcript_presentation.ItemRow = &.{},
 };
 
+pub const CodeCopyTarget = struct {
+    entry_id: u32,
+    row: u16,
+    first_col: u16,
+    last_col: u16,
+};
+
+pub const CodeCopyInteractionFrame = struct {
+    targets: std.ArrayList(CodeCopyTarget) = .empty,
+
+    pub fn deinit(self: *CodeCopyInteractionFrame, alloc: Allocator) void {
+        self.targets.deinit(alloc);
+        self.* = undefined;
+    }
+
+    pub fn clear(self: *CodeCopyInteractionFrame) void {
+        self.targets.clearRetainingCapacity();
+    }
+
+    pub fn hitTest(self: CodeCopyInteractionFrame, row: u16, col: u16) ?u32 {
+        for (self.targets.items) |target| {
+            if (target.row == row and col >= target.first_col and col <= target.last_col) {
+                return target.entry_id;
+            }
+        }
+        return null;
+    }
+};
+
+pub fn codeCopyTargetsForWindow(
+    alloc: Allocator,
+    projection: *const Projection,
+    document_offset: u32,
+    area_top: u16,
+    visible_rows: u16,
+) !CodeCopyInteractionFrame {
+    if (projection.measured_item_rows.items.len != projection.item_boundaries.items.len) {
+        return error.MissingProjectionMeasurement;
+    }
+
+    var targets: std.ArrayList(CodeCopyTarget) = .empty;
+    errdefer targets.deinit(alloc);
+    const document_end = document_offset +| visible_rows;
+    for (projection.item_boundaries.items, projection.measured_item_rows.items) |boundary, item| {
+        const span = boundary.code_copy_span orelse continue;
+        if (item.row < document_offset or item.row >= document_end) continue;
+        const relative_row = item.row - document_offset;
+        const screen_row = std.math.cast(
+            u16,
+            @as(u32, area_top) + relative_row,
+        ) orelse return error.InvalidTargetRow;
+        try targets.append(alloc, .{
+            .entry_id = boundary.entry_id,
+            .row = screen_row,
+            .first_col = span.first_col,
+            .last_col = span.last_col,
+        });
+    }
+    return .{ .targets = targets };
+}
+
 /// Owns the in-progress static writer while composing a Projection, so every
 /// build-time segment boundary transfers through one place.
 const ProjectionBuilder = struct {
@@ -680,6 +814,17 @@ const ProjectionBuilder = struct {
             .entry_id = entry_id,
             .segment_index = self.projection.segments.items.len,
         });
+    }
+
+    fn recordCodeAction(
+        self: *ProjectionBuilder,
+        entry_id: u32,
+        span: transcript_blocks.CodeBlockActionSpan,
+    ) void {
+        std.debug.assert(self.projection.item_boundaries.items.len > 0);
+        const boundary = &self.projection.item_boundaries.items[self.projection.item_boundaries.items.len - 1];
+        std.debug.assert(boundary.entry_id == entry_id);
+        boundary.code_copy_span = span;
     }
 
     fn appendStoredResult(self: *ProjectionBuilder, stored: StoredResult) !void {
@@ -4434,6 +4579,7 @@ pub fn buildProjectionForDepthWithEntryActionsInterruptible(
         .override_kind = ProjectionComposeContext.overrideKind,
         .append_override = ProjectionComposeContext.appendOverride,
         .before_entry = ProjectionComposeContext.beforeEntry,
+        .record_code_action = ProjectionComposeContext.recordCodeAction,
         .append_detail = ProjectionComposeContext.appendDetail,
     };
     try transcript_blocks.renderEntriesForFullPresentationInterruptible(
@@ -6637,7 +6783,11 @@ fn renderProjectionViewportSourceWithSelection(
                     cols,
                     checkpoint,
                 );
-                break :blk selector.select_offset(selector.context, measurement, visible_rows);
+                break :blk selector.select_offset(
+                    selector.context,
+                    measurement,
+                    visible_rows,
+                );
             },
         };
         return renderProjectionWindow(alloc, projection, capability, cols, visible_rows, offset, checkpoint) catch |err| switch (err) {
@@ -6971,6 +7121,15 @@ const ProjectionComposeContext = struct {
             _ = out;
             try self.builder.markAnchor();
         }
+    }
+
+    fn recordCodeAction(
+        context: *anyopaque,
+        entry_id: u32,
+        span: transcript_blocks.CodeBlockActionSpan,
+    ) !void {
+        const self = fromOpaque(context);
+        self.builder.recordCodeAction(entry_id, span);
     }
 
     fn appendDetail(

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -96,6 +96,7 @@ pub const FullPresentationSink = struct {
     override_kind: *const fn (context: *anyopaque, entry: TranscriptEntry) ?TranscriptBlockKind,
     append_override: *const fn (context: *anyopaque, entry: TranscriptEntry, out: *std.Io.Writer.Allocating) anyerror!bool,
     before_entry: *const fn (context: *anyopaque, entry_id: u32, out: *std.Io.Writer.Allocating) anyerror!void,
+    record_code_action: ?*const fn (context: *anyopaque, entry_id: u32, span: CodeBlockActionSpan) anyerror!void = null,
     append_detail: *const fn (context: *anyopaque, entry_id: u32, out: *std.Io.Writer.Allocating) anyerror!FullDetailAppend,
 };
 
@@ -903,18 +904,29 @@ pub fn renderCodeBlockForTranscript(
     block: assistant_presentation.CodeBlockPayload,
     cols: u16,
 ) ![]u8 {
-    return renderCodeBlockForTranscriptWithTheme(alloc, block, cols, .dark);
+    return (try renderCodeBlockForTranscriptWithTheme(alloc, block, cols, .dark, null)).bytes;
 }
+
+pub const CodeBlockActionSpan = struct {
+    first_col: u16,
+    last_col: u16,
+};
+
+const CodeBlockRender = struct {
+    bytes: []u8,
+    action_span: ?CodeBlockActionSpan = null,
+};
 
 fn renderCodeBlockForTranscriptWithTheme(
     alloc: Allocator,
     block: assistant_presentation.CodeBlockPayload,
     cols: u16,
     theme: CodeHighlightTheme,
-) ![]u8 {
+    header_action: ?[]const u8,
+) !CodeBlockRender {
     var rendered: std.ArrayList(u8) = .empty;
     errdefer rendered.deinit(alloc);
-    if (cols == 0) return rendered.toOwnedSlice(alloc);
+    if (cols == 0) return .{ .bytes = try rendered.toOwnedSlice(alloc) };
 
     const profile = if (block.language.len > 0)
         code_highlight_languages.resolve(block.language)
@@ -937,14 +949,24 @@ fn renderCodeBlockForTranscriptWithTheme(
     const available_width: usize = cols;
     const frame_would_wrap =
         max_code_width > available_width -| 4 and max_code_width <= available_width;
-    if (cols <= 5 or frame_would_wrap) {
+    const action_width = if (header_action) |action| display_width.visibleWidth(action) else 0;
+    if (cols <= 5 or frame_would_wrap or (header_action != null and cols < action_width + 4)) {
         try renderUnboxedCode(alloc, code, cols, &rendered);
-        return rendered.toOwnedSlice(alloc);
+        return .{ .bytes = try rendered.toOwnedSlice(alloc) };
     }
 
-    const panel_width = codePanelWidth(max_code_width, language, cols);
+    const panel_width = codePanelWidth(max_code_width, language, header_action, cols);
     const inner_width = panel_width - 4;
-    if (language.len > 0) {
+    var action_span: ?CodeBlockActionSpan = null;
+    if (header_action) |action| {
+        action_span = try appendCodePanelActionHeader(
+            alloc,
+            &rendered,
+            panel_width,
+            language,
+            action,
+        );
+    } else if (language.len > 0) {
         try appendCodePanelHeader(alloc, &rendered, panel_width, language);
     } else {
         try appendCodePanelBorder(alloc, &rendered, panel_width, "┌", "┐");
@@ -961,7 +983,10 @@ fn renderCodeBlockForTranscriptWithTheme(
     }
     if (!emitted_line) try appendCodePanelLine(alloc, &rendered, "", inner_width);
     try appendCodePanelBorder(alloc, &rendered, panel_width, "└", "┘");
-    return rendered.toOwnedSlice(alloc);
+    return .{
+        .bytes = try rendered.toOwnedSlice(alloc),
+        .action_span = action_span,
+    };
 }
 
 const CodeStyle = struct {
@@ -1028,12 +1053,62 @@ fn maxCodeLineWidth(code: []const u8) usize {
     return max_width;
 }
 
-fn codePanelWidth(max_code_width: usize, language: []const u8, cols: u16) usize {
+fn codePanelWidth(
+    max_code_width: usize,
+    language: []const u8,
+    header_action: ?[]const u8,
+    cols: u16,
+) usize {
     const label_width = if (language.len == 0) 0 else @min(
         display_width.visibleWidth(language),
         @as(usize, cols) - 5,
     );
-    return @min(@as(usize, cols), @max(@as(usize, 6), @max(max_code_width + 4, label_width + 5)));
+    const action_width = if (header_action) |action|
+        if (label_width == 0)
+            display_width.visibleWidth(action) + 4
+        else
+            label_width + display_width.visibleWidth(action) + 7
+    else
+        0;
+    return @min(
+        @as(usize, cols),
+        @max(@as(usize, 6), @max(max_code_width + 4, @max(label_width + 5, action_width))),
+    );
+}
+
+fn appendCodePanelActionHeader(
+    alloc: Allocator,
+    out: *std.ArrayList(u8),
+    panel_width: usize,
+    language: []const u8,
+    action: []const u8,
+) !CodeBlockActionSpan {
+    const action_width = display_width.visibleWidth(action);
+    std.debug.assert(action_width > 0);
+    std.debug.assert(panel_width >= action_width + 4);
+    const action_first_col = panel_width - action_width - 1;
+    const header_width = action_first_col - 3;
+
+    try out.appendSlice(alloc, "┌");
+    const label_limit = header_width -| 2;
+    const label = display_width.prefixByWidth(language, label_limit);
+    const label_width = display_width.visibleWidth(label);
+    if (label_width > 0) {
+        try out.appendSlice(alloc, " ");
+        try out.appendSlice(alloc, "\x1b[2m");
+        try out.appendSlice(alloc, label);
+        try out.appendSlice(alloc, "\x1b[22m ");
+    }
+    var edge: usize = label_width + @as(usize, @intFromBool(label_width > 0)) * 2;
+    while (edge < header_width) : (edge += 1) try out.appendSlice(alloc, "─");
+    try out.appendSlice(alloc, " ");
+    try out.appendSlice(alloc, action);
+    try out.appendSlice(alloc, " ┐\n");
+    std.debug.assert(panel_width <= std.math.maxInt(u16));
+    return .{
+        .first_col = @intCast(action_first_col),
+        .last_col = @intCast(action_first_col + action_width - 1),
+    };
 }
 
 fn appendCodePanelHeader(
@@ -1618,10 +1693,16 @@ fn renderEntryToBlockForPresentationInterruptible(
                 e.block,
                 cols -| gutter,
                 styles.code_highlight_theme,
+                if (presentation == .full) "Copy" else null,
             );
-            defer alloc.free(rendered);
-            const prefixed = try assistant_wrap.prefixStructuralRows(alloc, rendered, gutter);
-            break :blk try normalizeOwnedRenderedBlock(alloc, kind, prefixed);
+            defer alloc.free(rendered.bytes);
+            const prefixed = try assistant_wrap.prefixStructuralRows(alloc, rendered.bytes, gutter);
+            var normalized = try normalizeOwnedRenderedBlock(alloc, kind, prefixed);
+            if (rendered.action_span) |span| normalized.code_action_span = .{
+                .first_col = span.first_col + gutter,
+                .last_col = span.last_col + gutter,
+            };
+            break :blk normalized;
         },
         .assistant_thematic_rule => blk: {
             const rendered = try renderThematicRuleForTranscript(alloc, cols);
@@ -1706,6 +1787,9 @@ pub fn renderEntriesForFullPresentationInterruptible(
 
         try out.writer.splatByteAll('\n', sequence.separatorNewlineCountBefore(block.kind));
         try sink.before_entry(sink.context, entry_id, out);
+        if (block.code_action_span) |span| {
+            if (sink.record_code_action) |record| try record(sink.context, entry_id, span);
+        }
         try out.writer.writeAll(block.bytes);
         const detail = try sink.append_detail(sink.context, entry_id, out);
         sequence.observe(block.kind, detail.ends_with_newline, if (detail.attached) 0 else block.stored_tail_newlines);
@@ -2641,6 +2725,7 @@ pub const RenderedBlock = struct {
     stored_tail_newlines: usize,
     allocation: []const u8 = &.{},
     owned: bool = false,
+    code_action_span: ?CodeBlockActionSpan = null,
 
     pub fn deinit(self: RenderedBlock, alloc: Allocator) void {
         if (self.owned) alloc.free(self.allocation);
@@ -3026,6 +3111,58 @@ test "renderCodeBlockForTranscript frames language labels in the top border" {
             "└────┘\n",
         wide_rune,
     );
+}
+
+test "full presentation shows Copy only for boxed code blocks" {
+    const alloc = std.testing.allocator;
+    const language = try alloc.dupe(u8, "zig");
+    defer alloc.free(language);
+    const code = try alloc.dupe(u8, "const value = 1;");
+    defer alloc.free(code);
+    const entry = TranscriptEntry{ .assistant_code_block = .{
+        .id = 1,
+        .block = .{ .language = language, .code = code },
+    } };
+
+    const inline_block = try renderEntryToBlockForPresentation(alloc, entry, 80, .{}, .compact);
+    defer inline_block.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, inline_block.bytes, "Copy") == null);
+
+    const boxed = try renderEntryToBlockForPresentation(alloc, entry, 80, .{}, .full);
+    defer boxed.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, boxed.bytes, "Copy") != null);
+
+    const unboxed = try renderEntryToBlockForPresentation(alloc, entry, 5, .{}, .full);
+    defer unboxed.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, unboxed.bytes, "Copy") == null);
+}
+
+test "boxed code action span is one-based inclusive and panel-local" {
+    const alloc = std.testing.allocator;
+    const language = try alloc.dupe(u8, "zig");
+    defer alloc.free(language);
+    const code = try alloc.dupe(u8, "const value = 1;");
+    defer alloc.free(code);
+    const block = assistant_presentation.CodeBlockPayload{
+        .language = language,
+        .code = code,
+    };
+
+    const boxed = try renderCodeBlockForTranscriptWithTheme(alloc, block, 80, .dark, "Copy");
+    defer alloc.free(boxed.bytes);
+    const copy_byte = std.mem.find(u8, boxed.bytes, "Copy") orelse
+        return error.TestUnexpectedResult;
+    const expected_first: u16 = @intCast(
+        display_width.visibleWidthIgnoringAnsi(boxed.bytes[0..copy_byte]) + 1,
+    );
+    const span = boxed.action_span orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqual(expected_first, span.first_col);
+    try std.testing.expectEqual(expected_first + 3, span.last_col);
+
+    const unboxed = try renderCodeBlockForTranscriptWithTheme(alloc, block, 5, .dark, "Copy");
+    defer alloc.free(unboxed.bytes);
+    try std.testing.expect(unboxed.action_span == null);
+    try std.testing.expect(std.mem.find(u8, unboxed.bytes, "Copy") == null);
 }
 
 test "renderCodeBlockForTranscript bounds highlighted rows across every supported width" {

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -751,6 +751,58 @@ test "full transcript viewport snapshot restores reading position" {
     ));
 }
 
+test "full transcript code copy frame clears through dirty scroll and close" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{ .full_transcript = .{ .depth = .review } };
+    defer runtime.deinit(alloc);
+
+    if (comptime @hasDecl(TranscriptRuntime, "commitCodeCopyFrame") and
+        @hasDecl(TranscriptRuntime, "codeCopyHit"))
+    {
+        const commit = @field(TranscriptRuntime, "commitCodeCopyFrame");
+        const hit = @field(TranscriptRuntime, "codeCopyHit");
+
+        var dirty_frame: full_transcript_screen.CodeCopyInteractionFrame = .{};
+        defer dirty_frame.deinit(alloc);
+        try dirty_frame.targets.append(alloc, .{
+            .entry_id = 1,
+            .row = 4,
+            .first_col = 10,
+            .last_col = 13,
+        });
+        commit(&runtime, alloc, &dirty_frame);
+        try std.testing.expectEqual(@as(?u32, 1), hit(&runtime, 4, 11));
+        runtime.markTranscriptDirty();
+        try std.testing.expectEqual(@as(?u32, null), hit(&runtime, 4, 11));
+
+        var scroll_frame: full_transcript_screen.CodeCopyInteractionFrame = .{};
+        defer scroll_frame.deinit(alloc);
+        try scroll_frame.targets.append(alloc, .{
+            .entry_id = 2,
+            .row = 5,
+            .first_col = 20,
+            .last_col = 23,
+        });
+        commit(&runtime, alloc, &scroll_frame);
+        runtime.scrollFullTranscript(.up, .wheel);
+        try std.testing.expectEqual(@as(?u32, null), hit(&runtime, 5, 21));
+
+        var close_frame: full_transcript_screen.CodeCopyInteractionFrame = .{};
+        defer close_frame.deinit(alloc);
+        try close_frame.targets.append(alloc, .{
+            .entry_id = 3,
+            .row = 6,
+            .first_col = 30,
+            .last_col = 33,
+        });
+        commit(&runtime, alloc, &close_frame);
+        runtime.closeFullTranscriptState();
+        try std.testing.expectEqual(@as(?u32, null), hit(&runtime, 6, 31));
+    } else {
+        return error.TestUnexpectedResult;
+    }
+}
+
 test "opening the full transcript leaves compact command projection unchanged" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{ .layout = .{
@@ -823,12 +875,63 @@ test "full transcript staging paints its selected wheel viewport without reselec
     );
     defer staged.source.deinit(alloc);
     defer staged.prepared.deinit(alloc);
+    defer staged.code_copy_frame.deinit(alloc);
 
     try std.testing.expectEqual(@as(u32, 3), runtime.full_transcript.scroll_rows);
     try std.testing.expect(!runtime.full_transcript.follow_tail);
     try std.testing.expectEqual(@as(usize, 0), staged.prepared.selection.start_line);
     try std.testing.expect(std.mem.find(u8, staged.source.bytes, "row-3") != null);
     try std.testing.expect(std.mem.find(u8, staged.source.bytes, "row-0") == null);
+}
+
+test "full transcript staging carries visible code copy targets" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = .{
+            .rows = 12,
+            .cols = 80,
+            .content_bottom = 8,
+            .divider_top_row = 9,
+            .input_row = 10,
+            .divider_bottom_row = 11,
+            .hint_row = 12,
+        },
+        .owned_top_row = 1,
+        .full_transcript = .{ .depth = .review },
+    };
+    defer runtime.deinit(alloc);
+
+    var language: ?[]u8 = try alloc.dupe(u8, "zig");
+    errdefer if (language) |bytes| alloc.free(bytes);
+    var code: ?[]u8 = try alloc.dupe(u8, "const value = 1;");
+    errdefer if (code) |bytes| alloc.free(bytes);
+    _ = try runtime.appendAssistantCodeBlockOwned(alloc, .{
+        .language = language.?,
+        .code = code.?,
+    });
+    language = null;
+    code = null;
+    var projection = try runtime.buildFullTranscriptProjection(alloc, null);
+    defer projection.deinit(alloc);
+    var metrics: Metrics = .{};
+    var staged = try runtime.prepareFullTranscriptSurfacePaint(
+        alloc,
+        &metrics,
+        &projection,
+        null,
+        .{ .top = 2, .bottom = 8 },
+    );
+    defer staged.source.deinit(alloc);
+    defer staged.prepared.deinit(alloc);
+    defer staged.code_copy_frame.deinit(alloc);
+
+    if (comptime @hasField(TranscriptRuntime.FullTranscriptSurfacePaint, "code_copy_frame")) {
+        const frame = @field(staged, "code_copy_frame");
+        try std.testing.expectEqual(@as(usize, 1), frame.targets.items.len);
+        try std.testing.expectEqual(@as(u16, 2), frame.targets.items[0].row);
+    } else {
+        return error.TestUnexpectedResult;
+    }
 }
 
 test "full transcript projection cache survives navigation and invalidates on content change" {
@@ -1643,6 +1746,7 @@ test "full transcript staging keeps its selected viewport visible during resize 
     );
     defer staged.source.deinit(alloc);
     defer staged.prepared.deinit(alloc);
+    defer staged.code_copy_frame.deinit(alloc);
 
     try std.testing.expect(std.mem.find(u8, staged.source.bytes, "row-3") != null);
     try std.testing.expect(std.mem.find(u8, staged.source.bytes, "row-0") == null);
@@ -1819,6 +1923,7 @@ test "full transcript opening follows the tail instead of consuming its compact 
     );
     defer staged.source.deinit(alloc);
     defer staged.prepared.deinit(alloc);
+    defer staged.code_copy_frame.deinit(alloc);
 
     try std.testing.expectEqual(@as(usize, 0), staged.prepared.selection.start_line);
     try std.testing.expectEqual(
@@ -4124,6 +4229,7 @@ pub const TranscriptRuntime = struct {
     full_transcript_open_rows: u16 = 0,
     full_transcript_primary_recovery_entry_id: ?u32 = null,
     full_transcript_projection_cache: FullTranscriptProjectionCache = .{},
+    full_transcript_code_copy_frame: full_transcript_screen.CodeCopyInteractionFrame = .{},
     full_transcript_content_revision: u64 = 0,
     full_transcript_review_revision: u64 = 0,
     compact_transcript_source_cache: CompactTranscriptSourceCache = .{},
@@ -4233,6 +4339,7 @@ pub const TranscriptRuntime = struct {
         self.disableShadowVt();
         self.compact_transcript_source_cache.deinit(alloc);
         self.full_transcript_projection_cache.deinit(alloc);
+        self.full_transcript_code_copy_frame.deinit(alloc);
         self.lifecycle_state.deinit(alloc);
         for (self.tool_details.items) |*detail| detail.deinit(alloc);
         self.tool_details.deinit(alloc);
@@ -6230,7 +6337,37 @@ pub const TranscriptRuntime = struct {
     }
 
     pub fn closeFullTranscriptState(self: *TranscriptRuntime) void {
+        self.clearCodeCopyFrame();
         self.full_transcript = self.full_transcript.closed();
+    }
+
+    pub fn commitCodeCopyFrame(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        candidate: *full_transcript_screen.CodeCopyInteractionFrame,
+    ) void {
+        self.full_transcript_code_copy_frame.deinit(alloc);
+        self.full_transcript_code_copy_frame = candidate.*;
+        candidate.* = .{};
+    }
+
+    pub fn codeCopyHit(self: *const TranscriptRuntime, row: u16, col: u16) ?u32 {
+        return self.full_transcript_code_copy_frame.hitTest(row, col);
+    }
+
+    pub fn assistantCodeBlockSource(self: *const TranscriptRuntime, entry_id: u32) ?[]const u8 {
+        for (self.entries.items) |entry| {
+            if (entry.id() != entry_id) continue;
+            return switch (entry) {
+                .assistant_code_block => |code_block| code_block.block.code,
+                else => null,
+            };
+        }
+        return null;
+    }
+
+    fn clearCodeCopyFrame(self: *TranscriptRuntime) void {
+        self.full_transcript_code_copy_frame.clear();
     }
 
     pub fn fullTranscriptAnchorEntryId(self: *const TranscriptRuntime) ?u32 {
@@ -6246,6 +6383,7 @@ pub const TranscriptRuntime = struct {
         direction: input_action.MouseWheel,
         unit: FullTranscriptScrollUnit,
     ) void {
+        self.clearCodeCopyFrame();
         const rows = switch (unit) {
             .wheel => full_transcript_wheel_rows,
             .page => self.fullTranscriptPageRows(),
@@ -9246,6 +9384,7 @@ pub const TranscriptRuntime = struct {
     pub const FullTranscriptSurfacePaint = struct {
         source: TranscriptPreparationSource,
         prepared: transcript_painter.PreparedTranscriptSurfacePaint,
+        code_copy_frame: full_transcript_screen.CodeCopyInteractionFrame,
     };
 
     pub noinline fn buildFullTranscriptProjection(
@@ -9588,6 +9727,19 @@ pub const TranscriptRuntime = struct {
             .{ .context = self, .select_offset = selectProjectionViewportOffset },
             checkpoint,
         );
+        const selected_offset = self.full_transcript.select_visual_offset(
+            projection.measured_total_rows,
+            area.height(),
+            projection.measured_item_rows.items,
+        ).offset;
+        var code_copy_frame = try full_transcript_screen.codeCopyTargetsForWindow(
+            alloc,
+            projection,
+            selected_offset,
+            area.top,
+            area.height(),
+        );
+        errdefer code_copy_frame.deinit(alloc);
         var source = try self.prepareFullTranscriptViewportSource(alloc, source_bytes);
         errdefer source.deinit(alloc);
         const prepared = try transcript_painter.preparePreselectedTranscriptSurfacePaintFromSourceForArea(
@@ -9597,7 +9749,11 @@ pub const TranscriptRuntime = struct {
             &source,
             area,
         );
-        return .{ .source = source, .prepared = prepared };
+        return .{
+            .source = source,
+            .prepared = prepared,
+            .code_copy_frame = code_copy_frame,
+        };
     }
 
     fn selectProjectionViewportOffset(
@@ -9740,6 +9896,7 @@ pub const TranscriptRuntime = struct {
     }
 
     pub fn markTranscriptDirty(self: *TranscriptRuntime) void {
+        self.clearCodeCopyFrame();
         self.transcript_band_dirty = true;
         self.render_requests.request(.transcript);
     }

--- a/tests/e2e/tui-slash-extra.test.ts
+++ b/tests/e2e/tui-slash-extra.test.ts
@@ -174,6 +174,107 @@ describe.skipIf(!tmuxAvailable())("tui: credits slash command", () => {
 
 describe.skipIf(!tmuxAvailable() || CLIPBOARD_PROGRAM === null)("tui: clipboard host", () => {
   test(
+    "Ctrl-O copies boxed code after scrolling and a boxed-to-unboxed resize",
+    async () => {
+      if (CLIPBOARD_PROGRAM === null) throw new Error("unsupported clipboard platform");
+
+      const workDir = mkdtempSync(join(tmpdir(), "fx-code-block-copy-"));
+      const homeDir = join(workDir, "home");
+      const binDir = join(workDir, "bin");
+      const capturePath = join(workDir, "clipboard.txt");
+      const stderrPath = join(workDir, "stderr.log");
+      const clipboardPath = join(binDir, CLIPBOARD_PROGRAM);
+      mkdirSync(homeDir);
+      mkdirSync(binDir);
+      writeFileSync(clipboardPath, "#!/bin/sh\ncat > \"$FX_TEST_CLIPBOARD_CAPTURE\"\n");
+      chmodSync(clipboardPath, 0o755);
+
+      const code = "const copied = true;\n";
+      const reply = [
+        ...Array.from({ length: 24 }, (_, index) => `context row ${index + 1}`),
+        "```zig",
+        code.trimEnd(),
+        "```",
+      ].join("\n");
+      const gateway = startDynamicFakeGateway(() => fakeGatewayFinalText(reply));
+      try {
+        session = await TmuxSession.create({
+          cwd: workDir,
+          stderrPath,
+          env: {
+            HOME: homeDir,
+            AI_GATEWAY_API_KEY: "code-copy-fake-key",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_MODEL: FAKE_GATEWAY_MODEL,
+            FX_TEST_CLIPBOARD_CAPTURE: capturePath,
+            PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          },
+          width: 100,
+          height: 28,
+        });
+        await session.waitForComposer(10_000);
+
+        await session.sendText("render the code fixture");
+        await session.waitForText("const copied = true;", 10_000);
+        const inline = await session.waitForComposer(10_000);
+        expect(inline).not.toContain("Copy");
+
+        await session.sendKeys("C-o");
+        await session.waitForText("Copy", 10_000);
+        await session.sendHexBytes(toHexBytes("\x1b[<64;1;1M"));
+        await session.sendHexBytes(toHexBytes("\x1b[<65;1;1M"));
+        const wide = await session.waitForText("Copy", 10_000);
+        const staleTarget = textCoordinate(wide, "Copy");
+
+        await session.resizeWindow(24, 28, 750);
+        const narrow = await session.capturePane();
+        expect(narrow).not.toContain("Copy");
+        expect(narrow).toContain("Review");
+        await session.sendHexBytes(toHexBytes(
+          `\x1b[<0;${staleTarget.column};${staleTarget.row}M`,
+        ));
+        expect(existsSync(capturePath)).toBe(false);
+        expect(await session.capturePane()).toContain("Review");
+
+        await session.resizeWindow(100, 28, 750);
+        const boxed = await session.waitForText("Copy", 10_000);
+        const target = textCoordinate(boxed, "Copy");
+        await session.sendHexBytes(toHexBytes(
+          `\x1b[<0;${target.column};${target.row}M`,
+        ));
+        const restored = await session.waitForComposer(10_000);
+        expect(restored).not.toContain("Review ·");
+        expect(readFileSync(capturePath, "utf8")).toBe(code);
+
+        writeFileSync(clipboardPath, "#!/bin/sh\nexit 23\n");
+        await session.sendKeys("C-o");
+        const failureView = await session.waitForText("Copy", 10_000);
+        const failureTarget = textCoordinate(failureView, "Copy");
+        await session.sendHexBytes(toHexBytes(
+          `\x1b[<0;${failureTarget.column};${failureTarget.row}M`,
+        ));
+        const failed = await session.waitForText(
+          "Failed to copy code block to clipboard.",
+          10_000,
+        );
+        expect(hasEmptyComposer(failed)).toBe(true);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+      } finally {
+        if (session) {
+          await session.kill();
+          session = null;
+        }
+        gateway.stop();
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    },
+    LONG_TIMEOUT,
+  );
+
+  test(
     "/copy sends exact reply bytes to the host clipboard and reports process failure",
     async () => {
       if (CLIPBOARD_PROGRAM === null) throw new Error("unsupported clipboard platform");
@@ -515,4 +616,20 @@ function countOccurrences(value: string, needle: string): number {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function toHexBytes(value: string): string[] {
+  return Array.from(Buffer.from(value, "utf8"), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  );
+}
+
+function textCoordinate(pane: string, text: string): { row: number; column: number } {
+  const rows = pane.replace(/\n$/, "").split("\n");
+  const rowIndex = rows.findIndex((row) => row.includes(text));
+  if (rowIndex < 0) throw new Error(`Missing ${JSON.stringify(text)} in pane`);
+  return {
+    row: rowIndex + 1,
+    column: rows[rowIndex].indexOf(text) + 1,
+  };
 }


### PR DESCRIPTION
## Summary

- Show `Copy` in the top-right of boxed completed code blocks in Ctrl-O.
- Keep Inline and unboxed code blocks unchanged.
- Copy exact code bytes on click and return the active transcript to Inline.
- Return to Inline and show a clipboard error when copying fails.