### PR TITLE
Reduce duplicated error-result constants

### DIFF
--- a/src/core/mcp/project_config.zig
+++ b/src/core/mcp/project_config.zig
@@ -178,13 +178,21 @@ pub fn parseProfileJson(alloc: Allocator, json_text: []const u8) !std.ArrayList(
     return configs;
 }
 
+inline fn failProfileParse(err: anytype) @TypeOf(err)!ProfileParseResult {
+    return @errorCast(failProfileParseDynamic(err));
+}
+
+noinline fn failProfileParseDynamic(err: anyerror) anyerror!ProfileParseResult {
+    return err;
+}
+
 pub fn parseProfileDocument(alloc: Allocator, json_text: []const u8) !ProfileParseResult {
     var parsed = std.json.parseFromSlice(std.json.Value, alloc, json_text, .{}) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.McpConfigInvalidJson,
+        error.OutOfMemory => return failProfileParse(error.OutOfMemory),
+        else => return failProfileParse(error.McpConfigInvalidJson),
     };
     defer parsed.deinit();
-    if (parsed.value != .object) return error.McpConfigRootMustBeObject;
+    if (parsed.value != .object) return failProfileParse(error.McpConfigRootMustBeObject);
 
     const object = parsed.value.object;
     const canonical = object.get("mcp");
@@ -855,21 +863,48 @@ pub fn configRetainsWorkspaceAuthority(
     return false;
 }
 
+inline fn failServerConfig(err: anytype) @TypeOf(err)!McpServerConfig {
+    return @errorCast(failServerConfigDynamic(err));
+}
+
+noinline fn failServerConfigDynamic(err: anyerror) anyerror!McpServerConfig {
+    return err;
+}
+
+test "project config failures preserve exact error types and identities" {
+    const invalid = failServerConfig(error.McpConfigInvalidType);
+    try std.testing.expect(
+        @TypeOf(invalid) == error{McpConfigInvalidType}!McpServerConfig,
+    );
+    try std.testing.expectError(error.McpConfigInvalidType, invalid);
+    try std.testing.expectError(
+        error.McpConfigServerMustBeObject,
+        failServerConfig(error.McpConfigServerMustBeObject),
+    );
+    try std.testing.expectError(error.OutOfMemory, failServerConfig(error.OutOfMemory));
+
+    const invalid_profile = failProfileParse(error.McpConfigInvalidJson);
+    try std.testing.expect(
+        @TypeOf(invalid_profile) == error{McpConfigInvalidJson}!ProfileParseResult,
+    );
+    try std.testing.expectError(error.McpConfigInvalidJson, invalid_profile);
+}
+
 fn parseServerEntry(
     alloc: Allocator,
     name: []const u8,
     value: std.json.Value,
     policy: ParsePolicy,
 ) !McpServerConfig {
-    if (value != .object) return error.McpConfigServerMustBeObject;
+    if (value != .object) return failServerConfig(error.McpConfigServerMustBeObject);
     if (!mcp_contract.sourceAllowsScope(policy.source, policy.scope) or
         !mcp_contract.sourceAllowsWorkspaceAdmission(policy.source, policy.workspace_admission))
     {
-        return error.McpConfigPolicyInvalid;
+        return failServerConfig(error.McpConfigPolicyInvalid);
     }
     const object = value.object;
     const type_string = if (object.get("type")) |kind_value|
-        (if (kind_value == .string) kind_value.string else return error.McpConfigInvalidType)
+        (if (kind_value == .string) kind_value.string else return failServerConfig(error.McpConfigInvalidType))
     else
         "local";
     const transport: McpTransport = if (std.mem.eql(u8, type_string, "sse"))
@@ -880,22 +915,22 @@ fn parseServerEntry(
         .stdio;
     if (transport == .stdio and
         !std.mem.eql(u8, type_string, "local") and
-        !std.mem.eql(u8, type_string, "stdio")) return error.McpConfigInvalidType;
+        !std.mem.eql(u8, type_string, "stdio")) return failServerConfig(error.McpConfigInvalidType);
 
     const enabled = if (object.get("enabled")) |field|
-        if (field == .bool) field.bool else return error.McpConfigInvalidEnabled
+        if (field == .bool) field.bool else return failServerConfig(error.McpConfigInvalidEnabled)
     else
         true;
     const configured_required = if (object.get("required")) |field|
-        if (field == .bool) field.bool else return error.McpConfigInvalidRequired
+        if (field == .bool) field.bool else return failServerConfig(error.McpConfigInvalidRequired)
     else
         false;
     const required = if (policy.force_optional) false else configured_required;
 
     if (transport != .stdio) {
-        const url_value = object.get("url") orelse return error.McpConfigMissingUrl;
-        if (url_value != .string) return error.McpConfigInvalidUrl;
-        streamable_http.validateEndpoint(url_value.string) catch return error.McpConfigInvalidUrl;
+        const url_value = object.get("url") orelse return failServerConfig(error.McpConfigMissingUrl);
+        if (url_value != .string) return failServerConfig(error.McpConfigInvalidUrl);
+        streamable_http.validateEndpoint(url_value.string) catch return failServerConfig(error.McpConfigInvalidUrl);
         const timeouts = try parseTimeouts(object);
         const env = try parseSelectedEnvironment(alloc, object);
         errdefer freeEnvVars(alloc, env);
@@ -909,10 +944,10 @@ fn parseServerEntry(
         errdefer freeHttpHeaderEnv(alloc, header_env);
         const bearer_token_env = try parseOptionalOwnedString(alloc, object, "bearer_token_env");
         errdefer if (bearer_token_env) |field| alloc.free(field);
-        if (bearer_token_env) |field| if (!isValidEnvName(field)) return error.McpConfigInvalidBearerEnvironment;
+        if (bearer_token_env) |field| if (!isValidEnvName(field)) return failServerConfig(error.McpConfigInvalidBearerEnvironment);
         var auth = parseProfileAuth(alloc, object) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            else => return error.McpConfigInvalidOAuth,
+            error.OutOfMemory => return failServerConfig(error.OutOfMemory),
+            else => return failServerConfig(error.McpConfigInvalidOAuth),
         };
         errdefer if (auth) |*field| field.deinit(alloc);
         const owned_name = try alloc.dupe(u8, name);
@@ -945,10 +980,10 @@ fn parseServerEntry(
         mcp_contract.default_restart_limit,
         0,
         std.math.maxInt(u8),
-    ) catch return error.McpConfigInvalidRestartLimit;
+    ) catch return failServerConfig(error.McpConfigInvalidRestartLimit);
     const command = parseCommandSpec(alloc, object) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.McpConfigInvalidCommand,
+        error.OutOfMemory => return failServerConfig(error.OutOfMemory),
+        else => return failServerConfig(error.McpConfigInvalidCommand),
     };
     errdefer freeParsedCommandSpec(alloc, command);
     const env = try parseSelectedEnvironment(alloc, object);

--- a/src/core/session/session_event.zig
+++ b/src/core/session/session_event.zig
@@ -269,20 +269,35 @@ pub fn encodeFrame(alloc: Allocator, envelope: Envelope) ![]u8 {
     return try out.toOwnedSlice();
 }
 
+inline fn failEnvelope(err: anytype) @TypeOf(err)!Envelope {
+    return @errorCast(failEnvelopeDynamic(err));
+}
+
+noinline fn failEnvelopeDynamic(err: anyerror) anyerror!Envelope {
+    return err;
+}
+
+test "session envelope failures preserve exact error types and identities" {
+    const invalid = failEnvelope(error.InvalidEventFrame);
+    try std.testing.expect(@TypeOf(invalid) == error{InvalidEventFrame}!Envelope);
+    try std.testing.expectError(error.InvalidEventFrame, invalid);
+    try std.testing.expectError(error.OutOfMemory, failEnvelope(error.OutOfMemory));
+}
+
 pub fn decodeFrame(alloc: Allocator, line: []const u8) !Envelope {
-    if (line.len > event_frame_max_bytes) return error.EventFrameTooLarge;
+    if (line.len > event_frame_max_bytes) return failEnvelope(error.EventFrameTooLarge);
     if (line.len == 0 or line[line.len - 1] != '\n') {
-        return error.InvalidEventFrame;
+        return failEnvelope(error.InvalidEventFrame);
     }
     if (std.mem.indexOfScalar(u8, line[0 .. line.len - 1], '\n') != null) {
-        return error.InvalidEventFrame;
+        return failEnvelope(error.InvalidEventFrame);
     }
 
     var parsed = std.json.parseFromSlice(std.json.Value, alloc, line[0 .. line.len - 1], .{
         .parse_numbers = false,
     }) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.InvalidEventFrame,
+        error.OutOfMemory => return failEnvelope(error.OutOfMemory),
+        else => return failEnvelope(error.InvalidEventFrame),
     };
     defer parsed.deinit();
     const root = try exactObject(parsed.value, &.{
@@ -294,15 +309,15 @@ pub fn decodeFrame(alloc: Allocator, line: []const u8) !Envelope {
         "kind",
         "payload",
     });
-    if (try requireU64(root, "schema_version") != 1) return error.UnsupportedEventSchema;
+    if (try requireU64(root, "schema_version") != 1) return failEnvelope(error.UnsupportedEventSchema);
     const kind = std.meta.stringToEnum(Kind, try requireString(root, "kind")) orelse
-        return error.InvalidEventFrame;
+        return failEnvelope(error.InvalidEventFrame);
     var envelope = Envelope{
         .log_generation = try parseIdentifier(try requireString(root, "log_generation")),
         .seq = try requireU64(root, "seq"),
         .event_id = try parseIdentifier(try requireString(root, "event_id")),
         .timestamp_ms = try requireI64(root, "timestamp_ms"),
-        .event = try parsePayload(alloc, kind, root.get("payload") orelse return error.InvalidEventFrame),
+        .event = try parsePayload(alloc, kind, root.get("payload") orelse return failEnvelope(error.InvalidEventFrame)),
     };
     errdefer envelope.deinit(alloc);
     try validateEnvelope(envelope);
@@ -433,6 +448,23 @@ pub fn applyEventFrame(
     return reductionBoundary(envelope, frame_bytes);
 }
 
+inline fn failReduction(err: anytype) @TypeOf(err)!Reduction {
+    return @errorCast(failReductionDynamic(err));
+}
+
+noinline fn failReductionDynamic(err: anyerror) anyerror!Reduction {
+    return err;
+}
+
+test "session event reduction failures preserve exact error types and identities" {
+    const invalid = failReduction(error.InvalidReductionStart);
+    try std.testing.expect(
+        @TypeOf(invalid) == error{InvalidReductionStart}!Reduction,
+    );
+    try std.testing.expectError(error.InvalidReductionStart, invalid);
+    try std.testing.expectError(error.MissingSessionStarted, failReduction(error.MissingSessionStarted));
+}
+
 pub fn reduceJsonlFrom(
     alloc: Allocator,
     source: *std.Io.Reader,
@@ -444,7 +476,7 @@ pub fn reduceJsonlFrom(
     if (start.next_seq == 0 or
         (state == null and (start.generation != null or start.next_seq != 1)))
     {
-        return error.InvalidReductionStart;
+        return failReduction(error.InvalidReductionStart);
     }
     var validator = SequenceValidator{
         .generation = start.generation,
@@ -467,7 +499,7 @@ pub fn reduceJsonlFrom(
         try validator.validate(envelope);
 
         if (envelope.kind() == .state_replacement_started) {
-            if (state == null) return error.InvalidReplacement;
+            if (state == null) return failReduction(error.InvalidReplacement);
             const replacement = try reduceReplacement(
                 alloc,
                 source,
@@ -493,14 +525,14 @@ pub fn reduceJsonlFrom(
         if (envelope.kind() == .state_replacement_chunk or
             envelope.kind() == .state_replacement_committed)
         {
-            return error.InvalidReplacement;
+            return failReduction(error.InvalidReplacement);
         }
         try applyDelta(alloc, &state, envelope);
         through = reductionBoundary(envelope, byte_offset);
     }
 
     return .{
-        .state = state orelse return error.MissingSessionStarted,
+        .state = state orelse return failReduction(error.MissingSessionStarted),
         .through = through,
         .bytes_consumed = byte_offset,
     };

--- a/src/core/session/session_replay.zig
+++ b/src/core/session/session_replay.zig
@@ -155,6 +155,26 @@ pub const ExactReplay = struct {
     }
 };
 
+inline fn failExactReplay(err: anytype) @TypeOf(err)!ExactReplay {
+    return @errorCast(failExactReplayDynamic(err));
+}
+
+noinline fn failExactReplayDynamic(err: anyerror) anyerror!ExactReplay {
+    return err;
+}
+
+test "exact replay failures preserve exact error types and identities" {
+    const invalid = failExactReplay(error.InvalidSessionFormat);
+    try std.testing.expect(
+        @TypeOf(invalid) == error{InvalidSessionFormat}!ExactReplay,
+    );
+    try std.testing.expectError(error.InvalidSessionFormat, invalid);
+    try std.testing.expectError(
+        error.UnsupportedSessionSchema,
+        failExactReplay(error.UnsupportedSessionSchema),
+    );
+}
+
 pub fn replayExactPosition(
     alloc: Allocator,
     file: std.Io.File,
@@ -165,7 +185,7 @@ pub fn replayExactPosition(
     if (expected_bytes == 0 or
         try file.length(io_mod.getIo()) != expected_bytes)
     {
-        return error.InvalidSessionFormat;
+        return failExactReplay(error.InvalidSessionFormat);
     }
     var file_buffer: [8192]u8 = undefined;
     var file_reader = file.reader(io_mod.getIo(), &file_buffer);
@@ -180,18 +200,18 @@ pub fn replayExactPosition(
         null,
     ) catch |err| switch (err) {
         error.OutOfMemory, error.ReadFailed => return err,
-        error.UnsupportedEventSchema => return error.UnsupportedSessionSchema,
-        else => return error.InvalidSessionFormat,
+        error.UnsupportedEventSchema => return failExactReplay(error.UnsupportedSessionSchema),
+        else => return failExactReplay(error.InvalidSessionFormat),
     };
     errdefer reduction.deinit(alloc);
-    const through = reduction.through orelse return error.InvalidSessionFormat;
+    const through = reduction.through orelse return failExactReplay(error.InvalidSessionFormat);
     if (reduction.truncate_from != null or
         reduction.bytes_consumed != expected_bytes or
         through.byte_offset != expected_bytes or
         through.seq != expected_seq or
         !std.mem.eql(u8, &through.log_generation, &expected_generation))
     {
-        return error.InvalidSessionFormat;
+        return failExactReplay(error.InvalidSessionFormat);
     }
     const state = reduction.state;
     reduction.state = undefined;

--- a/src/core/shared/lexical_relevance.zig
+++ b/src/core/shared/lexical_relevance.zig
@@ -18,6 +18,20 @@ pub const PreparedQuery = struct {
     }
 };
 
+inline fn failPreparedQuery(err: anytype) @TypeOf(err)!PreparedQuery {
+    return @errorCast(failPreparedQueryDynamic(err));
+}
+
+noinline fn failPreparedQueryDynamic(err: anyerror) anyerror!PreparedQuery {
+    return err;
+}
+
+test "prepared query failures preserve exact error types and identities" {
+    const too_long = failPreparedQuery(error.QueryTooLong);
+    try std.testing.expect(@TypeOf(too_long) == error{QueryTooLong}!PreparedQuery);
+    try std.testing.expectError(error.QueryTooLong, too_long);
+}
+
 pub const Score = struct {
     exact_identity: bool = false,
     strong_hits: usize = 0,
@@ -25,7 +39,7 @@ pub const Score = struct {
 };
 
 pub fn prepare(query: []const u8) PrepareError!PreparedQuery {
-    if (query.len > max_query_bytes) return error.QueryTooLong;
+    if (query.len > max_query_bytes) return failPreparedQuery(error.QueryTooLong);
 
     var prepared = PreparedQuery{
         .raw = query,

--- a/src/core/terminal/engine.zig
+++ b/src/core/terminal/engine.zig
@@ -219,6 +219,21 @@ const SavedScreen = struct {
     }
 };
 
+inline fn failGrid(err: anytype) @TypeOf(err)!Grid {
+    return @errorCast(failGridDynamic(err));
+}
+
+noinline fn failGridDynamic(err: anyerror) anyerror!Grid {
+    return err;
+}
+
+test "grid failures preserve exact error types and identities" {
+    const invalid = failGrid(error.InvalidGridSize);
+    try std.testing.expect(@TypeOf(invalid) == error{InvalidGridSize}!Grid);
+    try std.testing.expectError(error.InvalidGridSize, invalid);
+    try std.testing.expectError(error.OutOfMemory, failGrid(error.OutOfMemory));
+}
+
 pub const Grid = struct {
     alloc: Allocator,
     rows: u16,
@@ -302,14 +317,14 @@ pub const Grid = struct {
     feed_result: ?*FeedResult = null,
 
     pub fn init(alloc: Allocator, cols: u16, rows: u16) !Grid {
-        if (cols == 0 or rows == 0) return error.InvalidGridSize;
+        if (cols == 0 or rows == 0) return failGrid(error.InvalidGridSize);
         const cell_count = std.math.mul(
             usize,
             @intCast(cols),
             @intCast(rows),
-        ) catch return error.InvalidGridSize;
+        ) catch return failGrid(error.InvalidGridSize);
         if (cell_count > contracts.max_render_cells) {
-            return error.InvalidGridSize;
+            return failGrid(error.InvalidGridSize);
         }
         const cells = try alloc.alloc(Cell, cell_count);
         errdefer alloc.free(cells);
@@ -1963,19 +1978,19 @@ pub const Grid = struct {
     /// reply effects. Callers replay later journal bytes observationally.
     pub fn restoreCheckpoint(alloc: Allocator, payload: []const u8) !Grid {
         if (payload.len > contracts.max_checkpoint_payload_bytes) {
-            return error.CheckpointTooLarge;
+            return failGrid(error.CheckpointTooLarge);
         }
         var decoder = CheckpointDecoder.init(payload);
         const magic = try decoder.fixed(checkpoint_magic.len);
         if (!std.mem.eql(u8, magic, checkpoint_magic)) {
-            return error.InvalidEngineCheckpoint;
+            return failGrid(error.InvalidEngineCheckpoint);
         }
         if (try decoder.int(u16) != checkpoint_schema_revision) {
-            return error.UnsupportedEngineRevision;
+            return failGrid(error.UnsupportedEngineRevision);
         }
         var grid = try decodeGridState(alloc, &decoder);
         errdefer grid.deinit();
-        if (!decoder.finished()) return error.InvalidEngineCheckpoint;
+        if (!decoder.finished()) return failGrid(error.InvalidEngineCheckpoint);
         try grid.validateCheckpointState();
         return grid;
     }

--- a/src/core/terminal/native_session.zig
+++ b/src/core/terminal/native_session.zig
@@ -4893,6 +4893,23 @@ fn screenDurable(
     ) catch return error.OutOfMemory;
 }
 
+inline fn failReconstructedGrid(err: anytype) @TypeOf(err)!terminal_engine.Grid {
+    return @errorCast(failReconstructedGridDynamic(err));
+}
+
+noinline fn failReconstructedGridDynamic(err: anyerror) anyerror!terminal_engine.Grid {
+    return err;
+}
+
+test "reconstructed grid failures preserve exact error types and identities" {
+    const corrupt = failReconstructedGrid(error.ScreenCorrupt);
+    try std.testing.expect(
+        @TypeOf(corrupt) == error{ScreenCorrupt}!terminal_engine.Grid,
+    );
+    try std.testing.expectError(error.ScreenCorrupt, corrupt);
+    try std.testing.expectError(error.OutOfMemory, failReconstructedGrid(error.OutOfMemory));
+}
+
 fn reconstructEngine(
     alloc: Allocator,
     durable: *terminal_store.DurableSession,
@@ -4943,7 +4960,7 @@ fn reconstructEngine(
         output,
     )) {
         try durable.mark_screen_unavailable(.raw_gap, io_mod.milliTimestamp());
-        return error.ScreenRawGap;
+        return failReconstructedGrid(error.ScreenRawGap);
     }
 
     var grid = terminal_engine.Grid.restoreCheckpoint(
@@ -4981,14 +4998,14 @@ fn reconstructEngine(
         checkpoint.envelope.applied_cursor,
         output,
     ) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
+        error.OutOfMemory => return failReconstructedGrid(error.OutOfMemory),
         error.ScreenRawGap, error.MissingJournalSegment => {
             try durable.mark_screen_unavailable(.raw_gap, io_mod.milliTimestamp());
-            return error.ScreenRawGap;
+            return failReconstructedGrid(error.ScreenRawGap);
         },
         error.ScreenCorrupt, error.CorruptJournalSegment => {
             try durable.mark_screen_unavailable(.corrupt, io_mod.milliTimestamp());
-            return error.ScreenCorrupt;
+            return failReconstructedGrid(error.ScreenCorrupt);
         },
         else => return err,
     };
@@ -5045,11 +5062,11 @@ fn replayFromStart(
     replayEngine(alloc, durable, &grid, initial, output) catch |err| switch (err) {
         error.ScreenRawGap, error.MissingJournalSegment => {
             try durable.mark_screen_unavailable(.raw_gap, io_mod.milliTimestamp());
-            return error.ScreenRawGap;
+            return failReconstructedGrid(error.ScreenRawGap);
         },
         error.ScreenCorrupt, error.CorruptJournalSegment => {
             try durable.mark_screen_unavailable(.corrupt, io_mod.milliTimestamp());
-            return error.ScreenCorrupt;
+            return failReconstructedGrid(error.ScreenCorrupt);
         },
         else => return err,
     };

--- a/src/core/terminal/protocol.zig
+++ b/src/core/terminal/protocol.zig
@@ -193,13 +193,30 @@ pub fn projectResultForCapabilities(
     return .{ .failure = compatible };
 }
 
+inline fn failDecodedFrame(err: anytype) @TypeOf(err)!DecodedFrame {
+    return @errorCast(failDecodedFrameDynamic(err));
+}
+
+noinline fn failDecodedFrameDynamic(err: anyerror) anyerror!DecodedFrame {
+    return err;
+}
+
+test "decoded frame failures preserve exact error types and identities" {
+    const truncated = failDecodedFrame(error.TruncatedFrame);
+    try std.testing.expect(
+        @TypeOf(truncated) == error{TruncatedFrame}!DecodedFrame,
+    );
+    try std.testing.expectError(error.TruncatedFrame, truncated);
+    try std.testing.expectError(error.OutOfMemory, failDecodedFrame(error.OutOfMemory));
+}
+
 pub fn decodeFrame(alloc: Allocator, bytes: []const u8) DecodeError!DecodedFrame {
     const header = try Header.decode(bytes);
     const payload_len: usize = header.envelope.payload_len;
     const expected_len = std.math.add(usize, header_len, payload_len) catch
-        return error.HostFrameTooLarge;
-    if (bytes.len < expected_len) return error.TruncatedFrame;
-    if (bytes.len != expected_len) return error.InvalidHostFrame;
+        return failDecodedFrame(error.HostFrameTooLarge);
+    if (bytes.len < expected_len) return failDecodedFrame(error.TruncatedFrame);
+    if (bytes.len != expected_len) return failDecodedFrame(error.InvalidHostFrame);
 
     var parsed = std.json.parseFromSlice(
         contracts.MessagePayload,
@@ -207,8 +224,8 @@ pub fn decodeFrame(alloc: Allocator, bytes: []const u8) DecodeError!DecodedFrame
         bytes[header_len..],
         .{ .allocate = .alloc_always },
     ) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.InvalidPayload,
+        error.OutOfMemory => return failDecodedFrame(error.OutOfMemory),
+        else => return failDecodedFrame(error.InvalidPayload),
     };
     errdefer parsed.deinit();
     try (contracts.HostMessage{
@@ -227,18 +244,18 @@ pub fn readFrame(
 ) (DecodeError || std.Io.Reader.Error)!DecodedFrame {
     var header_bytes: [header_len]u8 = undefined;
     reader.readSliceAll(&header_bytes) catch |err| switch (err) {
-        error.EndOfStream => return error.TruncatedFrame,
+        error.EndOfStream => return failDecodedFrame(error.TruncatedFrame),
         else => return err,
     };
     const header = try Header.decode(&header_bytes);
     const payload_len: usize = header.envelope.payload_len;
     const total_len = std.math.add(usize, header_len, payload_len) catch
-        return error.HostFrameTooLarge;
+        return failDecodedFrame(error.HostFrameTooLarge);
     var bytes = try alloc.alloc(u8, total_len);
     defer alloc.free(bytes);
     @memcpy(bytes[0..header_len], &header_bytes);
     reader.readSliceAll(bytes[header_len..]) catch |err| switch (err) {
-        error.EndOfStream => return error.TruncatedFrame,
+        error.EndOfStream => return failDecodedFrame(error.TruncatedFrame),
         else => return err,
     };
     return decodeFrame(alloc, bytes);

--- a/src/core/terminal/store.zig
+++ b/src/core/terminal/store.zig
@@ -6013,28 +6013,46 @@ fn save_record(
     entry.deinit(alloc);
 }
 
+inline fn failRecord(err: anytype) @TypeOf(err)!Record {
+    return @errorCast(failRecordDynamic(err));
+}
+
+noinline fn failRecordDynamic(err: anyerror) anyerror!Record {
+    return err;
+}
+
+test "terminal record failures preserve exact error types and identities" {
+    const missing = failRecord(error.TerminalRecordNotFound);
+    try std.testing.expect(
+        @TypeOf(missing) == error{TerminalRecordNotFound}!Record,
+    );
+    try std.testing.expectError(error.TerminalRecordNotFound, missing);
+    try std.testing.expectError(error.OutOfMemory, failRecord(error.OutOfMemory));
+}
+
 fn load_record(
     alloc: Allocator,
     capability: *session_child_store.SessionChildCapability,
     session_id: []const u8,
 ) !Record {
-    const name = try record_name(alloc, session_id);
+    const name = record_name(alloc, session_id) catch |err|
+        return failRecord(err);
     defer alloc.free(name);
     var file = capability.openFileReadOnly(
         alloc,
         .terminal_state,
         name,
     ) catch |err| switch (err) {
-        error.FileNotFound => return error.TerminalRecordNotFound,
-        else => return err,
+        error.FileNotFound => return failRecord(error.TerminalRecordNotFound),
+        else => return failRecord(err),
     };
     defer file.deinit();
     const bytes = file.readToEnd(alloc, max_record_bytes) catch |err| switch (err) {
-        error.StreamTooLong => return error.TerminalRecordTooLarge,
-        else => return err,
+        error.StreamTooLong => return failRecord(error.TerminalRecordTooLarge),
+        else => return failRecord(err),
     };
     defer alloc.free(bytes);
-    return parse_record(alloc, bytes);
+    return parse_record(alloc, bytes) catch |err| return failRecord(err);
 }
 
 fn write_owner_catalog_proof(


### PR DESCRIPTION
## Summary

- Share repeated failure-result publication across MCP config parsing, session replay, terminal recovery, and bounded query parsing.
- Preserve error identities and successful paths while removing one 16 KiB ReleaseSafe file block.

Stacked on #473.