### PR TITLE
preserve prompt history navigation for recalled slash commands

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -9965,6 +9965,38 @@ test "app_input_runtime plain vertical routes visible slash picker while stream 
     try std.testing.expect(app.input_runtime.vertical_navigation.preferredColumn() == null);
 }
 
+test "app_input_runtime recalled slash command keeps prompt history navigation" {
+    const alloc = std.testing.allocator;
+    var app = FakeApprovalCancelApp{ .alloc = alloc };
+    defer app.deinit();
+    app.stream.active = false;
+    try app.input_runtime.composer_history.installTextEntries(alloc, &.{ "older", "/help" });
+
+    try input_completion_runtime.CompletionRuntime(FakeApprovalCancelApp).navigatePromptHistory(&app, -1);
+    try std.testing.expectEqualStrings("/help", app.input_runtime.edit_state.input.items);
+    try std.testing.expect(Runtime(FakeApprovalCancelApp).routeSlashCompletionMove(&app, 1));
+
+    try Runtime(FakeApprovalCancelApp).routePlainVertical(&app, .up, -1);
+    try std.testing.expectEqualStrings("/help", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 0), app.input_runtime.edit_state.cursor);
+
+    try Runtime(FakeApprovalCancelApp).routePlainVertical(&app, .up, -1);
+    try std.testing.expectEqualStrings("older", app.input_runtime.edit_state.input.items);
+}
+
+test "app_input_runtime recalled slash command keeps modified prompt history navigation" {
+    const alloc = std.testing.allocator;
+    var app = FakeApprovalCancelApp{ .alloc = alloc };
+    defer app.deinit();
+    app.stream.active = false;
+    try app.input_runtime.composer_history.installTextEntries(alloc, &.{ "older", "/help" });
+
+    try input_completion_runtime.CompletionRuntime(FakeApprovalCancelApp).navigatePromptHistory(&app, -1);
+    try Runtime(FakeApprovalCancelApp).routeModifiedHistory(&app, .up, -1);
+
+    try std.testing.expectEqualStrings("older", app.input_runtime.edit_state.input.items);
+}
+
 test "app_input_runtime plain vertical keeps composer precedence over wrapped slash picker" {
     const alloc = std.testing.allocator;
     var app = FakeApprovalCancelApp{ .alloc = alloc };

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -172,10 +172,10 @@ pub fn CompletionRuntime(comptime App: type) type {
             app.input_runtime.vertical_navigation.reset();
             if (routeNonSlashPickerMove(app, delta)) {
                 return;
+            } else if (app.input_runtime.composer_history.activeIndex() != null) {
+                try navigatePromptHistory(app, delta);
             } else if (!routeSlashCompletionMove(app, delta)) {
-                if (app.input_runtime.composer_history.activeIndex() != null) {
-                    try navigatePromptHistory(app, delta);
-                } else if (direction == .up and app.input_runtime.edit_state.cursor > 0) {
+                if (direction == .up and app.input_runtime.edit_state.cursor > 0) {
                     _ = horizontal_navigation.move(
                         .draft_start,
                         &app.input_runtime.edit_state,
@@ -248,7 +248,10 @@ pub fn CompletionRuntime(comptime App: type) type {
                 app.shell.layout.content_bottom,
                 true,
             );
-            const visible_slash_count = if (capped.input_extra == 0) visibleSlashCompletionCount(app) else 0;
+            const visible_slash_count = if (app.input_runtime.composer_history.activeIndex() == null and capped.input_extra == 0)
+                visibleSlashCompletionCount(app)
+            else
+                0;
             if (visible_slash_count > 0) {
                 app.input_runtime.vertical_navigation.reset();
                 navigateSlashCompletion(app, picker_delta, visible_slash_count);


### PR DESCRIPTION
### summary

- keep arrow-key navigation in prompt history after recalling a slash command
- prevent the slash picker from intercepting continued history navigation
- add regression coverage for plain and modified history navigation

## validation
- verified with `./zig-out/bin/fx` in tmux by recalling `/help` and navigating back to `/clear`
- confirmed clean stderr and clean process exit