### PR TITLE
Fix MCP credential, environment, and issuer handling

### DIFF
--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -163,6 +163,29 @@ fn handleCommand(alloc: Allocator, rest: []const u8, command_request: CommandReq
                 false,
             );
         }
+        if (result.repaired_entries > 0) {
+            const text = if (result.revocation_failed)
+                try std.fmt.allocPrint(
+                    alloc,
+                    "Logged out of MCP server '{s}' locally; remote revocation failed. Removed {d} unreadable MCP credential {s}.",
+                    .{
+                        name,
+                        result.repaired_entries,
+                        if (result.repaired_entries == 1) "entry" else "entries",
+                    },
+                )
+            else
+                try std.fmt.allocPrint(
+                    alloc,
+                    "Logged out of MCP server '{s}'. Removed {d} unreadable MCP credential {s}.",
+                    .{
+                        name,
+                        result.repaired_entries,
+                        if (result.repaired_entries == 1) "entry" else "entries",
+                    },
+                );
+            return .{ .display = .{ .line = text }, .reload = true };
+        }
         if (result.revocation_failed) {
             return lineParts(
                 alloc,
@@ -1790,6 +1813,7 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
         auth_calls: usize = 0,
         logout_calls: usize = 0,
         logout_busy: bool = false,
+        logout_repaired_entries: usize = 0,
 
         fn list(_: *anyopaque, alloc: Allocator) ![]u8 {
             return alloc.dupe(u8, "");
@@ -1825,7 +1849,10 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
             try std.testing.expectEqualStrings("remote", name);
             self.logout_calls += 1;
             if (self.logout_busy) return .{ .busy = true };
-            return .{ .removed = true };
+            return .{
+                .removed = true,
+                .repaired_entries = self.logout_repaired_entries,
+            };
         }
     };
     const alloc = std.testing.allocator;
@@ -1902,6 +1929,15 @@ test "MCP auth requires explicit browser confirmation and logout stays non-secre
     defer logged_out.deinit(alloc);
     try expectLine(logged_out, "Logged out of MCP server 'remote'.", true);
     try std.testing.expectEqual(@as(usize, 2), fixture.logout_calls);
+
+    fixture.logout_repaired_entries = 2;
+    var repaired = try handleCommand(alloc, "logout remote", command_request);
+    defer repaired.deinit(alloc);
+    try expectLine(
+        repaired,
+        "Logged out of MCP server 'remote'. Removed 2 unreadable MCP credential entries.",
+        true,
+    );
 }
 
 test "loadConfigFromJson parses canonical local config with command array" {

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -140,11 +140,22 @@ fn formatMcpIssuerMismatch(
     errdefer out.deinit();
     try out.writer.print("MCP authentication for '{s}' was rejected: expected issuer ", .{server_name});
     try std.json.Stringify.value(expected.bytes, .{}, &out.writer);
-    try out.writer.writeAll(" but metadata returned ");
-    try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
-    try out.writer.writeAll(". Add \"oauth\":{\"issuer\":");
-    try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
-    try out.writer.writeAll("} to this server's entry in ~/.fx/mcp.json and retry.");
+    switch (mismatch.source) {
+        .authorization_metadata => {
+            try out.writer.writeAll(" but metadata returned ");
+            try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
+            try out.writer.writeAll(". Add \"oauth\":{\"issuer\":");
+            try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
+            try out.writer.writeAll("} to this server's entry in ~/.fx/mcp.json and retry.");
+        },
+        .authorization_response => {
+            try out.writer.writeAll(" but the authorization response returned issuer ");
+            try std.json.Stringify.value(returned.bytes, .{}, &out.writer);
+            try out.writer.writeAll(
+                ". fx stopped before token exchange. Contact the MCP server provider; changing oauth.issuer is not a safe workaround.",
+            );
+        },
+    }
     return out.toOwnedSlice();
 }
 
@@ -452,12 +463,23 @@ pub fn Handlers(comptime App: type) type {
 
             if (completion.result) |authentication| {
                 switch (authentication) {
-                    .authenticated => {
-                        const success = try std.fmt.allocPrint(
-                            app.alloc,
-                            "Authenticated MCP server '{s}'.",
-                            .{completion.server_name},
-                        );
+                    .authenticated => |authenticated| {
+                        const success = if (authenticated.repaired_entries == 0)
+                            try std.fmt.allocPrint(
+                                app.alloc,
+                                "Authenticated MCP server '{s}'.",
+                                .{completion.server_name},
+                            )
+                        else
+                            try std.fmt.allocPrint(
+                                app.alloc,
+                                "Authenticated MCP server '{s}'.\nRemoved {d} unreadable MCP credential {s}.",
+                                .{
+                                    completion.server_name,
+                                    authenticated.repaired_entries,
+                                    if (authenticated.repaired_entries == 1) "entry" else "entries",
+                                },
+                            );
                         defer app.alloc.free(success);
                         app.beginMcpReload() catch |err| {
                             const body = try std.fmt.allocPrint(
@@ -1433,6 +1455,7 @@ pub fn Handlers(comptime App: type) type {
             return .{
                 .removed = result.removed,
                 .revocation_failed = result.revocation_failed,
+                .repaired_entries = result.repaired_entries,
             };
         }
 
@@ -3494,7 +3517,7 @@ const McpCommandFakeApp = struct {
         self.authentication_pending = false;
         return .{
             .server_name = try self.alloc.dupe(u8, "fixture"),
-            .result = .authenticated,
+            .result = .{ .authenticated = .{} },
         };
     }
 

--- a/src/core/mcp/command_provider.zig
+++ b/src/core/mcp/command_provider.zig
@@ -22,6 +22,7 @@ pub const LogoutResult = struct {
     busy: bool = false,
     removed: bool = false,
     revocation_failed: bool = false,
+    repaired_entries: usize = 0,
 };
 
 pub const LogoutServerFn = *const fn (

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -154,13 +154,20 @@ pub const Credentials = struct {
     }
 };
 
+pub const IssuerMismatchSource = enum {
+    authorization_metadata,
+    authorization_response,
+};
+
 pub const IssuerMismatch = struct {
     owner_alloc: Allocator,
+    source: IssuerMismatchSource,
     expected: []u8,
     returned: []u8,
 
     pub fn init(
         alloc: Allocator,
+        source: IssuerMismatchSource,
         expected: []const u8,
         returned: []const u8,
     ) !IssuerMismatch {
@@ -168,6 +175,7 @@ pub const IssuerMismatch = struct {
         errdefer alloc.free(owned_expected);
         return .{
             .owner_alloc = alloc,
+            .source = source,
             .expected = owned_expected,
             .returned = try alloc.dupe(u8, returned),
         };
@@ -186,7 +194,9 @@ pub const AuthorizationResult = union(enum) {
 };
 
 pub const AuthenticationResult = union(enum) {
-    authenticated,
+    authenticated: struct {
+        repaired_entries: usize = 0,
+    },
     issuer_mismatch: IssuerMismatch,
 
     pub fn deinit(self: *AuthenticationResult) void {
@@ -584,6 +594,7 @@ fn parseAuthorizationMetadataOutcome(
     if (!std.mem.eql(u8, issuer, expected_issuer)) {
         return .{ .issuer_mismatch = try IssuerMismatch.init(
             alloc,
+            .authorization_metadata,
             expected_issuer,
             issuer,
         ) };
@@ -1159,6 +1170,7 @@ fn authorizeWithRedirect(
         error.AuthorizationResponseIssuerMismatch => return .{
             .issuer_mismatch = try IssuerMismatch.init(
                 alloc,
+                .authorization_response,
                 metadata.issuer,
                 callback.issuer.?,
             ),
@@ -2338,6 +2350,10 @@ test "authorization metadata mismatch retains exact issuer values and fails clos
     switch (outcome) {
         .metadata => return error.TestUnexpectedResult,
         .issuer_mismatch => |mismatch| {
+            try std.testing.expectEqual(
+                IssuerMismatchSource.authorization_metadata,
+                mismatch.source,
+            );
             try std.testing.expectEqualStrings(
                 "https://login.example.com/",
                 mismatch.expected,

--- a/src/core/mcp/mcp_auth_store.zig
+++ b/src/core/mcp/mcp_auth_store.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const mcp_auth = @import("mcp_auth.zig");
 const native_keychain = @import("../hosts/native_keychain.zig");
 const io_mod = @import("../shared/io.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
 const profile_paths = @import("../shared/profile_paths.zig");
 const secret = @import("../auth/secret.zig");
 
@@ -122,8 +123,13 @@ pub const Status = enum {
     authenticated,
 };
 
+pub const SaveResult = struct {
+    repaired_entries: usize = 0,
+};
+
 pub const DeleteResult = struct {
     removed: usize = 0,
+    repaired_entries: usize = 0,
     durable: bool = true,
 };
 
@@ -140,6 +146,7 @@ const StoredCredential = struct {
 
 const Store = struct {
     credentials: std.ArrayList(StoredCredential) = .empty,
+    rejected_entries: usize = 0,
 
     fn deinit(self: *Store, alloc: Allocator) void {
         for (self.credentials.items) |*entry| entry.deinit(alloc);
@@ -266,7 +273,7 @@ pub fn save(
     alloc: Allocator,
     server_identity: []const u8,
     credentials: mcp_auth.Credentials,
-) !void {
+) !SaveResult {
     const backend = storageBackend();
     var locked = try openOrCreateLockedDir();
     defer locked.deinit();
@@ -286,11 +293,12 @@ pub fn save(
         entry.* = replacement;
         transferred = true;
         try writeStore(alloc, &locked.dir, store, backend, native_keychain_backend);
-        return;
+        return .{ .repaired_entries = store.rejected_entries };
     }
     try store.credentials.append(alloc, replacement);
     transferred = true;
     try writeStore(alloc, &locked.dir, store, backend, native_keychain_backend);
+    return .{ .repaired_entries = store.rejected_entries };
 }
 
 pub fn delete(
@@ -320,13 +328,16 @@ pub fn delete(
         deleted.deinit(alloc);
         removed += 1;
     }
-    if (removed == 0) return .{};
+    if (removed == 0 and store.rejected_entries == 0) return .{};
     if (store.credentials.items.len == 0) {
         try clearStore(alloc, &locked.dir, backend, native_keychain_backend);
     } else {
         try writeStore(alloc, &locked.dir, store, backend, native_keychain_backend);
     }
-    return .{ .removed = removed };
+    return .{
+        .removed = removed,
+        .repaired_entries = store.rejected_entries,
+    };
 }
 
 fn sameIdentity(
@@ -498,6 +509,13 @@ fn loadStoreControlled(
                 keychain,
                 cancel_flag,
             );
+            if (store.rejected_entries > 0) {
+                debug_trace.logf(
+                    "mcp",
+                    "removed unreadable MCP credential entries actor=migration count={d}",
+                    .{store.rejected_entries},
+                );
+            }
             try checkCancellation(cancel_flag);
             try deleteCredentialFile(dir);
             return store;
@@ -557,18 +575,40 @@ fn parseStore(alloc: Allocator, bytes: []const u8) !Store {
     var store: Store = .{};
     errdefer store.deinit(alloc);
     for (values.array.items) |value| {
-        if (value != .object) return error.InvalidMcpCredentialStore;
+        if (value != .object) {
+            store.rejected_entries += 1;
+            continue;
+        }
         const object = value.object;
-        const server_identity = try dupeRequiredString(alloc, object, "server_identity");
-        errdefer alloc.free(server_identity);
-        var credentials = try parseCredentials(alloc, object);
-        var credentials_transferred = false;
-        errdefer if (!credentials_transferred) credentials.deinit(alloc);
-        try store.credentials.append(alloc, .{
+        const server_identity = dupeRequiredString(
+            alloc,
+            object,
+            "server_identity",
+        ) catch |err| switch (err) {
+            error.InvalidMcpCredentialStore => {
+                store.rejected_entries += 1;
+                continue;
+            },
+            else => |other| return other,
+        };
+        var credentials = parseCredentials(alloc, object) catch |err| {
+            alloc.free(server_identity);
+            switch (err) {
+                error.InvalidMcpCredentialStore => {
+                    store.rejected_entries += 1;
+                    continue;
+                },
+                else => |other| return other,
+            }
+        };
+        store.credentials.append(alloc, .{
             .server_identity = server_identity,
             .credentials = credentials,
-        });
-        credentials_transferred = true;
+        }) catch |err| {
+            alloc.free(server_identity);
+            credentials.deinit(alloc);
+            return err;
+        };
     }
     return store;
 }
@@ -591,7 +631,7 @@ fn parseCredentials(
     errdefer secret.zeroAndFree(alloc, access_token);
     const refresh_token = try dupeOptionalString(alloc, object, "refresh_token");
     errdefer if (refresh_token) |value| secret.zeroAndFree(alloc, value);
-    const scope = try dupeRequiredString(alloc, object, "scope");
+    const scope = try dupeStringAllowEmpty(alloc, object, "scope");
     errdefer alloc.free(scope);
     const token_type = try dupeRequiredString(alloc, object, "token_type");
     errdefer alloc.free(token_type);
@@ -803,6 +843,16 @@ fn dupeRequiredString(
     return alloc.dupe(u8, value.string);
 }
 
+fn dupeStringAllowEmpty(
+    alloc: Allocator,
+    object: std.json.ObjectMap,
+    key: []const u8,
+) ![]u8 {
+    const value = object.get(key) orelse return error.InvalidMcpCredentialStore;
+    if (value != .string) return error.InvalidMcpCredentialStore;
+    return alloc.dupe(u8, value.string);
+}
+
 fn dupeOptionalString(
     alloc: Allocator,
     object: std.json.ObjectMap,
@@ -837,10 +887,98 @@ test "credential store parser keeps distinct server and OAuth identities" {
     );
 }
 
-test "credential store rejects missing identity fields" {
+test "credential store round-trip accepts empty OAuth scope" {
+    const alloc = std.testing.allocator;
+    var credentials = try testCredentials(
+        alloc,
+        "https://mcp.example/no-scope",
+        "empty-scope-secret",
+    );
+    alloc.free(credentials.scope);
+    credentials.scope = try alloc.dupe(u8, "");
+
+    const server_identity = try alloc.dupe(u8, "no-scope");
+    var transferred = false;
+    defer if (!transferred) {
+        alloc.free(server_identity);
+        credentials.deinit(alloc);
+    };
+
+    var source: Store = .{};
+    defer source.deinit(alloc);
+    try source.credentials.append(alloc, .{
+        .server_identity = server_identity,
+        .credentials = credentials,
+    });
+    transferred = true;
+
+    const bytes = try serializeStore(alloc, source);
+    defer secret.zeroAndFree(alloc, bytes);
+    var decoded = try parseStore(alloc, bytes);
+    defer decoded.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), decoded.credentials.items.len);
+    try std.testing.expectEqualStrings(
+        "",
+        decoded.credentials.items[0].credentials.scope,
+    );
+}
+
+test "credential store isolates malformed entries from valid credentials" {
+    const json =
+        \\{"version":1,"credentials":[
+        \\{},
+        \\{"server_identity":"valid","endpoint":"https://mcp.example/a","resource":"https://mcp.example/","issuer":"https://issuer.example","client_id":"client","client_secret":null,"access_token":"secret","refresh_token":null,"scope":"read","token_type":"Bearer","token_endpoint_auth_method":"none","expires_at_ms":456,"authorization_endpoint":"https://issuer.example/authorize","token_endpoint":"https://issuer.example/token","revocation_endpoint":null}
+        \\]}
+    ;
+    var store = try parseStore(std.testing.allocator, json);
+    defer store.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), store.credentials.items.len);
+    try std.testing.expectEqual(@as(usize, 1), store.rejected_entries);
+    try std.testing.expectEqualStrings(
+        "valid",
+        store.credentials.items[0].server_identity,
+    );
+}
+
+test "credential store skips an entry with missing identity fields" {
+    var store = try parseStore(
+        std.testing.allocator,
+        "{\"version\":1,\"credentials\":[{}]}",
+    );
+    defer store.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), store.credentials.items.len);
+    try std.testing.expectEqual(@as(usize, 1), store.rejected_entries);
+}
+
+test "credential store keeps top-level schema version strict" {
     try std.testing.expectError(
         error.InvalidMcpCredentialStore,
-        parseStore(std.testing.allocator, "{\"version\":1,\"credentials\":[{}]}"),
+        parseStore(
+            std.testing.allocator,
+            "{\"version\":2,\"credentials\":[]}",
+        ),
+    );
+}
+
+fn checkCredentialStoreIsolationAllocationFailures(alloc: Allocator) !void {
+    const json =
+        \\{"version":1,"credentials":[
+        \\{},
+        \\{"server_identity":"valid","endpoint":"https://mcp.example/a","resource":"https://mcp.example/","issuer":"https://issuer.example","client_id":"client","client_secret":null,"access_token":"secret","refresh_token":null,"scope":"","token_type":"Bearer","token_endpoint_auth_method":"none","expires_at_ms":456,"authorization_endpoint":"https://issuer.example/authorize","token_endpoint":"https://issuer.example/token","revocation_endpoint":null}
+        \\]}
+    ;
+    var store = try parseStore(alloc, json);
+    defer store.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), store.credentials.items.len);
+    try std.testing.expectEqual(@as(usize, 1), store.rejected_entries);
+}
+
+test "credential store isolation cleans up every allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        checkCredentialStoreIsolationAllocationFailures,
+        .{},
     );
 }
 
@@ -1059,7 +1197,7 @@ test "Keychain migration publishes before deleting portable credentials" {
         "migration-secret",
     );
     defer credentials.deinit(alloc);
-    try save(alloc, "server-one", credentials);
+    _ = try save(alloc, "server-one", credentials);
 
     var fake = FakeKeychain{ .alloc = alloc };
     defer fake.deinit();
@@ -1112,7 +1250,7 @@ test "Keychain migration publishes before deleting portable credentials" {
         try std.testing.expect(fake.value == null);
     }
 
-    try save(alloc, "server-one", credentials);
+    _ = try save(alloc, "server-one", credentials);
     fake.fail_store = true;
     {
         var locked = (try openExistingLockedDir()).?;
@@ -1155,6 +1293,62 @@ test "Keychain migration publishes before deleting portable credentials" {
     }
 }
 
+test "Keychain migration sanitizes rejected entries after verified publication" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home");
+    const home = try tmp.dir.realPathFileAlloc(std.testing.io, "home", alloc);
+    defer alloc.free(home);
+    var test_home = try TestHome.init(home);
+    defer test_home.deinit();
+    test_home.activate();
+
+    const json =
+        \\{"version":1,"credentials":[
+        \\{},
+        \\{"server_identity":"valid","endpoint":"https://mcp.example/a","resource":"https://mcp.example/","issuer":"https://issuer.example","client_id":"client","client_secret":null,"access_token":"secret","refresh_token":null,"scope":"","token_type":"Bearer","token_endpoint_auth_method":"none","expires_at_ms":456,"authorization_endpoint":"https://issuer.example/authorize","token_endpoint":"https://issuer.example/token","revocation_endpoint":null}
+        \\]}
+    ;
+    {
+        var locked = try openOrCreateLockedDir();
+        defer locked.deinit();
+        try io_mod.durableReplaceVerified(
+            alloc,
+            &locked.dir,
+            profile_paths.mcp_credentials_file_name,
+            json,
+        );
+    }
+
+    var fake = FakeKeychain{ .alloc = alloc };
+    defer fake.deinit();
+    var locked = (try openExistingLockedDir()).?;
+    defer locked.deinit();
+    var migrated = try loadStore(
+        alloc,
+        &locked.dir,
+        .macos_keychain,
+        fake.backend(),
+    );
+    defer migrated.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), migrated.rejected_entries);
+    try std.testing.expectEqual(@as(usize, 1), fake.store_calls);
+    try std.testing.expectError(
+        error.FileNotFound,
+        locked.dir.dir.statFile(
+            std.testing.io,
+            profile_paths.mcp_credentials_file_name,
+            .{},
+        ),
+    );
+
+    var published = try parseStore(alloc, fake.value.?);
+    defer published.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), published.credentials.items.len);
+    try std.testing.expectEqual(@as(usize, 0), published.rejected_entries);
+}
+
 test "credential store is private atomic and supports restart deletion" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
@@ -1172,7 +1366,7 @@ test "credential store is private atomic and supports restart deletion" {
         "access-secret",
     );
     defer credentials.deinit(alloc);
-    try save(alloc, "server-one", credentials);
+    _ = try save(alloc, "server-one", credentials);
 
     var loaded = (try load(
         alloc,
@@ -1225,6 +1419,96 @@ test "credential store is private atomic and supports restart deletion" {
         null,
         null,
     )) == null);
+}
+
+test "credential delete sanitizes a store containing only rejected entries" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home");
+    const home = try tmp.dir.realPathFileAlloc(std.testing.io, "home", alloc);
+    defer alloc.free(home);
+    var test_home = try TestHome.init(home);
+    defer test_home.deinit();
+    test_home.activate();
+
+    {
+        var locked = try openOrCreateLockedDir();
+        defer locked.deinit();
+        try io_mod.durableReplaceVerified(
+            alloc,
+            &locked.dir,
+            profile_paths.mcp_credentials_file_name,
+            "{\"version\":1,\"credentials\":[{}]}",
+        );
+    }
+
+    const result = try delete(
+        alloc,
+        "fixture",
+        "https://mcp.example/service",
+    );
+    try std.testing.expectEqual(@as(usize, 0), result.removed);
+    try std.testing.expectEqual(@as(usize, 1), result.repaired_entries);
+
+    var locked = (try openExistingLockedDir()).?;
+    defer locked.deinit();
+    try std.testing.expectError(
+        error.FileNotFound,
+        locked.dir.dir.statFile(
+            std.testing.io,
+            profile_paths.mcp_credentials_file_name,
+            .{},
+        ),
+    );
+}
+
+test "credential save sanitizes rejected entries and reports the repair count" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home");
+    const home = try tmp.dir.realPathFileAlloc(std.testing.io, "home", alloc);
+    defer alloc.free(home);
+    var test_home = try TestHome.init(home);
+    defer test_home.deinit();
+    test_home.activate();
+
+    {
+        var locked = try openOrCreateLockedDir();
+        defer locked.deinit();
+        try io_mod.durableReplaceVerified(
+            alloc,
+            &locked.dir,
+            profile_paths.mcp_credentials_file_name,
+            "{\"version\":1,\"credentials\":[{}]}",
+        );
+    }
+
+    var credentials = try testCredentials(
+        alloc,
+        "https://mcp.example/service",
+        "replacement-secret",
+    );
+    defer credentials.deinit(alloc);
+    const result = try save(alloc, "fixture", credentials);
+    try std.testing.expectEqual(@as(usize, 1), result.repaired_entries);
+
+    var locked = (try openExistingLockedDir()).?;
+    defer locked.deinit();
+    var store = try loadStore(
+        alloc,
+        &locked.dir,
+        .profile_file,
+        native_keychain_backend,
+    );
+    defer store.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), store.credentials.items.len);
+    try std.testing.expectEqual(@as(usize, 0), store.rejected_entries);
+    try std.testing.expectEqualStrings(
+        "replacement-secret",
+        store.credentials.items[0].credentials.access_token,
+    );
 }
 
 test "credential load cancellation interrupts a held advisory lock" {
@@ -1328,7 +1612,7 @@ test "credential cancellation interrupts Keychain read and preserves migration s
         "migration-secret",
     );
     defer credentials.deinit(alloc);
-    try save(alloc, "fixture", credentials);
+    _ = try save(alloc, "fixture", credentials);
     {
         var locked = (try openExistingLockedDir()).?;
         defer locked.deinit();
@@ -1376,13 +1660,13 @@ test "credential load refuses an ambiguous discovered issuer identity" {
         "access-one",
     );
     defer first.deinit(alloc);
-    try save(alloc, "server-one", first);
+    _ = try save(alloc, "server-one", first);
 
     var migrated = try first.clone(alloc);
     defer migrated.deinit(alloc);
     alloc.free(migrated.issuer);
     migrated.issuer = try alloc.dupe(u8, "https://issuer-two.example");
-    try save(alloc, "server-one", migrated);
+    _ = try save(alloc, "server-one", migrated);
 
     try std.testing.expect((try load(
         alloc,
@@ -1431,8 +1715,9 @@ test "credential store serializes concurrent writers without dropping identities
                 return;
             };
             defer credentials.deinit(thread_alloc);
-            save(thread_alloc, self.server, credentials) catch |err| {
+            _ = save(thread_alloc, self.server, credentials) catch |err| {
                 self.failure = err;
+                return;
             };
         }
     };

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -5309,6 +5309,7 @@ pub const McpRuntime = struct {
             .issuer_mismatch => |mismatch| return .{ .issuer_mismatch = mismatch },
         };
         var transferred = false;
+        var repaired_entries: usize = 0;
         defer if (!transferred) credentials.deinit(self.alloc);
         {
             server.auth_lock.lockUncancelable(io_mod.getIo());
@@ -5318,7 +5319,12 @@ pub const McpRuntime = struct {
                 source.generation,
                 cancellation,
             );
-            try mcp_auth_store.save(self.alloc, server.config.name, credentials);
+            const save_result = try mcp_auth_store.save(
+                self.alloc,
+                server.config.name,
+                credentials,
+            );
+            repaired_entries = save_result.repaired_entries;
             installAuthCredentials(self.alloc, server, &credentials);
             transferred = true;
             if (server.pending_auth_challenge) |*pending| pending.deinit(self.alloc);
@@ -5340,7 +5346,9 @@ pub const McpRuntime = struct {
         server.connection_lock.unlockShared(io_mod.getIo());
         connection_locked = false;
         try resumeToolSubscriptionAfterAuthentication(self, server, deadline);
-        return .authenticated;
+        return .{ .authenticated = .{
+            .repaired_entries = repaired_entries,
+        } };
     }
 
     pub fn validateAuthenticationServer(self: *McpRuntime, name: []const u8) !void {
@@ -5370,6 +5378,7 @@ pub const McpRuntime = struct {
     pub const LogoutResult = struct {
         removed: bool = false,
         revocation_failed: bool = false,
+        repaired_entries: usize = 0,
     };
 
     const DetachedLogoutAuth = struct {
@@ -5461,7 +5470,10 @@ pub const McpRuntime = struct {
             self.restoreAuthAfterLogout(server, &auth);
             return err;
         };
-        if (deleted.removed == 0 and auth.credentials == null) {
+        if (deleted.removed == 0 and
+            deleted.repaired_entries == 0 and
+            auth.credentials == null)
+        {
             self.restoreAuthAfterLogout(server, &auth);
             return .{};
         }
@@ -5501,6 +5513,7 @@ pub const McpRuntime = struct {
         return .{
             .removed = true,
             .revocation_failed = revocation_failed,
+            .repaired_entries = deleted.repaired_entries,
         };
     }
 
@@ -9793,8 +9806,12 @@ fn connectServer(
         existing.deinit();
         server.env_map = null;
     }
+    defer {
+        if (server.env_map) |*environment| environment.deinit();
+        server.env_map = null;
+    }
     if (server.config.env.len > 0) {
-        server.env_map = EnvMap.init(alloc);
+        server.env_map = try io_mod.cloneEnvironMap(alloc);
         for (server.config.env) |entry| {
             try server.env_map.?.put(entry.key, entry.value);
         }
@@ -11930,7 +11947,16 @@ fn refreshSharedCredentials(
     {
         return false;
     }
-    try mcp_auth_store.save(alloc, server.config.name, refreshed);
+    const save_result = try mcp_auth_store.save(
+        alloc,
+        server.config.name,
+        refreshed,
+    );
+    traceCredentialStoreRepair(
+        "refresh",
+        server.config.name,
+        save_result.repaired_entries,
+    );
     installAuthCredentials(alloc, server, &refreshed);
     transferred = true;
     return true;
@@ -12023,8 +12049,12 @@ fn authorizeForChallenge(
         .credentials => |credentials| credentials,
         .issuer_mismatch => |owned_mismatch| {
             var mismatch = owned_mismatch;
+            const err = switch (mismatch.source) {
+                .authorization_metadata => error.AuthorizationMetadataIssuerMismatch,
+                .authorization_response => error.AuthorizationResponseIssuerMismatch,
+            };
             mismatch.deinit();
-            return error.AuthorizationMetadataIssuerMismatch;
+            return err;
         },
     };
     var credentials_transferred = false;
@@ -12037,9 +12067,31 @@ fn authorizeForChallenge(
         credentials.deinit(alloc);
         return;
     }
-    try mcp_auth_store.save(alloc, server.config.name, credentials);
+    const save_result = try mcp_auth_store.save(
+        alloc,
+        server.config.name,
+        credentials,
+    );
+    traceCredentialStoreRepair(
+        "automated_auth",
+        server.config.name,
+        save_result.repaired_entries,
+    );
     installAuthCredentials(alloc, server, &credentials);
     credentials_transferred = true;
+}
+
+fn traceCredentialStoreRepair(
+    actor: []const u8,
+    server_name: []const u8,
+    repaired_entries: usize,
+) void {
+    if (repaired_entries == 0) return;
+    debug_trace.logf(
+        "mcp",
+        "removed unreadable MCP credential entries actor={s} server={s} count={d}",
+        .{ actor, server_name, repaired_entries },
+    );
 }
 
 fn installAuthCredentials(

--- a/src/core/shared/io.zig
+++ b/src/core/shared/io.zig
@@ -397,6 +397,29 @@ pub fn environMap() ?*const std.process.Environ.Map {
     return global_environ;
 }
 
+pub const CloneEnvironMapError = std.mem.Allocator.Error ||
+    std.process.Environ.CreateMapError ||
+    error{EnvironmentUnavailable};
+
+pub fn cloneEnvironMap(
+    alloc: std.mem.Allocator,
+) CloneEnvironMapError!std.process.Environ.Map {
+    if (global_environ) |map| return map.clone(alloc);
+    if (global_environ_block) |block| {
+        return std.process.Environ.createMap(.{ .block = block }, alloc);
+    }
+    if (global_raw_environ) |raw| {
+        var len: usize = 0;
+        while (raw[len] != null) : (len += 1) {}
+        const entries: []const [*:0]const u8 = @ptrCast(raw[0..len]);
+        var map = std.process.Environ.Map.init(alloc);
+        errdefer map.deinit();
+        try map.putPosixBlock(.{ .slice = entries });
+        return map;
+    }
+    return error.EnvironmentUnavailable;
+}
+
 fn getenvFromBlock(block: std.process.Environ.Block, key: []const u8) ?[]const u8 {
     if (comptime builtin.os.tag == .windows or builtin.os.tag == .freestanding or builtin.os.tag == .other) {
         return null;
@@ -997,6 +1020,71 @@ test "environMap returns borrowed process environment map" {
     const borrowed = environMap().?;
     try std.testing.expectEqualStrings("present", borrowed.get("FX_CORE2_IO_TEST").?);
     global_environ = null;
+}
+
+test "cloneEnvironMap owns an independent copy of map environment state" {
+    const previous_map = global_environ;
+    const previous_block = global_environ_block;
+    const previous_raw = global_raw_environ;
+    defer {
+        global_environ = previous_map;
+        global_environ_block = previous_block;
+        global_raw_environ = previous_raw;
+    }
+
+    var source = std.process.Environ.Map.init(std.testing.allocator);
+    defer source.deinit();
+    try source.put("PATH", "/map/bin");
+    setEnvironMap(&source);
+
+    var cloned = try cloneEnvironMap(std.testing.allocator);
+    defer cloned.deinit();
+    try source.put("PATH", "/changed");
+    try std.testing.expectEqualStrings("/map/bin", cloned.get("PATH").?);
+}
+
+test "cloneEnvironMap copies installed block environment state" {
+    const previous_map = global_environ;
+    const previous_block = global_environ_block;
+    const previous_raw = global_raw_environ;
+    defer {
+        global_environ = previous_map;
+        global_environ_block = previous_block;
+        global_raw_environ = previous_raw;
+    }
+
+    var source = std.process.Environ.Map.init(std.testing.allocator);
+    defer source.deinit();
+    try source.put("HOME", "/block/home");
+    const block = try source.createPosixBlock(std.testing.allocator, .{});
+    defer block.deinit(std.testing.allocator);
+    setEnvironBlock(block);
+
+    var cloned = try cloneEnvironMap(std.testing.allocator);
+    defer cloned.deinit();
+    try std.testing.expectEqualStrings("/block/home", cloned.get("HOME").?);
+}
+
+test "cloneEnvironMap copies installed raw environment state" {
+    const previous_map = global_environ;
+    const previous_block = global_environ_block;
+    const previous_raw = global_raw_environ;
+    defer {
+        global_environ = previous_map;
+        global_environ_block = previous_block;
+        global_raw_environ = previous_raw;
+    }
+
+    const raw_entries = [_:null]?[*:0]const u8{
+        "PATH=/raw/bin",
+        "HOME=/raw/home",
+    };
+    setRawEnviron(@ptrCast(&raw_entries));
+
+    var cloned = try cloneEnvironMap(std.testing.allocator);
+    defer cloned.deinit();
+    try std.testing.expectEqualStrings("/raw/bin", cloned.get("PATH").?);
+    try std.testing.expectEqualStrings("/raw/home", cloned.get("HOME").?);
 }
 
 test "readFileToEnd: file under cap returns full content" {

--- a/tests/e2e/fixtures/mcp-modern-stdio.mjs
+++ b/tests/e2e/fixtures/mcp-modern-stdio.mjs
@@ -14,6 +14,7 @@ const recoveryReleasePath = process.env.FX_MCP_RECOVERY_RELEASE_PATH;
 const initialToolName = process.env.FX_MCP_INITIAL_TOOL_NAME ?? "echo";
 const recoveredToolName = process.env.FX_MCP_RECOVERED_TOOL_NAME ?? initialToolName;
 const expectedElicitation = process.env.FX_MCP_EXPECT_ELICITATION ?? "none";
+const environmentCapturePath = process.env.FX_MCP_ENV_CAPTURE;
 const resourcesSubscribe = process.env.FX_MCP_RESOURCES_SUBSCRIBE !== "0";
 const resourceTtlMs = process.env.FX_MCP_RESOURCE_TTL_MS === undefined
   ? null
@@ -35,6 +36,15 @@ const stalledRequestIds = new Set();
 let buffer = Buffer.alloc(0);
 
 if (pidPath) writeFileSync(pidPath, String(process.pid));
+if (environmentCapturePath) {
+  writeFileSync(environmentCapturePath, JSON.stringify({
+    configured: process.env.FX_MCP_ENV_SENTINEL,
+    inherited: process.env.FX_MCP_INHERITED_SENTINEL,
+    path: process.env.PATH,
+    home: process.env.HOME,
+    httpsProxy: process.env.HTTPS_PROXY,
+  }));
+}
 if (stallRecovery) setInterval(() => {}, 1000);
 
 function send(message) {

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -178,6 +178,8 @@ function startAuthFixture(
     failFeatureRefreshAfterRotation?: boolean;
     rejectResourceTemplateAuth?: boolean;
     authorizationServerTrailingSlash?: boolean;
+    authorizationResponseIssuer?: string;
+    omitScopes?: boolean;
   } = {},
 ) {
   const transport = options.transport ?? "http";
@@ -230,8 +232,9 @@ function startAuthFixture(
           return new Response("", {
             status: 401,
             headers: {
-              "www-authenticate":
-                `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource${resourcePath}", scope="tools.read"`,
+              "www-authenticate": options.omitScopes
+                ? `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource${resourcePath}"`
+                : `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource${resourcePath}", scope="tools.read"`,
             },
           });
         }
@@ -375,7 +378,9 @@ function startAuthFixture(
           authorization_servers: [
             options.authorizationServerTrailingSlash ? `${origin}/` : origin,
           ],
-          scopes_supported: ["tools.read", "tools.call", "offline_access"],
+          ...(options.omitScopes
+            ? {}
+            : { scopes_supported: ["tools.read", "tools.call", "offline_access"] }),
         });
       }
       if (url.pathname === "/.well-known/oauth-authorization-server") {
@@ -384,7 +389,9 @@ function startAuthFixture(
           authorization_endpoint: `${origin}/authorize`,
           token_endpoint: `${origin}/token`,
           revocation_endpoint: `${origin}/revoke`,
-          scopes_supported: ["tools.read", "tools.call", "offline_access"],
+          ...(options.omitScopes
+            ? {}
+            : { scopes_supported: ["tools.read", "tools.call", "offline_access"] }),
           grant_types_supported: ["authorization_code", "refresh_token"],
           token_endpoint_auth_methods_supported: ["none"],
           code_challenge_methods_supported: ["S256"],
@@ -411,7 +418,10 @@ function startAuthFixture(
           "state",
           options.wrongState ? "wrong-state" : url.searchParams.get("state")!,
         );
-        redirect.searchParams.set("iss", origin);
+        redirect.searchParams.set(
+          "iss",
+          options.authorizationResponseIssuer ?? origin,
+        );
         return Response.redirect(redirect, 302);
       }
       if (url.pathname === "/token") {
@@ -473,7 +483,7 @@ function startAuthFixture(
             ? REFRESH_ROTATED
             : REFRESH_INITIAL,
           token_type: "Bearer",
-          scope: expectedScope,
+          ...(options.omitScopes ? {} : { scope: expectedScope }),
           expires_in: 3600,
         });
       }
@@ -774,6 +784,90 @@ async function preserveAuthTuiFailure(
 }
 
 describe("MCP remote authentication lifecycle", () => {
+  test.skipIf(!tmuxAvailable())(
+    "no-scope OAuth credentials survive reload and preserve an unrelated server",
+    async () => {
+      upstream = startModernMcpHttpFixture("json");
+      const canary = startModernMcpHttpFixture("json");
+      auth = startAuthFixture(upstream.url, { omitScopes: true });
+      const root = createRoot(auth);
+      const profilePath = join(root.home, ".fx", "mcp.json");
+      const profile = JSON.parse(readFileSync(profilePath, "utf8"));
+      delete profile.mcp.fixture.oauth.scopes;
+      profile.mcp.canary = {
+        type: "http",
+        url: canary.url,
+        startup_timeout_ms: 5_000,
+        operation_timeout_ms: 5_000,
+      };
+      writeFileSync(profilePath, JSON.stringify(profile));
+      const credentialDir = join(root.home, ".fx", "mcp-credentials");
+      mkdirSync(credentialDir, { recursive: true, mode: 0o700 });
+      const credentialPath = join(credentialDir, "credentials.json");
+      writeFileSync(
+        credentialPath,
+        JSON.stringify({ version: 1, credentials: [{}] }),
+        { mode: 0o600 },
+      );
+      chmodSync(credentialPath, 0o600);
+      gateway = startFakeGateway([], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+
+      try {
+        const env = {
+          ...baseEnv(root),
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+        };
+        tui = await TmuxSession.create({
+          isolated: true,
+          cwd: root.workspace,
+          env,
+          width: 150,
+          height: 38,
+        });
+        await tui.waitForComposer(15_000);
+
+        await tui.sendText("/mcp auth fixture --open");
+        const authenticated = await tui.waitForText(
+          "Authenticated MCP server 'fixture'.",
+          15_000,
+        );
+        expect(authenticated).toContain(
+          "Removed 1 unreadable MCP credential entry.",
+        );
+        await tui.waitForText("MCP configuration reloaded", 15_000);
+        await tui.sendText("/mcp list");
+        let pane = await tui.waitForText("MCP health (2 servers):", 10_000);
+        expect(pane).toMatch(/fixture[\s\S]{0,240}state=ready/);
+        expect(pane).toMatch(/canary[\s\S]{0,240}state=ready/);
+
+        const stored = JSON.parse(readFileSync(credentialPath, "utf8"));
+        expect(stored.credentials).toHaveLength(1);
+        expect(stored.credentials[0].scope).toBe("");
+
+        await tui.kill();
+        tui = null;
+        tui = await TmuxSession.create({
+          isolated: true,
+          cwd: root.workspace,
+          env,
+          width: 150,
+          height: 38,
+        });
+        await tui.waitForComposer(15_000);
+        await tui.sendText("/mcp list");
+        pane = await tui.waitForText("MCP health (2 servers):", 10_000);
+        expect(pane).toMatch(/fixture[\s\S]{0,240}state=ready/);
+        expect(pane).toMatch(/canary[\s\S]{0,240}state=ready/);
+      } finally {
+        canary.stop();
+      }
+    },
+    45_000,
+  );
+
   test("required resource template authentication failure propagates before read", async () => {
     upstream = startModernMcpHttpFixture("features");
     auth = startAuthFixture(upstream.url, {
@@ -1960,6 +2054,47 @@ describe("MCP remote authentication lifecycle", () => {
       expect(auth.tokenExchanges).toBe(1);
     },
     45_000,
+  );
+
+  test.skipIf(!tmuxAvailable())(
+    "authorization response issuer mismatch names the response and preserves the trust boundary",
+    async () => {
+      upstream = startModernMcpHttpFixture("json");
+      const returnedIssuer = "https://authorization-response.example.test";
+      auth = startAuthFixture(upstream.url, {
+        authorizationResponseIssuer: returnedIssuer,
+      });
+      const root = createRoot(auth);
+      gateway = startFakeGateway([], {
+        models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+      });
+      tui = await TmuxSession.create({
+        isolated: true,
+        cwd: root.workspace,
+        env: {
+          ...baseEnv(root),
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+        },
+        width: 140,
+        height: 36,
+      });
+      await tui.waitForComposer(15_000);
+
+      await tui.sendText("/mcp auth fixture --open");
+      const mismatch = await tui.waitForText("was rejected", 15_000);
+      const compactMismatch = mismatch.replace(/\s+/g, " ");
+      expect(compactMismatch).toContain("authorization response returned issuer");
+      expect(compactMismatch).toContain("authorization-response.example.test");
+      expect(compactMismatch).toContain("stopped before token exchange");
+      expect(compactMismatch).toContain("Contact the MCP server provider");
+      expect(compactMismatch).not.toContain('Add "oauth":{"issuer":');
+      expect(auth.authorizationRequests).toBe(1);
+      expect(auth.tokenExchanges).toBe(0);
+      expect(existsSync(join(root.home, ".fx", "mcp-credentials", "credentials.json")))
+        .toBe(false);
+    },
+    30_000,
   );
 
   test.skipIf(!tmuxAvailable())(

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -47,6 +47,7 @@ type FixtureRoot = {
   launchLogPath: string;
   traceLogPath: string;
   invalidationReleasePath: string;
+  environmentCapturePath: string;
 };
 
 type WireEntry = {
@@ -125,6 +126,7 @@ type RootOptions = {
   required?: boolean;
   resourcesSubscribe?: boolean;
   resourceTtlMs?: number;
+  captureEnvironment?: boolean;
 };
 
 function createRoot(
@@ -139,6 +141,7 @@ function createRoot(
   const wireLogPath = join(root, "mcp-wire.jsonl");
   const launchLogPath = join(root, "mcp-launches.txt");
   const invalidationReleasePath = join(root, "mcp-invalidation-release");
+  const environmentCapturePath = join(root, "mcp-environment.json");
   const command = options.recordLaunchAttempts
     ? [
       "/bin/sh",
@@ -195,6 +198,12 @@ function createRoot(
               options.legacyRejectNewerInitialize ? "1" : undefined,
             FX_MCP_DRAFT7_PATTERN: options.draft7Pattern,
             FX_MCP_URL_REQUIRED_OPERATION: options.urlRequiredOperation,
+            FX_MCP_ENV_CAPTURE: options.captureEnvironment
+              ? environmentCapturePath
+              : undefined,
+            FX_MCP_ENV_SENTINEL: options.captureEnvironment
+              ? "configured"
+              : undefined,
           },
           startup_timeout_ms: options.startupTimeoutMs,
           operation_timeout_ms: options.operationTimeoutMs,
@@ -211,6 +220,7 @@ function createRoot(
     launchLogPath,
     traceLogPath: join(root, "fx-trace.log"),
     invalidationReleasePath,
+    environmentCapturePath,
   };
 }
 
@@ -1891,6 +1901,49 @@ describe("modern MCP stdio compatibility", () => {
       await expectFixtureProcessesExited(wire);
     });
   }
+
+  test("configured MCP stdio environment overlays inherited process values", async () => {
+    const root = createRoot("ask-environment-overlay", MODERN_FIXTURE, {
+      captureEnvironment: true,
+    });
+    const activeGateway = startToolGateway("Environment overlay complete.");
+    gateway = activeGateway;
+    const inheritedSentinel = "inherited-parent-value";
+    const proxySentinel = "http://proxy.example.test:8080";
+    const parentPath = process.env.PATH ?? "/usr/bin:/bin";
+
+    const result = await runFx(
+      ["ask", "--json", "--auto", "--no-save", "Call the environment MCP fixture."],
+      {
+        cwd: root.workspace,
+        env: {
+          ...fixtureEnv(root, activeGateway),
+          PATH: parentPath,
+          FX_MCP_INHERITED_SENTINEL: inheritedSentinel,
+          HTTPS_PROXY: proxySentinel,
+        },
+        timeoutMs: 20_000,
+      },
+    );
+
+    expect(result.code, result.stderr || result.stdout).toBe(0);
+    expect(JSON.parse(result.stdout).output).toContain("Environment overlay complete.");
+    const captured = JSON.parse(readFileSync(root.environmentCapturePath, "utf8")) as {
+      configured?: string;
+      inherited?: string;
+      path?: string;
+      home?: string;
+      httpsProxy?: string;
+    };
+    expect(captured).toEqual({
+      configured: "configured",
+      inherited: inheritedSentinel,
+      path: parentPath,
+      home: root.home,
+      httpsProxy: proxySentinel,
+    });
+    await expectFixtureProcessesExited(readWire(root.wireLogPath));
+  }, 30_000);
 
   test("fx ask does not start an unused optional MCP server", async () => {
     const root = createRoot("ask-unused-optional", MODERN_FIXTURE, {


### PR DESCRIPTION
## Summary

- Accept OAuth credentials when the authorization server advertises no scopes and keep them readable after restart.
- Isolate malformed credential entries and remove them on the next successful store rewrite without affecting valid servers.
- Report credential repair counts during interactive auth and logout, with secret-free traces for background rewrites.
- Merge configured stdio variables over the inherited child environment.
- Attribute callback issuer mismatches to the authorization response and avoid unsafe issuer override guidance.