### PR TITLE
Add OpenCode Zen and Go support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,21 @@ fx login grok
 fx
 ```
 
-`fx login codex` and `fx login grok` select that provider and a model from its authenticated catalog. Inside fx, open `/setup` and choose **Switch provider** to move between Gateway, Codex, and Grok. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Use `/logout codex` or `/logout grok` to remove that subscription session without affecting other providers; choosing it again from **Switch provider** starts sign-in.
+Or use an OpenCode Zen or Go API key:
+
+```bash
+export OPENCODE_API_KEY=<your-opencode-api-key>
+fx login opencode
+fx
+```
+
+The provider-specific login commands select that provider and a model from its live catalog. Inside fx, open `/setup` and choose **Switch provider** to move between Gateway, Codex, Grok, and OpenCode. `/model` lists the active provider's supported fetched models. Use `/logout codex`, `/logout grok`, or `/logout opencode` to remove that saved provider session without affecting the others; choosing it again from **Switch provider** starts sign-in.
 
 The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed. On supported Codex models, `/fast` requests OpenAI's priority service tier and consumes ChatGPT credits at the higher Fast mode rate.
 
 The Grok route uses subscription access directly at xAI and never sends its OAuth token to Vercel AI Gateway or OpenAI. Its session is stored privately at `~/.fx/grok-auth.json`, refreshed when needed, and used only with the authenticated xAI catalog and Responses API.
+
+`fx login opencode` imports `OPENCODE_API_KEY` into a private copy at `~/.fx/opencode-auth.json`; later commands use that saved copy, so `fx logout opencode` remains effective even while the environment variable is exported. The OpenCode route sends the saved key only to OpenCode. fx currently lists the Zen and Go models whose published endpoint uses OpenAI-compatible Chat Completions; models requiring OpenAI Responses, Anthropic Messages, or Gemini protocols remain hidden. Go model IDs use the `go/<model-id>` prefix in fx.
 
 To use an AI Gateway API key instead:
 

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -443,12 +443,10 @@ pub fn handlePrompt(
     if (!try server.selectCredentialForProvider(state, session.provider)) {
         return .{ .rpc_error = .{
             .code = ErrorCode.invalid_request,
-            .message = if (session.provider == .codex)
-                credentials.missing_chatgpt_credential_message
-            else if (session.provider == .grok)
-                credentials.missing_grok_credential_message
-            else
-                credentials.missing_credential_message,
+            .message = credentials.missingCredentialMessage(
+                model_provider.requiredCredentialSource(session.provider),
+                .cli,
+            ),
         } };
     }
 

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -322,7 +322,9 @@ fn adoptServerCredential(state: *ServerState, credential: *credentials.Credentia
         active.credential_source = state.credential_source;
         active.account_id = state.account_id;
         if (comptime !host_target.is_wasm) {
-            if (state.credential_source == .chatgpt_subscription or state.credential_source == .grok_subscription) {
+            if (state.credential_source != null and
+                !model_provider.authorizesCredential(.gateway, state.credential_source))
+            {
                 active.session_rt.usage.clearReconciliationCredential();
             }
         }
@@ -1375,12 +1377,10 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
         if (routed_credential == null) {
             return state.writer.writeError(alloc, msg.id, .{
                 .code = ErrorCode.invalid_request,
-                .message = if (state.provider == .codex)
-                    credentials.missing_chatgpt_credential_message
-                else if (state.provider == .grok)
-                    credentials.missing_grok_credential_message
-                else
-                    credentials.missing_credential_message,
+                .message = credentials.missingCredentialMessage(
+                    model_provider.requiredCredentialSource(state.provider),
+                    .cli,
+                ),
             });
         }
         break :routed &routed_credential.?;
@@ -1388,12 +1388,10 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
     if (credential.token.len == 0) {
         return state.writer.writeError(alloc, msg.id, .{
             .code = ErrorCode.invalid_request,
-            .message = if (state.provider == .codex)
-                credentials.missing_chatgpt_credential_message
-            else if (state.provider == .grok)
-                credentials.missing_grok_credential_message
-            else
-                credentials.missing_credential_message,
+            .message = credentials.missingCredentialMessage(
+                model_provider.requiredCredentialSource(state.provider),
+                .cli,
+            ),
         });
     }
     adoptServerCredential(state, credential);
@@ -1571,10 +1569,10 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                 if (!try selectCredentialForProvider(state, session.provider)) {
                     return state.writer.writeError(alloc, msg.id, .{
                         .code = ErrorCode.invalid_request,
-                        .message = if (session.provider == .codex)
-                            credentials.missing_chatgpt_credential_message
-                        else
-                            credentials.missing_grok_credential_message,
+                        .message = credentials.missingCredentialMessage(
+                            model_provider.requiredCredentialSource(session.provider),
+                            .cli,
+                        ),
                     });
                 }
             }
@@ -1635,7 +1633,7 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
             if (host_target.is_wasm) {
                 return state.writer.writeError(alloc, msg.id, .{
                     .code = ErrorCode.invalid_request,
-                    .message = "Subscription provider switching is unavailable in this WASM runtime",
+                    .message = "Non-Gateway provider switching is unavailable in this WASM runtime",
                 });
             }
             var staged_credential = if (target == .gateway and state.cfg.credential_override != null)
@@ -1655,12 +1653,10 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                 break :credential resolution.credential orelse
                     return state.writer.writeError(alloc, msg.id, .{
                         .code = ErrorCode.invalid_request,
-                        .message = if (target == .codex)
-                            credentials.missing_chatgpt_credential_message
-                        else if (target == .grok)
-                            credentials.missing_grok_credential_message
-                        else
-                            credentials.missing_credential_message,
+                        .message = credentials.missingCredentialMessage(
+                            model_provider.requiredCredentialSource(target),
+                            .cli,
+                        ),
                     });
             };
             defer staged_credential.deinit(alloc);

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -563,12 +563,10 @@ fn handleRestoreSession(
     if (!try server.selectCredentialForProvider(state, effective_provider)) {
         return state.writer.writeError(alloc, msg.id, .{
             .code = ErrorCode.invalid_request,
-            .message = if (effective_provider == .codex)
-                credentials.missing_chatgpt_credential_message
-            else if (effective_provider == .grok)
-                credentials.missing_grok_credential_message
-            else
-                credentials.missing_credential_message,
+            .message = credentials.missingCredentialMessage(
+                model_provider.requiredCredentialSource(effective_provider),
+                .cli,
+            ),
         });
     }
     const model_copy = try alloc.dupe(u8, effective_model);

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -89,13 +89,13 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .login,
         .token = "login",
-        .usage = "login [vercel|codex|grok]",
+        .usage = "login [vercel|codex|grok|opencode]",
         .summary = "Sign in to Vercel or a selected provider",
     },
     .{
         .kind = .logout,
         .token = "logout",
-        .usage = "logout [vercel|codex|grok]",
+        .usage = "logout [vercel|codex|grok|opencode]",
         .summary = "Sign out of Vercel or a selected provider session",
     },
     .{
@@ -137,7 +137,7 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .provider,
         .token = "provider",
-        .usage = "provider <gateway|codex|grok>",
+        .usage = "provider <gateway|codex|grok|opencode>",
         .summary = "Choose the model provider used by fx",
     },
     .{
@@ -292,9 +292,9 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
         .{ .kind = .replay, .usage = "replay <tape>" },
     } },
     .{ .entries = &.{
-        .{ .kind = .login, .usage = "login [vercel|codex|grok]" },
-        .{ .kind = .logout, .usage = "logout [vercel|codex|grok]" },
-        .{ .kind = .provider, .usage = "provider <gateway|codex|grok>" },
+        .{ .kind = .login, .usage = "login [vercel|codex|grok|opencode]" },
+        .{ .kind = .logout, .usage = "logout [vercel|codex|grok|opencode]" },
+        .{ .kind = .provider, .usage = "provider <gateway|codex|grok|opencode>" },
         .{ .kind = .setup, .usage = "setup" },
         .{ .kind = .teams, .usage = "teams" },
         .{ .kind = .credits, .usage = "credits|balance" },
@@ -419,8 +419,8 @@ pub const slash_specs = [_]SlashSpec{
     .{ .kind = .resume_session, .command = "/resume", .help_entry = "/resume", .completion_description = "resume a saved session", .presentation_category = .session },
     .{ .kind = .continue_recovery, .command = "/continue", .help_entry = "/continue", .completion_description = "continue a paused model response", .presentation_category = .session, .requires_prompt_credential = true },
     .{ .kind = .rename_session, .command = "/rename", .help_entry = "/rename <title>", .completion_description = "rename the current session", .presentation_category = .session, .has_args = true, .accepts_payload = true },
-    .{ .kind = .login, .command = "/login", .help_entry = "/login", .completion_description = "choose Vercel or Codex sign-in", .presentation_category = .account },
-    .{ .kind = .logout, .command = "/logout", .help_entry = "/logout [vercel|codex|grok]", .completion_description = "sign out of a provider session", .presentation_category = .account, .has_args = true, .accepts_payload = true },
+    .{ .kind = .login, .command = "/login", .help_entry = "/login", .completion_description = "choose a provider sign-in method", .presentation_category = .account },
+    .{ .kind = .logout, .command = "/logout", .help_entry = "/logout [vercel|codex|grok|opencode]", .completion_description = "sign out of a provider session", .presentation_category = .account, .has_args = true, .accepts_payload = true },
     .{ .kind = .setup, .command = "/setup", .help_entry = "/setup", .completion_description = "manage accounts and AI Gateway access", .presentation_category = .account },
     .{ .kind = .stats, .command = "/stats", .help_entry = "/stats", .completion_description = "show token and turn statistics", .presentation_category = .account },
     .{ .kind = .usage, .command = "/usage", .aliases = &.{"/cost"}, .help_entry = "/usage (/cost)", .completion_description = "show local fx tokens, models, and spend", .presentation_category = .account },

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -640,6 +640,9 @@ fn fetchCredits(
     if (input.credential_source == .grok_subscription) {
         return creditsErrorSnapshot(alloc, "AI Gateway credits are unavailable for a Grok subscription.");
     }
+    if (input.credential_source == .opencode_api_key) {
+        return creditsErrorSnapshot(alloc, "AI Gateway credits are unavailable for an OpenCode API key.");
+    }
     return fetchCreditsWithFetch(
         alloc,
         input.credential,

--- a/src/builtins/providers.zig
+++ b/src/builtins/providers.zig
@@ -6,6 +6,8 @@ const openai_codex_permission_reviewer = @import("../gateway/openai_codex_permis
 const xai_grok = @import("../gateway/xai_grok.zig");
 const xai_grok_models = @import("../gateway/xai_grok_models.zig");
 const xai_grok_permission_reviewer = @import("../gateway/xai_grok_permission_reviewer.zig");
+const opencode = @import("../gateway/opencode.zig");
+const opencode_models = @import("../gateway/opencode_models.zig");
 const provider_catalog = @import("../core/auth/provider_catalog.zig");
 
 pub const native = provider_set.Set{
@@ -25,5 +27,11 @@ pub const native = provider_set.Set{
         .cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
         .model_catalog = xai_grok_models.model_catalog_provider,
         .permission_reviewer = xai_grok_permission_reviewer.provider,
+    },
+    .opencode = .{
+        .presentation = provider_catalog.find(.opencode),
+        .agent_stream = opencode.agent_stream_provider,
+        .cli_model_catalog = opencode_models.cli_model_catalog_provider,
+        .model_catalog = opencode_models.model_catalog_provider,
     },
 };

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1036,6 +1036,11 @@ pub fn Runtime(comptime App: type) type {
                         .agent_stream = tool_context.agent_stream_provider,
                         .permission_reviewer = tool_context.permission_reviewer_provider,
                     },
+                    .opencode = .{
+                        .capabilities = tool_context.provider_capabilities,
+                        .agent_stream = tool_context.agent_stream_provider,
+                        .permission_reviewer = tool_context.permission_reviewer_provider,
+                    },
                 };
             return subagent_agent_adapter.run(.{
                 .host = app_session_runtime.Runtime(App).subagentHost(app) orelse

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -10,12 +10,15 @@ const auth_runtime = @import("../auth/auth_runtime.zig");
 const login_flow = @import("../auth/login_flow.zig");
 const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
 const grok_oauth = @import("../auth/grok_oauth.zig");
+const opencode_session = @import("../auth/opencode_session.zig");
 const provider_catalog = @import("../auth/provider_catalog.zig");
 const auth_transition = @import("../auth/auth_transition.zig");
 const model_provider = @import("../config/model_provider.zig");
 const model_catalog = @import("../gateway/model_catalog.zig");
 const provider_runtime = @import("provider_runtime.zig");
 const types = @import("../shared/types.zig");
+const collections = @import("../shared/collections.zig");
+const opencode_models = @import("../../gateway/opencode_models.zig");
 
 fn oauthAuthEnabled(comptime App: type) bool {
     return runtime_profile.allows(App, .native_auth) or
@@ -56,11 +59,8 @@ pub fn Runtime(comptime App: type) type {
                 @hasDecl(@TypeOf(app.auth), "selectForProvider"))
             {
                 const provider = provider_runtime.provider(app);
-                const required_source: credentials.Source = switch (provider) {
-                    .codex => .chatgpt_subscription,
-                    .grok => .grok_subscription,
-                    .gateway => app.auth.credentialSource() orelse .fx_login,
-                };
+                const required_source = model_provider.requiredCredentialSource(provider) orelse
+                    app.auth.credentialSource() orelse .fx_login;
                 const route_change = app.auth.selectForProvider(app.alloc, provider) catch |err| switch (err) {
                     error.OutOfMemory => return err,
                     else => return recoverCredentialFailure(app, required_source, err),
@@ -71,12 +71,10 @@ pub fn Runtime(comptime App: type) type {
                     try app.writeDomainNotice(.{
                         .topic = "auth",
                         .tone = .warning,
-                        .body = if (provider == .grok)
-                            credentials.missing_grok_interactive_credential_message
-                        else if (provider == .codex)
-                            credentials.missing_chatgpt_interactive_credential_message
-                        else
-                            credentials.missing_interactive_credential_message,
+                        .body = credentials.missingCredentialMessage(
+                            model_provider.requiredCredentialSource(provider),
+                            .interactive,
+                        ),
                     }, true);
                     app.shell.render_requests.request(.footer);
                     return false;
@@ -133,7 +131,7 @@ pub fn Runtime(comptime App: type) type {
                     try writeAuthNotice(app, .{
                         .topic = "auth",
                         .tone = .warning,
-                        .body = "Usage: /logout [vercel|codex|grok]",
+                        .body = "Usage: /logout [vercel|codex|grok|opencode]",
                     });
                     return;
                 };
@@ -279,6 +277,7 @@ pub fn Runtime(comptime App: type) type {
                     .login => try beginSignIn(app, true),
                     .chatgpt_login => try beginChatGptSignIn(app),
                     .grok_login => try beginGrokSignIn(app),
+                    .opencode_login => try beginOpenCodeSignIn(app),
                     .setup => {
                         if (comptime !runtime_profile.allows(App, .native_auth)) {
                             try app.writeDomainNotice(.{
@@ -577,7 +576,7 @@ pub fn Runtime(comptime App: type) type {
         fn rememberCredentialSource(app: *App, source: credentials.Source) void {
             // ChatGPT is selected by model route, not as a global Gateway
             // credential preference. Its saved session coexists independently.
-            if (source == .chatgpt_subscription or source == .grok_subscription) return;
+            if (!model_provider.authorizesCredential(.gateway, source)) return;
             if (comptime @hasDecl(App, "persistCredentialSourcePreference")) {
                 app.persistCredentialSourcePreference(source);
                 return;
@@ -658,6 +657,44 @@ pub fn Runtime(comptime App: type) type {
                 app.shell.render_requests.request(.footer);
                 if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) try openSignInBrowser(app);
             }
+        }
+
+        fn beginOpenCodeSignIn(app: *App) anyerror!void {
+            if (comptime provider_runtime.supported(App)) {
+                const decision = decideProviderSwitch(.{
+                    .current = provider_runtime.provider(app),
+                    .target = .opencode,
+                    .target_credential_ready = false,
+                    .intent = .post_oauth,
+                    .stream_active = app.stream.active,
+                    .queued_prompts = app.worker.queuedPromptCount(),
+                });
+                if (decision == .busy) {
+                    try app.writeDomainNotice(.{
+                        .topic = "auth",
+                        .tone = .warning,
+                        .body = "OpenCode sign-in is unavailable until active and queued work finishes.",
+                    }, true);
+                    return;
+                }
+            }
+            const key = io_mod.getenv("OPENCODE_API_KEY") orelse {
+                try app.writeDomainNotice(.{
+                    .topic = "auth",
+                    .tone = .warning,
+                    .body = "Set OPENCODE_API_KEY to your opencode.ai key, then choose Sign in with OpenCode again.",
+                }, true);
+                return;
+            };
+            var session = opencode_session.Session{ .api_key = try app.alloc.dupe(u8, key) };
+            defer session.deinit(app.alloc);
+            opencode_session.saveNewSession(app.alloc, session) catch |err| {
+                debug_trace.logf("auth", "OpenCode login failed err={s}", .{@errorName(err)});
+                try writeLoginError(app, .opencode_api_key, err);
+                return;
+            };
+            try app.auth.refreshSourceInventory(app.alloc);
+            try switchProvider(app, .opencode, false, .post_oauth);
         }
 
         fn beginCodexSignInForProviderSwitch(app: *App) !void {
@@ -781,6 +818,10 @@ pub fn Runtime(comptime App: type) type {
                     try beginGrokSignInForProviderSwitch(app);
                     return;
                 }
+                if (target == .opencode and allow_login) {
+                    try beginOpenCodeSignIn(app);
+                    return;
+                }
                 try app.writeDomainNotice(.{
                     .topic = "provider",
                     .tone = .warning,
@@ -790,6 +831,8 @@ pub fn Runtime(comptime App: type) type {
                         "Run fx login codex, then try switching again."
                     else if (target == .grok)
                         "Run fx login grok, then try switching again."
+                    else if (target == .opencode)
+                        "Set OPENCODE_API_KEY and run fx login opencode, then try switching again."
                     else
                         credentials.missing_interactive_credential_message,
                 }, true);
@@ -1079,7 +1122,66 @@ pub fn Runtime(comptime App: type) type {
                 return false;
             }
             if (!try ensurePromptCredential(app)) return false;
-            return preparePromptCredential(app);
+            if (!try preparePromptCredential(app)) return false;
+            return reconcileOpenCodeModelForPrompt(app);
+        }
+
+        fn reconcileOpenCodeModelIds(app: *App, model_ids: []const []u8) !void {
+            if (provider_runtime.provider(app) != .opencode or io_mod.getenv("FX_MODEL") != null) return;
+
+            const current = provider_runtime.model(app);
+            const replacement = opencode_models.selectAvailableModel(model_ids, current) orelse return;
+            if (std.mem.eql(u8, replacement, current)) return;
+
+            try provider_runtime.replaceModel(app, replacement);
+            try app.worker.syncQueuedPromptModel(std.heap.c_allocator, replacement);
+            var persistence = app.persistRuntimePreferences(.{
+                .provider = .opencode,
+                .model = replacement,
+            });
+            defer persistence.deinit(app.alloc);
+            const saved = persistence.settings_error == null and persistence.session_error == null;
+            try app.writeDomainNotice(.{
+                .topic = "provider",
+                .tone = if (saved) .neutral else .warning,
+                .body = if (saved)
+                    "The saved OpenCode model is unavailable. Switched to a supported model."
+                else
+                    "The saved OpenCode model is unavailable. Switched for this run, but could not save the selection.",
+            }, true);
+        }
+
+        pub fn reconcileLoadedProviderModel(app: *App) !void {
+            if (comptime !provider_runtime.supported(App) or
+                !@hasDecl(App, "snapshotCachedModelIds")) return;
+            var model_ids = (try app.snapshotCachedModelIds(app.alloc)) orelse return;
+            defer collections.freeStringList(app.alloc, &model_ids);
+            try reconcileOpenCodeModelIds(app, model_ids.items);
+        }
+
+        fn reconcileOpenCodeModelForPrompt(app: *App) !bool {
+            if (comptime !provider_runtime.supported(App) or
+                !@hasDecl(App, "snapshotCachedModelIds") or
+                !@hasDecl(App, "fetchModelIds")) return true;
+            if (provider_runtime.provider(app) != .opencode or io_mod.getenv("FX_MODEL") != null) return true;
+            if (try app.snapshotCachedModelIds(app.alloc)) |model_ids_value| {
+                var model_ids = model_ids_value;
+                defer collections.freeStringList(app.alloc, &model_ids);
+                try reconcileOpenCodeModelIds(app, model_ids.items);
+            } else if (!opencode_models.supportsChatCompletionsModel(provider_runtime.model(app))) {
+                var model_ids = app.fetchModelIds() catch |err| {
+                    debug_trace.logf("provider", "OpenCode prompt catalog failed err={s}", .{@errorName(err)});
+                    try app.writeDomainNotice(.{
+                        .topic = "provider",
+                        .tone = .warning,
+                        .body = "Could not refresh the OpenCode model list. Try again.",
+                    }, true);
+                    return false;
+                };
+                defer collections.freeStringList(app.alloc, &model_ids);
+                try reconcileOpenCodeModelIds(app, model_ids.items);
+            }
+            return true;
         }
 
         fn preparePromptCredential(app: *App) !bool {
@@ -1144,7 +1246,7 @@ pub fn Runtime(comptime App: type) type {
             {
                 if (app.auth.gatewayCredential()) |credential| {
                     const subscription = if (comptime @hasField(@TypeOf(credential), "source"))
-                        credential.source == .chatgpt_subscription or credential.source == .grok_subscription
+                        !model_provider.authorizesCredential(.gateway, credential.source)
                     else
                         false;
                     if (subscription) {
@@ -1187,6 +1289,8 @@ pub fn Runtime(comptime App: type) type {
                     error.GrokLoginTimedOut, error.LoginTimedOut => .{ .topic = "auth", .tone = .warning, .body = "Grok sign-in expired. The current credential is unchanged; run /login to try again." },
                     else => .{ .topic = "auth", .tone = .@"error", .body = "Grok sign-in failed. The current credential is unchanged." },
                 }
+            else if (source == .opencode_api_key)
+                .{ .topic = "auth", .tone = .@"error", .body = "OpenCode sign-in failed. Check OPENCODE_API_KEY; the current credential is unchanged." }
             else switch (err) {
                 error.ClientIdMissing => .{ .topic = "auth", .tone = .@"error", .body = "fx login is not configured yet. The current credential is unchanged." },
                 error.AccessDenied => .{ .topic = "auth", .tone = .@"error", .body = "Vercel sign-in was denied. The current credential is unchanged." },
@@ -1378,7 +1482,7 @@ test "interactive subscription sign-in rejects active and queued work before OAu
             switch (provider) {
                 .codex => try Runtime(BusySignInApp).beginChatGptSignIn(&app),
                 .grok => try Runtime(BusySignInApp).beginGrokSignIn(&app),
-                .gateway => unreachable,
+                .gateway, .opencode => unreachable,
             }
 
             try std.testing.expectEqual(@as(usize, 0), app.auth.start_count);

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -916,12 +916,19 @@ pub fn Bindings(comptime App: type) type {
             else
                 try gateway_error_format.formatHttpErrorMessage(std.heap.c_allocator, status, detail);
             defer std.heap.c_allocator.free(message);
-            const label = if (auth_failure != null)
-                try std.fmt.allocPrint(
-                    std.heap.c_allocator,
-                    "⚠ {s} · Run /setup to choose another source.",
-                    .{message},
-                )
+            const label = if (auth_failure) |failure|
+                if (failure.source == .opencode_api_key)
+                    try std.fmt.allocPrint(
+                        std.heap.c_allocator,
+                        "⚠ {s} · Choose a free model with /model, or sign in again.",
+                        .{message},
+                    )
+                else
+                    try std.fmt.allocPrint(
+                        std.heap.c_allocator,
+                        "⚠ {s} · Run /setup to choose another source.",
+                        .{message},
+                    )
             else
                 try std.fmt.allocPrint(std.heap.c_allocator, "⚠ {s}", .{message});
             defer std.heap.c_allocator.free(label);
@@ -2158,6 +2165,26 @@ test "agent context and system notices share semantic transport with distinct fi
     try std.testing.expectEqualStrings("background", interactive.topic);
     try std.testing.expectEqual(types.NoticeTone.information, interactive.tone);
     try std.testing.expectEqualStrings("Command #1 started. Log: /tmp/run.log", interactive.body);
+}
+
+test "OpenCode unauthorized status suggests a free model or signing in again" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+
+    const deps = Bindings(FakeApp).agentRuntimeDeps(&app);
+    try deps.push_http_error(
+        deps.ctx,
+        .unauthorized,
+        "provider detail must not be shown",
+        .opencode_api_key,
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), app.worker.events.items.len);
+    try std.testing.expect(app.worker.events.items[0] == .api_status_text);
+    try std.testing.expectEqualStrings(
+        "⚠ OpenCode rejected the API key or selected model access · HTTP 401 · Choose a free model with /model, or sign in again.",
+        app.worker.events.items[0].api_status_text,
+    );
 }
 
 test "worker bridge deps forward UI operations" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -3934,7 +3934,7 @@ test "app_input_runtime auth stage Escape pops before closing the picker" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..6) |_| _ = app.auth.movePicker(1);
+    for (0..7) |_| _ = app.auth.movePicker(1);
     try std.testing.expect((auth_runtime.Choice{ .action = .switch_credential }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -3962,7 +3962,7 @@ test "app_input_runtime disabled change team action stays silent" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..5) |_| _ = app.auth.movePicker(1);
+    for (0..6) |_| _ = app.auth.movePicker(1);
     try std.testing.expect((auth_runtime.Choice{ .action = .change_team }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -7595,7 +7595,7 @@ fn openRoutingAuthPicker(app: *RoutingFakeApp) !void {
     app.auth.source_inventory.insert(.ai_gateway_api_key);
     app.auth.openPicker(app.alloc);
     try std.testing.expect(app.auth.movePicker(1));
-    try std.testing.expectEqual(@as(usize, 7), app.auth.pickerView().choiceCount());
+    try std.testing.expectEqual(@as(usize, 8), app.auth.pickerView().choiceCount());
     try std.testing.expectEqual(@as(usize, 1), app.auth.pickerView().selectedIndex());
 }
 

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -1113,6 +1113,7 @@ fn configuredProviderSelection(
         .gateway => default_model,
         .codex => return error.CodexModelNotSelected,
         .grok => return error.GrokModelNotSelected,
+        .opencode => return error.OpenCodeModelNotSelected,
     };
     return .{ .provider = provider, .model = model };
 }

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -30,6 +30,7 @@ const credential_source_order = [_]credentials.Source{
     .stored_key,
     .chatgpt_subscription,
     .grok_subscription,
+    .opencode_api_key,
 };
 
 const SourceProbeFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!bool;
@@ -68,13 +69,17 @@ pub const FailureSnapshot = struct {
         var out: std.Io.Writer.Allocating = .init(alloc);
         defer out.deinit();
 
-        try out.writer.print("{s} {s}", .{
-            credentials.sourceLabel(self.source),
-            switch (self.reason) {
-                .credential_refresh_failed => "credential refresh failed",
-                .http_unauthorized => "authentication failed",
-            },
-        });
+        if (self.source == .opencode_api_key and self.reason == .http_unauthorized) {
+            try out.writer.writeAll("OpenCode rejected the API key or selected model access");
+        } else {
+            try out.writer.print("{s} {s}", .{
+                credentials.sourceLabel(self.source),
+                switch (self.reason) {
+                    .credential_refresh_failed => "credential refresh failed",
+                    .http_unauthorized => "authentication failed",
+                },
+            });
+        }
         if (self.http_status) |status| {
             try out.writer.print(" · HTTP {d}", .{@intFromEnum(status)});
         }
@@ -152,6 +157,7 @@ pub const AcquisitionAction = enum {
     login,
     chatgpt_login,
     grok_login,
+    opencode_login,
     setup,
     change_team,
     switch_credential,
@@ -388,12 +394,12 @@ pub const PickerView = struct {
     pub fn choiceCount(self: PickerView) usize {
         return switch (self.stage) {
             .root => if (self.include_skip)
-                if (comptime host_target.is_wasm) 2 else 4
+                if (comptime host_target.is_wasm) 2 else 5
             else if (comptime host_target.is_wasm)
                 4
             else
-                7,
-            .provider => if (comptime host_target.is_wasm) 2 else 3,
+                8,
+            .provider => if (comptime host_target.is_wasm) 2 else 4,
             .sign_in, .api_key => 0,
             .change_team => blk: {
                 var count: usize = 0;
@@ -419,7 +425,8 @@ pub const PickerView = struct {
                     0 => .{ .action = .login },
                     1 => .{ .action = .chatgpt_login },
                     2 => .{ .action = .grok_login },
-                    3 => .{ .action = .setup },
+                    3 => .{ .action = .opencode_login },
+                    4 => .{ .action = .setup },
                     else => null,
                 }
             else if (comptime host_target.is_wasm)
@@ -434,16 +441,18 @@ pub const PickerView = struct {
                 0 => .{ .action = .login },
                 1 => .{ .action = .chatgpt_login },
                 2 => .{ .action = .grok_login },
-                3 => .{ .action = .setup },
-                4 => .{ .action = .switch_provider },
-                5 => .{ .action = .change_team },
-                6 => .{ .action = .switch_credential },
+                3 => .{ .action = .opencode_login },
+                4 => .{ .action = .setup },
+                5 => .{ .action = .switch_provider },
+                6 => .{ .action = .change_team },
+                7 => .{ .action = .switch_credential },
                 else => null,
             },
             .provider => switch (index) {
                 0 => .{ .provider = .gateway },
                 1 => .{ .provider = .codex },
                 2 => if (comptime host_target.is_wasm) null else .{ .provider = .grok },
+                3 => if (comptime host_target.is_wasm) null else .{ .provider = .opencode },
                 else => null,
             },
             .sign_in, .api_key => null,
@@ -487,6 +496,7 @@ pub const PickerView = struct {
                 .login => "Sign in with Vercel",
                 .chatgpt_login => "Sign in with Codex",
                 .grok_login => "Sign in with Grok",
+                .opencode_login => "Sign in with OpenCode",
                 .setup => if (self.include_skip) "Add an API key" else "API key",
                 .change_team => "Change team",
                 .switch_credential => "Switch credential",
@@ -505,6 +515,7 @@ pub const PickerView = struct {
                 .login => if (self.fx_login_session_available) "connected" else "",
                 .chatgpt_login => if (self.available_sources.contains(.chatgpt_subscription)) "connected" else "",
                 .grok_login => if (self.available_sources.contains(.grok_subscription)) "connected" else "",
+                .opencode_login => if (self.available_sources.contains(.opencode_api_key)) "connected" else "",
                 .setup, .switch_credential, .switch_provider => "",
                 .automatic => "use normal precedence",
                 .change_team => if (self.fx_login_session_available) "choose a team" else "sign in first",
@@ -517,7 +528,8 @@ pub const PickerView = struct {
         return switch (choice) {
             .action => |action| (action != .change_team or self.fx_login_session_available) and
                 (action != .chatgpt_login or !host_target.is_wasm) and
-                (action != .grok_login or !host_target.is_wasm),
+                (action != .grok_login or !host_target.is_wasm) and
+                (action != .opencode_login or !host_target.is_wasm),
             .provider, .source, .team => true,
         };
     }
@@ -549,10 +561,7 @@ pub const GatewayTeamStatus = enum {
     }
 };
 
-pub const MissingHelpSurface = enum {
-    cli,
-    interactive,
-};
+pub const MissingHelpSurface = credentials.MissingHelpSurface;
 
 pub const StatusSnapshot = struct {
     active_source: ?credentials.Source = null,
@@ -563,6 +572,7 @@ pub const StatusSnapshot = struct {
     gateway_connected: bool = false,
     chatgpt_connected: bool = false,
     grok_connected: bool = false,
+    opencode_connected: bool = false,
     /// The active credential is past its refresh deadline. Distinct from `refreshable`,
     /// which answers whether this source type can refresh at all.
     expired: bool = false,
@@ -584,22 +594,7 @@ pub const StatusSnapshot = struct {
     pub fn missingHelp(self: StatusSnapshot, surface: MissingHelpSurface) ?[]const u8 {
         if (self.active_source != null) return null;
         if (self.stored_key_status == .unavailable) return credentials.unreadable_store_message;
-        if (self.required_source == .chatgpt_subscription) {
-            return switch (surface) {
-                .cli => credentials.missing_chatgpt_credential_message,
-                .interactive => credentials.missing_chatgpt_interactive_credential_message,
-            };
-        }
-        if (self.required_source == .grok_subscription) {
-            return switch (surface) {
-                .cli => credentials.missing_grok_credential_message,
-                .interactive => credentials.missing_grok_interactive_credential_message,
-            };
-        }
-        return switch (surface) {
-            .cli => credentials.missing_credential_message,
-            .interactive => credentials.missing_interactive_credential_message,
-        };
+        return credentials.missingCredentialMessage(self.required_source, surface);
     }
 
     /// Returns owned doctor status text containing no credential bytes.
@@ -647,6 +642,14 @@ pub fn loadStatusSnapshotForProvider(
         error.OutOfMemory => return err,
         else => false,
     };
+    const opencode_connected = credentials.sourceExists(
+        alloc,
+        secret_store,
+        .opencode_api_key,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => false,
+    };
     // Resolves in `.stored` mode: a diagnostic must not refresh, because refreshing
     // rewrites the session file and performs network I/O. It reports the expired state
     // instead of repairing it.
@@ -675,9 +678,9 @@ pub fn loadStatusSnapshotForProvider(
         },
     };
     const resolved_source = if (resolution.credential) |credential| credential.source else null;
-    var gateway_connected = resolved_source != null and resolved_source != .chatgpt_subscription and resolved_source != .grok_subscription;
-    const gateway_probe_required = provider == .codex or provider == .grok or
-        resolved_source == .chatgpt_subscription or resolved_source == .grok_subscription;
+    var gateway_connected = resolved_source != null and model_provider.authorizesCredential(.gateway, resolved_source);
+    const gateway_probe_required = provider == .codex or provider == .grok or provider == .opencode or
+        (resolved_source != null and !model_provider.authorizesCredential(.gateway, resolved_source));
     if (gateway_probe_required) {
         for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key }) |source| {
             if (credentials.sourceExists(alloc, secret_store, source) catch |err| switch (err) {
@@ -702,20 +705,20 @@ pub fn loadStatusSnapshotForProvider(
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
             .grok_connected = grok_connected,
+            .opencode_connected = opencode_connected,
             .expired = expired,
         };
     }
     return .{
-        .required_source = if (provider == .codex)
-            .chatgpt_subscription
-        else if (provider == .grok)
-            .grok_subscription
+        .required_source = if (provider) |selected_provider|
+            model_provider.requiredCredentialSource(selected_provider)
         else
             null,
         .stored_key_status = resolution.stored_key_status,
         .gateway_connected = gateway_connected,
         .chatgpt_connected = chatgpt_connected,
         .grok_connected = grok_connected,
+        .opencode_connected = opencode_connected,
     };
 }
 
@@ -866,10 +869,12 @@ pub const Runtime = struct {
             self.source_inventory.contains(.stored_key);
         const chatgpt_connected = self.source_inventory.contains(.chatgpt_subscription);
         const grok_connected = self.source_inventory.contains(.grok_subscription);
+        const opencode_connected = self.source_inventory.contains(.opencode_api_key);
         const credential = self.selected_credential orelse return .{
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
             .grok_connected = grok_connected,
+            .opencode_connected = opencode_connected,
         };
         return .{
             .active_source = credential.source,
@@ -877,6 +882,7 @@ pub const Runtime = struct {
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
             .grok_connected = grok_connected,
+            .opencode_connected = opencode_connected,
             .expired = credential.needsRefreshAt(now_ms),
         };
     }
@@ -1054,7 +1060,7 @@ pub const Runtime = struct {
         self.picker_stage = .switch_credential;
         const active_source = self.credentialSource();
         self.picker_selection = if (active_source) |source|
-            if (source != .chatgpt_subscription and source != .grok_subscription and self.source_inventory.contains(source))
+            if (model_provider.authorizesCredential(.gateway, source) and self.source_inventory.contains(source))
                 .{ .source = source }
             else
                 self.pickerView().choiceAt(0)
@@ -1312,7 +1318,7 @@ pub const Runtime = struct {
                     .setup => {},
                     // Only reachable from the switch screen, never the root.
                     .automatic => unreachable,
-                    .login, .chatgpt_login, .grok_login => self.closePicker(alloc),
+                    .login, .chatgpt_login, .grok_login, .opencode_login => self.closePicker(alloc),
                 },
                 .team => unreachable,
             },
@@ -1404,35 +1410,23 @@ pub const Runtime = struct {
         alloc: Allocator,
         provider: model_provider.ProviderId,
     ) !?bool {
-        return switch (provider) {
-            .codex => if (self.credentialSource() == .chatgpt_subscription)
-                false
-            else
-                self.selectSourceWithLoader(
-                    alloc,
-                    .chatgpt_subscription,
-                    self,
-                    loadRuntimeCredentialSource,
-                ),
-            .grok => if (self.credentialSource() == .grok_subscription)
-                false
-            else
-                self.selectSourceWithLoader(
-                    alloc,
-                    .grok_subscription,
-                    self,
-                    loadRuntimeCredentialSource,
-                ),
-            .gateway => if (self.credentialSource() != .chatgpt_subscription and self.credentialSource() != .grok_subscription)
-                false
-            else
-                @as(?bool, try self.reselectByPrecedenceWithDeps(
-                    alloc,
-                    self,
-                    probeCredentialSource,
-                    loadRuntimeCredentialSource,
-                )),
-        };
+        if (model_provider.requiredCredentialSource(provider)) |required_source| {
+            if (self.credentialSource() == required_source) return false;
+            return self.selectSourceWithLoader(
+                alloc,
+                required_source,
+                self,
+                loadRuntimeCredentialSource,
+            );
+        }
+        const current_source = self.credentialSource() orelse return false;
+        if (model_provider.authorizesCredential(.gateway, current_source)) return false;
+        return @as(?bool, try self.reselectByPrecedenceWithDeps(
+            alloc,
+            self,
+            probeCredentialSource,
+            loadRuntimeCredentialSource,
+        ));
     }
 
     pub fn refreshFxLoginIfNeeded(self: *Self, alloc: Allocator) !bool {
@@ -1468,7 +1462,7 @@ pub const Runtime = struct {
 
         try self.refreshSourceInventoryWithProbe(alloc, ctx, probe);
         for (credential_source_order) |source| {
-            if (source == .chatgpt_subscription or source == .grok_subscription) continue;
+            if (!model_provider.authorizesCredential(.gateway, source)) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) {
                 return self.credentialSource() != previous;
@@ -1494,6 +1488,18 @@ pub const Runtime = struct {
     pub fn reconcileAfterGrokLogout(self: *Self, alloc: Allocator) !bool {
         const was_available = self.source_inventory.contains(.grok_subscription);
         const was_active = self.credentialSource() == .grok_subscription;
+        if (was_active) {
+            if (self.selected_credential) |*credential| credential.deinit(alloc);
+            self.selected_credential = null;
+            self.credential_refresh_failure_source = null;
+        }
+        try self.refreshSourceInventory(alloc);
+        return was_active or was_available;
+    }
+
+    pub fn reconcileAfterOpenCodeLogout(self: *Self, alloc: Allocator) !bool {
+        const was_available = self.source_inventory.contains(.opencode_api_key);
+        const was_active = self.credentialSource() == .opencode_api_key;
         if (was_active) {
             if (self.selected_credential) |*credential| credential.deinit(alloc);
             self.selected_credential = null;
@@ -1530,7 +1536,7 @@ pub const Runtime = struct {
         if (!login_was_active) return false;
 
         for (credential_source_order) |source| {
-            if (source == .chatgpt_subscription or source == .grok_subscription) continue;
+            if (!model_provider.authorizesCredential(.gateway, source)) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) return true;
             self.source_inventory.remove(source);
@@ -1626,7 +1632,7 @@ fn takeDisplayTeam(alloc: Allocator, credential: *credentials.Credential) ?[]u8 
 fn gatewaySourceCount(sources: SourceSet) usize {
     var count: usize = 0;
     for (credential_source_order) |source| {
-        if (source == .chatgpt_subscription or source == .grok_subscription or !sources.contains(source)) continue;
+        if (!model_provider.authorizesCredential(.gateway, source) or !sources.contains(source)) continue;
         count += 1;
     }
     return count;
@@ -1635,7 +1641,7 @@ fn gatewaySourceCount(sources: SourceSet) usize {
 fn gatewaySourceAtIndex(sources: SourceSet, wanted_index: usize) ?credentials.Source {
     var index: usize = 0;
     for (credential_source_order) |source| {
-        if (source == .chatgpt_subscription or source == .grok_subscription or !sources.contains(source)) continue;
+        if (!model_provider.authorizesCredential(.gateway, source) or !sources.contains(source)) continue;
         if (index == wanted_index) return source;
         index += 1;
     }
@@ -1823,6 +1829,25 @@ test "auth failure snapshot names every selected source without exposing styling
         try std.testing.expectEqual(@as(i64, 401), parsed.value.object.get("http_status").?.integer);
         try std.testing.expect(std.mem.find(u8, json, "\x1b") == null);
     }
+}
+
+test "OpenCode unauthorized failure distinguishes credentials from model access" {
+    const snapshot = FailureSnapshot.fromHttp(.unauthorized, .opencode_api_key).?;
+
+    const message = try snapshot.renderText(std.testing.allocator);
+    defer std.testing.allocator.free(message);
+    try std.testing.expectEqualStrings(
+        "OpenCode rejected the API key or selected model access · HTTP 401",
+        message,
+    );
+
+    const json = try snapshot.renderJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("OpenCode API key", parsed.value.object.get("source").?.string);
+    try std.testing.expectEqualStrings("http_unauthorized", parsed.value.object.get("reason").?.string);
+    try std.testing.expectEqual(@as(i64, 401), parsed.value.object.get("http_status").?.integer);
 }
 
 test "auth failure snapshot keeps refresh failures distinct from HTTP rejection" {
@@ -2295,16 +2320,16 @@ test "auth picker root starts on sign in and keeps sources in the switch stage" 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.active);
     try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
-    try std.testing.expectEqual(@as(usize, 7), picker.choiceCount());
-    try std.testing.expectEqualStrings("Switch provider", picker.choiceLabel(picker.choiceAt(4).?));
-    try std.testing.expect(picker.choiceAt(7) == null);
+    try std.testing.expectEqual(@as(usize, 8), picker.choiceCount());
+    try std.testing.expectEqualStrings("Switch provider", picker.choiceLabel(picker.choiceAt(5).?));
+    try std.testing.expect(picker.choiceAt(8) == null);
 }
 
-test "credential switcher excludes provider-routed subscription sessions" {
+test "credential switcher excludes provider-routed credentials" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     defer runtime.deinit(alloc);
-    runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .chatgpt_subscription, .grok_subscription });
+    runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .chatgpt_subscription, .grok_subscription, .opencode_api_key });
     runtime.openPicker(alloc);
     runtime.openSwitchCredentialPicker(alloc);
 
@@ -2314,7 +2339,7 @@ test "credential switcher excludes provider-routed subscription sessions" {
     try std.testing.expect((Choice{ .action = .automatic }).eql(picker.choiceAt(1).?));
 }
 
-test "auth picker navigation wraps across the seven hub actions" {
+test "auth picker navigation wraps across the eight hub actions" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .fx_login });
@@ -2324,6 +2349,8 @@ test "auth picker navigation wraps across the seven hub actions" {
     try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expect((Choice{ .action = .grok_login }).eql(runtime.pickerView().selected_choice.?));
+    try std.testing.expect(runtime.movePicker(1));
+    try std.testing.expect((Choice{ .action = .opencode_login }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expect((Choice{ .action = .setup }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
@@ -2359,7 +2386,7 @@ test "auth picker without credentials exposes acquisition actions" {
     try std.testing.expect(picker.active_source == null);
     try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
     try std.testing.expectEqual(@as(usize, 0), picker.available_sources.count());
-    try std.testing.expectEqual(@as(usize, 7), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 8), picker.choiceCount());
     try std.testing.expect(!picker.choiceEnabled(.{ .action = .change_team }));
     try std.testing.expectEqualStrings("missing", picker.activeSourceLabel());
 }
@@ -2371,13 +2398,14 @@ test "auth onboarding picker exposes the setup paths" {
 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.include_skip);
-    try std.testing.expectEqual(@as(usize, 4), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 5), picker.choiceCount());
     try std.testing.expect((Choice{ .action = .login }).eql(picker.choiceAt(0).?));
     try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(picker.choiceAt(1).?));
     try std.testing.expect((Choice{ .action = .grok_login }).eql(picker.choiceAt(2).?));
-    try std.testing.expect((Choice{ .action = .setup }).eql(picker.choiceAt(3).?));
-    try std.testing.expectEqualStrings("Add an API key", picker.choiceLabel(picker.choiceAt(3).?));
-    try std.testing.expect(picker.choiceAt(4) == null);
+    try std.testing.expect((Choice{ .action = .opencode_login }).eql(picker.choiceAt(3).?));
+    try std.testing.expect((Choice{ .action = .setup }).eql(picker.choiceAt(4).?));
+    try std.testing.expectEqualStrings("Add an API key", picker.choiceLabel(picker.choiceAt(4).?));
+    try std.testing.expect(picker.choiceAt(5) == null);
 }
 
 test "clearing a remembered choice re-resolves even when no login was active" {

--- a/src/core/auth/auth_transition.zig
+++ b/src/core/auth/auth_transition.zig
@@ -39,6 +39,7 @@ pub const LogoutFacts = struct {
 
 pub fn decideLogoutProvider(facts: LogoutFacts) model_provider.ProviderId {
     if (facts.requested) |provider| return provider;
+    if (facts.selected == .opencode or facts.active_source == .opencode_api_key) return .opencode;
     if (facts.selected == .grok or facts.active_source == .grok_subscription) return .grok;
     if (facts.selected == .codex or facts.active_source == .chatgpt_subscription) return .codex;
 
@@ -73,6 +74,10 @@ pub fn signInCompletion(
             .{ .switch_provider = .grok }
         else
             .{ .activate_source = .grok_subscription },
+        .opencode => if (provider_routing_supported)
+            .{ .switch_provider = .opencode }
+        else
+            .{ .activate_source = .opencode_api_key },
     };
 }
 

--- a/src/core/auth/credential_authority.zig
+++ b/src/core/auth/credential_authority.zig
@@ -25,6 +25,7 @@ pub fn derive(
         .ai_gateway_api_key,
         .fx_login,
         .stored_key,
+        .opencode_api_key,
         => hash.update("\x00slot\x00"),
         .chatgpt_subscription,
         .grok_subscription,

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -9,6 +9,7 @@ const model_provider = @import("../config/model_provider.zig");
 const oauth = @import("oauth.zig");
 const oauth_session = @import("oauth_session.zig");
 const oauth_transport = @import("oauth_transport.zig");
+const opencode_session = @import("opencode_session.zig");
 const secret = @import("secret.zig");
 const types = @import("../shared/types.zig");
 
@@ -44,6 +45,7 @@ pub const CatalogAuthenticatedSource = enum {
     stored_key,
     chatgpt_subscription,
     grok_subscription,
+    opencode_api_key,
 
     fn credentialSource(self: CatalogAuthenticatedSource) Source {
         return switch (self) {
@@ -53,6 +55,7 @@ pub const CatalogAuthenticatedSource = enum {
             .stored_key => .stored_key,
             .chatgpt_subscription => .chatgpt_subscription,
             .grok_subscription => .grok_subscription,
+            .opencode_api_key => .opencode_api_key,
         };
     }
 };
@@ -91,7 +94,10 @@ pub const CatalogAccess = union(enum) {
     pub fn publicFallbackAfterRejection(self: CatalogAccess) ?CatalogAccess {
         return switch (self) {
             .public_only => null,
-            .authenticated => |access| if (access.source == .chatgpt_subscription or access.source == .grok_subscription)
+            .authenticated => |access| if (!model_provider.authorizesCredential(
+                .gateway,
+                access.source.credentialSource(),
+            ))
                 null
             else
                 .{
@@ -168,6 +174,7 @@ pub fn catalogAccessForCredentialAndAccount(
         .stored_key => .stored_key,
         .chatgpt_subscription => .chatgpt_subscription,
         .grok_subscription => .grok_subscription,
+        .opencode_api_key => .opencode_api_key,
         .fx_login => blk: {
             const team = team_context orelse
                 return .{ .public_only = .fx_login_team_required };
@@ -180,7 +187,7 @@ pub fn catalogAccessForCredentialAndAccount(
         .authenticated = .{
             .source = authenticated_source,
             .credential = credential,
-            .team_context = if (authenticated_source == .chatgpt_subscription or authenticated_source == .grok_subscription) null else team_context,
+            .team_context = if (model_provider.authorizesCredential(.gateway, selected_source)) team_context else null,
             .account_id = if (authenticated_source == .grok_subscription) account_id else null,
         },
     };
@@ -202,7 +209,35 @@ pub const missing_chatgpt_credential_message = "fx needs a Codex subscription lo
 pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login and choose Sign in with Codex.";
 pub const missing_grok_credential_message = "fx needs a Grok subscription login for this model. Run fx login grok.";
 pub const missing_grok_interactive_credential_message = "Grok needs a subscription login. Run /login and choose Sign in with Grok.";
+pub const missing_opencode_credential_message = "fx needs an OpenCode API key for this model. Set OPENCODE_API_KEY and run fx login opencode.";
+pub const missing_opencode_interactive_credential_message = "OpenCode needs an API key. Set OPENCODE_API_KEY, then run /login and choose Sign in with OpenCode.";
 pub const unreadable_store_message = "Fx could not read the stored API key from " ++ stored_key_backend_label ++ ". A key may be saved but unreadable. Set FX_TRACE_LOG for the failing step, or set AI_GATEWAY_API_KEY.";
+
+pub const MissingHelpSurface = enum {
+    cli,
+    interactive,
+};
+
+pub fn missingCredentialMessage(required_source: ?Source, surface: MissingHelpSurface) []const u8 {
+    return switch (required_source orelse .fx_login) {
+        .chatgpt_subscription => switch (surface) {
+            .cli => missing_chatgpt_credential_message,
+            .interactive => missing_chatgpt_interactive_credential_message,
+        },
+        .grok_subscription => switch (surface) {
+            .cli => missing_grok_credential_message,
+            .interactive => missing_grok_interactive_credential_message,
+        },
+        .opencode_api_key => switch (surface) {
+            .cli => missing_opencode_credential_message,
+            .interactive => missing_opencode_interactive_credential_message,
+        },
+        else => switch (surface) {
+            .cli => missing_credential_message,
+            .interactive => missing_interactive_credential_message,
+        },
+    };
+}
 
 pub const Credential = struct {
     token: []u8,
@@ -291,6 +326,10 @@ pub fn resolveForProvider(
             };
             return .{ .credential = credential };
         },
+        .opencode => {
+            const credential = try loadSource(alloc, transport, secret_store, .opencode_api_key);
+            return .{ .credential = credential };
+        },
         .gateway => {},
     }
     return resolvePreferring(
@@ -298,7 +337,7 @@ pub fn resolveForProvider(
         transport,
         secret_store,
         mode,
-        if (preferred == .chatgpt_subscription or preferred == .grok_subscription) null else preferred,
+        if (preferred != null and model_provider.authorizesCredential(.gateway, preferred)) preferred else null,
     );
 }
 
@@ -405,6 +444,7 @@ pub fn loadSource(
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
         .chatgpt_subscription => loadChatGptCredential(alloc, transport, .if_needed),
         .grok_subscription => loadGrokCredential(alloc, transport, .if_needed),
+        .opencode_api_key => loadOpenCodeApiKeyCredential(alloc),
     };
 }
 
@@ -430,6 +470,7 @@ pub fn sourceExists(
         },
         .chatgpt_subscription => chatgpt_oauth.sourceExists(alloc),
         .grok_subscription => grok_oauth.sourceExists(alloc),
+        .opencode_api_key => try openCodeFileKeyExists(alloc),
         .stored_key => blk: {
             if (secret_store.isDisabled()) break :blk false;
             const stored = secret_store.load(alloc) catch |err| switch (err) {
@@ -465,6 +506,25 @@ fn loadStoredKeyCredential(
     if (secret_store.isDisabled()) return null;
     const value = (try secret_store.load(alloc)) orelse return null;
     return .{ .token = value, .source = .stored_key };
+}
+
+fn openCodeFileKeyExists(alloc: std.mem.Allocator) !bool {
+    var session = opencode_session.load(alloc) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "source probe failed source=opencode_api_key err={s}", .{@errorName(err)});
+            return false;
+        },
+    };
+    defer if (session) |*loaded| loaded.deinit(alloc);
+    return session != null;
+}
+
+fn loadOpenCodeApiKeyCredential(alloc: std.mem.Allocator) !?Credential {
+    var session = try opencode_session.load(alloc);
+    defer if (session) |*loaded| loaded.deinit(alloc);
+    const stored = session orelse return null;
+    return .{ .token = try alloc.dupe(u8, stored.api_key), .source = .opencode_api_key };
 }
 
 fn loadChatGptCredential(
@@ -656,6 +716,7 @@ pub fn sourceLabel(source: Source) []const u8 {
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
         .chatgpt_subscription => "Codex subscription",
         .grok_subscription => "Grok subscription",
+        .opencode_api_key => "OpenCode API key",
     };
 }
 

--- a/src/core/auth/opencode_session.zig
+++ b/src/core/auth/opencode_session.zig
@@ -1,0 +1,234 @@
+const std = @import("std");
+const debug_trace = @import("../shared/debug_trace.zig");
+const host_target = @import("../hosts/target.zig");
+const io_mod = @import("../shared/io.zig");
+const profile_paths = @import("../shared/profile_paths.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+const schema_version: i64 = 1;
+const max_auth_file_bytes: usize = 64 * 1024;
+const mutation_lock_file_name = "opencode-auth.lock";
+const mutation_lock_deadline_ms: u64 = 2000;
+const max_api_key_bytes: usize = 8 * 1024;
+
+const auth_file_name = profile_paths.opencode_auth_file_name;
+
+pub const Session = struct {
+    api_key: []u8,
+
+    pub fn deinit(self: *Session, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.api_key);
+        self.* = undefined;
+    }
+};
+
+pub const DeleteOutcome = enum {
+    deleted,
+    missing,
+    deleted_not_durable,
+};
+
+const Mutation = struct {
+    fx_dir: io_mod.VerifiedDir,
+    lock: io_mod.TimedAdvisoryLock,
+
+    fn deinit(self: *Mutation) void {
+        self.lock.release();
+        self.fx_dir.close();
+        self.* = undefined;
+    }
+
+    fn save(self: *Mutation, alloc: Allocator, session: Session) !void {
+        const text = try stringify(alloc, session);
+        defer secret.zeroAndFree(alloc, text);
+        try io_mod.durableReplaceVerified(alloc, &self.fx_dir, auth_file_name, text);
+    }
+
+    fn delete(self: *Mutation) !DeleteOutcome {
+        self.fx_dir.dir.deleteFile(io_mod.getIo(), auth_file_name) catch |err| switch (err) {
+            error.FileNotFound => return .missing,
+            else => return err,
+        };
+        const durable: io_mod.DurableOps = .{};
+        durable.sync_dir(durable.ctx, self.fx_dir.dir) catch return .deleted_not_durable;
+        return .deleted;
+    }
+};
+
+pub fn load(alloc: Allocator) !?Session {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return null;
+    var home_dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch return null;
+    defer home_dir.close(io_mod.getIo());
+    var fx_dir = home_dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer fx_dir.close(io_mod.getIo());
+    return loadFromDir(alloc, &fx_dir);
+}
+
+fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir) !?Session {
+    var file = fx_dir.openFile(io_mod.getIo(), auth_file_name, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => {
+            debug_trace.logf("auth", "OpenCode session load failed step=open_file err={s}", .{@errorName(err)});
+            return null;
+        },
+    };
+    defer file.close(io_mod.getIo());
+
+    const stat = try file.stat(io_mod.getIo());
+    if (stat.kind != .file or stat.permissions.toMode() & 0o077 != 0) {
+        debug_trace.logf("auth", "OpenCode session load failed step=permissions err=InsecureAuthFile", .{});
+        return null;
+    }
+    const bytes = try io_mod.readFileToEnd(alloc, &file, max_auth_file_bytes);
+    defer secret.zeroAndFree(alloc, bytes);
+    return parse(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "OpenCode session load failed step=parse err={s}", .{@errorName(err)});
+            return null;
+        },
+    };
+}
+
+pub fn saveNewSession(alloc: Allocator, session: Session) !void {
+    if (comptime host_target.is_wasm) return error.OpenCodeAuthUnavailable;
+    var mutation = try beginMutation();
+    defer mutation.deinit();
+    try mutation.save(alloc, session);
+}
+
+pub fn logout() !DeleteOutcome {
+    var mutation = (try beginExistingMutation()) orelse return .missing;
+    defer mutation.deinit();
+    return mutation.delete();
+}
+
+fn beginExistingMutation() !?Mutation {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+
+    const fx_dir = openExistingPrivateFxDir(&home_dir) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    return try lockMutation(fx_dir);
+}
+
+fn beginMutation() !Mutation {
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+
+    const fx_dir = try io_mod.openOrCreateVerifiedPrivateDir(&home_dir, profile_paths.root_dir_name);
+    return lockMutation(fx_dir);
+}
+
+fn lockMutation(open_fx_dir: io_mod.VerifiedDir) !Mutation {
+    var fx_dir = open_fx_dir;
+    errdefer fx_dir.close();
+    var lock = try io_mod.acquireTimedAdvisoryLock(
+        &fx_dir,
+        mutation_lock_file_name,
+        mutation_lock_deadline_ms,
+    );
+    errdefer lock.release();
+    return .{ .fx_dir = fx_dir, .lock = lock };
+}
+
+fn openExistingPrivateFxDir(home_dir: *io_mod.VerifiedDir) !io_mod.VerifiedDir {
+    var dir = try home_dir.dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    errdefer dir.close(io_mod.getIo());
+
+    const initial_stat = try dir.stat(io_mod.getIo());
+    if (initial_stat.kind != .directory) return error.DurablePathUnsafe;
+    if (initial_stat.permissions.toMode() & 0o200 == 0) return error.PrivateStatePermissionsUnsupported;
+    dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {
+        return error.PrivateStatePermissionsUnsupported;
+    };
+    const stat = try dir.stat(io_mod.getIo());
+    if (stat.kind != .directory or stat.permissions.toMode() & 0o777 != 0o700) {
+        return error.PrivateStatePermissionsUnsupported;
+    }
+    return .{ .dir = dir };
+}
+
+fn parse(alloc: Allocator, bytes: []const u8) !Session {
+    if (bytes.len > max_auth_file_bytes) return error.OpenCodeAuthFileTooLarge;
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidOpenCodeAuthFile;
+    const version = parsed.value.object.get("schema_version") orelse return error.InvalidOpenCodeAuthFile;
+    if (version != .integer or version.integer != schema_version) return error.InvalidOpenCodeAuthFile;
+    const api_key_value = parsed.value.object.get("api_key") orelse return error.InvalidOpenCodeAuthFile;
+    if (api_key_value != .string) return error.InvalidOpenCodeAuthFile;
+    if (!validApiKey(api_key_value.string)) return error.InvalidOpenCodeAuthFile;
+    return .{ .api_key = try alloc.dupe(u8, api_key_value.string) };
+}
+
+fn stringify(alloc: Allocator, session: Session) ![]u8 {
+    if (!validApiKey(session.api_key)) return error.InvalidOpenCodeAuthFile;
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"schema_version\":");
+    try out.writer.print("{d}", .{schema_version});
+    try out.writer.writeAll(",\"api_key\":");
+    try std.json.Stringify.value(session.api_key, .{}, &out.writer);
+    try out.writer.writeAll("}\n");
+    return out.toOwnedSlice();
+}
+
+pub fn validApiKey(value: []const u8) bool {
+    if (value.len == 0 or value.len > max_api_key_bytes) return false;
+    for (value) |byte| if (byte < 0x20 or byte == 0x7f) return false;
+    return true;
+}
+
+test "OpenCode auth session round trips and validates its schema" {
+    const alloc = std.testing.allocator;
+    var session = Session{ .api_key = try alloc.dupe(u8, "oc_test_key") };
+    defer session.deinit(alloc);
+
+    const encoded = try stringify(alloc, session);
+    defer secret.zeroAndFree(alloc, encoded);
+    var decoded = try parse(alloc, encoded);
+    defer decoded.deinit(alloc);
+    try std.testing.expectEqualStrings(session.api_key, decoded.api_key);
+
+    try std.testing.expectError(
+        error.InvalidOpenCodeAuthFile,
+        parse(alloc, "{\"schema_version\":2,\"api_key\":\"oc_test_key\"}"),
+    );
+    try std.testing.expectError(
+        error.InvalidOpenCodeAuthFile,
+        parse(alloc, "{\"schema_version\":1,\"api_key\":\"bad\\nkey\"}"),
+    );
+}
+
+test "OpenCode API keys are bounded before serialization" {
+    try std.testing.expect(validApiKey("oc_test_key"));
+    try std.testing.expect(!validApiKey(""));
+    try std.testing.expect(!validApiKey("bad\r\nkey"));
+    try std.testing.expect(!validApiKey("a" ** (max_api_key_bytes + 1)));
+}

--- a/src/core/auth/provider_catalog.zig
+++ b/src/core/auth/provider_catalog.zig
@@ -37,6 +37,14 @@ pub const entries = [_]Entry{
         .description = "SuperGrok or X Premium subscription",
         .subscription = true,
     },
+    .{
+        .id = .opencode,
+        .slug = "opencode",
+        .name = "OpenCode",
+        .route_name = "OpenCode",
+        .description = "Zen or Go API key from opencode.ai",
+        .subscription = false,
+    },
 };
 
 pub fn parse(value: []const u8) ?model_provider.ProviderId {
@@ -61,9 +69,12 @@ test "auth provider catalog uses the model provider identity and explicit aliase
     try std.testing.expectEqual(model_provider.ProviderId.gateway, parse("gateway").?);
     try std.testing.expectEqual(model_provider.ProviderId.codex, parse("codex").?);
     try std.testing.expectEqual(model_provider.ProviderId.grok, parse("grok").?);
+    try std.testing.expectEqual(model_provider.ProviderId.opencode, parse("opencode").?);
+    try std.testing.expect(parse("zen") == null);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("chatgpt") == null);
     try std.testing.expect(parse("unknown") == null);
     try std.testing.expect(find(.codex).subscription);
     try std.testing.expect(find(.grok).subscription);
+    try std.testing.expect(!find(.opencode).subscription);
 }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1376,12 +1376,10 @@ fn missingCredentialResult(
     options: RunOptions,
     provider: model_provider.ProviderId,
 ) !PromptRunResult {
-    const message = if (provider == .codex)
-        credentials.missing_chatgpt_credential_message
-    else if (provider == .grok)
-        credentials.missing_grok_credential_message
-    else
-        credentials.missing_credential_message;
+    const message = credentials.missingCredentialMessage(
+        model_provider.requiredCredentialSource(provider),
+        .cli,
+    );
     try options.deps.write_stderr(options.deps.stderr_ctx, "fx ask: ");
     try options.deps.write_stderr(options.deps.stderr_ctx, message);
     try options.deps.write_stderr(options.deps.stderr_ctx, "\n");

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -6,6 +6,7 @@ const background_record_liveness = @import("../background/background_record_live
 const background_store = @import("../background/background_store.zig");
 const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
 const grok_oauth = @import("../auth/grok_oauth.zig");
+const opencode_session = @import("../auth/opencode_session.zig");
 const acp_runner = @import("acp_runner.zig");
 const cli_ask = @import("cli_ask.zig");
 const cli_replay = @import("cli_replay.zig");
@@ -685,6 +686,7 @@ fn activateProviderSelection(
             .gateway => "Gateway is already selected.\n",
             .codex => "Codex is already selected.\n",
             .grok => "Grok is already selected.\n",
+            .opencode => "OpenCode is already selected.\n",
         });
         return true;
     }
@@ -731,6 +733,7 @@ fn activateProviderSelection(
             switch (target) {
                 .codex => "Codex credential is unavailable",
                 .grok => "Grok credential is unavailable",
+                .opencode => "OpenCode credential is unavailable",
                 .gateway => "configure a Gateway credential first",
             },
         );
@@ -740,6 +743,7 @@ fn activateProviderSelection(
         try writeProviderActivationError(alloc, deps, caller, switch (target) {
             .codex => "Codex model catalog is unavailable",
             .grok => "Grok model catalog is unavailable",
+            .opencode => "OpenCode model catalog is unavailable",
             .gateway => "Gateway model catalog is unavailable",
         });
         return false;
@@ -785,6 +789,7 @@ fn activateProviderSelection(
     if (performed_login) |provider| switch (provider) {
         .codex => try writeStdout(deps, "Signed in with Codex.\n"),
         .grok => try writeStdout(deps, "Signed in with Grok.\n"),
+        .opencode => try writeStdout(deps, "Signed in with OpenCode.\n"),
         .gateway => unreachable,
     };
     if (caller == .provider_command) {
@@ -792,6 +797,7 @@ fn activateProviderSelection(
             .gateway => "Provider set to Gateway.\n",
             .codex => "Provider set to Codex.\n",
             .grok => "Provider set to Grok.\n",
+            .opencode => "Provider set to OpenCode.\n",
         });
     }
     return true;
@@ -910,7 +916,7 @@ fn runNonInteractiveWithDeps(
         .issue => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .issue),
         .login => |rest| {
             const maybe_login_provider = parseLoginProvider(rest) catch {
-                try writeStderr(deps, "usage: fx login [vercel|codex|grok]\n");
+                try writeStderr(deps, "usage: fx login [vercel|codex|grok|opencode]\n");
                 return .handled_failure;
             };
             // Preserve the original `fx login` behavior for scripts and users.
@@ -964,12 +970,29 @@ fn runNonInteractiveWithDeps(
                     }
                     try writeStdout(deps, "Signed in with Grok.\n");
                 },
+                .opencode => {
+                    const key = io_mod.getenv("OPENCODE_API_KEY") orelse {
+                        try writeStderr(deps, "fx login: set OPENCODE_API_KEY to your opencode.ai key first\n");
+                        return .handled_failure;
+                    };
+                    var session = opencode_session.Session{ .api_key = try alloc.dupe(u8, key) };
+                    defer session.deinit(alloc);
+                    opencode_session.saveNewSession(alloc, session) catch |err| {
+                        debug_trace.logf("auth", "OpenCode login failed err={s}", .{@errorName(err)});
+                        try writeStderr(deps, "fx login: failed to store the OpenCode API key\n");
+                        return .handled_failure;
+                    };
+                    if (!try activateProviderSelection(alloc, cfg, deps, .opencode, .provider_login)) {
+                        return .handled_failure;
+                    }
+                    try writeStdout(deps, "Signed in with OpenCode.\n");
+                },
             }
             return .handled_success;
         },
         .logout => |rest| {
             const maybe_login_provider = parseLoginProvider(rest) catch {
-                try writeStderr(deps, "usage: fx logout [vercel|codex|grok]\n");
+                try writeStderr(deps, "usage: fx logout [vercel|codex|grok|opencode]\n");
                 return .handled_failure;
             };
             // Preserve the original `fx logout` behavior for scripts and users.
@@ -1017,6 +1040,26 @@ fn runNonInteractiveWithDeps(
                     },
                 };
             }
+            if (login_provider == .opencode) {
+                const outcome = opencode_session.logout() catch {
+                    try writeStderr(deps, "fx logout: failed to durably remove saved OpenCode login\n");
+                    return .handled_failure;
+                };
+                return switch (outcome) {
+                    .deleted => result: {
+                        try writeStdout(deps, "Signed out of OpenCode.\n");
+                        break :result .handled_success;
+                    },
+                    .missing => result: {
+                        try writeStdout(deps, "No OpenCode login session found.\n");
+                        break :result .handled_success;
+                    },
+                    .deleted_not_durable => result: {
+                        try writeStderr(deps, "fx logout: failed to durably remove saved OpenCode login\n");
+                        break :result .handled_failure;
+                    },
+                };
+            }
             const result = login_flow.logout(alloc, cfg.gateway_provider.oauth_transport) catch |err| switch (err) {
                 error.SessionDeleteFailed => {
                     try writeStderr(deps, "fx logout: failed to durably remove saved Fx login\n");
@@ -1058,11 +1101,11 @@ fn runNonInteractiveWithDeps(
         },
         .provider => |rest| {
             if (rest.len != 1) {
-                try writeStderr(deps, "usage: fx provider <gateway|codex|grok>\n");
+                try writeStderr(deps, "usage: fx provider <gateway|codex|grok|opencode>\n");
                 return .handled_failure;
             }
             const target = model_provider.parse(rest[0]) orelse {
-                try writeStderr(deps, "fx provider: expected gateway, codex, or grok\n");
+                try writeStderr(deps, "fx provider: expected gateway, codex, grok, or opencode\n");
                 return .handled_failure;
             };
             return if (try activateProviderSelection(alloc, cfg, deps, target, .provider_command))
@@ -1150,6 +1193,7 @@ fn runNonInteractiveWithDeps(
                     .gateway => "fx models: Gateway model catalog is unavailable\n",
                     .codex => "fx models: Codex model catalog is unavailable\n",
                     .grok => "fx models: Grok model catalog is unavailable\n",
+                    .opencode => "fx models: OpenCode model catalog is unavailable\n",
                 });
                 return .handled_failure;
             };

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -545,6 +545,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "provider",
         "codex_model",
         "grok_model",
+        "opencode_model",
         "effort",
         "fast_mode",
         "slash_menu_categories",
@@ -1299,6 +1300,12 @@ fn parseProfileOnlyFields(
                 try settings.models.putCopy(alloc, provider, model_value.string);
             }
         }
+    }
+
+    if (root.object.get("opencode_model")) |model_value| {
+        if (model_value != .string) return error.InvalidOpenCodeModelType;
+        settings_store.validateModel(model_value.string) catch return error.InvalidOpenCodeModelValue;
+        try settings.models.putCopy(alloc, .opencode, model_value.string);
     }
 
     if (root.object.get("permission_mode")) |permission_mode_value| {

--- a/src/core/config/model_provider.zig
+++ b/src/core/config/model_provider.zig
@@ -5,6 +5,7 @@ pub const ProviderId = enum {
     gateway,
     codex,
     grok,
+    opencode,
 };
 
 pub const ProviderSelection = struct {
@@ -16,15 +17,25 @@ pub fn parse(value: []const u8) ?ProviderId {
     if (std.ascii.eqlIgnoreCase(value, "gateway")) return .gateway;
     if (std.ascii.eqlIgnoreCase(value, "codex")) return .codex;
     if (std.ascii.eqlIgnoreCase(value, "grok")) return .grok;
+    if (std.ascii.eqlIgnoreCase(value, "opencode")) return .opencode;
     return null;
+}
+
+pub fn requiredCredentialSource(provider: ProviderId) ?types.CredentialSource {
+    return switch (provider) {
+        .gateway => null,
+        .codex => .chatgpt_subscription,
+        .grok => .grok_subscription,
+        .opencode => .opencode_api_key,
+    };
 }
 
 pub fn authorizesCredential(provider: ProviderId, source: ?types.CredentialSource) bool {
     const selected = source orelse return false;
+    if (requiredCredentialSource(provider)) |required| return selected == required;
     return switch (provider) {
-        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription,
-        .codex => selected == .chatgpt_subscription,
-        .grok => selected == .grok_subscription,
+        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription and selected != .opencode_api_key,
+        .codex, .grok, .opencode => unreachable,
     };
 }
 
@@ -38,12 +49,17 @@ test "explicit providers authorize only their own credential origins" {
     try std.testing.expect(authorizesCredential(.grok, .grok_subscription));
     try std.testing.expect(!authorizesCredential(.grok, .chatgpt_subscription));
     try std.testing.expect(!authorizesCredential(.gateway, .grok_subscription));
+    try std.testing.expect(authorizesCredential(.opencode, .opencode_api_key));
+    try std.testing.expect(!authorizesCredential(.gateway, .opencode_api_key));
+    try std.testing.expectEqual(types.CredentialSource.opencode_api_key, requiredCredentialSource(.opencode).?);
+    try std.testing.expect(requiredCredentialSource(.gateway) == null);
 }
 
-test "provider parsing exposes gateway codex and grok" {
+test "provider parsing exposes every provider" {
     try std.testing.expectEqual(ProviderId.gateway, parse("gateway").?);
     try std.testing.expectEqual(ProviderId.codex, parse("CODEX").?);
     try std.testing.expectEqual(ProviderId.grok, parse("GROK").?);
+    try std.testing.expectEqual(ProviderId.opencode, parse("OpenCode").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("") == null);
 }

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -1411,6 +1411,7 @@ fn putModelPreference(
         .gateway => "model",
         .codex => "codex_model",
         .grok => "grok_model",
+        .opencode => "opencode_model",
     };
     if (root.contains(legacy_key)) {
         _ = root.orderedRemove(legacy_key);
@@ -1640,6 +1641,10 @@ fn validateKnownSettingsObject(
         }
     }
     if (object.get("codex_model")) |value| {
+        if (value != .string) return error.InvalidSettingsFormat;
+        try validateModel(value.string);
+    }
+    if (object.get("opencode_model")) |value| {
         if (value != .string) return error.InvalidSettingsFormat;
         try validateModel(value.string);
     }

--- a/src/core/gateway/provider_set.zig
+++ b/src/core/gateway/provider_set.zig
@@ -52,12 +52,14 @@ pub const Set = struct {
     gateway: Bundle,
     codex: Bundle,
     grok: Bundle,
+    opencode: Bundle,
 
     pub fn select(self: Set, provider: model_provider.ProviderId) Bundle {
         return switch (provider) {
             .gateway => self.gateway,
             .codex => self.codex,
             .grok => self.grok,
+            .opencode => self.opencode,
         };
     }
 
@@ -66,6 +68,7 @@ pub const Set = struct {
             .gateway = self.gateway.deferred_usage,
             .codex = self.codex.deferred_usage,
             .grok = self.grok.deferred_usage,
+            .opencode = self.opencode.deferred_usage,
         };
     }
 };
@@ -75,6 +78,7 @@ pub fn gateway_only(gateway: Bundle) Set {
         .gateway = gateway,
         .codex = .{},
         .grok = .{},
+        .opencode = .{},
     };
 }
 
@@ -82,6 +86,7 @@ test "provider set selects each provider's complete route" {
     var gateway_tag: u8 = 0;
     var codex_tag: u8 = 0;
     var grok_tag: u8 = 0;
+    var opencode_tag: u8 = 0;
 
     const Fake = struct {
         fn cli_catalog(
@@ -145,7 +150,15 @@ test "provider set selects each provider's complete route" {
         .model_catalog = .{ .context = &grok_tag, .fetch_fn = Fake.model_catalog_fetch },
         .permission_reviewer = .{ .context = &grok_tag, .review_fn = Fake.review },
     };
-    var providers = Set{ .gateway = gateway, .codex = codex, .grok = grok };
+    const opencode = Bundle{
+        .agent_stream = stream_provider.Provider{
+            .context = &opencode_tag,
+            .stream_fn = stream_provider.unavailable_provider.stream_fn,
+        },
+        .cli_model_catalog = .{ .context = &opencode_tag, .fetch_fn = Fake.cli_catalog },
+        .model_catalog = .{ .context = &opencode_tag, .fetch_fn = Fake.model_catalog_fetch },
+    };
+    var providers = Set{ .gateway = gateway, .codex = codex, .grok = grok, .opencode = opencode };
 
     try std.testing.expect(providers.select(.gateway).agent_stream.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(providers.select(.gateway).capabilities.fx_search);
@@ -160,6 +173,7 @@ test "provider set selects each provider's complete route" {
     try std.testing.expect(providers.select(.gateway).cli_model_catalog.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(providers.select(.codex).model_catalog.?.context.? == @as(*anyopaque, @ptrCast(&codex_tag)));
     try std.testing.expect(providers.select(.grok).permission_reviewer.?.context.? == @as(*anyopaque, @ptrCast(&grok_tag)));
+    try std.testing.expect(providers.select(.opencode).model_catalog.?.context.? == @as(*anyopaque, @ptrCast(&opencode_tag)));
     try std.testing.expect(providers.select(.codex).agent_stream_or_unavailable().context.? == @as(*anyopaque, @ptrCast(&codex_tag)));
 
     providers.codex.model_catalog = null;

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -363,7 +363,7 @@ fn writeTerminalSafe(writer: *std.Io.Writer, alloc: Allocator, raw: []const u8) 
 
 fn gatewayProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
     const source = auth.active_source orelse return auth.gateway_connected;
-    return auth.gateway_connected or (source != .chatgpt_subscription and source != .grok_subscription);
+    return auth.gateway_connected or model_provider.authorizesCredential(.gateway, source);
 }
 
 fn chatGptProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
@@ -372,6 +372,10 @@ fn chatGptProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
 
 fn grokProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
     return auth.grok_connected or auth.active_source == .grok_subscription;
+}
+
+fn openCodeProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
+    return auth.opencode_connected or auth.active_source == .opencode_api_key;
 }
 
 fn writeConnectedProvidersText(writer: *std.Io.Writer, auth: auth_runtime.StatusSnapshot) !void {
@@ -388,6 +392,11 @@ fn writeConnectedProvidersText(writer: *std.Io.Writer, auth: auth_runtime.Status
     if (grokProviderConnected(auth)) {
         if (wrote_provider) try writer.writeAll(", Grok");
         if (!wrote_provider) try writer.writeAll("Grok");
+        wrote_provider = true;
+    }
+    if (openCodeProviderConnected(auth)) {
+        if (wrote_provider) try writer.writeAll(", OpenCode");
+        if (!wrote_provider) try writer.writeAll("OpenCode");
         wrote_provider = true;
     }
     if (!wrote_provider) try writer.writeAll("none");
@@ -526,6 +535,12 @@ pub const StatusSnapshot = struct {
             if (grokProviderConnected(self.auth)) {
                 if (wrote_provider) try writer.writeByte(',');
                 try std.json.Stringify.value("grok", .{}, writer);
+                wrote_provider = true;
+            }
+            if (openCodeProviderConnected(self.auth)) {
+                if (wrote_provider) try writer.writeByte(',');
+                try std.json.Stringify.value("opencode", .{}, writer);
+                wrote_provider = true;
             }
             try writer.writeByte(']');
         }
@@ -751,6 +766,7 @@ pub const ModelListSnapshot = struct {
             .gateway => "gateway",
             .codex => provider_catalog.label(.codex),
             .grok => provider_catalog.label(.grok),
+            .opencode => provider_catalog.label(.opencode),
         };
     }
 
@@ -2032,6 +2048,29 @@ test "status distinguishes the selected model route from connected providers" {
     defer std.testing.allocator.free(json);
     try std.testing.expect(std.mem.find(u8, json, "\"model_source\":\"Codex subscription\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"connected_providers\":[\"vercel-ai-gateway\",\"codex\"]") != null);
+}
+
+test "status renders OpenCode as the only connected provider" {
+    const snapshot = StatusSnapshot{
+        .model = "big-pickle",
+        .provider = .opencode,
+        .auth = .{
+            .active_source = .opencode_api_key,
+            .opencode_connected = true,
+        },
+        .permission_mode = .auto,
+        .workspace_root = "/tmp/fx",
+        .history_turns = 0,
+        .session_permission_grants = 0,
+        .agent_step_limit = 24,
+    };
+    const text = try snapshot.renderText(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.find(u8, text, "connected_providers=OpenCode\n") != null);
+
+    const json = try snapshot.renderJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.find(u8, json, "\"connected_providers\":[\"opencode\"]") != null);
 }
 
 test "MCP config diagnostic renders in status text and JSON but not interactive body" {

--- a/src/core/session/generation_usage_provider.zig
+++ b/src/core/session/generation_usage_provider.zig
@@ -85,6 +85,7 @@ pub const Set = struct {
     gateway: ?Provider = null,
     codex: ?Provider = null,
     grok: ?Provider = null,
+    opencode: ?Provider = null,
 
     pub fn gatewayOnly(provider: Provider) Set {
         return .{ .gateway = provider };
@@ -95,6 +96,7 @@ pub const Set = struct {
             .gateway => self.gateway,
             .codex => self.codex,
             .grok => self.grok,
+            .opencode => self.opencode,
         };
     }
 };
@@ -155,4 +157,5 @@ test "generation usage providers are selected by provider identity" {
     try std.testing.expect(routes.select(.gateway) != null);
     try std.testing.expect(routes.select(.codex) == null);
     try std.testing.expect(routes.select(.grok) == null);
+    try std.testing.expect(routes.select(.opencode) == null);
 }

--- a/src/core/shared/profile_paths.zig
+++ b/src/core/shared/profile_paths.zig
@@ -6,6 +6,7 @@ pub const root_dir_name = ".fx";
 pub const auth_file_name = "auth.json";
 pub const chatgpt_auth_file_name = "chatgpt-auth.json";
 pub const grok_auth_file_name = "grok-auth.json";
+pub const opencode_auth_file_name = "opencode-auth.json";
 pub const api_key_file_name = "api-key";
 pub const sessions_dir_name = "sessions";
 pub const prompt_history_file_name = "history.jsonl";

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -94,6 +94,7 @@ pub const CredentialSource = enum {
     stored_key,
     chatgpt_subscription,
     grok_subscription,
+    opencode_api_key,
 };
 
 pub fn parseCredentialSource(text: []const u8) ?CredentialSource {

--- a/src/gateway/opencode.zig
+++ b/src/gateway/opencode.zig
@@ -1,0 +1,1110 @@
+const std = @import("std");
+const image_attachments = @import("../core/images/image_attachments.zig");
+const opencode_session = @import("../core/auth/opencode_session.zig");
+const opencode_models = @import("opencode_models.zig");
+const secret = @import("../core/auth/secret.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
+
+const Allocator = std.mem.Allocator;
+const endpoint_zen = "https://opencode.ai/zen/v1/chat/completions";
+const endpoint_go = "https://opencode.ai/zen/go/v1/chat/completions";
+const go_model_prefix = "go/";
+const e2e_endpoint_env = "FX_E2E_OPENCODE_CHAT_URL";
+const max_error_body_bytes: usize = 256 * 1024;
+const max_sse_line_bytes: usize = 1024 * 1024;
+const max_sse_aggregate_bytes: usize = 64 * 1024 * 1024;
+const max_sse_events: usize = 100_000;
+const max_tool_calls: usize = 128;
+const max_tool_identity_bytes: usize = 1024;
+const max_tool_arguments_bytes: usize = 4 * 1024 * 1024;
+const transfer_buffer_bytes: usize = 256 * 1024;
+const connect_timeout_ms: i64 = 30_000;
+
+const Route = struct {
+    endpoint: []const u8,
+    wire_model: []const u8,
+};
+
+fn route(model: []const u8) Route {
+    if (std.mem.startsWith(u8, model, go_model_prefix)) {
+        return .{
+            .endpoint = endpoint_go,
+            .wire_model = model[go_model_prefix.len..],
+        };
+    }
+    return .{
+        .endpoint = endpoint_zen,
+        .wire_model = model,
+    };
+}
+
+pub const agent_stream_provider = stream_provider.Provider{
+    .stream_fn = streamCompletion,
+};
+
+fn validateModel(model: []const u8) !void {
+    if (model.len == 0 or model.len > 256) return error.InvalidOpenCodeModel;
+    for (model) |byte| {
+        if (byte <= 0x20 or byte == 0x7f) return error.InvalidOpenCodeModel;
+    }
+    const wire_model = route(model).wire_model;
+    if (wire_model.len == 0) return error.InvalidOpenCodeModel;
+    if (!opencode_models.supportsChatCompletionsModel(model)) return error.UnsupportedOpenCodeModelProtocol;
+}
+
+pub fn buildRequest(
+    alloc: Allocator,
+    request: stream_provider.RequestData,
+) ![]u8 {
+    try validateModel(request.model);
+    if (request.budget) |budget| {
+        if (budget.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+        _ = budget.deadline;
+    }
+
+    const wire_model = route(request.model).wire_model;
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll("{\"model\":");
+    try std.json.Stringify.value(wire_model, .{}, writer);
+    try writer.writeAll(",\"messages\":[");
+    try writeMessages(writer, alloc, request.messages, request.verified_images);
+    try writer.writeAll("],\"stream\":true,\"stream_options\":{\"include_usage\":true}");
+
+    const tool_count = try writeTools(writer, alloc, request.tools, request.vision_mode);
+    if (tool_count > 0) {
+        try writer.writeAll(",\"tool_choice\":");
+        try std.json.Stringify.value(request.tool_choice.label(), .{}, writer);
+        try writer.writeAll(",\"parallel_tool_calls\":true");
+    }
+
+    if (request.response_format) |format| {
+        if (format.schema != .object) return error.InvalidStructuredResponseSchema;
+        try writer.writeAll(",\"response_format\":{\"type\":\"json_schema\",\"json_schema\":{\"name\":");
+        try std.json.Stringify.value(format.name, .{}, writer);
+        try writer.writeAll(",\"description\":");
+        try std.json.Stringify.value(format.description, .{}, writer);
+        try writer.writeAll(",\"schema\":");
+        try std.json.Stringify.value(format.schema, .{}, writer);
+        try writer.writeAll(",\"strict\":true}}");
+    }
+
+    if (request.max_output_tokens) |limit| try writer.print(",\"max_tokens\":{d}", .{limit});
+    if (request.provider_options.reasoning) |effort| {
+        try writer.writeAll(",\"reasoning_effort\":");
+        try std.json.Stringify.value(effort.label(), .{}, writer);
+    }
+    try writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn writeMessages(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    messages: []const types.ChatMessage,
+    verified_images: ?[]const image_attachments.VerifiedSnapshot,
+) !void {
+    var first = true;
+    var last_user_index: ?usize = null;
+    for (messages, 0..) |message, index| {
+        if (message.role == .user) last_user_index = index;
+    }
+    for (messages, 0..) |message, index| {
+        const has_images = verified_images != null and verified_images.?.len > 0 and
+            message.role == .user and index == last_user_index;
+        const has_content = message.content != null and message.content.?.len > 0;
+        if (!has_content and !has_images and message.role != .assistant) continue;
+        if (first) {
+            first = false;
+        } else {
+            try writer.writeByte(',');
+        }
+        switch (message.role) {
+            .system => {
+                try writer.writeAll("{\"role\":\"system\",\"content\":");
+                try std.json.Stringify.value(message.content orelse "", .{}, writer);
+                try writer.writeByte('}');
+            },
+            .user => {
+                if (has_images) {
+                    try writer.writeAll("{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":");
+                    try std.json.Stringify.value(message.content orelse "", .{}, writer);
+                    try writer.writeByte('}');
+                    for (verified_images.?) |image| {
+                        try writer.writeAll(",{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:");
+                        try writer.writeAll(image.media_type);
+                        try writer.writeAll(";base64,");
+                        try writeBase64(writer, alloc, image.bytes);
+                        try writer.writeAll("\"}}");
+                    }
+                    try writer.writeAll("]}");
+                } else {
+                    try writer.writeAll("{\"role\":\"user\",\"content\":");
+                    try std.json.Stringify.value(message.content orelse "", .{}, writer);
+                    try writer.writeByte('}');
+                }
+            },
+            .assistant => {
+                try writer.writeAll("{\"role\":\"assistant\"");
+                if (has_content) {
+                    try writer.writeAll(",\"content\":");
+                    try std.json.Stringify.value(message.content orelse "", .{}, writer);
+                } else if (message.tool_calls.len == 0) {
+                    try writer.writeAll(",\"content\":\"\"");
+                } else {
+                    try writer.writeAll(",\"content\":null");
+                }
+                if (message.tool_calls.len > 0) {
+                    try writer.writeAll(",\"tool_calls\":[");
+                    var tool_first = true;
+                    for (message.tool_calls) |call| {
+                        if (call.id.len == 0 or call.id.len > max_tool_identity_bytes or
+                            call.name.len == 0 or call.name.len > max_tool_identity_bytes or
+                            call.arguments_json.len > max_tool_arguments_bytes)
+                        {
+                            return error.InvalidOpenCodeToolCall;
+                        }
+                        if (tool_first) {
+                            tool_first = false;
+                        } else {
+                            try writer.writeByte(',');
+                        }
+                        try writer.writeAll("{\"id\":");
+                        try std.json.Stringify.value(call.id, .{}, writer);
+                        try writer.writeAll(",\"type\":\"function\",\"function\":{\"name\":");
+                        try std.json.Stringify.value(call.name, .{}, writer);
+                        try writer.writeAll(",\"arguments\":");
+                        try std.json.Stringify.value(call.arguments_json, .{}, writer);
+                        try writer.writeAll("}}");
+                    }
+                    try writer.writeByte(']');
+                }
+                try writer.writeByte('}');
+            },
+            .tool => {
+                const tool_call_id = message.tool_call_id orelse return error.InvalidOpenCodeToolCall;
+                if (tool_call_id.len == 0 or tool_call_id.len > max_tool_identity_bytes) {
+                    return error.InvalidOpenCodeToolCall;
+                }
+                try writer.writeAll("{\"role\":\"tool\",\"tool_call_id\":");
+                try std.json.Stringify.value(tool_call_id, .{}, writer);
+                try writer.writeAll(",\"content\":");
+                try std.json.Stringify.value(message.content orelse "", .{}, writer);
+                try writer.writeByte('}');
+            },
+        }
+    }
+}
+
+fn writeBase64(writer: *std.Io.Writer, alloc: Allocator, bytes: []const u8) !void {
+    const encoded_len = std.base64.standard.Encoder.calcSize(bytes.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = std.base64.standard.Encoder.encode(encoded, bytes);
+    try writer.writeAll(encoded);
+}
+
+fn writeTools(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    tools: stream_provider.ToolSelection,
+    vision_mode: stream_provider.VisionMode,
+) !usize {
+    var count: usize = 0;
+    var tools_out: std.Io.Writer.Allocating = .init(alloc);
+    defer tools_out.deinit();
+    try tools_out.writer.writeAll(",\"tools\":[");
+
+    if (vision_mode == .required) {
+        const vision = tools.registry.lookup("vision") orelse return error.VisionToolNotRegistered;
+        try writeStaticFunctionTool(&tools_out.writer, alloc, vision.model_schema, false);
+        count = 1;
+    } else {
+        for (tools.advertised_names) |name| {
+            const function = tools.advertisedFunction(name) orelse function: {
+                const tool = tools.registry.lookup(name) orelse return error.AdvertisedToolNotRegistered;
+                break :function tool.model_schema;
+            };
+            try writeStaticFunctionTool(&tools_out.writer, alloc, function, count != 0);
+            count += 1;
+        }
+        for (tools.additional_functions) |function| {
+            if (containsName(tools.advertised_names, function.name)) continue;
+            try writeStaticFunctionTool(&tools_out.writer, alloc, function, count != 0);
+            count += 1;
+        }
+        for (tools.selected_dynamic) |tool| {
+            if (containsName(tools.advertised_names, tool.name)) continue;
+            try writeDynamicFunctionTool(&tools_out.writer, tool, count != 0);
+            count += 1;
+        }
+        if (vision_mode == .optional and !containsName(tools.advertised_names, "vision")) {
+            const vision = tools.registry.lookup("vision") orelse return error.VisionToolNotRegistered;
+            try writeStaticFunctionTool(&tools_out.writer, alloc, vision.model_schema, count != 0);
+            count += 1;
+        }
+    }
+
+    try tools_out.writer.writeByte(']');
+    if (count > 0) try writer.writeAll(tools_out.written());
+    return count;
+}
+
+fn containsName(names: []const []const u8, expected: []const u8) bool {
+    for (names) |name| if (std.mem.eql(u8, name, expected)) return true;
+    return false;
+}
+
+fn writeStaticFunctionTool(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    function: model_tool_schema.FunctionSchema,
+    comma: bool,
+) !void {
+    if (comma) try writer.writeByte(',');
+    try writer.writeAll("{\"type\":\"function\",\"function\":{\"name\":");
+    try std.json.Stringify.value(function.name, .{}, writer);
+    try writer.writeAll(",\"description\":");
+    try model_tool_schema.writeCappedDescriptionJsonString(alloc, writer, function.description);
+    try writer.writeAll(",\"parameters\":");
+    try model_tool_schema.writeObjectSchema(alloc, writer, function.input_schema);
+    try writer.writeAll("}}");
+}
+
+fn writeDynamicFunctionTool(
+    writer: *std.Io.Writer,
+    tool: stream_provider.DynamicFunctionTool,
+    comma: bool,
+) !void {
+    if (tool.input_schema != .object) return error.InvalidToolSchema;
+    if (comma) try writer.writeByte(',');
+    try writer.writeAll("{\"type\":\"function\",\"function\":{\"name\":");
+    try std.json.Stringify.value(tool.name, .{}, writer);
+    try writer.writeAll(",\"description\":");
+    try std.json.Stringify.value(tool.description, .{}, writer);
+    try writer.writeAll(",\"parameters\":");
+    try std.json.Stringify.value(tool.input_schema, .{}, writer);
+    try writer.writeAll("}}");
+}
+
+fn streamCompletion(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.ModelRequest,
+) !stream_provider.Result {
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.credential.source != .opencode_api_key) {
+        return error.OpenCodeApiKeyCredentialRequired;
+    }
+    if (!opencode_session.validApiKey(request.credential.secret)) {
+        return error.OpenCodeApiKeyCredentialRequired;
+    }
+    try validateModel(request.model);
+    const payload = try buildRequest(alloc, request.data());
+    defer alloc.free(payload);
+
+    var result = streamCompletionCore(alloc, request, payload) catch |err| {
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        if (requestDeadlineExpired(request)) return error.Timeout;
+        request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(err, request.delivery.load());
+        return err;
+    };
+    if (requestDeadlineExpired(request)) {
+        result.deinit(alloc);
+        return error.Timeout;
+    }
+    return result;
+}
+
+fn requestDeadlineExpired(request: stream_provider.ModelRequest) bool {
+    const deadline = request.deadline orelse return false;
+    const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+    return !std.Io.Clock.Timestamp.compare(now, .lt, deadline);
+}
+
+const OpenedRequest = struct {
+    request: ?std.http.Client.Request,
+
+    pub fn deinit(self: *OpenedRequest, _: Allocator) void {
+        if (self.request) |*request| request.deinit();
+        self.request = null;
+    }
+
+    pub fn take(self: *OpenedRequest) std.http.Client.Request {
+        const request = self.request.?;
+        self.request = null;
+        return request;
+    }
+};
+
+const OpenRequestOperation = struct {
+    client: *std.http.Client,
+    uri: std.Uri,
+    auth_header: []const u8,
+
+    pub fn run(self: *@This()) !OpenedRequest {
+        return .{ .request = try self.client.request(.POST, self.uri, .{
+            .headers = .{
+                .content_type = .{ .override = "application/json" },
+                .authorization = .{ .override = self.auth_header },
+                .accept_encoding = .omit,
+                .user_agent = .{ .override = gateway_client.user_agent },
+            },
+            .extra_headers = &[_]std.http.Header{
+                .{ .name = "accept", .value = "text/event-stream" },
+            },
+            .keep_alive = false,
+            .redirect_behavior = .unhandled,
+        }) };
+    }
+};
+
+fn streamCompletionCore(
+    alloc: Allocator,
+    request: stream_provider.ModelRequest,
+    payload: []const u8,
+) !stream_provider.Result {
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    const open_route = route(request.model);
+    const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.credential.secret});
+    defer secret.zeroAndFree(alloc, auth_header);
+    const request_endpoint = if (io_mod.getenv(e2e_endpoint_env)) |override| endpoint: {
+        if (!gateway_client.isLoopbackHttpUrl(override)) return error.InvalidE2EOpenCodeEndpoint;
+        break :endpoint override;
+    } else open_route.endpoint;
+    const uri = try std.Uri.parse(request_endpoint);
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
+    defer client.deinit();
+    var open_operation = OpenRequestOperation{
+        .client = &client,
+        .uri = uri,
+        .auth_header = auth_header,
+    };
+    var connect_deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+        .clock = .awake,
+        .raw = .fromMilliseconds(connect_timeout_ms),
+    });
+    if (request.deadline) |deadline| {
+        if (std.Io.Clock.Timestamp.compare(deadline, .lt, connect_deadline)) {
+            connect_deadline = deadline;
+        }
+    }
+    try request.admission.admit();
+    var opened = try gateway_client.runBoundedHttpOperation(
+        OpenedRequest,
+        alloc,
+        request.cancel_flag,
+        connect_deadline,
+        &open_operation,
+    );
+    var http_request = opened.take();
+    defer http_request.deinit();
+    var cancel_watch_done = std.atomic.Value(bool).init(false);
+    const cancel_watcher = if (http_request.connection) |connection|
+        if (request.deadline) |deadline|
+            try gateway_client.spawnHttpCancelWatcherBounded(
+                &cancel_watch_done,
+                request.cancel_flag,
+                deadline,
+                connection.stream_writer.stream,
+            )
+        else
+            try gateway_client.spawnHttpCancelWatcher(
+                &cancel_watch_done,
+                request.cancel_flag,
+                connection.stream_writer.stream,
+            )
+    else
+        null;
+    defer {
+        cancel_watch_done.store(true, .seq_cst);
+        if (cancel_watcher) |thread| thread.join();
+    }
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    http_request.transfer_encoding = .{ .content_length = payload.len };
+    var send_buffer: [8192]u8 = undefined;
+    request.delivery.markPossiblySent();
+    var body_writer = try http_request.sendBodyUnflushed(&send_buffer);
+    try body_writer.writer.writeAll(payload);
+    try body_writer.end();
+    if (http_request.connection) |connection| try connection.flush();
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    var response = try http_request.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        var transfer: [16 * 1024]u8 = undefined;
+        const reader = response.reader(&transfer);
+        const bounded_body = reader.allocRemaining(alloc, .limited(max_error_body_bytes + 1)) catch |err| switch (err) {
+            error.StreamTooLong => try alloc.dupe(u8, "OpenCode error response exceeded the local limit"),
+            else => return err,
+        };
+        const body = if (bounded_body.len > max_error_body_bytes) body: {
+            alloc.free(bounded_body);
+            break :body try alloc.dupe(u8, "OpenCode error response exceeded the local limit");
+        } else bounded_body;
+        return .{ .failed = .{
+            .kind = failureKindWithDetail(response.head.status, body),
+            .detail = body,
+            .ownership = .owned,
+        } };
+    }
+
+    var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
+    const reader = response.reader(&transfer_buffer);
+    var events = request.events;
+    const completion = try consumeSse(
+        alloc,
+        reader,
+        &events,
+        EventBridge.content,
+        EventBridge.toolStart,
+        EventBridge.reasoning,
+        EventBridge.toolInput,
+        request.cancel_flag,
+        request.content_capture_limit,
+    );
+    return .{ .completed = .{
+        .completion = completion,
+        .usage = .{ .immediate = null },
+        .ownership = .owned,
+    } };
+}
+
+const EventBridge = struct {
+    fn sink(raw: *anyopaque) *stream_provider.EventSink {
+        return @ptrCast(@alignCast(raw));
+    }
+
+    fn content(raw: *anyopaque, chunk: []const u8) void {
+        sink(raw).emit(.{ .content_delta = chunk });
+    }
+
+    fn reasoning(raw: *anyopaque, chunk: []const u8) void {
+        sink(raw).emit(.{ .reasoning_delta = chunk });
+    }
+
+    fn toolInput(raw: *anyopaque, chunk: []const u8) void {
+        sink(raw).emit(.{ .tool_input_delta = chunk });
+    }
+
+    fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, label: ?[]const u8) void {
+        sink(raw).emit(.{ .tool_started = .{ .id = id, .name = name, .label = label } });
+    }
+};
+
+fn failureKind(status: std.http.Status) stream_provider.FailureKind {
+    return switch (status) {
+        .bad_request => .invalid_request,
+        .unauthorized => .unauthorized,
+        .forbidden => .forbidden,
+        .payload_too_large => .request_too_large,
+        .too_many_requests => .rate_limited,
+        .internal_server_error => .server_error,
+        .bad_gateway => .bad_gateway,
+        .service_unavailable => .unavailable,
+        .gateway_timeout => .gateway_timeout,
+        else => .provider_error,
+    };
+}
+
+fn failureKindWithDetail(status: std.http.Status, detail: []const u8) stream_provider.FailureKind {
+    if (status == .too_many_requests and isUsageLimitError(detail)) return .provider_error;
+    return failureKind(status);
+}
+
+fn isUsageLimitError(detail: []const u8) bool {
+    return std.mem.find(u8, detail, "GoUsageLimitError") != null or
+        std.mem.find(u8, detail, "FreeUsageLimitError") != null;
+}
+
+const ChatToolAccumulator = struct {
+    index: i64,
+    id: []u8,
+    name: []u8,
+    arguments: std.ArrayList(u8) = .empty,
+    started: bool = false,
+
+    fn deinit(self: *ChatToolAccumulator, alloc: Allocator) void {
+        alloc.free(self.id);
+        alloc.free(self.name);
+        self.arguments.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+const SseReader = struct {
+    pending_line: std.ArrayList(u8) = .empty,
+    aggregate_bytes: usize = 0,
+    saw_done: bool = false,
+
+    const Line = struct {
+        bytes: []const u8,
+        wire_bytes: usize,
+    };
+
+    fn deinit(self: *SseReader, alloc: Allocator) void {
+        self.pending_line.deinit(alloc);
+    }
+
+    fn release(self: *SseReader) void {
+        self.pending_line.clearRetainingCapacity();
+    }
+
+    fn next(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
+        while (true) {
+            const line = try self.readLine(alloc, reader) orelse return null;
+            self.aggregate_bytes = try checkedAccumulatedSize(
+                self.aggregate_bytes,
+                line.wire_bytes,
+                max_sse_aggregate_bytes,
+            );
+            const trimmed = std.mem.trim(u8, line.bytes, " \t\r");
+            if (trimmed.len == 0 or trimmed[0] == ':') {
+                self.release();
+                continue;
+            }
+            if (!std.mem.startsWith(u8, trimmed, "data:")) {
+                self.release();
+                continue;
+            }
+            const data = std.mem.trim(u8, trimmed["data:".len..], " \t");
+            if (std.mem.eql(u8, data, "[DONE]")) {
+                self.saw_done = true;
+                return null;
+            }
+            return data;
+        }
+    }
+
+    fn readLine(self: *SseReader, alloc: Allocator, reader: anytype) !?Line {
+        while (true) {
+            const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
+                error.StreamTooLong => {
+                    const buffered = reader.buffered();
+                    if (buffered.len == 0) return error.OpenCodeSseReadStalled;
+                    if (buffered.len > max_sse_line_bytes - self.pending_line.items.len) {
+                        return error.OpenCodeSseEventTooLarge;
+                    }
+                    try self.pending_line.appendSlice(alloc, buffered);
+                    reader.tossBuffered();
+                    continue;
+                },
+                error.ReadFailed => return error.ReadFailed,
+            } orelse {
+                if (self.pending_line.items.len > 0) {
+                    return .{
+                        .bytes = self.pending_line.items,
+                        .wire_bytes = self.pending_line.items.len,
+                    };
+                }
+                return null;
+            };
+            if (fragment.len > max_sse_line_bytes - self.pending_line.items.len) {
+                return error.OpenCodeSseEventTooLarge;
+            }
+            if (self.pending_line.items.len == 0) {
+                return .{
+                    .bytes = fragment,
+                    .wire_bytes = fragment.len + 1,
+                };
+            }
+            try self.pending_line.appendSlice(alloc, fragment);
+            return .{
+                .bytes = self.pending_line.items,
+                .wire_bytes = self.pending_line.items.len + 1,
+            };
+        }
+    }
+};
+
+fn consumeSse(
+    alloc: Allocator,
+    reader: anytype,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    on_tool_input_chunk: ?stream_provider.StreamCallback,
+    cancel_flag: *std.atomic.Value(bool),
+    content_capture_limit: ?usize,
+) !types.ModelCompletion {
+    var content: std.ArrayList(u8) = .empty;
+    errdefer content.deinit(alloc);
+    var tools: std.ArrayList(ChatToolAccumulator) = .empty;
+    defer {
+        for (tools.items) |*tool| tool.deinit(alloc);
+        tools.deinit(alloc);
+    }
+    var sse: SseReader = .{};
+    defer sse.deinit(alloc);
+    var finish_reason: ?types.ProviderFinishReason = null;
+    var usage: types.Usage = .{};
+    var generation_id: ?[]u8 = null;
+    errdefer if (generation_id) |id| alloc.free(id);
+    var event_count: usize = 0;
+    while (try sse.next(alloc, reader)) |json_text| {
+        defer sse.release();
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        event_count = try checkedAccumulatedSize(event_count, 1, max_sse_events);
+        var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch |err| switch (err) {
+            error.OutOfMemory => return err,
+            else => return error.InvalidOpenCodeSseEvent,
+        };
+        defer parsed.deinit();
+        if (parsed.value != .object) continue;
+        if (parsed.value.object.get("error") != null) return error.OpenCodeResponseFailed;
+        if (generation_id == null) {
+            if (stringField(parsed.value.object, "id")) |id| {
+                if (id.len > 0 and id.len <= max_tool_identity_bytes) {
+                    generation_id = try alloc.dupe(u8, id);
+                }
+            }
+        }
+        if (parsed.value.object.get("usage")) |usage_value| {
+            usage = parseUsageValue(usage_value);
+        }
+        const choices = parsed.value.object.get("choices") orelse continue;
+        if (choices != .array or choices.array.items.len == 0) continue;
+        const choice = choices.array.items[0];
+        if (choice != .object) continue;
+
+        if (choice.object.get("delta")) |delta_value| {
+            if (delta_value == .object) {
+                if (stringField(delta_value.object, "content")) |delta| {
+                    if (delta.len > 0) {
+                        on_content_chunk(callback_ctx, delta);
+                        try appendCaptured(alloc, &content, delta, content_capture_limit);
+                    }
+                }
+                if (on_reasoning_chunk) |callback| {
+                    if (stringField(delta_value.object, "reasoning_content")) |delta| {
+                        if (delta.len > 0) callback(callback_ctx, delta);
+                    } else if (stringField(delta_value.object, "reasoning")) |delta| {
+                        if (delta.len > 0) callback(callback_ctx, delta);
+                    }
+                }
+                if (delta_value.object.get("tool_calls")) |tool_calls_value| {
+                    if (tool_calls_value == .array) {
+                        for (tool_calls_value.array.items) |call_value| {
+                            if (call_value != .object) continue;
+                            const index = integerField(call_value.object, "index") orelse continue;
+                            var accumulator_index: ?usize = findChatTool(tools.items, index);
+                            if (accumulator_index == null) {
+                                if (tools.items.len >= max_tool_calls) return error.OpenCodeResourceLimitExceeded;
+                                var id: []u8 = try alloc.dupe(u8, "");
+                                errdefer alloc.free(id);
+                                var name: []u8 = try alloc.dupe(u8, "");
+                                errdefer alloc.free(name);
+                                if (stringField(call_value.object, "id")) |call_id| {
+                                    if (call_id.len > 0 and call_id.len <= max_tool_identity_bytes) {
+                                        const replacement = try alloc.dupe(u8, call_id);
+                                        alloc.free(id);
+                                        id = replacement;
+                                    }
+                                }
+                                if (nestedStringField(call_value.object, "function", "name")) |function_name| {
+                                    if (function_name.len > 0 and function_name.len <= max_tool_identity_bytes) {
+                                        const replacement = try alloc.dupe(u8, function_name);
+                                        alloc.free(name);
+                                        name = replacement;
+                                    }
+                                }
+                                try tools.append(alloc, .{
+                                    .index = index,
+                                    .id = id,
+                                    .name = name,
+                                });
+                                accumulator_index = tools.items.len - 1;
+                            } else {
+                                const tool = &tools.items[accumulator_index.?];
+                                if (tool.id.len == 0) {
+                                    if (stringField(call_value.object, "id")) |call_id| {
+                                        if (call_id.len > 0 and call_id.len <= max_tool_identity_bytes) {
+                                            const replacement = try alloc.dupe(u8, call_id);
+                                            alloc.free(tool.id);
+                                            tool.id = replacement;
+                                        }
+                                    }
+                                }
+                                if (tool.name.len == 0) {
+                                    if (nestedStringField(call_value.object, "function", "name")) |function_name| {
+                                        if (function_name.len > 0 and function_name.len <= max_tool_identity_bytes) {
+                                            const replacement = try alloc.dupe(u8, function_name);
+                                            alloc.free(tool.name);
+                                            tool.name = replacement;
+                                        }
+                                    }
+                                }
+                            }
+                            const tool = &tools.items[accumulator_index.?];
+                            if (!tool.started and tool.id.len > 0 and tool.name.len > 0) {
+                                if (on_tool_start) |callback| callback(callback_ctx, tool.id, tool.name, null);
+                                tool.started = true;
+                            }
+                            if (nestedStringField(call_value.object, "function", "arguments")) |arguments_delta| {
+                                if (arguments_delta.len > 0) {
+                                    try appendToolArguments(alloc, &tools.items[accumulator_index.?].arguments, arguments_delta);
+                                    if (on_tool_input_chunk) |callback| callback(callback_ctx, arguments_delta);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (choice.object.get("finish_reason")) |finish_value| {
+            if (finish_value == .string) {
+                finish_reason = mapFinishReason(finish_value.string, tools.items.len > 0);
+            }
+        }
+    }
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    // The SseReader consumes the [DONE] sentinel and reports it through
+    // `saw_done`; reaching the end of the stream without it means the server
+    // closed early.
+    if (!sse.saw_done or finish_reason == null) return error.OpenCodeStreamIncomplete;
+
+    const owned_content = if (content.items.len > 0) try content.toOwnedSlice(alloc) else null;
+    if (owned_content != null) content = .empty;
+    errdefer if (owned_content) |value| alloc.free(value);
+    const owned_tools: []types.ToolCall = if (tools.items.len > 0)
+        try alloc.alloc(types.ToolCall, tools.items.len)
+    else
+        &.{};
+    var initialized_tools: usize = 0;
+    errdefer {
+        for (owned_tools[0..initialized_tools]) |call| {
+            alloc.free(call.id);
+            alloc.free(call.name);
+            alloc.free(@constCast(call.arguments_json));
+        }
+        if (owned_tools.len > 0) alloc.free(owned_tools);
+    }
+    for (tools.items, 0..) |*tool, index| {
+        if (tool.id.len == 0 or tool.name.len == 0) return error.InvalidOpenCodeSseEvent;
+        owned_tools[index] = try dupeToolCall(alloc, tool);
+        initialized_tools += 1;
+    }
+    return .{
+        .content = owned_content,
+        .tool_calls = owned_tools,
+        .generation_id = generation_id,
+        .finish_reason = finish_reason.?,
+        .usage = usage,
+    };
+}
+
+fn mapFinishReason(raw: []const u8, has_tools: bool) types.ProviderFinishReason {
+    if (std.mem.eql(u8, raw, "stop")) return .stop;
+    if (std.mem.eql(u8, raw, "length") or std.mem.eql(u8, raw, "max_tokens")) return .length;
+    if (std.mem.eql(u8, raw, "tool_calls") or std.mem.eql(u8, raw, "function_call")) return .tool_calls;
+    if (std.mem.eql(u8, raw, "content_filter")) return .content_filter;
+    return if (has_tools) .tool_calls else .other;
+}
+
+fn dupeToolCall(alloc: Allocator, tool: *const ChatToolAccumulator) !types.ToolCall {
+    const id = try alloc.dupe(u8, tool.id);
+    errdefer alloc.free(id);
+    const name = try alloc.dupe(u8, tool.name);
+    errdefer alloc.free(name);
+    const arguments = try alloc.dupe(u8, tool.arguments.items);
+    return .{ .id = id, .name = name, .arguments_json = arguments };
+}
+
+fn parseUsageValue(value: std.json.Value) types.Usage {
+    if (value != .object) return .{};
+    return .{
+        .input_tokens = unsignedField(value.object, "prompt_tokens"),
+        .output_tokens = unsignedField(value.object, "completion_tokens"),
+    };
+}
+
+fn findChatTool(tools: []ChatToolAccumulator, index: i64) ?usize {
+    for (tools, 0..) |*tool, position| {
+        if (tool.index == index) return position;
+    }
+    return null;
+}
+
+fn appendCaptured(
+    alloc: Allocator,
+    content: *std.ArrayList(u8),
+    delta: []const u8,
+    capture_limit: ?usize,
+) !void {
+    if (capture_limit) |limit| {
+        if (content.items.len >= limit) return;
+        const remaining = limit - content.items.len;
+        const bounded = if (delta.len > remaining) delta[0..remaining] else delta;
+        try content.appendSlice(alloc, bounded);
+        return;
+    }
+    try content.appendSlice(alloc, delta);
+}
+
+fn appendToolArguments(alloc: Allocator, arguments: *std.ArrayList(u8), delta: []const u8) !void {
+    const projected = try checkedAccumulatedSize(arguments.items.len, delta.len, max_tool_arguments_bytes);
+    _ = projected;
+    try arguments.appendSlice(alloc, delta);
+}
+
+fn checkedAccumulatedSize(current: usize, incoming: usize, limit: usize) !usize {
+    const total = std.math.add(usize, current, incoming) catch return error.OpenCodeResourceLimitExceeded;
+    if (total > limit) return error.OpenCodeResourceLimitExceeded;
+    return total;
+}
+
+fn stringField(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    if (value != .string) return null;
+    return value.string;
+}
+
+fn nestedStringField(object: std.json.ObjectMap, container_key: []const u8, key: []const u8) ?[]const u8 {
+    const container = object.get(container_key) orelse return null;
+    if (container != .object) return null;
+    return stringField(container.object, key);
+}
+
+fn integerField(object: std.json.ObjectMap, key: []const u8) ?i64 {
+    const value = object.get(key) orelse return null;
+    if (value != .integer) return null;
+    return value.integer;
+}
+
+fn unsignedField(object: std.json.ObjectMap, key: []const u8) ?u64 {
+    const value = object.get(key) orelse return null;
+    if (value != .integer) return null;
+    if (value.integer < 0) return null;
+    return @intCast(value.integer);
+}
+
+test "route separates zen and go endpoints by model prefix" {
+    const zen = route("kimi-k3");
+    try std.testing.expectEqualStrings(endpoint_zen, zen.endpoint);
+    try std.testing.expectEqualStrings("kimi-k3", zen.wire_model);
+    const go = route("go/kimi-k3");
+    try std.testing.expectEqualStrings(endpoint_go, go.endpoint);
+    try std.testing.expectEqualStrings("kimi-k3", go.wire_model);
+    try std.testing.expectEqualStrings("", route("go/").wire_model);
+}
+
+test "OpenCode usage-limit error types disable transient retries" {
+    try std.testing.expect(isUsageLimitError(
+        "{\"error\":{\"type\":\"GoUsageLimitError\"}}",
+    ));
+    try std.testing.expect(isUsageLimitError(
+        "{\"error\":{\"type\":\"FreeUsageLimitError\"}}",
+    ));
+    try std.testing.expect(!isUsageLimitError(
+        "{\"error\":{\"type\":\"RateLimitError\"}}",
+    ));
+    try std.testing.expectEqual(
+        stream_provider.FailureKind.provider_error,
+        failureKindWithDetail(.too_many_requests, "{\"error\":{\"type\":\"GoUsageLimitError\"}}"),
+    );
+    try std.testing.expectEqual(
+        stream_provider.FailureKind.rate_limited,
+        failureKindWithDetail(.too_many_requests, "{\"error\":{\"type\":\"RateLimitError\"}}"),
+    );
+}
+
+test "buildRequest emits chat-completions wire for text conversation" {
+    const messages = [_]types.ChatMessage{
+        .{ .role = .system, .content = "be brief" },
+        .{ .role = .user, .content = "hello" },
+        .{ .role = .assistant, .content = "hi" },
+        .{ .role = .user, .content = "bye" },
+    };
+    const body = try buildRequest(std.testing.allocator, .{
+        .model = "go/kimi-k3",
+        .messages = &messages,
+        .tool_choice = .auto,
+        .provider_options = .{},
+    });
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.startsWith(u8, body, "{\"model\":\"kimi-k3\",\"messages\":["));
+    try std.testing.expect(std.mem.find(u8, body, "\"role\":\"system\",\"content\":\"be brief\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"role\":\"user\",\"content\":\"bye\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"stream\":true,\"stream_options\":{\"include_usage\":true}") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"tools\":") == null);
+}
+
+test "buildRequest serializes assistant tool calls and tool results" {
+    const calls = [_]types.ToolCall{.{ .id = "call_1", .name = "read_file", .arguments_json = "{\"path\":\"README.md\"}" }};
+    const messages = [_]types.ChatMessage{
+        .{ .role = .user, .content = "read it" },
+        .{ .role = .assistant, .tool_calls = &calls },
+        .{ .role = .tool, .tool_call_id = "call_1", .content = "contents" },
+    };
+    const body = try buildRequest(std.testing.allocator, .{
+        .model = "glm-5",
+        .messages = &messages,
+        .tool_choice = .auto,
+        .provider_options = .{},
+    });
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_calls\":[{\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\\\"README.md\\\"}\"}}]") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"role\":\"tool\",\"tool_call_id\":\"call_1\",\"content\":\"contents\"") != null);
+}
+
+test "buildRequest converts registry tools into nested OpenAI function form" {
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "question" }};
+    const functions = [_]model_tool_schema.FunctionSchema{.{
+        .name = "read_file",
+        .description = "Read",
+    }};
+    const body = try buildRequest(std.testing.allocator, .{
+        .model = "kimi-k3",
+        .messages = &messages,
+        .tools = .{ .additional_functions = &functions },
+        .tool_choice = .auto,
+        .provider_options = .{},
+    });
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.find(u8, body, ",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"description\":\"Read\",\"parameters\":{\"type\":\"object\",\"properties\":{}}}}]") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_choice\":\"auto\",\"parallel_tool_calls\":true") != null);
+}
+
+test "buildRequest rejects empty wire model and oversized model ids" {
+    const messages = [_]types.ChatMessage{.{ .role = .user, .content = "hello" }};
+    const base = stream_provider.RequestData{
+        .model = "go/",
+        .messages = &messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+    };
+    try std.testing.expectError(error.InvalidOpenCodeModel, buildRequest(std.testing.allocator, base));
+    try std.testing.expectError(error.UnsupportedOpenCodeModelProtocol, buildRequest(std.testing.allocator, .{
+        .model = "gpt-5.6-sol",
+        .messages = &messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+    }));
+    var oversized: [257]u8 = undefined;
+    @memset(&oversized, 'a');
+    try std.testing.expectError(error.InvalidOpenCodeModel, buildRequest(std.testing.allocator, .{
+        .model = &oversized,
+        .messages = &messages,
+        .tool_choice = .none,
+        .provider_options = .{},
+    }));
+}
+
+test "OpenCode SSE maps text reasoning tool deltas finish reason and usage" {
+    const sse_text =
+        "data: {\"id\":\"gen_1\",\"choices\":[{\"delta\":{\"content\":\"hello\",\"reasoning_content\":\"thinking\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\"}}]},\"finish_reason\":null}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"README.md\\\"}\"}}]},\"finish_reason\":\"unexpected_tool_finish\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":4}}\n\n" ++
+        "data: [DONE]\n\n";
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    const Capture = struct {
+        content: std.ArrayList(u8) = .empty,
+        reasoning: std.ArrayList(u8) = .empty,
+        saw_tool: bool = false,
+
+        fn contentChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.content.appendSlice(std.testing.allocator, chunk) catch unreachable;
+        }
+        fn reasoningChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.reasoning.appendSlice(std.testing.allocator, chunk) catch unreachable;
+        }
+        fn toolStart(raw: *anyopaque, id: []const u8, name: []const u8, _: ?[]const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.saw_tool = std.mem.eql(u8, id, "call_1") and std.mem.eql(u8, name, "read_file");
+        }
+    };
+    var capture: Capture = .{};
+    defer capture.content.deinit(std.testing.allocator);
+    defer capture.reasoning.deinit(std.testing.allocator);
+    const completion = try consumeSse(
+        std.testing.allocator,
+        &reader,
+        &capture,
+        Capture.contentChunk,
+        Capture.toolStart,
+        Capture.reasoningChunk,
+        null,
+        &cancelled,
+        null,
+    );
+    defer {
+        if (completion.content) |value| std.testing.allocator.free(@constCast(value));
+        if (completion.generation_id) |value| std.testing.allocator.free(@constCast(value));
+        types.freeToolCallSlice(std.testing.allocator, @constCast(completion.tool_calls));
+    }
+    try std.testing.expectEqualStrings("hello", capture.content.items);
+    try std.testing.expectEqualStrings("thinking", capture.reasoning.items);
+    try std.testing.expect(capture.saw_tool);
+    try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason);
+    try std.testing.expectEqual(@as(?u64, 10), completion.usage.input_tokens);
+    try std.testing.expectEqual(@as(?u64, 4), completion.usage.output_tokens);
+}
+
+fn ignoreTestChunk(_: *anyopaque, _: []const u8) void {}
+
+test "OpenCode SSE requires both finish reason and done sentinel" {
+    const sse_text =
+        "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n" ++
+        "data: [DONE]\n\n";
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    var callback_ctx: u8 = 0;
+    try std.testing.expectError(error.OpenCodeStreamIncomplete, consumeSse(
+        std.testing.allocator,
+        &reader,
+        &callback_ctx,
+        ignoreTestChunk,
+        null,
+        null,
+        null,
+        &cancelled,
+        null,
+    ));
+}
+
+fn runSseAllocationFailureCase(alloc: Allocator) !void {
+    const sse_text =
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\"}}]},\"finish_reason\":null}]}\n\n" ++
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read_file\",\"arguments\":\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n" ++
+        "data: [DONE]\n\n";
+    var reader: std.Io.Reader = .fixed(sse_text);
+    var cancelled = std.atomic.Value(bool).init(false);
+    var callback_ctx: u8 = 0;
+    const completion = try consumeSse(
+        alloc,
+        &reader,
+        &callback_ctx,
+        ignoreTestChunk,
+        null,
+        null,
+        null,
+        &cancelled,
+        null,
+    );
+    defer {
+        if (completion.content) |value| alloc.free(@constCast(value));
+        if (completion.generation_id) |value| alloc.free(@constCast(value));
+        types.freeToolCallSlice(alloc, @constCast(completion.tool_calls));
+    }
+    try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+}
+
+test "OpenCode SSE delayed tool identity is allocation-failure safe" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        runSseAllocationFailureCase,
+        .{},
+    );
+}

--- a/src/gateway/opencode_models.zig
+++ b/src/gateway/opencode_models.zig
@@ -1,0 +1,366 @@
+const std = @import("std");
+const credentials = @import("../core/auth/credentials.zig");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+
+const max_models_per_surface: usize = 128;
+const max_model_id_bytes: usize = 256;
+const max_catalog_bytes: usize = 1024 * 1024;
+const fetch_timeout_ms: i64 = 30_000;
+const zen_models_endpoint = "https://opencode.ai/zen/v1/models";
+const go_models_endpoint = "https://opencode.ai/zen/go/v1/models";
+const e2e_zen_models_endpoint_env = "FX_E2E_OPENCODE_ZEN_MODELS_URL";
+const e2e_go_models_endpoint_env = "FX_E2E_OPENCODE_GO_MODELS_URL";
+const go_model_prefix = "go/";
+
+// OpenCode's /models responses do not include each model's wire protocol. fx
+// currently implements OpenAI-compatible Chat Completions for this provider,
+// so intersect the live catalogs with the protocol mapping published in the
+// OpenCode source tree instead of advertising Responses, Messages, or Gemini
+// models through an incompatible encoder.
+const zen_chat_completion_models = [_][]const u8{
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+    "minimax-m3",
+    "minimax-m2.7",
+    "minimax-m2.5",
+    "glm-5.2",
+    "glm-5.1",
+    "glm-5",
+    "kimi-k2.5",
+    "kimi-k2.6",
+    "kimi-k2.7-code",
+    "kimi-k3",
+    "big-pickle",
+    "x-preview-f-free",
+    "mimo-v2.5-free",
+    "hy3-free",
+    "nemotron-3-ultra-free",
+    "nemotron-3.5-lightning-free",
+};
+
+const go_chat_completion_models = [_][]const u8{
+    "glm-5.3",
+    "glm-5.2",
+    "glm-5.1",
+    "kimi-k3",
+    "kimi-k2.7-code",
+    "kimi-k2.6",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+    "deepseek-v4-flash-vision-exp",
+    "mimo-v2.5",
+    "mimo-v2.5-pro",
+    "hy3",
+    "ox-alpha-free",
+};
+
+pub const model_catalog_provider = model_catalog.Provider{
+    .fetch_fn = fetchCatalogForProvider,
+};
+
+pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
+    .fetch_fn = fetchCliModelCatalog,
+};
+
+fn fetchCliModelCatalog(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: gateway_provider.CliModelCatalogInput,
+) gateway_provider.CliModelCatalogResult {
+    return switch (model_catalog.fetchWithPublicFallback(model_catalog_provider, alloc, .{
+        .access = input.access,
+        .endpoint = input.endpoint,
+        .cancel_flag = input.cancel_flag,
+        .view = .full,
+    })) {
+        .loaded => |loaded| blk: {
+            var catalog = loaded.catalog;
+            defer model_catalog.freeModelCatalog(alloc, &catalog);
+            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
+                .access = loaded.provenance.access,
+                .anonymous_fallback_used = false,
+                .failure = .{ .category = .resource_exhausted },
+            } };
+            break :blk .{ .loaded = .{
+                .ids = ids,
+                .provenance = loaded.provenance,
+            } };
+        },
+        .failed => |failure| .{ .failure = failure },
+    };
+}
+
+fn fetchCatalogForProvider(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: model_catalog.FetchInput,
+) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    if (input.access.credentialSource() != .opencode_api_key) {
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    }
+
+    var fallback_cancel = std.atomic.Value(bool).init(false);
+    const cancel_flag = input.cancel_flag orelse &fallback_cancel;
+    const deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+        .clock = .awake,
+        .raw = .fromMilliseconds(fetch_timeout_ms),
+    });
+
+    const zen_body = fetchModelsBody(alloc, zen_models_endpoint, e2e_zen_models_endpoint_env, cancel_flag, deadline) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = catalogFetchFailure(err) };
+    };
+    defer alloc.free(zen_body);
+    const go_body = fetchModelsBody(alloc, go_models_endpoint, e2e_go_models_endpoint_env, cancel_flag, deadline) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = catalogFetchFailure(err) };
+    };
+    defer alloc.free(go_body);
+
+    const catalog = parseCatalog(alloc, zen_body, go_body) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{ .category = .malformed_response, .http_status = .ok } };
+    };
+    return .{ .catalog = catalog };
+}
+
+fn catalogFetchFailure(err: anyerror) model_catalog.Failure {
+    if (err == error.Cancelled) return .{ .category = .cancellation };
+    if (err == error.OpenCodeModelCatalogTooLarge) return .{ .category = .malformed_response };
+    return .{ .category = .transport, .retryable = true };
+}
+
+const ModelsGetOperation = struct {
+    alloc: std.mem.Allocator,
+    url: []const u8,
+
+    const Output = struct {
+        status: std.http.Status,
+        body: []u8,
+
+        pub fn deinit(self: *Output, alloc: std.mem.Allocator) void {
+            alloc.free(self.body);
+        }
+    };
+
+    pub fn run(self: *@This()) !Output {
+        var client: std.http.Client = .{ .allocator = self.alloc, .io = io_mod.getIo() };
+        defer client.deinit();
+        const body_buffer = try self.alloc.alloc(u8, max_catalog_bytes + 1);
+        defer self.alloc.free(body_buffer);
+        var response_writer = std.Io.Writer.fixed(body_buffer);
+        const response = client.fetch(.{
+            .location = .{ .url = self.url },
+            .method = .GET,
+            .headers = .{
+                .accept_encoding = .omit,
+                .user_agent = .{ .override = gateway_client.user_agent },
+            },
+            .response_writer = &response_writer,
+        }) catch |err| switch (err) {
+            error.WriteFailed => return error.OpenCodeModelCatalogTooLarge,
+            else => return err,
+        };
+        const body = response_writer.buffered();
+        if (body.len > max_catalog_bytes) return error.OpenCodeModelCatalogTooLarge;
+        return .{ .status = response.status, .body = try self.alloc.dupe(u8, body) };
+    }
+};
+
+fn fetchModelsBody(
+    alloc: std.mem.Allocator,
+    default_url: []const u8,
+    e2e_url_env: []const u8,
+    cancel_flag: *std.atomic.Value(bool),
+    deadline: std.Io.Clock.Timestamp,
+) ![]u8 {
+    const request_url = if (io_mod.getenv(e2e_url_env)) |override| blk: {
+        if (!gateway_client.isLoopbackHttpUrl(override)) return error.InvalidE2EOpenCodeEndpoint;
+        break :blk override;
+    } else default_url;
+    var operation = ModelsGetOperation{
+        .alloc = alloc,
+        .url = request_url,
+    };
+    var output = try gateway_client.runBoundedHttpOperation(
+        ModelsGetOperation.Output,
+        alloc,
+        cancel_flag,
+        deadline,
+        &operation,
+    );
+    if (output.status != .ok) {
+        output.deinit(alloc);
+        return error.OpenCodeModelsEndpointFailed;
+    }
+    return output.body;
+}
+
+fn parseCatalog(
+    alloc: std.mem.Allocator,
+    zen_json: []const u8,
+    go_json: []const u8,
+) !std.ArrayList(model_catalog.ModelCatalogEntry) {
+    var catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    errdefer model_catalog.freeModelCatalog(alloc, &catalog);
+    try appendSurface(alloc, &catalog, zen_json, "", &zen_chat_completion_models);
+    try appendSurface(alloc, &catalog, go_json, go_model_prefix, &go_chat_completion_models);
+    if (catalog.items.len == 0) return error.InvalidOpenCodeModelCatalog;
+    for (catalog.items, 0..) |entry, index| {
+        if (!std.mem.endsWith(u8, entry.id, "-free")) continue;
+        if (index > 0) std.mem.swap(model_catalog.ModelCatalogEntry, &catalog.items[0], &catalog.items[index]);
+        break;
+    }
+    return catalog;
+}
+
+fn appendSurface(
+    alloc: std.mem.Allocator,
+    catalog: *std.ArrayList(model_catalog.ModelCatalogEntry),
+    body: []const u8,
+    id_prefix: []const u8,
+    supported_models: []const []const u8,
+) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidOpenCodeModelCatalog;
+    const data = parsed.value.object.get("data") orelse return error.InvalidOpenCodeModelCatalog;
+    if (data != .array) return error.InvalidOpenCodeModelCatalog;
+    for (data.array.items) |value| {
+        if (value != .object) continue;
+        const raw_id = stringField(value.object, "id") orelse continue;
+        if (raw_id.len == 0 or raw_id.len > max_model_id_bytes) continue;
+        if (!containsModel(supported_models, raw_id)) continue;
+        if (findDuplicate(catalog.items, id_prefix, raw_id)) continue;
+        if (catalog.items.len >= max_models_per_surface * 2) return error.OpenCodeModelCatalogTooLarge;
+        const id = try std.fmt.allocPrint(alloc, "{s}{s}", .{ id_prefix, raw_id });
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        try catalog.append(alloc, .{
+            .id = id,
+            .model_type = model_type,
+            .has_tool_use = true,
+        });
+    }
+}
+
+fn containsModel(supported_models: []const []const u8, raw_id: []const u8) bool {
+    for (supported_models) |supported| if (std.mem.eql(u8, supported, raw_id)) return true;
+    return false;
+}
+
+pub fn supportsChatCompletionsModel(model: []const u8) bool {
+    if (std.mem.startsWith(u8, model, go_model_prefix)) {
+        return containsModel(&go_chat_completion_models, model[go_model_prefix.len..]);
+    }
+    return containsModel(&zen_chat_completion_models, model);
+}
+
+fn isFreeModel(model: []const u8) bool {
+    return std.mem.endsWith(u8, model, "-free") or std.mem.eql(u8, model, "big-pickle");
+}
+
+fn isGoModel(model: []const u8) bool {
+    return std.mem.startsWith(u8, model, go_model_prefix);
+}
+
+pub fn selectAvailableModel(model_ids: []const []u8, preferred: []const u8) ?[]const u8 {
+    for (model_ids) |model| if (std.mem.eql(u8, model, preferred)) return model;
+
+    const preferred_is_free = isFreeModel(preferred);
+    const preferred_is_go = isGoModel(preferred);
+    if (preferred_is_free) {
+        for (model_ids) |model| {
+            if (isGoModel(model) == preferred_is_go and isFreeModel(model)) return model;
+        }
+    }
+    for (model_ids) |model| {
+        if (isGoModel(model) == preferred_is_go) return model;
+    }
+    return if (model_ids.len > 0) model_ids[0] else null;
+}
+
+/// Rejects an exact full-id repeat within or across surfaces. The same model
+/// name on both surfaces is not a duplicate: zen and go are distinct routes.
+fn findDuplicate(entries: []const model_catalog.ModelCatalogEntry, id_prefix: []const u8, raw_id: []const u8) bool {
+    for (entries) |entry| {
+        if (entry.id.len != id_prefix.len + raw_id.len) continue;
+        if (!std.mem.startsWith(u8, entry.id, id_prefix)) continue;
+        if (!std.mem.eql(u8, entry.id[id_prefix.len..], raw_id)) continue;
+        return true;
+    }
+    return false;
+}
+
+fn stringField(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    if (value != .string) return null;
+    return value.string;
+}
+
+test "parseCatalog merges both surfaces and keeps same-name models as distinct routes" {
+    const zen = "{\"object\":\"list\",\"data\":[{\"id\":\"kimi-k3\",\"object\":\"model\"},{\"id\":\"glm-5\",\"object\":\"model\"},{\"id\":\"gpt-5.6-sol\",\"object\":\"model\"}]}";
+    const go = "{\"object\":\"list\",\"data\":[{\"id\":\"kimi-k3\",\"object\":\"model\"},{\"id\":\"kimi-k3\",\"object\":\"model\"},{\"id\":\"deepseek-v4-flash\",\"object\":\"model\"},{\"id\":\"minimax-m3\",\"object\":\"model\"}]}";
+    var catalog = try parseCatalog(std.testing.allocator, zen, go);
+    defer model_catalog.freeModelCatalog(std.testing.allocator, &catalog);
+    try std.testing.expectEqual(@as(usize, 4), catalog.items.len);
+    try std.testing.expectEqualStrings("kimi-k3", catalog.items[0].id);
+    try std.testing.expectEqualStrings("glm-5", catalog.items[1].id);
+    try std.testing.expectEqualStrings("go/kimi-k3", catalog.items[2].id);
+    try std.testing.expectEqualStrings("go/deepseek-v4-flash", catalog.items[3].id);
+    for (catalog.items) |entry| {
+        try std.testing.expectEqualStrings("language", entry.model_type);
+        try std.testing.expect(entry.has_tool_use);
+    }
+}
+
+test "parseCatalog hides live models that require unsupported OpenCode protocols" {
+    const unsupported_zen = "{\"data\":[{\"id\":\"gpt-5.6-sol\"},{\"id\":\"claude-opus-5\"}]}";
+    const unsupported_go = "{\"data\":[{\"id\":\"grok-4.5\"},{\"id\":\"minimax-m3\"}]}";
+    try std.testing.expectError(
+        error.InvalidOpenCodeModelCatalog,
+        parseCatalog(std.testing.allocator, unsupported_zen, unsupported_go),
+    );
+}
+
+test "protocol allowlist distinguishes Zen and Go model routes" {
+    try std.testing.expect(supportsChatCompletionsModel("big-pickle"));
+    try std.testing.expect(supportsChatCompletionsModel("go/kimi-k3"));
+    try std.testing.expect(!supportsChatCompletionsModel("gpt-5.6-sol"));
+    try std.testing.expect(!supportsChatCompletionsModel("go/minimax-m3"));
+    try std.testing.expect(!supportsChatCompletionsModel("go/"));
+}
+
+test "stale OpenCode selection stays on its surface and free tier" {
+    var ids = [_][]u8{
+        @constCast("deepseek-v4-pro"),
+        @constCast("x-preview-f-free"),
+        @constCast("go/glm-5.3"),
+        @constCast("go/ox-alpha-free"),
+    };
+    try std.testing.expectEqualStrings("x-preview-f-free", selectAvailableModel(&ids, "deepseek-v4-flash-free").?);
+    try std.testing.expectEqualStrings("go/ox-alpha-free", selectAvailableModel(&ids, "go/retired-free").?);
+    try std.testing.expectEqualStrings("go/glm-5.3", selectAvailableModel(&ids, "go/retired-paid").?);
+    try std.testing.expectEqualStrings("deepseek-v4-pro", selectAvailableModel(&ids, "retired-paid").?);
+}
+
+test "OpenCode catalog puts explicit free models first" {
+    const zen = "{\"data\":[{\"id\":\"deepseek-v4-pro\"},{\"id\":\"x-preview-f-free\"}]}";
+    const go = "{\"data\":[{\"id\":\"glm-5.3\"},{\"id\":\"ox-alpha-free\"}]}";
+    var catalog = try parseCatalog(std.testing.allocator, zen, go);
+    defer model_catalog.freeModelCatalog(std.testing.allocator, &catalog);
+    try std.testing.expectEqualStrings("x-preview-f-free", catalog.items[0].id);
+    try std.testing.expectEqualStrings("deepseek-v4-pro", catalog.items[1].id);
+    try std.testing.expectEqualStrings("go/glm-5.3", catalog.items[2].id);
+    try std.testing.expectEqualStrings("go/ox-alpha-free", catalog.items[3].id);
+}
+
+test "parseCatalog rejects empty or malformed catalogs" {
+    try std.testing.expectError(error.InvalidOpenCodeModelCatalog, parseCatalog(std.testing.allocator, "{}", "{}"));
+    try std.testing.expectError(error.InvalidOpenCodeModelCatalog, parseCatalog(std.testing.allocator, "{\"data\":[]}", "{\"data\":[]}"));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -2515,6 +2515,7 @@ const App = struct {
             }
         }
         if (try self.model_cache.pollLoadTransition()) {
+            try AuthAppRuntime.reconcileLoadedProviderModel(self);
             RenderAppRuntime.requestActiveSurfaceFrame(self, .footer);
         }
         try app_commands.Handlers(App).collectMcpAuthenticationFacts(self);
@@ -3833,9 +3834,12 @@ test {
     _ = @import("gateway/openai_codex_permission_reviewer.zig");
     _ = @import("core/auth/grok_session.zig");
     _ = @import("core/auth/grok_oauth.zig");
+    _ = @import("core/auth/opencode_session.zig");
     _ = @import("gateway/xai_grok_models.zig");
     _ = @import("gateway/xai_grok.zig");
     _ = @import("gateway/xai_grok_permission_reviewer.zig");
+    _ = @import("gateway/opencode_models.zig");
+    _ = @import("gateway/opencode.zig");
     _ = credentials;
     _ = @import("core/auth/oauth.zig");
     _ = @import("core/auth/oauth_session.zig");

--- a/src/ui/footer/model_menu_presentation.zig
+++ b/src/ui/footer/model_menu_presentation.zig
@@ -357,6 +357,7 @@ fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]
             .stored_key => "Gateway catalog: authenticated with the stored API key.",
             .chatgpt_subscription => "Codex catalog: authenticated with a subscription.",
             .grok_subscription => "Grok catalog: authenticated with a subscription.",
+            .opencode_api_key => "OpenCode catalog: authenticated with an API key.",
         };
     }
     return null;

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -55,7 +55,7 @@ fn teamQueryProjection(query: []const u8, width: u16) TeamQueryProjection {
 pub fn authPickerRowCount(view: auth_runtime.PickerView) u16 {
     if (view.stage == .sign_in) return 7;
     if (view.stage == .api_key) return 4;
-    if (view.stage == .root and view.include_skip) return 18;
+    if (view.stage == .root and view.include_skip) return 19;
     return @intCast(1 + @max(view.choiceCount(), 1));
 }
 
@@ -157,13 +157,13 @@ const onboarding_note = "   ⚠︎ Note: fx is experimental and defaults to auto
 const onboarding_note_link = onboarding_note ++ " \x1b]8;id=fx-onboarding;https://fx.sh/docs/stability\x1b\\\x1b[4mLearn more\x1b[24m\x1b]8;;\x1b\\";
 
 fn onboardingProjectedRowIndex(view: auth_runtime.PickerView, row_index: u16, row_count: u16) u16 {
-    if (row_count >= 18) return row_index;
+    if (row_count >= 19) return row_index;
 
     const selected_row: u16 = 8 + @as(u16, @intCast(view.selectedIndex()));
-    const priority = [_]u16{ selected_row, 11, 9, 10, 8, 15, 7, 12, 5, 0, 2, 3, 6, 13, 14, 1, 4, 16, 17 };
+    const priority = [_]u16{ selected_row, 12, 9, 10, 11, 8, 16, 7, 13, 5, 0, 2, 3, 6, 14, 15, 1, 4, 17, 18 };
 
     var projected_index: u16 = 0;
-    for (0..18) |source_row| {
+    for (0..19) |source_row| {
         for (priority[0..@min(row_count, priority.len)]) |included_row| {
             if (source_row != included_row) continue;
             if (projected_index == row_index) return @intCast(source_row);
@@ -171,7 +171,7 @@ fn onboardingProjectedRowIndex(view: auth_runtime.PickerView, row_index: u16, ro
             break;
         }
     }
-    return 17;
+    return 18;
 }
 
 fn composeOnboardingPickerRow(
@@ -191,6 +191,7 @@ fn composeOnboardingPickerRow(
         9 => 1,
         10 => 2,
         11 => 3,
+        12 => 4,
         else => null,
     };
     if (maybe_choice_index) |choice_index| {
@@ -218,10 +219,10 @@ fn composeOnboardingPickerRow(
         5 => "   You can change this anytime with /setup.",
         6 => "",
         7 => "   Get started",
-        12 => if (display_width.visibleWidthIgnoringAnsi(onboarding_note_link) <= width) onboarding_note_link else onboarding_note,
-        13, 14 => "",
-        15 => "   Esc to set up later · Explore all commands with /help",
-        16, 17 => "",
+        13 => if (display_width.visibleWidthIgnoringAnsi(onboarding_note_link) <= width) onboarding_note_link else onboarding_note,
+        14, 15 => "",
+        16 => "   Esc to set up later · Explore all commands with /help",
+        17, 18 => "",
         else => "",
     };
     try row_text.appendClipped(alloc, &row, label, width);
@@ -371,6 +372,11 @@ pub fn authPickerReservedRows(view: auth_runtime.PickerView, terminal_rows: u16,
     if (view.stage == .sign_in or (view.stage == .root and view.include_skip)) {
         const available_rows = terminal_rows -| (5 +| input_extra +| banner_rows);
         return @min(authPickerRowCount(view), @max(available_rows, 1));
+    }
+    if (view.stage == .root) {
+        const available_rows = terminal_rows -| (5 +| input_extra +| banner_rows);
+        const max_rows = input_presentation.max_model_picker_rows + 1;
+        return @min(authPickerRowCount(view), @min(max_rows, @max(available_rows, 1)));
     }
     return @min(authPickerRowCount(view), activeListPickerReservedRows(terminal_rows, input_extra, banner_rows));
 }
@@ -1581,7 +1587,7 @@ test "auth onboarding composes the welcome copy and setup choices" {
         .include_skip = true,
     };
 
-    try std.testing.expectEqual(@as(u16, 18), authPickerRowCount(view));
+    try std.testing.expectEqual(@as(u16, 19), authPickerRowCount(view));
     var screen: std.ArrayList(u8) = .empty;
     defer screen.deinit(alloc);
     for (0..authPickerRowCount(view)) |row_index| {
@@ -1597,6 +1603,7 @@ test "auth onboarding composes the welcome copy and setup choices" {
     try std.testing.expect(std.mem.find(u8, screen.items, "⚠︎ Note: fx is experimental and defaults to auto mode. \x1b]8;id=fx-onboarding;https://fx.sh/docs/stability\x1b\\\x1b[4mLearn more\x1b[24m\x1b]8;;\x1b\\") != null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Learn more: https://") == null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Sign in with Vercel") != null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Sign in with OpenCode") != null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Add an API key") != null);
     try std.testing.expect(std.mem.find(u8, screen.items, "Esc to set up later · Explore all commands with /help") != null);
 
@@ -1620,11 +1627,15 @@ test "auth onboarding composes the welcome copy and setup choices" {
     defer grok_row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, grok_row.items, "Sign in with Grok") != null);
 
-    var unselected_row = try composeAuthPickerRow(alloc, view, 11, authPickerRowCount(view), 100);
+    var opencode_row = try composeAuthPickerRow(alloc, view, 11, authPickerRowCount(view), 100);
+    defer opencode_row.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, opencode_row.items, "Sign in with OpenCode") != null);
+
+    var unselected_row = try composeAuthPickerRow(alloc, view, 12, authPickerRowCount(view), 100);
     defer unselected_row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, unselected_row.items, "Add an API key") != null);
 
-    var narrow_note = try composeAuthPickerRow(alloc, view, 12, authPickerRowCount(view), 58);
+    var narrow_note = try composeAuthPickerRow(alloc, view, 13, authPickerRowCount(view), 58);
     defer narrow_note.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow_note.items, "https://fx.sh/docs/stability") == null);
 
@@ -1652,7 +1663,8 @@ test "auth picker composes only detected credential sources" {
         .include_skip = false,
     };
     const row_count = authPickerRowCount(view);
-    try std.testing.expectEqual(@as(u16, 8), row_count);
+    try std.testing.expectEqual(@as(u16, 9), row_count);
+    try std.testing.expectEqual(@as(u16, 7), authPickerReservedRows(view, 40, 0, 0));
 
     var header = try composeAuthPickerRow(alloc, view, 0, row_count, 80);
     defer header.deinit(alloc);
@@ -1670,20 +1682,24 @@ test "auth picker composes only detected credential sources" {
     defer grok.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, grok.items, "Sign in with Grok") != null);
 
-    var setup = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
+    var opencode = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
+    defer opencode.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, opencode.items, "Sign in with OpenCode") != null);
+
+    var setup = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
     defer setup.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, setup.items, "API key") != null);
 
-    var switch_provider = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
+    var switch_provider = try composeAuthPickerRow(alloc, view, 6, row_count, 80);
     defer switch_provider.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, switch_provider.items, "Switch provider") != null);
 
-    var change_team = try composeAuthPickerRow(alloc, view, 6, row_count, 80);
+    var change_team = try composeAuthPickerRow(alloc, view, 7, row_count, 80);
     defer change_team.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, change_team.items, "Change team") != null);
     try std.testing.expect(std.mem.find(u8, change_team.items, "sign in first") != null);
 
-    var switch_credential = try composeAuthPickerRow(alloc, view, 7, row_count, 80);
+    var switch_credential = try composeAuthPickerRow(alloc, view, 8, row_count, 80);
     defer switch_credential.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, switch_credential.items, "Switch credential") != null);
 }

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -616,6 +616,60 @@ function startFakeGrokOAuth(options: {
   };
 }
 
+function startFakeOpenCode() {
+  const apiKey = "opencode-e2e-api-key";
+  const requests: Array<{
+    path: string;
+    authorization: string | null;
+    body: string | null;
+  }> = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const body = request.method === "POST" ? await request.text() : null;
+      requests.push({
+        path: url.pathname,
+        authorization: request.headers.get("authorization"),
+        body,
+      });
+      if (url.pathname === "/zen/models") {
+        return Response.json({ data: [
+          { id: "gpt-5.6-sol", object: "model" },
+          { id: "big-pickle", object: "model" },
+        ] });
+      }
+      if (url.pathname === "/go/models") {
+        return Response.json({ data: [
+          { id: "minimax-m3", object: "model" },
+          { id: "kimi-k3", object: "model" },
+        ] });
+      }
+      if (url.pathname === "/chat") {
+        return new Response(
+          'data: {"id":"opencode-generation","choices":[{"delta":{"content":"OPENCODE_DIRECT_RESPONSE"},"finish_reason":null}]}\n\n' +
+            'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":2}}\n\n' +
+            "data: [DONE]\n\n",
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const baseUrl = `http://127.0.0.1:${server.port}`;
+  return {
+    apiKey,
+    requests,
+    env: {
+      FX_E2E_OPENCODE_ZEN_MODELS_URL: `${baseUrl}/zen/models`,
+      FX_E2E_OPENCODE_GO_MODELS_URL: `${baseUrl}/go/models`,
+      FX_E2E_OPENCODE_CHAT_URL: `${baseUrl}/chat`,
+    },
+    stop() { server.stop(true); },
+  };
+}
+
 async function runGrokLoginWithBrowser(env: Record<string, string | undefined>) {
   const childEnv: NodeJS.ProcessEnv = { ...process.env };
   for (const [key, value] of Object.entries(env)) {
@@ -1371,6 +1425,7 @@ tmuxTest(
         pane.includes("Sign in with Vercel") &&
         pane.includes("Sign in with Codex") &&
         pane.includes("Sign in with Grok") &&
+        pane.includes("Sign in with OpenCode") &&
         pane.includes("API key") &&
         pane.includes("Switch provider"),
       TIMEOUT,
@@ -1383,6 +1438,7 @@ tmuxTest(
     await session.sendKeys("Escape");
     await session.waitForText("Setup", TIMEOUT);
 
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
@@ -1472,7 +1528,7 @@ async function waitForTrace(tracePath: string, needle: string): Promise<void> {
 }
 
 async function enterSwitchCredential(pickerSession: TmuxSession): Promise<void> {
-  for (let index = 0; index < 6; index += 1) {
+  for (let index = 0; index < 7; index += 1) {
     await pickerSession.sendKeys("Down");
   }
   await pickerSession.sendKeys("Enter");
@@ -1482,7 +1538,7 @@ async function enterSwitchCredential(pickerSession: TmuxSession): Promise<void> 
 async function openProviderPicker(pickerSession: TmuxSession): Promise<void> {
   await pickerSession.sendText("/setup");
   await pickerSession.waitForText("Setup", TIMEOUT);
-  for (let index = 0; index < 4; index += 1) {
+  for (let index = 0; index < 5; index += 1) {
     await pickerSession.sendKeys("Down");
   }
   await pickerSession.sendKeys("Enter");
@@ -1519,6 +1575,7 @@ profileStoredKeyTmuxTest(
 
     await session.sendText("/setup");
     await session.waitForText("API key", TIMEOUT);
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
@@ -1642,6 +1699,7 @@ tmuxTest(
 
     await session.sendText("/setup");
     await session.waitForText("Setup", TIMEOUT);
+    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
@@ -2223,6 +2281,76 @@ test(
   },
   60_000,
 );
+
+test("OpenCode CLI login filters protocols, routes its key directly, and logs out locally", async () => {
+  home = mkdtempSync(join(tmpdir(), "fx-opencode-cli-login-"));
+  gateway = startFakeGateway([]);
+  const opencode = startFakeOpenCode();
+  try {
+    const commonEnv = {
+      HOME: home,
+      AI_GATEWAY_API_KEY: "gateway-opencode-sentinel",
+      VERCEL_OIDC_TOKEN: undefined,
+      FX_DISABLE_KEYCHAIN: "1",
+      FX_SKIP_ONBOARDING: "1",
+      FX_AUTO_UPGRADE: "0",
+      FX_MODEL: undefined,
+      FX_GATEWAY_BASE_URL: gateway.baseUrl,
+      FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+      ...opencode.env,
+    };
+    const loginEnv = { ...commonEnv, OPENCODE_API_KEY: opencode.apiKey };
+    const login = await runFx(["login", "opencode"], {
+      env: loginEnv,
+      timeoutMs: TIMEOUT,
+    });
+    expect(login.code, `stdout: ${login.stdout}\nstderr: ${login.stderr}`).toBe(0);
+    expect(login.stdout).toContain("Signed in with OpenCode.");
+
+    const authPath = join(home, ".fx", "opencode-auth.json");
+    expect(existsSync(authPath)).toBe(true);
+    expect(statSync(authPath).mode & 0o077).toBe(0);
+    const settingsPath = join(home, ".fx", "settings.json");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(settings.provider).toBe("opencode");
+    expect(settings.models.opencode).toBe("big-pickle");
+
+    const storedEnv = { ...commonEnv, OPENCODE_API_KEY: undefined };
+    const models = await runFx(["models", "--json"], { env: storedEnv, timeoutMs: TIMEOUT });
+    expect(models.code, `stdout: ${models.stdout}\nstderr: ${models.stderr}`).toBe(0);
+    const modelIds = (JSON.parse(models.stdout) as { models: Array<{ id: string }> }).models
+      .map((model) => model.id);
+    expect(modelIds).toEqual(["big-pickle", "go/kimi-k3"]);
+
+    const ask = await runFx(["ask", "--json", "--auto", "--no-save", "Answer directly."], {
+      env: storedEnv,
+      timeoutMs: TIMEOUT,
+    });
+    expect(ask.code, `stdout: ${ask.stdout}\nstderr: ${ask.stderr}`).toBe(0);
+    expect(ask.stdout).toContain("OPENCODE_DIRECT_RESPONSE");
+    const chatRequests = opencode.requests.filter((request) => request.path === "/chat");
+    expect(chatRequests).toHaveLength(1);
+    expect(chatRequests[0]!.authorization).toBe(`Bearer ${opencode.apiKey}`);
+    expect(JSON.parse(chatRequests[0]!.body ?? "{}").model).toBe("big-pickle");
+    for (const request of [...gateway.requests, ...gateway.modelRequests]) {
+      expect(request.headers.get("authorization")).not.toBe(`Bearer ${opencode.apiKey}`);
+    }
+
+    const logout = await runFx(["logout", "opencode"], { env: loginEnv, timeoutMs: TIMEOUT });
+    expect(logout.code, `stdout: ${logout.stdout}\nstderr: ${logout.stderr}`).toBe(0);
+    expect(logout.stdout).toContain("Signed out of OpenCode.");
+    expect(existsSync(authPath)).toBe(false);
+
+    const missing = await runFx(["ask", "--json", "--no-save", "Still OpenCode?"], {
+      env: loginEnv,
+      timeoutMs: TIMEOUT,
+    });
+    expect(missing.code).toBe(1);
+    expect(missing.stderr).toContain("fx login opencode");
+  } finally {
+    opencode.stop();
+  }
+});
 
 test("Grok logout removes local credentials when remote revocation fails", async () => {
   home = mkdtempSync(join(tmpdir(), "fx-grok-logout-revoke-failure-"));

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -389,6 +389,7 @@ describe.skipIf(SKIP_TMUX)("tui: credential onboarding", () => {
           pane.includes("Sign in with Vercel") &&
           pane.includes("Sign in with Codex") &&
           pane.includes("Sign in with Grok") &&
+          pane.includes("Sign in with OpenCode") &&
           pane.includes("API key") &&
           pane.includes("Switch provider"),
         TIMEOUT,


### PR DESCRIPTION
## Summary

- Add OpenCode sign-in, provider switching, model persistence, and logout without sharing credentials with Gateway, Codex, or Grok.
- Fetch the live Zen and Go catalogs, expose only models compatible with OpenAI Chat Completions, and route Go models with an internal `go/` prefix.
- Use the selected OpenCode route from the TUI, `fx ask`, ACP, and subagents, including tools, images, reasoning, structured output, and usage.
- Replace unavailable saved models before prompt admission. Preserve OpenCode's 401 and entitlement details, and stop retrying account limits that reset days later.

## Verification

- `zig fmt --check src/`
- `tui-auth-source-selection.test.ts`: 50 passed, 0 failed
- ReleaseSafe live checks: catalog, free-model prompt, tool call, resumed session, ACP, TUI, and cancellation recovery
- ReleaseSafe loopback checks: 401, Go entitlement 403, and terminal `GoUsageLimitError` 429
