### PR TITLE
Preserve safety caution state across resume

### DIFF
--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -6583,12 +6583,16 @@ test "execution replay preserves permission denial reasons" {
         .auto_denied,
         .policy_denied,
         .permission_required,
+        .review_caution,
+        .review_unavailable,
     };
     const call_ids = [_][]const u8{
         "call_user_denied",
         "call_auto_denied",
         "call_policy_denied",
         "call_permission_required",
+        "call_review_caution",
+        "call_review_unavailable",
     };
     var outputs: [reasons.len][]u8 = undefined;
     var allocated_outputs: usize = 0;
@@ -6596,11 +6600,19 @@ test "execution replay preserves permission denial reasons" {
     var calls: [reasons.len]types.ToolCall = undefined;
     var results: [reasons.len]types.PersistedToolResult = undefined;
     for (reasons, 0..) |reason, index| {
-        outputs[index] = try tool_result_errors.toolPermissionDeniedJson(
-            alloc,
-            "run_command",
-            reason,
-        );
+        outputs[index] = switch (reason) {
+            .review_caution, .review_unavailable => try tool_result_errors.toolReviewHeldJson(
+                alloc,
+                "run_command",
+                reason,
+                null,
+            ),
+            .user_denied, .auto_denied, .policy_denied, .permission_required => try tool_result_errors.toolPermissionDeniedJson(
+                alloc,
+                "run_command",
+                reason,
+            ),
+        };
         allocated_outputs += 1;
         calls[index] = .{
             .id = call_ids[index],
@@ -6625,14 +6637,16 @@ test "execution replay preserves permission denial reasons" {
 
     try std.testing.expectEqualSlices(
         types.ToolOutcomeKind,
-        &.{ .denied, .denied, .denied, .denied },
+        &.{ .denied, .denied, .denied, .denied, .denied, .denied },
         app.completed_tool_outcomes.items,
     );
-    try std.testing.expectEqual(@as(usize, 4), app.completed_tool_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 6), app.completed_tool_statuses.items.len);
     try std.testing.expectEqualStrings("● Denied run_command\n", app.completed_tool_statuses.items[0]);
     try std.testing.expectEqualStrings("● Denied by auto agent run_command\n", app.completed_tool_statuses.items[1]);
     try std.testing.expectEqualStrings("● Denied run_command\n", app.completed_tool_statuses.items[2]);
     try std.testing.expectEqualStrings("● Permission required run_command\n", app.completed_tool_statuses.items[3]);
+    try std.testing.expectEqualStrings("● Safety caution run_command\n", app.completed_tool_statuses.items[4]);
+    try std.testing.expectEqualStrings("● Review unavailable run_command\n", app.completed_tool_statuses.items[5]);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
 }
 

--- a/src/core/tooling/tool_result_errors.zig
+++ b/src/core/tooling/tool_result_errors.zig
@@ -237,12 +237,22 @@ pub fn toolPermissionDenialReason(output: []const u8) ?types.ToolPermissionDenia
         .string => |value| value,
         else => return null,
     };
-    if (!std.mem.eql(u8, type_value, "tool_permission_denied")) return null;
+    const review_held = std.mem.eql(u8, type_value, "tool_review_held");
+    if (!review_held and !std.mem.eql(u8, type_value, "tool_permission_denied")) return null;
     const reason_value = switch (error_value.get("reason") orelse return null) {
         .string => |value| value,
         else => return null,
     };
-    return std.meta.stringToEnum(types.ToolPermissionDenialReason, reason_value);
+    const reason = std.meta.stringToEnum(
+        types.ToolPermissionDenialReason,
+        reason_value,
+    ) orelse return null;
+    const review_reason = switch (reason) {
+        .review_caution, .review_unavailable => true,
+        .user_denied, .auto_denied, .policy_denied, .permission_required => false,
+    };
+    if (review_held != review_reason) return null;
+    return reason;
 }
 
 pub fn toolExecutionFailureJson(alloc: Allocator, failure: ExecutionFailure) Allocator.Error![]u8 {
@@ -468,9 +478,23 @@ test "review hold JSON distinguishes caution and unavailable from permission den
     try std.testing.expect(std.mem.find(u8, caution, "approval_request_id") == null);
     try std.testing.expect(isToolReviewHeldOutput(caution));
     try std.testing.expect(!isToolPermissionDeniedOutput(caution));
+    try std.testing.expectEqual(
+        @as(?types.ToolPermissionDenialReason, .review_caution),
+        toolPermissionDenialReason(caution),
+    );
     try std.testing.expect(std.mem.find(u8, unavailable, "\"reason\":\"review_unavailable\"") != null);
     try std.testing.expect(std.mem.find(u8, unavailable, "\"advice\"") == null);
     try std.testing.expect(isToolReviewHeldOutput(unavailable));
+    try std.testing.expectEqual(
+        @as(?types.ToolPermissionDenialReason, .review_unavailable),
+        toolPermissionDenialReason(unavailable),
+    );
+    try std.testing.expect(toolPermissionDenialReason(
+        "{\"error\":{\"type\":\"tool_review_held\",\"reason\":\"auto_denied\"}}",
+    ) == null);
+    try std.testing.expect(toolPermissionDenialReason(
+        "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"review_caution\"}}",
+    ) == null);
 }
 
 test "tool permission denied JSON explains policy and headless blockers" {

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -2535,7 +2535,7 @@ describe("effect-aware command permissions", () => {
       expect(gateway.classifierRequests).toHaveLength(1);
       expect(pane).not.toContain("Auto agent denied");
       expect(pane).toContain("1 denied");
-      expect(pane).toContain(`Denied by auto agent ${command}`);
+      expect(pane).toContain(`Safety caution ${command}`);
       expect(pane).not.toContain("└ terminal");
       expect(gateway.requests).toHaveLength(2);
       const permissionResultRequest = gateway.requests[1]!.body;
@@ -2567,7 +2567,7 @@ describe("effect-aware command permissions", () => {
       });
       await activeSession.waitForComposer(TIMEOUT);
       const resumedPane = await activeSession.waitForPane(
-        (value) => value.includes(`Denied by auto agent ${command}`),
+        (value) => value.includes(`Safety caution ${command}`),
         TIMEOUT,
       );
       expect(resumedPane).toContain("1 denied");


### PR DESCRIPTION
## Summary

- recognize persisted held-review results without accepting mismatched result and reason types
- preserve `Safety caution` and `Review unavailable` status labels after session resume
- align the live and resumed TUI regression coverage with the persisted result contract

## Verification

- `/Users/faxes/.codex/skills/fx-simplify/scripts/verify.sh /Users/faxes/Developer/Fx/worktrees/preserve-safety-caution-resume`
- `zig build -Doptimize=ReleaseSafe`
- `TERM=xterm-256color bun test tui-command-permissions.test.ts -t "TUI automatic caution returns advice without prompting" --max-concurrency 1`
- `./zig-out/bin/fx sessions --json`