### PR TITLE
Reduce session migration return constants

### DIFF
--- a/src/core/session/session_migration.zig
+++ b/src/core/session/session_migration.zig
@@ -104,6 +104,32 @@ pub fn migrateLegacyLocked(
     options: ResumeOptions,
     lifecycle: *?session_log.CommitLifecycle,
 ) !LoadedWritableSession {
+    var loaded: LoadedWritableSession = undefined;
+    try migrateLegacyLockedInto(
+        &loaded,
+        ctx,
+        alloc,
+        writable,
+        workspace_root,
+        preference_source,
+        options,
+        lifecycle,
+    );
+    return loaded;
+}
+
+// Keep fallible construction behind a noinline out-parameter boundary so
+// error returns do not materialize the full LoadedWritableSession payload.
+noinline fn migrateLegacyLockedInto(
+    out: *LoadedWritableSession,
+    ctx: StoreContext,
+    alloc: Allocator,
+    writable: *session_log.WritableSessionDir,
+    workspace_root: []const u8,
+    preference_source: MigrationPreferenceSource,
+    options: ResumeOptions,
+    lifecycle: *?session_log.CommitLifecycle,
+) !void {
     try assertMigratable(
         alloc,
         writable,
@@ -216,7 +242,7 @@ pub fn migrateLegacyLocked(
     lifecycle.* = null;
     writable.* = undefined;
     _ = result.publishCommitLifecycle(alloc);
-    return result;
+    out.* = result;
 }
 
 /// Asserts the session may be migrated: takes the commit lock, requires no

--- a/src/core/session/session_store.zig
+++ b/src/core/session/session_store.zig
@@ -3453,6 +3453,29 @@ pub const Store = struct {
         preference_source: MigrationPreferenceSource,
         options: ResumeOptions,
     ) !LoadedWritableSession {
+        var loaded: LoadedWritableSession = undefined;
+        try self.migrateLegacyForWriteInto(
+            &loaded,
+            alloc,
+            session_id,
+            workspace_root,
+            preference_source,
+            options,
+        );
+        return loaded;
+    }
+
+    // Keep cold fallible constructors behind noinline out-parameter boundaries
+    // so error returns do not materialize the full LoadedWritableSession payload.
+    noinline fn migrateLegacyForWriteInto(
+        self: Store,
+        out: *LoadedWritableSession,
+        alloc: Allocator,
+        session_id: []const u8,
+        workspace_root: []const u8,
+        preference_source: MigrationPreferenceSource,
+        options: ResumeOptions,
+    ) !void {
         if (self.canonical_root.mode != .writable or
             self.canonical_root.sessions == null)
         {
@@ -3494,7 +3517,7 @@ pub const Store = struct {
             .writer_lock = writer_lock,
             .session_id = owned_id,
         };
-        return self.migrateLegacyWithLatestCache(
+        const loaded = self.migrateLegacyWithLatestCache(
             alloc,
             &writable,
             workspace_root,
@@ -3504,6 +3527,7 @@ pub const Store = struct {
             writable.deinit(alloc);
             return err;
         };
+        out.* = loaded;
     }
 
     fn migrateLegacyWithLatestCache(
@@ -3539,6 +3563,27 @@ pub const Store = struct {
         preference_source: MigrationPreferenceSource,
         options: ResumeOptions,
     ) !LoadedWritableSession {
+        var loaded: LoadedWritableSession = undefined;
+        try self.resolveAuthorityTransitionForWriteInto(
+            &loaded,
+            alloc,
+            session_id,
+            workspace_root,
+            preference_source,
+            options,
+        );
+        return loaded;
+    }
+
+    noinline fn resolveAuthorityTransitionForWriteInto(
+        self: Store,
+        out: *LoadedWritableSession,
+        alloc: Allocator,
+        session_id: []const u8,
+        workspace_root: []const u8,
+        preference_source: MigrationPreferenceSource,
+        options: ResumeOptions,
+    ) !void {
         var read_dir = try self.openSessionDir(session_id);
         var transition = (try loadAuthorityTransitionOptional(
             alloc,
@@ -3553,11 +3598,13 @@ pub const Store = struct {
 
         if (transition.kind == .session_create) {
             var root = self.canonical_root;
-            return root.resumeForWrite(
+            const loaded = try root.resumeForWrite(
                 alloc,
                 session_id,
                 options.log,
             );
+            out.* = loaded;
+            return;
         }
 
         var writable = try self.openWritableSessionDir(
@@ -3635,7 +3682,8 @@ pub const Store = struct {
             errdefer loaded.deinit(alloc);
             try loaded.installCommitLifecycle(lifecycle);
             _ = loaded.publishCommitLifecycle(alloc);
-            return loaded;
+            out.* = loaded;
+            return;
         }
 
         try restoreLegacyAuthority(alloc, &writable, current);
@@ -3648,7 +3696,7 @@ pub const Store = struct {
             preference_source,
             options,
         );
-        return loaded;
+        out.* = loaded;
     }
 
     fn openWritableSessionDir(


### PR DESCRIPTION
## Summary

- Preserve legacy session migration and interrupted authority recovery behavior while reducing the native release binary.
- Keep session ownership, persisted state, and error behavior unchanged.