### PR TITLE
Record Codex and Grok usage in the durable ledger

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -135,7 +135,7 @@ pub const agent_stream_provider = agent_stream_provider_contract.Provider{
 };
 
 pub const provider_bundle = provider_set.Bundle{
-    .capabilities = .{ .fx_search = true, .vision_fallback = true, .deferred_usage = true },
+    .capabilities = .{ .fx_search = true, .vision_fallback = true },
     .presentation = provider_catalog.find(.gateway),
     .auth_strategy = .vercel,
     .fallback_model_capabilities_fn = vercel_model_policy.capabilitiesForModel,
@@ -567,7 +567,7 @@ fn gatewayUsageOutcome(
     const reference = gatewayUsageReference(request, completion) orelse
         return .{ .unavailable = .possibly_billed };
     return if (completion.billing != null)
-        .{ .immediate = reference }
+        .{ .exact = .gateway }
     else
         .{ .deferred = reference };
 }
@@ -1062,7 +1062,7 @@ fn gatewayWorkerUsageOutcome(
         ),
     };
     return if (completion.billing != null)
-        .{ .immediate = reference }
+        .{ .exact = .gateway }
     else
         .{ .deferred = reference };
 }

--- a/src/builtins/gateway/permission_reviewer.zig
+++ b/src/builtins/gateway/permission_reviewer.zig
@@ -240,7 +240,7 @@ fn usageOutcome(
         ),
     };
     return if (completion.billing != null)
-        .{ .immediate = reference }
+        .{ .exact = .gateway }
     else
         .{ .deferred = reference };
 }

--- a/src/core/agent/runtime/config.zig
+++ b/src/core/agent/runtime/config.zig
@@ -37,7 +37,6 @@ pub const Config = struct {
     provider_capabilities: provider_set.Bundle.Capabilities = .{
         .fx_search = true,
         .vision_fallback = true,
-        .deferred_usage = true,
     },
     custom_tool_guidance: []const u8 = "",
     agent_step_limit: usize,

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -340,7 +340,7 @@ test "possibly sent gateway failure marks billing incomplete" {
     try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
 }
 
-test "provider-local immediate usage bypasses durable Gateway observations" {
+test "provider-local exact usage reaches session accounting" {
     const LocalProvider = struct {
         calls: usize = 0,
 
@@ -356,10 +356,21 @@ test "provider-local immediate usage bypasses durable Gateway observations" {
             return .{ .completed = .{
                 .completion = .{
                     .generation_id = "resp_provider_local",
+                    .billing = .{
+                        .created_at_ms = 1,
+                        .model = "codex/gpt-test",
+                        .total_cost = 0,
+                        .input_tokens = 3,
+                        .output_tokens = 1,
+                        .cache_read_tokens = 0,
+                        .cache_write_tokens = 0,
+                        .reasoning_tokens = null,
+                        .billable_web_search_calls = 0,
+                    },
                     .finish_reason = .stop,
                     .usage = .{ .input_tokens = 3, .output_tokens = 1 },
                 },
-                .usage = .{ .immediate = null },
+                .usage = .{ .exact = .codex },
             } };
         }
     };
@@ -378,45 +389,49 @@ test "provider-local immediate usage bypasses durable Gateway observations" {
     var cancel_flag = std.atomic.Value(bool).init(false);
     var callback_ctx: u8 = 0;
 
-    for (0..65) |_| {
-        var delivery = DeliveryCertainty.init();
-        var attempt_evidence: AttemptEvidence = .{};
-        var result = try streamModelCompletion(
-            provider,
-            alloc,
-            .{
-                .credential = .{
-                    .secret = "subscription-token",
-                    .source = .chatgpt_subscription,
-                    .account_id = "acct_test",
-                },
-                .session_id = "session-test",
-                .model = "gpt-test",
-                .retry_count = 1,
-                .messages = &.{},
-                .tool_choice = .auto,
-                .provider_options = .{},
-                .trace_ctx = .{},
-                .content_capture_limit = null,
-                .delivery = &delivery,
-                .attempt_evidence = &attempt_evidence,
-                .events = .{ .context = &callback_ctx, .emit_fn = Callbacks.event },
-                .cancel_flag = &cancel_flag,
-                .provider_attempt_owner = .agent,
+    var delivery = DeliveryCertainty.init();
+    var attempt_evidence: AttemptEvidence = .{};
+    var result = try streamModelCompletion(
+        provider,
+        alloc,
+        .{
+            .credential = .{
+                .secret = "subscription-token",
+                .source = .chatgpt_subscription,
+                .account_id = "acct_test",
             },
-            null,
-            alloc,
-        );
-        defer result.deinit(alloc);
-        try std.testing.expect(std.meta.activeTag(result) == .completed);
-    }
+            .session_id = "session-test",
+            .model = "gpt-test",
+            .retry_count = 1,
+            .messages = &.{},
+            .tool_choice = .auto,
+            .provider_options = .{},
+            .trace_ctx = .{},
+            .content_capture_limit = null,
+            .delivery = &delivery,
+            .attempt_evidence = &attempt_evidence,
+            .events = .{ .context = &callback_ctx, .emit_fn = Callbacks.event },
+            .cancel_flag = &cancel_flag,
+            .provider_attempt_owner = .agent,
+        },
+        &usage,
+        alloc,
+    );
+    defer result.deinit(alloc);
+    try std.testing.expect(std.meta.activeTag(result) == .completed);
 
-    try std.testing.expectEqual(@as(usize, 65), local_provider.calls);
+    try std.testing.expectEqual(@as(usize, 1), local_provider.calls);
     var snapshot = try usage.snapshot(alloc);
     defer snapshot.deinit(alloc);
     try std.testing.expectEqual(session_usage.Availability.complete, snapshot.billing);
     try std.testing.expect(snapshot.api_duration_complete);
-    try std.testing.expectEqual(@as(u64, 1), snapshot.next_sequence);
-    try std.testing.expectEqual(@as(u64, 0), snapshot.settled_through_sequence);
+    try std.testing.expectEqual(@as(u64, 2), snapshot.next_sequence);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
+    try std.testing.expectEqual(@as(u64, 3), snapshot.input_tokens);
+    try std.testing.expectEqual(@as(u64, 1), snapshot.output_tokens);
+    try std.testing.expectEqual(@as(?u64, 1), snapshot.request_count);
+    try std.testing.expectEqual(@as(usize, 1), snapshot.models.len);
+    try std.testing.expectEqualStrings("codex/gpt-test", snapshot.models[0].model);
     try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
+    try std.testing.expectEqual(@as(usize, 0), snapshot.publication_backlog.len);
 }

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3142,7 +3142,7 @@ fn processQueuedPromptLoop(
                 deps.agent_stream_provider,
                 arena,
                 model_request,
-                if (config.provider_capabilities.deferred_usage) deps.usage else null,
+                deps.usage,
                 deps.usage_allocator,
             ) catch |err| {
                 parent_turn_delivery.observeGatewayDelivery(

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -6,6 +6,7 @@ const token_estimate = @import("../../../shared/token_estimate.zig");
 const worker_runtime = @import("../../worker_runtime.zig");
 const session_runtime = @import("../../../session/session.zig");
 const session_codec = @import("../../../session/session_codec.zig");
+const session_usage = @import("../../../session/session_usage.zig");
 const model_capabilities = @import("../../../config/model_capabilities.zig");
 const debug_trace = @import("../../../shared/debug_trace.zig");
 const image_attachments = @import("../../../images/image_attachments.zig");
@@ -171,6 +172,46 @@ test "processQueuedPrompt projects lifecycle session identity to the provider" {
         "session-provider-123",
         gateway.request_session_ids.items[0].?,
     );
+}
+
+test "processQueuedPrompt accounts exact direct-provider usage without deferred capability" {
+    const alloc = std.testing.allocator;
+    const completions = [_]FakeCompletion{.{
+        .content = "ok",
+        .generation_id = "response-codex-1",
+        .billing = .{
+            .created_at_ms = 1,
+            .model = "codex/gpt-test",
+            .total_cost = 0,
+            .input_tokens = 17,
+            .output_tokens = 7,
+            .cache_read_tokens = 0,
+            .cache_write_tokens = 0,
+            .reasoning_tokens = null,
+            .billable_web_search_calls = 0,
+        },
+        .exact_usage_provider = .codex,
+    }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var usage = session_usage.Usage.initFresh();
+    defer usage.deinit(alloc);
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.usage = &usage;
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.provider_capabilities = .{};
+    var job = fixture.job();
+    job.provider = .codex;
+
+    try runFakePrompt(&gateway, &hooks, config, job);
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(@as(u64, 17), snapshot.input_tokens);
+    try std.testing.expectEqual(@as(u64, 7), snapshot.output_tokens);
+    try std.testing.expectEqual(@as(?u64, 1), snapshot.request_count);
 }
 
 fn makeOwnedProviderPrompt(alloc: Allocator, text: []const u8, model: []const u8) !QueuedPrompt {
@@ -5739,11 +5780,29 @@ test "Codex 401 replay keeps payload and semantic recovery unchanged for the cap
     const alloc = std.testing.allocator;
     const completions = [_]FakeCompletion{
         .{ .status = .unauthorized, .err_body = "expired" },
-        .{ .content = "Done." },
+        .{
+            .content = "Done.",
+            .generation_id = "response-replay-success",
+            .billing = .{
+                .created_at_ms = 1,
+                .model = "codex/gpt-test",
+                .total_cost = 0,
+                .input_tokens = 17,
+                .output_tokens = 7,
+                .cache_read_tokens = 0,
+                .cache_write_tokens = 0,
+                .reasoning_tokens = null,
+                .billable_web_search_calls = 0,
+            },
+            .exact_usage_provider = .codex,
+        },
     };
     var gateway = FakeGateway.init(alloc, &completions);
     defer gateway.deinit();
+    var usage = session_usage.Usage.initFresh();
+    defer usage.deinit(alloc);
     var hooks = FakeAgentRuntimeDeps.init(alloc);
+    hooks.usage = &usage;
     hooks.credential_refresh_tokens = &.{ "stale-loaded", "fresh-token" };
     hooks.enable_recovery_checkpoint = true;
     defer hooks.deinit();
@@ -5762,6 +5821,13 @@ test "Codex 401 replay keeps payload and semantic recovery unchanged for the cap
     try std.testing.expectEqualStrings("acct-a", hooks.last_credential_refresh_expected_account.?);
     try std.testing.expectEqual(@as(usize, 0), hooks.route_recovery_count);
     try std.testing.expectEqual(types.TurnPresentationOutcome.completed, hooks.finalized_outcome.?);
+    var usage_snapshot = try usage.snapshot(alloc);
+    defer usage_snapshot.deinit(alloc);
+    try std.testing.expectEqual(@as(u64, 17), usage_snapshot.input_tokens);
+    try std.testing.expectEqual(@as(u64, 7), usage_snapshot.output_tokens);
+    try std.testing.expectEqual(@as(?u64, 1), usage_snapshot.request_count);
+    try std.testing.expectEqual(@as(u64, 3), usage_snapshot.next_sequence);
+    try std.testing.expectEqual(@as(u64, 2), usage_snapshot.settled_through_sequence);
 }
 
 test "Codex 401 account change makes no second provider request" {

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -12,6 +12,8 @@ const builtin_gateway = @import("../../../../builtins/gateway.zig");
 const builtin_tools = @import("../../../../builtins/tools.zig");
 const session_runtime = @import("../../../session/session.zig");
 const session_codec = @import("../../../session/session_codec.zig");
+const session_usage = @import("../../../session/session_usage.zig");
+const model_provider = @import("../../../config/model_provider.zig");
 const command_replay_store = @import("../../../session/command_replay_store.zig");
 const session_child_store = @import("../../../session/session_child_store.zig");
 const lifecycle_hooks = @import("../../../hooks/hooks.zig");
@@ -216,6 +218,9 @@ pub const FakeCompletion = struct {
     finish_reason: ?types.ProviderFinishReason = null,
     omit_finish: bool = false,
     usage: types.Usage = .{},
+    generation_id: ?[]const u8 = null,
+    billing: ?types.ProviderBilling = null,
+    exact_usage_provider: ?model_provider.ProviderId = null,
     delivery_ambiguous: bool = false,
     pause_before_output: bool = false,
     cancel_before_output: bool = false,
@@ -346,8 +351,13 @@ pub const FakeGateway = struct {
                 else
                     completion.finish_reason orelse if (completion.tool_calls.len > 0) .tool_calls else .stop,
                 .usage = completion.usage,
+                .generation_id = completion.generation_id,
+                .billing = completion.billing,
             },
-            .usage = .{ .unavailable = .possibly_billed },
+            .usage = if (completion.exact_usage_provider) |provider_id|
+                .{ .exact = provider_id }
+            else
+                .{ .unavailable = .possibly_billed },
         } };
     }
 
@@ -597,6 +607,7 @@ pub const FakeAgentRuntimeDeps = struct {
     cancel_on_execute_delay_ms: u64 = 0,
     ordinary_cancel_on_execute_name: ?[]const u8 = null,
     session_context: ?*session_runtime.SessionRuntime = null,
+    usage: ?*session_usage.Usage = null,
     validation_not_registered_names: []const []const u8 = &.{},
     validation_failure_names: []const []const u8 = &.{},
     validation_results: []const ?[]const u8 = &.{},
@@ -754,6 +765,8 @@ pub const FakeAgentRuntimeDeps = struct {
             .format_tool_execution_error = formatError,
             .record_tool_call_rejected = recordRejected,
             .report_inner_tool_usage = reportCapturedInnerToolUsage,
+            .usage = self.usage,
+            .usage_allocator = self.alloc,
         };
     }
 

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -254,7 +254,7 @@ pub const UsageUnavailable = enum {
 };
 
 pub const UsageOutcome = union(enum) {
-    immediate: ?DeferredUsageReference,
+    exact: model_provider.ProviderId,
     deferred: DeferredUsageReference,
     unavailable: UsageUnavailable,
 };
@@ -337,7 +337,7 @@ test "stream provider accepts one typed request and emits ordered neutral events
             request.events.emit(.{ .reasoning_delta = "second" });
             return .{ .completed = .{
                 .completion = .{ .content = "done" },
-                .usage = .{ .immediate = null },
+                .usage = .{ .exact = .gateway },
             } };
         }
     };
@@ -402,5 +402,5 @@ test "stream provider accepts one typed request and emits ordered neutral events
     try std.testing.expect(!capture.failed);
     try std.testing.expectEqualStrings("firstsecond", capture.chunks.items);
     try std.testing.expectEqualStrings("done", result.completed.completion.content.?);
-    try std.testing.expect(std.meta.activeTag(result.completed.usage) == .immediate);
+    try std.testing.expect(std.meta.activeTag(result.completed.usage) == .exact);
 }

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -197,7 +197,7 @@ pub fn Runtime(comptime App: type) type {
             const provider_capabilities = if (comptime @hasDecl(App, "providerSet"))
                 app.providerSet().select(selected_provider).capabilities
             else if (selected_provider == .gateway)
-                provider_set.Bundle.Capabilities{ .fx_search = true, .vision_fallback = true, .deferred_usage = true }
+                provider_set.Bundle.Capabilities{ .fx_search = true, .vision_fallback = true }
             else
                 provider_set.Bundle.Capabilities{};
             var ctx: tool_runtime.Context = .{
@@ -1097,7 +1097,7 @@ pub fn Runtime(comptime App: type) type {
                 .provider_capabilities = if (comptime @hasDecl(App, "providerSet"))
                     app.providerSet().select(job.provider).capabilities
                 else if (job.provider == .gateway)
-                    .{ .fx_search = true, .vision_fallback = true, .deferred_usage = true }
+                    .{ .fx_search = true, .vision_fallback = true }
                 else
                     .{},
                 .custom_tool_guidance = tool_projection.custom_guidance,

--- a/src/core/gateway/provider_set.zig
+++ b/src/core/gateway/provider_set.zig
@@ -20,7 +20,6 @@ pub const Bundle = struct {
     pub const Capabilities = struct {
         fx_search: bool = false,
         vision_fallback: bool = false,
-        deferred_usage: bool = false,
     };
 
     capabilities: Capabilities = .{},
@@ -115,7 +114,7 @@ test "provider set selects each provider's complete route" {
     };
 
     const gateway = Bundle{
-        .capabilities = .{ .fx_search = true, .vision_fallback = true, .deferred_usage = true },
+        .capabilities = .{ .fx_search = true, .vision_fallback = true },
         .presentation = provider_catalog.find(.gateway),
         .auth_strategy = .vercel,
         .agent_stream = stream_provider.Provider{
@@ -150,12 +149,10 @@ test "provider set selects each provider's complete route" {
     try std.testing.expect(providers.select(.gateway).agent_stream.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(providers.select(.gateway).capabilities.fx_search);
     try std.testing.expect(providers.select(.gateway).capabilities.vision_fallback);
-    try std.testing.expect(providers.select(.gateway).capabilities.deferred_usage);
     try std.testing.expect(providers.select(.gateway).deferred_usage != null);
     try std.testing.expectEqualStrings("vercel", providers.select(.gateway).presentation.?.slug);
     try std.testing.expectEqual(Bundle.AuthStrategy.vercel, providers.select(.gateway).auth_strategy.?);
     try std.testing.expect(!providers.select(.codex).capabilities.fx_search);
-    try std.testing.expect(!providers.select(.codex).capabilities.deferred_usage);
     try std.testing.expect(providers.select(.codex).deferred_usage == null);
     try std.testing.expect(providers.select(.gateway).cli_model_catalog.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(providers.select(.codex).model_catalog.?.context.? == @as(*anyopaque, @ptrCast(&codex_tag)));

--- a/src/core/session/session_log.zig
+++ b/src/core/session/session_log.zig
@@ -5075,6 +5075,163 @@ test "usage sidecar publication stays inside the canonical commit boundary" {
     try std.testing.expectEqual(@as(usize, 0), read_only.usage.?.incidents.len);
 }
 
+test "torn exact settlement restores stale sidecar backlog over settled rollback" {
+    const Checkpoint = struct {
+        fn persist(_: *anyopaque, _: session_usage.Snapshot) !void {}
+    };
+    const RejectPublication = struct {
+        fn publish(_: *anyopaque, event: session_usage.usage_report.ProfileEvent) !void {
+            if (event == .generation) return error.InjectedPublicationFailure;
+        }
+    };
+    const PublicationProbe = struct {
+        generations: usize = 0,
+
+        fn publish(raw: *anyopaque, event: session_usage.usage_report.ProfileEvent) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            if (event == .generation) self.generations += 1;
+        }
+    };
+    const TearSidecar = struct {
+        dir: *io_mod.VerifiedDir,
+        torn: bool = false,
+        const stale_file = "usage-v2.stale-test";
+
+        fn boundary(raw: ?*anyopaque, point: Boundary) !void {
+            if (point != .before_usage_sidecar_write) return;
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            try self.dir.dir.rename(
+                session_usage_sidecar.sidecar_file,
+                self.dir.dir,
+                stale_file,
+                io_mod.getIo(),
+            );
+            try self.dir.dir.createDir(
+                io_mod.getIo(),
+                session_usage_sidecar.sidecar_file,
+                std.Io.File.Permissions.fromMode(0o700),
+            );
+            self.torn = true;
+        }
+
+        fn restore(self: *@This()) !void {
+            try self.dir.dir.deleteDir(
+                io_mod.getIo(),
+                session_usage_sidecar.sidecar_file,
+            );
+            try self.dir.dir.rename(
+                stale_file,
+                self.dir.dir,
+                session_usage_sidecar.sidecar_file,
+                io_mod.getIo(),
+            );
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    var temp = try TempRoot.init(alloc);
+    defer temp.deinit(alloc);
+    var initial = try testState(alloc, "session-usage-torn-exact", 10);
+    defer initial.deinit(alloc);
+    {
+        var loaded = try temp.root.startWritableSession(alloc, initial, .{});
+        defer loaded.deinit(alloc);
+        const completion: types.ModelCompletion = .{
+            .generation_id = "response-torn-log",
+            .billing = .{
+                .created_at_ms = 100,
+                .model = "codex/gpt-test",
+                .total_cost = 0,
+                .input_tokens = 17,
+                .output_tokens = 7,
+                .cache_read_tokens = 2,
+                .cache_write_tokens = 0,
+                .reasoning_tokens = 1,
+                .billable_web_search_calls = 0,
+            },
+        };
+
+        var checkpoint_context: u8 = 0;
+        var publication_context: u8 = 0;
+        var bridge = session_usage.Usage.initFresh();
+        defer bridge.deinit(alloc);
+        bridge.configureCheckpointSink(.{
+            .context = &checkpoint_context,
+            .allocator = alloc,
+            .persist = Checkpoint.persist,
+        });
+        bridge.configurePublicationSink(.{
+            .context = &publication_context,
+            .allocator = alloc,
+            .publish = RejectPublication.publish,
+        });
+        const bridge_observation = try session_usage.InvocationObservation.begin(&bridge);
+        try bridge_observation.complete(alloc, completion, .{ .exact = .codex });
+        var bridge_snapshot = try bridge.snapshot(alloc);
+        defer bridge_snapshot.deinit(alloc);
+        try std.testing.expectEqual(@as(usize, 1), bridge_snapshot.pending.len);
+        try std.testing.expectEqual(@as(usize, 1), bridge_snapshot.publication_backlog.len);
+        _ = try loaded.appendEvent(
+            alloc,
+            .{ .usage_checkpointed = .{ .usage = bridge_snapshot } },
+            20,
+            .retry_expected_tail,
+            .{},
+        );
+
+        var settled = session_usage.Usage.initFresh();
+        defer settled.deinit(alloc);
+        const settled_observation = try session_usage.InvocationObservation.begin(&settled);
+        try settled_observation.complete(alloc, completion, .{ .exact = .codex });
+        var settled_snapshot = try settled.snapshot(alloc);
+        defer settled_snapshot.deinit(alloc);
+        try std.testing.expectEqual(@as(u64, 17), settled_snapshot.input_tokens);
+        try std.testing.expectEqual(@as(usize, 0), settled_snapshot.pending.len);
+
+        var tear = TearSidecar{ .dir = &loaded.log.dir };
+        _ = try loaded.appendEvent(
+            alloc,
+            .{ .usage_checkpointed = .{ .usage = settled_snapshot } },
+            30,
+            .retry_expected_tail,
+            .{ .test_controls = .{
+                .context = &tear,
+                .boundary_fn = TearSidecar.boundary,
+            } },
+        );
+        try std.testing.expect(tear.torn);
+        try tear.restore();
+    }
+
+    var read_only = try temp.root.loadReadOnly(alloc, initial.id, .{});
+    defer read_only.deinit(alloc);
+    const recovered = read_only.usage.?;
+    try std.testing.expectEqual(@as(u64, 17), recovered.input_tokens);
+    try std.testing.expectEqual(@as(u64, 7), recovered.output_tokens);
+    try std.testing.expectEqual(@as(?u64, null), recovered.request_count);
+    try std.testing.expectEqual(@as(usize, 0), recovered.pending.len);
+    try std.testing.expectEqual(@as(usize, 1), recovered.publication_backlog.len);
+    try std.testing.expectEqual(@as(usize, 1), recovered.incidents.len);
+
+    var publication = PublicationProbe{};
+    var resumed = session_usage.Usage.initFresh();
+    defer resumed.deinit(alloc);
+    resumed.configurePublicationSink(.{
+        .context = &publication,
+        .allocator = alloc,
+        .publish = PublicationProbe.publish,
+    });
+    try resumed.restore(alloc, recovered, 1);
+    var final = try resumed.snapshot(alloc);
+    defer final.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), publication.generations);
+    try std.testing.expectEqual(@as(u64, 17), final.input_tokens);
+    try std.testing.expectEqual(@as(u64, 7), final.output_tokens);
+    try std.testing.expectEqual(@as(?u64, null), final.request_count);
+    try std.testing.expectEqual(@as(usize, 0), final.pending.len);
+    try std.testing.expectEqual(@as(usize, 0), final.publication_backlog.len);
+}
+
 test "indeterminate canonical usage retry repairs the rich sidecar" {
     const alloc = std.testing.allocator;
     var temp = try TempRoot.init(alloc);

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -113,9 +113,7 @@ pub const InvocationObservation = struct {
         usage_outcome: stream_provider.UsageOutcome,
     ) !void {
         const ledger = self.usage orelse return;
-        const reference = switch (usage_outcome) {
-            .immediate => |maybe_reference| maybe_reference,
-            .deferred => |value| value,
+        switch (usage_outcome) {
             .unavailable => |availability| {
                 const delivery: DeliveryOutcome = switch (availability) {
                     .unbilled => .unbilled,
@@ -134,10 +132,8 @@ pub const InvocationObservation = struct {
                 }
                 return;
             },
-        } orelse {
-            try ledger.finishInvocationDurably(self.sequence, self.elapsedMs(), .unbilled);
-            return;
-        };
+            .exact, .deferred => {},
+        }
         const delivery: DeliveryOutcome = if (completion.delivery_ambiguous)
             .ambiguous_delivery
         else if (!completion.generation_metadata_invalid)
@@ -153,36 +149,73 @@ pub const InvocationObservation = struct {
             );
             return;
         }
-        const accepted = try ledger.finishDeferredInvocationDurably(
-            alloc,
-            self.sequence,
-            self.elapsedMs(),
-            delivery,
-            reference,
-        );
-        if (!accepted) return;
-        debug_trace.logf(
-            "session",
-            "usage generation queued sequence={d} id={s}",
-            .{ self.sequence, reference.generation_id },
-        );
-        if (completion.billing) |billing| {
-            ledger.applyProviderBilling(alloc, reference.generation_id, billing) catch |err| {
+        switch (usage_outcome) {
+            .exact => |provider| {
+                const generation_id = completion.generation_id orelse {
+                    try ledger.finishInvocationDurably(
+                        self.sequence,
+                        self.elapsedMs(),
+                        if (completion.delivery_ambiguous)
+                            .ambiguous_delivery
+                        else
+                            .possibly_billed_without_identity,
+                    );
+                    debug_trace.logf(
+                        "session",
+                        "usage billing incomplete sequence={d} reason=generation_identity_missing",
+                        .{self.sequence},
+                    );
+                    return;
+                };
+                const billing = completion.billing orelse {
+                    try ledger.finishInvocationDurably(
+                        self.sequence,
+                        self.elapsedMs(),
+                        if (completion.delivery_ambiguous)
+                            .ambiguous_delivery
+                        else
+                            .possibly_billed_without_identity,
+                    );
+                    debug_trace.logf(
+                        "session",
+                        "usage billing incomplete sequence={d} reason=exact_usage_missing",
+                        .{self.sequence},
+                    );
+                    return;
+                };
+                const accepted = try ledger.finishExactInvocationDurably(
+                    alloc,
+                    self.sequence,
+                    self.elapsedMs(),
+                    delivery,
+                    provider,
+                    generation_id,
+                    billing,
+                );
+                if (!accepted) return;
                 debug_trace.logf(
                     "session",
-                    "usage stream billing apply failed id={s} reason={s}",
-                    .{ reference.generation_id, @errorName(err) },
+                    "usage exact generation settled sequence={d} id={s}",
+                    .{ self.sequence, generation_id },
+                );
+            },
+            .deferred => |reference| {
+                const accepted = try ledger.finishDeferredInvocationDurably(
+                    alloc,
+                    self.sequence,
+                    self.elapsedMs(),
+                    delivery,
+                    reference,
+                );
+                if (!accepted) return;
+                debug_trace.logf(
+                    "session",
+                    "usage generation queued sequence={d} id={s}",
+                    .{ self.sequence, reference.generation_id },
                 );
                 ledger.flushProfilePublications();
-                return;
-            };
-            debug_trace.logf(
-                "session",
-                "usage stream billing settled sequence={d} id={s}",
-                .{ self.sequence, reference.generation_id },
-            );
-        } else {
-            ledger.flushProfilePublications();
+            },
+            .unavailable => unreachable,
         }
     }
 
@@ -564,6 +597,138 @@ pub const Usage = struct {
         return accepted;
     }
 
+    fn finishExactInvocationDurably(
+        self: *Usage,
+        alloc: Allocator,
+        sequence: u64,
+        duration_ms: u64,
+        outcome: DeliveryOutcome,
+        provider: model_provider.ProviderId,
+        external_id: []const u8,
+        billing: types.ProviderBilling,
+    ) !bool {
+        var canonical_buffer: [30]u8 = undefined;
+        const canonical_id = canonicalExactGenerationId(
+            provider,
+            external_id,
+            &canonical_buffer,
+        ) catch |err| {
+            try self.finishInvocationDurably(
+                sequence,
+                duration_ms,
+                if (outcome == .ambiguous_delivery)
+                    .ambiguous_delivery
+                else
+                    .possibly_billed_without_identity,
+            );
+            debug_trace.logf(
+                "session",
+                "usage exact generation rejected reason={s}",
+                .{@errorName(err)},
+            );
+            return false;
+        };
+        const record = GenerationRecord{
+            .id = canonical_id,
+            .created_at_ms = billing.created_at_ms,
+            .model = billing.model,
+            .total_cost = billing.total_cost,
+            .input_tokens = billing.input_tokens,
+            .output_tokens = billing.output_tokens,
+            .cache_read_tokens = billing.cache_read_tokens,
+            .cache_write_tokens = billing.cache_write_tokens,
+            .reasoning_tokens = billing.reasoning_tokens,
+            .billable_web_search_calls = billing.billable_web_search_calls,
+        };
+        validateGenerationRecord(record) catch |err| {
+            try self.finishInvocationDurably(
+                sequence,
+                duration_ms,
+                if (outcome == .ambiguous_delivery)
+                    .ambiguous_delivery
+                else
+                    .possibly_billed_without_identity,
+            );
+            debug_trace.logf(
+                "session",
+                "usage exact generation rejected reason={s}",
+                .{@errorName(err)},
+            );
+            return false;
+        };
+
+        self.checkpoint_mutex.lockUncancelable(io_mod.getIo());
+        const durable_bridge = self.checkpoint_sink != null;
+        const accepted = self.finishExactInvocationAccepted(
+            alloc,
+            sequence,
+            duration_ms,
+            outcome,
+            provider,
+            canonical_id,
+            record,
+            durable_bridge,
+        ) catch |err| {
+            self.markBillingIncomplete();
+            _ = self.persistCheckpointBestEffortLocked();
+            self.checkpoint_mutex.unlock(io_mod.getIo());
+            debug_trace.logf(
+                "session",
+                "usage exact generation checkpointed incomplete reason={s}",
+                .{@errorName(err)},
+            );
+            return false;
+        };
+        if (!accepted) {
+            _ = self.persistCheckpointBestEffortLocked();
+            self.checkpoint_mutex.unlock(io_mod.getIo());
+            return false;
+        }
+        if (durable_bridge and !self.persistCheckpointBestEffortLocked()) {
+            self.checkpoint_mutex.unlock(io_mod.getIo());
+            return false;
+        }
+        self.checkpoint_mutex.unlock(io_mod.getIo());
+        if (durable_bridge) self.flushProfilePublications();
+        return true;
+    }
+
+    fn finishExactInvocationAccepted(
+        self: *Usage,
+        alloc: Allocator,
+        sequence: u64,
+        duration_ms: u64,
+        outcome: DeliveryOutcome,
+        provider: model_provider.ProviderId,
+        generation_id: []const u8,
+        record: GenerationRecord,
+        durable_bridge: bool,
+    ) !bool {
+        self.mutex.lockUncancelable(io_mod.getIo());
+        defer self.mutex.unlock(io_mod.getIo());
+        if (!self.finishInvocationUnlocked(sequence, duration_ms, outcome)) return false;
+        try self.observeGenerationFieldsUnlocked(
+            alloc,
+            sequence,
+            generation_id,
+            provider,
+            exactUsageOrigin(provider),
+            null,
+            null,
+            null,
+            null,
+        );
+        if (durable_bridge) {
+            try self.stagePublicationBacklogUnlocked(
+                alloc,
+                generationFactBorrowed(record),
+            );
+        } else {
+            try self.applyGenerationUnlocked(alloc, record, false);
+        }
+        return true;
+    }
+
     fn persistCheckpointRequiredLocked(self: *Usage) !void {
         const sink = self.checkpoint_sink orelse return;
         var persisted = try self.snapshotCurrent(sink.allocator);
@@ -907,26 +1072,6 @@ pub const Usage = struct {
         if (publication == .failed) self.flushProfilePublications();
     }
 
-    fn applyProviderBilling(
-        self: *Usage,
-        alloc: Allocator,
-        generation_id: []const u8,
-        billing: types.ProviderBilling,
-    ) !void {
-        try self.applyGeneration(alloc, .{
-            .id = generation_id,
-            .created_at_ms = billing.created_at_ms,
-            .model = billing.model,
-            .total_cost = billing.total_cost,
-            .input_tokens = billing.input_tokens,
-            .output_tokens = billing.output_tokens,
-            .cache_read_tokens = billing.cache_read_tokens,
-            .cache_write_tokens = billing.cache_write_tokens,
-            .reasoning_tokens = billing.reasoning_tokens,
-            .billable_web_search_calls = billing.billable_web_search_calls,
-        });
-    }
-
     fn applyGenerationUnlocked(
         self: *Usage,
         alloc: Allocator,
@@ -1060,12 +1205,16 @@ pub const Usage = struct {
         alloc: Allocator,
         fact: usage_report.GenerationFact,
     ) !void {
-        var owned = try fact.dupe(alloc);
-        var owns_fact = true;
-        defer if (owns_fact) owned.deinit(alloc);
-
         self.mutex.lockUncancelable(io_mod.getIo());
         defer self.mutex.unlock(io_mod.getIo());
+        try self.stagePublicationBacklogUnlocked(alloc, fact);
+    }
+
+    fn stagePublicationBacklogUnlocked(
+        self: *Usage,
+        alloc: Allocator,
+        fact: usage_report.GenerationFact,
+    ) !void {
         const pending_exists = for (self.pending.items) |pending| {
             if (std.mem.eql(u8, pending.id, fact.id)) break true;
         } else false;
@@ -1086,8 +1235,9 @@ pub const Usage = struct {
             self.dirty = true;
             return error.UsageCapacityExceeded;
         }
+        var owned = try fact.dupe(alloc);
+        errdefer owned.deinit(alloc);
         try self.publication_backlog.append(alloc, owned);
-        owns_fact = false;
         self.dirty = true;
     }
 
@@ -3095,8 +3245,86 @@ pub fn dupeSnapshotOwned(alloc: Allocator, source: Snapshot) !Snapshot {
     };
 }
 
+fn canonicalExactGenerationId(
+    provider: model_provider.ProviderId,
+    external_id: []const u8,
+    buffer: *[30]u8,
+) ![]const u8 {
+    if (provider == .gateway) {
+        try validateGenerationId(external_id);
+        return external_id;
+    }
+    try validateExternalGenerationId(external_id);
+    var digest: [Sha256.digest_length]u8 = undefined;
+    var hash = Sha256.init(.{});
+    hash.update(@tagName(provider));
+    hash.update(&.{0});
+    hash.update(external_id);
+    hash.final(&digest);
+    const encoded = std.fmt.bytesToHex(digest[0..13].*, .upper);
+    @memcpy(buffer[0..4], "gen_");
+    @memcpy(buffer[4..], &encoded);
+    return buffer;
+}
+
+fn exactUsageOrigin(provider: model_provider.ProviderId) []const u8 {
+    return switch (provider) {
+        .gateway => "exact/gateway",
+        .codex => "exact/codex",
+        .grok => "exact/grok",
+    };
+}
+
+test "direct exact generation IDs are deterministic and provider scoped" {
+    var first_buffer: [30]u8 = undefined;
+    var replay_buffer: [30]u8 = undefined;
+    var other_provider_buffer: [30]u8 = undefined;
+    const first = try canonicalExactGenerationId(
+        .codex,
+        "response-shared-id",
+        &first_buffer,
+    );
+    const replay = try canonicalExactGenerationId(
+        .codex,
+        "response-shared-id",
+        &replay_buffer,
+    );
+    const other_provider = try canonicalExactGenerationId(
+        .grok,
+        "response-shared-id",
+        &other_provider_buffer,
+    );
+
+    try std.testing.expectEqualStrings(first, replay);
+    try std.testing.expect(!std.mem.eql(u8, first, other_provider));
+    try std.testing.expect(types.validGatewayGenerationId(first));
+    try std.testing.expect(types.validGatewayGenerationId(other_provider));
+
+    var gateway_buffer: [30]u8 = undefined;
+    const gateway_id = "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV";
+    try std.testing.expectEqualStrings(
+        gateway_id,
+        try canonicalExactGenerationId(.gateway, gateway_id, &gateway_buffer),
+    );
+    try std.testing.expectError(
+        error.InvalidGenerationId,
+        canonicalExactGenerationId(.codex, "", &gateway_buffer),
+    );
+    try std.testing.expectError(
+        error.InvalidGenerationId,
+        canonicalExactGenerationId(.grok, "response\ninvalid", &gateway_buffer),
+    );
+}
+
 fn validateGenerationId(id: []const u8) !void {
     if (!types.validGatewayGenerationId(id)) return error.InvalidGenerationId;
+}
+
+fn validateExternalGenerationId(id: []const u8) !void {
+    if (id.len == 0 or id.len > max_identifier_bytes or !std.unicode.utf8ValidateSlice(id)) {
+        return error.InvalidGenerationId;
+    }
+    for (id) |byte| if (std.ascii.isControl(byte)) return error.InvalidGenerationId;
 }
 
 fn validateModel(model: []const u8) !void {
@@ -3226,14 +3454,13 @@ fn testGatewayUsageOutcome(
     generation_id: []const u8,
     immediate: bool,
 ) stream_provider.UsageOutcome {
-    const reference = testGatewayUsageReference(
-        generation_id,
-        "https://ai-gateway.vercel.sh",
-    );
     return if (immediate)
-        .{ .immediate = reference }
+        .{ .exact = .gateway }
     else
-        .{ .deferred = reference };
+        .{ .deferred = testGatewayUsageReference(
+            generation_id,
+            "https://ai-gateway.vercel.sh",
+        ) };
 }
 
 fn testGatewayUsageReference(
@@ -4108,11 +4335,21 @@ test "invalid generation identity settles the provider observation" {
     const observation = try InvocationObservation.begin(&usage);
     try observation.complete(
         alloc,
-        .{ .generation_id = "resp_provider_local" },
-        .{ .immediate = testGatewayUsageReference(
-            "resp_provider_local",
-            "https://ai-gateway.vercel.sh",
-        ) },
+        .{
+            .generation_id = "resp_provider_local",
+            .billing = .{
+                .created_at_ms = 1,
+                .model = "provider/model",
+                .total_cost = 0,
+                .input_tokens = 1,
+                .output_tokens = 1,
+                .cache_read_tokens = 0,
+                .cache_write_tokens = 0,
+                .reasoning_tokens = null,
+                .billable_web_search_calls = 0,
+            },
+        },
+        .{ .exact = .gateway },
     );
 
     var snapshot = try usage.snapshot(alloc);
@@ -4160,6 +4397,7 @@ test "rejected observed generation settles without publishing its identity or bi
         alloc,
         .{
             .generation_id = rejected_id,
+            .generation_metadata_invalid = true,
             .billing = .{
                 .created_at_ms = 1,
                 .model = "provider/model",
@@ -4172,10 +4410,7 @@ test "rejected observed generation settles without publishing its identity or bi
                 .billable_web_search_calls = 0,
             },
         },
-        .{ .immediate = testGatewayUsageReference(
-            rejected_id,
-            "https://provider.example\ninvalid",
-        ) },
+        .{ .exact = .gateway },
     );
 
     var snapshot = try usage.snapshot(alloc);
@@ -4471,6 +4706,9 @@ test "terminal Gateway billing settles the durable observation immediately" {
 
 test "duplicate Gateway terminal callback does not republish inline billing" {
     const alloc = std.testing.allocator;
+    const CheckpointProbe = struct {
+        fn persist(_: *anyopaque, _: Snapshot) !void {}
+    };
     const PublicationProbe = struct {
         generations: usize = 0,
 
@@ -4484,8 +4722,14 @@ test "duplicate Gateway terminal callback does not republish inline billing" {
     };
 
     var probe = PublicationProbe{};
+    var checkpoint_context: u8 = 0;
     var usage = Usage.initFresh();
     defer usage.deinit(alloc);
+    usage.configureCheckpointSink(.{
+        .context = &checkpoint_context,
+        .allocator = alloc,
+        .persist = CheckpointProbe.persist,
+    });
     usage.configurePublicationSink(.{
         .context = &probe,
         .allocator = alloc,

--- a/src/core/session/session_usage_sidecar.zig
+++ b/src/core/session/session_usage_sidecar.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
 const session_usage = @import("session_usage.zig");
+const generation_usage = @import("generation_usage_provider.zig");
+const stream_provider = @import("../agent/stream_provider.zig");
+const types = @import("../shared/types.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -550,6 +553,125 @@ test "missing and corrupt usage sidecars retain canonical usage with one fixed g
     );
     try std.testing.expectEqual(@as(usize, 1), corrupt.incidents.len);
     try std.testing.expectEqual(@as(i64, 31), corrupt.incidents[0].occurred_at_ms);
+}
+
+test "torn exact settlement republishes stale backlog without reapplying totals" {
+    const Checkpoint = struct {
+        fn persist(_: *anyopaque, _: session_usage.Snapshot) !void {}
+    };
+    const RejectPublication = struct {
+        fn publish(_: *anyopaque, event: session_usage.usage_report.ProfileEvent) !void {
+            if (event == .generation) return error.InjectedPublicationFailure;
+        }
+    };
+    const PublicationProbe = struct {
+        generations: usize = 0,
+
+        fn publish(raw: *anyopaque, event: session_usage.usage_report.ProfileEvent) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            if (event == .generation) self.generations += 1;
+        }
+    };
+    const LookupProbe = struct {
+        calls: usize = 0,
+
+        fn lookup(
+            raw: ?*anyopaque,
+            _: Allocator,
+            _: generation_usage.LookupInput,
+        ) generation_usage.LookupError!generation_usage.LookupOutcome {
+            const self: *@This() = @ptrCast(@alignCast(raw.?));
+            self.calls += 1;
+            return error.Unavailable;
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    const completion: types.ModelCompletion = .{
+        .generation_id = "response-torn-1",
+        .billing = .{
+            .created_at_ms = 100,
+            .model = "codex/gpt-test",
+            .total_cost = 0,
+            .input_tokens = 17,
+            .output_tokens = 7,
+            .cache_read_tokens = 2,
+            .cache_write_tokens = 0,
+            .reasoning_tokens = 1,
+            .billable_web_search_calls = 0,
+        },
+    };
+    const exact = stream_provider.UsageOutcome{ .exact = .codex };
+
+    var checkpoint_context: u8 = 0;
+    var publication_context: u8 = 0;
+    var bridge_source = session_usage.Usage.initFresh();
+    defer bridge_source.deinit(alloc);
+    bridge_source.configureCheckpointSink(.{
+        .context = &checkpoint_context,
+        .allocator = alloc,
+        .persist = Checkpoint.persist,
+    });
+    bridge_source.configurePublicationSink(.{
+        .context = &publication_context,
+        .allocator = alloc,
+        .publish = RejectPublication.publish,
+    });
+    const bridge_observation = try session_usage.InvocationObservation.begin(&bridge_source);
+    try bridge_observation.complete(alloc, completion, exact);
+    var stale_rich = try bridge_source.snapshot(alloc);
+    defer stale_rich.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), stale_rich.pending.len);
+    try std.testing.expectEqual(@as(usize, 1), stale_rich.publication_backlog.len);
+    try std.testing.expectEqual(@as(u64, 0), stale_rich.input_tokens);
+
+    var settled_source = session_usage.Usage.initFresh();
+    defer settled_source.deinit(alloc);
+    const settled_observation = try session_usage.InvocationObservation.begin(&settled_source);
+    try settled_observation.complete(alloc, completion, exact);
+    var durable = try settled_source.snapshot(alloc);
+    defer durable.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 0), durable.pending.len);
+    try std.testing.expectEqual(@as(u64, 17), durable.input_tokens);
+
+    const stale_bytes = try encode(alloc, "session-torn", stale_rich);
+    defer alloc.free(stale_bytes);
+    try std.testing.expectEqual(
+        RestoreOutcome.mismatched,
+        try restoreCaptured(
+            alloc,
+            .{ .encoded = stale_bytes },
+            "session-torn",
+            200,
+            &durable,
+        ),
+    );
+    try std.testing.expectEqual(@as(usize, 0), durable.pending.len);
+    try std.testing.expectEqual(@as(usize, 1), durable.publication_backlog.len);
+    try std.testing.expectEqual(@as(u64, 17), durable.input_tokens);
+
+    var lookup = LookupProbe{};
+    var publication = PublicationProbe{};
+    var resumed = session_usage.Usage.initFreshWithProviders(.{
+        .codex = .{ .context = &lookup, .lookup_fn = LookupProbe.lookup },
+    });
+    defer resumed.deinit(alloc);
+    resumed.configurePublicationSink(.{
+        .context = &publication,
+        .allocator = alloc,
+        .publish = PublicationProbe.publish,
+    });
+    try resumed.restore(alloc, durable, 1);
+
+    var final = try resumed.snapshot(alloc);
+    defer final.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 1), publication.generations);
+    try std.testing.expectEqual(@as(usize, 0), lookup.calls);
+    try std.testing.expectEqual(@as(usize, 0), final.pending.len);
+    try std.testing.expectEqual(@as(usize, 0), final.publication_backlog.len);
+    try std.testing.expectEqual(@as(u64, 17), final.input_tokens);
+    try std.testing.expectEqual(@as(u64, 7), final.output_tokens);
+    try std.testing.expectEqual(@as(?u64, 1), final.request_count);
 }
 
 fn legacyCopyForTest(

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -880,9 +880,12 @@ pub const ChatMessage = struct {
 pub const Usage = struct {
     input_tokens: ?u64 = null,
     output_tokens: ?u64 = null,
+    cache_read_tokens: ?u64 = null,
+    cache_write_tokens: ?u64 = null,
+    reasoning_tokens: ?u64 = null,
 };
 
-/// Exact usage metadata returned by a completed Gateway stream. `model` is
+/// Exact usage metadata returned by a completed provider stream. `model` is
 /// owned by the completion carrying this value.
 pub const ProviderBilling = struct {
     created_at_ms: i64,

--- a/src/gateway/host_stream_provider.zig
+++ b/src/gateway/host_stream_provider.zig
@@ -150,7 +150,7 @@ fn gatewayUsageOutcome(
     const reference = gatewayUsageReference(request, completion) orelse
         return .{ .unavailable = .possibly_billed };
     return if (completion.billing != null)
-        .{ .immediate = reference }
+        .{ .exact = .gateway }
     else
         .{ .deferred = reference };
 }

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -280,7 +280,7 @@ pub fn streamPrepared(
     var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
     var events = request.events;
-    const completion = try consumeSse(
+    var completion = try consumeSse(
         alloc,
         reader,
         &events,
@@ -292,9 +292,29 @@ pub fn streamPrepared(
         request.content_capture_limit,
         .{},
     );
+    errdefer {
+        var owned = stream_provider.Result{ .completed = .{
+            .completion = completion,
+            .ownership = .owned,
+        } };
+        owned.deinit(alloc);
+    }
+    const usage_outcome: stream_provider.UsageOutcome = usage: {
+        if (completion.generation_id == null) {
+            break :usage .{ .unavailable = .possibly_billed };
+        }
+        completion.billing = try responses_protocol.buildSubscriptionBilling(
+            alloc,
+            .codex,
+            request.model,
+            @max(io_mod.milliTimestamp(), 0),
+            completion.usage,
+        ) orelse break :usage .{ .unavailable = .possibly_billed };
+        break :usage .{ .exact = .codex };
+    };
     return .{ .completed = .{
         .completion = completion,
-        .usage = .{ .immediate = null },
+        .usage = usage_outcome,
         .ownership = .owned,
     } };
 }

--- a/src/gateway/responses_permission_reviewer.zig
+++ b/src/gateway/responses_permission_reviewer.zig
@@ -3,6 +3,8 @@ const permission_auto_classifier = @import("../core/permissions/auto_classifier.
 const stream_provider = @import("../core/agent/stream_provider.zig");
 const types = @import("../core/shared/types.zig");
 const io_mod = @import("../core/shared/io.zig");
+const debug_trace = @import("../core/shared/debug_trace.zig");
+const session_usage = @import("../core/session/session_usage.zig");
 const vercel_protocol = @import("vercel_protocol.zig");
 
 const Allocator = std.mem.Allocator;
@@ -125,11 +127,14 @@ const OwnedResult = struct {
 };
 
 const ReviewAdmission = struct {
+    usage: ?*session_usage.Usage,
     evidence: *stream_provider.AttemptEvidence,
+    observation: ?session_usage.InvocationObservation = null,
 
     fn admit(raw: *anyopaque) !void {
         const self: *@This() = @ptrCast(@alignCast(raw));
-        if (self.evidence.provider_admitted) return error.ProviderAdmissionRepeated;
+        if (self.observation != null) return error.ProviderAdmissionRepeated;
+        self.observation = try session_usage.InvocationObservation.begin(self.usage);
         self.evidence.provider_admitted = true;
     }
 };
@@ -160,7 +165,10 @@ fn sendReview(
 
     var delivery = stream_provider.DeliveryCertainty.init();
     var evidence: stream_provider.AttemptEvidence = .{};
-    var admission = ReviewAdmission{ .evidence = &evidence };
+    var admission = ReviewAdmission{
+        .usage = runtime.input.usage,
+        .evidence = &evidence,
+    };
     var callback_context: u8 = 0;
     var result = runtime.adapter.send_fn(alloc, .{
         .credential = .{
@@ -184,6 +192,12 @@ fn sendReview(
         .cancel_flag = cancel_flag,
         .provider_attempt_owner = .transport,
     }, payload) catch |err| {
+        if (admission.observation) |observation| observation.fail(
+            if (delivery.load() == .possibly_sent) .ambiguous_delivery else .unbilled,
+        ) catch |usage_err| {
+            debugUsageFailure("transport_failure", usage_err);
+            return .permanent_failure;
+        };
         if (err == error.OutOfMemory) return error.OutOfMemory;
         if (err == error.Cancelled or cancel_flag.load(.seq_cst)) return .cancelled;
         if (err == error.Timeout) return .timed_out;
@@ -191,6 +205,21 @@ fn sendReview(
     };
     var result_owned = true;
     defer if (result_owned) result.deinit(alloc);
+    const observation = admission.observation orelse {
+        debugUsageFailure("completion", error.ProviderAdmissionMissing);
+        return .permanent_failure;
+    };
+    (switch (result) {
+        .failed => observation.fail(.unbilled),
+        .completed => |completed| observation.complete(
+            runtime.input.usage_allocator,
+            completed.completion,
+            completed.usage,
+        ),
+    }) catch |err| {
+        debugUsageFailure("completion", err);
+        return .permanent_failure;
+    };
     if (cancel_flag.load(.seq_cst)) return .cancelled;
     if (std.meta.activeTag(result) == .failed) return switch (result.failed.kind) {
         .rate_limited, .server_error, .bad_gateway, .unavailable, .gateway_timeout => .transient_failure,
@@ -209,4 +238,200 @@ fn sendReview(
         .context = owned,
         .deinit_fn = deinitOwnedResult,
     } };
+}
+
+fn debugUsageFailure(phase: []const u8, err: anyerror) void {
+    debug_trace.logf(
+        "permission",
+        "event=auto_review_usage result=permanent_failure phase={s} reason={s}",
+        .{ phase, @errorName(err) },
+    );
+}
+
+test "direct review exact usage settles through the session ledger" {
+    const Fake = struct {
+        fn validate(_: Allocator, _: permission_auto_classifier.ProviderInput) !void {}
+
+        fn build(_: Allocator, _: stream_provider.RequestData) ![]u8 {
+            return error.TestUnexpectedBuild;
+        }
+
+        fn send(
+            _: Allocator,
+            request: stream_provider.ModelRequest,
+            _: []const u8,
+        ) !stream_provider.Result {
+            try request.admission.admit();
+            request.delivery.markPossiblySent();
+            return .{ .completed = .{
+                .completion = .{
+                    .content = "clear",
+                    .generation_id = "response-review-1",
+                    .billing = .{
+                        .created_at_ms = 1,
+                        .model = "codex/gpt-review",
+                        .total_cost = 0,
+                        .input_tokens = 11,
+                        .output_tokens = 3,
+                        .cache_read_tokens = 0,
+                        .cache_write_tokens = 0,
+                        .reasoning_tokens = null,
+                        .billable_web_search_calls = 0,
+                    },
+                    .finish_reason = .stop,
+                },
+                .usage = .{ .exact = .codex },
+            } };
+        }
+    };
+
+    const alloc = std.testing.allocator;
+    var usage = session_usage.Usage.initFresh();
+    defer usage.deinit(alloc);
+    var runtime = Runtime{
+        .input = .{ .usage = &usage, .usage_allocator = alloc },
+        .adapter = .{
+            .source = .chatgpt_subscription,
+            .model = "gpt-review",
+            .validate_fn = Fake.validate,
+            .build_fn = Fake.build,
+            .send_fn = Fake.send,
+        },
+    };
+    var cancelled = std.atomic.Value(bool).init(false);
+    var outcome = try sendReview(
+        &runtime,
+        alloc,
+        "gpt-review",
+        "{}",
+        std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+            .clock = .awake,
+            .raw = .fromSeconds(5),
+        }),
+        &cancelled,
+    );
+    defer if (outcome == .completion) outcome.completion.deinit(alloc);
+
+    var snapshot = try usage.snapshot(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(@as(u64, 11), snapshot.input_tokens);
+    try std.testing.expectEqual(@as(u64, 3), snapshot.output_tokens);
+    try std.testing.expectEqual(@as(?u64, 1), snapshot.request_count);
+}
+
+test "direct review settles every post-admission outcome before projection" {
+    const Fake = struct {
+        fn validate(_: Allocator, _: permission_auto_classifier.ProviderInput) !void {}
+
+        fn build(_: Allocator, _: stream_provider.RequestData) ![]u8 {
+            return error.TestUnexpectedBuild;
+        }
+
+        fn exactCompletion() stream_provider.Result {
+            return .{ .completed = .{
+                .completion = .{
+                    .generation_id = "response-review-outcome",
+                    .billing = .{
+                        .created_at_ms = 1,
+                        .model = "codex/gpt-review",
+                        .total_cost = 0,
+                        .input_tokens = 11,
+                        .output_tokens = 3,
+                        .cache_read_tokens = 0,
+                        .cache_write_tokens = 0,
+                        .reasoning_tokens = null,
+                        .billable_web_search_calls = 0,
+                    },
+                    .finish_reason = .stop,
+                },
+                .usage = .{ .exact = .codex },
+            } };
+        }
+
+        fn send(
+            _: Allocator,
+            request: stream_provider.ModelRequest,
+            payload: []const u8,
+        ) !stream_provider.Result {
+            try request.admission.admit();
+            if (std.mem.eql(u8, payload, "cancelled")) {
+                request.delivery.markPossiblySent();
+                return error.Cancelled;
+            }
+            if (std.mem.eql(u8, payload, "timed_out")) {
+                request.delivery.markPossiblySent();
+                return error.Timeout;
+            }
+            if (std.mem.eql(u8, payload, "provider_failure")) {
+                return .{ .failed = .{ .kind = .unauthorized } };
+            }
+            if (std.mem.eql(u8, payload, "malformed")) {
+                return .{ .completed = .{
+                    .completion = .{ .finish_reason = .stop },
+                    .usage = .{ .unavailable = .possibly_billed },
+                } };
+            }
+            if (std.mem.eql(u8, payload, "cancel_after_completion")) {
+                request.cancel_flag.store(true, .seq_cst);
+                return exactCompletion();
+            }
+            if (std.mem.eql(u8, payload, "provider_error")) {
+                var result = exactCompletion();
+                result.completed.completion.finish_reason = .provider_error;
+                return result;
+            }
+            return error.TestUnexpectedPayload;
+        }
+    };
+
+    const cases = [_]struct {
+        payload: []const u8,
+        outcome: std.meta.Tag(permission_auto_classifier.TransportOutcome),
+        billing: session_usage.Availability,
+        request_count: ?u64,
+    }{
+        .{ .payload = "cancelled", .outcome = .cancelled, .billing = .incomplete, .request_count = 0 },
+        .{ .payload = "timed_out", .outcome = .timed_out, .billing = .incomplete, .request_count = 0 },
+        .{ .payload = "provider_failure", .outcome = .permanent_failure, .billing = .complete, .request_count = 0 },
+        .{ .payload = "malformed", .outcome = .completion, .billing = .incomplete, .request_count = 0 },
+        .{ .payload = "cancel_after_completion", .outcome = .cancelled, .billing = .complete, .request_count = 1 },
+        .{ .payload = "provider_error", .outcome = .transient_failure, .billing = .complete, .request_count = 1 },
+    };
+
+    for (cases) |case| {
+        var usage = session_usage.Usage.initFresh();
+        defer usage.deinit(std.testing.allocator);
+        var runtime = Runtime{
+            .input = .{ .usage = &usage, .usage_allocator = std.testing.allocator },
+            .adapter = .{
+                .source = .chatgpt_subscription,
+                .model = "gpt-review",
+                .validate_fn = Fake.validate,
+                .build_fn = Fake.build,
+                .send_fn = Fake.send,
+            },
+        };
+        var cancelled = std.atomic.Value(bool).init(false);
+        var outcome = try sendReview(
+            &runtime,
+            std.testing.allocator,
+            "gpt-review",
+            case.payload,
+            std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+                .clock = .awake,
+                .raw = .fromSeconds(5),
+            }),
+            &cancelled,
+        );
+        defer if (outcome == .completion) outcome.completion.deinit(std.testing.allocator);
+        try std.testing.expectEqual(case.outcome, std.meta.activeTag(outcome));
+
+        var snapshot = try usage.snapshot(std.testing.allocator);
+        defer snapshot.deinit(std.testing.allocator);
+        try std.testing.expectEqual(case.billing, snapshot.billing);
+        try std.testing.expectEqual(case.request_count, snapshot.request_count);
+        try std.testing.expectEqual(@as(u64, 2), snapshot.next_sequence);
+        try std.testing.expectEqual(@as(u64, 1), snapshot.settled_through_sequence);
+        try std.testing.expectEqual(@as(usize, 0), snapshot.pending.len);
+    }
 }

--- a/src/gateway/responses_protocol.zig
+++ b/src/gateway/responses_protocol.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const stream_provider = @import("../core/agent/stream_provider.zig");
+const model_provider = @import("../core/config/model_provider.zig");
 const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
 const types = @import("../core/shared/types.zig");
 const image_attachments = @import("../core/images/image_attachments.zig");
@@ -530,10 +531,82 @@ fn finishReason(
 fn parseUsage(response: std.json.ObjectMap) types.Usage {
     const value = response.get("usage") orelse return .{};
     if (value != .object) return .{};
+    const input_details = value.object.get("input_tokens_details");
+    const output_details = value.object.get("output_tokens_details");
     return .{
         .input_tokens = unsignedField(value.object, "input_tokens"),
         .output_tokens = unsignedField(value.object, "output_tokens"),
+        .cache_read_tokens = nestedUnsignedField(
+            input_details,
+            "cached_tokens",
+        ),
+        .cache_write_tokens = nestedUnsignedField(
+            input_details,
+            "cache_write_tokens",
+        ),
+        .reasoning_tokens = nestedUnsignedField(
+            output_details,
+            "reasoning_tokens",
+        ),
     };
+}
+
+fn nestedUnsignedField(value: ?std.json.Value, key: []const u8) ?u64 {
+    const object = value orelse return null;
+    if (object != .object) return null;
+    return unsignedField(object.object, key);
+}
+
+/// Builds exact subscription metrics from a provider-neutral Responses usage
+/// projection. The caller owns `model` in the returned value.
+pub fn buildSubscriptionBilling(
+    alloc: std.mem.Allocator,
+    provider: model_provider.ProviderId,
+    model: []const u8,
+    created_at_ms: i64,
+    usage: types.Usage,
+) !?types.ProviderBilling {
+    if (provider == .gateway or created_at_ms < 0) return null;
+    const input_tokens = usage.input_tokens orelse return null;
+    const output_tokens = usage.output_tokens orelse return null;
+    const qualified_model = try std.fmt.allocPrint(
+        alloc,
+        "{s}/{s}",
+        .{ @tagName(provider), model },
+    );
+    return .{
+        .created_at_ms = created_at_ms,
+        .model = qualified_model,
+        .total_cost = 0,
+        .input_tokens = input_tokens,
+        .output_tokens = output_tokens,
+        .cache_read_tokens = boundedOptionalCounter(
+            usage.cache_read_tokens,
+            input_tokens,
+            @as(u64, 0),
+        ),
+        .cache_write_tokens = boundedOptionalCounter(
+            usage.cache_write_tokens,
+            input_tokens,
+            @as(u64, 0),
+        ),
+        .reasoning_tokens = boundedOptionalCounter(
+            usage.reasoning_tokens,
+            output_tokens,
+            @as(?u64, null),
+        ),
+        .billable_web_search_calls = 0,
+    };
+}
+
+fn boundedOptionalCounter(
+    value: ?u64,
+    parent_total: u64,
+    fallback: anytype,
+) @TypeOf(fallback) {
+    const count = value orelse return fallback;
+    if (count > parent_total) return fallback;
+    return count;
 }
 
 fn stringField(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
@@ -647,4 +720,68 @@ test "Responses tools serialize typed static and dynamic functions once" {
     ));
     try std.testing.expect(std.mem.find(u8, out.written(), "\"name\":\"read_file\"") != null);
     try std.testing.expect(std.mem.find(u8, out.written(), "\"name\":\"mcp_search\"") != null);
+}
+
+test "Responses usage projection retains optional cached and reasoning detail" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        std.testing.allocator,
+        "{\"usage\":{\"input_tokens\":17,\"output_tokens\":7,\"input_tokens_details\":{\"cached_tokens\":5,\"cache_write_tokens\":2},\"output_tokens_details\":{\"reasoning_tokens\":3}}}",
+        .{},
+    );
+    defer parsed.deinit();
+    const usage = parseUsage(parsed.value.object);
+    try std.testing.expectEqual(@as(?u64, 17), usage.input_tokens);
+    try std.testing.expectEqual(@as(?u64, 7), usage.output_tokens);
+    try std.testing.expectEqual(@as(?u64, 5), usage.cache_read_tokens);
+    try std.testing.expectEqual(@as(?u64, 2), usage.cache_write_tokens);
+    try std.testing.expectEqual(@as(?u64, 3), usage.reasoning_tokens);
+}
+
+test "Responses protocol owns one subscription billing projection" {
+    const alloc = std.testing.allocator;
+    const billing = (try buildSubscriptionBilling(
+        alloc,
+        .codex,
+        "gpt-test",
+        42,
+        .{
+            .input_tokens = 17,
+            .output_tokens = 7,
+            .cache_read_tokens = 5,
+            .cache_write_tokens = 2,
+            .reasoning_tokens = 3,
+        },
+    )).?;
+    defer alloc.free(@constCast(billing.model));
+    try std.testing.expectEqualStrings("codex/gpt-test", billing.model);
+    try std.testing.expectEqual(@as(u64, 5), billing.cache_read_tokens);
+    try std.testing.expectEqual(@as(u64, 2), billing.cache_write_tokens);
+    try std.testing.expectEqual(@as(?u64, 3), billing.reasoning_tokens);
+
+    const bounded = (try buildSubscriptionBilling(
+        alloc,
+        .grok,
+        "grok-test",
+        43,
+        .{
+            .input_tokens = 10,
+            .output_tokens = 4,
+            .cache_read_tokens = 11,
+            .cache_write_tokens = 12,
+            .reasoning_tokens = 5,
+        },
+    )).?;
+    defer alloc.free(@constCast(bounded.model));
+    try std.testing.expectEqual(@as(u64, 0), bounded.cache_read_tokens);
+    try std.testing.expectEqual(@as(u64, 0), bounded.cache_write_tokens);
+    try std.testing.expectEqual(@as(?u64, null), bounded.reasoning_tokens);
+
+    try std.testing.expect((try buildSubscriptionBilling(
+        alloc,
+        .codex,
+        "gpt-test",
+        44,
+        .{ .input_tokens = 10 },
+    )) == null);
 }

--- a/src/gateway/xai_grok.zig
+++ b/src/gateway/xai_grok.zig
@@ -302,7 +302,7 @@ pub fn streamPrepared(
     var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
     const reader = response.reader(&transfer_buffer);
     var events = request.events;
-    const completion = try consumeSse(
+    var completion = try consumeSse(
         alloc,
         reader,
         &events,
@@ -313,9 +313,29 @@ pub fn streamPrepared(
         request.cancel_flag,
         request.content_capture_limit,
     );
+    errdefer {
+        var owned = stream_provider.Result{ .completed = .{
+            .completion = completion,
+            .ownership = .owned,
+        } };
+        owned.deinit(alloc);
+    }
+    const usage_outcome: stream_provider.UsageOutcome = usage: {
+        if (completion.generation_id == null) {
+            break :usage .{ .unavailable = .possibly_billed };
+        }
+        completion.billing = try responses_protocol.buildSubscriptionBilling(
+            alloc,
+            .grok,
+            request.model,
+            @max(io_mod.milliTimestamp(), 0),
+            completion.usage,
+        ) orelse break :usage .{ .unavailable = .possibly_billed };
+        break :usage .{ .exact = .grok };
+    };
     return .{ .completed = .{
         .completion = completion,
-        .usage = .{ .immediate = null },
+        .usage = usage_outcome,
         .ownership = .owned,
     } };
 }

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -17,6 +17,7 @@ import { FX_BIN, REPO_ROOT, runFx } from "../evals/eval-helpers";
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  fakeGatewaySse,
   startFakeGateway,
   TmuxSession,
   tmuxAvailable,
@@ -58,6 +59,52 @@ function grokModalityModel(id: string, vision: boolean) {
     id,
     input_modalities: vision ? ["text", "image"] : ["text"],
     output_modalities: ["text"],
+  };
+}
+
+function startFakeDirectUsageProvider(
+  provider: "codex" | "grok",
+  model: string,
+  responseId: string,
+  inputTokens: number,
+  outputTokens: number,
+) {
+  let responses = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const path = new URL(request.url).pathname;
+      if (path === "/models") {
+        return provider === "codex"
+          ? Response.json({ models: [{
+            slug: model,
+            visibility: "list",
+            supported_in_api: true,
+            supported_reasoning_levels: [{ effort: "high" }],
+            additional_speed_tiers: [],
+            input_modalities: ["text"],
+            context_window: 272000,
+          }] })
+          : Response.json({ data: [grokSubscriptionModel(model, 500_000)] });
+      }
+      if (path === "/modalities") {
+        return Response.json({ models: [grokModalityModel(model, false)] });
+      }
+      responses += 1;
+      return new Response(
+        `data: ${JSON.stringify({ type: "response.output_text.delta", delta: `${provider.toUpperCase()}_USAGE_OK` })}\n\n` +
+          `data: ${JSON.stringify({ type: "response.completed", response: { id: responseId, status: "completed", usage: { input_tokens: inputTokens, output_tokens: outputTokens } } })}\n\n`,
+        { headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  });
+  return {
+    get responses() { return responses; },
+    responsesUrl: `http://127.0.0.1:${server.port}/responses`,
+    modelsUrl: `http://127.0.0.1:${server.port}/models`,
+    modalitiesUrl: `http://127.0.0.1:${server.port}/modalities`,
+    stop() { server.stop(true); },
   };
 }
 
@@ -122,6 +169,10 @@ function readSingleUsageSnapshot(testHome: string): {
   billing: string;
   next_sequence: number;
   settled_through_sequence: number;
+  input_tokens: number;
+  output_tokens: number;
+  request_count: number | null;
+  models: Array<{ model: string; request_count: number | null }>;
   pending: unknown[];
 } {
   const sessionsDir = join(testHome, ".fx", "sessions");
@@ -135,6 +186,10 @@ function readSingleUsageSnapshot(testHome: string): {
       billing: string;
       next_sequence: number;
       settled_through_sequence: number;
+      input_tokens: number;
+      output_tokens: number;
+      request_count: number | null;
+      models: Array<{ model: string; request_count: number | null }>;
       pending: unknown[];
     };
   }).snapshot;
@@ -2965,6 +3020,127 @@ test(
 );
 
 test(
+  "saved provider switching publishes Gateway, Codex, and Grok usage to one profile ledger",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-provider-usage-ledger-"));
+    const workspace = join(home, "workspace");
+    mkdirSync(workspace, { recursive: true });
+    gateway = startFakeGateway([
+      fakeGatewaySse([
+        {
+          type: "response-metadata",
+          modelId: FAKE_GATEWAY_MODEL,
+          timestamp: new Date().toISOString(),
+        },
+        {
+          type: "text-start",
+          id: "gateway_answer",
+          providerMetadata: {
+            gateway: { generationId: "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV" },
+          },
+        },
+        { type: "text-delta", id: "gateway_answer", delta: "GATEWAY_USAGE_OK" },
+        { type: "text-end", id: "gateway_answer" },
+        {
+          type: "finish",
+          finishReason: { unified: "stop", raw: "stop" },
+          usage: {
+            inputTokens: { total: 13 },
+            outputTokens: { total: 4 },
+          },
+          providerMetadata: {
+            gateway: {
+              generationId: "gen_01ARZ3NDEKTSV4RRFFQ69G5FAV",
+              cost: "0.01",
+              routing: { canonicalSlug: FAKE_GATEWAY_MODEL },
+            },
+          },
+        },
+      ]),
+    ]);
+    const codex = startFakeDirectUsageProvider(
+      "codex",
+      "gpt-5.6-sol",
+      "response-codex-profile",
+      17,
+      7,
+    );
+    const grok = startFakeDirectUsageProvider(
+      "grok",
+      "grok-4.20",
+      "response-grok-profile",
+      19,
+      5,
+    );
+    try {
+      writeSeededChatGptLogin(home, chatgptAccessToken("acct_usage"));
+      writeSeededGrokLogin(home, "grok-usage-token", "acct_usage");
+      const env = {
+        HOME: home,
+        AI_GATEWAY_API_KEY: "gateway-usage-key",
+        VERCEL_OIDC_TOKEN: undefined,
+        FX_DISABLE_KEYCHAIN: "1",
+        FX_AUTO_UPGRADE: "0",
+        FX_GATEWAY_BASE_URL: gateway.baseUrl,
+        FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+        FX_E2E_GATEWAY_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+        FX_E2E_OPENAI_CODEX_RESPONSES_URL: codex.responsesUrl,
+        FX_E2E_OPENAI_CODEX_MODELS_URL: codex.modelsUrl,
+        FX_E2E_XAI_GROK_RESPONSES_URL: grok.responsesUrl,
+        FX_E2E_XAI_GROK_MODELS_URL: grok.modelsUrl,
+        FX_E2E_XAI_GROK_MODALITIES_URL: grok.modalitiesUrl,
+      };
+      const settingsPath = join(home, ".fx", "settings.json");
+      const routes = [
+        { settings: { provider: "gateway", model: FAKE_GATEWAY_MODEL }, text: "GATEWAY_USAGE_OK" },
+        { settings: { provider: "codex", codex_model: "gpt-5.6-sol" }, text: "CODEX_USAGE_OK" },
+        { settings: { provider: "grok", grok_model: "grok-4.20" }, text: "GROK_USAGE_OK" },
+      ];
+      for (const route of routes) {
+        writeFileSync(settingsPath, JSON.stringify(route.settings) + "\n", { mode: 0o600 });
+        const result = await runFx(
+          ["ask", "--json", `Return ${route.text}.`],
+          { cwd: workspace, env, timeoutMs: TIMEOUT },
+        );
+        expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain(route.text);
+      }
+
+      const usage = await runFx(
+        ["usage", "--json", "--period", "24h"],
+        { cwd: workspace, env: { HOME: home }, timeoutMs: TIMEOUT },
+      );
+      expect(usage.code, usage.stderr).toBe(0);
+      const report = JSON.parse(usage.stdout) as {
+        completeness: string;
+        totals: { input_tokens: number; output_tokens: number; request_count: number };
+        models: Array<{ model: string; totals: { request_count: number } }>;
+      };
+      expect(report.completeness).toBe("complete");
+      expect(report.totals).toMatchObject({
+        input_tokens: 49,
+        output_tokens: 16,
+        request_count: 3,
+      });
+      expect(Object.fromEntries(
+        report.models.map((model) => [model.model, model.totals.request_count]),
+      )).toEqual({
+        [FAKE_GATEWAY_MODEL]: 1,
+        "codex/gpt-5.6-sol": 1,
+        "grok/grok-4.20": 1,
+      });
+      expect(gateway.requests).toHaveLength(1);
+      expect(codex.responses).toBe(1);
+      expect(grok.responses).toBe(1);
+    } finally {
+      codex.stop();
+      grok.stop();
+    }
+  },
+  60_000,
+);
+
+test(
   "Codex automatic review uses gpt-5.4-mini while Gateway review stays untouched",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-codex-auto-review-"));
@@ -3007,8 +3183,15 @@ test(
       expect(readSingleUsageSnapshot(home)).toMatchObject({
         billing: "complete",
         api_duration_complete: true,
-        next_sequence: 1,
-        settled_through_sequence: 0,
+        next_sequence: 4,
+        settled_through_sequence: 3,
+        input_tokens: 20,
+        output_tokens: 8,
+        request_count: 3,
+        models: [
+          { model: "codex/gpt-5.6-sol", request_count: 2 },
+          { model: "codex/gpt-5.4-mini", request_count: 1 },
+        ],
         pending: [],
       });
     } finally {
@@ -3071,8 +3254,12 @@ test(
       expect(readSingleUsageSnapshot(home)).toMatchObject({
         billing: "complete",
         api_duration_complete: true,
-        next_sequence: 1,
-        settled_through_sequence: 0,
+        next_sequence: 4,
+        settled_through_sequence: 3,
+        input_tokens: 20,
+        output_tokens: 8,
+        request_count: 3,
+        models: [{ model: "grok/grok-4.20", request_count: 3 }],
         pending: [],
       });
     } finally {


### PR DESCRIPTION
## Summary

- Persist exact usage from saved Codex and Grok requests in the existing profile ledger.
- Count direct automatic permission reviews and successful auth retries once.
- Keep Gateway deferred accounting and `fx ask --no-save` behavior unchanged.
- Recover exact facts across checkpoint and profile publication failures without double-counting.