### PR TITLE
Shorten update notices

### DIFF
--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -3688,7 +3688,7 @@ pub fn Runtime(comptime App: type) type {
                 .upgrade => |version| {
                     const body = try std.fmt.allocPrint(
                         app.alloc,
-                        "𝒇x has been updated to v{s}",
+                        "fx has been updated to v{s}",
                         .{version},
                     );
                     defer app.alloc.free(body);
@@ -7426,7 +7426,7 @@ test "upgrade resume restores active session with the installed version notice" 
     try std.testing.expectEqualStrings("inspect file", context[1].assistant.user.text);
     try std.testing.expectEqualStrings("run server", context[2].background_command.user.text);
     try std.testing.expectEqual(@as(usize, 3), app.notices.items.len);
-    try std.testing.expectEqualStrings("● 𝒇x has been updated to v9.9.9", app.notices.items[0]);
+    try std.testing.expectEqualStrings("● fx has been updated to v9.9.9", app.notices.items[0]);
     try std.testing.expect(std.mem.find(u8, app.notices.items[1], "older context") != null);
     try std.testing.expect(std.mem.find(u8, app.notices.items[2], "Re-check runtime context") != null);
     try std.testing.expectEqual(@as(usize, 2), app.completed_tool_statuses.items.len);

--- a/src/core/upgrade/auto_upgrade.zig
+++ b/src/core/upgrade/auto_upgrade.zig
@@ -106,7 +106,7 @@ pub const AutoUpgrade = struct {
                 const ver = self.getLatestVersion(&ver_buf);
                 return std.fmt.bufPrint(buf, "upgrading to {s}...", .{ver}) catch "";
             },
-            .ready => return "Update installed: ctrl+g to reload",
+            .ready => return "update ready: ctrl+g to reload",
             .failed => return "upgrade failed",
             else => return "",
         }
@@ -292,7 +292,7 @@ test "statusLabel ready explains ctrl+g reload" {
     au.setState(.ready);
     var buf: [64]u8 = undefined;
     const label = au.statusLabel(&buf);
-    try std.testing.expectEqualStrings("Update installed: ctrl+g to reload", label);
+    try std.testing.expectEqualStrings("update ready: ctrl+g to reload", label);
 }
 
 test "setLatestVersion stores normalized version" {

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -1478,7 +1478,7 @@ test "compose hint row right-aligns upgrade status" {
         .selected_subagent_id = null,
         .selected_subagent_label = null,
         .selected_subagent_status = null,
-        .upgrade_status = "Update installed: ctrl+g to reload",
+        .upgrade_status = "update ready: ctrl+g to reload",
         .statusline = .{
             .workspace_label = "/a/long/workspace/path/that/uses/the/statusline-tail",
         },
@@ -1489,8 +1489,8 @@ test "compose hint row right-aligns upgrade status" {
     defer row.deinit(std.testing.allocator);
 
     try std.testing.expect(std.mem.find(u8, row.items, "gpt-5.1") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Update installed: ctrl+g to reload") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "\x1b[15G") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "update ready: ctrl+g to reload") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "\x1b[19G") != null);
 }
 
 test "compose hint row right-aligns upgrade status after styled auto mode" {
@@ -1508,7 +1508,7 @@ test "compose hint row right-aligns upgrade status after styled auto mode" {
         .selected_subagent_id = null,
         .selected_subagent_label = null,
         .selected_subagent_status = null,
-        .upgrade_status = "Update installed: ctrl+g to reload",
+        .upgrade_status = "update ready: ctrl+g to reload",
         .input = &input,
     };
 
@@ -1518,8 +1518,8 @@ test "compose hint row right-aligns upgrade status after styled auto mode" {
 
     try std.testing.expect(std.mem.find(u8, row.items, "auto") != null);
     try std.testing.expect(std.mem.find(u8, row.items, "gpt-4o") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Update installed: ctrl+g to reload") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "\x1b[23G") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "update ready: ctrl+g to reload") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "\x1b[27G") != null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 56);
 }
 
@@ -1611,13 +1611,13 @@ test "question hint row excludes model and upgrade status at supported widths" {
         var ctx = testRenderContext(&input);
         ctx.question = prompt.projection();
         ctx.model = "model-x";
-        ctx.upgrade_status = "Update installed: ctrl+g to reload";
+        ctx.upgrade_status = "update ready: ctrl+g to reload";
         var row = try composeHintRow(std.testing.allocator, false, null, ctx, case.width);
         defer row.deinit(std.testing.allocator);
 
         try std.testing.expect(std.mem.find(u8, row.items, case.hint) != null);
         try std.testing.expect(std.mem.find(u8, row.items, "model-x") == null);
-        try std.testing.expect(std.mem.find(u8, row.items, "Update installed: ctrl+g to reload") == null);
+        try std.testing.expect(std.mem.find(u8, row.items, "update ready: ctrl+g to reload") == null);
         try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= case.width);
     }
 }

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -4872,7 +4872,7 @@ test.skipIf(!tmuxAvailable())(
       const sessionId = sessionIdFromHome(home);
 
       await active.waitForText(
-        "Update installed: ctrl+g to reload",
+        "update ready: ctrl+g to reload",
         UPGRADE_TIMEOUT,
       );
       expect(readFileSync(installedFx, "utf8")).toContain(argvLogPath);
@@ -4889,7 +4889,7 @@ test.skipIf(!tmuxAvailable())(
       expect(readFileSync(argvLogPath, "utf8").trim().split("\n")).toEqual([
         installedFx,
       ]);
-      expect(await fresh.capturePane()).not.toContain("Update installed: ctrl+g to reload");
+      expect(await fresh.capturePane()).not.toContain("update ready: ctrl+g to reload");
       await fresh.sendText("/quit");
       expect(await fresh.waitForSessionEnd()).toBe(true);
       await fresh.kill();
@@ -4898,7 +4898,7 @@ test.skipIf(!tmuxAvailable())(
       const version = (await runFx(["--version"])).stdout.trim();
       await active.sendHexBytes(["07"]);
 
-      const updatedNotice = `● 𝒇x has been updated to v${version}`;
+      const updatedNotice = `● fx has been updated to v${version}`;
       await active.waitForText(updatedNotice, TIMEOUT);
       const resumed = await waitForScrollback(active, "UPGRADE_CTRL_G_INITIAL_DONE");
       expect(resumed).toContain("UPGRADE_CTRL_G_INITIAL_DONE");
@@ -4984,7 +4984,7 @@ test.skipIf(!tmuxAvailable())(
       await waitForCommittedSessionMarker(home, "UPGRADE_CORRUPT_INITIAL_DONE");
       const sessionId = sessionIdFromHome(home);
       await active.waitForText(
-        "Update installed: ctrl+g to reload",
+        "update ready: ctrl+g to reload",
         UPGRADE_TIMEOUT,
       );
 
@@ -4996,7 +4996,7 @@ test.skipIf(!tmuxAvailable())(
       const version = (await runFx(["--version"])).stdout.trim();
       await active.sendHexBytes(["07"]);
 
-      await active.waitForText(`● 𝒇x has been updated to v${version}`, TIMEOUT);
+      await active.waitForText(`● fx has been updated to v${version}`, TIMEOUT);
       const resumed = await waitForScrollback(
         active,
         "UPGRADE_CORRUPT_INITIAL_DONE",


### PR DESCRIPTION
## Summary

- Shorten the installed-update hint to `update ready: ctrl+g to reload`.
- Use plain `fx` in the post-reload update notice.