### PR TITLE
Isolate MCP discovery and authentication failures

### DIFF
--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -108,7 +108,7 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
                 "Interactive MCP authentication is unavailable here.",
                 false,
             );
-        var authentication = authenticate(
+        const authentication = authenticate(
             command_request.auth_ctx orelse command_request.list_ctx,
             name,
         ) catch |err| {
@@ -118,17 +118,16 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
                 false,
             );
         };
-        defer authentication.deinit();
         return switch (authentication) {
-            .authenticated => lineParts(
+            .started => lineParts(
                 alloc,
-                &.{ "Authenticated MCP server '", name, "'." },
-                true,
+                &.{ "Waiting for MCP authentication for '", name, "'. You can continue using fx while the browser flow completes." },
+                false,
             ),
-            .issuer_mismatch => |mismatch| issuerMismatchResult(
+            .busy => lineParts(
                 alloc,
-                name,
-                mismatch,
+                &.{ "MCP authentication for '", name, "' is already in progress or MCP configuration is reloading." },
+                false,
             ),
         };
     }
@@ -150,6 +149,13 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
                 false,
             );
         };
+        if (result.busy) {
+            return lineParts(
+                alloc,
+                &.{ "MCP authentication for '", name, "' is still in progress. Wait for it to finish before logging out." },
+                false,
+            );
+        }
         if (!result.removed) {
             return lineParts(
                 alloc,
@@ -337,28 +343,6 @@ fn lineLiteral(alloc: Allocator, text: []const u8, reload: bool) !CommandResult 
 // string splice.
 fn lineParts(alloc: Allocator, parts: []const []const u8, reload: bool) !CommandResult {
     return .{ .display = .{ .line = try std.mem.concat(alloc, u8, parts) }, .reload = reload };
-}
-
-fn issuerMismatchResult(
-    alloc: Allocator,
-    server_name: []const u8,
-    mismatch: mcp_auth.IssuerMismatch,
-) !CommandResult {
-    var expected = try text_utils.encodeTerminalSafe(alloc, mismatch.expected, 1024);
-    defer expected.deinit(alloc);
-    var returned = try text_utils.encodeTerminalSafe(alloc, mismatch.returned, 1024);
-    defer returned.deinit(alloc);
-
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    errdefer out.deinit();
-    try out.writer.print("MCP authentication for '{s}' was rejected: expected issuer ", .{server_name});
-    try std.json.Stringify.value(expected.bytes, .{}, &out.writer);
-    try out.writer.writeAll(" but metadata returned ");
-    try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
-    try out.writer.writeAll(". Add \"oauth\":{\"issuer\":");
-    try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
-    try out.writer.writeAll("} to this server's entry in ~/.fx/mcp.json and retry.");
-    return .{ .display = .{ .line = try out.toOwnedSlice() } };
 }
 
 pub fn configPathFromHome(alloc: Allocator, home: []const u8) ![]u8 {
@@ -1805,6 +1789,7 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
         validation_calls: usize = 0,
         auth_calls: usize = 0,
         logout_calls: usize = 0,
+        logout_busy: bool = false,
 
         fn list(_: *anyopaque, alloc: Allocator) ![]u8 {
             return alloc.dupe(u8, "");
@@ -1813,19 +1798,12 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
         fn authenticate(
             raw: *anyopaque,
             name: []const u8,
-        ) !mcp_auth.AuthenticationResult {
+        ) !command_provider_contract.AuthenticationStart {
             const self: *@This() = @ptrCast(@alignCast(raw));
-            if (std.mem.eql(u8, name, "mismatch")) {
-                self.auth_calls += 1;
-                return .{ .issuer_mismatch = try mcp_auth.IssuerMismatch.init(
-                    std.testing.allocator,
-                    "https://signin.auth.plain.com/",
-                    "https://signin.auth.plain.com",
-                ) };
-            }
-            try std.testing.expectEqualStrings("remote", name);
             self.auth_calls += 1;
-            return .authenticated;
+            if (std.mem.eql(u8, name, "busy")) return .busy;
+            try std.testing.expectEqualStrings("remote", name);
+            return .started;
         }
 
         fn validate(raw: *anyopaque, name: []const u8) !void {
@@ -1834,7 +1812,7 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
             if (std.mem.eql(u8, name, "local")) {
                 return error.McpAuthenticationNotRemote;
             }
-            if (!std.mem.eql(u8, name, "mismatch")) {
+            if (!std.mem.eql(u8, name, "busy")) {
                 try std.testing.expectEqualStrings("remote", name);
             }
         }
@@ -1846,6 +1824,7 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
             const self: *@This() = @ptrCast(@alignCast(raw));
             try std.testing.expectEqualStrings("remote", name);
             self.logout_calls += 1;
+            if (self.logout_busy) return .{ .busy = true };
             return .{ .removed = true };
         }
     };
@@ -1871,25 +1850,29 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
     try std.testing.expectEqual(@as(usize, 1), fixture.validation_calls);
     try std.testing.expectEqual(@as(usize, 0), fixture.auth_calls);
 
-    var authenticated = try handleCommand(
+    var started = try handleCommand(
         alloc,
         "auth remote --open",
         command_request,
     );
-    defer authenticated.deinit(alloc);
-    try expectLine(authenticated, "Authenticated MCP server 'remote'.", true);
+    defer started.deinit(alloc);
+    try expectLine(
+        started,
+        "Waiting for MCP authentication for 'remote'. You can continue using fx while the browser flow completes.",
+        false,
+    );
     try std.testing.expectEqual(@as(usize, 2), fixture.validation_calls);
     try std.testing.expectEqual(@as(usize, 1), fixture.auth_calls);
 
-    var mismatch = try handleCommand(
+    var busy = try handleCommand(
         alloc,
-        "auth mismatch --open",
+        "auth busy --open",
         command_request,
     );
-    defer mismatch.deinit(alloc);
+    defer busy.deinit(alloc);
     try expectLine(
-        mismatch,
-        "MCP authentication for 'mismatch' was rejected: expected issuer \"https://signin.auth.plain.com/\" but metadata returned \"https://signin.auth.plain.com\". Add \"oauth\":{\"issuer\":\"https://signin.auth.plain.com\"} to this server's entry in ~/.fx/mcp.json and retry.",
+        busy,
+        "MCP authentication for 'busy' is already in progress or MCP configuration is reloading.",
         false,
     );
     try std.testing.expectEqual(@as(usize, 3), fixture.validation_calls);
@@ -1905,10 +1888,20 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
     try std.testing.expectEqual(@as(usize, 4), fixture.validation_calls);
     try std.testing.expectEqual(@as(usize, 2), fixture.auth_calls);
 
+    fixture.logout_busy = true;
+    var logout_busy = try handleCommand(alloc, "logout remote", command_request);
+    defer logout_busy.deinit(alloc);
+    try expectLine(
+        logout_busy,
+        "MCP authentication for 'remote' is still in progress. Wait for it to finish before logging out.",
+        false,
+    );
+    fixture.logout_busy = false;
+
     var logged_out = try handleCommand(alloc, "logout remote", command_request);
     defer logged_out.deinit(alloc);
     try expectLine(logged_out, "Logged out of MCP server 'remote'.", true);
-    try std.testing.expectEqual(@as(usize, 1), fixture.logout_calls);
+    try std.testing.expectEqual(@as(usize, 2), fixture.logout_calls);
 }
 
 test "loadConfigFromJson parses canonical local config with command array" {

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -126,6 +126,28 @@ fn formatMcpPublishedReload(
     return out.toOwnedSlice();
 }
 
+fn formatMcpIssuerMismatch(
+    alloc: std.mem.Allocator,
+    server_name: []const u8,
+    mismatch: mcp_auth.IssuerMismatch,
+) ![]u8 {
+    var expected = try text_utils.encodeTerminalSafe(alloc, mismatch.expected, 1024);
+    defer expected.deinit(alloc);
+    var returned = try text_utils.encodeTerminalSafe(alloc, mismatch.returned, 1024);
+    defer returned.deinit(alloc);
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.print("MCP authentication for '{s}' was rejected: expected issuer ", .{server_name});
+    try std.json.Stringify.value(expected.bytes, .{}, &out.writer);
+    try out.writer.writeAll(" but metadata returned ");
+    try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
+    try out.writer.writeAll(". Add \"oauth\":{\"issuer\":");
+    try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
+    try out.writer.writeAll("} to this server's entry in ~/.fx/mcp.json and retry.");
+    return out.toOwnedSlice();
+}
+
 fn persistUserPreferences(
     app: anytype,
     label: []const u8,
@@ -421,6 +443,67 @@ pub fn Handlers(comptime App: type) type {
                 .tone = if (warning) .warning else .neutral,
                 .body = body,
             }, true);
+        }
+
+        pub fn collectMcpAuthenticationFacts(app: *App) !void {
+            if (comptime !@hasDecl(App, "takeMcpAuthenticationCompletion")) return;
+            var completion = (try app.takeMcpAuthenticationCompletion()) orelse return;
+            defer completion.deinit(app.alloc);
+
+            if (completion.result) |authentication| {
+                switch (authentication) {
+                    .authenticated => {
+                        const success = try std.fmt.allocPrint(
+                            app.alloc,
+                            "Authenticated MCP server '{s}'.",
+                            .{completion.server_name},
+                        );
+                        defer app.alloc.free(success);
+                        app.beginMcpReload() catch |err| {
+                            const body = try std.fmt.allocPrint(
+                                app.alloc,
+                                "{s}\nMCP configuration could not be reloaded. Your existing MCP servers are still active. Check the configuration and run /mcp list for details before trying again.",
+                                .{success},
+                            );
+                            defer app.alloc.free(body);
+                            debug_trace.logf("mcp", "profile reload retained current runtime err={s}", .{@errorName(err)});
+                            try app.writeDomainNotice(.{ .topic = "mcp", .tone = .warning, .body = body }, true);
+                            return;
+                        };
+                        const body = try std.fmt.allocPrint(
+                            app.alloc,
+                            "{s}\nMCP reconnection started. Your existing MCP servers will stay active while the new configuration is checked.",
+                            .{success},
+                        );
+                        defer app.alloc.free(body);
+                        try app.writeDomainNotice(.{ .topic = "mcp", .tone = .neutral, .body = body }, true);
+                    },
+                    .issuer_mismatch => |mismatch| {
+                        const body = try formatMcpIssuerMismatch(
+                            app.alloc,
+                            completion.server_name,
+                            mismatch,
+                        );
+                        defer app.alloc.free(body);
+                        try app.writeDomainNotice(.{ .topic = "mcp", .tone = .warning, .body = body }, true);
+                    },
+                }
+            } else |err| {
+                const body = if (err == error.Cancelled)
+                    try std.fmt.allocPrint(
+                        app.alloc,
+                        "MCP authentication for '{s}' was cancelled.",
+                        .{completion.server_name},
+                    )
+                else
+                    try std.fmt.allocPrint(
+                        app.alloc,
+                        "MCP authentication for '{s}' failed: {s}.",
+                        .{ completion.server_name, @errorName(err) },
+                    );
+                defer app.alloc.free(body);
+                try app.writeDomainNotice(.{ .topic = "mcp", .tone = .warning, .body = body }, true);
+            }
         }
 
         fn handleFeedback(app: *App) !void {
@@ -1315,16 +1398,12 @@ pub fn Handlers(comptime App: type) type {
         fn authenticateMcpServer(
             ctx: *anyopaque,
             name: []const u8,
-        ) !mcp_auth.AuthenticationResult {
-            if (comptime !@hasDecl(App, "acquireMcpRuntime") or
-                !@hasDecl(App, "urlOpener"))
-            {
+        ) !mcp_command_provider.AuthenticationStart {
+            if (comptime !@hasDecl(App, "startMcpAuthentication")) {
                 return error.McpAuthenticationUnavailable;
             }
             const app: *App = @ptrCast(@alignCast(ctx));
-            var lease = app.acquireMcpRuntime() orelse return error.McpServerNotFound;
-            defer lease.deinit();
-            return lease.runtime.authenticateServer(name, app, openMcpAuthUrl);
+            return app.startMcpAuthentication(name);
         }
 
         fn validateMcpAuthenticationServer(ctx: *anyopaque, name: []const u8) !void {
@@ -1337,16 +1416,6 @@ pub fn Handlers(comptime App: type) type {
             try lease.runtime.validateAuthenticationServer(name);
         }
 
-        fn openMcpAuthUrl(
-            ctx: ?*anyopaque,
-            alloc: std.mem.Allocator,
-            url: []const u8,
-        ) anyerror!bool {
-            if (comptime !@hasDecl(App, "urlOpener")) return false;
-            const app: *App = @ptrCast(@alignCast(ctx.?));
-            return app.urlOpener().open(alloc, url);
-        }
-
         fn logoutMcpServer(
             ctx: *anyopaque,
             name: []const u8,
@@ -1355,6 +1424,9 @@ pub fn Handlers(comptime App: type) type {
                 return error.McpAuthenticationUnavailable;
             }
             const app: *App = @ptrCast(@alignCast(ctx));
+            if (comptime @hasDecl(App, "mcpAuthenticationPending")) {
+                if (app.mcpAuthenticationPending(name)) return .{ .busy = true };
+            }
             var lease = app.acquireMcpRuntime() orelse return error.McpServerNotFound;
             defer lease.deinit();
             const result = try lease.runtime.logoutServer(name);
@@ -3323,6 +3395,7 @@ const McpCommandFakeApp = struct {
     last_tone: ?types.NoticeTone = null,
     reload_behavior: ReloadBehavior = .published_empty,
     reload_pending: bool = false,
+    authentication_pending: bool = false,
 
     fn deinit(self: *McpCommandFakeApp) void {
         self.notice_body.deinit(self.alloc);
@@ -3337,7 +3410,6 @@ const McpCommandFakeApp = struct {
         rest: []const u8,
         request: mcp_command_provider.Request,
     ) !mcp_command_provider.Result {
-        _ = request;
         if (std.mem.eql(u8, rest, "reload")) {
             return .{
                 .display = .{
@@ -3348,11 +3420,15 @@ const McpCommandFakeApp = struct {
             };
         }
         try std.testing.expectEqualStrings("auth fixture --open", rest);
+        const self: *McpCommandFakeApp = @ptrCast(@alignCast(request.list_ctx));
+        self.authentication_pending = true;
         return .{
             .display = .{
-                .line = try alloc.dupe(u8, "Authenticated MCP server 'fixture'."),
+                .line = try alloc.dupe(
+                    u8,
+                    "Waiting for MCP authentication for 'fixture'. You can continue using fx while the browser flow completes.",
+                ),
             },
-            .reload = true,
         };
     }
 
@@ -3408,6 +3484,17 @@ const McpCommandFakeApp = struct {
             } },
             .completion_failed => .{ .failed = error.TestReloadFailed },
             .begin_failed => unreachable,
+        };
+    }
+
+    fn takeMcpAuthenticationCompletion(
+        self: *McpCommandFakeApp,
+    ) !?app_mcp_runtime.AuthenticationCompletion {
+        if (!self.authentication_pending) return null;
+        self.authentication_pending = false;
+        return .{
+            .server_name = try self.alloc.dupe(u8, "fixture"),
+            .result = .authenticated,
         };
     }
 
@@ -3972,16 +4059,24 @@ test "app_commands preserves command display after implicit MCP reload" {
 
     try Handlers(McpCommandFakeApp).commandHandleMcp(@ptrCast(&app), "auth fixture --open");
 
-    try std.testing.expectEqual(@as(usize, 1), app.reload_count);
+    try std.testing.expectEqual(@as(usize, 0), app.reload_count);
     try std.testing.expectEqual(@as(usize, 1), app.notice_count);
     try std.testing.expectEqualStrings("mcp", app.last_topic.?);
     try std.testing.expectEqual(types.NoticeTone.neutral, app.last_tone.?);
     try std.testing.expectEqualStrings(
-        "Authenticated MCP server 'fixture'.\nMCP reconnection started. Your existing MCP servers will stay active while the new configuration is checked.",
+        "Waiting for MCP authentication for 'fixture'. You can continue using fx while the browser flow completes.",
         app.notice_body.items,
     );
-    try Handlers(McpCommandFakeApp).collectMcpReloadFacts(&app);
+    try Handlers(McpCommandFakeApp).collectMcpAuthenticationFacts(&app);
+    try std.testing.expectEqual(@as(usize, 1), app.reload_count);
     try std.testing.expectEqual(@as(usize, 2), app.notice_count);
+    try std.testing.expect(std.mem.endsWith(
+        u8,
+        app.notice_body.items,
+        "Authenticated MCP server 'fixture'.\nMCP reconnection started. Your existing MCP servers will stay active while the new configuration is checked.",
+    ));
+    try Handlers(McpCommandFakeApp).collectMcpReloadFacts(&app);
+    try std.testing.expectEqual(@as(usize, 3), app.notice_count);
 }
 
 test "app_commands warns when implicit MCP reload cannot replace the active servers" {
@@ -3994,13 +4089,16 @@ test "app_commands warns when implicit MCP reload cannot replace the active serv
 
         try Handlers(McpCommandFakeApp).commandHandleMcp(@ptrCast(&app), "auth fixture --open");
 
-        try std.testing.expectEqual(@as(usize, 1), app.reload_count);
+        try std.testing.expectEqual(@as(usize, 0), app.reload_count);
         try std.testing.expectEqual(@as(usize, 1), app.notice_count);
         try std.testing.expectEqualStrings("mcp", app.last_topic.?);
+        try Handlers(McpCommandFakeApp).collectMcpAuthenticationFacts(&app);
+        try std.testing.expectEqual(@as(usize, 1), app.reload_count);
+        try std.testing.expectEqual(@as(usize, 2), app.notice_count);
         if (behavior != .begin_failed) {
             try std.testing.expectEqual(types.NoticeTone.neutral, app.last_tone.?);
             try Handlers(McpCommandFakeApp).collectMcpReloadFacts(&app);
-            try std.testing.expectEqual(@as(usize, 2), app.notice_count);
+            try std.testing.expectEqual(@as(usize, 3), app.notice_count);
             try std.testing.expectEqual(types.NoticeTone.warning, app.last_tone.?);
             try std.testing.expect(std.mem.find(
                 u8,

--- a/src/core/app/app_mcp_runtime.zig
+++ b/src/core/app/app_mcp_runtime.zig
@@ -1,7 +1,11 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const io_mod = @import("../shared/io.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
+const host = @import("../hosts/host.zig");
 const mcp_access = @import("../mcp/access_policy.zig");
+const mcp_auth = @import("../mcp/mcp_auth.zig");
+const mcp_command_provider = @import("../mcp/command_provider.zig");
 const mcp_contract = @import("../mcp/mcp_contract.zig");
 const elicitation = @import("../mcp/elicitation.zig");
 const mcp_health = @import("../mcp/health.zig");
@@ -157,12 +161,78 @@ const PendingReload = struct {
     }
 };
 
+pub const AuthenticationCompletion = struct {
+    server_name: []u8,
+    result: anyerror!mcp_auth.AuthenticationResult,
+
+    pub fn deinit(self: *AuthenticationCompletion, alloc: Allocator) void {
+        alloc.free(self.server_name);
+        deinitAuthenticationResult(self.result);
+        self.* = undefined;
+    }
+};
+
+const PendingAuthentication = struct {
+    alloc: Allocator,
+    server_name: []u8,
+    lease: Lease,
+    opener: host.UrlOpener,
+    cancel_requested: std.atomic.Value(bool) = .init(false),
+    done: std.atomic.Value(bool) = .init(false),
+    thread: ?std.Thread = null,
+    result: ?(anyerror!mcp_auth.AuthenticationResult) = null,
+
+    fn run(self: *PendingAuthentication) void {
+        self.result = self.lease.runtime.authenticateServerControlled(
+            self.server_name,
+            self,
+            openUrl,
+            &self.cancel_requested,
+        );
+        self.done.store(true, .release);
+    }
+
+    fn openUrl(
+        raw: ?*anyopaque,
+        alloc: Allocator,
+        url: []const u8,
+    ) anyerror!bool {
+        const self: *PendingAuthentication = @ptrCast(@alignCast(raw.?));
+        return self.opener.open(alloc, url);
+    }
+
+    fn join(self: *PendingAuthentication) void {
+        if (comptime builtin.single_threaded) {
+            std.debug.assert(self.thread == null);
+            return;
+        }
+        if (self.thread) |thread| {
+            self.thread = null;
+            thread.join();
+        }
+    }
+
+    fn deinit(self: *PendingAuthentication) void {
+        self.join();
+        if (self.result) |result| deinitAuthenticationResult(result);
+        self.lease.deinit();
+        self.alloc.free(self.server_name);
+        self.alloc.destroy(self);
+    }
+};
+
+fn deinitAuthenticationResult(result: anyerror!mcp_auth.AuthenticationResult) void {
+    var owned = result catch return;
+    owned.deinit();
+}
+
 /// Owns the native profile MCP runtime. All transport work and retirement happen
 /// after releasing this state lock; the lock protects only pointer publication.
 pub const State = struct {
     lock: std.Io.RwLock = .init,
     runtime: ?*mcp_runtime.McpRuntime = null,
     pending_reload: ?*PendingReload = null,
+    pending_authentication: ?*PendingAuthentication = null,
 
     pub fn installInitial(self: *State, runtime: ?*mcp_runtime.McpRuntime) void {
         std.debug.assert(self.runtime == null);
@@ -342,6 +412,96 @@ pub const State = struct {
         return lease.runtime.requiredStartupFailure(alloc, captured_at_ms);
     }
 
+    pub fn startAuthentication(
+        self: *State,
+        alloc: Allocator,
+        server_name: []const u8,
+        opener: host.UrlOpener,
+    ) !mcp_command_provider.AuthenticationStart {
+        const pending = try alloc.create(PendingAuthentication);
+        var pending_owned = true;
+        errdefer if (pending_owned) alloc.destroy(pending);
+        const owned_name = try alloc.dupe(u8, server_name);
+        var name_owned = true;
+        errdefer if (name_owned) alloc.free(owned_name);
+
+        self.lock.lockUncancelable(io_mod.getIo());
+        if (self.pending_authentication != null or self.pending_reload != null) {
+            self.lock.unlock(io_mod.getIo());
+            alloc.free(owned_name);
+            alloc.destroy(pending);
+            return .busy;
+        }
+        const runtime = self.runtime orelse {
+            self.lock.unlock(io_mod.getIo());
+            return error.McpServerNotFound;
+        };
+        if (!runtime.acquireUse()) {
+            self.lock.unlock(io_mod.getIo());
+            return error.McpServerNotFound;
+        }
+        runtime.validateAuthenticationServer(server_name) catch |err| {
+            runtime.releaseUse();
+            self.lock.unlock(io_mod.getIo());
+            return err;
+        };
+        pending.* = .{
+            .alloc = alloc,
+            .server_name = owned_name,
+            .lease = .{ .runtime = runtime },
+            .opener = opener,
+        };
+        pending_owned = false;
+        name_owned = false;
+        self.pending_authentication = pending;
+        self.lock.unlock(io_mod.getIo());
+
+        if (comptime builtin.single_threaded) {
+            pending.run();
+        } else {
+            pending.thread = std.Thread.spawn(.{}, PendingAuthentication.run, .{pending}) catch |err| {
+                self.lock.lockUncancelable(io_mod.getIo());
+                if (self.pending_authentication == pending) self.pending_authentication = null;
+                self.lock.unlock(io_mod.getIo());
+                pending.deinit();
+                return err;
+            };
+        }
+        return .started;
+    }
+
+    pub fn takeAuthenticationCompletion(self: *State) ?AuthenticationCompletion {
+        self.lock.lockUncancelable(io_mod.getIo());
+        const pending = self.pending_authentication orelse {
+            self.lock.unlock(io_mod.getIo());
+            return null;
+        };
+        if (!pending.done.load(.acquire)) {
+            self.lock.unlock(io_mod.getIo());
+            return null;
+        }
+        self.pending_authentication = null;
+        self.lock.unlock(io_mod.getIo());
+
+        pending.join();
+        const result = pending.result.?;
+        pending.result = null;
+        const server_name = pending.server_name;
+        pending.lease.deinit();
+        pending.alloc.destroy(pending);
+        return .{
+            .server_name = server_name,
+            .result = result,
+        };
+    }
+
+    pub fn authenticationPending(self: *State, server_name: []const u8) bool {
+        self.lock.lockSharedUncancelable(io_mod.getIo());
+        defer self.lock.unlockShared(io_mod.getIo());
+        const pending = self.pending_authentication orelse return false;
+        return std.mem.eql(u8, pending.server_name, server_name);
+    }
+
     pub fn reload(
         self: *State,
         alloc: Allocator,
@@ -383,8 +543,11 @@ pub const State = struct {
         };
         self.lock.lockUncancelable(io_mod.getIo());
         std.debug.assert(self.pending_reload == null);
+        const authentication = self.pending_authentication;
+        self.pending_authentication = null;
         self.pending_reload = pending;
         self.lock.unlock(io_mod.getIo());
+        if (authentication) |task| cancelAndDeinitAuthentication(task, "reload");
 
         if (comptime builtin.single_threaded) {
             pending.run();
@@ -430,6 +593,14 @@ pub const State = struct {
         self.pending_reload = null;
         self.lock.unlock(io_mod.getIo());
         if (pending) |task| task.deinit();
+    }
+
+    fn cancelPendingAuthentication(self: *State, reason: []const u8) void {
+        self.lock.lockUncancelable(io_mod.getIo());
+        const pending = self.pending_authentication;
+        self.pending_authentication = null;
+        self.lock.unlock(io_mod.getIo());
+        if (pending) |task| cancelAndDeinitAuthentication(task, reason);
     }
 
     fn reloadControlled(
@@ -486,6 +657,7 @@ pub const State = struct {
     }
 
     pub fn deinit(self: *State, alloc: Allocator) void {
+        self.cancelPendingAuthentication("shutdown");
         self.cancelPendingReload();
         self.lock.lockUncancelable(io_mod.getIo());
         const previous = self.runtime;
@@ -495,6 +667,19 @@ pub const State = struct {
         self.* = .{};
     }
 };
+
+fn cancelAndDeinitAuthentication(
+    pending: *PendingAuthentication,
+    reason: []const u8,
+) void {
+    debug_trace.logf(
+        "mcp",
+        "discarding pending authentication server={s} reason={s}",
+        .{ pending.server_name, reason },
+    );
+    pending.cancel_requested.store(true, .release);
+    pending.deinit();
+}
 
 pub fn buildGatewayToolProjection(
     state: *State,
@@ -691,6 +876,62 @@ test "pending reload returns immediately and publishes one completion" {
     }
     try std.testing.expect(state.takeReloadCompletion() == null);
     try std.testing.expect(state.acquire() == null);
+}
+
+test "authentication admission is busy while reload is pending" {
+    const alloc = std.testing.allocator;
+    var state: State = .{};
+    defer state.deinit(alloc);
+
+    test_reload_mode = .delayed_empty;
+    try state.beginReload(alloc, .{}, loadTestReloadRuntime, .{}, 55);
+    try std.testing.expectEqual(
+        mcp_command_provider.AuthenticationStart.busy,
+        try state.startAuthentication(
+            alloc,
+            "fixture",
+            host.unavailable_url_opener,
+        ),
+    );
+
+    var completion: ?ReloadCompletion = null;
+    const deadline = io_mod.milliTimestamp() + 2_000;
+    while (completion == null and io_mod.milliTimestamp() < deadline) {
+        io_mod.sleep(std.time.ns_per_ms);
+        completion = state.takeReloadCompletion();
+    }
+    var loaded = completion orelse return error.TestUnexpectedResult;
+    loaded.deinit(alloc);
+}
+
+test "authentication completion releases its lease and is taken once" {
+    const alloc = std.testing.allocator;
+    var state: State = .{};
+    defer state.deinit(alloc);
+    const runtime = try alloc.create(mcp_runtime.McpRuntime);
+    runtime.* = mcp_runtime.McpRuntime.init(alloc);
+    state.installInitial(runtime);
+
+    const pending = try alloc.create(PendingAuthentication);
+    pending.* = .{
+        .alloc = alloc,
+        .server_name = try alloc.dupe(u8, "fixture"),
+        .lease = state.acquire() orelse return error.TestUnexpectedResult,
+        .opener = host.unavailable_url_opener,
+        .done = .init(true),
+        .result = error.Cancelled,
+    };
+    state.pending_authentication = pending;
+    try std.testing.expect(state.authenticationPending("fixture"));
+    try std.testing.expect(!state.authenticationPending("other"));
+
+    var completion = state.takeAuthenticationCompletion() orelse
+        return error.TestUnexpectedResult;
+    defer completion.deinit(alloc);
+    try std.testing.expectEqualStrings("fixture", completion.server_name);
+    try std.testing.expectError(error.Cancelled, completion.result);
+    try std.testing.expect(!state.authenticationPending("fixture"));
+    try std.testing.expect(state.takeAuthenticationCompletion() == null);
 }
 
 test "superseding and deinitializing a stalled pending reload cancel before join" {

--- a/src/core/mcp/command_provider.zig
+++ b/src/core/mcp/command_provider.zig
@@ -1,20 +1,25 @@
 const std = @import("std");
-const mcp_auth = @import("mcp_auth.zig");
 
 const Allocator = std.mem.Allocator;
+
+pub const AuthenticationStart = enum {
+    started,
+    busy,
+};
 
 pub const ListServersFn = *const fn (ctx: *anyopaque, alloc: Allocator) anyerror![]u8;
 pub const SummarizeServersFn = *const fn (ctx: *anyopaque, alloc: Allocator) anyerror![]u8;
 pub const AuthenticateServerFn = *const fn (
     ctx: *anyopaque,
     name: []const u8,
-) anyerror!mcp_auth.AuthenticationResult;
+) anyerror!AuthenticationStart;
 pub const ValidateAuthenticationServerFn = *const fn (
     ctx: *anyopaque,
     name: []const u8,
 ) anyerror!void;
 
 pub const LogoutResult = struct {
+    busy: bool = false,
     removed: bool = false,
     revocation_failed: bool = false,
 };

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -203,7 +203,15 @@ pub const AutomatedAuthorizationOptions = struct {
     challenge: Challenge,
     config: ClientConfig = .{},
     previous_scope: ?[]const u8 = null,
+    cancel_flag: ?*const std.atomic.Value(bool) = null,
     lifecycle_cancel_flag: ?*const std.atomic.Value(bool) = null,
+
+    fn cancellation(self: AutomatedAuthorizationOptions) operation_control.CancellationSources {
+        return .{
+            .caller = self.cancel_flag,
+            .runtime = self.lifecycle_cancel_flag,
+        };
+    }
 };
 
 pub const OpenUrlFn = *const fn (
@@ -219,6 +227,7 @@ pub const InteractiveAuthorizationOptions = struct {
     previous_scope: ?[]const u8 = null,
     open_ctx: ?*anyopaque = null,
     open_url: OpenUrlFn,
+    cancel_flag: ?*const std.atomic.Value(bool) = null,
     lifecycle_cancel_flag: ?*const std.atomic.Value(bool) = null,
 };
 
@@ -1013,7 +1022,10 @@ pub fn authorizeInteractive(
         .listener = &listener,
         .open_ctx = options.open_ctx,
         .open_url = options.open_url,
-        .lifecycle_cancel_flag = options.lifecycle_cancel_flag,
+        .cancellation = .{
+            .caller = options.cancel_flag,
+            .runtime = options.lifecycle_cancel_flag,
+        },
     };
     return authorizeWithRedirect(
         alloc,
@@ -1022,6 +1034,7 @@ pub fn authorizeInteractive(
             .challenge = options.challenge,
             .config = options.config,
             .previous_scope = options.previous_scope,
+            .cancel_flag = options.cancel_flag,
             .lifecycle_cancel_flag = options.lifecycle_cancel_flag,
         },
         redirect_uri,
@@ -1044,7 +1057,7 @@ fn authorizeWithRedirect(
     authorization_ctx: ?*anyopaque,
     request_authorization: AuthorizationRequestFn,
 ) !AuthorizationResult {
-    try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
+    try checkAuthorizationCancellation(options.cancellation());
     const endpoint = try canonicalResource(alloc, options.endpoint);
     errdefer alloc.free(endpoint);
     var resource = if (options.config.resource) |configured|
@@ -1059,7 +1072,7 @@ fn authorizeWithRedirect(
         options.challenge.resource_metadata,
     );
     defer prm.deinit(alloc);
-    try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
+    try checkAuthorizationCancellation(options.cancellation());
     if (!std.mem.eql(u8, resource, prm.resource)) {
         alloc.free(resource);
         resource = try alloc.dupe(u8, prm.resource);
@@ -1071,7 +1084,7 @@ fn authorizeWithRedirect(
         .issuer_mismatch => |mismatch| return .{ .issuer_mismatch = mismatch },
     };
     defer metadata.deinit(alloc);
-    try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
+    try checkAuthorizationCancellation(options.cancellation());
     try validateAuthorizationMetadataUrls(metadata, resource);
     if (!metadata.supports(.s256)) return error.PkceS256NotSupported;
 
@@ -1083,7 +1096,7 @@ fn authorizeWithRedirect(
         redirect_uri,
     );
     defer registration.deinit(alloc);
-    try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
+    try checkAuthorizationCancellation(options.cancellation());
 
     const scope = try requestedScope(
         alloc,
@@ -1128,7 +1141,7 @@ fn authorizeWithRedirect(
         scope,
     );
     defer secret.zeroAndFree(alloc, authorization_url);
-    try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
+    try checkAuthorizationCancellation(options.cancellation());
     var callback = try request_authorization(
         authorization_ctx,
         alloc,
@@ -1136,7 +1149,7 @@ fn authorizeWithRedirect(
         redirect_uri,
     );
     defer callback.deinit(alloc);
-    try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
+    try checkAuthorizationCancellation(options.cancellation());
     validateAuthorizationResponse(
         state,
         metadata.issuer,
@@ -1164,7 +1177,7 @@ fn authorizeWithRedirect(
         scope,
     );
     errdefer grant.deinit(alloc);
-    try checkAuthorizationCancellation(options.lifecycle_cancel_flag);
+    try checkAuthorizationCancellation(options.cancellation());
     const owned_issuer = try alloc.dupe(u8, metadata.issuer);
     errdefer alloc.free(owned_issuer);
     const authorization_endpoint = try alloc.dupe(u8, metadata.authorization_endpoint);
@@ -1223,23 +1236,21 @@ const InteractiveAuthorizationContext = struct {
     listener: *std.Io.net.Server,
     open_ctx: ?*anyopaque,
     open_url: OpenUrlFn,
-    lifecycle_cancel_flag: ?*const std.atomic.Value(bool),
+    cancellation: operation_control.CancellationSources,
 };
 
 const interactive_callback_timeout_ms: i32 = 5 * 60 * 1000;
 const interactive_callback_poll_ms: i32 = 50;
 
 fn checkAuthorizationCancellation(
-    lifecycle_cancel_flag: ?*const std.atomic.Value(bool),
+    cancellation: operation_control.CancellationSources,
 ) !void {
-    if (lifecycle_cancel_flag) |flag| {
-        if (flag.load(.acquire)) return error.Cancelled;
-    }
+    if (cancellation.cancelled()) return error.Cancelled;
 }
 
 fn waitForInteractiveCallback(
     listener: *std.Io.net.Server,
-    lifecycle_cancel_flag: ?*const std.atomic.Value(bool),
+    cancellation: operation_control.CancellationSources,
 ) !void {
     var fds = [_]std.posix.pollfd{.{
         .fd = listener.socket.handle,
@@ -1248,7 +1259,7 @@ fn waitForInteractiveCallback(
     }};
     var remaining_ms = interactive_callback_timeout_ms;
     while (remaining_ms > 0) {
-        try checkAuthorizationCancellation(lifecycle_cancel_flag);
+        try checkAuthorizationCancellation(cancellation);
         fds[0].revents = 0;
         const wait_ms = @min(remaining_ms, interactive_callback_poll_ms);
         const ready = try std.posix.poll(&fds, wait_ms);
@@ -1256,7 +1267,7 @@ fn waitForInteractiveCallback(
             if ((fds[0].revents & std.posix.POLL.IN) == 0) {
                 return error.McpAuthorizationCallbackTimedOut;
             }
-            try checkAuthorizationCancellation(lifecycle_cancel_flag);
+            try checkAuthorizationCancellation(cancellation);
             return;
         }
         remaining_ms -= wait_ms;
@@ -1271,11 +1282,11 @@ fn requestInteractiveAuthorization(
     _: []const u8,
 ) !AuthorizationResponse {
     const ctx: *InteractiveAuthorizationContext = @ptrCast(@alignCast(raw_ctx.?));
-    try checkAuthorizationCancellation(ctx.lifecycle_cancel_flag);
+    try checkAuthorizationCancellation(ctx.cancellation);
     if (!try ctx.open_url(ctx.open_ctx, alloc, authorization_url)) {
         return error.McpAuthorizationBrowserOpenFailed;
     }
-    try waitForInteractiveCallback(ctx.listener, ctx.lifecycle_cancel_flag);
+    try waitForInteractiveCallback(ctx.listener, ctx.cancellation);
 
     var stream = try ctx.listener.accept(io_mod.getIo());
     defer stream.close(io_mod.getIo());
@@ -2441,7 +2452,7 @@ test "authorization redirect target must match the registered callback" {
     );
 }
 
-test "interactive callback wait observes lifecycle cancellation" {
+test "interactive callback wait observes caller and lifecycle cancellation" {
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
         return error.SkipZigTest;
     }
@@ -2449,20 +2460,27 @@ test "interactive callback wait observes lifecycle cancellation" {
     var listener = try address.listen(std.testing.io, .{ .reuse_address = true });
     defer listener.deinit(std.testing.io);
 
-    var cancelled = std.atomic.Value(bool).init(false);
     const Flip = struct {
         fn run(flag: *std.atomic.Value(bool)) void {
             io_mod.sleep(20 * std.time.ns_per_ms);
             flag.store(true, .release);
         }
     };
-    const thread = try std.Thread.spawn(.{}, Flip.run, .{&cancelled});
-    defer thread.join();
+    inline for (.{ "caller", "runtime" }) |source| {
+        var caller = std.atomic.Value(bool).init(false);
+        var runtime = std.atomic.Value(bool).init(false);
+        const flag = if (std.mem.eql(u8, source, "caller")) &caller else &runtime;
+        const thread = try std.Thread.spawn(.{}, Flip.run, .{flag});
+        defer thread.join();
 
-    const started_ms = io_mod.milliTimestamp();
-    try std.testing.expectError(
-        error.Cancelled,
-        waitForInteractiveCallback(&listener, &cancelled),
-    );
-    try std.testing.expect(io_mod.milliTimestamp() - started_ms < 1_000);
+        const started_ms = io_mod.milliTimestamp();
+        try std.testing.expectError(
+            error.Cancelled,
+            waitForInteractiveCallback(&listener, .{
+                .caller = &caller,
+                .runtime = &runtime,
+            }),
+        );
+        try std.testing.expect(io_mod.milliTimestamp() - started_ms < 1_000);
+    }
 }

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -5236,6 +5236,26 @@ pub const McpRuntime = struct {
         open_ctx: ?*anyopaque,
         open_url: mcp_auth.OpenUrlFn,
     ) !mcp_auth.AuthenticationResult {
+        return self.authenticateServerControlled(
+            name,
+            open_ctx,
+            open_url,
+            null,
+        );
+    }
+
+    pub fn authenticateServerControlled(
+        self: *McpRuntime,
+        name: []const u8,
+        open_ctx: ?*anyopaque,
+        open_url: mcp_auth.OpenUrlFn,
+        cancel_flag: ?*const std.atomic.Value(bool),
+    ) !mcp_auth.AuthenticationResult {
+        const cancellation = operation_control.CancellationSources{
+            .caller = cancel_flag,
+            .runtime = &self.retiring,
+        };
+        if (cancellation.cancelled()) return error.Cancelled;
         const server = try self.authenticationServer(name);
         server.connection_lock.lockSharedUncancelable(io_mod.getIo());
         var connection_locked = true;
@@ -5282,6 +5302,7 @@ pub const McpRuntime = struct {
             .previous_scope = source.previous_scope,
             .open_ctx = open_ctx,
             .open_url = open_url,
+            .cancel_flag = cancel_flag,
             .lifecycle_cancel_flag = &self.retiring,
         })) {
             .credentials => |credentials| credentials,
@@ -5292,7 +5313,11 @@ pub const McpRuntime = struct {
         {
             server.auth_lock.lockUncancelable(io_mod.getIo());
             defer server.auth_lock.unlock(io_mod.getIo());
-            try validateInteractiveAuthPublication(self, server, source.generation);
+            try validateInteractiveAuthPublication(
+                server,
+                source.generation,
+                cancellation,
+            );
             try mcp_auth_store.save(self.alloc, server.config.name, credentials);
             installAuthCredentials(self.alloc, server, &credentials);
             transferred = true;
@@ -5330,11 +5355,11 @@ pub const McpRuntime = struct {
     }
 
     fn validateInteractiveAuthPublication(
-        self: *const McpRuntime,
         server: *const McpServer,
         generation: u64,
+        cancellation: operation_control.CancellationSources,
     ) !void {
-        if (self.retiring.load(.acquire)) return error.Cancelled;
+        if (cancellation.cancelled()) return error.Cancelled;
         if (server.auth_logout_in_progress.load(.acquire) or
             server.auth_generation.load(.acquire) != generation)
         {
@@ -5906,7 +5931,9 @@ pub const McpRuntime = struct {
                 for (server.tool_catalog.tools.items) |tool| {
                     if (!operation_access.allows(.{ .tool = tool.prefixed_name })) continue;
                     if (permissions.rulesDenyAllTargetsForPermission(permission_rules, tool.prefixed_name)) continue;
-                    if (!toolMatchesQuery(tool, searchable_instructions, query)) continue;
+                    const exact_identity = queryContainsCompleteIdentity(query, tool.original_name) or
+                        queryContainsCompleteIdentity(query, tool.prefixed_name);
+                    if (!exact_identity and !toolMatchesQuery(tool, searchable_instructions, query)) continue;
                     server_matched = true;
                     if (matches.items.len >= capped_limit) {
                         more_available = true;
@@ -5929,6 +5956,7 @@ pub const McpRuntime = struct {
                     alloc,
                     self.servers.items,
                     &operation_access,
+                    query,
                 )) |output| {
                     break :result tool_mcp_runtime.SearchResult{ .model_output = output, .notice = null };
                 }
@@ -8509,9 +8537,11 @@ fn renderAuthenticationRequired(
     alloc: Allocator,
     servers: []McpServer,
     access: *const OperationAccessGuard,
+    query: []const u8,
 ) !?[]u8 {
     for (servers) |*server| {
         if (!access.allows(.{ .tool_server = server.config.name })) continue;
+        if (!queryContainsCompleteIdentity(query, server.config.name)) continue;
         server.status_lock.lockUncancelable(io_mod.getIo());
         const failed = server.state == .failed;
         server.status_lock.unlock(io_mod.getIo());
@@ -8735,21 +8765,32 @@ test "private catalog visibility is bound to the producing auth generation" {
 
 test "interactive authentication publishes only to its live auth generation" {
     var runtime = McpRuntime.init(std.testing.allocator);
+    var caller_cancelled = std.atomic.Value(bool).init(false);
     var server = McpServer{
         .config = .{ .name = "fixture" },
         .auth_generation = .init(7),
     };
+    const cancellation = operation_control.CancellationSources{
+        .caller = &caller_cancelled,
+        .runtime = &runtime.retiring,
+    };
 
-    try runtime.validateInteractiveAuthPublication(&server, 7);
+    try McpRuntime.validateInteractiveAuthPublication(&server, 7, cancellation);
+    caller_cancelled.store(true, .release);
+    try std.testing.expectError(
+        error.Cancelled,
+        McpRuntime.validateInteractiveAuthPublication(&server, 7, cancellation),
+    );
+    caller_cancelled.store(false, .release);
     server.auth_generation.store(8, .release);
     try std.testing.expectError(
         error.McpAuthorityChanged,
-        runtime.validateInteractiveAuthPublication(&server, 7),
+        McpRuntime.validateInteractiveAuthPublication(&server, 7, cancellation),
     );
     runtime.retiring.store(true, .release);
     try std.testing.expectError(
         error.Cancelled,
-        runtime.validateInteractiveAuthPublication(&server, 8),
+        McpRuntime.validateInteractiveAuthPublication(&server, 8, cancellation),
     );
 }
 
@@ -8780,7 +8821,11 @@ test "a newer pending challenge invalidates interactive authentication publicati
     try std.testing.expectEqual(@as(u64, 8), server.auth_generation.load(.acquire));
     try std.testing.expectError(
         error.McpAuthorityChanged,
-        runtime.validateInteractiveAuthPublication(&server, interactive_generation),
+        McpRuntime.validateInteractiveAuthPublication(
+            &server,
+            interactive_generation,
+            .{ .runtime = &runtime.retiring },
+        ),
     );
     try std.testing.expect(server.pending_auth_challenge != null);
     try std.testing.expectEqualStrings(
@@ -11403,6 +11448,20 @@ fn toolMatchesQuery(tool: McpTool, server_instructions: []const u8, query: []con
             !text_utils.containsIgnoreCase(server_instructions, token)) return false;
     }
     return found_token or query.len == 0;
+}
+
+fn queryContainsCompleteIdentity(query: []const u8, identity: []const u8) bool {
+    if (identity.len == 0 or identity.len > query.len) return false;
+
+    var start: usize = 0;
+    while (start <= query.len - identity.len) : (start += 1) {
+        const end = start + identity.len;
+        if (!std.ascii.eqlIgnoreCase(query[start..end], identity)) continue;
+        if (start > 0 and isSearchByte(query[start - 1])) continue;
+        if (end < query.len and isSearchByte(query[end])) continue;
+        return true;
+    }
+    return false;
 }
 
 fn buildToolTags(alloc: Allocator, server_name: []const u8, tool_name: []const u8) ![]const []u8 {
@@ -17574,6 +17633,72 @@ test "parseAndStoreTools duplicates original_name for owned cleanup" {
     try std.testing.expectEqualStrings("read", server.tool_catalog.tools.items[0].original_name);
 }
 
+test "MCP search preserves exact identities and scopes authentication guidance" {
+    const alloc = std.testing.allocator;
+    var runtime = McpRuntime.init(alloc);
+    defer runtime.deinit();
+
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "linear"),
+        .command = try alloc.dupe(u8, "cmd"),
+    });
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "slack"),
+        .command = try alloc.dupe(u8, "cmd"),
+        .bearer_token_env = try alloc.dupe(u8, "SLACK_TOKEN"),
+    });
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "a/b"),
+        .command = try alloc.dupe(u8, "cmd"),
+        .bearer_token_env = try alloc.dupe(u8, "PUNCTUATED_TOKEN"),
+    });
+    runtime.servers.items[0].state = .ready;
+    runtime.servers.items[1].state = .failed;
+    runtime.servers.items[2].state = .failed;
+
+    var used = std.StringHashMap(void).init(alloc);
+    defer used.deinit();
+    const response =
+        \\{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"echo","description":"Echo Linear data","inputSchema":{"type":"object"}},{"name":"read/file","description":"Read a Linear file","inputSchema":{"type":"object"}}]}}
+    ;
+    try parseAndStoreTools(alloc, &runtime.servers.items[0], .{}, response, &used);
+
+    const cases = [_]struct {
+        query: []const u8,
+        expected_tool: []const u8,
+    }{
+        .{ .query = "Please use MCP_LINEAR_ECHO for this request", .expected_tool = "mcp_linear_echo" },
+        .{ .query = "Please use read/file for this request", .expected_tool = "mcp_linear_read_file" },
+    };
+    for (cases) |case| {
+        var result = try runtime.searchTools(alloc, case.query, 5, .{}, .{}, .unrestricted);
+        defer result.deinit(alloc);
+        try std.testing.expect(std.mem.find(u8, result.model_output, case.expected_tool) != null);
+        try std.testing.expect(std.mem.find(u8, result.model_output, "authentication_required") == null);
+    }
+
+    var partial = try runtime.searchTools(alloc, "mcp_linear_echoes", 5, .{}, .{}, .unrestricted);
+    defer partial.deinit(alloc);
+    try std.testing.expectEqualStrings("{\"tools\":[],\"count\":0}", partial.model_output);
+
+    var unrelated = try runtime.searchTools(alloc, "linear issue", 5, .{}, .{}, .unrestricted);
+    defer unrelated.deinit(alloc);
+    try std.testing.expectEqualStrings("{\"tools\":[],\"count\":0}", unrelated.model_output);
+
+    var targeted = try runtime.searchTools(alloc, "authenticate slack now", 5, .{}, .{}, .unrestricted);
+    defer targeted.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, targeted.model_output, "\"server\":\"slack\"") != null);
+    try std.testing.expect(std.mem.find(u8, targeted.model_output, "SLACK_TOKEN") != null);
+
+    var punctuated = try runtime.searchTools(alloc, "authenticate a/b now", 5, .{}, .{}, .unrestricted);
+    defer punctuated.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, punctuated.model_output, "\"server\":\"a/b\"") != null);
+
+    var adjacent = try runtime.searchTools(alloc, "authenticate xa/by now", 5, .{}, .{}, .unrestricted);
+    defer adjacent.deinit(alloc);
+    try std.testing.expectEqualStrings("{\"tools\":[],\"count\":0}", adjacent.model_output);
+}
+
 test "MCP search returns metadata without advertising every executable schema" {
     const alloc = std.testing.allocator;
     var runtime = McpRuntime.init(alloc);
@@ -18084,6 +18209,7 @@ test "scoped MCP authentication rendering excludes denied servers" {
         alloc,
         runtime.servers.items,
         &scoped,
+        "denied",
     ) == null);
 
     var root = try OperationAccessGuard.init(alloc, .unrestricted, runtime.generation);
@@ -18092,6 +18218,7 @@ test "scoped MCP authentication rendering excludes denied servers" {
         alloc,
         runtime.servers.items,
         &root,
+        "denied",
     )).?;
     defer alloc.free(rendered);
     try std.testing.expect(std.mem.find(u8, rendered, "denied") != null);

--- a/src/core/mcp/streamable_http.zig
+++ b/src/core/mcp/streamable_http.zig
@@ -457,8 +457,15 @@ fn modernRequestInfo(value: std.json.Value) !RequestInfo {
     if (capabilities != .object) return error.InvalidModernRequest;
 
     const method = method_value.string;
-    const name = if (std.mem.eql(u8, method, "tools/call")) blk: {
-        const name_value = params_value.object.get("name") orelse return error.InvalidModernRequest;
+    const identity_field: ?[]const u8 = if (std.mem.eql(u8, method, "tools/call") or
+        std.mem.eql(u8, method, "prompts/get"))
+        "name"
+    else if (std.mem.eql(u8, method, "resources/read"))
+        "uri"
+    else
+        null;
+    const name = if (identity_field) |field| blk: {
+        const name_value = params_value.object.get(field) orelse return error.InvalidModernRequest;
         if (name_value != .string) return error.InvalidModernRequest;
         break :blk name_value.string;
     } else null;
@@ -1128,6 +1135,55 @@ test "modern MCP request headers include protocol metadata and direct scalar pro
     try expectHeader(headers, "Mcp-Param-Empty", "");
     try std.testing.expect(findHeader(headers, "Mcp-Param-Ignored") == null);
     try std.testing.expect(findHeader(headers, "Mcp-Param-Nullable") == null);
+}
+
+test "modern MCP request headers include feature identities" {
+    const alloc = std.testing.allocator;
+    const meta =
+        \\{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"fx","version":"test"},"io.modelcontextprotocol/clientCapabilities":{}}
+    ;
+    const cases = [_]struct {
+        body: []const u8,
+        method: []const u8,
+        name: []const u8,
+    }{
+        .{
+            .body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"resources/read\",\"params\":{\"_meta\":" ++ meta ++ ",\"uri\":\"Hello, 世界\"}}",
+            .method = "resources/read",
+            .name = "=?base64?SGVsbG8sIOS4lueVjA==?=",
+        },
+        .{
+            .body = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"prompts/get\",\"params\":{\"_meta\":" ++ meta ++ ",\"name\":\"review\",\"arguments\":{}}}",
+            .method = "prompts/get",
+            .name = "review",
+        },
+    };
+    for (cases) |case| {
+        var prepared = try prepareRequest(alloc, &.{}, case.body, null);
+        defer prepared.deinit(alloc);
+        try expectHeader(&prepared.headers, "Mcp-Method", case.method);
+        try expectHeader(&prepared.headers, "Mcp-Name", case.name);
+    }
+
+    const list_body =
+        \\{"jsonrpc":"2.0","id":3,"method":"resources/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"fx","version":"test"},"io.modelcontextprotocol/clientCapabilities":{}}}}
+    ;
+    var list = try prepareRequest(alloc, &.{}, list_body, null);
+    defer list.deinit(alloc);
+    try std.testing.expect(findHeader(&list.headers, "Mcp-Name") == null);
+
+    const invalid_bodies = [_][]const u8{
+        \\{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"fx","version":"test"},"io.modelcontextprotocol/clientCapabilities":{}}}}
+        ,
+        \\{"jsonrpc":"2.0","id":5,"method":"prompts/get","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientInfo":{"name":"fx","version":"test"},"io.modelcontextprotocol/clientCapabilities":{}},"name":7}}
+        ,
+    };
+    for (invalid_bodies) |body| {
+        try std.testing.expectError(
+            error.InvalidModernRequest,
+            prepareRequest(alloc, &.{}, body, null),
+        );
+    }
 }
 
 test "HTTP discovery carries required protocol metadata" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1413,6 +1413,30 @@ const App = struct {
         );
     }
 
+    pub fn startMcpAuthentication(
+        self: *App,
+        server_name: []const u8,
+    ) !mcp_command_provider.AuthenticationStart {
+        return self.mcp.startAuthentication(
+            self.alloc,
+            server_name,
+            self.urlOpener(),
+        );
+    }
+
+    pub fn takeMcpAuthenticationCompletion(
+        self: *App,
+    ) !?app_mcp_runtime.AuthenticationCompletion {
+        return self.mcp.takeAuthenticationCompletion();
+    }
+
+    pub fn mcpAuthenticationPending(
+        self: *App,
+        server_name: []const u8,
+    ) bool {
+        return self.mcp.authenticationPending(server_name);
+    }
+
     pub fn takeMcpReloadCompletion(self: *App) !?app_mcp_runtime.ReloadCompletion {
         return self.mcp.takeReloadCompletion();
     }
@@ -2496,6 +2520,7 @@ const App = struct {
         if (try self.model_cache.pollLoadTransition()) {
             RenderAppRuntime.requestActiveSurfaceFrame(self, .footer);
         }
+        try app_commands.Handlers(App).collectMcpAuthenticationFacts(self);
         try app_commands.Handlers(App).collectMcpReloadFacts(self);
         if (comptime host_profile.native_auth or host_profile.js_host_auth) {
             try AuthAppRuntime.collectSignInFacts(self);

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -528,6 +528,7 @@ function createRoot(
   configureOauth = true,
   transport: "http" | "sse" = "http",
   serverUrl = activeAuth.url,
+  followAuthorization = true,
 ) {
   const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-mcp-auth-")));
   cleanupRoot = root;
@@ -535,6 +536,8 @@ function createRoot(
   const workspace = join(root, "workspace");
   const bin = join(root, "bin");
   const trace = join(root, "trace.log");
+  const openLog = join(root, "open.log");
+  const stderr = join(root, "stderr.log");
   mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
   mkdirSync(workspace, { recursive: true });
   mkdirSync(bin, { recursive: true });
@@ -563,14 +566,17 @@ function createRoot(
       },
     }),
   );
+  const follow = followAuthorization
+    ? "nohup curl --location --silent --show-error \"$1\" >/dev/null 2>&1 &\n"
+    : "";
   const opener =
-    "#!/bin/sh\nnohup curl --location --silent --show-error \"$1\" >/dev/null 2>&1 &\nexit 0\n";
+    `#!/bin/sh\nprintf '%s\\n' "$1" > '${openLog}'\n${follow}exit 0\n`;
   for (const name of ["open", "xdg-open"]) {
     const path = join(bin, name);
     writeFileSync(path, opener);
     chmodSync(path, 0o700);
   }
-  return { root, home, workspace, bin, trace };
+  return { root, home, workspace, bin, trace, openLog, stderr };
 }
 
 function baseEnv(root: ReturnType<typeof createRoot>) {
@@ -1450,6 +1456,85 @@ describe("MCP remote authentication lifecycle", () => {
   }
 
   test(
+    "fx ask isolates failed-server authentication from healthy tool search",
+    async () => {
+      upstream = startModernMcpHttpFixture("json");
+      auth = startAuthFixture(upstream.url);
+      const root = createRoot(auth);
+      writeFileSync(
+        join(root.home, ".fx", "mcp.json"),
+        JSON.stringify({
+          mcp: {
+            linear: {
+              type: "http",
+              url: upstream.url,
+              startup_timeout_ms: 5_000,
+              operation_timeout_ms: 5_000,
+            },
+            slack: {
+              type: "http",
+              url: auth.url,
+              oauth: {
+                client_id: "fx-mcp-auth-test",
+                scopes: ["tools.read"],
+              },
+              startup_timeout_ms: 5_000,
+              operation_timeout_ms: 5_000,
+            },
+          },
+        }),
+      );
+      gateway = startFakeGateway([
+        fakeGatewayToolCall("search_exact", "mcp_search_tools", {
+          query: "Please use mcp_linear_echo for this request",
+        }),
+        fakeGatewayToolCall("search_unrelated", "mcp_search_tools", {
+          query: "linear issue",
+        }),
+        fakeGatewayToolCall("search_targeted", "mcp_search_tools", {
+          query: "authenticate slack now",
+        }),
+        fakeGatewayToolCall("search_healthy", "mcp_search_tools", {
+          query: "linear echo",
+        }),
+        fakeGatewayFinalText("MCP search isolation observed."),
+      ], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Exercise mixed MCP search."],
+        {
+          cwd: root.workspace,
+          env: {
+            ...baseEnv(root),
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          },
+          timeoutMs: 20_000,
+        },
+      );
+
+      expect(result.code).toBe(0);
+      const finalBody = gateway.requests.at(-1)?.body ?? "";
+      const exact = toolResultText(finalBody, "search_exact");
+      expect(exact).toContain("mcp_linear_echo");
+      expect(exact).not.toContain("authentication_required");
+      const unrelated = toolResultText(finalBody, "search_unrelated");
+      expect(unrelated).toContain('\"tools\":[],\"count\":0');
+      expect(unrelated).not.toContain("authentication_required");
+      const targeted = toolResultText(finalBody, "search_targeted");
+      expect(targeted).toContain("authentication_required");
+      expect(targeted).toContain('\"server\":\"slack\"');
+      expect(toolResultText(finalBody, "search_healthy")).toContain(
+        "mcp_linear_echo",
+      );
+      expect(auth.authorizationRequests).toBe(0);
+    },
+    30_000,
+  );
+
+  test(
     "fx ask reports an actionable auth requirement without opening a browser",
     async () => {
       upstream = startModernMcpHttpFixture("json");
@@ -1600,6 +1685,81 @@ describe("MCP remote authentication lifecycle", () => {
       }
     },
     45_000,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "pending browser authentication keeps input responsive and cancels on exit",
+    async () => {
+      upstream = startModernMcpHttpFixture("json");
+      auth = startAuthFixture(upstream.url);
+      const root = createRoot(auth, true, "http", auth.url, false);
+      gateway = startFakeGateway([], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+      tui = await TmuxSession.create({
+        isolated: true,
+        cwd: root.workspace,
+        env: {
+          ...baseEnv(root),
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+        },
+        width: 110,
+        height: 34,
+        stderrPath: root.stderr,
+      });
+      await tui.waitForComposer(15_000);
+
+      await tui.sendText("/mcp auth fixture --open");
+      await tui.waitForText(
+        "Waiting for MCP authentication for 'fixture'.",
+        5_000,
+      );
+      expect(await waitForFile(root.openLog, 5_000)).toBe(true);
+      expect(auth.authorizationRequests).toBe(0);
+
+      await tui.sendText("/mcp logout fixture");
+      await tui.waitForText(
+        "MCP authentication for 'fixture' is still in progress. Wait for it to finish before logging out.",
+        5_000,
+      );
+      await tui.sendText("/mcp list");
+      await tui.waitForText("auth=required", 5_000);
+
+      await tui.sendText("/mcp reload");
+      await tui.waitForText("MCP reconnection started.", 5_000);
+      await tui.waitForText("MCP configuration reloaded", 10_000);
+      expect(readFileSync(root.trace, "utf8")).toContain(
+        "discarding pending authentication server=fixture reason=reload",
+      );
+
+      rmSync(root.openLog, { force: true });
+      await tui.sendText("/mcp auth fixture --open");
+      expect(await waitForFile(root.openLog, 5_000)).toBe(true);
+
+      await tui.sendKeys("C-c");
+      await tui.waitForText("press ctrl+c again to exit", 5_000);
+      await tui.sendKeys("C-c");
+      expect(await tui.waitForSessionEnd(10_000)).toBe(true);
+
+      const trace = readFileSync(root.trace, "utf8");
+      expect(trace).toContain(
+        "discarding pending authentication server=fixture reason=shutdown",
+      );
+      for (const secretMarker of [
+        "redirect_uri=",
+        "code_verifier",
+        "access_token",
+        "refresh_token",
+      ]) {
+        expect(trace).not.toContain(secretMarker);
+      }
+      expect(
+        existsSync(join(root.home, ".fx", "mcp-credentials", "credentials.json")),
+      ).toBe(false);
+      expect(readFileSync(root.stderr, "utf8")).toBe("");
+    },
+    30_000,
   );
 
   test.skipIf(!tmuxAvailable())(

--- a/tests/e2e/mcp-http.test.ts
+++ b/tests/e2e/mcp-http.test.ts
@@ -508,9 +508,22 @@ describe("modern MCP Streamable HTTP", () => {
     expect(bodies).toContain('\\"trust\\":\\"untrusted_external\\"');
     expect(bodies).toContain("HTTP_RESOURCE_TEXT");
     expect(bodies).toContain("HTTP_PROMPT_TEXT");
-    expect(fixture.requests.filter((entry) =>
+    const resourceReads = fixture.requests.filter((entry) =>
       entry.message.method === "resources/read"
-    )).toHaveLength(2);
+    );
+    expect(resourceReads).toHaveLength(2);
+    for (const entry of resourceReads) {
+      expect(entry.headers["mcp-name"]).toBe("custom://alpha");
+    }
+    const promptGet = fixture.requests.find((entry) =>
+      entry.message.method === "prompts/get"
+    );
+    expect(promptGet?.headers["mcp-name"]).toBe("review");
+    for (const entry of fixture.requests.filter((request) =>
+      ["resources/list", "prompts/list"].includes(request.message.method)
+    )) {
+      expect(entry.headers["mcp-name"]).toBeUndefined();
+    }
     expect(fixture.requests.filter((entry) =>
       entry.message.method === "completion/complete"
     )).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Preserve exact MCP tool identities when search queries include surrounding context.
- Keep unrelated server authentication failures out of empty tool search results.
- Send the required `Mcp-Name` header for modern resource reads and prompt gets.
- Keep terminal input responsive while browser-based MCP authentication is pending.
- Return a busy response when authentication overlaps an MCP reload or same-server logout.
- Cancel pending authentication when MCP configuration reloads or fx exits, while preserving successful credential reload behavior.
