### PR TITLE
Add custom slash commands from user and workspace prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,30 @@ The WebAssembly SDK is experimental. See the [WebAssembly SDK](sdk/README.md) an
 
 Add reusable instructions with [skills](https://fx.sh/docs/capabilities/skills), connect external tools through [MCP](https://fx.sh/docs/capabilities/mcp), or delegate independent work to [subagents](https://fx.sh/docs/capabilities/subagents). Project instruction files may link within their scope, and read-only workspace or compatibility skill directories and their primary `SKILL.md` files may link within their owning workspace or home; managed skills, secondary resources, and escaping links remain no-follow. Skills installed via symlinks that resolve outside home or workspace (e.g. Nix store paths) are loaded when their resolved target is inside a directory listed in the `FX_SKILL_SYMLINK_AUTHORITIES` environment variable (colon-separated absolute paths). `fx status` and `fx doctor` report an invalid trusted MCP profile without starting its servers.
 
+### Custom slash commands
+
+Put personal commands in `~/.fx/prompts` or commit project commands to `.fx/prompts` in a workspace. fx scans only regular `.md` files directly inside each prompts directory. The scan is flat: subdirectories are not read. A filename such as `review-pr.md` always defines `/review-pr`; optional frontmatter can provide `description` and `argument-hint`:
+
+```markdown
+---
+description: Review a pull request
+argument-hint: <number> [focus]
+---
+Review pull request $1, focusing on ${2:-correctness}.
+The complete input was: $ARGUMENTS
+```
+
+`/review-pr 512 security` sends `Review pull request 512, focusing on security.` followed by `The complete input was: 512 security`. Placeholder expansion is single-pass and supports:
+
+- `$ARGUMENTS`: all invocation arguments, preserving their internal spacing. Example: `/echo one two` expands `Input: $ARGUMENTS` to `Input: one two`.
+- `$1` through `$9`: the corresponding whitespace-separated argument, or an empty string when missing. Example: `/greet Ada` expands `Hello $1` to `Hello Ada`.
+- `$$`: one literal dollar sign. Example: `Cost: $$5` expands to `Cost: $5`.
+- `${N:-default}` for `N` from 1 through 9: the positional argument or the literal fallback when missing. Example: `/base` expands `Branch: ${1:-main}` to `Branch: main`.
+
+Built-in slash commands have precedence over custom commands, and custom commands have precedence over skills when the same token exists. Among custom commands, the nearest workspace directory wins, followed by parent workspace directories and then `~/.fx/prompts`. Help and completion display the exact source directory for every command. This differs from Claude Code's personal-wins rule. A rejected file does not stop fx or prevent other commands from loading. To inspect discovery diagnostics for missing commands, start fx with `FX_TRACE_LOG=/path/to/trace.log FX_TRACE_SCOPES=commands` and read the trace.
+
+Treat a repository's `.fx/prompts` files with the same trust as its `AGENTS.md` and `.fx/skills`. fx adds no workspace trust prompt. Invoking a custom command sends its expanded body as prompt text on your behalf. Expansion itself does not execute shell commands, read referenced files, or make network requests.
+
 ## Documentation
 
 Read the [fx documentation](https://fx.sh/docs).

--- a/scripts/pgso/corpus.json
+++ b/scripts/pgso/corpus.json
@@ -106,6 +106,7 @@
     {"name": "e2e-tui-interrupt-recovery", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-interrupt-recovery.test.ts"], "test_file": "tui-interrupt-recovery.test.ts"},
     {"name": "e2e-tui-subagent-manager", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-subagent-manager.test.ts"], "test_file": "tui-subagent-manager.test.ts"},
     {"name": "e2e-tui-terminal-tool", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-terminal-tool.test.ts"], "test_file": "tui-terminal-tool.test.ts"},
+    {"name": "e2e-tui-slash-custom-commands", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-slash-custom-commands.test.ts"], "test_file": "tui-slash-custom-commands.test.ts"},
     {"name": "e2e-tui-native-clear-recovery", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-native-clear-recovery.test.ts"], "test_file": "tui-native-clear-recovery.test.ts"},
     {"name": "e2e-tui-gateway-stream-lifecycle", "argv": ["bun", "test", "--max-concurrency", "1", "./tui-gateway-stream-lifecycle.test.ts"], "test_file": "tui-gateway-stream-lifecycle.test.ts"}
   ],

--- a/scripts/pgso/tests/test_corpus.py
+++ b/scripts/pgso/tests/test_corpus.py
@@ -48,6 +48,7 @@ TRAINING_E2E_TESTS = (
     "tui-interrupt-recovery.test.ts",
     "tui-subagent-manager.test.ts",
     "tui-terminal-tool.test.ts",
+    "tui-slash-custom-commands.test.ts",
     "tui-native-clear-recovery.test.ts",
     "tui-gateway-stream-lifecycle.test.ts",
 )
@@ -364,8 +365,8 @@ class PgsoCorpusTests(unittest.TestCase):
             EXCLUDED_E2E_TESTS,
             tuple(test_file for test_file, _ in corpus.intentional_exclusions),
         )
-        self.assertEqual(36, len(corpus.scenarios))
-        self.assertEqual(53, len(corpus.candidate_scenarios))
+        self.assertEqual(37, len(corpus.scenarios))
+        self.assertEqual(54, len(corpus.candidate_scenarios))
         self.assertEqual(
             100,
             next(

--- a/src/builtins/custom_commands.zig
+++ b/src/builtins/custom_commands.zig
@@ -1,0 +1,469 @@
+const std = @import("std");
+
+const builtin_commands = @import("commands.zig");
+const custom_commands = @import("../core/slash_commands/custom_commands.zig");
+const profile_paths = @import("../core/shared/profile_paths.zig");
+const skill_contract = @import("../core/skills/skill_contract.zig");
+
+const RootSpec = skill_contract.RootSpec;
+
+/// Workspace-relative command root, scanned at the workspace root and each
+/// ancestor directory below home. The directory name is composed from the
+/// single `profile_paths` constant so a rename stays a one-line change.
+const workspace_root_path = profile_paths.root_dir_name ++ "/" ++ profile_paths.prompts_dir_name;
+
+const workspace_roots = [_]RootSpec{
+    .{ .source = .workspace_fx, .path = workspace_root_path },
+};
+
+/// Custom slash commands ship no compatibility roots: fx deliberately does not
+/// read another tool's command directories.
+pub const root_policy: skill_contract.RootPolicy = .{
+    .workspace_roots = &workspace_roots,
+    .managed_root_source = .global_fx,
+    .global_roots = &.{},
+};
+
+test "command root policy orders workspace roots before the user root" {
+    try std.testing.expectEqual(@as(usize, 1), root_policy.workspace_roots.len);
+    try std.testing.expectEqual(skill_contract.SkillSource.workspace_fx, root_policy.workspace_roots[0].source);
+    try std.testing.expectEqualStrings(".fx/prompts", root_policy.workspace_roots[0].path);
+    try std.testing.expectEqual(skill_contract.SkillSource.global_fx, root_policy.managed_root_source.?);
+    try std.testing.expectEqual(@as(usize, 0), root_policy.global_roots.len);
+}
+
+test "command root path is derived from the profile path constants" {
+    const expected = profile_paths.root_dir_name ++ "/" ++ profile_paths.prompts_dir_name;
+    try std.testing.expectEqualStrings(expected, workspace_root_path);
+}
+
+/// Asserts that a file whose stem equals `token` cannot become a command.
+/// Multi-word tokens are skipped: no filename stem can derive them.
+fn expectBuiltinReserved(token: []const u8) !void {
+    try std.testing.expect(token.len > 1 and token[0] == '/');
+    const name = token[1..];
+    if (!custom_commands.validCommandName(name)) return;
+    try std.testing.expect(custom_commands.reservedCollision(builtin_commands.slash_registry, name) != null);
+}
+
+test "no builtin token or alias can be claimed by a command file" {
+    for (builtin_commands.slash_specs) |spec| {
+        try expectBuiltinReserved(spec.command);
+        for (spec.aliases) |alias| try expectBuiltinReserved(alias);
+    }
+}
+
+test "a case-only near miss of a builtin token still collides against the real registry" {
+    try std.testing.expectEqualStrings(
+        "help",
+        custom_commands.reservedCollision(builtin_commands.slash_registry, "HELP").?,
+    );
+    try std.testing.expectEqualStrings(
+        "exit",
+        custom_commands.reservedCollision(builtin_commands.slash_registry, "Exit").?,
+    );
+    try std.testing.expectEqual(
+        @as(?[]const u8, null),
+        custom_commands.reservedCollision(builtin_commands.slash_registry, "review-pr"),
+    );
+}
+
+const command_router = @import("../core/slash_commands/command_router.zig");
+const command_specs = @import("../core/slash_commands/command_specs.zig");
+
+const Allocator = std.mem.Allocator;
+
+const FixtureCommand = struct {
+    name: []const u8,
+    description: []const u8,
+    has_explicit_description: bool = true,
+    source: skill_contract.SkillSource = .workspace_fx,
+    source_root: []const u8 = "/tmp/workspace/.fx/prompts",
+    argument_hint: ?[]const u8 = null,
+    body: []const u8 = "prompt body",
+};
+
+/// Merges a literal command table against the real 42 builtin specs, so the
+/// assertions below run over the registry production actually serves.
+fn fixtureRuntime(
+    alloc: Allocator,
+    fixtures: []const FixtureCommand,
+) !custom_commands.CommandRuntime {
+    if (fixtures.len == 0) {
+        return custom_commands.buildRuntime(alloc, builtin_commands.slash_registry, .{});
+    }
+
+    const commands = try alloc.alloc(custom_commands.CustomCommand, fixtures.len);
+    for (fixtures, commands) |fixture, *command| {
+        command.* = .{
+            .name = try alloc.dupe(u8, fixture.name),
+            .description = try alloc.dupe(u8, fixture.description),
+            .has_explicit_description = fixture.has_explicit_description,
+            .argument_hint = if (fixture.argument_hint) |hint| try alloc.dupe(u8, hint) else null,
+            .body = try alloc.dupe(u8, fixture.body),
+            .path = try std.fmt.allocPrint(alloc, "{s}/{s}.md", .{ fixture.source_root, fixture.name }),
+            .source = fixture.source,
+        };
+    }
+
+    var discovery: custom_commands.CommandDiscovery = .{ .commands = commands };
+    return custom_commands.buildRuntime(
+        alloc,
+        builtin_commands.slash_registry,
+        discovery,
+    ) catch |err| {
+        discovery.deinit(alloc);
+        return err;
+    };
+}
+
+const merge_fixtures = [_]FixtureCommand{
+    .{ .name = "review-pr", .description = "Review a pull request" },
+    .{ .name = "model-review", .description = "Review the model choice" },
+    .{ .name = "notes", .description = "custom command from /tmp/home/.fx/prompts", .has_explicit_description = false, .source = .global_fx, .source_root = "/tmp/home/.fx/prompts" },
+};
+
+test "merged registry preserves the builtin array and keeps every token unique" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &merge_fixtures);
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(builtin_commands.slash_registry);
+    try std.testing.expectEqual(
+        builtin_commands.slash_specs.len + merge_fixtures.len,
+        registry.commands.len,
+    );
+    for (builtin_commands.slash_specs, registry.commands[0..builtin_commands.slash_specs.len]) |expected, actual| {
+        try std.testing.expectEqualStrings(expected.command, actual.command);
+        try std.testing.expectEqual(expected.kind, actual.kind);
+        try std.testing.expectEqual(expected.presentation_category, actual.presentation_category);
+    }
+
+    for (registry.commands) |spec| {
+        try std.testing.expectEqual(
+            @as(usize, 1),
+            command_specs.slashTokenOccurrences(registry, spec.command),
+        );
+        for (spec.aliases) |alias| {
+            try std.testing.expectEqual(
+                @as(usize, 1),
+                command_specs.slashTokenOccurrences(registry, alias),
+            );
+        }
+    }
+}
+
+test "a builtin token still resolves to its builtin spec in the merged registry" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &merge_fixtures);
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(builtin_commands.slash_registry);
+    for (builtin_commands.slash_specs) |spec| {
+        try std.testing.expectEqual(spec.kind, registry.lookup(spec.command).?.kind);
+    }
+    // The whitespace boundary in the prefix matcher keeps a longer custom token
+    // from being reached through the shorter builtin one, and the reverse.
+    try std.testing.expectEqual(
+        command_specs.SlashKind.model,
+        registry.lookup("/model").?.kind,
+    );
+    try std.testing.expectEqual(
+        command_specs.SlashKind.custom,
+        registry.lookup("/model-review").?.kind,
+    );
+}
+
+test "a custom command parses to its own merged registry index" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &merge_fixtures);
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(builtin_commands.slash_registry);
+    for (merge_fixtures, 0..) |fixture, offset| {
+        var buf: [64]u8 = undefined;
+        const input = try std.fmt.bufPrint(&buf, "/{s} 512", .{fixture.name});
+        const parsed = command_router.parse(registry, input);
+        try std.testing.expectEqual(
+            builtin_commands.slash_specs.len + offset,
+            parsed.custom.index,
+        );
+        try std.testing.expectEqualStrings("512", parsed.custom.args);
+    }
+
+    // A builtin sharing the prefix still parses to its own variant, so the
+    // index-carrying variant never swallows a builtin token.
+    try std.testing.expectEqualStrings("gpt", command_router.parse(registry, "/model gpt").model);
+}
+
+test "custom commands render in the extensions help category with their source" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &merge_fixtures);
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(builtin_commands.slash_registry);
+    const builtin_extensions = command_specs.helpCatalogCategoryCount(
+        builtin_commands.slash_registry,
+        "",
+        .extensions,
+    );
+    try std.testing.expectEqual(
+        builtin_extensions + merge_fixtures.len,
+        command_specs.helpCatalogCategoryCount(registry, "", .extensions),
+    );
+
+    const help = try command_specs.renderSlashHelp(alloc, registry);
+    defer alloc.free(help);
+    try std.testing.expect(std.mem.find(u8, help, "/review-pr") != null);
+
+    const spec = registry.lookup("/review-pr").?;
+    try std.testing.expectEqualStrings(
+        "Review a pull request (/tmp/workspace/.fx/prompts)",
+        spec.completion_description.?,
+    );
+    try std.testing.expectEqualStrings(
+        "custom command from /tmp/home/.fx/prompts",
+        registry.lookup("/notes").?.completion_description.?,
+    );
+}
+
+test "completion lists the builtin before a custom command sharing its prefix" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &merge_fixtures);
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(builtin_commands.slash_registry);
+    try std.testing.expect(command_specs.slashCompletionCount(registry, "/model") >= 2);
+    try std.testing.expectEqualStrings(
+        "/model",
+        command_specs.nthSlashCompletion(registry, "/model", 0).?,
+    );
+    var saw_custom = false;
+    var index: usize = 0;
+    while (command_specs.nthSlashCompletion(registry, "/model", index)) |completion| : (index += 1) {
+        if (std.mem.eql(u8, completion, "/model-review")) saw_custom = true;
+    }
+    try std.testing.expect(saw_custom);
+}
+
+test "zero discovered commands leave the slash surface byte-identical" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &.{});
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(builtin_commands.slash_registry);
+    try std.testing.expectEqual(builtin_commands.slash_registry.commands.ptr, registry.commands.ptr);
+    try std.testing.expectEqual(builtin_commands.slash_registry.commands.len, registry.commands.len);
+
+    const merged_help = try command_specs.renderSlashHelp(alloc, registry);
+    defer alloc.free(merged_help);
+    const builtin_help = try command_specs.renderSlashHelp(alloc, builtin_commands.slash_registry);
+    defer alloc.free(builtin_help);
+    try std.testing.expectEqualStrings(builtin_help, merged_help);
+}
+
+const app_commands = @import("../core/app/app_commands.zig");
+const types = @import("../core/shared/types.zig");
+
+/// Serves the merged registry and resolves indices exactly as `App` does, so
+/// `app_commands.Handlers(...).route` runs the production dispatch path over a
+/// real 42-builtin registry.
+const RouteFakeApp = struct {
+    alloc: Allocator,
+    runtime: *const custom_commands.CommandRuntime,
+    enqueued: ?[]u8 = null,
+    notice_topic: ?[]const u8 = null,
+    notice_tone: ?types.NoticeTone = null,
+    notice_body: ?[]const u8 = null,
+
+    fn deinit(self: *RouteFakeApp) void {
+        if (self.enqueued) |prompt| self.alloc.free(prompt);
+        self.enqueued = null;
+    }
+
+    pub fn slashRegistry(self: *const RouteFakeApp) command_specs.SlashRegistry {
+        return self.runtime.registry(builtin_commands.slash_registry);
+    }
+
+    pub fn customCommandBody(self: *const RouteFakeApp, index: usize) ?[]const u8 {
+        const command = self.runtime.commandAt(
+            builtin_commands.slash_registry,
+            index,
+        ) orelse return null;
+        return command.body;
+    }
+
+    pub fn enqueuePrompt(self: *RouteFakeApp, prompt: []const u8) !bool {
+        if (self.enqueued) |previous| self.alloc.free(previous);
+        self.enqueued = try self.alloc.dupe(u8, prompt);
+        return true;
+    }
+
+    pub fn writeDomainNotice(self: *RouteFakeApp, notice: types.SemanticNotice, _: bool) !void {
+        self.notice_topic = notice.topic;
+        self.notice_tone = notice.tone;
+        self.notice_body = notice.body;
+    }
+};
+
+fn unexpectedNoPayload(_: *anyopaque) anyerror!void {
+    return error.UnexpectedCallback;
+}
+
+fn unexpectedPayload(_: *anyopaque, _: []const u8) anyerror!void {
+    return error.UnexpectedCallback;
+}
+
+/// Binds the production `run_custom` handler and refuses every other dispatch
+/// slot, so a custom command that landed on the wrong branch fails loudly.
+/// The full `Handlers(...).commandHandlers` table cannot be built here: it
+/// references every App capability, and this fake owns only the four the
+/// custom path touches.
+fn customOnlyHandlers(app: *RouteFakeApp) command_router.CommandHandlers {
+    var handlers: command_router.CommandHandlers = undefined;
+    handlers.ctx = @ptrCast(app);
+    inline for (@typeInfo(command_router.CommandHandlers).@"struct".fields) |field| {
+        if (comptime field.type == @TypeOf(&unexpectedNoPayload)) {
+            @field(handlers, field.name) = unexpectedNoPayload;
+        } else if (comptime field.type == @TypeOf(&unexpectedPayload)) {
+            @field(handlers, field.name) = unexpectedPayload;
+        }
+    }
+    handlers.run_custom = app_commands.Handlers(RouteFakeApp).commandRunCustom;
+    return handlers;
+}
+
+fn routeCustom(app: *RouteFakeApp, cmd: []const u8) !void {
+    const handlers = customOnlyHandlers(app);
+    try command_router.route(app.slashRegistry(), &handlers, cmd);
+}
+
+const greet_fixtures = [_]FixtureCommand{
+    .{
+        .name = "greet",
+        .description = "Greet someone",
+        .argument_hint = "<name>",
+        .body = "Hello $1, full input was $ARGUMENTS",
+    },
+    .{
+        .name = "notes",
+        .description = "Open the notes",
+        .source = .global_fx,
+        .body = "Open notes for ${1:-today}",
+    },
+};
+
+test "typing a custom command routes through dispatch into the prompt queue" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &greet_fixtures);
+    defer runtime.deinit(alloc);
+
+    var app = RouteFakeApp{ .alloc = alloc, .runtime = &runtime };
+    defer app.deinit();
+
+    try routeCustom(&app, "/greet Ada Lovelace");
+
+    try std.testing.expectEqualStrings(
+        "Hello Ada, full input was Ada Lovelace",
+        app.enqueued.?,
+    );
+    try std.testing.expectEqual(@as(?[]const u8, null), app.notice_body);
+}
+
+test "a custom command routed with no arguments falls back to its default" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &greet_fixtures);
+    defer runtime.deinit(alloc);
+
+    var app = RouteFakeApp{ .alloc = alloc, .runtime = &runtime };
+    defer app.deinit();
+
+    try routeCustom(&app, "/notes");
+    try std.testing.expectEqualStrings("Open notes for today", app.enqueued.?);
+
+    try routeCustom(&app, "/notes tomorrow");
+    try std.testing.expectEqualStrings("Open notes for tomorrow", app.enqueued.?);
+}
+
+test "an index the registry no longer holds reports an unknown command" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &greet_fixtures);
+    defer runtime.deinit(alloc);
+
+    const first_custom = builtin_commands.slash_specs.len;
+    try std.testing.expect(runtime.commandAt(builtin_commands.slash_registry, first_custom) != null);
+    for ([_]usize{
+        0,
+        first_custom - 1,
+        first_custom + greet_fixtures.len,
+        std.math.maxInt(usize),
+    }) |index| {
+        try std.testing.expectEqual(
+            @as(?*const custom_commands.CustomCommand, null),
+            runtime.commandAt(builtin_commands.slash_registry, index),
+        );
+    }
+
+    var app = RouteFakeApp{ .alloc = alloc, .runtime = &runtime };
+    defer app.deinit();
+
+    try app_commands.Handlers(RouteFakeApp).commandRunCustom(
+        @ptrCast(&app),
+        first_custom + greet_fixtures.len,
+        "arguments",
+    );
+
+    try std.testing.expectEqual(@as(?[]u8, null), app.enqueued);
+    try std.testing.expectEqual(types.NoticeTone.@"error", app.notice_tone.?);
+    try std.testing.expectEqualStrings("Unknown command. Try /help.", app.notice_body.?);
+}
+
+test "an argument hint decorates the picker label without changing insertion" {
+    const alloc = std.testing.allocator;
+    var runtime = try fixtureRuntime(alloc, &greet_fixtures);
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(builtin_commands.slash_registry);
+    try std.testing.expectEqualStrings(
+        "/greet <name>",
+        command_specs.nthSlashCompletionLabel(registry, "/greet", 0).?,
+    );
+    try std.testing.expectEqualStrings(
+        "/greet",
+        command_specs.nthSlashCompletion(registry, "/greet", 0).?,
+    );
+
+    // No hint means the bare token, so no separator or empty placeholder is
+    // ever rendered.
+    try std.testing.expectEqualStrings(
+        "/notes",
+        command_specs.nthSlashCompletionLabel(registry, "/notes", 0).?,
+    );
+    try std.testing.expectEqualStrings(
+        "/notes",
+        command_specs.nthSlashCompletion(registry, "/notes", 0).?,
+    );
+
+    const help = try command_specs.renderSlashHelp(alloc, registry);
+    defer alloc.free(help);
+    try std.testing.expect(std.mem.find(u8, help, "/greet <name>") != null);
+}
+
+test "a hinted label stays bounded by the sanitized hint length" {
+    const alloc = std.testing.allocator;
+    const max_argument_hint_bytes: usize = 128;
+    const long_hint = "x" ** max_argument_hint_bytes;
+    const fixtures = [_]FixtureCommand{
+        .{ .name = "wide", .description = "Wide hint", .argument_hint = long_hint },
+    };
+    var runtime = try fixtureRuntime(alloc, &fixtures);
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(builtin_commands.slash_registry);
+    const label = command_specs.nthSlashCompletionLabel(registry, "/wide", 0).?;
+    try std.testing.expectEqual(
+        "/wide ".len + max_argument_hint_bytes,
+        label.len,
+    );
+    for (label) |byte| try std.testing.expect(byte >= 0x20 and byte != 0x7f);
+}

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -59,6 +59,7 @@ const workspace_access = @import("../workspace/workspace_access.zig");
 const js_host_workspace = @import("../hosts/js_host_workspace.zig");
 
 const Allocator = std.mem.Allocator;
+const RefreshProjectContextError = context_contract.ProviderError || error{PaintGuardViolated};
 const ChatMessage = types.ChatMessage;
 const PermissionGrant = types.PermissionGrant;
 const PermissionMode = types.PermissionMode;
@@ -811,7 +812,7 @@ pub fn Runtime(comptime App: type) type {
             }, arena, messages);
         }
 
-        pub fn refreshProjectContext(app: *App, targets: []const context_contract.ApplicableTarget) context_contract.ProviderError!void {
+        pub fn refreshProjectContext(app: *App, targets: []const context_contract.ApplicableTarget) RefreshProjectContextError!void {
             app.context_snapshot.deinit(app.alloc);
             if (!app.context_enabled) return;
 

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -9,6 +9,7 @@ const background_commands = @import("../background/background_commands.zig");
 const gateway_provider = @import("../gateway/gateway_provider.zig");
 const host = @import("../hosts/host.zig");
 const change_tracker_mod = @import("../workspace/change_tracker.zig");
+const command_expansion = @import("../slash_commands/command_expansion.zig");
 const command_router = @import("../slash_commands/command_router.zig");
 const command_specs = @import("../slash_commands/command_specs.zig");
 const config_runtime = @import("../config/config_runtime.zig");
@@ -373,6 +374,7 @@ pub fn Handlers(comptime App: type) type {
                 .handle_notifications = commandHandleNotifications,
                 .handle_workspace = commandHandleWorkspace,
                 .show_version = commandShowVersion,
+                .run_custom = commandRunCustom,
                 .unknown = commandUnknown,
             };
         }
@@ -1770,6 +1772,34 @@ pub fn Handlers(comptime App: type) type {
                 .tone = .@"error",
                 .body = "Unknown command. Try /help.",
             }, true);
+        }
+
+        /// Expands a discovered command body against the typed arguments and
+        /// enqueues the result through the same prompt path a typed message
+        /// takes. The expanded text is owned here and copied by the queue, so
+        /// no registry memory outlives the call.
+        pub fn commandRunCustom(ctx: *anyopaque, index: usize, args: []const u8) !void {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            if (comptime !@hasDecl(App, "customCommandBody")) return commandUnknown(ctx, "");
+
+            // A reload can retire the index a queued invocation carries; the
+            // lookup is bounds-checked and reports the same message a typo does.
+            const body = app.customCommandBody(index) orelse return commandUnknown(ctx, "");
+
+            const expanded = command_expansion.expand(app.alloc, body, args) catch |err| switch (err) {
+                error.ExpandedCommandTooLarge => {
+                    try app.writeDomainNotice(.{
+                        .topic = "command",
+                        .tone = .@"error",
+                        .body = command_expansion.too_large_notice,
+                    }, true);
+                    return;
+                },
+                else => |other| return other,
+            };
+            defer app.alloc.free(expanded);
+
+            _ = try app.enqueuePrompt(expanded);
         }
     };
 }
@@ -3920,6 +3950,106 @@ test "trace renders gateway schema diagnostics without raw payload content" {
     try std.testing.expect(std.mem.find(u8, text, "gateway_schema=\"path=prompt.0.content expected=string received=array\"") != null);
     try std.testing.expect(std.mem.find(u8, text, "request_shape=\"bytes=123 prompt_count=1 prompt.0 role=system content=array") != null);
     try std.testing.expect(std.mem.find(u8, text, "SECRET_RAW_PROMPT") == null);
+}
+
+/// Stands in for the real `App` with only what `commandRunCustom` touches: a
+/// bounds-checked body lookup, an allocator, the prompt queue, and notices.
+const CustomCommandFakeApp = struct {
+    alloc: std.mem.Allocator = std.testing.allocator,
+    bodies: []const []const u8 = &.{},
+    /// Mirrors production: builtin specs occupy the low indices of the merged
+    /// registry, so a custom index starts past them.
+    first_custom_index: usize = 42,
+    enqueued: ?[]u8 = null,
+    tone: ?types.NoticeTone = null,
+    topic: ?[]const u8 = null,
+    body: ?[]const u8 = null,
+
+    fn deinit(self: *CustomCommandFakeApp) void {
+        if (self.enqueued) |prompt| self.alloc.free(prompt);
+        self.enqueued = null;
+    }
+
+    noinline fn customCommandBody(self: *const CustomCommandFakeApp, index: usize) ?[]const u8 {
+        if (index < self.first_custom_index) return null;
+        const offset = index - self.first_custom_index;
+        if (offset >= self.bodies.len) return null;
+        return self.bodies[offset];
+    }
+
+    /// Copies like the real queue does, so a borrowed expansion buffer that
+    /// outlived the handler would surface as a use-after-free under the
+    /// testing allocator.
+    noinline fn enqueuePrompt(self: *CustomCommandFakeApp, prompt: []const u8) !bool {
+        if (self.enqueued) |previous| self.alloc.free(previous);
+        self.enqueued = try self.alloc.dupe(u8, prompt);
+        return true;
+    }
+
+    noinline fn writeDomainNotice(self: *CustomCommandFakeApp, notice: types.SemanticNotice, _: bool) !void {
+        self.tone = notice.tone;
+        self.topic = notice.topic;
+        self.body = notice.body;
+    }
+};
+
+const custom_command_bodies = [_][]const u8{"Hello $1, full input was $ARGUMENTS"};
+
+test "custom command dispatch enqueues the expanded body" {
+    var app = CustomCommandFakeApp{ .bodies = &custom_command_bodies };
+    defer app.deinit();
+
+    try Handlers(CustomCommandFakeApp).commandRunCustom(@ptrCast(&app), 42, "Ada Lovelace");
+
+    try std.testing.expectEqualStrings(
+        "Hello Ada, full input was Ada Lovelace",
+        app.enqueued.?,
+    );
+    try std.testing.expectEqual(@as(?types.NoticeTone, null), app.tone);
+}
+
+test "a custom command invoked with no arguments expands to empty placeholders" {
+    var app = CustomCommandFakeApp{ .bodies = &custom_command_bodies };
+    defer app.deinit();
+
+    try Handlers(CustomCommandFakeApp).commandRunCustom(@ptrCast(&app), 42, "");
+
+    try std.testing.expectEqualStrings("Hello , full input was ", app.enqueued.?);
+}
+
+test "custom command dispatch reports an unknown command without reading the index" {
+    for ([_]usize{ 0, 41, 43, std.math.maxInt(usize) }) |index| {
+        var app = CustomCommandFakeApp{ .bodies = &custom_command_bodies };
+        defer app.deinit();
+
+        try Handlers(CustomCommandFakeApp).commandRunCustom(@ptrCast(&app), index, "arguments");
+
+        try std.testing.expectEqual(@as(?[]u8, null), app.enqueued);
+        try std.testing.expectEqual(types.NoticeTone.@"error", app.tone.?);
+        try std.testing.expectEqualStrings("command", app.topic.?);
+        try std.testing.expectEqualStrings("Unknown command. Try /help.", app.body.?);
+    }
+}
+
+test "an oversized expansion is refused with a diagnostic instead of enqueued" {
+    const alloc = std.testing.allocator;
+    const args = try alloc.alloc(u8, 1024 * 1024);
+    defer alloc.free(args);
+    @memset(args, 'x');
+
+    const bodies = [_][]const u8{"$1$1$1$1$1$1$1$1$1"};
+    var app = CustomCommandFakeApp{ .bodies = &bodies };
+    defer app.deinit();
+
+    try Handlers(CustomCommandFakeApp).commandRunCustom(@ptrCast(&app), 42, args);
+
+    try std.testing.expectEqual(@as(?[]u8, null), app.enqueued);
+    try std.testing.expectEqual(types.NoticeTone.@"error", app.tone.?);
+    try std.testing.expectEqualStrings("command", app.topic.?);
+    try std.testing.expectEqualStrings(
+        command_expansion.too_large_notice,
+        app.body.?,
+    );
 }
 
 test "app_commands exposes active handler API surface" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -10789,9 +10789,12 @@ const FakeSubmitApp = struct {
     fail_enqueue_after_snapshot: bool = false,
     fail_command_after_pending_clear: bool = false,
     snapshot_dir: ?[]const u8 = null,
+    /// Lets a test serve the merged registry a discovered command produces,
+    /// the way `App.slashRegistry()` does in production.
+    slash_registry_override: ?command_specs.SlashRegistry = null,
 
-    pub fn slashRegistry(_: *const FakeSubmitApp) command_specs.SlashRegistry {
-        return routing_test_slash_registry;
+    pub fn slashRegistry(self: *const FakeSubmitApp) command_specs.SlashRegistry {
+        return self.slash_registry_override orelse routing_test_slash_registry;
     }
 
     fn deinit(self: *FakeSubmitApp) void {
@@ -11306,6 +11309,80 @@ test "app_input_runtime submit preserves a dismissed slash query" {
 
     try std.testing.expect(app.last_command == null);
     try std.testing.expectEqualStrings("/he", app.last_prompt.?);
+}
+
+/// A merged registry shaped like the one `custom_commands.buildRuntime`
+/// produces: the routing builtins first, then one custom spec.
+const custom_submit_slash_specs = routing_test_slash_specs ++ [_]command_specs.SlashSpec{
+    .{ .kind = .custom, .command = "/greet", .help_entry = "/greet <name>", .completion_label = "/greet <name>", .completion_description = "greet someone (/tmp/workspace/.fx/prompts)", .presentation_category = .extensions, .has_args = true, .accepts_payload = true, .requires_prompt_credential = true },
+};
+const custom_submit_slash_registry = command_specs.SlashRegistry{ .commands = custom_submit_slash_specs[0..] };
+
+test "app_input_runtime intercepts a custom command before enqueueing a prompt" {
+    const alloc = std.testing.allocator;
+    var app = FakeSubmitApp{ .alloc = alloc, .slash_registry_override = custom_submit_slash_registry };
+    defer app.deinit();
+
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "/greet Ada Lovelace");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try std.testing.expectEqualStrings("/greet Ada Lovelace", app.last_command.?);
+    try std.testing.expect(app.last_prompt == null);
+    try std.testing.expectEqual(@as(usize, 1), app.preflight_count);
+    try std.testing.expectEqual(@as(usize, 0), app.input_runtime.edit_state.input.items.len);
+}
+
+test "app_input_runtime matches a custom command typed with trailing whitespace only" {
+    const alloc = std.testing.allocator;
+    var app = FakeSubmitApp{ .alloc = alloc, .slash_registry_override = custom_submit_slash_registry };
+    defer app.deinit();
+
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "/greet ");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    // Submission forwards the draft verbatim; the router is what tolerates the
+    // trailing blank, so the proof is the parse, not the recorded text.
+    try std.testing.expectEqualStrings("/greet ", app.last_command.?);
+    try std.testing.expectEqual(@as(usize, 1), app.command_count);
+    try std.testing.expect(app.last_prompt == null);
+
+    const command_router = @import("../slash_commands/command_router.zig");
+    switch (command_router.parse(custom_submit_slash_registry, app.last_command.?)) {
+        .custom => |custom| {
+            try std.testing.expectEqual(
+                @as(usize, custom_submit_slash_specs.len - 1),
+                custom.index,
+            );
+            try std.testing.expectEqualStrings("", custom.args);
+        },
+        else => return error.CustomCommandNotMatched,
+    }
+}
+
+test "a custom command is refused when no prompt credential is usable" {
+    const alloc = std.testing.allocator;
+    var app = FakeSubmitApp{
+        .alloc = alloc,
+        .slash_registry_override = custom_submit_slash_registry,
+        .prompt_admitted = false,
+    };
+    defer app.deinit();
+
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "/greet Ada");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try std.testing.expectEqual(@as(usize, 1), app.preflight_count);
+    try std.testing.expectEqual(@as(usize, 0), app.command_count);
+    try std.testing.expect(app.last_prompt == null);
+    // The refusal leaves the draft intact, exactly as a credential-requiring
+    // builtin does.
+    try std.testing.expectEqualStrings("/greet Ada", app.input_runtime.edit_state.input.items);
 }
 
 test "app_input_runtime routes an unmatched visible slash query as an unknown command" {

--- a/src/core/app/app_runtime_setup.zig
+++ b/src/core/app/app_runtime_setup.zig
@@ -1,4 +1,6 @@
 const std = @import("std");
+const command_specs = @import("../slash_commands/command_specs.zig");
+const custom_commands = @import("../slash_commands/custom_commands.zig");
 const io_mod = @import("../shared/io.zig");
 const profile_paths = @import("../shared/profile_paths.zig");
 const skill_contract = @import("../skills/skill_contract.zig");
@@ -6,6 +8,7 @@ const skill_runtime = @import("../skills/skill_runtime.zig");
 
 const Allocator = std.mem.Allocator;
 pub const LoadSkillsError = Allocator.Error;
+const LoadCustomCommandsError = Allocator.Error;
 
 pub const LoadedSkills = struct {
     dir: []u8 = &.{},
@@ -41,6 +44,54 @@ pub fn loadSkills(
         .skills = discovery.skills,
         .diagnostics = discovery.diagnostics,
     };
+}
+
+/// Discovers custom slash commands from the workspace roots and the user root.
+/// A missing HOME leaves the user root out and limits workspace discovery to
+/// the workspace itself, because no safe ancestor boundary is then known.
+pub fn loadCustomCommands(
+    alloc: Allocator,
+    workspace_root: []const u8,
+    root_policy: skill_contract.RootPolicy,
+    reserved: command_specs.SlashRegistry,
+) LoadCustomCommandsError!custom_commands.CommandDiscovery {
+    const configured_home = io_mod.getenv("HOME") orelse {
+        return custom_commands.loadCustomCommands(alloc, workspace_root, null, "", .{
+            .workspace_roots = root_policy.workspace_roots,
+            .managed_root_source = null,
+        }, reserved);
+    };
+    const canonical_home = io_mod.realpathAlloc(alloc, configured_home) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => null,
+    };
+    defer if (canonical_home) |home| alloc.free(home);
+    const home = canonical_home orelse configured_home;
+    // The only `profile_paths` call site for the command root, so PR #278's
+    // signature change touches one line.
+    const dir = try profile_paths.promptsDir(alloc, home);
+    defer alloc.free(dir);
+    return custom_commands.loadCustomCommands(alloc, workspace_root, home, dir, root_policy, reserved);
+}
+
+/// Replaces the live custom-command registry only after discovery and registry
+/// construction both succeed. The caller's allocator owns the full runtime.
+pub fn reloadCustomCommandRuntime(
+    alloc: Allocator,
+    runtime: *custom_commands.CommandRuntime,
+    workspace_root: []const u8,
+    root_policy: skill_contract.RootPolicy,
+    reserved: command_specs.SlashRegistry,
+    surface: []const u8,
+) LoadCustomCommandsError!void {
+    var discovered = try loadCustomCommands(alloc, workspace_root, root_policy, reserved);
+    custom_commands.traceDiagnostics(surface, discovered.diagnostics);
+    const replacement = custom_commands.buildRuntime(alloc, reserved, discovered) catch |err| {
+        discovered.deinit(alloc);
+        return err;
+    };
+    runtime.deinit(alloc);
+    runtime.* = replacement;
 }
 
 var stable_test_environ: ?*std.process.Environ.Map = null;
@@ -200,4 +251,99 @@ test "loadSkills propagates allocation failure instead of returning an empty inv
         error.OutOfMemory,
         loadSkills(failing.allocator(), workspace_path, test_root_policy),
     );
+}
+
+const test_command_root_policy: skill_contract.RootPolicy = .{
+    .workspace_roots = &[_]skill_contract.RootSpec{
+        .{ .source = .workspace_fx, .path = ".fx/prompts" },
+    },
+    .managed_root_source = .global_fx,
+};
+
+const test_command_reserved_specs = [_]command_specs.SlashSpec{
+    .{ .kind = .help, .command = "/help" },
+};
+const test_command_reserved: command_specs.SlashRegistry = .{ .commands = &test_command_reserved_specs };
+
+test "loadCustomCommands without HOME loads only the immediate workspace root" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "parent/workspace/.fx/prompts/local.md", "Local prompt.");
+    try writeTempFile(&tmp, "parent/.fx/prompts/ancestor.md", "Must stay outside the unknown boundary.");
+    const workspace_path = try tmpPath(alloc, tmp.dir, "parent/workspace");
+    defer alloc.free(workspace_path);
+
+    const home = try TestHome.install(alloc, null);
+    defer home.deinit();
+
+    var discovery = try loadCustomCommands(alloc, workspace_path, test_command_root_policy, test_command_reserved);
+    defer discovery.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try std.testing.expectEqualStrings("local", discovery.commands[0].name);
+    try std.testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
+}
+
+test "loadCustomCommands loads workspace and user commands through the profile path helper" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "home/.fx/prompts/notes.md", "Take notes about $ARGUMENTS.");
+    try writeTempFile(&tmp, "home/workspace/.fx/prompts/deploy.md",
+        \\---
+        \\description: Deploy a service
+        \\argument-hint: <service>
+        \\---
+        \\Deploy $1 to production.
+    );
+    try writeTempFile(&tmp, "home/workspace/.fx/prompts/help.md", "Shadows a builtin.");
+
+    const home_path = try tmpPath(alloc, tmp.dir, "home");
+    defer alloc.free(home_path);
+    const workspace_path = try tmpPath(alloc, tmp.dir, "home/workspace");
+    defer alloc.free(workspace_path);
+
+    const home = try TestHome.install(alloc, home_path);
+    defer home.deinit();
+
+    var discovery = try loadCustomCommands(alloc, workspace_path, test_command_root_policy, test_command_reserved);
+    defer discovery.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 2), discovery.commands.len);
+    try std.testing.expectEqualStrings("deploy", discovery.commands[0].name);
+    try std.testing.expectEqualStrings("Deploy a service", discovery.commands[0].description);
+    try std.testing.expectEqualStrings("<service>", discovery.commands[0].argument_hint.?);
+    try std.testing.expectEqual(skill_contract.SkillSource.workspace_fx, discovery.commands[0].source);
+    try std.testing.expectEqualStrings("notes", discovery.commands[1].name);
+    try std.testing.expectEqual(skill_contract.SkillSource.global_fx, discovery.commands[1].source);
+
+    try std.testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try std.testing.expectEqual(
+        custom_commands.CommandDiagnosticCause.builtin_collision,
+        discovery.diagnostics[0].cause,
+    );
+}
+
+test "loadCustomCommands leaves fx unaffected when no command root exists" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/workspace");
+    const home_path = try tmpPath(alloc, tmp.dir, "home");
+    defer alloc.free(home_path);
+    const workspace_path = try tmpPath(alloc, tmp.dir, "home/workspace");
+    defer alloc.free(workspace_path);
+
+    const home = try TestHome.install(alloc, home_path);
+    defer home.deinit();
+
+    var discovery = try loadCustomCommands(alloc, workspace_path, test_command_root_policy, test_command_reserved);
+    defer discovery.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 0), discovery.commands.len);
+    try std.testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
 }

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1521,7 +1521,7 @@ pub fn Runtime(comptime App: type) type {
             switch (decision.action) {
                 .apply_pending => |policy| {
                     applyIdleLiveSessionTransition(app, policy, .{});
-                    try installFreshLiveSession(app);
+                    try installFreshLiveSession(app, policy);
                 },
                 .none => {},
                 .apply_now, .cancel_and_defer => unreachable,
@@ -1533,14 +1533,36 @@ pub fn Runtime(comptime App: type) type {
             background_policy: BackgroundSessionPolicy,
         ) !void {
             try prepareLiveSessionTransition(app, background_policy, .{});
-            try installFreshLiveSession(app);
+            try installFreshLiveSession(app, background_policy);
         }
 
-        fn installFreshLiveSession(app: *App) !void {
+        fn installFreshLiveSession(app: *App, background_policy: BackgroundSessionPolicy) !void {
             try beginFreshPersistedSession(app);
             enableSessionStores(app);
             refreshSubagentProjectionAfterSessionInstall(app);
             try finishLiveSessionTransition(app);
+            reloadCustomCommandsAtSessionBoundary(app, background_policy);
+        }
+
+        /// `/new` and `/clear` use `.carry_forward`; `/reset` deliberately does
+        /// not reload commands. A deferred transition only lands once the
+        /// worker is idle, so rebuilding here never invalidates a parsed
+        /// `.custom` index while a turn is holding one. A failed rebuild keeps
+        /// the previous registry rather than degrading the session.
+        fn reloadCustomCommandsAtSessionBoundary(
+            app: *App,
+            background_policy: BackgroundSessionPolicy,
+        ) void {
+            if (comptime !@hasDecl(App, "reloadCustomCommands")) return;
+            if (background_policy != .carry_forward) return;
+            if (app.worker.isProcessing()) return;
+            app.reloadCustomCommands("session_boundary") catch |err| {
+                debug_trace.logf(
+                    "commands",
+                    "reload_failed surface=session_boundary error={s}",
+                    .{@errorName(err)},
+                );
+            };
         }
 
         pub fn prepareLiveSessionResume(
@@ -10043,4 +10065,60 @@ test "terminal title bounds session and model context" {
     try std.testing.expect(label.len <= Runtime(TestApp).terminal_title_label_max_bytes);
     try std.testing.expect(std.mem.find(u8, label, "...") != null);
     try std.testing.expect(std.mem.find(u8, label, " · provider/") != null);
+}
+
+const CommandReloadFakeApp = struct {
+    const Worker = struct {
+        processing: bool = false,
+
+        fn isProcessing(self: Worker) bool {
+            return self.processing;
+        }
+    };
+
+    worker: Worker = .{},
+    reloads: usize = 0,
+    surface: []const u8 = "",
+    fail: bool = false,
+
+    noinline fn reloadCustomCommands(self: *CommandReloadFakeApp, surface: []const u8) !void {
+        self.reloads += 1;
+        self.surface = surface;
+        if (self.fail) return error.OutOfMemory;
+    }
+};
+
+test "new and clear rebuild the command registry only while the worker is idle" {
+    var app: CommandReloadFakeApp = .{};
+
+    Runtime(CommandReloadFakeApp).reloadCustomCommandsAtSessionBoundary(&app, .carry_forward);
+    try std.testing.expectEqual(@as(usize, 1), app.reloads);
+    try std.testing.expectEqualStrings("session_boundary", app.surface);
+
+    app.worker.processing = true;
+    Runtime(CommandReloadFakeApp).reloadCustomCommandsAtSessionBoundary(&app, .carry_forward);
+    try std.testing.expectEqual(@as(usize, 1), app.reloads);
+
+    app.worker.processing = false;
+    Runtime(CommandReloadFakeApp).reloadCustomCommandsAtSessionBoundary(&app, .stop_forget);
+    try std.testing.expectEqual(@as(usize, 1), app.reloads);
+
+    // A failed rebuild is traced, never propagated, so the session transition
+    // that triggered it still completes with the previous registry in place.
+    app.fail = true;
+    Runtime(CommandReloadFakeApp).reloadCustomCommandsAtSessionBoundary(&app, .carry_forward);
+    try std.testing.expectEqual(@as(usize, 2), app.reloads);
+}
+
+const NoCommandReloadFakeApp = struct {
+    worker: struct {
+        fn isProcessing(_: @This()) bool {
+            return false;
+        }
+    } = .{},
+};
+
+test "a host without command discovery skips the session boundary rebuild" {
+    var app: NoCommandReloadFakeApp = .{};
+    Runtime(NoCommandReloadFakeApp).reloadCustomCommandsAtSessionBoundary(&app, .carry_forward);
 }

--- a/src/core/shared/profile_paths.zig
+++ b/src/core/shared/profile_paths.zig
@@ -18,6 +18,9 @@ pub const mcp_credentials_file_name = "credentials.json";
 const settings_file_name = "settings.json";
 const mcp_config_file_name = "mcp.json";
 const managed_skills_dir_name = "skills";
+/// Single source of truth for the custom slash command directory name. A
+/// maintainer rename stays a one-line change here.
+pub const prompts_dir_name = "prompts";
 const memories_file_name = "memories.json";
 const logs_dir_name = "logs";
 const trace_log_file_name = "trace.log";
@@ -50,6 +53,13 @@ pub fn mcpCredentialsPath(alloc: Allocator, home: []const u8) ![]u8 {
 
 pub fn managedSkillsDir(alloc: Allocator, home: []const u8) ![]u8 {
     return std.fs.path.join(alloc, &.{ home, root_dir_name, managed_skills_dir_name });
+}
+
+/// Resolves the user-scoped custom slash command root. Command discovery has
+/// exactly this one call site, so a profile-root signature change touches one
+/// line.
+pub fn promptsDir(alloc: Allocator, home: []const u8) ![]u8 {
+    return std.fs.path.join(alloc, &.{ home, root_dir_name, prompts_dir_name });
 }
 
 pub fn authPath(alloc: Allocator, home: []const u8) ![]u8 {
@@ -128,6 +138,10 @@ test "profile path helpers preserve current default locations" {
     const skills = try managedSkillsDir(alloc, "/tmp/fake-home");
     defer alloc.free(skills);
     try std.testing.expectEqualStrings("/tmp/fake-home/.fx/skills", skills);
+
+    const commands = try promptsDir(alloc, "/tmp/fake-home");
+    defer alloc.free(commands);
+    try std.testing.expectEqualStrings("/tmp/fake-home/.fx/prompts", commands);
 
     const auth = try authPath(alloc, "/tmp/fake-home");
     defer alloc.free(auth);

--- a/src/core/skills/skill_contract.zig
+++ b/src/core/skills/skill_contract.zig
@@ -78,8 +78,28 @@ pub const ParsedSkillFile = struct {
     name: ?[]const u8,
     description: ?[]const u8,
     description_block: ?BlockDescription = null,
+    /// Value of `options.additional_scalar_key` when the document declares it.
+    /// Borrowed from the parsed content like every other field.
+    additional_scalar: ?[]const u8 = null,
     body: []const u8,
     status: MetadataStatus,
+};
+
+pub const NameMode = enum {
+    required,
+    ignored,
+};
+
+/// Caller-owned relaxations for documents that are not skills. The defaults
+/// reproduce skill parsing exactly.
+pub const ParseOptions = struct {
+    name_mode: NameMode = .required,
+    /// Additional recognized scalar key returned as
+    /// `ParsedSkillFile.additional_scalar`.
+    additional_scalar_key: ?[]const u8 = null,
+    /// Preserve blank lines immediately following the closing frontmatter
+    /// delimiter. Skills retain their established normalized body behavior.
+    preserve_body_prefix: bool = false,
 };
 
 pub const SkillMetadata = struct {
@@ -122,6 +142,10 @@ pub fn resolveMetadata(parsed: ParsedSkillFile, fallback_name: []const u8) Skill
 }
 
 pub fn parseSkillFile(content: []const u8) ParsedSkillFile {
+    return parseSkillFileWithOptions(content, .{});
+}
+
+pub fn parseSkillFileWithOptions(content: []const u8, options: ParseOptions) ParsedSkillFile {
     const header_start = frontmatterHeaderStart(content) orelse {
         return .{
             .name = null,
@@ -140,14 +164,20 @@ pub fn parseSkillFile(content: []const u8) ParsedSkillFile {
     };
 
     const header = content[header_start..closing.header_end];
-    const body = std.mem.trimStart(u8, content[closing.body_start..], "\r\n");
+    const raw_body = content[closing.body_start..];
+    const body = if (options.preserve_body_prefix)
+        raw_body
+    else
+        std.mem.trimStart(u8, raw_body, "\r\n");
 
     var name: ?[]const u8 = null;
     var description: ?[]const u8 = null;
     var description_block: ?BlockDescription = null;
+    var additional_scalar: ?[]const u8 = null;
     var invalid_cause: ?InvalidMetadataCause = null;
     var saw_name = false;
     var saw_description = false;
+    var saw_additional_scalar = false;
     var previous_line_recognized = false;
 
     var line_offset: usize = 0;
@@ -168,7 +198,7 @@ pub fn parseSkillFile(content: []const u8) ParsedSkillFile {
         const key = std.mem.trim(u8, trimmed[0..colon_idx], " \t");
         const raw_value = std.mem.trim(u8, trimmed[colon_idx + 1 ..], " \t");
 
-        if (std.mem.eql(u8, key, "name")) {
+        if (options.name_mode != .ignored and std.mem.eql(u8, key, "name")) {
             previous_line_recognized = true;
             if (saw_name) setFirstInvalidCause(&invalid_cause, .duplicate_recognized_key);
             saw_name = true;
@@ -192,6 +222,13 @@ pub fn parseSkillFile(content: []const u8) ParsedSkillFile {
                 description_block = null;
                 if (parsed_value.invalid_cause) |cause| setFirstInvalidCause(&invalid_cause, cause);
             }
+        } else if (options.additional_scalar_key != null and std.mem.eql(u8, key, options.additional_scalar_key.?)) {
+            previous_line_recognized = true;
+            if (saw_additional_scalar) setFirstInvalidCause(&invalid_cause, .duplicate_recognized_key);
+            saw_additional_scalar = true;
+            const parsed_value = parseRecognizedValue(raw_value);
+            additional_scalar = parsed_value.value;
+            if (parsed_value.invalid_cause) |cause| setFirstInvalidCause(&invalid_cause, cause);
         } else {
             previous_line_recognized = false;
         }
@@ -199,7 +236,7 @@ pub fn parseSkillFile(content: []const u8) ParsedSkillFile {
 
     if (name) |skill_name| {
         if (invalidSkillNameCause(skill_name)) |cause| setFirstInvalidCause(&invalid_cause, cause);
-    } else {
+    } else if (options.name_mode == .required) {
         setFirstInvalidCause(&invalid_cause, .missing_name);
     }
     if (description_block == null) {
@@ -217,6 +254,7 @@ pub fn parseSkillFile(content: []const u8) ParsedSkillFile {
         .name = name,
         .description = description,
         .description_block = description_block,
+        .additional_scalar = additional_scalar,
         .body = body,
         .status = if (invalid_cause) |cause| .{ .invalid = cause } else .valid,
     };

--- a/src/core/slash_commands/command_expansion.zig
+++ b/src/core/slash_commands/command_expansion.zig
@@ -1,0 +1,212 @@
+const std = @import("std");
+
+const paste_framing = @import("../input/paste_framing.zig");
+
+const Allocator = std.mem.Allocator;
+
+/// A custom command expands into the composer, so it inherits the composer
+/// ceiling rather than defining a second limit that could drift from it.
+const max_expanded_bytes: usize = paste_framing.default_input_limits.composer_bytes;
+
+/// Shown when a body plus its arguments would outgrow the composer.
+pub const too_large_notice = "expanded command exceeds the input limit";
+
+const Error = Allocator.Error || error{ExpandedCommandTooLarge};
+
+const arguments_token = "$ARGUMENTS";
+
+/// Expands `body` against the raw `args` text of one invocation.
+///
+/// Expansion is strictly single-pass: every substitution is appended to the
+/// output and the cursor jumps past the placeholder, so text coming from the
+/// user is never rescanned for placeholders. It touches no file, no process,
+/// and no socket: the whole pass is a scan over two slices.
+pub fn expand(alloc: Allocator, body: []const u8, args: []const u8) Error![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+
+    var cursor: usize = 0;
+    while (std.mem.indexOfScalarPos(u8, body, cursor, '$')) |at| {
+        try appendBounded(alloc, &out, body[cursor..at]);
+        const placeholder = placeholderAt(body[at..], args);
+        try appendBounded(alloc, &out, placeholder.text);
+        cursor = at + placeholder.consumed;
+    }
+    try appendBounded(alloc, &out, body[cursor..]);
+
+    return out.toOwnedSlice(alloc);
+}
+
+const Placeholder = struct {
+    /// Borrowed from `body` or from `args`; the caller copies it immediately.
+    text: []const u8,
+    consumed: usize,
+};
+
+/// A `$` that starts no placeholder is emitted alone, so the bytes behind it
+/// are re-entered as ordinary text and stay verbatim.
+const literal_dollar: Placeholder = .{ .text = "$", .consumed = 1 };
+
+fn placeholderAt(rest: []const u8, args: []const u8) Placeholder {
+    std.debug.assert(rest.len > 0 and rest[0] == '$');
+
+    if (rest.len >= 2 and rest[1] == '$') return .{ .text = "$", .consumed = 2 };
+    if (std.mem.startsWith(u8, rest, arguments_token)) {
+        return .{ .text = args, .consumed = arguments_token.len };
+    }
+    if (rest.len >= 2 and isPositional(rest[1])) {
+        // `$10` is not `$1` followed by a zero: a second digit means the run
+        // was never a placeholder, so it is left verbatim.
+        if (rest.len >= 3 and std.ascii.isDigit(rest[2])) return literal_dollar;
+        return .{ .text = positional(args, rest[1]), .consumed = 2 };
+    }
+    if (fallbackAt(rest, args)) |placeholder| return placeholder;
+    return literal_dollar;
+}
+
+/// Matches `${N:-default}` for N in 1-9. Every other shape, including an
+/// unterminated one, returns null so the text survives verbatim.
+fn fallbackAt(rest: []const u8, args: []const u8) ?Placeholder {
+    if (rest.len < 3 or rest[1] != '{') return null;
+    if (!isPositional(rest[2])) return null;
+    if (!std.mem.startsWith(u8, rest[3..], ":-")) return null;
+
+    const default_start = "${N:-".len;
+    const close = std.mem.indexOfScalarPos(u8, rest, default_start, '}') orelse return null;
+    const value = positional(args, rest[2]);
+    return .{
+        // The default is emitted as written: expanding it would make the pass
+        // recursive, and a default containing `$1` is a literal `$1`.
+        .text = if (value.len > 0) value else rest[default_start..close],
+        .consumed = close + 1,
+    };
+}
+
+fn isPositional(byte: u8) bool {
+    return byte >= '1' and byte <= '9';
+}
+
+/// Returns the `digit`-th whitespace-separated argument, or the empty string
+/// when the invocation supplied fewer.
+fn positional(args: []const u8, digit: u8) []const u8 {
+    var it = std.mem.tokenizeAny(u8, args, " \t\r\n");
+    var seen: u8 = 0;
+    while (it.next()) |token| {
+        seen += 1;
+        if (seen == digit - '0') return token;
+    }
+    return "";
+}
+
+/// Checks the ceiling before every append, so an oversized expansion fails
+/// with a diagnostic instead of growing the buffer toward it.
+fn appendBounded(alloc: Allocator, out: *std.ArrayList(u8), text: []const u8) Error!void {
+    if (text.len > max_expanded_bytes - out.items.len) return error.ExpandedCommandTooLarge;
+    try out.appendSlice(alloc, text);
+}
+
+const testing = std.testing;
+
+fn expectExpands(body: []const u8, args: []const u8, expected: []const u8) !void {
+    const expanded = try expand(testing.allocator, body, args);
+    defer testing.allocator.free(expanded);
+    try testing.expectEqualStrings(expected, expanded);
+}
+
+test "the epic definition of done expands in one pass" {
+    try expectExpands(
+        "Hello $1, full input was $ARGUMENTS",
+        "Ada Lovelace",
+        "Hello Ada, full input was Ada Lovelace",
+    );
+}
+
+test "$ARGUMENTS keeps the original internal spacing" {
+    try expectExpands("[$ARGUMENTS]", "a  b\tc", "[a  b\tc]");
+}
+
+test "positional placeholders past the supplied arguments become empty" {
+    try expectExpands(
+        "1=$1 2=$2 3=$3 9=$9",
+        "a b",
+        "1=a 2=b 3= 9=",
+    );
+}
+
+test "a doubled dollar becomes one literal dollar and shields the next byte" {
+    try expectExpands("$$", "a b", "$");
+    try expectExpands("$$1", "a b", "$1");
+    try expectExpands("$$ARGUMENTS", "a b", "$ARGUMENTS");
+    try expectExpands("$$$1", "a b", "$a");
+}
+
+test "$0, $10, and $FOO are left verbatim" {
+    try expectExpands("$0", "a b", "$0");
+    try expectExpands("$10", "a b", "$10");
+    try expectExpands("$FOO", "a b", "$FOO");
+    try expectExpands("cost is 10$ today", "a b", "cost is 10$ today");
+    try expectExpands("trailing $", "a b", "trailing $");
+}
+
+test "substituted argument text is never rescanned" {
+    try expectExpands("$1", "$ARGUMENTS", "$ARGUMENTS");
+    try expectExpands("$ARGUMENTS", "$1 $ARGUMENTS", "$1 $ARGUMENTS");
+    try expectExpands("$1|$2", "$2 $1", "$2|$1");
+}
+
+test "an invocation with no arguments empties every placeholder and succeeds" {
+    try expectExpands("[$ARGUMENTS][$1][$9]", "", "[][][]");
+}
+
+test "${N:-default} uses the argument when one was supplied" {
+    try expectExpands("${1:-main}", "feature", "feature");
+    try expectExpands("checkout ${2:-main}", "origin feature", "checkout feature");
+}
+
+test "${N:-default} falls back when the argument is missing" {
+    try expectExpands("${1:-main}", "", "main");
+    try expectExpands("${2:-main}", "only", "main");
+    try expectExpands("${1:-}", "", "");
+}
+
+test "a default containing a placeholder is emitted verbatim" {
+    try expectExpands("${1:-$1}", "", "$1");
+    try expectExpands("${1:-$ARGUMENTS}", "", "$ARGUMENTS");
+    try expectExpands("${1:-$2}", "", "$2");
+}
+
+test "malformed fallback forms are emitted verbatim without failing" {
+    try expectExpands("${1:-", "a", "${1:-");
+    try expectExpands("${0:-x}", "a", "${0:-x}");
+    try expectExpands("${99:-x}", "a", "${99:-x}");
+    try expectExpands("${1}", "a", "${1}");
+    try expectExpands("${1:x}", "a", "${1:x}");
+    try expectExpands("${", "a", "${");
+    try expectExpands("$", "a", "$");
+}
+
+test "expansion fails with a diagnostic instead of outgrowing the composer" {
+    const alloc = testing.allocator;
+    const args = try alloc.alloc(u8, 1024 * 1024);
+    defer alloc.free(args);
+    @memset(args, 'x');
+
+    // Nine copies of a one-megabyte argument overshoot the eight-megabyte
+    // composer ceiling, and the failure lands before the buffer reaches it.
+    try testing.expectError(
+        error.ExpandedCommandTooLarge,
+        expand(alloc, "$1$1$1$1$1$1$1$1$1", args),
+    );
+
+    const under = try expand(alloc, "$1$1", args);
+    defer alloc.free(under);
+    try testing.expectEqual(@as(usize, 2 * 1024 * 1024), under.len);
+}
+
+test "the expansion ceiling tracks the composer limit" {
+    try testing.expectEqual(@as(usize, 8 * 1024 * 1024), max_expanded_bytes);
+    try testing.expectEqual(
+        paste_framing.default_input_limits.forOwner(.composer),
+        max_expanded_bytes,
+    );
+}

--- a/src/core/slash_commands/command_router.zig
+++ b/src/core/slash_commands/command_router.zig
@@ -3,6 +3,15 @@ const command_specs = @import("command_specs.zig");
 
 const SlashKind = command_specs.SlashKind;
 const SlashRegistry = command_specs.SlashRegistry;
+const SlashSpec = command_specs.SlashSpec;
+
+/// A `.custom` command is addressed by its position in the registry that parsed
+/// it. An index survives a registry replacement as a value that can be range
+/// checked, where a borrowed spec pointer would dangle.
+pub const CustomInvocation = struct {
+    index: usize,
+    args: []const u8,
+};
 
 pub const ParsedCommand = union(enum) {
     quit,
@@ -45,6 +54,7 @@ pub const ParsedCommand = union(enum) {
     notifications: []const u8,
     workspace: []const u8,
     version,
+    custom: CustomInvocation,
     unknown,
 };
 
@@ -90,6 +100,7 @@ pub const CommandHandlers = struct {
     handle_notifications: *const fn (ctx: *anyopaque, rest: []const u8) anyerror!void,
     handle_workspace: *const fn (ctx: *anyopaque, rest: []const u8) anyerror!void,
     show_version: *const fn (ctx: *anyopaque) anyerror!void,
+    run_custom: *const fn (ctx: *anyopaque, index: usize, args: []const u8) anyerror!void,
     unknown: *const fn (ctx: *anyopaque, cmd: []const u8) anyerror!void,
 };
 
@@ -97,7 +108,7 @@ fn command_payload(cmd: []const u8, prefix: []const u8) []const u8 {
     return std.mem.trim(u8, cmd[prefix.len..], " \t");
 }
 
-fn parsedCommand(kind: SlashKind, payload: []const u8) ParsedCommand {
+fn parsedCommand(kind: SlashKind, index: usize, payload: []const u8) ParsedCommand {
     return switch (kind) {
         .quit => .quit,
         .clear_screen => .clear_screen,
@@ -139,17 +150,28 @@ fn parsedCommand(kind: SlashKind, payload: []const u8) ParsedCommand {
         .notifications => .{ .notifications = payload },
         .workspace => .{ .workspace = payload },
         .version => .version,
+        .custom => .{ .custom = .{ .index = index, .args = payload } },
     };
 }
 
+/// Exact match anchored on `spec` rather than on its kind. `matchExact` returns
+/// the first registry entry carrying the token, so an entry that duplicates an
+/// earlier token never wins here.
+fn matchesSpecExact(registry: SlashRegistry, cmd: []const u8, spec: *const SlashSpec) bool {
+    const matched = registry.matchExact(cmd) orelse return false;
+    return matched.command == spec;
+}
+
+/// Matches against the entry being iterated, by identity. Resolving a kind back
+/// to a spec would collapse every entry sharing a kind onto the first one.
 pub fn parse(registry: SlashRegistry, cmd: []const u8) ParsedCommand {
-    for (registry.commands) |spec| {
+    for (registry.commands, 0..) |*spec, index| {
         if (spec.accepts_payload) {
-            if (command_specs.matchedSlashPrefix(registry, cmd, spec.kind)) |prefix| {
-                return parsedCommand(spec.kind, command_payload(cmd, prefix));
+            if (registry.matchEntryPrefix(cmd, spec)) |prefix| {
+                return parsedCommand(spec.kind, index, command_payload(cmd, prefix));
             }
-        } else if (command_specs.matchesSlashExact(registry, cmd, spec.kind)) {
-            return parsedCommand(spec.kind, "");
+        } else if (matchesSpecExact(registry, cmd, spec)) {
+            return parsedCommand(spec.kind, index, "");
         }
     }
     return .unknown;
@@ -197,6 +219,7 @@ pub fn route(registry: SlashRegistry, handlers: *const CommandHandlers, cmd: []c
         .notifications => |rest| try handlers.handle_notifications(handlers.ctx, rest),
         .workspace => |rest| try handlers.handle_workspace(handlers.ctx, rest),
         .version => try handlers.show_version(handlers.ctx),
+        .custom => |invocation| try handlers.run_custom(handlers.ctx, invocation.index, invocation.args),
         .unknown => try handlers.unknown(handlers.ctx, cmd),
     }
 }
@@ -401,6 +424,182 @@ test "parse trims only spaces and tabs around payload" {
     }
 }
 
+const ParseBaselineCase = struct {
+    input: []const u8,
+    tag: []const u8,
+};
+
+/// Captured from the kind-based parser before it was anchored on spec identity.
+/// Two rows per token: bare, and followed by a payload.
+const builtin_parse_baseline = [_]ParseBaselineCase{
+    .{ .input = "/help", .tag = "help" },
+    .{ .input = "/help sample", .tag = "unknown" },
+    .{ .input = "/clear", .tag = "clear_screen" },
+    .{ .input = "/clear sample", .tag = "unknown" },
+    .{ .input = "/new", .tag = "new_session" },
+    .{ .input = "/new sample", .tag = "unknown" },
+    .{ .input = "/reset", .tag = "reset_session" },
+    .{ .input = "/reset sample", .tag = "unknown" },
+    .{ .input = "/resume", .tag = "resume_session" },
+    .{ .input = "/resume sample", .tag = "unknown" },
+    .{ .input = "/continue", .tag = "continue_recovery" },
+    .{ .input = "/continue sample", .tag = "unknown" },
+    .{ .input = "/rename", .tag = "rename_session" },
+    .{ .input = "/rename sample", .tag = "rename_session" },
+    .{ .input = "/login", .tag = "login" },
+    .{ .input = "/login sample", .tag = "unknown" },
+    .{ .input = "/logout", .tag = "logout" },
+    .{ .input = "/logout sample", .tag = "logout" },
+    .{ .input = "/setup", .tag = "setup" },
+    .{ .input = "/setup sample", .tag = "unknown" },
+    .{ .input = "/stats", .tag = "stats" },
+    .{ .input = "/stats sample", .tag = "unknown" },
+    .{ .input = "/usage", .tag = "usage" },
+    .{ .input = "/usage sample", .tag = "unknown" },
+    .{ .input = "/cost", .tag = "usage" },
+    .{ .input = "/cost sample", .tag = "unknown" },
+    .{ .input = "/status", .tag = "status" },
+    .{ .input = "/status sample", .tag = "unknown" },
+    .{ .input = "/background", .tag = "background" },
+    .{ .input = "/background sample", .tag = "unknown" },
+    .{ .input = "/background stop", .tag = "background_stop" },
+    .{ .input = "/background stop sample", .tag = "background_stop" },
+    .{ .input = "/background open", .tag = "background_open" },
+    .{ .input = "/background open sample", .tag = "background_open" },
+    .{ .input = "/background logs", .tag = "background_logs" },
+    .{ .input = "/background logs sample", .tag = "background_logs" },
+    .{ .input = "/image", .tag = "image" },
+    .{ .input = "/image sample", .tag = "image" },
+    .{ .input = "/img", .tag = "image" },
+    .{ .input = "/img sample", .tag = "image" },
+    .{ .input = "/images", .tag = "images" },
+    .{ .input = "/images sample", .tag = "images" },
+    .{ .input = "/model", .tag = "model" },
+    .{ .input = "/model sample", .tag = "model" },
+    .{ .input = "/models", .tag = "models" },
+    .{ .input = "/models sample", .tag = "unknown" },
+    .{ .input = "/permissions", .tag = "permissions" },
+    .{ .input = "/permissions sample", .tag = "permissions" },
+    .{ .input = "/allowlist", .tag = "allowlist" },
+    .{ .input = "/allowlist sample", .tag = "allowlist" },
+    .{ .input = "/undo", .tag = "undo" },
+    .{ .input = "/undo sample", .tag = "unknown" },
+    .{ .input = "/mcp", .tag = "mcp" },
+    .{ .input = "/mcp sample", .tag = "mcp" },
+    .{ .input = "/skills", .tag = "skills" },
+    .{ .input = "/skills sample", .tag = "skills" },
+    .{ .input = "/copy", .tag = "copy" },
+    .{ .input = "/copy sample", .tag = "unknown" },
+    .{ .input = "/feedback", .tag = "feedback" },
+    .{ .input = "/feedback sample", .tag = "unknown" },
+    .{ .input = "/trace", .tag = "trace" },
+    .{ .input = "/trace sample", .tag = "unknown" },
+    .{ .input = "/compact", .tag = "compact" },
+    .{ .input = "/compact sample", .tag = "unknown" },
+    .{ .input = "/settings", .tag = "settings" },
+    .{ .input = "/settings sample", .tag = "settings" },
+    .{ .input = "/alias", .tag = "alias" },
+    .{ .input = "/alias sample", .tag = "alias" },
+    .{ .input = "/credits", .tag = "credits" },
+    .{ .input = "/credits sample", .tag = "unknown" },
+    .{ .input = "/balance", .tag = "credits" },
+    .{ .input = "/balance sample", .tag = "unknown" },
+    .{ .input = "/paste", .tag = "paste" },
+    .{ .input = "/paste sample", .tag = "unknown" },
+    .{ .input = "/fast", .tag = "fast" },
+    .{ .input = "/fast sample", .tag = "unknown" },
+    .{ .input = "/statusline", .tag = "statusline" },
+    .{ .input = "/statusline sample", .tag = "statusline" },
+    .{ .input = "/sound", .tag = "notifications" },
+    .{ .input = "/sound sample", .tag = "notifications" },
+    .{ .input = "/workspace", .tag = "workspace" },
+    .{ .input = "/workspace sample", .tag = "workspace" },
+    .{ .input = "/version", .tag = "version" },
+    .{ .input = "/version sample", .tag = "unknown" },
+    .{ .input = "/quit", .tag = "quit" },
+    .{ .input = "/quit sample", .tag = "unknown" },
+    .{ .input = "/exit", .tag = "quit" },
+    .{ .input = "/exit sample", .tag = "unknown" },
+};
+
+test "parse resolves every builtin token and alias to its pre-refactor variant" {
+    const registry = testSlashRegistry();
+    for (builtin_parse_baseline) |case| {
+        try std.testing.expectEqualStrings(case.tag, @tagName(parse(registry, case.input)));
+    }
+
+    var expected_rows: usize = 0;
+    for (registry.commands) |spec| expected_rows += 2 * (1 + spec.aliases.len);
+    try std.testing.expectEqual(expected_rows, builtin_parse_baseline.len);
+}
+
+const same_kind_payload_specs = [_]command_specs.SlashSpec{
+    .{ .kind = .custom, .command = "/alpha", .accepts_payload = true },
+    .{ .kind = .custom, .command = "/beta", .accepts_payload = true },
+    .{ .kind = .custom, .command = "/gamma", .accepts_payload = true },
+};
+
+const same_kind_exact_specs = [_]command_specs.SlashSpec{
+    .{ .kind = .custom, .command = "/alpha" },
+    .{ .kind = .custom, .command = "/beta" },
+    .{ .kind = .custom, .command = "/gamma" },
+};
+
+fn expectCustomAt(parsed: ParsedCommand, index: usize, args: []const u8) !void {
+    switch (parsed) {
+        .custom => |invocation| {
+            try std.testing.expectEqual(index, invocation.index);
+            try std.testing.expectEqualStrings(args, invocation.args);
+        },
+        else => return error.TestExpectedCustomCommand,
+    }
+}
+
+test "parse dispatches payload specs sharing one slash kind to their own entry" {
+    const registry = SlashRegistry{ .commands = same_kind_payload_specs[0..] };
+
+    try expectCustomAt(parse(registry, "/alpha one"), 0, "one");
+    try expectCustomAt(parse(registry, "/beta two"), 1, "two");
+    try expectCustomAt(parse(registry, "/gamma three"), 2, "three");
+    try expectCustomAt(parse(registry, "/gamma"), 2, "");
+    try std.testing.expectEqual(ParsedCommand.unknown, parse(registry, "/delta"));
+}
+
+test "parse dispatches non-payload specs sharing one slash kind to their own entry" {
+    const registry = SlashRegistry{ .commands = same_kind_exact_specs[0..] };
+
+    try expectCustomAt(parse(registry, "/alpha"), 0, "");
+    try expectCustomAt(parse(registry, "/beta"), 1, "");
+    try expectCustomAt(parse(registry, "/gamma"), 2, "");
+    try std.testing.expectEqual(ParsedCommand.unknown, parse(registry, "/beta payload"));
+}
+
+test "parse returns unknown for kinds absent from a filtered registry" {
+    var storage: [command_specs.child_chat_slash_command_count]command_specs.SlashSpec = undefined;
+    const child = command_specs.childChatSlashRegistry(testSlashRegistry(), &storage);
+
+    try std.testing.expectEqual(ParsedCommand.unknown, parse(child, "/help"));
+    try std.testing.expectEqual(ParsedCommand.unknown, parse(child, "/model claude-opus"));
+    try std.testing.expectEqual(ParsedCommand.unknown, parse(child, "/mcp list"));
+    try std.testing.expectEqual(ParsedCommand.quit, parse(child, "/quit"));
+}
+
+test "parse keeps the whitespace boundary between a builtin and a longer token" {
+    try std.testing.expectEqual(ParsedCommand.unknown, parse(testSlashRegistry(), "/model-review 512"));
+
+    var merged: [2]command_specs.SlashSpec = .{
+        (testSlashRegistry().lookup("/model") orelse return error.TestExpectedEqual).*,
+        .{ .kind = .custom, .command = "/model-review", .accepts_payload = true },
+    };
+    const registry = SlashRegistry{ .commands = merged[0..] };
+
+    try expectCustomAt(parse(registry, "/model-review 512"), 1, "512");
+    switch (parse(registry, "/model claude-opus")) {
+        .model => |query| try std.testing.expectEqualStrings("claude-opus", query),
+        else => return error.TestExpectedModelCommand,
+    }
+}
+
 fn parsedIsUnknown(parsed: ParsedCommand) bool {
     return switch (parsed) {
         .unknown => true,
@@ -433,6 +632,7 @@ test "parse payload acceptance follows slash spec metadata" {
 const TestContext = struct {
     called: []const u8 = "",
     payload: []const u8 = "",
+    custom_index: usize = std.math.maxInt(usize),
 };
 
 fn testContext(ctx: *anyopaque) *TestContext {
@@ -447,6 +647,13 @@ fn unexpectedNoPayload(ctx: *anyopaque) anyerror!void {
 fn unexpectedPayload(ctx: *anyopaque, value: []const u8) anyerror!void {
     _ = ctx;
     _ = value;
+    return error.UnexpectedCallback;
+}
+
+fn unexpectedCustom(ctx: *anyopaque, index: usize, args: []const u8) anyerror!void {
+    _ = ctx;
+    _ = index;
+    _ = args;
     return error.UnexpectedCallback;
 }
 
@@ -545,6 +752,7 @@ fn testHandlers(ctx: *TestContext) CommandHandlers {
         .handle_notifications = unexpectedPayload,
         .handle_workspace = unexpectedPayload,
         .show_version = unexpectedNoPayload,
+        .run_custom = unexpectedCustom,
         .unknown = unexpectedPayload,
     };
 }
@@ -650,6 +858,31 @@ test "route sends original command string to unknown handler" {
     try std.testing.expectEqualStrings("unknown", ctx.called);
     try std.testing.expectEqualStrings(cmd, ctx.payload);
     try std.testing.expect(ctx.payload.ptr == cmd.ptr);
+}
+
+fn recordCustom(ctx: *anyopaque, index: usize, args: []const u8) anyerror!void {
+    const test_context = testContext(ctx);
+    test_context.called = "custom";
+    test_context.custom_index = index;
+    test_context.payload = args;
+}
+
+test "route dispatches each same-kind custom entry to the custom handler" {
+    const registry = SlashRegistry{ .commands = same_kind_payload_specs[0..] };
+
+    for ([_][]const u8{ "/alpha", "/beta", "/gamma" }, 0..) |token, expected_index| {
+        var ctx: TestContext = .{};
+        var handlers = testHandlers(&ctx);
+        handlers.run_custom = recordCustom;
+        var buf: [64]u8 = undefined;
+        const cmd = try std.fmt.bufPrint(&buf, "{s} payload", .{token});
+
+        try route(registry, &handlers, cmd);
+
+        try std.testing.expectEqualStrings("custom", ctx.called);
+        try std.testing.expectEqual(expected_index, ctx.custom_index);
+        try std.testing.expectEqualStrings("payload", ctx.payload);
+    }
 }
 
 test "route propagates callback errors" {

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -72,6 +72,9 @@ pub const SlashKind = enum {
     notifications,
     workspace,
     version,
+    /// Runtime-registered command. Several specs share this kind, so it is the
+    /// one kind that never resolves through a kind-to-spec lookup.
+    custom,
 };
 
 pub const OptionDoc = struct {
@@ -163,6 +166,9 @@ pub const SlashSpec = struct {
     aliases: []const []const u8 = &.{},
     show_aliases_in_completion: bool = true,
     help_entry: ?[]const u8 = null,
+    /// Display-only override for the completion row. Insertion always uses
+    /// `command`, so a decorated label cannot corrupt what gets typed.
+    completion_label: ?[]const u8 = null,
     completion_description: ?[]const u8 = null,
     presentation_category: ?SlashPresentationCategory = null,
     show_in_welcome: bool = false,
@@ -606,7 +612,14 @@ pub fn nthSlashCompletionLabel(registry: SlashRegistry, prefix: []const u8, n: u
     if (workspaceArgCompletionPrefix(prefix)) |query| {
         return nthWorkspaceArgLabel(query, n);
     }
-    return nthSlashCompletion(registry, prefix, n);
+    if (prefix.len == 0 or prefix[0] != '/') return null;
+    const match = nthSlashCommandCompletionMatch(registry, prefix, n) orelse return null;
+    // An alias keeps its own bare form: the decorated label describes the
+    // primary token only.
+    if (match.spec.completion_label) |label| {
+        if (std.mem.eql(u8, match.command, match.spec.command)) return label;
+    }
+    return match.command;
 }
 
 pub fn nthSlashCompletionDescription(registry: SlashRegistry, prefix: []const u8, n: usize) ?[]const u8 {
@@ -1444,7 +1457,9 @@ fn topLevelTokenOccurrences(registry: TopLevelRegistry, token: []const u8) usize
     return count;
 }
 
-fn slashTokenOccurrences(registry: SlashRegistry, token: []const u8) usize {
+/// Counts how many entries publish `token`. The merged runtime registry has to
+/// hold the same uniqueness invariant the builtin array is asserted against.
+pub fn slashTokenOccurrences(registry: SlashRegistry, token: []const u8) usize {
     var count: usize = 0;
     for (registry.commands) |spec| {
         if (std.mem.eql(u8, token, spec.command)) count += 1;
@@ -1805,7 +1820,7 @@ test "top-level specs cover every TopLevelKind" {
     }
 }
 
-test "slash specs cover every SlashKind" {
+test "slash specs cover every builtin SlashKind" {
     var seen = [_]bool{false} ** std.meta.fields(SlashKind).len;
     const registry = testSlashRegistry();
     for (registry.commands) |spec| {
@@ -1815,6 +1830,12 @@ test "slash specs cover every SlashKind" {
     }
     inline for (std.meta.fields(SlashKind)) |field| {
         const kind: SlashKind = @enumFromInt(field.value);
+        // `.custom` is registered at runtime by several specs at once, so the
+        // builtin array neither carries it nor supports a kind-to-spec lookup.
+        if (kind == .custom) {
+            try std.testing.expect(!seen[@intFromEnum(kind)]);
+            continue;
+        }
         try std.testing.expect(seen[@intFromEnum(kind)]);
         _ = slashSpec(registry, kind);
     }

--- a/src/core/slash_commands/custom_commands.zig
+++ b/src/core/slash_commands/custom_commands.zig
@@ -1215,9 +1215,15 @@ test "a same-root duplicate keeps the first entry in directory order" {
     defer prompts_dir.close(io_mod.getIo());
     var iterator = prompts_dir.iterate();
     const first_entry = (try iterator.next(io_mod.getIo())).?;
+    const second_entry = (try iterator.next(io_mod.getIo())) orelse {
+        // A case-insensitive volume cannot represent both extension variants,
+        // so the same-root collision is not constructible on that filesystem.
+        return error.SkipZigTest;
+    };
     const first_name = try alloc.dupe(u8, first_entry.name);
     defer alloc.free(first_name);
-    const second_name = if (std.mem.eql(u8, first_name, "foo.md")) "foo.MD" else "foo.md";
+    const second_name = try alloc.dupe(u8, second_entry.name);
+    defer alloc.free(second_name);
 
     var discovery = try loadFromTmp(alloc, &tmp, "workspace");
     defer discovery.deinit(alloc);

--- a/src/core/slash_commands/custom_commands.zig
+++ b/src/core/slash_commands/custom_commands.zig
@@ -1,0 +1,1695 @@
+//! Discovery of user-authored slash commands stored as `.md` files under the
+//! configured command roots. Discovery never fails the caller: every rejected
+//! file becomes exactly one typed diagnostic and every other file in the same
+//! root still loads.
+
+const std = @import("std");
+
+const command_specs = @import("command_specs.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
+const io_mod = @import("../shared/io.zig");
+const pathing = @import("../workspace/pathing.zig");
+const skill_contract = @import("../skills/skill_contract.zig");
+
+const Allocator = std.mem.Allocator;
+const SkillSource = skill_contract.SkillSource;
+
+/// Total number of command files read per load, across every root.
+const max_commands: usize = 256;
+const max_command_file_bytes: usize = 262_144;
+const max_command_name_bytes: usize = 64;
+const max_argument_hint_bytes: usize = 128;
+
+const command_file_extension = ".md";
+const argument_hint_key = "argument-hint";
+
+/// One discovered command. Every slice is owned by the discovery allocator.
+pub const CustomCommand = struct {
+    name: []u8,
+    description: []u8,
+    /// False when `description` is the root-derived fallback. The merged spec
+    /// appends the source label only to a frontmatter description, so a row
+    /// never names its root twice.
+    has_explicit_description: bool,
+    argument_hint: ?[]u8,
+    body: []u8,
+    path: []u8,
+    source: SkillSource,
+};
+
+pub const CommandDiagnosticCause = union(enum) {
+    /// A command root exists but could not be opened or iterated.
+    unreadable_root,
+    /// A command file could not be opened, stat'ed, or read.
+    unreadable,
+    oversized,
+    invalid_frontmatter,
+    empty_body,
+    invalid_name,
+    /// The derived name matches a builtin token or alias, case-insensitively.
+    builtin_collision,
+    /// An earlier root already published this name.
+    shadowed,
+    /// The same root already published this name.
+    duplicate_name,
+    /// A symlinked entry whose canonical target leaves its root.
+    escapes_root,
+    /// Files left unread once the load hit `max_commands`.
+    count_cap: usize,
+};
+
+pub const CommandDiagnostic = struct {
+    /// Owned. The file path for file-scoped causes, the root path for
+    /// `.unreadable_root`, and empty for `.count_cap`.
+    path: []u8,
+    /// Owned derived name, present once a name exists.
+    name: ?[]u8 = null,
+    /// Owned. The colliding builtin token for `.builtin_collision` and the
+    /// winning file path for `.shadowed`.
+    detail: ?[]u8 = null,
+    source: SkillSource,
+    cause: CommandDiagnosticCause,
+};
+
+pub const CommandDiscovery = struct {
+    commands: []CustomCommand = &.{},
+    diagnostics: []CommandDiagnostic = &.{},
+
+    pub fn deinit(self: *CommandDiscovery, alloc: Allocator) void {
+        freeCommands(alloc, self.commands);
+        freeDiagnostics(alloc, self.diagnostics);
+        self.* = .{};
+    }
+};
+
+fn freeCommand(alloc: Allocator, command: CustomCommand) void {
+    alloc.free(command.name);
+    alloc.free(command.description);
+    if (command.argument_hint) |hint| alloc.free(hint);
+    alloc.free(command.body);
+    alloc.free(command.path);
+}
+
+fn freeCommands(alloc: Allocator, commands: []CustomCommand) void {
+    for (commands) |command| freeCommand(alloc, command);
+    if (commands.len > 0) alloc.free(commands);
+}
+
+fn freeDiagnostic(alloc: Allocator, diagnostic: CommandDiagnostic) void {
+    alloc.free(diagnostic.path);
+    if (diagnostic.name) |name| alloc.free(name);
+    if (diagnostic.detail) |detail| alloc.free(detail);
+}
+
+fn freeDiagnostics(alloc: Allocator, diagnostics: []CommandDiagnostic) void {
+    for (diagnostics) |diagnostic| freeDiagnostic(alloc, diagnostic);
+    if (diagnostics.len > 0) alloc.free(diagnostics);
+}
+
+/// Writes the user-facing text for one diagnostic. The trace channel and every
+/// future surface share this single wording.
+fn writeDiagnosticMessage(writer: *std.Io.Writer, diagnostic: CommandDiagnostic) !void {
+    const name = diagnostic.name orelse "";
+    switch (diagnostic.cause) {
+        .unreadable_root => try writer.print("cannot read command root: {s}", .{diagnostic.path}),
+        .unreadable => try writer.print("cannot read command file: {s}", .{diagnostic.path}),
+        .oversized => try writer.print(
+            "command file exceeds {d} bytes: {s}",
+            .{ max_command_file_bytes, diagnostic.path },
+        ),
+        .invalid_frontmatter => try writer.print("invalid command frontmatter: {s}", .{diagnostic.path}),
+        .empty_body => try writer.print("command file has an empty body: {s}", .{diagnostic.path}),
+        .invalid_name => try writer.print("invalid command name derived from {s}", .{diagnostic.path}),
+        .builtin_collision => try writer.print(
+            "command '{s}' conflicts with a built-in command: {s}",
+            .{ diagnostic.detail orelse name, diagnostic.path },
+        ),
+        .shadowed => try writer.print(
+            "command '{s}' from {s} is shadowed by {s}",
+            .{ name, diagnostic.path, diagnostic.detail orelse "" },
+        ),
+        .duplicate_name => try writer.print(
+            "duplicate command '{s}': {s} ignored",
+            .{ name, diagnostic.path },
+        ),
+        .escapes_root => try writer.print("command file escapes its root: {s}", .{diagnostic.path}),
+        .count_cap => |skipped| try writer.print(
+            "skipped {d} command files above the {d} limit",
+            .{ skipped, max_commands },
+        ),
+    }
+}
+
+/// Routes discovery diagnostics through the trace channel skills already use.
+/// No diagnostic blocks or delays startup.
+pub fn traceDiagnostics(surface: []const u8, diagnostics: []const CommandDiagnostic) void {
+    for (diagnostics) |diagnostic| {
+        var message_buf: [1024]u8 = undefined;
+        var message_writer = std.Io.Writer.fixed(&message_buf);
+        writeDiagnosticMessage(&message_writer, diagnostic) catch {};
+        debug_trace.logf(
+            "commands",
+            "discovery_diagnostic surface={s} source={s} cause={s} message=\"{f}\"",
+            .{
+                surface,
+                @tagName(diagnostic.source),
+                @tagName(diagnostic.cause),
+                std.zig.fmtString(message_writer.buffered()),
+            },
+        );
+    }
+}
+
+const CommandRoot = struct {
+    path: []const u8,
+    source: SkillSource,
+};
+
+const CommandEntry = struct {
+    name: []u8,
+    linked: bool,
+};
+
+/// Deduplicates roots that resolve to the same directory so a symlinked or
+/// repeated root is read exactly once per load.
+const CanonicalRoots = struct {
+    paths: std.StringHashMapUnmanaged(void) = .empty,
+
+    fn deinit(self: *CanonicalRoots, alloc: Allocator) void {
+        var keys = self.paths.keyIterator();
+        while (keys.next()) |path| alloc.free(@constCast(path.*));
+        self.paths.deinit(alloc);
+        self.* = .{};
+    }
+
+    /// Takes ownership of `canonical_path` when it is new.
+    fn remember(self: *CanonicalRoots, alloc: Allocator, canonical_path: []u8) !bool {
+        if (self.paths.contains(canonical_path)) return false;
+        try self.paths.put(alloc, canonical_path, {});
+        return true;
+    }
+};
+
+const LoadState = struct {
+    alloc: Allocator,
+    commands: *std.ArrayList(CustomCommand),
+    diagnostics: *std.ArrayList(CommandDiagnostic),
+    by_name: *std.StringHashMapUnmanaged(usize),
+    reserved: command_specs.SlashRegistry,
+    considered: usize = 0,
+    skipped_over_cap: usize = 0,
+};
+
+pub fn loadCustomCommands(
+    alloc: Allocator,
+    workspace_root: ?[]const u8,
+    home: ?[]const u8,
+    user_prompts_dir: []const u8,
+    root_policy: skill_contract.RootPolicy,
+    reserved: command_specs.SlashRegistry,
+) !CommandDiscovery {
+    var commands: std.ArrayList(CustomCommand) = .empty;
+    errdefer {
+        for (commands.items) |command| freeCommand(alloc, command);
+        commands.deinit(alloc);
+    }
+    var diagnostics: std.ArrayList(CommandDiagnostic) = .empty;
+    errdefer {
+        for (diagnostics.items) |diagnostic| freeDiagnostic(alloc, diagnostic);
+        diagnostics.deinit(alloc);
+    }
+    var by_name: std.StringHashMapUnmanaged(usize) = .empty;
+    defer by_name.deinit(alloc);
+
+    var roots: std.ArrayList(CommandRoot) = .empty;
+    defer {
+        for (roots.items) |root| alloc.free(@constCast(root.path));
+        roots.deinit(alloc);
+    }
+
+    if (workspace_root) |root| {
+        try appendWorkspaceRoots(alloc, &roots, root, home, root_policy.workspace_roots);
+    }
+    if (root_policy.managed_root_source) |source| {
+        try appendRoot(alloc, &roots, try alloc.dupe(u8, user_prompts_dir), source);
+    }
+    if (home) |home_root| {
+        for (root_policy.global_roots) |spec| {
+            try appendRoot(alloc, &roots, try std.fs.path.join(alloc, &.{ home_root, spec.path }), spec.source);
+        }
+    }
+
+    var canonical_roots: CanonicalRoots = .{};
+    defer canonical_roots.deinit(alloc);
+
+    var state: LoadState = .{
+        .alloc = alloc,
+        .commands = &commands,
+        .diagnostics = &diagnostics,
+        .by_name = &by_name,
+        .reserved = reserved,
+    };
+
+    for (roots.items) |root| {
+        try appendCommandsFromRoot(&state, &canonical_roots, root);
+    }
+
+    if (state.skipped_over_cap > 0) {
+        try appendDiagnostic(alloc, &diagnostics, "", null, null, .global_fx, .{ .count_cap = state.skipped_over_cap });
+    }
+
+    const owned_commands = try commands.toOwnedSlice(alloc);
+    errdefer freeCommands(alloc, owned_commands);
+    const owned_diagnostics = try diagnostics.toOwnedSlice(alloc);
+    return .{ .commands = owned_commands, .diagnostics = owned_diagnostics };
+}
+
+/// Walks the workspace root and each ancestor, stopping at the home directory
+/// so a command root above `$HOME` is never read.
+fn appendWorkspaceRoots(
+    alloc: Allocator,
+    roots: *std.ArrayList(CommandRoot),
+    workspace_root: []const u8,
+    home: ?[]const u8,
+    root_specs: []const skill_contract.RootSpec,
+) !void {
+    // Without a usable home boundary, discover only the workspace itself. The
+    // immediate root is always in scope, while walking any parent could load a
+    // prompt from outside the user's intended workspace hierarchy. A home that
+    // is not an ancestor is no boundary at all, so it follows the same rule.
+    if (home == null or !pathing.pathInside(home.?, workspace_root)) {
+        for (root_specs) |spec| {
+            try appendRoot(alloc, roots, try std.fs.path.join(alloc, &.{ workspace_root, spec.path }), spec.source);
+        }
+        return;
+    }
+
+    var current: ?[]const u8 = workspace_root;
+    while (current) |dir| : (current = std.fs.path.dirname(dir)) {
+        if (home) |home_root| {
+            if (std.mem.eql(u8, dir, home_root)) break;
+        }
+        for (root_specs) |spec| {
+            try appendRoot(alloc, roots, try std.fs.path.join(alloc, &.{ dir, spec.path }), spec.source);
+        }
+    }
+}
+
+/// Takes ownership of `path`.
+fn appendRoot(alloc: Allocator, roots: *std.ArrayList(CommandRoot), path: []u8, source: SkillSource) !void {
+    for (roots.items) |root| {
+        if (std.mem.eql(u8, root.path, path)) {
+            alloc.free(path);
+            return;
+        }
+    }
+    roots.append(alloc, .{ .path = path, .source = source }) catch |err| {
+        alloc.free(path);
+        return err;
+    };
+}
+
+fn appendCommandsFromRoot(state: *LoadState, canonical_roots: *CanonicalRoots, root: CommandRoot) !void {
+    const alloc = state.alloc;
+    const canonical_root = io_mod.realpathAlloc(alloc, root.path) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        // An absent root is the normal case and never produces a diagnostic.
+        if (err == error.FileNotFound or err == error.NotDir) return;
+        try appendDiagnostic(alloc, state.diagnostics, root.path, null, null, root.source, .unreadable_root);
+        return;
+    };
+    var canonical_owned = true;
+    defer if (canonical_owned) alloc.free(canonical_root);
+
+    if (!try canonical_roots.remember(alloc, canonical_root)) return;
+    canonical_owned = false;
+
+    var dir = io_mod.openDirAbsoluteNoFollow(canonical_root, .{ .iterate = true }) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        if (err == error.FileNotFound) return;
+        try appendDiagnostic(alloc, state.diagnostics, root.path, null, null, root.source, .unreadable_root);
+        return;
+    };
+    defer dir.close(io_mod.getIo());
+
+    var entries: std.ArrayList(CommandEntry) = .empty;
+    defer {
+        for (entries.items) |entry| alloc.free(entry.name);
+        entries.deinit(alloc);
+    }
+
+    var it = dir.iterate();
+    while (true) {
+        const entry = it.next(io_mod.getIo()) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            try appendDiagnostic(alloc, state.diagnostics, root.path, null, null, root.source, .unreadable_root);
+            break;
+        } orelse break;
+        // Subdirectories are never descended into and never treated as commands.
+        if (entry.kind == .directory) continue;
+        const linked = entry.kind == .sym_link;
+        if (entry.kind != .file and !linked) continue;
+        if (!hasCommandExtension(entry.name)) continue;
+
+        const owned_name = try alloc.dupe(u8, entry.name);
+        entries.append(alloc, .{ .name = owned_name, .linked = linked }) catch |err| {
+            alloc.free(owned_name);
+            return err;
+        };
+    }
+
+    for (entries.items) |entry| {
+        try appendCommandCandidate(state, root, canonical_root, &dir, entry);
+    }
+}
+
+fn appendCommandCandidate(
+    state: *LoadState,
+    root: CommandRoot,
+    canonical_root: []const u8,
+    dir: *std.Io.Dir,
+    entry: CommandEntry,
+) !void {
+    const alloc = state.alloc;
+    if (state.considered >= max_commands) {
+        state.skipped_over_cap += 1;
+        return;
+    }
+    state.considered += 1;
+
+    const file_path = try std.fs.path.join(alloc, &.{ root.path, entry.name });
+    defer alloc.free(file_path);
+
+    var file = (try openCommandFile(alloc, state, root, canonical_root, dir, entry, file_path)) orelse return;
+    defer file.close(io_mod.getIo());
+
+    const stat = file.stat(io_mod.getIo()) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .unreadable);
+        return;
+    };
+    if (stat.kind != .file) {
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .unreadable);
+        return;
+    }
+    if (stat.size > max_command_file_bytes) {
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .oversized);
+        return;
+    }
+
+    const content = io_mod.readFileToEnd(alloc, &file, max_command_file_bytes) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        const cause: CommandDiagnosticCause = if (err == error.StreamTooLong) .oversized else .unreadable;
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, cause);
+        return;
+    };
+    defer alloc.free(content);
+
+    const parsed = skill_contract.parseSkillFileWithOptions(content, .{
+        .name_mode = .ignored,
+        .additional_scalar_key = argument_hint_key,
+        .preserve_body_prefix = true,
+    });
+    switch (parsed.status) {
+        .invalid => {
+            try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .invalid_frontmatter);
+            return;
+        },
+        .valid, .no_frontmatter => {},
+    }
+    // A frontmatter block above the supported header size is rejected rather
+    // than parsed from a truncated prefix.
+    if (content.len - parsed.body.len > skill_contract.max_frontmatter_bytes) {
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .invalid_frontmatter);
+        return;
+    }
+
+    const body = parsed.body;
+    if (std.mem.trim(u8, body, " \t\r\n").len == 0) {
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .empty_body);
+        return;
+    }
+
+    const derived_name = commandNameStem(entry.name);
+    if (!validCommandName(derived_name)) {
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .invalid_name);
+        return;
+    }
+
+    if (reservedCollision(state.reserved, derived_name)) |builtin_token| {
+        try appendDiagnostic(alloc, state.diagnostics, file_path, derived_name, builtin_token, root.source, .builtin_collision);
+        return;
+    }
+
+    if (state.by_name.get(derived_name)) |winner_index| {
+        const winner = state.commands.items[winner_index];
+        const winner_root = std.fs.path.dirname(winner.path) orelse "";
+        const same_root = std.mem.eql(u8, winner_root, root.path);
+        try appendDiagnostic(
+            alloc,
+            state.diagnostics,
+            file_path,
+            derived_name,
+            if (same_root) null else winner.path,
+            root.source,
+            if (same_root) .duplicate_name else .shadowed,
+        );
+        return;
+    }
+
+    try appendCommand(state, root, file_path, derived_name, parsed, body);
+}
+
+fn appendCommand(
+    state: *LoadState,
+    root: CommandRoot,
+    file_path: []const u8,
+    derived_name: []const u8,
+    parsed: skill_contract.ParsedSkillFile,
+    body: []const u8,
+) !void {
+    const alloc = state.alloc;
+    const name = try alloc.dupe(u8, derived_name);
+    errdefer alloc.free(name);
+
+    const has_explicit_description = parsed.description != null;
+    const description = if (parsed.description) |raw| description: {
+        const metadata: skill_contract.SkillMetadata = .{
+            .name = derived_name,
+            .description = raw,
+            .description_block = parsed.description_block,
+        };
+        const decoded = try alloc.alloc(u8, metadata.description_len());
+        metadata.write_description(decoded);
+        break :description decoded;
+    } else description: {
+        const display_root = try encodeSourceRoot(alloc, root.path);
+        defer alloc.free(display_root);
+        break :description try std.fmt.allocPrint(alloc, "custom command from {s}", .{display_root});
+    };
+    errdefer alloc.free(description);
+
+    const argument_hint = if (parsed.additional_scalar) |raw|
+        try sanitizeArgumentHint(alloc, raw)
+    else
+        null;
+    errdefer if (argument_hint) |hint| alloc.free(hint);
+
+    const owned_body = try alloc.dupe(u8, body);
+    errdefer alloc.free(owned_body);
+    const owned_path = try alloc.dupe(u8, file_path);
+    errdefer alloc.free(owned_path);
+
+    // Reserved before the append so no fallible step follows it and the
+    // command list can never hold an entry the name index does not know.
+    try state.by_name.ensureUnusedCapacity(alloc, 1);
+    try state.commands.append(alloc, .{
+        .name = name,
+        .description = description,
+        .has_explicit_description = has_explicit_description,
+        .argument_hint = argument_hint,
+        .body = owned_body,
+        .path = owned_path,
+        .source = root.source,
+    });
+    state.by_name.putAssumeCapacity(name, state.commands.items.len - 1);
+}
+
+/// Opens a candidate, enforcing that a symlinked entry never resolves outside
+/// its own root. Returns null when the entry produced a diagnostic or vanished.
+fn openCommandFile(
+    alloc: Allocator,
+    state: *LoadState,
+    root: CommandRoot,
+    canonical_root: []const u8,
+    dir: *std.Io.Dir,
+    entry: CommandEntry,
+    file_path: []const u8,
+) !?std.Io.File {
+    if (!entry.linked) {
+        return io_mod.openExistingReadOnlyRegularFile(dir.*, entry.name, .no_follow) catch |err| {
+            if (err == error.OutOfMemory) return error.OutOfMemory;
+            if (err == error.FileNotFound) return null;
+            try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .unreadable);
+            return null;
+        };
+    }
+
+    const target_path = io_mod.dirRealpathAlloc(alloc, dir.*, entry.name) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .escapes_root);
+        return null;
+    };
+    defer alloc.free(target_path);
+    if (!pathing.pathInside(canonical_root, target_path)) {
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .escapes_root);
+        return null;
+    }
+
+    var file = io_mod.openExistingReadOnlyRegularFile(dir.*, entry.name, .follow) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        if (err == error.FileNotFound) return null;
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .unreadable);
+        return null;
+    };
+    errdefer file.close(io_mod.getIo());
+
+    // Recheck after opening so a link swapped between preflight and open is
+    // still rejected before a single byte is read.
+    const opened_path = io_mod.openedFilePathAlloc(alloc, file) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        file.close(io_mod.getIo());
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .escapes_root);
+        return null;
+    };
+    defer alloc.free(opened_path);
+    if (!pathing.pathInside(canonical_root, opened_path)) {
+        file.close(io_mod.getIo());
+        try appendDiagnostic(alloc, state.diagnostics, file_path, null, null, root.source, .escapes_root);
+        return null;
+    }
+    return file;
+}
+
+fn appendDiagnostic(
+    alloc: Allocator,
+    diagnostics: *std.ArrayList(CommandDiagnostic),
+    path: []const u8,
+    name: ?[]const u8,
+    detail: ?[]const u8,
+    source: SkillSource,
+    cause: CommandDiagnosticCause,
+) !void {
+    const owned_path = try alloc.dupe(u8, path);
+    errdefer alloc.free(owned_path);
+    const owned_name = if (name) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (owned_name) |value| alloc.free(value);
+    const owned_detail = if (detail) |value| try alloc.dupe(u8, value) else null;
+    errdefer if (owned_detail) |value| alloc.free(value);
+
+    try diagnostics.append(alloc, .{
+        .path = owned_path,
+        .name = owned_name,
+        .detail = owned_detail,
+        .source = source,
+        .cause = cause,
+    });
+}
+
+/// Matches `.md` case-insensitively so `foo.MD` is a command file too.
+fn hasCommandExtension(file_name: []const u8) bool {
+    if (file_name.len <= command_file_extension.len) return false;
+    const suffix = file_name[file_name.len - command_file_extension.len ..];
+    return std.ascii.eqlIgnoreCase(suffix, command_file_extension);
+}
+
+fn commandNameStem(file_name: []const u8) []const u8 {
+    return file_name[0 .. file_name.len - command_file_extension.len];
+}
+
+/// Restricts names to `[A-Za-z_][A-Za-z0-9_-]*` within 64 bytes, so no name can
+/// encode whitespace, a leading digit, a path separator, or `..`.
+pub fn validCommandName(name: []const u8) bool {
+    if (name.len == 0 or name.len > max_command_name_bytes) return false;
+    if (!std.ascii.isAlphabetic(name[0]) and name[0] != '_') return false;
+    for (name) |byte| {
+        if (std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_') continue;
+        return false;
+    }
+    return true;
+}
+
+/// Registry tokens carry their leading slash; a derived command name never
+/// does. Comparing the two verbatim would never match, so the slash is dropped
+/// before the comparison.
+fn tokenName(token: []const u8) []const u8 {
+    return if (token.len > 0 and token[0] == '/') token[1..] else token;
+}
+
+/// Slash matching is byte-exact, so a case-only near-miss of a builtin is a
+/// user error rather than a distinct command. Returns the colliding token in
+/// the same slashless shape as a derived command name.
+pub fn reservedCollision(reserved: command_specs.SlashRegistry, name: []const u8) ?[]const u8 {
+    for (reserved.commands) |spec| {
+        const command = tokenName(spec.command);
+        if (std.ascii.eqlIgnoreCase(command, name)) return command;
+        for (spec.aliases) |alias| {
+            const alias_name = tokenName(alias);
+            if (std.ascii.eqlIgnoreCase(alias_name, name)) return alias_name;
+        }
+    }
+    return null;
+}
+
+/// Strips control bytes and truncates at a UTF-8 boundary so a hint can never
+/// corrupt the TUI layout.
+fn sanitizeArgumentHint(alloc: Allocator, raw: []const u8) !?[]u8 {
+    var cleaned: std.ArrayList(u8) = .empty;
+    defer cleaned.deinit(alloc);
+    for (raw) |byte| {
+        if (byte < 0x20 or byte == 0x7f) continue;
+        try cleaned.append(alloc, byte);
+    }
+
+    var end = cleaned.items.len;
+    if (end > max_argument_hint_bytes) {
+        end = max_argument_hint_bytes;
+        while (end > 0 and cleaned.items[end] & 0xC0 == 0x80) end -= 1;
+    }
+    const trimmed = std.mem.trim(u8, cleaned.items[0..end], " \t");
+    if (trimmed.len == 0) return null;
+    return try alloc.dupe(u8, trimmed);
+}
+
+/// Encodes every non-printable or non-ASCII source byte as `\xNN`. Source
+/// roots are filesystem data, so they must not inject terminal controls or
+/// depend on color to remain distinguishable in help and completion.
+fn encodeSourceRoot(alloc: Allocator, raw: []const u8) ![]u8 {
+    const hex = "0123456789ABCDEF";
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+    for (raw) |byte| {
+        if (byte >= 0x20 and byte <= 0x7e) {
+            try out.append(alloc, byte);
+        } else {
+            try out.appendSlice(alloc, "\\x");
+            try out.append(alloc, hex[byte >> 4]);
+            try out.append(alloc, hex[byte & 0x0f]);
+        }
+    }
+    return out.toOwnedSlice(alloc);
+}
+
+/// Owns the discovered commands and the merged registry slice that
+/// `App.slashRegistry()` serves. The builtin specs come first, so a builtin
+/// wins any token collision for free: every matcher returns on its first hit.
+pub const CommandRuntime = struct {
+    discovery: CommandDiscovery = .{},
+    /// One owned `/name` per custom spec. It is both the spec token and its
+    /// help entry, so a command costs a single string here.
+    tokens: [][]u8 = &.{},
+    /// One owned completion description per custom spec, naming the source
+    /// root in plain text.
+    descriptions: [][]u8 = &.{},
+    /// One owned display label per custom spec: `/name <hint>` when the file
+    /// declares an `argument-hint`, and the bare token otherwise, so a command
+    /// without a hint renders no separator.
+    labels: [][]u8 = &.{},
+    /// `builtins ++ custom`, a single allocation. Left empty when no command
+    /// was discovered so the builtin registry is served untouched.
+    merged: []command_specs.SlashSpec = &.{},
+
+    pub fn deinit(self: *CommandRuntime, alloc: Allocator) void {
+        self.discovery.deinit(alloc);
+        freeOwnedStrings(alloc, self.tokens);
+        freeOwnedStrings(alloc, self.descriptions);
+        freeOwnedStrings(alloc, self.labels);
+        if (self.merged.len > 0) alloc.free(self.merged);
+        self.* = .{};
+    }
+
+    /// Serves `builtins` verbatim when nothing was discovered, so an fx without
+    /// a `.fx/prompts` directory anywhere is byte-identical to one built
+    /// before this feature.
+    pub fn registry(
+        self: *const CommandRuntime,
+        builtins: command_specs.SlashRegistry,
+    ) command_specs.SlashRegistry {
+        if (self.merged.len == 0) return builtins;
+        return .{ .commands = self.merged };
+    }
+
+    /// Resolves a merged-registry index back to the command it was built from.
+    ///
+    /// Returns null for a builtin index and for any index past the end, so a
+    /// reload that raced a queued invocation reports an unknown command instead
+    /// of reading out of bounds.
+    pub fn commandAt(
+        self: *const CommandRuntime,
+        builtins: command_specs.SlashRegistry,
+        index: usize,
+    ) ?*const CustomCommand {
+        if (self.merged.len == 0) return null;
+        if (index < builtins.commands.len) return null;
+        const offset = index - builtins.commands.len;
+        if (offset >= self.discovery.commands.len) return null;
+        return &self.discovery.commands[offset];
+    }
+};
+
+fn freeOwnedStrings(alloc: Allocator, strings: [][]u8) void {
+    for (strings) |string| alloc.free(string);
+    if (strings.len > 0) alloc.free(strings);
+}
+
+/// Releases a row that is still being filled: `built` is only a prefix view of
+/// `storage`, so the strings and the full backing array must be freed
+/// separately.
+fn freePartialStrings(alloc: Allocator, storage: [][]u8, built: [][]u8) void {
+    for (built) |string| alloc.free(string);
+    if (storage.len > 0) alloc.free(storage);
+}
+
+/// Builds the merged registry from `discovery`, which the returned runtime owns
+/// on success. On failure the caller still owns `discovery`.
+pub fn buildRuntime(
+    alloc: Allocator,
+    builtins: command_specs.SlashRegistry,
+    discovery: CommandDiscovery,
+) Allocator.Error!CommandRuntime {
+    if (discovery.commands.len == 0) return .{ .discovery = discovery };
+
+    var runtime: CommandRuntime = .{};
+    var token_storage: [][]u8 = &.{};
+    var description_storage: [][]u8 = &.{};
+    var label_storage: [][]u8 = &.{};
+    errdefer {
+        freePartialStrings(alloc, token_storage, runtime.tokens);
+        freePartialStrings(alloc, description_storage, runtime.descriptions);
+        freePartialStrings(alloc, label_storage, runtime.labels);
+        if (runtime.merged.len > 0) alloc.free(runtime.merged);
+    }
+
+    const tokens = try alloc.alloc([]u8, discovery.commands.len);
+    token_storage = tokens;
+    runtime.tokens = tokens[0..0];
+    for (discovery.commands) |command| {
+        tokens[runtime.tokens.len] = try std.fmt.allocPrint(alloc, "/{s}", .{command.name});
+        runtime.tokens = tokens[0 .. runtime.tokens.len + 1];
+    }
+
+    const descriptions = try alloc.alloc([]u8, discovery.commands.len);
+    description_storage = descriptions;
+    runtime.descriptions = descriptions[0..0];
+    for (discovery.commands) |command| {
+        const source_root = std.fs.path.dirname(command.path) orelse command.path;
+        const display_root = try encodeSourceRoot(alloc, source_root);
+        defer alloc.free(display_root);
+        descriptions[runtime.descriptions.len] = if (command.has_explicit_description)
+            try std.fmt.allocPrint(
+                alloc,
+                "{s} ({s})",
+                .{ command.description, display_root },
+            )
+        else
+            try alloc.dupe(u8, command.description);
+        runtime.descriptions = descriptions[0 .. runtime.descriptions.len + 1];
+    }
+
+    const labels = try alloc.alloc([]u8, discovery.commands.len);
+    label_storage = labels;
+    runtime.labels = labels[0..0];
+    for (discovery.commands, 0..) |command, index| {
+        labels[runtime.labels.len] = if (command.argument_hint) |hint|
+            try std.fmt.allocPrint(alloc, "{s} {s}", .{ tokens[index], hint })
+        else
+            try alloc.dupe(u8, tokens[index]);
+        runtime.labels = labels[0 .. runtime.labels.len + 1];
+    }
+
+    const merged = try alloc.alloc(
+        command_specs.SlashSpec,
+        builtins.commands.len + discovery.commands.len,
+    );
+    runtime.merged = merged;
+    @memcpy(merged[0..builtins.commands.len], builtins.commands);
+    for (discovery.commands, 0..) |_, index| {
+        merged[builtins.commands.len + index] = customSpec(
+            tokens[index],
+            labels[index],
+            descriptions[index],
+        );
+    }
+
+    runtime.discovery = discovery;
+    return runtime;
+}
+
+/// Fills every field the visibility gates read, so a custom entry reaches the
+/// help catalog and the completion picker on the same terms as `/mcp`.
+fn customSpec(
+    token: []const u8,
+    label: []const u8,
+    description: []const u8,
+) command_specs.SlashSpec {
+    return .{
+        .kind = .custom,
+        .command = token,
+        // `/name <hint>` matches how a builtin such as `/model <id-or-query>`
+        // states its arguments in the same catalog.
+        .help_entry = label,
+        .completion_label = label,
+        .completion_description = description,
+        .presentation_category = .extensions,
+        .has_args = true,
+        .accepts_payload = true,
+        .requires_prompt_credential = true,
+    };
+}
+
+const testing = std.testing;
+
+const test_reserved_specs = [_]command_specs.SlashSpec{
+    .{ .kind = .help, .command = "/help", .aliases = &.{"/h"} },
+    .{ .kind = .model, .command = "/model" },
+};
+const test_reserved: command_specs.SlashRegistry = .{ .commands = &test_reserved_specs };
+
+fn writeTempFile(tmp: *std.testing.TmpDir, sub_path: []const u8, content: []const u8) !void {
+    if (std.fs.path.dirname(sub_path)) |parent| {
+        try tmp.dir.createDirPath(io_mod.getIo(), parent);
+    }
+    var file = try tmp.dir.createFile(std.testing.io, sub_path, .{ .truncate = true });
+    defer file.close(io_mod.getIo());
+    try file.writeStreamingAll(io_mod.getIo(), content);
+}
+
+fn createTempSymlinkOrSkip(tmp: *std.testing.TmpDir, target_path: []const u8, link_path: []const u8) !void {
+    if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;
+    if (std.fs.path.dirname(link_path)) |parent| {
+        try tmp.dir.createDirPath(io_mod.getIo(), parent);
+    }
+    tmp.dir.symLink(std.testing.io, target_path, link_path, .{ .is_directory = false }) catch |err| {
+        if (err == error.AccessDenied or err == error.FileSystem) return error.SkipZigTest;
+        return err;
+    };
+}
+
+fn tmpPath(alloc: Allocator, tmp: *std.testing.TmpDir, sub_path: []const u8) ![]u8 {
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    if (sub_path.len == 0) return alloc.dupe(u8, root);
+    return std.fs.path.join(alloc, &.{ root, sub_path });
+}
+
+/// Runs discovery over a tmp tree shaped like the production layout: `home` is
+/// the tmp root, so the workspace ancestor walk stops there.
+fn loadFromTmp(alloc: Allocator, tmp: *std.testing.TmpDir, workspace_sub_path: []const u8) !CommandDiscovery {
+    const home = try tmpPath(alloc, tmp, "");
+    defer alloc.free(home);
+    const workspace = try tmpPath(alloc, tmp, workspace_sub_path);
+    defer alloc.free(workspace);
+    const user_dir = try tmpPath(alloc, tmp, "user/.fx/prompts");
+    defer alloc.free(user_dir);
+    return loadCustomCommands(alloc, workspace, home, user_dir, test_policy, test_reserved);
+}
+
+const test_policy: skill_contract.RootPolicy = .{
+    .workspace_roots = &[_]skill_contract.RootSpec{
+        .{ .source = .workspace_fx, .path = ".fx/prompts" },
+    },
+    .managed_root_source = .global_fx,
+};
+
+fn findCommand(discovery: CommandDiscovery, name: []const u8) ?CustomCommand {
+    for (discovery.commands) |command| {
+        if (std.mem.eql(u8, command.name, name)) return command;
+    }
+    return null;
+}
+
+fn countDiagnostics(discovery: CommandDiscovery, cause: std.meta.Tag(CommandDiagnosticCause)) usize {
+    var total: usize = 0;
+    for (discovery.diagnostics) |diagnostic| {
+        if (diagnostic.cause == cause) total += 1;
+    }
+    return total;
+}
+
+fn expectMessage(expected: []const u8, diagnostic: CommandDiagnostic) !void {
+    var buf: [1024]u8 = undefined;
+    var writer = std.Io.Writer.fixed(&buf);
+    try writeDiagnosticMessage(&writer, diagnostic);
+    try testing.expectEqualStrings(expected, writer.buffered());
+}
+
+test "discovery finds commands in workspace and user roots with source attribution" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/deploy.md", "Deploy $1 now.");
+    try writeTempFile(&tmp, "user/.fx/prompts/notes.md", "Take notes.");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 2), discovery.commands.len);
+    try testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
+    try testing.expectEqualStrings("deploy", discovery.commands[0].name);
+    try testing.expectEqual(SkillSource.workspace_fx, discovery.commands[0].source);
+    try testing.expectEqualStrings("Deploy $1 now.", discovery.commands[0].body);
+    try testing.expectEqualStrings("notes", discovery.commands[1].name);
+    try testing.expectEqual(SkillSource.global_fx, discovery.commands[1].source);
+}
+
+test "discovery returns nothing when no command root exists" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 0), discovery.commands.len);
+    try testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
+}
+
+test "a command root that is not a directory is diagnosed by path" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(&tmp, "workspace/.fx/prompts", "not a directory");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 0), discovery.commands.len);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(CommandDiagnosticCause.unreadable_root, discovery.diagnostics[0].cause);
+    try testing.expect(std.mem.endsWith(u8, discovery.diagnostics[0].path, ".fx/prompts"));
+}
+
+test "a file without frontmatter uses the filename stem and a source fallback description" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(&tmp, "workspace/.fx/prompts/review-pr.md", "Review pull request $1.");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    const command = discovery.commands[0];
+    try testing.expectEqualStrings("review-pr", command.name);
+    try testing.expectEqualStrings("Review pull request $1.", command.body);
+    const source_root = std.fs.path.dirname(command.path) orelse return error.TestExpectedPath;
+    const expected_description = try std.fmt.allocPrint(alloc, "custom command from {s}", .{source_root});
+    defer alloc.free(expected_description);
+    try testing.expectEqualStrings(expected_description, command.description);
+    try testing.expectEqual(@as(?[]u8, null), command.argument_hint);
+}
+
+test "frontmatter description and argument-hint are captured without unknown-key errors" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(&tmp, "workspace/.fx/prompts/greet.md",
+        \\---
+        \\description: Greets a person
+        \\argument-hint: <name>
+        \\model: ignored-unknown-key
+        \\---
+        \\Hello $1.
+    );
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    const command = discovery.commands[0];
+    try testing.expectEqualStrings("greet", command.name);
+    try testing.expectEqualStrings("Greets a person", command.description);
+    try testing.expectEqualStrings("<name>", command.argument_hint.?);
+    try testing.expectEqualStrings("Hello $1.", command.body);
+}
+
+test "the filename remains authoritative when frontmatter declares a name" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(&tmp, "workspace/.fx/prompts/whatever.md",
+        \\---
+        \\name: 2 invalid and ignored
+        \\---
+        \\Ship it.
+    );
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("whatever", discovery.commands[0].name);
+}
+
+test "command bodies preserve leading and trailing template whitespace" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const expected = "\n  Keep this indentation.  \n\n";
+    try writeTempFile(&tmp, "workspace/.fx/prompts/verbatim.md", "---\ndescription: Preserve formatting\n---\n" ++ expected);
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings(expected, discovery.commands[0].body);
+}
+
+test "an empty body is rejected with a diagnostic" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(&tmp, "workspace/.fx/prompts/hollow.md",
+        \\---
+        \\description: Nothing follows
+        \\---
+        \\
+    );
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 0), discovery.commands.len);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(CommandDiagnosticCause.empty_body, discovery.diagnostics[0].cause);
+}
+
+test "an unterminated frontmatter block is rejected without a truncated parse" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTempFile(&tmp, "workspace/.fx/prompts/broken.md",
+        \\---
+        \\description: never closed
+        \\Body text.
+    );
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 0), discovery.commands.len);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(CommandDiagnosticCause.invalid_frontmatter, discovery.diagnostics[0].cause);
+}
+
+test "an oversized file is skipped while the rest of the root loads" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const big = try alloc.alloc(u8, max_command_file_bytes + 1);
+    defer alloc.free(big);
+    @memset(big, 'x');
+    try writeTempFile(&tmp, "workspace/.fx/prompts/huge.md", big);
+    try writeTempFile(&tmp, "workspace/.fx/prompts/small.md", "Still loads.");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("small", discovery.commands[0].name);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(CommandDiagnosticCause.oversized, discovery.diagnostics[0].cause);
+}
+
+test "non-markdown files and subdirectories are ignored without diagnostics" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/readme.txt", "not a command");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/nested/deep.md", "not discovered");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/real.md", "A real command.");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("real", discovery.commands[0].name);
+    try testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
+}
+
+test "a builtin collision is rejected and names the builtin, including case-only near misses" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/help.md", "Shadow attempt.");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/Model.md", "Case-only near miss.");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/h.md", "Alias collision.");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 0), discovery.commands.len);
+    try testing.expectEqual(@as(usize, 3), discovery.diagnostics.len);
+    for (discovery.diagnostics) |diagnostic| {
+        try testing.expectEqual(CommandDiagnosticCause.builtin_collision, diagnostic.cause);
+        try testing.expect(diagnostic.detail != null);
+    }
+    var model_diagnostic: ?CommandDiagnostic = null;
+    for (discovery.diagnostics) |diagnostic| {
+        if (diagnostic.name) |name| {
+            if (std.mem.eql(u8, name, "Model")) model_diagnostic = diagnostic;
+        }
+    }
+    const diagnostic = model_diagnostic orelse return error.TestExpectedModelDiagnostic;
+    const expected = try std.fmt.allocPrint(
+        alloc,
+        "command 'model' conflicts with a built-in command: {s}",
+        .{diagnostic.path},
+    );
+    defer alloc.free(expected);
+    try expectMessage(expected, diagnostic);
+}
+
+test "invalid derived names are rejected before reaching the registry" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/my command.md", "Whitespace name.");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/2fast.md", "Leading digit.");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 0), discovery.commands.len);
+    try testing.expectEqual(@as(usize, 2), countDiagnostics(discovery, .invalid_name));
+}
+
+test "validCommandName enforces the documented character and length rules" {
+    try testing.expect(validCommandName("review-pr"));
+    try testing.expect(validCommandName("_private"));
+    try testing.expect(validCommandName("a1"));
+    try testing.expect(!validCommandName(""));
+    try testing.expect(!validCommandName("2fast"));
+    try testing.expect(!validCommandName("my command"));
+    try testing.expect(!validCommandName("nested/name"));
+    try testing.expect(!validCommandName(".."));
+    try testing.expect(!validCommandName("a" ** (max_command_name_bytes + 1)));
+    try testing.expect(validCommandName("a" ** max_command_name_bytes));
+}
+
+test "a cross-root duplicate keeps the earlier root and diagnoses the loser" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/deploy.md", "Workspace wins.");
+    try writeTempFile(&tmp, "user/.fx/prompts/deploy.md", "User loses.");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("Workspace wins.", discovery.commands[0].body);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    const diagnostic = discovery.diagnostics[0];
+    try testing.expectEqual(CommandDiagnosticCause.shadowed, diagnostic.cause);
+    try testing.expectEqualStrings("deploy", diagnostic.name.?);
+    try testing.expectEqualStrings(discovery.commands[0].path, diagnostic.detail.?);
+}
+
+test "a same-root duplicate keeps the first entry in directory order" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/foo.md", "lowercase file.");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/foo.MD", "uppercase file.");
+
+    var prompts_dir = try tmp.dir.openDir(io_mod.getIo(), "workspace/.fx/prompts", .{ .iterate = true });
+    defer prompts_dir.close(io_mod.getIo());
+    var iterator = prompts_dir.iterate();
+    const first_entry = (try iterator.next(io_mod.getIo())).?;
+    const first_name = try alloc.dupe(u8, first_entry.name);
+    defer alloc.free(first_name);
+    const second_name = if (std.mem.eql(u8, first_name, "foo.md")) "foo.MD" else "foo.md";
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("foo", discovery.commands[0].name);
+    try testing.expect(std.mem.endsWith(u8, discovery.commands[0].path, first_name));
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(CommandDiagnosticCause.duplicate_name, discovery.diagnostics[0].cause);
+    try testing.expect(std.mem.endsWith(u8, discovery.diagnostics[0].path, second_name));
+}
+
+test "a symlinked entry whose target escapes the root is rejected and never read" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "outside/secret.md", "Should never load.");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/inside.md", "Loads fine.");
+    const outside = try tmpPath(alloc, &tmp, "outside/secret.md");
+    defer alloc.free(outside);
+    try createTempSymlinkOrSkip(&tmp, outside, "workspace/.fx/prompts/escape.md");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("inside", discovery.commands[0].name);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(CommandDiagnosticCause.escapes_root, discovery.diagnostics[0].cause);
+    try testing.expect(std.mem.endsWith(u8, discovery.diagnostics[0].path, "escape.md"));
+}
+
+test "a symlinked entry that stays inside the root loads" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/base.md", "Shared body.");
+    const inside = try tmpPath(alloc, &tmp, "workspace/.fx/prompts/base.md");
+    defer alloc.free(inside);
+    try createTempSymlinkOrSkip(&tmp, inside, "workspace/.fx/prompts/alias.md");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 2), discovery.commands.len);
+    try testing.expect(findCommand(discovery, "alias") != null);
+    try testing.expect(findCommand(discovery, "base") != null);
+    try testing.expectEqualStrings("Shared body.", findCommand(discovery, "alias").?.body);
+    try testing.expectEqualStrings("Shared body.", findCommand(discovery, "base").?.body);
+    try testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
+}
+
+test "a symlink to a directory inside the root is diagnosed as unreadable" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/nested/keep.txt", "placeholder");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/real.md", "Still loads.");
+    const nested = try tmpPath(alloc, &tmp, "workspace/.fx/prompts/nested");
+    defer alloc.free(nested);
+    try createTempSymlinkOrSkip(&tmp, nested, "workspace/.fx/prompts/bogus.md");
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("real", discovery.commands[0].name);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(CommandDiagnosticCause.unreadable, discovery.diagnostics[0].cause);
+}
+
+test "a file without read permission is skipped and discovery still returns" {
+    if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;
+    if (std.c.geteuid() == 0) return error.SkipZigTest;
+
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/locked.md", "Never read.");
+    try writeTempFile(&tmp, "workspace/.fx/prompts/open.md", "Still loads.");
+
+    {
+        var locked = try tmp.dir.openFile(io_mod.getIo(), "workspace/.fx/prompts/locked.md", .{});
+        defer locked.close(io_mod.getIo());
+        locked.setPermissions(io_mod.getIo(), @enumFromInt(@as(std.posix.mode_t, 0o000))) catch return error.SkipZigTest;
+    }
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("open", discovery.commands[0].name);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(CommandDiagnosticCause.unreadable, discovery.diagnostics[0].cause);
+    try testing.expect(std.mem.endsWith(u8, discovery.diagnostics[0].path, "locked.md"));
+}
+
+test "roots that resolve to the same canonical path are read once" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/once.md", "Only once.");
+
+    const home = try tmpPath(alloc, &tmp, "");
+    defer alloc.free(home);
+    const workspace = try tmpPath(alloc, &tmp, "workspace");
+    defer alloc.free(workspace);
+    const user_dir = try tmpPath(alloc, &tmp, "workspace/.fx/prompts");
+    defer alloc.free(user_dir);
+
+    var discovery = try loadCustomCommands(alloc, workspace, home, user_dir, test_policy, test_reserved);
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqual(SkillSource.workspace_fx, discovery.commands[0].source);
+    try testing.expectEqual(@as(usize, 0), discovery.diagnostics.len);
+}
+
+test "the workspace ancestor walk stops at the home directory" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, ".fx/prompts/above-home.md", "Above the boundary.");
+    try writeTempFile(&tmp, "home/workspace/.fx/prompts/below-home.md", "Below the boundary.");
+
+    const home = try tmpPath(alloc, &tmp, "home");
+    defer alloc.free(home);
+    const workspace = try tmpPath(alloc, &tmp, "home/workspace");
+    defer alloc.free(workspace);
+    const user_dir = try tmpPath(alloc, &tmp, "home/.fx/prompts");
+    defer alloc.free(user_dir);
+
+    var discovery = try loadCustomCommands(alloc, workspace, home, user_dir, test_policy, test_reserved);
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("below-home", discovery.commands[0].name);
+}
+
+test "a workspace outside home does not scan parent prompt roots" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "outside/workspace/.fx/prompts/local.md", "Local prompt.");
+    try writeTempFile(&tmp, "outside/.fx/prompts/parent.md", "Must not load.");
+    try tmp.dir.createDirPath(io_mod.getIo(), "home");
+
+    const home = try tmpPath(alloc, &tmp, "home");
+    defer alloc.free(home);
+    const workspace = try tmpPath(alloc, &tmp, "outside/workspace");
+    defer alloc.free(workspace);
+    const user_dir = try tmpPath(alloc, &tmp, "home/.fx/prompts");
+    defer alloc.free(user_dir);
+
+    var discovery = try loadCustomCommands(alloc, workspace, home, user_dir, test_policy, test_reserved);
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 1), discovery.commands.len);
+    try testing.expectEqualStrings("local", discovery.commands[0].name);
+}
+
+test "the command count cap loads the first files and reports the remainder once" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var index: usize = 0;
+    while (index < max_commands + 3) : (index += 1) {
+        const name = try std.fmt.allocPrint(alloc, "workspace/.fx/prompts/cmd{d:0>4}.md", .{index});
+        defer alloc.free(name);
+        try writeTempFile(&tmp, name, "Body.");
+    }
+
+    var prompts_dir = try tmp.dir.openDir(io_mod.getIo(), "workspace/.fx/prompts", .{ .iterate = true });
+    defer prompts_dir.close(io_mod.getIo());
+    var iterator = prompts_dir.iterate();
+    const first_entry = (try iterator.next(io_mod.getIo())).?;
+    const first_name = commandNameStem(first_entry.name);
+
+    var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+    defer discovery.deinit(alloc);
+
+    try testing.expectEqual(max_commands, discovery.commands.len);
+    try testing.expectEqualStrings(first_name, discovery.commands[0].name);
+    try testing.expectEqual(@as(usize, 1), discovery.diagnostics.len);
+    try testing.expectEqual(@as(usize, 3), discovery.diagnostics[0].cause.count_cap);
+    try expectMessage("skipped 3 command files above the 256 limit", discovery.diagnostics[0]);
+}
+
+test "diagnostic messages match the documented wording" {
+    const path = "/repo/.fx/prompts/deploy.md";
+    try expectMessage("cannot read command root: /repo/.fx/prompts", .{
+        .path = @constCast("/repo/.fx/prompts"),
+        .source = .workspace_fx,
+        .cause = .unreadable_root,
+    });
+    try expectMessage("cannot read command file: " ++ path, .{
+        .path = @constCast(path),
+        .source = .workspace_fx,
+        .cause = .unreadable,
+    });
+    try expectMessage("command file exceeds 262144 bytes: " ++ path, .{
+        .path = @constCast(path),
+        .source = .workspace_fx,
+        .cause = .oversized,
+    });
+    try expectMessage("invalid command frontmatter: " ++ path, .{
+        .path = @constCast(path),
+        .source = .workspace_fx,
+        .cause = .invalid_frontmatter,
+    });
+    try expectMessage("command file has an empty body: " ++ path, .{
+        .path = @constCast(path),
+        .source = .workspace_fx,
+        .cause = .empty_body,
+    });
+    try expectMessage("invalid command name derived from " ++ path, .{
+        .path = @constCast(path),
+        .source = .workspace_fx,
+        .cause = .invalid_name,
+    });
+    try expectMessage("command 'help' conflicts with a built-in command: " ++ path, .{
+        .path = @constCast(path),
+        .name = @constCast(@as([]const u8, "help")),
+        .detail = @constCast(@as([]const u8, "help")),
+        .source = .workspace_fx,
+        .cause = .builtin_collision,
+    });
+    try expectMessage("command 'deploy' from " ++ path ++ " is shadowed by /home/.fx/prompts/deploy.md", .{
+        .path = @constCast(path),
+        .name = @constCast(@as([]const u8, "deploy")),
+        .detail = @constCast(@as([]const u8, "/home/.fx/prompts/deploy.md")),
+        .source = .global_fx,
+        .cause = .shadowed,
+    });
+    try expectMessage("duplicate command 'deploy': " ++ path ++ " ignored", .{
+        .path = @constCast(path),
+        .name = @constCast(@as([]const u8, "deploy")),
+        .source = .workspace_fx,
+        .cause = .duplicate_name,
+    });
+    try expectMessage("command file escapes its root: " ++ path, .{
+        .path = @constCast(path),
+        .source = .workspace_fx,
+        .cause = .escapes_root,
+    });
+}
+
+test "an argument hint is stripped of control bytes and truncated" {
+    const alloc = testing.allocator;
+    const sanitized = (try sanitizeArgumentHint(alloc, "  <na\x07me>  ")).?;
+    defer alloc.free(sanitized);
+    try testing.expectEqualStrings("<name>", sanitized);
+
+    const long = "x" ** (max_argument_hint_bytes + 40);
+    const truncated = (try sanitizeArgumentHint(alloc, long)).?;
+    defer alloc.free(truncated);
+    try testing.expectEqual(max_argument_hint_bytes, truncated.len);
+
+    try testing.expectEqual(@as(?[]u8, null), try sanitizeArgumentHint(alloc, "   "));
+}
+
+test "reservedCollision matches builtin tokens and aliases case-insensitively" {
+    try testing.expectEqualStrings("help", reservedCollision(test_reserved, "HELP").?);
+    try testing.expectEqualStrings("h", reservedCollision(test_reserved, "h").?);
+    try testing.expectEqual(@as(?[]const u8, null), reservedCollision(test_reserved, "model-review"));
+    // A derived name never carries a slash, so a slashed candidate is not a
+    // collision, it is an invalid name rejected earlier.
+    try testing.expectEqual(@as(?[]const u8, null), reservedCollision(test_reserved, "/help"));
+}
+
+/// Discovers into a runtime the caller owns, mirroring the production sequence
+/// where a failed merge leaves the previous registry untouched.
+fn runtimeFromTmp(
+    alloc: Allocator,
+    tmp: *std.testing.TmpDir,
+    workspace_sub_path: []const u8,
+) !CommandRuntime {
+    var discovery = try loadFromTmp(alloc, tmp, workspace_sub_path);
+    return buildRuntime(alloc, test_reserved, discovery) catch |err| {
+        discovery.deinit(alloc);
+        return err;
+    };
+}
+
+test "merged registry keeps builtins first and custom entries in root precedence order" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/deploy.md", "Deploy $1 now.");
+    try writeTempFile(&tmp, "user/.fx/prompts/notes.md", "Take notes.");
+
+    var runtime = try runtimeFromTmp(alloc, &tmp, "workspace");
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(test_reserved);
+    try testing.expectEqual(test_reserved.commands.len + 2, registry.commands.len);
+    for (test_reserved.commands, registry.commands[0..test_reserved.commands.len]) |expected, actual| {
+        try testing.expectEqualStrings(expected.command, actual.command);
+        try testing.expectEqual(expected.kind, actual.kind);
+    }
+    try testing.expectEqualStrings("/deploy", registry.commands[test_reserved.commands.len].command);
+    try testing.expectEqualStrings("/notes", registry.commands[test_reserved.commands.len + 1].command);
+
+    // The builtin still wins its own token even though the merged slice is
+    // longer, because every matcher returns on its first hit.
+    try testing.expectEqual(
+        command_specs.SlashKind.help,
+        registry.lookup("/help").?.kind,
+    );
+    try testing.expectEqual(
+        command_specs.SlashKind.custom,
+        registry.lookup("/deploy").?.kind,
+    );
+}
+
+test "custom specs fill every field the visibility gates read" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/deploy.md", "Deploy $1 now.");
+
+    var runtime = try runtimeFromTmp(alloc, &tmp, "workspace");
+    defer runtime.deinit(alloc);
+
+    const spec = runtime.registry(test_reserved).commands[test_reserved.commands.len];
+    try testing.expectEqual(command_specs.SlashKind.custom, spec.kind);
+    try testing.expect(spec.requires_prompt_credential);
+    try testing.expect(spec.has_args);
+    try testing.expect(spec.accepts_payload);
+    try testing.expectEqualStrings("/deploy", spec.help_entry.?);
+    try testing.expect(spec.completion_description != null);
+    try testing.expectEqual(
+        command_specs.SlashPresentationCategory.extensions,
+        spec.presentation_category.?,
+    );
+}
+
+test "an explicit description names its source root and a fallback is not doubled" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/deploy.md",
+        \\---
+        \\description: Ship a service
+        \\---
+        \\Deploy $1 now.
+    );
+    try writeTempFile(&tmp, "user/.fx/prompts/notes.md", "Take notes.");
+
+    var runtime = try runtimeFromTmp(alloc, &tmp, "workspace");
+    defer runtime.deinit(alloc);
+
+    const commands = runtime.registry(test_reserved).commands[test_reserved.commands.len..];
+    const workspace_root = std.fs.path.dirname(runtime.discovery.commands[0].path) orelse return error.TestExpectedPath;
+    const expected_explicit = try std.fmt.allocPrint(alloc, "Ship a service ({s})", .{workspace_root});
+    defer alloc.free(expected_explicit);
+    try testing.expectEqualStrings(expected_explicit, commands[0].completion_description.?);
+    // The fallback already names the root, so the merge leaves it alone.
+    const user_root = std.fs.path.dirname(runtime.discovery.commands[1].path) orelse return error.TestExpectedPath;
+    const expected_fallback = try std.fmt.allocPrint(alloc, "custom command from {s}", .{user_root});
+    defer alloc.free(expected_fallback);
+    try testing.expectEqualStrings(expected_fallback, commands[1].completion_description.?);
+    for (commands) |spec| {
+        for (spec.completion_description.?) |byte| {
+            try testing.expect(byte >= 0x20 and byte < 0x7f);
+        }
+    }
+}
+
+test "source roots are ASCII-encoded before help and completion rendering" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const workspace = "work\x1b-\xc3\xa9";
+    try writeTempFile(&tmp, "work\x1b-\xc3\xa9/.fx/prompts/explicit.md",
+        \\---
+        \\description: Explicit command
+        \\---
+        \\Prompt.
+    );
+    try writeTempFile(&tmp, "work\x1b-\xc3\xa9/.fx/prompts/fallback.md", "Prompt.");
+
+    var runtime = try runtimeFromTmp(alloc, &tmp, workspace);
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(test_reserved);
+    const explicit = registry.lookup("/explicit").?.completion_description.?;
+    const fallback = registry.lookup("/fallback").?.completion_description.?;
+    for ([_][]const u8{ explicit, fallback }) |description| {
+        try testing.expect(std.mem.find(u8, description, "\\x1B") != null);
+        try testing.expect(std.mem.find(u8, description, "\\xC3\\xA9") != null);
+        try testing.expect(std.mem.findScalar(u8, description, 0x1b) == null);
+        for (description) |byte| try testing.expect(byte >= 0x20 and byte < 0x7f);
+    }
+}
+
+test "a load with no commands serves the builtin registry unchanged" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+
+    var runtime = try runtimeFromTmp(alloc, &tmp, "workspace");
+    defer runtime.deinit(alloc);
+
+    const registry = runtime.registry(test_reserved);
+    try testing.expectEqual(test_reserved.commands.len, registry.commands.len);
+    try testing.expectEqual(test_reserved.commands.ptr, registry.commands.ptr);
+}
+
+test "rebuilding to an empty load releases the previously merged commands" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(&tmp, "workspace/.fx/prompts/deploy.md", "Deploy $1 now.");
+    var runtime = try runtimeFromTmp(alloc, &tmp, "workspace");
+    defer runtime.deinit(alloc);
+    try testing.expect(runtime.registry(test_reserved).lookup("/deploy") != null);
+
+    try tmp.dir.deleteFile(io_mod.getIo(), "workspace/.fx/prompts/deploy.md");
+    var rebuilt = try runtimeFromTmp(alloc, &tmp, "workspace");
+    runtime.deinit(alloc);
+    runtime = rebuilt;
+    rebuilt = .{};
+
+    try testing.expectEqual(@as(?*const command_specs.SlashSpec, null), runtime.registry(test_reserved).lookup("/deploy"));
+}
+
+test "a merge that runs out of memory releases every partial allocation" {
+    const alloc = testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTempFile(
+        &tmp,
+        "workspace/.fx/prompts/deploy.md",
+        "---\ndescription: Deploy the app\n---\nDeploy $1 now.",
+    );
+    try writeTempFile(&tmp, "user/.fx/prompts/notes.md", "Take notes.");
+
+    // Every allocation the merge makes is failed in turn. The token and
+    // description rows are prefix views while they fill, so an unwind that
+    // mistook the prefix for the whole row would leak or free the backing
+    // array with the wrong length, and the testing allocator would report it.
+    // The ceiling only has to exceed the real allocation count, which shifts
+    // with the formatting internals `allocPrint` uses.
+    var fail_index: usize = 0;
+    while (fail_index < 64) : (fail_index += 1) {
+        var discovery = try loadFromTmp(alloc, &tmp, "workspace");
+        var failing = std.testing.FailingAllocator.init(alloc, .{ .fail_index = fail_index });
+        var runtime = buildRuntime(failing.allocator(), test_reserved, discovery) catch |err| {
+            try testing.expectEqual(error.OutOfMemory, err);
+            discovery.deinit(alloc);
+            continue;
+        };
+        // The budget covered the whole merge, so no later index can fail.
+        defer runtime.deinit(failing.allocator());
+        try testing.expectEqual(test_reserved.commands.len + 2, runtime.registry(test_reserved).commands.len);
+        break;
+    } else return error.MergeNeverSucceeded;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -48,6 +48,7 @@ const model_capabilities = @import("core/config/model_capabilities.zig");
 const prompt_policy = @import("core/config/prompt_policy.zig");
 const builtin_commands = @import("builtins/commands.zig");
 const command_specs = @import("core/slash_commands/command_specs.zig");
+const custom_commands = @import("core/slash_commands/custom_commands.zig");
 const builtin_context = @import("builtins/context.zig");
 const builtin_gateway = @import("builtins/gateway.zig");
 const builtin_providers = @import("builtins/providers.zig");
@@ -60,6 +61,7 @@ const agent_stream_provider = @import("core/agent/stream_provider.zig");
 const builtin_hooks = @import("builtins/hooks.zig");
 const builtin_mcp = @import("builtins/mcp.zig");
 const builtin_modes = @import("builtins/modes.zig");
+const builtin_custom_commands = @import("builtins/custom_commands.zig");
 const builtin_skills = @import("builtins/skills.zig");
 const host = @import("core/hosts/host.zig");
 const host_runtime_profile = @import("core/hosts/runtime_profile.zig");
@@ -355,6 +357,12 @@ const WorkspaceHostRuntime = if (host_target.is_wasm) js_host_workspace.Runtime 
 const wasm_skill_root_policy: @import("core/skills/skill_contract.zig").RootPolicy = .{
     .managed_root_source = null,
 };
+/// The wasm host has no profile directory, so command discovery keeps only the
+/// workspace roots there.
+const wasm_command_root_policy: @import("core/skills/skill_contract.zig").RootPolicy = .{
+    .workspace_roots = builtin_custom_commands.root_policy.workspace_roots,
+    .managed_root_source = null,
+};
 fn currentBuild() update_target.CurrentBuild {
     return .{
         .channel = compiled_update_channel,
@@ -404,8 +412,22 @@ const App = struct {
         return builtin_context.prompt_policy;
     }
 
-    pub fn slashRegistry(_: *const Self) command_specs.SlashRegistry {
-        return builtin_commands.slash_registry;
+    /// The only production injection point for the slash registry. Builtins
+    /// come first in the merged slice, and a load with no discovered command
+    /// serves `builtin_commands.slash_registry` itself.
+    pub fn slashRegistry(self: *const Self) command_specs.SlashRegistry {
+        return self.custom_commands.registry(builtin_commands.slash_registry);
+    }
+
+    /// Resolves a merged-registry index parsed by `command_router` back to the
+    /// discovered body it names. Returns null when the index no longer resolves,
+    /// which is what a reload racing a queued invocation looks like.
+    pub fn customCommandBody(self: *const Self, index: usize) ?[]const u8 {
+        const command = self.custom_commands.commandAt(
+            builtin_commands.slash_registry,
+            index,
+        ) orelse return null;
+        return command.body;
     }
 
     pub fn mcpCommandProvider(_: *const Self) mcp_command_provider.Provider {
@@ -548,6 +570,7 @@ const App = struct {
     change_tracker: change_tracker_mod.ChangeTracker = .{},
     mcp: app_mcp_runtime.State = .{},
     skills: skill_runtime.Runtime = .{},
+    custom_commands: custom_commands.CommandRuntime = .{},
     context_snapshot: context_contract.GatheredContextSnapshot = .{},
     file_index: file_index_mod.FileIndex = .{},
     context_enabled: bool = true,
@@ -626,6 +649,7 @@ const App = struct {
             },
         );
         errdefer app.deinit();
+        try app.reloadCustomCommands("interactive_startup");
         try WorkspaceAppRuntime.applyLaunch(
             &app,
             launch.modifiers.additional_directories,
@@ -857,6 +881,7 @@ const App = struct {
         self.diff_entries.deinit(std.heap.c_allocator);
         self.mcp.deinit(self.alloc);
         self.skills.deinit(std.heap.c_allocator);
+        self.custom_commands.deinit(self.alloc);
         self.context_snapshot.deinit(self.alloc);
         self.file_index.deinit(std.heap.c_allocator);
         self.lifecycle_runtime.deinit();
@@ -1587,6 +1612,21 @@ const App = struct {
         const loaded = try app_runtime_setup.loadSkills(std.heap.c_allocator, self.workspace_root, builtin_skills.root_policy);
         skill_runtime.traceDiagnostics("interactive_reload", loaded.diagnostics);
         self.skills.replaceLoaded(std.heap.c_allocator, loaded.dir, loaded.skills, loaded.diagnostics);
+    }
+
+    pub fn reloadCustomCommands(self: *App, surface: []const u8) !void {
+        const policy = if (comptime host_target.is_wasm)
+            wasm_command_root_policy
+        else
+            builtin_custom_commands.root_policy;
+        try app_runtime_setup.reloadCustomCommandRuntime(
+            self.alloc,
+            &self.custom_commands,
+            self.workspace_root,
+            policy,
+            builtin_commands.slash_registry,
+            surface,
+        );
     }
 
     pub fn allowToolForSession(self: *App, tool_name: []const u8, target_path: []const u8) !void {
@@ -3812,8 +3852,10 @@ test {
     _ = @import("core/cli/cli_surface.zig");
     _ = @import("core/workspace/change_tracker.zig");
     _ = @import("core/shared/collections.zig");
+    _ = @import("core/slash_commands/command_expansion.zig");
     _ = @import("core/slash_commands/command_router.zig");
     _ = @import("core/slash_commands/command_specs.zig");
+    _ = @import("core/slash_commands/custom_commands.zig");
     _ = @import("core/config/config_runtime.zig");
     _ = @import("core/config/settings_store.zig");
     _ = @import("ui/footer/compact_command_menu_presentation.zig");
@@ -3929,6 +3971,7 @@ test {
     _ = @import("core/tooling/tool_runtime.zig");
     _ = @import("core/tooling/tool_specs.zig");
     _ = @import("builtins/commands.zig");
+    _ = @import("builtins/custom_commands.zig");
     _ = @import("builtins/mcp.zig");
     _ = @import("builtins/modes.zig");
     _ = @import("builtins/tools.zig");

--- a/tests/e2e/ci-shard-weights.json
+++ b/tests/e2e/ci-shard-weights.json
@@ -44,6 +44,7 @@
   { "file": "tui-resize.test.ts", "weight": 187 },
   { "file": "tui-resume-brutal.test.ts", "weight": 18 },
   { "file": "tui-resume.test.ts", "weight": 289 },
+  { "file": "tui-slash-custom-commands.test.ts", "weight": 4 },
   { "file": "tui-slash-commands.test.ts", "weight": 5 },
   { "file": "tui-slash-extra.test.ts", "weight": 4 },
   { "file": "tui-slash-menu.test.ts", "weight": 88 },

--- a/tests/e2e/tui-slash-custom-commands.test.ts
+++ b/tests/e2e/tui-slash-custom-commands.test.ts
@@ -103,7 +103,7 @@ describe.skipIf(SKIP)("tui: custom slash commands", () => {
           FX_AUTO_UPGRADE: "0",
         },
         stderrPath: fixture.stderrPath,
-        width: 180,
+        width: 260,
         height: 30,
       });
       await session.waitForComposer(10_000);
@@ -165,7 +165,7 @@ describe.skipIf(SKIP)("tui: custom slash commands", () => {
           FX_TRACE_SCOPES: "commands",
         },
         stderrPath: fixture.stderrPath,
-        width: 180,
+        width: 260,
         height: 30,
       });
       await session.waitForComposer(10_000);

--- a/tests/e2e/tui-slash-custom-commands.test.ts
+++ b/tests/e2e/tui-slash-custom-commands.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  FAKE_GATEWAY_MODEL,
+  fakeGatewayFinalText,
+  hasEmptyComposer,
+  startFakeGateway,
+  TmuxSession,
+  tmuxAvailable,
+} from "./tmux-helpers";
+
+const SKIP = !tmuxAvailable();
+const TIMEOUT = 30_000;
+const TEST_TIMEOUT = 120_000;
+
+let session: TmuxSession | null = null;
+let gateway: ReturnType<typeof startFakeGateway> | null = null;
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  if (session) {
+    await session.kill();
+    session = null;
+  }
+  gateway?.stop();
+  gateway = null;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createFixture(label: string) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), `fx-custom-commands-${label}-`)));
+  const home = join(root, "home");
+  const workspace = join(root, "workspace");
+  const promptsRoot = join(workspace, ".fx", "prompts");
+  const stderrPath = join(root, "stderr.log");
+  const tracePath = join(root, "trace.log");
+  mkdirSync(join(home, ".fx"), { recursive: true });
+  mkdirSync(promptsRoot, { recursive: true });
+  writeFileSync(join(home, ".fx", "settings.json"), "{}\n");
+  tempDirs.push(root);
+  return { home, promptsRoot, stderrPath, tracePath, workspace };
+}
+
+function nestedText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) return content.map(nestedText).join("");
+  if (content && typeof content === "object") {
+    const value = content as Record<string, unknown>;
+    return [nestedText(value.text), nestedText(value.value), nestedText(value.content)].join("");
+  }
+  return "";
+}
+
+function gatewayPromptText(body: string): string {
+  const request = JSON.parse(body) as { prompt: Array<{ content: unknown }> };
+  return request.prompt.map((message) => nestedText(message.content)).join("\n");
+}
+
+function readTrace(path: string): string {
+  return existsSync(path) ? readFileSync(path, "utf8") : "";
+}
+
+describe.skipIf(SKIP)("tui: custom slash commands", () => {
+  test(
+    "workspace command appears in completion and sends its expanded prompt",
+    async () => {
+      const fixture = createFixture("happy");
+      writeFileSync(
+        join(fixture.promptsRoot, "review-pr.md"),
+        [
+          "---",
+          "description: Review a pull request",
+          "argument-hint: <number> [focus]",
+          "---",
+          "CUSTOM_REVIEW number=$1 focus=${2:-general}",
+          "CUSTOM_REVIEW arguments=$ARGUMENTS literal=$$",
+          "",
+        ].join("\n"),
+      );
+
+      gateway = startFakeGateway([fakeGatewayFinalText("CUSTOM_REVIEW_COMPLETE")]);
+      session = await TmuxSession.create({
+        cwd: fixture.workspace,
+        env: {
+          HOME: fixture.home,
+          AI_GATEWAY_API_KEY: "local-fixture-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_AUTO_UPGRADE: "0",
+        },
+        stderrPath: fixture.stderrPath,
+        width: 180,
+        height: 30,
+      });
+      await session.waitForComposer(10_000);
+
+      await session.sendLiteralText("/review");
+      const completion = await session.waitForText(fixture.promptsRoot, 5_000);
+      expect(completion).toContain("/review-pr <number> [focus]");
+      expect(completion).toContain(`Review a pull request (${fixture.promptsRoot})`);
+
+      await session.sendKeys("C-u");
+      await session.sendText("/help");
+      await session.waitForText("Commands 38", 5_000);
+      await session.sendLiteralText("review-pr");
+      const help = await session.waitForText("Commands 1", 5_000);
+      expect(help).toContain("/review-pr <number> [focus]");
+      expect(help).toContain(fixture.promptsRoot);
+      await session.sendKeys("Escape");
+      await session.waitForPane(
+        (pane) => hasEmptyComposer(pane) && !pane.includes("Enter Open"),
+        5_000,
+      );
+
+      await session.sendText("/review-pr 512 security");
+      await session.waitForText("CUSTOM_REVIEW_COMPLETE", 10_000);
+
+      expect(gateway.requests).toHaveLength(1);
+      expect(gatewayPromptText(gateway.requests[0]!.body)).toContain(
+        "CUSTOM_REVIEW number=512 focus=security\n" +
+          "CUSTOM_REVIEW arguments=512 security literal=$",
+      );
+      expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      session = null;
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "rejected files are diagnosed while valid custom and builtin commands remain available",
+    async () => {
+      const fixture = createFixture("rejections");
+      writeFileSync(join(fixture.promptsRoot, "help.md"), "CUSTOM_HELP_MUST_NOT_LOAD\n");
+      writeFileSync(
+        join(fixture.promptsRoot, "malformed.md"),
+        "---\ndescription: unterminated frontmatter\nMALFORMED_MUST_NOT_LOAD\n",
+      );
+      writeFileSync(join(fixture.promptsRoot, "still-works.md"), "VALID_CUSTOM_BODY\n");
+
+      session = await TmuxSession.create({
+        cwd: fixture.workspace,
+        env: {
+          HOME: fixture.home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_TRACE_LOG: fixture.tracePath,
+          FX_TRACE_SCOPES: "commands",
+        },
+        stderrPath: fixture.stderrPath,
+        width: 180,
+        height: 30,
+      });
+      await session.waitForComposer(10_000);
+
+      const trace = readTrace(fixture.tracePath);
+      expect(trace).toContain("cause=builtin_collision");
+      expect(trace).toContain("command 'help' conflicts with a built-in command");
+      expect(trace).toContain("cause=invalid_frontmatter");
+      expect(trace).toContain("invalid command frontmatter");
+
+      await session.sendLiteralText("/still");
+      const completion = await session.waitForText("/still-works", 5_000);
+      expect(completion).toContain(fixture.promptsRoot);
+      expect(completion).not.toContain("/malformed");
+
+      await session.sendKeys("C-u");
+      await session.sendText("/help");
+      const help = await session.waitForText("Enter Open", 5_000);
+      expect(help).toContain("/help");
+      expect(help).not.toContain("CUSTOM_HELP_MUST_NOT_LOAD");
+      expect(session.paneStatus()).toEqual({ dead: false, status: null });
+
+      await session.sendKeys("Escape");
+      await session.waitForPane(hasEmptyComposer, 5_000);
+      expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      session = null;
+    },
+    TEST_TIMEOUT,
+  );
+});


### PR DESCRIPTION
## Summary

- Discover Markdown slash commands from `.fx/prompts/` in the workspace hierarchy and from `~/.fx/prompts/`.
- Parse command metadata from frontmatter, merge custom commands into help and completion, and resolve collisions deterministically.
- Expand `$ARGUMENTS` and positional placeholders with defaults before submitting the rendered prompt.
- Reload commands with the active workspace and document the supported format and precedence.
- Add focused unit and deterministic TUI coverage, including cross-platform filesystem behavior.

## Validation

- `zig fmt --check src/`
- Focused Zig command, registry, and session reload tests
- `zig build`
- Built-binary interactive custom-command exercise
- Focused deterministic TUI tests
- Full CI on the exact head commit across Linux and macOS, x86_64 and arm64: https://github.com/arthjean/fx/actions/runs/32714595915

Refs #183
