### PR TITLE
Preserve terminal outcomes across runtime failures

### DIFF
--- a/src/core/agent/runtime/finalization.zig
+++ b/src/core/agent/runtime/finalization.zig
@@ -87,8 +87,7 @@ pub const TurnFinalizationGuard = struct {
         }
     }
 
-    fn cleanup_agent_terminal_leases(self: *TurnFinalizationGuard) !void {
-        var first_error: ?anyerror = null;
+    fn cleanup_agent_terminal_leases(self: *TurnFinalizationGuard) void {
         for (self.agent_terminal_leases.items) |session_id| {
             self.deps.release_agent_terminal_lease(
                 self.deps.ctx,
@@ -99,10 +98,8 @@ pub const TurnFinalizationGuard = struct {
                     "turn lease cleanup failed turn_id={d} session_id={s} err={s}",
                     .{ self.turn_id, session_id, @errorName(err) },
                 );
-                if (first_error == null) first_error = err;
             };
         }
-        if (first_error) |err| return err;
     }
 
     pub fn finish(
@@ -123,13 +120,7 @@ pub const TurnFinalizationGuard = struct {
             return;
         }
 
-        self.cleanup_agent_terminal_leases() catch |err| {
-            self.state = .fatal;
-            if (finished_prompt) |finished| {
-                types.freeFinishedPrompt(std.heap.c_allocator, finished);
-            }
-            return err;
-        };
+        self.cleanup_agent_terminal_leases();
 
         self.deps.finalize_turn(self.deps.ctx, self.turn_id, outcome, disposition) catch |err| {
             self.state = .fatal;

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -331,12 +331,15 @@ fn agent_terminal_lease_transition(
     if (parsed != .object) return error.InvalidTerminalLeaseTrackingInput;
     const action = parsed.object.get("action") orelse return error.InvalidTerminalLeaseTrackingInput;
     if (action != .string) return error.InvalidTerminalLeaseTrackingInput;
-    if (!std.mem.eql(u8, action.string, "write")) return null;
+    const is_write = std.mem.eql(u8, action.string, "write");
+    const is_close = std.mem.eql(u8, action.string, "close");
+    if (!is_write and !is_close) return null;
     const session_id = parsed.object.get("session_id") orelse
         return error.InvalidTerminalLeaseTrackingInput;
     if (session_id != .string) {
         return error.InvalidTerminalLeaseTrackingInput;
     }
+    if (is_close) return .{ .remove = session_id.string };
     const lease_value = parsed.object.get("lease");
     const lease_absent = lease_value == null or terminal_lease_is_absent(lease_value.?);
     if (lease_absent) {
@@ -357,7 +360,7 @@ fn agent_terminal_lease_transition(
     };
 }
 
-test "agent terminal lease transitions derive from normalized validated write intent" {
+test "agent terminal lease transitions derive from normalized validated actions" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -426,6 +429,22 @@ test "agent terminal lease transitions derive from normalized validated write in
             ),
             .track, .remove => unreachable,
         }
+    }
+    const close = (try agent_terminal_lease_transition(
+        arena,
+        registry,
+        .{
+            .id = "close",
+            .name = "terminal",
+            .arguments_json = "{\"action\":\"close\",\"session_id\":\"terminal-one\",\"close_policy\":\"force\"}",
+        },
+    )).?;
+    switch (close) {
+        .remove => |session_id| try std.testing.expectEqualStrings(
+            "terminal-one",
+            session_id,
+        ),
+        .track, .atomic => unreachable,
     }
     try std.testing.expect((try agent_terminal_lease_transition(
         arena,

--- a/src/core/agent/runtime/tests/finalization_flow.zig
+++ b/src/core/agent/runtime/tests/finalization_flow.zig
@@ -1719,7 +1719,7 @@ test "TurnFinalizationGuard runs PostTurnEnd once for every terminal outcome and
     }
 }
 
-test "TurnFinalizationGuard attempts every tracked lease and returns the first cleanup error" {
+test "TurnFinalizationGuard attempts every tracked lease without replacing accepted completion" {
     const alloc = std.testing.allocator;
     const cleanup_errors = [_]?anyerror{
         error.TestFirstCleanupFailed,
@@ -1739,16 +1739,23 @@ test "TurnFinalizationGuard attempts every tracked lease and returns the first c
     try finalization.track_agent_terminal_lease("terminal-one");
     try finalization.track_agent_terminal_lease("terminal-two");
     finalization.remove_agent_terminal_lease("terminal-missing");
+    const finished = try types.dupeFinishedPrompt(std.heap.c_allocator, .{
+        .turn = .{ .assistant = .{
+            .user = .{ .text = @constCast("prompt") },
+            .assistant = @constCast("accepted answer"),
+        } },
+    });
 
-    try std.testing.expectError(
-        error.TestFirstCleanupFailed,
-        finalization.finish(.failed, null, null),
-    );
-    try std.testing.expectEqual(TurnFinalizationGuard.State.fatal, finalization.state);
+    try finalization.finish(.completed, .completed, finished);
+    try finalization.finish(.failed, null, null);
+    try std.testing.expectEqual(TurnFinalizationGuard.State.emitted, finalization.state);
     try std.testing.expectEqual(@as(usize, 2), deps.terminal_lease_cleanup_ids.items.len);
     try std.testing.expectEqualStrings("terminal-one", deps.terminal_lease_cleanup_ids.items[0]);
     try std.testing.expectEqualStrings("terminal-two", deps.terminal_lease_cleanup_ids.items[1]);
-    try std.testing.expectEqual(@as(usize, 0), deps.finalization_count);
+    try std.testing.expectEqual(@as(usize, 1), deps.finalization_count);
+    try std.testing.expectEqual(@as(usize, 1), deps.finish_event_count);
+    try std.testing.expectEqual(@as(usize, 1), deps.finish_event_attempt_count);
+    try std.testing.expectEqualStrings("accepted answer", deps.finish_assistant_text.?);
 }
 
 test "TurnFinalizationGuard removes explicit release without cleanup" {

--- a/src/core/execution/command_contract.zig
+++ b/src/core/execution/command_contract.zig
@@ -23,6 +23,7 @@ pub const ForegroundCommandResult = struct {
     exit_code: ?i64 = null,
     signal: ?u32 = null,
     timed_out: bool = false,
+    termination_indeterminate: bool = false,
     duration_ms: ?u64 = null,
     stdout_bytes: usize = 0,
     stderr_bytes: usize = 0,
@@ -72,6 +73,7 @@ pub const ForegroundCommandStatus = union(enum) {
     exit_code: i64,
     signal: u32,
     finished,
+    indeterminate,
 };
 
 pub const ForegroundCommandResultSnapshot = struct {
@@ -105,6 +107,7 @@ pub fn formatForegroundCommandResult(
             .cwd = snapshot.cwd,
             .exit_code = foregroundExitCode(snapshot.status),
             .signal = foregroundSignal(snapshot.status),
+            .termination_indeterminate = snapshot.status == .indeterminate,
             .duration_ms = snapshot.duration_ms,
             .stdout_bytes = snapshot.stdout_bytes,
             .stderr_bytes = snapshot.stderr_bytes,
@@ -117,6 +120,10 @@ fn writeForegroundStatusLine(writer: *std.Io.Writer, status: ForegroundCommandSt
         .exit_code => |code| try writer.print("exit_code={d}\n", .{code}),
         .signal => |signal| try writer.print("signal={d}\n", .{signal}),
         .finished => try writer.writeAll("process finished\n"),
+        .indeterminate => try writer.writeAll(
+            "termination_indeterminate=true\n" ++
+                "message=the command was started, but fx could not confirm its final process status; do not retry unchanged because side effects may already exist\n",
+        ),
     }
 }
 
@@ -157,6 +164,9 @@ fn writeForegroundJson(result: ForegroundCommandResult, writer: *std.Io.Writer) 
     try writeOptionalIntField(writer, "exit_code", result.exit_code);
     try writeOptionalIntField(writer, "signal", result.signal);
     try writeBoolField(writer, "timed_out", result.timed_out);
+    if (result.termination_indeterminate) {
+        try writeBoolField(writer, "termination_indeterminate", true);
+    }
     try writeOptionalIntField(writer, "duration_ms", result.duration_ms);
     try writeIntField(writer, "stdout_bytes", result.stdout_bytes);
     try writeIntField(writer, "stderr_bytes", result.stderr_bytes);
@@ -258,4 +268,35 @@ test "foreground result preserves empty finished output" {
     });
     defer std.testing.allocator.free(result.output);
     try std.testing.expectEqualStrings("process finished\n(no output)\n", result.output);
+}
+
+test "foreground result represents indeterminate termination without implying no execution" {
+    const result = try formatForegroundCommandResult(std.testing.allocator, .{
+        .command = "printf effect > marker",
+        .cwd = "/tmp",
+        .status = .indeterminate,
+        .stdout_display = "observed output",
+        .stderr_display = "",
+        .stdout_bytes = 15,
+        .stderr_bytes = 0,
+    });
+    defer std.testing.allocator.free(result.output);
+
+    try std.testing.expect(std.mem.find(
+        u8,
+        result.output,
+        "termination_indeterminate=true",
+    ) != null);
+    try std.testing.expect(std.mem.find(u8, result.output, "do not retry unchanged") != null);
+    const foreground = result.command_result.?.foreground;
+    try std.testing.expect(foreground.termination_indeterminate);
+    try std.testing.expectEqual(@as(?i64, null), foreground.exit_code);
+    try std.testing.expectEqual(@as(?u32, null), foreground.signal);
+    const json = try result.command_result.?.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.find(
+        u8,
+        json,
+        "\"termination_indeterminate\":true",
+    ) != null);
 }

--- a/src/core/execution/command_contract.zig
+++ b/src/core/execution/command_contract.zig
@@ -87,6 +87,12 @@ pub const ForegroundCommandResultSnapshot = struct {
     duration_ms: ?u64 = null,
 };
 
+pub const ForegroundStatusProjection = struct {
+    exit_code: ?i64,
+    signal: ?u32,
+    termination_indeterminate: bool,
+};
+
 pub fn formatForegroundCommandResult(
     alloc: std.mem.Allocator,
     snapshot: ForegroundCommandResultSnapshot,
@@ -99,15 +105,16 @@ pub fn formatForegroundCommandResult(
 
     try writeForegroundStatusLine(&out.writer, snapshot.status);
     try writeForegroundOutputEnvelopes(&out.writer, stdout_text, stderr_text);
+    const status = projectForegroundStatus(snapshot.status);
 
     return .{
         .output = try out.toOwnedSlice(),
         .command_result = .{ .foreground = .{
             .command = snapshot.command,
             .cwd = snapshot.cwd,
-            .exit_code = foregroundExitCode(snapshot.status),
-            .signal = foregroundSignal(snapshot.status),
-            .termination_indeterminate = snapshot.status == .indeterminate,
+            .exit_code = status.exit_code,
+            .signal = status.signal,
+            .termination_indeterminate = status.termination_indeterminate,
             .duration_ms = snapshot.duration_ms,
             .stdout_bytes = snapshot.stdout_bytes,
             .stderr_bytes = snapshot.stderr_bytes,
@@ -115,7 +122,7 @@ pub fn formatForegroundCommandResult(
     };
 }
 
-fn writeForegroundStatusLine(writer: *std.Io.Writer, status: ForegroundCommandStatus) !void {
+pub fn writeForegroundStatusLine(writer: *std.Io.Writer, status: ForegroundCommandStatus) !void {
     switch (status) {
         .exit_code => |code| try writer.print("exit_code={d}\n", .{code}),
         .signal => |signal| try writer.print("signal={d}\n", .{signal}),
@@ -143,17 +150,30 @@ fn writeForegroundOutputEnvelopes(writer: *std.Io.Writer, stdout_text: []const u
     }
 }
 
-fn foregroundExitCode(status: ForegroundCommandStatus) ?i64 {
+pub fn projectForegroundStatus(
+    status: ForegroundCommandStatus,
+) ForegroundStatusProjection {
     return switch (status) {
-        .exit_code => |code| code,
-        else => null,
-    };
-}
-
-fn foregroundSignal(status: ForegroundCommandStatus) ?u32 {
-    return switch (status) {
-        .signal => |signal| signal,
-        else => null,
+        .exit_code => |code| .{
+            .exit_code = code,
+            .signal = null,
+            .termination_indeterminate = false,
+        },
+        .signal => |signal| .{
+            .exit_code = null,
+            .signal = signal,
+            .termination_indeterminate = false,
+        },
+        .finished => .{
+            .exit_code = null,
+            .signal = null,
+            .termination_indeterminate = false,
+        },
+        .indeterminate => .{
+            .exit_code = null,
+            .signal = null,
+            .termination_indeterminate = true,
+        },
     };
 }
 

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -252,18 +252,14 @@ fn foregroundRequestAtDeadline(
 const ChildWaiter = struct {
     child: *std.process.Child,
     io: std.Io,
-    inject_indeterminate: bool,
     ready: std.atomic.Value(bool) = .init(false),
-    result: (std.process.Child.WaitError || error{
-        InjectedChildTerminationIndeterminate,
-    })!std.process.Child.Term = undefined,
+    result: std.process.Child.WaitError!std.process.Child.Term = undefined,
     future: ?std.Io.Future(void) = null,
 
-    fn init(child: *std.process.Child, inject_indeterminate: bool) ChildWaiter {
+    fn init(child: *std.process.Child) ChildWaiter {
         return .{
             .child = child,
             .io = io_mod.getIo(),
-            .inject_indeterminate = inject_indeterminate,
         };
     }
 
@@ -276,17 +272,7 @@ const ChildWaiter = struct {
     }
 
     fn waitMain(self: *ChildWaiter) void {
-        const term = self.child.wait(self.io) catch |err| {
-            self.result = err;
-            self.ready.store(true, .release);
-            return;
-        };
-        self.result = if (self.inject_indeterminate and io_mod.getenv(
-            "FX_COMMAND_TEST_INDETERMINATE_AFTER_EXIT",
-        ) != null)
-            error.InjectedChildTerminationIndeterminate
-        else
-            term;
+        self.result = self.child.wait(self.io);
         self.ready.store(true, .release);
     }
 
@@ -331,7 +317,7 @@ fn waitForForegroundTarget(
         try descendants.refresh(target_pid);
         try std.posix.kill(target_pid, std.posix.SIG.CONT);
     }
-    var waiter = ChildWaiter.init(target, false);
+    var waiter = ChildWaiter.init(target);
     try waiter.start();
     var wait_pending = true;
     defer if (wait_pending) waiter.abort(target_pid);
@@ -673,14 +659,8 @@ fn emitAcceptedOutputChunk(
     try callback(ctx, cfg.output_chunk_lifecycle_id, stream, bytes);
 }
 
-const ProcessTermination = struct {
-    term: std.process.Child.Term,
-    indeterminate: bool = false,
-};
-
 const CollectedProcess = struct {
-    term: std.process.Child.Term,
-    termination_indeterminate: bool = false,
+    status: command_contract.ForegroundCommandStatus,
     stdout: []const u8,
     stderr: []const u8,
     stdout_bytes: usize,
@@ -932,15 +912,14 @@ const OutputCollector = struct {
 
     fn finish(
         self: *OutputCollector,
-        termination: ProcessTermination,
+        status: command_contract.ForegroundCommandStatus,
     ) !CollectedProcess {
         if (self.artifact) |*artifact| {
             try artifact.sync();
             try artifact.contentAddressManagedOutput(self.alloc);
             const truncated = self.totalBytes() > self.cfg.max_command_output_bytes;
             return .{
-                .term = termination.term,
-                .termination_indeterminate = termination.indeterminate,
+                .status = status,
                 .stdout = "",
                 .stderr = "",
                 .stdout_bytes = self.stdout_bytes,
@@ -955,8 +934,7 @@ const OutputCollector = struct {
         }
 
         return .{
-            .term = termination.term,
-            .termination_indeterminate = termination.indeterminate,
+            .status = status,
             .stdout = try self.stdout.toOwnedSlice(self.alloc),
             .stderr = try self.stderr.toOwnedSlice(self.alloc),
             .stdout_bytes = self.stdout_bytes,
@@ -991,7 +969,7 @@ const OutputCollector = struct {
 
 fn finishCollectedProcess(
     output: *OutputCollector,
-    termination: ProcessTermination,
+    status: command_contract.ForegroundCommandStatus,
     duration_ms: u64,
     source: TerminationSource,
 ) !CollectedProcess {
@@ -1009,7 +987,7 @@ fn finishCollectedProcess(
         },
     }
 
-    var result = output.finish(termination) catch |err| {
+    var result = output.finish(status) catch |err| {
         if (source != .cancelled) return err;
         debug_trace.logf("core", "cancelled command artifact finalization failed err={s}", .{@errorName(err)});
         return error.Cancelled;
@@ -1088,7 +1066,7 @@ fn executeProcessWithInput(
 
     return finishCollectedProcess(
         &output,
-        collected.termination,
+        collected.status,
         duration_ms,
         collected.source,
     );
@@ -1228,13 +1206,13 @@ fn executeProcessWithDetachedSession(
     const duration_ms = elapsedMs(started_ms, io_mod.milliTimestamp());
 
     if (foregroundSessionReplacementError(
-        collected.termination.term,
+        collected.status,
         launch_failure_probe,
     )) |launch_err| return launch_err;
     if (script_write_error) |write_err| return write_err;
     return finishCollectedProcess(
         &output,
-        collected.termination,
+        collected.status,
         duration_ms,
         collected.source,
     );
@@ -1324,11 +1302,11 @@ fn cleanupForegroundSessionChild(
 }
 
 fn foregroundSessionReplacementError(
-    term: std.process.Child.Term,
+    status: command_contract.ForegroundCommandStatus,
     probe: ForegroundLaunchFailureProbe,
 ) ?(std.process.ReplaceError || error{CommandLaunchFailed}) {
-    switch (term) {
-        .exited => |code| if (code != foreground_session_replace_failure_exit_code) return null,
+    switch (status) {
+        .exit_code => |code| if (code != foreground_session_replace_failure_exit_code) return null,
         else => return null,
     }
     if (probe.status != .failed) return null;
@@ -1381,7 +1359,7 @@ fn executeProcessWithScriptUnisolated(
 
     return finishCollectedProcess(
         &output,
-        collected.termination,
+        collected.status,
         duration_ms,
         collected.source,
     );
@@ -1822,10 +1800,7 @@ fn formatCollectedOutputValue(alloc: Allocator, command: []const u8, cwd: []cons
         alloc,
         command,
         cwd,
-        if (result.termination_indeterminate)
-            .indeterminate
-        else
-            foregroundCommandStatusFromTerm(result.term),
+        result.status,
         result.stdout,
         result.stderr,
         result.duration_ms,
@@ -1833,14 +1808,7 @@ fn formatCollectedOutputValue(alloc: Allocator, command: []const u8, cwd: []cons
 
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
-    if (result.termination_indeterminate) {
-        try out.writer.writeAll(
-            "termination_indeterminate=true\n" ++
-                "message=the command was started, but fx could not confirm its final process status; do not retry unchanged because side effects may already exist\n",
-        );
-    } else {
-        try writeTermLine(&out.writer, result.term);
-    }
+    try command_contract.writeForegroundStatusLine(&out.writer, result.status);
     try out.writer.print("truncated={s}\n", .{if (result.truncated) "true" else "false"});
     try out.writer.print("stdout_bytes={d}\n", .{result.stdout_bytes});
     try out.writer.print("stderr_bytes={d}\n", .{result.stderr_bytes});
@@ -1852,15 +1820,16 @@ fn formatCollectedOutputValue(alloc: Allocator, command: []const u8, cwd: []cons
         try writePreviewEnvelope(alloc, &out.writer, "stderr", result.stderr_preview);
     }
     const output = try out.toOwnedSlice();
+    const status = command_contract.projectForegroundStatus(result.status);
     return .{
         .output = output,
         .cancelled = result.cancelled,
         .command_result = .{ .foreground = .{
             .command = command,
             .cwd = cwd,
-            .exit_code = termExitCode(result.term),
-            .signal = termSignal(result.term),
-            .termination_indeterminate = result.termination_indeterminate,
+            .exit_code = status.exit_code,
+            .signal = status.signal,
+            .termination_indeterminate = status.termination_indeterminate,
             .duration_ms = result.duration_ms,
             .stdout_bytes = result.stdout_bytes,
             .stderr_bytes = result.stderr_bytes,
@@ -1869,28 +1838,6 @@ fn formatCollectedOutputValue(alloc: Allocator, command: []const u8, cwd: []cons
             .stdout_file = metadataField(output, "stdout_file="),
             .stderr_file = metadataField(output, "stderr_file="),
         } },
-    };
-}
-
-fn writeTermLine(writer: *std.Io.Writer, term: std.process.Child.Term) !void {
-    switch (term) {
-        .exited => |code| try writer.print("exit_code={d}\n", .{code}),
-        .signal => |sig| try writer.print("signal={d}\n", .{sig}),
-        else => try writer.writeAll("process finished\n"),
-    }
-}
-
-fn termExitCode(term: std.process.Child.Term) ?i64 {
-    return switch (term) {
-        .exited => |code| @intCast(code),
-        else => null,
-    };
-}
-
-fn termSignal(term: std.process.Child.Term) ?u32 {
-    return switch (term) {
-        .signal => |sig| @intFromEnum(sig),
-        else => null,
     };
 }
 
@@ -2215,7 +2162,7 @@ const ProcessObserver = struct {
             child.stderr = null;
         }
         return .{
-            .waiter = ChildWaiter.init(child, true),
+            .waiter = ChildWaiter.init(child),
             .process_id = process_id,
             .stdout = stdout,
             .stderr = stderr,
@@ -2236,24 +2183,19 @@ const ProcessObserver = struct {
         try self.waiter.start();
     }
 
-    fn observe(self: *ProcessObserver) ?ProcessTermination {
+    fn observe(self: *ProcessObserver) ?command_contract.ForegroundCommandStatus {
         if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return null;
         if (!self.waiter.isReady()) return null;
         const term = self.waiter.awaitReady() catch |err| {
-            debug_trace.logf(
-                "core",
-                "command termination became indeterminate err={s}",
-                .{@errorName(err)},
-            );
-            return .{ .term = .{ .unknown = 0 }, .indeterminate = true };
+            return indeterminateStatus(err);
         };
-        return .{ .term = term };
+        return statusFromTerm(term);
     }
 
     fn awaitTermination(
         self: *ProcessObserver,
         source: TerminationSource,
-    ) !ProcessTermination {
+    ) !command_contract.ForegroundCommandStatus {
         if (comptime builtin.os.tag != .windows and builtin.os.tag != .wasi) {
             self.waiter.awaitDiscard();
             return self.observe().?;
@@ -2261,15 +2203,7 @@ const ProcessObserver = struct {
         const term = self.waiter.child.wait(self.waiter.io) catch |err| {
             return switch (source) {
                 .natural => blk: {
-                    debug_trace.logf(
-                        "core",
-                        "command termination became indeterminate err={s}",
-                        .{@errorName(err)},
-                    );
-                    break :blk .{
-                        .term = .{ .unknown = 0 },
-                        .indeterminate = true,
-                    };
+                    break :blk indeterminateStatus(err);
                 },
                 .cancelled, .timed_out => mapTerminationError(
                     source,
@@ -2279,7 +2213,32 @@ const ProcessObserver = struct {
                 ),
             };
         };
-        return .{ .term = term };
+        return statusFromTerm(term);
+    }
+
+    fn statusFromTerm(
+        term: std.process.Child.Term,
+    ) command_contract.ForegroundCommandStatus {
+        if (io_mod.getenv("FX_COMMAND_TEST_INDETERMINATE_AFTER_EXIT") != null) {
+            debug_trace.logf(
+                "core",
+                "command termination became indeterminate reason=injected_after_exit",
+                .{},
+            );
+            return .indeterminate;
+        }
+        return foregroundCommandStatusFromTerm(term);
+    }
+
+    fn indeterminateStatus(
+        err: anyerror,
+    ) command_contract.ForegroundCommandStatus {
+        debug_trace.logf(
+            "core",
+            "command termination became indeterminate err={s}",
+            .{@errorName(err)},
+        );
+        return .indeterminate;
     }
 
     fn signal(
@@ -2330,7 +2289,7 @@ fn collectOutput(
     launch_failure_probe: ?*ForegroundLaunchFailureProbe,
     process_group_id: ?std.posix.pid_t,
     termination_protocol: TerminationProtocol,
-    leader_termination: *?ProcessTermination,
+    leader_status: *?command_contract.ForegroundCommandStatus,
 ) !TerminationSource {
     const zio = io_mod.getIo();
     var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
@@ -2360,9 +2319,9 @@ fn collectOutput(
             &signal_started_ms,
             &force_kill_sent,
         );
-        if (leader_termination.* == null) {
-            if (observer.observe()) |termination| {
-                leader_termination.* = termination;
+        if (leader_status.* == null) {
+            if (observer.observe()) |status| {
+                leader_status.* = status;
                 if (process_group_id) |pid| {
                     if (source.* == .natural) {
                         terminateRemainingProcessGroup(pid);
@@ -2444,7 +2403,7 @@ fn collectOutputForProcess(
     launch_failure_probe: ?*ForegroundLaunchFailureProbe,
     process_group_id: ?std.posix.pid_t,
     termination_protocol: TerminationProtocol,
-    leader_termination: *?ProcessTermination,
+    leader_status: *?command_contract.ForegroundCommandStatus,
 ) !TerminationSource {
     var source: TerminationSource = .natural;
     return collectOutput(
@@ -2456,7 +2415,7 @@ fn collectOutputForProcess(
         launch_failure_probe,
         process_group_id,
         termination_protocol,
-        leader_termination,
+        leader_status,
     ) catch |err|
         return mapTerminationError(source, cfg.cancel_flag, "output collection", err);
 }
@@ -2465,24 +2424,24 @@ fn waitForCollectedProcess(
     observer: *ProcessObserver,
     source: TerminationSource,
     process_group_id: ?std.posix.pid_t,
-    leader_termination: ?ProcessTermination,
-) !ProcessTermination {
-    if (leader_termination) |termination| {
+    leader_status: ?command_contract.ForegroundCommandStatus,
+) !command_contract.ForegroundCommandStatus {
+    if (leader_status) |status| {
         if (comptime builtin.os.tag != .windows and builtin.os.tag != .wasi) {
             observer.waiter.awaitDiscard();
         }
-        return termination;
+        return status;
     }
-    const termination = try observer.awaitTermination(source);
+    const status = try observer.awaitTermination(source);
     if (process_group_id) |pid| {
         terminateRemainingProcessGroup(pid);
     }
-    return termination;
+    return status;
 }
 
 const CollectedTermination = struct {
     source: TerminationSource,
-    termination: ProcessTermination,
+    status: command_contract.ForegroundCommandStatus,
 };
 
 fn collectSpawnedProcess(
@@ -2508,17 +2467,14 @@ fn collectSpawnedProcess(
         cleanupChild(child);
         return .{
             .source = .natural,
-            .termination = .{
-                .term = .{ .unknown = 0 },
-                .indeterminate = true,
-            },
+            .status = .indeterminate,
         };
     };
 
     var wait_pending = true;
     defer if (wait_pending) observer.abort(process_group_id);
 
-    var leader_termination: ?ProcessTermination = null;
+    var leader_status: ?command_contract.ForegroundCommandStatus = null;
     const source = try collectOutputForProcess(
         arena,
         &observer,
@@ -2527,16 +2483,16 @@ fn collectSpawnedProcess(
         launch_failure_probe,
         process_group_id,
         termination_protocol,
-        &leader_termination,
+        &leader_status,
     );
-    const termination = try waitForCollectedProcess(
+    const status = try waitForCollectedProcess(
         &observer,
         source,
         process_group_id,
-        leader_termination,
+        leader_status,
     );
     wait_pending = false;
-    return .{ .source = source, .termination = termination };
+    return .{ .source = source, .status = status };
 }
 
 fn mapTerminationError(
@@ -3944,7 +3900,7 @@ test "artifact write failure after cancellation remains a bare error" {
     defer observer.deinit();
     try observer.start();
     defer observer.abort(process_group_id);
-    var leader_termination: ?ProcessTermination = null;
+    var leader_status: ?command_contract.ForegroundCommandStatus = null;
     try std.testing.expectError(error.Cancelled, collectOutputForProcess(
         alloc,
         &observer,
@@ -3953,7 +3909,7 @@ test "artifact write failure after cancellation remains a bare error" {
         null,
         process_group_id,
         .process_group,
-        &leader_termination,
+        &leader_status,
     ));
     try std.testing.expect(ready_seen.load(.seq_cst));
 }

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -249,6 +249,73 @@ fn foregroundRequestAtDeadline(
     return if (now_ms >= deadline) .force else .none;
 }
 
+const ChildWaiter = struct {
+    child: *std.process.Child,
+    io: std.Io,
+    inject_indeterminate: bool,
+    ready: std.atomic.Value(bool) = .init(false),
+    result: (std.process.Child.WaitError || error{
+        InjectedChildTerminationIndeterminate,
+    })!std.process.Child.Term = undefined,
+    future: ?std.Io.Future(void) = null,
+
+    fn init(child: *std.process.Child, inject_indeterminate: bool) ChildWaiter {
+        return .{
+            .child = child,
+            .io = io_mod.getIo(),
+            .inject_indeterminate = inject_indeterminate,
+        };
+    }
+
+    fn start(self: *ChildWaiter) !void {
+        self.future = try std.Io.concurrent(
+            self.io,
+            ChildWaiter.waitMain,
+            .{self},
+        );
+    }
+
+    fn waitMain(self: *ChildWaiter) void {
+        const term = self.child.wait(self.io) catch |err| {
+            self.result = err;
+            self.ready.store(true, .release);
+            return;
+        };
+        self.result = if (self.inject_indeterminate and io_mod.getenv(
+            "FX_COMMAND_TEST_INDETERMINATE_AFTER_EXIT",
+        ) != null)
+            error.InjectedChildTerminationIndeterminate
+        else
+            term;
+        self.ready.store(true, .release);
+    }
+
+    fn isReady(self: *const ChildWaiter) bool {
+        return self.ready.load(.acquire);
+    }
+
+    fn awaitReady(self: *ChildWaiter) !std.process.Child.Term {
+        std.debug.assert(self.isReady());
+        var future = &self.future.?;
+        future.await(self.io);
+        return try self.result;
+    }
+
+    fn awaitDiscard(self: *ChildWaiter) void {
+        var future = &self.future.?;
+        future.await(self.io);
+    }
+
+    fn abort(self: *ChildWaiter, pid: std.posix.pid_t) void {
+        if (self.isReady()) {
+            self.awaitDiscard();
+            return;
+        }
+        signalProcess(pid, std.posix.SIG.KILL) catch {};
+        self.awaitDiscard();
+    }
+};
+
 fn waitForForegroundTarget(
     target: *std.process.Child,
     process_witness: ?*const process_tree.DarwinProcessWitness,
@@ -264,6 +331,10 @@ fn waitForForegroundTarget(
         try descendants.refresh(target_pid);
         try std.posix.kill(target_pid, std.posix.SIG.CONT);
     }
+    var waiter = ChildWaiter.init(target, false);
+    try waiter.start();
+    var wait_pending = true;
+    defer if (wait_pending) waiter.abort(target_pid);
     var termination_started_ms: ?i64 = null;
     var forced = false;
 
@@ -287,7 +358,9 @@ fn waitForForegroundTarget(
             &forced,
         );
 
-        if (try pollProcessLeader(target)) |term| {
+        if (waiter.isReady()) {
+            wait_pending = false;
+            const term = try waiter.awaitReady();
             try refreshForegroundTargetTree(&descendants, target_pid);
             advanceForegroundTargetTermination(
                 &descendants,
@@ -600,8 +673,14 @@ fn emitAcceptedOutputChunk(
     try callback(ctx, cfg.output_chunk_lifecycle_id, stream, bytes);
 }
 
+const ProcessTermination = struct {
+    term: std.process.Child.Term,
+    indeterminate: bool = false,
+};
+
 const CollectedProcess = struct {
     term: std.process.Child.Term,
+    termination_indeterminate: bool = false,
     stdout: []const u8,
     stderr: []const u8,
     stdout_bytes: usize,
@@ -851,13 +930,17 @@ const OutputCollector = struct {
         }
     }
 
-    fn finish(self: *OutputCollector, term: std.process.Child.Term) !CollectedProcess {
+    fn finish(
+        self: *OutputCollector,
+        termination: ProcessTermination,
+    ) !CollectedProcess {
         if (self.artifact) |*artifact| {
             try artifact.sync();
             try artifact.contentAddressManagedOutput(self.alloc);
             const truncated = self.totalBytes() > self.cfg.max_command_output_bytes;
             return .{
-                .term = term,
+                .term = termination.term,
+                .termination_indeterminate = termination.indeterminate,
                 .stdout = "",
                 .stderr = "",
                 .stdout_bytes = self.stdout_bytes,
@@ -872,7 +955,8 @@ const OutputCollector = struct {
         }
 
         return .{
-            .term = term,
+            .term = termination.term,
+            .termination_indeterminate = termination.indeterminate,
             .stdout = try self.stdout.toOwnedSlice(self.alloc),
             .stderr = try self.stderr.toOwnedSlice(self.alloc),
             .stdout_bytes = self.stdout_bytes,
@@ -907,7 +991,7 @@ const OutputCollector = struct {
 
 fn finishCollectedProcess(
     output: *OutputCollector,
-    term: std.process.Child.Term,
+    termination: ProcessTermination,
     duration_ms: u64,
     source: TerminationSource,
 ) !CollectedProcess {
@@ -925,7 +1009,7 @@ fn finishCollectedProcess(
         },
     }
 
-    var result = output.finish(term) catch |err| {
+    var result = output.finish(termination) catch |err| {
         if (source != .cancelled) return err;
         debug_trace.logf("core", "cancelled command artifact finalization failed err={s}", .{@errorName(err)});
         return error.Cancelled;
@@ -990,8 +1074,8 @@ fn executeProcessWithInput(
         child.id
     else
         null;
-    var leader_term: ?std.process.Child.Term = null;
-    const source = try collectOutputForProcess(
+    child_needs_cleanup = false;
+    const collected = try collectSpawnedProcess(
         scratch,
         &child,
         &output,
@@ -999,18 +1083,15 @@ fn executeProcessWithInput(
         null,
         process_group_id,
         .process_group,
-        &leader_term,
-    );
-    const term = try waitForCollectedProcess(
-        &child,
-        source,
-        process_group_id,
-        leader_term,
     );
     const duration_ms = elapsedMs(started_ms, io_mod.milliTimestamp());
-    child_needs_cleanup = false;
 
-    return finishCollectedProcess(&output, term, duration_ms, source);
+    return finishCollectedProcess(
+        &output,
+        collected.termination,
+        duration_ms,
+        collected.source,
+    );
 }
 
 fn executeProcessWithScript(
@@ -1129,8 +1210,8 @@ fn executeProcessWithDetachedSession(
 
     var launch_failure_probe = ForegroundLaunchFailureProbe.init(&failure_marker);
     const process_group_id = child.id;
-    var leader_term: ?std.process.Child.Term = null;
-    var source = try collectOutputForProcess(
+    child_needs_cleanup = false;
+    var collected = try collectSpawnedProcess(
         scratch,
         &child,
         &output,
@@ -1138,25 +1219,25 @@ fn executeProcessWithDetachedSession(
         &launch_failure_probe,
         process_group_id,
         .foreground_supervisor,
-        &leader_term,
     );
-    source = reconcileForegroundTerminationSource(
-        source,
+    collected.source = reconcileForegroundTerminationSource(
+        collected.source,
         deadline_ms,
         io_mod.milliTimestamp(),
     );
-    const term = try waitForCollectedProcess(
-        &child,
-        source,
-        process_group_id,
-        leader_term,
-    );
     const duration_ms = elapsedMs(started_ms, io_mod.milliTimestamp());
-    child_needs_cleanup = false;
 
-    if (foregroundSessionReplacementError(term, launch_failure_probe)) |launch_err| return launch_err;
+    if (foregroundSessionReplacementError(
+        collected.termination.term,
+        launch_failure_probe,
+    )) |launch_err| return launch_err;
     if (script_write_error) |write_err| return write_err;
-    return finishCollectedProcess(&output, term, duration_ms, source);
+    return finishCollectedProcess(
+        &output,
+        collected.termination,
+        duration_ms,
+        collected.source,
+    );
 }
 
 fn foregroundSessionExecutable(scratch: Allocator) ![]const u8 {
@@ -1286,8 +1367,8 @@ fn executeProcessWithScriptUnisolated(
     script_write_open = false;
 
     const process_group_id = child.id;
-    var leader_term: ?std.process.Child.Term = null;
-    const source = try collectOutputForProcess(
+    child_needs_cleanup = false;
+    const collected = try collectSpawnedProcess(
         scratch,
         &child,
         &output,
@@ -1295,18 +1376,15 @@ fn executeProcessWithScriptUnisolated(
         null,
         process_group_id,
         .process_group,
-        &leader_term,
-    );
-    const term = try waitForCollectedProcess(
-        &child,
-        source,
-        process_group_id,
-        leader_term,
     );
     const duration_ms = elapsedMs(started_ms, io_mod.milliTimestamp());
-    child_needs_cleanup = false;
 
-    return finishCollectedProcess(&output, term, duration_ms, source);
+    return finishCollectedProcess(
+        &output,
+        collected.termination,
+        duration_ms,
+        collected.source,
+    );
 }
 
 fn streamPreviewLimit(max_command_output_bytes: usize) usize {
@@ -1691,10 +1769,30 @@ fn formatExitOutput(alloc: Allocator, command: []const u8, cwd: []const u8, exit
 }
 
 fn formatOutput(alloc: Allocator, command: []const u8, cwd: []const u8, term: std.process.Child.Term, stdout_raw: []const u8, stderr_raw: []const u8, duration_ms: ?u64) !command_contract.RunCommandResult {
+    return formatOutputWithStatus(
+        alloc,
+        command,
+        cwd,
+        foregroundCommandStatusFromTerm(term),
+        stdout_raw,
+        stderr_raw,
+        duration_ms,
+    );
+}
+
+fn formatOutputWithStatus(
+    alloc: Allocator,
+    command: []const u8,
+    cwd: []const u8,
+    status: command_contract.ForegroundCommandStatus,
+    stdout_raw: []const u8,
+    stderr_raw: []const u8,
+    duration_ms: ?u64,
+) !command_contract.RunCommandResult {
     return command_contract.formatForegroundCommandResult(alloc, .{
         .command = command,
         .cwd = cwd,
-        .status = foregroundCommandStatusFromTerm(term),
+        .status = status,
         .stdout_display = stdout_raw,
         .stderr_display = stderr_raw,
         .stdout_bytes = stdout_raw.len,
@@ -1720,11 +1818,29 @@ fn formatCollectedOutput(alloc: Allocator, command: []const u8, cwd: []const u8,
 }
 
 fn formatCollectedOutputValue(alloc: Allocator, command: []const u8, cwd: []const u8, result: CollectedProcess) !command_contract.RunCommandResult {
-    if (result.output_file == null) return formatOutput(alloc, command, cwd, result.term, result.stdout, result.stderr, result.duration_ms);
+    if (result.output_file == null) return formatOutputWithStatus(
+        alloc,
+        command,
+        cwd,
+        if (result.termination_indeterminate)
+            .indeterminate
+        else
+            foregroundCommandStatusFromTerm(result.term),
+        result.stdout,
+        result.stderr,
+        result.duration_ms,
+    );
 
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
-    try writeTermLine(&out.writer, result.term);
+    if (result.termination_indeterminate) {
+        try out.writer.writeAll(
+            "termination_indeterminate=true\n" ++
+                "message=the command was started, but fx could not confirm its final process status; do not retry unchanged because side effects may already exist\n",
+        );
+    } else {
+        try writeTermLine(&out.writer, result.term);
+    }
     try out.writer.print("truncated={s}\n", .{if (result.truncated) "true" else "false"});
     try out.writer.print("stdout_bytes={d}\n", .{result.stdout_bytes});
     try out.writer.print("stderr_bytes={d}\n", .{result.stderr_bytes});
@@ -1744,6 +1860,7 @@ fn formatCollectedOutputValue(alloc: Allocator, command: []const u8, cwd: []cons
             .cwd = cwd,
             .exit_code = termExitCode(result.term),
             .signal = termSignal(result.term),
+            .termination_indeterminate = result.termination_indeterminate,
             .duration_ms = result.duration_ms,
             .stdout_bytes = result.stdout_bytes,
             .stderr_bytes = result.stderr_bytes,
@@ -2080,21 +2197,145 @@ fn parseReplaceError(name: []const u8) ?std.process.ReplaceError {
     return null;
 }
 
+const ProcessObserver = struct {
+    waiter: ChildWaiter,
+    process_id: std.process.Child.Id,
+    stdout: std.Io.File,
+    stderr: std.Io.File,
+    detached_pipes: bool = false,
+
+    fn init(child: *std.process.Child) !ProcessObserver {
+        const process_id = child.id orelse return error.SpawnFailed;
+        const stdout = child.stdout orelse return error.SpawnFailed;
+        const stderr = child.stderr orelse return error.SpawnFailed;
+        const detached_pipes = comptime builtin.os.tag != .windows and
+            builtin.os.tag != .wasi;
+        if (detached_pipes) {
+            child.stdout = null;
+            child.stderr = null;
+        }
+        return .{
+            .waiter = ChildWaiter.init(child, true),
+            .process_id = process_id,
+            .stdout = stdout,
+            .stderr = stderr,
+            .detached_pipes = detached_pipes,
+        };
+    }
+
+    fn deinit(self: *ProcessObserver) void {
+        if (self.detached_pipes) {
+            self.stdout.close(self.waiter.io);
+            self.stderr.close(self.waiter.io);
+        }
+        self.* = undefined;
+    }
+
+    fn start(self: *ProcessObserver) !void {
+        if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+        try self.waiter.start();
+    }
+
+    fn observe(self: *ProcessObserver) ?ProcessTermination {
+        if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return null;
+        if (!self.waiter.isReady()) return null;
+        const term = self.waiter.awaitReady() catch |err| {
+            debug_trace.logf(
+                "core",
+                "command termination became indeterminate err={s}",
+                .{@errorName(err)},
+            );
+            return .{ .term = .{ .unknown = 0 }, .indeterminate = true };
+        };
+        return .{ .term = term };
+    }
+
+    fn awaitTermination(
+        self: *ProcessObserver,
+        source: TerminationSource,
+    ) !ProcessTermination {
+        if (comptime builtin.os.tag != .windows and builtin.os.tag != .wasi) {
+            self.waiter.awaitDiscard();
+            return self.observe().?;
+        }
+        const term = self.waiter.child.wait(self.waiter.io) catch |err| {
+            return switch (source) {
+                .natural => blk: {
+                    debug_trace.logf(
+                        "core",
+                        "command termination became indeterminate err={s}",
+                        .{@errorName(err)},
+                    );
+                    break :blk .{
+                        .term = .{ .unknown = 0 },
+                        .indeterminate = true,
+                    };
+                },
+                .cancelled, .timed_out => mapTerminationError(
+                    source,
+                    null,
+                    "process wait",
+                    err,
+                ),
+            };
+        };
+        return .{ .term = term };
+    }
+
+    fn signal(
+        self: *ProcessObserver,
+        process_group_id: ?std.posix.pid_t,
+        protocol: TerminationProtocol,
+        intent: TerminationIntent,
+    ) !void {
+        if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+            self.waiter.child.kill(self.waiter.io);
+            return;
+        }
+        const target_pid = process_group_id orelse self.process_id;
+        const plan = terminationSignalPlan(protocol, intent);
+        return switch (plan.scope) {
+            .process_group => signalProcessGroup(target_pid, plan.signal),
+            .supervisor => signalProcess(target_pid, plan.signal),
+        };
+    }
+
+    fn abort(self: *ProcessObserver, process_group_id: ?std.posix.pid_t) void {
+        if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+            cleanupChild(self.waiter.child);
+            return;
+        }
+        if (self.waiter.isReady()) {
+            self.waiter.awaitDiscard();
+            return;
+        }
+        const pid = process_group_id orelse self.process_id;
+        signalProcessGroup(pid, std.posix.SIG.KILL) catch |err| {
+            debug_trace.logf(
+                "core",
+                "command observer cleanup kill failed err={s}",
+                .{@errorName(err)},
+            );
+        };
+        self.waiter.awaitDiscard();
+    }
+};
+
 fn collectOutput(
     arena: Allocator,
-    child: *std.process.Child,
+    observer: *ProcessObserver,
     output: *OutputCollector,
     cfg: Config,
     source: *TerminationSource,
     launch_failure_probe: ?*ForegroundLaunchFailureProbe,
     process_group_id: ?std.posix.pid_t,
     termination_protocol: TerminationProtocol,
-    leader_term: *?std.process.Child.Term,
+    leader_termination: *?ProcessTermination,
 ) !TerminationSource {
     const zio = io_mod.getIo();
     var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
     var multi_reader: std.Io.File.MultiReader = undefined;
-    multi_reader.init(arena, zio, multi_reader_buffer.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    multi_reader.init(arena, zio, multi_reader_buffer.toStreams(), &.{ observer.stdout, observer.stderr });
     defer multi_reader.deinit();
 
     const stdout_r = multi_reader.reader(0);
@@ -2110,7 +2351,7 @@ fn collectOutput(
 
     while (true) {
         try updateTerminationSignal(
-            child,
+            observer,
             process_group_id,
             termination_protocol,
             cfg,
@@ -2119,9 +2360,9 @@ fn collectOutput(
             &signal_started_ms,
             &force_kill_sent,
         );
-        if (leader_term.* == null) {
-            if (try pollProcessLeader(child)) |term| {
-                leader_term.* = term;
+        if (leader_termination.* == null) {
+            if (observer.observe()) |termination| {
+                leader_termination.* = termination;
                 if (process_group_id) |pid| {
                     if (source.* == .natural) {
                         terminateRemainingProcessGroup(pid);
@@ -2197,76 +2438,105 @@ fn collectOutput(
 
 fn collectOutputForProcess(
     arena: Allocator,
-    child: *std.process.Child,
+    observer: *ProcessObserver,
     output: *OutputCollector,
     cfg: Config,
     launch_failure_probe: ?*ForegroundLaunchFailureProbe,
     process_group_id: ?std.posix.pid_t,
     termination_protocol: TerminationProtocol,
-    leader_term: *?std.process.Child.Term,
+    leader_termination: *?ProcessTermination,
 ) !TerminationSource {
     var source: TerminationSource = .natural;
     return collectOutput(
         arena,
-        child,
+        observer,
         output,
         cfg,
         &source,
         launch_failure_probe,
         process_group_id,
         termination_protocol,
-        leader_term,
+        leader_termination,
     ) catch |err|
         return mapTerminationError(source, cfg.cancel_flag, "output collection", err);
 }
 
 fn waitForCollectedProcess(
-    child: *std.process.Child,
+    observer: *ProcessObserver,
     source: TerminationSource,
     process_group_id: ?std.posix.pid_t,
-    leader_term: ?std.process.Child.Term,
-) !std.process.Child.Term {
-    if (leader_term) |term| {
-        closeChildPipes(child);
-        return term;
+    leader_termination: ?ProcessTermination,
+) !ProcessTermination {
+    if (leader_termination) |termination| {
+        if (comptime builtin.os.tag != .windows and builtin.os.tag != .wasi) {
+            observer.waiter.awaitDiscard();
+        }
+        return termination;
     }
-    const term = child.wait(io_mod.getIo()) catch |err|
-        return mapTerminationError(source, null, "process wait", err);
+    const termination = try observer.awaitTermination(source);
     if (process_group_id) |pid| {
         terminateRemainingProcessGroup(pid);
     }
-    return term;
+    return termination;
 }
 
-fn pollProcessLeader(child: *std.process.Child) !?std.process.Child.Term {
-    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return null;
-    const pid = child.id orelse return null;
-    var status: if (builtin.link_libc) c_int else u32 = undefined;
-    while (true) {
-        const result = std.posix.system.waitpid(pid, &status, std.posix.W.NOHANG);
-        switch (std.posix.errno(result)) {
-            .SUCCESS => {
-                if (result == 0) return null;
-                if (result != pid) return error.Unexpected;
-                child.id = null;
-                return childTermFromStatus(@bitCast(status));
+const CollectedTermination = struct {
+    source: TerminationSource,
+    termination: ProcessTermination,
+};
+
+fn collectSpawnedProcess(
+    arena: Allocator,
+    child: *std.process.Child,
+    output: *OutputCollector,
+    cfg: Config,
+    launch_failure_probe: ?*ForegroundLaunchFailureProbe,
+    process_group_id: ?std.posix.pid_t,
+    termination_protocol: TerminationProtocol,
+) !CollectedTermination {
+    var observer = ProcessObserver.init(child) catch |err| {
+        cleanupChild(child);
+        return err;
+    };
+    defer observer.deinit();
+    observer.start() catch |err| {
+        debug_trace.logf(
+            "core",
+            "command wait authority unavailable after spawn err={s}",
+            .{@errorName(err)},
+        );
+        cleanupChild(child);
+        return .{
+            .source = .natural,
+            .termination = .{
+                .term = .{ .unknown = 0 },
+                .indeterminate = true,
             },
-            .INTR => continue,
-            .CHILD => return error.Unexpected,
-            else => |err| return std.posix.unexpectedErrno(err),
-        }
-    }
-}
+        };
+    };
 
-fn childTermFromStatus(status: u32) std.process.Child.Term {
-    return if (std.posix.W.IFEXITED(status))
-        .{ .exited = std.posix.W.EXITSTATUS(status) }
-    else if (std.posix.W.IFSIGNALED(status))
-        .{ .signal = std.posix.W.TERMSIG(status) }
-    else if (std.posix.W.IFSTOPPED(status))
-        .{ .stopped = std.posix.W.STOPSIG(status) }
-    else
-        .{ .unknown = status };
+    var wait_pending = true;
+    defer if (wait_pending) observer.abort(process_group_id);
+
+    var leader_termination: ?ProcessTermination = null;
+    const source = try collectOutputForProcess(
+        arena,
+        &observer,
+        output,
+        cfg,
+        launch_failure_probe,
+        process_group_id,
+        termination_protocol,
+        &leader_termination,
+    );
+    const termination = try waitForCollectedProcess(
+        &observer,
+        source,
+        process_group_id,
+        leader_termination,
+    );
+    wait_pending = false;
+    return .{ .source = source, .termination = termination };
 }
 
 fn mapTerminationError(
@@ -2293,7 +2563,7 @@ fn mapTerminationError(
 }
 
 fn updateTerminationSignal(
-    child: *std.process.Child,
+    observer: *ProcessObserver,
     process_group_id: ?std.posix.pid_t,
     termination_protocol: TerminationProtocol,
     cfg: Config,
@@ -2318,12 +2588,12 @@ fn updateTerminationSignal(
         switch (source.*) {
             .natural => {},
             .cancelled => {
-                try signalChild(child, process_group_id, termination_protocol, .cooperative);
+                try observer.signal(process_group_id, termination_protocol, .cooperative);
                 debug_trace.logf("core", "command termination requested source=cancelled", .{});
                 signal_started_ms.* = now_ms;
             },
             .timed_out => {
-                try signalChild(child, process_group_id, termination_protocol, .force);
+                try observer.signal(process_group_id, termination_protocol, .force);
                 force_kill_sent.* = true;
                 debug_trace.logf("core", "command termination requested source=timeout", .{});
                 signal_started_ms.* = now_ms;
@@ -2333,7 +2603,7 @@ fn updateTerminationSignal(
 
     if (signal_started_ms.*) |sent_ms| {
         if (!force_kill_sent.* and now_ms - sent_ms >= 800) {
-            try signalChild(child, process_group_id, termination_protocol, .force);
+            try observer.signal(process_group_id, termination_protocol, .force);
             debug_trace.logf("core", "command force-killed after termination grace expired", .{});
             force_kill_sent.* = true;
         }
@@ -2351,26 +2621,6 @@ fn emitOutputChunk(
     if (chunk.len == 0) return;
     if (projection == .model_safe and !text_utils.isModelSafeText(chunk)) return;
     try callback(ctx, lifecycle_id, stream, chunk);
-}
-
-fn signalChild(
-    child: *std.process.Child,
-    process_group_id: ?std.posix.pid_t,
-    protocol: TerminationProtocol,
-    intent: TerminationIntent,
-) !void {
-    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
-        child.kill(io_mod.getIo());
-        return;
-    }
-
-    const pid = child.id orelse return;
-    const target_pid = process_group_id orelse pid;
-    const plan = terminationSignalPlan(protocol, intent);
-    return switch (plan.scope) {
-        .process_group => signalProcessGroup(target_pid, plan.signal),
-        .supervisor => signalProcess(target_pid, plan.signal),
-    };
 }
 
 fn signalProcess(pid: std.posix.pid_t, signal: std.posix.SIG) !void {
@@ -3577,21 +3827,54 @@ test "below-cap cancellation retains complete artifact and non-truncated metadat
 }
 
 test "zero-output cancellation remains a bare error" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(workspace);
+    const ready_path = try std.fs.path.join(alloc, &.{ workspace, "zero-output-ready" });
+    defer alloc.free(ready_path);
+    const quoted_ready = try shellQuote(alloc, ready_path);
+    defer alloc.free(quoted_ready);
+    const command = try std.fmt.allocPrint(
+        alloc,
+        ": > {s}; exec sleep 5",
+        .{quoted_ready},
+    );
+    defer alloc.free(command);
+
     var cancel = std.atomic.Value(bool).init(false);
-    const Flip = struct {
-        fn run(flag: *std.atomic.Value(bool)) void {
-            io_mod.sleep(120 * std.time.ns_per_ms);
+    var ready_seen = std.atomic.Value(bool).init(false);
+    const Watcher = struct {
+        fn run(
+            path: []const u8,
+            flag: *std.atomic.Value(bool),
+            seen: *std.atomic.Value(bool),
+        ) void {
+            const started_ms = io_mod.milliTimestamp();
+            while (io_mod.milliTimestamp() - started_ms < 2000) {
+                if (absoluteFileExists(path)) {
+                    seen.store(true, .seq_cst);
+                    break;
+                }
+                io_mod.sleep(10 * std.time.ns_per_ms);
+            }
             flag.store(true, .seq_cst);
         }
     };
-    const thread = try std.Thread.spawn(.{}, Flip.run, .{&cancel});
+    const thread = try std.Thread.spawn(
+        .{},
+        Watcher.run,
+        .{ ready_path, &cancel, &ready_seen },
+    );
     defer thread.join();
 
     try std.testing.expectError(error.Cancelled, executeCommand(.{
         .max_command_output_bytes = 1024,
         .cancel_flag = &cancel,
-        .timeout_ms = 1000,
-    }, std.testing.allocator, "exec sleep 5", "/tmp"));
+        .timeout_ms = 3000,
+    }, alloc, command, workspace));
+    try std.testing.expect(ready_seen.load(.seq_cst));
 }
 
 test "artifact write failure after cancellation remains a bare error" {
@@ -3657,16 +3940,20 @@ test "artifact write failure after cancellation remains a bare error" {
     defer watcher.join();
 
     const process_group_id = child.id;
-    var leader_term: ?std.process.Child.Term = null;
+    var observer = try ProcessObserver.init(&child);
+    defer observer.deinit();
+    try observer.start();
+    defer observer.abort(process_group_id);
+    var leader_termination: ?ProcessTermination = null;
     try std.testing.expectError(error.Cancelled, collectOutputForProcess(
         alloc,
-        &child,
+        &observer,
         &output,
         cfg,
         null,
         process_group_id,
         .process_group,
-        &leader_term,
+        &leader_termination,
     ));
     try std.testing.expect(ready_seen.load(.seq_cst));
 }

--- a/src/core/tooling/command_result_mapping.zig
+++ b/src/core/tooling/command_result_mapping.zig
@@ -41,6 +41,23 @@ pub const Foreground = struct {
             .foreground => |foreground| foreground,
             .background => return null,
         };
+        if (foreground.termination_indeterminate) {
+            const details = [_]tool_result_errors.Detail{
+                .{ .name = "command", .value = .{ .string = foreground.command } },
+                .{ .name = "cwd", .value = .{ .string = foreground.cwd } },
+                .{ .name = "termination_indeterminate", .value = .{ .boolean = true } },
+            };
+            return .{
+                .status = .failure,
+                .model_output = try tool_result_errors.toolExecutionFailureJson(arena, .{
+                    .tool_name = "terminal",
+                    .message = "Command started, but its final process status could not be confirmed",
+                    .details = &details,
+                    .suggestion = "Do not retry the command unchanged because its side effects may already exist. Inspect the resulting state first.",
+                }),
+                .command_result_json = try command_result.toJson(arena),
+            };
+        }
         if ((foreground.exit_code == null or foreground.exit_code.? == 0) and
             foreground.signal == null and
             !foreground.timed_out) return null;
@@ -375,6 +392,25 @@ test "command result mapping preserves non-zero stderr envelope and JSON" {
     try expectContains(result.model_output, "\"stderr\":\"bad [redacted]\"");
     try expectContains(result.command_result_json.?, "\"kind\":\"foreground\"");
     try expectContains(result.command_result_json.?, "\"exit_code\":7");
+}
+
+test "command result mapping reports indeterminate termination with structured evidence" {
+    const alloc = std.testing.allocator;
+    const result = try Foreground.nonZeroFailure(alloc, .{
+        .output = "termination_indeterminate=true\n",
+        .command_result = .{ .foreground = .{
+            .command = "printf effect > marker",
+            .cwd = "/tmp/workspace",
+            .termination_indeterminate = true,
+        } },
+    }) orelse return error.TestExpectedEqual;
+    defer alloc.free(result.model_output);
+    defer alloc.free(result.command_result_json.?);
+
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.failure, result.status);
+    try expectContains(result.model_output, "could not be confirmed");
+    try expectContains(result.model_output, "Do not retry");
+    try expectContains(result.command_result_json.?, "\"termination_indeterminate\":true");
 }
 
 test "cancelled command mapping survives metadata serialization failure" {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2934,6 +2934,76 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test("indeterminate terminal termination reports one truthful result without replaying effects", async () => {
+    const root = createFixtureRoot("terminal-indeterminate-outcome");
+    const tracePath = join(root.root, "trace.log");
+    const effectPath = join(root.workspace, "command-effect.txt");
+    const callId = "terminal_indeterminate_1";
+    let observedFailure = "";
+    let step = 0;
+    const gateway = startGateway((body) => {
+      switch (step++) {
+        case 0:
+          return fakeGatewayToolCall(callId, "terminal", {
+            action: "exec",
+            command: "printf 'effect\\n' >> command-effect.txt",
+            timeout_ms: 30_000,
+          });
+        case 1:
+          observedFailure = toolResultOutput(body, callId);
+          return fakeGatewayFinalText("Indeterminate command outcome acknowledged without retry.");
+        default:
+          return new Response("unexpected request", { status: 500 });
+      }
+    });
+
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--yolo", "--no-save", "Run the mutation exactly once."],
+        {
+          cwd: root.workspace,
+          env: {
+            ...fixtureEnv(root, gateway, tracePath),
+            FX_COMMAND_TEST_INDETERMINATE_AFTER_EXIT: "1",
+          },
+          timeoutMs: 15_000,
+        },
+      );
+      const json = JSON.parse(result.stdout) as {
+        exit_code: number;
+        output: string;
+        tool_calls: Array<{
+          name: string;
+          status: string;
+          command_result?: { termination_indeterminate?: boolean };
+        }>;
+      };
+
+      expect(result.code).toBe(0);
+      expect(json.exit_code).toBe(0);
+      expect(json.output).toContain("acknowledged without retry");
+      expect(gateway.requestCount()).toBe(2);
+      expect(readFileSync(effectPath, "utf8")).toBe("effect\n");
+      expect(observedFailure).toContain("could not be confirmed");
+      expect(observedFailure).toContain("Do not retry");
+      expect(observedFailure).not.toContain("Unexpected");
+      expect(json.tool_calls).toHaveLength(1);
+      expect(json.tool_calls[0]).toMatchObject({
+        name: "terminal",
+        status: "error",
+        command_result: { termination_indeterminate: true },
+      });
+      expect(readFileSync(tracePath, "utf8")).toContain(
+        "command termination became indeterminate",
+      );
+      expect(result.stderr).not.toContain("Unexpected");
+      expect(result.stderr).not.toContain("error.Unexpected");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("suffixless stored result handle remains readable", async () => {
     const root = createFixtureRoot("suffixless-tool-result-handle");
     const tracePath = join(root.root, "trace.log");

--- a/tests/e2e/tui-terminal-tool.test.ts
+++ b/tests/e2e/tui-terminal-tool.test.ts
@@ -2297,6 +2297,95 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "successful terminal close preserves the accepted turn after a lost atomic write response",
+  async () => {
+    const fixture = createFixture("fx-tui-terminal-close-finalization-");
+    const effectPath = join(
+      fixture.workspace,
+      "close-finalization-effect.txt",
+    );
+    let terminalSessionId = "";
+    let writeFailure = "";
+    const gateway = startFakeGateway([
+      fakeGatewayToolCall("close_finalization_start", "terminal", {
+        action: "start",
+        cwd: fixture.workspace,
+        command:
+          "printf 'CLOSE_FINALIZATION_READY\\n'; " +
+          "while IFS= read -r line; do " +
+          "printf 'CLOSE_FINALIZATION_ECHO:%s\\n' \"$line\"; " +
+          "printf '%s\\n' \"$line\" >> close-finalization-effect.txt; done",
+        shell: {
+          kind: "executable",
+          path: TERMINAL_FIXTURE_SHELL,
+          clean_start: true,
+        },
+        backend: "native",
+        return_when: { kind: "match", pattern: "CLOSE_FINALIZATION_READY" },
+        wait_ceiling_ms: 20_000,
+        dimensions: { rows: 24, columns: 80 },
+      }),
+      (body) => {
+        const result = JSON.parse(
+          toolResultText(body, "close_finalization_start"),
+        ) as {
+          success: { start: { session: { session_id: string } } };
+        };
+        terminalSessionId = result.success.start.session.session_id;
+        return fakeGatewayToolCall("close_finalization_write", "terminal", {
+          request: {
+            action: "write",
+            session_id: terminalSessionId,
+            input: { text: "one effect only\n" },
+          },
+        });
+      },
+      (body) => {
+        writeFailure = toolResultText(body, "close_finalization_write");
+        return fakeGatewayToolCall("close_finalization_close", "terminal", {
+          action: "close",
+          session_id: terminalSessionId,
+          close_policy: "force",
+        });
+      },
+      (body) => {
+        expect(toolResultText(body, "close_finalization_close"))
+          .toContain('"lifecycle":"closed"');
+        return fakeGatewayFinalText("CLOSE_FINALIZATION_RESULT_PRESERVED");
+      },
+    ]);
+    gateways.push(gateway);
+    const active = await launch(fixture, gateway, {
+      FX_TERMINAL_TEST_HOST_FAILURE_POINT: "response_write",
+      FX_TERMINAL_TEST_HOST_FAILURE_CORRELATION: "4",
+    });
+
+    await active.sendText("Write once, close the session, and report completion.");
+    const pane = await active.waitForText(
+      "CLOSE_FINALIZATION_RESULT_PRESERVED",
+      TIMEOUT,
+    );
+    const trace = readFileSync(fixture.tracePath, "utf8");
+
+    expect(writeFailure).toContain('"code":"session_lost"');
+    expect(pane).toContain("CLOSE_FINALIZATION_RESULT_PRESERVED");
+    expect(gateway.requests).toHaveLength(4);
+    expect(readFileSync(effectPath, "utf8")).toBe("one effect only\n");
+    expect(trace).toContain("response failed correlation=4");
+    expect(trace).not.toContain("turn lease cleanup failed");
+    expect(terminalRecords(fixture.home)).toEqual([
+      expect.objectContaining({
+        session_id: terminalSessionId,
+        lifecycle: "closed",
+        attention: expect.objectContaining({ write_lease: "none" }),
+      }),
+    ]);
+    expect(readFileSync(fixture.stderrPath, "utf8")).toBe("");
+  },
+  TIMEOUT,
+);
+
+test.skipIf(!tmuxAvailable())(
   "TUI terminal write lease payload contract rejects combined acquire and delivers after valid acquisition",
   async () => {
     const fixture = createFixture("fx-tui-terminal-lease-payload-");


### PR DESCRIPTION
## Summary

- Report uncertain command termination as an explicit indeterminate result so completed effects are not blindly retried.
- Preserve completed assistant responses when terminal lease cleanup fails.
- Clear stale agent lease tracking after a successful terminal close.