### PR TITLE
Fix MCP compatibility and container cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,6 +277,11 @@ add. Trust updates the canonical workspace entry in profile settings. Auth and
 logout run the existing remote credential lifecycle. None of these commands
 constructs the TUI or contacts the Gateway.
 
+The default MCP startup timeout is 30 seconds and remains overridable per
+server with `startup_timeout_ms`. Exact direct `docker run` stdio commands
+without `--cidfile` receive a private cidfile so fx can remove the container
+after shutdown or startup failure. An explicit cidfile remains user-owned.
+
 MongoDB Atlas Managed MCP configuration service accounts use the OAuth
 client-credentials grant. fx does not implement that grant directly. Use
 MongoDB's `mongodb-atlas-mcp-remote` stdio wrapper with inherited

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Add reusable instructions with [skills](https://fx.sh/docs/capabilities/skills),
 
 Use `fx mcp list`, `fx mcp path`, and `fx mcp remove NAME` for noninteractive profile management. `fx mcp trust approve|reject NAME`, `fx mcp trust approve-all`, and `fx mcp trust reset` manage workspace-scoped project trust. `fx mcp auth NAME` and `fx mcp logout NAME` run the existing remote credential lifecycle without opening the TUI or contacting the Gateway.
 
-MongoDB Atlas Managed MCP configuration service accounts use OAuth client credentials, which fx does not acquire directly. Export `MDB_MCP_API_CLIENT_ID` and `MDB_MCP_API_CLIENT_SECRET`, then run `fx mcp add MongoDB npx -y mongodb-atlas-mcp-remote@latest`. MongoDB's browser-based Atlas App Connection flow is a separate user-delegated authentication model and is not interchangeable with those configuration credentials.
+MCP servers have a 30-second startup timeout by default; set `startup_timeout_ms` on a server when its cold start needs a different bound. For direct `docker run` stdio entries, fx uses a private container ID file to remove the owned container after shutdown or startup failure. A configuration that already supplies `--cidfile` keeps ownership of its own cleanup policy.
 
 ## Documentation
 

--- a/src/core/mcp/docker_run.zig
+++ b/src/core/mcp/docker_run.zig
@@ -1,0 +1,224 @@
+const std = @import("std");
+const debug_trace = @import("../shared/debug_trace.zig");
+const io_mod = @import("../shared/io.zig");
+
+const Allocator = std.mem.Allocator;
+const max_container_id_bytes: usize = 128;
+const cleanup_timeout: std.Io.Timeout = .{
+    .duration = .{
+        .raw = .{ .nanoseconds = 15 * std.time.ns_per_s },
+        .clock = .awake,
+    },
+};
+
+pub const Prepared = struct {
+    argv: []const []const u8,
+    owned_argv: ?[][]const u8 = null,
+    cleanup: ?Cleanup = null,
+
+    pub fn takeCleanup(self: *Prepared) ?Cleanup {
+        const cleanup = self.cleanup;
+        self.cleanup = null;
+        return cleanup;
+    }
+
+    pub fn deinit(self: *Prepared, alloc: Allocator) void {
+        if (self.owned_argv) |owned| alloc.free(owned);
+        if (self.cleanup) |*cleanup| cleanup.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+pub const Cleanup = struct {
+    docker_command: []u8,
+    cidfile_path: []u8,
+    environ_map: ?std.process.Environ.Map = null,
+
+    pub fn cloneEnvironment(
+        self: *Cleanup,
+        alloc: Allocator,
+        source: *const std.process.Environ.Map,
+    ) !void {
+        std.debug.assert(self.environ_map == null);
+        self.environ_map = try source.clone(alloc);
+    }
+
+    pub fn deinit(self: *Cleanup, alloc: Allocator) void {
+        if (self.environ_map) |*environment| environment.deinit();
+        alloc.free(self.docker_command);
+        alloc.free(self.cidfile_path);
+        self.* = undefined;
+    }
+
+    pub fn run(self: *const Cleanup, alloc: Allocator) void {
+        defer std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), self.cidfile_path) catch {};
+        const container_id = readContainerId(alloc, self.cidfile_path) catch |err| {
+            if (err != error.FileNotFound) {
+                debug_trace.logf(
+                    "mcp",
+                    "docker MCP cleanup skipped unreadable cidfile err={s}",
+                    .{@errorName(err)},
+                );
+            }
+            return;
+        };
+        defer alloc.free(container_id);
+        const result = std.process.run(alloc, io_mod.getIo(), .{
+            .argv = &.{ self.docker_command, "rm", "-f", container_id },
+            .stdout_limit = .limited(max_container_id_bytes),
+            .stderr_limit = .limited(4096),
+            .timeout = cleanup_timeout,
+            .environ_map = if (self.environ_map) |*environment| environment else null,
+        }) catch |err| {
+            debug_trace.logf(
+                "mcp",
+                "docker MCP cleanup failed err={s}",
+                .{@errorName(err)},
+            );
+            return;
+        };
+        defer alloc.free(result.stdout);
+        defer alloc.free(result.stderr);
+        if (result.term != .exited or result.term.exited != 0) {
+            debug_trace.logf(
+                "mcp",
+                "docker MCP cleanup failed term={t}",
+                .{result.term},
+            );
+            return;
+        }
+        debug_trace.logf("mcp", "docker MCP container cleanup complete", .{});
+    }
+};
+
+pub fn prepare(alloc: Allocator, argv: []const []const u8) !Prepared {
+    if (!isDirectDockerRun(argv) or hasCidfile(argv)) return .{ .argv = argv };
+
+    const temp_root = temporaryRoot() orelse return .{ .argv = argv };
+    if (!std.fs.path.isAbsolute(temp_root)) return .{ .argv = argv };
+    var nonce: [16]u8 = undefined;
+    try std.Io.randomSecure(io_mod.getIo(), &nonce);
+    const nonce_hex = std.fmt.bytesToHex(nonce, .lower);
+    const cidfile_path = try std.fmt.allocPrint(
+        alloc,
+        "{s}/fx-mcp-{s}.cid",
+        .{ std.mem.trimEnd(u8, temp_root, "/\\"), &nonce_hex },
+    );
+    errdefer alloc.free(cidfile_path);
+    const docker_command = try alloc.dupe(u8, argv[0]);
+    errdefer alloc.free(docker_command);
+
+    const owned_argv = try alloc.alloc([]const u8, argv.len + 2);
+    errdefer alloc.free(owned_argv);
+    owned_argv[0] = argv[0];
+    owned_argv[1] = argv[1];
+    owned_argv[2] = "--cidfile";
+    owned_argv[3] = cidfile_path;
+    @memcpy(owned_argv[4..], argv[2..]);
+    return .{
+        .argv = owned_argv,
+        .owned_argv = owned_argv,
+        .cleanup = .{
+            .docker_command = docker_command,
+            .cidfile_path = cidfile_path,
+        },
+    };
+}
+
+fn isDirectDockerRun(argv: []const []const u8) bool {
+    if (argv.len < 2 or !std.mem.eql(u8, argv[1], "run")) return false;
+    const command = std.fs.path.basename(argv[0]);
+    return std.ascii.eqlIgnoreCase(command, "docker") or
+        std.ascii.eqlIgnoreCase(command, "docker.exe");
+}
+
+fn hasCidfile(argv: []const []const u8) bool {
+    for (argv[2..]) |arg| {
+        if (std.mem.eql(u8, arg, "--cidfile") or
+            std.mem.startsWith(u8, arg, "--cidfile=")) return true;
+    }
+    return false;
+}
+
+fn temporaryRoot() ?[]const u8 {
+    return io_mod.getenv("TMPDIR") orelse
+        io_mod.getenv("TEMP") orelse
+        io_mod.getenv("TMP") orelse
+        if (@import("builtin").os.tag == .windows) null else "/tmp";
+}
+
+fn readContainerId(alloc: Allocator, path: []const u8) ![]u8 {
+    const parent_path = std.fs.path.dirname(path) orelse return error.InvalidContainerId;
+    const basename = std.fs.path.basename(path);
+    var parent = try std.Io.Dir.openDirAbsolute(io_mod.getIo(), parent_path, .{});
+    defer parent.close(io_mod.getIo());
+    var file = try io_mod.openExistingRegularFile(parent, basename, .read_only);
+    defer file.close(io_mod.getIo());
+    const stat = try file.stat(io_mod.getIo());
+    if (stat.size > max_container_id_bytes) return error.InvalidContainerId;
+    const bytes = try io_mod.readFileToEnd(alloc, &file, max_container_id_bytes);
+    errdefer alloc.free(bytes);
+    const id = std.mem.trim(u8, bytes, " \t\r\n");
+    if (id.len < 12 or id.len > 64) return error.InvalidContainerId;
+    for (id) |byte| if (!std.ascii.isHex(byte)) return error.InvalidContainerId;
+    if (id.ptr == bytes.ptr and id.len == bytes.len) return bytes;
+    const owned = try alloc.dupe(u8, id);
+    alloc.free(bytes);
+    return owned;
+}
+
+test "docker MCP launch preparation injects one private cidfile" {
+    const alloc = std.testing.allocator;
+    var prepared = try prepare(alloc, &.{
+        "/usr/local/bin/docker",
+        "run",
+        "--rm",
+        "-i",
+        "fixture",
+    });
+    defer prepared.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 7), prepared.argv.len);
+    try std.testing.expectEqualStrings("--cidfile", prepared.argv[2]);
+    try std.testing.expect(prepared.cleanup != null);
+    try std.testing.expectEqualStrings(prepared.argv[3], prepared.cleanup.?.cidfile_path);
+
+    var explicit = try prepare(alloc, &.{
+        "docker",
+        "run",
+        "--cidfile=/tmp/owned.cid",
+        "fixture",
+    });
+    defer explicit.deinit(alloc);
+    try std.testing.expect(explicit.owned_argv == null);
+    try std.testing.expect(explicit.cleanup == null);
+
+    var unrelated = try prepare(alloc, &.{ "podman", "run", "fixture" });
+    defer unrelated.deinit(alloc);
+    try std.testing.expect(unrelated.owned_argv == null);
+}
+
+test "docker MCP cleanup accepts only bounded hexadecimal container ids" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const cidfile = try std.fmt.allocPrint(alloc, "{s}/fixture.cid", .{root});
+    defer alloc.free(cidfile);
+
+    {
+        var file = try std.Io.Dir.createFileAbsolute(std.testing.io, cidfile, .{});
+        defer file.close(std.testing.io);
+        try file.writeStreamingAll(std.testing.io, "0123456789abcdef\n");
+    }
+    const valid = try readContainerId(alloc, cidfile);
+    defer alloc.free(valid);
+    try std.testing.expectEqualStrings("0123456789abcdef", valid);
+
+    {
+        var file = try std.Io.Dir.createFileAbsolute(std.testing.io, cidfile, .{ .truncate = true });
+        defer file.close(std.testing.io);
+        try file.writeStreamingAll(std.testing.io, "not-a-container-id\n");
+    }
+    try std.testing.expectError(error.InvalidContainerId, readContainerId(alloc, cidfile));
+}

--- a/src/core/mcp/features/tools.zig
+++ b/src/core/mcp/features/tools.zig
@@ -344,24 +344,29 @@ pub fn parseCallOutcome(
     }
     for (content.array.items) |item| try validateContentItem(alloc, item, limits);
 
-    if (result.object.get("isError")) |value| if (value != .bool) return error.InvalidCallResult;
+    const is_error = if (result.object.get("isError")) |value| blk: {
+        if (value != .bool) return error.InvalidCallResult;
+        break :blk value.bool;
+    } else false;
     const structured_content = result.object.get("structuredContent");
-    if (output_schema_json) |schema_json| {
-        const structured = structured_content orelse return error.InvalidStructuredContent;
-        var schema = std.json.parseFromSlice(std.json.Value, alloc, schema_json, .{
-            .parse_numbers = false,
-        }) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            else => return error.InvalidStructuredContent,
-        };
-        defer schema.deinit();
-        const validation = json_schema.validateValue(alloc, schema.value, structured, limits.schema) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            else => return error.InvalidStructuredContent,
-        };
-        switch (validation) {
-            .valid, .server_authoritative => {},
-            .invalid => return error.InvalidStructuredContent,
+    if (!is_error) {
+        if (output_schema_json) |schema_json| {
+            const structured = structured_content orelse return error.InvalidStructuredContent;
+            var schema = std.json.parseFromSlice(std.json.Value, alloc, schema_json, .{
+                .parse_numbers = false,
+            }) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return error.InvalidStructuredContent,
+            };
+            defer schema.deinit();
+            const validation = json_schema.validateValue(alloc, schema.value, structured, limits.schema) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return error.InvalidStructuredContent,
+            };
+            switch (validation) {
+                .valid, .server_authoritative => {},
+                .invalid => return error.InvalidStructuredContent,
+            }
         }
     }
     const serialization_limit = std.math.add(usize, max_result_bytes, 16 * 1024) catch
@@ -369,7 +374,7 @@ pub fn parseCallOutcome(
     const result_json = try stringifyValueAlloc(alloc, result, serialization_limit);
     return .{ .complete = .{
         .result_json = result_json,
-        .is_error = if (result.object.get("isError")) |value| value.bool else false,
+        .is_error = is_error,
     } };
 }
 
@@ -996,7 +1001,7 @@ test "tools list rejects malformed schemas behind local references" {
     );
 }
 
-test "tool call results preserve every content type and validate structured content" {
+test "MCP tool call results preserve content types errors and structured validation" {
     const alloc = std.testing.allocator;
     var outcome = try parseCallOutcome(
         alloc,
@@ -1011,11 +1016,30 @@ test "tool call results preserve every content type and validate structured cont
     defer outcome.deinit(alloc);
     try std.testing.expect(!outcome.complete.is_error);
     try std.testing.expect(std.mem.find(u8, outcome.complete.result_json, "resource_link") != null);
+
+    var error_outcome = try parseCallOutcome(
+        alloc,
+        \\{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"No active project"}],"isError":true}}
+    ,
+        .legacy,
+        \\{"type":"object","properties":{"result":{"type":"string"}},"required":["result"]}
+    ,
+        64 * 1024,
+        .{},
+    );
+    defer error_outcome.deinit(alloc);
+    try std.testing.expect(error_outcome.complete.is_error);
+    try std.testing.expect(std.mem.find(
+        u8,
+        error_outcome.complete.result_json,
+        "No active project",
+    ) != null);
+
     try std.testing.expectError(
         error.InvalidStructuredContent,
         parseCallOutcome(
             alloc,
-            \\{"jsonrpc":"2.0","id":2,"result":{"content":[],"structuredContent":"wrong"}}
+            \\{"jsonrpc":"2.0","id":3,"result":{"content":[],"structuredContent":"wrong"}}
         ,
             .modern,
             \\{"type":"array"}
@@ -1028,7 +1052,7 @@ test "tool call results preserve every content type and validate structured cont
         error.InvalidStructuredContent,
         parseCallOutcome(
             alloc,
-            \\{"jsonrpc":"2.0","id":3,"result":{"content":[]}}
+            \\{"jsonrpc":"2.0","id":4,"result":{"content":[]}}
         ,
             .modern,
             \\{"type":"object"}

--- a/src/core/mcp/mcp_contract.zig
+++ b/src/core/mcp/mcp_contract.zig
@@ -2,10 +2,14 @@ const std = @import("std");
 
 const Allocator = std.mem.Allocator;
 
-pub const default_startup_timeout_ms: u32 = 10_000;
+pub const default_startup_timeout_ms: u32 = 30_000;
 pub const default_operation_timeout_ms: u32 = 60_000;
 pub const default_elicitation_timeout_ms: u32 = 30 * 60_000;
 pub const default_restart_limit: u8 = 1;
+
+test "MCP default startup timeout allows thirty-second cold starts" {
+    try std.testing.expectEqual(@as(u32, 30_000), default_startup_timeout_ms);
+}
 
 pub const max_profile_config_warning_key_bytes: usize = 128;
 

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -27,6 +27,7 @@ const operation_control = @import("operation_control.zig");
 const controlled_lock = @import("controlled_lock.zig");
 const mcp_json = @import("mcp_json.zig");
 const protocol_negotiation = @import("protocol_negotiation.zig");
+const docker_run = @import("docker_run.zig");
 const stdio_dispatcher = @import("stdio_dispatcher.zig");
 const streamable_http = @import("streamable_http.zig");
 const feature_cache = @import("feature_cache.zig");
@@ -10351,8 +10352,17 @@ fn spawnStdioServer(alloc: Allocator, server: *McpServer, argv: []const []const 
     const generation = server.next_generation;
     server.next_generation = std.math.add(u64, generation, 1) catch
         return error.McpGenerationExhausted;
+    var prepared = try docker_run.prepare(alloc, argv);
+    defer prepared.deinit(alloc);
+    var docker_cleanup = prepared.takeCleanup();
+    defer if (docker_cleanup) |*cleanup| cleanup.deinit(alloc);
+    if (docker_cleanup) |*cleanup| {
+        if (server.env_map) |*environment| {
+            try cleanup.cloneEnvironment(alloc, environment);
+        }
+    }
     const child = try std.process.spawn(io_mod.getIo(), .{
-        .argv = argv,
+        .argv = prepared.argv,
         .stdin = .pipe,
         .stdout = .pipe,
         .stderr = .ignore,
@@ -10360,13 +10370,20 @@ fn spawnStdioServer(alloc: Allocator, server: *McpServer, argv: []const []const 
         .pgid = if (builtin.os.tag == .windows) null else 0,
     });
 
-    server.dispatcher = try stdio_dispatcher.StdioDispatcher.create(
+    server.dispatcher = stdio_dispatcher.StdioDispatcher.create(
         alloc,
         std.heap.c_allocator,
         child,
         generation,
         mcp_discovery_response_frame_cap_bytes,
-    );
+    ) catch |err| {
+        if (docker_cleanup) |*cleanup| cleanup.run(alloc);
+        return err;
+    };
+    if (docker_cleanup) |cleanup| {
+        server.dispatcher.?.installDockerCleanup(cleanup);
+        docker_cleanup = null;
+    }
 }
 
 fn connectServerLegacy(
@@ -16001,11 +16018,14 @@ test "legacy stdio initialization transitions are bounded and monotonic" {
         .{ .offered = .v2025_11_25, .observation = .{ .accepted = .v2025_11_25 }, .expected = .{ .accept = .v2025_11_25 } },
         .{ .offered = .v2025_11_25, .observation = .{ .accepted = .v2024_11_05 }, .expected = .{ .accept = .v2024_11_05 } },
         .{ .offered = .v2025_06_18, .observation = .{ .accepted = .v2025_11_25 }, .expected = .{ .accept = .v2025_11_25 } },
+        .{ .offered = .v2025_03_26, .observation = .{ .accepted = .v2025_03_26 }, .expected = .{ .accept = .v2025_03_26 } },
         .{ .offered = .v2025_11_25, .observation = .connection_closed, .expected = .{ .retry = .v2025_06_18 } },
-        .{ .offered = .v2025_06_18, .observation = .connection_closed, .expected = .{ .retry = .v2024_11_05 } },
+        .{ .offered = .v2025_06_18, .observation = .connection_closed, .expected = .{ .retry = .v2025_03_26 } },
+        .{ .offered = .v2025_03_26, .observation = .connection_closed, .expected = .{ .retry = .v2024_11_05 } },
         .{ .offered = .v2024_11_05, .observation = .connection_closed, .expected = .fail },
         .{ .offered = .v2025_11_25, .observation = .{ .unsupported = null }, .expected = .{ .retry = .v2025_06_18 } },
-        .{ .offered = .v2025_06_18, .observation = .{ .unsupported = null }, .expected = .{ .retry = .v2024_11_05 } },
+        .{ .offered = .v2025_06_18, .observation = .{ .unsupported = null }, .expected = .{ .retry = .v2025_03_26 } },
+        .{ .offered = .v2025_03_26, .observation = .{ .unsupported = null }, .expected = .{ .retry = .v2024_11_05 } },
         .{ .offered = .v2024_11_05, .observation = .{ .unsupported = null }, .expected = .fail },
         .{ .offered = .v2025_11_25, .observation = .{ .unsupported = .v2024_11_05 }, .expected = .{ .retry = .v2024_11_05 } },
         .{ .offered = .v2025_11_25, .observation = .{ .unsupported = .v2025_11_25 }, .expected = .fail },

--- a/src/core/mcp/protocol_negotiation.zig
+++ b/src/core/mcp/protocol_negotiation.zig
@@ -5,6 +5,7 @@ const elicitation = @import("elicitation.zig");
 const mcp_contract = @import("mcp_contract.zig");
 
 pub const legacy_protocol_version = "2024-11-05";
+pub const legacy_2025_03_protocol_version = "2025-03-26";
 pub const legacy_2025_06_protocol_version = "2025-06-18";
 pub const legacy_2025_11_protocol_version = "2025-11-25";
 pub const modern_protocol_version = "2026-07-28";
@@ -49,12 +50,14 @@ pub const HttpDiscoveryOutcome = enum {
 pub const LegacyStdioVersion = enum {
     v2025_11_25,
     v2025_06_18,
+    v2025_03_26,
     v2024_11_05,
 
     pub fn string(self: LegacyStdioVersion) []const u8 {
         return switch (self) {
             .v2025_11_25 => legacy_2025_11_protocol_version,
             .v2025_06_18 => legacy_2025_06_protocol_version,
+            .v2025_03_26 => legacy_2025_03_protocol_version,
             .v2024_11_05 => legacy_protocol_version,
         };
     }
@@ -63,13 +66,14 @@ pub const LegacyStdioVersion = enum {
         return switch (self) {
             .v2025_11_25 => .legacy_mcp_2025_11,
             .v2025_06_18 => .legacy_mcp_2025_06,
-            .v2024_11_05 => null,
+            .v2025_03_26, .v2024_11_05 => null,
         };
     }
 
     pub fn parse(value: []const u8) ?LegacyStdioVersion {
         if (std.mem.eql(u8, value, legacy_2025_11_protocol_version)) return .v2025_11_25;
         if (std.mem.eql(u8, value, legacy_2025_06_protocol_version)) return .v2025_06_18;
+        if (std.mem.eql(u8, value, legacy_2025_03_protocol_version)) return .v2025_03_26;
         if (std.mem.eql(u8, value, legacy_protocol_version)) return .v2024_11_05;
         return null;
     }
@@ -77,15 +81,17 @@ pub const LegacyStdioVersion = enum {
     pub fn older(self: LegacyStdioVersion) ?LegacyStdioVersion {
         return switch (self) {
             .v2025_11_25 => .v2025_06_18,
-            .v2025_06_18 => .v2024_11_05,
+            .v2025_06_18 => .v2025_03_26,
+            .v2025_03_26 => .v2024_11_05,
             .v2024_11_05 => null,
         };
     }
 
-    fn preference(self: LegacyStdioVersion) u2 {
+    fn preference(self: LegacyStdioVersion) u3 {
         return switch (self) {
-            .v2025_11_25 => 3,
-            .v2025_06_18 => 2,
+            .v2025_11_25 => 4,
+            .v2025_06_18 => 3,
+            .v2025_03_26 => 2,
             .v2024_11_05 => 1,
         };
     }
@@ -238,6 +244,7 @@ pub fn selectLegacyStdioVersionForRequest(
     inline for ([_]LegacyStdioVersion{
         .v2025_11_25,
         .v2025_06_18,
+        .v2025_03_26,
         .v2024_11_05,
     }) |version| {
         if (protocolErrorSupportsVersionForRequest(
@@ -316,11 +323,14 @@ test "legacy initialization transitions are bounded and monotonic" {
         .{ .offered = .v2025_11_25, .observation = .{ .accepted = .v2025_11_25 }, .expected = .{ .accept = .v2025_11_25 } },
         .{ .offered = .v2025_11_25, .observation = .{ .accepted = .v2024_11_05 }, .expected = .{ .accept = .v2024_11_05 } },
         .{ .offered = .v2025_06_18, .observation = .{ .accepted = .v2025_11_25 }, .expected = .{ .accept = .v2025_11_25 } },
+        .{ .offered = .v2025_03_26, .observation = .{ .accepted = .v2025_03_26 }, .expected = .{ .accept = .v2025_03_26 } },
         .{ .offered = .v2025_11_25, .observation = .connection_closed, .expected = .{ .retry = .v2025_06_18 } },
-        .{ .offered = .v2025_06_18, .observation = .connection_closed, .expected = .{ .retry = .v2024_11_05 } },
+        .{ .offered = .v2025_06_18, .observation = .connection_closed, .expected = .{ .retry = .v2025_03_26 } },
+        .{ .offered = .v2025_03_26, .observation = .connection_closed, .expected = .{ .retry = .v2024_11_05 } },
         .{ .offered = .v2024_11_05, .observation = .connection_closed, .expected = .fail },
         .{ .offered = .v2025_11_25, .observation = .{ .unsupported = null }, .expected = .{ .retry = .v2025_06_18 } },
-        .{ .offered = .v2025_06_18, .observation = .{ .unsupported = null }, .expected = .{ .retry = .v2024_11_05 } },
+        .{ .offered = .v2025_06_18, .observation = .{ .unsupported = null }, .expected = .{ .retry = .v2025_03_26 } },
+        .{ .offered = .v2025_03_26, .observation = .{ .unsupported = null }, .expected = .{ .retry = .v2024_11_05 } },
         .{ .offered = .v2024_11_05, .observation = .{ .unsupported = null }, .expected = .fail },
         .{ .offered = .v2025_11_25, .observation = .{ .unsupported = .v2024_11_05 }, .expected = .{ .retry = .v2024_11_05 } },
         .{ .offered = .v2025_11_25, .observation = .{ .unsupported = .v2025_11_25 }, .expected = .fail },
@@ -332,6 +342,21 @@ test "legacy initialization transitions are bounded and monotonic" {
             decideLegacyInitializeTransition(case.offered, case.observation),
         );
     }
+}
+
+test "MCP legacy stdio negotiation includes 2025-03-26" {
+    try std.testing.expectEqual(
+        LegacyStdioVersion.v2025_03_26,
+        LegacyStdioVersion.parse("2025-03-26").?,
+    );
+    try std.testing.expectEqual(
+        LegacyStdioVersion.v2025_03_26,
+        LegacyStdioVersion.v2025_06_18.older().?,
+    );
+    try std.testing.expectEqual(
+        LegacyStdioVersion.v2024_11_05,
+        LegacyStdioVersion.v2025_03_26.older().?,
+    );
 }
 
 test "method-not-found discovery begins fallback at the newest legacy version" {

--- a/src/core/mcp/stdio_dispatcher.zig
+++ b/src/core/mcp/stdio_dispatcher.zig
@@ -4,11 +4,13 @@ const builtin = @import("builtin");
 const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
 const mcp_contract = @import("mcp_contract.zig");
+const docker_run = @import("docker_run.zig");
 const operation_control = @import("operation_control.zig");
 
 const Allocator = std.mem.Allocator;
 const request_poll_ns: u64 = 5 * std.time.ns_per_ms;
 const shutdown_grace_ms: i64 = 1_000;
+const termination_grace_ms: i64 = 1_000;
 const cancellation_write_timeout_ms: u32 = 100;
 const server_request_write_timeout_ms: u32 = 1_000;
 
@@ -249,6 +251,7 @@ pub const StdioDispatcher = struct {
     next_request_id: u64 = 0,
     generation: u64,
     max_frame_bytes: std.atomic.Value(usize),
+    docker_cleanup: ?docker_run.Cleanup = null,
     notification_sink: ?NotificationSink = null,
     notification_callback_active: bool = false,
     active_server_request_workers: usize = 0,
@@ -324,7 +327,16 @@ pub const StdioDispatcher = struct {
         self.destroy();
     }
 
+    pub fn installDockerCleanup(
+        self: *StdioDispatcher,
+        cleanup: docker_run.Cleanup,
+    ) void {
+        std.debug.assert(self.docker_cleanup == null);
+        self.docker_cleanup = cleanup;
+    }
+
     fn destroy(self: *StdioDispatcher) void {
+        std.debug.assert(self.docker_cleanup == null);
         self.pending.deinit();
         const owner_allocator = self.owner_allocator;
         owner_allocator.destroy(self);
@@ -800,6 +812,7 @@ pub const StdioDispatcher = struct {
         self.closeStdin();
         if (!should_join) {
             self.markStopped();
+            self.runDockerCleanupOnce();
             return;
         }
 
@@ -808,6 +821,22 @@ pub const StdioDispatcher = struct {
                 i64,
                 io_mod.milliTimestamp(),
                 shutdown_grace_ms,
+            ) catch std.math.maxInt(i64);
+            while (!self.readerIsDone() and io_mod.milliTimestamp() < deadline_ms) {
+                io_mod.sleep(request_poll_ns);
+            }
+        }
+        if (!self.readerIsDone()) {
+            debug_trace.logf(
+                "mcp",
+                "stdio dispatcher requesting child termination generation={d}",
+                .{self.generation},
+            );
+            terminateChildGracefully(self.child_id);
+            const deadline_ms = std.math.add(
+                i64,
+                io_mod.milliTimestamp(),
+                termination_grace_ms,
             ) catch std.math.maxInt(i64);
             while (!self.readerIsDone() and io_mod.milliTimestamp() < deadline_ms) {
                 io_mod.sleep(request_poll_ns);
@@ -830,11 +859,19 @@ pub const StdioDispatcher = struct {
         while (!self.usersDone()) io_mod.sleep(request_poll_ns);
         self.stdout = null;
         self.markStopped();
+        self.runDockerCleanupOnce();
         debug_trace.logf(
             "mcp",
             "stdio dispatcher stopped generation={d} reader_joined=true",
             .{self.generation},
         );
+    }
+
+    fn runDockerCleanupOnce(self: *StdioDispatcher) void {
+        var cleanup = self.docker_cleanup orelse return;
+        self.docker_cleanup = null;
+        defer cleanup.deinit(self.owner_allocator);
+        cleanup.run(self.owner_allocator);
     }
 
     fn registerPending(
@@ -1683,6 +1720,21 @@ fn terminateChild(child_id: std.process.Child.Id) void {
     }
 }
 
+fn terminateChildGracefully(child_id: std.process.Child.Id) void {
+    switch (builtin.os.tag) {
+        .windows => terminateChild(child_id),
+        .wasi => {},
+        else => std.posix.kill(child_id, .TERM) catch |err| switch (err) {
+            error.ProcessNotFound => {},
+            else => debug_trace.logf(
+                "mcp",
+                "failed to request stdio child termination pid={d} err={s}",
+                .{ child_id, @errorName(err) },
+            ),
+        },
+    }
+}
+
 test "classifyInbound separates responses notifications progress and requests" {
     const alloc = std.testing.allocator;
     const cases = [_]struct {
@@ -2312,6 +2364,71 @@ test "operation timeout returns and shutdown joins an uncooperative child" {
     );
 
     dispatcher.shutdown();
+    try expectProcessReaped(fixture.pid);
+}
+
+test "MCP normal shutdown gives a cooperative child TERM before forced cleanup" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    }
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const sentinel = try std.fmt.allocPrint(alloc, "{s}/term-sentinel", .{root});
+    defer alloc.free(sentinel);
+    const ready = try std.fmt.allocPrint(alloc, "{s}/ready", .{root});
+    defer alloc.free(ready);
+    const script = try std.fmt.allocPrint(
+        alloc,
+        "trap 'printf term > \"{s}\"; exit 0' TERM\nprintf ready > \"{s}\"\nwhile :; do :; done",
+        .{ sentinel, ready },
+    );
+    defer alloc.free(script);
+
+    const fixture = try createShellDispatcher(script);
+    const dispatcher = fixture.dispatcher;
+    defer dispatcher.deinit();
+
+    dispatcher.shutdown();
+    try std.Io.Dir.accessAbsolute(std.testing.io, sentinel, .{});
+    try expectProcessReaped(fixture.pid);
+}
+
+test "MCP forced shutdown gives launchers bounded TERM before KILL" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    }
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const sentinel = try std.fmt.allocPrint(alloc, "{s}/term-sentinel", .{root});
+    defer alloc.free(sentinel);
+    const ready = try std.fmt.allocPrint(alloc, "{s}/ready", .{root});
+    defer alloc.free(ready);
+    const script = try std.fmt.allocPrint(
+        alloc,
+        "trap 'printf term > \"{s}\"; exit 0' TERM\nprintf ready > \"{s}\"\nwhile :; do :; done",
+        .{ sentinel, ready },
+    );
+    defer alloc.free(script);
+
+    const fixture = try createShellDispatcher(script);
+    const dispatcher = fixture.dispatcher;
+    defer dispatcher.deinit();
+
+    for (0..100) |_| {
+        std.Io.Dir.accessAbsolute(std.testing.io, ready, .{}) catch {
+            io_mod.sleep(5 * std.time.ns_per_ms);
+            continue;
+        };
+        break;
+    } else return error.TestExpectedReady;
+    dispatcher.shutdownForced();
+    try std.Io.Dir.accessAbsolute(std.testing.io, sentinel, .{});
     try expectProcessReaped(fixture.pid);
 }
 

--- a/src/core/mcp/streamable_http.zig
+++ b/src/core/mcp/streamable_http.zig
@@ -406,8 +406,13 @@ fn postCore(alloc: Allocator, options: PostOptions) !PostResponse {
     }
 
     const content_type = response.head.content_type orelse return error.MissingContentType;
-    const media_type = parseMediaType(content_type) orelse return error.UnsupportedContentType;
-    if (version_error and media_type != .json) return error.UnsupportedContentType;
+    const media_type = parseMediaType(content_type);
+    const legacy_plain_text_discovery = version_error and prepared.is_discovery and
+        isPlainTextMediaType(content_type);
+    if (media_type == null and !legacy_plain_text_discovery) return error.UnsupportedContentType;
+    if (version_error and media_type != .json and !legacy_plain_text_discovery) {
+        return error.UnsupportedContentType;
+    }
 
     var transfer_buffer: [16 * 1024]u8 = undefined;
     var content_length_reader: McpContentLengthReader = undefined;
@@ -425,13 +430,24 @@ fn postCore(alloc: Allocator, options: PostOptions) !PostResponse {
         },
         .standard => response.reader(&transfer_buffer),
     };
-    const body = switch (media_type) {
-        .json => try readJsonResponse(
+    var body_auth_rejection: AuthRejection = .none;
+    const body = if (legacy_plain_text_discovery)
+        try readJsonResponseClassified(
             alloc,
             reader,
             prepared.id,
             options.max_response_bytes,
             prepared.is_discovery,
+            &body_auth_rejection,
+        )
+    else switch (media_type.?) {
+        .json => try readJsonResponseClassified(
+            alloc,
+            reader,
+            prepared.id,
+            options.max_response_bytes,
+            prepared.is_discovery,
+            &body_auth_rejection,
         ),
         .sse => try readSseResponse(
             alloc,
@@ -445,10 +461,17 @@ fn postCore(alloc: Allocator, options: PostOptions) !PostResponse {
             options.control.cancellation(),
         ),
     };
+    errdefer alloc.free(body);
+    if (legacy_plain_text_discovery and body_auth_rejection == .none and
+        !try isLegacyDiscoveryCompatibilityResponse(alloc, body))
+    {
+        return error.UnsupportedContentType;
+    }
     return .{
         .body = body,
         .version_error = version_error,
         .discovery_mismatch_status = discovery_mismatch_status,
+        .auth_rejection = body_auth_rejection,
     };
 }
 
@@ -797,6 +820,12 @@ fn parseMediaType(value: []const u8) ?MediaType {
     return null;
 }
 
+fn isPlainTextMediaType(value: []const u8) bool {
+    const separator = std.mem.indexOfScalar(u8, value, ';') orelse value.len;
+    const media_type = std.mem.trim(u8, value[0..separator], " \t");
+    return std.ascii.eqlIgnoreCase(media_type, "text/plain");
+}
+
 fn readJsonResponse(
     alloc: Allocator,
     reader: *std.Io.Reader,
@@ -804,6 +833,31 @@ fn readJsonResponse(
     max_response_bytes: usize,
     allow_discovery_error_id_mismatch: bool,
 ) ![]u8 {
+    var auth_rejection: AuthRejection = .none;
+    const body = try readJsonResponseClassified(
+        alloc,
+        reader,
+        request_id,
+        max_response_bytes,
+        allow_discovery_error_id_mismatch,
+        &auth_rejection,
+    );
+    if (auth_rejection != .none) {
+        alloc.free(body);
+        return error.InvalidJsonResponse;
+    }
+    return body;
+}
+
+fn readJsonResponseClassified(
+    alloc: Allocator,
+    reader: *std.Io.Reader,
+    request_id: i64,
+    max_response_bytes: usize,
+    allow_discovery_error_id_mismatch: bool,
+    auth_rejection: *AuthRejection,
+) ![]u8 {
+    auth_rejection.* = .none;
     var body_list: std.ArrayList(u8) = .empty;
     defer body_list.deinit(alloc);
     var chunk: [16 * 1024]u8 = undefined;
@@ -817,13 +871,46 @@ fn readJsonResponse(
     }
     const body = try body_list.toOwnedSlice(alloc);
     errdefer alloc.free(body);
-    try validateFinalResponse(
+    validateFinalResponse(
         alloc,
         body,
         request_id,
         allow_discovery_error_id_mismatch,
-    );
+    ) catch |err| {
+        if (allow_discovery_error_id_mismatch) {
+            const rejection = try discoveryAuthenticationRejection(alloc, body);
+            if (rejection != .none) {
+                auth_rejection.* = rejection;
+                return body;
+            }
+        }
+        return err;
+    };
     return body;
+}
+
+fn discoveryAuthenticationRejection(
+    alloc: Allocator,
+    body: []const u8,
+) Allocator.Error!AuthRejection {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, body, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return .none,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object or parsed.value.object.contains("jsonrpc")) {
+        return .none;
+    }
+    const status = parsed.value.object.get("error") orelse return .none;
+    const reason = parsed.value.object.get("reason") orelse return .none;
+    if (status != .integer or reason != .string) return .none;
+    if (status.integer == 401 and std.mem.eql(u8, reason.string, "Unauthorized")) {
+        return .unauthorized;
+    }
+    if (status.integer == 403 and std.mem.eql(u8, reason.string, "Forbidden")) {
+        return .insufficient_scope;
+    }
+    return .none;
 }
 
 const SseEvent = struct {
@@ -1078,7 +1165,7 @@ fn validateFinalResponse(
     }
     const id_value = parsed.value.object.get("id") orelse {
         if (allow_discovery_error_id_mismatch and
-            isLegacySessionlessDiscoveryError(parsed.value.object)) return;
+            isLegacyDiscoveryCompatibilityError(parsed.value.object)) return;
         return error.InvalidJsonResponse;
     };
     const matching_id = id_value == .integer and id_value.integer == request_id;
@@ -1094,15 +1181,29 @@ fn validateFinalResponse(
 }
 
 const legacy_sessionless_invalid_request_code: i64 = -32004;
+const legacy_session_required_code: i64 = -32000;
 
-fn isLegacySessionlessDiscoveryError(object: std.json.ObjectMap) bool {
+fn isLegacyDiscoveryCompatibilityError(object: std.json.ObjectMap) bool {
     if (object.contains("result")) return false;
     const error_value = object.get("error") orelse return false;
     if (error_value != .object) return false;
     const code = error_value.object.get("code") orelse return false;
     const message = error_value.object.get("message") orelse return false;
-    return code == .integer and code.integer == legacy_sessionless_invalid_request_code and
-        message == .string and std.mem.eql(u8, message.string, "invalid request");
+    if (code != .integer or message != .string) return false;
+    return (code.integer == legacy_sessionless_invalid_request_code and
+        std.mem.eql(u8, message.string, "invalid request")) or
+        (code.integer == legacy_session_required_code and
+            std.mem.eql(u8, message.string, "Bad Request: Mcp-Session-Id header is required"));
+}
+
+fn isLegacyDiscoveryCompatibilityResponse(alloc: Allocator, body: []const u8) Allocator.Error!bool {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, body, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return false,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return false;
+    return isLegacyDiscoveryCompatibilityError(parsed.value.object);
 }
 
 fn waitForCancellation(cancellation: operation_control.CancellationSources) anyerror!void {
@@ -1612,6 +1713,39 @@ test "modern MCP JSON responses are bounded and retain request ownership" {
         mongodb_session_error_body,
     );
 
+    const gitmcp_session_error =
+        "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32000,\"message\":\"Bad Request: Mcp-Session-Id header is required\"}}";
+    var gitmcp_parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        gitmcp_session_error,
+        .{},
+    );
+    defer gitmcp_parsed.deinit();
+    try std.testing.expect(isLegacyDiscoveryCompatibilityError(gitmcp_parsed.value.object));
+
+    const stock_session_error =
+        "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32000,\"message\":\"Bad Request: Mcp-Session-Id header is required\"}}";
+    var stock_session_error_reader = std.Io.Reader.fixed(stock_session_error);
+    const stock_session_error_body = try readJsonResponse(
+        alloc,
+        &stock_session_error_reader,
+        7,
+        stock_session_error.len,
+        true,
+    );
+    defer alloc.free(stock_session_error_body);
+    try std.testing.expectEqualStrings(stock_session_error, stock_session_error_body);
+
+    var unrelated_session_error = try std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32000,\"message\":\"Session expired\"}}",
+        .{},
+    );
+    defer unrelated_session_error.deinit();
+    try std.testing.expect(!isLegacyDiscoveryCompatibilityError(unrelated_session_error.value.object));
+
     const unrelated_missing_id_error =
         "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}";
     var unrelated_missing_id_reader = std.Io.Reader.fixed(unrelated_missing_id_error);
@@ -1638,6 +1772,39 @@ test "modern MCP JSON responses are bounded and retain request ownership" {
             string_id_success.len,
             true,
         ),
+    );
+}
+
+test "MCP discovery recognizes bounded authorization error documents" {
+    const alloc = std.testing.allocator;
+    const unauthorized =
+        "{\"error\":401,\"reason\":\"Unauthorized\",\"detail\":\"You are not authorized for this resource.\"}";
+    try std.testing.expectEqual(
+        AuthRejection.unauthorized,
+        try discoveryAuthenticationRejection(alloc, unauthorized),
+    );
+    var strict_reader = std.Io.Reader.fixed(unauthorized);
+    try std.testing.expectError(
+        error.InvalidJsonResponse,
+        readJsonResponse(alloc, &strict_reader, 7, unauthorized.len, true),
+    );
+    try std.testing.expectEqual(
+        AuthRejection.insufficient_scope,
+        try discoveryAuthenticationRejection(
+            alloc,
+            "{\"error\":403,\"reason\":\"Forbidden\",\"detail\":\"Insufficient scope.\"}",
+        ),
+    );
+    try std.testing.expectEqual(
+        AuthRejection.none,
+        try discoveryAuthenticationRejection(
+            alloc,
+            "{\"error\":401,\"reason\":\"not an authorization response\"}",
+        ),
+    );
+    try std.testing.expectEqual(
+        AuthRejection.none,
+        try discoveryAuthenticationRejection(alloc, "not json"),
     );
 }
 

--- a/src/core/mcp/streamable_http.zig
+++ b/src/core/mcp/streamable_http.zig
@@ -1182,6 +1182,7 @@ fn validateFinalResponse(
 
 const legacy_sessionless_invalid_request_code: i64 = -32004;
 const legacy_session_required_code: i64 = -32000;
+const legacy_missing_session_header_code: i64 = -32600;
 
 fn isLegacyDiscoveryCompatibilityError(object: std.json.ObjectMap) bool {
     if (object.contains("result")) return false;
@@ -1193,7 +1194,13 @@ fn isLegacyDiscoveryCompatibilityError(object: std.json.ObjectMap) bool {
     return (code.integer == legacy_sessionless_invalid_request_code and
         std.mem.eql(u8, message.string, "invalid request")) or
         (code.integer == legacy_session_required_code and
-            std.mem.eql(u8, message.string, "Bad Request: Mcp-Session-Id header is required"));
+            std.mem.eql(u8, message.string, "Bad Request: Mcp-Session-Id header is required")) or
+        (code.integer == legacy_missing_session_header_code and
+            std.mem.eql(
+                u8,
+                message.string,
+                "Missing required Mcp-Session-Id header. Non-initialize requests must include a session ID.",
+            ));
 }
 
 fn isLegacyDiscoveryCompatibilityResponse(alloc: Allocator, body: []const u8) Allocator.Error!bool {
@@ -1736,6 +1743,24 @@ test "modern MCP JSON responses are bounded and retain request ownership" {
     );
     defer alloc.free(stock_session_error_body);
     try std.testing.expectEqualStrings(stock_session_error, stock_session_error_body);
+
+    const mongodb_deployed_session_error =
+        "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Missing required Mcp-Session-Id header. Non-initialize requests must include a session ID.\"}}";
+    var mongodb_deployed_session_error_reader = std.Io.Reader.fixed(
+        mongodb_deployed_session_error,
+    );
+    const mongodb_deployed_session_error_body = try readJsonResponse(
+        alloc,
+        &mongodb_deployed_session_error_reader,
+        7,
+        mongodb_deployed_session_error.len,
+        true,
+    );
+    defer alloc.free(mongodb_deployed_session_error_body);
+    try std.testing.expectEqualStrings(
+        mongodb_deployed_session_error,
+        mongodb_deployed_session_error_body,
+    );
 
     var unrelated_session_error = try std.json.parseFromSlice(
         std.json.Value,

--- a/tests/e2e/fixtures/mcp-modern-http.ts
+++ b/tests/e2e/fixtures/mcp-modern-http.ts
@@ -37,7 +37,10 @@ export type ModernHttpMode =
   | "features_stale_read"
   | "features_ttl_expiry"
   | "mrtr_form"
-  | "legacy_session_required";
+  | "legacy_session_required"
+  | "legacy_json_session_required"
+  | "legacy_plaintext_auth_rejection"
+  | "legacy_plaintext_session_required";
 
 export type ModernHttpRequest = {
   message: {
@@ -83,13 +86,16 @@ export function startModernMcpHttpFixture(
     idleTimeout: 30,
     async fetch(request) {
       httpMethods.push(request.method);
-      if (mode === "legacy_session_required" && request.method === "GET") {
+      const legacySessionRequired = mode === "legacy_session_required" ||
+        mode === "legacy_json_session_required" ||
+        mode === "legacy_plaintext_session_required";
+      if (legacySessionRequired && request.method === "GET") {
         return new Response("Method Not Allowed", {
           status: 405,
           headers: { Allow: "POST, DELETE" },
         });
       }
-      if (mode === "legacy_session_required" && request.method === "DELETE") {
+      if (legacySessionRequired && request.method === "DELETE") {
         return new Response(null, { status: 200 });
       }
       const message = await request.json() as ModernHttpRequest["message"];
@@ -103,9 +109,54 @@ export function startModernMcpHttpFixture(
       if (message.method === "resources/list") resourcesListCalls += 1;
       if (message.method === "resources/read") resourceReadCalls += 1;
 
-      if (mode === "legacy_session_required") {
+      if (
+        mode === "legacy_plaintext_auth_rejection" &&
+        message.method === "server/discover"
+      ) {
+        return new Response(
+          JSON.stringify({
+            error: 401,
+            reason: "Unauthorized",
+            detail: "You are not authorized for this resource.",
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "text/plain;charset=UTF-8" },
+          },
+        );
+      }
+
+      if (legacySessionRequired) {
         const sessionId = "mongodb-managed-session";
         if (message.method === "server/discover") {
+          if (mode === "legacy_json_session_required") {
+            return Response.json(
+              {
+                jsonrpc: "2.0",
+                error: {
+                  code: -32000,
+                  message: "Bad Request: Mcp-Session-Id header is required",
+                },
+              },
+              { status: 400 },
+            );
+          }
+          if (mode === "legacy_plaintext_session_required") {
+            return new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: null,
+                error: {
+                  code: -32000,
+                  message: "Bad Request: Mcp-Session-Id header is required",
+                },
+              }),
+              {
+                status: 400,
+                headers: { "content-type": "text/plain;charset=UTF-8" },
+              },
+            );
+          }
           return Response.json(
             {
               jsonrpc: "2.0",
@@ -120,10 +171,14 @@ export function startModernMcpHttpFixture(
               jsonrpc: "2.0",
               id: message.id,
               result: {
-                protocolVersion: "2025-11-25",
+                protocolVersion: mode === "legacy_plaintext_session_required"
+                  ? "2025-03-26"
+                  : "2025-11-25",
                 capabilities: { tools: {} },
                 serverInfo: {
-                  name: "mongodb-managed-fixture",
+                  name: mode === "legacy_plaintext_session_required"
+                    ? "gitmcp-fixture"
+                    : "mongodb-managed-fixture",
                   version: "1.0.0",
                 },
               },

--- a/tests/e2e/fixtures/mcp-modern-http.ts
+++ b/tests/e2e/fixtures/mcp-modern-http.ts
@@ -39,6 +39,7 @@ export type ModernHttpMode =
   | "mrtr_form"
   | "legacy_session_required"
   | "legacy_json_session_required"
+  | "legacy_mongodb_session_required"
   | "legacy_plaintext_auth_rejection"
   | "legacy_plaintext_session_required";
 
@@ -88,6 +89,7 @@ export function startModernMcpHttpFixture(
       httpMethods.push(request.method);
       const legacySessionRequired = mode === "legacy_session_required" ||
         mode === "legacy_json_session_required" ||
+        mode === "legacy_mongodb_session_required" ||
         mode === "legacy_plaintext_session_required";
       if (legacySessionRequired && request.method === "GET") {
         return new Response("Method Not Allowed", {
@@ -129,6 +131,19 @@ export function startModernMcpHttpFixture(
       if (legacySessionRequired) {
         const sessionId = "mongodb-managed-session";
         if (message.method === "server/discover") {
+          if (mode === "legacy_mongodb_session_required") {
+            return Response.json(
+              {
+                jsonrpc: "2.0",
+                error: {
+                  code: -32600,
+                  message:
+                    "Missing required Mcp-Session-Id header. Non-initialize requests must include a session ID.",
+                },
+              },
+              { status: 400 },
+            );
+          }
           if (mode === "legacy_json_session_required") {
             return Response.json(
               {

--- a/tests/e2e/fixtures/mcp-modern-stdio.mjs
+++ b/tests/e2e/fixtures/mcp-modern-stdio.mjs
@@ -253,6 +253,15 @@ function handle(message) {
                 properties: { text: { type: "string" } },
                 required: ["text"],
               },
+              ...(mode === "tool_failure"
+                ? {
+                    outputSchema: {
+                      type: "object",
+                      properties: { result: { type: "string" } },
+                      required: ["result"],
+                    },
+                  }
+                : {}),
             }],
         ttlMs: 60_000,
         cacheScope: "public",

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -196,6 +196,7 @@ function startAuthFixture(
     authorizationResponseIssuer?: string;
     omitScopes?: boolean;
     rejectDiscoveryWithoutChallenge?: boolean;
+    rejectDiscoveryWithRestAuthorizationDocument?: boolean;
   } = {},
 ) {
   const transport = options.transport ?? "http";
@@ -260,6 +261,19 @@ function startAuthFixture(
           options.rejectDiscoveryWithoutChallenge
         ) {
           return new Response("", { status: 403 });
+        }
+        if (
+          message?.method === "server/discover" &&
+          options.rejectDiscoveryWithRestAuthorizationDocument
+        ) {
+          return Response.json(
+            {
+              error: 401,
+              reason: "Unauthorized",
+              detail: "You are not authorized for this resource.",
+            },
+            { status: 400 },
+          );
         }
         if (message?.method === "resources/read") {
           resourceReadRequests += 1;
@@ -978,6 +992,85 @@ describe("MCP remote authentication lifecycle", () => {
       "notifications/initialized",
       "tools/list",
     ]);
+  }, 30_000);
+
+  test("OAuth-authenticated missing-id session error reaches legacy tools", async () => {
+    upstream = startModernMcpHttpFixture("legacy_json_session_required");
+    auth = startAuthFixture(upstream.url);
+    const root = createRoot(auth);
+    const env = {
+      ...baseEnv(root),
+      AI_GATEWAY_API_KEY: undefined,
+    };
+
+    const authenticated = await runFx(["mcp", "auth", "fixture"], {
+      cwd: root.workspace,
+      env,
+      timeoutMs: 20_000,
+    });
+    expect(authenticated.code).toBe(0);
+    expect(authenticated.stdout).toContain("Authenticated MCP server 'fixture'");
+
+    const listed = await runFx(["mcp", "list", "--connect"], {
+      cwd: root.workspace,
+      env,
+      timeoutMs: 20_000,
+    });
+    expect(listed.code).toBe(0);
+    expect(listed.stderr).toBe("");
+    expect(listed.stdout).toMatch(
+      /fixture[\s\S]{0,240}state=ready auth=authenticated/,
+    );
+    expect(listed.stdout).toContain("protocol=2025-11-25");
+    expect(listed.stdout).toContain(
+      "negotiated_name=mongodb-managed-fixture negotiated_version=1.0.0",
+    );
+    expect(listed.stdout).toContain("tools=1");
+    expect(upstream.requests.map((entry) => entry.message.method)).toEqual([
+      "server/discover",
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+    ]);
+  }, 30_000);
+
+  test("MongoDB-like REST authorization document rejects stored credentials", async () => {
+    upstream = startModernMcpHttpFixture("json");
+    auth = startAuthFixture(upstream.url, {
+      rejectDiscoveryWithRestAuthorizationDocument: true,
+    });
+    const root = createRoot(auth);
+    const env = {
+      ...baseEnv(root),
+      AI_GATEWAY_API_KEY: undefined,
+    };
+
+    const authenticated = await runFx(["mcp", "auth", "fixture"], {
+      cwd: root.workspace,
+      env,
+      timeoutMs: 20_000,
+    });
+    expect(authenticated.code).toBe(0);
+    expect(authenticated.stdout).toContain("Authenticated MCP server 'fixture'");
+
+    const listed = await runFx(["mcp", "list", "--connect"], {
+      cwd: root.workspace,
+      env,
+      timeoutMs: 20_000,
+    });
+    expect(listed.code).toBe(0);
+    expect(listed.stdout).toMatch(/fixture[\s\S]{0,240}auth=required/);
+    expect(listed.stdout).not.toContain("auth=authenticated");
+    expect(listed.stdout).toContain("Authentication is required");
+    expect(listed.stdout).not.toContain("InvalidJsonResponse");
+    expect(upstream.requests).toHaveLength(0);
+    for (const secret of [ACCESS_INITIAL, REFRESH_INITIAL]) {
+      expect(listed.stdout).not.toContain(secret);
+      expect(listed.stderr).not.toContain(secret);
+      if (existsSync(root.trace)) {
+        expect(readFileSync(root.trace, "utf8")).not.toContain(secret);
+      }
+    }
   }, 30_000);
 
   test.skipIf(process.platform !== "darwin")(

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -994,8 +994,8 @@ describe("MCP remote authentication lifecycle", () => {
     ]);
   }, 30_000);
 
-  test("OAuth-authenticated missing-id session error reaches legacy tools", async () => {
-    upstream = startModernMcpHttpFixture("legacy_json_session_required");
+  test("OAuth-authenticated MongoDB deployed session error reaches legacy tools", async () => {
+    upstream = startModernMcpHttpFixture("legacy_mongodb_session_required");
     auth = startAuthFixture(upstream.url);
     const root = createRoot(auth);
     const env = {

--- a/tests/e2e/mcp-http.test.ts
+++ b/tests/e2e/mcp-http.test.ts
@@ -247,6 +247,70 @@ describe("modern MCP Streamable HTTP", () => {
     ]);
   }, 25_000);
 
+  test("GitMCP-like plain-text discovery error falls back to legacy initialize", async () => {
+    fixture = startModernMcpHttpFixture("legacy_plaintext_session_required");
+    const root = createRoot("gitmcp-legacy-fallback", fixture);
+
+    const result = await runFx(
+      ["mcp", "list", "--connect"],
+      {
+        cwd: root.workspace,
+        env: {
+          HOME: root.home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_TRACE_LOG: root.traceLogPath,
+          FX_TRACE_SCOPES: "mcp",
+        },
+        timeoutMs: 20_000,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toMatch(/fixture[\s\S]{0,240}state=ready/);
+    expect(result.stdout).toContain("protocol=2025-03-26");
+    expect(result.stdout).toContain(
+      "negotiated_name=gitmcp-fixture negotiated_version=1.0.0",
+    );
+    expect(result.stdout).toContain("tools=1");
+    expect(fixture.requests.map((entry) => entry.message.method)).toEqual([
+      "server/discover",
+      "initialize",
+      "notifications/initialized",
+      "tools/list",
+    ]);
+  }, 25_000);
+
+  test("plain-text discovery auth rejection fails closed without aborting fx", async () => {
+    fixture = startModernMcpHttpFixture("legacy_plaintext_auth_rejection");
+    const root = createRoot("plaintext-auth-rejection", fixture);
+
+    const result = await runFx(
+      ["mcp", "list", "--connect"],
+      {
+        cwd: root.workspace,
+        env: {
+          HOME: root.home,
+          AI_GATEWAY_API_KEY: undefined,
+          VERCEL_OIDC_TOKEN: undefined,
+          FX_AUTO_UPGRADE: "0",
+          FX_TRACE_LOG: root.traceLogPath,
+          FX_TRACE_SCOPES: "mcp",
+        },
+        timeoutMs: 20_000,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toMatch(/fixture[\s\S]{0,240}auth=required/);
+    expect(result.stdout).not.toContain("InvalidJsonResponse");
+    expect(fixture.requests.map((entry) => entry.message.method)).toEqual([
+      "server/discover",
+    ]);
+  }, 25_000);
+
   test("top-level mcp add persists HTTP and a later ask calls it", async () => {
     fixture = startModernMcpHttpFixture("json");
     const root = createEmptyRoot("top-level-add");

--- a/tests/e2e/mcp-stdio.test.ts
+++ b/tests/e2e/mcp-stdio.test.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -356,6 +357,108 @@ async function expectProcessesExited(pids: Iterable<number>, timeoutMs = 5_000) 
 }
 
 describe("modern MCP stdio compatibility", () => {
+  test("direct docker run servers are cleaned through the injected cidfile", async () => {
+    const root = createRoot("docker-cidfile-cleanup", MODERN_FIXTURE);
+    const fakeDocker = join(root.root, "docker");
+    const cleanupLog = join(root.root, "docker-cleanup.log");
+    const cidfileLog = join(root.root, "docker-cidfile.log");
+    const dockerLaunchLog = join(root.root, "docker-launches.txt");
+    writeFileSync(
+      fakeDocker,
+      `#!/bin/sh
+if [ "$1" = "rm" ]; then
+  printf '%s\\n' "$*" > "$FX_DOCKER_CLEANUP_LOG"
+  exit 0
+fi
+printf '%s\\n' "$$" >> "$FX_DOCKER_LAUNCH_LOG"
+test "$1" = "run" || exit 21
+shift
+test "$1" = "--cidfile" || exit 22
+cidfile=$2
+shift 2
+printf '%s\\n' '0123456789abcdef' > "$cidfile"
+printf '%s\\n' "$cidfile" >> "$FX_DOCKER_CIDFILE_LOG"
+exec "$FX_MCP_FIXTURE_RUNTIME" "$FX_MCP_FIXTURE_PATH"
+`,
+      { mode: 0o755 },
+    );
+    const profilePath = join(root.home, ".fx", "mcp.json");
+    const profile = JSON.parse(readFileSync(profilePath, "utf8"));
+    profile.mcp.fixture.command = [
+      fakeDocker,
+      "run",
+      "--rm",
+      "-i",
+      "fixture-image",
+    ];
+    profile.mcp.fixture.environment.FX_DOCKER_CLEANUP_LOG = cleanupLog;
+    profile.mcp.fixture.environment.FX_DOCKER_CIDFILE_LOG = cidfileLog;
+    profile.mcp.fixture.environment.FX_DOCKER_LAUNCH_LOG = dockerLaunchLog;
+    profile.mcp.fixture.environment.FX_MCP_FIXTURE_RUNTIME = process.execPath;
+    profile.mcp.fixture.environment.FX_MCP_FIXTURE_PATH = MODERN_FIXTURE;
+    writeFileSync(profilePath, JSON.stringify(profile));
+
+    const result = await runFx(["mcp", "list", "--connect"], {
+      cwd: root.workspace,
+      env: {
+        HOME: root.home,
+        TMPDIR: root.root,
+        AI_GATEWAY_API_KEY: undefined,
+        VERCEL_OIDC_TOKEN: undefined,
+        FX_AUTO_UPGRADE: "0",
+        FX_TRACE_LOG: root.traceLogPath,
+        FX_TRACE_SCOPES: "mcp",
+      },
+      timeoutMs: 20_000,
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toMatch(/fixture[\s\S]{0,240}state=ready/);
+    expect(readFileSync(cleanupLog, "utf8").trim()).toBe(
+      "rm -f 0123456789abcdef",
+    );
+    expect(readdirSync(root.root).some((name) =>
+      name.startsWith("fx-mcp-") && name.endsWith(".cid")
+    )).toBe(false);
+    expect(readFileSync(root.traceLogPath, "utf8")).toContain(
+      "docker MCP container cleanup complete",
+    );
+    await expectProcessesExited(readAttemptedPids(dockerLaunchLog));
+
+    rmSync(cleanupLog);
+    rmSync(cidfileLog);
+    profile.mcp.fixture.environment.FX_MCP_MODE = "stall_startup";
+    profile.mcp.fixture.startup_timeout_ms = 50;
+    profile.mcp.fixture.restart_limit = 0;
+    writeFileSync(profilePath, JSON.stringify(profile));
+    const timedOut = await runFx(["mcp", "list", "--connect"], {
+      cwd: root.workspace,
+      env: {
+        HOME: root.home,
+        TMPDIR: root.root,
+        AI_GATEWAY_API_KEY: undefined,
+        VERCEL_OIDC_TOKEN: undefined,
+        FX_AUTO_UPGRADE: "0",
+        FX_TRACE_LOG: root.traceLogPath,
+        FX_TRACE_SCOPES: "mcp",
+      },
+      timeoutMs: 20_000,
+    });
+    expect(timedOut.code).toBe(0);
+    expect(timedOut.stdout).toMatch(/fixture[\s\S]{0,240}state=failed/);
+    if (existsSync(cidfileLog)) {
+      expect(readFileSync(cleanupLog, "utf8").trim()).toBe(
+        "rm -f 0123456789abcdef",
+      );
+    } else {
+      expect(existsSync(cleanupLog)).toBe(false);
+    }
+    expect(readdirSync(root.root).some((name) =>
+      name.startsWith("fx-mcp-") && name.endsWith(".cid")
+    )).toBe(false);
+    await expectProcessesExited(readAttemptedPids(dockerLaunchLog));
+  }, 30_000);
+
   test.skipIf(!tmuxAvailable())(
     "the TUI shows exact dynamic MCP arguments before human approval",
     async () => {
@@ -1802,9 +1905,10 @@ describe("modern MCP stdio compatibility", () => {
     expect(initialize.map((entry) => entry.message.params?.protocolVersion)).toEqual([
       "2025-11-25",
       "2025-06-18",
+      "2025-03-26",
       "2024-11-05",
     ]);
-    expect(new Set(initialize.map((entry) => entry.pid)).size).toBe(3);
+    expect(new Set(initialize.map((entry) => entry.pid)).size).toBe(4);
     expect(wire.filter((entry) => entry.message.method === "tools/call"))
       .toHaveLength(1);
     await expectFixtureProcessesExited(wire);


### PR DESCRIPTION
## Summary

- Remove containers started by direct MCP `docker run` commands after shutdown and startup failure.
- Give MCP servers 30 seconds to finish cold startup unless configured otherwise.
- Negotiate legacy `2025-03-26` servers and fall back only for recognized session-required discovery responses.
- Treat recognized OAuth discovery rejections as authentication failures instead of malformed MCP JSON.
- Preserve text-only MCP tool errors without relaxing successful structured output validation.