### PR TITLE
Add direct Fireworks and Modal providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export MODAL_PROXY_TOKEN_SECRET=...
 FX_PROVIDER=modal fx
 ```
 
-`FX_PROVIDER` pins the provider for that process while preserving a separate saved model for each provider. `/model` shows the active provider's catalog: Fireworks is fetched from the authenticated account, while Modal exposes the four configured Robomart endpoints. After choosing a reasoning model, `/model` opens a second stage with the effort values accepted by that provider and model. The same choices appear under **Reasoning effort** in `/settings`.
+`FX_PROVIDER` pins the provider for that process while preserving a separate saved model for each provider. `/model` shows the active provider's catalog: Fireworks is fetched from the authenticated account, while Modal exposes the four configured Robomart endpoints. After choosing a reasoning model, `/model` opens a second stage with that provider and model's supported effort values. The same choices appear under **Reasoning effort** in `/settings`.
 
 To use an AI Gateway API key instead:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ The OpenAI Codex route uses ChatGPT subscription access directly and never sends
 
 The Grok route uses subscription access directly at xAI and never sends its OAuth token to Vercel AI Gateway or OpenAI. Its session is stored privately at `~/.fx/grok-auth.json`, refreshed when needed, and used only with the authenticated xAI catalog and Responses API.
 
+This fork also supports direct Fireworks and Modal routes through environment credentials:
+
+```bash
+export FIREWORKS_API_KEY=...
+FX_PROVIDER=fireworks fx
+
+export MODAL_PROXY_TOKEN_ID=...
+export MODAL_PROXY_TOKEN_SECRET=...
+FX_PROVIDER=modal fx
+```
+
+`FX_PROVIDER` pins the provider for that process while preserving a separate saved model for each provider. `/model` shows the active provider's catalog: Fireworks is fetched from the authenticated account, while Modal exposes the four configured Robomart endpoints.
+
 To use an AI Gateway API key instead:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export MODAL_PROXY_TOKEN_SECRET=...
 FX_PROVIDER=modal fx
 ```
 
-`FX_PROVIDER` pins the provider for that process while preserving a separate saved model for each provider. `/model` shows the active provider's catalog: Fireworks is fetched from the authenticated account, while Modal exposes the four configured Robomart endpoints.
+`FX_PROVIDER` pins the provider for that process while preserving a separate saved model for each provider. `/model` shows the active provider's catalog: Fireworks is fetched from the authenticated account, while Modal exposes the four configured Robomart endpoints. After choosing a reasoning model, `/model` opens a second stage with the effort values accepted by that provider and model. The same choices appear under **Reasoning effort** in `/settings`.
 
 To use an AI Gateway API key instead:
 

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -137,7 +137,7 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .provider,
         .token = "provider",
-        .usage = "provider <gateway|codex|grok>",
+        .usage = "provider <gateway|codex|grok|fireworks|modal>",
         .summary = "Choose the model provider used by fx",
     },
     .{
@@ -294,7 +294,7 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
     .{ .entries = &.{
         .{ .kind = .login, .usage = "login [vercel|codex|grok]" },
         .{ .kind = .logout, .usage = "logout [vercel|codex|grok]" },
-        .{ .kind = .provider, .usage = "provider <gateway|codex|grok>" },
+        .{ .kind = .provider, .usage = "provider <name>" },
         .{ .kind = .setup, .usage = "setup" },
         .{ .kind = .teams, .usage = "teams" },
         .{ .kind = .credits, .usage = "credits|balance" },

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -20,6 +20,7 @@ const gateway_provider = @import("../core/gateway/gateway_provider.zig");
 const provider_set = @import("../core/gateway/provider_set.zig");
 const provider_catalog = @import("../core/auth/provider_catalog.zig");
 const credential_authority = @import("../core/auth/credential_authority.zig");
+const model_provider = @import("../core/config/model_provider.zig");
 const model_capabilities = @import("../core/config/model_capabilities.zig");
 const vercel_model_policy = @import("../gateway/vercel_model_policy.zig");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
@@ -501,7 +502,7 @@ fn streamAgentCompletion(
     alloc: Allocator,
     request: agent_stream_provider_contract.ModelRequest,
 ) anyerror!agent_stream_provider_contract.Result {
-    if (request.credential.source == .chatgpt_subscription or request.credential.source == .grok_subscription) {
+    if (!model_provider.authorizesCredential(.gateway, request.credential.source)) {
         return error.SubscriptionCredentialCannotAuthorizeGateway;
     }
     const payload = try buildAgentRequest(alloc, request.data());

--- a/src/builtins/providers.zig
+++ b/src/builtins/providers.zig
@@ -6,7 +6,31 @@ const openai_codex_permission_reviewer = @import("../gateway/openai_codex_permis
 const xai_grok = @import("../gateway/xai_grok.zig");
 const xai_grok_models = @import("../gateway/xai_grok_models.zig");
 const xai_grok_permission_reviewer = @import("../gateway/xai_grok_permission_reviewer.zig");
+const openai_compatible = @import("../gateway/openai_compatible.zig");
+const fireworks_models = @import("../gateway/fireworks_models.zig");
+const modal_models = @import("../gateway/modal_models.zig");
 const provider_catalog = @import("../core/auth/provider_catalog.zig");
+
+const fireworks_context = openai_compatible.Context{
+    .provider = .fireworks,
+    .credential_source = .fireworks_api_key,
+    .auth = .bearer,
+    .endpoint = "https://api.fireworks.ai/inference/v1/chat/completions",
+};
+
+const modal_routes = [_]openai_compatible.Route{
+    .{ .id = modal_models.definitions[0].id, .wire_model = modal_models.definitions[0].wire_model, .endpoint = modal_models.definitions[0].endpoint },
+    .{ .id = modal_models.definitions[1].id, .wire_model = modal_models.definitions[1].wire_model, .endpoint = modal_models.definitions[1].endpoint },
+    .{ .id = modal_models.definitions[2].id, .wire_model = modal_models.definitions[2].wire_model, .endpoint = modal_models.definitions[2].endpoint },
+    .{ .id = modal_models.definitions[3].id, .wire_model = modal_models.definitions[3].wire_model, .endpoint = modal_models.definitions[3].endpoint },
+};
+
+const modal_context = openai_compatible.Context{
+    .provider = .modal,
+    .credential_source = .modal_proxy_token,
+    .auth = .modal_proxy,
+    .routes = &modal_routes,
+};
 
 pub const native = provider_set.Set{
     .gateway = gateway.provider_bundle,
@@ -25,5 +49,17 @@ pub const native = provider_set.Set{
         .cli_model_catalog = xai_grok_models.cli_model_catalog_provider,
         .model_catalog = xai_grok_models.model_catalog_provider,
         .permission_reviewer = xai_grok_permission_reviewer.provider,
+    },
+    .fireworks = .{
+        .presentation = provider_catalog.find(.fireworks),
+        .agent_stream = openai_compatible.provider(&fireworks_context),
+        .cli_model_catalog = fireworks_models.cli_model_catalog_provider,
+        .model_catalog = fireworks_models.model_catalog_provider,
+    },
+    .modal = .{
+        .presentation = provider_catalog.find(.modal),
+        .agent_stream = openai_compatible.provider(&modal_context),
+        .cli_model_catalog = modal_models.cli_model_catalog_provider,
+        .model_catalog = modal_models.model_catalog_provider,
     },
 };

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -1064,6 +1064,16 @@ pub fn Runtime(comptime App: type) type {
                         .agent_stream = tool_context.agent_stream_provider,
                         .permission_reviewer = tool_context.permission_reviewer_provider,
                     },
+                    .fireworks = .{
+                        .capabilities = tool_context.provider_capabilities,
+                        .agent_stream = tool_context.agent_stream_provider,
+                        .permission_reviewer = tool_context.permission_reviewer_provider,
+                    },
+                    .modal = .{
+                        .capabilities = tool_context.provider_capabilities,
+                        .agent_stream = tool_context.agent_stream_provider,
+                        .permission_reviewer = tool_context.permission_reviewer_provider,
+                    },
                 };
             return subagent_agent_adapter.run(.{
                 .host = app_session_runtime.Runtime(App).subagentHost(app) orelse

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -59,6 +59,8 @@ pub fn Runtime(comptime App: type) type {
                 const required_source: credentials.Source = switch (provider) {
                     .codex => .chatgpt_subscription,
                     .grok => .grok_subscription,
+                    .fireworks => .fireworks_api_key,
+                    .modal => .modal_proxy_token,
                     .gateway => app.auth.credentialSource() orelse .fx_login,
                 };
                 const route_change = app.auth.selectForProvider(app.alloc, provider) catch |err| switch (err) {
@@ -71,12 +73,13 @@ pub fn Runtime(comptime App: type) type {
                     try app.writeDomainNotice(.{
                         .topic = "auth",
                         .tone = .warning,
-                        .body = if (provider == .grok)
-                            credentials.missing_grok_interactive_credential_message
-                        else if (provider == .codex)
-                            credentials.missing_chatgpt_interactive_credential_message
-                        else
-                            credentials.missing_interactive_credential_message,
+                        .body = switch (provider) {
+                            .grok => credentials.missing_grok_interactive_credential_message,
+                            .codex => credentials.missing_chatgpt_interactive_credential_message,
+                            .fireworks => credentials.missing_fireworks_interactive_credential_message,
+                            .modal => credentials.missing_modal_interactive_credential_message,
+                            .gateway => credentials.missing_interactive_credential_message,
+                        },
                     }, true);
                     app.shell.render_requests.request(.footer);
                     return false;
@@ -594,9 +597,9 @@ pub fn Runtime(comptime App: type) type {
         /// leaves the source active for this run rather than refusing a working
         /// credential the user already selected.
         fn rememberCredentialSource(app: *App, source: credentials.Source) void {
-            // ChatGPT is selected by model route, not as a global Gateway
-            // credential preference. Its saved session coexists independently.
-            if (source == .chatgpt_subscription or source == .grok_subscription) return;
+            // Direct providers are selected by model route, not as a global
+            // Gateway credential preference. Their credentials coexist independently.
+            if (!model_provider.authorizesCredential(.gateway, source)) return;
             if (comptime @hasDecl(App, "persistCredentialSourcePreference")) {
                 app.persistCredentialSourcePreference(source);
                 return;
@@ -809,6 +812,10 @@ pub fn Runtime(comptime App: type) type {
                         "Run fx login codex, then try switching again."
                     else if (target == .grok)
                         "Run fx login grok, then try switching again."
+                    else if (target == .fireworks)
+                        credentials.missing_fireworks_interactive_credential_message
+                    else if (target == .modal)
+                        credentials.missing_modal_interactive_credential_message
                     else
                         credentials.missing_interactive_credential_message,
                 }, true);
@@ -1162,11 +1169,11 @@ pub fn Runtime(comptime App: type) type {
                 @hasField(@TypeOf(app.session), "usage"))
             {
                 if (app.auth.gatewayCredential()) |credential| {
-                    const subscription = if (comptime @hasField(@TypeOf(credential), "source"))
-                        credential.source == .chatgpt_subscription or credential.source == .grok_subscription
+                    const gateway_credential = if (comptime @hasField(@TypeOf(credential), "source"))
+                        model_provider.authorizesCredential(.gateway, credential.source)
                     else
-                        false;
-                    if (subscription) {
+                        true;
+                    if (!gateway_credential) {
                         app.session.usage.clearReconciliationCredential();
                     } else {
                         if (comptime @hasDecl(
@@ -1397,7 +1404,7 @@ test "interactive subscription sign-in rejects active and queued work before OAu
             switch (provider) {
                 .codex => try Runtime(BusySignInApp).beginChatGptSignIn(&app),
                 .grok => try Runtime(BusySignInApp).beginGrokSignIn(&app),
-                .gateway => unreachable,
+                .gateway, .fireworks, .modal => unreachable,
             }
 
             try std.testing.expectEqual(@as(usize, 0), app.auth.start_count);

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -1113,6 +1113,8 @@ fn configuredProviderSelection(
         .gateway => default_model,
         .codex => return error.CodexModelNotSelected,
         .grok => return error.GrokModelNotSelected,
+        .fireworks => "accounts/fireworks/models/kimi-k3",
+        .modal => "glm-5-3-flash",
     };
     return .{ .provider = provider, .model = model };
 }

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -31,6 +31,8 @@ const credential_source_order = [_]credentials.Source{
     .stored_key,
     .chatgpt_subscription,
     .grok_subscription,
+    .fireworks_api_key,
+    .modal_proxy_token,
 };
 
 const SourceProbeFn = *const fn (?*anyopaque, Allocator, credentials.Source) anyerror!bool;
@@ -407,7 +409,7 @@ pub const PickerView = struct {
             else
                 4,
             .connections => connectionChoiceCount(),
-            .provider => if (comptime host_target.is_wasm) 2 else 3,
+            .provider => if (comptime host_target.is_wasm) 2 else 5,
             .sign_in, .api_key => 0,
             .change_team => blk: {
                 var count: usize = 0;
@@ -441,6 +443,8 @@ pub const PickerView = struct {
                 0 => .{ .provider = .gateway },
                 1 => .{ .provider = .codex },
                 2 => if (comptime host_target.is_wasm) null else .{ .provider = .grok },
+                3 => if (comptime host_target.is_wasm) null else .{ .provider = .fireworks },
+                4 => if (comptime host_target.is_wasm) null else .{ .provider = .modal },
                 else => null,
             },
             .sign_in, .api_key => null,
@@ -583,6 +587,8 @@ pub const StatusSnapshot = struct {
     gateway_connected: bool = false,
     chatgpt_connected: bool = false,
     grok_connected: bool = false,
+    fireworks_connected: bool = false,
+    modal_connected: bool = false,
     /// The active credential is past its refresh deadline. Distinct from `refreshable`,
     /// which answers whether this source type can refresh at all.
     expired: bool = false,
@@ -614,6 +620,18 @@ pub const StatusSnapshot = struct {
             return switch (surface) {
                 .cli => credentials.missing_grok_credential_message,
                 .interactive => credentials.missing_grok_interactive_credential_message,
+            };
+        }
+        if (self.required_source == .fireworks_api_key) {
+            return switch (surface) {
+                .cli => credentials.missing_fireworks_credential_message,
+                .interactive => credentials.missing_fireworks_interactive_credential_message,
+            };
+        }
+        if (self.required_source == .modal_proxy_token) {
+            return switch (surface) {
+                .cli => credentials.missing_modal_credential_message,
+                .interactive => credentials.missing_modal_interactive_credential_message,
             };
         }
         return switch (surface) {
@@ -667,6 +685,22 @@ pub fn loadStatusSnapshotForProvider(
         error.OutOfMemory => return err,
         else => false,
     };
+    const fireworks_connected = credentials.sourceExists(
+        alloc,
+        secret_store,
+        .fireworks_api_key,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => false,
+    };
+    const modal_connected = credentials.sourceExists(
+        alloc,
+        secret_store,
+        .modal_proxy_token,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => false,
+    };
     // Resolves in `.stored` mode: a diagnostic must not refresh, because refreshing
     // rewrites the session file and performs network I/O. It reports the expired state
     // instead of repairing it.
@@ -694,19 +728,14 @@ pub fn loadStatusSnapshotForProvider(
             break :blk credentials.Resolution{ .stored_key_status = .unavailable };
         },
     };
-    const resolved_source = if (resolution.credential) |credential| credential.source else null;
-    var gateway_connected = resolved_source != null and resolved_source != .chatgpt_subscription and resolved_source != .grok_subscription;
-    const gateway_probe_required = provider == .codex or provider == .grok or
-        resolved_source == .chatgpt_subscription or resolved_source == .grok_subscription;
-    if (gateway_probe_required) {
-        for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key }) |source| {
-            if (credentials.sourceExists(alloc, secret_store, source) catch |err| switch (err) {
-                error.OutOfMemory => return err,
-                else => false,
-            }) {
-                gateway_connected = true;
-                break;
-            }
+    var gateway_connected = false;
+    for ([_]credentials.Source{ .vercel_oidc_token, .ai_gateway_api_key, .fx_login, .stored_key }) |source| {
+        if (credentials.sourceExists(alloc, secret_store, source) catch |err| switch (err) {
+            error.OutOfMemory => return err,
+            else => false,
+        }) {
+            gateway_connected = true;
+            break;
         }
     }
     if (resolution.credential) |loaded| {
@@ -722,6 +751,8 @@ pub fn loadStatusSnapshotForProvider(
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
             .grok_connected = grok_connected,
+            .fireworks_connected = fireworks_connected,
+            .modal_connected = modal_connected,
             .expired = expired,
         };
     }
@@ -730,12 +761,18 @@ pub fn loadStatusSnapshotForProvider(
             .chatgpt_subscription
         else if (provider == .grok)
             .grok_subscription
+        else if (provider == .fireworks)
+            .fireworks_api_key
+        else if (provider == .modal)
+            .modal_proxy_token
         else
             null,
         .stored_key_status = resolution.stored_key_status,
         .gateway_connected = gateway_connected,
         .chatgpt_connected = chatgpt_connected,
         .grok_connected = grok_connected,
+        .fireworks_connected = fireworks_connected,
+        .modal_connected = modal_connected,
     };
 }
 
@@ -889,10 +926,14 @@ pub const Runtime = struct {
             self.source_inventory.contains(.stored_key);
         const chatgpt_connected = self.source_inventory.contains(.chatgpt_subscription);
         const grok_connected = self.source_inventory.contains(.grok_subscription);
+        const fireworks_connected = self.source_inventory.contains(.fireworks_api_key);
+        const modal_connected = self.source_inventory.contains(.modal_proxy_token);
         const credential = self.selected_credential orelse return .{
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
             .grok_connected = grok_connected,
+            .fireworks_connected = fireworks_connected,
+            .modal_connected = modal_connected,
         };
         return .{
             .active_source = credential.source,
@@ -900,6 +941,8 @@ pub const Runtime = struct {
             .gateway_connected = gateway_connected,
             .chatgpt_connected = chatgpt_connected,
             .grok_connected = grok_connected,
+            .fireworks_connected = fireworks_connected,
+            .modal_connected = modal_connected,
             .expired = credential.needsRefreshAt(now_ms),
         };
     }
@@ -1108,7 +1151,7 @@ pub const Runtime = struct {
         self.picker_stage = .switch_credential;
         const active_source = self.credentialSource();
         self.picker_selection = if (active_source) |source|
-            if (source != .chatgpt_subscription and source != .grok_subscription and self.source_inventory.contains(source))
+            if (model_provider.authorizesCredential(.gateway, source) and self.source_inventory.contains(source))
                 .{ .source = source }
             else
                 self.pickerView().choiceAt(0)
@@ -1596,7 +1639,25 @@ pub const Runtime = struct {
                     self,
                     loadRuntimeCredentialSource,
                 ),
-            .gateway => if (self.credentialSource() != .chatgpt_subscription and self.credentialSource() != .grok_subscription)
+            .fireworks => if (self.credentialSource() == .fireworks_api_key)
+                false
+            else
+                self.selectSourceWithLoader(
+                    alloc,
+                    .fireworks_api_key,
+                    self,
+                    loadRuntimeCredentialSource,
+                ),
+            .modal => if (self.credentialSource() == .modal_proxy_token)
+                false
+            else
+                self.selectSourceWithLoader(
+                    alloc,
+                    .modal_proxy_token,
+                    self,
+                    loadRuntimeCredentialSource,
+                ),
+            .gateway => if (model_provider.authorizesCredential(.gateway, self.credentialSource()))
                 false
             else
                 @as(?bool, try self.reselectByPrecedenceWithDeps(
@@ -1641,7 +1702,7 @@ pub const Runtime = struct {
 
         try self.refreshSourceInventoryWithProbe(alloc, ctx, probe);
         for (credential_source_order) |source| {
-            if (source == .chatgpt_subscription or source == .grok_subscription) continue;
+            if (!model_provider.authorizesCredential(.gateway, source)) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) {
                 return self.credentialSource() != previous;
@@ -1703,7 +1764,7 @@ pub const Runtime = struct {
         if (!login_was_active) return false;
 
         for (credential_source_order) |source| {
-            if (source == .chatgpt_subscription or source == .grok_subscription) continue;
+            if (!model_provider.authorizesCredential(.gateway, source)) continue;
             if (!self.source_inventory.contains(source)) continue;
             if (try self.selectSourceWithLoader(alloc, source, ctx, loader) != null) return true;
             self.source_inventory.remove(source);
@@ -1799,7 +1860,7 @@ fn takeDisplayTeam(alloc: Allocator, credential: *credentials.Credential) ?[]u8 
 fn gatewaySourceCount(sources: SourceSet) usize {
     var count: usize = 0;
     for (credential_source_order) |source| {
-        if (source == .chatgpt_subscription or source == .grok_subscription or !sources.contains(source)) continue;
+        if (!model_provider.authorizesCredential(.gateway, source) or !sources.contains(source)) continue;
         count += 1;
     }
     return count;
@@ -1808,7 +1869,7 @@ fn gatewaySourceCount(sources: SourceSet) usize {
 fn gatewaySourceAtIndex(sources: SourceSet, wanted_index: usize) ?credentials.Source {
     var index: usize = 0;
     for (credential_source_order) |source| {
-        if (source == .chatgpt_subscription or source == .grok_subscription or !sources.contains(source)) continue;
+        if (!model_provider.authorizesCredential(.gateway, source) or !sources.contains(source)) continue;
         if (index == wanted_index) return source;
         index += 1;
     }
@@ -2185,6 +2246,19 @@ test "auth status snapshot preserves display team and surface-specific missing h
     const selected = runtime.statusSnapshot();
     try std.testing.expectEqualStrings("vercel-labs", selected.team.?);
     try std.testing.expect(selected.missingHelp(.cli) == null);
+}
+
+test "auth status snapshot gives provider-specific help for direct providers" {
+    const fireworks = StatusSnapshot{ .required_source = .fireworks_api_key };
+    try std.testing.expectEqualStrings(
+        credentials.missing_fireworks_credential_message,
+        fireworks.missingHelp(.cli).?,
+    );
+    const modal = StatusSnapshot{ .required_source = .modal_proxy_token };
+    try std.testing.expectEqualStrings(
+        credentials.missing_modal_interactive_credential_message,
+        modal.missingHelp(.interactive).?,
+    );
 }
 
 test "auth status snapshot distinguishes an absent store from an unreadable one" {

--- a/src/core/auth/auth_transition.zig
+++ b/src/core/auth/auth_transition.zig
@@ -73,6 +73,8 @@ pub fn signInCompletion(
             .{ .switch_provider = .grok }
         else
             .{ .activate_source = .grok_subscription },
+        .fireworks => .{ .activate_source = .fireworks_api_key },
+        .modal => .{ .activate_source = .modal_proxy_token },
     };
 }
 

--- a/src/core/auth/credential_authority.zig
+++ b/src/core/auth/credential_authority.zig
@@ -25,9 +25,11 @@ pub fn derive(
         .ai_gateway_api_key,
         .fx_login,
         .stored_key,
+        .fireworks_api_key,
         => hash.update("\x00slot\x00"),
         .chatgpt_subscription,
         .grok_subscription,
+        .modal_proxy_token,
         => {
             const account = account_id orelse return null;
             if (account.len == 0) return null;

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -44,6 +44,8 @@ pub const CatalogAuthenticatedSource = enum {
     stored_key,
     chatgpt_subscription,
     grok_subscription,
+    fireworks_api_key,
+    modal_proxy_token,
 
     fn credentialSource(self: CatalogAuthenticatedSource) Source {
         return switch (self) {
@@ -53,6 +55,8 @@ pub const CatalogAuthenticatedSource = enum {
             .stored_key => .stored_key,
             .chatgpt_subscription => .chatgpt_subscription,
             .grok_subscription => .grok_subscription,
+            .fireworks_api_key => .fireworks_api_key,
+            .modal_proxy_token => .modal_proxy_token,
         };
     }
 };
@@ -168,6 +172,8 @@ pub fn catalogAccessForCredentialAndAccount(
         .stored_key => .stored_key,
         .chatgpt_subscription => .chatgpt_subscription,
         .grok_subscription => .grok_subscription,
+        .fireworks_api_key => .fireworks_api_key,
+        .modal_proxy_token => .modal_proxy_token,
         .fx_login => blk: {
             const team = team_context orelse
                 return .{ .public_only = .fx_login_team_required };
@@ -180,8 +186,8 @@ pub fn catalogAccessForCredentialAndAccount(
         .authenticated = .{
             .source = authenticated_source,
             .credential = credential,
-            .team_context = if (authenticated_source == .chatgpt_subscription or authenticated_source == .grok_subscription) null else team_context,
-            .account_id = if (authenticated_source == .grok_subscription) account_id else null,
+            .team_context = if (authenticated_source == .chatgpt_subscription or authenticated_source == .grok_subscription or authenticated_source == .fireworks_api_key or authenticated_source == .modal_proxy_token) null else team_context,
+            .account_id = if (authenticated_source == .grok_subscription or authenticated_source == .modal_proxy_token) account_id else null,
         },
     };
 }
@@ -202,11 +208,17 @@ pub const missing_chatgpt_credential_message = "fx needs a Codex subscription lo
 pub const missing_chatgpt_interactive_credential_message = "Codex needs a subscription login. Run /login, open Connections, then choose Codex subscription.";
 pub const missing_grok_credential_message = "fx needs a Grok subscription login for this model. Run fx login grok.";
 pub const missing_grok_interactive_credential_message = "Grok needs a subscription login. Run /login, open Connections, then choose Grok subscription.";
+pub const missing_fireworks_credential_message = "fx needs FIREWORKS_API_KEY for the Fireworks provider.";
+pub const missing_fireworks_interactive_credential_message = "Fireworks needs FIREWORKS_API_KEY in the launch environment.";
+pub const missing_modal_credential_message = "fx needs MODAL_PROXY_TOKEN_ID and MODAL_PROXY_TOKEN_SECRET for the Modal provider.";
+pub const missing_modal_interactive_credential_message = "Modal needs MODAL_PROXY_TOKEN_ID and MODAL_PROXY_TOKEN_SECRET in the launch environment.";
 pub const unreadable_store_message = "fx could not read the stored API key from " ++ stored_key_backend_label ++ ". A key may be saved but unreadable. Set FX_TRACE_LOG for the failing step, or set AI_GATEWAY_API_KEY.";
 
 test "public credential guidance spells fx lowercase" {
     try std.testing.expect(std.mem.startsWith(u8, missing_credential_message, "fx needs"));
     try std.testing.expect(std.mem.startsWith(u8, missing_interactive_credential_message, "fx needs"));
+    try std.testing.expect(std.mem.startsWith(u8, missing_fireworks_credential_message, "fx needs"));
+    try std.testing.expect(std.mem.startsWith(u8, missing_modal_credential_message, "fx needs"));
     try std.testing.expect(std.mem.startsWith(u8, unreadable_store_message, "fx could"));
 }
 
@@ -297,6 +309,8 @@ pub fn resolveForProvider(
             };
             return .{ .credential = credential };
         },
+        .fireworks => return .{ .credential = try loadSource(alloc, transport, secret_store, .fireworks_api_key) },
+        .modal => return .{ .credential = try loadSource(alloc, transport, secret_store, .modal_proxy_token) },
         .gateway => {},
     }
     return resolvePreferring(
@@ -304,7 +318,7 @@ pub fn resolveForProvider(
         transport,
         secret_store,
         mode,
-        if (preferred == .chatgpt_subscription or preferred == .grok_subscription) null else preferred,
+        if (model_provider.authorizesCredential(.gateway, preferred)) preferred else null,
     );
 }
 
@@ -394,6 +408,7 @@ fn loadPreferredSource(
             .stored => loadStoredGrokCredential(alloc),
             .refresh_if_needed => loadGrokCredential(alloc, transport, .if_needed),
         },
+        .fireworks_api_key, .modal_proxy_token => loadSource(alloc, transport, secret_store, source),
         else => loadSource(alloc, transport, secret_store, source),
     };
 }
@@ -411,6 +426,8 @@ pub fn loadSource(
         .stored_key => loadStoredKeyCredential(alloc, secret_store),
         .chatgpt_subscription => loadChatGptCredential(alloc, transport, .if_needed),
         .grok_subscription => loadGrokCredential(alloc, transport, .if_needed),
+        .fireworks_api_key => loadEnvCredential(alloc, "FIREWORKS_API_KEY", source),
+        .modal_proxy_token => loadModalProxyCredential(alloc),
     };
 }
 
@@ -436,6 +453,8 @@ pub fn sourceExists(
         },
         .chatgpt_subscription => chatgpt_oauth.sourceExists(alloc),
         .grok_subscription => grok_oauth.sourceExists(alloc),
+        .fireworks_api_key => nonEmptyEnvValue("FIREWORKS_API_KEY") != null,
+        .modal_proxy_token => nonEmptyEnvValue("MODAL_PROXY_TOKEN_ID") != null and nonEmptyEnvValue("MODAL_PROXY_TOKEN_SECRET") != null,
         .stored_key => blk: {
             if (secret_store.isDisabled()) break :blk false;
             const stored = secret_store.load(alloc) catch |err| switch (err) {
@@ -461,6 +480,19 @@ fn loadEnvCredential(
     return .{
         .token = try alloc.dupe(u8, value),
         .source = source,
+    };
+}
+
+fn loadModalProxyCredential(alloc: std.mem.Allocator) !?Credential {
+    const token_id = nonEmptyEnvValue("MODAL_PROXY_TOKEN_ID") orelse return null;
+    const token_secret = nonEmptyEnvValue("MODAL_PROXY_TOKEN_SECRET") orelse return null;
+    const secret_copy = try alloc.dupe(u8, token_secret);
+    errdefer secret.zeroAndFree(alloc, secret_copy);
+    const id_copy = try alloc.dupe(u8, token_id);
+    return .{
+        .token = secret_copy,
+        .source = .modal_proxy_token,
+        .account_id = id_copy,
     };
 }
 
@@ -662,6 +694,8 @@ pub fn sourceLabel(source: Source) []const u8 {
         .stored_key => "stored API key (" ++ stored_key_backend_label ++ ")",
         .chatgpt_subscription => "Codex subscription",
         .grok_subscription => "Grok subscription",
+        .fireworks_api_key => "FIREWORKS_API_KEY",
+        .modal_proxy_token => "Modal proxy token",
     };
 }
 
@@ -925,6 +959,28 @@ test "source-specific credential loading bypasses generic precedence" {
     try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .ai_gateway_api_key));
     try std.testing.expect(try sourceExists(alloc, host.unavailable_secret_store, .vercel_oidc_token));
     try std.testing.expect(!(try sourceExists(alloc, host.unavailable_secret_store, .stored_key)));
+}
+
+test "Fireworks and Modal credentials load only from their dedicated environment variables" {
+    const alloc = std.testing.allocator;
+    const env = try CredentialTestEnv.install(alloc, &.{
+        .{ "FIREWORKS_API_KEY", "fireworks-key" },
+        .{ "MODAL_PROXY_TOKEN_ID", "modal-id" },
+        .{ "MODAL_PROXY_TOKEN_SECRET", "modal-secret" },
+    });
+    defer env.deinit();
+
+    var fireworks = (try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .fireworks_api_key)).?;
+    defer fireworks.deinit(alloc);
+    try std.testing.expectEqual(Source.fireworks_api_key, fireworks.source);
+    try std.testing.expectEqualStrings("fireworks-key", fireworks.token);
+    try std.testing.expect(fireworks.accountId() == null);
+
+    var modal = (try loadSource(alloc, oauth_transport.unavailable_provider, host.unavailable_secret_store, .modal_proxy_token)).?;
+    defer modal.deinit(alloc);
+    try std.testing.expectEqual(Source.modal_proxy_token, modal.source);
+    try std.testing.expectEqualStrings("modal-secret", modal.token);
+    try std.testing.expectEqualStrings("modal-id", modal.accountId().?);
 }
 
 test "a remembered choice outranks the environment" {

--- a/src/core/auth/provider_catalog.zig
+++ b/src/core/auth/provider_catalog.zig
@@ -37,6 +37,22 @@ pub const entries = [_]Entry{
         .description = "SuperGrok or X Premium subscription",
         .subscription = true,
     },
+    .{
+        .id = .fireworks,
+        .slug = "fireworks",
+        .name = "Fireworks",
+        .route_name = "Fireworks",
+        .description = "Fireworks account API models",
+        .subscription = false,
+    },
+    .{
+        .id = .modal,
+        .slug = "modal",
+        .name = "Modal",
+        .route_name = "Modal",
+        .description = "Robomart Modal model endpoints",
+        .subscription = false,
+    },
 };
 
 pub fn parse(value: []const u8) ?model_provider.ProviderId {
@@ -61,6 +77,8 @@ test "auth provider catalog uses the model provider identity and explicit aliase
     try std.testing.expectEqual(model_provider.ProviderId.gateway, parse("gateway").?);
     try std.testing.expectEqual(model_provider.ProviderId.codex, parse("codex").?);
     try std.testing.expectEqual(model_provider.ProviderId.grok, parse("grok").?);
+    try std.testing.expectEqual(model_provider.ProviderId.fireworks, parse("fireworks").?);
+    try std.testing.expectEqual(model_provider.ProviderId.modal, parse("modal").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("chatgpt") == null);
     try std.testing.expect(parse("unknown") == null);

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -206,7 +206,11 @@ const LocalSurfaceOptions = struct {
 fn parseLoginProvider(rest: []const [:0]const u8) !?model_provider.ProviderId {
     if (rest.len == 0) return null;
     if (rest.len != 1) return error.InvalidLoginProviderArgs;
-    return provider_catalog.parse(rest[0]) orelse error.InvalidLoginProviderArgs;
+    const provider = provider_catalog.parse(rest[0]) orelse return error.InvalidLoginProviderArgs;
+    return switch (provider) {
+        .gateway, .codex, .grok => provider,
+        .fireworks, .modal => error.InvalidLoginProviderArgs,
+    };
 }
 
 fn selectCatalogModel(
@@ -685,6 +689,8 @@ fn activateProviderSelection(
             .gateway => "Gateway is already selected.\n",
             .codex => "Codex is already selected.\n",
             .grok => "Grok is already selected.\n",
+            .fireworks => "Fireworks is already selected.\n",
+            .modal => "Modal is already selected.\n",
         });
         return true;
     }
@@ -731,6 +737,8 @@ fn activateProviderSelection(
             switch (target) {
                 .codex => "Codex credential is unavailable",
                 .grok => "Grok credential is unavailable",
+                .fireworks => "FIREWORKS_API_KEY is unavailable",
+                .modal => "Modal proxy token is unavailable",
                 .gateway => "configure a Gateway credential first",
             },
         );
@@ -740,6 +748,8 @@ fn activateProviderSelection(
         try writeProviderActivationError(alloc, deps, caller, switch (target) {
             .codex => "Codex model catalog is unavailable",
             .grok => "Grok model catalog is unavailable",
+            .fireworks => "Fireworks model catalog is unavailable",
+            .modal => "Modal model catalog is unavailable",
             .gateway => "Gateway model catalog is unavailable",
         });
         return false;
@@ -785,13 +795,15 @@ fn activateProviderSelection(
     if (performed_login) |provider| switch (provider) {
         .codex => try writeStdout(deps, "Signed in with Codex.\n"),
         .grok => try writeStdout(deps, "Signed in with Grok.\n"),
-        .gateway => unreachable,
+        .gateway, .fireworks, .modal => unreachable,
     };
     if (caller == .provider_command) {
         try writeStdout(deps, switch (target) {
             .gateway => "Provider set to Gateway.\n",
             .codex => "Provider set to Codex.\n",
             .grok => "Provider set to Grok.\n",
+            .fireworks => "Provider set to Fireworks.\n",
+            .modal => "Provider set to Modal.\n",
         });
     }
     return true;
@@ -964,6 +976,14 @@ fn runNonInteractiveWithDeps(
                     }
                     try writeStdout(deps, "Signed in with Grok.\n");
                 },
+                .fireworks => {
+                    try writeStderr(deps, "fx login: Fireworks uses FIREWORKS_API_KEY; no login flow is required\n");
+                    return .handled_failure;
+                },
+                .modal => {
+                    try writeStderr(deps, "fx login: Modal uses MODAL_PROXY_TOKEN_ID and MODAL_PROXY_TOKEN_SECRET; no login flow is required\n");
+                    return .handled_failure;
+                },
             }
             return .handled_success;
         },
@@ -1058,11 +1078,11 @@ fn runNonInteractiveWithDeps(
         },
         .provider => |rest| {
             if (rest.len != 1) {
-                try writeStderr(deps, "usage: fx provider <gateway|codex|grok>\n");
+                try writeStderr(deps, "usage: fx provider <gateway|codex|grok|fireworks|modal>\n");
                 return .handled_failure;
             }
             const target = model_provider.parse(rest[0]) orelse {
-                try writeStderr(deps, "fx provider: expected gateway, codex, or grok\n");
+                try writeStderr(deps, "fx provider: expected gateway, codex, grok, fireworks, or modal\n");
                 return .handled_failure;
             };
             return if (try activateProviderSelection(alloc, cfg, deps, target, .provider_command))
@@ -1150,6 +1170,8 @@ fn runNonInteractiveWithDeps(
                     .gateway => "fx models: Gateway model catalog is unavailable\n",
                     .codex => "fx models: Codex model catalog is unavailable\n",
                     .grok => "fx models: Grok model catalog is unavailable\n",
+                    .fireworks => "fx models: Fireworks model catalog is unavailable\n",
+                    .modal => "fx models: Modal model catalog is unavailable\n",
                 });
                 return .handled_failure;
             };

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -443,6 +443,16 @@ fn loadMergedSettingsDetailedWithOptionalHome(
         }
     }
 
+    if (io_mod.getenv("FX_PROVIDER")) |provider_override| {
+        const trimmed = std.mem.trim(u8, provider_override, " \t\r\n");
+        if (trimmed.len > 0) {
+            if (model_provider.parse(trimmed)) |provider| {
+                settings.provider = provider;
+                sources.provider = .process_override;
+            }
+        }
+    }
+
     if (io_mod.getenv("FX_MODEL")) |model_override| {
         if (std.mem.trim(u8, model_override, " \t\r\n").len > 0) {
             sources.models.set(settings.provider orelse .gateway, .process_override);
@@ -3300,6 +3310,33 @@ test "detailed settings report non-empty process model override as winning sourc
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(ConfigSource.process_override, result.sources.models.get(.gateway));
+    try std.testing.expectEqual(ModelSource.process_override, result.model_source.?);
+    try std.testing.expectEqualStrings("user/model", result.settings.models.get(.gateway).?);
+}
+
+test "process provider override scopes the process model override" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+
+    const home_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "home");
+    defer std.testing.allocator.free(home_root);
+    const workspace_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "workspace");
+    defer std.testing.allocator.free(workspace_root);
+    try writeFixtureFile(tmp.dir, "home/.fx/settings.json", "{\"provider\":\"gateway\",\"models\":{\"gateway\":\"user/model\"}}\n");
+
+    const home = try TestHome.install(std.testing.allocator, home_root);
+    defer home.deinit();
+    try home.map.put("FX_PROVIDER", "modal");
+    try home.map.put("FX_MODEL", "kimi-k3");
+
+    var result = try loadMergedSettingsDetailedFromHome(std.testing.allocator, home_root, workspace_root);
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(model_provider.ProviderId.modal, result.settings.provider.?);
+    try std.testing.expectEqual(ConfigSource.process_override, result.sources.provider);
+    try std.testing.expectEqual(ConfigSource.process_override, result.sources.models.get(.modal));
     try std.testing.expectEqual(ModelSource.process_override, result.model_source.?);
     try std.testing.expectEqualStrings("user/model", result.settings.models.get(.gateway).?);
 }

--- a/src/core/config/model_provider.zig
+++ b/src/core/config/model_provider.zig
@@ -5,6 +5,8 @@ pub const ProviderId = enum {
     gateway,
     codex,
     grok,
+    fireworks,
+    modal,
 };
 
 pub const ProviderSelection = struct {
@@ -16,15 +18,19 @@ pub fn parse(value: []const u8) ?ProviderId {
     if (std.ascii.eqlIgnoreCase(value, "gateway")) return .gateway;
     if (std.ascii.eqlIgnoreCase(value, "codex")) return .codex;
     if (std.ascii.eqlIgnoreCase(value, "grok")) return .grok;
+    if (std.ascii.eqlIgnoreCase(value, "fireworks")) return .fireworks;
+    if (std.ascii.eqlIgnoreCase(value, "modal")) return .modal;
     return null;
 }
 
 pub fn authorizesCredential(provider: ProviderId, source: ?types.CredentialSource) bool {
     const selected = source orelse return false;
     return switch (provider) {
-        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription,
+        .gateway => selected != .chatgpt_subscription and selected != .grok_subscription and selected != .fireworks_api_key and selected != .modal_proxy_token,
         .codex => selected == .chatgpt_subscription,
         .grok => selected == .grok_subscription,
+        .fireworks => selected == .fireworks_api_key,
+        .modal => selected == .modal_proxy_token,
     };
 }
 
@@ -36,14 +42,18 @@ test "explicit providers authorize only their own credential origins" {
     try std.testing.expect(!authorizesCredential(.codex, .ai_gateway_api_key));
     try std.testing.expect(!authorizesCredential(.codex, null));
     try std.testing.expect(authorizesCredential(.grok, .grok_subscription));
+    try std.testing.expect(authorizesCredential(.fireworks, .fireworks_api_key));
+    try std.testing.expect(authorizesCredential(.modal, .modal_proxy_token));
     try std.testing.expect(!authorizesCredential(.grok, .chatgpt_subscription));
     try std.testing.expect(!authorizesCredential(.gateway, .grok_subscription));
 }
 
-test "provider parsing exposes gateway codex and grok" {
+test "provider parsing exposes every provider" {
     try std.testing.expectEqual(ProviderId.gateway, parse("gateway").?);
     try std.testing.expectEqual(ProviderId.codex, parse("CODEX").?);
     try std.testing.expectEqual(ProviderId.grok, parse("GROK").?);
+    try std.testing.expectEqual(ProviderId.fireworks, parse("FIREWORKS").?);
+    try std.testing.expectEqual(ProviderId.modal, parse("MODAL").?);
     try std.testing.expect(parse("openai-codex") == null);
     try std.testing.expect(parse("") == null);
 }

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -1411,8 +1411,9 @@ fn putModelPreference(
         .gateway => "model",
         .codex => "codex_model",
         .grok => "grok_model",
+        .fireworks, .modal => "",
     };
-    if (root.contains(legacy_key)) {
+    if (legacy_key.len > 0 and root.contains(legacy_key)) {
         _ = root.orderedRemove(legacy_key);
         changed = true;
     }

--- a/src/core/gateway/provider_set.zig
+++ b/src/core/gateway/provider_set.zig
@@ -51,12 +51,16 @@ pub const Set = struct {
     gateway: Bundle,
     codex: Bundle,
     grok: Bundle,
+    fireworks: Bundle,
+    modal: Bundle,
 
     pub fn select(self: Set, provider: model_provider.ProviderId) Bundle {
         return switch (provider) {
             .gateway => self.gateway,
             .codex => self.codex,
             .grok => self.grok,
+            .fireworks => self.fireworks,
+            .modal => self.modal,
         };
     }
 
@@ -65,6 +69,8 @@ pub const Set = struct {
             .gateway = self.gateway.deferred_usage,
             .codex = self.codex.deferred_usage,
             .grok = self.grok.deferred_usage,
+            .fireworks = self.fireworks.deferred_usage,
+            .modal = self.modal.deferred_usage,
         };
     }
 };
@@ -74,6 +80,8 @@ pub fn gateway_only(gateway: Bundle) Set {
         .gateway = gateway,
         .codex = .{},
         .grok = .{},
+        .fireworks = .{},
+        .modal = .{},
     };
 }
 
@@ -144,7 +152,7 @@ test "provider set selects each provider's complete route" {
         .model_catalog = .{ .context = &grok_tag, .fetch_fn = Fake.model_catalog_fetch },
         .permission_reviewer = .{ .context = &grok_tag, .review_fn = Fake.review },
     };
-    var providers = Set{ .gateway = gateway, .codex = codex, .grok = grok };
+    var providers = Set{ .gateway = gateway, .codex = codex, .grok = grok, .fireworks = .{}, .modal = .{} };
 
     try std.testing.expect(providers.select(.gateway).agent_stream.?.context.? == @as(*anyopaque, @ptrCast(&gateway_tag)));
     try std.testing.expect(providers.select(.gateway).capabilities.fx_search);

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -362,8 +362,7 @@ fn writeTerminalSafe(writer: *std.Io.Writer, alloc: Allocator, raw: []const u8) 
 }
 
 fn gatewayProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
-    const source = auth.active_source orelse return auth.gateway_connected;
-    return auth.gateway_connected or (source != .chatgpt_subscription and source != .grok_subscription);
+    return auth.gateway_connected or model_provider.authorizesCredential(.gateway, auth.active_source);
 }
 
 fn chatGptProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
@@ -372,6 +371,14 @@ fn chatGptProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
 
 fn grokProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
     return auth.grok_connected or auth.active_source == .grok_subscription;
+}
+
+fn fireworksProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
+    return auth.fireworks_connected or auth.active_source == .fireworks_api_key;
+}
+
+fn modalProviderConnected(auth: auth_runtime.StatusSnapshot) bool {
+    return auth.modal_connected or auth.active_source == .modal_proxy_token;
 }
 
 fn writeConnectedProvidersText(writer: *std.Io.Writer, auth: auth_runtime.StatusSnapshot) !void {
@@ -388,6 +395,16 @@ fn writeConnectedProvidersText(writer: *std.Io.Writer, auth: auth_runtime.Status
     if (grokProviderConnected(auth)) {
         if (wrote_provider) try writer.writeAll(", Grok");
         if (!wrote_provider) try writer.writeAll("Grok");
+        wrote_provider = true;
+    }
+    if (fireworksProviderConnected(auth)) {
+        if (wrote_provider) try writer.writeAll(", Fireworks");
+        if (!wrote_provider) try writer.writeAll("Fireworks");
+        wrote_provider = true;
+    }
+    if (modalProviderConnected(auth)) {
+        if (wrote_provider) try writer.writeAll(", Modal");
+        if (!wrote_provider) try writer.writeAll("Modal");
         wrote_provider = true;
     }
     if (!wrote_provider) try writer.writeAll("none");
@@ -526,6 +543,16 @@ pub const StatusSnapshot = struct {
             if (grokProviderConnected(self.auth)) {
                 if (wrote_provider) try writer.writeByte(',');
                 try std.json.Stringify.value("grok", .{}, writer);
+                wrote_provider = true;
+            }
+            if (fireworksProviderConnected(self.auth)) {
+                if (wrote_provider) try writer.writeByte(',');
+                try std.json.Stringify.value("fireworks", .{}, writer);
+                wrote_provider = true;
+            }
+            if (modalProviderConnected(self.auth)) {
+                if (wrote_provider) try writer.writeByte(',');
+                try std.json.Stringify.value("modal", .{}, writer);
             }
             try writer.writeByte(']');
         }
@@ -751,6 +778,8 @@ pub const ModelListSnapshot = struct {
             .gateway => "gateway",
             .codex => provider_catalog.label(.codex),
             .grok => provider_catalog.label(.grok),
+            .fireworks => provider_catalog.label(.fireworks),
+            .modal => provider_catalog.label(.modal),
         };
     }
 
@@ -2032,6 +2061,32 @@ test "status distinguishes the selected model route from connected providers" {
     defer std.testing.allocator.free(json);
     try std.testing.expect(std.mem.find(u8, json, "\"model_source\":\"Codex subscription\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"connected_providers\":[\"vercel-ai-gateway\",\"codex\"]") != null);
+}
+
+test "status reports direct provider connections without relabeling them as Gateway" {
+    const snapshot = StatusSnapshot{
+        .model = "glm-5-3-flash",
+        .provider = .modal,
+        .auth = .{
+            .active_source = .modal_proxy_token,
+            .fireworks_connected = true,
+            .modal_connected = true,
+        },
+        .permission_mode = .yolo,
+        .workspace_root = "/tmp/fx",
+        .history_turns = 0,
+        .session_permission_grants = 0,
+        .agent_step_limit = 24,
+    };
+    const text = try snapshot.renderText(std.testing.allocator);
+    defer std.testing.allocator.free(text);
+    try std.testing.expect(std.mem.find(u8, text, "model_source=Modal") != null);
+    try std.testing.expect(std.mem.find(u8, text, "connected_providers=Fireworks, Modal") != null);
+    try std.testing.expect(std.mem.find(u8, text, "connected_providers=Vercel AI Gateway") == null);
+
+    const json = try snapshot.renderJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.find(u8, json, "\"connected_providers\":[\"fireworks\",\"modal\"]") != null);
 }
 
 test "MCP config diagnostic renders in status text and JSON but not interactive body" {

--- a/src/core/session/generation_usage_provider.zig
+++ b/src/core/session/generation_usage_provider.zig
@@ -85,6 +85,8 @@ pub const Set = struct {
     gateway: ?Provider = null,
     codex: ?Provider = null,
     grok: ?Provider = null,
+    fireworks: ?Provider = null,
+    modal: ?Provider = null,
 
     pub fn gatewayOnly(provider: Provider) Set {
         return .{ .gateway = provider };
@@ -95,6 +97,8 @@ pub const Set = struct {
             .gateway => self.gateway,
             .codex => self.codex,
             .grok => self.grok,
+            .fireworks => self.fireworks,
+            .modal => self.modal,
         };
     }
 };

--- a/src/core/session/session_usage.zig
+++ b/src/core/session/session_usage.zig
@@ -3272,6 +3272,8 @@ fn exactUsageOrigin(provider: model_provider.ProviderId) []const u8 {
         .gateway => "exact/gateway",
         .codex => "exact/codex",
         .grok => "exact/grok",
+        .fireworks => "exact/fireworks",
+        .modal => "exact/modal",
     };
 }
 

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1693,7 +1693,6 @@ pub const ReasoningEffort = union(enum) {
 
     pub fn parse(raw: []const u8) ?ReasoningEffort {
         if (std.ascii.eqlIgnoreCase(raw, "auto") or
-            std.ascii.eqlIgnoreCase(raw, "adaptive") or
             std.ascii.eqlIgnoreCase(raw, "default")) return .auto;
         return .{ .named = Name.parse(raw) orelse return null };
     }
@@ -2605,7 +2604,7 @@ test "ConversationLanguage preserves core constructors" {
 }
 
 test "ReasoningEffort preserves default aliases and opaque names" {
-    const default_aliases = [_][]const u8{ "auto", "AUTO", "adaptive", "default" };
+    const default_aliases = [_][]const u8{ "auto", "AUTO", "default" };
     for (default_aliases) |alias| {
         const parsed = ReasoningEffort.parseDisplayLabel(alias) orelse return error.ExpectedReasoningEffort;
         try std.testing.expectEqual(ReasoningEffort.auto, parsed);
@@ -2614,7 +2613,7 @@ test "ReasoningEffort preserves default aliases and opaque names" {
         try std.testing.expect(parsed.gatewayValue() == null);
     }
 
-    const named_values = [_][]const u8{ "none", "low", "xhigh", "future-tier" };
+    const named_values = [_][]const u8{ "none", "low", "xhigh", "adaptive", "future-tier" };
     for (named_values) |raw| {
         const parsed = ReasoningEffort.parse(raw) orelse return error.ExpectedReasoningEffort;
         try std.testing.expectEqualStrings(raw, parsed.label());

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -94,6 +94,8 @@ pub const CredentialSource = enum {
     stored_key,
     chatgpt_subscription,
     grok_subscription,
+    fireworks_api_key,
+    modal_proxy_token,
 };
 
 pub fn parseCredentialSource(text: []const u8) ?CredentialSource {

--- a/src/gateway/fireworks_models.zig
+++ b/src/gateway/fireworks_models.zig
@@ -1,0 +1,221 @@
+const std = @import("std");
+const credentials = @import("../core/auth/credentials.zig");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const io_mod = @import("../core/shared/io.zig");
+const secret = @import("../core/auth/secret.zig");
+const gateway_client = @import("client.zig");
+
+const max_catalog_models: usize = 256;
+const max_model_id_bytes: usize = 1024;
+const max_catalog_bytes: usize = 2 * 1024 * 1024;
+const fetch_timeout_ms: i64 = 30_000;
+const default_models_endpoint = "https://api.fireworks.ai/inference/v1/models";
+const e2e_models_endpoint_env = "FX_E2E_FIREWORKS_MODELS_URL";
+
+pub const model_catalog_provider = model_catalog.Provider{
+    .fetch_fn = fetchCatalogForProvider,
+};
+
+pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
+    .fetch_fn = fetchCliModelCatalog,
+};
+
+fn fetchCliModelCatalog(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: gateway_provider.CliModelCatalogInput,
+) gateway_provider.CliModelCatalogResult {
+    return switch (model_catalog.fetchWithPublicFallback(model_catalog_provider, alloc, .{
+        .access = input.access,
+        .endpoint = input.endpoint,
+        .cancel_flag = input.cancel_flag,
+        .view = .full,
+    })) {
+        .loaded => |loaded| blk: {
+            var catalog = loaded.catalog;
+            defer model_catalog.freeModelCatalog(alloc, &catalog);
+            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
+                .access = loaded.provenance.access,
+                .anonymous_fallback_used = false,
+                .failure = .{ .category = .resource_exhausted },
+            } };
+            break :blk .{ .loaded = .{ .ids = ids, .provenance = loaded.provenance } };
+        },
+        .failed => |failure| .{ .failure = failure },
+    };
+}
+
+fn fetchCatalogForProvider(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: model_catalog.FetchInput,
+) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    if (input.access.credentialSource() != .fireworks_api_key) {
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    }
+    const credential = input.access.authorizationCredential() orelse
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    const url = modelsUrl() catch return .{ .failure = .{ .category = .runtime } };
+    var fallback_cancel = std.atomic.Value(bool).init(false);
+    const cancel_flag = input.cancel_flag orelse &fallback_cancel;
+    const deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+        .clock = .awake,
+        .raw = .fromMilliseconds(fetch_timeout_ms),
+    });
+    var operation = FetchOperation{ .alloc = alloc, .url = url, .credential = credential };
+    var response = gateway_client.runBoundedHttpOperation(
+        FetchResponse,
+        alloc,
+        cancel_flag,
+        deadline,
+        &operation,
+    ) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = if (err == error.Cancelled)
+            .{ .category = .cancellation }
+        else
+            .{ .category = .transport, .retryable = true } };
+    };
+    defer response.deinit(alloc);
+    if (response.status != .ok) return .{ .failure = model_catalog.failureForHttpStatus(response.status) };
+    const catalog = parseCatalog(alloc, response.body) catch |err| {
+        if (err == error.OutOfMemory) return error.OutOfMemory;
+        return .{ .failure = .{ .category = .malformed_response, .http_status = .ok } };
+    };
+    return .{ .catalog = catalog };
+}
+
+const FetchResponse = struct {
+    status: std.http.Status,
+    body: []u8,
+
+    pub fn deinit(self: *FetchResponse, alloc: std.mem.Allocator) void {
+        secret.zeroAndFree(alloc, self.body);
+    }
+};
+
+const FetchOperation = struct {
+    alloc: std.mem.Allocator,
+    url: []const u8,
+    credential: []const u8,
+
+    pub fn run(self: *@This()) !FetchResponse {
+        var client: std.http.Client = .{ .allocator = self.alloc, .io = io_mod.getIo() };
+        defer client.deinit();
+        const auth_header = try std.fmt.allocPrint(self.alloc, "Bearer {s}", .{self.credential});
+        defer secret.zeroAndFree(self.alloc, auth_header);
+        const body_buffer = try self.alloc.alloc(u8, max_catalog_bytes + 1);
+        defer secret.zeroAndFree(self.alloc, body_buffer);
+        var response_writer = std.Io.Writer.fixed(body_buffer);
+        const result = client.fetch(.{
+            .location = .{ .url = self.url },
+            .method = .GET,
+            .headers = .{
+                .authorization = .{ .override = auth_header },
+                .user_agent = .{ .override = gateway_client.user_agent },
+                .accept_encoding = .omit,
+            },
+            .extra_headers = &.{.{ .name = "accept", .value = "application/json" }},
+            .response_writer = &response_writer,
+            .redirect_behavior = .unhandled,
+        }) catch |err| switch (err) {
+            error.WriteFailed => return error.FireworksModelCatalogTooLarge,
+            else => return err,
+        };
+        return .{ .status = result.status, .body = try self.alloc.dupe(u8, response_writer.buffered()) };
+    }
+};
+
+fn modelsUrl() ![]const u8 {
+    const value = io_mod.getenv(e2e_models_endpoint_env) orelse return default_models_endpoint;
+    if (!gateway_client.isLoopbackHttpUrl(value)) return error.InvalidE2EFireworksModelsEndpoint;
+    return value;
+}
+
+fn parseCatalog(alloc: std.mem.Allocator, body: []const u8) !std.ArrayList(model_catalog.ModelCatalogEntry) {
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidFireworksModelCatalog;
+    const data = parsed.value.object.get("data") orelse return error.InvalidFireworksModelCatalog;
+    if (data != .array or data.array.items.len > max_catalog_models) return error.InvalidFireworksModelCatalog;
+
+    var catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    errdefer model_catalog.freeModelCatalog(alloc, &catalog);
+    for (data.array.items) |value| {
+        if (value != .object) return error.InvalidFireworksModelCatalog;
+        const object = value.object;
+        if (!optionalBool(object, "supports_chat") or !optionalBool(object, "supports_tools")) continue;
+        const kind = optionalString(object, "kind") orelse "";
+        if (containsIgnoreCase(kind, "embedding") or containsIgnoreCase(kind, "rerank")) continue;
+        const raw_id = optionalString(object, "id") orelse return error.InvalidFireworksModelCatalog;
+        try validateModelId(raw_id);
+        const id = try alloc.dupe(u8, raw_id);
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        try catalog.append(alloc, .{
+            .id = id,
+            .model_type = model_type,
+            .released = optionalInteger(object, "created") orelse 0,
+            .has_tool_use = true,
+            .has_vision = optionalBool(object, "supports_image_input"),
+            .has_file_input = optionalBool(object, "supports_image_input"),
+            .context_window = optionalPositiveU32(object, "context_length") orelse 0,
+        });
+    }
+    return catalog;
+}
+
+fn optionalString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = object.get(key) orelse return null;
+    if (value != .string or value.string.len == 0) return null;
+    return value.string;
+}
+
+fn optionalBool(object: std.json.ObjectMap, key: []const u8) bool {
+    const value = object.get(key) orelse return false;
+    return value == .bool and value.bool;
+}
+
+fn optionalInteger(object: std.json.ObjectMap, key: []const u8) ?i64 {
+    const value = object.get(key) orelse return null;
+    return if (value == .integer) value.integer else null;
+}
+
+fn optionalPositiveU32(object: std.json.ObjectMap, key: []const u8) ?u32 {
+    const value = object.get(key) orelse return null;
+    if (value != .integer or value.integer <= 0) return null;
+    return std.math.cast(u32, value.integer);
+}
+
+fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0 or needle.len > haystack.len) return false;
+    var index: usize = 0;
+    while (index + needle.len <= haystack.len) : (index += 1) {
+        if (std.ascii.eqlIgnoreCase(haystack[index .. index + needle.len], needle)) return true;
+    }
+    return false;
+}
+
+fn validateModelId(id: []const u8) !void {
+    if (id.len == 0 or id.len > max_model_id_bytes) return error.InvalidFireworksModelCatalog;
+    for (id) |byte| if (byte <= 0x20 or byte == 0x7f) return error.InvalidFireworksModelCatalog;
+}
+
+test "Fireworks catalog keeps only chat models with tool use" {
+    const body =
+        \\{"data":[
+        \\  {"id":"accounts/fireworks/models/kimi-k3","kind":"HF_BASE_MODEL","supports_chat":true,"supports_tools":true,"supports_image_input":true,"context_length":1048576,"created":10},
+        \\  {"id":"accounts/fireworks/models/embed","kind":"EMBEDDING","supports_chat":true,"supports_tools":true},
+        \\  {"id":"accounts/fireworks/models/no-tools","kind":"HF_BASE_MODEL","supports_chat":true,"supports_tools":false}
+        \\]}
+    ;
+    var catalog = try parseCatalog(std.testing.allocator, body);
+    defer model_catalog.freeModelCatalog(std.testing.allocator, &catalog);
+    try std.testing.expectEqual(@as(usize, 1), catalog.items.len);
+    try std.testing.expectEqualStrings("accounts/fireworks/models/kimi-k3", catalog.items[0].id);
+    try std.testing.expect(catalog.items[0].has_tool_use);
+    try std.testing.expect(catalog.items[0].has_vision);
+    try std.testing.expectEqual(@as(u32, 1_048_576), catalog.items[0].context_window);
+}

--- a/src/gateway/fireworks_models.zig
+++ b/src/gateway/fireworks_models.zig
@@ -4,6 +4,7 @@ const model_catalog = @import("../core/gateway/model_catalog.zig");
 const gateway_provider = @import("../core/gateway/gateway_provider.zig");
 const io_mod = @import("../core/shared/io.zig");
 const secret = @import("../core/auth/secret.zig");
+const types = @import("../core/shared/types.zig");
 const gateway_client = @import("client.zig");
 
 const max_catalog_models: usize = 256;
@@ -12,6 +13,76 @@ const max_catalog_bytes: usize = 2 * 1024 * 1024;
 const fetch_timeout_ms: i64 = 30_000;
 const default_models_endpoint = "https://api.fireworks.ai/inference/v1/models";
 const e2e_models_endpoint_env = "FX_E2E_FIREWORKS_MODELS_URL";
+
+const standard_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("none"),
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("xhigh"),
+    types.ReasoningEffort.literal("max"),
+};
+const required_extended_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("xhigh"),
+    types.ReasoningEffort.literal("max"),
+};
+const basic_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("high"),
+};
+const adaptive_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("none"),
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("xhigh"),
+    types.ReasoningEffort.literal("max"),
+    types.ReasoningEffort.literal("adaptive"),
+};
+
+const ReasoningProfile = enum {
+    standard,
+    required_extended,
+    basic,
+    adaptive,
+};
+
+const ReasoningCapability = struct {
+    id: []const u8,
+    profile: ReasoningProfile,
+};
+
+// Fireworks does not include per-model reasoning tiers in /v1/models. Keep this
+// allowlist synchronized with the values accepted by Chat Completions so newly
+// listed models fail closed until their controls have been verified.
+const reasoning_capabilities = [_]ReasoningCapability{
+    .{ .id = "accounts/fireworks/models/glm-5p2", .profile = .standard },
+    .{ .id = "accounts/fireworks/routers/glm-5p2-fast", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/kimi-k2p6", .profile = .standard },
+    .{ .id = "accounts/fireworks/routers/kimi-k2p6-turbo", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/kimi-k2p7-code", .profile = .standard },
+    .{ .id = "accounts/fireworks/routers/kimi-k2p7-code-fast", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/minimax-m2p7", .profile = .basic },
+    .{ .id = "accounts/fireworks/models/minimax-m3", .profile = .adaptive },
+    .{ .id = "accounts/fireworks/models/gpt-oss-120b", .profile = .basic },
+    .{ .id = "accounts/fireworks/models/deepseek-v4-pro", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/qwen3p7-plus", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/nemotron-3-ultra-nvfp4", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/kimi-k3", .profile = .standard },
+    .{ .id = "accounts/fireworks/routers/kimi-k3-fast", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/deepseek-v4-flash-0731", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/muse-glimmer-30b", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/qwen3p8-max", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/deepseek-v4-pro-0813", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/glm-5p3-flash", .profile = .required_extended },
+    .{ .id = "accounts/fireworks/models/qwen3p8-2p4t-a95b", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b", .profile = .standard },
+    .{ .id = "accounts/fireworks/models/inkling", .profile = .standard },
+};
 
 pub const model_catalog_provider = model_catalog.Provider{
     .fetch_fn = fetchCatalogForProvider,
@@ -154,17 +225,38 @@ fn parseCatalog(alloc: std.mem.Allocator, body: []const u8) !std.ArrayList(model
         errdefer alloc.free(id);
         const model_type = try alloc.dupe(u8, "language");
         errdefer alloc.free(model_type);
+        var reasoning_efforts = try reasoningEffortsForModel(alloc, raw_id);
+        errdefer reasoning_efforts.deinit(alloc);
         try catalog.append(alloc, .{
             .id = id,
             .model_type = model_type,
             .released = optionalInteger(object, "created") orelse 0,
             .has_tool_use = true,
+            .has_reasoning = reasoning_efforts.items.len > 0,
+            .reasoning_efforts = reasoning_efforts,
             .has_vision = optionalBool(object, "supports_image_input"),
             .has_file_input = optionalBool(object, "supports_image_input"),
             .context_window = optionalPositiveU32(object, "context_length") orelse 0,
         });
     }
     return catalog;
+}
+
+fn reasoningEffortsForModel(alloc: std.mem.Allocator, id: []const u8) !std.ArrayList(types.ReasoningEffort) {
+    var efforts: std.ArrayList(types.ReasoningEffort) = .empty;
+    errdefer efforts.deinit(alloc);
+    for (reasoning_capabilities) |capability| {
+        if (!std.mem.eql(u8, id, capability.id)) continue;
+        const values: []const types.ReasoningEffort = switch (capability.profile) {
+            .standard => &standard_reasoning_efforts,
+            .required_extended => &required_extended_reasoning_efforts,
+            .basic => &basic_reasoning_efforts,
+            .adaptive => &adaptive_reasoning_efforts,
+        };
+        try efforts.appendSlice(alloc, values);
+        break;
+    }
+    return efforts;
 }
 
 fn optionalString(object: std.json.ObjectMap, key: []const u8) ?[]const u8 {
@@ -203,19 +295,37 @@ fn validateModelId(id: []const u8) !void {
     for (id) |byte| if (byte <= 0x20 or byte == 0x7f) return error.InvalidFireworksModelCatalog;
 }
 
-test "Fireworks catalog keeps only chat models with tool use" {
+test "Fireworks catalog keeps only chat models with tool use and attaches verified reasoning efforts" {
     const body =
         \\{"data":[
         \\  {"id":"accounts/fireworks/models/kimi-k3","kind":"HF_BASE_MODEL","supports_chat":true,"supports_tools":true,"supports_image_input":true,"context_length":1048576,"created":10},
+        \\  {"id":"accounts/fireworks/models/glm-5p3-flash","kind":"HF_BASE_MODEL","supports_chat":true,"supports_tools":true},
+        \\  {"id":"accounts/fireworks/models/minimax-m2p7","kind":"HF_BASE_MODEL","supports_chat":true,"supports_tools":true},
+        \\  {"id":"accounts/fireworks/models/minimax-m3","kind":"HF_BASE_MODEL","supports_chat":true,"supports_tools":true},
+        \\  {"id":"accounts/fireworks/models/future-model","kind":"HF_BASE_MODEL","supports_chat":true,"supports_tools":true},
         \\  {"id":"accounts/fireworks/models/embed","kind":"EMBEDDING","supports_chat":true,"supports_tools":true},
         \\  {"id":"accounts/fireworks/models/no-tools","kind":"HF_BASE_MODEL","supports_chat":true,"supports_tools":false}
         \\]}
     ;
     var catalog = try parseCatalog(std.testing.allocator, body);
     defer model_catalog.freeModelCatalog(std.testing.allocator, &catalog);
-    try std.testing.expectEqual(@as(usize, 1), catalog.items.len);
+    try std.testing.expectEqual(@as(usize, 5), catalog.items.len);
     try std.testing.expectEqualStrings("accounts/fireworks/models/kimi-k3", catalog.items[0].id);
     try std.testing.expect(catalog.items[0].has_tool_use);
+    try std.testing.expect(catalog.items[0].has_reasoning);
+    try std.testing.expectEqual(@as(usize, 6), catalog.items[0].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("none", catalog.items[0].reasoning_efforts.items[0].label());
+    try std.testing.expectEqualStrings("max", catalog.items[0].reasoning_efforts.items[5].label());
     try std.testing.expect(catalog.items[0].has_vision);
     try std.testing.expectEqual(@as(u32, 1_048_576), catalog.items[0].context_window);
+
+    try std.testing.expectEqual(@as(usize, 5), catalog.items[1].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("low", catalog.items[1].reasoning_efforts.items[0].label());
+    try std.testing.expectEqualStrings("max", catalog.items[1].reasoning_efforts.items[4].label());
+    try std.testing.expectEqual(@as(usize, 3), catalog.items[2].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("high", catalog.items[2].reasoning_efforts.items[2].label());
+    try std.testing.expectEqual(@as(usize, 7), catalog.items[3].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("adaptive", catalog.items[3].reasoning_efforts.items[6].label());
+    try std.testing.expect(!catalog.items[4].has_reasoning);
+    try std.testing.expectEqual(@as(usize, 0), catalog.items[4].reasoning_efforts.items.len);
 }

--- a/src/gateway/modal_models.zig
+++ b/src/gateway/modal_models.zig
@@ -1,11 +1,28 @@
 const std = @import("std");
 const model_catalog = @import("../core/gateway/model_catalog.zig");
 const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+const types = @import("../core/shared/types.zig");
+
+const flexible_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("none"),
+    types.ReasoningEffort.literal("minimal"),
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("xhigh"),
+    types.ReasoningEffort.literal("max"),
+};
+const kimi_k3_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("max"),
+};
 
 pub const Definition = struct {
     id: []const u8,
     wire_model: []const u8,
     endpoint: []const u8,
+    reasoning_efforts: []const types.ReasoningEffort,
 };
 
 pub const definitions = [_]Definition{
@@ -13,21 +30,25 @@ pub const definitions = [_]Definition{
         .id = "glm-5-3-flash",
         .wire_model = "zai-org/GLM-5.3-Flash",
         .endpoint = "https://robomart-rsi--ep-glm-5-3-flash-server.us-west.modal.direct/v1/chat/completions",
+        .reasoning_efforts = &flexible_reasoning_efforts,
     },
     .{
         .id = "qwen3-8-2-4t-a95b",
         .wire_model = "Qwen/Qwen3.8-2.4T-A95B",
         .endpoint = "https://robomart-rsi--ep-qwen3-8-2-4t-a95b-server.us-west.modal.direct/v1/chat/completions",
+        .reasoning_efforts = &flexible_reasoning_efforts,
     },
     .{
         .id = "inkling-nvfp4",
         .wire_model = "thinkingmachines/Inkling-NVFP4",
         .endpoint = "https://robomart-rsi--ep-inkling-nvfp4-server.us-west.modal.direct/v1/chat/completions",
+        .reasoning_efforts = &flexible_reasoning_efforts,
     },
     .{
         .id = "kimi-k3",
         .wire_model = "moonshotai/Kimi-K3",
         .endpoint = "https://robomart-rsi--ep-kimi-k3-server.us-west.modal.direct/v1/chat/completions",
+        .reasoning_efforts = &kimi_k3_reasoning_efforts,
     },
 };
 
@@ -83,10 +104,15 @@ fn fetchCatalog(
         errdefer alloc.free(id);
         const model_type = try alloc.dupe(u8, "language");
         errdefer alloc.free(model_type);
+        var reasoning_efforts: std.ArrayList(types.ReasoningEffort) = .empty;
+        errdefer reasoning_efforts.deinit(alloc);
+        try reasoning_efforts.appendSlice(alloc, definition.reasoning_efforts);
         catalog.appendAssumeCapacity(.{
             .id = id,
             .model_type = model_type,
             .has_tool_use = true,
+            .has_reasoning = reasoning_efforts.items.len > 0,
+            .reasoning_efforts = reasoning_efforts,
         });
     }
     return .{ .catalog = catalog };
@@ -107,5 +133,11 @@ test "Modal catalog exposes the four endpoint aliases" {
     defer model_catalog.freeModelCatalog(std.testing.allocator, &catalog);
     try std.testing.expectEqual(@as(usize, 4), catalog.items.len);
     try std.testing.expectEqualStrings("glm-5-3-flash", catalog.items[0].id);
+    try std.testing.expect(catalog.items[0].has_reasoning);
+    try std.testing.expectEqual(@as(usize, 7), catalog.items[0].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("xhigh", catalog.items[0].reasoning_efforts.items[5].label());
     try std.testing.expectEqualStrings("kimi-k3", catalog.items[3].id);
+    try std.testing.expectEqual(@as(usize, 3), catalog.items[3].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("low", catalog.items[3].reasoning_efforts.items[0].label());
+    try std.testing.expectEqualStrings("max", catalog.items[3].reasoning_efforts.items[2].label());
 }

--- a/src/gateway/modal_models.zig
+++ b/src/gateway/modal_models.zig
@@ -3,19 +3,23 @@ const model_catalog = @import("../core/gateway/model_catalog.zig");
 const gateway_provider = @import("../core/gateway/gateway_provider.zig");
 const types = @import("../core/shared/types.zig");
 
-const flexible_reasoning_efforts = [_]types.ReasoningEffort{
+const low_high_max_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("high"),
+    types.ReasoningEffort.literal("max"),
+};
+const qwen_reasoning_efforts = [_]types.ReasoningEffort{
+    types.ReasoningEffort.literal("low"),
+    types.ReasoningEffort.literal("medium"),
+    types.ReasoningEffort.literal("xhigh"),
+};
+const inkling_reasoning_efforts = [_]types.ReasoningEffort{
     types.ReasoningEffort.literal("none"),
     types.ReasoningEffort.literal("minimal"),
     types.ReasoningEffort.literal("low"),
     types.ReasoningEffort.literal("medium"),
     types.ReasoningEffort.literal("high"),
     types.ReasoningEffort.literal("xhigh"),
-    types.ReasoningEffort.literal("max"),
-};
-const kimi_k3_reasoning_efforts = [_]types.ReasoningEffort{
-    types.ReasoningEffort.literal("low"),
-    types.ReasoningEffort.literal("high"),
-    types.ReasoningEffort.literal("max"),
 };
 
 pub const Definition = struct {
@@ -30,25 +34,25 @@ pub const definitions = [_]Definition{
         .id = "glm-5-3-flash",
         .wire_model = "zai-org/GLM-5.3-Flash",
         .endpoint = "https://robomart-rsi--ep-glm-5-3-flash-server.us-west.modal.direct/v1/chat/completions",
-        .reasoning_efforts = &flexible_reasoning_efforts,
+        .reasoning_efforts = &low_high_max_reasoning_efforts,
     },
     .{
         .id = "qwen3-8-2-4t-a95b",
         .wire_model = "Qwen/Qwen3.8-2.4T-A95B",
         .endpoint = "https://robomart-rsi--ep-qwen3-8-2-4t-a95b-server.us-west.modal.direct/v1/chat/completions",
-        .reasoning_efforts = &flexible_reasoning_efforts,
+        .reasoning_efforts = &qwen_reasoning_efforts,
     },
     .{
         .id = "inkling-nvfp4",
         .wire_model = "thinkingmachines/Inkling-NVFP4",
         .endpoint = "https://robomart-rsi--ep-inkling-nvfp4-server.us-west.modal.direct/v1/chat/completions",
-        .reasoning_efforts = &flexible_reasoning_efforts,
+        .reasoning_efforts = &inkling_reasoning_efforts,
     },
     .{
         .id = "kimi-k3",
         .wire_model = "moonshotai/Kimi-K3",
         .endpoint = "https://robomart-rsi--ep-kimi-k3-server.us-west.modal.direct/v1/chat/completions",
-        .reasoning_efforts = &kimi_k3_reasoning_efforts,
+        .reasoning_efforts = &low_high_max_reasoning_efforts,
     },
 };
 
@@ -134,8 +138,15 @@ test "Modal catalog exposes the four endpoint aliases" {
     try std.testing.expectEqual(@as(usize, 4), catalog.items.len);
     try std.testing.expectEqualStrings("glm-5-3-flash", catalog.items[0].id);
     try std.testing.expect(catalog.items[0].has_reasoning);
-    try std.testing.expectEqual(@as(usize, 7), catalog.items[0].reasoning_efforts.items.len);
-    try std.testing.expectEqualStrings("xhigh", catalog.items[0].reasoning_efforts.items[5].label());
+    try std.testing.expectEqual(@as(usize, 3), catalog.items[0].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("low", catalog.items[0].reasoning_efforts.items[0].label());
+    try std.testing.expectEqualStrings("max", catalog.items[0].reasoning_efforts.items[2].label());
+    try std.testing.expectEqual(@as(usize, 3), catalog.items[1].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("medium", catalog.items[1].reasoning_efforts.items[1].label());
+    try std.testing.expectEqualStrings("xhigh", catalog.items[1].reasoning_efforts.items[2].label());
+    try std.testing.expectEqual(@as(usize, 6), catalog.items[2].reasoning_efforts.items.len);
+    try std.testing.expectEqualStrings("none", catalog.items[2].reasoning_efforts.items[0].label());
+    try std.testing.expectEqualStrings("xhigh", catalog.items[2].reasoning_efforts.items[5].label());
     try std.testing.expectEqualStrings("kimi-k3", catalog.items[3].id);
     try std.testing.expectEqual(@as(usize, 3), catalog.items[3].reasoning_efforts.items.len);
     try std.testing.expectEqualStrings("low", catalog.items[3].reasoning_efforts.items[0].label());

--- a/src/gateway/modal_models.zig
+++ b/src/gateway/modal_models.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+const model_catalog = @import("../core/gateway/model_catalog.zig");
+const gateway_provider = @import("../core/gateway/gateway_provider.zig");
+
+pub const Definition = struct {
+    id: []const u8,
+    wire_model: []const u8,
+    endpoint: []const u8,
+};
+
+pub const definitions = [_]Definition{
+    .{
+        .id = "glm-5-3-flash",
+        .wire_model = "zai-org/GLM-5.3-Flash",
+        .endpoint = "https://robomart-rsi--ep-glm-5-3-flash-server.us-west.modal.direct/v1/chat/completions",
+    },
+    .{
+        .id = "qwen3-8-2-4t-a95b",
+        .wire_model = "Qwen/Qwen3.8-2.4T-A95B",
+        .endpoint = "https://robomart-rsi--ep-qwen3-8-2-4t-a95b-server.us-west.modal.direct/v1/chat/completions",
+    },
+    .{
+        .id = "inkling-nvfp4",
+        .wire_model = "thinkingmachines/Inkling-NVFP4",
+        .endpoint = "https://robomart-rsi--ep-inkling-nvfp4-server.us-west.modal.direct/v1/chat/completions",
+    },
+    .{
+        .id = "kimi-k3",
+        .wire_model = "moonshotai/Kimi-K3",
+        .endpoint = "https://robomart-rsi--ep-kimi-k3-server.us-west.modal.direct/v1/chat/completions",
+    },
+};
+
+pub const model_catalog_provider = model_catalog.Provider{
+    .fetch_fn = fetchCatalog,
+};
+
+pub const cli_model_catalog_provider = gateway_provider.CliModelCatalogProvider{
+    .fetch_fn = fetchCliModelCatalog,
+};
+
+fn fetchCliModelCatalog(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: gateway_provider.CliModelCatalogInput,
+) gateway_provider.CliModelCatalogResult {
+    return switch (model_catalog.fetchWithPublicFallback(model_catalog_provider, alloc, .{
+        .access = input.access,
+        .endpoint = input.endpoint,
+        .cancel_flag = input.cancel_flag,
+        .view = .full,
+    })) {
+        .loaded => |loaded| blk: {
+            var catalog = loaded.catalog;
+            defer model_catalog.freeModelCatalog(alloc, &catalog);
+            const ids = model_catalog.projectModelIds(alloc, catalog.items) catch return .{ .failure = .{
+                .access = loaded.provenance.access,
+                .anonymous_fallback_used = false,
+                .failure = .{ .category = .resource_exhausted },
+            } };
+            break :blk .{ .loaded = .{ .ids = ids, .provenance = loaded.provenance } };
+        },
+        .failed => |failure| .{ .failure = failure },
+    };
+}
+
+fn fetchCatalog(
+    _: ?*anyopaque,
+    alloc: std.mem.Allocator,
+    input: model_catalog.FetchInput,
+) std.mem.Allocator.Error!model_catalog.ProviderResult {
+    if (input.access.credentialSource() != .modal_proxy_token or
+        input.access.authorizationCredential() == null or
+        input.access.accountId() == null)
+    {
+        return .{ .failure = .{ .category = .authentication, .http_status = .unauthorized } };
+    }
+    var catalog: std.ArrayList(model_catalog.ModelCatalogEntry) = .empty;
+    errdefer model_catalog.freeModelCatalog(alloc, &catalog);
+    try catalog.ensureTotalCapacity(alloc, definitions.len);
+    for (definitions) |definition| {
+        const id = try alloc.dupe(u8, definition.id);
+        errdefer alloc.free(id);
+        const model_type = try alloc.dupe(u8, "language");
+        errdefer alloc.free(model_type);
+        catalog.appendAssumeCapacity(.{
+            .id = id,
+            .model_type = model_type,
+            .has_tool_use = true,
+        });
+    }
+    return .{ .catalog = catalog };
+}
+
+test "Modal catalog exposes the four endpoint aliases" {
+    const access = @import("../core/auth/credentials.zig").catalogAccessForCredentialAndAccount(
+        .modal_proxy_token,
+        "secret",
+        null,
+        "id",
+    );
+    const result = try fetchCatalog(null, std.testing.allocator, .{
+        .access = access,
+        .endpoint = "",
+    });
+    var catalog = result.catalog;
+    defer model_catalog.freeModelCatalog(std.testing.allocator, &catalog);
+    try std.testing.expectEqual(@as(usize, 4), catalog.items.len);
+    try std.testing.expectEqualStrings("glm-5-3-flash", catalog.items[0].id);
+    try std.testing.expectEqualStrings("kimi-k3", catalog.items[3].id);
+}

--- a/src/gateway/openai_compatible.zig
+++ b/src/gateway/openai_compatible.zig
@@ -647,14 +647,14 @@ const Reducer = struct {
         for (self.tools.items) |*tool| {
             if (tool.id.items.len == 0 or tool.name.items.len == 0) return error.InvalidOpenAICompatibleSseEvent;
             if (!tool.started) request.events.emit(.{ .tool_started = .{ .id = tool.id.items, .name = tool.name.items } });
-            const arguments = if (tool.arguments.items.len == 0) "{}" else tool.arguments.items;
-            if (try types.ToolArgumentIntegrity.classifySerialized(alloc, arguments) == .malformed_json) {
-                return error.InvalidOpenAICompatibleToolArguments;
-            }
+            const streamed_arguments = if (tool.arguments.items.len == 0) "{}" else tool.arguments.items;
+            const argument_integrity = try types.ToolArgumentIntegrity.classifySerialized(alloc, streamed_arguments);
+            const arguments = if (argument_integrity == .valid) streamed_arguments else "{}";
             owned_tools[count] = .{
                 .id = try alloc.dupe(u8, tool.id.items),
                 .name = try alloc.dupe(u8, tool.name.items),
                 .arguments_json = try alloc.dupe(u8, arguments),
+                .argument_integrity = argument_integrity,
             };
             count += 1;
         }
@@ -791,5 +791,39 @@ test "OpenAI compatible reducer maps text reasoning tools and usage" {
     try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", capture.tool_input.items);
     try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", completion.tool_calls[0].arguments_json);
     try std.testing.expectEqual(@as(?u64, 10), completion.usage.input_tokens);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}
+
+test "OpenAI compatible reducer defers malformed tool arguments to agent recovery" {
+    const Capture = struct {
+        fn emit(_: *anyopaque, _: stream_provider.Event) void {}
+    };
+    var capture: u8 = 0;
+    var cancel = std.atomic.Value(bool).init(false);
+    var delivery = stream_provider.DeliveryCertainty.init();
+    var evidence: stream_provider.AttemptEvidence = .{};
+    var reducer: Reducer = .{};
+    defer reducer.deinit(std.testing.allocator);
+    const request = stream_provider.ModelRequest{
+        .credential = .{ .secret = "key" },
+        .model = "model",
+        .retry_count = 0,
+        .messages = &.{},
+        .tool_choice = .auto,
+        .provider_options = .{},
+        .trace_ctx = .{},
+        .content_capture_limit = null,
+        .delivery = &delivery,
+        .attempt_evidence = &evidence,
+        .events = .{ .context = &capture, .emit_fn = Capture.emit },
+        .cancel_flag = &cancel,
+    };
+    try reducer.apply(std.testing.allocator, "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\"}}]},\"finish_reason\":\"tool_calls\"}]}", request);
+    const completion = try reducer.finish(std.testing.allocator, request);
+    defer types.freeToolCallSlice(std.testing.allocator, @constCast(completion.tool_calls));
+
+    try std.testing.expectEqual(@as(usize, 1), completion.tool_calls.len);
+    try std.testing.expectEqualStrings("{}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(types.ToolArgumentIntegrity.malformed_json, completion.tool_calls[0].argument_integrity);
     try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
 }

--- a/src/gateway/openai_compatible.zig
+++ b/src/gateway/openai_compatible.zig
@@ -1,0 +1,795 @@
+const std = @import("std");
+const image_attachments = @import("../core/images/image_attachments.zig");
+const secret = @import("../core/auth/secret.zig");
+const stream_provider = @import("../core/agent/stream_provider.zig");
+const model_provider = @import("../core/config/model_provider.zig");
+const model_tool_schema = @import("../core/tooling/model_tool_schema.zig");
+const io_mod = @import("../core/shared/io.zig");
+const types = @import("../core/shared/types.zig");
+const gateway_client = @import("client.zig");
+
+const Allocator = std.mem.Allocator;
+const max_error_body_bytes: usize = 256 * 1024;
+const max_sse_line_bytes: usize = 8 * 1024 * 1024;
+const max_sse_aggregate_bytes: usize = 64 * 1024 * 1024;
+const max_sse_events: usize = 100_000;
+const max_tool_calls: usize = 128;
+const max_tool_identity_bytes: usize = 1024;
+const max_tool_arguments_bytes: usize = 4 * 1024 * 1024;
+const transfer_buffer_bytes: usize = 256 * 1024;
+const connect_timeout_ms: i64 = 30_000;
+
+pub const AuthKind = enum {
+    bearer,
+    modal_proxy,
+};
+
+pub const Route = struct {
+    id: []const u8,
+    wire_model: []const u8,
+    endpoint: []const u8,
+};
+
+pub const Context = struct {
+    provider: model_provider.ProviderId,
+    credential_source: types.CredentialSource,
+    auth: AuthKind,
+    endpoint: []const u8 = "",
+    routes: []const Route = &.{},
+
+    fn resolve(self: *const Context, model: []const u8) !struct {
+        wire_model: []const u8,
+        endpoint: []const u8,
+    } {
+        if (self.routes.len == 0) {
+            try validateModel(model);
+            if (self.endpoint.len == 0) return error.OpenAICompatibleEndpointMissing;
+            return .{ .wire_model = model, .endpoint = self.endpoint };
+        }
+        for (self.routes) |route| {
+            if (std.mem.eql(u8, model, route.id) or std.mem.eql(u8, model, route.wire_model)) {
+                return .{ .wire_model = route.wire_model, .endpoint = route.endpoint };
+            }
+        }
+        return error.OpenAICompatibleModelUnavailable;
+    }
+};
+
+pub fn provider(context: *const Context) stream_provider.Provider {
+    return .{
+        .context = @constCast(context),
+        .stream_fn = streamCompletion,
+    };
+}
+
+fn validateModel(model: []const u8) !void {
+    if (model.len == 0 or model.len > 1024) return error.InvalidOpenAICompatibleModel;
+    for (model) |byte| {
+        if (byte <= 0x20 or byte == 0x7f) return error.InvalidOpenAICompatibleModel;
+    }
+}
+
+pub fn buildRequest(
+    alloc: Allocator,
+    wire_model: []const u8,
+    request: stream_provider.RequestData,
+) ![]u8 {
+    try validateModel(wire_model);
+    if (request.budget) |budget| {
+        if (budget.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+    }
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    errdefer out.deinit();
+    const writer = &out.writer;
+    try writer.writeAll("{\"model\":");
+    try std.json.Stringify.value(wire_model, .{}, writer);
+    try writer.writeAll(",\"messages\":[");
+    var system_text: std.Io.Writer.Allocating = .init(alloc);
+    defer system_text.deinit();
+    for (request.messages) |message| {
+        if (message.role != .system) continue;
+        const content = message.content orelse continue;
+        if (content.len == 0) continue;
+        if (system_text.written().len > 0) try system_text.writer.writeAll("\n\n");
+        try system_text.writer.writeAll(content);
+    }
+    var wrote_message = false;
+    if (system_text.written().len > 0) {
+        try writer.writeAll("{\"role\":\"system\",\"content\":");
+        try std.json.Stringify.value(system_text.written(), .{}, writer);
+        try writer.writeByte('}');
+        wrote_message = true;
+    }
+    for (request.messages, 0..) |message, index| {
+        if (message.role == .system) continue;
+        if (wrote_message) try writer.writeByte(',');
+        try writeMessage(writer, alloc, message, index, request.messages.len, request.verified_images, request.budget);
+        wrote_message = true;
+    }
+    try writer.writeByte(']');
+
+    const tool_count = try writeTools(writer, alloc, request.tools);
+    if (tool_count > 0) {
+        try writer.writeAll(",\"tool_choice\":");
+        try std.json.Stringify.value(request.tool_choice.label(), .{}, writer);
+        try writer.writeAll(",\"parallel_tool_calls\":true");
+    }
+    if (request.max_output_tokens) |limit| try writer.print(",\"max_tokens\":{d}", .{limit});
+    if (request.provider_options.reasoning) |effort| {
+        try writer.writeAll(",\"reasoning_effort\":");
+        try std.json.Stringify.value(effort.label(), .{}, writer);
+    }
+    if (request.response_format) |format| {
+        if (format.schema != .object) return error.InvalidStructuredResponseSchema;
+        try writer.writeAll(",\"response_format\":{\"type\":\"json_schema\",\"json_schema\":{\"name\":");
+        try std.json.Stringify.value(format.name, .{}, writer);
+        try writer.writeAll(",\"description\":");
+        try std.json.Stringify.value(format.description, .{}, writer);
+        try writer.writeAll(",\"schema\":");
+        try std.json.Stringify.value(format.schema, .{}, writer);
+        try writer.writeAll(",\"strict\":true}}");
+    }
+    try writer.writeAll(",\"stream\":true,\"stream_options\":{\"include_usage\":true}}");
+    return out.toOwnedSlice();
+}
+
+fn writeMessage(
+    writer: *std.Io.Writer,
+    alloc: Allocator,
+    message: types.ChatMessage,
+    message_index: usize,
+    message_count: usize,
+    verified_images: ?[]const image_attachments.VerifiedSnapshot,
+    budget: ?stream_provider.BuildBudget,
+) !void {
+    try writer.writeAll("{\"role\":");
+    try std.json.Stringify.value(@tagName(message.role), .{}, writer);
+    switch (message.role) {
+        .system => {
+            try writer.writeAll(",\"content\":");
+            try std.json.Stringify.value(message.content orelse "", .{}, writer);
+        },
+        .user => {
+            const images = if (message_index + 1 == message_count) verified_images else null;
+            if (images == null or images.?.len == 0) {
+                try writer.writeAll(",\"content\":");
+                try std.json.Stringify.value(message.content orelse "", .{}, writer);
+            } else {
+                try writer.writeAll(",\"content\":[");
+                var wrote = false;
+                if (message.content) |content| if (content.len > 0) {
+                    try writer.writeAll("{\"type\":\"text\",\"text\":");
+                    try std.json.Stringify.value(content, .{}, writer);
+                    try writer.writeByte('}');
+                    wrote = true;
+                };
+                for (images.?) |image| {
+                    if (wrote) try writer.writeByte(',');
+                    try writeImage(writer, image, budget);
+                    wrote = true;
+                }
+                try writer.writeByte(']');
+            }
+        },
+        .assistant => {
+            try writer.writeAll(",\"content\":");
+            if (message.content) |content| {
+                try std.json.Stringify.value(content, .{}, writer);
+            } else {
+                try writer.writeAll("null");
+            }
+            if (message.tool_calls.len > max_tool_calls) return error.OpenAICompatibleToolCallLimitExceeded;
+            if (message.tool_calls.len > 0) {
+                try writer.writeAll(",\"tool_calls\":[");
+                for (message.tool_calls, 0..) |call, index| {
+                    if (call.id.len == 0 or call.id.len > max_tool_identity_bytes or
+                        call.name.len == 0 or call.name.len > max_tool_identity_bytes)
+                    {
+                        return error.OpenAICompatibleToolCallLimitExceeded;
+                    }
+                    if (call.arguments_json.len > max_tool_arguments_bytes) return error.OpenAICompatibleToolArgumentsTooLarge;
+                    if (index > 0) try writer.writeByte(',');
+                    try writer.writeAll("{\"id\":");
+                    try std.json.Stringify.value(call.id, .{}, writer);
+                    try writer.writeAll(",\"type\":\"function\",\"function\":{\"name\":");
+                    try std.json.Stringify.value(call.name, .{}, writer);
+                    try writer.writeAll(",\"arguments\":");
+                    try std.json.Stringify.value(call.arguments_json, .{}, writer);
+                    try writer.writeAll("}}");
+                }
+                try writer.writeByte(']');
+            }
+        },
+        .tool => {
+            try writer.writeAll(",\"tool_call_id\":");
+            try std.json.Stringify.value(message.tool_call_id orelse "", .{}, writer);
+            try writer.writeAll(",\"content\":");
+            try std.json.Stringify.value(message.content orelse "", .{}, writer);
+        },
+    }
+    try writer.writeByte('}');
+    _ = alloc;
+}
+
+fn writeImage(
+    writer: *std.Io.Writer,
+    image: image_attachments.VerifiedSnapshot,
+    budget: ?stream_provider.BuildBudget,
+) !void {
+    if (budget) |active| {
+        if (active.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+    }
+    try writer.writeAll("{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:");
+    try writer.writeAll(image.media_type);
+    try writer.writeAll(";base64,");
+    var offset: usize = 0;
+    while (offset < image.bytes.len) {
+        if (budget) |active| {
+            if (active.cancel_flag) |flag| if (flag.load(.seq_cst)) return error.Cancelled;
+        }
+        const end = @min(offset + 3 * 1024, image.bytes.len);
+        try std.base64.standard.Encoder.encodeWriter(writer, image.bytes[offset..end]);
+        offset = end;
+    }
+    try writer.writeAll("\"}}");
+}
+
+fn writeTools(writer: *std.Io.Writer, alloc: Allocator, tools: stream_provider.ToolSelection) !usize {
+    var scratch: std.Io.Writer.Allocating = .init(alloc);
+    defer scratch.deinit();
+    try scratch.writer.writeAll(",\"tools\":[");
+    var count: usize = 0;
+    for (tools.advertised_names) |name| {
+        const tool = tools.advertisedFunction(name) orelse continue;
+        if (count > 0) try scratch.writer.writeByte(',');
+        try writeStaticTool(&scratch.writer, alloc, tool);
+        count += 1;
+    }
+    for (tools.additional_functions) |tool| {
+        if (containsName(tools.advertised_names, tool.name)) continue;
+        if (count > 0) try scratch.writer.writeByte(',');
+        try writeStaticTool(&scratch.writer, alloc, tool);
+        count += 1;
+    }
+    for (tools.selected_dynamic) |tool| {
+        if (containsName(tools.advertised_names, tool.name)) continue;
+        if (count > 0) try scratch.writer.writeByte(',');
+        try scratch.writer.writeAll("{\"type\":\"function\",\"function\":{\"name\":");
+        try std.json.Stringify.value(tool.name, .{}, &scratch.writer);
+        try scratch.writer.writeAll(",\"description\":");
+        try model_tool_schema.writeCappedDescriptionJsonString(alloc, &scratch.writer, tool.description);
+        try scratch.writer.writeAll(",\"parameters\":");
+        try std.json.Stringify.value(tool.input_schema, .{}, &scratch.writer);
+        try scratch.writer.writeAll("}}");
+        count += 1;
+    }
+    try scratch.writer.writeByte(']');
+    if (count > 0) try writer.writeAll(scratch.written());
+    return count;
+}
+
+fn writeStaticTool(writer: *std.Io.Writer, alloc: Allocator, tool: model_tool_schema.FunctionSchema) !void {
+    try writer.writeAll("{\"type\":\"function\",\"function\":{\"name\":");
+    try std.json.Stringify.value(tool.name, .{}, writer);
+    try writer.writeAll(",\"description\":");
+    try model_tool_schema.writeCappedDescriptionJsonString(alloc, writer, tool.description);
+    try writer.writeAll(",\"parameters\":");
+    try model_tool_schema.writeObjectSchema(alloc, writer, tool.input_schema);
+    try writer.writeAll("}}");
+}
+
+fn containsName(names: []const []const u8, wanted: []const u8) bool {
+    for (names) |name| if (std.mem.eql(u8, name, wanted)) return true;
+    return false;
+}
+
+fn streamCompletion(raw: ?*anyopaque, alloc: Allocator, request: stream_provider.ModelRequest) !stream_provider.Result {
+    const context: *const Context = @ptrCast(@alignCast(raw.?));
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.credential.source != context.credential_source) return error.OpenAICompatibleCredentialRequired;
+    const route = try context.resolve(request.model);
+    const payload = try buildRequest(alloc, route.wire_model, request.data());
+    defer alloc.free(payload);
+    var result = streamPrepared(alloc, context, route.endpoint, request, payload) catch |err| {
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        if (requestDeadlineExpired(request)) return error.Timeout;
+        request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(err, request.delivery.load());
+        return err;
+    };
+    if (requestDeadlineExpired(request)) {
+        result.deinit(alloc);
+        return error.Timeout;
+    }
+    return result;
+}
+
+fn requestDeadlineExpired(request: stream_provider.ModelRequest) bool {
+    const deadline = request.deadline orelse return false;
+    const now = std.Io.Clock.Timestamp.now(io_mod.getIo(), .awake);
+    return !std.Io.Clock.Timestamp.compare(now, .lt, deadline);
+}
+
+const OpenedRequest = struct {
+    request: ?std.http.Client.Request,
+
+    pub fn deinit(self: *OpenedRequest, _: Allocator) void {
+        if (self.request) |*request| request.deinit();
+        self.request = null;
+    }
+
+    fn take(self: *OpenedRequest) std.http.Client.Request {
+        const request = self.request.?;
+        self.request = null;
+        return request;
+    }
+};
+
+const OpenRequestOperation = struct {
+    client: *std.http.Client,
+    uri: std.Uri,
+    auth_header: ?[]const u8,
+    extra_headers: []const std.http.Header,
+
+    pub fn run(self: *@This()) !OpenedRequest {
+        return .{ .request = try self.client.request(.POST, self.uri, .{
+            .headers = .{
+                .content_type = .{ .override = "application/json" },
+                .authorization = if (self.auth_header) |value| .{ .override = value } else .omit,
+                .accept_encoding = .omit,
+                .user_agent = .{ .override = gateway_client.user_agent },
+            },
+            .extra_headers = self.extra_headers,
+            .keep_alive = false,
+            .redirect_behavior = .unhandled,
+        }) };
+    }
+};
+
+fn streamPrepared(
+    alloc: Allocator,
+    context: *const Context,
+    endpoint: []const u8,
+    request: stream_provider.ModelRequest,
+    payload: []const u8,
+) !stream_provider.Result {
+    const uri = try std.Uri.parse(endpoint);
+    var auth_header: ?[]u8 = null;
+    defer if (auth_header) |value| secret.zeroAndFree(alloc, value);
+    var extra_headers_buf: [3]std.http.Header = undefined;
+    var extra_count: usize = 0;
+    extra_headers_buf[extra_count] = .{ .name = "accept", .value = "text/event-stream" };
+    extra_count += 1;
+    switch (context.auth) {
+        .bearer => auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.credential.secret}),
+        .modal_proxy => {
+            const token_id = request.credential.account_id orelse return error.ModalProxyTokenIdRequired;
+            extra_headers_buf[extra_count] = .{ .name = "Modal-Key", .value = token_id };
+            extra_count += 1;
+            extra_headers_buf[extra_count] = .{ .name = "Modal-Secret", .value = request.credential.secret };
+            extra_count += 1;
+        },
+    }
+
+    var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
+    defer client.deinit();
+    var operation = OpenRequestOperation{
+        .client = &client,
+        .uri = uri,
+        .auth_header = auth_header,
+        .extra_headers = extra_headers_buf[0..extra_count],
+    };
+    var connect_deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
+        .clock = .awake,
+        .raw = .fromMilliseconds(connect_timeout_ms),
+    });
+    if (request.deadline) |deadline| if (std.Io.Clock.Timestamp.compare(deadline, .lt, connect_deadline)) {
+        connect_deadline = deadline;
+    };
+    try request.admission.admit();
+    var opened = try gateway_client.runBoundedHttpOperation(
+        OpenedRequest,
+        alloc,
+        request.cancel_flag,
+        connect_deadline,
+        &operation,
+    );
+    var http_request = opened.take();
+    defer http_request.deinit();
+
+    var cancel_watch_done = std.atomic.Value(bool).init(false);
+    const cancel_watcher = if (http_request.connection) |connection|
+        if (request.deadline) |deadline|
+            try gateway_client.spawnHttpCancelWatcherBounded(&cancel_watch_done, request.cancel_flag, deadline, connection.stream_writer.stream)
+        else
+            try gateway_client.spawnHttpCancelWatcher(&cancel_watch_done, request.cancel_flag, connection.stream_writer.stream)
+    else
+        null;
+    defer {
+        cancel_watch_done.store(true, .seq_cst);
+        if (cancel_watcher) |thread| thread.join();
+    }
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    http_request.transfer_encoding = .{ .content_length = payload.len };
+    var send_buffer: [8192]u8 = undefined;
+    request.delivery.markPossiblySent();
+    var body_writer = try http_request.sendBodyUnflushed(&send_buffer);
+    try body_writer.writer.writeAll(payload);
+    try body_writer.end();
+    if (http_request.connection) |connection| try connection.flush();
+    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+
+    var response = try http_request.receiveHead(&.{});
+    if (response.head.status != .ok) {
+        var transfer: [16 * 1024]u8 = undefined;
+        const reader = response.reader(&transfer);
+        const body = reader.allocRemaining(alloc, .limited(max_error_body_bytes)) catch |err| switch (err) {
+            error.StreamTooLong => try alloc.dupe(u8, "provider error response exceeded the local limit"),
+            else => return err,
+        };
+        return .{ .failed = .{
+            .kind = failureKind(response.head.status),
+            .detail = body,
+            .ownership = .owned,
+        } };
+    }
+
+    var transfer_buffer: [transfer_buffer_bytes]u8 = undefined;
+    const reader = response.reader(&transfer_buffer);
+    const completion = try consumeSse(alloc, reader, request);
+    errdefer {
+        var owned = stream_provider.Result{ .completed = .{
+            .completion = completion,
+            .ownership = .owned,
+        } };
+        owned.deinit(alloc);
+    }
+    return .{ .completed = .{
+        .completion = completion,
+        .usage = .{ .unavailable = .possibly_billed },
+        .ownership = .owned,
+    } };
+}
+
+fn failureKind(status: std.http.Status) stream_provider.FailureKind {
+    return switch (status) {
+        .bad_request => .invalid_request,
+        .unauthorized => .unauthorized,
+        .forbidden => .forbidden,
+        .payload_too_large => .request_too_large,
+        .too_many_requests => .rate_limited,
+        .internal_server_error => .server_error,
+        .bad_gateway => .bad_gateway,
+        .service_unavailable => .unavailable,
+        .gateway_timeout => .gateway_timeout,
+        else => .provider_error,
+    };
+}
+
+const SseReader = struct {
+    pending_line: std.ArrayList(u8) = .empty,
+    aggregate_bytes: usize = 0,
+
+    fn deinit(self: *SseReader, alloc: Allocator) void {
+        self.pending_line.deinit(alloc);
+    }
+
+    fn release(self: *SseReader) void {
+        self.pending_line.clearRetainingCapacity();
+    }
+
+    fn next(self: *SseReader, alloc: Allocator, reader: anytype) !?[]const u8 {
+        while (true) {
+            const line = try self.readLine(alloc, reader) orelse return null;
+            self.aggregate_bytes = std.math.add(usize, self.aggregate_bytes, line.wire_bytes) catch
+                return error.OpenAICompatibleResourceLimitExceeded;
+            if (self.aggregate_bytes > max_sse_aggregate_bytes) return error.OpenAICompatibleResourceLimitExceeded;
+            const trimmed = std.mem.trim(u8, line.bytes, " \t\r");
+            if (trimmed.len == 0 or trimmed[0] == ':') {
+                self.release();
+                continue;
+            }
+            if (!std.mem.startsWith(u8, trimmed, "data:")) {
+                self.release();
+                continue;
+            }
+            const data = std.mem.trim(u8, trimmed["data:".len..], " \t");
+            if (std.mem.eql(u8, data, "[DONE]")) return null;
+            return data;
+        }
+    }
+
+    const Line = struct { bytes: []const u8, wire_bytes: usize };
+
+    fn readLine(self: *SseReader, alloc: Allocator, reader: anytype) !?Line {
+        while (true) {
+            const fragment = reader.takeDelimiter('\n') catch |err| switch (err) {
+                error.StreamTooLong => {
+                    const buffered = reader.buffered();
+                    if (buffered.len == 0) return error.OpenAICompatibleSseReadStalled;
+                    if (buffered.len > max_sse_line_bytes - self.pending_line.items.len) return error.OpenAICompatibleSseEventTooLarge;
+                    try self.pending_line.appendSlice(alloc, buffered);
+                    reader.tossBuffered();
+                    continue;
+                },
+                error.ReadFailed => return error.ReadFailed,
+            } orelse {
+                if (self.pending_line.items.len > 0) return .{ .bytes = self.pending_line.items, .wire_bytes = self.pending_line.items.len };
+                return null;
+            };
+            if (fragment.len > max_sse_line_bytes - self.pending_line.items.len) return error.OpenAICompatibleSseEventTooLarge;
+            if (self.pending_line.items.len == 0) return .{ .bytes = fragment, .wire_bytes = fragment.len + 1 };
+            try self.pending_line.appendSlice(alloc, fragment);
+            return .{ .bytes = self.pending_line.items, .wire_bytes = self.pending_line.items.len + 1 };
+        }
+    }
+};
+
+const ToolAccumulator = struct {
+    id: std.ArrayList(u8) = .empty,
+    name: std.ArrayList(u8) = .empty,
+    arguments: std.ArrayList(u8) = .empty,
+    started: bool = false,
+
+    fn deinit(self: *ToolAccumulator, alloc: Allocator) void {
+        self.id.deinit(alloc);
+        self.name.deinit(alloc);
+        self.arguments.deinit(alloc);
+    }
+};
+
+const Reducer = struct {
+    content: std.ArrayList(u8) = .empty,
+    tools: std.ArrayList(ToolAccumulator) = .empty,
+    generation_id: ?[]u8 = null,
+    finish_reason: ?types.ProviderFinishReason = null,
+    usage: types.Usage = .{},
+    events_seen: usize = 0,
+
+    fn deinit(self: *Reducer, alloc: Allocator) void {
+        self.content.deinit(alloc);
+        for (self.tools.items) |*tool| tool.deinit(alloc);
+        self.tools.deinit(alloc);
+        if (self.generation_id) |id| alloc.free(id);
+    }
+
+    fn ensureTool(self: *Reducer, alloc: Allocator, index: usize) !*ToolAccumulator {
+        if (index >= max_tool_calls) return error.OpenAICompatibleToolCallLimitExceeded;
+        while (self.tools.items.len <= index) try self.tools.append(alloc, .{});
+        return &self.tools.items[index];
+    }
+
+    fn apply(self: *Reducer, alloc: Allocator, json_text: []const u8, request: stream_provider.ModelRequest) !void {
+        self.events_seen += 1;
+        if (self.events_seen > max_sse_events) return error.OpenAICompatibleResourceLimitExceeded;
+        var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch
+            return error.InvalidOpenAICompatibleSseEvent;
+        defer parsed.deinit();
+        if (parsed.value != .object) return error.InvalidOpenAICompatibleSseEvent;
+        const root = parsed.value.object;
+        if (root.get("error") != null) return error.OpenAICompatibleResponseFailed;
+        if (self.generation_id == null) if (root.get("id")) |id| if (id == .string and id.string.len > 0) {
+            self.generation_id = try alloc.dupe(u8, id.string);
+        };
+        if (root.get("usage")) |usage| {
+            if (usage == .object) self.usage = parseUsage(usage.object);
+        }
+        const choices = root.get("choices") orelse return;
+        if (choices != .array) return error.InvalidOpenAICompatibleSseEvent;
+        for (choices.array.items) |choice| {
+            if (choice != .object) return error.InvalidOpenAICompatibleSseEvent;
+            if (choice.object.get("delta")) |delta| {
+                if (delta != .object) return error.InvalidOpenAICompatibleSseEvent;
+                try self.applyDelta(alloc, delta.object, request);
+            }
+            if (choice.object.get("finish_reason")) |finish_value| {
+                if (finish_value == .string and finish_value.string.len > 0) {
+                    self.finish_reason = types.ProviderFinishReason.parse_legacy(finish_value.string) orelse .other;
+                }
+            }
+        }
+    }
+
+    fn applyDelta(self: *Reducer, alloc: Allocator, delta: std.json.ObjectMap, request: stream_provider.ModelRequest) !void {
+        if (delta.get("content")) |content| if (content == .string and content.string.len > 0) {
+            request.events.emit(.{ .content_delta = content.string });
+            const limit = request.content_capture_limit orelse std.math.maxInt(usize);
+            const remaining = limit -| self.content.items.len;
+            try self.content.appendSlice(alloc, content.string[0..@min(remaining, content.string.len)]);
+        };
+        for ([_][]const u8{ "reasoning_content", "reasoning" }) |key| {
+            if (delta.get(key)) |reasoning| if (reasoning == .string and reasoning.string.len > 0) {
+                request.events.emit(.{ .reasoning_delta = reasoning.string });
+                break;
+            };
+        }
+        const calls = delta.get("tool_calls") orelse return;
+        if (calls == .null) return;
+        if (calls != .array) return error.InvalidOpenAICompatibleSseEvent;
+        for (calls.array.items) |item| {
+            if (item != .object) return error.InvalidOpenAICompatibleSseEvent;
+            const index_value = item.object.get("index") orelse return error.InvalidOpenAICompatibleSseEvent;
+            if (index_value != .integer or index_value.integer < 0) return error.InvalidOpenAICompatibleSseEvent;
+            const index = std.math.cast(usize, index_value.integer) orelse return error.InvalidOpenAICompatibleSseEvent;
+            const tool = try self.ensureTool(alloc, index);
+            if (item.object.get("id")) |id| if (id == .string) {
+                if (id.string.len > max_tool_identity_bytes - tool.id.items.len) return error.OpenAICompatibleToolCallLimitExceeded;
+                try tool.id.appendSlice(alloc, id.string);
+            };
+            if (item.object.get("function")) |function| {
+                if (function != .object) return error.InvalidOpenAICompatibleSseEvent;
+                if (function.object.get("name")) |name| if (name == .string) {
+                    if (name.string.len > max_tool_identity_bytes - tool.name.items.len) return error.OpenAICompatibleToolCallLimitExceeded;
+                    try tool.name.appendSlice(alloc, name.string);
+                };
+                if (!tool.started and tool.id.items.len > 0 and tool.name.items.len > 0) {
+                    request.events.emit(.{ .tool_started = .{ .id = tool.id.items, .name = tool.name.items } });
+                    tool.started = true;
+                }
+                if (function.object.get("arguments")) |arguments| if (arguments == .string and arguments.string.len > 0) {
+                    if (arguments.string.len > max_tool_arguments_bytes - tool.arguments.items.len) return error.OpenAICompatibleToolArgumentsTooLarge;
+                    try tool.arguments.appendSlice(alloc, arguments.string);
+                    request.events.emit(.{ .tool_input_delta = arguments.string });
+                };
+            }
+        }
+    }
+
+    fn finish(self: *Reducer, alloc: Allocator, request: stream_provider.ModelRequest) !types.ModelCompletion {
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        const owned_tools = try alloc.alloc(types.ToolCall, self.tools.items.len);
+        var count: usize = 0;
+        errdefer {
+            types.freeToolCallSlice(alloc, owned_tools[0..count]);
+            if (count < owned_tools.len) alloc.free(owned_tools);
+        }
+        for (self.tools.items) |*tool| {
+            if (tool.id.items.len == 0 or tool.name.items.len == 0) return error.InvalidOpenAICompatibleSseEvent;
+            if (!tool.started) request.events.emit(.{ .tool_started = .{ .id = tool.id.items, .name = tool.name.items } });
+            const arguments = if (tool.arguments.items.len == 0) "{}" else tool.arguments.items;
+            if (try types.ToolArgumentIntegrity.classifySerialized(alloc, arguments) == .malformed_json) {
+                return error.InvalidOpenAICompatibleToolArguments;
+            }
+            owned_tools[count] = .{
+                .id = try alloc.dupe(u8, tool.id.items),
+                .name = try alloc.dupe(u8, tool.name.items),
+                .arguments_json = try alloc.dupe(u8, arguments),
+            };
+            count += 1;
+        }
+        const content = if (self.content.items.len > 0) try self.content.toOwnedSlice(alloc) else null;
+        errdefer if (content) |value| alloc.free(value);
+        const generation_id = self.generation_id;
+        self.generation_id = null;
+        return .{
+            .content = content,
+            .tool_calls = owned_tools,
+            .generation_id = generation_id,
+            .finish_reason = self.finish_reason orelse if (owned_tools.len > 0) .tool_calls else .stop,
+            .usage = self.usage,
+        };
+    }
+};
+
+fn parseUsage(object: std.json.ObjectMap) types.Usage {
+    var usage: types.Usage = .{};
+    usage.input_tokens = optionalUnsigned(object.get("prompt_tokens"));
+    usage.output_tokens = optionalUnsigned(object.get("completion_tokens"));
+    if (object.get("prompt_tokens_details")) |details| if (details == .object) {
+        usage.cache_read_tokens = optionalUnsigned(details.object.get("cached_tokens"));
+    };
+    if (object.get("completion_tokens_details")) |details| if (details == .object) {
+        usage.reasoning_tokens = optionalUnsigned(details.object.get("reasoning_tokens"));
+    };
+    if (usage.reasoning_tokens == null) usage.reasoning_tokens = optionalUnsigned(object.get("reasoning_tokens"));
+    return usage;
+}
+
+fn optionalUnsigned(value: ?std.json.Value) ?u64 {
+    const actual = value orelse return null;
+    if (actual != .integer or actual.integer < 0) return null;
+    return std.math.cast(u64, actual.integer);
+}
+
+fn consumeSse(alloc: Allocator, reader: anytype, request: stream_provider.ModelRequest) !types.ModelCompletion {
+    var reducer: Reducer = .{};
+    defer reducer.deinit(alloc);
+    var sse: SseReader = .{};
+    defer sse.deinit(alloc);
+    while (try sse.next(alloc, reader)) |json_text| {
+        defer sse.release();
+        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        if (request.cooperative_pulse) |pulse| try pulse.pulse();
+        try reducer.apply(alloc, json_text, request);
+    }
+    return reducer.finish(alloc, request);
+}
+
+test "OpenAI compatible request serializes messages tools and images" {
+    const tool = model_tool_schema.FunctionSchema{
+        .name = "read_file",
+        .description = "Read a file",
+        .input_schema = .{
+            .properties = &.{.{ .name = "path", .json_type = .string }},
+            .required = &.{"path"},
+            .additional_properties = false,
+        },
+    };
+    const messages = [_]types.ChatMessage{
+        .{ .role = .system, .content = "Be concise." },
+        .{ .role = .assistant, .tool_calls = &.{.{ .id = "call_1", .name = "read_file", .arguments_json = "{\"path\":\"README.md\"}" }} },
+        .{ .role = .tool, .tool_call_id = "call_1", .tool_name = "read_file", .content = "contents" },
+        .{ .role = .user, .content = "Continue." },
+    };
+    const body = try buildRequest(std.testing.allocator, "served/model", .{
+        .model = "alias",
+        .messages = &messages,
+        .tools = .{ .additional_functions = &.{tool} },
+        .tool_choice = .auto,
+        .provider_options = .{},
+    });
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(std.mem.find(u8, body, "\"model\":\"served/model\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"tool_calls\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"parameters\"") != null);
+    try std.testing.expect(std.mem.find(u8, body, "\"stream_options\":{\"include_usage\":true}") != null);
+}
+
+test "OpenAI compatible reducer maps text reasoning tools and usage" {
+    const Capture = struct {
+        content: std.ArrayList(u8) = .empty,
+        reasoning: std.ArrayList(u8) = .empty,
+        tool_name: std.ArrayList(u8) = .empty,
+        tool_input: std.ArrayList(u8) = .empty,
+
+        fn emit(raw: *anyopaque, event: stream_provider.Event) void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            switch (event) {
+                .content_delta => |value| self.content.appendSlice(std.testing.allocator, value) catch unreachable,
+                .reasoning_delta => |value| self.reasoning.appendSlice(std.testing.allocator, value) catch unreachable,
+                .tool_started => |value| self.tool_name.appendSlice(std.testing.allocator, value.name) catch unreachable,
+                .tool_input_delta => |value| self.tool_input.appendSlice(std.testing.allocator, value) catch unreachable,
+            }
+        }
+    };
+    var capture: Capture = .{};
+    defer capture.content.deinit(std.testing.allocator);
+    defer capture.reasoning.deinit(std.testing.allocator);
+    defer capture.tool_name.deinit(std.testing.allocator);
+    defer capture.tool_input.deinit(std.testing.allocator);
+    var cancel = std.atomic.Value(bool).init(false);
+    var delivery = stream_provider.DeliveryCertainty.init();
+    var evidence: stream_provider.AttemptEvidence = .{};
+    var reducer: Reducer = .{};
+    defer reducer.deinit(std.testing.allocator);
+    const request = stream_provider.ModelRequest{
+        .credential = .{ .secret = "key" },
+        .model = "model",
+        .retry_count = 0,
+        .messages = &.{},
+        .tool_choice = .auto,
+        .provider_options = .{},
+        .trace_ctx = .{},
+        .content_capture_limit = null,
+        .delivery = &delivery,
+        .attempt_evidence = &evidence,
+        .events = .{ .context = &capture, .emit_fn = Capture.emit },
+        .cancel_flag = &cancel,
+    };
+    try reducer.apply(std.testing.allocator, "{\"id\":\"chatcmpl_1\",\"choices\":[{\"delta\":{\"reasoning_content\":\"think\",\"content\":\"hello\",\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\"}}]},\"finish_reason\":null}]}", request);
+    try reducer.apply(std.testing.allocator, "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"README.md\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":4}}", request);
+    const completion = try reducer.finish(std.testing.allocator, request);
+    defer {
+        if (completion.content) |content| std.testing.allocator.free(@constCast(content));
+        if (completion.generation_id) |id| std.testing.allocator.free(@constCast(id));
+        types.freeToolCallSlice(std.testing.allocator, @constCast(completion.tool_calls));
+    }
+    try std.testing.expectEqualStrings("hello", capture.content.items);
+    try std.testing.expectEqualStrings("think", capture.reasoning.items);
+    try std.testing.expectEqualStrings("read_file", capture.tool_name.items);
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", capture.tool_input.items);
+    try std.testing.expectEqualStrings("{\"path\":\"README.md\"}", completion.tool_calls[0].arguments_json);
+    try std.testing.expectEqual(@as(?u64, 10), completion.usage.input_tokens);
+    try std.testing.expectEqual(types.ProviderFinishReason.tool_calls, completion.finish_reason.?);
+}

--- a/src/ui/footer/model_menu_presentation.zig
+++ b/src/ui/footer/model_menu_presentation.zig
@@ -418,6 +418,8 @@ fn loadedCatalogStatusText(state: model_cache_runtime.ModelMenuCatalogState) ?[]
             .stored_key => "Gateway catalog: authenticated with the stored API key.",
             .chatgpt_subscription => "Codex catalog: authenticated with a subscription.",
             .grok_subscription => "Grok catalog: authenticated with a subscription.",
+            .fireworks_api_key => "Fireworks catalog: authenticated with FIREWORKS_API_KEY.",
+            .modal_proxy_token => "Modal catalog: authenticated with the proxy token.",
         };
     }
     return null;

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -2061,7 +2061,7 @@ test "auth picker renders the staged switch and disabled team screens" {
         .stage = .provider,
     };
     const provider_rows = authPickerRowCount(provider_view);
-    try std.testing.expectEqual(@as(u16, 5), provider_rows);
+    try std.testing.expectEqual(@as(u16, 7), provider_rows);
     var provider_header = try composeAuthPickerRow(alloc, provider_view, 0, provider_rows, 80);
     defer provider_header.deinit(alloc);
     try std.testing.expect(std.mem.startsWith(u8, provider_header.items, ui_render.dim_style));

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -3024,24 +3024,22 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
 
       await session.sendLiteralText(`/model ${selectedModel}`);
       await session.sendKeys("Enter");
-      let effortPane = await session.waitForPane(
+      const effortPane = await session.waitForPane(
         (current) =>
           composerContains(current, `/model ${selectedModel}`) &&
-          current.includes("minimal") &&
-          current.includes("high"),
+          current.includes("low") &&
+          current.includes("high") &&
+          current.includes("max"),
         10_000,
       );
-      for (const effort of ["default", "none", "minimal", "low", "medium", "high"]) {
+      for (const effort of ["default", "low", "high", "max"]) {
         expect(effortPane).toContain(effort);
       }
+      for (const unsupported of ["none", "minimal", "medium", "xhigh"]) {
+        expect(effortPane).not.toContain(unsupported);
+      }
 
-      for (let index = 0; index < 6; index += 1) await session.sendKeys("Down");
-      effortPane = await session.waitForText("xhigh", 5_000);
-      expect(effortPane).toContain("xhigh");
-      await session.sendKeys("Down");
-      effortPane = await session.waitForText("max", 5_000);
-      expect(effortPane).toContain("max");
-      await session.sendKeys("Up");
+      for (let index = 0; index < 3; index += 1) await session.sendKeys("Down");
       await session.sendKeys("Enter");
       await session.waitForPane(hasEmptyComposer, 5_000);
 
@@ -3049,7 +3047,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
         effort?: string;
         models?: { modal?: string };
       };
-      expect(settings.effort).toBe("xhigh");
+      expect(settings.effort).toBe("max");
       expect(settings.models?.modal).toBe(selectedModel);
       expect(session.isAlive()).toBe(true);
       expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -2995,6 +2995,150 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
   );
 
   test(
+    "Modal GLM model picker exposes provider-specific reasoning efforts",
+    async () => {
+      const fixture = createModelsMenuFixture();
+      const selectedModel = "glm-5-3-flash";
+      session = await TmuxSession.create({
+        cwd: fixture.workspace,
+        stderrPath: fixture.stderrPath,
+        env: {
+          HOME: fixture.home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_PROVIDER: "modal",
+          FX_MODEL: selectedModel,
+          MODAL_PROXY_TOKEN_ID: "fake-modal-token-id",
+          MODAL_PROXY_TOKEN_SECRET: "fake-modal-token-secret",
+          FX_AUTO_UPGRADE: "0",
+        },
+        width: 120,
+        height: 32,
+      });
+      await session.waitForComposer(10_000);
+
+      await session.sendText("/model");
+      await waitForModelsMenu(session, 4);
+      await session.sendKeys("Escape");
+      await session.waitForPane(hasEmptyComposer, 5_000);
+
+      await session.sendLiteralText(`/model ${selectedModel}`);
+      await session.sendKeys("Enter");
+      let effortPane = await session.waitForPane(
+        (current) =>
+          composerContains(current, `/model ${selectedModel}`) &&
+          current.includes("minimal") &&
+          current.includes("high"),
+        10_000,
+      );
+      for (const effort of ["default", "none", "minimal", "low", "medium", "high"]) {
+        expect(effortPane).toContain(effort);
+      }
+
+      for (let index = 0; index < 6; index += 1) await session.sendKeys("Down");
+      effortPane = await session.waitForText("xhigh", 5_000);
+      expect(effortPane).toContain("xhigh");
+      await session.sendKeys("Down");
+      effortPane = await session.waitForText("max", 5_000);
+      expect(effortPane).toContain("max");
+      await session.sendKeys("Up");
+      await session.sendKeys("Enter");
+      await session.waitForPane(hasEmptyComposer, 5_000);
+
+      const settings = JSON.parse(readFileSync(fixture.settingsPath, "utf8")) as {
+        effort?: string;
+        models?: { modal?: string };
+      };
+      expect(settings.effort).toBe("xhigh");
+      expect(settings.models?.modal).toBe(selectedModel);
+      expect(session.isAlive()).toBe(true);
+      expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      session = null;
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
+    "Fireworks GLM model picker exposes the verified Fireworks effort set",
+    async () => {
+      const fixture = createModelsMenuFixture();
+      const selectedModel = "accounts/fireworks/models/glm-5p3-flash";
+      gateway = startFakeGateway([], {
+        models: () => Response.json({
+          data: [{
+            id: selectedModel,
+            kind: "HF_BASE_MODEL",
+            supports_chat: true,
+            supports_tools: true,
+          }],
+        }),
+      });
+      session = await TmuxSession.create({
+        cwd: fixture.workspace,
+        stderrPath: fixture.stderrPath,
+        env: {
+          HOME: fixture.home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_PROVIDER: "fireworks",
+          FX_MODEL: selectedModel,
+          FIREWORKS_API_KEY: "fake-fireworks-key",
+          FX_E2E_FIREWORKS_MODELS_URL: `${gateway.baseUrl}/coding-agent/v1/models`,
+          FX_AUTO_UPGRADE: "0",
+        },
+        width: 120,
+        height: 32,
+      });
+      await session.waitForComposer(10_000);
+
+      await session.sendText("/model");
+      await waitForModelsMenu(session, 1);
+      await session.sendKeys("Escape");
+      await session.waitForPane(hasEmptyComposer, 5_000);
+
+      await session.sendLiteralText(`/model ${selectedModel}`);
+      await session.sendKeys("Enter");
+      const effortPane = await session.waitForPane(
+        (current) =>
+          composerContains(current, `/model ${selectedModel}`) &&
+          current.includes("xhigh") &&
+          current.includes("max"),
+        10_000,
+      );
+      for (const effort of ["default", "low", "medium", "high", "xhigh", "max"]) {
+        expect(effortPane).toContain(effort);
+      }
+      expect(effortPane).not.toContain("minimal");
+      expect(effortPane).not.toContain("adaptive");
+
+      await session.sendLiteralText("xhigh");
+      await session.sendKeys("Enter");
+      await session.waitForPane(hasEmptyComposer, 5_000);
+
+      const settings = JSON.parse(readFileSync(fixture.settingsPath, "utf8")) as {
+        effort?: string;
+        models?: { fireworks?: string };
+      };
+      expect(settings.effort).toBe("xhigh");
+      expect(settings.models?.fireworks).toBe(selectedModel);
+      expect(gateway.modelRequests).toHaveLength(1);
+      expect(gateway.modelRequests[0]!.headers.get("authorization")).toBe(
+        "Bearer fake-fireworks-key",
+      );
+      expect(session.isAlive()).toBe(true);
+      expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(TIMEOUT)).toBe(true);
+      session = null;
+    },
+    TEST_TIMEOUT,
+  );
+
+  test(
     "skills catalog retains input ownership for global view shortcuts",
     async () => {
       const fixture = createSkillsMenuFixture();


### PR DESCRIPTION
## Summary

- add first-class Fireworks and Modal provider routes
- discover the authenticated Fireworks model catalog and expose four configured Modal endpoints
- keep model preferences separate per provider and support process-scoped `FX_PROVIDER` selection
- expose Fireworks-validated tiers and each Modal model's native reasoning tiers through the existing `/model` second-stage picker and `/settings`
- preserve streaming text, reasoning, images, structured output, and tool calls through an OpenAI-compatible transport

## Validation

- `zig fmt --check src/`
- `git diff --check`
- `zig build`
- `umask 022; zig build test`
- `bun test ./tui-slash-menu.test.ts --test-name-pattern "Modal GLM|Fireworks GLM"`
- raw Fireworks catalog and one-token inference probes, including an invalid-tier negative control
- Modal native-tier verification against model documentation and endpoint tokenization
- installed Superset launcher smoke tests for both Modal and Fireworks presets
- live Fireworks Kimi K3 text and `read_file` tool calls
- live Modal GLM-5.3-Flash text and `read_file` tool calls