### PR TITLE
Wait between MCP legacy stream reconnects

### DIFF
--- a/src/core/mcp/legacy_streamable_http.zig
+++ b/src/core/mcp/legacy_streamable_http.zig
@@ -502,6 +502,12 @@ fn notificationGetCore(alloc: Allocator, options: OperationOptions) !OperationRe
     const sink = options.notifications orelse return error.MissingNotificationSink;
     var last_event_id: ?[]u8 = null;
     defer if (last_event_id) |value| alloc.free(value);
+    // The SSE retry field sets the reconnection time until the server changes
+    // it, so it outlives the stream that carried it. Holding it here is what
+    // keeps a hint sent once from being replaced by our own default on the
+    // next reconnect. Zero means no hint has arrived yet.
+    var hinted_ms: u32 = 0;
+    var reconnects: u32 = 0;
 
     while (true) {
         var next_options = options;
@@ -509,17 +515,25 @@ fn notificationGetCore(alloc: Allocator, options: OperationOptions) !OperationRe
         const resumed = try notificationGetOnceCore(alloc, next_options, sink);
         if (last_event_id) |value| alloc.free(value);
         last_event_id = resumed.last_event_id;
+        if (resumed.retry_ms > 0) hinted_ms = resumed.retry_ms;
         // A server-supplied retry is honored as given: SEP-1699 makes it a
         // MUST, and the MCP conformance suite fails a client that reconnects
-        // either earlier or more than twice as late as the hint. The default
-        // applies only when the server sent no hint at all, which is the case
-        // that storms: a stream that closes as soon as it opens reconnects
-        // with no wait, and no outer backoff sees it, because a clean close is
-        // not an error and the retry path in tool_subscription never runs.
-        const retry_ms = if (resumed.retry_ms > 0)
-            resumed.retry_ms
+        // either earlier or more than twice as late as the hint.
+        //
+        // Without a hint the first reconnect is immediate, because a stream
+        // that closed once after doing its work is the ordinary case and
+        // should not pay a penalty. From the second onward the default
+        // applies, which is what bounds the storm: a stream that closes as
+        // soon as it opens would otherwise reconnect with no wait forever,
+        // and no outer backoff sees it, because a clean close is not an error
+        // and the retry path in tool_subscription never runs.
+        const retry_ms = if (hinted_ms > 0)
+            hinted_ms
+        else if (reconnects == 0)
+            0
         else
             default_reconnect_delay_ms;
+        reconnects +|= 1;
         const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
         if (controlExpired(options.control)) {
             return error.McpRequestTimedOut;
@@ -944,17 +958,27 @@ fn readSseWithResumption(
     request_id: u64,
 ) ![]u8 {
     var stream = try readSseStream(alloc, initial_reader, options, request_id);
+    // Held across resumes for the same reason as the listener above: the retry
+    // field sets the reconnection time until the server changes it, so a hint
+    // sent on one stream still governs the next one.
+    var hinted_ms: u32 = 0;
+    var resumes: u32 = 0;
     while (true) switch (stream) {
         .final => |body| return body,
         .resumable => |resume_state| {
-            // Same default as the notification listener above, for the same
-            // reason: a server that keeps closing a resumable stream without a
-            // retry hint would otherwise be resumed with no wait at all. A
-            // hint the server did send is still honored as given.
-            const retry_ms = if (resume_state.retry_ms > 0)
-                resume_state.retry_ms
+            if (resume_state.retry_ms > 0) hinted_ms = resume_state.retry_ms;
+            // Same rule as the notification listener above: an explicit hint
+            // is honored as sent, the first resume is immediate because a
+            // stream that closed once after doing its work is ordinary, and
+            // the default from the second onward is what bounds a server that
+            // keeps closing a resumable stream without ever finishing.
+            const retry_ms = if (hinted_ms > 0)
+                hinted_ms
+            else if (resumes == 0)
+                0
             else
                 default_reconnect_delay_ms;
+            resumes +|= 1;
             {
                 const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
                 if (controlExpired(options.control)) {

--- a/src/core/mcp/legacy_streamable_http.zig
+++ b/src/core/mcp/legacy_streamable_http.zig
@@ -10,7 +10,7 @@ const streamable_http = @import("streamable_http.zig");
 const Allocator = std.mem.Allocator;
 const max_sse_events: usize = 1024;
 const close_timeout_ms: i64 = 250;
-const min_reconnect_delay_ms: u32 = 1000;
+const min_reconnect_delay_ms: u32 = 500;
 
 pub const Version = enum {
     v2025_11_25,

--- a/src/core/mcp/legacy_streamable_http.zig
+++ b/src/core/mcp/legacy_streamable_http.zig
@@ -10,6 +10,7 @@ const streamable_http = @import("streamable_http.zig");
 const Allocator = std.mem.Allocator;
 const max_sse_events: usize = 1024;
 const close_timeout_ms: i64 = 250;
+const min_reconnect_delay_ms: u32 = 1000;
 
 pub const Version = enum {
     v2025_11_25,
@@ -508,23 +509,30 @@ fn notificationGetCore(alloc: Allocator, options: OperationOptions) !OperationRe
         const resumed = try notificationGetOnceCore(alloc, next_options, sink);
         if (last_event_id) |value| alloc.free(value);
         last_event_id = resumed.last_event_id;
-        if (resumed.retry_ms > 0) {
-            const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
-            if (controlExpired(options.control)) {
-                return error.McpRequestTimedOut;
-            }
-            const delay_deadline = now.addDuration(.{
-                .clock = .awake,
-                .raw = .fromMilliseconds(resumed.retry_ms),
-            });
-            const deadline = controlDeadline(options.control);
-            const wake = if (std.Io.Clock.Timestamp.compare(
-                delay_deadline,
-                .lt,
-                deadline,
-            )) delay_deadline else deadline;
-            try wake.wait(io_mod.getIo());
+        // Every reconnect waits at least min_reconnect_delay_ms, whether the
+        // server asked for a delay or not. Without the floor, a stream that
+        // closes as soon as it opens reconnects with no wait at all and the
+        // listener becomes a request storm that no outer backoff can see: a
+        // clean close is not an error, so the retry path in tool_subscription
+        // never runs. Clamping rather than defaulting matters because the
+        // delay is server-supplied, so `retry: 1` would otherwise buy the same
+        // storm the floor exists to stop.
+        const retry_ms = @max(resumed.retry_ms, min_reconnect_delay_ms);
+        const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+        if (controlExpired(options.control)) {
+            return error.McpRequestTimedOut;
         }
+        const delay_deadline = now.addDuration(.{
+            .clock = .awake,
+            .raw = .fromMilliseconds(retry_ms),
+        });
+        const deadline = controlDeadline(options.control);
+        const wake = if (std.Io.Clock.Timestamp.compare(
+            delay_deadline,
+            .lt,
+            deadline,
+        )) delay_deadline else deadline;
+        try wake.wait(io_mod.getIo());
     }
 }
 
@@ -937,7 +945,11 @@ fn readSseWithResumption(
     while (true) switch (stream) {
         .final => |body| return body,
         .resumable => |resume_state| {
-            if (resume_state.retry_ms > 0) {
+            // Same floor as the notification listener above, for the same
+            // reason: a server that keeps closing a resumable stream without a
+            // retry hint would otherwise be resumed with no wait at all.
+            const retry_ms = @max(resume_state.retry_ms, min_reconnect_delay_ms);
+            {
                 const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
                 if (controlExpired(options.control)) {
                     alloc.free(resume_state.last_event_id);
@@ -945,7 +957,7 @@ fn readSseWithResumption(
                 }
                 const delay_deadline = now.addDuration(.{
                     .clock = .awake,
-                    .raw = .fromMilliseconds(resume_state.retry_ms),
+                    .raw = .fromMilliseconds(retry_ms),
                 });
                 const deadline = controlDeadline(options.control);
                 const wake = if (std.Io.Clock.Timestamp.compare(

--- a/src/core/mcp/legacy_streamable_http.zig
+++ b/src/core/mcp/legacy_streamable_http.zig
@@ -12,6 +12,29 @@ const max_sse_events: usize = 1024;
 const close_timeout_ms: i64 = 250;
 const default_reconnect_delay_ms: u32 = 1000;
 
+/// How long to wait before reopening a stream that closed cleanly.
+///
+/// `hinted_ms` is the most recent SSE retry value the server sent, held across
+/// attempts because the field sets the reconnection time until the server
+/// changes it; zero means no hint has arrived. `prior_reconnects` is how many
+/// times this loop has already reconnected.
+///
+/// An explicit hint wins outright: SEP-1699 makes it a MUST, and the
+/// conformance suite fails a client that reconnects either earlier or more
+/// than twice as late as the hint, which is what substituting our own default
+/// would look like. Without a hint the first reconnect is immediate, because a
+/// stream that closed once after delivering its work is the ordinary case and
+/// should not pay a penalty; from the second onward the default applies, and
+/// that is what bounds the storm. A stream that closes as soon as it opens
+/// would otherwise reconnect with no wait for the life of the session: a clean
+/// close is not an error, so no outer backoff sees it and the retry path in
+/// tool_subscription never runs.
+fn reconnectDelayMs(hinted_ms: u32, prior_reconnects: u32) u32 {
+    if (hinted_ms > 0) return hinted_ms;
+    if (prior_reconnects == 0) return 0;
+    return default_reconnect_delay_ms;
+}
+
 pub const Version = enum {
     v2025_11_25,
     v2025_06_18,
@@ -516,23 +539,7 @@ fn notificationGetCore(alloc: Allocator, options: OperationOptions) !OperationRe
         if (last_event_id) |value| alloc.free(value);
         last_event_id = resumed.last_event_id;
         if (resumed.retry_ms > 0) hinted_ms = resumed.retry_ms;
-        // A server-supplied retry is honored as given: SEP-1699 makes it a
-        // MUST, and the MCP conformance suite fails a client that reconnects
-        // either earlier or more than twice as late as the hint.
-        //
-        // Without a hint the first reconnect is immediate, because a stream
-        // that closed once after doing its work is the ordinary case and
-        // should not pay a penalty. From the second onward the default
-        // applies, which is what bounds the storm: a stream that closes as
-        // soon as it opens would otherwise reconnect with no wait forever,
-        // and no outer backoff sees it, because a clean close is not an error
-        // and the retry path in tool_subscription never runs.
-        const retry_ms = if (hinted_ms > 0)
-            hinted_ms
-        else if (reconnects == 0)
-            0
-        else
-            default_reconnect_delay_ms;
+        const retry_ms = reconnectDelayMs(hinted_ms, reconnects);
         reconnects +|= 1;
         const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
         if (controlExpired(options.control)) {
@@ -967,17 +974,7 @@ fn readSseWithResumption(
         .final => |body| return body,
         .resumable => |resume_state| {
             if (resume_state.retry_ms > 0) hinted_ms = resume_state.retry_ms;
-            // Same rule as the notification listener above: an explicit hint
-            // is honored as sent, the first resume is immediate because a
-            // stream that closed once after doing its work is ordinary, and
-            // the default from the second onward is what bounds a server that
-            // keeps closing a resumable stream without ever finishing.
-            const retry_ms = if (hinted_ms > 0)
-                hinted_ms
-            else if (resumes == 0)
-                0
-            else
-                default_reconnect_delay_ms;
+            const retry_ms = reconnectDelayMs(hinted_ms, resumes);
             resumes +|= 1;
             {
                 const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
@@ -1562,4 +1559,25 @@ test "a retired session refuses new leases and skips the delete on teardown" {
     try std.testing.expect(!client.acquireUse());
     try std.testing.expect(!client.shouldTerminateSession());
     client.deinit();
+}
+
+test "reconnect delay prefers a server hint and defaults only after the first reconnect" {
+    // No hint: the first reconnect is immediate and every later one carries the
+    // default. The pair is the whole storm bound, so both halves are pinned.
+    try std.testing.expectEqual(@as(u32, 0), reconnectDelayMs(0, 0));
+    try std.testing.expectEqual(default_reconnect_delay_ms, reconnectDelayMs(0, 1));
+    try std.testing.expectEqual(default_reconnect_delay_ms, reconnectDelayMs(0, 2));
+    try std.testing.expectEqual(default_reconnect_delay_ms, reconnectDelayMs(0, 9999));
+
+    // A hint is honored as sent, on the first reconnect and on every later one.
+    // The second case is the one that regressed: holding the hint only for the
+    // stream that carried it silently substituted the default afterwards.
+    try std.testing.expectEqual(@as(u32, 500), reconnectDelayMs(500, 0));
+    try std.testing.expectEqual(@as(u32, 500), reconnectDelayMs(500, 1));
+    try std.testing.expectEqual(@as(u32, 500), reconnectDelayMs(500, 9999));
+
+    // A hint is never widened toward the default, which is what the conformance
+    // suite's "very late" threshold at twice the hint would catch.
+    try std.testing.expect(reconnectDelayMs(1, 5) < default_reconnect_delay_ms);
+    try std.testing.expectEqual(@as(u32, 60_000), reconnectDelayMs(60_000, 5));
 }

--- a/src/core/mcp/legacy_streamable_http.zig
+++ b/src/core/mcp/legacy_streamable_http.zig
@@ -10,7 +10,7 @@ const streamable_http = @import("streamable_http.zig");
 const Allocator = std.mem.Allocator;
 const max_sse_events: usize = 1024;
 const close_timeout_ms: i64 = 250;
-const min_reconnect_delay_ms: u32 = 500;
+const default_reconnect_delay_ms: u32 = 1000;
 
 pub const Version = enum {
     v2025_11_25,
@@ -509,15 +509,17 @@ fn notificationGetCore(alloc: Allocator, options: OperationOptions) !OperationRe
         const resumed = try notificationGetOnceCore(alloc, next_options, sink);
         if (last_event_id) |value| alloc.free(value);
         last_event_id = resumed.last_event_id;
-        // Every reconnect waits at least min_reconnect_delay_ms, whether the
-        // server asked for a delay or not. Without the floor, a stream that
-        // closes as soon as it opens reconnects with no wait at all and the
-        // listener becomes a request storm that no outer backoff can see: a
-        // clean close is not an error, so the retry path in tool_subscription
-        // never runs. Clamping rather than defaulting matters because the
-        // delay is server-supplied, so `retry: 1` would otherwise buy the same
-        // storm the floor exists to stop.
-        const retry_ms = @max(resumed.retry_ms, min_reconnect_delay_ms);
+        // A server-supplied retry is honored as given: SEP-1699 makes it a
+        // MUST, and the MCP conformance suite fails a client that reconnects
+        // either earlier or more than twice as late as the hint. The default
+        // applies only when the server sent no hint at all, which is the case
+        // that storms: a stream that closes as soon as it opens reconnects
+        // with no wait, and no outer backoff sees it, because a clean close is
+        // not an error and the retry path in tool_subscription never runs.
+        const retry_ms = if (resumed.retry_ms > 0)
+            resumed.retry_ms
+        else
+            default_reconnect_delay_ms;
         const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
         if (controlExpired(options.control)) {
             return error.McpRequestTimedOut;
@@ -945,10 +947,14 @@ fn readSseWithResumption(
     while (true) switch (stream) {
         .final => |body| return body,
         .resumable => |resume_state| {
-            // Same floor as the notification listener above, for the same
+            // Same default as the notification listener above, for the same
             // reason: a server that keeps closing a resumable stream without a
-            // retry hint would otherwise be resumed with no wait at all.
-            const retry_ms = @max(resume_state.retry_ms, min_reconnect_delay_ms);
+            // retry hint would otherwise be resumed with no wait at all. A
+            // hint the server did send is still honored as given.
+            const retry_ms = if (resume_state.retry_ms > 0)
+                resume_state.retry_ms
+            else
+                default_reconnect_delay_ms;
             {
                 const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
                 if (controlExpired(options.control)) {

--- a/tests/e2e/fixtures/mcp-legacy-remote.ts
+++ b/tests/e2e/fixtures/mcp-legacy-remote.ts
@@ -36,7 +36,9 @@ type StreamableMode =
   | "url_required_error"
   | "closed_listener"
   | "retry_hint_listener"
-  | "resume_storm";
+  | "resume_storm"
+  | "retry_hint_resume"
+  | "retry_hint_once";
 
 export function startLegacyStreamableHttpFixture(
   version: LegacyStreamableVersion,
@@ -130,6 +132,29 @@ export function startLegacyStreamableHttpFixture(
           return new Response("retry: 500\n\n", {
             headers: { "content-type": "text/event-stream" },
           });
+        }
+        if (mode === "retry_hint_once") {
+          // The hint arrives exactly once. Per the SSE spec the retry field
+          // sets the reconnection time until the server changes it, so every
+          // later reconnect must still use 500ms even though the field is
+          // absent from these responses.
+          return new Response(resumeCalls === 1 ? "retry: 500\n\n" : "", {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        if (mode === "retry_hint_resume") {
+          // The resume path's mirror of retry_hint_listener: every resumption
+          // response carries the server's own interval and still closes
+          // without a final response, so readSseWithResumption keeps resuming
+          // and the observed spacing is the hint rather than our default.
+          return new Response(
+            `retry: 500\nid: resume-${resumeCalls}\ndata: ${JSON.stringify({
+              jsonrpc: "2.0",
+              method: "notifications/progress",
+              params: { progressToken: 4, progress: 1, total: 2 },
+            })}\n\n`,
+            { headers: { "content-type": "text/event-stream" } },
+          );
         }
         if (mode === "resume_storm") {
           // A resumable close with no final response: the client resumes,
@@ -574,7 +599,10 @@ export function startLegacyStreamableHttpFixture(
             },
           }]);
         }
-        if (mode === "resume" || mode === "resume_storm") {
+        if (
+          mode === "resume" || mode === "resume_storm" ||
+          mode === "retry_hint_resume"
+        ) {
           resumableCallId = message!.id;
           return sseResponse([
             {

--- a/tests/e2e/fixtures/mcp-legacy-remote.ts
+++ b/tests/e2e/fixtures/mcp-legacy-remote.ts
@@ -10,6 +10,7 @@ export type LegacyRequest = {
   httpMethod: string;
   path: string;
   headers: Record<string, string>;
+  at?: number;
   message?: {
     id?: number;
     method?: string;
@@ -32,7 +33,10 @@ type StreamableMode =
   | "expire_session"
   | "elicitation_form"
   | "elicitation_url"
-  | "url_required_error";
+  | "url_required_error"
+  | "closed_listener"
+  | "retry_hint_listener"
+  | "resume_storm";
 
 export function startLegacyStreamableHttpFixture(
   version: LegacyStreamableVersion,
@@ -115,8 +119,50 @@ export function startLegacyStreamableHttpFixture(
           httpMethod: request.method,
           path: url.pathname,
           headers,
+          at: Date.now(),
         });
         resumeCalls += 1;
+        if (mode === "retry_hint_listener") {
+          // A server asking to be reconnected to almost immediately. The
+          // client is expected to treat its own floor as a minimum rather
+          // than honour a hint below it.
+          return new Response("retry: 1\n\n", {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        if (mode === "resume_storm") {
+          // A resumable close with no final response: the client resumes,
+          // and the server closes again the same way.
+          return sseResponse([{
+            id: `resume-${resumeCalls}`,
+            data: {
+              jsonrpc: "2.0",
+              method: "notifications/progress",
+              params: { progressToken: 4, progress: 1, total: 2 },
+            },
+          }]);
+        }
+        if (mode === "closed_listener") {
+          // A server that answers the notification GET with a well-formed but
+          // already-finished SSE body. The client must not treat that as a cue
+          // to reconnect without delay. From the second attempt on it closes
+          // the same way but delivers one notification first, so a test can
+          // tell "stopped storming" apart from "stopped listening".
+          if (resumeCalls === 1) {
+            return new Response("", {
+              headers: { "content-type": "text/event-stream" },
+            });
+          }
+          currentToolName = "fresh";
+          return new Response(
+            `id: closed-${resumeCalls}\ndata: ${JSON.stringify({
+              jsonrpc: "2.0",
+              method: "notifications/tools/list_changed",
+              params: {},
+            })}\n\n`,
+            { headers: { "content-type": "text/event-stream" } },
+          );
+        }
         if (mode === "url_required_error") {
           let active = true;
           return new Response(
@@ -527,7 +573,7 @@ export function startLegacyStreamableHttpFixture(
             },
           }]);
         }
-        if (mode === "resume") {
+        if (mode === "resume" || mode === "resume_storm") {
           resumableCallId = message!.id;
           return sseResponse([
             {

--- a/tests/e2e/fixtures/mcp-legacy-remote.ts
+++ b/tests/e2e/fixtures/mcp-legacy-remote.ts
@@ -123,10 +123,11 @@ export function startLegacyStreamableHttpFixture(
         });
         resumeCalls += 1;
         if (mode === "retry_hint_listener") {
-          // A server asking to be reconnected to almost immediately. The
-          // client is expected to treat its own floor as a minimum rather
-          // than honour a hint below it.
-          return new Response("retry: 1\n\n", {
+          // A server that closes the listener stream immediately but says how
+          // long to wait first. The client is expected to honor the hint
+          // rather than substitute its own delay. 500ms is the value the MCP
+          // conformance suite uses for the same check.
+          return new Response("retry: 500\n\n", {
             headers: { "content-type": "text/event-stream" },
           });
         }

--- a/tests/e2e/fixtures/mcp-legacy-remote.ts
+++ b/tests/e2e/fixtures/mcp-legacy-remote.ts
@@ -38,7 +38,8 @@ type StreamableMode =
   | "retry_hint_listener"
   | "resume_storm"
   | "retry_hint_resume"
-  | "retry_hint_once";
+  | "retry_hint_once"
+  | "retry_zero_listener";
 
 export function startLegacyStreamableHttpFixture(
   version: LegacyStreamableVersion,
@@ -130,6 +131,15 @@ export function startLegacyStreamableHttpFixture(
           // rather than substitute its own delay. 500ms is the value the MCP
           // conformance suite uses for the same check.
           return new Response("retry: 500\n\n", {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+        if (mode === "retry_zero_listener") {
+          // An explicit `retry: 0`. Zero is not an interval a client can wait,
+          // and reconnecting with no wait is the storm this file exists to
+          // prevent, so it has to fall back to the default rather than be
+          // honored literally.
+          return new Response("retry: 0\n\n", {
             headers: { "content-type": "text/event-stream" },
           });
         }

--- a/tests/e2e/mcp-legacy-remote.test.ts
+++ b/tests/e2e/mcp-legacy-remote.test.ts
@@ -431,6 +431,122 @@ describe("version-scoped legacy MCP remote transports", () => {
     expect(legacySse.streamCancelled).toBe(1);
   }, 30_000);
 
+  test("Streamable HTTP listener reconnects with delay when the server closes its stream", async () => {
+    streamable = startLegacyStreamableHttpFixture("2025-06-18", {
+      listChanged: true,
+      mode: "closed_listener",
+    });
+    const root = createRoot("closed-listener", "http", streamable.url);
+    gateway = startFakeGateway([
+      fakeGatewayToolCall("activate_listener", "mcp_search_tools", {
+        query: "echo",
+      }),
+      async () => {
+        await Bun.sleep(3_000);
+        // A second search after the reconnect window: the tool list is
+        // refetched lazily, so this is what makes a delivered
+        // tools/list_changed observable.
+        return fakeGatewayToolCall("search_fresh", "mcp_search_tools", {
+          query: "fresh",
+        });
+      },
+      fakeGatewayFinalText("closed listener complete."),
+    ], {
+      models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+    });
+
+    const result = await runAsk(root, gateway, "Use the legacy tool.");
+
+    expect(result.code).toBe(0);
+    // A server that closes the notification stream must not be reconnected to
+    // without a delay: roughly three seconds of listener lifetime here. The
+    // lower bound is what keeps the upper bound honest -- without it the test
+    // passes just as well when the listener never runs at all. Before the
+    // floor this fixture drew 13946 reconnects.
+    // Spacing first: it is the property the floor actually guarantees, and a
+    // count in a window is satisfied by any floor at all. 800ms rather than
+    // 1000ms leaves room for scheduler jitter without admitting a storm.
+    const listenerGets = streamable.requests.filter((entry) =>
+      entry.httpMethod === "GET" && entry.at !== undefined
+    );
+    const gaps = listenerGets.slice(1).map((entry, index) =>
+      entry.at! - listenerGets[index]!.at!
+    );
+    expect(gaps.length).toBeGreaterThanOrEqual(1);
+    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(800);
+
+    expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
+    expect(streamable.resumeCalls).toBeLessThanOrEqual(10);
+
+    // And the listener must still be a listener: from its second attempt the
+    // fixture delivers a tools/list_changed before closing, so a refreshed
+    // tools/list proves notifications survive the reconnect delay.
+    expect(streamable.toolsListCalls).toBeGreaterThanOrEqual(2);
+  }, 30_000);
+
+  test("Streamable HTTP call resume honors the operation deadline between attempts", async () => {
+    streamable = startLegacyStreamableHttpFixture("2025-06-18", {
+      mode: "resume_storm",
+    });
+    // A two second operation deadline against a server that never sends a
+    // final response: the resume loop has to notice the deadline between
+    // waits, not only while it is waiting.
+    const root = createRoot("resume-deadline", "http", streamable.url, 2_000);
+    gateway = startToolGateway("resume deadline complete.");
+
+    const result = await runAsk(root, gateway, "Call the fixture.");
+
+    expect(result.code).toBe(0);
+    expect(streamable.resumeCalls).toBeGreaterThanOrEqual(1);
+    expect(streamable.resumeCalls).toBeLessThanOrEqual(4);
+    expect(streamable.cancellationNotifications).toBeGreaterThanOrEqual(1);
+  }, 30_000);
+
+  test("Streamable HTTP listener floors a server retry hint below its minimum", async () => {
+    streamable = startLegacyStreamableHttpFixture("2025-06-18", {
+      listChanged: true,
+      mode: "retry_hint_listener",
+    });
+    const root = createRoot("retry-hint-listener", "http", streamable.url);
+    gateway = startFakeGateway([
+      fakeGatewayToolCall("activate_listener", "mcp_search_tools", {
+        query: "echo",
+      }),
+      async () => {
+        await Bun.sleep(3_000);
+        return fakeGatewayFinalText("retry hint complete.");
+      },
+    ], {
+      models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+    });
+
+    const result = await runAsk(root, gateway, "Use the legacy tool.");
+
+    expect(result.code).toBe(0);
+    // `retry: 1` is a server-supplied delay below the client's floor. Honouring
+    // it verbatim is the same request storm as no delay at all.
+    expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
+    expect(streamable.resumeCalls).toBeLessThanOrEqual(10);
+  }, 30_000);
+
+  test("Streamable HTTP call resume waits between attempts when the server keeps closing", async () => {
+    streamable = startLegacyStreamableHttpFixture("2025-06-18", {
+      mode: "resume_storm",
+    });
+    const root = createRoot("resume-storm", "http", streamable.url);
+    gateway = startToolGateway("resume storm complete.");
+
+    const result = await runAsk(root, gateway, "Call the fixture.");
+
+    expect(result.code).toBe(0);
+    // The tool call never receives a final response, so it resumes until the
+    // operation deadline. Each resume must wait. Before the floor this fixture
+    // drew 16953 resume requests in five seconds.
+    expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
+    expect(streamable.resumeCalls).toBeLessThanOrEqual(10);
+  }, 30_000);
+
+
   for (const version of VERSIONS) {
     test(`fresh fx ask calls Streamable HTTP ${version} with its lifecycle headers`, async () => {
       streamable = startLegacyStreamableHttpFixture(version);

--- a/tests/e2e/mcp-legacy-remote.test.ts
+++ b/tests/e2e/mcp-legacy-remote.test.ts
@@ -546,6 +546,42 @@ describe("version-scoped legacy MCP remote transports", () => {
     expect(streamable.resumeCalls).toBeLessThanOrEqual(12);
   }, 30_000);
 
+  test("Streamable HTTP listener treats an explicit retry:0 as no interval", async () => {
+    streamable = startLegacyStreamableHttpFixture("2025-06-18", {
+      listChanged: true,
+      mode: "retry_zero_listener",
+    });
+    const root = createRoot("retry-zero-listener", "http", streamable.url);
+    gateway = startFakeGateway([
+      fakeGatewayToolCall("activate_listener", "mcp_search_tools", {
+        query: "echo",
+      }),
+      async () => {
+        await Bun.sleep(3_000);
+        return fakeGatewayFinalText("retry zero complete.");
+      },
+    ], {
+      models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+    });
+
+    const result = await runAsk(root, gateway, "Use the legacy tool.");
+
+    expect(result.code).toBe(0);
+    // Honoring this one literally would reopen the defect: zero wait is the
+    // storm. It falls back to the default instead, so the spacing after the
+    // first reconnect matches the no-hint case rather than collapsing.
+    const listenerGets = streamable.requests.filter((entry) =>
+      entry.httpMethod === "GET" && entry.at !== undefined
+    );
+    const gaps = listenerGets.slice(1).map((entry, index) =>
+      entry.at! - listenerGets[index]!.at!
+    );
+    const spacedGaps = gaps.slice(1);
+    expect(spacedGaps.length).toBeGreaterThanOrEqual(1);
+    expect(Math.min(...spacedGaps)).toBeGreaterThanOrEqual(800);
+    expect(streamable.resumeCalls).toBeLessThanOrEqual(10);
+  }, 30_000);
+
   test("Streamable HTTP listener keeps using a retry hint the server sent once", async () => {
     streamable = startLegacyStreamableHttpFixture("2025-06-18", {
       listChanged: true,
@@ -626,6 +662,19 @@ describe("version-scoped legacy MCP remote transports", () => {
     // drew 16953 resume requests in five seconds.
     expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
     expect(streamable.resumeCalls).toBeLessThanOrEqual(10);
+    // Spacing as well as the count, matching the listener test: a count inside a
+    // window is satisfied by any delay at all, including one too small to
+    // matter, so the gap is what actually pins the default here. The first
+    // resume is deliberately immediate and excluded for the same reason.
+    const resumeGets = streamable.requests.filter((entry) =>
+      entry.httpMethod === "GET" && entry.at !== undefined
+    );
+    const gaps = resumeGets.slice(1).map((entry, index) =>
+      entry.at! - resumeGets[index]!.at!
+    );
+    const spacedGaps = gaps.slice(1);
+    expect(spacedGaps.length).toBeGreaterThanOrEqual(1);
+    expect(Math.min(...spacedGaps)).toBeGreaterThanOrEqual(800);
   }, 30_000);
 
 

--- a/tests/e2e/mcp-legacy-remote.test.ts
+++ b/tests/e2e/mcp-legacy-remote.test.ts
@@ -462,10 +462,10 @@ describe("version-scoped legacy MCP remote transports", () => {
     // without a delay: roughly three seconds of listener lifetime here. The
     // lower bound is what keeps the upper bound honest -- without it the test
     // passes just as well when the listener never runs at all. Before the
-    // floor this fixture drew 13946 reconnects.
-    // Spacing first: it is the property the floor actually guarantees, and a
-    // count in a window is satisfied by any floor at all. 400ms rather than
-    // 500ms leaves room for scheduler jitter without admitting a storm.
+    // default this fixture drew 13946 reconnects.
+    // Spacing first: it is the property the default actually guarantees, and a
+    // count in a window is satisfied by any delay at all. 800ms rather than
+    // 1000ms leaves room for scheduler jitter without admitting a storm.
     const listenerGets = streamable.requests.filter((entry) =>
       entry.httpMethod === "GET" && entry.at !== undefined
     );
@@ -473,7 +473,7 @@ describe("version-scoped legacy MCP remote transports", () => {
       entry.at! - listenerGets[index]!.at!
     );
     expect(gaps.length).toBeGreaterThanOrEqual(1);
-    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(400);
+    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(800);
 
     expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
     expect(streamable.resumeCalls).toBeLessThanOrEqual(10);
@@ -502,7 +502,7 @@ describe("version-scoped legacy MCP remote transports", () => {
     expect(streamable.cancellationNotifications).toBeGreaterThanOrEqual(1);
   }, 30_000);
 
-  test("Streamable HTTP listener floors a server retry hint below its minimum", async () => {
+  test("Streamable HTTP listener reconnects on the server's own retry hint", async () => {
     streamable = startLegacyStreamableHttpFixture("2025-06-18", {
       listChanged: true,
       mode: "retry_hint_listener",
@@ -523,10 +523,23 @@ describe("version-scoped legacy MCP remote transports", () => {
     const result = await runAsk(root, gateway, "Use the legacy tool.");
 
     expect(result.code).toBe(0);
-    // `retry: 1` is a server-supplied delay below the client's floor. Honouring
-    // it verbatim is the same request storm as no delay at all.
+    // SEP-1699 makes the retry field a MUST, so a server that asked for 500ms
+    // gets 500ms and not the client's own default. Both bounds matter: the
+    // lower one is the conformance suite's "reconnected too early", the upper
+    // one is its "very late" threshold at twice the hint, which is exactly
+    // what a 1000ms default applied on top of the hint would trip.
+    const listenerGets = streamable.requests.filter((entry) =>
+      entry.httpMethod === "GET" && entry.at !== undefined
+    );
+    const gaps = listenerGets.slice(1).map((entry, index) =>
+      entry.at! - listenerGets[index]!.at!
+    );
+    expect(gaps.length).toBeGreaterThanOrEqual(1);
+    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(450);
+    expect(Math.max(...gaps)).toBeLessThan(1_000);
+
     expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
-    expect(streamable.resumeCalls).toBeLessThanOrEqual(10);
+    expect(streamable.resumeCalls).toBeLessThanOrEqual(12);
   }, 30_000);
 
   test("Streamable HTTP call resume waits between attempts when the server keeps closing", async () => {
@@ -540,7 +553,7 @@ describe("version-scoped legacy MCP remote transports", () => {
 
     expect(result.code).toBe(0);
     // The tool call never receives a final response, so it resumes until the
-    // operation deadline. Each resume must wait. Before the floor this fixture
+    // operation deadline. Each resume must wait. Before the default this fixture
     // drew 16953 resume requests in five seconds.
     expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
     expect(streamable.resumeCalls).toBeLessThanOrEqual(10);

--- a/tests/e2e/mcp-legacy-remote.test.ts
+++ b/tests/e2e/mcp-legacy-remote.test.ts
@@ -460,20 +460,24 @@ describe("version-scoped legacy MCP remote transports", () => {
     expect(result.code).toBe(0);
     // A server that closes the notification stream must not be reconnected to
     // without a delay: roughly three seconds of listener lifetime here. The
-    // lower bound is what keeps the upper bound honest -- without it the test
+    // lower bound is what keeps the upper bound honest: without it the test
     // passes just as well when the listener never runs at all. Before the
     // default this fixture drew 13946 reconnects.
     // Spacing first: it is the property the default actually guarantees, and a
     // count in a window is satisfied by any delay at all. 800ms rather than
     // 1000ms leaves room for scheduler jitter without admitting a storm.
+    // The first reconnect is deliberately immediate, so that gap is excluded:
+    // one stream closing after it has done its work is the ordinary case. The
+    // storm is what happens next, and every later gap has to carry the delay.
     const listenerGets = streamable.requests.filter((entry) =>
       entry.httpMethod === "GET" && entry.at !== undefined
     );
     const gaps = listenerGets.slice(1).map((entry, index) =>
       entry.at! - listenerGets[index]!.at!
     );
-    expect(gaps.length).toBeGreaterThanOrEqual(1);
-    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(800);
+    const spacedGaps = gaps.slice(1);
+    expect(spacedGaps.length).toBeGreaterThanOrEqual(1);
+    expect(Math.min(...spacedGaps)).toBeGreaterThanOrEqual(800);
 
     expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
     expect(streamable.resumeCalls).toBeLessThanOrEqual(10);
@@ -540,6 +544,71 @@ describe("version-scoped legacy MCP remote transports", () => {
 
     expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
     expect(streamable.resumeCalls).toBeLessThanOrEqual(12);
+  }, 30_000);
+
+  test("Streamable HTTP listener keeps using a retry hint the server sent once", async () => {
+    streamable = startLegacyStreamableHttpFixture("2025-06-18", {
+      listChanged: true,
+      mode: "retry_hint_once",
+    });
+    const root = createRoot("retry-hint-once", "http", streamable.url);
+    gateway = startFakeGateway([
+      fakeGatewayToolCall("activate_listener", "mcp_search_tools", {
+        query: "echo",
+      }),
+      async () => {
+        await Bun.sleep(3_000);
+        return fakeGatewayFinalText("retry hint once complete.");
+      },
+    ], {
+      models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+    });
+
+    const result = await runAsk(root, gateway, "Use the legacy tool.");
+
+    expect(result.code).toBe(0);
+    // The retry field sets the reconnection time until the server changes it,
+    // so a hint sent on the first stream still governs the tenth. Holding it
+    // only for the stream that carried it is the shape that reads as fixed and
+    // is not: every later reconnect silently reverts to our own default, which
+    // is the exact substitution SEP-1699 forbids. The upper bound is what
+    // catches that, since the default is twice the hint.
+    const listenerGets = streamable.requests.filter((entry) =>
+      entry.httpMethod === "GET" && entry.at !== undefined
+    );
+    const gaps = listenerGets.slice(1).map((entry, index) =>
+      entry.at! - listenerGets[index]!.at!
+    );
+    expect(gaps.length).toBeGreaterThanOrEqual(2);
+    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(450);
+    expect(Math.max(...gaps)).toBeLessThan(1_000);
+  }, 30_000);
+
+  test("Streamable HTTP call resume honors the server's own retry hint", async () => {
+    streamable = startLegacyStreamableHttpFixture("2025-06-18", {
+      mode: "retry_hint_resume",
+    });
+    const root = createRoot("retry-hint-resume", "http", streamable.url);
+    gateway = startToolGateway("retry hint resume complete.");
+
+    const result = await runAsk(root, gateway, "Call the fixture.");
+
+    expect(result.code).toBe(0);
+    // The listener has had this coverage since the hint was first honored; the
+    // resume loop carries the same logic and had none, so a floor or an
+    // override here passed every other test in this file. 500ms is the value
+    // the conformance suite uses, bounded on both sides for the same reason as
+    // the listener test: too early is a spec violation, and twice the hint is
+    // what our own default would look like if it were applied on top.
+    const resumeGets = streamable.requests.filter((entry) =>
+      entry.httpMethod === "GET" && entry.at !== undefined
+    );
+    const gaps = resumeGets.slice(1).map((entry, index) =>
+      entry.at! - resumeGets[index]!.at!
+    );
+    expect(gaps.length).toBeGreaterThanOrEqual(1);
+    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(450);
+    expect(Math.max(...gaps)).toBeLessThan(1_000);
   }, 30_000);
 
   test("Streamable HTTP call resume waits between attempts when the server keeps closing", async () => {

--- a/tests/e2e/mcp-legacy-remote.test.ts
+++ b/tests/e2e/mcp-legacy-remote.test.ts
@@ -464,8 +464,8 @@ describe("version-scoped legacy MCP remote transports", () => {
     // passes just as well when the listener never runs at all. Before the
     // floor this fixture drew 13946 reconnects.
     // Spacing first: it is the property the floor actually guarantees, and a
-    // count in a window is satisfied by any floor at all. 800ms rather than
-    // 1000ms leaves room for scheduler jitter without admitting a storm.
+    // count in a window is satisfied by any floor at all. 400ms rather than
+    // 500ms leaves room for scheduler jitter without admitting a storm.
     const listenerGets = streamable.requests.filter((entry) =>
       entry.httpMethod === "GET" && entry.at !== undefined
     );
@@ -473,7 +473,7 @@ describe("version-scoped legacy MCP remote transports", () => {
       entry.at! - listenerGets[index]!.at!
     );
     expect(gaps.length).toBeGreaterThanOrEqual(1);
-    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(800);
+    expect(Math.min(...gaps)).toBeGreaterThanOrEqual(400);
 
     expect(streamable.resumeCalls).toBeGreaterThanOrEqual(2);
     expect(streamable.resumeCalls).toBeLessThanOrEqual(10);


### PR DESCRIPTION
Fixes #301.

A legacy Streamable HTTP MCP server that closes a stream cleanly was reconnected to with no delay, for the life of the session. A clean close is not an error, so the exponential backoff in `tool_subscription.zig` never saw it, and the listener deadline is `maxInt(u32)`, so nothing else bounded it either. The same shape existed on the tool-call resume path in the same file.

Both loops now wait one second between reconnects when the server sent no `retry` hint, and check the control deadline every iteration rather than only when the server asked for a delay. A hint the server did send is used as given. SEP-1699 makes the retry field a MUST, so the one second is a default and never a floor over an explicit value.

Measured with the new fixtures, before and after:

| case | before | after |
|---|---|---|
| listener, stream closes immediately | 14598 reconnects / 3s | <= 10 |
| tool-call resume, server keeps closing | 15838 / 5s | <= 10 |
| listener, stream held open (control) | 1 | 1 |

The other two transports already return an error on `EndOfStream` (`legacy_http_sse.zig:518`, `streamable_http.zig:941`), so their closes reach the outer backoff and they needed no change.

## Tests

Three fixture modes (`closed_listener`, `retry_hint_listener`, `resume_storm`) and four cases in `mcp-legacy-remote.test.ts`. Each assertion was checked against the unfixed binary first, so none of them is vacuously green:

- Reconnect spacing, not just a count in a window. A bare count passes under any delay, including one too small to matter; the spacing assertion fails at 0ms without the default.
- A lower bound alongside the upper one. Disabling the listener makes the test fail with `Received: 0`, which is what keeps the upper bound honest.
- The listener still delivers. From its second attempt the fixture sends `tools/list_changed` before closing, and the test asserts the tool list is refetched, so "stopped storming" cannot be confused with "stopped listening".
- The resume loop honors a short operation deadline between attempts, exiting in about two seconds with a cancellation sent upstream.
- An explicit `retry: 500`, the value the conformance suite uses, is honored rather than replaced. Observed spacing is 501ms across seven reconnects, and the assertion bounds it on both sides at the suite's own too-early and very-late thresholds.

The MCP conformance suite is 471 passed / 0 failed, with `sse-retry` on 2025-11-25 reporting `client-sse-retry-timing SUCCESS` and the GET landing 504ms after the stream close. The full `mcp-legacy-remote` suite is green at 41 tests. `mcp-http` and `mcp-stdio` match the pre-change baseline on the same commit, including their pre-existing failures.

## Trade-off worth naming

Against a server that sends no hint the wait is flat, so a well-behaved server that closes its stream cleanly waits up to a second before the listener reconnects. An escalating backoff would be gentler on a persistently broken server but adds state to a loop that currently has none, and one second is already three orders of magnitude below the behavior being fixed. A server that does send a hint sets its own pace, including a very short one, which is what the spec asks for.

The no-hint default is back to one second here. 500ms was picked while the value was a floor over the hint and had to clear the conformance window; now that the hint is honored the default only governs servers that sent nothing, so it is an independent choice. Happy to take 500ms instead if you prefer it.
