### PR TITLE
Support a pinned OAuth callback port for MCP servers

### DIFF
--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -2236,6 +2236,8 @@ test "remote config keeps a pinned OAuth callback port" {
 
 test "profile config rejects out-of-range OAuth callback ports" {
     const cases = [_][]const u8{
+        \\{"mcp":{"api":{"type":"http","url":"https://api.example.com/mcp","oauth":{"callback_port":null}}}}
+        ,
         \\{"mcp":{"api":{"type":"http","url":"https://api.example.com/mcp","oauth":{"callback_port":0}}}}
         ,
         \\{"mcp":{"api":{"type":"http","url":"https://api.example.com/mcp","oauth":{"callback_port":65536}}}}

--- a/src/builtins/mcp.zig
+++ b/src/builtins/mcp.zig
@@ -1100,6 +1100,11 @@ fn renderConfigJson(alloc: Allocator, configs: []const McpServerConfig) ![]u8 {
                 }
                 try out.writer.writeByte(']');
             }
+            if (auth.callback_port) |port| {
+                if (!first_auth) try out.writer.writeByte(',');
+                first_auth = false;
+                try out.writer.print("\"callback_port\":{d}", .{port});
+            }
             try out.writer.writeByte('}');
         }
         if (config.env.len > 0) {
@@ -2212,6 +2217,38 @@ test "remote config keeps credential references and OAuth policy without secrets
     try std.testing.expectEqualStrings("fx-client", auth.client_id.?);
     try std.testing.expectEqualStrings("MCP_CLIENT_SECRET", auth.client_secret_env.?);
     try std.testing.expectEqual(@as(usize, 2), auth.scopes.len);
+    try std.testing.expectEqual(@as(?u16, null), auth.callback_port);
+}
+
+test "remote config keeps a pinned OAuth callback port" {
+    const alloc = std.testing.allocator;
+    const json =
+        \\{"mcp":{"slack":{"type":"http","url":"https://mcp.slack.com/mcp","oauth":{"client_id":"fx-client","callback_port":3118}}}}
+    ;
+    var configs = try loadConfigFromJson(alloc, json);
+    defer freeConfigs(alloc, &configs);
+
+    try std.testing.expectEqual(@as(usize, 1), configs.items.len);
+    const auth = configs.items[0].auth.?;
+    try std.testing.expectEqualStrings("fx-client", auth.client_id.?);
+    try std.testing.expectEqual(@as(?u16, 3118), auth.callback_port);
+}
+
+test "profile config rejects out-of-range OAuth callback ports" {
+    const cases = [_][]const u8{
+        \\{"mcp":{"api":{"type":"http","url":"https://api.example.com/mcp","oauth":{"callback_port":0}}}}
+        ,
+        \\{"mcp":{"api":{"type":"http","url":"https://api.example.com/mcp","oauth":{"callback_port":65536}}}}
+        ,
+        \\{"mcp":{"api":{"type":"http","url":"https://api.example.com/mcp","oauth":{"callback_port":"3118"}}}}
+        ,
+    };
+    for (cases) |json| {
+        try std.testing.expectError(
+            error.McpConfigInvalidOAuth,
+            loadConfigFromJson(std.testing.allocator, json),
+        );
+    }
 }
 
 test "profile config rejects a mixed set containing invalid client metadata URLs" {

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -1031,7 +1031,7 @@ pub fn authorizeInteractive(
     }
     const configured_port = options.config.callback_port;
     var address = try std.Io.net.IpAddress.parse("127.0.0.1", configured_port orelse 0);
-    var listener = address.listen(io_mod.getIo(), .{ .reuse_address = true }) catch |err| {
+    var listener = address.listen(io_mod.getIo(), .{ .reuse_address = configured_port == null }) catch |err| {
         if (configured_port != null) return error.McpCallbackPortUnavailable;
         return err;
     };
@@ -2490,6 +2490,31 @@ test "interactive callback redirect honors a pinned port" {
     defer alloc.free(ephemeral);
     try std.testing.expectEqualStrings("http://127.0.0.1:54321/callback", ephemeral);
     try std.testing.expect(isLoopbackEndpoint(ephemeral));
+}
+
+test "interactive callback rejects a pinned port already listening" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    }
+    var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var listener = try address.listen(std.testing.io, .{ .reuse_address = true });
+    defer listener.deinit(std.testing.io);
+    var cancelled = std.atomic.Value(bool).init(true);
+    const OpenUrl = struct {
+        fn run(_: ?*anyopaque, _: Allocator, _: []const u8) anyerror!bool {
+            return true;
+        }
+    };
+    try std.testing.expectError(
+        error.McpCallbackPortUnavailable,
+        authorizeInteractive(std.testing.allocator, .{
+            .endpoint = "http://127.0.0.1:8080",
+            .challenge = .{},
+            .config = .{ .callback_port = listener.socket.address.getPort() },
+            .open_url = OpenUrl.run,
+            .cancel_flag = &cancelled,
+        }),
+    );
 }
 
 test "interactive callback wait observes caller and lifecycle cancellation" {

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -62,6 +62,7 @@ pub const ClientConfig = struct {
     client_secret: ?[]const u8 = null,
     client_metadata_url: ?[]const u8 = null,
     scopes: []const []const u8 = &.{},
+    callback_port: ?u16 = null,
 };
 
 pub const Credentials = struct {
@@ -1014,6 +1015,13 @@ pub fn authorizeAutomated(
     );
 }
 
+fn callbackRedirectUri(alloc: Allocator, configured_port: ?u16, bound_port: u16) ![]u8 {
+    if (configured_port) |port| {
+        return std.fmt.allocPrint(alloc, "http://localhost:{d}/callback", .{port});
+    }
+    return std.fmt.allocPrint(alloc, "http://127.0.0.1:{d}/callback", .{bound_port});
+}
+
 pub fn authorizeInteractive(
     alloc: Allocator,
     options: InteractiveAuthorizationOptions,
@@ -1021,13 +1029,17 @@ pub fn authorizeInteractive(
     if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) {
         return error.InteractiveMcpAuthorizationUnsupported;
     }
-    var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
-    var listener = try address.listen(io_mod.getIo(), .{ .reuse_address = true });
+    const configured_port = options.config.callback_port;
+    var address = try std.Io.net.IpAddress.parse("127.0.0.1", configured_port orelse 0);
+    var listener = address.listen(io_mod.getIo(), .{ .reuse_address = true }) catch |err| {
+        if (configured_port != null) return error.McpCallbackPortUnavailable;
+        return err;
+    };
     defer listener.deinit(io_mod.getIo());
-    const redirect_uri = try std.fmt.allocPrint(
+    const redirect_uri = try callbackRedirectUri(
         alloc,
-        "http://127.0.0.1:{d}/callback",
-        .{listener.socket.address.getPort()},
+        configured_port,
+        listener.socket.address.getPort(),
     );
     defer alloc.free(redirect_uri);
     var context = InteractiveAuthorizationContext{
@@ -2463,6 +2475,21 @@ test "authorization redirect target must match the registered callback" {
             "http://localhost:3000/callback",
         ),
     );
+}
+
+test "interactive callback redirect honors a pinned port" {
+    const alloc = std.testing.allocator;
+
+    const pinned = try callbackRedirectUri(alloc, 3118, 54321);
+    defer alloc.free(pinned);
+    try std.testing.expectEqualStrings("http://localhost:3118/callback", pinned);
+    try std.testing.expect(isLoopbackEndpoint(pinned));
+    try validateRedirectTarget("http://localhost:3118/callback?code=one&state=two", pinned);
+
+    const ephemeral = try callbackRedirectUri(alloc, null, 54321);
+    defer alloc.free(ephemeral);
+    try std.testing.expectEqualStrings("http://127.0.0.1:54321/callback", ephemeral);
+    try std.testing.expect(isLoopbackEndpoint(ephemeral));
 }
 
 test "interactive callback wait observes caller and lifecycle cancellation" {

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -1408,6 +1408,7 @@ const InteractiveAuthorizationContext = struct {
 
 const interactive_callback_timeout_ms: i32 = 5 * 60 * 1000;
 const interactive_callback_poll_ms: i32 = 50;
+const interactive_callback_max_accepts: usize = 16;
 
 fn checkAuthorizationCancellation(
     cancellation: operation_control.CancellationSources,
@@ -1465,10 +1466,36 @@ fn requestInteractiveAuthorization(
     if (!try ctx.open_url(ctx.open_ctx, alloc, authorization_url)) {
         return error.McpAuthorizationBrowserOpenFailed;
     }
-    const listener = try waitForInteractiveCallback(ctx.listener, ctx.ipv6_listener, ctx.cancellation);
+    const max_accepts = if (ctx.ipv6_listener == null)
+        1
+    else
+        interactive_callback_max_accepts;
+    var accepts: usize = 0;
+    while (accepts < max_accepts) : (accepts += 1) {
+        const listener = try waitForInteractiveCallback(ctx.listener, ctx.ipv6_listener, ctx.cancellation);
+        var stream = listener.accept(io_mod.getIo()) catch |err| {
+            if (ctx.ipv6_listener != null and
+                (err == error.ConnectionAborted or err == error.WouldBlock))
+            {
+                continue;
+            }
+            return err;
+        };
+        const response = readInteractiveAuthorizationCallback(alloc, stream) catch |err| {
+            stream.close(io_mod.getIo());
+            if (ctx.ipv6_listener != null and err == error.ReadFailed) continue;
+            return err;
+        };
+        stream.close(io_mod.getIo());
+        return response;
+    }
+    return error.InvalidAuthorizationCallback;
+}
 
-    var stream = try listener.accept(io_mod.getIo());
-    defer stream.close(io_mod.getIo());
+fn readInteractiveAuthorizationCallback(
+    alloc: Allocator,
+    stream: std.Io.net.Stream,
+) !AuthorizationResponse {
     setSocketTimeouts(stream.socket.handle, callback_io_timeout_seconds);
     var socket_buffer: [4096]u8 = undefined;
     var reader = stream.reader(io_mod.getIo(), &socket_buffer);
@@ -2036,27 +2063,36 @@ fn validateJsonContentType(content_type: ?[]const u8) !void {
 fn setSocketTimeouts(socket: std.posix.socket_t, seconds: i64) void {
     if (comptime host_target.is_wasm) return;
     const timeout = std.posix.timeval{ .sec = seconds, .usec = 0 };
-    const bytes = std.mem.asBytes(&timeout);
-    std.posix.setsockopt(
+    const receive_rc = std.c.setsockopt(
         socket,
-        std.posix.SOL.SOCKET,
-        std.posix.SO.RCVTIMEO,
-        bytes,
-    ) catch |err| debug_trace.logf(
-        "mcp",
-        "OAuth receive timeout setup failed err={s}",
-        .{@errorName(err)},
+        std.c.SOL.SOCKET,
+        std.c.SO.RCVTIMEO,
+        &timeout,
+        @sizeOf(std.posix.timeval),
     );
-    std.posix.setsockopt(
+    if (receive_rc != 0) {
+        const err = std.posix.errno(receive_rc);
+        debug_trace.logf(
+            "mcp",
+            "OAuth receive timeout setup failed errno={s}",
+            .{@tagName(err)},
+        );
+    }
+    const send_rc = std.c.setsockopt(
         socket,
-        std.posix.SOL.SOCKET,
-        std.posix.SO.SNDTIMEO,
-        bytes,
-    ) catch |err| debug_trace.logf(
-        "mcp",
-        "OAuth send timeout setup failed err={s}",
-        .{@errorName(err)},
+        std.c.SOL.SOCKET,
+        std.c.SO.SNDTIMEO,
+        &timeout,
+        @sizeOf(std.posix.timeval),
     );
+    if (send_rc != 0) {
+        const err = std.posix.errno(send_rc);
+        debug_trace.logf(
+            "mcp",
+            "OAuth send timeout setup failed errno={s}",
+            .{@tagName(err)},
+        );
+    }
 }
 
 fn dupeRequiredSecret(

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -1036,6 +1036,14 @@ pub fn authorizeInteractive(
         return err;
     };
     defer listener.deinit(io_mod.getIo());
+    var ipv6_listener: ?std.Io.net.Server = null;
+    if (configured_port) |port| {
+        var ipv6_address = try std.Io.net.IpAddress.parse("::1", port);
+        ipv6_listener = ipv6_address.listen(io_mod.getIo(), .{}) catch {
+            return error.McpCallbackPortUnavailable;
+        };
+    }
+    defer if (ipv6_listener) |*value| value.deinit(io_mod.getIo());
     const redirect_uri = try callbackRedirectUri(
         alloc,
         configured_port,
@@ -1044,6 +1052,7 @@ pub fn authorizeInteractive(
     defer alloc.free(redirect_uri);
     var context = InteractiveAuthorizationContext{
         .listener = &listener,
+        .ipv6_listener = if (ipv6_listener) |*value| value else null,
         .open_ctx = options.open_ctx,
         .open_url = options.open_url,
         .cancellation = .{
@@ -1259,6 +1268,7 @@ fn requestAutomatedAuthorization(
 
 const InteractiveAuthorizationContext = struct {
     listener: *std.Io.net.Server,
+    ipv6_listener: ?*std.Io.net.Server,
     open_ctx: ?*anyopaque,
     open_url: OpenUrlFn,
     cancellation: operation_control.CancellationSources,
@@ -1275,25 +1285,37 @@ fn checkAuthorizationCancellation(
 
 fn waitForInteractiveCallback(
     listener: *std.Io.net.Server,
+    ipv6_listener: ?*std.Io.net.Server,
     cancellation: operation_control.CancellationSources,
-) !void {
-    var fds = [_]std.posix.pollfd{.{
+) !*std.Io.net.Server {
+    var fds = [_]std.posix.pollfd{ .{
         .fd = listener.socket.handle,
         .events = std.posix.POLL.IN,
         .revents = 0,
-    }};
+    }, undefined };
+    const listeners = [_]*std.Io.net.Server{ listener, ipv6_listener orelse listener };
+    const listener_count: usize = if (ipv6_listener == null) 1 else 2;
+    if (ipv6_listener) |value| {
+        fds[1] = .{
+            .fd = value.socket.handle,
+            .events = std.posix.POLL.IN,
+            .revents = 0,
+        };
+    }
     var remaining_ms = interactive_callback_timeout_ms;
     while (remaining_ms > 0) {
         try checkAuthorizationCancellation(cancellation);
-        fds[0].revents = 0;
+        for (fds[0..listener_count]) |*fd| fd.revents = 0;
         const wait_ms = @min(remaining_ms, interactive_callback_poll_ms);
-        const ready = try std.posix.poll(&fds, wait_ms);
+        const ready = try std.posix.poll(fds[0..listener_count], wait_ms);
         if (ready > 0) {
-            if ((fds[0].revents & std.posix.POLL.IN) == 0) {
-                return error.McpAuthorizationCallbackTimedOut;
+            for (fds[0..listener_count], listeners[0..listener_count]) |fd, ready_listener| {
+                if ((fd.revents & std.posix.POLL.IN) != 0) {
+                    try checkAuthorizationCancellation(cancellation);
+                    return ready_listener;
+                }
             }
-            try checkAuthorizationCancellation(cancellation);
-            return;
+            return error.McpAuthorizationCallbackTimedOut;
         }
         remaining_ms -= wait_ms;
     }
@@ -1311,9 +1333,9 @@ fn requestInteractiveAuthorization(
     if (!try ctx.open_url(ctx.open_ctx, alloc, authorization_url)) {
         return error.McpAuthorizationBrowserOpenFailed;
     }
-    try waitForInteractiveCallback(ctx.listener, ctx.cancellation);
+    const listener = try waitForInteractiveCallback(ctx.listener, ctx.ipv6_listener, ctx.cancellation);
 
-    var stream = try ctx.listener.accept(io_mod.getIo());
+    var stream = try listener.accept(io_mod.getIo());
     defer stream.close(io_mod.getIo());
     setSocketTimeouts(stream.socket.handle, callback_io_timeout_seconds);
     var socket_buffer: [4096]u8 = undefined;
@@ -2517,6 +2539,34 @@ test "interactive callback rejects a pinned port already listening" {
     );
 }
 
+test "interactive callback rejects a pinned IPv6 port already listening" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    }
+    var address = try std.Io.net.IpAddress.parse("::1", 0);
+    var listener = address.listen(std.testing.io, .{ .reuse_address = true }) catch |err| switch (err) {
+        error.AddressFamilyUnsupported, error.AddressUnavailable => return error.SkipZigTest,
+        else => return err,
+    };
+    defer listener.deinit(std.testing.io);
+    var cancelled = std.atomic.Value(bool).init(true);
+    const OpenUrl = struct {
+        fn run(_: ?*anyopaque, _: Allocator, _: []const u8) anyerror!bool {
+            return true;
+        }
+    };
+    try std.testing.expectError(
+        error.McpCallbackPortUnavailable,
+        authorizeInteractive(std.testing.allocator, .{
+            .endpoint = "http://127.0.0.1:8080",
+            .challenge = .{},
+            .config = .{ .callback_port = listener.socket.address.getPort() },
+            .open_url = OpenUrl.run,
+            .cancel_flag = &cancelled,
+        }),
+    );
+}
+
 test "interactive callback wait observes caller and lifecycle cancellation" {
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
         return error.SkipZigTest;
@@ -2541,7 +2591,7 @@ test "interactive callback wait observes caller and lifecycle cancellation" {
         const started_ms = io_mod.milliTimestamp();
         try std.testing.expectError(
             error.Cancelled,
-            waitForInteractiveCallback(&listener, .{
+            waitForInteractiveCallback(&listener, null, .{
                 .caller = &caller,
                 .runtime = &runtime,
             }),

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -1022,6 +1022,137 @@ fn callbackRedirectUri(alloc: Allocator, configured_port: ?u16, bound_port: u16)
     return std.fmt.allocPrint(alloc, "http://127.0.0.1:{d}/callback", .{bound_port});
 }
 
+const CallbackSocketCreation = struct {
+    flags: u32,
+    needs_cloexec_fallback: bool,
+};
+
+fn callbackSocketCreation(comptime os_tag: std.Target.Os.Tag) CallbackSocketCreation {
+    const needs_fallback = os_tag.isDarwin() or os_tag == .haiku;
+    return .{
+        .flags = std.posix.SOCK.STREAM |
+            if (needs_fallback) 0 else std.posix.SOCK.CLOEXEC,
+        .needs_cloexec_fallback = needs_fallback,
+    };
+}
+
+fn listenPinnedCallback(address: std.Io.net.IpAddress) std.Io.net.IpAddress.ListenError!std.Io.net.Server {
+    const posix = std.posix;
+    const SocketAddress = extern union {
+        any: posix.sockaddr,
+        ip4: posix.sockaddr.in,
+        ip6: posix.sockaddr.in6,
+    };
+    const AddressDetails = struct {
+        family: posix.sa_family_t,
+        len: posix.socklen_t,
+    };
+
+    var socket_address: SocketAddress = undefined;
+    const details: AddressDetails = switch (address) {
+        .ip4 => |value| values: {
+            socket_address.ip4 = .{
+                .port = std.mem.nativeToBig(u16, value.port),
+                .addr = @bitCast(value.bytes),
+            };
+            break :values .{ .family = posix.AF.INET, .len = @sizeOf(posix.sockaddr.in) };
+        },
+        .ip6 => |value| values: {
+            socket_address.ip6 = .{
+                .port = std.mem.nativeToBig(u16, value.port),
+                .flowinfo = value.flow,
+                .addr = value.bytes,
+                .scope_id = value.interface.index,
+            };
+            break :values .{ .family = posix.AF.INET6, .len = @sizeOf(posix.sockaddr.in6) };
+        },
+    };
+    const socket_creation = comptime callbackSocketCreation(builtin.os.tag);
+
+    const socket_fd = while (true) {
+        const rc = posix.system.socket(details.family, socket_creation.flags, 0);
+        switch (posix.errno(rc)) {
+            .SUCCESS => break @as(posix.socket_t, @intCast(rc)),
+            .INTR => continue,
+            .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+            .INVAL => return error.ProtocolUnsupportedBySystem,
+            .MFILE => return error.ProcessFdQuotaExceeded,
+            .NFILE => return error.SystemFdQuotaExceeded,
+            .NOBUFS, .NOMEM => return error.SystemResources,
+            .PROTONOSUPPORT => return error.ProtocolUnsupportedByAddressFamily,
+            .PROTOTYPE => return error.SocketModeUnsupported,
+            else => |err| return posix.unexpectedErrno(err),
+        }
+    };
+    const socket: std.Io.net.Socket = .{ .handle = socket_fd, .address = address };
+    errdefer socket.close(io_mod.getIo());
+
+    if (comptime socket_creation.needs_cloexec_fallback) {
+        while (true) switch (posix.errno(posix.system.fcntl(
+            socket_fd,
+            posix.F.SETFD,
+            @as(usize, posix.FD_CLOEXEC),
+        ))) {
+            .SUCCESS => break,
+            .INTR => continue,
+            else => |err| return posix.unexpectedErrno(err),
+        };
+    }
+
+    // Zig's reuse_address also enables SO_REUSEPORT on POSIX. Pinned OAuth
+    // callbacks need TIME_WAIT reuse without allowing concurrent listeners.
+    const reuse_address: u32 = 1;
+    const reuse_bytes = std.mem.asBytes(&reuse_address);
+    while (true) switch (posix.errno(posix.system.setsockopt(
+        socket_fd,
+        posix.SOL.SOCKET,
+        posix.SO.REUSEADDR,
+        reuse_bytes.ptr,
+        @intCast(reuse_bytes.len),
+    ))) {
+        .SUCCESS => break,
+        .INTR => continue,
+        .NOPROTOOPT => return error.OptionUnsupported,
+        else => |err| return posix.unexpectedErrno(err),
+    };
+
+    while (true) switch (posix.errno(posix.system.bind(
+        socket_fd,
+        &socket_address.any,
+        details.len,
+    ))) {
+        .SUCCESS => break,
+        .INTR => continue,
+        .ADDRINUSE => return error.AddressInUse,
+        .ADDRNOTAVAIL => return error.AddressUnavailable,
+        .AFNOSUPPORT => return error.AddressFamilyUnsupported,
+        .NOBUFS, .NOMEM => return error.SystemResources,
+        else => |err| return posix.unexpectedErrno(err),
+    };
+
+    while (true) switch (posix.errno(posix.system.listen(
+        socket_fd,
+        std.Io.net.default_kernel_backlog,
+    ))) {
+        .SUCCESS => break,
+        .INTR => continue,
+        .ADDRINUSE => return error.AddressInUse,
+        else => |err| return posix.unexpectedErrno(err),
+    };
+
+    return .{
+        .socket = socket,
+        .options = if (std.Io.net.Server.AcceptOptions != void) .{
+            .mode = .stream,
+            .protocol = .tcp,
+        },
+    };
+}
+
+fn isUnavailableIpv6CallbackError(err: std.Io.net.IpAddress.ListenError) bool {
+    return err == error.AddressFamilyUnsupported or err == error.AddressUnavailable;
+}
+
 pub fn authorizeInteractive(
     alloc: Allocator,
     options: InteractiveAuthorizationOptions,
@@ -1031,15 +1162,16 @@ pub fn authorizeInteractive(
     }
     const configured_port = options.config.callback_port;
     var address = try std.Io.net.IpAddress.parse("127.0.0.1", configured_port orelse 0);
-    var listener = address.listen(io_mod.getIo(), .{ .reuse_address = configured_port == null }) catch |err| {
-        if (configured_port != null) return error.McpCallbackPortUnavailable;
-        return err;
-    };
+    var listener = if (configured_port != null)
+        listenPinnedCallback(address) catch return error.McpCallbackPortUnavailable
+    else
+        try address.listen(io_mod.getIo(), .{ .reuse_address = true });
     defer listener.deinit(io_mod.getIo());
     var ipv6_listener: ?std.Io.net.Server = null;
     if (configured_port) |port| {
-        var ipv6_address = try std.Io.net.IpAddress.parse("::1", port);
-        ipv6_listener = ipv6_address.listen(io_mod.getIo(), .{}) catch {
+        const ipv6_address = try std.Io.net.IpAddress.parse("::1", port);
+        ipv6_listener = listenPinnedCallback(ipv6_address) catch |err| fallback: {
+            if (isUnavailableIpv6CallbackError(err)) break :fallback null;
             return error.McpCallbackPortUnavailable;
         };
     }
@@ -2565,6 +2697,70 @@ test "interactive callback rejects a pinned IPv6 port already listening" {
             .cancel_flag = &cancelled,
         }),
     );
+}
+
+test "interactive callback immediately reuses a completed pinned port" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return error.SkipZigTest;
+    }
+    var address = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var listener = try address.listen(std.testing.io, .{ .reuse_address = true });
+    var listener_open = true;
+    defer if (listener_open) listener.deinit(std.testing.io);
+    const port = listener.socket.address.getPort();
+
+    address.setPort(port);
+    var client = try address.connect(std.testing.io, .{ .mode = .stream });
+    var client_open = true;
+    defer if (client_open) client.close(std.testing.io);
+    var accepted = try listener.accept(std.testing.io);
+    var accepted_open = true;
+    defer if (accepted_open) accepted.close(std.testing.io);
+    accepted.close(std.testing.io);
+    accepted_open = false;
+    var socket_buffer: [1]u8 = undefined;
+    var reader = client.reader(std.testing.io, &socket_buffer);
+    try std.testing.expectError(error.EndOfStream, reader.interface.takeByte());
+    client.close(std.testing.io);
+    client_open = false;
+    listener.deinit(std.testing.io);
+    listener_open = false;
+
+    var cancelled = std.atomic.Value(bool).init(true);
+    const OpenUrl = struct {
+        fn run(_: ?*anyopaque, _: Allocator, _: []const u8) anyerror!bool {
+            return true;
+        }
+    };
+    try std.testing.expectError(
+        error.Cancelled,
+        authorizeInteractive(std.testing.allocator, .{
+            .endpoint = "http://127.0.0.1:8080",
+            .challenge = .{},
+            .config = .{ .callback_port = port },
+            .open_url = OpenUrl.run,
+            .cancel_flag = &cancelled,
+        }),
+    );
+}
+
+test "interactive callback treats unavailable IPv6 as optional" {
+    try std.testing.expect(isUnavailableIpv6CallbackError(error.AddressFamilyUnsupported));
+    try std.testing.expect(isUnavailableIpv6CallbackError(error.AddressUnavailable));
+    try std.testing.expect(!isUnavailableIpv6CallbackError(error.AddressInUse));
+    try std.testing.expect(!isUnavailableIpv6CallbackError(error.SystemResources));
+}
+
+test "pinned callback sockets create close-on-exec atomically where supported" {
+    const linux = callbackSocketCreation(.linux);
+    try std.testing.expect((linux.flags & std.posix.SOCK.CLOEXEC) != 0);
+    try std.testing.expect(!linux.needs_cloexec_fallback);
+
+    inline for (.{ .macos, .haiku }) |os_tag| {
+        const fallback = callbackSocketCreation(os_tag);
+        try std.testing.expectEqual(std.posix.SOCK.STREAM, fallback.flags);
+        try std.testing.expect(fallback.needs_cloexec_fallback);
+    }
 }
 
 test "interactive callback wait observes caller and lifecycle cancellation" {

--- a/src/core/mcp/mcp_contract.zig
+++ b/src/core/mcp/mcp_contract.zig
@@ -75,6 +75,7 @@ pub const McpAuthConfig = struct {
     client_secret_env: ?[]u8 = null,
     client_metadata_url: ?[]u8 = null,
     scopes: [][]u8 = &.{},
+    callback_port: ?u16 = null,
 
     pub fn deinit(self: *McpAuthConfig, alloc: Allocator) void {
         if (self.resource) |value| alloc.free(value);

--- a/src/core/mcp/mcp_runtime.zig
+++ b/src/core/mcp/mcp_runtime.zig
@@ -5510,6 +5510,7 @@ pub const McpRuntime = struct {
                 .client_secret = client_secret,
                 .client_metadata_url = auth_config.client_metadata_url,
                 .scopes = auth_config.scopes,
+                .callback_port = auth_config.callback_port,
             },
             .previous_scope = source.previous_scope,
             .open_ctx = open_ctx,

--- a/src/core/mcp/project_config.zig
+++ b/src/core/mcp/project_config.zig
@@ -1061,6 +1061,7 @@ fn parseProfileAuth(alloc: Allocator, object: std.json.ObjectMap) !?McpAuthConfi
     auth.client_secret_env = try parseOptionalOwnedString(alloc, auth_object, "client_secret_env");
     auth.client_metadata_url = try parseOptionalOwnedString(alloc, auth_object, "client_metadata_url");
     if (auth_object.get("scopes")) |field| auth.scopes = try parseStringArray(alloc, field);
+    auth.callback_port = try parseOptionalPort(auth_object, "callback_port");
     if (auth.client_secret_env) |field| {
         if (!isValidEnvName(field) or auth.client_id == null) return error.McpConfigInvalidOAuth;
     }
@@ -1070,6 +1071,14 @@ fn parseProfileAuth(alloc: Allocator, object: std.json.ObjectMap) !?McpAuthConfi
     }
     if (auth.client_metadata_url) |field| mcp_auth.validateClientMetadataUrl(field) catch return error.McpConfigInvalidOAuth;
     return auth;
+}
+
+fn parseOptionalPort(object: std.json.ObjectMap, key: []const u8) !?u16 {
+    const value = object.get(key) orelse return null;
+    if (value == .null) return null;
+    if (value != .integer) return error.McpConfigInvalidOAuth;
+    if (value.integer < 1 or value.integer > 65535) return error.McpConfigInvalidOAuth;
+    return @intCast(value.integer);
 }
 
 fn parseOptionalOwnedString(alloc: Allocator, object: std.json.ObjectMap, key: []const u8) !?[]u8 {

--- a/src/core/mcp/project_config.zig
+++ b/src/core/mcp/project_config.zig
@@ -1075,7 +1075,6 @@ fn parseProfileAuth(alloc: Allocator, object: std.json.ObjectMap) !?McpAuthConfi
 
 fn parseOptionalPort(object: std.json.ObjectMap, key: []const u8) !?u16 {
     const value = object.get(key) orelse return null;
-    if (value == .null) return null;
     if (value != .integer) return error.McpConfigInvalidOAuth;
     if (value.integer < 1 or value.integer > 65535) return error.McpConfigInvalidOAuth;
     return @intCast(value.integer);

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -147,6 +147,17 @@ async function waitForFileText(
   return existsSync(path) && readFileSync(path, "utf8").includes(expected);
 }
 
+function unusedCallbackPort(): number {
+  const listener = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response("reserved"),
+  });
+  const port = listener.port;
+  listener.stop(true);
+  return port;
+}
+
 afterEach(async () => {
   const activeTui = tui;
   const activeGateway = gateway;
@@ -890,6 +901,79 @@ describe("MCP remote authentication lifecycle", () => {
     expect(existsSync(credentialPath)).toBe(false);
     expect(auth.revocations).toBe(2);
   }, 30_000);
+
+  test("pinned localhost callback reuses one port without aborting", async () => {
+    upstream = startModernMcpHttpFixture("json");
+    auth = startAuthFixture(upstream.url);
+    const root = createRoot(auth, true, "http", auth.url, false);
+    const callbackPort = unusedCallbackPort();
+    const profilePath = join(root.home, ".fx", "mcp.json");
+    const profile = JSON.parse(readFileSync(profilePath, "utf8"));
+    profile.mcp.fixture.oauth.callback_port = callbackPort;
+    writeFileSync(profilePath, JSON.stringify(profile));
+    const env = {
+      ...baseEnv(root),
+      AI_GATEWAY_API_KEY: undefined,
+    };
+
+    const attempts = 12;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      rmSync(root.openLog, { force: true });
+      const authentication = runFx(["mcp", "auth", "fixture"], {
+        cwd: root.workspace,
+        env,
+        timeoutMs: 20_000,
+      });
+      const opened = await waitForFileText(root.openLog, "http", 5_000);
+      let callbackStatus: number | null = null;
+      let callbackBody = "";
+      let callbackError: unknown = null;
+      if (opened) {
+        try {
+          const authorizationUrl = readFileSync(root.openLog, "utf8").trim();
+          const authorizationResponse = await fetch(authorizationUrl, {
+            redirect: "manual",
+          });
+          const callbackUrl = authorizationResponse.headers.get("location");
+          if (!callbackUrl) throw new Error("authorization redirect is missing");
+          const callbackResponse = await fetch(callbackUrl);
+          callbackStatus = callbackResponse.status;
+          callbackBody = await callbackResponse.text();
+        } catch (error) {
+          callbackError = error;
+        }
+      }
+      const authenticated = await authentication;
+      if (
+        !opened ||
+        callbackError !== null ||
+        callbackStatus !== 200 ||
+        authenticated.code !== 0 ||
+        authenticated.stderr !== ""
+      ) {
+        throw new Error(JSON.stringify({
+          attempt,
+          callbackPort,
+          opened,
+          callbackStatus,
+          callbackError: callbackError === null ? null : String(callbackError),
+          authenticated,
+        }, null, 2));
+      }
+      expect(callbackBody).toContain("Authorization complete");
+      expect(authenticated.stdout).toContain("Authenticated MCP server 'fixture'");
+
+      const loggedOut = await runFx(["mcp", "logout", "fixture"], {
+        cwd: root.workspace,
+        env,
+        timeoutMs: 20_000,
+      });
+      expect(loggedOut.code).toBe(0);
+      expect(loggedOut.stderr).toBe("");
+    }
+    expect(auth.authorizationRequests).toBe(attempts);
+    expect(auth.tokenExchanges).toBe(attempts);
+  }, 90_000);
 
   test("rejected stored credentials report required auth without discovery fallback", async () => {
     upstream = startModernMcpHttpFixture("json");


### PR DESCRIPTION
## Summary

- add an optional `oauth.callback_port` to MCP server config
- bind the interactive authorization callback to that port instead of an ephemeral one
- advertise `http://localhost:<port>/callback` when a port is pinned, matching the host form providers register

## Problem

`authorizeInteractive` binds the loopback callback listener to port `0`, so the OS assigns a different port on every attempt and the advertised `redirect_uri` changes each run:

```
redirect_uri=http://127.0.0.1:53230/callback   run 1
redirect_uri=http://127.0.0.1:53268/callback   run 2
```

Providers that require a pre-registered redirect URI can never be authorized, because no registration can match a port that changes per run. Slack's hosted MCP server (`https://mcp.slack.com/mcp`) is the case that surfaced this: it does not support Dynamic Client Registration, so the client must supply a `client_id` whose redirect URI is already registered.

There is a second, quieter mismatch. Registered loopback redirects are conventionally written as `localhost`, and providers compare redirect URIs as exact strings, so emitting `127.0.0.1` fails to match even when the port is correct.

Setting `oauth.client_id` alone already clears `ClientRegistrationUnavailable`, so today the flow gets past discovery and then fails at the provider's redirect validation with no way to proceed.

## Reproduction

```json
{
  "mcp": {
    "slack": {
      "type": "http",
      "url": "https://mcp.slack.com/mcp",
      "enabled": true,
      "oauth": { "client_id": "<a registered Slack app client id>" }
    }
  }
}
```

`fx mcp auth slack` opens an authorize URL whose `redirect_uri` is a fresh ephemeral port, which the provider rejects.

## Fix

```json
"oauth": {
  "client_id": "<client id>",
  "callback_port": 3118
}
```

When `callback_port` is set the listener binds it and the redirect becomes `http://localhost:3118/callback`. When it is absent, behavior is byte-for-byte unchanged: ephemeral port, `127.0.0.1` host. Binding still happens on `127.0.0.1`; only the advertised string changes. `isLoopbackHost` already accepts `localhost`, `127.0.0.1`, and `[::1]`, so nothing downstream shifts.

A pinned port that is already in use now fails as `McpCallbackPortUnavailable` rather than a bare listen error, since that is a routine and recoverable user situation.

Ports are validated at config parse time and must be 1-65535.

This mirrors prior art: opencode exposes `callbackPort` and `redirectUri`, and Claude Code pins `3118`.

## Verification

- `zig build` clean, `zig fmt src/` clean
- `zig build test`: 8747/8755 pass, +3 from this change. The 6 failures are pre-existing and environmental on this machine (iTerm2 shell-integration escapes leaking into captured command output in `command_runner` / `tool_runtime` / `builtins.context`); the identical 6 fail on an unmodified checkout, and none touch the files in this diff.
- exercised end to end with `./zig-out/bin/fx mcp auth slack` against an isolated profile:

with `callback_port: 3118`
```
redirect_uri=http://localhost:3118/callback
```

with the key removed
```
redirect_uri=http://127.0.0.1:59235/callback
```

The pinned run produced a complete authorize URL carrying the configured `client_id`, PKCE `S256`, the `resource` parameter, and all scopes advertised by the server's protected-resource metadata.