### PR TITLE
Preserve scrollback while final responses stream

### DIFF
--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -3438,6 +3438,92 @@ test "closed tool group finality flows through fixed point resolution and sealin
     try expectGridContains(&h, "SECOND_GROUP_INTRO");
 }
 
+test "completed tool group lets streamed assistant hard lines enter history" {
+    const alloc = std.testing.allocator;
+    var h = try Harness.init(alloc, 80, 14, 3);
+    defer h.deinit();
+
+    var input = InputRuntime{};
+    defer input.deinit(alloc);
+    var approval = approval_prompt.ApprovalPrompt{};
+    defer approval.deinit(alloc);
+
+    try h.shell.initViewport(&h.metrics, 8);
+    for (0..4) |index| {
+        var line: [32]u8 = undefined;
+        const text = try std.fmt.bufPrint(&line, "startup row {d}\n", .{index});
+        _ = try h.shell.appendRawTranscriptEntry(alloc, text);
+    }
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    const group = types.ToolPresentationGroupId{ .turn_id = 93, .anchor_step_id = 1 };
+    var call_ids: [18][20]u8 = undefined;
+    for (0..call_ids.len - 1) |index| {
+        const call_id = try std.fmt.bufPrint(
+            &call_ids[index],
+            "answer-a-{d:0>2}",
+            .{index},
+        );
+        try applyCompletedReadForGroupFinalityResizeTest(&h, 93, call_id, group);
+    }
+    const active_call_id = try std.fmt.bufPrint(
+        &call_ids[call_ids.len - 1],
+        "answer-a-{d:0>2}",
+        .{call_ids.len - 1},
+    );
+    const active_id = types.ToolLifecycleId{ .turn_id = 93, .call_id = active_call_id };
+    _ = try h.shell.applyToolLifecycle(alloc, .{ .authoritative_started = .{
+        .id = active_id,
+        .presentation_group_id = group,
+        .reconciles_provisional_call_id = null,
+        .tool_name = "read_file",
+        .activity_kind = .read,
+    } });
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    var held_source = try h.shell.prepareTranscriptSource(alloc, null);
+    defer held_source.deinit(alloc);
+    const held = h.shell.stableTranscriptProjectionForFlow(held_source.bytes) orelse
+        return error.TestExpectedStableTranscript;
+    try std.testing.expect(held.visual_offset > held.history_visual_offset);
+
+    _ = try h.shell.streamAssistantChunk(
+        alloc,
+        &h.metrics,
+        "FINAL_LINE_01\nFINAL_LINE_02\nFINAL_LINE_03\npartial tail",
+    );
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.planned_scroll_rows);
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.committed_scroll_rows);
+
+    _ = try h.shell.applyToolLifecycle(alloc, .{ .terminal = .{
+        .id = active_id,
+        .outcome = .{ .kind = .completed, .summary = "Read fixed-point fixture" },
+    } });
+    h.frame_redraw = true;
+    try renderTestFooter(&h, &input, &approval, &h.frame_redraw);
+    try h.flush();
+
+    try std.testing.expect(h.last_frame.planned_scroll_rows > 0);
+    try std.testing.expect(h.last_frame.committed_scroll_rows > 0);
+    try std.testing.expect(h.last_frame.document_append_bytes > 0);
+    try std.testing.expect(h.last_frame.transcript_history_floor_respected);
+    try std.testing.expectEqual(@as(u16, 0), h.last_frame.unplanned_scroll_rows);
+
+    var released_source = try h.shell.prepareTranscriptSource(alloc, null);
+    defer released_source.deinit(alloc);
+    const released = h.shell.stableTranscriptProjectionForFlow(released_source.bytes) orelse
+        return error.TestExpectedStableTranscript;
+    try std.testing.expect(released.history_visual_offset > held.visual_offset);
+    try expectGridContains(&h, "partial tail");
+}
+
 test "hidden auto approval lifecycle reposition adds no compact scroll rows" {
     var h = try Harness.init(std.testing.allocator, 80, 12, 4);
     defer h.deinit();

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -40,12 +40,14 @@ const FinalityNomination = struct {
 const ToolFinalityIdentity = struct {
     turn_id: u64,
     presentation_group_id: ?types.ToolPresentationGroupId,
+    terminal: bool,
 };
 
 const ToolTurnNomination = struct {
     earliest_entry_id: u32,
     selected_entry_id: u32,
     selected_group_id: ?types.ToolPresentationGroupId,
+    selected_group_terminal: bool,
 };
 
 fn entryHiddenByActions(
@@ -69,13 +71,42 @@ fn collectFinalityNominations(
     var nominations: std.ArrayList(FinalityNomination) = .empty;
     errdefer nominations.deinit(alloc);
 
+    const assistant_tail_entry_id: ?u32 = if (self.entries.items.len > 0) tail: {
+        const tail_index = self.entries.items.len - 1;
+        const tail_entry = self.entries.items[tail_index];
+        if (tail_entry != .assistant_turn or
+            omitted_entry_id == tail_entry.id() or
+            entryHiddenByActions(entry_actions, tail_index))
+        {
+            break :tail null;
+        }
+        break :tail tail_entry.id();
+    } else null;
+
+    var group_terminality: std.AutoHashMapUnmanaged(types.ToolPresentationGroupId, bool) = .empty;
+    defer group_terminality.deinit(alloc);
+    for (self.tool_details.items) |detail| {
+        const group = detail.presentation_group_id orelse continue;
+        const result = try group_terminality.getOrPut(alloc, group);
+        if (!result.found_existing) result.value_ptr.* = true;
+        result.value_ptr.* = result.value_ptr.* and detail.outcome != null;
+    }
+
     var entry_tool_identities: std.AutoHashMapUnmanaged(u32, ToolFinalityIdentity) = .empty;
     defer entry_tool_identities.deinit(alloc);
     for (self.tool_details.items) |detail| {
         const identity: ToolFinalityIdentity = if (detail.presentation_group_id) |group|
-            .{ .turn_id = group.turn_id, .presentation_group_id = group }
+            .{
+                .turn_id = group.turn_id,
+                .presentation_group_id = group,
+                .terminal = group_terminality.get(group).?,
+            }
         else if (detail.lifecycle_id) |lifecycle|
-            .{ .turn_id = lifecycle.turn_id, .presentation_group_id = null }
+            .{
+                .turn_id = lifecycle.turn_id,
+                .presentation_group_id = null,
+                .terminal = detail.outcome != null,
+            }
         else
             continue;
         try entry_tool_identities.put(alloc, detail.entry_id, identity);
@@ -108,6 +139,8 @@ fn collectFinalityNominations(
                     .earliest_entry_id = entry_id,
                     .selected_entry_id = entry_id,
                     .selected_group_id = identity.presentation_group_id,
+                    .selected_group_terminal = identity.presentation_group_id != null and
+                        identity.terminal,
                 };
                 continue;
             }
@@ -116,12 +149,17 @@ fn collectFinalityNominations(
             const group_id = identity.presentation_group_id orelse {
                 turn.selected_entry_id = turn.earliest_entry_id;
                 turn.selected_group_id = null;
+                turn.selected_group_terminal = false;
                 continue;
             };
             const selected_group = turn.selected_group_id.?;
+            if (group_id.anchor_step_id == selected_group.anchor_step_id) {
+                continue;
+            }
             if (group_id.anchor_step_id > selected_group.anchor_step_id) {
                 turn.selected_entry_id = entry_id;
                 turn.selected_group_id = group_id;
+                turn.selected_group_terminal = identity.terminal;
             }
         }
     }
@@ -140,23 +178,26 @@ fn collectFinalityNominations(
         const identity = entry_tool_identities.get(entry_id) orelse continue;
         const turn = turn_nominations.get(identity.turn_id).?;
         if (turn.selected_entry_id != entry_id) continue;
+        // A later assistant entry closes a concrete group once all of its
+        // tools are terminal. Any subsequent tool start after visible text
+        // receives a new presentation-group identity.
+        if (assistant_tail_entry_id != null and
+            turn.selected_group_id != null and
+            turn.selected_group_terminal)
+        {
+            continue;
+        }
         try nominations.append(alloc, .{
             .entry_id = entry_id,
             .kind = .tool_turn,
             .turn_id = identity.turn_id,
         });
     }
-    if (self.entries.items.len > 0) {
-        const tail = self.entries.items[self.entries.items.len - 1];
-        if (tail == .assistant_turn and
-            omitted_entry_id != tail.id() and
-            !entryHiddenByActions(entry_actions, self.entries.items.len - 1))
-        {
-            try nominations.append(alloc, .{
-                .entry_id = tail.id(),
-                .kind = .assistant_tail,
-            });
-        }
+    if (assistant_tail_entry_id) |entry_id| {
+        try nominations.append(alloc, .{
+            .entry_id = entry_id,
+            .kind = .assistant_tail,
+        });
     }
     return nominations;
 }


### PR DESCRIPTION
## Summary

- Keep completed tool-call history fixed once a later assistant response begins.
- Keep tool groups mutable until every child call reaches a terminal outcome.
- Preserve terminal scroll position while final response lines continue streaming.