### PR TITLE
Add a profile system prompt at ~/.fx/SYSTEM.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ The status line hides the workspace path and Git branch by default. Enable the `
 }
 ```
 
+Replace the compiled system prompt for every session by writing your own to `~/.fx/SYSTEM.md`:
+
+```bash
+$EDITOR ~/.fx/SYSTEM.md
+```
+
+The file applies to the interactive TUI, `fx ask`, `fx acp`, and subagents. `fx ask --system` still overrides it for a single request, and `~/.fx/AGENTS.md` keeps adding instructions to the prompt instead of replacing it. fx keeps the compiled prompt when the file is missing, blank, larger than 64 KiB, symlinked, or not valid UTF-8. Run `fx doctor` to see which prompt is active and why a file was refused.
+
 List saved sessions with `fx sessions`. Resume the latest session for the current workspace, or select an exact session ID, through the same command group:
 
 ```bash

--- a/src/core/cli/doctor_runtime.zig
+++ b/src/core/cli/doctor_runtime.zig
@@ -98,6 +98,7 @@ pub fn collect(
         // Settings are unreadable, so no remembered choice is available to honour.
         snapshot.auth = try auth_runtime.loadStatusSnapshot(alloc, secret_store, null);
         try appendConfigLoadFailureCheck(&checks, alloc, "config", "failed to load config", err);
+        try appendSystemPromptCheck(&checks, alloc);
         try appendMcpConfigCheck(&checks, alloc, mcp_config_diagnostic);
         try appendAuthCheck(&checks, alloc, snapshot.auth);
         try appendConfigLoadFailureCheck(&checks, alloc, "startup", "failed to resolve startup settings", err);
@@ -120,6 +121,7 @@ pub fn collect(
 
     try appendConfigCheck(&checks, alloc, paths, detailed.diagnostics);
     try appendConfigDiagnosticChecks(&checks, alloc, detailed.diagnostics);
+    try appendSystemPromptCheck(&checks, alloc);
     try appendMcpConfigCheck(&checks, alloc, mcp_config_diagnostic);
     try appendAuthCheck(&checks, alloc, snapshot.auth);
     try appendResolvedStartupCheck(&snapshot, &checks, alloc, .{
@@ -543,6 +545,46 @@ fn appendCheckOwned(checks: *std.ArrayList(Check), alloc: Allocator, name: []con
         .detail = detail,
         .owned_detail = detail,
     });
+}
+
+fn appendSystemPromptCheck(checks: *std.ArrayList(Check), alloc: Allocator) !void {
+    var source = try config_runtime.loadSystemPromptSource(alloc);
+    defer source.deinit(alloc);
+
+    switch (source) {
+        .compiled => try appendCheck(checks, alloc, "system_prompt", .ok, "using the compiled prompt"),
+        .profile => |text| try appendCheckOwned(
+            checks,
+            alloc,
+            "system_prompt",
+            .ok,
+            try std.fmt.allocPrint(alloc, "using ~/.fx/SYSTEM.md ({d} bytes)", .{text.len}),
+        ),
+        .refused => |refusal| try appendCheckOwned(
+            checks,
+            alloc,
+            "system_prompt",
+            .warn,
+            try std.fmt.allocPrint(
+                alloc,
+                "ignoring ~/.fx/SYSTEM.md because {s}; using the compiled prompt",
+                .{refusal.label()},
+            ),
+        ),
+    }
+}
+
+test "system prompt check reports the profile file and its refusals" {
+    const alloc = std.testing.allocator;
+    var checks: std.ArrayList(Check) = .empty;
+    defer {
+        for (checks.items) |*entry| entry.deinit(alloc);
+        checks.deinit(alloc);
+    }
+
+    try appendSystemPromptCheck(&checks, alloc);
+    try std.testing.expectEqual(@as(usize, 1), checks.items.len);
+    try std.testing.expectEqualStrings("system_prompt", checks.items[0].name);
 }
 
 fn appendMcpConfigCheck(

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -6,6 +6,7 @@ const profile_paths = @import("../shared/profile_paths.zig");
 const tool_result_limits = @import("../tooling/tool_result_limits.zig");
 const types = @import("../shared/types.zig");
 const workspace_access = @import("../workspace/workspace_access.zig");
+const text_utils = @import("../shared/text_utils.zig");
 const settings_store = @import("settings_store.zig");
 const project_config = @import("../mcp/project_config.zig");
 const model_provider = @import("model_provider.zig");
@@ -15,6 +16,7 @@ pub const context_limits = @import("context_limits.zig");
 
 const Allocator = std.mem.Allocator;
 const max_settings_bytes: usize = 64 * 1024;
+const max_system_prompt_bytes: usize = 64 * 1024;
 pub const default_permission_mode: types.PermissionMode = .auto;
 
 pub const Paths = struct {
@@ -1138,6 +1140,104 @@ fn readOptionalFile(alloc: Allocator, path: []const u8) !?[]u8 {
     return try io_mod.readFileToEnd(alloc, &file, max_settings_bytes + 1);
 }
 
+pub const SystemPromptRefusal = enum {
+    blank,
+    oversized,
+    unsafe_path,
+    unsafe_text,
+    unreadable,
+
+    pub fn label(self: SystemPromptRefusal) []const u8 {
+        return switch (self) {
+            .blank => "the file holds no text",
+            .oversized => "the file is too large",
+            .unsafe_path => "the path is a symlink or not a regular file",
+            .unsafe_text => "the file is not valid UTF-8 text",
+            .unreadable => "the file could not be read",
+        };
+    }
+};
+
+/// Where the effective system prompt comes from. A `profile` value owns its bytes.
+pub const SystemPromptSource = union(enum) {
+    compiled,
+    profile: []u8,
+    refused: SystemPromptRefusal,
+
+    pub fn text(self: SystemPromptSource) ?[]const u8 {
+        return switch (self) {
+            .profile => |value| value,
+            .compiled, .refused => null,
+        };
+    }
+
+    pub fn deinit(self: *SystemPromptSource, alloc: Allocator) void {
+        if (self.* == .profile) alloc.free(self.profile);
+        self.* = .compiled;
+    }
+};
+
+/// Resolves the system prompt from `~/.fx/SYSTEM.md`, which replaces the compiled prompt.
+/// Caller owns the returned bytes.
+pub fn loadSystemPromptSource(alloc: Allocator) Allocator.Error!SystemPromptSource {
+    const home = io_mod.getenv("HOME") orelse return .compiled;
+    return loadSystemPromptSourceFromHome(alloc, home);
+}
+
+fn loadSystemPromptSourceFromHome(alloc: Allocator, home: []const u8) Allocator.Error!SystemPromptSource {
+    const text = readSystemPromptFile(alloc, home) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.FileNotFound => return .compiled,
+        else => {
+            const refusal: SystemPromptRefusal = switch (err) {
+                error.SystemPromptBlank => .blank,
+                error.StreamTooLong => .oversized,
+                error.SystemPromptNotModelSafe => .unsafe_text,
+                error.NotDir, error.SymLinkLoop, error.DurablePathUnsafe, error.IsDir => .unsafe_path,
+                else => .unreadable,
+            };
+            debug_trace.logf(
+                "core",
+                "system prompt not applied file={s}/{s} refusal={s} err={s}",
+                .{
+                    profile_paths.root_dir_name,
+                    profile_paths.system_prompt_file_name,
+                    @tagName(refusal),
+                    @errorName(err),
+                },
+            );
+            return .{ .refused = refusal };
+        },
+    };
+    return .{ .profile = text };
+}
+
+/// Opens the profile directory without following it, the way `settings_store` does, so a
+/// symlinked `~/.fx` is refused. `O_NOFOLLOW` on the file guards only the last path component.
+fn readSystemPromptFile(alloc: Allocator, home: []const u8) ![]u8 {
+    const zio = io_mod.getIo();
+    var home_dir = try std.Io.Dir.openDirAbsolute(zio, home, .{});
+    defer home_dir.close(zio);
+    var profile_dir = try home_dir.openDir(zio, profile_paths.root_dir_name, .{ .follow_symlinks = false });
+    defer profile_dir.close(zio);
+
+    var file = try io_mod.openExistingRegularFile(
+        profile_dir,
+        profile_paths.system_prompt_file_name,
+        .read_only,
+    );
+    defer file.close(zio);
+
+    const stat = try file.stat(zio);
+    if (stat.size > max_system_prompt_bytes) return error.StreamTooLong;
+
+    const text = try io_mod.readFileToEnd(alloc, &file, max_system_prompt_bytes + 1);
+    errdefer alloc.free(text);
+    if (std.mem.trim(u8, text, " \t\r\n").len == 0) return error.SystemPromptBlank;
+    if (!text_utils.isModelSafeText(text)) return error.SystemPromptNotModelSafe;
+    return text;
+}
+
 fn parseSettingsJson(alloc: Allocator, json_text: []const u8) !Settings {
     return parseSettingsJsonForLayer(alloc, json_text, .profile);
 }
@@ -1808,6 +1908,75 @@ test "discoverPathsFromHome returns home-backed and workspace paths" {
     try std.testing.expectEqualStrings("/Users/tester/.fx", paths.home_fx_dir.?);
     try std.testing.expectEqualStrings("/Users/tester/.fx/sessions", paths.sessions_dir.?);
     try std.testing.expectEqualStrings("/tmp/workspace", paths.workspace_root);
+}
+
+test "system prompt source names why a file is refused" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "missing/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "blank/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "custom/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "oversized/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "invalid/.fx");
+    try writeFixtureFile(tmp.dir, "blank/.fx/SYSTEM.md", "\n  \t\n");
+    try writeFixtureFile(tmp.dir, "custom/.fx/SYSTEM.md", "You are a pirate.\n");
+    try writeFixtureFile(tmp.dir, "invalid/.fx/SYSTEM.md", "You are a pirate.\xff\n");
+
+    const alloc = std.testing.allocator;
+    const expected = [_]struct { home: []const u8, source: SystemPromptSource }{
+        .{ .home = "missing", .source = .compiled },
+        .{ .home = "blank", .source = .{ .refused = .blank } },
+        .{ .home = "invalid", .source = .{ .refused = .unsafe_text } },
+    };
+    for (expected) |case| {
+        const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, case.home);
+        defer alloc.free(home);
+        var source = try loadSystemPromptSourceFromHome(alloc, home);
+        defer source.deinit(alloc);
+        try std.testing.expectEqual(case.source, source);
+        try std.testing.expectEqual(@as(?[]const u8, null), source.text());
+    }
+
+    const custom_home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "custom");
+    defer alloc.free(custom_home);
+    var custom = try loadSystemPromptSourceFromHome(alloc, custom_home);
+    defer custom.deinit(alloc);
+    try std.testing.expectEqualStrings("You are a pirate.\n", custom.text().?);
+
+    const oversized_home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "oversized");
+    defer alloc.free(oversized_home);
+    const oversized_path = try profile_paths.systemPromptPath(alloc, oversized_home);
+    defer alloc.free(oversized_path);
+    try writeRepeatedByteAbsolute(oversized_path, 'a', max_system_prompt_bytes + 1);
+    var oversized = try loadSystemPromptSourceFromHome(alloc, oversized_home);
+    defer oversized.deinit(alloc);
+    try std.testing.expectEqual(SystemPromptSource{ .refused = .oversized }, oversized);
+}
+
+test "system prompt source refuses a symlinked profile directory and a symlinked file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "elsewhere");
+    try tmp.dir.createDirPath(io_mod.getIo(), "linked_dir");
+    try tmp.dir.createDirPath(io_mod.getIo(), "linked_file/.fx");
+    try writeFixtureFile(tmp.dir, "elsewhere/SYSTEM.md", "You are a pirate.\n");
+    tmp.dir.symLink(io_mod.getIo(), "../elsewhere", "linked_dir/.fx", .{ .is_directory = true }) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+    tmp.dir.symLink(io_mod.getIo(), "../../elsewhere/SYSTEM.md", "linked_file/.fx/SYSTEM.md", .{}) catch |err| switch (err) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    const alloc = std.testing.allocator;
+    for ([_][]const u8{ "linked_dir", "linked_file" }) |name| {
+        const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, name);
+        defer alloc.free(home);
+        var source = try loadSystemPromptSourceFromHome(alloc, home);
+        defer source.deinit(alloc);
+        try std.testing.expectEqual(SystemPromptSource{ .refused = .unsafe_path }, source);
+    }
 }
 
 test "merged settings rejects symlinked durable root reload path" {

--- a/src/core/shared/profile_paths.zig
+++ b/src/core/shared/profile_paths.zig
@@ -12,6 +12,7 @@ pub const prompt_history_file_name = "history.jsonl";
 pub const usage_file_name = "usage.jsonl";
 pub const usage_recovery_dir_name = "usage-recovery";
 pub const backups_dir_name = "backups";
+pub const system_prompt_file_name = "SYSTEM.md";
 pub const mcp_credentials_dir_name = "mcp-credentials";
 pub const mcp_credentials_file_name = "credentials.json";
 
@@ -28,6 +29,10 @@ pub fn rootDir(alloc: Allocator, home: []const u8) ![]u8 {
 
 pub fn settingsPath(alloc: Allocator, home: []const u8) ![]u8 {
     return std.fs.path.join(alloc, &.{ home, root_dir_name, settings_file_name });
+}
+
+pub fn systemPromptPath(alloc: Allocator, home: []const u8) ![]u8 {
+    return std.fs.path.join(alloc, &.{ home, root_dir_name, system_prompt_file_name });
 }
 
 pub fn mcpConfigPath(alloc: Allocator, home: []const u8) ![]u8 {

--- a/src/main.zig
+++ b/src/main.zig
@@ -431,8 +431,10 @@ const App = struct {
         return null;
     }
 
-    pub fn promptPolicy(_: *const Self) prompt_policy.Policy {
-        return builtin_context.prompt_policy;
+    pub fn promptPolicy(self: *const Self) prompt_policy.Policy {
+        var policy = builtin_context.prompt_policy;
+        if (self.system_prompt.text()) |text| policy.system_prompt = text;
+        return policy;
     }
 
     pub fn slashRegistry(_: *const Self) command_specs.SlashRegistry {
@@ -577,6 +579,7 @@ const App = struct {
     file_index: file_index_mod.FileIndex = .{},
     context_enabled: bool = true,
     context_limits: config_runtime.context_limits.Values = .{},
+    system_prompt: config_runtime.SystemPromptSource = .compiled,
     fast_mode: bool = false,
     auto_upgrade_enabled: bool = true,
     effort: ReasoningEffort = .auto,
@@ -668,6 +671,9 @@ const App = struct {
             launch.modifiers.saved_directories_suppressed,
         );
         app.context_limits.applyCommandLine(launch.modifiers.context_limit_overrides);
+        if (comptime !host_target.is_wasm) {
+            app.system_prompt = try config_runtime.loadSystemPromptSource(alloc);
+        }
         if (comptime host_profile.durable_sessions or host_profile.js_host_sessions) {
             if (app.requested_resume != null) {
                 if (launch.upgrade_relaunch) {
@@ -886,6 +892,7 @@ const App = struct {
         self.mcp.deinit(self.alloc);
         self.skills.deinit(std.heap.c_allocator);
         self.context_snapshot.deinit(self.alloc);
+        self.system_prompt.deinit(self.alloc);
         self.file_index.deinit(std.heap.c_allocator);
         self.lifecycle_runtime.deinit();
 
@@ -3355,7 +3362,7 @@ fn runNonBenchmark(raw_args: []const [*:0]const u8, raw_env: RawEnviron, cli_arg
     io_mod.setRawEnviron(raw_env);
 
     const alloc = processAllocator();
-    const cfg = if (cli_args.len == 0)
+    var cfg = if (cli_args.len == 0)
         emptyEntryConfig()
     else if (needsFullEntryConfig(cli_args))
         fullEntryConfig()
@@ -3373,6 +3380,14 @@ fn runNonBenchmark(raw_args: []const [*:0]const u8, raw_env: RawEnviron, cli_arg
         });
         if (early_threaded) |*threaded| io_mod.setIo(threaded.io());
     }
+
+    var system_prompt: config_runtime.SystemPromptSource = .compiled;
+    defer system_prompt.deinit(alloc);
+    if (needsFullEntryConfig(cli_args)) {
+        debug_trace.configureFromEnv(alloc, ".");
+        system_prompt = try config_runtime.loadSystemPromptSource(alloc);
+    }
+    cfg = entryConfigWithSystemPrompt(cfg, system_prompt.text());
 
     const before = try app_entry_runtime.runBeforeInteractive(alloc, cli_args, cfg);
     switch (before) {
@@ -3740,6 +3755,38 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .remove_mcp_profile_server = builtin_mcp.removeProfileServer,
         .acp_runner = .{ .run_fn = runAcpServer },
     };
+}
+
+fn entryConfigWithSystemPrompt(
+    cfg: app_entry_runtime.Config,
+    override: ?[]const u8,
+) app_entry_runtime.Config {
+    var resolved = cfg;
+    if (override) |text| resolved.prompt_policy.system_prompt = text;
+    return resolved;
+}
+
+test "entry config takes the profile system prompt over the compiled one" {
+    const compiled = entryConfigWithSystemPrompt(fullEntryConfig(), null);
+    try std.testing.expectEqualStrings(
+        builtin_context.gateway_system_prompt,
+        compiled.prompt_policy.system_prompt,
+    );
+
+    const overridden = entryConfigWithSystemPrompt(fullEntryConfig(), "You are a pirate.");
+    try std.testing.expectEqualStrings("You are a pirate.", overridden.prompt_policy.system_prompt);
+}
+
+test "interactive app takes the profile system prompt over the compiled one" {
+    var app = App{ .alloc = std.testing.allocator };
+    try std.testing.expectEqualStrings(
+        builtin_context.gateway_system_prompt,
+        app.promptPolicy().system_prompt,
+    );
+
+    var custom = "You are a pirate.".*;
+    app.system_prompt = .{ .profile = &custom };
+    try std.testing.expectEqualStrings("You are a pirate.", app.promptPolicy().system_prompt);
 }
 
 fn localEntryConfig() app_entry_runtime.Config {

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -36,6 +36,11 @@ const NO_AUTH = {
 const serialTest = test.serial;
 const SELECTED_COMPLETION_SGR = "\x1b[1m\x1b[38;5;255m";
 
+function systemPromptCheck(doctorJson: string): unknown {
+  const checks = JSON.parse(doctorJson).checks as Array<{ name: string }>;
+  return checks.find((entry) => entry.name === "system_prompt");
+}
+
 function selectedModelStageRow(paneEscapes: string, label: string): string | null {
   return paneEscapes.split("\n").find((line) => {
     const visible = line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "").trim();
@@ -1587,6 +1592,116 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  serialTest(
+    "profile system prompt replaces the compiled prompt and reports why a file is refused",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-system-prompt-"));
+      const gateway = startFakeGateway([
+        fakeGatewayFinalText("SONAR-7 ready."),
+      ]);
+      try {
+        const homeDir = join(root, "home");
+        mkdirSync(join(homeDir, ".fx"), { recursive: true });
+        const workspace = join(root, "workspace");
+        mkdirSync(workspace);
+        const home = realpathSync(homeDir);
+        const workspaceRoot = realpathSync(workspace);
+        const promptPath = join(home, ".fx", "SYSTEM.md");
+        const doctorEnv = { ...NO_AUTH, HOME: home };
+
+        const compiled = await runFx(["doctor", "--json"], {
+          cwd: workspaceRoot,
+          env: doctorEnv,
+        });
+        expect(compiled.code).toBe(0);
+        expect(systemPromptCheck(compiled.stdout)).toEqual({
+          name: "system_prompt",
+          status: "ok",
+          detail: "using the compiled prompt",
+        });
+
+        const promptText = "You are Sonar. Begin every reply with SONAR-7.\n";
+        writeFileSync(promptPath, promptText, { mode: 0o600 });
+        const applied = await runFx(["doctor", "--json"], {
+          cwd: workspaceRoot,
+          env: doctorEnv,
+        });
+        expect(applied.code).toBe(0);
+        expect(systemPromptCheck(applied.stdout)).toEqual({
+          name: "system_prompt",
+          status: "ok",
+          detail: `using ~/.fx/SYSTEM.md (${promptText.length} bytes)`,
+        });
+
+        const ask = await runFx(["ask", "--json", "--no-save", "say hello"], {
+          cwd: workspaceRoot,
+          env: {
+            HOME: home,
+            AI_GATEWAY_API_KEY: "fake-system-prompt-key",
+            VERCEL_OIDC_TOKEN: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_SKIP_ONBOARDING: "1",
+            FX_MODEL: FAKE_GATEWAY_MODEL,
+            FX_PERMISSION_MODE: "auto",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+          },
+        });
+        expect(ask.code).toBe(0);
+        expect(gateway.requests.length).toBe(1);
+        const sent = gateway.requests[0]!.body;
+        expect(sent).toContain("You are Sonar. Begin every reply with SONAR-7.");
+        expect(sent).not.toContain("You are fx, a local coding CLI assistant");
+
+        const refusals: Array<{ write: () => void; detail: string }> = [
+          {
+            write: () => writeFileSync(promptPath, "  \n\t\n", { mode: 0o600 }),
+            detail: "the file holds no text",
+          },
+          {
+            write: () =>
+              writeFileSync(promptPath, Buffer.from("You are Sonar.\xff\n", "binary"), {
+                mode: 0o600,
+              }),
+            detail: "the file is not valid UTF-8 text",
+          },
+          {
+            write: () =>
+              writeFileSync(promptPath, "x".repeat(64 * 1024 + 1), { mode: 0o600 }),
+            detail: "the file is too large",
+          },
+          {
+            write: () => {
+              const outside = join(root, "outside-prompt.md");
+              writeFileSync(outside, promptText, { mode: 0o600 });
+              rmSync(promptPath);
+              symlinkSync(outside, promptPath);
+            },
+            detail: "the path is a symlink or not a regular file",
+          },
+        ];
+        for (const refusal of refusals) {
+          refusal.write();
+          const refused = await runFx(["doctor", "--json"], {
+            cwd: workspaceRoot,
+            env: doctorEnv,
+          });
+          expect(refused.code).toBe(0);
+          expect(systemPromptCheck(refused.stdout)).toEqual({
+            name: "system_prompt",
+            status: "warn",
+            detail: `ignoring ~/.fx/SYSTEM.md because ${refusal.detail}; using the compiled prompt`,
+          });
+        }
+      } finally {
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    45_000,
+  );
 
   serialTest(
     "concurrent global mutations preserve both values and unknown keys",


### PR DESCRIPTION
`~/.fx/SYSTEM.md` replaces the compiled system prompt for the interactive TUI, `fx ask`, `fx acp`, and subagents. `fx ask --system` still wins for a single request, and `~/.fx/AGENTS.md` keeps appending instead of replacing.

The profile directory is opened without following it, so a symlinked `~/.fx` cannot redirect the read, and prompt text carrying invalid UTF-8 or an embedded NUL is refused before it reaches the gateway serializer. A blank, oversized, symlinked, or unsafe file leaves the compiled prompt in place, and `fx doctor` reports the active prompt plus any refusal reason.

Verified with the real binary on both the TUI and `fx ask`, plus a deterministic E2E that asserts the prompt reaches the model request against a fake gateway.