### PR TITLE
Expose Fast mode over ACP

### DIFF
--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -1551,6 +1551,10 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                 .code = ErrorCode.invalid_params,
                 .message = "Invalid session model",
             });
+        const next_fast_mode = session.fast_mode and sessions.modelSupportsFastMode(
+            value,
+            state.capability_resolver.catalogEntries(),
+        );
         if (comptime !host_target.is_wasm) {
             if (session.provider != .gateway) {
                 var model_available = false;
@@ -1586,9 +1590,12 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                     .message = "Failed to update session model",
                 });
             const previous_model = session.model;
+            const previous_fast_mode = session.fast_mode;
             session.model = next_model;
+            session.fast_mode = next_fast_mode;
             sessions.commitWasmSession(alloc, session) catch {
                 session.model = previous_model;
+                session.fast_mode = previous_fast_mode;
                 alloc.free(next_model);
                 return state.writer.writeError(alloc, msg.id, .{
                     .code = ErrorCode.internal_error,
@@ -1600,6 +1607,7 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
             alloc,
             session,
             value,
+            next_fast_mode,
             session_test_controls.logOptions(),
         ) catch |err| {
             if (modelCommitFailureTerminatesConnection(err)) {
@@ -1619,6 +1627,53 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                     "Invalid session model"
                 else
                     "Failed to persist session model",
+            });
+        };
+    } else if (std.mem.eql(u8, config_id, "fast")) {
+        const session = if (state.active_session) |*active| active else return state.writer.writeError(alloc, msg.id, .{
+            .code = ErrorCode.invalid_request,
+            .message = "No active session",
+        });
+        const enabled = if (std.mem.eql(u8, value, "normal"))
+            false
+        else if (std.mem.eql(u8, value, "fast"))
+            true
+        else
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_params,
+                .message = "Invalid Fast mode",
+            });
+        if (!sessions.modelSupportsFastMode(
+            session.model,
+            state.capability_resolver.catalogEntries(),
+        )) {
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.invalid_params,
+                .message = "Fast mode is not supported by the active model",
+            });
+        }
+        if (host_target.is_wasm and session.writable == null) {
+            const previous_fast_mode = session.fast_mode;
+            session.fast_mode = enabled;
+            sessions.commitWasmSession(alloc, session) catch {
+                session.fast_mode = previous_fast_mode;
+                return state.writer.writeError(alloc, msg.id, .{
+                    .code = ErrorCode.internal_error,
+                    .message = "Failed to persist session Fast mode",
+                });
+            };
+        } else commitActiveSessionFastMode(
+            alloc,
+            session,
+            enabled,
+            session_test_controls.logOptions(),
+        ) catch |err| {
+            if (modelCommitFailureTerminatesConnection(err)) {
+                state.terminate_connection = true;
+            }
+            return state.writer.writeError(alloc, msg.id, .{
+                .code = ErrorCode.internal_error,
+                .message = "Failed to persist session Fast mode",
             });
         };
     } else if (std.mem.eql(u8, config_id, "provider")) {
@@ -1716,11 +1771,14 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                     }
                 }
             }
+            const next_fast_mode = session.fast_mode and
+                sessions.modelSupportsFastMode(selected_model, catalog.items);
             commitActiveSessionProvider(
                 alloc,
                 session,
                 target,
                 selected_model,
+                next_fast_mode,
                 session_test_controls.logOptions(),
             ) catch |err| {
                 if (modelCommitFailureTerminatesConnection(err)) {
@@ -1760,6 +1818,16 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
         current_model,
         state.capability_resolver.catalogEntries(),
     );
+    if (sessions.modelSupportsFastMode(
+        current_model,
+        state.capability_resolver.catalogEntries(),
+    )) {
+        try out.writer.writeAll(",");
+        try sessions.writeFastConfigOption(
+            &out.writer,
+            if (state.active_session) |session| session.fast_mode else state.fast_mode,
+        );
+    }
     try out.writer.writeAll(",");
     try sessions.writeModeConfigOption(&out.writer, state.cfg.mode_registry, current_mode);
     try out.writer.writeAll("]}");
@@ -1771,6 +1839,7 @@ fn commitActiveSessionProvider(
     session: *ActiveSessionState,
     provider: model_provider.ProviderId,
     model: []const u8,
+    fast_mode: bool,
     options: session_log.Options,
 ) !void {
     session.session_write_mutex.lockUncancelable(io_mod.getIo());
@@ -1786,6 +1855,7 @@ fn commitActiveSessionProvider(
         .{ .preferences_changed = .{
             .provider = provider,
             .model = @constCast(model),
+            .fast_mode = fast_mode,
         } },
         io_mod.milliTimestamp(),
         .rollback_before_adapter_continue,
@@ -1794,12 +1864,14 @@ fn commitActiveSessionProvider(
     alloc.free(session.model);
     session.model = staged_model;
     session.provider = provider;
+    session.fast_mode = fast_mode;
 }
 
 fn commitActiveSessionModel(
     alloc: Allocator,
     session: *ActiveSessionState,
     value: []const u8,
+    fast_mode: bool,
     options: session_log.Options,
 ) !void {
     session.session_write_mutex.lockUncancelable(io_mod.getIo());
@@ -1813,8 +1885,10 @@ fn commitActiveSessionModel(
         writable,
         &session.model,
         value,
+        fast_mode,
         options,
     );
+    session.fast_mode = fast_mode;
 }
 
 fn commitSessionModel(
@@ -1822,19 +1896,45 @@ fn commitSessionModel(
     writable: *session_store.LoadedWritableSession,
     active_model: *[]u8,
     value: []const u8,
+    fast_mode: bool,
     options: session_log.Options,
 ) !void {
     const staged_model = try alloc.dupe(u8, value);
     errdefer alloc.free(staged_model);
     _ = try writable.appendEvent(
         alloc,
-        .{ .preferences_changed = .{ .model = @constCast(value) } },
+        .{ .preferences_changed = .{
+            .model = @constCast(value),
+            .fast_mode = fast_mode,
+        } },
         io_mod.milliTimestamp(),
         .rollback_before_adapter_continue,
         options,
     );
     alloc.free(active_model.*);
     active_model.* = staged_model;
+}
+
+fn commitActiveSessionFastMode(
+    alloc: Allocator,
+    session: *ActiveSessionState,
+    enabled: bool,
+    options: session_log.Options,
+) !void {
+    session.session_write_mutex.lockUncancelable(io_mod.getIo());
+    defer session.session_write_mutex.unlock(io_mod.getIo());
+    const writable = if (session.writable) |*active|
+        active
+    else
+        return error.SessionPersistenceUnavailable;
+    _ = try writable.appendEvent(
+        alloc,
+        .{ .preferences_changed = .{ .fast_mode = enabled } },
+        io_mod.milliTimestamp(),
+        .rollback_before_adapter_continue,
+        options,
+    );
+    session.fast_mode = enabled;
 }
 
 fn modelCommitFailureTerminatesConnection(err: anyerror) bool {
@@ -2308,7 +2408,7 @@ fn acpModelTestState(
         .preferences = .{
             .model = model,
             .effort = .auto,
-            .fast_mode = false,
+            .fast_mode = true,
         },
         .history = history,
         .total_input_tokens = 0,
@@ -2348,6 +2448,7 @@ test "ACP model commit rolls back before later request can succeed" {
             &writable,
             &active_model,
             "rejected-model",
+            false,
             failure.options(),
         ),
     );
@@ -2356,6 +2457,7 @@ test "ACP model commit rolls back before later request can succeed" {
         "old-model",
         writable.state.preferences.model,
     );
+    try std.testing.expect(writable.state.preferences.fast_mode);
     try std.testing.expect(writable.degradedTail() == null);
 
     try commitSessionModel(
@@ -2363,6 +2465,7 @@ test "ACP model commit rolls back before later request can succeed" {
         &writable,
         &active_model,
         "accepted-model",
+        false,
         .{},
     );
     try std.testing.expectEqualStrings("accepted-model", active_model);
@@ -2370,6 +2473,7 @@ test "ACP model commit rolls back before later request can succeed" {
         "accepted-model",
         writable.state.preferences.model,
     );
+    try std.testing.expect(!writable.state.preferences.fast_mode);
 }
 
 test "ACP indeterminate model commit leaves staged runtime value unapplied" {
@@ -2408,6 +2512,7 @@ test "ACP indeterminate model commit leaves staged runtime value unapplied" {
         &writable,
         &active_model,
         "uncertain-model",
+        false,
         failure.options(),
     );
     try std.testing.expectError(error.SessionCommitIndeterminate, result);
@@ -2445,6 +2550,7 @@ test "ACP model commits honor the active session write boundary" {
                 self.alloc,
                 self.active,
                 "new-model",
+                false,
                 .{},
             ) catch |err| {
                 self.failure = err;

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -268,6 +268,13 @@ fn writeNewSessionResponse(
         state.active_session.?.model,
         state.capability_resolver.catalogEntries(),
     );
+    if (modelSupportsFastMode(
+        state.active_session.?.model,
+        state.capability_resolver.catalogEntries(),
+    )) {
+        try out.writer.writeAll(",");
+        try writeFastConfigOption(&out.writer, state.active_session.?.fast_mode);
+    }
     try out.writer.writeAll(",");
     try writeModeConfigOption(
         &out.writer,
@@ -806,6 +813,10 @@ fn writeLoadSessionResponse(
         model,
         state.capability_resolver.catalogEntries(),
     );
+    if (modelSupportsFastMode(model, state.capability_resolver.catalogEntries())) {
+        try out.writer.writeAll(",");
+        try writeFastConfigOption(&out.writer, state.active_session.?.fast_mode);
+    }
     try out.writer.writeAll(",");
     try writeModeConfigOption(
         &out.writer,
@@ -1304,6 +1315,24 @@ pub fn writeModelConfigOption(
     try w.writeAll("]}");
 }
 
+pub fn modelSupportsFastMode(
+    model: []const u8,
+    catalog: ?[]const model_catalog.ModelCatalogEntry,
+) bool {
+    const entries = catalog orelse return false;
+    for (entries) |entry| {
+        if (std.mem.eql(u8, entry.id, model)) return entry.supports_fast_mode;
+    }
+    return false;
+}
+
+/// Callers omit this option when the active catalog entry has no Fast support.
+pub fn writeFastConfigOption(w: *std.Io.Writer, enabled: bool) !void {
+    try w.writeAll("{\"id\":\"fast\",\"name\":\"Fast mode\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":");
+    try writeJsonStr(if (enabled) "fast" else "normal", w);
+    try w.writeAll(",\"options\":[{\"value\":\"normal\",\"name\":\"Normal\"},{\"value\":\"fast\",\"name\":\"Fast\"}]}");
+}
+
 pub fn writeProviderConfigOption(
     w: *std.Io.Writer,
     current: model_provider.ProviderId,
@@ -1447,6 +1476,29 @@ test "writeModelConfigOption appends current model when not in cached list" {
     try std.testing.expect(std.mem.find(u8, items, "\"currentValue\":\"custom/my-model\"") != null);
     try std.testing.expect(std.mem.find(u8, items, "anthropic/claude-opus-4.6") != null);
     try std.testing.expect(std.mem.find(u8, items, "custom/my-model") != null);
+}
+
+test "Fast config option is catalog gated and uses ACP select values" {
+    const alloc = std.testing.allocator;
+    const entries = [_]model_catalog.ModelCatalogEntry{
+        .{
+            .id = @constCast("provider/fast"),
+            .model_type = @constCast("language"),
+            .supports_fast_mode = true,
+        },
+        .{ .id = @constCast("provider/plain"), .model_type = @constCast("language") },
+    };
+    try std.testing.expect(modelSupportsFastMode("provider/fast", &entries));
+    try std.testing.expect(!modelSupportsFastMode("provider/plain", &entries));
+    try std.testing.expect(!modelSupportsFastMode("provider/missing", &entries));
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try writeFastConfigOption(&out.writer, true);
+    try std.testing.expectEqualStrings(
+        "{\"id\":\"fast\",\"name\":\"Fast mode\",\"category\":\"model\",\"type\":\"select\",\"currentValue\":\"fast\",\"options\":[{\"value\":\"normal\",\"name\":\"Normal\"},{\"value\":\"fast\",\"name\":\"Fast\"}]}",
+        out.writer.buffered(),
+    );
 }
 
 test "writeModeConfigOption produces valid json with all modes" {

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -8129,6 +8129,81 @@ describe("acp: model-independent", () => {
     },
     TIMEOUT,
   );
+
+  test(
+    "Fast config follows model support and reaches the Gateway request",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-fast-config-");
+      const plainModel = "provider/plain-model";
+      const gateway = startFakeGateway([finalText("fast complete")], {
+        models: [
+          {
+            id: FAKE_GATEWAY_MODEL,
+            type: "language",
+            tags: ["tool-use"],
+            fast_options: [{ type: "toggle" }],
+          },
+          { id: plainModel, type: "language", tags: ["tool-use"] },
+        ],
+      });
+      const fastOption = (response: any) =>
+        response.result.configOptions.find((option: any) => option.id === "fast");
+      try {
+        client = await AcpClient.create({
+          cwd: root.workspace,
+          env: fakeGatewayEnv(root, gateway),
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 1);
+        const created = await client.request("session/new", { mcpServers: [] }, 2) as any;
+        expect(fastOption(created).currentValue).toBe("normal");
+        expect(fastOption(created).options.map((option: any) => option.value))
+          .toEqual(["normal", "fast"]);
+        await client.readLine(); // consume session/update notification
+
+        const selected = await client.request("session/set_config_option", {
+          configId: "fast",
+          value: "fast",
+        }, 3) as any;
+        expect(fastOption(selected).currentValue).toBe("fast");
+
+        await client.request("session/new", { mcpServers: [] }, 4);
+        await client.readLine(); // consume session/update notification
+        const loaded = await client.request("session/load", {
+          sessionId: created.result.sessionId,
+          mcpServers: [],
+        }, 5) as any;
+        expect(fastOption(loaded).currentValue).toBe("fast");
+
+        const prompt = await runPrompt(client, "Confirm Fast mode.", TIMEOUT);
+        expect(prompt.promptResult.result.stopReason).toBe("end_turn");
+        expect(JSON.parse(gateway.requests[0]!.body).providerOptions.gateway.speed)
+          .toBe("fast");
+
+        const invalid = await client.request("session/set_config_option", {
+          configId: "fast",
+          value: "turbo",
+        }, 6) as any;
+        expect(invalid.result).toBeUndefined();
+        expect(invalid.error.code).toBe(-32602);
+        expect(invalid.error.message).toContain("Invalid Fast mode");
+
+        const changedModel = await client.request("session/set_config_option", {
+          configId: "model",
+          value: plainModel,
+        }, 7) as any;
+        expect(fastOption(changedModel)).toBeUndefined();
+
+        client.endStdin();
+        expect(await client.waitForExit()).toBe(0);
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
 });
 
 describe("acp: model catalog authentication", () => {


### PR DESCRIPTION
## Summary

- expose a model-gated Fast mode select in session/new and session/load configOptions
- handle normal and fast through session/set_config_option and persist the preference
- reset Fast mode when switching to a model or provider model without Fast support
- cover serialization, durable rollback, persistence, prompt-wire behavior, validation, and model switching

## Why

ACP clients need the same Fast control that fx already exposes interactively. The local ACP schema has no boolean config-option variant, so this uses a select with normal and fast values and omits it for models whose catalog entry does not advertise Fast support.

This advances #276 without changing provider or gateway request construction.

## Testing

- zig test -ODebug --dep build_options -Mroot=src/acp/sessions.zig -Mbuild_options=.zig-cache/c/a9e9d0d980db0aac99bbb236ec7c4e53/options.zig --test-filter "Fast config option"
- focused server durable-rollback test through a temporary root importing src/acp/server.zig
- zig build -Dtarget=x86_64-linux-gnu
- bun test acp.test.ts -t "Fast config follows"
- zig fmt --check src/
- git diff --check

Built-binary proof used ./zig-out/bin/fx acp with initialize, session/new, Fast=fast, and session/prompt. It exited 0 with empty stderr; FX_TRACE recorded fast_mode=true and fast=selected on the provider-options event.

### Authenticated runtime proof

On the exact PR commit, a freshly built `./zig-out/bin/fx acp` used the authenticated Codex subscription with `gpt-5.6-sol`. `session/new` exposed `provider`, `model`, `fast`, and `mode`; selecting `fast` followed by a real prompt returned the requested marker with `stopReason=end_turn`. The process exited 0 with empty stderr.

### Grok runtime proof

An authenticated `grok-4.6` run confirmed the fail-closed catalog gate: because that model does not advertise Fast support, the ACP response omitted the `fast` option. A real prompt still completed with `stopReason=end_turn`, exit 0, and empty stderr.

### Vercel AI Gateway runtime proof

An authenticated Gateway run used `openai/gpt-5.2`, exposed the Fast option, selected `fast`, and completed a real prompt with `stopReason=end_turn`, exit 0, and empty stderr.


### Current-main verification

Rebased onto upstream `1b87677`. The exact rebased commit passed the 13-test focused Zig filter, the focused ACP E2E, `zig fmt --check src/`, `git diff --check`, and a fresh `x86_64-linux-gnu` build. A real authenticated Codex prompt through `./zig-out/bin/fx acp` selected Fast mode, returned `stopReason=end_turn`, exited 0, and produced empty stderr.