### PR TITLE
Add collapsible tool call setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands.
 
+Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O.
+
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 
 ```json

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -292,6 +292,7 @@ pub fn Runtime(comptime App: type) type {
             app.context_enabled = startup.context_enabled;
             app.fast_mode = startup.fast_mode;
             app.input_runtime.slash_menu_categories = startup.slash_menu_categories;
+            app.shell.collapse_tool_calls = startup.collapse_tool_calls;
             app.auto_upgrade_enabled = startup.auto_upgrade;
             app.upgrader.configure_channel(startup.update_channel);
             app.effort = startup.effort;

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -3434,6 +3434,9 @@ pub fn settingsCatalogSnapshot(app: anytype) settings_catalog.Snapshot {
             snapshot.slash_menu_categories = app.input_runtime.slash_menu_categories;
         }
     }
+    if (comptime @hasField(App, "shell") and @hasField(@TypeOf(app.shell), "collapse_tool_calls")) {
+        snapshot.collapse_tool_calls = app.shell.collapse_tool_calls;
+    }
     if (comptime @hasField(App, "statusline_context")) snapshot.statusline_context = app.statusline_context;
     if (comptime @hasField(App, "statusline_session")) snapshot.statusline_session = app.statusline_session;
     if (comptime @hasField(App, "workspace_identity")) snapshot.statusline_workspace = app.workspace_identity.enabled;
@@ -3494,6 +3497,21 @@ pub fn applySettingsCatalogChange(app: anytype, change: settings_catalog.Change)
             if (enabled != statuslineItemEnabled(app, item)) {
                 try applyStatuslineItem(app, item, enabled, .announce);
             }
+        },
+        .collapse_tool_calls => {
+            const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;
+            const runtime_changed = enabled != app.shell.collapse_tool_calls;
+            if (runtime_changed) {
+                app.shell.collapse_tool_calls = enabled;
+                app.shell.markTranscriptStructureDirty();
+                app.shell.render_requests.request(.transcript);
+            }
+            try persistUserPreferences(
+                app,
+                "collapse tool calls",
+                .{ .collapse_tool_calls = enabled },
+                runtime_changed,
+            );
         },
         .slash_menu_categories => {
             const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -133,6 +133,7 @@ pub const StartupState = struct {
     fast_mode: bool = false,
     fast_mode_source: config_runtime.ConfigSource = .compiled_default,
     slash_menu_categories: bool = true,
+    collapse_tool_calls: bool = false,
     auto_upgrade: bool = true,
     update_channel: update_target.Channel = .stable,
     startup_scrollback: bool = true,
@@ -426,6 +427,7 @@ fn loadStartupStateFromOwnedWorkspace(
         (state.provider == .gateway and state.model_source == .compiled_default);
     state.fast_mode_source = detailed.sources.fast_mode;
     state.slash_menu_categories = settings.slash_menu_categories orelse true;
+    state.collapse_tool_calls = settings.collapse_tool_calls orelse false;
     state.auto_upgrade = settings.auto_upgrade orelse true;
     state.update_channel = settings.update_channel orelse .stable;
     state.startup_scrollback = settings.startup_scrollback orelse true;

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -49,6 +49,7 @@ pub const Settings = struct {
     context: ?bool = null,
     fast_mode: ?bool = null,
     slash_menu_categories: ?bool = null,
+    collapse_tool_calls: ?bool = null,
     auto_upgrade: ?bool = null,
     update_channel: ?update_target.Channel = null,
     startup_scrollback: ?bool = null,
@@ -115,6 +116,7 @@ pub const ConfigSources = struct {
     effort: ConfigSource = .compiled_default,
     fast_mode: ConfigSource = .compiled_default,
     slash_menu_categories: ConfigSource = .compiled_default,
+    collapse_tool_calls: ConfigSource = .compiled_default,
     startup_scrollback: ConfigSource = .compiled_default,
     prompt_history_enabled: ConfigSource = .compiled_default,
     statusline_context: ConfigSource = .compiled_default,
@@ -573,6 +575,7 @@ fn hasLegacyWorkspacePreferences(root: std.json.Value) bool {
             "effort",
             "fast_mode",
             "slash_menu_categories",
+            "collapse_tool_calls",
             "startup_scrollback",
         }) |key| {
             if (workspace.contains(key)) return true;
@@ -602,6 +605,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "effort",
         "fast_mode",
         "slash_menu_categories",
+        "collapse_tool_calls",
         "startup_scrollback",
         "prompt_history",
         "statusLine",
@@ -648,6 +652,7 @@ fn updateConfigSources(sources: *ConfigSources, settings: Settings, source: Conf
     if (settings.effort != null) sources.effort = source;
     if (settings.fast_mode != null) sources.fast_mode = source;
     if (settings.slash_menu_categories != null) sources.slash_menu_categories = source;
+    if (settings.collapse_tool_calls != null) sources.collapse_tool_calls = source;
     if (settings.startup_scrollback != null) sources.startup_scrollback = source;
     if (settings.prompt_history_enabled != null) sources.prompt_history_enabled = source;
     if (settings.statusline_context != null) sources.statusline_context = source;
@@ -1419,6 +1424,12 @@ fn parseProfileOnlyFields(
         settings.slash_menu_categories = value.bool;
     }
 
+    if (root.object.get("collapse_tool_calls")) |collapse_tool_calls_value| {
+        const value = collapse_tool_calls_value;
+        if (value != .bool) return error.InvalidCollapseToolCallsType;
+        settings.collapse_tool_calls = value.bool;
+    }
+
     if (root.object.get("auto_upgrade")) |auto_upgrade_value| {
         const value = auto_upgrade_value;
         if (value != .bool) return error.InvalidAutoUpgradeType;
@@ -1536,6 +1547,7 @@ fn mergeSettings(target: *Settings, incoming: *Settings, alloc: Allocator) void 
     if (incoming.context) |value| target.context = value;
     if (incoming.fast_mode) |value| target.fast_mode = value;
     if (incoming.slash_menu_categories) |value| target.slash_menu_categories = value;
+    if (incoming.collapse_tool_calls) |value| target.collapse_tool_calls = value;
     if (incoming.auto_upgrade) |value| target.auto_upgrade = value;
     if (incoming.update_channel) |value| target.update_channel = value;
     if (incoming.startup_scrollback) |value| target.startup_scrollback = value;
@@ -2150,6 +2162,26 @@ test "startup_scrollback parses merges rejects invalid type and round trips" {
     const json = try serializeJsonObject(std.testing.allocator, parsed.value);
     defer std.testing.allocator.free(json);
     try std.testing.expect(std.mem.find(u8, json, "\"startup_scrollback\":false") != null);
+}
+
+test "collapse tool calls parses merges and rejects invalid types" {
+    var absent = try parseSettingsJson(std.testing.allocator, "{}");
+    defer absent.deinit(std.testing.allocator);
+    try std.testing.expect(absent.collapse_tool_calls == null);
+
+    var first = try parseSettingsJson(std.testing.allocator, "{\"collapse_tool_calls\":true}");
+    defer first.deinit(std.testing.allocator);
+    try std.testing.expect(first.collapse_tool_calls.?);
+
+    var second = try parseSettingsJson(std.testing.allocator, "{\"collapse_tool_calls\":false}");
+    defer second.deinit(std.testing.allocator);
+    mergeSettings(&first, &second, std.testing.allocator);
+    try std.testing.expect(!first.collapse_tool_calls.?);
+
+    try std.testing.expectError(
+        error.InvalidCollapseToolCallsType,
+        parseSettingsJson(std.testing.allocator, "{\"collapse_tool_calls\":\"off\"}"),
+    );
 }
 
 test "slash menu categories parses merges and rejects invalid types" {

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -27,6 +27,7 @@ pub const SettingId = enum {
     statusline_session,
     statusline_workspace,
     slash_menu_categories,
+    collapse_tool_calls,
     model,
     effort,
     fast_mode,
@@ -54,6 +55,7 @@ pub const Snapshot = struct {
     statusline_session: bool = false,
     statusline_workspace: bool = false,
     slash_menu_categories: bool = true,
+    collapse_tool_calls: bool = false,
     startup_scrollback: bool = true,
     prompt_history: bool = true,
     sound_level: []const u8 = "on",
@@ -68,6 +70,7 @@ pub const Snapshot = struct {
             .statusline_session => onOff(self.statusline_session),
             .statusline_workspace => onOff(self.statusline_workspace),
             .slash_menu_categories => onOff(self.slash_menu_categories),
+            .collapse_tool_calls => onOff(self.collapse_tool_calls),
             .startup_scrollback => onOff(self.startup_scrollback),
             .prompt_history => onOff(self.prompt_history),
             .sound_level => self.sound_level,
@@ -253,6 +256,7 @@ const specs = [_]Spec{
     .{ .id = .statusline_session, .category = .interface, .label = "Status line session", .description = "Show the session title in the status line" },
     .{ .id = .statusline_workspace, .category = .interface, .label = "Status line workspace", .description = "Show the workspace path and Git branch in the status line" },
     .{ .id = .slash_menu_categories, .category = .interface, .label = "Slash menu categories", .description = "Show categories and skill sources in slash-command results" },
+    .{ .id = .collapse_tool_calls, .category = .interface, .label = "Collapse tool calls", .description = "Show only a summary for each group of tool calls" },
     .{ .id = .model, .category = .agent, .label = "Model", .description = "Choose the model used for new turns" },
     .{ .id = .effort, .category = .agent, .label = "Reasoning effort", .description = "Control how much reasoning the model applies" },
     .{ .id = .fast_mode, .category = .agent, .label = "Fast mode", .description = "Use faster inference when the model supports it" },
@@ -367,6 +371,7 @@ fn staticOptionsFor(id: SettingId) []const []const u8 {
         .statusline_session,
         .statusline_workspace,
         .slash_menu_categories,
+        .collapse_tool_calls,
         .startup_scrollback,
         .prompt_history,
         => &on_off_options,
@@ -425,8 +430,8 @@ test "settings catalog projects grouped searchable preferences" {
         .sound_level = "on",
     };
 
-    try std.testing.expectEqual(@as(usize, 11), filteredCount(snapshot, .all, ""));
-    try std.testing.expectEqual(@as(usize, 4), filteredCount(snapshot, .interface, ""));
+    try std.testing.expectEqual(@as(usize, 12), filteredCount(snapshot, .all, ""));
+    try std.testing.expectEqual(@as(usize, 5), filteredCount(snapshot, .interface, ""));
     try std.testing.expectEqual(@as(usize, 4), filteredCount(snapshot, .agent, ""));
     try std.testing.expectEqual(@as(usize, 1), filteredCount(snapshot, .notifications, ""));
     try std.testing.expectEqual(@as(usize, 2), filteredCount(snapshot, .advanced, ""));
@@ -467,6 +472,18 @@ test "settings catalog returns typed edit choices without effects" {
     try std.testing.expectEqualStrings("future-tier", optionAt(&snapshot, .effort, 1).?);
     try std.testing.expectEqualStrings("high", optionAt(&snapshot, .effort, 2).?);
     try std.testing.expectEqual(@as(usize, 1), selectedOptionIndex(&snapshot, .effort).?);
+}
+
+test "settings catalog exposes collapse tool calls as an interface toggle" {
+    const expanded: Snapshot = .{ .collapse_tool_calls = false };
+    const item = itemAt(expanded, .interface, "collapse tool calls", 0).?;
+
+    try std.testing.expectEqual(SettingId.collapse_tool_calls, item.id);
+    try std.testing.expectEqualStrings("Collapse tool calls", item.label);
+    try std.testing.expectEqualStrings("off", item.value);
+    const collapse = changeAt(&expanded, .collapse_tool_calls, 1).?;
+    try std.testing.expectEqual(SettingId.collapse_tool_calls, collapse.setting);
+    try std.testing.expectEqualStrings("on", collapse.value);
 }
 
 test "settings catalog exposes slash menu categories as an interface toggle" {

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -102,6 +102,7 @@ pub const UserSettingsPatch = struct {
     effort: ?types.ReasoningEffort = null,
     fast_mode: ?bool = null,
     slash_menu_categories: ?bool = null,
+    collapse_tool_calls: ?bool = null,
     update_channel: ?update_target.Channel = null,
     startup_scrollback: ?bool = null,
     prompt_history_enabled: ?bool = null,
@@ -120,6 +121,7 @@ pub const UserSettingsPatch = struct {
             self.effort == null and
             self.fast_mode == null and
             self.slash_menu_categories == null and
+            self.collapse_tool_calls == null and
             self.update_channel == null and
             self.startup_scrollback == null and
             self.prompt_history_enabled == null and
@@ -212,6 +214,7 @@ const UserPreferenceField = enum(u4) {
     effort,
     fast_mode,
     slash_menu_categories,
+    collapse_tool_calls,
     update_channel,
     startup_scrollback,
     prompt_history_enabled,
@@ -229,6 +232,7 @@ const UserPreferenceField = enum(u4) {
             .effort => "settings.json.preference-migration.effort.json",
             .fast_mode => "settings.json.preference-migration.fast_mode.json",
             .slash_menu_categories => "settings.json.preference-migration.slash_menu_categories.json",
+            .collapse_tool_calls => "settings.json.preference-migration.collapse_tool_calls.json",
             .update_channel => "settings.json.preference-migration.update_channel.json",
             .startup_scrollback => "settings.json.preference-migration.startup_scrollback.json",
             .prompt_history_enabled => "settings.json.preference-migration.prompt_history_enabled.json",
@@ -244,6 +248,7 @@ const user_preference_fields = [_]UserPreferenceField{
     .effort,
     .fast_mode,
     .slash_menu_categories,
+    .collapse_tool_calls,
     .update_channel,
     .startup_scrollback,
     .prompt_history_enabled,
@@ -915,6 +920,19 @@ test "clearing the credential choice removes the key rather than blanking it" {
     try std.testing.expect(!application.changed);
 }
 
+test "collapse tool calls user patch writes the profile preference" {
+    const alloc = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    var parsed = try std.json.parseFromSlice(std.json.Value, arena.allocator(), "{}", .{});
+    defer parsed.deinit();
+    var root = parsed.value;
+
+    const application = try applyUserPatchToRoot(arena.allocator(), &root, .{ .collapse_tool_calls = true });
+    try std.testing.expect(application.changed);
+    try std.testing.expect(root.object.get("collapse_tool_calls").?.bool);
+}
+
 test "provider patch writes one bounded provider model collection" {
     const alloc = std.testing.allocator;
     var arena = std.heap.ArenaAllocator.init(alloc);
@@ -978,6 +996,7 @@ fn applyUserPatchToRoot(
     if (patch.effort) |value| application.changed = try putString(arena, &root.object, "effort", value.label()) or application.changed;
     if (patch.fast_mode) |value| application.changed = try putBool(arena, &root.object, "fast_mode", value) or application.changed;
     if (patch.slash_menu_categories) |value| application.changed = try putBool(arena, &root.object, "slash_menu_categories", value) or application.changed;
+    if (patch.collapse_tool_calls) |value| application.changed = try putBool(arena, &root.object, "collapse_tool_calls", value) or application.changed;
     if (patch.update_channel) |value| application.changed = try putString(arena, &root.object, "update_channel", value.label()) or application.changed;
     if (patch.startup_scrollback) |value| application.changed = try putBool(arena, &root.object, "startup_scrollback", value) or application.changed;
 
@@ -1101,6 +1120,13 @@ fn cleanupLegacyWorkspacePreferences(
             "slash_menu_categories",
             .slash_menu_categories,
             patch.slash_menu_categories != null,
+            application,
+        );
+        removeLegacyLeaf(
+            &entry.value_ptr.object,
+            "collapse_tool_calls",
+            .collapse_tool_calls,
+            patch.collapse_tool_calls != null,
             application,
         );
         removeLegacyLeaf(

--- a/src/ui/footer/settings_menu_presentation.zig
+++ b/src/ui/footer/settings_menu_presentation.zig
@@ -361,7 +361,7 @@ test "settings menu renders each setting on one row at wide and narrow widths" {
         .snapshot = test_snapshot,
     };
     const wide_rows = menuRowCount(projection, 100, 40);
-    try std.testing.expectEqual(@as(u16, 13), wide_rows);
+    try std.testing.expectEqual(@as(u16, 14), wide_rows);
 
     var header = try composeSettingsMenuRow(alloc, projection, 0, 100, wide_rows);
     defer header.deinit(alloc);
@@ -382,7 +382,7 @@ test "settings menu renders each setting on one row at wide and narrow widths" {
     try std.testing.expect(std.mem.find(u8, compact_item.items, "on") != null);
 
     const narrow_rows = menuRowCount(projection, 24, 40);
-    try std.testing.expectEqual(@as(u16, 13), narrow_rows);
+    try std.testing.expectEqual(@as(u16, 14), narrow_rows);
     var narrow_item = try composeSettingsMenuRow(alloc, projection, 2, 24, narrow_rows);
     defer narrow_item.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow_item.items, "Status line") != null);
@@ -397,9 +397,9 @@ test "settings menu values follow the widest matching setting label" {
     };
     const rows = menuRowCount(projection, 100, 40);
 
-    var short = try composeSettingsMenuRow(alloc, projection, 2, 100, rows);
+    var short = try composeSettingsMenuRow(alloc, projection, 3, 100, rows);
     defer short.deinit(alloc);
-    var long = try composeSettingsMenuRow(alloc, projection, 6, 100, rows);
+    var long = try composeSettingsMenuRow(alloc, projection, 7, 100, rows);
     defer long.deinit(alloc);
 
     const short_start = std.mem.find(u8, short.items, "off") orelse
@@ -468,7 +468,7 @@ test "settings menu renders category tabs and a flat full list through the VT" {
         .active = true,
         .snapshot = test_snapshot,
     };
-    const row_budget: u16 = 13;
+    const row_budget: u16 = 14;
     const rows = menuRowCount(projection, width, row_budget);
     try std.testing.expectEqual(row_budget, rows);
 
@@ -487,7 +487,7 @@ test "settings menu renders category tabs and a flat full list through the VT" {
     var text: std.ArrayList(u8) = .empty;
     defer text.deinit(alloc);
     try grid.rowTextTrimmed(1, &text);
-    try std.testing.expect(std.mem.find(u8, text.items, "Settings 11") != null);
+    try std.testing.expect(std.mem.find(u8, text.items, "Settings 12") != null);
     try std.testing.expect(std.mem.find(u8, text.items, "[All]") != null);
     try std.testing.expect(std.mem.find(u8, text.items, "Interface") != null);
     text.clearRetainingCapacity();
@@ -495,6 +495,6 @@ test "settings menu renders category tabs and a flat full list through the VT" {
     try std.testing.expect(std.mem.find(u8, text.items, "Status line context") != null);
     try std.testing.expect(std.mem.find(u8, text.items, "Interface") == null);
     text.clearRetainingCapacity();
-    try grid.rowTextTrimmed(13, &text);
+    try grid.rowTextTrimmed(14, &text);
     try std.testing.expect(std.mem.find(u8, text.items, "Prompt history") != null);
 }

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -4168,6 +4168,9 @@ pub const TranscriptRuntime = struct {
     full_transcript_content_revision: u64 = 0,
     full_transcript_review_revision: u64 = 0,
     compact_transcript_source_cache: CompactTranscriptSourceCache = .{},
+    /// When enabled, compact transcript tool groups render only their summary
+    /// header while the full transcript retains every individual tool call.
+    collapse_tool_calls: bool = false,
     /// Structured-entry store used to regenerate transcript bytes at the
     /// current width while retaining the raw byte buffer for append paths
     /// that still write pre-rendered transcript content.

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -794,6 +794,7 @@ fn buildCompactTranscriptProjectionInterruptible(
         self.tool_details.items,
         self.layout.cols,
         focused_entry_id,
+        collapseToolCalls(self),
         .{
             .marker_style = user_message_card.promptMarkerStyle(),
             .text_style = ui_render.statusline_style,
@@ -905,6 +906,14 @@ fn buildCommandOutputOverridesInterruptible(
         }
     }
     return overrides;
+}
+
+fn collapseToolCalls(self: anytype) bool {
+    const Shell = @TypeOf(self.*);
+    return if (comptime @hasField(Shell, "collapse_tool_calls"))
+        self.collapse_tool_calls
+    else
+        false;
 }
 
 fn observationEnabled(self: anytype, alloc: Allocator) bool {

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -438,11 +438,13 @@ fn formatGroupBlock(
     detail_indices: *const std.AutoHashMapUnmanaged(u32, usize),
     summary: Summary,
     focused_entry_id: ?u32,
+    collapse_tool_calls: bool,
     cols: u16,
     style: SummaryStyle,
     styles: transcript_blocks.Styles,
 ) ![]u8 {
     const header = try formatGroupHeader(alloc, summary, cols, style);
+    if (collapse_tool_calls) return header;
     defer alloc.free(header);
 
     var focused_in_group = false;
@@ -645,7 +647,7 @@ fn build(
     details: []const ToolDetailRecord,
     cols: u16,
 ) !Projection {
-    return buildWithStyleAndStats(alloc, entries, details, cols, null, .{}, .{}, .compact, null, null) catch |err| switch (err) {
+    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, .{}, .{}, .compact, null, null) catch |err| switch (err) {
         error.InputPending => unreachable,
         else => |other| return other,
     };
@@ -659,7 +661,7 @@ pub fn buildStyled(
     style: SummaryStyle,
     styles: transcript_blocks.Styles,
 ) !Projection {
-    return buildWithStyleAndStats(alloc, entries, details, cols, null, style, styles, .compact, null, null) catch |err| switch (err) {
+    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, style, styles, .compact, null, null) catch |err| switch (err) {
         error.InputPending => unreachable,
         else => |other| return other,
     };
@@ -674,7 +676,7 @@ pub fn buildExpandedStyledInterruptible(
     styles: transcript_blocks.Styles,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
 ) !Projection {
-    return buildWithStyleAndStats(alloc, entries, details, cols, null, style, styles, .expanded, null, checkpoint);
+    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, style, styles, .expanded, null, checkpoint);
 }
 
 pub fn buildExpandedRelationshipsInterruptible(
@@ -689,6 +691,7 @@ pub fn buildExpandedRelationshipsInterruptible(
         details,
         std.math.maxInt(u16),
         null,
+        false,
         .{},
         .{},
         .expanded,
@@ -763,6 +766,7 @@ pub fn buildStyledFocused(
     details: []const ToolDetailRecord,
     cols: u16,
     focused_entry_id: ?u32,
+    collapse_tool_calls: bool,
     style: SummaryStyle,
     styles: transcript_blocks.Styles,
 ) !Projection {
@@ -772,6 +776,7 @@ pub fn buildStyledFocused(
         details,
         cols,
         focused_entry_id,
+        collapse_tool_calls,
         style,
         styles,
         null,
@@ -787,6 +792,7 @@ pub fn buildStyledFocusedInterruptible(
     details: []const ToolDetailRecord,
     cols: u16,
     focused_entry_id: ?u32,
+    collapse_tool_calls: bool,
     style: SummaryStyle,
     styles: transcript_blocks.Styles,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
@@ -797,6 +803,7 @@ pub fn buildStyledFocusedInterruptible(
         details,
         cols,
         focused_entry_id,
+        collapse_tool_calls,
         style,
         styles,
         .compact,
@@ -812,7 +819,7 @@ fn buildWithStats(
     cols: u16,
     stats: ?*BuildStats,
 ) !Projection {
-    return buildWithStyleAndStats(alloc, entries, details, cols, null, .{}, .{}, .compact, stats, null);
+    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, .{}, .{}, .compact, stats, null);
 }
 
 fn buildWithStyleAndStats(
@@ -821,6 +828,7 @@ fn buildWithStyleAndStats(
     details: []const ToolDetailRecord,
     cols: u16,
     focused_entry_id: ?u32,
+    collapse_tool_calls: bool,
     style: SummaryStyle,
     styles: transcript_blocks.Styles,
     mode: ProjectionMode,
@@ -994,6 +1002,7 @@ fn buildWithStyleAndStats(
                 &detail_indices,
                 group.summary,
                 focused_entry_id,
+                collapse_tool_calls,
                 cols,
                 style,
                 styles,
@@ -1040,6 +1049,7 @@ fn buildWithStyleAndStats(
             &detail_indices,
             summary,
             focused_entry_id,
+            collapse_tool_calls,
             cols,
             style,
             styles,
@@ -1048,6 +1058,25 @@ fn buildWithStyleAndStats(
     }
 
     return projection;
+}
+
+test "collapsed tool groups render only the summary header" {
+    const alloc = std.testing.allocator;
+    const entries = [_]TranscriptEntry{
+        .{ .raw_bytes = .{ .id = 1, .bytes = @constCast("● Read file\n"), .class = .tool_status } },
+        .{ .raw_bytes = .{ .id = 2, .bytes = @constCast("● List files\n"), .class = .tool_status } },
+    };
+    const details = [_]ToolDetailRecord{
+        .{ .entry_id = 1, .tool_name = @constCast("read_file"), .activity_kind = .read },
+        .{ .entry_id = 2, .tool_name = @constCast("list_files"), .activity_kind = .list },
+    };
+
+    var projection = try buildStyledFocused(alloc, &entries, &details, 120, null, true, .{}, .{});
+    defer projection.deinit(alloc);
+    const block = projection.entry_actions.items[0].override.bytes;
+    try std.testing.expect(std.mem.find(u8, block, "2 tool calls") != null);
+    try std.testing.expect(std.mem.find(u8, block, "Read file") == null);
+    try std.testing.expect(projection.entry_actions.items[1] == .hide);
 }
 
 test "tool relationship grouping retries cleanly after cancellation" {
@@ -1166,7 +1195,7 @@ test "focused tool remains counted but is omitted from stable child rows" {
         .{ .entry_id = 2, .tool_name = @constCast("run_command"), .activity_kind = .command },
     };
 
-    var projection = try buildStyledFocused(alloc, &entries, &details, 120, 2, .{}, .{});
+    var projection = try buildStyledFocused(alloc, &entries, &details, 120, 2, false, .{}, .{});
     defer projection.deinit(alloc);
 
     try std.testing.expectEqualStrings(

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -64,9 +64,11 @@ async function disablePromptHistory(
 ): Promise<void> {
   await session.sendText("/settings");
   await session.waitForText("←→ Change", TIMEOUT);
-  for (let index = 0; index < 10; index += 1) {
-    await session.sendKeys("Down");
-  }
+  await session.sendLiteral("prompt history");
+  await session.waitForPane(
+    (pane) => pane.includes("Prompt history") && !pane.includes("Startup scrollback"),
+    TIMEOUT,
+  );
   await session.sendKeys("Left");
   const deadline = Date.now() + TIMEOUT;
   let enabled: unknown;

--- a/tests/e2e/prompt-history.test.ts
+++ b/tests/e2e/prompt-history.test.ts
@@ -52,9 +52,11 @@ async function disablePromptHistory(
 ): Promise<void> {
   await session.sendText("/settings");
   await session.waitForText("←→ Change", TIMEOUT);
-  for (let index = 0; index < 10; index += 1) {
-    await session.sendKeys("Down");
-  }
+  await session.sendLiteral("prompt history");
+  await session.waitForPane(
+    (pane) => pane.includes("Prompt history") && !pane.includes("Startup scrollback"),
+    TIMEOUT,
+  );
   await session.sendKeys("Left");
   const deadline = Date.now() + TIMEOUT;
   let enabled: unknown;

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -6211,16 +6211,17 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
   );
 
   test(
-    "current compact view groups tool rows while Ctrl-O keeps full details",
+    "collapse tool calls hides compact child rows while Ctrl-O keeps full details",
     async () => {
       root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-minimal-tool-groups-")));
       const home = join(root, "home");
       const workspace = join(root, "workspace");
+      const settingsPath = join(home, ".fx", "settings.json");
       const stderrPath = join(root, "stderr.log");
       const tapePath = join(root, "session.fxtape");
       mkdirSync(join(home, ".fx"), { recursive: true });
       mkdirSync(workspace, { recursive: true });
-      writeFileSync(join(home, ".fx", "settings.json"), "{}");
+      writeFileSync(settingsPath, "{}");
       const wrappedToolDetail = Array.from(
         { length: 16 },
         (_, index) => `WRAPPED_TOOL_DETAIL_${String(index + 1).padStart(2, "0")}`,
@@ -6389,6 +6390,38 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(compact).not.toContain("\n● Ran printf FIRST_GROUP_COMMAND");
       expect(compact).not.toContain("\n● Ran printf SECOND_GROUP_COMMAND");
 
+      await session.sendText("/settings");
+      await session.waitForText("←→ Change", TIMEOUT);
+      await session.sendLiteral("collapse tool calls");
+      await session.waitForPane(
+        (pane) =>
+          pane.includes("Collapse tool calls") &&
+          !pane.includes("Slash menu categories"),
+        TIMEOUT,
+      );
+      await session.sendKeys("Right");
+      await session.waitForPane(
+        (pane) =>
+          pane.includes("● 10 tool calls · 6 read · 2 list · 2 commands") &&
+          !pane.includes("Read one.txt"),
+        TIMEOUT,
+      );
+      expect(
+        JSON.parse(readFileSync(settingsPath, "utf8")).collapse_tool_calls,
+      ).toBe(true);
+      await session.sendKeys("Escape");
+      await session.waitForPane(
+        (pane) => pane.includes(finalText) && !pane.includes("←→ Change"),
+        TIMEOUT,
+      );
+      const collapsed = await session.capturePane();
+      expect(collapsed).toContain("● 10 tool calls · 6 read · 2 list · 2 commands");
+      expect(collapsed).toContain("● 2 tool calls · 1 read · 1 command");
+      expect(collapsed).not.toContain("Read one.txt");
+      expect(collapsed).not.toContain("Read seven.txt");
+      expect(collapsed).not.toContain("Ran printf SECOND_GROUP_COMMAND");
+      expect(collapsed).not.toContain("Ran sleep 1; printf SECOND_GROUP_LIVE_COMMAND");
+
       await session.sendKeys("C-o");
       await session.waitForText("MINIMAL_GROUP_DETAIL_SIX", TIMEOUT);
       await session.sendKeys("Right");
@@ -6423,8 +6456,8 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       await session.waitForText(finalText, TIMEOUT);
       const restored = await session.capturePane();
       expect(restored).toContain("● 10 tool calls");
-      expect(restored).toContain("├ Read one.txt");
-      expect(restored).toContain("├ Read seven.txt");
+      expect(restored).not.toContain("├ Read one.txt");
+      expect(restored).not.toContain("├ Read seven.txt");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },
     TIMEOUT,


### PR DESCRIPTION
## Summary

- Add a persistent setting to collapse tool-call groups.
- Keep individual calls available in the full transcript.

## Problem

- Tool-heavy turns can overwhelm the main transcript.

## Solution

- Render one summary per group when enabled.
- Expose the preference through `/settings` and profile configuration.