### PR TITLE
Expose reasoning effort over ACP

### DIFF
--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -1551,6 +1551,14 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                 .code = ErrorCode.invalid_params,
                 .message = "Invalid session model",
             });
+        const next_effort = if (sessions.reasoningEffortSupported(
+            value,
+            session.effort,
+            state.capability_resolver.catalogEntries(),
+        ))
+            session.effort
+        else
+            types.ReasoningEffort.auto;
         if (comptime !host_target.is_wasm) {
             if (session.provider != .gateway) {
                 var model_available = false;
@@ -1586,9 +1594,12 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                     .message = "Failed to update session model",
                 });
             const previous_model = session.model;
+            const previous_effort = session.effort;
             session.model = next_model;
+            session.effort = next_effort;
             sessions.commitWasmSession(alloc, session) catch {
                 session.model = previous_model;
+                session.effort = previous_effort;
                 alloc.free(next_model);
                 return state.writer.writeError(alloc, msg.id, .{
                     .code = ErrorCode.internal_error,
@@ -1600,6 +1611,7 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
             alloc,
             session,
             value,
+            next_effort,
             session_test_controls.logOptions(),
         ) catch |err| {
             if (modelCommitFailureTerminatesConnection(err)) {
@@ -1619,6 +1631,50 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                     "Invalid session model"
                 else
                     "Failed to persist session model",
+            });
+        };
+    } else if (std.mem.eql(u8, config_id, "effort")) {
+        const session = if (state.active_session) |*active| active else return state.writer.writeError(alloc, msg.id, .{
+            .code = ErrorCode.invalid_request,
+            .message = "No active session",
+        });
+        const effort = types.ReasoningEffort.parse(value) orelse
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_params,
+                .message = "Invalid reasoning effort",
+            });
+        if (!sessions.reasoningEffortSupported(
+            session.model,
+            effort,
+            state.capability_resolver.catalogEntries(),
+        )) {
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_params,
+                .message = "Reasoning effort is not supported by the active model",
+            });
+        }
+        if (host_target.is_wasm and session.writable == null) {
+            const previous_effort = session.effort;
+            session.effort = effort;
+            sessions.commitWasmSession(alloc, session) catch {
+                session.effort = previous_effort;
+                return state.writer.writeError(alloc, msg.id, .{
+                    .code = ErrorCode.internal_error,
+                    .message = "Failed to persist session effort",
+                });
+            };
+        } else commitActiveSessionEffort(
+            alloc,
+            session,
+            effort,
+            session_test_controls.logOptions(),
+        ) catch |err| {
+            if (modelCommitFailureTerminatesConnection(err)) {
+                state.terminate_connection = true;
+            }
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.internal_error,
+                .message = "Failed to persist session effort",
             });
         };
     } else if (std.mem.eql(u8, config_id, "provider")) {
@@ -1716,11 +1772,17 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                     }
                 }
             }
+            const next_effort = if (sessions.reasoningEffortSupported(
+                selected_model,
+                session.effort,
+                catalog.items,
+            )) session.effort else types.ReasoningEffort.auto;
             commitActiveSessionProvider(
                 alloc,
                 session,
                 target,
                 selected_model,
+                next_effort,
                 session_test_controls.logOptions(),
             ) catch |err| {
                 if (modelCommitFailureTerminatesConnection(err)) {
@@ -1761,6 +1823,13 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
         state.capability_resolver.catalogEntries(),
     );
     try out.writer.writeAll(",");
+    try sessions.writeEffortConfigOption(
+        &out.writer,
+        current_model,
+        if (state.active_session) |session| session.effort else state.effort,
+        state.capability_resolver.catalogEntries(),
+    );
+    try out.writer.writeAll(",");
     try sessions.writeModeConfigOption(&out.writer, state.cfg.mode_registry, current_mode);
     try out.writer.writeAll("]}");
     try state.writer.writeResponse(alloc, msg.id, out.writer.buffered());
@@ -1771,6 +1840,7 @@ fn commitActiveSessionProvider(
     session: *ActiveSessionState,
     provider: model_provider.ProviderId,
     model: []const u8,
+    effort: types.ReasoningEffort,
     options: session_log.Options,
 ) !void {
     session.session_write_mutex.lockUncancelable(io_mod.getIo());
@@ -1786,6 +1856,7 @@ fn commitActiveSessionProvider(
         .{ .preferences_changed = .{
             .provider = provider,
             .model = @constCast(model),
+            .effort = effort,
         } },
         io_mod.milliTimestamp(),
         .rollback_before_adapter_continue,
@@ -1794,12 +1865,14 @@ fn commitActiveSessionProvider(
     alloc.free(session.model);
     session.model = staged_model;
     session.provider = provider;
+    session.effort = effort;
 }
 
 fn commitActiveSessionModel(
     alloc: Allocator,
     session: *ActiveSessionState,
     value: []const u8,
+    effort: types.ReasoningEffort,
     options: session_log.Options,
 ) !void {
     session.session_write_mutex.lockUncancelable(io_mod.getIo());
@@ -1813,8 +1886,10 @@ fn commitActiveSessionModel(
         writable,
         &session.model,
         value,
+        effort,
         options,
     );
+    session.effort = effort;
 }
 
 fn commitSessionModel(
@@ -1822,19 +1897,45 @@ fn commitSessionModel(
     writable: *session_store.LoadedWritableSession,
     active_model: *[]u8,
     value: []const u8,
+    effort: types.ReasoningEffort,
     options: session_log.Options,
 ) !void {
     const staged_model = try alloc.dupe(u8, value);
     errdefer alloc.free(staged_model);
     _ = try writable.appendEvent(
         alloc,
-        .{ .preferences_changed = .{ .model = @constCast(value) } },
+        .{ .preferences_changed = .{
+            .model = @constCast(value),
+            .effort = effort,
+        } },
         io_mod.milliTimestamp(),
         .rollback_before_adapter_continue,
         options,
     );
     alloc.free(active_model.*);
     active_model.* = staged_model;
+}
+
+fn commitActiveSessionEffort(
+    alloc: Allocator,
+    session: *ActiveSessionState,
+    effort: types.ReasoningEffort,
+    options: session_log.Options,
+) !void {
+    session.session_write_mutex.lockUncancelable(io_mod.getIo());
+    defer session.session_write_mutex.unlock(io_mod.getIo());
+    const writable = if (session.writable) |*active|
+        active
+    else
+        return error.SessionPersistenceUnavailable;
+    _ = try writable.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .effort = effort } },
+        io_mod.milliTimestamp(),
+        .rollback_before_adapter_continue,
+        options,
+    );
+    session.effort = effort;
 }
 
 fn modelCommitFailureTerminatesConnection(err: anyerror) bool {
@@ -2307,7 +2408,7 @@ fn acpModelTestState(
         .conversation_language = session_runtime.ConversationLanguage.literal("en"),
         .preferences = .{
             .model = model,
-            .effort = .auto,
+            .effort = types.ReasoningEffort.literal("high"),
             .fast_mode = false,
         },
         .history = history,
@@ -2348,6 +2449,7 @@ test "ACP model commit rolls back before later request can succeed" {
             &writable,
             &active_model,
             "rejected-model",
+            .auto,
             failure.options(),
         ),
     );
@@ -2356,6 +2458,10 @@ test "ACP model commit rolls back before later request can succeed" {
         "old-model",
         writable.state.preferences.model,
     );
+    try std.testing.expectEqual(
+        types.ReasoningEffort.literal("high"),
+        writable.state.preferences.effort,
+    );
     try std.testing.expect(writable.degradedTail() == null);
 
     try commitSessionModel(
@@ -2363,12 +2469,17 @@ test "ACP model commit rolls back before later request can succeed" {
         &writable,
         &active_model,
         "accepted-model",
+        .auto,
         .{},
     );
     try std.testing.expectEqualStrings("accepted-model", active_model);
     try std.testing.expectEqualStrings(
         "accepted-model",
         writable.state.preferences.model,
+    );
+    try std.testing.expectEqual(
+        types.ReasoningEffort.auto,
+        writable.state.preferences.effort,
     );
 }
 
@@ -2408,6 +2519,7 @@ test "ACP indeterminate model commit leaves staged runtime value unapplied" {
         &writable,
         &active_model,
         "uncertain-model",
+        .auto,
         failure.options(),
     );
     try std.testing.expectError(error.SessionCommitIndeterminate, result);
@@ -2445,6 +2557,7 @@ test "ACP model commits honor the active session write boundary" {
                 self.alloc,
                 self.active,
                 "new-model",
+                .auto,
                 .{},
             ) catch |err| {
                 self.failure = err;

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -269,6 +269,13 @@ fn writeNewSessionResponse(
         state.capability_resolver.catalogEntries(),
     );
     try out.writer.writeAll(",");
+    try writeEffortConfigOption(
+        &out.writer,
+        state.active_session.?.model,
+        state.active_session.?.effort,
+        state.capability_resolver.catalogEntries(),
+    );
+    try out.writer.writeAll(",");
     try writeModeConfigOption(
         &out.writer,
         state.cfg.mode_registry,
@@ -807,6 +814,13 @@ fn writeLoadSessionResponse(
         state.capability_resolver.catalogEntries(),
     );
     try out.writer.writeAll(",");
+    try writeEffortConfigOption(
+        &out.writer,
+        model,
+        state.active_session.?.effort,
+        state.capability_resolver.catalogEntries(),
+    );
+    try out.writer.writeAll(",");
     try writeModeConfigOption(
         &out.writer,
         state.cfg.mode_registry,
@@ -1304,6 +1318,49 @@ pub fn writeModelConfigOption(
     try w.writeAll("]}");
 }
 
+pub fn reasoningEffortSupported(
+    model: []const u8,
+    effort: types.ReasoningEffort,
+    catalog: ?[]const model_catalog.ModelCatalogEntry,
+) bool {
+    if (effort.isDefault()) return true;
+    const entries = catalog orelse return false;
+    for (entries) |entry| {
+        if (!std.mem.eql(u8, entry.id, model)) continue;
+        for (entry.reasoning_efforts.items) |option| {
+            if (option.eql(effort)) return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+/// The option remains present with only `auto` when the active model declares
+/// no reasoning tiers, so clients always have a representable fail-closed value.
+pub fn writeEffortConfigOption(
+    w: *std.Io.Writer,
+    model: []const u8,
+    current: types.ReasoningEffort,
+    catalog: ?[]const model_catalog.ModelCatalogEntry,
+) !void {
+    try w.writeAll("{\"id\":\"effort\",\"name\":\"Reasoning effort\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":");
+    try writeJsonStr(current.label(), w);
+    try w.writeAll(",\"options\":[{\"value\":\"auto\",\"name\":\"Auto\"}");
+    const entries = catalog orelse &.{};
+    for (entries) |entry| {
+        if (!std.mem.eql(u8, entry.id, model)) continue;
+        for (entry.reasoning_efforts.items) |effort| {
+            try w.writeAll(",{\"value\":");
+            try writeJsonStr(effort.label(), w);
+            try w.writeAll(",\"name\":");
+            try writeJsonStr(effort.displayLabel(), w);
+            try w.writeAll("}");
+        }
+        break;
+    }
+    try w.writeAll("]}");
+}
+
 pub fn writeProviderConfigOption(
     w: *std.Io.Writer,
     current: model_provider.ProviderId,
@@ -1447,6 +1504,52 @@ test "writeModelConfigOption appends current model when not in cached list" {
     try std.testing.expect(std.mem.find(u8, items, "\"currentValue\":\"custom/my-model\"") != null);
     try std.testing.expect(std.mem.find(u8, items, "anthropic/claude-opus-4.6") != null);
     try std.testing.expect(std.mem.find(u8, items, "custom/my-model") != null);
+}
+
+test "writeEffortConfigOption uses only catalog-declared tiers" {
+    const alloc = std.testing.allocator;
+    const efforts = [_]types.ReasoningEffort{
+        types.ReasoningEffort.literal("low"),
+        types.ReasoningEffort.literal("high"),
+    };
+    const entries = [_]model_catalog.ModelCatalogEntry{
+        .{
+            .id = @constCast("provider/reasoning"),
+            .model_type = @constCast("language"),
+            .reasoning_efforts = .{
+                .items = @constCast(efforts[0..]),
+                .capacity = efforts.len,
+            },
+        },
+    };
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try writeEffortConfigOption(
+        &out.writer,
+        "provider/reasoning",
+        types.ReasoningEffort.literal("high"),
+        &entries,
+    );
+    try std.testing.expectEqualStrings(
+        "{\"id\":\"effort\",\"name\":\"Reasoning effort\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"high\",\"options\":[{\"value\":\"auto\",\"name\":\"Auto\"},{\"value\":\"low\",\"name\":\"low\"},{\"value\":\"high\",\"name\":\"high\"}]}",
+        out.writer.buffered(),
+    );
+}
+
+test "writeEffortConfigOption emits only auto without declared tiers" {
+    const alloc = std.testing.allocator;
+    const entries = [_]model_catalog.ModelCatalogEntry{
+        .{ .id = @constCast("provider/plain"), .model_type = @constCast("language") },
+    };
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try writeEffortConfigOption(&out.writer, "provider/plain", .auto, &entries);
+    try std.testing.expectEqualStrings(
+        "{\"id\":\"effort\",\"name\":\"Reasoning effort\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"auto\",\"options\":[{\"value\":\"auto\",\"name\":\"Auto\"}]}",
+        out.writer.buffered(),
+    );
 }
 
 test "writeModeConfigOption produces valid json with all modes" {

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -8129,6 +8129,84 @@ describe("acp: model-independent", () => {
     },
     TIMEOUT,
   );
+
+  test(
+    "reasoning effort config follows model tiers and reaches the Gateway request",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-effort-config-");
+      const plainModel = "provider/plain-model";
+      const gateway = startFakeGateway([finalText("effort complete")], {
+        models: [
+          {
+            id: FAKE_GATEWAY_MODEL,
+            type: "language",
+            tags: ["reasoning", "tool-use"],
+            reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+          },
+          { id: plainModel, type: "language", tags: ["tool-use"] },
+        ],
+      });
+      const effortOption = (response: any) =>
+        response.result.configOptions.find((option: any) => option.id === "effort");
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+        const created = await client.request("session/new", { mcpServers: [] }, 2) as any;
+        expect(effortOption(created).currentValue).toBe("auto");
+        expect(effortOption(created).options.map((option: any) => option.value))
+          .toEqual(["auto", "low", "high"]);
+        await client.readLine(); // consume session/update notification
+
+        const selected = await client.request("session/set_config_option", {
+          configId: "effort",
+          value: "high",
+        }, 3) as any;
+        expect(effortOption(selected).currentValue).toBe("high");
+
+        await client.request("session/new", { mcpServers: [] }, 4);
+        await client.readLine(); // consume session/update notification
+        const loaded = await client.request("session/load", {
+          sessionId: created.result.sessionId,
+          mcpServers: [],
+        }, 5) as any;
+        expect(effortOption(loaded).currentValue).toBe("high");
+        expect(effortOption(loaded).options.map((option: any) => option.value))
+          .toEqual(["auto", "low", "high"]);
+
+        const prompt = await runPrompt(client, "Confirm the selected effort.", TIMEOUT);
+        expect(prompt.promptResult.result.stopReason).toBe("end_turn");
+        expect(JSON.parse(gateway.requests[0]!.body).reasoning).toBe("high");
+
+        const invalid = await client.request("session/set_config_option", {
+          configId: "effort",
+          value: "max",
+        }, 6) as any;
+        expect(invalid.result).toBeUndefined();
+        expect(invalid.error.code).toBe(-32602);
+        expect(invalid.error.message).toContain("not supported");
+
+        const changedModel = await client.request("session/set_config_option", {
+          configId: "model",
+          value: plainModel,
+        }, 7) as any;
+        expect(effortOption(changedModel).currentValue).toBe("auto");
+        expect(effortOption(changedModel).options.map((option: any) => option.value))
+          .toEqual(["auto"]);
+
+        client.endStdin();
+        expect(await client.waitForExit()).toBe(0);
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
 });
 
 describe("acp: model catalog authentication", () => {


### PR DESCRIPTION
## Summary

- Add a catalog-derived `effort` select option after the ACP model option for new and loaded sessions
- Validate and persist `session/set_config_option` effort changes
- Reset unsupported effort selections to `auto` when a model or provider change removes the selected tier
- Cover serialization, persistence, invalid input, model reset, and the Gateway request wire value

## Why

ACP clients can select a model today but cannot control the reasoning effort already available through the fx model picker. The option is intentionally fail closed: it exposes only tiers declared by the active model catalog, always includes `auto`, and exposes only `auto` when the model declares no tiers.

This extends the client-side control surface related to #276 without changing provider request construction.

## Testing

- Focused Zig serializer tests: 14 passed
- Focused Zig durable model/effort rollback test: 12 passed
- `zig build -Dtarget=x86_64-linux-gnu`
- `bun test acp.test.ts -t "reasoning effort config"`: 1 passed, 14 skipped
- `zig fmt --check src/`
- `git diff --check`
- Direct `./zig-out/bin/fx acp` protocol proof: exit 0 with empty stderr
- `zig build test -Doptimize=ReleaseSafe -Dtarget=x86_64-linux-gnu`: 8,445 passed and 15 skipped; the run retains one unrelated pre-existing ANSI presentation failure and five allocations leaked by the untouched terminal start test. Full CI is authoritative for the exact commit.

### Manual ACP proof

```json
-> {"id":1,"method":"initialize","params":{"protocolVersion":1}}
<- {"id":1,"result":{"protocolVersion":1,"agentInfo":{"name":"fx","version":"0.0.5"}}}
-> {"id":2,"method":"session/new","params":{"mcpServers":[]}}
<- {"id":2,"result":{"sessionId":"<session-id>"}}
-> {"id":3,"method":"session/set_config_option","params":{"configId":"effort","value":"high"}}
<- {"id":3,"result":{"effort":{"id":"effort","currentValue":"high","options":[{"value":"auto"},{"value":"low"},{"value":"high"}]}}}
-> {"id":4,"method":"session/prompt","params":{"prompt":[{"type":"text","text":"Return the proof response."}]}}
<- {"id":4,"result":{"stopReason":"end_turn"}}
```

```text
[gateway] event=provider_options turn_id=1 step_id=1 model=openai/gpt-5 fast_mode=false effort=high reasoning=selected fast=default
```

### Authenticated runtime proof

On the exact PR commit, a freshly built `./zig-out/bin/fx acp` used the authenticated Codex subscription with `gpt-5.6-sol`. `session/new` exposed `provider`, `model`, `effort`, and `mode`; selecting `effort=high` followed by a real prompt returned the requested marker with `stopReason=end_turn`. The process exited 0 with empty stderr.

### Grok runtime proof

A second authenticated run selected the `grok` provider and `grok-4.6`, exposed the catalog-derived effort option, selected `high`, and completed a real prompt with `stopReason=end_turn`, exit 0, and empty stderr.

### Vercel AI Gateway runtime proof

An authenticated Gateway run used `openai/gpt-5.2`, exposed the catalog-derived effort option, selected `high`, and completed a real prompt with `stopReason=end_turn`, exit 0, and empty stderr.


### Current-main verification

Rebased onto upstream `1b87677`. The exact rebased commit passed the 14-test focused Zig serializer filter, the focused ACP E2E, `zig fmt --check src/`, `git diff --check`, and a fresh `x86_64-linux-gnu` build. A real authenticated Codex prompt through `./zig-out/bin/fx acp` selected `effort=high`, returned `stopReason=end_turn`, exited 0, and produced empty stderr.