### PR TITLE
Prevent undo from destroying files it cannot restore

### DIFF
--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -1013,12 +1013,26 @@ pub fn Handlers(comptime App: type) type {
                     defer display_path.deinit(app.alloc);
                     break :blk try std.fmt.allocPrint(app.alloc, "Deleted {s} (was newly created)", .{display_path.bytes});
                 },
+                .unavailable => |path| blk: {
+                    var display_path = try text_utils.encodeTerminalSafe(
+                        app.alloc,
+                        path,
+                        std.Io.Dir.max_path_bytes,
+                    );
+                    defer display_path.deinit(app.alloc);
+                    break :blk try std.fmt.allocPrint(
+                        app.alloc,
+                        "Could not undo {s}",
+                        .{display_path.bytes},
+                    );
+                },
                 .empty => try app.alloc.dupe(u8, "Nothing to undo."),
             };
             defer app.alloc.free(msg);
             switch (result) {
                 .restored => |path| std.heap.c_allocator.free(path),
                 .deleted => |path| std.heap.c_allocator.free(path),
+                .unavailable => |path| std.heap.c_allocator.free(path),
                 .empty => {},
             }
             try app.writeDomainNotice(.{

--- a/src/core/tooling/tracked_file_mutations.zig
+++ b/src/core/tooling/tracked_file_mutations.zig
@@ -170,7 +170,7 @@ fn captureDelete(
         .path = owned_path,
         .previous_content = preimage.content,
         .timestamp_ms = 0,
-        .preimage_unavailable = preimage.unavailable,
+        .unavailable_cause = preimage.unavailable_cause,
     };
 }
 
@@ -181,7 +181,7 @@ fn captureRename(
 ) ?change_tracker.FileOperation {
     if (tracker == null) return null;
     const owned_old_path = std.heap.c_allocator.dupe(u8, old_path) catch return null;
-    const owned_new_path = std.heap.c_allocator.dupe(u8, new_path) catch return .{
+    const owned_new_path = std.heap.c_allocator.dupe(u8, new_path) catch |err| return .{
         // Keep a barrier in the undo history when the rename succeeded but the
         // destination path could not be retained. Without it, /undo would act on
         // an older operation; treating a missing path as a completed restore would
@@ -190,7 +190,7 @@ fn captureRename(
         .path = owned_old_path,
         .previous_content = null,
         .timestamp_ms = 0,
-        .preimage_unavailable = true,
+        .unavailable_cause = .{ .stage = .new_path_clone, .err = err },
     };
     const preimage = capturePreimage(new_path);
     return .{
@@ -199,7 +199,7 @@ fn captureRename(
         .previous_content = preimage.content,
         .new_path = owned_new_path,
         .timestamp_ms = 0,
-        .preimage_unavailable = preimage.unavailable,
+        .unavailable_cause = preimage.unavailable_cause,
     };
 }
 
@@ -215,13 +215,13 @@ fn captureCopy(
         .path = owned_path,
         .previous_content = preimage.content,
         .timestamp_ms = 0,
-        .preimage_unavailable = preimage.unavailable,
+        .unavailable_cause = preimage.unavailable_cause,
     };
 }
 
 const Preimage = struct {
     content: ?[]u8 = null,
-    unavailable: bool = false,
+    unavailable_cause: ?change_tracker.UnavailableCause = null,
 };
 
 /// Resolves the preimage an undo record needs. A file proven absent records no content
@@ -232,7 +232,7 @@ fn capturePreimage(capture_path: []const u8) Preimage {
     return switch (change_tracker.ChangeTracker.captureFileState(std.heap.c_allocator, capture_path)) {
         .captured => |content| .{ .content = content },
         .absent => .{},
-        .unavailable => .{ .unavailable = true },
+        .unavailable => |cause| .{ .unavailable_cause = cause },
     };
 }
 
@@ -798,7 +798,7 @@ test "copy over a destination that cannot be captured refuses to undo it" {
 
     // The destination predates the copy, so undo must never treat it as a file the copy created.
     try std.testing.expectEqual(@as(usize, 1), tracker.stack.items.len);
-    try std.testing.expect(tracker.stack.items[0].preimage_unavailable);
+    try std.testing.expect(tracker.stack.items[0].unavailable_cause != null);
 
     const undo = tracker.undoLast(std.heap.c_allocator);
     switch (undo) {

--- a/src/core/tooling/tracked_file_mutations.zig
+++ b/src/core/tooling/tracked_file_mutations.zig
@@ -181,7 +181,17 @@ fn captureRename(
 ) ?change_tracker.FileOperation {
     if (tracker == null) return null;
     const owned_old_path = std.heap.c_allocator.dupe(u8, old_path) catch return null;
-    const owned_new_path = std.heap.c_allocator.dupe(u8, new_path) catch null;
+    const owned_new_path = std.heap.c_allocator.dupe(u8, new_path) catch return .{
+        // Keep a barrier in the undo history when the rename succeeded but the
+        // destination path could not be retained. Without it, /undo would act on
+        // an older operation; treating a missing path as a completed restore would
+        // be equally misleading.
+        .kind = .rename,
+        .path = owned_old_path,
+        .previous_content = null,
+        .timestamp_ms = 0,
+        .preimage_unavailable = true,
+    };
     const preimage = capturePreimage(new_path);
     return .{
         .kind = .rename,

--- a/src/core/tooling/tracked_file_mutations.zig
+++ b/src/core/tooling/tracked_file_mutations.zig
@@ -164,14 +164,13 @@ fn captureDelete(
 ) ?change_tracker.FileOperation {
     if (tracker == null) return null;
     const owned_path = std.heap.c_allocator.dupe(u8, path) catch return null;
+    const preimage = capturePreimage(path);
     return .{
         .kind = .delete,
         .path = owned_path,
-        .previous_content = change_tracker.ChangeTracker.captureFileState(
-            std.heap.c_allocator,
-            path,
-        ),
+        .previous_content = preimage.content,
         .timestamp_ms = 0,
+        .preimage_unavailable = preimage.unavailable,
     };
 }
 
@@ -183,15 +182,14 @@ fn captureRename(
     if (tracker == null) return null;
     const owned_old_path = std.heap.c_allocator.dupe(u8, old_path) catch return null;
     const owned_new_path = std.heap.c_allocator.dupe(u8, new_path) catch null;
+    const preimage = capturePreimage(new_path);
     return .{
         .kind = .rename,
         .path = owned_old_path,
-        .previous_content = change_tracker.ChangeTracker.captureFileState(
-            std.heap.c_allocator,
-            new_path,
-        ),
+        .previous_content = preimage.content,
         .new_path = owned_new_path,
         .timestamp_ms = 0,
+        .preimage_unavailable = preimage.unavailable,
     };
 }
 
@@ -201,14 +199,30 @@ fn captureCopy(
 ) ?change_tracker.FileOperation {
     if (tracker == null) return null;
     const owned_path = std.heap.c_allocator.dupe(u8, destination) catch return null;
+    const preimage = capturePreimage(destination);
     return .{
         .kind = .write,
         .path = owned_path,
-        .previous_content = change_tracker.ChangeTracker.captureFileState(
-            std.heap.c_allocator,
-            destination,
-        ),
+        .previous_content = preimage.content,
         .timestamp_ms = 0,
+        .preimage_unavailable = preimage.unavailable,
+    };
+}
+
+const Preimage = struct {
+    content: ?[]u8 = null,
+    unavailable: bool = false,
+};
+
+/// Resolves the preimage an undo record needs. A file proven absent records no content
+/// and stays undoable, because undo reads that as "the tool created this". A file whose
+/// state could not be read records no content either, but is marked unavailable so undo
+/// refuses it instead of deleting a file the tool never created.
+fn capturePreimage(capture_path: []const u8) Preimage {
+    return switch (change_tracker.ChangeTracker.captureFileState(std.heap.c_allocator, capture_path)) {
+        .captured => |content| .{ .content = content },
+        .absent => .{},
+        .unavailable => .{ .unavailable = true },
     };
 }
 
@@ -745,4 +759,41 @@ fn createSymlinkOrSkip(tmp: *std.testing.TmpDir, target_path: []const u8, link_p
         }
         return err;
     };
+}
+
+test "copy over a destination that cannot be captured refuses to undo it" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestFile(tmp.dir, "workspace/source.txt", "small source");
+    {
+        var destination = try tmp.dir.createFile(std.testing.io, "workspace/dest.bin", .{ .truncate = true });
+        defer destination.close(io_mod.getIo());
+        try destination.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
+    }
+
+    const workspace = try workspaceRoot(alloc, tmp);
+    defer alloc.free(workspace);
+    var tracker: change_tracker.ChangeTracker = .{};
+    defer tracker.deinit(std.heap.c_allocator);
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const input = testInput(arena_state.allocator(), workspace, &tracker);
+
+    _ = try executeCopy(
+        input,
+        testCall("copy_file", "{\"source\":\"source.txt\",\"destination\":\"dest.bin\",\"overwrite\":true}"),
+    );
+
+    // The destination predates the copy, so undo must never treat it as a file the copy created.
+    try std.testing.expectEqual(@as(usize, 1), tracker.stack.items.len);
+    try std.testing.expect(tracker.stack.items[0].preimage_unavailable);
+
+    const undo = tracker.undoLast(std.heap.c_allocator);
+    switch (undo) {
+        .unavailable => |path| std.heap.c_allocator.free(path),
+        else => return error.ExpectedUnavailable,
+    }
+    try std.testing.expect(pathExists(tmp.dir, "workspace/dest.bin"));
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
 
 const Allocator = std.mem.Allocator;
@@ -17,10 +18,21 @@ pub const FileOperation = struct {
     previous_content: ?[]u8,
     new_path: ?[]u8 = null,
     timestamp_ms: i64,
-    /// Set when state required to reverse the mutation could not be retained. Such
-    /// an operation is still recorded, so undo consumes it and says so, rather than
+    /// Records why state required to reverse the mutation could not be retained.
+    /// The operation remains a barrier, so undo consumes it and says so rather than
     /// silently undoing an older operation the user did not ask about.
-    preimage_unavailable: bool = false,
+    unavailable_cause: ?UnavailableCause = null,
+};
+
+pub const UnavailableStage = enum {
+    capture_open,
+    capture_read,
+    new_path_clone,
+};
+
+pub const UnavailableCause = struct {
+    stage: UnavailableStage,
+    err: anyerror,
 };
 
 pub const UndoResult = union(enum) {
@@ -40,8 +52,18 @@ pub const UndoResult = union(enum) {
 pub const CaptureResult = union(enum) {
     captured: []u8,
     absent,
-    unavailable,
+    unavailable: UnavailableCause,
 };
+
+const RollbackOutcome = union(enum) {
+    not_attempted,
+    succeeded,
+    failed: anyerror,
+};
+
+const UndoTestControl = if (builtin.is_test) struct {
+    before_rename_rollback: ?*const fn ([]const u8) void = null,
+} else struct {};
 
 pub const ChangeTracker = struct {
     stack: std.ArrayList(FileOperation) = .empty,
@@ -67,13 +89,22 @@ pub const ChangeTracker = struct {
     }
 
     pub fn undoLast(self: *ChangeTracker, alloc: Allocator) UndoResult {
+        return self.undoLastWithTestControl(alloc, .{});
+    }
+
+    fn undoLastWithTestControl(
+        self: *ChangeTracker,
+        alloc: Allocator,
+        test_control: UndoTestControl,
+    ) UndoResult {
         if (self.stack.items.len == 0) return .empty;
 
         const op = self.stack.pop().?;
         defer if (op.new_path) |new_path| alloc.free(new_path);
 
-        if (op.preimage_unavailable) {
+        if (op.unavailable_cause) |cause| {
             if (op.previous_content) |content| alloc.free(content);
+            traceUnavailable(op, @tagName(cause.stage), cause.err, .not_attempted);
             return .{ .unavailable = op.path };
         }
 
@@ -81,7 +112,8 @@ pub const ChangeTracker = struct {
             .delete => {
                 if (op.previous_content) |content| {
                     defer alloc.free(content);
-                    restoreContent(alloc, op.path, content) catch {
+                    restoreContent(alloc, op.path, content) catch |err| {
+                        traceUnavailable(op, "restore_deleted", err, .not_attempted);
                         return .{ .unavailable = op.path };
                     };
                     return .{ .restored = op.path };
@@ -91,18 +123,31 @@ pub const ChangeTracker = struct {
             },
             .rename => {
                 if (op.new_path) |new_path| {
-                    std.Io.Dir.renameAbsolute(new_path, op.path, io_mod.getIo()) catch {
+                    std.Io.Dir.renameAbsolute(new_path, op.path, io_mod.getIo()) catch |err| {
                         if (op.previous_content) |content| alloc.free(content);
+                        traceUnavailable(op, "rename_back", err, .not_attempted);
                         return .{ .unavailable = op.path };
                     };
                     // previous_content holds the overwritten destination preimage.
                     if (op.previous_content) |content| {
                         defer alloc.free(content);
-                        restoreContent(alloc, new_path, content) catch {
+                        restoreContent(alloc, new_path, content) catch |err| {
                             // The rename back succeeded but the file it displaced could
                             // not be put back. Undo the rename too, so the tree is left
                             // as it was rather than half reversed under a success report.
-                            std.Io.Dir.renameAbsolute(op.path, new_path, io_mod.getIo()) catch {};
+                            if (comptime builtin.is_test) {
+                                if (test_control.before_rename_rollback) |callback| callback(new_path);
+                            }
+                            const rollback: RollbackOutcome = if (std.Io.Dir.renameAbsolute(op.path, new_path, io_mod.getIo()))
+                                .succeeded
+                            else |rollback_err|
+                                .{ .failed = rollback_err };
+                            traceUnavailable(
+                                op,
+                                "restore_destination",
+                                err,
+                                rollback,
+                            );
                             return .{ .unavailable = op.path };
                         };
                     }
@@ -114,7 +159,8 @@ pub const ChangeTracker = struct {
             .write, .edit => {
                 if (op.previous_content) |content| {
                     defer alloc.free(content);
-                    restoreContent(alloc, op.path, content) catch {
+                    restoreContent(alloc, op.path, content) catch |err| {
+                        traceUnavailable(op, "restore_content", err, .not_attempted);
                         return .{ .unavailable = op.path };
                     };
                     return .{ .restored = op.path };
@@ -125,6 +171,7 @@ pub const ChangeTracker = struct {
                     // other failure leaves the file's state uncertain and must not
                     // be reported as a successful deletion.
                     if (err != error.FileNotFound) {
+                        traceUnavailable(op, "delete_created", err, .not_attempted);
                         return .{ .unavailable = op.path };
                     }
                 };
@@ -135,10 +182,16 @@ pub const ChangeTracker = struct {
 
     pub fn captureFileState(alloc: Allocator, absolute_path: []const u8) CaptureResult {
         var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), absolute_path, .{}) catch |err| {
-            return if (err == error.FileNotFound) .absent else .unavailable;
+            return if (err == error.FileNotFound) .absent else .{ .unavailable = .{
+                .stage = .capture_open,
+                .err = err,
+            } };
         };
         defer file.close(io_mod.getIo());
-        const content = io_mod.readFileToEnd(alloc, &file, 10 * 1024 * 1024) catch return .unavailable;
+        const content = io_mod.readFileToEnd(alloc, &file, 10 * 1024 * 1024) catch |err| return .{ .unavailable = .{
+            .stage = .capture_read,
+            .err = err,
+        } };
         return .{ .captured = content };
     }
 
@@ -146,19 +199,12 @@ pub const ChangeTracker = struct {
     /// until the replacement is durable. A failed restore leaves the current file
     /// untouched and is reported to the caller rather than swallowed.
     ///
-    /// Symlinks are resolved first, so undoing an edit to a linked file rewrites the
-    /// file the link points at instead of replacing the link with a regular file.
-    ///
     /// There is no in-place fallback for a file whose directory denies writes. Such a
     /// file cannot be replaced atomically, and writing the preimage over it directly
     /// would leave a half-replaced file behind on any mid-write failure, which is the
     /// damage undo exists to avoid. The caller reports the refusal instead.
     fn restoreContent(alloc: Allocator, absolute_path: []const u8, content: []const u8) !void {
-        const resolved = io_mod.realpathAlloc(alloc, absolute_path) catch null;
-        defer if (resolved) |path| alloc.free(path);
-        const target = resolved orelse absolute_path;
-
-        try io_mod.writeFileAtomic(alloc, target, content);
+        try io_mod.writeFileAtomic(alloc, absolute_path, content);
     }
 
     fn freeOperation(alloc: Allocator, op: FileOperation) void {
@@ -167,6 +213,39 @@ pub const ChangeTracker = struct {
         if (op.new_path) |new_path| alloc.free(new_path);
     }
 };
+
+fn traceUnavailable(
+    op: FileOperation,
+    stage: []const u8,
+    err: anyerror,
+    rollback: RollbackOutcome,
+) void {
+    var path_buf: [256]u8 = undefined;
+    const path = debug_trace.terminalPreview(path_buf[0..], op.path);
+    switch (rollback) {
+        .not_attempted => debug_trace.eventf(
+            "undo",
+            "undo_unavailable",
+            .{},
+            "kind={s} path={s} stage={s} error={s} rollback=not_attempted",
+            .{ @tagName(op.kind), path, stage, @errorName(err) },
+        ),
+        .succeeded => debug_trace.eventf(
+            "undo",
+            "undo_unavailable",
+            .{},
+            "kind={s} path={s} stage={s} error={s} rollback=succeeded",
+            .{ @tagName(op.kind), path, stage, @errorName(err) },
+        ),
+        .failed => |rollback_err| debug_trace.eventf(
+            "undo",
+            "undo_unavailable",
+            .{},
+            "kind={s} path={s} stage={s} error={s} rollback=failed rollback_error={s}",
+            .{ @tagName(op.kind), path, stage, @errorName(err), @errorName(rollback_err) },
+        ),
+    }
+}
 
 fn tmpPath(alloc: Allocator, dir: std.Io.Dir, name: []const u8) ![]u8 {
     const root = try io_mod.dirRealpathAlloc(alloc, dir, "");
@@ -191,6 +270,87 @@ fn expectMissing(path: []const u8) !void {
         file.close(io_mod.getIo());
         return error.FileStillExists;
     } else |_| {}
+}
+
+const FileSizeLimitGuard = struct {
+    saved_limit: std.posix.rlimit,
+    saved_action: std.posix.Sigaction,
+
+    fn restore(self: FileSizeLimitGuard) void {
+        std.posix.setrlimit(.FSIZE, self.saved_limit) catch {};
+        std.posix.sigaction(std.posix.SIG.XFSZ, &self.saved_action, null);
+    }
+};
+
+fn limitFileSizeForTest(bytes: u64, fail_after_signal: bool) !FileSizeLimitGuard {
+    var saved_action: std.posix.Sigaction = undefined;
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, &saved_action);
+    errdefer std.posix.sigaction(std.posix.SIG.XFSZ, &saved_action, null);
+    if (fail_after_signal) return error.InjectedSetupFailure;
+
+    const saved_limit = try std.posix.getrlimit(.FSIZE);
+    try std.posix.setrlimit(.FSIZE, .{ .cur = bytes, .max = saved_limit.max });
+    return .{ .saved_limit = saved_limit, .saved_action = saved_action };
+}
+
+fn expectSigactionEqual(expected: std.posix.Sigaction, actual: std.posix.Sigaction) !void {
+    try std.testing.expectEqual(expected.handler.handler, actual.handler.handler);
+    try std.testing.expectEqual(expected.flags, actual.flags);
+    try std.testing.expectEqualSlices(u8, std.mem.asBytes(&expected.mask), std.mem.asBytes(&actual.mask));
+    if (comptime @hasField(std.posix.Sigaction, "restorer")) {
+        try std.testing.expectEqual(expected.restorer, actual.restorer);
+    }
+}
+
+fn readUndoTrace(alloc: Allocator, tmp: std.testing.TmpDir, name: []const u8) ![]u8 {
+    const path = try tmpPath(alloc, tmp.dir, name);
+    defer alloc.free(path);
+    return readAbsolute(alloc, path);
+}
+
+test "file size limit guard restores SIGXFSZ after normal use" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+
+    var original: std.posix.Sigaction = undefined;
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.DFL },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, &original);
+    defer std.posix.sigaction(std.posix.SIG.XFSZ, &original, null);
+
+    var expected: std.posix.Sigaction = undefined;
+    std.posix.sigaction(std.posix.SIG.XFSZ, null, &expected);
+    const guard = try limitFileSizeForTest(4096, false);
+    guard.restore();
+
+    var actual: std.posix.Sigaction = undefined;
+    std.posix.sigaction(std.posix.SIG.XFSZ, null, &actual);
+    try expectSigactionEqual(expected, actual);
+}
+
+test "file size limit setup restores SIGXFSZ on failure" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+
+    var original: std.posix.Sigaction = undefined;
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.DFL },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, &original);
+    defer std.posix.sigaction(std.posix.SIG.XFSZ, &original, null);
+
+    var expected: std.posix.Sigaction = undefined;
+    std.posix.sigaction(std.posix.SIG.XFSZ, null, &expected);
+    try std.testing.expectError(error.InjectedSetupFailure, limitFileSizeForTest(4096, true));
+
+    var actual: std.posix.Sigaction = undefined;
+    std.posix.sigaction(std.posix.SIG.XFSZ, null, &actual);
+    try expectSigactionEqual(expected, actual);
 }
 
 test "undoLast returns empty on an initially empty stack" {
@@ -544,7 +704,7 @@ test "undoLast refuses rename operations without the required new_path" {
         .path = try alloc.dupe(u8, "/workspace/original.txt"),
         .previous_content = try alloc.dupe(u8, "previous"),
         .timestamp_ms = 1,
-        .preimage_unavailable = true,
+        .unavailable_cause = .{ .stage = .new_path_clone, .err = error.OutOfMemory },
     });
 
     const result = tracker.undoLast(alloc);
@@ -617,7 +777,10 @@ test "captureFileState reports unavailable for files at the size limit" {
     defer file.close(io_mod.getIo());
     try file.setLength(io_mod.getIo(), 10 * 1024 * 1024);
 
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == .unavailable);
+    switch (ChangeTracker.captureFileState(alloc, path)) {
+        .unavailable => |cause| try std.testing.expectEqual(UnavailableStage.capture_read, cause.stage),
+        else => return error.ExpectedUnavailable,
+    }
 }
 
 test "captureFileState reports unavailable for files over the size limit" {
@@ -632,7 +795,10 @@ test "captureFileState reports unavailable for files over the size limit" {
     defer file.close(io_mod.getIo());
     try file.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
 
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == .unavailable);
+    switch (ChangeTracker.captureFileState(alloc, path)) {
+        .unavailable => |cause| try std.testing.expectEqual(UnavailableStage.capture_read, cause.stage),
+        else => return error.ExpectedUnavailable,
+    }
 }
 
 test "undoLast leaves the original file intact when the restore write fails" {
@@ -661,14 +827,8 @@ test "undoLast leaves the original file intact when the restore write fails" {
     });
 
     // Fail every write past 4 KiB, without the file-size signal killing the test process.
-    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
-        .handler = .{ .handler = std.posix.SIG.IGN },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    }, null);
-    const saved_limit = try std.posix.getrlimit(.FSIZE);
-    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
-    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+    const file_size_guard = try limitFileSizeForTest(4096, false);
+    defer file_size_guard.restore();
 
     switch (tracker.undoLast(alloc)) {
         .unavailable => |reported| alloc.free(reported),
@@ -697,13 +857,22 @@ test "captureFileState separates absent from unavailable" {
         defer file.close(io_mod.getIo());
         try file.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
     }
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, oversized_path) == .unavailable);
+    switch (ChangeTracker.captureFileState(alloc, oversized_path)) {
+        .unavailable => |cause| try std.testing.expectEqual(UnavailableStage.capture_read, cause.stage),
+        else => return error.ExpectedUnavailable,
+    }
 }
 
 test "undoLast refuses an operation whose preimage was never captured" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
+    const trace_path = try tmpPath(alloc, tmp.dir, "preimage-unavailable.log");
+    defer alloc.free(trace_path);
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "undo");
+
     const path = try tmpPath(alloc, tmp.dir, "uncaptured.txt");
     defer alloc.free(path);
     defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), path) catch {};
@@ -717,7 +886,7 @@ test "undoLast refuses an operation whose preimage was never captured" {
         .path = try alloc.dupe(u8, path),
         .previous_content = null,
         .timestamp_ms = 1,
-        .preimage_unavailable = true,
+        .unavailable_cause = .{ .stage = .capture_read, .err = error.FileTooBig },
     });
 
     switch (tracker.undoLast(alloc)) {
@@ -728,6 +897,14 @@ test "undoLast refuses an operation whose preimage was never captured" {
     const survived = try readAbsolute(alloc, path);
     defer alloc.free(survived);
     try std.testing.expectEqualStrings("content the tool did not create", survived);
+
+    const trace = try readUndoTrace(alloc, tmp, "preimage-unavailable.log");
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(u8, trace, "event=undo_unavailable") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "kind=write") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "stage=capture_read") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "error=FileTooBig") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "rollback=not_attempted") != null);
 }
 
 test "undo refuses a file whose directory denies writes and leaves it intact" {
@@ -767,36 +944,42 @@ test "undo refuses a file whose directory denies writes and leaves it intact" {
     try std.testing.expectEqualStrings("current bytes", survived);
 }
 
-test "undo rewrites the file a symlink points at rather than replacing the link" {
+test "undo restore cannot be redirected by a symlink introduced after capture" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const real_path = try tmpPath(alloc, tmp.dir, "real.txt");
-    defer alloc.free(real_path);
-    const link_path = try tmpPath(alloc, tmp.dir, "link.txt");
-    defer alloc.free(link_path);
-    try writeAbsolute(real_path, "current bytes");
-    tmp.dir.symLink(std.testing.io, real_path, "link.txt", .{ .is_directory = false }) catch return error.SkipZigTest;
+    const recorded_path = try tmpPath(alloc, tmp.dir, "recorded.txt");
+    defer alloc.free(recorded_path);
+    const redirect_target = try tmpPath(alloc, tmp.dir, "redirect-target.txt");
+    defer alloc.free(redirect_target);
+    try writeAbsolute(recorded_path, "current bytes");
+    try writeAbsolute(redirect_target, "must stay untouched");
 
     var tracker: ChangeTracker = .{};
     defer tracker.deinit(alloc);
     try tracker.pushOperation(alloc, .{
         .kind = .edit,
-        .path = try alloc.dupe(u8, link_path),
+        .path = try alloc.dupe(u8, recorded_path),
         .previous_content = try alloc.dupe(u8, "preimage bytes"),
         .timestamp_ms = 1,
     });
+
+    try std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), recorded_path);
+    tmp.dir.symLink(std.testing.io, redirect_target, "recorded.txt", .{ .is_directory = false }) catch return error.SkipZigTest;
 
     switch (tracker.undoLast(alloc)) {
         .restored => |restored| alloc.free(restored),
         else => return error.ExpectedRestore,
     }
 
-    const link_stat = try tmp.dir.statFile(io_mod.getIo(), "link.txt", .{ .follow_symlinks = false });
-    try std.testing.expectEqual(std.Io.File.Kind.sym_link, link_stat.kind);
-    const through_link = try readAbsolute(alloc, real_path);
-    defer alloc.free(through_link);
-    try std.testing.expectEqualStrings("preimage bytes", through_link);
+    const restored_stat = try tmp.dir.statFile(io_mod.getIo(), "recorded.txt", .{ .follow_symlinks = false });
+    try std.testing.expectEqual(std.Io.File.Kind.file, restored_stat.kind);
+    const restored = try readAbsolute(alloc, recorded_path);
+    defer alloc.free(restored);
+    try std.testing.expectEqualStrings("preimage bytes", restored);
+    const untouched = try readAbsolute(alloc, redirect_target);
+    defer alloc.free(untouched);
+    try std.testing.expectEqualStrings("must stay untouched", untouched);
 }
 
 test "undo rolls back a rename when the displaced file cannot be restored" {
@@ -804,6 +987,12 @@ test "undo rolls back a rename when the displaced file cannot be restored" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
+    const trace_path = try tmpPath(alloc, tmp.dir, "rename-rollback.log");
+    defer alloc.free(trace_path);
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "undo");
+
     const old_path = try tmpPath(alloc, tmp.dir, "old.txt");
     defer alloc.free(old_path);
     const new_path = try tmpPath(alloc, tmp.dir, "new.txt");
@@ -824,14 +1013,8 @@ test "undo rolls back a rename when the displaced file cannot be restored" {
         .timestamp_ms = 1,
     });
 
-    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
-        .handler = .{ .handler = std.posix.SIG.IGN },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    }, null);
-    const saved_limit = try std.posix.getrlimit(.FSIZE);
-    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
-    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+    const file_size_guard = try limitFileSizeForTest(4096, false);
+    defer file_size_guard.restore();
 
     switch (tracker.undoLast(alloc)) {
         .unavailable => |reported| alloc.free(reported),
@@ -843,6 +1026,74 @@ test "undo rolls back a rename when the displaced file cannot be restored" {
     defer alloc.free(displaced);
     try std.testing.expectEqualStrings("renamed content", displaced);
     try expectMissing(old_path);
+
+    const trace = try readUndoTrace(alloc, tmp, "rename-rollback.log");
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(u8, trace, "event=undo_unavailable") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "kind=rename") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "stage=restore_destination") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "rollback=succeeded") != null);
+}
+
+test "undo traces a failed rename rollback" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const trace_path = try tmpPath(alloc, tmp.dir, "rename-rollback-failure.log");
+    defer alloc.free(trace_path);
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "undo");
+
+    const old_path = try tmpPath(alloc, tmp.dir, "old.txt");
+    defer alloc.free(old_path);
+    const new_path = try tmpPath(alloc, tmp.dir, "new.txt");
+    defer alloc.free(new_path);
+    try writeAbsolute(new_path, "renamed content");
+
+    const preimage = try alloc.alloc(u8, 64 * 1024);
+    defer alloc.free(preimage);
+    @memset(preimage, 'D');
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .rename,
+        .path = try alloc.dupe(u8, old_path),
+        .new_path = try alloc.dupe(u8, new_path),
+        .previous_content = try alloc.dupe(u8, preimage),
+        .timestamp_ms = 1,
+    });
+
+    const file_size_guard = try limitFileSizeForTest(4096, false);
+    defer file_size_guard.restore();
+
+    const InjectRollbackFailure = struct {
+        fn beforeRollback(path: []const u8) void {
+            std.Io.Dir.createDirAbsolute(io_mod.getIo(), path, .default_dir) catch unreachable;
+        }
+    };
+    switch (tracker.undoLastWithTestControl(alloc, .{
+        .before_rename_rollback = InjectRollbackFailure.beforeRollback,
+    })) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
+
+    const source = try readAbsolute(alloc, old_path);
+    defer alloc.free(source);
+    try std.testing.expectEqualStrings("renamed content", source);
+    const blocked_target = try tmp.dir.statFile(io_mod.getIo(), "new.txt", .{ .follow_symlinks = false });
+    try std.testing.expectEqual(std.Io.File.Kind.directory, blocked_target.kind);
+
+    const trace = try readUndoTrace(alloc, tmp, "rename-rollback-failure.log");
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(u8, trace, "event=undo_unavailable") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "kind=rename") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "stage=restore_destination") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "rollback=failed") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "rollback_error=") != null);
 }
 
 test "a locked directory plus a failing write never leaves a half-replaced file" {
@@ -879,14 +1130,8 @@ test "a locked directory plus a failing write never leaves a half-replaced file"
     if (std.c.chmod(dir_path_z.ptr, 0o500) != 0) return error.SkipZigTest;
     defer _ = std.c.chmod(dir_path_z.ptr, 0o700);
 
-    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
-        .handler = .{ .handler = std.posix.SIG.IGN },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    }, null);
-    const saved_limit = try std.posix.getrlimit(.FSIZE);
-    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
-    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+    const file_size_guard = try limitFileSizeForTest(4096, false);
+    defer file_size_guard.restore();
 
     switch (tracker.undoLast(alloc)) {
         .unavailable => |reported| alloc.free(reported),

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -17,8 +17,8 @@ pub const FileOperation = struct {
     previous_content: ?[]u8,
     new_path: ?[]u8 = null,
     timestamp_ms: i64,
-    /// Set when the file's state before the mutation could not be read. Such an
-    /// operation is still recorded, so undo consumes it and says so, rather than
+    /// Set when state required to reverse the mutation could not be retained. Such
+    /// an operation is still recorded, so undo consumes it and says so, rather than
     /// silently undoing an older operation the user did not ask about.
     preimage_unavailable: bool = false,
 };
@@ -534,7 +534,7 @@ test "undoLast reports unavailable when renaming back fails" {
     try std.testing.expect(tracker.undoLast(alloc) == .empty);
 }
 
-test "undoLast returns restored for rename operations without new_path" {
+test "undoLast refuses rename operations without the required new_path" {
     const alloc = std.testing.allocator;
     var tracker: ChangeTracker = .{};
     defer tracker.deinit(alloc);
@@ -544,15 +544,16 @@ test "undoLast returns restored for rename operations without new_path" {
         .path = try alloc.dupe(u8, "/workspace/original.txt"),
         .previous_content = try alloc.dupe(u8, "previous"),
         .timestamp_ms = 1,
+        .preimage_unavailable = true,
     });
 
     const result = tracker.undoLast(alloc);
     switch (result) {
-        .restored => |restored_path| {
-            defer alloc.free(restored_path);
-            try std.testing.expectEqualStrings("/workspace/original.txt", restored_path);
+        .unavailable => |reported_path| {
+            defer alloc.free(reported_path);
+            try std.testing.expectEqualStrings("/workspace/original.txt", reported_path);
         },
-        else => return error.ExpectedRestore,
+        else => return error.ExpectedUnavailable,
     }
 }
 

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -93,8 +93,7 @@ pub const ChangeTracker = struct {
                 if (op.new_path) |new_path| {
                     std.Io.Dir.renameAbsolute(new_path, op.path, io_mod.getIo()) catch {
                         if (op.previous_content) |content| alloc.free(content);
-                        alloc.free(op.path);
-                        return .empty;
+                        return .{ .unavailable = op.path };
                     };
                     // previous_content holds the overwritten destination preimage.
                     if (op.previous_content) |content| {
@@ -121,7 +120,14 @@ pub const ChangeTracker = struct {
                     return .{ .restored = op.path };
                 }
 
-                std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), op.path) catch {};
+                std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), op.path) catch |err| {
+                    // An already-absent file has reached the requested state. Every
+                    // other failure leaves the file's state uncertain and must not
+                    // be reported as a successful deletion.
+                    if (err != error.FileNotFound) {
+                        return .{ .unavailable = op.path };
+                    }
+                };
                 return .{ .deleted = op.path };
             },
         }
@@ -335,6 +341,46 @@ test "undoLast reports deleted for a new write when the file is already absent" 
     try expectMissing(path);
 }
 
+test "undoLast reports unavailable when a new file cannot be deleted" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "locked");
+    const path = try tmpPath(alloc, tmp.dir, "locked/new.txt");
+    defer alloc.free(path);
+    try writeAbsolute(path, "new content");
+
+    const dir_path = try tmpPath(alloc, tmp.dir, "locked");
+    defer alloc.free(dir_path);
+    const dir_path_z = try alloc.dupeZ(u8, dir_path);
+    defer alloc.free(dir_path_z);
+    if (std.c.chmod(dir_path_z.ptr, 0o500) != 0) return error.SkipZigTest;
+    defer _ = std.c.chmod(dir_path_z.ptr, 0o700);
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .write,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = null,
+        .timestamp_ms = 1,
+    });
+
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported_path| {
+            defer alloc.free(reported_path);
+            try std.testing.expectEqualStrings(path, reported_path);
+        },
+        else => return error.ExpectedUnavailable,
+    }
+    try std.testing.expectEqual(@as(usize, 0), tracker.stack.items.len);
+
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings("new content", survived);
+}
+
 test "undoLast restores deleted files when previous content exists" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -458,7 +504,7 @@ test "undoLast restores destination preimage after overwrite rename" {
     try std.testing.expectEqualStrings("dest-preimage", dest);
 }
 
-test "undoLast consumes rename operations when renaming back fails" {
+test "undoLast reports unavailable when renaming back fails" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -477,7 +523,13 @@ test "undoLast consumes rename operations when renaming back fails" {
         .timestamp_ms = 1,
     });
 
-    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported_path| {
+            defer alloc.free(reported_path);
+            try std.testing.expectEqualStrings(old_path, reported_path);
+        },
+        else => return error.ExpectedUnavailable,
+    }
     try std.testing.expectEqual(@as(usize, 0), tracker.stack.items.len);
     try std.testing.expect(tracker.undoLast(alloc) == .empty);
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -835,29 +835,6 @@ test "undoLast leaves the original file intact when the restore write fails" {
     try std.testing.expectEqualStrings(current, survived);
 }
 
-test "captureFileState separates absent from unavailable" {
-    const alloc = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    const missing_path = try tmpPath(alloc, tmp.dir, "missing.txt");
-    defer alloc.free(missing_path);
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, missing_path) == .absent);
-
-    const oversized_path = try tmpPath(alloc, tmp.dir, "oversized.bin");
-    defer alloc.free(oversized_path);
-    defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), oversized_path) catch {};
-    {
-        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), oversized_path, .{ .truncate = true });
-        defer file.close(io_mod.getIo());
-        try file.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
-    }
-    switch (ChangeTracker.captureFileState(alloc, oversized_path)) {
-        .unavailable => |cause| try std.testing.expectEqual(UnavailableStage.capture_read, cause.stage),
-        else => return error.ExpectedUnavailable,
-    }
-}
-
 test "undoLast refuses an operation whose preimage was never captured" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -82,8 +82,7 @@ pub const ChangeTracker = struct {
                 if (op.previous_content) |content| {
                     defer alloc.free(content);
                     restoreContent(alloc, op.path, content) catch {
-                        alloc.free(op.path);
-                        return .empty;
+                        return .{ .unavailable = op.path };
                     };
                     return .{ .restored = op.path };
                 }
@@ -104,11 +103,8 @@ pub const ChangeTracker = struct {
                             // The rename back succeeded but the file it displaced could
                             // not be put back. Undo the rename too, so the tree is left
                             // as it was rather than half reversed under a success report.
-                            std.Io.Dir.renameAbsolute(op.path, new_path, io_mod.getIo()) catch {
-                                return .{ .unavailable = op.path };
-                            };
-                            alloc.free(op.path);
-                            return .empty;
+                            std.Io.Dir.renameAbsolute(op.path, new_path, io_mod.getIo()) catch {};
+                            return .{ .unavailable = op.path };
                         };
                     }
                     return .{ .restored = op.path };
@@ -120,8 +116,7 @@ pub const ChangeTracker = struct {
                 if (op.previous_content) |content| {
                     defer alloc.free(content);
                     restoreContent(alloc, op.path, content) catch {
-                        alloc.free(op.path);
-                        return .empty;
+                        return .{ .unavailable = op.path };
                     };
                     return .{ .restored = op.path };
                 }
@@ -145,32 +140,19 @@ pub const ChangeTracker = struct {
     /// until the replacement is durable. A failed restore leaves the current file
     /// untouched and is reported to the caller rather than swallowed.
     ///
-    /// Two properties of the old truncate-in-place restore are kept deliberately.
     /// Symlinks are resolved first, so undoing an edit to a linked file rewrites the
-    /// file the link points at instead of replacing the link with a regular file. And
-    /// a directory that denies writes still permits an in-place restore, because
-    /// rewriting an existing file never needed permission on its parent; that path
-    /// cannot be atomic, so it is taken only when the atomic one is refused.
+    /// file the link points at instead of replacing the link with a regular file.
+    ///
+    /// There is no in-place fallback for a file whose directory denies writes. Such a
+    /// file cannot be replaced atomically, and writing the preimage over it directly
+    /// would leave a half-replaced file behind on any mid-write failure, which is the
+    /// damage undo exists to avoid. The caller reports the refusal instead.
     fn restoreContent(alloc: Allocator, absolute_path: []const u8, content: []const u8) !void {
         const resolved = io_mod.realpathAlloc(alloc, absolute_path) catch null;
         defer if (resolved) |path| alloc.free(path);
         const target = resolved orelse absolute_path;
 
-        io_mod.writeFileAtomic(alloc, target, content) catch |err| switch (err) {
-            error.AccessDenied, error.ReadOnlyFileSystem => try restoreInPlace(target, content),
-            else => return err,
-        };
-    }
-
-    /// Rewrites `content` over an existing file without unlinking it. The file is
-    /// truncated to the restored length only after every byte is written, so a failed
-    /// write cannot shorten it and is still reported.
-    fn restoreInPlace(absolute_path: []const u8, content: []const u8) !void {
-        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), absolute_path, .{ .truncate = false });
-        defer file.close(io_mod.getIo());
-        try file.writeStreamingAll(io_mod.getIo(), content);
-        try file.setLength(io_mod.getIo(), content.len);
-        try file.sync(io_mod.getIo());
+        try io_mod.writeFileAtomic(alloc, target, content);
     }
 
     fn freeOperation(alloc: Allocator, op: FileOperation) void {
@@ -522,7 +504,7 @@ test "undoLast returns restored for rename operations without new_path" {
     }
 }
 
-test "undoLast pops before filesystem restore failures and does not create parents" {
+test "undoLast pops before filesystem restore failures, reports them, and does not create parents" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -538,9 +520,13 @@ test "undoLast pops before filesystem restore failures and does not create paren
         .timestamp_ms = 1,
     });
 
-    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
     try std.testing.expectEqual(@as(usize, 0), tracker.stack.items.len);
     try expectMissing(path);
+    // The stack is empty now, which is a different answer from a failed restore.
     try std.testing.expect(tracker.undoLast(alloc) == .empty);
 }
 
@@ -631,7 +617,10 @@ test "undoLast leaves the original file intact when the restore write fails" {
     try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
     defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
 
-    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
 
     const survived = try readAbsolute(alloc, path);
     defer alloc.free(survived);
@@ -688,7 +677,7 @@ test "undoLast refuses an operation whose preimage was never captured" {
     try std.testing.expectEqualStrings("content the tool did not create", survived);
 }
 
-test "undo restores a file whose directory denies writes" {
+test "undo refuses a file whose directory denies writes and leaves it intact" {
     if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -714,13 +703,15 @@ test "undo restores a file whose directory denies writes" {
         .timestamp_ms = 1,
     });
 
+    // The file cannot be replaced atomically here, and a direct overwrite could
+    // leave it half replaced, so undo reports that it could not act.
     switch (tracker.undoLast(alloc)) {
-        .restored => |restored| alloc.free(restored),
-        else => return error.ExpectedRestore,
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
     }
     const survived = try readAbsolute(alloc, path);
     defer alloc.free(survived);
-    try std.testing.expectEqualStrings("preimage bytes", survived);
+    try std.testing.expectEqualStrings("current bytes", survived);
 }
 
 test "undo rewrites the file a symlink points at rather than replacing the link" {
@@ -789,11 +780,68 @@ test "undo rolls back a rename when the displaced file cannot be restored" {
     try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
     defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
 
-    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
 
     // The tree is left exactly as it was before the undo attempt.
     const displaced = try readAbsolute(alloc, new_path);
     defer alloc.free(displaced);
     try std.testing.expectEqualStrings("renamed content", displaced);
     try expectMissing(old_path);
+}
+
+test "a locked directory plus a failing write never leaves a half-replaced file" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "locked");
+    const path = try tmpPath(alloc, tmp.dir, "locked/file.txt");
+    defer alloc.free(path);
+
+    const current = "the bytes the user has right now";
+    try writeAbsolute(path, current);
+
+    // Large enough that any direct overwrite would be cut short by the limit
+    // below, which is what would leave a prefix of preimage bytes behind.
+    const preimage = try alloc.alloc(u8, 64 * 1024);
+    defer alloc.free(preimage);
+    @memset(preimage, 'R');
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .edit,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = try alloc.dupe(u8, preimage),
+        .timestamp_ms = 1,
+    });
+
+    const dir_path = try tmpPath(alloc, tmp.dir, "locked");
+    defer alloc.free(dir_path);
+    const dir_path_z = try alloc.dupeZ(u8, dir_path);
+    defer alloc.free(dir_path_z);
+    if (std.c.chmod(dir_path_z.ptr, 0o500) != 0) return error.SkipZigTest;
+    defer _ = std.c.chmod(dir_path_z.ptr, 0o700);
+
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, null);
+    const saved_limit = try std.posix.getrlimit(.FSIZE);
+    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
+    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
+
+    // Not shortened, not partly rewritten: exactly the bytes that were there.
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings(current, survived);
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const io_mod = @import("../shared/io.zig");
 
 const Allocator = std.mem.Allocator;
@@ -16,12 +17,30 @@ pub const FileOperation = struct {
     previous_content: ?[]u8,
     new_path: ?[]u8 = null,
     timestamp_ms: i64,
+    /// Set when the file's state before the mutation could not be read. Such an
+    /// operation is still recorded, so undo consumes it and says so, rather than
+    /// silently undoing an older operation the user did not ask about.
+    preimage_unavailable: bool = false,
 };
 
 pub const UndoResult = union(enum) {
     restored: []const u8,
     deleted: []const u8,
+    /// The operation was consumed but could not be reversed, either because its
+    /// preimage was never captured or because restoring it failed. Undo must not
+    /// guess, and must not report this as a restore.
+    unavailable: []const u8,
     empty,
+};
+
+/// The state of a file before a mutation. `absent` means the file was proven not to
+/// exist, which is the only case that licenses undo to delete it again; `unavailable`
+/// means the state could not be read (too large, permissions, IO error) and nothing
+/// about the file may be assumed.
+pub const CaptureResult = union(enum) {
+    captured: []u8,
+    absent,
+    unavailable,
 };
 
 pub const ChangeTracker = struct {
@@ -53,17 +72,19 @@ pub const ChangeTracker = struct {
         const op = self.stack.pop().?;
         defer if (op.new_path) |new_path| alloc.free(new_path);
 
+        if (op.preimage_unavailable) {
+            if (op.previous_content) |content| alloc.free(content);
+            return .{ .unavailable = op.path };
+        }
+
         switch (op.kind) {
             .delete => {
                 if (op.previous_content) |content| {
-                    var file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), op.path, .{ .truncate = true }) catch {
-                        alloc.free(content);
+                    defer alloc.free(content);
+                    restoreContent(alloc, op.path, content) catch {
                         alloc.free(op.path);
                         return .empty;
                     };
-                    defer file.close(io_mod.getIo());
-                    file.writeStreamingAll(io_mod.getIo(), content) catch {};
-                    alloc.free(content);
                     return .{ .restored = op.path };
                 }
                 alloc.free(op.path);
@@ -78,13 +99,17 @@ pub const ChangeTracker = struct {
                     };
                     // previous_content holds the overwritten destination preimage.
                     if (op.previous_content) |content| {
-                        var file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), new_path, .{ .truncate = true }) catch {
-                            alloc.free(content);
-                            return .{ .restored = op.path };
+                        defer alloc.free(content);
+                        restoreContent(alloc, new_path, content) catch {
+                            // The rename back succeeded but the file it displaced could
+                            // not be put back. Undo the rename too, so the tree is left
+                            // as it was rather than half reversed under a success report.
+                            std.Io.Dir.renameAbsolute(op.path, new_path, io_mod.getIo()) catch {
+                                return .{ .unavailable = op.path };
+                            };
+                            alloc.free(op.path);
+                            return .empty;
                         };
-                        defer file.close(io_mod.getIo());
-                        file.writeStreamingAll(io_mod.getIo(), content) catch {};
-                        alloc.free(content);
                     }
                     return .{ .restored = op.path };
                 }
@@ -93,14 +118,11 @@ pub const ChangeTracker = struct {
             },
             .write, .edit => {
                 if (op.previous_content) |content| {
-                    var file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), op.path, .{ .truncate = true }) catch {
-                        alloc.free(content);
+                    defer alloc.free(content);
+                    restoreContent(alloc, op.path, content) catch {
                         alloc.free(op.path);
                         return .empty;
                     };
-                    defer file.close(io_mod.getIo());
-                    file.writeStreamingAll(io_mod.getIo(), content) catch {};
-                    alloc.free(content);
                     return .{ .restored = op.path };
                 }
 
@@ -110,10 +132,45 @@ pub const ChangeTracker = struct {
         }
     }
 
-    pub fn captureFileState(alloc: Allocator, absolute_path: []const u8) ?[]u8 {
-        var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), absolute_path, .{}) catch return null;
+    pub fn captureFileState(alloc: Allocator, absolute_path: []const u8) CaptureResult {
+        var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), absolute_path, .{}) catch |err| {
+            return if (err == error.FileNotFound) .absent else .unavailable;
+        };
         defer file.close(io_mod.getIo());
-        return io_mod.readFileToEnd(alloc, &file, 10 * 1024 * 1024) catch null;
+        const content = io_mod.readFileToEnd(alloc, &file, 10 * 1024 * 1024) catch return .unavailable;
+        return .{ .captured = content };
+    }
+
+    /// Restores `content` at `absolute_path` without destroying what is already there
+    /// until the replacement is durable. A failed restore leaves the current file
+    /// untouched and is reported to the caller rather than swallowed.
+    ///
+    /// Two properties of the old truncate-in-place restore are kept deliberately.
+    /// Symlinks are resolved first, so undoing an edit to a linked file rewrites the
+    /// file the link points at instead of replacing the link with a regular file. And
+    /// a directory that denies writes still permits an in-place restore, because
+    /// rewriting an existing file never needed permission on its parent; that path
+    /// cannot be atomic, so it is taken only when the atomic one is refused.
+    fn restoreContent(alloc: Allocator, absolute_path: []const u8, content: []const u8) !void {
+        const resolved = io_mod.realpathAlloc(alloc, absolute_path) catch null;
+        defer if (resolved) |path| alloc.free(path);
+        const target = resolved orelse absolute_path;
+
+        io_mod.writeFileAtomic(alloc, target, content) catch |err| switch (err) {
+            error.AccessDenied, error.ReadOnlyFileSystem => try restoreInPlace(target, content),
+            else => return err,
+        };
+    }
+
+    /// Rewrites `content` over an existing file without unlinking it. The file is
+    /// truncated to the restored length only after every byte is written, so a failed
+    /// write cannot shorten it and is still reported.
+    fn restoreInPlace(absolute_path: []const u8, content: []const u8) !void {
+        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), absolute_path, .{ .truncate = false });
+        defer file.close(io_mod.getIo());
+        try file.writeStreamingAll(io_mod.getIo(), content);
+        try file.setLength(io_mod.getIo(), content.len);
+        try file.sync(io_mod.getIo());
     }
 
     fn freeOperation(alloc: Allocator, op: FileOperation) void {
@@ -497,16 +554,19 @@ test "captureFileState captures existing files and returns null for missing file
 
     try writeAbsolute(path, "snapshot");
 
-    const captured = ChangeTracker.captureFileState(alloc, path) orelse return error.ExpectedCapture;
+    const captured = switch (ChangeTracker.captureFileState(alloc, path)) {
+        .captured => |content| content,
+        else => return error.ExpectedCapture,
+    };
     defer alloc.free(captured);
     try std.testing.expectEqualStrings("snapshot", captured);
 
     const missing_path = try tmpPath(alloc, tmp.dir, "missing.txt");
     defer alloc.free(missing_path);
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, missing_path) == null);
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, missing_path) == .absent);
 }
 
-test "captureFileState returns null for files at the size limit" {
+test "captureFileState reports unavailable for files at the size limit" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -518,10 +578,10 @@ test "captureFileState returns null for files at the size limit" {
     defer file.close(io_mod.getIo());
     try file.setLength(io_mod.getIo(), 10 * 1024 * 1024);
 
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == null);
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == .unavailable);
 }
 
-test "captureFileState returns null for files over the size limit" {
+test "captureFileState reports unavailable for files over the size limit" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -533,5 +593,207 @@ test "captureFileState returns null for files over the size limit" {
     defer file.close(io_mod.getIo());
     try file.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
 
-    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == null);
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, path) == .unavailable);
+}
+
+test "undoLast leaves the original file intact when the restore write fails" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try tmpPath(alloc, tmp.dir, "restore-target.txt");
+    defer alloc.free(path);
+    defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), path) catch {};
+
+    const current = "bytes the user still has on disk";
+    try writeAbsolute(path, current);
+
+    const preimage = try alloc.alloc(u8, 64 * 1024);
+    defer alloc.free(preimage);
+    @memset(preimage, 'R');
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .write,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = try alloc.dupe(u8, preimage),
+        .timestamp_ms = 1,
+    });
+
+    // Fail every write past 4 KiB, without the file-size signal killing the test process.
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, null);
+    const saved_limit = try std.posix.getrlimit(.FSIZE);
+    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
+    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+
+    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings(current, survived);
+}
+
+test "captureFileState separates absent from unavailable" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const missing_path = try tmpPath(alloc, tmp.dir, "missing.txt");
+    defer alloc.free(missing_path);
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, missing_path) == .absent);
+
+    const oversized_path = try tmpPath(alloc, tmp.dir, "oversized.bin");
+    defer alloc.free(oversized_path);
+    defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), oversized_path) catch {};
+    {
+        var file = try std.Io.Dir.createFileAbsolute(io_mod.getIo(), oversized_path, .{ .truncate = true });
+        defer file.close(io_mod.getIo());
+        try file.setLength(io_mod.getIo(), 10 * 1024 * 1024 + 1);
+    }
+    try std.testing.expect(ChangeTracker.captureFileState(alloc, oversized_path) == .unavailable);
+}
+
+test "undoLast refuses an operation whose preimage was never captured" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const path = try tmpPath(alloc, tmp.dir, "uncaptured.txt");
+    defer alloc.free(path);
+    defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), path) catch {};
+
+    try writeAbsolute(path, "content the tool did not create");
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .write,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = null,
+        .timestamp_ms = 1,
+        .preimage_unavailable = true,
+    });
+
+    switch (tracker.undoLast(alloc)) {
+        .unavailable => |reported| alloc.free(reported),
+        else => return error.ExpectedUnavailable,
+    }
+
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings("content the tool did not create", survived);
+}
+
+test "undo restores a file whose directory denies writes" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "locked");
+    const path = try tmpPath(alloc, tmp.dir, "locked/file.txt");
+    defer alloc.free(path);
+    try writeAbsolute(path, "current bytes");
+
+    const dir_path = try tmpPath(alloc, tmp.dir, "locked");
+    defer alloc.free(dir_path);
+    const dir_path_z = try alloc.dupeZ(u8, dir_path);
+    defer alloc.free(dir_path_z);
+    if (std.c.chmod(dir_path_z.ptr, 0o500) != 0) return error.SkipZigTest;
+    defer _ = std.c.chmod(dir_path_z.ptr, 0o700);
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .edit,
+        .path = try alloc.dupe(u8, path),
+        .previous_content = try alloc.dupe(u8, "preimage bytes"),
+        .timestamp_ms = 1,
+    });
+
+    switch (tracker.undoLast(alloc)) {
+        .restored => |restored| alloc.free(restored),
+        else => return error.ExpectedRestore,
+    }
+    const survived = try readAbsolute(alloc, path);
+    defer alloc.free(survived);
+    try std.testing.expectEqualStrings("preimage bytes", survived);
+}
+
+test "undo rewrites the file a symlink points at rather than replacing the link" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const real_path = try tmpPath(alloc, tmp.dir, "real.txt");
+    defer alloc.free(real_path);
+    const link_path = try tmpPath(alloc, tmp.dir, "link.txt");
+    defer alloc.free(link_path);
+    try writeAbsolute(real_path, "current bytes");
+    tmp.dir.symLink(std.testing.io, real_path, "link.txt", .{ .is_directory = false }) catch return error.SkipZigTest;
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .edit,
+        .path = try alloc.dupe(u8, link_path),
+        .previous_content = try alloc.dupe(u8, "preimage bytes"),
+        .timestamp_ms = 1,
+    });
+
+    switch (tracker.undoLast(alloc)) {
+        .restored => |restored| alloc.free(restored),
+        else => return error.ExpectedRestore,
+    }
+
+    const link_stat = try tmp.dir.statFile(io_mod.getIo(), "link.txt", .{ .follow_symlinks = false });
+    try std.testing.expectEqual(std.Io.File.Kind.sym_link, link_stat.kind);
+    const through_link = try readAbsolute(alloc, real_path);
+    defer alloc.free(through_link);
+    try std.testing.expectEqualStrings("preimage bytes", through_link);
+}
+
+test "undo rolls back a rename when the displaced file cannot be restored" {
+    if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const old_path = try tmpPath(alloc, tmp.dir, "old.txt");
+    defer alloc.free(old_path);
+    const new_path = try tmpPath(alloc, tmp.dir, "new.txt");
+    defer alloc.free(new_path);
+    try writeAbsolute(new_path, "renamed content");
+
+    const preimage = try alloc.alloc(u8, 64 * 1024);
+    defer alloc.free(preimage);
+    @memset(preimage, 'D');
+
+    var tracker: ChangeTracker = .{};
+    defer tracker.deinit(alloc);
+    try tracker.pushOperation(alloc, .{
+        .kind = .rename,
+        .path = try alloc.dupe(u8, old_path),
+        .new_path = try alloc.dupe(u8, new_path),
+        .previous_content = try alloc.dupe(u8, preimage),
+        .timestamp_ms = 1,
+    });
+
+    std.posix.sigaction(std.posix.SIG.XFSZ, &.{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    }, null);
+    const saved_limit = try std.posix.getrlimit(.FSIZE);
+    try std.posix.setrlimit(.FSIZE, .{ .cur = 4096, .max = saved_limit.max });
+    defer std.posix.setrlimit(.FSIZE, saved_limit) catch {};
+
+    try std.testing.expect(tracker.undoLast(alloc) == .empty);
+
+    // The tree is left exactly as it was before the undo attempt.
+    const displaced = try readAbsolute(alloc, new_path);
+    defer alloc.free(displaced);
+    try std.testing.expectEqualStrings("renamed content", displaced);
+    try expectMissing(old_path);
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -283,7 +283,7 @@ const FileSizeLimitGuard = struct {
 };
 
 fn limitFileSizeForTest(bytes: u64, fail_after_signal: bool) !FileSizeLimitGuard {
-    var saved_action: std.posix.Sigaction = undefined;
+    var saved_action: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, &.{
         .handler = .{ .handler = std.posix.SIG.IGN },
         .mask = std.posix.sigemptyset(),
@@ -321,7 +321,7 @@ fn readUndoTrace(alloc: Allocator, tmp: std.testing.TmpDir, name: []const u8) ![
 test "file size limit guard restores SIGXFSZ after normal use" {
     if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
 
-    var original: std.posix.Sigaction = undefined;
+    var original: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, &.{
         .handler = .{ .handler = std.posix.SIG.DFL },
         .mask = std.posix.sigemptyset(),
@@ -329,12 +329,12 @@ test "file size limit guard restores SIGXFSZ after normal use" {
     }, &original);
     defer std.posix.sigaction(std.posix.SIG.XFSZ, &original, null);
 
-    var expected: std.posix.Sigaction = undefined;
+    var expected: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, null, &expected);
     const guard = try limitFileSizeForTest(4096, false);
     guard.restore();
 
-    var actual: std.posix.Sigaction = undefined;
+    var actual: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, null, &actual);
     try expectSigactionEqual(expected, actual);
 }
@@ -342,7 +342,7 @@ test "file size limit guard restores SIGXFSZ after normal use" {
 test "file size limit setup restores SIGXFSZ on failure" {
     if (builtin.os.tag != .linux and builtin.os.tag != .macos) return error.SkipZigTest;
 
-    var original: std.posix.Sigaction = undefined;
+    var original: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, &.{
         .handler = .{ .handler = std.posix.SIG.DFL },
         .mask = std.posix.sigemptyset(),
@@ -350,11 +350,11 @@ test "file size limit setup restores SIGXFSZ on failure" {
     }, &original);
     defer std.posix.sigaction(std.posix.SIG.XFSZ, &original, null);
 
-    var expected: std.posix.Sigaction = undefined;
+    var expected: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, null, &expected);
     try std.testing.expectError(error.InjectedSetupFailure, limitFileSizeForTest(4096, true));
 
-    var actual: std.posix.Sigaction = undefined;
+    var actual: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, null, &actual);
     try expectSigactionEqual(expected, actual);
 }

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -297,19 +297,8 @@ fn limitFileSizeForTest(bytes: u64, fail_after_signal: bool) !FileSizeLimitGuard
     return .{ .saved_limit = saved_limit, .saved_action = saved_action };
 }
 
-fn expectSigactionEqual(expected: std.posix.Sigaction, actual: std.posix.Sigaction) !void {
+fn expectSignalHandlerEqual(expected: std.posix.Sigaction, actual: std.posix.Sigaction) !void {
     try std.testing.expectEqual(expected.handler.handler, actual.handler.handler);
-    try std.testing.expectEqual(expected.flags, actual.flags);
-    inline for (std.meta.fields(std.posix.SIG)) |field| {
-        const signal: std.posix.SIG = @enumFromInt(field.value);
-        try std.testing.expectEqual(
-            std.posix.sigismember(&expected.mask, signal),
-            std.posix.sigismember(&actual.mask, signal),
-        );
-    }
-    if (comptime @hasField(std.posix.Sigaction, "restorer")) {
-        try std.testing.expectEqual(expected.restorer, actual.restorer);
-    }
 }
 
 fn readUndoTrace(alloc: Allocator, tmp: std.testing.TmpDir, name: []const u8) ![]u8 {
@@ -336,7 +325,7 @@ test "file size limit guard restores SIGXFSZ after normal use" {
 
     var actual: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, null, &actual);
-    try expectSigactionEqual(expected, actual);
+    try expectSignalHandlerEqual(expected, actual);
 }
 
 test "file size limit setup restores SIGXFSZ on failure" {
@@ -356,7 +345,7 @@ test "file size limit setup restores SIGXFSZ on failure" {
 
     var actual: std.posix.Sigaction = std.mem.zeroes(std.posix.Sigaction);
     std.posix.sigaction(std.posix.SIG.XFSZ, null, &actual);
-    try expectSigactionEqual(expected, actual);
+    try expectSignalHandlerEqual(expected, actual);
 }
 
 test "undoLast returns empty on an initially empty stack" {

--- a/src/core/workspace/change_tracker.zig
+++ b/src/core/workspace/change_tracker.zig
@@ -300,7 +300,13 @@ fn limitFileSizeForTest(bytes: u64, fail_after_signal: bool) !FileSizeLimitGuard
 fn expectSigactionEqual(expected: std.posix.Sigaction, actual: std.posix.Sigaction) !void {
     try std.testing.expectEqual(expected.handler.handler, actual.handler.handler);
     try std.testing.expectEqual(expected.flags, actual.flags);
-    try std.testing.expectEqualSlices(u8, std.mem.asBytes(&expected.mask), std.mem.asBytes(&actual.mask));
+    inline for (std.meta.fields(std.posix.SIG)) |field| {
+        const signal: std.posix.SIG = @enumFromInt(field.value);
+        try std.testing.expectEqual(
+            std.posix.sigismember(&expected.mask, signal),
+            std.posix.sigismember(&actual.mask, signal),
+        );
+    }
     if (comptime @hasField(std.posix.Sigaction, "restorer")) {
         try std.testing.expectEqual(expected.restorer, actual.restorer);
     }

--- a/tests/e2e/tui-slash-commands.test.ts
+++ b/tests/e2e/tui-slash-commands.test.ts
@@ -1,20 +1,36 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, HAS_API_KEY } from "../evals/eval-helpers";
-import { TmuxSession, tmuxAvailable } from "./tmux-helpers";
+import {
+  FAKE_GATEWAY_MODEL,
+  fakeGatewayFinalText,
+  fakeGatewayToolCall,
+  startFakeGateway,
+  TmuxSession,
+  tmuxAvailable,
+} from "./tmux-helpers";
 
 const TMUX_SKIP = !tmuxAvailable();
 const SKIP = TMUX_SKIP || !HAS_API_KEY;
 const TIMEOUT = 30_000;
 
 let session: TmuxSession | null = null;
+let gateway: ReturnType<typeof startFakeGateway> | null = null;
 const tempDirs: string[] = [];
 
 afterEach(async () => {
   if (session) { await session.kill(); session = null; }
+  if (gateway) { gateway.stop(); gateway = null; }
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -71,6 +87,81 @@ describe.skipIf(TMUX_SKIP)("tui: no-key slash commands", () => {
       await session.sendText("/undo");
       const pane = await session.waitForText("Nothing to undo.", 5_000);
       expect(pane).toContain("Nothing to undo.");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "/undo refuses an unavailable copy preimage before exposing older history",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-undo-unavailable-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const sourcePath = join(workspace, "source.txt");
+      const olderPath = join(workspace, "older.txt");
+      const destinationPath = join(workspace, "dest.bin");
+      mkdirSync(home);
+      mkdirSync(workspace);
+      writeFileSync(stderrPath, "");
+      writeFileSync(sourcePath, "small source");
+      writeFileSync(destinationPath, Buffer.alloc(10 * 1024 * 1024 + 1, "D"));
+      tempDirs.push(root);
+
+      gateway = startFakeGateway([
+        fakeGatewayToolCall("copy-older", "copy_file", {
+          source: "source.txt",
+          destination: "older.txt",
+          overwrite: true,
+        }),
+        fakeGatewayFinalText("older copy complete"),
+        fakeGatewayToolCall("copy-unavailable", "copy_file", {
+          source: "source.txt",
+          destination: "dest.bin",
+          overwrite: true,
+        }),
+        fakeGatewayFinalText("oversized copy complete"),
+      ]);
+      session = await TmuxSession.create({
+        cwd: workspace,
+        stderrPath,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "undo-e2e-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_DISABLE_KEYCHAIN: "1",
+          FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_PERMISSION_MODE: "yolo",
+        },
+      });
+      await session.waitForComposer(10_000);
+
+      await session.sendText("Copy source.txt to older.txt.");
+      await session.waitForText("older copy complete", 10_000);
+      await session.sendText("Copy source.txt over dest.bin.");
+      await session.waitForText("oversized copy complete", 10_000);
+      expect(readFileSync(destinationPath, "utf8")).toBe("small source");
+      expect(existsSync(olderPath)).toBe(true);
+
+      await session.sendText("/undo");
+      await session.waitForText("Could not undo", 5_000);
+      const refused = await session.captureFullScrollback();
+      expect(refused).toContain("Could not undo");
+      expect(refused).toContain("dest.bin");
+      expect(readFileSync(destinationPath, "utf8")).toBe("small source");
+      expect(existsSync(olderPath)).toBe(true);
+
+      await session.sendText("/undo");
+      await session.waitForText("Deleted", 5_000);
+      expect(await session.captureFullScrollback()).toContain("older.txt");
+      expect(existsSync(olderPath)).toBe(false);
+      expect(readFileSync(destinationPath, "utf8")).toBe("small source");
+      expect(await session.waitForComposer(5_000)).toContain("Run /help for commands");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
     TIMEOUT,
   );


### PR DESCRIPTION
## Summary

- restore undo preimages atomically and refuse unsafe in-place fallback
- distinguish absent preimages from unavailable preimages so undo never deletes a pre-existing file it could not capture
- report rename-back and deletion failures as unavailable instead of reporting an empty or successful undo
- preserve file modes and symlink behavior

Carries forward #212 as a maintainer branch, preserving both contributor-authored commits, rebased onto current main, and adds the final review corrections. #212 remains open and unchanged.

Fixes #211.
Tracks FXC-247.

## Validation

- `zig fmt --check src/`
- `zig build test`
- `zig build`
- freshly built `./zig-out/bin/fx --version` → `0.0.5`
- `bun test tui-slash-commands.test.ts --test-name-pattern "/undo reports the exact empty state"`