### PR TITLE
Preserve terminal signal outcomes

### DIFF
--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -4187,6 +4187,10 @@ const Session = struct {
         };
         if (!self.matchesSignalTarget(target)) return false;
 
+        const shell_group_delivery = if (failSignalStageForTest("shell_group"))
+            ProcessGroupDelivery.failed
+        else
+            self.signalVerifiedProcessGroup(target, signal);
         var descendants_delivery = descendants.signalOutsideProcessGroupChecked(
             signalValue(signal),
             target.pid,
@@ -4201,10 +4205,7 @@ const Session = struct {
         );
         return terminalSignalCompleted(
             descendants_delivery,
-            if (failSignalStageForTest("shell_group"))
-                .failed
-            else
-                self.signalVerifiedProcessGroup(target, signal),
+            shell_group_delivery,
         );
     }
 

--- a/tests/e2e/terminal-host.test.ts
+++ b/tests/e2e/terminal-host.test.ts
@@ -7865,7 +7865,7 @@ test("force close reports incomplete refresh descendant and shell delivery", asy
   for (const [index, stage] of stages.entries()) {
     const home = makeHome();
     const paths = hostPaths(home);
-    const host = startHost(home, undefined, 200, {
+    const host = startHost(home, undefined, TMUX_INITIAL_STARTUP_OBSERVATION_BUDGET_MS, {
       FX_TERMINAL_TEST_FAIL_SIGNAL_STAGE: stage,
     });
     await waitFor(() => existsSync(paths.socket));


### PR DESCRIPTION
## Summary

- Preserve the requested signal outcome when a recovered terminal command has detached child processes.
- Continue stopping detached child processes during terminal signal delivery.