### PR TITLE
Use one inline skill picker

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1692,25 +1692,9 @@ pub fn Runtime(comptime App: type) type {
             return app.auth.popPickerStage(app.alloc);
         }
 
-        fn dismissSkillsMenuForComposerEdit(app: *App) bool {
-            if (comptime !@hasField(App, "skills")) return false;
-            if (!app.skills.menu.active) return false;
-            if (isMentionSkillsMenuOrigin(app.skills.menu.origin) or commandSkillsMenuActive(app)) return false;
-            app.skills.closeMenu();
-            return true;
-        }
-
-        fn isMentionSkillsMenuOrigin(origin: skill_runtime.SkillMenuOrigin) bool {
-            return origin == .dollar or origin == .paste;
-        }
-
-        fn isCommandSkillsMenuOrigin(origin: skill_runtime.SkillMenuOrigin) bool {
-            return origin == .command or origin == .slash;
-        }
-
         fn commandSkillsMenuActive(app: *App) bool {
             if (comptime !@hasField(App, "skills")) return false;
-            return app.skills.menu.active and isCommandSkillsMenuOrigin(app.skills.menu.origin);
+            return app.skills.menu.active and !app.skills.menu.origin.isMention();
         }
 
         fn skillsMenuActive(app: *App) bool {
@@ -1754,7 +1738,7 @@ pub fn Runtime(comptime App: type) type {
         fn dismissMentionSkillsMenuForSpace(app: *App) void {
             if (comptime !@hasField(App, "skills")) return;
             if (!app.skills.menu.active) return;
-            if (!isMentionSkillsMenuOrigin(app.skills.menu.origin)) return;
+            if (!app.skills.menu.origin.isMention()) return;
             app.skills.closeMenu();
             app.shell.render_requests.request(.footer);
         }
@@ -1805,9 +1789,7 @@ pub fn Runtime(comptime App: type) type {
         }
 
         fn dismissActiveMenusForComposerEdit(app: *App) bool {
-            var dismissed = dismissAuthPickerForComposerEdit(app);
-            dismissed = dismissSkillsMenuForComposerEdit(app) or dismissed;
-            return dismissed;
+            return dismissAuthPickerForComposerEdit(app);
         }
 
         fn dismissActiveMenusThenRedraw(app: *App) void {
@@ -1824,14 +1806,14 @@ pub fn Runtime(comptime App: type) type {
             const origin = app.skills.menu.origin;
             syncSkillsMenu(app);
             const skill = app.skills.selectedMenuSkill() orelse {
-                if (isMentionSkillsMenuOrigin(origin)) {
+                if (origin.isMention()) {
                     app.skills.closeMenu();
                     app.shell.render_requests.request(.footer);
                     return false;
                 }
                 return true;
             };
-            const target = if (isCommandSkillsMenuOrigin(origin))
+            const target = if (!origin.isMention())
                 skill_runtime.SkillMenuTarget{ .start = 0, .end = app.input_runtime.edit_state.input.items.len }
             else
                 app.skills.menu.target orelse skill_runtime.SkillMenuTarget{
@@ -2244,7 +2226,7 @@ pub fn Runtime(comptime App: type) type {
         fn syncSkillsMenu(app: *App) void {
             if (comptime !@hasField(App, "skills")) return;
             if (!app.skills.menu.active) return;
-            if (isCommandSkillsMenuOrigin(app.skills.menu.origin)) {
+            if (!app.skills.menu.origin.isMention()) {
                 app.skills.menu.setQuery(app.input_runtime.edit_state.input.items);
                 app.skills.menu.clamp(app.skills.items);
                 return;
@@ -2500,7 +2482,7 @@ pub fn Runtime(comptime App: type) type {
         fn cancelSkillsMenu(app: *App) bool {
             if (comptime !@hasField(App, "skills")) return false;
             if (!app.skills.menu.active) return false;
-            const clear_query = isCommandSkillsMenuOrigin(app.skills.menu.origin);
+            const clear_query = !app.skills.menu.origin.isMention();
             app.skills.closeMenu();
             if (clear_query) {
                 app.input_runtime.inputResetState().clearCurrent(app.alloc);
@@ -4168,7 +4150,7 @@ test "app_input_runtime skills menu navigation remains interactive while streami
     try std.testing.expectEqual(@as(usize, 1), app.skills.menu.selected_index);
 }
 
-test "app_input_runtime skills menu navigation uses the dedicated composer window" {
+test "app_input_runtime command skills navigation uses the inline composer window" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);
     defer app.deinit();
@@ -4194,7 +4176,7 @@ test "app_input_runtime skills menu navigation uses the dedicated composer windo
     try Runtime(RoutingFakeApp).routeModifiedHistory(&app, .down, 1);
 
     try std.testing.expectEqual(@as(usize, 1), app.skills.menu.selected_index);
-    try std.testing.expectEqual(@as(usize, 0), app.skills.menu.window_start);
+    try std.testing.expectEqual(@as(usize, 1), app.skills.menu.window_start);
 }
 
 test "app_input_runtime Escape closes an idle skills menu before empty-composer handling" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -153,7 +153,6 @@ const SurfaceFrameShell = struct {
 const RenderReconciliation = union(enum) {
     inline_render: InlineRenderReconciliation,
     file_approval_screen,
-    skills_screen,
     models_screen,
     resume_screen,
     help_screen,
@@ -1528,7 +1527,6 @@ pub fn Runtime(comptime App: type) type {
                 if (modelMenuActive(app)) return .models_screen;
                 if (sessionMenuActive(app)) return .resume_screen;
                 if (helpMenuActive(app)) return .help_screen;
-                if (skillsCatalogMenuActive(app)) return .skills_screen;
             }
 
             if (app.terminal.catalogMenuScreenActive()) {
@@ -1654,7 +1652,6 @@ pub fn Runtime(comptime App: type) type {
             else switch (try reconcileBeforeFrameRender(app, render_input.queuedBannerRows(footer_ctx))) {
                 .inline_render => |inline_render| inline_render,
                 .file_approval_screen => return renderApprovalScreen(app),
-                .skills_screen => return renderSkillsScreen(app, footer_ctx),
                 .models_screen => return renderModelsScreen(app, footer_ctx),
                 .resume_screen => return renderResumeScreen(app, footer_ctx),
                 .help_screen => return renderHelpScreen(app, footer_ctx),
@@ -2283,42 +2280,6 @@ pub fn Runtime(comptime App: type) type {
             };
         }
 
-        fn renderSkillsScreen(app: *App, ctx: render_input.RenderContext) !FrameAttemptResult {
-            if (comptime !@hasField(App, "terminal") or !@hasField(App, "skills")) {
-                return error.MissingSkillsScreenRuntime;
-            }
-
-            const clear_display = !app.terminal.catalogMenuScreenActive();
-            try app_lifecycle.enterCatalogMenuScreen(&app.terminal, &app.shell, &app.metrics);
-            if (app.shell.shadow_vt) |grid| {
-                if (grid.cols != app.shell.layout.cols or grid.rows != app.shell.layout.rows) {
-                    try grid.resize(app.shell.layout.cols, app.shell.layout.rows);
-                }
-            }
-
-            var screen = try skills_screen.paint(app.alloc, .{
-                .rows = app.shell.layout.rows,
-                .cols = app.shell.layout.cols,
-                .skills = render_input.skillsMenuProjection(&app.skills),
-                .composer = .{
-                    .input = ctx.input.edit_state.input.items,
-                    .cursor = ctx.input.edit_state.cursor,
-                    .images = ctx.pending_images,
-                    .pasted_blocks = ctx.input.entities.pasted_blocks.items,
-                    .image_tokens = ctx.input.entities.image_tokens.items,
-                    .skill_tokens = ctx.input.entities.skill_tokens.items,
-                },
-                .ctrl_c_pending = ctx.ctrl_c_pending,
-                .clear_display = clear_display,
-            });
-            defer screen.deinit(app.alloc);
-            try app_lifecycle.writeLifecycleTerminalBytes(&app.shell, &app.metrics, screen.bytes);
-            return .{
-                .shadow_state = .committed,
-                .animation_visible = false,
-            };
-        }
-
         fn renderModelsScreen(app: *App, ctx: render_input.RenderContext) !FrameAttemptResult {
             if (comptime !@hasField(App, "terminal") or !@hasField(App, "model_cache")) {
                 return error.MissingModelsScreenRuntime;
@@ -2658,13 +2619,6 @@ pub fn Runtime(comptime App: type) type {
             return false;
         }
 
-        fn skillsCatalogMenuActive(app: *const App) bool {
-            if (comptime @hasField(App, "skills")) {
-                return app.skills.menu.active and !app.skills.menu.origin.isMention();
-            }
-            return false;
-        }
-
         fn modelMenuActive(app: *const App) bool {
             if (comptime @hasField(App, "model_cache")) return app.model_cache.menu.active;
             return false;
@@ -2688,7 +2642,6 @@ pub fn Runtime(comptime App: type) type {
         fn catalogMenuActive(app: *const App) bool {
             return settingsMenuActive(app) or
                 helpMenuActive(app) or
-                skillsCatalogMenuActive(app) or
                 modelMenuActive(app) or
                 sessionMenuActive(app);
         }
@@ -5205,7 +5158,7 @@ test "core.app_render_runtime first requested startup frame commits through the 
     try std.testing.expectEqual(first_len, try file.length(io_mod.getIo()));
 }
 
-test "core.app_render_runtime mention skills stay inline while command skills retain the catalog screen" {
+test "core.app_render_runtime main skill menu origins share the inline footer" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -5324,8 +5277,9 @@ test "core.app_render_runtime mention skills stay inline while command skills re
     app.skills.openMenu();
     app.shell.render_requests.request(.footer);
     try Runtime(CoordinatorTestApp).flushRequestedFrame(&app);
-    try std.testing.expect(app.terminal.catalogMenuScreenActive());
-    try std.testing.expect(!(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript stays visible")));
+    try std.testing.expect(!app.terminal.catalogMenuScreenActive());
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "pure-core"));
+    try std.testing.expect(try coordinatorGridContains(app.shell.shadow_vt.?.*, "transcript stays visible"));
 
     app.skills.closeMenu();
     app.shell.render_requests.request(.footer);
@@ -5335,8 +5289,8 @@ test "core.app_render_runtime mention skills stay inline while command skills re
     var read_offset: u64 = 0;
     const terminal_bytes = try readCoordinatorFrameBytes(alloc, file, &read_offset);
     defer alloc.free(terminal_bytes);
-    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, terminal_bytes, "\x1b[?1049h"));
-    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, terminal_bytes, "\x1b[?1049l"));
+    try std.testing.expectEqual(@as(usize, 0), std.mem.count(u8, terminal_bytes, "\x1b[?1049h"));
+    try std.testing.expectEqual(@as(usize, 0), std.mem.count(u8, terminal_bytes, "\x1b[?1049l"));
 }
 
 test "core.app_render_runtime width-changed queued editor keeps mention navigation and render aligned" {

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -498,31 +498,14 @@ pub fn CompletionRuntime(comptime App: type) type {
 
         fn skillsMenuVisibleRows(app: *App) !u16 {
             const projection = render_input.skillsMenuProjection(&app.skills);
-            if (app.skills.menu.origin.isMention()) {
-                const budget = try footerRowBudget(app);
-                return skills_menu_presentation.inlineVisibleNavigationRowsForBudget(
-                    projection,
-                    picker_presentation.inlinePickerRowBudget(
-                        app.shell.layout.rows,
-                        budget.input_extra,
-                        budget.banner_rows,
-                    ),
-                );
-            }
-            const scan = ui_input.scanInputCursorVertical(
-                &app.input_runtime,
-                .down,
-                app.shell.layout.cols,
-                app.pending_images.items,
-            );
-            const layout = catalog_screen_layout.screenLayout(
-                app.shell.layout.rows,
-                scan.total_rows,
-                scan.cursor_row,
-            );
-            return skills_menu_presentation.visibleNavigationRowsForBudget(
+            const budget = try footerRowBudget(app);
+            return skills_menu_presentation.inlineVisibleNavigationRowsForBudget(
                 projection,
-                layout.menu_row_budget,
+                picker_presentation.inlinePickerRowBudget(
+                    app.shell.layout.rows,
+                    budget.input_extra,
+                    budget.banner_rows,
+                ),
             );
         }
 
@@ -1562,7 +1545,7 @@ test "model picker effort completion labels survive capability resolution" {
     try std.testing.expectEqualStrings("high", values[2].displayLabel());
 }
 
-test "mention skills navigation measures a width-changed queued editor before frame commit" {
+test "command skills navigation measures a width-changed queued editor before frame commit" {
     const alloc = std.testing.allocator;
     const rt = CompletionRuntime(SkillsNavigationTestApp);
     const skills = [_]skill_runtime.Skill{
@@ -1577,7 +1560,7 @@ test "mention skills navigation measures a width-changed queued editor before fr
     var app = SkillsNavigationTestApp{ .alloc = alloc };
     defer app.deinit();
     app.skills.items = @constCast(&skills);
-    app.skills.openMenuWithQuery(.dollar, .{ .start = 0, .end = 1 }, "");
+    app.skills.openMenu();
     try app.input_runtime.textReplacementState().replace(alloc, "x" ** 60);
 
     const entries = try alloc.alloc(input_queue_runtime.ReviewEntry, 2);

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -631,7 +631,7 @@ async function waitForSkillsMenuGrid(
   while (Date.now() < deadline) {
     last = await s.capturePaneGrid();
     const text = last.join("\n");
-    if (text.includes(`Skills ${count}`) && findSkillsScreen(last) !== null) {
+    if (text.includes(`Skills ${count}`) && findInlineSkillsPicker(last) !== null) {
       return last;
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -655,8 +655,7 @@ function expectSkillsMenuGrid(
   expect(text).toContain("Fx · Global");
   expect(names.some((name) => text.includes(name))).toBe(true);
   expect(text).not.toContain("Visible skills (");
-  expect(text).not.toContain("Run /help for commands");
-  expect(findSkillsScreen(grid)).not.toBeNull();
+  expect(findInlineSkillsPicker(grid)).not.toBeNull();
   expect(grid.filter(isInputRow)).toHaveLength(1);
 }
 
@@ -1039,14 +1038,18 @@ function findFooter(grid: string[]): FooterBlock | null {
   return findFooterBlocks(grid).at(-1) ?? null;
 }
 
-function findSkillsScreen(grid: string[]): { topDivider: number; header: number; bottomDivider: number; hint: number } | null {
+function findInlineSkillsPicker(
+  grid: string[],
+): { input: number; topDivider: number; header: number; bottomDivider: number; hint: number } | null {
   const header = grid.findIndex((line) => line.includes("Skills "));
-  if (header <= 0 || !isDividerRow(grid[header - 1]!)) return null;
-  if (!isInputRow(grid[0]!)) return null;
+  if (header <= 1 || !isDividerRow(grid[header - 1]!)) return null;
+  const input = header - 2;
+  if (!isInputRow(grid[input]!)) return null;
   const bottomDivider = grid.findLastIndex((line) => isDividerRow(line));
   if (bottomDivider <= header || bottomDivider + 1 >= grid.length) return null;
   if (!grid[bottomDivider + 1]!.includes("Esc Close")) return null;
   return {
+    input,
     topDivider: header - 1,
     header,
     bottomDivider,
@@ -1165,8 +1168,12 @@ async function runLargeSkillResizeAttempt(attempt: number): Promise<string> {
       cycle.newSize.rows === shrinkRows
     );
     expect(shrinkCycle.historyRowDelta).toBeGreaterThanOrEqual(0);
-    expect(attemptLine(shrinkAttempt, "attempt_result ")).toBeUndefined();
-    expect(attemptLine(shrinkAttempt, "transcript_transition_finalize ")).toBeUndefined();
+    expect(attemptLine(shrinkAttempt, "attempt_result ")).toContain(
+      "shadow_state=committed",
+    );
+    expect(attemptLine(shrinkAttempt, "transcript_transition_finalize ")).toContain(
+      "body_disposition=paint",
+    );
     expect(attemptLine(shrinkAttempt, "tmux_clear_history_complete")).toBeUndefined();
     const shrinkGrid = await waitForSkillsMenuGrid(s, LARGE_SKILL_COUNT);
     expectSkillsMenuGrid(shrinkGrid, LARGE_SKILL_COUNT, fixture.names);
@@ -1186,8 +1193,12 @@ async function runLargeSkillResizeAttempt(attempt: number): Promise<string> {
       (candidate) => attemptHasReason(candidate, "resize"),
     );
     expect(s.paneSize()).toEqual({ cols: 120, rows: 34 });
-    expect(attemptLine(growAttempt, "attempt_result ")).toBeUndefined();
-    expect(attemptLine(growAttempt, "transcript_transition_commit ")).toBeUndefined();
+    expect(attemptLine(growAttempt, "attempt_result ")).toContain(
+      "shadow_state=committed",
+    );
+    expect(attemptLine(growAttempt, "transcript_transition_commit ")).toContain(
+      "state=stable",
+    );
     const growGrid = await waitForSkillsMenuGrid(s, LARGE_SKILL_COUNT);
     expectSkillsMenuGrid(growGrid, LARGE_SKILL_COUNT, fixture.names);
     const growScrollback = await s.captureFullScrollback();
@@ -1212,7 +1223,7 @@ async function runLargeSkillResizeAttempt(attempt: number): Promise<string> {
     const scrollbackLines = scrollback.replace(/\n$/, "").split("\n").length;
     expect(scrollbackLines).toBeLessThan(historyLimit / 2);
     expect(finalGrid.filter(isInputRow)).toHaveLength(1);
-    expect(findSkillsScreen(finalGrid)).not.toBeNull();
+    expect(findInlineSkillsPicker(finalGrid)).not.toBeNull();
     expect(s.paneStatus()).toEqual({ dead: false, status: null });
     expect(s.isPaneAlive()).toBe(true);
     expect(readFileSync(stderrPath, "utf8")).toBe("");
@@ -1344,19 +1355,31 @@ async function runRapidSkillResizeAttempt(
     expect(s.paneSize()).toEqual({ cols: 120, rows: 34 });
 
     const growCommit = attemptLine(grow.attempt, "transcript_transition_commit ");
-    expect(growCommit).toBeUndefined();
+    expect(growCommit).toContain("state=stable");
     const growGrid = await waitForSkillsMenuGrid(s, RAPID_SKILL_COUNT);
     expectSkillsMenuGrid(growGrid, RAPID_SKILL_COUNT, fixture.names);
     const growScrollback = await s.captureFullScrollback();
     expectNoTranscriptSkillInventory(growScrollback);
     writeFileSync(join(fixture.root, "scrollback-after-grow.txt"), growScrollback);
 
-    expect(attemptLine(shrink.attempt, "transcript_transition_finalize ")).toBeUndefined();
-    expect(attemptLine(grow.attempt, "transcript_transition_finalize ")).toBeUndefined();
-    expect(attemptLine(shrink.attempt, "attempt_result ")).toBeUndefined();
-    expect(attemptLine(grow.attempt, "attempt_result ")).toBeUndefined();
-    expect(attemptLine(shrink.attempt, "tmux_clear_history_complete")).toBeUndefined();
-    expect(attemptLine(grow.attempt, "tmux_clear_history_complete")).toBeUndefined();
+    expect(attemptLine(shrink.attempt, "transcript_transition_finalize ")).toContain(
+      "body_disposition=paint",
+    );
+    expect(attemptLine(grow.attempt, "transcript_transition_finalize ")).toContain(
+      "body_disposition=paint",
+    );
+    expect(attemptLine(shrink.attempt, "attempt_result ")).toContain(
+      "shadow_state=committed",
+    );
+    expect(attemptLine(grow.attempt, "attempt_result ")).toContain(
+      "shadow_state=committed",
+    );
+    expect(attemptLine(shrink.attempt, "tmux_clear_history_complete")).toContain(
+      "tmux_clear_history_complete",
+    );
+    expect(attemptLine(grow.attempt, "tmux_clear_history_complete")).toContain(
+      "tmux_clear_history_complete",
+    );
 
     await s.sendKeys("C-[");
     const dismissed = await s.waitForPane(
@@ -1375,7 +1398,7 @@ async function runRapidSkillResizeAttempt(
     const finalScrollback = await s.captureFullScrollback();
     expectNoTranscriptSkillInventory(finalScrollback);
     expect(finalGrid.filter(isInputRow)).toHaveLength(1);
-    expect(findSkillsScreen(finalGrid)).not.toBeNull();
+    expect(findInlineSkillsPicker(finalGrid)).not.toBeNull();
     expect(s.paneStatus()).toEqual({ dead: false, status: null });
     expect(s.isPaneAlive()).toBe(true);
     expect(readFileSync(stderrPath, "utf8")).toBe("");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -2314,7 +2314,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
   );
 
   test(
-    "inline completions stay in the composer while leading triggers open their menus",
+    "skill and completion menus stay inline with the composer",
     async () => {
       const fixture = createSkillsMenuFixture();
       const tapePath = join(fixture.home, "dollar-inline.fxtape");
@@ -2332,6 +2332,10 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         stderrPath: fixture.stderrPath,
       });
       await session.waitForComposer(10_000);
+      const alternateCount = (sequence: string) =>
+        countOccurrences(readFileSync(tapePath).toString("latin1"), sequence);
+      const entersBeforeSkills = alternateCount("\x1b[?1049h");
+      const leavesBeforeSkills = alternateCount("\x1b[?1049l");
 
       await session.sendKeys("-l '/sk'");
       await session.waitForText("browse and manage skills", 5_000);
@@ -2341,8 +2345,10 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("Enter");
       grid = await waitForSkillsMenu(session, 4);
       const pane = grid.join("\n");
-      expect(pane).not.toContain("𝒇x");
-      expect(pane).not.toContain("Run /help for commands");
+      expect(pane).toContain("𝒇x");
+      expect(pane).toContain("Run /help for commands");
+      expect(alternateCount("\x1b[?1049h")).toBe(entersBeforeSkills);
+      expect(alternateCount("\x1b[?1049l")).toBe(leavesBeforeSkills);
       expect(pane).toContain("[All]");
       expect(pane).toContain("Fx");
       expect(pane).toContain("Workspace");
@@ -2381,8 +2387,6 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         5_000,
       );
 
-      const alternateCount = (sequence: string) =>
-        countOccurrences(readFileSync(tapePath).toString("latin1"), sequence);
       const entersBeforeDollar = alternateCount("\x1b[?1049h");
       const leavesBeforeDollar = alternateCount("\x1b[?1049l");
 
@@ -2558,6 +2562,8 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       await session.sendKeys("C-[");
       await session.waitForPane((current) => !current.includes("↑↓ Navigate"), 5_000);
+      expect(alternateCount("\x1b[?1049h")).toBe(entersBeforeSkills);
+      expect(alternateCount("\x1b[?1049l")).toBe(leavesBeforeSkills);
       await session.sendKeys("C-u");
       await session.sendText("/quit");
       expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);


### PR DESCRIPTION
## Summary

- Show `/skills` in the same six-row inline picker as `$`.
- Keep the transcript visible and avoid alternate-screen transitions for both skill entry points.
- Share navigation, resize, source filtering, and source-column behavior between them.
- Keep child skill catalogs full-screen.