### PR TITLE
Preserve scrollback during streamed responses

### DIFF
--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -579,9 +579,17 @@ pub fn Runtime(comptime App: type) type {
                 }
             }
             if (!app.stream.active and !app.pacer.hasCompletedAssistantPresentationTail()) return false;
+            const native_history_active = if (comptime @hasDecl(
+                @TypeOf(app.shell),
+                "nativeHistoryActive",
+            ))
+                app.shell.nativeHistoryActive()
+            else
+                false;
             if (app.approval_prompt.isActive() or
                 app.question_prompt.isActive() or
-                !app.shell.shimmer_active)
+                !app.shell.shimmer_active or
+                native_history_active)
             {
                 return false;
             }
@@ -1342,6 +1350,7 @@ const FakeCommandOutputDisplay = struct {
 const FakeShell = struct {
     command_output_display: FakeCommandOutputDisplay = .{},
     shimmer_active: bool = false,
+    native_history_active: bool = false,
     render_requests: render_request.RenderRequestState = .{},
     lifecycle: transcript_runtime.TranscriptRuntime = .{
         .layout = .{
@@ -1364,6 +1373,10 @@ const FakeShell = struct {
         self.lifecycle.deinit(alloc);
         for (self.raw_entries.items) |entry| alloc.free(entry);
         self.raw_entries.deinit(alloc);
+    }
+
+    fn nativeHistoryActive(self: *const FakeShell) bool {
+        return self.native_history_active;
     }
 
     fn trimTrailingBlankLines(self: *FakeShell) void {
@@ -2116,6 +2129,27 @@ test "core.app_worker_runtime advances visible animation exactly at its deadline
 
     try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(&app, NoopBridge.lifecyclePresenter(&app), 1_050));
     try std.testing.expectEqual(before, app.shell.render_requests.visibleAnimationPhase());
+}
+
+test "core.app_worker_runtime pauses visible animation after native history starts" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+
+    app.stream = .{
+        .active = true,
+        .last_activity_kind = .ask,
+    };
+    app.shell.shimmer_active = true;
+    app.shell.native_history_active = true;
+    app.shell.render_requests.animation_visible = true;
+    app.shell.render_requests.animation_next_deadline_ms = 1;
+
+    try std.testing.expect(!Runtime(FakeApp).advanceVisibleAnimation(
+        &app,
+        NoopBridge.lifecyclePresenter(&app),
+        1,
+    ));
+    try std.testing.expect(!app.shell.render_requests.hasReason(.animation));
 }
 
 test "core.app_worker_runtime expires selected child worker status while idle" {

--- a/src/ui/render_engine/assistant_wrap.zig
+++ b/src/ui/render_engine/assistant_wrap.zig
@@ -56,7 +56,7 @@ const AssistantContinuation = union(enum) {
 /// Pre-existing hard newlines in `text` are honoured. The returned slice is
 /// owned by the caller and freed with `alloc`.
 pub fn wrapAssistantText(alloc: Allocator, text: []const u8, cols: u16) ![]u8 {
-    return wrapAssistantTextWithBaseGutter(alloc, text, cols, 0, false, false, null);
+    return wrapAssistantTextWithBaseGutter(alloc, text, cols, 0, false, false, null, null);
 }
 
 fn wrapAssistantTextWithBaseGutter(
@@ -67,9 +67,17 @@ fn wrapAssistantTextWithBaseGutter(
     replace_wide_runes_at_one_content_col: bool,
     literal_command: bool,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
+    finalized_prefix_bytes: ?*usize,
 ) ![]u8 {
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(alloc);
+    if (finalized_prefix_bytes) |bytes| bytes.* = 0;
+    var finalized_source_end: usize = 0;
+    if (finalized_prefix_bytes != null) {
+        if (std.mem.findScalarLast(u8, text, '\n')) |newline| {
+            finalized_source_end = newline + 1;
+        }
+    }
 
     if (cols == 0) {
         return out.toOwnedSlice(alloc);
@@ -135,6 +143,9 @@ fn wrapAssistantTextWithBaseGutter(
             try out.append(alloc, ch);
             col = base_gutter + 1;
             i += 1;
+            if (finalized_prefix_bytes) |bytes| {
+                if (i == finalized_source_end) bytes.* = out.items.len;
+            }
             continuation = if (literal_command) null else assistantContinuation(text, i);
             word_breaks = .{};
             has_word_on_row = false;
@@ -391,7 +402,38 @@ pub fn wrapTranscriptAssistantTextInterruptible(
         true,
         false,
         checkpoint,
+        null,
     );
+}
+
+/// `bytes` is owned by the caller. `finalized_prefix_bytes` ends after the
+/// last source hard newline and excludes soft wraps from the unfinished line.
+pub const TranscriptAssistantWrap = struct {
+    bytes: []u8,
+    finalized_prefix_bytes: usize,
+};
+
+pub fn wrapTranscriptAssistantTextWithFinalityInterruptible(
+    alloc: Allocator,
+    text: []const u8,
+    cols: u16,
+    checkpoint: ?*build_checkpoint.BuildCheckpoint,
+) !TranscriptAssistantWrap {
+    var finalized_prefix_bytes: usize = 0;
+    const bytes = try wrapAssistantTextWithBaseGutter(
+        alloc,
+        text,
+        cols,
+        gutterWidth(cols),
+        true,
+        false,
+        checkpoint,
+        &finalized_prefix_bytes,
+    );
+    return .{
+        .bytes = bytes,
+        .finalized_prefix_bytes = finalized_prefix_bytes,
+    };
 }
 
 /// Reflow canonical command output as literal terminal text. Every physical
@@ -412,6 +454,7 @@ pub fn wrapLiteralCommandOutput(
         gutter,
         true,
         true,
+        null,
         null,
     );
 }
@@ -444,6 +487,7 @@ pub fn wrapLiteralToolOutputInterruptible(
         true,
         true,
         checkpoint,
+        null,
     );
 }
 

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -1591,18 +1591,23 @@ fn renderEntryToBlockForPresentationInterruptible(
             break :blk try normalizeOwnedRenderedBlock(alloc, kind, card);
         },
         .assistant_turn => |e| blk: {
-            const wrapped = try assistant_wrap.wrapTranscriptAssistantTextInterruptible(
+            const wrapped = try assistant_wrap.wrapTranscriptAssistantTextWithFinalityInterruptible(
                 alloc,
                 e.segments.text.items,
                 cols,
                 checkpoint,
             );
-            break :blk try normalizeOwnedRenderedBlockWithAllocation(
+            const trimmed = trimAssistantBlockHead(wrapped.bytes);
+            const trimmed_head_bytes = wrapped.bytes.len - trimmed.len;
+            var block = try normalizeOwnedRenderedBlockWithAllocation(
                 alloc,
                 kind,
-                trimAssistantBlockHead(wrapped),
-                wrapped,
+                trimmed,
+                wrapped.bytes,
             );
+            block.assistant_finalized_prefix_bytes =
+                wrapped.finalized_prefix_bytes -| trimmed_head_bytes;
+            break :blk block;
         },
         .assistant_table => |e| blk: {
             const gutter = assistant_wrap.gutterWidth(cols);
@@ -1919,7 +1924,7 @@ const RenderEntriesOptions = struct {
     target_entry_id: ?u32 = null,
     target_byte_entry_id: ?u32 = null,
     finality_entry_ids: []const u32 = &.{},
-    finality_entry_start_bytes: []?usize = &.{},
+    finality_entry_floor_bytes: []?usize = &.{},
     omitted_entry_id: ?u32 = null,
     entry_actions: []const EntryRenderAction = &.{},
     summary_entry_ids: []const ?u32 = &.{},
@@ -2035,7 +2040,8 @@ const RenderEntriesBuilder = struct {
         if (options.target_byte_entry_id == entry_id) self.target_entry_start_byte = self.out.items.len;
         for (options.finality_entry_ids, 0..) |finality_entry_id, index| {
             if (finality_entry_id == entry_id) {
-                options.finality_entry_start_bytes[index] = self.out.items.len;
+                options.finality_entry_floor_bytes[index] = self.out.items.len +
+                    (block.assistant_finalized_prefix_bytes orelse 0);
             }
         }
         for (options.summary_entry_ids, 0..) |summary_entry_id, index| {
@@ -2085,6 +2091,7 @@ fn renderEntriesInterruptible(
     options: RenderEntriesOptions,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
 ) !RenderedEntries {
+    std.debug.assert(options.finality_entry_ids.len == options.finality_entry_floor_bytes.len);
     options.resetSummaryIndices();
     if (options.entry_actions.len > 0) {
         std.debug.assert(options.entry_actions.len == entries.len);
@@ -2260,7 +2267,9 @@ pub const TranscriptPreparationOptions = struct {
     target_entry_id: ?u32 = null,
     target_byte_entry_id: ?u32 = null,
     finality_entry_ids: []const u32 = &.{},
-    finality_entry_start_bytes: []?usize = &.{},
+    /// Parallel to `finality_entry_ids`. Each rendered nomination writes the
+    /// first byte that remains mutable; immutable entries use their start.
+    finality_entry_floor_bytes: []?usize = &.{},
     omitted_entry_id: ?u32 = null,
     entry_actions: []const EntryRenderAction = &.{},
     folded_summary_entry_ids: []const ?u32 = &.{},
@@ -2309,7 +2318,7 @@ pub fn renderEntriesForPreparationInterruptible(
             .target_entry_id = options.target_entry_id,
             .target_byte_entry_id = options.target_byte_entry_id,
             .finality_entry_ids = options.finality_entry_ids,
-            .finality_entry_start_bytes = options.finality_entry_start_bytes,
+            .finality_entry_floor_bytes = options.finality_entry_floor_bytes,
             .omitted_entry_id = options.omitted_entry_id,
             .entry_actions = options.entry_actions,
             .summary_entry_ids = options.folded_summary_entry_ids,
@@ -2641,6 +2650,7 @@ pub const RenderedBlock = struct {
     stored_tail_newlines: usize,
     allocation: []const u8 = &.{},
     owned: bool = false,
+    assistant_finalized_prefix_bytes: ?usize = null,
 
     pub fn deinit(self: RenderedBlock, alloc: Allocator) void {
         if (self.owned) alloc.free(self.allocation);

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -6246,12 +6246,12 @@ test "inline approval footer reflow preserves concurrent transcript progress" {
     try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
     try h.flush();
 
-    // The assistant producer is still open, so the streamed rows are not
-    // final: the viewport follows them through an in-place repaint and no
-    // transcript row is released into scrollback.
-    try std.testing.expectEqual(@as(u16, 0), h.last_frame.planned_scroll_rows);
-    try std.testing.expectEqual(@as(u16, 0), h.last_frame.committed_scroll_rows);
+    // Complete streamed rows are final even while the producer remains open,
+    // so they enter history instead of sliding the viewport by repaint.
+    try std.testing.expectEqual(@as(u16, 2), h.last_frame.planned_scroll_rows);
+    try std.testing.expectEqual(@as(u16, 2), h.last_frame.committed_scroll_rows);
     try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
+    try std.testing.expect(h.last_frame.document_append_bytes > 0);
     try std.testing.expectEqual(
         @as(usize, 1),
         std.mem.count(u8, h.shell.transcript.items, append_one),
@@ -6263,20 +6263,13 @@ test "inline approval footer reflow preserves concurrent transcript progress" {
     try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_one));
     try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_two));
 
-    // Closing the producer finalizes the tail; the held rows settle through
-    // the catch-up replay, possibly across frames.
+    // Closing the producer has no completed-row debt left to settle.
     h.shell.transcript_release = h.shell.transcript_release.with_assistant_tail_writable(false);
-    var settle_frames: usize = 0;
-    var settled_scroll_rows: u32 = 0;
-    while (settle_frames < 8) : (settle_frames += 1) {
-        h.frame_redraw = true;
-        try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
-        try h.flush();
-        try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
-        if (h.last_frame.planned_scroll_rows == 0) break;
-        settled_scroll_rows += h.last_frame.planned_scroll_rows;
-    }
-    try std.testing.expect(settled_scroll_rows > 0);
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.planned_scroll_rows);
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
     try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_one));
     try std.testing.expectEqual(@as(usize, 1), try countGridOccurrences(&h, append_two));
 

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -6023,7 +6023,20 @@ pub const TranscriptRuntime = struct {
         metrics: *Metrics,
         text: []const u8,
     ) !u32 {
-        return transcript_store.streamAssistantChunk(self, alloc, metrics, text);
+        const transcript_was_pending = self.render_requests.hasReason(.transcript);
+        const entry_id = try transcript_store.streamAssistantChunk(self, alloc, metrics, text);
+        if (!transcript_was_pending and
+            self.nativeHistoryActive() and
+            std.mem.findScalar(u8, text, '\n') == null)
+        {
+            self.render_requests.clearReason(.transcript);
+            debug_trace.logf(
+                "scroll",
+                "assistant_partial_paint_deferred bytes={d} entry_id={d}",
+                .{ text.len, entry_id },
+            );
+        }
+        return entry_id;
     }
 
     pub fn retintEntriesForTheme(
@@ -9784,6 +9797,14 @@ pub const TranscriptRuntime = struct {
     pub fn markTranscriptDirty(self: *TranscriptRuntime) void {
         self.transcript_band_dirty = true;
         self.render_requests.request(.transcript);
+    }
+
+    pub fn nativeHistoryActive(self: *const TranscriptRuntime) bool {
+        return switch (self.transcript_commit_state) {
+            .invalid => false,
+            .stable => |anchor| anchor.history_visual_offset > 0,
+            .recovering => |receipt| receipt.accepted_history_visual_offset > 0,
+        };
     }
 
     pub fn markTranscriptContentDirty(self: *TranscriptRuntime) void {

--- a/src/ui/transcript/runtime_tests.zig
+++ b/src/ui/transcript/runtime_tests.zig
@@ -15357,6 +15357,148 @@ test "lifecycle pins survive low cap until batch cleanup restores prune eligibil
     );
 }
 
+test "streaming assistant finality releases complete rows and holds only the partial tail" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(40, 10, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    var metrics: Metrics = .{};
+    _ = try runtime.streamAssistantChunk(
+        alloc,
+        &metrics,
+        "first finalized row\nsecond finalized row\npartial tail",
+    );
+
+    var partial_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer partial_source.deinit(alloc);
+    const partial_start = std.mem.find(u8, partial_source.bytes, "  partial tail") orelse
+        return error.TestExpectedPartialAssistantTail;
+    try std.testing.expectEqual(
+        @as(?usize, partial_start),
+        runtime.transcript_release.finality_floor(
+            partial_source.finality,
+            runtime.finalizedToolTurnWatermark(),
+            null,
+        ),
+    );
+
+    _ = try runtime.streamAssistantChunk(alloc, &metrics, "\n");
+    var completed_source = try runtime.prepareTranscriptSource(alloc, null);
+    defer completed_source.deinit(alloc);
+    try std.testing.expectEqual(
+        @as(?usize, completed_source.bytes.len),
+        runtime.transcript_release.finality_floor(
+            completed_source.finality,
+            runtime.finalizedToolTurnWatermark(),
+            null,
+        ),
+    );
+}
+
+test "blank streaming assistant tail keeps finality inside the prepared source" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(40, 10, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    _ = try runtime.appendRawTranscriptEntry(alloc, "stable history\n");
+    var metrics: Metrics = .{};
+    _ = try runtime.streamAssistantChunk(alloc, &metrics, "   ");
+
+    var source = try runtime.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    try std.testing.expectEqual(
+        @as(?usize, source.bytes.len),
+        runtime.transcript_release.finality_floor(
+            source.finality,
+            runtime.finalizedToolTurnWatermark(),
+            null,
+        ),
+    );
+}
+
+test "empty assistant tail leaves the complete prepared source final" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(40, 10, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    _ = try runtime.appendRawTranscriptEntry(alloc, "stable history\n");
+    _ = try runtime.appendAssistantTurnEntry(alloc);
+
+    var source = try runtime.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    try std.testing.expectEqual(
+        @as(?usize, source.bytes.len),
+        runtime.transcript_release.finality_floor(
+            source.finality,
+            runtime.finalizedToolTurnWatermark(),
+            null,
+        ),
+    );
+}
+
+test "native history defers partial assistant paints but publishes hard lines" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(40, 10, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+    try installStableAnchorForTest(
+        &runtime,
+        alloc,
+        "history\n",
+        testSelection(1),
+        1,
+        4,
+        1,
+        1,
+    );
+    var metrics: Metrics = .{};
+    _ = try runtime.streamAssistantChunk(alloc, &metrics, "partial");
+    try std.testing.expect(!runtime.render_requests.hasReason(.transcript));
+
+    _ = try runtime.streamAssistantChunk(alloc, &metrics, " line\n");
+    try std.testing.expect(runtime.render_requests.hasReason(.transcript));
+}
+
+test "streaming assistant finality keeps soft wraps of a partial hard line mutable" {
+    const alloc = std.testing.allocator;
+    var runtime = TranscriptRuntime{
+        .layout = transcriptTestLayout(12, 10, 4),
+        .owned_top_row = 1,
+    };
+    defer runtime.deinit(alloc);
+
+    var metrics: Metrics = .{};
+    _ = try runtime.streamAssistantChunk(
+        alloc,
+        &metrics,
+        "finalized row\npartial tail wraps across several visual rows",
+    );
+
+    var source = try runtime.prepareTranscriptSource(alloc, null);
+    defer source.deinit(alloc);
+    const partial_start = std.mem.find(u8, source.bytes, "  partial") orelse
+        return error.TestExpectedWrappedPartialAssistantTail;
+    try std.testing.expectEqual(
+        @as(?usize, partial_start),
+        runtime.transcript_release.finality_floor(
+            source.finality,
+            runtime.finalizedToolTurnWatermark(),
+            null,
+        ),
+    );
+}
+
 test "finality floor holds unfenced tool turn across quiet ticks and settles after the fence" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -481,11 +481,11 @@ fn prepareTranscriptSourceInternal(
         defer finality_nominations.deinit(alloc);
         const finality_entry_ids = try alloc.alloc(u32, finality_nominations.items.len);
         defer alloc.free(finality_entry_ids);
-        const finality_entry_start_bytes = try alloc.alloc(?usize, finality_nominations.items.len);
-        defer alloc.free(finality_entry_start_bytes);
+        const finality_entry_floor_bytes = try alloc.alloc(?usize, finality_nominations.items.len);
+        defer alloc.free(finality_entry_floor_bytes);
         for (finality_nominations.items, 0..) |nomination, index| {
             finality_entry_ids[index] = nomination.entry_id;
-            finality_entry_start_bytes[index] = null;
+            finality_entry_floor_bytes[index] = null;
         }
         const summary_entry_ids = try alloc.alloc(?u32, self.folded_command_blocks.items.len);
         defer alloc.free(summary_entry_ids);
@@ -502,7 +502,7 @@ fn prepareTranscriptSourceInternal(
                 .target_entry_id = tracked_entry_id,
                 .target_byte_entry_id = replaceable_entry_id,
                 .finality_entry_ids = finality_entry_ids,
-                .finality_entry_start_bytes = finality_entry_start_bytes,
+                .finality_entry_floor_bytes = finality_entry_floor_bytes,
                 .omitted_entry_id = omitted_entry_id,
                 .folded_summary_entry_ids = summary_entry_ids,
                 .capture_provenance = capture_provenance,
@@ -519,22 +519,28 @@ fn prepareTranscriptSourceInternal(
         var tool_turn_floors: std.ArrayList(transcript_release.ToolTurnFloor) = .empty;
         errdefer tool_turn_floors.deinit(alloc);
         for (finality_nominations.items, 0..) |nomination, index| {
-            const start_byte = finality_entry_start_bytes[index] orelse blk: {
-                // A nominated entry that produced no bytes cannot anchor the
-                // boundary; hold the whole flow rather than release past it.
+            const floor_byte = finality_entry_floor_bytes[index] orelse blk: {
+                // An empty assistant tail contributes no mutable rendered
+                // bytes, so the complete prepared flow is final. Other empty
+                // nominations remain conservative because their state may
+                // still mutate an earlier rendered entry.
+                const fallback = switch (nomination.kind) {
+                    .assistant_tail => bytes.len,
+                    .mutation_pin, .tool_turn => 0,
+                };
                 debug_trace.logf(
                     "scroll",
-                    "finality_nomination_unrecorded entry_id={d} kind={s}",
-                    .{ nomination.entry_id, @tagName(nomination.kind) },
+                    "finality_nomination_empty entry_id={d} kind={s} fallback={d}",
+                    .{ nomination.entry_id, @tagName(nomination.kind), fallback },
                 );
-                break :blk 0;
+                break :blk fallback;
             };
             switch (nomination.kind) {
-                .mutation_pin => finality.mutation_pin_start = start_byte,
-                .assistant_tail => finality.assistant_tail_start = start_byte,
+                .mutation_pin => finality.mutation_pin_start = floor_byte,
+                .assistant_tail => finality.assistant_tail_start = @min(bytes.len, floor_byte),
                 .tool_turn => try tool_turn_floors.append(alloc, .{
                     .turn_id = nomination.turn_id,
-                    .start_byte = start_byte,
+                    .start_byte = floor_byte,
                 }),
             }
         }

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -7508,6 +7508,35 @@ describe.skipIf(!tmuxAvailable())("transcript scrollback release", () => {
     });
   }
 
+  function sbHistoryText(sessionName: string): string {
+    const historySize = Number.parseInt(
+      execFileSync(
+        "tmux",
+        ["list-panes", "-t", sessionName, "-F", "#{history_size}"],
+        { encoding: "utf8" },
+      ).trim(),
+      10,
+    );
+    if (!Number.isSafeInteger(historySize) || historySize < 0) {
+      throw new Error(`invalid tmux history size: ${historySize}`);
+    }
+    if (historySize === 0) return "";
+    return execFileSync(
+      "tmux",
+      [
+        "capture-pane",
+        "-p",
+        "-t",
+        sessionName,
+        "-S",
+        String(-historySize),
+        "-E",
+        "-1",
+      ],
+      { encoding: "utf8" },
+    );
+  }
+
   test(
     "closed tool groups enter native scrollback before the turn finishes",
     async () => {
@@ -7973,5 +8002,288 @@ describe.skipIf(!tmuxAvailable())("transcript scrollback release", () => {
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
     SB_TIMEOUT + 60_000,
+  );
+
+  test(
+    "completed streamed UI blocks append without rewriting scrolled history",
+    async () => {
+      root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-sb-ui-blocks-")));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const stderrPath = join(root, "stderr.log");
+      const tapePath = join(root, "ui-blocks.fxtape");
+      mkdirSync(join(home, ".fx"), { recursive: true });
+      mkdirSync(workspace, { recursive: true });
+      writeFileSync(join(home, ".fx", "settings.json"), sbSettings());
+      writeFileSync(stderrPath, "");
+
+      const phaseOneRows = Array.from(
+        { length: 48 },
+        (_, index) =>
+          `ANCHOR_PHASE_ONE_${String(index + 1).padStart(2, "0")} finalized row`,
+      );
+      const phaseTwoRows = Array.from(
+        { length: 24 },
+        (_, index) =>
+          `ANCHOR_PHASE_TWO_${String(index + 1).padStart(2, "0")} finalized row`,
+      );
+      const phaseOne = [
+        "# BLOCK_HEADING",
+        "BLOCK_PROSE with **bold**, *italic*, `inline code`, and [BLOCK_LINK](https://example.com).",
+        "",
+        "- BLOCK_BULLET",
+        "  1. BLOCK_NESTED_ORDERED",
+        "- [x] BLOCK_TASK_COMPLETE",
+        "",
+        "> QUOTE_BLOCK_FIRST",
+        "> QUOTE_BLOCK_SECOND",
+        "",
+        "BLOCK_DEFINITION_TERM",
+        ": BLOCK_DEFINITION_BODY",
+        "",
+        "BLOCK_FOOTNOTE_REFERENCE[^1]",
+        "",
+        "[^1]: BLOCK_FOOTNOTE_BODY",
+        "",
+        "BLOCK_BEFORE_RULE",
+        "",
+        "---",
+        "",
+        "BLOCK_AFTER_RULE",
+        "",
+        "```zig",
+        "const BLOCK_CODE_LINE = true;",
+        "```",
+        "",
+        "| BLOCK_TABLE_HEADER | State |",
+        "| --- | --- |",
+        "| row | BLOCK_TABLE_CELL |",
+        "",
+        `BLOCK_WRAPPED_LINE ${"wrapped content ".repeat(12)}`,
+        "",
+        ...phaseOneRows,
+      ].join("\n") + "\n";
+      const phaseTwo = `${phaseTwoRows.join("\n")}\n`;
+
+      let phaseOneResolve!: () => void;
+      const phaseOneSent = new Promise<void>((resolve) => {
+        phaseOneResolve = resolve;
+      });
+      let phaseTwoResolve!: () => void;
+      const phaseTwoSent = new Promise<void>((resolve) => {
+        phaseTwoResolve = resolve;
+      });
+      let releasePhaseTwo!: () => void;
+      const phaseTwoGate = new Promise<void>((resolve) => {
+        releasePhaseTwo = resolve;
+      });
+      let releaseFinish!: () => void;
+      const finishGate = new Promise<void>((resolve) => {
+        releaseFinish = resolve;
+      });
+
+      gateway = startDynamicFakeGateway(
+        () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              async start(controller) {
+                const encoder = new TextEncoder();
+                controller.enqueue(
+                  encoder.encode(
+                    sbSseEvent({ type: "text-start", id: "answer_1" }),
+                  ),
+                );
+                for (const chunk of sbTokenChunks(phaseOne, 17)) {
+                  controller.enqueue(
+                    encoder.encode(
+                      sbSseEvent({
+                        type: "text-delta",
+                        id: "answer_1",
+                        delta: chunk,
+                      }),
+                    ),
+                  );
+                  await Bun.sleep(4);
+                }
+                phaseOneResolve();
+                await phaseTwoGate;
+                for (const chunk of sbTokenChunks(phaseTwo, 13)) {
+                  controller.enqueue(
+                    encoder.encode(
+                      sbSseEvent({
+                        type: "text-delta",
+                        id: "answer_1",
+                        delta: chunk,
+                      }),
+                    ),
+                  );
+                  await Bun.sleep(4);
+                }
+                phaseTwoResolve();
+                await finishGate;
+                controller.enqueue(
+                  encoder.encode(
+                    sbSseEvent({ type: "text-end", id: "answer_1" }),
+                  ),
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    sbSseEvent({
+                      type: "finish",
+                      finishReason: { unified: "stop", raw: "stop" },
+                      usage: {
+                        inputTokens: { total: 3 },
+                        outputTokens: { total: 120 },
+                      },
+                    }),
+                  ),
+                );
+                controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+                controller.close();
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          ),
+      );
+      const fakeGateway = gateway as ReturnType<typeof startDynamicFakeGateway>;
+
+      session = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: workspace,
+        width: 100,
+        height: 24,
+        minimumHistoryLines: 10_000,
+        stderrPath,
+        env: {
+          HOME: home,
+          AI_GATEWAY_API_KEY: "fake-sb-ui-blocks-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_GATEWAY_BASE_URL: fakeGateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: fakeGateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: fakeGateway.chatUrl,
+          FX_MODEL: MODEL,
+          FX_RECORD: tapePath,
+          FX_RECORD_INPUT: "1",
+        },
+      });
+
+      try {
+        await session.waitForComposer(SB_TIMEOUT);
+        await session.sendText("Render every prepared UI block.");
+        await phaseOneSent;
+        await session.waitForText("ANCHOR_PHASE_ONE_47", SB_TIMEOUT);
+        await Bun.sleep(500);
+
+        const phaseOneHistory = sbHistoryText(session.name);
+        expect(phaseOneHistory).toContain("ANCHOR_PHASE_ONE_01");
+        expect(phaseOneHistory).toContain("BLOCK_HEADING");
+        expect(phaseOneHistory).toContain("BLOCK_CODE_LINE");
+        expect(phaseOneHistory).toContain("BLOCK_TABLE_CELL");
+        expect(phaseOneHistory).toContain("• BLOCK_BULLET");
+        expect(phaseOneHistory).toContain("✓ BLOCK_TASK_COMPLETE");
+        expect(phaseOneHistory).toContain("│ QUOTE_BLOCK_FIRST");
+        expect(phaseOneHistory).toContain("┌ zig ");
+        expect(phaseOneHistory).toContain("┬");
+        expect(phaseOneHistory).toContain("┼");
+        expect(phaseOneHistory).toContain("┴");
+        const beforeRule = phaseOneHistory.indexOf("BLOCK_BEFORE_RULE");
+        const afterRule = phaseOneHistory.indexOf("BLOCK_AFTER_RULE");
+        expect(beforeRule).toBeGreaterThanOrEqual(0);
+        expect(afterRule).toBeGreaterThan(beforeRule);
+        expect(phaseOneHistory.slice(beforeRule, afterRule)).toContain("─");
+
+        execFileSync("tmux", ["copy-mode", "-t", session.name]);
+        execFileSync("tmux", [
+          "send-keys",
+          "-t",
+          session.name,
+          "-X",
+          "history-top",
+        ]);
+        await Bun.sleep(100);
+        const historyBeforePhaseTwo = phaseOneHistory;
+
+        releasePhaseTwo();
+        await phaseTwoSent;
+        await session.waitForText("ANCHOR_PHASE_TWO_23", SB_TIMEOUT);
+        await Bun.sleep(500);
+        const historyAfterPhaseTwo = sbHistoryText(session.name);
+        expect(historyAfterPhaseTwo.length).toBeGreaterThan(
+          historyBeforePhaseTwo.length,
+        );
+        expect(historyAfterPhaseTwo.startsWith(historyBeforePhaseTwo)).toBe(
+          true,
+        );
+        expect(historyAfterPhaseTwo).toContain("ANCHOR_PHASE_TWO_01");
+
+        execFileSync("tmux", [
+          "send-keys",
+          "-t",
+          session.name,
+          "-X",
+          "cancel",
+        ]);
+        releaseFinish();
+        await session.waitForPane(hasEmptyComposer, SB_TIMEOUT);
+        await Bun.sleep(250);
+
+        const scrollback = await session.captureFullScrollback();
+        const orderedMarkers = [
+          "BLOCK_HEADING",
+          "BLOCK_PROSE",
+          "BLOCK_LINK",
+          "BLOCK_BULLET",
+          "BLOCK_NESTED_ORDERED",
+          "BLOCK_TASK_COMPLETE",
+          "QUOTE_BLOCK_FIRST",
+          "QUOTE_BLOCK_SECOND",
+          "BLOCK_DEFINITION_TERM",
+          "BLOCK_DEFINITION_BODY",
+          "BLOCK_FOOTNOTE_REFERENCE",
+          "BLOCK_BEFORE_RULE",
+          "BLOCK_AFTER_RULE",
+          "BLOCK_CODE_LINE",
+          "BLOCK_TABLE_HEADER",
+          "BLOCK_TABLE_CELL",
+          "BLOCK_WRAPPED_LINE",
+          "ANCHOR_PHASE_ONE_01",
+          "ANCHOR_PHASE_ONE_48",
+          "ANCHOR_PHASE_TWO_01",
+          "ANCHOR_PHASE_TWO_24",
+        ];
+        let previous = -1;
+        for (const marker of orderedMarkers) {
+          expect(countOccurrences(scrollback, marker), marker).toBe(1);
+          const index = scrollback.indexOf(marker);
+          expect(index, marker).toBeGreaterThan(previous);
+          previous = index;
+        }
+        expect(countOccurrences(scrollback, "BLOCK_FOOTNOTE_BODY")).toBe(1);
+        expect(existsSync(tapePath)).toBe(true);
+        expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+        await session.sendText("/quit");
+        expect(await session.waitForSessionEnd(5_000)).toBe(true);
+        session = undefined;
+
+        const replay = JSON.parse(
+          execFileSync(FX_BIN, ["replay", tapePath, "--json"], {
+            encoding: "utf8",
+          }),
+        ) as { frame_count: number; stdout_bytes: number };
+        expect(replay.frame_count).toBeGreaterThan(0);
+        expect(replay.stdout_bytes).toBeGreaterThan(0);
+        const goldenPath = join(root, "ui-blocks-golden.txt");
+        execFileSync(FX_BIN, ["replay", tapePath, "--golden", goldenPath]);
+        expect(readFileSync(goldenPath, "utf8")).toContain(
+          "ANCHOR_PHASE_TWO_24",
+        );
+      } finally {
+        releasePhaseTwo();
+        releaseFinish();
+      }
+    },
+    SB_TIMEOUT + 30_000,
   );
 });


### PR DESCRIPTION
## Summary

- Keep native scrollback anchored while streamed responses continue producing new lines.
- Move completed assistant lines into terminal history before the response finishes, including Markdown blocks and wrapped text.
- Hold only the unfinished line mutable and publish it on newline or response completion.
- Pause activity animation after native history starts to avoid repeated live-screen updates.