### PR TITLE
Remove redundant stat syscalls from session file reads

### DIFF
--- a/src/core/session/session_authority.zig
+++ b/src/core/session/session_authority.zig
@@ -33,6 +33,11 @@ const AuthorityMarker = struct {
     }
 };
 
+const OpenedSessionFile = struct {
+    file: std.Io.File,
+    stat: std.Io.File.Stat,
+};
+
 const LegacyFingerprint = struct {
     schema: session_json.LegacySchemaVersion,
     primary_bytes: u64,
@@ -115,20 +120,19 @@ fn isPreparedCreationOrphan(
     session_dir: *io_mod.VerifiedDir,
     session_id: []const u8,
 ) !bool {
-    var file = openSessionFile(session_dir, "session.json", .read_only) catch |err| switch (err) {
+    var opened = openSessionFileWithStat(session_dir, "session.json", .read_only) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
-    defer file.close(io_mod.getIo());
-    const stat = try file.stat(io_mod.getIo());
-    if (stat.size > session_projection.manifest_max_bytes) {
+    defer opened.file.close(io_mod.getIo());
+    if (opened.stat.size > session_projection.manifest_max_bytes) {
         return false;
     }
 
     const manifest_bytes = readExactLegacyFile(
         alloc,
-        &file,
-        stat.size,
+        &opened.file,
+        opened.stat.size,
     ) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.InvalidSessionFormat,
@@ -492,12 +496,12 @@ pub fn readOptionalSessionFile(
     name: []const u8,
     max_bytes: usize,
 ) !?[]u8 {
-    var file = openSessionFile(session_dir, name, .read_only) catch |err| switch (err) {
+    var opened = openSessionFileWithStat(session_dir, name, .read_only) catch |err| switch (err) {
         error.FileNotFound => return null,
         else => return err,
     };
-    defer file.close(io_mod.getIo());
-    return io_mod.readFileToEnd(alloc, &file, max_bytes) catch |err| switch (err) {
+    defer opened.file.close(io_mod.getIo());
+    return io_mod.readFileToEndSized(alloc, &opened.file, opened.stat.size, max_bytes) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.InvalidSessionFormat,
     };
@@ -510,9 +514,19 @@ pub fn openSessionFile(
     name: []const u8,
     mode: session_log.OpenMode,
 ) !std.Io.File {
+    const opened = try openSessionFileWithStat(session_dir, name, mode);
+    return opened.file;
+}
+
+fn openSessionFileWithStat(
+    session_dir: *io_mod.VerifiedDir,
+    name: []const u8,
+    mode: session_log.OpenMode,
+) !OpenedSessionFile {
     const file = session_dir.dir.openFile(io_mod.getIo(), name, .{
         .mode = if (mode == .writable) .read_write else .read_only,
-        .allow_directory = false,
+        // The stat below rejects directories and other non-files.
+        .allow_directory = true,
         .follow_symlinks = false,
         .resolve_beneath = true,
     }) catch |err| switch (err) {
@@ -520,8 +534,9 @@ pub fn openSessionFile(
         else => return err,
     };
     errdefer file.close(io_mod.getIo());
-    try verifyOpenedSessionFile(try file.stat(io_mod.getIo()), mode);
-    return file;
+    const stat = try file.stat(io_mod.getIo());
+    try verifyOpenedSessionFile(stat, mode);
+    return .{ .file = file, .stat = stat };
 }
 
 fn verifyOpenedSessionFile(
@@ -749,7 +764,7 @@ pub fn readExactLegacyFile(
 ) ![]u8 {
     const limit = std.math.add(u64, size, 1) catch return error.OutOfMemory;
     const max_bytes = std.math.cast(usize, limit) orelse return error.OutOfMemory;
-    return io_mod.readFileToEnd(alloc, file, max_bytes);
+    return io_mod.readFileToEndSized(alloc, file, size, max_bytes);
 }
 
 /// Normalizes a canonical-replay `OutOfMemory` into

--- a/src/core/session/session_display_metadata.zig
+++ b/src/core/session/session_display_metadata.zig
@@ -234,7 +234,8 @@ pub fn readSidecarOrFallback(
 ) !DisplayMetadata {
     var file = session_dir.dir.openFile(io_mod.getIo(), sidecar_file, .{
         .mode = .read_only,
-        .allow_directory = false,
+        // The stat below rejects directories and other non-files.
+        .allow_directory = true,
         .follow_symlinks = false,
         .resolve_beneath = true,
     }) catch |err| switch (err) {
@@ -243,7 +244,12 @@ pub fn readSidecarOrFallback(
         else => return err,
     };
     defer file.close(io_mod.getIo());
-    const bytes = io_mod.readFileToEnd(alloc, &file, max_sidecar_bytes) catch |err| switch (err) {
+    const stat = file.stat(io_mod.getIo()) catch |err| {
+        debug_trace.logf("session", "event=display_sidecar_unreadable err={s}", .{@errorName(err)});
+        return missingFallback(alloc);
+    };
+    if (stat.kind != .file) return missingFallback(alloc);
+    const bytes = io_mod.readFileToEndSized(alloc, &file, stat.size, max_sidecar_bytes) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => {
             debug_trace.logf("session", "event=display_sidecar_unreadable err={s}", .{@errorName(err)});

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -481,7 +481,7 @@ pub fn readFileToEndSized(alloc: std.mem.Allocator, file: *std.Io.File, size: u6
     const len: usize = @intCast(size);
     const buf = try alloc.alloc(u8, len + 1);
     errdefer alloc.free(buf);
-    const read_len = try file.readPositional(getIo(), &.{buf}, 0);
+    const read_len = try file.readPositionalAll(getIo(), buf, 0);
     if (read_len > len) return error.StreamTooLong;
     return alloc.realloc(buf, read_len);
 }
@@ -1176,6 +1176,22 @@ test "readFileToEndSized: file over cap returns error.StreamTooLong" {
     try writeTempFile(tmp.dir, "sized-over.txt", "0123456789");
 
     if (readTempFileSized(alloc, tmp.dir, "sized-over.txt", 5)) |data| {
+        defer alloc.free(data);
+        try std.testing.expect(false);
+    } else |err| {
+        try std.testing.expectEqual(error.StreamTooLong, err);
+    }
+}
+
+test "readFileToEndSized: stale size detects file growth" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(tmp.dir, "sized-growth.txt", "0123456789");
+
+    var file = try tmp.dir.openFile(getIo(), "sized-growth.txt", .{});
+    defer file.close(getIo());
+    if (readFileToEndSized(alloc, &file, 5, 100)) |data| {
         defer alloc.free(data);
         try std.testing.expect(false);
     } else |err| {

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -474,6 +474,18 @@ pub fn readFileToEndZ(alloc: std.mem.Allocator, file: *std.Io.File, max_bytes: u
     return result[0..data.len :0];
 }
 
+/// Reads an opened regular file with a verified size.
+/// The caller owns the returned memory. One extra byte detects file growth.
+pub fn readFileToEndSized(alloc: std.mem.Allocator, file: *std.Io.File, size: u64, max_bytes: usize) ![]u8 {
+    if (size >= max_bytes) return error.StreamTooLong;
+    const len: usize = @intCast(size);
+    const buf = try alloc.alloc(u8, len + 1);
+    errdefer alloc.free(buf);
+    const read_len = try file.readPositional(getIo(), &.{buf}, 0);
+    if (read_len > len) return error.StreamTooLong;
+    return alloc.realloc(buf, read_len);
+}
+
 pub fn milliTimestamp() i64 {
     const ts = std.Io.Timestamp.now(getIo(), .real);
     return @intCast(@divFloor(ts.nanoseconds, 1_000_000));
@@ -985,6 +997,13 @@ fn readTempFile(alloc: std.mem.Allocator, dir: std.Io.Dir, name: []const u8, max
     return readFileToEnd(alloc, &file, max_bytes);
 }
 
+fn readTempFileSized(alloc: std.mem.Allocator, dir: std.Io.Dir, name: []const u8, max_bytes: usize) ![]u8 {
+    var file = try dir.openFile(getIo(), name, .{});
+    defer file.close(getIo());
+    const stat = try file.stat(getIo());
+    return readFileToEndSized(alloc, &file, stat.size, max_bytes);
+}
+
 test "getenv returns null before setEnvironMap" {
     const previous = global_environ;
     global_environ = null;
@@ -1111,6 +1130,74 @@ test "readFileToEnd: file at exact cap returns error.StreamTooLong" {
     } else |err| {
         try std.testing.expectEqual(error.StreamTooLong, err);
     }
+}
+
+test "readFileToEndSized: file under cap returns full content" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(tmp.dir, "sized-under.txt", "0123456789");
+
+    const data = try readTempFileSized(alloc, tmp.dir, "sized-under.txt", 100);
+    defer alloc.free(data);
+    try std.testing.expectEqual(@as(usize, 10), data.len);
+    try std.testing.expectEqualStrings("0123456789", data);
+}
+
+test "readFileToEndSized: empty file returns empty slice" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(tmp.dir, "sized-empty.txt", "");
+
+    const data = try readTempFileSized(alloc, tmp.dir, "sized-empty.txt", 100);
+    defer alloc.free(data);
+    try std.testing.expectEqual(@as(usize, 0), data.len);
+}
+
+test "readFileToEndSized: file at exact cap returns error.StreamTooLong" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(tmp.dir, "sized-exact.txt", "0123456789");
+
+    if (readTempFileSized(alloc, tmp.dir, "sized-exact.txt", 10)) |data| {
+        defer alloc.free(data);
+        try std.testing.expect(false);
+    } else |err| {
+        try std.testing.expectEqual(error.StreamTooLong, err);
+    }
+}
+
+test "readFileToEndSized: file over cap returns error.StreamTooLong" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(tmp.dir, "sized-over.txt", "0123456789");
+
+    if (readTempFileSized(alloc, tmp.dir, "sized-over.txt", 5)) |data| {
+        defer alloc.free(data);
+        try std.testing.expect(false);
+    } else |err| {
+        try std.testing.expectEqual(error.StreamTooLong, err);
+    }
+}
+
+test "readFileToEndSized: repeated reads return full content" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(tmp.dir, "sized-pos.txt", "0123456789");
+
+    var file = try tmp.dir.openFile(getIo(), "sized-pos.txt", .{});
+    defer file.close(getIo());
+    const stat = try file.stat(getIo());
+    const first_read = try readFileToEndSized(alloc, &file, stat.size, 100);
+    defer alloc.free(first_read);
+    const second_read = try readFileToEndSized(alloc, &file, stat.size, 100);
+    defer alloc.free(second_read);
+    try std.testing.expectEqualStrings("0123456789", first_read);
+    try std.testing.expectEqualStrings("0123456789", second_read);
 }
 
 test "readFileToEnd: file over cap returns error.StreamTooLong" {


### PR DESCRIPTION
## Summary

- Reuse the stat that verifies an opened session file.
- Use the verified size for bounded file reads.
- Skip Zig's directory probe when fx performs a stricter file check immediately after opening.

## Measurement

Measured with an eight-session fixture. Both binaries used ReleaseSafe builds.

| Syscalls | `origin/main` | This branch | Change |
| --- | ---: | ---: | ---: |
| Total | 383 | 327 | -56 (-15%) |
| `statx` | 130 | 74 | -56 (-43%) |

The comparison used `origin/main` at `4a8f765` and this branch at `93f777a`.

```sh
python3 benchmarks/session_list_fixture.py \
  --home /tmp/fxclean/home \
  --workspace /tmp/fxclean/workspace

cd /tmp/fxclean/workspace
HOME=/tmp/fxclean/home strace -c <release-safe-binary> background --json
```

## Verification

- ReleaseSafe build passes.
- Session recovery E2E passes: 16/16.
- Session and background JSON output remains byte-identical on clean and corrupted fixtures.