### PR TITLE
Add fx ask --bare mode with explicit MCP config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Use `fx ask` for a single request:
 fx ask "explain the changes in this repository"
 ```
 
+For scripted and CI use, `fx ask --bare` skips skills, AGENTS.md discovery, and MCP server startup, and reads credentials only from the environment, so every machine produces the same run without touching your login or keychain. `FX_BARE=1` enables the same mode. Bare mode requires `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN`; OAuth logins and stored keys are never read. Pair `--mcp-config <path>` with `--bare` to load MCP servers from an explicit file instead of `~/.fx/mcp.json`; under `--bare` only servers that do not require OAuth are usable.
+
 Foreground terminal commands run with an explicit finite deadline. fx uses durable terminal sessions for services, watchers, GUI applications, and other long-lived work, and keeps captured foreground output available through an opaque bounded-read handle for the active session or `--no-save` process.
 
 fx starts in `auto` permission mode. Routine understood development actions run directly. Each unresolved action receives one narrow safety review based on the current user request and the exact pending action. A clear result authorizes only that action. A caution or unavailable review holds the action and returns advice to the agent without opening a permission prompt or ending the turn. See [Permissions](https://fx.sh/docs/configure-fx/permissions) for other modes and persistent rules.

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -30,7 +30,7 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .ask,
         .token = "ask",
-        .usage = "ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>",
+        .usage = "ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--bare] [--mcp-config PATH] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>",
         .summary = "Run one noninteractive request",
         .options = &.{
             .{ .flag = "--auto", .description = "Automatically review unresolved permission requests" },
@@ -41,6 +41,8 @@ pub const top_level_specs = [_]TopLevelSpec{
             .{ .flag = "--prompt-permissions", .description = "Prompt for Y/N permission approval when stdin is a TTY" },
             .{ .flag = "--no-save", .description = "Do not save the session; incompatible with --resume and --resume-id" },
             .{ .flag = "--no-color", .description = "Render TTY output without colors or hyperlinks" },
+            .{ .flag = "--bare", .description = "Skip skills, AGENTS.md, and MCP discovery; read credentials only from the environment" },
+            .{ .flag = "--mcp-config PATH", .description = "Load MCP servers from PATH instead of ~/.fx/mcp.json" },
             .{ .flag = "--resume <last|id>", .description = "Continue the last session or a session by id" },
             .{ .flag = "--resume-id <id>", .description = "Continue a session by exact id" },
             .{ .flag = "--continue-recovery", .description = "Resume the paused model response in the selected session" },
@@ -51,6 +53,7 @@ pub const top_level_specs = [_]TopLevelSpec{
             "TTY stdout uses the Minimal transcript presentation; redirected stdout emits raw assistant Markdown.",
             "Operational progress and diagnostics are written to stderr. JSON output keeps raw Markdown in `output`.",
             "With --prompt-permissions, JSON and quiet requests may prompt on stderr only when stdin is a TTY.",
+            "--bare also enables via FX_BARE=1; it requires AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN and never reads OAuth logins or stored keys.",
         },
     },
     .{

--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -357,6 +357,16 @@ pub fn loadRuntime(
     const config_path = try configPathFromHome(alloc, home);
     defer alloc.free(config_path);
 
+    return loadRuntimeFromPath(alloc, elicitation_capabilities, config_path);
+}
+
+/// Load servers from an explicit config file instead of the profile default.
+/// Used by `fx ask --mcp-config`.
+pub fn loadRuntimeFromPath(
+    alloc: Allocator,
+    elicitation_capabilities: elicitation.Capabilities,
+    config_path: []const u8,
+) !?*mcp_runtime.McpRuntime {
     var configs = try loadConfigFromPath(alloc, config_path);
     defer freeConfigs(alloc, &configs);
 
@@ -2163,6 +2173,32 @@ test "save and reload preserves mixed stdio and sse configs" {
     try std.testing.expect(!reloaded.items[0].enabled);
     try std.testing.expectEqual(McpTransport.sse, reloaded.items[1].transport);
     try std.testing.expectEqualStrings("https://mcp.example.com", try reloaded.items[1].remoteUrl());
+}
+
+test "loadRuntimeFromPath loads an explicit config and tolerates a missing file" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmpRoot(alloc, tmp);
+    defer alloc.free(root);
+    const path = try tmpPath(alloc, root, "mcp.json");
+    defer alloc.free(path);
+
+    const missing = try loadRuntimeFromPath(alloc, .{}, "/nonexistent/fx-mcp-config.json");
+    try std.testing.expect(missing == null);
+
+    var configs = try loadConfigFromJson(alloc,
+        \\{"mcp":{"local":{"type":"local","command":["node","server.js"]}}}
+    );
+    defer freeConfigs(alloc, &configs);
+    try saveConfigsToPath(alloc, path, configs.items);
+
+    const runtime = (try loadRuntimeFromPath(alloc, .{}, path)) orelse
+        return error.TestUnexpectedResult;
+    defer alloc.destroy(runtime);
+    defer runtime.deinit();
+    try std.testing.expectEqual(@as(usize, 1), runtime.servers.items.len);
 }
 
 test "save and reload preserves HTTP identity and headers" {

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -64,6 +64,7 @@ pub const Config = struct {
     tool_set: tool_set_contract.ToolSet,
     inspect_mcp_profile_config: mcp_contract.InspectProfileConfigFn,
     load_mcp_runtime: mcp_runtime.LoadRuntimeFn,
+    load_mcp_runtime_from_path: mcp_runtime.LoadRuntimeFromPathFn,
     acp_runner: acp_runner.Runner,
 };
 
@@ -405,6 +406,7 @@ fn cliSurfaceConfig(cfg: Config) cli_surface.Config {
         .tool_set = cfg.tool_set,
         .inspect_mcp_profile_config = cfg.inspect_mcp_profile_config,
         .load_mcp_runtime = cfg.load_mcp_runtime,
+        .load_mcp_runtime_from_path = cfg.load_mcp_runtime_from_path,
         .acp_runner = cfg.acp_runner,
     };
 }
@@ -484,6 +486,10 @@ fn noMcpRuntimeForTest(_: Allocator, _: @import("../mcp/elicitation.zig").Capabi
     return null;
 }
 
+fn noMcpRuntimeFromPathForTest(_: Allocator, _: @import("../mcp/elicitation.zig").Capabilities, _: []const u8) !?*mcp_runtime.McpRuntime {
+    return null;
+}
+
 fn noMcpConfigInspectionForTest(
     _: Allocator,
 ) error{OutOfMemory}!mcp_contract.ProfileConfigDiagnostic {
@@ -521,6 +527,7 @@ fn testConfig() Config {
         .mode_registry = .{ .default_mode_id = "entry" },
         .inspect_mcp_profile_config = noMcpConfigInspectionForTest,
         .load_mcp_runtime = noMcpRuntimeForTest,
+        .load_mcp_runtime_from_path = noMcpRuntimeFromPathForTest,
         .acp_runner = .{ .run_fn = unexpectedAcpRunForTest },
         .tool_set = .{
             .registry = .{ .tools = &.{} },

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -198,6 +198,8 @@ const FxLoginRefreshMode = enum { if_needed, force };
 
 pub const missing_credential_message = "Fx needs access to Vercel AI Gateway. Run fx login to sign in, fx setup to use an API key, or set AI_GATEWAY_API_KEY.";
 pub const missing_interactive_credential_message = "Fx needs access to Vercel AI Gateway. Run /login to sign in, /setup to use an API key, or set AI_GATEWAY_API_KEY.";
+pub const missing_bare_credential_message = "fx ask --bare never reads OAuth logins or stored keys. Set AI_GATEWAY_API_KEY (or VERCEL_OIDC_TOKEN) in the environment.";
+pub const missing_bare_subscription_credential_message = "fx ask --bare never reads OAuth logins or stored keys, so ChatGPT and Grok subscription credentials are unavailable. Use the gateway with AI_GATEWAY_API_KEY.";
 pub const missing_chatgpt_credential_message = "fx needs a Codex subscription login for this model. Run fx login codex.";
 pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login and choose Sign in with Codex.";
 pub const missing_grok_credential_message = "fx needs a Grok subscription login for this model. Run fx login grok.";
@@ -352,6 +354,28 @@ pub fn resolvePreferring(
     };
     if (stored) |credential| return .{ .credential = credential, .fx_login_status = fx_login_status };
     return .{ .stored_key_status = status, .fx_login_status = fx_login_status };
+}
+
+pub fn envCredentialAvailable() bool {
+    return nonEmptyEnvValue("VERCEL_OIDC_TOKEN") != null or
+        nonEmptyEnvValue("AI_GATEWAY_API_KEY") != null;
+}
+
+/// Bare-mode credential resolution: environment-variable keys only. OAuth
+/// session files and the secret store are never read, and subscription
+/// providers (codex, grok) have no environment key, so they do not resolve.
+pub fn resolveEnvOnly(
+    alloc: std.mem.Allocator,
+    provider: model_provider.ProviderId,
+) !Resolution {
+    if (provider != .gateway) return .{};
+    if (try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .vercel_oidc_token)) |credential| {
+        return .{ .credential = credential };
+    }
+    if (try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .ai_gateway_api_key)) |credential| {
+        return .{ .credential = credential };
+    }
+    return .{};
 }
 
 fn loadFxLoginForPrecedence(
@@ -919,6 +943,49 @@ test "source-specific credential loading bypasses generic precedence" {
     try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .ai_gateway_api_key));
     try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .vercel_oidc_token));
     try std.testing.expect(!(try sourceExists(alloc, host.unavailable_secret_store, .stored_key)));
+}
+
+test "bare resolution reads only environment keys and prefers OIDC" {
+    const alloc = std.testing.allocator;
+    const env = try CredentialTestEnv.install(alloc, &.{
+        .{ "VERCEL_OIDC_TOKEN", "oidc-token" },
+        .{ "AI_GATEWAY_API_KEY", "api-key" },
+    });
+    defer env.deinit();
+
+    const resolution = try resolveEnvOnly(alloc, .gateway);
+    var credential = resolution.credential orelse return error.TestExpectedCredential;
+    defer credential.deinit(alloc);
+    try std.testing.expectEqualStrings("oidc-token", credential.token);
+    try std.testing.expectEqual(Source.vercel_oidc_token, credential.source);
+
+    const api_only = try resolveEnvOnly(alloc, .codex);
+    try std.testing.expect(api_only.credential == null);
+    const grok_only = try resolveEnvOnly(alloc, .grok);
+    try std.testing.expect(grok_only.credential == null);
+}
+
+test "bare resolution falls back to the API key and reports absence" {
+    const alloc = std.testing.allocator;
+
+    {
+        const env = try CredentialTestEnv.install(alloc, &.{
+            .{ "AI_GATEWAY_API_KEY", "api-key" },
+        });
+        defer env.deinit();
+        const resolution = try resolveEnvOnly(alloc, .gateway);
+        var credential = resolution.credential orelse return error.TestExpectedCredential;
+        defer credential.deinit(alloc);
+        try std.testing.expectEqualStrings("api-key", credential.token);
+        try std.testing.expectEqual(Source.ai_gateway_api_key, credential.source);
+    }
+
+    {
+        const env = try CredentialTestEnv.install(alloc, &.{});
+        defer env.deinit();
+        const resolution = try resolveEnvOnly(alloc, .gateway);
+        try std.testing.expect(resolution.credential == null);
+    }
 }
 
 test "a remembered choice outranks the environment" {

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -241,6 +241,7 @@ pub const Config = struct {
     max_history_turns: usize,
     mode_registry: mode_registry.Registry,
     load_mcp_runtime: mcp_runtime.LoadRuntimeFn,
+    load_mcp_runtime_from_path: ?mcp_runtime.LoadRuntimeFromPathFn = null,
     context_limit_overrides: []const config_runtime.context_limits.Override = &.{},
     additional_directories: []const []const u8 = &.{},
     saved_directories_suppressed: bool = false,
@@ -315,6 +316,7 @@ const AskOptions = struct {
     image_paths: std.ArrayList([]u8) = .empty,
     images: std.ArrayList(ImageAttachment) = .empty,
     system_prompt_override: ?[]u8 = null,
+    mcp_config_path: ?[]u8 = null,
     json_output: bool = false,
     prompt_permissions: bool = false,
     timeout_ms: ?usize = null,
@@ -323,6 +325,7 @@ const AskOptions = struct {
     no_save: bool = false,
     no_color: bool = false,
     continue_recovery: bool = false,
+    bare: bool = false,
 
     fn deinit(self: *AskOptions, alloc: Allocator) void {
         alloc.free(self.prompt);
@@ -331,6 +334,7 @@ const AskOptions = struct {
         for (self.images.items) |image| types.freeImageAttachment(alloc, image);
         self.images.deinit(alloc);
         if (self.system_prompt_override) |s| alloc.free(s);
+        if (self.mcp_config_path) |p| alloc.free(p);
     }
 };
 
@@ -378,6 +382,7 @@ const NotifyAttentionFn = *const fn (?*anyopaque) void;
 const PermissionApprovalPromptFn = *const fn (?*anyopaque, ?*anyopaque, WriteFn, []const u8, ?*anyopaque, NotifyAttentionFn) anyerror!PermissionApprovalPromptResult;
 const IsTtyFn = *const fn (?*anyopaque) bool;
 const LoadStartupStateFn = *const fn (Allocator, oauth_transport.Provider, host.SecretStore, []const u8, usize) anyerror!app_lifecycle.StartupState;
+const LoadStartupStateWithoutCredentialsFn = *const fn (Allocator, []const u8, usize) anyerror!app_lifecycle.StartupState;
 const InitializeSessionStoresFn = *const fn (*AskContext) anyerror!void;
 const LoadSkillsFn = *const fn (
     Allocator,
@@ -400,11 +405,13 @@ const RunDeps = struct {
     stdout_is_tty: IsTtyFn = realStdoutIsTty,
     stderr_is_tty: IsTtyFn = realStderrIsTty,
     load_startup_state: LoadStartupStateFn = loadStartupStateDefault,
+    load_startup_state_without_credentials: LoadStartupStateWithoutCredentialsFn = app_lifecycle.loadStartupStateWithoutCredentials,
     initialize_session_stores: InitializeSessionStoresFn = initializeSessionStoresDefault,
     load_skills: LoadSkillsFn = app_runtime_setup.loadSkills,
     context_registry: context_contract.Registry,
     tool_set: tool_set_contract.ToolSet,
     load_mcp_runtime: mcp_runtime.LoadRuntimeFn,
+    load_mcp_runtime_from_path: ?mcp_runtime.LoadRuntimeFromPathFn = null,
     process_queued_prompt: ProcessQueuedPromptFn = processQueuedPromptDefault,
     persist_yolo_acknowledgment: PersistYoloAcknowledgmentFn = persistYoloAcknowledgmentDefault,
     discard_pristine_session_ctx: ?*anyopaque = null,
@@ -439,6 +446,8 @@ const RunOptions = struct {
     resume_target: ?ResumeTarget = null,
     color_enabled: bool = true,
     continue_recovery: bool = false,
+    bare: bool = false,
+    mcp_config_path: ?[]const u8 = null,
     deps: RunDeps,
 };
 
@@ -1126,6 +1135,7 @@ pub fn run(alloc: Allocator, args: []const [:0]const u8, cfg: Config, context_re
         .context_registry = context_registry,
         .tool_set = tool_set,
         .load_mcp_runtime = cfg.load_mcp_runtime,
+        .load_mcp_runtime_from_path = cfg.load_mcp_runtime_from_path,
         .install_headless_interrupt = true,
     });
 }
@@ -1243,6 +1253,9 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
     defer options.deinit(alloc);
 
     if (interrupt_scope.requested()) return headless_interrupt.exitCode();
+    if (options.mcp_config_path) |path| {
+        if (!try preflightMcpConfig(deps, path)) return 1;
+    }
     if (options.image_paths.items.len > 0) {
         const workspace_root = try io_mod.realpathAlloc(alloc, ".");
         defer alloc.free(workspace_root);
@@ -1270,6 +1283,8 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
         .resume_target = options.resume_target,
         .color_enabled = !options.no_color,
         .continue_recovery = options.continue_recovery,
+        .bare = options.bare,
+        .mcp_config_path = options.mcp_config_path,
         .deps = deps,
     }) catch |err| {
         if (interrupt_scope.requested()) return headless_interrupt.exitCode();
@@ -1310,6 +1325,27 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
         headless_interrupt.exitCode()
     else
         result.exit_code;
+}
+
+fn preflightMcpConfig(
+    deps: RunDeps,
+    path: []const u8,
+) !bool {
+    var file = std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{}) catch |err| {
+        if (err == error.OutOfMemory) return err;
+        const reason = switch (err) {
+            error.FileNotFound => "file not found",
+            else => @errorName(err),
+        };
+        try deps.write_stderr(deps.stderr_ctx, "fx ask: MCP config ");
+        try deps.write_stderr(deps.stderr_ctx, path);
+        try deps.write_stderr(deps.stderr_ctx, ": ");
+        try deps.write_stderr(deps.stderr_ctx, reason);
+        try deps.write_stderr(deps.stderr_ctx, "\n");
+        return false;
+    };
+    file.close(io_mod.getIo());
+    return true;
 }
 
 fn preflightAskImages(
@@ -1384,7 +1420,12 @@ fn missingCredentialResult(
     options: RunOptions,
     provider: model_provider.ProviderId,
 ) !PromptRunResult {
-    const message = if (provider == .codex)
+    const message = if (options.bare)
+        (if (provider == .gateway)
+            credentials.missing_bare_credential_message
+        else
+            credentials.missing_bare_subscription_credential_message)
+    else if (provider == .codex)
         credentials.missing_chatgpt_credential_message
     else if (provider == .grok)
         credentials.missing_grok_credential_message
@@ -1405,13 +1446,20 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     defer alloc.free(owned_prompt);
 
     try checkHeadlessCancellation(options.deps);
-    var startup = try options.deps.load_startup_state(
-        alloc,
-        cfg.gateway_provider.oauth_transport,
-        cfg.secret_store,
-        cfg.default_model,
-        cfg.default_agent_step_limit,
-    );
+    var startup = if (options.bare)
+        try options.deps.load_startup_state_without_credentials(
+            alloc,
+            cfg.default_model,
+            cfg.default_agent_step_limit,
+        )
+    else
+        try options.deps.load_startup_state(
+            alloc,
+            cfg.gateway_provider.oauth_transport,
+            cfg.secret_store,
+            cfg.default_model,
+            cfg.default_agent_step_limit,
+        );
     defer startup.deinit(alloc);
     try checkHeadlessCancellation(options.deps);
 
@@ -1445,8 +1493,14 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     );
     try checkHeadlessCancellation(options.deps);
 
-    if (!options.continue_recovery and options.resume_target == null and startup.credential == null) {
-        return missingCredentialResult(alloc, options, startup.provider);
+    if (!options.continue_recovery and options.resume_target == null) {
+        if (options.bare) {
+            if (startup.provider != .gateway or !credentials.envCredentialAvailable()) {
+                return missingCredentialResult(alloc, options, startup.provider);
+            }
+        } else if (startup.credential == null) {
+            return missingCredentialResult(alloc, options, startup.provider);
+        }
     }
 
     var owned_resumed_model: ?[]u8 = null;
@@ -1485,7 +1539,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     ctx.permission_mode = permission_mode;
     ctx.mode_id = mode_id;
     ctx.permission_rules = try takeCorePermissionRules(alloc, &startup);
-    ctx.context_enabled = startup.context_enabled;
+    ctx.context_enabled = startup.context_enabled and !options.bare;
     if (options.output_mode.isTerminal()) {
         presenter = try ask_presentation.Runtime.init(alloc, .{
             .text = owned_prompt,
@@ -1525,22 +1579,29 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
 
     var routed_credential: ?credentials.Credential = null;
     defer if (routed_credential) |*credential| credential.deinit(alloc);
-    const startup_matches_final_model = if (startup.credential) |credential|
-        model_provider.authorizesCredential(ctx.provider, credential.source)
+    const startup_matches_final_model = if (!options.bare)
+        (if (startup.credential) |credential|
+            model_provider.authorizesCredential(ctx.provider, credential.source)
+        else
+            false)
     else
         false;
     const credential: *const credentials.Credential = if (startup_matches_final_model)
         &startup.credential.?
     else routed: {
-        const preferred = if (startup.credential) |value| value.source else null;
-        const resolution = try credentials.resolveForProvider(
-            alloc,
-            cfg.gateway_provider.oauth_transport,
-            cfg.secret_store,
-            .refresh_if_needed,
-            ctx.provider,
-            preferred,
-        );
+        const resolution = if (options.bare)
+            try credentials.resolveEnvOnly(alloc, ctx.provider)
+        else blk: {
+            const preferred = if (startup.credential) |value| value.source else null;
+            break :blk try credentials.resolveForProvider(
+                alloc,
+                cfg.gateway_provider.oauth_transport,
+                cfg.secret_store,
+                .refresh_if_needed,
+                ctx.provider,
+                preferred,
+            );
+        };
         routed_credential = resolution.credential;
         if (routed_credential == null) {
             return missingCredentialResult(alloc, options, ctx.provider);
@@ -1601,17 +1662,20 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     defer types.freeImageAttachmentSlice(alloc, authorized_image_catalog);
 
     try ctx.checkCancellation();
-    var loaded_skills = try options.deps.load_skills(
-        alloc,
-        startup.workspace_root,
-        cfg.skill_root_policy,
-    );
+    var loaded_skills: app_runtime_setup.LoadedSkills = if (options.bare)
+        .{}
+    else
+        try options.deps.load_skills(
+            alloc,
+            startup.workspace_root,
+            cfg.skill_root_policy,
+        );
     defer loaded_skills.deinit(alloc);
     try ctx.checkCancellation();
     skill_runtime.traceDiagnostics("ask_startup", loaded_skills.diagnostics);
     ctx.skills_dir = loaded_skills.dir;
     loaded_skills.dir = &.{};
-    if (startup.context_enabled) {
+    if (ctx.context_enabled) {
         try ctx.checkCancellation();
         const context_targets = try context_contract.applicableTargetsForImages(alloc, current_images);
         defer if (context_targets.len > 0) alloc.free(context_targets);
@@ -1626,7 +1690,15 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     }
 
     try ctx.checkCancellation();
-    ctx.mcp = try options.deps.load_mcp_runtime(alloc, ctx.mcp_elicitation_capabilities);
+    if (options.mcp_config_path) |mcp_path| {
+        const loader = options.deps.load_mcp_runtime_from_path orelse {
+            try ctx.writeStderr("fx ask: --mcp-config is not supported in this build\n");
+            return error.McpConfigUnsupported;
+        };
+        ctx.mcp = try loader(alloc, ctx.mcp_elicitation_capabilities, mcp_path);
+    } else if (!options.bare) {
+        ctx.mcp = try options.deps.load_mcp_runtime(alloc, ctx.mcp_elicitation_capabilities);
+    }
     if (ctx.mcp) |mcp| mcp.connectRequiredForAsk(ctx.toolRegistry());
     try ctx.checkCancellation();
     if (ctx.mcp) |mcp| {
@@ -3304,6 +3376,13 @@ fn onBackgroundUrlReady(raw_ctx: *anyopaque, task_id: u64, url: []const u8) void
     ctx.writeStderr(line) catch {};
 }
 
+fn envFlagEnabled(name: []const u8) bool {
+    const raw = io_mod.getenv(name) orelse return false;
+    const value = std.mem.trim(u8, raw, " \t\r\n");
+    if (value.len == 0) return false;
+    return !(std.mem.eql(u8, value, "0") or std.ascii.eqlIgnoreCase(value, "false"));
+}
+
 fn parseOptionsWithStdin(alloc: Allocator, args: []const [:0]const u8, stdin: StdinSource) !AskOptions {
     var opts: AskOptions = .{ .prompt = &.{} };
     errdefer opts.deinit(alloc);
@@ -3364,12 +3443,28 @@ fn parseOptionsWithStdin(alloc: Allocator, args: []const [:0]const u8, stdin: St
         } else if (std.mem.eql(u8, arg, "--continue-recovery")) {
             if (opts.continue_recovery) return error.InvalidAskArgs;
             opts.continue_recovery = true;
+        } else if (std.mem.eql(u8, arg, "--bare")) {
+            opts.bare = true;
+        } else if (std.mem.eql(u8, arg, "--mcp-config")) {
+            if (opts.mcp_config_path != null) return error.InvalidAskArgs;
+            i += 1;
+            if (i >= args.len) return error.InvalidAskArgs;
+            const path = std.mem.trim(u8, args[i], " \t\r\n");
+            if (path.len == 0) return error.InvalidAskArgs;
+            opts.mcp_config_path = try alloc.dupe(u8, path);
+        } else if (std.mem.startsWith(u8, arg, "--mcp-config=")) {
+            if (opts.mcp_config_path != null) return error.InvalidAskArgs;
+            const path = std.mem.trim(u8, arg["--mcp-config=".len..], " \t\r\n");
+            if (path.len == 0) return error.InvalidAskArgs;
+            opts.mcp_config_path = try alloc.dupe(u8, path);
         } else if (arg.len > 1 and arg[0] == '-') {
             return error.InvalidAskArgs;
         } else {
             try prompt_parts.append(alloc, arg);
         }
     }
+
+    opts.bare = opts.bare or envFlagEnabled("FX_BARE");
 
     if (opts.continue_recovery) {
         if (opts.resume_target == null or opts.no_save or
@@ -4819,6 +4914,64 @@ test "parse options accepts yolo and rejects permission flag conflicts" {
             &.{ "--auto", "--yolo", "hello" },
             .tty,
         ),
+    );
+}
+
+var ask_test_empty_env: std.process.Environ.Map = std.process.Environ.Map.init(std.heap.c_allocator);
+
+test "parse options enables bare via --bare flag or FX_BARE env" {
+    const alloc = std.testing.allocator;
+    defer io_mod.setEnvironMap(&ask_test_empty_env);
+
+    var flagged = try parseOptionsWithStdin(alloc, &.{ "--bare", "hello" }, .tty);
+    defer flagged.deinit(alloc);
+    try std.testing.expect(flagged.bare);
+
+    var env = std.process.Environ.Map.init(alloc);
+    defer env.deinit();
+    try env.put("FX_BARE", "1");
+    io_mod.setEnvironMap(&env);
+    var from_env = try parseOptionsWithStdin(alloc, &.{"hello"}, .tty);
+    defer from_env.deinit(alloc);
+    try std.testing.expect(from_env.bare);
+
+    try env.put("FX_BARE", "false");
+    var disabled = try parseOptionsWithStdin(alloc, &.{"hello"}, .tty);
+    defer disabled.deinit(alloc);
+    try std.testing.expect(!disabled.bare);
+
+    io_mod.setEnvironMap(&ask_test_empty_env);
+    var no_env = try parseOptionsWithStdin(alloc, &.{"hello"}, .tty);
+    defer no_env.deinit(alloc);
+    try std.testing.expect(!no_env.bare);
+}
+
+test "parse options accepts --mcp-config in space and equals forms" {
+    const alloc = std.testing.allocator;
+
+    var spaced = try parseOptionsWithStdin(alloc, &.{ "--mcp-config", "/tmp/mcp.json", "hello" }, .tty);
+    defer spaced.deinit(alloc);
+    try std.testing.expectEqualStrings("/tmp/mcp.json", spaced.mcp_config_path.?);
+
+    var equals = try parseOptionsWithStdin(alloc, &.{ "--mcp-config=/tmp/other.json", "hello" }, .tty);
+    defer equals.deinit(alloc);
+    try std.testing.expectEqualStrings("/tmp/other.json", equals.mcp_config_path.?);
+
+    try std.testing.expectError(
+        error.InvalidAskArgs,
+        parseOptionsWithStdin(alloc, &.{ "--mcp-config", "/a.json", "--mcp-config", "/b.json", "hello" }, .tty),
+    );
+    try std.testing.expectError(
+        error.InvalidAskArgs,
+        parseOptionsWithStdin(alloc, &.{"--mcp-config"}, .tty),
+    );
+    try std.testing.expectError(
+        error.InvalidAskArgs,
+        parseOptionsWithStdin(alloc, &.{ "--mcp-config", "   ", "hello" }, .tty),
+    );
+    try std.testing.expectError(
+        error.InvalidAskArgs,
+        parseOptionsWithStdin(alloc, &.{ "--mcp-config=", "hello" }, .tty),
     );
 }
 

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -241,7 +241,7 @@ pub const Config = struct {
     max_history_turns: usize,
     mode_registry: mode_registry.Registry,
     load_mcp_runtime: mcp_runtime.LoadRuntimeFn,
-    load_mcp_runtime_from_path: ?mcp_runtime.LoadRuntimeFromPathFn = null,
+    load_mcp_runtime_from_path: mcp_runtime.LoadRuntimeFromPathFn,
     context_limit_overrides: []const config_runtime.context_limits.Override = &.{},
     additional_directories: []const []const u8 = &.{},
     saved_directories_suppressed: bool = false,
@@ -411,7 +411,7 @@ const RunDeps = struct {
     context_registry: context_contract.Registry,
     tool_set: tool_set_contract.ToolSet,
     load_mcp_runtime: mcp_runtime.LoadRuntimeFn,
-    load_mcp_runtime_from_path: ?mcp_runtime.LoadRuntimeFromPathFn = null,
+    load_mcp_runtime_from_path: mcp_runtime.LoadRuntimeFromPathFn,
     process_queued_prompt: ProcessQueuedPromptFn = processQueuedPromptDefault,
     persist_yolo_acknowledgment: PersistYoloAcknowledgmentFn = persistYoloAcknowledgmentDefault,
     discard_pristine_session_ctx: ?*anyopaque = null,
@@ -1397,6 +1397,7 @@ pub fn runPrompt(alloc: Allocator, prompt: []const u8, auto_permission: bool, cf
             .context_registry = context_registry,
             .tool_set = tool_set,
             .load_mcp_runtime = cfg.load_mcp_runtime,
+            .load_mcp_runtime_from_path = cfg.load_mcp_runtime_from_path,
         },
     });
     defer result.deinit(alloc);
@@ -1411,6 +1412,7 @@ pub fn runPromptCapture(alloc: Allocator, prompt: []const u8, auto_permission: b
             .context_registry = context_registry,
             .tool_set = tool_set,
             .load_mcp_runtime = cfg.load_mcp_runtime,
+            .load_mcp_runtime_from_path = cfg.load_mcp_runtime_from_path,
         },
     });
 }
@@ -1691,11 +1693,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
 
     try ctx.checkCancellation();
     if (options.mcp_config_path) |mcp_path| {
-        const loader = options.deps.load_mcp_runtime_from_path orelse {
-            try ctx.writeStderr("fx ask: --mcp-config is not supported in this build\n");
-            return error.McpConfigUnsupported;
-        };
-        ctx.mcp = try loader(alloc, ctx.mcp_elicitation_capabilities, mcp_path);
+        ctx.mcp = try options.deps.load_mcp_runtime_from_path(alloc, ctx.mcp_elicitation_capabilities, mcp_path);
     } else if (!options.bare) {
         ctx.mcp = try options.deps.load_mcp_runtime(alloc, ctx.mcp_elicitation_capabilities);
     }
@@ -3924,6 +3922,7 @@ fn testConfig() Config {
         .max_history_turns = 2,
         .mode_registry = test_mode_registry,
         .load_mcp_runtime = testNoMcpRuntime,
+        .load_mcp_runtime_from_path = testNoMcpRuntimeFromPath,
     };
 }
 
@@ -4459,6 +4458,10 @@ fn testNoMcpRuntime(_: Allocator, _: mcp_elicitation.Capabilities) !?*mcp_runtim
     return null;
 }
 
+fn testNoMcpRuntimeFromPath(_: Allocator, _: mcp_elicitation.Capabilities, _: []const u8) !?*mcp_runtime.McpRuntime {
+    return null;
+}
+
 fn testPromptRunDeps(stdout_capture: *TestCapture, stderr_capture: *TestCapture, load_startup_state: LoadStartupStateFn) RunDeps {
     return .{
         .stdout_ctx = stdout_capture,
@@ -4471,6 +4474,7 @@ fn testPromptRunDeps(stdout_capture: *TestCapture, stderr_capture: *TestCapture,
         .context_registry = test_no_context_registry,
         .tool_set = builtin_tools.advertisement_set,
         .load_mcp_runtime = testNoMcpRuntime,
+        .load_mcp_runtime_from_path = testNoMcpRuntimeFromPath,
         .process_queued_prompt = testProcessQueuedPrompt,
     };
 }
@@ -4917,11 +4921,10 @@ test "parse options accepts yolo and rejects permission flag conflicts" {
     );
 }
 
-var ask_test_empty_env: std.process.Environ.Map = std.process.Environ.Map.init(std.heap.c_allocator);
-
 test "parse options enables bare via --bare flag or FX_BARE env" {
     const alloc = std.testing.allocator;
-    defer io_mod.setEnvironMap(&ask_test_empty_env);
+    const empty_env = try TestAskHome.stableEmptyEnv();
+    defer io_mod.setEnvironMap(empty_env);
 
     var flagged = try parseOptionsWithStdin(alloc, &.{ "--bare", "hello" }, .tty);
     defer flagged.deinit(alloc);
@@ -4940,7 +4943,7 @@ test "parse options enables bare via --bare flag or FX_BARE env" {
     defer disabled.deinit(alloc);
     try std.testing.expect(!disabled.bare);
 
-    io_mod.setEnvironMap(&ask_test_empty_env);
+    io_mod.setEnvironMap(empty_env);
     var no_env = try parseOptionsWithStdin(alloc, &.{"hello"}, .tty);
     defer no_env.deinit(alloc);
     try std.testing.expect(!no_env.bare);
@@ -8579,6 +8582,7 @@ test "fx ask JSON permission-denied capture is best effort under allocation fail
             .context_registry = test_no_context_registry,
             .tool_set = builtin_tools.advertisement_set,
             .load_mcp_runtime = testNoMcpRuntime,
+            .load_mcp_runtime_from_path = testNoMcpRuntimeFromPath,
         },
         "/tmp/workspace",
     );
@@ -8692,6 +8696,7 @@ fn checkAskJsonCaptureAllocationFailures(alloc: Allocator) !void {
         .context_registry = test_no_context_registry,
         .tool_set = builtin_tools.advertisement_set,
         .load_mcp_runtime = testNoMcpRuntime,
+        .load_mcp_runtime_from_path = testNoMcpRuntimeFromPath,
     }, "/tmp/workspace");
     defer ctx.deinit();
     ctx.output_mode = .json;
@@ -8779,6 +8784,7 @@ test "fx ask JSON clips ask_user_question text at a UTF-8 boundary" {
         .context_registry = test_no_context_registry,
         .tool_set = builtin_tools.advertisement_set,
         .load_mcp_runtime = testNoMcpRuntime,
+        .load_mcp_runtime_from_path = testNoMcpRuntimeFromPath,
     }, "/tmp/workspace");
     defer ctx.deinit();
     ctx.output_mode = .json;

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -196,6 +196,7 @@ pub const Config = struct {
     tool_set: tool_set_contract.ToolSet,
     inspect_mcp_profile_config: mcp_contract.InspectProfileConfigFn,
     load_mcp_runtime: mcp_runtime.LoadRuntimeFn,
+    load_mcp_runtime_from_path: mcp_runtime.LoadRuntimeFromPathFn,
     acp_runner: acp_runner.Runner,
 };
 
@@ -2980,6 +2981,7 @@ fn workflowConfig(cfg: Config) @import("cli_ask.zig").Config {
         .max_history_turns = cfg.max_history_turns,
         .mode_registry = cfg.mode_registry,
         .load_mcp_runtime = cfg.load_mcp_runtime,
+        .load_mcp_runtime_from_path = cfg.load_mcp_runtime_from_path,
     };
 }
 
@@ -5180,6 +5182,10 @@ fn noMcpRuntimeForTest(_: Allocator, _: @import("../mcp/elicitation.zig").Capabi
     return null;
 }
 
+fn noMcpRuntimeFromPathForTest(_: Allocator, _: @import("../mcp/elicitation.zig").Capabilities, _: []const u8) !?*mcp_runtime.McpRuntime {
+    return null;
+}
+
 fn clearMcpConfigInspectionForTest(
     _: Allocator,
 ) error{OutOfMemory}!mcp_contract.ProfileConfigDiagnostic {
@@ -5247,6 +5253,7 @@ fn testConfig() Config {
         .mode_registry = .{ .default_mode_id = "surface" },
         .inspect_mcp_profile_config = clearMcpConfigInspectionForTest,
         .load_mcp_runtime = noMcpRuntimeForTest,
+        .load_mcp_runtime_from_path = noMcpRuntimeFromPathForTest,
         .acp_runner = .{ .run_fn = unexpectedAcpRunForTest },
         .tool_set = .{
             .registry = .{ .tools = &.{} },

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -91,6 +91,10 @@ fn allocateRuntimeGeneration() u64 {
 
 pub const LoadRuntimeFn = *const fn (Allocator, elicitation.Capabilities) anyerror!?*McpRuntime;
 
+/// Explicit-config variant of `LoadRuntimeFn`: load servers from the given
+/// file instead of the profile default (`fx ask --mcp-config`).
+pub const LoadRuntimeFromPathFn = *const fn (Allocator, elicitation.Capabilities, []const u8) anyerror!?*McpRuntime;
+
 const ConnectionControl = struct {
     deadline: ?std.Io.Clock.Timestamp = null,
     cancel_flag: ?*std.atomic.Value(bool) = null,

--- a/src/main.zig
+++ b/src/main.zig
@@ -3276,6 +3276,7 @@ fn fullEntryConfig() app_entry_runtime.Config {
         .tool_set = builtin_tools.advertisement_set,
         .inspect_mcp_profile_config = builtin_mcp.inspectProfileConfig,
         .load_mcp_runtime = builtin_mcp.loadRuntime,
+        .load_mcp_runtime_from_path = builtin_mcp.loadRuntimeFromPath,
         .acp_runner = .{ .run_fn = runAcpServer },
     };
 }
@@ -3311,6 +3312,7 @@ fn localEntryConfig() app_entry_runtime.Config {
         .tool_set = builtin_tools.advertisement_set,
         .inspect_mcp_profile_config = builtin_mcp.inspectProfileConfig,
         .load_mcp_runtime = builtin_mcp.loadRuntime,
+        .load_mcp_runtime_from_path = builtin_mcp.loadRuntimeFromPath,
         .acp_runner = .{ .run_fn = runAcpServer },
     };
 }
@@ -3346,6 +3348,7 @@ fn emptyEntryConfig() app_entry_runtime.Config {
         .tool_set = builtin_tools.advertisement_set,
         .inspect_mcp_profile_config = builtin_mcp.inspectProfileConfig,
         .load_mcp_runtime = builtin_mcp.loadRuntime,
+        .load_mcp_runtime_from_path = builtin_mcp.loadRuntimeFromPath,
         .acp_runner = .{ .run_fn = runAcpServer },
     };
 }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -310,7 +310,7 @@ describe("cli: help", () => {
 Run one noninteractive request
 
 Usage:
-  fx ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>
+  fx ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--bare] [--mcp-config PATH] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>
 
 Options:
   --auto                Automatically review unresolved permission requests
@@ -321,6 +321,8 @@ Options:
   --prompt-permissions  Prompt for Y/N permission approval when stdin is a TTY
   --no-save             Do not save the session; incompatible with --resume and --resume-id
   --no-color            Render TTY output without colors or hyperlinks
+  --bare                Skip skills, AGENTS.md, and MCP discovery; read credentials only from the environment
+  --mcp-config PATH     Load MCP servers from PATH instead of ~/.fx/mcp.json
   --resume <last|id>    Continue the last session or a session by id
   --resume-id <id>      Continue a session by exact id
   --continue-recovery   Resume the paused model response in the selected session
@@ -330,6 +332,7 @@ The prompt may be passed as arguments or piped on stdin when no prompt args are 
 TTY stdout uses the Minimal transcript presentation; redirected stdout emits raw assistant Markdown.
 Operational progress and diagnostics are written to stderr. JSON output keeps raw Markdown in \`output\`.
 With --prompt-permissions, JSON and quiet requests may prompt on stderr only when stdin is a TTY.
+--bare also enables via FX_BARE=1; it requires AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN and never reads OAuth logins or stored keys.
 `;
 
       for (const alias of ["--help", "-h"]) {
@@ -438,6 +441,164 @@ With --prompt-permissions, JSON and quiet requests may prompt on stderr only whe
       TIMEOUT,
     );
   }
+});
+
+describe("cli: bare mode", () => {
+  const BARE_MISSING_CREDENTIALS =
+    "fx ask --bare never reads OAuth logins or stored keys. Set AI_GATEWAY_API_KEY (or VERCEL_OIDC_TOKEN) in the environment.";
+
+  test(
+    "fx ask --bare refuses to run without environment credentials",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-bare-auth-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace);
+      try {
+        const env = {
+          ...NO_GATEWAY_AUTH,
+          HOME: realpathSync(home),
+          FX_DISABLE_KEYCHAIN: "1",
+          FX_AUTO_UPGRADE: "0",
+        };
+        const cwd = realpathSync(workspace);
+
+        const bare = await runFx(["ask", "--bare", "--no-save", "hello"], {
+          cwd,
+          env,
+          timeoutMs: TIMEOUT,
+        });
+        expect(bare.code).toBe(1);
+        expect(bare.stderr).toContain(BARE_MISSING_CREDENTIALS);
+
+        const envFlag = await runFx(["ask", "--no-save", "hello"], {
+          cwd,
+          env: { ...env, FX_BARE: "1" },
+          timeoutMs: TIMEOUT,
+        });
+        expect(envFlag.code).toBe(1);
+        expect(envFlag.stderr).toContain(BARE_MISSING_CREDENTIALS);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fx ask --mcp-config reports a missing config file before startup",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-bare-mcp-missing-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace);
+      try {
+        const env = {
+          ...NO_GATEWAY_AUTH,
+          HOME: realpathSync(home),
+          FX_DISABLE_KEYCHAIN: "1",
+          FX_AUTO_UPGRADE: "0",
+        };
+        const cwd = realpathSync(workspace);
+        const missingPath = join(root, "does-not-exist.json");
+
+        const result = await runFx(
+          ["ask", "--bare", "--mcp-config", missingPath, "--no-save", "hello"],
+          { cwd, env, timeoutMs: TIMEOUT },
+        );
+        expect(result.code).toBe(1);
+        expect(result.stderr).toContain(
+          `fx ask: MCP config ${missingPath}: file not found`,
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fx ask --bare skips AGENTS.md delivery and MCP server startup",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-bare-discovery-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const launchMarker = join(root, "mcp-launched");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace);
+      writeFileSync(
+        join(workspace, "AGENTS.md"),
+        "# AGENTS.md\n\nBARE_MODE_SENTINEL_TOKEN must not ship to the model.\n",
+      );
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({}),
+      );
+      writeFileSync(
+        join(home, ".fx", "mcp.json"),
+        JSON.stringify({
+          mcp: {
+            fixture: {
+              type: "local",
+              command: [
+                "/bin/sh",
+                "-c",
+                `touch "${launchMarker}"; exec "${process.execPath}" "${join(import.meta.dirname, "fixtures", "mcp-modern-stdio.mjs")}"`,
+              ],
+              enabled: true,
+              required: true,
+            },
+          },
+        }),
+      );
+      const gateway = startFakeGateway([
+        fakeGatewayFinalText("bare answered"),
+        fakeGatewayFinalText("normal answered"),
+      ]);
+      try {
+        const cwd = realpathSync(workspace);
+        const env = {
+          HOME: realpathSync(home),
+          AI_GATEWAY_API_KEY: "bare-discovery-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_DISABLE_KEYCHAIN: "1",
+          FX_AUTO_UPGRADE: "0",
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+        };
+
+        const bare = await runFx(
+          ["ask", "--bare", "--json", "--no-save", "Reply briefly."],
+          { cwd, env, timeoutMs: TIMEOUT },
+        );
+        expect(bare.code).toBe(0);
+        expect(JSON.parse(bare.stdout).output.trim()).toBe("bare answered");
+        expect(existsSync(launchMarker)).toBe(false);
+        expect(gateway.requests).toHaveLength(1);
+        expect(gateway.requests[0].body).not.toContain(
+          "BARE_MODE_SENTINEL_TOKEN",
+        );
+
+        const normal = await runFx(
+          ["ask", "--json", "--no-save", "Reply briefly."],
+          { cwd, env, timeoutMs: TIMEOUT },
+        );
+        expect(normal.code).toBe(0);
+        expect(JSON.parse(normal.stdout).output.trim()).toBe(
+          "normal answered",
+        );
+        expect(existsSync(launchMarker)).toBe(true);
+        expect(gateway.requests).toHaveLength(2);
+        expect(gateway.requests[1].body).toContain("BARE_MODE_SENTINEL_TOKEN");
+      } finally {
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
 });
 
 describe("cli: version", () => {


### PR DESCRIPTION
## Summary

Adds `fx ask --bare`, a minimal mode for scripted and CI calls modeled on Claude Code's `--bare`: it skips all startup auto-discovery so runs start faster and behave identically on every machine.

- `--bare` (also enabled by `FX_BARE=1`) skips skill discovery, AGENTS.md context gathering, and MCP server loading, and reads credentials only from the environment
- `--mcp-config <path>` loads MCP servers from an explicit file instead of `~/.fx/mcp.json`; works with or without `--bare` and replaces the profile config whenever passed
- New `credentials.resolveEnvOnly` resolution path used by bare mode
- Help text, README docs, unit tests, and e2e coverage in the existing classified `cli.test.ts`

Bare mode deliberately never reads the fx login OAuth session or the keychain. Credentials must come from `AI_GATEWAY_API_KEY` or `VERCEL_OIDC_TOKEN`; ChatGPT/Grok subscription providers do not resolve under bare. This mirrors Claude Code's `--bare` (which refuses OAuth and keychain reads and requires `ANTHROPIC_API_KEY`) and keeps scripted runs deterministic: no machine-local login state, no keychain prompts, no refresh-token traffic. The startup state for bare runs goes through the existing credential-less loader, so OAuth files are not even opened.

Consequence worth noting: `--mcp-config` under `--bare` only supports servers that do not need OAuth, since MCP OAuth credentials live in the keychain.

## Verification

- New unit tests for parsing (`--bare`, `FX_BARE`, both `--mcp-config` forms), env-only credential resolution, and `loadRuntimeFromPath`
- New e2e tests: bare refuses without env credentials; missing `--mcp-config` file errors before startup; bare skips AGENTS.md delivery and MCP launch while normal runs do both
- Local binary runs against a fake gateway: bare 22ms vs normal 83ms average with a required MCP server configured; clean exit and clean stderr

Needs the `type: feature` label.
