### PR TITLE
Keep the active permission mode visible during turns

### DIFF
--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -462,11 +462,27 @@ pub fn Runtime(comptime App: type) type {
             else
                 app.fast_mode;
 
+            const selected_permission_mode = if (comptime @hasField(App, "permission_engine"))
+                app.permission_engine.mode
+            else
+                types.PermissionMode.ask;
+            const current_permission_mode = if (comptime @hasDecl(@TypeOf(app.worker), "effectivePermissionSnapshot"))
+                app.worker.effectivePermissionSnapshot(.{
+                    .mode = selected_permission_mode,
+                }).mode
+            else
+                selected_permission_mode;
+            const permission_display = ui_render.PermissionModeDisplay.init(
+                current_permission_mode,
+                selected_permission_mode,
+            );
+
             const upgrade_label = app.upgrader.statusLabel(upgrade_status_buf);
             const yolo_warning_active =
                 if (comptime @hasField(App, "permission_state") and
                 @hasField(App, "permission_engine"))
-                    app_permission_runtime.Runtime(App).yoloWarningActive(app)
+                    current_permission_mode == .yolo and
+                        app_permission_runtime.Runtime(App).yoloWarningActive(app)
                 else
                     false;
             const settings_snapshot = app_commands.settingsCatalogSnapshot(app);
@@ -486,10 +502,7 @@ pub fn Runtime(comptime App: type) type {
                 .has_api_key = app.auth.credentialSource() != null,
                 .model = visible_model,
                 .pending_images = app.pending_images.items,
-                .permission_mode = if (comptime @hasField(App, "permission_engine"))
-                    app.permission_engine.mode
-                else
-                    .ask,
+                .permission = permission_display,
                 .queued_count = if (queued_cards.cards.len > 0) queued_cards.cards.len else queue_preview.count,
                 .queued_paused = if (comptime @hasField(@TypeOf(queue_preview), "paused"))
                     queue_preview.paused
@@ -1071,7 +1084,7 @@ pub fn Runtime(comptime App: type) type {
             ctx.model = visible_model;
             ctx.pending_images = &.{};
             ctx.composer_visible = chat.messageable();
-            ctx.permission_mode = .auto;
+            ctx.permission = .{ .current = .auto };
             ctx.queued_count = 0;
             ctx.queued_paused = false;
             ctx.queued_cancel_all_available = false;
@@ -4666,7 +4679,7 @@ test "core.app_render_runtime keeps configured controls visible while model capa
         false,
         ctx.has_api_key,
         ctx.model,
-        ctx.permission_mode,
+        ctx.permission.current,
         ctx.queued_count,
         null,
         ctx.fast_mode,

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -307,12 +307,12 @@ pub fn composeHintRow(
         null;
     var hint_buf: [max_status_line_len]u8 = undefined;
     var hint_with_subagents_buf: [max_status_line_len + 128]u8 = undefined;
-    const base_hint_line = ui_render.buildHintLine(
+    const base_hint_line = ui_render.buildHintLineForPermissionDisplay(
         ctx.stream.active,
         approval_active,
         ctx.has_api_key or (ctx.auth_picker.active and ctx.auth_picker.include_skip),
         ctx.model,
-        ctx.permission_mode,
+        ctx.permission,
         ctx.queued_count,
         active_label,
         ctx.fast_mode,
@@ -1501,7 +1501,7 @@ test "compose hint row right-aligns upgrade status after styled auto mode" {
         .stream = .{},
         .has_api_key = true,
         .model = "openai/gpt-4o",
-        .permission_mode = .auto,
+        .permission = .{ .current = .auto },
         .queued_count = 0,
         .subagent_count = 0,
         .subagent_view_active = false,

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -269,7 +269,7 @@ pub const RenderContext = struct {
     model: []const u8,
     pending_images: []const types.ImageAttachment = &.{},
     composer_visible: bool = true,
-    permission_mode: types.PermissionMode = .ask,
+    permission: ui_render.PermissionModeDisplay = .{},
     queued_count: usize,
     queued_paused: bool = false,
     queued_cancel_all_available: bool = false,

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -250,6 +250,46 @@ fn permissionModeStatusLabel(mode: types.PermissionMode, out: []u8) []const u8 {
     };
 }
 
+pub const PermissionModeDisplay = struct {
+    current: types.PermissionMode = .ask,
+    next: ?types.PermissionMode = null,
+
+    pub fn init(current: types.PermissionMode, selected: types.PermissionMode) PermissionModeDisplay {
+        return .{
+            .current = current,
+            .next = if (current == selected) null else selected,
+        };
+    }
+};
+
+fn permissionModeDisplayStatusLabel(display: PermissionModeDisplay, out: []u8) []const u8 {
+    const next = display.next orelse return permissionModeStatusLabel(display.current, out);
+    var current_buf: [64]u8 = undefined;
+    var next_buf: [64]u8 = undefined;
+    return std.fmt.bufPrint(
+        out,
+        "{s} → {s} next",
+        .{
+            permissionModeStatusLabel(display.current, &current_buf),
+            permissionModeStatusLabel(next, &next_buf),
+        },
+    ) catch permissionModeStatusLabel(display.current, out);
+}
+
+fn compactPermissionModeDisplayStatusLabel(display: PermissionModeDisplay, out: []u8) []const u8 {
+    const next = display.next orelse return permissionModeStatusLabel(display.current, out);
+    var current_buf: [64]u8 = undefined;
+    var next_buf: [64]u8 = undefined;
+    return std.fmt.bufPrint(
+        out,
+        "{s}→{s} next",
+        .{
+            permissionModeStatusLabel(display.current, &current_buf),
+            permissionModeStatusLabel(next, &next_buf),
+        },
+    ) catch permissionModeStatusLabel(display.current, out);
+}
+
 fn appendStatusSegment(out: []u8, end: *usize, segment: []const u8) void {
     if (segment.len == 0) return;
     const sep = " · ";
@@ -404,15 +444,61 @@ pub fn buildHintLine(
     width: u16,
     out: []u8,
 ) []const u8 {
+    return buildHintLineForPermissionDisplay(
+        stream_active,
+        awaiting_permission,
+        has_api_key,
+        model,
+        .{ .current = permission_mode },
+        queued_count,
+        active_label,
+        fast_mode,
+        model_supports_fast,
+        effort,
+        model_supports_effort,
+        statusline,
+        width,
+        out,
+    );
+}
+
+pub fn buildHintLineForPermissionDisplay(
+    stream_active: bool,
+    awaiting_permission: bool,
+    has_api_key: bool,
+    model: []const u8,
+    permission: PermissionModeDisplay,
+    queued_count: usize,
+    active_label: ?[]const u8,
+    fast_mode: bool,
+    model_supports_fast: bool,
+    effort: types.ReasoningEffort,
+    model_supports_effort: bool,
+    statusline: StatuslineItems,
+    width: u16,
+    out: []u8,
+) []const u8 {
     _ = active_label;
     _ = stream_active;
 
     var model_buf: [96]u8 = undefined;
     const model_label = compactModelLabel(model, &model_buf);
-    var permission_buf: [64]u8 = undefined;
-    const permission_label = permissionModeStatusLabel(permission_mode, &permission_buf);
+    var permission_buf: [160]u8 = undefined;
+    var compact_permission_buf: [160]u8 = undefined;
+    const full_permission_label = permissionModeDisplayStatusLabel(permission, &permission_buf);
+    const status_limit = @min(@as(usize, width), out.len);
+    const permission_label = if (permission.next != null and
+        display_width.visibleWidthIgnoringAnsi(full_permission_label) > status_limit)
+        compactPermissionModeDisplayStatusLabel(permission, &compact_permission_buf)
+    else
+        full_permission_label;
 
     var end: usize = 0;
+    const permission_transition_visible = permission.next != null and
+        display_width.visibleWidthIgnoringAnsi(permission_label) <= status_limit;
+    if (permission_transition_visible) {
+        appendStatusSegment(out, &end, permission_label);
+    }
     if (!awaiting_permission and !has_api_key) {
         appendStatusSegment(out, &end, "run /login");
     }
@@ -420,10 +506,11 @@ pub fn buildHintLine(
         var queued_buf: [32]u8 = undefined;
         appendStatusSegment(out, &end, std.fmt.bufPrint(&queued_buf, "queued {d}", .{queued_count}) catch "");
     }
-    const status_limit = @min(@as(usize, width), out.len);
     const show_effort = model_supports_effort and !effort.isDefault();
     const show_fast = model_supports_fast and fast_mode;
-    if (leadingPermissionModeFits(status_limit, permission_label, model_label)) {
+    if (!permission_transition_visible and
+        leadingPermissionModeFits(status_limit, permission_label, model_label))
+    {
         appendStatusSegment(out, &end, permission_label);
     }
     appendStatusSegment(out, &end, model_label);
@@ -948,6 +1035,67 @@ test "buildHintLine hides effort when it is auto" {
     var buf: [128]u8 = undefined;
     const line = buildHintLine(false, false, true, "anthropic/claude-opus-4.7", .ask, 0, null, false, true, .auto, true, .{}, 80, &buf);
     try std.testing.expectEqualStrings("ask · opus 4.7", line);
+}
+
+test "buildHintLine distinguishes the current turn from the next permission mode" {
+    initTheme(false, null);
+    defer initTheme(false, null);
+
+    var buf: [160]u8 = undefined;
+    const line = buildHintLineForPermissionDisplay(
+        true,
+        false,
+        true,
+        "openai/gpt-5",
+        PermissionModeDisplay.init(.ask, .auto),
+        0,
+        null,
+        false,
+        false,
+        .auto,
+        false,
+        .{},
+        80,
+        &buf,
+    );
+    const expected = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "ask → {s}auto{s} next · gpt-5",
+        .{ permission_auto_style, statusline_style },
+    );
+    defer std.testing.allocator.free(expected);
+    try std.testing.expectEqualStrings(expected, line);
+}
+
+test "buildHintLine prioritizes a compact permission transition at narrow widths" {
+    initTheme(false, null);
+    defer initTheme(false, null);
+
+    var buf: [160]u8 = undefined;
+    const line = buildHintLineForPermissionDisplay(
+        true,
+        false,
+        true,
+        "openai/gpt-5",
+        PermissionModeDisplay.init(.ask, .auto),
+        0,
+        null,
+        false,
+        false,
+        .auto,
+        false,
+        .{},
+        13,
+        &buf,
+    );
+    const expected = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "ask→{s}auto{s} next",
+        .{ permission_auto_style, statusline_style },
+    );
+    defer std.testing.allocator.free(expected);
+    try std.testing.expectEqualStrings(expected, line);
+    try std.testing.expectEqual(@as(usize, 13), display_width.visibleWidthIgnoringAnsi(line));
 }
 
 test "buildHintLine hides effort for models without effort support" {

--- a/tests/e2e/yolo-permission-mode.test.ts
+++ b/tests/e2e/yolo-permission-mode.test.ts
@@ -15,6 +15,7 @@ import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
   fakeGatewayToolCall,
+  heldFakeGatewayFinalText,
   startFakeGateway,
   TmuxSession,
   tmuxAvailable,
@@ -285,6 +286,63 @@ describe.skipIf(!tmuxAvailable())("yolo interactive mode", () => {
       expect(statusPane).toContain("permission_mode=ask");
       expect(statusPane).not.toContain("sandbox=");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
+    },
+    45_000,
+  );
+
+  test(
+    "permission footer keeps the active turn mode visible until the next turn",
+    async () => {
+      const fixture = createFixture("fx-permission-mode-snapshot-");
+      const stderrPath = join(fixture.root, "stderr.log");
+      writeFileSync(
+        fixture.settingsPath,
+        JSON.stringify({
+          permission_mode: "ask",
+          yolo_acknowledged: true,
+        }) + "\n",
+      );
+      writeFileSync(stderrPath, "");
+
+      const held = heldFakeGatewayFinalText();
+      try {
+        const fake = startFakeGateway([held.response]);
+        gateway = fake;
+        session = await TmuxSession.create({
+          cwd: fixture.workspace,
+          stderrPath,
+          width: 120,
+          height: 40,
+          env: {
+            HOME: fixture.home,
+            AI_GATEWAY_API_KEY: "fake-permission-snapshot-key",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_AUTO_UPGRADE: "0",
+            FX_GATEWAY_BASE_URL: fake.baseUrl,
+            FX_GATEWAY_CHAT_URL: fake.chatUrl,
+            FX_MODEL: FAKE_GATEWAY_MODEL,
+            FX_PERMISSION_MODE: undefined,
+          },
+        });
+
+        await session.waitForText("ask · gpt-5", TIMEOUT);
+        await session.sendText("Hold this turn while I change permission mode.");
+        await session.waitForPane(() => fake.requests.length === 1, TIMEOUT);
+
+        await session.sendKeys("BTab");
+        const pendingPane = await session.waitForText("ask → auto next · gpt-5", TIMEOUT);
+        expect(pendingPane).toContain("ask → auto next · gpt-5");
+        expect(JSON.parse(readFileSync(fixture.settingsPath, "utf8")).permission_mode)
+          .toBe("auto");
+
+        held.release("PERMISSION_SNAPSHOT_TURN_DONE");
+        await session.waitForText("PERMISSION_SNAPSHOT_TURN_DONE", TIMEOUT);
+        const idlePane = await session.waitForText("auto · gpt-5", TIMEOUT);
+        expect(idlePane).not.toContain("ask → auto next");
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+      } finally {
+        held.dispose();
+      }
     },
     45_000,
   );


### PR DESCRIPTION
## Summary

- render the footer from the active turn’s permission snapshot
- show mid-turn changes as applying to the next turn
- prioritize a compact transition indicator at narrow terminal widths
- defer the YOLO warning until YOLO is actually effective

## Testing

- `zig fmt --check src/ui/render.zig src/ui/footer/render_input.zig src/ui/footer/input_presentation.zig src/core/app/app_render_runtime.zig`
- `zig build`
- `zig build test`
- `cd tests/e2e && bun test --max-concurrency 1 ./yolo-permission-mode.test.ts`

## Tracking

Fixes FXC-236.
Fixes #184.