### PR TITLE
Prevent subscription requests from exhausting Gateway usage

### DIFF
--- a/src/builtins/providers.zig
+++ b/src/builtins/providers.zig
@@ -1,3 +1,4 @@
+const std = @import("std");
 const model_provider = @import("../core/config/model_provider.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
 const stream_provider = @import("../core/agent/stream_provider.zig");
@@ -21,4 +22,10 @@ pub fn modelCatalog(provider: model_provider.ProviderId) model_catalog.Provider 
         .codex => openai_codex_models.model_catalog_provider,
         .grok => xai_grok_models.model_catalog_provider,
     };
+}
+
+test "subscription providers opt out of Gateway usage observation" {
+    try std.testing.expect(agentStream(.gateway).observes_gateway_usage);
+    try std.testing.expect(!agentStream(.codex).observes_gateway_usage);
+    try std.testing.expect(!agentStream(.grok).observes_gateway_usage);
 }

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -53,7 +53,8 @@ pub fn streamGatewayCompletion(
 ) !StreamResult {
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     const started_at_ms = io_mod.milliTimestamp();
-    const usage_observation = try session_usage.GatewayObservation.begin(usage);
+    const observed_usage = if (provider.observes_gateway_usage) usage else null;
+    const usage_observation = try session_usage.GatewayObservation.begin(observed_usage);
     attempt_evidence.provider_admitted = true;
     var result = provider.stream(alloc, .{
         .api_key = api_key,
@@ -445,4 +446,85 @@ test "possibly sent gateway failure marks billing incomplete" {
     try std.testing.expectEqual(session_usage.Availability.incomplete, snapshot.billing);
     try std.testing.expect(snapshot.api_duration_complete);
     try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
+}
+
+test "provider-local streams do not consume Gateway observation capacity" {
+    const LocalProvider = struct {
+        calls: usize = 0,
+
+        fn stream(
+            raw: ?*anyopaque,
+            _: Allocator,
+            request: agent_stream_provider.Request,
+        ) anyerror!agent_stream_provider.Result {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.calls += 1;
+            request.delivery.markPossiblySent();
+            return .{
+                .status = .ok,
+                .completion = .{
+                    .generation_id = "resp_provider_local",
+                    .finish_reason = .stop,
+                    .usage = .{ .input_tokens = 3, .output_tokens = 1 },
+                },
+            };
+        }
+    };
+    const Callbacks = struct {
+        fn content(_: *anyopaque, _: []const u8) void {}
+    };
+
+    const alloc = std.testing.allocator;
+    var local_provider: LocalProvider = .{};
+    const provider = agent_stream_provider.Provider{
+        .context = &local_provider,
+        .stream_fn = LocalProvider.stream,
+        .observes_gateway_usage = false,
+    };
+    var usage = session_usage.Usage.initFresh();
+    defer usage.deinit(alloc);
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    var callback_ctx: u8 = 0;
+
+    for (0..65) |_| {
+        var delivery = DeliveryCertainty.init();
+        var attempt_evidence: AttemptEvidence = .{};
+        const result = try streamGatewayCompletion(
+            provider,
+            alloc,
+            "subscription-token",
+            .chatgpt_subscription,
+            "acct_test",
+            null,
+            "session-test",
+            "gpt-test",
+            1,
+            "https://provider.example/responses",
+            "{}",
+            null,
+            &delivery,
+            &attempt_evidence,
+            &callback_ctx,
+            Callbacks.content,
+            null,
+            null,
+            null,
+            &cancel_flag,
+            &usage,
+            alloc,
+            .{},
+            null,
+            .agent,
+        );
+        try std.testing.expectEqual(std.http.Status.ok, result.status);
+    }
+
+    try std.testing.expectEqual(@as(usize, 65), local_provider.calls);
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(session_usage.Availability.complete, snapshot.billing);
+    try std.testing.expect(snapshot.api_duration_complete);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.next_sequence);
+    try std.testing.expectEqual(@as(u64, 0), snapshot.settled_through_sequence);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
 }

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -185,6 +185,7 @@ pub const BuildFn = *const fn (
 pub const Provider = struct {
     /// When set, context must remain valid until every in-flight `stream` returns.
     context: ?*anyopaque = null,
+    observes_gateway_usage: bool = true,
     build_fn: BuildFn = unavailableBuild,
     stream_fn: StreamFn,
 
@@ -209,6 +210,10 @@ fn unavailableStream(_: ?*anyopaque, _: Allocator, _: Request) anyerror!Result {
 pub const unavailable_provider = Provider{
     .stream_fn = unavailableStream,
 };
+
+test "stream providers observe Gateway usage by default" {
+    try std.testing.expect(unavailable_provider.observes_gateway_usage);
+}
 
 test "stream provider dispatches request and preserves ordered callbacks" {
     const Fake = struct {

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -146,7 +146,7 @@ pub const GatewayObservation = struct {
             );
             return;
         }
-        try ledger.finishObservedInvocationDurably(
+        const accepted = try ledger.finishObservedInvocationDurably(
             alloc,
             self.sequence,
             self.elapsedMs(),
@@ -155,6 +155,7 @@ pub const GatewayObservation = struct {
             origin,
             team,
         );
+        if (!accepted) return;
         debug_trace.logf(
             "session",
             "usage generation queued sequence={d} id={s}",
@@ -481,7 +482,7 @@ pub const Usage = struct {
         id: []const u8,
         origin: []const u8,
         team: ?[]const u8,
-    ) !void {
+    ) !bool {
         self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
         self.finishObservedInvocation(
             alloc,
@@ -501,10 +502,11 @@ pub const Usage = struct {
             );
             self.checkpoint_mutex.unlock(io_mod.getIo());
             self.flushProfilePublications();
-            return;
+            return false;
         };
         _ = self.persistCheckpointBestEffortLocked();
         self.checkpoint_mutex.unlock(io_mod.getIo());
+        return true;
     }
 
     fn persistCheckpointRequiredLocked(self: *Usage) !void {
@@ -561,13 +563,12 @@ pub const Usage = struct {
         origin: []const u8,
         team: ?[]const u8,
     ) !void {
-        try validateGenerationId(id);
-        try validateOrigin(origin);
-        if (team) |value| try validateTeam(value);
-
         self.mutex.lockUncancelable(io_mod.getIo());
         defer self.mutex.unlock(io_mod.getIo());
         if (!self.finishInvocationUnlocked(sequence, duration_ms, outcome)) return;
+        try validateGenerationId(id);
+        try validateOrigin(origin);
+        if (team) |value| try validateTeam(value);
         self.observeGenerationUnlocked(alloc, sequence, id, origin, team) catch |err| {
             self.billing = .incomplete;
             self.dirty = true;
@@ -3023,7 +3024,7 @@ test "restored publication backlog settles the pending generation exactly" {
     });
 
     const sequence = try source.reserveInvocationDurably();
-    try source.finishObservedInvocationDurably(
+    _ = try source.finishObservedInvocationDurably(
         alloc,
         sequence,
         1,
@@ -3110,7 +3111,7 @@ test "no-checkpoint usage drains a transient publication failure" {
     });
 
     const sequence = try usage.reserveInvocationDurably();
-    try usage.finishObservedInvocationDurably(
+    _ = try usage.finishObservedInvocationDurably(
         alloc,
         sequence,
         1,
@@ -3617,7 +3618,10 @@ test "active invocation capacity fails before Gateway admission" {
         GatewayObservation.begin(&usage),
     );
 
-    for (observations) |observation| try observation.fail(.unbilled);
+    try observations[0].fail(.unbilled);
+    const replacement = try GatewayObservation.begin(&usage);
+    for (observations[1..]) |observation| try observation.fail(.unbilled);
+    try replacement.fail(.unbilled);
     var snapshot = try usage.snapshot(alloc);
     defer snapshot.deinit(alloc);
     try std.testing.expectEqual(Availability.complete, snapshot.billing);
@@ -3649,7 +3653,99 @@ test "generation allocation failure marks billing incomplete before snapshot" {
     var snapshot = try usage.snapshot(alloc);
     defer snapshot.deinit(alloc);
     try std.testing.expectEqual(Availability.incomplete, snapshot.billing);
+    try std.testing.expect(snapshot.api_duration_complete);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
     try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
+}
+
+test "invalid generation identity settles the Gateway observation" {
+    const alloc = std.testing.allocator;
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+
+    const observation = try GatewayObservation.begin(&usage);
+    try observation.complete(
+        alloc,
+        .ok,
+        .{ .generation_id = "resp_provider_local" },
+        "https://ai-gateway.vercel.sh",
+        null,
+    );
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(Availability.incomplete, snapshot.billing);
+    try std.testing.expect(snapshot.api_duration_complete);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
+}
+
+test "rejected observed generation settles without publishing its identity or billing" {
+    const alloc = std.testing.allocator;
+    const rejected_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    const PublicationProbe = struct {
+        rejected_id: []const u8,
+        pending: usize = 0,
+        generations: usize = 0,
+        incidents: usize = 0,
+
+        fn publish(raw: *anyopaque, event: usage_report.ProfileEvent) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (event) {
+                .pending => |marker| {
+                    if (std.mem.eql(u8, marker.id, self.rejected_id)) self.pending += 1;
+                },
+                .generation => |fact| {
+                    if (std.mem.eql(u8, fact.id, self.rejected_id)) self.generations += 1;
+                },
+                .incident => self.incidents += 1,
+            }
+        }
+    };
+
+    var probe = PublicationProbe{ .rejected_id = rejected_id };
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+    usage.configurePublicationSink(.{
+        .context = &probe,
+        .allocator = alloc,
+        .publish = PublicationProbe.publish,
+    });
+
+    const observation = try GatewayObservation.begin(&usage);
+    try observation.complete(
+        alloc,
+        .ok,
+        .{
+            .generation_id = rejected_id,
+            .billing = .{
+                .created_at_ms = 1,
+                .model = "provider/model",
+                .total_cost = 0.25,
+                .input_tokens = 10,
+                .output_tokens = 2,
+                .cache_read_tokens = 1,
+                .cache_write_tokens = 0,
+                .reasoning_tokens = 1,
+                .billable_web_search_calls = 0,
+            },
+        },
+        "https://provider.example\ninvalid",
+        null,
+    );
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(Availability.incomplete, snapshot.billing);
+    try std.testing.expect(snapshot.api_duration_complete);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
+    try std.testing.expectEqual(@as(u64, 0), snapshot.input_tokens);
+    try std.testing.expectEqual(@as(u64, 0), snapshot.output_tokens);
+    try std.testing.expectEqual(@as(f64, 0), snapshot.total_cost);
+    try std.testing.expectEqual(@as(usize, 0), probe.pending);
+    try std.testing.expectEqual(@as(usize, 0), probe.generations);
+    try std.testing.expectEqual(@as(usize, 1), probe.incidents);
 }
 
 test "concurrent invocation completion and snapshots stay internally consistent" {

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -484,7 +484,7 @@ pub const Usage = struct {
         team: ?[]const u8,
     ) !bool {
         self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
-        self.finishObservedInvocation(
+        const accepted = self.finishObservedInvocationAccepted(
             alloc,
             sequence,
             duration_ms,
@@ -506,7 +506,7 @@ pub const Usage = struct {
         };
         _ = self.persistCheckpointBestEffortLocked();
         self.checkpoint_mutex.unlock(io_mod.getIo());
-        return true;
+        return accepted;
     }
 
     fn persistCheckpointRequiredLocked(self: *Usage) !void {
@@ -563,9 +563,30 @@ pub const Usage = struct {
         origin: []const u8,
         team: ?[]const u8,
     ) !void {
+        _ = try self.finishObservedInvocationAccepted(
+            alloc,
+            sequence,
+            duration_ms,
+            outcome,
+            id,
+            origin,
+            team,
+        );
+    }
+
+    fn finishObservedInvocationAccepted(
+        self: *Usage,
+        alloc: Allocator,
+        sequence: u64,
+        duration_ms: u64,
+        outcome: DeliveryOutcome,
+        id: []const u8,
+        origin: []const u8,
+        team: ?[]const u8,
+    ) !bool {
         self.mutex.lockUncancelable(io_mod.getIo());
         defer self.mutex.unlock(io_mod.getIo());
-        if (!self.finishInvocationUnlocked(sequence, duration_ms, outcome)) return;
+        if (!self.finishInvocationUnlocked(sequence, duration_ms, outcome)) return false;
         try validateGenerationId(id);
         try validateOrigin(origin);
         if (team) |value| try validateTeam(value);
@@ -574,6 +595,7 @@ pub const Usage = struct {
             self.dirty = true;
             return err;
         };
+        return true;
     }
 
     fn finishInvocationUnlocked(
@@ -4001,6 +4023,67 @@ test "terminal Gateway billing settles the durable observation immediately" {
     try std.testing.expectEqual(@as(u64, 130), snapshot.input_tokens);
     try std.testing.expectEqual(@as(u64, 25), snapshot.output_tokens);
     try std.testing.expectEqual(@as(u64, 2), snapshot.billable_web_search_calls);
+}
+
+test "duplicate Gateway terminal callback does not republish inline billing" {
+    const alloc = std.testing.allocator;
+    const PublicationProbe = struct {
+        generations: usize = 0,
+
+        fn publish(raw: *anyopaque, event: usage_report.ProfileEvent) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (event) {
+                .generation => self.generations += 1,
+                .pending, .incident => {},
+            }
+        }
+    };
+
+    var probe = PublicationProbe{};
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+    usage.configurePublicationSink(.{
+        .context = &probe,
+        .allocator = alloc,
+        .publish = PublicationProbe.publish,
+    });
+
+    const observation = try GatewayObservation.begin(&usage);
+    const completion: types.GatewayCompletion = .{
+        .generation_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        .billing = .{
+            .created_at_ms = 100,
+            .model = "provider/model",
+            .total_cost = 0.0123,
+            .input_tokens = 130,
+            .output_tokens = 25,
+            .cache_read_tokens = 20,
+            .cache_write_tokens = 10,
+            .reasoning_tokens = 5,
+            .billable_web_search_calls = 2,
+        },
+    };
+    try observation.complete(
+        alloc,
+        .ok,
+        completion,
+        "https://ai-gateway.vercel.sh",
+        null,
+    );
+    try observation.complete(
+        alloc,
+        .ok,
+        completion,
+        "https://ai-gateway.vercel.sh",
+        null,
+    );
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), probe.generations);
+    try std.testing.expectEqual(@as(f64, 0.0123), snapshot.total_cost);
+    try std.testing.expectEqual(@as(u64, 130), snapshot.input_tokens);
+    try std.testing.expectEqual(@as(u64, 25), snapshot.output_tokens);
 }
 
 test "successful retry after ambiguous delivery retains known generation" {

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -32,6 +32,7 @@ const CodexLimits = struct {
 };
 
 pub const agent_stream_provider = stream_provider.Provider{
+    .observes_gateway_usage = false,
     .build_fn = buildRequest,
     .stream_fn = streamCompletion,
 };

--- a/src/gateway/openai_codex_permission_reviewer.zig
+++ b/src/gateway/openai_codex_permission_reviewer.zig
@@ -3,7 +3,6 @@ const permission_auto_classifier = @import("../core/permissions/auto_classifier.
 const gateway_json = @import("../core/gateway/gateway_json.zig");
 const stream_provider = @import("../core/agent/stream_provider.zig");
 const types = @import("../core/shared/types.zig");
-const session_usage = @import("../core/session/session_usage.zig");
 const openai_codex = @import("openai_codex.zig");
 const openai_codex_models = @import("openai_codex_models.zig");
 
@@ -16,8 +15,6 @@ pub const provider = permission_auto_classifier.Provider{
 const ReviewConfig = struct {
     credential: []const u8,
     cancel_flag: ?*std.atomic.Value(bool),
-    usage: ?*session_usage.Usage,
-    usage_allocator: Allocator,
 };
 
 fn reviewCodex(
@@ -30,8 +27,6 @@ fn reviewCodex(
     var config = ReviewConfig{
         .credential = input.credential,
         .cancel_flag = input.cancel_flag,
-        .usage = input.usage,
-        .usage_allocator = input.usage_allocator,
     };
     return permission_auto_classifier.Reviewer.withTransportModel(
         .{
@@ -104,7 +99,6 @@ fn sendReview(
     var delivery = stream_provider.DeliveryCertainty.init();
     var evidence: stream_provider.AttemptEvidence = .{};
     var callback_context: u8 = 0;
-    const usage_observation = try session_usage.GatewayObservation.begin(config.usage);
     var result = openai_codex.agent_stream_provider.stream(alloc, .{
         .api_key = config.credential,
         .credential_source = .chatgpt_subscription,
@@ -124,23 +118,12 @@ fn sendReview(
         .cancel_flag = cancel_flag,
         .provider_attempt_owner = .transport,
     }) catch |err| {
-        usage_observation.fail(if (delivery.load() == .possibly_sent)
-            .ambiguous_delivery
-        else
-            .unbilled) catch return .permanent_failure;
         if (err == error.OutOfMemory) return error.OutOfMemory;
         if (err == error.Cancelled or cancel_flag.load(.seq_cst)) return .cancelled;
         return .transient_failure;
     };
     var result_owned = true;
     defer if (result_owned) result.deinit(alloc);
-    usage_observation.complete(
-        config.usage_allocator,
-        result.status,
-        result.completion,
-        "https://chatgpt.com/backend-api/codex",
-        null,
-    ) catch return .permanent_failure;
     if (cancel_flag.load(.seq_cst)) return .cancelled;
     if (result.status != .ok) {
         const code: u16 = @intFromEnum(result.status);

--- a/src/gateway/xai_grok.zig
+++ b/src/gateway/xai_grok.zig
@@ -25,6 +25,7 @@ const transfer_buffer_bytes: usize = 256 * 1024;
 const connect_timeout_ms: i64 = 30_000;
 
 pub const agent_stream_provider = stream_provider.Provider{
+    .observes_gateway_usage = false,
     .build_fn = buildRequest,
     .stream_fn = streamCompletion,
 };

--- a/src/gateway/xai_grok_permission_reviewer.zig
+++ b/src/gateway/xai_grok_permission_reviewer.zig
@@ -3,7 +3,6 @@ const permission_auto_classifier = @import("../core/permissions/auto_classifier.
 const gateway_json = @import("../core/gateway/gateway_json.zig");
 const stream_provider = @import("../core/agent/stream_provider.zig");
 const types = @import("../core/shared/types.zig");
-const session_usage = @import("../core/session/session_usage.zig");
 const xai_grok = @import("xai_grok.zig");
 
 const Allocator = std.mem.Allocator;
@@ -16,8 +15,6 @@ const ReviewConfig = struct {
     credential: []const u8,
     account_id: []const u8,
     cancel_flag: ?*std.atomic.Value(bool),
-    usage: ?*session_usage.Usage,
-    usage_allocator: Allocator,
 };
 
 fn reviewGrok(
@@ -32,8 +29,6 @@ fn reviewGrok(
         .credential = input.credential,
         .account_id = account_id,
         .cancel_flag = input.cancel_flag,
-        .usage = input.usage,
-        .usage_allocator = input.usage_allocator,
     };
     return permission_auto_classifier.Reviewer.withTransportModel(
         .{
@@ -106,7 +101,6 @@ fn sendReview(
     var delivery = stream_provider.DeliveryCertainty.init();
     var evidence: stream_provider.AttemptEvidence = .{};
     var callback_context: u8 = 0;
-    const usage_observation = try session_usage.GatewayObservation.begin(config.usage);
     var result = xai_grok.agent_stream_provider.stream(alloc, .{
         .api_key = config.credential,
         .credential_source = .grok_subscription,
@@ -128,21 +122,10 @@ fn sendReview(
         .cancel_flag = cancel_flag,
         .provider_attempt_owner = .transport,
     }) catch |err| {
-        usage_observation.fail(if (delivery.load() == .possibly_sent)
-            .ambiguous_delivery
-        else
-            .unbilled) catch return .permanent_failure;
         return mapStreamError(err, cancel_flag);
     };
     var result_owned = true;
     defer if (result_owned) result.deinit(alloc);
-    usage_observation.complete(
-        config.usage_allocator,
-        result.status,
-        result.completion,
-        "https://api.x.ai/v1",
-        null,
-    ) catch return .permanent_failure;
     if (cancel_flag.load(.seq_cst)) return .cancelled;
     if (result.status != .ok) {
         const code: u16 = @intFromEnum(result.status);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -115,6 +116,28 @@ function writeSeededGrokLogin(testHome: string, accessToken: string, accountId =
     account_id: accountId,
   }) + "\n", { mode: 0o600 });
   chmodSync(authPath, 0o600);
+}
+
+function readSingleUsageSnapshot(testHome: string): {
+  billing: string;
+  next_sequence: number;
+  settled_through_sequence: number;
+  pending: unknown[];
+} {
+  const sessionsDir = join(testHome, ".fx", "sessions");
+  const usagePaths = readdirSync(sessionsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(sessionsDir, entry.name, "usage-v2.json"))
+    .filter((path) => existsSync(path));
+  expect(usagePaths).toHaveLength(1);
+  return (JSON.parse(readFileSync(usagePaths[0]!, "utf8")) as {
+    snapshot: {
+      billing: string;
+      next_sequence: number;
+      settled_through_sequence: number;
+      pending: unknown[];
+    };
+  }).snapshot;
 }
 
 function writeSeededFxLogin(
@@ -734,6 +757,45 @@ function startFakeCodexToolLoop(options: {
       return new Response(
         `data: ${JSON.stringify({ type: "response.output_text.delta", delta: finalText })}\n\n` +
           'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":7,"output_tokens":3}}}\n\n',
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  });
+  return {
+    accessToken,
+    bodies,
+    responsesUrl: `http://127.0.0.1:${server.port}/responses`,
+    modelsUrl: `http://127.0.0.1:${server.port}/models`,
+    stop() { server.stop(true); },
+  };
+}
+
+function startFakeCodexCapacityLoop() {
+  const bodies: string[] = [];
+  const accessToken = chatgptAccessToken("acct_capacity_loop");
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      if (new URL(request.url).pathname === "/models") {
+        return Response.json({ models: [
+          { slug: "gpt-5.6-sol", visibility: "list", supported_in_api: true, supported_reasoning_levels: [{ effort: "high" }], additional_speed_tiers: [], input_modalities: ["text"], context_window: 272000 },
+        ] });
+      }
+      bodies.push(await request.text());
+      const call = bodies.length;
+      if (call <= 64) {
+        return new Response(
+          `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 0, item: { type: "function_call", call_id: `call_capacity_${call}`, name: "read_file" } })}\n\n` +
+            `data: ${JSON.stringify({ type: "response.function_call_arguments.done", output_index: 0, arguments: JSON.stringify({ path: "README.md", start_line: call, line_count: 1 }) })}\n\n` +
+            `data: ${JSON.stringify({ type: "response.completed", response: { id: `resp_capacity_${call}`, status: "completed", usage: { input_tokens: 5, output_tokens: 2 } } })}\n\n`,
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      const text = call === 65 ? "CODEX_CAPACITY_65_OK" : "CODEX_CAPACITY_NEXT_OK";
+      return new Response(
+        `data: ${JSON.stringify({ type: "response.output_text.delta", delta: text })}\n\n` +
+          `data: ${JSON.stringify({ type: "response.completed", response: { id: `resp_capacity_${call}`, status: "completed", usage: { input_tokens: 7, output_tokens: 3 } } })}\n\n`,
         { headers: { "content-type": "text/event-stream" } },
       );
     },
@@ -2479,6 +2541,44 @@ test(
   60_000,
 );
 
+tmuxTest(
+  "Codex remains usable beyond Gateway observation capacity in one process",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-codex-capacity-loop-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    const codex = startFakeCodexCapacityLoop();
+    try {
+      writeSeededChatGptLogin(home, codex.accessToken);
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({ provider: "codex", codex_model: "gpt-5.6-sol" }) + "\n",
+        { mode: 0o600 },
+      );
+      session = await startFx(home, stderrPath, gateway, undefined, undefined, {
+        FX_MODEL: undefined,
+        FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
+        FX_E2E_OPENAI_CODEX_MODELS_URL: codex.modelsUrl,
+      });
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText("Read enough lines to complete the capacity loop.");
+      await session.waitForText("CODEX_CAPACITY_65_OK", 120_000);
+      expect(codex.bodies).toHaveLength(65);
+
+      await session.sendText("Confirm the same process remains usable.");
+      await session.waitForText("CODEX_CAPACITY_NEXT_OK", TIMEOUT);
+      expect(codex.bodies).toHaveLength(66);
+      expect(await session.captureFullScrollback()).not.toContain("UsageCapacityExceeded");
+      expect(gateway.requests).toHaveLength(0);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+    } finally {
+      codex.stop();
+    }
+  },
+  150_000,
+);
+
 test(
   "Grok tool loops round-trip encrypted reasoning without Gateway leakage",
   async () => {
@@ -2712,7 +2812,7 @@ test(
         { mode: 0o600 },
       );
       const result = await runFx(
-        ["ask", "--json", "--auto", "--no-save", "Run pwd, then finish."],
+        ["ask", "--json", "--auto", "Run pwd, then finish."],
         {
           env: {
             HOME: home,
@@ -2736,6 +2836,12 @@ test(
       for (const request of gateway.requests) {
         expect(request.body).not.toContain("permission_decision");
       }
+      expect(readSingleUsageSnapshot(home)).toMatchObject({
+        billing: "complete",
+        next_sequence: 1,
+        settled_through_sequence: 0,
+        pending: [],
+      });
     } finally {
       codex.stop();
     }
@@ -2757,7 +2863,7 @@ test(
         { mode: 0o600 },
       );
       const result = await runFx(
-        ["ask", "--json", "--auto", "--no-save", "Run pwd, then finish."],
+        ["ask", "--json", "--auto", "Run pwd, then finish."],
         {
           env: {
             HOME: home,
@@ -2791,6 +2897,12 @@ test(
       for (const request of gateway.requests) {
         expect(request.body).not.toContain("permission_decision");
       }
+      expect(readSingleUsageSnapshot(home)).toMatchObject({
+        billing: "complete",
+        next_sequence: 1,
+        settled_through_sequence: 0,
+        pending: [],
+      });
     } finally {
       grok.stop();
     }


### PR DESCRIPTION
## Summary

- Keep Codex and Grok sessions usable beyond 64 sequential provider calls.
- Preserve Gateway usage observation and reconciliation behavior.
- Settle rejected Gateway generation metadata without publishing or billing that generation.
