### PR TITLE
Show submitted prompts before turn preparation

### DIFF
--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -564,6 +564,7 @@ pub const WorkerRuntime = struct {
     active_agent_turn_settings: ?AgentTurnSettings = null,
     active_context_snapshot: ?*const context_contract.GatheredContextSnapshot = null,
     active_prompt_snapshot_ownership: ?*ActivePromptSnapshotOwnership = null,
+    preserve_prompt_snapshot_turn_id: ?u64 = null,
 
     pub fn deinit(self: *WorkerRuntime, alloc: std.mem.Allocator) void {
         if (self.pending_permission_response) |response| {
@@ -1194,6 +1195,31 @@ pub const WorkerRuntime = struct {
         self.worker_mutex.lockUncancelable(io_mod.getIo());
         defer self.worker_mutex.unlock(io_mod.getIo());
 
+        self.clearQueuedPromptsLocked(alloc, retained_images);
+    }
+
+    /// Clears the queue while atomically transferring deletion responsibility
+    /// for a matching active or finished turn to the supplied retained images.
+    pub fn clearQueuedPromptsForSessionTransition(
+        self: *WorkerRuntime,
+        alloc: std.mem.Allocator,
+        turn_id: u64,
+        retained_images: []const types.ImageAttachment,
+    ) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+
+        if (retained_images.len > 0) {
+            _ = self.preservePromptSnapshotsLocked(turn_id, retained_images);
+        }
+        self.clearQueuedPromptsLocked(alloc, retained_images);
+    }
+
+    fn clearQueuedPromptsLocked(
+        self: *WorkerRuntime,
+        alloc: std.mem.Allocator,
+        retained_images: []const types.ImageAttachment,
+    ) void {
         const dropped = self.queued_prompt_count;
         if (dropped > 0) {
             debug_trace.logf("worker", "clear queued prompts dropped={d}", .{dropped});
@@ -1382,6 +1408,10 @@ pub const WorkerRuntime = struct {
         self.worker_mutex.lockUncancelable(io_mod.getIo());
         defer self.worker_mutex.unlock(io_mod.getIo());
         std.debug.assert(self.active_prompt_snapshot_ownership == null);
+        if (self.preserve_prompt_snapshot_turn_id == self.active_turn_id) {
+            _ = ownership.preserve();
+            self.preserve_prompt_snapshot_turn_id = null;
+        }
         self.active_prompt_snapshot_ownership = ownership;
     }
 
@@ -1406,21 +1436,20 @@ pub const WorkerRuntime = struct {
         ownership.deinit();
     }
 
-    /// Relinquishes deletion for the matching active or finished prompt. The
-    /// caller must already have established another owner for these files.
-    pub fn preservePromptSnapshots(
+    fn preservePromptSnapshotsLocked(
         self: *WorkerRuntime,
         turn_id: u64,
         images: []const types.ImageAttachment,
     ) bool {
         if (turn_id == 0 or images.len == 0) return false;
-        self.worker_mutex.lockUncancelable(io_mod.getIo());
-        defer self.worker_mutex.unlock(io_mod.getIo());
 
         var preserved = false;
         if (self.active_turn_id == turn_id) {
             if (self.active_prompt_snapshot_ownership) |ownership| {
                 preserved = ownership.preserve();
+            } else {
+                self.preserve_prompt_snapshot_turn_id = turn_id;
+                preserved = true;
             }
         }
         for (self.worker_events.items) |*event| {
@@ -2097,10 +2126,19 @@ test "active prompt snapshot ownership discards every pre-transfer boundary" {
 
 test "session transfer preserves active and finished prompt snapshots" {
     const alloc = std.testing.allocator;
-    for ([_]bool{ false, true }) |finished_before_transfer| {
+    const phases = [_]enum { take_before_begin, active, finished }{
+        .take_before_begin,
+        .active,
+        .finished,
+    };
+    for (phases) |phase| {
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
-        const name = if (finished_before_transfer) "finished.bin" else "active.bin";
+        const name = switch (phase) {
+            .take_before_begin => "take-before-begin.bin",
+            .active => "active.bin",
+            .finished => "finished.bin",
+        };
         {
             var file = try tmp.dir.createFile(std.testing.io, name, .{});
             defer file.close(std.testing.io);
@@ -2120,8 +2158,8 @@ test "session transfer preserves active and finished prompt snapshots" {
         defer runtime.deinit(alloc);
         runtime.active_turn_id = 41;
         var active = ActivePromptSnapshotOwnership.init(&images);
-        runtime.beginActivePromptSnapshots(&active);
-        if (finished_before_transfer) {
+        if (phase != .take_before_begin) runtime.beginActivePromptSnapshots(&active);
+        if (phase == .finished) {
             const ownership = (try runtime.handoffActivePromptSnapshots(alloc)) orelse
                 return error.TestExpectedSnapshotOwnership;
             try runtime.pushEvent(alloc, .{ .finish_prompt = .{
@@ -2136,8 +2174,9 @@ test "session transfer preserves active and finished prompt snapshots" {
             runtime.active_turn_id = 0;
         }
 
-        try std.testing.expect(runtime.preservePromptSnapshots(41, &images));
-        if (!finished_before_transfer) runtime.endActivePromptSnapshots(&active);
+        runtime.clearQueuedPromptsForSessionTransition(alloc, 41, &images);
+        if (phase == .take_before_begin) runtime.beginActivePromptSnapshots(&active);
+        if (phase != .finished) runtime.endActivePromptSnapshots(&active);
         runtime.discardEvents(alloc);
         try std.Io.Dir.accessAbsolute(std.testing.io, path, .{});
         try std.Io.Dir.deleteFileAbsolute(std.testing.io, path);

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -82,6 +82,10 @@ pub const QueuedPrompt = struct {
     /// assistant source. Recovery still restores the source for overlap and
     /// persistence, but publishes only novel continuation text.
     recovery_source_already_presented: bool = false,
+    /// The interactive transcript already contains this exact user turn.
+    /// Worker begin publishes only its identity so the UI can consume the
+    /// pending owner without painting a duplicate card.
+    user_prompt_already_presented: bool = false,
 };
 
 pub const ActivePromptSnapshotOwnership = struct {
@@ -452,6 +456,7 @@ pub const PendingQuestionBatchSnapshot = struct {
 pub const WorkerEvent = union(enum) {
     begin_prompt: types.UserTurn,
     begin_prompt_with_skill_bindings: BeginPromptWithSkillBindings,
+    begin_presented_prompt: u64,
     append_user_feedback: []u8,
     assistant_presentation: assistant_presentation.Event,
     notification: notification_contract.Notification,
@@ -1006,7 +1011,11 @@ pub const WorkerRuntime = struct {
         if (self.worker_stop_requested or self.queued_prompts.items.len == 0) return null;
 
         const queued = self.queued_prompts.items[0];
-        if (queued.recovery_checkpoint == null) {
+        if (queued.recovery_checkpoint == null and queued.user_prompt_already_presented) {
+            try self.worker_events.append(alloc, .{
+                .begin_presented_prompt = queued.turn_id,
+            });
+        } else if (queued.recovery_checkpoint == null) {
             const begin_prompt = try types.dupeUserTurn(alloc, .{ .text = queued.prompt, .images = queued.images });
             errdefer types.freeUserTurn(alloc, begin_prompt);
             if (queued.skill_bindings.len > 0 or queued.skill_display_spans.len > 0) {
@@ -2492,6 +2501,7 @@ pub fn dupeWorkerEvent(alloc: std.mem.Allocator, event: WorkerEvent) !WorkerEven
                 .skill_display_spans = skill_display_spans,
             } };
         },
+        .begin_presented_prompt => |turn_id| .{ .begin_presented_prompt = turn_id },
         .append_user_feedback => |text| .{ .append_user_feedback = try alloc.dupe(u8, text) },
         .assistant_presentation => |presentation| .{
             .assistant_presentation = try presentation.clone(alloc),
@@ -2565,6 +2575,7 @@ pub fn freeWorkerEvent(alloc: std.mem.Allocator, event: WorkerEvent) void {
             freeSkillBindings(alloc, begin.skill_bindings);
             freeSkillDisplaySpans(alloc, begin.skill_display_spans);
         },
+        .begin_presented_prompt => {},
         .append_user_feedback => |text| alloc.free(text),
         .assistant_presentation => |presentation| {
             var owned = presentation;
@@ -3883,6 +3894,26 @@ test "waitAndTakeNextPrompt assigns turn id and resets cancellation for next pro
     defer freeEventList(alloc, &events);
     try std.testing.expectEqual(@as(usize, 1), events.items.len);
     try std.testing.expect(events.items[0] == .begin_prompt);
+}
+
+test "already-presented queued prompt emits identity without duplicating user payload" {
+    const alloc = std.testing.allocator;
+    var runtime = WorkerRuntime{};
+    defer runtime.deinit(alloc);
+
+    var queued = try makePrompt(alloc, "already visible", "model");
+    queued.turn_id = 9001;
+    queued.user_prompt_already_presented = true;
+    try runtime.enqueuePrompt(alloc, queued);
+
+    const job = (try runtime.tryTakeNextPrompt(alloc)).?;
+    defer freeQueuedPrompt(alloc, job);
+    var events = runtime.takeEvents();
+    defer freeEventList(alloc, &events);
+
+    try std.testing.expectEqual(@as(usize, 1), events.items.len);
+    try std.testing.expect(events.items[0] == .begin_presented_prompt);
+    try std.testing.expectEqual(@as(u64, 9001), events.items[0].begin_presented_prompt);
 }
 
 test "requestRecoveryPause wakes the active operation without losing pause intent" {

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -89,6 +89,8 @@ pub const QueuedPrompt = struct {
 };
 
 pub const ActivePromptSnapshotOwnership = struct {
+    /// Owns snapshot deletion until the files are transferred to accepted
+    /// history or handed to a reference-counted finished-turn owner.
     images: []const types.ImageAttachment,
     state: enum {
         active,
@@ -1446,8 +1448,12 @@ pub const WorkerRuntime = struct {
         var preserved = false;
         if (self.active_turn_id == turn_id) {
             if (self.active_prompt_snapshot_ownership) |ownership| {
-                preserved = ownership.preserve();
+                if (sameImageSnapshots(ownership.images, images)) {
+                    preserved = ownership.preserve();
+                }
             } else {
+                // The unique active turn bridges queue take to ownership
+                // registration while both operations remain mutex-serialized.
                 self.preserve_prompt_snapshot_turn_id = turn_id;
                 preserved = true;
             }
@@ -2181,6 +2187,47 @@ test "session transfer preserves active and finished prompt snapshots" {
         try std.Io.Dir.accessAbsolute(std.testing.io, path, .{});
         try std.Io.Dir.deleteFileAbsolute(std.testing.io, path);
     }
+}
+
+test "session transfer discards mismatched active prompt snapshots" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    {
+        var file = try tmp.dir.createFile(std.testing.io, "active.bin", .{});
+        defer file.close(std.testing.io);
+        try file.writeStreamingAll(std.testing.io, "snapshot");
+    }
+    const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "active.bin");
+    defer alloc.free(path);
+    const active_images = [_]types.ImageAttachment{.{
+        .id = 1,
+        .path = @constCast("/tmp/source.png"),
+        .media_type = @constCast("image/png"),
+        .snapshot_path = path,
+        .snapshot_sha256 = @constCast("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    }};
+    const unrelated_images = [_]types.ImageAttachment{.{
+        .id = 1,
+        .path = @constCast("/tmp/other.png"),
+        .media_type = @constCast("image/png"),
+        .snapshot_path = @constCast("/tmp/other.bin"),
+        .snapshot_sha256 = @constCast("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+    }};
+
+    var runtime = WorkerRuntime{};
+    defer runtime.deinit(alloc);
+    runtime.active_turn_id = 42;
+    var active = ActivePromptSnapshotOwnership.init(&active_images);
+    runtime.beginActivePromptSnapshots(&active);
+
+    runtime.clearQueuedPromptsForSessionTransition(alloc, 42, &unrelated_images);
+    runtime.endActivePromptSnapshots(&active);
+
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.accessAbsolute(std.testing.io, path, .{}),
+    );
 }
 
 test "accepted active prompt ownership does not delete history files" {

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -93,6 +93,7 @@ pub const ActivePromptSnapshotOwnership = struct {
     state: enum {
         active,
         handed_off,
+        preserved,
         discarded,
     } = .active,
     shared_ownership: ?types.SnapshotFileOwnership = null,
@@ -120,6 +121,23 @@ pub const ActivePromptSnapshotOwnership = struct {
         const ownership = (try self.ensureSharedOwnership(alloc)).?;
         self.state = .handed_off;
         return ownership;
+    }
+
+    fn preserve(self: *ActivePromptSnapshotOwnership) bool {
+        if (self.images.len == 0) return false;
+        switch (self.state) {
+            .active => {
+                if (self.shared_ownership) |ownership| ownership.transfer();
+                self.state = .preserved;
+                return true;
+            },
+            .handed_off => {
+                if (self.shared_ownership) |ownership| ownership.transfer();
+                return true;
+            },
+            .preserved => return true,
+            .discarded => return false,
+        }
     }
 
     fn deinit(self: *ActivePromptSnapshotOwnership) void {
@@ -184,6 +202,36 @@ const SnapshotFileOwnershipState = struct {
         self.transferred.store(true, .seq_cst);
     }
 };
+
+fn historyTurnImages(turn: types.HistoryTurn) []const types.ImageAttachment {
+    return switch (turn) {
+        .assistant => |value| value.user.images,
+        .background_command => |value| value.user.images,
+        .interrupted => |value| value.user.images,
+        .compacted_summary => &.{},
+    };
+}
+
+fn sameImageSnapshots(
+    left: []const types.ImageAttachment,
+    right: []const types.ImageAttachment,
+) bool {
+    if (left.len == 0 or left.len != right.len) return false;
+    for (left) |image| {
+        const other = image_attachments.findById(right, image.id) orelse return false;
+        if (!optionalBytesEqual(image.snapshot_path, other.snapshot_path) or
+            !optionalBytesEqual(image.snapshot_sha256, other.snapshot_sha256))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+fn optionalBytesEqual(left: ?[]const u8, right: ?[]const u8) bool {
+    if (left == null or right == null) return left == null and right == null;
+    return std.mem.eql(u8, left.?, right.?);
+}
 
 pub const PermissionSnapshot = struct {
     mode: types.PermissionMode,
@@ -1331,6 +1379,8 @@ pub const WorkerRuntime = struct {
         self: *WorkerRuntime,
         ownership: *ActivePromptSnapshotOwnership,
     ) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
         std.debug.assert(self.active_prompt_snapshot_ownership == null);
         self.active_prompt_snapshot_ownership = ownership;
     }
@@ -1339,6 +1389,8 @@ pub const WorkerRuntime = struct {
         self: *WorkerRuntime,
         alloc: std.mem.Allocator,
     ) !?types.SnapshotFileOwnership {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
         const ownership = self.active_prompt_snapshot_ownership orelse return null;
         return ownership.handoff(alloc);
     }
@@ -1347,9 +1399,41 @@ pub const WorkerRuntime = struct {
         self: *WorkerRuntime,
         ownership: *ActivePromptSnapshotOwnership,
     ) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
         std.debug.assert(self.active_prompt_snapshot_ownership == ownership);
         self.active_prompt_snapshot_ownership = null;
         ownership.deinit();
+    }
+
+    /// Relinquishes deletion for the matching active or finished prompt. The
+    /// caller must already have established another owner for these files.
+    pub fn preservePromptSnapshots(
+        self: *WorkerRuntime,
+        turn_id: u64,
+        images: []const types.ImageAttachment,
+    ) bool {
+        if (turn_id == 0 or images.len == 0) return false;
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+
+        var preserved = false;
+        if (self.active_turn_id == turn_id) {
+            if (self.active_prompt_snapshot_ownership) |ownership| {
+                preserved = ownership.preserve();
+            }
+        }
+        for (self.worker_events.items) |*event| {
+            if (event.* != .finish_prompt) continue;
+            const finished = &event.finish_prompt;
+            const finished_images = historyTurnImages(finished.turn);
+            if (!sameImageSnapshots(finished_images, images)) continue;
+            if (finished.snapshot_file_ownership) |ownership| {
+                ownership.transfer();
+                preserved = true;
+            }
+        }
+        return preserved;
     }
 
     pub fn propagateGrant(self: *WorkerRuntime, alloc: std.mem.Allocator, tool_name: []const u8, target_path: []const u8) !void {
@@ -2008,6 +2092,55 @@ test "active prompt snapshot ownership discards every pre-transfer boundary" {
             error.FileNotFound,
             std.Io.Dir.accessAbsolute(std.testing.io, path, .{}),
         );
+    }
+}
+
+test "session transfer preserves active and finished prompt snapshots" {
+    const alloc = std.testing.allocator;
+    for ([_]bool{ false, true }) |finished_before_transfer| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        const name = if (finished_before_transfer) "finished.bin" else "active.bin";
+        {
+            var file = try tmp.dir.createFile(std.testing.io, name, .{});
+            defer file.close(std.testing.io);
+            try file.writeStreamingAll(std.testing.io, "snapshot");
+        }
+        const path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, name);
+        defer alloc.free(path);
+        const images = [_]types.ImageAttachment{.{
+            .id = 1,
+            .path = @constCast("/tmp/source.png"),
+            .media_type = @constCast("image/png"),
+            .snapshot_path = path,
+            .snapshot_sha256 = @constCast("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        }};
+
+        var runtime = WorkerRuntime{};
+        defer runtime.deinit(alloc);
+        runtime.active_turn_id = 41;
+        var active = ActivePromptSnapshotOwnership.init(&images);
+        runtime.beginActivePromptSnapshots(&active);
+        if (finished_before_transfer) {
+            const ownership = (try runtime.handoffActivePromptSnapshots(alloc)) orelse
+                return error.TestExpectedSnapshotOwnership;
+            try runtime.pushEvent(alloc, .{ .finish_prompt = .{
+                .turn = .{ .assistant = .{
+                    .user = .{ .text = @constCast("prompt"), .images = @constCast(&images) },
+                    .assistant = @constCast("done"),
+                } },
+                .snapshot_file_ownership = ownership,
+            } });
+            ownership.release();
+            runtime.endActivePromptSnapshots(&active);
+            runtime.active_turn_id = 0;
+        }
+
+        try std.testing.expect(runtime.preservePromptSnapshots(41, &images));
+        if (!finished_before_transfer) runtime.endActivePromptSnapshots(&active);
+        runtime.discardEvents(alloc);
+        try std.Io.Dir.accessAbsolute(std.testing.io, path, .{});
+        try std.Io.Dir.deleteFileAbsolute(std.testing.io, path);
     }
 }
 

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1558,6 +1558,10 @@ pub fn Runtime(comptime App: type) type {
                 return;
             }
 
+            if (comptime @hasDecl(App, "cancelUncommittedPendingSubmission")) {
+                if (App.cancelUncommittedPendingSubmission(app)) return;
+            }
+
             if (draftHasState(app)) clearDraftState(app, "ctrl_c");
             app.shell.render_requests.request(.footer);
         }
@@ -10760,10 +10764,24 @@ const FakeSubmitApp = struct {
         }
     } = .{},
     worker: struct {
+        hold_available: bool = false,
+        held: bool = false,
+
         pub fn queuedPromptCount(_: *@This()) usize {
             return 0;
         }
+
+        pub fn tryHoldTurnStart(self: *@This()) bool {
+            if (!self.hold_available or self.held) return false;
+            self.held = true;
+            return true;
+        }
+
+        pub fn releaseTurnStartHold(self: *@This()) void {
+            self.held = false;
+        }
     } = .{},
+    submission: input_submit_runtime.State = .{},
     shell: struct {
         render_requests: render_request.RenderRequestState = .{},
         layout: types.Layout = .{
@@ -10806,6 +10824,8 @@ const FakeSubmitApp = struct {
     }
 
     fn deinit(self: *FakeSubmitApp) void {
+        if (self.submission.pending) |*pending| pending.deinit(self.alloc);
+        self.submission.pending = null;
         self.prompt_history.deinit(self.alloc);
         self.clearPendingImages();
         self.pending_images.deinit(self.alloc);
@@ -11278,6 +11298,51 @@ test "app_input_runtime submit resolves slash completion through core command sp
     try std.testing.expect(app.last_prompt == null);
     try std.testing.expectEqual(@as(usize, 0), app.input_runtime.edit_state.input.items.len);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+}
+
+test "app_input_runtime idle submit installs one pending owner before queue effects" {
+    const alloc = std.testing.allocator;
+    var app = FakeSubmitApp{ .alloc = alloc };
+    defer app.deinit();
+    app.worker.hold_available = true;
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "pending first");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try std.testing.expect(app.submission.pending != null);
+    try std.testing.expectEqualStrings("pending first", app.submission.pending.?.draft.prompt);
+    try std.testing.expectEqual(
+        input_submit_runtime.PendingPhase.awaiting_frame,
+        app.submission.pending.?.phase,
+    );
+    try std.testing.expect(app.worker.held);
+    try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
+    try std.testing.expect(app.last_prompt == null);
+    try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
+    try std.testing.expectEqual(@as(usize, 0), app.input_runtime.edit_state.input.items.len);
+    try std.testing.expect(app.shell.render_requests.hasReason(.transcript));
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+}
+
+test "app_input_runtime second Enter preserves the newer draft until pending acknowledgement" {
+    const alloc = std.testing.allocator;
+    var app = FakeSubmitApp{ .alloc = alloc };
+    defer app.deinit();
+    app.worker.hold_available = true;
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "pending first");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "newer draft");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try std.testing.expectEqualStrings("pending first", app.submission.pending.?.draft.prompt);
+    try std.testing.expectEqualStrings("newer draft", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
+    try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
+    try std.testing.expect(app.worker.held);
 }
 
 test "app_input_runtime recalls a submitted slash command with history previous" {
@@ -11834,10 +11899,11 @@ test "app_input_runtime slash command records output without a pre-frame termina
     try std.testing.expectEqual(@as(u64, 0), try sink.length(io_mod.getIo()));
 }
 
-test "app_input_runtime idle pasted prompt defers frames until worker presentation" {
+test "app_input_runtime idle pasted prompt enters the pending acknowledgement frame" {
     const alloc = std.testing.allocator;
     var app = FakeSubmitApp{ .alloc = alloc };
     defer app.deinit();
+    app.worker.hold_available = true;
 
     try app.input_runtime.edit_state.input.appendSlice(alloc, "before [Pasted text #7, 2 lines] after");
     app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
@@ -11854,11 +11920,15 @@ test "app_input_runtime idle pasted prompt defers frames until worker presentati
     try Runtime(FakeSubmitApp).submit(&app, 100);
 
     try std.testing.expect(app.last_command == null);
-    try std.testing.expectEqualStrings("before alpha\nbeta after", app.last_prompt.?);
+    try std.testing.expect(app.last_prompt == null);
+    try std.testing.expectEqualStrings(
+        "before alpha\nbeta after",
+        app.submission.pending.?.draft.prompt,
+    );
     try std.testing.expectEqual(@as(usize, 0), app.input_runtime.entities.pasted_blocks.items.len);
-    try std.testing.expect(!app.shell.render_requests.hasReason(.footer));
-    try std.testing.expect(app.shell.render_requests.submittedPromptTransitionPending());
-    try std.testing.expect(app.shell.render_requests.blocksFrameCommit());
+    try std.testing.expect(app.shell.render_requests.hasReason(.transcript));
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+    try std.testing.expect(!app.shell.render_requests.blocksFrameCommit());
 }
 
 test "app_input_runtime submit rejects oversized registered paste backing" {
@@ -11901,11 +11971,10 @@ test "app_input_runtime accepted prompt repaints while a turn is active" {
 
     try std.testing.expectEqualStrings("queued follow-up", app.last_prompt.?);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
-    try std.testing.expect(!app.shell.render_requests.submittedPromptTransitionPending());
     try std.testing.expect(!app.shell.render_requests.blocksFrameCommit());
 }
 
-test "app_input_runtime completed presentation tail defers prompt frames until canonical admission" {
+test "app_input_runtime completed presentation tail keeps the active queue path unblocked" {
     const alloc = std.testing.allocator;
     var app = FakeSubmitApp{
         .alloc = alloc,
@@ -11921,8 +11990,7 @@ test "app_input_runtime completed presentation tail defers prompt frames until c
 
     try std.testing.expectEqualStrings("paced-tail follow-up", app.last_prompt.?);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
-    try std.testing.expect(app.shell.render_requests.submittedPromptTransitionPending());
-    try std.testing.expect(app.shell.render_requests.blocksFrameCommit());
+    try std.testing.expect(!app.shell.render_requests.blocksFrameCommit());
 }
 
 test "app_input_runtime blank submit repaints without a worker event" {
@@ -11938,23 +12006,24 @@ test "app_input_runtime blank submit repaints without a worker event" {
     try std.testing.expect(app.last_prompt == null);
     try std.testing.expectEqual(@as(usize, 0), app.input_runtime.edit_state.input.items.len);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
-    try std.testing.expect(!app.shell.render_requests.submittedPromptTransitionPending());
 }
 
-test "app_input_runtime idle image-only prompt waits for begin prompt repaint" {
+test "app_input_runtime idle image-only prompt enters the pending acknowledgement frame" {
     const alloc = std.testing.allocator;
     var app = FakeSubmitApp{ .alloc = alloc };
     defer app.deinit();
+    app.worker.hold_available = true;
     try appendOwnedPendingImage(&app, 1, "/tmp/image.png");
 
     try Runtime(FakeSubmitApp).submit(&app, 100);
 
-    try std.testing.expectEqualStrings("", app.last_prompt.?);
-    try std.testing.expectEqual(@as(usize, 1), app.last_images.len);
+    try std.testing.expect(app.last_prompt == null);
+    try std.testing.expectEqualStrings("", app.submission.pending.?.draft.prompt);
+    try std.testing.expectEqual(@as(usize, 1), app.submission.pending.?.draft.images.len);
     try std.testing.expectEqual(@as(usize, 0), app.pending_images.items.len);
-    try std.testing.expect(!app.shell.render_requests.hasReason(.footer));
-    try std.testing.expect(app.shell.render_requests.submittedPromptTransitionPending());
-    try std.testing.expect(app.shell.render_requests.blocksFrameCommit());
+    try std.testing.expect(app.shell.render_requests.hasReason(.transcript));
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+    try std.testing.expect(!app.shell.render_requests.blocksFrameCommit());
 }
 
 test "app_input_runtime submit preserves direct prompt boundary whitespace" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1558,8 +1558,8 @@ pub fn Runtime(comptime App: type) type {
                 return;
             }
 
-            if (comptime @hasDecl(App, "cancelUncommittedPendingSubmission")) {
-                if (App.cancelUncommittedPendingSubmission(app)) return;
+            if (comptime @hasDecl(App, "cancelPendingSubmission")) {
+                if (App.cancelPendingSubmission(app)) return;
             }
 
             if (draftHasState(app)) clearDraftState(app, "ctrl_c");
@@ -11352,7 +11352,19 @@ test "app_input_runtime second Enter preserves the newer draft until pending ack
     try std.testing.expectEqualStrings("newer draft", app.input_runtime.edit_state.input.items);
     try std.testing.expectEqual(@as(usize, 0), app.queue_accept_count);
     try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
+    try std.testing.expectEqual(@as(usize, 1), app.preflight_count);
+    try std.testing.expectEqual(@as(usize, 0), app.command_count);
+    try std.testing.expectEqual(@as(usize, 0), app.capture_count);
     try std.testing.expect(app.worker.held);
+
+    app.input_runtime.inputResetState().clearCurrent(alloc);
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "/help");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try std.testing.expectEqualStrings("/help", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 1), app.preflight_count);
+    try std.testing.expectEqual(@as(usize, 0), app.command_count);
 }
 
 test "app_input_runtime recalls a submitted slash command with history previous" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -10757,7 +10757,12 @@ const FakeSubmitApp = struct {
     pending_images: std.ArrayList(types.ImageAttachment) = .empty,
     stream: types.StreamState = .{},
     pacer: struct {
+        pending: bool = false,
         completed_assistant_presentation_tail: bool = false,
+
+        pub fn hasPending(self: *const @This()) bool {
+            return self.pending;
+        }
 
         pub fn hasCompletedAssistantPresentationTail(self: *const @This()) bool {
             return self.completed_assistant_presentation_tail;
@@ -10784,6 +10789,7 @@ const FakeSubmitApp = struct {
     submission: input_submit_runtime.State = .{},
     shell: struct {
         render_requests: render_request.RenderRequestState = .{},
+        full_transcript_active: bool = false,
         layout: types.Layout = .{
             .rows = 24,
             .cols = 80,
@@ -10793,6 +10799,10 @@ const FakeSubmitApp = struct {
             .divider_bottom_row = 23,
             .hint_row = 24,
         },
+
+        pub fn fullTranscriptActive(self: *const @This()) bool {
+            return self.full_transcript_active;
+        }
     } = .{},
     next_image_id_counter: usize = 1,
     transcript: std.ArrayList(u8) = .empty,
@@ -11963,6 +11973,7 @@ test "app_input_runtime accepted prompt repaints while a turn is active" {
     const alloc = std.testing.allocator;
     var app = FakeSubmitApp{ .alloc = alloc, .stream = .{ .active = true } };
     defer app.deinit();
+    app.worker.hold_available = true;
 
     try app.input_runtime.edit_state.input.appendSlice(alloc, "queued follow-up");
     app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
@@ -11970,6 +11981,7 @@ test "app_input_runtime accepted prompt repaints while a turn is active" {
     try Runtime(FakeSubmitApp).submit(&app, 100);
 
     try std.testing.expectEqualStrings("queued follow-up", app.last_prompt.?);
+    try std.testing.expect(app.submission.pending == null);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
     try std.testing.expect(!app.shell.render_requests.blocksFrameCommit());
 }
@@ -11991,6 +12003,42 @@ test "app_input_runtime completed presentation tail keeps the active queue path 
     try std.testing.expectEqualStrings("paced-tail follow-up", app.last_prompt.?);
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
     try std.testing.expect(!app.shell.render_requests.blocksFrameCommit());
+}
+
+test "app_input_runtime pending paced output keeps the active queue path" {
+    const alloc = std.testing.allocator;
+    var app = FakeSubmitApp{
+        .alloc = alloc,
+        .pacer = .{ .pending = true },
+    };
+    defer app.deinit();
+    app.worker.hold_available = true;
+
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "paced-output follow-up");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try std.testing.expectEqualStrings("paced-output follow-up", app.last_prompt.?);
+    try std.testing.expect(app.submission.pending == null);
+    try std.testing.expect(!app.worker.held);
+}
+
+test "app_input_runtime full transcript keeps the active queue path" {
+    const alloc = std.testing.allocator;
+    var app = FakeSubmitApp{ .alloc = alloc };
+    defer app.deinit();
+    app.worker.hold_available = true;
+    app.shell.full_transcript_active = true;
+
+    try app.input_runtime.edit_state.input.appendSlice(alloc, "full-transcript follow-up");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+
+    try std.testing.expectEqualStrings("full-transcript follow-up", app.last_prompt.?);
+    try std.testing.expect(app.submission.pending == null);
+    try std.testing.expect(!app.worker.held);
 }
 
 test "app_input_runtime blank submit repaints without a worker event" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -10826,6 +10826,7 @@ const FakeSubmitApp = struct {
     capture_error_id: ?usize = null,
     capture_error: ?anyerror = null,
     fail_enqueue_after_snapshot: bool = false,
+    fail_pending_finalization: bool = false,
     fail_command_after_pending_clear: bool = false,
     snapshot_dir: ?[]const u8 = null,
 
@@ -10908,6 +10909,20 @@ const FakeSubmitApp = struct {
     pub fn ensurePromptCredential(self: *FakeSubmitApp) !bool {
         self.preflight_count += 1;
         return self.prompt_admitted;
+    }
+
+    pub fn adoptPendingUserPrompt(
+        _: *FakeSubmitApp,
+        _: *const worker_runtime.QueuedPromptDraft,
+    ) !void {}
+
+    pub fn finalizePendingSubmission(
+        self: *FakeSubmitApp,
+        _: *const worker_runtime.QueuedPromptDraft,
+    ) !void {
+        if (self.fail_pending_finalization) {
+            return error.InjectedPendingFinalizationFailure;
+        }
     }
 
     pub fn enqueuePrompt(self: *FakeSubmitApp, text: []const u8) !bool {
@@ -12254,6 +12269,52 @@ test "app_input_runtime recalled image and skill resubmit with fresh provenance"
         std.math.maxInt(usize),
         app.next_image_id_counter,
     );
+}
+
+test "app_input_runtime recalls image after post-ack finalization failure" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeTestImage(&tmp, "failed-image.png");
+    const image_path = try realTmpPath(alloc, &tmp, "failed-image.png");
+    defer alloc.free(image_path);
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const snapshot_dir = try std.fs.path.join(alloc, &.{ root, "snapshots" });
+    defer alloc.free(snapshot_dir);
+
+    var app = FakeSubmitApp{
+        .alloc = alloc,
+        .snapshot_dir = snapshot_dir,
+        .fail_pending_finalization = true,
+    };
+    defer app.deinit();
+    app.worker.hold_available = true;
+    try app.input_runtime.edit_state.input.appendSlice(alloc, image_path);
+    app.input_runtime.edit_state.cursor = image_path.len;
+
+    try Runtime(FakeSubmitApp).submit(&app, 100);
+    try std.testing.expect(app.submission.pending != null);
+    try std.testing.expectEqual(@as(usize, 1), app.input_runtime.composer_history.count());
+
+    input_submit_runtime.SubmitRuntime(FakeSubmitApp).noteCommittedFrame(&app);
+    input_submit_runtime.SubmitRuntime(FakeSubmitApp).collectPendingSubmissionFacts(&app);
+
+    try std.testing.expect(app.submission.pending == null);
+    try std.testing.expectEqual(@as(usize, 1), app.notice_count);
+    try input_completion_runtime.CompletionRuntime(FakeSubmitApp).navigatePromptHistory(
+        &app,
+        -1,
+    );
+    try std.testing.expectEqualStrings("[Image #2]", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 1), app.pending_images.items.len);
+    try std.testing.expectEqual(@as(usize, 2), app.pending_images.items[0].id);
+    try std.testing.expectEqual(@as(usize, 2), try countTestSnapshotFiles(snapshot_dir));
+
+    app.clearPendingImages();
+    try std.testing.expectEqual(@as(usize, 1), try countTestSnapshotFiles(snapshot_dir));
+    app.input_runtime.composer_history.clear(alloc);
+    try std.testing.expectEqual(@as(usize, 0), try countTestSnapshotFiles(snapshot_dir));
 }
 
 test "app_input_runtime missing auth preserves the complete composer before prompt admission" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -10771,6 +10771,7 @@ const FakeSubmitApp = struct {
     worker: struct {
         hold_available: bool = false,
         held: bool = false,
+        queued_turn_id: ?u64 = null,
 
         pub fn queuedPromptCount(_: *@This()) usize {
             return 0;
@@ -10785,6 +10786,23 @@ const FakeSubmitApp = struct {
         pub fn releaseTurnStartHold(self: *@This()) void {
             self.held = false;
         }
+
+        pub fn deleteQueuedPromptDraft(
+            self: *@This(),
+            _: std.mem.Allocator,
+            turn_id: u64,
+            _: []const types.ImageAttachment,
+        ) bool {
+            if (self.queued_turn_id != turn_id) return false;
+            self.queued_turn_id = null;
+            return true;
+        }
+
+        pub fn activeTurnId(_: *const @This()) u64 {
+            return 0;
+        }
+
+        pub fn requestCancel(_: *@This()) void {}
     } = .{},
     submission: input_submit_runtime.State = .{},
     shell: struct {
@@ -10918,11 +10936,12 @@ const FakeSubmitApp = struct {
 
     pub fn finalizePendingSubmission(
         self: *FakeSubmitApp,
-        _: *const worker_runtime.QueuedPromptDraft,
+        draft: *const worker_runtime.QueuedPromptDraft,
     ) !void {
         if (self.fail_pending_finalization) {
             return error.InjectedPendingFinalizationFailure;
         }
+        self.worker.queued_turn_id = draft.turn_id;
     }
 
     pub fn enqueuePrompt(self: *FakeSubmitApp, text: []const u8) !bool {
@@ -12315,6 +12334,70 @@ test "app_input_runtime recalls image after post-ack finalization failure" {
     try std.testing.expectEqual(@as(usize, 1), try countTestSnapshotFiles(snapshot_dir));
     app.input_runtime.composer_history.clear(alloc);
     try std.testing.expectEqual(@as(usize, 0), try countTestSnapshotFiles(snapshot_dir));
+}
+
+test "app_input_runtime terminal pending cleanup preserves image history" {
+    const alloc = std.testing.allocator;
+    const PendingRuntime = input_submit_runtime.SubmitRuntime(FakeSubmitApp);
+    const cases = [_]struct {
+        name: []const u8,
+        queued: bool,
+        session_transition: bool,
+    }{
+        .{ .name = "ctrl-c-awaiting.png", .queued = false, .session_transition = false },
+        .{ .name = "ctrl-c-queued.png", .queued = true, .session_transition = false },
+        .{ .name = "reset-awaiting.png", .queued = false, .session_transition = true },
+        .{ .name = "reset-queued.png", .queued = true, .session_transition = true },
+    };
+
+    for (cases) |case| {
+        var tmp = std.testing.tmpDir(.{});
+        defer tmp.cleanup();
+        try writeTestImage(&tmp, case.name);
+        const image_path = try realTmpPath(alloc, &tmp, case.name);
+        defer alloc.free(image_path);
+        const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+        defer alloc.free(root);
+        const snapshot_dir = try std.fs.path.join(alloc, &.{ root, "snapshots" });
+        defer alloc.free(snapshot_dir);
+
+        var app = FakeSubmitApp{ .alloc = alloc, .snapshot_dir = snapshot_dir };
+        defer app.deinit();
+        app.worker.hold_available = true;
+        try app.input_runtime.edit_state.input.appendSlice(alloc, image_path);
+        app.input_runtime.edit_state.cursor = image_path.len;
+        try Runtime(FakeSubmitApp).submit(&app, 100);
+        if (case.queued) {
+            PendingRuntime.noteCommittedFrame(&app);
+            PendingRuntime.collectPendingSubmissionFacts(&app);
+            try std.testing.expectEqual(
+                input_submit_runtime.PendingPhase.queued,
+                app.submission.pending.?.phase,
+            );
+        }
+
+        if (case.session_transition) {
+            PendingRuntime.clearPendingSubmission(&app, "session_transition");
+            app.input_runtime.inputResetState().resetForSession(alloc);
+            app.worker.queued_turn_id = null;
+        } else {
+            try std.testing.expect(PendingRuntime.cancelPendingSubmission(&app));
+        }
+
+        try std.testing.expect(app.submission.pending == null);
+        try std.testing.expectEqual(@as(usize, 1), try countTestSnapshotFiles(snapshot_dir));
+        try input_completion_runtime.CompletionRuntime(FakeSubmitApp).navigatePromptHistory(
+            &app,
+            -1,
+        );
+        try std.testing.expectEqualStrings("[Image #2]", app.input_runtime.edit_state.input.items);
+        try std.testing.expectEqual(@as(usize, 2), try countTestSnapshotFiles(snapshot_dir));
+
+        app.clearPendingImages();
+        try std.testing.expectEqual(@as(usize, 1), try countTestSnapshotFiles(snapshot_dir));
+        app.input_runtime.composer_history.clear(alloc);
+        try std.testing.expectEqual(@as(usize, 0), try countTestSnapshotFiles(snapshot_dir));
+    }
 }
 
 test "app_input_runtime missing auth preserves the complete composer before prompt admission" {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -10826,12 +10826,13 @@ const FakeSubmitApp = struct {
             self.queued_images_alloc = null;
         }
 
-        pub fn preservePromptSnapshots(
-            _: *@This(),
+        pub fn clearQueuedPromptsForSessionTransition(
+            self: *@This(),
+            alloc: std.mem.Allocator,
             _: u64,
-            _: []const types.ImageAttachment,
-        ) bool {
-            return false;
+            retained_images: []const types.ImageAttachment,
+        ) void {
+            self.clearQueuedPrompts(alloc, retained_images);
         }
 
         pub fn activeTurnId(_: *const @This()) u64 {

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -10772,6 +10772,8 @@ const FakeSubmitApp = struct {
         hold_available: bool = false,
         held: bool = false,
         queued_turn_id: ?u64 = null,
+        queued_images: []types.ImageAttachment = &.{},
+        queued_images_alloc: ?std.mem.Allocator = null,
 
         pub fn queuedPromptCount(_: *@This()) usize {
             return 0;
@@ -10791,11 +10793,45 @@ const FakeSubmitApp = struct {
             self: *@This(),
             _: std.mem.Allocator,
             turn_id: u64,
-            _: []const types.ImageAttachment,
+            retained_images: []const types.ImageAttachment,
         ) bool {
             if (self.queued_turn_id != turn_id) return false;
+            image_attachments.deleteUnreferencedImageSnapshots(
+                self.queued_images,
+                retained_images,
+            );
+            self.freeQueuedImageMetadata();
             self.queued_turn_id = null;
             return true;
+        }
+
+        pub fn clearQueuedPrompts(
+            self: *@This(),
+            _: std.mem.Allocator,
+            retained_images: []const types.ImageAttachment,
+        ) void {
+            image_attachments.deleteUnreferencedImageSnapshots(
+                self.queued_images,
+                retained_images,
+            );
+            self.freeQueuedImageMetadata();
+            self.queued_turn_id = null;
+        }
+
+        fn freeQueuedImageMetadata(self: *@This()) void {
+            if (self.queued_images_alloc) |alloc| {
+                types.freeImageAttachmentSlice(alloc, self.queued_images);
+            }
+            self.queued_images = &.{};
+            self.queued_images_alloc = null;
+        }
+
+        pub fn preservePromptSnapshots(
+            _: *@This(),
+            _: u64,
+            _: []const types.ImageAttachment,
+        ) bool {
+            return false;
         }
 
         pub fn activeTurnId(_: *const @This()) u64 {
@@ -10867,6 +10903,7 @@ const FakeSubmitApp = struct {
         types.freeImageAttachmentSlice(self.alloc, self.last_images);
         self.clearLastSkillTokens();
         self.last_skill_tokens.deinit(self.alloc);
+        self.worker.freeQueuedImageMetadata();
     }
 
     pub fn writeDomainNotice(self: *FakeSubmitApp, notice: types.SemanticNotice, _: bool) !void {
@@ -10941,6 +10978,12 @@ const FakeSubmitApp = struct {
         if (self.fail_pending_finalization) {
             return error.InjectedPendingFinalizationFailure;
         }
+        self.worker.freeQueuedImageMetadata();
+        self.worker.queued_images = try types.dupeImageAttachmentSlice(
+            self.alloc,
+            draft.images,
+        );
+        self.worker.queued_images_alloc = self.alloc;
         self.worker.queued_turn_id = draft.turn_id;
     }
 
@@ -12377,9 +12420,8 @@ test "app_input_runtime terminal pending cleanup preserves image history" {
         }
 
         if (case.session_transition) {
-            PendingRuntime.clearPendingSubmission(&app, "session_transition");
+            PendingRuntime.clearPendingSubmissionForSessionTransition(&app);
             app.input_runtime.inputResetState().resetForSession(alloc);
-            app.worker.queued_turn_id = null;
         } else {
             try std.testing.expect(PendingRuntime.cancelPendingSubmission(&app));
         }

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -281,77 +281,6 @@ fn buildPendingCardProjection(
     };
 }
 
-test "pending prompt projection waits for a paintable terminal width" {
-    const alloc = std.testing.allocator;
-    const input_submit_runtime = @import("input_submit_runtime.zig");
-    const TestApp = struct {
-        alloc: std.mem.Allocator,
-        submission: input_submit_runtime.State,
-    };
-    const prompt = try alloc.dupe(u8, "visible prompt");
-    var app = TestApp{
-        .alloc = alloc,
-        .submission = .{ .pending = .{ .draft = .{
-            .turn_id = 1,
-            .prompt = prompt,
-            .images = &.{},
-            .skill_display_spans = &.{},
-        } } },
-    };
-    defer app.submission.pending.?.deinit(alloc);
-
-    for ([_]u16{ 1, 2 }) |cols| {
-        var shell = transcript_runtime.TranscriptRuntime{
-            .layout = .{
-                .rows = 4,
-                .cols = cols,
-                .content_bottom = 1,
-                .divider_top_row = 2,
-                .input_row = 2,
-                .divider_bottom_row = 3,
-                .hint_row = 4,
-            },
-            .cursor_row = 1,
-            .cursor_col = 1,
-        };
-        defer shell.deinit(alloc);
-
-        try std.testing.expect((try buildPendingCardProjection(
-            TestApp,
-            &app,
-            &shell,
-            null,
-        )) == null);
-        try std.testing.expectEqual(
-            input_submit_runtime.PendingPhase.awaiting_frame,
-            app.submission.pending.?.phase,
-        );
-    }
-
-    var resized_shell = transcript_runtime.TranscriptRuntime{
-        .layout = .{
-            .rows = 4,
-            .cols = 80,
-            .content_bottom = 1,
-            .divider_top_row = 2,
-            .input_row = 2,
-            .divider_bottom_row = 3,
-            .hint_row = 4,
-        },
-        .cursor_row = 1,
-        .cursor_col = 1,
-    };
-    defer resized_shell.deinit(alloc);
-    var projection = (try buildPendingCardProjection(
-        TestApp,
-        &app,
-        &resized_shell,
-        null,
-    )).?;
-    defer projection.deinit(alloc);
-    try std.testing.expect(projection.paint_row_count > 0);
-}
-
 fn pendingCardTerminalWireBytes(
     alloc: std.mem.Allocator,
     logical: []const u8,
@@ -3953,6 +3882,77 @@ fn solveFixedPointForTest(
         FixedPointTestContext.prepareCandidate,
         FixedPointTestContext.resolveCandidate,
     );
+}
+
+test "pending prompt projection waits for a paintable terminal width" {
+    const alloc = std.testing.allocator;
+    const input_submit_runtime = @import("input_submit_runtime.zig");
+    const TestApp = struct {
+        alloc: std.mem.Allocator,
+        submission: input_submit_runtime.State,
+    };
+    const prompt = try alloc.dupe(u8, "visible prompt");
+    var app = TestApp{
+        .alloc = alloc,
+        .submission = .{ .pending = .{ .draft = .{
+            .turn_id = 1,
+            .prompt = prompt,
+            .images = &.{},
+            .skill_display_spans = &.{},
+        } } },
+    };
+    defer app.submission.pending.?.deinit(alloc);
+
+    for ([_]u16{ 1, 2 }) |cols| {
+        var shell = transcript_runtime.TranscriptRuntime{
+            .layout = .{
+                .rows = 4,
+                .cols = cols,
+                .content_bottom = 1,
+                .divider_top_row = 2,
+                .input_row = 2,
+                .divider_bottom_row = 3,
+                .hint_row = 4,
+            },
+            .cursor_row = 1,
+            .cursor_col = 1,
+        };
+        defer shell.deinit(alloc);
+
+        try std.testing.expect((try buildPendingCardProjection(
+            TestApp,
+            &app,
+            &shell,
+            null,
+        )) == null);
+        try std.testing.expectEqual(
+            input_submit_runtime.PendingPhase.awaiting_frame,
+            app.submission.pending.?.phase,
+        );
+    }
+
+    var resized_shell = transcript_runtime.TranscriptRuntime{
+        .layout = .{
+            .rows = 4,
+            .cols = 80,
+            .content_bottom = 1,
+            .divider_top_row = 2,
+            .input_row = 2,
+            .divider_bottom_row = 3,
+            .hint_row = 4,
+        },
+        .cursor_row = 1,
+        .cursor_col = 1,
+    };
+    defer resized_shell.deinit(alloc);
+    var projection = (try buildPendingCardProjection(
+        TestApp,
+        &app,
+        &resized_shell,
+        null,
+    )).?;
+    defer projection.deinit(alloc);
+    try std.testing.expect(projection.paint_row_count > 0);
 }
 
 test "assistant tail writability changes remain traceable" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -198,7 +198,7 @@ const PendingCardPaintContext = struct {
         surface: *render_engine.frame_surface.FrameSurface,
     ) anyerror!void {
         const self: *PendingCardPaintContext = @ptrCast(@alignCast(raw));
-        _ = try surface.writeAnsiBand(
+        _ = try surface.writeAnsiBandNoWrap(
             self.row,
             self.max_rows,
             self.bytes,
@@ -238,28 +238,36 @@ fn buildPendingCardProjection(
         };
     }
 
-    const card = try user_message_card.buildUserPromptCardWithSkillTokensForTerminalPresentationInterruptible(
+    const has_prior_turns = if (comptime @hasField(App, "session"))
+        app.session.historyLen() > 0
+    else
+        false;
+    const cursor_row = @min(
+        @max(presentation_shell.cursor_row, 1),
+        presentation_shell.layout.content_bottom,
+    );
+    const leading_blank_rows: u16 = @intFromBool(
+        !has_prior_turns and
+            presentation_shell.cursor_col != 1 and
+            cursor_row < presentation_shell.layout.content_bottom,
+    );
+    const available_rows = presentation_shell.layout.content_bottom - cursor_row + 1 -| leading_blank_rows;
+    const card = try user_message_card.buildUserPromptCardTailForTerminalPresentationInterruptible(
         app.alloc,
         pending.draft.prompt,
         pending.draft.images,
         presentation_shell.layout.cols,
         skill_tokens,
+        @max(available_rows, 1),
         checkpoint,
     );
     defer app.alloc.free(card);
-    const has_prior_turns = if (comptime @hasField(App, "session"))
-        app.session.historyLen() > 0
-    else
-        false;
-    const leading_blank_rows: u16 = @intFromBool(
-        !has_prior_turns and presentation_shell.cursor_col != 1,
-    );
     const bytes = try pendingCardTerminalWireBytes(app.alloc, card);
     const rendered_line_count: u16 = @intCast(@min(
         std.mem.count(u8, card, "\n"),
         @as(usize, std.math.maxInt(u16)),
     ));
-    const paint_row_count = rendered_line_count +| 1;
+    const paint_row_count = rendered_line_count;
     const row_count = rendered_line_count +| leading_blank_rows;
     if (row_count == 0) {
         app.alloc.free(bytes);
@@ -277,21 +285,25 @@ fn pendingCardTerminalWireBytes(
     alloc: std.mem.Allocator,
     logical: []const u8,
 ) ![]u8 {
+    var logical_end = logical.len;
+    if (logical_end > 0 and logical[logical_end - 1] == '\n') logical_end -= 1;
+    if (logical_end > 0 and logical[logical_end - 1] == '\r') logical_end -= 1;
+    const source = logical[0..logical_end];
     var missing_carriage_returns: usize = 0;
-    for (logical, 0..) |byte, index| {
-        if (byte == '\n' and (index == 0 or logical[index - 1] != '\r')) {
+    for (source, 0..) |byte, index| {
+        if (byte == '\n' and (index == 0 or source[index - 1] != '\r')) {
             missing_carriage_returns += 1;
         }
     }
     const wire_len = try std.math.add(
         usize,
-        logical.len,
+        source.len,
         missing_carriage_returns,
     );
     const wire = try alloc.alloc(u8, wire_len);
     var written: usize = 0;
-    for (logical, 0..) |byte, index| {
-        if (byte == '\n' and (index == 0 or logical[index - 1] != '\r')) {
+    for (source, 0..) |byte, index| {
+        if (byte == '\n' and (index == 0 or source[index - 1] != '\r')) {
             wire[written] = '\r';
             written += 1;
         }
@@ -3581,6 +3593,15 @@ fn FixedPointTranscriptContext(comptime App: type) type {
             const candidate_rows = candidate.transcript_area.height();
             if (!self.prepare_transcript or candidate.transcript_area.isEmpty()) {
                 return .{ .occupied_transcript_rows = candidate_rows };
+            }
+            if (transcriptAreaBeforePendingTail(
+                candidate.transcript_area,
+                self.pending_tail_rows,
+            ).isEmpty()) {
+                return .{ .occupied_transcript_rows = @min(
+                    self.pending_tail_rows,
+                    candidate_rows,
+                ) };
             }
             const source = self.source orelse return error.MissingTranscriptPreparationSource;
             const prepared = if (self.prepared_transcript.*) |*value| value else return error.MissingTranscriptPaint;

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -179,7 +179,7 @@ const PendingCardProjection = struct {
     bytes: []u8,
     row_count: u16,
     paint_row_count: u16,
-    leading_blank_rows: u16,
+    leading_advance_rows: u16,
 
     fn deinit(self: *PendingCardProjection, alloc: std.mem.Allocator) void {
         alloc.free(self.bytes);
@@ -206,6 +206,19 @@ const PendingCardPaintContext = struct {
         );
     }
 };
+
+fn pendingCardLeadingAdvanceRows(
+    has_prior_turns: bool,
+    cursor_row: u16,
+    cursor_col: u16,
+    content_bottom: u16,
+) u16 {
+    if (has_prior_turns or cursor_col == 1 or cursor_row >= content_bottom) return 0;
+    return render_engine.transcript_blocks.blockSeparatorNewlineCount(
+        .unknown_raw,
+        .user_turn,
+    );
+}
 
 fn buildPendingCardProjection(
     comptime App: type,
@@ -245,12 +258,13 @@ fn buildPendingCardProjection(
         @max(presentation_shell.cursor_row, 1),
         presentation_shell.layout.content_bottom,
     );
-    const leading_blank_rows: u16 = @intFromBool(
-        !has_prior_turns and
-            presentation_shell.cursor_col != 1 and
-            cursor_row < presentation_shell.layout.content_bottom,
+    const leading_advance_rows = pendingCardLeadingAdvanceRows(
+        has_prior_turns,
+        cursor_row,
+        presentation_shell.cursor_col,
+        presentation_shell.layout.content_bottom,
     );
-    const available_rows = presentation_shell.layout.content_bottom - cursor_row + 1 -| leading_blank_rows;
+    const available_rows = presentation_shell.layout.content_bottom - cursor_row + 1 -| leading_advance_rows;
     const card = try user_message_card.buildUserPromptCardTailForTerminalPresentationInterruptible(
         app.alloc,
         pending.draft.prompt,
@@ -268,7 +282,7 @@ fn buildPendingCardProjection(
         @as(usize, std.math.maxInt(u16)),
     ));
     const paint_row_count = rendered_line_count;
-    const row_count = rendered_line_count +| leading_blank_rows;
+    const row_count = rendered_line_count +| leading_advance_rows;
     if (row_count == 0) {
         app.alloc.free(bytes);
         return error.EmptyPendingPromptCard;
@@ -277,7 +291,7 @@ fn buildPendingCardProjection(
         .bytes = bytes,
         .row_count = row_count,
         .paint_row_count = paint_row_count,
-        .leading_blank_rows = leading_blank_rows,
+        .leading_advance_rows = leading_advance_rows,
     };
 }
 
@@ -2247,7 +2261,7 @@ pub fn Runtime(comptime App: type) type {
                 .row = (if (prepared_transcript) |*prepared|
                     prepared.cursor.cursor_row
                 else
-                    presentation_shell.cursor_row) +| card.leading_blank_rows,
+                    presentation_shell.cursor_row) +| card.leading_advance_rows,
                 .max_rows = card.paint_row_count,
             } else null;
             if (pending_paint_ctx) |paint_ctx| switch (transcript_body) {
@@ -3953,6 +3967,25 @@ test "pending prompt projection waits for a paintable terminal width" {
     )).?;
     defer projection.deinit(alloc);
     try std.testing.expect(projection.paint_row_count > 0);
+}
+
+test "pending prompt uses the canonical user turn boundary" {
+    try std.testing.expectEqual(
+        @as(u16, 2),
+        pendingCardLeadingAdvanceRows(false, 8, 47, 20),
+    );
+    try std.testing.expectEqual(
+        @as(u16, 0),
+        pendingCardLeadingAdvanceRows(true, 8, 47, 20),
+    );
+    try std.testing.expectEqual(
+        @as(u16, 0),
+        pendingCardLeadingAdvanceRows(false, 8, 1, 20),
+    );
+    try std.testing.expectEqual(
+        @as(u16, 0),
+        pendingCardLeadingAdvanceRows(false, 20, 47, 20),
+    );
 }
 
 test "assistant tail writability changes remain traceable" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -214,10 +214,11 @@ fn pendingCardLeadingAdvanceRows(
     content_bottom: u16,
 ) u16 {
     if (has_prior_turns or cursor_col == 1 or cursor_row >= content_bottom) return 0;
-    return render_engine.transcript_blocks.blockSeparatorNewlineCount(
+    const canonical_rows = render_engine.transcript_blocks.blockSeparatorNewlineCount(
         .unknown_raw,
         .user_turn,
     );
+    return @min(canonical_rows, content_bottom - cursor_row);
 }
 
 fn buildPendingCardProjection(
@@ -3985,6 +3986,10 @@ test "pending prompt uses the canonical user turn boundary" {
     try std.testing.expectEqual(
         @as(u16, 0),
         pendingCardLeadingAdvanceRows(false, 20, 47, 20),
+    );
+    try std.testing.expectEqual(
+        @as(u16, 1),
+        pendingCardLeadingAdvanceRows(false, 19, 47, 20),
     );
 }
 

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -208,12 +208,11 @@ const PendingCardPaintContext = struct {
 };
 
 fn pendingCardLeadingAdvanceRows(
-    has_prior_turns: bool,
     cursor_row: u16,
     cursor_col: u16,
     content_bottom: u16,
 ) u16 {
-    if (has_prior_turns or cursor_col == 1 or cursor_row >= content_bottom) return 0;
+    if (cursor_col == 1 or cursor_row >= content_bottom) return 0;
     const canonical_rows = render_engine.transcript_blocks.blockSeparatorNewlineCount(
         .unknown_raw,
         .user_turn,
@@ -251,16 +250,11 @@ fn buildPendingCardProjection(
         };
     }
 
-    const has_prior_turns = if (comptime @hasField(App, "session"))
-        app.session.historyLen() > 0
-    else
-        false;
     const cursor_row = @min(
         @max(presentation_shell.cursor_row, 1),
         presentation_shell.layout.content_bottom,
     );
     const leading_advance_rows = pendingCardLeadingAdvanceRows(
-        has_prior_turns,
         cursor_row,
         presentation_shell.cursor_col,
         presentation_shell.layout.content_bottom,
@@ -3973,23 +3967,19 @@ test "pending prompt projection waits for a paintable terminal width" {
 test "pending prompt uses the canonical user turn boundary" {
     try std.testing.expectEqual(
         @as(u16, 2),
-        pendingCardLeadingAdvanceRows(false, 8, 47, 20),
+        pendingCardLeadingAdvanceRows(8, 47, 20),
     );
     try std.testing.expectEqual(
         @as(u16, 0),
-        pendingCardLeadingAdvanceRows(true, 8, 47, 20),
+        pendingCardLeadingAdvanceRows(8, 1, 20),
     );
     try std.testing.expectEqual(
         @as(u16, 0),
-        pendingCardLeadingAdvanceRows(false, 8, 1, 20),
-    );
-    try std.testing.expectEqual(
-        @as(u16, 0),
-        pendingCardLeadingAdvanceRows(false, 20, 47, 20),
+        pendingCardLeadingAdvanceRows(20, 47, 20),
     );
     try std.testing.expectEqual(
         @as(u16, 1),
-        pendingCardLeadingAdvanceRows(false, 19, 47, 20),
+        pendingCardLeadingAdvanceRows(19, 47, 20),
     );
 }
 

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const question_prompt = @import("../agent/question_prompt.zig");
 const input_completion_runtime = @import("input_completion_runtime.zig");
 const input_queue_runtime = @import("input_queue_runtime.zig");
-const input_submit_runtime = @import("input_submit_runtime.zig");
 const app_commands = @import("app_commands.zig");
 const app_lifecycle = @import("app_lifecycle.zig");
 const app_permission_runtime = @import("app_permission_runtime.zig");
@@ -262,6 +261,7 @@ fn buildPendingCardProjection(
         checkpoint,
     );
     defer app.alloc.free(card);
+    if (card.len == 0) return null;
     const bytes = try pendingCardTerminalWireBytes(app.alloc, card);
     const rendered_line_count: u16 = @intCast(@min(
         std.mem.count(u8, card, "\n"),
@@ -279,6 +279,77 @@ fn buildPendingCardProjection(
         .paint_row_count = paint_row_count,
         .leading_blank_rows = leading_blank_rows,
     };
+}
+
+test "pending prompt projection waits for a paintable terminal width" {
+    const alloc = std.testing.allocator;
+    const input_submit_runtime = @import("input_submit_runtime.zig");
+    const TestApp = struct {
+        alloc: std.mem.Allocator,
+        submission: input_submit_runtime.State,
+    };
+    const prompt = try alloc.dupe(u8, "visible prompt");
+    var app = TestApp{
+        .alloc = alloc,
+        .submission = .{ .pending = .{ .draft = .{
+            .turn_id = 1,
+            .prompt = prompt,
+            .images = &.{},
+            .skill_display_spans = &.{},
+        } } },
+    };
+    defer app.submission.pending.?.deinit(alloc);
+
+    for ([_]u16{ 1, 2 }) |cols| {
+        var shell = transcript_runtime.TranscriptRuntime{
+            .layout = .{
+                .rows = 4,
+                .cols = cols,
+                .content_bottom = 1,
+                .divider_top_row = 2,
+                .input_row = 2,
+                .divider_bottom_row = 3,
+                .hint_row = 4,
+            },
+            .cursor_row = 1,
+            .cursor_col = 1,
+        };
+        defer shell.deinit(alloc);
+
+        try std.testing.expect((try buildPendingCardProjection(
+            TestApp,
+            &app,
+            &shell,
+            null,
+        )) == null);
+        try std.testing.expectEqual(
+            input_submit_runtime.PendingPhase.awaiting_frame,
+            app.submission.pending.?.phase,
+        );
+    }
+
+    var resized_shell = transcript_runtime.TranscriptRuntime{
+        .layout = .{
+            .rows = 4,
+            .cols = 80,
+            .content_bottom = 1,
+            .divider_top_row = 2,
+            .input_row = 2,
+            .divider_bottom_row = 3,
+            .hint_row = 4,
+        },
+        .cursor_row = 1,
+        .cursor_col = 1,
+    };
+    defer resized_shell.deinit(alloc);
+    var projection = (try buildPendingCardProjection(
+        TestApp,
+        &app,
+        &resized_shell,
+        null,
+    )).?;
+    defer projection.deinit(alloc);
+    try std.testing.expect(projection.paint_row_count > 0);
 }
 
 fn pendingCardTerminalWireBytes(

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const question_prompt = @import("../agent/question_prompt.zig");
 const input_completion_runtime = @import("input_completion_runtime.zig");
 const input_queue_runtime = @import("input_queue_runtime.zig");
+const input_submit_runtime = @import("input_submit_runtime.zig");
 const app_commands = @import("app_commands.zig");
 const app_lifecycle = @import("app_lifecycle.zig");
 const app_permission_runtime = @import("app_permission_runtime.zig");
@@ -60,6 +61,7 @@ const resume_projection = @import("../../ui/transcript/resume_projection.zig");
 const transcript_runtime = @import("../../ui/transcript/runtime.zig");
 const ui_render = @import("../../ui/render.zig");
 const assistant_pacer = @import("../../ui/assistant/pacer.zig");
+const user_message_card = @import("../../ui/assistant/user_message_card.zig");
 
 fn set_transcript_assistant_tail_writable(
     runtime: *transcript_runtime.TranscriptRuntime,
@@ -83,6 +85,7 @@ const FrameAttemptResult = struct {
     shadow_state: render_engine.terminal_diff.ShadowCommitState,
     animation_visible: bool,
     yolo_warning_visible: bool = false,
+    pending_prompt_presented: bool = false,
 
     fn is_committed(self: FrameAttemptResult) bool {
         return self.shadow_state.is_committed();
@@ -172,6 +175,149 @@ const QueuedCardProjection = struct {
         self.* = .{};
     }
 };
+
+const PendingCardProjection = struct {
+    bytes: []u8,
+    row_count: u16,
+    paint_row_count: u16,
+    leading_blank_rows: u16,
+
+    fn deinit(self: *PendingCardProjection, alloc: std.mem.Allocator) void {
+        alloc.free(self.bytes);
+        self.* = undefined;
+    }
+};
+
+const PendingCardPaintContext = struct {
+    bytes: []const u8,
+    row: u16,
+    max_rows: u16,
+
+    fn paint(
+        raw: *anyopaque,
+        surface: *render_engine.frame_surface.FrameSurface,
+    ) anyerror!void {
+        const self: *PendingCardPaintContext = @ptrCast(@alignCast(raw));
+        _ = try surface.writeAnsiBand(
+            self.row,
+            self.max_rows,
+            self.bytes,
+            .transcript,
+            .same_owner,
+        );
+    }
+};
+
+fn buildPendingCardProjection(
+    comptime App: type,
+    app: *App,
+    presentation_shell: *const transcript_runtime.TranscriptRuntime,
+    checkpoint: ?*build_checkpoint.BuildCheckpoint,
+) !?PendingCardProjection {
+    if (comptime !@hasField(App, "submission")) return null;
+    const pending = app.submission.pending orelse return null;
+    switch (pending.phase) {
+        .awaiting_frame, .awaiting_adoption => {},
+        .adopted, .queued => return null,
+    }
+
+    const spans = pending.draft.skill_display_spans;
+    const skill_tokens: []registered_entities.SkillTokenSpan = if (spans.len == 0)
+        &.{}
+    else
+        try app.alloc.alloc(registered_entities.SkillTokenSpan, spans.len);
+    defer if (skill_tokens.len > 0) app.alloc.free(skill_tokens);
+    for (spans, 0..) |span, index| {
+        skill_tokens[index] = .{
+            .raw_start = span.raw_start,
+            .raw_end = span.raw_end,
+            .name = span.name,
+            .path = span.path,
+            .display_source = span.display_source,
+            .owns_trailing_separator = span.owns_trailing_separator,
+        };
+    }
+
+    const card = try user_message_card.buildUserPromptCardWithSkillTokensForTerminalPresentationInterruptible(
+        app.alloc,
+        pending.draft.prompt,
+        pending.draft.images,
+        presentation_shell.layout.cols,
+        skill_tokens,
+        checkpoint,
+    );
+    defer app.alloc.free(card);
+    const has_prior_turns = if (comptime @hasField(App, "session"))
+        app.session.historyLen() > 0
+    else
+        false;
+    const leading_blank_rows: u16 = @intFromBool(
+        !has_prior_turns and presentation_shell.cursor_col != 1,
+    );
+    const bytes = try pendingCardTerminalWireBytes(app.alloc, card);
+    const rendered_line_count: u16 = @intCast(@min(
+        std.mem.count(u8, card, "\n"),
+        @as(usize, std.math.maxInt(u16)),
+    ));
+    const paint_row_count = rendered_line_count +| 1;
+    const row_count = rendered_line_count +| leading_blank_rows;
+    if (row_count == 0) {
+        app.alloc.free(bytes);
+        return error.EmptyPendingPromptCard;
+    }
+    return .{
+        .bytes = bytes,
+        .row_count = row_count,
+        .paint_row_count = paint_row_count,
+        .leading_blank_rows = leading_blank_rows,
+    };
+}
+
+fn pendingCardTerminalWireBytes(
+    alloc: std.mem.Allocator,
+    logical: []const u8,
+) ![]u8 {
+    var missing_carriage_returns: usize = 0;
+    for (logical, 0..) |byte, index| {
+        if (byte == '\n' and (index == 0 or logical[index - 1] != '\r')) {
+            missing_carriage_returns += 1;
+        }
+    }
+    const wire_len = try std.math.add(
+        usize,
+        logical.len,
+        missing_carriage_returns,
+    );
+    const wire = try alloc.alloc(u8, wire_len);
+    var written: usize = 0;
+    for (logical, 0..) |byte, index| {
+        if (byte == '\n' and (index == 0 or logical[index - 1] != '\r')) {
+            wire[written] = '\r';
+            written += 1;
+        }
+        wire[written] = byte;
+        written += 1;
+    }
+    std.debug.assert(written == wire.len);
+    return wire;
+}
+
+fn previewWithPendingCard(
+    preview: render_engine.frame_layout.TranscriptFlowPreview,
+    pending: ?PendingCardProjection,
+) render_engine.frame_layout.TranscriptFlowPreview {
+    const card = pending orelse return preview;
+    var next = preview;
+    next.natural_visual_rows +|= card.row_count;
+    next.cursor_row +|= card.row_count;
+    next.cursor_col = 1;
+    next.replaceable_row = next.cursor_row;
+    next.tail_kind = .user_turn;
+    next.replaceable_active = false;
+    next.trailing_boundary_blank_rows = 0;
+    next.footer_boundary_gap_rows = 0;
+    return next;
+}
 
 // Queued prompts stay collapsed behind their summary row until the review is
 // opened; only then does the banner expand into one card per queued prompt.
@@ -962,6 +1108,7 @@ pub fn Runtime(comptime App: type) type {
                 },
                 .begin_prompt,
                 .begin_prompt_with_skill_bindings,
+                .begin_presented_prompt,
                 .append_user_feedback,
                 .notification,
                 .question_requested,
@@ -1361,6 +1508,11 @@ pub fn Runtime(comptime App: type) type {
                 render_request.animation_interval_ms,
                 result.animation_visible,
             );
+            if (comptime @hasDecl(App, "notePendingFrameCommitted")) {
+                if (result.pending_prompt_presented) {
+                    App.notePendingFrameCommitted(app);
+                }
+            }
             if (comptime @hasField(App, "permission_state") and
                 @hasField(App, "permission_engine"))
             {
@@ -1676,6 +1828,11 @@ pub fn Runtime(comptime App: type) type {
                 app.terminal.alternate_frame_layout
             else
                 app.shell.committed_frame_layout;
+            var pending_card = if (!render_reconciliation.alternate_screen_owns_rendering and child_view == null)
+                try buildPendingCardProjection(App, app, presentation_shell, checkpoint)
+            else
+                null;
+            defer if (pending_card) |*card| card.deinit(app.alloc);
 
             var attempt_invalidations = snapshot.invalidations;
             presentation_shell.normalizeFrameInvalidations(&attempt_invalidations);
@@ -1779,7 +1936,7 @@ pub fn Runtime(comptime App: type) type {
             );
             var planned_scroll_next_start_line: usize = 0;
             {
-                const transcript_preview = if (transcript_source) |source|
+                const canonical_transcript_preview = if (transcript_source) |source|
                     source.preview
                 else
                     render_engine.frame_layout.TranscriptFlowPreview{
@@ -1788,6 +1945,10 @@ pub fn Runtime(comptime App: type) type {
                         .cursor_col = presentation_shell.cursor_col,
                         .replaceable_row = presentation_shell.replaceable_row,
                     };
+                const transcript_preview = previewWithPendingCard(
+                    canonical_transcript_preview,
+                    pending_card,
+                );
                 const neutral_footer = if (footer_measurement) |*measurement|
                     measurement.frameLayoutMeasurement()
                 else
@@ -1821,6 +1982,7 @@ pub fn Runtime(comptime App: type) type {
                     else
                         footer_frame.paint.invalidation,
                     .attempt_invalidations = attempt_invalidations,
+                    .pending_tail_rows = if (pending_card) |card| card.row_count else 0,
                 };
                 const fixed_point = try render_engine.frame_fixed_point.solve(
                     FixedPointTranscriptContext(App),
@@ -2063,11 +2225,51 @@ pub fn Runtime(comptime App: type) type {
                 transition.document_append
             else
                 render_engine.frame_scroll_plan.FrameDocumentAppend{};
-            const transcript_body: render_engine.frame_builder.TranscriptBodyDisposition =
+            var transcript_body: render_engine.frame_builder.TranscriptBodyDisposition =
                 if (transcript_transition) |*transition| switch (transition.body_disposition) {
                     .paint => .paint,
                     .retain_committed => |retained| .{ .retain = retained },
                 } else .paint;
+            var pending_paint_ctx: ?PendingCardPaintContext = if (pending_card) |card| .{
+                .bytes = card.bytes,
+                .row = (if (prepared_transcript) |*prepared|
+                    prepared.cursor.cursor_row
+                else
+                    presentation_shell.cursor_row) +| card.leading_blank_rows,
+                .max_rows = card.paint_row_count,
+            } else null;
+            if (pending_paint_ctx) |paint_ctx| switch (transcript_body) {
+                .paint => {},
+                .retain => |retained_source| {
+                    const first_changed_row = paint_ctx.row;
+                    if (first_changed_row <= retained_source.source_area.top) {
+                        transcript_body = .paint;
+                    } else if (first_changed_row <= retained_source.source_area.bottom) {
+                        var narrowed = retained_source;
+                        narrowed.source_area.bottom = first_changed_row - 1;
+                        narrowed.occupied_last_row = @min(
+                            narrowed.occupied_last_row,
+                            narrowed.source_area.bottom,
+                        );
+                        transcript_body = .{ .retain = narrowed };
+                    }
+                },
+            };
+            if (pending_paint_ctx) |paint_ctx| {
+                debug_trace.logf(
+                    "frame_plan",
+                    "pending_prompt_tail start={d} paint_rows={d} layout_rows={d} bytes={d} transcript={d}..{d} body={s}",
+                    .{
+                        paint_ctx.row,
+                        paint_ctx.max_rows,
+                        pending_card.?.row_count,
+                        paint_ctx.bytes.len,
+                        footer_frame.paint.transcript_band.top,
+                        footer_frame.paint.transcript_band.bottom,
+                        @tagName(transcript_body),
+                    },
+                );
+            }
             const observation_rows = if (transcript_transition) |*transition|
                 switch (transition.body_disposition) {
                     .paint => transition.row_provenance,
@@ -2100,6 +2302,10 @@ pub fn Runtime(comptime App: type) type {
                     .document_append = document_append,
                     .terminal_transition = render_reconciliation.terminal_transition,
                     .body_painter = .{ .ctx = &frame_ctx, .paint = FramePaintContext(App).paintBody },
+                    .transcript_tail_painter = if (pending_paint_ctx) |*paint_ctx| .{
+                        .ctx = paint_ctx,
+                        .paint = PendingCardPaintContext.paint,
+                    } else null,
                     .footer_painter = .{ .ctx = &frame_ctx, .paint = FramePaintContext(App).paintFooter },
                     .activity_painter = .{ .ctx = &frame_ctx, .paint = FramePaintContext(App).paintActivity },
                     .trace_counters = &counters,
@@ -2195,6 +2401,7 @@ pub fn Runtime(comptime App: type) type {
                 .animation_visible = frame_ctx.activity_result.painted,
                 .yolo_warning_visible = !render_reconciliation.alternate_screen_owns_rendering and
                     footer_frame.composed.danger_status_visible,
+                .pending_prompt_presented = pending_card != null,
             };
         }
 
@@ -3307,6 +3514,7 @@ fn FixedPointTranscriptContext(comptime App: type) type {
         frame_activity: render_engine.frame_layout.ActivityState,
         base_invalidation: render_engine.paint_plan.FrameInvalidationSet,
         attempt_invalidations: render_engine.paint_plan.FrameInvalidationSet,
+        pending_tail_rows: u16 = 0,
         scroll_facts: ?transcript_runtime.TranscriptScrollFacts = null,
 
         fn prepareCandidate(
@@ -3324,12 +3532,23 @@ fn FixedPointTranscriptContext(comptime App: type) type {
                 .occupied_transcript_rows = candidate.transcript_area.height(),
             };
             const source = self.source orelse return error.MissingTranscriptPreparationSource;
+            const canonical_area = transcriptAreaBeforePendingTail(
+                candidate.transcript_area,
+                self.pending_tail_rows,
+            );
+            if (canonical_area.isEmpty()) return .{
+                .inline_advance_rows = 0,
+                .occupied_transcript_rows = @min(
+                    self.pending_tail_rows,
+                    candidate.transcript_area.height(),
+                ),
+            };
 
             self.prepared_transcript.* = try self.presentation_shell.prepareTranscriptSurfacePaintFromSourceForFrame(
                 self.app.alloc,
                 &self.app.metrics,
                 source,
-                candidate.transcript_area,
+                canonical_area,
                 self.footer_reservation_changed,
             );
             const prepared = &self.prepared_transcript.*.?;
@@ -3341,13 +3560,16 @@ fn FixedPointTranscriptContext(comptime App: type) type {
                 self.replay_displaced_footer_history,
             );
             self.scroll_facts = scroll_facts;
-            const occupied_transcript_rows = if (prepared.selection.last_visible_row >= candidate.transcript_area.top)
-                prepared.selection.last_visible_row - candidate.transcript_area.top + 1
+            const canonical_occupied_rows = if (prepared.selection.last_visible_row >= canonical_area.top)
+                prepared.selection.last_visible_row - canonical_area.top + 1
             else
                 0;
             return .{
                 .inline_advance_rows = scroll_facts.planned_rows,
-                .occupied_transcript_rows = occupied_transcript_rows,
+                .occupied_transcript_rows = @min(
+                    canonical_occupied_rows +| self.pending_tail_rows,
+                    candidate.transcript_area.height(),
+                ),
             };
         }
 
@@ -3410,9 +3632,21 @@ fn FixedPointTranscriptContext(comptime App: type) type {
                 activity == .overlay_entry,
             );
             self.resolved_target.* = target;
-            return .{ .occupied_transcript_rows = target.occupiedTranscriptRows() };
+            return .{ .occupied_transcript_rows = @min(
+                target.occupiedTranscriptRows() +| self.pending_tail_rows,
+                candidate.transcript_area.height(),
+            ) };
         }
     };
+}
+
+fn transcriptAreaBeforePendingTail(
+    area: render_engine.frame_layout.FrameRect,
+    tail_rows: u16,
+) render_engine.frame_layout.FrameRect {
+    if (area.isEmpty() or tail_rows == 0) return area;
+    if (tail_rows >= area.height()) return .empty();
+    return .{ .top = area.top, .bottom = area.bottom - tail_rows };
 }
 
 fn FramePaintContext(comptime App: type) type {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1531,10 +1531,14 @@ pub fn Runtime(comptime App: type) type {
             if (comptime @hasField(App, "queued_prompt_review")) {
                 input_queue_runtime.Runtime(App).reset(app);
             }
-            if (comptime @hasDecl(App, "clearPendingSubmission")) {
-                App.clearPendingSubmission(app, "session_transition");
+            if (comptime @hasDecl(App, "clearPendingSubmissionForSessionTransition")) {
+                App.clearPendingSubmissionForSessionTransition(app);
+            } else {
+                if (comptime @hasDecl(App, "clearPendingSubmission")) {
+                    App.clearPendingSubmission(app, "session_transition");
+                }
+                app.worker.clearQueuedPrompts(std.heap.c_allocator, &.{});
             }
-            app.worker.clearQueuedPrompts(std.heap.c_allocator, &.{});
         }
 
         fn applyIdleLiveSessionTransition(

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1531,7 +1531,9 @@ pub fn Runtime(comptime App: type) type {
             if (comptime @hasField(App, "queued_prompt_review")) {
                 input_queue_runtime.Runtime(App).reset(app);
             }
-            app.shell.render_requests.finishSubmittedPromptTransition();
+            if (comptime @hasDecl(App, "clearPendingSubmission")) {
+                App.clearPendingSubmission(app, "session_transition");
+            }
             app.worker.clearQueuedPrompts(std.heap.c_allocator, &.{});
         }
 

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -149,7 +149,7 @@ fn batchContainsInterruptedClosure(
 fn batchSegmentEndsInterrupted(events: []const WorkerEvent) bool {
     for (events, 0..) |event, index| {
         if (index > 0) switch (event) {
-            .begin_prompt, .begin_prompt_with_skill_bindings => return false,
+            .begin_prompt, .begin_prompt_with_skill_bindings, .begin_presented_prompt => return false,
             else => {},
         };
         const lifecycle = switch (event) {
@@ -210,6 +210,7 @@ pub fn Runtime(comptime App: type) type {
                 },
                 .begin_prompt,
                 .begin_prompt_with_skill_bindings,
+                .begin_presented_prompt,
                 .append_user_feedback,
                 .notification,
                 .question_requested,
@@ -651,7 +652,7 @@ pub fn Runtime(comptime App: type) type {
 
             events: while (batch.claim()) |event| {
                 if (!first_event) switch (event) {
-                    .begin_prompt, .begin_prompt_with_skill_bindings => {
+                    .begin_prompt, .begin_prompt_with_skill_bindings, .begin_presented_prompt => {
                         interrupted_segment = cancel_requested or
                             batchSegmentEndsInterrupted(batch.claimedAndRemaining());
                     },
@@ -700,7 +701,6 @@ pub fn Runtime(comptime App: type) type {
                         app.stream.active = true;
                         app.stream.turn_started_ms = io_mod.milliTimestamp();
                         app.shell.render_requests.request(.footer);
-                        defer app.shell.render_requests.finishSubmittedPromptTransition();
                         try handlers.write_user_prompt(handlers.ctx, prompt);
                     },
                     .begin_prompt_with_skill_bindings => |begin| {
@@ -713,11 +713,26 @@ pub fn Runtime(comptime App: type) type {
                         app.stream.active = true;
                         app.stream.turn_started_ms = io_mod.milliTimestamp();
                         app.shell.render_requests.request(.footer);
-                        defer app.shell.render_requests.finishSubmittedPromptTransition();
                         if (handlers.write_user_prompt_with_skill_bindings) |write_bound_prompt| {
                             try write_bound_prompt(handlers.ctx, begin.prompt, begin.skill_bindings, begin.skill_display_spans);
                         } else {
                             try handlers.write_user_prompt(handlers.ctx, begin.prompt);
+                        }
+                    },
+                    .begin_presented_prompt => |turn_id| {
+                        if (!try requireAssistantTextDrain(handlers)) {
+                            try retainClaimedEventAndSuffix(app, &batch, "assistant_text_drain_blocked");
+                            drain_owns_current = false;
+                            break :events;
+                        }
+                        resetStream(app, true);
+                        app.stream.active = true;
+                        app.stream.turn_started_ms = io_mod.milliTimestamp();
+                        app.shell.render_requests.request(.footer);
+                        if (comptime @hasDecl(App, "acceptPresentedPrompt")) {
+                            try App.acceptPresentedPrompt(app, turn_id);
+                        } else {
+                            return error.PresentedPromptUnsupported;
                         }
                     },
                     .append_user_feedback => |text| {
@@ -879,7 +894,6 @@ pub fn Runtime(comptime App: type) type {
                         }
                         resetStream(app, false);
                         app.shell.render_requests.request(.footer);
-                        defer app.shell.render_requests.finishSubmittedPromptTransition();
                         try handlers.error_text(handlers.ctx, notice);
                     },
                 }
@@ -2218,11 +2232,9 @@ test "core.app_worker_runtime resets turn token counters on begin and finish" {
         .active = true,
         .token_progress = .{ .input_tokens = 10, .output_tokens = 20 },
     };
-    app.shell.render_requests.beginSubmittedPromptTransition();
     try app.worker.pushEvent(std.heap.c_allocator, .{ .begin_prompt = try types.dupeUserTurn(std.heap.c_allocator, .{ .text = @constCast("next"), .images = &.{} }) });
     try tickNoop(&app);
     try std.testing.expectEqual(types.TurnTokenProgress{}, app.stream.token_progress);
-    try std.testing.expect(!app.shell.render_requests.submittedPromptTransitionPending());
     try std.testing.expect(!app.shell.render_requests.blocksFrameCommit());
 
     app.stream = .{
@@ -3812,7 +3824,6 @@ test "core.app_worker_runtime error text resets active stream and requests foote
         .assistant_text_started = true,
         .last_activity_kind = .ask,
     };
-    app.shell.render_requests.beginSubmittedPromptTransition();
     try app.worker.pushEvent(std.heap.c_allocator, .{ .error_text = .{
         .topic = "system",
         .tone = .@"error",
@@ -3825,7 +3836,6 @@ test "core.app_worker_runtime error text resets active stream and requests foote
     try std.testing.expect(capture.error_saw_drain);
     try std.testing.expect(capture.saw_reset_stream);
     try std.testing.expect(capture.saw_footer_request);
-    try std.testing.expect(!app.shell.render_requests.submittedPromptTransitionPending());
     try std.testing.expect(!app.shell.render_requests.blocksFrameCommit());
 }
 

--- a/src/core/app/input_queue_runtime.zig
+++ b/src/core/app/input_queue_runtime.zig
@@ -137,7 +137,6 @@ pub fn Runtime(comptime App: type) type {
                 app.alloc,
                 app.input_runtime.kill_ring.images.items,
             );
-            app.shell.render_requests.finishSubmittedPromptTransition();
             state.clear(app.alloc);
             app.input_runtime.inputResetState().clearCurrent(app.alloc);
             paste_blocks.clearBlocks(app.alloc, &app.input_runtime.entities.pasted_blocks);
@@ -186,7 +185,6 @@ pub fn Runtime(comptime App: type) type {
                 app.alloc.free(state.entries);
                 state.entries = &.{};
                 removed.deinit(app.alloc);
-                app.shell.render_requests.finishSubmittedPromptTransition();
                 debug_trace.eventf("input", "queue_review_draft_deleted", .{ .turn_id = turn_id }, "remaining=0", .{});
                 app.input_runtime.inputResetState().clearCurrent(app.alloc);
                 paste_blocks.clearBlocks(app.alloc, &app.input_runtime.entities.pasted_blocks);

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -39,9 +39,10 @@ pub const PendingSubmission = struct {
         return self.phase != .queued;
     }
 
-    pub fn markFrameCommitted(self: *PendingSubmission) PendingPhaseError!void {
-        if (self.phase != .awaiting_frame) return error.InvalidPendingPhase;
+    pub fn markFrameCommitted(self: *PendingSubmission) bool {
+        if (self.phase != .awaiting_frame) return false;
         self.phase = .awaiting_adoption;
+        return true;
     }
 
     pub fn markAdopted(self: *PendingSubmission) PendingPhaseError!void {
@@ -49,9 +50,10 @@ pub const PendingSubmission = struct {
         self.phase = .adopted;
     }
 
-    pub fn markQueued(self: *PendingSubmission) PendingPhaseError!void {
-        if (self.phase != .adopted) return error.InvalidPendingPhase;
+    pub fn markQueued(self: *PendingSubmission) bool {
+        if (self.phase != .adopted) return false;
         self.phase = .queued;
+        return true;
     }
 };
 
@@ -142,8 +144,7 @@ pub fn SubmitRuntime(comptime App: type) type {
         pub fn noteCommittedFrame(app: *App) void {
             if (comptime !@hasField(App, "submission")) return;
             const pending = if (app.submission.pending) |*value| value else return;
-            if (pending.phase != .awaiting_frame) return;
-            pending.markFrameCommitted() catch unreachable;
+            if (!pending.markFrameCommitted()) return;
             debug_trace.eventf(
                 "input",
                 "pending_prompt_frame_committed",
@@ -191,8 +192,17 @@ pub fn SubmitRuntime(comptime App: type) type {
                 finishPendingSubmissionFailure(app, err);
                 return;
             };
+            if (!pending.markQueued()) {
+                debug_trace.eventf(
+                    "input",
+                    "pending_prompt_queue_phase_invalid",
+                    .{ .turn_id = pending.draft.turn_id },
+                    "phase={s}",
+                    .{@tagName(pending.phase)},
+                );
+                return;
+            }
             app.worker.releaseTurnStartHold();
-            pending.markQueued() catch unreachable;
             debug_trace.eventf(
                 "input",
                 "pending_prompt_queued",
@@ -1826,20 +1836,20 @@ test "pending submission phase methods keep hold ownership explicit" {
     try std.testing.expect(pending.ownsTurnStartHold());
     try std.testing.expectError(error.InvalidPendingPhase, pending.markAdopted());
 
-    try pending.markFrameCommitted();
+    try std.testing.expect(pending.markFrameCommitted());
     try std.testing.expectEqual(PendingPhase.awaiting_adoption, pending.phase);
     try std.testing.expect(pending.ownsTurnStartHold());
-    try std.testing.expectError(error.InvalidPendingPhase, pending.markFrameCommitted());
+    try std.testing.expect(!pending.markFrameCommitted());
 
     try pending.markAdopted();
     try std.testing.expectEqual(PendingPhase.adopted, pending.phase);
     try std.testing.expect(pending.ownsTurnStartHold());
     try std.testing.expectError(error.InvalidPendingPhase, pending.markAdopted());
 
-    try pending.markQueued();
+    try std.testing.expect(pending.markQueued());
     try std.testing.expectEqual(PendingPhase.queued, pending.phase);
     try std.testing.expect(!pending.ownsTurnStartHold());
-    try std.testing.expectError(error.InvalidPendingPhase, pending.markQueued());
+    try std.testing.expect(!pending.markQueued());
     try std.testing.expectEqual(@as(u64, 41), pending.draft.turn_id);
     try std.testing.expectEqualStrings("use $review", pending.draft.prompt);
     try std.testing.expectEqual(@as(usize, 1), pending.draft.skill_display_spans.len);

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -281,6 +281,46 @@ pub fn SubmitRuntime(comptime App: type) type {
             clearPendingSubmissionWithSnapshots(app, reason, snapshot_cleanup);
         }
 
+        pub fn clearPendingSubmissionForSessionTransition(app: *App) void {
+            if (comptime !@hasField(App, "submission")) {
+                app.worker.clearQueuedPrompts(std.heap.c_allocator, &.{});
+                return;
+            }
+            const pending = app.submission.pending orelse {
+                app.worker.clearQueuedPrompts(std.heap.c_allocator, &.{});
+                return;
+            };
+            const history_owns_snapshots =
+                transferPendingImageSnapshotsToComposerHistory(app);
+            if (pending.phase == .queued) {
+                if (history_owns_snapshots) {
+                    if (comptime @hasDecl(@TypeOf(app.worker), "preservePromptSnapshots")) {
+                        _ = app.worker.preservePromptSnapshots(
+                            pending.draft.turn_id,
+                            pending.draft.images,
+                        );
+                    }
+                }
+                app.worker.clearQueuedPrompts(
+                    std.heap.c_allocator,
+                    if (history_owns_snapshots) pending.draft.images else &.{},
+                );
+                clearPendingSubmissionWithSnapshots(
+                    app,
+                    "session_transition",
+                    .preserve,
+                );
+                return;
+            }
+
+            app.worker.clearQueuedPrompts(std.heap.c_allocator, &.{});
+            clearPendingSubmissionWithSnapshots(
+                app,
+                "session_transition",
+                if (history_owns_snapshots) .preserve else .discard,
+            );
+        }
+
         fn clearPendingSubmissionWithSnapshots(
             app: *App,
             reason: []const u8,

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -126,8 +126,8 @@ pub fn SubmitRuntime(comptime App: type) type {
         };
 
         const PendingSnapshotCleanup = enum {
-            automatic,
-            transferred_to_composer_history,
+            discard,
+            preserve,
         };
 
         const AcceptedDraftProjection = struct {
@@ -222,7 +222,11 @@ pub fn SubmitRuntime(comptime App: type) type {
             const pending = app.submission.pending orelse return error.MissingPendingSubmission;
             if (pending.phase != .queued) return error.InvalidPendingPhase;
             if (pending.draft.turn_id != turn_id) return error.PendingTurnIdMismatch;
-            clearPendingSubmission(app, "worker_begin_presented");
+            clearPendingSubmissionWithSnapshots(
+                app,
+                "worker_begin_presented",
+                .preserve,
+            );
         }
 
         pub fn cancelPendingSubmission(app: *App) bool {
@@ -262,10 +266,6 @@ pub fn SubmitRuntime(comptime App: type) type {
                     );
                     return false;
                 }
-                image_attachments.discardImageSnapshots(
-                    app.alloc,
-                    app.submission.pending.?.draft.images,
-                );
             }
             clearPendingSubmission(app, "ctrl_c_pending_submission");
             app.shell.render_requests.request(.transcript);
@@ -274,7 +274,11 @@ pub fn SubmitRuntime(comptime App: type) type {
         }
 
         pub fn clearPendingSubmission(app: *App, reason: []const u8) void {
-            clearPendingSubmissionWithSnapshots(app, reason, .automatic);
+            const snapshot_cleanup: PendingSnapshotCleanup = if (transferPendingImageSnapshotsToComposerHistory(app))
+                .preserve
+            else
+                .discard;
+            clearPendingSubmissionWithSnapshots(app, reason, snapshot_cleanup);
         }
 
         fn clearPendingSubmissionWithSnapshots(
@@ -286,7 +290,7 @@ pub fn SubmitRuntime(comptime App: type) type {
             var pending = app.submission.pending orelse return;
             app.submission.pending = null;
             if (pending.ownsTurnStartHold()) app.worker.releaseTurnStartHold();
-            if (snapshot_cleanup == .automatic and pending.phase != .queued) {
+            if (snapshot_cleanup == .discard) {
                 image_attachments.discardImageSnapshots(app.alloc, pending.draft.images);
             }
             debug_trace.eventf(
@@ -318,10 +322,6 @@ pub fn SubmitRuntime(comptime App: type) type {
 
         fn finishPendingSubmissionFailure(app: *App, err: anyerror) void {
             const turn_id = app.submission.pending.?.draft.turn_id;
-            const snapshot_cleanup: PendingSnapshotCleanup = if (transferPendingImageSnapshotsToComposerHistory(app))
-                .transferred_to_composer_history
-            else
-                .automatic;
             const body = std.fmt.allocPrint(
                 app.alloc,
                 "failed to submit prompt after presentation ({s})",
@@ -332,11 +332,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                     "pending prompt failure notice allocation failed err={s}",
                     .{@errorName(notice_err)},
                 );
-                clearPendingSubmissionWithSnapshots(
-                    app,
-                    "finalization_failure",
-                    snapshot_cleanup,
-                );
+                clearPendingSubmission(app, "finalization_failure");
                 return;
             };
             defer app.alloc.free(body);
@@ -358,11 +354,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                 "err={s}",
                 .{@errorName(err)},
             );
-            clearPendingSubmissionWithSnapshots(
-                app,
-                "finalization_failure",
-                snapshot_cleanup,
-            );
+            clearPendingSubmission(app, "finalization_failure");
         }
 
         fn transferPendingImageSnapshotsToComposerHistory(app: *App) bool {

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -19,13 +19,13 @@ pub const PendingPhase = enum {
     queued,
 };
 
-pub const PendingPhaseError = error{InvalidPendingPhase};
+const PendingPhaseError = error{InvalidPendingPhase};
 
 pub const PendingSubmission = struct {
     draft: worker_runtime.QueuedPromptDraft,
     phase: PendingPhase = .awaiting_frame,
 
-    pub fn init(draft: worker_runtime.QueuedPromptDraft) PendingSubmission {
+    fn init(draft: worker_runtime.QueuedPromptDraft) PendingSubmission {
         std.debug.assert(draft.turn_id != 0);
         return .{ .draft = draft };
     }
@@ -35,22 +35,22 @@ pub const PendingSubmission = struct {
         self.* = undefined;
     }
 
-    pub fn ownsTurnStartHold(self: PendingSubmission) bool {
+    fn ownsTurnStartHold(self: PendingSubmission) bool {
         return self.phase != .queued;
     }
 
-    pub fn markFrameCommitted(self: *PendingSubmission) bool {
+    fn markFrameCommitted(self: *PendingSubmission) bool {
         if (self.phase != .awaiting_frame) return false;
         self.phase = .awaiting_adoption;
         return true;
     }
 
-    pub fn markAdopted(self: *PendingSubmission) PendingPhaseError!void {
+    fn markAdopted(self: *PendingSubmission) PendingPhaseError!void {
         if (self.phase != .awaiting_adoption) return error.InvalidPendingPhase;
         self.phase = .adopted;
     }
 
-    pub fn markQueued(self: *PendingSubmission) bool {
+    fn markQueued(self: *PendingSubmission) bool {
         if (self.phase != .adopted) return false;
         self.phase = .queued;
         return true;
@@ -61,7 +61,7 @@ pub const State = struct {
     pending: ?PendingSubmission = null,
 };
 
-pub fn buildQueuedPromptDraft(
+fn buildQueuedPromptDraft(
     alloc: std.mem.Allocator,
     turn_id: u64,
     prompt_source: []const u8,
@@ -222,11 +222,45 @@ pub fn SubmitRuntime(comptime App: type) type {
             clearPendingSubmission(app, "worker_begin_presented");
         }
 
-        pub fn cancelUncommittedPendingSubmission(app: *App) bool {
+        pub fn cancelPendingSubmission(app: *App) bool {
             if (comptime !@hasField(App, "submission")) return false;
             const pending = app.submission.pending orelse return false;
-            if (pending.phase != .awaiting_frame) return false;
-            clearPendingSubmission(app, "ctrl_c_before_frame");
+            if (pending.phase == .queued) {
+                if (comptime !@hasDecl(@TypeOf(app.worker), "deleteQueuedPromptDraft")) {
+                    return false;
+                }
+                if (!app.worker.deleteQueuedPromptDraft(
+                    std.heap.c_allocator,
+                    pending.draft.turn_id,
+                    pending.draft.images,
+                )) {
+                    if (comptime @hasDecl(@TypeOf(app.worker), "activeTurnId") and
+                        @hasDecl(@TypeOf(app.worker), "requestCancel"))
+                    {
+                        if (app.worker.activeTurnId() == pending.draft.turn_id) {
+                            app.worker.requestCancel();
+                            debug_trace.eventf(
+                                "input",
+                                "pending_prompt_active_cancel_requested",
+                                .{ .turn_id = pending.draft.turn_id },
+                                "",
+                                .{},
+                            );
+                            app.shell.render_requests.request(.footer);
+                            return true;
+                        }
+                    }
+                    debug_trace.eventf(
+                        "input",
+                        "pending_prompt_cancel_missed",
+                        .{ .turn_id = pending.draft.turn_id },
+                        "phase={s}",
+                        .{@tagName(pending.phase)},
+                    );
+                    return false;
+                }
+            }
+            clearPendingSubmission(app, "ctrl_c_pending_submission");
             app.shell.render_requests.request(.transcript);
             app.shell.render_requests.request(.footer);
             return true;
@@ -306,6 +340,18 @@ pub fn SubmitRuntime(comptime App: type) type {
         }
 
         pub fn submit(app: *App, max_prompt_history: usize) !void {
+            if (comptime @hasField(App, "submission")) {
+                if (app.submission.pending) |pending| {
+                    debug_trace.eventf(
+                        "input",
+                        "prompt_submit_deferred_for_pending",
+                        .{ .turn_id = pending.draft.turn_id },
+                        "phase={s}",
+                        .{@tagName(pending.phase)},
+                    );
+                    return;
+                }
+            }
             const expanded_len = paste_blocks.expandedLen(
                 app.input_runtime.edit_state.input.items,
                 app.input_runtime.entities.pasted_blocks.items,
@@ -1893,12 +1939,39 @@ const PendingLifecycleFake = struct {
     worker: struct {
         held: bool = true,
         release_count: usize = 0,
+        queued_turn_id: ?u64 = null,
+        active_turn_id: u64 = 0,
+        delete_count: usize = 0,
+        cancel_count: usize = 0,
 
         pub fn releaseTurnStartHold(self: *@This()) void {
             if (!self.held) return;
             self.held = false;
             self.release_count += 1;
         }
+
+        pub fn deleteQueuedPromptDraft(
+            self: *@This(),
+            _: std.mem.Allocator,
+            turn_id: u64,
+            _: []const types.ImageAttachment,
+        ) bool {
+            if (self.queued_turn_id == null or self.queued_turn_id.? != turn_id) return false;
+            self.queued_turn_id = null;
+            self.delete_count += 1;
+            return true;
+        }
+
+        pub fn activeTurnId(self: *@This()) u64 {
+            return self.active_turn_id;
+        }
+
+        pub fn requestCancel(self: *@This()) void {
+            self.cancel_count += 1;
+        }
+    } = .{},
+    shell: struct {
+        render_requests: @import("../../ui/render_request.zig").RenderRequestState = .{},
     } = .{},
     adoption_failures_remaining: usize = 0,
     adoption_count: usize = 0,
@@ -1923,10 +1996,11 @@ const PendingLifecycleFake = struct {
 
     pub fn finalizePendingSubmission(
         self: *PendingLifecycleFake,
-        _: *const worker_runtime.QueuedPromptDraft,
+        draft: *const worker_runtime.QueuedPromptDraft,
     ) !void {
         self.finalization_count += 1;
         if (self.finalization_error) return error.InjectedFinalizationFailure;
+        self.worker.queued_turn_id = draft.turn_id;
     }
 
     pub fn writeDomainNotice(
@@ -1996,4 +2070,62 @@ test "post-ack finalization failure leaves notice and consumes pending owner" {
     try std.testing.expectEqual(@as(usize, 1), app.adoption_count);
     try std.testing.expectEqual(@as(usize, 1), app.finalization_count);
     try std.testing.expectEqual(@as(usize, 1), app.notice_count);
+}
+
+test "Ctrl+C cancels pending ownership from every pre-worker phase" {
+    const Runtime = SubmitRuntime(PendingLifecycleFake);
+
+    var awaiting_frame = try pendingLifecycleFake(std.testing.allocator, 801);
+    defer awaiting_frame.deinit();
+    try std.testing.expect(Runtime.cancelPendingSubmission(&awaiting_frame));
+    try std.testing.expect(awaiting_frame.submission.pending == null);
+    try std.testing.expectEqual(@as(usize, 1), awaiting_frame.worker.release_count);
+
+    var awaiting_adoption = try pendingLifecycleFake(std.testing.allocator, 802);
+    defer awaiting_adoption.deinit();
+    awaiting_adoption.adoption_failures_remaining = 1;
+    Runtime.noteCommittedFrame(&awaiting_adoption);
+    try std.testing.expectEqual(PendingPhase.awaiting_adoption, awaiting_adoption.submission.pending.?.phase);
+    try std.testing.expect(Runtime.cancelPendingSubmission(&awaiting_adoption));
+    try std.testing.expect(awaiting_adoption.submission.pending == null);
+    try std.testing.expectEqual(@as(usize, 1), awaiting_adoption.worker.release_count);
+    try std.testing.expect(awaiting_adoption.shell.render_requests.hasReason(.transcript));
+    try std.testing.expect(awaiting_adoption.shell.render_requests.hasReason(.footer));
+
+    var adopted = try pendingLifecycleFake(std.testing.allocator, 803);
+    defer adopted.deinit();
+    Runtime.noteCommittedFrame(&adopted);
+    try std.testing.expectEqual(PendingPhase.adopted, adopted.submission.pending.?.phase);
+    try std.testing.expect(Runtime.cancelPendingSubmission(&adopted));
+    try std.testing.expect(adopted.submission.pending == null);
+    try std.testing.expectEqual(@as(usize, 1), adopted.worker.release_count);
+
+    var queued = try pendingLifecycleFake(std.testing.allocator, 804);
+    defer queued.deinit();
+    Runtime.noteCommittedFrame(&queued);
+    Runtime.collectPendingSubmissionFacts(&queued);
+    try std.testing.expectEqual(PendingPhase.queued, queued.submission.pending.?.phase);
+    try std.testing.expectEqual(@as(?u64, 804), queued.worker.queued_turn_id);
+    try std.testing.expect(Runtime.cancelPendingSubmission(&queued));
+    try std.testing.expect(queued.submission.pending == null);
+    try std.testing.expectEqual(@as(?u64, null), queued.worker.queued_turn_id);
+    try std.testing.expectEqual(@as(usize, 1), queued.worker.delete_count);
+    try std.testing.expectEqual(@as(usize, 1), queued.worker.release_count);
+}
+
+test "Ctrl+C requests cancellation after the pending turn leaves the queue" {
+    const Runtime = SubmitRuntime(PendingLifecycleFake);
+    var app = try pendingLifecycleFake(std.testing.allocator, 805);
+    defer app.deinit();
+    Runtime.noteCommittedFrame(&app);
+    Runtime.collectPendingSubmissionFacts(&app);
+    app.worker.queued_turn_id = null;
+    app.worker.active_turn_id = 805;
+
+    try std.testing.expect(Runtime.cancelPendingSubmission(&app));
+    try std.testing.expectEqual(@as(usize, 1), app.worker.cancel_count);
+    try std.testing.expect(app.submission.pending != null);
+    try Runtime.acceptPresentedPrompt(&app, 805);
+    try std.testing.expect(app.submission.pending == null);
+    try std.testing.expectEqual(@as(usize, 1), app.worker.release_count);
 }

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -116,14 +116,12 @@ pub fn SubmitRuntime(comptime App: type) type {
 
         const PromptAdmission = enum {
             rejected,
-            deferred,
             pending,
             enqueued,
         };
 
         const PendingInstall = enum {
             unavailable,
-            deferred,
             installed,
         };
 
@@ -259,6 +257,10 @@ pub fn SubmitRuntime(comptime App: type) type {
                     );
                     return false;
                 }
+                image_attachments.discardImageSnapshots(
+                    app.alloc,
+                    app.submission.pending.?.draft.images,
+                );
             }
             clearPendingSubmission(app, "ctrl_c_pending_submission");
             app.shell.render_requests.request(.transcript);
@@ -271,6 +273,9 @@ pub fn SubmitRuntime(comptime App: type) type {
             var pending = app.submission.pending orelse return;
             app.submission.pending = null;
             if (pending.ownsTurnStartHold()) app.worker.releaseTurnStartHold();
+            if (pending.phase != .queued) {
+                image_attachments.discardImageSnapshots(app.alloc, pending.draft.images);
+            }
             debug_trace.eventf(
                 "input",
                 "pending_prompt_cleared",
@@ -419,7 +424,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                 if (app.pending_images.items.len > 0) {
                     if (!try preflightPrompt(app)) return;
                     const admission = try enqueuePromptForSubmit(app, "", &.{}, null);
-                    if (admission == .rejected or admission == .deferred) return;
+                    if (admission == .rejected) return;
                     releasePendingImages(app);
                     app.input_runtime.inputResetState().clearCurrent(app.alloc);
                     if (acceptedPromptNeedsImmediateFooter(app)) {
@@ -550,7 +555,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                     display_skill_tokens,
                     &accepted_draft,
                 );
-            if (admission == .rejected or admission == .deferred) return;
+            if (admission == .rejected) return;
             commitStableExtractedImageIds(app, extracted.images);
             commitRemappedImageIds(app, visual_text.next_image_id);
             if (visual_text.text.len > 0) {
@@ -765,7 +770,6 @@ pub fn SubmitRuntime(comptime App: type) type {
         ) !PromptAdmission {
             switch (try installPendingSubmission(app, prompt, skill_tokens)) {
                 .installed => return .pending,
-                .deferred => return .deferred,
                 .unavailable => {},
             }
             const resume_review = if (comptime @hasField(App, "queued_prompt_review"))
@@ -842,7 +846,7 @@ pub fn SubmitRuntime(comptime App: type) type {
             {
                 if (app.shell.fullTranscriptActive()) return .unavailable;
             }
-            if (app.submission.pending != null) return .deferred;
+            std.debug.assert(app.submission.pending == null);
             if (!app.worker.tryHoldTurnStart()) return .unavailable;
             errdefer app.worker.releaseTurnStartHold();
 
@@ -887,7 +891,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                 skill_tokens,
                 accepted_draft,
             );
-            if (admission == .rejected or admission == .deferred) {
+            if (admission == .rejected) {
                 staged_images.* = app.pending_images;
                 app.pending_images = original_images;
                 return admission;
@@ -2025,6 +2029,42 @@ fn pendingLifecycleFake(alloc: std.mem.Allocator, turn_id: u64) !PendingLifecycl
     };
 }
 
+fn pendingLifecycleFakeWithSnapshot(
+    alloc: std.mem.Allocator,
+    turn_id: u64,
+    snapshot_path: []const u8,
+) !PendingLifecycleFake {
+    return .{
+        .alloc = alloc,
+        .submission = .{ .pending = PendingSubmission.init(try buildQueuedPromptDraft(
+            alloc,
+            turn_id,
+            "visible image prompt",
+            &.{.{
+                .id = 1,
+                .path = @constCast("/tmp/original.png"),
+                .media_type = @constCast("image/png"),
+                .snapshot_path = @constCast(snapshot_path),
+            }},
+            &.{},
+        )) },
+    };
+}
+
+fn writePendingSnapshotFixture(tmp: *std.testing.TmpDir, name: []const u8) ![]u8 {
+    var file = try tmp.dir.createFile(std.testing.io, name, .{});
+    defer file.close(std.testing.io);
+    try file.writeStreamingAll(std.testing.io, "snapshot");
+    return io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, name);
+}
+
+fn expectPendingSnapshotMissing(path: []const u8) !void {
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.openFileAbsolute(std.testing.io, path, .{}),
+    );
+}
+
 test "post-commit adoption failure keeps one retryable owner and hold" {
     const Runtime = SubmitRuntime(PendingLifecycleFake);
     var app = try pendingLifecycleFake(std.testing.allocator, 501);
@@ -2128,4 +2168,50 @@ test "Ctrl+C requests cancellation after the pending turn leaves the queue" {
     try Runtime.acceptPresentedPrompt(&app, 805);
     try std.testing.expect(app.submission.pending == null);
     try std.testing.expectEqual(@as(usize, 1), app.worker.release_count);
+}
+
+test "pending terminal cleanup deletes snapshots until a worker claims the turn" {
+    const alloc = std.testing.allocator;
+    const Runtime = SubmitRuntime(PendingLifecycleFake);
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const awaiting_path = try writePendingSnapshotFixture(&tmp, "awaiting.bin");
+    defer alloc.free(awaiting_path);
+    var awaiting = try pendingLifecycleFakeWithSnapshot(alloc, 901, awaiting_path);
+    defer awaiting.deinit();
+    try std.testing.expect(Runtime.cancelPendingSubmission(&awaiting));
+    try expectPendingSnapshotMissing(awaiting_path);
+
+    const failed_path = try writePendingSnapshotFixture(&tmp, "failed.bin");
+    defer alloc.free(failed_path);
+    var failed = try pendingLifecycleFakeWithSnapshot(alloc, 902, failed_path);
+    defer failed.deinit();
+    failed.finalization_error = true;
+    Runtime.noteCommittedFrame(&failed);
+    Runtime.collectPendingSubmissionFacts(&failed);
+    try std.testing.expect(failed.submission.pending == null);
+    try expectPendingSnapshotMissing(failed_path);
+
+    const queued_path = try writePendingSnapshotFixture(&tmp, "queued.bin");
+    defer alloc.free(queued_path);
+    var queued = try pendingLifecycleFakeWithSnapshot(alloc, 903, queued_path);
+    defer queued.deinit();
+    Runtime.noteCommittedFrame(&queued);
+    Runtime.collectPendingSubmissionFacts(&queued);
+    try std.testing.expect(Runtime.cancelPendingSubmission(&queued));
+    try expectPendingSnapshotMissing(queued_path);
+
+    const claimed_path = try writePendingSnapshotFixture(&tmp, "claimed.bin");
+    defer alloc.free(claimed_path);
+    var claimed = try pendingLifecycleFakeWithSnapshot(alloc, 904, claimed_path);
+    defer claimed.deinit();
+    Runtime.noteCommittedFrame(&claimed);
+    Runtime.collectPendingSubmissionFacts(&claimed);
+    claimed.worker.queued_turn_id = null;
+    claimed.worker.active_turn_id = 904;
+    try std.testing.expect(Runtime.cancelPendingSubmission(&claimed));
+    try Runtime.acceptPresentedPrompt(&claimed, 904);
+    var retained = try std.Io.Dir.openFileAbsolute(std.testing.io, claimed_path, .{});
+    retained.close(std.testing.io);
 }

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -7,14 +7,123 @@ const io_mod = @import("../shared/io.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const entity_spans = @import("../shared/entity_spans.zig");
 const types = @import("../shared/types.zig");
+const worker_runtime = @import("../agent/worker_runtime.zig");
 const input_queue_runtime = @import("input_queue_runtime.zig");
 const input_completion_runtime = @import("input_completion_runtime.zig");
 const input_limit_feedback = @import("input_limit_feedback.zig");
+
+pub const PendingPhase = enum {
+    awaiting_frame,
+    awaiting_adoption,
+    adopted,
+    queued,
+};
+
+pub const PendingPhaseError = error{InvalidPendingPhase};
+
+pub const PendingSubmission = struct {
+    draft: worker_runtime.QueuedPromptDraft,
+    phase: PendingPhase = .awaiting_frame,
+
+    pub fn init(draft: worker_runtime.QueuedPromptDraft) PendingSubmission {
+        std.debug.assert(draft.turn_id != 0);
+        return .{ .draft = draft };
+    }
+
+    pub fn deinit(self: *PendingSubmission, alloc: std.mem.Allocator) void {
+        worker_runtime.freeQueuedPromptDraft(alloc, self.draft);
+        self.* = undefined;
+    }
+
+    pub fn ownsTurnStartHold(self: PendingSubmission) bool {
+        return self.phase != .queued;
+    }
+
+    pub fn markFrameCommitted(self: *PendingSubmission) PendingPhaseError!void {
+        if (self.phase != .awaiting_frame) return error.InvalidPendingPhase;
+        self.phase = .awaiting_adoption;
+    }
+
+    pub fn markAdopted(self: *PendingSubmission) PendingPhaseError!void {
+        if (self.phase != .awaiting_adoption) return error.InvalidPendingPhase;
+        self.phase = .adopted;
+    }
+
+    pub fn markQueued(self: *PendingSubmission) PendingPhaseError!void {
+        if (self.phase != .adopted) return error.InvalidPendingPhase;
+        self.phase = .queued;
+    }
+};
+
+pub const State = struct {
+    pending: ?PendingSubmission = null,
+};
+
+pub fn buildQueuedPromptDraft(
+    alloc: std.mem.Allocator,
+    turn_id: u64,
+    prompt_source: []const u8,
+    image_source: []const types.ImageAttachment,
+    skill_tokens: []const registered_entities.SkillTokenSpan,
+) !worker_runtime.QueuedPromptDraft {
+    if (turn_id == 0) return error.InvalidTurnId;
+
+    const prompt = try alloc.dupe(u8, prompt_source);
+    errdefer alloc.free(prompt);
+    const images = try types.dupeImageAttachmentSlice(alloc, image_source);
+    errdefer types.freeImageAttachmentSlice(alloc, images);
+
+    const spans: []worker_runtime.SkillDisplaySpan = if (skill_tokens.len == 0)
+        @constCast(&.{})
+    else
+        try alloc.alloc(worker_runtime.SkillDisplaySpan, skill_tokens.len);
+    var span_count: usize = 0;
+    errdefer {
+        for (spans[0..span_count]) |span| {
+            alloc.free(span.name);
+            alloc.free(span.path);
+        }
+        if (spans.len > 0) alloc.free(spans);
+    }
+    while (span_count < skill_tokens.len) : (span_count += 1) {
+        const token = skill_tokens[span_count];
+        const name = try alloc.dupe(u8, token.name);
+        errdefer alloc.free(name);
+        spans[span_count] = .{
+            .raw_start = token.raw_start,
+            .raw_end = token.raw_end,
+            .name = name,
+            .path = try alloc.dupe(u8, token.path),
+            .display_source = token.display_source,
+            .owns_trailing_separator = token.owns_trailing_separator,
+        };
+    }
+
+    return .{
+        .turn_id = turn_id,
+        .prompt = prompt,
+        .images = images,
+        .skill_display_spans = spans,
+    };
+}
 
 pub fn SubmitRuntime(comptime App: type) type {
     return struct {
         const queue_rt = input_queue_runtime.Runtime(App);
         const completion_rt = input_completion_runtime.CompletionRuntime(App);
+
+        const PromptAdmission = enum {
+            rejected,
+            deferred,
+            pending,
+            enqueued,
+        };
+
+        const PendingInstall = enum {
+            unavailable,
+            deferred,
+            installed,
+        };
 
         const AcceptedDraftProjection = struct {
             input: []const u8,
@@ -29,6 +138,158 @@ pub fn SubmitRuntime(comptime App: type) type {
                 self.* = undefined;
             }
         };
+
+        pub fn noteCommittedFrame(app: *App) void {
+            if (comptime !@hasField(App, "submission")) return;
+            const pending = if (app.submission.pending) |*value| value else return;
+            if (pending.phase != .awaiting_frame) return;
+            pending.markFrameCommitted() catch unreachable;
+            debug_trace.eventf(
+                "input",
+                "pending_prompt_frame_committed",
+                .{ .turn_id = pending.draft.turn_id },
+                "",
+                .{},
+            );
+            adoptPendingSubmission(app) catch |err| {
+                debug_trace.eventf(
+                    "input",
+                    "pending_prompt_adoption_retry",
+                    .{ .turn_id = pending.draft.turn_id },
+                    "err={s}",
+                    .{@errorName(err)},
+                );
+            };
+        }
+
+        pub fn collectPendingSubmissionFacts(app: *App) void {
+            if (comptime !@hasField(App, "submission")) return;
+            var pending = if (app.submission.pending) |*value| value else return;
+            if (pending.phase == .awaiting_adoption) {
+                adoptPendingSubmission(app) catch |err| {
+                    debug_trace.eventf(
+                        "input",
+                        "pending_prompt_adoption_retry",
+                        .{ .turn_id = pending.draft.turn_id },
+                        "err={s}",
+                        .{@errorName(err)},
+                    );
+                    return;
+                };
+                pending = &app.submission.pending.?;
+            }
+            if (pending.phase != .adopted) return;
+
+            if (pending.draft.prompt.len > 0 and pending.draft.images.len == 0) {
+                recordAcceptedInput(app, pending.draft.prompt);
+            }
+            if (comptime !@hasDecl(App, "finalizePendingSubmission")) {
+                finishPendingSubmissionFailure(app, error.PendingFinalizationUnsupported);
+                return;
+            }
+            App.finalizePendingSubmission(app, &pending.draft) catch |err| {
+                finishPendingSubmissionFailure(app, err);
+                return;
+            };
+            app.worker.releaseTurnStartHold();
+            pending.markQueued() catch unreachable;
+            debug_trace.eventf(
+                "input",
+                "pending_prompt_queued",
+                .{ .turn_id = pending.draft.turn_id },
+                "",
+                .{},
+            );
+        }
+
+        pub fn acceptPresentedPrompt(app: *App, turn_id: u64) !void {
+            if (comptime !@hasField(App, "submission")) {
+                return error.PendingSubmissionUnsupported;
+            }
+            const pending = app.submission.pending orelse return error.MissingPendingSubmission;
+            if (pending.phase != .queued) return error.InvalidPendingPhase;
+            if (pending.draft.turn_id != turn_id) return error.PendingTurnIdMismatch;
+            clearPendingSubmission(app, "worker_begin_presented");
+        }
+
+        pub fn cancelUncommittedPendingSubmission(app: *App) bool {
+            if (comptime !@hasField(App, "submission")) return false;
+            const pending = app.submission.pending orelse return false;
+            if (pending.phase != .awaiting_frame) return false;
+            clearPendingSubmission(app, "ctrl_c_before_frame");
+            app.shell.render_requests.request(.transcript);
+            app.shell.render_requests.request(.footer);
+            return true;
+        }
+
+        pub fn clearPendingSubmission(app: *App, reason: []const u8) void {
+            if (comptime !@hasField(App, "submission")) return;
+            var pending = app.submission.pending orelse return;
+            app.submission.pending = null;
+            if (pending.ownsTurnStartHold()) app.worker.releaseTurnStartHold();
+            debug_trace.eventf(
+                "input",
+                "pending_prompt_cleared",
+                .{ .turn_id = pending.draft.turn_id },
+                "reason={s} phase={s}",
+                .{ reason, @tagName(pending.phase) },
+            );
+            pending.deinit(app.alloc);
+        }
+
+        fn adoptPendingSubmission(app: *App) !void {
+            const pending = &app.submission.pending.?;
+            if (pending.phase != .awaiting_adoption) return error.InvalidPendingPhase;
+            if (comptime !@hasDecl(App, "adoptPendingUserPrompt")) {
+                return error.PendingAdoptionUnsupported;
+            }
+            try App.adoptPendingUserPrompt(app, &pending.draft);
+            try pending.markAdopted();
+            debug_trace.eventf(
+                "input",
+                "pending_prompt_adopted",
+                .{ .turn_id = pending.draft.turn_id },
+                "",
+                .{},
+            );
+        }
+
+        fn finishPendingSubmissionFailure(app: *App, err: anyerror) void {
+            const turn_id = app.submission.pending.?.draft.turn_id;
+            const body = std.fmt.allocPrint(
+                app.alloc,
+                "failed to submit prompt after presentation ({s})",
+                .{@errorName(err)},
+            ) catch |notice_err| {
+                debug_trace.logf(
+                    "input",
+                    "pending prompt failure notice allocation failed err={s}",
+                    .{@errorName(notice_err)},
+                );
+                clearPendingSubmission(app, "finalization_failure");
+                return;
+            };
+            defer app.alloc.free(body);
+            app.writeDomainNotice(.{
+                .topic = "prompt",
+                .tone = .@"error",
+                .body = body,
+            }, true) catch |notice_err| {
+                debug_trace.logf(
+                    "input",
+                    "pending prompt failure notice output failed err={s}",
+                    .{@errorName(notice_err)},
+                );
+            };
+            debug_trace.eventf(
+                "input",
+                "pending_prompt_finalization_failed",
+                .{ .turn_id = turn_id },
+                "err={s}",
+                .{@errorName(err)},
+            );
+            clearPendingSubmission(app, "finalization_failure");
+        }
 
         pub fn submitInput(app: *App, max_prompt_history: usize) !void {
             try submit(app, max_prompt_history);
@@ -101,7 +362,8 @@ pub fn SubmitRuntime(comptime App: type) type {
             if (trimmed.len == 0) {
                 if (app.pending_images.items.len > 0) {
                     if (!try preflightPrompt(app)) return;
-                    if (!try enqueuePromptForSubmit(app, "", &.{}, null)) return;
+                    const admission = try enqueuePromptForSubmit(app, "", &.{}, null);
+                    if (admission == .rejected or admission == .deferred) return;
                     releasePendingImages(app);
                     app.input_runtime.inputResetState().clearCurrent(app.alloc);
                     if (acceptedPromptNeedsImmediateFooter(app)) {
@@ -111,7 +373,6 @@ pub fn SubmitRuntime(comptime App: type) type {
                 }
                 if (comptime @hasField(App, "queued_prompt_review")) {
                     if (try queue_rt.submitPausedQueueUnchanged(app)) {
-                        beginIdleSubmittedPromptTransition(app);
                         return;
                     }
                 }
@@ -218,7 +479,7 @@ pub fn SubmitRuntime(comptime App: type) type {
             else
                 app.pending_images.items.len > 0;
 
-            const queued = if (staged_images) |*images|
+            const admission = if (staged_images) |*images|
                 try enqueuePromptWithStagedImages(
                     app,
                     visual_text.text,
@@ -233,7 +494,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                     display_skill_tokens,
                     &accepted_draft,
                 );
-            if (!queued) return;
+            if (admission == .rejected or admission == .deferred) return;
             commitStableExtractedImageIds(app, extracted.images);
             commitRemappedImageIds(app, visual_text.next_image_id);
             if (visual_text.text.len > 0) {
@@ -243,7 +504,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                     &accepted_draft,
                 );
             }
-            if (!has_images_for_submit and visual_text.text.len > 0) {
+            if (admission == .enqueued and !has_images_for_submit and visual_text.text.len > 0) {
                 recordAcceptedInput(app, visual_text.text);
             }
             discard_extracted = false;
@@ -445,7 +706,12 @@ pub fn SubmitRuntime(comptime App: type) type {
             prompt: []const u8,
             skill_tokens: []const registered_entities.SkillTokenSpan,
             accepted_draft: ?*const AcceptedDraftProjection,
-        ) !bool {
+        ) !PromptAdmission {
+            switch (try installPendingSubmission(app, prompt, skill_tokens)) {
+                .installed => return .pending,
+                .deferred => return .deferred,
+                .unavailable => {},
+            }
             const resume_review = if (comptime @hasField(App, "queued_prompt_review"))
                 app.queued_prompt_review.active()
             else
@@ -459,8 +725,7 @@ pub fn SubmitRuntime(comptime App: type) type {
                     if (accepted_draft) |draft| draft.skill_tokens.items else skill_tokens,
                 )) {
                     .replaced => {
-                        beginIdleSubmittedPromptTransition(app);
-                        return true;
+                        return .enqueued;
                     },
                     .enqueue => {},
                 }
@@ -487,31 +752,49 @@ pub fn SubmitRuntime(comptime App: type) type {
                 try App.enqueuePromptWithSkillBindings(app, prompt, skill_tokens)
             else
                 try App.enqueuePrompt(app, prompt);
-            if (!accepted) return false;
+            if (!accepted) return .rejected;
             if (resume_review) {
                 if (comptime @hasField(App, "queued_prompt_review")) {
                     queue_rt.resumeAfterNewPrompt(app);
                 }
             }
-            beginIdleSubmittedPromptTransition(app);
-            return true;
+            return .enqueued;
         }
 
-        fn beginIdleSubmittedPromptTransition(app: *App) void {
-            if (comptime @hasField(App, "stream")) {
-                if (app.stream.active) {
-                    if (comptime @hasField(App, "pacer") and
-                        @hasDecl(@TypeOf(app.pacer), "hasCompletedAssistantPresentationTail"))
-                    {
-                        if (!app.pacer.hasCompletedAssistantPresentationTail()) return;
-                    } else {
-                        return;
-                    }
-                }
-            } else {
-                return;
+        fn installPendingSubmission(
+            app: *App,
+            prompt: []const u8,
+            skill_tokens: []const registered_entities.SkillTokenSpan,
+        ) !PendingInstall {
+            if (comptime !@hasField(App, "submission") or
+                !@hasField(App, "worker") or
+                !@hasDecl(@TypeOf(app.worker), "tryHoldTurnStart") or
+                !@hasDecl(@TypeOf(app.worker), "releaseTurnStartHold"))
+            {
+                return .unavailable;
             }
-            app.shell.render_requests.beginSubmittedPromptTransition();
+            if (app.submission.pending != null) return .deferred;
+            if (!app.worker.tryHoldTurnStart()) return .unavailable;
+            errdefer app.worker.releaseTurnStartHold();
+
+            const draft = try buildQueuedPromptDraft(
+                app.alloc,
+                debug_trace.nextTurnId(),
+                prompt,
+                app.pending_images.items,
+                skill_tokens,
+            );
+            app.submission.pending = PendingSubmission.init(draft);
+            app.shell.render_requests.request(.transcript);
+            app.shell.render_requests.request(.footer);
+            debug_trace.eventf(
+                "input",
+                "pending_prompt_installed",
+                .{ .turn_id = draft.turn_id },
+                "prompt_bytes={d} images={d} skill_spans={d}",
+                .{ draft.prompt.len, draft.images.len, draft.skill_display_spans.len },
+            );
+            return .installed;
         }
 
         fn enqueuePromptWithStagedImages(
@@ -520,7 +803,7 @@ pub fn SubmitRuntime(comptime App: type) type {
             skill_tokens: []const registered_entities.SkillTokenSpan,
             accepted_draft: *const AcceptedDraftProjection,
             staged_images: *std.ArrayList(types.ImageAttachment),
-        ) !bool {
+        ) !PromptAdmission {
             const original_images = app.pending_images;
             app.pending_images = staged_images.*;
             staged_images.* = .empty;
@@ -529,20 +812,21 @@ pub fn SubmitRuntime(comptime App: type) type {
                 app.pending_images = original_images;
             }
 
-            if (!try enqueuePromptForSubmit(
+            const admission = try enqueuePromptForSubmit(
                 app,
                 prompt,
                 skill_tokens,
                 accepted_draft,
-            )) {
+            );
+            if (admission == .rejected or admission == .deferred) {
                 staged_images.* = app.pending_images;
                 app.pending_images = original_images;
-                return false;
+                return admission;
             }
 
             var committed_images = original_images;
             deinitOwnedImageList(app.alloc, &committed_images);
-            return true;
+            return admission;
         }
 
         fn firstAvailableImageId(images: []const types.ImageAttachment) !usize {
@@ -1507,4 +1791,186 @@ test "direct terminal route requires the literal first character" {
     try std.testing.expectEqualStrings("", directCommand("!").?);
     try std.testing.expect(directCommand(" !printf prompt") == null);
     try std.testing.expect(directCommand("ordinary prompt") == null);
+}
+
+test "pending submission phase methods keep hold ownership explicit" {
+    const alloc = std.testing.allocator;
+    var pending = PendingSubmission.init(try buildQueuedPromptDraft(
+        alloc,
+        41,
+        "use $review",
+        &.{},
+        &.{.{
+            .raw_start = 4,
+            .raw_end = 11,
+            .name = "review",
+            .path = "/tmp/review/SKILL.md",
+        }},
+    ));
+    defer pending.deinit(alloc);
+
+    try std.testing.expectEqual(PendingPhase.awaiting_frame, pending.phase);
+    try std.testing.expect(pending.ownsTurnStartHold());
+    try std.testing.expectError(error.InvalidPendingPhase, pending.markAdopted());
+
+    try pending.markFrameCommitted();
+    try std.testing.expectEqual(PendingPhase.awaiting_adoption, pending.phase);
+    try std.testing.expect(pending.ownsTurnStartHold());
+    try std.testing.expectError(error.InvalidPendingPhase, pending.markFrameCommitted());
+
+    try pending.markAdopted();
+    try std.testing.expectEqual(PendingPhase.adopted, pending.phase);
+    try std.testing.expect(pending.ownsTurnStartHold());
+    try std.testing.expectError(error.InvalidPendingPhase, pending.markAdopted());
+
+    try pending.markQueued();
+    try std.testing.expectEqual(PendingPhase.queued, pending.phase);
+    try std.testing.expect(!pending.ownsTurnStartHold());
+    try std.testing.expectError(error.InvalidPendingPhase, pending.markQueued());
+    try std.testing.expectEqual(@as(u64, 41), pending.draft.turn_id);
+    try std.testing.expectEqualStrings("use $review", pending.draft.prompt);
+    try std.testing.expectEqual(@as(usize, 1), pending.draft.skill_display_spans.len);
+}
+
+fn checkPendingDraftConstructionAllocationFailure(alloc: std.mem.Allocator) !void {
+    const draft = try buildQueuedPromptDraft(
+        alloc,
+        77,
+        "hello $review",
+        &.{.{
+            .id = 5,
+            .path = @constCast("/tmp/image.png"),
+            .media_type = @constCast("image/png"),
+        }},
+        &.{.{
+            .raw_start = 6,
+            .raw_end = 13,
+            .name = "review",
+            .path = "/tmp/review/SKILL.md",
+        }},
+    );
+    defer worker_runtime.freeQueuedPromptDraft(alloc, draft);
+    try std.testing.expectEqual(@as(u64, 77), draft.turn_id);
+    try std.testing.expectEqualStrings("hello $review", draft.prompt);
+    try std.testing.expectEqual(@as(usize, 1), draft.images.len);
+    try std.testing.expectEqual(@as(usize, 1), draft.skill_display_spans.len);
+}
+
+test "pending draft construction frees every partial allocation" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        checkPendingDraftConstructionAllocationFailure,
+        .{},
+    );
+}
+
+const PendingLifecycleFake = struct {
+    alloc: std.mem.Allocator,
+    submission: State = .{},
+    worker: struct {
+        held: bool = true,
+        release_count: usize = 0,
+
+        pub fn releaseTurnStartHold(self: *@This()) void {
+            if (!self.held) return;
+            self.held = false;
+            self.release_count += 1;
+        }
+    } = .{},
+    adoption_failures_remaining: usize = 0,
+    adoption_count: usize = 0,
+    finalization_count: usize = 0,
+    finalization_error: bool = false,
+    notice_count: usize = 0,
+
+    fn deinit(self: *PendingLifecycleFake) void {
+        SubmitRuntime(PendingLifecycleFake).clearPendingSubmission(self, "test_deinit");
+    }
+
+    pub fn adoptPendingUserPrompt(
+        self: *PendingLifecycleFake,
+        _: *const worker_runtime.QueuedPromptDraft,
+    ) !void {
+        if (self.adoption_failures_remaining > 0) {
+            self.adoption_failures_remaining -= 1;
+            return error.InjectedAdoptionFailure;
+        }
+        self.adoption_count += 1;
+    }
+
+    pub fn finalizePendingSubmission(
+        self: *PendingLifecycleFake,
+        _: *const worker_runtime.QueuedPromptDraft,
+    ) !void {
+        self.finalization_count += 1;
+        if (self.finalization_error) return error.InjectedFinalizationFailure;
+    }
+
+    pub fn writeDomainNotice(
+        self: *PendingLifecycleFake,
+        _: types.SemanticNotice,
+        _: bool,
+    ) !void {
+        self.notice_count += 1;
+    }
+};
+
+fn pendingLifecycleFake(alloc: std.mem.Allocator, turn_id: u64) !PendingLifecycleFake {
+    return .{
+        .alloc = alloc,
+        .submission = .{ .pending = PendingSubmission.init(try buildQueuedPromptDraft(
+            alloc,
+            turn_id,
+            "visible prompt",
+            &.{},
+            &.{},
+        )) },
+    };
+}
+
+test "post-commit adoption failure keeps one retryable owner and hold" {
+    const Runtime = SubmitRuntime(PendingLifecycleFake);
+    var app = try pendingLifecycleFake(std.testing.allocator, 501);
+    defer app.deinit();
+    app.adoption_failures_remaining = 1;
+
+    Runtime.noteCommittedFrame(&app);
+    try std.testing.expectEqual(PendingPhase.awaiting_adoption, app.submission.pending.?.phase);
+    try std.testing.expect(app.worker.held);
+    try std.testing.expectEqual(@as(usize, 0), app.adoption_count);
+    try std.testing.expectEqual(@as(usize, 0), app.finalization_count);
+
+    Runtime.collectPendingSubmissionFacts(&app);
+    try std.testing.expectEqual(PendingPhase.queued, app.submission.pending.?.phase);
+    try std.testing.expect(!app.worker.held);
+    try std.testing.expectEqual(@as(usize, 1), app.worker.release_count);
+    try std.testing.expectEqual(@as(usize, 1), app.adoption_count);
+    try std.testing.expectEqual(@as(usize, 1), app.finalization_count);
+
+    try std.testing.expectError(
+        error.PendingTurnIdMismatch,
+        Runtime.acceptPresentedPrompt(&app, 999),
+    );
+    try std.testing.expect(app.submission.pending != null);
+    try Runtime.acceptPresentedPrompt(&app, 501);
+    try std.testing.expect(app.submission.pending == null);
+    try std.testing.expectEqual(@as(usize, 1), app.worker.release_count);
+}
+
+test "post-ack finalization failure leaves notice and consumes pending owner" {
+    const Runtime = SubmitRuntime(PendingLifecycleFake);
+    var app = try pendingLifecycleFake(std.testing.allocator, 777);
+    defer app.deinit();
+    app.finalization_error = true;
+
+    Runtime.noteCommittedFrame(&app);
+    try std.testing.expectEqual(PendingPhase.adopted, app.submission.pending.?.phase);
+    Runtime.collectPendingSubmissionFacts(&app);
+
+    try std.testing.expect(app.submission.pending == null);
+    try std.testing.expect(!app.worker.held);
+    try std.testing.expectEqual(@as(usize, 1), app.worker.release_count);
+    try std.testing.expectEqual(@as(usize, 1), app.adoption_count);
+    try std.testing.expectEqual(@as(usize, 1), app.finalization_count);
+    try std.testing.expectEqual(@as(usize, 1), app.notice_count);
 }

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -293,18 +293,25 @@ pub fn SubmitRuntime(comptime App: type) type {
             const history_owns_snapshots =
                 transferPendingImageSnapshotsToComposerHistory(app);
             if (pending.phase == .queued) {
-                if (history_owns_snapshots) {
-                    if (comptime @hasDecl(@TypeOf(app.worker), "preservePromptSnapshots")) {
-                        _ = app.worker.preservePromptSnapshots(
-                            pending.draft.turn_id,
-                            pending.draft.images,
-                        );
-                    }
+                const retained_images = if (history_owns_snapshots)
+                    pending.draft.images
+                else
+                    &.{};
+                if (comptime @hasDecl(
+                    @TypeOf(app.worker),
+                    "clearQueuedPromptsForSessionTransition",
+                )) {
+                    app.worker.clearQueuedPromptsForSessionTransition(
+                        std.heap.c_allocator,
+                        pending.draft.turn_id,
+                        retained_images,
+                    );
+                } else {
+                    app.worker.clearQueuedPrompts(
+                        std.heap.c_allocator,
+                        retained_images,
+                    );
                 }
-                app.worker.clearQueuedPrompts(
-                    std.heap.c_allocator,
-                    if (history_owns_snapshots) pending.draft.images else &.{},
-                );
                 clearPendingSubmissionWithSnapshots(
                     app,
                     "session_transition",

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -773,6 +773,19 @@ pub fn SubmitRuntime(comptime App: type) type {
             {
                 return .unavailable;
             }
+            if (comptime @hasField(App, "stream")) {
+                if (app.stream.active) return .unavailable;
+            }
+            if (comptime @hasField(App, "pacer") and
+                @hasDecl(@TypeOf(app.pacer), "hasPending"))
+            {
+                if (app.pacer.hasPending()) return .unavailable;
+            }
+            if (comptime @hasField(App, "shell") and
+                @hasDecl(@TypeOf(app.shell), "fullTranscriptActive"))
+            {
+                if (app.shell.fullTranscriptActive()) return .unavailable;
+            }
             if (app.submission.pending != null) return .deferred;
             if (!app.worker.tryHoldTurnStart()) return .unavailable;
             errdefer app.worker.releaseTurnStartHold();

--- a/src/core/app/input_submit_runtime.zig
+++ b/src/core/app/input_submit_runtime.zig
@@ -125,6 +125,11 @@ pub fn SubmitRuntime(comptime App: type) type {
             installed,
         };
 
+        const PendingSnapshotCleanup = enum {
+            automatic,
+            transferred_to_composer_history,
+        };
+
         const AcceptedDraftProjection = struct {
             input: []const u8,
             pasted_blocks: std.ArrayList(paste_blocks.PastedBlock) = .empty,
@@ -269,11 +274,19 @@ pub fn SubmitRuntime(comptime App: type) type {
         }
 
         pub fn clearPendingSubmission(app: *App, reason: []const u8) void {
+            clearPendingSubmissionWithSnapshots(app, reason, .automatic);
+        }
+
+        fn clearPendingSubmissionWithSnapshots(
+            app: *App,
+            reason: []const u8,
+            snapshot_cleanup: PendingSnapshotCleanup,
+        ) void {
             if (comptime !@hasField(App, "submission")) return;
             var pending = app.submission.pending orelse return;
             app.submission.pending = null;
             if (pending.ownsTurnStartHold()) app.worker.releaseTurnStartHold();
-            if (pending.phase != .queued) {
+            if (snapshot_cleanup == .automatic and pending.phase != .queued) {
                 image_attachments.discardImageSnapshots(app.alloc, pending.draft.images);
             }
             debug_trace.eventf(
@@ -305,6 +318,10 @@ pub fn SubmitRuntime(comptime App: type) type {
 
         fn finishPendingSubmissionFailure(app: *App, err: anyerror) void {
             const turn_id = app.submission.pending.?.draft.turn_id;
+            const snapshot_cleanup: PendingSnapshotCleanup = if (transferPendingImageSnapshotsToComposerHistory(app))
+                .transferred_to_composer_history
+            else
+                .automatic;
             const body = std.fmt.allocPrint(
                 app.alloc,
                 "failed to submit prompt after presentation ({s})",
@@ -315,7 +332,11 @@ pub fn SubmitRuntime(comptime App: type) type {
                     "pending prompt failure notice allocation failed err={s}",
                     .{@errorName(notice_err)},
                 );
-                clearPendingSubmission(app, "finalization_failure");
+                clearPendingSubmissionWithSnapshots(
+                    app,
+                    "finalization_failure",
+                    snapshot_cleanup,
+                );
                 return;
             };
             defer app.alloc.free(body);
@@ -337,7 +358,22 @@ pub fn SubmitRuntime(comptime App: type) type {
                 "err={s}",
                 .{@errorName(err)},
             );
-            clearPendingSubmission(app, "finalization_failure");
+            clearPendingSubmissionWithSnapshots(
+                app,
+                "finalization_failure",
+                snapshot_cleanup,
+            );
+        }
+
+        fn transferPendingImageSnapshotsToComposerHistory(app: *App) bool {
+            if (comptime !@hasField(App, "input_runtime")) return false;
+            if (comptime !@hasField(@TypeOf(app.input_runtime), "composer_history")) {
+                return false;
+            }
+            const pending = app.submission.pending orelse return false;
+            return app.input_runtime.composer_history.claimLatestImageSnapshots(
+                pending.draft.images,
+            );
         }
 
         pub fn submitInput(app: *App, max_prompt_history: usize) !void {

--- a/src/core/input/composer_history.zig
+++ b/src/core/input/composer_history.zig
@@ -400,6 +400,30 @@ pub const State = struct {
         }
     }
 
+    /// Transfers ownership of the latest entry's image snapshot files when it
+    /// describes the same accepted image set. Metadata remains independently
+    /// owned by the history entry.
+    pub fn claimLatestImageSnapshots(
+        self: *State,
+        expected: []const types.ImageAttachment,
+    ) bool {
+        if (expected.len == 0 or self.entries.items.len == 0) return false;
+        const latest = &self.entries.items[self.entries.items.len - 1];
+        if (latest.images.items.len != expected.len) return false;
+        for (latest.images.items, expected) |recorded, pending| {
+            if (recorded.id != pending.id or
+                !std.mem.eql(u8, recorded.path, pending.path) or
+                !std.mem.eql(u8, recorded.media_type, pending.media_type) or
+                !Snapshot.optionalBytesEql(recorded.snapshot_path, pending.snapshot_path) or
+                !Snapshot.optionalBytesEql(recorded.snapshot_sha256, pending.snapshot_sha256))
+            {
+                return false;
+            }
+        }
+        latest.owns_image_snapshots = true;
+        return true;
+    }
+
     pub fn installTextEntries(
         self: *State,
         alloc: Allocator,

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1481,6 +1481,8 @@ pub const FinishedPromptProjection = enum {
 };
 
 pub const SnapshotFileOwnership = struct {
+    /// Shared lifetime for snapshot files after worker completion. Copies must
+    /// retain/release; accepted history transfers deletion responsibility.
     ctx: *anyopaque,
     retain_fn: *const fn (*anyopaque) void,
     release_fn: *const fn (*anyopaque) void,

--- a/src/core/subagent/execution.zig
+++ b/src/core/subagent/execution.zig
@@ -1282,6 +1282,7 @@ fn livePresentationEventBytes(event: worker_runtime.WorkerEvent) ?usize {
             if (payload.full) |full| full.content.len +| full.lifecycle_id.call_id.len else 0,
         .begin_prompt,
         .begin_prompt_with_skill_bindings,
+        .begin_presented_prompt,
         .finish_prompt,
         .notification,
         .question_requested,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1152,8 +1152,8 @@ const App = struct {
         try InputSubmitRuntime.acceptPresentedPrompt(self, turn_id);
     }
 
-    pub fn cancelUncommittedPendingSubmission(self: *App) bool {
-        return InputSubmitRuntime.cancelUncommittedPendingSubmission(self);
+    pub fn cancelPendingSubmission(self: *App) bool {
+        return InputSubmitRuntime.cancelPendingSubmission(self);
     }
 
     pub fn clearPendingSubmission(self: *App, reason: []const u8) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1160,6 +1160,10 @@ const App = struct {
         InputSubmitRuntime.clearPendingSubmission(self, reason);
     }
 
+    pub fn clearPendingSubmissionForSessionTransition(self: *App) void {
+        InputSubmitRuntime.clearPendingSubmissionForSessionTransition(self);
+    }
+
     pub fn writeUserPromptCard(self: *App, user: types.UserTurn) !void {
         try self.writeUserPromptCardWithSpacing(user, self.session.historyLen() > 0);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -20,6 +20,7 @@ const app_entry_runtime = @import("core/app/app_entry_runtime.zig");
 const acp_runner = @import("core/cli/acp_runner.zig");
 const acp_server = @import("acp/server.zig");
 const app_input_runtime = @import("core/app/app_input_runtime.zig");
+const input_submit_runtime = @import("core/app/input_submit_runtime.zig");
 const core_input_runtime = @import("core/input/runtime.zig");
 const input_queue_runtime = @import("core/app/input_queue_runtime.zig");
 const app_bootstrap_runtime = @import("core/app/app_bootstrap_runtime.zig");
@@ -375,6 +376,7 @@ const App = struct {
     const HostConfigAppRuntime = app_host_config_runtime.Runtime(Self);
     const BootstrapAppRuntime = app_bootstrap_runtime.Runtime(Self);
     const InputAppRuntime = app_input_runtime.Runtime(Self);
+    const InputSubmitRuntime = input_submit_runtime.SubmitRuntime(Self);
     const NotificationAppRuntime = app_notification_runtime.Runtime(
         Self,
         builtin_hooks.notifications.provider(Self),
@@ -532,6 +534,7 @@ const App = struct {
     input_runtime: InputRuntime = .{},
     terminal_input_runtime: TerminalInputRuntime = .{},
     queued_prompt_review: input_queue_runtime.State = .{},
+    submission: input_submit_runtime.State = .{},
     pending_images: std.ArrayList(types.ImageAttachment) = .empty,
     next_image_id: usize = 1,
     shell: TranscriptRuntime = .{},
@@ -820,6 +823,7 @@ const App = struct {
         };
         self.terminal_client.deinit();
         self.model_cache.deinit();
+        InputSubmitRuntime.clearPendingSubmission(self, "shutdown");
         const resume_handoff = if (capture_resume_handoff and
             direct_deinit_disposition == .settled)
             SessionAppRuntime.finalizePersistenceWithResumeHandoff(self)
@@ -1097,6 +1101,65 @@ const App = struct {
         return true;
     }
 
+    pub fn adoptPendingUserPrompt(
+        self: *App,
+        draft: *const worker_runtime.QueuedPromptDraft,
+    ) !void {
+        try self.writeUserPromptCardWithSkillBindings(
+            .{ .text = draft.prompt, .images = draft.images },
+            &.{},
+            draft.skill_display_spans,
+        );
+    }
+
+    pub fn finalizePendingSubmission(
+        self: *App,
+        draft: *const worker_runtime.QueuedPromptDraft,
+    ) !void {
+        const context_targets = if (self.context_enabled)
+            try context_contract.applicableTargetsForImages(self.alloc, draft.images)
+        else
+            &.{};
+        defer if (context_targets.len > 0) self.alloc.free(context_targets);
+        try AgentAppRuntime.refreshProjectContext(self, context_targets);
+        self.session.setConversationLanguageFromUserMessage(draft.prompt);
+
+        const skill_tokens = try promptCardSkillTokensFromDisplaySpans(
+            self.alloc,
+            draft.skill_display_spans,
+        );
+        defer if (skill_tokens.len > 0) self.alloc.free(skill_tokens);
+        if (!try self.snapshotAndQueuePrompt(
+            draft.prompt,
+            skill_tokens,
+            null,
+            null,
+            draft.images,
+            draft.turn_id,
+            true,
+        )) return error.PendingPromptQueueRejected;
+        WorkerAppRuntime.syncState(
+            self,
+            app_callbacks.Bindings(App).worker_tool_lifecycle_presenter(self),
+        );
+    }
+
+    pub fn notePendingFrameCommitted(self: *App) void {
+        InputSubmitRuntime.noteCommittedFrame(self);
+    }
+
+    pub fn acceptPresentedPrompt(self: *App, turn_id: u64) !void {
+        try InputSubmitRuntime.acceptPresentedPrompt(self, turn_id);
+    }
+
+    pub fn cancelUncommittedPendingSubmission(self: *App) bool {
+        return InputSubmitRuntime.cancelUncommittedPendingSubmission(self);
+    }
+
+    pub fn clearPendingSubmission(self: *App, reason: []const u8) void {
+        InputSubmitRuntime.clearPendingSubmission(self, reason);
+    }
+
     pub fn writeUserPromptCard(self: *App, user: types.UserTurn) !void {
         try self.writeUserPromptCardWithSpacing(user, self.session.historyLen() > 0);
     }
@@ -1229,6 +1292,9 @@ const App = struct {
             skill_tokens,
             review_draft,
             null,
+            null,
+            0,
+            false,
         );
     }
 
@@ -1245,6 +1311,9 @@ const App = struct {
             &.{},
             null,
             checkpoint,
+            null,
+            checkpoint.turn_id,
+            false,
         )) return false;
         WorkerAppRuntime.syncState(
             self,
@@ -1259,8 +1328,18 @@ const App = struct {
         skill_tokens: []const registered_entities.SkillTokenSpan,
         review_draft: ?worker_runtime.QueueReviewDraft,
         recovery_checkpoint: ?*const session_codec.RecoveryCheckpoint,
+        prompt_images: ?[]const types.ImageAttachment,
+        turn_id: u64,
+        user_prompt_already_presented: bool,
     ) !bool {
         try self.reloadSkills();
+
+        const source_images = if (recovery_checkpoint) |checkpoint|
+            checkpoint.user.images
+        else if (prompt_images) |images|
+            images
+        else
+            self.pending_images.items;
 
         const prompt_copy = try std.heap.c_allocator.dupe(u8, prompt);
         errdefer std.heap.c_allocator.free(prompt_copy);
@@ -1285,10 +1364,7 @@ const App = struct {
 
         const authorized_image_catalog = try self.session.snapshotImageCatalog(
             std.heap.c_allocator,
-            if (recovery_checkpoint) |checkpoint|
-                checkpoint.user.images
-            else
-                self.pending_images.items,
+            source_images,
         );
         errdefer types.freeImageAttachmentSlice(std.heap.c_allocator, authorized_image_catalog);
 
@@ -1303,10 +1379,7 @@ const App = struct {
 
         const images_copy = try types.dupeImageAttachmentSlice(
             std.heap.c_allocator,
-            if (recovery_checkpoint) |checkpoint|
-                checkpoint.user.images
-            else
-                self.pending_images.items,
+            source_images,
         );
         errdefer types.freeImageAttachmentSlice(std.heap.c_allocator, images_copy);
 
@@ -1346,7 +1419,7 @@ const App = struct {
             );
 
         try self.worker.enqueuePrompt(std.heap.c_allocator, .{
-            .turn_id = if (recovery_checkpoint) |checkpoint| checkpoint.turn_id else 0,
+            .turn_id = if (recovery_checkpoint) |checkpoint| checkpoint.turn_id else turn_id,
             .prompt = prompt_copy,
             .images = images_copy,
             .authorized_image_catalog = authorized_image_catalog,
@@ -1366,6 +1439,7 @@ const App = struct {
             .context_snapshot = context_snapshot_copy,
             .recovery_checkpoint = recovery_checkpoint_copy,
             .recovery_source_already_presented = recovery_checkpoint != null,
+            .user_prompt_already_presented = user_prompt_already_presented,
         });
         HerdrAppRuntime.reportWorking(self);
         return true;
@@ -2494,6 +2568,7 @@ const App = struct {
     pub fn loopCollectFacts(ctx: *anyopaque) !void {
         const self: *App = @ptrCast(@alignCast(ctx));
         if (!try WorkerAppRuntime.authorizeInteractiveAdmission(self)) return;
+        InputSubmitRuntime.collectPendingSubmissionFacts(self);
 
         if (!self.terminal_takeover.blocksFxSurface(&self.terminal)) {
             try self.collectThemeFacts();

--- a/src/ui/assistant/user_message_card.zig
+++ b/src/ui/assistant/user_message_card.zig
@@ -136,6 +136,28 @@ pub fn buildUserPromptCardWithSkillTokensForTerminalPresentationInterruptible(
         skill_tokens,
         true,
         checkpoint,
+        null,
+    );
+}
+
+pub fn buildUserPromptCardTailForTerminalPresentationInterruptible(
+    alloc: std.mem.Allocator,
+    text: []const u8,
+    images: []const types.ImageAttachment,
+    cols: u16,
+    skill_tokens: []const visual_layout.SkillTokenSpan,
+    max_rows: usize,
+    checkpoint: ?*build_checkpoint.BuildCheckpoint,
+) ![]u8 {
+    return buildUserPromptCardWithSkillTokensAndLinksInterruptible(
+        alloc,
+        text,
+        images,
+        cols,
+        skill_tokens,
+        true,
+        checkpoint,
+        max_rows,
     );
 }
 
@@ -155,6 +177,7 @@ fn buildUserPromptCardWithSkillTokensAndLinks(
         skill_tokens,
         linked_images,
         null,
+        null,
     ) catch |err| switch (err) {
         error.InputPending => unreachable,
         else => |other| return other,
@@ -169,6 +192,7 @@ fn buildUserPromptCardWithSkillTokensAndLinksInterruptible(
     skill_tokens: []const visual_layout.SkillTokenSpan,
     linked_images: bool,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
+    max_rows: ?usize,
 ) ![]u8 {
     const window: usize = if (cols > 2) @as(usize, cols) - 2 else 0;
 
@@ -229,6 +253,7 @@ fn buildUserPromptCardWithSkillTokensAndLinksInterruptible(
         display_text,
         window,
         checkpoint,
+        max_rows,
     );
 
     for (rows.items) |content| {
@@ -276,6 +301,21 @@ fn appendRow(
     try rows.append(alloc, dup);
 }
 
+fn appendVisibleRow(
+    alloc: std.mem.Allocator,
+    rows: *std.ArrayList([]const u8),
+    content: []const u8,
+    max_rows: ?usize,
+) !void {
+    if (max_rows) |limit| {
+        if (limit == 0) return;
+        if (rows.items.len == limit) {
+            alloc.free(rows.orderedRemove(0));
+        }
+    }
+    try appendRow(alloc, rows, content);
+}
+
 fn writeRowPrefix(writer: *std.Io.Writer) !void {
     try writer.writeAll(marker_style);
     try writer.writeAll(user_turn_rail);
@@ -313,6 +353,7 @@ fn collectLogicalLinesWithFirstPrefix(
     text: []const u8,
     window: usize,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
+    max_rows: ?usize,
 ) !void {
     var it = std.mem.splitScalar(u8, text, '\n');
     while (it.next()) |line| {
@@ -322,7 +363,7 @@ fn collectLogicalLinesWithFirstPrefix(
         if (remaining.len == 0) {
             row_buf.clearRetainingCapacity();
             try writeRowPrefix(&row_buf.writer);
-            try appendRow(alloc, rows, row_buf.written());
+            try appendVisibleRow(alloc, rows, row_buf.written(), max_rows);
             continue;
         }
         while (remaining.len > 0) {
@@ -335,7 +376,7 @@ fn collectLogicalLinesWithFirstPrefix(
             try row_buf.writer.writeAll(fragment);
             active_hyperlink = hyperlinkStateAfter(fragment, active_hyperlink);
             if (active_hyperlink != null) try row_buf.writer.writeAll(osc8_close);
-            try appendRow(alloc, rows, row_buf.written());
+            try appendVisibleRow(alloc, rows, row_buf.written(), max_rows);
             remaining = remaining[c.skip_bytes..];
         }
     }
@@ -777,4 +818,24 @@ test "buildUserPromptCard handles leading newline with image" {
     try assertRowStructure(card);
     try std.testing.expect(std.mem.find(u8, card, "[Image 1]") != null);
     try std.testing.expect(std.mem.find(u8, card, "after") != null);
+}
+
+test "pending terminal card keeps only the visible tail rows" {
+    const alloc = std.testing.allocator;
+    const card = try buildUserPromptCardTailForTerminalPresentationInterruptible(
+        alloc,
+        "row0\nrow1\nrow2\nrow3\nrow4",
+        &.{},
+        80,
+        &.{},
+        2,
+        null,
+    );
+    defer alloc.free(card);
+
+    try std.testing.expectEqual(@as(usize, 2), std.mem.count(u8, card, "\n"));
+    try std.testing.expect(std.mem.find(u8, card, "row0") == null);
+    try std.testing.expect(std.mem.find(u8, card, "row2") == null);
+    try std.testing.expect(std.mem.find(u8, card, "row3") != null);
+    try std.testing.expect(std.mem.find(u8, card, "row4") != null);
 }

--- a/src/ui/assistant/user_message_card.zig
+++ b/src/ui/assistant/user_message_card.zig
@@ -149,6 +149,8 @@ pub fn buildUserPromptCardTailForTerminalPresentationInterruptible(
     max_rows: usize,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
 ) ![]u8 {
+    // The pending-frame path retains only the newest rows that fit its current
+    // transcript band; canonical formatting remains shared with ordinary turns.
     return buildUserPromptCardWithSkillTokensAndLinksInterruptible(
         alloc,
         text,

--- a/src/ui/render_engine/frame_builder.zig
+++ b/src/ui/render_engine/frame_builder.zig
@@ -52,6 +52,8 @@ pub const BuildFrameOptions = struct {
     document_append: frame_scroll_plan.FrameDocumentAppend = .{},
     terminal_transition: terminal_diff.FrameTerminalTransition = .none,
     body_painter: ?SurfacePainter = null,
+    /// Paints a bounded prompt tail after retained transcript rows and before
+    /// footer/activity surfaces. It never replaces the transcript body owner.
     transcript_tail_painter: ?SurfacePainter = null,
     footer_painter: ?SurfacePainter = null,
     activity_painter: ?SurfacePainter = null,

--- a/src/ui/render_engine/frame_builder.zig
+++ b/src/ui/render_engine/frame_builder.zig
@@ -52,6 +52,7 @@ pub const BuildFrameOptions = struct {
     document_append: frame_scroll_plan.FrameDocumentAppend = .{},
     terminal_transition: terminal_diff.FrameTerminalTransition = .none,
     body_painter: ?SurfacePainter = null,
+    transcript_tail_painter: ?SurfacePainter = null,
     footer_painter: ?SurfacePainter = null,
     activity_painter: ?SurfacePainter = null,
     presentation: FramePresentation = .styled,
@@ -238,6 +239,9 @@ fn paintFrameSurface(
                 retained.source_area,
             );
         },
+    }
+    if (options.transcript_tail_painter) |painter| {
+        try painter.paint(painter.ctx, surface);
     }
     if (options.footer_painter) |painter| {
         try painter.paint(painter.ctx, surface);
@@ -837,6 +841,71 @@ test "buildAndFlushFrame retains styled hyperlink body and appends footer namesp
     try std.testing.expectEqualStrings("https://body.example", shell.shadow.hyperlinkUrl(2).?);
     try std.testing.expectEqualStrings("https://footer.example", shell.shadow.hyperlinkUrl(3).?);
     try std.testing.expectEqual(@as(u32, 3), shell.shadow.cellAt(3, 1).?.style.hyperlink_id);
+}
+
+test "buildAndFlushFrame retains prior transcript and paints only a pending tail card" {
+    var sink = BuilderSink{};
+    defer sink.deinit(std.testing.allocator);
+    var shell = try TestShell.init(std.testing.allocator, sink.sink());
+    shell.bind();
+    defer shell.deinit();
+    try shell.shadow.feed("\x1b[2;1HOLD");
+    shell.shadow.cursor_row = 3;
+    shell.shadow.cursor_col = 1;
+
+    var plan = testPlan();
+    plan.layout.content_bottom = 3;
+    plan.layout.divider_top_row = 4;
+    plan.layout.input_row = 4;
+    plan.layout.divider_bottom_row = 4;
+    plan.layout.hint_row = 4;
+    plan.activity = .none;
+    plan.activity_band = paint_plan.FrameBand.empty(.activity);
+    plan.transcript_band = .{ .top = 2, .bottom = 3, .owner = .transcript };
+    plan.viewport.bottom_row = 3;
+    plan.viewport.last_visible_row = 3;
+    plan.footer.top = 4;
+    plan.footer.top_divider = 4;
+    plan.footer.banner = 4;
+    plan.footer.input_base = 4;
+    plan.footer.picker_divider = 4;
+    plan.footer.picker_start = 4;
+    plan.footer.bottom_divider = 4;
+    plan.footer.hint = 4;
+    plan.footer.total_rows = 1;
+    plan.footer_band = .{ .top = 4, .bottom = 4, .owner = .footer };
+    plan.cursor_target = .{ .row = 4, .col = 1, .visible = true };
+
+    var full_body = PaintCtx{ .text = "WRONG", .owner = .transcript, .row = 2 };
+    var pending_card = PaintCtx{ .text = "PENDING", .owner = .transcript, .row = 3 };
+    var footer = PaintCtx{ .text = ">", .owner = .footer, .row = 4 };
+    var counters: TraceCounters = .{};
+    var metrics: Metrics = .{};
+    const result = try buildAndFlushFrame(std.testing.allocator, &shell, &metrics, .{
+        .plan = plan,
+        .transcript_body = .{ .retain = .{
+            .source_area = .{ .top = 2, .bottom = 2 },
+            .occupied_last_row = 2,
+        } },
+        .scroll_plan = testScrollPlan(0),
+        .body_painter = .{ .ctx = &full_body, .paint = PaintCtx.painter },
+        .transcript_tail_painter = .{ .ctx = &pending_card, .paint = PaintCtx.painter },
+        .footer_painter = .{ .ctx = &footer, .paint = PaintCtx.painter },
+        .trace_counters = &counters,
+    });
+
+    try std.testing.expect(result.is_committed());
+    try std.testing.expectEqual(@as(usize, 0), counters.body_paints);
+    try std.testing.expect(std.mem.find(u8, sink.bytes.items, "OLD") == null);
+    try std.testing.expect(std.mem.find(u8, sink.bytes.items, "WRONG") == null);
+    try std.testing.expect(std.mem.find(u8, sink.bytes.items, "PENDING") != null);
+    var row_text: std.ArrayList(u8) = .empty;
+    defer row_text.deinit(std.testing.allocator);
+    try shell.shadow.rowTextTrimmed(2, &row_text);
+    try std.testing.expectEqualStrings("OLD", row_text.items);
+    row_text.clearRetainingCapacity();
+    try shell.shadow.rowTextTrimmed(3, &row_text);
+    try std.testing.expectEqualStrings("PENDING", row_text.items);
 }
 
 test "buildAndFlushFrame retains combining suffix without repainting body" {

--- a/src/ui/render_request.zig
+++ b/src/ui/render_request.zig
@@ -96,7 +96,6 @@ pub const RenderRequestState = struct {
     attempt_has_invalidations: bool = false,
     attempt_affects_approval: bool = false,
     frame_admission_block_depth: usize = 0,
-    submitted_prompt_transition_pending: bool = false,
     resize_dirty: bool = false,
     resize_apply_after_ms: i64 = 0,
     pending_settled_width_reflow: bool = false,
@@ -225,22 +224,6 @@ pub const RenderRequestState = struct {
     pub fn endFrameAdmissionBlock(self: *RenderRequestState) void {
         std.debug.assert(self.frame_admission_block_depth > 0);
         self.frame_admission_block_depth -= 1;
-    }
-
-    pub fn beginSubmittedPromptTransition(self: *RenderRequestState) void {
-        if (self.submitted_prompt_transition_pending) return;
-        self.submitted_prompt_transition_pending = true;
-        self.beginFrameAdmissionBlock();
-    }
-
-    pub fn finishSubmittedPromptTransition(self: *RenderRequestState) void {
-        if (!self.submitted_prompt_transition_pending) return;
-        self.submitted_prompt_transition_pending = false;
-        self.endFrameAdmissionBlock();
-    }
-
-    pub fn submittedPromptTransitionPending(self: RenderRequestState) bool {
-        return self.submitted_prompt_transition_pending;
     }
 
     pub fn requestAnimationDue(self: *RenderRequestState, now_ms: i64) bool {
@@ -579,31 +562,6 @@ test "frame admission block defers attempts without dropping pending work" {
     var attempt = (try state.beginAttempt()).?;
     try std.testing.expect(attempt.snapshot.reasons.contains(.footer));
     try std.testing.expect(attempt.snapshot.reasons.contains(.transcript));
-    attempt.restore();
-}
-
-test "submitted prompt transition coalesces pending work until presentation" {
-    var state = RenderRequestState{};
-    state.request(.transcript);
-
-    state.beginSubmittedPromptTransition();
-    state.beginSubmittedPromptTransition();
-    try std.testing.expect(state.submittedPromptTransitionPending());
-    try std.testing.expect(state.blocksFrameCommit());
-    try std.testing.expect((try state.beginAttempt()) == null);
-
-    state.beginFrameAdmissionBlock();
-    state.request(.footer);
-    state.finishSubmittedPromptTransition();
-    state.finishSubmittedPromptTransition();
-    try std.testing.expect(!state.submittedPromptTransitionPending());
-    try std.testing.expect(state.blocksFrameCommit());
-
-    state.endFrameAdmissionBlock();
-    try std.testing.expect(!state.blocksFrameCommit());
-    var attempt = (try state.beginAttempt()).?;
-    try std.testing.expect(attempt.snapshot.reasons.contains(.transcript));
-    try std.testing.expect(attempt.snapshot.reasons.contains(.footer));
     attempt.restore();
 }
 

--- a/tests/e2e/tmux-helpers.ts
+++ b/tests/e2e/tmux-helpers.ts
@@ -1174,6 +1174,36 @@ export class TmuxSession {
     );
   }
 
+  async waitForStableScrollback(
+    predicate: (scrollback: string) => boolean,
+    timeoutMs = 15_000,
+    stableMs = 100,
+  ): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    let stableSince: number | null = null;
+    let previousScrollback = "";
+    let lastScrollback = "";
+    while (Date.now() < deadline) {
+      const scrollback = await this.captureFullScrollback();
+      lastScrollback = scrollback;
+      if (predicate(scrollback)) {
+        if (scrollback !== previousScrollback) {
+          previousScrollback = scrollback;
+          stableSince = Date.now();
+        } else if (stableSince !== null && Date.now() - stableSince >= stableMs) {
+          return scrollback;
+        }
+      } else {
+        previousScrollback = "";
+        stableSince = null;
+      }
+      await sleep(25);
+    }
+    throw new Error(
+      `Timed out waiting for stable scrollback in ${this.name}.\nLast scrollback:\n${lastScrollback}`,
+    );
+  }
+
   async waitForSessionEnd(timeoutMs = 10_000): Promise<boolean> {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2562,6 +2562,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.sendLiteral(submittedPrompt);
       session.sendKeysImmediate(["Enter"]);
       session.sendLiteralImmediate(newerDraft);
+      session.sendKeysImmediate(["Enter"]);
       await waitForCondition(
         () => heldGateway.requests.length === 1 && hold.started,
         "held idle submitted prompt stream",

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -986,12 +986,7 @@ function assertFirstPostEnterOutputShowsSubmittedPrompt(
   submittedPrompt: string,
 ) {
   const frames = readTapeFrames(tapePath);
-  const enterIndex = frames.findIndex(
-    (frame) =>
-      frame.kind === 2 &&
-      frame.payload.equals(Buffer.from("\r")),
-  );
-  expect(enterIndex).toBeGreaterThanOrEqual(0);
+  const enterIndex = findEnterAfterSubmittedPrompt(frames, submittedPrompt);
 
   const firstOutput = frames
     .slice(enterIndex + 1)
@@ -1000,16 +995,30 @@ function assertFirstPostEnterOutputShowsSubmittedPrompt(
   expect(firstOutput!.payload.includes(Buffer.from(submittedPrompt))).toBe(true);
 }
 
+function findEnterAfterSubmittedPrompt(
+  frames: ReturnType<typeof readTapeFrames>,
+  submittedPrompt: string,
+): number {
+  const promptInputIndex = frames.findIndex((frame) =>
+    frame.kind === 2 && frame.payload.includes(Buffer.from(submittedPrompt))
+  );
+  expect(promptInputIndex).toBeGreaterThanOrEqual(0);
+  const enterIndex = frames.findIndex((frame, index) =>
+    index > promptInputIndex &&
+    frame.kind === 2 &&
+    frame.payload.equals(Buffer.from("\r"))
+  );
+  expect(enterIndex).toBeGreaterThan(promptInputIndex);
+  return enterIndex;
+}
+
 function assertSubmittedPromptRowStaysStableAfterEnter(
   tapePath: string,
   framesRoot: string,
   submittedPrompt: string,
 ) {
   const frames = readTapeFrames(tapePath);
-  const enterIndex = frames.findIndex(
-    (frame) => frame.kind === 2 && frame.payload.equals(Buffer.from("\r")),
-  );
-  expect(enterIndex).toBeGreaterThanOrEqual(0);
+  const enterIndex = findEnterAfterSubmittedPrompt(frames, submittedPrompt);
   const firstOutput = frames.slice(enterIndex + 1).find((frame) => frame.kind === 1);
   expect(firstOutput).toBeDefined();
   const gridDir = join(framesRoot, "frames");
@@ -2632,6 +2641,78 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(hold.cancelled).toBe(true);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
       expect(existsSync(tapePath)).toBe(true);
+      expect(session.isAlive()).toBe(true);
+      expect(session.isPaneAlive()).toBe(true);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "idle submitted prompt keeps its canonical row after a completed turn",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-idle-submit-multiturn-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const tapePath = join(root, "session.fxtape");
+      const framesRoot = join(root, "replay-frames");
+      const seedPrompt = "MULTI_TURN_SEED_PROMPT";
+      const seedReply = "MULTI_TURN_SEED_REPLY";
+      const submittedPrompt = "MULTI_TURN_ROW_SENTINEL";
+      const hold: HoldState = { started: false, cancelled: false };
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(join(home, ".fx", "settings.json"), "{}");
+
+      const queuedGateway = startFakeGateway([
+        fakeGatewayFinalText(seedReply),
+        () => heldGatewayResponse(hold),
+      ]);
+      gateway = queuedGateway;
+      session = await TmuxSession.create({
+        cwd: realpathSync(workspace),
+        width: 96,
+        height: 28,
+        stderrPath,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-idle-submit-multiturn-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_GATEWAY_BASE_URL: queuedGateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: queuedGateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: queuedGateway.chatUrl,
+          FX_MODEL: MODEL,
+          FX_RECORD: tapePath,
+          FX_RECORD_INPUT: "1",
+        },
+      });
+
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText(seedPrompt);
+      await session.waitForText(seedReply, TIMEOUT);
+      await session.waitForComposer(TIMEOUT);
+      await session.sendLiteral(submittedPrompt);
+      session.sendKeysImmediate(["Enter"]);
+      await waitForCondition(
+        () => queuedGateway.requests.length === 2 && hold.started,
+        "held multi-turn submitted prompt stream",
+      );
+      await session.waitForText("Thinking", TIMEOUT);
+      await Bun.sleep(250);
+      await session.sendKeys("C-c");
+      await session.waitForText("cancelled", TIMEOUT);
+
+      execFileSync(FX_BIN, ["replay", tapePath, "--frames-dir", framesRoot], {
+        encoding: "utf8",
+      });
+      assertFirstPostEnterOutputShowsSubmittedPrompt(tapePath, submittedPrompt);
+      assertSubmittedPromptRowStaysStableAfterEnter(
+        tapePath,
+        framesRoot,
+        submittedPrompt,
+      );
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
       expect(session.isAlive()).toBe(true);
       expect(session.isPaneAlive()).toBe(true);
     },

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -8365,9 +8365,12 @@ describe.skipIf(!tmuxAvailable())("transcript scrollback release", () => {
         ]);
         releaseFinish();
         await session.waitForPane(hasEmptyComposer, SB_TIMEOUT);
-        await Bun.sleep(250);
-
-        const scrollback = await session.captureFullScrollback();
+        const scrollback = await waitForScrollback(
+          session,
+          (value) => countOccurrences(value, "ANCHOR_PHASE_TWO_24") === 1,
+          "completed phase-two scrollback append",
+          SB_TIMEOUT,
+        );
         const orderedMarkers = [
           "BLOCK_HEADING",
           "BLOCK_PROSE",

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -1000,6 +1000,44 @@ function assertFirstPostEnterOutputShowsSubmittedPrompt(
   expect(firstOutput!.payload.includes(Buffer.from(submittedPrompt))).toBe(true);
 }
 
+function assertSubmittedPromptRowStaysStableAfterEnter(
+  tapePath: string,
+  framesRoot: string,
+  submittedPrompt: string,
+) {
+  const frames = readTapeFrames(tapePath);
+  const enterIndex = frames.findIndex(
+    (frame) => frame.kind === 2 && frame.payload.equals(Buffer.from("\r")),
+  );
+  expect(enterIndex).toBeGreaterThanOrEqual(0);
+  const firstOutput = frames.slice(enterIndex + 1).find((frame) => frame.kind === 1);
+  expect(firstOutput).toBeDefined();
+  const gridDir = join(framesRoot, "frames");
+  const frameNames = readdirSync(gridDir)
+    .filter((name) => name.endsWith(".grid.txt"))
+    .sort();
+  const firstGrid = readFileSync(
+    join(gridDir, `${String(firstOutput!.index).padStart(4, "0")}.grid.txt`),
+    "utf8",
+  );
+  const thinkingGrid = frameNames
+    .filter((name) => Number.parseInt(name, 10) > firstOutput!.index)
+    .map((name) => readFileSync(join(gridDir, name), "utf8"))
+    .find((grid) => grid.includes("Thinking"));
+  expect(thinkingGrid).toBeDefined();
+
+  const promptRow = (grid: string) => {
+    const row = grid.split(/\r?\n/).findIndex((line) =>
+      line.includes(submittedPrompt)
+    );
+    expect(row).toBeGreaterThanOrEqual(0);
+    return row;
+  };
+  expect(promptRow(thinkingGrid!)).toBe(
+    promptRow(firstGrid),
+  );
+}
+
 function hasBareRunningRow(value: string): boolean {
   return value.split(/\r?\n/).some((line) => line.trim() === "● Running");
 }
@@ -2576,6 +2614,11 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         encoding: "utf8",
       });
       assertFirstPostEnterOutputShowsSubmittedPrompt(tapePath, submittedPrompt);
+      assertSubmittedPromptRowStaysStableAfterEnter(
+        tapePath,
+        framesRoot,
+        submittedPrompt,
+      );
       assertThinkingFramesShowSubmittedPrompt(framesRoot, submittedPrompt);
       const trace = readFileSync(tracePath, "utf8");
       const frameCommitted = trace.indexOf("event=pending_prompt_frame_committed");

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -2518,8 +2518,10 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const workspacePath = join(root, "workspace");
       const stderrPath = join(root, "stderr.log");
       const tapePath = join(root, "session.fxtape");
+      const tracePath = join(root, "fx-trace.log");
       const framesRoot = join(root, "replay-frames");
       const submittedPrompt = "IDLE_SUBMIT_ORDER_SENTINEL";
+      const newerDraft = "RAPID_SECOND_DRAFT_SENTINEL";
       const hold: HoldState = { started: false, cancelled: false };
       mkdirSync(join(home, ".fx"), { recursive: true });
       mkdirSync(workspacePath, { recursive: true });
@@ -2551,11 +2553,15 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
           FX_MODEL: MODEL,
           FX_RECORD: tapePath,
           FX_RECORD_INPUT: "1",
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "input,worker",
         },
       });
 
       await session.waitForComposer(TIMEOUT);
-      await session.sendText(submittedPrompt);
+      await session.sendLiteral(submittedPrompt);
+      session.sendKeysImmediate(["Enter"]);
+      session.sendLiteralImmediate(newerDraft);
       await waitForCondition(
         () => heldGateway.requests.length === 1 && hold.started,
         "held idle submitted prompt stream",
@@ -2563,13 +2569,21 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.waitForText("Thinking", TIMEOUT);
       await Bun.sleep(250);
       await session.sendKeys("C-c");
-      await session.waitForText("cancelled", TIMEOUT);
+      const cancelledPane = await session.waitForText("cancelled", TIMEOUT);
 
       execFileSync(FX_BIN, ["replay", tapePath, "--frames-dir", framesRoot], {
         encoding: "utf8",
       });
       assertFirstPostEnterOutputShowsSubmittedPrompt(tapePath, submittedPrompt);
       assertThinkingFramesShowSubmittedPrompt(framesRoot, submittedPrompt);
+      const trace = readFileSync(tracePath, "utf8");
+      const frameCommitted = trace.indexOf("event=pending_prompt_frame_committed");
+      const promptQueued = trace.indexOf("event=prompt_enqueue");
+      const workerBegin = trace.indexOf("event=worker_begin");
+      expect(frameCommitted).toBeGreaterThanOrEqual(0);
+      expect(promptQueued).toBeGreaterThan(frameCommitted);
+      expect(workerBegin).toBeGreaterThan(promptQueued);
+      expect(composerContains(cancelledPane, newerDraft)).toBe(true);
 
       expect(hold.cancelled).toBe(true);
       expect(readFileSync(stderrPath, "utf8")).toBe("");

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -8365,10 +8365,10 @@ describe.skipIf(!tmuxAvailable())("transcript scrollback release", () => {
         ]);
         releaseFinish();
         await session.waitForPane(hasEmptyComposer, SB_TIMEOUT);
-        const scrollback = await waitForScrollback(
-          session,
-          (value) => countOccurrences(value, "ANCHOR_PHASE_TWO_24") === 1,
-          "completed phase-two scrollback append",
+        const scrollback = await session.waitForStableScrollback(
+          (value) =>
+            countOccurrences(value, "ANCHOR_PHASE_TWO_24") === 1 &&
+            TURN_SUMMARY_WITH_TOKENS.test(value),
           SB_TIMEOUT,
         );
         const orderedMarkers = [

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -3178,10 +3178,11 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("3");
       await active.sendKeys("Enter");
       await active.waitForText("CTRL_O_HANDOFF_DONE", TIMEOUT);
-      const scrollback = await waitForScrollbackOccurrences(
-        active,
-        priorSummary,
-        1,
+      const scrollback = await active.waitForStableScrollback(
+        (value) =>
+          value.includes("CTRL_O_HANDOFF_DONE") &&
+          countOccurrences(value, priorSummary) === 1,
+        TIMEOUT,
       );
       const inline = await active.capturePane();
       expect(inline).toContain("CTRL_O_HANDOFF_DONE");

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -3178,7 +3178,11 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("3");
       await active.sendKeys("Enter");
       await active.waitForText("CTRL_O_HANDOFF_DONE", TIMEOUT);
-      const scrollback = await active.captureFullScrollback();
+      const scrollback = await waitForScrollbackOccurrences(
+        active,
+        priorSummary,
+        1,
+      );
       const inline = await active.capturePane();
       expect(inline).toContain("CTRL_O_HANDOFF_DONE");
       expect(inline).not.toContain("Apply this change?");


### PR DESCRIPTION
## Summary

- Show accepted idle prompts on the first post-Enter frame before context, skill, snapshot, history, and worker preparation.
- Keep each prompt card canonical and visible exactly once through redraw, failure, cancellation, reset, and shutdown.
- Preserve credential admission, active-turn queue and review behavior, and rapid second drafts.