### PR TITLE
Add per-model AI Gateway provider routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ The status line hides the workspace path and Git branch by default. Enable the `
 }
 ```
 
+Gateway requests can be routed to specific upstream providers per model with `providerRouting` in `~/.fx/settings.json`. Provider slugs follow the AI Gateway's provider filtering and ordering. An entry keyed by model ID applies to that model; the `default` entry applies to every other model:
+
+```json
+{
+  "providerRouting": {
+    "default": { "order": ["wafer"] },
+    "anthropic/claude-sonnet-5": { "only": ["baseten"], "order": ["baseten", "bedrock"] }
+  }
+}
+```
+
+`order` lists the providers to attempt in sequence and `only` restricts routing to the listed providers. Workspace overrides in `~/.fx/settings.json` layer over profile-global entries per model.
+
 List saved sessions with `fx sessions`. Resume the latest session for the current workspace, or select an exact session ID, through the same command group:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Gateway requests can be routed to specific upstream providers per model with `pr
 {
   "providerRouting": {
     "default": { "order": ["wafer"] },
-    "anthropic/claude-sonnet-5": { "only": ["baseten"], "order": ["baseten", "bedrock"] }
+    "anthropic/claude-sonnet-5": { "only": ["baseten"], "order": ["baseten", "bedrock"] },
+    "zai/glm-5.3": { "only": ["togetherai"], "order": ["togetherai"] }
   }
 }
 ```

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -790,6 +790,7 @@ fn buildAgentConfig(state: *server.ServerState, session: *server.ActiveSessionSt
         else
             false,
         .context_limits = state.context_limits,
+        .gateway_provider_routing = &state.provider_routing,
     };
 }
 
@@ -4183,6 +4184,7 @@ test "ACP prompt agent config carries request options from active session" {
     try std.testing.expect(tool_projection_mod.containsName(config.advertised_tool_names, "read_file"));
     try std.testing.expectEqualStrings("acp custom tool guidance", config.custom_tool_guidance);
     try std.testing.expectEqualStrings("ACP test model overlay", config.model_prompt_overlay.?);
+    try std.testing.expect(config.gateway_provider_routing == &state.provider_routing);
     var ctx = AcpContext{ .alloc = alloc, .state = &state, .session_id = "session_1" };
     const tool_ctx = ctx.toolContext();
     try std.testing.expect(!tool_ctx.web_search_runtime_ready);

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -228,6 +228,7 @@ pub const ServerState = struct {
     agent_step_limit: usize = 0,
     max_tool_result_bytes: usize = 64 * 1024,
     context_limits: config_runtime.context_limits.Values = .{},
+    provider_routing: config_runtime.provider_routing.Map = .{},
     fast_mode: bool = false,
     effort: types.ReasoningEffort = .auto,
     first_call_tool_choice: types.ToolChoice = .auto,
@@ -273,6 +274,7 @@ pub const ServerState = struct {
         if (self.selected_model.len > 0) self.alloc.free(self.selected_model);
         if (self.configured_model.len > 0) self.alloc.free(self.configured_model);
         self.permission_rules.deinit(self.alloc);
+        self.provider_routing.deinit(self.alloc);
         self.background.deinit(std.heap.c_allocator);
         self.skills.deinit(self.alloc);
         self.context_snapshot.deinit(self.alloc);
@@ -1404,6 +1406,7 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
     state.max_tool_result_bytes = startup.max_tool_result_bytes;
     state.context_limits = startup.context_limits;
     state.context_limits.applyCommandLine(state.cfg.context_limit_overrides);
+    state.provider_routing = startup.takeProviderRouting();
     state.fast_mode = startup.fast_mode and
         (state.cfg.model_override == null or startup.fast_mode_source != .compiled_default);
     state.effort = startup.effort;

--- a/src/core/agent/runtime/config.zig
+++ b/src/core/agent/runtime/config.zig
@@ -4,6 +4,7 @@ const tool_result_limits = @import("../../tooling/tool_result_limits.zig");
 const session_child_store = @import("../../session/session_child_store.zig");
 const command_replay_store = @import("../../session/command_replay_store.zig");
 const context_limits = @import("../../config/context_limits.zig");
+const provider_routing = @import("../../config/provider_routing.zig");
 const workspace_access = @import("../../workspace/workspace_access.zig");
 const model_response_recovery = @import("model_response_recovery.zig");
 const provider_set = @import("../../gateway/provider_set.zig");
@@ -65,4 +66,6 @@ pub const Config = struct {
     ephemeral_command_replay: ?*command_replay_store.EphemeralStore = null,
     subagent_id: u64 = 0,
     context_limits: context_limits.Values = .{},
+    /// Borrowed from App-owned state; must outlive every turn it configures.
+    gateway_provider_routing: ?*const provider_routing.Map = null,
 };

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3493,7 +3493,15 @@ fn processQueuedPromptLoop(
                 projected_request_messages,
             );
             last_gateway_message_count = request_messages.len;
-            const provider_opts = model_capabilities.resolveProviderOptionsForCapabilities(request_capabilities, config.effort, route_fast_mode);
+            var provider_opts = model_capabilities.resolveProviderOptionsForCapabilities(request_capabilities, config.effort, route_fast_mode);
+            if (job.provider == .gateway) {
+                if (config.gateway_provider_routing) |routing| {
+                    if (routing.lookup(gateway_model)) |route| {
+                        provider_opts.gateway_order = route.order;
+                        provider_opts.gateway_only = route.only;
+                    }
+                }
+            }
             runtime_telemetry.traceGatewayProviderOptions(step_ctx, gateway_model, route_fast_mode, config.effort, provider_opts);
             const tool_choice: types.ToolChoice = if (recovery_strategy == .reconcile_tool)
                 .none

--- a/src/core/agent/runtime/telemetry.zig
+++ b/src/core/agent/runtime/telemetry.zig
@@ -304,17 +304,29 @@ pub fn traceGatewayProviderOptions(ctx: TraceContext, model: []const u8, fast_mo
         "default"
     else
         "unsupported_or_missing";
+    const gateway_order_first = if (provider_opts.gateway_order.len > 0)
+        provider_opts.gateway_order[0]
+    else
+        "none";
+    const gateway_only_first = if (provider_opts.gateway_only.len > 0)
+        provider_opts.gateway_only[0]
+    else
+        "none";
     debug_trace.eventf(
         "gateway",
         "provider_options",
         ctx,
-        "model={s} fast_mode={s} effort={s} reasoning={s} fast={s}",
+        "model={s} fast_mode={s} effort={s} reasoning={s} fast={s} gateway_order_count={d} gateway_order_first={s} gateway_only_count={d} gateway_only_first={s}",
         .{
             model,
             if (fast_mode) "true" else "false",
             effort.label(),
             reasoning_outcome,
             fast_outcome,
+            provider_opts.gateway_order.len,
+            gateway_order_first,
+            provider_opts.gateway_only.len,
+            gateway_only_first,
         },
     );
 }

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -215,6 +215,89 @@ test "processQueuedPrompt accounts exact direct-provider usage without deferred 
     try std.testing.expectEqual(@as(?u64, 1), snapshot.request_count);
 }
 
+test "processQueuedPrompt applies gateway provider routing to request bodies" {
+    const alloc = std.testing.allocator;
+    const provider_routing = @import("../../../config/provider_routing.zig");
+
+    const completions = [_]FakeCompletion{.{ .content = "ok" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+
+    const exact_text =
+        \\{"default": {"only": ["wafer"]}, "anthropic/claude-opus-4.6": {"order": ["baseten", "bedrock"]}}
+    ;
+    const exact_parsed = try std.json.parseFromSlice(std.json.Value, alloc, exact_text, .{});
+    defer exact_parsed.deinit();
+    var routing = try provider_routing.parseJsonObject(exact_parsed.value, alloc);
+    defer routing.deinit(alloc);
+
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.gateway_provider_routing = &routing;
+
+    try test_support.runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
+    try expectBodyContains(
+        &gateway,
+        0,
+        "\"providerOptions\":{\"gateway\":{\"order\":[\"baseten\",\"bedrock\"]}}",
+    );
+    try expectBodyNotContains(&gateway, 0, "\"only\"");
+}
+
+test "processQueuedPrompt falls back to default gateway provider routing" {
+    const alloc = std.testing.allocator;
+    const provider_routing = @import("../../../config/provider_routing.zig");
+
+    const completions = [_]FakeCompletion{.{ .content = "ok" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+
+    const default_text =
+        \\{"default": {"order": ["wafer"], "only": ["wafer"]}}
+    ;
+    const default_parsed = try std.json.parseFromSlice(std.json.Value, alloc, default_text, .{});
+    defer default_parsed.deinit();
+    var routing = try provider_routing.parseJsonObject(default_parsed.value, alloc);
+    defer routing.deinit(alloc);
+
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.gateway_provider_routing = &routing;
+
+    try test_support.runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
+    try expectBodyContains(
+        &gateway,
+        0,
+        "\"providerOptions\":{\"gateway\":{\"order\":[\"wafer\"],\"only\":[\"wafer\"]}}",
+    );
+}
+
+test "processQueuedPrompt omits providerOptions without configured routing" {
+    const alloc = std.testing.allocator;
+
+    const completions = [_]FakeCompletion{.{ .content = "ok" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+
+    var fixture = PromptFixture{};
+    const config = fixture.config();
+
+    try test_support.runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
+    try expectBodyNotContains(&gateway, 0, "\"providerOptions\":{\"gateway\"");
+}
+
 fn makeOwnedProviderPrompt(alloc: Allocator, text: []const u8, model: []const u8) !QueuedPrompt {
     const prompt = try alloc.dupe(u8, text);
     errdefer alloc.free(prompt);

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -248,6 +248,41 @@ test "processQueuedPrompt applies gateway provider routing to request bodies" {
     try expectBodyNotContains(&gateway, 0, "\"only\"");
 }
 
+test "processQueuedPrompt pins glm-5.3 to togetherai from settings-shaped routing" {
+    const alloc = std.testing.allocator;
+    const provider_routing = @import("../../../config/provider_routing.zig");
+
+    const completions = [_]FakeCompletion{.{ .content = "ok" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+
+    const routing_text =
+        \\{"default": {"order": ["wafer"]}, "deepseek/deepseek-v4-flash-0731": {"only": ["wafer"]}, "zai/glm-5.3": {"only": ["togetherai"], "order": ["togetherai"]}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, routing_text, .{});
+    defer parsed.deinit();
+    var routing = try provider_routing.parseJsonObject(parsed.value, alloc);
+    defer routing.deinit(alloc);
+
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.gateway_provider_routing = &routing;
+    var job = fixture.job();
+    job.model = @constCast("zai/glm-5.3");
+
+    try test_support.runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
+    try expectBodyContains(
+        &gateway,
+        0,
+        "\"providerOptions\":{\"gateway\":{\"order\":[\"togetherai\"],\"only\":[\"togetherai\"]}}",
+    );
+    try expectBodyContains(&gateway, 0, "\"provider\":{\"order\":[\"togetherai\"],\"only\":[\"togetherai\"]}");
+}
+
 test "processQueuedPrompt falls back to default gateway provider routing" {
     const alloc = std.testing.allocator;
     const provider_routing = @import("../../../config/provider_routing.zig");
@@ -2738,6 +2773,8 @@ test "processQueuedPrompt traces selected live controls without request payloads
     try std.testing.expect(std.mem.find(u8, trace, "effort=max") != null);
     try std.testing.expect(std.mem.find(u8, trace, "reasoning=selected") != null);
     try std.testing.expect(std.mem.find(u8, trace, "fast=selected") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "gateway_order_count=0") != null);
+    try std.testing.expect(std.mem.find(u8, trace, "gateway_only_count=0") != null);
     try std.testing.expect(std.mem.find(u8, trace, "\"reasoning\"") == null);
     try std.testing.expect(std.mem.find(u8, trace, "api-key") == null);
     try std.testing.expect(std.mem.find(u8, trace, "user prompt") == null);

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1156,6 +1156,7 @@ pub fn Runtime(comptime App: type) type {
                     false,
                 .session_child_capability = session_child_capability,
                 .context_limits = if (comptime @hasField(App, "context_limits")) app.context_limits else .{},
+                .gateway_provider_routing = if (comptime @hasField(App, "provider_routing")) &app.provider_routing else null,
             };
         }
     };

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -286,6 +286,7 @@ pub fn Runtime(comptime App: type) type {
             app.agent_step_limit = startup.agent_step_limit;
             app.worker.agent_turn_settings.max_tool_result_bytes = startup.max_tool_result_bytes;
             if (comptime @hasField(App, "context_limits")) app.context_limits = startup.context_limits;
+            if (comptime @hasField(App, "provider_routing")) app.provider_routing = startup.takeProviderRouting();
             app.worker.agent_turn_settings.first_call_tool_choice = startup.first_call_tool_choice;
             app.worker.agent_turn_settings.fast_mode = startup.fast_mode;
             app.worker.agent_turn_settings.effort = startup.effort;

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -129,6 +129,7 @@ pub const StartupState = struct {
     agent_step_limit: usize,
     max_tool_result_bytes: usize = tool_result_limits.default_max_tool_result_bytes,
     context_limits: config_runtime.context_limits.Values = .{},
+    provider_routing: config_runtime.provider_routing.Map = .{},
     context_enabled: bool = true,
     fast_mode: bool = false,
     fast_mode_source: config_runtime.ConfigSource = .compiled_default,
@@ -157,6 +158,7 @@ pub const StartupState = struct {
         if (self.selected_model.len > 0) alloc.free(self.selected_model);
         if (self.configured_model.len > 0) alloc.free(self.configured_model);
         self.permission_rules.deinit(alloc);
+        self.provider_routing.deinit(alloc);
         if (self.config_diagnostics.len > 0) {
             for (self.config_diagnostics) |*diagnostic| diagnostic.deinit(alloc);
             alloc.free(self.config_diagnostics);
@@ -173,6 +175,12 @@ pub const StartupState = struct {
     pub fn takeWorkspaceAccess(self: *StartupState) workspace_access.WorkspaceAccess {
         const value = self.workspace_access;
         self.workspace_access = .{};
+        return value;
+    }
+
+    pub fn takeProviderRouting(self: *StartupState) config_runtime.provider_routing.Map {
+        const value = self.provider_routing;
+        self.provider_routing = .{};
         return value;
     }
 
@@ -422,6 +430,7 @@ fn loadStartupStateFromOwnedWorkspace(
     state.agent_step_limit = loadAgentStepLimit(default_agent_step_limit, settings.max_agent_steps);
     state.max_tool_result_bytes = tool_result_limits.resolveMaxToolResultBytes(settings.max_tool_result_bytes, tool_result_limits.default_max_tool_result_bytes);
     state.context_limits = config_runtime.resolveContextLimits(settings, &.{});
+    state.provider_routing = try settings.provider_routing.dupe(alloc);
     state.context_enabled = settings.context orelse true;
     state.fast_mode = settings.fast_mode orelse
         (state.provider == .gateway and state.model_source == .compiled_default);

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -534,6 +534,7 @@ const AskContext = struct {
     agent_step_limit: usize = 0,
     max_tool_result_bytes: usize = 64 * 1024,
     context_limits: config_runtime.context_limits.Values = .{},
+    provider_routing: config_runtime.provider_routing.Map = .{},
     fast_mode: bool = false,
     effort: types.ReasoningEffort = .auto,
     first_call_tool_choice: types.ToolChoice = .auto,
@@ -732,6 +733,7 @@ const AskContext = struct {
         if (self.store) |*store| store.deinit(self.alloc);
         self.ephemeral_command_replay.deinit();
         self.permission_rules.deinit(self.alloc);
+        self.provider_routing.deinit(self.alloc);
         self.session.deinit(self.alloc);
         if (self.skills_dir.len > 0) self.alloc.free(self.skills_dir);
         self.context_snapshot.deinit(self.alloc);
@@ -1498,6 +1500,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     ctx.max_tool_result_bytes = startup.max_tool_result_bytes;
     ctx.context_limits = startup.context_limits;
     ctx.context_limits.applyCommandLine(cfg.context_limit_overrides);
+    ctx.provider_routing = startup.takeProviderRouting();
     ctx.fast_mode = startup.fast_mode;
     ctx.effort = toCoreReasoningEffort(startup.effort);
     ctx.first_call_tool_choice = startup.first_call_tool_choice;
@@ -1792,6 +1795,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         else
             false,
         .context_limits = ctx.context_limits,
+        .gateway_provider_routing = &ctx.provider_routing,
         .session_child_capability = session_child_capability,
         .ephemeral_command_replay = if (session_child_capability == null)
             &ctx.ephemeral_command_replay

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -623,6 +623,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "credential_source",
         "yolo_acknowledged",
         "permission",
+        "providerRouting",
         "additional_directories",
     }) |profile_key| {
         if (std.mem.eql(u8, key, profile_key)) return true;
@@ -1957,6 +1958,32 @@ test "loadMergedSettings merges project defaults before profile layers" {
     try std.testing.expectEqualStrings("override-model", settings.models.get(.gateway).?);
     try std.testing.expectEqual(types.PermissionMode.auto, settings.permission_mode.?);
     try std.testing.expectEqual(@as(usize, 8), settings.max_agent_steps.?);
+}
+
+test "provider routing loads glm-5.3 togetherai pins from profile settings" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+    const home_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "home");
+    defer std.testing.allocator.free(home_root);
+    const workspace_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "workspace");
+    defer std.testing.allocator.free(workspace_root);
+
+    try writeFixtureFile(
+        tmp.dir,
+        "home/.fx/settings.json",
+        "{\"providerRouting\":{\"default\":{\"order\":[\"wafer\"]},\"deepseek/deepseek-v4-flash-0731\":{\"only\":[\"wafer\"]},\"zai/glm-5.3\":{\"only\":[\"togetherai\"],\"order\":[\"togetherai\"]}},\"models\":{\"gateway\":\"zai/glm-5.3\"}}",
+    );
+
+    var settings = try loadMergedSettingsFromHome(std.testing.allocator, home_root, workspace_root);
+    defer settings.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("zai/glm-5.3", settings.models.get(.gateway).?);
+    const exact = settings.provider_routing.lookup("zai/glm-5.3").?;
+    try std.testing.expectEqualStrings("togetherai", exact.only[0]);
+    try std.testing.expectEqualStrings("togetherai", exact.order[0]);
 }
 
 test "provider routing merges profile layers with exact match over default" {

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -12,6 +12,7 @@ const model_provider = @import("model_provider.zig");
 const model_preferences = @import("model_preferences.zig");
 const update_target = @import("../upgrade/update_target.zig");
 pub const context_limits = @import("context_limits.zig");
+pub const provider_routing = @import("provider_routing.zig");
 
 const Allocator = std.mem.Allocator;
 const max_settings_bytes: usize = 64 * 1024;
@@ -63,10 +64,13 @@ pub const Settings = struct {
     notification_max: ?bool = null,
     permission_rules: types.PermissionRuleSet = .{},
     has_permission_rules: bool = false,
+    provider_routing: provider_routing.Map = .{},
+    has_provider_routing: bool = false,
 
     pub fn deinit(self: *Settings, alloc: Allocator) void {
         self.models.deinit(alloc);
         self.permission_rules.deinit(alloc);
+        self.provider_routing.deinit(alloc);
         self.* = .{};
     }
 };
@@ -1488,6 +1492,16 @@ fn parseProfileOnlyFields(
         }
     }
 
+    if (root.object.get("providerRouting")) |routing_value| {
+        if (routing_value != .object) {
+            if (!tolerate_non_object_user_containers) return error.InvalidProviderRoutingType;
+        } else {
+            settings.provider_routing.deinit(alloc);
+            settings.provider_routing = try provider_routing.parseJsonObject(routing_value, alloc);
+            settings.has_provider_routing = true;
+        }
+    }
+
     if (root.object.get("notifications")) |notifications_value| {
         if (notifications_value != .object) return error.InvalidNotificationsType;
         if (notifications_value.object.get("turn_end")) |value| {
@@ -1567,6 +1581,12 @@ fn mergeSettings(target: *Settings, incoming: *Settings, alloc: Allocator) void 
         incoming.permission_rules = .{};
         target.has_permission_rules = true;
         incoming.has_permission_rules = false;
+    }
+
+    if (incoming.has_provider_routing) {
+        target.provider_routing.merge(&incoming.provider_routing, alloc);
+        incoming.has_provider_routing = false;
+        target.has_provider_routing = true;
     }
 }
 
@@ -1937,6 +1957,57 @@ test "loadMergedSettings merges project defaults before profile layers" {
     try std.testing.expectEqualStrings("override-model", settings.models.get(.gateway).?);
     try std.testing.expectEqual(types.PermissionMode.auto, settings.permission_mode.?);
     try std.testing.expectEqual(@as(usize, 8), settings.max_agent_steps.?);
+}
+
+test "provider routing merges profile layers with exact match over default" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+    const home_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "home");
+    defer std.testing.allocator.free(home_root);
+    const workspace_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "workspace");
+    defer std.testing.allocator.free(workspace_root);
+
+    const user_settings = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"providerRouting\":{{\"default\":{{\"only\":[\"wafer\"]}}}},\"workspaces\":{{\"{s}\":{{\"providerRouting\":{{\"anthropic/claude-sonnet-5\":{{\"order\":[\"baseten\",\"bedrock\"]}}}}}}}}}}",
+        .{workspace_root},
+    );
+    defer std.testing.allocator.free(user_settings);
+    try writeFixtureFile(tmp.dir, "home/.fx/settings.json", user_settings);
+
+    var settings = try loadMergedSettingsFromHome(std.testing.allocator, home_root, workspace_root);
+    defer settings.deinit(std.testing.allocator);
+
+    try std.testing.expect(settings.has_provider_routing);
+    const exact = settings.provider_routing.lookup("anthropic/claude-sonnet-5").?;
+    try std.testing.expectEqual(@as(usize, 2), exact.order.len);
+    try std.testing.expectEqualStrings("bedrock", exact.order[1]);
+    const fallback = settings.provider_routing.lookup("openai/gpt-5").?;
+    try std.testing.expectEqualStrings("wafer", fallback.only[0]);
+}
+
+test "invalid provider routing settings fail parsing" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+    const home_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "home");
+    defer std.testing.allocator.free(home_root);
+    const workspace_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "workspace");
+    defer std.testing.allocator.free(workspace_root);
+
+    try writeFixtureFile(
+        tmp.dir,
+        "home/.fx/settings.json",
+        "{\"providerRouting\":{\"a/b\":{\"only\":\"wafer\"}}}",
+    );
+
+    const result = loadMergedSettingsFromHome(std.testing.allocator, home_root, workspace_root);
+    try std.testing.expectError(error.InvalidProviderRoutingSlugType, result);
 }
 
 test "context limits resolve command line over workspace and global profile values" {

--- a/src/core/config/model_capabilities.zig
+++ b/src/core/config/model_capabilities.zig
@@ -6,6 +6,10 @@ pub const ResolvedProviderOptions = struct {
     fast: bool = false,
     parallel_tool_calls: ?bool = null,
     prompt_caching: bool = false,
+    /// AI Gateway provider-routing slugs. Borrowed from config-owned
+    /// state and not owned here.
+    gateway_order: []const []const u8 = &.{},
+    gateway_only: []const []const u8 = &.{},
 };
 
 pub const ReasoningEffortOptions = struct {

--- a/src/core/config/provider_routing.zig
+++ b/src/core/config/provider_routing.zig
@@ -1,0 +1,348 @@
+const std = @import("std");
+
+const Allocator = std.mem.Allocator;
+
+pub const max_model_entries: usize = 32;
+pub const max_slugs_per_list: usize = 16;
+pub const max_slug_bytes: usize = 128;
+pub const max_model_key_bytes: usize = 512;
+
+/// Reserved map key applying to models without an exact entry.
+/// Gateway model IDs always contain a `/`, so this cannot collide.
+pub const default_key = "default";
+
+/// AI Gateway provider-routing controls for one model.
+/// Slugs are owned by the enclosing `Map`.
+pub const Routing = struct {
+    order: []const []const u8 = &.{},
+    only: []const []const u8 = &.{},
+};
+
+const ModelEntry = struct {
+    model: []u8,
+    routing: Routing,
+};
+
+pub const ParseError = error{
+    InvalidProviderRoutingType,
+    InvalidProviderRoutingEntryType,
+    InvalidProviderRoutingSlugType,
+    InvalidProviderRoutingSlugValue,
+    InvalidProviderRoutingDuplicateField,
+    InvalidProviderRoutingTooManyEntries,
+    InvalidProviderRoutingTooManySlugs,
+    InvalidProviderRoutingModelKey,
+} || Allocator.Error;
+
+fn dupeSlugs(
+    alloc: Allocator,
+    value: std.json.Value,
+) ParseError![]const []const u8 {
+    if (value != .array) return error.InvalidProviderRoutingSlugType;
+    if (value.array.items.len > max_slugs_per_list) return error.InvalidProviderRoutingTooManySlugs;
+
+    const slugs = try alloc.alloc([]const u8, value.array.items.len);
+    errdefer alloc.free(slugs);
+    for (value.array.items, 0..) |item, i| {
+        if (item != .string) return error.InvalidProviderRoutingSlugType;
+        const raw = item.string;
+        if (raw.len == 0 or raw.len > max_slug_bytes) return error.InvalidProviderRoutingSlugValue;
+        slugs[i] = try alloc.dupe(u8, raw);
+    }
+    return slugs;
+}
+
+fn freeSlugs(alloc: Allocator, slugs: []const []const u8) void {
+    for (slugs) |slug| alloc.free(slug);
+    alloc.free(slugs);
+}
+
+fn freeEntry(alloc: Allocator, entry: ModelEntry) void {
+    alloc.free(entry.model);
+    freeSlugs(alloc, entry.routing.order);
+    freeSlugs(alloc, entry.routing.only);
+}
+
+fn dupeSlugList(alloc: Allocator, slugs: []const []const u8) Allocator.Error![]const []const u8 {
+    const copy = try alloc.alloc([]const u8, slugs.len);
+    errdefer alloc.free(copy);
+    for (slugs, 0..) |slug, i| copy[i] = try alloc.dupe(u8, slug);
+    return copy;
+}
+
+fn parseRoutingEntry(value: std.json.Value, alloc: Allocator) ParseError!Routing {
+    if (value != .object) return error.InvalidProviderRoutingEntryType;
+
+    var order: ?[]const []const u8 = null;
+    var only: ?[]const []const u8 = null;
+    errdefer {
+        if (order) |slugs| alloc.free(slugs);
+        if (only) |slugs| alloc.free(slugs);
+    }
+    var iterator = value.object.iterator();
+    while (iterator.next()) |entry| {
+        const key = entry.key_ptr.*;
+        if (std.mem.eql(u8, key, "order")) {
+            if (order != null) return error.InvalidProviderRoutingDuplicateField;
+            order = try dupeSlugs(alloc, entry.value_ptr.*);
+        } else if (std.mem.eql(u8, key, "only")) {
+            if (only != null) return error.InvalidProviderRoutingDuplicateField;
+            only = try dupeSlugs(alloc, entry.value_ptr.*);
+        } else {
+            return error.InvalidProviderRoutingEntryType;
+        }
+    }
+
+    const resolved_order = order orelse &.{};
+    const resolved_only = only orelse &.{};
+    if (resolved_order.len == 0 and resolved_only.len == 0) {
+        if (order) |slugs| alloc.free(slugs);
+        if (only) |slugs| alloc.free(slugs);
+        return .{};
+    }
+    return .{ .order = resolved_order, .only = resolved_only };
+}
+
+/// Per-model Gateway routing configuration parsed from the
+/// `providerRouting` settings object. Owned strings live in `alloc`.
+pub const Map = struct {
+    default: ?Routing = null,
+    models: std.ArrayList(ModelEntry) = .empty,
+
+    pub fn isEmpty(self: *const Map) bool {
+        return self.default == null and self.models.items.len == 0;
+    }
+
+    pub fn deinit(self: *Map, alloc: Allocator) void {
+        if (self.default) |default| {
+            freeSlugs(alloc, default.order);
+            freeSlugs(alloc, default.only);
+        }
+        for (self.models.items) |entry| {
+            freeEntry(alloc, entry);
+        }
+        self.models.deinit(alloc);
+        self.* = .{};
+    }
+
+    /// Exact model-id match wins over `default`. Returns null when no
+    /// applicable entry exists.
+    pub fn lookup(self: *const Map, model: []const u8) ?Routing {
+        for (self.models.items) |entry| {
+            if (std.mem.eql(u8, entry.model, model)) return entry.routing;
+        }
+        return self.default;
+    }
+
+    /// Layers `incoming` over `self`, taking ownership of its entries.
+    /// A higher layer's entry for the same model (or its `default`)
+    /// replaces the lower layer's; unrelated entries are preserved.
+    /// Infallible: an out-of-memory append skips that single entry.
+    pub fn merge(self: *Map, incoming: *Map, alloc: Allocator) void {
+        if (incoming.default) |incoming_default| {
+            if (self.default) |current| {
+                freeSlugs(alloc, current.order);
+                freeSlugs(alloc, current.only);
+            }
+            self.default = incoming_default;
+            incoming.default = null;
+        }
+        for (incoming.models.items) |entry| {
+            var replaced = false;
+            for (self.models.items) |*existing| {
+                if (std.mem.eql(u8, existing.model, entry.model)) {
+                    freeEntry(alloc, existing.*);
+                    existing.* = entry;
+                    replaced = true;
+                    break;
+                }
+            }
+            if (!replaced) {
+                self.models.append(alloc, entry) catch {
+                    freeEntry(alloc, entry);
+                };
+            }
+        }
+        incoming.models.clearRetainingCapacity();
+    }
+
+    pub fn dupe(self: *const Map, alloc: Allocator) Allocator.Error!Map {
+        var copy: Map = .{};
+        errdefer copy.deinit(alloc);
+        if (self.default) |default| {
+            copy.default = .{
+                .order = try dupeSlugList(alloc, default.order),
+                .only = try dupeSlugList(alloc, default.only),
+            };
+        }
+        try copy.models.ensureTotalCapacity(alloc, self.models.items.len);
+        for (self.models.items) |entry| {
+            const model_copy = try alloc.dupe(u8, entry.model);
+            errdefer alloc.free(model_copy);
+            const order_copy = try dupeSlugList(alloc, entry.routing.order);
+            errdefer alloc.free(order_copy);
+            const only_copy = try dupeSlugList(alloc, entry.routing.only);
+            errdefer alloc.free(only_copy);
+            copy.models.appendAssumeCapacity(.{
+                .model = model_copy,
+                .routing = .{ .order = order_copy, .only = only_copy },
+            });
+        }
+        return copy;
+    }
+};
+
+pub fn parseJsonObject(value: std.json.Value, alloc: Allocator) ParseError!Map {
+    if (value != .object) return error.InvalidProviderRoutingType;
+
+    var result: Map = .{};
+    errdefer result.deinit(alloc);
+
+    var iterator = value.object.iterator();
+    while (iterator.next()) |entry| {
+        const key = entry.key_ptr.*;
+        if (key.len == 0 or key.len > max_model_key_bytes) return error.InvalidProviderRoutingModelKey;
+
+        const routing = try parseRoutingEntry(entry.value_ptr.*, alloc);
+
+        if (std.mem.eql(u8, key, default_key)) {
+            if (routing.order.len > 0 or routing.only.len > 0) {
+                if (result.default != null) return error.InvalidProviderRoutingDuplicateField;
+                result.default = routing;
+            }
+            continue;
+        }
+
+        if (routing.order.len == 0 and routing.only.len == 0) continue;
+
+        if (result.models.items.len >= max_model_entries) return error.InvalidProviderRoutingTooManyEntries;
+        const model_copy = try alloc.dupe(u8, key);
+        errdefer alloc.free(model_copy);
+        try result.models.append(alloc, .{ .model = model_copy, .routing = routing });
+    }
+    return result;
+}
+
+test "parses default and per-model entries" {
+    const alloc = std.testing.allocator;
+    const json_text =
+        \\{
+        \\  "default": {"order": ["wafer"]},
+        \\  "anthropic/claude-sonnet-5": {"only": ["baseten"], "order": ["baseten", "bedrock"]}
+        \\}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, json_text, .{});
+    defer parsed.deinit();
+
+    var map = try parseJsonObject(parsed.value, alloc);
+    defer map.deinit(alloc);
+
+    try std.testing.expect(!map.isEmpty());
+    const fallback = map.lookup("openai/gpt-5").?;
+    try std.testing.expectEqual(@as(usize, 1), fallback.order.len);
+    try std.testing.expectEqualStrings("wafer", fallback.order[0]);
+    try std.testing.expectEqual(@as(usize, 0), fallback.only.len);
+
+    const exact = map.lookup("anthropic/claude-sonnet-5").?;
+    try std.testing.expectEqualStrings("baseten", exact.only[0]);
+    try std.testing.expectEqual(@as(usize, 2), exact.order.len);
+    try std.testing.expectEqualStrings("bedrock", exact.order[1]);
+}
+
+test "exact match wins over default and misses fall back" {
+    const alloc = std.testing.allocator;
+    const json_text =
+        \\{"default": {"only": ["wafer"]}, "a/b": {"only": ["c"]}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, json_text, .{});
+    defer parsed.deinit();
+
+    var map = try parseJsonObject(parsed.value, alloc);
+    defer map.deinit(alloc);
+
+    try std.testing.expectEqualStrings("c", map.lookup("a/b").?.only[0]);
+    try std.testing.expectEqualStrings("wafer", map.lookup("x/y").?.only[0]);
+    try std.testing.expect(map.default != null);
+}
+
+test "rejects malformed shapes" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct { json: []const u8, expected: anyerror }{
+        .{ .json = "[]", .expected = error.InvalidProviderRoutingType },
+        .{ .json = "\"x\"", .expected = error.InvalidProviderRoutingType },
+        .{ .json = "{\"a/b\": \"wafer\"}", .expected = error.InvalidProviderRoutingEntryType },
+        .{ .json = "{\"a/b\": {\"only\": \"wafer\"}}", .expected = error.InvalidProviderRoutingSlugType },
+        .{ .json = "{\"a/b\": {\"only\": [1]}}", .expected = error.InvalidProviderRoutingSlugType },
+        .{ .json = "{\"a/b\": {\"only\": [\"\"]}}", .expected = error.InvalidProviderRoutingSlugValue },
+        .{ .json = "{\"a/b\": {\"unknown\": [\"wafer\"]}}", .expected = error.InvalidProviderRoutingEntryType },
+        .{ .json = "{\"a/b\": {\"too\": 512}}", .expected = error.InvalidProviderRoutingEntryType },
+    };
+    for (cases) |case| {
+        const parsed = try std.json.parseFromSlice(std.json.Value, alloc, case.json, .{});
+        defer parsed.deinit();
+        try std.testing.expectError(case.expected, parseJsonObject(parsed.value, alloc));
+    }
+}
+
+test "empty entries are dropped" {
+    const alloc = std.testing.allocator;
+    const json_text =
+        \\{"a/b": {}, "c/d": {"only": []}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, json_text, .{});
+    defer parsed.deinit();
+
+    var map = try parseJsonObject(parsed.value, alloc);
+    defer map.deinit(alloc);
+
+    try std.testing.expect(map.isEmpty());
+    try std.testing.expect(map.lookup("a/b") == null);
+}
+
+test "merge layers incoming entries and preserves unrelated ones" {
+    const alloc = std.testing.allocator;
+    const base_text =
+        \\{"default": {"only": ["wafer"]}, "a/b": {"order": ["x"]}, "c/d": {"only": ["y"]}}
+    ;
+    const overlay_text =
+        \\{"default": {"only": ["z"]}, "a/b": {"order": ["w"]}}
+    ;
+    var base_map = try parseText(base_text, alloc);
+    defer base_map.deinit(alloc);
+    var overlay_map = try parseText(overlay_text, alloc);
+    defer overlay_map.deinit(alloc);
+
+    base_map.merge(&overlay_map, alloc);
+    try std.testing.expect(overlay_map.isEmpty());
+
+    try std.testing.expectEqualStrings("z", base_map.lookup("q/r").?.only[0]);
+    try std.testing.expectEqualStrings("w", base_map.lookup("a/b").?.order[0]);
+    try std.testing.expectEqualStrings("y", base_map.lookup("c/d").?.only[0]);
+}
+
+fn parseText(text: []const u8, alloc: Allocator) ParseError!Map {
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, text, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidProviderRoutingType,
+    };
+    defer parsed.deinit();
+    return parseJsonObject(parsed.value, alloc);
+}
+
+test "dupe produces an independent owned copy" {
+    const alloc = std.testing.allocator;
+    const json_text =
+        \\{"default": {"order": ["wafer", "baseten"]}, "a/b": {"only": ["c"]}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, json_text, .{});
+    defer parsed.deinit();
+
+    var map = try parseJsonObject(parsed.value, alloc);
+    defer map.deinit(alloc);
+
+    var copy = try map.dupe(alloc);
+    defer copy.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 2), copy.lookup("x/y").?.order.len);
+    try std.testing.expectEqualStrings("c", copy.lookup("a/b").?.only[0]);
+}

--- a/src/core/config/provider_routing.zig
+++ b/src/core/config/provider_routing.zig
@@ -128,8 +128,9 @@ pub const Map = struct {
     /// Exact model-id match wins over `default`. Returns null when no
     /// applicable entry exists.
     pub fn lookup(self: *const Map, model: []const u8) ?Routing {
+        const needle = std.mem.trim(u8, model, " \t\r\n");
         for (self.models.items) |entry| {
-            if (std.mem.eql(u8, entry.model, model)) return entry.routing;
+            if (std.mem.eql(u8, entry.model, needle)) return entry.routing;
         }
         return self.default;
     }
@@ -200,7 +201,7 @@ pub fn parseJsonObject(value: std.json.Value, alloc: Allocator) ParseError!Map {
 
     var iterator = value.object.iterator();
     while (iterator.next()) |entry| {
-        const key = entry.key_ptr.*;
+        const key = std.mem.trim(u8, entry.key_ptr.*, " \t\r\n");
         if (key.len == 0 or key.len > max_model_key_bytes) return error.InvalidProviderRoutingModelKey;
 
         const routing = try parseRoutingEntry(entry.value_ptr.*, alloc);
@@ -247,6 +248,22 @@ test "parses default and per-model entries" {
     try std.testing.expectEqualStrings("baseten", exact.only[0]);
     try std.testing.expectEqual(@as(usize, 2), exact.order.len);
     try std.testing.expectEqualStrings("bedrock", exact.order[1]);
+}
+
+test "trims model keys and lookup needles" {
+    const alloc = std.testing.allocator;
+    const json_text =
+        \\{"zai/glm-5.3": {"only": ["togetherai"], "order": ["togetherai"]}}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, json_text, .{});
+    defer parsed.deinit();
+
+    var map = try parseJsonObject(parsed.value, alloc);
+    defer map.deinit(alloc);
+
+    const route = map.lookup("  zai/glm-5.3\n").?;
+    try std.testing.expectEqualStrings("togetherai", route.only[0]);
+    try std.testing.expectEqualStrings("togetherai", route.order[0]);
 }
 
 test "exact match wins over default and misses fall back" {

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -489,6 +489,30 @@ pub fn writeProviderOptions(writer: *std.Io.Writer, options: model_capabilities.
         try writer.writeByte('}');
     }
     try writer.writeByte('}');
+    // Chat Completions / REST also accept a top-level `provider` object.
+    if (options.gateway_order.len > 0 or options.gateway_only.len > 0) {
+        try writer.writeAll(",\"provider\":{");
+        var wrote_provider_field = false;
+        if (options.gateway_order.len > 0) {
+            try writer.writeAll("\"order\":[");
+            for (options.gateway_order, 0..) |slug, index| {
+                if (index > 0) try writer.writeByte(',');
+                try std.json.Stringify.value(slug, .{}, writer);
+            }
+            try writer.writeByte(']');
+            wrote_provider_field = true;
+        }
+        if (options.gateway_only.len > 0) {
+            if (wrote_provider_field) try writer.writeByte(',');
+            try writer.writeAll("\"only\":[");
+            for (options.gateway_only, 0..) |slug, index| {
+                if (index > 0) try writer.writeByte(',');
+                try std.json.Stringify.value(slug, .{}, writer);
+            }
+            try writer.writeByte(']');
+        }
+        try writer.writeByte('}');
+    }
 }
 
 pub fn validateToolMessageHistory(alloc: std.mem.Allocator, messages: []const ChatMessage) !void {
@@ -1372,6 +1396,7 @@ test "buildGatewayRequestBodyWithOptions emits gateway provider routing" {
     defer alloc.free(body);
 
     try std.testing.expect(std.mem.find(u8, body, "\"providerOptions\":{\"gateway\":{\"order\":[\"wafer\",\"baseten\"],\"only\":[\"baseten\"]}}") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"provider\":{\"order\":[\"wafer\",\"baseten\"],\"only\":[\"baseten\"]}") != null);
 
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
     defer parsed.deinit();

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -448,12 +448,42 @@ fn validatePendingToolReviewMessages(
 }
 
 pub fn writeProviderOptions(writer: *std.Io.Writer, options: model_capabilities.ResolvedProviderOptions) !void {
-    if (!options.fast and options.parallel_tool_calls == null) return;
+    const has_gateway = options.fast or
+        options.gateway_order.len > 0 or
+        options.gateway_only.len > 0;
+    if (!has_gateway and options.parallel_tool_calls == null) return;
 
     try writer.writeAll(",\"providerOptions\":{");
-    if (options.fast) try writer.writeAll("\"gateway\":{\"speed\":\"fast\"}");
+    if (has_gateway) {
+        try writer.writeAll("\"gateway\":{");
+        var wrote_field = false;
+        if (options.fast) {
+            try writer.writeAll("\"speed\":\"fast\"");
+            wrote_field = true;
+        }
+        if (options.gateway_order.len > 0) {
+            if (wrote_field) try writer.writeByte(',');
+            try writer.writeAll("\"order\":[");
+            for (options.gateway_order, 0..) |slug, index| {
+                if (index > 0) try writer.writeByte(',');
+                try std.json.Stringify.value(slug, .{}, writer);
+            }
+            try writer.writeByte(']');
+            wrote_field = true;
+        }
+        if (options.gateway_only.len > 0) {
+            if (wrote_field) try writer.writeByte(',');
+            try writer.writeAll("\"only\":[");
+            for (options.gateway_only, 0..) |slug, index| {
+                if (index > 0) try writer.writeByte(',');
+                try std.json.Stringify.value(slug, .{}, writer);
+            }
+            try writer.writeByte(']');
+        }
+        try writer.writeByte('}');
+    }
     if (options.parallel_tool_calls) |parallel_tool_calls| {
-        if (options.fast) try writer.writeByte(',');
+        if (has_gateway) try writer.writeByte(',');
         try writer.writeAll("\"xai\":{\"parallelToolCalls\":");
         try writer.writeAll(if (parallel_tool_calls) "true" else "false");
         try writer.writeByte('}');
@@ -1327,6 +1357,44 @@ test "buildGatewayRequestBodyWithOptions combines Gateway Fast and xai options" 
     defer alloc.free(body);
 
     try std.testing.expect(std.mem.find(u8, body, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\"},\"xai\":{\"parallelToolCalls\":true}}") != null);
+}
+
+test "buildGatewayRequestBodyWithOptions emits gateway provider routing" {
+    const alloc = std.testing.allocator;
+    const messages = [_]ChatMessage{
+        .{ .role = .user, .content = "question" },
+    };
+
+    const body = try buildGatewayRequestBodyWithOptions(alloc, "[]", &messages, .{
+        .gateway_order = &.{ "wafer", "baseten" },
+        .gateway_only = &.{"baseten"},
+    }, .auto);
+    defer alloc.free(body);
+
+    try std.testing.expect(std.mem.find(u8, body, "\"providerOptions\":{\"gateway\":{\"order\":[\"wafer\",\"baseten\"],\"only\":[\"baseten\"]}}") != null);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    const gateway = parsed.value.object.get("providerOptions").?.object.get("gateway").?;
+    try std.testing.expectEqual(@as(usize, 2), gateway.object.get("order").?.array.items.len);
+    try std.testing.expectEqualStrings("baseten", gateway.object.get("only").?.array.items[0].string);
+}
+
+test "buildGatewayRequestBodyWithOptions merges routing with fast mode" {
+    const alloc = std.testing.allocator;
+    const messages = [_]ChatMessage{
+        .{ .role = .user, .content = "question" },
+    };
+
+    const body = try buildGatewayRequestBodyWithOptions(alloc, "[]", &messages, .{
+        .fast = true,
+        .gateway_order = &.{"bedrock"},
+    }, .auto);
+    defer alloc.free(body);
+
+    try std.testing.expect(
+        std.mem.find(u8, body, "\"providerOptions\":{\"gateway\":{\"speed\":\"fast\",\"order\":[\"bedrock\"]}}") != null,
+    );
 }
 
 test "formatGatewayRequestShapeSummary reports content kinds without request content" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -568,6 +568,7 @@ const App = struct {
     file_index: file_index_mod.FileIndex = .{},
     context_enabled: bool = true,
     context_limits: config_runtime.context_limits.Values = .{},
+    provider_routing: config_runtime.provider_routing.Map = .{},
     fast_mode: bool = false,
     auto_upgrade_enabled: bool = true,
     effort: ReasoningEffort = .auto,
@@ -890,6 +891,7 @@ const App = struct {
         self.skills.deinit(std.heap.c_allocator);
         self.context_snapshot.deinit(self.alloc);
         self.file_index.deinit(std.heap.c_allocator);
+        self.provider_routing.deinit(self.alloc);
         self.lifecycle_runtime.deinit();
 
         self.auth.deinit(self.alloc);

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -803,6 +803,77 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
   );
 
   test(
+    "interactive session applies profile provider routing for the selected gateway model",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-provider-routing-"));
+      const model = "zai/glm-5.3";
+      const gateway = startFakeGateway(
+        [fakeGatewayFinalText("PROVIDER_ROUTING_TUI_COMPLETE")],
+        {
+          models: [{ id: model, type: "language", tags: ["tool-use"] }],
+        },
+      );
+      try {
+        const home = join(root, "home");
+        const workspace = join(root, "workspace");
+        const stderrPath = join(root, "stderr.log");
+        mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+        mkdirSync(workspace);
+        writeFileSync(
+          join(home, ".fx", "settings.json"),
+          JSON.stringify({
+            models: { gateway: model },
+            providerRouting: {
+              [model]: {
+                only: ["togetherai"],
+                order: ["togetherai"],
+              },
+            },
+          }),
+          { mode: 0o600 },
+        );
+
+        session = await TmuxSession.create({
+          cwd: realpathSync(workspace),
+          env: {
+            ...NO_AUTH,
+            HOME: home,
+            AI_GATEWAY_API_KEY: "fake-provider-routing-key",
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_GATEWAY_BASE_URL: gateway.baseUrl,
+            FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+            FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+          },
+          stderrPath,
+        });
+        await session.waitForComposer(TIMEOUT);
+        await session.sendText("Use the configured upstream provider.");
+        await session.waitForText("PROVIDER_ROUTING_TUI_COMPLETE", TIMEOUT);
+
+        expect(gateway.requests).toHaveLength(1);
+        expect(gateway.requests[0]!.headers.get("ai-language-model-id")).toBe(model);
+        expect(JSON.parse(gateway.requests[0]!.body)).toMatchObject({
+          providerOptions: {
+            gateway: {
+              only: ["togetherai"],
+              order: ["togetherai"],
+            },
+          },
+        });
+
+        await session.sendText("/quit");
+        await session.waitForSessionEnd(TIMEOUT);
+        session = null;
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+      } finally {
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    30_000,
+  );
+
+  test(
     "Opus 4.8 Fast pricing drives picker request and persistence",
     async () => {
       const root = mkdtempSync(join(tmpdir(), "fx-anthropic-capabilities-"));

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -906,6 +906,59 @@ describe("gateway stream lifecycle", () => {
     }
   }, 30_000);
 
+  test("fx ask applies profile provider routing for the selected gateway model", async () => {
+    const root = createFixtureRoot("profile-provider-routing");
+    const tracePath = join(root.root, "trace.log");
+    const gateway = startGateway(() =>
+      fakeGatewayFinalText("PROFILE_PROVIDER_ROUTING_COMPLETE")
+    );
+    writeFileSync(
+      join(root.home, ".fx", "settings.json"),
+      JSON.stringify({
+        models: { gateway: MODEL },
+        providerRouting: {
+          [MODEL]: {
+            only: ["togetherai"],
+            order: ["togetherai"],
+          },
+        },
+      }),
+    );
+
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Use profile routing."],
+        {
+          cwd: root.workspace,
+          env: {
+            ...fixtureEnv(root, gateway, tracePath),
+            FX_MODEL: undefined,
+          },
+          timeoutMs: 30_000,
+        },
+      );
+
+      expect(result.code).toBe(0);
+      expect(parseAskJson(result.stdout).output).toContain(
+        "PROFILE_PROVIDER_ROUTING_COMPLETE",
+      );
+      expect(result.stderr).toBe("");
+      expect(gateway.requests).toHaveLength(1);
+      expect(gateway.requests[0]!.headers.get("ai-language-model-id")).toBe(MODEL);
+      expect(JSON.parse(gateway.requests[0]!.body)).toMatchObject({
+        providerOptions: {
+          gateway: {
+            only: ["togetherai"],
+            order: ["togetherai"],
+          },
+        },
+      });
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test("fx ask projects explicit permission mode on initial and continuing requests", async () => {
     for (const mode of ["ask", "auto"] as const) {
       const root = createFixtureRoot(`permission-mode-${mode}`);


### PR DESCRIPTION
Add per-model AI Gateway provider routing

### Summary

Adds a `providerRouting` key to `~/.fx/settings.json` that routes AI Gateway chat requests to specific upstream providers per model, using the Gateway's provider filtering and ordering (`order` / `only` provider slugs):

```json
{
  "providerRouting": {
    "default": { "order": ["wafer"] },
    "anthropic/claude-sonnet-5": { "only": ["baseten"], "order": ["baseten", "bedrock"] }
  }
}
```

- An entry keyed by model ID applies to that model; the `default` entry applies to every other model. Exact matches win over `default`.
- Routing options merge into the existing `providerOptions.gateway` request object alongside Fast mode's `speed`.
- Workspace overrides layer over profile-global entries per model.
- Codex and Grok subscription routes are unaffected; routing applies only to Gateway requests.

### Implementation

- New `src/core/config/provider_routing.zig`: owned per-model map with bounded parsing (entry/slug limits), lookup precedence, layer merge, and unit tests.
- Settings plumbing through `config_runtime.zig`, startup state, `App`, and both turn-config paths (interactive and `fx ask`).
- Orchestrator resolves routing against the active model at request build time.
- `gateway_json.writeProviderOptions` serializes `order` / `only` into the merged `gateway` object.
- README documents the new key.

### Testing

- Unit tests at every layer: parser validation and precedence, settings round-trip and diagnostics, request-body shapes (order-only, only-only, merged with Fast mode), and orchestrator flow tests proving routing reaches request bodies through the real pipeline.
- Verified end to end with a live AI Gateway request: trace confirmed `"only":["wafer"]` on a deepseek model request, accepted by the Gateway.
- `zig build test` passes; `zig fmt` clean. ReleaseSafe binary builds.