### PR TITLE
Drop redundant saved notices for settings toggles

### DIFF
--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -131,6 +131,8 @@ fn persistUserPreferences(
     label: []const u8,
     patch: config_runtime.UserSettingsPatch,
     runtime_changed: bool,
+    // False when the caller announces state; failures still report.
+    announce_commit: bool,
 ) !void {
     var attempt = config_runtime.attemptUserPreferences(app.alloc, patch);
     defer attempt.deinit(app.alloc);
@@ -148,7 +150,7 @@ fn persistUserPreferences(
             patch,
             outcome,
             null,
-            true,
+            announce_commit,
         ),
     }
 }
@@ -2999,7 +3001,7 @@ fn applyStatuslineItem(
     };
     switch (feedback) {
         .announce => {
-            try persistUserPreferences(app, "statusline", patch, runtime_changed);
+            try persistUserPreferences(app, "statusline", patch, runtime_changed, false);
             const message = try std.fmt.allocPrint(
                 app.alloc,
                 "{s}: {s}",
@@ -3084,27 +3086,7 @@ fn handleNotificationsCommand(app: anytype, rest: []const u8) !void {
         .notification_attention_required = sound_on,
         .notification_max = max,
     };
-    var attempt = config_runtime.attemptUserPreferences(app.alloc, patch);
-    defer attempt.deinit(app.alloc);
-    switch (attempt) {
-        .failure => |failure| try session_commands.reportUserSettingsFailure(
-            app,
-            "sound",
-            failure.err,
-            failure.cleanup,
-            runtime_changed,
-        ),
-        // announce_commit=false drops the routine "saved" line (the state
-        // notice below covers it, matching /fast) but keeps warnings.
-        .outcome => |outcome| _ = try session_commands.reportUserSettingsCommit(
-            app,
-            "sound",
-            patch,
-            outcome,
-            null,
-            false,
-        ),
-    }
+    try persistUserPreferences(app, "sound", patch, runtime_changed, false);
 
     try app.writeDomainNotice(.{
         .topic = "sound",
@@ -3204,6 +3186,7 @@ pub fn applySettingsCatalogChange(app: anytype, change: settings_catalog.Change)
                 "slash menu categories",
                 .{ .slash_menu_categories = enabled },
                 runtime_changed,
+                true,
             );
         },
         .effort => {

--- a/src/core/session/session_commands.zig
+++ b/src/core/session/session_commands.zig
@@ -753,7 +753,8 @@ pub fn Commands(comptime App: type) type {
         }
 
         pub fn selectEffortFromSettings(app: *App, effort: types.ReasoningEffort) !void {
-            try applyEffort(app, effort, false, true);
+            // Announcing drops the redundant "saved" line, matching /sound.
+            try applyEffort(app, effort, true, true);
         }
 
         pub fn selectModelFromPicker(app: *App, model: []const u8, effort: types.ReasoningEffort, fast_mode: bool) !void {


### PR DESCRIPTION
## TL;DR

Setting toggles that already announce their new state printed a second, routine `saved to user settings (scope=user)` line right before the state line. This PR removes that redundancy so every toggle reports one line, matching the single-line pattern `/sound` already uses and asserts on in `tests/e2e/notifications.test.ts`.

Rebased onto `5ed3be1`. Net diff: 2 files, +10/−24.

## What changed

- **`src/core/app/app_commands.zig`** (core file)
  - `persistUserPreferences` gains an `announce_commit` param with the same semantics and doc comment as the existing `persistPreferenceTargets` in `session_commands.zig`.
  - The call site that also prints a state notice passes `false`: `/statusline`.
  - The `/sound` handler's inline attempt/report block was byte-for-byte equivalent to the generalized helper, so it collapses into one call.
  - `slash-menu-categories` keeps `true`: it has no state notice, so the saved line remains its only feedback.
- **`src/core/session/session_commands.zig`** (core file)
  - `selectEffortFromSettings` (settings-menu effort change) now announces state via the existing `applyEffort(effort, announce=true, persist=true)` path; persistence then drops its saved line through the pre-existing `!announce` wiring. `/history` is intentionally untouched.

No generated files, no mechanical-only files. Single commit, single concern.

## Behavior

- Success notices for `/statusline` and menu-driven effort changes go from two lines (or a bare "saved" line) to exactly one state line.
- Persistence failures still print, and commit warnings (shadowed sources, cleanup notes) are preserved by `reportUserSettingsCommit`'s existing non-benign check.
- Nothing else about ordering, tone, or persistence semantics changes.

## Risk

Low. The only suppressed output is the benign success line; every error/warning path still emits. Reviewer entry point: `applyStatuslineItem`, `handleNotificationsCommand`, and `persistUserPreferences` in `app_commands.zig`, plus `selectEffortFromSettings` in `session_commands.zig`.

## Test coverage

- `zig build test`: 8406 pass / 8 fail — identical failure set on the base commit `5ed3be1` (environment-specific session-picker, terminal-schema, and transcript-runtime failures, reproduced in a clean worktree of `origin/main`).
- `bun test config-persistence.test.ts notifications.test.ts`: 33 tests, 0 fail after rebase (covers statusline toggle persistence, sound notice assertions).
- Manual tmux verification against `zig-out/bin/fx`: `/statusline session` and `/statusline context` each emit exactly one line; `~/.fx/settings.json` persists correctly; stderr clean.

## Before / After

![before-after](https://raw.githubusercontent.com/doanbactam/fx/pr-media/before-after.png)

Left: `main` prints a redundant `saved to user settings (scope=user)` line for every statusline toggle. Right: this PR prints one state line per toggle. Same commands, fresh HOME, both binaries built from their exact commits.

