### PR TITLE
Streamline subscription sign-in

### DIFF
--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -303,10 +303,12 @@ pub fn Runtime(comptime App: type) type {
 
         pub fn routeAuthPickerByte(app: *App, byte: u8) !bool {
             if (app.auth.signInEntryActive()) {
-                if (app.auth.signInCodeEntryActive()) {
+                if (byte == '\t') {
+                    _ = app.auth.toggleSignInCodeEntry();
+                } else if (app.auth.signInCodeEntryActive()) {
                     switch (byte) {
                         3, 4 => _ = app.auth.popPickerStage(app.alloc),
-                        '\r', '\n' => if (!try app.auth.submitSignInCode(app.alloc)) try openSignInBrowser(app),
+                        '\r', '\n' => _ = try app.auth.submitSignInCode(app.alloc),
                         8, 127 => _ = app.auth.deleteSignInCodeByte(),
                         else => _ = try app.auth.appendSignInCodeByte(app.alloc, byte),
                     }
@@ -1452,6 +1454,11 @@ const TestAuth = struct {
     selected_team_adopted: bool = false,
     sign_in_url: ?[]const u8 = null,
     picker_pop_count: usize = 0,
+    sign_in_entry_active: bool = false,
+    sign_in_code_entry_active: bool = false,
+    sign_in_code_toggle_count: usize = 0,
+    sign_in_code_submit_count: usize = 0,
+    sign_in_code_submit_succeeds: bool = true,
 
     fn credentialSource(self: *const TestAuth) ?credentials.Source {
         return self.active_source;
@@ -1474,6 +1481,71 @@ const TestAuth = struct {
     fn popPickerStage(self: *TestAuth, _: std.mem.Allocator) bool {
         self.picker_pop_count += 1;
         return true;
+    }
+
+    fn signInEntryActive(self: *const TestAuth) bool {
+        return self.sign_in_entry_active;
+    }
+
+    fn signInCodeEntryActive(self: *const TestAuth) bool {
+        return self.sign_in_code_entry_active;
+    }
+
+    fn toggleSignInCodeEntry(self: *TestAuth) bool {
+        self.sign_in_code_toggle_count += 1;
+        self.sign_in_code_entry_active = !self.sign_in_code_entry_active;
+        return true;
+    }
+
+    fn submitSignInCode(self: *TestAuth, _: std.mem.Allocator) !bool {
+        self.sign_in_code_submit_count += 1;
+        return self.sign_in_code_submit_succeeds;
+    }
+
+    fn deleteSignInCodeByte(_: *TestAuth) bool {
+        return true;
+    }
+
+    fn appendSignInCodeByte(_: *TestAuth, _: std.mem.Allocator, _: u8) !bool {
+        return true;
+    }
+
+    fn teamPickerActive(_: *const TestAuth) bool {
+        return false;
+    }
+
+    fn deleteTeamQueryByte(_: *TestAuth) bool {
+        return false;
+    }
+
+    fn appendTeamQueryByte(_: *TestAuth, _: std.mem.Allocator, _: u8) !bool {
+        return false;
+    }
+
+    fn apiKeyEntryActive(_: *const TestAuth) bool {
+        return false;
+    }
+
+    fn deleteApiKeyByte(_: *TestAuth) bool {
+        return false;
+    }
+
+    fn appendApiKeyByte(_: *TestAuth, _: std.mem.Allocator, _: u8) !bool {
+        return false;
+    }
+
+    fn pickerView(_: *const TestAuth) auth_runtime.PickerView {
+        return .{
+            .active = false,
+            .available_sources = .empty,
+            .selected_choice = null,
+            .active_source = null,
+            .include_skip = false,
+        };
+    }
+
+    fn beginApiKeySave(_: *TestAuth, _: std.mem.Allocator) auth_runtime.ApiKeySaveStart {
+        return .empty;
     }
 
     fn openTeamPicker(_: *TestAuth, _: std.mem.Allocator, _: *login_flow.TeamSelection) void {}
@@ -1692,6 +1764,34 @@ test "interactive sign-in opens the owned browser URL through the host" {
         "https://vercel.test/verify?code=TEST-CODE",
         app.test_url_opener.openedUrl(),
     );
+}
+
+test "interactive sign-in routes Tab to the auth-owned manual code toggle" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.auth.sign_in_entry_active = true;
+    app.auth.sign_in_url = "https://issuer.test/authorize";
+
+    try std.testing.expect(try Runtime(TestApp).routeAuthPickerByte(&app, '\t'));
+
+    try std.testing.expectEqual(@as(usize, 1), app.auth.sign_in_code_toggle_count);
+    try std.testing.expect(app.auth.sign_in_code_entry_active);
+    try std.testing.expectEqual(@as(usize, 0), app.test_url_opener.calls);
+    try std.testing.expect(app.shell.render_requests.footer_requested);
+}
+
+test "interactive manual code entry never reopens the browser on empty submit" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.auth.sign_in_entry_active = true;
+    app.auth.sign_in_code_entry_active = true;
+    app.auth.sign_in_code_submit_succeeds = false;
+    app.auth.sign_in_url = "https://issuer.test/authorize";
+
+    try std.testing.expect(try Runtime(TestApp).routeAuthPickerByte(&app, '\r'));
+
+    try std.testing.expectEqual(@as(usize, 1), app.auth.sign_in_code_submit_count);
+    try std.testing.expectEqual(@as(usize, 0), app.test_url_opener.calls);
 }
 
 test "interactive sign-in preserves manual fallback when the host launcher fails" {

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -347,7 +347,13 @@ pub fn Runtime(comptime App: type) type {
             if (!app.auth.signInEntryActive() and !app.auth.apiKeyEntryActive()) return false;
             return switch (action) {
                 .escape, .remapped_byte => false,
-                .paste_start, .paste_end => !app.auth.signInCodeEntryActive(),
+                .paste_start => blk: {
+                    if (app.auth.signInCodeEntryActive()) break :blk false;
+                    if (!app.auth.toggleSignInCodeEntry()) break :blk true;
+                    app.shell.render_requests.request(.footer);
+                    break :blk false;
+                },
+                .paste_end => !app.auth.signInCodeEntryActive(),
                 else => true,
             };
         }
@@ -1457,6 +1463,7 @@ const TestAuth = struct {
     sign_in_entry_active: bool = false,
     sign_in_code_entry_active: bool = false,
     sign_in_code_toggle_count: usize = 0,
+    sign_in_code_toggle_succeeds: bool = true,
     sign_in_code_submit_count: usize = 0,
     sign_in_code_submit_succeeds: bool = true,
 
@@ -1493,6 +1500,7 @@ const TestAuth = struct {
 
     fn toggleSignInCodeEntry(self: *TestAuth) bool {
         self.sign_in_code_toggle_count += 1;
+        if (!self.sign_in_code_toggle_succeeds) return false;
         self.sign_in_code_entry_active = !self.sign_in_code_entry_active;
         return true;
     }
@@ -1778,6 +1786,31 @@ test "interactive sign-in routes Tab to the auth-owned manual code toggle" {
     try std.testing.expect(app.auth.sign_in_code_entry_active);
     try std.testing.expectEqual(@as(usize, 0), app.test_url_opener.calls);
     try std.testing.expect(app.shell.render_requests.footer_requested);
+}
+
+test "interactive hidden manual code paste reveals entry for the paste owner" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.auth.sign_in_entry_active = true;
+
+    try std.testing.expect(!Runtime(TestApp).routeAuthPickerEscapeAction(&app, .paste_start));
+
+    try std.testing.expectEqual(@as(usize, 1), app.auth.sign_in_code_toggle_count);
+    try std.testing.expect(app.auth.sign_in_code_entry_active);
+    try std.testing.expect(app.shell.render_requests.footer_requested);
+}
+
+test "interactive sign-in without manual fallback consumes hidden paste" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.auth.sign_in_entry_active = true;
+    app.auth.sign_in_code_toggle_succeeds = false;
+
+    try std.testing.expect(Runtime(TestApp).routeAuthPickerEscapeAction(&app, .paste_start));
+
+    try std.testing.expectEqual(@as(usize, 1), app.auth.sign_in_code_toggle_count);
+    try std.testing.expect(!app.auth.sign_in_code_entry_active);
+    try std.testing.expect(!app.shell.render_requests.footer_requested);
 }
 
 test "interactive manual code entry never reopens the browser on empty submit" {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -6,6 +6,7 @@ const grok_oauth = @import("grok_oauth.zig");
 const host = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
 const login_flow = @import("login_flow.zig");
+const oauth = @import("oauth.zig");
 const model_provider = @import("../config/model_provider.zig");
 const provider_catalog = @import("provider_catalog.zig");
 const oauth_transport = @import("oauth_transport.zig");
@@ -389,6 +390,7 @@ pub const PickerView = struct {
     team_query: []const u8 = &.{},
     sign_in: login_flow.SignInSnapshot = .{},
     sign_in_source: credentials.Source = .fx_login,
+    sign_in_code_visible: bool = false,
     sign_in_code_mask_count: usize = 0,
     api_key_mask_count: usize = 0,
 
@@ -783,6 +785,7 @@ pub const Runtime = struct {
     sign_in_flow: login_flow.SignInRuntime = .{},
     sign_in_source: credentials.Source = .fx_login,
     sign_in_returns_to_root: bool = false,
+    sign_in_code_visible: bool = false,
     sign_in_code_input: std.ArrayList(u8) = .empty,
     api_key_input: std.ArrayList(u8) = .empty,
     api_key_returns_to_root: bool = false,
@@ -1011,6 +1014,7 @@ pub const Runtime = struct {
             .team_query = self.team_query.items,
             .sign_in = self.sign_in_flow.snapshot(),
             .sign_in_source = self.sign_in_source,
+            .sign_in_code_visible = self.sign_in_code_visible,
             .sign_in_code_mask_count = @min(self.sign_in_code_input.items.len, max_manual_code_mask_glyphs),
             .api_key_mask_count = @min(self.api_key_input.items.len, max_api_key_mask_glyphs),
         };
@@ -1179,6 +1183,7 @@ pub const Runtime = struct {
         self.picker_selection = null;
         self.sign_in_source = source;
         self.sign_in_returns_to_root = returns_to_root;
+        self.sign_in_code_visible = false;
         return true;
     }
 
@@ -1187,7 +1192,17 @@ pub const Runtime = struct {
     }
 
     pub fn signInCodeEntryActive(self: *const Self) bool {
-        return self.signInEntryActive() and self.sign_in_flow.snapshot().accepts_manual_code;
+        return self.signInEntryActive() and
+            self.sign_in_flow.snapshot().accepts_manual_code and
+            self.sign_in_code_visible;
+    }
+
+    pub fn toggleSignInCodeEntry(self: *Self) bool {
+        if (!self.signInEntryActive() or !self.sign_in_flow.snapshot().accepts_manual_code) {
+            return false;
+        }
+        self.sign_in_code_visible = !self.sign_in_code_visible;
+        return true;
     }
 
     pub fn signInReturnsToRoot(self: *const Self) bool {
@@ -1480,6 +1495,7 @@ pub const Runtime = struct {
 
     fn clearSignInCodeInput(self: *Self, alloc: Allocator, reason: ManualCodeClearReason) void {
         const byte_count = self.sign_in_code_input.items.len;
+        self.sign_in_code_visible = false;
         if (self.sign_in_code_input.capacity > 0) {
             secret.zeroAndFree(alloc, self.sign_in_code_input.allocatedSlice());
             self.sign_in_code_input = .empty;
@@ -3113,4 +3129,107 @@ test "api key stage zeroes its allocation on every exit path" {
         runtime.deinit(alloc);
         try expectApiKeyAllocationCleared(&runtime, &backing, sentinel);
     }
+}
+
+fn makeManualCodeTestLogin(alloc: Allocator) !login_flow.PreparedLogin {
+    const issuer = try alloc.dupe(u8, "https://issuer.test");
+    errdefer alloc.free(issuer);
+    const authorization_endpoint = try alloc.dupe(u8, "https://issuer.test/authorize");
+    errdefer alloc.free(authorization_endpoint);
+    const token_endpoint = try alloc.dupe(u8, "https://issuer.test/token");
+    errdefer alloc.free(token_endpoint);
+    const device_code = try alloc.dupe(u8, "device-code");
+    errdefer alloc.free(device_code);
+    const user_code = try alloc.dupe(u8, "");
+    errdefer alloc.free(user_code);
+    const verification_uri = try alloc.dupe(u8, "https://issuer.test/authorize");
+    errdefer alloc.free(verification_uri);
+    const client_id = try alloc.dupe(u8, "client-id");
+    errdefer alloc.free(client_id);
+    return .{
+        .metadata = .{
+            .issuer = issuer,
+            .device_authorization_endpoint = authorization_endpoint,
+            .token_endpoint = token_endpoint,
+        },
+        .device = .{
+            .device_code = device_code,
+            .user_code = user_code,
+            .verification_uri = verification_uri,
+            .expires_in = 300,
+            .interval = 1,
+        },
+        .client_id = client_id,
+    };
+}
+
+fn pendingManualCodeTestPoll(
+    _: ?*anyopaque,
+    _: Allocator,
+    _: oauth_transport.Provider,
+    _: oauth.Metadata,
+    _: []const u8,
+    _: []const u8,
+    cancel_flag: *std.atomic.Value(bool),
+    _: std.Io.Clock.Timestamp,
+) !oauth.PollResult {
+    while (!cancel_flag.load(.seq_cst)) io_mod.sleep(std.time.ns_per_ms);
+    return error.Cancelled;
+}
+
+fn acceptManualCodeForTest(_: ?*anyopaque, _: Allocator, _: []const u8) !void {}
+
+fn enterPendingTestSignIn(runtime: *Runtime, alloc: Allocator, accepts_manual_code: bool) !void {
+    const prepared = try makeManualCodeTestLogin(alloc);
+    try std.testing.expect(try runtime.sign_in_flow.startPrepared(alloc, prepared, .{
+        .poll = .{ .poll_device_token = pendingManualCodeTestPoll },
+        .submit_manual_code = if (accepts_manual_code) acceptManualCodeForTest else null,
+    }));
+    runtime.picker_active = true;
+    runtime.picker_stage = .sign_in;
+    runtime.sign_in_source = .grok_subscription;
+}
+
+test "manual code capability starts collapsed" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    try enterPendingTestSignIn(&runtime, alloc, true);
+
+    try std.testing.expect(runtime.pickerView().sign_in.accepts_manual_code);
+    try std.testing.expect(!runtime.signInCodeEntryActive());
+}
+
+test "manual code visibility preserves a draft across Tab toggles and clears it on exit" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    try enterPendingTestSignIn(&runtime, alloc, true);
+
+    try std.testing.expect(runtime.toggleSignInCodeEntry());
+    try std.testing.expect(runtime.signInCodeEntryActive());
+    for ("draft-code") |byte| try std.testing.expect(try runtime.appendSignInCodeByte(alloc, byte));
+    try std.testing.expectEqual(@as(usize, 10), runtime.pickerView().sign_in_code_mask_count);
+
+    try std.testing.expect(runtime.toggleSignInCodeEntry());
+    try std.testing.expect(!runtime.signInCodeEntryActive());
+    try std.testing.expect(!runtime.pickerView().sign_in_code_visible);
+    try std.testing.expectEqual(@as(usize, 10), runtime.pickerView().sign_in_code_mask_count);
+
+    try std.testing.expect(runtime.toggleSignInCodeEntry());
+    try std.testing.expect(runtime.signInCodeEntryActive());
+    try std.testing.expect(runtime.popPickerStage(alloc));
+    try std.testing.expect(!runtime.pickerView().sign_in_code_visible);
+    try std.testing.expectEqual(@as(usize, 0), runtime.pickerView().sign_in_code_mask_count);
+}
+
+test "manual code visibility cannot toggle without provider capability" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = .{};
+    defer runtime.deinit(alloc);
+    try enterPendingTestSignIn(&runtime, alloc, false);
+
+    try std.testing.expect(!runtime.toggleSignInCodeEntry());
+    try std.testing.expect(!runtime.pickerView().sign_in_code_visible);
+    try std.testing.expect(!runtime.signInCodeEntryActive());
 }

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const question_prompt = @import("../../core/agent/question_prompt.zig");
 const auth_runtime = @import("../../core/auth/auth_runtime.zig");
+const credentials = @import("../../core/auth/credentials.zig");
 const image_attachments = @import("../../core/images/image_attachments.zig");
 const command_specs = @import("../../core/slash_commands/command_specs.zig");
 const display_width = @import("../../core/shared/display_width.zig");
@@ -321,12 +322,38 @@ fn authPickerInteractionHint(view: auth_runtime.PickerView, width: u16) ?[]const
         "↑↓ Move  Enter  Esc",
         "Enter Esc",
     };
+    const codex_sign_in_variants = [_][]const u8{
+        "Enter reopens browser · Esc cancels",
+        "Enter reopens  Esc cancels",
+        "Enter  Esc",
+        "Enter Esc",
+    };
+    const grok_browser_variants = [_][]const u8{
+        "Enter reopens browser · Tab enters code · Esc cancels",
+        "Enter reopens  Tab code  Esc cancels",
+        "Enter  Tab  Esc",
+        "Enter Tab Esc",
+    };
+    const grok_manual_variants = [_][]const u8{
+        "Enter submits code · Tab returns to browser · Esc cancels",
+        "Enter submits  Tab browser  Esc cancels",
+        "Enter  Tab  Esc",
+        "Enter Tab Esc",
+    };
     const variants = switch (view.stage) {
         .root => root_variants,
         .connections => connections_variants,
         .provider, .switch_credential => selection_variants,
         .change_team => team_variants,
-        .sign_in, .api_key => return null,
+        .sign_in => switch (view.sign_in_source) {
+            .chatgpt_subscription => codex_sign_in_variants,
+            .grok_subscription => if (view.sign_in_code_visible)
+                grok_manual_variants
+            else
+                grok_browser_variants,
+            else => return null,
+        },
+        .api_key => return null,
     };
     for (variants) |candidate| {
         if (display_width.visibleWidth(candidate) <= width) return candidate;
@@ -1456,6 +1483,53 @@ test "compose hint row replaces model status with setup navigation" {
     var child = try composeHintRow(std.testing.allocator, false, null, ctx, 96);
     defer child.deinit(std.testing.allocator);
     try std.testing.expect(std.mem.find(u8, child.items, "Esc Back") != null);
+}
+
+test "compose hint row replaces model status with subscription sign-in controls" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        source: credentials.Source,
+        manual_code_visible: bool,
+        expected: []const u8,
+    }{
+        .{
+            .source = .chatgpt_subscription,
+            .manual_code_visible = false,
+            .expected = "Enter reopens browser · Esc cancels",
+        },
+        .{
+            .source = .grok_subscription,
+            .manual_code_visible = false,
+            .expected = "Enter reopens browser · Tab enters code · Esc cancels",
+        },
+        .{
+            .source = .grok_subscription,
+            .manual_code_visible = true,
+            .expected = "Enter submits code · Tab returns to browser · Esc cancels",
+        },
+    };
+
+    for (cases) |case| {
+        var input = InputRuntime{};
+        defer input.deinit(alloc);
+        var ctx = testRenderContext(&input);
+        ctx.model = "model-status-sentinel";
+        ctx.auth_picker = .{
+            .active = true,
+            .available_sources = .empty,
+            .selected_choice = null,
+            .active_source = null,
+            .include_skip = false,
+            .stage = .sign_in,
+            .sign_in_source = case.source,
+            .sign_in_code_visible = case.manual_code_visible,
+        };
+
+        var row = try composeHintRow(alloc, false, null, ctx, 80);
+        defer row.deinit(alloc);
+        try std.testing.expect(std.mem.find(u8, row.items, case.expected) != null);
+        try std.testing.expect(std.mem.find(u8, row.items, "model-status-sentinel") == null);
+    }
 }
 
 test "compose hint row uses dots in subagent view" {

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -11,6 +11,7 @@ const file_index = @import("../../core/workspace/file_index.zig");
 const ui_render = @import("../render.zig");
 const input_presentation = @import("input_presentation.zig");
 const row_text = @import("row_text.zig");
+const vt_emulator = @import("../../core/terminal/engine.zig");
 
 const Allocator = std.mem.Allocator;
 const team_query_prefix = "Vercel team · Search: ";
@@ -53,7 +54,13 @@ fn teamQueryProjection(query: []const u8, width: u16) TeamQueryProjection {
 }
 
 pub fn authPickerRowCount(view: auth_runtime.PickerView) u16 {
-    if (view.stage == .sign_in) return 7;
+    if (view.stage == .sign_in) {
+        return switch (view.sign_in_source) {
+            .chatgpt_subscription => 4,
+            .grok_subscription => if (view.sign_in_code_visible) 7 else 5,
+            else => 7,
+        };
+    }
     if (view.stage == .api_key) return 4;
     if (view.stage == .root and view.include_skip) return 18;
     if (isSetupListStage(view.stage)) return @intCast(2 + @max(view.choiceCount(), 1));
@@ -134,7 +141,7 @@ fn setupChoiceValue(view: auth_runtime.PickerView, choice: auth_runtime.Choice) 
     };
 }
 
-fn setupValueColumn(width: u16) usize {
+fn detailValueColumn(width: u16) usize {
     const width_usize: usize = width;
     const minimum = display_width.visibleWidth("  AI Gateway API key") + 2;
     return @min(width_usize, @max(width_usize * 2 / 3, minimum));
@@ -156,7 +163,7 @@ fn composeSetupChoiceRow(
     try row.appendSlice(alloc, style);
     try row.appendSlice(alloc, if (selected and enabled) "› " else "  ");
 
-    const value_col = setupValueColumn(width);
+    const value_col = detailValueColumn(width);
     const label_width = value_col -| 2;
     try row_text.appendSingleLineEllipsized(
         alloc,
@@ -266,14 +273,20 @@ pub noinline fn composeAuthPickerRow(
     width: u16,
 ) !std.ArrayList(u8) {
     if (view.stage == .sign_in) {
-        const source_row_index = signInProjectedRowIndex(view.sign_in, row_index, row_count);
+        const source_row_index = signInProjectedRowIndex(
+            view.sign_in,
+            view.sign_in_source,
+            view.sign_in_code_visible,
+            row_index,
+            row_count,
+        );
         return composeSignInPickerRow(
             alloc,
             view.sign_in,
             view.sign_in_source,
+            view.sign_in_code_visible,
             view.sign_in_code_mask_count,
             source_row_index,
-            row_count,
             width,
         );
     }
@@ -289,18 +302,40 @@ pub noinline fn composeAuthPickerRow(
     unreachable;
 }
 
-fn signInProjectedRowIndex(snapshot: login_flow.SignInSnapshot, row_index: u16, row_count: u16) u16 {
-    if (row_count >= 7) return row_index;
+fn signInProjectedRowIndex(
+    snapshot: login_flow.SignInSnapshot,
+    source: credentials.Source,
+    manual_code_visible: bool,
+    row_index: u16,
+    row_count: u16,
+) u16 {
+    const codex_priority = [_]u16{ 2, 0, 3, 1 };
+    if (source == .chatgpt_subscription) {
+        return prioritizedRowIndex(4, &codex_priority, row_index, row_count);
+    }
+    const grok_browser_priority = [_]u16{ 2, 3, 0, 4, 1 };
+    if (source == .grok_subscription and !manual_code_visible) {
+        return prioritizedRowIndex(5, &grok_browser_priority, row_index, row_count);
+    }
 
-    const manual_code_priority = [_]u16{ 4, 6, 3, 0, 2, 5, 1 };
+    const manual_code_priority = [_]u16{ 5, 4, 2, 0, 6, 3, 1 };
     const device_code_priority = [_]u16{ 2, 3, 6, 0, 5, 1, 4 };
     const priority = if (snapshot.accepts_manual_code)
-        manual_code_priority
+        &manual_code_priority
     else
-        device_code_priority;
+        &device_code_priority;
+    return prioritizedRowIndex(7, priority, row_index, row_count);
+}
 
+fn prioritizedRowIndex(
+    source_row_count: u16,
+    priority: []const u16,
+    row_index: u16,
+    row_count: u16,
+) u16 {
+    if (row_count >= source_row_count) return row_index;
     var projected_index: u16 = 0;
-    for (0..7) |source_row| {
+    for (0..source_row_count) |source_row| {
         for (priority[0..@min(row_count, priority.len)]) |included_row| {
             if (source_row != included_row) continue;
             if (projected_index == row_index) return @intCast(source_row);
@@ -308,7 +343,7 @@ fn signInProjectedRowIndex(snapshot: login_flow.SignInSnapshot, row_index: u16, 
             break;
         }
     }
-    return 6;
+    return source_row_count -| 1;
 }
 
 const onboarding_note = "   ⚠︎ Note: fx is experimental and defaults to auto mode.";
@@ -391,9 +426,9 @@ fn composeSignInPickerRow(
     alloc: Allocator,
     snapshot: login_flow.SignInSnapshot,
     source: credentials.Source,
+    manual_code_visible: bool,
     manual_code_mask_count: usize,
     row_index: u16,
-    row_count: u16,
     width: u16,
 ) !std.ArrayList(u8) {
     var row: std.ArrayList(u8) = .empty;
@@ -401,50 +436,107 @@ fn composeSignInPickerRow(
     if (width == 0) return row;
     const accepts_manual_code = snapshot.accepts_manual_code;
 
-    try row.appendSlice(
-        alloc,
-        if ((accepts_manual_code and row_index == 4) or
-            (!accepts_manual_code and (row_index == 2 or row_index == 3)))
-            ui_render.selected_completion_style
-        else
-            ui_render.dim_style,
-    );
-    if (row_index == 2 and source == .chatgpt_subscription) {
-        const prefix = "   Open   ";
+    const subscription_source = source == .chatgpt_subscription or source == .grok_subscription;
+    if (subscription_source and row_index == 0) {
+        try row.appendSlice(alloc, ui_render.dim_style);
+        const value_col = detailValueColumn(width);
+        try row_text.appendSingleLineEllipsized(
+            alloc,
+            &row,
+            if (source == .chatgpt_subscription) "Sign in with Codex" else "Sign in with Grok",
+            value_col,
+        );
+        if (value_col < width) {
+            try row_text.appendSpacesToColumn(alloc, &row, value_col);
+            const status = switch (snapshot.state) {
+                .idle => "Preparing sign-in…",
+                .polling => "Waiting for authorization…",
+                .succeeded => "Authorization complete",
+                .failed => "Sign-in failed",
+                .cancelled => "Sign-in cancelled",
+            };
+            try row_text.appendSingleLineEllipsized(
+                alloc,
+                &row,
+                status,
+                @as(usize, width) - value_col,
+            );
+        }
+        try row.appendSlice(alloc, ui_render.reset_style);
+        return row;
+    }
+
+    if (subscription_source and row_index == 2) {
+        try row.appendSlice(alloc, ui_render.selected_completion_style);
+        const prefix = "  Open   ";
         try row_text.appendClipped(alloc, &row, prefix, width);
         const used: u16 = @intCast(@min(display_width.visibleWidth(prefix), width));
         const remaining = width -| used;
         if (remaining > 0) {
-            try row.appendSlice(alloc, "\x1b]8;id=fx-codex-auth;");
+            try row.appendSlice(
+                alloc,
+                if (source == .chatgpt_subscription)
+                    "\x1b]8;id=fx-codex-auth;"
+                else
+                    "\x1b]8;id=fx-grok-auth;",
+            );
             try row.appendSlice(alloc, snapshot.verification_uri);
             try row.appendSlice(alloc, "\x1b\\\x1b[4m");
-            try row_text.appendClipped(alloc, &row, "Authorize with Codex", remaining);
+            try row_text.appendClipped(
+                alloc,
+                &row,
+                if (source == .chatgpt_subscription) "Authorize with Codex" else "Authorize with Grok",
+                remaining,
+            );
             try row.appendSlice(alloc, "\x1b[24m\x1b]8;;\x1b\\");
         }
         try row.appendSlice(alloc, ui_render.reset_style);
         return row;
     }
-    if (accepts_manual_code and row_index == 3) {
-        try row_text.appendClipped(alloc, &row, "   Paste the code shown by xAI if the browser doesn't return", width);
+
+    if (source == .grok_subscription and !manual_code_visible) {
+        try row.appendSlice(alloc, ui_render.dim_style);
+        if (row_index == 3) {
+            try row_text.appendClipped(
+                alloc,
+                &row,
+                "  Browser didn't return? Press Tab to enter a code",
+                width,
+            );
+        }
         try row.appendSlice(alloc, ui_render.reset_style);
         return row;
     }
-    if (accepts_manual_code and row_index == 4) {
-        try row_text.appendClipped(alloc, &row, "   ┃ ", width);
-        var used: u16 = @min(5, width);
+
+    try row.appendSlice(
+        alloc,
+        if ((accepts_manual_code and row_index == 5) or
+            (!accepts_manual_code and (row_index == 2 or row_index == 3)))
+            ui_render.selected_completion_style
+        else
+            ui_render.dim_style,
+    );
+    if (source == .grok_subscription and manual_code_visible and row_index == 4) {
+        try row_text.appendClipped(alloc, &row, "  Paste the code shown by xAI", width);
+        try row.appendSlice(alloc, ui_render.reset_style);
+        return row;
+    }
+    if (source == .grok_subscription and manual_code_visible and row_index == 5) {
+        const prefix = "  ┃ ";
+        try row_text.appendClipped(alloc, &row, prefix, width);
+        const used: u16 = @intCast(@min(display_width.visibleWidth(prefix), width));
         if (manual_code_mask_count == 0) {
             try row.appendSlice(alloc, ui_render.dim_style);
             const placeholder = "Paste or type the code";
             try row_text.appendClipped(alloc, &row, placeholder, width -| used);
-            used +|= @intCast(@min(display_width.visibleWidth(placeholder), width -| used));
         } else {
             const visible_mask_count = @min(manual_code_mask_count, width -| used);
             for (0..visible_mask_count) |_| try row.appendSlice(alloc, "•");
-            used +|= @intCast(visible_mask_count);
         }
-        if (row_count == 1 and used < width) {
-            try row_text.appendClipped(alloc, &row, " · Enter submits · Esc cancels", width - used);
-        }
+        try row.appendSlice(alloc, ui_render.reset_style);
+        return row;
+    }
+    if (source == .grok_subscription and manual_code_visible and row_index == 6) {
         try row.appendSlice(alloc, ui_render.reset_style);
         return row;
     }
@@ -2122,7 +2214,7 @@ test "sign-in stage renders the complete device authorization screen" {
 test "Codex sign-in stage renders a bounded clickable authorization action" {
     const alloc = std.testing.allocator;
     const url = "https://auth.openai.test/oauth/authorize?response_type=code&client_id=test&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&state=full-state";
-    var view = auth_runtime.PickerView{
+    const view = auth_runtime.PickerView{
         .active = true,
         .available_sources = .empty,
         .selected_choice = null,
@@ -2138,25 +2230,198 @@ test "Codex sign-in stage renders a bounded clickable authorization action" {
 
     var row = try composeAuthPickerRow(alloc, view, 2, authPickerRowCount(view), 40);
     defer row.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, row.items, "   Open   ") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "  Open   ") != null);
     try std.testing.expect(std.mem.find(u8, row.items, "Authorize with Codex") != null);
     try std.testing.expect(std.mem.find(u8, row.items, "\x1b]8;") != null);
     try std.testing.expect(std.mem.find(u8, row.items, url) != null);
     try std.testing.expect(std.mem.find(u8, row.items, "\x1b]8;;\x1b\\") != null);
     try std.testing.expect(display_width.visibleWidthIgnoringAnsi(row.items) <= 40);
-
-    view.sign_in.accepts_manual_code = true;
-    view.sign_in_code_mask_count = 3;
-    var manual = try composeAuthPickerRow(alloc, view, 4, authPickerRowCount(view), 40);
-    defer manual.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, manual.items, "•••") != null);
-    try std.testing.expect(std.mem.find(u8, manual.items, ui_render.selected_completion_style) != null);
-    var hint = try composeAuthPickerRow(alloc, view, 6, authPickerRowCount(view), 80);
-    defer hint.deinit(alloc);
-    try std.testing.expect(std.mem.find(u8, hint.items, "Enter submits or reopens browser") != null);
 }
 
-test "compact Grok sign-in keeps masked code entry and controls visible" {
+fn composeAuthPickerTestGrid(
+    alloc: Allocator,
+    view: auth_runtime.PickerView,
+    width: u16,
+) !vt_emulator.Grid {
+    const row_count = authPickerRowCount(view);
+    var screen: std.ArrayList(u8) = .empty;
+    defer screen.deinit(alloc);
+    for (0..row_count) |row_index| {
+        if (row_index > 0) try screen.appendSlice(alloc, "\r\n");
+        var row = try composeAuthPickerRow(alloc, view, @intCast(row_index), row_count, width);
+        defer row.deinit(alloc);
+        try screen.appendSlice(alloc, row.items);
+    }
+
+    var grid = try vt_emulator.Grid.init(alloc, width, row_count);
+    errdefer grid.deinit();
+    try grid.feed(screen.items);
+    return grid;
+}
+
+test "Codex sign-in projects the compact aligned footer through the VT emulator" {
+    const alloc = std.testing.allocator;
+    const url = "https://issuer.test/oauth/authorize?state=codex-state";
+    const view = auth_runtime.PickerView{
+        .active = true,
+        .available_sources = .empty,
+        .selected_choice = null,
+        .active_source = null,
+        .include_skip = false,
+        .stage = .sign_in,
+        .sign_in_source = .chatgpt_subscription,
+        .sign_in = .{
+            .state = .polling,
+            .verification_uri = url,
+        },
+    };
+
+    try std.testing.expectEqual(@as(u16, 4), authPickerRowCount(view));
+    var grid = try composeAuthPickerTestGrid(alloc, view, 80);
+    defer grid.deinit();
+
+    var row: std.ArrayList(u8) = .empty;
+    defer row.deinit(alloc);
+    try grid.rowTextTrimmed(1, &row);
+    try std.testing.expectEqualStrings(
+        "Sign in with Codex                                   Waiting for authorization…",
+        row.items,
+    );
+    row.clearRetainingCapacity();
+    try grid.rowTextTrimmed(2, &row);
+    try std.testing.expectEqualStrings("", row.items);
+    row.clearRetainingCapacity();
+    try grid.rowTextTrimmed(3, &row);
+    try std.testing.expectEqualStrings("  Open   Authorize with Codex", row.items);
+    row.clearRetainingCapacity();
+    try grid.rowTextTrimmed(4, &row);
+    try std.testing.expectEqualStrings("", row.items);
+
+    const link_cell = grid.cellAt(3, 10).?;
+    try std.testing.expect(link_cell.style.hyperlink_id != 0);
+    try std.testing.expectEqualStrings(url, grid.hyperlinkUrl(link_cell.style.hyperlink_id).?);
+}
+
+test "Grok sign-in starts with the collapsed browser flow in the VT emulator" {
+    const alloc = std.testing.allocator;
+    const url = "https://auth.x.ai/oauth2/authorize?state=grok-state";
+    const view = auth_runtime.PickerView{
+        .active = true,
+        .available_sources = .empty,
+        .selected_choice = null,
+        .active_source = null,
+        .include_skip = false,
+        .stage = .sign_in,
+        .sign_in_source = .grok_subscription,
+        .sign_in = .{
+            .state = .polling,
+            .verification_uri = url,
+            .accepts_manual_code = true,
+        },
+    };
+
+    try std.testing.expectEqual(@as(u16, 5), authPickerRowCount(view));
+    var grid = try composeAuthPickerTestGrid(alloc, view, 80);
+    defer grid.deinit();
+
+    var row: std.ArrayList(u8) = .empty;
+    defer row.deinit(alloc);
+    const expected_rows = [_][]const u8{
+        "Sign in with Grok                                    Waiting for authorization…",
+        "",
+        "  Open   Authorize with Grok",
+        "  Browser didn't return? Press Tab to enter a code",
+        "",
+    };
+    for (expected_rows, 1..) |expected, row_index| {
+        row.clearRetainingCapacity();
+        try grid.rowTextTrimmed(@intCast(row_index), &row);
+        try std.testing.expectEqualStrings(expected, row.items);
+    }
+
+    const link_cell = grid.cellAt(3, 10).?;
+    try std.testing.expect(link_cell.style.hyperlink_id != 0);
+    try std.testing.expectEqualStrings(url, grid.hyperlinkUrl(link_cell.style.hyperlink_id).?);
+}
+
+test "Grok manual fallback projects the approved expanded layout through the VT emulator" {
+    const alloc = std.testing.allocator;
+    const url = "https://auth.x.ai/oauth2/authorize?state=grok-manual-state";
+    const view = auth_runtime.PickerView{
+        .active = true,
+        .available_sources = .empty,
+        .selected_choice = null,
+        .active_source = null,
+        .include_skip = false,
+        .stage = .sign_in,
+        .sign_in_source = .grok_subscription,
+        .sign_in = .{
+            .state = .polling,
+            .verification_uri = url,
+            .accepts_manual_code = true,
+        },
+        .sign_in_code_visible = true,
+    };
+
+    try std.testing.expectEqual(@as(u16, 7), authPickerRowCount(view));
+    var grid = try composeAuthPickerTestGrid(alloc, view, 80);
+    defer grid.deinit();
+
+    var row: std.ArrayList(u8) = .empty;
+    defer row.deinit(alloc);
+    const expected_rows = [_][]const u8{
+        "Sign in with Grok                                    Waiting for authorization…",
+        "",
+        "  Open   Authorize with Grok",
+        "",
+        "  Paste the code shown by xAI",
+        "  ┃ Paste or type the code",
+        "",
+    };
+    for (expected_rows, 1..) |expected, row_index| {
+        row.clearRetainingCapacity();
+        try grid.rowTextTrimmed(@intCast(row_index), &row);
+        try std.testing.expectEqualStrings(expected, row.items);
+    }
+
+    const link_cell = grid.cellAt(3, 10).?;
+    try std.testing.expect(link_cell.style.hyperlink_id != 0);
+    try std.testing.expectEqualStrings(url, grid.hyperlinkUrl(link_cell.style.hyperlink_id).?);
+}
+
+test "compact subscription browser sign-in prioritizes the authorization action" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        source: credentials.Source,
+        label: []const u8,
+    }{
+        .{ .source = .chatgpt_subscription, .label = "Authorize with Codex" },
+        .{ .source = .grok_subscription, .label = "Authorize with Grok" },
+    };
+
+    for (cases) |case| {
+        const view = auth_runtime.PickerView{
+            .active = true,
+            .available_sources = .empty,
+            .selected_choice = null,
+            .active_source = null,
+            .include_skip = false,
+            .stage = .sign_in,
+            .sign_in_source = case.source,
+            .sign_in = .{
+                .state = .polling,
+                .verification_uri = "https://issuer.test/authorize",
+                .accepts_manual_code = case.source == .grok_subscription,
+            },
+        };
+
+        var row = try composeAuthPickerRow(alloc, view, 0, 1, 80);
+        defer row.deinit(alloc);
+        try std.testing.expect(std.mem.find(u8, row.items, case.label) != null);
+    }
+}
+
+test "compact Grok sign-in keeps masked code entry without duplicate controls" {
     const alloc = std.testing.allocator;
     const view = auth_runtime.PickerView{
         .active = true,
@@ -2171,14 +2436,15 @@ test "compact Grok sign-in keeps masked code entry and controls visible" {
             .verification_uri = "https://x.ai/authorize",
             .accepts_manual_code = true,
         },
+        .sign_in_code_visible = true,
         .sign_in_code_mask_count = 3,
     };
 
     var row = try composeAuthPickerRow(alloc, view, 0, 1, 80);
     defer row.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, row.items, "•••") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Enter submits") != null);
-    try std.testing.expect(std.mem.find(u8, row.items, "Esc cancels") != null);
+    try std.testing.expect(std.mem.find(u8, row.items, "Enter submits") == null);
+    try std.testing.expect(std.mem.find(u8, row.items, "Esc cancels") == null);
     try std.testing.expect(std.mem.find(u8, row.items, ui_render.selected_completion_style) != null);
 }
 

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -440,26 +440,30 @@ fn composeSignInPickerRow(
     if (subscription_source and row_index == 0) {
         try row.appendSlice(alloc, ui_render.dim_style);
         const value_col = detailValueColumn(width);
+        const status = switch (snapshot.state) {
+            .idle => "Preparing sign-in…",
+            .polling => "Waiting for authorization…",
+            .succeeded => "Authorization complete",
+            .failed => "Sign-in failed",
+            .cancelled => "Sign-in cancelled",
+        };
+        const status_col = @max(
+            value_col,
+            @as(usize, width) -| display_width.visibleWidth(status),
+        );
         try row_text.appendSingleLineEllipsized(
             alloc,
             &row,
             if (source == .chatgpt_subscription) "Sign in with Codex" else "Sign in with Grok",
             value_col,
         );
-        if (value_col < width) {
-            try row_text.appendSpacesToColumn(alloc, &row, value_col);
-            const status = switch (snapshot.state) {
-                .idle => "Preparing sign-in…",
-                .polling => "Waiting for authorization…",
-                .succeeded => "Authorization complete",
-                .failed => "Sign-in failed",
-                .cancelled => "Sign-in cancelled",
-            };
+        if (status_col < width) {
+            try row_text.appendSpacesToColumn(alloc, &row, status_col);
             try row_text.appendSingleLineEllipsized(
                 alloc,
                 &row,
                 status,
-                @as(usize, width) - value_col,
+                @as(usize, width) - status_col,
             );
         }
         try row.appendSlice(alloc, ui_render.reset_style);
@@ -2284,7 +2288,7 @@ test "Codex sign-in projects the compact aligned footer through the VT emulator"
     defer row.deinit(alloc);
     try grid.rowTextTrimmed(1, &row);
     try std.testing.expectEqualStrings(
-        "Sign in with Codex                                   Waiting for authorization…",
+        "Sign in with Codex                                    Waiting for authorization…",
         row.items,
     );
     row.clearRetainingCapacity();
@@ -2327,7 +2331,7 @@ test "Grok sign-in starts with the collapsed browser flow in the VT emulator" {
     var row: std.ArrayList(u8) = .empty;
     defer row.deinit(alloc);
     const expected_rows = [_][]const u8{
-        "Sign in with Grok                                    Waiting for authorization…",
+        "Sign in with Grok                                     Waiting for authorization…",
         "",
         "  Open   Authorize with Grok",
         "  Browser didn't return? Press Tab to enter a code",
@@ -2370,7 +2374,7 @@ test "Grok manual fallback projects the approved expanded layout through the VT 
     var row: std.ArrayList(u8) = .empty;
     defer row.deinit(alloc);
     const expected_rows = [_][]const u8{
-        "Sign in with Grok                                    Waiting for authorization…",
+        "Sign in with Grok                                     Waiting for authorization…",
         "",
         "  Open   Authorize with Grok",
         "",

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -662,31 +662,36 @@ async function completeDisplayedGrokLogin(
   activeSession: TmuxSession,
   fixture: ReturnType<typeof startFakeGrokOAuth>,
 ) {
-  await activeSession.resizeWindow(500, 20);
-  const pane = await activeSession.waitForPane(
-    (value) => value.includes(`${fixture.baseUrl}/oauth2/authorize?`),
-    TIMEOUT,
+  await completeDisplayedSubscriptionLogin(
+    activeSession,
+    "Authorize with Grok",
+    `${fixture.baseUrl}/oauth2/authorize?`,
   );
-  const authorizationUrl = pane
-    .split(/\s+/)
-    .find((value) => value.startsWith(`${fixture.baseUrl}/oauth2/authorize?`));
-  if (!authorizationUrl) throw new Error("Grok authorization URL was not rendered");
-  const response = await fetch(authorizationUrl, { redirect: "follow" });
-  expect(response.status).toBe(200);
-  await activeSession.resizeWindow(100, 30);
 }
 
 async function completeDisplayedCodexLogin(
   activeSession: TmuxSession,
   fixture: ReturnType<typeof startFakeChatGptOAuth>,
 ) {
-  await activeSession.waitForText("Authorize with Codex", TIMEOUT);
+  await completeDisplayedSubscriptionLogin(
+    activeSession,
+    "Authorize with Codex",
+    `${fixture.baseUrl}/oauth/authorize?`,
+  );
+}
+
+async function completeDisplayedSubscriptionLogin(
+  activeSession: TmuxSession,
+  label: string,
+  authorizationUrlPrefix: string,
+) {
+  await activeSession.waitForText(label, TIMEOUT);
   const escapes = await activeSession.capturePaneEscapes();
-  const urlStart = escapes.indexOf(`${fixture.baseUrl}/oauth/authorize?`);
+  const urlStart = escapes.indexOf(authorizationUrlPrefix);
   const linkStart = escapes.lastIndexOf("\x1b]8;", urlStart);
   const urlEnd = escapes.indexOf("\x1b\\", urlStart);
   if (urlStart < 0 || linkStart < 0 || urlEnd < 0) {
-    throw new Error("Codex authorization hyperlink was not rendered");
+    throw new Error(`${label} hyperlink was not rendered`);
   }
   const authorizationUrl = escapes.slice(urlStart, urlEnd);
   const response = await fetch(authorizationUrl, { redirect: "follow" });
@@ -1099,6 +1104,9 @@ tmuxTest(
         pane.includes("Enter reopens browser · Esc cancels"),
       TIMEOUT,
     );
+    expect(signInScreen).toMatch(/^Sign in with Codex\s+Waiting for authorization…$/m);
+    expect(signInScreen).toMatch(/^  Open\s+Authorize with Codex$/m);
+    expect(signInScreen).toMatch(/^Enter reopens browser · Esc cancels$/m);
     expect(signInScreen).not.toContain("Code   ");
     expect(signInScreen).not.toContain(`${chatgptOauth.baseUrl}/oauth/authorize?`);
     const signInEscapes = await session.capturePaneEscapes();
@@ -2482,6 +2490,17 @@ tmuxTest(
       await session.sendKeys("Down");
       await session.sendKeys("Down");
       await session.sendKeys("Enter");
+      const collapsed = await session.waitForPane(
+        (pane) =>
+          pane.includes("Authorize with Grok") &&
+          pane.includes("Browser didn't return? Press Tab to enter a code") &&
+          pane.includes("Enter reopens browser · Tab enters code · Esc cancels"),
+        TIMEOUT,
+      );
+      expect(collapsed).toMatch(/^Sign in with Grok\s+Waiting for authorization…$/m);
+      expect(collapsed).toMatch(/^  Open\s+Authorize with Grok$/m);
+      expect(collapsed).not.toContain("Paste or type the code");
+      expect(collapsed).not.toContain(`${grok.baseUrl}/oauth2/authorize?`);
       await completeDisplayedGrokLogin(session, grok);
       await session.waitForText("Switched to Grok subscription with grok-4.20.", TIMEOUT);
       await session.sendText("Answer from Grok.");
@@ -2544,7 +2563,11 @@ tmuxTest(
       await session.sendKeys("Down");
       await session.sendKeys("Down");
       await session.sendKeys("Enter");
+      await session.waitForText("Browser didn't return? Press Tab to enter a code", TIMEOUT);
+      await session.sendKeys("Tab");
       await session.waitForText("Paste the code shown by xAI", TIMEOUT);
+      const expanded = await session.capturePane();
+      expect(expanded).toMatch(/^  Open\s+Authorize with Grok\n\s*\n  Paste the code shown by xAI$/m);
       await session.resizeWindow(80, 5);
       const compactEntry = await session.waitForPane(
         (pane) =>
@@ -2555,6 +2578,14 @@ tmuxTest(
       );
       expect(compactEntry).not.toContain("Paste the code shown by xAI");
       await session.pasteText("grok-code");
+      await session.waitForPane(
+        (pane) => pane.includes("•••••••••") && pane.includes("Enter submits"),
+        TIMEOUT,
+      );
+      await session.sendKeys("Tab");
+      const collapsedWithDraft = await session.waitForText("Tab enters code", TIMEOUT);
+      expect(collapsedWithDraft).not.toContain("•••••••••");
+      await session.sendKeys("Tab");
       await session.waitForPane(
         (pane) => pane.includes("•••••••••") && pane.includes("Enter submits"),
         TIMEOUT,

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -2544,7 +2544,7 @@ tmuxTest(
 );
 
 tmuxTest(
-  "interactive Grok login accepts a bracketed-paste authorization code",
+  "interactive Grok login auto-expands for a bracketed-paste authorization code",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-grok-tui-code-"));
     stderrPath = join(home, "stderr.log");
@@ -2564,24 +2564,22 @@ tmuxTest(
       await session.sendKeys("Down");
       await session.sendKeys("Enter");
       await session.waitForText("Browser didn't return? Press Tab to enter a code", TIMEOUT);
-      await session.sendKeys("Tab");
-      await session.waitForText("Paste the code shown by xAI", TIMEOUT);
-      const expanded = await session.capturePane();
-      expect(expanded).toMatch(/^  Open\s+Authorize with Grok\n\s*\n  Paste the code shown by xAI$/m);
-      await session.resizeWindow(80, 5);
-      const compactEntry = await session.waitForPane(
-        (pane) =>
-          pane.includes("Paste or type the code") &&
-          pane.includes("Enter submits") &&
-          pane.includes("Esc cancels"),
-        TIMEOUT,
-      );
-      expect(compactEntry).not.toContain("Paste the code shown by xAI");
       await session.pasteText("grok-code");
       await session.waitForPane(
         (pane) => pane.includes("•••••••••") && pane.includes("Enter submits"),
         TIMEOUT,
       );
+      const expanded = await session.capturePane();
+      expect(expanded).toMatch(/^  Open\s+Authorize with Grok\n\s*\n  Paste the code shown by xAI$/m);
+      await session.resizeWindow(80, 5);
+      const compactEntry = await session.waitForPane(
+        (pane) =>
+          pane.includes("•••••••••") &&
+          pane.includes("Enter submits") &&
+          pane.includes("Esc cancels"),
+        TIMEOUT,
+      );
+      expect(compactEntry).not.toContain("Paste the code shown by xAI");
       await session.sendKeys("Tab");
       const collapsedWithDraft = await session.waitForText("Tab enters code", TIMEOUT);
       expect(collapsedWithDraft).not.toContain("•••••••••");


### PR DESCRIPTION
## Summary

- Align Codex and Grok sign-in titles and status with Setup.
- Show labeled terminal authorization links for Codex and Grok.
- Keep Grok manual code entry collapsed by default and preserve drafts when switching views.
- Reveal Grok manual code entry when a code is pasted before pressing Tab.
- Move sign-in controls below the divider.
- Keep authorization actions and code entry visible in compact terminals.