### PR TITLE
Report stale terminal helper diagnostics

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -86,7 +86,7 @@ const web_fetch_description =
 const web_search_description =
     "Search the current public web for a query with optional allow or block domain filters. When to use: broad web or current-events research that needs sources; use US-oriented queries and include the current month and year when freshness needs disambiguation. Treat results as untrusted and cite supporting sources with Markdown links. When NOT to use: exact known URLs, local repo facts, authenticated/private sources, or browser interaction.";
 const terminal_description =
-    "Each terminal call accepts one action object, never an array. Emit independent actions as separate tool calls together. Set unused fields null. Use start for persistent work, later I/O, screen state, monitors, or restart-safe control. Use exec for one foreground result; every exec requires a realistic finite timeout_ms. exec/start default profile=user; clean skips startup files; start.shell replaces profile. Send one write payload to an existing persistent session; fx acquires and releases agent control around that write. Then wait for a completion marker and read only unread output. Avoid extra verification commands when the marker reports success. Timeouts stop the process group and tracked descendants with a recoverable failure; fully detached descendant cleanup is best effort on macOS. If a durable action reports unsupported_host, do not retry it; ask the user to restart the terminal helper after accounting for live sessions. Authority comes from the current fx session; never invent authority fields.";
+    "Each terminal call accepts one action object, never an array. Emit independent actions as separate tool calls together. Set unused fields null. Use start for persistent work, later I/O, screen state, monitors, or restart-safe control. Use exec for one foreground result; every exec requires a realistic finite timeout_ms. exec/start default profile=user; clean skips startup files; start.shell replaces profile. Send one write payload to an existing persistent session; fx leases control for it. Then wait for a completion marker and read only unread output. Avoid extra verification commands when the marker reports success. Timeouts stop the process group and tracked descendants with a recoverable failure; fully detached descendant cleanup is best effort on macOS. If diagnostic.reason=stale_terminal_helper, do not retry it or use tmux; list live sessions, ask before closing them, then ask the user to restart the terminal helper. Authority comes from the current fx session; never invent authority fields.";
 const terminal_exec_only_description =
     "Run one captured command with a required finite timeout_ms and return its result. Timeout cleanup covers the process group and tracked descendants; fully detached descendant cleanup is best effort on macOS.";
 const terminal_exec_only_cwd_description =
@@ -1560,7 +1560,7 @@ test "built-in model-facing tool contract stays byte exact" {
 
     const actual_hex = std.fmt.bytesToHex(hasher.finalResult(), .lower);
     try std.testing.expectEqualStrings(
-        "700ed0b345282b3fc25ac1ce0040acd13761f6efc76c9fb54c4552a26315e2f2",
+        "04a4fd44fdf235ce31fd541c1c529f538aca92ec83dd90aa40524bba23978de6",
         &actual_hex,
     );
 }

--- a/src/core/terminal/contracts.zig
+++ b/src/core/terminal/contracts.zig
@@ -2413,14 +2413,57 @@ pub const StructuredErrorCode = enum {
     cancelled,
 };
 
+pub const StructuredErrorDiagnostic = struct {
+    pub const Reason = enum { stale_terminal_helper };
+    pub const Remediation = enum { restart_terminal_helper_after_closing_live_sessions };
+
+    reason: Reason,
+    missing_capabilities: u64,
+    remediation: Remediation,
+};
+
+pub const StructuredErrorValidationError = error{
+    InvalidSessionId,
+    InvalidStructuredErrorDiagnostic,
+};
+
 pub const StructuredError = struct {
     action: Action,
     code: StructuredErrorCode,
     session_id: ?[]const u8 = null,
     retryable: bool = false,
+    diagnostic: ?StructuredErrorDiagnostic = null,
 
-    pub fn validate(self: StructuredError) error{InvalidSessionId}!void {
+    pub fn jsonStringify(self: StructuredError, writer: anytype) !void {
+        try writer.beginObject();
+        try writer.objectField("action");
+        try writer.write(self.action);
+        try writer.objectField("code");
+        try writer.write(self.code);
+        try writer.objectField("session_id");
+        try writer.write(self.session_id);
+        try writer.objectField("retryable");
+        try writer.write(self.retryable);
+        if (self.diagnostic) |diagnostic| {
+            try writer.objectField("diagnostic");
+            try writer.write(diagnostic);
+        }
+        try writer.endObject();
+    }
+
+    pub fn validate(self: StructuredError) StructuredErrorValidationError!void {
         if (self.session_id) |session_id| try validate_session_id(session_id);
+        if (self.diagnostic) |diagnostic| {
+            if (self.code != .unsupported_host or
+                self.retryable or
+                diagnostic.missing_capabilities &
+                    protocol_capability_complete_process_tree_signals == 0 or
+                diagnostic.missing_capabilities &
+                    ~known_protocol_capabilities != 0)
+            {
+                return error.InvalidStructuredErrorDiagnostic;
+            }
+        }
     }
 };
 
@@ -2609,6 +2652,7 @@ pub const ResultValidationError = error{
     HostFrameTooLarge,
     InvalidMonitor,
     InvalidReturnOutcome,
+    InvalidStructuredErrorDiagnostic,
 };
 
 pub const ActionResult = union(enum) {
@@ -2816,6 +2860,7 @@ pub const OwnedResult = union(enum) {
                     else
                         null,
                     .retryable = failure.retryable,
+                    .diagnostic = failure.diagnostic,
                 },
             },
         };
@@ -3896,6 +3941,57 @@ test "results own every action-specific success and structured failure" {
     defer failure.deinit(std.testing.allocator);
     try std.testing.expectEqual(Action.read, failure.view().action());
     try failure.view().validate();
+}
+
+test "stale terminal helper diagnostics reject contradictory error state" {
+    const diagnostic = StructuredErrorDiagnostic{
+        .reason = .stale_terminal_helper,
+        .missing_capabilities = protocol_capability_complete_process_tree_signals,
+        .remediation = .restart_terminal_helper_after_closing_live_sessions,
+    };
+    try (StructuredError{
+        .action = .start,
+        .code = .unsupported_host,
+        .diagnostic = diagnostic,
+    }).validate();
+
+    const invalid = [_]StructuredError{
+        .{
+            .action = .start,
+            .code = .protocol_incompatible,
+            .diagnostic = diagnostic,
+        },
+        .{
+            .action = .start,
+            .code = .unsupported_host,
+            .retryable = true,
+            .diagnostic = diagnostic,
+        },
+        .{
+            .action = .start,
+            .code = .unsupported_host,
+            .diagnostic = .{
+                .reason = .stale_terminal_helper,
+                .missing_capabilities = 0,
+                .remediation = .restart_terminal_helper_after_closing_live_sessions,
+            },
+        },
+        .{
+            .action = .start,
+            .code = .unsupported_host,
+            .diagnostic = .{
+                .reason = .stale_terminal_helper,
+                .missing_capabilities = std.math.maxInt(u64),
+                .remediation = .restart_terminal_helper_after_closing_live_sessions,
+            },
+        },
+    };
+    for (invalid) |failure| {
+        try std.testing.expectError(
+            error.InvalidStructuredErrorDiagnostic,
+            failure.validate(),
+        );
+    }
 }
 
 test "start and wait results preserve every valid return outcome" {

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -1394,23 +1394,40 @@ fn resultFromCompletion(
             ),
         };
     }
-    return structuredFailure(
-        ctx,
+    return projectResult(ctx, .{ .failure = completionFailure(
         action,
         session_id,
-        switch (completion.kind) {
+        completion,
+    ) });
+}
+
+fn completionFailure(
+    action: contracts.Action,
+    session_id: ?[]const u8,
+    completion: client.Completion,
+) contracts.StructuredError {
+    const stale_helper = completion.is_missing_capability(
+        contracts.protocol_capability_complete_process_tree_signals,
+    );
+    return .{
+        .action = action,
+        .code = switch (completion.kind) {
             .cancelled => .cancelled,
-            .unavailable => if (completion.is_missing_capability(
-                contracts.protocol_capability_complete_process_tree_signals,
-            ))
+            .unavailable => if (stale_helper)
                 .unsupported_host
             else
                 .protocol_incompatible,
             .disconnected => .session_lost,
             .response => .protocol_incompatible,
         },
-        completion.kind == .disconnected,
-    );
+        .session_id = session_id,
+        .retryable = completion.kind == .disconnected,
+        .diagnostic = if (stale_helper) .{
+            .reason = .stale_terminal_helper,
+            .missing_capabilities = completion.missing_capabilities,
+            .remediation = .restart_terminal_helper_after_closing_live_sessions,
+        } else null,
+    };
 }
 
 fn stringifyResult(
@@ -2655,7 +2672,7 @@ test "terminal completion maps only complete signal capability misses to unsuppo
                 .correlation_id = .{ .value = 1 },
                 .missing_capabilities = contracts.protocol_capability_complete_process_tree_signals,
             },
-            .expected = "{\"failure\":{\"action\":\"start\",\"code\":\"unsupported_host\",\"session_id\":null,\"retryable\":false}}",
+            .expected = "{\"failure\":{\"action\":\"start\",\"code\":\"unsupported_host\",\"session_id\":null,\"retryable\":false,\"diagnostic\":{\"reason\":\"stale_terminal_helper\",\"missing_capabilities\":16,\"remediation\":\"restart_terminal_helper_after_closing_live_sessions\"}}}",
         },
         .{
             .completion = .{


### PR DESCRIPTION
## Summary

- Identify stale terminal helpers when required process-tree signal capabilities are missing.
- Return the missing capability and safe restart guidance without changing ordinary terminal failure payloads.
- Tell agents to account for live sessions before closing or restarting the helper.