### PR TITLE
Cover terminal feedback contracts

### DIFF
--- a/src/core/agent/runtime/tests/finalization_flow.zig
+++ b/src/core/agent/runtime/tests/finalization_flow.zig
@@ -1685,6 +1685,7 @@ test "TurnFinalizationGuard runs PostTurnEnd once for every terminal outcome and
     }{
         .{ .scope_kind = .interactive, .outcome = .completed, .disposition = .completed },
         .{ .scope_kind = .ask, .outcome = .interrupted, .disposition = null },
+        .{ .scope_kind = .ask, .outcome = .paused, .disposition = null },
         .{ .scope_kind = .acp, .outcome = .failed, .disposition = .length_limited },
         .{ .scope_kind = .subagent, .outcome = .completed, .disposition = null },
     };

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -3782,14 +3782,14 @@ test "timeout terminates foreground process group descendants" {
     defer alloc.free(quoted_ready);
     const command = try std.fmt.allocPrint(
         alloc,
-        "(while :; do :; done) & child=$!; printf '%s' \"$child\" > {s}; wait",
+        "sleep 30 & child=$!; printf '%s' \"$child\" > {s}; wait",
         .{quoted_ready},
     );
     defer alloc.free(command);
 
     try std.testing.expectError(error.TimeoutExpired, executeCommand(.{
         .max_command_output_bytes = 1024,
-        .timeout_ms = 500,
+        .timeout_ms = 2000,
     }, alloc, command, workspace));
 
     const pid_text = try readAbsoluteFile(alloc, ready_path, 64);
@@ -3842,7 +3842,7 @@ test "timeout terminates redirected descendant after setsid" {
 
     try std.testing.expectError(error.TimeoutExpired, executeCommand(.{
         .max_command_output_bytes = 1024,
-        .timeout_ms = 500,
+        .timeout_ms = 2000,
     }, alloc, command, workspace));
 
     const pid_text = try readAbsoluteFile(alloc, pid_path, 64);
@@ -3885,7 +3885,7 @@ test "timeout terminates double-forked descendant after setsid" {
 
     try std.testing.expectError(error.TimeoutExpired, executeCommand(.{
         .max_command_output_bytes = 1024,
-        .timeout_ms = 500,
+        .timeout_ms = 2000,
     }, alloc, command, workspace));
 
     const pid_text = try readAbsoluteFile(alloc, pid_path, 64);

--- a/src/core/terminal/contracts.zig
+++ b/src/core/terminal/contracts.zig
@@ -4109,13 +4109,25 @@ test "next actions are the pure lifecycle authority and lease intersection" {
     );
     try std.testing.expectEqual(AllowedControls.observer(), observer);
 
-    const running = project_next_actions(
-        .running,
-        .full(),
-        .agent,
-        .{},
-    );
-    try std.testing.expect(running.monitor);
+    const lifecycle_cases = [_]struct {
+        lifecycle: Lifecycle,
+        monitor: bool,
+    }{
+        .{ .lifecycle = .starting, .monitor = true },
+        .{ .lifecycle = .running, .monitor = true },
+        .{ .lifecycle = .exited, .monitor = false },
+        .{ .lifecycle = .lost, .monitor = false },
+        .{ .lifecycle = .closed, .monitor = false },
+    };
+    for (lifecycle_cases) |case| {
+        const projected = project_next_actions(
+            case.lifecycle,
+            .full(),
+            .agent,
+            .{},
+        );
+        try std.testing.expectEqual(case.monitor, projected.monitor);
+    }
 
     const leased = project_next_actions(
         .running,

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -439,6 +439,51 @@ describe("fx ask presentation", () => {
     expect(json.stderr).toBe("");
   }, TIMEOUT);
 
+  test("JSON separates accumulated assistant Markdown from the completed final response", async () => {
+    const root = createRoot();
+    writeFileSync(join(root.workspace, "fixture.txt"), "fixture contents\n");
+    const intermediate = "I will inspect the fixture first.\n";
+    const final = "The fixture inspection is complete.";
+    const gateway = startFakeGateway([
+      fakeGatewaySerializedToolCall(
+        "read_fixture_for_final_output",
+        "read_file",
+        JSON.stringify({ path: "fixture.txt" }),
+        intermediate,
+      ),
+      fakeGatewayFinalText(final),
+    ]);
+    gateways.push(gateway);
+
+    const result = await runFx(
+      ["ask", "--json", "--auto", "--no-save", "Inspect fixture.txt."],
+      {
+        cwd: root.workspace,
+        env: gatewayEnv(root.home, gateway),
+        timeoutMs: TIMEOUT,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    const output = JSON.parse(result.stdout) as {
+      output: string;
+      final_output: string;
+      tool_calls: Array<{ name: string; status: string }>;
+    };
+    expect(output.output).toContain(intermediate.trim());
+    expect(output.output).toContain(final.trim());
+    expect(output.output.indexOf(intermediate.trim())).toBeLessThan(
+      output.output.indexOf(final.trim()),
+    );
+    expect(output.final_output).toBe(final);
+    expect(output.final_output).not.toContain(intermediate.trim());
+    expect(output.tool_calls).toEqual([
+      { name: "read_file", status: "success" },
+    ]);
+    expect(gateway.requests).toHaveLength(2);
+    expect(result.stderr).toContain("Reading fixture.txt");
+  }, TIMEOUT);
+
   test.skipIf(!tmuxAvailable())(
     "TTY stdout uses the Minimal transcript and compact tool group",
     async () => {
@@ -464,6 +509,7 @@ describe("fx ask presentation", () => {
       gateways.push(gateway);
 
       const session = await TmuxSession.create({
+        isolated: true,
         cmd: terminalCommand([
           "ask",
           "--auto",
@@ -515,6 +561,7 @@ describe("fx ask presentation", () => {
       gateways.push(gateway);
 
       const session = await TmuxSession.create({
+        isolated: true,
         cmd: terminalCommand([
           "ask",
           "--auto",
@@ -549,6 +596,7 @@ describe("fx ask presentation", () => {
       gateways.push(gateway);
 
       const session = await TmuxSession.create({
+        isolated: true,
         cmd: terminalCommand([
           "ask",
           "--no-color",
@@ -586,6 +634,7 @@ describe("fx ask presentation", () => {
       writeFileSync(stderrPath, "");
 
       const session = await TmuxSession.create({
+        isolated: true,
         cmd: `${terminalCommand([
           "ask",
           "--no-save",
@@ -643,6 +692,7 @@ describe("fx ask presentation", () => {
       writeFileSync(stderrPath, "");
 
       const session = await TmuxSession.create({
+        isolated: true,
         cmd: terminalCommand([
           "ask",
           "--no-save",
@@ -724,6 +774,7 @@ describe("fx ask presentation", () => {
       writeFileSync(stderrPath, "");
 
       const session = await TmuxSession.create({
+        isolated: true,
         cmd: terminalCommand([
           "ask",
           "--no-save",
@@ -805,6 +856,7 @@ describe("fx ask presentation", () => {
       writeFileSync(stderrPath, "");
 
       const session = await TmuxSession.create({
+        isolated: true,
         cmd: terminalCommand([
           "ask",
           "--no-save",
@@ -857,6 +909,7 @@ describe("fx ask presentation", () => {
       gateways.push(gateway);
 
       const session = await TmuxSession.create({
+        isolated: true,
         cmd: terminalCommand([
           "ask",
           "--auto",


### PR DESCRIPTION
## Summary

- Add regression coverage for terminal monitor feedback across lifecycle states.
- Cover agent lease cleanup when a turn pauses.
- Verify `fx ask --json` separates accumulated output from the completed final response.
- Isolate ask-presentation TUI tests from unrelated tmux sessions.
- Stabilize timeout descendant cleanup fixtures under load.