### PR TITLE
Preserve tool result failure types

### DIFF
--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -471,11 +471,14 @@ fn expectPermissionDeniedToolResult(gateway: *const FakeGateway, index: usize, t
             if (part_tool_name != .string or !std.mem.eql(u8, part_tool_name.string, tool_name)) continue;
             const output = part.object.get("output") orelse continue;
             if (output != .object) continue;
-            const value = output.object.get("value") orelse continue;
-            if (value != .string) continue;
+            const output_type = output.object.get("type") orelse continue;
+            if (output_type != .string or !std.mem.eql(u8, output_type.string, "execution-denied")) continue;
+            try std.testing.expect(output.object.get("value") == null);
+            const reason_value = output.object.get("reason") orelse continue;
+            if (reason_value != .string) continue;
 
-            try std.testing.expect(tool_result_errors.isToolPermissionDeniedOutput(value.string));
-            var payload = try std.json.parseFromSlice(std.json.Value, alloc, value.string, .{});
+            try std.testing.expect(tool_result_errors.isToolPermissionDeniedOutput(reason_value.string));
+            var payload = try std.json.parseFromSlice(std.json.Value, alloc, reason_value.string, .{});
             defer payload.deinit();
             const error_obj = payload.value.object.get("error").?.object;
             try std.testing.expectEqualStrings("tool_permission_denied", error_obj.get("type").?.string);

--- a/src/gateway/vercel_protocol.zig
+++ b/src/gateway/vercel_protocol.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const image_attachments = @import("../core/images/image_attachments.zig");
 const io_mod = @import("../core/shared/io.zig");
 const model_capabilities = @import("../core/config/model_capabilities.zig");
+const tool_result_errors = @import("../core/tooling/tool_result_errors.zig");
 const types = @import("../core/shared/types.zig");
 
 pub const ChatRole = types.ChatRole;
@@ -636,12 +637,20 @@ fn writeChatMessageJsonInner(
             } else {
                 try writer.writeAll("\"unknown\"");
             }
-            try writer.writeAll(",\"output\":{\"type\":\"text\",\"value\":");
-            if (message.content) |content| {
-                try std.json.Stringify.value(content, .{}, writer);
+            const content = message.content orelse "";
+            const failed = if (message.tool_result_status) |status|
+                status == .failure
+            else
+                false;
+            const denied = failed and tool_result_errors.toolPermissionDenialReason(content) != null;
+            if (denied) {
+                try writer.writeAll(",\"output\":{\"type\":\"execution-denied\",\"reason\":");
+            } else if (failed) {
+                try writer.writeAll(",\"output\":{\"type\":\"error-text\",\"value\":");
             } else {
-                try writer.writeAll("\"\"");
+                try writer.writeAll(",\"output\":{\"type\":\"text\",\"value\":");
             }
+            try std.json.Stringify.value(content, .{}, writer);
             try writer.writeAll("}}]");
         },
     }
@@ -1032,6 +1041,56 @@ test "writeChatMessageJson serializes tool-result fallbacks and escaped output" 
     try std.testing.expect(std.mem.find(u8, json, "\"toolCallId\":\"\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"toolName\":\"unknown\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"value\":\"line\\n\\ttext\"") != null);
+}
+
+test "writeChatMessageJson maps tool result status to the Vercel output variant" {
+    const denial = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"policy_denied\"}}";
+    const review_hold = "{\"error\":{\"type\":\"tool_review_held\",\"reason\":\"review_caution\"}}";
+    const malformed_denial = "{\"error\":{\"type\":\"tool_permission_denied\",\"reason\":\"review_caution\"}}";
+    const cases = [_]struct {
+        status: ?types.PersistedToolStatus,
+        content: []const u8,
+        output_type: []const u8,
+        content_field: []const u8,
+    }{
+        .{ .status = null, .content = "untyped result", .output_type = "text", .content_field = "value" },
+        .{ .status = .success, .content = "successful result", .output_type = "text", .content_field = "value" },
+        .{ .status = .failure, .content = "ordinary failure", .output_type = "error-text", .content_field = "value" },
+        .{ .status = .failure, .content = denial, .output_type = "execution-denied", .content_field = "reason" },
+        .{ .status = .failure, .content = review_hold, .output_type = "execution-denied", .content_field = "reason" },
+        .{ .status = .success, .content = denial, .output_type = "text", .content_field = "value" },
+        .{ .status = .failure, .content = malformed_denial, .output_type = "error-text", .content_field = "value" },
+    };
+
+    for (cases) |case| {
+        var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+        defer out.deinit();
+
+        try writeChatMessageJson(std.testing.allocator, &out.writer, .{
+            .role = .tool,
+            .content = case.content,
+            .tool_call_id = "call_1",
+            .tool_name = "terminal",
+            .tool_result_status = case.status,
+        });
+
+        var parsed = try std.json.parseFromSlice(
+            std.json.Value,
+            std.testing.allocator,
+            out.written(),
+            .{},
+        );
+        defer parsed.deinit();
+        const result = parsed.value.object.get("content").?.array.items[0].object;
+        const output = result.get("output").?.object;
+
+        try std.testing.expectEqualStrings("call_1", result.get("toolCallId").?.string);
+        try std.testing.expectEqualStrings("terminal", result.get("toolName").?.string);
+        try std.testing.expectEqualStrings(case.output_type, output.get("type").?.string);
+        try std.testing.expectEqualStrings(case.content, output.get(case.content_field).?.string);
+        const absent_field = if (std.mem.eql(u8, case.content_field, "value")) "reason" else "value";
+        try std.testing.expect(output.get(absent_field) == null);
+    }
 }
 
 test "writeChatMessageJsonCached adds provider options and non-cached omits them" {

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -104,7 +104,11 @@ function cleanCommandCall(command: string, id: string) {
   });
 }
 
-function toolResultText(body: string, toolCallId: string): string {
+function toolResultText(
+  body: string,
+  toolCallId: string,
+  outputType: "text" | "execution-denied" = "text",
+): string {
   const request = JSON.parse(body) as {
     prompt?: Array<{ content?: Array<Record<string, unknown>> }>;
   };
@@ -113,9 +117,10 @@ function toolResultText(body: string, toolCallId: string): string {
     .find((part) => part.type === "tool-result" && part.toolCallId === toolCallId);
   expect(result).toBeDefined();
   const output = result!.output as Record<string, unknown>;
-  expect(output.type).toBe("text");
-  expect(typeof output.value).toBe("string");
-  return output.value as string;
+  expect(output.type).toBe(outputType);
+  const content = outputType === "execution-denied" ? output.reason : output.value;
+  expect(typeof content).toBe("string");
+  return content as string;
 }
 
 function installRecorder(root: IsolatedRoot, name: string, marker: string) {
@@ -353,7 +358,7 @@ describe("lean auto mode reliability", () => {
           (body) => {
             expect(toolResultText(body, "clean_direct_pwd")).toContain("exit_code=0");
             expect(toolResultText(body, "clean_direct_git_status")).toContain("exit_code=0");
-            expect(toolResultText(body, "clean_blocked_reset")).toContain("review_caution");
+            expect(toolResultText(body, "clean_blocked_reset", "execution-denied")).toContain("review_caution");
             return fakeGatewayFinalText("Clean command group complete.");
           },
         ],
@@ -986,7 +991,7 @@ describe("lean auto mode reliability", () => {
             return userCommandCall(rebuildCommand, "injected_rebuild");
           },
           (body) => {
-            expect(toolResultText(body, "injected_rebuild")).toContain("review_caution");
+            expect(toolResultText(body, "injected_rebuild", "execution-denied")).toContain("review_caution");
             expect(body).not.toContain("approval_request_id");
             return commandCall("pwd", "safe_after_injection");
           },

--- a/tests/e2e/file-tool-paths.test.ts
+++ b/tests/e2e/file-tool-paths.test.ts
@@ -100,6 +100,23 @@ function toolResultOutput(body: string, callId: string): string {
   return contentText(result.output);
 }
 
+function toolResultReason(body: string, callId: string): string {
+  const request = JSON.parse(body) as {
+    prompt: Array<{ content: unknown }>;
+  };
+  const parts = request.prompt.flatMap((message) =>
+    Array.isArray(message.content) ? message.content : []
+  ) as Array<Record<string, unknown>>;
+  const result = parts.find((part) =>
+    part.type === "tool-result" && part.toolCallId === callId
+  );
+  if (!result) throw new Error(`Missing tool result for ${callId}`);
+  const output = result.output as Record<string, unknown>;
+  expect(output.type).toBe("execution-denied");
+  expect(typeof output.reason).toBe("string");
+  return output.reason as string;
+}
+
 function occurrenceCount(text: string, needle: string) {
   return text.split(needle).length - 1;
 }
@@ -979,7 +996,7 @@ describe("filesystem path handling", () => {
           content,
         }),
         (body) => {
-          const resultOutput = toolResultOutput(body, "write_large_review");
+          const resultOutput = toolResultReason(body, "write_large_review");
           expect(resultOutput).toContain('"reason":"review_caution"');
           expect(resultOutput).toContain("Action held after safety review");
           return finalText("large reviewed write blocked");

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2245,7 +2245,7 @@ describe("gateway stream lifecycle", () => {
           toolCallId: MALFORMED_CALL_ID,
           toolName: MALFORMED_TOOL_NAME,
           output: expect.objectContaining({
-            type: "text",
+            type: "error-text",
             value: expect.stringContaining("tool_execution_failed"),
           }),
         }),
@@ -2855,6 +2855,14 @@ describe("gateway stream lifecycle", () => {
         expect.objectContaining({ input: { request: {} } }),
       );
       expect(historicalResults).toHaveLength(1);
+      expect(historicalResults[0]).toEqual(
+        expect.objectContaining({
+          output: expect.objectContaining({
+            type: "error-text",
+            value: expect.stringContaining("tool_execution_failed"),
+          }),
+        }),
+      );
       expect(gateway.requests[2].body).toContain("tool_execution_failed");
       expect(gateway.requests[2].body).not.toContain(malformedArguments);
       const resumeTrace = readFileSync(resumeTracePath, "utf8");

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -729,7 +729,11 @@ function collectRegularFiles(root: string): string[] {
   return files;
 }
 
-function toolResultText(body: string, toolCallId: string): string {
+function toolResultText(
+  body: string,
+  toolCallId: string,
+  outputType: "text" | "error-text" = "text",
+): string {
   const request = JSON.parse(body) as {
     prompt?: Array<{ content?: Array<Record<string, unknown>> }>;
   };
@@ -740,7 +744,7 @@ function toolResultText(body: string, toolCallId: string): string {
     );
   if (!result) throw new Error(`Missing tool result for ${toolCallId}`);
   const output = result.output as Record<string, unknown>;
-  if (output.type !== "text" || typeof output.value !== "string") {
+  if (output.type !== outputType || typeof output.value !== "string") {
     throw new Error(`Invalid tool result for ${toolCallId}`);
   }
   return output.value;
@@ -1047,10 +1051,10 @@ describe("MCP remote authentication lifecycle", () => {
     );
     expect(result.code).toBe(0);
     const finalBody = gateway.requests.at(-1)!.body;
-    expect(toolResultText(finalBody, "template_auth_read")).toContain(
+    expect(toolResultText(finalBody, "template_auth_read", "error-text")).toContain(
       "McpAuthenticationRequired",
     );
-    expect(toolResultText(finalBody, "template_auth_read")).not.toContain(
+    expect(toolResultText(finalBody, "template_auth_read", "error-text")).not.toContain(
       "McpResourceNotFound",
     );
     expect(auth.requests.filter((request) =>
@@ -1239,7 +1243,7 @@ describe("MCP remote authentication lifecycle", () => {
     expect(toolResultText(finalBody, "private_read_a")).toContain(
       "HTTP_RESOURCE_TEXT",
     );
-    expect(toolResultText(finalBody, "private_rotate")).toContain(
+    expect(toolResultText(finalBody, "private_rotate", "error-text")).toContain(
       "tool_execution_failed",
     );
     for (const callId of [
@@ -1248,7 +1252,7 @@ describe("MCP remote authentication lifecycle", () => {
       "private_prompts_b",
       "private_read_b",
     ]) {
-      const output = toolResultText(finalBody, callId);
+      const output = toolResultText(finalBody, callId, "error-text");
       expect(output).not.toContain("custom://alpha");
       expect(output).not.toContain("custom://project/{path}");
       expect(output).not.toContain("review");
@@ -1437,7 +1441,11 @@ describe("MCP remote authentication lifecycle", () => {
       expect(toolResultText(finalBody, "ordered_read_a")).toContain(
         "HTTP_RESOURCE_TEXT",
       );
-      const second = toolResultText(finalBody, "ordered_read_b");
+      const second = toolResultText(
+        finalBody,
+        "ordered_read_b",
+        readCacheCase.publicCache ? "text" : "error-text",
+      );
       if (readCacheCase.publicCache) {
         expect(second).toContain("HTTP_RESOURCE_TEXT");
         expect(auth.refreshes).toBeGreaterThanOrEqual(1);

--- a/tests/e2e/mcp-http.test.ts
+++ b/tests/e2e/mcp-http.test.ts
@@ -136,7 +136,11 @@ function startToolGateway(finalText: string) {
   });
 }
 
-function toolResultText(body: string, toolCallId: string): string {
+function toolResultText(
+  body: string,
+  toolCallId: string,
+  outputType: "text" | "error-text" = "text",
+): string {
   const request = JSON.parse(body) as {
     prompt?: Array<{ content?: Array<Record<string, unknown>> }>;
   };
@@ -147,7 +151,7 @@ function toolResultText(body: string, toolCallId: string): string {
     );
   if (!result) throw new Error(`Missing tool result for ${toolCallId}`);
   const output = result.output as Record<string, unknown>;
-  if (output.type !== "text" || typeof output.value !== "string") {
+  if (output.type !== outputType || typeof output.value !== "string") {
     throw new Error(`Invalid tool result for ${toolCallId}`);
   }
   return output.value;
@@ -741,6 +745,7 @@ describe("modern MCP Streamable HTTP", () => {
     const cancelled = toolResultText(
       gateway.requests.at(-1)!.body,
       "http_resource_stall",
+      "error-text",
     );
     expect(cancelled).toContain("tool_execution_failed");
     expect(cancelled).not.toContain("HTTP_RESOURCE_TEXT");

--- a/tests/e2e/permission-errors.test.ts
+++ b/tests/e2e/permission-errors.test.ts
@@ -54,7 +54,7 @@ function parseFxJson(result: { stdout: string; stderr: string; code: number | nu
   return JSON.parse(result.stdout.trim()) as FxJson;
 }
 
-function toolResultText(body: string, toolCallId: string): string {
+function executionDeniedReason(body: string, toolCallId: string): string {
   const request = JSON.parse(body) as {
     prompt?: Array<{ content?: Array<Record<string, unknown>> }>;
   };
@@ -63,9 +63,10 @@ function toolResultText(body: string, toolCallId: string): string {
     .find((part) => part.type === "tool-result" && part.toolCallId === toolCallId);
   expect(result).toBeDefined();
   const output = result!.output as Record<string, unknown>;
-  expect(output.type).toBe("text");
-  expect(typeof output.value).toBe("string");
-  return output.value as string;
+  expect(output.type).toBe("execution-denied");
+  expect(typeof output.reason).toBe("string");
+  expect(output.value).toBeUndefined();
+  return output.reason as string;
 }
 
 function permissionEnv(
@@ -208,12 +209,13 @@ describe("generic permission typed errors", () => {
           timeoutMs: TIMEOUT,
         });
         const json = parseFxJson(result);
+        expect(result.stderr).toBe('Running touch "./denied-marker.txt"\n');
         expect(json.tool_calls).toContainEqual({ name: "terminal", status: "error" });
         expect(existsSync(marker)).toBe(false);
         expect(gateway.requests).toHaveLength(2);
 
         const toolResult = JSON.parse(
-          toolResultText(gateway.requests[1]!.body, toolCallId),
+          executionDeniedReason(gateway.requests[1]!.body, toolCallId),
         ) as { error: PermissionEcho };
         const echo = toolResult.error;
         expect(echo.type).toBe("tool_permission_denied");

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -3059,7 +3059,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(repairedResults).toEqual([
         expect.objectContaining({
           output: expect.objectContaining({
-            type: "text",
+            type: "error-text",
             value: expect.stringContaining("tool_execution_failed"),
           }),
         }),


### PR DESCRIPTION
## Summary

- Send failed tool results through Vercel AI Gateway as `error-text`.
- Send permission denials and review holds as `execution-denied`.
- Keep successful and untyped tool results as `text`.