### PR TITLE
Release each refreshed credential exactly once when the save fails

### DIFF
--- a/src/core/auth/chatgpt_oauth.zig
+++ b/src/core/auth/chatgpt_oauth.zig
@@ -459,7 +459,7 @@ fn refreshSession(
         .account_id = account_id,
     };
     token.access_token = &.{};
-    errdefer replacement.deinit(alloc);
+    errdefer secret.zeroAndFree(alloc, replacement.access_token);
     try mutation.save(alloc, replacement);
 
     session.deinit(alloc);
@@ -984,4 +984,132 @@ test "ChatGPT browser callback requires the exact path and state" {
             "expected",
         ),
     );
+}
+
+/// JWTs whose payload carries the namespaced `chatgpt_account_id` claim.
+const account_test_jwt = "header.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF90ZXN0In19.signature";
+const account_other_jwt = "header.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdF9vdGhlciJ9fQ.signature";
+
+fn refreshResponseBody(alloc: Allocator, access_token: []const u8) ![]u8 {
+    return std.fmt.allocPrint(
+        alloc,
+        "{{\"access_token\":\"{s}\",\"refresh_token\":\"new-refresh\",\"expires_in\":3600}}",
+        .{access_token},
+    );
+}
+
+test "ChatGPT refresh releases every credential exactly once when the save fails" {
+    const alloc = std.testing.allocator;
+    const State = struct {
+        fn execute(
+            _: ?*anyopaque,
+            a: Allocator,
+            request: oauth_transport.Request,
+        ) !oauth_transport.Response {
+            if (request.method != .post_json) return error.UnexpectedRequest;
+            return .{ .disposition = .accepted, .body = try refreshResponseBody(a, account_test_jwt) };
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var lock_file = try tmp.dir.createFile(io_mod.getIo(), "lock", .{ .truncate = true });
+    defer lock_file.close(io_mod.getIo());
+
+    // An unwritable profile directory is the ordinary disk condition that makes
+    // the save fail after the replacement session already owns the credentials.
+    tmp.dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o500)) catch
+        return error.SkipZigTest;
+    defer tmp.dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {};
+
+    var mutation = chatgpt_session.Mutation{
+        .fx_dir = .{ .dir = tmp.dir },
+        .lock = .{ .file = lock_file },
+    };
+    var session = chatgpt_session.Session{
+        .access_token = try alloc.dupe(u8, "old-access"),
+        .refresh_token = try alloc.dupe(u8, "old-refresh"),
+        .expires_at_ms = 0,
+        .account_id = try alloc.dupe(u8, "acct_test"),
+    };
+    defer session.deinit(alloc);
+
+    try std.testing.expectError(
+        error.DurableReplacePreRenameFailed,
+        refreshSession(alloc, .{ .execute_fn = State.execute }, &mutation, &session),
+    );
+    try std.testing.expectEqualStrings("old-refresh", session.refresh_token);
+}
+
+test "ChatGPT refresh replaces the stored session when the save succeeds" {
+    const alloc = std.testing.allocator;
+    const State = struct {
+        fn execute(
+            _: ?*anyopaque,
+            a: Allocator,
+            request: oauth_transport.Request,
+        ) !oauth_transport.Response {
+            if (request.method != .post_json) return error.UnexpectedRequest;
+            return .{ .disposition = .accepted, .body = try refreshResponseBody(a, account_test_jwt) };
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var lock_file = try tmp.dir.createFile(io_mod.getIo(), "lock", .{ .truncate = true });
+    defer lock_file.close(io_mod.getIo());
+
+    var mutation = chatgpt_session.Mutation{
+        .fx_dir = .{ .dir = tmp.dir },
+        .lock = .{ .file = lock_file },
+    };
+    var session = chatgpt_session.Session{
+        .access_token = try alloc.dupe(u8, "old-access"),
+        .refresh_token = try alloc.dupe(u8, "old-refresh"),
+        .expires_at_ms = 0,
+        .account_id = try alloc.dupe(u8, "acct_test"),
+    };
+    defer session.deinit(alloc);
+
+    try refreshSession(alloc, .{ .execute_fn = State.execute }, &mutation, &session);
+    try std.testing.expectEqualStrings(account_test_jwt, session.access_token);
+    try std.testing.expectEqualStrings("new-refresh", session.refresh_token);
+    try std.testing.expectEqualStrings("acct_test", session.account_id);
+}
+
+test "ChatGPT refresh rejects a changed account without leaking the extracted id" {
+    const alloc = std.testing.allocator;
+    const State = struct {
+        fn execute(
+            _: ?*anyopaque,
+            a: Allocator,
+            request: oauth_transport.Request,
+        ) !oauth_transport.Response {
+            if (request.method != .post_json) return error.UnexpectedRequest;
+            return .{ .disposition = .accepted, .body = try refreshResponseBody(a, account_other_jwt) };
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var lock_file = try tmp.dir.createFile(io_mod.getIo(), "lock", .{ .truncate = true });
+    defer lock_file.close(io_mod.getIo());
+
+    var mutation = chatgpt_session.Mutation{
+        .fx_dir = .{ .dir = tmp.dir },
+        .lock = .{ .file = lock_file },
+    };
+    var session = chatgpt_session.Session{
+        .access_token = try alloc.dupe(u8, "old-access"),
+        .refresh_token = try alloc.dupe(u8, "old-refresh"),
+        .expires_at_ms = 0,
+        .account_id = try alloc.dupe(u8, "acct_test"),
+    };
+    defer session.deinit(alloc);
+
+    try std.testing.expectError(
+        error.ChatGptAccountChanged,
+        refreshSession(alloc, .{ .execute_fn = State.execute }, &mutation, &session),
+    );
+    try std.testing.expectEqualStrings("old-access", session.access_token);
 }

--- a/src/core/auth/grok_oauth.zig
+++ b/src/core/auth/grok_oauth.zig
@@ -559,7 +559,7 @@ fn refreshSession(
         .account_id = account_id,
     };
     token.access_token = &.{};
-    errdefer replacement.deinit(alloc);
+    errdefer secret.zeroAndFree(alloc, replacement.access_token);
     try mutation.save(alloc, replacement);
 
     session.deinit(alloc);
@@ -1078,4 +1078,132 @@ test "Grok browser callback requires the exact path and state" {
             "expected",
         ),
     );
+}
+
+test "Grok refresh releases every credential exactly once when the save fails" {
+    const alloc = std.testing.allocator;
+    const State = struct {
+        fn execute(
+            _: ?*anyopaque,
+            a: Allocator,
+            request: oauth_transport.Request,
+        ) !oauth_transport.Response {
+            const body = switch (request.method) {
+                .post_form => "{\"access_token\":\"new-access\",\"refresh_token\":\"new-refresh\",\"expires_in\":3600}",
+                .get => "{\"sub\":\"acct_test\"}",
+                else => return error.UnexpectedRequest,
+            };
+            return .{ .disposition = .accepted, .body = try a.dupe(u8, body) };
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var lock_file = try tmp.dir.createFile(io_mod.getIo(), "lock", .{ .truncate = true });
+    defer lock_file.close(io_mod.getIo());
+
+    // An unwritable profile directory is the ordinary disk condition that makes
+    // the save fail after the replacement session already owns the credentials.
+    tmp.dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o500)) catch
+        return error.SkipZigTest;
+    defer tmp.dir.setPermissions(io_mod.getIo(), std.Io.File.Permissions.fromMode(0o700)) catch {};
+
+    var mutation = grok_session.Mutation{
+        .fx_dir = .{ .dir = tmp.dir },
+        .lock = .{ .file = lock_file },
+    };
+    var session = grok_session.Session{
+        .access_token = try alloc.dupe(u8, "old-access"),
+        .refresh_token = try alloc.dupe(u8, "old-refresh"),
+        .expires_at_ms = 0,
+        .account_id = try alloc.dupe(u8, "acct_test"),
+    };
+    defer session.deinit(alloc);
+
+    try std.testing.expectError(
+        error.DurableReplacePreRenameFailed,
+        refreshSession(alloc, .{ .execute_fn = State.execute }, &mutation, &session),
+    );
+    try std.testing.expectEqualStrings("old-refresh", session.refresh_token);
+}
+
+test "Grok refresh replaces the stored session when the save succeeds" {
+    const alloc = std.testing.allocator;
+    const State = struct {
+        fn execute(
+            _: ?*anyopaque,
+            a: Allocator,
+            request: oauth_transport.Request,
+        ) !oauth_transport.Response {
+            const body = switch (request.method) {
+                .post_form => "{\"access_token\":\"new-access\",\"refresh_token\":\"new-refresh\",\"expires_in\":3600}",
+                .get => "{\"sub\":\"acct_test\"}",
+                else => return error.UnexpectedRequest,
+            };
+            return .{ .disposition = .accepted, .body = try a.dupe(u8, body) };
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var lock_file = try tmp.dir.createFile(io_mod.getIo(), "lock", .{ .truncate = true });
+    defer lock_file.close(io_mod.getIo());
+
+    var mutation = grok_session.Mutation{
+        .fx_dir = .{ .dir = tmp.dir },
+        .lock = .{ .file = lock_file },
+    };
+    var session = grok_session.Session{
+        .access_token = try alloc.dupe(u8, "old-access"),
+        .refresh_token = try alloc.dupe(u8, "old-refresh"),
+        .expires_at_ms = 0,
+        .account_id = try alloc.dupe(u8, "acct_test"),
+    };
+    defer session.deinit(alloc);
+
+    try refreshSession(alloc, .{ .execute_fn = State.execute }, &mutation, &session);
+    try std.testing.expectEqualStrings("new-access", session.access_token);
+    try std.testing.expectEqualStrings("new-refresh", session.refresh_token);
+    try std.testing.expectEqualStrings("acct_test", session.account_id);
+}
+
+test "Grok refresh rejects a changed account without leaking the fetched id" {
+    const alloc = std.testing.allocator;
+    const State = struct {
+        fn execute(
+            _: ?*anyopaque,
+            a: Allocator,
+            request: oauth_transport.Request,
+        ) !oauth_transport.Response {
+            const body = switch (request.method) {
+                .post_form => "{\"access_token\":\"new-access\",\"refresh_token\":\"new-refresh\",\"expires_in\":3600}",
+                .get => "{\"sub\":\"acct_other\"}",
+                else => return error.UnexpectedRequest,
+            };
+            return .{ .disposition = .accepted, .body = try a.dupe(u8, body) };
+        }
+    };
+
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var lock_file = try tmp.dir.createFile(io_mod.getIo(), "lock", .{ .truncate = true });
+    defer lock_file.close(io_mod.getIo());
+
+    var mutation = grok_session.Mutation{
+        .fx_dir = .{ .dir = tmp.dir },
+        .lock = .{ .file = lock_file },
+    };
+    var session = grok_session.Session{
+        .access_token = try alloc.dupe(u8, "old-access"),
+        .refresh_token = try alloc.dupe(u8, "old-refresh"),
+        .expires_at_ms = 0,
+        .account_id = try alloc.dupe(u8, "acct_test"),
+    };
+    defer session.deinit(alloc);
+
+    try std.testing.expectError(
+        error.GrokAccountChanged,
+        refreshSession(alloc, .{ .execute_fn = State.execute }, &mutation, &session),
+    );
+    try std.testing.expectEqualStrings("old-access", session.access_token);
 }


### PR DESCRIPTION
Fixes #436.

`refreshSession` in both `grok_oauth.zig` and `chatgpt_oauth.zig` armed three errdefers over the same two allocations before persisting the refreshed session. `replacement` held the account id and the refresh token, and its own `errdefer replacement.deinit(alloc)` released all three `Session` fields, so a failed `mutation.save` unwound into the two earlier errdefers and freed the refresh token and the account id a second time, secure-zeroing into the freed block along the way.

An unwritable `~/.fx` is enough to reach it, and a background refresh can hit that with no user action.

The fix is one line per provider: give the access token its own errdefer rather than the composite deinit, which leaves exactly one owner per slice.

```
-    errdefer replacement.deinit(alloc);
+    errdefer secret.zeroAndFree(alloc, replacement.access_token);
```

The existing `replacement.access_token = &.{}` on the success path still disarms it, since `zeroAndFree` returns early on an empty slice, and the account-changed early return keeps the single owner it already had.

## Verification

Six regression tests, three per provider, in the files that already own `requestRefreshToken` coverage. The save-failure case points the mutation at a `0500` directory so `durableReplaceVerified` fails, and `std.testing.allocator` catches the rest.

Each branch was run both ways rather than reasoned through:

- save fails: 4 double frees and exit 1 before the fix, 0 and exit 0 after, so the new tests are load-bearing rather than vacuously green
- save succeeds: clean, session replaced with the new credentials
- account changed: `GrokAccountChanged` / `ChatGptAccountChanged`, account id freed exactly once, unchanged by this patch

Auth import graph is 87 passed / 11 skipped / 0 failed. `zig build` is clean and the binary runs.

## Scope

The other errdefer sites in these two files (`grok_oauth.zig` 352, 667, 732 and `chatgpt_oauth.zig` 322, 589, 659) already keep one owner per slice and are untouched. `credentials.refreshFxSession`, the Vercel path, updates session fields in place with no replacement struct and does not share the defect.

No file overlap with any open PR. #379 rewrites `stringify` in the session modules these tests reach through `mutation.save`, so I merged it locally and reran: still green, no conflict.