### PR TITLE
Show dollar skill suggestions inline

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -887,7 +887,7 @@ pub fn Runtime(comptime App: type) type {
                 return;
             }
             if (try routeUpgradeShortcut(app, byte)) return;
-            if (routePickerControlByte(app, byte)) return;
+            if (try routePickerControlByte(app, byte)) return;
 
             if (isComposerEditingByte(byte, raw.composer_shortcut) and
                 !activeCatalogMenuOwnsByte(app, byte) and
@@ -1127,10 +1127,10 @@ pub fn Runtime(comptime App: type) type {
             return .done;
         }
 
-        fn routePickerControlByte(app: *App, byte: u8) bool {
+        fn routePickerControlByte(app: *App, byte: u8) !bool {
             if (!composerPickerSurfaceVisible(app)) return false;
             const delta = pickerControlDelta(byte) orelse return false;
-            if (!routeVisiblePickerMove(app, delta)) return false;
+            if (!try routeVisiblePickerMove(app, delta)) return false;
             app.input_runtime.vertical_navigation.reset();
             app.shell.render_requests.request(.footer);
             return true;

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -183,6 +183,20 @@ fn buildQueuedCardProjection(comptime App: type, app: *App) !QueuedCardProjectio
         review_entries.len == 0) return .{};
     const draft_count = review_entries.len;
 
+    const measurement = try input_queue_runtime.measureVisibleReviewRows(
+        app.alloc,
+        &app.queued_prompt_review,
+        .{
+            .input = app.input_runtime.edit_state.input.items,
+            .cursor = app.input_runtime.edit_state.cursor,
+            .terminal_cols = app.shell.layout.cols,
+            .images = app.pending_images.items,
+            .pasted_blocks = app.input_runtime.entities.pasted_blocks.items,
+            .image_tokens = app.input_runtime.entities.image_tokens.items,
+            .skill_tokens = app.input_runtime.entities.skill_tokens.items,
+        },
+    );
+
     const cards = try app.alloc.alloc(render_input.QueuedPromptCard, draft_count);
     var built: usize = 0;
     errdefer {
@@ -190,36 +204,15 @@ fn buildQueuedCardProjection(comptime App: type, app: *App) !QueuedCardProjectio
         app.alloc.free(cards);
     }
 
-    const selected_turn_id: ?u64 = blk: {
-        const selected_index = app.queued_prompt_review.selected_index orelse break :blk null;
-        if (selected_index >= review_entries.len) break :blk null;
-        break :blk review_entries[selected_index].draft.turn_id;
-    };
-
-    var total_rows: u16 = 0;
-    var editor_active = false;
     while (built < draft_count) : (built += 1) {
         const draft = review_entries[built].draft;
-        const editing = selected_turn_id != null and draft.turn_id == selected_turn_id.?;
+        const editing = app.queued_prompt_review.selected_index != null and
+            app.queued_prompt_review.selected_index.? == built;
         if (editing) {
-            const source = input_visual_layout.Source{
-                .input = app.input_runtime.edit_state.input.items,
-                .cursor = app.input_runtime.edit_state.cursor,
-                .terminal_cols = app.shell.layout.cols,
-                .images = app.pending_images.items,
-                .pasted_blocks = app.input_runtime.entities.pasted_blocks.items,
-                .image_tokens = app.input_runtime.entities.image_tokens.items,
-                .skill_tokens = app.input_runtime.entities.skill_tokens.items,
-            };
-            const summary = input_visual_layout.summarize(source, null);
-            const row_count: u16 = @intCast(@min(summary.total_rows, std.math.maxInt(u16)));
             cards[built] = .{
                 .bytes = try app.alloc.dupe(u8, ""),
-                .row_count = @max(row_count, 1),
                 .editing = true,
             };
-            total_rows +|= cards[built].row_count;
-            editor_active = true;
             continue;
         }
 
@@ -253,15 +246,14 @@ fn buildQueuedCardProjection(comptime App: type, app: *App) !QueuedCardProjectio
                 .skill_tokens = skill_tokens,
             },
         );
-        const row_count: u16 = @intCast(@min(
-            std.mem.count(u8, bytes, "\n"),
-            std.math.maxInt(u16),
-        ));
-        cards[built] = .{ .bytes = bytes, .row_count = row_count };
-        total_rows +|= row_count;
+        cards[built] = .{ .bytes = bytes };
     }
 
-    return .{ .cards = cards, .row_count = total_rows, .editor_active = editor_active };
+    return .{
+        .cards = cards,
+        .row_count = measurement.card_rows,
+        .editor_active = measurement.editor_active,
+    };
 }
 
 noinline fn approvalScreenNeedsClear(
@@ -1536,7 +1528,7 @@ pub fn Runtime(comptime App: type) type {
                 if (modelMenuActive(app)) return .models_screen;
                 if (sessionMenuActive(app)) return .resume_screen;
                 if (helpMenuActive(app)) return .help_screen;
-                return .skills_screen;
+                if (skillsCatalogMenuActive(app)) return .skills_screen;
             }
 
             if (app.terminal.catalogMenuScreenActive()) {
@@ -2666,6 +2658,13 @@ pub fn Runtime(comptime App: type) type {
             return false;
         }
 
+        fn skillsCatalogMenuActive(app: *const App) bool {
+            if (comptime @hasField(App, "skills")) {
+                return app.skills.menu.active and !app.skills.menu.origin.isMention();
+            }
+            return false;
+        }
+
         fn modelMenuActive(app: *const App) bool {
             if (comptime @hasField(App, "model_cache")) return app.model_cache.menu.active;
             return false;
@@ -2689,7 +2688,7 @@ pub fn Runtime(comptime App: type) type {
         fn catalogMenuActive(app: *const App) bool {
             return settingsMenuActive(app) or
                 helpMenuActive(app) or
-                skillsMenuActive(app) or
+                skillsCatalogMenuActive(app) or
                 modelMenuActive(app) or
                 sessionMenuActive(app);
         }
@@ -4397,9 +4396,11 @@ test "core.app_render_runtime animation retry stays ahead of a newer fact" {
 
 const CoordinatorTestWorker = struct {
     submitted_permission: ?types.ToolPermissionDecision = null,
+    queued_count: usize = 0,
+    paused: bool = false,
 
-    fn queuePreview(_: *@This()) struct { count: usize = 0 } {
-        return .{};
+    pub fn queuePreview(self: *@This()) worker_runtime.QueuePreview {
+        return .{ .count = self.queued_count, .paused = self.paused };
     }
 
     pub fn submitPermissionResponse(
@@ -4483,6 +4484,7 @@ const CoordinatorTestApp = struct {
     shell: transcript_runtime.TranscriptRuntime,
     metrics: types.Metrics = .{},
     input_runtime: core_input_runtime.Runtime = .{},
+    queued_prompt_review: input_queue_runtime.State = .{},
     terminal_input_runtime: ui_input.Runtime = .{},
     approval_prompt: approval_prompt.ApprovalPrompt = .{},
     approval_screen: interaction_state.ApprovalScreenState = .{},
@@ -4516,6 +4518,7 @@ const CoordinatorTestApp = struct {
 
     fn deinit(self: *CoordinatorTestApp) void {
         self.shell.deinit(self.alloc);
+        self.queued_prompt_review.deinit(self.alloc);
         self.input_runtime.deinit(self.alloc);
         self.terminal_input_runtime.deinit(self.alloc);
         self.approval_prompt.deinit(self.alloc);
@@ -4531,7 +4534,7 @@ const CoordinatorTestApp = struct {
         return 0;
     }
 
-    fn fileCompletions(
+    pub fn fileCompletions(
         _: *CoordinatorTestApp,
         _: []const u8,
         _: []file_index.SearchResult,
@@ -4540,6 +4543,8 @@ const CoordinatorTestApp = struct {
     ) file_index.SearchError!usize {
         return 0;
     }
+
+    pub fn writeDomainNotice(_: *CoordinatorTestApp, _: types.SemanticNotice, _: bool) !void {}
 
     fn isModelCacheLoading(self: *CoordinatorTestApp) bool {
         return self.model_cache_loading;
@@ -4573,6 +4578,19 @@ const CoordinatorTestApp = struct {
         return false;
     }
 };
+
+fn makeCoordinatorReviewEntry(
+    alloc: std.mem.Allocator,
+    turn_id: u64,
+    text: []const u8,
+) !input_queue_runtime.ReviewEntry {
+    return .{ .draft = .{
+        .turn_id = turn_id,
+        .prompt = try alloc.dupe(u8, text),
+        .images = &.{},
+        .skill_display_spans = &.{},
+    } };
+}
 
 fn initCoordinatorProjectionTestApp(
     alloc: std.mem.Allocator,
@@ -5187,7 +5205,7 @@ test "core.app_render_runtime first requested startup frame commits through the 
     try std.testing.expectEqual(first_len, try file.length(io_mod.getIo()));
 }
 
-test "core.app_render_runtime active skills menu owns a transcript-free alternate screen" {
+test "core.app_render_runtime mention skills stay inline while command skills retain the catalog screen" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -5225,15 +5243,15 @@ test "core.app_render_runtime active skills menu owns a transcript-free alternat
     app.skills.openMenuWithQuery(.dollar, .{ .start = 0, .end = app.input_runtime.edit_state.input.items.len }, "pure");
     try app.shell.initBacking(alloc);
     try app.shell.enableShadowVt(alloc);
-    try app.shell.writeTranscript(alloc, &app.metrics, "transcript must stay behind the browser\n", true);
+    try app.shell.writeTranscript(alloc, &app.metrics, "transcript stays visible behind the picker\n", true);
 
     app.shell.render_requests.request(.footer);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
 
-    try std.testing.expect(app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "$pure"));
-    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Skills 1"));
-    try std.testing.expect(!(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript must stay behind")));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "pure-core"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript stays visible"));
 
     try std.testing.expect(try app.approval_prompt.syncRequest(alloc, .{
         .id = 42,
@@ -5250,7 +5268,7 @@ test "core.app_render_runtime active skills menu owns a transcript-free alternat
     app.approval_prompt.clear(alloc);
     app.shell.render_requests.request(.modal);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
-    try std.testing.expect(app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Skills 1"));
 
     const options = [_]types.QuestionOption{
@@ -5269,14 +5287,14 @@ test "core.app_render_runtime active skills menu owns a transcript-free alternat
     app.question_prompt.discard(alloc, "test_cleanup");
     app.shell.render_requests.request(.modal);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
-    try std.testing.expect(app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Skills 1"));
 
     try app.shell.writeTranscript(alloc, &app.metrics, "background transcript update\n", true);
     app.shell.render_requests.request(.transcript);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
-    try std.testing.expect(app.terminal.catalogMenuScreenActive());
-    try std.testing.expect(!(try coordinatorGridContains(app.shell.shadow_vt.?.*, "background transcript update")));
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "background transcript update"));
 
     app.shell.layout = .{
         .rows = 10,
@@ -5290,24 +5308,109 @@ test "core.app_render_runtime active skills menu owns a transcript-free alternat
     app.shell.render_requests.request(.resize);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
 
-    try std.testing.expect(app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
     try std.testing.expectEqual(@as(u16, 48), app.shell.shadow_vt.?.cols);
     try std.testing.expectEqual(@as(u16, 10), app.shell.shadow_vt.?.rows);
-    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Skills 1"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "pure-core"));
 
     app.skills.closeMenu();
     app.shell.render_requests.request(.footer);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
 
     try std.testing.expect(!app.terminal.catalogMenuScreenActive());
-    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript must stay behind"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript stays visible"));
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "background transcript update"));
+
+    app.skills.openMenu();
+    app.shell.render_requests.request(.footer);
+    try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+    try std.testing.expect(app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(!(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript stays visible")));
+
+    app.skills.closeMenu();
+    app.shell.render_requests.request(.footer);
+    try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
 
     var read_offset: u64 = 0;
     const terminal_bytes = try readCoordinatorFrameBytes(alloc, file, &read_offset);
     defer alloc.free(terminal_bytes);
-    try std.testing.expectEqual(@as(usize, 3), std.mem.count(u8, terminal_bytes, "\x1b[?1049h"));
-    try std.testing.expectEqual(@as(usize, 3), std.mem.count(u8, terminal_bytes, "\x1b[?1049l"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, terminal_bytes, "\x1b[?1049h"));
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, terminal_bytes, "\x1b[?1049l"));
+}
+
+test "core.app_render_runtime width-changed queued editor keeps mention navigation and render aligned" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile(std.testing.io, "skills-queue-width.log", .{ .read = true });
+    defer file.close(io_mod.getIo());
+
+    const skills = [_]skill_runtime.Skill{
+        .{ .name = "one", .description = "", .path = "/tmp/one", .source = .global_fx },
+        .{ .name = "two", .description = "", .path = "/tmp/two", .source = .global_fx },
+        .{ .name = "three", .description = "", .path = "/tmp/three", .source = .global_fx },
+        .{ .name = "four", .description = "", .path = "/tmp/four", .source = .global_fx },
+        .{ .name = "five", .description = "", .path = "/tmp/five", .source = .global_fx },
+        .{ .name = "six", .description = "", .path = "/tmp/six", .source = .global_fx },
+        .{ .name = "seven", .description = "", .path = "/tmp/seven", .source = .global_fx },
+    };
+    var app = CoordinatorTestApp{
+        .alloc = alloc,
+        .shell = .{
+            .stdout_file = file,
+            .layout = .{
+                .rows = 24,
+                .cols = 40,
+                .content_bottom = 20,
+                .divider_top_row = 21,
+                .input_row = 22,
+                .divider_bottom_row = 23,
+                .hint_row = 24,
+            },
+            .owned_top_row = 1,
+            .viewport_top_row = 1,
+        },
+    };
+    defer app.deinit();
+    try app.selected_model.appendSlice(alloc, "test-model");
+    app.skills.items = @constCast(&skills);
+    app.skills.openMenuWithQuery(.dollar, .{ .start = 0, .end = 1 }, "");
+    try app.input_runtime.textReplacementState().replace(alloc, "$" ++ "x" ** 59);
+
+    const entries = try alloc.alloc(input_queue_runtime.ReviewEntry, 2);
+    entries[0] = try makeCoordinatorReviewEntry(alloc, 1, "stored");
+    entries[1] = try makeCoordinatorReviewEntry(alloc, 2, "selected");
+    app.queued_prompt_review = .{
+        .entries = entries,
+        .selected_index = 1,
+        .reason = .manual,
+        .visible = true,
+    };
+    app.worker.queued_count = 2;
+
+    try app.shell.initBacking(alloc);
+    try app.shell.enableShadowVt(alloc);
+    try app.shell.writeTranscript(alloc, &app.metrics, "queue width transcript\n", true);
+    app.shell.render_requests.request(.footer);
+    try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+
+    app.shell.layout.cols = 12;
+    const completion = input_completion_runtime.CompletionRuntime(CoordinatorTestApp);
+    try completion.routeModifiedHistory(&app, .down, 1);
+    try completion.routeModifiedHistory(&app, .down, 1);
+    try completion.routeModifiedHistory(&app, .down, 1);
+    try std.testing.expectEqual(@as(usize, 3), app.skills.menu.selected_index);
+    try std.testing.expectEqual(@as(usize, 1), app.skills.menu.window_start);
+
+    app.shell.render_requests.request(.resize);
+    try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
+
+    try std.testing.expectEqual(@as(u16, 12), app.shell.shadow_vt.?.cols);
+    try std.testing.expectEqual(@as(usize, 3), app.skills.menu.selected_index);
+    try std.testing.expectEqual(@as(usize, 1), app.skills.menu.window_start);
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "four"));
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
 }
 
 test "core.app_render_runtime active setup hub stays on the inline transcript surface" {
@@ -5423,7 +5526,7 @@ test "core.app_render_runtime model catalog survives modal preemption and restor
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "model catalog transcript stays behind"));
 }
 
-test "core.app_render_runtime file approval returns to the preserved skills catalog" {
+test "core.app_render_runtime file approval returns to the preserved inline skills menu" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -5482,11 +5585,11 @@ test "core.app_render_runtime file approval returns to the preserved skills cata
     app.skills.openMenuWithQuery(.dollar, .{ .start = 0, .end = app.input_runtime.edit_state.input.items.len }, "pure");
     try app.shell.initBacking(alloc);
     try app.shell.enableShadowVt(alloc);
-    try app.shell.writeTranscript(alloc, &app.metrics, "transcript behind catalog\n", true);
+    try app.shell.writeTranscript(alloc, &app.metrics, "transcript behind inline skills\n", true);
 
     app.shell.render_requests.request(.footer);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
-    try std.testing.expect(app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
 
     try std.testing.expect(try app.approval_prompt.syncRequest(alloc, request));
     try std.testing.expect(app.approval_prompt.syncReview(&review));
@@ -5503,16 +5606,17 @@ test "core.app_render_runtime file approval returns to the preserved skills cata
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
 
-    try std.testing.expect(app.terminal.catalogMenuScreenActive());
+    try std.testing.expectEqual(shell_runtime.AlternateScreenOwner.none, app.terminal.alternate_screen_owner);
     try std.testing.expectEqualStrings("$pure", app.input_runtime.edit_state.input.items);
     try std.testing.expectEqualStrings("pure", app.skills.menu.query());
     try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "Skills 1"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript behind inline skills"));
 
     app.skills.closeMenu();
     app.shell.render_requests.request(.footer);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
     try std.testing.expectEqual(shell_runtime.AlternateScreenOwner.none, app.terminal.alternate_screen_owner);
-    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript behind catalog"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript behind inline skills"));
 }
 
 test "core.app_render_runtime file approvals commit the alternate screen for each request" {

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -31,6 +31,8 @@ const model_menu_presentation = @import("../../ui/footer/model_menu_presentation
 const resume_menu_presentation = @import("../../ui/footer/resume_menu_presentation.zig");
 const help_menu_presentation = @import("../../ui/footer/help_menu_presentation.zig");
 const settings_menu_presentation = @import("../../ui/footer/settings_menu_presentation.zig");
+const surface_frame = @import("../../ui/footer/surface_frame.zig");
+const footer_paint_plan = @import("../../ui/footer/paint_plan.zig");
 const catalog_screen_layout = @import("../../ui/catalog_screen_layout.zig");
 
 const ModelPickerStage = picker_state.ModelPickerStage;
@@ -170,7 +172,7 @@ pub fn CompletionRuntime(comptime App: type) type {
 
         pub fn routeModifiedHistory(app: *App, direction: visual_layout.Direction, delta: i32) !void {
             app.input_runtime.vertical_navigation.reset();
-            if (routeNonSlashPickerMove(app, delta)) {
+            if (try routeNonSlashPickerMove(app, delta)) {
                 return;
             } else if (!routeSlashCompletionMove(app, delta)) {
                 if (app.input_runtime.composer_history.activeIndex() != null) {
@@ -216,7 +218,7 @@ pub fn CompletionRuntime(comptime App: type) type {
                 delta * @as(i32, @intCast(@min(row_count, std.math.maxInt(i32))))
             else
                 delta;
-            if (routeNonSlashPickerMove(app, picker_delta)) {
+            if (try routeNonSlashPickerMove(app, picker_delta)) {
                 app.input_runtime.vertical_navigation.reset();
                 return;
             }
@@ -357,17 +359,17 @@ pub fn CompletionRuntime(comptime App: type) type {
             }
         }
 
-        pub fn routeVisiblePickerMove(app: *App, delta: i32) bool {
-            if (routeNonSlashPickerMove(app, delta)) return true;
+        pub fn routeVisiblePickerMove(app: *App, delta: i32) !bool {
+            if (try routeNonSlashPickerMove(app, delta)) return true;
             return routeSlashCompletionMove(app, delta);
         }
 
-        fn routeNonSlashPickerMove(app: *App, delta: i32) bool {
+        fn routeNonSlashPickerMove(app: *App, delta: i32) !bool {
             if (routeSettingsMenuMove(app, delta)) return true;
             if (routeHelpMenuMove(app, delta)) return true;
             if (routeModelMenuMove(app, delta)) return true;
             if (routeAuthPickerMove(app, delta)) return true;
-            if (routeSkillsMenuMove(app, delta)) return true;
+            if (try routeSkillsMenuMove(app, delta)) return true;
             if (comptime runtime_profile.allows(App, .durable_sessions)) {
                 if (routeSessionPickerMove(app, delta)) return true;
             }
@@ -489,12 +491,24 @@ pub fn CompletionRuntime(comptime App: type) type {
             return app.auth.movePicker(delta);
         }
 
-        fn routeSkillsMenuMove(app: *App, delta: i32) bool {
+        fn routeSkillsMenuMove(app: *App, delta: i32) !bool {
             if (comptime !@hasField(App, "skills")) return false;
-            return app.skills.moveMenuSelectionVisibleRows(delta, skillsMenuVisibleRows(app));
+            return app.skills.moveMenuSelectionVisibleRows(delta, try skillsMenuVisibleRows(app));
         }
 
-        fn skillsMenuVisibleRows(app: *App) u16 {
+        fn skillsMenuVisibleRows(app: *App) !u16 {
+            const projection = render_input.skillsMenuProjection(&app.skills);
+            if (app.skills.menu.origin.isMention()) {
+                const budget = try footerRowBudget(app);
+                return skills_menu_presentation.inlineVisibleNavigationRowsForBudget(
+                    projection,
+                    picker_presentation.inlinePickerRowBudget(
+                        app.shell.layout.rows,
+                        budget.input_extra,
+                        budget.banner_rows,
+                    ),
+                );
+            }
             const scan = ui_input.scanInputCursorVertical(
                 &app.input_runtime,
                 .down,
@@ -507,7 +521,7 @@ pub fn CompletionRuntime(comptime App: type) type {
                 scan.cursor_row,
             );
             return skills_menu_presentation.visibleNavigationRowsForBudget(
-                render_input.skillsMenuProjection(&app.skills),
+                projection,
                 layout.menu_row_budget,
             );
         }
@@ -517,7 +531,7 @@ pub fn CompletionRuntime(comptime App: type) type {
             banner_rows: u16,
         };
 
-        fn footerRowBudget(app: *App) FooterRowBudget {
+        fn footerRowBudget(app: *App) !FooterRowBudget {
             const scan = ui_input.scanInputCursorVertical(
                 &app.input_runtime,
                 .down,
@@ -529,9 +543,45 @@ pub fn CompletionRuntime(comptime App: type) type {
                 app.shell.layout.content_bottom,
                 true,
             );
+            if (comptime !@hasField(App, "queued_prompt_review")) {
+                return .{ .input_extra = capped.input_extra, .banner_rows = 0 };
+            }
+
+            const measurement = try input_queue_runtime.measureVisibleReviewRows(
+                app.alloc,
+                &app.queued_prompt_review,
+                .{
+                    .input = app.input_runtime.edit_state.input.items,
+                    .cursor = app.input_runtime.edit_state.cursor,
+                    .terminal_cols = app.shell.layout.cols,
+                    .images = app.pending_images.items,
+                    .pasted_blocks = app.input_runtime.entities.pasted_blocks.items,
+                    .image_tokens = app.input_runtime.entities.image_tokens.items,
+                    .skill_tokens = app.input_runtime.entities.skill_tokens.items,
+                },
+            );
+            const preview = app.worker.queuePreview();
+            const card_count = if (measurement.card_rows > 0)
+                app.queued_prompt_review.entries.len
+            else
+                0;
+            const queued_count = if (card_count > 0) card_count else preview.count;
+            const input_extra: u16 = if (measurement.editor_active) 0 else capped.input_extra;
+            const requested_banner_rows = render_input.queuedBannerRowsForFacts(.{
+                .queued_count = queued_count,
+                .paused = preview.paused,
+                .card_count = card_count,
+                .card_rows = measurement.card_rows,
+            });
             return .{
-                .input_extra = capped.input_extra,
-                .banner_rows = if (app.worker.queuedPromptCount() > 0) 1 else 0,
+                .input_extra = input_extra,
+                .banner_rows = surface_frame.clampQueuedBannerRows(
+                    requested_banner_rows,
+                    app.shell.layout.rows,
+                    true,
+                    footer_paint_plan.composerTopChromeRows(),
+                    input_extra,
+                ),
             };
         }
 
@@ -1426,6 +1476,51 @@ const InlineCompletionTestApp = struct {
     }
 };
 
+const SkillsNavigationTestWorker = struct {
+    fn queuePreview(_: *SkillsNavigationTestWorker) @import("../agent/worker_runtime.zig").QueuePreview {
+        return .{ .count = 2 };
+    }
+};
+
+const SkillsNavigationTestApp = struct {
+    alloc: std.mem.Allocator,
+    input_runtime: core_input_runtime.Runtime = .{},
+    pending_images: std.ArrayList(types.ImageAttachment) = .empty,
+    queued_prompt_review: input_queue_runtime.State = .{},
+    worker: SkillsNavigationTestWorker = .{},
+    skills: skill_runtime.Runtime = .{},
+    shell: struct {
+        layout: types.Layout = .{
+            .rows = 24,
+            .cols = 40,
+            .content_bottom = 20,
+            .divider_top_row = 21,
+            .input_row = 22,
+            .divider_bottom_row = 23,
+            .hint_row = 24,
+        },
+    } = .{},
+
+    fn deinit(self: *SkillsNavigationTestApp) void {
+        self.queued_prompt_review.deinit(self.alloc);
+        self.input_runtime.deinit(self.alloc);
+        self.pending_images.deinit(self.alloc);
+    }
+};
+
+fn makeSkillsNavigationReviewEntry(
+    alloc: std.mem.Allocator,
+    turn_id: u64,
+    text: []const u8,
+) !input_queue_runtime.ReviewEntry {
+    return .{ .draft = .{
+        .turn_id = turn_id,
+        .prompt = try alloc.dupe(u8, text),
+        .images = &.{},
+        .skill_display_spans = &.{},
+    } };
+}
+
 const ModelPickerCompletionTestApp = struct {
     alloc: std.mem.Allocator,
     input_runtime: core_input_runtime.Runtime = .{},
@@ -1465,6 +1560,43 @@ test "model picker effort completion labels survive capability resolution" {
     try std.testing.expectEqualStrings("default", values[0].displayLabel());
     try std.testing.expectEqualStrings("future-tier", values[1].displayLabel());
     try std.testing.expectEqualStrings("high", values[2].displayLabel());
+}
+
+test "mention skills navigation measures a width-changed queued editor before frame commit" {
+    const alloc = std.testing.allocator;
+    const rt = CompletionRuntime(SkillsNavigationTestApp);
+    const skills = [_]skill_runtime.Skill{
+        .{ .name = "one", .description = "", .path = "/tmp/one", .source = .global_fx },
+        .{ .name = "two", .description = "", .path = "/tmp/two", .source = .global_fx },
+        .{ .name = "three", .description = "", .path = "/tmp/three", .source = .global_fx },
+        .{ .name = "four", .description = "", .path = "/tmp/four", .source = .global_fx },
+        .{ .name = "five", .description = "", .path = "/tmp/five", .source = .global_fx },
+        .{ .name = "six", .description = "", .path = "/tmp/six", .source = .global_fx },
+        .{ .name = "seven", .description = "", .path = "/tmp/seven", .source = .global_fx },
+    };
+    var app = SkillsNavigationTestApp{ .alloc = alloc };
+    defer app.deinit();
+    app.skills.items = @constCast(&skills);
+    app.skills.openMenuWithQuery(.dollar, .{ .start = 0, .end = 1 }, "");
+    try app.input_runtime.textReplacementState().replace(alloc, "x" ** 60);
+
+    const entries = try alloc.alloc(input_queue_runtime.ReviewEntry, 2);
+    entries[0] = try makeSkillsNavigationReviewEntry(alloc, 1, "stored");
+    entries[1] = try makeSkillsNavigationReviewEntry(alloc, 2, "selected");
+    app.queued_prompt_review = .{
+        .entries = entries,
+        .selected_index = 1,
+        .reason = .manual,
+        .visible = true,
+    };
+
+    app.shell.layout.cols = 12;
+    try std.testing.expect(try rt.routeSkillsMenuMove(&app, 1));
+    try std.testing.expect(try rt.routeSkillsMenuMove(&app, 1));
+    try std.testing.expect(try rt.routeSkillsMenuMove(&app, 1));
+
+    try std.testing.expectEqual(@as(usize, 3), app.skills.menu.selected_index);
+    try std.testing.expectEqual(@as(usize, 1), app.skills.menu.window_start);
 }
 
 test "inline slash completion uses the shared visible suffix and acceptance path" {

--- a/src/core/app/input_queue_runtime.zig
+++ b/src/core/app/input_queue_runtime.zig
@@ -46,6 +46,57 @@ pub const State = struct {
     }
 };
 
+pub const VisibleReviewMeasurement = struct {
+    card_rows: u16 = 0,
+    editor_active: bool = false,
+};
+
+pub fn measureVisibleReviewRows(
+    alloc: std.mem.Allocator,
+    state: *const State,
+    editor_source: visual_layout.Source,
+) !VisibleReviewMeasurement {
+    if (!state.visible or !state.active() or state.entries.len == 0) return .{};
+
+    var result: VisibleReviewMeasurement = .{};
+    for (state.entries, 0..) |entry, entry_index| {
+        const editing = state.selected_index != null and state.selected_index.? == entry_index;
+        const row_count: u16 = if (editing) blk: {
+            result.editor_active = true;
+            const summary = visual_layout.summarize(editor_source, null);
+            break :blk @intCast(@min(@max(summary.total_rows, 1), std.math.maxInt(u16)));
+        } else blk: {
+            const draft = entry.draft;
+            const display_spans = draft.reviewSkillDisplaySpans();
+            var skill_tokens: std.ArrayList(registered_entities.SkillTokenSpan) = .empty;
+            defer skill_tokens.deinit(alloc);
+            try skill_tokens.ensureTotalCapacity(alloc, display_spans.len);
+            for (display_spans) |span| {
+                skill_tokens.appendAssumeCapacity(.{
+                    .raw_start = span.raw_start,
+                    .raw_end = span.raw_end,
+                    .name = span.name,
+                    .path = span.path,
+                    .display_source = span.display_source,
+                    .owns_trailing_separator = span.owns_trailing_separator,
+                });
+            }
+            const summary = visual_layout.summarize(.{
+                .input = draft.reviewInput(),
+                .cursor = 0,
+                .terminal_cols = editor_source.terminal_cols,
+                .images = draft.images,
+                .pasted_blocks = entry.pasted_blocks.items,
+                .image_tokens = entry.image_tokens.items,
+                .skill_tokens = skill_tokens.items,
+            }, null);
+            break :blk @intCast(@min(@max(summary.total_rows, 1), std.math.maxInt(u16)));
+        };
+        result.card_rows +|= row_count;
+    }
+    return result;
+}
+
 pub const PromptAdmission = enum {
     enqueue,
     replaced,
@@ -893,6 +944,159 @@ test "queued prompt review navigates newest to oldest and stays paused when hidd
     const worker_drafts = try app.worker.snapshotQueuedPromptDrafts(alloc);
     defer worker_runtime.freeQueuedPromptDrafts(alloc, worker_drafts);
     try std.testing.expectEqualStrings("second queued", worker_drafts[1].prompt);
+}
+
+test "visible queue review measurement aggregates stored cards and the live editor" {
+    const alloc = std.testing.allocator;
+    var app = ReviewTestApp{ .alloc = alloc };
+    defer app.deinit();
+    try app.worker.enqueuePrompt(alloc, try makeReviewTestPrompt(alloc, "first\nsecond"));
+    try app.worker.enqueuePrompt(alloc, try makeReviewTestPrompt(alloc, "selected"));
+
+    const rt = Runtime(ReviewTestApp);
+    try std.testing.expect(try rt.routeVertical(&app, .up));
+    try app.input_runtime.textReplacementState().replace(alloc, "selected\nthird\nfourth");
+    app.input_runtime.edit_state.cursor = app.input_runtime.edit_state.input.items.len;
+
+    const measured = try measureVisibleReviewRows(
+        alloc,
+        &app.queued_prompt_review,
+        .{
+            .input = app.input_runtime.edit_state.input.items,
+            .cursor = app.input_runtime.edit_state.cursor,
+            .terminal_cols = 80,
+            .images = app.pending_images.items,
+            .pasted_blocks = app.input_runtime.entities.pasted_blocks.items,
+            .image_tokens = app.input_runtime.entities.image_tokens.items,
+            .skill_tokens = app.input_runtime.entities.skill_tokens.items,
+        },
+    );
+
+    try std.testing.expectEqual(@as(u16, 5), measured.card_rows);
+    try std.testing.expect(measured.editor_active);
+}
+
+test "visible queue review aggregate matches composed entity-aware rows" {
+    const alloc = std.testing.allocator;
+    const queue_input_presentation = @import("../../ui/footer/input_presentation.zig");
+    const stored = "$skill [Image #1] [Pasted text #2, 2 lines] 界界界";
+    const image_label = "[Image #1]";
+    const paste_label = "[Pasted text #2, 2 lines]";
+    const image_start = std.mem.find(u8, stored, image_label).?;
+    const paste_start = std.mem.find(u8, stored, paste_label).?;
+    var images = [_]types.ImageAttachment{.{
+        .id = 1,
+        .path = @constCast("/tmp/one.png"),
+        .media_type = @constCast("image/png"),
+    }};
+    var display_spans = [_]worker_runtime.SkillDisplaySpan{.{
+        .raw_start = 0,
+        .raw_end = "$skill".len,
+        .name = @constCast("skill"),
+        .path = @constCast("/tmp/skill/SKILL.md"),
+        .display_source = .global_fx,
+    }};
+    var pasted = [_]paste_blocks.PastedBlock{.{
+        .id = 2,
+        .text = @constCast("pasted first\npasted second"),
+        .line_count = 2,
+        .span = .{ .raw_start = paste_start, .raw_end = paste_start + paste_label.len },
+    }};
+    var image_tokens = [_]entity_spans.ImageTokenSpan{.{
+        .id = 1,
+        .span = .{ .raw_start = image_start, .raw_end = image_start + image_label.len },
+    }};
+    var entries = [_]ReviewEntry{
+        .{
+            .draft = .{
+                .turn_id = 1,
+                .prompt = @constCast(stored),
+                .images = &images,
+                .skill_display_spans = &display_spans,
+            },
+            .pasted_blocks = .{ .items = &pasted, .capacity = pasted.len },
+            .image_tokens = .{ .items = &image_tokens, .capacity = image_tokens.len },
+        },
+        .{ .draft = .{
+            .turn_id = 2,
+            .prompt = @constCast("selected"),
+            .images = &.{},
+            .skill_display_spans = &.{},
+        } },
+    };
+    const state = State{
+        .entries = &entries,
+        .selected_index = 1,
+        .reason = .manual,
+        .visible = true,
+    };
+    const live_input = "live 界 editor wraps here";
+    const live_source = visual_layout.Source{
+        .input = live_input,
+        .cursor = live_input.len,
+        .terminal_cols = 18,
+    };
+
+    const measured = try measureVisibleReviewRows(alloc, &state, live_source);
+    var stored_skill_tokens = [_]registered_entities.SkillTokenSpan{.{
+        .raw_start = 0,
+        .raw_end = "$skill".len,
+        .name = "skill",
+        .path = "/tmp/skill/SKILL.md",
+        .display_source = .global_fx,
+    }};
+    const stored_card = try queue_input_presentation.composeQueuedPromptCard(alloc, .{
+        .input = stored,
+        .cursor = 0,
+        .terminal_cols = 18,
+        .images = &images,
+        .pasted_blocks = &pasted,
+        .image_tokens = &image_tokens,
+        .skill_tokens = &stored_skill_tokens,
+    });
+    defer alloc.free(stored_card);
+    const live_card = try queue_input_presentation.composeQueuedPromptCard(alloc, live_source);
+    defer alloc.free(live_card);
+    const expected_rows: u16 = @intCast(
+        std.mem.count(u8, stored_card, "\n") + std.mem.count(u8, live_card, "\n"),
+    );
+
+    try std.testing.expectEqual(expected_rows, measured.card_rows);
+    try std.testing.expect(measured.editor_active);
+}
+
+fn measureVisibleReviewRowsWithSkillScratch(alloc: std.mem.Allocator) !void {
+    var display_spans = [_]worker_runtime.SkillDisplaySpan{.{
+        .raw_start = 0,
+        .raw_end = "$skill".len,
+        .name = @constCast("skill"),
+        .path = @constCast("/tmp/skill/SKILL.md"),
+    }};
+    var entries = [_]ReviewEntry{.{ .draft = .{
+        .turn_id = 1,
+        .prompt = @constCast("$skill"),
+        .images = &.{},
+        .skill_display_spans = &display_spans,
+    } }};
+    const state = State{
+        .entries = &entries,
+        .reason = .manual,
+        .visible = true,
+    };
+    const measured = try measureVisibleReviewRows(alloc, &state, .{
+        .input = "",
+        .cursor = 0,
+        .terminal_cols = 20,
+    });
+    try std.testing.expectEqual(@as(u16, 1), measured.card_rows);
+}
+
+test "visible queue review measurement cleans scratch on allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        measureVisibleReviewRowsWithSkillScratch,
+        .{},
+    );
 }
 
 test "queued prompt review restores compact paste and commits expanded execution" {

--- a/src/core/skills/skill_runtime.zig
+++ b/src/core/skills/skill_runtime.zig
@@ -260,7 +260,21 @@ pub const SkillMenuOrigin = enum {
     dollar,
     slash,
     paste,
+
+    pub fn isMention(self: SkillMenuOrigin) bool {
+        return switch (self) {
+            .dollar, .paste => true,
+            .command, .slash => false,
+        };
+    }
 };
+
+test "skill menu origins classify mention surfaces exhaustively" {
+    try std.testing.expect(SkillMenuOrigin.dollar.isMention());
+    try std.testing.expect(SkillMenuOrigin.paste.isMention());
+    try std.testing.expect(!SkillMenuOrigin.command.isMention());
+    try std.testing.expect(!SkillMenuOrigin.slash.isMention());
+}
 
 pub const SkillMenuTarget = struct {
     start: usize = 0,
@@ -967,7 +981,7 @@ pub fn skillSourceShortLabel(source: SkillSource) []const u8 {
 pub fn skillMenuFilterLabel(filter: SkillMenuSourceFilter) []const u8 {
     return switch (filter) {
         .all => "All",
-        .fx => "Fx",
+        .fx => "fx",
         .workspace => "Workspace",
         .opencode => "OpenCode",
         .codex => "Codex",
@@ -992,6 +1006,10 @@ pub fn skillMenuFilterForSource(source: SkillSource) SkillMenuSourceFilter {
 
 pub fn skillSourceMatchesFilter(source: SkillSource, filter: SkillMenuSourceFilter) bool {
     return filter == .all or skillMenuFilterForSource(source) == filter;
+}
+
+pub fn skill_matches_menu_query(skill: Skill, query: []const u8) bool {
+    return skillMatchRank(skill, query) != null;
 }
 
 pub fn skillDisplaySource(skills: []const Skill, selected: Skill) ?SkillSource {

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -26,7 +26,7 @@ pub const composeDividerRow = row_text.composeDividerRow;
 pub const appendClipped = row_text.appendClipped;
 pub const appendAbsoluteColumn = row_text.appendAbsoluteColumn;
 
-pub const PickerKind = enum { model_stage, file, slash, auth };
+pub const PickerKind = enum { model_stage, file, slash, skills, auth };
 pub const CappedInputRows = struct {
     row_limit: usize,
     total_lines: u16,

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -19,6 +19,7 @@ const compact_command_menu_presentation = @import("compact_command_menu_presenta
 const input_presentation = @import("input_presentation.zig");
 const interaction_state = @import("interaction_state.zig");
 const picker_presentation = @import("picker_presentation.zig");
+const skills_menu_presentation = @import("skills_menu_presentation.zig");
 const question_ui = @import("question_ui.zig");
 const render_input = @import("render_input.zig");
 const row_text = @import("row_text.zig");
@@ -822,6 +823,29 @@ pub fn composeFooterFrame(
                 );
                 try pushFooterBandRow(alloc, &frame, plan, rows.picker_start + menu_row_index, &menu_row);
             }
+        } else if (input.picker_kind == .skills and ctx.skills_menu.active) {
+            var prepared = try skills_menu_presentation.prepareInlineSkillsMenu(
+                alloc,
+                ctx.skills_menu,
+                input.picker_rows,
+            );
+            defer prepared.deinit(alloc);
+            var menu_row_index: u16 = 0;
+            while (menu_row_index < prepared.rowCount()) : (menu_row_index += 1) {
+                var menu_row = try skills_menu_presentation.composeSkillsMenuRow(
+                    alloc,
+                    prepared,
+                    menu_row_index,
+                    shell.layout.cols,
+                );
+                try pushFooterBandRow(
+                    alloc,
+                    &frame,
+                    plan,
+                    rows.picker_start + menu_row_index,
+                    &menu_row,
+                );
+            }
         } else if (input.picker_kind == .auth and ctx.auth_picker.active) {
             var auth_row_index: u16 = 0;
             while (auth_row_index < input.picker_rows) : (auth_row_index += 1) {
@@ -945,6 +969,8 @@ pub fn composeFooterFrame(
             ),
             else => try input_presentation.composeCompactCommandMenuHintRow(alloc, shell.layout.cols, menu),
         }
+    else if (input.show_picker and input.picker_kind == .skills)
+        try input_presentation.composeSkillsMenuHintRow(alloc, shell.layout.cols, ctx.ctrl_c_pending)
     else if (input.show_picker and input.picker_kind == .slash and input.slash_menu_layout != null)
         try input_presentation.composeSlashMenuHintRow(alloc, shell.layout.cols)
     else blk: {
@@ -1540,8 +1566,8 @@ test "queued prompt cards stack above the composer with a paused hint" {
     const second = try user_message_card.buildUserPromptCard(alloc, "second queued\ncontinued", &.{}, shell.layout.cols);
     defer alloc.free(second);
     const cards = [_]render_input.QueuedPromptCard{
-        .{ .bytes = first, .row_count = 1 },
-        .{ .bytes = second, .row_count = 2 },
+        .{ .bytes = first },
+        .{ .bytes = second },
     };
 
     var ctx = testContext(&input);
@@ -1606,8 +1632,8 @@ test "queued editor paints and owns the cursor on its original card row" {
     const editing_bytes = try alloc.dupe(u8, "");
     defer alloc.free(editing_bytes);
     const cards = [_]render_input.QueuedPromptCard{
-        .{ .bytes = first, .row_count = 1 },
-        .{ .bytes = editing_bytes, .row_count = 1, .editing = true },
+        .{ .bytes = first },
+        .{ .bytes = editing_bytes, .editing = true },
     };
 
     var ctx = testContext(&input);
@@ -1678,7 +1704,7 @@ test "queued editor follows the cursor when its draft exceeds the card budget" {
     const editing_bytes = try alloc.dupe(u8, "");
     defer alloc.free(editing_bytes);
     const cards = [_]render_input.QueuedPromptCard{
-        .{ .bytes = editing_bytes, .row_count = 1, .editing = true },
+        .{ .bytes = editing_bytes, .editing = true },
     };
 
     var ctx = testContext(&input);

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -597,10 +597,7 @@ pub fn slashMenuLayout(
     const result_count = mixedSlashCompletionCount(registry, prefix, skills);
     if (result_count == 0) return null;
 
-    const fixed_rows: u16 = 5 +| input_extra +| banner_rows;
-    const minimum_transcript_rows: u16 = 5;
-    const available_picker_rows = (terminal_rows -| fixed_rows) -| minimum_transcript_rows;
-    const row_budget = @min(input_presentation.max_model_picker_rows + 2, @max(available_picker_rows, 1));
+    const row_budget = inlinePickerRowBudget(terminal_rows, input_extra, banner_rows);
     const show_header = row_budget > 2;
     const header_rows: u16 = if (show_header) 2 else 0;
     const selectable_rows = row_budget - header_rows;
@@ -617,6 +614,13 @@ pub fn slashMenuLayout(
         .result_count = result_count,
         .window = window,
     };
+}
+
+pub fn inlinePickerRowBudget(terminal_rows: u16, input_extra: u16, banner_rows: u16) u16 {
+    const fixed_rows: u16 = 5 +| input_extra +| banner_rows;
+    const minimum_transcript_rows: u16 = 5;
+    const available_picker_rows = (terminal_rows -| fixed_rows) -| minimum_transcript_rows;
+    return @min(input_presentation.max_model_picker_rows + 2, @max(available_picker_rows, 1));
 }
 
 pub noinline fn composePickerOptionRow(
@@ -637,7 +641,7 @@ pub noinline fn composePickerOptionRow(
     // pickers keep the filled row.
     const selected_style = switch (kind) {
         .model_stage => ui_render.selected_completion_style,
-        .file, .slash, .auth => ui_render.approval_button_inactive_style,
+        .file, .slash, .skills, .auth => ui_render.approval_button_inactive_style,
     };
     try row.appendSlice(alloc, if (selected) selected_style else ui_render.dim_style);
 
@@ -706,6 +710,7 @@ pub fn composePickerStatusRow(
         else
             "no matching files",
         .slash => "no matching slash commands",
+        .skills => "no matching skills",
         .auth => "authentication actions unavailable",
     };
 
@@ -1223,6 +1228,13 @@ test "slash menu layout keeps six selectable rows below its header" {
     const scrolled = slashMenuLayout(picker_test_slash_registry, "/", &.{}, 6, 0, 24, 0, 0).?;
     try std.testing.expectEqual(@as(usize, 1), scrolled.window.start);
     try std.testing.expectEqual(@as(usize, 7), scrolled.window.end);
+}
+
+test "inline picker row budget preserves six roomy choices and shrinks with height" {
+    try std.testing.expectEqual(@as(u16, 8), inlinePickerRowBudget(24, 0, 0));
+    try std.testing.expectEqual(@as(u16, 6), inlinePickerRowBudget(16, 0, 0));
+    try std.testing.expectEqual(@as(u16, 2), inlinePickerRowBudget(16, 0, 4));
+    try std.testing.expectEqual(@as(u16, 1), inlinePickerRowBudget(6, 0, 0));
 }
 
 test "slash menu layout prioritizes selection at short heights and excludes arguments" {

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -255,7 +255,6 @@ const max_static_status_activity_rows: u16 = 3;
 
 pub const QueuedPromptCard = struct {
     bytes: []const u8,
-    row_count: u16,
     editing: bool = false,
 };
 
@@ -357,16 +356,55 @@ pub fn queuedCardSpacerRows(ctx: RenderContext) u16 {
     return 1 +| above_hint;
 }
 
-pub fn queuedBannerRows(ctx: RenderContext) u16 {
-    if (ctx.queued_count == 0) return 0;
-    const paused_hint_rows: u16 = @intFromBool(ctx.queued_paused);
-    if (ctx.queued_prompt_card_rows > 0) {
-        return queuedCardContentRows(ctx) +|
-            paused_hint_rows +|
-            queuedCardSpacerRows(ctx);
+pub const QueuedBannerFacts = struct {
+    queued_count: usize = 0,
+    paused: bool = false,
+    card_count: usize = 0,
+    card_rows: u16 = 0,
+};
+
+pub fn queuedBannerRowsForFacts(facts: QueuedBannerFacts) u16 {
+    if (facts.queued_count == 0) return 0;
+    const paused_hint_rows: u16 = @intFromBool(facts.paused);
+    if (facts.card_rows > 0) {
+        const between_cards: u16 = @intCast(@min(
+            facts.card_count -| 1,
+            std.math.maxInt(u16),
+        ));
+        const spacer_rows: u16 = 1 +| paused_hint_rows;
+        return facts.card_rows +| between_cards +| paused_hint_rows +| spacer_rows;
     }
-    // No cards means the banner is collapsed to its single summary row.
     return 1 +| paused_hint_rows +| collapsed_queue_banner_gap_rows;
+}
+
+pub fn queuedBannerRows(ctx: RenderContext) u16 {
+    return queuedBannerRowsForFacts(.{
+        .queued_count = ctx.queued_count,
+        .paused = ctx.queued_paused,
+        .card_count = ctx.queued_prompt_cards.len,
+        .card_rows = ctx.queued_prompt_card_rows,
+    });
+}
+
+test "queued banner row policy consumes aggregate card facts" {
+    try std.testing.expectEqual(@as(u16, 2), queuedBannerRowsForFacts(.{
+        .queued_count = 2,
+    }));
+    try std.testing.expectEqual(@as(u16, 3), queuedBannerRowsForFacts(.{
+        .queued_count = 2,
+        .paused = true,
+    }));
+    try std.testing.expectEqual(@as(u16, 7), queuedBannerRowsForFacts(.{
+        .queued_count = 2,
+        .card_count = 2,
+        .card_rows = 5,
+    }));
+    try std.testing.expectEqual(@as(u16, 9), queuedBannerRowsForFacts(.{
+        .queued_count = 2,
+        .paused = true,
+        .card_count = 2,
+        .card_rows = 5,
+    }));
 }
 
 pub fn transientActivityGapRows(shell: *const TranscriptRuntime, tool_before_activity: bool) u16 {

--- a/src/ui/footer/skills_menu_presentation.zig
+++ b/src/ui/footer/skills_menu_presentation.zig
@@ -12,8 +12,9 @@ const SkillsMenuProjection = render_input.SkillsMenuProjection;
 const header_rows: u16 = 1;
 const roomy_top_gap_rows: u16 = 1;
 const title_rows: u16 = 1;
-// Each skill is a single line now: the name sits on the left and the source
-// scope on the right, so there is no separate description row or gap.
+const inline_scope_gap_width: usize = 4;
+// Each skill is a single line now, so there is no separate description row
+// or gap.
 const description_rows: u16 = 0;
 const item_gap_rows: u16 = 0;
 
@@ -21,6 +22,7 @@ const SkillsMenuLayout = struct {
     match_count: usize = 0,
     selected: usize = 0,
     visible_items: u16 = 0,
+    show_header: bool = true,
     first_item_row: u16 = header_rows,
     description_row_count: u16 = 0,
     item_stride: u16 = title_rows,
@@ -79,6 +81,47 @@ const SkillsMenuLayout = struct {
             .row_count = first_item_row + visible_items * item_stride - item_gap_rows,
         };
     }
+
+    fn buildInline(match_count: usize, selected_index: usize, row_budget: u16) SkillsMenuLayout {
+        if (row_budget == 0) return .{};
+
+        const selected = if (match_count > 0) selected_index % match_count else 0;
+        if (match_count == 0) {
+            if (row_budget < header_rows + roomy_top_gap_rows + 1) {
+                return .{
+                    .show_header = false,
+                    .first_item_row = 0,
+                    .row_count = 1,
+                };
+            }
+            return .{
+                .first_item_row = header_rows + roomy_top_gap_rows,
+                .row_count = header_rows + roomy_top_gap_rows + 1,
+            };
+        }
+
+        if (row_budget <= 2) {
+            const visible_items: u16 = @intCast(@min(match_count, row_budget));
+            return .{
+                .match_count = match_count,
+                .selected = selected,
+                .visible_items = visible_items,
+                .show_header = false,
+                .first_item_row = 0,
+                .row_count = visible_items,
+            };
+        }
+
+        const first_item_row = header_rows + roomy_top_gap_rows;
+        const visible_items: u16 = @intCast(@min(match_count, row_budget - first_item_row));
+        return .{
+            .match_count = match_count,
+            .selected = selected,
+            .visible_items = visible_items,
+            .first_item_row = first_item_row,
+            .row_count = first_item_row + visible_items,
+        };
+    }
 };
 
 pub const PreparedSkillsMenu = struct {
@@ -87,6 +130,7 @@ pub const PreparedSkillsMenu = struct {
     catalog_empty: bool,
     window_start: usize,
     visible_skills: []*const skill_runtime.Skill,
+    inline_name_column_width: ?usize,
     scope_column_width: usize,
 
     pub fn deinit(self: *PreparedSkillsMenu, alloc: Allocator) void {
@@ -106,6 +150,25 @@ pub fn prepareSkillsMenu(
 ) !PreparedSkillsMenu {
     const match_count = visibleSkillCount(projection);
     const layout = SkillsMenuLayout.build(match_count, projection.selected_index, row_budget);
+    return prepareSkillsMenuWithLayout(alloc, projection, layout, false);
+}
+
+pub fn prepareInlineSkillsMenu(
+    alloc: Allocator,
+    projection: SkillsMenuProjection,
+    row_budget: u16,
+) !PreparedSkillsMenu {
+    const match_count = visibleSkillCount(projection);
+    const layout = SkillsMenuLayout.buildInline(match_count, projection.selected_index, row_budget);
+    return prepareSkillsMenuWithLayout(alloc, projection, layout, true);
+}
+
+fn prepareSkillsMenuWithLayout(
+    alloc: Allocator,
+    projection: SkillsMenuProjection,
+    layout: SkillsMenuLayout,
+    inline_mode: bool,
+) !PreparedSkillsMenu {
     const window_start = list_window.updateEdgeStart(
         projection.window_start,
         layout.match_count,
@@ -133,6 +196,7 @@ pub fn prepareSkillsMenu(
         .catalog_empty = projection.items.len == 0,
         .window_start = window_start,
         .visible_skills = visible_skills,
+        .inline_name_column_width = if (inline_mode) matching_name_column_width(projection) else null,
         .scope_column_width = scopeColumnWidth(visible_skills),
     };
 }
@@ -148,6 +212,28 @@ pub fn visibleNavigationRowsForBudget(
     ).visible_items;
 }
 
+pub fn inlineVisibleNavigationRowsForBudget(
+    projection: SkillsMenuProjection,
+    row_budget: u16,
+) u16 {
+    return SkillsMenuLayout.buildInline(
+        visibleSkillCount(projection),
+        projection.selected_index,
+        row_budget,
+    ).visible_items;
+}
+
+pub fn inlineMenuRowCount(
+    projection: SkillsMenuProjection,
+    row_budget: u16,
+) u16 {
+    return SkillsMenuLayout.buildInline(
+        visibleSkillCount(projection),
+        projection.selected_index,
+        row_budget,
+    ).row_count;
+}
+
 pub fn composeSkillsMenuRow(
     alloc: Allocator,
     prepared: PreparedSkillsMenu,
@@ -156,7 +242,7 @@ pub fn composeSkillsMenuRow(
 ) !std.ArrayList(u8) {
     const row: std.ArrayList(u8) = .empty;
     if (width == 0 or row_index >= prepared.layout.row_count) return row;
-    if (row_index == 0) {
+    if (prepared.layout.show_header and row_index == 0) {
         return composeHeaderRow(
             alloc,
             prepared.layout.match_count,
@@ -185,9 +271,20 @@ pub fn composeSkillsMenuRow(
         alloc,
         skill,
         display_index == layout.selected,
+        prepared.inline_name_column_width,
         prepared.scope_column_width,
         width,
     );
+}
+
+fn matching_name_column_width(projection: SkillsMenuProjection) usize {
+    var col: usize = 0;
+    for (projection.items) |skill| {
+        if (!skill_runtime.skillSourceMatchesFilter(skill.source, projection.source_filter)) continue;
+        if (!skill_runtime.skill_matches_menu_query(skill, projection.query)) continue;
+        col = @max(col, display_width.visibleWidth(skill.name));
+    }
+    return col;
 }
 
 // Widest source-scope label across the visible skills, so the scope column
@@ -269,6 +366,7 @@ fn composeSkillTitleRow(
     alloc: Allocator,
     skill: skill_runtime.Skill,
     selected: bool,
+    inline_name_width: ?usize,
     scope_col: usize,
     width: u16,
 ) !std.ArrayList(u8) {
@@ -282,11 +380,16 @@ fn composeSkillTitleRow(
     const scope_width = @max(scope_col, display_width.visibleWidth(scope));
     const prefix_width = display_width.visibleWidthIgnoringAnsi(row.items);
     const content_width: usize = @as(usize, width) -| 1;
-    const show_scope = scope_width > 0 and content_width >= prefix_width + 8 + 2 + scope_width;
-    const name_budget = if (show_scope)
-        content_width - prefix_width - scope_width - 2
+    const show_scope = if (inline_name_width) |name_col|
+        scope_width > 0 and content_width >= prefix_width + name_col + inline_scope_gap_width + scope_width
     else
-        @as(usize, width) -| prefix_width;
+        scope_width > 0 and content_width >= prefix_width + 8 + 2 + scope_width;
+    const name_budget = if (!show_scope)
+        @as(usize, width) -| prefix_width
+    else if (inline_name_width) |name_col|
+        name_col
+    else
+        content_width - prefix_width - scope_width - 2;
 
     // Selection by brightness: bold bright white when selected, dim gray
     // otherwise, applied to the whole row (name and scope). No marker glyph.
@@ -295,7 +398,11 @@ fn composeSkillTitleRow(
     try row_text.appendSingleLineEllipsized(alloc, &row, skill.name, name_budget);
 
     if (show_scope) {
-        try row_text.appendSpacesToColumn(alloc, &row, content_width - scope_width);
+        const scope_start = if (inline_name_width) |name_col|
+            prefix_width + name_col + inline_scope_gap_width
+        else
+            content_width - scope_width;
+        try row_text.appendSpacesToColumn(alloc, &row, scope_start);
         try row.appendSlice(alloc, scope);
     }
     try row.appendSlice(alloc, ui_render.reset_style);
@@ -444,7 +551,8 @@ test "skills menu narrow header always shows the active source" {
         defer fx_prepared.deinit(alloc);
         var fx_header = try composeSkillsMenuRow(alloc, fx_prepared, 0, width);
         defer fx_header.deinit(alloc);
-        try std.testing.expect(std.mem.find(u8, fx_header.items, "[Fx]") != null);
+        try std.testing.expect(std.mem.find(u8, fx_header.items, "[fx]") != null);
+        try std.testing.expect(std.mem.find(u8, fx_header.items, "[Fx]") == null);
         try std.testing.expect(
             display_width.visibleWidthIgnoringAnsi(fx_header.items) <= width,
         );
@@ -462,6 +570,60 @@ test "skills menu navigation budget counts whole items" {
 
     // Single-line rows: header + gap (2) leave 8 for items, capped at 4 skills.
     try std.testing.expectEqual(@as(u16, 4), visibleNavigationRowsForBudget(projection, 10));
+}
+
+test "inline skills menu shows six roomy items and prioritizes selection when tiny" {
+    const alloc = std.testing.allocator;
+    const skills = [_]skill_runtime.Skill{
+        .{ .name = "one", .description = "", .path = "/tmp/one", .source = .global_fx },
+        .{ .name = "two", .description = "", .path = "/tmp/two", .source = .global_fx },
+        .{ .name = "three", .description = "", .path = "/tmp/three", .source = .global_fx },
+        .{ .name = "four", .description = "", .path = "/tmp/four", .source = .global_fx },
+        .{ .name = "five", .description = "", .path = "/tmp/five", .source = .global_fx },
+        .{ .name = "six", .description = "", .path = "/tmp/six", .source = .global_fx },
+        .{ .name = "seven", .description = "", .path = "/tmp/seven", .source = .global_fx },
+    };
+    const projection: SkillsMenuProjection = .{
+        .active = true,
+        .items = &skills,
+        .selected_index = 6,
+    };
+
+    var roomy = try prepareInlineSkillsMenu(alloc, projection, 8);
+    defer roomy.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 8), roomy.rowCount());
+    try std.testing.expectEqual(@as(u16, 6), inlineVisibleNavigationRowsForBudget(projection, 8));
+    try std.testing.expectEqual(@as(usize, 1), roomy.window_start);
+
+    var tiny = try prepareInlineSkillsMenu(alloc, projection, 1);
+    defer tiny.deinit(alloc);
+    try std.testing.expectEqual(@as(u16, 1), tiny.rowCount());
+    try std.testing.expectEqual(@as(u16, 1), inlineVisibleNavigationRowsForBudget(projection, 1));
+    var tiny_row = try composeSkillsMenuRow(alloc, tiny, 0, 20);
+    defer tiny_row.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, tiny_row.items, "seven") != null);
+    try std.testing.expect(std.mem.find(u8, tiny_row.items, "Skills") == null);
+}
+
+test "inline skills menu keeps an empty result visible at one row" {
+    const alloc = std.testing.allocator;
+    const skills = [_]skill_runtime.Skill{.{
+        .name = "managed",
+        .description = "",
+        .path = "/tmp/managed",
+        .source = .global_fx,
+    }};
+    const projection: SkillsMenuProjection = .{
+        .active = true,
+        .items = &skills,
+        .query = "missing",
+    };
+
+    var prepared = try prepareInlineSkillsMenu(alloc, projection, 1);
+    defer prepared.deinit(alloc);
+    var row = try composeSkillsMenuRow(alloc, prepared, 0, 24);
+    defer row.deinit(alloc);
+    try std.testing.expect(std.mem.find(u8, row.items, "No skills found.") != null);
 }
 
 test "skills menu keeps the selected whole item in its window" {
@@ -549,7 +711,7 @@ test "skills menu degrades to one complete item in a tiny row budget" {
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(title.items) <= 12);
 }
 
-test "prepared skills menu keeps a mixed-source scrolled window aligned" {
+test "prepared skills menu aligns sources beside the widest visible name" {
     const alloc = std.testing.allocator;
     const skills = [_]skill_runtime.Skill{
         .{ .name = "a", .description = "compat", .path = "/tmp/a", .source = .global_claw },
@@ -563,7 +725,7 @@ test "prepared skills menu keeps a mixed-source scrolled window aligned" {
         .selected_index = 3,
     };
 
-    var prepared = try prepareSkillsMenu(alloc, projection, 4);
+    var prepared = try prepareInlineSkillsMenu(alloc, projection, 4);
     defer prepared.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 2), prepared.window_start);
     try std.testing.expectEqual(@as(usize, 2), prepared.visible_skills.len);
@@ -577,11 +739,49 @@ test "prepared skills menu keeps a mixed-source scrolled window aligned" {
 
     const first_scope = std.mem.find(u8, first.items, "Claw · Global") orelse return error.MissingFirstScope;
     const second_scope = std.mem.find(u8, second.items, "OpenCode · Global") orelse return error.MissingSecondScope;
-    try std.testing.expectEqual(
-        display_width.visibleWidthIgnoringAnsi(first.items[0..first_scope]),
-        display_width.visibleWidthIgnoringAnsi(second.items[0..second_scope]),
-    );
+    const first_scope_col = display_width.visibleWidthIgnoringAnsi(first.items[0..first_scope]);
+    const second_scope_col = display_width.visibleWidthIgnoringAnsi(second.items[0..second_scope]);
+    try std.testing.expectEqual(@as(usize, 17), first_scope_col);
+    try std.testing.expectEqual(first_scope_col, second_scope_col);
     try std.testing.expect(std.mem.find(u8, second.items, ui_render.selected_completion_style) != null);
+}
+
+test "inline source column stays fixed to the widest matching skill across scroll windows" {
+    const alloc = std.testing.allocator;
+    const skills = [_]skill_runtime.Skill{
+        .{ .name = "one", .description = "", .path = "/tmp/one", .source = .global_opencode },
+        .{ .name = "longest-skill-name", .description = "", .path = "/tmp/longest", .source = .global_opencode },
+        .{ .name = "three", .description = "", .path = "/tmp/three", .source = .global_opencode },
+        .{ .name = "four", .description = "", .path = "/tmp/four", .source = .global_opencode },
+    };
+
+    var first_window = try prepareInlineSkillsMenu(alloc, .{
+        .active = true,
+        .items = &skills,
+    }, 4);
+    defer first_window.deinit(alloc);
+    var first_row = try composeSkillsMenuRow(alloc, first_window, 2, 80);
+    defer first_row.deinit(alloc);
+
+    var second_window = try prepareInlineSkillsMenu(alloc, .{
+        .active = true,
+        .items = &skills,
+        .selected_index = 3,
+    }, 4);
+    defer second_window.deinit(alloc);
+    var second_row = try composeSkillsMenuRow(alloc, second_window, 2, 80);
+    defer second_row.deinit(alloc);
+
+    const first_scope = std.mem.find(u8, first_row.items, "OpenCode · Global") orelse return error.MissingFirstScope;
+    const second_scope = std.mem.find(u8, second_row.items, "OpenCode · Global") orelse return error.MissingSecondScope;
+    try std.testing.expectEqual(
+        @as(usize, 24),
+        display_width.visibleWidthIgnoringAnsi(first_row.items[0..first_scope]),
+    );
+    try std.testing.expectEqual(
+        @as(usize, 24),
+        display_width.visibleWidthIgnoringAnsi(second_row.items[0..second_scope]),
+    );
 }
 
 test "skills menu result rows preserve content within one through four columns" {
@@ -595,7 +795,7 @@ test "skills menu result rows preserve content within one through four columns" 
 
     for (1..5) |width| {
         const terminal_width: u16 = @intCast(width);
-        var title = try composeSkillTitleRow(alloc, skill, true, 0, terminal_width);
+        var title = try composeSkillTitleRow(alloc, skill, true, null, 0, terminal_width);
         defer title.deinit(alloc);
         try std.testing.expect(display_width.visibleWidthIgnoringAnsi(title.items) <= width);
         try std.testing.expect(std.mem.find(u8, title.items, "●") == null);

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -15,6 +15,7 @@ const compact_command_menu_presentation = @import("compact_command_menu_presenta
 const input_presentation = @import("input_presentation.zig");
 const interaction_state = @import("interaction_state.zig");
 const picker_presentation = @import("picker_presentation.zig");
+const skills_menu_presentation = @import("skills_menu_presentation.zig");
 const question_ui = @import("question_ui.zig");
 const render_input = @import("render_input.zig");
 const surface_invalidation = @import("surface_invalidation.zig");
@@ -320,6 +321,22 @@ fn queuedBannerRowsForLayout(
     input_extra: u16,
 ) u16 {
     const requested = render_input.queuedBannerRows(ctx);
+    return clampQueuedBannerRows(
+        requested,
+        terminal_rows,
+        input_visible,
+        composer_top_chrome_rows,
+        input_extra,
+    );
+}
+
+pub fn clampQueuedBannerRows(
+    requested: u16,
+    terminal_rows: u16,
+    input_visible: bool,
+    composer_top_chrome_rows: u16,
+    input_extra: u16,
+) u16 {
     if (requested == 0) return 0;
     const non_banner_rows: u16 = if (input_visible)
         footer_layout.reservedBaseRows(true, composer_top_chrome_rows) +| 1 +| input_extra
@@ -356,9 +373,10 @@ fn buildFooterSurfaceProjection(
     const input_visible = ctx.composer_visible and !modal_active and !viewer_active;
     const composer_top_chrome_rows = footer_paint_plan.composerTopChromeRows();
     const show_auth_picker = !viewer_active and !modal_active and !ctx.stream.active and ctx.auth_picker.active;
+    const show_skills_query = !viewer_active and !show_auth_picker and !modal_active and ctx.skills_menu.active;
     const stream_suppresses_file_query = ctx.stream.active and !ctx.queued_editor_active;
-    const show_model_query = !viewer_active and !show_auth_picker and !modal_active and !ctx.stream.active and ctx.model_query_active;
-    const show_file_query = !viewer_active and !modal_active and !stream_suppresses_file_query and ctx.file_query_active and !show_model_query;
+    const show_model_query = !viewer_active and !show_auth_picker and !show_skills_query and !modal_active and !ctx.stream.active and ctx.model_query_active;
+    const show_file_query = !viewer_active and !show_skills_query and !modal_active and !stream_suppresses_file_query and ctx.file_query_active and !show_model_query;
     const geometry = input_presentation.measureRawInputGeometry(
         ctx,
         shell.layout.cols,
@@ -368,11 +386,13 @@ fn buildFooterSurfaceProjection(
         show_model_query,
         show_file_query,
     );
-    const show_slash_query = !show_auth_picker and geometry.show_slash_query;
-    const show_picker = show_auth_picker or show_model_query or show_file_query or show_slash_query;
+    const show_slash_query = !show_auth_picker and !show_skills_query and geometry.show_slash_query;
+    const show_picker = show_auth_picker or show_skills_query or show_model_query or show_file_query or show_slash_query;
     const picker_items: []const []const u8 = if (show_model_query) ctx.model_completions else &.{};
     const file_picker_items: []const file_index.SearchResult = if (show_file_query) ctx.file_completions else &.{};
-    const picker_selection_index: usize = if (show_slash_query)
+    const picker_selection_index: usize = if (show_skills_query)
+        ctx.skills_menu.selected_index
+    else if (show_slash_query)
         ctx.input.picker.slash_completion_index
     else if (show_auth_picker)
         ctx.auth_picker.selectedIndex()
@@ -382,7 +402,9 @@ fn buildFooterSurfaceProjection(
         ctx.file_completion_index
     else
         0;
-    const picker_window_start: usize = if (show_slash_query)
+    const picker_window_start: usize = if (show_skills_query)
+        ctx.skills_menu.window_start
+    else if (show_slash_query)
         ctx.input.picker.slash_completion_window_start
     else if (show_model_query)
         ctx.model_completion_window_start
@@ -402,7 +424,9 @@ fn buildFooterSurfaceProjection(
         ctx.file_completions_failed
     else
         false;
-    const picker_kind: PickerKind = if (show_slash_query)
+    const picker_kind: PickerKind = if (show_skills_query)
+        .skills
+    else if (show_slash_query)
         .slash
     else if (show_auth_picker)
         .auth
@@ -443,6 +467,11 @@ fn buildFooterSurfaceProjection(
         )
     else
         null;
+    const inline_picker_row_budget = picker_presentation.inlinePickerRowBudget(
+        shell.layout.rows,
+        geometry.input_extra,
+        banner_rows,
+    );
     const picker_rows: u16 = if (sizing_request) |request|
         if (request.file) |request_file|
             approval_ui.fileApprovalPickerRows(request_file)
@@ -463,6 +492,11 @@ fn buildFooterSurfaceProjection(
             shell.layout.rows,
             geometry.input_extra,
             banner_rows,
+        )
+    else if (show_skills_query)
+        skills_menu_presentation.inlineMenuRowCount(
+            ctx.skills_menu,
+            inline_picker_row_budget,
         )
     else if (slash_menu_layout) |layout|
         layout.row_count
@@ -1575,6 +1609,39 @@ test "surface footer measurement reserves rows for vertical slash completions" {
     try std.testing.expectEqual(PickerKind.slash, measurement.picker_kind);
     try std.testing.expect(measurement.picker_rows > 1);
     try std.testing.expect(measurement.footer_extra >= measurement.picker_rows + 1);
+}
+
+test "surface footer measurement reserves six inline skill choices" {
+    const alloc = std.testing.allocator;
+    const skills = [_]@import("../../core/skills/skill_runtime.zig").Skill{
+        .{ .name = "one", .description = "", .path = "/tmp/one", .source = .global_fx },
+        .{ .name = "two", .description = "", .path = "/tmp/two", .source = .global_fx },
+        .{ .name = "three", .description = "", .path = "/tmp/three", .source = .global_fx },
+        .{ .name = "four", .description = "", .path = "/tmp/four", .source = .global_fx },
+        .{ .name = "five", .description = "", .path = "/tmp/five", .source = .global_fx },
+        .{ .name = "six", .description = "", .path = "/tmp/six", .source = .global_fx },
+        .{ .name = "seven", .description = "", .path = "/tmp/seven", .source = .global_fx },
+    };
+    var input = InputRuntime{};
+    defer input.deinit(alloc);
+    try input.edit_state.input.appendSlice(alloc, "$");
+    input.edit_state.cursor = input.edit_state.input.items.len;
+
+    var approval = ApprovalPrompt{};
+    defer approval.deinit(alloc);
+    var shell = surfaceTestShell(24, 80);
+    defer shell.deinit(alloc);
+    var ctx = surfaceTestContext(&input);
+    ctx.skills_menu = .{
+        .active = true,
+        .items = &skills,
+    };
+
+    var measurement = try measureSurfaceFooter(alloc, &shell, approval.projection(), ctx);
+    defer measurement.deinit(alloc);
+    try std.testing.expect(measurement.show_picker);
+    try std.testing.expectEqual(PickerKind.skills, measurement.picker_kind);
+    try std.testing.expectEqual(@as(u16, 8), measurement.picker_rows);
 }
 
 test "surface footer reserves one non-selectable row for zero slash results" {

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -2317,6 +2317,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
     "inline completions stay in the composer while leading triggers open their menus",
     async () => {
       const fixture = createSkillsMenuFixture();
+      const tapePath = join(fixture.home, "dollar-inline.fxtape");
       session = await TmuxSession.create({
         cwd: fixture.workspace,
         env: {
@@ -2324,6 +2325,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           AI_GATEWAY_API_KEY: undefined,
           VERCEL_OIDC_TOKEN: undefined,
           FX_AUTO_UPGRADE: "0",
+          FX_RECORD: tapePath,
         },
         width: 120,
         height: 32,
@@ -2379,10 +2381,17 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
 
+      const alternateCount = (sequence: string) =>
+        countOccurrences(readFileSync(tapePath).toString("latin1"), sequence);
+      const entersBeforeDollar = alternateCount("\x1b[?1049h");
+      const leavesBeforeDollar = alternateCount("\x1b[?1049l");
+
       await session.sendLiteralText("$work");
       grid = await waitForSkillsMenu(session, 1);
       expect(composerContains(grid.join("\n"), "$work")).toBe(true);
-      expect(grid.join("\n")).not.toContain("𝒇x");
+      expect(grid.join("\n")).toContain("𝒇x");
+      expect(alternateCount("\x1b[?1049h")).toBe(entersBeforeDollar);
+      expect(alternateCount("\x1b[?1049l")).toBe(leavesBeforeDollar);
       await session.sendKeys("C-[");
       await session.waitForPane(
         (current) =>
@@ -2391,6 +2400,8 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           !current.includes("↑↓ Navigate"),
         5_000,
       );
+      expect(alternateCount("\x1b[?1049h")).toBe(entersBeforeDollar);
+      expect(alternateCount("\x1b[?1049l")).toBe(leavesBeforeDollar);
       await session.sendKeys("C-u");
 
       await session.sendLiteralText(" $");
@@ -2519,7 +2530,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendText("/skills");
       await waitForSkillsMenu(session, 4);
       await session.sendKeys("Tab");
-      await session.waitForText("[Fx]", 5_000);
+      await session.waitForText("[fx]", 5_000);
       await session.sendKeys("BTab");
       await session.waitForText("[All]", 5_000);
       await session.sendLiteralText("workspace");
@@ -2577,7 +2588,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendLiteralText("$");
       let grid = await waitForSkillsMenu(session, 220);
       const initialNames = visibleFxSkillNames(grid);
-      expect(initialNames.length).toBeGreaterThan(4);
+      expect(initialNames).toHaveLength(6);
 
       for (let i = 0; i < initialNames.length - 1; i += 1) {
         await session.sendKeys("Down");
@@ -2585,6 +2596,20 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       grid = await session.capturePaneGrid();
       expect(visibleFxSkillNames(grid)[0]).toBe(initialNames[0]);
+      expect(selectedSkillName(await session.capturePaneEscapes())).toBe(
+        initialNames[initialNames.length - 1],
+      );
+
+      await session.resizeWindow(72, 16);
+      grid = await waitForSkillsMenu(session, 220);
+      expect(visibleFxSkillNames(grid)).toHaveLength(4);
+      expect(selectedSkillName(await session.capturePaneEscapes())).toBe(
+        initialNames[initialNames.length - 1],
+      );
+
+      await session.resizeWindow(120, 28);
+      grid = await waitForSkillsMenu(session, 220);
+      expect(visibleFxSkillNames(grid)).toHaveLength(6);
       expect(selectedSkillName(await session.capturePaneEscapes())).toBe(
         initialNames[initialNames.length - 1],
       );
@@ -2900,7 +2925,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
   );
 
   test(
-    "Escape closes the skills catalog without cancelling an active stream",
+    "Escape closes the inline skills menu without cancelling an active stream",
     async () => {
       const fixture = createSkillsMenuFixture();
       const stream: HeldSkillStream = { cancelled: false };
@@ -2997,7 +3022,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
   );
 
   test(
-    "file approval returns to the preserved skills catalog",
+    "file approval returns to the preserved inline skills menu",
     async () => {
       const fixture = createSkillsMenuFixture();
       const target = join(fixture.workspace, "catalog-approval.txt");


### PR DESCRIPTION
## Summary

- Show typed and pasted `$skill` suggestions in the inline footer without hiding the transcript or acquiring the alternate screen.
- Limit the picker to six visible skills and keep selection stable across terminal resize and queued-editor reflow.
- Keep source labels aligned to the longest matching skill while scrolling.
- Preserve `/skills` and child skill catalogs as full-screen views.
- Restore the inline skill picker after streaming and file approval overlays.