### PR TITLE
gateway: reuse a process-wide HTTP client for streaming requests

### DIFF
--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -1154,6 +1154,37 @@ fn streamGatewayCompletionCore(
     );
 }
 
+/// Process-wide HTTP client for gateway streaming. Reusing one client lets
+/// std.http.Client's connection pool keep TCP/TLS connections warm across
+/// retry attempts and chat turns instead of paying DNS + TCP + TLS setup
+/// (~1-3 round trips, often 100-300 ms) on every model request.
+var shared_gateway_client: ?*std.http.Client = null;
+const shared_client_c = struct {
+    pub var mu: std.atomic.Value(bool) = .init(false);
+
+    fn tryLock() bool {
+        return !mu.swap(true, .acq_rel);
+    }
+    fn unlock() void {
+        mu.store(false, .release);
+    }
+};
+
+fn sharedGatewayClient() *std.http.Client {
+    while (!shared_client_c.tryLock()) {
+        std.Thread.yield() catch {};
+    }
+    defer shared_client_c.unlock();
+    if (shared_gateway_client == null) {
+        // The client outlives any single request's arena, so it must not
+        // hold an arena allocator.
+        const c = std.heap.c_allocator.create(std.http.Client) catch @panic("oom");
+        c.* = .{ .allocator = std.heap.c_allocator, .io = io_mod.getIo() };
+        shared_gateway_client = c;
+    }
+    return shared_gateway_client.?;
+}
+
 fn streamGatewayCompletionCoreWithOptions(
     alloc: std.mem.Allocator,
     request: StreamRequest,
@@ -1193,8 +1224,7 @@ fn streamGatewayCompletionCoreWithOptions(
     var setup_epoch: ?ConnectionSetupEpoch = null;
     while (attempt < retry_count) : (attempt += 1) {
         if (cancel_flag.load(.seq_cst)) return error.Cancelled;
-        var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
-        defer client.deinit();
+        const client = sharedGatewayClient();
 
         if (setup_epoch == null) {
             setup_epoch = ConnectionSetupEpoch.init(core_options.setup_timing);
@@ -1209,7 +1239,7 @@ fn streamGatewayCompletionCoreWithOptions(
 
         debug_trace.eventf("gateway", "before_http_open_connect", trace_ctx, "attempt={d} retry_count={d}", .{ attempt + 1, retry_count });
         debug_trace.eventf("gateway", "before_request_open", trace_ctx, "attempt={d} retry_count={d} payload_bytes={d}", .{ attempt + 1, retry_count, payload.len });
-        var req = openGatewayRequestBounded(&client, uri, .{
+        var req = openGatewayRequestBounded(client, uri, .{
             .headers = .{
                 .content_type = .{ .override = "application/json" },
                 .authorization = .{ .override = auth_header },
@@ -1217,7 +1247,7 @@ fn streamGatewayCompletionCoreWithOptions(
                 .user_agent = .{ .override = user_agent },
             },
             .extra_headers = extra_headers,
-            .keep_alive = false,
+            .keep_alive = true,
             .redirect_behavior = .unhandled,
         }, core_options.request_open_override, epoch, cancel_flag) catch |err| {
             debug_trace.eventf("gateway", "http_open_connect_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });


### PR DESCRIPTION
## What

`streamGatewayCompletionCoreWithOptions` constructed and destroyed a fresh `std.http.Client` per retry attempt, with `keep_alive = false` on the request. Every model request therefore paid full DNS + TCP + TLS connection setup — even mid-session, on every single turn.

This PR lazily initializes one process-wide client (mutex-guarded init; heap-allocated so it outlives any request arena) and keeps server-side connections alive so std.http.Client's connection pool can reuse them across retry attempts and chat turns.

## Why it matters

Measured connection-setup cost to the gateway host from a residential connection:

```
TCP+TLS handshake: 240 ms  (per model request, previously unavoidable)
DNS lookup:        ~190 ms first use
```

In an interactive session — where fx is a long-lived process handling many turns — this overhead was paid on **every turn**. With pooling, turn 2+ reuses the warm connection and pays zero setup. Retries within a turn also stop re-paying handshake costs.

## Notes

- The shared client intentionally uses `std.heap.c_allocator`, never a request arena, since it outlives individual requests.
- Init is race-safe via an atomic spin lock (std.Thread.Mutex is unavailable in Zig 0.16); contention is limited to first-use.
- Non-streaming metadata calls are untouched to keep the diff minimal; they can adopt the same client in a follow-up if maintainers want.
- `zig build -Doptimize=ReleaseFast` green; full test step passes; validated end-to-end with a live streaming request against the gateway.

Happy to adjust scope (e.g., extend pooling to the non-streaming helpers) if reviewers prefer.