### PR TITLE
Added claude code support oauth and API with extra usage and logged in CLI + options to enable claude tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - **Codex subscriptions:** Sign in with an eligible subscription through `fx login codex`, then use authenticated Codex models for interactive sessions, `fx ask`, native ACP, images, subagents, and automatic reviews
 - **Grok subscriptions:** Sign in with an eligible Grok subscription through `fx login grok`, then use authenticated xAI models, effort levels, images, local tools, persistent sessions, and automatic reviews
+- **Claude subscriptions:** Sign in with an eligible Claude subscription through `fx login claude`, then use authenticated Anthropic models through the Messages API for interactive sessions, `fx ask`, native ACP, images, subagents, and automatic reviews
 - **Workspace status line:** Opt in to the active workspace path and Git branch through `/settings`, `/statusline workspace`, or `statusLine.workspace`
 - **fx-native workspace skills:** Discover project skills from `.fx/skills` before other workspace and compatibility roots
 - **External skill authorities:** Allow symlinked skills under explicitly trusted external directories through `FX_SKILL_SYMLINK_AUTHORITIES`

--- a/README.md
+++ b/README.md
@@ -47,11 +47,20 @@ fx login grok
 fx
 ```
 
-`fx login codex` and `fx login grok` select that provider and a model from its authenticated catalog. Inside fx, open `/setup` and choose **Switch provider** to move between Gateway, Codex, and Grok. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Use `/logout codex` or `/logout grok` to remove that subscription session without affecting other providers; choosing it again from **Switch provider** starts sign-in.
+Or use an eligible Claude subscription through Anthropic OAuth:
+
+```bash
+fx login claude
+fx
+```
+
+`fx login codex`, `fx login grok`, and `fx login claude` select that provider and a model from its authenticated catalog. Inside fx, open `/setup` and choose **Switch provider** to move between Gateway, Codex, Grok, and Claude. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Use `/logout codex`, `/logout grok`, or `/logout claude` to remove that subscription session without affecting other providers; choosing it again from **Switch provider** starts sign-in.
 
 The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed. On supported Codex models, `/fast` requests OpenAI's priority service tier and consumes ChatGPT credits at the higher Fast mode rate.
 
 The Grok route uses subscription access directly at xAI and never sends its OAuth token to Vercel AI Gateway or OpenAI. Its session is stored privately at `~/.fx/grok-auth.json`, refreshed when needed, and used only with the authenticated xAI catalog and Responses API.
+
+The Claude route uses Anthropic subscription access directly and never sends its OAuth token to Vercel AI Gateway, OpenAI, or xAI. Its session is stored privately at `~/.fx/claude-auth.json`, refreshed when needed, and used only with the authenticated Anthropic catalog and Messages API.
 
 To use an AI Gateway API key instead:
 

--- a/README.md
+++ b/README.md
@@ -47,20 +47,22 @@ fx login grok
 fx
 ```
 
-Or use an eligible Claude subscription through Anthropic OAuth:
+Or, if Claude Code is already signed in on this machine, switch to that subscription:
 
 ```bash
-fx login claude
+fx provider claude
 fx
 ```
 
-`fx login codex`, `fx login grok`, and `fx login claude` select that provider and a model from its authenticated catalog. Inside fx, open `/setup` and choose **Switch provider** to move between Gateway, Codex, Grok, and Claude. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Use `/logout codex`, `/logout grok`, or `/logout claude` to remove that subscription session without affecting other providers; choosing it again from **Switch provider** starts sign-in.
+`fx login codex` and `fx login grok` select that provider and a model from its authenticated catalog. Claude uses the Claude Code login already on the machine (`~/.claude/credentials.json`); `fx login claude` remains a fallback when Claude Code is not signed in. Inside fx, open `/setup` and choose **Switch provider** to move between Gateway, Codex, Grok, and Claude. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Use `/logout codex` or `/logout grok` to remove that subscription session without affecting other providers. `/logout claude` clears only fx's own Claude session; it does not sign Claude Code out.
 
 The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed. On supported Codex models, `/fast` requests OpenAI's priority service tier and consumes ChatGPT credits at the higher Fast mode rate.
 
 The Grok route uses subscription access directly at xAI and never sends its OAuth token to Vercel AI Gateway or OpenAI. Its session is stored privately at `~/.fx/grok-auth.json`, refreshed when needed, and used only with the authenticated xAI catalog and Responses API.
 
-The Claude route uses Anthropic subscription access directly and never sends its OAuth token to Vercel AI Gateway, OpenAI, or xAI. Its session is stored privately at `~/.fx/claude-auth.json`, refreshed when needed, and used only with the authenticated Anthropic catalog and Messages API.
+The Claude route uses the Claude Code CLI Agent SDK (`claude -p --input-format stream-json --output-format stream-json --include-partial-messages`) and never sends its OAuth token to Vercel AI Gateway, OpenAI, or xAI. Chat runs as a long-lived stdio session against the local `claude` CLI so Max extra usage stays on that login. fx needs the CLI on PATH (`claude auth login`). A separate fx-owned session at `~/.fx/claude-auth.json` is used only as a fallback when Claude Code is not signed in. Catalog listing still uses the authenticated Anthropic models endpoint.
+
+Claude inference uses fx tools by default. User MCP servers from `~/.claude` are not attached. To let Claude Code keep its built-in tools, set `claude_code_tools` to `true` in `~/.fx/settings.json`, export `FX_CLAUDE_CODE_TOOLS=on`, or launch with `fx --claude-tools on`. fx `--tools` still limits the host tool set for every provider.
 
 To use an AI Gateway API key instead:
 

--- a/build.zig
+++ b/build.zig
@@ -77,8 +77,10 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run fx");
     run_step.dependOn(&run_cmd.step);
 
+    const test_filter = b.option([]const u8, "test-filter", "Only run tests whose names contain this string");
     const exe_tests = b.addTest(.{
         .root_module = exe.root_module,
+        .filters = if (test_filter) |filter| &.{filter} else &.{},
     });
     const run_exe_tests = b.addRunArtifact(exe_tests);
     run_exe_tests.step.dependOn(b.getInstallStep());

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -248,6 +248,7 @@ const AcpContext = struct {
                 .gateway => self.state.cfg.permission_reviewer_provider,
                 .codex => self.state.cfg.codex_permission_reviewer_provider,
                 .grok => self.state.cfg.grok_permission_reviewer_provider,
+                .claude => self.state.cfg.claude_permission_reviewer_provider,
             },
             .auto_classifier = self.auto_classifier,
             .subagent_host = self.state.subagent_host,
@@ -705,6 +706,10 @@ pub fn runSubagentChild(
             .grok = .{
                 .agent_stream_provider = server.streamProviderFor(state, .grok),
                 .permission_reviewer_provider = state.cfg.grok_permission_reviewer_provider,
+            },
+            .claude = .{
+                .agent_stream_provider = server.streamProviderFor(state, .claude),
+                .permission_reviewer_provider = state.cfg.claude_permission_reviewer_provider,
             },
         },
         .system_prompt = state.cfg.prompt_policy.system_prompt,

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -371,6 +371,8 @@ pub fn streamProviderFor(
             @import("../core/agent/stream_provider.zig").unavailable_provider,
         .grok => state.cfg.grok_agent_stream orelse
             @import("../core/agent/stream_provider.zig").unavailable_provider,
+        .claude => state.cfg.claude_agent_stream orelse
+            @import("../core/agent/stream_provider.zig").unavailable_provider,
     };
 }
 
@@ -382,6 +384,7 @@ pub fn catalogProviderFor(
         .gateway => state.cfg.gateway_provider.model_catalog,
         .codex => state.cfg.codex_model_catalog,
         .grok => state.cfg.grok_model_catalog,
+        .claude => state.cfg.claude_model_catalog,
     };
 }
 
@@ -1714,6 +1717,7 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                 .gateway => settings.model,
                 .codex => settings.codex_model,
                 .grok => settings.grok_model,
+                .claude => settings.claude_model,
             };
             var selected_model = catalog.items[0].id;
             if (saved_model) |saved| {

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -89,13 +89,13 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .login,
         .token = "login",
-        .usage = "login [vercel|codex|grok]",
+        .usage = "login [vercel|codex|grok|claude]",
         .summary = "Sign in to Vercel or a selected provider",
     },
     .{
         .kind = .logout,
         .token = "logout",
-        .usage = "logout [vercel|codex|grok]",
+        .usage = "logout [vercel|codex|grok|claude]",
         .summary = "Sign out of Vercel or a selected provider session",
     },
     .{
@@ -292,9 +292,9 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
         .{ .kind = .replay, .usage = "replay <tape>" },
     } },
     .{ .entries = &.{
-        .{ .kind = .login, .usage = "login [vercel|codex|grok]" },
-        .{ .kind = .logout, .usage = "logout [vercel|codex|grok]" },
-        .{ .kind = .provider, .usage = "provider <gateway|codex|grok>" },
+        .{ .kind = .login, .usage = "login [vercel|codex|grok|claude]" },
+        .{ .kind = .logout, .usage = "logout [vercel|codex|grok|claude]" },
+        .{ .kind = .provider, .usage = "provider <gateway|codex|grok|claude>" },
         .{ .kind = .setup, .usage = "setup" },
         .{ .kind = .teams, .usage = "teams" },
         .{ .kind = .credits, .usage = "credits|balance" },

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -137,7 +137,7 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .provider,
         .token = "provider",
-        .usage = "provider <gateway|codex|grok>",
+        .usage = "provider <gateway|codex|grok|claude>",
         .summary = "Choose the model provider used by fx",
     },
     .{
@@ -328,6 +328,10 @@ pub const top_level_flags = [_]TopLevelFlag{
     .{
         .usage = "--no-additional-dirs",
         .description = "Ignore saved additional directories",
+    },
+    .{
+        .usage = "--claude-tools on|off",
+        .description = "off: fx tools (default); on: Claude tools",
     },
     .{
         .usage = "-c, --continue",

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -634,6 +634,7 @@ const OAuthHttpOperation = struct {
                 else
                     .default,
             },
+            .extra_headers = self.request.extra_headers,
             .redirect_behavior = .unhandled,
             .response_writer = &response_writer,
         }) catch |err| switch (err) {

--- a/src/builtins/providers.zig
+++ b/src/builtins/providers.zig
@@ -6,12 +6,15 @@ const openai_codex = @import("../gateway/openai_codex.zig");
 const openai_codex_models = @import("../gateway/openai_codex_models.zig");
 const xai_grok = @import("../gateway/xai_grok.zig");
 const xai_grok_models = @import("../gateway/xai_grok_models.zig");
+const anthropic_claude = @import("../gateway/anthropic_claude.zig");
+const anthropic_claude_models = @import("../gateway/anthropic_claude_models.zig");
 
 pub fn agentStream(provider: model_provider.ProviderId) stream_provider.Provider {
     return switch (provider) {
         .gateway => gateway.agent_stream_provider,
         .codex => openai_codex.agent_stream_provider,
         .grok => xai_grok.agent_stream_provider,
+        .claude => anthropic_claude.agent_stream_provider,
     };
 }
 
@@ -20,5 +23,6 @@ pub fn modelCatalog(provider: model_provider.ProviderId) model_catalog.Provider 
         .gateway => gateway.model_catalog_provider,
         .codex => openai_codex_models.model_catalog_provider,
         .grok => xai_grok_models.model_catalog_provider,
+        .claude => anthropic_claude_models.model_catalog_provider,
     };
 }

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1030,6 +1030,10 @@ pub fn Runtime(comptime App: type) type {
                         .agent_stream_provider = tool_context.agent_stream_provider,
                         .permission_reviewer_provider = tool_context.permission_reviewer_provider,
                     },
+                    .claude = .{
+                        .agent_stream_provider = tool_context.agent_stream_provider,
+                        .permission_reviewer_provider = tool_context.permission_reviewer_provider,
+                    },
                 };
             return subagent_agent_adapter.run(.{
                 .host = app_session_runtime.Runtime(App).subagentHost(app) orelse

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -9,6 +9,7 @@ const credentials = @import("../auth/credentials.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
 const login_flow = @import("../auth/login_flow.zig");
 const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
+const claude_oauth = @import("../auth/claude_oauth.zig");
 const grok_oauth = @import("../auth/grok_oauth.zig");
 const provider_catalog = @import("../auth/provider_catalog.zig");
 const model_provider = @import("../config/model_provider.zig");
@@ -79,6 +80,7 @@ pub fn Runtime(comptime App: type) type {
                 const required_source: credentials.Source = switch (provider) {
                     .codex => .chatgpt_subscription,
                     .grok => .grok_subscription,
+                    .claude => .claude_subscription,
                     .gateway => app.auth.credentialSource() orelse .fx_login,
                 };
                 const route_change = app.auth.selectForProvider(app.alloc, provider) catch |err| switch (err) {
@@ -176,6 +178,48 @@ pub fn Runtime(comptime App: type) type {
             const grok_is_only_logout_session = provider_inventory.contains(.grok_subscription) and
                 !provider_inventory.contains(.fx_login) and
                 !provider_inventory.contains(.chatgpt_subscription);
+            const claude_is_only_logout_session = provider_inventory.contains(.claude_subscription) and
+                !provider_inventory.contains(.fx_login) and
+                !provider_inventory.contains(.chatgpt_subscription) and
+                !provider_inventory.contains(.grok_subscription);
+            const selected_model_uses_claude = if (comptime provider_runtime.supported(App))
+                provider_runtime.provider(app) == .claude
+            else
+                false;
+            const logout_claude = if (requested_provider) |provider|
+                provider == .claude
+            else
+                selected_model_uses_claude or
+                    app.auth.credentialSource() == .claude_subscription or
+                    claude_is_only_logout_session;
+            if (logout_claude) {
+                const outcome = claude_oauth.logout(app.alloc, app.auth.oauthTransport()) catch {
+                    try writeAuthNotice(app, .{
+                        .topic = "auth",
+                        .tone = .@"error",
+                        .body = "Could not durably sign out of Claude. The current source is unchanged.",
+                    });
+                    return;
+                };
+                const changed = if (comptime @hasDecl(@TypeOf(app.auth), "reconcileAfterClaudeLogout"))
+                    try app.auth.reconcileAfterClaudeLogout(app.alloc)
+                else
+                    false;
+                applyCredentialChange(app, changed);
+                try writeAuthNotice(app, switch (outcome.deletion) {
+                    .deleted => .{ .topic = "auth", .tone = .neutral, .body = "Signed out of Claude." },
+                    .missing => .{ .topic = "auth", .tone = .neutral, .body = "No Claude login session found." },
+                    .deleted_not_durable => .{ .topic = "auth", .tone = .warning, .body = "Signed out of Claude, but could not confirm the profile directory update." },
+                });
+                if (outcome.revocation_failed) {
+                    try writeAuthNotice(app, .{
+                        .topic = "auth",
+                        .tone = .warning,
+                        .body = "The local Claude session was removed, but remote revocation could not be confirmed.",
+                    });
+                }
+                return;
+            }
             const logout_grok = if (requested_provider) |provider|
                 provider == .grok
             else
@@ -471,6 +515,39 @@ pub fn Runtime(comptime App: type) type {
                                 .topic = "auth",
                                 .tone = .neutral,
                                 .body = "Signed in with Grok.",
+                            });
+                        },
+                        .claude => {
+                            try app.auth.refreshSourceInventory(app.alloc);
+                            if (comptime provider_runtime.supported(App)) {
+                                app.auth.closePicker(app.alloc);
+                                try switchProvider(app, .claude, false, .post_oauth);
+                                return;
+                            }
+                            const selected_model_uses_claude = if (comptime provider_runtime.supported(App))
+                                provider_runtime.provider(app) == .claude
+                            else
+                                false;
+                            if (selected_model_uses_claude and
+                                !try selectCredentialSource(app, .claude_subscription))
+                            {
+                                _ = app.auth.popPickerStage(app.alloc);
+                                try writeAuthNotice(app, .{
+                                    .topic = "auth",
+                                    .tone = .@"error",
+                                    .body = "Signed in, but the Claude subscription credential could not be loaded.",
+                                });
+                                return;
+                            }
+                            if (!selected_model_uses_claude) {
+                                app.model_cache.reset();
+                                if (comptime @hasDecl(App, "startModelCacheWarmup")) app.startModelCacheWarmup();
+                            }
+                            app.auth.closePicker(app.alloc);
+                            try writeAuthNotice(app, .{
+                                .topic = "auth",
+                                .tone = .neutral,
+                                .body = "Signed in with Claude.",
                             });
                         },
                     }
@@ -920,6 +997,7 @@ pub fn Runtime(comptime App: type) type {
                 .gateway => settings.model,
                 .codex => settings.codex_model,
                 .grok => settings.grok_model,
+                .claude => settings.claude_model,
             };
             const current_model = if (intent == .post_oauth and current == target)
                 provider_runtime.model(app)
@@ -1411,6 +1489,7 @@ test "interactive subscription sign-in rejects active and queued work before OAu
             switch (provider) {
                 .codex => try Runtime(BusySignInApp).beginChatGptSignIn(&app),
                 .grok => try Runtime(BusySignInApp).beginGrokSignIn(&app),
+                .claude => unreachable,
                 .gateway => unreachable,
             }
 

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -359,6 +359,7 @@ pub fn Runtime(comptime App: type) type {
                     .login => try beginSignIn(app, true),
                     .chatgpt_login => try beginChatGptSignIn(app),
                     .grok_login => try beginGrokSignIn(app),
+                    .claude_login => try beginClaudeSignIn(app),
                     .setup => {
                         if (comptime !runtime_profile.allows(App, .native_auth)) {
                             try app.writeDomainNotice(.{
@@ -807,6 +808,54 @@ pub fn Runtime(comptime App: type) type {
             }
         }
 
+        fn beginClaudeSignIn(app: *App) !void {
+            if (try credentials.sourceExists(app.alloc, app.auth.secretStore(), .claude_subscription)) {
+                try switchProvider(app, .claude, false, .manual);
+                return;
+            }
+            if (comptime provider_runtime.supported(App)) {
+                const decision = decideProviderSwitch(.{
+                    .current = provider_runtime.provider(app),
+                    .target = .claude,
+                    .target_credential_ready = false,
+                    .intent = .post_oauth,
+                    .stream_active = app.stream.active,
+                    .queued_prompts = app.worker.queuedPromptCount(),
+                });
+                if (decision == .busy) {
+                    try app.writeDomainNotice(.{
+                        .topic = "auth",
+                        .tone = .warning,
+                        .body = "Claude sign-in is unavailable until active and queued work finishes.",
+                    }, true);
+                    return;
+                }
+            }
+            try app.flushBeforeBlockingExternalWork();
+            const started = app.auth.openClaudeSignInPickerFromRoot(app.alloc);
+            if (started catch |err| {
+                debug_trace.logf("auth", "Claude login failed err={s}", .{@errorName(err)});
+                try writeLoginError(app, .claude_subscription, err);
+                return;
+            }) {
+                app.shell.render_requests.request(.footer);
+                if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) try openSignInBrowser(app);
+            }
+        }
+
+        fn beginClaudeSignInForProviderSwitch(app: *App) !void {
+            try app.flushBeforeBlockingExternalWork();
+            const started = app.auth.openClaudeSignInPickerForProviderSwitch(app.alloc);
+            if (started catch |err| {
+                debug_trace.logf("auth", "Claude login failed err={s}", .{@errorName(err)});
+                try writeLoginError(app, .claude_subscription, err);
+                return;
+            }) {
+                app.shell.render_requests.request(.footer);
+                if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) try openSignInBrowser(app);
+            }
+        }
+
         fn switchProvider(
             app: *App,
             target: model_provider.ProviderId,
@@ -902,6 +951,10 @@ pub fn Runtime(comptime App: type) type {
                     try beginGrokSignInForProviderSwitch(app);
                     return;
                 }
+                if (target == .claude and allow_login) {
+                    try beginClaudeSignInForProviderSwitch(app);
+                    return;
+                }
                 try app.writeDomainNotice(.{
                     .topic = "provider",
                     .tone = .warning,
@@ -911,6 +964,8 @@ pub fn Runtime(comptime App: type) type {
                         "Run fx login codex, then try switching again."
                     else if (target == .grok)
                         "Run fx login grok, then try switching again."
+                    else if (target == .claude)
+                        "Run claude auth login, then try switching again."
                     else
                         credentials.missing_interactive_credential_message,
                 }, true);
@@ -1297,6 +1352,17 @@ pub fn Runtime(comptime App: type) type {
                     error.GrokAuthorizationFailed => .{ .topic = "auth", .tone = .@"error", .body = "Grok sign-in was denied. The current credential is unchanged." },
                     error.GrokLoginTimedOut, error.LoginTimedOut => .{ .topic = "auth", .tone = .warning, .body = "Grok sign-in expired. The current credential is unchanged; run /login to try again." },
                     else => .{ .topic = "auth", .tone = .@"error", .body = "Grok sign-in failed. The current credential is unchanged." },
+                }
+            else if (source == .claude_subscription)
+                switch (err) {
+                    error.ClaudeOAuthRequestFailed => .{ .topic = "auth", .tone = .@"error", .body = "Claude rejected the authorization code. The current credential is unchanged; run /login to try again." },
+                    error.ClaudeOAuthStateMismatch => .{ .topic = "auth", .tone = .@"error", .body = "Claude authorization state did not match. The current credential is unchanged; run /login to try again." },
+                    error.ClaudeUserInfoRequestFailed => .{ .topic = "auth", .tone = .@"error", .body = "Claude accepted the token but rejected the profile request. The current credential is unchanged." },
+                    error.InvalidClaudeUserInfoResponse => .{ .topic = "auth", .tone = .@"error", .body = "Claude accepted the token but returned an unexpected profile. The current credential is unchanged." },
+                    error.InvalidClaudeOAuthResponse => .{ .topic = "auth", .tone = .@"error", .body = "Claude returned an unexpected token response. The current credential is unchanged." },
+                    error.ClaudeRefreshTokenMissing => .{ .topic = "auth", .tone = .@"error", .body = "Claude did not return a refresh token. The current credential is unchanged." },
+                    error.LoginTimedOut => .{ .topic = "auth", .tone = .warning, .body = "Claude sign-in expired. The current credential is unchanged; run /login to try again." },
+                    else => .{ .topic = "auth", .tone = .@"error", .body = "Claude sign-in failed. The current credential is unchanged." },
                 }
             else switch (err) {
                 error.ClientIdMissing => .{ .topic = "auth", .tone = .@"error", .body = "fx login is not configured yet. The current credential is unchanged." },

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -224,6 +224,11 @@ pub fn Runtime(comptime App: type) type {
                 app.auth.refreshChatGptSourceInventory(app.alloc) catch |err| {
                     debug_trace.logf("auth", "startup ChatGPT inventory refresh failed err={s}", .{@errorName(err)});
                 };
+                if (comptime @hasDecl(@TypeOf(app.auth), "refreshClaudeSourceInventory")) {
+                    app.auth.refreshClaudeSourceInventory(app.alloc) catch |err| {
+                        debug_trace.logf("auth", "startup Claude inventory refresh failed err={s}", .{@errorName(err)});
+                    };
+                }
             } else {
                 app.auth.refreshSourceInventory(app.alloc) catch |err| {
                     debug_trace.logf("auth", "startup source inventory refresh failed err={s}", .{@errorName(err)});

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -52,6 +52,9 @@ pub const Config = struct {
     grok_agent_stream: ?agent_stream_provider.Provider = null,
     grok_cli_model_catalog: ?gateway_provider.CliModelCatalogProvider = null,
     grok_model_catalog: ?model_catalog.Provider = null,
+    claude_agent_stream: ?agent_stream_provider.Provider = null,
+    claude_cli_model_catalog: ?gateway_provider.CliModelCatalogProvider = null,
+    claude_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     url_opener: host.UrlOpener,
@@ -75,6 +78,7 @@ pub const Config = struct {
     permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     codex_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     grok_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
+    claude_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
 };
 
 pub fn run(comptime App: type, alloc: Allocator, args: []const [:0]const u8, cfg: Config) !void {
@@ -402,6 +406,9 @@ fn cliSurfaceConfig(cfg: Config) cli_surface.Config {
         .grok_agent_stream = cfg.grok_agent_stream,
         .grok_cli_model_catalog = cfg.grok_cli_model_catalog,
         .grok_model_catalog = cfg.grok_model_catalog,
+        .claude_agent_stream = cfg.claude_agent_stream,
+        .claude_cli_model_catalog = cfg.claude_cli_model_catalog,
+        .claude_model_catalog = cfg.claude_model_catalog,
         .background_process_provider = cfg.background_process_provider,
         .url_opener = cfg.url_opener,
         .secret_store = cfg.secret_store,
@@ -424,6 +431,7 @@ fn cliSurfaceConfig(cfg: Config) cli_surface.Config {
         .permission_reviewer_provider = cfg.permission_reviewer_provider,
         .codex_permission_reviewer_provider = cfg.codex_permission_reviewer_provider,
         .grok_permission_reviewer_provider = cfg.grok_permission_reviewer_provider,
+        .claude_permission_reviewer_provider = cfg.claude_permission_reviewer_provider,
     };
 }
 

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -3934,7 +3934,7 @@ test "app_input_runtime auth stage Escape pops before closing the picker" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..6) |_| _ = app.auth.movePicker(1);
+    for (0..7) |_| _ = app.auth.movePicker(1);
     try std.testing.expect((auth_runtime.Choice{ .action = .switch_credential }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -3962,7 +3962,7 @@ test "app_input_runtime disabled change team action stays silent" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..5) |_| _ = app.auth.movePicker(1);
+    for (0..6) |_| _ = app.auth.movePicker(1);
     try std.testing.expect((auth_runtime.Choice{ .action = .change_team }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -7595,7 +7595,7 @@ fn openRoutingAuthPicker(app: *RoutingFakeApp) !void {
     app.auth.source_inventory.insert(.ai_gateway_api_key);
     app.auth.openPicker(app.alloc);
     try std.testing.expect(app.auth.movePicker(1));
-    try std.testing.expectEqual(@as(usize, 7), app.auth.pickerView().choiceCount());
+    try std.testing.expectEqual(@as(usize, 8), app.auth.pickerView().choiceCount());
     try std.testing.expectEqual(@as(usize, 1), app.auth.pickerView().selectedIndex());
 }
 

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -3,6 +3,7 @@ const io_mod = @import("../shared/io.zig");
 const agent_steps = @import("../config/agent_steps.zig");
 const config_runtime = @import("../config/config_runtime.zig");
 const auth_runtime = @import("../auth/auth_runtime.zig");
+const claude_code_store = @import("../auth/claude_code_store.zig");
 const credentials = @import("../auth/credentials.zig");
 const host = @import("../hosts/host.zig");
 const oauth_transport = @import("../auth/oauth_transport.zig");
@@ -313,6 +314,9 @@ pub fn loadStartupStatus(
     var detailed = try config_runtime.loadMergedSettingsDetailed(alloc, workspace_root);
     defer detailed.deinit(alloc);
     const settings = &detailed.settings;
+    if (settings.claude_code_tools) |enabled| {
+        claude_code_store.setClaudeCodeToolsFromSettings(enabled);
+    }
 
     const configured_selection = try configuredProviderSelection(default_model, settings);
     const selected_model = try loadStartupStatusModel(alloc, configured_selection.model, null);
@@ -384,6 +388,9 @@ fn loadStartupStateFromOwnedWorkspace(
         try config_runtime.loadMergedSettingsDetailed(alloc, state.workspace_root);
     defer detailed.deinit(alloc);
     const settings = &detailed.settings;
+    if (settings.claude_code_tools) |enabled| {
+        claude_code_store.setClaudeCodeToolsFromSettings(enabled);
+    }
 
     state.workspace_access = try workspace_access.WorkspaceAccess.init(
         alloc,

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -1113,6 +1113,7 @@ fn configuredProviderSelection(
         .gateway => settings.model orelse default_model,
         .codex => settings.codex_model orelse return error.CodexModelNotSelected,
         .grok => settings.grok_model orelse return error.GrokModelNotSelected,
+        .claude => settings.claude_model orelse return error.ClaudeModelNotSelected,
     };
     return .{ .provider = provider, .model = model };
 }

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -353,6 +353,7 @@ pub const SessionPreferencePatch = struct {
                 .gateway => patch.model = self.model,
                 .codex => patch.codex_model = self.model,
                 .grok => patch.grok_model = self.model,
+                .claude => patch.claude_model = self.model,
             }
         } else {
             patch.model = self.model;

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const api_key_validator = @import("api_key_validator.zig");
 const credentials = @import("credentials.zig");
 const chatgpt_oauth = @import("chatgpt_oauth.zig");
+const claude_oauth = @import("claude_oauth.zig");
 const grok_oauth = @import("grok_oauth.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
@@ -133,6 +134,10 @@ pub fn refreshCredentialTokenForAccount(
         .grok_subscription => switch (mode) {
             .if_needed => (try credentials.loadSource(alloc, transport, host.unavailable_secret_store, source)) orelse return null,
             .force => (try credentials.refreshGrokCredential(alloc, transport)) orelse return null,
+        },
+        .claude_subscription => switch (mode) {
+            .if_needed => (try credentials.loadSource(alloc, transport, host.unavailable_secret_store, source)) orelse return null,
+            .force => (try credentials.refreshClaudeCredential(alloc, transport)) orelse return null,
         },
         else => unreachable,
     };
@@ -1118,6 +1123,7 @@ pub const Runtime = struct {
             .fx_login => try self.sign_in_flow.start(alloc, self.oauth_transport),
             .chatgpt_subscription => try chatgpt_oauth.startSignIn(&self.sign_in_flow, alloc, self.oauth_transport),
             .grok_subscription => try grok_oauth.startSignIn(&self.sign_in_flow, alloc, self.oauth_transport),
+            .claude_subscription => try claude_oauth.startSignIn(&self.sign_in_flow, alloc, self.oauth_transport),
             else => return error.InvalidSignInSource,
         };
         if (!started) return false;
@@ -1422,7 +1428,16 @@ pub const Runtime = struct {
                     self,
                     loadRuntimeCredentialSource,
                 ),
-            .gateway => if (self.credentialSource() != .chatgpt_subscription and self.credentialSource() != .grok_subscription)
+            .claude => if (self.credentialSource() == .claude_subscription)
+                false
+            else
+                self.selectSourceWithLoader(
+                    alloc,
+                    .claude_subscription,
+                    self,
+                    loadRuntimeCredentialSource,
+                ),
+            .gateway => if (self.credentialSource() != .chatgpt_subscription and self.credentialSource() != .grok_subscription and self.credentialSource() != .claude_subscription)
                 false
             else
                 @as(?bool, try self.reselectByPrecedenceWithDeps(

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -30,6 +30,7 @@ const credential_source_order = [_]credentials.Source{
     .stored_key,
     .chatgpt_subscription,
     .grok_subscription,
+    .claude_subscription,
 };
 
 const SourceProbeFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!bool;
@@ -156,6 +157,7 @@ pub const AcquisitionAction = enum {
     login,
     chatgpt_login,
     grok_login,
+    claude_login,
     setup,
     change_team,
     switch_credential,
@@ -392,12 +394,12 @@ pub const PickerView = struct {
     pub fn choiceCount(self: PickerView) usize {
         return switch (self.stage) {
             .root => if (self.include_skip)
-                if (comptime host_target.is_wasm) 2 else 4
+                if (comptime host_target.is_wasm) 2 else 5
             else if (comptime host_target.is_wasm)
                 4
             else
-                7,
-            .provider => if (comptime host_target.is_wasm) 2 else 3,
+                8,
+            .provider => if (comptime host_target.is_wasm) 2 else 4,
             .sign_in, .api_key => 0,
             .change_team => blk: {
                 var count: usize = 0;
@@ -423,7 +425,8 @@ pub const PickerView = struct {
                     0 => .{ .action = .login },
                     1 => .{ .action = .chatgpt_login },
                     2 => .{ .action = .grok_login },
-                    3 => .{ .action = .setup },
+                    3 => .{ .action = .claude_login },
+                    4 => .{ .action = .setup },
                     else => null,
                 }
             else if (comptime host_target.is_wasm)
@@ -438,16 +441,18 @@ pub const PickerView = struct {
                 0 => .{ .action = .login },
                 1 => .{ .action = .chatgpt_login },
                 2 => .{ .action = .grok_login },
-                3 => .{ .action = .setup },
-                4 => .{ .action = .switch_provider },
-                5 => .{ .action = .change_team },
-                6 => .{ .action = .switch_credential },
+                3 => .{ .action = .claude_login },
+                4 => .{ .action = .setup },
+                5 => .{ .action = .switch_provider },
+                6 => .{ .action = .change_team },
+                7 => .{ .action = .switch_credential },
                 else => null,
             },
             .provider => switch (index) {
                 0 => .{ .provider = .gateway },
                 1 => .{ .provider = .codex },
                 2 => if (comptime host_target.is_wasm) null else .{ .provider = .grok },
+                3 => if (comptime host_target.is_wasm) null else .{ .provider = .claude },
                 else => null,
             },
             .sign_in, .api_key => null,
@@ -491,6 +496,7 @@ pub const PickerView = struct {
                 .login => "Sign in with Vercel",
                 .chatgpt_login => "Sign in with Codex",
                 .grok_login => "Sign in with Grok",
+                .claude_login => "Sign in with Claude",
                 .setup => if (self.include_skip) "Add an API key" else "API key",
                 .change_team => "Change team",
                 .switch_credential => "Switch credential",
@@ -509,6 +515,7 @@ pub const PickerView = struct {
                 .login => if (self.fx_login_session_available) "connected" else "",
                 .chatgpt_login => if (self.available_sources.contains(.chatgpt_subscription)) "connected" else "",
                 .grok_login => if (self.available_sources.contains(.grok_subscription)) "connected" else "",
+                .claude_login => if (self.available_sources.contains(.claude_subscription)) "connected" else "",
                 .setup, .switch_credential, .switch_provider => "",
                 .automatic => "use normal precedence",
                 .change_team => if (self.fx_login_session_available) "choose a team" else "sign in first",
@@ -521,7 +528,8 @@ pub const PickerView = struct {
         return switch (choice) {
             .action => |action| (action != .change_team or self.fx_login_session_available) and
                 (action != .chatgpt_login or !host_target.is_wasm) and
-                (action != .grok_login or !host_target.is_wasm),
+                (action != .grok_login or !host_target.is_wasm) and
+                (action != .claude_login or !host_target.is_wasm),
             .provider, .source, .team => true,
         };
     }
@@ -679,9 +687,9 @@ pub fn loadStatusSnapshotForProvider(
         },
     };
     const resolved_source = if (resolution.credential) |credential| credential.source else null;
-    var gateway_connected = resolved_source != null and resolved_source != .chatgpt_subscription and resolved_source != .grok_subscription;
-    const gateway_probe_required = provider == .codex or provider == .grok or
-        resolved_source == .chatgpt_subscription or resolved_source == .grok_subscription;
+    var gateway_connected = resolved_source != null and resolved_source != .chatgpt_subscription and resolved_source != .grok_subscription and resolved_source != .claude_subscription;
+    const gateway_probe_required = provider == .codex or provider == .grok or provider == .claude or
+        resolved_source == .chatgpt_subscription or resolved_source == .grok_subscription or resolved_source == .claude_subscription;
     if (gateway_probe_required) {
         for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key }) |source| {
             if (credentials.sourceExists(alloc, secret_store, source) catch |err| switch (err) {
@@ -714,6 +722,8 @@ pub fn loadStatusSnapshotForProvider(
             .chatgpt_subscription
         else if (provider == .grok)
             .grok_subscription
+        else if (provider == .claude)
+            .claude_subscription
         else
             null,
         .stored_key_status = resolution.stored_key_status,
@@ -933,6 +943,14 @@ pub const Runtime = struct {
         }
     }
 
+    pub fn refreshClaudeSourceInventory(self: *Self, alloc: Allocator) !void {
+        if (try credentials.sourceExists(alloc, self.secret_store, .claude_subscription)) {
+            self.source_inventory.insert(.claude_subscription);
+        } else if (self.credentialSource() != .claude_subscription) {
+            self.source_inventory.remove(.claude_subscription);
+        }
+    }
+
     fn refreshSourceInventoryWithProbe(
         self: *Self,
         alloc: Allocator,
@@ -1058,7 +1076,7 @@ pub const Runtime = struct {
         self.picker_stage = .switch_credential;
         const active_source = self.credentialSource();
         self.picker_selection = if (active_source) |source|
-            if (source != .chatgpt_subscription and source != .grok_subscription and self.source_inventory.contains(source))
+            if (source != .chatgpt_subscription and source != .grok_subscription and source != .claude_subscription and self.source_inventory.contains(source))
                 .{ .source = source }
             else
                 self.pickerView().choiceAt(0)
@@ -1110,6 +1128,16 @@ pub const Runtime = struct {
     pub fn openGrokSignInPickerForProviderSwitch(self: *Self, alloc: Allocator) !bool {
         if (comptime host_target.is_wasm) return error.GrokOAuthUnavailable;
         return self.openSignInPickerWithParent(alloc, false, .grok_subscription);
+    }
+
+    pub fn openClaudeSignInPickerFromRoot(self: *Self, alloc: Allocator) !bool {
+        if (comptime host_target.is_wasm) return error.ClaudeOAuthUnavailable;
+        return self.openSignInPickerWithParent(alloc, true, .claude_subscription);
+    }
+
+    pub fn openClaudeSignInPickerForProviderSwitch(self: *Self, alloc: Allocator) !bool {
+        if (comptime host_target.is_wasm) return error.ClaudeOAuthUnavailable;
+        return self.openSignInPickerWithParent(alloc, false, .claude_subscription);
     }
 
     fn openSignInPickerWithParent(
@@ -1274,6 +1302,8 @@ pub const Runtime = struct {
                 .chatgpt_login
             else if (self.sign_in_source == .grok_subscription)
                 .grok_login
+            else if (self.sign_in_source == .claude_subscription)
+                .claude_login
             else
                 .login,
             .api_key => .setup,
@@ -1317,7 +1347,7 @@ pub const Runtime = struct {
                     .setup => {},
                     // Only reachable from the switch screen, never the root.
                     .automatic => unreachable,
-                    .login, .chatgpt_login, .grok_login => self.closePicker(alloc),
+                    .login, .chatgpt_login, .grok_login, .claude_login => self.closePicker(alloc),
                 },
                 .team => unreachable,
             },
@@ -1482,7 +1512,7 @@ pub const Runtime = struct {
 
         try self.refreshSourceInventoryWithProbe(alloc, ctx, probe);
         for (credential_source_order) |source| {
-            if (source == .chatgpt_subscription or source == .grok_subscription) continue;
+            if (source == .chatgpt_subscription or source == .grok_subscription or source == .claude_subscription) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) {
                 return self.credentialSource() != previous;
@@ -1508,6 +1538,18 @@ pub const Runtime = struct {
     pub fn reconcileAfterGrokLogout(self: *Self, alloc: Allocator) !bool {
         const was_available = self.source_inventory.contains(.grok_subscription);
         const was_active = self.credentialSource() == .grok_subscription;
+        if (was_active) {
+            if (self.selected_credential) |*credential| credential.deinit(alloc);
+            self.selected_credential = null;
+            self.credential_refresh_failure_source = null;
+        }
+        try self.refreshSourceInventory(alloc);
+        return was_active or was_available;
+    }
+
+    pub fn reconcileAfterClaudeLogout(self: *Self, alloc: Allocator) !bool {
+        const was_available = self.source_inventory.contains(.claude_subscription);
+        const was_active = self.credentialSource() == .claude_subscription;
         if (was_active) {
             if (self.selected_credential) |*credential| credential.deinit(alloc);
             self.selected_credential = null;
@@ -1544,7 +1586,7 @@ pub const Runtime = struct {
         if (!login_was_active) return false;
 
         for (credential_source_order) |source| {
-            if (source == .chatgpt_subscription or source == .grok_subscription) continue;
+            if (source == .chatgpt_subscription or source == .grok_subscription or source == .claude_subscription) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) return true;
             self.source_inventory.remove(source);
@@ -1640,7 +1682,7 @@ fn takeDisplayTeam(alloc: Allocator, credential: *credentials.Credential) ?[]u8 
 fn gatewaySourceCount(sources: SourceSet) usize {
     var count: usize = 0;
     for (credential_source_order) |source| {
-        if (source == .chatgpt_subscription or source == .grok_subscription or !sources.contains(source)) continue;
+        if (source == .chatgpt_subscription or source == .grok_subscription or source == .claude_subscription or !sources.contains(source)) continue;
         count += 1;
     }
     return count;
@@ -1649,7 +1691,7 @@ fn gatewaySourceCount(sources: SourceSet) usize {
 fn gatewaySourceAtIndex(sources: SourceSet, wanted_index: usize) ?credentials.Source {
     var index: usize = 0;
     for (credential_source_order) |source| {
-        if (source == .chatgpt_subscription or source == .grok_subscription or !sources.contains(source)) continue;
+        if (source == .chatgpt_subscription or source == .grok_subscription or source == .claude_subscription or !sources.contains(source)) continue;
         if (index == wanted_index) return source;
         index += 1;
     }
@@ -2309,9 +2351,9 @@ test "auth picker root starts on sign in and keeps sources in the switch stage" 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.active);
     try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
-    try std.testing.expectEqual(@as(usize, 7), picker.choiceCount());
-    try std.testing.expectEqualStrings("Switch provider", picker.choiceLabel(picker.choiceAt(4).?));
-    try std.testing.expect(picker.choiceAt(7) == null);
+    try std.testing.expectEqual(@as(usize, 8), picker.choiceCount());
+    try std.testing.expectEqualStrings("Switch provider", picker.choiceLabel(picker.choiceAt(5).?));
+    try std.testing.expect(picker.choiceAt(8) == null);
 }
 
 test "credential switcher excludes provider-routed subscription sessions" {
@@ -2328,7 +2370,7 @@ test "credential switcher excludes provider-routed subscription sessions" {
     try std.testing.expect((Choice{ .action = .automatic }).eql(picker.choiceAt(1).?));
 }
 
-test "auth picker navigation wraps across the seven hub actions" {
+test "auth picker navigation wraps across the eight hub actions" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .fx_login });
@@ -2338,6 +2380,8 @@ test "auth picker navigation wraps across the seven hub actions" {
     try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expect((Choice{ .action = .grok_login }).eql(runtime.pickerView().selected_choice.?));
+    try std.testing.expect(runtime.movePicker(1));
+    try std.testing.expect((Choice{ .action = .claude_login }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expect((Choice{ .action = .setup }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
@@ -2373,7 +2417,7 @@ test "auth picker without credentials exposes acquisition actions" {
     try std.testing.expect(picker.active_source == null);
     try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
     try std.testing.expectEqual(@as(usize, 0), picker.available_sources.count());
-    try std.testing.expectEqual(@as(usize, 7), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 8), picker.choiceCount());
     try std.testing.expect(!picker.choiceEnabled(.{ .action = .change_team }));
     try std.testing.expectEqualStrings("missing", picker.activeSourceLabel());
 }
@@ -2385,13 +2429,14 @@ test "auth onboarding picker exposes the setup paths" {
 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.include_skip);
-    try std.testing.expectEqual(@as(usize, 4), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 5), picker.choiceCount());
     try std.testing.expect((Choice{ .action = .login }).eql(picker.choiceAt(0).?));
     try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(picker.choiceAt(1).?));
     try std.testing.expect((Choice{ .action = .grok_login }).eql(picker.choiceAt(2).?));
-    try std.testing.expect((Choice{ .action = .setup }).eql(picker.choiceAt(3).?));
-    try std.testing.expectEqualStrings("Add an API key", picker.choiceLabel(picker.choiceAt(3).?));
-    try std.testing.expect(picker.choiceAt(4) == null);
+    try std.testing.expect((Choice{ .action = .claude_login }).eql(picker.choiceAt(3).?));
+    try std.testing.expect((Choice{ .action = .setup }).eql(picker.choiceAt(4).?));
+    try std.testing.expectEqualStrings("Add an API key", picker.choiceLabel(picker.choiceAt(4).?));
+    try std.testing.expect(picker.choiceAt(5) == null);
 }
 
 test "clearing a remembered choice re-resolves even when no login was active" {

--- a/src/core/auth/claude_code_store.zig
+++ b/src/core/auth/claude_code_store.zig
@@ -1,0 +1,339 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const debug_trace = @import("../shared/debug_trace.zig");
+const host_target = @import("../hosts/target.zig");
+const io_mod = @import("../shared/io.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+const max_credentials_bytes: usize = 64 * 1024;
+const max_claude_json_bytes: usize = 1024 * 1024;
+const expiry_skew_ms: i64 = 60 * 1000;
+const default_user_agent = "claude-cli/2.1.0 (external, cli)";
+
+pub const user_agent = default_user_agent;
+pub const originator = "claude-code";
+pub const messages_beta = "oauth-2025-04-20,claude-code-20250219";
+
+pub const Stored = struct {
+    access_token: []u8,
+    refresh_token: []u8,
+    expires_at_ms: i64,
+    account_id: []u8,
+
+    pub fn deinit(self: *Stored, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.access_token);
+        secret.zeroAndFree(alloc, self.refresh_token);
+        alloc.free(self.account_id);
+        self.* = undefined;
+    }
+
+    pub fn expired(self: Stored, now_ms: i64) bool {
+        return refreshDeadlineMs(self.expires_at_ms) <= now_ms;
+    }
+};
+
+pub fn refreshDeadlineMs(expires_at_ms: i64) i64 {
+    return @max(expires_at_ms - expiry_skew_ms, 0);
+}
+
+pub fn e2eIsolated() bool {
+    return io_mod.getenv("FX_E2E_CLAUDE_TOKEN_URL") != null;
+}
+
+const tools_unset: u8 = 0;
+const tools_on: u8 = 1;
+const tools_off: u8 = 2;
+
+var cli_tools_override: std.atomic.Value(u8) = .init(tools_unset);
+var settings_tools_override: std.atomic.Value(u8) = .init(tools_unset);
+
+pub fn setClaudeCodeToolsFromCli(on: bool) void {
+    cli_tools_override.store(if (on) tools_on else tools_off, .seq_cst);
+}
+
+pub fn setClaudeCodeToolsFromSettings(on: bool) void {
+    settings_tools_override.store(if (on) tools_on else tools_off, .seq_cst);
+}
+
+pub fn claudeCodeToolsEnabled() bool {
+    if (io_mod.getenv("FX_CLAUDE_CODE_TOOLS")) |raw| {
+        if (parseToolsToggle(raw)) |value| return value;
+    }
+    return switch (cli_tools_override.load(.seq_cst)) {
+        tools_off => false,
+        tools_on => true,
+        else => switch (settings_tools_override.load(.seq_cst)) {
+            tools_on => true,
+            else => false,
+        },
+    };
+}
+
+pub fn parseToolsToggle(raw: []const u8) ?bool {
+    if (eqlIgnoreCase(raw, "on") or eqlIgnoreCase(raw, "true") or eqlIgnoreCase(raw, "1") or eqlIgnoreCase(raw, "claude"))
+        return true;
+    if (eqlIgnoreCase(raw, "off") or eqlIgnoreCase(raw, "false") or eqlIgnoreCase(raw, "0") or
+        eqlIgnoreCase(raw, "none") or eqlIgnoreCase(raw, "fx") or eqlIgnoreCase(raw, "host"))
+        return false;
+    return null;
+}
+
+fn eqlIgnoreCase(left: []const u8, right: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(left, right);
+}
+
+fn enabled() bool {
+    if (e2eIsolated()) return false;
+    if (comptime builtin.is_test) return io_mod.getenv("FX_TEST_CLAUDE_CODE_STORE") != null;
+    return true;
+}
+
+pub fn findCli(alloc: Allocator) !?[]u8 {
+    if (comptime host_target.is_wasm) return null;
+    if (io_mod.getenv("FX_CLAUDE_CLI")) |override| {
+        if (override.len > 0 and cliExists(override)) return try alloc.dupe(u8, override);
+    }
+    if (io_mod.getenv("PATH")) |path_env| {
+        if (try findCliInPath(alloc, path_env)) |found| return found;
+    }
+    if (io_mod.getenv("HOME")) |home| {
+        const candidate = try std.fs.path.join(alloc, &.{ home, ".local", "bin", "claude" });
+        defer alloc.free(candidate);
+        if (cliExists(candidate)) return try alloc.dupe(u8, candidate);
+    }
+    return null;
+}
+
+pub fn hasCredentials(alloc: Allocator) !bool {
+    var stored = (try load(alloc)) orelse return false;
+    stored.deinit(alloc);
+    return true;
+}
+
+pub fn load(alloc: Allocator) !?Stored {
+    if (comptime host_target.is_wasm) return null;
+    if (!enabled()) return null;
+    const home = io_mod.getenv("HOME") orelse return null;
+    const credentials_path = try std.fs.path.join(alloc, &.{ home, ".claude", "credentials.json" });
+    defer alloc.free(credentials_path);
+    const bytes = (try readPrivateFile(alloc, credentials_path, max_credentials_bytes)) orelse return null;
+    defer secret.zeroAndFree(alloc, bytes);
+    var stored = parseCredentials(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "Claude Code credentials parse failed err={s}", .{@errorName(err)});
+            return null;
+        },
+    };
+    errdefer stored.deinit(alloc);
+    if (stored.account_id.len == 0) {
+        alloc.free(stored.account_id);
+        stored.account_id = try loadAccountId(alloc, home);
+    }
+    return stored;
+}
+
+pub fn save(alloc: Allocator, stored: Stored) !void {
+    if (comptime host_target.is_wasm) return error.ClaudeOAuthUnavailable;
+    if (!enabled()) return error.InvalidE2EClaudeEndpoint;
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const path = try std.fs.path.join(alloc, &.{ home, ".claude", "credentials.json" });
+    defer alloc.free(path);
+    const text = try stringifyCredentials(alloc, stored);
+    defer secret.zeroAndFree(alloc, text);
+    io_mod.writeFileAtomic(alloc, path, text) catch |err| {
+        debug_trace.logf("auth", "Claude Code credentials save failed err={s}", .{@errorName(err)});
+        return err;
+    };
+}
+
+pub fn parseCredentials(alloc: Allocator, bytes: []const u8) !Stored {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidClaudeCodeCredentials;
+    const object = parsed.value.object;
+    const access_token = try dupeRequiredString(alloc, object, "oauth_token");
+    errdefer secret.zeroAndFree(alloc, access_token);
+    const refresh_token = try dupeRequiredString(alloc, object, "oauth_refresh_token");
+    errdefer secret.zeroAndFree(alloc, refresh_token);
+    const expires_at_ms = try expiresAtMs(object);
+    const account_id = if (object.get("account_uuid")) |value|
+        try dupeOptionalId(alloc, value)
+    else
+        try alloc.dupe(u8, "");
+    errdefer alloc.free(account_id);
+    return .{
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+        .expires_at_ms = expires_at_ms,
+        .account_id = account_id,
+    };
+}
+
+pub fn stringifyCredentials(alloc: Allocator, stored: Stored) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"oauth_token\":");
+    try std.json.Stringify.value(stored.access_token, .{}, &out.writer);
+    try out.writer.writeAll(",\"oauth_refresh_token\":");
+    try std.json.Stringify.value(stored.refresh_token, .{}, &out.writer);
+    const expires_at_s = @divTrunc(stored.expires_at_ms, 1000);
+    try out.writer.print(",\"oauth_expires_at\":{d}", .{expires_at_s});
+    try out.writer.writeAll("}\n");
+    return out.toOwnedSlice();
+}
+
+fn loadAccountId(alloc: Allocator, home: []const u8) ![]u8 {
+    const path = try std.fs.path.join(alloc, &.{ home, ".claude.json" });
+    defer alloc.free(path);
+    const bytes = (try readPrivateFile(alloc, path, max_claude_json_bytes)) orelse
+        return alloc.dupe(u8, "");
+    defer secret.zeroAndFree(alloc, bytes);
+    return parseAccountId(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => alloc.dupe(u8, ""),
+    };
+}
+
+pub fn parseAccountId(alloc: Allocator, bytes: []const u8) ![]u8 {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidClaudeCodeCredentials;
+    const account = parsed.value.object.get("oauthAccount") orelse
+        return error.InvalidClaudeCodeCredentials;
+    if (account != .object) return error.InvalidClaudeCodeCredentials;
+    const value = account.object.get("accountUuid") orelse
+        return error.InvalidClaudeCodeCredentials;
+    if (value != .string or value.string.len == 0) return error.InvalidClaudeCodeCredentials;
+    return alloc.dupe(u8, value.string);
+}
+
+fn expiresAtMs(object: std.json.ObjectMap) !i64 {
+    const value = object.get("oauth_expires_at") orelse return error.InvalidClaudeCodeCredentials;
+    const raw: i64 = switch (value) {
+        .integer => value.integer,
+        else => return error.InvalidClaudeCodeCredentials,
+    };
+    if (raw <= 0) return error.InvalidClaudeCodeCredentials;
+    if (raw > 1_000_000_000_000) return raw;
+    return std.math.mul(i64, raw, 1000) catch return error.InvalidClaudeCodeCredentials;
+}
+
+fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
+    const value = object.get(key) orelse return error.InvalidClaudeCodeCredentials;
+    if (value != .string or value.string.len == 0) return error.InvalidClaudeCodeCredentials;
+    return alloc.dupe(u8, value.string);
+}
+
+fn dupeOptionalId(alloc: Allocator, value: std.json.Value) ![]u8 {
+    if (value != .string) return error.InvalidClaudeCodeCredentials;
+    return alloc.dupe(u8, value.string);
+}
+
+fn readPrivateFile(alloc: Allocator, path: []const u8, max_bytes: usize) !?[]u8 {
+    var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{
+        .mode = .read_only,
+        .allow_directory = false,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => {
+            debug_trace.logf("auth", "Claude Code file open failed path_kind={s} err={s}", .{
+                std.fs.path.basename(path),
+                @errorName(err),
+            });
+            return null;
+        },
+    };
+    defer file.close(io_mod.getIo());
+    const stat = file.stat(io_mod.getIo()) catch return null;
+    if (stat.kind != .file) return null;
+    if (stat.permissions.toMode() & 0o077 != 0) {
+        debug_trace.logf("auth", "Claude Code file ignored step=permissions path_kind={s}", .{
+            std.fs.path.basename(path),
+        });
+        return null;
+    }
+    return io_mod.readFileToEnd(alloc, &file, max_bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "Claude Code file read failed path_kind={s} err={s}", .{
+                std.fs.path.basename(path),
+                @errorName(err),
+            });
+            return null;
+        },
+    };
+}
+
+fn findCliInPath(alloc: Allocator, path_env: []const u8) !?[]u8 {
+    var it = std.mem.splitScalar(u8, path_env, ':');
+    while (it.next()) |dir| {
+        if (dir.len == 0) continue;
+        const candidate = try std.fs.path.join(alloc, &.{ dir, "claude" });
+        if (cliExists(candidate)) return candidate;
+        alloc.free(candidate);
+    }
+    return null;
+}
+
+fn cliExists(path: []const u8) bool {
+    if (path.len == 0 or !std.fs.path.isAbsolute(path)) return false;
+    var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{
+        .mode = .read_only,
+        .allow_directory = false,
+    }) catch return false;
+    defer file.close(io_mod.getIo());
+    const stat = file.stat(io_mod.getIo()) catch return false;
+    return stat.kind == .file;
+}
+
+test "Claude Code credentials parse oauth_expires_at seconds" {
+    const alloc = std.testing.allocator;
+    var stored = try parseCredentials(
+        alloc,
+        "{\"oauth_token\":\"access\",\"oauth_refresh_token\":\"refresh\",\"oauth_expires_at\":1782251014}",
+    );
+    defer stored.deinit(alloc);
+    try std.testing.expectEqualStrings("access", stored.access_token);
+    try std.testing.expectEqualStrings("refresh", stored.refresh_token);
+    try std.testing.expectEqual(@as(i64, 1_782_251_014_000), stored.expires_at_ms);
+}
+
+test "Claude Code credentials stringify uses seconds" {
+    const alloc = std.testing.allocator;
+    var stored = Stored{
+        .access_token = try alloc.dupe(u8, "access"),
+        .refresh_token = try alloc.dupe(u8, "refresh"),
+        .expires_at_ms = 1_782_251_014_000,
+        .account_id = try alloc.dupe(u8, "acct"),
+    };
+    defer stored.deinit(alloc);
+    const text = try stringifyCredentials(alloc, stored);
+    defer secret.zeroAndFree(alloc, text);
+    try std.testing.expect(std.mem.find(u8, text, "\"oauth_expires_at\":1782251014") != null);
+    try std.testing.expect(std.mem.find(u8, text, "account") == null);
+}
+
+test "Claude Code account uuid comes from oauthAccount" {
+    const alloc = std.testing.allocator;
+    const account_id = try parseAccountId(
+        alloc,
+        "{\"oauthAccount\":{\"accountUuid\":\"acct-uuid\",\"organizationUuid\":\"org\"}}",
+    );
+    defer alloc.free(account_id);
+    try std.testing.expectEqualStrings("acct-uuid", account_id);
+}
+
+test "Claude Code tools toggle parses on and off aliases" {
+    try std.testing.expectEqual(true, parseToolsToggle("on").?);
+    try std.testing.expectEqual(true, parseToolsToggle("Claude").?);
+    try std.testing.expectEqual(false, parseToolsToggle("off").?);
+    try std.testing.expectEqual(false, parseToolsToggle("fx").?);
+    try std.testing.expect(parseToolsToggle("maybe") == null);
+}
+
+test "Claude Code tools default to off" {
+    if (io_mod.getenv("FX_CLAUDE_CODE_TOOLS") != null) return error.SkipZigTest;
+    try std.testing.expect(!claudeCodeToolsEnabled());
+}

--- a/src/core/auth/claude_oauth.zig
+++ b/src/core/auth/claude_oauth.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const claude_code_store = @import("claude_code_store.zig");
 const claude_session = @import("claude_session.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
@@ -14,10 +15,17 @@ const Allocator = std.mem.Allocator;
 const client_id = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const issuer_url = "https://claude.ai";
 const authorize_url = "https://claude.ai/oauth/authorize";
-const token_url = "https://platform.claude.com/v1/oauth/token";
+const token_url = "https://console.anthropic.com/v1/oauth/token";
 const userinfo_url = "https://api.anthropic.com/api/oauth/profile";
 pub const anthropic_api_version = "2023-06-01";
 pub const oauth_beta = "oauth-2025-04-20";
+pub const messages_beta = claude_code_store.messages_beta;
+pub const messages_originator = claude_code_store.originator;
+pub const messages_user_agent = claude_code_store.user_agent;
+pub const oauth_api_headers = [_]std.http.Header{
+    .{ .name = "anthropic-version", .value = anthropic_api_version },
+    .{ .name = "anthropic-beta", .value = oauth_beta },
+};
 const e2e_issuer_url_env = "FX_E2E_CLAUDE_ISSUER_URL";
 const e2e_authorize_url_env = "FX_E2E_CLAUDE_AUTHORIZE_URL";
 const e2e_token_url_env = "FX_E2E_CLAUDE_TOKEN_URL";
@@ -248,6 +256,7 @@ fn pollBrowserToken(
             code,
             context.code_verifier,
             context.redirect_uri,
+            context.state,
             cancel_flag,
             deadline,
         );
@@ -288,6 +297,7 @@ fn pollBrowserToken(
         callback.code,
         context.code_verifier,
         context.redirect_uri,
+        context.state,
         cancel_flag,
         deadline,
     ) catch |err| {
@@ -450,7 +460,10 @@ pub fn runLogin(
                 if (std.mem.findScalar(u8, paste_line.items, '\n') != null) {
                     const trimmed = std.mem.trim(u8, paste_line.items, " \t\r\n");
                     if (trimmed.len > 0) {
-                        submitPastedAuthorizationInput(&runtime, alloc, trimmed) catch {};
+                        submitPastedAuthorizationInput(&runtime, alloc, trimmed) catch |err| {
+                            debug_trace.logf("auth", "Claude pasted authorization rejected err={s}", .{@errorName(err)});
+                            return err;
+                        };
                     }
                     std.crypto.secureZero(u8, @volatileCast(paste_line.items));
                     paste_line.clearRetainingCapacity();
@@ -513,6 +526,7 @@ pub fn logout(alloc: Allocator, transport: oauth_transport.Provider) !LogoutResu
 }
 
 pub fn sourceExists(alloc: Allocator) !bool {
+    if (try claude_code_store.hasCredentials(alloc)) return true;
     var session = (try claude_session.load(alloc)) orelse return false;
     defer session.deinit(alloc);
     return true;
@@ -523,6 +537,7 @@ pub fn loadAccess(
     transport: oauth_transport.Provider,
     mode: RefreshMode,
 ) !?Access {
+    if (try loadClaudeCodeAccess(alloc, transport, mode)) |access| return access;
     if (mode == .stored) {
         var session = (try claude_session.load(alloc)) orelse return null;
         defer session.deinit(alloc);
@@ -538,6 +553,77 @@ pub fn loadAccess(
         try refreshSession(alloc, transport, &mutation, &session);
     }
     return takeAccess(&session);
+}
+
+fn loadClaudeCodeAccess(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    mode: RefreshMode,
+) !?Access {
+    var stored = (try claude_code_store.load(alloc)) orelse return null;
+    errdefer stored.deinit(alloc);
+    if (mode != .stored and (mode == .force or stored.expired(io_mod.milliTimestamp()))) {
+        refreshClaudeCodeSession(alloc, transport, &stored) catch |err| {
+            debug_trace.logf("auth", "Claude Code token refresh failed err={s}", .{@errorName(err)});
+            return null;
+        };
+        claude_code_store.save(alloc, stored) catch |err| {
+            debug_trace.logf("auth", "Claude Code token persist failed err={s}", .{@errorName(err)});
+        };
+    }
+    if (stored.account_id.len == 0 or !claude_session.validAccountId(stored.account_id)) {
+        const account_id = fetchAccountId(alloc, transport, stored.access_token) catch |err| {
+            debug_trace.logf("auth", "Claude Code account lookup failed err={s}", .{@errorName(err)});
+            return null;
+        };
+        alloc.free(stored.account_id);
+        stored.account_id = account_id;
+    }
+    if (try claude_code_store.findCli(alloc)) |cli| {
+        defer alloc.free(cli);
+        debug_trace.logf("auth", "Claude Code CLI detected", .{});
+    }
+    const access = Access{
+        .access_token = stored.access_token,
+        .account_id = stored.account_id,
+        .refresh_after_ms = claude_code_store.refreshDeadlineMs(stored.expires_at_ms),
+    };
+    secret.zeroAndFree(alloc, stored.refresh_token);
+    stored.access_token = &.{};
+    stored.refresh_token = &.{};
+    stored.account_id = &.{};
+    return access;
+}
+
+fn refreshClaudeCodeSession(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    stored: *claude_code_store.Stored,
+) !void {
+    const payload = try jsonObjectPayload(alloc, .{
+        .grant_type = "refresh_token",
+        .client_id = client_id,
+        .refresh_token = stored.refresh_token,
+    });
+    defer secret.zeroAndFree(alloc, payload);
+    var token = try requestRefreshToken(alloc, transport, payload);
+    defer token.deinit(alloc);
+    const access_token = token.access_token;
+    token.access_token = &.{};
+    errdefer secret.zeroAndFree(alloc, access_token);
+    const refresh_token = if (token.refresh_token) |rotated| rotated else try alloc.dupe(u8, stored.refresh_token);
+    if (token.refresh_token != null) token.refresh_token = null;
+    errdefer secret.zeroAndFree(alloc, refresh_token);
+    const expires_in = token.expires_in orelse return error.InvalidClaudeOAuthResponse;
+    const duration_ms = std.math.mul(i64, expires_in, std.time.ms_per_s) catch
+        return error.InvalidClaudeOAuthResponse;
+    const expires_at_ms = std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
+        return error.InvalidClaudeOAuthResponse;
+    secret.zeroAndFree(alloc, stored.access_token);
+    secret.zeroAndFree(alloc, stored.refresh_token);
+    stored.access_token = access_token;
+    stored.refresh_token = refresh_token;
+    stored.expires_at_ms = expires_at_ms;
 }
 
 fn takeAccess(session: *claude_session.Session) Access {
@@ -558,13 +644,13 @@ fn refreshSession(
     mutation: *claude_session.Mutation,
     session: *claude_session.Session,
 ) !void {
-    var body: std.Io.Writer.Allocating = .init(alloc);
-    defer body.deinit();
-    var form: FormBody = .{};
-    try form.append(&body.writer, "grant_type", "refresh_token");
-    try form.append(&body.writer, "client_id", client_id);
-    try form.append(&body.writer, "refresh_token", session.refresh_token);
-    var token = try requestRefreshToken(alloc, transport, body.written());
+    const payload = try jsonObjectPayload(alloc, .{
+        .grant_type = "refresh_token",
+        .client_id = client_id,
+        .refresh_token = session.refresh_token,
+    });
+    defer secret.zeroAndFree(alloc, payload);
+    var token = try requestRefreshToken(alloc, transport, payload);
     defer token.deinit(alloc);
 
     const account_id = try fetchAccountId(alloc, transport, token.access_token);
@@ -620,7 +706,7 @@ fn requestRefreshToken(
     const bytes = try requestAccepted(
         alloc,
         transport,
-        .post_form,
+        .post_json,
         endpoint_url,
         payload,
     );
@@ -654,18 +740,20 @@ fn exchangeAuthorizationCodeForRedirectWithBounds(
     authorization_code: []const u8,
     code_verifier: []const u8,
     redirect_uri: []const u8,
+    state: []const u8,
     cancel_flag: ?*std.atomic.Value(bool),
     deadline: ?std.Io.Clock.Timestamp,
 ) !TokenSet {
-    var form: FormBody = .{};
-    var body: std.Io.Writer.Allocating = .init(alloc);
-    defer body.deinit();
-    try form.append(&body.writer, "grant_type", "authorization_code");
-    try form.append(&body.writer, "client_id", client_id);
-    try form.append(&body.writer, "code", authorization_code);
-    try form.append(&body.writer, "code_verifier", code_verifier);
-    try form.append(&body.writer, "redirect_uri", redirect_uri);
-    return requestTokenAtWithBounds(alloc, transport, endpoint_url, body.written(), cancel_flag, deadline);
+    const payload = try jsonObjectPayload(alloc, .{
+        .grant_type = "authorization_code",
+        .code = authorization_code,
+        .state = state,
+        .code_verifier = code_verifier,
+        .redirect_uri = redirect_uri,
+        .client_id = client_id,
+    });
+    defer secret.zeroAndFree(alloc, payload);
+    return requestTokenAtWithBounds(alloc, transport, endpoint_url, payload, cancel_flag, deadline);
 }
 
 fn requestTokenAtWithBounds(
@@ -679,7 +767,7 @@ fn requestTokenAtWithBounds(
     const bytes = try requestAcceptedWithBounds(
         alloc,
         transport,
-        .post_form,
+        .post_json,
         endpoint_url,
         payload,
         cancel_flag,
@@ -745,15 +833,11 @@ fn fetchAccountId(
     defer alloc.free(endpoint_url);
     const authorization = try std.fmt.allocPrint(alloc, "Bearer {s}", .{access_token});
     defer secret.zeroAndFree(alloc, authorization);
-    const extra_headers = [_]std.http.Header{
-        .{ .name = "anthropic-version", .value = anthropic_api_version },
-        .{ .name = "anthropic-beta", .value = oauth_beta },
-    };
     var response = try transport.execute(alloc, .{
         .method = .get,
         .url = endpoint_url,
         .authorization = authorization,
-        .extra_headers = &extra_headers,
+        .extra_headers = &oauth_api_headers,
     });
     defer response.deinit(alloc);
     if (response.disposition != .accepted) {
@@ -832,10 +916,27 @@ fn requestAcceptedWithBounds(
     });
     defer response.deinit(alloc);
     if (response.disposition != .accepted) {
-        debug_trace.logf("auth", "Claude OAuth request rejected url={s}", .{url});
+        logRejectedOAuthBody(url, response.body);
         return error.ClaudeOAuthRequestFailed;
     }
     return response.takeBody();
+}
+
+fn jsonObjectPayload(alloc: Allocator, value: anytype) ![]u8 {
+    var body: std.Io.Writer.Allocating = .init(alloc);
+    errdefer body.deinit();
+    try std.json.Stringify.value(value, .{}, &body.writer);
+    return body.toOwnedSlice();
+}
+
+fn logRejectedOAuthBody(url: []const u8, body: []const u8) void {
+    var snippet: [160]u8 = undefined;
+    const n = @min(body.len, snippet.len);
+    @memcpy(snippet[0..n], body[0..n]);
+    for (snippet[0..n]) |*byte| {
+        if (byte.* < 0x20 or byte.* == 0x7f) byte.* = ' ';
+    }
+    debug_trace.logf("auth", "Claude OAuth request rejected url={s} body={s}", .{ url, snippet[0..n] });
 }
 
 fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
@@ -1081,6 +1182,155 @@ test "Claude browser callback requires the exact path and state" {
             std.testing.allocator,
             "/other?code=auth&state=expected",
             "expected",
+        ),
+    );
+}
+
+test "Claude account identity prefers nested profile uuid and sends oauth headers" {
+    const State = struct {
+        authorization_seen: bool = false,
+        saw_version: bool = false,
+        saw_beta: bool = false,
+
+        fn execute(raw: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.authorization_seen = std.mem.eql(u8, request.authorization orelse "", "Bearer access-token");
+            for (request.extra_headers) |header| {
+                if (std.mem.eql(u8, header.name, "anthropic-version") and
+                    std.mem.eql(u8, header.value, anthropic_api_version))
+                {
+                    self.saw_version = true;
+                }
+                if (std.mem.eql(u8, header.name, "anthropic-beta") and
+                    std.mem.eql(u8, header.value, oauth_beta))
+                {
+                    self.saw_beta = true;
+                }
+            }
+            return .{
+                .disposition = .accepted,
+                .body = try alloc.dupe(u8, "{\"account\":{\"uuid\":\"acct_test\"},\"organization\":{\"uuid\":\"org_test\"}}"),
+            };
+        }
+    };
+    var state = State{};
+    const account_id = try fetchAccountId(
+        std.testing.allocator,
+        .{ .context = &state, .execute_fn = State.execute },
+        "access-token",
+    );
+    defer std.testing.allocator.free(account_id);
+    try std.testing.expect(state.authorization_seen);
+    try std.testing.expect(state.saw_version);
+    try std.testing.expect(state.saw_beta);
+    try std.testing.expectEqualStrings("acct_test", account_id);
+}
+
+test "Claude account identity accepts OIDC sub when account uuid is absent" {
+    const State = struct {
+        fn execute(_: ?*anyopaque, alloc: Allocator, _: oauth_transport.Request) !oauth_transport.Response {
+            return .{ .disposition = .accepted, .body = try alloc.dupe(u8, "{\"sub\":\"acct_oidc\"}") };
+        }
+    };
+    const account_id = try fetchAccountId(
+        std.testing.allocator,
+        .{ .execute_fn = State.execute },
+        "access-token",
+    );
+    defer std.testing.allocator.free(account_id);
+    try std.testing.expectEqualStrings("acct_oidc", account_id);
+}
+
+test "Claude token exchange uses JSON with state and omits API headers" {
+    const State = struct {
+        method: ?oauth_transport.Method = null,
+        payload: [1024]u8 = undefined,
+        payload_len: usize = 0,
+        extra_header_count: usize = 0,
+
+        fn execute(raw: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            const payload = request.payload orelse &.{};
+            self.method = request.method;
+            self.payload_len = @min(payload.len, self.payload.len);
+            @memcpy(self.payload[0..self.payload_len], payload[0..self.payload_len]);
+            self.extra_header_count = request.extra_headers.len;
+            return .{
+                .disposition = .accepted,
+                .body = try alloc.dupe(u8, "{\"access_token\":\"access\",\"refresh_token\":\"refresh\",\"expires_in\":3600}"),
+            };
+        }
+    };
+    var state = State{};
+    var token = try exchangeAuthorizationCodeForRedirectWithBounds(
+        std.testing.allocator,
+        .{ .context = &state, .execute_fn = State.execute },
+        "http://127.0.0.1:1/token",
+        "auth-code",
+        "verifier",
+        browser_redirect_uri,
+        "state-value",
+        null,
+        null,
+    );
+    defer token.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(oauth_transport.Method.post_json, state.method.?);
+    try std.testing.expectEqual(@as(usize, 0), state.extra_header_count);
+    const payload = state.payload[0..state.payload_len];
+    try std.testing.expect(std.mem.find(u8, payload, "\"grant_type\":\"authorization_code\"") != null);
+    try std.testing.expect(std.mem.find(u8, payload, "\"code\":\"auth-code\"") != null);
+    try std.testing.expect(std.mem.find(u8, payload, "\"state\":\"state-value\"") != null);
+    try std.testing.expect(std.mem.find(u8, payload, "\"client_id\":\"") != null);
+    try std.testing.expect(std.mem.find(u8, payload, "\"code_verifier\":\"verifier\"") != null);
+    try std.testing.expect(std.mem.find(u8, payload, "grant_type=authorization_code") == null);
+    try std.testing.expectEqualStrings("access", token.access_token);
+}
+
+test "Claude refresh uses JSON" {
+    const State = struct {
+        method: ?oauth_transport.Method = null,
+        payload: [512]u8 = undefined,
+        payload_len: usize = 0,
+
+        fn execute(raw: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            const payload = request.payload orelse &.{};
+            self.method = request.method;
+            self.payload_len = @min(payload.len, self.payload.len);
+            @memcpy(self.payload[0..self.payload_len], payload[0..self.payload_len]);
+            return .{
+                .disposition = .accepted,
+                .body = try alloc.dupe(u8, "{\"access_token\":\"new-access\",\"expires_in\":3600}"),
+            };
+        }
+    };
+    var state = State{};
+    var response = try requestRefreshToken(
+        std.testing.allocator,
+        .{ .context = &state, .execute_fn = State.execute },
+        "{\"grant_type\":\"refresh_token\",\"client_id\":\"client\",\"refresh_token\":\"[redacted]\"}",
+    );
+    defer response.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(oauth_transport.Method.post_json, state.method.?);
+    try std.testing.expect(std.mem.find(u8, state.payload[0..state.payload_len], "\"grant_type\":\"refresh_token\"") != null);
+    try std.testing.expect(response.refresh_token == null);
+    try std.testing.expectEqual(@as(?i64, 3600), response.expires_in);
+}
+
+test "Claude account identity rejects unsafe userinfo bytes" {
+    const State = struct {
+        fn execute(_: ?*anyopaque, alloc: Allocator, _: oauth_transport.Request) !oauth_transport.Response {
+            return .{ .disposition = .accepted, .body = try alloc.dupe(u8, "{\"account\":{\"uuid\":\"acct\\ninjected\"}}") };
+        }
+    };
+    try std.testing.expectError(
+        error.InvalidClaudeUserInfoResponse,
+        fetchAccountId(
+            std.testing.allocator,
+            .{ .execute_fn = State.execute },
+            "access-token",
         ),
     );
 }

--- a/src/core/auth/claude_oauth.zig
+++ b/src/core/auth/claude_oauth.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const chatgpt_session = @import("chatgpt_session.zig");
+const claude_session = @import("claude_session.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
@@ -11,14 +11,19 @@ const secret = @import("secret.zig");
 
 const Allocator = std.mem.Allocator;
 
-pub const client_id = "app_EMoamEEZ73f0CkXaXp7hrann";
-pub const token_url = "https://auth.openai.com/oauth/token";
-pub const issuer_url = "https://auth.openai.com";
-const e2e_token_url_env = "FX_E2E_CHATGPT_TOKEN_URL";
-const e2e_issuer_url_env = "FX_E2E_CHATGPT_ISSUER_URL";
-const jwt_auth_claim = "https://api.openai.com/auth";
-const browser_scope = "openid profile email offline_access api.connectors.read api.connectors.invoke";
-const browser_callback_ports = [_]u16{ 1455, 1457 };
+const client_id = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const issuer_url = "https://claude.ai";
+const authorize_url = "https://claude.ai/oauth/authorize";
+const token_url = "https://platform.claude.com/v1/oauth/token";
+const userinfo_url = "https://api.anthropic.com/api/oauth/profile";
+pub const anthropic_api_version = "2023-06-01";
+pub const oauth_beta = "oauth-2025-04-20";
+const e2e_issuer_url_env = "FX_E2E_CLAUDE_ISSUER_URL";
+const e2e_authorize_url_env = "FX_E2E_CLAUDE_AUTHORIZE_URL";
+const e2e_token_url_env = "FX_E2E_CLAUDE_TOKEN_URL";
+const e2e_userinfo_url_env = "FX_E2E_CLAUDE_USERINFO_URL";
+const browser_scope = "user:profile user:inference user:sessions:claude_code user:mcp_servers";
+const browser_redirect_uri = "https://console.anthropic.com/oauth/code/callback";
 const browser_login_timeout_seconds: i64 = 5 * 60;
 const browser_callback_poll_ms: i32 = 100;
 const browser_callback_io_timeout_seconds: i64 = 30;
@@ -58,13 +63,33 @@ const BrowserLoginContext = struct {
     redirect_uri: []u8,
     code_verifier: []u8,
     state: []u8,
+    transport: oauth_transport.Provider,
+    paste_mutex: std.Io.Mutex = .init,
+    pasted_code: ?[]u8 = null,
 
     fn deinit(self: *BrowserLoginContext, alloc: Allocator) void {
         self.listener.deinit(io_mod.getIo());
         alloc.free(self.redirect_uri);
         secret.zeroAndFree(alloc, self.code_verifier);
         secret.zeroAndFree(alloc, self.state);
+        if (self.pasted_code) |code| secret.zeroAndFree(alloc, code);
         self.* = undefined;
+    }
+
+    fn takePastedCode(self: *BrowserLoginContext) ?[]u8 {
+        self.paste_mutex.lockUncancelable(io_mod.getIo());
+        defer self.paste_mutex.unlock(io_mod.getIo());
+        const code = self.pasted_code;
+        self.pasted_code = null;
+        return code;
+    }
+
+    fn setPastedCode(self: *BrowserLoginContext, alloc: Allocator, code: []const u8) !void {
+        const owned = try alloc.dupe(u8, code);
+        self.paste_mutex.lockUncancelable(io_mod.getIo());
+        defer self.paste_mutex.unlock(io_mod.getIo());
+        if (self.pasted_code) |previous| secret.zeroAndFree(alloc, previous);
+        self.pasted_code = owned;
     }
 };
 
@@ -78,7 +103,7 @@ pub fn startSignIn(
     alloc: Allocator,
     transport: oauth_transport.Provider,
 ) !bool {
-    const browser = try prepareBrowserSignIn(alloc);
+    const browser = try prepareBrowserSignIn(alloc, transport);
     return runtime.startPrepared(
         alloc,
         browser.prepared,
@@ -96,21 +121,24 @@ pub fn startSignIn(
     );
 }
 
-fn prepareBrowserSignIn(alloc: Allocator) !PreparedBrowserLogin {
-    const configured_issuer = try configuredEndpoint(alloc, e2e_issuer_url_env, issuer_url);
-    defer alloc.free(configured_issuer);
+fn prepareBrowserSignIn(alloc: Allocator, transport: oauth_transport.Provider) !PreparedBrowserLogin {
+    const configured_authorize = try configuredEndpoint(alloc, e2e_authorize_url_env, authorize_url);
+    defer alloc.free(configured_authorize);
     const configured_token_endpoint = try configuredEndpoint(alloc, e2e_token_url_env, token_url);
     errdefer alloc.free(configured_token_endpoint);
 
-    var listener = try bindBrowserCallback(io_mod.getenv(e2e_issuer_url_env) != null);
+    var listener = try bindBrowserCallback();
     var listener_owned = true;
     errdefer if (listener_owned) listener.deinit(io_mod.getIo());
-    const callback_port = listener.socket.address.getPort();
-    const redirect_uri = try std.fmt.allocPrint(
-        alloc,
-        "http://localhost:{d}/auth/callback",
-        .{callback_port},
-    );
+    const e2e = io_mod.getenv(e2e_authorize_url_env) != null;
+    const redirect_uri = if (e2e)
+        try std.fmt.allocPrint(
+            alloc,
+            "http://127.0.0.1:{d}/callback",
+            .{listener.socket.address.getPort()},
+        )
+    else
+        try alloc.dupe(u8, browser_redirect_uri);
     errdefer alloc.free(redirect_uri);
     const code_verifier = try randomUrlSafeSecret(alloc);
     errdefer secret.zeroAndFree(alloc, code_verifier);
@@ -120,7 +148,7 @@ fn prepareBrowserSignIn(alloc: Allocator) !PreparedBrowserLogin {
     defer alloc.free(code_challenge);
     const authorization_url = try buildBrowserAuthorizationUrl(
         alloc,
-        configured_issuer,
+        configured_authorize,
         redirect_uri,
         code_challenge,
         state,
@@ -134,29 +162,26 @@ fn prepareBrowserSignIn(alloc: Allocator) !PreparedBrowserLogin {
         .redirect_uri = redirect_uri,
         .code_verifier = code_verifier,
         .state = state,
+        .transport = transport,
     };
     listener_owned = false;
 
-    const owned_issuer = try alloc.dupe(u8, configured_issuer);
-    errdefer alloc.free(owned_issuer);
-    const authorization_endpoint = try std.fmt.allocPrint(
-        alloc,
-        "{s}/oauth/authorize",
-        .{std.mem.trimEnd(u8, configured_issuer, "/")},
-    );
-    errdefer alloc.free(authorization_endpoint);
+    const owned_authorize = try alloc.dupe(u8, configured_authorize);
+    errdefer alloc.free(owned_authorize);
     const device_code = try alloc.dupe(u8, "");
     errdefer secret.zeroAndFree(alloc, device_code);
     const user_code = try alloc.dupe(u8, "");
     errdefer alloc.free(user_code);
     const owned_client_id = try alloc.dupe(u8, client_id);
     errdefer alloc.free(owned_client_id);
+    const owned_issuer = try alloc.dupe(u8, issuer_url);
+    errdefer alloc.free(owned_issuer);
 
     return .{
         .prepared = .{
             .metadata = .{
                 .issuer = owned_issuer,
-                .device_authorization_endpoint = authorization_endpoint,
+                .device_authorization_endpoint = owned_authorize,
                 .token_endpoint = configured_token_endpoint,
             },
             .device = .{
@@ -178,19 +203,9 @@ fn deinitBrowserLoginContext(raw: ?*anyopaque, alloc: Allocator) void {
     alloc.destroy(context);
 }
 
-fn bindBrowserCallback(e2e: bool) !std.Io.net.Server {
-    if (e2e) {
-        var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
-        return address.listen(io_mod.getIo(), .{ .reuse_address = true });
-    }
-    for (browser_callback_ports) |port| {
-        var address = try std.Io.net.IpAddress.parse("127.0.0.1", port);
-        return address.listen(io_mod.getIo(), .{ .reuse_address = true }) catch |err| switch (err) {
-            error.AddressInUse => continue,
-            else => return err,
-        };
-    }
-    return error.ChatGptOAuthCallbackPortUnavailable;
+fn bindBrowserCallback() !std.Io.net.Server {
+    var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    return address.listen(io_mod.getIo(), .{ .reuse_address = true });
 }
 
 fn randomUrlSafeSecret(alloc: Allocator) ![]u8 {
@@ -221,9 +236,38 @@ fn pollBrowserToken(
     cancel_flag: *std.atomic.Value(bool),
     deadline: std.Io.Clock.Timestamp,
 ) !oauth.PollResult {
-    if (comptime host_target.is_wasm) return error.ChatGptOAuthUnavailable;
+    if (comptime host_target.is_wasm) return error.ClaudeOAuthUnavailable;
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     const context: *BrowserLoginContext = @ptrCast(@alignCast(raw.?));
+    if (context.takePastedCode()) |code| {
+        defer secret.zeroAndFree(alloc, code);
+        var token = try exchangeAuthorizationCodeForRedirectWithBounds(
+            alloc,
+            transport,
+            metadata.token_endpoint,
+            code,
+            context.code_verifier,
+            context.redirect_uri,
+            cancel_flag,
+            deadline,
+        );
+        errdefer token.deinit(alloc);
+        const scope = try alloc.dupe(u8, "");
+        errdefer if (scope.len > 0) alloc.free(scope);
+        const token_type = try alloc.dupe(u8, "Bearer");
+        errdefer alloc.free(token_type);
+        const access_token = token.access_token;
+        token.access_token = &.{};
+        const refresh_token = token.refresh_token;
+        token.refresh_token = &.{};
+        return .{ .success = .{
+            .access_token = access_token,
+            .refresh_token = refresh_token,
+            .expires_in = token.expires_in,
+            .scope = scope,
+            .token_type = token_type,
+        } };
+    }
     if (!try browserCallbackReady(&context.listener, cancel_flag)) return .pending;
 
     var stream = try context.listener.accept(io_mod.getIo());
@@ -284,7 +328,7 @@ fn browserCallbackReady(
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     if (ready == 0) return false;
     if ((fds[0].revents & std.posix.POLL.IN) == 0) {
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidClaudeOAuthCallback;
     }
     return true;
 }
@@ -296,21 +340,21 @@ fn readBrowserCallbackTarget(alloc: Allocator, stream: std.Io.net.Stream) ![]u8 
     var request_len: usize = 0;
     while (request_len < request_bytes.len) {
         request_bytes[request_len] = reader.interface.takeByte() catch |err| switch (err) {
-            error.EndOfStream => return error.InvalidChatGptOAuthCallback,
+            error.EndOfStream => return error.InvalidClaudeOAuthCallback,
             else => return err,
         };
         request_len += 1;
         if (std.mem.endsWith(u8, request_bytes[0..request_len], "\r\n\r\n")) break;
     }
-    if (request_len == request_bytes.len) return error.ChatGptOAuthCallbackTooLarge;
+    if (request_len == request_bytes.len) return error.ClaudeOAuthCallbackTooLarge;
     const line_end = std.mem.find(u8, request_bytes[0..request_len], "\r\n") orelse
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidClaudeOAuthCallback;
     const request_line = request_bytes[0..line_end];
     if (!std.mem.startsWith(u8, request_line, "GET ")) {
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidClaudeOAuthCallback;
     }
     const target_end = std.mem.findScalarPos(u8, request_line, 4, ' ') orelse
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidClaudeOAuthCallback;
     return alloc.dupe(u8, request_line[4..target_end]);
 }
 
@@ -332,28 +376,29 @@ fn setBrowserSocketTimeouts(socket: std.posix.socket_t) void {
     const timeout = std.posix.timeval{ .sec = browser_callback_io_timeout_seconds, .usec = 0 };
     const bytes = std.mem.asBytes(&timeout);
     std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, bytes) catch |err| {
-        debug_trace.logf("auth", "ChatGPT callback receive timeout setup failed err={s}", .{@errorName(err)});
+        debug_trace.logf("auth", "Claude callback receive timeout setup failed err={s}", .{@errorName(err)});
     };
     std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, bytes) catch |err| {
-        debug_trace.logf("auth", "ChatGPT callback send timeout setup failed err={s}", .{@errorName(err)});
+        debug_trace.logf("auth", "Claude callback send timeout setup failed err={s}", .{@errorName(err)});
     };
 }
 
 fn completeSignIn(
-    _: ?*anyopaque,
+    raw: ?*anyopaque,
     alloc: Allocator,
     _: []const u8,
     _: []const u8,
     token: *oauth.TokenSet,
 ) !login_flow.SignInCompletion {
-    const refresh_token = token.refresh_token orelse return error.ChatGptRefreshTokenMissing;
-    const account_id = try extractAccountId(alloc, token.access_token);
+    const context: *BrowserLoginContext = @ptrCast(@alignCast(raw.?));
+    const refresh_token = token.refresh_token orelse return error.ClaudeRefreshTokenMissing;
+    const account_id = try fetchAccountId(alloc, context.transport, token.access_token);
     errdefer alloc.free(account_id);
     const duration_ms = std.math.mul(i64, token.expires_in, std.time.ms_per_s) catch
-        return error.InvalidChatGptOAuthResponse;
+        return error.InvalidClaudeOAuthResponse;
     const expires_at_ms = std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
-        return error.InvalidChatGptOAuthResponse;
-    const completion: login_flow.SignInCompletion = .{ .chatgpt = .{
+        return error.InvalidClaudeOAuthResponse;
+    const completion: login_flow.SignInCompletion = .{ .claude = .{
         .access_token = token.access_token,
         .refresh_token = refresh_token,
         .expires_at_ms = expires_at_ms,
@@ -366,10 +411,10 @@ fn completeSignIn(
 
 fn saveSignIn(_: ?*anyopaque, alloc: Allocator, completion: login_flow.SignInCompletion) !void {
     const session = switch (completion) {
-        .chatgpt => |session| session,
-        .vercel, .grok, .claude => return error.InvalidSignInCompletion,
+        .claude => |session| session,
+        .vercel, .chatgpt, .grok => return error.InvalidSignInCompletion,
     };
-    try chatgpt_session.saveNewSession(alloc, session);
+    try claude_session.saveNewSession(alloc, session);
 }
 
 pub fn runLogin(
@@ -379,21 +424,41 @@ pub fn runLogin(
 ) !void {
     var runtime: login_flow.SignInRuntime = .{};
     defer runtime.deinit(alloc);
-    if (!try startSignIn(&runtime, alloc, transport)) return error.ChatGptLoginBusy;
+    if (!try startSignIn(&runtime, alloc, transport)) return error.ClaudeLoginBusy;
 
     const authorization_url = (try runtime.browserUrlAlloc(alloc)) orelse
-        return error.ChatGptAuthorizationUrlMissing;
+        return error.ClaudeAuthorizationUrlMissing;
     defer alloc.free(authorization_url);
-    try writeStdout("Open this URL to sign in with Codex:\n");
+    try writeStdout("Open this URL to sign in with Claude:\n");
     try writeStdout(authorization_url);
-    try writeStdout("\n\nWaiting for browser authorization...\n");
+    try writeStdout("\n\nAfter you authorize, paste the code from the browser and press Enter.\n");
     if (io_mod.getenv("FX_NO_OPEN_BROWSER") == null) {
         _ = url_opener.open(alloc, authorization_url) catch false;
     }
 
+    var paste_line: std.ArrayList(u8) = .empty;
+    defer {
+        if (paste_line.items.len > 0) std.crypto.secureZero(u8, @volatileCast(paste_line.items));
+        paste_line.deinit(alloc);
+    }
+    var stdin_buf: [1024]u8 = undefined;
     while (true) {
+        if (try stdinHasInput(50)) {
+            const n = std.posix.read(std.posix.STDIN_FILENO, &stdin_buf) catch 0;
+            if (n > 0) {
+                try paste_line.appendSlice(alloc, stdin_buf[0..n]);
+                if (std.mem.findScalar(u8, paste_line.items, '\n') != null) {
+                    const trimmed = std.mem.trim(u8, paste_line.items, " \t\r\n");
+                    if (trimmed.len > 0) {
+                        submitPastedAuthorizationInput(&runtime, alloc, trimmed) catch {};
+                    }
+                    std.crypto.secureZero(u8, @volatileCast(paste_line.items));
+                    paste_line.clearRetainingCapacity();
+                }
+            }
+        }
         switch (runtime.pollTransition(alloc)) {
-            .none => try io_mod.getIo().sleep(.fromMilliseconds(50), .awake),
+            .none => {},
             .succeeded => |completion| {
                 var owned = completion;
                 defer owned.deinit(alloc);
@@ -405,14 +470,50 @@ pub fn runLogin(
     }
 }
 
-pub fn logout() !chatgpt_session.DeleteOutcome {
-    var mutation = (try chatgpt_session.beginExistingMutation()) orelse return .missing;
+fn submitPastedAuthorizationInput(runtime: *login_flow.SignInRuntime, alloc: Allocator, input: []const u8) !void {
+    const context: *BrowserLoginContext = @ptrCast(@alignCast(runtime.deps.ctx orelse return error.InvalidClaudeOAuthCallback));
+    var parsed = try parsePastedAuthorizationInput(alloc, input, context.state);
+    defer parsed.deinit(alloc);
+    try context.setPastedCode(alloc, parsed.code);
+}
+
+fn stdinHasInput(timeout_ms: i32) !bool {
+    var fds = [_]std.posix.pollfd{.{
+        .fd = std.posix.STDIN_FILENO,
+        .events = std.posix.POLL.IN,
+        .revents = 0,
+    }};
+    const ready = try std.posix.poll(&fds, timeout_ms);
+    return ready > 0 and (fds[0].revents & std.posix.POLL.IN) != 0;
+}
+
+pub const LogoutResult = struct {
+    deletion: claude_session.DeleteOutcome,
+    revocation_failed: bool,
+};
+
+pub fn logout(alloc: Allocator, transport: oauth_transport.Provider) !LogoutResult {
+    var mutation = (try claude_session.beginExistingMutation()) orelse return .{
+        .deletion = .missing,
+        .revocation_failed = false,
+    };
     defer mutation.deinit();
-    return mutation.delete();
+    var revocation_failed = false;
+    if (try mutation.load(alloc)) |loaded| {
+        var session = loaded;
+        defer session.deinit(alloc);
+        revokeToken(alloc, transport, session.refresh_token) catch {
+            revocation_failed = true;
+        };
+    }
+    return .{
+        .deletion = try mutation.delete(),
+        .revocation_failed = revocation_failed,
+    };
 }
 
 pub fn sourceExists(alloc: Allocator) !bool {
-    var session = (try chatgpt_session.load(alloc)) orelse return false;
+    var session = (try claude_session.load(alloc)) orelse return false;
     defer session.deinit(alloc);
     return true;
 }
@@ -423,12 +524,12 @@ pub fn loadAccess(
     mode: RefreshMode,
 ) !?Access {
     if (mode == .stored) {
-        var session = (try chatgpt_session.load(alloc)) orelse return null;
+        var session = (try claude_session.load(alloc)) orelse return null;
         defer session.deinit(alloc);
         return takeAccess(&session);
     }
 
-    var mutation = (try chatgpt_session.beginExistingMutation()) orelse return null;
+    var mutation = (try claude_session.beginExistingMutation()) orelse return null;
     defer mutation.deinit();
     var session = (try mutation.load(alloc)) orelse return null;
     defer session.deinit(alloc);
@@ -439,7 +540,7 @@ pub fn loadAccess(
     return takeAccess(&session);
 }
 
-fn takeAccess(session: *chatgpt_session.Session) Access {
+fn takeAccess(session: *claude_session.Session) Access {
     const access_token = session.access_token;
     session.access_token = &.{};
     const account_id = session.account_id;
@@ -447,41 +548,40 @@ fn takeAccess(session: *chatgpt_session.Session) Access {
     return .{
         .access_token = access_token,
         .account_id = account_id,
-        .refresh_after_ms = chatgpt_session.refreshDeadlineMs(session.expires_at_ms),
+        .refresh_after_ms = claude_session.refreshDeadlineMs(session.expires_at_ms),
     };
 }
 
 fn refreshSession(
     alloc: Allocator,
     transport: oauth_transport.Provider,
-    mutation: *chatgpt_session.Mutation,
-    session: *chatgpt_session.Session,
+    mutation: *claude_session.Mutation,
+    session: *claude_session.Session,
 ) !void {
     var body: std.Io.Writer.Allocating = .init(alloc);
     defer body.deinit();
-    try body.writer.writeAll("{\"client_id\":");
-    try std.json.Stringify.value(client_id, .{}, &body.writer);
-    try body.writer.writeAll(",\"grant_type\":\"refresh_token\",\"refresh_token\":");
-    try std.json.Stringify.value(session.refresh_token, .{}, &body.writer);
-    try body.writer.writeByte('}');
+    var form: FormBody = .{};
+    try form.append(&body.writer, "grant_type", "refresh_token");
+    try form.append(&body.writer, "client_id", client_id);
+    try form.append(&body.writer, "refresh_token", session.refresh_token);
     var token = try requestRefreshToken(alloc, transport, body.written());
     defer token.deinit(alloc);
 
-    const account_id = try extractAccountId(alloc, token.access_token);
+    const account_id = try fetchAccountId(alloc, transport, token.access_token);
     errdefer alloc.free(account_id);
     if (!std.mem.eql(u8, account_id, session.account_id)) {
-        return error.ChatGptAccountChanged;
+        return error.ClaudeAccountChanged;
     }
     const refresh_token = if (token.refresh_token) |rotated| rotated else try alloc.dupe(u8, session.refresh_token);
     if (token.refresh_token != null) token.refresh_token = null;
     errdefer secret.zeroAndFree(alloc, refresh_token);
     const expires_at_ms = if (token.expires_in) |expires_in| blk: {
         const duration_ms = std.math.mul(i64, expires_in, std.time.ms_per_s) catch
-            return error.InvalidChatGptOAuthResponse;
+            return error.InvalidClaudeOAuthResponse;
         break :blk std.math.add(i64, io_mod.milliTimestamp(), duration_ms) catch
-            return error.InvalidChatGptOAuthResponse;
-    } else try accessTokenExpiresAtMs(alloc, token.access_token);
-    var replacement = chatgpt_session.Session{
+            return error.InvalidClaudeOAuthResponse;
+    } else return error.InvalidClaudeOAuthResponse;
+    var replacement = claude_session.Session{
         .access_token = token.access_token,
         .refresh_token = refresh_token,
         .expires_at_ms = expires_at_ms,
@@ -520,24 +620,24 @@ fn requestRefreshToken(
     const bytes = try requestAccepted(
         alloc,
         transport,
-        .post_json,
+        .post_form,
         endpoint_url,
         payload,
     );
     defer secret.zeroAndFree(alloc, bytes);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidChatGptOAuthResponse;
+    if (parsed.value != .object) return error.InvalidClaudeOAuthResponse;
     const object = parsed.value.object;
     const access_token = try dupeRequiredString(alloc, object, "access_token");
     errdefer secret.zeroAndFree(alloc, access_token);
     const refresh_token = if (object.get("refresh_token")) |value| blk: {
-        if (value != .string or value.string.len == 0) return error.InvalidChatGptOAuthResponse;
+        if (value != .string or value.string.len == 0) return error.InvalidClaudeOAuthResponse;
         break :blk try alloc.dupe(u8, value.string);
     } else null;
     errdefer if (refresh_token) |token| secret.zeroAndFree(alloc, token);
     const expires_in = if (object.get("expires_in")) |value| blk: {
-        if (value != .integer or value.integer <= 0) return error.InvalidChatGptOAuthResponse;
+        if (value != .integer or value.integer <= 0) return error.InvalidClaudeOAuthResponse;
         break :blk value.integer;
     } else null;
     return .{
@@ -545,28 +645,6 @@ fn requestRefreshToken(
         .refresh_token = refresh_token,
         .expires_in = expires_in,
     };
-}
-
-fn accessTokenExpiresAtMs(alloc: Allocator, token: []const u8) !i64 {
-    var parts = std.mem.splitScalar(u8, token, '.');
-    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
-    const payload = parts.next() orelse return error.InvalidChatGptAccessToken;
-    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
-    if (parts.next() != null) return error.InvalidChatGptAccessToken;
-    const decoded_len = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(payload) catch
-        return error.InvalidChatGptAccessToken;
-    const decoded = try alloc.alloc(u8, decoded_len);
-    defer alloc.free(decoded);
-    std.base64.url_safe_no_pad.Decoder.decode(decoded, payload) catch
-        return error.InvalidChatGptAccessToken;
-    var parsed = std.json.parseFromSlice(std.json.Value, alloc, decoded, .{}) catch
-        return error.InvalidChatGptAccessToken;
-    defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidChatGptAccessToken;
-    const exp = parsed.value.object.get("exp") orelse return error.InvalidChatGptOAuthResponse;
-    if (exp != .integer or exp.integer <= 0) return error.InvalidChatGptOAuthResponse;
-    return std.math.mul(i64, exp.integer, std.time.ms_per_s) catch
-        return error.InvalidChatGptOAuthResponse;
 }
 
 fn exchangeAuthorizationCodeForRedirectWithBounds(
@@ -610,7 +688,7 @@ fn requestTokenAtWithBounds(
     defer secret.zeroAndFree(alloc, bytes);
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidChatGptOAuthResponse;
+    if (parsed.value != .object) return error.InvalidClaudeOAuthResponse;
     const object = parsed.value.object;
     const access_token = try dupeRequiredString(alloc, object, "access_token");
     errdefer secret.zeroAndFree(alloc, access_token);
@@ -626,7 +704,7 @@ fn requestTokenAtWithBounds(
 fn configuredEndpoint(alloc: Allocator, env_name: []const u8, default_url: []const u8) ![]u8 {
     const candidate = io_mod.getenv(env_name) orelse default_url;
     if (io_mod.getenv(env_name) != null and !isLoopbackHttpUrl(candidate)) {
-        return error.InvalidE2EChatGptEndpoint;
+        return error.InvalidE2EClaudeEndpoint;
     }
     return alloc.dupe(u8, candidate);
 }
@@ -658,6 +736,83 @@ fn requestAccepted(
     return requestAcceptedWithBounds(alloc, transport, method, url, payload, null, null);
 }
 
+fn fetchAccountId(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    access_token: []const u8,
+) ![]u8 {
+    const endpoint_url = try configuredEndpoint(alloc, e2e_userinfo_url_env, userinfo_url);
+    defer alloc.free(endpoint_url);
+    const authorization = try std.fmt.allocPrint(alloc, "Bearer {s}", .{access_token});
+    defer secret.zeroAndFree(alloc, authorization);
+    const extra_headers = [_]std.http.Header{
+        .{ .name = "anthropic-version", .value = anthropic_api_version },
+        .{ .name = "anthropic-beta", .value = oauth_beta },
+    };
+    var response = try transport.execute(alloc, .{
+        .method = .get,
+        .url = endpoint_url,
+        .authorization = authorization,
+        .extra_headers = &extra_headers,
+    });
+    defer response.deinit(alloc);
+    if (response.disposition != .accepted) {
+        debug_trace.logf("auth", "Claude userinfo request rejected", .{});
+        return error.ClaudeUserInfoRequestFailed;
+    }
+    return accountIdFromProfileJson(alloc, response.body) catch |err| {
+        debug_trace.logf("auth", "Claude userinfo parse failed err={s}", .{@errorName(err)});
+        return err;
+    };
+}
+
+fn accountIdFromProfileJson(alloc: Allocator, bytes: []const u8) ![]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{}) catch
+        return error.InvalidClaudeUserInfoResponse;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidClaudeUserInfoResponse;
+    return accountIdFromProfileObject(alloc, parsed.value.object);
+}
+
+fn accountIdFromProfileObject(alloc: Allocator, object: std.json.ObjectMap) ![]u8 {
+    if (try nestedAccountId(alloc, object, "account")) |account_id| return account_id;
+    if (try optionalProfileId(alloc, object, "sub")) |account_id| return account_id;
+    if (try optionalProfileId(alloc, object, "uuid")) |account_id| return account_id;
+    if (try nestedAccountId(alloc, object, "organization")) |account_id| return account_id;
+    return error.InvalidClaudeUserInfoResponse;
+}
+
+fn nestedAccountId(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) !?[]u8 {
+    const value = object.get(key) orelse return null;
+    if (value != .object) return error.InvalidClaudeUserInfoResponse;
+    if (try optionalProfileId(alloc, value.object, "uuid")) |account_id| return account_id;
+    if (try optionalProfileId(alloc, value.object, "id")) |account_id| return account_id;
+    return error.InvalidClaudeUserInfoResponse;
+}
+
+fn optionalProfileId(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) !?[]u8 {
+    const value = object.get(key) orelse return null;
+    if (value != .string or value.string.len == 0) return error.InvalidClaudeUserInfoResponse;
+    if (!claude_session.validAccountId(value.string)) return error.InvalidClaudeUserInfoResponse;
+    return try alloc.dupe(u8, value.string);
+}
+
+fn revokeToken(
+    alloc: Allocator,
+    transport: oauth_transport.Provider,
+    token: []const u8,
+) !void {
+    const endpoint_url = try configuredEndpoint(alloc, e2e_token_url_env, token_url);
+    defer alloc.free(endpoint_url);
+    var body: std.Io.Writer.Allocating = .init(alloc);
+    defer body.deinit();
+    var form: FormBody = .{};
+    try form.append(&body.writer, "token", token);
+    try form.append(&body.writer, "client_id", client_id);
+    const bytes = try requestAccepted(alloc, transport, .post_form, endpoint_url, body.written());
+    secret.zeroAndFree(alloc, bytes);
+}
+
 fn requestAcceptedWithBounds(
     alloc: Allocator,
     transport: oauth_transport.Provider,
@@ -677,76 +832,22 @@ fn requestAcceptedWithBounds(
     });
     defer response.deinit(alloc);
     if (response.disposition != .accepted) {
-        debug_trace.logf("auth", "ChatGPT OAuth request rejected url={s}", .{url});
-        return error.ChatGptOAuthRequestFailed;
+        debug_trace.logf("auth", "Claude OAuth request rejected url={s}", .{url});
+        return error.ClaudeOAuthRequestFailed;
     }
     return response.takeBody();
 }
 
-fn sessionFromToken(alloc: Allocator, token: *TokenSet, now_ms: i64) !chatgpt_session.Session {
-    const account_id = try extractAccountId(alloc, token.access_token);
-    errdefer alloc.free(account_id);
-    const duration_ms = std.math.mul(i64, token.expires_in, std.time.ms_per_s) catch
-        return error.InvalidChatGptOAuthResponse;
-    const expires_at_ms = std.math.add(i64, now_ms, duration_ms) catch
-        return error.InvalidChatGptOAuthResponse;
-    const session = chatgpt_session.Session{
-        .access_token = token.access_token,
-        .refresh_token = token.refresh_token,
-        .expires_at_ms = expires_at_ms,
-        .account_id = account_id,
-    };
-    token.access_token = &.{};
-    token.refresh_token = &.{};
-    return session;
-}
-
-pub fn extractAccountId(alloc: Allocator, token: []const u8) ![]u8 {
-    var parts = std.mem.splitScalar(u8, token, '.');
-    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
-    const payload = parts.next() orelse return error.InvalidChatGptAccessToken;
-    _ = parts.next() orelse return error.InvalidChatGptAccessToken;
-    if (parts.next() != null) return error.InvalidChatGptAccessToken;
-
-    const decoded_len = std.base64.url_safe_no_pad.Decoder.calcSizeForSlice(payload) catch
-        return error.InvalidChatGptAccessToken;
-    const decoded = try alloc.alloc(u8, decoded_len);
-    defer alloc.free(decoded);
-    std.base64.url_safe_no_pad.Decoder.decode(decoded, payload) catch
-        return error.InvalidChatGptAccessToken;
-
-    var parsed = std.json.parseFromSlice(std.json.Value, alloc, decoded, .{}) catch
-        return error.InvalidChatGptAccessToken;
-    defer parsed.deinit();
-    if (parsed.value != .object) return error.InvalidChatGptAccessToken;
-    const claim = parsed.value.object.get(jwt_auth_claim) orelse return error.InvalidChatGptAccessToken;
-    if (claim != .object) return error.InvalidChatGptAccessToken;
-    return dupeRequiredString(alloc, claim.object, "chatgpt_account_id") catch
-        return error.InvalidChatGptAccessToken;
-}
-
 fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
-    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
-    if (value != .string or value.string.len == 0) return error.InvalidChatGptOAuthResponse;
+    const value = object.get(key) orelse return error.InvalidClaudeOAuthResponse;
+    if (value != .string or value.string.len == 0) return error.InvalidClaudeOAuthResponse;
     return alloc.dupe(u8, value.string);
 }
 
 fn requiredPositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
-    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
-    if (value != .integer or value.integer <= 0) return error.InvalidChatGptOAuthResponse;
+    const value = object.get(key) orelse return error.InvalidClaudeOAuthResponse;
+    if (value != .integer or value.integer <= 0) return error.InvalidClaudeOAuthResponse;
     return value.integer;
-}
-
-fn flexiblePositiveInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
-    const value = object.get(key) orelse return error.InvalidChatGptOAuthResponse;
-    const result = switch (value) {
-        .integer => value.integer,
-        .string => std.fmt.parseInt(i64, std.mem.trim(u8, value.string, " \t\r\n"), 10) catch
-            return error.InvalidChatGptOAuthResponse,
-        else => return error.InvalidChatGptOAuthResponse,
-    };
-    if (result < 0) return error.InvalidChatGptOAuthResponse;
-    return result;
 }
 
 const BrowserCallback = struct {
@@ -760,26 +861,52 @@ const BrowserCallback = struct {
 
 fn buildBrowserAuthorizationUrl(
     alloc: Allocator,
-    issuer: []const u8,
+    authorize: []const u8,
     redirect_uri: []const u8,
     code_challenge: []const u8,
     state: []const u8,
 ) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
-    try out.writer.print("{s}/oauth/authorize?", .{std.mem.trimEnd(u8, issuer, "/")});
+    try out.writer.print("{s}?", .{std.mem.trimEnd(u8, authorize, "/")});
     var form: FormBody = .{};
+    try form.append(&out.writer, "code", "true");
     try form.append(&out.writer, "response_type", "code");
     try form.append(&out.writer, "client_id", client_id);
     try form.append(&out.writer, "redirect_uri", redirect_uri);
     try form.append(&out.writer, "scope", browser_scope);
     try form.append(&out.writer, "code_challenge", code_challenge);
     try form.append(&out.writer, "code_challenge_method", "S256");
-    try form.append(&out.writer, "id_token_add_organizations", "true");
-    try form.append(&out.writer, "codex_cli_simplified_flow", "true");
     try form.append(&out.writer, "state", state);
-    try form.append(&out.writer, "originator", "fx");
     return out.toOwnedSlice();
+}
+
+fn parsePastedAuthorizationInput(alloc: Allocator, input: []const u8, expected_state: []const u8) !BrowserCallback {
+    const trimmed = std.mem.trim(u8, input, " \t\r\n");
+    if (trimmed.len == 0) return error.InvalidClaudeOAuthCallback;
+
+    if (std.mem.find(u8, trimmed, "code=") != null) {
+        const query_start = if (std.mem.findScalar(u8, trimmed, '?')) |index| index + 1 else 0;
+        const query = trimmed[query_start..];
+        const query_only = if (std.mem.findScalar(u8, query, '#')) |index| query[0..index] else query;
+        const code = try queryValueAlloc(alloc, query_only, "code");
+        errdefer secret.zeroAndFree(alloc, code);
+        if (queryValueAlloc(alloc, query_only, "state")) |state| {
+            defer secret.zeroAndFree(alloc, state);
+            if (!std.mem.eql(u8, state, expected_state)) return error.ClaudeOAuthStateMismatch;
+        } else |_| {}
+        return .{ .code = code };
+    }
+
+    if (std.mem.findScalar(u8, trimmed, '#')) |index| {
+        const code_part = trimmed[0..index];
+        const state_part = trimmed[index + 1 ..];
+        if (code_part.len == 0) return error.InvalidClaudeOAuthCallback;
+        if (!std.mem.eql(u8, state_part, expected_state)) return error.ClaudeOAuthStateMismatch;
+        return .{ .code = try alloc.dupe(u8, code_part) };
+    }
+
+    return .{ .code = try alloc.dupe(u8, trimmed) };
 }
 
 fn parseBrowserCallbackTarget(
@@ -787,16 +914,16 @@ fn parseBrowserCallbackTarget(
     target: []const u8,
     expected_state: []const u8,
 ) !BrowserCallback {
-    const prefix = "/auth/callback?";
+    const prefix = "/callback?";
     if (!std.mem.startsWith(u8, target, prefix) or std.mem.findScalar(u8, target, '#') != null) {
-        return error.InvalidChatGptOAuthCallback;
+        return error.InvalidClaudeOAuthCallback;
     }
     const query = target[prefix.len..];
     const code = try queryValueAlloc(alloc, query, "code");
     errdefer secret.zeroAndFree(alloc, code);
     const state = try queryValueAlloc(alloc, query, "state");
     defer secret.zeroAndFree(alloc, state);
-    if (!std.mem.eql(u8, state, expected_state)) return error.ChatGptOAuthStateMismatch;
+    if (!std.mem.eql(u8, state, expected_state)) return error.ClaudeOAuthStateMismatch;
     return .{ .code = code };
 }
 
@@ -807,7 +934,7 @@ fn queryValueAlloc(alloc: Allocator, query: []const u8, key: []const u8) ![]u8 {
         if (!std.mem.eql(u8, pair[0..equals], key)) continue;
         return percentDecodeAlloc(alloc, pair[equals + 1 ..]);
     }
-    return error.InvalidChatGptOAuthCallback;
+    return error.InvalidClaudeOAuthCallback;
 }
 
 fn percentDecodeAlloc(alloc: Allocator, value: []const u8) ![]u8 {
@@ -817,11 +944,11 @@ fn percentDecodeAlloc(alloc: Allocator, value: []const u8) ![]u8 {
     var write_index: usize = 0;
     while (read_index < value.len) {
         if (value[read_index] == '%') {
-            if (read_index + 2 >= value.len) return error.InvalidChatGptOAuthCallback;
+            if (read_index + 2 >= value.len) return error.InvalidClaudeOAuthCallback;
             const high = std.fmt.charToDigit(value[read_index + 1], 16) catch
-                return error.InvalidChatGptOAuthCallback;
+                return error.InvalidClaudeOAuthCallback;
             const low = std.fmt.charToDigit(value[read_index + 2], 16) catch
-                return error.InvalidChatGptOAuthCallback;
+                return error.InvalidClaudeOAuthCallback;
             out[write_index] = @as(u8, @intCast(high * 16 + low));
             read_index += 3;
         } else {
@@ -830,7 +957,7 @@ fn percentDecodeAlloc(alloc: Allocator, value: []const u8) ![]u8 {
         }
         write_index += 1;
     }
-    if (write_index == 0) return error.InvalidChatGptOAuthCallback;
+    if (write_index == 0) return error.InvalidClaudeOAuthCallback;
     return alloc.realloc(out, write_index);
 }
 
@@ -864,104 +991,92 @@ fn writeStdout(text: []const u8) !void {
     try std.Io.File.stdout().writeStreamingAll(io_mod.getIo(), text);
 }
 
-test "ChatGPT E2E OAuth endpoint overrides accept only loopback HTTP" {
+test "Claude E2E OAuth endpoint overrides accept only loopback HTTP" {
     try std.testing.expect(isLoopbackHttpUrl("http://127.0.0.1:1234/token"));
     try std.testing.expect(isLoopbackHttpUrl("http://localhost:1234/token"));
     try std.testing.expect(!isLoopbackHttpUrl("https://127.0.0.1:1234/token"));
     try std.testing.expect(!isLoopbackHttpUrl("http://example.com:1234/token"));
 }
 
-test "ChatGPT account id is extracted from the namespaced JWT claim" {
-    const alloc = std.testing.allocator;
-    const payload =
-        \\{"https://api.openai.com/auth":{"chatgpt_account_id":"acct_test"}}
-    ;
-    const encoded_len = std.base64.url_safe_no_pad.Encoder.calcSize(payload.len);
-    const encoded = try alloc.alloc(u8, encoded_len);
-    defer alloc.free(encoded);
-    _ = std.base64.url_safe_no_pad.Encoder.encode(encoded, payload);
-    const token = try std.fmt.allocPrint(alloc, "header.{s}.signature", .{encoded});
-    defer alloc.free(token);
-
-    const account_id = try extractAccountId(alloc, token);
-    defer alloc.free(account_id);
-    try std.testing.expectEqualStrings("acct_test", account_id);
-}
-
-test "Codex refresh uses JSON and accepts omitted token rotation and lifetime" {
-    const State = struct {
-        method: ?oauth_transport.Method = null,
-        payload: [512]u8 = undefined,
-        payload_len: usize = 0,
-
-        fn execute(
-            raw: ?*anyopaque,
-            alloc: Allocator,
-            request: oauth_transport.Request,
-        ) !oauth_transport.Response {
-            const self: *@This() = @ptrCast(@alignCast(raw.?));
-            const payload = request.payload orelse &.{};
-            self.method = request.method;
-            self.payload_len = @min(payload.len, self.payload.len);
-            @memcpy(self.payload[0..self.payload_len], payload[0..self.payload_len]);
-            return .{
-                .disposition = .accepted,
-                .body = try alloc.dupe(u8, "{\"access_token\":\"header.payload.signature\"}"),
-            };
-        }
-    };
-    var state = State{};
-    var response = try requestRefreshToken(
-        std.testing.allocator,
-        .{ .context = &state, .execute_fn = State.execute },
-        "{\"client_id\":\"client\",\"grant_type\":\"refresh_token\",\"refresh_token\":\"refresh\"}",
-    );
-    defer response.deinit(std.testing.allocator);
-
-    try std.testing.expectEqual(oauth_transport.Method.post_json, state.method.?);
-    try std.testing.expect(std.mem.find(u8, state.payload[0..state.payload_len], "\"grant_type\":\"refresh_token\"") != null);
-    try std.testing.expect(response.refresh_token == null);
-    try std.testing.expect(response.expires_in == null);
-}
-
-test "ChatGPT browser authorization URL uses PKCE without device authentication" {
+test "Claude browser authorization URL uses PKCE against the Claude authorize endpoint" {
     const url = try buildBrowserAuthorizationUrl(
         std.testing.allocator,
-        "https://auth.openai.com",
-        "http://localhost:1455/auth/callback",
+        "https://claude.ai/oauth/authorize",
+        browser_redirect_uri,
         "challenge-value",
         "state-value",
     );
     defer std.testing.allocator.free(url);
 
-    try std.testing.expect(std.mem.startsWith(u8, url, "https://auth.openai.com/oauth/authorize?"));
+    try std.testing.expect(std.mem.startsWith(u8, url, "https://claude.ai/oauth/authorize?"));
+    try std.testing.expect(std.mem.find(u8, url, "code=true") != null);
     try std.testing.expect(std.mem.find(u8, url, "response_type=code") != null);
     try std.testing.expect(std.mem.find(u8, url, "code_challenge=challenge-value") != null);
     try std.testing.expect(std.mem.find(u8, url, "code_challenge_method=S256") != null);
     try std.testing.expect(std.mem.find(u8, url, "state=state-value") != null);
-    try std.testing.expect(std.mem.find(u8, url, "originator=fx") != null);
-    try std.testing.expect(std.mem.find(u8, url, "device") == null);
+    try std.testing.expect(std.mem.find(u8, url, "redirect_uri=https%3A%2F%2Fconsole.anthropic.com%2Foauth%2Fcode%2Fcallback") != null);
+    try std.testing.expect(std.mem.find(u8, url, "127.0.0.1") == null);
+    // Claude Code scopes are user-scoped; the issuer rejects OpenID scopes.
+    try std.testing.expect(std.mem.find(u8, url, "scope=user%3Aprofile") != null);
+    try std.testing.expect(std.mem.find(u8, url, "user%3Ainference") != null);
+    try std.testing.expect(std.mem.find(u8, url, "openid") == null);
+    try std.testing.expect(std.mem.find(u8, url, "email") == null);
 }
 
-test "ChatGPT browser callback requires the exact path and state" {
+test "Claude pasted authorization input accepts code#state and callback URLs" {
+    var from_pair = try parsePastedAuthorizationInput(
+        std.testing.allocator,
+        "  auth-code#state-value\n",
+        "state-value",
+    );
+    defer from_pair.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("auth-code", from_pair.code);
+
+    var from_url = try parsePastedAuthorizationInput(
+        std.testing.allocator,
+        "https://console.anthropic.com/oauth/code/callback?code=auth%20code&state=state-value",
+        "state-value",
+    );
+    defer from_url.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("auth code", from_url.code);
+
+    var from_raw = try parsePastedAuthorizationInput(
+        std.testing.allocator,
+        "raw-code",
+        "state-value",
+    );
+    defer from_raw.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("raw-code", from_raw.code);
+
+    try std.testing.expectError(
+        error.ClaudeOAuthStateMismatch,
+        parsePastedAuthorizationInput(
+            std.testing.allocator,
+            "auth-code#other",
+            "state-value",
+        ),
+    );
+}
+
+test "Claude browser callback requires the exact path and state" {
     var callback = try parseBrowserCallbackTarget(
         std.testing.allocator,
-        "/auth/callback?code=auth%20code&state=expected",
+        "/callback?code=auth%20code&state=expected",
         "expected",
     );
     defer callback.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("auth code", callback.code);
 
     try std.testing.expectError(
-        error.ChatGptOAuthStateMismatch,
+        error.ClaudeOAuthStateMismatch,
         parseBrowserCallbackTarget(
             std.testing.allocator,
-            "/auth/callback?code=auth&state=other",
+            "/callback?code=auth&state=other",
             "expected",
         ),
     );
     try std.testing.expectError(
-        error.InvalidChatGptOAuthCallback,
+        error.InvalidClaudeOAuthCallback,
         parseBrowserCallbackTarget(
             std.testing.allocator,
             "/other?code=auth&state=expected",

--- a/src/core/auth/claude_session.zig
+++ b/src/core/auth/claude_session.zig
@@ -1,0 +1,291 @@
+const std = @import("std");
+const debug_trace = @import("../shared/debug_trace.zig");
+const host_target = @import("../hosts/target.zig");
+const io_mod = @import("../shared/io.zig");
+const profile_paths = @import("../shared/profile_paths.zig");
+const secret = @import("secret.zig");
+
+const Allocator = std.mem.Allocator;
+const schema_version: i64 = 1;
+const max_auth_file_bytes: usize = 64 * 1024;
+const expiry_skew_ms: i64 = 60 * 1000;
+const mutation_lock_file_name = "claude-auth.lock";
+const mutation_lock_deadline_ms: u64 = 2000;
+const max_account_id_bytes: usize = 1024;
+
+const auth_file_name = profile_paths.claude_auth_file_name;
+
+pub fn refreshDeadlineMs(expires_at_ms: i64) i64 {
+    return @max(expires_at_ms - expiry_skew_ms, 0);
+}
+
+pub fn validAccountId(account_id: []const u8) bool {
+    if (account_id.len == 0 or account_id.len > max_account_id_bytes) return false;
+    for (account_id) |byte| {
+        if (byte < 0x21 or byte > 0x7e) return false;
+    }
+    return true;
+}
+
+pub const Session = struct {
+    access_token: []u8,
+    refresh_token: []u8,
+    expires_at_ms: i64,
+    account_id: []u8,
+
+    pub fn deinit(self: *Session, alloc: Allocator) void {
+        secret.zeroAndFree(alloc, self.access_token);
+        secret.zeroAndFree(alloc, self.refresh_token);
+        alloc.free(self.account_id);
+        self.* = undefined;
+    }
+
+    pub fn expired(self: Session, now_ms: i64) bool {
+        return refreshDeadlineMs(self.expires_at_ms) <= now_ms;
+    }
+};
+
+pub const DeleteOutcome = enum {
+    deleted,
+    missing,
+    deleted_not_durable,
+};
+
+pub const Mutation = struct {
+    fx_dir: io_mod.VerifiedDir,
+    lock: io_mod.TimedAdvisoryLock,
+
+    pub fn deinit(self: *Mutation) void {
+        self.lock.release();
+        self.fx_dir.close();
+        self.* = undefined;
+    }
+
+    pub fn load(self: *Mutation, alloc: Allocator) !?Session {
+        return loadFromDir(alloc, &self.fx_dir.dir, true);
+    }
+
+    pub fn save(self: *Mutation, alloc: Allocator, session: Session) !void {
+        const text = try stringify(alloc, session);
+        defer secret.zeroAndFree(alloc, text);
+        try io_mod.durableReplaceVerified(alloc, &self.fx_dir, auth_file_name, text);
+    }
+
+    pub fn delete(self: *Mutation) !DeleteOutcome {
+        self.fx_dir.dir.deleteFile(io_mod.getIo(), auth_file_name) catch |err| switch (err) {
+            error.FileNotFound => return .missing,
+            else => return err,
+        };
+        const durable: io_mod.DurableOps = .{};
+        durable.sync_dir(durable.ctx, self.fx_dir.dir) catch return .deleted_not_durable;
+        return .deleted;
+    }
+};
+
+pub fn load(alloc: Allocator) !?Session {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return null;
+    var home_dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch |err| {
+        debug_trace.logf("auth", "Claude session load failed step=open_home err={s}", .{@errorName(err)});
+        return null;
+    };
+    defer home_dir.close(io_mod.getIo());
+
+    var fx_dir = home_dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    }) catch |err| {
+        if (err != error.FileNotFound) {
+            debug_trace.logf("auth", "Claude session load failed step=open_profile err={s}", .{@errorName(err)});
+        }
+        return null;
+    };
+    defer fx_dir.close(io_mod.getIo());
+    return loadFromDir(alloc, &fx_dir, false);
+}
+
+fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, report_open_failure: bool) !?Session {
+    var file = fx_dir.openFile(io_mod.getIo(), auth_file_name, .{
+        .mode = .read_only,
+        .allow_directory = false,
+        .follow_symlinks = false,
+        .resolve_beneath = true,
+    }) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => {
+            debug_trace.logf("auth", "Claude session load failed step=open_file err={s}", .{@errorName(err)});
+            if (report_open_failure) return err;
+            return null;
+        },
+    };
+    defer file.close(io_mod.getIo());
+
+    const stat = try file.stat(io_mod.getIo());
+    if (stat.kind != .file or stat.permissions.toMode() & 0o077 != 0) {
+        debug_trace.logf("auth", "Claude session load failed step=permissions err=InsecureAuthFile", .{});
+        return null;
+    }
+
+    const bytes = try io_mod.readFileToEnd(alloc, &file, max_auth_file_bytes);
+    defer secret.zeroAndFree(alloc, bytes);
+    return parse(alloc, bytes) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => {
+            debug_trace.logf("auth", "Claude session load failed step=parse err={s}", .{@errorName(err)});
+            return null;
+        },
+    };
+}
+
+pub fn saveNewSession(alloc: Allocator, session: Session) !void {
+    if (comptime host_target.is_wasm) return error.ClaudeOAuthUnavailable;
+    var mutation = try beginMutation();
+    defer mutation.deinit();
+    try mutation.save(alloc, session);
+}
+
+pub fn beginExistingMutation() !?Mutation {
+    if (comptime host_target.is_wasm) return null;
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+
+    const fx_dir = openExistingPrivateFxDir(&home_dir) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    return try lockMutation(fx_dir);
+}
+
+fn beginMutation() !Mutation {
+    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    var home_dir = io_mod.VerifiedDir{
+        .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
+    };
+    defer home_dir.close();
+
+    const fx_dir = try io_mod.openOrCreateVerifiedPrivateDir(&home_dir, profile_paths.root_dir_name);
+    return lockMutation(fx_dir);
+}
+
+fn lockMutation(open_fx_dir: io_mod.VerifiedDir) !Mutation {
+    var fx_dir = open_fx_dir;
+    errdefer fx_dir.close();
+    var lock = try io_mod.acquireTimedAdvisoryLock(
+        &fx_dir,
+        mutation_lock_file_name,
+        mutation_lock_deadline_ms,
+    );
+    errdefer lock.release();
+    return .{ .fx_dir = fx_dir, .lock = lock };
+}
+
+fn openExistingPrivateFxDir(home_dir: *io_mod.VerifiedDir) !io_mod.VerifiedDir {
+    var dir = try home_dir.dir.openDir(io_mod.getIo(), profile_paths.root_dir_name, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    errdefer dir.close(io_mod.getIo());
+
+    const initial_stat = try dir.stat(io_mod.getIo());
+    if (initial_stat.kind != .directory) return error.DurablePathUnsafe;
+    if (initial_stat.permissions.toMode() & 0o200 == 0) return error.PrivateStatePermissionsUnsupported;
+    dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {
+        return error.PrivateStatePermissionsUnsupported;
+    };
+    const stat = try dir.stat(io_mod.getIo());
+    if (stat.kind != .directory or stat.permissions.toMode() & 0o777 != 0o700) {
+        return error.PrivateStatePermissionsUnsupported;
+    }
+    return .{ .dir = dir };
+}
+
+pub fn parse(alloc: Allocator, bytes: []const u8) !Session {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidClaudeAuthSession;
+    const object = parsed.value.object;
+    const version = object.get("version") orelse return error.InvalidClaudeAuthSession;
+    if (version != .integer or version.integer != schema_version) return error.InvalidClaudeAuthSession;
+
+    const access_token = try dupeRequiredString(alloc, object, "access_token");
+    errdefer secret.zeroAndFree(alloc, access_token);
+    const refresh_token = try dupeRequiredString(alloc, object, "refresh_token");
+    errdefer secret.zeroAndFree(alloc, refresh_token);
+    const account_id = try dupeRequiredString(alloc, object, "account_id");
+    errdefer alloc.free(account_id);
+    if (!validAccountId(account_id)) return error.InvalidClaudeAuthSession;
+    const expires_at_ms = try requiredInteger(object, "expires_at_ms");
+    return .{
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+        .expires_at_ms = expires_at_ms,
+        .account_id = account_id,
+    };
+}
+
+pub fn stringify(alloc: Allocator, session: Session) ![]u8 {
+    if (!validAccountId(session.account_id)) return error.InvalidClaudeAuthSession;
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"version\":1,\"access_token\":");
+    try std.json.Stringify.value(session.access_token, .{}, &out.writer);
+    try out.writer.writeAll(",\"refresh_token\":");
+    try std.json.Stringify.value(session.refresh_token, .{}, &out.writer);
+    try out.writer.print(",\"expires_at_ms\":{d},\"account_id\":", .{session.expires_at_ms});
+    try std.json.Stringify.value(session.account_id, .{}, &out.writer);
+    try out.writer.writeAll("}\n");
+    return out.toOwnedSlice();
+}
+
+fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
+    const value = object.get(key) orelse return error.InvalidClaudeAuthSession;
+    if (value != .string or value.string.len == 0) return error.InvalidClaudeAuthSession;
+    return alloc.dupe(u8, value.string);
+}
+
+fn requiredInteger(object: std.json.ObjectMap, key: []const u8) !i64 {
+    const value = object.get(key) orelse return error.InvalidClaudeAuthSession;
+    if (value != .integer) return error.InvalidClaudeAuthSession;
+    return value.integer;
+}
+
+test "Claude auth session round trips without exposing token fields to structure" {
+    const alloc = std.testing.allocator;
+    var session = Session{
+        .access_token = try alloc.dupe(u8, "header.payload.signature"),
+        .refresh_token = try alloc.dupe(u8, "refresh"),
+        .expires_at_ms = 1234,
+        .account_id = try alloc.dupe(u8, "acct_123"),
+    };
+    defer session.deinit(alloc);
+
+    const encoded = try stringify(alloc, session);
+    defer secret.zeroAndFree(alloc, encoded);
+    var decoded = try parse(alloc, encoded);
+    defer decoded.deinit(alloc);
+
+    try std.testing.expectEqualStrings(session.access_token, decoded.access_token);
+    try std.testing.expectEqualStrings(session.refresh_token, decoded.refresh_token);
+    try std.testing.expectEqualStrings(session.account_id, decoded.account_id);
+    try std.testing.expectEqual(session.expires_at_ms, decoded.expires_at_ms);
+}
+
+test "Claude account identity is bounded and safe for HTTP headers" {
+    try std.testing.expect(validAccountId("acct_123"));
+    try std.testing.expect(!validAccountId(""));
+    try std.testing.expect(!validAccountId("acct\r\ninjected"));
+    try std.testing.expect(!validAccountId("a" ** (max_account_id_bytes + 1)));
+
+    const invalid =
+        \\{"version":1,"access_token":"access","refresh_token":"refresh","expires_at_ms":1234,"account_id":"acct\ninjected"}
+    ;
+    try std.testing.expectError(error.InvalidClaudeAuthSession, parse(std.testing.allocator, invalid));
+}
+
+test "Claude session refresh deadline keeps a one minute safety margin" {
+    try std.testing.expectEqual(@as(i64, 40_000), refreshDeadlineMs(100_000));
+    try std.testing.expectEqual(@as(i64, 0), refreshDeadlineMs(10_000));
+}

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const chatgpt_oauth = @import("chatgpt_oauth.zig");
+const claude_oauth = @import("claude_oauth.zig");
 const grok_oauth = @import("grok_oauth.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
@@ -22,6 +23,7 @@ pub const CatalogPublicOnly = union(enum) {
     authenticated_credential_rejected: Source,
     chatgpt_subscription,
     grok_subscription,
+    claude_subscription,
 
     fn credentialSource(self: CatalogPublicOnly) ?Source {
         return switch (self) {
@@ -31,6 +33,7 @@ pub const CatalogPublicOnly = union(enum) {
             .authenticated_credential_rejected => |source| source,
             .chatgpt_subscription => .chatgpt_subscription,
             .grok_subscription => .grok_subscription,
+            .claude_subscription => .claude_subscription,
         };
     }
 };
@@ -44,6 +47,7 @@ pub const CatalogAuthenticatedSource = enum {
     stored_key,
     chatgpt_subscription,
     grok_subscription,
+    claude_subscription,
 
     fn credentialSource(self: CatalogAuthenticatedSource) Source {
         return switch (self) {
@@ -53,6 +57,7 @@ pub const CatalogAuthenticatedSource = enum {
             .stored_key => .stored_key,
             .chatgpt_subscription => .chatgpt_subscription,
             .grok_subscription => .grok_subscription,
+            .claude_subscription => .claude_subscription,
         };
     }
 };
@@ -91,7 +96,7 @@ pub const CatalogAccess = union(enum) {
     pub fn publicFallbackAfterRejection(self: CatalogAccess) ?CatalogAccess {
         return switch (self) {
             .public_only => null,
-            .authenticated => |access| if (access.source == .chatgpt_subscription or access.source == .grok_subscription)
+            .authenticated => |access| if (access.source == .chatgpt_subscription or access.source == .grok_subscription or access.source == .claude_subscription)
                 null
             else
                 .{
@@ -168,6 +173,7 @@ pub fn catalogAccessForCredentialAndAccount(
         .stored_key => .stored_key,
         .chatgpt_subscription => .chatgpt_subscription,
         .grok_subscription => .grok_subscription,
+        .claude_subscription => .claude_subscription,
         .fx_login => blk: {
             const team = team_context orelse
                 return .{ .public_only = .fx_login_team_required };
@@ -180,8 +186,8 @@ pub fn catalogAccessForCredentialAndAccount(
         .authenticated = .{
             .source = authenticated_source,
             .credential = credential,
-            .team_context = if (authenticated_source == .chatgpt_subscription or authenticated_source == .grok_subscription) null else team_context,
-            .account_id = if (authenticated_source == .grok_subscription) account_id else null,
+            .team_context = if (authenticated_source == .chatgpt_subscription or authenticated_source == .grok_subscription or authenticated_source == .claude_subscription) null else team_context,
+            .account_id = if (authenticated_source == .grok_subscription or authenticated_source == .claude_subscription) account_id else null,
         },
     };
 }
@@ -202,6 +208,8 @@ pub const missing_chatgpt_credential_message = "fx needs a Codex subscription lo
 pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login and choose Sign in with Codex.";
 pub const missing_grok_credential_message = "fx needs a Grok subscription login for this model. Run fx login grok.";
 pub const missing_grok_interactive_credential_message = "Grok needs a subscription login. Run /login and choose Sign in with Grok.";
+pub const missing_claude_credential_message = "fx needs a Claude subscription login for this model. Run fx login claude.";
+pub const missing_claude_interactive_credential_message = "Claude needs a subscription login. Run /login and choose Sign in with Claude.";
 pub const unreadable_store_message = "Fx could not read the stored API key from " ++ stored_key_backend_label ++ ". A key may be saved but unreadable. Set FX_TRACE_LOG for the failing step, or set AI_GATEWAY_API_KEY.";
 
 pub const Credential = struct {
@@ -291,6 +299,13 @@ pub fn resolveForProvider(
             };
             return .{ .credential = credential };
         },
+        .claude => {
+            const credential = switch (mode) {
+                .stored => try loadStoredClaudeCredential(alloc),
+                .refresh_if_needed => try loadClaudeCredential(alloc, transport, .if_needed),
+            };
+            return .{ .credential = credential };
+        },
         .gateway => {},
     }
     return resolvePreferring(
@@ -298,7 +313,7 @@ pub fn resolveForProvider(
         transport,
         secret_store,
         mode,
-        if (preferred == .chatgpt_subscription or preferred == .grok_subscription) null else preferred,
+        if (preferred == .chatgpt_subscription or preferred == .grok_subscription or preferred == .claude_subscription) null else preferred,
     );
 }
 
@@ -388,6 +403,10 @@ fn loadPreferredSource(
             .stored => loadStoredGrokCredential(alloc),
             .refresh_if_needed => loadGrokCredential(alloc, transport, .if_needed),
         },
+        .claude_subscription => switch (mode) {
+            .stored => loadStoredClaudeCredential(alloc),
+            .refresh_if_needed => loadClaudeCredential(alloc, transport, .if_needed),
+        },
         else => loadSource(alloc, transport, secret_store, source),
     };
 }
@@ -405,6 +424,7 @@ pub fn loadSource(
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
         .chatgpt_subscription => loadChatGptCredential(alloc, transport, .if_needed),
         .grok_subscription => loadGrokCredential(alloc, transport, .if_needed),
+        .claude_subscription => loadClaudeCredential(alloc, transport, .if_needed),
     };
 }
 
@@ -430,6 +450,7 @@ pub fn sourceExists(
         },
         .chatgpt_subscription => chatgpt_oauth.sourceExists(alloc),
         .grok_subscription => grok_oauth.sourceExists(alloc),
+        .claude_subscription => claude_oauth.sourceExists(alloc),
         .stored_key => blk: {
             if (secret_store.isDisabled()) break :blk false;
             const stored = secret_store.load(alloc) catch |err| switch (err) {
@@ -513,6 +534,29 @@ fn loadStoredGrokCredential(alloc: std.mem.Allocator) !?Credential {
     return loadGrokCredential(alloc, oauth_transport.unavailable_provider, .stored);
 }
 
+fn loadClaudeCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+    mode: claude_oauth.RefreshMode,
+) !?Credential {
+    var access = (try claude_oauth.loadAccess(alloc, transport, mode)) orelse return null;
+    defer access.deinit(alloc);
+    const token = access.access_token;
+    access.access_token = &.{};
+    const account_id = access.account_id;
+    access.account_id = &.{};
+    return .{
+        .token = token,
+        .source = .claude_subscription,
+        .account_id = account_id,
+        .refresh_after_ms = access.refresh_after_ms,
+    };
+}
+
+fn loadStoredClaudeCredential(alloc: std.mem.Allocator) !?Credential {
+    return loadClaudeCredential(alloc, oauth_transport.unavailable_provider, .stored);
+}
+
 fn nonEmptyEnvValue(name: []const u8) ?[]const u8 {
     return nonEmptyValue(io_mod.getenv(name));
 }
@@ -562,6 +606,13 @@ pub fn refreshGrokCredential(
     transport: oauth_transport.Provider,
 ) !?Credential {
     return loadGrokCredential(alloc, transport, .force);
+}
+
+pub fn refreshClaudeCredential(
+    alloc: std.mem.Allocator,
+    transport: oauth_transport.Provider,
+) !?Credential {
+    return loadClaudeCredential(alloc, transport, .force);
 }
 
 fn refreshFxLoginCredentialLocked(
@@ -656,11 +707,12 @@ pub fn sourceLabel(source: Source) []const u8 {
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
         .chatgpt_subscription => "Codex subscription",
         .grok_subscription => "Grok subscription",
+        .claude_subscription => "Claude subscription",
     };
 }
 
 pub fn sourceRefreshable(source: Source) bool {
-    return source == .fx_login or source == .chatgpt_subscription or source == .grok_subscription;
+    return source == .fx_login or source == .chatgpt_subscription or source == .grok_subscription or source == .claude_subscription;
 }
 
 test "stored key label discloses the backend that answered" {

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -208,8 +208,8 @@ pub const missing_chatgpt_credential_message = "fx needs a Codex subscription lo
 pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login and choose Sign in with Codex.";
 pub const missing_grok_credential_message = "fx needs a Grok subscription login for this model. Run fx login grok.";
 pub const missing_grok_interactive_credential_message = "Grok needs a subscription login. Run /login and choose Sign in with Grok.";
-pub const missing_claude_credential_message = "fx needs a Claude subscription login for this model. Run fx login claude.";
-pub const missing_claude_interactive_credential_message = "Claude needs a subscription login. Run /login and choose Sign in with Claude.";
+pub const missing_claude_credential_message = "fx needs a Claude Code login for this model. Run claude auth login, then fx provider claude.";
+pub const missing_claude_interactive_credential_message = "Claude needs a Claude Code login. Run claude auth login, then choose the Claude provider.";
 pub const unreadable_store_message = "Fx could not read the stored API key from " ++ stored_key_backend_label ++ ". A key may be saved but unreadable. Set FX_TRACE_LOG for the failing step, or set AI_GATEWAY_API_KEY.";
 
 pub const Credential = struct {

--- a/src/core/auth/grok_oauth.zig
+++ b/src/core/auth/grok_oauth.zig
@@ -362,7 +362,7 @@ fn completeSignIn(
 fn saveSignIn(_: ?*anyopaque, alloc: Allocator, completion: login_flow.SignInCompletion) !void {
     const session = switch (completion) {
         .grok => |session| session,
-        .vercel, .chatgpt => return error.InvalidSignInCompletion,
+        .vercel, .chatgpt, .claude => return error.InvalidSignInCompletion,
     };
     try grok_session.saveNewSession(alloc, session);
 }

--- a/src/core/auth/js_host_auth.zig
+++ b/src/core/auth/js_host_auth.zig
@@ -58,7 +58,7 @@ fn executeOAuthRequest(
 ) !oauth_transport.Response {
     try checkRequestBounds(request);
     const Header = struct { name: []const u8, value: []const u8 };
-    var header_buf: [2]Header = undefined;
+    var header_buf: [8]Header = undefined;
     var header_count: usize = 0;
     switch (request.method) {
         .get => {},
@@ -73,6 +73,11 @@ fn executeOAuthRequest(
     }
     if (request.authorization) |value| {
         header_buf[header_count] = .{ .name = "authorization", .value = value };
+        header_count += 1;
+    }
+    if (header_count + request.extra_headers.len > header_buf.len) return error.OAuthRequestHeadersTooLarge;
+    for (request.extra_headers) |header| {
+        header_buf[header_count] = .{ .name = header.name, .value = header.value };
         header_count += 1;
     }
     var response = try executeRequest(

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const credentials = @import("credentials.zig");
 const chatgpt_session = @import("chatgpt_session.zig");
+const claude_session = @import("claude_session.zig");
 const grok_session = @import("grok_session.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
@@ -138,12 +139,14 @@ pub const SignInCompletion = union(enum) {
     vercel: TeamSelection,
     chatgpt: chatgpt_session.Session,
     grok: grok_session.Session,
+    claude: claude_session.Session,
 
     pub fn deinit(self: *SignInCompletion, alloc: Allocator) void {
         switch (self.*) {
             .vercel => |*selection| selection.deinit(alloc),
             .chatgpt => |*session| session.deinit(alloc),
             .grok => |*session| session.deinit(alloc),
+            .claude => |*session| session.deinit(alloc),
         }
         self.* = .{ .vercel = .{} };
     }
@@ -530,7 +533,7 @@ fn completeSignIn(
 fn saveSignIn(_: ?*anyopaque, alloc: Allocator, completion: SignInCompletion) !void {
     const session = switch (completion) {
         .vercel => |selection| selection.session orelse return LoginError.NoSession,
-        .chatgpt, .grok => return error.InvalidSignInCompletion,
+        .chatgpt, .grok, .claude => return error.InvalidSignInCompletion,
     };
     try oauth_session.saveNewSession(alloc, session);
 }

--- a/src/core/auth/oauth_transport.zig
+++ b/src/core/auth/oauth_transport.zig
@@ -15,6 +15,8 @@ pub const Request = struct {
     payload: ?[]const u8 = null,
     /// Optional preformatted Authorization value, borrowed for this request.
     authorization: ?[]const u8 = null,
+    /// Optional extra headers borrowed for this request.
+    extra_headers: []const std.http.Header = &.{},
     cancel_flag: ?*std.atomic.Value(bool) = null,
     deadline: ?std.Io.Clock.Timestamp = null,
 };

--- a/src/core/auth/provider_catalog.zig
+++ b/src/core/auth/provider_catalog.zig
@@ -4,12 +4,14 @@ pub const Id = enum {
     vercel,
     codex,
     grok,
+    claude,
 
     pub fn slug(self: Id) []const u8 {
         return switch (self) {
             .vercel => "vercel",
             .codex => "codex",
             .grok => "grok",
+            .claude => "claude",
         };
     }
 };
@@ -40,6 +42,12 @@ pub const entries = [_]Entry{
         .description = "SuperGrok or X Premium subscription",
         .subscription = true,
     },
+    .{
+        .id = .claude,
+        .name = "Claude",
+        .description = "Claude Pro, Max, Team, or Enterprise subscription",
+        .subscription = true,
+    },
 };
 
 pub fn parse(value: []const u8) ?Id {
@@ -47,6 +55,7 @@ pub fn parse(value: []const u8) ?Id {
         std.ascii.eqlIgnoreCase(value, "ai-gateway")) return .vercel;
     if (std.ascii.eqlIgnoreCase(value, "codex")) return .codex;
     if (std.ascii.eqlIgnoreCase(value, "grok")) return .grok;
+    if (std.ascii.eqlIgnoreCase(value, "claude")) return .claude;
     return null;
 }
 
@@ -59,9 +68,11 @@ test "auth provider catalog exposes subscription providers without aliases" {
     try std.testing.expectEqual(Id.vercel, parse("vercel").?);
     try std.testing.expectEqual(Id.codex, parse("codex").?);
     try std.testing.expectEqual(Id.grok, parse("grok").?);
+    try std.testing.expectEqual(Id.claude, parse("claude").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("chatgpt") == null);
     try std.testing.expect(parse("unknown") == null);
     try std.testing.expect(find(.codex).subscription);
     try std.testing.expect(find(.grok).subscription);
+    try std.testing.expect(find(.claude).subscription);
 }

--- a/src/core/cli/acp_runner.zig
+++ b/src/core/cli/acp_runner.zig
@@ -25,6 +25,8 @@ pub const Config = struct {
     codex_model_catalog: ?model_catalog.Provider = null,
     grok_agent_stream: ?agent_stream_provider.Provider = null,
     grok_model_catalog: ?model_catalog.Provider = null,
+    claude_agent_stream: ?agent_stream_provider.Provider = null,
+    claude_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     secret_store: host.SecretStore,
@@ -42,6 +44,7 @@ pub const Config = struct {
     permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     codex_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     grok_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
+    claude_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     model_override: ?[]const u8 = null,
     credential_override: ?[]const u8 = null,
     home_override: ?[]const u8 = null,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -226,6 +226,8 @@ pub const Config = struct {
     codex_model_catalog: ?model_catalog.Provider = null,
     grok_agent_stream: ?agent_stream_provider.Provider = null,
     grok_model_catalog: ?model_catalog.Provider = null,
+    claude_agent_stream: ?agent_stream_provider.Provider = null,
+    claude_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     secret_store: host.SecretStore,
@@ -244,6 +246,7 @@ pub const Config = struct {
     permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     codex_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     grok_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
+    claude_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     context_limit_overrides: []const config_runtime.context_limits.Override = &.{},
     additional_directories: []const []const u8 = &.{},
     saved_directories_suppressed: bool = false,
@@ -284,6 +287,10 @@ fn runAskChild(
             .grok = .{
                 .agent_stream_provider = ctx.cfg.grok_agent_stream orelse agent_stream_provider.unavailable_provider,
                 .permission_reviewer_provider = ctx.cfg.grok_permission_reviewer_provider,
+            },
+            .claude = .{
+                .agent_stream_provider = ctx.cfg.claude_agent_stream orelse agent_stream_provider.unavailable_provider,
+                .permission_reviewer_provider = ctx.cfg.claude_permission_reviewer_provider,
             },
         },
         .system_prompt = ctx.cfg.prompt_policy.system_prompt,
@@ -1061,6 +1068,7 @@ const AskContext = struct {
             .gateway => self.cfg.permission_reviewer_provider,
             .codex => self.cfg.codex_permission_reviewer_provider,
             .grok => self.cfg.grok_permission_reviewer_provider,
+            .claude => self.cfg.claude_permission_reviewer_provider,
         } orelse
             return permission_auto_classifier.Classifier.disabled();
         return permission_auto_classifier.Classifier.withProvider(provider, .{
@@ -1079,6 +1087,7 @@ const AskContext = struct {
             .gateway => self.cfg.gateway_provider.agent_stream,
             .codex => self.cfg.codex_agent_stream orelse agent_stream_provider.unavailable_provider,
             .grok => self.cfg.grok_agent_stream orelse agent_stream_provider.unavailable_provider,
+            .claude => self.cfg.claude_agent_stream orelse agent_stream_provider.unavailable_provider,
         };
     }
 
@@ -2005,6 +2014,7 @@ fn resolveModelCapabilities(raw_ctx: *anyopaque, _: Allocator, model: []const u8
         ctx.cfg.gateway_provider.model_catalog,
         ctx.cfg.codex_model_catalog,
         ctx.cfg.grok_model_catalog,
+        ctx.cfg.claude_model_catalog,
     ) orelse return model_capabilities.capabilitiesForModel(model);
     return ctx.capability_resolver.resolve(
         ctx.alloc,
@@ -2023,11 +2033,13 @@ fn selectModelCatalog(
     gateway: model_catalog.Provider,
     codex: ?model_catalog.Provider,
     grok: ?model_catalog.Provider,
+    claude: ?model_catalog.Provider,
 ) ?model_catalog.Provider {
     return switch (provider) {
         .gateway => gateway,
         .codex => codex,
         .grok => grok,
+        .claude => claude,
     };
 }
 
@@ -2046,21 +2058,27 @@ test "provider catalog selection never falls back across origins" {
     var grok_tag: u8 = 0;
     var grok = test_builtin_gateway.model_catalog_provider;
     grok.context = &grok_tag;
+    var claude_tag: u8 = 0;
+    var claude = test_builtin_gateway.model_catalog_provider;
+    claude.context = &claude_tag;
     const cases = [_]struct {
         provider: model_provider.ProviderId,
         codex: ?model_catalog.Provider,
         grok: ?model_catalog.Provider,
+        claude: ?model_catalog.Provider,
         expected_context: ?*anyopaque,
     }{
-        .{ .provider = .gateway, .codex = codex, .grok = grok, .expected_context = &gateway_tag },
-        .{ .provider = .codex, .codex = codex, .grok = grok, .expected_context = &codex_tag },
-        .{ .provider = .codex, .codex = null, .grok = grok, .expected_context = null },
-        .{ .provider = .grok, .codex = codex, .grok = grok, .expected_context = &grok_tag },
-        .{ .provider = .grok, .codex = codex, .grok = null, .expected_context = null },
+        .{ .provider = .gateway, .codex = codex, .grok = grok, .claude = claude, .expected_context = &gateway_tag },
+        .{ .provider = .codex, .codex = codex, .grok = grok, .claude = claude, .expected_context = &codex_tag },
+        .{ .provider = .codex, .codex = null, .grok = grok, .claude = claude, .expected_context = null },
+        .{ .provider = .grok, .codex = codex, .grok = grok, .claude = claude, .expected_context = &grok_tag },
+        .{ .provider = .grok, .codex = codex, .grok = null, .claude = claude, .expected_context = null },
+        .{ .provider = .claude, .codex = codex, .grok = grok, .claude = claude, .expected_context = &claude_tag },
+        .{ .provider = .claude, .codex = codex, .grok = grok, .claude = null, .expected_context = null },
     };
 
     for (cases) |case| {
-        const selected = selectModelCatalog(case.provider, gateway, case.codex, case.grok);
+        const selected = selectModelCatalog(case.provider, gateway, case.codex, case.grok, case.claude);
         if (case.expected_context) |expected| {
             try std.testing.expect(selected != null);
             try std.testing.expect(selected.?.context.? == expected);

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -5,6 +5,7 @@ const app_lifecycle = @import("../app/app_lifecycle.zig");
 const background_record_liveness = @import("../background/background_record_liveness.zig");
 const background_store = @import("../background/background_store.zig");
 const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
+const claude_code_store = @import("../auth/claude_code_store.zig");
 const claude_oauth = @import("../auth/claude_oauth.zig");
 const grok_oauth = @import("../auth/grok_oauth.zig");
 const acp_runner = @import("acp_runner.zig");
@@ -406,6 +407,17 @@ fn parseGlobalLaunchArgs(
         } else if (std.mem.eql(u8, arg, "--no-additional-dirs")) {
             if (suppress_saved) return error.DuplicateAdditionalDirectorySuppression;
             suppress_saved = true;
+        } else if (std.mem.eql(u8, arg, "--claude-tools")) {
+            index += 1;
+            if (index >= args.len) return error.MissingClaudeToolsValue;
+            const enabled = claude_code_store.parseToolsToggle(args[index]) orelse
+                return error.InvalidClaudeToolsValue;
+            claude_code_store.setClaudeCodeToolsFromCli(enabled);
+        } else if (std.mem.startsWith(u8, arg, "--claude-tools=")) {
+            const value = arg["--claude-tools=".len..];
+            const enabled = claude_code_store.parseToolsToggle(value) orelse
+                return error.InvalidClaudeToolsValue;
+            claude_code_store.setClaudeCodeToolsFromCli(enabled);
         } else {
             break;
         }
@@ -432,11 +444,15 @@ pub fn commandAfterGlobalLaunchArgs(args: []const [:0]const u8) ?[]const u8 {
     var index: usize = 0;
     while (index < args.len) {
         const arg = args[index];
-        if (std.mem.eql(u8, arg, "--context-limit") or std.mem.eql(u8, arg, "--add-dir")) {
+        if (std.mem.eql(u8, arg, "--context-limit") or
+            std.mem.eql(u8, arg, "--add-dir") or
+            std.mem.eql(u8, arg, "--claude-tools"))
+        {
             index += 1;
             if (index >= args.len) return null;
         } else if (!std.mem.startsWith(u8, arg, "--context-limit=") and
             !std.mem.startsWith(u8, arg, "--add-dir=") and
+            !std.mem.startsWith(u8, arg, "--claude-tools=") and
             !std.mem.eql(u8, arg, "--no-additional-dirs"))
         {
             return arg;
@@ -862,7 +878,7 @@ fn runIfRequestedWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Con
         } else {
             try writer.writer.print("fx: invalid global launch option: {s}\n", .{@errorName(err)});
         }
-        try writer.writer.writeAll("usage: fx [--context-limit NAME=BYTES|off] [--add-dir PATH]... [--no-additional-dirs] <command>\n");
+        try writer.writer.writeAll("usage: fx [--context-limit NAME=BYTES|off] [--add-dir PATH]... [--no-additional-dirs] [--claude-tools on|off] <command>\n");
         try writeStderr(deps, writer.written());
         return .handled_failure;
     };
@@ -966,6 +982,7 @@ fn runNonInteractiveWithDeps(
         .pr => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .pull_request),
         .issue => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .issue),
         .login => |rest| {
+            debug_trace.configureFromEnv(alloc, ".");
             const maybe_login_provider = parseLoginProvider(rest) catch {
                 try writeStderr(deps, "usage: fx login [vercel|codex|grok|claude]\n");
                 return .handled_failure;
@@ -1028,7 +1045,17 @@ fn runNonInteractiveWithDeps(
                         cfg.url_opener,
                     ) catch |err| {
                         debug_trace.logf("auth", "Claude login failed err={s}", .{@errorName(err)});
-                        try writeStderr(deps, "fx login: failed to sign in with Claude\n");
+                        const message = switch (err) {
+                            error.ClaudeOAuthRequestFailed => "fx login: Claude rejected the authorization code. Request a new code and try again.\n",
+                            error.ClaudeOAuthStateMismatch => "fx login: Claude authorization state did not match. Request a new code and try again.\n",
+                            error.ClaudeUserInfoRequestFailed => "fx login: Claude accepted the token but rejected the profile request\n",
+                            error.InvalidClaudeUserInfoResponse => "fx login: Claude accepted the token but returned an unexpected profile\n",
+                            error.InvalidClaudeOAuthResponse => "fx login: Claude returned an unexpected token response\n",
+                            error.ClaudeRefreshTokenMissing => "fx login: Claude did not return a refresh token\n",
+                            error.LoginTimedOut => "fx login: Claude authorization expired; run fx login claude again\n",
+                            else => "fx login: failed to sign in with Claude\n",
+                        };
+                        try writeStderr(deps, message);
                         return .handled_failure;
                     };
                     if (!try activateProviderSelection(alloc, cfg, deps, .claude, .provider_login)) {
@@ -1153,11 +1180,11 @@ fn runNonInteractiveWithDeps(
         },
         .provider => |rest| {
             if (rest.len != 1) {
-                try writeStderr(deps, "usage: fx provider <gateway|codex|grok>\n");
+                try writeStderr(deps, "usage: fx provider <gateway|codex|grok|claude>\n");
                 return .handled_failure;
             }
             const target = model_provider.parse(rest[0]) orelse {
-                try writeStderr(deps, "fx provider: expected gateway, codex, or grok\n");
+                try writeStderr(deps, "fx provider: expected gateway, codex, grok, or claude\n");
                 return .handled_failure;
             };
             return if (try activateProviderSelection(alloc, cfg, deps, target, .provider_command))
@@ -3121,6 +3148,8 @@ fn globalLaunchErrorMessage(err: anyerror) ?[]const u8 {
     return switch (err) {
         error.MissingAddDirectoryValue => "--add-dir requires a directory path",
         error.DuplicateAdditionalDirectorySuppression => "--no-additional-dirs may only be specified once",
+        error.MissingClaudeToolsValue => "--claude-tools requires on or off",
+        error.InvalidClaudeToolsValue => "--claude-tools requires on or off",
         else => null,
     };
 }

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -5,6 +5,7 @@ const app_lifecycle = @import("../app/app_lifecycle.zig");
 const background_record_liveness = @import("../background/background_record_liveness.zig");
 const background_store = @import("../background/background_store.zig");
 const chatgpt_oauth = @import("../auth/chatgpt_oauth.zig");
+const claude_oauth = @import("../auth/claude_oauth.zig");
 const grok_oauth = @import("../auth/grok_oauth.zig");
 const acp_runner = @import("acp_runner.zig");
 const cli_ask = @import("cli_ask.zig");
@@ -183,6 +184,9 @@ pub const Config = struct {
     grok_agent_stream: ?agent_stream_provider.Provider = null,
     grok_cli_model_catalog: ?gateway_provider.CliModelCatalogProvider = null,
     grok_model_catalog: ?model_catalog.Provider = null,
+    claude_agent_stream: ?agent_stream_provider.Provider = null,
+    claude_cli_model_catalog: ?gateway_provider.CliModelCatalogProvider = null,
+    claude_model_catalog: ?model_catalog.Provider = null,
     background_process_provider: background_process_provider.Provider =
         background_process_provider.unavailable_provider,
     url_opener: host.UrlOpener,
@@ -206,6 +210,7 @@ pub const Config = struct {
     permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     codex_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
     grok_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
+    claude_permission_reviewer_provider: ?permission_auto_classifier.Provider = null,
 };
 
 const LocalSurfaceOptions = struct {
@@ -694,6 +699,7 @@ fn activateProviderSelection(
             .gateway => "Gateway is already selected.\n",
             .codex => "Codex is already selected.\n",
             .grok => "Grok is already selected.\n",
+            .claude => "Claude is already selected.\n",
         });
         return true;
     }
@@ -731,6 +737,22 @@ fn activateProviderSelection(
             settings.credential_source,
         );
     }
+    if (resolution.credential == null and target == .claude and caller == .provider_command) {
+        claude_oauth.runLogin(alloc, cfg.gateway_provider.oauth_transport, cfg.url_opener) catch |err| {
+            debug_trace.logf("auth", "provider selection Claude login failed err={s}", .{@errorName(err)});
+            try writeProviderActivationError(alloc, deps, caller, "Claude login failed");
+            return false;
+        };
+        performed_login = .claude;
+        resolution = try credentials.resolveForProvider(
+            alloc,
+            cfg.gateway_provider.oauth_transport,
+            cfg.secret_store,
+            .refresh_if_needed,
+            target,
+            settings.credential_source,
+        );
+    }
 
     const credential = if (resolution.credential) |*value| value else {
         try writeProviderActivationError(
@@ -740,6 +762,7 @@ fn activateProviderSelection(
             switch (target) {
                 .codex => "Codex credential is unavailable",
                 .grok => "Grok credential is unavailable",
+                .claude => "Claude credential is unavailable",
                 .gateway => "configure a Gateway credential first",
             },
         );
@@ -752,6 +775,10 @@ fn activateProviderSelection(
         },
         .grok => cfg.grok_model_catalog orelse {
             try writeProviderActivationError(alloc, deps, caller, "Grok model catalog is unavailable");
+            return false;
+        },
+        .claude => cfg.claude_model_catalog orelse {
+            try writeProviderActivationError(alloc, deps, caller, "Claude model catalog is unavailable");
             return false;
         },
         .gateway => cfg.gateway_provider.model_catalog,
@@ -780,6 +807,7 @@ fn activateProviderSelection(
         .gateway => settings.model,
         .codex => settings.codex_model,
         .grok => settings.grok_model,
+        .claude => settings.claude_model,
     };
     const selected_model = selectCatalogModel(loaded.catalog.items, saved_model) orelse {
         try writeProviderActivationError(alloc, deps, caller, "target model catalog is empty");
@@ -789,6 +817,7 @@ fn activateProviderSelection(
         .gateway => .{ .provider = target, .model = selected_model },
         .codex => .{ .provider = target, .codex_model = selected_model },
         .grok => .{ .provider = target, .grok_model = selected_model },
+        .claude => .{ .provider = target, .claude_model = selected_model },
     });
     defer attempt.deinit(alloc);
     switch (attempt) {
@@ -802,6 +831,7 @@ fn activateProviderSelection(
     if (performed_login) |provider| switch (provider) {
         .codex => try writeStdout(deps, "Signed in with Codex.\n"),
         .grok => try writeStdout(deps, "Signed in with Grok.\n"),
+        .claude => try writeStdout(deps, "Signed in with Claude.\n"),
         .gateway => unreachable,
     };
     if (caller == .provider_command) {
@@ -809,6 +839,7 @@ fn activateProviderSelection(
             .gateway => "Provider set to Gateway.\n",
             .codex => "Provider set to Codex.\n",
             .grok => "Provider set to Grok.\n",
+            .claude => "Provider set to Claude.\n",
         });
     }
     return true;
@@ -905,6 +936,8 @@ fn runNonInteractiveWithDeps(
                 .codex_model_catalog = cfg.codex_model_catalog,
                 .grok_agent_stream = cfg.grok_agent_stream,
                 .grok_model_catalog = cfg.grok_model_catalog,
+                .claude_agent_stream = cfg.claude_agent_stream,
+                .claude_model_catalog = cfg.claude_model_catalog,
                 .background_process_provider = cfg.background_process_provider,
                 .secret_store = cfg.secret_store,
                 .prompt_policy = cfg.prompt_policy,
@@ -921,6 +954,7 @@ fn runNonInteractiveWithDeps(
                 .permission_reviewer_provider = cfg.permission_reviewer_provider,
                 .codex_permission_reviewer_provider = cfg.codex_permission_reviewer_provider,
                 .grok_permission_reviewer_provider = cfg.grok_permission_reviewer_provider,
+                .claude_permission_reviewer_provider = cfg.claude_permission_reviewer_provider,
                 .context_limit_overrides = global_args.modifiers.context_limit_overrides,
                 .additional_directories = global_args.modifiers.additional_directories,
                 .saved_directories_suppressed = global_args.modifiers.saved_directories_suppressed,
@@ -933,7 +967,7 @@ fn runNonInteractiveWithDeps(
         .issue => |rest| return runGithubWorkflow(alloc, rest, cfg, global_args.modifiers, deps, .issue),
         .login => |rest| {
             const maybe_login_provider = parseLoginProvider(rest) catch {
-                try writeStderr(deps, "usage: fx login [vercel|codex|grok]\n");
+                try writeStderr(deps, "usage: fx login [vercel|codex|grok|claude]\n");
                 return .handled_failure;
             };
             // Preserve the original `fx login` behavior for scripts and users.
@@ -987,12 +1021,27 @@ fn runNonInteractiveWithDeps(
                     }
                     try writeStdout(deps, "Signed in with Grok.\n");
                 },
+                .claude => {
+                    claude_oauth.runLogin(
+                        alloc,
+                        cfg.gateway_provider.oauth_transport,
+                        cfg.url_opener,
+                    ) catch |err| {
+                        debug_trace.logf("auth", "Claude login failed err={s}", .{@errorName(err)});
+                        try writeStderr(deps, "fx login: failed to sign in with Claude\n");
+                        return .handled_failure;
+                    };
+                    if (!try activateProviderSelection(alloc, cfg, deps, .claude, .provider_login)) {
+                        return .handled_failure;
+                    }
+                    try writeStdout(deps, "Signed in with Claude.\n");
+                },
             }
             return .handled_success;
         },
         .logout => |rest| {
             const maybe_login_provider = parseLoginProvider(rest) catch {
-                try writeStderr(deps, "usage: fx logout [vercel|codex|grok]\n");
+                try writeStderr(deps, "usage: fx logout [vercel|codex|grok|claude]\n");
                 return .handled_failure;
             };
             // Preserve the original `fx logout` behavior for scripts and users.
@@ -1036,6 +1085,29 @@ fn runNonInteractiveWithDeps(
                     },
                     .deleted_not_durable => result: {
                         try writeStderr(deps, "fx logout: failed to durably remove saved Grok login\n");
+                        break :result .handled_failure;
+                    },
+                };
+            }
+            if (login_provider == .claude) {
+                const outcome = claude_oauth.logout(alloc, cfg.gateway_provider.oauth_transport) catch {
+                    try writeStderr(deps, "fx logout: failed to durably remove saved Claude login\n");
+                    return .handled_failure;
+                };
+                if (outcome.revocation_failed) {
+                    try writeStderr(deps, "fx logout: local Claude session removed, but remote revocation could not be confirmed\n");
+                }
+                return switch (outcome.deletion) {
+                    .deleted => result: {
+                        try writeStdout(deps, "Signed out of Claude.\n");
+                        break :result .handled_success;
+                    },
+                    .missing => result: {
+                        try writeStdout(deps, "No Claude login session found.\n");
+                        break :result .handled_success;
+                    },
+                    .deleted_not_durable => result: {
+                        try writeStderr(deps, "fx logout: failed to durably remove saved Claude login\n");
                         break :result .handled_failure;
                     },
                 };
@@ -1175,6 +1247,10 @@ fn runNonInteractiveWithDeps(
                 },
                 .grok => cfg.grok_cli_model_catalog orelse {
                     try writeStderr(deps, "fx models: Grok model catalog is unavailable\n");
+                    return .handled_failure;
+                },
+                .claude => cfg.claude_cli_model_catalog orelse {
+                    try writeStderr(deps, "fx models: Claude model catalog is unavailable\n");
                     return .handled_failure;
                 },
                 .gateway => cfg.gateway_provider.cli_model_catalog,
@@ -2993,6 +3069,8 @@ fn workflowConfig(cfg: Config) @import("cli_ask.zig").Config {
         .codex_model_catalog = cfg.codex_model_catalog,
         .grok_agent_stream = cfg.grok_agent_stream,
         .grok_model_catalog = cfg.grok_model_catalog,
+        .claude_agent_stream = cfg.claude_agent_stream,
+        .claude_model_catalog = cfg.claude_model_catalog,
         .background_process_provider = cfg.background_process_provider,
         .secret_store = cfg.secret_store,
         .prompt_policy = cfg.prompt_policy,
@@ -3010,6 +3088,7 @@ fn workflowConfig(cfg: Config) @import("cli_ask.zig").Config {
         .permission_reviewer_provider = cfg.permission_reviewer_provider,
         .codex_permission_reviewer_provider = cfg.codex_permission_reviewer_provider,
         .grok_permission_reviewer_provider = cfg.grok_permission_reviewer_provider,
+        .claude_permission_reviewer_provider = cfg.claude_permission_reviewer_provider,
     };
 }
 

--- a/src/core/cli/doctor_runtime.zig
+++ b/src/core/cli/doctor_runtime.zig
@@ -127,6 +127,7 @@ pub fn collect(
             .gateway => detailed.settings.model,
             .codex => detailed.settings.codex_model,
             .grok => detailed.settings.grok_model,
+            .claude => detailed.settings.claude_model,
         },
         .permission_mode = detailed.settings.permission_mode,
         .max_agent_steps = detailed.settings.max_agent_steps,

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -49,6 +49,7 @@ pub const Settings = struct {
     first_call_tool_choice: ?types.ToolChoice = null,
     context: ?bool = null,
     fast_mode: ?bool = null,
+    claude_code_tools: ?bool = null,
     slash_menu_categories: ?bool = null,
     auto_upgrade: ?bool = null,
     update_channel: ?update_target.Channel = null,
@@ -69,8 +70,6 @@ pub const Settings = struct {
         if (self.codex_model) |value| alloc.free(value);
         if (self.grok_model) |value| alloc.free(value);
         if (self.claude_model) |value| alloc.free(value);
-        if (self.input_appearance) |value| alloc.free(value);
-        if (self.maxxing_mode) |value| alloc.free(value);
         self.permission_rules.deinit(alloc);
         self.* = .{};
     }
@@ -544,6 +543,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "claude_model",
         "effort",
         "fast_mode",
+        "claude_code_tools",
         "slash_menu_categories",
         "startup_scrollback",
         "prompt_history",
@@ -1330,6 +1330,12 @@ fn parseProfileOnlyFields(
         const value = fast_mode_value;
         if (value != .bool) return error.InvalidFastModeType;
         settings.fast_mode = value.bool;
+    }
+
+    if (root.object.get("claude_code_tools")) |claude_code_tools_value| {
+        const value = claude_code_tools_value;
+        if (value != .bool) return error.InvalidClaudeCodeToolsType;
+        settings.claude_code_tools = value.bool;
     }
 
     if (root.object.get("slash_menu_categories")) |slash_menu_categories_value| {

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -39,6 +39,7 @@ pub const Settings = struct {
     provider: ?model_provider.ProviderId = null,
     codex_model: ?[]u8 = null,
     grok_model: ?[]u8 = null,
+    claude_model: ?[]u8 = null,
     permission_mode: ?types.PermissionMode = null,
     credential_source: ?types.CredentialSource = null,
     yolo_acknowledged: ?bool = null,
@@ -67,6 +68,9 @@ pub const Settings = struct {
         if (self.model) |value| alloc.free(value);
         if (self.codex_model) |value| alloc.free(value);
         if (self.grok_model) |value| alloc.free(value);
+        if (self.claude_model) |value| alloc.free(value);
+        if (self.input_appearance) |value| alloc.free(value);
+        if (self.maxxing_mode) |value| alloc.free(value);
         self.permission_rules.deinit(alloc);
         self.* = .{};
     }
@@ -103,6 +107,7 @@ pub const ConfigSources = struct {
     provider: ConfigSource = .compiled_default,
     codex_model: ConfigSource = .compiled_default,
     grok_model: ConfigSource = .compiled_default,
+    claude_model: ConfigSource = .compiled_default,
     permission_mode: ConfigSource = .compiled_default,
     effort: ConfigSource = .compiled_default,
     fast_mode: ConfigSource = .compiled_default,
@@ -536,6 +541,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "provider",
         "codex_model",
         "grok_model",
+        "claude_model",
         "effort",
         "fast_mode",
         "slash_menu_categories",
@@ -581,6 +587,7 @@ fn updateConfigSources(sources: *ConfigSources, settings: Settings, source: Conf
     if (settings.provider != null) sources.provider = source;
     if (settings.codex_model != null) sources.codex_model = source;
     if (settings.grok_model != null) sources.grok_model = source;
+    if (settings.claude_model != null) sources.claude_model = source;
     if (settings.permission_mode != null) sources.permission_mode = source;
     if (settings.effort != null) sources.effort = source;
     if (settings.fast_mode != null) sources.fast_mode = source;
@@ -1281,6 +1288,12 @@ fn parseProfileOnlyFields(
         settings.grok_model = try alloc.dupe(u8, model_value.string);
     }
 
+    if (root.object.get("claude_model")) |model_value| {
+        if (model_value != .string) return error.InvalidClaudeModelType;
+        settings_store.validateModel(model_value.string) catch return error.InvalidClaudeModelValue;
+        settings.claude_model = try alloc.dupe(u8, model_value.string);
+    }
+
     if (root.object.get("permission_mode")) |permission_mode_value| {
         const value = permission_mode_value;
         if (value != .string) return error.InvalidPermissionModeType;
@@ -1445,6 +1458,11 @@ fn mergeSettings(target: *Settings, incoming: *Settings, alloc: Allocator) void 
         if (target.grok_model) |current| alloc.free(current);
         target.grok_model = value;
         incoming.grok_model = null;
+    }
+    if (incoming.claude_model) |value| {
+        if (target.claude_model) |current| alloc.free(current);
+        target.claude_model = value;
+        incoming.claude_model = null;
     }
     if (incoming.permission_mode) |value| target.permission_mode = value;
     if (incoming.credential_source) |value| target.credential_source = value;

--- a/src/core/config/model_provider.zig
+++ b/src/core/config/model_provider.zig
@@ -5,6 +5,7 @@ pub const ProviderId = enum {
     gateway,
     codex,
     grok,
+    claude,
 };
 
 pub const ProviderSelection = struct {
@@ -16,6 +17,7 @@ pub fn parse(value: []const u8) ?ProviderId {
     if (std.ascii.eqlIgnoreCase(value, "gateway")) return .gateway;
     if (std.ascii.eqlIgnoreCase(value, "codex")) return .codex;
     if (std.ascii.eqlIgnoreCase(value, "grok")) return .grok;
+    if (std.ascii.eqlIgnoreCase(value, "claude")) return .claude;
     return null;
 }
 
@@ -24,15 +26,17 @@ pub fn label(provider: ProviderId) []const u8 {
         .gateway => "Vercel AI Gateway",
         .codex => "Codex subscription",
         .grok => "Grok subscription",
+        .claude => "Claude subscription",
     };
 }
 
 pub fn authorizesCredential(provider: ProviderId, source: ?types.CredentialSource) bool {
     const selected = source orelse return false;
     return switch (provider) {
-        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription,
+        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription and selected != .claude_subscription,
         .codex => selected == .chatgpt_subscription,
         .grok => selected == .grok_subscription,
+        .claude => selected == .claude_subscription,
     };
 }
 
@@ -49,13 +53,17 @@ test "explicit providers authorize only their own credential origins" {
     try std.testing.expect(!authorizesCredential(.codex, null));
     try std.testing.expect(authorizesCredential(.grok, .grok_subscription));
     try std.testing.expect(!authorizesCredential(.grok, .chatgpt_subscription));
+    try std.testing.expect(authorizesCredential(.claude, .claude_subscription));
+    try std.testing.expect(!authorizesCredential(.claude, .grok_subscription));
     try std.testing.expect(!authorizesCredential(.gateway, .grok_subscription));
+    try std.testing.expect(!authorizesCredential(.gateway, .claude_subscription));
 }
 
 test "provider parsing exposes gateway codex and grok" {
     try std.testing.expectEqual(ProviderId.gateway, parse("gateway").?);
     try std.testing.expectEqual(ProviderId.codex, parse("CODEX").?);
     try std.testing.expectEqual(ProviderId.grok, parse("GROK").?);
+    try std.testing.expectEqual(ProviderId.claude, parse("CLAUDE").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("") == null);
 }

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -89,6 +89,7 @@ pub const UserSettingsPatch = struct {
     provider: ?model_provider.ProviderId = null,
     codex_model: ?[]const u8 = null,
     grok_model: ?[]const u8 = null,
+    claude_model: ?[]const u8 = null,
     permission_mode: ?types.PermissionMode = null,
     credential_source: ?types.CredentialSource = null,
     /// Removes the key entirely so resolution returns to plain precedence.
@@ -111,6 +112,7 @@ pub const UserSettingsPatch = struct {
             self.provider == null and
             self.codex_model == null and
             self.grok_model == null and
+            self.claude_model == null and
             self.permission_mode == null and
             self.credential_source == null and
             !self.clear_credential_source and
@@ -931,6 +933,7 @@ fn applyUserPatchToRoot(
     if (patch.provider) |value| application.changed = try putString(arena, &root.object, "provider", @tagName(value)) or application.changed;
     if (patch.codex_model) |value| application.changed = try putString(arena, &root.object, "codex_model", value) or application.changed;
     if (patch.grok_model) |value| application.changed = try putString(arena, &root.object, "grok_model", value) or application.changed;
+    if (patch.claude_model) |value| application.changed = try putString(arena, &root.object, "claude_model", value) or application.changed;
     if (patch.permission_mode) |value| application.changed = try putString(arena, &root.object, "permission_mode", @tagName(value)) or application.changed;
     if (patch.credential_source) |value| application.changed = try putString(arena, &root.object, "credential_source", @tagName(value)) or application.changed;
     if (patch.clear_credential_source and root.object.contains("credential_source")) {
@@ -1616,6 +1619,10 @@ fn validateKnownSettingsObject(
         try validateModel(value.string);
     }
     if (object.get("grok_model")) |value| {
+        if (value != .string) return error.InvalidSettingsFormat;
+        try validateModel(value.string);
+    }
+    if (object.get("claude_model")) |value| {
         if (value != .string) return error.InvalidSettingsFormat;
         try validateModel(value.string);
     }

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -750,6 +750,7 @@ pub const ModelListSnapshot = struct {
             .gateway => "gateway",
             .codex => model_provider.label(.codex),
             .grok => model_provider.label(.grok),
+            .claude => model_provider.label(.claude),
         };
     }
 
@@ -764,6 +765,7 @@ pub const ModelListSnapshot = struct {
             .authenticated_credential_rejected => "Your Gateway credential was rejected; using the public model catalog.",
             .chatgpt_subscription => "Codex models require an authenticated Codex catalog.",
             .grok_subscription => "Grok models require an authenticated Grok catalog.",
+            .claude_subscription => "Claude models require an authenticated Claude catalog.",
         };
     }
 };

--- a/src/core/shared/profile_paths.zig
+++ b/src/core/shared/profile_paths.zig
@@ -6,6 +6,7 @@ pub const root_dir_name = ".fx";
 pub const auth_file_name = "auth.json";
 pub const chatgpt_auth_file_name = "chatgpt-auth.json";
 pub const grok_auth_file_name = "grok-auth.json";
+pub const claude_auth_file_name = "claude-auth.json";
 pub const api_key_file_name = "api-key";
 pub const sessions_dir_name = "sessions";
 pub const prompt_history_file_name = "history.jsonl";
@@ -62,6 +63,10 @@ pub fn chatgptAuthPath(alloc: Allocator, home: []const u8) ![]u8 {
 
 pub fn grokAuthPath(alloc: Allocator, home: []const u8) ![]u8 {
     return std.fs.path.join(alloc, &.{ home, root_dir_name, grok_auth_file_name });
+}
+
+pub fn claudeAuthPath(alloc: Allocator, home: []const u8) ![]u8 {
+    return std.fs.path.join(alloc, &.{ home, root_dir_name, claude_auth_file_name });
 }
 
 pub fn apiKeyPath(alloc: Allocator, home: []const u8) ![]u8 {
@@ -136,6 +141,10 @@ test "profile path helpers preserve current default locations" {
     const chatgpt_auth = try chatgptAuthPath(alloc, "/tmp/fake-home");
     defer alloc.free(chatgpt_auth);
     try std.testing.expectEqualStrings("/tmp/fake-home/.fx/chatgpt-auth.json", chatgpt_auth);
+
+    const claude_auth = try claudeAuthPath(alloc, "/tmp/fake-home");
+    defer alloc.free(claude_auth);
+    try std.testing.expectEqualStrings("/tmp/fake-home/.fx/claude-auth.json", claude_auth);
 
     const api_key = try apiKeyPath(alloc, "/tmp/fake-home");
     defer alloc.free(api_key);

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -94,6 +94,7 @@ pub const CredentialSource = enum {
     stored_key,
     chatgpt_subscription,
     grok_subscription,
+    claude_subscription,
 };
 
 pub fn parseCredentialSource(text: []const u8) ?CredentialSource {

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1559,6 +1559,7 @@ test "rendered top-level help is a complete CLI navigation page" {
     try std.testing.expect(std.mem.find(u8, text, "--context-limit <spec>") != null);
     try std.testing.expect(std.mem.find(u8, text, "Set name=bytes|off; repeatable") != null);
     try std.testing.expect(std.mem.find(u8, text, "--add-dir <path>") != null);
+    try std.testing.expect(std.mem.find(u8, text, "--claude-tools on|off") != null);
     try std.testing.expect(std.mem.find(u8, text, "-c, --continue") != null);
     try std.testing.expect(std.mem.find(u8, text, "-r") != null);
     try std.testing.expect(std.mem.find(u8, text, "-c, -r, --continue") == null);
@@ -1614,6 +1615,7 @@ test "top-level help renders flags as compact aligned rows" {
     try std.testing.expect(lineContainsBoth(wide, "--record", "Record terminal output"));
     try std.testing.expect(lineContainsBoth(wide, "--context-limit <spec>", "Set name=bytes|off; repeatable"));
     try std.testing.expect(lineContainsBoth(wide, "--add-dir <path>", "Add a workspace directory; repeatable"));
+    try std.testing.expect(lineContainsBoth(wide, "--claude-tools on|off", "off: fx tools (default); on: Claude tools"));
     try std.testing.expect(lineContainsBoth(wide, "-c, --continue", "Resume the latest workspace session"));
     try std.testing.expect(lineContainsBoth(wide, "-r", "Open the saved-session picker"));
     try std.testing.expect(lineContainsBoth(wide, "--resume [last|<id>]", "Resume the latest workspace session or an exact ID"));

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -40,12 +40,14 @@ pub const ProviderRoutes = struct {
     gateway: ProviderRoute,
     codex: ProviderRoute,
     grok: ProviderRoute,
+    claude: ProviderRoute,
 
     pub fn select(self: ProviderRoutes, provider: model_provider.ProviderId) ProviderRoute {
         return switch (provider) {
             .gateway => self.gateway,
             .codex => self.codex,
             .grok => self.grok,
+            .claude => self.claude,
         };
     }
 };
@@ -54,12 +56,15 @@ test "provider routes select independent streams and reviewers" {
     var gateway_tag: u8 = 0;
     var codex_tag: u8 = 0;
     var grok_tag: u8 = 0;
+    var claude_tag: u8 = 0;
     var gateway_stream = stream_provider.unavailable_provider;
     gateway_stream.context = &gateway_tag;
     var codex_stream = stream_provider.unavailable_provider;
     codex_stream.context = &codex_tag;
     var grok_stream = stream_provider.unavailable_provider;
     grok_stream.context = &grok_tag;
+    var claude_stream = stream_provider.unavailable_provider;
+    claude_stream.context = &claude_tag;
     const Reviewer = struct {
         fn review(
             _: ?*anyopaque,
@@ -73,10 +78,12 @@ test "provider routes select independent streams and reviewers" {
     const gateway_reviewer = auto_classifier.Provider{ .context = &gateway_tag, .review_fn = Reviewer.review };
     const codex_reviewer = auto_classifier.Provider{ .context = &codex_tag, .review_fn = Reviewer.review };
     const grok_reviewer = auto_classifier.Provider{ .context = &grok_tag, .review_fn = Reviewer.review };
+    const claude_reviewer = auto_classifier.Provider{ .context = &claude_tag, .review_fn = Reviewer.review };
     const routes = ProviderRoutes{
         .gateway = .{ .agent_stream_provider = gateway_stream, .permission_reviewer_provider = gateway_reviewer },
         .codex = .{ .agent_stream_provider = codex_stream, .permission_reviewer_provider = codex_reviewer },
         .grok = .{ .agent_stream_provider = grok_stream, .permission_reviewer_provider = grok_reviewer },
+        .claude = .{ .agent_stream_provider = claude_stream, .permission_reviewer_provider = claude_reviewer },
     };
 
     try std.testing.expect(routes.select(.gateway).agent_stream_provider.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));

--- a/src/gateway/anthropic_claude.zig
+++ b/src/gateway/anthropic_claude.zig
@@ -1,0 +1,690 @@
+const std = @import("std");
+const claude_oauth = @import("../core/auth/claude_oauth.zig");
+const image_attachments = @import("../core/images/image_attachments.zig");
+const secret = @import("../core/auth/secret.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+
+const Allocator = std.mem.Allocator;
+const endpoint = "https://api.anthropic.com/v1/messages";
+const generation_origin = "https://api.anthropic.com/v1";
+const e2e_endpoint_env = "FX_E2E_ANTHROPIC_CLAUDE_MESSAGES_URL";
+const anthropic_version = "2023-06-01";
+const max_error_body_bytes: usize = 256 * 1024;
+const max_sse_line_bytes: usize = 1024 * 1024;
+const max_sse_aggregate_bytes: usize = 64 * 1024 * 1024;
+const max_sse_events: usize = 100_000;
+const max_tool_calls: usize = 128;
+const max_tool_identity_bytes: usize = 1024;
+const max_tool_arguments_bytes: usize = 4 * 1024 * 1024;
+const max_provider_state_bytes: usize = 4 * 1024 * 1024;
+const transfer_buffer_bytes: usize = 256 * 1024;
+const connect_timeout_ms: i64 = 30_000;
+
+const ClaudeLimits = struct {
+    aggregate_bytes: usize = max_sse_aggregate_bytes,
+    events: usize = max_sse_events,
+    tool_calls: usize = max_tool_calls,
+    tool_identity_bytes: usize = max_tool_identity_bytes,
+    tool_arguments_bytes: usize = max_tool_arguments_bytes,
+};
+
+pub const agent_stream_provider = stream_provider.Provider{
+    .build_fn = buildRequest,
+    .stream_fn = streamCompletion,
+};
+
+fn validateModel(model: []const u8) !void {
+    if (model.len == 0 or model.len > 1024) return error.InvalidAnthropicClaudeModel;
+    for (model) |byte| {
+        if (byte <= 0x20 or byte == 0x7f) return error.InvalidAnthropicClaudeModel;
+    }
+}
+
+pub fn buildRequest(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.BuildRequest,
+) ![]u8 {
+    try validateModel(request.model);
+    if (request.budget) |budget| {
+        if (budget.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+        _ = budget.deadline;
+    }
+
+    var instructions: std.Io.Writer.Allocating = .init(alloc);
+    defer instructions.deinit();
+    for (request.messages) |message| {
+        if (message.role != .system) continue;
+        const text = message.content orelse continue;
+        if (text.len == 0) continue;
+        if (instructions.written().len > 0) try instructions.writer.writeAll("\n\n");
+        try instructions.writer.writeAll(text);
+    }
+    if (instructions.written().len == 0) {
+        instructions.writer.writeAll("You are a helpful assistant.") catch {};
+    }
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll("{\"model\":");
+    try std.json.Stringify.value(request.model, .{}, writer);
+    try writer.writeAll(",\"stream\":true,\"max_tokens\":");
+    try writer.print("{d}", .{request.max_output_tokens orelse 8192});
+    try writer.writeAll(",\"system\":");
+    try std.json.Stringify.value(instructions.written(), .{}, writer);
+    try writer.writeAll(",\"messages\":[");
+    try writeMessages(writer, alloc, request.messages, request.verified_images);
+    try writer.writeByte(']');
+    _ = try writeTools(writer, alloc, request.serialized_tools, request.selected_dynamic_tool_schemas);
+    if (request.tool_choice != .auto and request.tool_choice != .none) {
+        try writer.writeAll(",\"tool_choice\":{");
+        try writer.writeAll("\"type\":\"any\"");
+        try writer.writeByte('}');
+    }
+    try writer.writeByte('}');
+    return out.toOwnedSlice();
+}
+
+fn writeMessages(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    messages: []const types.ChatMessage,
+    verified_images: ?[]const image_attachments.VerifiedSnapshot,
+) !void {
+    var first = true;
+    for (messages, 0..) |message, message_index| {
+        switch (message.role) {
+            .system => continue,
+            .user => {
+                try writeComma(writer, &first);
+                try writer.writeAll("{\"role\":\"user\",\"content\":[");
+                var first_part = true;
+                if (message.content) |content| if (content.len > 0) {
+                    try writer.writeAll("{\"type\":\"text\",\"text\":");
+                    try std.json.Stringify.value(content, .{}, writer);
+                    try writer.writeByte('}');
+                    first_part = false;
+                };
+                if (verified_images) |images| {
+                    if (message_index == messages.len - 1) {
+                        for (images) |image| {
+                            if (!first_part) try writer.writeByte(',');
+                            try writeInputImage(writer, alloc, image);
+                            first_part = false;
+                        }
+                    }
+                }
+                try writer.writeAll("]}");
+            },
+            .assistant => {
+                try writeComma(writer, &first);
+                try writer.writeAll("{\"role\":\"assistant\",\"content\":[");
+                var first_part = true;
+                if (message.content) |content| if (content.len > 0) {
+                    try writer.writeAll("{\"type\":\"text\",\"text\":");
+                    try std.json.Stringify.value(content, .{}, writer);
+                    try writer.writeByte('}');
+                    first_part = false;
+                };
+                for (message.tool_calls) |call| {
+                    if (!first_part) try writer.writeByte(',');
+                    try writer.writeAll("{\"type\":\"tool_use\",\"id\":");
+                    try std.json.Stringify.value(call.id, .{}, writer);
+                    try writer.writeAll(",\"name\":");
+                    try std.json.Stringify.value(call.name, .{}, writer);
+                    try writer.writeAll(",\"input\":");
+                    try writer.writeAll(call.arguments_json);
+                    try writer.writeByte('}');
+                    first_part = false;
+                }
+                try writer.writeAll("]}");
+            },
+            .tool => {
+                try writeComma(writer, &first);
+                try writer.writeAll("{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":");
+                try std.json.Stringify.value(message.tool_call_id orelse "", .{}, writer);
+                try writer.writeAll(",\"content\":");
+                try std.json.Stringify.value(message.content orelse "", .{}, writer);
+                try writer.writeByte('}');
+                try writer.writeByte(']');
+            },
+        }
+    }
+}
+
+fn writeInputImage(writer: *std.Io.Writer, alloc: Allocator, image: image_attachments.VerifiedSnapshot) !void {
+    const encoded_len = std.base64.standard.Encoder.calcSize(image.bytes.len);
+    const encoded = try alloc.alloc(u8, encoded_len);
+    defer alloc.free(encoded);
+    _ = std.base64.standard.Encoder.encode(encoded, image.bytes);
+    try writer.writeAll("{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":");
+    try std.json.Stringify.value(image.media_type, .{}, writer);
+    try writer.writeAll(",\"data\":");
+    try std.json.Stringify.value(encoded, .{}, writer);
+    try writer.writeAll("}}");
+}
+
+fn writeTools(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    serialized_tools: []const u8,
+    selected_dynamic_schemas: []const []const u8,
+) !usize {
+    var count: usize = 0;
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, serialized_tools, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidToolSchema,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .array) return error.InvalidToolSchema;
+
+    var tools_out: std.Io.Writer.Allocating = .init(alloc);
+    defer tools_out.deinit();
+    try tools_out.writer.writeAll(",\"tools\":[");
+    for (parsed.value.array.items) |tool| {
+        if (try writeFunctionTool(&tools_out.writer, tool, count != 0)) count += 1;
+    }
+    for (selected_dynamic_schemas) |schema_json| {
+        var selected = std.json.parseFromSlice(std.json.Value, alloc, schema_json, .{}) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.InvalidToolSchema,
+        };
+        defer selected.deinit();
+        if (try writeFunctionTool(&tools_out.writer, selected.value, count != 0)) count += 1;
+    }
+    try tools_out.writer.writeByte(']');
+    if (count > 0) try writer.writeAll(tools_out.written());
+    return count;
+}
+
+fn writeFunctionTool(writer: *std.Io.Writer, value: std.json.Value, comma: bool) !bool {
+    if (value != .object) return false;
+    const kind = value.object.get("type") orelse return false;
+    if (kind != .string or !std.mem.eql(u8, kind.string, "function")) return false;
+    const name = value.object.get("name") orelse return false;
+    if (name != .string or name.string.len == 0) return false;
+    const parameters = value.object.get("inputSchema") orelse value.object.get("parameters") orelse return false;
+    if (parameters != .object) return false;
+    if (comma) try writer.writeByte(',');
+    try writer.writeAll("{\"name\":");
+    try std.json.Stringify.value(name.string, .{}, writer);
+    if (value.object.get("description")) |description| if (description == .string) {
+        try writer.writeAll(",\"description\":");
+        try std.json.Stringify.value(description.string, .{}, writer);
+    };
+    try writer.writeAll(",\"input_schema\":");
+    try std.json.Stringify.value(parameters, .{}, writer);
+    try writer.writeByte('}');
+    return true;
+}
+
+fn writeComma(writer: *std.Io.Writer, first: *bool) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+}
+
+fn streamCompletion(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    request: stream_provider.Request,
+) !stream_provider.Result {
+    return streamCompletionCore(alloc, request) catch |err| {
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(err, request.delivery.load());
+        return err;
+    };
+}
+
+fn streamCompletionCore(alloc: Allocator, request: stream_provider.Request) !stream_provider.Result {
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.credential_source != .claude_subscription) {
+        return error.ClaudeSubscriptionCredentialRequired;
+    }
+    try validateModel(request.model);
+    const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.api_key});
+    defer secret.zeroAndFree(alloc, auth_header);
+    const request_endpoint = if (io_mod.getenv(e2e_endpoint_env)) |override| endpoint: {
+        if (!gateway_client.isLoopbackHttpUrl(override)) return error.InvalidE2EAnthropicClaudeEndpoint;
+        break :endpoint override;
+    } else endpoint;
+    const uri = try std.Uri.parse(request_endpoint);
+
+    var extra_headers_buf: [3]std.http.Header = undefined;
+    var extra_count: usize = 0;
+    extra_headers_buf[extra_count] = .{ .name = "anthropic-version", .value = anthropic_version };
+    extra_count += 1;
+    extra_headers_buf[extra_count] = .{ .name = "originator", .value = "fx" };
+    extra_count += 1;
+    extra_headers_buf[extra_count] = .{ .name = "accept", .value = "text/event-stream" };
+    extra_count += 1;
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
+    defer client.deinit();
+    var open_operation = OpenRequestOperation{
+        .client = &client,
+        .uri = uri,
+        .auth_header = auth_header,
+        .extra_headers = extra_headers_buf[0..extra_count],
+    };
+    const connect_deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+        .clock = .awake,
+        .raw = .fromMilliseconds(connect_timeout_ms),
+    });
+    var opened = try gateway_client.runBoundedHttpOperation(
+        OpenedRequest,
+        alloc,
+        request.cancel_flag,
+        connect_deadline,
+        &open_operation,
+    );
+    var http_request = opened.take();
+    defer http_request.deinit();
+    var cancel_watch_done = std.atomic.Value(bool).init(false);
+    const cancel_watcher = if (http_request.connection) |connection|
+        try gateway_client.spawnHttpCancelWatcher(
+            &cancel_watch_done,
+            request.cancel_flag,
+            connection.stream_writer.stream,
+        )
+    else
+        null;
+    defer {
+        cancel_watch_done.store(true, .seq_cst);
+        if (cancel_watcher) |thread| thread.join();
+    }
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    http_request.transfer_encoding = .{ .content_length = request.payload.len };
+    var send_buffer: [8192]u8 = undefined;
+    request.delivery.markPossiblySent();
+    var body_writer = try http_request.sendBodyUnflushed(&send_buffer);
+    try body_writer.writer.writeAll(request.payload);
+    try body_writer.end();
+    if (http_request.connection) |connection| try connection.flush();
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    var response = try http_request.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        var transfer: [16 * 1024]u8 = undefined;
+        const reader = response.reader(&transfer);
+        const body = reader.allocRemaining(alloc, .limited(max_error_body_bytes)) catch |err| switch (err) {
+            error.StreamTooLong => try alloc.dupe(u8, "Anthropic Claude error response exceeded the local limit"),
+            else => return err,
+        };
+        return .{
+            .status = response.head.status,
+            .err_body = body,
+            .ownership = .owned,
+        };
+    }
+
+    var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
+    const reader = response.reader(&transfer_buffer);
+    const completion = try consumeMessagesSse(
+        alloc,
+        reader,
+        request.callback_ctx,
+        request.on_content_chunk,
+        request.on_tool_start,
+        request.on_reasoning_chunk,
+        request.on_tool_input_chunk,
+        request.cancel_flag,
+        request.content_capture_limit,
+        .{},
+    );
+    return .{
+        .status = .ok,
+        .completion = completion,
+        .generation_origin = generation_origin,
+        .ownership = .owned,
+    };
+}
+
+const ToolAccumulator = struct {
+    id: []u8,
+    name: []u8,
+    arguments: std.ArrayList(u8) = .empty,
+    saw_arguments: bool = false,
+
+    fn deinit(self: *ToolAccumulator, alloc: Allocator) void {
+        alloc.free(self.id);
+        alloc.free(self.name);
+        self.arguments.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+const SseReader = struct {
+    pending_line: std.ArrayList(u8) = .empty,
+
+    fn deinit(self: *SseReader, alloc: Allocator) void {
+        self.pending_line.deinit(alloc);
+    }
+
+    fn release(self: *SseReader) void {
+        self.pending_line.clearRetainingCapacity();
+    }
+
+    fn next(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
+        while (true) {
+            const line = try self.readLine(alloc, reader) orelse return null;
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (trimmed.len == 0 or trimmed[0] == ':') {
+                self.release();
+                continue;
+            }
+            if (!std.mem.startsWith(u8, trimmed, "data:")) {
+                self.release();
+                continue;
+            }
+            const data = std.mem.trim(u8, trimmed["data:".len..], " \t");
+            if (std.mem.eql(u8, data, "[DONE]")) return null;
+            return data;
+        }
+    }
+
+    fn readLine(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
+        while (true) {
+            const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
+                error.StreamTooLong => {
+                    const buffered = reader.buffered();
+                    if (buffered.len == 0) return error.AnthropicClaudeSseReadStalled;
+                    if (buffered.len > max_sse_line_bytes - self.pending_line.items.len) {
+                        return error.AnthropicClaudeSseEventTooLarge;
+                    }
+                    try self.pending_line.appendSlice(alloc, buffered);
+                    reader.tossBuffered();
+                    continue;
+                },
+                error.ReadFailed => return error.ReadFailed,
+            } orelse {
+                if (self.pending_line.items.len > 0) return self.pending_line.items;
+                return null;
+            };
+            if (fragment.len > max_sse_line_bytes - self.pending_line.items.len) {
+                return error.AnthropicClaudeSseEventTooLarge;
+            }
+            if (self.pending_line.items.len == 0) return fragment;
+            try self.pending_line.appendSlice(alloc, fragment);
+            return self.pending_line.items;
+        }
+    }
+};
+
+fn consumeMessagesSse(
+    alloc: Allocator,
+    reader: anytype,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    on_tool_input_chunk: ?stream_provider.StreamCallback,
+    cancel_flag: *std.atomic.Value(bool),
+    content_capture_limit: ?usize,
+    limits: ClaudeLimits,
+) !types.GatewayCompletion {
+    var content: std.ArrayList(u8) = .empty;
+    errdefer content.deinit(alloc);
+    var tools: std.ArrayList(ToolAccumulator) = .empty;
+    defer {
+        for (tools.items) |*tool| tool.deinit(alloc);
+        tools.deinit(alloc);
+    }
+    var sse: SseReader = .{};
+    defer sse.deinit(alloc);
+    const finish_reason: ?types.ProviderFinishReason = null;
+    var usage: types.Usage = .{};
+    var generation_id: ?[]u8 = null;
+    errdefer if (generation_id) |id| alloc.free(id);
+    var saw_content_delta = false;
+    var saw_tool_use = false;
+    var terminal_seen = false;
+    var event_count: usize = 0;
+    var aggregate_bytes: usize = 0;
+    var current_tool_index: ?usize = null;
+
+    while (try sse.next(alloc, reader)) |json_text| {
+        defer sse.release();
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        event_count = try checkedAccumulatedSize(event_count, 1, limits.events);
+        aggregate_bytes = try checkedAccumulatedSize(aggregate_bytes, json_text.len, limits.aggregate_bytes);
+        var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch
+            return error.InvalidAnthropicClaudeSseEvent;
+        defer parsed.deinit();
+        if (parsed.value != .object) continue;
+        const event_type = stringField(parsed.value.object, "type") orelse continue;
+
+        if (std.mem.eql(u8, event_type, "content_block_start")) {
+            const block = parsed.value.object.get("content_block") orelse continue;
+            if (block != .object) continue;
+            const block_type = stringField(block.object, "type") orelse continue;
+            if (std.mem.eql(u8, block_type, "tool_use")) {
+                saw_tool_use = true;
+                const tool_id = stringField(block.object, "id") orelse continue;
+                const name = stringField(block.object, "name") orelse continue;
+                try appendTool(alloc, &tools, tool_id, name, limits);
+                current_tool_index = tools.items.len - 1;
+                if (on_tool_start) |callback| callback(callback_ctx, tool_id, name, null);
+            }
+        } else if (std.mem.eql(u8, event_type, "content_block_delta")) {
+            const delta = parsed.value.object.get("delta") orelse continue;
+            if (delta != .object) continue;
+            const delta_type = stringField(delta.object, "type") orelse continue;
+            if (std.mem.eql(u8, delta_type, "text_delta")) {
+                const text = stringField(delta.object, "text") orelse continue;
+                saw_content_delta = true;
+                on_content_chunk(callback_ctx, text);
+                try appendCaptured(alloc, &content, text, content_capture_limit);
+            } else if (std.mem.eql(u8, delta_type, "input_json_delta")) {
+                const partial = stringField(delta.object, "partial_json") orelse continue;
+                if (current_tool_index) |index| {
+                    try appendToolArguments(alloc, &tools.items[index].arguments, partial, limits.tool_arguments_bytes);
+                    tools.items[index].saw_arguments = true;
+                    if (on_tool_input_chunk) |callback| callback(callback_ctx, partial);
+                }
+            } else if (std.mem.eql(u8, delta_type, "thinking_delta")) {
+                const thinking = stringField(delta.object, "thinking") orelse continue;
+                if (on_reasoning_chunk) |callback| callback(callback_ctx, thinking);
+            }
+        } else if (std.mem.eql(u8, event_type, "content_block_stop")) {
+            current_tool_index = null;
+        } else if (std.mem.eql(u8, event_type, "message_delta")) {
+            if (parsed.value.object.get("usage")) |usage_value| {
+                if (usage_value == .object) {
+                    usage.output_tokens = unsignedField(usage_value.object, "output_tokens");
+                }
+            }
+        } else if (std.mem.eql(u8, event_type, "message_start")) {
+            if (parsed.value.object.get("message")) |message_value| {
+                if (message_value == .object) {
+                    if (stringField(message_value.object, "id")) |id| {
+                        generation_id = try alloc.dupe(u8, id);
+                    }
+                    if (message_value.object.get("usage")) |usage_value| {
+                        if (usage_value == .object) {
+                            usage.input_tokens = unsignedField(usage_value.object, "input_tokens");
+                        }
+                    }
+                }
+            }
+        } else if (std.mem.eql(u8, event_type, "message_stop")) {
+            terminal_seen = true;
+            break;
+        } else if (std.mem.eql(u8, event_type, "error")) {
+            return error.AnthropicClaudeResponseFailed;
+        }
+    }
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (!terminal_seen) return error.AnthropicClaudeStreamIncomplete;
+
+    const owned_content = if (content.items.len > 0) try content.toOwnedSlice(alloc) else null;
+    if (owned_content != null) content = .empty;
+    errdefer if (owned_content) |value| alloc.free(value);
+    const owned_tools: []types.ToolCall = if (tools.items.len > 0)
+        try alloc.alloc(types.ToolCall, tools.items.len)
+    else
+        &.{};
+    errdefer if (owned_tools.len > 0) alloc.free(owned_tools);
+    var initialized: usize = 0;
+    errdefer for (owned_tools[0..initialized]) |call| {
+        alloc.free(call.id);
+        alloc.free(call.name);
+        alloc.free(call.arguments_json);
+    };
+    for (tools.items, 0..) |*tool, index| {
+        const arguments = if (tool.arguments.items.len > 0)
+            try tool.arguments.toOwnedSlice(alloc)
+        else
+            try alloc.dupe(u8, "{}");
+        tool.arguments = .empty;
+        owned_tools[index] = .{
+            .id = tool.id,
+            .name = tool.name,
+            .arguments_json = arguments,
+        };
+        tool.id = &.{};
+        tool.name = &.{};
+        initialized += 1;
+    }
+    return .{
+        .content = owned_content,
+        .tool_calls = owned_tools,
+        .generation_id = generation_id,
+        .finish_reason = finish_reason orelse if (owned_tools.len > 0) .tool_calls else .stop,
+        .usage = usage,
+    };
+}
+
+fn appendTool(
+    alloc: Allocator,
+    tools: *std.ArrayList(ToolAccumulator),
+    call_id: []const u8,
+    name: []const u8,
+    limits: ClaudeLimits,
+) !void {
+    if (tools.items.len >= limits.tool_calls or call_id.len == 0 or call_id.len > limits.tool_identity_bytes or
+        name.len == 0 or name.len > limits.tool_identity_bytes)
+    {
+        return error.AnthropicClaudeToolCallLimitExceeded;
+    }
+    const id = try alloc.dupe(u8, call_id);
+    errdefer alloc.free(id);
+    const owned_name = try alloc.dupe(u8, name);
+    errdefer alloc.free(owned_name);
+    try tools.append(alloc, .{
+        .id = id,
+        .name = owned_name,
+    });
+}
+
+fn appendToolArguments(
+    alloc: Allocator,
+    arguments: *std.ArrayList(u8),
+    delta: []const u8,
+    maximum: usize,
+) !void {
+    _ = checkedAccumulatedSize(arguments.items.len, delta.len, maximum) catch
+        return error.AnthropicClaudeToolArgumentsTooLarge;
+    try arguments.appendSlice(alloc, delta);
+}
+
+fn checkedAccumulatedSize(current: usize, additional: usize, maximum: usize) !usize {
+    const next = std.math.add(usize, current, additional) catch
+        return error.AnthropicClaudeResourceLimitExceeded;
+    if (next > maximum) return error.AnthropicClaudeResourceLimitExceeded;
+    return next;
+}
+
+fn appendCaptured(
+    alloc: Allocator,
+    content: *std.ArrayList(u8),
+    delta: []const u8,
+    limit: ?usize,
+) !void {
+    const remaining = if (limit) |maximum| maximum -| @min(maximum, content.items.len) else delta.len;
+    try content.appendSlice(alloc, delta[0..@min(delta.len, remaining)]);
+}
+
+fn stringField(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    if (value != .string) return null;
+    return value.string;
+}
+
+fn integerField(object: std.json.ObjectMap, key: []const u8) ?i64 {
+    const value = object.get(key) orelse return null;
+    if (value != .integer) return null;
+    return value.integer;
+}
+
+fn unsignedField(object: std.json.ObjectMap, key: []const u8) ?u64 {
+    const value = integerField(object, key) orelse return null;
+    if (value < 0) return null;
+    return @intCast(value);
+}
+
+const OpenedRequest = struct {
+    request: ?std.http.Client.Request,
+
+    pub fn deinit(self: *OpenedRequest, _: Allocator) void {
+        if (self.request) |*request| request.deinit();
+        self.request = null;
+    }
+
+    pub fn take(self: *OpenedRequest) std.http.Client.Request {
+        const request = self.request.?;
+        self.request = null;
+        return request;
+    }
+};
+
+const OpenRequestOperation = struct {
+    client: *std.http.Client,
+    uri: std.Uri,
+    auth_header: []const u8,
+    extra_headers: []const std.http.Header,
+
+    pub fn run(self: *@This()) !OpenedRequest {
+        return .{ .request = try self.client.request(.POST, self.uri, .{
+            .headers = .{
+                .content_type = .{ .override = "application/json" },
+                .authorization = .{ .override = self.auth_header },
+                .accept_encoding = .omit,
+                .user_agent = .{ .override = gateway_client.user_agent },
+            },
+            .extra_headers = self.extra_headers,
+            .keep_alive = false,
+            .redirect_behavior = .unhandled,
+        }) };
+    }
+};
+
+test "Anthropic Claude request uses Messages wire format" {
+    const messages = [_]types.ChatMessage{
+        .{ .role = .system, .content = "Be concise." },
+        .{ .role = .user, .content = "Read it." },
+        .{
+            .role = .assistant,
+            .tool_calls = &.{.{ .id = "toolu_1", .name = "read_file", .arguments_json = "{\"path\":\"README.md\"}" }},
+        },
+        .{ .role = .tool, .tool_call_id = "toolu_1", .tool_name = "read_file", .content = "contents" },
+    };
+    const body = try agent_stream_provider.build(std.testing.allocator, .{
+        .model = "claude-sonnet-4-5",
+        .serialized_tools = "[{\"type\":\"function\",\"name\":\"read_file\",\"description\":\"Read\",\"inputSchema\":{\"type\":\"object\"}}]",
+        .messages = &messages,
+        .tool_choice = .auto,
+        .provider_options = .{ .reasoning = types.ReasoningEffort.literal("high"), .fast = true },
+    });
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"claude-sonnet-4-5\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"stream\":true") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"messages\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_use\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_result\"") != null);
+}

--- a/src/gateway/anthropic_claude.zig
+++ b/src/gateway/anthropic_claude.zig
@@ -1,17 +1,19 @@
 const std = @import("std");
 const claude_oauth = @import("../core/auth/claude_oauth.zig");
+const claude_session = @import("../core/auth/claude_session.zig");
 const image_attachments = @import("../core/images/image_attachments.zig");
 const secret = @import("../core/auth/secret.zig");
 const stream_provider = @import("../core/agent/stream_provider.zig");
 const io_mod = @import("../core/shared/io.zig");
 const types = @import("../core/shared/types.zig");
 const gateway_client = @import("client.zig");
+const anthropic_claude_cli = @import("anthropic_claude_cli.zig");
 
 const Allocator = std.mem.Allocator;
 const endpoint = "https://api.anthropic.com/v1/messages";
 const generation_origin = "https://api.anthropic.com/v1";
 const e2e_endpoint_env = "FX_E2E_ANTHROPIC_CLAUDE_MESSAGES_URL";
-const anthropic_version = "2023-06-01";
+const anthropic_version = claude_oauth.anthropic_api_version;
 const max_error_body_bytes: usize = 256 * 1024;
 const max_sse_line_bytes: usize = 1024 * 1024;
 const max_sse_aggregate_bytes: usize = 64 * 1024 * 1024;
@@ -245,6 +247,20 @@ fn streamCompletionCore(alloc: Allocator, request: stream_provider.Request) !str
         return error.ClaudeSubscriptionCredentialRequired;
     }
     try validateModel(request.model);
+    if (io_mod.getenv(e2e_endpoint_env) != null) {
+        return streamHttpCompletion(alloc, request);
+    }
+    return anthropic_claude_cli.streamCompletion(alloc, request);
+}
+
+pub fn streamHttpCompletion(alloc: Allocator, request: stream_provider.Request) !stream_provider.Result {
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.credential_source != .claude_subscription) {
+        return error.ClaudeSubscriptionCredentialRequired;
+    }
+    const account_id = request.account_id orelse return error.ClaudeSubscriptionAccountRequired;
+    if (!claude_session.validAccountId(account_id)) return error.InvalidClaudeSubscriptionAccount;
+    try validateModel(request.model);
     const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.api_key});
     defer secret.zeroAndFree(alloc, auth_header);
     const request_endpoint = if (io_mod.getenv(e2e_endpoint_env)) |override| endpoint: {
@@ -253,11 +269,15 @@ fn streamCompletionCore(alloc: Allocator, request: stream_provider.Request) !str
     } else endpoint;
     const uri = try std.Uri.parse(request_endpoint);
 
-    var extra_headers_buf: [3]std.http.Header = undefined;
+    var extra_headers_buf: [5]std.http.Header = undefined;
     var extra_count: usize = 0;
     extra_headers_buf[extra_count] = .{ .name = "anthropic-version", .value = anthropic_version };
     extra_count += 1;
-    extra_headers_buf[extra_count] = .{ .name = "originator", .value = "fx" };
+    extra_headers_buf[extra_count] = .{ .name = "anthropic-beta", .value = claude_oauth.messages_beta };
+    extra_count += 1;
+    extra_headers_buf[extra_count] = .{ .name = "anthropic-account-uuid", .value = account_id };
+    extra_count += 1;
+    extra_headers_buf[extra_count] = .{ .name = "originator", .value = claude_oauth.messages_originator };
     extra_count += 1;
     extra_headers_buf[extra_count] = .{ .name = "accept", .value = "text/event-stream" };
     extra_count += 1;
@@ -654,7 +674,7 @@ const OpenRequestOperation = struct {
                 .content_type = .{ .override = "application/json" },
                 .authorization = .{ .override = self.auth_header },
                 .accept_encoding = .omit,
-                .user_agent = .{ .override = gateway_client.user_agent },
+                .user_agent = .{ .override = claude_oauth.messages_user_agent },
             },
             .extra_headers = self.extra_headers,
             .keep_alive = false,

--- a/src/gateway/anthropic_claude_cli.zig
+++ b/src/gateway/anthropic_claude_cli.zig
@@ -1,0 +1,1146 @@
+const std = @import("std");
+const claude_code_store = @import("../core/auth/claude_code_store.zig");
+const debug_trace = @import("../core/shared/debug_trace.zig");
+const host_target = @import("../core/hosts/target.zig");
+const io_mod = @import("../core/shared/io.zig");
+const secret = @import("../core/auth/secret.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const types = @import("../core/shared/types.zig");
+
+const Allocator = std.mem.Allocator;
+const generation_origin = "claude-code";
+const max_line_bytes: usize = 1024 * 1024;
+const stdout_poll_ms: i32 = 50;
+
+pub const missing_cli_message = "fx needs the Claude Code CLI on PATH. Install Claude Code and run claude auth login.";
+
+pub fn streamCompletion(alloc: Allocator, request: stream_provider.Request) !stream_provider.Result {
+    if (comptime host_target.is_wasm) return error.ClaudeOAuthUnavailable;
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    const cli = (try claude_code_store.findCli(alloc)) orelse {
+        return .{
+            .status = .unauthorized,
+            .err_body = try alloc.dupe(u8, missing_cli_message),
+            .ownership = .owned,
+        };
+    };
+    defer alloc.free(cli);
+
+    var prompt = try extractPrompt(alloc, request.payload);
+    defer prompt.deinit(alloc);
+
+    var argv_store: std.ArrayList([]const u8) = .empty;
+    defer argv_store.deinit(alloc);
+    const claude_tools = claude_code_store.claudeCodeToolsEnabled();
+    try appendSpawnArgs(alloc, &argv_store, cli, request.model, claude_tools);
+
+    debug_trace.logf("auth", "Claude Agent SDK spawn model={s} claude_tools={}", .{ request.model, claude_tools });
+    var child = std.process.spawn(io_mod.getIo(), .{
+        .argv = argv_store.items,
+        .stdin = .pipe,
+        .stdout = .pipe,
+        .stderr = .ignore,
+        .pgid = 0,
+    }) catch |err| {
+        debug_trace.logf("auth", "Claude Agent SDK spawn failed err={s}", .{@errorName(err)});
+        return .{
+            .status = .bad_gateway,
+            .err_body = try alloc.dupe(u8, "fx could not start the Claude Code CLI"),
+            .ownership = .owned,
+        };
+    };
+    var child_owned = true;
+    errdefer if (child_owned) {
+        killChild(&child);
+        reapChild(&child);
+    };
+
+    var stdin = child.stdin orelse return error.ClaudeAgentSdkSpawnFailed;
+    child.stdin = null;
+    var stdout = child.stdout orelse return error.ClaudeAgentSdkSpawnFailed;
+    child.stdout = null;
+
+    const user_line = try encodeUserMessage(alloc, prompt.user);
+    defer secret.zeroAndFree(alloc, user_line);
+
+    var consumed = consumeCliStream(
+        alloc,
+        stdin,
+        stdout,
+        request.callback_ctx,
+        request.on_content_chunk,
+        request.on_tool_start,
+        request.on_reasoning_chunk,
+        request.cancel_flag,
+        request.cooperative_pulse,
+        request.content_capture_limit,
+        claude_tools,
+        prompt.tools_json,
+        user_line,
+        request.delivery,
+    ) catch |err| {
+        stdin.close(io_mod.getIo());
+        stdout.close(io_mod.getIo());
+        killChild(&child);
+        reapChild(&child);
+        child_owned = false;
+        if (err == error.Cancelled or request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        return err;
+    };
+
+    stdin.close(io_mod.getIo());
+    stdout.close(io_mod.getIo());
+    reapChild(&child);
+    child_owned = false;
+
+    if (request.cancel_flag.load(.seq_cst)) {
+        consumed.deinit(alloc);
+        return error.Cancelled;
+    }
+    if (consumed.failed) {
+        const err_body = consumed.err_body orelse try alloc.dupe(u8, "Claude Code Agent SDK turn failed");
+        consumed.err_body = null;
+        consumed.deinit(alloc);
+        return .{
+            .status = .bad_gateway,
+            .err_body = err_body,
+            .generation_origin = generation_origin,
+            .ownership = .owned,
+        };
+    }
+    if (consumed.err_body) |body| alloc.free(body);
+    return .{
+        .status = .ok,
+        .completion = consumed.completion,
+        .generation_origin = generation_origin,
+        .ownership = .owned,
+    };
+}
+
+const Prompt = struct {
+    user: []u8,
+    tools_json: []u8,
+
+    fn deinit(self: *Prompt, alloc: Allocator) void {
+        alloc.free(self.user);
+        alloc.free(self.tools_json);
+        self.* = undefined;
+    }
+};
+
+const Handshake = struct {
+    init_acked: bool = false,
+    system_init: bool = false,
+    tools_listed: bool = false,
+    mcp_initialized: bool = false,
+
+    fn ready(self: Handshake, claude_tools: bool) bool {
+        if (claude_tools) return self.init_acked or self.system_init;
+        return self.tools_listed or self.system_init;
+    }
+};
+
+fn appendSpawnArgs(
+    alloc: Allocator,
+    argv: *std.ArrayList([]const u8),
+    cli: []const u8,
+    model: []const u8,
+    claude_tools: bool,
+) !void {
+    try argv.appendSlice(alloc, &.{
+        cli,
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--input-format",
+        "stream-json",
+        "--include-partial-messages",
+        "--verbose",
+        "--permission-prompt-tool",
+        "stdio",
+        "--permission-mode",
+        "bypassPermissions",
+        "--allow-dangerously-skip-permissions",
+        "--strict-mcp-config",
+        "--disable-slash-commands",
+        "--no-session-persistence",
+        "--no-chrome",
+        "--model",
+        model,
+    });
+    if (!claude_tools) {
+        try argv.appendSlice(alloc, &.{
+            "--tools=",
+            "--setting-sources=",
+        });
+    }
+}
+
+const ConsumedStream = struct {
+    completion: types.GatewayCompletion = .{},
+    err_body: ?[]u8 = null,
+    failed: bool = false,
+
+    fn deinit(self: *ConsumedStream, alloc: Allocator) void {
+        if (self.completion.content) |content| alloc.free(@constCast(content));
+        if (self.completion.generation_id) |id| alloc.free(@constCast(id));
+        types.freeToolCallSlice(alloc, @constCast(self.completion.tool_calls));
+        if (self.err_body) |body| alloc.free(body);
+        self.* = undefined;
+    }
+};
+
+fn extractPrompt(alloc: Allocator, payload: []const u8) !Prompt {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, payload, .{}) catch
+        return error.InvalidAnthropicClaudeRequest;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidAnthropicClaudeRequest;
+    const user = try conversationText(alloc, parsed.value.object.get("messages"));
+    errdefer alloc.free(user);
+    const tools_json = try extractToolsJson(alloc, parsed.value.object.get("tools"));
+    return .{ .user = user, .tools_json = tools_json };
+}
+
+fn extractToolsJson(alloc: Allocator, tools_value: ?std.json.Value) ![]u8 {
+    const tools = tools_value orelse return alloc.dupe(u8, "[]");
+    if (tools != .array) return alloc.dupe(u8, "[]");
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try std.json.Stringify.value(tools, .{}, &out.writer);
+    return out.toOwnedSlice();
+}
+
+fn conversationText(alloc: Allocator, messages_value: ?std.json.Value) ![]u8 {
+    const messages = messages_value orelse return error.InvalidAnthropicClaudeRequest;
+    if (messages != .array or messages.array.items.len == 0) return error.InvalidAnthropicClaudeRequest;
+
+    var user_count: usize = 0;
+    var other_count: usize = 0;
+    for (messages.array.items) |message| {
+        if (message != .object) continue;
+        const role = stringField(message.object, "role") orelse continue;
+        if (std.mem.eql(u8, role, "user")) {
+            user_count += 1;
+        } else if (std.mem.eql(u8, role, "assistant") or std.mem.eql(u8, role, "tool")) {
+            other_count += 1;
+        }
+    }
+    if (user_count == 0) return error.InvalidAnthropicClaudeRequest;
+    if (user_count == 1 and other_count == 0) return lastUserText(alloc, messages_value);
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    var first = true;
+    for (messages.array.items) |message| {
+        if (message != .object) continue;
+        const role = stringField(message.object, "role") orelse continue;
+        const label: []const u8 = if (std.mem.eql(u8, role, "user"))
+            "User"
+        else if (std.mem.eql(u8, role, "assistant"))
+            "Assistant"
+        else if (std.mem.eql(u8, role, "tool"))
+            "Tool"
+        else
+            continue;
+        const text = try messagePlainText(alloc, message.object);
+        defer alloc.free(text);
+        if (text.len == 0) continue;
+        if (!first) try out.writer.writeAll("\n\n");
+        try out.writer.writeAll(label);
+        try out.writer.writeAll(": ");
+        try out.writer.writeAll(text);
+        first = false;
+    }
+    if (out.written().len == 0) return error.InvalidAnthropicClaudeRequest;
+    return out.toOwnedSlice();
+}
+
+fn lastUserText(alloc: Allocator, messages_value: ?std.json.Value) ![]u8 {
+    const messages = messages_value orelse return error.InvalidAnthropicClaudeRequest;
+    if (messages != .array or messages.array.items.len == 0) return error.InvalidAnthropicClaudeRequest;
+    var index = messages.array.items.len;
+    while (index > 0) {
+        index -= 1;
+        const message = messages.array.items[index];
+        if (message != .object) continue;
+        const role = stringField(message.object, "role") orelse continue;
+        if (!std.mem.eql(u8, role, "user")) continue;
+        return messagePlainText(alloc, message.object);
+    }
+    return error.InvalidAnthropicClaudeRequest;
+}
+
+fn messagePlainText(alloc: Allocator, message: std.json.ObjectMap) ![]u8 {
+    const content = message.get("content") orelse return alloc.dupe(u8, "");
+    if (content == .string) return alloc.dupe(u8, content.string);
+    if (content != .array) return alloc.dupe(u8, "");
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    for (content.array.items) |part| {
+        if (part != .object) continue;
+        const part_type = stringField(part.object, "type") orelse continue;
+        if (std.mem.eql(u8, part_type, "text")) {
+            const text = stringField(part.object, "text") orelse continue;
+            if (text.len == 0) continue;
+            if (out.written().len > 0) try out.writer.writeAll("\n");
+            try out.writer.writeAll(text);
+        } else if (std.mem.eql(u8, part_type, "tool_result")) {
+            const text = stringField(part.object, "content") orelse continue;
+            if (text.len == 0) continue;
+            if (out.written().len > 0) try out.writer.writeAll("\n");
+            try out.writer.writeAll(text);
+        } else if (std.mem.eql(u8, part_type, "tool_use")) {
+            const name = stringField(part.object, "name") orelse continue;
+            if (out.written().len > 0) try out.writer.writeAll("\n");
+            try out.writer.writeAll("[tool ");
+            try out.writer.writeAll(name);
+            try out.writer.writeAll("]");
+        }
+    }
+    return out.toOwnedSlice();
+}
+
+fn encodeUserMessage(alloc: Allocator, user: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"type\":\"user\",\"parent_tool_use_id\":null,\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":");
+    try std.json.Stringify.value(user, .{}, &out.writer);
+    try out.writer.writeAll("}]}}\n");
+    return out.toOwnedSlice();
+}
+
+fn encodeControlAllow(alloc: Allocator, request_id: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":");
+    try std.json.Stringify.value(request_id, .{}, &out.writer);
+    try out.writer.writeAll(",\"response\":{\"behavior\":\"allow\"}}}\n");
+    return out.toOwnedSlice();
+}
+
+fn encodeInitialize(alloc: Allocator, claude_tools: bool) ![]u8 {
+    if (claude_tools) {
+        return alloc.dupe(
+            u8,
+            "{\"type\":\"control_request\",\"request_id\":\"fx-init-1\",\"request\":{\"subtype\":\"initialize\"}}\n",
+        );
+    }
+    return alloc.dupe(
+        u8,
+        "{\"type\":\"control_request\",\"request_id\":\"fx-init-1\",\"request\":{\"subtype\":\"initialize\",\"sdkMcpServers\":[\"fx\"]}}\n",
+    );
+}
+
+fn encodeMcpControlResult(alloc: Allocator, request_id: []const u8, rpc_id: std.json.Value, result_json: []const u8) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":");
+    try std.json.Stringify.value(request_id, .{}, &out.writer);
+    try out.writer.writeAll(",\"response\":{\"mcp_response\":{\"jsonrpc\":\"2.0\",\"id\":");
+    try std.json.Stringify.value(rpc_id, .{}, &out.writer);
+    try out.writer.writeAll(",\"result\":");
+    try out.writer.writeAll(result_json);
+    try out.writer.writeAll("}}}}\n");
+    return out.toOwnedSlice();
+}
+
+fn consumeCliStream(
+    alloc: Allocator,
+    stdin: std.Io.File,
+    stdout: std.Io.File,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    cancel_flag: *std.atomic.Value(bool),
+    cooperative_pulse: ?stream_provider.CooperativePulse,
+    content_capture_limit: ?usize,
+    claude_tools: bool,
+    tools_json: []const u8,
+    user_line: []const u8,
+    delivery: *stream_provider.DeliveryCertainty,
+) !ConsumedStream {
+    var line: std.ArrayList(u8) = .empty;
+    defer line.deinit(alloc);
+    var content: std.ArrayList(u8) = .empty;
+    defer content.deinit(alloc);
+    var host_tool_calls: std.ArrayList(types.ToolCall) = .empty;
+    defer host_tool_calls.deinit(alloc);
+    errdefer for (host_tool_calls.items) |call| types.freeToolCall(alloc, call);
+    var saw_text_delta = false;
+    var done = false;
+    var is_error = false;
+    var intercept_idle: u8 = 0;
+    var handshake_polls: u32 = 0;
+    var user_sent = false;
+    var handshake = Handshake{};
+    var generation_id: ?[]u8 = null;
+    errdefer if (generation_id) |id| alloc.free(id);
+    var err_body: ?[]u8 = null;
+    errdefer if (err_body) |body| alloc.free(body);
+    var read_buf: [8192]u8 = undefined;
+
+    const init_line = try encodeInitialize(alloc, claude_tools);
+    defer alloc.free(init_line);
+    stdin.writeStreamingAll(io_mod.getIo(), init_line) catch |err| {
+        debug_trace.logf("auth", "Claude Agent SDK initialize failed err={s}", .{@errorName(err)});
+        return error.ClaudeAgentSdkWriteFailed;
+    };
+
+    const handshake_timeout_polls: u32 = if (claude_tools) 100 else 300;
+
+    while (!done) {
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        if (!user_sent and (handshake.ready(claude_tools) or handshake_polls >= handshake_timeout_polls)) {
+            if (!handshake.ready(claude_tools)) {
+                debug_trace.logf(
+                    "auth",
+                    "Claude Agent SDK handshake timeout init_acked={} system_init={} tools_listed={}",
+                    .{ handshake.init_acked, handshake.system_init, handshake.tools_listed },
+                );
+            }
+            delivery.markPossiblySent();
+            stdin.writeStreamingAll(io_mod.getIo(), user_line) catch |err| {
+                debug_trace.logf("auth", "Claude Agent SDK stdin write failed err={s}", .{@errorName(err)});
+                return error.ClaudeAgentSdkWriteFailed;
+            };
+            user_sent = true;
+            debug_trace.logf(
+                "auth",
+                "Claude Agent SDK user sent init_acked={} system_init={} tools_listed={}",
+                .{ handshake.init_acked, handshake.system_init, handshake.tools_listed },
+            );
+        }
+        if (!try stdoutReady(stdout.handle, stdout_poll_ms)) {
+            if (cooperative_pulse) |pulse| try pulse.pulse();
+            if (!user_sent) handshake_polls += 1;
+            if (!claude_tools and host_tool_calls.items.len > 0) {
+                intercept_idle += 1;
+                if (intercept_idle >= 4) break;
+            }
+            continue;
+        }
+        intercept_idle = 0;
+        const n = stdout.readStreaming(io_mod.getIo(), &.{read_buf[0..]}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        for (read_buf[0..n]) |byte| {
+            if (byte == '\n') {
+                if (line.items.len > 0) {
+                    const outcome = try applyStreamJsonLine(
+                        alloc,
+                        line.items,
+                        stdin,
+                        callback_ctx,
+                        on_content_chunk,
+                        on_tool_start,
+                        on_reasoning_chunk,
+                        &content,
+                        &saw_text_delta,
+                        &generation_id,
+                        &err_body,
+                        content_capture_limit,
+                        claude_tools,
+                        tools_json,
+                        &host_tool_calls,
+                        &handshake,
+                    );
+                    line.clearRetainingCapacity();
+                    switch (outcome) {
+                        .more => {},
+                        .tools => {},
+                        .done => done = true,
+                        .failed => {
+                            is_error = true;
+                            done = true;
+                        },
+                    }
+                }
+            } else {
+                if (line.items.len >= max_line_bytes) return error.ClaudeAgentSdkLineTooLarge;
+                try line.append(alloc, byte);
+            }
+            if (done) break;
+        }
+    }
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (!done and host_tool_calls.items.len == 0) return error.ClaudeAgentSdkStreamIncomplete;
+
+    const owned_tools = try host_tool_calls.toOwnedSlice(alloc);
+    errdefer types.freeToolCallSlice(alloc, owned_tools);
+    host_tool_calls = .empty;
+    return .{
+        .completion = .{
+            .content = if (content.items.len > 0) try content.toOwnedSlice(alloc) else null,
+            .tool_calls = owned_tools,
+            .generation_id = generation_id,
+            .finish_reason = if (is_error)
+                .provider_error
+            else if (owned_tools.len > 0)
+                .tool_calls
+            else
+                .stop,
+        },
+        .err_body = err_body,
+        .failed = is_error,
+    };
+}
+
+const LineOutcome = enum { more, done, failed, tools };
+
+fn applyStreamJsonLine(
+    alloc: Allocator,
+    line: []const u8,
+    stdin: ?std.Io.File,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    content: *std.ArrayList(u8),
+    saw_text_delta: *bool,
+    generation_id: *?[]u8,
+    err_body: *?[]u8,
+    content_capture_limit: ?usize,
+    claude_tools: bool,
+    tools_json: []const u8,
+    host_tool_calls: *std.ArrayList(types.ToolCall),
+    handshake: ?*Handshake,
+) !LineOutcome {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, line, .{}) catch return .more;
+    defer parsed.deinit();
+    if (parsed.value != .object) return .more;
+    const object = parsed.value.object;
+    const event_type = stringField(object, "type") orelse return .more;
+    if (std.mem.eql(u8, event_type, "control_response") or std.mem.eql(u8, event_type, "sdk_control_response")) {
+        if (handshake) |hs| {
+            if (controlResponseRequestId(object)) |id| {
+                if (std.mem.eql(u8, id, "fx-init-1")) hs.init_acked = true;
+            }
+        }
+        return .more;
+    }
+    if (std.mem.eql(u8, event_type, "control_request") or std.mem.eql(u8, event_type, "sdk_control_request")) {
+        return handleControlRequest(
+            alloc,
+            stdin,
+            object,
+            callback_ctx,
+            on_tool_start,
+            claude_tools,
+            tools_json,
+            host_tool_calls,
+            handshake,
+        );
+    }
+    if (std.mem.eql(u8, event_type, "system")) {
+        try captureSessionId(alloc, object, generation_id);
+        const subtype = stringField(object, "subtype") orelse "";
+        if (handshake) |hs| {
+            if (std.mem.eql(u8, subtype, "init")) hs.system_init = true;
+        }
+        return .more;
+    }
+    if (std.mem.eql(u8, event_type, "result")) {
+        try captureSessionId(alloc, object, generation_id);
+        const subtype = stringField(object, "subtype") orelse "success";
+        const failed = if (object.get("is_error")) |flag|
+            flag == .bool and flag.bool
+        else
+            !(std.mem.eql(u8, subtype, "success") or std.mem.eql(u8, subtype, "error_max_turns"));
+        if (!failed and !saw_text_delta.*) {
+            if (stringField(object, "result")) |text| {
+                if (text.len > 0) {
+                    on_content_chunk(callback_ctx, text);
+                    try appendCaptured(alloc, content, text, content_capture_limit);
+                }
+            }
+        }
+        if (failed) {
+            const text = stringField(object, "result") orelse stringField(object, "error") orelse "Claude Code Agent SDK turn failed";
+            if (err_body.*) |old| alloc.free(old);
+            err_body.* = try alloc.dupe(u8, text);
+            return .failed;
+        }
+        return .done;
+    }
+    if (std.mem.eql(u8, event_type, "stream_event")) {
+        const event = object.get("event") orelse return .more;
+        if (event != .object) return .more;
+        try applyApiStreamEvent(
+            alloc,
+            event.object,
+            callback_ctx,
+            on_content_chunk,
+            on_tool_start,
+            on_reasoning_chunk,
+            content,
+            saw_text_delta,
+            generation_id,
+            content_capture_limit,
+        );
+        return .more;
+    }
+    if (std.mem.eql(u8, event_type, "assistant") and !saw_text_delta.*) {
+        const message = object.get("message") orelse return .more;
+        if (message != .object) return .more;
+        try captureAssistantText(alloc, message.object, callback_ctx, on_content_chunk, on_tool_start, content, content_capture_limit);
+        return .more;
+    }
+    return .more;
+}
+
+fn handleControlRequest(
+    alloc: Allocator,
+    stdin: ?std.Io.File,
+    object: std.json.ObjectMap,
+    callback_ctx: *anyopaque,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    claude_tools: bool,
+    tools_json: []const u8,
+    host_tool_calls: *std.ArrayList(types.ToolCall),
+    handshake: ?*Handshake,
+) !LineOutcome {
+    const request = object.get("request");
+    const request_object = if (request) |value| if (value == .object) value.object else null else null;
+    const subtype = if (request_object) |req| stringField(req, "subtype") else stringField(object, "subtype");
+    if (!claude_tools) {
+        if (subtype) |kind| {
+            if (std.mem.eql(u8, kind, "mcp_message")) {
+                if (try interceptMcpToolCall(alloc, request_object, callback_ctx, on_tool_start, host_tool_calls))
+                    return .tools;
+                try answerMcpMessage(alloc, stdin, object, request_object, tools_json, handshake);
+                return .more;
+            }
+            if (std.mem.eql(u8, kind, "can_use_tool")) {
+                if (try interceptHostTool(alloc, object, request_object, callback_ctx, on_tool_start, host_tool_calls))
+                    return .tools;
+            }
+        }
+    }
+    try answerControlAllow(alloc, stdin, object);
+    return .more;
+}
+
+fn answerControlAllow(alloc: Allocator, stdin: ?std.Io.File, object: std.json.ObjectMap) !void {
+    const dest = stdin orelse return;
+    const request_id = controlRequestId(object) orelse return;
+    const line = try encodeControlAllow(alloc, request_id);
+    defer alloc.free(line);
+    dest.writeStreamingAll(io_mod.getIo(), line) catch |err| {
+        debug_trace.logf("auth", "Claude Agent SDK control reply failed err={s}", .{@errorName(err)});
+        return error.ClaudeAgentSdkWriteFailed;
+    };
+}
+
+fn answerMcpMessage(
+    alloc: Allocator,
+    stdin: ?std.Io.File,
+    object: std.json.ObjectMap,
+    request_object: ?std.json.ObjectMap,
+    tools_json: []const u8,
+    handshake: ?*Handshake,
+) !void {
+    const dest = stdin orelse return;
+    const request_id = controlRequestId(object) orelse return;
+    const req = request_object orelse return;
+    const message = req.get("message") orelse return;
+    if (message != .object) return;
+    const method = stringField(message.object, "method") orelse return;
+    const rpc_id = message.object.get("id") orelse {
+        try answerControlAllow(alloc, dest, object);
+        return;
+    };
+    const result_json = if (std.mem.eql(u8, method, "initialize"))
+        "{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{\"tools\":{\"listChanged\":false}},\"serverInfo\":{\"name\":\"fx\",\"version\":\"0.1\"}}"
+    else if (std.mem.eql(u8, method, "tools/list"))
+        try mcpToolsListJson(alloc, tools_json)
+    else if (std.mem.eql(u8, method, "tools/call"))
+        "{\"content\":[{\"type\":\"text\",\"text\":\"handed to fx\"}]}"
+    else
+        return;
+    const owned_list = std.mem.eql(u8, method, "tools/list");
+    defer if (owned_list) alloc.free(result_json);
+    const line = try encodeMcpControlResult(alloc, request_id, rpc_id, result_json);
+    defer alloc.free(line);
+    dest.writeStreamingAll(io_mod.getIo(), line) catch |err| {
+        debug_trace.logf("auth", "Claude Agent SDK MCP reply failed err={s}", .{@errorName(err)});
+        return error.ClaudeAgentSdkWriteFailed;
+    };
+    if (handshake) |hs| {
+        if (std.mem.eql(u8, method, "initialize")) hs.mcp_initialized = true;
+        if (std.mem.eql(u8, method, "tools/list")) hs.tools_listed = true;
+    }
+}
+
+fn interceptMcpToolCall(
+    alloc: Allocator,
+    request_object: ?std.json.ObjectMap,
+    callback_ctx: *anyopaque,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    host_tool_calls: *std.ArrayList(types.ToolCall),
+) !bool {
+    const req = request_object orelse return false;
+    const message = req.get("message") orelse return false;
+    if (message != .object) return false;
+    const method = stringField(message.object, "method") orelse return false;
+    if (!std.mem.eql(u8, method, "tools/call")) return false;
+    const params = message.object.get("params") orelse return false;
+    if (params != .object) return false;
+    const name = stringField(params.object, "name") orelse return false;
+    const fx_name = hostToolName(name) orelse name;
+    const id = stringField(message.object, "id") orelse fx_name;
+    const arguments = if (params.object.get("arguments")) |value|
+        try stringifyJsonValue(alloc, value)
+    else
+        try alloc.dupe(u8, "{}");
+    errdefer alloc.free(arguments);
+    try appendHostToolCall(alloc, host_tool_calls, id, fx_name, arguments, callback_ctx, on_tool_start);
+    return true;
+}
+
+fn interceptHostTool(
+    alloc: Allocator,
+    object: std.json.ObjectMap,
+    request_object: ?std.json.ObjectMap,
+    callback_ctx: *anyopaque,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    host_tool_calls: *std.ArrayList(types.ToolCall),
+) !bool {
+    const req = request_object orelse object;
+    const name = stringField(req, "tool_name") orelse return false;
+    const fx_name = hostToolName(name) orelse return false;
+    const id = stringField(req, "tool_use_id") orelse fx_name;
+    const arguments = if (req.get("input")) |value|
+        try stringifyJsonValue(alloc, value)
+    else
+        try alloc.dupe(u8, "{}");
+    errdefer alloc.free(arguments);
+    try appendHostToolCall(alloc, host_tool_calls, id, fx_name, arguments, callback_ctx, on_tool_start);
+    return true;
+}
+
+fn appendHostToolCall(
+    alloc: Allocator,
+    host_tool_calls: *std.ArrayList(types.ToolCall),
+    id: []const u8,
+    name: []const u8,
+    arguments: []u8,
+    callback_ctx: *anyopaque,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+) !void {
+    for (host_tool_calls.items) |existing| {
+        if (std.mem.eql(u8, existing.id, id)) {
+            alloc.free(arguments);
+            return;
+        }
+    }
+    const owned_id = try alloc.dupe(u8, id);
+    errdefer alloc.free(owned_id);
+    const owned_name = try alloc.dupe(u8, name);
+    errdefer alloc.free(owned_name);
+    try host_tool_calls.append(alloc, .{
+        .id = owned_id,
+        .name = owned_name,
+        .arguments_json = arguments,
+    });
+    if (on_tool_start) |callback| callback(callback_ctx, owned_id, owned_name, null);
+}
+
+fn hostToolName(name: []const u8) ?[]const u8 {
+    const prefix = "mcp__fx__";
+    if (std.mem.startsWith(u8, name, prefix)) return name[prefix.len..];
+    if (std.mem.eql(u8, name, "Read")) return "read_file";
+    if (std.mem.eql(u8, name, "Write")) return "write_file";
+    if (std.mem.eql(u8, name, "Edit") or std.mem.eql(u8, name, "StrReplace")) return "edit_file";
+    if (std.mem.eql(u8, name, "Bash")) return "terminal";
+    if (std.mem.eql(u8, name, "Grep")) return "grep_files";
+    if (std.mem.eql(u8, name, "Glob")) return "glob_files";
+    if (std.mem.eql(u8, name, "LS")) return "list_files";
+    if (std.mem.eql(u8, name, "WebFetch")) return "web_fetch";
+    if (std.mem.eql(u8, name, "WebSearch")) return "web_search";
+    return name;
+}
+
+fn stringifyJsonValue(alloc: Allocator, value: std.json.Value) ![]u8 {
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try std.json.Stringify.value(value, .{}, &out.writer);
+    return out.toOwnedSlice();
+}
+
+fn mcpToolsListJson(alloc: Allocator, tools_json: []const u8) ![]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, tools_json, .{}) catch
+        return alloc.dupe(u8, "{\"tools\":[]}");
+    defer parsed.deinit();
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    try out.writer.writeAll("{\"tools\":[");
+    var first = true;
+    if (parsed.value == .array) {
+        for (parsed.value.array.items) |tool| {
+            if (tool != .object) continue;
+            const name = stringField(tool.object, "name") orelse continue;
+            if (!first) try out.writer.writeByte(',');
+            first = false;
+            try out.writer.writeAll("{\"name\":");
+            try std.json.Stringify.value(name, .{}, &out.writer);
+            if (stringField(tool.object, "description")) |description| {
+                try out.writer.writeAll(",\"description\":");
+                try std.json.Stringify.value(description, .{}, &out.writer);
+            }
+            const schema = tool.object.get("input_schema") orelse tool.object.get("inputSchema");
+            if (schema) |value| {
+                try out.writer.writeAll(",\"inputSchema\":");
+                try std.json.Stringify.value(value, .{}, &out.writer);
+            }
+            try out.writer.writeByte('}');
+        }
+    }
+    try out.writer.writeAll("]}");
+    return out.toOwnedSlice();
+}
+
+fn controlRequestId(object: std.json.ObjectMap) ?[]const u8 {
+    if (stringField(object, "request_id")) |id| return id;
+    const request = object.get("request") orelse return null;
+    if (request != .object) return null;
+    return stringField(request.object, "request_id");
+}
+
+fn controlResponseRequestId(object: std.json.ObjectMap) ?[]const u8 {
+    if (stringField(object, "request_id")) |id| return id;
+    const response = object.get("response") orelse return null;
+    if (response != .object) return null;
+    return stringField(response.object, "request_id");
+}
+
+fn captureSessionId(alloc: Allocator, object: std.json.ObjectMap, generation_id: *?[]u8) !void {
+    const id = stringField(object, "session_id") orelse return;
+    if (id.len == 0) return;
+    if (generation_id.*) |old| alloc.free(old);
+    generation_id.* = try alloc.dupe(u8, id);
+}
+
+fn applyApiStreamEvent(
+    alloc: Allocator,
+    event: std.json.ObjectMap,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    on_reasoning_chunk: ?stream_provider.StreamCallback,
+    content: *std.ArrayList(u8),
+    saw_text_delta: *bool,
+    generation_id: *?[]u8,
+    content_capture_limit: ?usize,
+) !void {
+    const event_type = stringField(event, "type") orelse return;
+    if (std.mem.eql(u8, event_type, "message_start")) {
+        if (event.get("message")) |message| {
+            if (message == .object) {
+                if (stringField(message.object, "id")) |id| {
+                    if (generation_id.* == null) generation_id.* = try alloc.dupe(u8, id);
+                }
+            }
+        }
+        return;
+    }
+    if (std.mem.eql(u8, event_type, "content_block_start")) {
+        const block = event.get("content_block") orelse return;
+        if (block != .object) return;
+        if (std.mem.eql(u8, stringField(block.object, "type") orelse "", "tool_use")) {
+            const name = stringField(block.object, "name") orelse return;
+            const tool_id = stringField(block.object, "id") orelse name;
+            if (on_tool_start) |callback| callback(callback_ctx, tool_id, name, null);
+        }
+        return;
+    }
+    if (!std.mem.eql(u8, event_type, "content_block_delta")) return;
+    const delta = event.get("delta") orelse return;
+    if (delta != .object) return;
+    const delta_type = stringField(delta.object, "type") orelse return;
+    if (std.mem.eql(u8, delta_type, "text_delta")) {
+        const text = stringField(delta.object, "text") orelse return;
+        saw_text_delta.* = true;
+        on_content_chunk(callback_ctx, text);
+        try appendCaptured(alloc, content, text, content_capture_limit);
+    } else if (std.mem.eql(u8, delta_type, "thinking_delta")) {
+        const thinking = stringField(delta.object, "thinking") orelse return;
+        if (on_reasoning_chunk) |callback| callback(callback_ctx, thinking);
+    }
+}
+
+fn captureAssistantText(
+    alloc: Allocator,
+    message: std.json.ObjectMap,
+    callback_ctx: *anyopaque,
+    on_content_chunk: stream_provider.StreamCallback,
+    on_tool_start: ?stream_provider.ToolStartCallback,
+    content: *std.ArrayList(u8),
+    content_capture_limit: ?usize,
+) !void {
+    const value = message.get("content") orelse return;
+    if (value == .string) {
+        if (value.string.len == 0) return;
+        on_content_chunk(callback_ctx, value.string);
+        try appendCaptured(alloc, content, value.string, content_capture_limit);
+        return;
+    }
+    if (value != .array) return;
+    for (value.array.items) |part| {
+        if (part != .object) continue;
+        const part_type = stringField(part.object, "type") orelse continue;
+        if (std.mem.eql(u8, part_type, "tool_use")) {
+            const name = stringField(part.object, "name") orelse continue;
+            const tool_id = stringField(part.object, "id") orelse name;
+            if (on_tool_start) |callback| callback(callback_ctx, tool_id, name, null);
+            continue;
+        }
+        if (!std.mem.eql(u8, part_type, "text")) continue;
+        const text = stringField(part.object, "text") orelse continue;
+        if (text.len == 0) continue;
+        on_content_chunk(callback_ctx, text);
+        try appendCaptured(alloc, content, text, content_capture_limit);
+    }
+}
+
+fn appendCaptured(alloc: Allocator, content: *std.ArrayList(u8), text: []const u8, limit: ?usize) !void {
+    const remaining = if (limit) |max| std.math.sub(usize, max, content.items.len) catch 0 else text.len;
+    if (remaining == 0) return;
+    try content.appendSlice(alloc, text[0..@min(text.len, remaining)]);
+}
+
+fn stringField(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    return if (value == .string) value.string else null;
+}
+
+fn stdoutReady(handle: std.posix.fd_t, timeout_ms: i32) !bool {
+    var fds = [_]std.posix.pollfd{.{
+        .fd = handle,
+        .events = std.posix.POLL.IN,
+        .revents = 0,
+    }};
+    const ready = try std.posix.poll(&fds, timeout_ms);
+    if (ready == 0) return false;
+    if ((fds[0].revents & (std.posix.POLL.HUP | std.posix.POLL.ERR | std.posix.POLL.NVAL)) != 0) {
+        return ready > 0;
+    }
+    return (fds[0].revents & std.posix.POLL.IN) != 0;
+}
+
+fn killChild(child: *std.process.Child) void {
+    if (child.id) |pid| {
+        std.posix.kill(pid, std.posix.SIG.INT) catch {};
+    }
+}
+
+fn reapChild(child: *std.process.Child) void {
+    _ = child.wait(io_mod.getIo()) catch {};
+}
+
+test "Claude Agent SDK flattens multi-turn conversation text" {
+    const alloc = std.testing.allocator;
+    var prompt = try extractPrompt(
+        alloc,
+        "{\"system\":\"Be brief.\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"first\"}]},{\"role\":\"assistant\",\"content\":\"ok\"},{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"second\"}]}]}",
+    );
+    defer prompt.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, prompt.user, "first") != null);
+    try std.testing.expect(std.mem.find(u8, prompt.user, "second") != null);
+    try std.testing.expect(std.mem.find(u8, prompt.user, "User:") != null);
+}
+
+test "Claude Agent SDK keeps a single user prompt unprefixed" {
+    const alloc = std.testing.allocator;
+    var prompt = try extractPrompt(
+        alloc,
+        "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"pong\"}]}]}",
+    );
+    defer prompt.deinit(alloc);
+    try std.testing.expectEqualStrings("pong", prompt.user);
+}
+
+test "Claude Agent SDK stream-json maps text deltas and result" {
+    const alloc = std.testing.allocator;
+    const Sink = struct {
+        text: std.ArrayList(u8) = .empty,
+        fn onChunk(raw: *anyopaque, chunk: []const u8) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.text.appendSlice(std.testing.allocator, chunk) catch {};
+        }
+    };
+    var sink = Sink{};
+    defer sink.text.deinit(alloc);
+    var content: std.ArrayList(u8) = .empty;
+    defer content.deinit(alloc);
+    var saw = false;
+    var generation_id: ?[]u8 = null;
+    defer if (generation_id) |id| alloc.free(id);
+    var err_body: ?[]u8 = null;
+    defer if (err_body) |body| alloc.free(body);
+    var host_tool_calls: std.ArrayList(types.ToolCall) = .empty;
+    defer host_tool_calls.deinit(alloc);
+
+    const delta = try applyStreamJsonLine(
+        alloc,
+        "{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hel\"}}}",
+        null,
+        @ptrCast(&sink),
+        Sink.onChunk,
+        null,
+        null,
+        &content,
+        &saw,
+        &generation_id,
+        &err_body,
+        null,
+        true,
+        "[]",
+        &host_tool_calls,
+        null,
+    );
+    try std.testing.expectEqual(LineOutcome.more, delta);
+    const done = try applyStreamJsonLine(
+        alloc,
+        "{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"sess_1\",\"result\":\"Hello\"}",
+        null,
+        @ptrCast(&sink),
+        Sink.onChunk,
+        null,
+        null,
+        &content,
+        &saw,
+        &generation_id,
+        &err_body,
+        null,
+        true,
+        "[]",
+        &host_tool_calls,
+        null,
+    );
+    try std.testing.expectEqual(LineOutcome.done, done);
+    try std.testing.expectEqualStrings("Hel", sink.text.items);
+    try std.testing.expectEqualStrings("Hel", content.items);
+    try std.testing.expectEqualStrings("sess_1", generation_id.?);
+}
+
+test "Claude Agent SDK control allow is stream-json" {
+    const alloc = std.testing.allocator;
+    const line = try encodeControlAllow(alloc, "req_1");
+    defer alloc.free(line);
+    try std.testing.expect(std.mem.find(u8, line, "\"type\":\"control_response\"") != null);
+    try std.testing.expect(std.mem.find(u8, line, "\"request_id\":\"req_1\"") != null);
+    try std.testing.expect(std.mem.find(u8, line, "\"behavior\":\"allow\"") != null);
+    try std.testing.expect(line[line.len - 1] == '\n');
+}
+
+test "Claude host tools map Claude names and MCP prefixes" {
+    try std.testing.expectEqualStrings("read_file", hostToolName("Read").?);
+    try std.testing.expectEqualStrings("terminal", hostToolName("Bash").?);
+    try std.testing.expectEqualStrings("read_file", hostToolName("mcp__fx__read_file").?);
+    try std.testing.expectEqualStrings("web_search", hostToolName("web_search").?);
+}
+
+test "Claude host tools list uses fx schemas" {
+    const alloc = std.testing.allocator;
+    const json = try mcpToolsListJson(
+        alloc,
+        "[{\"name\":\"read_file\",\"description\":\"Read\",\"input_schema\":{\"type\":\"object\"}}]",
+    );
+    defer alloc.free(json);
+    try std.testing.expect(std.mem.find(u8, json, "\"name\":\"read_file\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"inputSchema\"") != null);
+}
+
+test "Claude Agent SDK spawn asks for stdio permission prompts" {
+    const alloc = std.testing.allocator;
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(alloc);
+    try appendSpawnArgs(alloc, &argv, "/bin/claude", "claude-opus-5", true);
+    try std.testing.expect(containsArg(argv.items, "--permission-prompt-tool"));
+    try std.testing.expect(containsArg(argv.items, "stdio"));
+    try std.testing.expect(containsArg(argv.items, "--allow-dangerously-skip-permissions"));
+    try std.testing.expect(containsArg(argv.items, "--strict-mcp-config"));
+    try std.testing.expect(containsArg(argv.items, "--disable-slash-commands"));
+    try std.testing.expect(!containsArg(argv.items, "--replay-user-messages"));
+    try std.testing.expect(!containsArg(argv.items, "--tools="));
+}
+
+test "Claude Agent SDK spawn isolates host tools when Claude tools are off" {
+    const alloc = std.testing.allocator;
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(alloc);
+    try appendSpawnArgs(alloc, &argv, "/bin/claude", "claude-opus-5", false);
+    try std.testing.expect(containsArg(argv.items, "--tools="));
+    try std.testing.expect(containsArg(argv.items, "--setting-sources="));
+    try std.testing.expect(containsArg(argv.items, "--disable-slash-commands"));
+    try std.testing.expect(containsArg(argv.items, "--permission-prompt-tool"));
+}
+
+test "Claude Agent SDK initialize includes fx MCP only when tools are off" {
+    const alloc = std.testing.allocator;
+    const with_fx = try encodeInitialize(alloc, false);
+    defer alloc.free(with_fx);
+    try std.testing.expect(std.mem.find(u8, with_fx, "sdkMcpServers") != null);
+    const without_fx = try encodeInitialize(alloc, true);
+    defer alloc.free(without_fx);
+    try std.testing.expect(std.mem.find(u8, without_fx, "sdkMcpServers") == null);
+}
+
+test "Claude Agent SDK handshake is ready after system init when tools stay on" {
+    var handshake = Handshake{ .system_init = true };
+    try std.testing.expect(handshake.ready(true));
+    try std.testing.expect(handshake.ready(false));
+    handshake = .{ .init_acked = true, .mcp_initialized = true };
+    try std.testing.expect(handshake.ready(true));
+    try std.testing.expect(!handshake.ready(false));
+    handshake.tools_listed = true;
+    try std.testing.expect(handshake.ready(false));
+}
+
+test "Claude Agent SDK acks initialize control_response" {
+    const alloc = std.testing.allocator;
+    const Sink = struct {
+        fn onChunk(_: *anyopaque, _: []const u8) void {}
+    };
+    var sink: u8 = 0;
+    var content: std.ArrayList(u8) = .empty;
+    defer content.deinit(alloc);
+    var saw = false;
+    var generation_id: ?[]u8 = null;
+    defer if (generation_id) |id| alloc.free(id);
+    var err_body: ?[]u8 = null;
+    defer if (err_body) |body| alloc.free(body);
+    var host_tool_calls: std.ArrayList(types.ToolCall) = .empty;
+    defer host_tool_calls.deinit(alloc);
+    var handshake = Handshake{};
+    const outcome = try applyStreamJsonLine(
+        alloc,
+        "{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\",\"request_id\":\"fx-init-1\",\"response\":{}}}",
+        null,
+        @ptrCast(&sink),
+        Sink.onChunk,
+        null,
+        null,
+        &content,
+        &saw,
+        &generation_id,
+        &err_body,
+        null,
+        true,
+        "[]",
+        &host_tool_calls,
+        &handshake,
+    );
+    try std.testing.expectEqual(LineOutcome.more, outcome);
+    try std.testing.expect(handshake.init_acked);
+}
+
+fn containsArg(argv: []const []const u8, wanted: []const u8) bool {
+    for (argv) |arg| {
+        if (std.mem.eql(u8, arg, wanted)) return true;
+    }
+    return false;
+}

--- a/src/gateway/anthropic_claude_models.zig
+++ b/src/gateway/anthropic_claude_models.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const claude_oauth = @import("../core/auth/claude_oauth.zig");
+const claude_session = @import("../core/auth/claude_session.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
 const gateway_provider = @import("../core/gateway/gateway_provider.zig");
 const io_mod = @import("../core/shared/io.zig");
@@ -13,7 +14,7 @@ const max_catalog_bytes: usize = 4 * 1024 * 1024;
 const fetch_timeout_ms: i64 = 30_000;
 const default_models_endpoint = "https://api.anthropic.com/v1/models";
 const e2e_models_endpoint_env = "FX_E2E_ANTHROPIC_CLAUDE_MODELS_URL";
-const anthropic_version = "2023-06-01";
+const anthropic_version = claude_oauth.anthropic_api_version;
 
 pub const model_catalog_provider = model_catalog.Provider{
     .fetch_fn = fetchCatalogForProvider,
@@ -63,7 +64,9 @@ fn fetchCatalogForProvider(
         return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
     const account_id = input.access.accountId() orelse
         return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
-    _ = account_id;
+    if (!claude_session.validAccountId(account_id)) {
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    }
     const request_url = modelsUrl(alloc) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         return .{ .failure = .{ .category = .runtime } };
@@ -76,6 +79,7 @@ fn fetchCatalogForProvider(
         .alloc = alloc,
         .url = request_url,
         .credential = credential,
+        .account_id = account_id,
     };
     var response = gateway_client.runBoundedHttpOperation(
         FetchResponse,
@@ -122,6 +126,7 @@ const FetchOperation = struct {
     alloc: std.mem.Allocator,
     url: []const u8,
     credential: []const u8,
+    account_id: []const u8,
 
     pub fn run(self: *@This()) !FetchResponse {
         var client: std.http.Client = .{ .allocator = self.alloc, .io = io_mod.getIo() };
@@ -131,19 +136,22 @@ const FetchOperation = struct {
         const body_buffer = try self.alloc.alloc(u8, max_catalog_bytes + 1);
         defer secret.zeroAndFree(self.alloc, body_buffer);
         var response_writer = std.Io.Writer.fixed(body_buffer);
+        const extra_headers = [_]std.http.Header{
+            .{ .name = "anthropic-version", .value = anthropic_version },
+            .{ .name = "anthropic-beta", .value = claude_oauth.messages_beta },
+            .{ .name = "anthropic-account-uuid", .value = self.account_id },
+            .{ .name = "originator", .value = claude_oauth.messages_originator },
+            .{ .name = "accept", .value = "application/json" },
+        };
         const result = client.fetch(.{
             .location = .{ .url = self.url },
             .method = .GET,
             .headers = .{
                 .authorization = .{ .override = auth_header },
-                .user_agent = .{ .override = gateway_client.user_agent },
+                .user_agent = .{ .override = claude_oauth.messages_user_agent },
                 .accept_encoding = .omit,
             },
-            .extra_headers = &.{
-                .{ .name = "anthropic-version", .value = anthropic_version },
-                .{ .name = "originator", .value = "fx" },
-                .{ .name = "accept", .value = "application/json" },
-            },
+            .extra_headers = &extra_headers,
             .response_writer = &response_writer,
             .redirect_behavior = .unhandled,
         }) catch |err| switch (err) {

--- a/src/gateway/anthropic_claude_models.zig
+++ b/src/gateway/anthropic_claude_models.zig
@@ -1,0 +1,243 @@
+const std = @import("std");
+const claude_oauth = @import("../core/auth/claude_oauth.zig");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const secret = @import("../core/auth/secret.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+
+const max_catalog_models: usize = 128;
+const max_model_id_bytes: usize = 1024;
+const max_catalog_bytes: usize = 4 * 1024 * 1024;
+const fetch_timeout_ms: i64 = 30_000;
+const default_models_endpoint = "https://api.anthropic.com/v1/models";
+const e2e_models_endpoint_env = "FX_E2E_ANTHROPIC_CLAUDE_MODELS_URL";
+const anthropic_version = "2023-06-01";
+
+pub const model_catalog_provider = model_catalog.Provider{
+    .fetch_fn = fetchCatalogForProvider,
+};
+
+pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
+    .fetch_fn = fetchCliModelCatalog,
+};
+
+fn fetchCliModelCatalog(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: gateway_provider.CliModelCatalogInput,
+) gateway_provider.CliModelCatalogResult {
+    return switch (model_catalog.fetchWithPublicFallback(model_catalog_provider, alloc, .{
+        .access = input.access,
+        .endpoint = input.endpoint,
+        .cancel_flag = input.cancel_flag,
+        .view = .full,
+    })) {
+        .loaded => |loaded| blk: {
+            var catalog = loaded.catalog;
+            defer model_catalog.freeModelCatalog(alloc, &catalog);
+            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
+                .access = loaded.provenance.access,
+                .anonymous_fallback_used = false,
+                .failure = .{ .category = .resource_exhausted },
+            } };
+            break :blk .{ .loaded = .{
+                .ids = ids,
+                .provenance = loaded.provenance,
+            } };
+        },
+        .failed => |failure| .{ .failure = failure },
+    };
+}
+
+fn fetchCatalogForProvider(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: model_catalog.FetchInput,
+) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    if (input.access.credentialSource() != .claude_subscription) {
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    }
+    const credential = input.access.authorizationCredential() orelse
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    const account_id = input.access.accountId() orelse
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    _ = account_id;
+    const request_url = modelsUrl(alloc) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{ .category = .runtime } };
+    };
+    defer alloc.free(request_url);
+
+    var fallback_cancel = std.atomic.Value(bool).init(false);
+    const cancel_flag = input.cancel_flag orelse &fallback_cancel;
+    var operation = FetchOperation{
+        .alloc = alloc,
+        .url = request_url,
+        .credential = credential,
+    };
+    var response = gateway_client.runBoundedHttpOperation(
+        FetchResponse,
+        alloc,
+        cancel_flag,
+        std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+            .clock = .awake,
+            .raw = .fromMilliseconds(fetch_timeout_ms),
+        }),
+        &operation,
+    ) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{
+            .category = if (err == error.Cancelled) .cancellation else .transport,
+            .retryable = err != error.Cancelled,
+        } };
+    };
+    defer response.deinit(alloc);
+    if (response.status != .ok) {
+        return .{ .failure = model_catalog.failureForHttpStatus(response.status) };
+    }
+    var catalog = parseCatalog(alloc, response.body) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{ .category = .malformed_response, .http_status = .ok } };
+    };
+    if (catalog.items.len == 0) {
+        model_catalog.freeModelCatalog(alloc, &catalog);
+        return .{ .failure = .{ .category = .malformed_response, .http_status = .ok } };
+    }
+    return .{ .catalog = catalog };
+}
+
+const FetchResponse = struct {
+    status: std.http.Status,
+    body: []u8,
+
+    pub fn deinit(self: *FetchResponse, alloc: std.mem.Allocator) void {
+        secret.zeroAndFree(alloc, self.body);
+        self.* = undefined;
+    }
+};
+
+const FetchOperation = struct {
+    alloc: std.mem.Allocator,
+    url: []const u8,
+    credential: []const u8,
+
+    pub fn run(self: *@This()) !FetchResponse {
+        var client: std.http.Client = .{ .allocator = self.alloc, .io = io_mod.getIo() };
+        defer client.deinit();
+        const auth_header = try std.fmt.allocPrint(self.alloc, "Bearer {s}", .{self.credential});
+        defer secret.zeroAndFree(self.alloc, auth_header);
+        const body_buffer = try self.alloc.alloc(u8, max_catalog_bytes + 1);
+        defer secret.zeroAndFree(self.alloc, body_buffer);
+        var response_writer = std.Io.Writer.fixed(body_buffer);
+        const result = client.fetch(.{
+            .location = .{ .url = self.url },
+            .method = .GET,
+            .headers = .{
+                .authorization = .{ .override = auth_header },
+                .user_agent = .{ .override = gateway_client.user_agent },
+                .accept_encoding = .omit,
+            },
+            .extra_headers = &.{
+                .{ .name = "anthropic-version", .value = anthropic_version },
+                .{ .name = "originator", .value = "fx" },
+                .{ .name = "accept", .value = "application/json" },
+            },
+            .response_writer = &response_writer,
+            .redirect_behavior = .unhandled,
+        }) catch |err| switch (err) {
+            error.WriteFailed => return error.ClaudeModelCatalogTooLarge,
+            else => return err,
+        };
+        const body = response_writer.buffered();
+        if (body.len > max_catalog_bytes) return error.ClaudeModelCatalogTooLarge;
+        return .{
+            .status = result.status,
+            .body = try self.alloc.dupe(u8, body),
+        };
+    }
+};
+
+fn modelsUrl(alloc: std.mem.Allocator) ![]u8 {
+    return std.fmt.allocPrint(alloc, "{s}", .{
+        io_mod.getenv(e2e_models_endpoint_env) orelse default_models_endpoint,
+    });
+}
+
+fn parseCatalog(
+    alloc: std.mem.Allocator,
+    json_text: []const u8,
+) !std.ArrayList(model_catalog.ModelCatalogEntry) {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, json_text, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidClaudeModelCatalog;
+    const models_value = parsed.value.object.get("data") orelse
+        return error.InvalidClaudeModelCatalog;
+    if (models_value != .array or models_value.array.items.len > max_catalog_models) {
+        return error.InvalidClaudeModelCatalog;
+    }
+
+    var catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    errdefer model_catalog.freeModelCatalog(alloc, &catalog);
+    for (models_value.array.items) |value| {
+        if (value != .object) return error.InvalidClaudeModelCatalog;
+        const object = value.object;
+        const id = try requiredString(object, "id");
+        try validateModelId(id);
+        const owned_id = try alloc.dupe(u8, id);
+        errdefer alloc.free(owned_id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        const context_window = try optionalPositiveU32(object, "context_window");
+        try catalog.append(alloc, .{
+            .id = owned_id,
+            .model_type = model_type,
+            .has_tool_use = true,
+            .has_reasoning = true,
+            .has_vision = true,
+            .has_file_input = true,
+            .has_implicit_caching = true,
+            .context_window = context_window,
+        });
+    }
+    return catalog;
+}
+
+fn optionalPositiveU32(object: std.json.ObjectMap, key: []const u8) !u32 {
+    const value = object.get(key) orelse return 0;
+    if (value == .null) return 0;
+    if (value != .integer or value.integer < 0) return error.InvalidClaudeModelCatalog;
+    return std.math.cast(u32, value.integer) orelse error.InvalidClaudeModelCatalog;
+}
+
+fn requiredString(object: std.json.ObjectMap, key: []const u8) ![]const u8 {
+    const value = object.get(key) orelse return error.InvalidClaudeModelCatalog;
+    if (value != .string or value.string.len == 0) return error.InvalidClaudeModelCatalog;
+    return value.string;
+}
+
+fn validateModelId(id: []const u8) !void {
+    if (id.len == 0 or id.len > max_model_id_bytes) return error.InvalidClaudeModelCatalog;
+    for (id) |byte| {
+        if (byte <= 0x20 or byte == 0x7f) return error.InvalidClaudeModelCatalog;
+    }
+}
+
+test "Claude catalog parser keeps visible API models" {
+    const alloc = std.testing.allocator;
+    const json =
+        \\{"data":[
+        \\  {"id":"claude-sonnet-4-5","display_name":"Sonnet 4.5","context_window":200000},
+        \\  {"id":"claude-opus-4-1","display_name":"Opus 4.1","context_window":200000}
+        \\]}
+    ;
+    var catalog = try parseCatalog(alloc, json);
+    defer model_catalog.freeModelCatalog(alloc, &catalog);
+
+    try std.testing.expectEqual(@as(usize, 2), catalog.items.len);
+    try std.testing.expectEqualStrings("claude-sonnet-4-5", catalog.items[0].id);
+    try std.testing.expect(catalog.items[0].has_tool_use);
+    try std.testing.expect(catalog.items[0].has_reasoning);
+    try std.testing.expectEqual(@as(u32, 200_000), catalog.items[0].context_window);
+}

--- a/src/gateway/anthropic_claude_permission_reviewer.zig
+++ b/src/gateway/anthropic_claude_permission_reviewer.zig
@@ -107,7 +107,7 @@ fn sendReview(
     var evidence: stream_provider.AttemptEvidence = .{};
     var callback_context: u8 = 0;
     const usage_observation = try session_usage.GatewayObservation.begin(config.usage);
-    var result = anthropic_claude.agent_stream_provider.stream(alloc, .{
+    var result = anthropic_claude.streamHttpCompletion(alloc, .{
         .api_key = config.credential,
         .credential_source = .claude_subscription,
         .account_id = config.account_id,

--- a/src/gateway/anthropic_claude_permission_reviewer.zig
+++ b/src/gateway/anthropic_claude_permission_reviewer.zig
@@ -1,0 +1,219 @@
+const std = @import("std");
+const permission_auto_classifier = @import("../core/permissions/auto_classifier.zig");
+const gateway_json = @import("../core/gateway/gateway_json.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const types = @import("../core/shared/types.zig");
+const session_usage = @import("../core/session/session_usage.zig");
+const anthropic_claude = @import("anthropic_claude.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub const provider = permission_auto_classifier.Provider{
+    .review_fn = reviewClaude,
+};
+
+const ReviewConfig = struct {
+    credential: []const u8,
+    account_id: []const u8,
+    cancel_flag: ?*std.atomic.Value(bool),
+    usage: ?*session_usage.Usage,
+    usage_allocator: Allocator,
+};
+
+fn reviewClaude(
+    _: ?*anyopaque,
+    alloc: Allocator,
+    input: permission_auto_classifier.ProviderInput,
+    request: permission_auto_classifier.ReviewRequest,
+) anyerror!permission_auto_classifier.ParseOutcome {
+    if (input.credential.len == 0) return .invalid;
+    const account_id = input.account_id orelse return .invalid;
+    var config = ReviewConfig{
+        .credential = input.credential,
+        .account_id = account_id,
+        .cancel_flag = input.cancel_flag,
+        .usage = input.usage,
+        .usage_allocator = input.usage_allocator,
+    };
+    return permission_auto_classifier.Reviewer.withTransportModel(
+        .{
+            .context = @ptrCast(&config),
+            .build_fn = buildReviewPayload,
+            .send_fn = sendReview,
+        },
+        config.cancel_flag,
+        permission_auto_classifier.Reviewer.default_timeout_ms,
+        request.review_turn.model,
+    ).review(alloc, request);
+}
+
+fn buildReviewPayload(
+    _: *anyopaque,
+    alloc: Allocator,
+    model: []const u8,
+    tools_json: []const u8,
+    messages: []const types.ChatMessage,
+    target_call_id: []const u8,
+    deadline: std.Io.Clock.Timestamp,
+    cancel_flag: *std.atomic.Value(bool),
+) ![]u8 {
+    const expanded = try gateway_json.expandPendingToolReviewMessages(
+        alloc,
+        messages,
+        target_call_id,
+        deadline,
+        cancel_flag,
+    );
+    defer alloc.free(expanded);
+    return anthropic_claude.agent_stream_provider.build(alloc, .{
+        .model = model,
+        .serialized_tools = tools_json,
+        .messages = expanded,
+        .tool_choice = .required,
+        .provider_options = .{},
+        .max_output_tokens = 2048,
+        .budget = .{ .deadline = deadline, .cancel_flag = cancel_flag },
+    });
+}
+
+const OwnedResult = struct {
+    result: stream_provider.Result,
+};
+
+fn deinitOwnedResult(raw: *anyopaque, alloc: Allocator) void {
+    const owned: *OwnedResult = @ptrCast(@alignCast(raw));
+    owned.result.deinit(alloc);
+    alloc.destroy(owned);
+}
+
+fn ignoreChunk(_: *anyopaque, _: []const u8) void {}
+
+fn sendReview(
+    raw: *anyopaque,
+    alloc: Allocator,
+    model: []const u8,
+    payload: []const u8,
+    deadline: std.Io.Clock.Timestamp,
+    cancel_flag: *std.atomic.Value(bool),
+) !permission_auto_classifier.TransportOutcome {
+    const config: *ReviewConfig = @ptrCast(@alignCast(raw));
+    if (cancel_flag.load(.seq_cst)) return .cancelled;
+    if (std.Io.Clock.Timestamp.now(@import("../core/shared/io.zig").getIo(), .awake).raw.nanoseconds >=
+        deadline.raw.nanoseconds)
+    {
+        return .timed_out;
+    }
+    var delivery = stream_provider.DeliveryCertainty.init();
+    var evidence: stream_provider.AttemptEvidence = .{};
+    var callback_context: u8 = 0;
+    const usage_observation = try session_usage.GatewayObservation.begin(config.usage);
+    var result = anthropic_claude.agent_stream_provider.stream(alloc, .{
+        .api_key = config.credential,
+        .credential_source = .claude_subscription,
+        .account_id = config.account_id,
+        .team = null,
+        .model = model,
+        .retry_count = 1,
+        .chat_url = "",
+        .payload = payload,
+        .trace_ctx = .{},
+        .content_capture_limit = 16 * 1024,
+        .deadline = deadline,
+        .delivery = &delivery,
+        .attempt_evidence = &evidence,
+        .callback_ctx = @ptrCast(&callback_context),
+        .on_content_chunk = ignoreChunk,
+        .on_tool_start = null,
+        .on_reasoning_chunk = null,
+        .cancel_flag = cancel_flag,
+        .provider_attempt_owner = .transport,
+    }) catch |err| {
+        usage_observation.fail(if (delivery.load() == .possibly_sent)
+            .ambiguous_delivery
+        else
+            .unbilled) catch return .permanent_failure;
+        return mapStreamError(err, cancel_flag);
+    };
+    var result_owned = true;
+    defer if (result_owned) result.deinit(alloc);
+    usage_observation.complete(
+        config.usage_allocator,
+        result.status,
+        result.completion,
+        "https://api.anthropic.com/v1",
+        null,
+    ) catch return .permanent_failure;
+    if (cancel_flag.load(.seq_cst)) return .cancelled;
+    if (result.status != .ok) {
+        const code: u16 = @intFromEnum(result.status);
+        return if (code == 408 or code == 425 or code == 429 or code >= 500)
+            .transient_failure
+        else
+            .permanent_failure;
+    }
+    if (result.completion.finish_reason) |reason| switch (reason) {
+        .provider_error => return .transient_failure,
+        .content_filter => return .permanent_failure,
+        .stop, .length, .tool_calls, .other => {},
+    };
+    const owned = try alloc.create(OwnedResult);
+    owned.* = .{ .result = result };
+    result_owned = false;
+    return .{ .completion = .{
+        .completion = owned.result.completion,
+        .context = @ptrCast(owned),
+        .deinit_fn = deinitOwnedResult,
+    } };
+}
+
+fn mapStreamError(
+    err: anyerror,
+    cancel_flag: *std.atomic.Value(bool),
+) error{OutOfMemory}!permission_auto_classifier.TransportOutcome {
+    if (err == error.OutOfMemory) return error.OutOfMemory;
+    if (err == error.Cancelled or cancel_flag.load(.seq_cst)) return .cancelled;
+    if (err == error.Timeout) return .timed_out;
+    return .transient_failure;
+}
+
+test "Claude reviewer builds a direct Messages request with the admitted model" {
+    const messages = [_]types.ChatMessage{
+        .{ .role = .user, .content = "User requested the change." },
+        .{
+            .role = .assistant,
+            .tool_calls = &.{.{
+                .id = "toolu_review",
+                .name = "write_file",
+                .arguments_json = "{\"path\":\"a.txt\"}",
+            }},
+        },
+        .{ .role = .system, .content = "Review the pending action." },
+    };
+    var cancelled = std.atomic.Value(bool).init(false);
+    var context: u8 = 0;
+    const body = try buildReviewPayload(
+        @ptrCast(&context),
+        std.testing.allocator,
+        "claude-sonnet-4-5",
+        "[{\"type\":\"function\",\"name\":\"permission_decision\"}]",
+        &messages,
+        "toolu_review",
+        std.Io.Clock.Timestamp.fromNow(@import("../core/shared/io.zig").getIo(), .{
+            .clock = .awake,
+            .raw = .fromSeconds(5),
+        }),
+        &cancelled,
+    );
+    defer std.testing.allocator.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"claude-sonnet-4-5\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"messages\"") != null);
+}
+
+test "Claude reviewer maps an enforced stream deadline to fail-closed timeout" {
+    var cancelled = std.atomic.Value(bool).init(false);
+    try std.testing.expectEqual(
+        permission_auto_classifier.TransportOutcome.timed_out,
+        try mapStreamError(error.Timeout, &cancelled),
+    );
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -55,6 +55,8 @@ const openai_codex_models = @import("gateway/openai_codex_models.zig");
 const openai_codex_permission_reviewer = @import("gateway/openai_codex_permission_reviewer.zig");
 const xai_grok_models = @import("gateway/xai_grok_models.zig");
 const xai_grok_permission_reviewer = @import("gateway/xai_grok_permission_reviewer.zig");
+const anthropic_claude_models = @import("gateway/anthropic_claude_models.zig");
+const anthropic_claude_permission_reviewer = @import("gateway/anthropic_claude_permission_reviewer.zig");
 const gateway_provider = @import("core/gateway/gateway_provider.zig");
 const model_catalog = @import("core/gateway/model_catalog.zig");
 const generation_usage_provider = @import("core/session/generation_usage_provider.zig");
@@ -1605,6 +1607,16 @@ const App = struct {
                     builtin_providers.agentStream(.grok),
                 .permission_reviewer_provider = if (comptime host_profile.tools and !host_target.is_wasm)
                     xai_grok_permission_reviewer.provider
+                else
+                    null,
+            },
+            .claude = .{
+                .agent_stream_provider = if (comptime host_target.is_wasm)
+                    agent_stream_provider.unavailable_provider
+                else
+                    builtin_providers.agentStream(.claude),
+                .permission_reviewer_provider = if (comptime host_profile.tools and !host_target.is_wasm)
+                    anthropic_claude_permission_reviewer.provider
                 else
                     null,
             },
@@ -3241,6 +3253,9 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .grok_agent_stream = builtin_providers.agentStream(.grok),
         .grok_cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
         .grok_model_catalog = xai_grok_models.model_catalog_provider,
+        .claude_agent_stream = builtin_providers.agentStream(.claude),
+        .claude_cli_model_catalog = anthropic_claude_models.cli_model_catalog_provider,
+        .claude_model_catalog = anthropic_claude_models.model_catalog_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3263,6 +3278,7 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .permission_reviewer_provider = builtin_gateway.permission_reviewer.provider,
         .codex_permission_reviewer_provider = openai_codex_permission_reviewer.provider,
         .grok_permission_reviewer_provider = xai_grok_permission_reviewer.provider,
+        .claude_permission_reviewer_provider = anthropic_claude_permission_reviewer.provider,
     };
 }
 
@@ -3284,6 +3300,9 @@ fn localEntryConfig() app_entry_runtime.Config {
         .grok_agent_stream = builtin_providers.agentStream(.grok),
         .grok_cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
         .grok_model_catalog = xai_grok_models.model_catalog_provider,
+        .claude_agent_stream = builtin_providers.agentStream(.claude),
+        .claude_cli_model_catalog = anthropic_claude_models.cli_model_catalog_provider,
+        .claude_model_catalog = anthropic_claude_models.model_catalog_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,
@@ -3324,6 +3343,9 @@ fn emptyEntryConfig() app_entry_runtime.Config {
         .grok_agent_stream = builtin_providers.agentStream(.grok),
         .grok_cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
         .grok_model_catalog = xai_grok_models.model_catalog_provider,
+        .claude_agent_stream = builtin_providers.agentStream(.claude),
+        .claude_cli_model_catalog = anthropic_claude_models.cli_model_catalog_provider,
+        .claude_model_catalog = anthropic_claude_models.model_catalog_provider,
         .background_process_provider = background_process.provider,
         .url_opener = url_opener.native_opener,
         .secret_store = native_host.secret_store,

--- a/src/ui/footer/model_menu_presentation.zig
+++ b/src/ui/footer/model_menu_presentation.zig
@@ -346,6 +346,7 @@ fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]
             .authenticated_credential_rejected => "Your Gateway credential was rejected; using the public model catalog.",
             .chatgpt_subscription => "Codex models require an authenticated Codex catalog.",
             .grok_subscription => "Grok models require an authenticated Grok catalog.",
+            .claude_subscription => "Claude models require an authenticated Claude catalog.",
         };
     }
     if (state.access_level == .authenticated) {
@@ -357,6 +358,7 @@ fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]
             .stored_key => "Gateway catalog: authenticated with the stored API key.",
             .chatgpt_subscription => "Codex catalog: authenticated with a subscription.",
             .grok_subscription => "Grok catalog: authenticated with a subscription.",
+            .claude_subscription => "Claude catalog: authenticated with a subscription.",
         };
     }
     return null;

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -268,6 +268,8 @@ fn composeSignInPickerRow(
             "   Sign in with Codex"
         else if (source == .grok_subscription)
             "   Sign in with Grok"
+        else if (source == .claude_subscription)
+            "   Sign in with Claude"
         else
             "   Sign in with Vercel",
         1, 4 => "",
@@ -279,9 +281,13 @@ fn composeSignInPickerRow(
             "   Open the Codex authorization page"
         else if (source == .grok_subscription)
             "   Open the Grok authorization page"
+        else if (source == .claude_subscription)
+            "   Open the Claude authorization page"
         else
             "   Open the Vercel device authorization page",
-        3 => if (snapshot.user_code.len == 0)
+        3 => if (source == .claude_subscription)
+            "   Paste the authorization code from the browser"
+        else if (snapshot.user_code.len == 0)
             ""
         else
             std.fmt.bufPrint(
@@ -296,7 +302,10 @@ fn composeSignInPickerRow(
             .failed => "   Sign-in failed",
             .cancelled => "   Sign-in cancelled",
         },
-        6 => "   Enter reopens browser · Esc cancels",
+        6 => if (source == .claude_subscription)
+            "   Enter reopens browser · paste the code in the terminal · Esc cancels"
+        else
+            "   Enter reopens browser · Esc cancels",
         else => "",
     };
     try row_text.appendClipped(alloc, &row, label, width);

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -55,7 +55,7 @@ fn teamQueryProjection(query: []const u8, width: u16) TeamQueryProjection {
 pub fn authPickerRowCount(view: auth_runtime.PickerView) u16 {
     if (view.stage == .sign_in) return 7;
     if (view.stage == .api_key) return 4;
-    if (view.stage == .root and view.include_skip) return 18;
+    if (view.stage == .root and view.include_skip) return 19;
     return @intCast(1 + @max(view.choiceCount(), 1));
 }
 
@@ -157,13 +157,13 @@ const onboarding_note = "   ⚠︎ Note: fx is experimental and defaults to auto
 const onboarding_note_link = onboarding_note ++ " \x1b]8;id=fx-onboarding;https://fx.sh/docs/stability\x1b\\\x1b[4mLearn more\x1b[24m\x1b]8;;\x1b\\";
 
 fn onboardingProjectedRowIndex(view: auth_runtime.PickerView, row_index: u16, row_count: u16) u16 {
-    if (row_count >= 18) return row_index;
+    if (row_count >= 19) return row_index;
 
     const selected_row: u16 = 8 + @as(u16, @intCast(view.selectedIndex()));
-    const priority = [_]u16{ selected_row, 11, 9, 10, 8, 15, 7, 12, 5, 0, 2, 3, 6, 13, 14, 1, 4, 16, 17 };
+    const priority = [_]u16{ selected_row, 12, 9, 10, 8, 11, 16, 7, 13, 5, 0, 2, 3, 6, 14, 15, 1, 4, 17, 18 };
 
     var projected_index: u16 = 0;
-    for (0..18) |source_row| {
+    for (0..19) |source_row| {
         for (priority[0..@min(row_count, priority.len)]) |included_row| {
             if (source_row != included_row) continue;
             if (projected_index == row_index) return @intCast(source_row);
@@ -171,7 +171,7 @@ fn onboardingProjectedRowIndex(view: auth_runtime.PickerView, row_index: u16, ro
             break;
         }
     }
-    return 17;
+    return 18;
 }
 
 fn composeOnboardingPickerRow(
@@ -191,6 +191,7 @@ fn composeOnboardingPickerRow(
         9 => 1,
         10 => 2,
         11 => 3,
+        12 => 4,
         else => null,
     };
     if (maybe_choice_index) |choice_index| {
@@ -218,10 +219,10 @@ fn composeOnboardingPickerRow(
         5 => "   You can change this anytime with /setup.",
         6 => "",
         7 => "   Get started",
-        12 => if (display_width.visibleWidthIgnoringAnsi(onboarding_note_link) <= width) onboarding_note_link else onboarding_note,
-        13, 14 => "",
-        15 => "   Esc to set up later · Explore all commands with /help",
-        16, 17 => "",
+        13 => if (display_width.visibleWidthIgnoringAnsi(onboarding_note_link) <= width) onboarding_note_link else onboarding_note,
+        14, 15 => "",
+        16 => "   Esc to set up later · Explore all commands with /help",
+        17, 18 => "",
         else => "",
     };
     try row_text.appendClipped(alloc, &row, label, width);
@@ -1590,7 +1591,7 @@ test "auth onboarding composes the welcome copy and setup choices" {
         .include_skip = true,
     };
 
-    try std.testing.expectEqual(@as(u16, 18), authPickerRowCount(view));
+    try std.testing.expectEqual(@as(u16, 19), authPickerRowCount(view));
     var screen: std.ArrayList(u8) = .empty;
     defer screen.deinit(alloc);
     for (0..authPickerRowCount(view)) |row_index| {
@@ -1629,11 +1630,15 @@ test "auth onboarding composes the welcome copy and setup choices" {
     defer grok_row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, grok_row.items, "Sign in with Grok") != null);
 
-    var unselected_row = try composeAuthPickerRow(alloc, view, 11, authPickerRowCount(view), 100);
+    var claude_row = try composeAuthPickerRow(alloc, view, 11, authPickerRowCount(view), 100);
+    defer claude_row.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, claude_row.items, "Sign in with Claude") != null);
+
+    var unselected_row = try composeAuthPickerRow(alloc, view, 12, authPickerRowCount(view), 100);
     defer unselected_row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, unselected_row.items, "Add an API key") != null);
 
-    var narrow_note = try composeAuthPickerRow(alloc, view, 12, authPickerRowCount(view), 58);
+    var narrow_note = try composeAuthPickerRow(alloc, view, 13, authPickerRowCount(view), 58);
     defer narrow_note.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow_note.items, "https://fx.sh/docs/stability") == null);
 
@@ -1661,7 +1666,7 @@ test "auth picker composes only detected credential sources" {
         .include_skip = false,
     };
     const row_count = authPickerRowCount(view);
-    try std.testing.expectEqual(@as(u16, 8), row_count);
+    try std.testing.expectEqual(@as(u16, 9), row_count);
 
     var header = try composeAuthPickerRow(alloc, view, 0, row_count, 80);
     defer header.deinit(alloc);
@@ -1679,20 +1684,24 @@ test "auth picker composes only detected credential sources" {
     defer grok.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, grok.items, "Sign in with Grok") != null);
 
-    var setup = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
+    var claude = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
+    defer claude.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, claude.items, "Sign in with Claude") != null);
+
+    var setup = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
     defer setup.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, setup.items, "API key") != null);
 
-    var switch_provider = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
+    var switch_provider = try composeAuthPickerRow(alloc, view, 6, row_count, 80);
     defer switch_provider.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, switch_provider.items, "Switch provider") != null);
 
-    var change_team = try composeAuthPickerRow(alloc, view, 6, row_count, 80);
+    var change_team = try composeAuthPickerRow(alloc, view, 7, row_count, 80);
     defer change_team.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, change_team.items, "Change team") != null);
     try std.testing.expect(std.mem.find(u8, change_team.items, "sign in first") != null);
 
-    var switch_credential = try composeAuthPickerRow(alloc, view, 7, row_count, 80);
+    var switch_credential = try composeAuthPickerRow(alloc, view, 8, row_count, 80);
     defer switch_credential.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, switch_credential.items, "Switch credential") != null);
 }


### PR DESCRIPTION
This pull request adds support for Anthropic Claude as a first-class provider in fx, allowing users to sign in, select, and use Claude models alongside existing providers (Gateway, Codex, Grok). It updates authentication, configuration, command-line interface, and documentation to integrate Claude throughout the application. The main changes are grouped below:

**Claude Provider Integration:**

* Added Claude as a selectable provider across the codebase, including authentication, provider switching, and model catalog selection (`src/builtins/commands.zig`, `src/builtins/providers.zig`, `src/acp/server.zig`, `src/core/app/app_auth_runtime.zig`, `src/core/app/app_agent_runtime.zig`, `src/acp/prompt.zig`). [[1]](diffhunk://#diff-fef46a04918a7d70ce73fa38397a982c8b7de7467edf3b886b19cd9188b028f6L92-R98) [[2]](diffhunk://#diff-fef46a04918a7d70ce73fa38397a982c8b7de7467edf3b886b19cd9188b028f6L140-R140) [[3]](diffhunk://#diff-fef46a04918a7d70ce73fa38397a982c8b7de7467edf3b886b19cd9188b028f6L295-R297) [[4]](diffhunk://#diff-faac400cac88cd4af37b4fd3e88a786ddc0e52cf88084425ba3dde191f0323e9R9-R17) [[5]](diffhunk://#diff-faac400cac88cd4af37b4fd3e88a786ddc0e52cf88084425ba3dde191f0323e9R26) [[6]](diffhunk://#diff-3df3db71f92bfb27b8827da73ef0cf245ffb7dd8a9f3b2b5fda6df050e2ec293R374-R375) [[7]](diffhunk://#diff-3df3db71f92bfb27b8827da73ef0cf245ffb7dd8a9f3b2b5fda6df050e2ec293R387) [[8]](diffhunk://#diff-3df3db71f92bfb27b8827da73ef0cf245ffb7dd8a9f3b2b5fda6df050e2ec293R1720) [[9]](diffhunk://#diff-3fca0c7128d4adcbabda27fbf4f8e10c66ef8a17d1ca80ba0a91ba7bcf125803R251) [[10]](diffhunk://#diff-3fca0c7128d4adcbabda27fbf4f8e10c66ef8a17d1ca80ba0a91ba7bcf125803R710-R713) [[11]](diffhunk://#diff-3b75a42943239536968acbe77146cc3711f044408d605eb7f6a94d6449fa07e8R1033-R1036)

* Implemented Claude authentication flow, including sign-in (`fx login claude`), sign-out (`fx logout claude`), and session management, with fallback to fx-owned sessions if Claude Code CLI is not signed in (`src/core/app/app_auth_runtime.zig`, `src/builtins/commands.zig`, `src/builtins/providers.zig`). [[1]](diffhunk://#diff-48240109654649a5d4378a48dd97db545856c0123624503e7d6fddf5ada8f584R12) [[2]](diffhunk://#diff-48240109654649a5d4378a48dd97db545856c0123624503e7d6fddf5ada8f584R83) [[3]](diffhunk://#diff-48240109654649a5d4378a48dd97db545856c0123624503e7d6fddf5ada8f584R181-R222) [[4]](diffhunk://#diff-48240109654649a5d4378a48dd97db545856c0123624503e7d6fddf5ada8f584R362) [[5]](diffhunk://#diff-48240109654649a5d4378a48dd97db545856c0123624503e7d6fddf5ada8f584R521-R553)

**Command-Line Interface and Help Updates:**

* Updated CLI commands and help text to include Claude as an option for `login`, `logout`, and `provider`, and added a new flag `--claude-tools` for tool selection (`src/builtins/commands.zig`). [[1]](diffhunk://#diff-fef46a04918a7d70ce73fa38397a982c8b7de7467edf3b886b19cd9188b028f6L92-R98) [[2]](diffhunk://#diff-fef46a04918a7d70ce73fa38397a982c8b7de7467edf3b886b19cd9188b028f6L140-R140) [[3]](diffhunk://#diff-fef46a04918a7d70ce73fa38397a982c8b7de7467edf3b886b19cd9188b028f6L295-R297) [[4]](diffhunk://#diff-fef46a04918a7d70ce73fa38397a982c8b7de7467edf3b886b19cd9188b028f6R332-R335)

* Extended documentation in `README.md` to describe Claude integration, usage, and session behavior, including fallback mechanisms and tool selection (`README.md`).

**Configuration and Prompt Handling:**

* Added Claude-specific configuration options for agent streams, permission reviewers, and model selection, ensuring Claude is handled consistently with other providers (`src/acp/prompt.zig`, `src/acp/server.zig`). [[1]](diffhunk://#diff-3fca0c7128d4adcbabda27fbf4f8e10c66ef8a17d1ca80ba0a91ba7bcf125803R251) [[2]](diffhunk://#diff-3fca0c7128d4adcbabda27fbf4f8e10c66ef8a17d1ca80ba0a91ba7bcf125803R710-R713) [[3]](diffhunk://#diff-3df3db71f92bfb27b8827da73ef0cf245ffb7dd8a9f3b2b5fda6df050e2ec293R374-R375) [[4]](diffhunk://#diff-3df3db71f92bfb27b8827da73ef0cf245ffb7dd8a9f3b2b5fda6df050e2ec293R387) [[5]](diffhunk://#diff-3df3db71f92bfb27b8827da73ef0cf245ffb7dd8a9f3b2b5fda6df050e2ec293R1720)

**Testing and Build Improvements:**

* Added a `test-filter` build option to allow running a subset of tests by name, improving test workflow (`build.zig`).

**Changelog and Miscellaneous:**

* Updated `CHANGELOG.md` to announce Claude subscription support and document new features (`CHANGELOG.md`).

These changes collectively enable seamless Claude provider support, bringing parity with other major AI providers in fx.