### PR TITLE
Reduce native binary and MCP catalog memory

### DIFF
--- a/scripts/pgso/corpus.json
+++ b/scripts/pgso/corpus.json
@@ -34,6 +34,7 @@
       "argv": ["{binary}", "help"],
       "cwd": ".",
       "env_set": {"FX_SKIP_ONBOARDING": "1"},
+      "profile_runs": 100,
       "timeout_seconds": 60,
       "requires_tmux": false
     },

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -2526,13 +2526,11 @@ test "ACP lifecycle resolves dynamic MCP availability through session context" {
     const mcp_server = &runtime.servers.items[0];
     mcp_server.state = .ready;
     try mcp_server.tool_catalog.tools.append(alloc, .{
-        .server_name = mcp_server.config.name,
         .original_name = try alloc.dupe(u8, "echo"),
         .prefixed_name = try alloc.dupe(u8, "mcp_fixture_echo"),
         .description = try alloc.dupe(u8, "Echo input"),
         .input_schema_json = try alloc.dupe(u8, "{\"type\":\"object\"}"),
         .tags = &.{},
-        .search_text = try alloc.dupe(u8, "echo input"),
     });
     state.active_session.?.mcp = runtime;
     runtime_owned = false;

--- a/src/builtins/browser_workspace_tools.zig
+++ b/src/builtins/browser_workspace_tools.zig
@@ -21,7 +21,7 @@ fn buildTerminalSpec() tool_dispatch.Tool {
                 .{
                     .name = "command",
                     .json_type = .string,
-                    .max_length = 64 * 1024,
+                    .bounds = &.{ .max_length = 64 * 1024 },
                     .description = "Foreground command to run in the browser workspace.",
                 },
             },
@@ -61,10 +61,27 @@ test "browser workspace projects exactly one command-only terminal" {
     try std.testing.expectEqual(@as(usize, 2), schema.input_schema.properties.len);
     try std.testing.expectEqualStrings("action", schema.input_schema.properties[0].name);
     try std.testing.expectEqualStrings("command", schema.input_schema.properties[1].name);
-    try std.testing.expectEqual(@as(?usize, 64 * 1024), schema.input_schema.properties[1].max_length);
+    try std.testing.expectEqual(@as(?usize, 64 * 1024), schema.input_schema.properties[1].bounds.?.max_length);
     try std.testing.expectEqual(false, schema.input_schema.additional_properties.?);
     try std.testing.expect(std.mem.find(u8, schema.description, "shell is the workspace interface") != null);
     try std.testing.expect(std.mem.find(u8, schema.description, "clean root-fixed") != null);
+}
+
+test "browser workspace model-facing tool contract stays byte exact" {
+    const gateway_schema = @import("../core/tooling/gateway_schema.zig");
+    const schema_json = try gateway_schema.builtinFunctionSchemaJsonAlloc(
+        std.testing.allocator,
+        registry.tools[0].gateway_schema,
+    );
+    defer std.testing.allocator.free(schema_json);
+
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(schema_json, &digest, .{});
+    const actual_hex = std.fmt.bytesToHex(digest, .lower);
+    try std.testing.expectEqualStrings(
+        "6b818f083e689d8832dff7f9c7e238c4ade0999eb4f2abb1ef91522d096dcc64",
+        &actual_hex,
+    );
 }
 
 fn expectDecodeFailure(arguments_json: []const u8) !void {

--- a/src/builtins/browser_workspace_tools.zig
+++ b/src/builtins/browser_workspace_tools.zig
@@ -68,10 +68,10 @@ test "browser workspace projects exactly one command-only terminal" {
 }
 
 test "browser workspace model-facing tool contract stays byte exact" {
-    const gateway_schema = @import("../core/tooling/gateway_schema.zig");
-    const schema_json = try gateway_schema.builtinFunctionSchemaJsonAlloc(
+    const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
+    const schema_json = try model_tool_schema.builtinFunctionSchemaJsonAlloc(
         std.testing.allocator,
-        registry.tools[0].gateway_schema,
+        registry.tools[0].model_schema,
     );
     defer std.testing.allocator.free(schema_json);
 

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -107,7 +107,7 @@ const terminal_shell_schema = model_tool_schema.ObjectSchema{
 const terminal_return_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "started", "exit", "quiet", "match" } }, .description = "started is for start readiness; exit waits for session exit; quiet requires duration_ms; match requires pattern. output_contains is a monitor condition, not a return kind." },
-        .{ .name = "duration_ms", .json_type = .integer, .minimum = 1, .description = "Required for quiet." },
+        .{ .name = "duration_ms", .json_type = .integer, .bounds = &.{ .minimum = 1 }, .description = "Required for quiet." },
         .{ .name = "pattern", .json_type = .string, .description = "Required for match." },
     },
     .required = &.{"kind"},
@@ -116,8 +116,8 @@ const terminal_return_schema = model_tool_schema.ObjectSchema{
 
 const terminal_dimensions_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "rows", .json_type = .integer, .minimum = 1, .maximum = 4096 },
-        .{ .name = "columns", .json_type = .integer, .minimum = 1, .maximum = 4096 },
+        .{ .name = "rows", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = 4096 } },
+        .{ .name = "columns", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = 4096 } },
     },
     .required = &.{ "rows", "columns" },
     .additional_properties = false,
@@ -127,11 +127,11 @@ const terminal_monitor_condition_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "process_exit", "exit_code", "signal", "output_contains", "output_matches", "output_quiet", "screen_matches", "tcp_ready", "http_ready", "path_exists", "path_changed", "path_size", "custom_probe" } } },
         .{ .name = "pattern", .json_type = .string, .description = "Output/screen pattern or HTTP URL, according to kind." },
-        .{ .name = "duration_ms", .json_type = .integer, .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms), .description = "Required for output_quiet." },
+        .{ .name = "duration_ms", .json_type = .integer, .bounds = &.{ .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms) }, .description = "Required for output_quiet." },
         .{ .name = "exit_code", .json_type = .integer },
         .{ .name = "signal", .json_type = .string, .shape = &.{ .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } } },
         .{ .name = "host", .json_type = .string },
-        .{ .name = "port", .json_type = .integer, .minimum = 1, .maximum = 65535 },
+        .{ .name = "port", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = 65535 } },
         .{ .name = "path", .json_type = .string, .description = "Required for path conditions. The path must resolve within the terminal workspace; external paths are rejected." },
         .{ .name = "minimum_bytes", .json_type = .integer },
         .{ .name = "command", .json_type = .string },
@@ -144,8 +144,8 @@ const terminal_monitor_condition_schema = model_tool_schema.ObjectSchema{
 const terminal_monitor_notify_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "on_match", "on_state_change", "on_exit", "every_check", "every_n_checks", "interval" } } },
-        .{ .name = "count", .json_type = .integer, .minimum = 1 },
-        .{ .name = "interval_ms", .json_type = .integer, .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms) },
+        .{ .name = "count", .json_type = .integer, .bounds = &.{ .minimum = 1 } },
+        .{ .name = "interval_ms", .json_type = .integer, .bounds = &.{ .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms) } },
     },
     .required = &.{"kind"},
     .additional_properties = false,
@@ -154,7 +154,7 @@ const terminal_monitor_notify_schema = model_tool_schema.ObjectSchema{
 const terminal_monitor_lifetime_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "kind", .json_type = .string, .shape = &.{ .enum_values = &.{ "until_match", "until_session_end", "duration" } } },
-        .{ .name = "duration_ms", .json_type = .integer, .minimum = 1, .maximum = @intCast(terminal_monitor.maximum_lifetime_ms) },
+        .{ .name = "duration_ms", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = @intCast(terminal_monitor.maximum_lifetime_ms) } },
     },
     .required = &.{"kind"},
     .additional_properties = false,
@@ -163,7 +163,7 @@ const terminal_monitor_lifetime_schema = model_tool_schema.ObjectSchema{
 const terminal_monitor_definition_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "condition", .json_type = .object, .shape = &.{ .object = &terminal_monitor_condition_schema } },
-        .{ .name = "check_interval_ms", .json_type = .integer, .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms), .description = "Required for polling conditions tcp_ready, http_ready, path_exists, path_changed, path_size, and custom_probe. Event-driven conditions process_exit, exit_code, signal, output_contains, output_matches, output_quiet, and screen_matches omit it; materialized values are ignored." },
+        .{ .name = "check_interval_ms", .json_type = .integer, .bounds = &.{ .minimum = @intCast(terminal_monitor.minimum_schedule_ms), .maximum = @intCast(terminal_monitor.maximum_schedule_ms) }, .description = "Required for polling conditions tcp_ready, http_ready, path_exists, path_changed, path_size, and custom_probe. Event-driven conditions process_exit, exit_code, signal, output_contains, output_matches, output_quiet, and screen_matches omit it; materialized values are ignored." },
         .{ .name = "notify", .json_type = .object, .shape = &.{ .object = &terminal_monitor_notify_schema } },
         .{ .name = "lifetime", .json_type = .object, .shape = &.{ .object = &terminal_monitor_lifetime_schema } },
     },
@@ -195,27 +195,27 @@ const terminal_write_schema = model_tool_schema.ObjectSchema{
 const terminal_properties = [_]model_tool_schema.Property{
     .{ .name = "session_id", .json_type = .string, .description = "Required for session-targeted actions. Set null for start and list; owner-catalog authority is private." },
     .{ .name = "cwd", .json_type = .string, .description = "Working directory for exec or start; defaults to the workspace." },
-    .{ .name = "command", .json_type = .string, .max_length = terminal_contracts.max_command_bytes, .description = "Command for exec, or optional command for start; omit on start for an interactive shell." },
+    .{ .name = "command", .json_type = .string, .bounds = &.{ .max_length = terminal_contracts.max_command_bytes }, .description = "Command for exec, or optional command for start; omit on start for an interactive shell." },
     .{ .name = "profile", .json_type = .string, .shape = &.{ .enum_values = &.{ "clean", "user" } }, .description = "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile." },
     .{ .name = "timeout_ms", .json_type = .integer, .minimum = terminal_impl.exec_timeout_min_ms, .maximum = terminal_impl.exec_timeout_max_ms, .description = "Required for exec. Maximum foreground runtime in milliseconds; use start for persistent work." },
     .{ .name = "shell", .json_type = .object, .shape = &.{ .object = &terminal_shell_schema } },
     .{ .name = "backend", .json_type = .string, .shape = &.{ .enum_values = &.{ "native", "tmux" } }, .description = "Start backend or optional list filter." },
     .{ .name = "return_when", .json_type = .object, .shape = &.{ .object = &terminal_return_schema }, .description = "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only." },
-    .{ .name = "wait_ceiling_ms", .json_type = .integer, .minimum = 1, .description = "Required for wait; required for start when return_when is non-immediate; maximum blocking time in milliseconds." },
+    .{ .name = "wait_ceiling_ms", .json_type = .integer, .bounds = &.{ .minimum = 1 }, .description = "Required for wait; required for start when return_when is non-immediate; maximum blocking time in milliseconds." },
     .{ .name = "dimensions", .json_type = .object, .shape = &.{ .object = &terminal_dimensions_schema } },
-    .{ .name = "initial_monitors", .json_type = .array, .max_items = 32, .shape = &.{ .array_objects = &terminal_monitor_definition_schema } },
-    .{ .name = "cursor_segment", .json_type = .integer, .minimum = 1, .description = "Only for read and required for every read. For a new session's first read, use segment 1 with cursor_offset 0; otherwise use unread_range.start or raw_gap.available_from from the latest session facts. Continue from the previous raw_range.end." },
+    .{ .name = "initial_monitors", .json_type = .array, .bounds = &.{ .max_items = 32 }, .shape = &.{ .array_objects = &terminal_monitor_definition_schema } },
+    .{ .name = "cursor_segment", .json_type = .integer, .bounds = &.{ .minimum = 1 }, .description = "Only for read and required for every read. For a new session's first read, use segment 1 with cursor_offset 0; otherwise use unread_range.start or raw_gap.available_from from the latest session facts. Continue from the previous raw_range.end." },
     .{ .name = "cursor_offset", .json_type = .integer, .description = "Only for read. Use 0 with segment 1 for a new session's first read, then continue from the previous raw_range.end offset." },
     .{ .name = "after_event_id", .json_type = .integer },
-    .{ .name = "acknowledge_event_id", .json_type = .integer, .minimum = 1 },
-    .{ .name = "max_events", .json_type = .integer, .minimum = 1, .maximum = 256 },
+    .{ .name = "acknowledge_event_id", .json_type = .integer, .bounds = &.{ .minimum = 1 } },
+    .{ .name = "max_events", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = 256 } },
     .{ .name = "write", .json_type = .object, .shape = &.{ .object = &terminal_write_schema }, .description = "Payload is valid only with lease=use. Set null for acquire, release, and revoke." },
     .{ .name = "lease", .json_type = .string, .shape = &.{ .enum_values = &.{ "acquire", "use", "release", "revoke" } }, .description = "Use lease=acquire without write, then send a second call with lease=use and the payload. Release and revoke also require write=null." },
     .{ .name = "monitor", .json_type = .object, .shape = &.{ .object = &terminal_monitor_operation_schema } },
     .{ .name = "task_id", .json_type = .string },
     .{ .name = "workspace_root", .json_type = .string },
-    .{ .name = "rows", .json_type = .integer, .minimum = 1, .maximum = 4096 },
-    .{ .name = "columns", .json_type = .integer, .minimum = 1, .maximum = 4096 },
+    .{ .name = "rows", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = 4096 } },
+    .{ .name = "columns", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = 4096 } },
     .{ .name = "signal", .json_type = .string, .shape = &.{ .enum_values = &.{ "hangup", "interrupt", "quit", "terminate", "kill" } } },
     .{ .name = "close_policy", .json_type = .string, .shape = &.{ .enum_values = &.{ "graceful", "force" } }, .description = "Only for close and required for close. Close is final; read or inspect all needed output before closing." },
 };
@@ -229,8 +229,9 @@ fn terminalNullableDescription(comptime description: []const u8) []const u8 {
 
 fn terminalNullableProperty(comptime property: model_tool_schema.Property) model_tool_schema.Property {
     var result = property;
-    result.nullable = true;
-    result.nullable_description = terminalNullableDescription(property.description);
+    result.nullable = &.{
+        .description = terminalNullableDescription(property.description),
+    };
     return result;
 }
 
@@ -375,7 +376,7 @@ const ask_user_question_option_schema = model_tool_schema.ObjectSchema{
 const ask_user_question_question_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "question", .json_type = .string, .description = "Specific blocking decision shown to the user; do not ask for facts tools can inspect." },
-        .{ .name = "options", .json_type = .array, .min_items = 2, .max_items = 6, .shape = &.{ .array_objects = &ask_user_question_option_schema } },
+        .{ .name = "options", .json_type = .array, .bounds = &.{ .min_items = 2, .max_items = 6 }, .shape = &.{ .array_objects = &ask_user_question_option_schema } },
     },
     .required = &.{ "question", "options" },
 };
@@ -395,21 +396,21 @@ const subagent_terminal_schema = model_tool_schema.ObjectSchema{
 const subagent_notifications_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "terminal", .json_type = .object, .shape = &.{ .object = &subagent_terminal_schema } },
-        .{ .name = "milestones", .json_type = .array, .max_items = subagent_domain.max_milestones, .shape = &.{ .array_values = .{ .json_type = .string } } },
-        .{ .name = "report_interval_ms", .json_type = .integer, .minimum = 1 },
-        .{ .name = "report_duration_ms", .json_type = .integer, .minimum = 1 },
-        .{ .name = "stop_conditions", .json_type = .array, .max_items = subagent_domain.max_stop_conditions, .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "terminal", "duration_elapsed" } } } },
+        .{ .name = "milestones", .json_type = .array, .bounds = &.{ .max_items = subagent_domain.max_milestones }, .shape = &.{ .array_values = .{ .json_type = .string } } },
+        .{ .name = "report_interval_ms", .json_type = .integer, .bounds = &.{ .minimum = 1 } },
+        .{ .name = "report_duration_ms", .json_type = .integer, .bounds = &.{ .minimum = 1 } },
+        .{ .name = "stop_conditions", .json_type = .array, .bounds = &.{ .max_items = subagent_domain.max_stop_conditions }, .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "terminal", "duration_elapsed" } } } },
     },
     .additional_properties = false,
 };
 
 const subagent_create_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "name", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_name_bytes },
+        .{ .name = "name", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_name_bytes } },
         .{ .name = "mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "one_off", "persistent" } } },
-        .{ .name = "prompt", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_prompt_bytes },
-        .{ .name = "model", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_model_bytes },
-        .{ .name = "effort", .json_type = .string, .min_length = 1, .max_length = types.ReasoningEffort.max_name_bytes },
+        .{ .name = "prompt", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_prompt_bytes } },
+        .{ .name = "model", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_model_bytes } },
+        .{ .name = "effort", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = types.ReasoningEffort.max_name_bytes } },
         .{ .name = "permission_mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "ask", "auto", "yolo" } }, .description = "Child permission mode. Inherits the caller when omitted and cannot exceed it." },
         .{ .name = "notifications", .json_type = .object, .shape = &.{ .object = &subagent_notifications_schema } },
     },
@@ -420,8 +421,8 @@ const subagent_create_schema = model_tool_schema.ObjectSchema{
 const subagent_inspect_wait_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "until", .json_type = .string, .shape = &.{ .enum_values = &.{"settled"} }, .description = "Wait until a persistent child is idle or the child reaches another non-running terminal/recovery state." },
-        .{ .name = "after_generation", .json_type = .integer, .minimum = 0, .description = "Optional durable generation that must be exceeded before the wait can complete." },
-        .{ .name = "timeout_ms", .json_type = .integer, .minimum = 1, .maximum = subagent_domain.max_inspect_wait_ms, .description = "Bounded wait deadline in milliseconds. A timeout returns the latest inspection with status wait_timed_out." },
+        .{ .name = "after_generation", .json_type = .integer, .bounds = &.{ .minimum = 0 }, .description = "Optional durable generation that must be exceeded before the wait can complete." },
+        .{ .name = "timeout_ms", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = subagent_domain.max_inspect_wait_ms }, .description = "Bounded wait deadline in milliseconds. A timeout returns the latest inspection with status wait_timed_out." },
     },
     .required = &.{ "until", "timeout_ms" },
     .additional_properties = false,
@@ -429,10 +430,10 @@ const subagent_inspect_wait_schema = model_tool_schema.ObjectSchema{
 
 const subagent_inspect_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "id", .json_type = .string, .min_length = 1 },
-        .{ .name = "sections", .json_type = .array, .min_items = 1, .max_items = 6, .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "status", "messages", "tool_activity", "events", "configuration", "relationship" } } } },
-        .{ .name = "cursor", .json_type = .string, .min_length = 1 },
-        .{ .name = "limit", .json_type = .integer, .minimum = 1, .maximum = subagent_domain.max_page_limit },
+        .{ .name = "id", .json_type = .string, .bounds = &.{ .min_length = 1 } },
+        .{ .name = "sections", .json_type = .array, .bounds = &.{ .min_items = 1, .max_items = 6 }, .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "status", "messages", "tool_activity", "events", "configuration", "relationship" } } } },
+        .{ .name = "cursor", .json_type = .string, .bounds = &.{ .min_length = 1 } },
+        .{ .name = "limit", .json_type = .integer, .bounds = &.{ .minimum = 1, .maximum = subagent_domain.max_page_limit } },
         .{ .name = "wait", .json_type = .object, .shape = &.{ .object = &subagent_inspect_wait_schema }, .description = "Optional condition-driven same-turn wait. Requires the status section and cannot be combined with a cursor." },
     },
     .required = &.{ "id", "sections" },
@@ -441,15 +442,15 @@ const subagent_inspect_schema = model_tool_schema.ObjectSchema{
 
 const subagent_send_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "id", .json_type = .string, .min_length = 1 },
-        .{ .name = "content", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_message_bytes },
+        .{ .name = "id", .json_type = .string, .bounds = &.{ .min_length = 1 } },
+        .{ .name = "content", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_message_bytes } },
     },
     .required = &.{ "id", "content" },
     .additional_properties = false,
 };
 
 const subagent_milestone_schema = model_tool_schema.ObjectSchema{
-    .properties = &.{.{ .name = "name", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_name_bytes }},
+    .properties = &.{.{ .name = "name", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_name_bytes } }},
     .required = &.{"name"},
     .additional_properties = false,
 };
@@ -467,8 +468,8 @@ const subagent_message_schema = model_tool_schema.ObjectSchema{
 const subagent_relationship_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
         .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{ "attach", "detach", "reparent" } } },
-        .{ .name = "id", .json_type = .string, .min_length = 1 },
-        .{ .name = "parent_id", .json_type = .string, .min_length = 1 },
+        .{ .name = "id", .json_type = .string, .bounds = &.{ .min_length = 1 } },
+        .{ .name = "parent_id", .json_type = .string, .bounds = &.{ .min_length = 1 } },
     },
     .required = &.{ "action", "id" },
     .additional_properties = false,
@@ -476,10 +477,10 @@ const subagent_relationship_schema = model_tool_schema.ObjectSchema{
 
 const subagent_configure_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "id", .json_type = .string, .min_length = 1 },
-        .{ .name = "name", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_name_bytes },
-        .{ .name = "model", .json_type = .string, .min_length = 1, .max_length = subagent_domain.max_model_bytes },
-        .{ .name = "effort", .json_type = .string, .min_length = 1, .max_length = types.ReasoningEffort.max_name_bytes },
+        .{ .name = "id", .json_type = .string, .bounds = &.{ .min_length = 1 } },
+        .{ .name = "name", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_name_bytes } },
+        .{ .name = "model", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = subagent_domain.max_model_bytes } },
+        .{ .name = "effort", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = types.ReasoningEffort.max_name_bytes } },
         .{ .name = "permission_mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "ask", "auto", "yolo" } }, .description = "New child permission mode. Cannot exceed the caller's current mode." },
         .{ .name = "notifications", .json_type = .object, .shape = &.{ .object = &subagent_notifications_schema } },
     },
@@ -489,7 +490,7 @@ const subagent_configure_schema = model_tool_schema.ObjectSchema{
 
 const subagent_lifecycle_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
-        .{ .name = "id", .json_type = .string, .min_length = 1 },
+        .{ .name = "id", .json_type = .string, .bounds = &.{ .min_length = 1 } },
         .{ .name = "action", .json_type = .string, .shape = &.{ .enum_values = &.{ "cancel", "resume", "close", "reopen" } } },
     },
     .required = &.{ "id", "action" },
@@ -983,7 +984,7 @@ pub const web_search = ToolSpec{
         .description = web_search_description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "query", .json_type = .string, .min_length = 2 },
+                .{ .name = "query", .json_type = .string, .bounds = &.{ .min_length = 2 } },
                 .{ .name = "allowed_domains", .json_type = .array, .shape = &.{ .array_values = .{ .json_type = .string } } },
                 .{ .name = "blocked_domains", .json_type = .array, .shape = &.{ .array_values = .{ .json_type = .string } } },
             },
@@ -1252,7 +1253,7 @@ pub const ask_user_question = ToolSpec{
         .description = ask_user_question_description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "questions", .json_type = .array, .min_items = 1, .max_items = 4, .shape = &.{ .array_objects = &ask_user_question_question_schema } },
+                .{ .name = "questions", .json_type = .array, .bounds = &.{ .min_items = 1, .max_items = 4 }, .shape = &.{ .array_objects = &ask_user_question_question_schema } },
             },
             .required = &.{"questions"},
         },
@@ -1285,21 +1286,21 @@ pub const vision = ToolSpec{
                     .name = "image_ids",
                     .json_type = .array,
                     .description = "Ordered unique IDs of user-authorized images to inspect.",
-                    .min_items = 1,
+                    .bounds = &.{ .min_items = 1 },
                     .shape = &.{ .array_values = .{ .json_type = .integer } },
                 },
                 .{
                     .name = "paths",
                     .json_type = .array,
                     .description = "Ordered unique local image paths supplied by the user. Relative paths resolve from the workspace; ~/ resolves from the user's home directory.",
-                    .min_items = 1,
+                    .bounds = &.{ .min_items = 1 },
                     .shape = &.{ .array_values = .{ .json_type = .string } },
                 },
                 .{
                     .name = "focus",
                     .json_type = .string,
                     .description = "Specific visual evidence to extract from every requested image.",
-                    .min_length = 1,
+                    .bounds = &.{ .min_length = 1 },
                 },
             },
             .required = &.{"focus"},
@@ -1387,6 +1388,39 @@ pub const all = [_]tool_dispatch.Tool{
 
 pub const registry = tool_dispatch.Registry{ .tools = all[0..] };
 
+test "built-in model-facing tool contract stays byte exact" {
+    const alloc = std.testing.allocator;
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+
+    inline for (all) |tool| {
+        try std.testing.expectEqualStrings(tool.name, tool.gateway_schema.name);
+        try std.testing.expectEqualStrings(
+            tool.description,
+            tool.gateway_schema.description,
+        );
+        const schema_json = try tool_specs.toolGatewaySchemaJson(alloc, tool);
+        defer alloc.free(schema_json);
+        hasher.update(schema_json);
+        hasher.update("\x00");
+    }
+    for (advertisement_order) |name| {
+        hasher.update(name);
+        hasher.update("\x00");
+    }
+    const exec_only_json = try tool_specs.toolGatewaySchemaJson(
+        alloc,
+        terminalExecOnlySpec(),
+    );
+    defer alloc.free(exec_only_json);
+    hasher.update(exec_only_json);
+
+    const actual_hex = std.fmt.bytesToHex(hasher.finalResult(), .lower);
+    try std.testing.expectEqualStrings(
+        "33d8513797a6a673dcb22110095ce4694d1852fa8d72ad7947882974b40b6ce7",
+        &actual_hex,
+    );
+}
+
 test "registry classifies every built-in progress label" {
     inline for (all) |tool| {
         var started_buf: [96]u8 = undefined;
@@ -1459,7 +1493,7 @@ test "terminal tool schema derives one closed branch per terminal action" {
         for (contract.allowed, branch.properties) |field_name, property| {
             try std.testing.expectEqualStrings(field_name, property.name);
             if (std.mem.eql(u8, field_name, "action")) {
-                try std.testing.expect(!property.nullable);
+                try std.testing.expect(property.nullable == null);
                 try std.testing.expectEqualSlices(
                     []const u8,
                     &.{@tagName(action)},
@@ -1469,7 +1503,7 @@ test "terminal tool schema derives one closed branch per terminal action" {
             }
             try std.testing.expectEqual(
                 !nameInSet(contract.required, field_name),
-                property.nullable,
+                property.nullable != null,
             );
         }
     }
@@ -1512,11 +1546,11 @@ test "terminal tool schema derives one closed branch per terminal action" {
     );
     try std.testing.expectEqualStrings(
         "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only. Set null when the selected action does not use this field.",
-        schemaProperty(start_schema, "return_when").?.nullable_description,
+        schemaProperty(start_schema, "return_when").?.nullable.?.description,
     );
     try std.testing.expectEqualStrings(
         "Only for read. Use 0 with segment 1 for a new session's first read, then continue from the previous raw_range.end offset. Set null when the selected action does not use this field.",
-        schemaProperty(read_schema, "cursor_offset").?.nullable_description,
+        schemaProperty(read_schema, "cursor_offset").?.nullable.?.description,
     );
     try std.testing.expectEqualStrings(
         "Only for close and required for close. Close is final; read or inspect all needed output before closing.",
@@ -1532,14 +1566,14 @@ test "terminal tool schema derives one closed branch per terminal action" {
     const notification_interval = schemaProperty(terminal_monitor_notify_schema, "interval_ms").?;
     const lifetime_duration = schemaProperty(terminal_monitor_lifetime_schema, "duration_ms").?;
     const check_interval = schemaProperty(terminal_monitor_definition_schema, "check_interval_ms").?;
-    try std.testing.expectEqual(@as(?u64, terminal_monitor.minimum_schedule_ms), output_quiet_duration.minimum);
-    try std.testing.expectEqual(@as(?u64, terminal_monitor.maximum_schedule_ms), output_quiet_duration.maximum);
-    try std.testing.expectEqual(@as(?u64, terminal_monitor.minimum_schedule_ms), notification_interval.minimum);
-    try std.testing.expectEqual(@as(?u64, terminal_monitor.maximum_schedule_ms), notification_interval.maximum);
-    try std.testing.expectEqual(@as(?u64, 1), lifetime_duration.minimum);
-    try std.testing.expectEqual(@as(?u64, terminal_monitor.maximum_lifetime_ms), lifetime_duration.maximum);
-    try std.testing.expectEqual(@as(?u64, terminal_monitor.minimum_schedule_ms), check_interval.minimum);
-    try std.testing.expectEqual(@as(?u64, terminal_monitor.maximum_schedule_ms), check_interval.maximum);
+    try std.testing.expectEqual(@as(?u64, terminal_monitor.minimum_schedule_ms), output_quiet_duration.bounds.?.minimum);
+    try std.testing.expectEqual(@as(?u64, terminal_monitor.maximum_schedule_ms), output_quiet_duration.bounds.?.maximum);
+    try std.testing.expectEqual(@as(?u64, terminal_monitor.minimum_schedule_ms), notification_interval.bounds.?.minimum);
+    try std.testing.expectEqual(@as(?u64, terminal_monitor.maximum_schedule_ms), notification_interval.bounds.?.maximum);
+    try std.testing.expectEqual(@as(?u64, 1), lifetime_duration.bounds.?.minimum);
+    try std.testing.expectEqual(@as(?u64, terminal_monitor.maximum_lifetime_ms), lifetime_duration.bounds.?.maximum);
+    try std.testing.expectEqual(@as(?u64, terminal_monitor.minimum_schedule_ms), check_interval.bounds.?.minimum);
+    try std.testing.expectEqual(@as(?u64, terminal_monitor.maximum_schedule_ms), check_interval.bounds.?.maximum);
     try std.testing.expectEqualStrings(
         "Required for path conditions. The path must resolve within the terminal workspace; external paths are rejected.",
         monitor_path.description,

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -1393,10 +1393,10 @@ test "built-in model-facing tool contract stays byte exact" {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
 
     inline for (all) |tool| {
-        try std.testing.expectEqualStrings(tool.name, tool.gateway_schema.name);
+        try std.testing.expectEqualStrings(tool.name, tool.model_schema.name);
         try std.testing.expectEqualStrings(
             tool.description,
-            tool.gateway_schema.description,
+            tool.model_schema.description,
         );
         const schema_json = try tool_specs.toolGatewaySchemaJson(alloc, tool);
         defer alloc.free(schema_json);
@@ -1416,7 +1416,7 @@ test "built-in model-facing tool contract stays byte exact" {
 
     const actual_hex = std.fmt.bytesToHex(hasher.finalResult(), .lower);
     try std.testing.expectEqualStrings(
-        "33d8513797a6a673dcb22110095ce4694d1852fa8d72ad7947882974b40b6ce7",
+        "e4439b952e577a959ac4916025cf4f0d222713ec7bd1bc83dd703bfedd220af1",
         &actual_hex,
     );
 }

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -197,7 +197,7 @@ const terminal_properties = [_]model_tool_schema.Property{
     .{ .name = "cwd", .json_type = .string, .description = "Working directory for exec or start; defaults to the workspace." },
     .{ .name = "command", .json_type = .string, .bounds = &.{ .max_length = terminal_contracts.max_command_bytes }, .description = "Command for exec, or optional command for start; omit on start for an interactive shell." },
     .{ .name = "profile", .json_type = .string, .shape = &.{ .enum_values = &.{ "clean", "user" } }, .description = "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile." },
-    .{ .name = "timeout_ms", .json_type = .integer, .minimum = terminal_impl.exec_timeout_min_ms, .maximum = terminal_impl.exec_timeout_max_ms, .description = "Required for exec. Maximum foreground runtime in milliseconds; use start for persistent work." },
+    .{ .name = "timeout_ms", .json_type = .integer, .bounds = &.{ .minimum = terminal_impl.exec_timeout_min_ms, .maximum = terminal_impl.exec_timeout_max_ms }, .description = "Required for exec. Maximum foreground runtime in milliseconds; use start for persistent work." },
     .{ .name = "shell", .json_type = .object, .shape = &.{ .object = &terminal_shell_schema } },
     .{ .name = "backend", .json_type = .string, .shape = &.{ .enum_values = &.{ "native", "tmux" } }, .description = "Start backend or optional list filter." },
     .{ .name = "return_when", .json_type = .object, .shape = &.{ .object = &terminal_return_schema }, .description = "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only." },
@@ -1416,7 +1416,7 @@ test "built-in model-facing tool contract stays byte exact" {
 
     const actual_hex = std.fmt.bytesToHex(hasher.finalResult(), .lower);
     try std.testing.expectEqualStrings(
-        "e4439b952e577a959ac4916025cf4f0d222713ec7bd1bc83dd703bfedd220af1",
+        "e1bde312041e1b39f641b5034d59afcaee8159c93884aa2f812ada8cab334187",
         &actual_hex,
     );
 }
@@ -1516,9 +1516,9 @@ test "terminal tool schema derives one closed branch per terminal action" {
     const close_schema = terminal_action_schema(.close);
     const exec_timeout = schemaProperty(exec_schema, "timeout_ms").?;
     try std.testing.expectEqual(model_tool_schema.JsonType.integer, exec_timeout.json_type);
-    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_min_ms), exec_timeout.minimum);
-    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_max_ms), exec_timeout.maximum);
-    try std.testing.expect(!exec_timeout.nullable);
+    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_min_ms), exec_timeout.bounds.?.minimum);
+    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_max_ms), exec_timeout.bounds.?.maximum);
+    try std.testing.expect(exec_timeout.nullable == null);
     try std.testing.expectEqualSlices(
         []const u8,
         &.{ "native", "tmux" },
@@ -1620,9 +1620,9 @@ test "terminal exec-only schema reuses exec structure with focused descriptions"
         terminal_exec_only_timeout_description,
         timeout.description,
     );
-    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_min_ms), timeout.minimum);
-    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_max_ms), timeout.maximum);
-    try std.testing.expect(!timeout.nullable);
+    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_min_ms), timeout.bounds.?.minimum);
+    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_max_ms), timeout.bounds.?.maximum);
+    try std.testing.expect(timeout.nullable == null);
 }
 
 test "terminal gateway advertisement projects a provider-compatible object schema" {

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -2458,7 +2458,6 @@ pub const McpServerConfig = mcp_contract.McpServerConfig;
 const freeOwnedStrings = mcp_contract.freeOwnedStrings;
 
 pub const McpTool = struct {
-    server_name: []const u8,
     original_name: []const u8,
     prefixed_name: []u8,
     title: ?[]u8 = null,
@@ -2469,8 +2468,6 @@ pub const McpTool = struct {
     annotations_json: ?[]u8 = null,
     metadata_json: ?[]u8 = null,
     tags: []const []u8,
-    search_text: []u8,
-    server_instructions: ?[]const u8 = null,
 };
 
 pub const ToolCatalogSnapshot = struct {
@@ -3575,7 +3572,6 @@ fn freeTools(alloc: Allocator, tools: []const McpTool) void {
         if (tool.annotations_json) |value| alloc.free(value);
         if (tool.metadata_json) |value| alloc.free(value);
         freeOwnedStrings(alloc, tool.tags);
-        alloc.free(tool.search_text);
     }
 }
 
@@ -5830,11 +5826,16 @@ pub const McpRuntime = struct {
                 const auth_witness = catalogAuthWitness(match.server);
                 if (permissions.rulesDenyAllTargetsForPermission(permission_rules, match.tool.prefixed_name)) break :result null;
                 const instruction_limit = limits.mcp_server_instructions_bytes;
-                const instructions = if (match.tool.server_instructions) |value|
+                const server_instructions = match.server.instructions;
+                const instruction_observed_bytes = if (server_instructions) |value|
+                    value.len
+                else
+                    0;
+                const instructions = if (server_instructions) |value|
                     value[0..context_limits.lineSafePrefixLength(value, instruction_limit.effectiveBytes())]
                 else
                     null;
-                const instructions_truncated = if (match.tool.server_instructions) |value|
+                const instructions_truncated = if (server_instructions) |value|
                     instructions.?.len < value.len
                 else
                     false;
@@ -5843,6 +5844,7 @@ pub const McpRuntime = struct {
                     match.tool,
                     instructions,
                     instructions_truncated,
+                    instruction_observed_bytes,
                     instruction_limit,
                 );
                 var schema_owned = true;
@@ -5881,7 +5883,7 @@ pub const McpRuntime = struct {
                         alloc,
                         match.tool.prefixed_name,
                         "instructions truncated",
-                        match.tool.server_instructions.?.len,
+                        instruction_observed_bytes,
                         instruction_limit,
                         "mcp_server_instructions_bytes",
                     )
@@ -5927,7 +5929,7 @@ pub const McpRuntime = struct {
             self.catalog_mutex.lockSharedUncancelable(io_mod.getIo());
             defer self.catalog_mutex.unlockShared(io_mod.getIo());
             const capped_limit = @min(if (limit == 0) default_mcp_search_limit else limit, max_mcp_search_limit);
-            var matches: std.ArrayList(McpTool) = .empty;
+            var matches: std.ArrayList(ToolSearchMatch) = .empty;
             defer matches.deinit(alloc);
             var auth_witnesses: std.ArrayList(CatalogAuthWitness) = .empty;
             defer auth_witnesses.deinit(alloc);
@@ -5941,18 +5943,27 @@ pub const McpRuntime = struct {
                 else
                     "";
                 var server_matched = false;
-                for (server.tool_catalog.tools.items) |tool| {
+                for (server.tool_catalog.tools.items) |*tool| {
                     if (!operation_access.allows(.{ .tool = tool.prefixed_name })) continue;
                     if (permissions.rulesDenyAllTargetsForPermission(permission_rules, tool.prefixed_name)) continue;
                     const exact_identity = queryContainsCompleteIdentity(query, tool.original_name) or
                         queryContainsCompleteIdentity(query, tool.prefixed_name);
-                    if (!exact_identity and !toolMatchesQuery(tool, searchable_instructions, query)) continue;
+                    if (!exact_identity and
+                        !toolMatchesQuery(
+                            tool,
+                            server.config.name,
+                            searchable_instructions,
+                            query,
+                        )) continue;
                     server_matched = true;
                     if (matches.items.len >= capped_limit) {
                         more_available = true;
                         break;
                     }
-                    try matches.append(alloc, tool);
+                    try matches.append(alloc, .{
+                        .server = server,
+                        .tool = tool,
+                    });
                 }
                 if (server_matched) {
                     if (catalogAuthWitness(server)) |generation| {
@@ -8682,13 +8693,11 @@ test "MRTR tool snapshots bind server schemas and both generations" {
         .content_digest = feature_cache.authIdentity(&.{}),
     };
     try server.tool_catalog.tools.append(alloc, .{
-        .server_name = "fixture",
         .original_name = @constCast("echo"),
         .prefixed_name = @constCast("mcp_fixture_echo"),
         .description = @constCast("Echo"),
         .input_schema_json = @constCast("{\"type\":\"object\"}"),
         .tags = &.{},
-        .search_text = @constCast("echo"),
     });
     try runtime.servers.append(alloc, server);
     defer runtime.servers.items[0].tool_catalog.tools.deinit(alloc);
@@ -10496,9 +10505,6 @@ fn buildProtocolTools(
         const tags = try buildToolTags(alloc, server.config.name, name);
         errdefer freeOwnedStrings(alloc, tags);
 
-        const search_text = try buildSearchText(alloc, server.config.name, name, description, input_schema_json, tags);
-        errdefer alloc.free(search_text);
-
         const title = if (protocol_tool.title) |value| try alloc.dupe(u8, value) else null;
         errdefer if (title) |value| alloc.free(value);
         const output_schema_json = if (protocol_tool.output_schema_json) |value| try alloc.dupe(u8, value) else null;
@@ -10513,7 +10519,6 @@ fn buildProtocolTools(
         try result.tools.ensureUnusedCapacity(alloc, 1);
         try used_tool_names.put(prefixed_name, {});
         result.tools.appendAssumeCapacity(.{
-            .server_name = server.config.name,
             .original_name = original_name,
             .prefixed_name = prefixed_name,
             .title = title,
@@ -10524,8 +10529,6 @@ fn buildProtocolTools(
             .annotations_json = annotations_json,
             .metadata_json = metadata_json,
             .tags = tags,
-            .search_text = search_text,
-            .server_instructions = server.instructions,
         });
     }
     return result;
@@ -11182,9 +11185,9 @@ fn serverHasSnapshotTool(
     server: *const McpServer,
     snapshot: *const ToolCallSnapshot,
 ) bool {
+    if (!std.mem.eql(u8, server.config.name, snapshot.server_name)) return false;
     for (server.tool_catalog.tools.items) |tool| {
-        if (std.mem.eql(u8, tool.server_name, snapshot.server_name) and
-            std.mem.eql(u8, tool.original_name, snapshot.original_name) and
+        if (std.mem.eql(u8, tool.original_name, snapshot.original_name) and
             std.mem.eql(u8, tool.prefixed_name, snapshot.prefixed_name) and
             std.mem.eql(u8, tool.input_schema_json, snapshot.input_schema_json) and
             optionalBytesEqual(tool.output_schema_json, snapshot.output_schema_json))
@@ -11263,6 +11266,7 @@ fn buildToolSchemaJsonWithLimitMarker(
     tool: McpTool,
     instructions: ?[]const u8,
     instructions_truncated: bool,
+    instruction_observed_bytes: usize,
     limit: context_limits.Resolved,
 ) ![]u8 {
     const encoded_description = try encodeScalarAlloc(alloc, tool.description);
@@ -11274,7 +11278,7 @@ fn buildToolSchemaJsonWithLimitMarker(
             try std.fmt.allocPrint(
                 alloc,
                 "{s}\n\nServer instructions: {s}\n<context_limit name=\"mcp_server_instructions_bytes\" action=\"truncated\" observed_bytes=\"{d}\" effective_bytes=\"{d}\" source=\"{s}\" override=\"--context-limit mcp_server_instructions_bytes=BYTES|off\" />",
-                .{ encoded_description, encoded_instructions.?, tool.server_instructions.?.len, limit.effectiveBytes(), limit.source.label() },
+                .{ encoded_description, encoded_instructions.?, instruction_observed_bytes, limit.effectiveBytes(), limit.source.label() },
             )
         else
             try std.fmt.allocPrint(alloc, "{s}\n\nServer instructions: {s}", .{ encoded_description, encoded_instructions.? })
@@ -11289,9 +11293,14 @@ fn buildToolSchemaJsonWithLimitMarker(
     );
 }
 
+const ToolSearchMatch = struct {
+    server: *const McpServer,
+    tool: *const McpTool,
+};
+
 fn renderSearchResult(
     alloc: Allocator,
-    matches: []const McpTool,
+    matches: []const ToolSearchMatch,
     selected_count: usize,
     description_limit: context_limits.Resolved,
     result_limit: context_limits.Resolved,
@@ -11302,9 +11311,9 @@ fn renderSearchResult(
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
     try out.writer.writeAll("{\"tools\":[");
-    for (matches[0..selected_count], 0..) |tool, index| {
+    for (matches[0..selected_count], 0..) |match, index| {
         if (index > 0) try out.writer.writeByte(',');
-        try writeToolMetadataJson(alloc, &out.writer, tool, description_limit);
+        try writeToolMetadataJson(alloc, &out.writer, match, description_limit);
     }
     try out.writer.print("],\"count\":{d}", .{selected_count});
     if (more_available) try out.writer.writeAll(",\"more_available\":true");
@@ -11322,7 +11331,7 @@ fn renderSearchResult(
 
 fn renderSearchNotice(
     alloc: Allocator,
-    matches: []const McpTool,
+    matches: []const ToolSearchMatch,
     selected_count: usize,
     limits: context_limits.Values,
     observed_bytes: usize,
@@ -11330,7 +11339,8 @@ fn renderSearchNotice(
 ) !?[]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
-    for (matches[0..selected_count]) |tool| {
+    for (matches[0..selected_count]) |match| {
+        const tool = match.tool;
         const encoded_description = try encodeScalarAlloc(alloc, tool.description);
         defer alloc.free(encoded_description);
         if (encoded_description.len <= limits.mcp_description_bytes.effectiveBytes()) continue;
@@ -11343,9 +11353,9 @@ fn renderSearchNotice(
     }
     if (result_limit_triggered) {
         try out.writer.print("[context] MCP search omitted {d} tool(s) (", .{matches.len - selected_count});
-        for (matches[selected_count..], 0..) |tool, index| {
+        for (matches[selected_count..], 0..) |match, index| {
             if (index > 0) try out.writer.writeAll(", ");
-            try model_context_encoding.writeScalar(&out.writer, tool.prefixed_name);
+            try model_context_encoding.writeScalar(&out.writer, match.tool.prefixed_name);
         }
         try out.writer.print(
             "): observed={d} bytes effective={d} bytes source={s}; override with --context-limit mcp_search_result_bytes=BYTES|off",
@@ -11377,9 +11387,10 @@ fn renderSchemaNotice(
 fn writeToolMetadataJson(
     alloc: Allocator,
     writer: *std.Io.Writer,
-    tool: McpTool,
+    match: ToolSearchMatch,
     description_limit: context_limits.Resolved,
 ) !void {
+    const tool = match.tool;
     const bounded = try boundedEncodedScalar(
         alloc,
         tool.description,
@@ -11389,7 +11400,7 @@ fn writeToolMetadataJson(
     try writer.writeAll("{\"name\":");
     try writeEncodedJsonScalar(alloc, writer, tool.prefixed_name);
     try writer.writeAll(",\"server\":");
-    try writeEncodedJsonScalar(alloc, writer, tool.server_name);
+    try writeEncodedJsonScalar(alloc, writer, match.server.config.name);
     try writer.writeAll(",\"description\":");
     try std.json.Stringify.value(bounded.text, .{}, writer);
     try writer.writeAll(",\"purpose\":");
@@ -11442,7 +11453,29 @@ fn writeEncodedJsonScalar(alloc: Allocator, writer: *std.Io.Writer, value: []con
     try std.json.Stringify.value(encoded, .{}, writer);
 }
 
-fn toolMatchesQuery(tool: McpTool, server_instructions: []const u8, query: []const u8) bool {
+fn toolContainsToken(
+    tool: *const McpTool,
+    server_name: []const u8,
+    token: []const u8,
+) bool {
+    for ([_][]const u8{
+        server_name,
+        tool.original_name,
+        tool.description,
+        tool.input_schema_json,
+        "mcp",
+    }) |field| {
+        if (text_utils.containsIgnoreCase(field, token)) return true;
+    }
+    return false;
+}
+
+fn toolMatchesQuery(
+    tool: *const McpTool,
+    server_name: []const u8,
+    server_instructions: []const u8,
+    query: []const u8,
+) bool {
     var found_token = false;
     var start: ?usize = null;
     for (query, 0..) |byte, index| {
@@ -11453,7 +11486,7 @@ fn toolMatchesQuery(tool: McpTool, server_instructions: []const u8, query: []con
         if (start) |s| {
             found_token = true;
             const token = query[s..index];
-            if (!text_utils.containsIgnoreCase(tool.search_text, token) and
+            if (!toolContainsToken(tool, server_name, token) and
                 !text_utils.containsIgnoreCase(server_instructions, token)) return false;
             start = null;
         }
@@ -11461,7 +11494,7 @@ fn toolMatchesQuery(tool: McpTool, server_instructions: []const u8, query: []con
     if (start) |s| {
         found_token = true;
         const token = query[s..];
-        if (!text_utils.containsIgnoreCase(tool.search_text, token) and
+        if (!toolContainsToken(tool, server_name, token) and
             !text_utils.containsIgnoreCase(server_instructions, token)) return false;
     }
     return found_token or query.len == 0;
@@ -11523,24 +11556,6 @@ fn appendTag(alloc: Allocator, tags: *std.ArrayList([]u8), raw: []const u8) !voi
 
 fn isSearchByte(byte: u8) bool {
     return std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '-';
-}
-
-fn buildSearchText(
-    alloc: Allocator,
-    server_name: []const u8,
-    tool_name: []const u8,
-    description: []const u8,
-    input_schema_json: []const u8,
-    tags: []const []u8,
-) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    defer out.deinit();
-
-    try out.writer.print("{s} {s} {s} {s}", .{ server_name, tool_name, description, input_schema_json });
-    for (tags) |tag| try out.writer.print(" {s}", .{tag});
-    const text = try out.toOwnedSlice();
-    defer alloc.free(text);
-    return try std.ascii.allocLowerString(alloc, text);
 }
 
 fn retainFeatureProtocolDiagnostic(
@@ -17685,6 +17700,80 @@ test "parseAndStoreTools duplicates original_name for owned cleanup" {
     try std.testing.expectEqualStrings("read", server.tool_catalog.tools.items[0].original_name);
 }
 
+test "MCP tool catalog retains only tool-owned search data" {
+    try std.testing.expect(!@hasField(McpTool, "server_name"));
+    try std.testing.expect(!@hasField(McpTool, "server_instructions"));
+    try std.testing.expect(!@hasField(McpTool, "search_text"));
+    try std.testing.expectEqual(@as(usize, 160), @sizeOf(McpTool));
+}
+
+test "MCP search matches each retained source field" {
+    const alloc = std.testing.allocator;
+    var runtime = McpRuntime.init(alloc);
+    defer runtime.deinit();
+
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "git-hub"),
+        .command = try alloc.dupe(u8, "fixture"),
+    });
+    runtime.servers.items[0].state = .ready;
+    runtime.servers.items[0].instructions = try alloc.dupe(u8, "workflow guide");
+
+    var used = std.StringHashMap(void).init(alloc);
+    defer used.deinit();
+    try parseAndStoreTools(
+        alloc,
+        &runtime.servers.items[0],
+        .{},
+        \\{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"create_issue","description":"Create ticket","inputSchema":{"type":"object","properties":{"repository_slug":{"type":"string"}}}}]}}
+    ,
+        &used,
+    );
+
+    const cases = [_][]const u8{
+        "mcp",
+        "GIT-HUB",
+        "create_issue",
+        "TICKET",
+        "repository_slug",
+        "workflow",
+        "git-hub repository_slug",
+    };
+    const expected_output =
+        "{\"tools\":[{\"name\":\"mcp_git-hub_create_issue\",\"server\":\"git-hub\",\"description\":\"Create ticket\",\"purpose\":\"Create ticket\",\"usage\":[\"mcp\",\"git-hub\",\"create_issue\"]}],\"count\":1}";
+    for (cases) |query| {
+        var result = try runtime.searchTools(alloc, query, 5, .{}, .{}, .unrestricted);
+        defer result.deinit(alloc);
+        try std.testing.expectEqualStrings(expected_output, result.model_output);
+        try std.testing.expect(result.notice == null);
+
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, result.model_output, .{});
+        defer parsed.deinit();
+        const tools = parsed.value.object.get("tools").?.array.items;
+        try std.testing.expectEqual(@as(usize, 1), tools.len);
+        const usage = tools[0].object.get("usage").?.array.items;
+        try std.testing.expectEqual(@as(usize, 3), usage.len);
+        try std.testing.expectEqualStrings("mcp", usage[0].string);
+        try std.testing.expectEqualStrings("git-hub", usage[1].string);
+        try std.testing.expectEqualStrings("create_issue", usage[2].string);
+    }
+
+    var missing = try runtime.searchTools(
+        alloc,
+        "missing-token",
+        5,
+        .{},
+        .{},
+        .unrestricted,
+    );
+    defer missing.deinit(alloc);
+    try std.testing.expectEqualStrings(
+        "{\"tools\":[],\"count\":0}",
+        missing.model_output,
+    );
+    try std.testing.expect(missing.notice == null);
+}
+
 test "MCP search preserves exact identities and scopes authentication guidance" {
     const alloc = std.testing.allocator;
     var runtime = McpRuntime.init(alloc);
@@ -18298,9 +18387,6 @@ test "MCP server instructions are captured from initialize and exposed only when
     ;
     try parseAndStoreTools(alloc, &server, .{}, tools_response, &used);
     try std.testing.expectEqual(@as(usize, 2), server.tool_catalog.tools.items.len);
-    for (server.tool_catalog.tools.items) |tool| {
-        try std.testing.expect(std.mem.find(u8, tool.search_text, "github issue workflows") == null);
-    }
     server.state = .ready;
 
     var runtime = McpRuntime.init(alloc);
@@ -18479,6 +18565,7 @@ test "tool schema uses prefixed name and call request uses raw name" {
         tool,
         null,
         false,
+        0,
         (context_limits.Values{}).mcp_server_instructions_bytes,
     );
     defer alloc.free(schema);

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -5929,8 +5929,8 @@ pub const McpRuntime = struct {
             self.catalog_mutex.lockSharedUncancelable(io_mod.getIo());
             defer self.catalog_mutex.unlockShared(io_mod.getIo());
             const capped_limit = @min(if (limit == 0) default_mcp_search_limit else limit, max_mcp_search_limit);
-            var matches: std.ArrayList(ToolSearchMatch) = .empty;
-            defer matches.deinit(alloc);
+            var match_storage: [max_mcp_search_limit]ToolSearchMatch = undefined;
+            var match_count: usize = 0;
             var auth_witnesses: std.ArrayList(CatalogAuthWitness) = .empty;
             defer auth_witnesses.deinit(alloc);
             var more_available = false;
@@ -5954,16 +5954,17 @@ pub const McpRuntime = struct {
                             server.config.name,
                             searchable_instructions,
                             query,
-                        )) continue;
+                    )) continue;
                     server_matched = true;
-                    if (matches.items.len >= capped_limit) {
+                    if (match_count >= capped_limit) {
                         more_available = true;
                         break;
                     }
-                    try matches.append(alloc, .{
+                    match_storage[match_count] = .{
                         .server = server,
                         .tool = tool,
-                    });
+                    };
+                    match_count += 1;
                 }
                 if (server_matched) {
                     if (catalogAuthWitness(server)) |generation| {
@@ -5975,7 +5976,8 @@ pub const McpRuntime = struct {
                 }
                 if (more_available) break :server_loop;
             }
-            if (matches.items.len == 0) {
+            const matches = match_storage[0..match_count];
+            if (matches.len == 0) {
                 if (try renderAuthenticationRequired(
                     alloc,
                     self.servers.items,
@@ -5988,8 +5990,8 @@ pub const McpRuntime = struct {
 
             const full = try renderSearchResult(
                 alloc,
-                matches.items,
-                matches.items.len,
+                matches,
+                matches.len,
                 limits.mcp_description_bytes,
                 limits.mcp_search_result_bytes,
                 0,
@@ -6000,19 +6002,19 @@ pub const McpRuntime = struct {
             const effective_bytes = limits.mcp_search_result_bytes.effectiveBytes();
             if (full.len <= effective_bytes) {
                 errdefer alloc.free(full);
-                const notice = try renderSearchNotice(alloc, matches.items, matches.items.len, limits, observed_bytes, false);
+                const notice = try renderSearchNotice(alloc, matches, matches.len, limits, observed_bytes, false);
                 errdefer if (notice) |value| alloc.free(value);
                 try validateCatalogAuthWitnesses(auth_witnesses.items);
                 break :result tool_mcp_runtime.SearchResult{ .model_output = full, .notice = notice };
             }
             alloc.free(full);
 
-            var selected_count = matches.items.len;
+            var selected_count = matches.len;
             var model_output: ?[]u8 = null;
             while (true) {
                 const candidate = try renderSearchResult(
                     alloc,
-                    matches.items,
+                    matches,
                     selected_count,
                     limits.mcp_description_bytes,
                     limits.mcp_search_result_bytes,
@@ -6033,7 +6035,7 @@ pub const McpRuntime = struct {
             }
             const output = model_output.?;
             errdefer alloc.free(output);
-            const notice = try renderSearchNotice(alloc, matches.items, selected_count, limits, observed_bytes, true);
+            const notice = try renderSearchNotice(alloc, matches, selected_count, limits, observed_bytes, true);
             errdefer if (notice) |value| alloc.free(value);
             try validateCatalogAuthWitnesses(auth_witnesses.items);
             break :result tool_mcp_runtime.SearchResult{ .model_output = output, .notice = notice };
@@ -17772,6 +17774,47 @@ test "MCP search matches each retained source field" {
         missing.model_output,
     );
     try std.testing.expect(missing.notice == null);
+}
+
+test "MCP search keeps bounded matches off the allocator" {
+    const alloc = std.testing.allocator;
+    var runtime = McpRuntime.init(alloc);
+    defer runtime.deinit();
+
+    try runtime.addServer(.{
+        .name = try alloc.dupe(u8, "github"),
+        .command = try alloc.dupe(u8, "fixture"),
+    });
+    runtime.servers.items[0].state = .ready;
+
+    var used = std.StringHashMap(void).init(alloc);
+    defer used.deinit();
+    try parseAndStoreTools(
+        alloc,
+        &runtime.servers.items[0],
+        .{},
+        \\{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"create_issue","description":"Create issue","inputSchema":{"type":"object"}}]}}
+    ,
+        &used,
+    );
+
+    var counting = std.testing.FailingAllocator.init(alloc, .{});
+    const search_alloc = counting.allocator();
+    var result = try runtime.searchTools(
+        search_alloc,
+        "github issue",
+        max_mcp_search_limit,
+        .{},
+        .{},
+        .unrestricted,
+    );
+    defer result.deinit(search_alloc);
+
+    try std.testing.expectEqualStrings(
+        "{\"tools\":[{\"name\":\"mcp_github_create_issue\",\"server\":\"github\",\"description\":\"Create issue\",\"purpose\":\"Create issue\",\"usage\":[\"mcp\",\"github\",\"create_issue\"]}],\"count\":1}",
+        result.model_output,
+    );
+    try std.testing.expectEqual(@as(usize, 18), counting.allocations);
 }
 
 test "MCP search preserves exact identities and scopes authentication guidance" {

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -5954,7 +5954,7 @@ pub const McpRuntime = struct {
                             server.config.name,
                             searchable_instructions,
                             query,
-                    )) continue;
+                        )) continue;
                     server_matched = true;
                     if (match_count >= capped_limit) {
                         more_available = true;

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -1077,6 +1077,19 @@ fn toolsJsonAlloc(alloc: std.mem.Allocator) ![]u8 {
     return std.fmt.allocPrint(alloc, "[{s}]", .{schema_json});
 }
 
+test "automatic review model-facing tool contract stays byte exact" {
+    const tools_json = try toolsJsonAlloc(std.testing.allocator);
+    defer std.testing.allocator.free(tools_json);
+
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(tools_json, &digest, .{});
+    const actual_hex = std.fmt.bytesToHex(digest, .lower);
+    try std.testing.expectEqualStrings(
+        "a8980fcb16cd2ab8d1f98f7a4d61eed40df435fe406bfb65fc1d3ef4126def08",
+        &actual_hex,
+    );
+}
+
 fn buildTestReviewPayload(
     _: *anyopaque,
     alloc: std.mem.Allocator,

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -1085,7 +1085,7 @@ test "automatic review model-facing tool contract stays byte exact" {
     std.crypto.hash.sha2.Sha256.hash(tools_json, &digest, .{});
     const actual_hex = std.fmt.bytesToHex(digest, .lower);
     try std.testing.expectEqualStrings(
-        "a8980fcb16cd2ab8d1f98f7a4d61eed40df435fe406bfb65fc1d3ef4126def08",
+        "a8000b05e90c3a89d1a54a7a38c1250e45447b8826564989c50eeaf81cadda12",
         &actual_hex,
     );
 }

--- a/src/core/tooling/model_tool_schema.zig
+++ b/src/core/tooling/model_tool_schema.zig
@@ -24,19 +24,28 @@ const PropertyShape = union(enum) {
     array_objects: *const ObjectSchema,
 };
 
-pub const Property = struct {
-    name: []const u8,
-    json_type: JsonType,
-    description: []const u8 = "",
-    nullable: bool = false,
-    nullable_description: []const u8 = "",
-    shape: ?*const PropertyShape = null,
+const PropertyBounds = struct {
     min_length: u32 = no_u32_bound,
     max_length: u32 = no_u32_bound,
     minimum: u64 = no_u64_bound,
     maximum: u64 = no_u64_bound,
     min_items: u32 = no_u32_bound,
     max_items: u32 = no_u32_bound,
+};
+
+const no_property_bounds = PropertyBounds{};
+
+const NullableMetadata = struct {
+    description: []const u8 = "",
+};
+
+pub const Property = struct {
+    name: []const u8,
+    description: []const u8 = "",
+    shape: ?*const PropertyShape = null,
+    bounds: ?*const PropertyBounds = null,
+    nullable: ?*const NullableMetadata = null,
+    json_type: JsonType,
 };
 
 pub const ObjectSchema = struct {
@@ -73,7 +82,7 @@ pub fn isSingleRequiredObjectUnionField(
 }
 
 test "static property representation stays within the measured size budget" {
-    try std.testing.expect(@sizeOf(Property) <= 96);
+    try std.testing.expect(@sizeOf(Property) <= 64);
 }
 
 fn cappedDescriptionAlloc(alloc: std.mem.Allocator, text: []const u8) ![]u8 {
@@ -198,19 +207,18 @@ fn writePropertySchema(
     writer: *std.Io.Writer,
     property: Property,
 ) anyerror!void {
-    if (property.nullable) {
+    if (property.nullable) |nullable| {
         var concrete = property;
-        concrete.nullable = false;
-        concrete.nullable_description = "";
+        concrete.nullable = null;
         try writer.writeAll("{\"anyOf\":[");
         try writePropertySchema(alloc, writer, concrete);
         try writer.writeAll(",{\"type\":\"null\"}]");
-        if (property.nullable_description.len > 0) {
+        if (nullable.description.len > 0) {
             try writer.writeAll(",\"description\":");
             try writeCappedDescriptionJsonString(
                 alloc,
                 writer,
-                property.nullable_description,
+                nullable.description,
             );
         }
         try writer.writeByte('}');
@@ -240,16 +248,17 @@ fn writePropertySchema(
             else => {},
         }
     }
-    if (property.min_length != no_u32_bound) try writer.print(",\"minLength\":{d}", .{property.min_length});
-    if (property.max_length != no_u32_bound) try writer.print(",\"maxLength\":{d}", .{property.max_length});
-    if (property.minimum != no_u64_bound) try writer.print(",\"minimum\":{d}", .{property.minimum});
-    if (property.maximum != no_u64_bound) try writer.print(",\"maximum\":{d}", .{property.maximum});
+    const bounds = property.bounds orelse &no_property_bounds;
+    if (bounds.min_length != no_u32_bound) try writer.print(",\"minLength\":{d}", .{bounds.min_length});
+    if (bounds.max_length != no_u32_bound) try writer.print(",\"maxLength\":{d}", .{bounds.max_length});
+    if (bounds.minimum != no_u64_bound) try writer.print(",\"minimum\":{d}", .{bounds.minimum});
+    if (bounds.maximum != no_u64_bound) try writer.print(",\"maximum\":{d}", .{bounds.maximum});
     if (property.description.len > 0) {
         try writer.writeAll(",\"description\":");
         try writeCappedDescriptionJsonString(alloc, writer, property.description);
     }
-    if (property.min_items != no_u32_bound) try writer.print(",\"minItems\":{d}", .{property.min_items});
-    if (property.max_items != no_u32_bound) try writer.print(",\"maxItems\":{d}", .{property.max_items});
+    if (bounds.min_items != no_u32_bound) try writer.print(",\"minItems\":{d}", .{bounds.min_items});
+    if (bounds.max_items != no_u32_bound) try writer.print(",\"maxItems\":{d}", .{bounds.max_items});
     if (property.shape) |shape| {
         switch (shape.*) {
             .array_values => |values| {
@@ -291,15 +300,13 @@ test "nullable properties preserve concrete constraints and add one null branch"
                     .name = "choice",
                     .json_type = .string,
                     .description = "Concrete choice.",
-                    .nullable = true,
-                    .nullable_description = "Concrete choice. Set null when unused.",
+                    .nullable = &.{ .description = "Concrete choice. Set null when unused." },
                     .shape = &.{ .enum_values = &.{ "one", "two" } },
                 },
                 .{
                     .name = "config",
                     .json_type = .object,
-                    .nullable = true,
-                    .nullable_description = "Set null when unused.",
+                    .nullable = &.{ .description = "Set null when unused." },
                     .shape = &.{ .object = &object_value_schema },
                 },
             },
@@ -479,17 +486,15 @@ test "builtinFunctionSchemaJsonAlloc serializes every supported property shape" 
                     .json_type = .string,
                     .description = "bounded choice",
                     .shape = &.{ .enum_values = &.{ "alpha", "beta" } },
-                    .min_length = 1,
-                    .max_length = 8,
+                    .bounds = &.{ .min_length = 1, .max_length = 8 },
                 },
-                .{ .name = "count", .json_type = .integer, .minimum = 2, .maximum = 9 },
+                .{ .name = "count", .json_type = .integer, .bounds = &.{ .minimum = 2, .maximum = 9 } },
                 .{ .name = "enabled", .json_type = .boolean },
                 .{ .name = "config", .json_type = .object, .shape = &.{ .object = &object_value_schema } },
                 .{
                     .name = "tags",
                     .json_type = .array,
-                    .min_items = 1,
-                    .max_items = 3,
+                    .bounds = &.{ .min_items = 1, .max_items = 3 },
                     .shape = &.{ .array_values = .{ .json_type = .string, .enum_values = &.{ "red", "blue" } } },
                 },
                 .{ .name = "records", .json_type = .array, .shape = &.{ .array_objects = &array_item_schema } },

--- a/src/core/tooling/tool_projection.zig
+++ b/src/core/tooling/tool_projection.zig
@@ -904,16 +904,12 @@ fn appendTestMcpTool(runtime: *mcp_runtime.McpRuntime, server_index: usize, name
     errdefer alloc.free(tags);
     tags[0] = try alloc.dupe(u8, "test");
     errdefer alloc.free(tags[0]);
-    const search_text = try std.ascii.allocLowerString(alloc, name);
-    errdefer alloc.free(search_text);
     try runtime.servers.items[server_index].tool_catalog.tools.append(alloc, .{
-        .server_name = runtime.servers.items[server_index].config.name,
         .original_name = try alloc.dupe(u8, name),
         .prefixed_name = try alloc.dupe(u8, name),
         .description = description,
         .input_schema_json = input_schema,
         .tags = tags,
-        .search_text = search_text,
     });
 }
 

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -346,10 +346,11 @@ fn actionFieldCorrection(
 }
 
 const OwnedInput = struct {
-    parsed: std.json.Parsed(Input),
+    arena_state: std.heap.ArenaAllocator.State,
+    value: Input,
 
-    fn deinit(self: *OwnedInput) void {
-        self.parsed.deinit();
+    fn deinit(self: *OwnedInput, alloc: Allocator) void {
+        self.arena_state.promote(alloc).deinit();
         self.* = undefined;
     }
 };
@@ -426,18 +427,11 @@ pub fn decode(
         },
     };
 
-    var normalized: std.Io.Writer.Allocating = .init(ctx.allocator);
-    defer normalized.deinit();
-    std.json.Stringify.value(raw, .{}, &normalized.writer) catch
-        return error.OutOfMemory;
-    const normalized_json = try normalized.toOwnedSlice();
-    defer ctx.allocator.free(normalized_json);
-
-    const parsed = std.json.parseFromSlice(
+    const input = std.json.parseFromValueLeaky(
         Input,
-        ctx.allocator,
-        normalized_json,
-        .{ .allocate = .alloc_always },
+        arena,
+        raw,
+        .{},
     ) catch {
         return .{ .failure = try ctx.allocator.dupe(
             u8,
@@ -445,7 +439,11 @@ pub fn decode(
         ) };
     };
     const owned = try ctx.allocator.create(OwnedInput);
-    owned.* = .{ .parsed = parsed };
+    owned.* = .{
+        .arena_state = arena_state.state,
+        .value = input,
+    };
+    arena_state.state = .init;
     return .{ .input = .{
         .ptr = owned,
         .deinit_fn = inputDeinit,
@@ -487,7 +485,7 @@ fn normalizeCompositeArguments(
 
 fn inputDeinit(ptr: *anyopaque, alloc: Allocator) void {
     const input: *OwnedInput = @ptrCast(@alignCast(ptr));
-    input.deinit();
+    input.deinit(alloc);
     alloc.destroy(input);
 }
 
@@ -495,7 +493,7 @@ pub fn validate(
     ctx: tool_dispatch.DispatchContext,
     erased: tool_dispatch.ToolInput,
 ) tool_dispatch.DispatchError!?[]u8 {
-    const input = &erased.as(OwnedInput).parsed.value;
+    const input = &erased.as(OwnedInput).value;
     var arena_state = std.heap.ArenaAllocator.init(ctx.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -552,7 +550,7 @@ pub fn call(
     ctx: tool_dispatch.DispatchContext,
     erased: tool_dispatch.ToolInput,
 ) tool_dispatch.DispatchError!tool_dispatch.ToolResult {
-    const input = &erased.as(OwnedInput).parsed.value;
+    const input = &erased.as(OwnedInput).value;
     if (input.action == .exec) return callExec(ctx, input);
     const runtime = ctx.terminal_client orelse return structuredFailure(
         ctx.allocator,
@@ -737,7 +735,7 @@ fn durableAction(action: Action) ?contracts.Action {
 }
 
 pub fn isCapturedCommand(erased: tool_dispatch.ToolInput) bool {
-    return erased.as(OwnedInput).parsed.value.action == .exec;
+    return erased.as(OwnedInput).value.action == .exec;
 }
 
 const PreparedRequest = struct {
@@ -1298,7 +1296,7 @@ fn mapErrorCode(err: anyerror) contracts.StructuredErrorCode {
 }
 
 pub fn readsOnly(erased: tool_dispatch.ToolInput) bool {
-    const input = erased.as(OwnedInput).parsed.value;
+    const input = erased.as(OwnedInput).value;
     return switch (input.action) {
         .read, .screen, .list => true,
         .inspect => input.acknowledge_event_id == null,
@@ -1437,11 +1435,30 @@ test "terminal decoder accepts every public action and owns its input" {
                 defer input.deinit(alloc);
                 try std.testing.expectEqual(
                     case[0],
-                    input.as(OwnedInput).parsed.value.action,
+                    input.as(OwnedInput).value.action,
                 );
             },
         }
     }
+}
+
+test "terminal decoder keeps complex decode within allocation budget" {
+    var counted = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const alloc = counted.allocator();
+    const args =
+        "{\"action\":\"start\",\"cwd\":\"/workspace\",\"backend\":\"native\",\"command\":\"printf SHOULD_NOT_RUN\",\"return_when\":\"{\\\"kind\\\":\\\"started\\\"}\",\"initial_monitors\":\"[{\\\"condition\\\":{\\\"kind\\\":\\\"path_exists\\\",\\\"path\\\":\\\"/private/tmp/fx-monitor-outside-ready\\\",\\\"check_interval_ms\\\":1000},\\\"notify\\\":{\\\"kind\\\":\\\"on_match\\\"},\\\"lifetime\\\":{\\\"kind\\\":\\\"until_match\\\"}}]\"}";
+    const decoded = try decode(.{ .allocator = alloc }, args);
+    switch (decoded) {
+        .failure => |message| {
+            defer alloc.free(message);
+            return error.TestUnexpectedResult;
+        },
+        .input => |input| input.deinit(alloc),
+    }
+
+    try std.testing.expectEqual(counted.allocations, counted.deallocations);
+    try std.testing.expectEqual(counted.allocated_bytes, counted.freed_bytes);
+    try std.testing.expect(counted.allocations <= 6);
 }
 
 test "terminal presentation maps every action to operation-first labels" {
@@ -1609,7 +1626,7 @@ test "terminal decoder elides known null placeholders but structures unknown nul
         },
         .input => |input| {
             defer input.deinit(alloc);
-            const value = input.as(OwnedInput).parsed.value;
+            const value = input.as(OwnedInput).value;
             try std.testing.expectEqual(Action.start, value.action);
             try std.testing.expect(value.session_id == null);
         },
@@ -1652,7 +1669,7 @@ test "terminal decoder elides textual null placeholders like real nulls" {
         },
         .input => |input| {
             defer input.deinit(alloc);
-            const value = input.as(OwnedInput).parsed.value;
+            const value = input.as(OwnedInput).value;
             try std.testing.expectEqual(Action.exec, value.action);
             try std.testing.expectEqualStrings("echo ONE", value.command.?);
             try std.testing.expectEqualStrings(".", value.cwd.?);
@@ -1675,7 +1692,7 @@ test "terminal decoder elides textual null placeholders like real nulls" {
         },
         .input => |input| {
             defer input.deinit(alloc);
-            const value = input.as(OwnedInput).parsed.value;
+            const value = input.as(OwnedInput).value;
             try std.testing.expectEqual(Action.start, value.action);
             try std.testing.expect(value.shell == null);
             try std.testing.expect(value.write == null);
@@ -1699,7 +1716,7 @@ test "terminal decoder keeps command text that merely contains a null placeholde
             defer input.deinit(alloc);
             try std.testing.expectEqualStrings(
                 "echo null",
-                input.as(OwnedInput).parsed.value.command.?,
+                input.as(OwnedInput).value.command.?,
             );
         },
     }
@@ -1977,7 +1994,7 @@ test "terminal decoder normalizes gateway stringified start composites" {
         },
         .input => |input| {
             defer input.deinit(alloc);
-            const parsed = input.as(OwnedInput).parsed.value;
+            const parsed = input.as(OwnedInput).value;
             try std.testing.expectEqual(ReturnKind.started, parsed.return_when.?.kind);
             try std.testing.expectEqual(@as(usize, 1), parsed.initial_monitors.len);
             const monitor = parsed.initial_monitors[0];
@@ -2326,7 +2343,7 @@ test "terminal public wait ceiling maps to action-specific Core requests" {
             const request = try semanticRequest(
                 arena,
                 ctx,
-                &input.as(OwnedInput).parsed.value,
+                &input.as(OwnedInput).value,
             );
             switch (request) {
                 .start => |value| try std.testing.expectEqual(
@@ -2352,7 +2369,7 @@ test "terminal public wait ceiling maps to action-specific Core requests" {
             const request = try semanticRequest(
                 arena,
                 ctx,
-                &input.as(OwnedInput).parsed.value,
+                &input.as(OwnedInput).value,
             );
             switch (request) {
                 .wait => |value| try std.testing.expectEqual(
@@ -2519,7 +2536,7 @@ test "terminal public list rejects lifecycle and projects supported filters" {
             const request = try semanticRequest(
                 arena,
                 ctx,
-                &input.as(OwnedInput).parsed.value,
+                &input.as(OwnedInput).value,
             );
             try request.validate();
             switch (request) {
@@ -2551,7 +2568,7 @@ test "terminal public list rejects lifecycle and projects supported filters" {
             const request = try semanticRequest(
                 arena,
                 ctx,
-                &input.as(OwnedInput).parsed.value,
+                &input.as(OwnedInput).value,
             );
             try request.validate();
             switch (request) {
@@ -2581,7 +2598,7 @@ test "terminal public list rejects lifecycle and projects supported filters" {
             const request = try semanticRequest(
                 arena,
                 ctx,
-                &input.as(OwnedInput).parsed.value,
+                &input.as(OwnedInput).value,
             );
             try request.validate();
             switch (request) {
@@ -2613,7 +2630,7 @@ test "terminal public list rejects lifecycle and projects supported filters" {
                 semanticRequest(
                     arena,
                     ctx,
-                    &input.as(OwnedInput).parsed.value,
+                    &input.as(OwnedInput).value,
                 ),
             );
         },


### PR DESCRIPTION
## Summary

- Keep built-in tool schemas byte-for-byte stable while using smaller property records.
- Keep terminal tool argument behavior unchanged while reducing decode allocations.
- Keep MCP search, schema selection, permissions, and protocol responses unchanged while retaining less catalog data.