### PR TITLE
speed up large session resume

### DIFF
--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -539,6 +539,45 @@ fn mutable_user_for_history_turn(turn: *HistoryTurn) ?*UserTurn {
     };
 }
 
+/// Returns whether a resumed history needs the legacy image migration path.
+/// This preflight avoids deep-copying large modern histories that contain no
+/// legacy image metadata.
+pub fn history_needs_legacy_image_repair(history: []const HistoryTurn) bool {
+    for (history) |turn| {
+        for (images_for_history_turn(turn)) |attachment| {
+            if (attachment.id == 0 or
+                attachment.snapshot_path == null or
+                attachment.snapshot_sha256 == null)
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+test "legacy image repair preflight skips complete modern histories" {
+    const image = ImageAttachment{
+        .id = 1,
+        .path = @constCast("/tmp/image.png"),
+        .media_type = @constCast("image/png"),
+        .snapshot_path = @constCast("/tmp/snapshot.png"),
+        .snapshot_sha256 = @constCast("sha256"),
+    };
+    var images = [_]ImageAttachment{image};
+    const history = [_]HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("image"), .images = &images },
+        .assistant = @constCast("done"),
+    } }};
+
+    try std.testing.expect(!history_needs_legacy_image_repair(&history));
+    images[0].id = 0;
+    try std.testing.expect(history_needs_legacy_image_repair(&history));
+    images[0] = image;
+    images[0].snapshot_sha256 = null;
+    try std.testing.expect(history_needs_legacy_image_repair(&history));
+}
+
 /// Repairs image IDs omitted by the legacy session deep-copy path. This is
 /// only for allocator-owned history loaded from durable storage. Rebuilt text
 /// remains owned by its history turn. Returns whether any attachment changed.

--- a/src/core/session/session_projection.zig
+++ b/src/core/session/session_projection.zig
@@ -9,7 +9,7 @@ const Allocator = std.mem.Allocator;
 const Sha256 = std.crypto.hash.sha2.Sha256;
 
 pub const manifest_max_bytes: usize = 64 * 1024;
-pub const checkpoint_max_bytes: usize = 32 * 1024 * 1024;
+pub const checkpoint_max_bytes: usize = 128 * 1024 * 1024;
 pub const Digest = [Sha256.digest_length]u8;
 
 pub const Manifest = struct {
@@ -322,7 +322,24 @@ pub fn decodeCheckpoint(alloc: Allocator, bytes: []const u8) !Checkpoint {
 
 fn decodeCheckpointImpl(alloc: Allocator, bytes: []const u8) !Checkpoint {
     if (bytes.len == 0 or bytes.len > checkpoint_max_bytes) return error.CheckpointTooLarge;
-    var parsed = std.json.parseFromSlice(std.json.Value, alloc, bytes, .{
+    const canonical = std.mem.trim(u8, bytes, " \t\r\n");
+    const state_marker = ",\"state\":";
+    const marker_start = std.mem.find(u8, canonical, state_marker) orelse
+        return error.InvalidCheckpoint;
+    const state_start = marker_start + state_marker.len;
+    if (canonical.len == 0 or canonical[canonical.len - 1] != '}' or
+        state_start >= canonical.len - 1)
+    {
+        return error.InvalidCheckpoint;
+    }
+
+    const metadata_bytes = try std.mem.concat(
+        alloc,
+        u8,
+        &.{ canonical[0..state_start], "null}" },
+    );
+    defer alloc.free(metadata_bytes);
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, metadata_bytes, .{
         .parse_numbers = false,
     }) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
@@ -338,16 +355,13 @@ fn decodeCheckpointImpl(alloc: Allocator, bytes: []const u8) !Checkpoint {
         "through_event_log_bytes",
         "state",
     });
-    if (try requireU64(root, "schema_version") != 1) return error.InvalidCheckpoint;
+    if (try requireU64(root, "schema_version") != 1) {
+        return error.InvalidCheckpoint;
+    }
+    const metadata_state = root.get("state") orelse return error.InvalidCheckpoint;
+    if (metadata_state != .null) return error.InvalidCheckpoint;
 
-    var state_json: std.Io.Writer.Allocating = .init(alloc);
-    defer state_json.deinit();
-    try std.json.Stringify.value(
-        root.get("state") orelse return error.InvalidCheckpoint,
-        .{},
-        &state_json.writer,
-    );
-    var state_source = std.Io.Reader.fixed(state_json.written());
+    var state_source = std.Io.Reader.fixed(canonical[state_start .. canonical.len - 1]);
     var state = session_codec.decodeState(alloc, &state_source, .{}) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.InvalidCheckpoint,

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -1096,24 +1096,26 @@ pub const Store = struct {
             loaded.state.permission_state.deinit(alloc);
             loaded.state.permission_state = migrated_permission_state;
         }
-        var migration_state = try loaded.state.dupe(alloc);
-        defer migration_state.deinit(alloc);
-        const session_dir = try sessionDirPath(
-            alloc,
-            self.sessions_dir,
-            loaded.active_id,
-        );
-        defer alloc.free(session_dir);
-        const snapshot_dir = try std.fs.path.join(alloc, &.{ session_dir, "images" });
-        defer alloc.free(snapshot_dir);
-        const needs_image_migration = try session.repair_legacy_images_transactionally(
-            alloc,
-            migration_state.history,
-            snapshot_dir,
-        );
-        const needs_migration_commit = needs_permission_migration or
-            needs_image_migration;
-        if (needs_migration_commit) {
+        const may_need_image_migration =
+            session.history_needs_legacy_image_repair(loaded.state.history);
+        if (needs_permission_migration or may_need_image_migration) {
+            var migration_state = try loaded.state.dupe(alloc);
+            defer migration_state.deinit(alloc);
+            const session_dir = try sessionDirPath(
+                alloc,
+                self.sessions_dir,
+                loaded.active_id,
+            );
+            defer alloc.free(session_dir);
+            const snapshot_dir = try std.fs.path.join(alloc, &.{ session_dir, "images" });
+            defer alloc.free(snapshot_dir);
+            if (may_need_image_migration) {
+                _ = try session.repair_legacy_images_transactionally(
+                    alloc,
+                    migration_state.history,
+                    snapshot_dir,
+                );
+            }
             var migration_committed = false;
             errdefer if (!migration_committed) {
                 deleteSnapshotFilesAddedByMigration(


### PR DESCRIPTION
### summary

- raise the checkpoint size limit for large sessions
- decode checkpoint state without materializing the full json tree
- skip legacy image migration copies when they are unnecessary
- tested by resuming and exiting a copied 78 mb session
