### PR TITLE
Send stable prompt cache keys to Codex

### DIFF
--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -159,6 +159,8 @@ pub const CredentialLease = struct {
 /// Every slice and JSON value is borrowed for the call.
 pub const RequestData = struct {
     model: []const u8,
+    /// Saved session identity, borrowed for the serializer call.
+    session_id: ?[]const u8 = null,
     messages: []const types.ChatMessage,
     tools: ToolSelection = .{},
     tool_choice: types.ToolChoice,
@@ -202,6 +204,7 @@ pub const ModelRequest = struct {
     pub fn data(self: ModelRequest) RequestData {
         return .{
             .model = self.model,
+            .session_id = self.session_id,
             .messages = self.messages,
             .tools = self.tools,
             .tool_choice = self.tool_choice,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1055,6 +1055,7 @@ const AskContext = struct {
             return permission_auto_classifier.Classifier.disabled();
         return permission_auto_classifier.Classifier.withProvider(provider, .{
             .credential = self.api_key,
+            .session_id = self.lifecycleContext().scope.session_id,
             .account_id = self.account_id,
             .tenant = self.gateway_team,
             .endpoint = self.cfg.gateway_chat_url,

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -319,6 +319,7 @@ pub const OverrideFn = *const fn (
 pub const ProviderInput = struct {
     credential: []const u8 = "",
     credential_source: ?types.CredentialSource = null,
+    session_id: ?[]const u8 = null,
     account_id: ?[]const u8 = null,
     tenant: ?[]const u8 = null,
     endpoint: []const u8 = "",

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -283,6 +283,7 @@ pub const Context = struct {
             return permission_auto_classifier.Classifier.disabled();
         return permission_auto_classifier.Classifier.withProvider(provider, .{
             .credential = self.api_key,
+            .session_id = self.lifecycle_scope.session_id,
             .account_id = self.account_id,
             .tenant = self.gateway_team,
             .endpoint = self.gateway_chat_url,

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -69,6 +69,12 @@ pub fn buildRequest(
     const writer = &out.writer;
     try writer.writeAll("{\"model\":");
     try std.json.Stringify.value(request.model, .{}, writer);
+    if (request.session_id) |session_id| {
+        if (session_id.len > 0) {
+            try writer.writeAll(",\"prompt_cache_key\":");
+            try std.json.Stringify.value(session_id, .{}, writer);
+        }
+    }
     try writer.writeAll(",\"store\":false,\"stream\":true,\"instructions\":");
     try std.json.Stringify.value(instructions.written(), .{}, writer);
     try writer.writeAll(",\"input\":[");
@@ -484,6 +490,25 @@ test "OpenAI Codex request uses Responses input and converts AI SDK tool schemas
     try std.testing.expect(std.mem.find(u8, body, "\"reasoning\":{\"effort\":\"high\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"service_tier\":\"priority\"") != null);
     try std.testing.expect(std.mem.find(u8, body, "\"max_output_tokens\"") == null);
+}
+
+test "OpenAI Codex omits prompt cache key without a non-empty session identity" {
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "Hello." }};
+    for ([_]?[]const u8{ null, "" }) |session_id| {
+        const body = try buildRequest(std.testing.allocator, .{
+            .model = "gpt-5.6-sol",
+            .session_id = session_id,
+            .messages = &messages,
+            .tool_choice = .none,
+            .provider_options = .{},
+        });
+        defer std.testing.allocator.free(body);
+
+        var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, body, .{});
+        defer parsed.deinit();
+        try std.testing.expect(parsed.value == .object);
+        try std.testing.expect(parsed.value.object.get("prompt_cache_key") == null);
+    }
 }
 
 fn makeSizedProviderState(alloc: Allocator, size: usize) ![]u8 {

--- a/src/gateway/responses_permission_reviewer.zig
+++ b/src/gateway/responses_permission_reviewer.zig
@@ -78,6 +78,7 @@ fn buildReviewPayload(
     defer alloc.free(expanded);
     return runtime.adapter.build_fn(alloc, .{
         .model = model,
+        .session_id = runtime.input.session_id,
         .messages = expanded,
         .tools = .{ .additional_functions = &.{permission_auto_classifier.function_schema} },
         .tool_choice = .required,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -2676,7 +2676,7 @@ test(
         { mode: 0o600 },
       );
       const result = await runFx(
-        ["ask", "--json", "--auto", "--no-save", "Read the README, then finish."],
+        ["ask", "--json", "--auto", "Read the README, then finish."],
         {
           env: {
             HOME: home,
@@ -2695,6 +2695,12 @@ test(
       expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
       expect(result.stdout).toContain("CODEX_TOOL_LOOP_OK");
       expect(codex.bodies).toHaveLength(2);
+      const output = JSON.parse(result.stdout) as { session_id: string };
+      expect(output.session_id.length).toBeGreaterThan(0);
+      const promptCacheKeys = codex.bodies.map(
+        (body) => (JSON.parse(body) as { prompt_cache_key?: string }).prompt_cache_key,
+      );
+      expect(promptCacheKeys).toEqual([output.session_id, output.session_id]);
       expect(codex.bodies[1]).toContain('"encrypted_content":"opaque-tool-loop"');
       expect(codex.bodies[1]).toContain('"type":"function_call_output"');
       for (const request of [...gateway.requests, ...gateway.modelRequests]) {
@@ -2893,6 +2899,10 @@ test(
       expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
       expect(result.stdout).toContain("CODEX_VISION_DISABLED_OK");
       expect(codex.bodies).toHaveLength(2);
+      expect((JSON.parse(result.stdout) as { session_id: string }).session_id).toBe("");
+      expect(codex.bodies.map(
+        (body) => (JSON.parse(body) as { prompt_cache_key?: string }).prompt_cache_key,
+      )).toEqual([undefined, undefined]);
       expect(codex.bodies[0]).not.toContain('"name":"vision"');
       const continuation = JSON.parse(codex.bodies[1]) as {
         input: Array<{ type?: string; output?: string }>;
@@ -2996,8 +3006,15 @@ test(
       );
       expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
       expect(result.stdout).toContain("CODEX_AUTO_REVIEW_OK");
-      expect(codex.bodies.map((body) => (JSON.parse(body) as { model: string }).model))
+      const requests = codex.bodies.map(
+        (body) => JSON.parse(body) as { model: string; prompt_cache_key?: string },
+      );
+      expect(requests.map((request) => request.model))
         .toEqual(["gpt-5.6-sol", "gpt-5.4-mini", "gpt-5.6-sol"]);
+      const output = JSON.parse(result.stdout) as { session_id: string };
+      expect(output.session_id.length).toBeGreaterThan(0);
+      expect(requests.map((request) => request.prompt_cache_key))
+        .toEqual([output.session_id, output.session_id, output.session_id]);
       expect(codex.bodies[1]).toContain('"name":"permission_decision"');
       expect(codex.bodies[2]).toContain('"type":"function_call_output"');
       expect(codex.bodies[2]).toContain("exit_code=0");


### PR DESCRIPTION
## Summary

- pass the saved fx session identity through the typed provider request contract
- emit that identity as `prompt_cache_key` on every direct Codex request in the session
- include provider-backed automatic review requests in the same cache identity
- omit the field when no non-empty saved session identity exists, including `--no-save`
- keep Gateway, provider state, TTL, retry, retention, and telemetry behavior unchanged

Official Codex uses session identity for this field: https://github.com/openai/codex/blob/4f39251a010a8bd7d692d25fb33832ff06f1635a/codex-rs/core/src/client.rs#L485-L497

## Verification

Exact head: `beca424a0f70996d84f81db5e3f068437718fbe6`  
Parent: `v0.0.6` (`79666393e5f613c85f2f0b4b65475f1addd55379`)

- changed-file `zig fmt --check`: passed
- `scripts/check-public-surface.sh`: passed
- omission focused Zig tests: 13 passed
- focused direct-Codex E2E: 3 passed; saved tool loops, no-save omission, vision fallback, and automatic review shared the intended identity contract
- native build: passed
- built `./zig-out/bin/fx ask` loopback smoke: two direct requests used the exact emitted session ID as `prompt_cache_key`, exit 0, and stderr contained only expected tool progress
- current `origin/main` merge simulation: clean

Full CI passed all four platform aggregates on the exact head: https://github.com/alphastorm/fx/actions/runs/32898529074

Final ship gate: SHIP for `beca424a0f70996d84f81db5e3f068437718fbe6`.

Fixes #297.
