### PR TITLE
Gate privileged release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,7 @@ jobs:
   release:
     needs: [check-version, build-linux, build-macos-x86_64, build-macos-arm64]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:

--- a/scripts/tests/test_macos_signing.py
+++ b/scripts/tests/test_macos_signing.py
@@ -14,6 +14,9 @@ import unittest
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "sign-and-notarize-macos.sh"
 RELEASE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
+PUBLISH_LIBFX_WORKFLOW_PATH = (
+    REPO_ROOT / ".github" / "workflows" / "publish-libfx.yml"
+)
 PGSO_WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "pgso-macos-arm64.yml"
 )
@@ -340,6 +343,16 @@ else:
 
 
 class MacosSigningWorkflowTests(unittest.TestCase):
+    def test_every_privileged_publish_job_uses_an_environment_gate(self) -> None:
+        release = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+        publish_libfx = PUBLISH_LIBFX_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        release_job = release.split("  release:\n", 1)[1]
+        npm_publish_job = publish_libfx.split("  publish:\n", 1)[1]
+
+        self.assertIn("environment: release", release_job)
+        self.assertIn("environment: npm", npm_publish_job)
+
     def test_stable_release_is_the_only_workflow_with_signing_secrets(self) -> None:
         release = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
         pgso = PGSO_WORKFLOW_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Pause stable tag, GitHub Release, and CDN publication for lead approval.
- Keep npm publishing and Apple signing behind their protected environments.
- Require each privileged release environment to deploy from main.