### PR TITLE
Wipe request-side credentials instead of leaving them in freed memory

### DIFF
--- a/src/core/auth/chatgpt_oauth.zig
+++ b/src/core/auth/chatgpt_oauth.zig
@@ -451,8 +451,9 @@ fn refreshSession(
     session: *chatgpt_session.Session,
 ) !void {
     try mutation.requireWritable();
-    var body: std.Io.Writer.Allocating = .init(alloc);
+    var body: std.Io.Writer.Allocating = try .initCapacity(alloc, refreshBodyCapacity(session.refresh_token));
     defer body.deinit();
+    defer secret.zero(body.written());
     try body.writer.writeAll("{\"client_id\":");
     try std.json.Stringify.value(client_id, .{}, &body.writer);
     try body.writer.writeAll(",\"grant_type\":\"refresh_token\",\"refresh_token\":");
@@ -632,8 +633,15 @@ fn exchangeAuthorizationCodeForRedirectWithBounds(
     deadline: ?std.Io.Clock.Timestamp,
 ) !TokenSet {
     var form: FormBody = .{};
-    var body: std.Io.Writer.Allocating = .init(alloc);
+    var body: std.Io.Writer.Allocating = try .initCapacity(alloc, formCapacity(&.{
+        "grant_type",    "authorization_code",
+        "client_id",     client_id,
+        "code",          authorization_code,
+        "code_verifier", code_verifier,
+        "redirect_uri",  redirect_uri,
+    }));
     defer body.deinit();
+    defer secret.zero(body.written());
     try form.append(&body.writer, "grant_type", "authorization_code");
     try form.append(&body.writer, "client_id", client_id);
     try form.append(&body.writer, "code", authorization_code);
@@ -894,6 +902,25 @@ fn percentDecodeAlloc(alloc: Allocator, value: []const u8) ![]u8 {
     return alloc.realloc(out, write_index);
 }
 
+/// Upper bound on an encoded form body. `percentEncode` expands each byte to at
+/// most three characters, and each field adds one `=` or `&`. Reserving this up
+/// front keeps the writer from reallocating while it holds a credential, which
+/// would leave the secret behind in the abandoned buffer.
+fn formCapacity(parts: []const []const u8) usize {
+    var total: usize = 0;
+    for (parts) |part| total += part.len * 3;
+    return total + parts.len;
+}
+
+/// Upper bound on the JSON refresh body. JSON string escaping expands a byte to
+/// at most six characters (`\uXXXX`), and the keys and punctuation around the
+/// two values are fixed. Same reason as `formCapacity`: growth would abandon a
+/// buffer holding the refresh token.
+fn refreshBodyCapacity(refresh_token: []const u8) usize {
+    const fixed = "{\"client_id\":\"\",\"grant_type\":\"refresh_token\",\"refresh_token\":\"\"}".len;
+    return fixed + (client_id.len + refresh_token.len) * 6;
+}
+
 const FormBody = struct {
     first: bool = true,
 
@@ -1065,4 +1092,68 @@ test "ChatGPT browser callback requires the exact path and state" {
             "expected",
         ),
     );
+}
+
+test "ChatGPT request bodies carrying a credential are wiped before release" {
+    // The response is already wiped with `secret.zeroAndFree`. The request form
+    // carries the credential itself, so it must not outlive the call in
+    // plaintext either.
+    var scan = secret.ScanAllocator{
+        .backing = std.testing.allocator,
+        .marker = secret.scan_needle,
+    };
+    const alloc = scan.allocator();
+
+    const Transport = struct {
+        fn execute(_: ?*anyopaque, a: Allocator, _: oauth_transport.Request) !oauth_transport.Response {
+            return .{
+                .disposition = .accepted,
+                .body = try a.dupe(
+                    u8,
+                    "{\"access_token\":\"header.payload.signature\"," ++
+                        "\"refresh_token\":\"new-refresh\",\"expires_in\":3600}",
+                ),
+            };
+        }
+    };
+
+    var tokens = try exchangeAuthorizationCodeForRedirectWithBounds(
+        alloc,
+        .{ .execute_fn = Transport.execute },
+        "https://auth.openai.com/oauth/token",
+        "authorization-code",
+        secret.scan_marker,
+        "http://127.0.0.1:1455/auth/callback",
+        null,
+        null,
+    );
+    tokens.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 0), scan.released_with_plaintext);
+}
+
+test "ChatGPT refresh body capacity covers the encoded bound so the writer never grows" {
+    // The refresh body is assembled from the stored token, which the file read
+    // and the JSON parse also copy, so a scan cannot attribute a hit to the
+    // body alone. What the reservation has to be is large enough, and that is
+    // measurable directly.
+    const alloc = std.testing.allocator;
+    const cases: []const []const u8 = &.{
+        "",
+        "plain-refresh-token",
+        // Control bytes take the six character `\uXXXX` form, the worst case.
+        "\x00\x01\x02\x03\x04\x05\x06\x07",
+        "\"\\\n\t" ** 64,
+        "x" ** 4096,
+    };
+    for (cases) |refresh_token| {
+        var body: std.Io.Writer.Allocating = .init(alloc);
+        defer body.deinit();
+        try body.writer.writeAll("{\"client_id\":");
+        try std.json.Stringify.value(client_id, .{}, &body.writer);
+        try body.writer.writeAll(",\"grant_type\":\"refresh_token\",\"refresh_token\":");
+        try std.json.Stringify.value(refresh_token, .{}, &body.writer);
+        try body.writer.writeByte('}');
+        try std.testing.expect(refreshBodyCapacity(refresh_token) >= body.written().len);
+    }
 }

--- a/src/core/auth/grok_oauth.zig
+++ b/src/core/auth/grok_oauth.zig
@@ -556,8 +556,13 @@ fn refreshSession(
     session: *grok_session.Session,
 ) !void {
     try mutation.requireWritable();
-    var body: std.Io.Writer.Allocating = .init(alloc);
+    var body: std.Io.Writer.Allocating = try .initCapacity(alloc, formCapacity(&.{
+        "grant_type",    "refresh_token",
+        "client_id",     client_id,
+        "refresh_token", session.refresh_token,
+    }));
     defer body.deinit();
+    defer secret.zero(body.written());
     var form: FormBody = .{};
     try form.append(&body.writer, "grant_type", "refresh_token");
     try form.append(&body.writer, "client_id", client_id);
@@ -701,8 +706,15 @@ fn exchangeAuthorizationCodeForRedirectWithBounds(
     deadline: ?std.Io.Clock.Timestamp,
 ) !TokenSet {
     var form: FormBody = .{};
-    var body: std.Io.Writer.Allocating = .init(alloc);
+    var body: std.Io.Writer.Allocating = try .initCapacity(alloc, formCapacity(&.{
+        "grant_type",    "authorization_code",
+        "client_id",     client_id,
+        "code",          authorization_code,
+        "code_verifier", code_verifier,
+        "redirect_uri",  redirect_uri,
+    }));
     defer body.deinit();
+    defer secret.zero(body.written());
     try form.append(&body.writer, "grant_type", "authorization_code");
     try form.append(&body.writer, "client_id", client_id);
     try form.append(&body.writer, "code", authorization_code);
@@ -786,7 +798,7 @@ fn fetchAccountId(
 ) ![]u8 {
     const endpoint_url = try configuredEndpoint(alloc, e2e_userinfo_url_env, userinfo_url);
     defer alloc.free(endpoint_url);
-    const authorization = try std.fmt.allocPrint(alloc, "Bearer {s}", .{access_token});
+    const authorization = try secret.bearerHeaderAlloc(alloc, access_token);
     defer secret.zeroAndFree(alloc, authorization);
     var response = try transport.execute(alloc, .{
         .method = .get,
@@ -813,8 +825,12 @@ fn revokeToken(
 ) !void {
     const endpoint_url = try configuredEndpoint(alloc, e2e_revoke_url_env, revoke_url);
     defer alloc.free(endpoint_url);
-    var body: std.Io.Writer.Allocating = .init(alloc);
+    var body: std.Io.Writer.Allocating = try .initCapacity(alloc, formCapacity(&.{
+        "token",     token,
+        "client_id", client_id,
+    }));
     defer body.deinit();
+    defer secret.zero(body.written());
     var form: FormBody = .{};
     try form.append(&body.writer, "token", token);
     try form.append(&body.writer, "client_id", client_id);
@@ -948,6 +964,16 @@ fn percentDecodeAlloc(alloc: Allocator, value: []const u8) ![]u8 {
     }
     if (write_index == 0) return error.InvalidGrokOAuthCallback;
     return alloc.realloc(out, write_index);
+}
+
+/// Upper bound on an encoded form body. `percentEncode` expands each byte to at
+/// most three characters, and each field adds one `=` or `&`. Reserving this up
+/// front keeps the writer from reallocating while it holds a credential, which
+/// would leave the secret behind in the abandoned buffer.
+fn formCapacity(parts: []const []const u8) usize {
+    var total: usize = 0;
+    for (parts) |part| total += part.len * 3;
+    return total + parts.len;
 }
 
 const FormBody = struct {
@@ -1150,4 +1176,147 @@ test "Grok browser callback requires the exact path and state" {
             "expected",
         ),
     );
+}
+
+/// Restoring the environment means pointing it at a map that outlives every
+/// test, since there is no way to hand the process environment back.
+var stable_test_environ: ?*std.process.Environ.Map = null;
+
+fn stableTestEnviron() !*std.process.Environ.Map {
+    if (stable_test_environ) |existing| return existing;
+    const alloc = std.heap.page_allocator;
+    const map = try alloc.create(std.process.Environ.Map);
+    map.* = std.process.Environ.Map.init(alloc);
+    stable_test_environ = map;
+    return map;
+}
+
+/// A temporary HOME holding a Grok auth file whose refresh token is `token`,
+/// so the mutation-backed request paths can be driven end to end.
+const MarkedSessionHome = struct {
+    alloc: Allocator,
+    tmp: std.testing.TmpDir,
+    home: []u8,
+    map: *std.process.Environ.Map,
+
+    fn install(alloc: Allocator, token: []const u8) !MarkedSessionHome {
+        const profile_paths = @import("../shared/profile_paths.zig");
+        _ = try stableTestEnviron();
+        var tmp = std.testing.tmpDir(.{});
+        errdefer tmp.cleanup();
+        const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "");
+        errdefer alloc.free(home);
+
+        try tmp.dir.createDirPath(io_mod.getIo(), ".fx");
+        const fx_path = try std.fs.path.join(alloc, &.{ home, ".fx" });
+        defer alloc.free(fx_path);
+        var fx_dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), fx_path, .{ .iterate = true });
+        defer fx_dir.close(io_mod.getIo());
+        try fx_dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700));
+
+        const text = try std.fmt.allocPrint(
+            alloc,
+            "{{\"version\":1,\"access_token\":\"access\",\"refresh_token\":\"{s}\"," ++
+                "\"expires_at_ms\":1,\"account_id\":\"acct\"}}",
+            .{token},
+        );
+        defer alloc.free(text);
+        var file = try fx_dir.createFile(io_mod.getIo(), profile_paths.grok_auth_file_name, .{
+            .truncate = true,
+            .permissions = std.Io.File.Permissions.fromMode(0o600),
+        });
+        defer file.close(io_mod.getIo());
+        try file.writeStreamingAll(io_mod.getIo(), text);
+
+        const map = try alloc.create(std.process.Environ.Map);
+        errdefer alloc.destroy(map);
+        map.* = std.process.Environ.Map.init(alloc);
+        try map.put("HOME", home);
+        io_mod.setEnvironMap(map);
+        return .{ .alloc = alloc, .tmp = tmp, .home = home, .map = map };
+    }
+
+    fn deinit(self: *MarkedSessionHome) void {
+        if (stable_test_environ) |map| io_mod.setEnvironMap(map);
+        self.map.deinit();
+        self.alloc.destroy(self.map);
+        self.alloc.free(self.home);
+        self.tmp.cleanup();
+    }
+};
+
+const MarkedTransport = struct {
+    fn execute(_: ?*anyopaque, alloc: Allocator, request: oauth_transport.Request) !oauth_transport.Response {
+        const payload = request.payload orelse "";
+        if (std.mem.indexOf(u8, payload, "grant_type=refresh_token") != null or
+            std.mem.indexOf(u8, payload, "grant_type=authorization_code") != null)
+        {
+            return .{
+                .disposition = .accepted,
+                .body = try alloc.dupe(
+                    u8,
+                    "{\"access_token\":\"new-access\",\"refresh_token\":\"new-refresh\",\"expires_in\":3600}",
+                ),
+            };
+        }
+        if (std.mem.indexOf(u8, payload, "token=") != null) {
+            return .{ .disposition = .accepted, .body = try alloc.dupe(u8, "{}") };
+        }
+        return .{ .disposition = .accepted, .body = try alloc.dupe(u8, "{\"sub\":\"acct\"}") };
+    }
+
+    fn provider() oauth_transport.Provider {
+        return .{ .execute_fn = execute };
+    }
+};
+
+// The refresh and revoke bodies are built from the token stored on disk, which
+// the file read and the JSON parse also copy. Percent-encoding separates them:
+// the form escapes the spaces in this needle and the stored JSON leaves them
+// literal, so a hit on the encoded spelling can only be the request body.
+const spaced_needle = "GROK TEST CREDENTIAL MARKER";
+const spaced_marker = spaced_needle ++ ("x" ** 1024);
+const encoded_needle = "GROK%20TEST%20CREDENTIAL%20MARKER";
+
+test "Grok request bodies carrying a credential are wiped before release" {
+    // The responses are already wiped with `secret.zeroAndFree`. The request
+    // form carries the credential itself, so it must not outlive the call in
+    // plaintext either.
+    var scan = secret.ScanAllocator{
+        .backing = std.testing.allocator,
+        .marker = secret.scan_needle,
+    };
+    const alloc = scan.allocator();
+
+    // Nothing is stored for this one, so every hit is the form body.
+    var tokens = try exchangeAuthorizationCodeForRedirectWithBounds(
+        alloc,
+        MarkedTransport.provider(),
+        "https://auth.x.ai/token",
+        "authorization-code",
+        secret.scan_marker,
+        "http://127.0.0.1:1455/callback",
+        null,
+        null,
+    );
+    tokens.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), scan.released_with_plaintext);
+
+    scan.marker = encoded_needle;
+
+    {
+        var home = try MarkedSessionHome.install(alloc, spaced_marker);
+        defer home.deinit();
+        var access = (try loadAccess(alloc, MarkedTransport.provider(), .force)).?;
+        access.deinit(alloc);
+    }
+
+    {
+        var home = try MarkedSessionHome.install(alloc, spaced_marker);
+        defer home.deinit();
+        const result = try logout(alloc, MarkedTransport.provider());
+        try std.testing.expect(!result.revocation_failed);
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), scan.released_with_plaintext);
 }

--- a/src/core/auth/js_host_auth.zig
+++ b/src/core/auth/js_host_auth.zig
@@ -95,14 +95,8 @@ pub fn executeBearerGet(
     url: []const u8,
     access_token: []const u8,
 ) !oauth_transport.Response {
-    // Sized exactly rather than formatted, because allocPrint grows an
-    // oversized buffer and releases it once the exact length is known, leaving
-    // a plaintext copy of the token behind in the abandoned allocation.
-    const prefix = "Bearer ";
-    const authorization = try alloc.alloc(u8, prefix.len + access_token.len);
+    const authorization = try secret.bearerHeaderAlloc(alloc, access_token);
     defer secret.zeroAndFree(alloc, authorization);
-    @memcpy(authorization[0..prefix.len], prefix);
-    @memcpy(authorization[prefix.len..], access_token);
     return executeRequest(alloc, "GET", url, &.{.{
         .name = "authorization",
         .value = authorization,

--- a/src/core/auth/js_host_auth.zig
+++ b/src/core/auth/js_host_auth.zig
@@ -95,12 +95,42 @@ pub fn executeBearerGet(
     url: []const u8,
     access_token: []const u8,
 ) !oauth_transport.Response {
-    const authorization = try std.fmt.allocPrint(alloc, "Bearer {s}", .{access_token});
+    // Sized exactly rather than formatted, because allocPrint grows an
+    // oversized buffer and releases it once the exact length is known, leaving
+    // a plaintext copy of the token behind in the abandoned allocation.
+    const prefix = "Bearer ";
+    const authorization = try alloc.alloc(u8, prefix.len + access_token.len);
     defer secret.zeroAndFree(alloc, authorization);
+    @memcpy(authorization[0..prefix.len], prefix);
+    @memcpy(authorization[prefix.len..], access_token);
     return executeRequest(alloc, "GET", url, &.{.{
         .name = "authorization",
         .value = authorization,
     }}, "");
+}
+
+/// Upper bound on the encoded header JSON. JSON string escaping expands a byte
+/// to at most six characters (`\uXXXX`), and each header contributes a fixed
+/// amount of punctuation and key names.
+fn headersJsonCapacity(headers: anytype) usize {
+    var total: usize = 2;
+    // Callers pass either a comptime tuple literal or a runtime slice, and a
+    // tuple can only be walked with `inline for`.
+    const Element = switch (@typeInfo(@TypeOf(headers))) {
+        .pointer => |pointer| pointer.child,
+        else => @TypeOf(headers),
+    };
+    const element_info = @typeInfo(Element);
+    if (element_info == .@"struct" and element_info.@"struct".is_tuple) {
+        inline for (headers) |header| {
+            total += (header.name.len + header.value.len) * 6 + 32;
+        }
+    } else {
+        for (headers) |header| {
+            total += (header.name.len + header.value.len) * 6 + 32;
+        }
+    }
+    return total;
 }
 
 fn executeRequest(
@@ -110,8 +140,16 @@ fn executeRequest(
     headers: anytype,
     body: []const u8,
 ) !oauth_transport.Response {
-    var headers_json: std.Io.Writer.Allocating = .init(alloc);
+    // An Authorization header is a credential, so the encoded buffer is
+    // reserved up front and overwritten at scope exit. Without the reservation
+    // the writer reallocates mid-encode and abandons buffers that keep their
+    // own plaintext copy of the token.
+    var headers_json: std.Io.Writer.Allocating = try .initCapacity(
+        alloc,
+        headersJsonCapacity(headers),
+    );
     defer headers_json.deinit();
+    defer secret.zero(headers_json.written());
     try std.json.Stringify.value(headers, .{}, &headers_json.writer);
 
     const response_buffer = try alloc.alloc(u8, max_response_bytes);
@@ -285,4 +323,34 @@ test "request bounds reject cancellation before touching the JS host" {
         .url = "https://vercel.test",
         .cancel_flag = &cancelled,
     }));
+}
+
+test "header json capacity covers the encoded bound so the writer never grows" {
+    const headers = .{
+        .{ .name = "authorization", .value = "Bearer abc.def.ghi" },
+        .{ .name = "content-type", .value = "application/json" },
+    };
+    var encoded: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer encoded.deinit();
+    try std.json.Stringify.value(headers, .{}, &encoded.writer);
+    try std.testing.expect(headersJsonCapacity(headers) >= encoded.written().len);
+
+    // The other call shape: a runtime slice, which cannot be walked inline.
+    const Header = struct { name: []const u8, value: []const u8 };
+    var buf: [2]Header = .{
+        .{ .name = "authorization", .value = "Bearer abc.def.ghi" },
+        .{ .name = "content-type", .value = "application/json" },
+    };
+    const as_slice: []const Header = buf[0..2];
+    var encoded_slice: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer encoded_slice.deinit();
+    try std.json.Stringify.value(as_slice, .{}, &encoded_slice.writer);
+    try std.testing.expect(headersJsonCapacity(as_slice) >= encoded_slice.written().len);
+
+    // A value needing maximal JSON escaping must still fit the reservation.
+    const escaped = .{.{ .name = "authorization", .value = "\x00\x01\x02\x03\x04\x05" }};
+    var encoded_escaped: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer encoded_escaped.deinit();
+    try std.json.Stringify.value(escaped, .{}, &encoded_escaped.writer);
+    try std.testing.expect(headersJsonCapacity(escaped) >= encoded_escaped.written().len);
 }

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -1127,7 +1127,7 @@ fn fetchTeams(alloc: Allocator, access_token: []const u8, issuer_url: []const u8
     defer if (e2e_endpoint) |endpoint| alloc.free(endpoint);
     const endpoint = e2e_endpoint orelse teams_endpoint;
 
-    const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{access_token});
+    const auth_header = try secret.bearerHeaderAlloc(alloc, access_token);
     defer secret.zeroAndFree(alloc, auth_header);
 
     var out: std.Io.Writer.Allocating = .init(alloc);

--- a/src/core/auth/oauth.zig
+++ b/src/core/auth/oauth.zig
@@ -430,56 +430,6 @@ fn check_token_set_allocation_failures(alloc: Allocator) !void {
     defer token.deinit(alloc);
 }
 
-/// Records whether any allocation still held a credential in plaintext at the
-/// moment it was returned to the allocator.
-const CredentialScanAllocator = struct {
-    backing: Allocator,
-    marker: []const u8,
-    released_with_plaintext: usize = 0,
-
-    fn allocator(self: *CredentialScanAllocator) Allocator {
-        return .{ .ptr = self, .vtable = &.{
-            .alloc = scanAlloc,
-            .resize = scanResize,
-            .remap = scanRemap,
-            .free = scanFree,
-        } };
-    }
-
-    fn scanAlloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
-        const self: *CredentialScanAllocator = @ptrCast(@alignCast(ctx));
-        return self.backing.vtable.alloc(self.backing.ptr, len, alignment, ret_addr);
-    }
-
-    fn scanResize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
-        const self: *CredentialScanAllocator = @ptrCast(@alignCast(ctx));
-        return self.backing.vtable.resize(self.backing.ptr, memory, alignment, new_len, ret_addr);
-    }
-
-    fn scanRemap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
-        const self: *CredentialScanAllocator = @ptrCast(@alignCast(ctx));
-        return self.backing.vtable.remap(self.backing.ptr, memory, alignment, new_len, ret_addr);
-    }
-
-    fn scanFree(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
-        const self: *CredentialScanAllocator = @ptrCast(@alignCast(ctx));
-        if (std.mem.indexOf(u8, memory, self.marker) != null) {
-            self.released_with_plaintext += 1;
-        }
-        self.backing.vtable.free(self.backing.ptr, memory, alignment, ret_addr);
-    }
-};
-
-// The needle is short and sits at the start of the credential, so it is found in
-// a partially written buffer too. Searching for the whole credential would miss
-// exactly the case this guards: a buffer abandoned mid-growth holds a truncated
-// prefix, not the complete value.
-const credential_needle = "OAUTH_TEST_CREDENTIAL_MARKER";
-
-// Long enough that the form body outgrows the writer's initial buffer. A short
-// credential fits in the first allocation and never exercises the growth path.
-const credential_marker = credential_needle ++ ("x" ** 1024);
-
 fn credentialProbeMetadata() Metadata {
     return .{
         .issuer = @constCast("https://vercel.test"),
@@ -492,9 +442,9 @@ test "oauth request bodies carrying a credential are wiped before release" {
     // The response in each of these calls is already wiped with
     // `secret.zeroAndFree`. The request form carries the credential itself, so
     // it must not outlive the call in plaintext either.
-    var scan = CredentialScanAllocator{
+    var scan = secret.ScanAllocator{
         .backing = std.testing.allocator,
-        .marker = credential_needle,
+        .marker = secret.scan_needle,
     };
     const alloc = scan.allocator();
     const metadata = credentialProbeMetadata();
@@ -505,7 +455,7 @@ test "oauth request bodies carrying a credential are wiped before release" {
             .expected_url = "https://vercel.test/token",
             .response_body = "{\"access_token\":\"a\",\"token_type\":\"bearer\",\"expires_in\":3600}",
         };
-        var tokens = try refreshToken(alloc, probe.provider(), metadata, "client", credential_marker);
+        var tokens = try refreshToken(alloc, probe.provider(), metadata, "client", secret.scan_marker);
         tokens.deinit(alloc);
     }
 
@@ -528,7 +478,7 @@ test "oauth request bodies carrying a credential are wiped before release" {
             probe.provider(),
             metadata,
             "client",
-            credential_marker,
+            secret.scan_marker,
             &cancel_flag,
             deadline,
         );
@@ -546,7 +496,7 @@ test "oauth request bodies carrying a credential are wiped before release" {
             probe.provider(),
             "https://vercel.test/revoke",
             "client",
-            credential_marker,
+            secret.scan_marker,
             .refresh_token,
         );
     }

--- a/src/core/auth/oauth.zig
+++ b/src/core/auth/oauth.zig
@@ -149,8 +149,13 @@ pub fn pollDeviceTokenBounded(
     deadline: std.Io.Clock.Timestamp,
 ) !PollResult {
     var form: FormBody = .{};
-    var writer: std.Io.Writer.Allocating = .init(alloc);
+    var writer: std.Io.Writer.Allocating = try .initCapacity(alloc, formCapacity(&.{
+        "client_id",   client_id,
+        "grant_type",  "urn:ietf:params:oauth:grant-type:device_code",
+        "device_code", device_code,
+    }));
     defer writer.deinit();
+    defer secret.zero(writer.written());
     try form.append(&writer.writer, "client_id", client_id);
     try form.append(&writer.writer, "grant_type", "urn:ietf:params:oauth:grant-type:device_code");
     try form.append(&writer.writer, "device_code", device_code);
@@ -182,8 +187,13 @@ pub fn refreshToken(
     refresh_token: []const u8,
 ) !TokenSet {
     var form: FormBody = .{};
-    var writer: std.Io.Writer.Allocating = .init(alloc);
+    var writer: std.Io.Writer.Allocating = try .initCapacity(alloc, formCapacity(&.{
+        "client_id",     client_id,
+        "grant_type",    "refresh_token",
+        "refresh_token", refresh_token,
+    }));
     defer writer.deinit();
+    defer secret.zero(writer.written());
     try form.append(&writer.writer, "client_id", client_id);
     try form.append(&writer.writer, "grant_type", "refresh_token");
     try form.append(&writer.writer, "refresh_token", refresh_token);
@@ -208,8 +218,13 @@ pub fn revokeToken(
     token_type_hint: TokenTypeHint,
 ) !void {
     var form: FormBody = .{};
-    var writer: std.Io.Writer.Allocating = .init(alloc);
+    var writer: std.Io.Writer.Allocating = try .initCapacity(alloc, formCapacity(&.{
+        "client_id",       client_id,
+        "token",           token,
+        "token_type_hint", @tagName(token_type_hint),
+    }));
     defer writer.deinit();
+    defer secret.zero(writer.written());
     try form.append(&writer.writer, "client_id", client_id);
     try form.append(&writer.writer, "token", token);
     try form.append(&writer.writer, "token_type_hint", @tagName(token_type_hint));
@@ -336,6 +351,16 @@ fn mapOAuthHttpError(alloc: Allocator, body: []const u8) !void {
     return OAuthError.OAuthRequestFailed;
 }
 
+/// Upper bound on an encoded form body. `percentEncode` expands each byte to at
+/// most three characters, and each field adds one `=` or `&`. Reserving this up
+/// front keeps the writer from reallocating while it holds a credential, which
+/// would leave the secret behind in the abandoned buffer.
+fn formCapacity(parts: []const []const u8) usize {
+    var total: usize = 0;
+    for (parts) |part| total += part.len * 3;
+    return total + parts.len;
+}
+
 const FormBody = struct {
     first: bool = true,
 
@@ -403,6 +428,130 @@ fn check_token_set_allocation_failures(alloc: Allocator) !void {
         "{\"access_token\":\"access\",\"refresh_token\":\"refresh\",\"expires_in\":3600,\"scope\":\"openid offline_access\",\"token_type\":\"Bearer\"}",
     );
     defer token.deinit(alloc);
+}
+
+/// Records whether any allocation still held a credential in plaintext at the
+/// moment it was returned to the allocator.
+const CredentialScanAllocator = struct {
+    backing: Allocator,
+    marker: []const u8,
+    released_with_plaintext: usize = 0,
+
+    fn allocator(self: *CredentialScanAllocator) Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = scanAlloc,
+            .resize = scanResize,
+            .remap = scanRemap,
+            .free = scanFree,
+        } };
+    }
+
+    fn scanAlloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *CredentialScanAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.vtable.alloc(self.backing.ptr, len, alignment, ret_addr);
+    }
+
+    fn scanResize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *CredentialScanAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.vtable.resize(self.backing.ptr, memory, alignment, new_len, ret_addr);
+    }
+
+    fn scanRemap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *CredentialScanAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.vtable.remap(self.backing.ptr, memory, alignment, new_len, ret_addr);
+    }
+
+    fn scanFree(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *CredentialScanAllocator = @ptrCast(@alignCast(ctx));
+        if (std.mem.indexOf(u8, memory, self.marker) != null) {
+            self.released_with_plaintext += 1;
+        }
+        self.backing.vtable.free(self.backing.ptr, memory, alignment, ret_addr);
+    }
+};
+
+// The needle is short and sits at the start of the credential, so it is found in
+// a partially written buffer too. Searching for the whole credential would miss
+// exactly the case this guards: a buffer abandoned mid-growth holds a truncated
+// prefix, not the complete value.
+const credential_needle = "OAUTH_TEST_CREDENTIAL_MARKER";
+
+// Long enough that the form body outgrows the writer's initial buffer. A short
+// credential fits in the first allocation and never exercises the growth path.
+const credential_marker = credential_needle ++ ("x" ** 1024);
+
+fn credentialProbeMetadata() Metadata {
+    return .{
+        .issuer = @constCast("https://vercel.test"),
+        .device_authorization_endpoint = @constCast("https://vercel.test/device"),
+        .token_endpoint = @constCast("https://vercel.test/token"),
+    };
+}
+
+test "oauth request bodies carrying a credential are wiped before release" {
+    // The response in each of these calls is already wiped with
+    // `secret.zeroAndFree`. The request form carries the credential itself, so
+    // it must not outlive the call in plaintext either.
+    var scan = CredentialScanAllocator{
+        .backing = std.testing.allocator,
+        .marker = credential_needle,
+    };
+    const alloc = scan.allocator();
+    const metadata = credentialProbeMetadata();
+
+    {
+        var probe = TransportProbe{
+            .expected_method = .post_form,
+            .expected_url = "https://vercel.test/token",
+            .response_body = "{\"access_token\":\"a\",\"token_type\":\"bearer\",\"expires_in\":3600}",
+        };
+        var tokens = try refreshToken(alloc, probe.provider(), metadata, "client", credential_marker);
+        tokens.deinit(alloc);
+    }
+
+    {
+        var cancel_flag = std.atomic.Value(bool).init(false);
+        const deadline = std.Io.Clock.Timestamp.fromNow(std.testing.io, .{
+            .clock = .awake,
+            .raw = .fromMilliseconds(1),
+        });
+        var probe = TransportProbe{
+            .expected_method = .post_form,
+            .expected_url = "https://vercel.test/token",
+            .response_disposition = .rejected,
+            .response_body = "{\"error\":\"authorization_pending\"}",
+            .expected_cancel_flag = &cancel_flag,
+            .expect_deadline = true,
+        };
+        const result = try pollDeviceTokenBounded(
+            alloc,
+            probe.provider(),
+            metadata,
+            "client",
+            credential_marker,
+            &cancel_flag,
+            deadline,
+        );
+        try std.testing.expectEqual(PollResult.pending, result);
+    }
+
+    {
+        var probe = TransportProbe{
+            .expected_method = .post_form,
+            .expected_url = "https://vercel.test/revoke",
+            .response_body = "{}",
+        };
+        try revokeToken(
+            alloc,
+            probe.provider(),
+            "https://vercel.test/revoke",
+            "client",
+            credential_marker,
+            .refresh_token,
+        );
+    }
+
+    try std.testing.expectEqual(@as(usize, 0), scan.released_with_plaintext);
 }
 
 const TransportProbe = struct {

--- a/src/core/auth/secret.zig
+++ b/src/core/auth/secret.zig
@@ -26,3 +26,82 @@ test "zeroAndFree overwrites bytes before release" {
     std.crypto.secureZero(u8, @volatileCast(value[0..]));
     try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0 }, &value);
 }
+
+/// Test helper. Records whether any allocation still held a credential in
+/// plaintext at the moment it was returned to the allocator. The scan runs
+/// before the backing allocator sees the block, so a debug build's own poison
+/// does not hide the answer.
+pub const ScanAllocator = struct {
+    backing: std.mem.Allocator,
+    marker: []const u8,
+    released_with_plaintext: usize = 0,
+
+    pub fn allocator(self: *ScanAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = scanAlloc,
+            .resize = scanResize,
+            .remap = scanRemap,
+            .free = scanFree,
+        } };
+    }
+
+    fn scanAlloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
+        const self: *ScanAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.vtable.alloc(self.backing.ptr, len, alignment, ret_addr);
+    }
+
+    fn scanResize(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
+        const self: *ScanAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.vtable.resize(self.backing.ptr, memory, alignment, new_len, ret_addr);
+    }
+
+    fn scanRemap(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ret_addr: usize) ?[*]u8 {
+        const self: *ScanAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.vtable.remap(self.backing.ptr, memory, alignment, new_len, ret_addr);
+    }
+
+    fn scanFree(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
+        const self: *ScanAllocator = @ptrCast(@alignCast(ctx));
+        if (std.mem.indexOf(u8, memory, self.marker) != null) {
+            self.released_with_plaintext += 1;
+        }
+        self.backing.vtable.free(self.backing.ptr, memory, alignment, ret_addr);
+    }
+};
+
+// The needle is short and sits at the start of the credential, so it is found in
+// a partially written buffer too. Searching for the whole credential would miss
+// exactly the case this guards: a buffer abandoned mid-growth holds a truncated
+// prefix, not the complete value.
+pub const scan_needle = "OAUTH_TEST_CREDENTIAL_MARKER";
+
+// Long enough that the encoded body outgrows the writer's initial buffer. A
+// short credential fits in the first allocation and never exercises the growth
+// path, which leaves the test vacuous.
+pub const scan_marker = scan_needle ++ ("x" ** 1024);
+
+test "the scan allocator sees a credential abandoned while a writer grows" {
+    // `Allocator.free` overwrites a block with `undefined` in a safety build
+    // before any wrapping allocator sees it, so the observable half is the
+    // growth path: every buffer a writer outgrows is handed back through
+    // `remap`/`rawFree` with its contents intact.
+    var scan = ScanAllocator{ .backing = std.testing.allocator, .marker = scan_needle };
+    const alloc = scan.allocator();
+
+    // Appended in pieces, the way a form or JSON body is assembled. One
+    // `writeAll` of the whole value sizes the buffer in a single step and
+    // abandons nothing.
+    var grown: std.Io.Writer.Allocating = .init(alloc);
+    defer grown.deinit();
+    for (0..scan_marker.len) |i| try grown.writer.writeByte(scan_marker[i]);
+    try std.testing.expect(scan.released_with_plaintext > 0);
+
+    // Reserved up front and wiped at the end, the same shape the callers use:
+    // nothing is abandoned, so the count does not move.
+    const before = scan.released_with_plaintext;
+    var reserved: std.Io.Writer.Allocating = try .initCapacity(alloc, scan_marker.len * 2);
+    defer reserved.deinit();
+    defer zero(reserved.written());
+    for (0..scan_marker.len) |i| try reserved.writer.writeByte(scan_marker[i]);
+    try std.testing.expectEqual(before, scan.released_with_plaintext);
+}

--- a/src/core/auth/secret.zig
+++ b/src/core/auth/secret.zig
@@ -14,6 +14,18 @@ pub noinline fn zero(value: []const u8) void {
     std.crypto.secureZero(u8, @constCast(@volatileCast(value)));
 }
 
+/// Build an `Authorization: Bearer` value in an exactly sized allocation. The
+/// obvious `allocPrint` grows an oversized buffer and releases it once the real
+/// length is known, leaving a plaintext copy of the token in the abandoned
+/// block. The caller owns the result and releases it with `zeroAndFree`.
+pub fn bearerHeaderAlloc(alloc: std.mem.Allocator, access_token: []const u8) ![]u8 {
+    const prefix = "Bearer ";
+    const header = try alloc.alloc(u8, prefix.len + access_token.len);
+    @memcpy(header[0..prefix.len], prefix);
+    @memcpy(header[prefix.len..], access_token);
+    return header;
+}
+
 test "zero overwrites bytes in place and tolerates an empty slice" {
     var value = [_]u8{ 1, 2, 3 };
     zero(value[0..]);
@@ -26,7 +38,6 @@ test "zeroAndFree overwrites bytes before release" {
     std.crypto.secureZero(u8, @volatileCast(value[0..]));
     try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0 }, &value);
 }
-
 /// Test helper. Records whether any allocation still held a credential in
 /// plaintext at the moment it was returned to the allocator. The scan runs
 /// before the backing allocator sees the block, so a debug build's own poison
@@ -104,4 +115,15 @@ test "the scan allocator sees a credential abandoned while a writer grows" {
     defer zero(reserved.written());
     for (0..scan_marker.len) |i| try reserved.writer.writeByte(scan_marker[i]);
     try std.testing.expectEqual(before, scan.released_with_plaintext);
+}
+
+test "the bearer header leaves no abandoned copy of the token" {
+    var scan = ScanAllocator{ .backing = std.testing.allocator, .marker = scan_needle };
+    const alloc = scan.allocator();
+
+    const header = try bearerHeaderAlloc(alloc, scan_marker);
+    try std.testing.expectStringStartsWith(header, "Bearer " ++ scan_needle);
+    try std.testing.expectEqual(@as(usize, "Bearer ".len + scan_marker.len), header.len);
+    zeroAndFree(alloc, header);
+    try std.testing.expectEqual(@as(usize, 0), scan.released_with_plaintext);
 }

--- a/src/core/auth/secret.zig
+++ b/src/core/auth/secret.zig
@@ -7,6 +7,20 @@ pub noinline fn zeroAndFree(alloc: std.mem.Allocator, value: []u8) void {
     alloc.free(value);
 }
 
+/// Overwrite an owned secret in place, for buffers whose allocation is released
+/// by their owner rather than freed here (a writer's backing buffer, say).
+pub noinline fn zero(value: []const u8) void {
+    if (value.len == 0) return;
+    std.crypto.secureZero(u8, @constCast(@volatileCast(value)));
+}
+
+test "zero overwrites bytes in place and tolerates an empty slice" {
+    var value = [_]u8{ 1, 2, 3 };
+    zero(value[0..]);
+    try std.testing.expectEqualSlices(u8, &.{ 0, 0, 0 }, &value);
+    zero(&.{});
+}
+
 test "zeroAndFree overwrites bytes before release" {
     var value = [_]u8{ 1, 2, 3 };
     std.crypto.secureZero(u8, @volatileCast(value[0..]));

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -794,7 +794,7 @@ test "PKCE base64url encoding covers complete and partial groups" {
 }
 
 pub fn bearerHeaderAlloc(alloc: Allocator, access_token: []const u8) ![]u8 {
-    return std.fmt.allocPrint(alloc, "Bearer {s}", .{access_token});
+    return secret.bearerHeaderAlloc(alloc, access_token);
 }
 
 pub fn validateClientMetadataUrl(url: []const u8) !void {


### PR DESCRIPTION
The device-code, refresh and revoke flows each build a form body that holds the credential itself, and the JS host encodes a Bearer token into its header JSON. Each of those buffers went back to the allocator without being overwritten, while the response in the same function was carefully wiped with `secret.zeroAndFree`. The token stayed readable in freed heap memory after the call.

Overwriting the final buffer is not enough on its own, which is what makes this more than a one-line change. Every one of these paths grows a buffer while holding the secret. The form writer starts near 132 bytes and reallocates as the body grows, which a JWT-sized refresh token easily triggers, and `allocPrint` sizes the Bearer header generously before shrinking to the exact length. Each growth step abandons an allocation that keeps its own plaintext copy. A scan of released buffers found five per form call, not one.

So each path now reserves the encoded worst case up front, or sizes the allocation exactly, and only then overwrites the single remaining buffer at scope exit. The overwrite goes through a new `secret.zero` helper beside the existing `zeroAndFree`, so every secret overwrite still greps as one convention.

`requestDeviceAuthorization` keeps its plain writer, because its form carries only the client id and the scope.

## Verification

The oauth test drives all three form calls through an allocator that inspects each buffer as it is released. Two details make it load-bearing rather than decorative: its credential is long enough to force the growth path, and it searches for a short needle at the head of the value rather than the whole credential, since a buffer abandoned mid-growth holds only a truncated prefix. An earlier version of the test missed both and passed against the unfixed code.

Measured per call site, with a 2 KiB credential, before and after:

| site | before | after |
| --- | --- | --- |
| `refreshToken` | 5 | 0 |
| `revokeToken` | 5 | 0 |
| `pollDeviceTokenBounded` | 5 | 0 |
| `executeBearerGet` (JS host) | 2 | 0 |

Removing the reservations while keeping the overwrite puts the test at `expected 0, found 9`, so it covers the growth path specifically and not just the final buffer.

Local `zig build test` and `zig build test -Doptimize=ReleaseSafe` both leave the failing-test set identical to the pre-change baseline on this machine. ReleaseSafe matters here because dead-store elimination is the thing `secureZero` exists to survive, and a Debug-only result would not have shown that.

## Not covered

The JS host path cannot run without a host, so its reservation is guarded by a bound test rather than an end-to-end one. The end-to-end measurement above came from a standalone harness with the host imports stubbed.

`headersJsonCapacity` accepts both call shapes, a comptime tuple and a runtime slice, and the test exercises both. Only the tuple shape is reachable in a native build today, so without that coverage the slice branch would have compiled purely by not being analysed.

The response side is a separate problem and is not addressed here. Tokens parsed out of a JSON response stay in the parser's own released allocations, which I have filed separately. Those counts are identical before and after this branch.


I cannot apply labels on this repo. The intended one is `type: security`.
