### PR TITLE
Add trace lineage to subagent runs

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2206,13 +2206,24 @@ pub fn processQueuedPrompt(
     if (effective_job.turn_id == 0) {
         effective_job.turn_id = debug_trace.nextTurnId();
     }
+    var effective_config = config;
+    if (effective_config.origin == .subagent and effective_config.subagent_id == 0) {
+        effective_config.subagent_id = debug_trace.nextSubagentId();
+    }
+    var effective_lifecycle = lifecycle;
+    if (effective_config.origin == .subagent and
+        effective_lifecycle.scope.kind == .subagent and
+        effective_lifecycle.scope.subagent_id == null)
+    {
+        effective_lifecycle.scope.subagent_id = effective_config.subagent_id;
+    }
     var finalization = TurnFinalizationGuard.init(
         deps,
         effective_job.turn_id,
-        lifecycle,
+        effective_lifecycle,
     );
 
-    processQueuedPromptInner(deps, semantic_presentation, lifecycle, config, effective_job, &finalization) catch |err| {
+    processQueuedPromptInner(deps, semantic_presentation, effective_lifecycle, effective_config, effective_job, &finalization) catch |err| {
         if (finalization.state == .open) {
             finalization.finish(.failed, null, null) catch |finalization_err| return finalization_err;
         }

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -6080,3 +6080,41 @@ test "processQueuedPrompt trace records history shape returned tool calls and wa
     try std.testing.expect(std.mem.find(u8, trace, "secret.txt") == null);
     try std.testing.expect(std.mem.find(u8, trace, "abc123") == null);
 }
+
+test "processQueuedPrompt assigns trace lineage to subagent runs" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const trace_path = try std.fs.path.join(alloc, &.{ root, "subagent-trace.log" });
+    defer alloc.free(trace_path);
+
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "agent");
+
+    const completions = [_]FakeCompletion{.{ .content = "Done" }};
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.origin = .subagent;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+    debug_trace.shutdown();
+
+    const trace = try readTraceFile(alloc, trace_path, 65536);
+    defer alloc.free(trace);
+    const prompt_start = std.mem.find(u8, trace, "event=prompt_start") orelse
+        return error.TestExpectedEqual;
+    const prompt_line_end = std.mem.findScalarPos(u8, trace, prompt_start, '\n') orelse
+        trace.len;
+    try std.testing.expect(std.mem.find(
+        u8,
+        trace[prompt_start..prompt_line_end],
+        "subagent_id=",
+    ) != null);
+}

--- a/src/core/shared/debug_trace.zig
+++ b/src/core/shared/debug_trace.zig
@@ -30,6 +30,7 @@ var state_mutex: std.Io.Mutex = .init;
 var state: State = .{};
 var next_turn_id = std.atomic.Value(u64).init(1);
 var next_step_id = std.atomic.Value(u64).init(1);
+var next_subagent_id = std.atomic.Value(u64).init(1);
 
 pub fn configureFromEnv(alloc: Allocator, workspace_root: []const u8) void {
     const options = loadOptionsFromEnv(alloc, workspace_root) catch return;
@@ -65,6 +66,11 @@ pub fn nextTurnId() u64 {
 pub fn nextStepId() u64 {
     if (comptime @import("builtin").os.tag == .wasi) return 1;
     return next_step_id.fetchAdd(1, .seq_cst);
+}
+
+pub fn nextSubagentId() u64 {
+    if (comptime @import("builtin").os.tag == .wasi) return 1;
+    return next_subagent_id.fetchAdd(1, .seq_cst);
 }
 
 pub fn logf(scope: []const u8, comptime fmt: []const u8, args: anytype) void {
@@ -288,6 +294,7 @@ pub fn resetForTest() void {
     shutdown();
     next_turn_id.store(1, .seq_cst);
     next_step_id.store(1, .seq_cst);
+    next_subagent_id.store(1, .seq_cst);
 }
 
 pub fn configureForTest(alloc: Allocator, path: []const u8) !void {

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -21,6 +21,7 @@ const context_contract = @import("../workspace/context_contract.zig");
 const hooks = @import("../hooks/hooks.zig");
 const execution_memory = @import("../agent/execution_memory.zig");
 const gateway_error_format = @import("../shared/gateway_error_format.zig");
+const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
 const session_codec = @import("../session/session_codec.zig");
 const types = @import("../shared/types.zig");
@@ -54,6 +55,7 @@ const Context = struct {
     turn: *execution.TurnContext,
     admission: domain.AdmissionSnapshot,
     cancel: *std.atomic.Value(bool),
+    subagent_id: u64,
     input_tokens: u64 = 0,
     output_tokens: u64 = 0,
     turn_outcome: ?types.TurnPresentationOutcome = null,
@@ -95,6 +97,7 @@ const Context = struct {
             .kind = .subagent,
             .workspace_root = result.workspace_root,
             .session_id = self.turn.child_id,
+            .subagent_id = self.subagent_id,
         };
         return result;
     }
@@ -168,17 +171,22 @@ pub fn run(
         routed_config.tool_context.web_search_backend = null;
         routed_config.tool_context.web_search_runtime_ready = false;
     }
+    const trace_context = debug_trace.TraceContext{
+        .turn_id = debug_trace.nextTurnId(),
+        .subagent_id = debug_trace.nextSubagentId(),
+    };
     var context = Context{
         .config = routed_config,
         .turn = turn,
         .admission = admission,
         .cancel = cancel,
+        .subagent_id = trace_context.subagent_id,
     };
     const history = turn.sessionRuntime().snapshotHistory(arena) catch return error.OutOfMemory;
     const recovery_checkpoint = turn.snapshotRecoveryCheckpoint(arena) catch
         return error.OutOfMemory;
     const prompt = worker_runtime.QueuedPrompt{
-        .turn_id = 1,
+        .turn_id = trace_context.turn_id,
         .prompt = arena.dupe(u8, message.content) catch return error.OutOfMemory,
         .images = &.{},
         .model = arena.dupe(u8, admission.model) catch return error.OutOfMemory,
@@ -209,6 +217,17 @@ pub fn run(
         .recovery_checkpoint = recovery_checkpoint,
         .recovery_source_already_presented = recovery_checkpoint != null,
     };
+    debug_trace.eventf(
+        "subagent",
+        "trace_identity",
+        trace_context,
+        "child_id={s} parent_id={s} work_id={s}",
+        .{
+            turn.child_id orelse "unknown",
+            admission.parent_id,
+            turn.active_work_id orelse "unknown",
+        },
+    );
     const deps = runtimeDeps(&context);
     execution.runNormalAgentTurn(
         &deps,
@@ -219,6 +238,7 @@ pub fn run(
                 .kind = .subagent,
                 .workspace_root = config.tool_context.workspace_root,
                 .session_id = turn.child_id,
+                .subagent_id = trace_context.subagent_id,
             },
             .outcome_allocator = turn.alloc,
         },
@@ -246,6 +266,7 @@ pub fn run(
             .root_user_messages = message.root_user_messages,
             .root_user_evidence_complete = message.root_user_evidence_complete,
             .session_child_capability = turn.childCapability() catch null,
+            .subagent_id = trace_context.subagent_id,
             .context_limits = config.tool_context.context_limits,
         },
         prompt,


### PR DESCRIPTION
## Summary

- allocate process-unique turn and subagent trace IDs for child runs
- propagate child identity through runtime configuration and lifecycle scopes
- emit a `trace_identity` event mapping numeric trace identity to durable child, parent, and work IDs
- defensively assign lineage for other subagent-origin runtime callers

## Why

Subagent runs used a hard-coded turn ID and the default zero subagent ID. Concurrent root and child events could therefore share `turn_id=1`, while child events omitted `subagent_id` entirely, preventing reliable timeline reconstruction.

## Tests

- `zig fmt --check src/`
- `zig build test`
- `zig build`
- `./zig-out/bin/fx --version`
