### PR TITLE
Keep turn activity visible across provider phases

### DIFF
--- a/src/core/agent/runtime/assistant_stream.zig
+++ b/src/core/agent/runtime/assistant_stream.zig
@@ -75,6 +75,7 @@ pub const StreamChunkContext = struct {
     continuation_prefix_len: usize = 0,
     continuation_probe_remaining: usize = 0,
     continuation_resolved: bool = true,
+    published_phase: ?types.TurnPhase = null,
     initial_line_prefix: std.ArrayList(u8) = .empty,
     provisional_statuses: runtime_tool_presentation.ProvisionalToolStatuses = .{},
 
@@ -127,6 +128,7 @@ pub const StreamChunkContext = struct {
         self.saw_provider_tool_start = false;
         self.saw_visible_text_after_tool_start = false;
         self.first_model_output_at_ms = null;
+        self.published_phase = null;
     }
 
     /// Restores durable partial source before a restarted turn sends anything.
@@ -178,6 +180,7 @@ pub const StreamChunkContext = struct {
 pub fn onStreamContentChunk(ctx: *anyopaque, chunk: []const u8) void {
     const stream_ctx: *StreamChunkContext = @ptrCast(@alignCast(ctx));
     stream_ctx.markModelOutput();
+    publishTurnPhase(stream_ctx, .generating);
     if (stream_ctx.token_progress) |progress| {
         pushTokenProgressUpdate(stream_ctx, progress.consumeContent(chunk)) catch |err| {
             debug_trace.logf("agent", "token progress publication failed source=content err={s}", .{@errorName(err)});
@@ -191,6 +194,8 @@ pub fn onStreamContentChunk(ctx: *anyopaque, chunk: []const u8) void {
 
 pub fn onStreamReasoningChunk(ctx: *anyopaque, chunk: []const u8) void {
     const stream_ctx: *StreamChunkContext = @ptrCast(@alignCast(ctx));
+    stream_ctx.markModelOutput();
+    publishTurnPhase(stream_ctx, .thinking);
     if (stream_ctx.token_progress) |progress| {
         pushTokenProgressUpdate(stream_ctx, progress.consumeReasoning(chunk)) catch |err| {
             debug_trace.logf("agent", "token progress publication failed source=reasoning err={s}", .{@errorName(err)});
@@ -198,17 +203,22 @@ pub fn onStreamReasoningChunk(ctx: *anyopaque, chunk: []const u8) void {
     }
 }
 
-/// Tools that publish no provisional status leave the activity row with
-/// nothing to say while their arguments stream, which can take as long as the
-/// response did. Tell the shell the turn is composing so the row stays alive.
-fn publishToolPayloadStarted(stream_ctx: *StreamChunkContext) void {
-    stream_ctx.hooks.push_event(stream_ctx.hooks.ctx, .tool_payload_started) catch |err| {
-        debug_trace.logf("agent", "tool payload notice publication failed err={s}", .{@errorName(err)});
+pub fn publishTurnPhase(stream_ctx: *StreamChunkContext, phase: types.TurnPhase) void {
+    if (stream_ctx.published_phase == phase) return;
+    stream_ctx.hooks.push_event(stream_ctx.hooks.ctx, .{ .turn_phase_update = .{
+        .turn_id = stream_ctx.turn_id,
+        .step_id = stream_ctx.step_id,
+        .phase = phase,
+    } }) catch |err| {
+        debug_trace.logf("agent", "turn phase publication failed phase={s} err={s}", .{ @tagName(phase), @errorName(err) });
+        return;
     };
+    stream_ctx.published_phase = phase;
 }
 
 pub fn onStreamToolInputChunk(ctx: *anyopaque, chunk: []const u8) void {
     const stream_ctx: *StreamChunkContext = @ptrCast(@alignCast(ctx));
+    publishTurnPhase(stream_ctx, .running);
     if (stream_ctx.token_progress) |progress| {
         pushTokenProgressUpdate(stream_ctx, progress.consumeToolInput(chunk)) catch |err| {
             debug_trace.logf("agent", "token progress publication failed source=tool_input err={s}", .{@errorName(err)});
@@ -232,7 +242,7 @@ pub fn onStreamToolStart(ctx: *anyopaque, tool_id: []const u8, tool_name: []cons
     const first_tool_in_step = !stream_ctx.saw_tool_start;
     recordStreamToolStart(ctx, tool_name);
     const preflight = runtime_tool_presentation.ProvisionalToolStatuses.preflight(stream_ctx.hooks.tool_registry, tool_name) orelse {
-        publishToolPayloadStarted(stream_ctx);
+        publishTurnPhase(stream_ctx, .running);
         return;
     };
     stream_ctx.markModelOutput();
@@ -251,11 +261,12 @@ pub fn onStreamToolStart(ctx: *anyopaque, tool_id: []const u8, tool_name: []cons
             .anchor_step_id = stream_ctx.step_id,
         };
     }
+    publishTurnPhase(stream_ctx, .running);
     switch (preflight) {
         // Published last: the flush above can push the response's trailing
         // newline, and any text landing after the notice reopens the response
         // row.
-        .ineligible => publishToolPayloadStarted(stream_ctx),
+        .ineligible => {},
         .eligible => |metadata| stream_ctx.provisional_statuses.publish(
             stream_ctx.hooks,
             stream_ctx.alloc,
@@ -701,6 +712,7 @@ const StreamCapture = struct {
     code_blocks: std.ArrayList(assistant_presentation.CodeBlockPayload) = .empty,
     thematic_rule_count: usize = 0,
     token_progress_updates: std.ArrayList(types.TurnTokenProgress) = .empty,
+    phase_updates: std.ArrayList(types.TurnPhase) = .empty,
     trace: std.ArrayList(StreamTraceEntry) = .empty,
     presentation_order: std.ArrayList(PresentationEntry) = .empty,
     capture_alloc: Allocator = std.testing.allocator,
@@ -724,6 +736,7 @@ const StreamCapture = struct {
         for (self.code_blocks.items) |*block| block.deinit(alloc);
         self.code_blocks.deinit(alloc);
         self.token_progress_updates.deinit(alloc);
+        self.phase_updates.deinit(alloc);
         self.trace.deinit(alloc);
         self.presentation_order.deinit(alloc);
     }
@@ -810,8 +823,9 @@ const StreamCapture = struct {
         if (self.event_error) |err| return err;
         const progress = switch (event) {
             .turn_token_update => |update| update,
-            .tool_payload_started => {
-                try self.trace.append(self.capture_alloc, .tool_payload_started);
+            .turn_phase_update => |update| {
+                try self.phase_updates.append(self.capture_alloc, update.phase);
+                try self.trace.append(self.capture_alloc, .{ .turn_phase = update.phase });
                 return;
             },
             else => return,
@@ -874,13 +888,39 @@ const StreamCapture = struct {
     }
 };
 
+test "provider callbacks publish each activity phase transition once" {
+    const alloc = std.testing.allocator;
+    var capture = StreamCapture{};
+    defer capture.deinit(alloc);
+    var hook_set = capture.hooks();
+    var stream_ctx = StreamChunkContext{
+        .hooks = &hook_set,
+        .turn_id = 7,
+        .step_id = 11,
+        .alloc = alloc,
+    };
+    defer stream_ctx.deinit();
+
+    onStreamReasoningChunk(&stream_ctx, "reasoning");
+    onStreamReasoningChunk(&stream_ctx, " continues");
+    onStreamContentChunk(&stream_ctx, "response");
+    onStreamContentChunk(&stream_ctx, " continues\n");
+    onStreamToolStart(&stream_ctx, "command_1", "terminal", null);
+
+    try std.testing.expectEqualSlices(
+        types.TurnPhase,
+        &.{ .thinking, .generating, .running },
+        capture.phase_updates.items,
+    );
+}
+
 const PresentationEntry = enum { text, table, code_block, thematic_rule };
 
 const StreamTraceEntry = union(enum) {
     text: usize,
     provisional: usize,
     progress: usize,
-    tool_payload_started,
+    turn_phase: types.TurnPhase,
 };
 
 const ansi_span_fixture_env = "FX_TEST_C04_STREAM_ANSI_OSC8_FIXTURE";
@@ -1451,19 +1491,20 @@ test "streamed tool start flushes presentation before separator and lifecycle" {
             try std.testing.expectEqualStrings(case.id, capture.lifecycle_events.items[0].provisional.id.call_id);
             try std.testing.expectEqualStrings(case.name, capture.lifecycle_events.items[0].provisional.tool_name.?);
             try std.testing.expectEqualStrings(case.id, capture.lifecycle_events.items[1].progress.id.call_id);
-            try std.testing.expectEqual(@as(usize, 4), capture.trace.items.len);
+            try std.testing.expectEqual(@as(usize, 5), capture.trace.items.len);
             try std.testing.expectEqual(StreamTraceEntry{ .text = 0 }, capture.trace.items[0]);
             try std.testing.expectEqual(StreamTraceEntry{ .text = 1 }, capture.trace.items[1]);
-            try std.testing.expectEqual(StreamTraceEntry{ .provisional = 0 }, capture.trace.items[2]);
-            try std.testing.expectEqual(StreamTraceEntry{ .progress = 1 }, capture.trace.items[3]);
+            try std.testing.expectEqual(types.TurnPhase.running, capture.trace.items[2].turn_phase);
+            try std.testing.expectEqual(StreamTraceEntry{ .provisional = 0 }, capture.trace.items[3]);
+            try std.testing.expectEqual(StreamTraceEntry{ .progress = 1 }, capture.trace.items[4]);
         } else {
             try std.testing.expectEqual(@as(usize, 0), capture.lifecycle_events.items.len);
-            // The payload notice lands after the separator: text arriving after
+            // The working phase lands after the separator: text arriving after
             // it would hand the activity row back to the response.
             try std.testing.expectEqual(@as(usize, 3), capture.trace.items.len);
             try std.testing.expectEqual(StreamTraceEntry{ .text = 0 }, capture.trace.items[0]);
             try std.testing.expectEqual(StreamTraceEntry{ .text = 1 }, capture.trace.items[1]);
-            try std.testing.expectEqual(StreamTraceEntry.tool_payload_started, capture.trace.items[2]);
+            try std.testing.expectEqual(types.TurnPhase.running, capture.trace.items[2].turn_phase);
         }
     }
 
@@ -1479,10 +1520,11 @@ test "streamed tool start flushes presentation before separator and lifecycle" {
     try std.testing.expectEqual(@as(usize, 1), newline_capture.text_spans.items.len);
     try std.testing.expectEqualStrings("complete line\n", newline_capture.text_spans.items[0]);
     try std.testing.expectEqual(@as(usize, 2), newline_capture.lifecycle_events.items.len);
-    try std.testing.expectEqual(@as(usize, 3), newline_capture.trace.items.len);
+    try std.testing.expectEqual(@as(usize, 4), newline_capture.trace.items.len);
     try std.testing.expectEqual(StreamTraceEntry{ .text = 0 }, newline_capture.trace.items[0]);
-    try std.testing.expectEqual(StreamTraceEntry{ .provisional = 0 }, newline_capture.trace.items[1]);
-    try std.testing.expectEqual(StreamTraceEntry{ .progress = 1 }, newline_capture.trace.items[2]);
+    try std.testing.expectEqual(types.TurnPhase.running, newline_capture.trace.items[1].turn_phase);
+    try std.testing.expectEqual(StreamTraceEntry{ .provisional = 0 }, newline_capture.trace.items[2]);
+    try std.testing.expectEqual(StreamTraceEntry{ .progress = 1 }, newline_capture.trace.items[3]);
 }
 
 test "assistant prose before the first tool starts a new presentation group" {
@@ -1946,7 +1988,7 @@ test "streamed presentation suppresses callback-time failures" {
 
         try std.testing.expectEqualStrings("visible\n", stream_ctx.raw_text.items);
         try std.testing.expectEqual(@as(usize, 1), capture.source_calls);
-        try std.testing.expectEqual(@as(usize, 0), capture.event_calls);
+        try std.testing.expectEqual(@as(usize, 1), capture.event_calls);
         try std.testing.expectEqual(@as(usize, 0), capture.text_calls);
     }
 
@@ -1960,7 +2002,7 @@ test "streamed presentation suppresses callback-time failures" {
         onStreamContentChunk(&stream_ctx, "visible\n");
 
         try std.testing.expectEqualStrings("visible\n", stream_ctx.raw_text.items);
-        try std.testing.expectEqual(@as(usize, 0), capture.event_calls);
+        try std.testing.expectEqual(@as(usize, 1), capture.event_calls);
         try std.testing.expectEqual(@as(usize, 1), capture.text_calls);
     }
 
@@ -1974,7 +2016,7 @@ test "streamed presentation suppresses callback-time failures" {
         onStreamContentChunk(&stream_ctx, "visible\n");
 
         try std.testing.expectEqualStrings("visible\n", stream_ctx.raw_text.items);
-        try std.testing.expectEqual(@as(usize, 0), capture.event_calls);
+        try std.testing.expectEqual(@as(usize, 1), capture.event_calls);
         try std.testing.expectEqual(@as(usize, 1), capture.text_calls);
     }
 

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2399,18 +2399,18 @@ fn pushAutoRetryStatus(
     return deadline;
 }
 
-const AutoRetryAdmission = struct {
+const ProviderAdmission = struct {
     deps: *const AgentRuntimeDeps,
+    stream: *runtime_assistant_stream.StreamChunkContext,
     pending_status: *?types.RouteRecoveryStatus,
-    published: bool = false,
 
     fn admit(raw: *anyopaque) !void {
         const self: *@This() = @ptrCast(@alignCast(raw));
-        if (self.published) return;
-        const status = self.pending_status.* orelse return;
-        try pushRouteRecoveryStatus(self.deps, status);
-        self.pending_status.* = null;
-        self.published = true;
+        runtime_assistant_stream.publishTurnPhase(self.stream, .thinking);
+        if (self.pending_status.*) |status| {
+            try pushRouteRecoveryStatus(self.deps, status);
+            self.pending_status.* = null;
+        }
     }
 };
 
@@ -3508,8 +3508,9 @@ fn processQueuedPromptLoop(
                 .stream = &stream_ctx,
                 .required_vision = vision_mode == .required,
             };
-            var auto_retry_admission = AutoRetryAdmission{
+            var provider_admission = ProviderAdmission{
                 .deps = deps,
+                .stream = &stream_ctx,
                 .pending_status = &pending_auto_retry_status,
             };
             var model_request = agent_stream_provider.ModelRequest{
@@ -3544,10 +3545,7 @@ fn processQueuedPromptLoop(
                 .delivery = &gateway_delivery,
                 .attempt_evidence = &gateway_attempt_evidence,
                 .events = .{ .context = &provider_events, .emit_fn = onProviderEvent },
-                .admission = if (pending_auto_retry_status != null)
-                    .{ .context = &auto_retry_admission, .admit_fn = AutoRetryAdmission.admit }
-                else
-                    .{},
+                .admission = .{ .context = &provider_admission, .admit_fn = ProviderAdmission.admit },
                 .cancel_flag = config.cancel_flag,
                 .provider_attempt_owner = .agent,
             };

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -520,9 +520,7 @@ pub const WorkerEvent = union(enum) {
     command_output_complete: ?types.ToolLifecycleId,
     tool_lifecycle: types.ToolLifecycleEvent,
     turn_token_update: types.TurnTokenProgress,
-    /// A tool call that publishes no status row of its own began streaming its
-    /// arguments. The turn is working, with nothing to print until it lands.
-    tool_payload_started,
+    turn_phase_update: types.TurnPhaseUpdate,
     diff_block: diff_mod.DiffEntryPayload,
     finish_prompt: types.FinishedPrompt,
     session_grant: types.PermissionGrant,
@@ -2748,7 +2746,7 @@ pub fn dupeWorkerEvent(alloc: std.mem.Allocator, event: WorkerEvent) !WorkerEven
             .tool_lifecycle = try dupeToolLifecycleEvent(alloc, lifecycle),
         },
         .turn_token_update => |update| .{ .turn_token_update = update },
-        .tool_payload_started => .tool_payload_started,
+        .turn_phase_update => |update| .{ .turn_phase_update = update },
         .diff_block => |payload| blk: {
             const preview = try alloc.dupe(u8, payload.preview);
             errdefer alloc.free(preview);

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1134,7 +1134,7 @@ pub fn Runtime(comptime App: type) type {
                 .question_requested,
                 .open_model_picker,
                 .turn_token_update,
-                .tool_payload_started,
+                .turn_phase_update,
                 .finish_prompt,
                 .session_grant,
                 => {},

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -187,7 +187,7 @@ pub fn Runtime(comptime App: type) type {
                 .semantic_notice,
                 .command_output,
                 .turn_token_update,
-                .tool_payload_started,
+                .turn_phase_update,
                 .diff_block,
                 => .drop,
                 .route_recovery_status => |status| if (status.action == .paused)
@@ -630,9 +630,9 @@ pub fn Runtime(comptime App: type) type {
         ) ?[]const u8 {
             // Existence guard only: pass no clock so the label skips the counter.
             if (!app.stream.active and app.pacer.hasCompletedAssistantPresentationTail()) {
-                return activity_status.buildThinkingLabel(buf, .{ .active = true }, 0);
+                return activity_status.buildTurnLabel(buf, .{ .active = true }, 0);
             }
-            if (activity_status.buildThinkingLabel(buf, app.stream, 0)) |label| return label;
+            if (activity_status.buildTurnLabel(buf, app.stream, 0)) |label| return label;
             if (app.stream.last_activity_kind == .ask) return ui_render.ask_activity_label;
             switch (presenter.snapshot().activity) {
                 .tool_slot => |slot| return slot.fallback_label,
@@ -762,7 +762,6 @@ pub fn Runtime(comptime App: type) type {
                         }
                         switch (presentation) {
                             .text => |text| {
-                                app.stream = nextStreamAfterAssistantText(app.stream, text);
                                 try handlers.append_text(handlers.ctx, text);
                                 debug_trace.eventf(
                                     "worker",
@@ -773,17 +772,14 @@ pub fn Runtime(comptime App: type) type {
                                 );
                             },
                             .table => |table| {
-                                markAssistantText(app);
                                 drain_owns_current = false;
                                 try handlers.append_table(handlers.ctx, table);
                             },
                             .code_block => |block| {
-                                markAssistantText(app);
                                 drain_owns_current = false;
                                 try handlers.append_code_block(handlers.ctx, block);
                             },
                             .thematic_rule => {
-                                markAssistantText(app);
                                 drain_owns_current = false;
                                 try handlers.append_thematic_rule(handlers.ctx);
                             },
@@ -872,9 +868,8 @@ pub fn Runtime(comptime App: type) type {
                     .turn_token_update => |update| {
                         applyTurnTokenProgress(app, update);
                     },
-                    .tool_payload_started => {
-                        app.stream.composing_tool_payload = true;
-                        app.shell.render_requests.request(.footer);
+                    .turn_phase_update => |update| {
+                        applyTurnPhase(app, update);
                     },
                     .diff_block => |payload| {
                         drain_owns_current = false;
@@ -961,9 +956,9 @@ pub fn Runtime(comptime App: type) type {
             presenter: activity_runtime.LifecyclePresenter,
             lifecycle: types.ToolLifecycleEvent,
         ) !void {
-            const starts_tool_stretch = switch (lifecycle) {
-                .provisional, .authoritative_started => true,
-                .progress, .terminal, .turn_finished => false,
+            const tool_work_active = switch (lifecycle) {
+                .provisional, .authoritative_started, .progress => true,
+                .terminal, .turn_finished => false,
             };
             const transition = try presenter.apply(
                 app.alloc,
@@ -988,23 +983,12 @@ pub fn Runtime(comptime App: type) type {
             }
 
             const focused_activity_kind = transition.snapshot.focused_activity_kind;
-            if (starts_tool_stretch) {
-                // The payload landed, or another tool took the row.
-                app.stream.composing_tool_payload = false;
-                if (focused_activity_kind != null) {
-                    app.stream.assistant_text_started = false;
-                }
-            }
+            if (tool_work_active) app.stream.phase = .running;
             app.stream.last_activity_kind = focused_activity_kind;
             if (transition.focus_changed()) {
                 app.shell.render_requests.requestAnimationReset();
             }
             app.shell.render_requests.request(.footer);
-        }
-
-        fn markAssistantText(app: *App) void {
-            app.stream.assistant_text_started = true;
-            app.stream.composing_tool_payload = false;
         }
 
         fn resetStream(app: *App, clear_route_recovery: bool) void {
@@ -1041,24 +1025,17 @@ pub fn Runtime(comptime App: type) type {
                 app.shell.render_requests.animation_next_deadline_ms != 0;
             if (changed and !animation_armed) app.shell.render_requests.request(.footer);
         }
+
+        fn applyTurnPhase(app: *App, update: types.TurnPhaseUpdate) void {
+            if (!app.stream.active or update.turn_id != app.worker.activeTurnId()) return;
+            if (update.step_id < app.stream.phase_step_id) return;
+
+            const changed = app.stream.phase != update.phase;
+            app.stream.phase = update.phase;
+            app.stream.phase_step_id = update.step_id;
+            if (changed) app.shell.render_requests.request(.footer);
+        }
     };
-}
-
-fn nextStreamAfterAssistantText(
-    current: types.StreamState,
-    text: []const u8,
-) types.StreamState {
-    var next = current;
-    if (current.composing_tool_payload and
-        std.mem.trim(u8, text, " \t\r\n").len == 0)
-    {
-        next.assistant_text_started = false;
-        return next;
-    }
-
-    next.assistant_text_started = true;
-    next.composing_tool_payload = false;
-    return next;
 }
 
 fn formatWebSearchProgress(alloc: std.mem.Allocator, progress: types.WebSearchProgress) ![]u8 {
@@ -2143,6 +2120,55 @@ test "core.app_worker_runtime applies turn token output as an absolute snapshot"
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
 }
 
+test "core.app_worker_runtime applies only current monotonic turn phase updates" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+
+    app.worker.processing = true;
+    app.worker.active_turn_id = 7;
+    app.stream.active = true;
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .turn_phase_update = .{
+        .turn_id = 7,
+        .step_id = 12,
+        .phase = .generating,
+    } });
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .turn_phase_update = .{
+        .turn_id = 7,
+        .step_id = 11,
+        .phase = .running,
+    } });
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .turn_phase_update = .{
+        .turn_id = 6,
+        .step_id = 13,
+        .phase = .running,
+    } });
+
+    try tickNoop(&app);
+
+    try std.testing.expectEqual(types.TurnPhase.generating, app.stream.phase);
+    try std.testing.expectEqual(@as(u64, 12), app.stream.phase_step_id);
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+}
+
+test "core.app_worker_runtime next admitted model step returns running to thinking" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+
+    app.worker.processing = true;
+    app.worker.active_turn_id = 7;
+    app.stream = .{ .active = true, .phase = .running, .phase_step_id = 12 };
+    try app.worker.pushEvent(std.heap.c_allocator, .{ .turn_phase_update = .{
+        .turn_id = 7,
+        .step_id = 13,
+        .phase = .thinking,
+    } });
+
+    try tickNoop(&app);
+
+    try std.testing.expectEqual(types.TurnPhase.thinking, app.stream.phase);
+    try std.testing.expectEqual(@as(u64, 13), app.stream.phase_step_id);
+}
+
 test "core.app_worker_runtime advances visible animation exactly at its deadline" {
     var app = FakeApp.init(std.testing.allocator);
     defer app.deinit();
@@ -2867,7 +2893,7 @@ test "core.app_worker_runtime syncState clears a completed approval" {
     try std.testing.expect(app.shell.render_requests.hasReason(.modal));
 }
 
-test "core.app_worker_runtime syncState freezes the thinking clock while an approval waits" {
+test "core.app_worker_runtime syncState freezes the turn clock while an approval waits" {
     var app = FakeApp.init(std.testing.allocator);
     defer app.deinit();
 
@@ -3192,14 +3218,13 @@ test "core.app_worker_runtime lifecycle starts drain real paced text into one as
     try std.testing.expectEqual(@as(usize, 2), app.shell.lifecyclePinCount());
 }
 
-test "core.app_worker_runtime structural separator opens thinking stretch during tool composition" {
+test "core.app_worker_runtime structural separator preserves running phase during tool composition" {
     var app = FakeApp.init(std.testing.allocator);
     defer app.deinit();
     app.worker.processing = true;
     app.stream = .{
         .active = true,
-        .assistant_text_started = true,
-        .composing_tool_payload = true,
+        .phase = .running,
     };
 
     try app.worker.pushEvent(std.heap.c_allocator, .{
@@ -3208,17 +3233,16 @@ test "core.app_worker_runtime structural separator opens thinking stretch during
 
     try tickNoop(&app);
 
-    try std.testing.expect(!app.stream.assistant_text_started);
-    try std.testing.expect(app.stream.composing_tool_payload);
+    try std.testing.expectEqual(types.TurnPhase.running, app.stream.phase);
 }
 
-test "core.app_worker_runtime provisional tool start opens the next thinking stretch" {
+test "core.app_worker_runtime provisional tool start switches generating to running" {
     var app = FakeApp.init(std.testing.allocator);
     defer app.deinit();
     app.worker.processing = true;
     app.stream = .{
         .active = true,
-        .assistant_text_started = true,
+        .phase = .generating,
     };
 
     try queueLifecycle(&app, .{ .provisional = .{
@@ -3229,7 +3253,7 @@ test "core.app_worker_runtime provisional tool start opens the next thinking str
 
     try tickNoop(&app);
 
-    try std.testing.expect(!app.stream.assistant_text_started);
+    try std.testing.expectEqual(types.TurnPhase.running, app.stream.phase);
     try std.testing.expectEqual(
         @as(?types.ToolActivityKind, .read),
         app.stream.last_activity_kind,
@@ -3934,7 +3958,7 @@ test "core.app_worker_runtime error text resets active stream and requests foote
     app.worker.processing = true;
     app.stream = .{
         .active = true,
-        .assistant_text_started = true,
+        .phase = .generating,
         .last_activity_kind = .ask,
     };
     try app.worker.pushEvent(std.heap.c_allocator, .{ .error_text = .{
@@ -3990,7 +4014,7 @@ test "core.app_worker_runtime blocked error drain retains the error and suffix i
     app.worker.processing = true;
     app.stream = .{
         .active = true,
-        .assistant_text_started = true,
+        .phase = .generating,
         .last_activity_kind = .ask,
     };
     try app.worker.pushEvent(std.heap.c_allocator, .{ .error_text = .{

--- a/src/core/output/activity_status.zig
+++ b/src/core/output/activity_status.zig
@@ -23,21 +23,30 @@ fn streamStatusVerb(stream: StreamState) []const u8 {
     };
 }
 
-pub fn buildThinkingLabel(buf: []u8, stream: StreamState, now_ms: i64) ?[]const u8 {
+fn markedTurnPhaseLabel(phase: types.TurnPhase) []const u8 {
+    return switch (phase) {
+        .thinking => "• Thinking",
+        .generating => "• Generating",
+        .running => "• Running",
+    };
+}
+
+pub fn buildTurnLabel(buf: []u8, stream: StreamState, now_ms: i64) ?[]const u8 {
     if (stream.last_activity_kind != null) return null;
     var out: std.Io.Writer = .fixed(buf);
-    out.writeAll("• Thinking") catch return "• Thinking";
-    appendThinkingElapsedSuffix(&out, stream, now_ms) catch return out.buffered();
+    const marked_phase = markedTurnPhaseLabel(stream.phase);
+    out.writeAll(marked_phase) catch return marked_phase;
+    appendTurnElapsedSuffix(&out, stream, now_ms) catch return out.buffered();
     appendTurnTokenSuffix(&out, stream) catch return out.buffered();
     return out.buffered();
 }
 
-pub const thinking_blink_half_period_ms: i64 = 500;
+pub const activity_blink_half_period_ms: i64 = 500;
 
-/// The instant the Thinking clock reads. While fx waits on user input the
+/// The instant the turn clock reads. While fx waits on user input the
 /// clock is frozen at the moment the wait began, so time spent on an approval
-/// or question never counts as thinking.
-fn thinkingClockNow(stream: StreamState, now_ms: i64) i64 {
+/// or question never counts toward active work.
+fn turnClockNow(stream: StreamState, now_ms: i64) i64 {
     if (stream.waiting_since_ms > 0 and stream.waiting_since_ms < now_ms) {
         return stream.waiting_since_ms;
     }
@@ -49,18 +58,18 @@ fn thinkingClockNow(stream: StreamState, now_ms: i64) i64 {
 /// seconds digit advances. Steady on while waiting on user input (a frozen
 /// clock would otherwise strand the marker dark). Null when no turn is being
 /// timed.
-pub fn thinkingBlinkVisible(stream: StreamState, now_ms: i64) ?bool {
+pub fn activityBlinkVisible(stream: StreamState, now_ms: i64) ?bool {
     if (stream.turn_started_ms <= 0 or now_ms < stream.turn_started_ms) return null;
     if (stream.waiting_since_ms > 0) return true;
-    const half_periods = @divTrunc(now_ms - stream.turn_started_ms, thinking_blink_half_period_ms);
+    const half_periods = @divTrunc(now_ms - stream.turn_started_ms, activity_blink_half_period_ms);
     return @mod(half_periods, 2) == 0;
 }
 
-fn appendThinkingElapsedSuffix(writer: *std.Io.Writer, stream: StreamState, now_ms: i64) !void {
+fn appendTurnElapsedSuffix(writer: *std.Io.Writer, stream: StreamState, now_ms: i64) !void {
     if (stream.turn_started_ms <= 0 or now_ms < stream.turn_started_ms) return;
     // One displayed second spans exactly one on/off blink period.
-    const ms_per_second = 2 * thinking_blink_half_period_ms;
-    const seconds = @divTrunc(thinkingClockNow(stream, now_ms) - stream.turn_started_ms, ms_per_second);
+    const ms_per_second = 2 * activity_blink_half_period_ms;
+    const seconds = @divTrunc(turnClockNow(stream, now_ms) - stream.turn_started_ms, ms_per_second);
     try writer.writeAll(" (");
     try writeElapsed(writer, seconds);
     try writer.writeByte(')');
@@ -84,7 +93,7 @@ fn writeElapsed(writer: *std.Io.Writer, seconds: i64) !void {
 }
 
 /// Tracks whether fx is waiting on user input (approval prompt or question)
-/// and keeps the Thinking clock honest: the clock freezes when the wait
+/// and keeps the turn clock honest: the clock freezes when the wait
 /// begins, and on resume the whole wait is excluded by shifting
 /// turn_started_ms forward. Call whenever the waiting state may have changed.
 pub fn syncWaitingClock(stream: *StreamState, waiting: bool, now_ms: i64) void {
@@ -105,27 +114,14 @@ pub fn syncWaitingClock(stream: *StreamState, waiting: bool, now_ms: i64) void {
 // Width of the "• " marker every other activity row carries.
 const marker_indent = "  ";
 
-// The printed response is its own progress report, so this row drops the marker
-// and the verb and keeps the live counter in the marker's column. A markerless
-// label also renders static, which stops the marker blinking through the text.
-pub fn buildStreamingLabel(buf: []u8, stream: StreamState) []const u8 {
+// The completed turn summary occupies the same marker column without retaining
+// the active phase label or blink.
+pub fn buildCompletedTurnLabel(buf: []u8, stream: StreamState) []const u8 {
     const progress = stream.token_progress;
     if (progress.input_tokens == 0 and progress.output_tokens == 0) return marker_indent;
     var out: std.Io.Writer = .fixed(buf);
     out.writeAll(marker_indent) catch return marker_indent;
     writeTokenProgress(&out, progress) catch return out.buffered();
-    return out.buffered();
-}
-
-/// The response stretch is open but nothing is printing: the model is still
-/// producing output fx cannot show yet, typically a large tool payload. The row
-/// takes the marker back so it blinks and carries the turn clock, and stays
-/// verbless because naming the work would mean guessing at it.
-pub fn buildQuietTurnLabel(buf: []u8, stream: StreamState, now_ms: i64) []const u8 {
-    var out: std.Io.Writer = .fixed(buf);
-    out.writeAll("•") catch return "•";
-    appendThinkingElapsedSuffix(&out, stream, now_ms) catch return out.buffered();
-    appendTurnTokenSuffix(&out, stream) catch return out.buffered();
     return out.buffered();
 }
 
@@ -211,62 +207,62 @@ pub fn appendTurnTokenSuffix(writer: *std.Io.Writer, stream: StreamState) !void 
     try appendTokenProgressSuffix(writer, stream.token_progress);
 }
 
-test "buildThinkingLabel returns thinking when no tool activity" {
+test "buildTurnLabel returns thinking when no tool activity" {
     var buf: [32]u8 = undefined;
-    const label = buildThinkingLabel(&buf, .{ .active = true }, 0);
+    const label = buildTurnLabel(&buf, .{ .active = true }, 0);
     try std.testing.expectEqualStrings("• Thinking", label.?);
 }
 
-test "buildThinkingLabel renders turn token suffix with input only" {
+test "buildTurnLabel renders turn token suffix with input only" {
     var buf: [64]u8 = undefined;
-    const label = buildThinkingLabel(&buf, .{
+    const label = buildTurnLabel(&buf, .{
         .active = true,
         .token_progress = .{ .input_tokens = 10 },
     }, 0);
     try std.testing.expectEqualStrings("• Thinking (↑10 ↓0)", label.?);
 }
 
-test "buildThinkingLabel renders turn token suffix with input and output" {
+test "buildTurnLabel renders turn token suffix with input and output" {
     var buf: [64]u8 = undefined;
-    const label = buildThinkingLabel(&buf, .{
+    const label = buildTurnLabel(&buf, .{
         .active = true,
         .token_progress = .{ .input_tokens = 10, .output_tokens = 20 },
     }, 0);
     try std.testing.expectEqualStrings("• Thinking (↑10 ↓20)", label.?);
 }
 
-test "buildThinkingLabel renders elapsed seconds for the running turn" {
+test "buildTurnLabel renders elapsed seconds for the running turn" {
     var buf: [64]u8 = undefined;
-    const label = buildThinkingLabel(&buf, .{
+    const label = buildTurnLabel(&buf, .{
         .active = true,
         .turn_started_ms = 1_000,
     }, 6_500);
     try std.testing.expectEqualStrings("• Thinking (5s)", label.?);
 }
 
-test "buildThinkingLabel renders elapsed minutes and seconds for long turns" {
+test "buildTurnLabel renders elapsed minutes and seconds for long turns" {
     var buf: [64]u8 = undefined;
     // 1080s of blink periods elapsed → 18m0s instead of a raw second count.
-    const label = buildThinkingLabel(&buf, .{
+    const label = buildTurnLabel(&buf, .{
         .active = true,
         .turn_started_ms = 1_000,
     }, 1_000 + 1_080 * 1_000);
     try std.testing.expectEqualStrings("• Thinking (18m0s)", label.?);
 }
 
-test "buildThinkingLabel renders elapsed hours for very long turns" {
+test "buildTurnLabel renders elapsed hours for very long turns" {
     var buf: [64]u8 = undefined;
     // 3663s → 1h1m3s.
-    const label = buildThinkingLabel(&buf, .{
+    const label = buildTurnLabel(&buf, .{
         .active = true,
         .turn_started_ms = 1_000,
     }, 1_000 + 3_663 * 1_000);
     try std.testing.expectEqualStrings("• Thinking (1h1m3s)", label.?);
 }
 
-test "buildThinkingLabel renders elapsed seconds before the token suffix" {
+test "buildTurnLabel renders elapsed seconds before the token suffix" {
     var buf: [64]u8 = undefined;
-    const label = buildThinkingLabel(&buf, .{
+    const label = buildTurnLabel(&buf, .{
         .active = true,
         .turn_started_ms = 1_000,
         .token_progress = .{ .input_tokens = 10, .output_tokens = 20 },
@@ -274,41 +270,41 @@ test "buildThinkingLabel renders elapsed seconds before the token suffix" {
     try std.testing.expectEqualStrings("• Thinking (12s) (↑10 ↓20)", label.?);
 }
 
-test "thinking blink relights exactly when the seconds digit advances" {
+test "activity blink relights exactly when the seconds digit advances" {
     const stream: StreamState = .{ .active = true, .turn_started_ms = 1_000 };
-    try std.testing.expectEqual(@as(?bool, true), thinkingBlinkVisible(stream, 1_000));
-    try std.testing.expectEqual(@as(?bool, true), thinkingBlinkVisible(stream, 1_499));
-    try std.testing.expectEqual(@as(?bool, false), thinkingBlinkVisible(stream, 1_500));
-    try std.testing.expectEqual(@as(?bool, false), thinkingBlinkVisible(stream, 1_999));
-    try std.testing.expectEqual(@as(?bool, true), thinkingBlinkVisible(stream, 2_000));
+    try std.testing.expectEqual(@as(?bool, true), activityBlinkVisible(stream, 1_000));
+    try std.testing.expectEqual(@as(?bool, true), activityBlinkVisible(stream, 1_499));
+    try std.testing.expectEqual(@as(?bool, false), activityBlinkVisible(stream, 1_500));
+    try std.testing.expectEqual(@as(?bool, false), activityBlinkVisible(stream, 1_999));
+    try std.testing.expectEqual(@as(?bool, true), activityBlinkVisible(stream, 2_000));
 
     var label_buf: [64]u8 = undefined;
-    const at_relight = buildThinkingLabel(&label_buf, stream, 2_000).?;
+    const at_relight = buildTurnLabel(&label_buf, stream, 2_000).?;
     try std.testing.expectEqualStrings("• Thinking (1s)", at_relight);
 }
 
-test "thinking blink has no clock without a running turn" {
-    try std.testing.expectEqual(@as(?bool, null), thinkingBlinkVisible(.{ .active = true }, 5_000));
+test "activity blink has no clock without a running turn" {
+    try std.testing.expectEqual(@as(?bool, null), activityBlinkVisible(.{ .active = true }, 5_000));
     try std.testing.expectEqual(
         @as(?bool, null),
-        thinkingBlinkVisible(.{ .active = true, .turn_started_ms = 6_000 }, 5_000),
+        activityBlinkVisible(.{ .active = true, .turn_started_ms = 6_000 }, 5_000),
     );
 }
 
-test "thinking clock freezes while waiting on user input and excludes the wait" {
+test "turn clock freezes while waiting on user input and excludes the wait" {
     var stream: StreamState = .{ .active = true, .turn_started_ms = 1_000 };
     var buf: [64]u8 = undefined;
 
     syncWaitingClock(&stream, true, 5_000);
     try std.testing.expectEqual(@as(i64, 5_000), stream.waiting_since_ms);
 
-    try std.testing.expectEqualStrings("• Thinking (4s)", buildThinkingLabel(&buf, stream, 900_000).?);
-    try std.testing.expectEqual(@as(?bool, true), thinkingBlinkVisible(stream, 900_000));
+    try std.testing.expectEqualStrings("• Thinking (4s)", buildTurnLabel(&buf, stream, 900_000).?);
+    try std.testing.expectEqual(@as(?bool, true), activityBlinkVisible(stream, 900_000));
 
     syncWaitingClock(&stream, false, 900_000);
     try std.testing.expectEqual(@as(i64, 0), stream.waiting_since_ms);
-    try std.testing.expectEqualStrings("• Thinking (4s)", buildThinkingLabel(&buf, stream, 900_000).?);
-    try std.testing.expectEqualStrings("• Thinking (7s)", buildThinkingLabel(&buf, stream, 903_000).?);
+    try std.testing.expectEqualStrings("• Thinking (4s)", buildTurnLabel(&buf, stream, 900_000).?);
+    try std.testing.expectEqualStrings("• Thinking (7s)", buildTurnLabel(&buf, stream, 903_000).?);
 }
 
 test "waiting clock accumulates across repeated prompts in one turn" {
@@ -324,7 +320,7 @@ test "waiting clock accumulates across repeated prompts in one turn" {
     syncWaitingClock(&stream, true, 11_000);
     syncWaitingClock(&stream, false, 20_000);
     var buf: [64]u8 = undefined;
-    try std.testing.expectEqualStrings("• Thinking (2s)", buildThinkingLabel(&buf, stream, 20_000).?);
+    try std.testing.expectEqualStrings("• Thinking (2s)", buildTurnLabel(&buf, stream, 20_000).?);
 }
 
 test "waiting clock does not start without an active stream" {
@@ -333,18 +329,18 @@ test "waiting clock does not start without an active stream" {
     try std.testing.expectEqual(@as(i64, 0), stream.waiting_since_ms);
 }
 
-test "buildThinkingLabel hides elapsed seconds when the clock runs behind the mark" {
+test "buildTurnLabel hides elapsed seconds when the clock runs behind the mark" {
     var buf: [64]u8 = undefined;
-    const label = buildThinkingLabel(&buf, .{
+    const label = buildTurnLabel(&buf, .{
         .active = true,
         .turn_started_ms = 2_000,
     }, 1_000);
     try std.testing.expectEqualStrings("• Thinking", label.?);
 }
 
-test "buildStreamingLabel renders live token progress without approximation markers" {
+test "buildCompletedTurnLabel renders token progress without approximation markers" {
     var buf: [64]u8 = undefined;
-    const label = buildStreamingLabel(&buf, .{
+    const label = buildCompletedTurnLabel(&buf, .{
         .active = true,
         .token_progress = .{
             .input_tokens = 1_500,
@@ -356,33 +352,14 @@ test "buildStreamingLabel renders live token progress without approximation mark
     try std.testing.expectEqualStrings("  (↑1.5k ↓20)", label);
 }
 
-test "buildStreamingLabel holds the marker column before the first usage report" {
+test "buildCompletedTurnLabel holds the marker column before the first usage report" {
     var buf: [64]u8 = undefined;
-    try std.testing.expectEqualStrings("  ", buildStreamingLabel(&buf, .{ .active = true }));
+    try std.testing.expectEqualStrings("  ", buildCompletedTurnLabel(&buf, .{ .active = true }));
 }
 
-test "buildQuietTurnLabel keeps the marker and the clock without naming the work" {
-    var buf: [64]u8 = undefined;
-    const label = buildQuietTurnLabel(&buf, .{
-        .active = true,
-        .turn_started_ms = 1_000,
-        .token_progress = .{ .input_tokens = 169, .output_tokens = 5_100 },
-    }, 13_000);
-    try std.testing.expectEqualStrings("• (12s) (↑169 ↓5.1k)", label);
-}
-
-test "buildQuietTurnLabel omits the clock before the turn is timed" {
-    var buf: [64]u8 = undefined;
-    const label = buildQuietTurnLabel(&buf, .{
-        .active = true,
-        .token_progress = .{ .input_tokens = 169, .output_tokens = 20 },
-    }, 13_000);
-    try std.testing.expectEqualStrings("• (↑169 ↓20)", label);
-}
-
-test "buildThinkingLabel returns null when tool activity is set" {
+test "buildTurnLabel returns null when tool activity is set" {
     var buf: [32]u8 = undefined;
-    const label = buildThinkingLabel(&buf, .{ .active = true, .last_activity_kind = .write }, 0);
+    const label = buildTurnLabel(&buf, .{ .active = true, .last_activity_kind = .write }, 0);
     try std.testing.expect(label == null);
 }
 

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -172,8 +172,22 @@ pub const ToolLifecycleEvent = union(enum) {
     turn_finished: TurnFinished,
 };
 
+pub const TurnPhase = enum {
+    thinking,
+    generating,
+    running,
+};
+
+pub const TurnPhaseUpdate = struct {
+    turn_id: u64,
+    step_id: u64,
+    phase: TurnPhase,
+};
+
 pub const StreamState = struct {
     active: bool = false,
+    phase: TurnPhase = .thinking,
+    phase_step_id: u64 = 0,
     chunks: usize = 0,
     read_count: usize = 0,
     list_count: usize = 0,
@@ -184,22 +198,13 @@ pub const StreamState = struct {
     subagent_count: usize = 0,
     token_progress: TurnTokenProgress = .{},
     last_activity_kind: ?ToolActivityKind = null,
-    /// When the turn started; 0 hides the Thinking elapsed counter and its
-    /// wall-clock blink. Monotonic for the whole turn: tool boundaries never
-    /// reset it.
+    /// When the turn started; 0 hides the elapsed counter and activity blink.
+    /// Monotonic for the whole turn: phase and tool boundaries never reset it.
     turn_started_ms: i64 = 0,
     /// When fx started waiting on user input (approval or question); 0 means
-    /// not waiting. While set, the Thinking clock freezes at this instant;
+    /// not waiting. While set, the turn clock freezes at this instant;
     /// on resume the wait is excluded by shifting turn_started_ms forward.
     waiting_since_ms: i64 = 0,
-    /// Assistant text reached the transcript in the current stretch: the
-    /// status row stays with the response instead of flipping back to Thinking
-    /// whenever the pacer catches up. A tool start opens the next stretch.
-    assistant_text_started: bool = false,
-    /// The model is streaming tool arguments that open no status row of their
-    /// own, so the turn is producing output the transcript cannot show yet.
-    /// Cleared as soon as assistant text resumes or the tool itself starts.
-    composing_tool_payload: bool = false,
 };
 
 pub const RouteRecoveryUnsafeReason = enum {

--- a/src/core/subagent/execution.zig
+++ b/src/core/subagent/execution.zig
@@ -1259,7 +1259,7 @@ fn livePresentationEventBytes(event: worker_runtime.WorkerEvent) ?usize {
         .clear_route_recovery_status,
         .route_recovery_status,
         .turn_token_update,
-        .tool_payload_started,
+        .turn_phase_update,
         => 1,
         .semantic_notice, .error_text => |notice| notice.topic.len +| notice.body.len,
         .command_output => |chunk| chunk.text.len +|

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -481,54 +481,32 @@ pub fn frameOwnedActivityProjection(
 ) ActivityProjection {
     if (approval != null or ctx.question != null) return .none;
     switch (ctx.activity) {
-        .tool_slot => return thinkingActivityProjection(buf, shell, ctx),
+        .tool_slot => {},
         .turn_thinking => |thinking| {
             if (thinking.tone != .thinking) return ctx.activity;
-            return thinkingActivityProjection(buf, shell, ctx);
         },
-        .none => return thinkingActivityProjection(buf, shell, ctx),
+        .none => {},
     }
+    return turnActivityProjection(buf, shell, ctx);
 }
 
-fn thinkingActivityProjection(
+fn turnActivityProjection(
     buf: []u8,
     shell: *TranscriptRuntime,
     ctx: RenderContext,
 ) ActivityProjection {
     _ = shell;
-    // The markerless counter row belongs to the response: the text landing on
-    // screen is its own progress report, and it keeps the row through the gaps
-    // where the pacer waits on the next chunk. Once the model switches to a
-    // tool payload nothing will print for a while, so the row takes the marker
-    // back and starts blinking again.
-    if (ctx.stream.active and ctx.stream.assistant_text_started and ctx.stream.composing_tool_payload) {
-        return .{ .turn_thinking = .{
-            .label = activity_status.buildQuietTurnLabel(buf, ctx.stream, ctx.now_ms),
-        } };
-    }
-    if (ctx.writing_response or (ctx.stream.active and ctx.stream.assistant_text_started)) {
-        return .{ .turn_thinking = .{
-            .label = activity_status.buildStreamingLabel(buf, ctx.stream),
-            .tone = if (ctx.stream.active) .thinking else .neutral,
-        } };
-    }
     if (!ctx.stream.active) {
-        if (!ctx.completed_assistant_presentation_tail) return .none;
-        const presentation_stream: StreamState = .{ .active = true };
+        if (!ctx.writing_response and !ctx.completed_assistant_presentation_tail) return .none;
         return .{ .turn_thinking = .{
-            .label = activity_status.buildThinkingLabel(buf, presentation_stream, ctx.now_ms) orelse "• Thinking",
+            .label = activity_status.buildCompletedTurnLabel(buf, ctx.stream),
+            .tone = .neutral,
         } };
     }
-    var thinking_stream = ctx.stream;
-    thinking_stream.last_activity_kind = null;
-    thinking_stream.read_count = 0;
-    thinking_stream.list_count = 0;
-    thinking_stream.write_count = 0;
-    thinking_stream.edit_count = 0;
-    thinking_stream.open_count = 0;
-    thinking_stream.command_count = 0;
-    thinking_stream.subagent_count = 0;
-    if (activity_status.buildThinkingLabel(buf, thinking_stream, ctx.now_ms)) |label| {
+
+    var visible_stream = ctx.stream;
+    visible_stream.last_activity_kind = null;
+    if (activity_status.buildTurnLabel(buf, visible_stream, ctx.now_ms)) |label| {
         return .{ .turn_thinking = .{ .label = label } };
     }
     return .{ .turn_thinking = .{
@@ -795,6 +773,8 @@ test "current frame-owned activity leaves the focused tool in the transcript" {
     const ctx: RenderContext = .{
         .stream = .{
             .active = true,
+            .phase = .running,
+            .turn_started_ms = 1_000,
             .command_count = 1,
             .last_activity_kind = .command,
             .token_progress = .{
@@ -818,6 +798,7 @@ test "current frame-owned activity leaves the focused tool in the transcript" {
             .active = true,
             .kind = .command,
         } },
+        .now_ms = 13_000,
         .input = &input,
     };
 
@@ -825,7 +806,7 @@ test "current frame-owned activity leaves the focused tool in the transcript" {
     const projection = frameOwnedActivityProjection(&active_buf, &shell, ctx, null);
     switch (projection) {
         .turn_thinking => |thinking| try std.testing.expectEqualStrings(
-            "• Thinking (↑50k ↓1.2k)",
+            "• Running (12s) (↑50k ↓1.2k)",
             thinking.label,
         ),
         .none, .tool_slot => return error.TestUnexpectedResult,
@@ -833,10 +814,11 @@ test "current frame-owned activity leaves the focused tool in the transcript" {
 
     var streaming_buf: [256]u8 = undefined;
     var streaming_ctx = ctx;
+    streaming_ctx.stream.phase = .generating;
     streaming_ctx.writing_response = true;
     switch (frameOwnedActivityProjection(&streaming_buf, &shell, streaming_ctx, null)) {
         .turn_thinking => |thinking| try std.testing.expectEqualStrings(
-            "  (↑50k ↓1.2k)",
+            "• Generating (12s) (↑50k ↓1.2k)",
             thinking.label,
         ),
         .none, .tool_slot => return error.TestUnexpectedResult,
@@ -912,6 +894,8 @@ test "frame-owned activity shows live streaming token progress" {
     const ctx: RenderContext = .{
         .stream = .{
             .active = true,
+            .phase = .generating,
+            .turn_started_ms = 1_000,
             .token_progress = .{
                 .input_tokens = 50_000,
                 .output_tokens = 1_250,
@@ -929,42 +913,42 @@ test "frame-owned activity shows live streaming token progress" {
         .selected_subagent_label = null,
         .selected_subagent_status = null,
         .activity = .none,
+        .now_ms = 13_000,
         .input = &input,
     };
 
     var active_buf: [256]u8 = undefined;
     switch (frameOwnedActivityProjection(&active_buf, &shell, ctx, null)) {
         .turn_thinking => |thinking| {
-            try std.testing.expectEqualStrings("  (↑50k ↓1.2k)", thinking.label);
+            try std.testing.expectEqualStrings("• Generating (12s) (↑50k ↓1.2k)", thinking.label);
             try std.testing.expectEqual(ActivityProjection.Tone.thinking, thinking.tone);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
 
-    // Pacer caught up mid-response and is waiting on the next chunk: the quiet
-    // row holds for the whole response instead of flipping inside every gap.
+    // Pacer caught up mid-response and is waiting on the next chunk: the
+    // Generating phase holds instead of flipping inside every gap.
     var drained_ctx = ctx;
     drained_ctx.writing_response = false;
-    drained_ctx.stream.assistant_text_started = true;
     var drained_buf: [256]u8 = undefined;
     switch (frameOwnedActivityProjection(&drained_buf, &shell, drained_ctx, null)) {
         .turn_thinking => |thinking| {
-            try std.testing.expectEqualStrings("  (↑50k ↓1.2k)", thinking.label);
+            try std.testing.expectEqualStrings("• Generating (12s) (↑50k ↓1.2k)", thinking.label);
             try std.testing.expectEqual(ActivityProjection.Tone.thinking, thinking.tone);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,
     }
 
-    // The model moved on to a tool payload that prints nothing: the marker
-    // comes back with the turn clock so the row does not read as finished.
+    // The model moved on to a tool payload that prints nothing: only the phase
+    // word changes while the marker, turn clock, and token totals remain.
     var composing_ctx = drained_ctx;
-    composing_ctx.stream.composing_tool_payload = true;
+    composing_ctx.stream.phase = .running;
     composing_ctx.stream.turn_started_ms = 1_000;
     composing_ctx.now_ms = 13_000;
     var stalled_buf: [256]u8 = undefined;
     switch (frameOwnedActivityProjection(&stalled_buf, &shell, composing_ctx, null)) {
         .turn_thinking => |thinking| {
-            try std.testing.expectEqualStrings("• (12s) (↑50k ↓1.2k)", thinking.label);
+            try std.testing.expectEqualStrings("• Running (12s) (↑50k ↓1.2k)", thinking.label);
             try std.testing.expectEqual(ActivityProjection.Tone.thinking, thinking.tone);
         },
         .none, .tool_slot => return error.TestUnexpectedResult,

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -736,7 +736,7 @@ fn assembleSurfaceFooterFrame(
         .activity_label = activity_label,
         .tool_activity_label = tool_activity_label,
         .shimmer_pos = assembly.planner_input.ctx.shimmer_pos,
-        .thinking_blink = activity_status.thinkingBlinkVisible(
+        .thinking_blink = activity_status.activityBlinkVisible(
             assembly.planner_input.ctx.stream,
             assembly.planner_input.ctx.now_ms,
         ),

--- a/src/ui/render_request.zig
+++ b/src/ui/render_request.zig
@@ -68,7 +68,7 @@ const animation_max_phase: i16 = 31;
 pub const animation_interval_ms: i64 = 50;
 pub const max_consecutive_input_pending_aborts: u8 = 4;
 /// Marker blink half-period: 10 frames on, 10 frames off at the 50ms cadence,
-/// matching the 1s period of the wall-clock-synced thinking blink.
+/// matching the 1s period of the wall-clock-synced activity blink.
 pub const blink_half_period_frames: i16 = 10;
 
 comptime {
@@ -76,10 +76,10 @@ comptime {
     // the marker visibly stutters at the wrap.
     const cycle = animation_max_phase + animation_padding + 1;
     std.debug.assert(@mod(cycle, 2 * blink_half_period_frames) == 0);
-    // Frame-phase blink (tool markers) and wall-clock blink (thinking
-    // counter) must share one tempo or the two markers drift visibly apart.
+    // Frame-phase blink (tool markers) and the wall-clock activity blink must
+    // share one tempo or the two markers drift visibly apart.
     std.debug.assert(
-        blink_half_period_frames * animation_interval_ms == activity_status.thinking_blink_half_period_ms,
+        blink_half_period_frames * animation_interval_ms == activity_status.activity_blink_half_period_ms,
     );
 }
 

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2370,7 +2370,7 @@ test "thinking shimmer reserves assistant-gap rows and clears back to stable foo
     try std.testing.expectEqual(footer_idle, footer_after);
 }
 
-test "completed presentation tail keeps thinking slot until turn summary" {
+test "completed presentation tail keeps activity slot until turn summary" {
     var h = try Harness.init(std.testing.allocator, 80, 22, 4);
     defer h.deinit();
 
@@ -2405,11 +2405,9 @@ test "completed presentation tail keeps thinking slot until turn summary" {
     try h.flush();
 
     const assistant_row = try findRowContaining(&h, "assistant starts here");
-    const thinking_after_provider_finish = try findRowContaining(&h, "Thinking");
-    try std.testing.expect(thinking_after_provider_finish > thinking_row);
-    try expectExactlyOneBlankRowBetween(&h, assistant_row, thinking_after_provider_finish);
-    const footer_after_assistant = try findFirstDividerRowAfter(&h, thinking_after_provider_finish);
-    try expectExactlyOneBlankRowBetween(&h, thinking_after_provider_finish, footer_after_assistant);
+    try expectGridNotContains(&h, "Thinking");
+    const footer_after_assistant = try findFirstDividerRowAfter(&h, assistant_row);
+    try expectOnlyBlankRowsBetween(&h, assistant_row, footer_after_assistant);
 
     _ = try h.shell.appendTurnSummaryEntry(h.alloc, .{
         .thinking_duration_ms = 1_000,

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -333,7 +333,7 @@ type ToolPayloadHoldState = HoldState & {
 
 function streamingOutputTokens(scrollback: string): number | null {
   const matches = [...scrollback.matchAll(
-    /^  \(↑\d+(?:\.\d)?k? ↓(\d+(?:\.\d)?k?)\)$/gm,
+    /^• Generating \(\d+(?:h\d+m\d+s|m\d+s|s)\) \(↑\d+(?:\.\d)?k? ↓(\d+(?:\.\d)?k?)\)$/gm,
   )];
   const value = matches.at(-1)?.[1];
   if (!value) return null;
@@ -344,7 +344,7 @@ function streamingOutputTokens(scrollback: string): number | null {
 
 function quietToolPayloadOutputTokens(scrollback: string): number | null {
   const matches = [...scrollback.matchAll(
-    /^•(?: \(\d+s\))? \(↑\d+(?:\.\d)?k? ↓(\d+(?:\.\d)?k?)\)$/gm,
+    /^• Running \(\d+(?:h\d+m\d+s|m\d+s|s)\) \(↑\d+(?:\.\d)?k? ↓(\d+(?:\.\d)?k?)\)$/gm,
   )];
   const value = matches.at(-1)?.[1];
   if (!value) return null;
@@ -1577,6 +1577,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
     "streamed write payload keeps the activity row live",
     async () => {
       const hold: ToolPayloadHoldState = { started: false, cancelled: false };
+      const nextStep: HoldState = { started: false, cancelled: false };
       const payloadPath = "payload-progress.md";
       // Preserve two substantial streamed input chunks for the live
       // activity-row assertions.
@@ -1593,7 +1594,17 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
               payloadPath,
               payloadContent,
             ),
-          fakeGatewayFinalText(finalSentinel),
+          () => heldGatewayResponse(nextStep, [], [
+            { type: "text-delta", id: "answer_2", delta: finalSentinel },
+            {
+              type: "finish",
+              finishReason: { unified: "stop", raw: "stop" },
+              usage: {
+                inputTokens: { total: 8 },
+                outputTokens: { total: 5 },
+              },
+            },
+          ]),
         ],
       );
 
@@ -1622,6 +1633,20 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       );
 
       hold.finish?.();
+      await waitForCondition(
+        () => queuedGateway.requests.length === 2 && nextStep.started,
+        "next model step after tool completion",
+      );
+      const nextStepPane = await waitForScrollback(
+        session!,
+        (value) =>
+          /• Thinking \(\d+(?:h\d+m\d+s|m\d+s|s)\) \(↑\d+(?:\.\d)?k? ↓\d+(?:\.\d)?k?\)/.test(
+            value,
+          ) && !value.includes(finalSentinel),
+        "thinking activity during the next admitted model step",
+      );
+      expect(nextStepPane).not.toContain(finalSentinel);
+      nextStep.release?.();
       await session!.waitForText(finalSentinel, TIMEOUT);
       expect(queuedGateway.classifierRequests).toHaveLength(0);
       const writtenPath = join(root!, "workspace", payloadPath);
@@ -6240,7 +6265,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(running).toContain(
         "● 2 tool calls · 1 read · 1 command\n├ Read seven.txt\n└ Running sleep 1; printf SECOND_GROUP_LIVE_COMMAND",
       );
-      expect(running).toMatch(/\n *(?:• )?Thinking \(\d+s\)/);
+      expect(running).toMatch(/\n *(?:• )?Running \(\d+s\)/);
       await session.waitForText(finalText, TIMEOUT);
       const compact = await session.capturePane();
       expect(compact).toContain(
@@ -6697,7 +6722,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       const reviewing = await session.capturePane();
       expect(reviewing).toContain("I will inspect the process list.");
-      expect(reviewing).toMatch(/Thinking \(\d+s\)/);
+      expect(reviewing).toMatch(/Running \(\d+s\)/);
       expect(reviewing).not.toContain(finalText);
 
       releaseClassifier(fakeGatewayPermissionDecision("clear"));
@@ -6712,7 +6737,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         execFileSync(FX_BIN, ["replay", tapePath, "--frames"], {
           encoding: "utf8",
         }),
-      ).toMatch(/Thinking \(\d+s\)/);
+      ).toMatch(/Running \(\d+s\)/);
     },
     TIMEOUT,
   );
@@ -6773,7 +6798,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const scrollback = await waitForScrollback(
         session,
         (candidate) =>
-          candidate.includes("Thinking") &&
+          candidate.includes("Running") &&
           !candidate.includes("● Preparing command") &&
           !candidate.includes("Using terminal") &&
           !hasBareRunningRow(candidate),
@@ -6788,7 +6813,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(scrollback).not.toContain("● Preparing command");
       expect(scrollback).not.toContain("Using terminal");
       expect(scrollback).not.toContain("Used terminal");
-      expect(scrollback).toContain("Thinking");
+      expect(scrollback).toContain("Running");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
       expect(existsSync(tapePath)).toBe(true);
       expect(existsSync(tracePath)).toBe(true);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -3068,7 +3068,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         () => queuedGateway.requests.length === 1 && hold.started,
         "held active Gateway request",
       );
-      await session.waitForText("Thinking", TIMEOUT);
+      await session.waitForText("Generating", TIMEOUT);
 
       await session.sendText(`/image ${image}`);
       await session.waitForText("attached image: queued-snapshot.png", TIMEOUT);
@@ -3232,7 +3232,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
             visible.includes(toolHeader) &&
             visible.includes(toolMarker) &&
             visible.includes(permissionMarker) &&
-            visible.includes("Thinking");
+            visible.includes("Generating");
         },
         "local permissions output during held post-tool continuation",
       );
@@ -3244,7 +3244,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         (pane) =>
           pane.includes(activeBefore.trim()) &&
           pane.includes(activeAfter.trim()) &&
-          !pane.includes("Thinking"),
+          !pane.includes("Generating"),
         TIMEOUT,
       );
       expect(heldGateway.requests).toHaveLength(2);
@@ -3256,7 +3256,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       );
       await session.waitForText(followupResponse, TIMEOUT);
       await session.waitForPane(
-        (pane) => pane.includes(followupResponse) && !pane.includes("Thinking"),
+        (pane) => pane.includes(followupResponse) && !pane.includes("Generating"),
         TIMEOUT,
       );
 
@@ -3476,7 +3476,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         "hidden queue review before stream cancellation",
       );
       await session.waitForPane(
-        (pane) => pane.includes("Thinking"),
+        (pane) => pane.includes("Generating"),
         TIMEOUT,
       );
       expect(hold.cancelled).toBe(false);

--- a/tests/e2e/tui-resize.test.ts
+++ b/tests/e2e/tui-resize.test.ts
@@ -2283,7 +2283,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
       });
       await session.waitForComposer(10_000);
       await session.sendText("stream across a resize");
-      await session.waitForText("Thinking", 30_000);
+      await session.waitForText("Generating", 30_000);
       const activeStage = await session.captureFullScrollback();
       expect(activeStage).not.toContain(markers[0]);
       expect(activeStage).not.toContain(markers[1]);
@@ -3319,7 +3319,7 @@ describe.skipIf(SKIP)("tui: resize", () => {
       session = launched.active;
       await session.sendText("Reply with exactly resize_activity_done.");
       await waitForGatewayRequestCount(gateway, 1);
-      await session.waitForText("Thinking", TIMEOUT);
+      await session.waitForText("Generating", TIMEOUT);
       await session.resizeWindow(90, 30, 500);
 
       const grid = await waitForSettledFooter(session);

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -724,7 +724,7 @@ function expectNoRawToolReplay(scrollback: string): void {
 
 function normalizeVolatileStatusRows(grid: string[]): string[] {
   return grid.map((line) =>
-    /^• Thinking(?: \(\d+s\))?$/.test(line) ||
+    /^• (?:Thinking|Generating|Running)(?: \(\d+s\))?$/.test(line) ||
       /^• Streaming \([^)]*\)$/.test(line) ||
       isVolatileTokenStatusRow(line)
       ? "<status>"
@@ -6129,7 +6129,7 @@ test.skipIf(!tmuxAvailable())(
       await active.waitForComposer(TIMEOUT);
       await active.sendText("Keep this response active.");
       await waitForCondition(() => hold.started, "held gateway response");
-      await active.waitForText("Thinking", TIMEOUT);
+      await active.waitForText("Generating", TIMEOUT);
 
       await active.sendText("/resume");
       await active.waitForText("resume is unavailable until the response finishes", TIMEOUT);

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -3053,13 +3053,13 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       await session.sendText("Keep this response active.");
       await waitForHeldSkillStream(stream);
-      await session.waitForText("Thinking", 10_000);
+      await session.waitForText("Generating", 10_000);
       await session.sendLiteralText("$");
       await waitForSkillsMenu(session, 4);
 
       await session.sendKeys("C-[");
       await session.waitForPane(
-        (pane) => pane.includes("Thinking") && !pane.includes("↑↓ Navigate"),
+        (pane) => pane.includes("Generating") && !pane.includes("↑↓ Navigate"),
         5_000,
       );
       expect(stream.cancelled).toBe(false);
@@ -3102,14 +3102,14 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       await session.sendText("Keep this slash response active.");
       await waitForHeldSkillStream(stream);
-      await session.waitForText("Thinking", 10_000);
+      await session.waitForText("Generating", 10_000);
       await session.sendLiteralText("/he");
       await session.waitForText("Esc Close", 10_000);
 
       await session.sendKeys("Escape");
       await session.waitForPane(
         (pane) =>
-          pane.includes("Thinking") &&
+          pane.includes("Generating") &&
           pane.includes("/he") &&
           !pane.includes("Esc Close"),
         5_000,


### PR DESCRIPTION
## Summary

- Keep the activity marker, elapsed time, and token counts visible until the turn ends.
- Show Thinking during reasoning, Generating during response content, and Running during tool work.
- Preserve the activity row across tool payload streaming and the next model step.