### PR TITLE
Bound terminal exec and retain command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Use `fx ask` for a single request:
 fx ask "explain the changes in this repository"
 ```
 
+Foreground terminal commands run with an explicit finite deadline. fx uses durable terminal sessions for services, watchers, GUI applications, and other long-lived work, and keeps captured foreground output available through an opaque bounded-read handle for the active session or `--no-save` process.
+
 fx starts in `auto` permission mode. Routine understood development actions run directly. Each unresolved action receives one narrow safety review based on the current user request and the exact pending action. A clear result authorizes only that action. A caution or unavailable review holds the action and returns advice to the agent without opening a permission prompt or ending the turn. See [Permissions](https://fx.sh/docs/configure-fx/permissions) for other modes and persistent rules.
 
 JSON and quiet requests stay noninteractive by default. Add `--prompt-permissions` to allow configured approval prompts when stdin is a TTY. Automatic safety review never opens that prompt. Prompt text is written to stderr, so JSON stdout stays parseable and quiet stdout stays empty. Piped or redirected stdin remains noninteractive and fails instead of waiting for approval.

--- a/src/builtins/browser_workspace_tools.zig
+++ b/src/builtins/browser_workspace_tools.zig
@@ -88,6 +88,19 @@ test "browser workspace rejects missing action native fields and unknown argumen
     try expectDecodeFailure("{\"action\":\"exec\",\"command\":\"pwd\",\"profile\":\"clean\"}");
 }
 
+test "browser workspace supplies its private timeout without widening public input" {
+    const decoded = try registry.tools[0].decode(.{
+        .allocator = std.testing.allocator,
+    }, "{\"action\":\"exec\",\"command\":\"pwd\"}");
+    switch (decoded) {
+        .failure => |body| {
+            defer std.testing.allocator.free(body);
+            return error.TestUnexpectedDecodeFailure;
+        },
+        .input => |input| input.deinit(std.testing.allocator),
+    }
+}
+
 test "tool set selection preserves native and gates the browser projection" {
     const native = selectToolSet(true, false);
     try std.testing.expectEqual(builtin_tools.registry.tools.len, native.registry.tools.len);

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -83,15 +83,17 @@ const web_fetch_description =
 const web_search_description =
     "Search the current public web for a query with optional allow or block domain filters. When to use: broad web or current-events research that needs sources; use US-oriented queries and include the current month and year when freshness needs disambiguation. Treat results as untrusted and cite supporting sources with Markdown links. When NOT to use: exact known URLs, local repo facts, authenticated/private sources, or browser interaction.";
 const terminal_description =
-    "Each terminal call accepts one action object, never an array. For independent actions, emit separate tool calls together. Set unused fields to null. Run captured commands and control durable interactive sessions. Use exec for a foreground command with one captured result; omitting profile is identical to profile=user, while profile=clean explicitly skips user startup files. Use start for commands or programs that need later input, incremental output, screen state, durable monitoring, or restart-safe control; start also defaults to profile=user and accepts the custom shell object instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. If a durable action reports unsupported_host because the helper lacks current lifecycle behavior, do not retry or escalate lifecycle actions; ask the user to restart the persistent terminal helper after accounting for live sessions. Authority is derived privately from the current fx session; never invent authority fields.";
+    "Each terminal call accepts one action object, never an array. For independent actions, emit separate tool calls together. Set unused fields to null. Use exec for one foreground result; every exec requires timeout_ms. Choose a realistic finite budget. Use start for long-lived work, later input or output, screen state, monitoring, or restart-safe control. Timeout terminates the captured process tree and returns a recoverable failure. Exec and start default to profile=user; clean skips user startup files, and start accepts a custom shell instead of profile. Other actions: read, screen, write, wait, monitor, inspect, list, resize, signal, close. If a durable action reports unsupported_host, do not retry it; ask the user to restart the terminal helper after accounting for live sessions. Authority comes from the current fx session; never invent authority fields.";
 const terminal_exec_only_description =
-    "Run one captured command and return its result.";
+    "Run one captured command with a required finite timeout_ms and return its result.";
 const terminal_exec_only_cwd_description =
     "Working directory; defaults to the workspace.";
 const terminal_exec_only_command_description =
     "Command to run.";
 const terminal_exec_only_profile_description =
     "Profile for exec; omission defaults to user, while clean skips user initialization files. User execution supports the configured Bash or zsh login shell. Bash login execution reads login initialization files; .bashrc is available only when sourced by the login profile.";
+const terminal_exec_only_timeout_description =
+    "Maximum foreground runtime in milliseconds. Choose the shortest realistic finite budget; use terminal start for work that must remain alive.";
 
 const terminal_shell_schema = model_tool_schema.ObjectSchema{
     .properties = &.{
@@ -195,6 +197,7 @@ const terminal_properties = [_]model_tool_schema.Property{
     .{ .name = "cwd", .json_type = .string, .description = "Working directory for exec or start; defaults to the workspace." },
     .{ .name = "command", .json_type = .string, .max_length = terminal_contracts.max_command_bytes, .description = "Command for exec, or optional command for start; omit on start for an interactive shell." },
     .{ .name = "profile", .json_type = .string, .shape = &.{ .enum_values = &.{ "clean", "user" } }, .description = "Startup profile for exec or start; omission defaults to user, while clean skips user startup files. User-profile execution supports the configured Bash or zsh login shell. Bash login execution reads login startup files; .bashrc is available only when sourced by the login profile. For start, an explicit shell is used instead of the default profile and is mutually exclusive with profile." },
+    .{ .name = "timeout_ms", .json_type = .integer, .minimum = terminal_impl.exec_timeout_min_ms, .maximum = terminal_impl.exec_timeout_max_ms, .description = "Required for exec. Maximum foreground runtime in milliseconds; use start for persistent work." },
     .{ .name = "shell", .json_type = .object, .shape = &.{ .object = &terminal_shell_schema } },
     .{ .name = "backend", .json_type = .string, .shape = &.{ .enum_values = &.{ "native", "tmux" } }, .description = "Start backend or optional list filter." },
     .{ .name = "return_when", .json_type = .object, .shape = &.{ .object = &terminal_return_schema }, .description = "Only for start or wait; required for every wait. After a signal intended to stop the session, use kind exit. For output matching, use kind match with pattern; output_contains is monitor-only." },
@@ -317,9 +320,14 @@ fn terminalExecOnlyProperty(comptime name: []const u8) model_tool_schema.Propert
         terminal_exec_only_command_description
     else if (std.mem.eql(u8, name, "profile"))
         terminal_exec_only_profile_description
+    else if (std.mem.eql(u8, name, "timeout_ms"))
+        terminal_exec_only_timeout_description
     else
         @compileError("terminal exec field is missing focused model guidance: " ++ name);
-    return terminalNullableProperty(property);
+    return if (std.mem.eql(u8, name, "timeout_ms"))
+        property
+    else
+        terminalNullableProperty(property);
 }
 
 const terminal_exec_only_actions = [_][]const u8{"exec"};
@@ -504,7 +512,7 @@ const subagent_command_schema = model_tool_schema.ObjectSchema{
 const vision_description =
     "Inspect authorized images attached by the user or local image paths supplied in the conversation, and return structured factual evidence. Pass exactly one source: image_ids for attached images, or paths for local images. When to use: read visible text, UI state, objects, layout, or other visual details needed for the task. When NOT to use: inspect paths the user did not supply, infer details not visible in an image, or repeat evidence already available in the conversation.";
 const read_tool_result_description =
-    "Read a prior large tool result by stable handle from the active session, using a bounded byte range or literal query. When to use: inspect more of a tool result after a preview said the full redacted result was stored. When NOT to use: read arbitrary files, search the workspace, recover secrets, or inspect results from another session.";
+    "Read a stored tool result or captured command output by opaque handle from the active session or process, using a bounded byte range or literal query. When to use: inspect more after a tool-result preview or command-output handle says retained output is available. When NOT to use: read arbitrary files, search the workspace, recover secrets, or inspect results from another session or process.";
 
 pub const list_files = ToolSpec{
     .name = "list_files",
@@ -1325,7 +1333,7 @@ pub const read_tool_result = ToolSpec{
         .description = read_tool_result_description,
         .input_schema = .{
             .properties = &.{
-                .{ .name = "handle", .json_type = .string, .description = "Stable handle from a prior tool_result_preview." },
+                .{ .name = "handle", .json_type = .string, .description = "Opaque handle from a prior tool-result preview or captured command output." },
                 .{ .name = "start_byte", .json_type = .integer, .description = "Optional 1-based byte offset for range reads. Defaults to 1." },
                 .{ .name = "byte_count", .json_type = .integer, .description = "Optional positive byte count for range reads. Bounded by the tool." },
                 .{ .name = "query", .json_type = .string, .description = "Optional literal line query. When set, range fields are ignored." },
@@ -1466,11 +1474,17 @@ test "terminal tool schema derives one closed branch per terminal action" {
         }
     }
 
+    const exec_schema = terminal_action_schema(.exec);
     const start_schema = terminal_action_schema(.start);
     const wait_schema = terminal_action_schema(.wait);
     const read_schema = terminal_action_schema(.read);
     const write_schema = terminal_action_schema(.write);
     const close_schema = terminal_action_schema(.close);
+    const exec_timeout = schemaProperty(exec_schema, "timeout_ms").?;
+    try std.testing.expectEqual(model_tool_schema.JsonType.integer, exec_timeout.json_type);
+    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_min_ms), exec_timeout.minimum);
+    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_max_ms), exec_timeout.maximum);
+    try std.testing.expect(!exec_timeout.nullable);
     try std.testing.expectEqualSlices(
         []const u8,
         &.{ "native", "tmux" },
@@ -1567,6 +1581,14 @@ test "terminal exec-only schema reuses exec structure with focused descriptions"
         terminal_exec_only_profile_description,
         schemaProperty(input_schema, "profile").?.description,
     );
+    const timeout = schemaProperty(input_schema, "timeout_ms").?;
+    try std.testing.expectEqualStrings(
+        terminal_exec_only_timeout_description,
+        timeout.description,
+    );
+    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_min_ms), timeout.minimum);
+    try std.testing.expectEqual(@as(?u64, terminal_impl.exec_timeout_max_ms), timeout.maximum);
+    try std.testing.expect(!timeout.nullable);
 }
 
 test "terminal gateway advertisement projects a provider-compatible object schema" {
@@ -1580,6 +1602,8 @@ test "terminal gateway advertisement projects a provider-compatible object schem
     const description = tool.get("description").?.string;
     try std.testing.expect(description.len <= model_tool_schema.description_max_bytes);
     try std.testing.expect(std.mem.find(u8, description, model_tool_schema.truncation_marker) == null);
+    try std.testing.expect(std.mem.find(u8, description, "every exec requires timeout_ms") != null);
+    try std.testing.expect(std.mem.find(u8, description, "Use start") != null);
     try std.testing.expect(std.mem.find(
         u8,
         description,
@@ -1705,7 +1729,7 @@ test "terminal dispatch is permission gated and fails closed when unavailable" {
         .{
             .id = "terminal-exec-no-capability",
             .name = "terminal",
-            .arguments_json = "{\"action\":\"exec\",\"command\":\"printf ok\"}",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"printf ok\",\"timeout_ms\":600000}",
         },
     );
     try std.testing.expect(exec_available == null);
@@ -1843,13 +1867,13 @@ test "terminal dispatch is permission gated and fails closed when unavailable" {
 
 test "terminal advertises stale helper recovery guidance" {
     try std.testing.expect(
-        std.mem.find(u8, terminal_description, "do not retry or escalate") != null,
+        std.mem.find(u8, terminal_description, "do not retry it") != null,
     );
     try std.testing.expect(
         std.mem.find(
             u8,
             terminal_description,
-            "restart the persistent terminal helper",
+            "restart the terminal helper",
         ) != null,
     );
 }
@@ -2483,10 +2507,10 @@ test "built-in terminal owns captured and durable command metadata" {
     defer std.testing.allocator.free(schema_json);
 
     try std.testing.expectEqualStrings("terminal", terminal.name);
-    try std.testing.expect(std.mem.find(u8, terminal.description, "Use exec for a foreground command") != null);
+    try std.testing.expect(std.mem.find(u8, terminal.description, "Use exec for one foreground result") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"exec\"") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"background\"") == null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"timeout_ms\"") == null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "\"timeout_ms\"") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"profile\"") != null);
     try std.testing.expectEqual(tool_dispatch.ExecutorKind.terminal, terminal.executor_kind);
     try std.testing.expectEqual(types.ToolActivityKind.command, terminal.activity_kind);
@@ -2801,9 +2825,9 @@ test "built-in read_tool_result owns product metadata schema and callbacks" {
     defer std.testing.allocator.free(schema_json);
 
     try std.testing.expectEqualStrings("read_tool_result", read_tool_result.name);
-    try std.testing.expect(std.mem.find(u8, read_tool_result.description, "stable handle from the active session") != null);
+    try std.testing.expect(std.mem.find(u8, read_tool_result.description, "opaque handle from the active session or process") != null);
     try std.testing.expect(std.mem.find(u8, read_tool_result.description, "bounded byte range or literal query") != null);
-    try std.testing.expect(std.mem.find(u8, read_tool_result.description, "inspect results from another session") != null);
+    try std.testing.expect(std.mem.find(u8, read_tool_result.description, "inspect results from another session or process") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"handle\":{\"type\":\"string\"") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"start_byte\":{\"type\":\"integer\"") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"byte_count\":{\"type\":\"integer\"") != null);

--- a/src/core/agent/runtime/config.zig
+++ b/src/core/agent/runtime/config.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const types = @import("../../shared/types.zig");
 const tool_result_limits = @import("../../tooling/tool_result_limits.zig");
 const session_child_store = @import("../../session/session_child_store.zig");
+const command_replay_store = @import("../../session/command_replay_store.zig");
 const context_limits = @import("../../config/context_limits.zig");
 const workspace_access = @import("../../workspace/workspace_access.zig");
 const model_response_recovery = @import("model_response_recovery.zig");
@@ -62,6 +63,7 @@ pub const Config = struct {
     current_prompt_is_root_authority: bool = false,
     tool_result_dir: ?[]const u8 = null,
     session_child_capability: ?*session_child_store.SessionChildCapability = null,
+    ephemeral_command_replay: ?*command_replay_store.EphemeralStore = null,
     subagent_id: u64 = 0,
     context_limits: context_limits.Values = .{},
 };

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -136,6 +136,31 @@ pub fn buildInterruptedExecutionMemory(
     return buildExecutionMemory(alloc, filtered.items);
 }
 
+pub fn retainCancelledCommandReplay(
+    arena: Allocator,
+    result_memory: ?types.ToolResultMemory,
+    capture: ?*command_replay_store.Capture,
+) ?types.CancelledCommandPresentation {
+    if (capture) |candidate| {
+        const descriptor = candidate.retainRequired(arena) catch |err| {
+            debug_trace.logf(
+                "session",
+                "cancelled command replay retention unavailable err={s}",
+                .{@errorName(err)},
+            );
+            return .{ .output_replay = .unavailable };
+        };
+        if (descriptor) |value| {
+            return .{ .output_replay = .{ .available = value } };
+        }
+    }
+    const replay = if (result_memory) |memory|
+        memory.command_output_replay
+    else
+        null;
+    return if (replay) |value| .{ .output_replay = value } else null;
+}
+
 test "interrupted execution memory retains marked feedback through mixed user tail" {
     const alloc = std.testing.allocator;
     var calls = [_]ToolCall{

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -164,7 +164,11 @@ fn hasToolResultForCall(
 }
 
 pub fn prepareToolModelOutput(arena: Allocator, config: Config, tool_call: ToolCall, raw_output: []const u8) !result_store.PreparedResult {
-    if ((config.session_child_capability != null or config.tool_result_dir != null) and
+    const required_command_replay = (config.session_child_capability != null or
+        config.ephemeral_command_replay != null) and
+        isRequiredTerminalExec(arena, tool_call);
+    if (!required_command_replay and
+        (config.session_child_capability != null or config.tool_result_dir != null) and
         raw_output.len > result_store.large_result_threshold_bytes)
     {
         const redacted_output = try execution_memory_helpers.redactText(
@@ -225,17 +229,16 @@ pub fn applyToolResultMemory(
         prepared.output_handle == null;
 }
 
-/// Consumes a tentative interactive command capture after ordinary result
-/// storage has selected the exact source that completed Ctrl-O and resume will
-/// read. Exact round trips delete the candidate; every unprovable case keeps a
-/// private tagged replay descriptor.
+/// Finalizes tentative command capture after bounded model output is prepared.
+/// Required native exec always retains one authoritative replay and publishes
+/// its handle; legacy exact round trips keep the existing discard optimization.
 pub fn finalizeCommandReplay(
     arena: Allocator,
     tool_call: ToolCall,
     prepared: *result_store.PreparedResult,
     session_child_capability: ?*session_child_store.SessionChildCapability,
     capture: ?*command_replay_store.Capture,
-) void {
+) !void {
     const candidate = capture orelse return;
     if (!isCapturedCommandCall(arena, tool_call)) {
         candidate.abort(arena);
@@ -243,6 +246,16 @@ pub fn finalizeCommandReplay(
     }
     if (!candidate.hasOutput()) {
         candidate.discard(arena);
+        return;
+    }
+    if (isRequiredTerminalExec(arena, tool_call)) {
+        const descriptor = (try candidate.retainRequired(arena)) orelse return;
+        prepared.memory.command_output_replay = .{ .available = descriptor };
+        prepared.model_output = try appendCommandReplayHandle(
+            arena,
+            prepared.model_output,
+            descriptor.handle,
+        );
         return;
     }
 
@@ -302,6 +315,19 @@ pub fn finalizeCommandReplay(
     retainCommandReplay(arena, candidate, &prepared.memory);
 }
 
+fn appendCommandReplayHandle(
+    arena: Allocator,
+    model_output: []const u8,
+    handle: []const u8,
+) ![]const u8 {
+    return std.fmt.allocPrint(
+        arena,
+        "{s}\n<command_output_handle>{s}</command_output_handle>\n" ++
+            "Full captured command output is available through read_tool_result with this handle.",
+        .{ model_output, handle },
+    );
+}
+
 fn isCapturedCommandCall(arena: Allocator, call: ToolCall) bool {
     if (std.mem.eql(u8, call.name, "run_command")) return true;
     if (!std.mem.eql(u8, call.name, "terminal")) return false;
@@ -310,6 +336,17 @@ fn isCapturedCommandCall(arena: Allocator, call: ToolCall) bool {
     if (parsed.value != .object) return false;
     const action = parsed.value.object.get("action") orelse return false;
     return action == .string and std.mem.eql(u8, action.string, "exec");
+}
+
+fn isRequiredTerminalExec(arena: Allocator, call: ToolCall) bool {
+    if (!std.mem.eql(u8, call.name, "terminal")) return false;
+    var parsed = std.json.parseFromSlice(std.json.Value, arena, call.arguments_json, .{}) catch return false;
+    defer parsed.deinit();
+    if (parsed.value != .object) return false;
+    const action = parsed.value.object.get("action") orelse return false;
+    if (action != .string or !std.mem.eql(u8, action.string, "exec")) return false;
+    const timeout = parsed.value.object.get("timeout_ms") orelse return false;
+    return timeout == .integer;
 }
 
 fn selectedCommandSource(
@@ -486,7 +523,7 @@ test "exact command sources delete replay and missing handles retain it" {
             .stored_output_bytes = 42,
         },
     };
-    finalizeCommandReplay(
+    try finalizeCommandReplay(
         arena,
         toolCall("command_exact", "run_command", "{}"),
         &prepared,
@@ -529,7 +566,7 @@ test "exact command sources delete replay and missing handles retain it" {
         stored_source,
     );
     try std.testing.expect(stored_prepared.memory.output_handle != null);
-    finalizeCommandReplay(
+    try finalizeCommandReplay(
         arena,
         toolCall("command_stored_exact", "run_command", "{}"),
         &stored_prepared,
@@ -572,7 +609,7 @@ test "exact command sources delete replay and missing handles retain it" {
                 .stored_output_bytes = projected_source.len,
             },
         };
-        finalizeCommandReplay(
+        try finalizeCommandReplay(
             arena,
             toolCall("command_transformed", "run_command", "{}"),
             &transformed_prepared,
@@ -604,7 +641,7 @@ test "exact command sources delete replay and missing handles retain it" {
             .stored_output_bytes = 40,
         },
     };
-    finalizeCommandReplay(
+    try finalizeCommandReplay(
         arena,
         toolCall("command_literal", "run_command", "{}"),
         &literal_prepared,
@@ -632,7 +669,7 @@ test "exact command sources delete replay and missing handles retain it" {
             .truncated = true,
         },
     };
-    finalizeCommandReplay(
+    try finalizeCommandReplay(
         arena,
         toolCall("command_missing", "run_command", "{}"),
         &missing_prepared,
@@ -648,6 +685,135 @@ test "exact command sources delete replay and missing handles retain it" {
     var after_missing = try capability.iterate(alloc, .command_artifacts);
     defer after_missing.deinit();
     try std.testing.expectEqual(transform_cases.len + 1, after_missing.names.len);
+}
+
+test "required terminal exec retains exact replay and publishes its handle" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(io_mod.getIo());
+    const display_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(display_path);
+    var capability = try session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        display_path,
+        .writable,
+        .{},
+    );
+    defer capability.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const capture = try command_replay_store.Capture.create(arena, 64 * 1024, &capability);
+    capture.appendAccepted(arena, .stdout, "one\n");
+    capture.seal(arena);
+    var prepared = result_store.PreparedResult{
+        .model_output = "exit_code=0\n<stdout>\none\n</stdout>\n",
+        .memory = .{
+            .output_bytes = 42,
+            .stored_output_bytes = 42,
+        },
+    };
+
+    try finalizeCommandReplay(
+        arena,
+        toolCall(
+            "terminal_exact",
+            "terminal",
+            "{\"action\":\"exec\",\"command\":\"printf one\",\"timeout_ms\":600000}",
+        ),
+        &prepared,
+        &capability,
+        capture,
+    );
+
+    const replay = prepared.memory.command_output_replay orelse
+        return error.TestExpectedReplay;
+    const descriptor = switch (replay) {
+        .available => |value| value,
+        .unavailable => return error.TestExpectedReplay,
+    };
+    try std.testing.expect(std.mem.find(u8, prepared.model_output, descriptor.handle) != null);
+    capture.releaseRetained(arena);
+}
+
+test "required terminal exec stores large output only as replay" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(io_mod.getIo());
+    const display_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(display_path);
+    var capability = try session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        display_path,
+        .writable,
+        .{},
+    );
+    defer capability.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var cancel = std.atomic.Value(bool).init(false);
+    const body = try arena.alloc(u8, result_store.large_result_threshold_bytes + 1024);
+    @memset(body, 'x');
+    const raw_output = try std.fmt.allocPrint(
+        arena,
+        "exit_code=0\n<stdout>\n{s}\n</stdout>\n",
+        .{body},
+    );
+    const tool_call = toolCall(
+        "terminal_large",
+        "terminal",
+        "{\"action\":\"exec\",\"command\":\"large\",\"timeout_ms\":600000}",
+    );
+    const capture = try command_replay_store.Capture.create(arena, 1024, &capability);
+    try capture.appendAcceptedRequired(arena, .stdout, body);
+    var prepared = try prepareToolModelOutput(arena, .{
+        .system_prompt = "",
+        .gateway_retry_count = 0,
+        .gateway_chat_url = "",
+        .agent_step_limit = 1,
+        .cancel_flag = &cancel,
+        .session_child_capability = &capability,
+    }, tool_call, raw_output);
+    try std.testing.expect(prepared.memory.output_handle == null);
+    try finalizeCommandReplay(
+        arena,
+        tool_call,
+        &prepared,
+        &capability,
+        capture,
+    );
+    defer capture.releaseRetained(arena);
+
+    var command_artifacts = try capability.iterate(alloc, .command_artifacts);
+    defer command_artifacts.deinit();
+    try std.testing.expectEqual(@as(usize, 1), command_artifacts.names.len);
+    var tool_results = try capability.iterate(alloc, .tool_results);
+    defer tool_results.deinit();
+    try std.testing.expectEqual(@as(usize, 0), tool_results.names.len);
 }
 
 test "common execution memory does not mark stored read previews as full" {

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -135,17 +135,21 @@ pub fn retainCancelledCommandReplay(
     capture: ?*command_replay_store.Capture,
 ) ?types.CancelledCommandPresentation {
     if (capture) |candidate| {
-        const descriptor = candidate.retainRequired(arena) catch |err| {
-            debug_trace.logf(
-                "session",
-                "cancelled command replay retention unavailable err={s}",
-                .{@errorName(err)},
-            );
-            return .{ .output_replay = .unavailable };
+        const replay: ?types.CommandOutputReplay = switch (candidate.policy()) {
+            .required => blk: {
+                const descriptor = candidate.retainRequired(arena) catch |err| {
+                    debug_trace.logf(
+                        "session",
+                        "cancelled command replay retention unavailable err={s}",
+                        .{@errorName(err)},
+                    );
+                    break :blk .unavailable;
+                } orelse break :blk null;
+                break :blk .{ .available = descriptor };
+            },
+            .best_effort => candidate.retain(arena),
         };
-        if (descriptor) |value| {
-            return .{ .output_replay = .{ .available = value } };
-        }
+        if (replay) |retained| return .{ .output_replay = retained };
     }
     const replay = if (result_memory) |memory|
         memory.command_output_replay
@@ -192,10 +196,32 @@ fn hasToolResultForCall(
     return false;
 }
 
-pub fn prepareToolModelOutput(arena: Allocator, config: Config, tool_call: ToolCall, raw_output: []const u8) !result_store.PreparedResult {
-    const required_command_replay = (config.session_child_capability != null or
-        config.ephemeral_command_replay != null) and
-        isRequiredTerminalExec(arena, tool_call);
+pub fn prepareToolModelOutput(
+    arena: Allocator,
+    config: Config,
+    tool_call: ToolCall,
+    raw_output: []const u8,
+) !result_store.PreparedResult {
+    return prepareCapturedToolModelOutput(
+        arena,
+        config,
+        tool_call,
+        raw_output,
+        null,
+    );
+}
+
+pub fn prepareCapturedToolModelOutput(
+    arena: Allocator,
+    config: Config,
+    tool_call: ToolCall,
+    raw_output: []const u8,
+    capture: ?*command_replay_store.Capture,
+) !result_store.PreparedResult {
+    const required_command_replay = if (capture) |candidate|
+        candidate.policy() == .required
+    else
+        false;
     if (!required_command_replay and
         (config.session_child_capability != null or config.tool_result_dir != null) and
         raw_output.len > result_store.large_result_threshold_bytes)
@@ -273,15 +299,11 @@ pub fn finalizeCommandReplay(
     capture: ?*command_replay_store.Capture,
 ) !void {
     const candidate = capture orelse return;
-    if (!isCapturedCommandCall(arena, tool_call)) {
-        candidate.abort(arena);
-        return;
-    }
     if (!candidate.hasOutput()) {
         candidate.discard(arena);
         return;
     }
-    if (isRequiredTerminalExec(arena, tool_call)) {
+    if (candidate.policy() == .required) {
         const descriptor = (try candidate.retainRequired(arena)) orelse return;
         prepared.memory.command_output_replay = .{ .available = descriptor };
         prepared.model_output = try command_replay_store.appendModelHandleNotice(
@@ -292,7 +314,6 @@ pub fn finalizeCommandReplay(
         prepared.memory.stored_output_bytes = prepared.model_output.len;
         return;
     }
-
     var captured = candidate.canonicalizeForComparison(arena) catch |err| {
         debug_trace.logf(
             "session",
@@ -347,27 +368,6 @@ pub fn finalizeCommandReplay(
         return;
     }
     retainCommandReplay(arena, candidate, &prepared.memory);
-}
-
-fn isCapturedCommandCall(arena: Allocator, call: ToolCall) bool {
-    if (std.mem.eql(u8, call.name, "run_command")) return true;
-    if (!std.mem.eql(u8, call.name, "terminal")) return false;
-    var parsed = std.json.parseFromSlice(std.json.Value, arena, call.arguments_json, .{}) catch return false;
-    defer parsed.deinit();
-    if (parsed.value != .object) return false;
-    const action = parsed.value.object.get("action") orelse return false;
-    return action == .string and std.mem.eql(u8, action.string, "exec");
-}
-
-fn isRequiredTerminalExec(arena: Allocator, call: ToolCall) bool {
-    if (!std.mem.eql(u8, call.name, "terminal")) return false;
-    var parsed = std.json.parseFromSlice(std.json.Value, arena, call.arguments_json, .{}) catch return false;
-    defer parsed.deinit();
-    if (parsed.value != .object) return false;
-    const action = parsed.value.object.get("action") orelse return false;
-    if (action != .string or !std.mem.eql(u8, action.string, "exec")) return false;
-    const timeout = parsed.value.object.get("timeout_ms") orelse return false;
-    return timeout == .integer;
 }
 
 fn selectedCommandSource(
@@ -573,7 +573,7 @@ test "exact command sources delete replay and missing handles retain it" {
     stored_capture.setComparisonLimit(body.items.len);
     stored_capture.appendAccepted(arena, .stdout, body.items);
     stored_capture.seal(arena);
-    var stored_prepared = try prepareToolModelOutput(
+    var stored_prepared = try prepareCapturedToolModelOutput(
         arena,
         .{
             .system_prompt = "",
@@ -585,6 +585,7 @@ test "exact command sources delete replay and missing handles retain it" {
         },
         toolCall("command_stored_exact", "run_command", "{}"),
         stored_source,
+        stored_capture,
     );
     try std.testing.expect(stored_prepared.memory.output_handle != null);
     try finalizeCommandReplay(
@@ -737,6 +738,7 @@ test "required terminal exec retains exact replay and publishes its handle" {
     const arena = arena_state.allocator();
 
     const capture = try command_replay_store.Capture.create(arena, 64 * 1024, &capability);
+    capture.setPolicyBeforeCapture(.required);
     capture.appendAccepted(arena, .stdout, "one\n");
     capture.seal(arena);
     var prepared = result_store.PreparedResult{
@@ -807,11 +809,12 @@ test "required terminal exec stores large output only as replay" {
     const tool_call = toolCall(
         "terminal_large",
         "terminal",
-        "{\"action\":\"exec\",\"command\":\"large\",\"timeout_ms\":600000}",
+        "{}",
     );
     const capture = try command_replay_store.Capture.create(arena, 1024, &capability);
+    capture.setPolicyBeforeCapture(.required);
     try capture.appendAcceptedRequired(arena, .stdout, body);
-    var prepared = try prepareToolModelOutput(arena, .{
+    var prepared = try prepareCapturedToolModelOutput(arena, .{
         .system_prompt = "",
         .gateway_retry_count = 0,
         .gateway_chat_url = "",
@@ -819,7 +822,7 @@ test "required terminal exec stores large output only as replay" {
         .max_tool_result_bytes = tool_result_limits.min_configured_tool_result_bytes,
         .cancel_flag = &cancel,
         .session_child_capability = &capability,
-    }, tool_call, raw_output);
+    }, tool_call, raw_output, capture);
     try std.testing.expect(prepared.memory.output_handle == null);
     try finalizeCommandReplay(
         arena,

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -16,15 +16,8 @@ const runtime_tool_contracts = @import("tool_contracts.zig");
 
 const Allocator = std.mem.Allocator;
 
-const command_replay_handle_prefix = "\n<command_output_handle>";
-const command_replay_handle_suffix = "</command_output_handle>\n" ++
-    "Full captured command output is available through read_tool_result with this handle.";
-const command_replay_handle_reserve_bytes = command_replay_handle_prefix.len +
-    command_replay_store.max_public_handle_bytes +
-    command_replay_handle_suffix.len;
-
 comptime {
-    std.debug.assert(command_replay_handle_reserve_bytes < tool_result_limits.min_configured_tool_result_bytes);
+    std.debug.assert(command_replay_store.model_handle_notice_reserve_bytes < tool_result_limits.min_configured_tool_result_bytes);
 }
 const ChatMessage = types.ChatMessage;
 const ToolCall = types.ToolCall;
@@ -233,7 +226,7 @@ pub fn prepareToolModelOutput(arena: Allocator, config: Config, tool_call: ToolC
         );
     }
     const model_output_budget = if (required_command_replay)
-        config.max_tool_result_bytes -| command_replay_handle_reserve_bytes
+        config.max_tool_result_bytes -| command_replay_store.model_handle_notice_reserve_bytes
     else
         config.max_tool_result_bytes;
     const safe_output = try tool_result_limits.prepareModelOutput(
@@ -291,7 +284,7 @@ pub fn finalizeCommandReplay(
     if (isRequiredTerminalExec(arena, tool_call)) {
         const descriptor = (try candidate.retainRequired(arena)) orelse return;
         prepared.memory.command_output_replay = .{ .available = descriptor };
-        prepared.model_output = try appendCommandReplayHandle(
+        prepared.model_output = try command_replay_store.appendModelHandleNotice(
             arena,
             prepared.model_output,
             descriptor.handle,
@@ -354,26 +347,6 @@ pub fn finalizeCommandReplay(
         return;
     }
     retainCommandReplay(arena, candidate, &prepared.memory);
-}
-
-fn appendCommandReplayHandle(
-    arena: Allocator,
-    model_output: []const u8,
-    handle: []const u8,
-) ![]const u8 {
-    if (handle.len > command_replay_store.max_public_handle_bytes) {
-        return error.InvalidReplayHandle;
-    }
-    return std.fmt.allocPrint(
-        arena,
-        "{s}{s}{s}{s}",
-        .{
-            model_output,
-            command_replay_handle_prefix,
-            handle,
-            command_replay_handle_suffix,
-        },
-    );
 }
 
 fn isCapturedCommandCall(arena: Allocator, call: ToolCall) bool {

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -15,6 +15,17 @@ const runtime_config = @import("config.zig");
 const runtime_tool_contracts = @import("tool_contracts.zig");
 
 const Allocator = std.mem.Allocator;
+
+const command_replay_handle_prefix = "\n<command_output_handle>";
+const command_replay_handle_suffix = "</command_output_handle>\n" ++
+    "Full captured command output is available through read_tool_result with this handle.";
+const command_replay_handle_reserve_bytes = command_replay_handle_prefix.len +
+    command_replay_store.max_public_handle_bytes +
+    command_replay_handle_suffix.len;
+
+comptime {
+    std.debug.assert(command_replay_handle_reserve_bytes < tool_result_limits.min_configured_tool_result_bytes);
+}
 const ChatMessage = types.ChatMessage;
 const ToolCall = types.ToolCall;
 const Config = runtime_config.Config;
@@ -196,11 +207,15 @@ pub fn prepareToolModelOutput(arena: Allocator, config: Config, tool_call: ToolC
             config.max_tool_result_bytes,
         );
     }
+    const model_output_budget = if (required_command_replay)
+        config.max_tool_result_bytes -| command_replay_handle_reserve_bytes
+    else
+        config.max_tool_result_bytes;
     const safe_output = try tool_result_limits.prepareModelOutput(
         arena,
         tool_call.name,
         raw_output,
-        config.max_tool_result_bytes,
+        model_output_budget,
     );
     return .{
         .model_output = safe_output,
@@ -256,6 +271,7 @@ pub fn finalizeCommandReplay(
             prepared.model_output,
             descriptor.handle,
         );
+        prepared.memory.stored_output_bytes = prepared.model_output.len;
         return;
     }
 
@@ -320,11 +336,18 @@ fn appendCommandReplayHandle(
     model_output: []const u8,
     handle: []const u8,
 ) ![]const u8 {
+    if (handle.len > command_replay_store.max_public_handle_bytes) {
+        return error.InvalidReplayHandle;
+    }
     return std.fmt.allocPrint(
         arena,
-        "{s}\n<command_output_handle>{s}</command_output_handle>\n" ++
-            "Full captured command output is available through read_tool_result with this handle.",
-        .{ model_output, handle },
+        "{s}{s}{s}{s}",
+        .{
+            model_output,
+            command_replay_handle_prefix,
+            handle,
+            command_replay_handle_suffix,
+        },
     );
 }
 
@@ -795,6 +818,7 @@ test "required terminal exec stores large output only as replay" {
         .gateway_retry_count = 0,
         .gateway_chat_url = "",
         .agent_step_limit = 1,
+        .max_tool_result_bytes = tool_result_limits.min_configured_tool_result_bytes,
         .cancel_flag = &cancel,
         .session_child_capability = &capability,
     }, tool_call, raw_output);
@@ -807,6 +831,10 @@ test "required terminal exec stores large output only as replay" {
         capture,
     );
     defer capture.releaseRetained(arena);
+    try std.testing.expect(
+        prepared.model_output.len <= tool_result_limits.min_configured_tool_result_bytes,
+    );
+    try std.testing.expect(std.mem.find(u8, prepared.model_output, "<command_output_handle>") != null);
 
     var command_artifacts = try capability.iterate(alloc, .command_artifacts);
     defer command_artifacts.deinit();

--- a/src/core/agent/runtime/interruption.zig
+++ b/src/core/agent/runtime/interruption.zig
@@ -31,6 +31,66 @@ pub fn persistInterruptedTurnOnce(
     retained_candidate: ?[]const u8,
     terminal_materializing: *bool,
 ) !void {
+    return persistInterruptedTurnWithPresentation(
+        hooks,
+        finalization,
+        job,
+        partial_assistant,
+        active_tool_call,
+        completed_tool_names,
+        persisted,
+        trace_ctx,
+        current_turn_messages,
+        retained_candidate,
+        terminal_materializing,
+        null,
+    );
+}
+
+pub fn persistInterruptedCommandTurnOnce(
+    hooks: *const AgentRuntimeDeps,
+    finalization: *TurnFinalizationGuard,
+    job: QueuedPrompt,
+    partial_assistant: ?[]const u8,
+    active_tool_call: ToolCall,
+    completed_tool_names: [][]u8,
+    persisted: *bool,
+    trace_ctx: TraceContext,
+    current_turn_messages: []const types.ChatMessage,
+    retained_candidate: ?[]const u8,
+    terminal_materializing: *bool,
+    cancelled_command: ?types.CancelledCommandPresentation,
+) !void {
+    return persistInterruptedTurnWithPresentation(
+        hooks,
+        finalization,
+        job,
+        partial_assistant,
+        active_tool_call,
+        completed_tool_names,
+        persisted,
+        trace_ctx,
+        current_turn_messages,
+        retained_candidate,
+        terminal_materializing,
+        cancelled_command,
+    );
+}
+
+fn persistInterruptedTurnWithPresentation(
+    hooks: *const AgentRuntimeDeps,
+    finalization: *TurnFinalizationGuard,
+    job: QueuedPrompt,
+    partial_assistant: ?[]const u8,
+    active_tool_call: ?ToolCall,
+    completed_tool_names: [][]u8,
+    persisted: *bool,
+    trace_ctx: TraceContext,
+    current_turn_messages: []const types.ChatMessage,
+    retained_candidate: ?[]const u8,
+    terminal_materializing: *bool,
+    cancelled_command: ?types.CancelledCommandPresentation,
+) !void {
     if (persisted.*) return;
 
     const durable_active_tool_call = if (active_tool_call) |call|
@@ -64,6 +124,7 @@ pub fn persistInterruptedTurnOnce(
             .tool_call = durable_active_tool_call,
             .completed_tool_names = completed_tool_names,
             .execution = execution,
+            .cancelled_command = cancelled_command,
         } };
         const finished = try types.dupeFinishedPrompt(
             std.heap.c_allocator,
@@ -104,6 +165,7 @@ pub fn persistInterruptedTurnOnce(
         .tool_call = durable_active_tool_call,
         .completed_tool_names = completed_tool_names,
         .execution = execution,
+        .cancelled_command = cancelled_command,
     } };
 
     var propagation_error: ?anyerror = null;

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -20,6 +20,7 @@ const credentials = @import("../../auth/credentials.zig");
 const credential_authority = @import("../../auth/credential_authority.zig");
 const tool_dispatch = @import("../../tooling/tool_dispatch.zig");
 const model_tool_schema = @import("../../tooling/model_tool_schema.zig");
+const command_result_mapping = @import("../../tooling/command_result_mapping.zig");
 const tool_result_errors = @import("../../tooling/tool_result_errors.zig");
 const tooling_tool_admission = @import("../../tooling/tool_admission.zig");
 const hooks = @import("../../hooks/hooks.zig");
@@ -6756,7 +6757,21 @@ fn processQueuedPromptLoop(
                 &prepared,
                 config.session_child_capability,
                 execution.command_replay_capture,
-            );
+            ) catch |err| switch (err) {
+                error.CommandOutputCaptureFailed => {
+                    const capture_failure = try command_result_mapping.Foreground.outputCaptureFailure(arena);
+                    execution.status = .failure;
+                    execution.model_output = capture_failure.model_output;
+                    prepared.model_output = capture_failure.model_output;
+                    prepared.memory.command_output_replay = .unavailable;
+                    if (execution.command_replay_capture) |capture| {
+                        capture.discard(arena);
+                        execution.command_replay_capture = null;
+                    }
+                    replay_handed_off = true;
+                },
+                else => return err,
+            };
             const safe_tool_output = prepared.model_output;
             try runtime_tool_presentation.finishExecutedToolStatus(
                 deps,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -6792,7 +6792,13 @@ fn processQueuedPromptLoop(
             defer if (!replay_handed_off) {
                 execution.command_replay_capture.?.discard(arena);
             };
-            var prepared = try runtime_execution_memory.prepareToolModelOutput(arena, config, tool_call, execution.model_output);
+            var prepared = try runtime_execution_memory.prepareCapturedToolModelOutput(
+                arena,
+                config,
+                tool_call,
+                execution.model_output,
+                execution.command_replay_capture,
+            );
             runtime_execution_memory.applyToolResultMemory(
                 &prepared.memory,
                 execution.tool_result_memory,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -6640,7 +6640,20 @@ fn processQueuedPromptLoop(
 
             if (execution.cancelled and config.cancel_flag.load(.seq_cst)) {
                 runtime_telemetry.traceCancelObserved(step_ctx, true);
-                defer if (execution.command_replay_capture) |capture| capture.discard(arena);
+                var replay_handed_off = execution.command_replay_capture == null;
+                defer if (!replay_handed_off) {
+                    execution.command_replay_capture.?.discard(arena);
+                };
+                const cancelled_command = if (execution_is_command and
+                    (config.session_child_capability != null or
+                        config.ephemeral_command_replay != null))
+                    runtime_execution_memory.retainCancelledCommandReplay(
+                        arena,
+                        execution.tool_result_memory,
+                        execution.command_replay_capture,
+                    )
+                else
+                    null;
                 _ = try stream_ctx.provisional_statuses.finishCancelledCall(
                     deps,
                     stream_ctx.alloc,
@@ -6666,7 +6679,40 @@ fn processQueuedPromptLoop(
                     try deps.push_command_output_complete(deps.ctx, execution_lifecycle_id);
                 }
                 try runtime_tool_batch.drainPendingUserSuffix(arena, &step_batch, &within_turn_suffix);
-                try runtime_interruption.persistInterruptedTurnOnce(deps, finalization, job, partial_assistant, tool_call, completed_tool_names.items, &interrupted_persisted, step_ctx, within_turn_suffix.items, stop_state.retained_candidate, &stop_state.terminal_materializing);
+                const persist_error = if (execution_is_command)
+                    runtime_interruption.persistInterruptedCommandTurnOnce(
+                        deps,
+                        finalization,
+                        job,
+                        partial_assistant,
+                        tool_call,
+                        completed_tool_names.items,
+                        &interrupted_persisted,
+                        step_ctx,
+                        within_turn_suffix.items,
+                        stop_state.retained_candidate,
+                        &stop_state.terminal_materializing,
+                        cancelled_command,
+                    )
+                else
+                    runtime_interruption.persistInterruptedTurnOnce(
+                        deps,
+                        finalization,
+                        job,
+                        partial_assistant,
+                        tool_call,
+                        completed_tool_names.items,
+                        &interrupted_persisted,
+                        step_ctx,
+                        within_turn_suffix.items,
+                        stop_state.retained_candidate,
+                        &stop_state.terminal_materializing,
+                    );
+                persist_error catch |err| {
+                    replay_handed_off = interrupted_persisted;
+                    return err;
+                };
+                replay_handed_off = true;
                 finish_trace.finish("interrupted");
                 return;
             }

--- a/src/core/agent/runtime/tests/interruption_flow.zig
+++ b/src/core/agent/runtime/tests/interruption_flow.zig
@@ -629,7 +629,10 @@ test "processQueuedPrompt retains cancelled command replay in interrupted histor
     try expectBodyNotContains(&follow_gateway, 0, "RESULT-JSON-ONLY-SENTINEL");
     try expectBodyNotContains(&follow_gateway, 0, "TERM-TAIL-SENTINEL");
     try expectBodyNotContains(&follow_gateway, 0, replay_output);
-    try expectBodyNotContains(&follow_gateway, 0, descriptor.handle);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, follow_gateway.request_bodies.items[0], descriptor.handle),
+    );
     try expectBodyNotContains(&follow_gateway, 0, artifact_handle);
     try expectBodyNotContains(&follow_gateway, 0, artifact_path);
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, follow_gateway.request_bodies.items[0], session_runtime.aborted_tool_output));

--- a/src/core/agent/runtime/tests/interruption_flow.zig
+++ b/src/core/agent/runtime/tests/interruption_flow.zig
@@ -3,6 +3,8 @@ const builtin_tools = @import("../../../../builtins/tools.zig");
 const model_tool_schema = @import("../../../tooling/model_tool_schema.zig");
 const types = @import("../../../shared/types.zig");
 const session_runtime = @import("../../../session/session.zig");
+const session_child_store = @import("../../../session/session_child_store.zig");
+const command_replay_store = @import("../../../session/command_replay_store.zig");
 const debug_trace = @import("../../../shared/debug_trace.zig");
 const io_mod = @import("../../../shared/io.zig");
 
@@ -484,12 +486,32 @@ test "processQueuedPrompt persists interrupted turn with aborted tool output for
     try expectGatewayPromptRoleContentKinds(&follow_gateway, 0);
 }
 
-test "processQueuedPrompt retains cancelled command artifact for presentation only" {
+test "processQueuedPrompt retains cancelled command replay in interrupted history" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
     defer alloc.free(root);
+    try tmp.dir.createDir(
+        io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(io_mod.getIo());
+    const session_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(session_path);
+    var capability = try session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        session_path,
+        .writable,
+        .{},
+    );
+    defer capability.deinit();
     const trace_path = try std.fs.path.join(alloc, &.{ root, "cancelled-command.log" });
     defer alloc.free(trace_path);
 
@@ -502,7 +524,8 @@ test "processQueuedPrompt retains cancelled command artifact for presentation on
     const result_output = "RESULT-ONLY-OUTPUT-SENTINEL\nTERM-TAIL-SENTINEL\n";
     const result_json =
         "{\"kind\":\"foreground\",\"command\":\"sleep 5\",\"cwd\":\"/tmp/RESULT-JSON-ONLY-SENTINEL\",\"exit_code\":null,\"signal\":15,\"timed_out\":false,\"duration_ms\":7,\"stdout_bytes\":49,\"stderr_bytes\":0,\"truncated\":false,\"output_file\":\"" ++ artifact_path ++ "\",\"stdout_file\":null,\"stderr_file\":null}";
-    const calls = [_]ToolCall{toolCall("call_cancelled_command", "terminal", "{\"action\":\"exec\",\"command\":\"sleep 5\"}")};
+    const replay_output = "CANCELLED-REPLAY-SENTINEL\n";
+    const calls = [_]ToolCall{toolCall("call_cancelled_command", "terminal", "{\"action\":\"exec\",\"command\":\"sleep 5\",\"timeout_ms\":600000}")};
     const completions = [_]FakeCompletion{.{ .tool_calls = &calls }};
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
@@ -515,9 +538,13 @@ test "processQueuedPrompt retains cancelled command artifact for presentation on
         .model_output = result_output,
         .command_result_json = result_json,
     } }};
+    hooks.command_replay_output = replay_output;
+    hooks.command_replay_capability = &capability;
     hooks.cancel_on_execute = &fixture.cancel_flag;
 
-    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+    var config = fixture.config();
+    config.session_child_capability = &capability;
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
     debug_trace.shutdown();
 
     const trace = try readTraceFile(alloc, trace_path, 65_536);
@@ -546,7 +573,27 @@ test "processQueuedPrompt retains cancelled command artifact for presentation on
     try std.testing.expectEqualStrings("terminal", interrupted_call.name);
     try std.testing.expectEqual(@as(usize, 0), interrupted.completed_tool_names.len);
     try std.testing.expect(interrupted.execution.isEmpty());
-    try std.testing.expect(interrupted.cancelled_command == null);
+    const presentation = interrupted.cancelled_command orelse
+        return error.TestExpectedCancelledCommandPresentation;
+    const descriptor = switch (presentation.output_replay orelse
+        return error.TestExpectedReplay) {
+        .available => |value| value,
+        .unavailable => return error.TestExpectedReplay,
+    };
+    const page = try command_replay_store.readAgentPageManaged(
+        alloc,
+        &capability,
+        descriptor.handle,
+        1,
+        4096,
+    );
+    defer alloc.free(page);
+    try std.testing.expect(
+        std.mem.find(u8, page, "CANCELLED-REPLAY-SENTINEL") != null,
+    );
+    var artifacts = try capability.iterate(alloc, .command_artifacts);
+    defer artifacts.deinit();
+    try std.testing.expectEqual(@as(usize, 1), artifacts.names.len);
 
     const complete_log = try std.fmt.allocPrint(
         alloc,
@@ -581,6 +628,8 @@ test "processQueuedPrompt retains cancelled command artifact for presentation on
     try expectBodyNotContains(&follow_gateway, 0, "RESULT-ONLY-OUTPUT-SENTINEL");
     try expectBodyNotContains(&follow_gateway, 0, "RESULT-JSON-ONLY-SENTINEL");
     try expectBodyNotContains(&follow_gateway, 0, "TERM-TAIL-SENTINEL");
+    try expectBodyNotContains(&follow_gateway, 0, replay_output);
+    try expectBodyNotContains(&follow_gateway, 0, descriptor.handle);
     try expectBodyNotContains(&follow_gateway, 0, artifact_handle);
     try expectBodyNotContains(&follow_gateway, 0, artifact_path);
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, follow_gateway.request_bodies.items[0], session_runtime.aborted_tool_output));

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -1400,6 +1400,7 @@ pub const FakeAgentRuntimeDeps = struct {
                 1,
                 self.command_replay_capability,
             );
+            capture.setPolicyBeforeCapture(.required);
             capture.appendAccepted(request.result_allocator, .stdout, output);
             capture.seal(request.result_allocator);
             result.command_replay_capture = capture;

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -164,12 +164,7 @@ pub fn assembleParallelToolResults(
                 },
             }
         };
-        var prepared = try runtime_execution_memory.prepareToolModelOutput(
-            arena,
-            config,
-            original_call,
-            execution.model_output,
-        );
+        var prepared = try runtime_execution_memory.prepareToolModelOutput(arena, config, original_call, execution.model_output);
         runtime_execution_memory.applyToolResultMemory(
             &prepared.memory,
             execution.tool_result_memory,

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -164,12 +164,11 @@ pub fn assembleParallelToolResults(
                 },
             }
         };
-        var prepared = try runtime_execution_memory.prepareCapturedToolModelOutput(
+        var prepared = try runtime_execution_memory.prepareToolModelOutput(
             arena,
             config,
             original_call,
             execution.model_output,
-            execution.command_replay_capture,
         );
         runtime_execution_memory.applyToolResultMemory(
             &prepared.memory,

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -164,7 +164,13 @@ pub fn assembleParallelToolResults(
                 },
             }
         };
-        var prepared = try runtime_execution_memory.prepareToolModelOutput(arena, config, original_call, execution.model_output);
+        var prepared = try runtime_execution_memory.prepareCapturedToolModelOutput(
+            arena,
+            config,
+            original_call,
+            execution.model_output,
+            execution.command_replay_capture,
+        );
         runtime_execution_memory.applyToolResultMemory(
             &prepared.memory,
             execution.tool_result_memory,

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -983,28 +983,6 @@ fn listResumablePageForScope(
     );
 }
 
-const default_cancelled_command_replay_inline_limit: usize = 64 * 1024;
-
-const DisabledCancelledCommandCapture = struct {
-    turn_id: u64,
-    call_id_hash: u64,
-    call_id_len: usize,
-
-    fn init(id: types.ToolLifecycleId) DisabledCancelledCommandCapture {
-        return .{
-            .turn_id = id.turn_id,
-            .call_id_hash = std.hash.Wyhash.hash(0, id.call_id),
-            .call_id_len = id.call_id.len,
-        };
-    }
-
-    fn matches(self: DisabledCancelledCommandCapture, id: types.ToolLifecycleId) bool {
-        return self.turn_id == id.turn_id and
-            self.call_id_len == id.call_id.len and
-            self.call_id_hash == std.hash.Wyhash.hash(0, id.call_id);
-    }
-};
-
 const JsHostSessionStore = struct {
     ctx: ?*anyopaque = null,
     load_fn: *const fn (?*anyopaque, Allocator, []const u8) anyerror!?js_host_session_store.Loaded = if (host_target.is_wasm) loadDefault else loadUnavailable,
@@ -1076,9 +1054,6 @@ const JsHostSessionOwner = struct {
 
 const PendingCancelledCommand = struct {
     lifecycle_id: types.ToolLifecycleId,
-    capture: ?*command_replay_store.Capture,
-    cancelled: bool = false,
-    completed: bool = false,
     command_artifact_handle: ?[]u8 = null,
 
     fn matches(self: PendingCancelledCommand, id: types.ToolLifecycleId) bool {
@@ -1087,20 +1062,6 @@ const PendingCancelledCommand = struct {
     }
 
     fn discard(self: *PendingCancelledCommand, alloc: Allocator) void {
-        if (self.capture) |capture| {
-            capture.discard(alloc);
-            alloc.destroy(capture);
-        }
-        alloc.free(@constCast(self.lifecycle_id.call_id));
-        if (self.command_artifact_handle) |handle| alloc.free(handle);
-        self.* = undefined;
-    }
-
-    fn releaseRetained(self: *PendingCancelledCommand, alloc: Allocator) void {
-        if (self.capture) |capture| {
-            capture.releaseRetained(alloc);
-            alloc.destroy(capture);
-        }
         alloc.free(@constCast(self.lifecycle_id.call_id));
         if (self.command_artifact_handle) |handle| alloc.free(handle);
         self.* = undefined;
@@ -1125,7 +1086,6 @@ pub const Persistence = struct {
     session_picker_all_cache: SessionPickerPageCache = .{},
     degraded_warning_emitted: bool = false,
     pending_cancelled_command: ?PendingCancelledCommand = null,
-    disabled_cancelled_command_capture: ?DisabledCancelledCommandCapture = null,
     image_snapshot_temp_dir: ?[]u8 = null,
     resume_view_admission: ?session_store.ResumeViewAdmission = null,
     resume_handoff_intent: ResumeHandoffIntent = .none,
@@ -2363,28 +2323,6 @@ pub fn Runtime(comptime App: type) type {
             return moved;
         }
 
-        pub fn recordAppliedCommandOutput(
-            app: *App,
-            lifecycle_id: ?types.ToolLifecycleId,
-            stream: command_output_content.Stream,
-            bytes: []const u8,
-        ) void {
-            const id = lifecycle_id orelse return;
-            if (app.session_persistence.disabled_cancelled_command_capture) |disabled| {
-                if (disabled.matches(id)) return;
-                debug_trace.logf(
-                    "session",
-                    "cancelled command replay disabled lifecycle replaced turn_id={d}",
-                    .{disabled.turn_id},
-                );
-                app.session_persistence.disabled_cancelled_command_capture = null;
-            }
-            const pending = ensurePendingCancelledCommand(app, id, true) orelse return;
-            if (pending.capture) |capture| {
-                capture.appendAccepted(app.alloc, stream, bytes);
-            }
-        }
-
         pub fn recordToolTerminal(
             app: *App,
             event: types.ToolLifecycleEvent,
@@ -2394,13 +2332,6 @@ pub fn Runtime(comptime App: type) type {
                 .terminal => |value| value,
                 .provisional, .authoritative_started, .progress, .turn_finished => return,
             };
-            const capture_disabled = if (app.session_persistence.disabled_cancelled_command_capture) |disabled|
-                disabled.matches(terminal.id)
-            else
-                false;
-            if (capture_disabled) {
-                app.session_persistence.disabled_cancelled_command_capture = null;
-            }
             if (!captured_command_call) {
                 discardPendingCancelledCommand(app, terminal.id, "non_command_terminal");
                 return;
@@ -2409,12 +2340,7 @@ pub fn Runtime(comptime App: type) type {
                 discardPendingCancelledCommand(app, terminal.id, "ordinary_command_terminal");
                 return;
             }
-            const pending = ensurePendingCancelledCommand(
-                app,
-                terminal.id,
-                !capture_disabled,
-            ) orelse return;
-            pending.cancelled = true;
+            const pending = ensurePendingCancelledCommand(app, terminal.id) orelse return;
             if (pending.command_artifact_handle) |handle| {
                 app.alloc.free(handle);
                 pending.command_artifact_handle = null;
@@ -2429,20 +2355,6 @@ pub fn Runtime(comptime App: type) type {
                     return;
                 };
             }
-        }
-
-        pub fn recordCommandOutputComplete(
-            app: *App,
-            lifecycle_id: ?types.ToolLifecycleId,
-        ) void {
-            const id = lifecycle_id orelse return;
-            const pending = if (app.session_persistence.pending_cancelled_command) |*value|
-                value
-            else
-                return;
-            if (!pending.matches(id)) return;
-            if (pending.capture) |capture| capture.seal(app.alloc);
-            pending.completed = true;
         }
 
         pub fn appendHistoryTurn(app: *App, turn: types.HistoryTurn) !void {
@@ -2607,7 +2519,6 @@ pub fn Runtime(comptime App: type) type {
                 else => return appendHistoryTurnWithOutcome(app, turn, mode, snapshot_file_ownership),
             };
             var pending = app.session_persistence.pending_cancelled_command orelse {
-                app.session_persistence.disabled_cancelled_command_capture = null;
                 return appendHistoryTurnWithOutcome(app, turn, mode, snapshot_file_ownership);
             };
             app.session_persistence.pending_cancelled_command = null;
@@ -2620,25 +2531,15 @@ pub fn Runtime(comptime App: type) type {
                 call.name,
                 call.arguments_json,
             );
-            if (!pending.cancelled or
-                !pending.completed or
-                !is_command or
+            if (!is_command or
                 !std.mem.eql(u8, call.id, pending.lifecycle_id.call_id))
             {
                 pending.discard(app.alloc);
                 return appendHistoryTurnWithOutcome(app, turn, mode, snapshot_file_ownership);
             }
+            defer pending.discard(app.alloc);
 
             if (interrupted.cancelled_command) |authoritative| {
-                const shares_replay = pendingReplayMatchesAuthoritative(
-                    app.alloc,
-                    &pending,
-                    authoritative.output_replay,
-                );
-                defer if (shares_replay)
-                    pending.releaseRetained(app.alloc)
-                else
-                    pending.discard(app.alloc);
                 var enriched_presentation = authoritative;
                 if (enriched_presentation.command_artifact_handle == null) {
                     enriched_presentation.command_artifact_handle =
@@ -2646,7 +2547,7 @@ pub fn Runtime(comptime App: type) type {
                 }
                 var enriched_interrupted = interrupted;
                 enriched_interrupted.cancelled_command = enriched_presentation;
-                return appendHistoryTurnWithExternallyOwnedCancelledReplay(
+                return appendHistoryTurnWithOutcome(
                     app,
                     .{ .interrupted = enriched_interrupted },
                     mode,
@@ -2654,46 +2555,17 @@ pub fn Runtime(comptime App: type) type {
                 );
             }
 
-            const output_replay = if (pending.capture) |capture|
-                capture.retain(app.alloc)
-            else
-                null;
             var enriched_interrupted = interrupted;
             enriched_interrupted.cancelled_command = .{
-                .output_replay = output_replay,
                 .command_artifact_handle = pending.command_artifact_handle,
             };
             const enriched: types.HistoryTurn = .{ .interrupted = enriched_interrupted };
-            defer pending.releaseRetained(app.alloc);
             return appendHistoryTurnWithOutcome(app, enriched, mode, snapshot_file_ownership);
-        }
-
-        fn pendingReplayMatchesAuthoritative(
-            alloc: Allocator,
-            pending: *PendingCancelledCommand,
-            authoritative: ?types.CommandOutputReplay,
-        ) bool {
-            const authoritative_descriptor = switch (authoritative orelse
-                return false) {
-                .available => |descriptor| descriptor,
-                .unavailable => return false,
-            };
-            const capture = pending.capture orelse return false;
-            const fallback = capture.retain(alloc) orelse return false;
-            return switch (fallback) {
-                .available => |descriptor| std.mem.eql(
-                    u8,
-                    descriptor.handle,
-                    authoritative_descriptor.handle,
-                ),
-                .unavailable => false,
-            };
         }
 
         fn ensurePendingCancelledCommand(
             app: *App,
             id: types.ToolLifecycleId,
-            capture_enabled: bool,
         ) ?*PendingCancelledCommand {
             if (app.session_persistence.pending_cancelled_command) |*pending| {
                 if (pending.matches(id)) return pending;
@@ -2701,38 +2573,18 @@ pub fn Runtime(comptime App: type) type {
             }
 
             const call_id = app.alloc.dupe(u8, id.call_id) catch |err| {
-                app.session_persistence.disabled_cancelled_command_capture =
-                    DisabledCancelledCommandCapture.init(id);
                 debug_trace.logf(
                     "session",
-                    "cancelled command capture identity unavailable call_id={s} err={s}",
+                    "cancelled command metadata identity unavailable call_id={s} err={s}",
                     .{ id.call_id, @errorName(err) },
                 );
                 return null;
             };
-            errdefer app.alloc.free(call_id);
-            const capability = childCapability(app);
-            const capture = if (capture_enabled)
-                command_replay_store.Capture.create(
-                    app.alloc,
-                    default_cancelled_command_replay_inline_limit,
-                    capability,
-                ) catch |err| blk: {
-                    debug_trace.logf(
-                        "session",
-                        "cancelled command replay capture unavailable call_id={s} err={s}",
-                        .{ id.call_id, @errorName(err) },
-                    );
-                    break :blk null;
-                }
-            else
-                null;
             app.session_persistence.pending_cancelled_command = .{
                 .lifecycle_id = .{
                     .turn_id = id.turn_id,
                     .call_id = call_id,
                 },
-                .capture = capture,
             };
             return &app.session_persistence.pending_cancelled_command.?;
         }
@@ -2757,7 +2609,7 @@ pub fn Runtime(comptime App: type) type {
                 return;
             debug_trace.logf(
                 "session",
-                "cancelled command replay candidate discarded call_id={s} reason={s}",
+                "cancelled command metadata discarded call_id={s} reason={s}",
                 .{ pending.lifecycle_id.call_id, reason },
             );
             pending.discard(app.alloc);
@@ -2770,57 +2622,12 @@ pub fn Runtime(comptime App: type) type {
             mode: AppendHistoryMode,
             snapshot_file_ownership: ?types.SnapshotFileOwnership,
         ) !HistoryAppendOutcome {
-            return appendHistoryTurnWithReplayCleanup(
-                app,
-                turn,
-                mode,
-                snapshot_file_ownership,
-                .app_owned,
-            );
-        }
-
-        fn appendHistoryTurnWithExternallyOwnedCancelledReplay(
-            app: *App,
-            turn: types.HistoryTurn,
-            mode: AppendHistoryMode,
-            snapshot_file_ownership: ?types.SnapshotFileOwnership,
-        ) !HistoryAppendOutcome {
-            return appendHistoryTurnWithReplayCleanup(
-                app,
-                turn,
-                mode,
-                snapshot_file_ownership,
-                .external,
-            );
-        }
-
-        const CancelledReplayCleanupOwner = enum {
-            app_owned,
-            external,
-        };
-
-        fn appendHistoryTurnWithReplayCleanup(
-            app: *App,
-            turn: types.HistoryTurn,
-            mode: AppendHistoryMode,
-            snapshot_file_ownership: ?types.SnapshotFileOwnership,
-            replay_owner: CancelledReplayCleanupOwner,
-        ) !HistoryAppendOutcome {
-            var inserted = false;
-            defer {
-                if (comptime @hasField(App, "session_persistence")) {
-                    if (!inserted and replay_owner == .app_owned) {
-                        discardUncommittedCancelledReplay(app, turn);
-                    }
-                }
-            }
             app.session.appendHistoryEntry(app.alloc, turn) catch |err| {
                 return switch (mode) {
                     .strict => err,
                     .visual_epoch => .uncommitted,
                 };
             };
-            inserted = true;
             if (snapshot_file_ownership) |ownership| ownership.transfer();
             // The footer title freezes at the first usable prompt, matching the
             // sidecar derivation the resume picker shows.
@@ -2892,37 +2699,6 @@ pub fn Runtime(comptime App: type) type {
                 },
             };
             return .committed;
-        }
-
-        fn discardUncommittedCancelledReplay(
-            app: *App,
-            turn: types.HistoryTurn,
-        ) void {
-            const interrupted = switch (turn) {
-                .interrupted => |entry| entry,
-                else => return,
-            };
-            const presentation = interrupted.cancelled_command orelse return;
-            const replay = presentation.output_replay orelse return;
-            const descriptor = switch (replay) {
-                .available => |value| value,
-                .unavailable => return,
-            };
-            const capability = childCapability(app) orelse {
-                debug_trace.logf(
-                    "session",
-                    "uncommitted cancelled replay cleanup unavailable handle_bytes={d}",
-                    .{descriptor.handle.len},
-                );
-                return;
-            };
-            capability.delete(.command_artifacts, descriptor.handle) catch |err| {
-                debug_trace.logf(
-                    "session",
-                    "uncommitted cancelled replay cleanup failed handle_bytes={d} err={s}",
-                    .{ descriptor.handle.len, @errorName(err) },
-                );
-            };
         }
 
         pub fn compactHistory(app: *App) !void {
@@ -3380,7 +3156,6 @@ pub fn Runtime(comptime App: type) type {
         /// Background authority must already be detached (or is detached here).
         fn abandonParkedWritableSession(app: *App) void {
             discardAnyPendingCancelledCommand(app, "writable_session_abandon");
-            app.session_persistence.disabled_cancelled_command_capture = null;
             const loaded = if (app.session_persistence.writable) |*value|
                 value
             else
@@ -4522,7 +4297,6 @@ pub fn Runtime(comptime App: type) type {
             app.session_persistence.write_mutex.lockUncancelable(io_mod.getIo());
             defer app.session_persistence.write_mutex.unlock(io_mod.getIo());
             discardAnyPendingCancelledCommand(app, "writable_session_close");
-            app.session_persistence.disabled_cancelled_command_capture = null;
             const loaded = if (app.session_persistence.writable) |*value|
                 value
             else
@@ -8285,22 +8059,22 @@ test "cancelled command presentation survives a persisted session restart" {
         try configureTestPreferences(&app);
         try Runtime(TestApp).initializePersistence(&app, true);
         try Runtime(TestApp).beginFreshPersistedSession(&app);
+        const capability = Runtime(TestApp).childCapability(&app) orelse
+            return error.TestExpectedSessionCapability;
+        const capture = try command_replay_store.Capture.create(alloc, 1, capability);
+        capture.setPolicyBeforeCapture(.required);
+        try capture.appendAcceptedRequired(alloc, .stdout, "INTERRUPT_START\n");
+        try capture.appendAcceptedRequired(alloc, .stderr, "warning\n");
+        const descriptor = (try capture.retainRequired(alloc)) orelse
+            return error.TestExpectedReplay;
+        defer {
+            capture.releaseRetained(alloc);
+            alloc.destroy(capture);
+        }
         const lifecycle_id = types.ToolLifecycleId{
             .turn_id = 7,
             .call_id = "cancelled-command",
         };
-        Runtime(TestApp).recordAppliedCommandOutput(
-            &app,
-            lifecycle_id,
-            .stdout,
-            "INTERRUPT_START\n",
-        );
-        Runtime(TestApp).recordAppliedCommandOutput(
-            &app,
-            lifecycle_id,
-            .stderr,
-            "warning\n",
-        );
         Runtime(TestApp).recordToolTerminal(
             &app,
             .{ .terminal = .{
@@ -8310,7 +8084,6 @@ test "cancelled command presentation survives a persisted session restart" {
             } },
             true,
         );
-        Runtime(TestApp).recordCommandOutputComplete(&app, lifecycle_id);
 
         try Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
             .user = .{ .text = @constCast("run the slow command") },
@@ -8319,6 +8092,9 @@ test "cancelled command presentation survives a persisted session restart" {
                 .id = "cancelled-command",
                 .name = "terminal",
                 .arguments_json = "{\"action\":\"exec\",\"command\":\"slow\"}",
+            },
+            .cancelled_command = .{
+                .output_replay = .{ .available = descriptor },
             },
         } });
         session_id = try alloc.dupe(u8, app.session_persistence.writable.?.active_id);
@@ -8353,7 +8129,7 @@ test "cancelled command presentation survives a persisted session restart" {
     );
 }
 
-test "cancelled command capture creation failure preserves the row" {
+test "cancelled command metadata allocation failure preserves core presentation" {
     const alloc = std.testing.allocator;
     var failing = std.testing.FailingAllocator.init(alloc, .{});
     const app_alloc = failing.allocator();
@@ -8363,14 +8139,7 @@ test "cancelled command capture creation failure preserves the row" {
         .turn_id = 8,
         .call_id = "capture-unavailable",
     };
-    failing.fail_index = failing.alloc_index + 1;
-    Runtime(TestApp).recordAppliedCommandOutput(
-        &app,
-        lifecycle_id,
-        .stdout,
-        "applied before capture failure\n",
-    );
-    failing.fail_index = std.math.maxInt(usize);
+    failing.fail_index = failing.alloc_index;
     Runtime(TestApp).recordToolTerminal(
         &app,
         .{ .terminal = .{
@@ -8379,7 +8148,7 @@ test "cancelled command capture creation failure preserves the row" {
         } },
         true,
     );
-    Runtime(TestApp).recordCommandOutputComplete(&app, lifecycle_id);
+    failing.fail_index = std.math.maxInt(usize);
     try Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
         .user = .{ .text = @constCast("cancel") },
         .tool_call = .{
@@ -8387,6 +8156,7 @@ test "cancelled command capture creation failure preserves the row" {
             .name = "run_command",
             .arguments_json = "{\"command\":\"slow\"}",
         },
+        .cancelled_command = .{},
     } });
 
     const history = try app.session.snapshotHistory(alloc);
@@ -8396,9 +8166,7 @@ test "cancelled command capture creation failure preserves the row" {
     try std.testing.expect(presentation.output_replay == null);
 }
 
-fn expectAuthoritativeCancelledReplayReconciliation(
-    fallback_output: []const u8,
-) !void {
+fn expectAuthoritativeCancelledReplayIsSoleArtifact() !void {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -8421,6 +8189,7 @@ fn expectAuthoritativeCancelledReplayReconciliation(
         1,
         capability,
     );
+    authoritative.setPolicyBeforeCapture(.required);
     try authoritative.appendAcceptedRequired(
         alloc,
         .stdout,
@@ -8441,12 +8210,6 @@ fn expectAuthoritativeCancelledReplayReconciliation(
         .turn_id = 9,
         .call_id = "authoritative-cancelled-command",
     };
-    Runtime(TestApp).recordAppliedCommandOutput(
-        &app,
-        lifecycle_id,
-        .stdout,
-        fallback_output,
-    );
     Runtime(TestApp).recordToolTerminal(
         &app,
         .{ .terminal = .{
@@ -8456,7 +8219,6 @@ fn expectAuthoritativeCancelledReplayReconciliation(
         } },
         true,
     );
-    Runtime(TestApp).recordCommandOutputComplete(&app, lifecycle_id);
 
     try Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
         .user = .{ .text = @constCast("cancel") },
@@ -8495,47 +8257,23 @@ fn expectAuthoritativeCancelledReplayReconciliation(
     try std.testing.expect(
         std.mem.find(u8, page, "SHARED-CANCELLED-OUTPUT") != null,
     );
-    if (!std.mem.eql(u8, fallback_output, "SHARED-CANCELLED-OUTPUT\n")) {
-        try std.testing.expect(std.mem.find(u8, page, fallback_output) == null);
-    }
     var artifacts = try capability.iterate(alloc, .command_artifacts);
     defer artifacts.deinit();
     try std.testing.expectEqual(@as(usize, 1), artifacts.names.len);
 }
 
-test "authoritative cancelled replay reconciles shared and distinct app captures" {
-    try expectAuthoritativeCancelledReplayReconciliation(
-        "SHARED-CANCELLED-OUTPUT\n",
-    );
-    try expectAuthoritativeCancelledReplayReconciliation(
-        "DISTINCT-APP-CAPTURE\n",
-    );
+test "authoritative cancelled replay is the sole output artifact" {
+    try expectAuthoritativeCancelledReplayIsSoleArtifact();
 }
 
-test "cancelled command identity failure never persists a replay suffix" {
+test "cancelled command metadata does not create output replay" {
     const alloc = std.testing.allocator;
-    var failing = std.testing.FailingAllocator.init(alloc, .{});
-    const app_alloc = failing.allocator();
-    var app = try TestApp.init(app_alloc, "/workspace");
+    var app = try TestApp.init(alloc, "/workspace");
     defer app.deinit();
     const lifecycle_id = types.ToolLifecycleId{
         .turn_id = 9,
         .call_id = "identity-unavailable",
     };
-    failing.fail_index = failing.alloc_index;
-    Runtime(TestApp).recordAppliedCommandOutput(
-        &app,
-        lifecycle_id,
-        .stdout,
-        "first chunk\n",
-    );
-    failing.fail_index = std.math.maxInt(usize);
-    Runtime(TestApp).recordAppliedCommandOutput(
-        &app,
-        lifecycle_id,
-        .stdout,
-        "must not become a suffix\n",
-    );
     Runtime(TestApp).recordToolTerminal(
         &app,
         .{ .terminal = .{
@@ -8544,7 +8282,6 @@ test "cancelled command identity failure never persists a replay suffix" {
         } },
         true,
     );
-    Runtime(TestApp).recordCommandOutputComplete(&app, lifecycle_id);
     try Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
         .user = .{ .text = @constCast("cancel") },
         .tool_call = .{
@@ -8561,125 +8298,7 @@ test "cancelled command identity failure never persists a replay suffix" {
     try std.testing.expect(presentation.output_replay == null);
 }
 
-test "cancelled command spill failure degrades without losing the row" {
-    const alloc = std.testing.allocator;
-    var app = try TestApp.init(alloc, "/workspace");
-    defer app.deinit();
-    const lifecycle_id = types.ToolLifecycleId{
-        .turn_id = 10,
-        .call_id = "spill-unavailable",
-    };
-    const output = try alloc.alloc(u8, default_cancelled_command_replay_inline_limit + 1);
-    defer alloc.free(output);
-    @memset(output, 'x');
-    Runtime(TestApp).recordAppliedCommandOutput(&app, lifecycle_id, .stdout, output);
-    Runtime(TestApp).recordAppliedCommandOutput(
-        &app,
-        lifecycle_id,
-        .stderr,
-        "must not become a suffix\n",
-    );
-    Runtime(TestApp).recordToolTerminal(
-        &app,
-        .{ .terminal = .{
-            .id = lifecycle_id,
-            .outcome = .{ .kind = .cancelled, .summary = "Cancelled" },
-        } },
-        true,
-    );
-    Runtime(TestApp).recordCommandOutputComplete(&app, lifecycle_id);
-    try Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
-        .user = .{ .text = @constCast("cancel") },
-        .tool_call = .{
-            .id = "spill-unavailable",
-            .name = "run_command",
-            .arguments_json = "{\"command\":\"slow\"}",
-        },
-    } });
-
-    const history = try app.session.snapshotHistory(alloc);
-    defer session_runtime.freeHistoryTurnSlice(alloc, history);
-    const replay = history[0].interrupted.cancelled_command.?.output_replay orelse
-        return error.TestExpectedReplay;
-    try std.testing.expect(replay == .unavailable);
-}
-
-test "reactive interrupted history discards the app replay candidate" {
-    const alloc = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const paths = try testPaths(alloc, &tmp);
-    defer {
-        alloc.free(paths.home);
-        alloc.free(paths.workspace);
-    }
-    const home = try TestHome.install(alloc, paths.home);
-    defer home.deinit();
-    var app = try TestApp.init(alloc, paths.workspace);
-    defer app.deinit();
-    try configureTestPreferences(&app);
-    try Runtime(TestApp).initializePersistence(&app, true);
-    try Runtime(TestApp).beginFreshPersistedSession(&app);
-    const lifecycle_id = types.ToolLifecycleId{
-        .turn_id = 9,
-        .call_id = "reactive-cancelled-command",
-    };
-    const output = try alloc.alloc(u8, default_cancelled_command_replay_inline_limit + 1);
-    defer alloc.free(output);
-    @memset(output, 'x');
-    Runtime(TestApp).recordAppliedCommandOutput(&app, lifecycle_id, .stdout, output);
-    Runtime(TestApp).recordToolTerminal(
-        &app,
-        .{ .terminal = .{
-            .id = lifecycle_id,
-            .outcome = .{ .kind = .cancelled, .summary = "Cancelled" },
-        } },
-        true,
-    );
-    Runtime(TestApp).recordCommandOutputComplete(&app, lifecycle_id);
-    var before = try Runtime(TestApp).childCapability(&app).?.iterate(
-        alloc,
-        .command_artifacts,
-    );
-    defer before.deinit();
-    try std.testing.expectEqual(@as(usize, 1), before.names.len);
-
-    var execution_calls = [_]types.ToolCall{.{
-        .id = "reactive-execution-command",
-        .name = "run_command",
-        .arguments_json = "{\"command\":\"restricted then broader\"}",
-    }};
-    var execution_results = [_]types.PersistedToolResult{.{
-        .tool_call_id = @constCast("reactive-execution-command"),
-        .tool_name = @constCast("run_command"),
-        .status = .failure,
-        .output = @constCast("restricted and broader attempts retained"),
-        .output_bytes = 40,
-        .stored_output_bytes = 40,
-    }};
-    var execution_steps = [_]types.ToolExecutionStep{.{
-        .tool_calls = execution_calls[0..],
-        .tool_results = execution_results[0..],
-    }};
-    try Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
-        .user = .{ .text = @constCast("cancel") },
-        .tool_call = null,
-        .execution = .{ .tool_steps = execution_steps[0..] },
-    } });
-    const history = try app.session.snapshotHistory(alloc);
-    defer session_runtime.freeHistoryTurnSlice(alloc, history);
-    try std.testing.expect(history[0].interrupted.cancelled_command == null);
-    try Runtime(TestApp).replayHistory(&app, history);
-    try std.testing.expectEqual(@as(usize, 1), app.completed_tool_statuses.items.len);
-    var after = try Runtime(TestApp).childCapability(&app).?.iterate(
-        alloc,
-        .command_artifacts,
-    );
-    defer after.deinit();
-    try std.testing.expectEqual(@as(usize, 0), after.names.len);
-}
-
-test "ordinary command terminal discards the app replay candidate" {
+test "ordinary command terminal creates no cancellation metadata" {
     const alloc = std.testing.allocator;
     var app = try TestApp.init(alloc, "/workspace");
     defer app.deinit();
@@ -8687,7 +8306,6 @@ test "ordinary command terminal discards the app replay candidate" {
         .turn_id = 10,
         .call_id = "completed-command",
     };
-    Runtime(TestApp).recordAppliedCommandOutput(&app, lifecycle_id, .stdout, "done\n");
     Runtime(TestApp).recordToolTerminal(
         &app,
         .{ .terminal = .{
@@ -8699,7 +8317,7 @@ test "ordinary command terminal discards the app replay candidate" {
     try std.testing.expect(app.session_persistence.pending_cancelled_command == null);
 }
 
-test "cancelled durable terminal action preserves the exec replay candidate" {
+test "cancelled durable terminal action preserves exec metadata" {
     const alloc = std.testing.allocator;
     var app = try TestApp.init(alloc, "/workspace");
     defer app.deinit();
@@ -8712,12 +8330,6 @@ test "cancelled durable terminal action preserves the exec replay candidate" {
         .call_id = "cancelled-read",
     };
 
-    Runtime(TestApp).recordAppliedCommandOutput(
-        &app,
-        exec_id,
-        .stdout,
-        "captured before cancellation\n",
-    );
     Runtime(TestApp).recordToolTerminal(
         &app,
         .{ .terminal = .{
@@ -8726,7 +8338,6 @@ test "cancelled durable terminal action preserves the exec replay candidate" {
         } },
         true,
     );
-    Runtime(TestApp).recordCommandOutputComplete(&app, exec_id);
 
     Runtime(TestApp).recordToolTerminal(
         &app,
@@ -8740,8 +8351,6 @@ test "cancelled durable terminal action preserves the exec replay candidate" {
     const pending = app.session_persistence.pending_cancelled_command orelse
         return error.TestExpectedEqual;
     try std.testing.expect(pending.matches(exec_id));
-    try std.testing.expect(pending.cancelled);
-    try std.testing.expect(pending.completed);
 }
 
 test "zero-output cancelled command restores detail without an output block" {
@@ -8861,56 +8470,7 @@ test "cancelled replay survives event persistence failure after history insertio
     _ = try capability.stat(.command_artifacts, descriptor.handle);
 }
 
-test "cancelled replay is deleted when history insertion fails" {
-    const alloc = std.testing.allocator;
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-    const paths = try testPaths(alloc, &tmp);
-    defer {
-        alloc.free(paths.home);
-        alloc.free(paths.workspace);
-    }
-    const home = try TestHome.install(alloc, paths.home);
-    defer home.deinit();
-    var app = try TestApp.init(alloc, paths.workspace);
-    defer app.deinit();
-    try configureTestPreferences(&app);
-    try Runtime(TestApp).initializePersistence(&app, true);
-    try Runtime(TestApp).beginFreshPersistedSession(&app);
-    const capability = Runtime(TestApp).childCapability(&app).?;
-    var capture_arena = std.heap.ArenaAllocator.init(alloc);
-    defer capture_arena.deinit();
-    const capture_alloc = capture_arena.allocator();
-    const capture = try command_replay_store.Capture.create(capture_alloc, 1, capability);
-    capture.appendAccepted(capture_alloc, .stdout, "accepted\n");
-    const replay = capture.retain(capture_alloc) orelse return error.TestExpectedReplay;
-    const descriptor = switch (replay) {
-        .available => |value| value,
-        .unavailable => return error.TestExpectedReplay,
-    };
-    var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = 0 });
-    app.alloc = failing.allocator();
-    defer app.alloc = alloc;
-
-    try std.testing.expectError(
-        error.OutOfMemory,
-        Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
-            .user = .{ .text = @constCast("cancel") },
-            .tool_call = .{
-                .id = "failed-insert",
-                .name = "run_command",
-                .arguments_json = "{\"command\":\"slow\"}",
-            },
-            .cancelled_command = .{ .output_replay = replay },
-        } }),
-    );
-    try std.testing.expectError(
-        error.FileNotFound,
-        capability.stat(.command_artifacts, descriptor.handle),
-    );
-}
-
-test "externally owned cancelled replay survives history insertion failure" {
+test "authoritative cancelled replay survives history insertion failure" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -8935,6 +8495,7 @@ test "externally owned cancelled replay survives history insertion failure" {
         1,
         capability,
     );
+    capture.setPolicyBeforeCapture(.required);
     try capture.appendAcceptedRequired(
         capture_alloc,
         .stdout,
@@ -8948,22 +8509,17 @@ test "externally owned cancelled replay survives history insertion failure" {
 
     try std.testing.expectError(
         error.OutOfMemory,
-        Runtime(TestApp).appendHistoryTurnWithExternallyOwnedCancelledReplay(
-            &app,
-            .{ .interrupted = .{
-                .user = .{ .text = @constCast("cancel") },
-                .tool_call = .{
-                    .id = "failed-external-insert",
-                    .name = "terminal",
-                    .arguments_json = "{\"action\":\"exec\",\"command\":\"slow\",\"timeout_ms\":600000}",
-                },
-                .cancelled_command = .{
-                    .output_replay = .{ .available = descriptor },
-                },
-            } },
-            .strict,
-            null,
-        ),
+        Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
+            .user = .{ .text = @constCast("cancel") },
+            .tool_call = .{
+                .id = "failed-external-insert",
+                .name = "terminal",
+                .arguments_json = "{\"action\":\"exec\",\"command\":\"slow\",\"timeout_ms\":600000}",
+            },
+            .cancelled_command = .{
+                .output_replay = .{ .available = descriptor },
+            },
+        } }),
     );
     _ = try capability.stat(.command_artifacts, descriptor.handle);
     const page = try command_replay_store.readAgentPageManaged(

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -2629,6 +2629,31 @@ pub fn Runtime(comptime App: type) type {
                 return appendHistoryTurnWithOutcome(app, turn, mode, snapshot_file_ownership);
             }
 
+            if (interrupted.cancelled_command) |authoritative| {
+                const shares_replay = pendingReplayMatchesAuthoritative(
+                    app.alloc,
+                    &pending,
+                    authoritative.output_replay,
+                );
+                defer if (shares_replay)
+                    pending.releaseRetained(app.alloc)
+                else
+                    pending.discard(app.alloc);
+                var enriched_presentation = authoritative;
+                if (enriched_presentation.command_artifact_handle == null) {
+                    enriched_presentation.command_artifact_handle =
+                        pending.command_artifact_handle;
+                }
+                var enriched_interrupted = interrupted;
+                enriched_interrupted.cancelled_command = enriched_presentation;
+                return appendHistoryTurnWithExternallyOwnedCancelledReplay(
+                    app,
+                    .{ .interrupted = enriched_interrupted },
+                    mode,
+                    snapshot_file_ownership,
+                );
+            }
+
             const output_replay = if (pending.capture) |capture|
                 capture.retain(app.alloc)
             else
@@ -2641,6 +2666,28 @@ pub fn Runtime(comptime App: type) type {
             const enriched: types.HistoryTurn = .{ .interrupted = enriched_interrupted };
             defer pending.releaseRetained(app.alloc);
             return appendHistoryTurnWithOutcome(app, enriched, mode, snapshot_file_ownership);
+        }
+
+        fn pendingReplayMatchesAuthoritative(
+            alloc: Allocator,
+            pending: *PendingCancelledCommand,
+            authoritative: ?types.CommandOutputReplay,
+        ) bool {
+            const authoritative_descriptor = switch (authoritative orelse
+                return false) {
+                .available => |descriptor| descriptor,
+                .unavailable => return false,
+            };
+            const capture = pending.capture orelse return false;
+            const fallback = capture.retain(alloc) orelse return false;
+            return switch (fallback) {
+                .available => |descriptor| std.mem.eql(
+                    u8,
+                    descriptor.handle,
+                    authoritative_descriptor.handle,
+                ),
+                .unavailable => false,
+            };
         }
 
         fn ensurePendingCancelledCommand(
@@ -2723,10 +2770,48 @@ pub fn Runtime(comptime App: type) type {
             mode: AppendHistoryMode,
             snapshot_file_ownership: ?types.SnapshotFileOwnership,
         ) !HistoryAppendOutcome {
+            return appendHistoryTurnWithReplayCleanup(
+                app,
+                turn,
+                mode,
+                snapshot_file_ownership,
+                .app_owned,
+            );
+        }
+
+        fn appendHistoryTurnWithExternallyOwnedCancelledReplay(
+            app: *App,
+            turn: types.HistoryTurn,
+            mode: AppendHistoryMode,
+            snapshot_file_ownership: ?types.SnapshotFileOwnership,
+        ) !HistoryAppendOutcome {
+            return appendHistoryTurnWithReplayCleanup(
+                app,
+                turn,
+                mode,
+                snapshot_file_ownership,
+                .external,
+            );
+        }
+
+        const CancelledReplayCleanupOwner = enum {
+            app_owned,
+            external,
+        };
+
+        fn appendHistoryTurnWithReplayCleanup(
+            app: *App,
+            turn: types.HistoryTurn,
+            mode: AppendHistoryMode,
+            snapshot_file_ownership: ?types.SnapshotFileOwnership,
+            replay_owner: CancelledReplayCleanupOwner,
+        ) !HistoryAppendOutcome {
             var inserted = false;
             defer {
                 if (comptime @hasField(App, "session_persistence")) {
-                    if (!inserted) discardUncommittedCancelledReplay(app, turn);
+                    if (!inserted and replay_owner == .app_owned) {
+                        discardUncommittedCancelledReplay(app, turn);
+                    }
                 }
             }
             app.session.appendHistoryEntry(app.alloc, turn) catch |err| {
@@ -8311,6 +8396,122 @@ test "cancelled command capture creation failure preserves the row" {
     try std.testing.expect(presentation.output_replay == null);
 }
 
+fn expectAuthoritativeCancelledReplayReconciliation(
+    fallback_output: []const u8,
+) !void {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const capability = Runtime(TestApp).childCapability(&app) orelse
+        return error.TestExpectedSessionCapability;
+    const authoritative = try command_replay_store.Capture.create(
+        alloc,
+        1,
+        capability,
+    );
+    try authoritative.appendAcceptedRequired(
+        alloc,
+        .stdout,
+        "SHARED-CANCELLED-OUTPUT\n",
+    );
+    const descriptor = (try authoritative.retainRequired(alloc)) orelse
+        return error.TestExpectedReplay;
+    var published = false;
+    defer {
+        if (published)
+            authoritative.releaseRetained(alloc)
+        else
+            authoritative.discard(alloc);
+        alloc.destroy(authoritative);
+    }
+
+    const lifecycle_id = types.ToolLifecycleId{
+        .turn_id = 9,
+        .call_id = "authoritative-cancelled-command",
+    };
+    Runtime(TestApp).recordAppliedCommandOutput(
+        &app,
+        lifecycle_id,
+        .stdout,
+        fallback_output,
+    );
+    Runtime(TestApp).recordToolTerminal(
+        &app,
+        .{ .terminal = .{
+            .id = lifecycle_id,
+            .outcome = .{ .kind = .cancelled, .summary = "Cancelled" },
+            .command_artifact_handle = "fx-command-cancelled.log",
+        } },
+        true,
+    );
+    Runtime(TestApp).recordCommandOutputComplete(&app, lifecycle_id);
+
+    try Runtime(TestApp).appendHistoryTurn(&app, .{ .interrupted = .{
+        .user = .{ .text = @constCast("cancel") },
+        .tool_call = .{
+            .id = "authoritative-cancelled-command",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"slow\",\"timeout_ms\":600000}",
+        },
+        .cancelled_command = .{
+            .output_replay = .{ .available = descriptor },
+        },
+    } });
+    published = true;
+
+    const history = try app.session.snapshotHistory(alloc);
+    defer session_runtime.freeHistoryTurnSlice(alloc, history);
+    const stored = switch (history[0].interrupted.cancelled_command.?
+        .output_replay orelse return error.TestExpectedReplay) {
+        .available => |value| value,
+        .unavailable => return error.TestExpectedReplay,
+    };
+    try std.testing.expectEqualStrings(descriptor.handle, stored.handle);
+    try std.testing.expectEqualStrings(
+        "fx-command-cancelled.log",
+        history[0].interrupted.cancelled_command.?
+            .command_artifact_handle orelse return error.TestExpectedArtifactHandle,
+    );
+    const page = try command_replay_store.readAgentPageManaged(
+        alloc,
+        capability,
+        stored.handle,
+        1,
+        4096,
+    );
+    defer alloc.free(page);
+    try std.testing.expect(
+        std.mem.find(u8, page, "SHARED-CANCELLED-OUTPUT") != null,
+    );
+    if (!std.mem.eql(u8, fallback_output, "SHARED-CANCELLED-OUTPUT\n")) {
+        try std.testing.expect(std.mem.find(u8, page, fallback_output) == null);
+    }
+    var artifacts = try capability.iterate(alloc, .command_artifacts);
+    defer artifacts.deinit();
+    try std.testing.expectEqual(@as(usize, 1), artifacts.names.len);
+}
+
+test "authoritative cancelled replay reconciles shared and distinct app captures" {
+    try expectAuthoritativeCancelledReplayReconciliation(
+        "SHARED-CANCELLED-OUTPUT\n",
+    );
+    try expectAuthoritativeCancelledReplayReconciliation(
+        "DISTINCT-APP-CAPTURE\n",
+    );
+}
+
 test "cancelled command identity failure never persists a replay suffix" {
     const alloc = std.testing.allocator;
     var failing = std.testing.FailingAllocator.init(alloc, .{});
@@ -8707,6 +8908,73 @@ test "cancelled replay is deleted when history insertion fails" {
         error.FileNotFound,
         capability.stat(.command_artifacts, descriptor.handle),
     );
+}
+
+test "externally owned cancelled replay survives history insertion failure" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try testPaths(alloc, &tmp);
+    defer {
+        alloc.free(paths.home);
+        alloc.free(paths.workspace);
+    }
+    const home = try TestHome.install(alloc, paths.home);
+    defer home.deinit();
+    var app = try TestApp.init(alloc, paths.workspace);
+    defer app.deinit();
+    try configureTestPreferences(&app);
+    try Runtime(TestApp).initializePersistence(&app, true);
+    try Runtime(TestApp).beginFreshPersistedSession(&app);
+    const capability = Runtime(TestApp).childCapability(&app).?;
+    var capture_arena = std.heap.ArenaAllocator.init(alloc);
+    defer capture_arena.deinit();
+    const capture_alloc = capture_arena.allocator();
+    const capture = try command_replay_store.Capture.create(
+        capture_alloc,
+        1,
+        capability,
+    );
+    try capture.appendAcceptedRequired(
+        capture_alloc,
+        .stdout,
+        "externally owned\n",
+    );
+    const descriptor = (try capture.retainRequired(capture_alloc)) orelse
+        return error.TestExpectedReplay;
+    var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = 0 });
+    app.alloc = failing.allocator();
+    defer app.alloc = alloc;
+
+    try std.testing.expectError(
+        error.OutOfMemory,
+        Runtime(TestApp).appendHistoryTurnWithExternallyOwnedCancelledReplay(
+            &app,
+            .{ .interrupted = .{
+                .user = .{ .text = @constCast("cancel") },
+                .tool_call = .{
+                    .id = "failed-external-insert",
+                    .name = "terminal",
+                    .arguments_json = "{\"action\":\"exec\",\"command\":\"slow\",\"timeout_ms\":600000}",
+                },
+                .cancelled_command = .{
+                    .output_replay = .{ .available = descriptor },
+                },
+            } },
+            .strict,
+            null,
+        ),
+    );
+    _ = try capability.stat(.command_artifacts, descriptor.handle);
+    const page = try command_replay_store.readAgentPageManaged(
+        alloc,
+        capability,
+        descriptor.handle,
+        1,
+        4096,
+    );
+    defer alloc.free(page);
+    try std.testing.expect(std.mem.find(u8, page, "externally owned") != null);
 }
 
 test "appendHistoryTurn commits canonical history event and totals" {

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -826,23 +826,9 @@ pub fn Runtime(comptime App: type) type {
                     },
                     .command_output => |chunk| {
                         try handlers.command_output(handlers.ctx, chunk.lifecycle_id, chunk.stream, chunk.text);
-                        if (comptime @hasField(App, "session_persistence")) {
-                            app_session_runtime.Runtime(App).recordAppliedCommandOutput(
-                                app,
-                                chunk.lifecycle_id,
-                                chunk.stream,
-                                chunk.text,
-                            );
-                        }
                     },
                     .command_output_complete => |lifecycle_id| {
                         try handlers.command_output_complete(handlers.ctx, lifecycle_id);
-                        if (comptime @hasField(App, "session_persistence")) {
-                            app_session_runtime.Runtime(App).recordCommandOutputComplete(
-                                app,
-                                lifecycle_id,
-                            );
-                        }
                     },
                     .turn_token_update => |update| {
                         applyTurnTokenProgress(app, update);
@@ -908,12 +894,6 @@ pub fn Runtime(comptime App: type) type {
                 .{},
             );
             try handlers.command_output_complete(handlers.ctx, lifecycle_id);
-            if (comptime @hasField(App, "session_persistence")) {
-                app_session_runtime.Runtime(App).recordCommandOutputComplete(
-                    app,
-                    lifecycle_id,
-                );
-            }
         }
 
         fn requireAssistantTextDrain(handlers: WorkerEventHandlers) !bool {
@@ -4149,11 +4129,7 @@ test "core.app_worker_runtime records accepted command output once and drops rej
 
     try std.testing.expectEqual(@as(usize, 4), capture.chunk_count);
     try std.testing.expectEqual(@as(usize, 1), capture.completion_count);
-    const pending = app.session_persistence.pending_cancelled_command orelse
-        return error.MissingCancelledCommandCapture;
-    try std.testing.expectEqualStrings(lifecycle_id.call_id, pending.lifecycle_id.call_id);
-    try std.testing.expect(pending.completed);
-    try std.testing.expect(pending.capture.?.hasOutput());
+    try std.testing.expect(app.session_persistence.pending_cancelled_command == null);
 
     app.worker.worker_cancel_requested.store(true, .seq_cst);
     try Runtime(FakeApp).pushCommandOutput(&app, lifecycle_id, .stdout, "late-stdout\n");

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -46,6 +46,7 @@ const permission_gate = @import("../permissions/permission_gate.zig");
 const permission_request = @import("../permissions/permission_request.zig");
 const permissions = @import("../permissions/permissions.zig");
 const session_runtime = @import("../session/session.zig");
+const command_replay_store = @import("../session/command_replay_store.zig");
 const session_codec = @import("../session/session_codec.zig");
 const session_usage = @import("../session/session_usage.zig");
 const usage_report = @import("../session/usage_report.zig");
@@ -528,6 +529,7 @@ const AskContext = struct {
     use_process_interrupt_flag: bool = false,
     background: BackgroundRuntime = .{},
     terminal_client: terminal_client_runtime.Runtime = .{},
+    ephemeral_command_replay: command_replay_store.EphemeralStore,
     subagent_host: ?*subagent_tool_host.Runtime = null,
     subagent_skills_prompt: []u8 = &.{},
     subagent_explicit_skills_prompt: []u8 = &.{},
@@ -595,6 +597,7 @@ const AskContext = struct {
             .terminal_client = terminal_client_runtime.Runtime.init(
                 cfg.background_process_provider,
             ),
+            .ephemeral_command_replay = command_replay_store.EphemeralStore.init(alloc),
             .lifecycle_runtime = lifecycle_runtime,
             .lifecycle_view = hooks.RuntimeView.empty(),
         };
@@ -709,6 +712,7 @@ const AskContext = struct {
         if (self.writable) |*writable| writable.deinit(self.alloc);
         self.writable = null;
         if (self.store) |*store| store.deinit(self.alloc);
+        self.ephemeral_command_replay.deinit();
         self.permission_rules.deinit(self.alloc);
         self.session.deinit(self.alloc);
         if (self.skills_dir.len > 0) self.alloc.free(self.skills_dir);
@@ -991,6 +995,10 @@ const AskContext = struct {
             .on_background_url_ready = onBackgroundUrlReady,
             .session_child_capability = if (self.writable) |*writable|
                 writable.childCapability() catch null
+            else
+                null,
+            .ephemeral_command_replay = if (self.writable == null)
+                &self.ephemeral_command_replay
             else
                 null,
             .terminal_client = &self.terminal_client,
@@ -1740,6 +1748,10 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
             false,
         .context_limits = ctx.context_limits,
         .session_child_capability = session_child_capability,
+        .ephemeral_command_replay = if (session_child_capability == null)
+            &ctx.ephemeral_command_replay
+        else
+            null,
     }, job) catch |err| switch (err) {
         error.NonInteractivePermissionRequired => {
             const assistant_output = try alloc.dupe(u8, ctx.assistant_output.items);
@@ -3935,7 +3947,9 @@ fn testProcessQueuedPromptChecksTimeout(deps: *const agent_runtime.AgentRuntimeD
 fn testProcessQueuedPromptChecksExecOnlyTerminal(deps: *const agent_runtime.AgentRuntimeDeps, semantic_presentation: ?agent_runtime.SemanticPresentationSink, _: agent_runtime.LifecycleContext, cfg: agent_runtime.Config, _: worker_runtime.QueuedPrompt) !void {
     try std.testing.expect(semantic_presentation == null);
     try std.testing.expect(cfg.session_child_capability == null);
+    try std.testing.expect(cfg.ephemeral_command_replay != null);
     const ctx: *AskContext = @ptrCast(@alignCast(deps.ctx));
+    try std.testing.expect(ctx.toolContext().ephemeral_command_replay != null);
     try std.testing.expectEqualStrings("inspect", ctx.mode_id);
     try std.testing.expect(tool_projection_mod.containsName(cfg.advertised_tool_names, "read_file"));
     try std.testing.expect(tool_projection_mod.containsName(cfg.advertised_tool_names, "terminal"));
@@ -3948,6 +3962,8 @@ fn testProcessQueuedPromptChecksExecOnlyTerminal(deps: *const agent_runtime.Agen
         advertised_terminal.input_schema,
         "request",
     ));
+    try std.testing.expect(std.mem.find(u8, advertised_terminal.description, "required finite timeout_ms") != null);
+    try std.testing.expect(std.mem.find(u8, advertised_terminal.description, "Use start") == null);
     try std.testing.expectEqualStrings(builtin_tools.web_search.description, cfg.custom_tool_guidance);
     try std.testing.expectEqualStrings("test model overlay", cfg.model_prompt_overlay.?);
     const runtime_terminal = deps.tool_registry.lookup("terminal") orelse
@@ -3960,6 +3976,10 @@ fn testProcessQueuedPromptChecksFullTerminal(deps: *const agent_runtime.AgentRun
     try std.testing.expect(semantic_presentation == null);
     try std.testing.expect(cfg.session_child_capability != null);
     try std.testing.expect(tool_projection_mod.containsName(cfg.advertised_tool_names, "terminal"));
+    const advertised_terminal = for (cfg.advertised_functions) |function| {
+        if (std.mem.eql(u8, function.name, "terminal")) break function;
+    } else return error.TestExpectedEqual;
+    try std.testing.expect(std.mem.find(u8, advertised_terminal.description, "Use start") != null);
     try testPushAssistantText(deps, "assistant text");
 }
 

--- a/src/core/session/command_replay_store.zig
+++ b/src/core/session/command_replay_store.zig
@@ -1453,7 +1453,12 @@ test "ephemeral command replay unlinks backing before publication and remains re
         return error.TestExpectedReplay;
     defer capture.releaseRetained(arena);
 
-    var entries = tmp.dir.iterate();
+    var inspect_dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), temp_path, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer inspect_dir.close(io_mod.getIo());
+    var entries = inspect_dir.iterate();
     try std.testing.expect(try entries.next(io_mod.getIo()) == null);
 
     var reader = try Reader.openEphemeralHandle(alloc, &store, descriptor.handle);

--- a/src/core/session/command_replay_store.zig
+++ b/src/core/session/command_replay_store.zig
@@ -16,6 +16,10 @@ const max_frame_payload_bytes: usize = 1024 * 1024;
 const max_agent_line_bytes: usize = max_frame_payload_bytes;
 const agent_projection_overlap_bytes: usize = 64;
 pub const max_public_handle_bytes: usize = 128;
+pub const CapturePolicy = enum {
+    best_effort,
+    required,
+};
 const model_handle_prefix = "\n<command_output_handle>";
 const model_handle_suffix = "</command_output_handle>\n" ++
     "Full captured command output is available through read_tool_result with this handle.";
@@ -153,68 +157,51 @@ pub const EphemeralStore = struct {
         self.* = undefined;
     }
 
-    fn createSpool(self: *EphemeralStore, alloc: Allocator) !OpenSpool {
+    fn createSpoolWithStem(
+        self: *EphemeralStore,
+        alloc: Allocator,
+        stem: []const u8,
+    ) !OpenSpool {
         if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
             return error.EphemeralReplayUnavailable;
         }
-        var attempt: usize = 0;
-        while (attempt < 8) : (attempt += 1) {
-            var random: [16]u8 = undefined;
-            try std.Io.randomSecure(io_mod.getIo(), &random);
-            const random_hex = std.fmt.bytesToHex(random, .lower);
-            const handle = try std.fmt.allocPrint(
-                alloc,
-                "fx-command-replay-{s}.bin",
-                .{&random_hex},
-            );
-            errdefer alloc.free(handle);
-            const temp_name = try std.fmt.allocPrint(
-                alloc,
-                ".fx-command-replay-{s}.tmp",
-                .{&random_hex},
-            );
-            defer alloc.free(temp_name);
-            const temp_path = try std.fs.path.join(alloc, &.{ self.temp_dir, temp_name });
-            defer alloc.free(temp_path);
-            var writer_file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), temp_path, .{
-                .read = true,
-                .exclusive = true,
-                .permissions = std.Io.File.Permissions.fromMode(0o600),
-            }) catch |err| switch (err) {
-                error.PathAlreadyExists => return error.ReplayNameCollision,
-                else => return error.EphemeralReplayUnavailable,
-            };
-            errdefer writer_file.close(io_mod.getIo());
-            std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), temp_path) catch
-                return error.EphemeralReplayUnavailable;
-            const stored_file = try duplicateFile(writer_file);
-            errdefer stored_file.close(io_mod.getIo());
-            const owned_handle = try self.alloc.dupe(u8, handle);
-            errdefer self.alloc.free(owned_handle);
+        const handle = try std.fmt.allocPrint(alloc, "{s}.bin", .{stem});
+        errdefer alloc.free(handle);
+        const temp_name = try std.fmt.allocPrint(alloc, ".{s}.tmp", .{stem});
+        defer alloc.free(temp_name);
+        const temp_path = try std.fs.path.join(alloc, &.{ self.temp_dir, temp_name });
+        defer alloc.free(temp_path);
+        var writer_file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), temp_path, .{
+            .read = true,
+            .exclusive = true,
+            .permissions = std.Io.File.Permissions.fromMode(0o600),
+        }) catch |err| switch (err) {
+            error.PathAlreadyExists => return error.ReplayNameCollision,
+            else => return error.EphemeralReplayUnavailable,
+        };
+        errdefer writer_file.close(io_mod.getIo());
+        std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), temp_path) catch
+            return error.EphemeralReplayUnavailable;
+        const stored_file = try duplicateFile(writer_file);
+        errdefer stored_file.close(io_mod.getIo());
+        const owned_handle = try self.alloc.dupe(u8, handle);
+        errdefer self.alloc.free(owned_handle);
 
-            const io = io_mod.getIo();
-            self.mutex.lockUncancelable(io);
-            defer self.mutex.unlock(io);
-            if (self.files.contains(handle)) {
-                self.alloc.free(owned_handle);
-                stored_file.close(io);
-                writer_file.close(io);
-                alloc.free(handle);
-                continue;
-            }
-            try self.files.put(self.alloc, owned_handle, stored_file);
-            @import("../shared/debug_trace.zig").logf(
-                "session",
-                "command replay ephemeral backing opened handle_bytes={d}",
-                .{handle.len},
-            );
-            return .{
-                .file = .{ .ephemeral = writer_file },
-                .handle = handle,
-                .framed_bytes = 0,
-            };
-        }
-        return error.ReplayNameCollision;
+        const io = io_mod.getIo();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        if (self.files.contains(handle)) return error.ReplayNameCollision;
+        try self.files.put(self.alloc, owned_handle, stored_file);
+        @import("../shared/debug_trace.zig").logf(
+            "session",
+            "command replay ephemeral backing opened handle_bytes={d}",
+            .{handle.len},
+        );
+        return .{
+            .file = .{ .ephemeral = writer_file },
+            .handle = handle,
+            .framed_bytes = 0,
+        };
     }
 
     fn open(self: *EphemeralStore, handle: []const u8) !ReplayFile {
@@ -285,6 +272,7 @@ pub const Capture = struct {
     inline_limit: usize,
     comparison_limit: usize,
     backing: ?ReplayBacking,
+    capture_policy: CapturePolicy = .best_effort,
     state: CaptureState = .{ .buffered = .empty },
     had_output: bool = false,
     sealed: bool = false,
@@ -317,6 +305,15 @@ pub const Capture = struct {
             .backing = .{ .ephemeral = store },
         };
         return capture;
+    }
+
+    pub fn setPolicyBeforeCapture(self: *Capture, replay_policy: CapturePolicy) void {
+        std.debug.assert(!self.had_output and !self.sealed);
+        self.capture_policy = replay_policy;
+    }
+
+    pub fn policy(self: *const Capture) CapturePolicy {
+        return self.capture_policy;
     }
 
     /// Records bytes only after the downstream callback accepted them.
@@ -807,31 +804,53 @@ fn createSpool(
     alloc: Allocator,
     backing: ReplayBacking,
 ) !OpenSpool {
-    if (backing == .ephemeral) return backing.ephemeral.createSpool(alloc);
-    const capability = backing.saved;
-    var attempt: usize = 0;
-    while (attempt < 8) : (attempt += 1) {
-        const handle = try std.fmt.allocPrint(
-            alloc,
-            "fx-command-replay-{d}-{d}-{d}.bin",
-            .{ std.c.getpid(), io_mod.nanoTimestamp(), attempt },
-        );
-        const file = capability.createExclusiveFile(
-            alloc,
-            .command_artifacts,
-            handle,
-        ) catch |err| {
-            alloc.free(handle);
-            if (err == error.PathAlreadyExists) continue;
-            return err;
-        };
-        return .{
-            .file = .{ .saved = file },
-            .handle = handle,
-            .framed_bytes = 0,
+    for (0..8) |_| {
+        const stem = try randomReplayStem(alloc);
+        defer alloc.free(stem);
+        return createSpoolWithStem(alloc, backing, stem) catch |err| switch (err) {
+            error.ReplayNameCollision => continue,
+            else => return err,
         };
     }
     return error.ReplayNameCollision;
+}
+
+fn randomReplayStem(alloc: Allocator) ![]u8 {
+    var random: [16]u8 = undefined;
+    try std.Io.randomSecure(io_mod.getIo(), &random);
+    const random_hex = std.fmt.bytesToHex(random, .lower);
+    return std.fmt.allocPrint(
+        alloc,
+        "fx-command-replay-{s}",
+        .{&random_hex},
+    );
+}
+
+fn createSpoolWithStem(
+    alloc: Allocator,
+    backing: ReplayBacking,
+    stem: []const u8,
+) !OpenSpool {
+    return switch (backing) {
+        .ephemeral => |store| store.createSpoolWithStem(alloc, stem),
+        .saved => |capability| blk: {
+            const handle = try std.fmt.allocPrint(alloc, "{s}.bin", .{stem});
+            errdefer alloc.free(handle);
+            const file = capability.createExclusiveFile(
+                alloc,
+                .command_artifacts,
+                handle,
+            ) catch |err| switch (err) {
+                error.PathAlreadyExists => return error.ReplayNameCollision,
+                else => return err,
+            };
+            break :blk .{
+                .file = .{ .saved = file },
+                .handle = handle,
+                .framed_bytes = 0,
+            };
+        },
+    };
 }
 
 fn contentAddressedHandle(
@@ -1434,6 +1453,67 @@ test "required command replay reports unavailable backing instead of dropping ou
     try std.testing.expectError(
         error.CommandOutputCaptureFailed,
         capture.appendAcceptedRequired(arena, .stderr, "still required\n"),
+    );
+}
+
+test "saved and ephemeral replay backings share collision handling" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(io_mod.getIo());
+    const display_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(display_path);
+    var capability = try session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        display_path,
+        .writable,
+        .{},
+    );
+    defer capability.deinit();
+
+    const stem = "fx-command-replay-fixed-collision";
+    var saved = try createSpoolWithStem(alloc, .{ .saved = &capability }, stem);
+    defer {
+        saved.file.deinit();
+        capability.delete(.command_artifacts, saved.handle) catch {};
+        alloc.free(saved.handle);
+    }
+    try std.testing.expectError(
+        error.ReplayNameCollision,
+        createSpoolWithStem(alloc, .{ .saved = &capability }, stem),
+    );
+
+    const temp_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(temp_path);
+    var ephemeral_store = EphemeralStore.initForTesting(alloc, temp_path);
+    defer ephemeral_store.deinit();
+    var ephemeral = try createSpoolWithStem(
+        alloc,
+        .{ .ephemeral = &ephemeral_store },
+        stem,
+    );
+    defer {
+        ephemeral.file.deinit();
+        ephemeral_store.delete(ephemeral.handle);
+        alloc.free(ephemeral.handle);
+    }
+    try std.testing.expectError(
+        error.ReplayNameCollision,
+        createSpoolWithStem(
+            alloc,
+            .{ .ephemeral = &ephemeral_store },
+            stem,
+        ),
     );
 }
 

--- a/src/core/session/command_replay_store.zig
+++ b/src/core/session/command_replay_store.zig
@@ -15,6 +15,7 @@ const frame_header_bytes: usize = 9;
 const max_frame_payload_bytes: usize = 1024 * 1024;
 const max_agent_line_bytes: usize = max_frame_payload_bytes;
 const agent_projection_overlap_bytes: usize = 64;
+pub const max_public_handle_bytes: usize = 128;
 
 const DecodedFrameHeader = struct {
     stream: Stream,
@@ -325,6 +326,7 @@ pub const Capture = struct {
         bytes: []const u8,
     ) !void {
         if (bytes.len == 0 or self.sealed) return;
+        if (self.state == .unavailable) return error.CommandOutputCaptureFailed;
         self.had_output = true;
         self.appendAcceptedFallible(alloc, stream, bytes) catch |err| {
             self.makeUnavailable(alloc, err);
@@ -1094,7 +1096,14 @@ const AgentProjectionReader = struct {
                 continue;
             }
             if (self.line.items.len == max_agent_line_bytes) {
-                if (containsModelSecretTrigger(self.line.items)) {
+                const masked = try text_utils.maskSecrets(alloc, self.line.items);
+                defer if (masked.ptr != self.line.items.ptr) alloc.free(@constCast(masked));
+                if (masked.ptr != self.line.items.ptr or
+                    text_utils.secretMayCrossBoundary(
+                        self.line.items,
+                        agent_projection_overlap_bytes,
+                    ))
+                {
                     self.line.clearRetainingCapacity();
                     self.discarding_sensitive_line = true;
                     if (next_byte.value == '\n') return try self.finishLine(alloc);
@@ -1144,42 +1153,6 @@ const AgentProjectionReader = struct {
     }
 };
 
-fn containsModelSecretTrigger(bytes: []const u8) bool {
-    const triggers = [_][]const u8{
-        "password",
-        "passwd",
-        "api_key",
-        "apikey",
-        "secret",
-        "token",
-        "private_key",
-        "access_key",
-        "https://",
-        "sk-",
-        "sk_live_",
-        "pk_live_",
-        "github_pat_",
-        "xoxb-",
-        "xoxp-",
-        "bearer ",
-        "ghp_",
-        "gho_",
-        "ghu_",
-        "ghs_",
-        "ghr_",
-        "akia",
-        "asia",
-        "aida",
-        "agpa",
-        "aroa",
-        "anpa",
-    };
-    for (triggers) |trigger| {
-        if (text_utils.containsIgnoreCase(bytes, trigger)) return true;
-    }
-    return false;
-}
-
 pub fn readAgentPageManaged(
     alloc: Allocator,
     capability: *session_child_store.SessionChildCapability,
@@ -1213,6 +1186,8 @@ fn readAgentPage(
 ) ![]u8 {
     const requested_start = if (start_byte == 0) 0 else start_byte - 1;
     var projected_offset: usize = 0;
+    var page_start: ?usize = null;
+    var page_closed = false;
     var page: std.ArrayList(u8) = .empty;
     defer page.deinit(alloc);
     var projector: AgentProjectionReader = .{ .reader = reader };
@@ -1221,12 +1196,13 @@ fn readAgentPage(
     while (try projector.next(alloc)) |block| {
         defer alloc.free(block);
         const block_end = try std.math.add(usize, projected_offset, block.len);
-        if (block_end > requested_start and page.items.len < byte_count) {
+        if (!page_closed and block_end > requested_start and page.items.len < byte_count) {
             const local_start = if (requested_start > projected_offset)
                 requested_start - projected_offset
             else
                 0;
             const safe_start = text_utils.utf8ForwardBoundary(block, local_start);
+            if (page_start == null) page_start = projected_offset + safe_start;
             const available = block.len - safe_start;
             const remaining = byte_count - page.items.len;
             const raw_end = safe_start + @min(available, remaining);
@@ -1234,11 +1210,14 @@ fn readAgentPage(
             if (safe_end > safe_start) {
                 try page.appendSlice(alloc, block[safe_start..safe_end]);
             }
+            if (safe_end < raw_end or page.items.len == byte_count) {
+                page_closed = true;
+            }
         }
         projected_offset = block_end;
     }
 
-    const response_start = @min(requested_start, projected_offset);
+    const response_start = page_start orelse @min(requested_start, projected_offset);
     const response_end = try std.math.add(usize, response_start, page.items.len);
     return std.fmt.allocPrint(
         alloc,
@@ -1433,6 +1412,10 @@ test "required command replay reports unavailable backing instead of dropping ou
         error.CommandOutputCaptureFailed,
         capture.appendAcceptedRequired(arena, .stdout, "required\n"),
     );
+    try std.testing.expectError(
+        error.CommandOutputCaptureFailed,
+        capture.appendAcceptedRequired(arena, .stderr, "still required\n"),
+    );
 }
 
 test "ephemeral command replay unlinks backing before publication and remains readable" {
@@ -1526,6 +1509,58 @@ test "agent command replay masks secrets split across callback frames" {
     try std.testing.expect(std.mem.find(u8, query, "needle split across frames") != null);
 }
 
+test "agent command replay pages stay contiguous across utf8 boundaries" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const temp_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(temp_path);
+    var store = EphemeralStore.initForTesting(alloc, temp_path);
+    defer store.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const capture = try Capture.createEphemeral(arena, 0, &store);
+    try capture.appendAcceptedRequired(arena, .stdout, "ab\xe2\x98\x83cd\n");
+    const descriptor = (try capture.retainRequired(arena)) orelse
+        return error.TestExpectedReplay;
+    defer capture.releaseRetained(arena);
+
+    const first = try readAgentPageEphemeral(
+        alloc,
+        &store,
+        descriptor.handle,
+        1,
+        12,
+    );
+    defer alloc.free(first);
+    try std.testing.expect(std.mem.find(u8, first, "start_byte=\"1\"") != null);
+    try std.testing.expect(std.mem.find(u8, first, "end_byte=\"11\"") != null);
+    const first_body_start = (std.mem.find(u8, first, ">\n") orelse
+        return error.TestExpectedReplay) + 2;
+    const first_body_end = std.mem.findPos(
+        u8,
+        first,
+        first_body_start,
+        "</command_output>",
+    ) orelse return error.TestExpectedReplay;
+    const first_body = first[first_body_start..first_body_end];
+    try std.testing.expect(std.mem.find(u8, first_body, "ab") != null);
+    try std.testing.expect(std.mem.find(u8, first_body, "cd") == null);
+
+    const second = try readAgentPageEphemeral(
+        alloc,
+        &store,
+        descriptor.handle,
+        12,
+        4096,
+    );
+    defer alloc.free(second);
+    try std.testing.expect(std.mem.find(u8, second, "start_byte=\"12\"") != null);
+    try std.testing.expect(std.mem.find(u8, second, "\xe2\x98\x83cd") != null);
+}
+
 test "agent command replay keeps split utf8 valid and omits oversized secret-bearing lines" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -1581,6 +1616,7 @@ test "agent command replay streams non-secret oversized lines without omission" 
     const capture = try Capture.createEphemeral(arena, 0, &store);
     const chunk = try arena.alloc(u8, max_agent_line_bytes / 2);
     @memset(chunk, 'x');
+    try capture.appendAcceptedRequired(arena, .stdout, "https://example.com ");
     try capture.appendAcceptedRequired(arena, .stdout, chunk);
     try capture.appendAcceptedRequired(arena, .stdout, chunk);
     try capture.appendAcceptedRequired(arena, .stdout, "NONSECRET-LATE-SENTINEL\n");

--- a/src/core/session/command_replay_store.zig
+++ b/src/core/session/command_replay_store.zig
@@ -16,6 +16,25 @@ const max_frame_payload_bytes: usize = 1024 * 1024;
 const max_agent_line_bytes: usize = max_frame_payload_bytes;
 const agent_projection_overlap_bytes: usize = 64;
 pub const max_public_handle_bytes: usize = 128;
+const model_handle_prefix = "\n<command_output_handle>";
+const model_handle_suffix = "</command_output_handle>\n" ++
+    "Full captured command output is available through read_tool_result with this handle.";
+pub const model_handle_notice_reserve_bytes = model_handle_prefix.len +
+    max_public_handle_bytes +
+    model_handle_suffix.len;
+
+pub fn appendModelHandleNotice(
+    alloc: Allocator,
+    model_output: []const u8,
+    handle: []const u8,
+) ![]u8 {
+    if (handle.len > max_public_handle_bytes) return error.InvalidReplayHandle;
+    return std.fmt.allocPrint(
+        alloc,
+        "{s}{s}{s}{s}",
+        .{ model_output, model_handle_prefix, handle, model_handle_suffix },
+    );
+}
 
 const DecodedFrameHeader = struct {
     stream: Stream,

--- a/src/core/session/command_replay_store.zig
+++ b/src/core/session/command_replay_store.zig
@@ -1601,6 +1601,52 @@ test "agent command replay keeps split utf8 valid and omits oversized secret-bea
     try std.testing.expect(std.mem.find(u8, page, "after oversized line") != null);
 }
 
+test "agent command replay omits oversized sensitive assignments split after delimiters" {
+    const alloc = std.testing.allocator;
+    const delimiters = [_][]const u8{ "=", "=\"", "='" };
+
+    for (delimiters) |delimiter| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const temp_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+        defer alloc.free(temp_path);
+        var store = EphemeralStore.initForTesting(alloc, temp_path);
+        defer store.deinit();
+        var arena_state = std.heap.ArenaAllocator.init(alloc);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+
+        const key =
+            "MY_VERY_LONG_TOKEN_KEY_THAT_CONTINUES_BEYOND_THE_RETAINED_" ++
+            "SIXTY_FOUR_BYTE_SUFFIX";
+        const prefix_len = max_agent_line_bytes - key.len - delimiter.len;
+        const prefix = try arena.alloc(u8, prefix_len);
+        @memset(prefix, 'x');
+
+        const capture = try Capture.createEphemeral(arena, 0, &store);
+        try capture.appendAcceptedRequired(arena, .stdout, prefix);
+        try capture.appendAcceptedRequired(arena, .stdout, key);
+        try capture.appendAcceptedRequired(arena, .stdout, delimiter);
+        try capture.appendAcceptedRequired(arena, .stdout, "secret-after-boundary\nafter line\n");
+        const descriptor = (try capture.retainRequired(arena)) orelse
+            return error.TestExpectedReplay;
+        defer capture.releaseRetained(arena);
+
+        const page = try readAgentPageEphemeral(
+            alloc,
+            &store,
+            descriptor.handle,
+            1,
+            4096,
+        );
+        defer alloc.free(page);
+        try std.testing.expect(std.mem.find(u8, page, "output line omitted") != null);
+        try std.testing.expect(std.mem.find(u8, page, "MY_VERY_LONG_TOKEN_KEY") == null);
+        try std.testing.expect(std.mem.find(u8, page, "secret-after-boundary") == null);
+        try std.testing.expect(std.mem.find(u8, page, "after line") != null);
+    }
+}
+
 test "agent command replay streams non-secret oversized lines without omission" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/core/session/command_replay_store.zig
+++ b/src/core/session/command_replay_store.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const command_output_content = @import("../tooling/command_output_content.zig");
 const io_mod = @import("../shared/io.zig");
+const text_utils = @import("../shared/text_utils.zig");
 const types = @import("../shared/types.zig");
 const artifact_digest = @import("artifact_digest.zig");
 const session_child_store = @import("session_child_store.zig");
@@ -11,6 +13,8 @@ const Stream = command_output_content.Stream;
 const replay_magic = "FXRPLY01";
 const frame_header_bytes: usize = 9;
 const max_frame_payload_bytes: usize = 1024 * 1024;
+const max_agent_line_bytes: usize = max_frame_payload_bytes;
+const agent_projection_overlap_bytes: usize = 64;
 
 const DecodedFrameHeader = struct {
     stream: Stream,
@@ -32,8 +36,204 @@ fn decodeFrameHeader(header: []const u8) !DecodedFrameHeader {
     return .{ .stream = stream, .payload_len = payload_len };
 }
 
+const ReplayFile = union(enum) {
+    saved: session_child_store.ManagedFile,
+    ephemeral: std.Io.File,
+
+    fn deinit(self: *ReplayFile) void {
+        switch (self.*) {
+            .saved => |*file| file.deinit(),
+            .ephemeral => |file| file.close(io_mod.getIo()),
+        }
+        self.* = undefined;
+    }
+
+    fn writeAll(self: *ReplayFile, bytes: []const u8) !void {
+        switch (self.*) {
+            .saved => |*file| try file.writeAll(bytes),
+            .ephemeral => |file| try file.writeStreamingAll(io_mod.getIo(), bytes),
+        }
+    }
+
+    fn sync(self: *ReplayFile) !void {
+        switch (self.*) {
+            .saved => |*file| try file.sync(),
+            .ephemeral => |file| try file.sync(io_mod.getIo()),
+        }
+    }
+
+    fn size(self: *ReplayFile) !usize {
+        const raw_size = switch (self.*) {
+            .saved => |*file| (try file.stat()).size,
+            .ephemeral => |file| (try file.stat(io_mod.getIo())).size,
+        };
+        return std.math.cast(usize, raw_size) orelse error.ReplayTooLarge;
+    }
+
+    fn readRange(
+        self: *ReplayFile,
+        alloc: Allocator,
+        start: u64,
+        len: usize,
+    ) ![]u8 {
+        return switch (self.*) {
+            .saved => |*file| file.readRange(alloc, start, len),
+            .ephemeral => |file| readFileRange(alloc, file, start, len),
+        };
+    }
+
+    fn readRangeInto(self: *ReplayFile, start: u64, out: []u8) !usize {
+        return switch (self.*) {
+            .saved => |*file| file.readRangeInto(start, out),
+            .ephemeral => |file| readFileRangeInto(file, start, out),
+        };
+    }
+};
+
+fn readFileRange(
+    alloc: Allocator,
+    file: std.Io.File,
+    start: u64,
+    len: usize,
+) ![]u8 {
+    if (len == 0) return alloc.dupe(u8, "");
+    const out = try alloc.alloc(u8, len);
+    errdefer alloc.free(out);
+    const read_len = try readFileRangeInto(file, start, out);
+    if (read_len == out.len) return out;
+    return alloc.realloc(out, read_len);
+}
+
+fn readFileRangeInto(file: std.Io.File, start: u64, out: []u8) !usize {
+    if (out.len == 0) return 0;
+    return file.readPositionalAll(io_mod.getIo(), out, start);
+}
+
+pub const EphemeralStore = struct {
+    alloc: Allocator,
+    temp_dir: []const u8,
+    files: std.StringHashMapUnmanaged(std.Io.File) = .empty,
+    mutex: std.Io.Mutex = .init,
+
+    pub fn init(alloc: Allocator) EphemeralStore {
+        return .{ .alloc = alloc, .temp_dir = "/tmp" };
+    }
+
+    pub fn initForTesting(alloc: Allocator, temp_dir: []const u8) EphemeralStore {
+        return .{ .alloc = alloc, .temp_dir = temp_dir };
+    }
+
+    pub fn deinit(self: *EphemeralStore) void {
+        var iterator = self.files.iterator();
+        while (iterator.next()) |entry| {
+            entry.value_ptr.*.close(io_mod.getIo());
+            self.alloc.free(entry.key_ptr.*);
+        }
+        self.files.deinit(self.alloc);
+        self.* = undefined;
+    }
+
+    fn createSpool(self: *EphemeralStore, alloc: Allocator) !OpenSpool {
+        if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+            return error.EphemeralReplayUnavailable;
+        }
+        var attempt: usize = 0;
+        while (attempt < 8) : (attempt += 1) {
+            var random: [16]u8 = undefined;
+            try std.Io.randomSecure(io_mod.getIo(), &random);
+            const random_hex = std.fmt.bytesToHex(random, .lower);
+            const handle = try std.fmt.allocPrint(
+                alloc,
+                "fx-command-replay-{s}.bin",
+                .{&random_hex},
+            );
+            errdefer alloc.free(handle);
+            const temp_name = try std.fmt.allocPrint(
+                alloc,
+                ".fx-command-replay-{s}.tmp",
+                .{&random_hex},
+            );
+            defer alloc.free(temp_name);
+            const temp_path = try std.fs.path.join(alloc, &.{ self.temp_dir, temp_name });
+            defer alloc.free(temp_path);
+            var writer_file = std.Io.Dir.createFileAbsolute(io_mod.getIo(), temp_path, .{
+                .read = true,
+                .exclusive = true,
+                .permissions = std.Io.File.Permissions.fromMode(0o600),
+            }) catch |err| switch (err) {
+                error.PathAlreadyExists => return error.ReplayNameCollision,
+                else => return error.EphemeralReplayUnavailable,
+            };
+            errdefer writer_file.close(io_mod.getIo());
+            std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), temp_path) catch
+                return error.EphemeralReplayUnavailable;
+            const stored_file = try duplicateFile(writer_file);
+            errdefer stored_file.close(io_mod.getIo());
+            const owned_handle = try self.alloc.dupe(u8, handle);
+            errdefer self.alloc.free(owned_handle);
+
+            const io = io_mod.getIo();
+            self.mutex.lockUncancelable(io);
+            defer self.mutex.unlock(io);
+            if (self.files.contains(handle)) {
+                self.alloc.free(owned_handle);
+                stored_file.close(io);
+                writer_file.close(io);
+                alloc.free(handle);
+                continue;
+            }
+            try self.files.put(self.alloc, owned_handle, stored_file);
+            @import("../shared/debug_trace.zig").logf(
+                "session",
+                "command replay ephemeral backing opened handle_bytes={d}",
+                .{handle.len},
+            );
+            return .{
+                .file = .{ .ephemeral = writer_file },
+                .handle = handle,
+                .framed_bytes = 0,
+            };
+        }
+        return error.ReplayNameCollision;
+    }
+
+    fn open(self: *EphemeralStore, handle: []const u8) !ReplayFile {
+        const io = io_mod.getIo();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        const file = self.files.get(handle) orelse return error.ResultHandleNotFound;
+        return .{ .ephemeral = try duplicateFile(file) };
+    }
+
+    fn delete(self: *EphemeralStore, handle: []const u8) void {
+        const io = io_mod.getIo();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+        const removed = self.files.fetchRemove(handle) orelse return;
+        removed.value.close(io);
+        self.alloc.free(removed.key);
+    }
+};
+
+fn duplicateFile(file: std.Io.File) !std.Io.File {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.EphemeralReplayUnavailable;
+    }
+    const duplicated = std.c.fcntl(file.handle, std.c.F.DUPFD_CLOEXEC, @as(std.c.fd_t, 0));
+    if (duplicated < 0) return error.EphemeralReplayUnavailable;
+    return .{
+        .handle = @intCast(duplicated),
+        .flags = file.flags,
+    };
+}
+
+const ReplayBacking = union(enum) {
+    saved: *session_child_store.SessionChildCapability,
+    ephemeral: *EphemeralStore,
+};
+
 const OpenSpool = struct {
-    file: session_child_store.ManagedFile,
+    file: ReplayFile,
     handle: []u8,
     framed_bytes: usize,
 };
@@ -64,7 +264,7 @@ const CaptureState = union(enum) {
 pub const Capture = struct {
     inline_limit: usize,
     comparison_limit: usize,
-    capability: ?*session_child_store.SessionChildCapability,
+    backing: ?ReplayBacking,
     state: CaptureState = .{ .buffered = .empty },
     had_output: bool = false,
     sealed: bool = false,
@@ -80,7 +280,21 @@ pub const Capture = struct {
         capture.* = .{
             .inline_limit = inline_limit,
             .comparison_limit = inline_limit,
-            .capability = capability,
+            .backing = if (capability) |value| .{ .saved = value } else null,
+        };
+        return capture;
+    }
+
+    pub fn createEphemeral(
+        alloc: Allocator,
+        inline_limit: usize,
+        store: *EphemeralStore,
+    ) !*Capture {
+        const capture = try alloc.create(Capture);
+        capture.* = .{
+            .inline_limit = inline_limit,
+            .comparison_limit = inline_limit,
+            .backing = .{ .ephemeral = store },
         };
         return capture;
     }
@@ -99,6 +313,27 @@ pub const Capture = struct {
             self.makeUnavailable(alloc, err);
             return;
         };
+        self.updateDigest(stream, bytes);
+    }
+
+    /// Records required command output. Any storage failure becomes visible so
+    /// the execution owner can stop the command instead of losing later bytes.
+    pub fn appendAcceptedRequired(
+        self: *Capture,
+        alloc: Allocator,
+        stream: Stream,
+        bytes: []const u8,
+    ) !void {
+        if (bytes.len == 0 or self.sealed) return;
+        self.had_output = true;
+        self.appendAcceptedFallible(alloc, stream, bytes) catch |err| {
+            self.makeUnavailable(alloc, err);
+            return error.CommandOutputCaptureFailed;
+        };
+        self.updateDigest(stream, bytes);
+    }
+
+    fn updateDigest(self: *Capture, stream: Stream, bytes: []const u8) void {
         if (!self.digest_started) {
             self.content_hasher.update(replay_magic);
             self.digest_started = true;
@@ -159,8 +394,8 @@ pub const Capture = struct {
         header: []const u8,
         bytes: []const u8,
     ) !void {
-        const capability = self.capability orelse return error.ReplayStoreUnavailable;
-        var spool = try createSpool(alloc, capability);
+        const backing = self.backing orelse return error.ReplayStoreUnavailable;
+        var spool = try createSpool(alloc, backing);
         var transferred = false;
         errdefer if (!transferred) {
             spool.file.deinit();
@@ -186,27 +421,16 @@ pub const Capture = struct {
         transferred = true;
     }
 
-    /// Closes and synchronizes any spool before the capture leaves tool runtime.
-    pub fn seal(self: *Capture, alloc: Allocator) void {
+    fn sealFallible(self: *Capture, alloc: Allocator) !void {
         if (self.sealed) return;
         self.sealed = true;
         switch (self.state) {
             .streaming => |*spool| {
-                spool.file.sync() catch |err| {
-                    self.makeUnavailable(alloc, err);
-                    return;
-                };
+                try spool.file.sync();
                 var digest: [Sha256.digest_length]u8 = undefined;
                 var hasher = self.content_hasher;
                 hasher.final(&digest);
-                self.contentAddressSpool(
-                    alloc,
-                    spool,
-                    digest,
-                ) catch |err| {
-                    self.makeUnavailable(alloc, err);
-                    return;
-                };
+                try self.contentAddressSpool(alloc, spool, digest);
                 const descriptor = OwnedDescriptor{
                     .handle = spool.handle,
                     .framed_bytes = spool.framed_bytes,
@@ -216,6 +440,19 @@ pub const Capture = struct {
             },
             else => {},
         }
+    }
+
+    /// Closes and synchronizes any spool before the capture leaves tool runtime.
+    pub fn seal(self: *Capture, alloc: Allocator) void {
+        self.sealFallible(alloc) catch |err| self.makeUnavailable(alloc, err);
+    }
+
+    pub fn sealRequired(self: *Capture, alloc: Allocator) !void {
+        self.sealFallible(alloc) catch |err| {
+            self.makeUnavailable(alloc, err);
+            return error.CommandOutputCaptureFailed;
+        };
+        if (self.state == .unavailable) return error.CommandOutputCaptureFailed;
     }
 
     pub fn hasOutput(self: *const Capture) bool {
@@ -265,8 +502,8 @@ pub const Capture = struct {
         descriptor: OwnedDescriptor,
         max_payload_bytes: usize,
     ) !command_output_content.CanonicalOutput {
-        const capability = self.capability orelse return error.ReplayStoreUnavailable;
-        var reader = try Reader.open(alloc, capability, descriptor.view());
+        const backing = self.backing orelse return error.ReplayStoreUnavailable;
+        var reader = try Reader.openBacking(alloc, backing, descriptor.view());
         defer reader.deinit();
         var output: command_output_content.CanonicalOutput = .{};
         errdefer output.deinit(alloc);
@@ -364,13 +601,47 @@ pub const Capture = struct {
         };
     }
 
+    /// Retains required replay as one durable descriptor. The caller receives
+    /// a borrowed view and the capture remains the cleanup owner until handoff.
+    pub fn retainRequired(
+        self: *Capture,
+        alloc: Allocator,
+    ) !?types.CommandOutputReplayDescriptor {
+        try self.sealRequired(alloc);
+        if (!self.had_output) {
+            self.abort(alloc);
+            return null;
+        }
+        return switch (self.state) {
+            .buffered => |*buffered| blk: {
+                const descriptor = self.materializeInline(alloc, buffered) catch |err| {
+                    self.makeUnavailable(alloc, err);
+                    return error.CommandOutputCaptureFailed;
+                };
+                self.state = .{ .retained = descriptor };
+                break :blk descriptor.view();
+            },
+            .sealed_file => |descriptor| blk: {
+                self.state = .{ .retained = descriptor };
+                break :blk descriptor.view();
+            },
+            .retained => |descriptor| if (descriptor) |value|
+                value.view()
+            else
+                return error.CommandOutputCaptureFailed,
+            .unavailable => return error.CommandOutputCaptureFailed,
+            .streaming => unreachable,
+            .consumed => null,
+        };
+    }
+
     fn materializeInline(
         self: *Capture,
         alloc: Allocator,
         buffered: *std.ArrayList(u8),
     ) !OwnedDescriptor {
-        const capability = self.capability orelse return error.ReplayStoreUnavailable;
-        var spool = try createSpool(alloc, capability);
+        const backing = self.backing orelse return error.ReplayStoreUnavailable;
+        var spool = try createSpool(alloc, backing);
         var transferred = false;
         errdefer if (!transferred) {
             spool.file.deinit();
@@ -398,8 +669,9 @@ pub const Capture = struct {
         spool: *OpenSpool,
         digest: [Sha256.digest_length]u8,
     ) !void {
-        const capability = self.capability orelse
-            return error.ReplayStoreUnavailable;
+        const backing = self.backing orelse return error.ReplayStoreUnavailable;
+        if (backing == .ephemeral) return;
+        const capability = backing.saved;
         const target_handle = try contentAddressedHandle(
             alloc,
             spool.handle,
@@ -496,21 +768,26 @@ pub const Capture = struct {
     }
 
     fn deleteSpool(self: *Capture, handle: []const u8) void {
-        const capability = self.capability orelse return;
-        capability.delete(.command_artifacts, handle) catch |err| {
-            @import("../shared/debug_trace.zig").logf(
-                "session",
-                "command replay orphan cleanup failed handle_bytes={d} err={s}",
-                .{ handle.len, @errorName(err) },
-            );
-        };
+        const backing = self.backing orelse return;
+        switch (backing) {
+            .saved => |capability| capability.delete(.command_artifacts, handle) catch |err| {
+                @import("../shared/debug_trace.zig").logf(
+                    "session",
+                    "command replay orphan cleanup failed handle_bytes={d} err={s}",
+                    .{ handle.len, @errorName(err) },
+                );
+            },
+            .ephemeral => |store| store.delete(handle),
+        }
     }
 };
 
 fn createSpool(
     alloc: Allocator,
-    capability: *session_child_store.SessionChildCapability,
+    backing: ReplayBacking,
 ) !OpenSpool {
+    if (backing == .ephemeral) return backing.ephemeral.createSpool(alloc);
+    const capability = backing.saved;
     var attempt: usize = 0;
     while (attempt < 8) : (attempt += 1) {
         const handle = try std.fmt.allocPrint(
@@ -528,7 +805,7 @@ fn createSpool(
             return err;
         };
         return .{
-            .file = file,
+            .file = .{ .saved = file },
             .handle = handle,
             .framed_bytes = 0,
         };
@@ -578,7 +855,7 @@ pub const Byte = struct {
 };
 
 pub const Reader = struct {
-    file: session_child_store.ManagedFile,
+    file: ReplayFile,
     size: usize,
     offset: usize,
     byte_buffer: [8192]u8 = undefined,
@@ -592,36 +869,80 @@ pub const Reader = struct {
         capability: *session_child_store.SessionChildCapability,
         descriptor: types.CommandOutputReplayDescriptor,
     ) !Reader {
-        var reader: Reader = undefined;
-        try openInto(&reader, alloc, capability, descriptor);
-        return reader;
+        return openBacking(alloc, .{ .saved = capability }, descriptor);
     }
 
-    // noinline keeps the comptime-known error returns behind a call
-    // boundary; inlined into a `!Reader` result location they each
-    // materialize a Reader-sized (~8KB) error-union constant.
-    noinline fn openInto(
-        reader: *Reader,
+    fn openBacking(
+        alloc: Allocator,
+        backing: ReplayBacking,
+        descriptor: types.CommandOutputReplayDescriptor,
+    ) !Reader {
+        var file = switch (backing) {
+            .saved => |capability| ReplayFile{ .saved = try capability.openFileReadOnly(
+                alloc,
+                .command_artifacts,
+                descriptor.handle,
+            ) },
+            .ephemeral => |store| try store.open(descriptor.handle),
+        };
+        const size = file.size() catch |err| {
+            file.deinit();
+            return err;
+        };
+        if (size != descriptor.framed_bytes) {
+            file.deinit();
+            return error.ReplaySizeMismatch;
+        }
+        return initialize(alloc, file, size);
+    }
+
+    pub fn openHandle(
         alloc: Allocator,
         capability: *session_child_store.SessionChildCapability,
-        descriptor: types.CommandOutputReplayDescriptor,
-    ) !void {
-        var file = try capability.openFileReadOnly(
+        handle: []const u8,
+    ) !Reader {
+        if (!hasContentDigest(handle)) return error.ResultHandleNotFound;
+        var file = ReplayFile{ .saved = capability.openFileReadOnly(
             alloc,
             .command_artifacts,
-            descriptor.handle,
-        );
-        errdefer file.deinit();
-        const stat = try file.stat();
-        const size = std.math.cast(usize, stat.size) orelse
-            return error.ReplayTooLarge;
-        if (size != descriptor.framed_bytes) return error.ReplaySizeMismatch;
+            handle,
+        ) catch |err| switch (err) {
+            error.FileNotFound => return error.ResultHandleNotFound,
+            else => return err,
+        } };
+        const size = file.size() catch |err| {
+            file.deinit();
+            return err;
+        };
+        return initialize(alloc, file, size);
+    }
+
+    pub fn openEphemeralHandle(
+        alloc: Allocator,
+        store: *EphemeralStore,
+        handle: []const u8,
+    ) !Reader {
+        var file = try store.open(handle);
+        const size = file.size() catch |err| {
+            file.deinit();
+            return err;
+        };
+        return initialize(alloc, file, size);
+    }
+
+    noinline fn initialize(
+        alloc: Allocator,
+        file: ReplayFile,
+        size: usize,
+    ) !Reader {
+        var owned_file = file;
+        errdefer owned_file.deinit();
         if (size < replay_magic.len) return error.InvalidReplayHeader;
-        const magic = try readExactRange(alloc, &file, 0, replay_magic.len);
+        const magic = try readExactRange(alloc, &owned_file, 0, replay_magic.len);
         defer alloc.free(magic);
         if (!std.mem.eql(u8, magic, replay_magic)) return error.InvalidReplayHeader;
-        reader.* = .{
-            .file = file,
+        return .{
+            .file = owned_file,
             .size = size,
             .offset = replay_magic.len,
         };
@@ -711,8 +1032,282 @@ pub const Reader = struct {
     }
 };
 
+fn projectedOutput(
+    alloc: Allocator,
+    stream: Stream,
+    payload: []const u8,
+) ![]u8 {
+    const masked = try text_utils.maskSecrets(alloc, payload);
+    defer if (masked.ptr != payload.ptr) alloc.free(@constCast(masked));
+    const max_encoded_bytes = std.math.mul(usize, masked.len, 12) catch
+        return error.OutOfMemory;
+    var encoded = try text_utils.encodeTerminalSafe(
+        alloc,
+        masked,
+        max_encoded_bytes,
+    );
+    defer encoded.deinit(alloc);
+    const stream_name = @tagName(stream);
+    return std.fmt.allocPrint(
+        alloc,
+        "[{s}]\n{s}\n[/{s}]\n",
+        .{ stream_name, encoded.bytes, stream_name },
+    );
+}
+
+const AgentProjectionReader = struct {
+    reader: *Reader,
+    line: std.ArrayList(u8) = .empty,
+    stream: ?Stream = null,
+    pending_byte: ?Byte = null,
+    discarding_sensitive_line: bool = false,
+
+    fn deinit(self: *AgentProjectionReader, alloc: Allocator) void {
+        self.line.deinit(alloc);
+        self.* = undefined;
+    }
+
+    /// Projects logical lines so masking cannot be bypassed by a secret split
+    /// across callback frames. Non-secret oversized lines stream in bounded
+    /// chunks; suspicious oversized lines are suppressed conservatively.
+    fn next(self: *AgentProjectionReader, alloc: Allocator) !?[]u8 {
+        while (true) {
+            const next_byte = if (self.pending_byte) |byte| blk: {
+                self.pending_byte = null;
+                break :blk byte;
+            } else (try self.reader.nextByte()) orelse {
+                if (self.stream == null) return null;
+                return try self.finishLine(alloc);
+            };
+
+            if (self.stream) |stream| {
+                if (stream != next_byte.stream) {
+                    self.pending_byte = next_byte;
+                    return try self.finishLine(alloc);
+                }
+            } else {
+                self.stream = next_byte.stream;
+            }
+
+            if (self.discarding_sensitive_line) {
+                if (next_byte.value == '\n') return try self.finishLine(alloc);
+                continue;
+            }
+            if (self.line.items.len == max_agent_line_bytes) {
+                if (containsModelSecretTrigger(self.line.items)) {
+                    self.line.clearRetainingCapacity();
+                    self.discarding_sensitive_line = true;
+                    if (next_byte.value == '\n') return try self.finishLine(alloc);
+                    continue;
+                }
+                self.pending_byte = next_byte;
+                return try self.finishChunk(alloc);
+            }
+            try self.line.append(alloc, next_byte.value);
+            if (next_byte.value == '\n') return try self.finishLine(alloc);
+        }
+    }
+
+    fn finishLine(self: *AgentProjectionReader, alloc: Allocator) ![]u8 {
+        const stream = self.stream.?;
+        defer {
+            self.line.clearRetainingCapacity();
+            self.stream = null;
+            self.discarding_sensitive_line = false;
+        }
+        if (self.discarding_sensitive_line) {
+            const stream_name = @tagName(stream);
+            return std.fmt.allocPrint(
+                alloc,
+                "[{s}]\n[secret-bearing output line omitted after {d} bytes]\n[/{s}]\n",
+                .{ stream_name, max_agent_line_bytes, stream_name },
+            );
+        }
+        return projectedOutput(alloc, stream, self.line.items);
+    }
+
+    fn finishChunk(self: *AgentProjectionReader, alloc: Allocator) ![]u8 {
+        std.debug.assert(self.line.items.len == max_agent_line_bytes);
+        const flush_len = self.line.items.len - agent_projection_overlap_bytes;
+        const projected = try projectedOutput(
+            alloc,
+            self.stream.?,
+            self.line.items[0..flush_len],
+        );
+        std.mem.copyForwards(
+            u8,
+            self.line.items[0..agent_projection_overlap_bytes],
+            self.line.items[flush_len..],
+        );
+        self.line.shrinkRetainingCapacity(agent_projection_overlap_bytes);
+        return projected;
+    }
+};
+
+fn containsModelSecretTrigger(bytes: []const u8) bool {
+    const triggers = [_][]const u8{
+        "password",
+        "passwd",
+        "api_key",
+        "apikey",
+        "secret",
+        "token",
+        "private_key",
+        "access_key",
+        "https://",
+        "sk-",
+        "sk_live_",
+        "pk_live_",
+        "github_pat_",
+        "xoxb-",
+        "xoxp-",
+        "bearer ",
+        "ghp_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+        "akia",
+        "asia",
+        "aida",
+        "agpa",
+        "aroa",
+        "anpa",
+    };
+    for (triggers) |trigger| {
+        if (text_utils.containsIgnoreCase(bytes, trigger)) return true;
+    }
+    return false;
+}
+
+pub fn readAgentPageManaged(
+    alloc: Allocator,
+    capability: *session_child_store.SessionChildCapability,
+    handle: []const u8,
+    start_byte: usize,
+    byte_count: usize,
+) ![]u8 {
+    var reader = try Reader.openHandle(alloc, capability, handle);
+    defer reader.deinit();
+    return readAgentPage(alloc, &reader, handle, start_byte, byte_count);
+}
+
+pub fn readAgentPageEphemeral(
+    alloc: Allocator,
+    store: *EphemeralStore,
+    handle: []const u8,
+    start_byte: usize,
+    byte_count: usize,
+) ![]u8 {
+    var reader = try Reader.openEphemeralHandle(alloc, store, handle);
+    defer reader.deinit();
+    return readAgentPage(alloc, &reader, handle, start_byte, byte_count);
+}
+
+fn readAgentPage(
+    alloc: Allocator,
+    reader: *Reader,
+    handle: []const u8,
+    start_byte: usize,
+    byte_count: usize,
+) ![]u8 {
+    const requested_start = if (start_byte == 0) 0 else start_byte - 1;
+    var projected_offset: usize = 0;
+    var page: std.ArrayList(u8) = .empty;
+    defer page.deinit(alloc);
+    var projector: AgentProjectionReader = .{ .reader = reader };
+    defer projector.deinit(alloc);
+
+    while (try projector.next(alloc)) |block| {
+        defer alloc.free(block);
+        const block_end = try std.math.add(usize, projected_offset, block.len);
+        if (block_end > requested_start and page.items.len < byte_count) {
+            const local_start = if (requested_start > projected_offset)
+                requested_start - projected_offset
+            else
+                0;
+            const safe_start = text_utils.utf8ForwardBoundary(block, local_start);
+            const available = block.len - safe_start;
+            const remaining = byte_count - page.items.len;
+            const raw_end = safe_start + @min(available, remaining);
+            const safe_end = text_utils.utf8BackwardBoundary(block, raw_end);
+            if (safe_end > safe_start) {
+                try page.appendSlice(alloc, block[safe_start..safe_end]);
+            }
+        }
+        projected_offset = block_end;
+    }
+
+    const response_start = @min(requested_start, projected_offset);
+    const response_end = try std.math.add(usize, response_start, page.items.len);
+    return std.fmt.allocPrint(
+        alloc,
+        "<command_output handle=\"{s}\" start_byte=\"{d}\" end_byte=\"{d}\" total_bytes=\"{d}\">\n{s}</command_output>",
+        .{ handle, response_start + 1, response_end, projected_offset, page.items },
+    );
+}
+
+pub fn searchAgentQueryManaged(
+    alloc: Allocator,
+    capability: *session_child_store.SessionChildCapability,
+    handle: []const u8,
+    query: []const u8,
+    max_response_bytes: usize,
+) ![]u8 {
+    const trimmed_query = std.mem.trim(u8, query, " \t\r\n");
+    if (trimmed_query.len == 0) return error.InvalidQuery;
+    var reader = try Reader.openHandle(alloc, capability, handle);
+    defer reader.deinit();
+    return searchAgentQuery(alloc, &reader, handle, trimmed_query, max_response_bytes);
+}
+
+pub fn searchAgentQueryEphemeral(
+    alloc: Allocator,
+    store: *EphemeralStore,
+    handle: []const u8,
+    query: []const u8,
+    max_response_bytes: usize,
+) ![]u8 {
+    const trimmed_query = std.mem.trim(u8, query, " \t\r\n");
+    if (trimmed_query.len == 0) return error.InvalidQuery;
+    var reader = try Reader.openEphemeralHandle(alloc, store, handle);
+    defer reader.deinit();
+    return searchAgentQuery(alloc, &reader, handle, trimmed_query, max_response_bytes);
+}
+
+fn searchAgentQuery(
+    alloc: Allocator,
+    reader: *Reader,
+    handle: []const u8,
+    trimmed_query: []const u8,
+    max_response_bytes: usize,
+) ![]u8 {
+    var matches: std.ArrayList(u8) = .empty;
+    defer matches.deinit(alloc);
+    var match_count: usize = 0;
+    var projector: AgentProjectionReader = .{ .reader = reader };
+    defer projector.deinit(alloc);
+
+    while (try projector.next(alloc)) |block| {
+        defer alloc.free(block);
+        if (std.mem.find(u8, block, trimmed_query) == null) continue;
+        const remaining = max_response_bytes -| matches.items.len;
+        if (remaining == 0) break;
+        const end = text_utils.utf8BackwardBoundary(block, @min(block.len, remaining));
+        if (end > 0) try matches.appendSlice(alloc, block[0..end]);
+        match_count += 1;
+        if (match_count >= 50 or matches.items.len >= max_response_bytes) break;
+    }
+    if (match_count == 0) try matches.appendSlice(alloc, "(no matches)\n");
+    return std.fmt.allocPrint(
+        alloc,
+        "<command_output_query handle=\"{s}\">\nquery: {f}\n{s}</command_output_query>",
+        .{ handle, std.json.fmt(trimmed_query, .{}), matches.items },
+    );
+}
+
 fn readExactInto(
-    file: *session_child_store.ManagedFile,
+    file: *ReplayFile,
     start: usize,
     out: []u8,
 ) !void {
@@ -724,7 +1319,7 @@ fn readExactInto(
 
 fn readExactRange(
     alloc: Allocator,
-    file: *session_child_store.ManagedFile,
+    file: *ReplayFile,
     start: usize,
     len: usize,
 ) ![]u8 {
@@ -824,6 +1419,240 @@ test "command replay capture spills without losing callback order" {
         try std.testing.expectEqual(expected_byte.value, actual.value);
     }
     try std.testing.expect((try byte_reader.nextByte()) == null);
+}
+
+test "required command replay reports unavailable backing instead of dropping output" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const capture = try Capture.create(arena, 0, null);
+    defer capture.abort(arena);
+
+    try std.testing.expectError(
+        error.CommandOutputCaptureFailed,
+        capture.appendAcceptedRequired(arena, .stdout, "required\n"),
+    );
+}
+
+test "ephemeral command replay unlinks backing before publication and remains readable" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const temp_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(temp_path);
+    var store = EphemeralStore.initForTesting(alloc, temp_path);
+    defer store.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const capture = try Capture.createEphemeral(arena, 0, &store);
+    try capture.appendAcceptedRequired(arena, .stdout, "TOKEN=private-value\nephemeral needle\n");
+    const descriptor = (try capture.retainRequired(arena)) orelse
+        return error.TestExpectedReplay;
+    defer capture.releaseRetained(arena);
+
+    var entries = tmp.dir.iterate();
+    try std.testing.expect(try entries.next(io_mod.getIo()) == null);
+
+    var reader = try Reader.openEphemeralHandle(alloc, &store, descriptor.handle);
+    defer reader.deinit();
+    const frame = (try reader.next(alloc)) orelse return error.TestExpectedReplay;
+    defer alloc.free(frame.payload);
+    try std.testing.expectEqual(Stream.stdout, frame.stream);
+    try std.testing.expectEqualStrings(
+        "TOKEN=private-value\nephemeral needle\n",
+        frame.payload,
+    );
+
+    const page = try readAgentPageEphemeral(
+        alloc,
+        &store,
+        descriptor.handle,
+        1,
+        4096,
+    );
+    defer alloc.free(page);
+    try std.testing.expect(std.mem.find(u8, page, "TOKEN=[redacted]") != null);
+    try std.testing.expect(std.mem.find(u8, page, "private-value") == null);
+    try std.testing.expect(std.mem.find(u8, page, "ephemeral needle") != null);
+}
+
+test "agent command replay masks secrets split across callback frames" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const temp_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(temp_path);
+    var store = EphemeralStore.initForTesting(alloc, temp_path);
+    defer store.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const capture = try Capture.createEphemeral(arena, 0, &store);
+    try capture.appendAcceptedRequired(arena, .stdout, "TOKEN=private-");
+    try capture.appendAcceptedRequired(arena, .stdout, "value\nneedle split across frames\n");
+    const descriptor = (try capture.retainRequired(arena)) orelse
+        return error.TestExpectedReplay;
+    defer capture.releaseRetained(arena);
+
+    const page = try readAgentPageEphemeral(
+        alloc,
+        &store,
+        descriptor.handle,
+        1,
+        4096,
+    );
+    defer alloc.free(page);
+    try std.testing.expect(std.mem.find(u8, page, "TOKEN=[redacted]") != null);
+    try std.testing.expect(std.mem.find(u8, page, "private-") == null);
+    try std.testing.expect(std.mem.find(u8, page, "value") == null);
+
+    const query = try searchAgentQueryEphemeral(
+        alloc,
+        &store,
+        descriptor.handle,
+        "split across frames",
+        4096,
+    );
+    defer alloc.free(query);
+    try std.testing.expect(std.mem.find(u8, query, "needle split across frames") != null);
+}
+
+test "agent command replay keeps split utf8 valid and omits oversized secret-bearing lines" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const temp_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(temp_path);
+    var store = EphemeralStore.initForTesting(alloc, temp_path);
+    defer store.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const capture = try Capture.createEphemeral(arena, 0, &store);
+    try capture.appendAcceptedRequired(arena, .stdout, "utf8 split \xe2");
+    try capture.appendAcceptedRequired(arena, .stdout, "\x98\x83\nTOKEN=");
+    const oversized = try arena.alloc(u8, max_agent_line_bytes / 2 + 1);
+    @memset(oversized, 's');
+    try capture.appendAcceptedRequired(arena, .stdout, oversized);
+    try capture.appendAcceptedRequired(arena, .stdout, oversized);
+    try capture.appendAcceptedRequired(arena, .stdout, "\nafter oversized line\n");
+    const descriptor = (try capture.retainRequired(arena)) orelse
+        return error.TestExpectedReplay;
+    defer capture.releaseRetained(arena);
+
+    const page = try readAgentPageEphemeral(
+        alloc,
+        &store,
+        descriptor.handle,
+        1,
+        4096,
+    );
+    defer alloc.free(page);
+    try std.testing.expect(std.unicode.utf8ValidateSlice(page));
+    try std.testing.expect(std.mem.find(u8, page, "utf8 split \xe2\x98\x83") != null);
+    try std.testing.expect(std.mem.find(u8, page, "output line omitted") != null);
+    try std.testing.expect(std.mem.find(u8, page, "TOKEN=") == null);
+    try std.testing.expect(std.mem.find(u8, page, "ssssssss") == null);
+    try std.testing.expect(std.mem.find(u8, page, "after oversized line") != null);
+}
+
+test "agent command replay streams non-secret oversized lines without omission" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const temp_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(temp_path);
+    var store = EphemeralStore.initForTesting(alloc, temp_path);
+    defer store.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const capture = try Capture.createEphemeral(arena, 0, &store);
+    const chunk = try arena.alloc(u8, max_agent_line_bytes / 2);
+    @memset(chunk, 'x');
+    try capture.appendAcceptedRequired(arena, .stdout, chunk);
+    try capture.appendAcceptedRequired(arena, .stdout, chunk);
+    try capture.appendAcceptedRequired(arena, .stdout, "NONSECRET-LATE-SENTINEL\n");
+    const descriptor = (try capture.retainRequired(arena)) orelse
+        return error.TestExpectedReplay;
+    defer capture.releaseRetained(arena);
+
+    const query = try searchAgentQueryEphemeral(
+        alloc,
+        &store,
+        descriptor.handle,
+        "NONSECRET-LATE-SENTINEL",
+        4096,
+    );
+    defer alloc.free(query);
+    try std.testing.expect(std.mem.find(u8, query, "NONSECRET-LATE-SENTINEL") != null);
+    try std.testing.expect(std.mem.find(u8, query, "(no matches)") == null);
+    try std.testing.expect(std.mem.find(u8, query, "[stdout]") != null);
+    try std.testing.expect(std.mem.find(u8, query, "output line omitted") == null);
+}
+
+test "saved command replay pages and searches beyond eight mebibytes with bounded memory" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(io_mod.getIo());
+    const session_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(session_path);
+    var capability = try session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        session_path,
+        .writable,
+        .{},
+    );
+    defer capability.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const capture = try Capture.create(arena, 1024, &capability);
+    var chunk = [_]u8{'x'} ** 8192;
+    chunk[chunk.len - 1] = '\n';
+    for (0..1025) |_| try capture.appendAcceptedRequired(arena, .stdout, &chunk);
+    try capture.appendAcceptedRequired(arena, .stderr, "TAIL-SENTINEL-9MIB\n");
+    const descriptor = (try capture.retainRequired(arena)) orelse
+        return error.TestExpectedReplay;
+    defer capture.releaseRetained(arena);
+
+    const page = try readAgentPageManaged(
+        alloc,
+        &capability,
+        descriptor.handle,
+        4 * 1024 * 1024,
+        4096,
+    );
+    defer alloc.free(page);
+    try std.testing.expect(page.len < 5000);
+    try std.testing.expect(std.mem.findScalar(u8, page, 'x') != null);
+
+    const query = try searchAgentQueryManaged(
+        alloc,
+        &capability,
+        descriptor.handle,
+        "TAIL-SENTINEL-9MIB",
+        64 * 1024,
+    );
+    defer alloc.free(query);
+    try std.testing.expect(std.mem.find(u8, query, "TAIL-SENTINEL-9MIB") != null);
 }
 
 test "command replay reader rejects descriptor and frame corruption" {

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -9,6 +9,7 @@ const session_permission_state = @import("../permissions/session_permission_stat
 const image_attachments = @import("../images/image_attachments.zig");
 const generation_usage_provider = @import("generation_usage_provider.zig");
 const web_fetch_artifacts = @import("web_fetch_artifacts.zig");
+const command_replay_store = @import("command_replay_store.zig");
 pub const session_usage = @import("session_usage.zig");
 pub const profile_usage_runtime = @import("profile_usage_runtime.zig");
 const command_contract = @import("../execution/command_contract.zig");
@@ -77,6 +78,36 @@ pub const CancelledCommandPresentation = core_types.CancelledCommandPresentation
 /// Stored interrupted turn marker, optionally paired with the active tool call.
 pub const InterruptedHistoryTurn = core_types.InterruptedHistoryTurn;
 pub const InterruptedTerminalReason = core_types.InterruptedTerminalReason;
+
+fn formatInterruptedToolOutput(
+    alloc: Allocator,
+    entry: InterruptedHistoryTurn,
+) ![]u8 {
+    const presentation = entry.cancelled_command orelse
+        return alloc.dupe(u8, aborted_tool_output);
+    const replay = presentation.output_replay orelse
+        return alloc.dupe(u8, aborted_tool_output);
+    const descriptor = switch (replay) {
+        .available => |value| value,
+        .unavailable => return alloc.dupe(u8, aborted_tool_output),
+    };
+    return command_replay_store.appendModelHandleNotice(
+        alloc,
+        aborted_tool_output,
+        descriptor.handle,
+    ) catch |err| switch (err) {
+        error.InvalidReplayHandle => {
+            debug_trace.logf(
+                "session",
+                "cancelled command replay handle omitted from model context handle_bytes={d}",
+                .{descriptor.handle.len},
+            );
+            return alloc.dupe(u8, aborted_tool_output);
+        },
+        else => return err,
+    };
+}
+
 /// Stored compacted context summary produced by core history compaction.
 pub const CompactedSummaryHistoryTurn = core_types.CompactedSummaryHistoryTurn;
 /// One persisted session history record.
@@ -2647,13 +2678,18 @@ fn appendHistoryMessagesImpl(
                     });
                     owns_assistant_content = false;
                     owns_calls = false;
+                    const tool_output = try formatInterruptedToolOutput(alloc, entry);
+                    var owns_tool_output = true;
+                    errdefer if (owns_tool_output) alloc.free(tool_output);
                     try messages.append(alloc, .{
                         .role = .tool,
-                        .content = .{ .text = aborted_tool_output },
+                        .content = .{ .text = tool_output },
                         .tool_call_id = tool_call.id,
                         .tool_name = tool_call.name,
                         .tool_result_status = .failure,
+                        .owns_content = true,
                     });
+                    owns_tool_output = false;
                 } else {
                     const assistant_content = try formatInterruptedAssistantClosedContent(alloc, entry);
                     var owns_assistant_content = true;
@@ -2784,9 +2820,10 @@ fn appendHistoryChatMessagesImpl(
                     const calls = try alloc.alloc(core_types.ToolCall, 1);
                     calls[0] = try core_types.dupeToolCall(alloc, tool_call);
                     try messages.append(alloc, .{ .role = .assistant, .content = assistant_content, .tool_calls = calls });
+                    const tool_output = try formatInterruptedToolOutput(alloc, entry);
                     try messages.append(alloc, .{
                         .role = .tool,
-                        .content = aborted_tool_output,
+                        .content = tool_output,
                         .tool_call_id = tool_call.id,
                         .tool_name = tool_call.name,
                         .tool_result_status = .failure,
@@ -4543,14 +4580,19 @@ test "interrupted history projects marker and aborted tool result" {
     try std.testing.expectEqualStrings("call-command", messages.items[1].tool_calls[0].id);
     try std.testing.expectEqualStrings("run_command", messages.items[1].tool_calls[0].name);
     try std.testing.expectEqual(.tool, messages.items[2].role);
-    try std.testing.expectEqualStrings(aborted_tool_output, messages.items[2].content.?.asText());
+    try std.testing.expect(
+        std.mem.find(u8, messages.items[2].content.?.asText(), aborted_tool_output) != null,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, messages.items[2].content.?.asText(), replay_sentinel),
+    );
     try std.testing.expectEqualStrings("call-command", messages.items[2].tool_call_id.?);
     try std.testing.expectEqual(.user, messages.items[3].role);
     try std.testing.expect(std.mem.find(u8, messages.items[3].content.?.asText(), "<turn_aborted>") != null);
     try std.testing.expect(std.mem.find(u8, messages.items[3].content.?.asText(), "Do not continue") != null);
     for (messages.items) |entry| {
         if (entry.content) |content| {
-            try std.testing.expect(std.mem.find(u8, content.asText(), replay_sentinel) == null);
             try std.testing.expect(std.mem.find(u8, content.asText(), artifact_sentinel) == null);
         }
     }
@@ -4567,12 +4609,17 @@ test "interrupted history projects marker and aborted tool result" {
     try std.testing.expect(chat_messages.items[1].content == null);
     try std.testing.expectEqualStrings("run_command", chat_messages.items[1].tool_calls[0].name);
     try std.testing.expectEqual(core_types.ChatRole.tool, chat_messages.items[2].role);
-    try std.testing.expectEqualStrings(aborted_tool_output, chat_messages.items[2].content.?);
+    try std.testing.expect(
+        std.mem.find(u8, chat_messages.items[2].content.?, aborted_tool_output) != null,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        std.mem.count(u8, chat_messages.items[2].content.?, replay_sentinel),
+    );
     try std.testing.expectEqual(core_types.ChatRole.user, chat_messages.items[3].role);
     try std.testing.expect(std.mem.find(u8, chat_messages.items[3].content.?, "<turn_aborted>") != null);
     for (chat_messages.items) |entry| {
         if (entry.content) |content| {
-            try std.testing.expect(std.mem.find(u8, content, replay_sentinel) == null);
             try std.testing.expect(std.mem.find(u8, content, artifact_sentinel) == null);
         }
     }

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -453,6 +453,27 @@ pub fn maskSecrets(arena: std.mem.Allocator, text: []const u8) ![]const u8 {
 pub fn secretMayCrossBoundary(text: []const u8, retained_suffix_bytes: usize) bool {
     const retained_start = text.len -| retained_suffix_bytes;
 
+    var assignment_end = text.len;
+    if (assignment_end > 0 and
+        (text[assignment_end - 1] == '"' or text[assignment_end - 1] == '\''))
+    {
+        assignment_end -= 1;
+    }
+    if (assignment_end > 0 and text[assignment_end - 1] == '=') {
+        const key_end = assignment_end - 1;
+        var unfinished_key_start = key_end;
+        while (unfinished_key_start > 0 and
+            isAssignmentKeyChar(text[unfinished_key_start - 1]))
+        {
+            unfinished_key_start -= 1;
+        }
+        if (unfinished_key_start < retained_start and
+            sensitiveAssignmentKey(text[unfinished_key_start..key_end]))
+        {
+            return true;
+        }
+    }
+
     var key_start = text.len;
     while (key_start > 0 and isAssignmentKeyChar(text[key_start - 1])) {
         key_start -= 1;
@@ -986,6 +1007,18 @@ test "secret boundary analysis preserves resolved URLs and catches unfinished ca
     ));
     try std.testing.expect(secretMayCrossBoundary(
         "MY_VERY_LONG_TOKEN_KEY",
+        4,
+    ));
+    try std.testing.expect(secretMayCrossBoundary(
+        "MY_VERY_LONG_TOKEN_KEY=",
+        4,
+    ));
+    try std.testing.expect(secretMayCrossBoundary(
+        "MY_VERY_LONG_TOKEN_KEY=\"",
+        4,
+    ));
+    try std.testing.expect(secretMayCrossBoundary(
+        "MY_VERY_LONG_TOKEN_KEY='",
         4,
     ));
     try std.testing.expect(secretMayCrossBoundary(

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -448,6 +448,39 @@ pub fn maskSecrets(arena: std.mem.Allocator, text: []const u8) ![]const u8 {
     return try out.toOwnedSlice();
 }
 
+/// Returns true when a secret candidate begins before the retained suffix and
+/// cannot be classified until later bytes arrive on the same logical line.
+pub fn secretMayCrossBoundary(text: []const u8, retained_suffix_bytes: usize) bool {
+    const retained_start = text.len -| retained_suffix_bytes;
+
+    var key_start = text.len;
+    while (key_start > 0 and isAssignmentKeyChar(text[key_start - 1])) {
+        key_start -= 1;
+    }
+    if (key_start < retained_start and
+        sensitiveAssignmentKey(text[key_start..]))
+    {
+        return true;
+    }
+
+    const prefix = "https://";
+    var search_start: usize = 0;
+    while (std.mem.findPos(u8, text, search_start, prefix)) |url_start| {
+        const credential_start = url_start + prefix.len;
+        var end = credential_start;
+        while (end < text.len and
+            text[end] != '\n' and
+            text[end] != '\r' and
+            !std.ascii.isWhitespace(text[end])) : (end += 1)
+        {
+            if (text[end] == '/' or text[end] == '?' or text[end] == '#' or text[end] == '@') break;
+        }
+        if (end == text.len and url_start < retained_start) return true;
+        search_start = if (end < text.len) end + 1 else text.len;
+    }
+    return false;
+}
+
 pub fn redactUrlForDisplay(alloc: std.mem.Allocator, raw_url: []const u8) error{OutOfMemory}![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
@@ -944,6 +977,25 @@ test "maskSecrets masks expanded model-facing secret patterns" {
         masked,
     );
     try std.testing.expect(std.mem.find(u8, masked, "AKIA0123456789ABCDEF") == null);
+}
+
+test "secret boundary analysis preserves resolved URLs and catches unfinished candidates" {
+    try std.testing.expect(!secretMayCrossBoundary(
+        "prefix https://example.com suffix ",
+        64,
+    ));
+    try std.testing.expect(secretMayCrossBoundary(
+        "MY_VERY_LONG_TOKEN_KEY",
+        4,
+    ));
+    try std.testing.expect(secretMayCrossBoundary(
+        "prefix https://user:password",
+        4,
+    ));
+    try std.testing.expect(!secretMayCrossBoundary(
+        "prefix ORDINARY_KEY",
+        4,
+    ));
 }
 
 test "redactUrlForDisplay masks credential-like query values" {

--- a/src/core/tooling/command_result_mapping.zig
+++ b/src/core/tooling/command_result_mapping.zig
@@ -99,6 +99,21 @@ pub const Foreground = struct {
             } }).toJson(arena),
         };
     }
+
+    pub fn outputCaptureFailure(arena: Allocator) !ToolExecutionResult {
+        const details = [_]tool_result_errors.Detail{
+            .{ .name = "output_capture_failed", .value = .{ .boolean = true } },
+        };
+        return .{
+            .status = .failure,
+            .model_output = try tool_result_errors.toolExecutionFailureJson(arena, .{
+                .tool_name = "terminal",
+                .message = "Command output could not be retained",
+                .details = &details,
+                .suggestion = "Do not retry unchanged. Inspect available command evidence, free storage if needed, or explain that complete output capture failed.",
+            }),
+        };
+    }
 };
 
 pub const Background = struct {
@@ -382,6 +397,15 @@ test "command result mapping preserves timeout JSON" {
         timeout.model_output,
     );
     try expectContains(timeout.command_result_json.?, "\"timed_out\":true");
+}
+
+test "foreground output capture failure is structured and recoverable" {
+    const result = try Foreground.outputCaptureFailure(std.testing.allocator);
+    defer std.testing.allocator.free(@constCast(result.model_output));
+
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
+    try expectContains(result.model_output, "\"output_capture_failed\":true");
+    try expectContains(result.model_output, "Command output could not be retained");
 }
 
 test "command result mapping projects background reuse output and JSON" {

--- a/src/core/tooling/command_result_mapping.zig
+++ b/src/core/tooling/command_result_mapping.zig
@@ -17,10 +17,10 @@ pub const Foreground = struct {
         result: command_contract.RunCommandResult,
     ) !?ToolExecutionResult {
         if (!result.cancelled) return null;
-        const command_result_json = if (result.command_result) |command_result|
-            command_result.toJson(arena) catch |err| {
+        const command_result_json: ?[]const u8 = if (result.command_result) |command_result|
+            command_result.toJson(arena) catch |err| blk: {
                 debug_trace.logf("tool", "cancelled command result metadata omitted err={s}", .{@errorName(err)});
-                return error.Cancelled;
+                break :blk null;
             }
         else
             null;
@@ -368,17 +368,18 @@ test "cancelled command mapping survives metadata serialization failure" {
         std.testing.allocator,
         .{ .fail_index = 0 },
     );
-    try std.testing.expectError(
-        error.Cancelled,
-        Foreground.cancelledFailure(failing.allocator(), .{
-            .output = "ignored",
-            .cancelled = true,
-            .command_result = .{ .foreground = .{
-                .command = "sleep 5",
-                .cwd = "/tmp",
-            } },
-        }),
-    );
+    const result = (try Foreground.cancelledFailure(failing.allocator(), .{
+        .output = "ignored",
+        .cancelled = true,
+        .command_result = .{ .foreground = .{
+            .command = "sleep 5",
+            .cwd = "/tmp",
+        } },
+    })) orelse return error.TestExpectedEqual;
+    try std.testing.expect(result.cancelled);
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
+    try std.testing.expectEqualStrings("command cancelled\n", result.model_output);
+    try std.testing.expect(result.command_result_json == null);
 }
 
 test "command result mapping preserves timeout JSON" {

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -2587,7 +2587,7 @@ test "interactive command approval keeps activity projection out of permission r
     try std.testing.expect(std.mem.endsWith(u8, approval_command, "\n" ++ raw_command));
 }
 
-test "terminal exec omission shares user grants while clean stays isolated" {
+test "terminal exec timeout and profile omission share user grants while clean stays isolated" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -2604,12 +2604,12 @@ test "terminal exec omission shares user grants while clean stays isolated" {
     const omitted = try permissionTargetForCall(input, arena, .{
         .id = "omitted",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf scoped\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf scoped\",\"timeout_ms\":1}",
     });
     const clean = permissionTargetForCall(input, arena, .{
         .id = "clean",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf scoped\",\"profile\":\"clean\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf scoped\",\"profile\":\"clean\",\"timeout_ms\":5000}",
     }) catch |err| switch (err) {
         error.MissingLoginShell, error.UnsupportedShell => return error.SkipZigTest,
         else => return err,
@@ -2617,7 +2617,7 @@ test "terminal exec omission shares user grants while clean stays isolated" {
     const user = try permissionTargetForCall(input, arena, .{
         .id = "user",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf scoped\",\"profile\":\"user\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf scoped\",\"profile\":\"user\",\"timeout_ms\":600000}",
     });
 
     try std.testing.expectEqualStrings(omitted, user);

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -13,6 +13,7 @@ const permission_gate = @import("../permissions/permission_gate.zig");
 const change_tracker = @import("../workspace/change_tracker.zig");
 const read_tracker_mod = @import("../workspace/read_tracker.zig");
 const session_child_store = @import("../session/session_child_store.zig");
+const command_replay_store = @import("../session/command_replay_store.zig");
 const command_runner = @import("../execution/command_runner.zig");
 const subagent_tool_provider = @import("../subagent/tool_provider.zig");
 const text_utils = @import("../shared/text_utils.zig");
@@ -171,6 +172,7 @@ pub const RunCommandRequest = struct {
     command: []const u8,
     resolved_cwd: []const u8,
     environment: command_environment.Environment,
+    timeout_ms: u64,
 };
 
 pub const RunCommandBackendFn = *const fn (
@@ -222,6 +224,7 @@ pub const DispatchContext = struct {
     command_artifact_dir: ?[]const u8 = null,
     tool_result_dir: ?[]const u8 = null,
     session_child_capability: ?*session_child_store.SessionChildCapability = null,
+    ephemeral_command_replay: ?*command_replay_store.EphemeralStore = null,
     terminal_client: ?*terminal_client_runtime.Runtime = null,
     terminal_owner_session_id: ?[]const u8 = null,
     terminal_transport_role: terminal_contracts.TransportRole = .interactive,

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -1399,6 +1399,29 @@ fn toolRunCommand(
             null,
             try command_result_mapping.Foreground.outputCaptureFailure(arena),
         );
+        if (err == error.Cancelled and runtimeCancelFlag(ctx).load(.seq_cst)) {
+            if (try requiredCaptureFailure(arena, replay_capture, replay_required)) |capture_failure| {
+                return finishCommandToolResult(
+                    replay_capture,
+                    false,
+                    &replay_transferred,
+                    null,
+                    capture_failure,
+                );
+            }
+            return finishCommandToolResult(
+                replay_capture,
+                replay_init.unavailable and
+                    (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
+                &replay_transferred,
+                null,
+                .{
+                    .status = .failure,
+                    .cancelled = true,
+                    .model_output = "command cancelled\n",
+                },
+            );
+        }
         return err;
     };
     const result = routed.result;

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -1309,6 +1309,7 @@ fn toolRunCommand(
             ) catch |err| {
                 if (err != error.CommandOutputCaptureFailed) return err;
                 return finishCommandToolResult(
+                    arena,
                     capture,
                     false,
                     &transferred,
@@ -1325,16 +1326,8 @@ fn toolRunCommand(
                 output,
             );
         }
-        if (try requiredCaptureFailure(arena, capture, replay_policy)) |capture_failure| {
-            return finishCommandToolResult(
-                capture,
-                false,
-                &transferred,
-                null,
-                capture_failure,
-            );
-        }
         return finishCommandToolResult(
+            arena,
             capture,
             intercepted_replay.unavailable and
                 (ctx.command_replay_unavailable or callback.had_accepted_output),
@@ -1388,16 +1381,8 @@ fn toolRunCommand(
         .command_artifact_dir = ctx.command_artifact_dir,
     }, arena, route) catch |err| {
         if (err == error.TimeoutExpired) {
-            if (try requiredCaptureFailure(arena, replay_capture, replay_policy)) |capture_failure| {
-                return finishCommandToolResult(
-                    replay_capture,
-                    false,
-                    &replay_transferred,
-                    null,
-                    capture_failure,
-                );
-            }
             return finishCommandToolResult(
+                arena,
                 replay_capture,
                 replay_init.unavailable and
                     (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
@@ -1413,6 +1398,7 @@ fn toolRunCommand(
             );
         }
         if (err == error.CommandOutputCaptureFailed) return finishCommandToolResult(
+            arena,
             replay_capture,
             false,
             &replay_transferred,
@@ -1420,16 +1406,8 @@ fn toolRunCommand(
             try command_result_mapping.Foreground.outputCaptureFailure(arena),
         );
         if (err == error.Cancelled and runtimeCancelFlag(ctx).load(.seq_cst)) {
-            if (try requiredCaptureFailure(arena, replay_capture, replay_policy)) |capture_failure| {
-                return finishCommandToolResult(
-                    replay_capture,
-                    false,
-                    &replay_transferred,
-                    null,
-                    capture_failure,
-                );
-            }
             return finishCommandToolResult(
+                arena,
                 replay_capture,
                 replay_init.unavailable and
                     (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
@@ -1446,18 +1424,9 @@ fn toolRunCommand(
     };
     const result = routed.result;
 
-    if (try requiredCaptureFailure(arena, replay_capture, replay_policy)) |capture_failure| {
-        return finishCommandToolResult(
-            replay_capture,
-            false,
-            &replay_transferred,
-            result,
-            capture_failure,
-        );
-    }
-
     if (try command_result_mapping.Foreground.cancelledFailure(arena, result)) |cancelled| {
         return finishCommandToolResult(
+            arena,
             replay_capture,
             replay_init.unavailable and
                 (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
@@ -1469,6 +1438,7 @@ fn toolRunCommand(
 
     if (try command_result_mapping.Foreground.nonZeroFailure(arena, result)) |failure| {
         return finishCommandToolResult(
+            arena,
             replay_capture,
             replay_init.unavailable and
                 (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
@@ -1479,6 +1449,7 @@ fn toolRunCommand(
     }
 
     return finishCommandToolResult(
+        arena,
         replay_capture,
         replay_init.unavailable and
             (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
@@ -1532,6 +1503,7 @@ fn executeWorkspaceRunCommand(
     var replay_transferred = false;
     if (try command_result_mapping.Foreground.cancelledFailure(arena, result)) |cancelled| {
         return finishCommandToolResult(
+            arena,
             null,
             false,
             &replay_transferred,
@@ -1541,6 +1513,7 @@ fn executeWorkspaceRunCommand(
     }
     if (try command_result_mapping.Foreground.nonZeroFailure(arena, result)) |failure| {
         return finishCommandToolResult(
+            arena,
             null,
             false,
             &replay_transferred,
@@ -1549,6 +1522,7 @@ fn executeWorkspaceRunCommand(
         );
     }
     return finishCommandToolResult(
+        arena,
         null,
         false,
         &replay_transferred,
@@ -1644,23 +1618,8 @@ fn initCommandReplayCapture(
     return .{ .capture = capture };
 }
 
-fn requiredCaptureFailure(
-    arena: Allocator,
-    capture: ?*command_replay_store.Capture,
-    policy: ?command_replay_store.CapturePolicy,
-) !?ToolExecutionResult {
-    if (policy != .required) return null;
-    const candidate = capture orelse {
-        return @as(?ToolExecutionResult, try command_result_mapping.Foreground.outputCaptureFailure(arena));
-    };
-    candidate.sealRequired(arena) catch return @as(
-        ?ToolExecutionResult,
-        try command_result_mapping.Foreground.outputCaptureFailure(arena),
-    );
-    return null;
-}
-
 fn finishCommandToolResult(
+    arena: Allocator,
     capture: ?*command_replay_store.Capture,
     replay_unavailable: bool,
     replay_transferred: *bool,
@@ -1668,6 +1627,12 @@ fn finishCommandToolResult(
     result: ToolExecutionResult,
 ) !ToolExecutionResult {
     var owned = result;
+    if (capture) |candidate| switch (candidate.policy()) {
+        .required => candidate.sealRequired(arena) catch {
+            owned = try command_result_mapping.Foreground.outputCaptureFailure(arena);
+        },
+        .best_effort => {},
+    };
     if (process_result) |command_result| {
         if (commandProcessPresentation(command_result)) |presentation| {
             var memory = owned.tool_result_memory orelse types.ToolResultMemory{};
@@ -6701,6 +6666,7 @@ test "interactive command replay capture allocation fails open" {
 
     var transferred = false;
     const result = try finishCommandToolResult(
+        std.testing.allocator,
         null,
         init.unavailable and callback.had_accepted_output,
         &transferred,
@@ -6711,6 +6677,42 @@ test "interactive command replay capture allocation fails open" {
     switch (result.tool_result_memory.?.command_output_replay.?) {
         .unavailable => {},
         .available => return error.TestExpectedUnavailableReplay,
+    }
+}
+
+test "required replay finalizer overrides every recoverable command result" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const initial_results = [_]ToolExecutionResult{
+        .{ .status = .success, .model_output = "compatibility success\n" },
+        .{ .status = .failure, .model_output = "timeout\n" },
+        .{ .status = .failure, .cancelled = true, .model_output = "cancelled\n" },
+        .{ .status = .failure, .model_output = "nonzero\n" },
+        .{ .status = .success, .model_output = "success\n" },
+    };
+
+    for (initial_results) |initial| {
+        const capture = try command_replay_store.Capture.create(arena, 0, null);
+        defer capture.abort(arena);
+        capture.setPolicyBeforeCapture(.required);
+        try std.testing.expectError(
+            error.CommandOutputCaptureFailed,
+            capture.appendAcceptedRequired(arena, .stdout, "accepted\n"),
+        );
+        var transferred = false;
+        const result = try finishCommandToolResult(
+            arena,
+            capture,
+            false,
+            &transferred,
+            null,
+            initial,
+        );
+        try std.testing.expect(transferred);
+        try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
+        try expectContains(result.model_output, "\"output_capture_failed\":true");
     }
 }
 

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -1200,6 +1200,28 @@ fn effectiveCommandTimeout(
     };
 }
 
+fn commandReplayPolicy(
+    environment: command_environment.Environment,
+    has_replay_capability: bool,
+    interactive: bool,
+    continued: ?command_replay_store.CapturePolicy,
+) ?command_replay_store.CapturePolicy {
+    if (continued) |policy| return policy;
+    return switch (environment) {
+        .workspace_clean => null,
+        .legacy => if (has_replay_capability or interactive)
+            .best_effort
+        else
+            null,
+        .clean, .user => if (has_replay_capability)
+            .required
+        else if (interactive)
+            .best_effort
+        else
+            null,
+    };
+}
+
 fn toolRunCommand(
     ctx: Context,
     arena: Allocator,
@@ -1221,11 +1243,13 @@ fn toolRunCommand(
         ctx.command_timeout_started_ms,
         io_mod.milliTimestamp(),
     );
-    const replay_required = ctx.session_child_capability != null or
-        ctx.ephemeral_command_replay != null;
-    const replay_enabled = ctx.interactive or
-        replay_required or
-        ctx.command_replay_capture != null;
+    const replay_policy = commandReplayPolicy(
+        request.environment,
+        ctx.session_child_capability != null or
+            ctx.ephemeral_command_replay != null,
+        ctx.interactive,
+        if (ctx.command_replay_capture) |capture| capture.policy() else null,
+    );
 
     if (comptime builtin.os.tag == .wasi or builtin.is_test) {
         if (ctx.workspace_executor) |executor| {
@@ -1256,8 +1280,7 @@ fn toolRunCommand(
         if (route != .approved_shell) return error.CommandAdmissionChanged;
         const intercepted_replay = try initCommandReplayCapture(
             arena,
-            replay_enabled,
-            replay_required,
+            replay_policy,
             ctx.max_command_output_bytes,
             ctx.max_command_output_bytes,
             ctx.session_child_capability,
@@ -1273,7 +1296,6 @@ fn toolRunCommand(
         var callback = CommandReplayCaptureCallback{
             .alloc = arena,
             .capture = capture,
-            .required = replay_required,
         };
         const output = switch (compatibility) {
             .success => |body| body,
@@ -1303,7 +1325,7 @@ fn toolRunCommand(
                 output,
             );
         }
-        if (try requiredCaptureFailure(arena, capture, replay_required)) |capture_failure| {
+        if (try requiredCaptureFailure(arena, capture, replay_policy)) |capture_failure| {
             return finishCommandToolResult(
                 capture,
                 false,
@@ -1330,8 +1352,7 @@ fn toolRunCommand(
 
     const replay_init = try initCommandReplayCapture(
         arena,
-        replay_enabled,
-        replay_required,
+        replay_policy,
         ctx.max_command_output_bytes,
         execution_router.foregroundResultComparisonLimit(
             route,
@@ -1350,7 +1371,6 @@ fn toolRunCommand(
     var replay_callback = CommandReplayCaptureCallback{
         .alloc = arena,
         .capture = replay_capture,
-        .required = replay_required,
     };
 
     const routed = execution_router.executePreparedRoute(.{
@@ -1368,7 +1388,7 @@ fn toolRunCommand(
         .command_artifact_dir = ctx.command_artifact_dir,
     }, arena, route) catch |err| {
         if (err == error.TimeoutExpired) {
-            if (try requiredCaptureFailure(arena, replay_capture, replay_required)) |capture_failure| {
+            if (try requiredCaptureFailure(arena, replay_capture, replay_policy)) |capture_failure| {
                 return finishCommandToolResult(
                     replay_capture,
                     false,
@@ -1400,7 +1420,7 @@ fn toolRunCommand(
             try command_result_mapping.Foreground.outputCaptureFailure(arena),
         );
         if (err == error.Cancelled and runtimeCancelFlag(ctx).load(.seq_cst)) {
-            if (try requiredCaptureFailure(arena, replay_capture, replay_required)) |capture_failure| {
+            if (try requiredCaptureFailure(arena, replay_capture, replay_policy)) |capture_failure| {
                 return finishCommandToolResult(
                     replay_capture,
                     false,
@@ -1426,7 +1446,7 @@ fn toolRunCommand(
     };
     const result = routed.result;
 
-    if (try requiredCaptureFailure(arena, replay_capture, replay_required)) |capture_failure| {
+    if (try requiredCaptureFailure(arena, replay_capture, replay_policy)) |capture_failure| {
         return finishCommandToolResult(
             replay_capture,
             false,
@@ -1546,7 +1566,6 @@ fn executeWorkspaceRunCommand(
 const CommandReplayCaptureCallback = struct {
     alloc: Allocator,
     capture: ?*command_replay_store.Capture,
-    required: bool,
     had_accepted_output: bool = false,
 
     fn onChunk(
@@ -1569,10 +1588,13 @@ const CommandReplayCaptureCallback = struct {
         if (chunk.len == 0) return;
         self.had_accepted_output = true;
         if (self.capture) |capture| {
-            if (self.required) {
-                try capture.appendAcceptedRequired(self.alloc, stream, chunk);
-            } else {
-                capture.appendAccepted(self.alloc, stream, chunk);
+            switch (capture.policy()) {
+                .required => try capture.appendAcceptedRequired(
+                    self.alloc,
+                    stream,
+                    chunk,
+                ),
+                .best_effort => capture.appendAccepted(self.alloc, stream, chunk),
             }
         }
     }
@@ -1585,8 +1607,7 @@ const CommandReplayCaptureInit = struct {
 
 fn initCommandReplayCapture(
     arena: Allocator,
-    enabled: bool,
-    required: bool,
+    replay_policy: ?command_replay_store.CapturePolicy,
     inline_limit: usize,
     comparison_limit: usize,
     capability: ?*session_child_store.SessionChildCapability,
@@ -1594,23 +1615,23 @@ fn initCommandReplayCapture(
     continued_capture: ?*command_replay_store.Capture,
     continued_unavailable: bool,
 ) !CommandReplayCaptureInit {
-    if (!enabled) return .{};
+    const policy = replay_policy orelse return .{};
     if (continued_unavailable) {
-        if (required) return error.CommandOutputCaptureFailed;
+        if (policy == .required) return error.CommandOutputCaptureFailed;
         return .{ .unavailable = true };
     }
     if (continued_capture) |capture| {
         capture.setComparisonLimit(comparison_limit);
         return .{ .capture = capture };
     }
-    const capture_inline_limit = if (required) 0 else inline_limit;
+    const capture_inline_limit = if (policy == .required) 0 else inline_limit;
     const capture = (if (capability) |saved|
         command_replay_store.Capture.create(arena, capture_inline_limit, saved)
     else if (ephemeral_store) |ephemeral|
         command_replay_store.Capture.createEphemeral(arena, capture_inline_limit, ephemeral)
     else
         command_replay_store.Capture.create(arena, capture_inline_limit, null)) catch |err| {
-        if (required) return err;
+        if (policy == .required) return err;
         debug_trace.logf(
             "session",
             "command replay capture initialization unavailable err={s}",
@@ -1618,6 +1639,7 @@ fn initCommandReplayCapture(
         );
         return .{ .unavailable = true };
     };
+    capture.setPolicyBeforeCapture(policy);
     capture.setComparisonLimit(comparison_limit);
     return .{ .capture = capture };
 }
@@ -1625,9 +1647,9 @@ fn initCommandReplayCapture(
 fn requiredCaptureFailure(
     arena: Allocator,
     capture: ?*command_replay_store.Capture,
-    required: bool,
+    policy: ?command_replay_store.CapturePolicy,
 ) !?ToolExecutionResult {
-    if (!required) return null;
+    if (policy != .required) return null;
     const candidate = capture orelse {
         return @as(?ToolExecutionResult, try command_result_mapping.Foreground.outputCaptureFailure(arena));
     };
@@ -6186,6 +6208,67 @@ test "effective command timeout uses the earlier remaining budget" {
     );
 }
 
+test "command replay policy is decided once from typed execution context" {
+    const Case = struct {
+        environment: command_environment.Environment,
+        has_replay_capability: bool,
+        interactive: bool,
+        continued: ?command_replay_store.CapturePolicy = null,
+        expected: ?command_replay_store.CapturePolicy,
+    };
+    const cases = [_]Case{
+        .{
+            .environment = .{ .clean = "/bin/zsh" },
+            .has_replay_capability = true,
+            .interactive = false,
+            .expected = .required,
+        },
+        .{
+            .environment = .{ .user = "/bin/zsh" },
+            .has_replay_capability = false,
+            .interactive = true,
+            .expected = .best_effort,
+        },
+        .{
+            .environment = .{ .clean = "/bin/zsh" },
+            .has_replay_capability = false,
+            .interactive = false,
+            .expected = null,
+        },
+        .{
+            .environment = .legacy,
+            .has_replay_capability = true,
+            .interactive = false,
+            .expected = .best_effort,
+        },
+        .{
+            .environment = .workspace_clean,
+            .has_replay_capability = true,
+            .interactive = true,
+            .expected = null,
+        },
+        .{
+            .environment = .{ .clean = "/bin/zsh" },
+            .has_replay_capability = true,
+            .interactive = false,
+            .continued = .best_effort,
+            .expected = .best_effort,
+        },
+    };
+
+    for (cases) |case| {
+        try std.testing.expectEqual(
+            case.expected,
+            commandReplayPolicy(
+                case.environment,
+                case.has_replay_capability,
+                case.interactive,
+                case.continued,
+            ),
+        );
+    }
+}
+
 test "terminal exec request timeout reaches execution without an ambient timeout" {
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
 
@@ -6249,10 +6332,15 @@ test "saved noninteractive terminal exec captures replay by capability" {
         .name = "terminal",
         .arguments_json = "{\"action\":\"exec\",\"command\":\"printf replay\",\"profile\":\"clean\",\"timeout_ms\":600000}",
     });
-    defer if (result.command_replay_capture) |capture| capture.abort(arena_state.allocator());
+    defer if (result.command_replay_capture) |capture| {
+        capture.abort(arena_state.allocator());
+    };
 
     try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.success, result.status);
-    try std.testing.expect(result.command_replay_capture != null);
+    try std.testing.expectEqual(
+        command_replay_store.CapturePolicy.required,
+        result.command_replay_capture.?.policy(),
+    );
 }
 
 test "no-save terminal exec publishes one readable ephemeral replay" {
@@ -6286,7 +6374,7 @@ test "no-save terminal exec publishes one readable ephemeral replay" {
     var handed_off = false;
     defer if (!handed_off) capture.discard(arena);
     var cancel = std.atomic.Value(bool).init(false);
-    var prepared = try runtime_execution_memory.prepareToolModelOutput(
+    var prepared = try runtime_execution_memory.prepareCapturedToolModelOutput(
         arena,
         .{
             .system_prompt = "",
@@ -6298,6 +6386,7 @@ test "no-save terminal exec publishes one readable ephemeral replay" {
         },
         tool_call,
         result.model_output,
+        capture,
     );
     try std.testing.expect(prepared.memory.output_handle == null);
     try runtime_execution_memory.finalizeCommandReplay(
@@ -6370,7 +6459,9 @@ test "required replay spill failure returns recoverable capture failure" {
         .name = "terminal",
         .arguments_json = "{\"action\":\"exec\",\"command\":\"printf xx\",\"profile\":\"clean\",\"timeout_ms\":600000}",
     });
-    defer if (result.command_replay_capture) |capture| capture.abort(arena_state.allocator());
+    defer if (result.command_replay_capture) |capture| {
+        capture.abort(arena_state.allocator());
+    };
 
     try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
     try expectContains(result.model_output, "\"output_capture_failed\":true");
@@ -6468,11 +6559,12 @@ test "run_command timeout returns model-visible failure" {
         .cancel_flag = &cancel,
         .session_child_capability = &capability,
     };
-    var prepared = try runtime_execution_memory.prepareToolModelOutput(
+    var prepared = try runtime_execution_memory.prepareCapturedToolModelOutput(
         arena,
         config,
         tool_call,
         result.model_output,
+        capture,
     );
     runtime_execution_memory.applyToolResultMemory(
         &prepared.memory,
@@ -6584,8 +6676,7 @@ test "interactive command replay capture allocation fails open" {
     );
     const init = try initCommandReplayCapture(
         failing.allocator(),
-        true,
-        false,
+        .best_effort,
         64 * 1024,
         64 * 1024,
         null,
@@ -6599,7 +6690,6 @@ test "interactive command replay capture allocation fails open" {
     var callback = CommandReplayCaptureCallback{
         .alloc = std.testing.allocator,
         .capture = null,
-        .required = false,
     };
     try CommandReplayCaptureCallback.onChunk(
         @ptrCast(&callback),

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -187,6 +187,7 @@ pub const Context = struct {
     command_artifact_dir: ?[]const u8 = null,
     tool_result_dir: ?[]const u8 = null,
     session_child_capability: ?*session_child_store.SessionChildCapability = null,
+    ephemeral_command_replay: ?*command_replay_store.EphemeralStore = null,
     terminal_client: ?*terminal_client_runtime.Runtime = null,
     command_timeout_ms: ?usize = null,
     command_timeout_started_ms: ?i64 = null,
@@ -876,6 +877,7 @@ fn typedDispatchContext(ctx: Context, arena: Allocator) tool_dispatch.DispatchCo
         .max_tool_result_bytes = ctx.max_tool_result_bytes,
         .tool_result_dir = ctx.tool_result_dir,
         .session_child_capability = ctx.session_child_capability,
+        .ephemeral_command_replay = ctx.ephemeral_command_replay,
         .terminal_client = ctx.terminal_client,
         .terminal_owner_session_id = ctx.lifecycle_scope.session_id,
         .terminal_transport_role = switch (ctx.lifecycle_scope.kind) {
@@ -1170,6 +1172,34 @@ pub fn withAdvertisedDynamicToolNames(ctx: Context, advertised_dynamic_tool_name
     return copy;
 }
 
+const EffectiveCommandTimeout = struct {
+    timeout_ms: usize,
+    started_ms: i64,
+};
+
+fn effectiveCommandTimeout(
+    request_timeout_ms: u64,
+    ambient_timeout_ms: ?usize,
+    ambient_started_ms: ?i64,
+    now_ms: i64,
+) !EffectiveCommandTimeout {
+    const requested = std.math.cast(usize, request_timeout_ms) orelse
+        return error.InvalidToolArguments;
+    const ambient = ambient_timeout_ms orelse return .{
+        .timeout_ms = requested,
+        .started_ms = now_ms,
+    };
+    const ambient_started = ambient_started_ms orelse now_ms;
+    const elapsed: usize = if (now_ms <= ambient_started)
+        0
+    else
+        std.math.cast(usize, now_ms - ambient_started) orelse std.math.maxInt(usize);
+    return .{
+        .timeout_ms = @min(requested, ambient -| elapsed),
+        .started_ms = now_ms,
+    };
+}
+
 fn toolRunCommand(
     ctx: Context,
     arena: Allocator,
@@ -1185,8 +1215,17 @@ fn toolRunCommand(
         .target_os = builtin.os.tag,
         .environment = request.environment,
     };
-    const timeout_started_ms = ctx.command_timeout_started_ms orelse
-        if (ctx.command_timeout_ms != null) io_mod.milliTimestamp() else null;
+    const timeout = try effectiveCommandTimeout(
+        request.timeout_ms,
+        ctx.command_timeout_ms,
+        ctx.command_timeout_started_ms,
+        io_mod.milliTimestamp(),
+    );
+    const replay_required = ctx.session_child_capability != null or
+        ctx.ephemeral_command_replay != null;
+    const replay_enabled = ctx.interactive or
+        replay_required or
+        ctx.command_replay_capture != null;
 
     if (comptime builtin.os.tag == .wasi or builtin.is_test) {
         if (ctx.workspace_executor) |executor| {
@@ -1196,7 +1235,7 @@ fn toolRunCommand(
                 command_ctx,
                 authority,
                 executor,
-                ctx.command_timeout_ms,
+                timeout.timeout_ms,
             );
         }
     }
@@ -1215,12 +1254,14 @@ fn toolRunCommand(
     );
     if (compatibility_result) |compatibility| {
         if (route != .approved_shell) return error.CommandAdmissionChanged;
-        const intercepted_replay = initCommandReplayCapture(
+        const intercepted_replay = try initCommandReplayCapture(
             arena,
-            ctx.interactive,
+            replay_enabled,
+            replay_required,
             ctx.max_command_output_bytes,
             ctx.max_command_output_bytes,
             ctx.session_child_capability,
+            ctx.ephemeral_command_replay,
             ctx.command_replay_capture,
             ctx.command_replay_unavailable,
         );
@@ -1232,22 +1273,43 @@ fn toolRunCommand(
         var callback = CommandReplayCaptureCallback{
             .alloc = arena,
             .capture = capture,
+            .required = replay_required,
         };
         const output = switch (compatibility) {
             .success => |body| body,
             .failure => |body| body,
         };
-        if (compatibility == .success and ctx.interactive and output.len > 0) {
-            try callback.accept(
+        if (compatibility == .success and capture != null and output.len > 0) {
+            callback.accept(
                 ctx.output_chunk_lifecycle_id,
                 .stdout,
                 output,
-            );
+            ) catch |err| {
+                if (err != error.CommandOutputCaptureFailed) return err;
+                return finishCommandToolResult(
+                    capture,
+                    false,
+                    &transferred,
+                    null,
+                    try command_result_mapping.Foreground.outputCaptureFailure(arena),
+                );
+            };
+        }
+        if (compatibility == .success and ctx.interactive and output.len > 0) {
             try ctx.on_output_chunk(
                 ctx.output_chunk_ctx,
                 ctx.output_chunk_lifecycle_id,
                 .stdout,
                 output,
+            );
+        }
+        if (try requiredCaptureFailure(arena, capture, replay_required)) |capture_failure| {
+            return finishCommandToolResult(
+                capture,
+                false,
+                &transferred,
+                null,
+                capture_failure,
             );
         }
         return finishCommandToolResult(
@@ -1266,15 +1328,17 @@ fn toolRunCommand(
         );
     }
 
-    const replay_init = initCommandReplayCapture(
+    const replay_init = try initCommandReplayCapture(
         arena,
-        ctx.interactive,
+        replay_enabled,
+        replay_required,
         ctx.max_command_output_bytes,
         execution_router.foregroundResultComparisonLimit(
             route,
             ctx.max_command_output_bytes,
         ),
         ctx.session_child_capability,
+        ctx.ephemeral_command_replay,
         ctx.command_replay_capture,
         ctx.command_replay_unavailable,
     );
@@ -1286,6 +1350,7 @@ fn toolRunCommand(
     var replay_callback = CommandReplayCaptureCallback{
         .alloc = arena,
         .capture = replay_capture,
+        .required = replay_required,
     };
 
     const routed = execution_router.executePreparedRoute(.{
@@ -1294,34 +1359,69 @@ fn toolRunCommand(
         .output_chunk_lifecycle_id = ctx.output_chunk_lifecycle_id,
         .output_chunk_ctx = ctx.output_chunk_ctx,
         .on_output_chunk = ctx.on_output_chunk,
-        .accepted_output_chunk_ctx = if (ctx.interactive) @ptrCast(&replay_callback) else null,
-        .on_accepted_output_chunk = if (ctx.interactive) CommandReplayCaptureCallback.onChunk else null,
+        .accepted_output_chunk_ctx = if (replay_capture != null) @ptrCast(&replay_callback) else null,
+        .on_accepted_output_chunk = if (replay_capture != null) CommandReplayCaptureCallback.onChunk else null,
         .callback_projection = if (ctx.interactive) .raw else .model_safe,
-        .timeout_ms = ctx.command_timeout_ms,
-        .timeout_started_ms = timeout_started_ms,
+        .timeout_ms = timeout.timeout_ms,
+        .timeout_started_ms = timeout.started_ms,
         .command_artifact_capability = ctx.session_child_capability,
         .command_artifact_dir = ctx.command_artifact_dir,
     }, arena, route) catch |err| {
-        if (err == error.TimeoutExpired) return finishCommandToolResult(
+        if (err == error.TimeoutExpired) {
+            if (try requiredCaptureFailure(arena, replay_capture, replay_required)) |capture_failure| {
+                return finishCommandToolResult(
+                    replay_capture,
+                    false,
+                    &replay_transferred,
+                    null,
+                    capture_failure,
+                );
+            }
+            return finishCommandToolResult(
+                replay_capture,
+                replay_init.unavailable and
+                    (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
+                &replay_transferred,
+                null,
+                try command_result_mapping.Foreground.timeoutFailure(
+                    arena,
+                    command,
+                    cwd,
+                    timeout.timeout_ms,
+                    timeout.started_ms,
+                ),
+            );
+        }
+        if (err == error.CommandOutputCaptureFailed) return finishCommandToolResult(
             replay_capture,
-            replay_init.unavailable and
-                (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
+            false,
             &replay_transferred,
             null,
-            try command_result_mapping.Foreground.timeoutFailure(
-                arena,
-                command,
-                cwd,
-                ctx.command_timeout_ms,
-                timeout_started_ms,
-            ),
+            try command_result_mapping.Foreground.outputCaptureFailure(arena),
         );
         return err;
     };
     const result = routed.result;
 
+    if (try requiredCaptureFailure(arena, replay_capture, replay_required)) |capture_failure| {
+        return finishCommandToolResult(
+            replay_capture,
+            false,
+            &replay_transferred,
+            result,
+            capture_failure,
+        );
+    }
+
     if (try command_result_mapping.Foreground.cancelledFailure(arena, result)) |cancelled| {
-        return cancelled;
+        return finishCommandToolResult(
+            replay_capture,
+            replay_init.unavailable and
+                (ctx.command_replay_unavailable or replay_callback.had_accepted_output),
+            &replay_transferred,
+            result,
+            cancelled,
+        );
     }
 
     if (try command_result_mapping.Foreground.nonZeroFailure(arena, result)) |failure| {
@@ -1423,6 +1523,7 @@ fn executeWorkspaceRunCommand(
 const CommandReplayCaptureCallback = struct {
     alloc: Allocator,
     capture: ?*command_replay_store.Capture,
+    required: bool,
     had_accepted_output: bool = false,
 
     fn onChunk(
@@ -1445,7 +1546,11 @@ const CommandReplayCaptureCallback = struct {
         if (chunk.len == 0) return;
         self.had_accepted_output = true;
         if (self.capture) |capture| {
-            capture.appendAccepted(self.alloc, stream, chunk);
+            if (self.required) {
+                try capture.appendAcceptedRequired(self.alloc, stream, chunk);
+            } else {
+                capture.appendAccepted(self.alloc, stream, chunk);
+            }
         }
     }
 };
@@ -1457,24 +1562,32 @@ const CommandReplayCaptureInit = struct {
 
 fn initCommandReplayCapture(
     arena: Allocator,
-    interactive: bool,
+    enabled: bool,
+    required: bool,
     inline_limit: usize,
     comparison_limit: usize,
     capability: ?*session_child_store.SessionChildCapability,
+    ephemeral_store: ?*command_replay_store.EphemeralStore,
     continued_capture: ?*command_replay_store.Capture,
     continued_unavailable: bool,
-) CommandReplayCaptureInit {
-    if (!interactive) return .{};
-    if (continued_unavailable) return .{ .unavailable = true };
+) !CommandReplayCaptureInit {
+    if (!enabled) return .{};
+    if (continued_unavailable) {
+        if (required) return error.CommandOutputCaptureFailed;
+        return .{ .unavailable = true };
+    }
     if (continued_capture) |capture| {
         capture.setComparisonLimit(comparison_limit);
         return .{ .capture = capture };
     }
-    const capture = command_replay_store.Capture.create(
-        arena,
-        inline_limit,
-        capability,
-    ) catch |err| {
+    const capture_inline_limit = if (required) 0 else inline_limit;
+    const capture = (if (capability) |saved|
+        command_replay_store.Capture.create(arena, capture_inline_limit, saved)
+    else if (ephemeral_store) |ephemeral|
+        command_replay_store.Capture.createEphemeral(arena, capture_inline_limit, ephemeral)
+    else
+        command_replay_store.Capture.create(arena, capture_inline_limit, null)) catch |err| {
+        if (required) return err;
         debug_trace.logf(
             "session",
             "command replay capture initialization unavailable err={s}",
@@ -1484,6 +1597,22 @@ fn initCommandReplayCapture(
     };
     capture.setComparisonLimit(comparison_limit);
     return .{ .capture = capture };
+}
+
+fn requiredCaptureFailure(
+    arena: Allocator,
+    capture: ?*command_replay_store.Capture,
+    required: bool,
+) !?ToolExecutionResult {
+    if (!required) return null;
+    const candidate = capture orelse {
+        return @as(?ToolExecutionResult, try command_result_mapping.Foreground.outputCaptureFailure(arena));
+    };
+    candidate.sealRequired(arena) catch return @as(
+        ?ToolExecutionResult,
+        try command_result_mapping.Foreground.outputCaptureFailure(arena),
+    );
+    return null;
 }
 
 fn finishCommandToolResult(
@@ -2024,7 +2153,7 @@ const test_context_registry = context_contract.Registry{ .default_provider = .{
 } };
 
 const test_review_calls = [_]ToolCall{
-    .{ .id = "test-review", .name = "terminal", .arguments_json = "{\"action\":\"exec\",\"command\":\"printf test\"}" },
+    .{ .id = "test-review", .name = "terminal", .arguments_json = "{\"action\":\"exec\",\"command\":\"printf test\",\"timeout_ms\":600000}" },
 };
 const test_review_root_messages = [_][]const u8{"test root request"};
 
@@ -2071,6 +2200,7 @@ const TestRuntime = struct {
     context_limits: context_limits.Values = .{},
     command_artifact_dir: ?[]const u8 = null,
     session_child_capability: ?*session_child_store.SessionChildCapability = null,
+    ephemeral_command_replay: ?*command_replay_store.EphemeralStore = null,
     command_timeout_ms: ?usize = null,
     interactive: bool = true,
     mcp_ctx: ?*anyopaque = null,
@@ -2145,6 +2275,7 @@ const TestRuntime = struct {
             .on_background_url_ready = noopBackgroundReady,
             .command_artifact_dir = self.command_artifact_dir,
             .session_child_capability = self.session_child_capability,
+            .ephemeral_command_replay = self.ephemeral_command_replay,
             .command_timeout_ms = self.command_timeout_ms,
             .tracker = self.tracker,
             .mcp_ctx = self.mcp_ctx,
@@ -3180,7 +3311,7 @@ fn runCommandArgsForTest(alloc: Allocator, command: []const u8) ![]u8 {
     defer out.deinit();
     try out.writer.writeAll("{\"action\":\"exec\",\"command\":");
     try std.json.Stringify.value(command, .{}, &out.writer);
-    try out.writer.writeByte('}');
+    try out.writer.writeAll(",\"timeout_ms\":600000}");
     return out.toOwnedSlice();
 }
 
@@ -3189,7 +3320,7 @@ fn runCommandArgsWithCleanProfileForTest(alloc: Allocator, command: []const u8) 
     defer out.deinit();
     try out.writer.writeAll("{\"action\":\"exec\",\"command\":");
     try std.json.Stringify.value(command, .{}, &out.writer);
-    try out.writer.writeAll(",\"profile\":\"clean\"}");
+    try out.writer.writeAll(",\"profile\":\"clean\",\"timeout_ms\":600000}");
     return out.toOwnedSlice();
 }
 
@@ -3225,6 +3356,7 @@ fn terminalExecCallForTest(arena: Allocator, call: ToolCall) !ToolCall {
     );
     if (args != .object) return error.InvalidToolArguments;
     try args.object.put(arena, "action", .{ .string = "exec" });
+    try args.object.put(arena, "timeout_ms", .{ .integer = 600_000 });
     var out: std.Io.Writer.Allocating = .init(arena);
     defer out.deinit();
     try std.json.Stringify.value(args, .{}, &out.writer);
@@ -3244,7 +3376,7 @@ test "registered terminal exec preserves invalid execution authority error" {
     const call = ToolCall{
         .id = "invalid-authority",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf should-not-run\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf should-not-run\",\"timeout_ms\":600000}",
     };
 
     try std.testing.expectError(
@@ -3273,6 +3405,7 @@ test "captured command compatibility bypasses compound commands" {
         .command = "fx-compatibility-probe; printf shell-fallback",
         .resolved_cwd = "/tmp",
         .environment = .legacy,
+        .timeout_ms = 600_000,
     })) == null);
 
     for ([_]command_environment.Environment{
@@ -3286,6 +3419,7 @@ test "captured command compatibility bypasses compound commands" {
                 .command = "fx-compatibility-probe",
                 .resolved_cwd = "/tmp",
                 .environment = environment,
+                .timeout_ms = 600_000,
             },
         )) == null);
     }
@@ -3307,6 +3441,7 @@ test "run command compatibility returns installer failure without shell fallback
             .command = "fx-compatibility-probe",
             .resolved_cwd = "/tmp",
             .environment = .legacy,
+            .timeout_ms = 600_000,
         },
     )) orelse return error.TestExpectedEqual;
 
@@ -4163,7 +4298,7 @@ test "terminal exec execution uses supplied registry entry" {
     const call = ToolCall{
         .id = "run-command-registry",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf bypassed\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf bypassed\",\"timeout_ms\":600000}",
     };
 
     var rt = TestRuntime{ .tool_registry = registry };
@@ -6009,6 +6144,210 @@ test "request tool permission checks copy and rename destinations" {
     try std.testing.expect(absolutePathExists(try std.fs.path.join(arena, &.{ root, "src/source.txt" })));
 }
 
+test "effective command timeout uses the earlier remaining budget" {
+    try std.testing.expectEqual(
+        EffectiveCommandTimeout{ .timeout_ms = 5000, .started_ms = 700 },
+        try effectiveCommandTimeout(5000, null, null, 700),
+    );
+    try std.testing.expectEqual(
+        EffectiveCommandTimeout{ .timeout_ms = 700, .started_ms = 400 },
+        try effectiveCommandTimeout(5000, 1000, 100, 400),
+    );
+    try std.testing.expectEqual(
+        EffectiveCommandTimeout{ .timeout_ms = 100, .started_ms = 400 },
+        try effectiveCommandTimeout(100, 5000, 100, 400),
+    );
+    try std.testing.expectEqual(
+        EffectiveCommandTimeout{ .timeout_ms = 0, .started_ms = 1200 },
+        try effectiveCommandTimeout(5000, 1000, 100, 1200),
+    );
+}
+
+test "terminal exec request timeout reaches execution without an ambient timeout" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+
+    const alloc = std.testing.allocator;
+    var rt = TestRuntime{};
+    defer rt.deinit(alloc);
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const result = try executeTestRunCommand(rt.context(), arena, .{
+        .id = "request-timeout",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"sleep 1\",\"profile\":\"clean\",\"timeout_ms\":25}",
+    });
+
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
+    try expectContains(result.model_output, "timeout=true\n");
+    try expectContains(result.model_output, "timeout_ms=25\n");
+    const structured = result.command_result_json orelse return error.TestExpectedEqual;
+    try expectCommandResultBool(structured, "timed_out", true);
+}
+
+test "saved noninteractive terminal exec captures replay by capability" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(io_mod.getIo());
+    const session_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(session_path);
+    var capability = try session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        session_path,
+        .writable,
+        .{},
+    );
+    defer capability.deinit();
+
+    var rt = TestRuntime{
+        .interactive = false,
+        .session_child_capability = &capability,
+    };
+    defer rt.deinit(alloc);
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+
+    const result = try executeTestRunCommand(rt.context(), arena_state.allocator(), .{
+        .id = "saved-noninteractive",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf replay\",\"profile\":\"clean\",\"timeout_ms\":600000}",
+    });
+    defer if (result.command_replay_capture) |capture| capture.abort(arena_state.allocator());
+
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.success, result.status);
+    try std.testing.expect(result.command_replay_capture != null);
+}
+
+test "no-save terminal exec publishes one readable ephemeral replay" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+
+    const runtime_execution_memory = @import("../agent/runtime/execution_memory.zig");
+    const read_tool_result = @import("../../tools/session/read_tool_result.zig");
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const temp_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(temp_path);
+    var store = command_replay_store.EphemeralStore.initForTesting(alloc, temp_path);
+    defer store.deinit();
+    var rt = TestRuntime{
+        .interactive = false,
+        .ephemeral_command_replay = &store,
+    };
+    defer rt.deinit(alloc);
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const tool_call = ToolCall{
+        .id = "no-save-replay",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf ephemeral-needle\",\"profile\":\"clean\",\"timeout_ms\":600000}",
+    };
+
+    const result = try executeTestRunCommand(rt.context(), arena, tool_call);
+    const capture = result.command_replay_capture orelse return error.TestExpectedReplay;
+    var handed_off = false;
+    defer if (!handed_off) capture.discard(arena);
+    var cancel = std.atomic.Value(bool).init(false);
+    var prepared = try runtime_execution_memory.prepareToolModelOutput(
+        arena,
+        .{
+            .system_prompt = "",
+            .gateway_retry_count = 0,
+            .gateway_chat_url = "",
+            .agent_step_limit = 1,
+            .cancel_flag = &cancel,
+            .ephemeral_command_replay = &store,
+        },
+        tool_call,
+        result.model_output,
+    );
+    try std.testing.expect(prepared.memory.output_handle == null);
+    try runtime_execution_memory.finalizeCommandReplay(
+        arena,
+        tool_call,
+        &prepared,
+        null,
+        capture,
+    );
+    const replay = prepared.memory.command_output_replay orelse
+        return error.TestExpectedReplay;
+    const descriptor = switch (replay) {
+        .available => |value| value,
+        .unavailable => return error.TestExpectedReplay,
+    };
+    try std.testing.expect(std.mem.find(u8, prepared.model_output, descriptor.handle) != null);
+    const read_arguments = try std.fmt.allocPrint(
+        arena,
+        "{{\"handle\":\"{s}\",\"start_byte\":1,\"byte_count\":4096}}",
+        .{descriptor.handle},
+    );
+    const read_ctx = tool_dispatch.DispatchContext{
+        .allocator = arena,
+        .ephemeral_command_replay = &store,
+    };
+    const decoded = try read_tool_result.decode(read_ctx, read_arguments);
+    const read_input = switch (decoded) {
+        .input => |value| value,
+        .failure => return error.TestUnexpectedDecodeFailure,
+    };
+    defer read_input.deinit(arena);
+    const read_result = try read_tool_result.call(read_ctx, read_input);
+    defer read_result.deinit(arena);
+    switch (read_result) {
+        .success => |page| try expectContains(page, "ephemeral-needle"),
+        .failure => return error.TestExpectedReplay,
+    }
+    capture.releaseRetained(arena);
+    handed_off = true;
+
+    var entries = tmp.dir.iterate();
+    try std.testing.expect(try entries.next(io_mod.getIo()) == null);
+}
+
+test "required replay spill failure returns recoverable capture failure" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+
+    const alloc = std.testing.allocator;
+    var store = command_replay_store.EphemeralStore.initForTesting(
+        alloc,
+        "/definitely/missing/fx-replay-dir",
+    );
+    defer store.deinit();
+    var rt = TestRuntime{
+        .interactive = false,
+        .ephemeral_command_replay = &store,
+        .max_command_output_bytes = 1,
+    };
+    defer rt.deinit(alloc);
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+
+    const result = try executeTestRunCommand(rt.context(), arena_state.allocator(), .{
+        .id = "capture-failure",
+        .name = "terminal",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf xx\",\"profile\":\"clean\",\"timeout_ms\":600000}",
+    });
+    defer if (result.command_replay_capture) |capture| capture.abort(arena_state.allocator());
+
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
+    try expectContains(result.model_output, "\"output_capture_failed\":true");
+}
+
 test "run_command timeout returns model-visible failure" {
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
 
@@ -6048,7 +6387,7 @@ test "run_command timeout returns model-visible failure" {
     const tool_call: ToolCall = .{
         .id = "cmd",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf 'PRE-TIMEOUT-OUT\\n'; printf 'PRE-TIMEOUT-ERR\\n' >&2; sleep 5\",\"profile\":\"clean\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf 'PRE-TIMEOUT-OUT\\n'; printf 'PRE-TIMEOUT-ERR\\n' >&2; sleep 5\",\"profile\":\"clean\",\"timeout_ms\":5000}",
     };
 
     const result = try executeTestRunCommand(rt.context(), arena, tool_call);
@@ -6113,7 +6452,7 @@ test "run_command timeout returns model-visible failure" {
     );
     var replay_finalized = false;
     defer if (!replay_finalized) capture.abort(arena);
-    runtime_execution_memory.finalizeCommandReplay(
+    try runtime_execution_memory.finalizeCommandReplay(
         arena,
         tool_call,
         &prepared,
@@ -6215,11 +6554,13 @@ test "interactive command replay capture allocation fails open" {
         std.testing.allocator,
         .{ .fail_index = 0 },
     );
-    const init = initCommandReplayCapture(
+    const init = try initCommandReplayCapture(
         failing.allocator(),
         true,
+        false,
         64 * 1024,
         64 * 1024,
+        null,
         null,
         null,
         false,
@@ -6230,6 +6571,7 @@ test "interactive command replay capture allocation fails open" {
     var callback = CommandReplayCaptureCallback{
         .alloc = std.testing.allocator,
         .capture = null,
+        .required = false,
     };
     try CommandReplayCaptureCallback.onChunk(
         @ptrCast(&callback),
@@ -6393,7 +6735,7 @@ test "run_command success exposes structured foreground metadata" {
     const result = try executeTestRunCommand(rt.context(), arena_state.allocator(), .{
         .id = "cmd",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf '\\\\150\\\\145\\\\154\\\\154\\\\157'\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf '\\\\150\\\\145\\\\154\\\\154\\\\157'\",\"timeout_ms\":600000}",
     });
 
     try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.success, result.status);
@@ -6575,7 +6917,7 @@ test "run_command propagates output callback failure" {
         executeTestRunCommand(ctx, arena_state.allocator(), .{
             .id = "cmd",
             .name = "terminal",
-            .arguments_json = "{\"action\":\"exec\",\"command\":\"printf 'handoff\\\\n'\"}",
+            .arguments_json = "{\"action\":\"exec\",\"command\":\"printf 'handoff\\\\n'\",\"timeout_ms\":600000}",
         }),
     );
 }
@@ -6594,7 +6936,7 @@ test "run_command returns model output and structured metadata" {
     const result = try executeTestRunCommand(rt.context(), arena_state.allocator(), .{
         .id = "cmd",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf 'quiet-stdout\\\\n'; printf 'quiet-stderr\\\\n' >&2\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf 'quiet-stdout\\\\n'; printf 'quiet-stderr\\\\n' >&2\",\"timeout_ms\":600000}",
     });
 
     try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.success, result.status);
@@ -6625,7 +6967,7 @@ test "run_command nonzero exit returns structured masked failure" {
     const result = try executeTestRunCommand(rt.context(), arena_state.allocator(), .{
         .id = "cmd",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf 'bad AKIA0123456789ABCDEF\\\\n' >&2; exit 7\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf 'bad AKIA0123456789ABCDEF\\\\n' >&2; exit 7\",\"timeout_ms\":600000}",
     });
 
     try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
@@ -6677,7 +7019,7 @@ test "run_command huge output exposes truncation and artifact paths without stdo
     const result = try executeTestRunCommand(rt.context(), arena_state.allocator(), .{
         .id = "cmd",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf %026d 0\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"printf %026d 0\",\"timeout_ms\":600000}",
     });
 
     try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.success, result.status);

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -6315,7 +6315,12 @@ test "no-save terminal exec publishes one readable ephemeral replay" {
     capture.releaseRetained(arena);
     handed_off = true;
 
-    var entries = tmp.dir.iterate();
+    var inspect_dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), temp_path, .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer inspect_dir.close(io_mod.getIo());
+    var entries = inspect_dir.iterate();
     try std.testing.expect(try entries.next(io_mod.getIo()) == null);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3944,6 +3944,7 @@ test {
     _ = @import("tools/web/html_to_markdown.zig");
     _ = @import("tools/filesystem/read_file.zig");
     _ = @import("tools/filesystem/semantic_search.zig");
+    _ = @import("tools/session/read_tool_result.zig");
     _ = @import("tools/skills/install_skill.zig");
     _ = @import("tools/skills/skill.zig");
     _ = @import("core/upgrade/upgrade_helpers.zig");

--- a/src/tools/session/read_tool_result.zig
+++ b/src/tools/session/read_tool_result.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const result_store = @import("../../core/session/result_store.zig");
+const command_replay_store = @import("../../core/session/command_replay_store.zig");
 const session_child_store = @import("../../core/session/session_child_store.zig");
 const io_mod = @import("../../core/shared/io.zig");
 const tool_dispatch = @import("../../core/tooling/tool_dispatch.zig");
@@ -87,7 +88,10 @@ pub fn validate(ctx: tool_dispatch.DispatchContext, erased: tool_dispatch.ToolIn
 
 pub fn call(ctx: tool_dispatch.DispatchContext, erased: tool_dispatch.ToolInput) tool_dispatch.DispatchError!tool_dispatch.ToolResult {
     const input = erased.as(Input);
-    if (ctx.session_child_capability == null and ctx.tool_result_dir == null) {
+    if (ctx.session_child_capability == null and
+        ctx.ephemeral_command_replay == null and
+        ctx.tool_result_dir == null)
+    {
         return .{ .failure = try ctx.allocator.dupe(u8, "No active session tool-result store is available.") };
     }
 
@@ -99,10 +103,48 @@ pub fn call(ctx: tool_dispatch.DispatchContext, erased: tool_dispatch.ToolInput)
 
 fn readOutput(ctx: tool_dispatch.DispatchContext, input: *Input) ![]u8 {
     if (ctx.session_child_capability) |capability| {
-        return if (input.query) |query|
+        const ordinary = if (input.query) |query|
             result_store.searchByQueryManaged(ctx.allocator, capability, input.handle, query)
         else
             result_store.readByRangeManaged(ctx.allocator, capability, input.handle, input.start_byte, input.byte_count);
+        return ordinary catch |err| switch (err) {
+            error.ResultHandleNotFound => if (input.query) |query|
+                command_replay_store.searchAgentQueryManaged(
+                    ctx.allocator,
+                    capability,
+                    input.handle,
+                    query,
+                    result_store.read_max_bytes,
+                )
+            else
+                command_replay_store.readAgentPageManaged(
+                    ctx.allocator,
+                    capability,
+                    input.handle,
+                    input.start_byte,
+                    input.byte_count,
+                ),
+            else => return err,
+        };
+    }
+
+    if (ctx.ephemeral_command_replay) |store| {
+        return if (input.query) |query|
+            command_replay_store.searchAgentQueryEphemeral(
+                ctx.allocator,
+                store,
+                input.handle,
+                query,
+                result_store.read_max_bytes,
+            )
+        else
+            command_replay_store.readAgentPageEphemeral(
+                ctx.allocator,
+                store,
+                input.handle,
+                input.start_byte,
+                input.byte_count,
+            );
     }
 
     const dir = ctx.tool_result_dir.?;
@@ -205,6 +247,69 @@ test "unknown read_tool_result handle returns failure for legacy and managed sto
         .failure => |body| try std.testing.expectEqualStrings(expected, body),
         .success => return error.TestExpectedFailure,
     }
+}
+
+test "read_tool_result pages and searches saved command replay handles" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(io_mod.getIo());
+    const session_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(session_path);
+    var capability = try session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        session_path,
+        .writable,
+        .{},
+    );
+    defer capability.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const capture = try command_replay_store.Capture.create(arena, 64 * 1024, &capability);
+    try capture.appendAcceptedRequired(arena, .stdout, "TOKEN=secret-value\nneedle tail\n");
+    const descriptor = (try capture.retainRequired(arena)) orelse
+        return error.TestExpectedReplay;
+    defer capture.releaseRetained(arena);
+
+    var page_input = Input{
+        .handle = try alloc.dupe(u8, descriptor.handle),
+        .start_byte = 1,
+        .byte_count = 4096,
+    };
+    defer page_input.deinit(alloc);
+    const page = try readOutput(.{
+        .allocator = alloc,
+        .session_child_capability = &capability,
+    }, &page_input);
+    defer alloc.free(page);
+    try std.testing.expect(std.mem.find(u8, page, "[stdout]") != null);
+    try std.testing.expect(std.mem.find(u8, page, "TOKEN=[redacted]") != null);
+    try std.testing.expect(std.mem.find(u8, page, "secret-value") == null);
+    try std.testing.expect(std.mem.find(u8, page, "needle tail") != null);
+
+    var query_input = Input{
+        .handle = try alloc.dupe(u8, descriptor.handle),
+        .query = try alloc.dupe(u8, "needle"),
+    };
+    defer query_input.deinit(alloc);
+    const query = try readOutput(.{
+        .allocator = alloc,
+        .session_child_capability = &capability,
+    }, &query_input);
+    defer alloc.free(query);
+    try std.testing.expect(std.mem.find(u8, query, "needle tail") != null);
 }
 
 test "large web_search result is previewed and available through read_tool_result" {

--- a/src/tools/terminal/browser_terminal.zig
+++ b/src/tools/terminal/browser_terminal.zig
@@ -34,7 +34,15 @@ pub fn decode(
     if (command.string.len > js_host_workspace.max_command_bytes) {
         return failure(ctx.allocator, "browser terminal field \"command\" exceeds 65536 bytes");
     }
-    return terminal.decode(ctx, args_json);
+    var native_args: std.Io.Writer.Allocating = .init(ctx.allocator);
+    defer native_args.deinit();
+    native_args.writer.writeAll("{\"action\":\"exec\",\"command\":") catch
+        return error.OutOfMemory;
+    std.json.Stringify.value(command.string, .{}, &native_args.writer) catch
+        return error.OutOfMemory;
+    native_args.writer.print(",\"timeout_ms\":{d}}}", .{js_host_workspace.max_timeout_ms}) catch
+        return error.OutOfMemory;
+    return terminal.decode(ctx, native_args.written());
 }
 
 fn failure(alloc: Allocator, message: []const u8) Allocator.Error!tool_dispatch.DecodeResult {

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -17,6 +17,9 @@ const shell_resolver = @import("../../core/terminal/shell_resolver.zig");
 
 const Allocator = std.mem.Allocator;
 
+pub const exec_timeout_min_ms: u64 = 1;
+pub const exec_timeout_max_ms: u64 = 600_000;
+
 const ShellKind = enum { user_login, executable };
 pub const Action = enum {
     exec,
@@ -139,6 +142,7 @@ pub const Input = struct {
     cwd: ?[]const u8 = null,
     command: ?[]const u8 = null,
     profile: ?command_environment.Profile = null,
+    timeout_ms: ?u64 = null,
     shell: ?ShellInput = null,
     backend: ?contracts.Backend = null,
     return_when: ?ReturnInput = null,
@@ -180,8 +184,8 @@ pub const ActionFieldContract = struct {
 pub fn actionFieldContract(action: Action) ActionFieldContract {
     return switch (action) {
         .exec => .{
-            .allowed = &.{ "action", "command", "cwd", "profile" },
-            .required = &.{ "action", "command" },
+            .allowed = &.{ "action", "command", "cwd", "profile", "timeout_ms" },
+            .required = &.{ "action", "command", "timeout_ms" },
         },
         .start => .{
             .allowed = &.{ "action", "cwd", "command", "profile", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors" },
@@ -392,6 +396,16 @@ pub fn decode(
             "terminal arguments must match the advertised action schema",
         ) };
     };
+    if (action == .exec) {
+        if (raw.object.get("timeout_ms")) |timeout_value| {
+            if (timeout_value != .integer) {
+                return .{ .failure = try ctx.allocator.dupe(
+                    u8,
+                    "terminal exec field \"timeout_ms\" must be an integer between 1 and 600000",
+                ) };
+            }
+        }
+    }
     elideKnownNullFields(&raw.object);
     var correction_scratch: ActionFieldCorrectionScratch = .{};
     defer correction_scratch.deinit(ctx.allocator);
@@ -491,6 +505,12 @@ pub fn validate(
         }
         if (input.command.?.len > contracts.max_command_bytes) {
             return try ctx.allocator.dupe(u8, "terminal exec arguments are invalid: InvalidCommand");
+        }
+        const timeout_ms = input.timeout_ms orelse {
+            return try ctx.allocator.dupe(u8, "terminal exec arguments are invalid: MissingTimeout");
+        };
+        if (timeout_ms < exec_timeout_min_ms or timeout_ms > exec_timeout_max_ms) {
+            return try ctx.allocator.dupe(u8, "terminal exec arguments are invalid: InvalidTimeout");
         }
         _ = resolveCwd(arena, ctx, input.cwd) catch |err| {
             return try std.fmt.allocPrint(
@@ -652,6 +672,9 @@ fn callExec(
     const command = input.command orelse return .{
         .failure = try ctx.allocator.dupe(u8, "terminal exec requires string field \"command\""),
     };
+    const timeout_ms = input.timeout_ms orelse return .{
+        .failure = try ctx.allocator.dupe(u8, "terminal exec requires integer field \"timeout_ms\""),
+    };
     const cwd = resolveCwd(ctx.allocator, ctx, input.cwd) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         return .{ .failure = try std.fmt.allocPrint(
@@ -678,6 +701,7 @@ fn callExec(
         .command = command,
         .resolved_cwd = cwd,
         .environment = environment_value,
+        .timeout_ms = timeout_ms,
     });
 }
 
@@ -1389,7 +1413,7 @@ pub fn isIrreversible(_: tool_dispatch.ToolInput) bool {
 test "terminal decoder accepts every public action and owns its input" {
     const alloc = std.testing.allocator;
     const cases = [_]struct { Action, []const u8 }{
-        .{ .exec, "{\"action\":\"exec\",\"command\":\"true\"}" },
+        .{ .exec, "{\"action\":\"exec\",\"command\":\"true\",\"timeout_ms\":600000}" },
         .{ .start, "{\"action\":\"start\"}" },
         .{ .read, "{\"action\":\"read\",\"session_id\":\"terminal-a\",\"cursor_segment\":1}" },
         .{ .screen, "{\"action\":\"screen\",\"session_id\":\"terminal-a\"}" },
@@ -1475,7 +1499,7 @@ test "terminal action field ownership is exact for every public action" {
         required: []const []const u8,
         conflicts: []const tool_result_errors.TerminalActionFieldConflict = &.{},
     }{
-        .{ .action = .exec, .fields = &.{ "action", "command", "cwd", "profile" }, .required = &.{ "action", "command" } },
+        .{ .action = .exec, .fields = &.{ "action", "command", "cwd", "profile", "timeout_ms" }, .required = &.{ "action", "command", "timeout_ms" } },
         .{ .action = .start, .fields = &.{ "action", "cwd", "command", "profile", "shell", "backend", "return_when", "wait_ceiling_ms", "dimensions", "initial_monitors" }, .required = &.{"action"}, .conflicts = &.{.{ "profile", "shell" }} },
         .{ .action = .read, .fields = &.{ "action", "session_id", "cursor_segment", "cursor_offset" }, .required = &.{ "action", "session_id", "cursor_segment" } },
         .{ .action = .screen, .fields = &.{ "action", "session_id" }, .required = &.{ "action", "session_id" } },
@@ -1515,6 +1539,59 @@ test "terminal action field ownership is exact for every public action" {
                 want_allowed,
                 actionAllowsField(want.action, field.name),
             );
+        }
+    }
+}
+
+test "terminal exec requires a strict bounded integer timeout" {
+    const alloc = std.testing.allocator;
+    const ctx = tool_dispatch.DispatchContext{
+        .allocator = alloc,
+        .workspace_root = "/tmp",
+    };
+
+    for ([_][]const u8{
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":1}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":1000}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":600000}",
+    }) |arguments_json| {
+        const accepted = try decode(ctx, arguments_json);
+        switch (accepted) {
+            .failure => |message| {
+                defer alloc.free(message);
+                return error.TestUnexpectedResult;
+            },
+            .input => |input| {
+                defer input.deinit(alloc);
+                const validation = try validate(ctx, input);
+                defer if (validation) |message| alloc.free(message);
+                try std.testing.expect(validation == null);
+            },
+        }
+    }
+
+    for ([_][]const u8{
+        "{\"action\":\"exec\",\"command\":\"pwd\"}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":null}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":\"1000\"}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":1.5}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":true}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":{}}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":[]}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":-1}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":0}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":600001}",
+        "{\"action\":\"exec\",\"command\":\"pwd\",\"timeout_ms\":18446744073709551616}",
+    }) |arguments_json| {
+        const rejected = try decode(ctx, arguments_json);
+        switch (rejected) {
+            .failure => |message| alloc.free(message),
+            .input => |input| {
+                defer input.deinit(alloc);
+                const validation = try validate(ctx, input);
+                defer if (validation) |message| alloc.free(message);
+                try std.testing.expect(validation != null);
+            },
         }
     }
 }
@@ -1564,7 +1641,7 @@ test "terminal decoder elides textual null placeholders like real nulls" {
     const alloc = std.testing.allocator;
     const exec_call = try decode(
         .{ .allocator = alloc },
-        "{\"action\":\"exec\",\"command\":\"echo ONE\",\"cwd\":\".\",\"profile\":\"NULL\"," ++
+        "{\"action\":\"exec\",\"command\":\"echo ONE\",\"cwd\":\".\",\"profile\":\"NULL\",\"timeout_ms\":600000," ++
             "\"session_id\":\"null\",\"task_id\":\"null\",\"workspace_root\":\" null \"," ++
             "\"shell\":null,\"backend\":\"null\",\"return_when\":\"null\",\"lease\":\"null\"}",
     );
@@ -1611,7 +1688,7 @@ test "terminal decoder keeps command text that merely contains a null placeholde
     const alloc = std.testing.allocator;
     const accepted = try decode(
         .{ .allocator = alloc },
-        "{\"action\":\"exec\",\"command\":\"echo null\"}",
+        "{\"action\":\"exec\",\"command\":\"echo null\",\"timeout_ms\":600000}",
     );
     switch (accepted) {
         .failure => |message| {
@@ -1632,7 +1709,7 @@ test "terminal decoder reports a textual null placeholder on a required field as
     const alloc = std.testing.allocator;
     const rejected = try decode(
         .{ .allocator = alloc },
-        "{\"action\":\"exec\",\"command\":\"null\"}",
+        "{\"action\":\"exec\",\"command\":\"null\",\"timeout_ms\":600000}",
     );
     switch (rejected) {
         .failure => |message| {
@@ -2117,7 +2194,7 @@ test "registered terminal validation enforces action-specific input before execu
     @memset(oversized_command, 'x');
     const oversized_json = try std.fmt.allocPrint(
         std.testing.allocator,
-        "{{\"action\":\"exec\",\"command\":\"{s}\"}}",
+        "{{\"action\":\"exec\",\"command\":\"{s}\",\"timeout_ms\":600000}}",
         .{oversized_command},
     );
     defer std.testing.allocator.free(oversized_json);

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -144,7 +144,7 @@ function lengthLimitedCommandCall(command: string) {
       type: "tool-call",
       toolCallId: "command_1",
       toolName: "terminal",
-      input: { action: "exec", command },
+      input: { action: "exec", timeout_ms: 600_000, command },
     },
     {
       type: "finish",
@@ -6224,6 +6224,7 @@ describe("acp: model-independent", () => {
       const gateway = startFakeGateway([
         fakeGatewayToolCall("approved_command_1", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: `printf approved > '${marker}'`,
         }),
         finalText("command approval complete"),
@@ -6999,6 +7000,7 @@ describe("acp: model-independent", () => {
         [
           fakeGatewayToolCall("cancelled_review_command", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: `printf cancelled > ${JSON.stringify(marker)}`,
           }),
           finalText("follow-up after ACP review cancellation"),

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -289,7 +289,7 @@ describe("fx ask presentation", () => {
     };
     const terminalTool = firstRequest.tools.find(({ name }) => name === "terminal");
     expect(terminalTool?.description).toBe(
-      "Run one captured command and return its result.",
+      "Run one captured command with a required finite timeout_ms and return its result.",
     );
     const terminalSchema = terminalTool?.inputSchema;
     expect(terminalSchema?.properties?.action?.enum).toEqual(["exec"]);
@@ -298,8 +298,15 @@ describe("fx ask presentation", () => {
       "command",
       "cwd",
       "profile",
+      "timeout_ms",
     ]);
-    expect(terminalSchema?.required).toEqual(["action", "command", "cwd", "profile"]);
+    expect(terminalSchema?.required).toEqual([
+      "action",
+      "command",
+      "cwd",
+      "profile",
+      "timeout_ms",
+    ]);
     expect(terminalSchema?.additionalProperties).toBe(false);
     expect(terminalSchema?.properties?.command?.description).toBe(
       "Command to run. Set null when the selected action does not use this field.",
@@ -309,6 +316,9 @@ describe("fx ask presentation", () => {
     );
     expect(terminalSchema?.properties?.profile?.description).toBe(
       "Profile for exec; omission defaults to user, while clean skips user initialization files. User execution supports the configured Bash or zsh login shell. Bash login execution reads login initialization files; .bashrc is available only when sourced by the login profile. Set null when the selected action does not use this field.",
+    );
+    expect(terminalSchema?.properties?.timeout_ms?.description).toBe(
+      "Maximum foreground runtime in milliseconds. Choose the shortest realistic finite budget; use terminal start for work that must remain alive.",
     );
     const serializedTerminalTool = JSON.stringify(terminalTool);
     expect(serializedTerminalTool).not.toContain("Use start");

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -145,13 +145,13 @@ describe("fx ask presentation", () => {
           type: "tool-call",
           toolCallId: "no-final-newline",
           toolName: "terminal",
-          input: { action: "exec", command: "printf no-final-newline" },
+          input: { action: "exec", timeout_ms: 600_000, command: "printf no-final-newline" },
         },
         {
           type: "tool-call",
           toolCallId: "next-command",
           toolName: "terminal",
-          input: { action: "exec", command: "printf 'next-output\\n'" },
+          input: { action: "exec", timeout_ms: 600_000, command: "printf 'next-output\\n'" },
         },
         {
           type: "finish",
@@ -216,15 +216,18 @@ describe("fx ask presentation", () => {
     const gateway = startFakeGateway([
       fakeGatewayToolCall("terminal-omitted", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: profileCommand,
       }),
       fakeGatewayToolCall("terminal-clean", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: profileCommand,
         profile: "clean",
       }),
       fakeGatewayToolCall("terminal-user", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: profileCommand,
         profile: "user",
       }),
@@ -237,11 +240,13 @@ describe("fx ask presentation", () => {
       fakeGatewayToolCall("terminal-nested-exec", "terminal", {
         request: {
           action: "exec",
+          timeout_ms: 600_000,
           command: `printf nested > ${JSON.stringify(nestedExecMarker)}`,
         },
       }),
       fakeGatewayToolCall("terminal-neighbor-exec", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: "printf neighbor-exec",
       }),
       fakeGatewayFinalText("Terminal no-save profiles verified.\n"),
@@ -842,6 +847,7 @@ describe("fx ask presentation", () => {
         [
           fakeGatewayToolCall("write_fixture", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: "printf notice-test > ask-notice.txt",
           }),
           fakeGatewayFinalText("Notice filtering complete.\n"),

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -83,12 +83,13 @@ function gatewayEnv(
 }
 
 function commandCall(command: string, id: string) {
-  return fakeGatewayToolCall(id, "terminal", { action: "exec", command });
+  return fakeGatewayToolCall(id, "terminal", { action: "exec", timeout_ms: 600_000, command });
 }
 
 function userCommandCall(command: string, id: string) {
   return fakeGatewayToolCall(id, "terminal", {
     action: "exec",
+    timeout_ms: 600_000,
     command,
     profile: "user",
   });
@@ -97,6 +98,7 @@ function userCommandCall(command: string, id: string) {
 function cleanCommandCall(command: string, id: string) {
   return fakeGatewayToolCall(id, "terminal", {
     action: "exec",
+    timeout_ms: 600_000,
     command,
     profile: "clean",
   });
@@ -319,7 +321,7 @@ describe("lean auto mode reliability", () => {
               type: "tool-call",
               toolCallId: "clean_direct_pwd",
               toolName: "terminal",
-              input: { action: "exec", command: "pwd", profile: "clean" },
+              input: { action: "exec", timeout_ms: 600_000, command: "pwd", profile: "clean" },
             },
             {
               type: "tool-call",
@@ -327,6 +329,7 @@ describe("lean auto mode reliability", () => {
               toolName: "terminal",
               input: {
                 action: "exec",
+                timeout_ms: 600_000,
                 command: "git status --short",
                 profile: "clean",
               },
@@ -337,6 +340,7 @@ describe("lean auto mode reliability", () => {
               toolName: "terminal",
               input: {
                 action: "exec",
+                timeout_ms: 600_000,
                 command: "git reset --hard",
                 profile: "clean",
               },
@@ -1189,13 +1193,13 @@ describe("lean auto mode reliability", () => {
               type: "tool-call",
               toolCallId: "mixed_block_3",
               toolName: "terminal",
-              input: { action: "exec", command: `touch ${JSON.stringify(markers[2]!)}` },
+              input: { action: "exec", timeout_ms: 600_000, command: `touch ${JSON.stringify(markers[2]!)}` },
             },
             {
               type: "tool-call",
               toolCallId: "mixed_safe_pwd",
               toolName: "terminal",
-              input: { action: "exec", command: "pwd" },
+              input: { action: "exec", timeout_ms: 600_000, command: "pwd" },
             },
             {
               type: "finish",
@@ -1322,7 +1326,7 @@ describe("lean auto mode reliability", () => {
       await activeSession.sendText("Initialize the saved allow session.");
       await activeSession.waitForText("allow session initialized", TIMEOUT);
       await activeSession.sendText(
-        `/permissions remember allow terminal ${JSON.stringify({ action: "exec", command: allowedCommand })}`,
+        `/permissions remember allow terminal ${JSON.stringify({ action: "exec", timeout_ms: 600_000, command: allowedCommand })}`,
       );
       await activeSession.waitForText("Remember allow for this saved session", TIMEOUT);
       await activeSession.sendKeys("1");
@@ -1444,7 +1448,7 @@ describe("lean auto mode reliability", () => {
       await activeSession.sendText("Initialize this saved session.");
       await activeSession.waitForText("session initialized", TIMEOUT);
       await activeSession.sendText(
-        `/permissions remember deny terminal ${JSON.stringify({ action: "exec", command: blockedCommand })}`,
+        `/permissions remember deny terminal ${JSON.stringify({ action: "exec", timeout_ms: 600_000, command: blockedCommand })}`,
       );
       await activeSession.waitForText("Remember deny for this saved session", TIMEOUT);
       await activeSession.sendKeys("1");

--- a/tests/e2e/file-tool-paths.test.ts
+++ b/tests/e2e/file-tool-paths.test.ts
@@ -12,7 +12,6 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EVAL_MODEL, HAS_API_KEY, runFx } from "../evals/eval-helpers";
-import { withNativeExecTimeout } from "./tmux-helpers";
 
 const TIMEOUT = 20_000;
 const MODEL = "openai/gpt-5";
@@ -30,9 +29,7 @@ type GatewayResponse =
 
 function sse(events: object[]) {
   return new Response(
-    events.map((event) =>
-      `data: ${JSON.stringify(withNativeExecTimeout(event))}\n\n`
-    ).join("") +
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") +
       "data: [DONE]\n\n",
     { headers: { "content-type": "text/event-stream" } },
   );
@@ -430,7 +427,7 @@ describe("filesystem path handling", () => {
           {
             id: "added_cwd_1",
             name: "terminal",
-            input: { action: "exec", command: "pwd", cwd: root.external },
+            input: { action: "exec", timeout_ms: 600_000, command: "pwd", cwd: root.external },
             expected: root.external,
           },
         ];
@@ -610,6 +607,7 @@ describe("filesystem path handling", () => {
       const gateway = startFakeGateway([
         toolCall("added_command_write_1", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: "printf COMMAND_ADDED_WRITE > command-proof.txt",
           cwd: root.external,
         }),
@@ -766,6 +764,7 @@ describe("filesystem path handling", () => {
           const gateway = startFakeGateway([
             toolCall(scenario.id, "terminal", {
               action: "exec",
+              timeout_ms: 600_000,
               command: `pwd; printf ${scenario.id} > ${scenario.id}.txt`,
               cwd: scenario.cwd,
             }),

--- a/tests/e2e/file-tool-paths.test.ts
+++ b/tests/e2e/file-tool-paths.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { EVAL_MODEL, HAS_API_KEY, runFx } from "../evals/eval-helpers";
+import { withNativeExecTimeout } from "./tmux-helpers";
 
 const TIMEOUT = 20_000;
 const MODEL = "openai/gpt-5";
@@ -29,7 +30,9 @@ type GatewayResponse =
 
 function sse(events: object[]) {
   return new Response(
-    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") +
+    events.map((event) =>
+      `data: ${JSON.stringify(withNativeExecTimeout(event))}\n\n`
+    ).join("") +
       "data: [DONE]\n\n",
     { headers: { "content-type": "text/event-stream" } },
   );

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -182,7 +183,7 @@ function lengthLimitedCommandResponse(command: string): Response {
       `data: ${JSON.stringify({
         type: "tool-call",
         toolName: "terminal",
-        input: { action: "exec", command },
+        input: { action: "exec", command, timeout_ms: 600_000 },
       })}\n\n` +
       'data: {"type":"finish","finishReason":{"unified":"length","raw":"length"}}\n\n' +
       "data: [DONE]\n\n",
@@ -739,7 +740,7 @@ describe("gateway stream lifecycle", () => {
       expect(request.prompt[1]?.role).toBe("system");
       expect(contentText(request.prompt[1]?.content)).toBe(WEB_SEARCH_GUIDANCE);
       expect(toolByName(oracleRequest, "terminal")?.description).toBe(
-        "Run one captured command and return its result.",
+        "Run one captured command with a required finite timeout_ms and return its result.",
       );
       expect(toolByName(oracleRequest, "skill")?.description).toContain(
         "the task clearly matches one",
@@ -2726,7 +2727,11 @@ describe("gateway stream lifecycle", () => {
     const command = `cat <<'FX_LONG_COMMAND' > long-command-output.txt\n${payload}\nFX_LONG_COMMAND\n`;
     expect(Buffer.byteLength(command)).toBeGreaterThan(20 * 1024);
     const responses = [
-      fakeGatewayToolCall(callId, "terminal", { action: "exec", command }),
+      fakeGatewayToolCall(callId, "terminal", {
+        action: "exec",
+        command,
+        timeout_ms: 600_000,
+      }),
       fakeGatewayFinalText("Long command fixture written."),
     ];
     const gateway = startGateway(() =>
@@ -2760,6 +2765,278 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test("no-save terminal timeout returns a readable process-scoped replay handle", async () => {
+    const root = createFixtureRoot("terminal-timeout-replay");
+    const tracePath = join(root.root, "trace.log");
+    const markerPath = join(root.workspace, "must-not-run.txt");
+    const childPidPath = join(root.workspace, "timeout-child.pid");
+    const invalidCallId = "terminal_missing_timeout_1";
+    const timeoutCallId = "terminal_timeout_1";
+    const readCallId = "terminal_replay_read_1";
+    let step = 0;
+    let replayHandle = "";
+    const gateway = startGateway((body) => {
+      switch (step++) {
+        case 0:
+          return fakeGatewayToolCall(invalidCallId, "terminal", {
+            action: "exec",
+            command: "printf should-not-run > must-not-run.txt",
+            timeout_ms: undefined,
+          });
+        case 1: {
+          const correction = toolResultOutput(body, invalidCallId);
+          expect(correction).toContain("missing_fields");
+          expect(correction).toContain("timeout_ms");
+          expect(existsSync(markerPath)).toBe(false);
+          return fakeGatewayToolCall(timeoutCallId, "terminal", {
+            action: "exec",
+            command: `sleep 30 & child=$!; printf '%s' "$child" > ${JSON.stringify(childPidPath)}; printf 'PRE-TIMEOUT-OUT\\n'; wait "$child"`,
+            profile: "clean",
+            timeout_ms: 500,
+          });
+        }
+        case 2: {
+          const timedOut = toolResultOutput(body, timeoutCallId);
+          expect(timedOut).toContain("timeout=true");
+          const match = timedOut.match(
+            /<command_output_handle>([^<]+)<\/command_output_handle>/,
+          );
+          replayHandle = match?.[1] ?? "";
+          expect(replayHandle).not.toBe("");
+          return fakeGatewayToolCall(readCallId, "read_tool_result", {
+            handle: replayHandle,
+            query: "PRE-TIMEOUT-OUT",
+          });
+        }
+        case 3:
+          expect(toolResultOutput(body, readCallId)).toContain("PRE-TIMEOUT-OUT");
+          return fakeGatewayFinalText("Timeout replay inspected.");
+        default:
+          return new Response("unexpected request", { status: 500 });
+      }
+    });
+
+    try {
+      const startedAt = Date.now();
+      const result = await runFx(
+        ["ask", "--json", "--yolo", "--no-save", "Run the timeout fixture."],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          timeoutMs: 15_000,
+        },
+      );
+      const elapsedMs = Date.now() - startedAt;
+      const json = parseAskJson(result.stdout);
+
+      expect(result.code).toBe(0);
+      expect(json.output).toContain("Timeout replay inspected.");
+      expect(gateway.requestCount()).toBe(4);
+      expect(elapsedMs).toBeLessThan(5_000);
+      expect(existsSync(markerPath)).toBe(false);
+      expect(existsSync(join(root.home, ".fx", "sessions"))).toBe(false);
+      const childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
+      expect(Number.isInteger(childPid)).toBe(true);
+      await waitForProcessExit(childPid);
+      expect(isProcessAlive(childPid)).toBe(false);
+
+      const expiredCallId = "expired_replay_read_1";
+      const expiredResponses = [
+        fakeGatewayToolCall(expiredCallId, "read_tool_result", {
+          handle: replayHandle,
+          start_byte: 1,
+          byte_count: 1024,
+        }),
+        fakeGatewayFinalText("Expired replay handled."),
+      ];
+      const expiredGateway = startGateway(() =>
+        expiredResponses.shift() ?? new Response("unexpected request", { status: 500 })
+      );
+      try {
+        const expired = await runFx(
+          ["ask", "--json", "--yolo", "--no-save", "Read the prior replay."],
+          {
+            cwd: root.workspace,
+            env: fixtureEnv(root, expiredGateway, tracePath),
+            timeoutMs: 15_000,
+          },
+        );
+        expect(expired.code).toBe(0);
+        expect(expiredGateway.requestCount()).toBe(2);
+        expect(
+          toolResultOutput(expiredGateway.requests[1]!.body, expiredCallId),
+        ).toContain("ResultHandleNotFound");
+      } finally {
+        expiredGateway.stop();
+      }
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("saved terminal replay handle remains readable after resume without re-execution", async () => {
+    const root = createFixtureRoot("saved-terminal-replay");
+    const firstTracePath = join(root.root, "first-trace.log");
+    const resumeTracePath = join(root.root, "resume-trace.log");
+    const executionsPath = join(root.workspace, "executions.txt");
+    const commandCallId = "saved_terminal_command_1";
+    const readCallId = "saved_terminal_read_1";
+    let replayHandle = "";
+    const firstResponses = [
+      fakeGatewayToolCall(commandCallId, "terminal", {
+        action: "exec",
+        command: "printf 'run\\n' >> executions.txt; printf 'SAVED-REPLAY-NEEDLE\\n'",
+        profile: "clean",
+        timeout_ms: 600_000,
+      }),
+      (body: string) => {
+        const commandOutput = toolResultOutput(body, commandCallId);
+        const match = commandOutput.match(
+          /<command_output_handle>([^<]+)<\/command_output_handle>/,
+        );
+        replayHandle = match?.[1] ?? "";
+        expect(replayHandle).not.toBe("");
+        return fakeGatewayToolCall(readCallId, "read_tool_result", {
+          handle: replayHandle,
+          query: "SAVED-REPLAY-NEEDLE",
+        });
+      },
+      (body: string) => {
+        expect(toolResultOutput(body, readCallId)).toContain("SAVED-REPLAY-NEEDLE");
+        return fakeGatewayFinalText("Saved replay inspected.");
+      },
+    ];
+    const firstGateway = startGateway((body) => {
+      const response = firstResponses.shift();
+      if (!response) return new Response("unexpected request", { status: 500 });
+      return typeof response === "function" ? response(body) : response;
+    });
+
+    try {
+      const first = await runFx(
+        ["ask", "--json", "--yolo", "Run the saved replay fixture."],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, firstGateway, firstTracePath),
+          timeoutMs: 15_000,
+        },
+      );
+      const firstJson = parseAskJson(first.stdout);
+      expect(first.code).toBe(0);
+      expect(firstJson.output).toContain("Saved replay inspected.");
+      expect(firstJson.session_id).not.toBe("");
+      expect(readFileSync(executionsPath, "utf8")).toBe("run\n");
+
+      const resumedReadCallId = "saved_terminal_resume_read_1";
+      const resumeResponses = [
+        fakeGatewayToolCall(resumedReadCallId, "read_tool_result", {
+          handle: replayHandle,
+          query: "SAVED-REPLAY-NEEDLE",
+        }),
+        (body: string) => {
+          expect(toolResultOutput(body, resumedReadCallId)).toContain(
+            "SAVED-REPLAY-NEEDLE",
+          );
+          return fakeGatewayFinalText("Resumed replay inspected.");
+        },
+      ];
+      const resumeGateway = startGateway((body) => {
+        const response = resumeResponses.shift();
+        if (!response) return new Response("unexpected request", { status: 500 });
+        return typeof response === "function" ? response(body) : response;
+      });
+      try {
+        const resumed = await runFx(
+          [
+            "ask",
+            "--json",
+            "--yolo",
+            "--resume-id",
+            firstJson.session_id,
+            "Read the saved replay again.",
+          ],
+          {
+            cwd: root.workspace,
+            env: fixtureEnv(root, resumeGateway, resumeTracePath),
+            timeoutMs: 15_000,
+          },
+        );
+        expect(resumed.code).toBe(0);
+        expect(parseAskJson(resumed.stdout).output).toContain(
+          "Resumed replay inspected.",
+        );
+        expect(readFileSync(executionsPath, "utf8")).toBe("run\n");
+      } finally {
+        resumeGateway.stop();
+      }
+    } finally {
+      firstGateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("SIGKILL leaves no named no-save replay output", async () => {
+    const root = createFixtureRoot("no-save-replay-sigkill");
+    const tracePath = join(root.root, "trace.log");
+    const before = new Set(
+      readdirSync(tmpdir()).filter((name) =>
+        name.startsWith(".fx-command-replay-")
+      ),
+    );
+    const gateway = startGateway(() =>
+      fakeGatewayToolCall("no_save_sigkill_1", "terminal", {
+        action: "exec",
+        command:
+          "awk 'BEGIN { for (i = 0; i < 100000; i++) printf \"x\"; printf \"\\n\" }'; sleep 30",
+        profile: "clean",
+        timeout_ms: 600_000,
+      })
+    );
+    const proc = Bun.spawn(
+      [FX_BIN, "ask", "--yolo", "--no-save", "Run the crash cleanup fixture."],
+      {
+        cwd: root.workspace,
+        env: {
+          ...fixtureEnv(root, gateway, tracePath),
+          FX_TRACE_SCOPES: "agent,core,gateway,stream,session",
+        },
+        stdout: "ignore",
+        stderr: "pipe",
+      },
+    );
+
+    try {
+      const deadline = Date.now() + 10_000;
+      while (
+        Date.now() < deadline &&
+        (!existsSync(tracePath) ||
+          !readFileSync(tracePath, "utf8").includes(
+            "command replay ephemeral backing opened",
+          ))
+      ) {
+        await Bun.sleep(25);
+      }
+      expect(existsSync(tracePath)).toBe(true);
+      expect(readFileSync(tracePath, "utf8")).toContain(
+        "command replay ephemeral backing opened",
+      );
+
+      proc.kill("SIGKILL");
+      await proc.exited;
+      await Bun.sleep(50);
+      const after = readdirSync(tmpdir()).filter((name) =>
+        name.startsWith(".fx-command-replay-") && !before.has(name)
+      );
+      expect(after).toEqual([]);
+      expect(existsSync(join(root.home, ".fx", "sessions"))).toBe(false);
+    } finally {
+      if (proc.exitCode === null) proc.kill("SIGKILL");
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 20_000);
+
   test("SIGTERM drains an active headless terminal command without panic or survivors", async () => {
     const root = createFixtureRoot("headless-sigterm");
     const tracePath = join(root.root, "trace.log");
@@ -2773,6 +3050,7 @@ describe("gateway stream lifecycle", () => {
       fakeGatewayToolCall("headless_sigterm_1", "terminal", {
         action: "exec",
         command,
+        timeout_ms: 600_000,
       })
     );
     const proc = Bun.spawn([
@@ -4587,7 +4865,7 @@ describe("gateway stream lifecycle", () => {
     const sentinelPath = join(root.workspace, "command-must-not-run.txt");
     const responses = [
       sse(
-        'data: {"type":"tool-call","toolCallId":"command_1","toolName":"terminal","input":{"action":"exec","command":"printf executed > command-must-not-run.txt"}}\n\n' +
+        'data: {"type":"tool-call","toolCallId":"command_1","toolName":"terminal","input":{"action":"exec","command":"printf executed > command-must-not-run.txt","timeout_ms":30000}}\n\n' +
           'data: {"type":"finish","finishReason":{"unified":"error","raw":"provider_error"}}\n\n' +
           "data: [DONE]\n\n",
       ),
@@ -5056,7 +5334,7 @@ describe("gateway stream lifecycle", () => {
     const sentinelPath = join(root.workspace, "command-must-not-run.txt");
     const gateway = startGateway(() =>
       sse(
-        'data: {"type":"tool-call","toolCallId":"command_1","toolName":"terminal","input":{"action":"exec","command":"printf executed > command-must-not-run.txt"}}\n\n' +
+        'data: {"type":"tool-call","toolCallId":"command_1","toolName":"terminal","input":{"action":"exec","command":"printf executed > command-must-not-run.txt","timeout_ms":30000}}\n\n' +
           'data: {"type":"finish","finishReason":{"unified":"","raw":"provider_error"}}\n\n' +
           "data: [DONE]\n\n",
       ),

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2980,7 +2980,7 @@ describe("gateway stream lifecycle", () => {
     const root = createFixtureRoot("no-save-replay-sigkill");
     const tracePath = join(root.root, "trace.log");
     const before = new Set(
-      readdirSync(tmpdir()).filter((name) =>
+      readdirSync("/tmp").filter((name) =>
         name.startsWith(".fx-command-replay-")
       ),
     );
@@ -3025,7 +3025,7 @@ describe("gateway stream lifecycle", () => {
       proc.kill("SIGKILL");
       await proc.exited;
       await Bun.sleep(50);
-      const after = readdirSync(tmpdir()).filter((name) =>
+      const after = readdirSync("/tmp").filter((name) =>
         name.startsWith(".fx-command-replay-") && !before.has(name)
       );
       expect(after).toEqual([]);
@@ -3844,6 +3844,7 @@ describe("gateway stream lifecycle", () => {
       if (responseIndex++ === 0) {
         return fakeGatewayToolCall("prompt_too_long_tool_1", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: `printf 'once\\n' >> '${sideEffectPath}'`,
         });
       }

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3118,6 +3118,118 @@ describe("gateway stream lifecycle", () => {
     }
   }, 20_000);
 
+  test("saved SIGINT retains cancelled terminal output for resume without re-execution", async () => {
+    const root = createFixtureRoot("saved-cancelled-terminal-replay");
+    const firstTracePath = join(root.root, "first-trace.log");
+    const resumeTracePath = join(root.root, "resume-trace.log");
+    const readyPath = join(root.workspace, "cancelled-command.ready");
+    const executionsPath = join(root.workspace, "cancelled-executions.txt");
+    const commandCallId = "saved_cancelled_terminal_1";
+    const readCallId = "saved_cancelled_replay_read_1";
+    const command = [
+      "printf 'run\\n' >> cancelled-executions.txt",
+      "printf 'CANCELLED-REPLAY-NEEDLE\\n'",
+      `printf ready > ${JSON.stringify(readyPath)}`,
+      "trap 'exit 0' TERM",
+      "while :; do sleep 1; done",
+    ].join("; ");
+    let phase: "initial" | "resume" = "initial";
+    let resumeStep = 0;
+    let replayHandle = "";
+    const gateway = startGateway((body) => {
+      if (phase === "initial") {
+        return fakeGatewayToolCall(commandCallId, "terminal", {
+          action: "exec",
+          command,
+          profile: "clean",
+          timeout_ms: 600_000,
+        });
+      }
+      if (resumeStep++ === 0) {
+        return fakeGatewayToolCall(readCallId, "read_tool_result", {
+          handle: replayHandle,
+          query: "CANCELLED-REPLAY-NEEDLE",
+        });
+      }
+      expect(toolResultOutput(body, readCallId)).toContain(
+        "CANCELLED-REPLAY-NEEDLE",
+      );
+      return fakeGatewayFinalText("Cancelled replay inspected after resume.");
+    });
+    const proc = Bun.spawn(
+      [FX_BIN, "ask", "--json", "--yolo", "Run the cancellable command fixture."],
+      {
+        cwd: root.workspace,
+        env: fixtureEnv(root, gateway, firstTracePath),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    try {
+      const startDeadline = Date.now() + 10_000;
+      while (!existsSync(readyPath)) {
+        if (Date.now() >= startDeadline) {
+          throw new Error("cancellable terminal command did not start");
+        }
+        await Bun.sleep(10);
+      }
+      proc.kill("SIGINT");
+      const exitCode = await proc.exited;
+      const stderr = await new Response(proc.stderr).text();
+      expect(exitCode).toBe(130);
+      expect(proc.signalCode).toBe("SIGINT");
+      expect(stderr).not.toContain("panic: reached unreachable code");
+
+      const latest = await runFx(["session", "last", "--json"], {
+        cwd: root.workspace,
+        env: { HOME: root.home },
+      });
+      expect(latest.code).toBe(0);
+      const sessionId = JSON.parse(latest.stdout).id as string;
+      const sessionRoot = join(root.home, ".fx", "sessions", sessionId);
+      const events = readFileSync(join(sessionRoot, "events.jsonl"), "utf8");
+      const replayMatch = events.match(
+        /"cancelled_command":\{"output_replay":\{"kind":"available","handle":"([^"]+)"/,
+      );
+      replayHandle = replayMatch?.[1] ?? "";
+      expect(replayHandle).not.toBe("");
+      expect(
+        readdirSync(join(sessionRoot, "logs", "commands")).filter((name) =>
+          name.endsWith(".bin")
+        ),
+      ).toHaveLength(1);
+
+      phase = "resume";
+      const resumed = await runFx(
+        [
+          "ask",
+          "--json",
+          "--yolo",
+          "--resume-id",
+          sessionId,
+          "Inspect the cancelled command output.",
+        ],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, resumeTracePath),
+          timeoutMs: 15_000,
+        },
+      );
+      expect(resumed.code).toBe(0);
+      expect(parseAskJson(resumed.stdout).output).toContain(
+        "Cancelled replay inspected after resume.",
+      );
+      expect(readFileSync(executionsPath, "utf8")).toBe("run\n");
+      expect(gateway.requestCount()).toBe(3);
+    } finally {
+      if (proc.exitCode === null) proc.kill("SIGKILL");
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test(
     "nine saved turns stay canonical while the next request uses bounded context",
     async () => {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3146,6 +3146,14 @@ describe("gateway stream lifecycle", () => {
         });
       }
       if (resumeStep++ === 0) {
+        const replayMatches = [
+          ...body.matchAll(
+            /<command_output_handle>([^<]+)<\/command_output_handle>/g,
+          ),
+        ];
+        expect(replayMatches).toHaveLength(1);
+        replayHandle = replayMatches[0]?.[1] ?? "";
+        expect(replayHandle).not.toBe("");
         return fakeGatewayToolCall(readCallId, "read_tool_result", {
           handle: replayHandle,
           query: "CANCELLED-REPLAY-NEEDLE",
@@ -3189,12 +3197,6 @@ describe("gateway stream lifecycle", () => {
       expect(latest.code).toBe(0);
       const sessionId = JSON.parse(latest.stdout).id as string;
       const sessionRoot = join(root.home, ".fx", "sessions", sessionId);
-      const events = readFileSync(join(sessionRoot, "events.jsonl"), "utf8");
-      const replayMatch = events.match(
-        /"cancelled_command":\{"output_replay":\{"kind":"available","handle":"([^"]+)"/,
-      );
-      replayHandle = replayMatch?.[1] ?? "";
-      expect(replayHandle).not.toBe("");
       expect(
         readdirSync(join(sessionRoot, "logs", "commands")).filter((name) =>
           name.endsWith(".bin")

--- a/tests/e2e/notifications.test.ts
+++ b/tests/e2e/notifications.test.ts
@@ -278,6 +278,7 @@ test.skipIf(!tmuxAvailable())(
     const gateway = startFakeGateway([
       fakeGatewayToolCall("ask_permission_1", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: "touch ask-permission-marker.txt",
       }),
       fakeGatewayFinalText("NOTIFICATION_ASK_PERMISSION_COMPLETE"),
@@ -330,6 +331,7 @@ test.skipIf(!tmuxAvailable())(
     const gateway = startFakeGateway([
       fakeGatewayToolCall("permission_1", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: "touch permission-marker.txt",
       }),
       fakeGatewayFinalText("NOTIFICATION_PERMISSION_COMPLETE"),

--- a/tests/e2e/permission-errors.test.ts
+++ b/tests/e2e/permission-errors.test.ts
@@ -120,6 +120,7 @@ async function runTtyPromptPermissionsCase(
   const gateway = startFakeGateway([
     fakeGatewayToolCall(`${decision}_${outputMode}_call`, "terminal", {
       action: "exec",
+      timeout_ms: 600_000,
       command: `touch ${JSON.stringify(marker)}`,
     }),
     fakeGatewayFinalText(`${decision} ${outputMode} complete`),
@@ -171,6 +172,7 @@ describe("generic permission typed errors", () => {
       const gateway = startFakeGateway([
         fakeGatewayToolCall(toolCallId, "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: `touch ${JSON.stringify(marker)}`,
         }),
         fakeGatewayFinalText("permission error observed"),
@@ -257,6 +259,7 @@ describe("generic permission typed errors", () => {
             if (index > 0) expect(body).toContain("review_caution");
             return fakeGatewayToolCall(`auto_call_${index + 1}`, "terminal", {
               action: "exec",
+              timeout_ms: 600_000,
               command: `touch ${JSON.stringify(marker)}`,
             });
           }),
@@ -335,6 +338,7 @@ describe("generic permission typed errors", () => {
         const gateway = startFakeGateway([
           fakeGatewayToolCall("non_tty_call", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: `touch ${JSON.stringify(marker)}`,
           }),
         ]);

--- a/tests/e2e/render-lab/index.ts
+++ b/tests/e2e/render-lab/index.ts
@@ -1746,7 +1746,7 @@ function startActiveToolGatewayFixture(): LocalGatewayFixture {
           ? [
               `data: ${JSON.stringify({ type: "tool-input-start", id: "active_tool_1", toolName: "terminal" })}`,
               "",
-              `data: ${JSON.stringify({ type: "tool-call", toolCallId: "active_tool_1", toolName: "terminal", input: { action: "exec", command: "sleep 1; i=1; while [ \"$i\" -le 32 ]; do printf 'ACTIVE_TOOL_LINE_%02d\\n' \"$i\"; i=$((i+1)); sleep 0.03; done; while [ ! -f .active-tool-release ]; do sleep 0.05; done" } })}`,
+              `data: ${JSON.stringify({ type: "tool-call", toolCallId: "active_tool_1", toolName: "terminal", input: { action: "exec", command: "sleep 1; i=1; while [ \"$i\" -le 32 ]; do printf 'ACTIVE_TOOL_LINE_%02d\\n' \"$i\"; i=$((i+1)); sleep 0.03; done; while [ ! -f .active-tool-release ]; do sleep 0.05; done", timeout_ms: 600_000 } })}`,
               "",
               `data: ${JSON.stringify({ type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" }, usage: { inputTokens: { total: 1 }, outputTokens: { total: 1 } } })}`,
               "",
@@ -1844,7 +1844,7 @@ function startObservabilityGatewayFixture(
                 type: "tool-call",
                 toolCallId: "observability-tool-1",
                 toolName: "terminal",
-                input: { action: "exec", command },
+                input: { action: "exec", command, timeout_ms: 600_000 },
               },
               {
                 type: "finish",

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -122,7 +122,7 @@ export function hasEmptyComposer(pane: string): boolean {
   return pane.split("\n").some(isEmptyComposerLine);
 }
 
-function withNativeExecTimeout(event: object): object {
+export function withNativeExecTimeout(event: object): object {
   const value = event as Record<string, unknown>;
   if (value.type !== "tool-call" || value.toolName !== "terminal") return event;
   if (typeof value.input === "string") {

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -122,37 +122,9 @@ export function hasEmptyComposer(pane: string): boolean {
   return pane.split("\n").some(isEmptyComposerLine);
 }
 
-export function withNativeExecTimeout(event: object): object {
-  const value = event as Record<string, unknown>;
-  if (value.type !== "tool-call" || value.toolName !== "terminal") return event;
-  if (typeof value.input === "string") {
-    try {
-      const parsed = JSON.parse(value.input) as Record<string, unknown>;
-      if (
-        parsed.action === "exec" &&
-        !Object.prototype.hasOwnProperty.call(parsed, "timeout_ms")
-      ) {
-        return { ...value, input: JSON.stringify({ ...parsed, timeout_ms: 600_000 }) };
-      }
-    } catch {
-      return event;
-    }
-    return event;
-  }
-  if (value.input === null || typeof value.input !== "object") return event;
-  const input = value.input as Record<string, unknown>;
-  if (
-    input.action !== "exec" ||
-    Object.prototype.hasOwnProperty.call(input, "timeout_ms")
-  ) {
-    return event;
-  }
-  return { ...value, input: { ...input, timeout_ms: 600_000 } };
-}
-
 export function fakeGatewaySse(events: object[]) {
   return new Response(
-    `${events.map((event) => `data: ${JSON.stringify(withNativeExecTimeout(event))}\n\n`).join("")}data: [DONE]\n\n`,
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
     { headers: { "content-type": "text/event-stream" } },
   );
 }

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -122,9 +122,37 @@ export function hasEmptyComposer(pane: string): boolean {
   return pane.split("\n").some(isEmptyComposerLine);
 }
 
+function withNativeExecTimeout(event: object): object {
+  const value = event as Record<string, unknown>;
+  if (value.type !== "tool-call" || value.toolName !== "terminal") return event;
+  if (typeof value.input === "string") {
+    try {
+      const parsed = JSON.parse(value.input) as Record<string, unknown>;
+      if (
+        parsed.action === "exec" &&
+        !Object.prototype.hasOwnProperty.call(parsed, "timeout_ms")
+      ) {
+        return { ...value, input: JSON.stringify({ ...parsed, timeout_ms: 600_000 }) };
+      }
+    } catch {
+      return event;
+    }
+    return event;
+  }
+  if (value.input === null || typeof value.input !== "object") return event;
+  const input = value.input as Record<string, unknown>;
+  if (
+    input.action !== "exec" ||
+    Object.prototype.hasOwnProperty.call(input, "timeout_ms")
+  ) {
+    return event;
+  }
+  return { ...value, input: { ...input, timeout_ms: 600_000 } };
+}
+
 export function fakeGatewaySse(events: object[]) {
   return new Response(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+    `${events.map((event) => `data: ${JSON.stringify(withNativeExecTimeout(event))}\n\n`).join("")}data: [DONE]\n\n`,
     { headers: { "content-type": "text/event-stream" } },
   );
 }

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -888,7 +888,7 @@ function startFakeCodexAutoReview() {
       if (mainRequests === 1) {
         return new Response(
           'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_terminal","name":"terminal"}}\n\n' +
-            'data: {"type":"response.function_call_arguments.done","output_index":0,"arguments":"{\\"action\\":\\"exec\\",\\"command\\":\\"pwd\\"}"}\n\n' +
+            'data: {"type":"response.function_call_arguments.done","output_index":0,"arguments":"{\\"action\\":\\"exec\\",\\"command\\":\\"pwd\\",\\"timeout_ms\\":600000}"}\n\n' +
             'data: {"type":"response.completed","response":{"id":"gen_main_1","status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}\n\n',
           { headers: { "content-type": "text/event-stream" } },
         );
@@ -954,7 +954,7 @@ function startFakeGrokAutoReview() {
       if (mainRequests === 1) {
         return new Response(
           'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_terminal","name":"terminal"}}\n\n' +
-            'data: {"type":"response.function_call_arguments.done","output_index":0,"arguments":"{\\"action\\":\\"exec\\",\\"command\\":\\"pwd\\"}"}\n\n' +
+            'data: {"type":"response.function_call_arguments.done","output_index":0,"arguments":"{\\"action\\":\\"exec\\",\\"command\\":\\"pwd\\",\\"timeout_ms\\":600000}"}\n\n' +
             'data: {"type":"response.completed","response":{"id":"gen_main_1","status":"completed","usage":{"input_tokens":5,"output_tokens":2}}}\n\n',
           { headers: { "content-type": "text/event-stream" } },
         );

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -27,7 +27,6 @@ import {
   startDynamicFakeGateway,
   TmuxSession,
   tmuxAvailable,
-  withNativeExecTimeout,
 } from "./tmux-helpers";
 
 const TIMEOUT = 30_000;
@@ -97,7 +96,7 @@ afterEach(async () => {
 
 function sse(events: object[]) {
   return new Response(
-    `${events.map((event) => `data: ${JSON.stringify(withNativeExecTimeout(event))}\n\n`).join("")}data: [DONE]\n\n`,
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
     { headers: { "content-type": "text/event-stream" } },
   );
 }
@@ -122,7 +121,7 @@ function toolCall(
   options: Record<string, unknown> = {},
   toolCallId = "command_1",
 ) {
-  return gatewayToolCall("terminal", { action: "exec", command, ...options }, toolCallId);
+  return gatewayToolCall("terminal", { action: "exec", timeout_ms: 600_000, command, ...options }, toolCallId);
 }
 
 function permissionDecision(
@@ -175,7 +174,7 @@ function toolCalls(command: string, callIds: string[]) {
       type: "tool-call",
       toolCallId,
       toolName: "terminal",
-      input: { action: "exec", command },
+      input: { action: "exec", timeout_ms: 600_000, command },
     })),
     {
       type: "finish",
@@ -190,13 +189,13 @@ function twoEffectfulCommandBatch(first: string, second: string) {
       type: "tool-call",
       toolCallId: "history_feedback_first",
       toolName: "terminal",
-      input: { action: "exec", command: first },
+      input: { action: "exec", timeout_ms: 600_000, command: first },
     },
     {
       type: "tool-call",
       toolCallId: "history_feedback_second",
       toolName: "terminal",
-      input: { action: "exec", command: second },
+      input: { action: "exec", timeout_ms: 600_000, command: second },
     },
     {
       type: "finish",
@@ -1110,6 +1109,7 @@ async function expectSavedTerminalExec(
   expect(JSON.parse(call.arguments_json)).toEqual(
     expect.objectContaining({
       action: "exec",
+      timeout_ms: 600_000,
       command,
       ...(background ? { background: true } : {}),
     }),
@@ -1369,7 +1369,7 @@ describe("effect-aware command permissions", () => {
             type: "tool-call",
             toolCallId: "command_1",
             toolName: "terminal",
-            input: { action: "exec", command: "pwd" },
+            input: { action: "exec", timeout_ms: 600_000, command: "pwd" },
           },
           {
             type: "finish",
@@ -1477,7 +1477,7 @@ describe("effect-aware command permissions", () => {
             type: "tool-call",
             toolCallId: call.id,
             toolName: "terminal",
-            input: { action: "exec", command: call.command },
+            input: { action: "exec", timeout_ms: 600_000, command: call.command },
           })),
           {
             type: "finish",
@@ -2196,7 +2196,7 @@ describe("effect-aware command permissions", () => {
               type: "tool-call",
               toolCallId: "scrollback_command",
               toolName: "terminal",
-              input: { action: "exec", command: "seq 1 1" },
+              input: { action: "exec", timeout_ms: 600_000, command: "seq 1 1" },
             },
             {
               type: "finish",
@@ -4720,6 +4720,7 @@ describe("effect-aware command permissions", () => {
         if (userText.includes(childPrompt)) {
           return gatewayToolCall("terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: `/usr/bin/touch ${shellQuote(markerPath)}`,
           }, childCommandCallId);
         }
@@ -4867,6 +4868,7 @@ describe("effect-aware command permissions", () => {
             if (childRequestCount > 1) expect(body).toContain("review_caution");
             return gatewayToolCall("terminal", {
               action: "exec",
+              timeout_ms: 600_000,
               command: `/usr/bin/touch ${shellQuote(markerPath)}`,
             }, `child_auto_command_${childRequestCount}`);
           }

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -27,6 +27,7 @@ import {
   startDynamicFakeGateway,
   TmuxSession,
   tmuxAvailable,
+  withNativeExecTimeout,
 } from "./tmux-helpers";
 
 const TIMEOUT = 30_000;
@@ -96,7 +97,7 @@ afterEach(async () => {
 
 function sse(events: object[]) {
   return new Response(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+    `${events.map((event) => `data: ${JSON.stringify(withNativeExecTimeout(event))}\n\n`).join("")}data: [DONE]\n\n`,
     { headers: { "content-type": "text/event-stream" } },
   );
 }

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1653,7 +1653,7 @@ describe("effect-aware command permissions", () => {
       expect(losslessCompactOutput).toBe("");
       expect(losslessCompact).toContain("Ran printf");
       for (const row of losslessRows) expect(losslessCompact).not.toContain(`│ ${row}`);
-      expect(commandReplayFiles(root)).toEqual([]);
+      expect(commandReplayFiles(root)).toHaveLength(1);
       const losslessGrid = await activeSession.capturePaneGrid();
 
       await activeSession.sendKeys("C-o");
@@ -1683,7 +1683,7 @@ describe("effect-aware command permissions", () => {
       expect(lossyCompactOutput).toBe("");
       expect(lossyCompact).toContain("Ran printf");
       for (const row of lossyRows) expect(lossyCompact).not.toContain(`│ ${row}`);
-      expect(commandReplayFiles(root)).toHaveLength(1);
+      expect(commandReplayFiles(root)).toHaveLength(2);
       const lossyGrid = await activeSession.capturePaneGrid();
 
       await activeSession.sendKeys("C-o");
@@ -1734,7 +1734,7 @@ describe("effect-aware command permissions", () => {
       expect(publicSession.stdout).not.toContain("command_replay");
       expect(publicSession.stdout).not.toContain("command_process_presentation");
       expect(publicSession.stdout).not.toContain("process_presentation");
-      expect(publicSession.stdout).not.toContain("fx-command-replay-");
+      expect(publicSession.stdout).toContain("<command_output_handle>fx-command-replay-");
 
       await activeSession.sendText("/quit");
       expect(await activeSession.waitForSessionEnd(TIMEOUT)).toBe(true);
@@ -2405,7 +2405,7 @@ describe("effect-aware command permissions", () => {
           gateway.requests[1]!.body,
           "terminal_session_command",
         );
-        expect(commandResult).toBe(
+        expect(commandResult).toContain(
           "exit_code=0\n" +
             "<stdout>\n" +
             "TTY_SESSION_STDOUT_BEGIN\n" +
@@ -2414,6 +2414,9 @@ describe("effect-aware command permissions", () => {
             "<stderr>\n" +
             "TTY_SESSION_STDERR\n" +
             "</stderr>\n",
+        );
+        expect(commandResult).toMatch(
+          /<command_output_handle>fx-command-replay-[^<]+<\/command_output_handle>/,
         );
         expect(gateway.requests[1]!.body).not.toContain("\\u001e");
         expect(gateway.requests[1]!.body).not.toContain("\\u0006");

--- a/tests/e2e/tui-decision-prompts.test.ts
+++ b/tests/e2e/tui-decision-prompts.test.ts
@@ -24,6 +24,7 @@ import {
   fakeGatewaySerializedToolCall,
   TmuxSession,
   tmuxAvailable,
+  withNativeExecTimeout,
 } from "./tmux-helpers";
 import { stdoutFrames } from "./render-lab/tape";
 
@@ -139,7 +140,9 @@ afterEach(async () => {
 
 function sse(events: object[], done = true) {
   return new Response(
-    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") +
+    events.map((event) =>
+      `data: ${JSON.stringify(withNativeExecTimeout(event))}\n\n`
+    ).join("") +
       (done ? "data: [DONE]\n\n" : ""),
     { headers: { "content-type": "text/event-stream" } },
   );

--- a/tests/e2e/tui-decision-prompts.test.ts
+++ b/tests/e2e/tui-decision-prompts.test.ts
@@ -24,7 +24,6 @@ import {
   fakeGatewaySerializedToolCall,
   TmuxSession,
   tmuxAvailable,
-  withNativeExecTimeout,
 } from "./tmux-helpers";
 import { stdoutFrames } from "./render-lab/tape";
 
@@ -140,9 +139,7 @@ afterEach(async () => {
 
 function sse(events: object[], done = true) {
   return new Response(
-    events.map((event) =>
-      `data: ${JSON.stringify(withNativeExecTimeout(event))}\n\n`
-    ).join("") +
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") +
       (done ? "data: [DONE]\n\n" : ""),
     { headers: { "content-type": "text/event-stream" } },
   );
@@ -170,7 +167,7 @@ function outerCommandCall() {
     {
       id: "command_outer_1",
       name: "terminal",
-      input: { action: "exec", command: "touch generic-preview-accepted.txt" },
+      input: { action: "exec", timeout_ms: 600_000, command: "touch generic-preview-accepted.txt" },
     },
   ]);
 }
@@ -189,7 +186,7 @@ function outerLongCommandCall() {
     {
       id: "long_command_outer_1",
       name: "terminal",
-      input: { action: "exec", command },
+      input: { action: "exec", timeout_ms: 600_000, command },
     },
   ]);
 }
@@ -206,7 +203,7 @@ function outerScrollableLongCommandCall() {
     {
       id: "scrollable_long_command_outer_1",
       name: "terminal",
-      input: { action: "exec", command },
+      input: { action: "exec", timeout_ms: 600_000, command },
     },
   ]);
 }
@@ -219,7 +216,7 @@ function outerFittingCommandCall() {
     {
       id: "fitting_command_outer_1",
       name: "terminal",
-      input: { action: "exec", command },
+      input: { action: "exec", timeout_ms: 600_000, command },
     },
   ]);
 }

--- a/tests/e2e/tui-full-transcript-brutal.test.ts
+++ b/tests/e2e/tui-full-transcript-brutal.test.ts
@@ -390,6 +390,7 @@ done
   responses.push(fakeGatewayFinalText(`${HISTORY_DONE}\n${TAIL_SENTINEL}`));
   responses.push(fakeGatewayToolCall("ctrl-o-brutal-live", "terminal", {
     action: "exec",
+    timeout_ms: 600_000,
     command: "./ctrl-o-live.sh",
   }));
   responses.push(fakeGatewayFinalText(LIVE_DONE));

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -161,7 +161,7 @@ function lengthLimitedCommandResponse(command: string) {
         type: "tool-call",
         toolCallId: "command_final",
         toolName: "terminal",
-        input: { action: "exec", command },
+        input: { action: "exec", timeout_ms: 600_000, command },
       })}\n\n` +
       'data: {"type":"finish","finishReason":{"unified":"length","raw":"length"}}\n\n' +
       "data: [DONE]\n\n",
@@ -2706,13 +2706,13 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         fakeGatewaySerializedToolCall(
           "first_turn_command",
           "terminal",
-          '{"action":"exec","command":"printf preflight-failed > preflight.txt"}',
+          '{"action":"exec","command":"printf preflight-failed > preflight.txt","timeout_ms":600000}',
         ),
         () => heldGatewayResponse(hold),
         fakeGatewaySerializedToolCall(
           "queued_grep_command",
           "terminal",
-          '{"action":"exec","command":"grep -R \\"preflight\\" -n . | head"}',
+          '{"action":"exec","command":"grep -R \\"preflight\\" -n . | head","timeout_ms":600000}',
         ),
         duplicateKeyToolResponse(),
         fakeGatewayFinalText(finalText),
@@ -4379,7 +4379,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
               type: "tool-call",
               toolCallId: "queue_scrollback_command",
               toolName: "terminal",
-              input: { action: "exec", command: "sleep 30" },
+              input: { action: "exec", timeout_ms: 600_000, command: "sleep 30" },
             },
             {
               type: "finish",
@@ -5100,6 +5100,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
           "terminal",
           JSON.stringify({
             action: "exec",
+            timeout_ms: 600_000,
             command:
               "for i in $(seq -w 1 27); do printf 'docs/source-%s.md\\tWalter (1)\\n' \"$i\"; done",
           }),
@@ -5650,7 +5651,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
             type: "tool-call",
             toolCallId: supportedCallId,
             toolName: "terminal",
-            input: { action: "exec", command: supportedCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: supportedCommand },
           },
           {
             type: "finish",
@@ -5812,19 +5813,19 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
             type: "tool-call",
             toolCallId: "tool_summary_first",
             toolName: "terminal",
-            input: { action: "exec", command: firstCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: firstCommand },
           },
           {
             type: "tool-call",
             toolCallId: "tool_summary_nested",
             toolName: "terminal",
-            input: { action: "exec", command: nestedCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: nestedCommand },
           },
           {
             type: "tool-call",
             toolCallId: "tool_summary_third",
             toolName: "terminal",
-            input: { action: "exec", command: thirdCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: thirdCommand },
           },
           {
             type: "finish",
@@ -6009,7 +6010,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
             type: "tool-call",
             toolCallId: "minimal_command_one",
             toolName: "terminal",
-            input: { action: "exec", command: firstCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: firstCommand },
           },
           {
             type: "finish",
@@ -6039,7 +6040,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
             type: "tool-call",
             toolCallId: "minimal_command_two",
             toolName: "terminal",
-            input: { action: "exec", command: secondCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: secondCommand },
           },
           {
             type: "finish",
@@ -6058,7 +6059,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
             type: "tool-call",
             toolCallId: "minimal_command_live",
             toolName: "terminal",
-            input: { action: "exec", command: liveCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: liveCommand },
           },
           {
             type: "finish",
@@ -6182,6 +6183,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const cancelledGateway = startFakeGateway([
         fakeGatewayToolCall("minimal_cancelled_command", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: "sleep 30",
         }),
       ]);
@@ -6515,7 +6517,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
             type: "tool-call",
             toolCallId: "command_1",
             toolName: "terminal",
-            input: { action: "exec", command: "seq 1 1" },
+            input: { action: "exec", timeout_ms: 600_000, command: "seq 1 1" },
           },
           {
             type: "finish",
@@ -6807,7 +6809,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       writeFileSync(stderrPath, "");
 
       const commandGateway = startFakeGateway([
-        fakeGatewayToolCall("multiline_command", "terminal", { action: "exec", command }),
+        fakeGatewayToolCall("multiline_command", "terminal", { action: "exec", timeout_ms: 600_000, command }),
         fakeGatewayFinalText(finalText),
       ]);
       gateway = commandGateway;
@@ -6930,27 +6932,27 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
           {
             type: "tool-input-delta",
             id: "stream_cmd_one",
-            delta: JSON.stringify({ action: "exec", command: firstCommand }),
+            delta: JSON.stringify({ action: "exec", timeout_ms: 600_000, command: firstCommand }),
           },
           { type: "tool-input-end", id: "stream_cmd_one" },
           { type: "tool-input-start", id: "stream_cmd_two", toolName: "terminal" },
           {
             type: "tool-input-delta",
             id: "stream_cmd_two",
-            delta: JSON.stringify({ action: "exec", command: secondCommand }),
+            delta: JSON.stringify({ action: "exec", timeout_ms: 600_000, command: secondCommand }),
           },
           { type: "tool-input-end", id: "stream_cmd_two" },
           {
             type: "tool-call",
             toolCallId: "stream_cmd_one",
             toolName: "terminal",
-            input: { action: "exec", command: firstCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: firstCommand },
           },
           {
             type: "tool-call",
             toolCallId: "stream_cmd_two",
             toolName: "terminal",
-            input: { action: "exec", command: secondCommand },
+            input: { action: "exec", timeout_ms: 600_000, command: secondCommand },
           },
           {
             type: "finish",

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -7539,6 +7539,7 @@ describe.skipIf(!tmuxAvailable())("transcript scrollback release", () => {
               input: {
                 action: "exec",
                 command: "sleep 5; printf HELD_COMMAND_DONE",
+                timeout_ms: 600_000,
               },
             },
           ],

--- a/tests/e2e/tui-interrupt-recovery.test.ts
+++ b/tests/e2e/tui-interrupt-recovery.test.ts
@@ -342,6 +342,7 @@ while :; do sleep 1; done
       gateway = startFakeGateway([
         fakeGatewayToolCall("workspace-cancel-hold", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: "./hold-workspace-cancel.sh",
         }),
       ]);

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -1598,7 +1598,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
       const command =
         "for i in $(seq 1 96); do printf 'resize-stream-marker %03d\\n' \"$i\"; sleep 0.03; done";
       const gateway = startFakeGateway([
-        fakeGatewayToolCall("resize-live-command", "terminal", { action: "exec", command }),
+        fakeGatewayToolCall("resize-live-command", "terminal", { action: "exec", timeout_ms: 600_000, command }),
         fakeGatewayFinalText(finalResponse),
       ]);
       gateways.push(gateway);
@@ -1732,7 +1732,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
       const command =
         `awk 'BEGIN { for (i = 0; i < 13500; i++) printf "RETENTION_SEED_%05d alpha beta gamma delta epsilon zeta eta theta iota kappa lambda\\n", i }'`;
       const gateway = startFakeGateway([
-        fakeGatewayToolCall("retention-seed", "terminal", { action: "exec", command }),
+        fakeGatewayToolCall("retention-seed", "terminal", { action: "exec", timeout_ms: 600_000, command }),
         response,
       ]);
       gateways.push(gateway);
@@ -1835,6 +1835,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
         fakeGatewayFinalText(seedMarker),
         fakeGatewayToolCall("approval-cancel-resize", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command,
         }),
       ]);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -884,6 +884,7 @@ printf '${trailingMarker}   '
     const gateway = startFakeGateway([
       fakeGatewayToolCall("terminal-safety-command", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: "./command-output-controls.sh",
       }),
       fakeGatewayFinalText(doneMarker),
@@ -1073,7 +1074,7 @@ test.skipIf(!tmuxAvailable())(
       "awk 'BEGIN { for (i = 1; i <= 3000; i++) printf \"FULL_CTRL_O_LINE_%04d\\n\", i }'" +
       ` # ${"argument-padding-".repeat(8)}${commandArgumentTail}`;
     const gateway = startFakeGateway([
-      fakeGatewayToolCall("ctrl-o-command", "terminal", { action: "exec", command }),
+      fakeGatewayToolCall("ctrl-o-command", "terminal", { action: "exec", timeout_ms: 600_000, command }),
       fakeGatewayFinalText("FULL_CTRL_O_DONE"),
     ]);
     let active: TmuxSession | null = null;
@@ -1212,7 +1213,7 @@ test.skipIf(!tmuxAvailable())(
       `printf '${stdoutTail}\\n'; sleep 0.05; printf '${stderrTail}\\n' >&2`;
     const finalMarker = "CAP_CROSSING_DONE";
     const gateway = startFakeGateway([
-      fakeGatewayToolCall("cap-crossing-command", "terminal", { action: "exec", command }),
+      fakeGatewayToolCall("cap-crossing-command", "terminal", { action: "exec", timeout_ms: 600_000, command }),
       fakeGatewayFinalText(finalMarker),
     ]);
     let active: TmuxSession | null = null;
@@ -1346,6 +1347,7 @@ printf '${tailMarker}\\n'
       fakeGatewayFinalText(historicalRows.join("\n")),
       fakeGatewayToolCall("active-overflow-command", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: "./active-overflow.sh",
       }),
       fakeGatewayFinalText(doneMarker),
@@ -1548,7 +1550,7 @@ while :; do :; done
       );
     });
     const gateway = startFakeGateway([
-      fakeGatewayToolCall(callId, "terminal", { action: "exec", command: "./cancel-cap.sh" }),
+      fakeGatewayToolCall(callId, "terminal", { action: "exec", timeout_ms: 600_000, command: "./cancel-cap.sh" }),
       () => nextResponse,
     ]);
     let active: TmuxSession | null = null;
@@ -1799,6 +1801,7 @@ while :; do :; done
     const gateway = startFakeGateway([
       fakeGatewayToolCall("cancelled-below-cap-command", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: "./cancel-below.sh",
       }),
     ]);
@@ -1958,7 +1961,7 @@ test.skipIf(!tmuxAvailable())(
       expect(countOccurrences(transcriptRegion, outputLine)).toBe(0);
     };
     const gateway = startFakeGateway([
-      fakeGatewayToolCall("order-repro-pwd", "terminal", { action: "exec", command: "pwd" }),
+      fakeGatewayToolCall("order-repro-pwd", "terminal", { action: "exec", timeout_ms: 600_000, command: "pwd" }),
       fakeGatewayFinalText(finalMarker),
     ]);
     let active: TmuxSession | null = null;
@@ -2362,7 +2365,7 @@ test.skipIf(!tmuxAvailable())(
 
     const command = `sh -c 'while :; do printf "${streamMarker}\\n"; sleep 0.1; done'`;
     const gateway = startFakeGateway([
-      fakeGatewayToolCall("ctrl-o-cancel-command", "terminal", { action: "exec", command }),
+      fakeGatewayToolCall("ctrl-o-cancel-command", "terminal", { action: "exec", timeout_ms: 600_000, command }),
     ]);
     let active: TmuxSession | null = null;
     try {
@@ -2428,7 +2431,7 @@ test.skipIf(!tmuxAvailable())(
     const tailMarker = "CTRL_O_LIVE_TAIL";
     const command = "sh -c 'printf \"CTRL_O_LIVE_HEAD\\n\"; sleep 1; printf \"CTRL_O_LIVE_TAIL\\n\"'";
     const gateway = startFakeGateway([
-      fakeGatewayToolCall("ctrl-o-live-command", "terminal", { action: "exec", command }),
+      fakeGatewayToolCall("ctrl-o-live-command", "terminal", { action: "exec", timeout_ms: 600_000, command }),
       fakeGatewayFinalText("CTRL_O_LIVE_DONE"),
     ]);
     let active: TmuxSession | null = null;
@@ -2494,7 +2497,7 @@ test.skipIf(!tmuxAvailable())(
     const doneMarker = "STREAM_SCROLL_INLINE_DONE";
     const command = `zsh -lc 'for i in {1..80}; do printf "${lineMarker} %03d\\n" "$i"; done; sleep 2; for i in {81..160}; do printf "${lineMarker} %03d\\n" "$i"; done; : > ${shellQuote(phaseTwoComplete)}'`;
     const gateway = startFakeGateway([
-      fakeGatewayToolCall("stream-scroll-handoff", "terminal", { action: "exec", command }),
+      fakeGatewayToolCall("stream-scroll-handoff", "terminal", { action: "exec", timeout_ms: 600_000, command }),
       fakeGatewayFinalText(doneMarker),
     ]);
     let active: TmuxSession | null = null;
@@ -2639,6 +2642,7 @@ test.skipIf(!tmuxAvailable())(
     const gateway = startFakeGateway([
       fakeGatewayToolCall("ctrl-o-navigation-command", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: `zsh -lc 'for i in {1..100}; do printf "${commandMarker} %05d\\n" "$i"; done; sleep 2; for i in {101..${lineCount}}; do printf "${commandMarker} %05d\\n" "$i"; done'`,
       }),
       fakeGatewayFinalText(doneMarker),
@@ -2718,6 +2722,7 @@ test.skipIf(!tmuxAvailable())(
     const gateway = startFakeGateway([
       fakeGatewayToolCall("ctrl-o-question-command", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: `sh -c 'printf "${commandMarker}\\n"; sleep 1'`,
       }),
       fakeGatewayToolCall("ctrl-o-question", "ask_user_question", {
@@ -2799,7 +2804,7 @@ test.skipIf(!tmuxAvailable())(
       fakeGatewaySerializedToolCall(
         "ctrl-o-spacing-command",
         "terminal",
-        JSON.stringify({ action: "exec", command }),
+        JSON.stringify({ action: "exec", timeout_ms: 600_000, command }),
         beforeMarker,
       ),
       fakeGatewayFinalText(afterMarker),
@@ -3106,7 +3111,7 @@ test.skipIf(!tmuxAvailable())(
       () => "The denied write remains visible while this streamed assistant response advances the compact transcript window.",
     ).join(" ")} CTRL_O_HANDOFF_DONE`;
     const gateway = startFakeGateway([
-      fakeGatewayToolCall("ctrl-o-handoff-prior", "terminal", { action: "exec", command: priorCommand }),
+      fakeGatewayToolCall("ctrl-o-handoff-prior", "terminal", { action: "exec", timeout_ms: 600_000, command: priorCommand }),
       fakeGatewayFinalText(priorSummary),
       fakeGatewaySse([
         {
@@ -3115,6 +3120,7 @@ test.skipIf(!tmuxAvailable())(
           toolName: "terminal",
           input: {
             action: "exec",
+            timeout_ms: 600_000,
             command: "sh -c 'sleep 5; printf \"CTRL_O_HANDOFF_READY\\n\"'",
           },
         },
@@ -3225,6 +3231,7 @@ test.skipIf(!tmuxAvailable())(
         await Bun.sleep(300);
         return fakeGatewayToolCall("ctrl-o-shell-approval", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: "sh -c 'printf \"CTRL_O_SHELL_APPROVAL_RAN\\n\"'",
         });
       },
@@ -3349,6 +3356,7 @@ test.skipIf(!tmuxAvailable())(
           toolName: "terminal",
           input: {
             action: "exec",
+            timeout_ms: 600_000,
             command: "sh -c 'touch ctrl-o-handoff-first; printf \"CTRL_O_HANDOFF_FIRST_RUNNING\\n\"; sleep 1; printf \"CTRL_O_HANDOFF_FIRST_DONE\\n\"'",
           },
         },
@@ -3358,6 +3366,7 @@ test.skipIf(!tmuxAvailable())(
           toolName: "terminal",
           input: {
             action: "exec",
+            timeout_ms: 600_000,
             command: "touch ctrl-o-handoff-second && printf 'CTRL_O_HANDOFF_SECOND_DONE\\n'",
           },
         },
@@ -3509,6 +3518,7 @@ test.skipIf(!tmuxAvailable())(
     const gateway = startFakeGateway([
       fakeGatewayToolCall("ctrl-o-pressure-setup", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: setupCommand,
       }),
       fakeGatewayFinalText(`${assistantHistory}\n${setupSentinel}`),
@@ -3517,7 +3527,7 @@ test.skipIf(!tmuxAvailable())(
           type: "tool-call",
           toolCallId: "ctrl-o-pressure-command",
           toolName: "terminal",
-          input: { action: "exec", command: activeCommand },
+          input: { action: "exec", timeout_ms: 600_000, command: activeCommand },
         },
         {
           type: "tool-call",
@@ -4087,7 +4097,7 @@ test.skipIf(!tmuxAvailable())(
         {
           type: "tool-input-delta",
           id: "deferred-command",
-          delta: JSON.stringify({ action: "exec", command, cwd: "nested" }),
+          delta: JSON.stringify({ action: "exec", timeout_ms: 600_000, command, cwd: "nested" }),
         },
         { type: "tool-input-end", id: "deferred-command" },
         {
@@ -4100,7 +4110,7 @@ test.skipIf(!tmuxAvailable())(
           type: "tool-call",
           toolCallId: "deferred-command",
           toolName: "terminal",
-          input: { action: "exec", command, cwd: "nested" },
+          input: { action: "exec", timeout_ms: 600_000, command, cwd: "nested" },
         },
         { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
       ]),
@@ -4115,13 +4125,13 @@ test.skipIf(!tmuxAvailable())(
           type: "tool-call",
           toolCallId: "reissued-command",
           toolName: "terminal",
-          input: { action: "exec", command, cwd: "nested" },
+          input: { action: "exec", timeout_ms: 600_000, command, cwd: "nested" },
         },
         {
           type: "tool-call",
           toolCallId: "ordinary-failure",
           toolName: "terminal",
-          input: { action: "exec", command: failureCommand },
+          input: { action: "exec", timeout_ms: 600_000, command: failureCommand },
         },
         { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
       ]),
@@ -4747,7 +4757,7 @@ test.skipIf(!tmuxAvailable())(
       const toolWorkspaceRoot = realpathSync(toolWorkspace);
       const toolReply = "TOOL_RESUME_FINAL_REPLY";
       const toolGateway = startFakeGateway([
-        fakeGatewayToolCall("resume_pwd", "terminal", { action: "exec", command: "pwd" }),
+        fakeGatewayToolCall("resume_pwd", "terminal", { action: "exec", timeout_ms: 600_000, command: "pwd" }),
         fakeGatewayFinalText(toolReply),
       ]);
       gateways.push(toolGateway);
@@ -5429,7 +5439,7 @@ printf '${stdoutTail2}\\n'
 
     try {
       const initialGateway = startFakeGateway([
-        fakeGatewayToolCall("resume_long_command", "terminal", { action: "exec", command: fixtureCommand }),
+        fakeGatewayToolCall("resume_long_command", "terminal", { action: "exec", timeout_ms: 600_000, command: fixtureCommand }),
         fakeGatewayFinalText(completion),
       ]);
       gateways.push(initialGateway);
@@ -6176,7 +6186,7 @@ while :; do sleep 1; done
       fakeGatewaySerializedToolCall(
         "resume-cancelled-command",
         "terminal",
-        JSON.stringify({ action: "exec", command: "./resume-cancel.sh" }),
+        JSON.stringify({ action: "exec", timeout_ms: 600_000, command: "./resume-cancel.sh" }),
         assistantMarker,
       ),
       fakeGatewayFinalText(followUpMarker),
@@ -6339,7 +6349,7 @@ test.skipIf(!tmuxAvailable())(
     chmodSync(scriptPath, 0o755);
 
     const initialGateway = startFakeGateway([
-      fakeGatewayToolCall("resume-zero-output-command", "terminal", { action: "exec", command: "./z.sh" }),
+      fakeGatewayToolCall("resume-zero-output-command", "terminal", { action: "exec", timeout_ms: 600_000, command: "./z.sh" }),
     ]);
     const resumedGateway = startFakeGateway([]);
     let active: TmuxSession | null = null;

--- a/tests/e2e/tui-subagent-manager.test.ts
+++ b/tests/e2e/tui-subagent-manager.test.ts
@@ -895,6 +895,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         if (body.includes(childPrompt)) {
           return fakeGatewayToolCall(callId, "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: `printf yolo > ${JSON.stringify(marker)}`,
           });
         }
@@ -1721,6 +1722,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
           }
           return fakeGatewayToolCall(`command_stream_${next}`, "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command:
               `printf COMMAND_${next}_START; sleep 0.35; printf COMMAND_${next}_END`,
           });
@@ -1728,6 +1730,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         if (body.includes(childPrompt)) {
           return fakeGatewayToolCall("command_stream_1", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command:
               "printf COMMAND_1_START; sleep 0.35; printf COMMAND_1_END",
           });
@@ -3855,6 +3858,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         await active.waitForText("Full detail · ←/→ switch · ctrl o close", TIMEOUT);
         releaseChildApproval(fakeGatewayToolCall(callId, "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: "printf approved > child-approval-effect.txt",
         }));
         const childApproval = await active.waitForPane(
@@ -5745,12 +5749,14 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         if (body.includes(firstPrompt)) {
           return fakeGatewayToolCall(firstCallId, "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: `printf first > ${JSON.stringify(firstMarker)}`,
           });
         }
         if (body.includes(secondPrompt)) {
           return fakeGatewayToolCall(secondCallId, "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: `printf second > ${JSON.stringify(secondMarker)}`,
           });
         }
@@ -6249,6 +6255,7 @@ describe.skipIf(!tmuxAvailable())("tui: Agents & processes", () => {
         if (body.includes(childPrompt)) {
           return fakeGatewayToolCall(childCallId, "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: "printf denied > cancelled-approval-effect.txt",
           });
         }

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -1503,6 +1503,7 @@ test.skipIf(!tmuxAvailable())(
     const gateway = startFakeGateway([
       fakeGatewayToolCall("terminal_null_placeholder_exec", "terminal", {
         action: "exec",
+        timeout_ms: 600_000,
         command: `printf NULL_PLACEHOLDER_OK > ${JSON.stringify(marker)}`,
         cwd: "null",
         profile: "null",

--- a/tests/e2e/ui-observer.ts
+++ b/tests/e2e/ui-observer.ts
@@ -461,6 +461,7 @@ async function setupScenario(
           await gate.promise;
           return fakeGatewayToolCall("observer_thinking_running", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: "sleep 5 # this command is intentionally verbose so the running status must end with an omission marker at the terminal boundary",
           });
         },
@@ -486,6 +487,7 @@ async function setupScenario(
           await gate.promise;
           return fakeGatewayToolCall("observer_thinking_final", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: "printf OBSERVER_THINKING_TOOL_FINAL # this command is intentionally verbose so the completed status must wrap and truncate at the terminal boundary",
           });
         },
@@ -511,6 +513,7 @@ async function setupScenario(
           await gate.promise;
           return fakeGatewayToolCall("observer_thinking_failed", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: "sh -c 'printf OBSERVER_THINKING_TOOL_FAILED >&2; exit 17' # this command is intentionally verbose so the failed status must wrap and truncate at the terminal boundary",
           });
         },

--- a/tests/e2e/yolo-permission-mode.test.ts
+++ b/tests/e2e/yolo-permission-mode.test.ts
@@ -93,6 +93,7 @@ describe("yolo permission mode", () => {
       const fake = startFakeGateway([
         fakeGatewayToolCall("yolo_command", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: `printf 'YOLO_COMMAND_OK\\n' > ${JSON.stringify(markerPath)}`,
         }),
         fakeGatewayFinalText("YOLO_HEADLESS_DONE"),
@@ -201,6 +202,7 @@ describe("yolo permission mode", () => {
       const fake = startFakeGateway([
         fakeGatewayToolCall("legacy_ps", "terminal", {
           action: "exec",
+          timeout_ms: 600_000,
           command: `ps -p $$ -o pid= > ${JSON.stringify(psPath)}; printf x >> ${JSON.stringify(attemptsPath)}`,
         }),
         fakeGatewayFinalText("LEGACY_PS_DONE"),
@@ -330,6 +332,7 @@ describe.skipIf(!tmuxAvailable())("yolo interactive mode", () => {
           await toolCallGate;
           return fakeGatewayToolCall("live_auto_command", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: `printf 'LIVE_AUTO_OK\\n' > ${JSON.stringify(markerPath)}`,
           });
         },
@@ -408,6 +411,7 @@ describe.skipIf(!tmuxAvailable())("yolo interactive mode", () => {
           await toolCallGate;
           return fakeGatewayToolCall("live_ask_command", "terminal", {
             action: "exec",
+            timeout_ms: 600_000,
             command: `printf 'LIVE_ASK_WRONG\\n' > ${JSON.stringify(markerPath)}`,
           });
         },


### PR DESCRIPTION
## Summary

- Require native terminal exec calls to include a finite deadline from 1 ms through 10 minutes.
- Stop timed-out foreground process trees with the existing cleanup path and return control to the agent.
- Direct services, watchers, GUI apps, and other long-lived work to terminal start.
- Keep captured foreground output readable through bounded opaque handles in saved sessions.
- Keep no-save output process-scoped and expire its handles when fx exits.
- Report output capture failures instead of continuing with incomplete replay.
- Preserve the Browser terminal input and its private 30-second deadline.