### PR TITLE
Fix automatic model retry recovery

### DIFF
--- a/src/acp/types.zig
+++ b/src/acp/types.zig
@@ -345,12 +345,14 @@ test "model recovery info update is structured and clearable" {
         .cause = .system_resumed,
         .action = .paused,
         .required_action = .continue_later,
+        .delay_seconds = 4,
         .diagnostic = core_types.ModelFailureDiagnostic.init("ConnectionResetByPeer"),
     }, true);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"state\":\"paused\"") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"cause\":\"system_resumed\"") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"requiredAction\":\"continue_later\"") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"attempt\":4") != null);
+    try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"delaySeconds\":4") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"durable\":true") != null);
     try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "ConnectionResetByPeer") != null);
 

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -22,12 +22,16 @@ const InvocationAdmission = struct {
     attempt_evidence: *AttemptEvidence,
     trace_ctx: TraceContext,
     model: []const u8,
+    caller_admission: agent_stream_provider.Admission,
     observation: ?session_usage.InvocationObservation = null,
 
     fn admit(raw: *anyopaque) !void {
         const self: *@This() = @ptrCast(@alignCast(raw));
         if (self.observation != null) return error.ProviderAdmissionRepeated;
         self.observation = try session_usage.InvocationObservation.begin(self.usage);
+        if (self.caller_admission.admit_fn != null) {
+            try self.caller_admission.admit();
+        }
         self.attempt_evidence.provider_admitted = true;
         debug_trace.eventf(
             "agent",
@@ -53,6 +57,7 @@ pub fn streamModelCompletion(
         .attempt_evidence = request_value.attempt_evidence,
         .trace_ctx = request_value.trace_ctx,
         .model = request_value.model,
+        .caller_admission = request_value.admission,
     };
     var request = request_value;
     request.admission = .{ .context = &admission, .admit_fn = InvocationAdmission.admit };
@@ -285,6 +290,146 @@ test "provider preflight failure does not reserve usage" {
     try std.testing.expectEqual(session_usage.Availability.complete, snapshot.billing);
     try std.testing.expect(snapshot.api_duration_complete);
     try std.testing.expectEqual(@as(u64, 0), snapshot.settled_through_sequence);
+}
+
+test "caller admission publishes before provider attempt is admitted" {
+    const CallerAdmission = struct {
+        calls: usize = 0,
+        attempt_evidence: *AttemptEvidence,
+
+        fn admit(raw: *anyopaque) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            try std.testing.expect(!self.attempt_evidence.provider_admitted);
+            self.calls += 1;
+        }
+    };
+    const Provider = struct {
+        opens: usize = 0,
+
+        fn stream(
+            raw: ?*anyopaque,
+            _: Allocator,
+            request: agent_stream_provider.ModelRequest,
+        ) anyerror!agent_stream_provider.Result {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            try request.admission.admit();
+            self.opens += 1;
+            return .{ .completed = .{ .completion = .{ .finish_reason = .stop } } };
+        }
+    };
+    const Callbacks = struct {
+        fn event(_: *anyopaque, _: agent_stream_provider.Event) void {}
+    };
+
+    const alloc = std.testing.allocator;
+    var usage = session_usage.Usage.initFresh();
+    defer usage.deinit(alloc);
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    var delivery = DeliveryCertainty.init();
+    var attempt_evidence: AttemptEvidence = .{};
+    var caller_admission = CallerAdmission{ .attempt_evidence = &attempt_evidence };
+    var provider: Provider = .{};
+    var callback_ctx: u8 = 0;
+
+    var result = try streamModelCompletion(
+        .{ .context = &provider, .stream_fn = Provider.stream },
+        alloc,
+        .{
+            .credential = .{ .secret = "test-key" },
+            .model = "test/model",
+            .retry_count = 1,
+            .messages = &.{},
+            .tool_choice = .auto,
+            .provider_options = .{},
+            .trace_ctx = .{},
+            .content_capture_limit = null,
+            .delivery = &delivery,
+            .attempt_evidence = &attempt_evidence,
+            .events = .{ .context = &callback_ctx, .emit_fn = Callbacks.event },
+            .admission = .{ .context = &caller_admission, .admit_fn = CallerAdmission.admit },
+            .cancel_flag = &cancel_flag,
+        },
+        &usage,
+        alloc,
+    );
+    defer result.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), caller_admission.calls);
+    try std.testing.expectEqual(@as(usize, 1), provider.opens);
+    try std.testing.expect(attempt_evidence.provider_admitted);
+}
+
+test "caller admission failure settles usage and prevents request open" {
+    const CallerAdmission = struct {
+        calls: usize = 0,
+
+        fn admit(raw: *anyopaque) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.calls += 1;
+            return error.InFlightPublicationFailed;
+        }
+    };
+    const Provider = struct {
+        opens: usize = 0,
+
+        fn stream(
+            raw: ?*anyopaque,
+            _: Allocator,
+            request: agent_stream_provider.ModelRequest,
+        ) anyerror!agent_stream_provider.Result {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            try request.admission.admit();
+            self.opens += 1;
+            return .{ .completed = .{ .completion = .{ .finish_reason = .stop } } };
+        }
+    };
+    const Callbacks = struct {
+        fn event(_: *anyopaque, _: agent_stream_provider.Event) void {}
+    };
+
+    const alloc = std.testing.allocator;
+    var usage = session_usage.Usage.initFresh();
+    defer usage.deinit(alloc);
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    var delivery = DeliveryCertainty.init();
+    var attempt_evidence: AttemptEvidence = .{};
+    var caller_admission: CallerAdmission = .{};
+    var provider: Provider = .{};
+    var callback_ctx: u8 = 0;
+
+    try std.testing.expectError(
+        error.InFlightPublicationFailed,
+        streamModelCompletion(
+            .{ .context = &provider, .stream_fn = Provider.stream },
+            alloc,
+            .{
+                .credential = .{ .secret = "test-key" },
+                .model = "test/model",
+                .retry_count = 1,
+                .messages = &.{},
+                .tool_choice = .auto,
+                .provider_options = .{},
+                .trace_ctx = .{},
+                .content_capture_limit = null,
+                .delivery = &delivery,
+                .attempt_evidence = &attempt_evidence,
+                .events = .{ .context = &callback_ctx, .emit_fn = Callbacks.event },
+                .admission = .{ .context = &caller_admission, .admit_fn = CallerAdmission.admit },
+                .cancel_flag = &cancel_flag,
+            },
+            &usage,
+            alloc,
+        ),
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), caller_admission.calls);
+    try std.testing.expectEqual(@as(usize, 0), provider.opens);
+    try std.testing.expect(!attempt_evidence.provider_admitted);
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(session_usage.Availability.complete, snapshot.billing);
+    try std.testing.expect(snapshot.api_duration_complete);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
 }
 
 test "possibly sent gateway failure marks billing incomplete" {

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1792,18 +1792,27 @@ fn isPostVisionAssistantPrefillRejection(
         std.mem.find(u8, detail, "must end with a user message") != null;
 }
 
-fn waitForRecoveryDelay(
+fn recovery_deadline(delay_ns: u64) std.Io.Clock.Timestamp {
+    const started = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+    return .{
+        .clock = .awake,
+        .raw = started.raw.addDuration(.fromNanoseconds(@intCast(delay_ns))),
+    };
+}
+
+fn wait_for_recovery_deadline(
     cancel_flag: *std.atomic.Value(bool),
-    delay_ns: u64,
+    deadline: std.Io.Clock.Timestamp,
 ) bool {
     if (comptime builtin.is_test) return !cancel_flag.load(.seq_cst);
-    var remaining = delay_ns;
-    const quantum = 25 * std.time.ns_per_ms;
-    while (remaining > 0) {
+    std.debug.assert(deadline.clock == .awake);
+    const quantum: i96 = 25 * std.time.ns_per_ms;
+    while (true) {
         if (cancel_flag.load(.seq_cst)) return false;
-        const current = @min(remaining, quantum);
-        io_mod.sleep(current);
-        remaining -= current;
+        const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+        if (!std.Io.Clock.Timestamp.compare(now, .lt, deadline)) break;
+        const remaining = now.raw.durationTo(deadline.raw).toNanoseconds();
+        io_mod.getIo().sleep(.fromNanoseconds(@min(remaining, quantum)), .awake) catch {};
     }
     return !cancel_flag.load(.seq_cst);
 }
@@ -1986,15 +1995,16 @@ fn refreshGatewayCredentialForJob(
     return true;
 }
 
-fn pushAutoRetryStatus(
-    deps: *const AgentRuntimeDeps,
+fn auto_retry_status(
     failed_attempt: usize,
     attempt_limit: usize,
     cause: model_response_recovery.FailureCause,
-    decision: model_response_recovery.Decision,
+    strategy: model_response_recovery.Strategy,
+    delay_seconds: u64,
+    retry_deadline: ?std.Io.Clock.Timestamp,
     diagnostic: types.ModelFailureDiagnostic,
-) !void {
-    try pushRouteRecoveryStatus(deps, .{
+) types.RouteRecoveryStatus {
+    return .{
         .kind = .auto_retry,
         .failed_attempt = failed_attempt,
         .attempt_limit = attempt_limit,
@@ -2008,7 +2018,7 @@ fn pushAutoRetryStatus(
             .request_limit_reached => .request_limit_reached,
             .content_filter => null,
         },
-        .action = switch (decision.strategy) {
+        .action = switch (strategy) {
             .retry_request => .retrying_request,
             .continue_response => .continuing_response,
             .regenerate_tool => .regenerating_tool,
@@ -2017,10 +2027,47 @@ fn pushAutoRetryStatus(
             .pause => .paused,
             .stop => null,
         },
-        .delay_seconds = decision.delay_ns / std.time.ns_per_s,
+        .delay_seconds = delay_seconds,
+        .retry_deadline = retry_deadline,
         .diagnostic = diagnostic,
-    });
+    };
 }
+
+fn pushAutoRetryStatus(
+    deps: *const AgentRuntimeDeps,
+    failed_attempt: usize,
+    attempt_limit: usize,
+    cause: model_response_recovery.FailureCause,
+    decision: model_response_recovery.Decision,
+    diagnostic: types.ModelFailureDiagnostic,
+) !std.Io.Clock.Timestamp {
+    const deadline = recovery_deadline(decision.delay_ns);
+    try pushRouteRecoveryStatus(deps, auto_retry_status(
+        failed_attempt,
+        attempt_limit,
+        cause,
+        decision.strategy,
+        decision.delay_ns / std.time.ns_per_s,
+        deadline,
+        diagnostic,
+    ));
+    return deadline;
+}
+
+const AutoRetryAdmission = struct {
+    deps: *const AgentRuntimeDeps,
+    pending_status: *?types.RouteRecoveryStatus,
+    published: bool = false,
+
+    fn admit(raw: *anyopaque) !void {
+        const self: *@This() = @ptrCast(@alignCast(raw));
+        if (self.published) return;
+        const status = self.pending_status.* orelse return;
+        try pushRouteRecoveryStatus(self.deps, status);
+        self.pending_status.* = null;
+        self.published = true;
+    }
+};
 
 fn pushAutoRecoveredStatus(
     deps: *const AgentRuntimeDeps,
@@ -2789,6 +2836,16 @@ fn processQueuedPromptLoop(
     else
         .transport_interrupted;
     var latest_recovery_diagnostic: ?types.ModelFailureDiagnostic = null;
+    var pending_auto_retry_status: ?types.RouteRecoveryStatus = null;
+    errdefer if (pending_auto_retry_status != null) {
+        clearAutoRetryStatusIfNeeded(deps, true) catch |clear_err| {
+            debug_trace.logf(
+                "agent",
+                "failed to clear due retry status err={s}",
+                .{@errorName(clear_err)},
+            );
+        };
+    };
     var preserved_tool_evidence: model_response_recovery.ToolEvidence = if (job.recovery_checkpoint) |checkpoint|
         restoredRecoveryToolEvidence(checkpoint.tool_state)
     else
@@ -2935,6 +2992,7 @@ fn processQueuedPromptLoop(
                     pausedRequiredAction(preserved_tool_evidence),
                     latest_recovery_diagnostic,
                 );
+                pending_auto_retry_status = null;
                 return;
             }
             if (semantic_attempt >= semantic_limit) {
@@ -2971,6 +3029,7 @@ fn processQueuedPromptLoop(
                     pausedRequiredAction(preserved_tool_evidence),
                     defaultRecoveryDiagnostic(.request_limit_reached),
                 );
+                pending_auto_retry_status = null;
                 return;
             }
             if (skip_next_preflight_refresh) {
@@ -3103,6 +3162,10 @@ fn processQueuedPromptLoop(
                 .stream = &stream_ctx,
                 .required_vision = vision_mode == .required,
             };
+            var auto_retry_admission = AutoRetryAdmission{
+                .deps = deps,
+                .pending_status = &pending_auto_retry_status,
+            };
             var model_request = agent_stream_provider.ModelRequest{
                 .credential = .{
                     .secret = active_api_key,
@@ -3135,6 +3198,10 @@ fn processQueuedPromptLoop(
                 .delivery = &gateway_delivery,
                 .attempt_evidence = &gateway_attempt_evidence,
                 .events = .{ .context = &provider_events, .emit_fn = onProviderEvent },
+                .admission = if (pending_auto_retry_status != null)
+                    .{ .context = &auto_retry_admission, .admit_fn = AutoRetryAdmission.admit }
+                else
+                    .{},
                 .cancel_flag = config.cancel_flag,
                 .provider_attempt_owner = .agent,
             };
@@ -3207,6 +3274,7 @@ fn processQueuedPromptLoop(
                         )),
                         failure_diagnostic,
                     );
+                    pending_auto_retry_status = null;
                     return;
                 }
                 var recovery_decision = if (network_failure) |evidence|
@@ -3289,8 +3357,9 @@ fn processQueuedPromptLoop(
                     step_ctx,
                 );
                 const auto_retry_status_published = will_auto_retry;
+                var retry_deadline: ?std.Io.Clock.Timestamp = null;
                 if (auto_retry_status_published) {
-                    try pushAutoRetryStatus(
+                    retry_deadline = try pushAutoRetryStatus(
                         deps,
                         consumed_attempts,
                         semantic_limit,
@@ -3299,9 +3368,9 @@ fn processQueuedPromptLoop(
                         failure_diagnostic,
                     );
                 }
-                const delay_completed = !will_auto_retry or waitForRecoveryDelay(
+                const delay_completed = !will_auto_retry or wait_for_recovery_deadline(
                     config.cancel_flag,
-                    recovery_decision.delay_ns,
+                    retry_deadline.?,
                 );
                 if (recoveryPauseRequested(config)) {
                     try persistRecoveryCheckpoint(
@@ -3352,6 +3421,7 @@ fn processQueuedPromptLoop(
                         deps,
                         recovery_strategy != null or auto_retry_status_published,
                     );
+                    pending_auto_retry_status = null;
                     try stream_ctx.provisional_statuses.finishTrackedCancelled(
                         deps,
                         stream_ctx.alloc,
@@ -3363,6 +3433,16 @@ fn processQueuedPromptLoop(
                     return;
                 }
                 if (will_auto_retry) {
+                    std.debug.assert(pending_auto_retry_status == null);
+                    pending_auto_retry_status = auto_retry_status(
+                        consumed_attempts + 1,
+                        semantic_limit,
+                        failure_cause,
+                        recovery_decision.strategy,
+                        0,
+                        null,
+                        failure_diagnostic,
+                    );
                     preserved_tool_evidence = effectiveRecoveryToolEvidence(
                         preserved_tool_evidence,
                         null,
@@ -3396,14 +3476,15 @@ fn processQueuedPromptLoop(
                     const exhausted_retryable =
                         stream_ctx.raw_text.items.len == 0 and
                         !stream_ctx.saw_provider_tool_start and
-                        semantic_attempt + 1 >= semantic_limit;
+                        consumed_attempts >= semantic_limit;
                     if (replay_safe or exhausted_retryable) {
                         try pushRouteRecoveryStatus(deps, .{
                             .kind = .terminal_provider_error,
-                            .failed_attempt = semantic_attempt + 1,
+                            .failed_attempt = consumed_attempts,
                             .attempt_limit = semantic_limit,
                             .diagnostic = failure_diagnostic,
                         });
+                        pending_auto_retry_status = null;
                     } else {
                         try pushUnsafeNoRetryStatus(
                             deps,
@@ -3417,10 +3498,11 @@ fn processQueuedPromptLoop(
                 } else if (semantic_attempt > 0) {
                     try pushRouteRecoveryStatus(deps, .{
                         .kind = .terminal_provider_error,
-                        .failed_attempt = semantic_attempt + 1,
+                        .failed_attempt = consumed_attempts,
                         .attempt_limit = semantic_limit,
                         .diagnostic = failure_diagnostic,
                     });
+                    pending_auto_retry_status = null;
                 }
                 try runtime_assistant_stream.flushAssistantStream(&stream_ctx);
                 const failed_assistant_source = stream_ctx.raw_text.items;
@@ -3778,7 +3860,7 @@ fn processQueuedPromptLoop(
                             step_ctx,
                         );
                     }
-                    try pushAutoRetryStatus(
+                    const retry_deadline = try pushAutoRetryStatus(
                         deps,
                         semantic_attempt + 1,
                         semantic_limit,
@@ -3786,7 +3868,17 @@ fn processQueuedPromptLoop(
                         decision,
                         diagnostic,
                     );
-                    if (waitForRecoveryDelay(config.cancel_flag, decision.delay_ns)) {
+                    if (wait_for_recovery_deadline(config.cancel_flag, retry_deadline)) {
+                        std.debug.assert(pending_auto_retry_status == null);
+                        pending_auto_retry_status = auto_retry_status(
+                            semantic_attempt + 2,
+                            semantic_limit,
+                            cause,
+                            decision.strategy,
+                            0,
+                            null,
+                            diagnostic,
+                        );
                         preserved_tool_evidence = effectiveRecoveryToolEvidence(
                             preserved_tool_evidence,
                             response_completion,
@@ -3973,7 +4065,7 @@ fn processQueuedPromptLoop(
                             step_ctx,
                         );
                     }
-                    try pushAutoRetryStatus(
+                    const retry_deadline = try pushAutoRetryStatus(
                         deps,
                         semantic_attempt + 1,
                         semantic_limit,
@@ -3981,7 +4073,17 @@ fn processQueuedPromptLoop(
                         decision,
                         diagnostic,
                     );
-                    if (waitForRecoveryDelay(config.cancel_flag, decision.delay_ns)) {
+                    if (wait_for_recovery_deadline(config.cancel_flag, retry_deadline)) {
+                        std.debug.assert(pending_auto_retry_status == null);
+                        pending_auto_retry_status = auto_retry_status(
+                            semantic_attempt + 2,
+                            semantic_limit,
+                            cause,
+                            decision.strategy,
+                            0,
+                            null,
+                            diagnostic,
+                        );
                         preserved_tool_evidence = effectiveRecoveryToolEvidence(
                             preserved_tool_evidence,
                             attempt_completion,

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3748,9 +3748,10 @@ test "processQueuedPrompt reconciles provider error before tool execution" {
     try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_count);
     try expectBodyContains(&gateway, 1, "\"toolChoice\":{\"type\":\"none\"}");
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error · checking uncertain tool state · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Provider unavailable · provider_error · checking uncertain tool state · attempt 2/2");
+    try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
 }
 
 test "processQueuedPrompt pauses when uncertain tool reconciliation returns another tool" {
@@ -4036,10 +4037,12 @@ test "processQueuedPrompt retries replay-safe provider errors before success" {
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "Recovered"));
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
-    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 5), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error: route failed once · retrying request · attempt 1/3");
-    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Provider unavailable · provider_error: route failed twice · retrying request in 1s · attempt 2/3");
-    try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 3/3");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Provider unavailable · provider_error: route failed once · retrying request · attempt 2/3");
+    try expectRouteStatus(&hooks, 2, .auto_retry, "⚠ Provider unavailable · provider_error: route failed twice · retrying request in 1s · attempt 2/3");
+    try expectRouteStatus(&hooks, 3, .auto_retry, "⚠ Provider unavailable · provider_error: route failed twice · retrying request · attempt 3/3");
+    try expectRouteStatus(&hooks, 4, .auto_recovered, "✓ recovered · succeeded on attempt 3/3");
 }
 
 test "processQueuedPrompt masks and terminal-encodes provider diagnostics" {
@@ -4278,9 +4281,12 @@ test "processQueuedPrompt retries replay-safe ReadFailed before success" {
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "Recovered"));
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/3");
-    try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/3");
+    try std.testing.expect(hooks.route_recovery_statuses.items[0].retry_deadline != null);
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 2/3");
+    try std.testing.expect(hooks.route_recovery_statuses.items[1].retry_deadline == null);
+    try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 2/3");
 
     const trace = try readTraceFile(alloc, trace_path, 65536);
     defer alloc.free(trace);
@@ -4324,6 +4330,12 @@ test "processQueuedPrompt counts and retries a definitely unsent native setup fa
     try expectRouteStatus(
         &hooks,
         1,
+        .auto_retry,
+        "⚠ Network interrupted · TlsInitializationFailed · retrying request · attempt 2/2",
+    );
+    try expectRouteStatus(
+        &hooks,
+        2,
         .auto_recovered,
         "✓ recovered · succeeded on attempt 2/2",
     );
@@ -4368,12 +4380,15 @@ test "processQueuedPrompt routes native network failure classes through one hear
         try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
         try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
-        try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+        try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
         try std.testing.expectEqual(types.RouteRecoveryStatus.Kind.auto_retry, hooks.route_recovery_statuses.items[0].kind);
         try std.testing.expectEqual(case.cause, hooks.route_recovery_statuses.items[0].cause.?);
         try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items[0].failed_attempt);
-        try std.testing.expectEqual(types.RouteRecoveryStatus.Kind.auto_recovered, hooks.route_recovery_statuses.items[1].kind);
-        try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items[1].succeeded_attempt);
+        try std.testing.expectEqual(types.RouteRecoveryStatus.Kind.auto_retry, hooks.route_recovery_statuses.items[1].kind);
+        try std.testing.expectEqual(case.cause, hooks.route_recovery_statuses.items[1].cause.?);
+        try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items[1].failed_attempt);
+        try std.testing.expectEqual(types.RouteRecoveryStatus.Kind.auto_recovered, hooks.route_recovery_statuses.items[2].kind);
+        try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items[2].succeeded_attempt);
     }
 }
 
@@ -4398,8 +4413,8 @@ test "processQueuedPrompt starts network pacing independently from the shared re
     try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
 
     try std.testing.expectEqual(@as(usize, 6), gateway.request_models.items.len);
-    try std.testing.expectEqual(@as(usize, 6), hooks.route_recovery_statuses.items.len);
-    const network_status = hooks.route_recovery_statuses.items[5];
+    try std.testing.expectEqual(@as(usize, 11), hooks.route_recovery_statuses.items.len);
+    const network_status = hooks.route_recovery_statuses.items[10];
     try std.testing.expectEqual(types.RouteRecoveryStatus.Kind.auto_retry, network_status.kind);
     try std.testing.expectEqual(types.ModelRecoveryCause.network_interrupted, network_status.cause.?);
     try std.testing.expectEqual(@as(usize, 6), network_status.failed_attempt);
@@ -4644,7 +4659,7 @@ test "processQueuedPrompt counts only failed provider attempts across tool follo
     try std.testing.expect(!checkpoint.outstanding_reservation);
     try std.testing.expectEqual(@as(usize, 1), checkpoint.execution.tool_steps.len);
     try std.testing.expectEqual(types.ModelRecoveryCause.provider_unavailable, checkpoint.cause);
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Provider unavailable · HTTP 502: gateway unavailable · recovery paused after 2/2 attempts");
+    try expectRouteStatus(&hooks, 2, .terminal_provider_error, "⚠ Provider unavailable · HTTP 502: gateway unavailable · recovery paused after 2/2 attempts");
 
     var continued_checkpoint = try checkpoint.dupe(alloc);
     defer continued_checkpoint.deinit(alloc);
@@ -4840,6 +4855,105 @@ test "processQueuedPrompt sends nothing when durable reservation fails" {
     try std.testing.expectEqual(@as(usize, 0), gateway.request_models.items.len);
 }
 
+test "processQueuedPrompt clears scheduled retry when the next reservation fails" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{
+        .{ .stream_error = error.ReadFailed },
+        .{ .content = "must not send" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.enable_recovery_checkpoint = true;
+    hooks.recovery_checkpoint_error_at = 3;
+    hooks.recovery_checkpoint_error = error.TestCheckpointWriteFailed;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.max_provider_attempts = 2;
+
+    try std.testing.expectError(
+        error.TestCheckpointWriteFailed,
+        runFakePrompt(&gateway, &hooks, config, fixture.job()),
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), gateway.admitted_requests);
+    try std.testing.expectEqual(@as(usize, 1), gateway.request_models.items.len);
+    try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
+    try std.testing.expect(hooks.route_recovery_statuses.items[0].retry_deadline != null);
+    try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_clear_count);
+    try std.testing.expectEqual(@as(usize, 2), hooks.recovery_checkpoints.items.len);
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        hooks.recovery_checkpoints.items[1].consumed_provider_attempts,
+    );
+}
+
+test "processQueuedPrompt replaces scheduled retry after provider pre-admission failure" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{
+        .{ .stream_error = error.ReadFailed },
+        .{ .pre_admission_error = error.TestProviderSerializationFailed },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.max_provider_attempts = 2;
+
+    try std.testing.expectError(
+        error.TestProviderSerializationFailed,
+        runFakePrompt(&gateway, &hooks, config, fixture.job()),
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), gateway.admitted_requests);
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
+    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expect(hooks.route_recovery_statuses.items[0].retry_deadline != null);
+    try expectRouteStatus(
+        &hooks,
+        1,
+        .terminal_provider_error,
+        "⚠ Provider unavailable · TestProviderSerializationFailed · recovery paused after 1/2 attempts",
+    );
+    try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_clear_count);
+}
+
+test "processQueuedPrompt replaces scheduled retry when in-flight publication fails" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{
+        .{ .stream_error = error.ReadFailed },
+        .{ .content = "must not send" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.route_recovery_status_error_attempt = 2;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.max_provider_attempts = 2;
+
+    try std.testing.expectError(
+        error.TestRouteRecoveryPublicationFailed,
+        runFakePrompt(&gateway, &hooks, config, fixture.job()),
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), gateway.admitted_requests);
+    try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
+    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expect(hooks.route_recovery_statuses.items[0].retry_deadline != null);
+    try expectRouteStatus(
+        &hooks,
+        1,
+        .terminal_provider_error,
+        "⚠ Provider unavailable · TestRouteRecoveryPublicationFailed · recovery paused after 1/2 attempts",
+    );
+    try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_clear_count);
+}
+
 test "processQueuedPrompt pauses replay-safe ReadFailed at attempt limit" {
     const alloc = std.testing.allocator;
     const completions = [_]FakeCompletion{
@@ -4862,10 +4976,12 @@ test "processQueuedPrompt pauses replay-safe ReadFailed at attempt limit" {
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
     try std.testing.expectEqual(types.TurnPresentationOutcome.paused, hooks.finalized_outcome.?);
-    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 5), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/3");
-    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request in 1s · attempt 2/3");
-    try expectRouteStatus(&hooks, 2, .terminal_provider_error, "⚠ Network interrupted · ReadFailed · recovery paused after 3/3 attempts");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 2/3");
+    try expectRouteStatus(&hooks, 2, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request in 1s · attempt 2/3");
+    try expectRouteStatus(&hooks, 3, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 3/3");
+    try expectRouteStatus(&hooks, 4, .terminal_provider_error, "⚠ Network interrupted · ReadFailed · recovery paused after 3/3 attempts");
 }
 
 test "processQueuedPrompt replaces retry status after a different stream error" {
@@ -4886,9 +5002,10 @@ test "processQueuedPrompt replaces retry status after a different stream error" 
     try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Network interrupted · ConnectionResetByPeer · recovery paused after 2/2 attempts");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 2/2");
+    try expectRouteStatus(&hooks, 2, .terminal_provider_error, "⚠ Network interrupted · ConnectionResetByPeer · recovery paused after 2/2 attempts");
 }
 
 test "processQueuedPrompt clears retry status when a replay is cancelled" {
@@ -4909,8 +5026,9 @@ test "processQueuedPrompt clears retry status when a replay is cancelled" {
     try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
-    try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/3");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 2/3");
     try std.testing.expectEqual(@as(usize, 1), hooks.route_recovery_clear_count);
     try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
 }
@@ -4933,9 +5051,10 @@ test "processQueuedPrompt replaces retry status when replay finish is missing" {
     try runFakePrompt(&gateway, &hooks, config, fixture.job());
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Response ended early · StreamInterrupted · recovery paused after 2/2 attempts");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 2/2");
+    try expectRouteStatus(&hooks, 2, .terminal_provider_error, "⚠ Response ended early · StreamInterrupted · recovery paused after 2/2 attempts");
 }
 
 test "processQueuedPrompt replaces retry status after an invalid replay completion" {
@@ -4959,9 +5078,10 @@ test "processQueuedPrompt replaces retry status after an invalid replay completi
     );
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 1/3");
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Provider unavailable · InvalidProviderCompletion · recovery paused after 2/3 attempts");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · retrying request · attempt 2/3");
+    try expectRouteStatus(&hooks, 2, .terminal_provider_error, "⚠ Provider unavailable · InvalidProviderCompletion · recovery paused after 2/3 attempts");
 }
 
 test "processQueuedPrompt pauses ReadFailed after assistant source is published" {
@@ -5116,9 +5236,10 @@ test "processQueuedPrompt regenerates and executes a local tool once after ReadF
     try std.testing.expectEqual(@as(usize, 1), hooks.executed_names.items.len);
     try std.testing.expectEqualStrings("read_file", hooks.executed_names.items[0]);
     try std.testing.expectEqualStrings("call_read_recovered", hooks.executed_call_ids.items[0]);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · regenerating unstarted tool · attempt 1/3");
-    try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/3");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · regenerating unstarted tool · attempt 2/3");
+    try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 2/3");
     try expectBodyContains(&gateway, 1, "did not execute the incomplete tool call");
     try expectBodyContains(&gateway, 2, "call_read_recovered");
     try expectBodyContains(&gateway, 2, "\"output\":{\"type\":\"text\",\"value\":\"ok\"}");
@@ -5154,7 +5275,8 @@ test "processQueuedPrompt settles an interrupted local tool after a different st
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · regenerating unstarted tool · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .terminal_provider_error, "⚠ Network interrupted · ConnectionResetByPeer · recovery paused after 2/2 attempts");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · regenerating unstarted tool · attempt 2/2");
+    try expectRouteStatus(&hooks, 2, .terminal_provider_error, "⚠ Network interrupted · ConnectionResetByPeer · recovery paused after 2/2 attempts");
     try expectFailedLifecycleContains(
         hooks.lifecycle_events.items,
         "call_read_interrupted",
@@ -5299,9 +5421,10 @@ test "processQueuedPrompt reconciles ReadFailed after provider-executed tool sta
 
     try std.testing.expectEqual(@as(usize, 2), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Network interrupted · ReadFailed · checking uncertain tool state · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Network interrupted · ReadFailed · checking uncertain tool state · attempt 2/2");
+    try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
 }
 
 test "processQueuedPrompt continues provider error after visible text without duplication" {
@@ -5332,9 +5455,10 @@ test "processQueuedPrompt continues provider error after visible text without du
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_count);
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "partial"));
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error: failed after text · continuing response · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Provider unavailable · provider_error: failed after text · continuing response · attempt 2/2");
+    try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
     try std.testing.expectEqualStrings("partial response", hooks.history_turns.items[0].assistant.assistant);
 }
 
@@ -5364,9 +5488,10 @@ test "processQueuedPrompt recovers provider error after streamed tool start" {
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_count);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error: failed after tool start · regenerating unstarted tool · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Provider unavailable · provider_error: failed after tool start · regenerating unstarted tool · attempt 2/2");
+    try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
 }
 
 test "processQueuedPrompt routes content filter to local recovery without replay" {
@@ -5443,9 +5568,10 @@ test "processQueuedPrompt disable Fast recovery retries the same exact model" {
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_count);
     try std.testing.expectEqual(@as(usize, 1), countText(&hooks, "Recovered without Fast"));
     try std.testing.expectEqual(@as(usize, 0), hooks.system_notices.items.len);
-    try std.testing.expectEqual(@as(usize, 2), hooks.route_recovery_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 3), hooks.route_recovery_statuses.items.len);
     try expectRouteStatus(&hooks, 0, .auto_retry, "⚠ Provider unavailable · provider_error: fast route failed · retrying request · attempt 1/2");
-    try expectRouteStatus(&hooks, 1, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
+    try expectRouteStatus(&hooks, 1, .auto_retry, "⚠ Provider unavailable · provider_error: fast route failed · retrying request · attempt 2/2");
+    try expectRouteStatus(&hooks, 2, .auto_recovered, "✓ recovered · succeeded on attempt 2/2");
 }
 
 test "processQueuedPrompt exhaustion pauses without invoking route recovery" {

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -204,6 +204,7 @@ pub const FakeCompletion = struct {
     failure_schema: ?[]const u8 = null,
     failure_request_shape: ?[]const u8 = null,
     retry_after_seconds: ?u64 = null,
+    pre_admission_error: ?anyerror = null,
     pre_send_error: ?anyerror = null,
     stream_error: ?anyerror = null,
     stream_error_after_chunks: ?anyerror = null,
@@ -236,6 +237,7 @@ pub const FakeGateway = struct {
     request_models: std.ArrayList([]u8) = .empty,
     request_api_keys: std.ArrayList([]u8) = .empty,
     request_session_ids: std.ArrayList(?[]u8) = .empty,
+    admitted_requests: usize = 0,
     recovery_pause_flag: ?*std.atomic.Value(bool) = null,
 
     pub fn init(alloc: Allocator, completions: []const FakeCompletion) FakeGateway {
@@ -278,7 +280,9 @@ pub const FakeGateway = struct {
         if (self.index >= self.completions.len) return error.TestUnexpectedGatewayRequest;
         const completion = self.completions[self.index];
         self.index += 1;
+        if (completion.pre_admission_error) |err| return err;
         try request.admission.admit();
+        self.admitted_requests += 1;
 
         if (completion.pre_send_error) |err| {
             recordNetworkFailureEvidence(request, err);
@@ -651,9 +655,12 @@ pub const FakeAgentRuntimeDeps = struct {
     enable_recovery_checkpoint: bool = false,
     recovery_checkpoints: std.ArrayList(session_codec.RecoveryCheckpoint) = .empty,
     recovery_checkpoint_error: ?anyerror = null,
+    recovery_checkpoint_error_at: ?usize = null,
+    recovery_checkpoint_calls: usize = 0,
     cancel_on_recovery_reservation: ?*std.atomic.Value(bool) = null,
     pause_on_auto_retry_status: bool = false,
     recovery_pause_flag: ?*std.atomic.Value(bool) = null,
+    route_recovery_status_error_attempt: ?usize = null,
 
     pub fn init(alloc: Allocator) FakeAgentRuntimeDeps {
         return .{ .alloc = alloc };
@@ -775,7 +782,14 @@ pub const FakeAgentRuntimeDeps = struct {
         checkpoint: session_codec.RecoveryCheckpoint,
     ) !void {
         const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
-        if (self.recovery_checkpoint_error) |err| return err;
+        self.recovery_checkpoint_calls += 1;
+        if (self.recovery_checkpoint_error) |err| {
+            if (self.recovery_checkpoint_error_at == null or
+                self.recovery_checkpoint_error_at.? == self.recovery_checkpoint_calls)
+            {
+                return err;
+            }
+        }
         try self.recovery_checkpoints.append(
             self.alloc,
             try checkpoint.dupe(self.alloc),
@@ -1633,8 +1647,14 @@ pub const FakeAgentRuntimeDeps = struct {
 
     fn routeRecoveryStatus(raw: *anyopaque, status: types.RouteRecoveryStatus) !void {
         const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
+        if (status.kind == .auto_retry and
+            status.retry_deadline == null and
+            self.route_recovery_status_error_attempt == status.failed_attempt)
+        {
+            return error.TestRouteRecoveryPublicationFailed;
+        }
         try self.route_recovery_statuses.append(self.alloc, status);
-        if (status.kind == .auto_retry) {
+        if (status.kind == .auto_retry and status.retry_deadline != null) {
             if (self.cancel_on_auto_retry_status) |flag| {
                 if (self.cancel_on_auto_retry_attempt == null or
                     self.cancel_on_auto_retry_attempt.? == status.failed_attempt)
@@ -1643,7 +1663,10 @@ pub const FakeAgentRuntimeDeps = struct {
                 }
             }
         }
-        if (self.pause_on_auto_retry_status and status.kind == .auto_retry) {
+        if (self.pause_on_auto_retry_status and
+            status.kind == .auto_retry and
+            status.retry_deadline != null)
+        {
             if (self.recovery_pause_flag) |flag| flag.store(true, .seq_cst);
         }
         var label_buf: [types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -549,7 +549,12 @@ pub fn Runtime(comptime App: type) type {
             if (!app.approval_prompt.isActive() and
                 !app.question_prompt.isActive())
             {
-                _ = advanceVisibleAnimation(app, event_handlers.tool_lifecycle, now_ms);
+                _ = advanceVisibleAnimation(
+                    app,
+                    event_handlers.tool_lifecycle,
+                    now_ms,
+                    std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake),
+                );
             }
         }
 
@@ -557,6 +562,7 @@ pub fn Runtime(comptime App: type) type {
             app: *App,
             presenter: activity_runtime.LifecyclePresenter,
             now_ms: i64,
+            now_awake: std.Io.Clock.Timestamp,
         ) bool {
             if (comptime @hasDecl(@TypeOf(app.subagents), "childPresentationView") and
                 @hasDecl(@TypeOf(app.subagents), "childConversationRuntime") and
@@ -566,11 +572,17 @@ pub fn Runtime(comptime App: type) type {
                     const view = app.subagents.childPresentationView() orelse return false;
                     const child_shell = app.subagents.childConversationRuntime() orelse return false;
                     const requests = app.subagents.activeRenderRequests();
+                    const status_changed = child_shell.worker_status_state().refresh_route_recovery(now_awake);
+                    if (status_changed) requests.request(.footer);
                     const status_expired = child_shell.worker_status_state().expire_transient(now_ms);
                     if (status_expired) requests.request(.footer);
-                    if (!view.chat.busy() or !child_shell.shimmer_active) return status_expired;
+                    if (!view.chat.busy() or !child_shell.shimmer_active) {
+                        return status_changed or status_expired;
+                    }
                     const previous_deadline = requests.animation_next_deadline_ms;
-                    if (!requests.requestAnimationDue(now_ms)) return status_expired;
+                    if (!requests.requestAnimationDue(now_ms)) {
+                        return status_changed or status_expired;
+                    }
                     debug_trace.logf(
                         "frame_schedule",
                         "child_animation_due previous_ms={d} now_ms={d} interval_ms={d}",
@@ -579,7 +591,11 @@ pub fn Runtime(comptime App: type) type {
                     return true;
                 }
             }
-            if (!app.stream.active and !app.pacer.hasCompletedAssistantPresentationTail()) return false;
+            const status_changed = app.shell.worker_status_state().refresh_route_recovery(now_awake);
+            if (status_changed) app.shell.render_requests.request(.footer);
+            if (!app.stream.active and !app.pacer.hasCompletedAssistantPresentationTail()) {
+                return status_changed;
+            }
             const native_history_active = if (comptime @hasDecl(
                 @TypeOf(app.shell),
                 "nativeHistoryActive",
@@ -592,13 +608,13 @@ pub fn Runtime(comptime App: type) type {
                 !app.shell.shimmer_active or
                 native_history_active)
             {
-                return false;
+                return status_changed;
             }
 
             var label_buf: [256]u8 = undefined;
-            _ = activityShimmerLabel(app, presenter, &label_buf) orelse return false;
+            _ = activityShimmerLabel(app, presenter, &label_buf) orelse return status_changed;
             const previous_deadline = app.shell.render_requests.animation_next_deadline_ms;
-            if (!app.shell.render_requests.requestAnimationDue(now_ms)) return false;
+            if (!app.shell.render_requests.requestAnimationDue(now_ms)) return status_changed;
             debug_trace.logf(
                 "frame_schedule",
                 "animation_due previous_ms={d} now_ms={d} interval_ms={d}",
@@ -1898,6 +1914,13 @@ fn tickNoop(app: *FakeApp) !void {
     try Runtime(FakeApp).tick(app, noopTaskCompletion, NoopBridge.handlers(app));
 }
 
+fn test_awake_timestamp(milliseconds: i64) std.Io.Clock.Timestamp {
+    return .{
+        .clock = .awake,
+        .raw = .fromNanoseconds(@as(i96, milliseconds) * std.time.ns_per_ms),
+    };
+}
+
 fn queueLifecycle(app: *FakeApp, event: types.ToolLifecycleEvent) !void {
     try app.worker.pushEvent(std.heap.c_allocator, .{ .tool_lifecycle = event });
 }
@@ -2133,15 +2156,15 @@ test "core.app_worker_runtime advances visible animation exactly at its deadline
     app.shell.render_requests.animation_next_deadline_ms = 1_050;
     const before = app.shell.render_requests.visibleAnimationPhase();
 
-    try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 1_049));
+    try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 1_049, test_awake_timestamp(1_049)));
     try std.testing.expectEqual(before, app.shell.render_requests.visibleAnimationPhase());
     try std.testing.expect(!app.shell.render_requests.hasReason(.animation));
 
-    try std.testing.expect(Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 1_050));
+    try std.testing.expect(Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 1_050, test_awake_timestamp(1_050)));
     try std.testing.expectEqual(before, app.shell.render_requests.visibleAnimationPhase());
     try std.testing.expect(app.shell.render_requests.hasReason(.animation));
 
-    try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 1_050));
+    try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 1_050, test_awake_timestamp(1_050)));
     try std.testing.expectEqual(before, app.shell.render_requests.visibleAnimationPhase());
 }
 
@@ -2162,8 +2185,65 @@ test "core.app_worker_runtime pauses visible animation after native history star
         &app,
         NoopBridge.lifecyclePresenter(&app),
         1,
+        test_awake_timestamp(1),
     ));
     try std.testing.expect(!app.shell.render_requests.hasReason(.animation));
+}
+
+test "core.app_worker_runtime refreshes root and selected child retry countdowns" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+
+    app.stream.active = true;
+    app.shell.shimmer_active = true;
+    app.shell.worker_status_state().set_route_recovery(.{
+        .kind = .auto_retry,
+        .failed_attempt = 1,
+        .attempt_limit = 3,
+        .delay_seconds = 4,
+        .retry_deadline = test_awake_timestamp(4_000),
+    }, 0);
+
+    try std.testing.expect(Runtime(FakeApp).advanceVisibleAnimation(
+        &app,
+        NoopBridge.lifecyclePresenter(&app),
+        0,
+        test_awake_timestamp(3_000),
+    ));
+    switch (app.shell.activityProjection()) {
+        .turn_thinking => |projection| try std.testing.expectEqualStrings(
+            "⚠ Provider unavailable · retrying request in 1s · attempt 1/3",
+            projection.label,
+        ),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+
+    app.subagents.view_active = true;
+    app.subagents.child_busy = true;
+    app.subagents.child_shell.shimmer_active = true;
+    app.subagents.child_shell.worker_status_state().set_route_recovery(.{
+        .kind = .auto_retry,
+        .failed_attempt = 2,
+        .attempt_limit = 3,
+        .delay_seconds = 4,
+        .retry_deadline = test_awake_timestamp(8_000),
+    }, 0);
+
+    try std.testing.expect(Runtime(FakeApp).advanceVisibleAnimation(
+        &app,
+        NoopBridge.lifecyclePresenter(&app),
+        0,
+        test_awake_timestamp(7_000),
+    ));
+    switch (app.subagents.child_shell.activityProjection()) {
+        .turn_thinking => |projection| try std.testing.expectEqualStrings(
+            "⚠ Provider unavailable · retrying request in 1s · attempt 2/3",
+            projection.label,
+        ),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(app.subagents.child_render_requests.hasReason(.footer));
 }
 
 test "core.app_worker_runtime expires selected child worker status while idle" {
@@ -2176,7 +2256,7 @@ test "core.app_worker_runtime expires selected child worker status while idle" {
         .attempt_limit = 3,
     }, 1_000);
 
-    _ = Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 2_500);
+    _ = Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 2_500, test_awake_timestamp(2_500));
 
     try std.testing.expect(app.subagents.child_shell.activityProjection() == .none);
     try std.testing.expect(app.subagents.child_render_requests.hasReason(.footer));
@@ -2310,6 +2390,39 @@ test "core.app_worker_runtime clears route recovery activity on clear event but 
     try tickNoop(&app);
     switch (app.shell.activityProjection()) {
         .turn_thinking => |thinking| try std.testing.expectEqualStrings("⚠ Provider unavailable · recovery paused after 3/3 attempts", thinking.label),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+}
+
+test "core.app_worker_runtime replaces a due retry with its consumed terminal attempt" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .route_recovery_status = .{
+        .kind = .auto_retry,
+        .failed_attempt = 1,
+        .attempt_limit = 2,
+        .delay_seconds = 4,
+        .retry_deadline = test_awake_timestamp(4_000),
+    } });
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .route_recovery_status = .{
+        .kind = .terminal_provider_error,
+        .failed_attempt = 1,
+        .attempt_limit = 2,
+        .diagnostic = types.ModelFailureDiagnostic.init("TestProviderSerializationFailed"),
+    } });
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .error_text = .{
+        .topic = "system",
+        .tone = .@"error",
+        .body = "request failed",
+    } });
+    try tickNoop(&app);
+
+    switch (app.shell.activityProjection()) {
+        .turn_thinking => |thinking| try std.testing.expectEqualStrings(
+            "⚠ Provider unavailable · TestProviderSerializationFailed · recovery paused after 1/2 attempts",
+            thinking.label,
+        ),
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
 }

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -3904,6 +3904,23 @@ fn testProcessQueuedPromptRecoveryLifecycle(deps: *const agent_runtime.AgentRunt
     try testPushAssistantText(deps, "assistant text");
 }
 
+fn testProcessQueuedPromptRetryAdmissionFailure(deps: *const agent_runtime.AgentRuntimeDeps, semantic_presentation: ?agent_runtime.SemanticPresentationSink, _: agent_runtime.LifecycleContext, _: agent_runtime.Config, _: worker_runtime.QueuedPrompt) !void {
+    try std.testing.expect(semantic_presentation == null);
+    try deps.push_route_recovery_status(deps.ctx, .{
+        .kind = .auto_retry,
+        .failed_attempt = 1,
+        .attempt_limit = 2,
+        .delay_seconds = 4,
+    });
+    try deps.push_route_recovery_status(deps.ctx, .{
+        .kind = .terminal_provider_error,
+        .failed_attempt = 1,
+        .attempt_limit = 2,
+        .diagnostic = types.ModelFailureDiagnostic.init("TestProviderSerializationFailed"),
+    });
+    return error.TestProviderSerializationFailed;
+}
+
 fn testProcessQueuedPromptPartialThenReadFailed(deps: *const agent_runtime.AgentRuntimeDeps, semantic_presentation: ?agent_runtime.SemanticPresentationSink, _: agent_runtime.LifecycleContext, _: agent_runtime.Config, _: worker_runtime.QueuedPrompt) !void {
     try std.testing.expect(semantic_presentation == null);
     try testPushAssistantText(deps, "partial ");
@@ -8955,6 +8972,34 @@ test "fx ask JSON recovery keeps stdout structured and reports progress on stder
         "[notice] ⚠ Network interrupted · waiting for connection · attempt 1/10\n",
         stderr_capture.bytes.items,
     );
+}
+
+test "fx ask JSON reports the consumed attempt after retry admission failure" {
+    const alloc = std.testing.allocator;
+    var stdout_capture: TestCapture = .{};
+    defer stdout_capture.deinit(alloc);
+    var stderr_capture: TestCapture = .{};
+    defer stderr_capture.deinit(alloc);
+    const deps = testPromptRunDepsWithProcess(
+        &stdout_capture,
+        &stderr_capture,
+        testProcessQueuedPromptRetryAdmissionFailure,
+    );
+
+    const exit_code = try runWithDeps(alloc, &.{ "--json", "hello" }, testConfig(), deps);
+    try std.testing.expectEqual(@as(u8, 1), exit_code);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, stdout_capture.bytes.items, .{});
+    defer parsed.deinit();
+    const recovery = parsed.value.object.get("recovery").?.object;
+    try std.testing.expectEqualStrings("paused", recovery.get("state").?.string);
+    try std.testing.expectEqual(@as(i64, 1), recovery.get("attempt").?.integer);
+    try std.testing.expectEqual(@as(i64, 0), recovery.get("delay_seconds").?.integer);
+    try std.testing.expectEqualStrings(
+        "TestProviderSerializationFailed",
+        parsed.value.object.get("error").?.string,
+    );
+    try std.testing.expect(std.mem.find(u8, stderr_capture.bytes.items, "retrying request in 4s · attempt 1/2") != null);
+    try std.testing.expect(std.mem.find(u8, stderr_capture.bytes.items, "recovery paused after 1/2 attempts") != null);
 }
 
 test "fx ask JSON preserves partial output on prompt failure" {

--- a/src/core/output/worker_status.zig
+++ b/src/core/output/worker_status.zig
@@ -18,38 +18,24 @@ const RouteRecoveryStatus = struct {
             else
                 0,
         };
-        var base_buf: [types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;
-        const label = if (status.isRecovered())
-            format_recovered_label(&result.label, status)
-        else if (status.action == .waiting_for_connectivity)
-            std.fmt.bufPrint(
-                &result.label,
-                "{s} · Esc to try later",
-                .{status.label(&base_buf)},
-            ) catch status.label(&result.label)
-        else if (status.action == .paused)
-            switch (status.required_action) {
-                .continue_later => std.fmt.bufPrint(
-                    &result.label,
-                    "{s} · /continue to resume",
-                    .{status.label(&base_buf)},
-                ) catch status.label(&result.label),
-                .inspect_uncertain_tool => std.fmt.bufPrint(
-                    &result.label,
-                    "{s} · inspect tool state before /continue",
-                    .{status.label(&base_buf)},
-                ) catch status.label(&result.label),
-                .change_request => std.fmt.bufPrint(
-                    &result.label,
-                    "{s} · change the request to continue",
-                    .{status.label(&base_buf)},
-                ) catch status.label(&result.label),
-                .none => status.label(&result.label),
-            }
-        else
-            status.label(&result.label);
+        const label = format_status_label(&result.label, status);
         store_label(result.label[0..], &result.label_len, label);
         return result;
+    }
+
+    fn refresh_retry_label(
+        self: *RouteRecoveryStatus,
+        now: std.Io.Clock.Timestamp,
+    ) bool {
+        if (self.status.kind != .auto_retry or self.status.retry_deadline == null) {
+            return false;
+        }
+
+        var next_buffer: [types.RouteRecoveryStatus.label_max_bytes + 64]u8 = undefined;
+        const next_label = format_retry_label(&next_buffer, self.status, now);
+        if (std.mem.eql(u8, self.label[0..self.label_len], next_label)) return false;
+        store_label(self.label[0..], &self.label_len, next_label);
+        return true;
     }
 
     fn projection(self: *const RouteRecoveryStatus) activity_runtime.ActivityProjection {
@@ -159,7 +145,73 @@ pub const State = union(enum) {
             .none, .api => false,
         };
     }
+
+    pub fn refresh_route_recovery(
+        self: *State,
+        now: std.Io.Clock.Timestamp,
+    ) bool {
+        return switch (self.*) {
+            .route_recovery => |*status| status.refresh_retry_label(now),
+            .none, .api => false,
+        };
+    }
 };
+
+fn format_status_label(
+    buf: []u8,
+    status: types.RouteRecoveryStatus,
+) []const u8 {
+    var base_buf: [types.RouteRecoveryStatus.label_max_bytes]u8 = undefined;
+    return if (status.isRecovered())
+        format_recovered_label(buf, status)
+    else if (status.action == .waiting_for_connectivity)
+        std.fmt.bufPrint(
+            buf,
+            "{s} · Esc to try later",
+            .{status.label(&base_buf)},
+        ) catch status.label(buf)
+    else if (status.action == .paused)
+        switch (status.required_action) {
+            .continue_later => std.fmt.bufPrint(
+                buf,
+                "{s} · /continue to resume",
+                .{status.label(&base_buf)},
+            ) catch status.label(buf),
+            .inspect_uncertain_tool => std.fmt.bufPrint(
+                buf,
+                "{s} · inspect tool state before /continue",
+                .{status.label(&base_buf)},
+            ) catch status.label(buf),
+            .change_request => std.fmt.bufPrint(
+                buf,
+                "{s} · change the request to continue",
+                .{status.label(&base_buf)},
+            ) catch status.label(buf),
+            .none => status.label(buf),
+        }
+    else
+        status.label(buf);
+}
+
+fn format_retry_label(
+    buf: []u8,
+    status: types.RouteRecoveryStatus,
+    now: std.Io.Clock.Timestamp,
+) []const u8 {
+    var projected = status;
+    const deadline = status.retry_deadline orelse return format_status_label(buf, status);
+    std.debug.assert(now.clock == .awake);
+    std.debug.assert(deadline.clock == .awake);
+    if (std.Io.Clock.Timestamp.compare(now, .lt, deadline)) {
+        const remaining_ns = now.raw.durationTo(deadline.raw).toNanoseconds();
+        const remaining_seconds = @divTrunc(remaining_ns - 1, std.time.ns_per_s) + 1;
+        projected.delay_seconds = std.math.cast(u64, remaining_seconds) orelse
+            std.math.maxInt(u64);
+    } else {
+        projected.delay_seconds = 0;
+    }
+    return format_status_label(buf, projected);
+}
 
 fn format_recovered_label(buf: []u8, status: types.RouteRecoveryStatus) []const u8 {
     return switch (status.kind) {
@@ -186,6 +238,13 @@ fn store_label(buffer: []u8, len: *usize, label: []const u8) void {
     len.* = label.len;
 }
 
+fn test_awake_timestamp(milliseconds: i64) std.Io.Clock.Timestamp {
+    return .{
+        .clock = .awake,
+        .raw = .fromNanoseconds(@as(i96, milliseconds) * std.time.ns_per_ms),
+    };
+}
+
 test "worker status projects route recovery and expires recovered state" {
     var state: State = .none;
     state.set_route_recovery(.{
@@ -210,6 +269,62 @@ test "worker status projects route recovery and expires recovered state" {
     try std.testing.expect(!state.expire_transient(2_499));
     try std.testing.expect(state.expire_transient(2_500));
     try std.testing.expect(state.projection() == null);
+}
+
+test "worker status refreshes retry countdown from awake deadline" {
+    var state: State = .none;
+    state.set_route_recovery(.{
+        .kind = .auto_retry,
+        .failed_attempt = 1,
+        .attempt_limit = 3,
+        .delay_seconds = 4,
+        .retry_deadline = test_awake_timestamp(4_000),
+    }, 0);
+
+    try std.testing.expect(!state.refresh_route_recovery(test_awake_timestamp(0)));
+    try std.testing.expect(state.refresh_route_recovery(test_awake_timestamp(1_000)));
+    switch (state.projection().?) {
+        .turn_thinking => |projection| try std.testing.expectEqualStrings(
+            "⚠ Provider unavailable · retrying request in 3s · attempt 1/3",
+            projection.label,
+        ),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+
+    try std.testing.expect(state.refresh_route_recovery(test_awake_timestamp(2_001)));
+    switch (state.projection().?) {
+        .turn_thinking => |projection| try std.testing.expectEqualStrings(
+            "⚠ Provider unavailable · retrying request in 2s · attempt 1/3",
+            projection.label,
+        ),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+
+    try std.testing.expect(state.refresh_route_recovery(test_awake_timestamp(3_750)));
+    switch (state.projection().?) {
+        .turn_thinking => |projection| try std.testing.expectEqualStrings(
+            "⚠ Provider unavailable · retrying request in 1s · attempt 1/3",
+            projection.label,
+        ),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+
+    try std.testing.expect(state.refresh_route_recovery(test_awake_timestamp(4_000)));
+    switch (state.projection().?) {
+        .turn_thinking => |projection| try std.testing.expectEqualStrings(
+            "⚠ Provider unavailable · retrying request · attempt 1/3",
+            projection.label,
+        ),
+        .none, .tool_slot => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(!state.refresh_route_recovery(test_awake_timestamp(4_250)));
+
+    state.set_route_recovery(.{
+        .kind = .auto_retry,
+        .failed_attempt = 2,
+        .attempt_limit = 3,
+    }, 0);
+    try std.testing.expect(!state.refresh_route_recovery(test_awake_timestamp(5_000)));
 }
 
 test "worker status API state is sticky until explicitly cleared" {

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -305,6 +305,7 @@ pub const RouteRecoveryStatus = struct {
     action: ?ModelRecoveryAction = null,
     required_action: ModelRecoveryRequiredAction = .none,
     delay_seconds: u64 = 0,
+    retry_deadline: ?std.Io.Clock.Timestamp = null,
     diagnostic: ?ModelFailureDiagnostic = null,
 
     pub fn tone(self: RouteRecoveryStatus) RouteRecoveryStatusTone {

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -56,6 +56,16 @@ fn connectedIoFailure(
     return transport_error;
 }
 
+fn connectedIoFailureWithWatch(
+    watch: ?*ConnectedRequestWatch,
+    cancelled: bool,
+    system_resumed: bool,
+    transport_error: anyerror,
+) anyerror {
+    const mapped = connectedIoFailure(cancelled, system_resumed, transport_error);
+    return if (watch) |state| state.finish_error(mapped) else mapped;
+}
+
 test "connected request failures prefer cancellation then wake evidence" {
     try std.testing.expectEqual(
         error.Cancelled,
@@ -535,7 +545,7 @@ fn fetchGatewayJsonAtUrlCore(
 
     var cancel_watch_done = std.atomic.Value(bool).init(false);
     const cancel_watcher = if (req.connection) |conn|
-        try spawn_gateway_cancel_watcher(&cancel_watch_done, cancel_flag, null, null, conn.stream_writer.stream)
+        try spawn_gateway_cancel_watcher(&cancel_watch_done, cancel_flag, null, null, null, conn.stream_writer.stream)
     else
         null;
     defer {
@@ -729,8 +739,18 @@ const ConnectionSetupTiming = struct {
     timeout_ms: i64 = gateway_connection_setup_timeout_ms,
 };
 
+const ResponseHeadTiming = struct {
+    timeout_ms: i64 = 30_000,
+};
+
 test "connection setup keeps the production timeout" {
     const timing = ConnectionSetupTiming{};
+
+    try std.testing.expectEqual(@as(i64, 30_000), timing.timeout_ms);
+}
+
+test "response head wait keeps the production timeout" {
+    const timing = ResponseHeadTiming{};
 
     try std.testing.expectEqual(@as(i64, 30_000), timing.timeout_ms);
 }
@@ -762,7 +782,135 @@ const RequestOpenOverride = struct {
 
 const StreamCoreOptions = struct {
     setup_timing: ConnectionSetupTiming = .{},
+    response_head_timing: ResponseHeadTiming = .{},
     request_open_override: ?RequestOpenOverride = null,
+};
+
+const ConnectedRequestWatch = struct {
+    const Phase = enum(u8) {
+        sending,
+        awaiting_head,
+        streaming,
+        completed,
+        timed_out,
+        cancelled,
+        system_resumed,
+    };
+
+    phase: std.atomic.Value(Phase) = .init(.sending),
+    response_head_deadline: std.Io.Clock.Timestamp = undefined,
+    timing: ResponseHeadTiming,
+
+    fn init(timing: ResponseHeadTiming) ConnectedRequestWatch {
+        return .{ .timing = timing };
+    }
+
+    fn arm_response_head(self: *ConnectedRequestWatch) ?anyerror {
+        self.response_head_deadline = std.Io.Clock.Timestamp.fromNow(
+            io_mod.getIo(),
+            .{
+                .clock = .awake,
+                .raw = .fromMilliseconds(self.timing.timeout_ms),
+            },
+        );
+        if (self.phase.cmpxchgStrong(
+            .sending,
+            .awaiting_head,
+            .seq_cst,
+            .seq_cst,
+        )) |winner| return phase_error(winner);
+        return null;
+    }
+
+    fn commit_response_head(self: *ConnectedRequestWatch) ?anyerror {
+        if (self.phase.cmpxchgStrong(
+            .awaiting_head,
+            .streaming,
+            .seq_cst,
+            .seq_cst,
+        )) |winner| return phase_error(winner);
+        return null;
+    }
+
+    fn finish(self: *ConnectedRequestWatch) ?anyerror {
+        var current = self.phase.load(.seq_cst);
+        while (is_active(current)) {
+            if (self.phase.cmpxchgWeak(
+                current,
+                .completed,
+                .seq_cst,
+                .seq_cst,
+            )) |observed| {
+                current = observed;
+                continue;
+            }
+            return null;
+        }
+        return phase_error(current);
+    }
+
+    fn finish_error(
+        self: *ConnectedRequestWatch,
+        transport_error: anyerror,
+    ) anyerror {
+        return self.finish() orelse transport_error;
+    }
+
+    fn win(self: *ConnectedRequestWatch, winner: Phase) bool {
+        std.debug.assert(!is_active(winner));
+        std.debug.assert(winner != .completed);
+        var current = self.phase.load(.seq_cst);
+        while (is_active(current)) {
+            if (self.phase.cmpxchgWeak(
+                current,
+                winner,
+                .seq_cst,
+                .seq_cst,
+            )) |observed| {
+                current = observed;
+                continue;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    fn win_response_head_timeout(self: *ConnectedRequestWatch) bool {
+        return self.phase.cmpxchgStrong(
+            .awaiting_head,
+            .timed_out,
+            .seq_cst,
+            .seq_cst,
+        ) == null;
+    }
+
+    fn response_head_expired(
+        self: *const ConnectedRequestWatch,
+        now: std.Io.Clock.Timestamp,
+    ) bool {
+        if (self.phase.load(.seq_cst) != .awaiting_head) return false;
+        return !std.Io.Clock.Timestamp.compare(
+            now,
+            .lt,
+            self.response_head_deadline,
+        );
+    }
+
+    fn is_active(phase: Phase) bool {
+        return switch (phase) {
+            .sending, .awaiting_head, .streaming => true,
+            .completed, .timed_out, .cancelled, .system_resumed => false,
+        };
+    }
+
+    fn phase_error(phase: Phase) ?anyerror {
+        return switch (phase) {
+            .timed_out => error.Timeout,
+            .cancelled => error.Cancelled,
+            .system_resumed => error.SystemResumed,
+            .sending, .awaiting_head, .streaming, .completed => null,
+        };
+    }
 };
 
 const RequestOpenOperation = struct {
@@ -1272,14 +1420,19 @@ fn streamGatewayCompletionCoreWithOptions(
 
         var cancel_watch_done = std.atomic.Value(bool).init(false);
         var system_resumed = std.atomic.Value(bool).init(false);
+        var connected_watch = ConnectedRequestWatch.init(core_options.response_head_timing);
         const cancel_watcher = if (watch_connected_socket)
             if (req.connection) |conn|
-                spawn_gateway_cancel_watcher(&cancel_watch_done, cancel_flag, &system_resumed, null, conn.stream_writer.stream) catch |err| {
+                spawn_gateway_cancel_watcher(&cancel_watch_done, cancel_flag, &system_resumed, null, &connected_watch, conn.stream_writer.stream) catch |err| {
                     debug_trace.eventf("gateway", "cancel_watcher_spawn_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
                     return @as(anyerror!StreamResult, err);
                 }
             else
                 null
+        else
+            null;
+        const active_connected_watch: ?*ConnectedRequestWatch = if (cancel_watcher != null)
+            &connected_watch
         else
             null;
         defer {
@@ -1295,7 +1448,8 @@ fn streamGatewayCompletionCoreWithOptions(
         if (request.delivery) |delivery| delivery.markPossiblySent();
         var body_writer = req.sendBodyUnflushed(&send_buf) catch |err| {
             debug_trace.eventf("gateway", "request_send_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
-            return @as(anyerror!StreamResult, connectedIoFailure(
+            return @as(anyerror!StreamResult, connectedIoFailureWithWatch(
+                active_connected_watch,
                 cancel_flag.load(.seq_cst),
                 system_resumed.load(.seq_cst),
                 err,
@@ -1303,7 +1457,8 @@ fn streamGatewayCompletionCoreWithOptions(
         };
         body_writer.writer.writeAll(payload) catch |err| {
             debug_trace.eventf("gateway", "request_send_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
-            return @as(anyerror!StreamResult, connectedIoFailure(
+            return @as(anyerror!StreamResult, connectedIoFailureWithWatch(
+                active_connected_watch,
                 cancel_flag.load(.seq_cst),
                 system_resumed.load(.seq_cst),
                 err,
@@ -1311,7 +1466,8 @@ fn streamGatewayCompletionCoreWithOptions(
         };
         body_writer.end() catch |err| {
             debug_trace.eventf("gateway", "request_send_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
-            return @as(anyerror!StreamResult, connectedIoFailure(
+            return @as(anyerror!StreamResult, connectedIoFailureWithWatch(
+                active_connected_watch,
                 cancel_flag.load(.seq_cst),
                 system_resumed.load(.seq_cst),
                 err,
@@ -1319,7 +1475,8 @@ fn streamGatewayCompletionCoreWithOptions(
         };
         req.connection.?.flush() catch |err| {
             debug_trace.eventf("gateway", "request_send_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
-            return @as(anyerror!StreamResult, connectedIoFailure(
+            return @as(anyerror!StreamResult, connectedIoFailureWithWatch(
+                active_connected_watch,
                 cancel_flag.load(.seq_cst),
                 system_resumed.load(.seq_cst),
                 err,
@@ -1328,10 +1485,14 @@ fn streamGatewayCompletionCoreWithOptions(
         debug_trace.eventf("gateway", "after_request_send", trace_ctx, "attempt={d} payload_bytes={d}", .{ attempt + 1, payload.len });
         debug_trace.eventf("gateway", "after_send", trace_ctx, "attempt={d} payload_bytes={d}", .{ attempt + 1, payload.len });
 
+        if (active_connected_watch) |watch| {
+            if (watch.arm_response_head()) |err| return @as(anyerror!StreamResult, err);
+        }
         debug_trace.eventf("gateway", "before_receive_head", trace_ctx, "attempt={d}", .{attempt + 1});
         var response = req.receiveHead(&.{}) catch |err| {
             debug_trace.eventf("gateway", "receive_head_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
-            const mapped = connectedIoFailure(
+            const mapped = connectedIoFailureWithWatch(
+                active_connected_watch,
                 cancel_flag.load(.seq_cst),
                 system_resumed.load(.seq_cst),
                 err,
@@ -1348,6 +1509,9 @@ fn streamGatewayCompletionCoreWithOptions(
             }
             return @as(anyerror!StreamResult, mapped);
         };
+        if (active_connected_watch) |watch| {
+            if (watch.commit_response_head()) |err| return @as(anyerror!StreamResult, err);
+        }
         debug_trace.eventf("gateway", "after_receive_head", trace_ctx, "attempt={d} status={d}", .{ attempt + 1, @intFromEnum(response.head.status) });
         const resolved_model_seen_in_head = traceResolvedModelHeader(response.head, model, trace_ctx);
 
@@ -1403,12 +1567,19 @@ fn streamGatewayCompletionCoreWithOptions(
             request.content_capture_limit,
         ) catch |err| {
             debug_trace.eventf("gateway", "sse_consume_error", trace_ctx, "attempt={d} err={s}", .{ attempt + 1, @errorName(err) });
-            return @as(anyerror!StreamResult, connectedIoFailure(
+            return @as(anyerror!StreamResult, connectedIoFailureWithWatch(
+                active_connected_watch,
                 cancel_flag.load(.seq_cst),
                 system_resumed.load(.seq_cst),
                 err,
             ));
         };
+        if (active_connected_watch) |watch| {
+            if (watch.finish()) |err| {
+                deinitGatewayCompletion(alloc, &completion);
+                return @as(anyerror!StreamResult, err);
+            }
+        }
         if (cancel_flag.load(.seq_cst)) {
             deinitGatewayCompletion(alloc, &completion);
             return error.Cancelled;
@@ -1695,12 +1866,29 @@ const GatewayCancelWatcher = struct {
         cancel_flag: *std.atomic.Value(bool),
         system_resumed: ?*std.atomic.Value(bool),
         deadline: ?std.Io.Clock.Timestamp,
+        connected_watch: ?*ConnectedRequestWatch,
         stream: std.Io.net.Stream,
     ) void {
         var previous = SuspendClockSample.now();
         while (!done.load(.seq_cst)) {
             if (cancel_flag.load(.seq_cst)) {
-                stream.shutdown(io_mod.getIo(), .both) catch {};
+                if (connected_watch == null or connected_watch.?.win(.cancelled)) {
+                    stream.shutdown(io_mod.getIo(), .both) catch {};
+                }
+                return;
+            }
+            const current = SuspendClockSample.now();
+            if (system_resumed != null and suspendGapDetected(previous, current)) {
+                if (cancel_flag.load(.seq_cst)) {
+                    if (connected_watch == null or connected_watch.?.win(.cancelled)) {
+                        stream.shutdown(io_mod.getIo(), .both) catch {};
+                    }
+                    return;
+                }
+                if (connected_watch == null or connected_watch.?.win(.system_resumed)) {
+                    system_resumed.?.store(true, .seq_cst);
+                    stream.shutdown(io_mod.getIo(), .both) catch {};
+                }
                 return;
             }
             if (deadline) |limit| {
@@ -1710,18 +1898,16 @@ const GatewayCancelWatcher = struct {
                     return;
                 }
             }
-            io_mod.sleep(10 * std.time.ns_per_ms);
-            const current = SuspendClockSample.now();
-            if (system_resumed != null and suspendGapDetected(previous, current)) {
-                if (cancel_flag.load(.seq_cst)) {
+            if (connected_watch) |watch| {
+                const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+                if (watch.response_head_expired(now) and watch.win_response_head_timeout()) {
                     stream.shutdown(io_mod.getIo(), .both) catch {};
                     return;
                 }
-                system_resumed.?.store(true, .seq_cst);
-                stream.shutdown(io_mod.getIo(), .both) catch {};
-                return;
+                if (watch.phase.load(.seq_cst) == .completed) return;
             }
             previous = current;
+            io_mod.sleep(10 * std.time.ns_per_ms);
         }
     }
 };
@@ -1753,7 +1939,7 @@ pub fn spawnHttpCancelWatcher(
     cancel_flag: *std.atomic.Value(bool),
     stream: std.Io.net.Stream,
 ) !std.Thread {
-    return spawn_gateway_cancel_watcher(done, cancel_flag, null, null, stream);
+    return spawn_gateway_cancel_watcher(done, cancel_flag, null, null, null, stream);
 }
 
 pub fn spawnHttpCancelWatcherBounded(
@@ -1762,7 +1948,7 @@ pub fn spawnHttpCancelWatcherBounded(
     deadline: std.Io.Clock.Timestamp,
     stream: std.Io.net.Stream,
 ) !std.Thread {
-    return spawn_gateway_cancel_watcher(done, cancel_flag, null, deadline, stream);
+    return spawn_gateway_cancel_watcher(done, cancel_flag, null, deadline, null, stream);
 }
 
 fn spawn_gateway_cancel_watcher(
@@ -1770,6 +1956,7 @@ fn spawn_gateway_cancel_watcher(
     cancel_flag: *std.atomic.Value(bool),
     system_resumed: ?*std.atomic.Value(bool),
     deadline: ?std.Io.Clock.Timestamp,
+    connected_watch: ?*ConnectedRequestWatch,
     stream: std.Io.net.Stream,
 ) !std.Thread {
     if (builtin.is_test) {
@@ -1780,6 +1967,7 @@ fn spawn_gateway_cancel_watcher(
         cancel_flag,
         system_resumed,
         deadline,
+        connected_watch,
         stream,
     });
 }
@@ -1798,6 +1986,30 @@ test "suspend gap classification compares boot and awake clocks" {
         .awake_ns = before.awake_ns + 10 * std.time.ns_per_ms,
         .boot_ns = before.boot_ns + 10 * std.time.ns_per_ms + suspend_gap_tolerance_ns + 1,
     }));
+}
+
+test "connected request watch keeps the first terminal winner" {
+    var cancelled = ConnectedRequestWatch.init(.{});
+    try std.testing.expect(cancelled.win(.cancelled));
+    try std.testing.expect(!cancelled.win_response_head_timeout());
+    try std.testing.expectEqual(error.Cancelled, cancelled.finish().?);
+
+    var resumed = ConnectedRequestWatch.init(.{});
+    try std.testing.expect(resumed.win(.system_resumed));
+    try std.testing.expect(!resumed.win(.cancelled));
+    try std.testing.expectEqual(error.SystemResumed, resumed.finish().?);
+
+    var ordinary = ConnectedRequestWatch.init(.{});
+    try std.testing.expect(ordinary.finish() == null);
+    try std.testing.expect(!ordinary.win(.cancelled));
+}
+
+test "connected request watch disarms timeout at response head" {
+    var watch = ConnectedRequestWatch.init(.{ .timeout_ms = 1 });
+    try std.testing.expect(watch.arm_response_head() == null);
+    try std.testing.expect(watch.commit_response_head() == null);
+    try std.testing.expect(!watch.win_response_head_timeout());
+    try std.testing.expect(watch.finish() == null);
 }
 
 fn resolveE2eGatewayUrl(env_name: []const u8, default_url: []const u8) ![]const u8 {
@@ -5492,6 +5704,7 @@ const LoopbackGatewayMode = enum {
     request_send_stall,
     response_head_stall,
     response_body_stall,
+    response_body_delayed_success,
     response_body_progress,
     retry_once,
     retry_once_then_success,
@@ -5679,6 +5892,24 @@ const LoopbackGatewayFixture = struct {
                 );
                 self.markStage();
                 self.hold();
+            },
+            .response_body_delayed_success => {
+                try readLoopbackGatewayRequest(zio, stream, self);
+                try writeLoopbackGatewayBytes(
+                    zio,
+                    stream,
+                    "HTTP/1.1 200 OK\r\n" ++
+                        "Content-Type: text/event-stream\r\n" ++
+                        "Connection: close\r\n\r\n",
+                );
+                self.markStage();
+                self.hold();
+                try writeLoopbackGatewayBytes(
+                    zio,
+                    stream,
+                    "data: {\"type\":\"text-delta\",\"id\":\"answer\",\"delta\":\"ok\"}\n\n" ++
+                        "data: {\"type\":\"finish\",\"finishReason\":{\"unified\":\"stop\"}}\n\n",
+                );
             },
             .response_body_progress => {
                 try readLoopbackGatewayRequest(zio, stream, self);
@@ -7187,6 +7418,91 @@ fn expectDirectLoopbackCancellation(
 
 test "direct gateway cancellation closes a stalled response body promptly" {
     try expectDirectLoopbackCancellation(.response_body_stall, "{}", 20, 800, 500);
+}
+
+test "direct gateway times out only while awaiting the response head" {
+    const zio = io_mod.getIo();
+    var fixture = try LoopbackGatewayFixture.init(.response_head_stall, 500);
+    defer fixture.deinit();
+    try fixture.start();
+    try std.testing.expect(fixture.waitForAcceptStart(5000));
+
+    const url = try std.fmt.allocPrint(std.testing.allocator, "http://127.0.0.1:{d}/chat", .{fixture.port()});
+    defer std.testing.allocator.free(url);
+    const Noop = struct {
+        fn onChunk(_: *anyopaque, _: []const u8) void {}
+    };
+    var callback_ctx: u8 = 0;
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    var delivery = DeliveryCertainty.init();
+    const started = std.Io.Clock.Timestamp.now(zio, .awake);
+    const result = streamGatewayCompletionCoreWithOptions(
+        std.testing.allocator,
+        .{
+            .api_key = "test-key",
+            .model = "test/model",
+            .retry_count = 1,
+            .chat_url = url,
+            .payload = "{}",
+            .delivery = &delivery,
+        },
+        @ptrCast(&callback_ctx),
+        Noop.onChunk,
+        null,
+        &cancel_flag,
+        null,
+        true,
+        .{ .response_head_timing = .{ .timeout_ms = 80 } },
+    );
+    const elapsed_ms = started.durationTo(std.Io.Clock.Timestamp.now(zio, .awake)).raw.toMilliseconds();
+
+    fixture.deinit();
+    try std.testing.expectError(error.Timeout, result);
+    if (fixture.failure) |err| return err;
+    try std.testing.expectEqual(DeliveryCertainty.State.possibly_sent, delivery.load());
+    try std.testing.expect(elapsed_ms < 500);
+}
+
+test "direct gateway response head timeout does not limit a delayed SSE body" {
+    const zio = io_mod.getIo();
+    var fixture = try LoopbackGatewayFixture.init(.response_body_delayed_success, 150);
+    defer fixture.deinit();
+    try fixture.start();
+    try std.testing.expect(fixture.waitForAcceptStart(5000));
+
+    const url = try std.fmt.allocPrint(std.testing.allocator, "http://127.0.0.1:{d}/chat", .{fixture.port()});
+    defer std.testing.allocator.free(url);
+    const Noop = struct {
+        fn onChunk(_: *anyopaque, _: []const u8) void {}
+    };
+    var callback_ctx: u8 = 0;
+    var cancel_flag = std.atomic.Value(bool).init(false);
+    const started = std.Io.Clock.Timestamp.now(zio, .awake);
+    var result = try streamGatewayCompletionCoreWithOptions(
+        std.testing.allocator,
+        .{
+            .api_key = "test-key",
+            .model = "test/model",
+            .retry_count = 1,
+            .chat_url = url,
+            .payload = "{}",
+        },
+        @ptrCast(&callback_ctx),
+        Noop.onChunk,
+        null,
+        &cancel_flag,
+        null,
+        true,
+        .{ .response_head_timing = .{ .timeout_ms = 40 } },
+    );
+    defer result.deinit(std.testing.allocator);
+    const elapsed_ms = started.durationTo(std.Io.Clock.Timestamp.now(zio, .awake)).raw.toMilliseconds();
+
+    fixture.deinit();
+    if (fixture.failure) |err| return err;
+    try std.testing.expectEqual(std.http.Status.ok, result.status);
+    try std.testing.expectEqualStrings("ok", result.completion.content.?);
+    try std.testing.expect(elapsed_ms >= 100);
 }
 
 test "direct gateway cancellation closes a stalled request send promptly" {

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -1866,7 +1866,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
   );
 
   test(
-    "provider route recovery renders retry, transient recovery, and normal summary row",
+    "provider route recovery counts down, times out a silent head, and recovers",
     async () => {
       root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-route-recovery-")));
       const home = join(root, "home");
@@ -1878,16 +1878,13 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const workspace = realpathSync(workspacePath);
 
       const finalText = "TUI route recovery completed.";
-      let releaseFinalResponse: (() => void) | null = null;
-      const finalResponseRelease = new Promise<void>((resolve) => {
-        releaseFinalResponse = resolve;
-      });
       const queuedGateway = startFakeGateway([
-        providerErrorResponse("tui route failed once"),
+        retryAfterUnavailable(4),
         async () => {
-          await finalResponseRelease;
-          return fakeGatewayFinalText(finalText);
+          await Bun.sleep(35_000);
+          return fakeGatewayFinalText("late response must be ignored");
         },
+        fakeGatewayFinalText(finalText),
       ], {
         models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
       });
@@ -1913,32 +1910,37 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       });
 
       await session.waitForComposer(TIMEOUT);
-      const retryVisible = session.waitForText(
-        "provider_error: tui route failed once",
-        TIMEOUT,
-      );
       await session.sendText("Recover from provider route failure.");
-      await Promise.all([
-        retryVisible,
-        waitForCondition(
-          () => queuedGateway.requests.length === 2,
-          "second route recovery request",
-        ),
-      ]);
+      await session.waitForText("retrying request in 4s", TIMEOUT);
+      await session.waitForText("retrying request in 3s", TIMEOUT);
+      await session.waitForText("retrying request in 2s", TIMEOUT);
+      await session.waitForText("retrying request in 1s", TIMEOUT);
+      await waitForCondition(
+        () => queuedGateway.requests.length === 2,
+        "silent-head retry request",
+      );
+      await session.waitForText("attempt 2/10", TIMEOUT);
+
+      const inFlightPane = await session.capturePane();
+      expect(inFlightPane).toContain("attempt 2/10");
+      expect(inFlightPane).not.toContain("retrying request in 1s");
 
       await session.resizeWindow(32, 24);
       const narrowPane = await session.capturePane();
       expect(narrowPane).toContain("⚠ Provider unavailable");
-      expect(narrowPane).toContain("provider_error:");
-      expect(narrowPane).toContain("attempt 1/10");
+      expect(narrowPane).toContain("attempt 2/10");
       expect(narrowPane).not.toContain("▲");
 
       await session.resizeWindow(72, 24);
-      releaseFinalResponse?.();
+      await waitForCondition(
+        () => queuedGateway.requests.length === 3,
+        "retry after silent response head timeout",
+        TIMEOUT * 2,
+      );
       await session.waitForText(finalText, TIMEOUT);
       const scrollback = await session.captureFullScrollback();
 
-      expect(queuedGateway.requests.length).toBe(2);
+      expect(queuedGateway.requests.length).toBe(3);
       expect(scrollback).not.toContain("System");
       expect(scrollback).not.toContain("Attempt 1 failed. Retrying route.");
       expect(scrollback).not.toContain("✓ recovered");
@@ -1946,7 +1948,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(scrollback).toContain(finalText);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
-    TIMEOUT,
+    TIMEOUT * 2,
   );
 
   test(


### PR DESCRIPTION
## Summary

- Count down automatic retry delays live and show the admitted attempt while its request is in flight.
- Close scheduled recovery state on pre-admission failure without consuming a request attempt.
- Time out silent Gateway response heads after 30 seconds without limiting streamed response bodies.