### PR TITLE
Add read-only mode to fx ask

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ fx ask "explain the changes in this repository"
 
 With `--json`, `output` contains accumulated assistant Markdown across the request, while `final_output` contains only a completed final assistant response and is `""` for interrupted, failed, background, or otherwise absent final responses.
 
+Add `--read-only` when the model should inspect the workspace without changing it:
+
+```bash
+fx ask --read-only "review the authentication flow and propose a migration plan"
+```
+
+Read-only requests expose only file listing, globbing, searching, reading, and authorized-image inspection tools. The restriction is enforced for that invocation, including resumed sessions, and cannot be relaxed by `--auto` or `--yolo`. Session metadata is still saved normally; combine the flag with `--no-save` when no session should be persisted.
+
 Foreground terminal commands run with an explicit finite deadline. fx uses durable terminal sessions for services, watchers, GUI applications, and other long-lived work, and keeps captured foreground output available through an opaque bounded-read handle for the active session or `--no-save` process.
 
 fx starts in `auto` permission mode. Routine understood development actions run directly. Each unresolved action receives one narrow safety review based on the current user request and the exact pending action. A clear result authorizes only that action. A caution or unavailable review holds the action and returns advice to the agent without opening a permission prompt or ending the turn. See [Permissions](https://fx.sh/docs/configure-fx/permissions) for other modes and persistent rules.

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -30,11 +30,12 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .ask,
         .token = "ask",
-        .usage = "ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>",
+        .usage = "ask [--auto|--yolo] [--read-only] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>",
         .summary = "Run one noninteractive request",
         .options = &.{
             .{ .flag = "--auto", .description = "Automatically review unresolved permission requests" },
             .{ .flag = "--yolo", .description = "Disable fx permission checks" },
+            .{ .flag = "--read-only", .description = "Restrict the model to read-only inspection tools" },
             .{ .flag = "--image PATH", .description = "Attach an image file; repeat for multiple images" },
             json_option,
             .{ .flag = "--quiet", .description = "Suppress assistant output" },

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -2214,6 +2214,7 @@ pub const read_only_tool_names = [_][]const u8{
     "glob_files",
     "grep_files",
     "list_files",
+    "vision",
 };
 
 pub fn isReadOnlyToolName(name: []const u8) bool {
@@ -3258,6 +3259,7 @@ test "built-in read-only tool set matches plan inspection tools" {
         "glob_files",
         "grep_files",
         "list_files",
+        "vision",
     };
 
     try std.testing.expectEqual(expected_names.len, read_only_tool_names.len);

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -110,6 +110,20 @@ const supports_headless_interrupt = switch (std_builtin.os.tag) {
 const HeadlessInterruptInstallError = error{HeadlessInterruptBusy};
 const headless_interrupt_exit_code: u8 = 130;
 const headless_termination_exit_code: u8 = 143;
+const read_only_mode_id = "read_only";
+const read_only_mode = mode_registry.ModeSpec{
+    .id = read_only_mode_id,
+    .name = "Read Only",
+    .description = "Inspect the workspace without modifying it",
+    .permission_mode = .ask,
+    .tool_policy = .read_only,
+    .tool_policy_denial_message = "Read-only mode only allows read-only inspection tools.",
+};
+const read_only_modes = [_]mode_registry.ModeSpec{read_only_mode};
+const read_only_registry = mode_registry.Registry{
+    .default_mode_id = read_only_mode_id,
+    .modes = read_only_modes[0..],
+};
 
 const headless_interrupt = if (supports_headless_interrupt) struct {
     var coordinator_mutex: std.Io.Mutex = .init;
@@ -290,6 +304,7 @@ pub const PromptRunResult = struct {
     final_output: []u8 = &.{},
     interrupted: bool = false,
     model: []u8 = &.{},
+    mode: []u8 = &.{},
     session_id: []u8 = &.{},
     tool_calls: []ToolCallRecord = &.{},
     step_count: usize = 0,
@@ -302,6 +317,7 @@ pub const PromptRunResult = struct {
         alloc.free(self.assistant_output);
         if (self.final_output.len > 0) alloc.free(self.final_output);
         if (self.model.len > 0) alloc.free(self.model);
+        if (self.mode.len > 0) alloc.free(self.mode);
         if (self.session_id.len > 0) alloc.free(self.session_id);
         freeToolCallRecords(alloc, self.tool_calls);
     }
@@ -314,6 +330,7 @@ const AskOptions = struct {
     prompt: []u8,
     resume_target: ?ResumeTarget = null,
     permission_override: ?PermissionMode = null,
+    read_only: bool = false,
     image_paths: std.ArrayList([]u8) = .empty,
     images: std.ArrayList(ImageAttachment) = .empty,
     system_prompt_override: ?[]u8 = null,
@@ -1258,6 +1275,7 @@ fn runWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: 
     if (options.system_prompt_override) |sp| {
         effective_cfg.prompt_policy.system_prompt = sp;
     }
+    if (options.read_only) effective_cfg.mode_registry = read_only_registry;
 
     const output_mode = selectOutputMode(
         options.quiet,
@@ -1387,6 +1405,7 @@ fn missingCredentialResult(
     alloc: Allocator,
     options: RunOptions,
     provider: model_provider.ProviderId,
+    mode_id: []const u8,
 ) !PromptRunResult {
     const message = if (provider == .codex)
         credentials.missing_chatgpt_credential_message
@@ -1397,9 +1416,13 @@ fn missingCredentialResult(
     try options.deps.write_stderr(options.deps.stderr_ctx, "fx ask: ");
     try options.deps.write_stderr(options.deps.stderr_ctx, message);
     try options.deps.write_stderr(options.deps.stderr_ctx, "\n");
+    const assistant_output = try alloc.dupe(u8, "");
+    errdefer alloc.free(assistant_output);
+    const result_mode = try alloc.dupe(u8, mode_id);
     return .{
         .exit_code = 1,
-        .assistant_output = try alloc.dupe(u8, ""),
+        .assistant_output = assistant_output,
+        .mode = result_mode,
         .error_code = "MissingCredentials",
     };
 }
@@ -1419,8 +1442,15 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     defer startup.deinit(alloc);
     try checkHeadlessCancellation(options.deps);
 
-    var permission_mode = toCorePermissionMode(startup.permission_mode);
     const mode_id: []const u8 = cfg.mode_registry.default_mode_id;
+    const mode_is_read_only = if (cfg.mode_registry.lookup(mode_id)) |mode|
+        mode.tool_policy == .read_only
+    else
+        false;
+    var effective_deps = options.deps;
+    if (mode_is_read_only) effective_deps.start_subagent_background_recovery = false;
+
+    var permission_mode = toCorePermissionMode(startup.permission_mode);
     if (permission_override) |explicit| permission_mode = explicit;
 
     if (permission_mode == .yolo and !startup.yolo_acknowledged) {
@@ -1450,12 +1480,12 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     try checkHeadlessCancellation(options.deps);
 
     if (!options.continue_recovery and options.resume_target == null and startup.credential == null) {
-        return missingCredentialResult(alloc, options, startup.provider);
+        return missingCredentialResult(alloc, options, startup.provider, mode_id);
     }
 
     var owned_resumed_model: ?[]u8 = null;
     defer if (owned_resumed_model) |model| alloc.free(model);
-    var ctx = AskContext.init(alloc, cfg, options.deps, startup.workspace_root);
+    var ctx = AskContext.init(alloc, cfg, effective_deps, startup.workspace_root);
     defer ctx.deinit();
     if (options.save_session) {
         _ = try ctx.session.initializeProfileUsage(alloc, io_mod.getenv("HOME"));
@@ -1547,7 +1577,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         );
         routed_credential = resolution.credential;
         if (routed_credential == null) {
-            return missingCredentialResult(alloc, options, ctx.provider);
+            return missingCredentialResult(alloc, options, ctx.provider, mode_id);
         }
         break :routed &routed_credential.?;
     };
@@ -1630,19 +1660,21 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     }
 
     try ctx.checkCancellation();
-    ctx.mcp = try options.deps.load_mcp_runtime(alloc, ctx.mcp_elicitation_capabilities);
-    if (ctx.mcp) |mcp| mcp.connectRequiredForAsk(ctx.toolRegistry());
-    try ctx.checkCancellation();
-    if (ctx.mcp) |mcp| {
-        if (try mcp.requiredStartupFailure(
-            alloc,
-            @intCast(@max(io_mod.milliTimestamp(), 0)),
-        )) |failure| {
-            defer alloc.free(failure);
-            try ctx.writeStderr("fx ask: ");
-            try ctx.writeStderr(failure);
-            try ctx.writeStderr("\n");
-            return error.McpRequiredServerUnavailable;
+    if (!mode_is_read_only) {
+        ctx.mcp = try options.deps.load_mcp_runtime(alloc, ctx.mcp_elicitation_capabilities);
+        if (ctx.mcp) |mcp| mcp.connectRequiredForAsk(ctx.toolRegistry());
+        try ctx.checkCancellation();
+        if (ctx.mcp) |mcp| {
+            if (try mcp.requiredStartupFailure(
+                alloc,
+                @intCast(@max(io_mod.milliTimestamp(), 0)),
+            )) |failure| {
+                defer alloc.free(failure);
+                try ctx.writeStderr("fx ask: ");
+                try ctx.writeStderr(failure);
+                try ctx.writeStderr("\n");
+                return error.McpRequiredServerUnavailable;
+            }
         }
     }
     const session_child_capability = if (ctx.writable) |*writable|
@@ -1760,11 +1792,14 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         error.NonInteractivePermissionRequired => {
             const assistant_output = try alloc.dupe(u8, ctx.assistant_output.items);
             errdefer alloc.free(assistant_output);
+            const mode = try alloc.dupe(u8, ctx.mode_id);
+            errdefer alloc.free(mode);
             const tool_calls = try takeToolCallRecords(&ctx, alloc);
             return .{
                 .exit_code = 1,
                 .assistant_output = assistant_output,
                 .interrupted = ctx.processInterruptRequested(),
+                .mode = mode,
                 .tool_calls = tool_calls,
                 .error_code = "NonInteractivePermissionRequired",
             };
@@ -1795,6 +1830,8 @@ fn takePromptRunResult(ctx: *AskContext, alloc: Allocator) !PromptRunResult {
     errdefer if (final_output.len > 0) alloc.free(final_output);
     const model = try alloc.dupe(u8, ctx.model);
     errdefer alloc.free(model);
+    const mode = try alloc.dupe(u8, ctx.mode_id);
+    errdefer alloc.free(mode);
     const session_id = if (ctx.writable) |writable|
         try alloc.dupe(u8, writable.active_id)
     else
@@ -1809,6 +1846,7 @@ fn takePromptRunResult(ctx: *AskContext, alloc: Allocator) !PromptRunResult {
         .final_output = final_output,
         .interrupted = ctx.processInterruptRequested(),
         .model = model,
+        .mode = mode,
         .session_id = session_id,
         .tool_calls = tool_calls,
         .step_count = ctx.step_count,
@@ -2439,6 +2477,19 @@ fn executeToolCallAuthorized(
     request: agent_runtime.ToolExecutionRequest,
 ) !ToolExecutionResult {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
+    if (try ctx.cfg.mode_registry.toolPolicyDeniedJson(
+        request.result_allocator,
+        ctx.deps.tool_set,
+        ctx.mode_id,
+        request.call.name,
+    )) |reason| {
+        const result = ToolExecutionResult{
+            .status = .failure,
+            .model_output = reason,
+        };
+        captureToolExecutionResult(ctx, request, result);
+        return result;
+    }
     var tool_ctx = ctx.toolContext();
     tool_ctx.root_user_intent_context = request.root_user_intent_context;
     tool_ctx.root_user_messages = request.root_user_messages;
@@ -3351,6 +3402,8 @@ fn parseOptionsWithStdin(alloc: Allocator, args: []const [:0]const u8, stdin: St
         } else if (std.mem.eql(u8, arg, "--yolo")) {
             if (opts.permission_override != null) return error.InvalidAskArgs;
             opts.permission_override = .yolo;
+        } else if (std.mem.eql(u8, arg, "--read-only")) {
+            opts.read_only = true;
         } else if (std.mem.eql(u8, arg, "--resume") or std.mem.eql(u8, arg, "--resume-id")) {
             if (opts.resume_target != null) return error.InvalidAskArgs;
             const exact_id = std.mem.eql(u8, arg, "--resume-id");
@@ -3540,6 +3593,8 @@ fn renderFinalJsonResult(alloc: Allocator, result: PromptRunResult) ![]u8 {
     try out.writer.print(",\"exit_code\":{d}", .{result.exit_code});
     try out.writer.writeAll(",\"model\":");
     try std.json.Stringify.value(result.model, .{}, &out.writer);
+    try out.writer.writeAll(",\"mode\":");
+    try std.json.Stringify.value(result.mode, .{}, &out.writer);
     try out.writer.writeAll(",\"session_id\":");
     try std.json.Stringify.value(result.session_id, .{}, &out.writer);
     try out.writer.print(",\"steps\":{d}", .{result.step_count});
@@ -3622,7 +3677,7 @@ fn renderErrorJsonResult(alloc: Allocator, err_name: []const u8) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
 
-    try out.writer.writeAll("{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":");
+    try out.writer.writeAll("{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":");
     try std.json.Stringify.value(err_name, .{}, &out.writer);
     try out.writer.writeAll("}\n");
     return try out.toOwnedSlice();
@@ -3833,7 +3888,7 @@ fn testModelPromptOverlay(model: []const u8) ?[]const u8 {
 
 fn testConfig() Config {
     return .{
-        .command_usage = "ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--] <prompt>",
+        .command_usage = "ask [--auto|--yolo] [--read-only] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--] <prompt>",
         .default_model = "model",
         .default_agent_step_limit = 4,
         .gateway_retry_count = 1,
@@ -4025,6 +4080,66 @@ fn testProcessQueuedPromptChecksFullTerminal(deps: *const agent_runtime.AgentRun
         if (std.mem.eql(u8, function.name, "terminal")) break function;
     } else return error.TestExpectedEqual;
     try std.testing.expect(std.mem.find(u8, advertised_terminal.description, "Use start") != null);
+    try testPushAssistantText(deps, "assistant text");
+}
+
+fn testProcessQueuedPromptChecksReadOnly(deps: *const agent_runtime.AgentRuntimeDeps, semantic_presentation: ?agent_runtime.SemanticPresentationSink, _: agent_runtime.LifecycleContext, cfg: agent_runtime.Config, _: worker_runtime.QueuedPrompt) !void {
+    try std.testing.expect(semantic_presentation == null);
+    const ctx: *AskContext = @ptrCast(@alignCast(deps.ctx));
+    try std.testing.expectEqualStrings(read_only_mode_id, ctx.mode_id);
+    try std.testing.expectEqual(PermissionMode.auto, ctx.permission_mode);
+    try std.testing.expect(ctx.mcp == null);
+    try std.testing.expect(!ctx.deps.start_subagent_background_recovery);
+    const expected_advertised_names = [_][]const u8{
+        "read_file",
+        "glob_files",
+        "grep_files",
+        "list_files",
+    };
+    try std.testing.expectEqual(expected_advertised_names.len, cfg.advertised_tool_names.len);
+    try std.testing.expectEqual(expected_advertised_names.len, cfg.advertised_functions.len);
+    for (expected_advertised_names, cfg.advertised_tool_names, cfg.advertised_functions) |expected, advertised_name, advertised_function| {
+        try std.testing.expectEqualStrings(expected, advertised_name);
+        try std.testing.expectEqualStrings(expected, advertised_function.name);
+    }
+    try std.testing.expectEqualStrings("", cfg.custom_tool_guidance);
+    try std.testing.expect(ctx.cfg.mode_registry.toolAllowed(ctx.deps.tool_set, ctx.mode_id, "read_file"));
+    try std.testing.expect(ctx.cfg.mode_registry.toolAllowed(ctx.deps.tool_set, ctx.mode_id, "vision"));
+
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const validate = deps.validate_tool_call orelse return error.TestExpectedEqual;
+    inline for (&.{ "write_file", "mcp_dynamic_mutation" }) |tool_name| {
+        const validation = try validate(deps.ctx, arena, .{
+            .id = tool_name,
+            .name = tool_name,
+            .arguments_json = "{}",
+        });
+        switch (validation) {
+            .failure => |reason| {
+                try std.testing.expect(std.mem.find(u8, reason, "tool_execution_failed") != null);
+                try std.testing.expect(std.mem.find(u8, reason, read_only_mode.tool_policy_denial_message.?) != null);
+            },
+            else => return error.TestExpectedEqual,
+        }
+    }
+
+    const execution = try deps.execute_tool_call(deps.ctx, .{
+        .call_allocator = arena,
+        .result_allocator = arena,
+        .call = .{
+            .id = "direct-write",
+            .name = "write_file",
+            .arguments_json = "{}",
+        },
+        .authority = .ordinary,
+        .session_grants = &.{},
+        .advertised_dynamic_tool_names = &.{},
+        .max_tool_result_bytes = ctx.max_tool_result_bytes,
+    });
+    try std.testing.expectEqual(agent_runtime.ToolExecutionStatus.failure, execution.status);
+    try std.testing.expect(std.mem.find(u8, execution.model_output, read_only_mode.tool_policy_denial_message.?) != null);
     try testPushAssistantText(deps, "assistant text");
 }
 
@@ -4407,6 +4522,10 @@ fn testPresentKeyNoContextStartup(alloc: Allocator, transport: oauth_transport.P
 
 fn testNoMcpRuntime(_: Allocator, _: mcp_elicitation.Capabilities) !?*mcp_runtime.McpRuntime {
     return null;
+}
+
+fn testUnexpectedMcpRuntime(_: Allocator, _: mcp_elicitation.Capabilities) !?*mcp_runtime.McpRuntime {
+    return error.TestUnexpectedMcpLoad;
 }
 
 fn testPromptRunDeps(stdout_capture: *TestCapture, stderr_capture: *TestCapture, load_startup_state: LoadStartupStateFn) RunDeps {
@@ -4814,6 +4933,7 @@ test "fx ask deps reject malformed native web_search calls" {
 test "parse options preserves active ask flags and operands" {
     var options = try parseOptionsWithStdin(std.testing.allocator, &.{
         "--auto",
+        "--read-only",
         "--image",
         "a.png",
         "--system",
@@ -4834,6 +4954,7 @@ test "parse options preserves active ask flags and operands" {
     defer options.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(@as(?PermissionMode, .auto), options.permission_override);
+    try std.testing.expect(options.read_only);
     try std.testing.expect(options.json_output);
     try std.testing.expect(options.prompt_permissions);
     try std.testing.expect(options.quiet);
@@ -4865,6 +4986,26 @@ test "parse options accepts yolo and rejects permission flag conflicts" {
             .tty,
         ),
     );
+}
+
+test "parse options keeps read-only independent from permissions and honors the option sentinel" {
+    var read_only_yolo = try parseOptionsWithStdin(
+        std.testing.allocator,
+        &.{ "--read-only", "--yolo", "inspect" },
+        .tty,
+    );
+    defer read_only_yolo.deinit(std.testing.allocator);
+    try std.testing.expect(read_only_yolo.read_only);
+    try std.testing.expectEqual(@as(?PermissionMode, .yolo), read_only_yolo.permission_override);
+
+    var literal = try parseOptionsWithStdin(
+        std.testing.allocator,
+        &.{ "--", "--read-only" },
+        .tty,
+    );
+    defer literal.deinit(std.testing.allocator);
+    try std.testing.expect(!literal.read_only);
+    try std.testing.expectEqualStrings("--read-only", literal.prompt);
 }
 
 test "headless yolo warning reaches stderr before acknowledgment persistence" {
@@ -5231,14 +5372,14 @@ test "stdin prompt errors keep exact structured names" {
     const overflow = try renderErrorJsonResult(alloc, "PromptResourceLimitExceeded");
     defer alloc.free(overflow);
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptResourceLimitExceeded\"}\n",
+        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptResourceLimitExceeded\"}\n",
         overflow,
     );
 
     const read_failure = try renderErrorJsonResult(alloc, "PromptInputReadFailed");
     defer alloc.free(read_failure);
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
+        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
         read_failure,
     );
 }
@@ -5255,7 +5396,7 @@ test "image preparation failure has stable text and JSON contracts" {
     const json = try renderErrorJsonResult(alloc, @errorName(error.ImagePreparationFailed));
     defer alloc.free(json);
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"ImagePreparationFailed\"}\n",
+        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"ImagePreparationFailed\"}\n",
         json,
     );
 }
@@ -5286,7 +5427,7 @@ test "stdin read failure has distinct text and JSON output contracts" {
         try runWithDeps(alloc, &.{"--json"}, testConfig(), deps),
     );
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
+        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"PromptInputReadFailed\"}\n",
         stdout_capture.bytes.items,
     );
     try std.testing.expectEqualStrings("", stderr_capture.bytes.items);
@@ -6766,6 +6907,35 @@ test "runWithDeps projects exec-only terminal when saved setup has no capability
     try std.testing.expectEqualStrings("assistant text", stdout_capture.bytes.items);
 }
 
+test "runWithDeps enforces invocation-scoped read-only mode before validation and execution" {
+    const alloc = std.testing.allocator;
+    var stdout_capture: TestCapture = .{};
+    defer stdout_capture.deinit(alloc);
+    var stderr_capture: TestCapture = .{};
+    defer stderr_capture.deinit(alloc);
+    var deps = testPromptRunDepsWithProcess(
+        &stdout_capture,
+        &stderr_capture,
+        testProcessQueuedPromptChecksReadOnly,
+    );
+    deps.load_mcp_runtime = testUnexpectedMcpRuntime;
+    deps.start_subagent_background_recovery = true;
+
+    const exit_code = try runWithDeps(
+        alloc,
+        &.{ "--json", "--no-save", "--auto", "--read-only", "inspect" },
+        testConfig(),
+        deps,
+    );
+
+    try std.testing.expectEqual(@as(u8, 0), exit_code);
+    try std.testing.expectEqualStrings("", stderr_capture.bytes.items);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, stdout_capture.bytes.items, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings(read_only_mode_id, parsed.value.object.get("mode").?.string);
+    try std.testing.expectEqualStrings("assistant text", parsed.value.object.get("output").?.string);
+}
+
 test "runWithDeps uses the supplied tool set for advertisement and runtime" {
     const alloc = std.testing.allocator;
     const tools = [_]tool_dispatch.Tool{builtin_tools.read_file};
@@ -7957,6 +8127,7 @@ test "render final JSON preserves shape escaping order and newline" {
         .exit_code = 0,
         .assistant_output = try alloc.dupe(u8, "hello \"zig\"\n"),
         .model = try alloc.dupe(u8, "model-x"),
+        .mode = try alloc.dupe(u8, read_only_mode_id),
         .session_id = try alloc.dupe(u8, "123"),
         .tool_calls = tool_calls,
         .step_count = 2,
@@ -7967,7 +8138,7 @@ test "render final JSON preserves shape escaping order and newline" {
     defer alloc.free(json);
 
     try std.testing.expectEqualStrings(
-        "{\"output\":\"hello \\\"zig\\\"\\n\",\"final_output\":\"\",\"exit_code\":0,\"model\":\"model-x\",\"session_id\":\"123\",\"steps\":2,\"tool_calls\":[{\"name\":\"read_file\",\"status\":\"success\"}]}\n",
+        "{\"output\":\"hello \\\"zig\\\"\\n\",\"final_output\":\"\",\"exit_code\":0,\"model\":\"model-x\",\"mode\":\"read_only\",\"session_id\":\"123\",\"steps\":2,\"tool_calls\":[{\"name\":\"read_file\",\"status\":\"success\"}]}\n",
         json,
     );
 }
@@ -7977,6 +8148,7 @@ test "render final JSON emits empty tool call array" {
     const result = PromptRunResult{
         .exit_code = 1,
         .assistant_output = try alloc.dupe(u8, ""),
+        .mode = try alloc.dupe(u8, "ask"),
     };
     defer result.deinit(alloc);
 
@@ -7984,7 +8156,7 @@ test "render final JSON emits empty tool call array" {
     defer alloc.free(json);
 
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[]}\n",
+        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"ask\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[]}\n",
         json,
     );
 }
@@ -8711,7 +8883,7 @@ test "json run with missing API key prints diagnostic then final object" {
     try std.testing.expectEqual(@as(u8, 1), exit_code);
     try std.testing.expectEqualStrings("fx ask: " ++ credentials.missing_credential_message ++ "\n", stderr_capture.bytes.items);
     try std.testing.expectEqualStrings(
-        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"MissingCredentials\"}\n",
+        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"inspect\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"MissingCredentials\"}\n",
         stdout_capture.bytes.items,
     );
 }
@@ -8919,8 +9091,8 @@ test "default fx ask preserves project context gathering error mappings" {
         json: ?[]const u8,
     }{
         .{ .err = error.OutOfMemory, .json = null },
-        .{ .err = error.NoSpaceLeft, .json = "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"NoSpaceLeft\"}\n" },
-        .{ .err = error.WriteFailed, .json = "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"WriteFailed\"}\n" },
+        .{ .err = error.NoSpaceLeft, .json = "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"NoSpaceLeft\"}\n" },
+        .{ .err = error.WriteFailed, .json = "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"mode\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"WriteFailed\"}\n" },
     };
 
     for (cases) |case| {
@@ -8973,7 +9145,7 @@ test "quiet suppresses streaming while quiet json captures final output" {
 
     const json_exit = try runWithDeps(alloc, &.{ "--quiet", "--json", "hello" }, testConfig(), testPromptRunDeps(&stdout_capture, &stderr_capture, testPresentKeyStartup));
     try std.testing.expectEqual(@as(u8, 0), json_exit);
-    try std.testing.expect(std.mem.startsWith(u8, stdout_capture.bytes.items, "{\"output\":\"assistant text\",\"final_output\":\"\",\"exit_code\":0,\"model\":\"model\",\"session_id\":\""));
+    try std.testing.expect(std.mem.startsWith(u8, stdout_capture.bytes.items, "{\"output\":\"assistant text\",\"final_output\":\"\",\"exit_code\":0,\"model\":\"model\",\"mode\":\"inspect\",\"session_id\":\""));
     try std.testing.expect(std.mem.endsWith(u8, stdout_capture.bytes.items, "\",\"steps\":0,\"tool_calls\":[]}\n"));
     try std.testing.expectEqualStrings("", stderr_capture.bytes.items);
 }

--- a/src/core/modes/mode_registry.zig
+++ b/src/core/modes/mode_registry.zig
@@ -40,11 +40,11 @@ pub const Registry = struct {
         id: []const u8,
         tool_name: []const u8,
     ) bool {
-        if (tool_set.registry.lookup(tool_name) == null) return true;
         const mode = self.lookup(id) orelse return true;
         return switch (mode.tool_policy) {
             .full => true,
-            .read_only => nameInSet(tool_set.read_only_tool_names, tool_name),
+            .read_only => tool_set.registry.lookup(tool_name) != null and
+                nameInSet(tool_set.read_only_tool_names, tool_name),
         };
     }
 
@@ -84,7 +84,7 @@ test "mode registry looks up modes by id" {
     try std.testing.expect(registry.lookup("missing") == null);
 }
 
-test "mode registry applies tool policy to the supplied tool set" {
+test "mode registry applies read-only tool policy to the supplied tool set" {
     const Fixture = struct {
         fn decode(ctx: tool_dispatch.DispatchContext, _: []const u8) tool_dispatch.DispatchError!tool_dispatch.DecodeResult {
             return .{ .failure = try ctx.allocator.dupe(u8, "unused") };
@@ -151,7 +151,8 @@ test "mode registry applies tool policy to the supplied tool set" {
     try std.testing.expect(registry.toolAllowed(tool_set, "inspect", "inspect"));
     try std.testing.expect(!registry.toolAllowed(tool_set, "inspect", "mutate"));
     try std.testing.expect(registry.toolAllowed(tool_set, "missing", "mutate"));
-    try std.testing.expect(registry.toolAllowed(tool_set, "inspect", "dynamic_tool"));
+    try std.testing.expect(registry.toolAllowed(tool_set, "full", "dynamic_tool"));
+    try std.testing.expect(!registry.toolAllowed(tool_set, "inspect", "dynamic_tool"));
 
     const denied = try registry.toolPolicyDeniedJson(
         std.testing.allocator,
@@ -161,4 +162,13 @@ test "mode registry applies tool policy to the supplied tool set" {
     ) orelse return error.TestExpectedEqual;
     defer std.testing.allocator.free(denied);
     try std.testing.expect(std.mem.find(u8, denied, "Inspection mode blocks mutations.") != null);
+
+    const dynamic_denied = try registry.toolPolicyDeniedJson(
+        std.testing.allocator,
+        tool_set,
+        "inspect",
+        "dynamic_tool",
+    ) orelse return error.TestExpectedEqual;
+    defer std.testing.allocator.free(dynamic_denied);
+    try std.testing.expect(std.mem.find(u8, dynamic_denied, "Inspection mode blocks mutations.") != null);
 }

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -28,8 +28,14 @@ import {
 import {
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
+  fakeGatewayToolCall,
   startFakeGateway,
 } from "./tmux-helpers";
+import {
+  parseGatewayRequest,
+  READ_ONLY_SERIALIZED_TOOL_NAMES,
+  serializedToolNames,
+} from "./conditional-guidance-oracle";
 
 const TIMEOUT = 15_000;
 const NO_GATEWAY_AUTH = {
@@ -310,11 +316,12 @@ describe("cli: help", () => {
 Run one noninteractive request
 
 Usage:
-  fx ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>
+  fx ask [--auto|--yolo] [--read-only] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save] [--no-color] [--resume <last|id>|--resume-id <id>] [--continue-recovery] [--] <prompt>
 
 Options:
   --auto                Automatically review unresolved permission requests
   --yolo                Disable fx permission checks
+  --read-only           Restrict the model to read-only inspection tools
   --image PATH          Attach an image file; repeat for multiple images
   --json                Emit machine-readable JSON instead of text
   --quiet               Suppress assistant output
@@ -4022,7 +4029,7 @@ describe("cli: ask success", () => {
       expect(jsonResult.code).toBe(1);
       expect(jsonResult.stderr).toBe("");
       expect(jsonResult.stdout).toBe(
-        '{"output":"","final_output":"","exit_code":1,"model":"","session_id":"","steps":0,"tool_calls":[],"error":"PromptResourceLimitExceeded"}\n',
+        '{"output":"","final_output":"","exit_code":1,"model":"","mode":"","session_id":"","steps":0,"tool_calls":[],"error":"PromptResourceLimitExceeded"}\n',
       );
     },
     120_000,
@@ -4284,6 +4291,139 @@ describe("cli: ask success", () => {
         expect(gateway.requests[2]?.headers.get("x-session-affinity")).toBeNull();
         expect(existsSync(join(noSaveHome, ".fx"))).toBe(false);
         expect(gateway.requests).toHaveLength(3);
+      } finally {
+        gateway.stop();
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+
+  test(
+    "read-only ask limits tools and remains scoped to one resumed invocation",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-ask-read-only-"));
+      const home = join(root, "home");
+      const workspace = join(root, "workspace");
+      const readable = join(workspace, "fixture.txt");
+      const blocked = join(workspace, "blocked.txt");
+      const fixture = "READ_ONLY_FIXTURE_CONTENT";
+      mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+      mkdirSync(workspace);
+      writeFileSync(readable, `${fixture}\n`);
+      writeFileSync(
+        join(home, ".fx", "settings.json"),
+        JSON.stringify({
+          permission_mode: "ask",
+          yolo_acknowledged: true,
+          permission: { edit: "deny" },
+        }) + "\n",
+        { mode: 0o600 },
+      );
+
+      const gateway = startFakeGateway([
+        fakeGatewayFinalText("normal session created"),
+        fakeGatewayToolCall("read_only_read", "read_file", {
+          path: readable,
+        }),
+        (body) => {
+          expect(body).toContain(fixture);
+          return fakeGatewayToolCall("read_only_write", "write_file", {
+            path: blocked,
+            content: "must not be written",
+          });
+        },
+        (body) => {
+          expect(body).toContain("tool_execution_failed");
+          expect(body).toContain(
+            "Read-only mode only allows read-only inspection tools.",
+          );
+          return fakeGatewayFinalText("read-only policy enforced");
+        },
+        fakeGatewayFinalText("normal mode restored"),
+      ]);
+
+      try {
+        const cwd = realpathSync(workspace);
+        const env = {
+          HOME: realpathSync(home),
+          AI_GATEWAY_API_KEY: "fake-read-only-key",
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_GATEWAY_BASE_URL: gateway.baseUrl,
+          FX_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_E2E_GATEWAY_CHAT_URL: gateway.chatUrl,
+          FX_MODEL: FAKE_GATEWAY_MODEL,
+          FX_AUTO_UPGRADE: "0",
+        };
+        const first = await runFx(
+          ["ask", "--json", "--yolo", "Create a normal saved session."],
+          { cwd, env, timeoutMs: 60_000 },
+        );
+        expect(first.code).toBe(0);
+        expect(first.stderr).toBe("");
+        const firstJson = JSON.parse(first.stdout);
+        expect(firstJson.mode).toBe("ask");
+        expect(firstJson.session_id.length).toBeGreaterThan(0);
+
+        const restricted = await runFx(
+          [
+            "ask",
+            "--json",
+            "--yolo",
+            "--read-only",
+            "--resume-id",
+            firstJson.session_id,
+            "Read the fixture, then try the requested write.",
+          ],
+          { cwd, env, timeoutMs: 60_000 },
+        );
+        expect(restricted.code).toBe(0);
+        const progressLines = restricted.stderr.split("\n").filter((line) =>
+          line.length > 0 && !line.startsWith("[notice]")
+        );
+        expect(progressLines.length).toBeGreaterThan(0);
+        expect(new Set(progressLines).size).toBe(progressLines.length);
+        const restrictedJson = JSON.parse(restricted.stdout);
+        expect(restrictedJson.mode).toBe("read_only");
+        expect(restrictedJson.session_id).toBe(firstJson.session_id);
+        expect(restrictedJson.tool_calls).toEqual([
+          { name: "read_file", status: "success" },
+          { name: "write_file", status: "error" },
+        ]);
+        expect(existsSync(blocked)).toBe(false);
+
+        const restored = await runFx(
+          [
+            "ask",
+            "--json",
+            "--yolo",
+            "--resume-id",
+            firstJson.session_id,
+            "Confirm normal mode is restored.",
+          ],
+          { cwd, env, timeoutMs: 60_000 },
+        );
+        expect(restored.code).toBe(0);
+        expect(restored.stderr).toBe("");
+        const restoredJson = JSON.parse(restored.stdout);
+        expect(restoredJson.mode).toBe("ask");
+        expect(restoredJson.session_id).toBe(firstJson.session_id);
+
+        expect(gateway.requests).toHaveLength(5);
+        expect(
+          serializedToolNames(parseGatewayRequest(gateway.requests[0]!.body)),
+        ).toContain("write_file");
+        for (const index of [1, 2, 3]) {
+          expect(
+            serializedToolNames(
+              parseGatewayRequest(gateway.requests[index]!.body),
+            ),
+          ).toEqual([...READ_ONLY_SERIALIZED_TOOL_NAMES, "vision"]);
+        }
+        expect(
+          serializedToolNames(parseGatewayRequest(gateway.requests[4]!.body)),
+        ).toContain("write_file");
+        expect(gateway.classifierRequests).toHaveLength(0);
       } finally {
         gateway.stop();
         rmSync(root, { recursive: true, force: true });
@@ -4604,7 +4744,7 @@ describe("cli: error handling", () => {
             "fx ask: --no-save cannot be used with --resume or --resume-id",
           );
           expect(rejected.stderr).toContain(
-            "usage: fx ask [--auto|--yolo] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save]",
+            "usage: fx ask [--auto|--yolo] [--read-only] [--image PATH] [--json] [--quiet] [--prompt-permissions] [--no-save]",
           );
         }
         expect(gateway.requests).toHaveLength(0);

--- a/tests/evals/eval-helpers.ts
+++ b/tests/evals/eval-helpers.ts
@@ -63,6 +63,7 @@ export interface HeadlessResult {
   output: string;
   exit_code: number;
   model: string;
+  mode: string;
   session_id: string;
   steps: number;
   tool_calls: Array<{


### PR DESCRIPTION
## Summary

- add `fx ask --read-only` as an invocation-scoped mode for inspecting a workspace without allowing mutations
- fail closed for mutating, unknown, and dynamic tool calls at both validation and execution boundaries
- keep the restriction active across resumed sessions and independent of `--auto` / `--yolo`, while restoring normal tools on later invocations
- skip MCP startup and background subagent recovery in read-only runs
- expose the active mode in `fx ask --json`, document the flag, and add unit and deterministic E2E coverage

The read-only allowlist includes file reading, listing, globbing, searching, and authorized-image inspection. This also tightens the shared `.read_only` registry policy so unregistered dynamic tools are denied for every read-only consumer; full-mode behavior is unchanged.

## Validation

- `zig fmt --check src`
- ReleaseSafe product build
- focused ReleaseSafe Zig tests: 20/20 passed
- targeted read-only resume/tool-policy E2E: passed
- targeted structured-error and ask-help E2E tests: passed
- TypeScript test/eval bundles: passed
- public-surface check: passed
- PGSO corpus classification check: passed

Needs `type: feature` label.
