### PR TITLE
Add Windows 11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,39 @@ jobs:
           MATRIX_RESULT: ${{ needs.zig_mode.result }}
         run: test "$MATRIX_RESULT" = success
 
+  windows-native:
+    name: Windows 11 Build & Test
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: "0.16.0"
+          cache-key: ci-windows-native
+
+      - name: Check formatting
+        run: zig fmt --check src/
+
+      - name: Build
+        run: zig build -Doptimize=ReleaseSafe
+
+      - name: Test Windows platform contracts
+        run: |
+          zig test src/core/shared/windows_console.zig
+          zig test src/core/shared/windows_process.zig
+          zig test src/core/shared/windows_file_io.zig
+          zig build test -Doptimize=ReleaseSafe '-Dtest-filter=Windows command execution uses cmd and returns foreground output'
+          zig build test -Doptimize=ReleaseSafe '-Dtest-filter=native provider transfers a prepared process to its owned handle'
+          zig build test -Doptimize=ReleaseSafe '-Dtest-filter=process instance tokens are canonical and require exact match'
+
+      - name: Smoke test
+        shell: pwsh
+        run: |
+          .\zig-out\bin\fx.exe status --json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
   sdk-node-wasm:
     name: SDK (Node + WASM)
     runs-on: ubuntu-latest
@@ -305,6 +338,10 @@ jobs:
             target: x86_64-macos
           - name: macos-aarch64
             target: aarch64-macos
+          - name: windows-x86_64
+            target: x86_64-windows
+          - name: windows-aarch64
+            target: aarch64-windows
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -27,12 +27,22 @@ jobs:
         include:
           - name: linux-x86_64
             target: x86_64-linux
+            binary: fx
           - name: linux-aarch64
             target: aarch64-linux
+            binary: fx
           - name: macos-x86_64
             target: x86_64-macos
+            binary: fx
           - name: macos-aarch64
             target: aarch64-macos
+            binary: fx
+          - name: windows-x86_64
+            target: x86_64-windows
+            binary: fx.exe
+          - name: windows-aarch64
+            target: aarch64-windows
+            binary: fx.exe
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,8 +60,8 @@ jobs:
         run: |
           package_dir="$RUNNER_TEMP/fx-package-${{ matrix.name }}"
           mkdir -p "$package_dir"
-          cp zig-out/bin/fx LICENSE THIRD_PARTY_NOTICES.md "$package_dir/"
-          tar -czf fx-${{ matrix.name }}.tar.gz -C "$package_dir" fx LICENSE THIRD_PARTY_NOTICES.md
+          cp "zig-out/bin/${{ matrix.binary }}" LICENSE THIRD_PARTY_NOTICES.md "$package_dir/"
+          tar -czf fx-${{ matrix.name }}.tar.gz -C "$package_dir" "${{ matrix.binary }}" LICENSE THIRD_PARTY_NOTICES.md
           sha256sum fx-${{ matrix.name }}.tar.gz > fx-${{ matrix.name }}.tar.gz.sha256
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,19 @@ jobs:
         include:
           - name: linux-x86_64
             target: x86_64-linux
+            binary: fx
           - name: linux-aarch64
             target: aarch64-linux
+            binary: fx
           - name: macos-x86_64
             target: x86_64-macos
+            binary: fx
+          - name: windows-x86_64
+            target: x86_64-windows
+            binary: fx.exe
+          - name: windows-aarch64
+            target: aarch64-windows
+            binary: fx.exe
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -72,8 +81,8 @@ jobs:
         run: |
           package_dir="$RUNNER_TEMP/fx-package-${{ matrix.name }}"
           mkdir -p "$package_dir"
-          cp zig-out/bin/fx LICENSE THIRD_PARTY_NOTICES.md "$package_dir/"
-          tar -czf fx-${{ matrix.name }}.tar.gz -C "$package_dir" fx LICENSE THIRD_PARTY_NOTICES.md
+          cp "zig-out/bin/${{ matrix.binary }}" LICENSE THIRD_PARTY_NOTICES.md "$package_dir/"
+          tar -czf fx-${{ matrix.name }}.tar.gz -C "$package_dir" "${{ matrix.binary }}" LICENSE THIRD_PARTY_NOTICES.md
           sha256sum fx-${{ matrix.name }}.tar.gz > fx-${{ matrix.name }}.tar.gz.sha256
 
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Workspace status line:** Opt in to the active workspace path and Git branch through `/settings`, `/statusline workspace`, or `statusLine.workspace`
 - **fx-native workspace skills:** Discover project skills from `.fx/skills` before other workspace and compatibility roots
 - **External skill authorities:** Allow symlinked skills under explicitly trusted external directories through `FX_SKILL_SYMLINK_AUTHORITIES`
+- **Windows 11 support:** Run the native CLI and interactive interface in Windows Terminal, execute commands through `cmd.exe`, open browser and file targets with Windows handlers, and install or upgrade native x86-64 and ARM64 releases
 
 ### Improvements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ Contributions should preserve that direction:
 
 Requirements:
 
-* Zig `0.16.0+`
+* Zig `0.16.0`
 
-* interactive terminal for manual shell testing
+* an interactive terminal for manual shell testing. Use Windows Terminal on Windows 11
 
 * a Vercel OAuth session via `fx login` for model-backed flows. macOS Keychain API keys (via `fx setup`), `AI_GATEWAY_API_KEY`, and `VERCEL_OIDC_TOKEN` are also supported
 
@@ -37,7 +37,7 @@ zig build run
 
 ## Verification Workflow
 
-Keep the local development loop focused: run the narrowest test that covers the changed path, build fx, and exercise the change using `./zig-out/bin/fx`. The installed `fx` on `PATH` is not valid development evidence.
+Keep the local development loop focused: run the narrowest test that covers the changed path, build fx, and exercise the change using `./zig-out/bin/fx` on macOS or Linux or `.\zig-out\bin\fx.exe` in PowerShell on Windows. The installed `fx` on `PATH` is not valid development evidence.
 
 Once the focused checks pass, create a clean checkpoint commit, push the non-`main` feature branch, and open a draft PR immediately. The **Full CI** workflow runs the complete deterministic suite on native Linux x86_64, Linux aarch64, macOS x86_64, and macOS aarch64 runners. The native matrix builds, tests, and smoke-tests ReleaseSafe on every platform; formatting and the public-surface audit run in those ReleaseSafe jobs. Four duration-balanced, isolated ReleaseSafe E2E shards per platform use checked-in weights to assign every Bun test file once; files inside each shard run sequentially in separate Bun processes so terminal fixtures and process state cannot leak between files. A failed file receives one bounded retry after tmux is reset.
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,31 @@ It's open source (Apache-2.0), model-agnostic, and suitable for both local and c
 
 ## Install
 
+### macOS and Linux
+
 ```bash
 curl -fsSL https://fx.sh/setup.sh | bash
 ```
+
+### Windows 11
+
+Run this in PowerShell to install the latest release for the current user's architecture:
+
+```powershell
+$architecture = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "aarch64" } else { "x86_64" }
+$version = (Invoke-RestMethod https://releases.fx.sh/latest.txt).Trim()
+$installDir = Join-Path $env:LOCALAPPDATA "Programs\fx"
+$archive = Join-Path $env:TEMP "fx-windows-$architecture.tar.gz"
+New-Item -ItemType Directory -Force $installDir | Out-Null
+Invoke-WebRequest "https://releases.fx.sh/$version/fx-windows-$architecture.tar.gz" -OutFile $archive
+tar.exe -xzf $archive -C $installDir
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if (($userPath -split ";") -notcontains $installDir) {
+  [Environment]::SetEnvironmentVariable("Path", "$installDir;$userPath", "User")
+}
+```
+
+Open a new Windows Terminal tab after installation, then run `fx`. The interactive interface uses Windows 11 virtual terminal input and output. Foreground and background commands executed by `run_command` use `cmd.exe`. Hosted `terminal` sessions still require macOS or Linux.
 
 ## Run fx
 
@@ -125,14 +147,15 @@ Read the [fx documentation](https://fx.sh/docs).
 
 ## Build from source
 
-Building fx requires [Zig 0.16.0+](https://ziglang.org/download/):
+Building fx requires [Zig 0.16.0](https://ziglang.org/download/):
 
 ```bash
 git clone https://github.com/vercel-labs/fx.git
 cd fx
 zig build -Doptimize=ReleaseSafe
-./zig-out/bin/fx
 ```
+
+Run the built binary with `./zig-out/bin/fx` on macOS or Linux, or `.\zig-out\bin\fx.exe` in PowerShell on Windows.
 
 Run the test suite with `zig build test`. See [CONTRIBUTING.md](CONTRIBUTING.md) for development and contribution guidelines.
 

--- a/build.zig
+++ b/build.zig
@@ -23,6 +23,7 @@ const NapiSurface = enum {
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const test_filter = b.option([]const u8, "test-filter", "Run only tests whose names contain this text");
     const pgso_artifact = b.option(
         PgsoArtifact,
         "pgso-artifact",
@@ -58,9 +59,9 @@ pub fn build(b: *std.Build) void {
             .link_libc = true,
             .stack_check = false,
             .stack_protector = false,
-            .omit_frame_pointer = true,
-            .unwind_tables = .none,
-            .error_tracing = false,
+            .omit_frame_pointer = optimize != .Debug,
+            .unwind_tables = if (optimize == .Debug) .sync else .none,
+            .error_tracing = optimize == .Debug,
             .strip = optimize != .Debug,
         }),
     });
@@ -79,8 +80,10 @@ pub fn build(b: *std.Build) void {
 
     const exe_tests = b.addTest(.{
         .root_module = exe.root_module,
+        .filters = if (test_filter) |filter| &.{filter} else &.{},
     });
     const run_exe_tests = b.addRunArtifact(exe_tests);
+    if (b.args) |args| run_exe_tests.addArgs(args);
     run_exe_tests.step.dependOn(b.getInstallStep());
     run_exe_tests.setEnvironmentVariable(
         "FX_TEST_PRODUCT_EXE",

--- a/src/acp/jsonrpc.zig
+++ b/src/acp/jsonrpc.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const io_mod = @import("../core/shared/io.zig");
 const host_target = @import("../core/hosts/target.zig");
 
@@ -299,11 +300,10 @@ pub const Reader = struct {
         return initCallback(context, read_fn);
     }
 
-    // Native ACP uses raw read(2) because Linux may pass socket-based stdin to
-    // child processes. WASI has no std.posix surface, so use the injected std.Io
-    // backend and let the host's fd_read import suspend through JSPI.
+    // POSIX uses raw read(2) because Linux may pass socket-based stdin to child
+    // processes. Windows and WASI use the injected portable file backend.
     fn readStdin(_: ?*anyopaque, destination: []u8) usize {
-        if (comptime host_target.is_wasm) {
+        if (comptime host_target.is_wasm or builtin.os.tag == .windows) {
             return std.Io.File.stdin().readStreaming(
                 io_mod.getIo(),
                 &.{destination},

--- a/src/acp/prompt_test_controls.zig
+++ b/src/acp/prompt_test_controls.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const io_mod = @import("../core/shared/io.zig");
 
-const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+const private_file_permissions = io_mod.private_file_permissions;
 
 const Controls = struct {
     terminal_ready_path: []const u8,

--- a/src/acp/session_test_controls.zig
+++ b/src/acp/session_test_controls.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const io_mod = @import("../core/shared/io.zig");
 const session_log = @import("../core/session/session_log.zig");
 
-const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+const private_file_permissions = io_mod.private_file_permissions;
 
 pub fn logOptions() session_log.Options {
     return logOptionsFromEnv(

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -200,7 +200,7 @@ pub fn handleNewSession(state: *server.ServerState, alloc: Allocator, msg: *json
     );
     var session_rt_owned = true;
     defer if (session_rt_owned) session_rt.deinit(alloc);
-    _ = try session_rt.initializeProfileUsage(alloc, io_mod.getenv("HOME"));
+    _ = try session_rt.initializeProfileUsage(alloc, io_mod.homeDir());
     if (writable.state.usage) |usage| {
         try session_rt.usage.restore(
             alloc,
@@ -581,7 +581,7 @@ fn handleRestoreSession(
     );
     var session_rt_owned = true;
     defer if (session_rt_owned) session_rt.deinit(alloc);
-    _ = try session_rt.initializeProfileUsage(alloc, io_mod.getenv("HOME"));
+    _ = try session_rt.initializeProfileUsage(alloc, io_mod.homeDir());
     try session_rt.restoreWithPermissionState(
         alloc,
         writable.state.conversation_language,

--- a/src/builtins/context.zig
+++ b/src/builtins/context.zig
@@ -248,7 +248,7 @@ fn loadsProjectInstructionFiles() bool {
 }
 
 fn gatherProjectContext(alloc: Allocator, input: InitialContextInput) context_contract.ProviderError!ProviderContext {
-    return gatherProjectContextWithHome(alloc, input, io_mod.getenv("HOME"));
+    return gatherProjectContextWithHome(alloc, input, io_mod.homeDir());
 }
 
 fn gatherProjectContextWithHome(
@@ -2090,7 +2090,7 @@ fn shellPath() ?[]const u8 {
 }
 
 fn homeDir() ?[]const u8 {
-    return io_mod.getenv("HOME") orelse io_mod.getenv("USERPROFILE");
+    return io_mod.homeDir() orelse io_mod.getenv("USERPROFILE");
 }
 
 fn todayUtcText(arena: Allocator) ![]const u8 {

--- a/src/builtins/hooks/herdr.zig
+++ b/src/builtins/hooks/herdr.zig
@@ -4,6 +4,7 @@
 //! ignored so the integration cannot block or terminate an fx session.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const io_mod = @import("../../core/shared/io.zig");
 const debug_trace = @import("../../core/shared/debug_trace.zig");
 const host_target = @import("../../core/hosts/target.zig");
@@ -181,6 +182,7 @@ pub const Client = struct {
 };
 
 fn applyResponseTimeout(stream: std.Io.net.Stream) void {
+    if (comptime builtin.os.tag == .windows) return;
     std.posix.setsockopt(
         stream.socket.handle,
         std.posix.SOL.SOCKET,

--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -353,7 +353,7 @@ pub fn loadRuntime(
     alloc: Allocator,
     elicitation_capabilities: elicitation.Capabilities,
 ) !?*mcp_runtime.McpRuntime {
-    const home = io_mod.getenv("HOME") orelse return null;
+    const home = io_mod.homeDir() orelse return null;
     const config_path = try configPathFromHome(alloc, home);
     defer alloc.free(config_path);
 
@@ -366,7 +366,7 @@ pub fn loadRuntime(
 pub fn inspectProfileConfig(
     alloc: Allocator,
 ) error{OutOfMemory}!mcp_contract.ProfileConfigDiagnostic {
-    const home = io_mod.getenv("HOME") orelse return .clear;
+    const home = io_mod.homeDir() orelse return .clear;
     const config_path = try configPathFromHome(alloc, home);
     defer alloc.free(config_path);
 

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -250,7 +250,7 @@ pub fn Runtime(comptime App: type) type {
                 prompt_history_unavailable =
                     (try app.prompt_history.initialize(
                         app.alloc,
-                        shared_io.getenv("HOME"),
+                        shared_io.homeDir(),
                         startup.prompt_history_enabled,
                         startup.prompt_history_store_allowed,
                     )) == .unavailable;
@@ -260,7 +260,7 @@ pub fn Runtime(comptime App: type) type {
             {
                 _ = try app.session.initializeProfileUsage(
                     app.alloc,
-                    shared_io.getenv("HOME"),
+                    shared_io.homeDir(),
                 );
             }
 

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -1785,7 +1785,7 @@ fn traceFilePermissions() std.Io.File.Permissions {
 }
 
 fn writeTraceReportFile(alloc: std.mem.Allocator, contents: []const u8) ![]u8 {
-    const tmp_dir = io_mod.tempDir() orelse ".";
+    const tmp_dir = io_mod.tempDir();
     const trimmed = std.mem.trimEnd(u8, tmp_dir, "/");
     const now_ms = io_mod.milliTimestamp();
     const now_secs: i64 = @max(@divFloor(now_ms, 1000), 0);

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -1046,7 +1046,7 @@ pub fn Handlers(comptime App: type) type {
             if (scope == .session) {
                 return app.session.usage.reportSnapshot(app.alloc);
             }
-            const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+            const home = io_mod.homeDir() orelse return error.HomeNotSet;
             const availability = try app.session.ensureProfileUsageReadable(
                 app.alloc,
                 home,
@@ -1114,7 +1114,7 @@ pub fn Handlers(comptime App: type) type {
         fn commandHandleMcp(ctx: *anyopaque, rest: []const u8) !void {
             const app: *App = @ptrCast(@alignCast(ctx));
             const result = try app.mcpCommandProvider().handle(app.alloc, rest, .{
-                .home = io_mod.getenv("HOME"),
+                .home = io_mod.homeDir(),
                 .list_ctx = @ptrCast(app),
                 .summarize_servers = summarizeMcpServers,
                 .list_servers_and_tools = listMcpServersAndTools,
@@ -1785,7 +1785,7 @@ fn traceFilePermissions() std.Io.File.Permissions {
 }
 
 fn writeTraceReportFile(alloc: std.mem.Allocator, contents: []const u8) ![]u8 {
-    const tmp_dir = io_mod.getenv("TMPDIR") orelse "/tmp";
+    const tmp_dir = io_mod.tempDir() orelse ".";
     const trimmed = std.mem.trimEnd(u8, tmp_dir, "/");
     const now_ms = io_mod.milliTimestamp();
     const now_secs: i64 = @max(@divFloor(now_ms, 1000), 0);
@@ -2006,12 +2006,15 @@ fn writeCurrentStateSummary(writer: *std.Io.Writer, app: anytype, alloc: std.mem
 }
 
 fn writeProcessSummary(writer: *std.Io.Writer, alloc: std.mem.Allocator) !void {
-    const pid = std.c.getpid();
+    const pid = io_mod.processId();
     try writer.print("process: pid={d}", .{pid});
     if (countOpenFileDescriptors()) |fd_count| try writer.print(" open_fds={d}", .{fd_count});
     try writer.writeByte('\n');
 
-    const ps = processMemorySnapshot(alloc, pid) catch null;
+    const ps = if (comptime @import("builtin").os.tag == .windows)
+        null
+    else
+        processMemorySnapshot(alloc, pid) catch null;
     if (ps) |text| {
         defer alloc.free(text);
         const trimmed = std.mem.trim(u8, text, " \t\r\n");

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -43,74 +43,69 @@ const alternate_screen_enter = "\x1b[?1049h";
 const alternate_mouse_tracking_enter = "\x1b[?1000h\x1b[?1006h";
 const terminal_takeover_reset = "\x1b[?2026l\x1b[?1000l\x1b[?1002l\x1b[?1004l\x1b[?1006l\x1b[?1l\x1b>\x1b[?2004l\x1b[<u\x1b[>4;0m\x1b[4l\x1b[?6l\x1b[?7h\x1b[0m\x1b[?25h";
 
-/// Original handlers, written at bootstrap and restored at shutdown.
-/// Signal context never mutates them.
-var old_sigterm_action: ?std.posix.Sigaction = null;
-var old_sighup_action: ?std.posix.Sigaction = null;
+const AbnormalExitSignals = if (shell_runtime.supports_resize_signal) struct {
+    /// Original handlers, written at bootstrap and restored at shutdown.
+    /// Signal context never mutates them.
+    var old_sigterm_action: ?std.posix.Sigaction = null;
+    var old_sighup_action: ?std.posix.Sigaction = null;
 
-/// Restores terminal state, installs the default disposition, and re-raises.
-/// Must remain async-signal-safe: only `write(2)`, `sigaction(2)`, and `raise(3)`.
-fn abnormalExitHandlerWithRestore(comptime restore: []const u8, sig: std.posix.SIG) void {
-    // Signal context cannot recover from a failed async-signal-safe write.
-    _ = std.c.write(
-        std.posix.STDOUT_FILENO,
-        restore.ptr,
-        restore.len,
-    );
+    /// Restores terminal state, installs the default disposition, and re-raises.
+    /// Must remain async-signal-safe: only `write(2)`, `sigaction(2)`, and `raise(3)`.
+    fn handleWithRestore(comptime restore: []const u8, sig: std.posix.SIG) void {
+        _ = std.c.write(std.posix.STDOUT_FILENO, restore.ptr, restore.len);
+        const default_action: std.posix.Sigaction = .{
+            .handler = .{ .handler = std.posix.SIG.DFL },
+            .mask = std.posix.sigemptyset(),
+            .flags = 0,
+        };
+        std.posix.sigaction(sig, &default_action, null);
+        _ = std.c.raise(sig);
+    }
 
-    const default_action: std.posix.Sigaction = .{
-        .handler = .{ .handler = std.posix.SIG.DFL },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    };
-    std.posix.sigaction(sig, &default_action, null);
-    _ = std.c.raise(sig);
-}
+    fn handle(sig: std.posix.SIG) callconv(.c) void {
+        handleWithRestore(abnormal_exit_restore, sig);
+    }
 
-fn abnormalExitHandler(sig: std.posix.SIG) callconv(.c) void {
-    abnormalExitHandlerWithRestore(abnormal_exit_restore, sig);
-}
+    fn handleTmux(sig: std.posix.SIG) callconv(.c) void {
+        handleWithRestore(tmux_abnormal_exit_restore, sig);
+    }
 
-fn tmuxAbnormalExitHandler(sig: std.posix.SIG) callconv(.c) void {
-    abnormalExitHandlerWithRestore(tmux_abnormal_exit_restore, sig);
-}
+    fn install(tmux: ?[]const u8) void {
+        const handler: std.posix.Sigaction.handler_fn = if (tmux == null) handle else handleTmux;
+        const act: std.posix.Sigaction = .{
+            .handler = .{ .handler = handler },
+            .mask = std.posix.sigemptyset(),
+            .flags = 0,
+        };
+        var old_term: std.posix.Sigaction = undefined;
+        std.posix.sigaction(std.posix.SIG.TERM, &act, &old_term);
+        old_sigterm_action = old_term;
+        var old_hup: std.posix.Sigaction = undefined;
+        std.posix.sigaction(std.posix.SIG.HUP, &act, &old_hup);
+        old_sighup_action = old_hup;
+    }
 
-/// Install handlers for SIGTERM and SIGHUP so an externally-terminated
-/// fx restores terminal state before dying. SIGINT is not included
-/// because raw mode disables terminal-generated SIGINT.
+    fn uninstall() void {
+        if (old_sigterm_action) |old| {
+            std.posix.sigaction(std.posix.SIG.TERM, &old, null);
+            old_sigterm_action = null;
+        }
+        if (old_sighup_action) |old| {
+            std.posix.sigaction(std.posix.SIG.HUP, &old, null);
+            old_sighup_action = null;
+        }
+    }
+} else struct {
+    fn install(_: ?[]const u8) void {}
+    fn uninstall() void {}
+};
+
 pub fn installAbnormalExitHandlers(tmux: ?[]const u8) void {
-    if (!shell_runtime.supports_resize_signal) return;
-
-    const handler: std.posix.Sigaction.handler_fn = if (tmux == null)
-        abnormalExitHandler
-    else
-        tmuxAbnormalExitHandler;
-    const act: std.posix.Sigaction = .{
-        .handler = .{ .handler = handler },
-        .mask = std.posix.sigemptyset(),
-        .flags = 0,
-    };
-
-    var old_term: std.posix.Sigaction = undefined;
-    std.posix.sigaction(std.posix.SIG.TERM, &act, &old_term);
-    old_sigterm_action = old_term;
-
-    var old_hup: std.posix.Sigaction = undefined;
-    std.posix.sigaction(std.posix.SIG.HUP, &act, &old_hup);
-    old_sighup_action = old_hup;
+    AbnormalExitSignals.install(tmux);
 }
 
 pub fn uninstallAbnormalExitHandlers() void {
-    if (!shell_runtime.supports_resize_signal) return;
-
-    if (old_sigterm_action) |old| {
-        std.posix.sigaction(std.posix.SIG.TERM, &old, null);
-        old_sigterm_action = null;
-    }
-    if (old_sighup_action) |old| {
-        std.posix.sigaction(std.posix.SIG.HUP, &old, null);
-        old_sighup_action = null;
-    }
+    AbnormalExitSignals.uninstall();
 }
 
 pub const StartupState = struct {
@@ -612,7 +607,7 @@ pub fn suspendToJobControl(
     metrics: *Metrics,
     footer_rows: u16,
 ) !void {
-    if (!shell_runtime.supports_resize_signal) return;
+    if (comptime !shell_runtime.supports_resize_signal) return;
 
     suspendTerminalForJobControl(terminal, shell, metrics);
     _ = std.c.raise(std.posix.SIG.TSTP);

--- a/src/core/app/app_runtime_setup.zig
+++ b/src/core/app/app_runtime_setup.zig
@@ -25,7 +25,7 @@ pub fn loadSkills(
     workspace_root: []const u8,
     root_policy: skill_contract.RootPolicy,
 ) LoadSkillsError!LoadedSkills {
-    const configured_home = io_mod.getenv("HOME") orelse return .{};
+    const configured_home = io_mod.homeDir() orelse return .{};
     const canonical_home = io_mod.realpathAlloc(alloc, configured_home) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => null,

--- a/src/core/auth/chatgpt_oauth.zig
+++ b/src/core/auth/chatgpt_oauth.zig
@@ -226,10 +226,19 @@ fn pollBrowserToken(
     if (comptime host_target.is_wasm) return error.ChatGptOAuthUnavailable;
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     const context: *BrowserLoginContext = @ptrCast(@alignCast(raw.?));
-    if (!try browserCallbackReady(&context.listener, cancel_flag)) return .pending;
-
-    var stream = try context.listener.accept(io_mod.getIo());
+    var stream = if (comptime builtin.os.tag == .windows) blk: {
+        const accepted = try windows_socket.acceptWithTimeout(
+            io_mod.getIo(),
+            &context.listener,
+            @intCast(browser_callback_poll_ms),
+        );
+        break :blk accepted orelse return .pending;
+    } else blk: {
+        if (!try browserCallbackReady(&context.listener, cancel_flag)) return .pending;
+        break :blk try context.listener.accept(io_mod.getIo());
+    };
     defer stream.close(io_mod.getIo());
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     setBrowserSocketTimeouts(stream.socket.handle);
     const target = try readBrowserCallbackTarget(alloc, stream);
     defer alloc.free(target);

--- a/src/core/auth/chatgpt_oauth.zig
+++ b/src/core/auth/chatgpt_oauth.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const chatgpt_session = @import("chatgpt_session.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
 const io_mod = @import("../shared/io.zig");
+const windows_socket = @import("../shared/windows_socket.zig");
 const login_flow = @import("login_flow.zig");
 const oauth = @import("oauth.zig");
 const oauth_transport = @import("oauth_transport.zig");
@@ -275,6 +277,17 @@ fn browserCallbackReady(
     cancel_flag: *std.atomic.Value(bool),
 ) !bool {
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (comptime builtin.os.tag == .windows) {
+        const result = try windows_socket.poll(
+            listener.socket.handle,
+            windows_socket.poll_read,
+            browser_callback_poll_ms,
+        );
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        if (!result.ready and !result.hung_up and !result.has_error) return false;
+        if (!result.ready) return error.InvalidChatGptOAuthCallback;
+        return true;
+    }
     var fds = [_]std.posix.pollfd{.{
         .fd = listener.socket.handle,
         .events = std.posix.POLL.IN,
@@ -328,7 +341,16 @@ fn writeBrowserCallbackResponse(stream: std.Io.net.Stream, success: bool) !void 
     try writer.interface.flush();
 }
 
-fn setBrowserSocketTimeouts(socket: std.posix.socket_t) void {
+fn setBrowserSocketTimeouts(socket: std.Io.net.Socket.Handle) void {
+    if (comptime builtin.os.tag == .windows) {
+        windows_socket.setTimeouts(
+            socket,
+            browser_callback_io_timeout_seconds * std.time.ms_per_s,
+        ) catch |err| {
+            debug_trace.logf("auth", "ChatGPT callback socket timeout setup failed err={s}", .{@errorName(err)});
+        };
+        return;
+    }
     const timeout = std.posix.timeval{ .sec = browser_callback_io_timeout_seconds, .usec = 0 };
     const bytes = std.mem.asBytes(&timeout);
     std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, bytes) catch |err| {

--- a/src/core/auth/chatgpt_session.zig
+++ b/src/core/auth/chatgpt_session.zig
@@ -76,7 +76,7 @@ pub const Mutation = struct {
 
 pub fn load(alloc: Allocator) !?Session {
     if (comptime host_target.is_wasm) return null;
-    const home = io_mod.getenv("HOME") orelse return null;
+    const home = io_mod.homeDir() orelse return null;
     var home_dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch |err| {
         debug_trace.logf("auth", "ChatGPT session load failed step=open_home err={s}", .{@errorName(err)});
         return null;
@@ -113,7 +113,7 @@ fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, report_open_failure: bool)
     defer file.close(io_mod.getIo());
 
     const stat = try file.stat(io_mod.getIo());
-    if (stat.kind != .file or stat.permissions.toMode() & 0o077 != 0) {
+    if (stat.kind != .file or !io_mod.permissionsPrivateFile(stat.permissions)) {
         debug_trace.logf("auth", "ChatGPT session load failed step=permissions err=InsecureAuthFile", .{});
         return null;
     }
@@ -138,7 +138,7 @@ pub fn saveNewSession(alloc: Allocator, session: Session) !void {
 
 pub fn beginExistingMutation() !?Mutation {
     if (comptime host_target.is_wasm) return null;
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
     };
@@ -152,7 +152,7 @@ pub fn beginExistingMutation() !?Mutation {
 }
 
 fn beginMutation() !Mutation {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
     };
@@ -183,12 +183,12 @@ fn openExistingPrivateFxDir(home_dir: *io_mod.VerifiedDir) !io_mod.VerifiedDir {
 
     const initial_stat = try dir.stat(io_mod.getIo());
     if (initial_stat.kind != .directory) return error.DurablePathUnsafe;
-    if (initial_stat.permissions.toMode() & 0o200 == 0) return error.PrivateStatePermissionsUnsupported;
-    dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {
+    if (!io_mod.permissionsWritable(initial_stat.permissions)) return error.PrivateStatePermissionsUnsupported;
+    io_mod.setPrivateDirPermissions(dir) catch {
         return error.PrivateStatePermissionsUnsupported;
     };
     const stat = try dir.stat(io_mod.getIo());
-    if (stat.kind != .directory or stat.permissions.toMode() & 0o777 != 0o700) {
+    if (stat.kind != .directory or !io_mod.permissionsPrivateDir(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
     return .{ .dir = dir };

--- a/src/core/auth/grok_oauth.zig
+++ b/src/core/auth/grok_oauth.zig
@@ -220,10 +220,19 @@ fn pollBrowserToken(
     if (comptime host_target.is_wasm) return error.GrokOAuthUnavailable;
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     const context: *BrowserLoginContext = @ptrCast(@alignCast(raw.?));
-    if (!try browserCallbackReady(&context.listener, cancel_flag)) return .pending;
-
-    var stream = try context.listener.accept(io_mod.getIo());
+    var stream = if (comptime builtin.os.tag == .windows) blk: {
+        const accepted = try windows_socket.acceptWithTimeout(
+            io_mod.getIo(),
+            &context.listener,
+            @intCast(browser_callback_poll_ms),
+        );
+        break :blk accepted orelse return .pending;
+    } else blk: {
+        if (!try browserCallbackReady(&context.listener, cancel_flag)) return .pending;
+        break :blk try context.listener.accept(io_mod.getIo());
+    };
     defer stream.close(io_mod.getIo());
+    if (cancel_flag.load(.seq_cst)) return error.Cancelled;
     setBrowserSocketTimeouts(stream.socket.handle);
     const target = try readBrowserCallbackTarget(alloc, stream);
     defer alloc.free(target);

--- a/src/core/auth/grok_oauth.zig
+++ b/src/core/auth/grok_oauth.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const grok_session = @import("grok_session.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
 const io_mod = @import("../shared/io.zig");
+const windows_socket = @import("../shared/windows_socket.zig");
 const login_flow = @import("login_flow.zig");
 const oauth = @import("oauth.zig");
 const oauth_transport = @import("oauth_transport.zig");
@@ -269,6 +271,17 @@ fn browserCallbackReady(
     cancel_flag: *std.atomic.Value(bool),
 ) !bool {
     if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (comptime builtin.os.tag == .windows) {
+        const result = try windows_socket.poll(
+            listener.socket.handle,
+            windows_socket.poll_read,
+            browser_callback_poll_ms,
+        );
+        if (cancel_flag.load(.seq_cst)) return error.Cancelled;
+        if (!result.ready and !result.hung_up and !result.has_error) return false;
+        if (!result.ready) return error.InvalidGrokOAuthCallback;
+        return true;
+    }
     var fds = [_]std.posix.pollfd{.{
         .fd = listener.socket.handle,
         .events = std.posix.POLL.IN,
@@ -322,7 +335,16 @@ fn writeBrowserCallbackResponse(stream: std.Io.net.Stream, success: bool) !void 
     try writer.interface.flush();
 }
 
-fn setBrowserSocketTimeouts(socket: std.posix.socket_t) void {
+fn setBrowserSocketTimeouts(socket: std.Io.net.Socket.Handle) void {
+    if (comptime builtin.os.tag == .windows) {
+        windows_socket.setTimeouts(
+            socket,
+            browser_callback_io_timeout_seconds * std.time.ms_per_s,
+        ) catch |err| {
+            debug_trace.logf("auth", "Grok callback socket timeout setup failed err={s}", .{@errorName(err)});
+        };
+        return;
+    }
     const timeout = std.posix.timeval{ .sec = browser_callback_io_timeout_seconds, .usec = 0 };
     const bytes = std.mem.asBytes(&timeout);
     std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, bytes) catch |err| {

--- a/src/core/auth/grok_session.zig
+++ b/src/core/auth/grok_session.zig
@@ -84,7 +84,7 @@ pub const Mutation = struct {
 
 pub fn load(alloc: Allocator) !?Session {
     if (comptime host_target.is_wasm) return null;
-    const home = io_mod.getenv("HOME") orelse return null;
+    const home = io_mod.homeDir() orelse return null;
     var home_dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch |err| {
         debug_trace.logf("auth", "Grok session load failed step=open_home err={s}", .{@errorName(err)});
         return null;
@@ -121,7 +121,7 @@ fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, report_open_failure: bool)
     defer file.close(io_mod.getIo());
 
     const stat = try file.stat(io_mod.getIo());
-    if (stat.kind != .file or stat.permissions.toMode() & 0o077 != 0) {
+    if (stat.kind != .file or !io_mod.permissionsPrivateFile(stat.permissions)) {
         debug_trace.logf("auth", "Grok session load failed step=permissions err=InsecureAuthFile", .{});
         return null;
     }
@@ -146,7 +146,7 @@ pub fn saveNewSession(alloc: Allocator, session: Session) !void {
 
 pub fn beginExistingMutation() !?Mutation {
     if (comptime host_target.is_wasm) return null;
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
     };
@@ -160,7 +160,7 @@ pub fn beginExistingMutation() !?Mutation {
 }
 
 fn beginMutation() !Mutation {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
     };
@@ -191,12 +191,12 @@ fn openExistingPrivateFxDir(home_dir: *io_mod.VerifiedDir) !io_mod.VerifiedDir {
 
     const initial_stat = try dir.stat(io_mod.getIo());
     if (initial_stat.kind != .directory) return error.DurablePathUnsafe;
-    if (initial_stat.permissions.toMode() & 0o200 == 0) return error.PrivateStatePermissionsUnsupported;
-    dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {
+    if (!io_mod.permissionsWritable(initial_stat.permissions)) return error.PrivateStatePermissionsUnsupported;
+    io_mod.setPrivateDirPermissions(dir) catch {
         return error.PrivateStatePermissionsUnsupported;
     };
     const stat = try dir.stat(io_mod.getIo());
-    if (stat.kind != .directory or stat.permissions.toMode() & 0o777 != 0o700) {
+    if (stat.kind != .directory or !io_mod.permissionsPrivateDir(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
     return .{ .dir = dir };

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -7,6 +7,7 @@ const debug_trace = @import("../shared/debug_trace.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
 const io_mod = @import("../shared/io.zig");
+const windows_console = @import("../shared/windows_console.zig");
 const js_host_auth = @import("js_host_auth.zig");
 const oauth = @import("oauth.zig");
 const oauth_session = @import("oauth_session.zig");
@@ -986,15 +987,22 @@ fn unavailableWaitForEnter(_: ?*anyopaque, _: u64) bool {
     return false;
 }
 
-fn realWaitForEnter(_: ?*anyopaque, timeout_ms: u64) bool {
+fn stdinReady(timeout_ms: i32) bool {
+    if (comptime builtin.os.tag == .windows) {
+        return (windows_console.waitForInput(std.Io.File.stdin().handle, timeout_ms) catch return false) == .ready;
+    }
     var fds = [_]std.posix.pollfd{.{
         .fd = std.posix.STDIN_FILENO,
         .events = std.posix.POLL.IN,
         .revents = 0,
     }};
+    const ready = std.posix.poll(&fds, timeout_ms) catch return false;
+    return ready != 0 and (fds[0].revents & std.posix.POLL.IN) != 0;
+}
+
+fn realWaitForEnter(_: ?*anyopaque, timeout_ms: u64) bool {
     const timeout: i32 = @intCast(@min(timeout_ms, @as(u64, @intCast(std.math.maxInt(i32)))));
-    const ready = std.posix.poll(&fds, timeout) catch return false;
-    if (ready == 0 or (fds[0].revents & std.posix.POLL.IN) == 0) return false;
+    if (!stdinReady(timeout)) return false;
     discardStdinLine();
     return true;
 }
@@ -1002,7 +1010,7 @@ fn realWaitForEnter(_: ?*anyopaque, timeout_ms: u64) bool {
 fn discardStdinLine() void {
     var buf: [256]u8 = undefined;
     while (true) {
-        const n = std.posix.read(std.posix.STDIN_FILENO, &buf) catch return;
+        const n = std.Io.File.stdin().readStreaming(io_mod.getIo(), &.{&buf}) catch return;
         if (n == 0) return;
         if (std.mem.findScalar(u8, buf[0..n], '\n') != null) return;
     }
@@ -1169,6 +1177,10 @@ fn selectTeamInteractive(alloc: Allocator, teams: []const Team, default_index: u
 }
 
 fn canUseInteractiveTeamPicker() bool {
+    if (comptime builtin.os.tag == .windows) {
+        return windows_console.isConsole(std.Io.File.stdin().handle) and
+            windows_console.isConsole(std.Io.File.stdout().handle);
+    }
     const stdin_tty = std.Io.File.stdin().isTty(io_mod.getIo()) catch false;
     return stdin_tty and std.c.isatty(std.posix.STDOUT_FILENO) != 0;
 }
@@ -1205,21 +1217,18 @@ const TeamPickerKey = union(enum) {
 
 fn readTeamPickerKey() !TeamPickerKey {
     var buf: [8]u8 = undefined;
-    const first_read = try std.posix.read(std.posix.STDIN_FILENO, buf[0..1]);
+    const first_read = try std.Io.File.stdin().readStreaming(io_mod.getIo(), &.{buf[0..1]});
     if (first_read == 0) return .ignored;
 
     var len = first_read;
     if (buf[0] == 0x1b) {
         while (len < buf.len) {
             if (escapeSequenceComplete(buf[0..len])) break;
-            var fds = [_]std.posix.pollfd{.{
-                .fd = std.posix.STDIN_FILENO,
-                .events = std.posix.POLL.IN,
-                .revents = 0,
-            }};
-            const ready = try std.posix.poll(&fds, 25);
-            if (ready == 0 or (fds[0].revents & std.posix.POLL.IN) == 0) break;
-            const n = try std.posix.read(std.posix.STDIN_FILENO, buf[len .. len + 1]);
+            if (!stdinReady(25)) break;
+            const n = try std.Io.File.stdin().readStreaming(
+                io_mod.getIo(),
+                &.{buf[len .. len + 1]},
+            );
             if (n == 0) break;
             len += n;
         }
@@ -1258,39 +1267,49 @@ fn parseEscapeTeamPickerKey(bytes: []const u8) TeamPickerKey {
 }
 
 const TeamPickerRawMode = struct {
-    original: std.posix.termios = undefined,
+    const NativeMode = if (builtin.os.tag == .windows)
+        windows_console.Mode
+    else
+        std.posix.termios;
+
+    original: NativeMode = undefined,
     active: bool = false,
 
     fn enable() !TeamPickerRawMode {
-        if (std.c.isatty(std.posix.STDIN_FILENO) == 0 or std.c.isatty(std.posix.STDOUT_FILENO) == 0) {
+        var self = TeamPickerRawMode{};
+        if (comptime builtin.os.tag == .windows) {
+            const input = std.Io.File.stdin().handle;
+            const output = std.Io.File.stdout().handle;
+            self.original = try windows_console.captureMode(input, output);
+            try windows_console.enableRawMode(input, output, self.original);
+            self.active = true;
+            return self;
+        }
+        if (std.c.isatty(std.posix.STDIN_FILENO) == 0 or
+            std.c.isatty(std.posix.STDOUT_FILENO) == 0)
+        {
             return error.NotATerminal;
         }
 
-        var self = TeamPickerRawMode{};
         self.original = try std.posix.tcgetattr(std.posix.STDIN_FILENO);
         var raw = self.original;
-
         raw.iflag.BRKINT = false;
         raw.iflag.ICRNL = false;
         raw.iflag.INPCK = false;
         raw.iflag.ISTRIP = false;
         raw.iflag.IXON = false;
         raw.iflag.IXOFF = false;
-
         raw.cflag.CSIZE = .CS8;
-
         raw.lflag.ECHO = false;
         raw.lflag.ICANON = false;
         raw.lflag.IEXTEN = false;
         raw.lflag.ISIG = false;
-
         const vmin_idx = vminIndex();
         const vtime_idx = vtimeIndex();
         if (vmin_idx < raw.cc.len and vtime_idx < raw.cc.len) {
             raw.cc[vmin_idx] = 1;
             raw.cc[vtime_idx] = 0;
         }
-
         try std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, raw);
         self.active = true;
         return self;
@@ -1298,7 +1317,15 @@ const TeamPickerRawMode = struct {
 
     fn disable(self: *TeamPickerRawMode) void {
         if (!self.active) return;
-        std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, self.original) catch {};
+        if (comptime builtin.os.tag == .windows) {
+            windows_console.restoreMode(
+                std.Io.File.stdin().handle,
+                std.Io.File.stdout().handle,
+                self.original,
+            );
+        } else {
+            std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, self.original) catch {};
+        }
         self.active = false;
     }
 };

--- a/src/core/auth/oauth_session.zig
+++ b/src/core/auth/oauth_session.zig
@@ -123,7 +123,7 @@ fn signalE2ELockContention(fx_dir: std.Io.Dir) void {
     if (!std.mem.eql(u8, enabled, "1")) return;
     var file = fx_dir.createFile(io_mod.getIo(), e2e_lock_contention_file_name, .{
         .truncate = true,
-        .permissions = std.Io.File.Permissions.fromMode(0o600),
+        .permissions = io_mod.private_file_permissions,
     }) catch return;
     defer file.close(io_mod.getIo());
     file.writeStreamingAll(io_mod.getIo(), "contended\n") catch {};
@@ -264,7 +264,7 @@ fn observeAuthFile(alloc: Allocator, fx_dir: *std.Io.Dir) !FileObservation {
         debug_trace.logf("auth", "session load failed source=file step=stat err={s}", .{@errorName(err)});
         return .unusable;
     };
-    if (stat.kind != .file or stat.nlink != 1 or stat.permissions.toMode() & 0o077 != 0) {
+    if (stat.kind != .file or stat.nlink != 1 or !io_mod.permissionsPrivateFile(stat.permissions)) {
         debug_trace.logf("auth", "session load failed source=file step=permissions err=InsecureAuthFile", .{});
         return .unusable;
     }
@@ -571,7 +571,7 @@ fn isLoopbackHttpUrl(url: []const u8, require_origin: bool) bool {
 
 pub fn load(alloc: Allocator) !?Session {
     if (comptime host_target.is_wasm) return loadFromHost(alloc, js_host_auth.oauth_session_store);
-    const home = io_mod.getenv("HOME") orelse {
+    const home = io_mod.homeDir() orelse {
         debug_trace.logf("auth", "session load skipped step=home err=HomeNotSet", .{});
         return null;
     };
@@ -629,7 +629,7 @@ fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir, mode: LoadMode) !?Session 
     defer file.close(io_mod.getIo());
 
     const stat = try file.stat(io_mod.getIo());
-    if (stat.kind != .file or stat.permissions.toMode() & 0o077 != 0) {
+    if (stat.kind != .file or !io_mod.permissionsPrivateFile(stat.permissions)) {
         debug_trace.logf("auth", "session load failed step=permissions err=InsecureAuthFile", .{});
         return null;
     }
@@ -668,7 +668,7 @@ pub fn beginExistingMutation() !?Mutation {
 }
 
 fn beginExistingNativeMutation() !?Mutation {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
     };
@@ -700,7 +700,7 @@ fn loadKeychainWithoutProfile(alloc: Allocator) !?Session {
 }
 
 fn beginMutation() !Mutation {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
     };
@@ -767,15 +767,15 @@ fn openExistingPrivateFxDir(home_dir: *io_mod.VerifiedDir) !io_mod.VerifiedDir {
 
     const initial_stat = try dir.stat(io_mod.getIo());
     if (initial_stat.kind != .directory) return error.DurablePathUnsafe;
-    if (initial_stat.permissions.toMode() & 0o200 == 0) {
+    if (!io_mod.permissionsWritable(initial_stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
-    dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {
+    io_mod.setPrivateDirPermissions(dir) catch {
         return error.PrivateStatePermissionsUnsupported;
     };
     const stat = try dir.stat(io_mod.getIo());
     if (stat.kind != .directory) return error.DurablePathUnsafe;
-    if (stat.permissions.toMode() & 0o777 != 0o700) {
+    if (!io_mod.permissionsPrivateDir(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
     return .{ .dir = dir };

--- a/src/core/background/background_commands.zig
+++ b/src/core/background/background_commands.zig
@@ -565,7 +565,7 @@ test "background open preserves opened failed and unsupported output" {
         alloc,
         opener,
         url,
-        host.nativeForOs(.windows).url_open,
+        host.nativeForOs(.freebsd).url_open,
     );
     defer alloc.free(unsupported.text);
     try std.testing.expect(!unsupported.succeeded);

--- a/src/core/background/background_launch_output.zig
+++ b/src/core/background/background_launch_output.zig
@@ -118,7 +118,7 @@ pub fn prepareManaged(
 }
 
 pub fn prepareExternal(alloc: Allocator) !Output {
-    const root = io_mod.tempDir() orelse ".";
+    const root = io_mod.tempDir();
     var attempt: usize = 0;
     while (attempt < 16) : (attempt += 1) {
         const name = try randomLogName(alloc);
@@ -131,7 +131,7 @@ pub fn prepareExternal(alloc: Allocator) !Output {
                 .read = true,
                 .truncate = false,
                 .exclusive = true,
-                .permissions = std.Io.File.Permissions.fromMode(0o600),
+                .permissions = io_mod.private_file_permissions,
             },
         ) catch |err| switch (err) {
             error.PathAlreadyExists => {
@@ -185,7 +185,7 @@ test "background launch output removes managed log on cancellation" {
     try tmp.dir.createDir(
         io_mod.getIo(),
         "session",
-        std.Io.File.Permissions.fromMode(0o700),
+        io_mod.private_dir_permissions,
     );
     const display_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
     defer alloc.free(display_path);

--- a/src/core/background/background_launch_output.zig
+++ b/src/core/background/background_launch_output.zig
@@ -118,7 +118,7 @@ pub fn prepareManaged(
 }
 
 pub fn prepareExternal(alloc: Allocator) !Output {
-    const root = io_mod.getenv("TMPDIR") orelse "/tmp";
+    const root = io_mod.tempDir() orelse ".";
     var attempt: usize = 0;
     while (attempt < 16) : (attempt += 1) {
         const name = try randomLogName(alloc);

--- a/src/core/background/process_supervisor.zig
+++ b/src/core/background/process_supervisor.zig
@@ -35,7 +35,9 @@ pub const ProcessInstanceToken = struct {
         if (!isLowerHex(boot_id, 32)) {
             return error.InvalidProcessInstanceToken;
         }
-        if (std.mem.eql(u8, platform, "linux")) {
+        if (std.mem.eql(u8, platform, "linux") or
+            std.mem.eql(u8, platform, "windows"))
+        {
             const start_ticks = parts.next() orelse
                 return error.InvalidProcessInstanceToken;
             if (parts.next() != null or
@@ -1013,6 +1015,13 @@ test "process instance tokens are canonical and require exact match" {
         token.view(),
     );
     try std.testing.expect(token.eql(token));
+    const windows_token = try ProcessInstanceToken.parse(
+        "windows:00000000000000000000000000000000:134170000000000000",
+    );
+    try std.testing.expectEqualStrings(
+        "windows:00000000000000000000000000000000:134170000000000000",
+        windows_token.view(),
+    );
     try std.testing.expectError(
         error.InvalidProcessInstanceToken,
         ProcessInstanceToken.parse(

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1446,7 +1446,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     var ctx = AskContext.init(alloc, cfg, options.deps, startup.workspace_root);
     defer ctx.deinit();
     if (options.save_session) {
-        _ = try ctx.session.initializeProfileUsage(alloc, io_mod.getenv("HOME"));
+        _ = try ctx.session.initializeProfileUsage(alloc, io_mod.homeDir());
         ctx.session.attachProfileUsagePublisher(alloc);
     }
     ctx.use_process_interrupt_flag = options.deps.install_headless_interrupt;

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const io_mod = @import("../shared/io.zig");
+const windows_console = @import("../shared/windows_console.zig");
 const app_lifecycle = @import("../app/app_lifecycle.zig");
 const background_record_liveness = @import("../background/background_record_liveness.zig");
 const background_store = @import("../background/background_store.zig");
@@ -1817,6 +1818,10 @@ fn runPasteSetup(
 }
 
 fn setupTerminalAvailableDefault(_: ?*anyopaque) bool {
+    if (comptime builtin.os.tag == .windows) {
+        return windows_console.isConsole(std.Io.File.stdin().handle) and
+            windows_console.isConsole(std.Io.File.stderr().handle);
+    }
     return std.c.isatty(std.posix.STDIN_FILENO) != 0 and
         std.c.isatty(std.posix.STDERR_FILENO) != 0;
 }
@@ -1837,7 +1842,7 @@ fn readMaskedKeyDefault(
 
     while (input.items.len < 8 * 1024) {
         var byte: [1]u8 = undefined;
-        if (try std.posix.read(std.posix.STDIN_FILENO, &byte) == 0) return error.SetupCancelled;
+        if (try std.Io.File.stdin().readStreaming(io_mod.getIo(), &.{&byte}) == 0) return error.SetupCancelled;
         switch (byte[0]) {
             '\r', '\n' => {
                 if (input.items.len == 0) continue;
@@ -1865,17 +1870,30 @@ fn readMaskedKeyDefault(
 }
 
 const MaskedKeyRawMode = struct {
-    original: std.posix.termios = undefined,
+    const NativeMode = if (builtin.os.tag == .windows)
+        windows_console.Mode
+    else
+        std.posix.termios;
+
+    original: NativeMode = undefined,
     active: bool = false,
 
     fn enable() !MaskedKeyRawMode {
+        var self: MaskedKeyRawMode = .{};
+        if (comptime builtin.os.tag == .windows) {
+            const input = std.Io.File.stdin().handle;
+            const output = std.Io.File.stderr().handle;
+            self.original = try windows_console.captureMode(input, output);
+            try windows_console.enableRawMode(input, output, self.original);
+            self.active = true;
+            return self;
+        }
         if (std.c.isatty(std.posix.STDIN_FILENO) == 0 or
             std.c.isatty(std.posix.STDERR_FILENO) == 0)
         {
             return error.NotATerminal;
         }
 
-        var self: MaskedKeyRawMode = .{};
         self.original = try std.posix.tcgetattr(std.posix.STDIN_FILENO);
         var raw = self.original;
         raw.iflag.BRKINT = false;
@@ -1908,7 +1926,15 @@ const MaskedKeyRawMode = struct {
 
     fn disable(self: *MaskedKeyRawMode) void {
         if (!self.active) return;
-        std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, self.original) catch {};
+        if (comptime builtin.os.tag == .windows) {
+            windows_console.restoreMode(
+                std.Io.File.stdin().handle,
+                std.Io.File.stderr().handle,
+                self.original,
+            );
+        } else {
+            std.posix.tcsetattr(std.posix.STDIN_FILENO, .FLUSH, self.original) catch {};
+        }
         self.active = false;
     }
 };

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -215,7 +215,7 @@ pub const DetailedSettings = struct {
 };
 
 pub fn discoverPaths(alloc: Allocator, workspace_root: []const u8) !Paths {
-    return discoverPathsWithOptionalHome(alloc, io_mod.getenv("HOME"), workspace_root);
+    return discoverPathsWithOptionalHome(alloc, io_mod.homeDir(), workspace_root);
 }
 
 pub fn discoverPathsFromHome(alloc: Allocator, home_dir: []const u8, workspace_root: []const u8) !Paths {
@@ -243,7 +243,7 @@ pub fn loadMergedSettingsDetailedFromHome(
 }
 
 pub fn loadMergedSettingsDetailed(alloc: Allocator, workspace_root: []const u8) !DetailedSettings {
-    return loadMergedSettingsDetailedWithOptionalHome(alloc, io_mod.getenv("HOME"), workspace_root);
+    return loadMergedSettingsDetailedWithOptionalHome(alloc, io_mod.homeDir(), workspace_root);
 }
 
 fn loadMergedSettingsDetailedWithOptionalHome(
@@ -744,7 +744,7 @@ fn ensureAbsoluteDir(path_abs: []const u8) !void {
 }
 
 pub fn userSettingsPath(alloc: Allocator) !?[]u8 {
-    const home = io_mod.getenv("HOME") orelse return null;
+    const home = io_mod.homeDir() orelse return null;
     return try profile_paths.settingsPath(alloc, home);
 }
 
@@ -784,7 +784,7 @@ pub fn attemptUserPreferences(
     alloc: Allocator,
     patch: UserSettingsPatch,
 ) CommitAttempt {
-    const home = io_mod.getenv("HOME") orelse return .{ .failure = .{ .err = error.HomeNotSet } };
+    const home = io_mod.homeDir() orelse return .{ .failure = .{ .err = error.HomeNotSet } };
     var store = settings_store.Store.initFromHome(alloc, home, .writable) catch |err| {
         return .{ .failure = .{ .err = err } };
     };
@@ -802,7 +802,7 @@ pub fn setUserPreferences(
     alloc: Allocator,
     patch: UserSettingsPatch,
 ) !CommitOutcome {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var store = try settings_store.Store.initFromHome(alloc, home, .writable);
     defer store.deinit(alloc);
     return store.applyUserPatch(alloc, patch);
@@ -812,7 +812,7 @@ pub fn mutateWorkspaceDirectory(
     alloc: Allocator,
     mutation: WorkspaceDirectoryMutation,
 ) !CommitOutcome {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var store = try settings_store.Store.initFromHome(alloc, home, .writable);
     defer store.deinit(alloc);
     return store.applyWorkspaceDirectoryPatch(alloc, mutation);
@@ -822,7 +822,7 @@ pub fn mutatePermission(
     alloc: Allocator,
     mutation: PermissionMutation,
 ) !CommitOutcome {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var store = try settings_store.Store.initFromHome(alloc, home, .writable);
     defer store.deinit(alloc);
     return store.applyPermissionPatch(alloc, mutation);

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -338,17 +338,15 @@ pub const Store = struct {
         errdefer durable_home.close(zio);
 
         if (mode == .writable) {
-            durable_home.setPermissions(zio, std.Io.File.Permissions.fromMode(0o700)) catch {
+            io_mod.setPrivateDirPermissions(durable_home) catch {
                 return error.PrivateStatePermissionsUnsupported;
             };
         }
         const stat = try durable_home.stat(zio);
         if (stat.kind != .directory) return error.DurablePathUnsafe;
-        const durable_mode = stat.permissions.toMode() & 0o777;
-        if (mode == .writable and durable_mode != 0o700) {
-            return error.PrivateStatePermissionsUnsupported;
-        }
-        if (mode == .read_only and durableModeWritableByGroupOrOther(durable_mode)) {
+        if ((mode == .writable and !io_mod.permissionsPrivateDir(stat.permissions)) or
+            (mode == .read_only and io_mod.permissionsGroupOrOtherWritable(stat.permissions)))
+        {
             return error.PrivateStatePermissionsUnsupported;
         }
 
@@ -693,16 +691,14 @@ pub const Store = struct {
         const stat = try file.stat(zio);
         try io_mod.verifyOpenedRegularFile(stat, open_mode);
         if (self.mode == .writable) {
-            file.setPermissions(zio, std.Io.File.Permissions.fromMode(0o600)) catch {
+            file.setPermissions(zio, io_mod.private_file_permissions) catch {
                 return error.PrivateStatePermissionsUnsupported;
             };
         }
         const verified_stat = if (self.mode == .writable) try file.stat(zio) else stat;
-        const primary_mode = verified_stat.permissions.toMode() & 0o777;
-        if (self.mode == .writable and primary_mode != 0o600) {
-            return error.PrivateStatePermissionsUnsupported;
-        }
-        if (self.mode == .read_only and durableModeWritableByGroupOrOther(primary_mode)) {
+        if ((self.mode == .writable and !io_mod.permissionsPrivateFile(verified_stat.permissions)) or
+            (self.mode == .read_only and io_mod.permissionsGroupOrOtherWritable(verified_stat.permissions)))
+        {
             return error.PrivateStatePermissionsUnsupported;
         }
         if (verified_stat.size > max_settings_bytes) return .oversized;

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -1310,7 +1310,7 @@ fn artifactPath(alloc: Allocator, dir: []const u8, stem: []const u8, suffix: []c
 }
 
 fn fallbackCommandArtifactDir(alloc: Allocator) ![]u8 {
-    const temp_root = io_mod.tempDir() orelse ".";
+    const temp_root = io_mod.tempDir();
     const pid_text = try std.fmt.allocPrint(alloc, "{d}", .{currentProcessId()});
     defer alloc.free(pid_text);
     return std.fs.path.join(alloc, &.{ temp_root, command_artifact_fallback_dir_name, pid_text });

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -1310,14 +1310,14 @@ fn artifactPath(alloc: Allocator, dir: []const u8, stem: []const u8, suffix: []c
 }
 
 fn fallbackCommandArtifactDir(alloc: Allocator) ![]u8 {
-    const temp_root = io_mod.getenv("TMPDIR") orelse "/tmp";
+    const temp_root = io_mod.tempDir() orelse ".";
     const pid_text = try std.fmt.allocPrint(alloc, "{d}", .{currentProcessId()});
     defer alloc.free(pid_text);
     return std.fs.path.join(alloc, &.{ temp_root, command_artifact_fallback_dir_name, pid_text });
 }
 
 fn currentProcessId() u64 {
-    return @intCast(std.c.getpid());
+    return @intCast(io_mod.processId());
 }
 
 fn elapsedMs(started_ms: i64, finished_ms: i64) u64 {
@@ -2049,7 +2049,7 @@ fn signalChild(
     process_group_id: ?std.posix.pid_t,
     force: bool,
 ) !void {
-    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
         child.kill(io_mod.getIo());
         return;
     }
@@ -2060,6 +2060,7 @@ fn signalChild(
 }
 
 fn signalProcessGroup(pid: std.posix.pid_t, force: bool) !void {
+    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
     std.posix.kill(-pid, if (force) std.posix.SIG.KILL else std.posix.SIG.TERM) catch |err| switch (err) {
         error.ProcessNotFound => {},
         else => return err,
@@ -2153,6 +2154,23 @@ test "format output covers stdout stderr empty signal and unknown statuses" {
     const signaled = try formatOutput(std.testing.allocator, "cmd", "/tmp", .{ .signal = .TERM }, "", "", null);
     defer std.testing.allocator.free(signaled.output);
     try std.testing.expectEqualStrings("signal=15\n(no output)\n", signaled.output);
+}
+
+test "Windows command execution uses cmd and returns foreground output" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const alloc = std.testing.allocator;
+    const cwd = try io_mod.realpathAlloc(alloc, ".");
+    defer alloc.free(cwd);
+    const result = try executeCommand(.{
+        .max_command_output_bytes = 4096,
+    }, alloc, "echo windows-command-ok", cwd);
+    defer alloc.free(result.output);
+
+    try std.testing.expect(std.mem.find(u8, result.output, "exit_code=0\n") != null);
+    try std.testing.expect(std.mem.find(u8, result.output, "windows-command-ok") != null);
+    const foreground = result.command_result.?.foreground;
+    try std.testing.expectEqualStrings("echo windows-command-ok", foreground.command);
+    try std.testing.expectEqual(@as(?i64, 0), foreground.exit_code);
 }
 
 test "raw process execution returns foreground output" {

--- a/src/core/hosts/host.zig
+++ b/src/core/hosts/host.zig
@@ -242,9 +242,9 @@ pub fn terminalSupportForOs(os_tag: std.Target.Os.Tag) TerminalSupport {
 
 pub fn nativeForOs(os_tag: std.Target.Os.Tag) Capabilities {
     return .{
-        .background_processes = os_tag != .windows and os_tag != .wasi,
-        .url_open = os_tag == .macos or os_tag == .linux,
-        .native_url_open = os_tag == .macos,
+        .background_processes = os_tag != .wasi,
+        .url_open = os_tag == .windows or os_tag == .macos or os_tag == .linux,
+        .native_url_open = os_tag == .windows or os_tag == .macos,
         .terminal = terminalSupportForOs(os_tag),
     };
 }
@@ -321,9 +321,9 @@ test "native host capabilities expose process and URL support" {
     try std.testing.expectEqual(TerminalSupport.supported, linux.terminal);
 
     const windows = nativeForOs(.windows);
-    try std.testing.expect(!windows.background_processes);
-    try std.testing.expect(!windows.url_open);
-    try std.testing.expect(!windows.native_url_open);
+    try std.testing.expect(windows.background_processes);
+    try std.testing.expect(windows.url_open);
+    try std.testing.expect(windows.native_url_open);
     try std.testing.expectEqual(TerminalSupport.unsupported, windows.terminal);
 
     const wasi = nativeForOs(.wasi);

--- a/src/core/hosts/native_secret_store.zig
+++ b/src/core/hosts/native_secret_store.zig
@@ -86,7 +86,7 @@ fn loadFromKeychain(alloc: Allocator) LoadError!?[]u8 {
 }
 
 fn loadFromProfile(alloc: Allocator) LoadError!?[]u8 {
-    const home = io_mod.getenv("HOME") orelse {
+    const home = io_mod.homeDir() orelse {
         debug_trace.logf("stored_key", "load failed step=home err=HomeNotSet", .{});
         return error.StoredKeyUnreadable;
     };
@@ -130,7 +130,7 @@ fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir) LoadError!?[]u8 {
         debug_trace.logf("stored_key", "load failed step=stat err={s}", .{@errorName(err)});
         return error.StoredKeyUnreadable;
     };
-    if (stat.kind != .file or stat.permissions.toMode() & 0o077 != 0) {
+    if (stat.kind != .file or !io_mod.permissionsPrivateFile(stat.permissions)) {
         debug_trace.logf("stored_key", "load failed step=permissions err=StoredKeyInsecure", .{});
         return error.StoredKeyInsecure;
     }
@@ -155,7 +155,7 @@ fn loadFromDir(alloc: Allocator, fx_dir: *std.Io.Dir) LoadError!?[]u8 {
 }
 
 fn storeInProfile(alloc: Allocator, value: []const u8) StoreError!void {
-    const home = io_mod.getenv("HOME") orelse return writeFailed("home", error.HomeNotSet);
+    const home = io_mod.homeDir() orelse return writeFailed("home", error.HomeNotSet);
     var home_dir = io_mod.VerifiedDir{
         .dir = std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }) catch |err| {
             return writeFailed("open_home", err);

--- a/src/core/hosts/url_opener.zig
+++ b/src/core/hosts/url_opener.zig
@@ -52,9 +52,11 @@ fn launchUrl(
     os_tag: std.Target.Os.Tag,
     launcher: Launcher,
 ) LaunchOutcome {
-    var macos_argv = [_][]const u8{ "open", url };
-    var linux_argv = [_][]const u8{ "xdg-open", url };
+    const macos_argv = [_][]const u8{ "open", url };
+    const linux_argv = [_][]const u8{ "xdg-open", url };
+    const windows_argv = [_][]const u8{ "rundll32.exe", "url.dll,FileProtocolHandler", url };
     const argv: []const []const u8 = switch (os_tag) {
+        .windows => &windows_argv,
         .macos => &macos_argv,
         .linux => &linux_argv,
         else => return .unsupported,
@@ -116,13 +118,18 @@ test "url opener selects the platform launcher argv" {
     defer linux.deinit(alloc);
     try std.testing.expectEqual(LaunchOutcome.opened, launchUrl(alloc, "http://localhost:3000", .linux, linux.launcher()));
     try std.testing.expectEqualStrings("xdg-open http://localhost:3000", linux.argv_joined.items);
+
+    var windows = MockLauncher{};
+    defer windows.deinit(alloc);
+    try std.testing.expectEqual(LaunchOutcome.opened, launchUrl(alloc, "http://localhost:3000", .windows, windows.launcher()));
+    try std.testing.expectEqualStrings("rundll32.exe url.dll,FileProtocolHandler http://localhost:3000", windows.argv_joined.items);
 }
 
 test "url opener reports unsupported platforms without launching" {
     const alloc = std.testing.allocator;
     var mock = MockLauncher{};
     defer mock.deinit(alloc);
-    try std.testing.expectEqual(LaunchOutcome.unsupported, launchUrl(alloc, "http://x", .windows, mock.launcher()));
+    try std.testing.expectEqual(LaunchOutcome.unsupported, launchUrl(alloc, "http://x", .freebsd, mock.launcher()));
     try std.testing.expectEqualStrings("", mock.argv_joined.items);
 }
 

--- a/src/core/images/image_attachments.zig
+++ b/src/core/images/image_attachments.zig
@@ -167,7 +167,7 @@ fn loadResolvedImageAttachment(
 }
 
 pub fn createTempSnapshotDir(alloc: std.mem.Allocator) ![]u8 {
-    const temp_root = try io_mod.realpathAlloc(alloc, "/tmp");
+    const temp_root = try io_mod.realpathAlloc(alloc, io_mod.tempDir() orelse ".");
     defer alloc.free(temp_root);
     for (0..16) |_| {
         var suffix: u64 = undefined;
@@ -181,7 +181,7 @@ pub fn createTempSnapshotDir(alloc: std.mem.Allocator) ![]u8 {
         std.Io.Dir.createDirAbsolute(
             io_mod.getIo(),
             path,
-            std.Io.File.Permissions.fromMode(0o700),
+            io_mod.private_dir_permissions,
         ) catch |err| switch (err) {
             error.PathAlreadyExists => {
                 alloc.free(path);
@@ -533,7 +533,7 @@ fn captureImageSnapshotFromOpenFileWithBudget(
             .{
                 .truncate = false,
                 .exclusive = true,
-                .permissions = std.Io.File.Permissions.fromMode(0o600),
+                .permissions = io_mod.private_file_permissions,
                 .resolve_beneath = true,
             },
         );
@@ -624,7 +624,7 @@ fn streamSourceToFile(
         .{
             .truncate = false,
             .exclusive = true,
-            .permissions = std.Io.File.Permissions.fromMode(0o600),
+            .permissions = io_mod.private_file_permissions,
             .resolve_beneath = true,
         },
     );
@@ -970,7 +970,7 @@ fn openOrCreateSnapshotDirectoryNoFollow(path: []const u8) !std.Io.Dir {
             parent.createDir(
                 io_mod.getIo(),
                 name,
-                std.Io.File.Permissions.fromMode(0o700),
+                io_mod.private_dir_permissions,
             ) catch |create_err| switch (create_err) {
                 error.PathAlreadyExists => {},
                 else => return unsafeSnapshotPathError(create_err),
@@ -1114,7 +1114,7 @@ pub fn copyVerifiedImageAttachmentToDir(
         .{
             .truncate = false,
             .exclusive = true,
-            .permissions = std.Io.File.Permissions.fromMode(0o600),
+            .permissions = io_mod.private_file_permissions,
             .resolve_beneath = true,
         },
     );

--- a/src/core/images/image_attachments.zig
+++ b/src/core/images/image_attachments.zig
@@ -167,7 +167,7 @@ fn loadResolvedImageAttachment(
 }
 
 pub fn createTempSnapshotDir(alloc: std.mem.Allocator) ![]u8 {
-    const temp_root = try io_mod.realpathAlloc(alloc, io_mod.tempDir() orelse ".");
+    const temp_root = try io_mod.realpathAlloc(alloc, io_mod.tempDir());
     defer alloc.free(temp_root);
     for (0..16) |_| {
         var suffix: u64 = undefined;

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -3,6 +3,7 @@ const host_target = @import("../hosts/target.zig");
 const builtin = @import("builtin");
 const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
+const windows_socket = @import("../shared/windows_socket.zig");
 const operation_control = @import("operation_control.zig");
 const secret = @import("../auth/secret.zig");
 
@@ -1006,7 +1007,7 @@ pub fn authorizeInteractive(
     alloc: Allocator,
     options: InteractiveAuthorizationOptions,
 ) !AuthorizationResult {
-    if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+    if (comptime builtin.os.tag == .wasi) {
         return error.InteractiveMcpAuthorizationUnsupported;
     }
     var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
@@ -1252,23 +1253,37 @@ fn waitForInteractiveCallback(
     listener: *std.Io.net.Server,
     cancellation: operation_control.CancellationSources,
 ) !void {
-    var fds = [_]std.posix.pollfd{.{
-        .fd = listener.socket.handle,
-        .events = std.posix.POLL.IN,
-        .revents = 0,
-    }};
     var remaining_ms = interactive_callback_timeout_ms;
     while (remaining_ms > 0) {
         try checkAuthorizationCancellation(cancellation);
-        fds[0].revents = 0;
         const wait_ms = @min(remaining_ms, interactive_callback_poll_ms);
-        const ready = try std.posix.poll(&fds, wait_ms);
-        if (ready > 0) {
-            if ((fds[0].revents & std.posix.POLL.IN) == 0) {
+        if (comptime builtin.os.tag == .windows) {
+            const result = try windows_socket.poll(
+                listener.socket.handle,
+                windows_socket.poll_read,
+                wait_ms,
+            );
+            if (result.ready) {
+                try checkAuthorizationCancellation(cancellation);
+                return;
+            }
+            if (result.hung_up or result.has_error or result.invalid) {
                 return error.McpAuthorizationCallbackTimedOut;
             }
-            try checkAuthorizationCancellation(cancellation);
-            return;
+        } else {
+            var fds = [_]std.posix.pollfd{.{
+                .fd = listener.socket.handle,
+                .events = std.posix.POLL.IN,
+                .revents = 0,
+            }};
+            const ready = try std.posix.poll(&fds, wait_ms);
+            if (ready > 0) {
+                if ((fds[0].revents & std.posix.POLL.IN) == 0) {
+                    return error.McpAuthorizationCallbackTimedOut;
+                }
+                try checkAuthorizationCancellation(cancellation);
+                return;
+            }
         }
         remaining_ms -= wait_ms;
     }
@@ -1858,9 +1873,18 @@ fn validateJsonContentType(content_type: ?[]const u8) !void {
     }
 }
 
-fn setSocketTimeouts(socket: std.posix.socket_t, seconds: i64) void {
+fn setSocketTimeouts(socket: std.Io.net.Socket.Handle, seconds: i64) void {
     if (comptime host_target.is_wasm) return;
-    const timeout = std.posix.timeval{ .sec = seconds, .usec = 0 };
+    if (comptime builtin.os.tag == .windows) {
+        const timeout_ms: u32 = @intCast(@max(seconds, 0) * std.time.ms_per_s);
+        windows_socket.setTimeouts(socket, timeout_ms) catch |err| debug_trace.logf(
+            "mcp",
+            "OAuth socket timeout setup failed err={s}",
+            .{@errorName(err)},
+        );
+        return;
+    }
+    const timeout = std.posix.timeval{ .sec = @intCast(seconds), .usec = 0 };
     const bytes = std.mem.asBytes(&timeout);
     std.posix.setsockopt(
         socket,

--- a/src/core/mcp/mcp_auth_store.zig
+++ b/src/core/mcp/mcp_auth_store.zig
@@ -347,7 +347,7 @@ fn openOrCreateLockedDir() !LockedDir {
 fn openOrCreateLockedDirControlled(
     cancel_flag: ?*const std.atomic.Value(bool),
 ) !LockedDir {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{ .iterate = true }),
     };
@@ -386,7 +386,7 @@ fn openExistingLockedDir() !?LockedDir {
 fn openExistingLockedDirControlled(
     cancel_flag: ?*const std.atomic.Value(bool),
 ) !?LockedDir {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var home_dir = io_mod.VerifiedDir{
         .dir = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), home, .{
             .iterate = true,
@@ -456,15 +456,12 @@ fn openExistingPrivateChild(
 fn normalizeAndVerifyPrivateDir(dir: std.Io.Dir) !void {
     const initial = try dir.stat(io_mod.getIo());
     if (initial.kind != .directory) return error.DurablePathUnsafe;
-    if (initial.permissions.toMode() & 0o200 == 0) {
+    if (!io_mod.permissionsWritable(initial.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
-    try dir.setPermissions(
-        io_mod.getIo(),
-        std.Io.File.Permissions.fromMode(0o700),
-    );
+    try io_mod.setPrivateDirPermissions(dir);
     const stat = try dir.stat(io_mod.getIo());
-    if (stat.kind != .directory or stat.permissions.toMode() & 0o777 != 0o700) {
+    if (stat.kind != .directory or !io_mod.permissionsPrivateDir(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
 }
@@ -533,7 +530,7 @@ fn loadFromDir(alloc: Allocator, dir: *io_mod.VerifiedDir) !?Store {
     defer file.close(io_mod.getIo());
     const stat = try file.stat(io_mod.getIo());
     if (stat.kind != .file or stat.nlink != 1) return error.DurablePathUnsafe;
-    if (stat.permissions.toMode() & 0o777 != 0o600) {
+    if (!io_mod.permissionsPrivateFile(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
     const bytes = try io_mod.readFileToEnd(alloc, &file, max_store_bytes);

--- a/src/core/session/command_replay_store.zig
+++ b/src/core/session/command_replay_store.zig
@@ -516,7 +516,7 @@ fn createSpool(
         const handle = try std.fmt.allocPrint(
             alloc,
             "fx-command-replay-{d}-{d}-{d}.bin",
-            .{ std.c.getpid(), io_mod.nanoTimestamp(), attempt },
+            .{ io_mod.processId(), io_mod.nanoTimestamp(), attempt },
         );
         const file = capability.createExclusiveFile(
             alloc,

--- a/src/core/session/profile_usage_store.zig
+++ b/src/core/session/profile_usage_store.zig
@@ -13,8 +13,8 @@ const max_record_bytes: usize = 16 * 1024;
 const max_records: usize = 200_000;
 const compaction_threshold_bytes: u64 = 8 * 1024 * 1024;
 const retention_ms: i64 = std.time.ms_per_day * 35;
-const private_dir_permissions = std.Io.Dir.Permissions.fromMode(0o700);
-const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+const private_dir_permissions = io_mod.private_dir_permissions;
+const private_file_permissions = io_mod.private_file_permissions;
 
 pub const AppendOutcome = enum {
     appended,
@@ -271,7 +271,7 @@ pub const Store = struct {
         const durable_home = self.durable_home orelse return;
         const stat = try durable_home.dir.stat(io_mod.getIo());
         if (stat.kind != .directory) return error.DurablePathUnsafe;
-        if (stat.permissions.toMode() & 0o777 != 0o700) {
+        if (!io_mod.permissionsPrivateDir(stat.permissions)) {
             return error.PrivateStatePermissionsUnsupported;
         }
     }
@@ -293,13 +293,11 @@ pub const Store = struct {
                 else => return error.DurableLayoutFailed,
             };
         }
-        self.durable_home.?.dir.setPermissions(
-            io_mod.getIo(),
-            private_dir_permissions,
-        ) catch return error.PrivateStatePermissionsUnsupported;
+        io_mod.setPrivateDirPermissions(self.durable_home.?.dir) catch
+            return error.PrivateStatePermissionsUnsupported;
         const stat = try self.durable_home.?.dir.stat(io_mod.getIo());
         if (stat.kind != .directory) return error.DurablePathUnsafe;
-        if (stat.permissions.toMode() & 0o777 != 0o700) {
+        if (!io_mod.permissionsPrivateDir(stat.permissions)) {
             return error.PrivateStatePermissionsUnsupported;
         }
     }
@@ -331,7 +329,7 @@ pub const Store = struct {
         if (stat.kind != .file or stat.nlink != 1) {
             return error.DurablePathUnsafe;
         }
-        if (stat.permissions.toMode() & 0o777 != 0o600) {
+        if (!io_mod.permissionsPrivateFile(stat.permissions)) {
             return error.PrivateStatePermissionsUnsupported;
         }
 
@@ -368,7 +366,7 @@ pub const Store = struct {
         if (stat.kind != .file or stat.nlink != 1) {
             return error.DurablePathUnsafe;
         }
-        if (stat.permissions.toMode() & 0o777 != 0o600) {
+        if (!io_mod.permissionsPrivateFile(stat.permissions)) {
             return error.PrivateStatePermissionsUnsupported;
         }
         return true;
@@ -416,7 +414,7 @@ pub const Store = struct {
                 return error.PrivateStatePermissionsUnsupported;
         }
         const verified = if (writable) try file.stat(zio) else initial;
-        if (verified.permissions.toMode() & 0o777 != 0o600) {
+        if (!io_mod.permissionsPrivateFile(verified.permissions)) {
             return error.PrivateStatePermissionsUnsupported;
         }
         if (created) {
@@ -608,6 +606,9 @@ fn openExistingUsageFile(
     dir: std.Io.Dir,
     mode: std.Io.Dir.OpenFileOptions.Mode,
 ) !std.Io.File {
+    if (comptime @import("builtin").os.tag == .windows) {
+        return io_mod.openExistingRegularFile(dir, usage_file, mode);
+    }
     return io_mod.openExistingRegularFile(dir, usage_file, mode) catch |err| switch (err) {
         error.FileControlFailed => error.UsageReadFailed,
         else => err,

--- a/src/core/session/prompt_history_store.zig
+++ b/src/core/session/prompt_history_store.zig
@@ -13,8 +13,8 @@ const max_record_bytes: usize = 256 * 1024;
 const compaction_threshold_bytes: u64 = 1024 * 1024;
 const compaction_record_limit: usize = 1000;
 const compaction_byte_limit: usize = 1024 * 1024;
-const private_dir_permissions = std.Io.File.Permissions.fromMode(0o700);
-const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+const private_dir_permissions = io_mod.private_dir_permissions;
+const private_file_permissions = io_mod.private_file_permissions;
 
 pub const LoadedPromptHistoryEntry = struct {
     text: []u8,
@@ -238,13 +238,11 @@ pub const Store = struct {
             };
         }
 
-        self.durable_home.?.dir.setPermissions(
-            io_mod.getIo(),
-            private_dir_permissions,
-        ) catch return error.PrivateStatePermissionsUnsupported;
+        io_mod.setPrivateDirPermissions(self.durable_home.?.dir) catch
+            return error.PrivateStatePermissionsUnsupported;
         const stat = try self.durable_home.?.dir.stat(io_mod.getIo());
         if (stat.kind != .directory) return error.DurablePathUnsafe;
-        if (stat.permissions.toMode() & 0o777 != 0o700) {
+        if (!io_mod.permissionsPrivateDir(stat.permissions)) {
             return error.PrivateStatePermissionsUnsupported;
         }
     }
@@ -300,7 +298,7 @@ pub const Store = struct {
             };
         }
         const verified = if (writable) try file.stat(zio) else initial;
-        if (verified.permissions.toMode() & 0o777 != 0o600) {
+        if (!io_mod.permissionsPrivateFile(verified.permissions)) {
             return error.PrivateStatePermissionsUnsupported;
         }
         if (created) {

--- a/src/core/session/session_authority.zig
+++ b/src/core/session/session_authority.zig
@@ -643,7 +643,7 @@ pub fn eventFileStat(
         .device = device,
         .inode = @intCast(stat.inode),
         .kind = .regular,
-        .mode = stat.permissions.toMode(),
+        .mode = io_mod.permissionsMode(stat.permissions),
         .link_count = @intCast(stat.nlink),
         .size = stat.size,
         .mtime_ns = stat.mtime.nanoseconds,

--- a/src/core/session/session_child_store.zig
+++ b/src/core/session/session_child_store.zig
@@ -3,8 +3,8 @@ const config_runtime = @import("../config/config_runtime.zig");
 const io_mod = @import("../shared/io.zig");
 
 const Allocator = std.mem.Allocator;
-const private_dir_permissions = std.Io.File.Permissions.fromMode(0o700);
-const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+const private_dir_permissions = io_mod.private_dir_permissions;
+const private_file_permissions = io_mod.private_file_permissions;
 
 pub const subagent_relationship_index_file = "relationship-index.bin";
 
@@ -379,7 +379,7 @@ const CapabilityImpl = struct {
         errdefer dir.close(io_mod.getIo());
 
         if (self.mode == .writable) {
-            dir.setPermissions(io_mod.getIo(), private_dir_permissions) catch
+            io_mod.setPrivateDirPermissions(dir) catch
                 return error.PrivateStatePermissionsUnsupported;
         }
         try verifyPrivateDirectory(dir);
@@ -535,7 +535,7 @@ pub const SessionChildCapability = struct {
         };
         errdefer route.close(io_mod.getIo());
         if (mode == .writable) {
-            route.setPermissions(io_mod.getIo(), private_dir_permissions) catch
+            io_mod.setPrivateDirPermissions(route) catch
                 return error.PrivateStatePermissionsUnsupported;
         }
         try verifyPrivateDirectory(route);
@@ -592,10 +592,8 @@ pub const SessionChildCapability = struct {
         };
         errdefer records.close(io_mod.getIo());
         if (mode == .writable) {
-            records.setPermissions(
-                io_mod.getIo(),
-                private_dir_permissions,
-            ) catch return error.PrivateStatePermissionsUnsupported;
+            io_mod.setPrivateDirPermissions(records) catch
+                return error.PrivateStatePermissionsUnsupported;
         }
         try verifyPrivateDirectory(records);
 
@@ -626,10 +624,8 @@ pub const SessionChildCapability = struct {
         errdefer if (logs) |route| route.close(io_mod.getIo());
         if (logs) |route| {
             if (mode == .writable) {
-                route.setPermissions(
-                    io_mod.getIo(),
-                    private_dir_permissions,
-                ) catch return error.PrivateStatePermissionsUnsupported;
+                io_mod.setPrivateDirPermissions(route) catch
+                    return error.PrivateStatePermissionsUnsupported;
             }
             try verifyPrivateDirectory(route);
         }
@@ -1162,7 +1158,7 @@ fn validateName(name: []const u8) !void {
 fn verifyPrivateDirectory(dir: std.Io.Dir) !void {
     const stat = try dir.stat(io_mod.getIo());
     if (stat.kind != .directory) return error.SessionPathUnsafe;
-    if (stat.permissions.toMode() & 0o777 != 0o700) {
+    if (!io_mod.permissionsPrivateDir(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
 }
@@ -1177,7 +1173,7 @@ fn verifyPrivateOpenedStat(
 ) !void {
     io_mod.verifyOpenedRegularFile(stat, mode) catch
         return error.SessionPathUnsafe;
-    if (stat.permissions.toMode() & 0o777 != 0o600) {
+    if (!io_mod.permissionsPrivateFile(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
 }
@@ -1186,7 +1182,7 @@ fn verifyPrivateStat(stat: std.Io.File.Stat) !void {
     if (stat.kind != .file or stat.nlink != 1) {
         return error.SessionPathUnsafe;
     }
-    if (stat.permissions.toMode() & 0o777 != 0o600) {
+    if (!io_mod.permissionsPrivateFile(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
 }

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -18,8 +18,8 @@ const session_usage_sidecar = @import("session_usage_sidecar.zig");
 
 const Allocator = std.mem.Allocator;
 const Identifier = session_event.Identifier;
-const private_dir_permissions = std.Io.File.Permissions.fromMode(0o700);
-const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+const private_dir_permissions = io_mod.private_dir_permissions;
+const private_file_permissions = io_mod.private_file_permissions;
 const lock_deadline_ms: u64 = 2000;
 const authority_max_bytes: usize = 16 * 1024;
 const authority_intent_max_bytes: usize = 32 * 1024;
@@ -1049,7 +1049,7 @@ pub const Root = struct {
         };
         defer durable_home.close(zio);
         if (mode == .writable) {
-            durable_home.setPermissions(zio, private_dir_permissions) catch
+            io_mod.setPrivateDirPermissions(durable_home) catch
                 return error.PrivateStatePermissionsUnsupported;
         }
         try verifyPrivateDir(durable_home, mode);
@@ -1081,7 +1081,7 @@ pub const Root = struct {
         };
         errdefer sessions_dir.close(zio);
         if (mode == .writable) {
-            sessions_dir.setPermissions(zio, private_dir_permissions) catch
+            io_mod.setPrivateDirPermissions(sessions_dir) catch
                 return error.PrivateStatePermissionsUnsupported;
         }
         try verifyPrivateDir(sessions_dir, mode);
@@ -1400,7 +1400,7 @@ fn validateLeaf(name: []const u8) !void {
 fn verifyPrivateDir(dir: std.Io.Dir, mode: OpenMode) !void {
     const stat = try dir.stat(io_mod.getIo());
     if (stat.kind != .directory) return error.SessionPathUnsafe;
-    if (mode == .writable and stat.permissions.toMode() & 0o777 != 0o700) {
+    if (mode == .writable and !io_mod.permissionsPrivateDir(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
 }
@@ -1408,7 +1408,7 @@ fn verifyPrivateDir(dir: std.Io.Dir, mode: OpenMode) !void {
 fn verifyManagedFile(file: std.Io.File, mode: OpenMode) !void {
     const stat = try file.stat(io_mod.getIo());
     if (stat.kind != .file or stat.nlink != 1) return error.SessionPathUnsafe;
-    if (mode == .writable and stat.permissions.toMode() & 0o777 != 0o600) {
+    if (mode == .writable and !io_mod.permissionsPrivateFile(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
 }
@@ -1428,7 +1428,7 @@ fn openSessionDir(
     };
     errdefer dir.close(io_mod.getIo());
     if (mode == .writable) {
-        dir.setPermissions(io_mod.getIo(), private_dir_permissions) catch
+        io_mod.setPrivateDirPermissions(dir) catch
             return error.PrivateStatePermissionsUnsupported;
     }
     try verifyPrivateDir(dir, mode);
@@ -4023,7 +4023,7 @@ fn eventStat(
         .device = try eventDevice(file),
         .inode = @intCast(stat.inode),
         .kind = .regular,
-        .mode = stat.permissions.toMode(),
+        .mode = io_mod.permissionsMode(stat.permissions),
         .link_count = @intCast(stat.nlink),
         .size = stat.size,
         .mtime_ns = stat.mtime.nanoseconds,
@@ -4383,7 +4383,7 @@ fn cleanupOrphansImpl(
             continue;
         };
         if (stat.kind != .file or stat.nlink != 1 or
-            stat.permissions.toMode() & 0o777 != 0o600)
+            !io_mod.permissionsPrivateFile(stat.permissions))
         {
             report.ignored += 1;
             continue;

--- a/src/core/session/session_resume_view.zig
+++ b/src/core/session/session_resume_view.zig
@@ -194,7 +194,7 @@ pub fn loadMatching(
 
 fn safeFile(stat: std.Io.File.Stat) bool {
     return stat.kind == .file and stat.nlink == 1 and
-        stat.permissions.toMode() & 0o777 == 0o600;
+        io_mod.permissionsPrivateFile(stat.permissions);
 }
 
 fn validVisibleText(text: []const u8) bool {

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -483,7 +483,7 @@ fn openUsageRecoveryProfileRoot(
     errdefer profile.close(zio);
     const stat = try profile.stat(zio);
     if (stat.kind != .directory or
-        stat.permissions.toMode() & 0o777 != 0o700)
+        !io_mod.permissionsPrivateDir(stat.permissions))
     {
         return error.InvalidUsageRecoveryIndex;
     }
@@ -506,7 +506,7 @@ fn openUsageRecoveryDir(
     errdefer dir.close(io_mod.getIo());
     const stat = try dir.stat(io_mod.getIo());
     if (stat.kind != .directory or
-        stat.permissions.toMode() & 0o777 != 0o700)
+        !io_mod.permissionsPrivateDir(stat.permissions))
     {
         return error.InvalidUsageRecoveryIndex;
     }
@@ -532,7 +532,7 @@ fn validateUsageRecoveryMarker(
         stat.nlink != 1 or
         stat.size == 0 or
         stat.size > max_usage_recovery_marker_bytes or
-        stat.permissions.toMode() & 0o777 != 0o600)
+        !io_mod.permissionsPrivateFile(stat.permissions))
     {
         return error.InvalidUsageRecoveryIndex;
     }
@@ -588,13 +588,13 @@ pub const Store = struct {
 
     /// Opens a writable store rooted at `$HOME`, creating the layout if needed.
     pub fn init(alloc: Allocator, workspace_root: []const u8) !Store {
-        const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+        const home = io_mod.homeDir() orelse return error.HomeNotSet;
         return initWithHome(alloc, home, workspace_root, true);
     }
 
     /// Opens a read-only store rooted at `$HOME`; never creates layout.
     pub fn initReadOnly(alloc: Allocator, workspace_root: []const u8) !Store {
-        const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+        const home = io_mod.homeDir() orelse return error.HomeNotSet;
         return initWithHome(alloc, home, workspace_root, false);
     }
 
@@ -4877,12 +4877,11 @@ fn loadedWriterBelongsToRoot(
 }
 
 fn prepareWritableSessionDir(dir: std.Io.Dir) !void {
-    const permissions = std.Io.File.Permissions.fromMode(0o700);
-    dir.setPermissions(io_mod.getIo(), permissions) catch
+    io_mod.setPrivateDirPermissions(dir) catch
         return error.PrivateStatePermissionsUnsupported;
     const stat = try dir.stat(io_mod.getIo());
     if (stat.kind != .directory) return error.SessionPathUnsafe;
-    if (stat.permissions.toMode() & 0o777 != 0o700) {
+    if (!io_mod.permissionsPrivateDir(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
 }

--- a/src/core/session/session_summary_codec.zig
+++ b/src/core/session/session_summary_codec.zig
@@ -53,8 +53,8 @@ pub const deferred_cache_dir = "deferred";
 pub const relationship_migration_candidate_limit: usize = 16;
 const relationship_migration_read_bytes: usize = 64 * 1024;
 const relationship_migration_overlap_bytes: u64 = 512;
-const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
-const private_dir_permissions = std.Io.File.Permissions.fromMode(0o700);
+const private_file_permissions = io_mod.private_file_permissions;
+const private_dir_permissions = io_mod.private_dir_permissions;
 
 const DeferredCachePositionJson = struct {
     log_generation: []const u8,
@@ -206,7 +206,7 @@ fn openDeferredCacheDirectory(
 fn requirePrivateCacheDirectory(dir: std.Io.Dir) !void {
     const stat = try dir.stat(io_mod.getIo());
     if (stat.kind != .directory or
-        stat.permissions.toMode() & 0o777 != private_dir_permissions.toMode())
+        !io_mod.permissionsPrivateDir(stat.permissions))
     {
         return error.InvalidSessionIndex;
     }
@@ -279,7 +279,7 @@ fn readDeferredCacheTokenFromDirectory(
     defer file.close(io_mod.getIo());
     const stat = try file.stat(io_mod.getIo());
     if (stat.kind != .file or stat.nlink != 1 or
-        stat.permissions.toMode() & 0o777 != private_file_permissions.toMode() or
+        !io_mod.permissionsPrivateFile(stat.permissions) or
         stat.size == 0 or stat.size > max_deferred_cache_token_bytes)
     {
         return error.InvalidSessionIndex;
@@ -1529,7 +1529,7 @@ pub fn refreshRelationshipMigrationSnapshot(
         return error.InvalidSessionIndex;
     if (target_stat.kind != .file or
         target_stat.nlink != 1 or
-        target_stat.permissions.toMode() & 0o777 != 0o600)
+        !io_mod.permissionsPrivateFile(target_stat.permissions))
     {
         return error.InvalidSessionIndex;
     }
@@ -1644,7 +1644,7 @@ fn openVerifiedSessionIndexFile(
     };
     errdefer file.close(io_mod.getIo());
     const stat = try file.stat(io_mod.getIo());
-    if (stat.kind != .file or stat.nlink != 1 or stat.permissions.toMode() & 0o777 != 0o600) {
+    if (stat.kind != .file or stat.nlink != 1 or !io_mod.permissionsPrivateFile(stat.permissions)) {
         return error.InvalidSessionIndex;
     }
     return file;

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -96,7 +96,7 @@ pub fn capture(
         return .{ .invalid = @errorName(err) };
     };
     if (initial.kind != .file or initial.nlink != 1 or
-        initial.permissions.toMode() & 0o777 != 0o600)
+        !io_mod.permissionsPrivateFile(initial.permissions))
     {
         return .{ .invalid = "unsafe_initial_shape" };
     }
@@ -117,7 +117,7 @@ pub fn capture(
     const verified = file.stat(io_mod.getIo()) catch |err|
         return .{ .invalid = @errorName(err) };
     if (verified.kind != .file or verified.nlink != 1 or
-        verified.permissions.toMode() & 0o777 != 0o600)
+        !io_mod.permissionsPrivateFile(verified.permissions))
     {
         return .{ .invalid = "unsafe_verified_shape" };
     }

--- a/src/core/session/web_fetch_artifacts.zig
+++ b/src/core/session/web_fetch_artifacts.zig
@@ -239,7 +239,7 @@ fn ensureManagedDir(parent_path: []const u8, child_name: []const u8) !void {
             .follow_symlinks = false,
         }) catch |err| switch (err) {
             error.FileNotFound => {
-                parent.createDir(zio, child_name, std.Io.File.Permissions.fromMode(0o700)) catch |create_err| switch (create_err) {
+                parent.createDir(zio, child_name, io_mod.private_dir_permissions) catch |create_err| switch (create_err) {
                     error.PathAlreadyExists => continue,
                     error.NotDir, error.SymLinkLoop => return error.CorruptArtifactStore,
                     else => return create_err,
@@ -251,10 +251,10 @@ fn ensureManagedDir(parent_path: []const u8, child_name: []const u8) !void {
             else => return err,
         };
         defer child.close(zio);
-        child.setPermissions(zio, std.Io.File.Permissions.fromMode(0o700)) catch
+        io_mod.setPrivateDirPermissions(child) catch
             return error.CorruptArtifactStore;
         const stat = try child.stat(zio);
-        if (stat.kind != .directory or stat.permissions.toMode() & 0o777 != 0o700) {
+        if (stat.kind != .directory or !io_mod.permissionsPrivateDir(stat.permissions)) {
             return error.CorruptArtifactStore;
         }
         return;

--- a/src/core/shared/debug_trace.zig
+++ b/src/core/shared/debug_trace.zig
@@ -440,7 +440,7 @@ fn resolveLogPath(alloc: Allocator, workspace_root: []const u8, raw_path: []cons
 }
 
 fn defaultLogPath(alloc: Allocator) ![]u8 {
-    if (io_mod.getenv("HOME")) |home| {
+    if (io_mod.homeDir()) |home| {
         return defaultLogPathForHome(alloc, home);
     }
     return fallbackLogPathForMillis(alloc, io_mod.milliTimestamp());

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -1,8 +1,22 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const darwin_process_spawn = @import("darwin_process_spawn.zig");
+const windows_file_io = @import("windows_file_io.zig");
 
 pub const RawEnviron = [*:null]const ?[*:0]const u8;
+pub const ProcessId = if (builtin.os.tag == .windows) std.os.windows.DWORD else std.posix.pid_t;
+
+pub fn processId() ProcessId {
+    if (comptime builtin.os.tag == .windows) return std.os.windows.GetCurrentProcessId();
+    return std.c.getpid();
+}
+
+pub fn tempDir() ?[]const u8 {
+    if (comptime builtin.os.tag == .windows) {
+        return getenv("TEMP") orelse getenv("TMP") orelse getenv("TMPDIR");
+    }
+    return getenv("TMPDIR") orelse getenv("TEMP") orelse getenv("TMP");
+}
 
 // Process globals are installed before threads start and remain read-only.
 var real_io: ?std.Io = null;
@@ -20,7 +34,11 @@ pub fn setIo(zio: std.Io) void {
 }
 
 fn process_io_for(comptime os_tag: std.Target.Os.Tag, zio: std.Io) std.Io {
-    return if (os_tag == .macos) darwin_process_spawn.wrap(zio) else zio;
+    return switch (os_tag) {
+        .macos => darwin_process_spawn.wrap(zio),
+        .windows => windows_file_io.wrap(zio),
+        else => zio,
+    };
 }
 
 pub fn getIo() std.Io {
@@ -387,6 +405,12 @@ pub fn getenv(key: []const u8) ?[]const u8 {
     return null;
 }
 
+/// Returns the profile home used by fx. Native Windows does not define HOME,
+/// so USERPROFILE is the equivalent profile root there.
+pub fn homeDir() ?[]const u8 {
+    return getenv("HOME") orelse getenv("USERPROFILE");
+}
+
 pub fn e2eFailIfDurableMutationAttempted() void {
     const enabled = getenv("FX_E2E_FAIL_ON_DURABLE_MUTATION") orelse return;
     if (!std.mem.eql(u8, enabled, "1")) return;
@@ -465,7 +489,7 @@ pub fn writeFileAtomic(alloc: std.mem.Allocator, path: []const u8, text: []const
     e2eFailIfDurableMutationAttempted();
     const maybe_existing_permissions = existingFilePermissions(path);
     if (maybe_existing_permissions) |existing_permissions| {
-        if (existing_permissions.toMode() & 0o222 == 0) return error.AccessDenied;
+        if (!permissionsWritable(existing_permissions)) return error.AccessDenied;
     }
     const permissions = maybe_existing_permissions orelse .default_file;
     const temp_path = try std.fmt.allocPrint(alloc, "{s}.tmp.{d}", .{ path, nanoTimestamp() });
@@ -485,8 +509,51 @@ pub fn writeFileAtomic(alloc: std.mem.Allocator, path: []const u8, text: []const
     cleanup_temp = false;
 }
 
-const private_dir_permissions = std.Io.File.Permissions.fromMode(0o700);
-const private_file_permissions = std.Io.File.Permissions.fromMode(0o600);
+pub const private_dir_permissions = permissionsFromMode(0o700);
+pub const private_file_permissions = permissionsFromMode(0o600);
+
+/// Converts a POSIX-style creation mode into the target's permission model.
+/// Windows exposes DOS attributes rather than Unix ownership bits; its profile
+/// ACL remains authoritative and the read-only attribute is preserved.
+pub fn permissionsFromMode(mode: u32) std.Io.File.Permissions {
+    if (comptime builtin.os.tag == .windows) {
+        const attributes: u32 = if (mode & 0o222 == 0) 0x0001 else 0;
+        return @enumFromInt(attributes);
+    }
+    return std.Io.File.Permissions.fromMode(@intCast(mode));
+}
+
+pub fn permissionsMode(permissions: std.Io.File.Permissions) u32 {
+    if (comptime builtin.os.tag == .windows) {
+        return if (@intFromEnum(permissions) & 0x0001 != 0) 0o444 else 0o666;
+    }
+    return @intCast(permissions.toMode());
+}
+
+pub fn permissionsWritable(permissions: std.Io.File.Permissions) bool {
+    if (comptime builtin.os.tag == .windows) return @intFromEnum(permissions) & 0x0001 == 0;
+    return !permissions.readOnly();
+}
+
+pub fn permissionsGroupOrOtherWritable(permissions: std.Io.File.Permissions) bool {
+    if (comptime builtin.os.tag == .windows) return false;
+    return permissions.toMode() & 0o022 != 0;
+}
+
+pub fn permissionsPrivateFile(permissions: std.Io.File.Permissions) bool {
+    if (comptime builtin.os.tag == .windows) return true;
+    return permissions.toMode() & 0o077 == 0;
+}
+
+pub fn permissionsPrivateDir(permissions: std.Io.File.Permissions) bool {
+    if (comptime builtin.os.tag == .windows) return true;
+    return permissions.toMode() & 0o777 == 0o700;
+}
+
+pub fn setPrivateDirPermissions(dir: std.Io.Dir) !void {
+    if (comptime builtin.os.tag == .windows) return;
+    try dir.setPermissions(getIo(), private_dir_permissions);
+}
 
 pub const VerifiedDir = struct {
     dir: std.Io.Dir,
@@ -550,19 +617,19 @@ fn validateRelativeLeaf(name: []const u8) !void {
 fn verifyPrivateRegularFile(file: std.Io.File) !void {
     const stat = try file.stat(getIo());
     if (stat.kind != .file or stat.nlink != 1) return error.DurablePathUnsafe;
-    if (stat.permissions.toMode() & 0o777 != 0o600) return error.PrivateStatePermissionsUnsupported;
+    if (!permissionsPrivateFile(stat.permissions)) return error.PrivateStatePermissionsUnsupported;
 }
 
 fn verifyPrivateDirectory(dir: std.Io.Dir) !void {
     const stat = try dir.stat(getIo());
     if (stat.kind != .directory) return error.DurablePathUnsafe;
-    if (stat.permissions.toMode() & 0o777 != 0o700) return error.PrivateStatePermissionsUnsupported;
+    if (!permissionsPrivateDir(stat.permissions)) return error.PrivateStatePermissionsUnsupported;
 }
 
 /// The handle must come from an `openDir` that requested iteration. Linux returns an
 /// `O_PATH` descriptor otherwise, and `fsync` rejects those with `EBADF`.
 pub fn syncVerifiedDir(dir: std.Io.Dir) !void {
-    if (comptime builtin.os.tag == .windows) return error.OperationUnsupported;
+    if (comptime builtin.os.tag == .windows) return;
     while (true) {
         const rc = std.c.fsync(dir.handle);
         if (rc == 0) return;
@@ -603,7 +670,7 @@ fn openOrCreateVerifiedPrivateChild(parent: std.Io.Dir, name: []const u8) !Verif
     };
     errdefer dir.close(zio);
 
-    dir.setPermissions(zio, private_dir_permissions) catch return error.PrivateStatePermissionsUnsupported;
+    setPrivateDirPermissions(dir) catch return error.PrivateStatePermissionsUnsupported;
     try verifyPrivateDirectory(dir);
     if (created) try syncVerifiedDir(parent);
     return .{ .dir = dir };
@@ -624,7 +691,7 @@ fn validateReplaceTarget(dir: std.Io.Dir, name: []const u8) !void {
         else => return err,
     };
     if (stat.kind != .file or stat.nlink != 1) return error.DurablePathUnsafe;
-    if (stat.permissions.toMode() & 0o222 == 0) return error.AccessDenied;
+    if (!permissionsWritable(stat.permissions)) return error.AccessDenied;
 }
 
 fn cleanupVerifiedTemp(dir: std.Io.Dir, name: []const u8) void {
@@ -689,7 +756,7 @@ pub fn durableReplaceVerifiedWithOps(
         return error.DurableReplacePostRenameFailed;
     };
     if (final_stat.kind != .file or final_stat.nlink != 1 or
-        final_stat.permissions.toMode() & 0o777 != 0o600)
+        !permissionsPrivateFile(final_stat.permissions))
     {
         return error.DurableReplacePostRenameFailed;
     }
@@ -822,7 +889,7 @@ pub fn copyFileAtomic(alloc: std.mem.Allocator, source_path: []const u8, dest_pa
     const stat = try source.stat(zio);
     if (stat.kind != .file) return error.NotRegularFile;
     if (existingFilePermissions(dest_path)) |existing_permissions| {
-        if (existing_permissions.toMode() & 0o222 == 0) return error.AccessDenied;
+        if (!permissionsWritable(existing_permissions)) return error.AccessDenied;
     }
 
     const temp_path = try std.fmt.allocPrint(alloc, "{s}.tmp.{d}", .{ dest_path, nanoTimestamp() });
@@ -879,6 +946,12 @@ pub fn makeDirRecursive(path: []const u8) !void {
 }
 
 pub fn realpathAlloc(alloc: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (comptime builtin.os.tag == .windows) {
+        return if (std.fs.path.isAbsolute(path))
+            std.Io.Dir.realPathFileAbsoluteAlloc(getIo(), path, alloc)
+        else
+            std.Io.Dir.cwd().realPathFileAlloc(getIo(), path, alloc);
+    }
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const path_z = try std.fmt.bufPrintZ(&buf, "{s}", .{path});
     var result_buf: [std.fs.max_path_bytes]u8 = undefined;
@@ -942,6 +1015,15 @@ pub fn dirRealpathAlloc(alloc: std.mem.Allocator, dir: std.Io.Dir, sub_path: []c
         const joined = try std.fs.path.join(alloc, &.{ dir_path, sub_path });
         defer alloc.free(joined);
         return realpathAlloc(alloc, joined);
+    } else if (comptime builtin.os.tag == .windows) {
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const path_len = dir.realPath(getIo(), &path_buf) catch
+            return error.FileNotFound;
+        const dir_path = path_buf[0..path_len];
+        if (sub_path.len == 0) return alloc.dupe(u8, dir_path);
+        const joined = try std.fs.path.join(alloc, &.{ dir_path, sub_path });
+        defer alloc.free(joined);
+        return realpathAlloc(alloc, joined);
     } else if (comptime builtin.os.tag == .wasi) {
         if (std.fs.path.isAbsolute(sub_path)) return alloc.dupe(u8, sub_path);
         return std.fs.path.resolve(alloc, &.{sub_path});
@@ -982,6 +1064,26 @@ test "getenv returns set value after setEnvironMap" {
     setEnvironMap(&environ);
     try std.testing.expectEqualStrings("present", getenv("FX_IO_TEST").?);
     global_environ = null;
+}
+
+test "homeDir falls back to USERPROFILE when HOME is absent" {
+    const previous_environ = global_environ;
+    const previous_block = global_environ_block;
+    const previous_raw = global_raw_environ;
+    defer {
+        global_environ = previous_environ;
+        global_environ_block = previous_block;
+        global_raw_environ = previous_raw;
+    }
+
+    var environ = std.process.Environ.Map.init(std.testing.allocator);
+    defer environ.deinit();
+    try environ.put("USERPROFILE", "C:\\Users\\fx-test");
+    setEnvironMap(&environ);
+    try std.testing.expectEqualStrings("C:\\Users\\fx-test", homeDir().?);
+
+    try environ.put("HOME", "C:\\Users\\preferred");
+    try std.testing.expectEqualStrings("C:\\Users\\preferred", homeDir().?);
 }
 
 test "environMap returns borrowed process environment map" {

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -412,7 +412,10 @@ pub fn getenv(key: []const u8) ?[]const u8 {
 /// Returns the profile home used by fx. Native Windows does not define HOME,
 /// so USERPROFILE is the equivalent profile root there.
 pub fn homeDir() ?[]const u8 {
-    return getenv("HOME") orelse getenv("USERPROFILE");
+    if (comptime builtin.os.tag == .windows) {
+        return getenv("HOME") orelse getenv("USERPROFILE");
+    }
+    return getenv("HOME");
 }
 
 pub fn e2eFailIfDurableMutationAttempted() void {
@@ -1070,7 +1073,7 @@ test "getenv returns set value after setEnvironMap" {
     global_environ = null;
 }
 
-test "homeDir falls back to USERPROFILE when HOME is absent" {
+test "homeDir uses USERPROFILE only on Windows" {
     const previous_environ = global_environ;
     const previous_block = global_environ_block;
     const previous_raw = global_raw_environ;
@@ -1084,7 +1087,11 @@ test "homeDir falls back to USERPROFILE when HOME is absent" {
     defer environ.deinit();
     try environ.put("USERPROFILE", "C:\\Users\\fx-test");
     setEnvironMap(&environ);
-    try std.testing.expectEqualStrings("C:\\Users\\fx-test", homeDir().?);
+    if (comptime builtin.os.tag == .windows) {
+        try std.testing.expectEqualStrings("C:\\Users\\fx-test", homeDir().?);
+    } else {
+        try std.testing.expect(homeDir() == null);
+    }
 
     try environ.put("HOME", "C:\\Users\\preferred");
     try std.testing.expectEqualStrings("C:\\Users\\preferred", homeDir().?);

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -11,11 +11,15 @@ pub fn processId() ProcessId {
     return std.c.getpid();
 }
 
-pub fn tempDir() ?[]const u8 {
+pub fn tempDir() []const u8 {
     if (comptime builtin.os.tag == .windows) {
-        return getenv("TEMP") orelse getenv("TMP") orelse getenv("TMPDIR");
+        return getenv("TEMP") orelse
+            getenv("TMP") orelse
+            getenv("TMPDIR") orelse
+            homeDir() orelse
+            "C:\\Windows\\Temp";
     }
-    return getenv("TMPDIR") orelse getenv("TEMP") orelse getenv("TMP");
+    return getenv("TMPDIR") orelse getenv("TEMP") orelse getenv("TMP") orelse "/tmp";
 }
 
 // Process globals are installed before threads start and remain read-only.

--- a/src/core/shared/windows_console.zig
+++ b/src/core/shared/windows_console.zig
@@ -1,0 +1,191 @@
+const std = @import("std");
+
+const windows = std.os.windows;
+
+const enable_processed_input: windows.DWORD = 0x0001;
+const enable_line_input: windows.DWORD = 0x0002;
+const enable_echo_input: windows.DWORD = 0x0004;
+const enable_window_input: windows.DWORD = 0x0008;
+const enable_quick_edit_mode: windows.DWORD = 0x0040;
+const enable_extended_flags: windows.DWORD = 0x0080;
+const enable_virtual_terminal_input: windows.DWORD = 0x0200;
+const enable_virtual_terminal_processing: windows.DWORD = 0x0004;
+
+const wait_object_0: windows.DWORD = 0;
+const wait_timeout: windows.DWORD = 258;
+const wait_failed: windows.DWORD = 0xffffffff;
+
+const Coord = extern struct {
+    x: i16,
+    y: i16,
+};
+
+const SmallRect = extern struct {
+    left: i16,
+    top: i16,
+    right: i16,
+    bottom: i16,
+};
+
+const ConsoleScreenBufferInfo = extern struct {
+    size: Coord,
+    cursor_position: Coord,
+    attributes: u16,
+    window: SmallRect,
+    maximum_window_size: Coord,
+};
+
+pub const Mode = struct {
+    input: windows.DWORD,
+    output: windows.DWORD,
+};
+
+pub const Size = struct {
+    rows: u16,
+    cols: u16,
+};
+
+pub const WaitResult = enum {
+    ready,
+    timeout,
+};
+
+const ControlHandler = ?*const fn (windows.DWORD) callconv(.winapi) windows.BOOL;
+var saved_input: ?windows.HANDLE = null;
+var saved_output: ?windows.HANDLE = null;
+var saved_mode: ?Mode = null;
+var control_handler_installed = false;
+
+extern "kernel32" fn GetConsoleMode(
+    handle: windows.HANDLE,
+    mode: *windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+
+extern "kernel32" fn SetConsoleMode(
+    handle: windows.HANDLE,
+    mode: windows.DWORD,
+) callconv(.winapi) windows.BOOL;
+
+extern "kernel32" fn GetConsoleScreenBufferInfo(
+    handle: windows.HANDLE,
+    info: *ConsoleScreenBufferInfo,
+) callconv(.winapi) windows.BOOL;
+
+extern "kernel32" fn WaitForSingleObject(
+    handle: windows.HANDLE,
+    milliseconds: windows.DWORD,
+) callconv(.winapi) windows.DWORD;
+
+extern "kernel32" fn SetConsoleCtrlHandler(
+    handler: ControlHandler,
+    add: windows.BOOL,
+) callconv(.winapi) windows.BOOL;
+
+fn restoreForControlEvent(_: windows.DWORD) callconv(.winapi) windows.BOOL {
+    if (saved_mode) |mode| {
+        if (saved_input) |input| _ = SetConsoleMode(input, mode.input);
+        if (saved_output) |output| _ = SetConsoleMode(output, mode.output);
+    }
+    return .FALSE;
+}
+
+pub fn isConsole(handle: windows.HANDLE) bool {
+    var mode: windows.DWORD = 0;
+    return GetConsoleMode(handle, &mode).toBool();
+}
+
+pub fn captureMode(input: windows.HANDLE, output: windows.HANDLE) !Mode {
+    var input_mode: windows.DWORD = 0;
+    var output_mode: windows.DWORD = 0;
+    if (!GetConsoleMode(input, &input_mode).toBool() or
+        !GetConsoleMode(output, &output_mode).toBool())
+    {
+        return error.NotATerminal;
+    }
+    return .{ .input = input_mode, .output = output_mode };
+}
+
+pub fn rawInputMode(original: windows.DWORD) windows.DWORD {
+    return (original |
+        enable_window_input |
+        enable_extended_flags |
+        enable_virtual_terminal_input) &
+        ~(enable_processed_input |
+            enable_line_input |
+            enable_echo_input |
+            enable_quick_edit_mode);
+}
+
+pub fn enableRawMode(input: windows.HANDLE, output: windows.HANDLE, original: Mode) !void {
+    const input_mode = rawInputMode(original.input);
+    if (!SetConsoleMode(input, input_mode).toBool()) return error.ConsoleModeUnavailable;
+    errdefer _ = SetConsoleMode(input, original.input);
+
+    const output_mode = original.output | enable_virtual_terminal_processing;
+    if (!SetConsoleMode(output, output_mode).toBool()) return error.ConsoleModeUnavailable;
+    saved_input = input;
+    saved_output = output;
+    saved_mode = original;
+    if (!SetConsoleCtrlHandler(restoreForControlEvent, .TRUE).toBool()) {
+        saved_input = null;
+        saved_output = null;
+        saved_mode = null;
+        return error.ConsoleModeUnavailable;
+    }
+    control_handler_installed = true;
+}
+
+pub fn restoreMode(input: windows.HANDLE, output: windows.HANDLE, original: Mode) void {
+    if (control_handler_installed) {
+        _ = SetConsoleCtrlHandler(restoreForControlEvent, .FALSE);
+        control_handler_installed = false;
+    }
+    saved_input = null;
+    saved_output = null;
+    saved_mode = null;
+    _ = SetConsoleMode(input, original.input);
+    _ = SetConsoleMode(output, original.output);
+}
+
+pub fn querySize(output: windows.HANDLE) !Size {
+    var info: ConsoleScreenBufferInfo = undefined;
+    if (!GetConsoleScreenBufferInfo(output, &info).toBool()) {
+        return error.UnableToReadTerminalSize;
+    }
+    const cols = @as(i32, info.window.right) - @as(i32, info.window.left) + 1;
+    const rows = @as(i32, info.window.bottom) - @as(i32, info.window.top) + 1;
+    if (cols <= 0 or rows <= 0 or
+        cols > std.math.maxInt(u16) or rows > std.math.maxInt(u16))
+    {
+        return error.UnableToReadTerminalSize;
+    }
+    return .{ .rows = @intCast(rows), .cols = @intCast(cols) };
+}
+
+pub fn waitForInput(input: windows.HANDLE, timeout_ms: i32) !WaitResult {
+    const timeout: windows.DWORD = if (timeout_ms < 0)
+        std.math.maxInt(windows.DWORD)
+    else
+        @intCast(timeout_ms);
+    return switch (WaitForSingleObject(input, timeout)) {
+        wait_object_0 => .ready,
+        wait_timeout => .timeout,
+        wait_failed => error.ConsoleWaitFailed,
+        else => error.ConsoleWaitFailed,
+    };
+}
+
+test "raw input mode enables VT events and disables cooked input" {
+    const original = enable_processed_input |
+        enable_line_input |
+        enable_echo_input |
+        enable_quick_edit_mode;
+    const mode = rawInputMode(original);
+    try std.testing.expect(mode & enable_window_input != 0);
+    try std.testing.expect(mode & enable_extended_flags != 0);
+    try std.testing.expect(mode & enable_virtual_terminal_input != 0);
+    try std.testing.expect(mode & enable_processed_input == 0);
+    try std.testing.expect(mode & enable_line_input == 0);
+    try std.testing.expect(mode & enable_echo_input == 0);
+    try std.testing.expect(mode & enable_quick_edit_mode == 0);
+}

--- a/src/core/shared/windows_console.zig
+++ b/src/core/shared/windows_console.zig
@@ -14,6 +14,7 @@ const enable_virtual_terminal_processing: windows.DWORD = 0x0004;
 const wait_object_0: windows.DWORD = 0;
 const wait_timeout: windows.DWORD = 258;
 const wait_failed: windows.DWORD = 0xffffffff;
+const utf8_code_page: windows.DWORD = 65001;
 
 const Coord = extern struct {
     x: i16,
@@ -38,6 +39,8 @@ const ConsoleScreenBufferInfo = extern struct {
 pub const Mode = struct {
     input: windows.DWORD,
     output: windows.DWORD,
+    input_code_page: windows.DWORD,
+    output_code_page: windows.DWORD,
 };
 
 pub const Size = struct {
@@ -66,6 +69,11 @@ extern "kernel32" fn SetConsoleMode(
     mode: windows.DWORD,
 ) callconv(.winapi) windows.BOOL;
 
+extern "kernel32" fn GetConsoleCP() callconv(.winapi) windows.DWORD;
+extern "kernel32" fn SetConsoleCP(code_page: windows.DWORD) callconv(.winapi) windows.BOOL;
+extern "kernel32" fn GetConsoleOutputCP() callconv(.winapi) windows.DWORD;
+extern "kernel32" fn SetConsoleOutputCP(code_page: windows.DWORD) callconv(.winapi) windows.BOOL;
+
 extern "kernel32" fn GetConsoleScreenBufferInfo(
     handle: windows.HANDLE,
     info: *ConsoleScreenBufferInfo,
@@ -85,6 +93,8 @@ fn restoreForControlEvent(_: windows.DWORD) callconv(.winapi) windows.BOOL {
     if (saved_mode) |mode| {
         if (saved_input) |input| _ = SetConsoleMode(input, mode.input);
         if (saved_output) |output| _ = SetConsoleMode(output, mode.output);
+        _ = SetConsoleCP(mode.input_code_page);
+        _ = SetConsoleOutputCP(mode.output_code_page);
     }
     return .FALSE;
 }
@@ -102,7 +112,17 @@ pub fn captureMode(input: windows.HANDLE, output: windows.HANDLE) !Mode {
     {
         return error.NotATerminal;
     }
-    return .{ .input = input_mode, .output = output_mode };
+    const input_code_page = GetConsoleCP();
+    const output_code_page = GetConsoleOutputCP();
+    if (input_code_page == 0 or output_code_page == 0) {
+        return error.ConsoleModeUnavailable;
+    }
+    return .{
+        .input = input_mode,
+        .output = output_mode,
+        .input_code_page = input_code_page,
+        .output_code_page = output_code_page,
+    };
 }
 
 pub fn rawInputMode(original: windows.DWORD) windows.DWORD {
@@ -117,9 +137,19 @@ pub fn rawInputMode(original: windows.DWORD) windows.DWORD {
 }
 
 pub fn enableRawMode(input: windows.HANDLE, output: windows.HANDLE, original: Mode) !void {
+    errdefer {
+        _ = SetConsoleMode(input, original.input);
+        _ = SetConsoleMode(output, original.output);
+        _ = SetConsoleCP(original.input_code_page);
+        _ = SetConsoleOutputCP(original.output_code_page);
+    }
+    if (!SetConsoleCP(utf8_code_page).toBool() or
+        !SetConsoleOutputCP(utf8_code_page).toBool())
+    {
+        return error.ConsoleModeUnavailable;
+    }
     const input_mode = rawInputMode(original.input);
     if (!SetConsoleMode(input, input_mode).toBool()) return error.ConsoleModeUnavailable;
-    errdefer _ = SetConsoleMode(input, original.input);
 
     const output_mode = original.output | enable_virtual_terminal_processing;
     if (!SetConsoleMode(output, output_mode).toBool()) return error.ConsoleModeUnavailable;
@@ -145,6 +175,8 @@ pub fn restoreMode(input: windows.HANDLE, output: windows.HANDLE, original: Mode
     saved_mode = null;
     _ = SetConsoleMode(input, original.input);
     _ = SetConsoleMode(output, original.output);
+    _ = SetConsoleCP(original.input_code_page);
+    _ = SetConsoleOutputCP(original.output_code_page);
 }
 
 pub fn querySize(output: windows.HANDLE) !Size {

--- a/src/core/shared/windows_file_io.zig
+++ b/src/core/shared/windows_file_io.zig
@@ -1,0 +1,56 @@
+const std = @import("std");
+
+var wrapped_vtable: std.Io.VTable = undefined;
+var wrapped_original_vtable: ?*const std.Io.VTable = null;
+
+pub fn wrap(original: std.Io) std.Io {
+    if (wrapped_original_vtable) |original_vtable| {
+        std.debug.assert(original_vtable == original.vtable);
+    } else {
+        wrapped_vtable = original.vtable.*;
+        wrapped_vtable.dirOpenFile = dirOpenFile;
+        wrapped_original_vtable = original.vtable;
+    }
+    return .{
+        .userdata = original.userdata,
+        .vtable = &wrapped_vtable,
+    };
+}
+
+fn dirOpenFile(
+    userdata: ?*anyopaque,
+    dir: std.Io.Dir,
+    sub_path: []const u8,
+    options: std.Io.Dir.OpenFileOptions,
+) std.Io.File.OpenError!std.Io.File {
+    var file = try wrapped_original_vtable.?.dirOpenFile(
+        userdata,
+        dir,
+        sub_path,
+        options,
+    );
+    // Zig 0.16 opens no-follow Windows files asynchronously but reports the
+    // handle as blocking. Positional reads then treat a normal PENDING result
+    // as an invariant failure. Keep the handle metadata aligned with NtCreateFile.
+    file.flags.nonblocking = !options.follow_symlinks;
+    return file;
+}
+
+test "no-follow Windows files report asynchronous handles" {
+    if (comptime @import("builtin").os.tag != .windows) return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    {
+        var created = try tmp.dir.createFile(std.testing.io, "value", .{});
+        defer created.close(std.testing.io);
+        try created.writeStreamingAll(std.testing.io, "ok");
+    }
+
+    const wrapped = wrap(std.testing.io);
+    var file = try tmp.dir.openFile(wrapped, "value", .{ .follow_symlinks = false });
+    defer file.close(wrapped);
+    try std.testing.expect(file.flags.nonblocking);
+    var bytes: [2]u8 = undefined;
+    try std.testing.expectEqual(@as(usize, 2), try file.readPositionalAll(wrapped, &bytes, 0));
+    try std.testing.expectEqualStrings("ok", &bytes);
+}

--- a/src/core/shared/windows_process.zig
+++ b/src/core/shared/windows_process.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const windows = std.os.windows;
+const process_query_limited_information: windows.DWORD = 0x1000;
+
+extern "kernel32" fn GetProcessId(
+    process: windows.HANDLE,
+) callconv(.winapi) windows.DWORD;
+
+extern "kernel32" fn OpenProcess(
+    desired_access: windows.DWORD,
+    inherit_handle: windows.BOOL,
+    process_id: windows.DWORD,
+) callconv(.winapi) ?windows.HANDLE;
+
+extern "kernel32" fn GetProcessTimes(
+    process: windows.HANDLE,
+    creation_time: *windows.FILETIME,
+    exit_time: *windows.FILETIME,
+    kernel_time: *windows.FILETIME,
+    user_time: *windows.FILETIME,
+) callconv(.winapi) windows.BOOL;
+
+pub fn idFromHandle(process: windows.HANDLE) !windows.DWORD {
+    const id = GetProcessId(process);
+    if (id == 0) return error.ProcessNotFound;
+    return id;
+}
+
+pub fn creationTime(process_id: windows.DWORD) !u64 {
+    const process = OpenProcess(
+        process_query_limited_information,
+        .FALSE,
+        process_id,
+    ) orelse return error.ProcessNotFound;
+    defer windows.CloseHandle(process);
+
+    var creation: windows.FILETIME = undefined;
+    var exit: windows.FILETIME = undefined;
+    var kernel: windows.FILETIME = undefined;
+    var user: windows.FILETIME = undefined;
+    if (!GetProcessTimes(process, &creation, &exit, &kernel, &user).toBool()) {
+        return error.ProcessIdentityUnavailable;
+    }
+    return (@as(u64, creation.dwHighDateTime) << 32) | creation.dwLowDateTime;
+}
+
+test "current Windows process has a stable creation time" {
+    if (comptime builtin.os.tag != .windows) return error.SkipZigTest;
+    const created = try creationTime(windows.GetCurrentProcessId());
+    try std.testing.expect(created > 0);
+}

--- a/src/core/shared/windows_socket.zig
+++ b/src/core/shared/windows_socket.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+
+const windows = std.os.windows;
+
+pub const poll_read: i16 = 0x0100 | 0x0200;
+pub const poll_write: i16 = 0x0010;
+pub const poll_error: i16 = 0x0001;
+pub const poll_hangup: i16 = 0x0002;
+pub const poll_invalid: i16 = 0x0004;
+
+const socket_error = -1;
+const sol_socket: c_int = 0xffff;
+const so_send_timeout: c_int = 0x1005;
+const so_receive_timeout: c_int = 0x1006;
+
+pub const PollFd = extern struct {
+    fd: windows.HANDLE,
+    events: i16,
+    revents: i16,
+};
+
+extern "ws2_32" fn WSAPoll(
+    fds: [*]PollFd,
+    count: windows.ULONG,
+    timeout_ms: c_int,
+) callconv(.winapi) c_int;
+
+extern "ws2_32" fn setsockopt(
+    socket: windows.HANDLE,
+    level: c_int,
+    option_name: c_int,
+    option_value: *const anyopaque,
+    option_length: c_int,
+) callconv(.winapi) c_int;
+
+pub const PollResult = struct {
+    ready: bool = false,
+    hung_up: bool = false,
+    has_error: bool = false,
+    invalid: bool = false,
+};
+
+pub fn poll(socket: windows.HANDLE, events: i16, timeout_ms: i32) !PollResult {
+    var fds = [_]PollFd{.{ .fd = socket, .events = events, .revents = 0 }};
+    const ready = WSAPoll(&fds, 1, timeout_ms);
+    if (ready == socket_error) return error.SocketPollFailed;
+    if (ready == 0) return .{};
+    const revents = fds[0].revents;
+    return .{
+        .ready = revents & events != 0,
+        .hung_up = revents & poll_hangup != 0,
+        .has_error = revents & poll_error != 0,
+        .invalid = revents & poll_invalid != 0,
+    };
+}
+
+pub fn setTimeouts(socket: windows.HANDLE, timeout_ms: u32) !void {
+    if (setsockopt(socket, sol_socket, so_receive_timeout, &timeout_ms, @sizeOf(u32)) == socket_error or
+        setsockopt(socket, sol_socket, so_send_timeout, &timeout_ms, @sizeOf(u32)) == socket_error)
+    {
+        return error.SocketOptionFailed;
+    }
+}

--- a/src/core/shared/windows_socket.zig
+++ b/src/core/shared/windows_socket.zig
@@ -40,6 +40,64 @@ pub const PollResult = struct {
     invalid: bool = false,
 };
 
+const AcceptEvent = union(enum) {
+    connection: anyerror!std.Io.net.Stream,
+    timeout: anyerror!void,
+};
+
+fn acceptConnection(
+    io: std.Io,
+    server: *std.Io.net.Server,
+) anyerror!std.Io.net.Stream {
+    return server.accept(io);
+}
+
+fn waitAcceptTimeout(io: std.Io, timeout_ms: u32) anyerror!void {
+    try io.sleep(.fromMilliseconds(timeout_ms), .awake);
+}
+
+fn cancelAccept(io: std.Io, select: *std.Io.Select(AcceptEvent)) void {
+    while (select.cancel()) |event| switch (event) {
+        .connection => |result| {
+            const stream = result catch continue;
+            stream.close(io);
+        },
+        .timeout => {},
+    };
+}
+
+pub fn acceptWithTimeout(
+    io: std.Io,
+    server: *std.Io.net.Server,
+    timeout_ms: u32,
+) !?std.Io.net.Stream {
+    var buffer: [2]AcceptEvent = undefined;
+    var select: std.Io.Select(AcceptEvent) = .init(io, &buffer);
+    try select.concurrent(.connection, acceptConnection, .{ io, server });
+    select.concurrent(.timeout, waitAcceptTimeout, .{ io, timeout_ms }) catch |err| {
+        cancelAccept(io, &select);
+        return err;
+    };
+    const event = select.await() catch |err| {
+        cancelAccept(io, &select);
+        return err;
+    };
+    return switch (event) {
+        .connection => |result| blk: {
+            select.cancelDiscard();
+            break :blk try result;
+        },
+        .timeout => |result| blk: {
+            result catch |err| {
+                cancelAccept(io, &select);
+                return err;
+            };
+            cancelAccept(io, &select);
+            break :blk null;
+        },
+    };
+}
+
 pub fn poll(socket: windows.HANDLE, events: i16, timeout_ms: i32) !PollResult {
     var fds = [_]PollFd{.{ .fd = socket, .events = events, .revents = 0 }};
     const ready = WSAPoll(&fds, 1, timeout_ms);
@@ -60,4 +118,40 @@ pub fn setTimeouts(socket: windows.HANDLE, timeout_ms: u32) !void {
     {
         return error.SocketOptionFailed;
     }
+}
+
+test "Windows AFD listener accepts with a bounded timeout" {
+    if (comptime @import("builtin").os.tag != .windows) return error.SkipZigTest;
+    const io = std.testing.io;
+    var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var server = try address.listen(io, .{ .reuse_address = true });
+    defer server.deinit(io);
+
+    try std.testing.expect((try acceptWithTimeout(io, &server, 10)) == null);
+
+    const ConnectState = struct {
+        io: std.Io,
+        address: std.Io.net.IpAddress,
+        failed: std.atomic.Value(bool) = .init(false),
+
+        fn run(self: *@This()) void {
+            self.io.sleep(.fromMilliseconds(20), .awake) catch {
+                self.failed.store(true, .release);
+                return;
+            };
+            var stream = self.address.connect(self.io, .{ .mode = .stream }) catch {
+                self.failed.store(true, .release);
+                return;
+            };
+            stream.close(self.io);
+        }
+    };
+    var state = ConnectState{ .io = io, .address = server.socket.address };
+    const connector = try std.Thread.spawn(.{}, ConnectState.run, .{&state});
+    defer connector.join();
+
+    var accepted = (try acceptWithTimeout(io, &server, 1000)) orelse
+        return error.TestExpectedConnection;
+    accepted.close(io);
+    try std.testing.expect(!state.failed.load(.acquire));
 }

--- a/src/core/skills/skill_invocation.zig
+++ b/src/core/skills/skill_invocation.zig
@@ -695,7 +695,7 @@ pub fn freeExecuteResult(alloc: Allocator, result: ExecuteResult) void {
 }
 
 fn loadVisibleSkillsForContext(alloc: Allocator, workspace_root: []const u8, skills_dir: []const u8) !skill_runtime.SkillDiscovery {
-    if (io_mod.getenv("HOME") orelse homeFromSkillsDir(skills_dir)) |home| {
+    if (io_mod.homeDir() orelse homeFromSkillsDir(skills_dir)) |home| {
         return skill_runtime.loadVisibleSkills(alloc, workspace_root, home, skills_dir, test_root_policy);
     }
     return skill_runtime.loadVisibleSkills(alloc, workspace_root, null, skills_dir, test_root_policy);

--- a/src/core/terminal/client.zig
+++ b/src/core/terminal/client.zig
@@ -765,7 +765,7 @@ fn connectAndHandshakeOnce(
     process_provider: background_process_provider.Provider,
 ) !Connected {
     if (!host.isSupported()) return error.TerminalHostUnsupported;
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var paths = try host.Paths.open(alloc, home);
     defer paths.deinit(alloc);
 

--- a/src/core/terminal/host.zig
+++ b/src/core/terminal/host.zig
@@ -198,7 +198,7 @@ pub const Paths = struct {
     endpoint_path: []u8,
 
     pub fn open(alloc: Allocator, home: []const u8) !Paths {
-        if (!isSupported()) return error.TerminalHostUnsupported;
+        if (comptime !isSupported()) return error.TerminalHostUnsupported;
         var selection = try resolveEndpointSelection(
             alloc,
             builtin.os.tag,
@@ -290,7 +290,7 @@ fn openVerifiedPrivateRuntimeDir(
             parent.createDir(
                 zio,
                 name,
-                std.Io.File.Permissions.fromMode(0o700),
+                io_mod.private_dir_permissions,
             ) catch |create_err| switch (create_err) {
                 error.PathAlreadyExists => {},
                 else => return create_err,
@@ -362,7 +362,7 @@ fn validatePrivateRuntimeDir(
 ) !void {
     if (stat.kind != .directory) return error.RuntimeDirectoryUnsafe;
     if (owner_uid != uid) return error.RuntimeDirectoryOwnerMismatch;
-    if (stat.permissions.toMode() & 0o777 != 0o700) {
+    if (!io_mod.permissionsPrivateDir(stat.permissions)) {
         return error.PrivateStatePermissionsUnsupported;
     }
 }
@@ -381,7 +381,7 @@ pub fn run(alloc: Allocator, config: Config) !void {
 }
 
 fn runSupported(alloc: Allocator, config: Config) !void {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var paths = try Paths.open(alloc, home);
     defer paths.deinit(alloc);
 

--- a/src/core/terminal/store.zig
+++ b/src/core/terminal/store.zig
@@ -460,7 +460,7 @@ pub const Record = struct {
             return error.InvalidTerminalRecord;
         }
         if (self.takeover_owner_pid) |pid| {
-            _ = std.fmt.parseInt(std.posix.pid_t, pid, 10) catch
+            _ = std.fmt.parseInt(io_mod.ProcessId, pid, 10) catch
                 return error.InvalidTerminalRecord;
             _ = process_supervisor.ProcessInstanceToken.parse(
                 self.takeover_owner_process_token.?,

--- a/src/core/tooling/file_mutation.zig
+++ b/src/core/tooling/file_mutation.zig
@@ -1001,9 +1001,9 @@ fn validatePreimage(
             const expected_identity = prepared.policy_targets.items[0].expected_identity orelse
                 break :blk .stale;
             if (!identityEql(actual_identity, expected_identity)) break :blk .stale;
-            if (stat.permissions.toMode() & 0o222 == 0) break :blk .io_failure;
+            if (!io_mod.permissionsWritable(stat.permissions)) break :blk .io_failure;
             if (expected_permissions) |permissions| {
-                if (stat.permissions.toMode() != permissions.toMode()) break :blk .stale;
+                if (io_mod.permissionsMode(stat.permissions) != io_mod.permissionsMode(permissions)) break :blk .stale;
             }
 
             var hasher = std.crypto.hash.sha2.Sha256.init(.{});

--- a/src/core/upgrade/upgrade_helpers.zig
+++ b/src/core/upgrade/upgrade_helpers.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const io_mod = @import("../shared/io.zig");
+const windows_socket = @import("../shared/windows_socket.zig");
 const update_target = @import("update_target.zig");
 
 const Allocator = std.mem.Allocator;
@@ -13,9 +14,13 @@ const Channel = update_target.Channel;
 const Target = update_target.Target;
 
 fn setRecvTimeout(conn: *std.http.Client.Connection) void {
-    const sock = conn.stream_writer.stream.socket.handle;
-    const timeout = std.posix.timeval{ .sec = recv_timeout_sec, .usec = 0 };
-    std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
+    const socket = conn.stream_writer.stream.socket.handle;
+    if (comptime builtin.os.tag == .windows) {
+        windows_socket.setTimeouts(socket, recv_timeout_sec * std.time.ms_per_s) catch {};
+        return;
+    }
+    const timeout = std.posix.timeval{ .sec = @intCast(recv_timeout_sec), .usec = 0 };
+    std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
 }
 
 pub const cdn_base = "https://releases.fx.sh";
@@ -47,10 +52,11 @@ fn isLoopbackE2eUpgradeBase(url: []const u8) bool {
 }
 
 pub const platform = platformFromTarget() orelse
-    @compileError("unsupported platform for auto-upgrade (requires macOS or Linux, x86_64 or aarch64)");
+    @compileError("unsupported platform for upgrade (requires Windows, macOS, or Linux on x86_64 or aarch64)");
 
 fn platformFromTarget() ?[]const u8 {
     const os: ?[]const u8 = switch (builtin.os.tag) {
+        .windows => "windows",
         .macos => "macos",
         .linux => "linux",
         else => null,
@@ -256,10 +262,48 @@ pub fn extractTarGz(alloc: Allocator, archive_path: []const u8, dest_dir: []cons
 }
 
 pub fn replaceBinary(new_path: []const u8, target_path: []const u8) !void {
+    if (comptime builtin.os.tag == .windows) {
+        return scheduleWindowsBinaryReplacement(new_path, target_path);
+    }
     std.Io.Dir.renameAbsolute(new_path, target_path, io_mod.getIo()) catch {
         copyBinary(new_path, target_path) catch return error.ReplaceFailed;
         return;
     };
+}
+
+fn scheduleWindowsBinaryReplacement(new_path: []const u8, target_path: []const u8) !void {
+    const alloc = std.heap.c_allocator;
+    const staged_path = std.fmt.allocPrint(
+        alloc,
+        "{s}.update.{d}.exe",
+        .{ target_path, io_mod.processId() },
+    ) catch return error.ReplaceFailed;
+    defer alloc.free(staged_path);
+    copyBinary(new_path, staged_path) catch return error.ReplaceFailed;
+    errdefer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), staged_path) catch {};
+
+    const pid_text = std.fmt.allocPrint(alloc, "{d}", .{io_mod.processId()}) catch
+        return error.ReplaceFailed;
+    defer alloc.free(pid_text);
+    const script =
+        "Wait-Process -Id ([int]$args[0]) -ErrorAction SilentlyContinue; " ++
+        "Copy-Item -LiteralPath $args[1] -Destination $args[2] -Force; " ++
+        "Remove-Item -LiteralPath $args[1] -Force";
+    _ = std.process.spawn(io_mod.getIo(), .{
+        .argv = &.{
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            script,
+            pid_text,
+            staged_path,
+            target_path,
+        },
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    }) catch return error.ReplaceFailed;
 }
 
 pub const ExecutablePathError = error{

--- a/src/core/upgrade/upgrade_runtime.zig
+++ b/src/core/upgrade/upgrade_runtime.zig
@@ -189,7 +189,7 @@ fn upgradeWorkerInner(
     progress.markUpdateFound();
     if (show_progress) io_mod.sleep(found_hold_ns);
 
-    const tmp_base: []const u8 = io_mod.getenv("TMPDIR") orelse "/tmp";
+    const tmp_base: []const u8 = io_mod.tempDir() orelse ".";
     var rand_buf: [8]u8 = undefined;
     io_mod.getIo().random(&rand_buf);
     const rand_hex = std.fmt.bytesToHex(rand_buf, .lower);
@@ -237,7 +237,8 @@ fn upgradeWorkerInner(
         return;
     };
 
-    const extracted_bin = try std.fmt.allocPrint(alloc, "{s}/fx", .{tmp_dir});
+    const extracted_name = if (@import("builtin").os.tag == .windows) "fx.exe" else "fx";
+    const extracted_bin = try std.fmt.allocPrint(alloc, "{s}/{s}", .{ tmp_dir, extracted_name });
     defer alloc.free(extracted_bin);
 
     var self_exe_buf: [std.fs.max_path_bytes]u8 = undefined;

--- a/src/core/upgrade/upgrade_runtime.zig
+++ b/src/core/upgrade/upgrade_runtime.zig
@@ -189,7 +189,7 @@ fn upgradeWorkerInner(
     progress.markUpdateFound();
     if (show_progress) io_mod.sleep(found_hold_ns);
 
-    const tmp_base: []const u8 = io_mod.tempDir() orelse ".";
+    const tmp_base: []const u8 = io_mod.tempDir();
     var rand_buf: [8]u8 = undefined;
     io_mod.getIo().random(&rand_buf);
     const rand_hex = std.fmt.bytesToHex(rand_buf, .lower);

--- a/src/core/workspace/pathing.zig
+++ b/src/core/workspace/pathing.zig
@@ -218,7 +218,7 @@ pub fn resolveWorkspaceOrExternalPath(
         arena,
         workspace_root,
         input_path,
-        io_mod.getenv("HOME"),
+        io_mod.homeDir(),
         .existing,
     );
 }
@@ -232,7 +232,7 @@ pub fn resolveWorkspaceOrExternalCreatePath(
         arena,
         workspace_root,
         input_path,
-        io_mod.getenv("HOME"),
+        io_mod.homeDir(),
         .create,
     );
 }
@@ -366,7 +366,7 @@ fn resolveBoundedFileTargetInput(
             .external_intent = true,
         },
         .home_relative => |relative| blk: {
-            const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+            const home = io_mod.homeDir() orelse return error.HomeNotSet;
             if (home.len == 0 or !std.fs.path.isAbsolute(home)) return error.InvalidPath;
             break :blk .{
                 .absolute = try normalizeBaseRelativePathInto(scratch, home, relative),

--- a/src/core/workspace/record_tape.zig
+++ b/src/core/workspace/record_tape.zig
@@ -106,7 +106,7 @@ fn configureAutomatic(
     initial_rows: u16,
     fx_version: []const u8,
 ) !void {
-    const home = if (io_mod.getenv("HOME")) |value| blk: {
+    const home = if (io_mod.homeDir()) |value| blk: {
         const trimmed = std.mem.trim(u8, value, " \t\r\n");
         break :blk if (trimmed.len > 0) trimmed else null;
     } else null;
@@ -181,7 +181,7 @@ fn openTape(path: []const u8, exclusive: bool, private: bool) !std.Io.File {
             return std.Io.Dir.createFileAbsolute(zio, path, .{
                 .truncate = !exclusive,
                 .exclusive = exclusive,
-                .permissions = .fromMode(0o600),
+                .permissions = io_mod.private_file_permissions,
             });
         }
         return std.Io.Dir.createFileAbsolute(zio, path, .{ .truncate = !exclusive, .exclusive = exclusive });
@@ -190,7 +190,7 @@ fn openTape(path: []const u8, exclusive: bool, private: bool) !std.Io.File {
         return std.Io.Dir.cwd().createFile(zio, path, .{
             .truncate = !exclusive,
             .exclusive = exclusive,
-            .permissions = .fromMode(0o600),
+            .permissions = io_mod.private_file_permissions,
         });
     }
     return std.Io.Dir.cwd().createFile(zio, path, .{ .truncate = !exclusive, .exclusive = exclusive });

--- a/src/main.zig
+++ b/src/main.zig
@@ -590,6 +590,7 @@ const App = struct {
             else
                 background_process.provider),
         };
+        app.shell.stdout_file = std.Io.File.stdout();
         if (comptime host_profile.js_host_workspace) {
             app.workspace_host = js_host_workspace.Runtime.init(alloc) catch |err| blk: {
                 if (err != error.WorkspaceUnavailable) {
@@ -747,6 +748,7 @@ const App = struct {
     /// Must be called after init() returns so the AutoUpgrade thread
     /// captures a pointer to the final App location (not a temporary).
     pub fn startAutoUpgrade(self: *App) void {
+        if (comptime builtin.os.tag == .windows) return;
         if (self.auto_upgrade_enabled) {
             self.upgrader.start(self.alloc, currentBuild());
         }
@@ -2607,6 +2609,12 @@ const App = struct {
     }
 
     fn admitPendingResizeSignal(self: *App, source: []const u8) bool {
+        if (comptime builtin.os.tag == .windows) {
+            const layout = self.terminal.queryLayout(footer_rows) catch return false;
+            if (layout.rows != self.shell.layout.rows or layout.cols != self.shell.layout.cols) {
+                resize_interlock.noteResizeSignal();
+            }
+        }
         return shell_runtime.admitResizeSignal(
             &self.shell,
             &resize_interlock,
@@ -2981,10 +2989,15 @@ fn rawArgs(c_argc: c_int, c_argv: [*][*:0]c_char) []const [*:0]const u8 {
 }
 
 fn argsFromRaw(raw_args: []const [*:0]const u8) std.process.Args {
+    if (comptime builtin.os.tag == .windows) {
+        const command_line = std.os.windows.peb().ProcessParameters.CommandLine;
+        return .{ .vector = command_line.Buffer.?[0 .. command_line.Length / @sizeOf(u16)] };
+    }
     return .{ .vector = raw_args };
 }
 
 fn environBlockFromRaw(raw_env: RawEnviron) std.process.Environ.Block {
+    if (comptime builtin.os.tag == .windows) return .global;
     var count: usize = 0;
     while (raw_env[count] != null) : (count += 1) {}
     return .{ .slice = raw_env[0..count :null] };
@@ -3362,10 +3375,10 @@ fn handleSigWinchWeb() callconv(.c) void {
     resize_interlock.noteResizeSignal();
 }
 
-const handle_sigwinch: app_lifecycle.ResizeHandler = if (host_target.is_wasm)
-    handleSigWinchWeb
+const handle_sigwinch: app_lifecycle.ResizeHandler = if (shell_runtime.supports_resize_signal)
+    handleSigWinchNative
 else
-    handleSigWinchNative;
+    handleSigWinchWeb;
 
 test "interactive startup does not begin with synthetic resize pending" {
     try std.testing.expect(!resize_interlock.resizePending());

--- a/src/terminal_client_fixture.zig
+++ b/src/terminal_client_fixture.zig
@@ -204,7 +204,7 @@ fn runCapabilityStartFixture(
     alloc: Allocator,
     process_provider: background_process_provider.Provider,
 ) !void {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     var runtime = client.Runtime.init(process_provider);
     defer runtime.deinit();
     const correlation_id = contracts.CorrelationId{ .value = 1 };
@@ -218,7 +218,7 @@ fn runCapabilityForceCloseFixture(
     alloc: Allocator,
     process_provider: background_process_provider.Provider,
 ) !void {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     const terminal_session_id = io_mod.getenv(
         "FX_TERMINAL_AUTHORITY_SESSION_ID",
     ) orelse return error.TerminalAuthorityFixtureSessionMissing;
@@ -286,7 +286,7 @@ fn runAuthorityStartFixture(
     alloc: Allocator,
     process_provider: background_process_provider.Provider,
 ) !void {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     const compatibility_fixture = if (io_mod.getenv(
         "FX_TERMINAL_AUTHORITY_FIXTURE_COMPAT",
     )) |value|
@@ -345,7 +345,7 @@ fn runAuthorityReloadFixture(
     alloc: Allocator,
     process_provider: background_process_provider.Provider,
 ) !void {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     const terminal_session_id = io_mod.getenv(
         "FX_TERMINAL_AUTHORITY_SESSION_ID",
     ) orelse return error.TerminalAuthorityFixtureSessionMissing;
@@ -519,7 +519,7 @@ fn runOutcomeOrderingFixture(
     alloc: Allocator,
     process_provider: background_process_provider.Provider,
 ) !void {
-    const home = io_mod.getenv("HOME") orelse return error.HomeNotSet;
+    const home = io_mod.homeDir() orelse return error.HomeNotSet;
     const shell = io_mod.getenv("SHELL") orelse return error.ShellNotSet;
     const initial_monitors = [_]contracts.MonitorDefinition{.{
         .condition = .{ .output_contains = "ordered-event" },

--- a/src/tools/filesystem/open_file.zig
+++ b/src/tools/filesystem/open_file.zig
@@ -109,14 +109,17 @@ fn displayPath(arena: Allocator, workspace_root: []const u8, absolute_path: []co
 }
 
 fn launch_file(alloc: Allocator, display_path: []const u8, target: []const u8, os_tag: std.Target.Os.Tag, launcher: Launcher) tool_dispatch.DispatchError!tool_dispatch.ToolResult {
-    var argv: [2][]const u8 = undefined;
-    switch (os_tag) {
-        .macos => argv = .{ "open", target },
-        .linux => argv = .{ "xdg-open", target },
+    const macos_argv = [_][]const u8{ "open", target };
+    const linux_argv = [_][]const u8{ "xdg-open", target };
+    const windows_argv = [_][]const u8{ "rundll32.exe", "url.dll,FileProtocolHandler", target };
+    const argv: []const []const u8 = switch (os_tag) {
+        .windows => &windows_argv,
+        .macos => &macos_argv,
+        .linux => &linux_argv,
         else => return .{ .failure = try alloc.dupe(u8, "open_file not supported on this OS") },
-    }
+    };
 
-    const result = launcher.launch(launcher.ctx, alloc, &argv) catch |err| {
+    const result = launcher.launch(launcher.ctx, alloc, argv) catch |err| {
         debug_trace.logf("core", "open_file launcher failed err={s} path={s} target={s}", .{ @errorName(err), display_path, target });
         return .{ .failure = try std.fmt.allocPrint(alloc, "failed to open {s}", .{target}) };
     };
@@ -315,6 +318,27 @@ test "open_file displays workspace-relative path on success" {
     try std.testing.expectEqualStrings(target, launcher.argv.items[1]);
 }
 
+test "open_file uses the Windows file protocol handler" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(workspace);
+    const target = try writeTempFile(alloc, &tmp, "notes.txt", "hello\n");
+    defer alloc.free(target);
+    var launcher = MockLauncher{};
+    defer launcher.deinit(alloc);
+
+    var result = try callPathWithMock(alloc, workspace, "notes.txt", .windows, &launcher);
+    defer result.deinit(alloc);
+
+    try expectSuccessBody(result, "opened notes.txt");
+    try std.testing.expectEqual(@as(usize, 3), launcher.argv.items.len);
+    try std.testing.expectEqualStrings("rundll32.exe", launcher.argv.items[0]);
+    try std.testing.expectEqualStrings("url.dll,FileProtocolHandler", launcher.argv.items[1]);
+    try std.testing.expectEqualStrings(target, launcher.argv.items[2]);
+}
+
 test "open_file accepts external absolute paths through active workspace resolver" {
     const alloc = std.testing.allocator;
     var workspace_tmp = std.testing.tmpDir(.{});
@@ -351,7 +375,7 @@ test "open_file unsupported os does not launch" {
     var launcher = MockLauncher{};
     defer launcher.deinit(alloc);
 
-    var result = try callPathWithMock(alloc, workspace, "notes.txt", .windows, &launcher);
+    var result = try callPathWithMock(alloc, workspace, "notes.txt", .freebsd, &launcher);
     defer result.deinit(alloc);
 
     try expectFailureBody(result, "open_file not supported on this OS");

--- a/src/tools/memory/memory.zig
+++ b/src/tools/memory/memory.zig
@@ -108,7 +108,7 @@ pub fn execute(arena: Allocator, args_json: []const u8) ![]u8 {
 fn runMemory(alloc: Allocator, action: []const u8, fact: ?[]const u8) ![]u8 {
     if (!isSupportedAction(action)) return error.UnsupportedMemoryAction;
 
-    const home = io_mod.getenv("HOME") orelse return std.fmt.allocPrint(alloc, "memory unavailable: HOME not set", .{});
+    const home = io_mod.homeDir() orelse return std.fmt.allocPrint(alloc, "memory unavailable: HOME not set", .{});
     const memories_path = try profile_paths.memoriesPath(alloc, home);
     defer alloc.free(memories_path);
 

--- a/src/tools/shell/background_process.zig
+++ b/src/tools/shell/background_process.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const io_mod = @import("../../core/shared/io.zig");
 const builtin = @import("builtin");
+const windows_process = @import("../../core/shared/windows_process.zig");
 const background_process_provider = @import(
     "../../core/execution/background_process_provider.zig",
 );
@@ -36,6 +37,19 @@ const blocked_background_wrapper_command = std.fmt.comptimePrint(
     .{ background_ready_byte, background_exit_marker },
 );
 
+const windows_background_wrapper_command =
+    "[Console]::Error.Write([char]82)\n" ++
+    "$release = [Console]::In.Read()\n" ++
+    "$null = [Console]::In.ReadLine()\n" ++
+    "if ($release -ne 6) { exit 125 }\n" ++
+    "$script = [Console]::In.ReadToEnd()\n" ++
+    "[Console]::SetError([Console]::Out)\n" ++
+    "& $env:ComSpec /D /S /C $script\n" ++
+    "$status = $LASTEXITCODE\n" ++
+    "if ($null -eq $status) { if ($?) { $status = 0 } else { $status = 1 } }\n" ++
+    "[Console]::Out.Write(\"`n" ++ background_exit_marker ++ "$status`n\")\n" ++
+    "exit $status";
+
 pub const provider = background_process_provider.Provider{
     .spawn_prepared_fn = spawnPrepared,
     .capture_token_fn = captureToken,
@@ -60,13 +74,20 @@ fn spawnPrepared(
 ) background_process_provider.ProviderError!background_process_provider.PreparedProcess {
     if (!host.current().background_processes) return error.Unsupported;
 
-    const direct_argv = [_][]const u8{
+    const posix_argv = [_][]const u8{
         "sh",
         "-lc",
         blocked_background_wrapper_command,
         "fx-background",
     };
-    const argv: []const []const u8 = &direct_argv;
+    const windows_argv = [_][]const u8{
+        "powershell.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        windows_background_wrapper_command,
+    };
+    const argv: []const []const u8 = if (builtin.os.tag == .windows) &windows_argv else &posix_argv;
     var child = try std.process.spawn(io_mod.getIo(), .{
         .argv = argv,
         .cwd = .{ .path = request.cwd },
@@ -84,7 +105,11 @@ fn spawnPrepared(
         _ = child.wait(io_mod.getIo()) catch {};
     };
 
-    const child_id = child.id orelse return error.SpawnFailed;
+    const child_handle = child.id orelse return error.SpawnFailed;
+    const child_id: u64 = if (comptime builtin.os.tag == .windows)
+        try windows_process.idFromHandle(child_handle)
+    else
+        @intCast(child_handle);
     const pid = try std.fmt.allocPrint(alloc, "{d}", .{child_id});
     var pid_owned = true;
     errdefer if (pid_owned) alloc.free(pid);
@@ -245,9 +270,13 @@ fn captureToken(
     alloc: Allocator,
     pid_text: []const u8,
 ) background_process_provider.ProviderError!process_supervisor.ProcessInstanceToken {
-    const pid = std.fmt.parseInt(std.posix.pid_t, pid_text, 10) catch
+    const pid = std.fmt.parseInt(io_mod.ProcessId, pid_text, 10) catch
         return error.InvalidPid;
     return switch (builtin.os.tag) {
+        .windows => captureWindowsToken(pid) catch |err| switch (err) {
+            error.ProcessNotFound => error.ProcessNotFound,
+            else => error.ProcessIdentityUnavailable,
+        },
         .linux => captureLinuxToken(alloc, pid) catch |err| switch (err) {
             error.OutOfMemory => error.OutOfMemory,
             error.ProcessNotFound => error.ProcessNotFound,
@@ -259,6 +288,18 @@ fn captureToken(
         },
         else => error.ProcessIdentityUnsupported,
     };
+}
+
+fn captureWindowsToken(pid: io_mod.ProcessId) !process_supervisor.ProcessInstanceToken {
+    if (comptime builtin.os.tag != .windows) return error.ProcessIdentityUnsupported;
+    const creation_time = try windows_process.creationTime(pid);
+    var token_buf: [128]u8 = undefined;
+    const text = try std.fmt.bufPrint(
+        &token_buf,
+        "windows:00000000000000000000000000000000:{d}",
+        .{creation_time},
+    );
+    return process_supervisor.ProcessInstanceToken.parse(text);
 }
 
 fn matchToken(
@@ -482,6 +523,19 @@ fn signalProcess(
         },
     }
     if (!host.current().background_processes) return error.Unsupported;
+    if (comptime builtin.os.tag == .windows) {
+        const result = std.process.run(alloc, io_mod.getIo(), .{
+            .argv = &.{ "taskkill.exe", "/PID", pid_text, "/T", "/F" },
+            .stdout_limit = .limited(16 * 1024),
+            .stderr_limit = .limited(16 * 1024),
+        }) catch return error.Unexpected;
+        defer alloc.free(result.stdout);
+        defer alloc.free(result.stderr);
+        return switch (result.term) {
+            .exited => |code| if (code == 0) {} else error.ProcessNotFound,
+            else => error.Unexpected,
+        };
+    }
     const pid = std.fmt.parseInt(std.posix.pid_t, pid_text, 10) catch
         return error.InvalidPid;
     try signalPidTree(pid);
@@ -1013,7 +1067,7 @@ test "native provider transfers a prepared process to its owned handle" {
     defer if (prepared_active) {
         _ = prepared.closeAndWaitUnreleased(null, 2000);
     };
-    var owned = try prepared.release("printf provider-owned");
+    var owned = try prepared.release(if (builtin.os.tag == .windows) "echo provider-owned" else "printf provider-owned");
     prepared_active = false;
     owned.wait();
 
@@ -1028,16 +1082,24 @@ test "native provider transfers a prepared process to its owned handle" {
 }
 
 test "native provider captures the current process identity" {
-    if (builtin.os.tag != .linux and builtin.os.tag != .macos) {
+    if (builtin.os.tag != .windows and
+        builtin.os.tag != .linux and
+        builtin.os.tag != .macos)
+    {
         return error.SkipZigTest;
     }
 
     const alloc = std.testing.allocator;
-    const pid = try std.fmt.allocPrint(alloc, "{d}", .{std.c.getpid()});
+    const pid = try std.fmt.allocPrint(alloc, "{d}", .{io_mod.processId()});
     defer alloc.free(pid);
 
     const token = try provider.captureToken(alloc, pid);
-    const platform = if (builtin.os.tag == .linux) "linux:" else "macos:";
+    const platform = switch (builtin.os.tag) {
+        .windows => "windows:",
+        .linux => "linux:",
+        .macos => "macos:",
+        else => unreachable,
+    };
     try std.testing.expect(std.mem.startsWith(u8, token.view(), platform));
 }
 
@@ -1079,7 +1141,7 @@ test "native provider writes through the verified borrowed output handle" {
     defer if (prepared_active) {
         _ = prepared.closeAndWaitUnreleased(null, 2000);
     };
-    var owned = try prepared.release("printf verified-handle");
+    var owned = try prepared.release(if (builtin.os.tag == .windows) "echo verified-handle" else "printf verified-handle");
     prepared_active = false;
     owned.wait();
 

--- a/src/tools/skills/skill.zig
+++ b/src/tools/skills/skill.zig
@@ -183,7 +183,7 @@ fn loadVisibleSkillsForContext(
     workspace_root: []const u8,
     skills_dir: []const u8,
 ) !skill_runtime.SkillDiscovery {
-    if (io_mod.getenv("HOME") orelse homeFromSkillsDir(skills_dir)) |home| {
+    if (io_mod.homeDir() orelse homeFromSkillsDir(skills_dir)) |home| {
         return skill_runtime.loadVisibleSkills(alloc, workspace_root, home, skills_dir, builtin_skills.root_policy);
     }
     return skill_runtime.loadVisibleSkills(alloc, workspace_root, null, skills_dir, builtin_skills.root_policy);

--- a/src/tools/web/http_fetch.zig
+++ b/src/tools/web/http_fetch.zig
@@ -1,11 +1,19 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const debug_trace = @import("../../core/shared/debug_trace.zig");
 const io_mod = @import("../../core/shared/io.zig");
 const url_policy = @import("url_policy.zig");
+const windows_socket = @import("../../core/shared/windows_socket.zig");
 
 const Allocator = std.mem.Allocator;
 const IpAddress = std.Io.net.IpAddress;
 const posix = std.posix;
+const PollFd = if (builtin.os.tag == .windows) windows_socket.PollFd else posix.pollfd;
+const poll_in: i16 = if (builtin.os.tag == .windows) windows_socket.poll_read else posix.POLL.IN;
+const poll_out: i16 = if (builtin.os.tag == .windows) windows_socket.poll_write else posix.POLL.OUT;
+const poll_error: i16 = if (builtin.os.tag == .windows) windows_socket.poll_error else posix.POLL.ERR;
+const poll_hangup: i16 = if (builtin.os.tag == .windows) windows_socket.poll_hangup else posix.POLL.HUP;
+const poll_invalid: i16 = if (builtin.os.tag == .windows) windows_socket.poll_invalid else posix.POLL.NVAL;
 
 pub const max_body_bytes: usize = 10 * 1024 * 1024;
 const max_redirect_hops: usize = 10;
@@ -1223,6 +1231,11 @@ fn readChunkedTrailers(reader: *BodyReader, alloc: Allocator) !void {
 
 fn connectPinned(address: IpAddress, options: FetchOptions) !posix.fd_t {
     try checkControl(options);
+    if (comptime builtin.os.tag == .windows) {
+        const stream = try address.connect(io_mod.getIo(), .{ .mode = .stream });
+        try checkControl(options);
+        return stream.socket.handle;
+    }
     const family: posix.sa_family_t = switch (address) {
         .ip4 => posix.AF.INET,
         .ip6 => posix.AF.INET6,
@@ -1239,7 +1252,7 @@ fn connectPinned(address: IpAddress, options: FetchOptions) !posix.fd_t {
             continue;
         },
         .INPROGRESS, .AGAIN, .ALREADY => {
-            try pollFd(fd, posix.POLL.OUT, options);
+            try pollFd(fd, poll_out, options);
             try checkSocketError(fd);
             return fd;
         },
@@ -1346,6 +1359,10 @@ fn checkSocketError(fd: posix.fd_t) !void {
 }
 
 fn closeFd(fd: posix.fd_t) void {
+    if (comptime builtin.os.tag == .windows) {
+        io_mod.getIo().vtable.netClose(io_mod.getIo().userdata, (&fd)[0..1]);
+        return;
+    }
     while (true) switch (posix.errno(posix.system.close(fd))) {
         .SUCCESS => return,
         .INTR => continue,
@@ -1489,14 +1506,27 @@ fn DeadlineWriter(comptime buffer_len: usize) type {
     };
 }
 
-const PollError = posix.PollError || error{Interrupted};
+const PollError = if (builtin.os.tag == .windows)
+    error{ Interrupted, SystemResources, NetworkDown, SocketPollFailed }
+else
+    posix.PollError || error{Interrupted};
 
 const Poller = struct {
     ctx: ?*anyopaque,
-    poll_fn: *const fn (?*anyopaque, []posix.pollfd, i32) PollError!usize,
+    poll_fn: *const fn (?*anyopaque, []PollFd, i32) PollError!usize,
 };
 
-fn pollDefault(_: ?*anyopaque, fds: []posix.pollfd, timeout_ms: i32) PollError!usize {
+fn pollDefault(_: ?*anyopaque, fds: []PollFd, timeout_ms: i32) PollError!usize {
+    if (comptime builtin.os.tag == .windows) {
+        if (fds.len != 1) return error.SystemResources;
+        const result = try windows_socket.poll(fds[0].fd, fds[0].events, timeout_ms);
+        fds[0].revents =
+            (if (result.ready) fds[0].events else 0) |
+            (if (result.hung_up) poll_hangup else 0) |
+            (if (result.has_error) poll_error else 0) |
+            (if (result.invalid) poll_invalid else 0);
+        return @intFromBool(fds[0].revents != 0);
+    }
     const fds_count = std.math.cast(posix.nfds_t, fds.len) orelse
         return error.SystemResources;
     const rc = posix.system.poll(fds.ptr, fds_count, timeout_ms);
@@ -1531,6 +1561,22 @@ const ReadSyscall = struct {
 };
 
 fn readDefault(_: ?*anyopaque, fd: posix.fd_t, buf: []u8) RawSyscallResult {
+    if (comptime builtin.os.tag == .windows) {
+        const zio = io_mod.getIo();
+        var slices = [_][]u8{buf};
+        const count = zio.vtable.netRead(zio.userdata, fd, &slices) catch |err| {
+            return .{ .failure = switch (err) {
+                error.ConnectionResetByPeer => .CONNRESET,
+                error.SocketUnconnected => .NOTCONN,
+                error.NetworkDown => .NETDOWN,
+                error.SystemResources => .NOBUFS,
+                error.Canceled => .CANCELED,
+                error.Timeout => .TIMEDOUT,
+                else => .IO,
+            } };
+        };
+        return .{ .count = count };
+    }
     const rc = posix.system.read(fd, buf.ptr, buf.len);
     return switch (posix.errno(rc)) {
         .SUCCESS => .{ .count = @intCast(rc) },
@@ -1587,7 +1633,7 @@ fn rawReadWith(
     syscall: ReadSyscall,
 ) !usize {
     while (true) {
-        try pollFdWith(fd, posix.POLL.IN, options, poller);
+        try pollFdWith(fd, poll_in, options, poller);
         switch (syscall.read_fn(syscall.ctx, fd, buf)) {
             .count => |count| return count,
             .failure => |err| switch (classifyReadErrno(err)) {
@@ -1608,22 +1654,39 @@ fn rawWriteAll(fd: posix.fd_t, bytes: []const u8, options: FetchOptions) !void {
 fn rawWriteAllWith(fd: posix.fd_t, bytes: []const u8, options: FetchOptions, poller: Poller) !void {
     var written: usize = 0;
     while (written < bytes.len) {
-        try pollFdWith(fd, posix.POLL.OUT, options, poller);
-        const rc = std.c.send(
-            fd,
-            bytes[written..].ptr,
-            bytes.len - written,
-            @intCast(posix.MSG.NOSIGNAL),
-        );
-        const errno = posix.errno(rc);
-        if (errno != .SUCCESS) switch (classifyWriteErrno(errno)) {
-            .retry => {
-                if (errno == .INTR) try checkControl(options);
-                continue;
-            },
-            .failure => |root| return root,
+        try pollFdWith(fd, poll_out, options, poller);
+        const n: usize = if (comptime builtin.os.tag == .windows) blk: {
+            const zio = io_mod.getIo();
+            const data = [_][]const u8{bytes[written..]};
+            break :blk zio.vtable.netWrite(zio.userdata, fd, "", &data, 1) catch |err| {
+                return switch (err) {
+                    error.ConnectionResetByPeer => error.ConnectionResetByPeer,
+                    error.NetworkUnreachable => error.NetworkUnreachable,
+                    error.HostUnreachable => error.HostUnreachable,
+                    error.NetworkDown => error.NetworkDown,
+                    error.ConnectionRefused => error.ConnectionRefused,
+                    error.SystemResources => error.SystemResources,
+                    error.Canceled => error.Canceled,
+                    else => error.WriteFailed,
+                };
+            };
+        } else blk: {
+            const rc = std.c.send(
+                fd,
+                bytes[written..].ptr,
+                bytes.len - written,
+                @intCast(posix.MSG.NOSIGNAL),
+            );
+            const errno = posix.errno(rc);
+            if (errno != .SUCCESS) switch (classifyWriteErrno(errno)) {
+                .retry => {
+                    if (errno == .INTR) try checkControl(options);
+                    continue;
+                },
+                .failure => |root| return root,
+            };
+            break :blk @intCast(rc);
         };
-        const n: usize = @intCast(rc);
         if (n == 0) return error.UnexpectedClose;
         written += n;
     }
@@ -1635,7 +1698,7 @@ fn pollFd(fd: posix.fd_t, events: i16, options: FetchOptions) !void {
 
 fn pollFdWith(fd: posix.fd_t, events: i16, options: FetchOptions, poller: Poller) !void {
     while (true) {
-        var fds = [_]posix.pollfd{.{
+        var fds = [_]PollFd{.{
             .fd = fd,
             .events = events,
             .revents = 0,
@@ -1657,15 +1720,16 @@ fn pollFdWith(fd: posix.fd_t, events: i16, options: FetchOptions, poller: Poller
 }
 
 fn classifyPollEvents(fd: posix.fd_t, events: i16, revents: i16) !void {
-    if ((revents & posix.POLL.NVAL) != 0) return error.InvalidDescriptor;
+    if ((revents & poll_invalid) != 0) return error.InvalidDescriptor;
     if ((revents & events) != 0) return;
-    if (events == posix.POLL.IN and (revents & posix.POLL.HUP) != 0) return;
-    if ((revents & posix.POLL.ERR) != 0) return pollSocketError(fd);
-    if ((revents & posix.POLL.HUP) != 0) return error.UnexpectedClose;
+    if (events == poll_in and (revents & poll_hangup) != 0) return;
+    if ((revents & poll_error) != 0) return pollSocketError(fd);
+    if ((revents & poll_hangup) != 0) return error.UnexpectedClose;
     return error.UnexpectedClose;
 }
 
 fn pollSocketError(fd: posix.fd_t) !void {
+    if (comptime builtin.os.tag == .windows) return error.UnexpectedClose;
     var value: c_int = 0;
     var len: std.c.socklen_t = @sizeOf(c_int);
     if (std.c.getsockopt(fd, posix.SOL.SOCKET, posix.SO.ERROR, &value, &len) != 0)

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -32,7 +32,7 @@ pub const Runtime = struct {
         user: types.UserTurn,
         no_color: bool,
     ) !Runtime {
-        const layout = zeroFooterLayout(try ui_terminal.queryLayout(std.posix.STDOUT_FILENO, 0));
+        const layout = zeroFooterLayout(try ui_terminal.queryLayout(0));
         var terminal = shell_runtime.TerminalState{};
         const cursor = probeTerminal(&terminal, layout, no_color);
         return initConfigured(
@@ -195,7 +195,7 @@ pub const Runtime = struct {
     }
 
     fn refreshGeometry(self: *Runtime) !void {
-        const queried = ui_terminal.queryLayout(std.posix.STDOUT_FILENO, 0) catch return;
+        const queried = ui_terminal.queryLayout(0) catch return;
         const layout = zeroFooterLayout(queried);
         if (layout.rows == self.shell.layout.rows and layout.cols == self.shell.layout.cols) return;
         try shell_runtime.applyResizeWithLayout(&self.shell, &self.metrics, layout, true);
@@ -400,7 +400,7 @@ fn probeTerminal(
     const fallback = shell_runtime.CursorPosition{ .row = layout.rows, .col = 1 };
     const fallback_light = if (no_color) false else ui_render.explicitThemeOverride() orelse false;
     ui_render.initTheme(fallback_light, null);
-    if (std.c.isatty(std.posix.STDIN_FILENO) == 0) return fallback;
+    terminal.ensureInteractive() catch return fallback;
     terminal.captureOriginalTermios() catch return fallback;
     terminal.enableRawMode() catch return fallback;
     defer terminal.disableRawMode();

--- a/src/ui/resize_runtime.zig
+++ b/src/ui/resize_runtime.zig
@@ -192,7 +192,7 @@ pub fn collectResizeFacts(
 ) !void {
     const now = io_mod.milliTimestamp();
 
-    if (supports_resize_signal) {
+    if (supports_resize_signal or builtin.os.tag == .windows) {
         if (cursor_probe_allowed) resumeResizeCursorProbeAfterPaste(probe, now);
         switch (probe.poll(now)) {
             .none => {},
@@ -284,7 +284,8 @@ pub fn admitResizeSignal(
     debounce_ms: i64,
     source: []const u8,
 ) bool {
-    if (!supports_resize_signal or !resize_interlock.takeResizePending()) return false;
+    if (comptime !supports_resize_signal and builtin.os.tag != .windows) return false;
+    if (!resize_interlock.takeResizePending()) return false;
     shell.render_requests.observeResizeSignal(now_ms, debounce_ms);
     debug_trace.logf(
         "frame_schedule",

--- a/src/ui/shell_runtime.zig
+++ b/src/ui/shell_runtime.zig
@@ -3,6 +3,7 @@ const activity_runtime = @import("../core/output/activity_runtime.zig");
 const builtin = @import("builtin");
 const debug_trace = @import("../core/shared/debug_trace.zig");
 const io_mod = @import("../core/shared/io.zig");
+const windows_console = @import("../core/shared/windows_console.zig");
 const types = @import("../core/shared/types.zig");
 const transcript_runtime = @import("transcript/runtime.zig");
 const frame_layout = @import("render_engine/frame_layout.zig");
@@ -35,10 +36,10 @@ extern "c" fn unlockpt(fd: c_int) c_int;
 extern "c" fn ptsname(fd: c_int) ?[*:0]u8;
 
 pub const supports_resize_signal = resize_runtime.supports_resize_signal;
-pub const ResizeHandler = if (builtin.os.tag == .wasi)
-    *const fn () callconv(.c) void
+pub const ResizeHandler = if (supports_resize_signal)
+    std.posix.Sigaction.handler_fn
 else
-    std.posix.Sigaction.handler_fn;
+    *const fn () callconv(.c) void;
 pub const ResizeApprovalInterlock = resize_runtime.ResizeApprovalInterlock;
 pub const RedrawMode = resize_runtime.RedrawMode;
 
@@ -64,14 +65,22 @@ pub const AlternateScreenOwner = enum {
 };
 
 pub const TerminalState = struct {
-    stdin_fd: std.posix.fd_t = std.posix.STDIN_FILENO,
-    original_termios: std.posix.termios = undefined,
+    const NativeMode = if (builtin.os.tag == .windows)
+        windows_console.Mode
+    else if (builtin.os.tag == .wasi)
+        void
+    else
+        std.posix.termios;
+    const SavedResizeAction = if (supports_resize_signal) ?std.posix.Sigaction else void;
+
+    stdin_handle: ?std.Io.File.Handle = null,
+    original_mode: NativeMode = undefined,
     raw_enabled: bool = false,
     alternate_screen_owner: AlternateScreenOwner = .none,
     alternate_frame_layout: frame_layout.CommittedLayoutSnapshot = .{},
     alternate_mouse_tracking_active: bool = false,
     signal_handler_installed: bool = false,
-    old_winch_action: ?std.posix.Sigaction = null,
+    old_winch_action: SavedResizeAction = if (supports_resize_signal) null else {},
 
     pub fn fileApprovalScreenActive(self: TerminalState) bool {
         return self.alternate_screen_owner == .file_approval;
@@ -93,16 +102,37 @@ pub const TerminalState = struct {
         return self.alternate_screen_owner == .terminal_session;
     }
 
+    fn inputHandle(self: TerminalState) std.Io.File.Handle {
+        return self.stdin_handle orelse std.Io.File.stdin().handle;
+    }
+
     pub fn ensureInteractive(self: TerminalState) !void {
         if (comptime builtin.os.tag == .wasi) return;
-        if (std.c.isatty(self.stdin_fd) == 0 or std.c.isatty(std.posix.STDOUT_FILENO) == 0) {
+        if (comptime builtin.os.tag == .windows) {
+            if (!windows_console.isConsole(self.inputHandle()) or
+                !windows_console.isConsole(std.Io.File.stdout().handle))
+            {
+                return error.NotATerminal;
+            }
+            return;
+        }
+        if (std.c.isatty(self.inputHandle()) == 0 or
+            std.c.isatty(std.posix.STDOUT_FILENO) == 0)
+        {
             return error.NotATerminal;
         }
     }
 
     pub fn captureOriginalTermios(self: *TerminalState) !void {
         if (comptime builtin.os.tag == .wasi) return;
-        self.original_termios = try std.posix.tcgetattr(self.stdin_fd);
+        if (comptime builtin.os.tag == .windows) {
+            self.original_mode = try windows_console.captureMode(
+                self.inputHandle(),
+                std.Io.File.stdout().handle,
+            );
+            return;
+        }
+        self.original_mode = try std.posix.tcgetattr(self.inputHandle());
     }
 
     pub fn enableRawMode(self: *TerminalState) !void {
@@ -110,7 +140,16 @@ pub const TerminalState = struct {
             self.raw_enabled = true;
             return;
         }
-        var raw = self.original_termios;
+        if (comptime builtin.os.tag == .windows) {
+            try windows_console.enableRawMode(
+                self.inputHandle(),
+                std.Io.File.stdout().handle,
+                self.original_mode,
+            );
+            self.raw_enabled = true;
+            return;
+        }
+        var raw = self.original_mode;
 
         raw.iflag.BRKINT = false;
         raw.iflag.ICRNL = false;
@@ -133,20 +172,26 @@ pub const TerminalState = struct {
             raw.cc[vtime_idx] = 0;
         }
 
-        try std.posix.tcsetattr(self.stdin_fd, .NOW, raw);
+        try std.posix.tcsetattr(self.inputHandle(), .NOW, raw);
         self.raw_enabled = true;
     }
 
     pub fn disableRawMode(self: *TerminalState) void {
         if (!self.raw_enabled) return;
-        if (comptime builtin.os.tag != .wasi) {
-            std.posix.tcsetattr(self.stdin_fd, .FLUSH, self.original_termios) catch {};
+        if (comptime builtin.os.tag == .windows) {
+            windows_console.restoreMode(
+                self.inputHandle(),
+                std.Io.File.stdout().handle,
+                self.original_mode,
+            );
+        } else if (comptime builtin.os.tag != .wasi) {
+            std.posix.tcsetattr(self.inputHandle(), .FLUSH, self.original_mode) catch {};
         }
         self.raw_enabled = false;
     }
 
     pub fn installResizeSignal(self: *TerminalState, handler: ResizeHandler) void {
-        if (!supports_resize_signal) return;
+        if (comptime !supports_resize_signal) return;
 
         const act: std.posix.Sigaction = .{
             .handler = .{ .handler = handler },
@@ -161,18 +206,19 @@ pub const TerminalState = struct {
     }
 
     pub fn uninstallResizeSignal(self: *TerminalState) void {
-        if (!supports_resize_signal or !self.signal_handler_installed) return;
+        if (comptime !supports_resize_signal) return;
+        if (!self.signal_handler_installed) return;
         if (self.old_winch_action) |old| {
             std.posix.sigaction(std.posix.SIG.WINCH, &old, null);
         }
         self.signal_handler_installed = false;
     }
 
-    pub fn queryLayout(self: TerminalState, footer_rows: u16) !Layout {
+    pub fn queryLayout(_: TerminalState, footer_rows: u16) !Layout {
         return if (comptime builtin.os.tag == .wasi)
             wasm_terminal.queryLayout(footer_rows)
         else
-            ui_terminal.queryLayout(self.stdin_fd, footer_rows);
+            ui_terminal.queryLayout(footer_rows);
     }
 
     pub fn queryCursorPosition(self: TerminalState) !CursorPosition {
@@ -248,10 +294,14 @@ pub const TerminalState = struct {
     }
 
     pub fn read(self: TerminalState, out: []u8) !usize {
-        if (comptime builtin.os.tag == .wasi) {
-            return std.Io.File.stdin().readStreaming(io_mod.getIo(), &.{out});
+        if (comptime builtin.os.tag == .wasi or builtin.os.tag == .windows) {
+            var input = if (self.stdin_handle) |handle|
+                std.Io.File{ .handle = handle, .flags = .{ .nonblocking = false } }
+            else
+                std.Io.File.stdin();
+            return input.readStreaming(io_mod.getIo(), &.{out});
         }
-        return std.posix.read(self.stdin_fd, out);
+        return std.posix.read(self.inputHandle(), out);
     }
 
     pub fn pollInput(self: TerminalState, timeout_ms: i32) !PollResult {
@@ -262,8 +312,14 @@ pub const TerminalState = struct {
                 else => .{},
             };
         }
+        if (comptime builtin.os.tag == .windows) {
+            return switch (try windows_console.waitForInput(self.inputHandle(), timeout_ms)) {
+                .ready => .{ .readable = true },
+                .timeout => .{},
+            };
+        }
         var fds = [_]std.posix.pollfd{.{
-            .fd = self.stdin_fd,
+            .fd = self.inputHandle(),
             .events = std.posix.POLL.IN,
             .revents = 0,
         }};
@@ -610,7 +666,7 @@ test "enableRawMode preserves already queued input" {
     }
     try std.posix.tcsetattr(pty.slave, .NOW, original);
 
-    var terminal = TerminalState{ .stdin_fd = pty.slave };
+    var terminal = TerminalState{ .stdin_handle = pty.slave };
     try terminal.captureOriginalTermios();
 
     const queued = [_]u8{3};

--- a/src/ui/terminal/terminal.zig
+++ b/src/ui/terminal/terminal.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const builtin = @import("builtin");
+const windows_console = @import("../../core/shared/windows_console.zig");
 const types = @import("../../core/shared/types.zig");
 
 pub const interactive_mode_enable_sequence = "\x1b[>4;2m\x1b[>1u\x1b[?2004h\x1b[?7l";
@@ -33,11 +35,15 @@ pub fn interactiveModeEnableSequence(tmux: ?[]const u8) []const u8 {
         tmux_interactive_mode_enable_sequence;
 }
 
-pub fn queryLayout(fd: std.posix.fd_t, footer_rows: u16) !types.Layout {
-    var ws: std.posix.winsize = .{ .row = 0, .col = 0, .xpixel = 0, .ypixel = 0 };
+pub fn queryLayout(footer_rows: u16) !types.Layout {
+    if (comptime builtin.os.tag == .windows) {
+        const size = try windows_console.querySize(std.Io.File.stdout().handle);
+        return layoutFromSize(size.rows, size.cols, footer_rows);
+    }
 
+    var ws: std.posix.winsize = .{ .row = 0, .col = 0, .xpixel = 0, .ypixel = 0 };
     const req: c_int = @intCast(std.c.T.IOCGWINSZ);
-    const rc = std.c.ioctl(fd, req, &ws);
+    const rc = std.c.ioctl(std.posix.STDIN_FILENO, req, &ws);
     if (rc == -1 or ws.row == 0 or ws.col == 0) {
         return error.UnableToReadTerminalSize;
     }

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const debug_trace = @import("../../core/shared/debug_trace.zig");
 const display_width = @import("../../core/shared/display_width.zig");
 const input_action = @import("../../core/input/input_action.zig");
@@ -4092,7 +4093,7 @@ fn sameFullDiffResolver(
 }
 
 pub const TranscriptRuntime = struct {
-    stdout_file: std.Io.File = std.Io.File.stdout(),
+    stdout_file: std.Io.File = if (builtin.os.tag == .windows) undefined else std.Io.File.stdout(),
     sync_updates_enabled: bool = true,
     history_reset_uses_ris: bool = false,
     layout: Layout = undefined,


### PR DESCRIPTION
## Summary
- add native Windows 11 console, filesystem, socket, process, and command execution support
- publish x86-64 and ARM64 Windows release artifacts with PowerShell installation and self-update support
- add Windows CI builds, focused platform tests, and user documentation

## Verification
- `zig fmt --check` on all changed Zig files
- focused Windows console, file I/O, process identity, command, background process, URL, and file-opening tests
- ReleaseSafe builds for native Windows, Windows ARM64, and Linux x86-64
- `./zig-out/bin/fx.exe status --json`
- interactive Windows TUI startup, `/version`, and `/quit` with exit code 0

Hosted `terminal` sessions remain limited to macOS and Linux; foreground and background `run_command` execution is supported on Windows through `cmd.exe`.