### PR TITLE
Stabilize one-off ACP delivery coverage

### DIFF
--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -6462,6 +6462,7 @@ describe("acp: model-independent", () => {
       const root = createIsolatedRoot("fx-acp-one-off-load-");
       const childName = "acp-readonly-child";
       const childPrompt = "ACP_ONE_OFF_LOAD_CHILD";
+      const childCompletion = heldFakeGatewayFinalText();
       const gateway = startDynamicFakeGateway((body) => {
         if (body.includes("Acknowledge the completed one-off result.")) {
           return finalText("ACP_ONE_OFF_RETIREMENT_ACK_DONE");
@@ -6470,7 +6471,7 @@ describe("acp: model-independent", () => {
           return finalText("ACP_ONE_OFF_LOAD_PARENT_DONE");
         }
         if (body.includes(childPrompt)) {
-          return finalText("ACP_ONE_OFF_LOAD_CHILD_DONE");
+          return childCompletion.response;
         }
         return fakeGatewayToolCall("acp_one_off_load_create", "subagent", {
           command: { create: {
@@ -6492,6 +6493,7 @@ describe("acp: model-independent", () => {
           TIMEOUT,
         );
         expect(result.promptResult.result.stopReason).toBe("end_turn");
+        childCompletion.release("ACP_ONE_OFF_LOAD_CHILD_DONE");
         const sessionsDir = join(root.home, ".fx", "sessions");
         let control: { id: string; path: string } | undefined;
         await waitForCondition(
@@ -6592,6 +6594,7 @@ describe("acp: model-independent", () => {
         expect(gateway.requests).toHaveLength(4);
         expect(client.stderr).toBe("");
       } finally {
+        childCompletion.dispose();
         await client?.close();
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- hold the one-off child response until the parent initial turn completes
- keep the load, delivery, and retirement assertions on a deterministic next-turn boundary