### PR TITLE
Recover omitted tool result suffixes

### DIFF
--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -6342,6 +6342,65 @@ test "saved noninteractive terminal exec captures replay by capability" {
     );
 }
 
+test "registered read_tool_result restores an omitted stored-result suffix" {
+    const result_store = @import("../session/result_store.zig");
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(
+        io_mod.getIo(),
+        "session",
+        std.Io.File.Permissions.fromMode(0o700),
+    );
+    var session_dir = try tmp.dir.openDir(io_mod.getIo(), "session", .{
+        .iterate = true,
+        .follow_symlinks = false,
+    });
+    defer session_dir.close(io_mod.getIo());
+    const session_path = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "session");
+    defer alloc.free(session_path);
+    var capability = try session_child_store.SessionChildCapability.initForTesting(
+        alloc,
+        session_dir,
+        session_path,
+        .writable,
+        .{},
+    );
+    defer capability.deinit();
+
+    const handle = try result_store.storeLargeResultManaged(
+        alloc,
+        &capability,
+        "integration-call",
+        "web_fetch",
+        "integration suffix needle",
+    );
+    defer alloc.free(handle);
+    try std.testing.expect(std.mem.endsWith(u8, handle, ".txt"));
+    const suffixless_handle = handle[0 .. handle.len - ".txt".len];
+
+    var rt = TestRuntime{ .session_child_capability = &capability };
+    defer rt.deinit(alloc);
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const arguments_json = try std.fmt.allocPrint(
+        arena,
+        "{{\"handle\":\"{s}\",\"query\":\"suffix needle\"}}",
+        .{suffixless_handle},
+    );
+
+    const result = try executeToolCall(rt.context(), arena, .{
+        .id = "suffixless-result-read",
+        .name = "read_tool_result",
+        .arguments_json = arguments_json,
+    });
+
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.success, result.status);
+    try expectContains(result.model_output, "integration suffix needle");
+    try expectContains(result.model_output, handle);
+}
+
 test "no-save terminal exec publishes one readable ephemeral replay" {
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
 

--- a/src/tools/session/read_tool_result.zig
+++ b/src/tools/session/read_tool_result.zig
@@ -7,6 +7,11 @@ const tool_dispatch = @import("../../core/tooling/tool_dispatch.zig");
 
 const Allocator = std.mem.Allocator;
 
+const HandleNormalization = struct {
+    trimmed: []const u8,
+    suffix: []const u8,
+};
+
 pub const Input = struct {
     handle: []u8,
     start_byte: usize = 1,
@@ -74,12 +79,22 @@ fn inputDeinit(ptr: *anyopaque, alloc: Allocator) void {
     alloc.destroy(input);
 }
 
+fn classifyHandleNormalization(handle: []const u8) HandleNormalization {
+    const trimmed = std.mem.trim(u8, handle, " \t\r\n");
+    const suffix = if (std.mem.startsWith(u8, trimmed, "result-") and
+        std.mem.findScalar(u8, trimmed, '.') == null)
+        ".txt"
+    else
+        "";
+    return .{ .trimmed = trimmed, .suffix = suffix };
+}
+
 pub fn validate(ctx: tool_dispatch.DispatchContext, erased: tool_dispatch.ToolInput) tool_dispatch.DispatchError!?[]u8 {
     const input = erased.as(Input);
-    const trimmed = std.mem.trim(u8, input.handle, " \t\r\n");
-    if (trimmed.len == 0) return try ctx.allocator.dupe(u8, "read_tool_result field \"handle\" must not be empty");
-    if (!std.mem.eql(u8, input.handle, trimmed)) {
-        const owned = try ctx.allocator.dupe(u8, trimmed);
+    const normalization = classifyHandleNormalization(input.handle);
+    if (normalization.trimmed.len == 0) return try ctx.allocator.dupe(u8, "read_tool_result field \"handle\" must not be empty");
+    if (normalization.suffix.len > 0 or !std.mem.eql(u8, input.handle, normalization.trimmed)) {
+        const owned = try std.mem.concat(ctx.allocator, u8, &.{ normalization.trimmed, normalization.suffix });
         ctx.allocator.free(input.handle);
         input.handle = owned;
     }
@@ -186,6 +201,45 @@ test "read_tool_result decodes range and query inputs" {
     try std.testing.expectEqual(@as(usize, 2), typed.start_byte);
     try std.testing.expectEqual(@as(usize, 9), typed.byte_count);
     try std.testing.expectEqualStrings("needle", typed.query.?);
+}
+
+test "read_tool_result admission restores only omitted stored-result suffixes" {
+    const alloc = std.testing.allocator;
+    const cases = [_]struct {
+        arguments_json: []const u8,
+        expected_handle: []const u8,
+    }{
+        .{
+            .arguments_json = "{\"handle\":\"result-web_fetch-1705079ba6e278c4-553514ccf082aeb9\"}",
+            .expected_handle = "result-web_fetch-1705079ba6e278c4-553514ccf082aeb9.txt",
+        },
+        .{
+            .arguments_json = "{\"handle\":\"result-web_fetch-1705079ba6e278c4-553514ccf082aeb9.txt\"}",
+            .expected_handle = "result-web_fetch-1705079ba6e278c4-553514ccf082aeb9.txt",
+        },
+        .{
+            .arguments_json = "{\"handle\":\"fx-command-replay-canonical.bin\"}",
+            .expected_handle = "fx-command-replay-canonical.bin",
+        },
+        .{
+            .arguments_json = "{\"handle\":\"unknown-dogfood-handle\"}",
+            .expected_handle = "unknown-dogfood-handle",
+        },
+    };
+
+    for (cases) |case| {
+        const decoded = try decode(.{ .allocator = alloc }, case.arguments_json);
+        const input = switch (decoded) {
+            .input => |value| value,
+            .failure => return error.TestUnexpectedDecodeFailure,
+        };
+        defer input.deinit(alloc);
+        if (try validate(.{ .allocator = alloc }, input)) |failure| {
+            defer alloc.free(failure);
+            return error.TestUnexpectedDecodeFailure;
+        }
+        try std.testing.expectEqualStrings(case.expected_handle, input.as(Input).handle);
+    }
 }
 
 test "unknown read_tool_result handle returns failure for legacy and managed stores" {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2926,6 +2926,87 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test("suffixless stored result handle remains readable", async () => {
+    const root = createFixtureRoot("suffixless-tool-result-handle");
+    const tracePath = join(root.root, "trace.log");
+    const readFileCallId = "suffixless_handle_read_file_1";
+    const readResultCallId = "suffixless_handle_read_result_1";
+    const needle = "E2E_SUFFIX_NEEDLE";
+    const lines = Array.from(
+      { length: 500 },
+      (_, index) => `fixture line ${index.toString().padStart(3, "0")}: ${"x".repeat(72)}`,
+    );
+    lines[300] = needle;
+    writeFileSync(join(root.workspace, "large-result.txt"), `${lines.join("\n")}\n`);
+
+    let step = 0;
+    let canonicalHandle = "";
+    let suffixlessHandle = "";
+    const gateway = startGateway((body) => {
+      switch (step++) {
+        case 0:
+          return fakeGatewayToolCall(readFileCallId, "read_file", {
+            path: "large-result.txt",
+          });
+        case 1: {
+          const output = toolResultOutput(body, readFileCallId);
+          const match = output.match(
+            /<tool_result_handle>([^<]+)<\/tool_result_handle>/,
+          );
+          canonicalHandle = match?.[1] ?? "";
+          expect(canonicalHandle.endsWith(".txt")).toBe(true);
+          suffixlessHandle = canonicalHandle.slice(0, -4);
+          return fakeGatewayToolCall(readResultCallId, "read_tool_result", {
+            handle: suffixlessHandle,
+            query: needle,
+          });
+        }
+        case 2: {
+          const output = toolResultOutput(body, readResultCallId);
+          expect(output).toContain(needle);
+          expect(output).toContain(
+            `<tool_result_query handle="${canonicalHandle}">`,
+          );
+          return fakeGatewayFinalText("Suffixless result handle inspected.");
+        }
+        default:
+          return new Response("unexpected request", { status: 500 });
+      }
+    });
+
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--yolo", "Inspect the retained large result."],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          timeoutMs: 15_000,
+        },
+      );
+      const json = parseAskJson(result.stdout);
+      const sessionRoot = join(root.home, ".fx", "sessions", json.session_id);
+
+      expect(result.code).toBe(0);
+      expect(json.error).toBeUndefined();
+      expect(json.output).toContain("Suffixless result handle inspected.");
+      expect(gateway.requestCount()).toBe(3);
+      expect(json.tool_calls).toContainEqual({ name: "read_file", status: "success" });
+      expect(json.tool_calls).toContainEqual({
+        name: "read_tool_result",
+        status: "success",
+      });
+      expect(existsSync(join(sessionRoot, "tool-results", canonicalHandle))).toBe(true);
+      const sessionEvents = readFileSync(join(sessionRoot, "events.jsonl"), "utf8");
+      expect(sessionEvents).toContain(suffixlessHandle);
+      expect(sessionEvents).toContain(canonicalHandle);
+      expect(sessionEvents).toContain(needle);
+      expect(result.stderr).not.toContain("ResultHandleNotFound");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("no-save terminal timeout returns a readable process-scoped replay handle", async () => {
     const root = createFixtureRoot("terminal-timeout-replay");
     const tracePath = join(root.root, "trace.log");


### PR DESCRIPTION
## Summary

- Read stored tool results when a generated `result-*` handle is returned without its `.txt` suffix.
- Keep canonical result handles, command replay handles, and unknown handles unchanged.