### PR TITLE
fix(ACP): list all sessions if cwd is not provided

### DIFF
--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -890,16 +890,27 @@ fn handleLoadFailure(
 }
 
 pub fn handleListSessions(state: *server.ServerState, alloc: Allocator, msg: *jsonrpc.Message) !void {
-    var store = session_store.Store.initReadOnly(
-        alloc,
-        state.workspace_root,
-    ) catch {
+    const cwd_filter = parseListSessionsCwd(alloc, msg) catch |err| switch (err) {
+        error.InvalidParams => return state.writer.writeError(alloc, msg.id, .{
+            .code = ErrorCode.invalid_params,
+            .message = "Invalid params",
+        }),
+        else => return err,
+    };
+    defer if (cwd_filter) |cwd| alloc.free(cwd);
+    var store = (if (state.cfg.home_override) |home|
+        session_store.Store.initReadOnlyFromHome(alloc, home, cwd_filter orelse state.workspace_root)
+    else
+        session_store.Store.initReadOnly(alloc, cwd_filter orelse state.workspace_root)) catch {
         try state.writer.writeResponse(alloc, msg.id, "{\"sessions\":[]}");
         return;
     };
     defer store.deinit(alloc);
 
-    var session_list = store.listForWorkspace(alloc) catch {
+    var session_list = (if (cwd_filter != null)
+        store.listForWorkspace(alloc)
+    else
+        store.list(alloc)) catch {
         try state.writer.writeResponse(alloc, msg.id, "{\"sessions\":[]}");
         return;
     };
@@ -917,7 +928,7 @@ pub fn handleListSessions(state: *server.ServerState, alloc: Allocator, msg: *js
         try out.writer.writeAll("{\"sessionId\":");
         try writeJsonStr(summary.id, &out.writer);
         try out.writer.writeAll(",\"cwd\":");
-        try writeJsonStr(state.workspace_root, &out.writer);
+        try writeJsonStr(summary.workspace_root orelse state.workspace_root, &out.writer);
         try out.writer.writeAll(",\"updatedAt\":");
         const iso = try formatIso8601(alloc, summary.updated_at_ms);
         defer alloc.free(iso);
@@ -927,6 +938,20 @@ pub fn handleListSessions(state: *server.ServerState, alloc: Allocator, msg: *js
     try out.writer.writeAll("]}");
 
     try state.writer.writeResponse(alloc, msg.id, out.writer.buffered());
+}
+
+fn parseListSessionsCwd(
+    alloc: Allocator,
+    msg: *jsonrpc.Message,
+) !?[]u8 {
+    const raw = msg.params_raw orelse return null;
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, raw, .{}) catch
+        return error.InvalidParams;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidParams;
+    const cwd = parsed.value.object.get("cwd") orelse return null;
+    if (cwd != .string) return error.InvalidParams;
+    return try alloc.dupe(u8, cwd.string);
 }
 
 fn sendHistoryTurnAsUpdates(state: *server.ServerState, alloc: Allocator, session_id: []const u8, turn: types.HistoryTurn) !void {

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -923,12 +923,30 @@ pub fn handleListSessions(state: *server.ServerState, alloc: Allocator, msg: *js
     defer out.deinit();
 
     try out.writer.writeAll("{\"sessions\":[");
-    for (session_list.items, 0..) |summary, i| {
-        if (i > 0) try out.writer.writeAll(",");
+    var wrote_session = false;
+    for (session_list.items) |summary| {
+        const workspace_root = summary.workspace_root orelse {
+            debug_trace.logf(
+                "acp",
+                "session operation=list outcome=omitted id={s} reason=workspace_unknown",
+                .{summary.id},
+            );
+            continue;
+        };
+        if (!std.fs.path.isAbsolute(workspace_root)) {
+            debug_trace.logf(
+                "acp",
+                "session operation=list outcome=omitted id={s} reason=workspace_not_absolute",
+                .{summary.id},
+            );
+            continue;
+        }
+        if (wrote_session) try out.writer.writeAll(",");
+        wrote_session = true;
         try out.writer.writeAll("{\"sessionId\":");
         try writeJsonStr(summary.id, &out.writer);
         try out.writer.writeAll(",\"cwd\":");
-        try writeJsonStr(summary.workspace_root orelse state.workspace_root, &out.writer);
+        try writeJsonStr(workspace_root, &out.writer);
         try out.writer.writeAll(",\"updatedAt\":");
         const iso = try formatIso8601(alloc, summary.updated_at_ms);
         defer alloc.free(iso);
@@ -950,7 +968,10 @@ fn parseListSessionsCwd(
     defer parsed.deinit();
     if (parsed.value != .object) return error.InvalidParams;
     const cwd = parsed.value.object.get("cwd") orelse return null;
-    if (cwd != .string) return error.InvalidParams;
+    if (cwd == .null) return null;
+    if (cwd != .string or !std.fs.path.isAbsolute(cwd.string)) {
+        return error.InvalidParams;
+    }
     return try alloc.dupe(u8, cwd.string);
 }
 

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -1007,6 +1007,31 @@ function writeAcpSession(
   );
 }
 
+function writeLegacyAcpSessionWithoutWorkspace(
+  home: string,
+  sessionId: string,
+  updatedAtMs: number,
+): void {
+  const sessionDir = join(home, ".fx", "sessions", sessionId);
+  mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+  chmodSync(join(home, ".fx"), 0o700);
+  chmodSync(join(home, ".fx", "sessions"), 0o700);
+  chmodSync(sessionDir, 0o700);
+  writeFileSync(
+    join(sessionDir, "session.json"),
+    JSON.stringify({
+      schema_version: 1,
+      id: sessionId,
+      created_at_ms: 1,
+      updated_at_ms: updatedAtMs,
+      conversation_language: "en",
+      history_len: 0,
+      history: [],
+    }) + "\n",
+    { mode: 0o600 },
+  );
+}
+
 function createPromptTerminalBoundary(root: string) {
   const terminalReady = join(root, "prompt-terminal.ready");
   const reapReady = join(root, "prompt-reap.ready");
@@ -5187,7 +5212,7 @@ describe("acp: model-independent", () => {
   );
 
   test(
-    "session/list without cwd returns all sessions and filters by cwd",
+    "session/list without cwd returns all sessions and filters by absolute cwd",
     async () => {
       const root = createIsolatedRoot("fx-acp-workspace-session-list-");
       const gateway = startFakeGateway([]);
@@ -5236,6 +5261,112 @@ describe("acp: model-independent", () => {
       } finally {
         await client?.close();
         gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "session/list treats null cwd as omitted",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-null-session-list-");
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            HOME: root.home,
+            AI_GATEWAY_API_KEY: "e2e-placeholder",
+            VERCEL_OIDC_TOKEN: "",
+          },
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+
+        const listed = await client.request("session/list", {}, 2) as any;
+        const listedWithNull = await client.request(
+          "session/list",
+          { cwd: null },
+          3,
+        ) as any;
+        expect(listedWithNull).toEqual({
+          jsonrpc: "2.0",
+          id: 3,
+          result: listed.result,
+        });
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "session/list rejects relative cwd",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-relative-session-list-");
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            HOME: root.home,
+            AI_GATEWAY_API_KEY: "e2e-placeholder",
+            VERCEL_OIDC_TOKEN: "",
+          },
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+
+        const relative = await client.request(
+          "session/list",
+          { cwd: "workspace-a" },
+          2,
+        ) as any;
+        expect(relative.error).toEqual({
+          code: -32602,
+          message: "Invalid params",
+        });
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "session/list omits legacy sessions without a workspace",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-legacy-session-list-");
+      try {
+        writeAcpSession(root.home, root.workspace, "workspace-session", 20);
+        writeLegacyAcpSessionWithoutWorkspace(
+          root.home,
+          "legacy-unknown-workspace",
+          40,
+        );
+
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            HOME: root.home,
+            AI_GATEWAY_API_KEY: "e2e-placeholder",
+            VERCEL_OIDC_TOKEN: "",
+          },
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+
+        const listed = await client.request("session/list", {}, 2) as any;
+        expect(listed.result?.sessions).toEqual([
+          expect.objectContaining({
+            sessionId: "workspace-session",
+            cwd: root.workspace,
+          }),
+        ]);
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
         rmSync(root.root, { recursive: true, force: true });
       }
     },

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -5187,7 +5187,7 @@ describe("acp: model-independent", () => {
   );
 
   test(
-    "session/list is scoped to the server workspace and exact load still works",
+    "session/list without cwd returns all sessions and filters by cwd",
     async () => {
       const root = createIsolatedRoot("fx-acp-workspace-session-list-");
       const gateway = startFakeGateway([]);
@@ -5204,21 +5204,31 @@ describe("acp: model-independent", () => {
         const listed = await client.request("session/list", {}, 2) as any;
         expect(listed.result?.sessions).toEqual([
           expect.objectContaining({
+            sessionId: "workspace-b-session",
+            cwd: root.external,
+          }),
+          expect.objectContaining({
             sessionId: "workspace-a-session",
             cwd: root.workspace,
           }),
         ]);
-        expect(
-          listed.result.sessions.some(
-            (session: { sessionId: string }) =>
-              session.sessionId === "workspace-b-session",
-          ),
-        ).toBe(false);
+
+        const filtered = await client.request(
+          "session/list",
+          { cwd: root.workspace },
+          3,
+        ) as any;
+        expect(filtered.result?.sessions).toEqual([
+          expect.objectContaining({
+            sessionId: "workspace-a-session",
+            cwd: root.workspace,
+          }),
+        ]);
 
         const loaded = await client.request(
           "session/load",
           { sessionId: "workspace-b-session", mcpServers: [] },
-          3,
+          4,
         ) as any;
         expect(loaded.error).toBeUndefined();
         expect(Array.isArray(loaded.result?.configOptions)).toBe(true);


### PR DESCRIPTION
## Summary

- Make ACP session/list return all saved fx sessions when the optional cwd filter is omitted.
- Preserve filtering when cwd is supplied, with each result reporting its actual workspace.

## Why

This enables cross-directory session discovery, matching Shellular’s Codex and Claude Code session views.

## Checklist

- [x] zig fmt src/
- [x] zig build
- [x] zig build test
- [x] zig build run
- [x] Manually tested `./zig-out/bin/fx acp`'s `session/list` without and with `cwd` (multiple workspaces)
