### PR TITLE
Report catalog-gated reasoning effort drops instead of discarding silently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,8 @@ Config precedence (highest wins):
 
 Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `permission_mode`, `credential_source`, and `permission` are ignored from project config before their values are parsed.
 
+`effort` is catalog-gated: fx sends it to the gateway only when the active model's catalog entry declares that effort tier. When it does not, fx reports this once via a system notice instead of silently discarding the setting.
+
 Runtime state lives under `~/.fx/sessions/<session-id>/` (`session.json`, `background/`, `subagent/`, `logs/`). Sessions are global and portable across workspaces — each session tracks its `workspace_root` which updates when resumed in a different workspace. A subagent child is an ordinary session with its own directory; `subagent/` holds create-operation identities on a parent and the control record on a child.
 
 ## Permissions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,8 @@ Config precedence (highest wins):
 
 Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `update_channel`, `permission_mode`, and `permission` are ignored from project config before their values are parsed.
 
+`effort` is catalog-gated: fx sends it to the gateway only when the active model's catalog entry declares that effort tier. When it does not, fx reports this once via a system notice instead of silently discarding the setting.
+
 Runtime state lives under `~/.fx/`:
 
 * `~/.fx/sessions/<session-id>/session.json`

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2972,6 +2972,7 @@ fn processQueuedPromptLoop(
     var last_tool_call_name: []const u8 = "none";
     var last_tool_call_id: []const u8 = "none";
     var last_gateway_message_count: usize = stable_prefix.items.len + history_messages.items.len + 1;
+    var last_dropped_effort_notice: ?struct { model: []const u8, effort: types.ReasoningEffort } = null;
     var selected_dynamic_tool_names: std.ArrayList([]const u8) = .empty;
     var selected_dynamic_tool_schemas: std.ArrayList([]const u8) = .empty;
     const current_user_effective = current_user_message;
@@ -3297,7 +3298,22 @@ fn processQueuedPromptLoop(
             );
             last_gateway_message_count = request_messages.len;
             const provider_opts = model_capabilities.resolveProviderOptionsForCapabilities(request_capabilities, config.effort, route_fast_mode);
-            runtime_telemetry.traceGatewayProviderOptions(step_ctx, gateway_model, route_fast_mode, config.effort, provider_opts);
+            runtime_telemetry.traceGatewayProviderOptions(step_ctx, gateway_model, route_fast_mode, config.effort, request_capabilities, provider_opts);
+            if (model_capabilities.reasoningEffortDropped(request_capabilities, config.effort)) {
+                const already_notified = if (last_dropped_effort_notice) |pair|
+                    pair.effort.eql(config.effort) and std.mem.eql(u8, pair.model, gateway_model)
+                else
+                    false;
+                if (!already_notified) {
+                    last_dropped_effort_notice = .{ .model = gateway_model, .effort = config.effort };
+                    const notice = try std.fmt.allocPrint(
+                        arena,
+                        "reasoning effort \"{s}\" is not available for {s}; the model's catalog entry does not declare that effort tier, so the request uses the provider default",
+                        .{ config.effort.displayLabel(), gateway_model },
+                    );
+                    try deps.push_system_notice(deps.ctx, notice);
+                }
+            }
             const tool_choice: types.ToolChoice = if (recovery_strategy == .reconcile_tool)
                 .none
             else if (configured_first_tool_choice_pending and vision_mode != .required)

--- a/src/core/agent/runtime/telemetry.zig
+++ b/src/core/agent/runtime/telemetry.zig
@@ -289,13 +289,13 @@ pub fn traceCancelObserved(ctx: TraceContext, active_tool_known: bool) void {
     debug_trace.eventf("interrupt", "cancel_observed", ctx, "active_tool_known={s}", .{if (active_tool_known) "true" else "false"});
 }
 
-pub fn traceGatewayProviderOptions(ctx: TraceContext, model: []const u8, fast_mode: bool, effort: ReasoningEffort, provider_opts: model_capabilities.ResolvedProviderOptions) void {
-    const reasoning_outcome = if (provider_opts.reasoning != null)
+pub fn traceGatewayProviderOptions(ctx: TraceContext, model: []const u8, fast_mode: bool, effort: ReasoningEffort, capabilities: model_capabilities.Capabilities, provider_opts: model_capabilities.ResolvedProviderOptions) void {
+    const reasoning_outcome = if (model_capabilities.reasoningEffortDropped(capabilities, effort))
+        "unsupported_or_missing"
+    else if (provider_opts.reasoning != null)
         "selected"
-    else if (effort.isDefault())
-        "default"
     else
-        "unsupported_or_missing";
+        "default";
     const fast_outcome = if (provider_opts.fast)
         "selected"
     else if (!fast_mode)

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -2809,6 +2809,78 @@ test "processQueuedPrompt traces why stale controls are omitted" {
     defer alloc.free(trace);
     try std.testing.expect(std.mem.find(u8, trace, "reasoning=unsupported_or_missing") != null);
     try std.testing.expect(std.mem.find(u8, trace, "fast=unsupported_or_missing") != null);
+    try std.testing.expectEqual(@as(usize, 1), hooks.system_notices.items.len);
+    try std.testing.expect(std.mem.find(u8, hooks.system_notices.items[0], "stale-tier") != null);
+    try std.testing.expect(std.mem.find(u8, hooks.system_notices.items[0], "provider/no-live-controls") != null);
+}
+
+test "processQueuedPrompt pushes the dropped-effort notice once across multiple Gateway steps" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{toolCall("call_read_stale_effort", "read_file", "{\"path\":\"a\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Final" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.effort = types.ReasoningEffort.literal("stale-tier");
+    var job = fixture.job();
+    job.model = @constCast("provider/no-live-controls");
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_bodies.items.len);
+    try std.testing.expectEqual(@as(usize, 1), hooks.system_notices.items.len);
+    try std.testing.expect(std.mem.find(u8, hooks.system_notices.items[0], "stale-tier") != null);
+}
+
+test "processQueuedPrompt does not push a dropped-effort notice for the default effort" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{.{ .content = "Done" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.effort = .auto;
+    var job = fixture.job();
+    job.model = @constCast("provider/no-live-controls");
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
+}
+
+test "processQueuedPrompt does not push a dropped-effort notice when the catalog declares the tier" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{.{ .content = "Done" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    const efforts = [_]types.ReasoningEffort{types.ReasoningEffort.literal("future-tier")};
+    const capability_overrides = [_]ModelCapabilityOverride{.{
+        .model = "provider/new-reasoning-model",
+        .capabilities = model_capabilities.resolveCapabilities(
+            "provider/new-reasoning-model",
+            .{ .reasoning_efforts = .fromSlice(&efforts) },
+        ),
+    }};
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.capability_overrides = &capability_overrides;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.effort = types.ReasoningEffort.literal("future-tier");
+    var job = fixture.job();
+    job.model = @constCast("provider/new-reasoning-model");
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
 }
 
 test "processQueuedPrompt persists interruption when capability resolution returns cancellation" {

--- a/src/core/config/model_capabilities.zig
+++ b/src/core/config/model_capabilities.zig
@@ -129,6 +129,10 @@ pub fn reasoningEffortSupported(capabilities: Capabilities, effort: types.Reason
     return false;
 }
 
+pub fn reasoningEffortDropped(capabilities: Capabilities, effort: types.ReasoningEffort) bool {
+    return !effort.isDefault() and !reasoningEffortSupported(capabilities, effort);
+}
+
 pub fn reasoningEffortIndex(capabilities: Capabilities, effort: types.ReasoningEffort) usize {
     if (effort.isDefault()) return 0;
     for (capabilities.reasoning_efforts.slice(), 0..) |option, i| {
@@ -296,6 +300,20 @@ test "request controls form a total fail-closed state machine" {
             try std.testing.expect(resolved.reasoning == null);
         }
     }
+}
+
+test "reasoningEffortDropped agrees with the fail-closed resolution" {
+    const declared_efforts = [_]types.ReasoningEffort{types.ReasoningEffort.literal("high")};
+    const declared_capabilities: Capabilities = .{ .reasoning_efforts = .fromSlice(&declared_efforts) };
+    const empty_capabilities: Capabilities = .{};
+    const high = types.ReasoningEffort.literal("high");
+    const stale = types.ReasoningEffort.literal("stale-tier");
+
+    try std.testing.expect(!reasoningEffortDropped(declared_capabilities, .auto));
+    try std.testing.expect(!reasoningEffortDropped(declared_capabilities, high));
+    try std.testing.expect(reasoningEffortDropped(declared_capabilities, stale));
+    try std.testing.expect(!reasoningEffortDropped(empty_capabilities, .auto));
+    try std.testing.expect(reasoningEffortDropped(empty_capabilities, high));
 }
 
 test "request controls remain safe across repeated state transitions" {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -4106,6 +4106,75 @@ describe("cli: ask success", () => {
     60_000,
   );
 
+  test(
+    "fx ask reports a dropped reasoning effort instead of silently discarding it",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-ask-dropped-reasoning-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const model = "provider/no-effort-tiers-model";
+      const gateway = startFakeGateway(
+        [fakeGatewayFinalText("dropped effort ask complete")],
+        {
+          models: [{
+            id: model,
+            type: "language",
+            tags: ["tool-use"],
+            context_window: 750_000,
+            max_tokens: 64_000,
+          }],
+        },
+      );
+      try {
+        mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+        mkdirSync(workspace);
+        writeFileSync(
+          join(home, ".fx", "settings.json"),
+          `${JSON.stringify({ model, effort: "high" })}\n`,
+        );
+
+        const result = await runFx(
+          ["ask", "--json", "--auto", "--no-save", "Use portable reasoning."],
+          {
+            cwd: realpathSync(workspace),
+            env: {
+              HOME: home,
+              AI_GATEWAY_API_KEY: "fake-dropped-ask-key",
+              VERCEL_OIDC_TOKEN: undefined,
+              FX_GATEWAY_BASE_URL: gateway.baseUrl,
+              FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+              FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+            },
+            timeoutMs: 60_000,
+          },
+        );
+
+        expect(result.code).toBe(0);
+        expect(JSON.parse(result.stdout).output.trim()).toBe("dropped effort ask complete");
+        expect(gateway.requests).toHaveLength(1);
+        const request = JSON.parse(gateway.requests[0]!.body);
+        expect(request).not.toHaveProperty("reasoning");
+        expect(
+          result.stderr
+            .replace(
+              /fx ask: warning: skipped \d+ invalid or unreadable skill candidates?; relaunch with FX_TRACE=1 to write a trace log\n/g,
+              "",
+            )
+            .replace(
+              /\[notice\] skill discovery warning: [^\n]*; relaunch with FX_TRACE=1 to write a trace log\n/g,
+              "",
+            ),
+        ).toBe(
+          `[notice] reasoning effort "high" is not available for ${model}; the model's catalog entry does not declare that effort tier, so the request uses the provider default\n`,
+        );
+      } finally {
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
   test.skipIf(!HAS_API_KEY)(
     "live Gateway accepts catalog-backed portable reasoning",
     async () => {


### PR DESCRIPTION
## Summary
- add `reasoningEffortDropped` next to the existing capability helpers so telemetry and the new notice share one definition of "dropped"
- push a one time `[notice]` when a configured effort isn't in the model's catalog tiers, right after the existing gateway trace call
- reuse the predicate in `traceGatewayProviderOptions` so the trace and the notice can't drift apart
- document that `effort` is catalog gated in CONTRIBUTING.md and AGENTS.md

## Why
#276 reports that `effort` in `~/.fx/settings.json` is a silent no-op for every Gateway model. Direction (1) from the issue (mapping effort into the gateway request) is already implemented, at `gateway_json.zig:373`, verified present at the exact commit the issue was filed against. The actual gap is direction (2): when the catalog doesn't declare the tier, `resolveProviderOptionsForCapabilities` intentionally drops it (fail closed, by design, see the test named "request controls form a total fail-closed state machine"), but nothing told the user it happened. For `zai/glm-5.2` the catalog declares no tiers, so `effort: "high"` was accepted and quietly discarded.

This doesn't touch the wire contract or the fail-closed resolution, it just makes the drop visible.

## Validation
- `zig fmt --check src/`
- `zig build`
- `zig build test` (focused: `model_capabilities`, `gateway_flow`)
- `zig build -Doptimize=ReleaseSafe`
- `bun test cli.test.ts -t reasoning` (from `tests/e2e/`)

Manual: ran `./zig-out/bin/fx ask` against a fake gateway catalog with no `reasoning_options` and `effort: "high"` set, got one `[notice]` line and an unchanged (empty) request body. With the tier declared, no notice and `"reasoning":"high"` on the wire.

Closes #276
