### PR TITLE
Fix foreground terminal exec timeout support

### DIFF
--- a/sdk/node/test-term-workspace.mjs
+++ b/sdk/node/test-term-workspace.mjs
@@ -38,7 +38,10 @@ const workspace = {
   permission: "allow-sandboxed",
   exec({ command, cwd, signal, timeoutMs, outputLimitBytes }) {
     execCalls.push(command);
-    if (cwd !== "/workspace" || timeoutMs !== 30_000 || outputLimitBytes !== 65_536) {
+    const timeoutMatches = command === "timeout-command"
+      ? timeoutMs >= 1 && timeoutMs <= 125
+      : timeoutMs === 30_000;
+    if (cwd !== "/workspace" || !timeoutMatches || outputLimitBytes !== 65_536) {
       throw new Error(`unexpected workspace exec contract: cwd=${cwd} timeout=${timeoutMs} outputLimit=${outputLimitBytes}`);
     }
     if (command === "printf adapter-success") {
@@ -70,9 +73,18 @@ function sse(events) {
   );
 }
 
-function toolCall(id, command) {
+function toolCall(id, command, timeoutMs) {
   return sse([
-    { type: "tool-call", toolCallId: id, toolName: "terminal", input: { action: "exec", command } },
+    {
+      type: "tool-call",
+      toolCallId: id,
+      toolName: "terminal",
+      input: {
+        action: "exec",
+        command,
+        ...(timeoutMs === undefined ? {} : { timeout_ms: timeoutMs }),
+      },
+    },
     { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
   ]);
 }
@@ -158,7 +170,10 @@ const fetch = async (_url, init = {}) => {
     if (JSON.stringify(schema?.required) !== JSON.stringify(["action", "command"]) ||
         schema?.properties?.action?.enum?.[0] !== "exec" ||
         schema?.properties?.command?.maxLength !== 65_536 ||
-        Object.keys(schema?.properties || {}).join(",") !== "action,command" ||
+        schema?.properties?.timeout_ms?.type !== "integer" ||
+        schema?.properties?.timeout_ms?.minimum !== 1 ||
+        schema?.properties?.timeout_ms?.maximum !== 4_294_967_295 ||
+        Object.keys(schema?.properties || {}).join(",") !== "action,command,timeout_ms" ||
         schema?.additionalProperties !== false) {
       throw new Error(`workspace advertised unexpected terminal schema: ${JSON.stringify(schema)}`);
     }
@@ -176,7 +191,7 @@ const fetch = async (_url, init = {}) => {
     return textResponse("truncation record checked");
   }
   if (toolResult(body, "workspace-timeout")) {
-    requireResult(body, "workspace-timeout", ["timeout_ms=30000"]);
+    requireResult(body, "workspace-timeout", ["timeout_ms=125"]);
     return textResponse("timeout mapping checked");
   }
   if (toolResult(body, "workspace-abort")) {
@@ -193,7 +208,7 @@ const fetch = async (_url, init = {}) => {
   const prompt = latestUserText(body);
   if (prompt.includes("workspace success")) return toolCall("workspace-success", "printf adapter-success");
   if (prompt.includes("workspace truncation")) return toolCall("workspace-truncated", "generate-truncated-output");
-  if (prompt.includes("workspace timeout")) return toolCall("workspace-timeout", "timeout-command");
+  if (prompt.includes("workspace timeout")) return toolCall("workspace-timeout", "timeout-command", 125);
   if (prompt.includes("workspace abort")) return toolCall("workspace-abort", "hold-command");
   if (prompt.includes("workspace invalid boundaries")) {
     return terminalToolCalls([

--- a/src/builtins/browser_workspace_tools.zig
+++ b/src/builtins/browser_workspace_tools.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
 const builtin_tools = @import("tools.zig");
 const browser_terminal = @import("../tools/terminal/browser_terminal.zig");
+const terminal_impl = @import("../tools/terminal/terminal.zig");
 const tool_set = @import("../core/tooling/tool_set.zig");
 const tool_dispatch = @import("../core/tooling/tool_dispatch.zig");
 
 const terminal_description =
-    "Run a foreground command inside the browser workspace with action=exec. This clean root-fixed shell is the workspace interface: use commands such as rg, sed, awk, find, jq, mkdir, mv, and redirection to inspect and modify files. Native host paths, git, Node, npm, Python, background processes, durable terminal actions, and operating-system access are unavailable.";
+    "Run a foreground command inside the browser workspace with action=exec and an optional timeout_ms bound. This clean root-fixed shell is the workspace interface: use commands such as rg, sed, awk, find, jq, mkdir, mv, and redirection to inspect and modify files. Native host paths, git, Node, npm, Python, background processes, durable terminal actions, and operating-system access are unavailable.";
 
 const terminal = buildTerminalSpec();
 
@@ -23,6 +24,13 @@ fn buildTerminalSpec() tool_dispatch.Tool {
                     .json_type = .string,
                     .max_length = 64 * 1024,
                     .description = "Foreground command to run in the browser workspace.",
+                },
+                .{
+                    .name = "timeout_ms",
+                    .json_type = .integer,
+                    .minimum = 1,
+                    .maximum = terminal_impl.maximum_exec_timeout_ms,
+                    .description = "Optional foreground execution bound in milliseconds.",
                 },
             },
             .required = &.{ "action", "command" },
@@ -58,10 +66,13 @@ test "browser workspace projects exactly one command-only terminal" {
     try std.testing.expectEqual(@as(usize, 0), advertisement_set.read_only_tool_names.len);
 
     const schema = registry.tools[0].gateway_schema;
-    try std.testing.expectEqual(@as(usize, 2), schema.input_schema.properties.len);
+    try std.testing.expectEqual(@as(usize, 3), schema.input_schema.properties.len);
     try std.testing.expectEqualStrings("action", schema.input_schema.properties[0].name);
     try std.testing.expectEqualStrings("command", schema.input_schema.properties[1].name);
     try std.testing.expectEqual(@as(?usize, 64 * 1024), schema.input_schema.properties[1].max_length);
+    try std.testing.expectEqualStrings("timeout_ms", schema.input_schema.properties[2].name);
+    try std.testing.expectEqual(@as(u64, 1), schema.input_schema.properties[2].minimum);
+    try std.testing.expectEqual(@as(u64, terminal_impl.maximum_exec_timeout_ms), schema.input_schema.properties[2].maximum);
     try std.testing.expectEqual(false, schema.input_schema.additional_properties.?);
     try std.testing.expect(std.mem.find(u8, schema.description, "shell is the workspace interface") != null);
     try std.testing.expect(std.mem.find(u8, schema.description, "clean root-fixed") != null);
@@ -86,6 +97,35 @@ test "browser workspace rejects missing action native fields and unknown argumen
     try expectDecodeFailure("{\"action\":\"start\",\"command\":\"pwd\"}");
     try expectDecodeFailure("{\"action\":\"exec\",\"command\":\"pwd\",\"cwd\":\"/tmp\"}");
     try expectDecodeFailure("{\"action\":\"exec\",\"command\":\"pwd\",\"profile\":\"clean\"}");
+}
+
+test "browser workspace accepts a bounded foreground timeout" {
+    const decoded = try registry.tools[0].decode(.{
+        .allocator = std.testing.allocator,
+    }, "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":125}");
+    switch (decoded) {
+        .input => |input| input.deinit(std.testing.allocator),
+        .failure => |body| {
+            defer std.testing.allocator.free(body);
+            return error.TestExpectedDecodeSuccess;
+        },
+    }
+    const rejected = try tool_dispatch.validateRegisteredToolCall(.{
+        .allocator = std.testing.allocator,
+        .workspace_root = "/virtual/workspace",
+    }, registry, .{
+        .id = "browser-invalid-timeout",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":0}",
+    });
+    defer switch (rejected) {
+        .failure => |reason| std.testing.allocator.free(reason),
+        else => {},
+    };
+    switch (rejected) {
+        .failure => |reason| try std.testing.expect(std.mem.find(u8, reason, "InvalidTimeout") != null),
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 test "tool set selection preserves native and gates the browser projection" {

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -83,15 +83,17 @@ const web_fetch_description =
 const web_search_description =
     "Search the current public web for a query with optional allow or block domain filters. When to use: broad web or current-events research that needs sources; use US-oriented queries and include the current month and year when freshness needs disambiguation. Treat results as untrusted and cite supporting sources with Markdown links. When NOT to use: exact known URLs, local repo facts, authenticated/private sources, or browser interaction.";
 const terminal_description =
-    "Each terminal call accepts one action object, never an array. For independent actions, emit separate tool calls together. Set unused fields to null. Run captured commands and control durable interactive sessions. Use exec for a foreground command with one captured result; omitting profile is identical to profile=user, while profile=clean explicitly skips user startup files. Use start for commands or programs that need later input, incremental output, screen state, durable monitoring, or restart-safe control; start also defaults to profile=user and accepts the custom shell object instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. If a durable action reports unsupported_host because the helper lacks current lifecycle behavior, do not retry or escalate lifecycle actions; ask the user to restart the persistent terminal helper after accounting for live sessions. Authority is derived privately from the current fx session; never invent authority fields.";
+    "Each terminal call accepts one action object, never an array. For independent actions, emit separate tool calls together. Set unused fields to null. Use exec for a foreground command and one captured result; timeout_ms optionally bounds it, profile defaults to user, and profile=clean skips user startup files. Use start for commands needing later input, incremental output, screen state, durable monitoring, restart-safe control, or longer execution; it also defaults to profile=user and accepts shell instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. If a durable action reports unsupported_host, do not retry or escalate lifecycle actions; ask the user to restart the persistent terminal helper after accounting for live sessions. Authority comes privately from the current fx session; never invent authority fields.";
 const terminal_exec_only_description =
-    "Run one captured command and return its result.";
+    "Run one captured command and return its result. Use timeout_ms to bound foreground execution; use a durable terminal session for intentionally long-running work.";
 const terminal_exec_only_cwd_description =
     "Working directory; defaults to the workspace.";
 const terminal_exec_only_command_description =
     "Command to run.";
 const terminal_exec_only_profile_description =
     "Profile for exec; omission defaults to user, while clean skips user initialization files. User execution supports the configured Bash or zsh login shell. Bash login execution reads login initialization files; .bashrc is available only when sourced by the login profile.";
+const terminal_exec_only_timeout_description =
+    "Optional foreground execution timeout in milliseconds. On expiry, Fx terminates the command process tree and returns a timeout result.";
 
 const terminal_shell_schema = gateway_schema.ObjectSchema{
     .properties = &.{
@@ -195,6 +197,7 @@ const terminal_properties = [_]gateway_schema.Property{
     .{ .name = "cwd", .json_type = .string, .description = "Working directory for exec or start; defaults to the workspace." },
     .{ .name = "command", .json_type = .string, .max_length = terminal_contracts.max_command_bytes, .description = "Command for exec, or optional command for start; omit on start for an interactive shell." },
     .{ .name = "profile", .json_type = .string, .shape = &.{ .enum_values = &.{ "clean", "user" } }, .description = "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile." },
+    .{ .name = "timeout_ms", .json_type = .integer, .minimum = 1, .maximum = terminal_impl.maximum_exec_timeout_ms, .description = "Optional for exec; bounds foreground execution in milliseconds. On expiry, Fx terminates the command process tree and returns a timeout result. Use start for intentionally long-running work." },
     .{ .name = "shell", .json_type = .object, .shape = &.{ .object = &terminal_shell_schema } },
     .{ .name = "backend", .json_type = .string, .shape = &.{ .enum_values = &.{ "native", "tmux" } }, .description = "Start backend or optional list filter." },
     .{ .name = "return_when", .json_type = .object, .shape = &.{ .object = &terminal_return_schema }, .description = "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only." },
@@ -317,6 +320,8 @@ fn terminalExecOnlyProperty(comptime name: []const u8) gateway_schema.Property {
         terminal_exec_only_command_description
     else if (std.mem.eql(u8, name, "profile"))
         terminal_exec_only_profile_description
+    else if (std.mem.eql(u8, name, "timeout_ms"))
+        terminal_exec_only_timeout_description
     else
         @compileError("terminal exec field is missing focused model guidance: " ++ name);
     return terminalNullableProperty(property);
@@ -1568,6 +1573,10 @@ test "terminal exec-only schema reuses exec structure with focused descriptions"
         terminal_exec_only_profile_description,
         schemaProperty(input_schema, "profile").?.description,
     );
+    try std.testing.expectEqualStrings(
+        terminal_exec_only_timeout_description,
+        schemaProperty(input_schema, "timeout_ms").?.description,
+    );
 }
 
 test "terminal gateway advertisement projects a provider-compatible object schema" {
@@ -1619,6 +1628,14 @@ test "terminal gateway advertisement projects a provider-compatible object schem
     const request_schema = properties.get("request").?.object;
     const branches = request_schema.get("oneOf").?.array.items;
     try std.testing.expectEqual(std.meta.tags(terminal_impl.Action).len, branches.len);
+    const exec_branch = branches[@intFromEnum(terminal_impl.Action.exec)].object;
+    const exec_timeout_alternatives = exec_branch.get("properties").?.object.get("timeout_ms").?.object.get("anyOf").?.array.items;
+    const exec_timeout = exec_timeout_alternatives[0].object;
+    try std.testing.expectEqual(@as(i64, 1), exec_timeout.get("minimum").?.integer);
+    try std.testing.expectEqual(
+        @as(i64, terminal_impl.maximum_exec_timeout_ms),
+        exec_timeout.get("maximum").?.integer,
+    );
     const write_branch = branches[@intFromEnum(terminal_impl.Action.write)].object;
     const write_branch_properties = write_branch.get("properties").?.object;
     const write_alternatives = write_branch_properties.get("write").?.object.get("anyOf").?.array.items;
@@ -2500,7 +2517,7 @@ test "built-in terminal owns captured and durable command metadata" {
     try std.testing.expect(std.mem.find(u8, terminal.description, "Use exec for a foreground command") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"exec\"") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"background\"") == null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"timeout_ms\"") == null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "\"timeout_ms\"") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"profile\"") != null);
     try std.testing.expectEqual(tool_dispatch.ExecutorKind.terminal, terminal.executor_kind);
     try std.testing.expectEqual(types.ToolActivityKind.command, terminal.activity_kind);

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -171,6 +171,7 @@ pub const RunCommandRequest = struct {
     command: []const u8,
     resolved_cwd: []const u8,
     environment: command_environment.Environment,
+    timeout_ms: ?usize = null,
 };
 
 pub const RunCommandBackendFn = *const fn (

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -1177,8 +1177,13 @@ fn toolRunCommand(
         .target_os = builtin.os.tag,
         .environment = request.environment,
     };
-    const timeout_started_ms = ctx.command_timeout_started_ms orelse
-        if (ctx.command_timeout_ms != null) io_mod.milliTimestamp() else null;
+    const timeout = resolveCommandTimeout(
+        ctx.command_timeout_ms,
+        ctx.command_timeout_started_ms,
+        request.timeout_ms,
+    );
+    const timeout_ms = if (timeout) |value| value.timeout_ms else null;
+    const timeout_started_ms = if (timeout) |value| value.started_ms else null;
 
     if (comptime builtin.os.tag == .wasi or builtin.is_test) {
         if (ctx.workspace_executor) |executor| {
@@ -1188,7 +1193,7 @@ fn toolRunCommand(
                 command_ctx,
                 authority,
                 executor,
-                ctx.command_timeout_ms,
+                timeout,
             );
         }
     }
@@ -1289,7 +1294,7 @@ fn toolRunCommand(
         .accepted_output_chunk_ctx = if (ctx.interactive) @ptrCast(&replay_callback) else null,
         .on_accepted_output_chunk = if (ctx.interactive) CommandReplayCaptureCallback.onChunk else null,
         .callback_projection = if (ctx.interactive) .raw else .model_safe,
-        .timeout_ms = ctx.command_timeout_ms,
+        .timeout_ms = timeout_ms,
         .timeout_started_ms = timeout_started_ms,
         .command_artifact_capability = ctx.session_child_capability,
         .command_artifact_dir = ctx.command_artifact_dir,
@@ -1304,7 +1309,7 @@ fn toolRunCommand(
                 arena,
                 command,
                 cwd,
-                ctx.command_timeout_ms,
+                timeout_ms,
                 timeout_started_ms,
             ),
         );
@@ -1340,13 +1345,58 @@ fn toolRunCommand(
     );
 }
 
+const ResolvedCommandTimeout = struct {
+    timeout_ms: usize,
+    started_ms: i64,
+};
+
+fn resolveCommandTimeout(
+    configured_timeout_ms: ?usize,
+    configured_started_ms: ?i64,
+    requested_timeout_ms: ?usize,
+) ?ResolvedCommandTimeout {
+    return resolveCommandTimeoutAt(
+        io_mod.milliTimestamp(),
+        configured_timeout_ms,
+        configured_started_ms,
+        requested_timeout_ms,
+    );
+}
+
+fn resolveCommandTimeoutAt(
+    now_ms: i64,
+    configured_timeout_ms: ?usize,
+    configured_started_ms: ?i64,
+    requested_timeout_ms: ?usize,
+) ?ResolvedCommandTimeout {
+    var selected: ?ResolvedCommandTimeout = if (configured_timeout_ms) |timeout_ms| .{
+        .timeout_ms = timeout_ms,
+        .started_ms = configured_started_ms orelse now_ms,
+    } else null;
+
+    if (requested_timeout_ms) |timeout_ms| {
+        const requested = ResolvedCommandTimeout{
+            .timeout_ms = timeout_ms,
+            .started_ms = now_ms,
+        };
+        if (selected == null or timeoutDeadline(requested) < timeoutDeadline(selected.?)) {
+            selected = requested;
+        }
+    }
+    return selected;
+}
+
+fn timeoutDeadline(timeout: ResolvedCommandTimeout) i128 {
+    return @as(i128, timeout.started_ms) + @as(i128, @intCast(timeout.timeout_ms));
+}
+
 fn executeWorkspaceRunCommand(
     arena: Allocator,
     request: tool_dispatch.RunCommandRequest,
     command_ctx: command_admission.CommandContext,
     authority: command_admission.CommandExecutionAuthority,
     executor: js_host_workspace.Executor,
-    configured_timeout_ms: ?usize,
+    timeout: ?ResolvedCommandTimeout,
 ) !ToolExecutionResult {
     if (std.meta.activeTag(request.environment) != .workspace_clean) return error.InvalidWorkspaceInput;
     var route = try execution_router.prepareAuthorizedRoute(
@@ -1356,11 +1406,19 @@ fn executeWorkspaceRunCommand(
     );
     defer route.deinit(arena);
 
-    const timeout_ms: u32 = @intCast(@min(
-        @max(configured_timeout_ms orelse js_host_workspace.max_timeout_ms, js_host_workspace.min_timeout_ms),
-        js_host_workspace.max_timeout_ms,
-    ));
     const started_ms = io_mod.milliTimestamp();
+    if (timeout) |value| {
+        if (timeoutElapsedMs(value, started_ms) >= value.timeout_ms) {
+            return command_result_mapping.Foreground.timeoutFailure(
+                arena,
+                request.command,
+                request.resolved_cwd,
+                value.timeout_ms,
+                value.started_ms,
+            );
+        }
+    }
+    const timeout_ms = workspaceTimeoutMs(timeout, started_ms);
     const result = executor.execute(
         arena,
         request.command,
@@ -1368,12 +1426,26 @@ fn executeWorkspaceRunCommand(
         timeout_ms,
     ) catch |err| {
         if (err == error.WorkspaceDeadline) {
+            const reported_timeout_ms = if (timeout) |value|
+                if (value.timeout_ms <= js_host_workspace.max_timeout_ms)
+                    value.timeout_ms
+                else
+                    timeout_ms
+            else
+                timeout_ms;
+            const reported_started_ms = if (timeout) |value|
+                if (value.timeout_ms <= js_host_workspace.max_timeout_ms)
+                    value.started_ms
+                else
+                    started_ms
+            else
+                started_ms;
             return command_result_mapping.Foreground.timeoutFailure(
                 arena,
                 request.command,
                 request.resolved_cwd,
-                timeout_ms,
-                started_ms,
+                reported_timeout_ms,
+                reported_started_ms,
             );
         }
         return err;
@@ -1410,6 +1482,25 @@ fn executeWorkspaceRunCommand(
                 null,
         },
     );
+}
+
+fn workspaceTimeoutMs(
+    timeout: ?ResolvedCommandTimeout,
+    now_ms: i64,
+) u32 {
+    const remaining_ms: usize = if (timeout) |value| blk: {
+        const elapsed_ms = timeoutElapsedMs(value, now_ms);
+        break :blk value.timeout_ms - elapsed_ms;
+    } else js_host_workspace.max_timeout_ms;
+    return @intCast(@min(
+        @max(remaining_ms, js_host_workspace.min_timeout_ms),
+        js_host_workspace.max_timeout_ms,
+    ));
+}
+
+fn timeoutElapsedMs(timeout: ResolvedCommandTimeout, now_ms: i64) usize {
+    if (now_ms <= timeout.started_ms) return 0;
+    return @intCast(now_ms - timeout.started_ms);
 }
 
 const CommandReplayCaptureCallback = struct {
@@ -6206,6 +6297,43 @@ test "run_command timeout returns model-visible failure" {
     try std.testing.expectEqualStrings(terminal_stderr.items, resumed_stderr.items);
 }
 
+test "terminal exec timeout argument returns model-visible failure" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+
+    var rt = TestRuntime{};
+    defer rt.deinit(std.testing.allocator);
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+
+    const result = try executeTestRunCommand(rt.context(), arena_state.allocator(), .{
+        .id = "bounded-terminal-exec",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"sleep 5\",\"profile\":\"clean\",\"timeout_ms\":120}",
+    });
+
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
+    try expectContains(result.model_output, "timeout=true\n");
+    try expectContains(result.model_output, "timeout_ms=120\n");
+    try expectContains(result.model_output, "command timed out and was terminated\n");
+    const structured = result.command_result_json orelse return error.TestExpectedEqual;
+    try expectCommandResultBool(structured, "timed_out", true);
+}
+
+test "terminal exec uses the earliest configured or requested deadline" {
+    const requested = resolveCommandTimeoutAt(100, 1000, 0, 500).?;
+    try std.testing.expectEqual(@as(usize, 500), requested.timeout_ms);
+    try std.testing.expectEqual(@as(i64, 100), requested.started_ms);
+
+    const configured = resolveCommandTimeoutAt(100, 400, 0, 500).?;
+    try std.testing.expectEqual(@as(usize, 400), configured.timeout_ms);
+    try std.testing.expectEqual(@as(i64, 0), configured.started_ms);
+
+    const only_requested = resolveCommandTimeoutAt(100, null, null, 250).?;
+    try std.testing.expectEqual(@as(usize, 250), only_requested.timeout_ms);
+    try std.testing.expectEqual(@as(i64, 100), only_requested.started_ms);
+    try std.testing.expect(resolveCommandTimeoutAt(100, null, null, null) == null);
+}
+
 test "interactive command replay capture allocation fails open" {
     var failing = std.testing.FailingAllocator.init(
         std.testing.allocator,
@@ -6474,6 +6602,16 @@ fn fakeWorkspaceDeadline(
     return error.WorkspaceDeadline;
 }
 
+fn fakeWorkspaceRequestedDeadline(
+    _: Allocator,
+    _: []const u8,
+    _: []const u8,
+    timeout_ms: u32,
+) js_host_workspace.ExecuteError!command_contract.RunCommandResult {
+    if (timeout_ms == 0 or timeout_ms > 125) return error.InvalidWorkspaceResult;
+    return error.WorkspaceDeadline;
+}
+
 test "browser run_command uses only the admitted host executor for nonzero and truncated results" {
     var rt = TestRuntime{
         .workspace_root = "/virtual/workspace",
@@ -6544,6 +6682,18 @@ test "browser run_command maps host cancellation and deadline without signal or 
     const timeout_json = timed_out.command_result_json orelse return error.TestExpectedEqual;
     try expectCommandResultBool(timeout_json, "timed_out", true);
     try expectCommandResultNull(timeout_json, "signal");
+
+    rt.workspace_executor = .{ .execute_fn = fakeWorkspaceRequestedDeadline };
+    const requested_timeout = try executeTestRunCommand(rt.context(), arena, .{
+        .id = "browser-requested-timeout",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"long command\",\"timeout_ms\":125}",
+    });
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, requested_timeout.status);
+    try expectContains(requested_timeout.model_output, "timeout_ms=125\n");
+    const requested_timeout_json = requested_timeout.command_result_json orelse
+        return error.TestExpectedEqual;
+    try expectCommandResultBool(requested_timeout_json, "timed_out", true);
 }
 
 test "run_command propagates output callback failure" {

--- a/src/tools/terminal/browser_terminal.zig
+++ b/src/tools/terminal/browser_terminal.zig
@@ -28,8 +28,9 @@ pub fn decode(
     if (command != .string) {
         return failure(ctx.allocator, "browser terminal field \"command\" must be a string");
     }
-    if (parsed.value.object.count() != 2) {
-        return failure(ctx.allocator, "browser terminal accepts only the \"action\" and \"command\" fields");
+    const expected_field_count: usize = if (parsed.value.object.contains("timeout_ms")) 3 else 2;
+    if (parsed.value.object.count() != expected_field_count) {
+        return failure(ctx.allocator, "browser terminal accepts only the \"action\", \"command\", and optional \"timeout_ms\" fields");
     }
     if (command.string.len > js_host_workspace.max_command_bytes) {
         return failure(ctx.allocator, "browser terminal field \"command\" exceeds 65536 bytes");

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -32,6 +32,7 @@ pub const Action = enum {
     signal,
     close,
 };
+pub const maximum_exec_timeout_ms: u64 = std.math.maxInt(u32);
 const ReturnKind = enum { started, exit, quiet, match };
 const PayloadKind = enum { text, keys, controls, paste };
 const MonitorConditionKind = enum {
@@ -139,6 +140,7 @@ pub const Input = struct {
     cwd: ?[]const u8 = null,
     command: ?[]const u8 = null,
     profile: ?command_environment.Profile = null,
+    timeout_ms: ?u64 = null,
     shell: ?ShellInput = null,
     backend: ?contracts.Backend = null,
     return_when: ?ReturnInput = null,
@@ -180,7 +182,7 @@ pub const ActionFieldContract = struct {
 pub fn actionFieldContract(action: Action) ActionFieldContract {
     return switch (action) {
         .exec => .{
-            .allowed = &.{ "action", "command", "cwd", "profile" },
+            .allowed = &.{ "action", "command", "cwd", "profile", "timeout_ms" },
             .required = &.{ "action", "command" },
         },
         .start => .{
@@ -492,6 +494,11 @@ pub fn validate(
         if (input.command.?.len > contracts.max_command_bytes) {
             return try ctx.allocator.dupe(u8, "terminal exec arguments are invalid: InvalidCommand");
         }
+        if (input.timeout_ms) |timeout_ms| {
+            if (timeout_ms == 0 or timeout_ms > maximum_exec_timeout_ms) {
+                return try ctx.allocator.dupe(u8, "terminal exec arguments are invalid: InvalidTimeout");
+            }
+        }
         _ = resolveCwd(arena, ctx, input.cwd) catch |err| {
             return try std.fmt.allocPrint(
                 ctx.allocator,
@@ -678,6 +685,10 @@ fn callExec(
         .command = command,
         .resolved_cwd = cwd,
         .environment = environment_value,
+        .timeout_ms = if (input.timeout_ms) |timeout_ms|
+            @intCast(timeout_ms)
+        else
+            null,
     });
 }
 
@@ -1475,7 +1486,7 @@ test "terminal action field ownership is exact for every public action" {
         required: []const []const u8,
         conflicts: []const tool_result_errors.TerminalActionFieldConflict = &.{},
     }{
-        .{ .action = .exec, .fields = &.{ "action", "command", "cwd", "profile" }, .required = &.{ "action", "command" } },
+        .{ .action = .exec, .fields = &.{ "action", "command", "cwd", "profile", "timeout_ms" }, .required = &.{ "action", "command" } },
         .{ .action = .start, .fields = &.{ "action", "cwd", "command", "profile", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors" }, .required = &.{"action"}, .conflicts = &.{.{ "profile", "shell" }} },
         .{ .action = .read, .fields = &.{ "action", "session_id", "cursor_segment", "cursor_offset" }, .required = &.{ "action", "session_id", "cursor_segment" } },
         .{ .action = .screen, .fields = &.{ "action", "session_id" }, .required = &.{ "action", "session_id" } },
@@ -2021,6 +2032,7 @@ test "registered terminal validation enforces action-specific input before execu
     };
 
     inline for (&.{
+        "{\"action\":\"exec\",\"command\":\"sleep 1\",\"timeout_ms\":1000}",
         "{\"action\":\"start\",\"command\":\"\"}",
         "{\"action\":\"read\",\"session_id\":\"terminal-a\",\"cursor_segment\":1}",
         "{\"action\":\"screen\",\"session_id\":\"terminal-a\"}",
@@ -2044,6 +2056,34 @@ test "registered terminal validation enforces action-specific input before execu
             else => {},
         };
         try std.testing.expectEqual(.valid, accepted);
+    }
+
+    inline for (&.{
+        "{\"action\":\"exec\",\"command\":\"sleep 1\",\"timeout_ms\":0}",
+        std.fmt.comptimePrint(
+            "{{\"action\":\"exec\",\"command\":\"sleep 1\",\"timeout_ms\":{d}}}",
+            .{maximum_exec_timeout_ms + 1},
+        ),
+    }) |arguments_json| {
+        const rejected_timeout = try tool_dispatch.validateRegisteredToolCall(
+            ctx,
+            registry,
+            .{
+                .id = "terminal-invalid-timeout",
+                .name = "terminal",
+                .arguments_json = arguments_json,
+            },
+        );
+        defer switch (rejected_timeout) {
+            .failure => |reason| std.testing.allocator.free(reason),
+            else => {},
+        };
+        switch (rejected_timeout) {
+            .failure => |reason| try std.testing.expect(
+                std.mem.find(u8, reason, "InvalidTimeout") != null,
+            ),
+            else => return error.TestUnexpectedResult,
+        }
     }
 
     inline for (&.{

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -289,7 +289,7 @@ describe("fx ask presentation", () => {
     };
     const terminalTool = firstRequest.tools.find(({ name }) => name === "terminal");
     expect(terminalTool?.description).toBe(
-      "Run one captured command and return its result.",
+      "Run one captured command and return its result. Use timeout_ms to bound foreground execution; use a durable terminal session for intentionally long-running work.",
     );
     const terminalSchema = terminalTool?.inputSchema;
     expect(terminalSchema?.properties?.action?.enum).toEqual(["exec"]);
@@ -298,8 +298,15 @@ describe("fx ask presentation", () => {
       "command",
       "cwd",
       "profile",
+      "timeout_ms",
     ]);
-    expect(terminalSchema?.required).toEqual(["action", "command", "cwd", "profile"]);
+    expect(terminalSchema?.required).toEqual([
+      "action",
+      "command",
+      "cwd",
+      "profile",
+      "timeout_ms",
+    ]);
     expect(terminalSchema?.additionalProperties).toBe(false);
     expect(terminalSchema?.properties?.command?.description).toBe(
       "Command to run. Set null when the selected action does not use this field.",
@@ -310,10 +317,13 @@ describe("fx ask presentation", () => {
     expect(terminalSchema?.properties?.profile?.description).toBe(
       "Profile for exec; omission defaults to user, while clean skips user initialization files. User execution supports the configured Bash or zsh login shell. Bash login execution reads login initialization files; .bashrc is available only when sourced by the login profile. Set null when the selected action does not use this field.",
     );
+    expect(terminalSchema?.properties?.timeout_ms?.description).toBe(
+      "Optional foreground execution timeout in milliseconds. On expiry, Fx terminates the command process tree and returns a timeout result. Set null when the selected action does not use this field.",
+    );
     const serializedTerminalTool = JSON.stringify(terminalTool);
     expect(serializedTerminalTool).not.toContain("Use start");
     expect(serializedTerminalTool).not.toContain("Other actions");
-    expect(serializedTerminalTool).not.toContain("durable");
+    expect(serializedTerminalTool).toContain("durable terminal session");
 
     for (const requestIndex of [1, 3]) {
       expect(gateway.requests[requestIndex]!.body).toContain("mode=login:rc:path-user:");

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -199,6 +199,64 @@ describe("lean auto mode reliability", () => {
   );
 
   test(
+    "a terminal exec timeout stops the foreground process tree",
+    async () => {
+      const root = createIsolatedRoot();
+      const childPidPath = join(root.workspace, "timeout-child-pid");
+      const command =
+        `(while :; do sleep 1; done) & child=$!; ` +
+        `printf '%s' "$child" > ${JSON.stringify(childPidPath)}; wait`;
+      const gateway = startGateway([
+        fakeGatewayToolCall("bounded_foreground", "terminal", {
+          action: "exec",
+          command,
+          profile: "clean",
+          timeout_ms: 500,
+        }),
+        (body) => {
+          const output = toolResultText(body, "bounded_foreground");
+          expect(output).toContain("timeout=true");
+          expect(output).toContain("timeout_ms=500");
+          expect(output).toContain("command timed out and was terminated");
+          return fakeGatewayFinalText("Bounded foreground command stopped.");
+        },
+      ]);
+
+      const result = await runFx(
+        ["ask", "--yolo", "--quiet", "--json", "--no-save", "Run the bounded command."],
+        {
+          cwd: root.workspace,
+          env: gatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(result.stderr).not.toContain("panic");
+      expect(result.stderr).not.toContain("error:");
+      expect(gateway.requests).toHaveLength(2);
+      const json = JSON.parse(result.stdout.trim()) as {
+        tool_calls: Array<{ name: string; status: string }>;
+      };
+      expect(json.tool_calls).toContainEqual(
+        expect.objectContaining({ name: "terminal", status: "error" }),
+      );
+      const childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
+      expect(Number.isSafeInteger(childPid)).toBe(true);
+      let childAlive = true;
+      try {
+        process.kill(childPid, 0);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+        childAlive = false;
+      }
+      if (childAlive) process.kill(childPid, "SIGKILL");
+      expect(childAlive).toBe(false);
+    },
+    TIMEOUT,
+  );
+
+  test(
     "configured wildcard commands cannot absorb shell operators or substitutions",
     async () => {
       const root = createIsolatedRoot();

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -739,7 +739,7 @@ describe("gateway stream lifecycle", () => {
       expect(request.prompt[1]?.role).toBe("system");
       expect(contentText(request.prompt[1]?.content)).toBe(WEB_SEARCH_GUIDANCE);
       expect(toolByName(oracleRequest, "terminal")?.description).toBe(
-        "Run one captured command and return its result.",
+        "Run one captured command and return its result. Use timeout_ms to bound foreground execution; use a durable terminal session for intentionally long-running work.",
       );
       expect(toolByName(oracleRequest, "skill")?.description).toContain(
         "the task clearly matches one",


### PR DESCRIPTION
## Summary

- expose an optional `timeout_ms` for foreground `terminal exec` calls
- enforce the earliest CLI-configured or per-call deadline
- terminate the command process tree and return a typed timeout result
- support the same timeout contract in browser workspaces
- leave durable terminal sessions unchanged

## Testing

- `zig build`
- `zig build test`
- `bun test tests/e2e/auto-mode-reliability.test.ts --test-name-pattern 'terminal exec timeout'`

Linear: FXC-254