### PR TITLE
Stage transcript projections against the rows the frame granted

### DIFF
--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -7286,6 +7286,17 @@ pub const TranscriptRuntime = struct {
         });
     }
 
+    fn projectionLayout(
+        self: *const TranscriptRuntime,
+        target_layout: render_engine.frame_layout.CommittedLayoutSnapshot,
+    ) Layout {
+        var layout = self.layout;
+        if (!target_layout.transcript_area.isEmpty()) {
+            layout.content_bottom = target_layout.transcript_area.bottom;
+        }
+        return layout;
+    }
+
     fn paintedStableTargetWouldRewind(
         self: *const TranscriptRuntime,
         target: TransitionTarget,
@@ -7365,6 +7376,12 @@ pub const TranscriptRuntime = struct {
         activity_overlay_active: bool,
     ) !TransitionTarget {
         var target = TransitionTarget.init(prepared, scroll_facts);
+        // Staging measures against the rows this frame granted the transcript,
+        // which need not match the app layout's content bottom: a frame that
+        // reserves fewer footer rows hands the transcript an area reaching
+        // past it, and measuring against the stale bottom rejects the
+        // transition outright.
+        const projection_layout = self.projectionLayout(target_layout);
         switch (self.transcript_commit_state) {
             .stable => |anchor| {
                 target.history_visual_offset = @min(
@@ -7410,7 +7427,7 @@ pub const TranscriptRuntime = struct {
                 )) {
                     try target.stagePreparedProjection(
                         alloc,
-                        self.layout,
+                        projection_layout,
                         prepared,
                         target_layout.transcript_area,
                         scroll_facts.source_visual_offset + accepted_semantic_progress_rows,
@@ -7422,7 +7439,7 @@ pub const TranscriptRuntime = struct {
                 {
                     try target.stagePreparedHistoryProjection(
                         alloc,
-                        self.layout,
+                        projection_layout,
                         prepared,
                         target_layout.transcript_area,
                     );
@@ -7449,8 +7466,6 @@ pub const TranscriptRuntime = struct {
                     // release: slide the window with an in-place repaint at
                     // the target offset. The rows passed over stay
                     // unreleased and settle later through the replay.
-                    var projection_layout = self.layout;
-                    projection_layout.content_bottom = target_layout.transcript_area.bottom;
                     try target.stagePreparedProjection(
                         alloc,
                         projection_layout,
@@ -7470,8 +7485,6 @@ pub const TranscriptRuntime = struct {
                     );
                 }
                 if (self.stableHistoryFloor(target, anchor, scroll_facts)) |history_floor| {
-                    var projection_layout = self.layout;
-                    projection_layout.content_bottom = target_layout.transcript_area.bottom;
                     try target.stagePreparedProjection(
                         alloc,
                         projection_layout,
@@ -7514,7 +7527,7 @@ pub const TranscriptRuntime = struct {
                     {
                         try target.stagePreparedProjection(
                             alloc,
-                            self.layout,
+                            projection_layout,
                             prepared,
                             target_layout.transcript_area,
                             target.visual_offset,
@@ -7522,7 +7535,7 @@ pub const TranscriptRuntime = struct {
                     } else {
                         try transcript_painter.reprojectPreparedTranscriptForVisualOffset(
                             alloc,
-                            self.layout,
+                            projection_layout,
                             prepared,
                             target_layout.transcript_area,
                             target.visual_offset,
@@ -7538,7 +7551,7 @@ pub const TranscriptRuntime = struct {
             )) {
                 try target.stagePreparedProjection(
                     alloc,
-                    self.layout,
+                    projection_layout,
                     prepared,
                     target_layout.transcript_area,
                     accepted_semantic_progress_rows,
@@ -11489,6 +11502,99 @@ test "measured recovery rebases from accepted projection before retiring resize 
     const retry = runtime.planTranscriptScroll(&retry_prepared);
     try std.testing.expectEqual(@as(u16, 0), retry.resize_reflow_rows);
     try std.testing.expectEqual(@as(u16, 2), retry.semantic_rows);
+}
+
+test "frame transcript rows past the layout content bottom still stage" {
+    const alloc = std.testing.allocator;
+    const flow =
+        "row-01\n" ++
+        "row-02\n" ++
+        "row-03\n" ++
+        "row-04\n" ++
+        "row-05\n" ++
+        "row-06\n";
+    // The app layout reserves four footer rows, so its content bottom is 4.
+    const layout: Layout = .{
+        .rows = 8,
+        .cols = 10,
+        .content_bottom = 4,
+        .divider_top_row = 5,
+        .input_row = 6,
+        .divider_bottom_row = 7,
+        .hint_row = 8,
+    };
+    // This frame reserves one row less, so the transcript area reaches row 5.
+    const transcript_area: render_engine.frame_layout.FrameRect = .{ .top = 1, .bottom = 5 };
+    var runtime = TranscriptRuntime{
+        .layout = layout,
+        .owned_top_row = 1,
+        .committed_frame_layout = .{
+            .layout_id = 23,
+            .owned_top = 1,
+            .owned_band = .{ .top = 1, .bottom = 8 },
+            .body_area = transcript_area,
+            .transcript_area = transcript_area,
+            .footer_area = .{ .top = 6, .bottom = 8 },
+            .solved_frame_height = 8,
+            .terminal_rows = 8,
+            .terminal_cols = 10,
+        },
+    };
+    defer runtime.deinit(alloc);
+    try runtime.transcript.appendSlice(alloc, flow);
+
+    var source = try runtime.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    var metrics: Metrics = .{};
+    var prepared = try runtime.prepareTranscriptSurfacePaintFromSourceForArea(
+        alloc,
+        &metrics,
+        &source,
+        transcript_area,
+    );
+    defer prepared.deinit(alloc);
+
+    const target_layout: render_engine.frame_layout.CommittedLayoutSnapshot = .{
+        .layout_id = 24,
+        .owned_top = 1,
+        .owned_band = .{ .top = 1, .bottom = 8 },
+        .body_area = transcript_area,
+        .transcript_area = transcript_area,
+        .footer_area = .{ .top = 6, .bottom = 8 },
+        .solved_frame_height = 8,
+        .terminal_rows = 8,
+        .terminal_cols = 10,
+    };
+    const scroll_plan = render_engine.frame_scroll_plan.merge(
+        runtime.layout.rows,
+        runtime.owned_top_row,
+        0,
+        0,
+    );
+    // Semantic progress the frame may not release yet: the transition stages a
+    // projection instead of advancing, which measures against the frame area.
+    const scroll_facts: TranscriptScrollFacts = .{
+        .semantic_rows = 1,
+        .semantic_progress_rows = 1,
+        .source_compatible = true,
+        .recovery_tracks_semantic_progress = true,
+    };
+
+    const resolved = try runtime.resolveTranscriptTransitionTargetForFrame(
+        alloc,
+        &source,
+        &prepared,
+        target_layout,
+        scroll_plan,
+        scroll_facts,
+        false,
+        false,
+    );
+    try std.testing.expectEqual(
+        transcript_area.bottom,
+        resolved.target.selection.bottom_row,
+    );
+    try std.testing.expect(resolved.target.projection_staged);
 }
 
 test "source rewrite replays unchanged history prefix after footer projection rebase" {


### PR DESCRIPTION
## Problem

Some saved sessions cannot be reopened. `fx --resume <id>` exits immediately:

```
$ fx --resume <id>
fx: InvalidTranscriptTransition
```

The session is intact — `fx session <id>` prints the whole transcript and `fx session recover` correctly refuses because the commit boundary is valid. What fails is the first frame after the resume projection, and the error escapes the render attempt and ends the process, so the session is simply unopenable.

## Root cause

Transition staging measures the projection against a `types.Layout`, and the painter guards it:

```zig
if (prepared.selection.split_active or
    prepared.use_selected or
    area.isEmpty() or
    area.top == 0 or
    area.bottom > layout.content_bottom)
{
    return error.InvalidTranscriptTransition;
}
```

`area` is the transcript area **this frame** solved, while `self.layout.content_bottom` is the app layout's content bottom. They disagree whenever the frame reserves fewer footer rows than the app layout does — on the failing resume, the frame granted the transcript rows 1..37 while `content_bottom` was still 36:

```
[scroll] transition_resolve state=invalid target_offset=973 source_offset=0 total_rows=1010 area=1..37
[scroll] painter_reject site=stage_guard split=false selected=false empty=false top=1 bottom=37 content_bottom=36 rows=40 offset=64
[scroll] transcript_target_resolution_failed err=InvalidTranscriptTransition ... target_visual_offset=973
[frame_schedule] attempt_restore outcome=error err=InvalidTranscriptTransition reasons=first_frame,transcript,external_damage
```

Two of the staging sites in `resolveTransitionTarget` already handled this, rebasing the layout onto the frame's area before staging:

```zig
var projection_layout = self.layout;
projection_layout.content_bottom = target_layout.transcript_area.bottom;
```

The other five — the stable semantic-progress staging, the stable history projection, both recovering paths, and the invalid path — passed `self.layout` unchanged, so a frame whose transcript area reached past the app content bottom aborted the transition instead of staging into it.

## Fix

Resolve the projection layout once, from the rows the frame actually granted the transcript, and use it for every staging call in the transition. The two sites that already rebased keep exactly their previous behavior.

For the other five sites this changes two cases:

* **Frame area below the app content bottom** (the crash): the guard now passes and the projection stages into the frame's rows.
* **Frame area above the app content bottom** (a frame that reserves more rows than the app layout — an activity row, a banner): `content_bottom` now drops to the frame's bottom, so a terminated last line that fills the area exactly places the cursor on the area's last row instead of one row below it, outside the rows the frame granted. This matches what the two existing rebase sites already did; it is a deliberate alignment, not an accident of the fix.

### Why this layer

`self.layout` is the app's fixed-footer `types.Layout`; `frame_layout.solve` is the per-frame source of truth, and the two can legitimately disagree on where the transcript ends. The transition already acknowledged that by rebasing at two sites, so extending that to every staging call is the smallest change consistent with the existing design. Keeping `self.layout.content_bottom` in sync with the committed frame layout would remove the need for the rebase entirely; that is a broader change and out of scope here.

## Verification

`zig build`, plus a focused test — `frame transcript rows past the layout content bottom still stage` — that resolves a transition whose transcript area ends one row below `layout.content_bottom`. It fails with `error.InvalidTranscriptTransition` when `projectionLayout` returns the layout unrebased and passes with the fix.

Exercised with `./zig-out/bin/fx --resume` on the session that produced the report, driven through a pty at 80x24, 100x30, 120x40, 160x50 and 200x100: every size resumed, painted the transcript tail and status line correctly, and logged no transition rejection. Three other saved sessions resume unchanged.

Full local suite: 8425 passed / 5 failed, the same five pre-existing failures as `main` (shell-profile tests that pick up local `zsh` startup noise).

Fixes #334.

Required label: `type: bug` (I cannot apply labels on this repository).
