### PR TITLE
fix(napi): zeroize the copied API key before free

### DIFF
--- a/sdk/NAPI.md
+++ b/sdk/NAPI.md
@@ -189,7 +189,7 @@ Do not replace the tagged wrapped object with a numeric pointer, externalized ad
 
 The API key is copied from the JavaScript string into native heap memory and passed as an in-memory credential override. It is not read from process-global environment state, written into generated package artifacts, or intentionally logged. Per-runtime overrides also avoid mutating environment variables shared by concurrent runtimes and workers.
 
-The copied key remains resident for the runtime lifetime and is freed during destruction. The allocation is not currently zeroized before free. Code handling diagnostics, crash reports, heap inspection, or allocator changes must treat this memory as sensitive. A future zeroization change should cover all destruction and partial-construction paths and must not be optimized away.
+The copied key remains resident for the runtime lifetime and is freed during destruction. The allocation is zeroized before free via `secret.zeroAndFree()` (`src/core/auth/secret.zig`), the same primitive used for other credential material in the codebase; it wraps `std.crypto.secureZero` behind a `noinline` function operating on a `@volatileCast` slice so the write cannot be optimized away. Both destruction paths are covered: normal teardown in `Runtime.deinit()` and the partial-construction `errdefer` in `createRuntime()` if a later field fails to validate. Code handling diagnostics, crash reports, heap inspection, or allocator changes should still treat this memory as sensitive for the window before it is freed.
 
 ## Native code trust boundary
 

--- a/src/napi_core_main.zig
+++ b/src/napi_core_main.zig
@@ -12,6 +12,7 @@ const fetch_state = @import("napi_fetch_state.zig");
 const streamable_http = @import("core/mcp/streamable_http.zig");
 const host_stream_provider = @import("gateway/host_stream_provider.zig");
 const oauth_transport = @import("core/auth/oauth_transport.zig");
+const secret = @import("core/auth/secret.zig");
 const builtin_context = @import("builtins/context.zig");
 const builtin_gateway = @import("builtins/gateway.zig");
 const builtin_modes = @import("builtins/modes.zig");
@@ -495,7 +496,7 @@ const Runtime = struct {
         self.fetch.deinit();
         self.input.deinit(self.alloc);
         self.output.deinit(self.alloc);
-        self.alloc.free(self.credential);
+        secret.zeroAndFree(self.alloc, self.credential);
         if (self.model) |model| self.alloc.free(model);
         self.alloc.free(self.home);
         self.alloc.free(self.workspace_root);
@@ -618,7 +619,7 @@ fn createRuntime(env: c.napi_env, options: c.napi_value) CreateError!*Runtime {
         else => return error.InvalidApiKey,
     };
     const api_key = credential orelse return error.InvalidApiKey;
-    errdefer alloc.free(api_key);
+    errdefer secret.zeroAndFree(alloc, api_key);
     const model = getNamedString(env, options, "model", alloc, max_model_bytes) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.InvalidModel,


### PR DESCRIPTION
## What

\`sdk/NAPI.md\`'s own "Secret handling" section documented this gap: the API key copied from JavaScript into native heap memory for the N-API core (\`src/napi_core_main.zig\`) was freed with a plain \`allocator.free()\`, with the doc stating plainly *"the allocation is not currently zeroized before free"* and asking for *"a future zeroization change [that] should cover all destruction and partial-construction paths and must not be optimized away."*

I found this while doing a broader manual security review of the repo (unrelated to any existing issue — I checked and didn't find one covering this).

## Where it's freed

Exactly two places, both covered here:
- \`Runtime.deinit()\` — normal teardown at the end of a runtime's life.
- the \`errdefer\` in \`createRuntime()\` — partial construction: fires if \`model\`/\`home\`/\`workspaceRoot\`/\`gatewayChatUrl\` validation fails, or the \`Runtime\` allocation/thread spawn fails, after \`api_key\` is already allocated.

No third path exists: \`createCore()\`'s own \`defer if (runtime_owned) runtime.deinit()\` routes every later failure (handle allocation, \`napi_wrap\`, etc.) back through \`Runtime.deinit()\`, so these two are jointly exhaustive.

## Fix

Route both frees through \`secret.zeroAndFree()\` (\`src/core/auth/secret.zig\`) instead of a plain \`alloc.free()\`. This is the same primitive already used for other credential material elsewhere in the codebase — not a new pattern. It wraps \`std.crypto.secureZero\` behind a \`noinline\` function operating on a \`@volatileCast\` slice specifically so the zeroing write cannot be elided by the optimizer — exactly the failure mode the doc's own comment called out.

Also updated the "Secret handling" section of \`sdk/NAPI.md\` to reflect the closed gap instead of describing it as future work.

## Verification

- \`zig fmt --check\` and \`zig ast-check\` pass on the changed file.
- \`zig build -Dnapi-surface=core -Doptimize=ReleaseSafe\` succeeds (\`zig-out/lib/libfx.node\` builds clean).
- \`npm run --prefix sdk test:node-napi\`: **11/12** native-surface test scripts pass, including the security-focused ones:
  \`\`\`
  native core misuse passed: argument, handle, stale, trace, backpressure, and closed-handle checks are enforced
  native core security passed: malformed creation is stable and ACP stdio MCP is blocked
  \`\`\`
  The 12th (\`test-libfx-loader.mjs\`) fails only on \`ENOENT\` for \`sdk/fx-core.wasm\` — the separate WebAssembly surface, which this change doesn't touch and which I didn't build locally (I only built \`-Dnapi-surface=core\`); unrelated to this diff.
- Full \`zig build test\` (whole-project unit suite): **8440/8443 passed, 2 skipped, 1 failed.** The one failure, \`core.tooling.tool_runtime.test.run_command timeout returns model-visible failure\`, lives in \`src/core/tooling/tool_runtime.zig\` (unrelated to \`src/napi_core_main.zig\` or \`src/core/auth/\`), asserts on a real subprocess's real wall-clock timeout, and failed "without output" (a flake signature, not a deterministic assertion diff) — consistent with scheduling jitter from 2+ concurrent ReleaseSafe zig compiles saturating my machine's CPU during that same run, not a regression from this change. Happy to re-run in isolation if useful for review.

Opening as draft per CONTRIBUTING.md, since I can't run the full 4-platform Full CI matrix locally — the change is small and self-contained (5 lines across 2 files) so should be quick to verify there.

Suggested label: \`type: security\`.