### PR TITLE
Preserve visible approval input ownership

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1403,20 +1403,20 @@ pub fn Runtime(comptime App: type) type {
             if (!app.approval_prompt.isActive()) return false;
             if (!app.subagents.isViewActive()) return true;
             const request = app.approval_prompt.request orelse return false;
-            if (comptime @hasField(App, "approval_screen")) {
-                if (app.approval_screen.screen_commit) |commit| {
-                    // Once this exact approval is visible, its input ownership
-                    // survives a transient subagent projection refresh.
-                    if (commit.request_id == request.id) return true;
-                }
-            }
             if (comptime !@hasDecl(@TypeOf(app.subagents), "childRouteId") or
                 !@hasDecl(@TypeOf(app.subagents), "mainApprovalBinding"))
             {
                 return true;
             }
-            const child_id = app.subagents.childRouteId() orelse return false;
             const binding = app.subagents.mainApprovalBinding(request.id) orelse return false;
+            if (comptime @hasField(App, "approval_screen")) {
+                if (app.approval_screen.screen_commit) |commit| {
+                    // A committed, still-resolvable approval keeps ownership
+                    // while the selected child route refreshes.
+                    if (commit.request_id == request.id) return true;
+                }
+            }
+            const child_id = app.subagents.childRouteId() orelse return false;
             return std.mem.eql(u8, binding.child_id, child_id);
         }
 
@@ -10625,6 +10625,10 @@ test "committed child approval owns input while its refreshed binding catches up
         .changed_or_notice_visible = true,
         .document_scrollable = false,
     });
+    try std.testing.expect(
+        !Runtime(ApprovalOwnershipApp).approvalOwnsCurrentSurface(&app),
+    );
+    app.subagents.binding = .{ .child_id = "approval-child" };
     try std.testing.expect(
         Runtime(ApprovalOwnershipApp).approvalOwnsCurrentSurface(&app),
     );

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1408,14 +1408,23 @@ pub fn Runtime(comptime App: type) type {
             {
                 return true;
             }
-            const binding = app.subagents.mainApprovalBinding(request.id) orelse return false;
-            if (comptime @hasField(App, "approval_screen")) {
-                if (app.approval_screen.screen_commit) |commit| {
-                    // A committed, still-resolvable approval keeps ownership
-                    // while the selected child route refreshes.
-                    if (commit.request_id == request.id) return true;
+            const committed = if (comptime @hasField(App, "approval_screen"))
+                if (app.approval_screen.screen_commit) |commit|
+                    commit.request_id == request.id
+                else
+                    false
+            else
+                false;
+            var maybe_binding = app.subagents.mainApprovalBinding(request.id);
+            if (maybe_binding == null and committed) {
+                if (comptime @hasDecl(@TypeOf(app.subagents), "mainApprovalCardBinding")) {
+                    maybe_binding = app.subagents.mainApprovalCardBinding(request.id);
                 }
             }
+            const binding = maybe_binding orelse return false;
+            // The current card remains resolvable while its presented flag and
+            // selected child route catch up with the committed approval screen.
+            if (committed) return true;
             const child_id = app.subagents.childRouteId() orelse return false;
             return std.mem.eql(u8, binding.child_id, child_id);
         }
@@ -10580,7 +10589,8 @@ const ApprovalOwnershipBinding = struct {
 const ApprovalOwnershipSubagents = struct {
     view_active: bool = true,
     child_id: []const u8 = "selected-child",
-    binding: ?ApprovalOwnershipBinding = null,
+    presented_binding: ?ApprovalOwnershipBinding = null,
+    card_binding: ?ApprovalOwnershipBinding = null,
 
     pub fn isViewActive(self: *const ApprovalOwnershipSubagents) bool {
         return self.view_active;
@@ -10594,7 +10604,14 @@ const ApprovalOwnershipSubagents = struct {
         self: *const ApprovalOwnershipSubagents,
         _: u64,
     ) ?ApprovalOwnershipBinding {
-        return self.binding;
+        return self.presented_binding;
+    }
+
+    pub fn mainApprovalCardBinding(
+        self: *const ApprovalOwnershipSubagents,
+        _: u64,
+    ) ?ApprovalOwnershipBinding {
+        return self.card_binding;
     }
 };
 
@@ -10628,7 +10645,7 @@ test "committed child approval owns input while its refreshed binding catches up
     try std.testing.expect(
         !Runtime(ApprovalOwnershipApp).approvalOwnsCurrentSurface(&app),
     );
-    app.subagents.binding = .{ .child_id = "approval-child" };
+    app.subagents.card_binding = .{ .child_id = "approval-child" };
     try std.testing.expect(
         Runtime(ApprovalOwnershipApp).approvalOwnsCurrentSurface(&app),
     );

--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1402,13 +1402,20 @@ pub fn Runtime(comptime App: type) type {
         fn approvalOwnsCurrentSurface(app: *const App) bool {
             if (!app.approval_prompt.isActive()) return false;
             if (!app.subagents.isViewActive()) return true;
+            const request = app.approval_prompt.request orelse return false;
+            if (comptime @hasField(App, "approval_screen")) {
+                if (app.approval_screen.screen_commit) |commit| {
+                    // Once this exact approval is visible, its input ownership
+                    // survives a transient subagent projection refresh.
+                    if (commit.request_id == request.id) return true;
+                }
+            }
             if (comptime !@hasDecl(@TypeOf(app.subagents), "childRouteId") or
                 !@hasDecl(@TypeOf(app.subagents), "mainApprovalBinding"))
             {
                 return true;
             }
             const child_id = app.subagents.childRouteId() orelse return false;
-            const request = app.approval_prompt.request orelse return false;
             const binding = app.subagents.mainApprovalBinding(request.id) orelse return false;
             return std.mem.eql(u8, binding.child_id, child_id);
         }
@@ -10564,6 +10571,63 @@ fn installReadyRoutingFileApproval(app: *RoutingFakeApp) !void {
         .changed_or_notice_visible = true,
         .document_scrollable = true,
     });
+}
+
+const ApprovalOwnershipBinding = struct {
+    child_id: []const u8,
+};
+
+const ApprovalOwnershipSubagents = struct {
+    view_active: bool = true,
+    child_id: []const u8 = "selected-child",
+    binding: ?ApprovalOwnershipBinding = null,
+
+    pub fn isViewActive(self: *const ApprovalOwnershipSubagents) bool {
+        return self.view_active;
+    }
+
+    pub fn childRouteId(self: *const ApprovalOwnershipSubagents) ?[]const u8 {
+        return self.child_id;
+    }
+
+    pub fn mainApprovalBinding(
+        self: *const ApprovalOwnershipSubagents,
+        _: u64,
+    ) ?ApprovalOwnershipBinding {
+        return self.binding;
+    }
+};
+
+const ApprovalOwnershipApp = struct {
+    approval_prompt: approval_prompt.ApprovalPrompt = .{},
+    approval_screen: interaction_state.ApprovalScreenState = .{},
+    subagents: ApprovalOwnershipSubagents = .{},
+};
+
+test "committed child approval owns input while its refreshed binding catches up" {
+    const alloc = std.testing.allocator;
+    var app = ApprovalOwnershipApp{};
+    defer app.approval_prompt.deinit(alloc);
+    try std.testing.expect(try app.approval_prompt.syncRequest(
+        alloc,
+        .{ .id = 41, .label = "write external-child.txt" },
+    ));
+
+    try std.testing.expect(
+        !Runtime(ApprovalOwnershipApp).approvalOwnsCurrentSurface(&app),
+    );
+    app.approval_screen.recordScreenCommit(41, .{
+        .request_id = 41,
+        .rows = 24,
+        .cols = 112,
+        .file_identity_visible = true,
+        .all_decision_controls_visible = true,
+        .changed_or_notice_visible = true,
+        .document_scrollable = false,
+    });
+    try std.testing.expect(
+        Runtime(ApprovalOwnershipApp).approvalOwnsCurrentSurface(&app),
+    );
 }
 
 test "app_input_runtime consumes legacy X10 reports during active file approval" {

--- a/src/core/app/input_approval_runtime.zig
+++ b/src/core/app/input_approval_runtime.zig
@@ -347,7 +347,19 @@ pub fn ApprovalRuntime(comptime App: type) type {
                 !@hasField(App, "session_persistence")) return false;
             if (comptime !@hasDecl(@TypeOf(app.subagents), "mainApprovalBinding")) return false;
             const request_id = app.approval_prompt.request.?.id;
-            const binding = app.subagents.mainApprovalBinding(request_id) orelse return false;
+            var maybe_binding = app.subagents.mainApprovalBinding(request_id);
+            if (maybe_binding == null) {
+                if (comptime @hasField(App, "approval_screen") and
+                    @hasDecl(@TypeOf(app.subagents), "mainApprovalCardBinding"))
+                {
+                    if (app.approval_screen.screen_commit) |commit| {
+                        if (commit.request_id == request_id) {
+                            maybe_binding = app.subagents.mainApprovalCardBinding(request_id);
+                        }
+                    }
+                }
+            }
+            const binding = maybe_binding orelse return false;
             const host = app_session_runtime.Runtime(App).subagentHost(app) orelse return true;
             var response = try app.approval_prompt.decision.materializeResponse(
                 app.alloc,
@@ -936,6 +948,23 @@ fn runApprovalBridgeScenario(
     const binding = app.subagents.mainApprovalBinding(main_request.id).?;
     try std.testing.expectEqualStrings(ApprovalBridgeWaiter.child_id, binding.child_id);
     try std.testing.expectEqualStrings(ApprovalBridgeWaiter.approval_id, binding.approval_id);
+
+    if (main_surface_wins) {
+        app.approval_screen.recordScreenCommit(main_request.id, .{
+            .request_id = main_request.id,
+            .rows = app.shell.layout.rows,
+            .cols = app.shell.layout.cols,
+            .file_identity_visible = true,
+            .all_decision_controls_visible = true,
+            .changed_or_notice_visible = true,
+            .document_scrollable = false,
+        });
+        app.subagents.markMainApprovalPresented(false);
+        try std.testing.expect(app.subagents.mainApprovalBinding(main_request.id) == null);
+        const card_binding = app.subagents.mainApprovalCardBinding(main_request.id).?;
+        try std.testing.expectEqualStrings(ApprovalBridgeWaiter.child_id, card_binding.child_id);
+        try std.testing.expectEqualStrings(ApprovalBridgeWaiter.approval_id, card_binding.approval_id);
+    }
 
     app.subagents.open(alloc);
     try std.testing.expectEqual(

--- a/src/ui/subagent/controller.zig
+++ b/src/ui/subagent/controller.zig
@@ -141,6 +141,13 @@ pub const Controller = struct {
         return self.runtime.mainApprovalBinding(prompt_id);
     }
 
+    pub fn mainApprovalCardBinding(
+        self: *const Controller,
+        prompt_id: u64,
+    ) ?subagent_runtime.MainApprovalBinding {
+        return self.runtime.mainApprovalCardBinding(prompt_id);
+    }
+
     pub fn dismissMainApproval(self: *Controller) void {
         self.runtime.dismissMainApproval();
     }

--- a/src/ui/subagent/runtime.zig
+++ b/src/ui/subagent/runtime.zig
@@ -966,11 +966,15 @@ pub const Runtime = struct {
         return self.main_approval_presented;
     }
 
-    pub fn mainApprovalBinding(self: *const Runtime, prompt_id: u64) ?MainApprovalBinding {
-        if (!self.main_approval_presented) return null;
+    pub fn mainApprovalCardBinding(self: *const Runtime, prompt_id: u64) ?MainApprovalBinding {
         const card = self.main_approval_card orelse return null;
         if (card.prompt_id != prompt_id) return null;
         return .{ .child_id = card.child_id, .approval_id = card.approval_id };
+    }
+
+    pub fn mainApprovalBinding(self: *const Runtime, prompt_id: u64) ?MainApprovalBinding {
+        if (!self.main_approval_presented) return null;
+        return self.mainApprovalCardBinding(prompt_id);
     }
 
     pub fn dismissMainApproval(self: *Runtime) void {


### PR DESCRIPTION
## Summary

- Keep visible child approvals interactive while their subagent projection refreshes.
- Route number-key decisions to the committed approval instead of the child conversation.