### PR TITLE
Add ACP reasoning effort flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,8 @@ Config precedence (highest wins):
 
 Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `update_channel`, `permission_mode`, and `permission` are ignored from project config before their values are parsed.
 
+`fx acp --model <id>` and `fx acp --effort <level>` apply process-local overrides to new and loaded ACP sessions. They do not update `~/.fx/settings.json`; omit the flags to return to the configured or saved session preferences.
+
 Runtime state lives under `~/.fx/`:
 
 * `~/.fx/sessions/<session-id>/session.json`

--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -223,6 +223,7 @@ pub const ServerState = struct {
     provider: model_provider.ProviderId = .gateway,
     configured_model: []u8 = &.{},
     process_model_override: bool = false,
+    process_effort_override: bool = false,
     permission_mode: types.PermissionMode = .ask,
     permission_rules: types.PermissionRuleSet = .{},
     agent_step_limit: usize = 0,
@@ -230,6 +231,7 @@ pub const ServerState = struct {
     context_limits: config_runtime.context_limits.Values = .{},
     fast_mode: bool = false,
     effort: types.ReasoningEffort = .auto,
+    configured_effort: types.ReasoningEffort = .auto,
     first_call_tool_choice: types.ToolChoice = .auto,
     context_enabled: bool = true,
     active_session: ?ActiveSessionState = null,
@@ -1406,7 +1408,14 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
     state.context_limits.applyCommandLine(state.cfg.context_limit_overrides);
     state.fast_mode = startup.fast_mode and
         (state.cfg.model_override == null or startup.fast_mode_source != .compiled_default);
-    state.effort = startup.effort;
+    state.configured_effort = startup.configured_effort;
+    if (state.cfg.effort_override) |override| {
+        state.effort = override;
+        state.process_effort_override = true;
+    } else {
+        state.effort = startup.effort;
+        state.process_effort_override = startup.effort_source == .process_override;
+    }
     state.first_call_tool_choice = startup.first_call_tool_choice;
     state.context_enabled = startup.context_enabled;
 

--- a/src/acp/sessions.zig
+++ b/src/acp/sessions.zig
@@ -550,7 +550,7 @@ fn handleRestoreSession(
     const seed_preferences = session_codec.DurableSessionPreferences{
         .provider = state.provider,
         .model = state.configured_model,
-        .effort = state.effort,
+        .effort = state.configured_effort,
         .fast_mode = state.fast_mode,
     };
     var writable = subagent_resume_admission.resumeForExternalPrompt(
@@ -628,7 +628,11 @@ fn handleRestoreSession(
         .model = model_copy,
         .provider = effective_provider,
         .fast_mode = writable.state.preferences.fast_mode,
-        .effort = writable.state.preferences.effort,
+        .effort = effectiveLoadedEffort(
+            state.process_effort_override,
+            state.effort,
+            writable.state.preferences.effort,
+        ),
         .session_rt = session_rt,
         .mcp = session_mcp,
     }) catch
@@ -846,13 +850,21 @@ fn freshAcpState(
         .preferences = .{
             .provider = state.provider,
             .model = model,
-            .effort = state.effort,
+            .effort = state.configured_effort,
             .fast_mode = state.fast_mode,
         },
         .history = history,
         .total_input_tokens = 0,
         .total_output_tokens = 0,
     };
+}
+
+fn effectiveLoadedEffort(
+    process_override: bool,
+    process_effort: types.ReasoningEffort,
+    saved_effort: types.ReasoningEffort,
+) types.ReasoningEffort {
+    return if (process_override) process_effort else saved_effort;
 }
 
 const SessionActivation = struct {
@@ -1460,6 +1472,13 @@ test "writeModeConfigOption produces valid json with all modes" {
     try std.testing.expect(std.mem.find(u8, items, "\"review\"") != null);
     try std.testing.expect(std.mem.find(u8, items, "\"inspect\"") != null);
     try std.testing.expect(std.mem.find(u8, items, "\"permissionMode\":\"ask\"") != null);
+}
+
+test "ACP loaded session effort honors only an active process override" {
+    const saved = types.ReasoningEffort.literal("low");
+    const process = types.ReasoningEffort.literal("high");
+    try std.testing.expect(effectiveLoadedEffort(false, process, saved).eql(saved));
+    try std.testing.expect(effectiveLoadedEffort(true, process, saved).eql(process));
 }
 
 test "writeModesArray preserves supplied registry order" {

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -58,10 +58,11 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .acp,
         .token = "acp",
-        .usage = "acp [--model <id>] [--log-file <path>]",
+        .usage = "acp [--model <id>] [--effort <level>] [--log-file <path>]",
         .summary = "Start an ACP server over stdio",
         .options = &.{
             .{ .flag = "--model <id>", .description = "Override the default model" },
+            .{ .flag = "--effort <level>", .description = "Override the configured reasoning effort" },
             .{ .flag = "--log-file <path>", .description = "Write ACP logs to a file" },
         },
     },

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -141,6 +141,8 @@ pub const StartupState = struct {
     prompt_history_store_allowed: bool = true,
     config_diagnostics: []config_runtime.ConfigDiagnostic = &.{},
     effort: types.ReasoningEffort = .auto,
+    configured_effort: types.ReasoningEffort = .auto,
+    effort_source: config_runtime.ConfigSource = .compiled_default,
     first_call_tool_choice: types.ToolChoice = .auto,
     statusline_context: bool = false,
     statusline_session: bool = false,
@@ -431,7 +433,9 @@ fn loadStartupStateFromOwnedWorkspace(
     state.auto_upgrade = settings.auto_upgrade orelse true;
     state.update_channel = settings.update_channel orelse .stable;
     state.startup_scrollback = settings.startup_scrollback orelse true;
-    state.effort = settings.effort orelse .auto;
+    state.configured_effort = settings.effort orelse .auto;
+    state.effort = state.configured_effort;
+    state.effort_source = detailed.sources.effort;
     state.first_call_tool_choice = settings.first_call_tool_choice orelse .auto;
     state.statusline_context = settings.statusline_context orelse false;
     state.statusline_session = settings.statusline_session orelse false;
@@ -2015,6 +2019,36 @@ test "loadStartupState applies core env overrides" {
     try std.testing.expectEqual(credentials.Source.ai_gateway_api_key, state.credential.?.source);
     try std.testing.expectEqual(PermissionMode.auto, state.permission_mode);
     try std.testing.expectEqual(@as(usize, 37), state.agent_step_limit);
+}
+
+test "loadStartupState reports the configured effort source" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+    const home_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "home");
+    defer std.testing.allocator.free(home_root);
+    const workspace_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "workspace");
+    defer std.testing.allocator.free(workspace_root);
+    try writeFixtureFile(tmp.dir, "home/.fx/settings.json", "{\"effort\":\"low\"}\n");
+
+    const owned_workspace_root = try std.testing.allocator.dupe(u8, workspace_root);
+    var state = try loadStartupStateFromOwnedWorkspace(
+        std.testing.allocator,
+        oauth_transport.unavailable_provider,
+        host.unavailable_secret_store,
+        owned_workspace_root,
+        "default-model",
+        12,
+        home_root,
+        null,
+    );
+    defer state.deinit(std.testing.allocator);
+
+    try std.testing.expect(state.configured_effort.eql(types.ReasoningEffort.literal("low")));
+    try std.testing.expect(state.effort.eql(types.ReasoningEffort.literal("low")));
+    try std.testing.expectEqual(config_runtime.ConfigSource.user_global, state.effort_source);
 }
 
 test "loadStartupState defaults fast mode on only for the compiled Gateway default and preserves explicit preferences" {

--- a/src/core/cli/acp_runner.zig
+++ b/src/core/cli/acp_runner.zig
@@ -9,6 +9,7 @@ const host = @import("../hosts/host.zig");
 const mode_registry = @import("../modes/mode_registry.zig");
 const prompt_policy = @import("../config/prompt_policy.zig");
 const context_contract = @import("../workspace/context_contract.zig");
+const types = @import("../shared/types.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -35,6 +36,7 @@ pub const Config = struct {
     context_registry: context_contract.Registry,
     mode_registry: mode_registry.Registry,
     model_override: ?[]const u8 = null,
+    effort_override: ?types.ReasoningEffort = null,
     credential_override: ?[]const u8 = null,
     home_override: ?[]const u8 = null,
     workspace_root_override: ?[]const u8 = null,

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -313,6 +313,7 @@ const SessionRecoveryOptions = struct {
 
 const AcpOptions = struct {
     model: ?[]const u8 = null,
+    effort: ?types.ReasoningEffort = null,
     log_file: ?[]const u8 = null,
 };
 
@@ -896,7 +897,7 @@ fn runNonInteractiveWithDeps(
         },
         .acp => |rest| {
             const acp_opts = parseAcpArgs(rest) catch {
-                try writeStderr(deps, "usage: fx acp [--model <id>] [--log-file <path>]\n");
+                try writeStderr(deps, "usage: fx acp [--model <id>] [--effort <level>] [--log-file <path>]\n");
                 return .handled_failure;
             };
             try cfg.acp_runner.run(alloc, .{
@@ -924,6 +925,7 @@ fn runNonInteractiveWithDeps(
                 .additional_directories = global_args.modifiers.additional_directories,
                 .saved_directories_suppressed = global_args.modifiers.saved_directories_suppressed,
                 .model_override = acp_opts.model,
+                .effort_override = acp_opts.effort,
                 .log_file = acp_opts.log_file,
             });
             return .handled_success;
@@ -3498,6 +3500,10 @@ fn parseAcpArgs(args: []const [:0]const u8) !AcpOptions {
             if (opts.model != null or i + 1 >= args.len) return error.InvalidAcpArgs;
             i += 1;
             opts.model = args[i];
+        } else if (std.mem.eql(u8, args[i], "--effort")) {
+            if (opts.effort != null or i + 1 >= args.len) return error.InvalidAcpArgs;
+            i += 1;
+            opts.effort = types.ReasoningEffort.parse(args[i]) orelse return error.InvalidAcpArgs;
         } else if (std.mem.eql(u8, args[i], "--log-file")) {
             if (opts.log_file != null or i + 1 >= args.len) return error.InvalidAcpArgs;
             i += 1;
@@ -4111,18 +4117,30 @@ test "parse acp args extracts known flags and rejects invalid arguments" {
     const opts = try parseAcpArgs(&.{
         @constCast("--model"),
         @constCast("openai/gpt-4o"),
+        @constCast("--effort"),
+        @constCast("high"),
         @constCast("--log-file"),
         @constCast("/tmp/fx.log"),
     });
     try std.testing.expectEqualStrings("openai/gpt-4o", opts.model.?);
+    try std.testing.expect(opts.effort.?.eql(types.ReasoningEffort.literal("high")));
     try std.testing.expectEqualStrings("/tmp/fx.log", opts.log_file.?);
 
     try std.testing.expectError(error.InvalidAcpArgs, parseAcpArgs(&.{@constCast("--unknown")}));
     try std.testing.expectError(error.InvalidAcpArgs, parseAcpArgs(&.{@constCast("--model")}));
+    try std.testing.expectError(error.InvalidAcpArgs, parseAcpArgs(&.{@constCast("--effort")}));
+    try std.testing.expectError(
+        error.InvalidAcpArgs,
+        parseAcpArgs(&.{ @constCast("--effort"), @constCast("not valid!") }),
+    );
     try std.testing.expectError(error.InvalidAcpArgs, parseAcpArgs(&.{@constCast("--log-file")}));
     try std.testing.expectError(
         error.InvalidAcpArgs,
         parseAcpArgs(&.{ @constCast("--model"), @constCast("first"), @constCast("--model"), @constCast("second") }),
+    );
+    try std.testing.expectError(
+        error.InvalidAcpArgs,
+        parseAcpArgs(&.{ @constCast("--effort"), @constCast("low"), @constCast("--effort"), @constCast("high") }),
     );
 }
 
@@ -4177,6 +4195,7 @@ test "ACP command routes parsed options and launch config through the injected r
                 std.mem.eql(u8, cfg.additional_directories[0], "/tmp/acp-extra") and
                 cfg.saved_directories_suppressed and
                 std.mem.eql(u8, cfg.model_override.?, "model-override") and
+                cfg.effort_override.?.eql(types.ReasoningEffort.literal("high")) and
                 std.mem.eql(u8, cfg.log_file.?, "/tmp/acp.log");
         }
     };
@@ -4196,6 +4215,8 @@ test "ACP command routes parsed options and launch config through the injected r
             @constCast("acp"),
             @constCast("--model"),
             @constCast("model-override"),
+            @constCast("--effort"),
+            @constCast("high"),
             @constCast("--log-file"),
             @constCast("/tmp/acp.log"),
         },

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1703,8 +1703,9 @@ test "ACP help documents accepted options" {
     defer std.testing.allocator.free(text);
 
     try std.testing.expect(std.mem.find(u8, text, "fx acp\n") != null);
-    try std.testing.expect(std.mem.find(u8, text, "Usage:\n  fx acp [--model <id>] [--log-file <path>]") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Usage:\n  fx acp [--model <id>] [--effort <level>] [--log-file <path>]") != null);
     try std.testing.expect(std.mem.find(u8, text, "--model <id>") != null);
+    try std.testing.expect(std.mem.find(u8, text, "--effort <level>") != null);
     try std.testing.expect(std.mem.find(u8, text, "--log-file <path>") != null);
 }
 

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -8254,6 +8254,90 @@ describe("acp: model catalog authentication", () => {
     },
     TIMEOUT,
   );
+
+  test(
+    "--effort overrides new and loaded sessions without persisting the override",
+    async () => {
+      const root = createIsolatedRoot("fx-acp-effort-flag-");
+      const model = "provider/effort-flag";
+      const settingsPath = join(root.home, ".fx", "settings.json");
+      const settings = `${JSON.stringify({ model, effort: "low" })}\n`;
+      writeFileSync(settingsPath, settings);
+      const gateway = startFakeGateway(
+        [
+          finalText("new override complete"),
+          finalText("load override complete"),
+          finalText("saved effort complete"),
+        ],
+        {
+          models: [{
+            id: model,
+            type: "language",
+            tags: ["reasoning", "tool-use"],
+            reasoning_options: [{ type: "effort", values: ["low", "high"] }],
+          }],
+        },
+      );
+      const env = {
+        ...fakeGatewayEnv(root, gateway),
+        FX_MODEL: undefined,
+      };
+      let sessionId: string;
+      try {
+        client = await AcpClient.create({
+          args: ["acp", "--effort", "high"],
+          cwd: root.workspace,
+          env,
+        });
+        sessionId = await startCodeSession(client);
+        expect((await runPrompt(client, "Use the process effort.")).promptResult.result.stopReason)
+          .toBe("end_turn");
+        expect(JSON.parse(gateway.requests[0]!.body)).toMatchObject({ reasoning: "high" });
+
+        await client.close();
+        client = await AcpClient.create({
+          args: ["acp", "--effort", "high"],
+          cwd: root.workspace,
+          env,
+        });
+        await client.request("initialize", { protocolVersion: 1 }, 10);
+        client.send({
+          jsonrpc: "2.0",
+          id: 11,
+          method: "session/load",
+          params: { sessionId, mcpServers: [] },
+        });
+        expect((await readResponse(client, 11)).error).toBeUndefined();
+        expect((await runPrompt(client, "Use the process effort after load.")).promptResult.result.stopReason)
+          .toBe("end_turn");
+        expect(JSON.parse(gateway.requests[1]!.body)).toMatchObject({ reasoning: "high" });
+
+        await client.close();
+        client = await AcpClient.create({ cwd: root.workspace, env });
+        await client.request("initialize", { protocolVersion: 1 }, 20);
+        client.send({
+          jsonrpc: "2.0",
+          id: 21,
+          method: "session/load",
+          params: { sessionId, mcpServers: [] },
+        });
+        expect((await readResponse(client, 21)).error).toBeUndefined();
+        expect((await runPrompt(client, "Use the saved effort.")).promptResult.result.stopReason)
+          .toBe("end_turn");
+        expect(JSON.parse(gateway.requests[2]!.body)).toMatchObject({ reasoning: "low" });
+        expect(readFileSync(settingsPath, "utf8")).toBe(settings);
+        expect(gateway.requests).toHaveLength(3);
+        client.endStdin();
+        expect(await client.waitForExit()).toBe(0);
+        expect(client.stderr).toBe("");
+      } finally {
+        await client?.close();
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
 });
 
 describe.skipIf(!HAS_API_KEY)("acp: model-backed protocol", () => {

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -377,9 +377,10 @@ With --prompt-permissions, JSON and quiet requests may prompt on stderr only whe
         expect(r.code).toBe(0);
         expect(r.stderr).toBe("");
         expect(r.stdout).toContain(
-          "Usage:\n  fx acp [--model <id>] [--log-file <path>]",
+          "Usage:\n  fx acp [--model <id>] [--effort <level>] [--log-file <path>]",
         );
         expect(r.stdout).toContain("--model <id>");
+        expect(r.stdout).toContain("--effort <level>");
         expect(r.stdout).toContain("--log-file <path>");
       }
     },
@@ -402,12 +403,12 @@ With --prompt-permissions, JSON and quiet requests may prompt on stderr only whe
   test(
     "fx acp rejects unknown options and missing option values",
     async () => {
-      for (const args of [["--bogus"], ["--model"], ["--log-file"]]) {
+      for (const args of [["--bogus"], ["--model"], ["--effort"], ["--log-file"]]) {
         const result = await runFx(["acp", ...args]);
         expect(result.code).toBe(1);
         expect(result.stdout).toBe("");
         expect(result.stderr).toBe(
-          "usage: fx acp [--model <id>] [--log-file <path>]\n",
+          "usage: fx acp [--model <id>] [--effort <level>] [--log-file <path>]\n",
         );
       }
     },


### PR DESCRIPTION
## Summary

- add a typed fx acp --effort <level> startup override alongside --model
- apply it to new and loaded ACP sessions while preserving configured and saved effort preferences
- carry the effort source through startup as ConfigSource.process_override
- document the flag and cover parsing, source resolution, load selection, and gateway-wire behavior

## Why

ACP clients and launchers need a process-local way to select reasoning effort before a session exists. This advances #276 and mirrors the existing model override without writing the temporary value to settings or durable session preferences.

## Testing

- zig test -ODebug -target x86_64-linux-gnu -lc --dep build_options -Mroot=src/main.zig -Mbuild_options=<generated-options> --test-filter "parse acp args"
- same focused command for "reports the configured effort source"
- same focused command for "loaded session effort"
- zig build -Dtarget=x86_64-linux-gnu
- bun test acp.test.ts -t "--effort overrides new and loaded sessions"
- zig fmt --check src/
- git diff --check

The ACP E2E drives ./zig-out/bin/fx through new, load with the override, and load without it. The three gateway requests carry high, high, then the saved low effort; settings remain unchanged and the final process exits 0 with empty stderr.

Additional focused verification after the CLI help repair:

- `bun test cli.test.ts -t "fx acp"`: 2 passed
- `bun test acp.test.ts -t "--effort overrides new and loaded sessions"`: 1 passed

### Authenticated runtime proof

On the exact PR commit, a freshly built `./zig-out/bin/fx acp --effort high` used the authenticated Codex subscription with `gpt-5.6-sol`. A real prompt returned the requested marker with `stopReason=end_turn`; the process exited 0 with empty stderr.

### Grok runtime proof

A freshly built `./zig-out/bin/fx acp --effort high` selected the authenticated `grok` provider and `grok-4.6`; a real prompt completed with `stopReason=end_turn`, exit 0, and empty stderr.

### Vercel AI Gateway runtime proof

A freshly built `./zig-out/bin/fx acp --effort high` used the authenticated Gateway and `openai/gpt-5.2`; a real prompt completed with `stopReason=end_turn`, exit 0, and empty stderr.


### Current-main verification

Rebased onto upstream `1b87677`. The exact rebased commit passed 42 effort-focused Zig tests, the focused ACP flag E2E, both ACP CLI help tests, `zig fmt --check src/`, `git diff --check`, and a fresh `x86_64-linux-gnu` build. A real authenticated Codex prompt through `./zig-out/bin/fx acp --effort high` returned `stopReason=end_turn`; the provider trace recorded `effort=high`, and the process exited 0 with empty stderr.