### PR TITLE
Fix remote MCP discovery and response framing

### DIFF
--- a/src/core/mcp/streamable_http.zig
+++ b/src/core/mcp/streamable_http.zig
@@ -270,6 +270,11 @@ const PreparedRequest = struct {
     }
 };
 
+// Zig 0.16's Response.reader can enter `.ready` before its content-length
+// stream reads the tagged remaining-length field, which aborts the process.
+// Keep MCP framing in independent state and requests one-shot so teardown never
+// re-enters that union. Remove this adapter when the pinned Response.reader
+// passes the fixed-length JSON and SSE regression cases.
 const McpContentLengthReader = struct {
     source: *std.Io.Reader,
     remaining: u64,

--- a/src/core/mcp/streamable_http.zig
+++ b/src/core/mcp/streamable_http.zig
@@ -270,6 +270,63 @@ const PreparedRequest = struct {
     }
 };
 
+const McpContentLengthReader = struct {
+    source: *std.Io.Reader,
+    remaining: u64,
+    interface: std.Io.Reader,
+
+    fn init(
+        source: *std.Io.Reader,
+        content_length: u64,
+        buffer: []u8,
+    ) McpContentLengthReader {
+        return .{
+            .source = source,
+            .remaining = content_length,
+            .interface = .{
+                .vtable = &.{
+                    .stream = stream,
+                },
+                .buffer = buffer,
+                .seek = 0,
+                .end = 0,
+            },
+        };
+    }
+
+    fn stream(
+        reader: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        limit: std.Io.Limit,
+    ) std.Io.Reader.StreamError!usize {
+        const self: *McpContentLengthReader = @fieldParentPtr("interface", reader);
+        if (self.remaining == 0) return error.EndOfStream;
+        const count = try self.source.stream(
+            writer,
+            limit.min(.limited64(self.remaining)),
+        );
+        const consumed: u64 = @intCast(count);
+        if (consumed > self.remaining) return error.ReadFailed;
+        self.remaining -= consumed;
+        return count;
+    }
+};
+
+const McpResponseBodyFraming = enum {
+    content_length,
+    standard,
+};
+
+fn mcpResponseBodyFraming(
+    transfer_encoding: std.http.TransferEncoding,
+    content_length: ?u64,
+) McpResponseBodyFraming {
+    if (transfer_encoding == .none and content_length != null) {
+        return .content_length;
+    }
+    return .standard;
+}
+
 fn postCore(alloc: Allocator, options: PostOptions) !PostResponse {
     var prepared = try prepareRequest(
         alloc,
@@ -288,6 +345,7 @@ fn postCore(alloc: Allocator, options: PostOptions) !PostResponse {
 
     var request = try client.request(.POST, uri, .{
         .redirect_behavior = .unhandled,
+        .keep_alive = false,
         .headers = .{
             .content_type = .{ .override = "application/json" },
             .accept_encoding = .omit,
@@ -349,7 +407,21 @@ fn postCore(alloc: Allocator, options: PostOptions) !PostResponse {
     if (version_error and media_type != .json) return error.UnsupportedContentType;
 
     var transfer_buffer: [16 * 1024]u8 = undefined;
-    const reader = response.reader(&transfer_buffer);
+    var content_length_reader: McpContentLengthReader = undefined;
+    const reader = switch (mcpResponseBodyFraming(
+        response.head.transfer_encoding,
+        response.head.content_length,
+    )) {
+        .content_length => reader: {
+            content_length_reader = .init(
+                response.request.reader.in,
+                response.head.content_length.?,
+                &transfer_buffer,
+            );
+            break :reader &content_length_reader.interface;
+        },
+        .standard => response.reader(&transfer_buffer),
+    };
     const body = switch (media_type) {
         .json => try readJsonResponse(
             alloc,
@@ -1359,6 +1431,91 @@ test "modern MCP tool header annotation names are unique across nested propertie
             \\{"type":"object","properties":{"region":{"type":"string","x-mcp-header":"Region"},"nested":{"type":"object","properties":{"value":{"type":"string","x-mcp-header":"region"}}}}}
             ,
         ),
+    );
+}
+
+test "modern MCP content length reader leaves bytes after the declared body unread" {
+    var source = std.Io.Reader.fixed("bodyafter");
+    var reader_buffer: [3]u8 = undefined;
+    var bounded = McpContentLengthReader.init(&source, 4, &reader_buffer);
+
+    var body: [8]u8 = undefined;
+    const body_len = try bounded.interface.readSliceShort(&body);
+    try std.testing.expectEqual(@as(usize, 4), body_len);
+    try std.testing.expectEqualStrings("body", body[0..body_len]);
+    try std.testing.expectError(
+        error.EndOfStream,
+        bounded.interface.readSliceAll(body[0..1]),
+    );
+
+    var after: [5]u8 = undefined;
+    try source.readSliceAll(&after);
+    try std.testing.expectEqualStrings("after", &after);
+}
+
+test "modern MCP content length reader applies one bound across discard and read" {
+    var source = std.Io.Reader.fixed("abcdef");
+    var reader_buffer: [3]u8 = undefined;
+    var bounded = McpContentLengthReader.init(&source, 4, &reader_buffer);
+
+    try bounded.interface.discardAll(2);
+    var body: [2]u8 = undefined;
+    try bounded.interface.readSliceAll(&body);
+    try std.testing.expectEqualStrings("cd", &body);
+    try std.testing.expectError(
+        error.EndOfStream,
+        bounded.interface.discardAll(1),
+    );
+
+    var after: [2]u8 = undefined;
+    try source.readSliceAll(&after);
+    try std.testing.expectEqualStrings("ef", &after);
+}
+
+test "modern MCP zero content length does not consume the source" {
+    var source = std.Io.Reader.fixed("x");
+    var reader_buffer: [1]u8 = undefined;
+    var bounded = McpContentLengthReader.init(&source, 0, &reader_buffer);
+
+    var byte: [1]u8 = undefined;
+    try std.testing.expectError(
+        error.EndOfStream,
+        bounded.interface.readSliceAll(&byte),
+    );
+    try source.readSliceAll(&byte);
+    try std.testing.expectEqualStrings("x", &byte);
+}
+
+test "modern MCP content length reader supports incremental buffered reads" {
+    var source = std.Io.Reader.fixed("abcdef");
+    var reader_buffer: [2]u8 = undefined;
+    var bounded = McpContentLengthReader.init(&source, 4, &reader_buffer);
+
+    try bounded.interface.fillMore();
+    try std.testing.expectEqualStrings("ab", bounded.interface.buffered());
+    bounded.interface.toss(2);
+    try bounded.interface.fillMore();
+    try std.testing.expectEqualStrings("cd", bounded.interface.buffered());
+    bounded.interface.toss(2);
+    try std.testing.expectError(error.EndOfStream, bounded.interface.fillMore());
+
+    var after: [2]u8 = undefined;
+    try source.readSliceAll(&after);
+    try std.testing.expectEqualStrings("ef", &after);
+}
+
+test "modern MCP response framing isolates only known content length bodies" {
+    try std.testing.expectEqual(
+        McpResponseBodyFraming.content_length,
+        mcpResponseBodyFraming(.none, 42),
+    );
+    try std.testing.expectEqual(
+        McpResponseBodyFraming.standard,
+        mcpResponseBodyFraming(.none, null),
+    );
+    try std.testing.expectEqual(
+        McpResponseBodyFraming.standard,
+        mcpResponseBodyFraming(.chunked, 42),
     );
 }
 

--- a/src/core/mcp/streamable_http.zig
+++ b/src/core/mcp/streamable_http.zig
@@ -270,11 +270,11 @@ const PreparedRequest = struct {
     }
 };
 
-// Zig 0.16's Response.reader can enter `.ready` before its content-length
-// stream reads the tagged remaining-length field, which aborts the process.
+// The pinned Zig 0.16 Response.reader has aborted on fixed-length MCP responses
+// by accessing body_remaining_content_length while its state was `.ready`.
 // Keep MCP framing in independent state and requests one-shot so teardown never
-// re-enters that union. Remove this adapter when the pinned Response.reader
-// passes the fixed-length JSON and SSE regression cases.
+// re-enters that body-state path. Remove this adapter when Response.reader
+// passes the fixed-length JSON and SSE regression cases on the pinned toolchain.
 const McpContentLengthReader = struct {
     source: *std.Io.Reader,
     remaining: u64,

--- a/src/core/mcp/streamable_http.zig
+++ b/src/core/mcp/streamable_http.zig
@@ -299,7 +299,7 @@ const McpContentLengthReader = struct {
         writer: *std.Io.Writer,
         limit: std.Io.Limit,
     ) std.Io.Reader.StreamError!usize {
-        const self: *McpContentLengthReader = @fieldParentPtr("interface", reader);
+        const self: *McpContentLengthReader = @alignCast(@fieldParentPtr("interface", reader));
         if (self.remaining == 0) return error.EndOfStream;
         const count = try self.source.stream(
             writer,

--- a/src/core/mcp/streamable_http.zig
+++ b/src/core/mcp/streamable_http.zig
@@ -727,7 +727,7 @@ fn readJsonResponse(
     reader: *std.Io.Reader,
     request_id: i64,
     max_response_bytes: usize,
-    allow_null_error_id: bool,
+    allow_discovery_error_id_mismatch: bool,
 ) ![]u8 {
     var body_list: std.ArrayList(u8) = .empty;
     defer body_list.deinit(alloc);
@@ -742,7 +742,12 @@ fn readJsonResponse(
     }
     const body = try body_list.toOwnedSlice(alloc);
     errdefer alloc.free(body);
-    try validateFinalResponse(alloc, body, request_id, allow_null_error_id);
+    try validateFinalResponse(
+        alloc,
+        body,
+        request_id,
+        allow_discovery_error_id_mismatch,
+    );
     return body;
 }
 
@@ -985,7 +990,7 @@ fn validateFinalResponse(
     alloc: Allocator,
     body: []const u8,
     request_id: i64,
-    allow_null_error_id: bool,
+    allow_discovery_error_id_mismatch: bool,
 ) !void {
     var parsed = std.json.parseFromSlice(std.json.Value, alloc, body, .{}) catch {
         return error.InvalidJsonResponse;
@@ -998,8 +1003,7 @@ fn validateFinalResponse(
     }
     const id_value = parsed.value.object.get("id") orelse return error.InvalidJsonResponse;
     const matching_id = id_value == .integer and id_value.integer == request_id;
-    const classifiable_discovery_error = allow_null_error_id and
-        id_value == .null and
+    const classifiable_discovery_error = allow_discovery_error_id_mismatch and
         parsed.value.object.contains("error") and
         !parsed.value.object.contains("result");
     if (!matching_id and !classifiable_discovery_error) {
@@ -1398,6 +1402,36 @@ test "modern MCP JSON responses are bounded and retain request ownership" {
     try std.testing.expectError(
         error.MismatchedResponseId,
         readJsonResponse(alloc, &strict_sdk_error_reader, 7, sdk_error.len, false),
+    );
+
+    const string_id_discovery_error =
+        "{\"jsonrpc\":\"2.0\",\"id\":\"server-error\",\"error\":{\"code\":-32600,\"message\":\"Unsupported protocol version\"}}";
+    var string_id_discovery_error_reader = std.Io.Reader.fixed(string_id_discovery_error);
+    const string_id_discovery_error_body = try readJsonResponse(
+        alloc,
+        &string_id_discovery_error_reader,
+        7,
+        string_id_discovery_error.len,
+        true,
+    );
+    defer alloc.free(string_id_discovery_error_body);
+    try std.testing.expectEqualStrings(
+        string_id_discovery_error,
+        string_id_discovery_error_body,
+    );
+
+    const string_id_success =
+        "{\"jsonrpc\":\"2.0\",\"id\":\"server-error\",\"result\":{}}";
+    var string_id_success_reader = std.Io.Reader.fixed(string_id_success);
+    try std.testing.expectError(
+        error.MismatchedResponseId,
+        readJsonResponse(
+            alloc,
+            &string_id_success_reader,
+            7,
+            string_id_success.len,
+            true,
+        ),
     );
 }
 

--- a/tests/e2e/fixtures/mcp-content-length-http.ts
+++ b/tests/e2e/fixtures/mcp-content-length-http.ts
@@ -1,0 +1,164 @@
+import { createServer, type Socket } from "node:net";
+import { MODERN_HTTP_TOOL_RESULT, MODERN_MCP_VERSION } from "./mcp-modern-http";
+
+export type ContentLengthResponseType = "json" | "sse";
+
+export type ContentLengthHttpRequest = {
+  message: {
+    id: number;
+    method: string;
+    params?: Record<string, any>;
+  };
+  headers: Record<string, string>;
+};
+
+export async function startContentLengthMcpHttpFixture(
+  responseType: ContentLengthResponseType,
+) {
+  const requests: ContentLengthHttpRequest[] = [];
+  const sockets = new Set<Socket>();
+  let failure: Error | undefined;
+
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", (error) => {
+      failure ??= error;
+    });
+
+    let requestBytes = Buffer.alloc(0);
+    let handled = false;
+    socket.on("data", (chunk) => {
+      if (handled) return;
+      if (requestBytes.length + chunk.length > 1024 * 1024) {
+        failure ??= new Error("content-length fixture request exceeded 1 MiB");
+        socket.destroy();
+        return;
+      }
+      requestBytes = Buffer.concat([requestBytes, chunk]);
+      const headerEnd = requestBytes.indexOf("\r\n\r\n");
+      if (headerEnd < 0) return;
+
+      const head = requestBytes.subarray(0, headerEnd).toString("utf8");
+      const lines = head.split("\r\n");
+      const headers: Record<string, string> = {};
+      for (const line of lines.slice(1)) {
+        const separator = line.indexOf(":");
+        if (separator < 0) continue;
+        headers[line.slice(0, separator).trim().toLowerCase()] =
+          line.slice(separator + 1).trim();
+      }
+      const contentLength = Number.parseInt(headers["content-length"] ?? "0", 10);
+      const bodyStart = headerEnd + 4;
+      if (requestBytes.length < bodyStart + contentLength) return;
+
+      handled = true;
+      try {
+        const message = JSON.parse(
+          requestBytes
+            .subarray(bodyStart, bodyStart + contentLength)
+            .toString("utf8"),
+        ) as ContentLengthHttpRequest["message"];
+        requests.push({ message, headers });
+        const response = responseFor(message);
+        const json = JSON.stringify(response);
+        const body = Buffer.from(
+          responseType === "sse"
+            ? `data: ${json}\n\n${": trailing bytes\n".repeat(2_000)}`
+            : json,
+          "utf8",
+        );
+        const responseHead = Buffer.from(
+          "HTTP/1.1 200 OK\r\n" +
+            `Content-Type: ${
+              responseType === "sse"
+                ? "text/event-stream"
+                : "application/json"
+            }\r\n` +
+            `Content-Length: ${body.length}\r\n` +
+            "Connection: keep-alive\r\n\r\n",
+          "utf8",
+        );
+        socket.write(responseHead);
+        const split = Math.max(1, Math.floor(body.length / 2));
+        socket.write(body.subarray(0, split));
+        setTimeout(() => {
+          if (!socket.destroyed) socket.write(body.subarray(split));
+        }, 5);
+      } catch (error) {
+        failure ??= error instanceof Error ? error : new Error(String(error));
+        socket.destroy();
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("missing content-length fixture address");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    requests,
+    get failure() {
+      return failure;
+    },
+    async stop() {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function responseFor(message: ContentLengthHttpRequest["message"]) {
+  if (message.method === "server/discover") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        resultType: "complete",
+        supportedVersions: [MODERN_MCP_VERSION],
+        capabilities: { tools: {} },
+        instructions: "Use the fixed-length echo tool.",
+      },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        resultType: "complete",
+        tools: [{
+          name: "echo",
+          description: "Echo text through the fixed-length fixture",
+          inputSchema: {
+            type: "object",
+            properties: { text: { type: "string" } },
+            required: ["text"],
+          },
+        }],
+        ttlMs: 60_000,
+        cacheScope: "public",
+      },
+    };
+  }
+  if (message.method === "tools/call") {
+    return {
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        resultType: "complete",
+        content: [{
+          type: "text",
+          text: `${MODERN_HTTP_TOOL_RESULT}:${message.params?.arguments?.text ?? ""}`,
+        }],
+      },
+    };
+  }
+  throw new Error(`unsupported MCP method: ${message.method}`);
+}

--- a/tests/e2e/fixtures/mcp-legacy-remote.ts
+++ b/tests/e2e/fixtures/mcp-legacy-remote.ts
@@ -48,7 +48,11 @@ export function startLegacyStreamableHttpFixture(
     urlRequiredOperation?: LegacyUrlRequiredOperation;
     completeBeforeElicitationResponse?: boolean;
     manualUrlCompletion?: boolean;
-    sdkDiscoveryError?: "uninitialized" | "unsupported-version";
+    initializeSse?: boolean;
+    sdkDiscoveryError?:
+      | "uninitialized"
+      | "unsupported-version"
+      | "unsupported-version-string-id";
   } = {},
 ) {
   const mode = options.mode ?? "normal";
@@ -269,12 +273,18 @@ export function startLegacyStreamableHttpFixture(
         if (options.sdkDiscoveryError) {
           return Response.json({
             jsonrpc: "2.0",
-            id: null,
+            id: options.sdkDiscoveryError === "unsupported-version-string-id"
+              ? "server-error"
+              : null,
             error: {
-              code: -32000,
+              code: options.sdkDiscoveryError === "unsupported-version-string-id"
+                ? -32600
+                : -32000,
               message: options.sdkDiscoveryError === "uninitialized"
                 ? "Server not initialized"
-                : "Bad Request: Unsupported protocol version: 2026-07-28",
+                : options.sdkDiscoveryError === "unsupported-version-string-id"
+                  ? "Bad Request: Unsupported protocol version: 2026-07-28. Supported versions: 2024-11-05, 2025-03-26, 2025-06-18, 2025-11-25"
+                  : "Bad Request: Unsupported protocol version: 2026-07-28",
             },
           }, { status: 400 });
         }
@@ -295,7 +305,7 @@ export function startLegacyStreamableHttpFixture(
             ? `session-${version}-${initializeCalls}`
             : `session-${version}`;
         }
-        return Response.json({
+        const initializeResponse = {
           jsonrpc: "2.0",
           id: message!.id,
           result: {
@@ -313,7 +323,11 @@ export function startLegacyStreamableHttpFixture(
             serverInfo: { name: "legacy-streamable-fixture", version: "1" },
             instructions: `Use the ${version} legacy HTTP fixture.`,
           },
-        }, {
+        };
+        if (options.initializeSse) {
+          return sseResponse([{ data: initializeResponse }]);
+        }
+        return Response.json(initializeResponse, {
           headers: sessionId ? { "MCP-Session-Id": sessionId } : undefined,
         });
       }

--- a/tests/e2e/mcp-http.test.ts
+++ b/tests/e2e/mcp-http.test.ts
@@ -11,6 +11,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runFx } from "../evals/eval-helpers";
 import {
+  startContentLengthMcpHttpFixture,
+  type ContentLengthResponseType,
+} from "./fixtures/mcp-content-length-http";
+import {
   MODERN_HTTP_TOOL_RESULT,
   MODERN_MCP_VERSION,
   startModernMcpHttpFixture,
@@ -30,6 +34,9 @@ const TOOL_NAME = "mcp_fixture_echo";
 
 let cleanupRoot: string | null = null;
 let fixture: ReturnType<typeof startModernMcpHttpFixture> | null = null;
+let contentLengthFixture: Awaited<
+  ReturnType<typeof startContentLengthMcpHttpFixture>
+> | null = null;
 let gateway: ReturnType<typeof startFakeGateway> | null = null;
 let tui: TmuxSession | null = null;
 
@@ -37,15 +44,18 @@ afterEach(async () => {
   const activeTui = tui;
   const activeGateway = gateway;
   const activeFixture = fixture;
+  const activeContentLengthFixture = contentLengthFixture;
   const activeCleanupRoot = cleanupRoot;
   tui = null;
   gateway = null;
   fixture = null;
+  contentLengthFixture = null;
   cleanupRoot = null;
 
   if (activeTui) await activeTui.kill();
   activeGateway?.stop();
   activeFixture?.stop();
+  if (activeContentLengthFixture) await activeContentLengthFixture.stop();
   if (activeCleanupRoot) {
     rmSync(activeCleanupRoot, { recursive: true, force: true });
   }
@@ -53,7 +63,7 @@ afterEach(async () => {
 
 function createRoot(
   label: string,
-  activeFixture: ReturnType<typeof startModernMcpHttpFixture>,
+  activeFixture: { url: string },
   operationTimeoutMs = 5_000,
   required = false,
 ) {
@@ -197,6 +207,50 @@ function assertModernWire(
 }
 
 describe("modern MCP Streamable HTTP", () => {
+  for (
+    const responseType of ["json", "sse"] as const satisfies readonly ContentLengthResponseType[]
+  ) {
+    test(`fixed-length ${responseType} responses complete on one-shot connections`, async () => {
+      contentLengthFixture = await startContentLengthMcpHttpFixture(responseType);
+      const root = createRoot(`content-length-${responseType}`, contentLengthFixture);
+      gateway = startToolGateway(`Fixed-length ${responseType} complete.`);
+
+      const result = await runFx(
+        [
+          "ask",
+          "--json",
+          "--auto",
+          "--no-save",
+          `Call the fixed-length ${responseType} fixture.`,
+        ],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway),
+          timeoutMs: 20_000,
+        },
+      );
+
+      if (result.code !== 0) {
+        const signal = result.signal ?? "none";
+        throw new Error(
+          `fixed-length ${responseType} failed signal=${signal} ` +
+            `stderr=${JSON.stringify(result.stderr)}`,
+        );
+      }
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.stdout).output).toContain(
+        `Fixed-length ${responseType} complete.`,
+      );
+      expect(contentLengthFixture.failure).toBeUndefined();
+      expect(
+        contentLengthFixture.requests.map((entry) => entry.message.method),
+      ).toEqual(["server/discover", "tools/list", "tools/call"]);
+      for (const request of contentLengthFixture.requests) {
+        expect(request.headers.connection).toBe("close");
+      }
+    }, 30_000);
+  }
+
   test.skipIf(!tmuxAvailable())(
     "/mcp add --transport http persists and reloads a remote server",
     async () => {

--- a/tests/e2e/mcp-legacy-remote.test.ts
+++ b/tests/e2e/mcp-legacy-remote.test.ts
@@ -176,6 +176,7 @@ describe("version-scoped legacy MCP remote transports", () => {
   for (const sdkDiscoveryError of [
     "uninitialized",
     "unsupported-version",
+    "unsupported-version-string-id",
   ] as const) {
     test(`stock SDK ${sdkDiscoveryError} discovery error falls back to Streamable HTTP initialization`, async () => {
       streamable = startLegacyStreamableHttpFixture("2025-11-25", {
@@ -496,6 +497,31 @@ describe("version-scoped legacy MCP remote transports", () => {
     const result = await runAsk(root, gateway, "Call the no-session fixture.");
 
     expect(result.code).toBe(0);
+    expect(streamable.deleteCalls).toBe(0);
+    for (const entry of streamable.requests) {
+      expect(entry.headers["mcp-session-id"]).toBeUndefined();
+    }
+  }, 30_000);
+
+  test("Clerk-like SSE initialization without a session remains searchable", async () => {
+    streamable = startLegacyStreamableHttpFixture("2025-11-25", {
+      initializeSse: true,
+      sdkDiscoveryError: "unsupported-version",
+      session: false,
+    });
+    const root = createRoot("clerk-like-sse-no-session", "http", streamable.url);
+    gateway = startToolGateway("Clerk-like search complete.");
+
+    const result = await runAsk(
+      root,
+      gateway,
+      "Find and call the legacy MCP tool.",
+    );
+
+    expect(result.code).toBe(0);
+    expect(streamable.initializeCalls).toBe(1);
+    expect(streamable.toolsListCalls).toBe(1);
+    expect(streamable.toolCallCalls).toBe(1);
     expect(streamable.deleteCalls).toBe(0);
     for (const entry of streamable.requests) {
       expect(entry.headers["mcp-session-id"]).toBeUndefined();


### PR DESCRIPTION
## Summary

- Fall back to supported legacy MCP versions when discovery errors use nonnumeric response IDs.
- Keep successful MCP responses strict about matching request IDs.
- Read fixed-length modern MCP JSON and SSE responses without process aborts.
- Close each modern MCP request after one response, including early final SSE events.
