### PR TITLE
clear composer during active turns

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -2423,6 +2423,7 @@ pub fn Runtime(comptime App: type) type {
                         return;
                     }
                 }
+                if (handleComposerDraftEscape(app, now)) return;
                 if (!interrupt_rt.pauseActiveRecovery(app)) {
                     try interrupt_rt.cancelActiveOperation(app);
                 }
@@ -2471,9 +2472,13 @@ pub fn Runtime(comptime App: type) type {
                     return;
                 }
             }
+            _ = handleComposerDraftEscape(app, now);
+        }
+
+        fn handleComposerDraftEscape(app: *App, now: i64) bool {
             if (!draftHasState(app)) {
                 _ = disarmEscapeClear(app);
-                return;
+                return false;
             }
             const transition = gesture_state.pressEscapeClear(
                 app.input_runtime.gestures,
@@ -2482,11 +2487,10 @@ pub fn Runtime(comptime App: type) type {
             app.input_runtime.gestures = transition.next;
             if (transition.result == .activated) {
                 clearDraftState(app, "double_escape");
-                app.shell.render_requests.request(.footer);
                 if (comptime @hasDecl(App, "playInputClearedSound")) app.playInputClearedSound();
-            } else {
-                app.shell.render_requests.request(.footer);
             }
+            app.shell.render_requests.request(.footer);
+            return true;
         }
 
         fn cancelSkillsMenu(app: *App) bool {
@@ -4085,7 +4089,7 @@ test "app_input_runtime Escape dismisses an idle inline slash completion" {
     try std.testing.expect(!app.input_runtime.gestures.escapeClearArmed());
 }
 
-test "app_input_runtime active operation Escape keeps precedence over inline skill dismissal" {
+test "app_input_runtime active draft Escape keeps precedence over inline skill dismissal" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);
     defer app.deinit();
@@ -4102,8 +4106,9 @@ test "app_input_runtime active operation Escape keeps precedence over inline ski
 
     try Runtime(RoutingFakeApp).resolveEscape(&app, true, 1);
 
-    try std.testing.expect(app.worker.cancel_requested);
-    try std.testing.expect(!app.stream.active);
+    try std.testing.expect(!app.worker.cancel_requested);
+    try std.testing.expect(app.stream.active);
+    try std.testing.expect(app.input_runtime.gestures.escapeClearArmed());
     try std.testing.expect(!app.input_runtime.picker.isInlinePickerDismissed(.skill));
 }
 
@@ -5099,6 +5104,33 @@ test "app_input_runtime Escape cancels an idle session picker before empty-compo
     try std.testing.expect(!app.session_persistence.session_picker.active);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
     try std.testing.expect(!app.worker.cancel_requested);
+}
+
+test "app_input_runtime stream double Escape clears the draft before cancelling" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    try app.input_runtime.textReplacementState().replace(alloc, "keep working");
+    app.stream.active = true;
+
+    try Runtime(RoutingFakeApp).resolveEscape(&app, true, 1);
+
+    try std.testing.expectEqualStrings("keep working", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(?i64, 1), app.input_runtime.gestures.escapeClearArmedAt());
+    try std.testing.expect(app.stream.active);
+    try std.testing.expect(!app.worker.cancel_requested);
+
+    try Runtime(RoutingFakeApp).resolveEscape(&app, true, 2);
+
+    try std.testing.expectEqualStrings("", app.input_runtime.edit_state.input.items);
+    try std.testing.expect(!app.input_runtime.gestures.escapeClearArmed());
+    try std.testing.expect(app.stream.active);
+    try std.testing.expect(!app.worker.cancel_requested);
+
+    try Runtime(RoutingFakeApp).resolveEscape(&app, true, 3);
+
+    try std.testing.expect(app.worker.cancel_requested);
+    try std.testing.expect(!app.stream.active);
 }
 
 test "app_input_runtime stream Escape retains cancellation precedence over session picker state" {

--- a/tests/e2e/tui-interrupt-recovery.test.ts
+++ b/tests/e2e/tui-interrupt-recovery.test.ts
@@ -14,9 +14,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readTrace } from "./tui-render-assertions";
 import {
+  composerContains,
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
   fakeGatewayToolCall,
+  hasEmptyComposer,
   startFakeGateway,
   TmuxSession,
   tmuxAvailable,
@@ -150,6 +152,68 @@ describe.skipIf(SKIP)("tui: interrupt recovery", () => {
       const events = readFileSync(eventsPath!, "utf8");
       expect(events).not.toContain('"kind":"interrupted"');
       expect(events).toContain(queuedText);
+    },
+    TIMEOUT * 2,
+  );
+
+  test(
+    "double Escape clears an active-turn draft without cancelling",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-active-draft-clear-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(join(home, ".fx", "settings.json"), "{}");
+
+      const held: HoldState = {
+        started: false,
+        cancelled: false,
+        cancelCount: 0,
+        released: false,
+      };
+      gateway = startFakeGateway([
+        () => heldUntilReleasedResponse(held),
+      ]);
+      session = await TmuxSession.create({
+        cwd: realpathSync(workspace),
+        stderrPath,
+        width: 120,
+        height: 40,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-active-draft-clear-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+        },
+      });
+      await session.waitForComposer(TIMEOUT);
+
+      await session.sendText("Hold this response while I clear a draft.");
+      await waitForCondition(() => held.started, "held response start");
+      await session.sendLiteral("discard this draft");
+      await session.waitForPane(
+        (pane) => composerContains(pane, "discard this draft"),
+        TIMEOUT,
+      );
+
+      await session.sendKeys("Escape");
+      await session.sendKeys("Escape");
+      await session.waitForPane(hasEmptyComposer, TIMEOUT);
+
+      expect(held.cancelled).toBe(false);
+      expect(held.cancelCount).toBe(0);
+      expect(session.isAlive()).toBe(true);
+      expect(session.isPaneAlive()).toBe(true);
+
+      held.release!();
+      await session.waitForStableComposer(TIMEOUT);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
     TIMEOUT * 2,
   );


### PR DESCRIPTION
### summary

- allow double Escape to clear a non-empty composer while a turn is active
- keep the active turn running after the draft is cleared
- preserve Escape cancellation when the composer is empty
- retain Ctrl+C as the immediate cancellation shortcut
- add unit and tmux E2E coverage for the interaction
