### PR TITLE
Preserve tool actions in transcript summaries

### DIFF
--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -5054,7 +5054,7 @@ test "processQueuedPrompt regenerates and executes a local tool once after ReadF
     try expectFailedLifecycleContains(
         hooks.lifecycle_events.items,
         "call_read_interrupted",
-        "before read_file ran",
+        "before tool call ran",
     );
     try std.testing.expectEqualStrings("Finished", hooks.history_turns.items[0].assistant.assistant);
 }
@@ -5087,7 +5087,7 @@ test "processQueuedPrompt settles an interrupted local tool after a different st
     try expectFailedLifecycleContains(
         hooks.lifecycle_events.items,
         "call_read_interrupted",
-        "before read_file ran",
+        "before tool call ran",
     );
 }
 
@@ -5119,7 +5119,7 @@ test "processQueuedPrompt settles an interrupted local tool after an HTTP failur
     try expectFailedLifecycleContains(
         hooks.lifecycle_events.items,
         "call_read_interrupted",
-        "before read_file ran",
+        "before tool call ran",
     );
 }
 

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -37,6 +37,17 @@ pub fn streamStartMayHaveExecutedAtProvider(
     return spec.provider_executed;
 }
 
+fn fallbackToolDisplay(
+    registry: tool_dispatch.Registry,
+    tool_name: []const u8,
+) []const u8 {
+    const lookup_name = if (std.mem.eql(u8, tool_name, "run_command"))
+        "terminal"
+    else
+        tool_name;
+    return if (registry.lookup(lookup_name) != null) "tool call" else tool_name;
+}
+
 pub const ProvisionalToolStatuses = struct {
     const TrackedStatus = struct {
         id: []u8,
@@ -150,7 +161,7 @@ pub const ProvisionalToolStatuses = struct {
         const summary = try std.fmt.allocPrint(
             arena,
             "{s} failed: invalid JSON arguments",
-            .{call.name},
+            .{fallbackToolDisplay(hooks.tool_registry, call.name)},
         );
         try hooks.push_tool_lifecycle(hooks.ctx, .{
             .terminal = .{
@@ -404,7 +415,8 @@ pub const ProvisionalToolStatuses = struct {
                 continue;
             }
             errdefer self.forgetTerminal(alloc, status.id);
-            const detail = status.label_value orelse status.tool_name;
+            const detail = status.label_value orelse
+                fallbackToolDisplay(hooks.tool_registry, status.tool_name);
             const encoded = try text_utils.encodeTerminalSafe(
                 arena,
                 detail,
@@ -448,7 +460,8 @@ pub const ProvisionalToolStatuses = struct {
                 continue;
             }
             errdefer self.forgetTerminal(alloc, status.id);
-            const detail = status.label_value orelse status.tool_name;
+            const detail = status.label_value orelse
+                fallbackToolDisplay(hooks.tool_registry, status.tool_name);
             const encoded = try text_utils.encodeTerminalSafe(
                 arena,
                 detail,
@@ -1555,7 +1568,7 @@ test "provisional lifecycle formats labeled and unlabeled eligible tools" {
     }
 }
 
-test "tracked provisional cancellation retains names and the latest label" {
+test "tracked provisional cancellation retains labels without exposing registered names" {
     const alloc = std.testing.allocator;
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();
@@ -1569,6 +1582,7 @@ test "tracked provisional cancellation retains names and the latest label" {
     try statuses.publish(&hooks, alloc, 9, "read_1", "read_file", .read, "Reading", null);
     try statuses.publish(&hooks, alloc, 9, "read_1", "read_file", .read, "Reading", "src/main.zig");
     try statuses.publish(&hooks, alloc, 9, "command_1", "run_command", .command, "Running", null);
+    try statuses.publish(&hooks, alloc, 9, "mcp_1", "mcp_custom", .read, "Running", null);
     try statuses.finishTrackedCancelled(&hooks, alloc, arena, 9);
 
     var terminal_count: usize = 0;
@@ -1579,17 +1593,55 @@ test "tracked provisional cancellation retains names and the latest label" {
         if (std.mem.eql(u8, event.terminal.id.call_id, "read_1")) {
             try std.testing.expectEqualStrings("Cancelled src/main.zig", event.terminal.outcome.summary);
         } else if (std.mem.eql(u8, event.terminal.id.call_id, "command_1")) {
-            try std.testing.expectEqualStrings("Cancelled run_command", event.terminal.outcome.summary);
+            try std.testing.expectEqualStrings("Cancelled tool call", event.terminal.outcome.summary);
+        } else if (std.mem.eql(u8, event.terminal.id.call_id, "mcp_1")) {
+            try std.testing.expectEqualStrings("Cancelled mcp_custom", event.terminal.outcome.summary);
         } else {
             return error.TestUnexpectedToolCallId;
         }
     }
-    try std.testing.expectEqual(@as(usize, 2), terminal_count);
+    try std.testing.expectEqual(@as(usize, 3), terminal_count);
     try std.testing.expectEqual(@as(usize, 0), statuses.tracked.items.len);
 
     const event_count = capture.events.items.len;
     try statuses.finishTrackedCancelled(&hooks, alloc, arena, 9);
     try std.testing.expectEqual(event_count, capture.events.items.len);
+}
+
+test "unmatched recovery starts hide registered names but retain unknown identities" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+    defer capture.deinit();
+    const hooks = capture.hooks();
+    var statuses = ProvisionalToolStatuses{};
+    defer statuses.deinit(alloc);
+
+    try statuses.publish(&hooks, alloc, 9, "command_1", "run_command", .command, "Running", null);
+    try statuses.publish(&hooks, alloc, 9, "mcp_1", "mcp_custom", .read, "Running", null);
+    try statuses.finishUnmatchedRecoveryStarts(&hooks, alloc, arena, 9, &.{});
+
+    var terminal_count: usize = 0;
+    for (capture.events.items) |event| {
+        if (event != .terminal) continue;
+        terminal_count += 1;
+        if (std.mem.eql(u8, event.terminal.id.call_id, "command_1")) {
+            try std.testing.expectEqualStrings(
+                "Connection interrupted before tool call ran",
+                event.terminal.outcome.summary,
+            );
+        } else if (std.mem.eql(u8, event.terminal.id.call_id, "mcp_1")) {
+            try std.testing.expectEqualStrings(
+                "Connection interrupted before mcp_custom ran",
+                event.terminal.outcome.summary,
+            );
+        } else {
+            return error.TestUnexpectedToolCallId;
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 2), terminal_count);
 }
 
 test "provisional lifecycle remains distinct from authoritative lifecycle" {
@@ -1732,12 +1784,23 @@ test "provisional lifecycle terminal matching prefers final id then provisional 
     }};
     try statuses.finishMalformedProviderToolArguments(&hooks, arena, 1, &provider_calls);
 
-    try std.testing.expectEqual(@as(usize, 2), capture.events.items.len);
+    _ = try statuses.record(alloc, "mcp_invalid");
+    try statuses.finishMalformedToolArguments(&hooks, arena, 1, .{
+        .id = "mcp_invalid",
+        .name = "mcp_lookup",
+        .arguments_json = "{",
+    });
+
+    try std.testing.expectEqual(@as(usize, 3), capture.events.items.len);
     for (capture.events.items) |event| {
         switch (event) {
             .terminal => |terminal| {
-                try std.testing.expectEqualStrings("provisional_read", terminal.id.call_id);
-                try std.testing.expectEqualStrings("read_file failed: invalid JSON arguments", terminal.outcome.summary);
+                if (std.mem.eql(u8, terminal.id.call_id, "mcp_invalid")) {
+                    try std.testing.expectEqualStrings("mcp_lookup failed: invalid JSON arguments", terminal.outcome.summary);
+                } else {
+                    try std.testing.expectEqualStrings("provisional_read", terminal.id.call_id);
+                    try std.testing.expectEqualStrings("tool call failed: invalid JSON arguments", terminal.outcome.summary);
+                }
             },
             else => return error.TestExpectedEqual,
         }

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1165,7 +1165,7 @@ fn formatToolAction(
         );
     }
     const args = tool_args.parseToolArgsObject(arena, call.arguments_json) catch {
-        return formatInvalidArgsToolAction(arena, state, denied_label, call.name);
+        return formatInvalidArgsToolAction(arena, state, denied_label);
     };
 
     const presentation = tool_dispatch.presentationForArgs(spec.*, args);
@@ -1177,7 +1177,7 @@ fn formatToolAction(
 
 fn formatWebSearchAction(arena: Allocator, call: ToolCall, state: ToolActionState, denied_label: ?[]const u8) ![]const u8 {
     const args = tool_args.parseToolArgsObject(arena, call.arguments_json) catch {
-        return formatInvalidArgsToolAction(arena, state, denied_label, call.name);
+        return formatInvalidArgsToolAction(arena, state, denied_label);
     };
     const label = switch (state) {
         .active => "Searching",
@@ -1195,10 +1195,11 @@ fn formatMissingSpecToolAction(arena: Allocator, state: ToolActionState, denied_
     };
 }
 
-fn formatInvalidArgsToolAction(arena: Allocator, state: ToolActionState, denied_label: ?[]const u8, name: []const u8) ![]const u8 {
+fn formatInvalidArgsToolAction(arena: Allocator, state: ToolActionState, denied_label: ?[]const u8) ![]const u8 {
     return switch (state) {
         .active => std.fmt.allocPrint(arena, "● Working…\x1b[0m", .{}),
-        .completed, .denied => formatMissingSpecToolAction(arena, state, denied_label, name),
+        .completed => formatToolActionValue(arena, "Completed", "tool call"),
+        .denied => formatToolActionValue(arena, denied_label.?, "tool call"),
     };
 }
 
@@ -2020,6 +2021,30 @@ test "app agent runtime formats active completed denied and MCP tool actions" {
     const denied = try app.describeToolActionDenied(arena, run_call, "Denied");
     try std.testing.expect(std.mem.find(u8, denied, "Denied") != null);
     try std.testing.expect(std.mem.find(u8, denied, "zig build") != null);
+
+    const malformed_registered: ToolCall = .{
+        .id = "malformed_registered",
+        .name = "memory",
+        .arguments_json = "{",
+    };
+    const malformed_completed = try app.describeToolActionCompleted(arena, malformed_registered);
+    try std.testing.expectEqualStrings(
+        "● Completed\x1b[0m \x1b[38;5;245mtool call\x1b[0m",
+        malformed_completed,
+    );
+    const malformed_denied = try app.describeToolActionDenied(arena, malformed_registered, "Denied");
+    try std.testing.expectEqualStrings(
+        "● Denied\x1b[0m \x1b[38;5;245mtool call\x1b[0m",
+        malformed_denied,
+    );
+
+    const malformed_unknown: ToolCall = .{
+        .id = "malformed_unknown",
+        .name = "mcp_unknown",
+        .arguments_json = "{",
+    };
+    const malformed_unknown_completed = try app.describeToolActionCompleted(arena, malformed_unknown);
+    try std.testing.expect(std.mem.find(u8, malformed_unknown_completed, "mcp_unknown") != null);
 
     const mcp_call: ToolCall = .{ .id = "mcp", .name = "mcp_lookup", .arguments_json = "{}" };
     const mcp_action = try app.describeToolActionCompleted(arena, mcp_call);

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -5,6 +5,7 @@ const config_runtime = @import("../config/config_runtime.zig");
 const model_capabilities = @import("../config/model_capabilities.zig");
 const model_provider = @import("../config/model_provider.zig");
 const assistant_presentation = @import("../agent/assistant_presentation.zig");
+const tool_admission = @import("../agent/runtime/tool_admission.zig");
 const tool_presentation = @import("../agent/runtime/tool_presentation.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const runtime_profile = @import("../hosts/runtime_profile.zig");
@@ -32,6 +33,7 @@ const result_store = @import("../session/result_store.zig");
 const command_replay_store = @import("../session/command_replay_store.zig");
 const command_output_content = @import("../tooling/command_output_content.zig");
 const captured_command = @import("../tooling/captured_command.zig");
+const tool_result_errors = @import("../tooling/tool_result_errors.zig");
 const session_display_metadata = @import("../session/session_display_metadata.zig");
 const session_log = @import("../session/session_log.zig");
 const session_resume_view = @import("../session/session_resume_view.zig");
@@ -3946,6 +3948,7 @@ pub fn Runtime(comptime App: type) type {
             );
             const context_deferred = types.isContextDeferredToolResult(result);
             const deferred = types.isDeferredToolResult(result);
+            const permission_denial_reason = tool_result_errors.toolPermissionDenialReason(result.output);
             const process_ran = result.command_process_presentation != null;
 
             var action_arena = std.heap.ArenaAllocator.init(app.alloc);
@@ -3959,6 +3962,14 @@ pub fn Runtime(comptime App: type) type {
                         types.context_deferred_tool_status_label
                     else
                         types.deferred_tool_result_output,
+                    &.{},
+                )
+            else if (permission_denial_reason) |reason|
+                try app.describeToolActionDeniedWithAdvertised(
+                    action_arena.allocator(),
+                    call,
+                    null,
+                    tool_admission.permissionDeniedStatusLabel(reason),
                     &.{},
                 )
             else if (result.status == .success or process_ran)
@@ -3981,7 +3992,7 @@ pub fn Runtime(comptime App: type) type {
 
             const outcome: types.ToolOutcomeKind = if (context_deferred)
                 .deferred
-            else if (deferred)
+            else if (deferred or permission_denial_reason != null)
                 .denied
             else if (result.status == .success or process_ran)
                 .completed
@@ -3992,7 +4003,7 @@ pub fn Runtime(comptime App: type) type {
                 outcome,
                 action,
             );
-            if (!is_command or deferred) {
+            if (!is_command or deferred or permission_denial_reason != null) {
                 try sink.attachHistoricalToolDetail(entry_id, call, result);
                 return;
             }
@@ -6565,6 +6576,69 @@ test "execution replay renders persisted permission feedback after its tool resu
     try std.testing.expectEqual(@as(usize, 1), app.cards.items.len);
     try std.testing.expectEqualStrings("Then read the file and report its exact contents.", app.cards.items[0].text);
     try std.testing.expect(app.cards.items[0].has_prior_turns);
+}
+
+test "execution replay preserves permission denial reasons" {
+    const alloc = std.testing.allocator;
+    var app = try TestApp.init(alloc, "/workspace");
+    defer app.deinit();
+
+    const reasons = [_]types.ToolPermissionDenialReason{
+        .user_denied,
+        .auto_denied,
+        .policy_denied,
+        .permission_required,
+    };
+    const call_ids = [_][]const u8{
+        "call_user_denied",
+        "call_auto_denied",
+        "call_policy_denied",
+        "call_permission_required",
+    };
+    var outputs: [reasons.len][]u8 = undefined;
+    var allocated_outputs: usize = 0;
+    defer for (outputs[0..allocated_outputs]) |output| alloc.free(output);
+    var calls: [reasons.len]types.ToolCall = undefined;
+    var results: [reasons.len]types.PersistedToolResult = undefined;
+    for (reasons, 0..) |reason, index| {
+        outputs[index] = try tool_result_errors.toolPermissionDeniedJson(
+            alloc,
+            "run_command",
+            reason,
+        );
+        allocated_outputs += 1;
+        calls[index] = .{
+            .id = call_ids[index],
+            .name = "run_command",
+            .arguments_json = "{\"command\":\"pwd\"}",
+        };
+        results[index] = .{
+            .tool_call_id = @constCast(call_ids[index]),
+            .tool_name = @constCast("run_command"),
+            .status = .failure,
+            .output = outputs[index],
+            .output_bytes = outputs[index].len,
+            .stored_output_bytes = outputs[index].len,
+        };
+    }
+    var steps = [_]types.ToolExecutionStep{.{
+        .tool_calls = calls[0..],
+        .tool_results = results[0..],
+    }};
+
+    try Runtime(TestApp).writeExecutionHistory(&app, .{ .tool_steps = steps[0..] });
+
+    try std.testing.expectEqualSlices(
+        types.ToolOutcomeKind,
+        &.{ .denied, .denied, .denied, .denied },
+        app.completed_tool_outcomes.items,
+    );
+    try std.testing.expectEqual(@as(usize, 4), app.completed_tool_statuses.items.len);
+    try std.testing.expectEqualStrings("● Denied run_command\n", app.completed_tool_statuses.items[0]);
+    try std.testing.expectEqualStrings("● Denied by auto agent run_command\n", app.completed_tool_statuses.items[1]);
+    try std.testing.expectEqualStrings("● Denied run_command\n", app.completed_tool_statuses.items[2]);
+    try std.testing.expectEqualStrings("● Permission required run_command\n", app.completed_tool_statuses.items[3]);
+    try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
 }
 
 test "execution replay writes completed status before saved command output" {

--- a/src/core/session/session_resume_view.zig
+++ b/src/core/session/session_resume_view.zig
@@ -9,7 +9,7 @@ pub const max_text_bytes: usize = 128 * 1024;
 const sidecar_file = "resume-view.bin";
 
 const magic = "FXRV";
-const schema_version: u8 = 2;
+const schema_version: u8 = 3;
 const fixed_header_bytes = magic.len + 1 + 2 + 2 + 2 + 1 + 16 + 8 + 8 + 4;
 const max_sidecar_bytes = fixed_header_bytes + 255 + max_text_bytes;
 
@@ -474,7 +474,13 @@ test "resume view sidecar treats missing and corrupt cache data as fallback" {
 
     const encoded = try encode(alloc, "session-1", boundary, test_capture, "cached session tail\n");
     defer alloc.free(encoded);
-    encoded[magic.len] = schema_version - 1;
+    encoded[magic.len] = 2;
+    try io_mod.durableReplaceVerified(alloc, &verified, sidecar_file, encoded);
+    var stale_presentation = try loadMatching(alloc, &verified, "session-1", boundary);
+    defer stale_presentation.deinit(alloc);
+    try std.testing.expect(stale_presentation == .invalid);
+
+    encoded[magic.len] = 1;
     try io_mod.durableReplaceVerified(alloc, &verified, sidecar_file, encoded);
     var old_schema = try loadMatching(alloc, &verified, "session-1", boundary);
     defer old_schema.deinit(alloc);

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -27,6 +27,7 @@ const ui_render = @import("../render.zig");
 const types = @import("../../core/shared/types.zig");
 const command_output_content = @import("../../core/tooling/command_output_content.zig");
 const captured_command = @import("../../core/tooling/captured_command.zig");
+const tool_result_errors = @import("../../core/tooling/tool_result_errors.zig");
 const vt_emulator = @import("../../core/terminal/engine.zig");
 const result_store = @import("../../core/session/result_store.zig");
 const session_child_store = @import("../../core/session/session_child_store.zig");
@@ -2479,6 +2480,46 @@ test "historical deferred tool detail keeps the call without result evidence" {
     try std.testing.expectEqual(types.ToolOutcomeKind.failed, failed_detail.outcome.?);
     try std.testing.expectEqualStrings("ordinary failure", failed_detail.result.?);
     try std.testing.expectEqualStrings("ordinary-failure.txt", failed_detail.result_handle.?);
+}
+
+test "historical permission denial keeps denied outcome without internal result detail" {
+    const alloc = std.testing.allocator;
+    const denial_output = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"auto_denied\"}}";
+    var runtime = TranscriptRuntime{};
+    defer runtime.deinit(alloc);
+
+    var metrics: Metrics = .{};
+    const entry_id = try runtime.writeCompletedToolStatusReturningEntryId(
+        alloc,
+        &metrics,
+        .denied,
+        "Denied by auto agent pwd",
+        true,
+    );
+    try runtime.attachHistoricalToolDetail(
+        alloc,
+        entry_id,
+        .{
+            .id = "denied-command",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"pwd\"}",
+        },
+        .command,
+        .{
+            .tool_call_id = @constCast("denied-command"),
+            .tool_name = @constCast("terminal"),
+            .status = .failure,
+            .output = @constCast(denial_output),
+            .output_bytes = denial_output.len,
+            .stored_output_bytes = denial_output.len,
+        },
+    );
+
+    const detail = runtime.toolDetailForEntry(entry_id).?;
+    try std.testing.expectEqual(types.ToolOutcomeKind.denied, detail.outcome.?);
+    try std.testing.expect(detail.result == null);
+    try std.testing.expect(detail.result_handle == null);
+    try std.testing.expect(detail.command_output_entry_id == null);
 }
 
 test "historical command detail keeps artifact handles after command block attaches" {
@@ -5231,7 +5272,8 @@ pub const TranscriptRuntime = struct {
     ) !void {
         const context_deferred = types.isContextDeferredToolResult(result);
         const deferred = types.isDeferredToolResult(result);
-        const command_artifact_handle = if (!deferred and activity_kind == .command)
+        const permission_denied = tool_result_errors.toolPermissionDenialReason(result.output) != null;
+        const command_artifact_handle = if (!deferred and !permission_denied and activity_kind == .command)
             command_output_runtime.commandArtifactHandleFromResult(result.output)
         else
             null;
@@ -5244,7 +5286,7 @@ pub const TranscriptRuntime = struct {
             activity_kind,
             if (context_deferred)
                 .deferred
-            else if (deferred)
+            else if (deferred or permission_denied)
                 .denied
             else if (result.status == .success or
                 (activity_kind == .command and
@@ -5252,8 +5294,8 @@ pub const TranscriptRuntime = struct {
                 .completed
             else
                 .failed,
-            if (deferred) null else result.output,
-            if (deferred) null else .{
+            if (deferred or permission_denied) null else result.output,
+            if (deferred or permission_denied) null else .{
                 .output_handle = result.output_handle,
                 .preview = result.preview,
                 .output_bytes = result.output_bytes,
@@ -5263,7 +5305,7 @@ pub const TranscriptRuntime = struct {
                 .command_process_presentation = result.command_process_presentation,
             },
             command_artifact_handle,
-            if (deferred) null else command_output_entry_id,
+            if (deferred or permission_denied) null else command_output_entry_id,
         );
     }
 

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -280,12 +280,10 @@ fn normalizeCanonicalStatus(
 ) !?[]const u8 {
     var index: usize = 0;
     while (skipSgrSequence(text, &index)) {}
-    const marker = if (std.mem.startsWith(u8, text[index..], "●"))
-        "●"
-    else if (std.mem.startsWith(u8, text[index..], "■"))
-        "■"
-    else
-        return null;
+    const markers = [_][]const u8{ "●", "■", "⊘", "↻" };
+    const marker = for (markers) |candidate| {
+        if (std.mem.startsWith(u8, text[index..], candidate)) break candidate;
+    } else return null;
     index += marker.len;
     while (skipSgrSequence(text, &index)) {}
     while (index < text.len and (text[index] == ' ' or text[index] == '\t')) : (index += 1) {}
@@ -1114,6 +1112,28 @@ test "small minimal tool groups surface canonical action targets" {
             "├ Read runtime.zig\n" ++
             "├ Searched snapshot\n" ++
             "└ Editing store.zig",
+        projection.entry_actions.items[0].override.bytes,
+    );
+}
+
+test "minimal tool groups preserve denied and deferred action text" {
+    const alloc = std.testing.allocator;
+    const entries = [_]TranscriptEntry{
+        .{ .raw_bytes = .{ .id = 1, .bytes = "⊘ Denied by auto agent zig build\n", .class = .tool_status } },
+        .{ .raw_bytes = .{ .id = 2, .bytes = "↻ Context updated runtime.zig\n", .class = .tool_status } },
+    };
+    const details = [_]ToolDetailRecord{
+        .{ .entry_id = 1, .tool_name = @constCast("terminal"), .activity_kind = .command, .outcome = .denied },
+        .{ .entry_id = 2, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .deferred },
+    };
+
+    var projection = try build(alloc, &entries, &details, 120);
+    defer projection.deinit(alloc);
+
+    try std.testing.expectEqualStrings(
+        "● 2 tool calls · 1 read · 1 command · 1 denied · 1 deferred\n" ++
+            "├ Denied by auto agent zig build\n" ++
+            "└ Context updated runtime.zig",
         projection.entry_actions.items[0].override.bytes,
     );
 }

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -2499,7 +2499,7 @@ describe("effect-aware command permissions", () => {
     async () => {
       const root = createIsolatedRoot();
       const marker = join(root.workspace, "classifier-user-check.txt");
-      const command = `printf user-check > ${JSON.stringify(marker)}`;
+      const command = "printf user-check > classifier-user-check.txt";
       const gateway = startFakeGateway(
         [
           toolCall(command),
@@ -2534,6 +2534,9 @@ describe("effect-aware command permissions", () => {
       expect(existsSync(marker)).toBe(false);
       expect(gateway.classifierRequests).toHaveLength(1);
       expect(pane).not.toContain("Auto agent denied");
+      expect(pane).toContain("1 denied");
+      expect(pane).toContain(`Denied by auto agent ${command}`);
+      expect(pane).not.toContain("└ terminal");
       expect(gateway.requests).toHaveLength(2);
       const permissionResultRequest = gateway.requests[1]!.body;
       expect(permissionResultRequest).toContain("tool_permission_denied");
@@ -2544,12 +2547,41 @@ describe("effect-aware command permissions", () => {
       expect(trace).toContain("decision=deny approval_source=denied");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
 
+      const sessionId = sessionIdFromHome(root);
+      await activeSession.sendText("/quit");
+      expect(await activeSession.waitForSessionEnd()).toBe(true);
+      await activeSession.kill();
+      activeSession = null;
+
+      rmSync(
+        join(root.home, ".fx", "sessions", sessionId, "resume-view.bin"),
+        { force: true },
+      );
+      activeSession = await TmuxSession.create({
+        cmd: `${FX_BIN} resume ${sessionId}`,
+        cwd: root.workspace,
+        env: gatewayEnv(root, gateway, { TMPDIR: root.root }),
+        stderrPath,
+        width: 120,
+        height: 40,
+      });
+      await activeSession.waitForComposer(TIMEOUT);
+      const resumedPane = await activeSession.waitForPane(
+        (value) => value.includes(`Denied by auto agent ${command}`),
+        TIMEOUT,
+      );
+      expect(resumedPane).toContain("1 denied");
+      expect(resumedPane).not.toContain("└ terminal");
+      expect(resumedPane).not.toContain("tool_permission_denied");
+      expect(gateway.requests).toHaveLength(2);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+
       await activeSession.sendText("/quit");
       expect(await activeSession.waitForSessionEnd()).toBe(true);
       await activeSession.kill();
       activeSession = null;
     },
-    TIMEOUT,
+    TIMEOUT * 2,
   );
 
   test.skipIf(!tmuxAvailable())(

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -6476,7 +6476,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       expect(queuedGateway.requests).toHaveLength(2);
       expect(pane).toContain("● 1 tool call · 1 read · 1 failed");
-      expect(pane).toContain("└ Connection interrupted before read_file ran");
+      expect(pane).toContain("└ Connection interrupted before tool call ran");
       expect(pane).not.toContain("● Reading");
     },
     TIMEOUT,

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -4133,8 +4133,12 @@ test.skipIf(!tmuxAvailable())(
     function expectDeferredPresentation(scrollback: string): void {
       expect(scrollback).toContain("1 failed");
       expect(scrollback).toContain("1 deferred");
-      expect(scrollback).not.toContain("Context updated");
+      expect(scrollback).toContain(`Context updated ${command}`);
       expect(scrollback).not.toContain("Not executed");
+      expect(scrollback).not.toContain("├ terminal");
+      expect(scrollback).not.toContain("└ terminal");
+      expect(scrollback).not.toContain("├ read_file");
+      expect(scrollback).not.toContain("└ read_file");
       expect(scrollback).not.toContain("● Failed nested/input.txt");
       expect(scrollback).not.toContain(`● Failed ${command}`);
       expect(scrollback).toContain("Read nested/input.txt");
@@ -4185,7 +4189,7 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("C-o");
       const detail = await active.waitForPane(
         (pane) =>
-          pane.includes(`↻ Context updated ${command}`) &&
+          pane.includes(`Context updated ${command}`) &&
           pane.includes("ordinary-failure-control"),
         TIMEOUT,
       );


### PR DESCRIPTION
## Summary

- Show real commands and action targets in denied and deferred compact tool rows instead of internal tool names.
- Preserve permission denial labels, outcomes, and action details when sessions resume.
- Rebuild stale rendered resume views and keep internal permission payloads out of the transcript.
- Use a neutral label when registered tool arguments or provisional state lacks display details, while retaining unknown MCP tool names.