### PR TITLE
Run workspace grep through the trusted Git executable

### DIFF
--- a/scripts/pgso/corpus.json
+++ b/scripts/pgso/corpus.json
@@ -82,6 +82,7 @@
     {"name": "e2e-file-tool-paths", "argv": ["bun", "test", "--max-concurrency", "1", "./file-tool-paths.test.ts"], "test_file": "file-tool-paths.test.ts"},
     {"name": "e2e-file-tool-permissions", "argv": ["bun", "test", "--max-concurrency", "1", "./file-tool-permissions.test.ts"], "test_file": "file-tool-permissions.test.ts"},
     {"name": "e2e-gateway-stream-lifecycle", "argv": ["bun", "test", "--max-concurrency", "1", "./gateway-stream-lifecycle.test.ts"], "test_file": "gateway-stream-lifecycle.test.ts"},
+    {"name": "e2e-grep-trusted-git", "argv": ["bun", "test", "--max-concurrency", "1", "./grep-trusted-git.test.ts"], "test_file": "grep-trusted-git.test.ts"},
     {"name": "e2e-web-fetch-fake-network", "argv": ["bun", "test", "--max-concurrency", "1", "./web-fetch-fake-network.test.ts"], "test_file": "web-fetch-fake-network.test.ts"},
     {"name": "e2e-web-search-fake-gateway", "argv": ["bun", "test", "--max-concurrency", "1", "./web-search-fake-gateway.test.ts"], "test_file": "web-search-fake-gateway.test.ts"},
     {"name": "e2e-vision-route-fake-gateway", "argv": ["bun", "test", "--max-concurrency", "1", "./vision-route-fake-gateway.test.ts"], "test_file": "vision-route-fake-gateway.test.ts"},

--- a/scripts/pgso/tests/test_corpus.py
+++ b/scripts/pgso/tests/test_corpus.py
@@ -29,6 +29,7 @@ TRAINING_E2E_TESTS = (
     "file-tool-paths.test.ts",
     "file-tool-permissions.test.ts",
     "gateway-stream-lifecycle.test.ts",
+    "grep-trusted-git.test.ts",
     "web-fetch-fake-network.test.ts",
     "web-search-fake-gateway.test.ts",
     "vision-route-fake-gateway.test.ts",
@@ -364,8 +365,8 @@ class PgsoCorpusTests(unittest.TestCase):
             EXCLUDED_E2E_TESTS,
             tuple(test_file for test_file, _ in corpus.intentional_exclusions),
         )
-        self.assertEqual(35, len(corpus.scenarios))
-        self.assertEqual(52, len(corpus.candidate_scenarios))
+        self.assertEqual(36, len(corpus.scenarios))
+        self.assertEqual(53, len(corpus.candidate_scenarios))
         self.assertEqual(
             {
                 "direct-help": 100,

--- a/src/core/workspace/grep_search.zig
+++ b/src/core/workspace/grep_search.zig
@@ -862,7 +862,9 @@ fn readTrace(alloc: Allocator, trace_path: []const u8) ![]u8 {
 fn runGitForTest(alloc: Allocator, cwd: []const u8, args: []const []const u8) !void {
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(alloc);
-    try argv.append(alloc, "git");
+    // Test setup resolves Git the same way production does, so this file holds
+    // no bare executable name for the argv guard below to have to except.
+    try argv.append(alloc, workspace_files.trustedGitExecutable() orelse return error.SkipZigTest);
     try argv.appendSlice(alloc, args);
 
     const result = std.process.run(alloc, std.testing.io, .{
@@ -949,13 +951,15 @@ test "grep search does not ignore workspace because ignored name is outside work
     try std.testing.expect(std.mem.endsWith(u8, result.matches[0].absolute_path, "src/file.txt"));
 }
 
-fn countScriptRuns(alloc: Allocator, marker_path: []const u8) !usize {
-    const contents = readFileToEndForTest(alloc, marker_path, 4096) catch |err| switch (err) {
-        error.FileNotFound => return 0,
+/// The argv of every spawn the injected executable received, one per line.
+/// A site that resolves its own name through PATH runs the real Git instead
+/// and leaves nothing here, so the caller asserts on content rather than a
+/// count: a tally cannot tell a missing spawn from an unrecorded one.
+fn recordedSpawns(alloc: Allocator, marker_path: []const u8) ![]u8 {
+    return readFileToEndForTest(alloc, marker_path, 4096) catch |err| switch (err) {
+        error.FileNotFound => return alloc.alloc(u8, 0),
         else => return err,
     };
-    defer alloc.free(contents);
-    return std.mem.count(u8, contents, "ran\n");
 }
 
 fn writeExecutableScript(tmp: *std.testing.TmpDir, sub_path: []const u8, body: []const u8) !void {
@@ -979,7 +983,7 @@ test "grep search spawns the selected Git executable rather than resolving one f
 
     const marker = try std.fs.path.join(alloc, &.{ workspace, "spawned.log" });
     defer alloc.free(marker);
-    const script = try std.fmt.allocPrint(alloc, "#!/bin/sh\nprintf 'ran\\n' >> {s}\nexit 1\n", .{marker});
+    const script = try std.fmt.allocPrint(alloc, "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{s}\"\nexit 1\n", .{marker});
     defer alloc.free(script);
     try writeExecutableScript(&tmp, "fake-git", script);
     const fake_git = try std.fs.path.join(alloc, &.{ workspace, "fake-git" });
@@ -999,9 +1003,13 @@ test "grep search spawns the selected Git executable rather than resolving one f
         fake_git,
     );
 
-    // Both spawns on this path used the selection. A bare "git" argv0 at
-    // either site would have resolved through PATH and gone unrecorded.
-    try std.testing.expectEqual(@as(usize, 2), try countScriptRuns(alloc, marker));
+    // Assert what the selection was asked to run, not how often it ran. A
+    // bare argv0 at either site resolves through PATH to the real Git and
+    // records nothing, so a missing line is the regression this catches.
+    const spawns = try recordedSpawns(alloc, marker);
+    defer alloc.free(spawns);
+    try std.testing.expect(std.mem.find(u8, spawns, "check-ignore") != null);
+    try std.testing.expect(std.mem.find(u8, spawns, "grep -n") != null);
 }
 
 test "grep search count path spawns the selected Git executable rather than resolving one from PATH" {
@@ -1018,7 +1026,7 @@ test "grep search count path spawns the selected Git executable rather than reso
 
     const marker = try std.fs.path.join(alloc, &.{ workspace, "spawned.log" });
     defer alloc.free(marker);
-    const script = try std.fmt.allocPrint(alloc, "#!/bin/sh\nprintf 'ran\\n' >> {s}\nexit 1\n", .{marker});
+    const script = try std.fmt.allocPrint(alloc, "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{s}\"\nexit 1\n", .{marker});
     defer alloc.free(script);
     try writeExecutableScript(&tmp, "fake-git", script);
     const fake_git = try std.fs.path.join(alloc, &.{ workspace, "fake-git" });
@@ -1038,10 +1046,13 @@ test "grep search count path spawns the selected Git executable rather than reso
         fake_git,
     );
 
-    try std.testing.expectEqual(@as(usize, 2), try countScriptRuns(alloc, marker));
+    const spawns = try recordedSpawns(alloc, marker);
+    defer alloc.free(spawns);
+    try std.testing.expect(std.mem.find(u8, spawns, "check-ignore") != null);
+    try std.testing.expect(std.mem.find(u8, spawns, "grep --count") != null);
 }
 
-test "grep search falls back to the Zig scanner when no trusted Git executable is available" {
+test "grep search refuses to resolve Git when no trusted executable is available" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1050,6 +1061,12 @@ test "grep search falls back to the Zig scanner when no trusted Git executable i
 
     const tracked = try writeTempFile(alloc, &tmp, "tracked.txt", "needle tracked\n");
     defer alloc.free(tracked);
+    const trace_path = try std.fs.path.join(alloc, &.{ workspace, "trace.log" });
+    defer alloc.free(trace_path);
+
+    debug_trace.resetForTest();
+    try debug_trace.configureForTest(alloc, trace_path);
+    defer debug_trace.resetForTest();
 
     var arena_state = std.heap.ArenaAllocator.init(alloc);
     defer arena_state.deinit();
@@ -1065,14 +1082,35 @@ test "grep search falls back to the Zig scanner when no trusted Git executable i
         null,
     );
 
+    // The trace line is what separates a refusal from a fallback reached by
+    // some other route: substituting a name for the missing executable would
+    // still land in the scanner, but never emits this.
+    const trace = try readTrace(alloc, trace_path);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(u8, trace, "trusted Git unavailable") != null);
+
     try std.testing.expectEqual(@as(usize, 1), result.matches.len);
     try std.testing.expect(std.mem.endsWith(u8, result.matches[0].absolute_path, "tracked.txt"));
 }
 
-test "workspace grep never selects a Git executable by bare name" {
-    if (workspace_files.trustedGitExecutable()) |executable| {
-        try std.testing.expect(std.fs.path.isAbsolute(executable));
-    }
+test "grep search builds no Git argv from a bare executable name" {
+    const alloc = std.testing.allocator;
+    var file = try std.Io.Dir.cwd().openFile(io_mod.getIo(), "src/core/workspace/grep_search.zig", .{});
+    defer file.close(io_mod.getIo());
+    const source = try io_mod.readFileToEnd(alloc, &file, 256 * 1024);
+    defer alloc.free(source);
+
+    // No argv in this file may name the executable instead of resolving it.
+    // Keyed on the bare literal, not on any argv shape, so a future spawn
+    // that skips the usual flags cannot slip past. Split so the needle does
+    // not match itself in this test's own source.
+    const bare = "\"gi" ++ "t\"";
+    try std.testing.expect(std.mem.find(u8, source, bare) == null);
+}
+
+test "workspace grep only ever selects an absolute Git executable" {
+    const executable = workspace_files.trustedGitExecutable() orelse return error.SkipZigTest;
+    try std.testing.expect(std.fs.path.isAbsolute(executable));
 }
 
 test "grep search falls back to Zig scanner outside git repositories" {

--- a/src/core/workspace/grep_search.zig
+++ b/src/core/workspace/grep_search.zig
@@ -1108,6 +1108,44 @@ test "grep search builds no Git argv from a bare executable name" {
     try std.testing.expect(std.mem.find(u8, source, bare) == null);
 }
 
+test "grep search public entry points resolve a trusted Git rather than skipping it" {
+    _ = workspace_files.trustedGitExecutable() orelse return error.SkipZigTest;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const workspace = try workspaceRoot(alloc, tmp);
+    defer alloc.free(workspace);
+    const tracked = try writeTempFile(alloc, &tmp, "tracked.txt", "needle tracked\n");
+    defer alloc.free(tracked);
+    const trace_path = try std.fs.path.join(alloc, &.{ workspace, "trace.log" });
+    defer alloc.free(trace_path);
+
+    debug_trace.resetForTest();
+    try debug_trace.configureForTest(alloc, trace_path);
+    defer debug_trace.resetForTest();
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    _ = try collectDirectoryMatchesWithIgnored(
+        arena_state.allocator(),
+        workspace,
+        workspace,
+        "needle",
+        false,
+        ignored_dirs.ignored_directory_names,
+        null,
+    );
+
+    // The wrappers are the only place the trusted executable is looked up, and
+    // handing the search a null there degrades every grep to the scanner while
+    // still returning the same matches. The refusal trace is the one signal
+    // that separates "resolved it" from "never asked".
+    const trace = try readTrace(alloc, trace_path);
+    defer alloc.free(trace);
+    try std.testing.expect(std.mem.find(u8, trace, "trusted Git unavailable") == null);
+}
+
 test "workspace grep only ever selects an absolute Git executable" {
     const executable = workspace_files.trustedGitExecutable() orelse return error.SkipZigTest;
     try std.testing.expect(std.fs.path.isAbsolute(executable));

--- a/src/core/workspace/grep_search.zig
+++ b/src/core/workspace/grep_search.zig
@@ -72,7 +72,7 @@ pub fn collectDirectoryMatchesWithIgnored(
     ignored_names: []const []const u8,
     include: ?glob_pattern.Pattern,
 ) !Result {
-    return collectDirectoryMatchesWithOptions(arena, workspace_root, absolute_root, pattern, case_insensitive, ignored_names, include, .{});
+    return collectDirectoryMatchesWithOptions(arena, workspace_root, absolute_root, pattern, case_insensitive, ignored_names, include, .{}, workspace_files.trustedGitExecutable());
 }
 
 pub fn countDirectoryMatchesWithIgnored(
@@ -84,7 +84,7 @@ pub fn countDirectoryMatchesWithIgnored(
     ignored_names: []const []const u8,
     include: ?glob_pattern.Pattern,
 ) !CountResult {
-    return countDirectoryMatchesWithOptions(arena, workspace_root, absolute_root, pattern, case_insensitive, ignored_names, include, .{});
+    return countDirectoryMatchesWithOptions(arena, workspace_root, absolute_root, pattern, case_insensitive, ignored_names, include, .{}, workspace_files.trustedGitExecutable());
 }
 
 fn collectDirectoryMatchesWithOptions(
@@ -96,6 +96,7 @@ fn collectDirectoryMatchesWithOptions(
     ignored_names: []const []const u8,
     include: ?glob_pattern.Pattern,
     workspace_options: workspace_files.Options,
+    git_executable_override: ?[]const u8,
 ) !Result {
     var matches: std.ArrayList(Match) = .empty;
     errdefer matches.deinit(arena);
@@ -103,8 +104,13 @@ fn collectDirectoryMatchesWithOptions(
     var truncated_reason: ?TruncatedReason = null;
     var stats: CandidateStats = .{ .cap = workspace_options.candidate_cap };
 
-    if (!workspace_options.force_fallback and !gitIgnoresRoot(arena, absolute_root)) git: {
-        const tracked = gitGrepTrackedMatches(arena, workspace_root, absolute_root, pattern, case_insensitive, include, &matches) catch |err| {
+    if (!workspace_options.force_fallback) git: {
+        const git_executable = git_executable_override orelse {
+            debug_trace.logf("core", "grep_files trusted Git unavailable; falling back root={s}", .{absolute_root});
+            break :git;
+        };
+        if (gitIgnoresRoot(arena, absolute_root, git_executable)) break :git;
+        const tracked = gitGrepTrackedMatches(arena, workspace_root, absolute_root, pattern, case_insensitive, include, &matches, git_executable) catch |err| {
             if (err == error.OutOfMemory) return error.OutOfMemory;
             debug_trace.logf("core", "grep_files git grep fallback root={s} err={s}", .{ absolute_root, @errorName(err) });
             break :git;
@@ -147,12 +153,18 @@ fn countDirectoryMatchesWithOptions(
     ignored_names: []const []const u8,
     include: ?glob_pattern.Pattern,
     workspace_options: workspace_files.Options,
+    git_executable_override: ?[]const u8,
 ) !CountResult {
     var count_result: CountResult = .{ .candidate_cap = workspace_options.candidate_cap };
     var stats: CandidateStats = .{ .cap = workspace_options.candidate_cap };
 
-    if (!workspace_options.force_fallback and !gitIgnoresRoot(arena, absolute_root)) git: {
-        const tracked = gitGrepTrackedCounts(arena, workspace_root, absolute_root, pattern, case_insensitive, include) catch |err| {
+    if (!workspace_options.force_fallback) git: {
+        const git_executable = git_executable_override orelse {
+            debug_trace.logf("core", "grep_files trusted Git unavailable; falling back root={s}", .{absolute_root});
+            break :git;
+        };
+        if (gitIgnoresRoot(arena, absolute_root, git_executable)) break :git;
+        const tracked = gitGrepTrackedCounts(arena, workspace_root, absolute_root, pattern, case_insensitive, include, git_executable) catch |err| {
             if (err == error.OutOfMemory) return error.OutOfMemory;
             debug_trace.logf("core", "grep_files git grep count fallback root={s} err={s}", .{ absolute_root, @errorName(err) });
             break :git;
@@ -185,8 +197,8 @@ fn countDirectoryMatchesWithOptions(
     return finishCount(count_result, stats);
 }
 
-fn gitIgnoresRoot(arena: Allocator, absolute_root: []const u8) bool {
-    const argv = [_][]const u8{ "git", "--no-optional-locks", "check-ignore", "-q", "--", "." };
+fn gitIgnoresRoot(arena: Allocator, absolute_root: []const u8, git_executable: []const u8) bool {
+    const argv = [_][]const u8{ git_executable, "--no-optional-locks", "check-ignore", "-q", "--", "." };
     const result = std.process.run(arena, io_mod.getIo(), .{
         .argv = &argv,
         .cwd = .{ .path = absolute_root },
@@ -399,8 +411,8 @@ fn countCandidateList(
     }
 }
 
-pub fn gitGrepArgvForTest() [9][]const u8 {
-    return .{ "git", "--no-optional-locks", "grep", "-n", "-I", "-F", "-z", "-e", "needle" };
+pub fn gitGrepArgvForTest(git_executable: []const u8) [9][]const u8 {
+    return .{ git_executable, "--no-optional-locks", "grep", "-n", "-I", "-F", "-z", "-e", "needle" };
 }
 
 const GitGrepMatchesResult = struct {
@@ -420,12 +432,13 @@ fn gitGrepTrackedMatches(
     case_insensitive: bool,
     include: ?glob_pattern.Pattern,
     matches: *std.ArrayList(Match),
+    git_executable: []const u8,
 ) !GitGrepMatchesResult {
     if (pattern.len == 0) return error.GitGrepUnsupported;
 
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(arena);
-    try argv.appendSlice(arena, &.{ "git", "--no-optional-locks", "grep", "-n", "-I", "-F", "-z" });
+    try argv.appendSlice(arena, &.{ git_executable, "--no-optional-locks", "grep", "-n", "-I", "-F", "-z" });
     if (case_insensitive) try argv.append(arena, "-i");
     try argv.appendSlice(arena, &.{ "-e", pattern, "--" });
     if (safeGitIncludePathspec(include)) |pathspec| {
@@ -463,12 +476,13 @@ fn gitGrepTrackedCounts(
     pattern: []const u8,
     case_insensitive: bool,
     include: ?glob_pattern.Pattern,
+    git_executable: []const u8,
 ) !CountResult {
     if (pattern.len == 0) return error.GitGrepUnsupported;
 
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(arena);
-    try argv.appendSlice(arena, &.{ "git", "--no-optional-locks", "grep", "--count", "-I", "-F", "-z" });
+    try argv.appendSlice(arena, &.{ git_executable, "--no-optional-locks", "grep", "--count", "-I", "-F", "-z" });
     if (case_insensitive) try argv.append(arena, "-i");
     try argv.appendSlice(arena, &.{ "-e", pattern, "--" });
     if (safeGitIncludePathspec(include)) |pathspec| {
@@ -867,9 +881,9 @@ fn runGitForTest(alloc: Allocator, cwd: []const u8, args: []const []const u8) !v
 }
 
 test "grep search git grep argv uses literal fixed-string flags" {
-    const argv = gitGrepArgvForTest();
+    const argv = gitGrepArgvForTest("/usr/bin/git");
 
-    try std.testing.expectEqualStrings("git", argv[0]);
+    try std.testing.expectEqualStrings("/usr/bin/git", argv[0]);
     try std.testing.expectEqualStrings("--no-optional-locks", argv[1]);
     try std.testing.expectEqualStrings("grep", argv[2]);
     try std.testing.expectEqualStrings("-n", argv[3]);
@@ -933,6 +947,132 @@ test "grep search does not ignore workspace because ignored name is outside work
     try std.testing.expectEqual(@as(usize, 1), result.matches.len);
     try std.testing.expect(result.truncated_reason == null);
     try std.testing.expect(std.mem.endsWith(u8, result.matches[0].absolute_path, "src/file.txt"));
+}
+
+fn countScriptRuns(alloc: Allocator, marker_path: []const u8) !usize {
+    const contents = readFileToEndForTest(alloc, marker_path, 4096) catch |err| switch (err) {
+        error.FileNotFound => return 0,
+        else => return err,
+    };
+    defer alloc.free(contents);
+    return std.mem.count(u8, contents, "ran\n");
+}
+
+fn writeExecutableScript(tmp: *std.testing.TmpDir, sub_path: []const u8, body: []const u8) !void {
+    var file = try tmp.dir.createFile(std.testing.io, sub_path, .{});
+    defer file.close(io_mod.getIo());
+    try file.writeStreamingAll(io_mod.getIo(), body);
+    try file.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o755));
+}
+
+test "grep search spawns the selected Git executable rather than resolving one from PATH" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const workspace = try workspaceRoot(alloc, tmp);
+    defer alloc.free(workspace);
+
+    const tracked = try writeTempFile(alloc, &tmp, "tracked.txt", "needle tracked\n");
+    defer alloc.free(tracked);
+
+    const marker = try std.fs.path.join(alloc, &.{ workspace, "spawned.log" });
+    defer alloc.free(marker);
+    const script = try std.fmt.allocPrint(alloc, "#!/bin/sh\nprintf 'ran\\n' >> {s}\nexit 1\n", .{marker});
+    defer alloc.free(script);
+    try writeExecutableScript(&tmp, "fake-git", script);
+    const fake_git = try std.fs.path.join(alloc, &.{ workspace, "fake-git" });
+    defer alloc.free(fake_git);
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    _ = try collectDirectoryMatchesWithOptions(
+        arena_state.allocator(),
+        workspace,
+        workspace,
+        "needle",
+        false,
+        ignored_dirs.ignored_directory_names,
+        null,
+        .{},
+        fake_git,
+    );
+
+    // Both spawns on this path used the selection. A bare "git" argv0 at
+    // either site would have resolved through PATH and gone unrecorded.
+    try std.testing.expectEqual(@as(usize, 2), try countScriptRuns(alloc, marker));
+}
+
+test "grep search count path spawns the selected Git executable rather than resolving one from PATH" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const workspace = try workspaceRoot(alloc, tmp);
+    defer alloc.free(workspace);
+
+    const tracked = try writeTempFile(alloc, &tmp, "tracked.txt", "needle tracked\n");
+    defer alloc.free(tracked);
+
+    const marker = try std.fs.path.join(alloc, &.{ workspace, "spawned.log" });
+    defer alloc.free(marker);
+    const script = try std.fmt.allocPrint(alloc, "#!/bin/sh\nprintf 'ran\\n' >> {s}\nexit 1\n", .{marker});
+    defer alloc.free(script);
+    try writeExecutableScript(&tmp, "fake-git", script);
+    const fake_git = try std.fs.path.join(alloc, &.{ workspace, "fake-git" });
+    defer alloc.free(fake_git);
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    _ = try countDirectoryMatchesWithOptions(
+        arena_state.allocator(),
+        workspace,
+        workspace,
+        "needle",
+        false,
+        ignored_dirs.ignored_directory_names,
+        null,
+        .{},
+        fake_git,
+    );
+
+    try std.testing.expectEqual(@as(usize, 2), try countScriptRuns(alloc, marker));
+}
+
+test "grep search falls back to the Zig scanner when no trusted Git executable is available" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const workspace = try workspaceRoot(alloc, tmp);
+    defer alloc.free(workspace);
+
+    const tracked = try writeTempFile(alloc, &tmp, "tracked.txt", "needle tracked\n");
+    defer alloc.free(tracked);
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const result = try collectDirectoryMatchesWithOptions(
+        arena_state.allocator(),
+        workspace,
+        workspace,
+        "needle",
+        false,
+        ignored_dirs.ignored_directory_names,
+        null,
+        .{},
+        null,
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), result.matches.len);
+    try std.testing.expect(std.mem.endsWith(u8, result.matches[0].absolute_path, "tracked.txt"));
+}
+
+test "workspace grep never selects a Git executable by bare name" {
+    if (workspace_files.trustedGitExecutable()) |executable| {
+        try std.testing.expect(std.fs.path.isAbsolute(executable));
+    }
 }
 
 test "grep search falls back to Zig scanner outside git repositories" {
@@ -1292,6 +1432,7 @@ test "grep_files path narrowing applies before candidate cap" {
             .candidate_cap = 1,
             .force_fallback = true,
         },
+        workspace_files.trustedGitExecutable(),
     );
 
     try std.testing.expectEqual(@as(usize, 1), result.candidate_count);

--- a/src/core/workspace/workspace_files.zig
+++ b/src/core/workspace/workspace_files.zig
@@ -257,7 +257,10 @@ fn runGitRawList(
     }
 }
 
-fn trustedGitExecutable() ?[]const u8 {
+/// The Git binary the workspace layer is willing to run, or null when none of
+/// the known-good absolute paths exist. Never falls back to a PATH lookup, so a
+/// `git` planted earlier on PATH cannot stand in for the real one.
+pub fn trustedGitExecutable() ?[]const u8 {
     const candidates = switch (builtin.os.tag) {
         .windows => &[_][]const u8{
             "C:\\Program Files\\Git\\cmd\\git.exe",

--- a/tests/e2e/ci-shard-weights.json
+++ b/tests/e2e/ci-shard-weights.json
@@ -1,8 +1,8 @@
 [
-  { "file": "auto-mode-reliability.test.ts", "weight": 4 },
   { "file": "acp.test.ts", "weight": 29 },
   { "file": "ask-presentation.test.ts", "weight": 5 },
   { "file": "auth-refresh.test.ts", "weight": 2 },
+  { "file": "auto-mode-reliability.test.ts", "weight": 4 },
   { "file": "ci-shards.test.ts", "weight": 15 },
   { "file": "cli.test.ts", "weight": 19 },
   { "file": "config-persistence.test.ts", "weight": 64 },
@@ -10,6 +10,7 @@
   { "file": "file-tool-paths.test.ts", "weight": 6 },
   { "file": "file-tool-permissions.test.ts", "weight": 2 },
   { "file": "gateway-stream-lifecycle.test.ts", "weight": 98 },
+  { "file": "grep-trusted-git.test.ts", "weight": 4 },
   { "file": "host-managed-auth.test.ts", "weight": 2 },
   { "file": "mcp-auth.test.ts", "weight": 105 },
   { "file": "mcp-http.test.ts", "weight": 10 },

--- a/tests/e2e/grep-trusted-git.test.ts
+++ b/tests/e2e/grep-trusted-git.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runFx } from "../evals/eval-helpers";
+
+const TIMEOUT = 30_000;
+const MODEL = "openai/gpt-5";
+const NEEDLE = "TRUSTED_GIT_E2E_NEEDLE";
+
+// Workspace grep resolves Git from a fixed absolute allowlist and never from
+// PATH. These tests drive the built binary with a `git` planted earlier on
+// PATH: the grep tool must not run it, and the control must, so an ineffective
+// PATH override cannot be mistaken for a guard that held.
+
+type GatewayResponse = Response | ((body: string) => Response);
+
+function sse(events: object[]) {
+  return new Response(
+    events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") +
+      "data: [DONE]\n\n",
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function toolCall(id: string, name: string, input: object) {
+  return sse([
+    { type: "tool-call", toolCallId: id, toolName: name, input },
+    { type: "finish", finishReason: { unified: "tool-calls", raw: "tool-calls" } },
+  ]);
+}
+
+function finalText(text: string) {
+  return sse([
+    { type: "text-delta", id: "answer_1", delta: text },
+    {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: { inputTokens: { total: 11 }, outputTokens: { total: 13 } },
+    },
+  ]);
+}
+
+function permissionDecision() {
+  return toolCall("permission_decision_1", "permission_decision", {
+    risk: "medium",
+    decision: "clear",
+    rationale: "test fixture",
+  });
+}
+
+function startFakeGateway(responses: GatewayResponse[]) {
+  const requests: { body: string }[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/coding-agent/v1/models") {
+        return Response.json({
+          data: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+        });
+      }
+      if (req.method !== "POST") return new Response("not found", { status: 404 });
+      const body = await req.text();
+      if (body.includes('"permission_decision"')) return permissionDecision();
+      requests.push({ body });
+      const response = responses.shift();
+      if (!response) return new Response("unexpected Gateway request", { status: 500 });
+      return typeof response === "function" ? response(body) : response;
+    },
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${server.port}`,
+    chatUrl: `http://127.0.0.1:${server.port}/v3/ai/language-model`,
+    requests,
+    stop() {
+      server.stop(true);
+    },
+  };
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) return content.map(contentText).join("");
+  if (content && typeof content === "object") {
+    const value = content as Record<string, unknown>;
+    return [contentText(value.text), contentText(value.value), contentText(value.content)].join("");
+  }
+  return "";
+}
+
+function toolResultOutput(body: string, callId: string): string {
+  const request = JSON.parse(body) as { prompt: Array<{ content: unknown }> };
+  const parts = request.prompt.flatMap((message) =>
+    Array.isArray(message.content) ? message.content : []
+  ) as Array<Record<string, unknown>>;
+  const result = parts.find(
+    (part) => part.type === "tool-result" && part.toolCallId === callId,
+  );
+  if (!result) throw new Error(`Missing tool result for ${callId}`);
+  return contentText(result.output);
+}
+
+function createRoot() {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-trusted-git-e2e-")));
+  const home = join(root, "home");
+  const workspace = join(root, "workspace");
+  const fakeBin = join(root, "fakebin");
+  mkdirSync(join(home, ".fx"), { recursive: true });
+  mkdirSync(workspace, { recursive: true });
+  mkdirSync(fakeBin, { recursive: true });
+  writeFileSync(join(home, ".fx", "settings.json"), "{}");
+  const marker = join(root, "planted-git.log");
+
+  // Exits 1 so a caller reading it as "no matches" still records the run.
+  writeFileSync(
+    join(fakeBin, "git"),
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> "${marker}"\nexit 1\n`,
+  );
+  chmodSync(join(fakeBin, "git"), 0o755);
+
+  writeFileSync(join(workspace, "tracked.txt"), `${NEEDLE} tracked\n`);
+  const git = (args: string[]) =>
+    execFileSync("/usr/bin/git", args, { cwd: workspace, stdio: "ignore" });
+  git(["init"]);
+  git(["config", "user.email", "e2e@example.com"]);
+  git(["config", "user.name", "e2e"]);
+  git(["add", "tracked.txt"]);
+  git(["commit", "-m", "seed"]);
+
+  return {
+    root,
+    home: realpathSync(home),
+    workspace: realpathSync(workspace),
+    fakeBin,
+    marker,
+    plantedRuns() {
+      if (!existsSync(marker)) return [];
+      return readFileSync(marker, "utf8").split("\n").filter((line) => line.length > 0);
+    },
+  };
+}
+
+function envFor(root: ReturnType<typeof createRoot>, gateway: ReturnType<typeof startFakeGateway>) {
+  return {
+    HOME: root.home,
+    PATH: `${root.fakeBin}:${process.env.PATH ?? ""}`,
+    AI_GATEWAY_API_KEY: "fake-trusted-git-key",
+    VERCEL_OIDC_TOKEN: undefined,
+    FX_GATEWAY_BASE_URL: gateway.baseUrl,
+    FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+    FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+    FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+    FX_MODEL: MODEL,
+    FX_AUTO_UPGRADE: "0",
+  };
+}
+
+async function runOneToolCall(
+  root: ReturnType<typeof createRoot>,
+  id: string,
+  name: string,
+  input: object,
+) {
+  const gateway = startFakeGateway([toolCall(id, name, input), finalText("done")]);
+  try {
+    const result = await runFx(
+      ["ask", "--auto", "--json", "--no-save", "Execute the requested tool once."],
+      { cwd: root.workspace, env: envFor(root, gateway), timeoutMs: TIMEOUT },
+    );
+    if (result.code !== 0) {
+      throw new Error(`fx exited ${result.code}\n${result.stdout}\n${result.stderr}`);
+    }
+    expect(gateway.requests).toHaveLength(2);
+    return toolResultOutput(gateway.requests[1]!.body, id);
+  } finally {
+    gateway.stop();
+  }
+}
+
+describe("workspace grep Git resolution", () => {
+  test(
+    "a git planted on PATH runs for the terminal tool but never for grep_files",
+    async () => {
+      const root = createRoot();
+      try {
+        // Control. Without it, "grep did not run the plant" cannot be told
+        // apart from a PATH override that never reached the child.
+        const control = await runOneToolCall(root, "control_1", "terminal", {
+          action: "exec",
+          command: "git --version",
+        });
+        expect(control).not.toContain("Not executed");
+        expect(root.plantedRuns()).toEqual(["--version"]);
+
+        rmSync(root.marker, { force: true });
+
+        const output = await runOneToolCall(root, "grep_1", "grep_files", {
+          pattern: NEEDLE,
+        });
+        // The search worked, so the guard is not passing by doing nothing.
+        expect(output).toContain("tracked.txt");
+        expect(output).not.toContain("Not executed");
+        // And it reached no part of the planted binary.
+        expect(root.plantedRuns()).toEqual([]);
+      } finally {
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT * 3,
+  );
+});

--- a/tests/e2e/grep-trusted-git.test.ts
+++ b/tests/e2e/grep-trusted-git.test.ts
@@ -17,6 +17,7 @@ import { runFx } from "../evals/eval-helpers";
 const TIMEOUT = 30_000;
 const MODEL = "openai/gpt-5";
 const NEEDLE = "TRUSTED_GIT_E2E_NEEDLE";
+const PROBE = "fx-trusted-git-e2e-probe";
 
 // Workspace grep resolves Git from a fixed absolute allowlist and never from
 // PATH. These tests drive the built binary with a `git` planted earlier on
@@ -121,13 +122,19 @@ function createRoot() {
   mkdirSync(fakeBin, { recursive: true });
   writeFileSync(join(home, ".fx", "settings.json"), "{}");
   const marker = join(root, "planted-git.log");
+  const probeMarker = join(root, "planted-probe.log");
 
   // Exits 1 so a caller reading it as "no matches" still records the run.
-  writeFileSync(
-    join(fakeBin, "git"),
-    `#!/bin/sh\nprintf '%s\\n' "$*" >> "${marker}"\nexit 1\n`,
-  );
-  chmodSync(join(fakeBin, "git"), 0o755);
+  const recorder = (name: string, log: string) => {
+    writeFileSync(join(fakeBin, name), `#!/bin/sh\nprintf '%s\\n' "$*" >> "${log}"\nexit 1\n`);
+    chmodSync(join(fakeBin, name), 0o755);
+  };
+  recorder("git", marker);
+  // The control cannot plant a second `git`: a macOS login shell runs
+  // path_helper, which puts the system paths first, so /usr/bin/git wins
+  // wherever the plant sits. A name that exists nowhere else resolves through
+  // PATH on every platform, which is the property the control needs.
+  recorder(PROBE, probeMarker);
 
   writeFileSync(join(workspace, "tracked.txt"), `${NEEDLE} tracked\n`);
   const git = (args: string[]) =>
@@ -147,6 +154,10 @@ function createRoot() {
     plantedRuns() {
       if (!existsSync(marker)) return [];
       return readFileSync(marker, "utf8").split("\n").filter((line) => line.length > 0);
+    },
+    probeRuns() {
+      if (!existsSync(probeMarker)) return [];
+      return readFileSync(probeMarker, "utf8").split("\n").filter((line) => line.length > 0);
     },
   };
 }
@@ -198,12 +209,12 @@ describe("workspace grep Git resolution", () => {
         // apart from a PATH override that never reached the child.
         const control = await runOneToolCall(root, "control_1", "terminal", {
           action: "exec",
-          command: "git --version",
+          command: `${PROBE} sentinel`,
         });
         expect(control).not.toContain("Not executed");
-        expect(root.plantedRuns()).toEqual(["--version"]);
-
-        rmSync(root.marker, { force: true });
+        expect(root.probeRuns()).toEqual(["sentinel"]);
+        // Planting is effective and nothing has touched the git plant yet.
+        expect(root.plantedRuns()).toEqual([]);
 
         const output = await runOneToolCall(root, "grep_1", "grep_files", {
           pattern: NEEDLE,


### PR DESCRIPTION
Fixes #395.

Workspace file discovery refuses to resolve `git` from PATH: `trustedGitExecutable` stats a fixed list of absolute paths and returns null rather than fall back. Grep did the opposite, passing a bare `"git"` as argv0 at `gitIgnoresRoot`, `gitGrepTrackedMatches`, and `gitGrepTrackedCounts`, with `cwd` set to the search root. One `grep_files` call ran a planted PATH `git` twice; the same workspace searched through discovery never touched it.

The three sites now take the executable discovery already selects, and grep skips the git backend when none is available, which is the `orelse break :git` shape `discoverWithStop` uses for its null case. Semantics are otherwise unchanged: `force_fallback` still suppresses the check-ignore spawn, and an ignored root still reaches the same fallback.

`trustedGitExecutable` becomes `pub`. `runGitForTest` in this file resolves Git the same way, which is what lets the argv guard key on the bare literal rather than on an argv shape.

### Verification

Each guard was run against the mutation it exists to catch.

| Mutation | Expected | Caught by |
|---|---|---|
| check-ignore argv0 -> bare name | RED | spawn tests + argv scan |
| `git grep -n` argv0 -> bare name | RED | collect spawn test + argv scan |
| `git grep --count` argv0 -> bare name | RED | count spawn test + argv scan |
| null guard -> `orelse "git"` | RED | refusal test |
| add a new bare-name spawn carrying no usual flags | RED | argv scan |
| both public wrappers pass null | RED | wrapper test |
| either wrapper alone passes null | RED | wrapper test |

The end-to-end test drives the built binary against a fake gateway with a `git` planted first on PATH. `grep_files` returns its match while the plant records nothing. The `terminal` control runs `git --version` through the same PATH and asserts the plant *did* record a run, so an override that never reached the child cannot read as a guard that held. Reintroducing the defect makes the grep half fail with the recorded argv.

Three of the four commits are test work because the first round of tests was not load-bearing: the spawn assertion counted runs, so adding a bare-name spawn kept it green while threading the executable to one more site turned it red, and the null-guard test passed with the guard replaced by a name.

`zig build test` on `88cb3da8`: 8403/8458 passing on base, 8409/8464 on the branch, with the same 33 failing test names and the same 7 crashes on both. The +6 accounts for the added tests. `zig fmt --check` clean.

### Scope

Two pre-existing gaps this does not close, both noted in #395: `src/core/github/git_context.zig:37` and `src/builtins/skills.zig:253` still build argv from a bare `"git"`, and `trustedGitExecutable` stats with `follow_symlinks = true` and checks only that the candidate is a file, so an allowlisted path that is user-writable or a symlink out of the allowlist is accepted. Pinning argv0 also does not stop the workspace's own `.git/config` from running a program through `core.fsmonitor`; that is unchanged by this PR, and `command_effect.zig` and `direct_command.zig` already harden their own git spawns.

The allowlist misses some real install locations (Linuxbrew, `/snap/bin`, asdf/mise shims). On those machines grep now uses the Zig scanner rather than the git backend. Results are equivalent, since the untracked pass already fell back there, but it is slower on a large repo.

The e2e test covers the collect path; the count path is covered at the module seam only. Both spawn tests skip on Windows, which the allowlist supports but CI does not run.
