### PR TITLE
Release the usage invocation slot when a generation identity is rejected

### DIFF
--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -146,6 +146,27 @@ pub const GatewayObservation = struct {
             );
             return;
         }
+        if (!types.validGatewayGenerationId(id)) {
+            // Subscription providers return their own response identifiers.
+            // The ledger only reconciles Gateway generation ids, so finish the
+            // invocation without identity tracking rather than pushing an
+            // unusable identity through the observed path. Ambiguous transport
+            // evidence stays the recorded reason.
+            try ledger.finishInvocationDurably(
+                self.sequence,
+                self.elapsedMs(),
+                if (delivery == .ambiguous_delivery)
+                    delivery
+                else
+                    .possibly_billed_without_identity,
+            );
+            debug_trace.logf(
+                "session",
+                "usage billing incomplete sequence={d} reason=generation_identity_unsupported",
+                .{self.sequence},
+            );
+            return;
+        }
         try ledger.finishObservedInvocationDurably(
             alloc,
             self.sequence,
@@ -561,9 +582,21 @@ pub const Usage = struct {
         origin: []const u8,
         team: ?[]const u8,
     ) !void {
-        try validateGenerationId(id);
-        try validateOrigin(origin);
-        if (team) |value| try validateTeam(value);
+        validateObservedIdentity(id, origin, team) catch |err| {
+            // A rejected identity must not strand the reservation: the
+            // invocation is finished before the failure surfaces so active
+            // capacity cannot drain across a session.
+            self.mutex.lockUncancelable(io_mod.getIo());
+            defer self.mutex.unlock(io_mod.getIo());
+            _ = self.finishInvocationUnlocked(
+                sequence,
+                duration_ms,
+                .possibly_billed_without_identity,
+            );
+            self.billing = .incomplete;
+            self.dirty = true;
+            return err;
+        };
 
         self.mutex.lockUncancelable(io_mod.getIo());
         defer self.mutex.unlock(io_mod.getIo());
@@ -2734,6 +2767,12 @@ fn validateGenerationId(id: []const u8) !void {
     if (!types.validGatewayGenerationId(id)) return error.InvalidGenerationId;
 }
 
+fn validateObservedIdentity(id: []const u8, origin: []const u8, team: ?[]const u8) !void {
+    try validateGenerationId(id);
+    try validateOrigin(origin);
+    if (team) |value| try validateTeam(value);
+}
+
 fn validateModel(model: []const u8) !void {
     if (model.len == 0 or model.len > max_model_bytes) {
         return error.InvalidModel;
@@ -3622,6 +3661,80 @@ test "active invocation capacity fails before Gateway admission" {
     defer snapshot.deinit(alloc);
     try std.testing.expectEqual(Availability.complete, snapshot.billing);
     try std.testing.expect(snapshot.api_duration_complete);
+}
+
+test "rejected generation identity releases the invocation slot" {
+    const alloc = std.testing.allocator;
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+
+    for (0..max_active_invocations + 1) |_| {
+        const sequence = try usage.reserveInvocation();
+        try std.testing.expectError(
+            error.InvalidGenerationId,
+            usage.finishObservedInvocation(
+                alloc,
+                sequence,
+                1,
+                .observed_generation,
+                "resp_02dd7a185a8e269d016a89d27cbe7487d2ac741377",
+                "https://chatgpt.com/backend-api/codex",
+                null,
+            ),
+        );
+    }
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(Availability.incomplete, snapshot.billing);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
+    try std.testing.expect(snapshot.api_duration_complete);
+    try std.testing.expectEqual(
+        @as(u64, max_active_invocations + 1),
+        snapshot.api_duration_ms,
+    );
+}
+
+test "unsupported provider generation identity keeps invocation capacity" {
+    const alloc = std.testing.allocator;
+    var usage = Usage.initFresh();
+    defer usage.deinit(alloc);
+
+    for (0..max_active_invocations + 1) |_| {
+        const observation = try GatewayObservation.begin(&usage);
+        try observation.complete(
+            alloc,
+            .ok,
+            .{ .generation_id = "resp_02dd7a185a8e269d016a89d27cbe7487d2ac741377" },
+            "https://chatgpt.com/backend-api/codex",
+            null,
+        );
+    }
+
+    const ambiguous = try GatewayObservation.begin(&usage);
+    try ambiguous.complete(
+        alloc,
+        .ok,
+        .{
+            .generation_id = "resp_02dd7a185a8e269d016a89d27cbe7487d2ac741377",
+            .delivery_ambiguous = true,
+        },
+        "https://chatgpt.com/backend-api/codex",
+        null,
+    );
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(Availability.incomplete, snapshot.billing);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
+    try std.testing.expectEqual(
+        @as(u64, max_active_invocations + 2),
+        snapshot.next_sequence - 1,
+    );
+    try std.testing.expectEqual(
+        snapshot.next_sequence - 1,
+        snapshot.settled_through_sequence,
+    );
 }
 
 test "generation allocation failure marks billing incomplete before snapshot" {


### PR DESCRIPTION
## Problem

On a Codex (ChatGPT subscription) session, every prompt starts failing with:

```
System: request failed: UsageCapacityExceeded
```

Once it starts, it never recovers within that session. Restarting fx and resuming works — for another 64 requests.

`UsageCapacityExceeded` here is not a provider signal, it is the session usage ledger's own active-invocation cap (`max_active_invocations = 64`).

## Root cause

`GatewayObservation.begin` reserves an invocation slot per Gateway call and the slot is released by `finishInvocationUnlocked`. On the observed path, identity validation ran first:

```zig
pub fn finishObservedInvocation(...) !void {
    try validateGenerationId(id);   // returns here
    ...
    if (!self.finishInvocationUnlocked(sequence, duration_ms, outcome)) return;
```

`validateGenerationId` accepts only Gateway ids (`gen_` + 26 ULID characters). Codex returns OpenAI response ids (`resp_…`), so the early return stranded the reservation on every single request:

```
[session] usage generation checkpointed incomplete reason=InvalidGenerationId
[session] usage generation queued sequence=1 id=resp_02dd7a185a8e269d016a89d27cbe7487d2ac741377642d1acf
```

The 65th `reserveInvocation` then returns `error.UsageCapacityExceeded`, which propagates out of the prompt as a system error. Restarting clears it because `restore` resets `active_sequence_count` to 0.

A session that hit this four times shows the fingerprint exactly — `next_sequence: 257` (4 × 64 reservations), with no invocation ever accounted:

```json
{"billing":"incomplete","api_duration_complete":false,"api_duration_ms":0,
 "next_sequence":257,"settled_through_sequence":0,"request_count":0,"models":[]}
```


## Fix

* `finishObservedInvocation` finishes the invocation before an identity failure surfaces, so a rejected identity can never strand active capacity. The outcome is recorded as `possibly_billed_without_identity`, matching what the ledger already concluded through the error path.
* `GatewayObservation.complete` routes an id that is not a Gateway generation id through the same path as a missing id, instead of pushing an unusable identity into the observed path. Ambiguous transport evidence keeps `.ambiguous_delivery` as the recorded reason.

Billing semantics are unchanged: these sessions were already recorded as incomplete, and the ledger still files one `incident: incomplete` per subscription request exactly as before. Whether a subscription request should instead count as `.unbilled` is a separate decision, raised on #333.

## Verification

`zig build`, then two new focused tests in `session_usage.zig`, each running `max_active_invocations + 1` iterations to prove capacity no longer drains:

* `rejected generation identity releases the invocation slot` — also asserts the API duration of every rejected invocation is accounted
* `unsupported provider generation identity keeps invocation capacity` — also covers an ambiguous delivery with an unsupported id, and that every sequence settles

Exercised with `./zig-out/bin/fx ask` on a Codex subscription. Trace before/after:

```
before: usage generation checkpointed incomplete reason=InvalidGenerationId
after:  usage billing incomplete sequence=1 reason=generation_identity_unsupported
```

Persisted snapshot for that request now accounts the invocation, where it previously recorded nothing:

```json
{"billing":"incomplete","api_duration_complete":true,"api_duration_ms":1689,
 "next_sequence":2,"settled_through_sequence":1}
```

Full local suite: 8424 passed / 5 failed on this branch versus 8422 passed / 5 failed on `main` — the same five pre-existing failures, which are shell-profile tests that pick up local `zsh` startup noise.

Required label: `type: bug` (I cannot apply labels on this repository).

Fixes #333.
