### PR TITLE
Preserve shell results across output failures

### DIFF
--- a/src/core/execution/command_contract.zig
+++ b/src/core/execution/command_contract.zig
@@ -11,6 +11,7 @@ pub const CommandResult = struct {
     signal: ?u32 = null,
     timed_out: bool = false,
     termination_indeterminate: bool = false,
+    output_incomplete: bool = false,
     duration_ms: ?u64 = null,
     stdout_bytes: usize = 0,
     stderr_bytes: usize = 0,
@@ -52,6 +53,7 @@ pub const CommandResultSnapshot = struct {
     stderr_display: []const u8,
     stdout_bytes: usize,
     stderr_bytes: usize,
+    output_incomplete: bool = false,
     duration_ms: ?u64 = null,
 };
 
@@ -83,6 +85,7 @@ pub fn formatCommandResult(
             .exit_code = status.exit_code,
             .signal = status.signal,
             .termination_indeterminate = status.termination_indeterminate,
+            .output_incomplete = snapshot.output_incomplete,
             .duration_ms = snapshot.duration_ms,
             .stdout_bytes = snapshot.stdout_bytes,
             .stderr_bytes = snapshot.stderr_bytes,
@@ -154,6 +157,9 @@ fn writeCommandJson(result: CommandResult, writer: *std.Io.Writer) !void {
     try writeBoolField(writer, "timed_out", result.timed_out);
     if (result.termination_indeterminate) {
         try writeBoolField(writer, "termination_indeterminate", true);
+    }
+    if (result.output_incomplete) {
+        try writeBoolField(writer, "output_incomplete", true);
     }
     try writeOptionalIntField(writer, "duration_ms", result.duration_ms);
     try writeIntField(writer, "stdout_bytes", result.stdout_bytes);
@@ -274,5 +280,31 @@ test "foreground result represents indeterminate termination without implying no
         u8,
         json,
         "\"termination_indeterminate\":true",
+    ) != null);
+}
+
+test "command result preserves observed status when output is incomplete" {
+    const result = try formatCommandResult(std.testing.allocator, .{
+        .command = "printf effect > marker",
+        .cwd = "/tmp",
+        .status = .{ .exit_code = 0 },
+        .stdout_display = "partial output",
+        .stderr_display = "",
+        .stdout_bytes = 14,
+        .stderr_bytes = 0,
+        .output_incomplete = true,
+    });
+    defer std.testing.allocator.free(result.output);
+
+    const command = result.command_result.?;
+    try std.testing.expectEqual(@as(?i64, 0), command.exit_code);
+    try std.testing.expect(command.output_incomplete);
+
+    const json = try command.toJson(std.testing.allocator);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.find(
+        u8,
+        json,
+        "\"output_incomplete\":true",
     ) != null);
 }

--- a/src/core/execution/command_runner.zig
+++ b/src/core/execution/command_runner.zig
@@ -702,6 +702,7 @@ fn emitAcceptedOutputChunk(
 
 const CollectedProcess = struct {
     status: command_contract.CommandStatus,
+    output_incomplete: bool = false,
     stdout: []const u8,
     stderr: []const u8,
     stdout_bytes: usize,
@@ -954,6 +955,7 @@ const OutputCollector = struct {
     fn finish(
         self: *OutputCollector,
         status: command_contract.CommandStatus,
+        output_incomplete: bool,
     ) !CollectedProcess {
         if (self.artifact) |*artifact| {
             try artifact.sync();
@@ -961,6 +963,7 @@ const OutputCollector = struct {
             const truncated = self.totalBytes() > self.cfg.max_command_output_bytes;
             return .{
                 .status = status,
+                .output_incomplete = output_incomplete,
                 .stdout = "",
                 .stderr = "",
                 .stdout_bytes = self.stdout_bytes,
@@ -976,6 +979,7 @@ const OutputCollector = struct {
 
         return .{
             .status = status,
+            .output_incomplete = output_incomplete,
             .stdout = try self.stdout.toOwnedSlice(self.alloc),
             .stderr = try self.stderr.toOwnedSlice(self.alloc),
             .stdout_bytes = self.stdout_bytes,
@@ -1011,6 +1015,7 @@ const OutputCollector = struct {
 fn finishCollectedProcess(
     output: *OutputCollector,
     status: command_contract.CommandStatus,
+    output_incomplete: bool,
     duration_ms: u64,
     source: TerminationSource,
 ) !CollectedProcess {
@@ -1028,7 +1033,7 @@ fn finishCollectedProcess(
         },
     }
 
-    var result = output.finish(status) catch |err| {
+    var result = output.finish(status, output_incomplete) catch |err| {
         if (source != .cancelled) return err;
         debug_trace.logf("core", "cancelled command artifact finalization failed err={s}", .{@errorName(err)});
         return error.Cancelled;
@@ -1108,6 +1113,7 @@ fn executeProcessWithInput(
     return finishCollectedProcess(
         &output,
         collected.status,
+        collected.output_incomplete,
         duration_ms,
         collected.source,
     );
@@ -1239,6 +1245,7 @@ fn executeProcessWithDetachedSession(
     return finishCollectedProcess(
         &output,
         collected.status,
+        collected.output_incomplete,
         duration_ms,
         collected.source,
     );
@@ -1386,6 +1393,7 @@ fn executeProcessWithScriptUnisolated(
     return finishCollectedProcess(
         &output,
         collected.status,
+        collected.output_incomplete,
         duration_ms,
         collected.source,
     );
@@ -1781,6 +1789,7 @@ fn formatOutput(alloc: Allocator, command: []const u8, cwd: []const u8, term: st
         stdout_raw,
         stderr_raw,
         duration_ms,
+        false,
     );
 }
 
@@ -1792,6 +1801,7 @@ fn formatOutputWithStatus(
     stdout_raw: []const u8,
     stderr_raw: []const u8,
     duration_ms: ?u64,
+    output_incomplete: bool,
 ) !command_contract.RunCommandResult {
     return command_contract.formatCommandResult(alloc, .{
         .command = command,
@@ -1801,6 +1811,7 @@ fn formatOutputWithStatus(
         .stderr_display = stderr_raw,
         .stdout_bytes = stdout_raw.len,
         .stderr_bytes = stderr_raw.len,
+        .output_incomplete = output_incomplete,
         .duration_ms = duration_ms,
     });
 }
@@ -1830,6 +1841,7 @@ fn formatCollectedOutputValue(alloc: Allocator, command: []const u8, cwd: []cons
         result.stdout,
         result.stderr,
         result.duration_ms,
+        result.output_incomplete,
     );
 
     var out: std.Io.Writer.Allocating = .init(alloc);
@@ -1856,6 +1868,7 @@ fn formatCollectedOutputValue(alloc: Allocator, command: []const u8, cwd: []cons
             .exit_code = status.exit_code,
             .signal = status.signal,
             .termination_indeterminate = status.termination_indeterminate,
+            .output_incomplete = result.output_incomplete,
             .duration_ms = result.duration_ms,
             .stdout_bytes = result.stdout_bytes,
             .stderr_bytes = result.stderr_bytes,
@@ -1910,6 +1923,11 @@ const TerminationSource = enum {
     natural,
     cancelled,
     timed_out,
+};
+
+const CollectedOutput = struct {
+    source: TerminationSource,
+    output_incomplete: bool = false,
 };
 
 fn reconcileForegroundTerminationSource(
@@ -1978,6 +1996,7 @@ fn terminationSignalPlan(
 const OutputChunkEmitter = struct {
     stdout_pending: std.ArrayList(u8) = .empty,
     stderr_pending: std.ArrayList(u8) = .empty,
+    presentation_suppressed: bool = false,
 
     fn deinit(self: *@This(), arena: Allocator) void {
         self.stdout_pending.deinit(arena);
@@ -1994,12 +2013,12 @@ const OutputChunkEmitter = struct {
     ) !void {
         try output.append(stream, bytes);
         try emitAcceptedOutputChunk(cfg, stream, bytes);
-        try emitPending(arena, self.pendingFor(stream), stream, bytes, cfg, false);
+        self.emitPending(arena, self.pendingFor(stream), stream, bytes, cfg, false);
     }
 
-    fn flush(self: *@This(), arena: Allocator, cfg: Config) !void {
-        try emitPending(arena, &self.stdout_pending, .stdout, "", cfg, true);
-        try emitPending(arena, &self.stderr_pending, .stderr, "", cfg, true);
+    fn flush(self: *@This(), arena: Allocator, cfg: Config) void {
+        self.emitPending(arena, &self.stdout_pending, .stdout, "", cfg, true);
+        self.emitPending(arena, &self.stderr_pending, .stderr, "", cfg, true);
     }
 
     fn pendingFor(self: *@This(), stream: CommandOutputStream) *std.ArrayList(u8) {
@@ -2010,20 +2029,28 @@ const OutputChunkEmitter = struct {
     }
 
     fn emitPending(
+        self: *@This(),
         arena: Allocator,
         pending: *std.ArrayList(u8),
         stream: CommandOutputStream,
         new_bytes: []const u8,
         cfg: Config,
         flush_remainder: bool,
-    ) !void {
+    ) void {
+        if (self.presentation_suppressed) return;
         const ctx = cfg.output_chunk_ctx orelse return;
         const callback = cfg.on_output_chunk orelse return;
-        if (new_bytes.len > 0) try pending.appendSlice(arena, new_bytes);
+        if (new_bytes.len > 0) pending.appendSlice(arena, new_bytes) catch |err| {
+            self.suppressPresentation(err);
+            return;
+        };
 
         while (std.mem.findScalar(u8, pending.items, '\n')) |newline_index| {
             const line = pending.items[0 .. newline_index + 1];
-            try emitOutputChunk(ctx, callback, cfg.output_chunk_lifecycle_id, stream, line, cfg.callback_projection);
+            emitOutputChunk(ctx, callback, cfg.output_chunk_lifecycle_id, stream, line, cfg.callback_projection) catch |err| {
+                self.suppressPresentation(err);
+                return;
+            };
 
             const remaining = pending.items.len - (newline_index + 1);
             std.mem.copyForwards(u8, pending.items[0..remaining], pending.items[newline_index + 1 ..]);
@@ -2031,14 +2058,31 @@ const OutputChunkEmitter = struct {
         }
 
         if (!flush_remainder and pending.items.len >= pending_output_flush_bytes) {
-            try emitOutputChunk(ctx, callback, cfg.output_chunk_lifecycle_id, stream, pending.items, cfg.callback_projection);
+            emitOutputChunk(ctx, callback, cfg.output_chunk_lifecycle_id, stream, pending.items, cfg.callback_projection) catch |err| {
+                self.suppressPresentation(err);
+                return;
+            };
             pending.clearRetainingCapacity();
         }
 
         if (flush_remainder and pending.items.len > 0) {
-            try emitOutputChunk(ctx, callback, cfg.output_chunk_lifecycle_id, stream, pending.items, cfg.callback_projection);
+            emitOutputChunk(ctx, callback, cfg.output_chunk_lifecycle_id, stream, pending.items, cfg.callback_projection) catch |err| {
+                self.suppressPresentation(err);
+                return;
+            };
             pending.clearRetainingCapacity();
         }
+    }
+
+    fn suppressPresentation(self: *@This(), err: anyerror) void {
+        debug_trace.logf(
+            "core",
+            "command output presentation suppressed err={s}",
+            .{@errorName(err)},
+        );
+        self.presentation_suppressed = true;
+        self.stdout_pending.clearRetainingCapacity();
+        self.stderr_pending.clearRetainingCapacity();
     }
 };
 
@@ -2316,7 +2360,7 @@ fn collectOutput(
     process_group_id: ?std.posix.pid_t,
     termination_protocol: TerminationProtocol,
     leader_status: *?command_contract.CommandStatus,
-) !TerminationSource {
+) !CollectedOutput {
     const zio = io_mod.getIo();
     var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
     var multi_reader: std.Io.File.MultiReader = undefined;
@@ -2333,6 +2377,7 @@ fn collectOutput(
     var signal_started_ms: ?i64 = null;
     var force_kill_sent = false;
     var streams_finished = false;
+    var output_incomplete = false;
 
     while (true) {
         try updateTerminationSignal(
@@ -2384,7 +2429,15 @@ fn collectOutput(
         else |err| switch (err) {
             error.EndOfStream => false,
             error.Timeout => true,
-            else => |e| return e,
+            else => |e| blk: {
+                if (source.* != .natural or cancelRequested(cfg.cancel_flag)) return e;
+                recordOutputDrainFailure(
+                    &output_incomplete,
+                    "reader_coordination",
+                    e,
+                );
+                break :blk false;
+            },
         };
 
         const stdout_buf = stdout_r.buffered();
@@ -2400,6 +2453,13 @@ fn collectOutput(
                 try emitter.append(arena, output, .stderr, stderr_buf, cfg);
             }
             stderr_r.tossBuffered();
+        }
+        if (emitter.presentation_suppressed and cancelRequested(cfg.cancel_flag)) {
+            return error.Cancelled;
+        }
+        if (source.* == .natural) {
+            recordMultiReaderFailure(&multi_reader, &output_incomplete);
+            if (output_incomplete) break;
         }
 
         if (!keep_reading) {
@@ -2417,8 +2477,37 @@ fn collectOutput(
     if (launch_failure_probe) |probe| {
         try probe.flush(arena, &emitter, output, cfg);
     }
-    try emitter.flush(arena, cfg);
-    return source.*;
+    emitter.flush(arena, cfg);
+    if (source.* == .natural) {
+        recordMultiReaderFailure(&multi_reader, &output_incomplete);
+    }
+    return .{
+        .source = source.*,
+        .output_incomplete = output_incomplete,
+    };
+}
+
+fn recordMultiReaderFailure(
+    multi_reader: *const std.Io.File.MultiReader,
+    output_incomplete: *bool,
+) void {
+    multi_reader.checkAnyError() catch |err| {
+        recordOutputDrainFailure(output_incomplete, "stream_read", err);
+    };
+}
+
+fn recordOutputDrainFailure(
+    output_incomplete: *bool,
+    reason: []const u8,
+    err: anyerror,
+) void {
+    if (output_incomplete.*) return;
+    output_incomplete.* = true;
+    debug_trace.logf(
+        "core",
+        "command output drain incomplete reason={s} err={s}",
+        .{ reason, @errorName(err) },
+    );
 }
 
 fn collectOutputForProcess(
@@ -2430,7 +2519,7 @@ fn collectOutputForProcess(
     process_group_id: ?std.posix.pid_t,
     termination_protocol: TerminationProtocol,
     leader_status: *?command_contract.CommandStatus,
-) !TerminationSource {
+) !CollectedOutput {
     var source: TerminationSource = .natural;
     return collectOutput(
         arena,
@@ -2468,6 +2557,7 @@ fn waitForCollectedProcess(
 const CollectedTermination = struct {
     source: TerminationSource,
     status: command_contract.CommandStatus,
+    output_incomplete: bool = false,
 };
 
 fn collectSpawnedProcess(
@@ -2501,7 +2591,7 @@ fn collectSpawnedProcess(
     defer if (wait_pending) observer.abort(process_group_id);
 
     var leader_status: ?command_contract.CommandStatus = null;
-    const source = try collectOutputForProcess(
+    const collected_output = try collectOutputForProcess(
         arena,
         &observer,
         output,
@@ -2511,14 +2601,40 @@ fn collectSpawnedProcess(
         termination_protocol,
         &leader_status,
     );
+    if (collected_output.output_incomplete and leader_status == null) {
+        debug_trace.logf(
+            "core",
+            "command output drain failed before process status; aborting command",
+            .{},
+        );
+        observer.abort(process_group_id);
+        wait_pending = false;
+        return .{
+            .source = collected_output.source,
+            .status = .indeterminate,
+            .output_incomplete = true,
+        };
+    }
     const status = try waitForCollectedProcess(
         &observer,
-        source,
+        collected_output.source,
         process_group_id,
         leader_status,
     );
     wait_pending = false;
-    return .{ .source = source, .status = status };
+    var output_incomplete = collected_output.output_incomplete;
+    if (io_mod.getenv("FX_COMMAND_TEST_OUTPUT_INCOMPLETE_AFTER_EXIT") != null) {
+        recordOutputDrainFailure(
+            &output_incomplete,
+            "injected_after_exit",
+            error.Unexpected,
+        );
+    }
+    return .{
+        .source = collected_output.source,
+        .status = status,
+        .output_incomplete = output_incomplete,
+    };
 }
 
 fn mapTerminationError(
@@ -3560,6 +3676,65 @@ test "line buffered streaming preserves stderr stream and tail" {
     try std.testing.expect(capture.contains(.stderr, "tail"));
 }
 
+test "multi-reader stream failure marks output incomplete" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+
+    const failed_pipe = try std.Io.Threaded.pipe2(.{});
+    const clean_pipe = try std.Io.Threaded.pipe2(.{});
+    var failed_read = std.Io.File{
+        .handle = failed_pipe[0],
+        .flags = .{ .nonblocking = false },
+    };
+    var failed_write = std.Io.File{
+        .handle = failed_pipe[1],
+        .flags = .{ .nonblocking = false },
+    };
+    var clean_read = std.Io.File{
+        .handle = clean_pipe[0],
+        .flags = .{ .nonblocking = false },
+    };
+    var clean_write = std.Io.File{
+        .handle = clean_pipe[1],
+        .flags = .{ .nonblocking = false },
+    };
+    failed_read.close(std.testing.io);
+    failed_write.close(std.testing.io);
+    clean_write.close(std.testing.io);
+    defer clean_read.close(std.testing.io);
+
+    var buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
+    var multi_reader: std.Io.File.MultiReader = undefined;
+    multi_reader.init(
+        std.testing.allocator,
+        std.testing.io,
+        buffer.toStreams(),
+        &.{ failed_read, clean_read },
+    );
+    defer multi_reader.deinit();
+
+    var output_incomplete = false;
+    try multi_reader.fill(1, .none);
+    recordMultiReaderFailure(&multi_reader, &output_incomplete);
+    try std.testing.expect(output_incomplete);
+    try std.testing.expectError(error.EndOfStream, multi_reader.fill(1, .none));
+}
+
+test "presentation failure preserves the complete command result" {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
+
+    var trigger = FailOutput{};
+    const result = try executeCommand(.{
+        .max_command_output_bytes = 4096,
+        .output_chunk_ctx = @ptrCast(&trigger),
+        .on_output_chunk = FailOutput.onChunk,
+    }, std.testing.allocator, "printf 'first\\nsecond\\n'", "/tmp");
+    defer std.testing.allocator.free(result.output);
+
+    try std.testing.expect(trigger.seen);
+    try std.testing.expectEqual(@as(?i64, 0), result.command_result.?.exit_code);
+    try std.testing.expect(std.mem.find(u8, result.output, "first\nsecond") != null);
+}
+
 test "raw callback projection preserves bytes without changing command result" {
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
 
@@ -3609,7 +3784,7 @@ test "accepted callbacks preserve repeated newline-free stream order" {
     try emitter.append(std.testing.allocator, &output, .stdout, "O1", cfg);
     try emitter.append(std.testing.allocator, &output, .stderr, "E2", cfg);
     try emitter.append(std.testing.allocator, &output, .stdout, "O2", cfg);
-    try emitter.flush(std.testing.allocator, cfg);
+    emitter.flush(std.testing.allocator, cfg);
 
     try std.testing.expectEqual(@as(usize, 4), capture.chunks.items.len);
     try std.testing.expectEqual(.stderr, capture.streams.items[0]);

--- a/src/core/execution/managed_execution.zig
+++ b/src/core/execution/managed_execution.zig
@@ -74,6 +74,7 @@ pub const Snapshot = struct {
     persistence: contract.Persistence = .process,
     output_delta: []u8,
     output_truncated: bool,
+    output_incomplete: bool = false,
     duration_ms: ?u64 = null,
     output_file: ?[]u8 = null,
     output_framed_bytes: usize = 0,
@@ -183,6 +184,7 @@ const Entry = struct {
     stdout_bytes: usize = 0,
     stderr_bytes: usize = 0,
     output_truncated: bool = false,
+    output_incomplete: bool = false,
     delivery: contract.DeliveryState = .{},
     active_waiter: ?u64 = null,
     preempted_waiter: ?u64 = null,
@@ -333,6 +335,7 @@ const Entry = struct {
             .replay_capability = replay_capability,
             .published_running = input.published_running,
             .output_truncated = input.output.len > input.max_output_bytes,
+            .output_incomplete = input.output_incomplete,
             .stdout_bytes = raw_output.len,
             .error_name = error_name,
         };
@@ -1144,6 +1147,8 @@ pub const Runtime = struct {
                 .output_delta = output_delta,
                 .output_truncated = entry.output_truncated or
                     if (metadata) |value| value.truncated else false,
+                .output_incomplete = entry.output_incomplete or
+                    if (metadata) |value| value.output_incomplete else false,
                 .duration_ms = if (metadata) |value| value.duration_ms else null,
                 .output_file = output_file,
                 .output_framed_bytes = entry.output_framed_bytes,
@@ -1382,6 +1387,7 @@ fn applyTtyUpdateLocked(entry: *Entry, input: TtyUpdate) !void {
     }
     try entry.appendBoundedOutput(input.output);
     entry.output_truncated = entry.output_truncated or input.output_incomplete;
+    entry.output_incomplete = entry.output_incomplete or input.output_incomplete;
     if (input.error_name) |error_name| {
         entry.error_name = try entry.arena.allocator().dupe(u8, error_name);
     }

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -5599,12 +5599,16 @@ test "browser run_command maps host cancellation and deadline without signal or 
     try expectCommandResultNull(timeout_json, "signal");
 }
 
-test "run_command propagates output callback failure" {
+test "run_command preserves result when presentation callback fails" {
     if (builtin.os.tag == .windows or builtin.os.tag == .wasi) return;
 
     const FailOutput = struct {
-        fn write(_: *anyopaque, _: ?types.ToolLifecycleId, _: command_contract.CommandOutputStream, _: []const u8) error{OutOfMemory}!void {
-            return error.OutOfMemory;
+        calls: usize = 0,
+
+        fn write(raw_ctx: *anyopaque, _: ?types.ToolLifecycleId, _: command_contract.CommandOutputStream, _: []const u8) error{Unexpected}!void {
+            const self: *@This() = @ptrCast(@alignCast(raw_ctx));
+            self.calls += 1;
+            return error.Unexpected;
         }
     };
 
@@ -5616,17 +5620,20 @@ test "run_command propagates output callback failure" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
 
+    var presentation = FailOutput{};
     var ctx = rt.context();
-    ctx.output_chunk_ctx = @ptrCast(&rt);
+    ctx.output_chunk_ctx = @ptrCast(&presentation);
     ctx.on_output_chunk = FailOutput.write;
-    try std.testing.expectError(
-        error.OutOfMemory,
-        executeTestRunCommand(ctx, arena_state.allocator(), .{
-            .id = "cmd",
-            .name = "shell",
-            .arguments_json = "{\"action\":\"run\",\"command\":\"printf 'handoff\\\\n'\",\"timeout_ms\":600000}",
-        }),
-    );
+    const result = try executeTestRunCommand(ctx, arena_state.allocator(), .{
+        .id = "cmd",
+        .name = "shell",
+        .arguments_json = "{\"action\":\"run\",\"command\":\"printf 'handoff\\\\nsecond\\\\n'\",\"timeout_ms\":600000}",
+    });
+    try std.testing.expectEqual(tool_contracts.ToolExecutionStatus.success, result.status);
+    try std.testing.expectEqual(@as(usize, 1), presentation.calls);
+    try expectContains(result.model_output, "handoff\nsecond");
+    const structured = result.command_result_json orelse return error.TestExpectedEqual;
+    try expectCommandResultInt(structured, "exit_code", 0);
 }
 
 test "run_command returns model output and structured metadata" {

--- a/src/tools/shell/shell.zig
+++ b/src/tools/shell/shell.zig
@@ -1151,7 +1151,7 @@ fn finishPrepared(
     handoffPreparedDelivery(ctx, runtime, prepared.reservation_id) catch {
         return .{ .failure = try ctx.allocator.dupe(u8, "shell result commit failed") };
     };
-    return if (action == .command and snapshotFailed(prepared.snapshot.state))
+    return if (action == .command and snapshotFailed(prepared.snapshot))
         .{ .failure = body }
     else
         .{ .success = body };
@@ -1221,6 +1221,7 @@ fn publishSnapshotMetadata(
             .signal = projection.signal,
             .timed_out = timed_out,
             .termination_indeterminate = projection.termination_indeterminate,
+            .output_incomplete = snapshot.output_incomplete,
             .duration_ms = snapshot.duration_ms,
             .stdout_bytes = snapshot.stdout_bytes,
             .stderr_bytes = snapshot.stderr_bytes,
@@ -1406,6 +1407,12 @@ fn formatSnapshotRaw(
             .signal = null,
             .termination_indeterminate = false,
         };
+    const retry_guidance: ?[]const u8 = if (snapshot.output_incomplete)
+        "Command output is incomplete. Inspect external state and available output before retrying; do not blindly rerun a command that may have changed state."
+    else switch (snapshot.state) {
+        .lost => "Execution status is indeterminate. Inspect external state before retrying; do not blindly rerun a command that may have changed state.",
+        .running, .completed, .stopped => null,
+    };
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
     try std.json.Stringify.value(.{
@@ -1414,6 +1421,7 @@ fn formatSnapshotRaw(
         .backend = @tagName(snapshot.backend),
         .persistence = @tagName(snapshot.persistence),
         .output_truncated = output_truncated,
+        .output_incomplete = snapshot.output_incomplete,
         .output_terminal_safe = true,
         .full_output_handle = snapshot.output_file,
         .exit_code = projection.exit_code,
@@ -1422,10 +1430,7 @@ fn formatSnapshotRaw(
         .duration_ms = snapshot.duration_ms,
         .accepted_bytes = accepted_bytes,
         .@"error" = snapshot.error_name,
-        .retry_guidance = switch (snapshot.state) {
-            .lost => "Execution status is indeterminate. Inspect external state before retrying; do not blindly rerun a command that may have changed state.",
-            .running, .completed, .stopped => null,
-        },
+        .retry_guidance = retry_guidance,
         .output_delta = output_delta,
     }, .{}, &out.writer);
     return try out.toOwnedSlice();
@@ -1440,8 +1445,9 @@ fn snapshotStateName(state: managed_execution.SnapshotState) []const u8 {
     };
 }
 
-fn snapshotFailed(state: managed_execution.SnapshotState) bool {
-    return switch (state) {
+fn snapshotFailed(snapshot: managed_execution.Snapshot) bool {
+    if (snapshot.output_incomplete) return true;
+    return switch (snapshot.state) {
         .running => false,
         .completed => |status| switch (status) {
             .exit_code => |code| code != 0,
@@ -1812,6 +1818,33 @@ test "lost shell snapshot preserves indeterminate execution guidance" {
     defer parsed.deinit();
     const object = parsed.value.object;
     try std.testing.expect(object.get("termination_indeterminate").?.bool);
+    try std.testing.expect(std.mem.find(
+        u8,
+        object.get("retry_guidance").?.string,
+        "do not blindly rerun",
+    ) != null);
+}
+
+test "completed shell snapshot reports incomplete output without losing status" {
+    const alloc = std.testing.allocator;
+    const body = try formatSnapshot(alloc, .{
+        .execution_id = @constCast("shell-incomplete"),
+        .command = @constCast("mutating-command"),
+        .cwd = @constCast("/tmp"),
+        .retained = false,
+        .state = .{ .completed = .{ .exit_code = 0 } },
+        .output_delta = @constCast("partial output"),
+        .output_truncated = false,
+        .output_incomplete = true,
+    }, null);
+    defer alloc.free(body);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    const object = parsed.value.object;
+    try std.testing.expectEqualStrings("completed", object.get("state").?.string);
+    try std.testing.expectEqual(@as(i64, 0), object.get("exit_code").?.integer);
+    try std.testing.expect(object.get("output_incomplete").?.bool);
     try std.testing.expect(std.mem.find(
         u8,
         object.get("retry_guidance").?.string,

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -3022,6 +3022,87 @@ describe("gateway stream lifecycle", () => {
     }
   });
 
+  test("incomplete shell output preserves process status without replaying effects", async () => {
+    const root = createFixtureRoot("shell-incomplete-output");
+    const tracePath = join(root.root, "trace.log");
+    const effectPath = join(root.workspace, "command-effect.txt");
+    const callId = "shell_incomplete_output_1";
+    let observedFailure = "";
+    let step = 0;
+    const gateway = startGateway((body) => {
+      switch (step++) {
+        case 0:
+          return fakeShellRun(
+            callId,
+            "printf 'effect\\n' >> command-effect.txt; printf 'partial output\\n'",
+            { timeout_ms: 30_000 },
+          );
+        case 1:
+          observedFailure = toolResultOutput(body, callId);
+          return fakeGatewayFinalText("Incomplete output acknowledged without retry.");
+        default:
+          return new Response("unexpected request", { status: 500 });
+      }
+    });
+
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--yolo", "--no-save", "Run the mutation exactly once."],
+        {
+          cwd: root.workspace,
+          env: {
+            ...fixtureEnv(root, gateway, tracePath),
+            FX_COMMAND_TEST_OUTPUT_INCOMPLETE_AFTER_EXIT: "1",
+          },
+          timeoutMs: 15_000,
+        },
+      );
+      const json = JSON.parse(result.stdout) as {
+        exit_code: number;
+        output: string;
+        tool_calls: Array<{
+          name: string;
+          status: string;
+          command_result?: {
+            exit_code?: number;
+            output_incomplete?: boolean;
+          };
+        }>;
+      };
+
+      expect(result.code).toBe(0);
+      expect(json.exit_code).toBe(0);
+      expect(json.output).toContain("acknowledged without retry");
+      expect(gateway.requestCount()).toBe(2);
+      expect(readFileSync(effectPath, "utf8")).toBe("effect\n");
+      expect(JSON.parse(observedFailure)).toMatchObject({
+        state: "completed",
+        exit_code: 0,
+        output_incomplete: true,
+      });
+      expect(observedFailure).toContain("partial output");
+      expect(observedFailure).toContain("do not blindly rerun");
+      expect(observedFailure).not.toContain("Unexpected");
+      expect(json.tool_calls).toHaveLength(1);
+      expect(json.tool_calls[0]).toMatchObject({
+        name: "shell",
+        status: "error",
+        command_result: {
+          exit_code: 0,
+          output_incomplete: true,
+        },
+      });
+      expect(readFileSync(tracePath, "utf8")).toContain(
+        "command output drain incomplete reason=injected_after_exit",
+      );
+      expect(result.stderr).not.toContain("Unexpected");
+      expect(result.stderr).not.toContain("error.Unexpected");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("suffixless stored result handle remains readable", async () => {
     const root = createFixtureRoot("suffixless-tool-result-handle");
     const tracePath = join(root.root, "trace.log");


### PR DESCRIPTION
## Summary

- Preserve observed command status and partial output when command output cannot be read completely.
- Return `output_incomplete` with inspect-before-retry guidance instead of a generic failure.
- Keep live presentation failures from discarding the final command result.
- Stop and reap commands when output fails before their status is known.