### PR TITLE
Keep agent turns alive after missing tool authority

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -5165,11 +5165,22 @@ fn processQueuedPromptLoop(
                         try runtime_tool_admission.applyInitialSessionGrants(deps, arena, &local_grants, config.workspace_root, parallel_call, target_path);
                     }
 
+                    const parallel_authority = permission_outcome.execution_authority orelse {
+                        const failure_output = try tool_result_errors.formatToolExecutionErrorJson(
+                            arena,
+                            parallel_call.name,
+                            error.MissingToolExecutionAuthority,
+                        );
+                        precomputed_results[group_index] = .{
+                            .status = .failure,
+                            .model_output = failure_output,
+                            .status_detail = "permission preflight failed",
+                        };
+                        continue;
+                    };
                     if (!parallel_status_started[group_index]) {
                         parallel_status_started[group_index] = try runtime_tool_presentation.startToolVisibleLifecycle(deps, arena, turn_id, stream_ctx.provisional_statuses.presentation_group_id, parallel_call, null, advertised_dynamic_tool_names);
                     }
-                    const parallel_authority = permission_outcome.execution_authority orelse
-                        return error.MissingToolExecutionAuthority;
                     if (parallel_authority != .ordinary) {
                         return error.UnexpectedCommandExecutionAuthority;
                     }
@@ -6462,7 +6473,54 @@ fn processQueuedPromptLoop(
                     "call_id={s} tool_name={s}",
                     .{ tool_call.id, tool_call.name },
                 );
-                return error.MissingToolExecutionAuthority;
+                const failure_output = try tool_result_errors.formatToolExecutionErrorJson(
+                    arena,
+                    tool_call.name,
+                    error.MissingToolExecutionAuthority,
+                );
+                const failure: ToolExecutionResult = .{
+                    .status = .failure,
+                    .model_output = failure_output,
+                    .status_detail = "permission preflight failed",
+                };
+                const prepared_failure = try runtime_execution_memory.prepareToolModelOutput(
+                    arena,
+                    config,
+                    tool_call,
+                    failure_output,
+                );
+                _ = try stream_ctx.provisional_statuses.finishExecutedCall(
+                    deps,
+                    stream_ctx.alloc,
+                    call_allocator,
+                    turn_id,
+                    execution_call,
+                    status_started,
+                    tool_display_target,
+                    failure,
+                    prepared_failure.model_output,
+                    prepared_failure.memory,
+                    null,
+                    advertised_dynamic_tool_names,
+                );
+                try runtime_tool_batch.appendToolResultContent(
+                    arena,
+                    &within_turn_suffix,
+                    &completed_tool_names,
+                    &step_batch,
+                    tool_call,
+                    prepared_failure.model_output,
+                    prepared_failure.memory,
+                    .{ .increment_error = true },
+                );
+                try runtime_tool_admission.recordRejectedToolCall(
+                    deps,
+                    arena,
+                    tool_call,
+                    prepared_failure.model_output,
+                    null,
+                );
+                continue;
             };
             if (try tooling_tool_admission.callUsesCommandAuthority(
                 deps.tool_registry,

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -517,6 +517,7 @@ pub const FakeAgentRuntimeDeps = struct {
     permission_feedback: []const []const u8 = &.{},
     permission_errors: []const ?anyerror = &.{},
     permission_human_approvals: []const command_admission.HumanApprovalProvenance = &.{},
+    permission_omit_execution_authority: bool = false,
     permission_request_override: ?PermissionRequestOverride = null,
     permission_wait_index: ?usize = null,
     permission_waiting: ?*std.atomic.Value(bool) = null,
@@ -1054,7 +1055,7 @@ pub const FakeAgentRuntimeDeps = struct {
                 std.Thread.yield() catch std.atomic.spinLoopHint();
             }
         }
-        const execution_authority = if (decision.isDenied()) null else if (revalidation) |request| switch (request) {
+        const execution_authority = if (decision.isDenied() or self.permission_omit_execution_authority) null else if (revalidation) |request| switch (request) {
             .action => |action| action.authority,
         } else if (file_mutation_contract.isToolName(call.name))
             command_admission.ToolExecutionAuthority{

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -975,6 +975,53 @@ test "denied web_fetch is presented without dns http or cache work" {
     try expectBodyContains(&gateway, 1, "permission_required");
 }
 
+test "missing serial permission authority fails the tool without aborting the turn" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{toolCall("call_1", "read_file", "{\"path\":\"README.md\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Recovered after the tool failure" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.permission_omit_execution_authority = true;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 2), gateway.index);
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    try std.testing.expectEqual(@as(usize, 1), hooks.rejected_names.items.len);
+    try expectBodyContains(&gateway, 1, "tool_execution_failed");
+}
+
+test "missing parallel permission authority fails one tool without aborting the batch" {
+    const alloc = std.testing.allocator;
+    const calls = [_]ToolCall{
+        toolCall("call_1", "read_file", "{\"path\":\"README.md\"}"),
+        toolCall("call_2", "glob_files", "{\"pattern\":\"*.md\",\"path\":\".\",\"mode\":\"matches\"}"),
+    };
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls },
+        .{ .content = "Recovered after parallel failures" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.permission_omit_execution_authority = true;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+
+    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 2), gateway.index);
+    try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    try std.testing.expectEqual(@as(usize, 2), hooks.rejected_names.items.len);
+    try expectBodyContains(&gateway, 1, "tool_execution_failed");
+}
+
 test "accepted automatic review remains internal before ordinary tool execution" {
     const alloc = std.testing.allocator;
     const calls = [_]ToolCall{toolCall("call_1", "terminal", "{\"action\":\"exec\",\"command\":\"printf done\"}")};


### PR DESCRIPTION
## TL;DR
Keep agent turns running when an allowed tool lacks execution authority. The affected tool now fails closed while the model can recover.

## Issue

- Missing tool authority aborts the entire agent turn
- Serial and parallel paths share the failure mode

## Fix

- Convert missing authority into a failed tool result
- Preserve continuation after serial and parallel failures
- Add regression coverage for both execution paths