### PR TITLE
Say when the team list could not be loaded during sign-in

### DIFF
--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -389,6 +389,9 @@ pub fn Runtime(comptime App: type) type {
                             }
                             rememberCredentialSource(app, .fx_login);
 
+                            // openTeamPicker takes the selection, so read the flag first.
+                            const team_fetch_failed = selection.team_fetch_failed;
+
                             if (selection.teams.items.len > 0) {
                                 app.auth.openTeamPicker(app.alloc, selection);
                             } else {
@@ -399,6 +402,13 @@ pub fn Runtime(comptime App: type) type {
                                 .tone = .neutral,
                                 .body = "Signed in to Vercel.",
                             });
+                            if (team_fetch_failed) {
+                                try writeAuthNotice(app, .{
+                                    .topic = "auth",
+                                    .tone = .warning,
+                                    .body = login_flow.team_fetch_warning_interactive,
+                                });
+                            }
                         },
                         .chatgpt => {
                             try finishSubscriptionSignIn(app, .codex);
@@ -1457,6 +1467,7 @@ const TestAuth = struct {
     catalog_ready: bool = true,
     gateway_ready_after_refresh_count: ?usize = null,
     team_selection: TestTeamSelection = .{},
+    taken_selection: login_flow.TeamSelection = .{},
     selected_team_adopted: bool = false,
     sign_in_url: ?[]const u8 = null,
     picker_pop_count: usize = 0,
@@ -1556,7 +1567,11 @@ const TestAuth = struct {
         return .empty;
     }
 
-    fn openTeamPicker(_: *TestAuth, _: std.mem.Allocator, _: *login_flow.TeamSelection) void {}
+    fn openTeamPicker(self: *TestAuth, alloc: std.mem.Allocator, selection: *login_flow.TeamSelection) void {
+        // Mirrors the real picker, which takes ownership of the selection.
+        self.taken_selection.deinit(alloc);
+        self.taken_selection = selection.take();
+    }
 
     fn refreshFxLoginIfNeeded(self: *TestAuth, _: std.mem.Allocator) !bool {
         self.refresh_count += 1;
@@ -1692,6 +1707,7 @@ const TestApp = struct {
     } = .{},
     model_cache_warmup_count: usize = 0,
     notice_write_count: usize = 0,
+    last_notice_tone: ?types.NoticeTone = null,
     transcript: std.ArrayList(u8) = .empty,
     test_url_opener: TestUrlOpener = .{},
     preference_write_count: usize = 0,
@@ -1703,6 +1719,7 @@ const TestApp = struct {
 
     fn deinit(self: *TestApp) void {
         self.transcript.deinit(self.alloc);
+        self.auth.taken_selection.deinit(self.alloc);
     }
 
     fn startModelCacheWarmup(self: *TestApp) void {
@@ -1715,6 +1732,7 @@ const TestApp = struct {
 
     fn writeDomainNotice(self: *TestApp, notice: types.SemanticNotice, _: bool) !void {
         self.notice_write_count += 1;
+        self.last_notice_tone = notice.tone;
         try self.transcript.appendSlice(self.alloc, notice.body);
         try self.transcript.append(self.alloc, '\n');
     }
@@ -1965,6 +1983,35 @@ test "successful direct login remembers fx login after activation" {
     try std.testing.expectEqual(@as(usize, 1), app.notice_write_count);
 }
 
+test "a failed team fetch warns even when the picker consumed the selection" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    app.auth.select_result = true;
+
+    // A team present alongside a failed fetch is the one combination the e2e
+    // cannot reach, because a failed fetch always yields an empty list today.
+    // It is what pins reading the flag before openTeamPicker takes the selection.
+    var teams: std.ArrayList(login_flow.Team) = .empty;
+    try teams.append(app.alloc, .{
+        .id = try app.alloc.dupe(u8, "team_123"),
+        .slug = try app.alloc.dupe(u8, "example-internal-team"),
+        .name = try app.alloc.dupe(u8, "Example Internal Team"),
+    });
+    app.auth.sign_in_transition = .{ .succeeded = .{ .vercel = .{
+        .teams = teams,
+        .team_fetch_failed = true,
+    } } };
+
+    try Runtime(TestApp).collectSignInFacts(&app);
+
+    try std.testing.expectEqual(@as(usize, 2), app.notice_write_count);
+    try std.testing.expectEqual(types.NoticeTone.warning, app.last_notice_tone.?);
+    try std.testing.expectEqualStrings(
+        "Signed in to Vercel.\n" ++ login_flow.team_fetch_warning_interactive ++ "\n",
+        app.transcript.items,
+    );
+}
+
 test "direct login source load failure leaves the environment preference unchanged" {
     var app: TestApp = .{};
     defer app.deinit();
@@ -2029,6 +2076,20 @@ test "cancelled login and rejected API key do not persist a source" {
 
     try std.testing.expectEqual(@as(usize, 0), app.preference_write_count);
     try std.testing.expectEqual(credentials.Source.ai_gateway_api_key, app.auth.active_source.?);
+}
+
+test "a cancelled sign-in writes no team warning" {
+    var app: TestApp = .{};
+    defer app.deinit();
+    // The cancelled arm carries no completion, so there is no selection to read
+    // a failed fetch from. This pins that: emitting the warning from
+    // completeSignIn instead of here would warn about a session never created.
+    app.auth.sign_in_transition = .cancelled;
+
+    try Runtime(TestApp).collectSignInFacts(&app);
+
+    try std.testing.expectEqual(@as(usize, 0), app.notice_write_count);
+    try std.testing.expectEqualStrings("", app.transcript.items);
 }
 
 test "team source load failure preserves the environment source and preference" {

--- a/src/core/auth/login_flow.zig
+++ b/src/core/auth/login_flow.zig
@@ -37,6 +37,12 @@ const LogoutError = error{SessionDeleteFailed};
 
 pub const remote_revocation_warning = "Warning: signed out locally, but the remote session could not be revoked.";
 
+/// Shared lead-in for both sign-in surfaces. The remedy differs per surface, so
+/// each one appends its own tail rather than sending a TUI user to a shell.
+pub const team_fetch_warning_prefix = "Your teams could not be loaded, so this session is personal scope for now.";
+pub const team_fetch_warning_cli = team_fetch_warning_prefix ++ " Run fx teams to pick a team.";
+pub const team_fetch_warning_interactive = team_fetch_warning_prefix ++ " Open /login and choose Change team.";
+
 pub const LogoutResult = struct {
     session_deleted: bool = false,
     local_durability_failed: bool = false,
@@ -70,6 +76,10 @@ pub const SelectedTeam = struct {
 pub const TeamSelection = struct {
     session: ?oauth_session.Session = null,
     teams: std.ArrayList(Team) = .empty,
+    /// True when the team fetch errored, as opposed to returning no teams. An
+    /// account with no teams is a normal state; a failed fetch is not, and only
+    /// the second one warrants telling the user the session is personal scope.
+    team_fetch_failed: bool = false,
 
     pub fn deinit(self: *TeamSelection, alloc: Allocator) void {
         if (self.session) |*session| session.deinit(alloc);
@@ -532,13 +542,22 @@ fn completeSignIn(
     client_id: []const u8,
     token: *oauth.TokenSet,
 ) !SignInCompletion {
-    var teams = fetchTeams(alloc, token.access_token, issuer_url) catch std.ArrayList(Team).empty;
+    var team_fetch_failed = false;
+    const parsed = fetchTeams(alloc, token.access_token, issuer_url) catch blk: {
+        team_fetch_failed = true;
+        break :blk ParsedTeams{};
+    };
+    // A partly unreadable list is also worth saying: the team they want may be
+    // one of the entries that did not survive parsing.
+    if (parsed.dropped > 0) team_fetch_failed = true;
+    var teams = parsed.teams;
     errdefer freeTeams(alloc, &teams);
     const now_ms = io_mod.milliTimestamp();
     const session = try take_login_session(alloc, issuer_url, client_id, token, null, now_ms);
     return .{ .vercel = .{
         .session = session,
         .teams = teams,
+        .team_fetch_failed = team_fetch_failed,
     } };
 }
 
@@ -579,7 +598,13 @@ pub fn runLogin(
     );
     defer token.deinit(alloc);
 
-    var teams = fetchTeams(alloc, token.access_token, prepared.metadata.issuer) catch std.ArrayList(Team).empty;
+    var team_fetch_failed = false;
+    const parsed = fetchTeams(alloc, token.access_token, prepared.metadata.issuer) catch blk: {
+        team_fetch_failed = true;
+        break :blk ParsedTeams{};
+    };
+    if (parsed.dropped > 0) team_fetch_failed = true;
+    var teams = parsed.teams;
     defer freeTeams(alloc, &teams);
     const selected_team_index = try selectTeam(alloc, teams.items, null);
     const selected_team = if (selected_team_index) |index| &teams.items[index] else null;
@@ -598,6 +623,7 @@ pub fn runLogin(
     try oauth_session.saveNewSession(alloc, session);
     try writeStdout("Signed in to Vercel.\n");
     try writeStdout("AI Gateway access may still require billing or API setup for the selected account.\n");
+    if (team_fetch_failed) try writeStdout(team_fetch_warning_cli ++ "\n");
 }
 
 fn take_login_session(
@@ -676,10 +702,10 @@ pub fn loadTeamSelection(
     };
     errdefer session.deinit(alloc);
 
-    const teams = try fetchTeams(alloc, session.access_token, session.issuer);
+    const parsed = try fetchTeams(alloc, session.access_token, session.issuer);
     return .{
         .session = session,
-        .teams = teams,
+        .teams = parsed.teams,
     };
 }
 
@@ -1023,7 +1049,7 @@ fn discardStdinLine() void {
     }
 }
 
-fn fetchTeams(alloc: Allocator, access_token: []const u8, issuer_url: []const u8) !std.ArrayList(Team) {
+fn fetchTeams(alloc: Allocator, access_token: []const u8, issuer_url: []const u8) !ParsedTeams {
     if (comptime host_target.is_wasm) return fetchTeamsFromJsHost(alloc, access_token, issuer_url);
     var client: std.http.Client = .{ .allocator = alloc, .io = io_mod.getIo() };
     defer client.deinit();
@@ -1061,7 +1087,7 @@ fn fetchTeamsFromJsHost(
     alloc: Allocator,
     access_token: []const u8,
     issuer_url: []const u8,
-) !std.ArrayList(Team) {
+) !ParsedTeams {
     const e2e_endpoint = if (oauth_session.isLoopbackE2EIssuer(issuer_url))
         try std.fmt.allocPrint(alloc, "{s}/v2/teams", .{issuer_url})
     else
@@ -1075,7 +1101,14 @@ fn fetchTeamsFromJsHost(
     return parseTeams(alloc, response.body);
 }
 
-fn parseTeams(alloc: Allocator, bytes: []const u8) !std.ArrayList(Team) {
+/// Teams read from a response, plus how many entries were unreadable. A drop
+/// count of zero is the only case where the list is known to be complete.
+const ParsedTeams = struct {
+    teams: std.ArrayList(Team) = .empty,
+    dropped: usize = 0,
+};
+
+fn parseTeams(alloc: Allocator, bytes: []const u8) !ParsedTeams {
     var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
     defer parsed.deinit();
 
@@ -1087,11 +1120,24 @@ fn parseTeams(alloc: Allocator, bytes: []const u8) !std.ArrayList(Team) {
 
     var teams: std.ArrayList(Team) = .empty;
     errdefer freeTeams(alloc, &teams);
+    var dropped: usize = 0;
     for (teams_value.array.items) |entry| {
-        if (entry != .object) continue;
-        const id = entry.object.get("id") orelse continue;
-        const slug = entry.object.get("slug") orelse continue;
-        if (id != .string or slug != .string) continue;
+        if (entry != .object) {
+            dropped += 1;
+            continue;
+        }
+        const id = entry.object.get("id") orelse {
+            dropped += 1;
+            continue;
+        };
+        const slug = entry.object.get("slug") orelse {
+            dropped += 1;
+            continue;
+        };
+        if (id != .string or slug != .string) {
+            dropped += 1;
+            continue;
+        }
         const name_value = entry.object.get("name");
         const name = if (name_value != null and name_value.? == .string and name_value.?.string.len > 0)
             name_value.?.string
@@ -1103,7 +1149,11 @@ fn parseTeams(alloc: Allocator, bytes: []const u8) !std.ArrayList(Team) {
             return err;
         };
     }
-    return teams;
+    // A non-empty array that yielded nothing usable is a response we could not
+    // read, not an account with no teams. Without this the two are identical to
+    // every caller, which is the ambiguity this whole path exists to remove.
+    if (teams.items.len == 0 and dropped > 0) return error.InvalidTeamsResponse;
+    return .{ .teams = teams, .dropped = dropped };
 }
 
 fn selectTeam(alloc: Allocator, teams: []const Team, current: ?[]const u8) !?usize {
@@ -1351,11 +1401,11 @@ fn dupeTeam(alloc: Allocator, source_id: []const u8, source_slug: []const u8, so
 }
 
 fn check_parse_teams_allocation_failures(alloc: Allocator) !void {
-    var teams = try parseTeams(
+    var parsed = try parseTeams(
         alloc,
         "{\"teams\":[{\"id\":\"team-1\",\"slug\":\"one\",\"name\":\"One\"},{\"id\":\"team-2\",\"slug\":\"two\",\"name\":\"Two\"}]}",
     );
-    defer freeTeams(alloc, &teams);
+    defer freeTeams(alloc, &parsed.teams);
 }
 
 fn check_take_login_session_allocation_failures(alloc: Allocator) !void {
@@ -1438,15 +1488,44 @@ fn writeStdoutFmt(comptime fmt: []const u8, args: anytype) !void {
 }
 
 test "login flow parses teams" {
-    var teams = try parseTeams(
+    var parsed = try parseTeams(
         std.testing.allocator,
         "{\"teams\":[{\"id\":\"team_1\",\"slug\":\"vercel-labs\",\"name\":\"Vercel Labs\"},{\"id\":\"team_2\",\"slug\":\"personal\"}]}",
     );
-    defer freeTeams(std.testing.allocator, &teams);
-    try std.testing.expectEqual(@as(usize, 2), teams.items.len);
-    try std.testing.expectEqualStrings("team_1", teams.items[0].id);
-    try std.testing.expectEqualStrings("Vercel Labs", teams.items[0].name);
-    try std.testing.expectEqualStrings("personal", teams.items[1].name);
+    defer freeTeams(std.testing.allocator, &parsed.teams);
+    try std.testing.expectEqual(@as(usize, 2), parsed.teams.items.len);
+    try std.testing.expectEqual(@as(usize, 0), parsed.dropped);
+    try std.testing.expectEqualStrings("team_1", parsed.teams.items[0].id);
+    try std.testing.expectEqualStrings("Vercel Labs", parsed.teams.items[0].name);
+    try std.testing.expectEqualStrings("personal", parsed.teams.items[1].name);
+}
+
+test "login flow rejects a teams array with nothing usable in it" {
+    try std.testing.expectError(error.InvalidTeamsResponse, parseTeams(
+        std.testing.allocator,
+        "{\"teams\":[{\"id\":123,\"slug\":\"acme\"}]}",
+    ));
+    try std.testing.expectError(error.InvalidTeamsResponse, parseTeams(
+        std.testing.allocator,
+        "{\"teams\":[{\"slug\":\"no-id\"},\"not-an-object\"]}",
+    ));
+}
+
+test "login flow counts entries it had to drop" {
+    var parsed = try parseTeams(
+        std.testing.allocator,
+        "{\"teams\":[{\"id\":\"team_1\",\"slug\":\"good\"},{\"id\":99,\"slug\":\"bad\"}]}",
+    );
+    defer freeTeams(std.testing.allocator, &parsed.teams);
+    try std.testing.expectEqual(@as(usize, 1), parsed.teams.items.len);
+    try std.testing.expectEqual(@as(usize, 1), parsed.dropped);
+}
+
+test "login flow accepts a genuinely empty teams array" {
+    var parsed = try parseTeams(std.testing.allocator, "{\"teams\":[]}");
+    defer freeTeams(std.testing.allocator, &parsed.teams);
+    try std.testing.expectEqual(@as(usize, 0), parsed.teams.items.len);
+    try std.testing.expectEqual(@as(usize, 0), parsed.dropped);
 }
 
 const ScriptedPollResult = enum {

--- a/tests/e2e/tui-auth-source-selection.test.ts
+++ b/tests/e2e/tui-auth-source-selection.test.ts
@@ -42,6 +42,14 @@ const DIRECT_LOGIN_RESPONSE = "DIRECT_LOGIN_RESPONSE";
 const LOGOUT_FALLBACK_RESPONSE = "LOGOUT_FALLBACK_RESPONSE";
 const REFRESH_RECOVERY_RESPONSE = "REFRESH_RECOVERY_RESPONSE";
 const ACQUIRED_LOGIN_TOKEN = "acquired-login-token";
+const TEAM_WARNING_CLI =
+  "Your teams could not be loaded, so this session is personal scope for now. Run fx teams to pick a team.";
+const TEAM_WARNING_TUI =
+  "Your teams could not be loaded, so this session is personal scope for now. Open /login and choose Change team.";
+// Every silence control asserts the ABSENCE of this needle, so it has to be a
+// real substring of the warnings. Untie the two and those controls start
+// checking for a string that can never appear and pass while proving nothing.
+const TEAM_WARNING_NEEDLE = "personal scope for now";
 
 function grokSubscriptionModel(id: string, contextWindow: number, efforts: string[] = []) {
   return {
@@ -316,6 +324,8 @@ function startFakeOAuth(
     rejectAllDeviceClients?: boolean;
     tokenDelayMs?: number;
     teams?: Array<{ id: string; slug: string; name: string }>;
+    /// Overrides the /v2/teams response entirely. Takes precedence over `teams`.
+    teamsResponse?: { status: number; body: string };
   } = {},
 ) {
   const providerDetail = `provider rejected ${LOGIN_TOKEN}, ${ENV_TOKEN}, and seeded-refresh-token`;
@@ -394,6 +404,11 @@ function startFakeOAuth(
           });
         }
         case "/v2/teams":
+          if (options.teamsResponse) {
+            return new Response(options.teamsResponse.body, {
+              status: options.teamsResponse.status,
+            });
+          }
           return Response.json({ teams: options.teams ?? [] });
         case "/oauth/revoke": {
           const form = await request.formData();
@@ -1813,6 +1828,52 @@ tmuxTest(
 );
 
 tmuxTest(
+  "TUI sign-in warns when the teams request fails",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-tui-login-teams-fail-"));
+    stderrPath = join(home, "stderr.log");
+    writeFileSync(stderrPath, "");
+    gateway = startFakeGateway([]);
+    oauth = startFakeOAuth(
+      ACQUIRED_LOGIN_TOKEN,
+      undefined,
+      3600,
+      Number.POSITIVE_INFINITY,
+      { teamsResponse: { status: 500, body: `upstream unavailable: ${LOGIN_TOKEN}` } },
+    );
+
+    session = await startFx(home, stderrPath, gateway, oauth.issuerUrl);
+    await session.waitForComposer(TIMEOUT);
+    await session.sendText("/login");
+    await session.waitForText("Connections", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Vercel account", TIMEOUT);
+    await session.sendKeys("Enter");
+    await session.waitForText("Signed in to Vercel", TIMEOUT);
+    // writeAuthNotice flushes per call, so the two notices land in separate
+    // flushes; wait for the second before capturing or this races.
+    await session.waitForText(TEAM_WARNING_NEEDLE, TIMEOUT);
+
+    const scrollback = await session.captureFullScrollback();
+    expect(scrollback).toContain("Signed in to Vercel.");
+    // The notice soft-wraps at the pane width, so the full body is never a
+    // contiguous substring here. This asserts the warning reached the screen;
+    // its exact text and ordering are pinned by the Zig unit test in
+    // src/core/app/app_auth_runtime.zig.
+    expect(scrollback).toContain(TEAM_WARNING_NEEDLE);
+    expect(scrollback).not.toContain(LOGIN_TOKEN);
+    expect(scrollback).not.toContain(ACQUIRED_LOGIN_TOKEN);
+    const persisted = JSON.parse(
+      readFileSync(join(home, ".fx", "auth.json"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(persisted.team_slug).toBeUndefined();
+    expect(persisted.team_id).toBeUndefined();
+    expect(readFileSync(stderrPath, "utf8")).toBe("");
+  },
+  60_000,
+);
+
+tmuxTest(
   "API key and fx login coexist through selection, restart, login, and logout",
   async () => {
     home = mkdtempSync(join(tmpdir(), "fx-tui-auth-lifecycle-"));
@@ -1904,9 +1965,13 @@ tmuxTest(
     expect(acquiredAuth.access_token).toBe(ACQUIRED_LOGIN_TOKEN);
     expect(acquiredAuth.refresh_token).toBe("acquired-refresh-token");
     expect(statSync(authPath).mode & 0o777).toBe(0o600);
-    expect(
-      (await session.captureFullScrollback()).match(/Signed in to Vercel\./g) ?? [],
-    ).toHaveLength(1);
+    const signedInScrollback = await session.captureFullScrollback();
+    expect(signedInScrollback.match(/Signed in to Vercel\./g) ?? []).toHaveLength(1);
+    // This account has no teams (startFakeOAuth is called with no `teams` option),
+    // so the team-fetch warning must not appear. The needle is the clause unique to
+    // that warning: "could not be loaded" is already emitted by the credential-load
+    // failure notice in the same sign-in arm.
+    expect(signedInScrollback).not.toContain(TEAM_WARNING_NEEDLE);
 
     await session.sendText("/status");
     await session.waitForText("auth=fx login", TIMEOUT);
@@ -2178,6 +2243,235 @@ test(
     expect(result.stdout.match(/Code: TEST-CODE/g) ?? []).toHaveLength(1);
     expect(result.stdout).not.toContain(oauth.providerDetail);
     expect(result.stderr).toBe("");
+  },
+  60_000,
+);
+
+function loginEnv(testHome: string, issuerUrl: string) {
+  return {
+    HOME: testHome,
+    AI_GATEWAY_API_KEY: undefined,
+    VERCEL_OIDC_TOKEN: undefined,
+    FX_DISABLE_KEYCHAIN: "1",
+    FX_SKIP_ONBOARDING: "1",
+    FX_AUTO_UPGRADE: "0",
+    FX_NO_OPEN_BROWSER: "1",
+    FX_OAUTH_CLIENT_ID: "test-client",
+    FX_E2E_OAUTH_ISSUER_URL: issuerUrl,
+  };
+}
+
+function persistedAuth(testHome: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(testHome, ".fx", "auth.json"), "utf8"),
+  ) as Record<string, unknown>;
+}
+
+test("the silence-control needle is a substring of both warnings", () => {
+  expect(TEAM_WARNING_CLI).toContain(TEAM_WARNING_NEEDLE);
+  expect(TEAM_WARNING_TUI).toContain(TEAM_WARNING_NEEDLE);
+});
+
+test(
+  "fx login warns when the teams request fails",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-login-teams-500-"));
+    oauth = startFakeOAuth(
+      ACQUIRED_LOGIN_TOKEN,
+      undefined,
+      3600,
+      Number.POSITIVE_INFINITY,
+      { teamsResponse: { status: 500, body: `upstream unavailable: ${LOGIN_TOKEN}` } },
+    );
+
+    const result = await runFx(["login"], {
+      env: loginEnv(home, oauth.issuerUrl),
+      timeoutMs: TIMEOUT,
+    });
+
+    expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("Signed in to Vercel.");
+    expect(result.stdout).toContain(TEAM_WARNING_CLI);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain(LOGIN_TOKEN);
+    expect(result.stdout).not.toContain(ACQUIRED_LOGIN_TOKEN);
+    const persisted = persistedAuth(home);
+    expect(persisted.team_slug).toBeUndefined();
+    expect(persisted.team_id).toBeUndefined();
+    expect(persisted.access_token).toBe(ACQUIRED_LOGIN_TOKEN);
+  },
+  60_000,
+);
+
+test(
+  "fx login warns when the teams response is not JSON",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-login-teams-garbage-"));
+    oauth = startFakeOAuth(
+      ACQUIRED_LOGIN_TOKEN,
+      undefined,
+      3600,
+      Number.POSITIVE_INFINITY,
+      { teamsResponse: { status: 200, body: `<html>${LOGIN_TOKEN}</html>` } },
+    );
+
+    const result = await runFx(["login"], {
+      env: loginEnv(home, oauth.issuerUrl),
+      timeoutMs: TIMEOUT,
+    });
+
+    expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("Signed in to Vercel.");
+    expect(result.stdout).toContain(TEAM_WARNING_CLI);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain(LOGIN_TOKEN);
+    expect(result.stdout).not.toContain(ACQUIRED_LOGIN_TOKEN);
+    const persisted = persistedAuth(home);
+    expect(persisted.team_slug).toBeUndefined();
+    expect(persisted.team_id).toBeUndefined();
+  },
+  60_000,
+);
+
+test(
+  "fx login warns when every teams entry is unreadable",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-login-teams-drift-"));
+    oauth = startFakeOAuth(
+      ACQUIRED_LOGIN_TOKEN,
+      undefined,
+      3600,
+      Number.POSITIVE_INFINITY,
+      { teamsResponse: { status: 200, body: '{"teams":[{"id":123,"slug":"acme"}]}' } },
+    );
+
+    const result = await runFx(["login"], {
+      env: loginEnv(home, oauth.issuerUrl),
+      timeoutMs: TIMEOUT,
+    });
+
+    expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("Signed in to Vercel.");
+    expect(result.stdout).toContain(TEAM_WARNING_CLI);
+    expect(result.stderr).toBe("");
+    const persisted = persistedAuth(home);
+    expect(persisted.team_slug).toBeUndefined();
+  },
+  60_000,
+);
+
+test(
+  "fx login warns when only some teams entries are unreadable",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-login-teams-partial-"));
+    oauth = startFakeOAuth(
+      ACQUIRED_LOGIN_TOKEN,
+      undefined,
+      3600,
+      Number.POSITIVE_INFINITY,
+      {
+        teamsResponse: {
+          status: 200,
+          body: '{"teams":[{"id":"team_123","slug":"example-internal-team","name":"Example Internal Team"},{"id":99,"slug":"unreadable"}]}',
+        },
+      },
+    );
+
+    const result = await runFx(["login"], {
+      env: loginEnv(home, oauth.issuerUrl),
+      timeoutMs: TIMEOUT,
+    });
+
+    expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+    // The readable team is still selected, and the user is told the list was
+    // incomplete, because the team they wanted may be the one that was dropped.
+    expect(persistedAuth(home).team_slug).toBe("example-internal-team");
+    expect(result.stdout).toContain(TEAM_WARNING_CLI);
+  },
+  60_000,
+);
+
+test(
+  "fx login warns when the teams request is rejected",
+  async () => {
+    for (const status of [401, 403]) {
+      home = mkdtempSync(join(tmpdir(), `fx-login-teams-${status}-`));
+      oauth = startFakeOAuth(
+        ACQUIRED_LOGIN_TOKEN,
+        undefined,
+        3600,
+        Number.POSITIVE_INFINITY,
+        { teamsResponse: { status, body: "forbidden" } },
+      );
+
+      const result = await runFx(["login"], {
+        env: loginEnv(home, oauth.issuerUrl),
+        timeoutMs: TIMEOUT,
+      });
+
+      expect(result.code, `status ${status} stdout: ${result.stdout}`).toBe(0);
+      expect(result.stdout).toContain(TEAM_WARNING_CLI);
+      expect(result.stderr).toBe("");
+      expect(persistedAuth(home).team_slug).toBeUndefined();
+      oauth.stop();
+      rmSync(home, { recursive: true, force: true });
+    }
+    home = undefined;
+    oauth = undefined;
+  },
+  90_000,
+);
+
+test(
+  "fx login persists the team and stays quiet on success",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-login-teams-ok-"));
+    oauth = startFakeOAuth(
+      ACQUIRED_LOGIN_TOKEN,
+      undefined,
+      3600,
+      Number.POSITIVE_INFINITY,
+      {
+        teams: [
+          { id: "team_123", slug: "example-internal-team", name: "Example Internal Team" },
+        ],
+      },
+    );
+
+    const result = await runFx(["login"], {
+      env: loginEnv(home, oauth.issuerUrl),
+      timeoutMs: TIMEOUT,
+    });
+
+    expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("Signed in to Vercel.");
+    expect(result.stdout).not.toContain(TEAM_WARNING_NEEDLE);
+    expect(result.stderr).toBe("");
+    const persisted = persistedAuth(home);
+    expect(persisted.team_slug).toBe("example-internal-team");
+    expect(persisted.team_id).toBe("team_123");
+  },
+  60_000,
+);
+
+test(
+  "fx login stays quiet for an account with no teams",
+  async () => {
+    home = mkdtempSync(join(tmpdir(), "fx-login-teams-empty-"));
+    oauth = startFakeOAuth(ACQUIRED_LOGIN_TOKEN);
+
+    const result = await runFx(["login"], {
+      env: loginEnv(home, oauth.issuerUrl),
+      timeoutMs: TIMEOUT,
+    });
+
+    expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+    expect(result.stdout).toContain("Signed in to Vercel.");
+    expect(result.stdout).not.toContain(TEAM_WARNING_NEEDLE);
+    expect(result.stderr).toBe("");
+    const persisted = persistedAuth(home);
+    expect(persisted.team_slug).toBeUndefined();
+    expect(persisted.team_id).toBeUndefined();
   },
   60_000,
 );


### PR DESCRIPTION
Fixes #476.

Needs `type: bug`. I cannot apply labels, so this stays in draft until a maintainer adds it. Full CI is green on this commit across all four native runners.

A failed team lookup during sign-in was indistinguishable from an account that has no teams, so `fx login` reported success and quietly left you in personal scope. Both sign-in paths did:

```zig
var teams = fetchTeams(alloc, token.access_token, issuer_url) catch std.ArrayList(Team).empty;
```

Every failure became an empty list, which is exactly what a zero-team account produces. No picker, no message, `auth.json` written without `team_slug` or `team_id`, and stdout byte-identical to a healthy login.

The sign-in itself is fine, so this keeps it. The token pair is valid and the team fetch is auxiliary; failing the login over it would be worse, and re-running the device flow is expensive. What was missing was any signal, so that is what this adds.

### What changed

Both call sites now track whether the list actually arrived. On a caught error the CLI prints one line after the existing gateway-access caveat, and the in-app flow emits a warning notice beside the existing sign-in notice. An account with genuinely no teams stays silent, which is the case that decides whether this is a useful signal or a false alarm.

`parseTeams` now counts entries it cannot read. A non-empty array that yields nothing usable is a response we could not read rather than an account with no teams, so it returns `InvalidTeamsResponse`; a partly readable list keeps what it got and still reports the shortfall, since the team you want may be the entry that dropped. Without this a `200` carrying `{"teams":[{"id":123,"slug":"acme"}]}` reproduced the original bug with no error anywhere.

That last part also reaches `fx teams`, which now fails loudly on a list it cannot read instead of reporting no teams. It already used `try` on the same call, so this is the direction it was already going, but it is a behavior change in a second command and worth your attention.

The two surfaces share a prefix constant and append their own remedy, following `remote_revocation_warning`, so the in-app notice does not tell you to run a shell command.

### On the test harness

Two changes there were load-bearing rather than incidental.

`TestAuth.openTeamPicker` was a no-op that did not take the selection the way the real picker does. The consumer reads the flag before the picker branch precisely because `openTeamPicker` takes ownership, and with the old stub a unit test covering that could pass whether or not the read was in the right place. Making the stub faithful is what lets the test actually pin it: removing the hoist now turns it red.

`TestApp` discarded `notice.tone`, so nothing could distinguish a warning notice from a neutral one. It records it now, and the test asserts the tone.

### Verification

Nine new end-to-end cases and six new unit tests. The three failure cases were each observed failing before the implementation, and both silence controls were proven load-bearing by forcing the flag true and watching them go red.

The full `tui-auth-source-selection.test.ts` run was compared against the same file on `main`: identical failing-test sets, 14 either way, none of them these. The Zig suite was compared the same way, by failing test name rather than count. `zig fmt --check src/` passes.

Full CI on my fork is green on this commit. It took a few runs to get there, and the reason is worth recording rather than hiding: `E2E (ReleaseSafe, macos-aarch64, shard 3/4)` failed twice before passing, on subagent-manager tests.

That shard is flaky on `main` independently of this change. I pushed `261a7c3f` unmodified to my fork and ran the same workflow: it passed once and then failed the same shard, on `configure rejects a concurrent winner then retries the preserved draft once`, `persistent child pointer drag replaces the selected composer range`, and `persistent child preserves its reading position across both reopen paths`. Across runs the failing set keeps changing, and the pointer-drag test failed on both `main` and this branch.

Tally on `macos-aarch64 shard 3/4`: unmodified `main` 1 pass / 1 fail, this branch 1 pass / 2 fail.

I mention it because my first read was that the shard could not be related since its tests never touch the login path, and that reasoning was wrong: every e2e test drives the same binary this change is compiled into. The A/B against unmodified `main` is what actually settles it, not the argument from test names.

### Not covered

A socket-level transport failure is not directly exercised. It reaches the same catch as the HTTP cases, so the flag is covered, but the socket path itself is not.

The wasm `fetchTeamsFromJsHost` branch has no test here.

Re-authenticating over an existing session still clears a previously selected team when the fetch fails. That predates this change and fixing it means deciding a team should survive re-login, which felt like a separate call to make.

