### PR TITLE
Streamline the setup menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fx login grok
 fx
 ```
 
-`fx login codex` and `fx login grok` select that provider and a model from its authenticated catalog. Inside fx, open `/setup` and choose **Switch provider** to move between Gateway, Codex, and Grok. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Use `/logout codex` or `/logout grok` to remove that subscription session without affecting other providers; choosing it again from **Switch provider** starts sign-in.
+`fx login codex` and `fx login grok` select that provider and a model from its authenticated catalog. Inside fx, open `/setup` and choose **Model provider** to move between Gateway, Codex, and Grok. `/model` lists the active provider's fetched models. Subscription model IDs are the raw IDs returned by each authenticated catalog. Use `/logout codex` or `/logout grok` to remove that subscription session without affecting other providers; choosing it again from **Model provider** starts sign-in.
 
 The OpenAI Codex route uses ChatGPT subscription access directly and never sends its OAuth token to Vercel AI Gateway. The session is stored privately at `~/.fx/chatgpt-auth.json` and refreshed when needed. On supported Codex models, `/fast` requests OpenAI's priority service tier and consumes ChatGPT credits at the higher Fast mode rate.
 

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -113,7 +113,7 @@ pub fn Runtime(comptime App: type) type {
                 return;
             }
             try app.auth.refreshSourceInventory(app.alloc);
-            app.auth.openPicker(app.alloc);
+            app.auth.openPickerForProvider(app.alloc, provider_runtime.provider(app));
             app.shell.render_requests.request(.footer);
         }
 
@@ -224,7 +224,7 @@ pub fn Runtime(comptime App: type) type {
                 return;
             }
             try app.auth.refreshSourceInventory(app.alloc);
-            app.auth.openPicker(app.alloc);
+            app.auth.openPickerForProvider(app.alloc, provider_runtime.provider(app));
             app.shell.render_requests.request(.footer);
         }
 
@@ -1107,7 +1107,7 @@ pub fn Runtime(comptime App: type) type {
             debug_trace.logf("auth", "prompt credential refresh failed source={t} err={s}", .{ source, @errorName(err) });
             if (app.auth.credentialSource() == source) app.auth.recordCredentialRefreshFailure(source);
             try app.auth.refreshSourceInventory(app.alloc);
-            app.auth.openPicker(app.alloc);
+            app.auth.openPickerForProvider(app.alloc, provider_runtime.provider(app));
             const failure = auth_runtime.FailureSnapshot{
                 .source = source,
                 .reason = .credential_refresh_failed,
@@ -1433,6 +1433,7 @@ const TestAuth = struct {
     source_inventory_refresh_count: usize = 0,
     refresh_failure_source: ?credentials.Source = null,
     picker_opened: bool = false,
+    picker_provider: model_provider.ProviderId = .gateway,
     picker_closed: bool = false,
     gateway_ready: bool = true,
     catalog_ready: bool = true,
@@ -1500,6 +1501,15 @@ const TestAuth = struct {
 
     fn openPicker(self: *TestAuth, _: std.mem.Allocator) void {
         self.picker_opened = true;
+    }
+
+    fn openPickerForProvider(
+        self: *TestAuth,
+        _: std.mem.Allocator,
+        provider: model_provider.ProviderId,
+    ) void {
+        self.picker_opened = true;
+        self.picker_provider = provider;
     }
 
     fn teamSelection(self: *TestAuth) ?*TestTeamSelection {
@@ -1588,6 +1598,7 @@ const TestUrlOpener = struct {
 
 const TestApp = struct {
     alloc: std.mem.Allocator = std.testing.allocator,
+    selected_provider: model_provider.ProviderId = .gateway,
     auth: TestAuth = .{},
     model_cache: TestModelCache = .{},
     session: struct {
@@ -1633,6 +1644,16 @@ const TestApp = struct {
         if (self.preference_write_succeeds) self.last_preference_source = source;
     }
 };
+
+test "setup hub projects the selected provider into the auth picker" {
+    var app: TestApp = .{ .selected_provider = .codex };
+    defer app.deinit();
+
+    try Runtime(TestApp).openSetupHub(&app);
+
+    try std.testing.expect(app.auth.picker_opened);
+    try std.testing.expectEqual(model_provider.ProviderId.codex, app.auth.picker_provider);
+}
 
 test "OAuth app gating accepts native auth or JS-host auth and rejects neither" {
     const NativeApp = struct {

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -276,6 +276,7 @@ pub fn Runtime(comptime App: type) type {
                 .provider => |provider| try switchProvider(app, provider, true, .manual),
                 .source => |source| try applySourceChoice(app, source),
                 .action => |action| switch (action) {
+                    .connections => unreachable,
                     .login => try beginSignIn(app, true),
                     .chatgpt_login => try beginChatGptSignIn(app),
                     .grok_login => try beginGrokSignIn(app),

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -1499,10 +1499,6 @@ const TestAuth = struct {
         self.refresh_failure_source = source;
     }
 
-    fn openPicker(self: *TestAuth, _: std.mem.Allocator) void {
-        self.picker_opened = true;
-    }
-
     fn openPickerForProvider(
         self: *TestAuth,
         _: std.mem.Allocator,

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -3782,7 +3782,7 @@ test "app_input_runtime routes auth picker navigation before composer history" {
 
     try Runtime(RoutingFakeApp).routeModifiedHistory(&app, .down, 1);
 
-    try std.testing.expect((auth_runtime.Choice{ .action = .chatgpt_login }).eql(app.auth.pickerView().selected_choice.?));
+    try std.testing.expect((auth_runtime.Choice{ .action = .switch_provider }).eql(app.auth.pickerView().selected_choice.?));
     try std.testing.expectEqual(@as(?usize, null), app.input_runtime.composer_history.activeIndex());
 }
 
@@ -3795,7 +3795,7 @@ test "app_input_runtime Tab cycles the active auth picker" {
 
     try Runtime(RoutingFakeApp).handleByte(&app, '\t', 4096, 100);
 
-    try std.testing.expect((auth_runtime.Choice{ .action = .chatgpt_login }).eql(app.auth.pickerView().selected_choice.?));
+    try std.testing.expect((auth_runtime.Choice{ .action = .switch_provider }).eql(app.auth.pickerView().selected_choice.?));
 }
 
 test "app_input_runtime Tab leaves a dismissed slash query unchanged" {
@@ -3888,12 +3888,15 @@ test "app_input_runtime auth picker enter closes before selecting a switched sou
     try std.testing.expectEqual(types.CredentialSource.fx_login, app.selected_credential_source.?);
 }
 
-test "app_input_runtime auth picker delegates typed acquisition actions" {
+test "app_input_runtime connections picker delegates typed acquisition actions" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);
     defer app.deinit();
     app.auth.source_inventory = auth_runtime.SourceSet.initMany(&.{ .ai_gateway_api_key, .fx_login });
     app.auth.openPicker(alloc);
+
+    try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
+    try std.testing.expectEqual(auth_runtime.PickerStage.connections, app.auth.pickerView().stage);
 
     try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
 
@@ -3934,7 +3937,7 @@ test "app_input_runtime auth stage Escape pops before closing the picker" {
     app.auth.source_inventory = auth_runtime.SourceSet.initOne(.stored_key);
     app.auth.openPicker(alloc);
 
-    for (0..6) |_| _ = app.auth.movePicker(1);
+    _ = app.auth.movePicker(-1);
     try std.testing.expect((auth_runtime.Choice{ .action = .switch_credential }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
@@ -3955,7 +3958,7 @@ test "app_input_runtime auth stage Escape pops before closing the picker" {
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
 }
 
-test "app_input_runtime disabled change team action stays silent" {
+test "app_input_runtime navigation bypasses disabled change team action" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);
     defer app.deinit();
@@ -3963,14 +3966,14 @@ test "app_input_runtime disabled change team action stays silent" {
     app.auth.openPicker(alloc);
 
     for (0..5) |_| _ = app.auth.movePicker(1);
-    try std.testing.expect((auth_runtime.Choice{ .action = .change_team }).eql(
+    try std.testing.expect((auth_runtime.Choice{ .action = .switch_credential }).eql(
         app.auth.pickerView().selected_choice.?,
     ));
 
     try Runtime(RoutingFakeApp).handleByte(&app, '\r', 4096, 100);
 
     try std.testing.expect(app.auth.pickerView().active);
-    try std.testing.expectEqual(auth_runtime.PickerStage.root, app.auth.pickerView().stage);
+    try std.testing.expectEqual(auth_runtime.PickerStage.switch_credential, app.auth.pickerView().stage);
     try std.testing.expect(app.selected_auth_action == null);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
 }
@@ -7595,7 +7598,7 @@ fn openRoutingAuthPicker(app: *RoutingFakeApp) !void {
     app.auth.source_inventory.insert(.ai_gateway_api_key);
     app.auth.openPicker(app.alloc);
     try std.testing.expect(app.auth.movePicker(1));
-    try std.testing.expectEqual(@as(usize, 7), app.auth.pickerView().choiceCount());
+    try std.testing.expectEqual(@as(usize, 4), app.auth.pickerView().choiceCount());
     try std.testing.expectEqual(@as(usize, 1), app.auth.pickerView().selectedIndex());
 }
 
@@ -7766,9 +7769,9 @@ test "app_input_runtime ctrl+j and ctrl+k navigate visible composer pickers" {
         bytes: []const u8,
         expected_index: usize,
     }{
-        .{ .bytes = "\x0a", .expected_index = 2 },
+        .{ .bytes = "\x0a", .expected_index = 3 },
         .{ .bytes = "\x0b", .expected_index = 0 },
-        .{ .bytes = "\x1b[106;5u", .expected_index = 2 },
+        .{ .bytes = "\x1b[106;5u", .expected_index = 3 },
         .{ .bytes = "\x1b[107;5u", .expected_index = 0 },
     };
 

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -5310,6 +5310,57 @@ test "core.app_render_runtime active skills menu owns a transcript-free alternat
     try std.testing.expectEqual(@as(usize, 3), std.mem.count(u8, terminal_bytes, "\x1b[?1049l"));
 }
 
+test "core.app_render_runtime active setup hub stays on the inline transcript surface" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile(std.testing.io, "setup-inline.log", .{ .read = true });
+    defer file.close(io_mod.getIo());
+
+    var app = CoordinatorTestApp{
+        .alloc = alloc,
+        .shell = .{
+            .stdout_file = file,
+            .layout = .{
+                .rows = 18,
+                .cols = 90,
+                .content_bottom = 14,
+                .divider_top_row = 15,
+                .input_row = 16,
+                .divider_bottom_row = 17,
+                .hint_row = 18,
+            },
+            .owned_top_row = 1,
+            .viewport_top_row = 1,
+        },
+    };
+    defer app.deinit();
+    try app.selected_model.appendSlice(alloc, "test-model");
+    app.auth.openPicker(alloc);
+    try app.shell.initBacking(alloc);
+    try app.shell.enableShadowVt(alloc);
+    try app.shell.writeTranscript(alloc, &app.metrics, "setup transcript stays behind\n", true);
+
+    app.shell.render_requests.request(.footer);
+    try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Setup"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Connections"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Credential source"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Enter Open"));
+    try std.testing.expect(!(try coordinatorGridContains(app.shell.shadow_vt.?.*, "test-model")));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "setup transcript stays behind"));
+
+    app.auth.closePicker(alloc);
+    app.shell.render_requests.request(.footer);
+    try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "setup transcript stays behind"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "test-model"));
+}
+
 test "core.app_render_runtime model catalog survives modal preemption and restores the transcript on close" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1444,6 +1444,7 @@ pub const Runtime = struct {
         credential.team_id = null;
         credential.team_slug = null;
         self.source_inventory.insert(source);
+        if (source == .fx_login) self.fx_login_session_available = true;
         if (source == .stored_key) self.stored_key_status = .not_attempted;
         return changed;
     }
@@ -2450,6 +2451,20 @@ test "setup picker projects the active Vercel team" {
     const current_team = runtime.pickerView().current_team;
     try std.testing.expect(current_team != null);
     try std.testing.expectEqualStrings("team_1", current_team.?);
+}
+
+test "adopting fx login publishes Vercel session availability to setup" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    var credential = try makeTestCredential(alloc, "token", .fx_login, null, null);
+    defer credential.deinit(alloc);
+
+    _ = runtime.adoptCredential(alloc, &credential);
+
+    const picker = runtime.pickerView();
+    try std.testing.expect(picker.fx_login_session_available);
+    try std.testing.expect(picker.choiceEnabled(.{ .action = .change_team }));
 }
 
 test "connections picker closes before returning its typed choice" {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -149,6 +149,7 @@ pub fn refreshCredentialTokenForAccount(
 }
 
 pub const AcquisitionAction = enum {
+    connections,
     login,
     chatgpt_login,
     grok_login,
@@ -163,6 +164,7 @@ pub const AcquisitionAction = enum {
 
 pub const PickerStage = enum {
     root,
+    connections,
     provider,
     sign_in,
     api_key,
@@ -388,11 +390,12 @@ pub const PickerView = struct {
     pub fn choiceCount(self: PickerView) usize {
         return switch (self.stage) {
             .root => if (self.include_skip)
-                if (comptime host_target.is_wasm) 2 else 4
+                connectionChoiceCount()
             else if (comptime host_target.is_wasm)
-                4
+                3
             else
-                7,
+                4,
+            .connections => connectionChoiceCount(),
             .provider => if (comptime host_target.is_wasm) 2 else 3,
             .sign_in, .api_key => 0,
             .change_team => blk: {
@@ -408,38 +411,21 @@ pub const PickerView = struct {
 
     pub fn choiceAt(self: PickerView, index: usize) ?Choice {
         return switch (self.stage) {
-            .root => if (self.include_skip)
-                if (comptime host_target.is_wasm)
-                    switch (index) {
-                        0 => .{ .action = .login },
-                        1 => .{ .action = .setup },
-                        else => null,
-                    }
-                else switch (index) {
-                    0 => .{ .action = .login },
-                    1 => .{ .action = .chatgpt_login },
-                    2 => .{ .action = .grok_login },
-                    3 => .{ .action = .setup },
-                    else => null,
-                }
-            else if (comptime host_target.is_wasm)
+            .root => if (self.include_skip) connectionChoiceAt(index) else if (comptime host_target.is_wasm)
                 switch (index) {
-                    0 => .{ .action = .login },
-                    1 => .{ .action = .setup },
-                    2 => .{ .action = .change_team },
-                    3 => .{ .action = .switch_credential },
+                    0 => .{ .action = .connections },
+                    1 => .{ .action = .change_team },
+                    2 => .{ .action = .switch_credential },
                     else => null,
                 }
             else switch (index) {
-                0 => .{ .action = .login },
-                1 => .{ .action = .chatgpt_login },
-                2 => .{ .action = .grok_login },
-                3 => .{ .action = .setup },
-                4 => .{ .action = .switch_provider },
-                5 => .{ .action = .change_team },
-                6 => .{ .action = .switch_credential },
+                0 => .{ .action = .connections },
+                1 => .{ .action = .switch_provider },
+                2 => .{ .action = .change_team },
+                3 => .{ .action = .switch_credential },
                 else => null,
             },
+            .connections => connectionChoiceAt(index),
             .provider => switch (index) {
                 0 => .{ .provider = .gateway },
                 1 => .{ .provider = .codex },
@@ -484,6 +470,7 @@ pub const PickerView = struct {
             .provider => |provider| provider_catalog.label(provider),
             .source => |source| credentials.sourceLabel(source),
             .action => |action| switch (action) {
+                .connections => "Connections",
                 .login => "Sign in with Vercel",
                 .chatgpt_login => "Sign in with Codex",
                 .grok_login => "Sign in with Grok",
@@ -502,11 +489,12 @@ pub const PickerView = struct {
             .provider => |provider| if (provider == self.active_provider) "current" else "available",
             .source => |source| if (self.active_source == source) "current" else "available",
             .action => |action| switch (action) {
+                .connections => "",
                 .login => if (self.fx_login_session_available) "connected" else "",
                 .chatgpt_login => if (self.available_sources.contains(.chatgpt_subscription)) "connected" else "",
                 .grok_login => if (self.available_sources.contains(.grok_subscription)) "connected" else "",
                 .setup, .switch_credential, .switch_provider => "",
-                .automatic => "use normal precedence",
+                .automatic => "use the first available source",
                 .change_team => if (self.fx_login_session_available) "choose a team" else "sign in first",
             },
             .team => |index| if (self.teamIsCurrent(index)) "current" else "",
@@ -529,6 +517,27 @@ pub const PickerView = struct {
         return std.mem.eql(u8, current, team.id) or std.mem.eql(u8, current, team.slug);
     }
 };
+
+fn connectionChoiceCount() usize {
+    return if (comptime host_target.is_wasm) 2 else 4;
+}
+
+fn connectionChoiceAt(index: usize) ?Choice {
+    if (comptime host_target.is_wasm) {
+        return switch (index) {
+            0 => .{ .action = .login },
+            1 => .{ .action = .setup },
+            else => null,
+        };
+    }
+    return switch (index) {
+        0 => .{ .action = .login },
+        1 => .{ .action = .chatgpt_login },
+        2 => .{ .action = .grok_login },
+        3 => .{ .action = .setup },
+        else => null,
+    };
+}
 
 fn teamMatchesQuery(team: login_flow.Team, query: []const u8) bool {
     return text_utils.containsIgnoreCase(team.name, query) or
@@ -973,7 +982,12 @@ pub const Runtime = struct {
             .stage = self.picker_stage,
             .fx_login_session_available = self.fx_login_session_available,
             .teams = if (self.team_selection) |*selection| selection.teams.items else &.{},
-            .current_team = if (self.team_selection) |*selection| selection.currentTeam() else null,
+            .current_team = if (self.team_selection) |*selection|
+                selection.currentTeam()
+            else if (self.selected_credential) |credential|
+                credential.gatewayTeam()
+            else
+                null,
             .team_query = self.team_query.items,
             .sign_in = self.sign_in_flow.snapshot(),
             .sign_in_source = self.sign_in_source,
@@ -986,15 +1000,20 @@ pub const Runtime = struct {
         const picker = self.pickerView();
         const choice_count = picker.choiceCount();
         if (choice_count < 2) return false;
-        const selected_index = picker.selectedIndex();
-        const next_index = if (delta < 0)
-            if (selected_index == 0) choice_count - 1 else selected_index - 1
-        else if (selected_index + 1 == choice_count)
-            0
-        else
-            selected_index + 1;
-        self.picker_selection = picker.choiceAt(next_index);
-        return true;
+        var next_index = picker.selectedIndex();
+        for (0..choice_count) |_| {
+            next_index = if (delta < 0)
+                if (next_index == 0) choice_count - 1 else next_index - 1
+            else if (next_index + 1 == choice_count)
+                0
+            else
+                next_index + 1;
+            const choice = picker.choiceAt(next_index) orelse continue;
+            if (!picker.choiceEnabled(choice)) continue;
+            self.picker_selection = choice;
+            return true;
+        }
+        return false;
     }
 
     pub fn openTeamPicker(self: *Self, alloc: Allocator, selection: *login_flow.TeamSelection) void {
@@ -1004,6 +1023,15 @@ pub const Runtime = struct {
         self.team_selection = selection.take();
         self.picker_stage = .change_team;
         self.picker_selection = self.currentTeamChoice() orelse self.pickerView().choiceAt(0);
+    }
+
+    fn openConnectionPicker(self: *Self, alloc: Allocator) void {
+        self.exitSignInStage(alloc);
+        self.exitApiKeyStage(alloc, .screen_replacement);
+        self.clearTeamSelection(alloc);
+        self.picker_active = true;
+        self.picker_stage = .connections;
+        self.picker_selection = self.pickerView().choiceAt(0);
     }
 
     pub fn openProviderPicker(
@@ -1236,6 +1264,11 @@ pub const Runtime = struct {
             self.picker_selection = .{ .action = .switch_provider };
             return true;
         }
+        if (stage == .connections) {
+            self.picker_stage = .root;
+            self.picker_selection = .{ .action = .connections };
+            return true;
+        }
 
         if (stage == .sign_in) {
             const returns_to_root = self.sign_in_returns_to_root;
@@ -1245,6 +1278,16 @@ pub const Runtime = struct {
                 self.picker_active = false;
                 self.picker_stage = .root;
                 self.picker_selection = null;
+                return true;
+            }
+            if (!self.picker_include_skip) {
+                self.clearTeamSelection(alloc);
+                self.picker_stage = .connections;
+                self.picker_selection = .{ .action = switch (self.sign_in_source) {
+                    .chatgpt_subscription => .chatgpt_login,
+                    .grok_subscription => .grok_login,
+                    else => .login,
+                } };
                 return true;
             }
         }
@@ -1258,12 +1301,19 @@ pub const Runtime = struct {
                 self.picker_selection = null;
                 return true;
             }
+            if (!self.picker_include_skip) {
+                self.clearTeamSelection(alloc);
+                self.picker_stage = .connections;
+                self.picker_selection = .{ .action = .setup };
+                return true;
+            }
         }
 
         self.clearTeamSelection(alloc);
         self.picker_stage = .root;
         self.picker_selection = .{ .action = switch (stage) {
             .root => unreachable,
+            .connections => unreachable,
             .provider => unreachable,
             .sign_in => if (self.sign_in_source == .chatgpt_subscription)
                 .chatgpt_login
@@ -1295,6 +1345,19 @@ pub const Runtime = struct {
 
         switch (self.picker_stage) {
             .sign_in, .api_key => unreachable,
+            .connections => switch (selected) {
+                .action => |action| switch (action) {
+                    .login, .chatgpt_login, .grok_login => self.closePicker(alloc),
+                    .setup => {},
+                    .connections,
+                    .change_team,
+                    .switch_credential,
+                    .switch_provider,
+                    .automatic,
+                    => unreachable,
+                },
+                .provider, .source, .team => unreachable,
+            },
             .provider => switch (selected) {
                 .provider => self.closePicker(alloc),
                 .source, .action, .team => unreachable,
@@ -1303,6 +1366,10 @@ pub const Runtime = struct {
                 .provider => unreachable,
                 .source => self.closePicker(alloc),
                 .action => |action| switch (action) {
+                    .connections => {
+                        self.openConnectionPicker(alloc);
+                        return null;
+                    },
                     .change_team => {},
                     .switch_provider => {},
                     .switch_credential => {
@@ -2280,7 +2347,7 @@ test "logout reconciliation adopts a newer concurrent fx login" {
     try std.testing.expect(runtime.source_inventory.contains(.fx_login));
 }
 
-test "auth picker root starts on sign in and keeps sources in the switch stage" {
+test "auth picker root exposes four setup sections" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     defer runtime.deinit(alloc);
@@ -2294,10 +2361,8 @@ test "auth picker root starts on sign in and keeps sources in the switch stage" 
 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.active);
-    try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
-    try std.testing.expectEqual(@as(usize, 7), picker.choiceCount());
-    try std.testing.expectEqualStrings("Switch provider", picker.choiceLabel(picker.choiceAt(4).?));
-    try std.testing.expect(picker.choiceAt(7) == null);
+    try std.testing.expect((Choice{ .action = .connections }).eql(picker.selected_choice.?));
+    try std.testing.expectEqual(@as(usize, 4), picker.choiceCount());
 }
 
 test "credential switcher excludes provider-routed subscription sessions" {
@@ -2312,20 +2377,19 @@ test "credential switcher excludes provider-routed subscription sessions" {
     try std.testing.expectEqual(@as(usize, 2), picker.choiceCount());
     try std.testing.expect((Choice{ .source = .ai_gateway_api_key }).eql(picker.choiceAt(0).?));
     try std.testing.expect((Choice{ .action = .automatic }).eql(picker.choiceAt(1).?));
+    try std.testing.expectEqualStrings(
+        "use the first available source",
+        picker.choiceDescription(picker.choiceAt(1).?),
+    );
 }
 
-test "auth picker navigation wraps across the seven hub actions" {
+test "auth picker navigation wraps across the four setup sections" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .fx_login });
+    runtime.fx_login_session_available = true;
     runtime.openPicker(alloc);
 
-    try std.testing.expect(runtime.movePicker(1));
-    try std.testing.expect((Choice{ .action = .chatgpt_login }).eql(runtime.pickerView().selected_choice.?));
-    try std.testing.expect(runtime.movePicker(1));
-    try std.testing.expect((Choice{ .action = .grok_login }).eql(runtime.pickerView().selected_choice.?));
-    try std.testing.expect(runtime.movePicker(1));
-    try std.testing.expect((Choice{ .action = .setup }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expectEqualStrings("Switch provider", runtime.pickerView().choiceLabel(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
@@ -2333,18 +2397,56 @@ test "auth picker navigation wraps across the seven hub actions" {
     try std.testing.expect(runtime.movePicker(1));
     try std.testing.expect((Choice{ .action = .switch_credential }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(1));
-    try std.testing.expect((Choice{ .action = .login }).eql(runtime.pickerView().selected_choice.?));
+    try std.testing.expect((Choice{ .action = .connections }).eql(runtime.pickerView().selected_choice.?));
     try std.testing.expect(runtime.movePicker(-1));
     try std.testing.expect((Choice{ .action = .switch_credential }).eql(runtime.pickerView().selected_choice.?));
 }
 
-test "auth picker selection closes before returning its typed choice" {
+test "auth picker navigation skips disabled hub actions" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    runtime.openPicker(alloc);
+
+    for (0..4) |_| try std.testing.expect(runtime.movePicker(1));
+    try std.testing.expect((Choice{ .action = .switch_provider }).eql(
+        runtime.pickerView().selected_choice.?,
+    ));
+
+    try std.testing.expect(runtime.movePicker(1));
+    try std.testing.expect((Choice{ .action = .switch_credential }).eql(
+        runtime.pickerView().selected_choice.?,
+    ));
+
+    try std.testing.expect(runtime.movePicker(-1));
+    try std.testing.expect((Choice{ .action = .switch_provider }).eql(
+        runtime.pickerView().selected_choice.?,
+    ));
+}
+
+test "setup picker projects the active Vercel team" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    var credential = try makeTestCredential(alloc, "token", .fx_login, "team_1", null);
+    defer credential.deinit(alloc);
+    _ = runtime.adoptCredential(alloc, &credential);
+    runtime.openPicker(alloc);
+
+    const current_team = runtime.pickerView().current_team;
+    try std.testing.expect(current_team != null);
+    try std.testing.expectEqualStrings("team_1", current_team.?);
+}
+
+test "connections picker closes before returning its typed choice" {
     const alloc = std.testing.allocator;
     var runtime: Runtime = .{};
     runtime.source_inventory = SourceSet.initMany(&.{ .ai_gateway_api_key, .fx_login });
 
     try std.testing.expect(runtime.takePickerChoice(alloc) == null);
     runtime.openPicker(alloc);
+    try std.testing.expect(runtime.takePickerChoice(alloc) == null);
+    try std.testing.expectEqual(PickerStage.connections, runtime.pickerView().stage);
 
     try std.testing.expect((Choice{ .action = .login }).eql(runtime.takePickerChoice(alloc).?));
     try std.testing.expect(!runtime.pickerView().active);
@@ -2357,9 +2459,9 @@ test "auth picker without credentials exposes acquisition actions" {
 
     const picker = runtime.pickerView();
     try std.testing.expect(picker.active_source == null);
-    try std.testing.expect((Choice{ .action = .login }).eql(picker.selected_choice.?));
+    try std.testing.expect((Choice{ .action = .connections }).eql(picker.selected_choice.?));
     try std.testing.expectEqual(@as(usize, 0), picker.available_sources.count());
-    try std.testing.expectEqual(@as(usize, 7), picker.choiceCount());
+    try std.testing.expectEqual(@as(usize, 4), picker.choiceCount());
     try std.testing.expect(!picker.choiceEnabled(.{ .action = .change_team }));
     try std.testing.expectEqualStrings("missing", picker.activeSourceLabel());
 }

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -954,6 +954,15 @@ pub const Runtime = struct {
     }
 
     pub fn openPicker(self: *Self, alloc: Allocator) void {
+        self.openPickerForProvider(alloc, .gateway);
+    }
+
+    pub fn openPickerForProvider(
+        self: *Self,
+        alloc: Allocator,
+        active_provider: model_provider.ProviderId,
+    ) void {
+        self.provider_picker_active = active_provider;
         self.openPickerWithSkip(alloc, false);
     }
 
@@ -1224,8 +1233,13 @@ pub const Runtime = struct {
         const returns_to_root = self.api_key_returns_to_root;
         self.exitApiKeyStage(alloc, .saved);
         self.picker_active = returns_to_root;
-        self.picker_stage = .root;
-        self.picker_selection = if (returns_to_root) .{ .action = .setup } else null;
+        if (!returns_to_root or self.picker_include_skip) {
+            self.picker_stage = .root;
+            self.picker_selection = if (returns_to_root) .{ .action = .setup } else null;
+        } else {
+            self.picker_stage = .connections;
+            self.picker_selection = .{ .action = .setup };
+        }
 
         return if (self.api_key_save.start(alloc, key, deps)) .started else .busy;
     }
@@ -2675,6 +2689,33 @@ test "an api key save runs off the event loop and is reaped" {
     try std.testing.expectEqual(@as(usize, 1), fixture.store_calls);
     try std.testing.expect(!runtime.apiKeySaveInFlight());
     try std.testing.expect(runtime.api_key_save.thread == null);
+}
+
+test "api key save from setup returns to the selected Connections row" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    var fixture: ApiKeySaveFixture = .{};
+
+    runtime.openPicker(alloc);
+    try std.testing.expect(runtime.takePickerChoice(alloc) == null);
+    try std.testing.expectEqual(PickerStage.connections, runtime.pickerView().stage);
+    for (0..3) |_| try std.testing.expect(runtime.movePicker(1));
+    try std.testing.expect((Choice{ .action = .setup }).eql(runtime.takePickerChoice(alloc).?));
+
+    runtime.openApiKeyPickerFromRoot(alloc);
+    for ("vck_setup_parent") |byte| _ = try runtime.appendApiKeyByte(alloc, byte);
+    try std.testing.expectEqual(ApiKeySaveStart.started, runtime.beginApiKeySaveWithDeps(alloc, .{
+        .ctx = @ptrCast(&fixture),
+        .validator = fixture.validator(),
+        .store = ApiKeySaveFixture.store,
+        .loader = ApiKeySaveFixture.load,
+    }));
+
+    const picker = runtime.pickerView();
+    try std.testing.expectEqual(PickerStage.connections, picker.stage);
+    try std.testing.expect((Choice{ .action = .setup }).eql(picker.selected_choice.?));
+    try std.testing.expect(picker.choiceIsSelected(picker.choiceAt(3).?));
 }
 
 test "auth runtime saves and reloads through its injected secret store" {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -1030,6 +1030,7 @@ pub const Runtime = struct {
         self.exitApiKeyStage(alloc, .screen_replacement);
         self.clearTeamSelection(alloc);
         self.team_selection = selection.take();
+        self.picker_include_skip = false;
         self.picker_stage = .change_team;
         self.picker_selection = self.currentTeamChoice() orelse self.pickerView().choiceAt(0);
     }
@@ -2598,6 +2599,26 @@ test "change team stage owns fetched rows and releases them when popped" {
     try std.testing.expect(runtime.popPickerStage(alloc));
     try std.testing.expectEqual(PickerStage.root, runtime.pickerView().stage);
     try std.testing.expectEqual(@as(usize, 0), runtime.pickerView().teams.len);
+}
+
+test "team selection reached from onboarding returns to the setup hub" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    runtime.fx_login_session_available = true;
+    runtime.openOnboardingPicker(alloc);
+
+    var selection: login_flow.TeamSelection = .{};
+    defer selection.deinit(alloc);
+    try appendTestTeam(&selection, alloc, "team_123", "vercel-labs", "Vercel Labs");
+    runtime.openTeamPicker(alloc, &selection);
+
+    try std.testing.expect(runtime.popPickerStage(alloc));
+    const root = runtime.pickerView();
+    try std.testing.expectEqual(PickerStage.root, root.stage);
+    try std.testing.expect(!root.include_skip);
+    try std.testing.expect((Choice{ .action = .change_team }).eql(root.selected_choice.?));
+    try std.testing.expect(root.choiceEnabled(root.selected_choice.?));
 }
 
 test "change team search filters by name and slug without losing original indexes" {

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -199,9 +199,9 @@ const FxLoginRefreshMode = enum { if_needed, force };
 pub const missing_credential_message = "Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.";
 pub const missing_interactive_credential_message = "Fx needs access to Vercel AI Gateway. Run /login to sign in, /setup to use an API key, or set AI_GATEWAY_API_KEY.";
 pub const missing_chatgpt_credential_message = "fx needs a Codex subscription login for this model. Run fx login codex.";
-pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login and choose Sign in with Codex.";
+pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login, open Connections, then choose Codex subscription.";
 pub const missing_grok_credential_message = "fx needs a Grok subscription login for this model. Run fx login grok.";
-pub const missing_grok_interactive_credential_message = "Grok needs a subscription login. Run /login and choose Sign in with Grok.";
+pub const missing_grok_interactive_credential_message = "Grok needs a subscription login. Run /login, open Connections, then choose Grok subscription.";
 pub const unreadable_store_message = "Fx could not read the stored API key from " ++ stored_key_backend_label ++ ". A key may be saved but unreadable. Set FX_TRACE_LOG for the failing step, or set AI_GATEWAY_API_KEY.";
 
 pub const Credential = struct {

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const question_prompt = @import("../../core/agent/question_prompt.zig");
+const auth_runtime = @import("../../core/auth/auth_runtime.zig");
 const image_attachments = @import("../../core/images/image_attachments.zig");
 const command_specs = @import("../../core/slash_commands/command_specs.zig");
 const display_width = @import("../../core/shared/display_width.zig");
@@ -293,6 +294,46 @@ pub fn measureRawInputGeometry(
     };
 }
 
+fn authPickerInteractionHint(view: auth_runtime.PickerView, width: u16) ?[]const u8 {
+    if (!view.active or view.include_skip) return null;
+
+    const root_variants = [_][]const u8{
+        "↑↓ Navigate     Enter Open     Esc Close",
+        "↑↓ Move  Enter Open  Esc",
+        "Enter Open  Esc Close",
+        "Enter Esc",
+    };
+    const connections_variants = [_][]const u8{
+        "↑↓ Navigate     Enter Open     Esc Back",
+        "↑↓ Move  Enter Open  Esc",
+        "Enter Open  Esc Back",
+        "Enter Esc",
+    };
+    const selection_variants = [_][]const u8{
+        "↑↓ Navigate     Enter Use     Esc Back",
+        "↑↓ Move  Enter Use  Esc",
+        "Enter Use  Esc Back",
+        "Enter Esc",
+    };
+    const team_variants = [_][]const u8{
+        "Type to search     ↑↓ Navigate     Enter Use     Esc Back",
+        "Type  ↑↓ Move  Enter  Esc",
+        "↑↓ Move  Enter  Esc",
+        "Enter Esc",
+    };
+    const variants = switch (view.stage) {
+        .root => root_variants,
+        .connections => connections_variants,
+        .provider, .switch_credential => selection_variants,
+        .change_team => team_variants,
+        .sign_in, .api_key => return null,
+    };
+    for (variants) |candidate| {
+        if (display_width.visibleWidth(candidate) <= width) return candidate;
+    }
+    return variants[variants.len - 1];
+}
+
 pub fn composeHintRow(
     alloc: Allocator,
     approval_active: bool,
@@ -303,6 +344,10 @@ pub fn composeHintRow(
     var question_hint_buf: [512]u8 = undefined;
     const question_hint = if (ctx.question) |projection|
         questionInteractionHint(projection, width, &question_hint_buf)
+    else
+        null;
+    const auth_hint = if (!approval_active and question_hint == null and !ctx.ctrl_c_pending)
+        authPickerInteractionHint(ctx.auth_picker, width)
     else
         null;
     var hint_buf: [max_status_line_len]u8 = undefined;
@@ -327,6 +372,8 @@ pub fn composeHintRow(
         hint
     else if (ctx.ctrl_c_pending)
         "press ctrl+c again to exit"
+    else if (auth_hint) |hint|
+        hint
     else if (ctx.selected_subagent_label) |label|
         if (ctx.selected_subagent_status) |status|
             std.fmt.bufPrint(
@@ -1383,6 +1430,32 @@ test "compose hint row keeps model in left hint text" {
     try std.testing.expect(std.mem.startsWith(u8, row.items, ui_render.statusline_style));
     try std.testing.expect(std.mem.find(u8, row.items, "gpt-5.1 · ⚡︎") != null);
     try std.testing.expect(std.mem.find(u8, row.items, "\x1b[14G") == null);
+}
+
+test "compose hint row replaces model status with setup navigation" {
+    var input = InputRuntime{};
+    defer input.deinit(std.testing.allocator);
+    var ctx = testRenderContext(&input);
+    ctx.auth_picker = .{
+        .active = true,
+        .available_sources = .empty,
+        .selected_choice = .{ .action = .connections },
+        .active_source = null,
+        .include_skip = false,
+    };
+
+    var root = try composeHintRow(std.testing.allocator, false, null, ctx, 96);
+    defer root.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.find(u8, root.items, "↑↓ Navigate") != null);
+    try std.testing.expect(std.mem.find(u8, root.items, "Enter Open") != null);
+    try std.testing.expect(std.mem.find(u8, root.items, "Esc Close") != null);
+    try std.testing.expect(std.mem.find(u8, root.items, "gpt-5.1") == null);
+
+    ctx.auth_picker.stage = .connections;
+    ctx.auth_picker.selected_choice = .{ .action = .login };
+    var child = try composeHintRow(std.testing.allocator, false, null, ctx, 96);
+    defer child.deinit(std.testing.allocator);
+    try std.testing.expect(std.mem.find(u8, child.items, "Esc Back") != null);
 }
 
 test "compose hint row uses dots in subagent view" {

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -266,12 +266,14 @@ pub noinline fn composeAuthPickerRow(
     width: u16,
 ) !std.ArrayList(u8) {
     if (view.stage == .sign_in) {
+        const source_row_index = signInProjectedRowIndex(view.sign_in, row_index, row_count);
         return composeSignInPickerRow(
             alloc,
             view.sign_in,
             view.sign_in_source,
             view.sign_in_code_mask_count,
-            row_index,
+            source_row_index,
+            row_count,
             width,
         );
     }
@@ -285,6 +287,28 @@ pub noinline fn composeAuthPickerRow(
         return composeSetupPickerRow(alloc, view, row_index, row_count, width);
     }
     unreachable;
+}
+
+fn signInProjectedRowIndex(snapshot: login_flow.SignInSnapshot, row_index: u16, row_count: u16) u16 {
+    if (row_count >= 7) return row_index;
+
+    const manual_code_priority = [_]u16{ 4, 6, 3, 0, 2, 5, 1 };
+    const device_code_priority = [_]u16{ 2, 3, 6, 0, 5, 1, 4 };
+    const priority = if (snapshot.accepts_manual_code)
+        manual_code_priority
+    else
+        device_code_priority;
+
+    var projected_index: u16 = 0;
+    for (0..7) |source_row| {
+        for (priority[0..@min(row_count, priority.len)]) |included_row| {
+            if (source_row != included_row) continue;
+            if (projected_index == row_index) return @intCast(source_row);
+            projected_index += 1;
+            break;
+        }
+    }
+    return 6;
 }
 
 const onboarding_note = "   ⚠︎ Note: fx is experimental and defaults to auto mode.";
@@ -369,6 +393,7 @@ fn composeSignInPickerRow(
     source: credentials.Source,
     manual_code_mask_count: usize,
     row_index: u16,
+    row_count: u16,
     width: u16,
 ) !std.ArrayList(u8) {
     var row: std.ArrayList(u8) = .empty;
@@ -406,11 +431,19 @@ fn composeSignInPickerRow(
     }
     if (accepts_manual_code and row_index == 4) {
         try row_text.appendClipped(alloc, &row, "   ┃ ", width);
+        var used: u16 = @min(5, width);
         if (manual_code_mask_count == 0) {
             try row.appendSlice(alloc, ui_render.dim_style);
-            try row_text.appendClipped(alloc, &row, "Paste or type the code", width -| 5);
+            const placeholder = "Paste or type the code";
+            try row_text.appendClipped(alloc, &row, placeholder, width -| used);
+            used +|= @intCast(@min(display_width.visibleWidth(placeholder), width -| used));
         } else {
-            for (0..@min(manual_code_mask_count, width -| 5)) |_| try row.appendSlice(alloc, "•");
+            const visible_mask_count = @min(manual_code_mask_count, width -| used);
+            for (0..visible_mask_count) |_| try row.appendSlice(alloc, "•");
+            used +|= @intCast(visible_mask_count);
+        }
+        if (row_count == 1 and used < width) {
+            try row_text.appendClipped(alloc, &row, " · Enter submits · Esc cancels", width - used);
         }
         try row.appendSlice(alloc, ui_render.reset_style);
         return row;
@@ -2109,6 +2142,32 @@ test "Codex sign-in stage renders a bounded clickable authorization action" {
     var hint = try composeAuthPickerRow(alloc, view, 6, authPickerRowCount(view), 80);
     defer hint.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, hint.items, "Enter submits or reopens browser") != null);
+}
+
+test "compact Grok sign-in keeps masked code entry and controls visible" {
+    const alloc = std.testing.allocator;
+    const view = auth_runtime.PickerView{
+        .active = true,
+        .available_sources = .empty,
+        .selected_choice = null,
+        .active_source = null,
+        .include_skip = false,
+        .stage = .sign_in,
+        .sign_in_source = .grok_subscription,
+        .sign_in = .{
+            .state = .polling,
+            .verification_uri = "https://x.ai/authorize",
+            .accepts_manual_code = true,
+        },
+        .sign_in_code_mask_count = 3,
+    };
+
+    var row = try composeAuthPickerRow(alloc, view, 0, 1, 80);
+    defer row.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, row.items, "•••") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "Enter submits") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "Esc cancels") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, ui_render.selected_completion_style) != null);
 }
 
 test "partially visible auth picker shows a source window without duplicates" {

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -13,7 +13,7 @@ const input_presentation = @import("input_presentation.zig");
 const row_text = @import("row_text.zig");
 
 const Allocator = std.mem.Allocator;
-const team_query_prefix = "   Choose a Vercel team · Search: ";
+const team_query_prefix = "Vercel team · Search: ";
 const compact_team_query_prefix = "Search: ";
 
 const TeamQueryProjection = struct {
@@ -56,7 +56,206 @@ pub fn authPickerRowCount(view: auth_runtime.PickerView) u16 {
     if (view.stage == .sign_in) return 7;
     if (view.stage == .api_key) return 4;
     if (view.stage == .root and view.include_skip) return 18;
+    if (isSetupListStage(view.stage)) return @intCast(2 + @max(view.choiceCount(), 1));
     return @intCast(1 + @max(view.choiceCount(), 1));
+}
+
+fn isSetupListStage(stage: auth_runtime.PickerStage) bool {
+    return switch (stage) {
+        .root, .connections, .provider, .change_team, .switch_credential => true,
+        .sign_in, .api_key => false,
+    };
+}
+
+fn setupChoiceLabel(view: auth_runtime.PickerView, choice: auth_runtime.Choice) []const u8 {
+    return switch (view.stage) {
+        .root => switch (choice) {
+            .action => |action| switch (action) {
+                .connections => "Connections",
+                .switch_provider => "Model provider",
+                .change_team => "Vercel team",
+                .switch_credential => "Credential source",
+                .login, .chatgpt_login, .grok_login, .setup, .automatic => "",
+            },
+            .provider, .source, .team => "",
+        },
+        .connections => switch (choice) {
+            .action => |action| switch (action) {
+                .login => "Vercel account",
+                .chatgpt_login => "Codex subscription",
+                .grok_login => "Grok subscription",
+                .setup => "AI Gateway API key",
+                .connections, .change_team, .switch_credential, .switch_provider, .automatic => "",
+            },
+            .provider, .source, .team => "",
+        },
+        .provider, .change_team, .switch_credential => view.choiceLabel(choice),
+        .sign_in, .api_key => "",
+    };
+}
+
+fn setupChoiceValue(view: auth_runtime.PickerView, choice: auth_runtime.Choice) []const u8 {
+    return switch (view.stage) {
+        .root => switch (choice) {
+            .action => |action| switch (action) {
+                .connections => if (view.available_sources.count() > 0) "connected" else "not connected",
+                .switch_provider => view.choiceLabel(.{ .provider = view.active_provider }),
+                .change_team => if (!view.fx_login_session_available)
+                    "sign in to manage"
+                else if (view.current_team != null)
+                    "selected"
+                else
+                    "choose a team",
+                .switch_credential => if (view.active_source != null)
+                    view.activeSourceLabel()
+                else
+                    "not connected",
+                .login, .chatgpt_login, .grok_login, .setup, .automatic => "",
+            },
+            .provider, .source, .team => "",
+        },
+        .connections => switch (choice) {
+            .action => |action| switch (action) {
+                .login => if (view.fx_login_session_available) "connected" else "not connected",
+                .chatgpt_login => if (view.available_sources.contains(.chatgpt_subscription)) "connected" else "not connected",
+                .grok_login => if (view.available_sources.contains(.grok_subscription)) "connected" else "not connected",
+                .setup => if (view.available_sources.contains(.stored_key))
+                    "stored"
+                else if (view.available_sources.contains(.ai_gateway_api_key))
+                    "environment"
+                else
+                    "not configured",
+                .connections, .change_team, .switch_credential, .switch_provider, .automatic => "",
+            },
+            .provider, .source, .team => "",
+        },
+        .provider, .change_team, .switch_credential => view.choiceDescription(choice),
+        .sign_in, .api_key => "",
+    };
+}
+
+fn setupValueColumn(width: u16) usize {
+    const width_usize: usize = width;
+    const minimum = display_width.visibleWidth("  AI Gateway API key") + 2;
+    return @min(width_usize, @max(width_usize * 2 / 3, minimum));
+}
+
+fn composeSetupChoiceRow(
+    alloc: Allocator,
+    view: auth_runtime.PickerView,
+    choice: auth_runtime.Choice,
+    width: u16,
+) !std.ArrayList(u8) {
+    var row: std.ArrayList(u8) = .empty;
+    errdefer row.deinit(alloc);
+    if (width == 0) return row;
+
+    const selected = view.choiceIsSelected(choice);
+    const enabled = view.choiceEnabled(choice);
+    const style = if (selected and enabled) ui_render.selected_completion_style else ui_render.dim_style;
+    try row.appendSlice(alloc, style);
+    try row.appendSlice(alloc, if (selected and enabled) "› " else "  ");
+
+    const value_col = setupValueColumn(width);
+    const label_width = value_col -| 2;
+    try row_text.appendSingleLineEllipsized(
+        alloc,
+        &row,
+        setupChoiceLabel(view, choice),
+        label_width,
+    );
+    try row.appendSlice(alloc, ui_render.reset_style);
+
+    if (value_col < width) {
+        try row_text.appendSpacesToColumn(alloc, &row, value_col);
+        try row.appendSlice(alloc, style);
+        try row_text.appendSingleLineEllipsized(
+            alloc,
+            &row,
+            setupChoiceValue(view, choice),
+            @as(usize, width) - value_col,
+        );
+        try row.appendSlice(alloc, ui_render.reset_style);
+    }
+    return row;
+}
+
+fn composeSetupHeaderRow(
+    alloc: Allocator,
+    view: auth_runtime.PickerView,
+    width: u16,
+) !std.ArrayList(u8) {
+    var row: std.ArrayList(u8) = .empty;
+    errdefer row.deinit(alloc);
+    try row.appendSlice(alloc, ui_render.dim_style);
+    if (view.stage == .change_team) {
+        const projection = teamQueryProjection(view.team_query, width);
+        try row_text.appendClipped(alloc, &row, projection.prefix, width);
+        const remaining: u16 = width -| @as(u16, @intCast(display_width.visibleWidth(projection.prefix)));
+        try row_text.appendClipped(alloc, &row, projection.query, remaining);
+    } else {
+        const heading = switch (view.stage) {
+            .root => "Setup",
+            .connections => "Connections",
+            .provider => "Model provider",
+            .switch_credential => "Credential source",
+            .sign_in, .api_key, .change_team => unreachable,
+        };
+        try row_text.appendClipped(alloc, &row, heading, width);
+    }
+    try row.appendSlice(alloc, ui_render.reset_style);
+    return row;
+}
+
+fn composeSetupEmptyRow(
+    alloc: Allocator,
+    view: auth_runtime.PickerView,
+    width: u16,
+) !std.ArrayList(u8) {
+    var row: std.ArrayList(u8) = .empty;
+    errdefer row.deinit(alloc);
+    try row.appendSlice(alloc, ui_render.dim_style);
+    try row_text.appendClipped(alloc, &row, switch (view.stage) {
+        .provider => "  No providers available",
+        .change_team => if (view.team_query.len == 0)
+            "  No Vercel teams available"
+        else
+            "  No matching Vercel teams",
+        .switch_credential => "  No credentials available",
+        .root, .connections, .sign_in, .api_key => "",
+    }, width);
+    try row.appendSlice(alloc, ui_render.reset_style);
+    return row;
+}
+
+fn composeSetupPickerRow(
+    alloc: Allocator,
+    view: auth_runtime.PickerView,
+    row_index: u16,
+    row_count: u16,
+    width: u16,
+) !std.ArrayList(u8) {
+    if (width == 0 or row_index >= row_count) return .empty;
+    if (row_count == 1) {
+        if (view.stage == .change_team) return composeSetupHeaderRow(alloc, view, width);
+        const selected = view.selected_choice orelse return composeSetupEmptyRow(alloc, view, width);
+        return composeSetupChoiceRow(alloc, view, selected, width);
+    }
+    if (row_index == 0) return composeSetupHeaderRow(alloc, view, width);
+
+    const choice_start: u16 = if (row_count >= 3) 2 else 1;
+    if (row_index < choice_start) return .empty;
+    if (view.choiceCount() == 0) return composeSetupEmptyRow(alloc, view, width);
+
+    const window = pickerWindow(
+        view.choiceCount(),
+        view.selectedIndex(),
+        row_count - choice_start,
+    );
+    const choice_index = window.start + row_index - choice_start;
+    if (choice_index >= window.end) return .empty;
+    const choice = view.choiceAt(choice_index) orelse return .empty;
+    return composeSetupChoiceRow(alloc, view, choice, width);
 }
 
 pub noinline fn composeAuthPickerRow(
@@ -75,82 +274,10 @@ pub noinline fn composeAuthPickerRow(
     if (view.stage == .root and view.include_skip) {
         return composeOnboardingPickerRow(alloc, view, row_index, row_count, width);
     }
-
-    var row: std.ArrayList(u8) = .empty;
-    if (width == 0) return row;
-
-    const show_header = row_index == 0 and (row_count > 1 or view.stage == .change_team);
-    if (show_header) {
-        try row.appendSlice(alloc, ui_render.dim_style);
-        if (view.stage == .change_team) {
-            const projection = teamQueryProjection(view.team_query, width);
-            try row_text.appendClipped(alloc, &row, projection.prefix, width);
-            const remaining: u16 = width -| @as(u16, @intCast(display_width.visibleWidth(projection.prefix)));
-            try row_text.appendClipped(alloc, &row, projection.query, remaining);
-            try row.appendSlice(alloc, ui_render.reset_style);
-            return row;
-        }
-        const header = switch (view.stage) {
-            .root => "   Setup",
-            .provider => "   Switch provider",
-            .sign_in => unreachable,
-            .api_key => unreachable,
-            .change_team => unreachable,
-            .switch_credential => "   Use this credential",
-        };
-        try row_text.appendClipped(alloc, &row, header, width);
-        try row.appendSlice(alloc, ui_render.reset_style);
-        return row;
+    if (isSetupListStage(view.stage)) {
+        return composeSetupPickerRow(alloc, view, row_index, row_count, width);
     }
-
-    const maybe_choice = if (row_count == 1)
-        view.selected_choice
-    else if (row_index > 0) blk: {
-        const window = pickerWindow(view.choiceCount(), view.selectedIndex(), row_count - 1);
-        const choice_index = window.start + row_index - 1;
-        if (choice_index >= window.end) break :blk null;
-        break :blk view.choiceAt(choice_index);
-    } else null;
-    const choice = maybe_choice orelse {
-        try row.appendSlice(alloc, ui_render.dim_style);
-        try row_text.appendClipped(alloc, &row, switch (view.stage) {
-            .root => "",
-            .provider => "     No providers available",
-            .sign_in => unreachable,
-            .api_key => unreachable,
-            .change_team => if (view.team_query.len == 0)
-                "     No Vercel teams available"
-            else
-                "     No matching Vercel teams",
-            .switch_credential => "     No credentials available",
-        }, width);
-        try row.appendSlice(alloc, ui_render.reset_style);
-        return row;
-    };
-
-    const selected = view.choiceIsSelected(choice);
-    const enabled = view.choiceEnabled(choice);
-    try row.appendSlice(
-        alloc,
-        if (selected and enabled) ui_render.selected_completion_style else ui_render.dim_style,
-    );
-
-    var label_buf: [96]u8 = undefined;
-    const label = std.fmt.bufPrint(
-        &label_buf,
-        "{s}{s}",
-        .{ if (selected) "   › " else "     ", view.choiceLabel(choice) },
-    ) catch view.choiceLabel(choice);
-    try row_text.appendClipped(alloc, &row, label, width);
-
-    const description_col = authPickerDescriptionColumn(view);
-    if (width >= description_col) {
-        try row_text.appendAbsoluteColumn(alloc, &row, description_col);
-        const description = view.choiceDescription(choice);
-        try row_text.appendClipped(alloc, &row, description, width - description_col + 1);
-    }
-    try row.appendSlice(alloc, ui_render.reset_style);
-    return row;
+    unreachable;
 }
 
 const onboarding_note = "   ⚠︎ Note: fx is experimental and defaults to auto mode.";
@@ -343,16 +470,6 @@ fn composeApiKeyPickerRow(
     }
     try row.appendSlice(alloc, ui_render.reset_style);
     return row;
-}
-
-fn authPickerDescriptionColumn(view: auth_runtime.PickerView) u16 {
-    var column: usize = 31;
-    var index: usize = 0;
-    while (view.choiceAt(index)) |choice| : (index += 1) {
-        const label_end = 5 + display_width.visibleWidth(view.choiceLabel(choice));
-        column = @max(column, label_end + 2);
-    }
-    return @intCast(@min(column, std.math.maxInt(u16)));
 }
 
 pub fn pickerRowCount(completion_count: usize) u16 {
@@ -1642,50 +1759,88 @@ test "auth onboarding composes the welcome copy and setup choices" {
     try std.testing.expect(std.mem.find(u8, screen.items, "Sign in with Grok") != null);
 }
 
-test "auth picker composes only detected credential sources" {
+test "setup root shows prerequisites and active routing values" {
     const alloc = std.testing.allocator;
     const view = auth_runtime.PickerView{
         .active = true,
-        .available_sources = auth_runtime.SourceSet.initMany(&.{ .ai_gateway_api_key, .fx_login }),
-        .selected_choice = .{ .source = .fx_login },
-        .active_source = .fx_login,
+        .available_sources = auth_runtime.SourceSet.initOne(.ai_gateway_api_key),
+        .selected_choice = .{ .action = .switch_provider },
+        .active_source = .ai_gateway_api_key,
         .include_skip = false,
     };
     const row_count = authPickerRowCount(view);
-    try std.testing.expectEqual(@as(u16, 8), row_count);
+    try std.testing.expectEqual(@as(u16, 6), row_count);
 
     var header = try composeAuthPickerRow(alloc, view, 0, row_count, 80);
     defer header.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, header.items, "Setup") != null);
 
-    var sign_in = try composeAuthPickerRow(alloc, view, 1, row_count, 80);
-    defer sign_in.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, sign_in.items, "Sign in with Vercel") != null);
+    var provider = try composeAuthPickerRow(alloc, view, 3, row_count, 80);
+    defer provider.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, provider.items, "Model provider") != null);
+    try std.testing.expect(std.mem.find(u8, provider.items, "Vercel AI Gateway") != null);
 
-    var chatgpt = try composeAuthPickerRow(alloc, view, 2, row_count, 80);
-    defer chatgpt.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, chatgpt.items, "Sign in with Codex") != null);
+    var team = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
+    defer team.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, team.items, "Vercel team") != null);
+    try std.testing.expect(std.mem.find(u8, team.items, "sign in to manage") != null);
 
-    var grok = try composeAuthPickerRow(alloc, view, 3, row_count, 80);
-    defer grok.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, grok.items, "Sign in with Grok") != null);
+    var credential = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
+    defer credential.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, credential.items, "Credential source") != null);
+    try std.testing.expect(std.mem.find(u8, credential.items, "AI_GATEWAY_API_KEY") != null);
+}
 
-    var setup = try composeAuthPickerRow(alloc, view, 4, row_count, 80);
-    defer setup.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, setup.items, "API key") != null);
+test "setup root fits the inline picker with status and controls" {
+    const alloc = std.testing.allocator;
+    const view = auth_runtime.PickerView{
+        .active = true,
+        .available_sources = auth_runtime.SourceSet.initMany(&.{ .chatgpt_subscription, .stored_key }),
+        .selected_choice = .{ .action = .connections },
+        .active_source = .stored_key,
+        .active_provider = .codex,
+        .include_skip = false,
+    };
+    const row_count = authPickerRowCount(view);
+    try std.testing.expectEqual(@as(u16, 6), row_count);
 
-    var switch_provider = try composeAuthPickerRow(alloc, view, 5, row_count, 80);
-    defer switch_provider.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, switch_provider.items, "Switch provider") != null);
+    var screen: std.ArrayList(u8) = .empty;
+    defer screen.deinit(alloc);
+    for (0..row_count) |row_index| {
+        var row = try composeAuthPickerRow(alloc, view, @intCast(row_index), row_count, 100);
+        defer row.deinit(alloc);
+        try screen.appendSlice(alloc, row.items);
+        try screen.append(alloc, '\n');
+    }
 
-    var change_team = try composeAuthPickerRow(alloc, view, 6, row_count, 80);
-    defer change_team.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, change_team.items, "Change team") != null);
-    try std.testing.expect(std.mem.find(u8, change_team.items, "sign in first") != null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Connections") != null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Model provider") != null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Vercel team") != null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Credential source") != null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Enter Open") == null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Esc Close") == null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Routing") == null);
+    try std.testing.expect(std.mem.find(u8, screen.items, "Vercel account") == null);
 
-    var switch_credential = try composeAuthPickerRow(alloc, view, 7, row_count, 80);
-    defer switch_credential.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, switch_credential.items, "Switch credential") != null);
+    var gap = try composeAuthPickerRow(alloc, view, 1, row_count, 100);
+    defer gap.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), gap.items.len);
+
+    var header = try composeAuthPickerRow(alloc, view, 0, row_count, 100);
+    defer header.deinit(alloc);
+    const heading_start = std.mem.find(u8, header.items, "Setup").?;
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        display_width.visibleWidthIgnoringAnsi(header.items[0..heading_start]),
+    );
+
+    var selected = try composeAuthPickerRow(alloc, view, 2, row_count, 100);
+    defer selected.deinit(alloc);
+    const marker_start = std.mem.find(u8, selected.items, "›").?;
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        display_width.visibleWidthIgnoringAnsi(selected.items[0..marker_start]),
+    );
 }
 
 test "compact auth picker keeps the selected hub action visible" {
@@ -1701,11 +1856,43 @@ test "compact auth picker keeps the selected hub action visible" {
     var row = try composeAuthPickerRow(alloc, view, 0, 1, 80);
     defer row.deinit(alloc);
 
-    try std.testing.expect(std.mem.find(u8, row.items, "Switch credential") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "Credential source") != null);
 }
 
 test "auth picker renders the staged switch and disabled team screens" {
     const alloc = std.testing.allocator;
+
+    const provider_view = auth_runtime.PickerView{
+        .active = true,
+        .available_sources = .empty,
+        .selected_choice = .{ .provider = .gateway },
+        .active_source = null,
+        .active_provider = .gateway,
+        .include_skip = false,
+        .stage = .provider,
+    };
+    const provider_rows = authPickerRowCount(provider_view);
+    try std.testing.expectEqual(@as(u16, 5), provider_rows);
+    var provider_header = try composeAuthPickerRow(alloc, provider_view, 0, provider_rows, 80);
+    defer provider_header.deinit(alloc);
+    try std.testing.expect(std.mem.startsWith(u8, provider_header.items, ui_render.dim_style));
+    const provider_heading = std.mem.find(u8, provider_header.items, "Model provider").?;
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        display_width.visibleWidthIgnoringAnsi(provider_header.items[0..provider_heading]),
+    );
+    var provider_gap = try composeAuthPickerRow(alloc, provider_view, 1, provider_rows, 80);
+    defer provider_gap.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), provider_gap.items.len);
+    var provider_selected = try composeAuthPickerRow(alloc, provider_view, 2, provider_rows, 80);
+    defer provider_selected.deinit(alloc);
+    const provider_marker = std.mem.find(u8, provider_selected.items, "›").?;
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        display_width.visibleWidthIgnoringAnsi(provider_selected.items[0..provider_marker]),
+    );
+    try std.testing.expect(std.mem.find(u8, provider_selected.items, "current") != null);
+
     const switch_view = auth_runtime.PickerView{
         .active = true,
         .available_sources = auth_runtime.SourceSet.initOne(.stored_key),
@@ -1714,19 +1901,20 @@ test "auth picker renders the staged switch and disabled team screens" {
         .include_skip = false,
         .stage = .switch_credential,
     };
-
-    var switch_header = try composeAuthPickerRow(alloc, switch_view, 0, 2, 80);
+    const switch_rows = authPickerRowCount(switch_view);
+    try std.testing.expectEqual(@as(u16, 4), switch_rows);
+    var switch_header = try composeAuthPickerRow(alloc, switch_view, 0, switch_rows, 80);
     defer switch_header.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, switch_header.items, "Use this credential") != null);
+    try std.testing.expect(std.mem.find(u8, switch_header.items, "Credential source") != null);
 
-    var switch_source = try composeAuthPickerRow(alloc, switch_view, 1, 2, 80);
+    var switch_gap = try composeAuthPickerRow(alloc, switch_view, 1, switch_rows, 80);
+    defer switch_gap.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), switch_gap.items.len);
+
+    var switch_source = try composeAuthPickerRow(alloc, switch_view, 2, switch_rows, 80);
     defer switch_source.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, switch_source.items, credentials.sourceLabel(.stored_key)) != null);
     try std.testing.expect(std.mem.find(u8, switch_source.items, "current") != null);
-    try std.testing.expect(
-        authPickerDescriptionColumn(switch_view) >
-            5 + display_width.visibleWidth(credentials.sourceLabel(.stored_key)),
-    );
 
     const team_view = auth_runtime.PickerView{
         .active = true,
@@ -1736,22 +1924,28 @@ test "auth picker renders the staged switch and disabled team screens" {
         .include_skip = false,
         .stage = .change_team,
     };
-    var team_header = try composeAuthPickerRow(alloc, team_view, 0, 2, 80);
+    const team_rows = authPickerRowCount(team_view);
+    try std.testing.expectEqual(@as(u16, 3), team_rows);
+    var team_header = try composeAuthPickerRow(alloc, team_view, 0, team_rows, 80);
     defer team_header.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, team_header.items, "Choose a Vercel team") != null);
+    try std.testing.expect(std.mem.find(u8, team_header.items, "Vercel team · Search:") != null);
 
-    var no_teams = try composeAuthPickerRow(alloc, team_view, 1, 2, 80);
+    var team_gap = try composeAuthPickerRow(alloc, team_view, 1, team_rows, 80);
+    defer team_gap.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), team_gap.items.len);
+
+    var no_teams = try composeAuthPickerRow(alloc, team_view, 2, team_rows, 80);
     defer no_teams.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, no_teams.items, "No Vercel teams available") != null);
 
     var search_view = team_view;
     search_view.team_query = "play";
-    var search_header = try composeAuthPickerRow(alloc, search_view, 0, 2, 80);
+    var search_header = try composeAuthPickerRow(alloc, search_view, 0, team_rows, 80);
     defer search_header.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, search_header.items, "Search: play") != null);
 
     search_view.team_query = "example-internal-team";
-    var narrow_search_header = try composeAuthPickerRow(alloc, search_view, 0, 2, 20);
+    var narrow_search_header = try composeAuthPickerRow(alloc, search_view, 0, team_rows, 20);
     defer narrow_search_header.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow_search_header.items, "nternal-team") != null);
     try std.testing.expectEqual(
@@ -1759,7 +1953,7 @@ test "auth picker renders the staged switch and disabled team screens" {
         authPickerQueryCursorColumn(search_view, 20).?,
     );
 
-    var no_matches = try composeAuthPickerRow(alloc, search_view, 1, 2, 80);
+    var no_matches = try composeAuthPickerRow(alloc, search_view, 2, team_rows, 80);
     defer no_matches.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, no_matches.items, "No matching Vercel teams") != null);
 }
@@ -1889,22 +2083,22 @@ test "partially visible auth picker shows a source window without duplicates" {
         .stage = .switch_credential,
     };
 
-    var first_source = try composeAuthPickerRow(alloc, view, 1, 3, 80);
+    var first_source = try composeAuthPickerRow(alloc, view, 2, 4, 80);
     defer first_source.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, first_source.items, "AI_GATEWAY_API_KEY") != null);
     try std.testing.expect(std.mem.find(u8, first_source.items, "fx login") == null);
 
-    var selected_source = try composeAuthPickerRow(alloc, view, 2, 3, 80);
+    var selected_source = try composeAuthPickerRow(alloc, view, 3, 4, 80);
     defer selected_source.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, selected_source.items, "fx login") != null);
 
     var scrolled_view = view;
     scrolled_view.selected_choice = .{ .source = .stored_key };
-    var scrolled_first = try composeAuthPickerRow(alloc, scrolled_view, 1, 3, 80);
+    var scrolled_first = try composeAuthPickerRow(alloc, scrolled_view, 2, 4, 80);
     defer scrolled_first.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, scrolled_first.items, "fx login") != null);
 
-    var scrolled_selected = try composeAuthPickerRow(alloc, scrolled_view, 2, 3, 80);
+    var scrolled_selected = try composeAuthPickerRow(alloc, scrolled_view, 3, 4, 80);
     defer scrolled_selected.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, scrolled_selected.items, credentials.sourceLabel(.stored_key)) != null);
 }

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -1759,7 +1759,7 @@ test "surface footer places the cursor after the Vercel team query" {
     defer frame.deinit(alloc);
 
     try std.testing.expectEqual(frame.paint.footer.picker_start, frame.composed.cursor.row);
-    try std.testing.expectEqual(@as(u16, 39), frame.composed.cursor.col);
+    try std.testing.expectEqual(@as(u16, 27), frame.composed.cursor.col);
     try std.testing.expect(frame.composed.cursor_visible);
 }
 
@@ -1819,7 +1819,7 @@ test "surface footer keeps the Vercel team query and cursor visible at minimum h
     }
     try std.testing.expect(query_visible);
     try std.testing.expectEqual(frame.paint.footer.picker_start, frame.composed.cursor.row);
-    try std.testing.expectEqual(@as(u16, 39), frame.composed.cursor.col);
+    try std.testing.expectEqual(@as(u16, 27), frame.composed.cursor.col);
     try std.testing.expect(frame.composed.cursor_visible);
 }
 
@@ -1837,6 +1837,7 @@ test "surface footer keeps the selected auth source visible at minimum height" {
         .selected_choice = .{ .source = .fx_login },
         .active_source = .ai_gateway_api_key,
         .include_skip = false,
+        .stage = .switch_credential,
     };
 
     var shell = surfaceTestShell(5, 80);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1547,6 +1547,11 @@ profileStoredKeyTmuxTest(
     await session.sendLiteralText(STORED_TOKEN);
     await session.sendKeys("Enter");
     await session.waitForText("Saved the API key to profile file and made it active", TIMEOUT);
+    const returnedConnections = await session.waitForPane(
+      (pane) => pane.includes("Connections") && pane.includes("AI Gateway API key"),
+      TIMEOUT,
+    );
+    expect(returnedConnections).toMatch(/^› AI Gateway API key\s+stored$/m);
     await session.sendText("/status");
     await session.waitForText("auth=stored API key (profile file)", TIMEOUT);
     expect(savedCredentialSource(home)).toBe("stored_key");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1536,7 +1536,9 @@ profileStoredKeyTmuxTest(
     await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
 
     await session.sendText("/setup");
-    await session.waitForText("API key", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("AI Gateway API key", TIMEOUT);
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
@@ -1662,9 +1664,6 @@ tmuxTest(
 
     await session.sendText("/setup");
     await session.waitForText("Setup", TIMEOUT);
-    await session.sendKeys("Down");
-    await session.sendKeys("Down");
-    await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
@@ -3290,10 +3289,9 @@ tmuxTest(
       (pane) =>
         pane.includes("Setup") &&
         pane.includes("Connections") &&
-        pane.includes("Vercel account") &&
-        pane.includes("Grok subscription") &&
-        pane.includes("AI Gateway API key") &&
-        pane.includes("Model provider"),
+        pane.includes("Model provider") &&
+        pane.includes("Vercel team") &&
+        pane.includes("Credential source"),
       TIMEOUT,
     );
     expect(inventory).not.toMatch(/^\s+fx login\s+/m);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1435,6 +1435,43 @@ tmuxTest(
   60_000,
 );
 
+tmuxTest(
+  "first-run Vercel team Escape continues into the setup hub",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-onboarding-team-back-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    oauth = startFakeOAuth(
+      ACQUIRED_LOGIN_TOKEN,
+      undefined,
+      3600,
+      Number.POSITIVE_INFINITY,
+      {
+        teams: [{ id: "team_123", slug: "vercel-labs", name: "Vercel Labs" }],
+      },
+    );
+
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl, undefined, {
+      AI_GATEWAY_API_KEY: undefined,
+      FX_SKIP_ONBOARDING: "0",
+    });
+    await session.waitForText("Welcome to fx", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Vercel team · Search:", TIMEOUT);
+    await session.sendKeys("Escape");
+    const setup = await session.waitForPane(
+      (pane) => pane.includes("Setup") && /Connections\s+connected/.test(pane),
+      TIMEOUT,
+    );
+    expect(setup).toMatch(/^› Vercel team\s+choose a team$/m);
+    expect(setup).not.toContain("Welcome to fx");
+    expect(setup).not.toContain("sign in to manage");
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
 async function startFxWithoutAuth(
   testHome: string,
   testStderrPath: string,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -2545,7 +2545,20 @@ tmuxTest(
       await session.sendKeys("Down");
       await session.sendKeys("Enter");
       await session.waitForText("Paste the code shown by xAI", TIMEOUT);
+      await session.resizeWindow(80, 5);
+      const compactEntry = await session.waitForPane(
+        (pane) =>
+          pane.includes("Paste or type the code") &&
+          pane.includes("Enter submits") &&
+          pane.includes("Esc cancels"),
+        TIMEOUT,
+      );
+      expect(compactEntry).not.toContain("Paste the code shown by xAI");
       await session.pasteText("grok-code");
+      await session.waitForPane(
+        (pane) => pane.includes("•••••••••") && pane.includes("Enter submits"),
+        TIMEOUT,
+      );
       await session.sendKeys("Enter");
       await session.waitForText("Switched to Grok subscription with grok-4.20.", TIMEOUT);
 

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -2538,7 +2538,9 @@ tmuxTest(
       });
       await session.waitForComposer(TIMEOUT);
       await session.sendText("/login");
-      await session.waitForText("Sign in with Grok", TIMEOUT);
+      await session.waitForText("Connections", TIMEOUT);
+      await session.sendKeys("Enter");
+      await session.waitForText("Grok subscription", TIMEOUT);
       await session.sendKeys("Down");
       await session.sendKeys("Down");
       await session.sendKeys("Enter");

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1034,7 +1034,9 @@ tmuxTest(
     session = await startFx(home, stderrPath, gateway, oauth.issuerUrl);
     await session.waitForComposer(TIMEOUT);
     await session.sendText("/login");
-    await session.waitForText("Sign in with Codex", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Vercel account", TIMEOUT);
     await session.sendKeys("Enter");
     const signInScreen = await session.waitForPane(
       (pane) =>
@@ -1077,7 +1079,9 @@ tmuxTest(
     );
     await session.waitForComposer(TIMEOUT);
     await session.sendText("/login");
-    await session.waitForText("Sign in with Codex", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Codex subscription", TIMEOUT);
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
     const signInScreen = await session.waitForPane(
@@ -1293,7 +1297,9 @@ tmuxTest(
     );
     await session.waitForComposer(TIMEOUT);
     await session.sendText("/login");
-    await session.waitForText("Sign in with Codex", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Codex subscription", TIMEOUT);
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
     await completeDisplayedCodexLogin(session, chatgptOauth);
@@ -1368,20 +1374,22 @@ tmuxTest(
     const root = await session.waitForPane(
       (pane) =>
         pane.includes("Setup") &&
-        pane.includes("Sign in with Vercel") &&
-        pane.includes("Sign in with Codex") &&
-        pane.includes("Sign in with Grok") &&
-        pane.includes("API key") &&
-        pane.includes("Switch provider"),
+        pane.includes("Connections") &&
+        pane.includes("Model provider") &&
+        pane.includes("Vercel team") &&
+        pane.includes("Credential source"),
       TIMEOUT,
     );
-    expect(root).not.toContain("AI_GATEWAY_API_KEY");
+    expect(root).toContain("AI_GATEWAY_API_KEY");
     expect(root).not.toContain("fx login");
+    expect(root).not.toContain("Vercel account");
 
+    await session.sendKeys("Enter");
+    await session.waitForText("Vercel account", TIMEOUT);
     await session.sendKeys("Enter");
     await session.waitForText("Enter reopens browser · Esc cancels", TIMEOUT);
     await session.sendKeys("Escape");
-    await session.waitForText("Setup", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
 
     await session.sendKeys("Down");
     await session.sendKeys("Down");
@@ -1390,23 +1398,31 @@ tmuxTest(
     const apiKey = await session.waitForText("Paste your AI Gateway API key", TIMEOUT);
     expect(apiKey).toContain("Saves to");
     await session.sendKeys("Escape");
-    await session.waitForText("Setup", TIMEOUT);
-
-    await session.sendKeys("Down");
-    await session.sendKeys("Enter");
-    await session.waitForText("Switch provider", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
     await session.sendKeys("Escape");
     await session.waitForText("Setup", TIMEOUT);
 
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
-    await session.waitForText("Choose a Vercel team", TIMEOUT);
+    await session.waitForPane(
+      (pane) => pane.includes("Model provider") && pane.includes("Grok subscription"),
+      TIMEOUT,
+    );
     await session.sendKeys("Escape");
-    await session.waitForText("Switch credential", TIMEOUT);
+    await session.waitForText("Setup", TIMEOUT);
 
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
-    const sources = await session.waitForText("Use this credential", TIMEOUT);
+    await session.waitForText("Vercel team · Search:", TIMEOUT);
+    await session.sendKeys("Escape");
+    await session.waitForText("Credential source", TIMEOUT);
+
+    await session.sendKeys("Down");
+    await session.sendKeys("Enter");
+    const sources = await session.waitForPane(
+      (pane) => pane.includes("Credential source") && pane.includes("Automatic"),
+      TIMEOUT,
+    );
     expect(sources).toContain("AI_GATEWAY_API_KEY");
     expect(sources).toContain("fx login");
     await session.sendKeys("Escape");
@@ -1472,21 +1488,23 @@ async function waitForTrace(tracePath: string, needle: string): Promise<void> {
 }
 
 async function enterSwitchCredential(pickerSession: TmuxSession): Promise<void> {
-  for (let index = 0; index < 6; index += 1) {
-    await pickerSession.sendKeys("Down");
-  }
+  await pickerSession.sendKeys("Up");
   await pickerSession.sendKeys("Enter");
-  await pickerSession.waitForText("Use this credential", TIMEOUT);
+  await pickerSession.waitForPane(
+    (pane) => pane.includes("Credential source") && pane.includes("Automatic"),
+    TIMEOUT,
+  );
 }
 
 async function openProviderPicker(pickerSession: TmuxSession): Promise<void> {
   await pickerSession.sendText("/setup");
   await pickerSession.waitForText("Setup", TIMEOUT);
-  for (let index = 0; index < 4; index += 1) {
-    await pickerSession.sendKeys("Down");
-  }
+  await pickerSession.sendKeys("Down");
   await pickerSession.sendKeys("Enter");
-  await pickerSession.waitForText("Switch provider", TIMEOUT);
+  await pickerSession.waitForPane(
+    (pane) => pane.includes("Model provider") && pane.includes("Grok subscription"),
+    TIMEOUT,
+  );
 }
 
 async function openSwitchCredential(pickerSession: TmuxSession): Promise<void> {
@@ -1572,7 +1590,9 @@ tmuxTest(
     await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
 
     await session.sendText("/login");
-    await session.waitForText("Sign in with Codex", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Vercel account", TIMEOUT);
     await session.sendKeys("Enter");
     await session.waitForText("Signed in to Vercel", TIMEOUT);
     await session.sendText("/status");
@@ -1648,7 +1668,7 @@ tmuxTest(
     await session.sendKeys("Down");
     await session.sendKeys("Down");
     await session.sendKeys("Enter");
-    await session.waitForText("Choose a Vercel team", TIMEOUT);
+    await session.waitForText("Vercel team · Search:", TIMEOUT);
     await session.sendKeys("Enter");
     await session.waitForText("Changed Vercel team to Vercel Labs", TIMEOUT);
     await session.sendText("/status");
@@ -1742,7 +1762,9 @@ tmuxTest(
     expect(gateway.requests[2].headers.get("authorization")).toBe(`Bearer ${LOGIN_TOKEN}`);
 
     await session.sendText("/login");
-    await session.waitForText("Sign in with Codex", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Vercel account", TIMEOUT);
     await session.sendKeys("Enter");
     const loginCompleted = await session.waitForText("Signed in to Vercel", TIMEOUT);
     expect(loginCompleted).not.toContain("Setup");
@@ -1865,9 +1887,11 @@ tmuxTest(
     expect(gateway.modelRequests[0].headers.get("authorization")).toBeNull();
 
     await session.sendText("/login");
-    await session.waitForText("Sign in with Codex", TIMEOUT);
+    await session.waitForText("Connections", TIMEOUT);
     await session.sendKeys("Enter");
-    await session.waitForText("Choose a Vercel team", TIMEOUT);
+    await session.waitForText("Vercel account", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Vercel team · Search:", TIMEOUT);
     await session.resizeWindow(80, 5);
     await session.sendLiteralText("example");
     await session.waitForPane((pane) => pane.includes("Search: example"), TIMEOUT);
@@ -1884,7 +1908,7 @@ tmuxTest(
     await session.resizeWindow(80, 24);
     await session.waitForPane(
       (pane) =>
-        pane.includes("Choose a Vercel team") &&
+        pane.includes("Vercel team · Search:") &&
         pane.includes("Search: example") &&
         pane.includes("Example Internal Team") &&
         !pane.includes("Other Team"),
@@ -2362,7 +2386,9 @@ tmuxTest(
       await session.waitForText("auto ·", TIMEOUT);
 
       await session.sendText("/login");
-      await session.waitForText("Sign in with Grok", TIMEOUT);
+      await session.waitForText("Connections", TIMEOUT);
+      await session.sendKeys("Enter");
+      await session.waitForText("Grok subscription", TIMEOUT);
       await session.sendKeys("Down");
       await session.sendKeys("Down");
       await session.sendKeys("Enter");
@@ -3103,7 +3129,7 @@ tmuxTest(
     await session.waitForText("auth=AI_GATEWAY_API_KEY", TIMEOUT);
     await openSwitchCredential(session);
     const inventory = await session.waitForPane(
-      (pane) => pane.includes("AI_GATEWAY_API_KEY") && pane.includes("Use this credential"),
+      (pane) => pane.includes("AI_GATEWAY_API_KEY") && pane.includes("Automatic"),
       TIMEOUT,
     );
     expect(inventory).not.toMatch(/^\s+fx login\s+(?:current|available)\s*$/m);
@@ -3263,16 +3289,17 @@ tmuxTest(
     const inventory = await session.waitForPane(
       (pane) =>
         pane.includes("Setup") &&
-        pane.includes("Sign in with Vercel") &&
-        pane.includes("Sign in with Grok") &&
-        pane.includes("API key") &&
-        pane.includes("Switch provider"),
+        pane.includes("Connections") &&
+        pane.includes("Vercel account") &&
+        pane.includes("Grok subscription") &&
+        pane.includes("AI Gateway API key") &&
+        pane.includes("Model provider"),
       TIMEOUT,
     );
     expect(inventory).not.toMatch(/^\s+fx login\s+/m);
     await session.sendKeys("Escape");
     await session.waitForPane(
-      (pane) => !pane.includes("   Setup"),
+      (pane) => !pane.includes("Connections") && !pane.includes("Routing"),
       TIMEOUT,
     );
 
@@ -3364,7 +3391,7 @@ tmuxTest(
         pane.includes("fx login credential refresh failed.") &&
         pane.includes("Choose another source below") &&
         pane.includes("Setup") &&
-        pane.includes("Switch provider"),
+        pane.includes("Model provider"),
       TIMEOUT,
     );
     expect(failed).toContain(`${promptHead}${promptTail}`);
@@ -3598,14 +3625,14 @@ tmuxTest(
       (pane) =>
         pane.includes(blockedPrompt) &&
         pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Switch provider"),
+        pane.includes("Model provider"),
       TIMEOUT,
     );
     expect(gateway.requests).toHaveLength(0);
 
     await session.sendKeys("Escape");
     await session.waitForPane(
-      (pane) => pane.includes(blockedPrompt) && !pane.includes("   Setup"),
+      (pane) => pane.includes(blockedPrompt) && !pane.includes("Connections"),
       TIMEOUT,
     );
     await session.sendKeys("C-u");
@@ -3670,7 +3697,7 @@ tmuxTest(
       (pane) =>
         pane.includes(firstPrompt) &&
         pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Switch provider"),
+        pane.includes("Model provider"),
       TIMEOUT,
     );
     expect(firstFailure).toContain("Choose another source below.");
@@ -3683,7 +3710,7 @@ tmuxTest(
 
     await session.sendKeys("Escape");
     await session.waitForPane(
-      (pane) => pane.includes(firstPrompt) && !pane.includes("   Setup"),
+      (pane) => pane.includes(firstPrompt) && !pane.includes("Connections"),
       TIMEOUT,
     );
     await session.sendKeys("C-u");
@@ -3705,7 +3732,7 @@ tmuxTest(
       (pane) =>
         pane.includes(secondPrompt) &&
         pane.includes("fx login credential refresh failed.") &&
-        pane.includes("Switch provider"),
+        pane.includes("Model provider"),
       TIMEOUT,
     );
     expect(gateway.requests).toHaveLength(0);

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -1896,6 +1896,15 @@ tmuxTest(
     await session.waitForText("Vercel account", TIMEOUT);
     await session.sendKeys("Enter");
     await session.waitForText("Vercel team · Search:", TIMEOUT);
+    await session.sendKeys("Escape");
+    const setupAfterSignIn = await session.waitForPane(
+      (pane) => pane.includes("Setup") && /Connections\s+connected/.test(pane),
+      TIMEOUT,
+    );
+    expect(setupAfterSignIn).toMatch(/^› Vercel team\s+choose a team$/m);
+    expect(setupAfterSignIn).not.toContain("sign in to manage");
+    await session.sendKeys("Enter");
+    await session.waitForText("Vercel team · Search:", TIMEOUT);
     await session.resizeWindow(80, 5);
     await session.sendLiteralText("example");
     await session.waitForPane((pane) => pane.includes("Search: example"), TIMEOUT);

--- a/tests/e2e/tui-startup.test.ts
+++ b/tests/e2e/tui-startup.test.ts
@@ -367,7 +367,7 @@ describe.skipIf(SKIP_TMUX)("tui: MCP startup", () => {
 
 describe.skipIf(SKIP_TMUX)("tui: credential onboarding", () => {
   test(
-    "/setup opens account and provider actions without source rows",
+    "/setup opens an inline status-first hub",
     async () => {
       const home = realpathSync(mkdtempSync(join(tmpdir(), "fx-e2e-direct-setup-")));
       session = await TmuxSession.create({
@@ -386,15 +386,31 @@ describe.skipIf(SKIP_TMUX)("tui: credential onboarding", () => {
       const setup = await session.waitForPane(
         (pane) =>
           pane.includes("Setup") &&
-          pane.includes("Sign in with Vercel") &&
-          pane.includes("Sign in with Codex") &&
-          pane.includes("Sign in with Grok") &&
-          pane.includes("API key") &&
-          pane.includes("Switch provider"),
+          pane.includes("Connections") &&
+          pane.includes("Model provider") &&
+          pane.includes("Vercel team") &&
+          pane.includes("Credential source") &&
+          pane.includes("Enter Open") &&
+          pane.includes("Esc Close"),
         TIMEOUT,
       );
       expect(setup).not.toContain("AI_GATEWAY_API_KEY");
       expect(setup).not.toContain("fx login");
+      expect(setup).not.toContain("Vercel account");
+      expect(setup).not.toContain("run /login");
+
+      for (let index = 0; index < 2; index += 1) {
+        await session.sendKeys("Down");
+      }
+      await session.sendKeys("Enter");
+      await session.waitForPane(
+        (pane) => pane.includes("Credential source") && pane.includes("Automatic"),
+        TIMEOUT,
+      );
+      await session.sendKeys("Escape");
+      await session.waitForText("Setup", TIMEOUT);
+      await session.sendKeys("Escape");
+      await session.waitForComposer(TIMEOUT);
     },
     TIMEOUT,
   );


### PR DESCRIPTION
## Summary

- Group sign-in methods under Connections.
- Show current connection, provider, team, and credential status in the setup hub.
- Keep the setup hub and child screens inline with consistent headings, spacing, and row alignment.
- Replace the model status line with contextual setup controls, then restore it when the menu closes.
- Return from child screens to the setup hub and skip unavailable team selection during keyboard navigation.
- Keep Vercel team management available after sign-in when returning without selecting a team.
- Keep the AI Gateway API key row selected after saving a key from Connections.
- Keep active sign-in fields and controls visible in compact terminals.
- Update subscription recovery guidance and provider documentation to the current setup labels.
