### PR TITLE
Preserve Codex turn state within each turn

### DIFF
--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -14,6 +14,7 @@ const ToolExecutionResult = runtime_tool_contracts.ToolExecutionResult;
 
 pub const DeliveryCertainty = agent_stream_provider.DeliveryCertainty;
 pub const AttemptEvidence = agent_stream_provider.AttemptEvidence;
+pub const ProviderTurnState = agent_stream_provider.ProviderTurnState;
 
 pub const StreamResult = agent_stream_provider.Result;
 

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2794,6 +2794,12 @@ fn processQueuedPromptLoop(
     else
         .none;
     var restore_recovery_source = job.recovery_checkpoint != null;
+    var provider_turn_state = runtime_gateway_step.ProviderTurnState.init(std.heap.c_allocator);
+    defer provider_turn_state.deinit();
+    const provider_turn_state_ptr: ?*runtime_gateway_step.ProviderTurnState = if (job.provider == .codex)
+        &provider_turn_state
+    else
+        null;
     var step: usize = 0;
     while (agent_steps.allowsStep(config.agent_step_limit, step)) : (step += 1) {
         current_step_index = step + 1;
@@ -3137,6 +3143,7 @@ fn processQueuedPromptLoop(
                 .events = .{ .context = &provider_events, .emit_fn = onProviderEvent },
                 .cancel_flag = config.cancel_flag,
                 .provider_attempt_owner = .agent,
+                .provider_turn_state = provider_turn_state_ptr,
             };
             stream_result = runtime_gateway_step.streamModelCompletion(
                 deps.agent_stream_provider,

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -99,6 +99,49 @@ pub const AttemptEvidence = struct {
     network_failure: ?NetworkFailureEvidence = null,
 };
 
+/// Opaque provider state whose lifetime is exactly one user turn. The owner
+/// allocates on first capture, keeps that value immutable, and releases it at
+/// turn end. It is never part of a request body or durable message state.
+pub const ProviderTurnState = struct {
+    pub const maximum_bytes: usize = 8 * 1024;
+
+    allocator: Allocator,
+    value: ?[]u8 = null,
+
+    pub fn init(allocator: Allocator) ProviderTurnState {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *ProviderTurnState) void {
+        if (self.value) |value| {
+            @memset(value, 0);
+            self.allocator.free(value);
+            self.value = null;
+        }
+    }
+
+    pub fn get(self: *const ProviderTurnState) ?[]const u8 {
+        return self.value;
+    }
+
+    /// Captures the first usable header value. Later response attempts cannot
+    /// replace it, while malformed provider metadata is ignored.
+    pub fn capture(self: *ProviderTurnState, candidate: []const u8) Allocator.Error!void {
+        if (self.value != null or !is_valid_candidate(candidate)) return;
+        self.value = try self.allocator.dupe(u8, candidate);
+    }
+
+    fn is_valid_candidate(candidate: []const u8) bool {
+        if (candidate.len == 0 or candidate.len > maximum_bytes) return false;
+        var has_non_whitespace = false;
+        for (candidate) |byte| {
+            if ((byte < 0x20 and byte != '\t') or byte == 0x7f) return false;
+            if (byte != ' ' and byte != '\t') has_non_whitespace = true;
+        }
+        return has_non_whitespace;
+    }
+};
+
 /// Gives a cooperative single-threaded host a chance to publish UI and runtime
 /// state while provider transport remains pending.
 pub const CooperativePulse = struct {
@@ -198,6 +241,8 @@ pub const ModelRequest = struct {
     admission: Admission = .{},
     cancel_flag: *std.atomic.Value(bool),
     provider_attempt_owner: ProviderAttemptOwner = .transport,
+    /// Optional mutable turn-scoped owner, borrowed only for this call.
+    provider_turn_state: ?*ProviderTurnState = null,
 
     pub fn data(self: ModelRequest) RequestData {
         return .{
@@ -403,4 +448,40 @@ test "stream provider accepts one typed request and emits ordered neutral events
     try std.testing.expectEqualStrings("firstsecond", capture.chunks.items);
     try std.testing.expectEqualStrings("done", result.completed.completion.content.?);
     try std.testing.expect(std.meta.activeTag(result.completed.usage) == .immediate);
+}
+
+test "provider turn state accepts only the first response value" {
+    var state = ProviderTurnState.init(std.testing.allocator);
+    defer state.deinit();
+
+    try state.capture("accepted-state");
+    try state.capture("later-attempt-state");
+
+    try std.testing.expectEqualStrings("accepted-state", state.get().?);
+}
+
+test "provider turn state ignores unusable values and accepts its exact byte bound" {
+    const candidate = try std.testing.allocator.alloc(u8, ProviderTurnState.maximum_bytes + 1);
+    defer std.testing.allocator.free(candidate);
+    @memset(candidate, 's');
+
+    var state = ProviderTurnState.init(std.testing.allocator);
+    defer state.deinit();
+    for ([_][]const u8{
+        "",
+        candidate,
+        "contains\rreturn",
+        "contains\nnewline",
+        " ",
+        "\t",
+        " \t ",
+        "contains\x01control",
+        "contains\x7fdelete",
+    }) |unusable| {
+        try state.capture(unusable);
+        try std.testing.expect(state.get() == null);
+    }
+
+    try state.capture(candidate[0..ProviderTurnState.maximum_bytes]);
+    try std.testing.expectEqual(ProviderTurnState.maximum_bytes, state.get().?.len);
 }

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -11,6 +11,7 @@ const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
 
 const Allocator = std.mem.Allocator;
 const endpoint = "https://chatgpt.com/backend-api/codex/responses";
+const turn_state_header = "x-codex-turn-state";
 const e2e_endpoint_env = "FX_E2E_OPENAI_CODEX_RESPONSES_URL";
 const max_error_body_bytes: usize = 1024 * 1024;
 const max_sse_line_bytes: usize = 32 * 1024 * 1024;
@@ -209,6 +210,10 @@ pub fn streamPrepared(
     extra_count += 1;
     extra_headers_buf[extra_count] = .{ .name = "accept", .value = "text/event-stream" };
     extra_count += 1;
+    if (request.provider_turn_state) |turn_state| if (turn_state.get()) |value| {
+        extra_headers_buf[extra_count] = .{ .name = turn_state_header, .value = value };
+        extra_count += 1;
+    };
     if (request.session_id) |session_id| if (session_id.len > 0) {
         extra_headers_buf[extra_count] = .{ .name = "session-id", .value = session_id };
         extra_count += 1;
@@ -276,6 +281,9 @@ pub fn streamPrepared(
             .ownership = .owned,
         } };
     }
+    if (request.provider_turn_state) |turn_state| {
+        try capture_response_turn_state(response.head, turn_state);
+    }
 
     var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
@@ -288,6 +296,7 @@ pub fn streamPrepared(
         EventBridge.toolStart,
         EventBridge.reasoning,
         EventBridge.toolInput,
+        request.provider_turn_state,
         request.cancel_flag,
         request.content_capture_limit,
         .{},
@@ -297,6 +306,19 @@ pub fn streamPrepared(
         .usage = .{ .immediate = null },
         .ownership = .owned,
     } };
+}
+
+fn capture_response_turn_state(
+    head: std.http.Client.Response.Head,
+    turn_state: *stream_provider.ProviderTurnState,
+) Allocator.Error!void {
+    if (turn_state.get() != null) return;
+    var headers = head.iterateHeaders();
+    while (headers.next()) |header| {
+        if (!std.ascii.eqlIgnoreCase(header.name, turn_state_header)) continue;
+        try turn_state.capture(header.value);
+        if (turn_state.get() != null) return;
+    }
 }
 
 const EventBridge = struct {
@@ -401,6 +423,7 @@ fn consumeSse(
     on_tool_start: ?stream_provider.ToolStartCallback,
     on_reasoning_chunk: ?stream_provider.StreamCallback,
     on_tool_input_chunk: ?stream_provider.StreamCallback,
+    provider_turn_state: ?*stream_provider.ProviderTurnState,
     cancel_flag: *std.atomic.Value(bool),
     content_capture_limit: ?usize,
     limits: CodexLimits,
@@ -426,6 +449,9 @@ fn consumeSse(
     };
     while (try sse.next(alloc, reader)) |json_text| {
         defer sse.release();
+        if (provider_turn_state) |turn_state| {
+            try capture_metadata_turn_state(alloc, json_text, turn_state);
+        }
         if (reducer.applyJson(
             alloc,
             json_text,
@@ -449,6 +475,35 @@ fn mapReducerError(err: anyerror) anyerror {
         error.ResourceLimitExceeded => error.OpenAICodexResourceLimitExceeded,
         else => err,
     };
+}
+
+fn capture_metadata_turn_state(
+    alloc: Allocator,
+    json_text: []const u8,
+    turn_state: *stream_provider.ProviderTurnState,
+) !void {
+    if (turn_state.get() != null or std.mem.find(u8, json_text, "response.metadata") == null) return;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch
+        return error.InvalidOpenAICodexSseEvent;
+    defer parsed.deinit();
+    if (parsed.value != .object) return;
+    const event_type = parsed.value.object.get("type") orelse return;
+    if (event_type != .string or !std.mem.eql(u8, event_type.string, "response.metadata")) return;
+    if (metadataHeaderValue(parsed.value.object, turn_state_header)) |value| {
+        try turn_state.capture(value);
+    }
+}
+
+fn metadataHeaderValue(event: std.json.ObjectMap, name: []const u8) ?[]const u8 {
+    const headers = event.get("headers") orelse return null;
+    if (headers != .object) return null;
+    var iterator = headers.object.iterator();
+    while (iterator.next()) |entry| {
+        if (!std.ascii.eqlIgnoreCase(entry.key_ptr.*, name)) continue;
+        if (entry.value_ptr.* != .string) return null;
+        return entry.value_ptr.*.string;
+    }
+    return null;
 }
 
 test "OpenAI Codex request uses Responses input and converts AI SDK tool schemas" {
@@ -700,6 +755,7 @@ test "OpenAI Codex SSE maps text reasoning tools and usage" {
         Capture.toolStart,
         Capture.reasoningChunk,
         null,
+        null,
         &cancelled,
         null,
         .{},
@@ -721,6 +777,95 @@ test "OpenAI Codex SSE maps text reasoning tools and usage" {
     try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
 }
 
+test "OpenAI Codex SSE metadata captures the first usable exact turn-state value" {
+    const sse_text =
+        "data: {\"type\":\"response.metadata\",\"headers\":{\"x-codex-turn-state\":\"\"}}\n\n" ++
+        "data: {\"type\":\"response.metadata\",\"headers\":{\"x-codex-turn-state\":\" \"}}\n\n" ++
+        "data: {\"type\":\"response.metadata\",\"headers\":{\"x-codex-turn-state\":\"\\t\"}}\n\n" ++
+        "data: {\"type\":\"response.metadata\",\"headers\":{\"x-codex-turn-state\":\"unsafe\\r\\nstate\"}}\n\n" ++
+        "data: {\"type\":\"response.metadata\",\"headers\":{\"X-Codex-Turn-State\":\"metadata-state/+=\"}}\n\n" ++
+        "data: {\"type\":\"response.metadata\",\"headers\":{\"x-codex-turn-state\":\"replacement-state\"}}\n\n" ++
+        "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n";
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    var callback_context: u8 = 0;
+    var turn_state = stream_provider.ProviderTurnState.init(std.testing.allocator);
+    defer turn_state.deinit();
+    const completion = try consumeSse(
+        std.testing.allocator,
+        &reader,
+        &callback_context,
+        struct {
+            fn ignore(_: *anyopaque, _: []const u8) void {}
+        }.ignore,
+        null,
+        null,
+        null,
+        &turn_state,
+        &cancelled,
+        null,
+        .{},
+    );
+    defer freeOpenAICodexTestCompletion(completion);
+
+    try std.testing.expectEqualStrings("metadata-state/+=", turn_state.get().?);
+}
+
+test "OpenAI Codex response headers skip unusable duplicate turn state" {
+    const head = try std.http.Client.Response.Head.parse(
+        "HTTP/1.1 200 OK\r\nx-codex-turn-state: \t \r\nX-Codex-Turn-State: header-state/+=\r\n\r\n",
+    );
+    var turn_state = stream_provider.ProviderTurnState.init(std.testing.allocator);
+    defer turn_state.deinit();
+    try capture_response_turn_state(head, &turn_state);
+
+    try std.testing.expectEqualStrings("header-state/+=", turn_state.get().?);
+}
+
+test "OpenAI Codex failed partial stream keeps its first turn state" {
+    const sse_text =
+        "data: {\"type\":\"response.metadata\",\"headers\":{\"x-codex-turn-state\":\"failed-attempt-state\"}}\n\n" ++
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n";
+    const cases = [_]struct {
+        initial: ?[]const u8,
+        expected: []const u8,
+    }{
+        .{ .initial = null, .expected = "failed-attempt-state" },
+        .{ .initial = "accepted-state", .expected = "accepted-state" },
+    };
+    for (cases) |case| {
+        var reader: std.Io.Reader = .fixed(sse_text);
+        var cancelled = std.atomic.Value(bool).init(false);
+        var callback_context: u8 = 0;
+        var turn_state = stream_provider.ProviderTurnState.init(std.testing.allocator);
+        defer turn_state.deinit();
+        if (case.initial) |initial| try turn_state.capture(initial);
+
+        const result = consumeSse(
+            std.testing.allocator,
+            &reader,
+            &callback_context,
+            struct {
+                fn ignore(_: *anyopaque, _: []const u8) void {}
+            }.ignore,
+            null,
+            null,
+            null,
+            &turn_state,
+            &cancelled,
+            null,
+            .{},
+        );
+        if (result) |completion| {
+            freeOpenAICodexTestCompletion(completion);
+            return error.TestExpectedOpenAICodexStreamIncomplete;
+        } else |err| {
+            try std.testing.expectEqual(error.OpenAICodexStreamIncomplete, err);
+        }
+        try std.testing.expectEqualStrings(case.expected, turn_state.get().?);
+    }
+}
+
 fn consumeOpenAICodexTestSse(sse_text: []const u8, limits: CodexLimits) !types.ModelCompletion {
     var reader: std.Io.Reader = .fixed(sse_text);
     var cancelled = std.atomic.Value(bool).init(false);
@@ -732,6 +877,7 @@ fn consumeOpenAICodexTestSse(sse_text: []const u8, limits: CodexLimits) !types.M
         struct {
             fn ignore(_: *anyopaque, _: []const u8) void {}
         }.ignore,
+        null,
         null,
         null,
         null,

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -577,11 +577,21 @@ function codexLatestToolResult(body: string): { callId: string; output: string }
 function startAcpFakeCodex(options: {
   unauthorizedResponses?: number;
   route?: (body: string) => string | Promise<string>;
+  responseTurnStates?: readonly (string | null)[];
 } = {}) {
   const accessToken = acpChatGptAccessToken("acct_acp_e2e", "stale");
   const refreshedAccessToken = acpChatGptAccessToken("acct_acp_e2e", "fresh");
-  const requests: Array<{ path: string; authorization: string | null; body: string }> = [];
-  const modelRequests: Array<{ path: string; authorization: string | null }> = [];
+  const requests: Array<{
+    path: string;
+    authorization: string | null;
+    turnState: string | null;
+    body: string;
+  }> = [];
+  const modelRequests: Array<{
+    path: string;
+    authorization: string | null;
+    turnState: string | null;
+  }> = [];
   const tokenRequests: Array<{ path: string; authorization: string | null }> = [];
   let unauthorizedResponses = options.unauthorizedResponses ?? 0;
   const server = Bun.serve({
@@ -589,7 +599,11 @@ function startAcpFakeCodex(options: {
     port: 0,
     async fetch(request) {
       const path = new URL(request.url).pathname;
-      const recorded = { path, authorization: request.headers.get("authorization") };
+      const recorded = {
+        path,
+        authorization: request.headers.get("authorization"),
+        turnState: request.headers.get("x-codex-turn-state"),
+      };
       if (path === "/models") {
         modelRequests.push(recorded);
         return Response.json({ models: [
@@ -611,9 +625,14 @@ function startAcpFakeCodex(options: {
         unauthorizedResponses -= 1;
         return Response.json({ error: { message: "expired" } }, { status: 401 });
       }
+      const headers = new Headers({ "content-type": "text/event-stream" });
+      const responseTurnState = options.responseTurnStates?.[requests.length - 1];
+      if (responseTurnState !== null && responseTurnState !== undefined) {
+        headers.set("x-codex-turn-state", responseTurnState);
+      }
       return new Response(
         options.route ? await options.route(body) : codexFinalText("ACP_CHATGPT_RESPONSE"),
-        { headers: { "content-type": "text/event-stream" } },
+        { headers },
       );
     },
   });
@@ -7352,6 +7371,110 @@ describe("acp: model-independent", () => {
         expect(client.stderr).toBe("");
       } finally {
         await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "Codex turn state is exact, turn-scoped, and origin-isolated",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-codex-turn-state-");
+      const gateway = startFakeGateway([finalText("ACP_GATEWAY_AFTER_CODEX_STATE")]);
+      const acceptedTurnState = "state.v1/+=opaque";
+      const replacementTurnState = "state.v2-must-not-replace";
+      let responseCount = 0;
+      const codex = startAcpFakeCodex({
+        responseTurnStates: [acceptedTurnState, replacementTurnState, null, null],
+        route() {
+          responseCount += 1;
+          if (responseCount === 1) {
+            return codexToolCall("turn_state_read_1", "read_file", {
+              path: "turn-state-fixture.txt",
+              line_count: 10,
+            });
+          }
+          if (responseCount === 2) {
+            return "data: " + JSON.stringify({
+              type: "response.metadata",
+              headers: { "x-codex-turn-state": replacementTurnState },
+            }) + "\n\n" + codexToolCall("turn_state_read_2", "read_file", {
+              path: "turn-state-fixture.txt",
+              line_count: 10,
+            });
+          }
+          return codexFinalText(
+            responseCount === 3
+              ? "ACP_CODEX_TURN_STATE_FIRST_DONE"
+              : "ACP_CODEX_TURN_STATE_SECOND_DONE",
+          );
+        },
+      });
+      writeFileSync(join(root.workspace, "turn-state-fixture.txt"), "turn state fixture\n");
+      writeSeededAcpChatGptLogin(root.home, codex.accessToken);
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: {
+            ...fakeGatewayEnv(root, gateway),
+            FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
+            FX_E2E_OPENAI_CODEX_MODELS_URL: codex.modelsUrl,
+          },
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+        const created = await client.request("session/new", { mcpServers: [] }, 2) as any;
+        await client.readLine();
+        await client.request("session/set_mode", { modeId: "code" }, 3);
+        await client.request("session/set_config_option", {
+          configId: "provider",
+          value: "codex",
+        }, 4);
+
+        const first = await runPrompt(client, "Read the turn-state fixture twice.", TIMEOUT);
+        expect(first.promptResult.result.stopReason).toBe("end_turn");
+        expect(JSON.stringify(first.messages)).toContain("ACP_CODEX_TURN_STATE_FIRST_DONE");
+        const second = await runPrompt(client, "Answer the new turn directly.", TIMEOUT);
+        expect(second.promptResult.result.stopReason).toBe("end_turn");
+        expect(JSON.stringify(second.messages)).toContain("ACP_CODEX_TURN_STATE_SECOND_DONE");
+        await client.request("session/set_config_option", {
+          configId: "provider",
+          value: "gateway",
+        }, 5);
+        const gatewayPrompt = await runPrompt(
+          client,
+          "Answer after switching origins.",
+          TIMEOUT,
+        );
+        expect(gatewayPrompt.promptResult.result.stopReason).toBe("end_turn");
+        expect(JSON.stringify(gatewayPrompt.messages)).toContain("ACP_GATEWAY_AFTER_CODEX_STATE");
+
+        expect(codex.requests).toHaveLength(4);
+        expect(codex.requests.map((request) => request.turnState)).toEqual([
+          null,
+          acceptedTurnState,
+          acceptedTurnState,
+          null,
+        ]);
+        expect(codexLatestToolResult(codex.requests[1]!.body)?.callId)
+          .toBe("turn_state_read_1");
+        expect(codexLatestToolResult(codex.requests[2]!.body)?.callId)
+          .toBe("turn_state_read_2");
+        expect(codex.modelRequests.map((request) => request.turnState)).toEqual([null]);
+        for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+          expect(request.headers.get("x-codex-turn-state")).toBeNull();
+        }
+        const sessionJson = readFileSync(
+          join(root.home, ".fx", "sessions", created.result.sessionId, "session.json"),
+          "utf8",
+        );
+        expect(sessionJson).not.toContain(acceptedTurnState);
+        expect(sessionJson).not.toContain(replacementTurnState);
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        codex.stop();
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

- capture the first usable `x-codex-turn-state` value from a direct Codex response header or `response.metadata` event
- replay it byte-for-byte on later direct Codex requests in the same user turn, then free and reset it before the next turn
- ignore empty, whitespace-only, control-bearing, duplicate-leading, or over-8-KiB values without aborting an in-flight response
- keep the opaque value out of Gateway, model discovery, images, permission review, messages, provider state, recovery state, and session JSON

Official Codex defines the value as turn-scoped routing state: https://github.com/openai/codex/blob/4f39251a010a8bd7d692d25fb33832ff06f1635a/codex-rs/core/src/client.rs#L284-L288

## Verification

Exact head: `2ff52ac9d038b072167636248ff0e2c9ea72da98`  
Parent: `v0.0.6` (`79666393e5f613c85f2f0b4b65475f1addd55379`)

- `zig fmt --check src/`: passed
- `scripts/check-public-surface.sh`: passed
- turn-state ownership, validation, duplicate-header, and interrupted-stream focused Zig tests: 16 passed
- metadata-event focused Zig tests: 13 passed
- focused ACP turn-state E2E: 1 passed, 17 assertions
- native ReleaseSafe build: passed
- built `./zig-out/bin/fx acp` E2E exercised two user turns and an origin switch: direct request states were `[null, accepted, accepted, null]`; model discovery and Gateway requests carried no state; session JSON contained no state; exit 0 and stderr empty
- current `origin/main` merge simulation: clean

Full CI passed all four platform aggregates on the exact head: https://github.com/alphastorm/fx/actions/runs/32898919752

Final ship gate: SHIP for `2ff52ac9d038b072167636248ff0e2c9ea72da98`.

Fixes #298.