### PR TITLE
Reserve the auth session buffer before writing the tokens into it

### DIFF
--- a/src/core/auth/chatgpt_session.zig
+++ b/src/core/auth/chatgpt_session.zig
@@ -235,16 +235,28 @@ pub fn parse(alloc: Allocator, bytes: []const u8) !Session {
 }
 
 pub fn stringify(alloc: Allocator, session: Session) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(alloc);
+    // Measure first and reserve the exact size, so the buffer holding the tokens
+    // never grows. A growing buffer copies the plaintext into a larger block and
+    // releases the smaller one unwiped, and the caller can only wipe the slice it
+    // gets back.
+    var counter: std.Io.Writer.Discarding = .init(&.{});
+    try writeSession(&counter.writer, session);
+    const exact = std.math.cast(usize, counter.fullCount()) orelse return error.OutOfMemory;
+
+    var out: std.Io.Writer.Allocating = try .initCapacity(alloc, exact);
     errdefer out.deinit();
-    try out.writer.writeAll("{\"version\":1,\"access_token\":");
-    try std.json.Stringify.value(session.access_token, .{}, &out.writer);
-    try out.writer.writeAll(",\"refresh_token\":");
-    try std.json.Stringify.value(session.refresh_token, .{}, &out.writer);
-    try out.writer.print(",\"expires_at_ms\":{d},\"account_id\":", .{session.expires_at_ms});
-    try std.json.Stringify.value(session.account_id, .{}, &out.writer);
-    try out.writer.writeAll("}\n");
+    try writeSession(&out.writer, session);
     return out.toOwnedSlice();
+}
+
+fn writeSession(writer: *std.Io.Writer, session: Session) !void {
+    try writer.writeAll("{\"version\":1,\"access_token\":");
+    try std.json.Stringify.value(session.access_token, .{}, writer);
+    try writer.writeAll(",\"refresh_token\":");
+    try std.json.Stringify.value(session.refresh_token, .{}, writer);
+    try writer.print(",\"expires_at_ms\":{d},\"account_id\":", .{session.expires_at_ms});
+    try std.json.Stringify.value(session.account_id, .{}, writer);
+    try writer.writeAll("}\n");
 }
 
 fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
@@ -295,4 +307,71 @@ test "ChatGPT auth session rejects account identifiers unsafe for HTTP headers" 
     };
     defer session.deinit(std.testing.allocator);
     return error.TestExpectedInvalidChatGptAuthSession;
+}
+
+/// Counts the blocks a wrapped allocator releases, so a test can assert that
+/// serializing a secret never abandons a buffer holding it. Scanning freed memory
+/// for the token cannot be the assertion here: a test build overwrites every block
+/// with `undefined` inside `Allocator.free` before the allocator sees it, so the
+/// scan reads clean whether or not the bug is present.
+const ReleaseCounter = struct {
+    child: std.mem.Allocator,
+    releases: usize = 0,
+
+    fn allocFn(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawAlloc(len, alignment, ra);
+    }
+
+    fn resizeFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawResize(memory, alignment, new_len, ra);
+    }
+
+    fn remapFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawRemap(memory, alignment, new_len, ra);
+    }
+
+    fn freeFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        self.releases += 1;
+        self.child.rawFree(memory, alignment, ra);
+    }
+
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = allocFn,
+        .resize = resizeFn,
+        .remap = remapFn,
+        .free = freeFn,
+    };
+
+    fn allocator(self: *ReleaseCounter) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+};
+
+test "stringify never abandons a buffer holding the session tokens" {
+    var counter: ReleaseCounter = .{ .child = std.testing.allocator };
+    const alloc = counter.allocator();
+
+    var session = Session{
+        // Realistic length: these are JWTs in production, and a short token fits
+        // inside the first allocation, so a shorter fixture would pass whether or
+        // not the buffer is sized up front.
+        .access_token = try alloc.dupe(u8, "header." ++ "a" ** 200 ++ ".signature"),
+        .refresh_token = try alloc.dupe(u8, "refresh." ++ "b" ** 200),
+        .expires_at_ms = 1234,
+        .account_id = try alloc.dupe(u8, "acct_1234567890"),
+    };
+    defer session.deinit(alloc);
+
+    counter.releases = 0;
+    const text = try stringify(alloc, session);
+    const releases_during_stringify = counter.releases;
+    defer secret.zeroAndFree(alloc, text);
+
+    // Every block released while the tokens are in flight is one the caller's
+    // zeroAndFree on the returned slice cannot reach.
+    try std.testing.expectEqual(@as(usize, 0), releases_during_stringify);
 }

--- a/src/core/auth/grok_session.zig
+++ b/src/core/auth/grok_session.zig
@@ -239,16 +239,28 @@ pub fn parse(alloc: Allocator, bytes: []const u8) !Session {
 
 pub fn stringify(alloc: Allocator, session: Session) ![]u8 {
     if (!validAccountId(session.account_id)) return error.InvalidGrokAuthSession;
-    var out: std.Io.Writer.Allocating = .init(alloc);
+    // Measure first and reserve the exact size, so the buffer holding the tokens
+    // never grows. A growing buffer copies the plaintext into a larger block and
+    // releases the smaller one unwiped, and the caller can only wipe the slice it
+    // gets back.
+    var counter: std.Io.Writer.Discarding = .init(&.{});
+    try writeSession(&counter.writer, session);
+    const exact = std.math.cast(usize, counter.fullCount()) orelse return error.OutOfMemory;
+
+    var out: std.Io.Writer.Allocating = try .initCapacity(alloc, exact);
     errdefer out.deinit();
-    try out.writer.writeAll("{\"version\":1,\"access_token\":");
-    try std.json.Stringify.value(session.access_token, .{}, &out.writer);
-    try out.writer.writeAll(",\"refresh_token\":");
-    try std.json.Stringify.value(session.refresh_token, .{}, &out.writer);
-    try out.writer.print(",\"expires_at_ms\":{d},\"account_id\":", .{session.expires_at_ms});
-    try std.json.Stringify.value(session.account_id, .{}, &out.writer);
-    try out.writer.writeAll("}\n");
+    try writeSession(&out.writer, session);
     return out.toOwnedSlice();
+}
+
+fn writeSession(writer: *std.Io.Writer, session: Session) !void {
+    try writer.writeAll("{\"version\":1,\"access_token\":");
+    try std.json.Stringify.value(session.access_token, .{}, writer);
+    try writer.writeAll(",\"refresh_token\":");
+    try std.json.Stringify.value(session.refresh_token, .{}, writer);
+    try writer.print(",\"expires_at_ms\":{d},\"account_id\":", .{session.expires_at_ms});
+    try std.json.Stringify.value(session.account_id, .{}, writer);
+    try writer.writeAll("}\n");
 }
 
 fn dupeRequiredString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) ![]u8 {
@@ -299,4 +311,71 @@ test "Grok account identity is bounded and safe for HTTP headers" {
 test "Grok session refresh deadline keeps a one minute safety margin" {
     try std.testing.expectEqual(@as(i64, 40_000), refreshDeadlineMs(100_000));
     try std.testing.expectEqual(@as(i64, 0), refreshDeadlineMs(10_000));
+}
+
+/// Counts the blocks a wrapped allocator releases, so a test can assert that
+/// serializing a secret never abandons a buffer holding it. Scanning freed memory
+/// for the token cannot be the assertion here: a test build overwrites every block
+/// with `undefined` inside `Allocator.free` before the allocator sees it, so the
+/// scan reads clean whether or not the bug is present.
+const ReleaseCounter = struct {
+    child: std.mem.Allocator,
+    releases: usize = 0,
+
+    fn allocFn(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawAlloc(len, alignment, ra);
+    }
+
+    fn resizeFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawResize(memory, alignment, new_len, ra);
+    }
+
+    fn remapFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawRemap(memory, alignment, new_len, ra);
+    }
+
+    fn freeFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        self.releases += 1;
+        self.child.rawFree(memory, alignment, ra);
+    }
+
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = allocFn,
+        .resize = resizeFn,
+        .remap = remapFn,
+        .free = freeFn,
+    };
+
+    fn allocator(self: *ReleaseCounter) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+};
+
+test "stringify never abandons a buffer holding the session tokens" {
+    var counter: ReleaseCounter = .{ .child = std.testing.allocator };
+    const alloc = counter.allocator();
+
+    var session = Session{
+        // Realistic length: these are JWTs in production, and a short token fits
+        // inside the first allocation, so a shorter fixture would pass whether or
+        // not the buffer is sized up front.
+        .access_token = try alloc.dupe(u8, "header." ++ "a" ** 200 ++ ".signature"),
+        .refresh_token = try alloc.dupe(u8, "refresh." ++ "b" ** 200),
+        .expires_at_ms = 1234,
+        .account_id = try alloc.dupe(u8, "1234567890"),
+    };
+    defer session.deinit(alloc);
+
+    counter.releases = 0;
+    const text = try stringify(alloc, session);
+    const releases_during_stringify = counter.releases;
+    defer secret.zeroAndFree(alloc, text);
+
+    // Every block released while the tokens are in flight is one the caller's
+    // zeroAndFree on the returned slice cannot reach.
+    try std.testing.expectEqual(@as(usize, 0), releases_during_stringify);
 }

--- a/src/core/auth/oauth_session.zig
+++ b/src/core/auth/oauth_session.zig
@@ -890,9 +890,22 @@ pub fn parse(alloc: Allocator, bytes: []const u8) !Session {
 }
 
 pub fn stringify(alloc: Allocator, session: Session) ![]u8 {
-    var out: std.Io.Writer.Allocating = .init(alloc);
+    // Measure first and reserve the exact size, so the buffer holding the tokens
+    // never grows. A growing buffer copies the plaintext into a larger block and
+    // releases the smaller one unwiped, and the caller can only wipe the slice it
+    // gets back. Same reason auth_runtime reserves the API-key entry ceiling up
+    // front rather than letting the input buffer reallocate.
+    var counter: std.Io.Writer.Discarding = .init(&.{});
+    try writeSession(&counter.writer, session);
+    const exact = std.math.cast(usize, counter.fullCount()) orelse return error.OutOfMemory;
+
+    var out: std.Io.Writer.Allocating = try .initCapacity(alloc, exact);
     errdefer out.deinit();
-    const writer = &out.writer;
+    try writeSession(&out.writer, session);
+    return out.toOwnedSlice();
+}
+
+fn writeSession(writer: *std.Io.Writer, session: Session) !void {
     try writer.writeAll("{\"version\":1");
     try writeField(writer, "issuer", session.issuer);
     try writeField(writer, "client_id", session.client_id);
@@ -904,7 +917,6 @@ pub fn stringify(alloc: Allocator, session: Session) ![]u8 {
     if (session.team_slug) |value| try writeField(writer, "team_slug", value);
     if (session.team_id) |value| try writeField(writer, "team_id", value);
     try writer.writeAll("}\n");
-    return out.toOwnedSlice();
 }
 
 fn writeField(writer: *std.Io.Writer, name: []const u8, value: []const u8) !void {
@@ -1034,6 +1046,200 @@ test "oauth session stringifies and parses" {
     try std.testing.expectEqualStrings("access", parsed.access_token);
     try std.testing.expectEqualStrings("vercel-labs", parsed.team_slug.?);
     try std.testing.expectEqualStrings("team_123", parsed.team_id.?);
+}
+
+const StringifyCase = struct {
+    name: []const u8,
+    access: []const u8,
+    refresh: []const u8,
+    scope: []const u8,
+    team_slug: ?[]const u8,
+    team_id: ?[]const u8,
+};
+
+/// Every combination that changes what `stringify` writes: the optional fields
+/// present and absent, and values whose JSON encoding is longer than the input.
+/// The two passes must agree on all of them, because the first sizes the buffer
+/// the second writes into.
+const stringify_cases = [_]StringifyCase{
+    .{
+        .name = "all optional fields present",
+        .access = "access-token-long-enough-to-grow-the-buffer",
+        .refresh = "refresh-token-long-enough-to-grow-the-buffer",
+        .scope = "openid offline_access",
+        .team_slug = "vercel-labs",
+        .team_id = "team_123",
+    },
+    .{
+        .name = "both optional fields absent",
+        .access = "access-token-long-enough-to-grow-the-buffer",
+        .refresh = "refresh-token-long-enough-to-grow-the-buffer",
+        .scope = "openid offline_access",
+        .team_slug = null,
+        .team_id = null,
+    },
+    .{
+        .name = "team_slug present, team_id absent",
+        .access = "access-token-long-enough-to-grow-the-buffer",
+        .refresh = "refresh-token-long-enough-to-grow-the-buffer",
+        .scope = "openid offline_access",
+        .team_slug = "vercel-labs",
+        .team_id = null,
+    },
+    .{
+        .name = "team_id present, team_slug absent",
+        .access = "access-token-long-enough-to-grow-the-buffer",
+        .refresh = "refresh-token-long-enough-to-grow-the-buffer",
+        .scope = "openid offline_access",
+        .team_slug = null,
+        .team_id = "team_123",
+    },
+    .{
+        .name = "values whose JSON encoding is longer than the input",
+        .access = "quote\" backslash\\ newline\n tab\t",
+        .refresh = "control\x01\x02 and \"more\"",
+        .scope = "openid \"offline_access\"",
+        .team_slug = "slug\\with\\backslashes",
+        .team_id = "id\"with\"quotes",
+    },
+    .{
+        .name = "multibyte values",
+        .access = "\u{e9}\u{4e2d}\u{6587}\u{1f512}-access-token-value",
+        .refresh = "\u{e9}\u{4e2d}\u{6587}\u{1f512}-refresh-token-value",
+        .scope = "openid \u{4e2d}\u{6587}",
+        .team_slug = "\u{1f512}",
+        .team_id = "\u{e9}",
+    },
+};
+
+fn sessionForCase(alloc: Allocator, case: StringifyCase) !Session {
+    const owned_issuer = try alloc.dupe(u8, issuer);
+    errdefer alloc.free(owned_issuer);
+    const client_id = try alloc.dupe(u8, "client");
+    errdefer alloc.free(client_id);
+    const access_token = try alloc.dupe(u8, case.access);
+    errdefer secret.zeroAndFree(alloc, access_token);
+    const refresh_token = try alloc.dupe(u8, case.refresh);
+    errdefer secret.zeroAndFree(alloc, refresh_token);
+    const scope = try alloc.dupe(u8, case.scope);
+    errdefer alloc.free(scope);
+    const token_type = try alloc.dupe(u8, "Bearer");
+    errdefer alloc.free(token_type);
+    const team_slug = if (case.team_slug) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (team_slug) |value| alloc.free(value);
+    const team_id = if (case.team_id) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (team_id) |value| alloc.free(value);
+
+    return .{
+        .issuer = owned_issuer,
+        .client_id = client_id,
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+        .expires_at_ms = 1234,
+        .scope = scope,
+        .token_type = token_type,
+        .team_slug = team_slug,
+        .team_id = team_id,
+    };
+}
+
+/// Counts the blocks a wrapped allocator releases, so a test can assert that
+/// serializing a secret never abandons a buffer holding it. Scanning freed memory
+/// for the token cannot be the assertion here: a test build overwrites every block
+/// with `undefined` inside `Allocator.free` before the allocator sees it, so the
+/// scan reads clean whether or not the bug is present.
+const ReleaseCounter = struct {
+    child: std.mem.Allocator,
+    releases: usize = 0,
+
+    fn allocFn(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawAlloc(len, alignment, ra);
+    }
+
+    fn resizeFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawResize(memory, alignment, new_len, ra);
+    }
+
+    fn remapFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        return self.child.rawRemap(memory, alignment, new_len, ra);
+    }
+
+    fn freeFn(ctx: *anyopaque, memory: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *ReleaseCounter = @ptrCast(@alignCast(ctx));
+        self.releases += 1;
+        self.child.rawFree(memory, alignment, ra);
+    }
+
+    const vtable: std.mem.Allocator.VTable = .{
+        .alloc = allocFn,
+        .resize = resizeFn,
+        .remap = remapFn,
+        .free = freeFn,
+    };
+
+    fn allocator(self: *ReleaseCounter) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &vtable };
+    }
+};
+
+test "stringify never abandons a buffer holding the session tokens" {
+    for (stringify_cases) |case| {
+        errdefer std.debug.print("case: {s}\n", .{case.name});
+
+        var counter: ReleaseCounter = .{ .child = std.testing.allocator };
+        const alloc = counter.allocator();
+
+        var session = try sessionForCase(alloc, case);
+        defer session.deinit(alloc);
+
+        counter.releases = 0;
+        const text = try stringify(alloc, session);
+        const releases_during_stringify = counter.releases;
+        defer secret.zeroAndFree(alloc, text);
+
+        // Every block released while the tokens are in flight is one the caller's
+        // zeroAndFree on the returned slice cannot reach.
+        try std.testing.expectEqual(@as(usize, 0), releases_during_stringify);
+
+        // The sizing pass and the writing pass must agree, or the buffer either
+        // grows (releasing a copy) or carries a tail the caller never asked for.
+        var parsed = try parse(std.testing.allocator, text);
+        defer parsed.deinit(std.testing.allocator);
+        try std.testing.expectEqualStrings(case.access, parsed.access_token);
+        try std.testing.expectEqualStrings(case.refresh, parsed.refresh_token);
+        try std.testing.expectEqualStrings(case.scope, parsed.scope);
+        if (case.team_slug) |value| {
+            try std.testing.expectEqualStrings(value, parsed.team_slug.?);
+        } else {
+            try std.testing.expect(parsed.team_slug == null);
+        }
+        if (case.team_id) |value| {
+            try std.testing.expectEqualStrings(value, parsed.team_id.?);
+        } else {
+            try std.testing.expect(parsed.team_id == null);
+        }
+    }
+}
+
+fn stringifyUnderAllocationFailure(alloc: Allocator, case: StringifyCase) !void {
+    var session = try sessionForCase(alloc, case);
+    defer session.deinit(alloc);
+    const text = try stringify(alloc, session);
+    secret.zeroAndFree(alloc, text);
+}
+
+test "stringify releases everything it allocated when an allocation fails" {
+    for (stringify_cases) |case| {
+        errdefer std.debug.print("case: {s}\n", .{case.name});
+        try std.testing.checkAllAllocationFailures(
+            std.testing.allocator,
+            stringifyUnderAllocationFailure,
+            .{case},
+        );
+    }
 }
 
 test "OAuth storage backend selection is platform scoped and explicitly disableable" {


### PR DESCRIPTION
Fixes #378.

`stringify` builds the session JSON in a `std.Io.Writer.Allocating` with no reserved capacity, so the buffer grows while it holds the access and refresh tokens. Each growth copies the plaintext into a larger block and hands the smaller one back to the allocator without overwriting it. The callers wipe only the slice they get back, so those abandoned buffers keep both tokens.

This measures the exact length first with a discarding writer, reserves precisely that, then writes once. The buffer never grows, so nothing is abandoned. `auth_runtime` already applies the same rule to the API key entry buffer, and says why in a comment: reserve the ceiling up front so growth never abandons an unzeroed buffer.

`grok_session` and `chatgpt_session` carry the identical shape with the same callers, so they get the same treatment. Three sites, one mechanism.

Measured with an allocator that scans every block as it is released, in a release build:

| | before | after |
|---|---|---|
| `oauth_session.stringify` | 1 released block carrying both tokens, 165 bytes | 0 |
| real save path, `saveNewSession` through `saveFile` to disk | 5 blocks released, 1 carrying the token | 0 |
| `grok_session` / `chatgpt_session`, JWT-length tokens | 1 per call | 0 |

The end to end run also clears the rest of the save path: no other stage released the tokens unwiped.

Output is byte identical before and after across every case, including values whose JSON encoding is longer than the input and multibyte values. That matters here because the size is computed in one pass and the bytes are written in another, so the two have to agree exactly.

On the tests, two traps are worth naming because both produce a green that means nothing:

A test that scans freed memory cannot work. `Allocator.free` overwrites the block with `undefined` before a wrapping allocator sees it, so in a test build the scan reads clean either way. The tests therefore assert that no block is released at all while the tokens are in flight.

A short token fits inside the first allocation, so the buffer never grows and the assertion passes on the unfixed code. The Grok and ChatGPT fixtures use lengths these fields actually carry. With the sizing removed, each of the three tests reports one released block; with a 43 byte token the sibling tests report none.

Verification: each test fails with the sizing removed and passes with it, confirmed by mutating the source and checking the mutation applied. Full suite against `origin/main` as the baseline shows the same 32 failing test names on both sides, no regressions, and none of them in auth. Local runs of the whole suite here carry about 30 pre-existing environment failures, so the comparison is by test name rather than by count.

Not covered: the macOS Keychain publish path and the wasm host path cannot execute on this Linux host, so both were read rather than run.
