### PR TITLE
Reduce duplicate decoder and error-path overhead

### DIFF
--- a/src/core/subagent/control_store.zig
+++ b/src/core/subagent/control_store.zig
@@ -122,6 +122,21 @@ pub const LockError = error{
     ControlStoreFailed,
 };
 
+inline fn failOptionalRecord(err: anytype) @TypeOf(err)!?Record {
+    return @errorCast(failOptionalRecordDynamic(err));
+}
+
+noinline fn failOptionalRecordDynamic(err: anyerror) anyerror!?Record {
+    return err;
+}
+
+test "optional control record failures preserve exact error types and identities" {
+    const invalid = failOptionalRecord(error.InvalidControlRecord);
+    try std.testing.expect(@TypeOf(invalid) == error{InvalidControlRecord}!?Record);
+    try std.testing.expectError(error.InvalidControlRecord, invalid);
+    try std.testing.expectError(error.OutOfMemory, failOptionalRecord(error.OutOfMemory));
+}
+
 pub const Store = struct {
     capability: *session_child_store.SessionChildCapability,
     expected_child_id: []const u8,
@@ -149,24 +164,25 @@ pub const Store = struct {
             record_file,
         ) catch |err| switch (err) {
             error.FileNotFound => return null,
-            error.OutOfMemory => return error.OutOfMemory,
-            error.SessionPathUnsafe => return error.ControlPathUnsafe,
+            error.OutOfMemory => return failOptionalRecord(error.OutOfMemory),
+            error.SessionPathUnsafe => return failOptionalRecord(error.ControlPathUnsafe),
             error.PrivateStatePermissionsUnsupported => {
-                return error.PrivateStatePermissionsUnsupported;
+                return failOptionalRecord(error.PrivateStatePermissionsUnsupported);
             },
-            else => return error.ControlStoreFailed,
+            else => return failOptionalRecord(error.ControlStoreFailed),
         };
         defer file.deinit();
         const bytes = file.readToEnd(alloc, max_record_bytes) catch |err| switch (err) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.StreamTooLong => return error.ControlRecordTooLarge,
-            else => return error.ControlStoreFailed,
+            error.OutOfMemory => return failOptionalRecord(error.OutOfMemory),
+            error.StreamTooLong => return failOptionalRecord(error.ControlRecordTooLarge),
+            else => return failOptionalRecord(error.ControlStoreFailed),
         };
         defer alloc.free(bytes);
-        var record = try parseRecord(alloc, bytes);
+        var record = parseRecord(alloc, bytes) catch |err|
+            return failOptionalRecord(err);
         errdefer record.deinit(alloc);
         if (!std.mem.eql(u8, record.child_id, self.expected_child_id)) {
-            return error.InvalidControlRecord;
+            return failOptionalRecord(error.InvalidControlRecord);
         }
         return record;
     }

--- a/src/core/terminal/store.zig
+++ b/src/core/terminal/store.zig
@@ -2469,7 +2469,7 @@ pub fn reloadAuthorityClaim(
     ) or !std.mem.eql(u8, record.cwd, input.principal.cwd) or
         record.backend != input.principal.backend)
     {
-        return error.PrincipalMismatch;
+        return failReloadedAuthorityClaim(error.PrincipalMismatch);
     }
     const authority = try load_authority(
         alloc,
@@ -2482,21 +2482,21 @@ pub fn reloadAuthorityClaim(
         &authority.value,
     );
     if (record.authority_revoked or authority.value.revoked) {
-        return error.AuthorityRevoked;
+        return failReloadedAuthorityClaim(error.AuthorityRevoked);
     }
     const grant = authority.value.grant;
     if (!grant.principal.eql(input.principal)) {
-        return error.PrincipalMismatch;
+        return failReloadedAuthorityClaim(error.PrincipalMismatch);
     }
     if (record.authority_generation.value != input.generation.value or
         grant.generation.value != input.generation.value)
     {
-        return error.StaleAuthorityGeneration;
+        return failReloadedAuthorityClaim(error.StaleAuthorityGeneration);
     }
     const direct_model_observer = observer_policy and
         grant.actor == .human and input.actor == .agent;
     if (!direct_model_observer and grant.actor != input.actor) {
-        return error.ActorRoleMismatch;
+        return failReloadedAuthorityClaim(error.ActorRoleMismatch);
     }
     const controls = if (direct_model_observer)
         contracts.AllowedControls.observer()
@@ -2507,7 +2507,7 @@ pub fn reloadAuthorityClaim(
     defer std.crypto.secureZero(u8, @volatileCast(proof.bytes[0..]));
     const actual = proof_verifier(proof, grant, observer_policy);
     if (!std.mem.eql(u8, &actual, &authority.value.verifier)) {
-        return error.InvalidHolderProof;
+        return failReloadedAuthorityClaim(error.InvalidHolderProof);
     }
     return operation.ownAuthorityClaim(alloc, .{
         .principal = input.principal,
@@ -2515,6 +2515,26 @@ pub fn reloadAuthorityClaim(
         .generation = input.generation,
         .proof = proof,
     }, controls);
+}
+
+inline fn failReloadedAuthorityClaim(err: anytype) @TypeOf(err)!operation.OwnedAuthorityClaim {
+    return @errorCast(failReloadedAuthorityClaimDynamic(err));
+}
+
+noinline fn failReloadedAuthorityClaimDynamic(err: anyerror) anyerror!operation.OwnedAuthorityClaim {
+    return err;
+}
+
+test "reloaded authority failures preserve exact error types and identities" {
+    const revoked = failReloadedAuthorityClaim(error.AuthorityRevoked);
+    try std.testing.expect(
+        @TypeOf(revoked) == error{AuthorityRevoked}!operation.OwnedAuthorityClaim,
+    );
+    try std.testing.expectError(error.AuthorityRevoked, revoked);
+    try std.testing.expectError(
+        error.InvalidHolderProof,
+        failReloadedAuthorityClaim(error.InvalidHolderProof),
+    );
 }
 
 pub const RecoveredExecutionScope = struct {

--- a/src/core/tooling/tool_args.zig
+++ b/src/core/tooling/tool_args.zig
@@ -1,4 +1,77 @@
 const std = @import("std");
+const lexical_relevance = @import("../shared/lexical_relevance.zig");
+
+pub const OwnedSearchQueryInput = struct {
+    query: []u8,
+    prepared: lexical_relevance.PreparedQuery,
+
+    pub fn deinit(self: *OwnedSearchQueryInput, alloc: std.mem.Allocator) void {
+        alloc.free(self.query);
+        self.* = undefined;
+    }
+};
+
+pub const OwnedSearchQueryDecode = union(enum) {
+    failure: []u8,
+    input: *OwnedSearchQueryInput,
+};
+
+pub noinline fn decodeOwnedSearchQuery(
+    alloc: std.mem.Allocator,
+    args_json: []const u8,
+    tool_name: []const u8,
+) error{OutOfMemory}!OwnedSearchQueryDecode {
+    var parsed = std.json.parseFromSlice(std.json.Value, alloc, args_json, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return .{ .failure = try prefixedFailure(alloc, tool_name, " arguments must be valid JSON") },
+    };
+    defer parsed.deinit();
+
+    if (parsed.value != .object) {
+        return .{ .failure = try prefixedFailure(alloc, tool_name, " arguments must be an object") };
+    }
+    const query_value = parsed.value.object.get("query") orelse {
+        return .{ .failure = try prefixedFailure(alloc, tool_name, " field \"query\" is required") };
+    };
+    if (query_value != .string) {
+        return .{ .failure = try prefixedFailure(alloc, tool_name, " field \"query\" must be a string") };
+    }
+    if (query_value.string.len > lexical_relevance.max_query_bytes) {
+        return .{ .failure = try prefixedFailure(alloc, tool_name, " query must not exceed 4096 bytes") };
+    }
+
+    const query = try alloc.dupe(u8, query_value.string);
+    errdefer alloc.free(query);
+    const prepared = lexical_relevance.prepare(query) catch |err| switch (err) {
+        error.QueryTooLong => unreachable,
+        error.TooManyTokens => {
+            const body = try prefixedFailure(alloc, tool_name, " query must not exceed 64 tokens");
+            alloc.free(query);
+            return .{ .failure = body };
+        },
+    };
+    const input = try alloc.create(OwnedSearchQueryInput);
+    input.* = .{ .query = query, .prepared = prepared };
+    return .{ .input = input };
+}
+
+pub fn destroyOwnedSearchQueryInput(ptr: *anyopaque, alloc: std.mem.Allocator) void {
+    const input: *OwnedSearchQueryInput = @ptrCast(@alignCast(ptr));
+    input.deinit(alloc);
+    alloc.destroy(input);
+}
+
+noinline fn prefixedFailure(
+    alloc: std.mem.Allocator,
+    prefix: []const u8,
+    suffix: []const u8,
+) error{OutOfMemory}![]u8 {
+    const len = std.math.add(usize, prefix.len, suffix.len) catch return error.OutOfMemory;
+    const message = try alloc.alloc(u8, len);
+    @memcpy(message[0..prefix.len], prefix);
+    @memcpy(message[prefix.len..], suffix);
+    return message;
+}
 
 pub fn parseToolArgsObject(alloc: std.mem.Allocator, args_json: []const u8) !std.json.ObjectMap {
     const parsed = try std.json.parseFromSlice(std.json.Value, alloc, args_json, .{});

--- a/src/tools/capabilities/capability_search.zig
+++ b/src/tools/capabilities/capability_search.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const lexical_relevance = @import("../../core/shared/lexical_relevance.zig");
 const result_store = @import("../../core/session/result_store.zig");
+const tool_args = @import("../../core/tooling/tool_args.zig");
 const tool_dispatch = @import("../../core/tooling/tool_dispatch.zig");
 const tool_result_limits = @import("../../core/tooling/tool_result_limits.zig");
 const skill_search = @import("../skills/skill_search.zig");
@@ -8,15 +9,7 @@ const skill_search = @import("../skills/skill_search.zig");
 const Allocator = std.mem.Allocator;
 const mcp_result_limit: usize = 8;
 
-const Input = struct {
-    query: []u8,
-    prepared: lexical_relevance.PreparedQuery,
-
-    fn deinit(self: *Input, alloc: Allocator) void {
-        alloc.free(self.query);
-        self.* = undefined;
-    }
-};
+const Input = tool_args.OwnedSearchQueryInput;
 
 const ProjectionCheck = union(enum) {
     valid,
@@ -30,42 +23,10 @@ pub fn decode(
     ctx: tool_dispatch.DispatchContext,
     args_json: []const u8,
 ) tool_dispatch.DispatchError!tool_dispatch.DecodeResult {
-    var parsed = std.json.parseFromSlice(std.json.Value, ctx.allocator, args_json, .{}) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return failure(ctx.allocator, "capability_search arguments must be valid JSON"),
+    return switch (try tool_args.decodeOwnedSearchQuery(ctx.allocator, args_json, "capability_search")) {
+        .failure => |body| .{ .failure = body },
+        .input => |input| .{ .input = .{ .ptr = input, .deinit_fn = tool_args.destroyOwnedSearchQueryInput } },
     };
-    defer parsed.deinit();
-
-    if (parsed.value != .object) {
-        return failure(ctx.allocator, "capability_search arguments must be an object");
-    }
-    const query_value = parsed.value.object.get("query") orelse {
-        return failure(ctx.allocator, "capability_search field \"query\" is required");
-    };
-    if (query_value != .string) {
-        return failure(ctx.allocator, "capability_search field \"query\" must be a string");
-    }
-    if (query_value.string.len > lexical_relevance.max_query_bytes) {
-        return failure(ctx.allocator, "capability_search query must not exceed 4096 bytes");
-    }
-
-    const query = try ctx.allocator.dupe(u8, query_value.string);
-    errdefer ctx.allocator.free(query);
-    const prepared = lexical_relevance.prepare(query) catch |err| switch (err) {
-        error.QueryTooLong => unreachable,
-        error.TooManyTokens => {
-            const result = try failure(
-                ctx.allocator,
-                "capability_search query must not exceed 64 tokens",
-            );
-            ctx.allocator.free(query);
-            return result;
-        },
-    };
-    const input = try ctx.allocator.create(Input);
-    errdefer ctx.allocator.destroy(input);
-    input.* = .{ .query = query, .prepared = prepared };
-    return .{ .input = .{ .ptr = input, .deinit_fn = inputDeinit } };
 }
 
 pub fn validate(
@@ -118,16 +79,6 @@ pub fn readsOnly(_: tool_dispatch.ToolInput) bool {
 
 pub fn isIrreversible(_: tool_dispatch.ToolInput) bool {
     return false;
-}
-
-fn inputDeinit(ptr: *anyopaque, alloc: Allocator) void {
-    const input: *Input = @ptrCast(@alignCast(ptr));
-    input.deinit(alloc);
-    alloc.destroy(input);
-}
-
-fn failure(alloc: Allocator, message: []const u8) Allocator.Error!tool_dispatch.DecodeResult {
-    return .{ .failure = try alloc.dupe(u8, message) };
 }
 
 fn executionFailure(

--- a/src/tools/skills/skill_search.zig
+++ b/src/tools/skills/skill_search.zig
@@ -4,21 +4,14 @@ const context_limits = @import("../../core/config/context_limits.zig");
 const lexical_relevance = @import("../../core/shared/lexical_relevance.zig");
 const result_store = @import("../../core/session/result_store.zig");
 const skill_runtime = @import("../../core/skills/skill_runtime.zig");
+const tool_args = @import("../../core/tooling/tool_args.zig");
 const tool_dispatch = @import("../../core/tooling/tool_dispatch.zig");
 const tool_result_limits = @import("../../core/tooling/tool_result_limits.zig");
 
 const Allocator = std.mem.Allocator;
 const max_results: usize = 8;
 
-const Input = struct {
-    query: []u8,
-    prepared: lexical_relevance.PreparedQuery,
-
-    pub fn deinit(self: *Input, alloc: Allocator) void {
-        alloc.free(self.query);
-        self.* = undefined;
-    }
-};
+const Input = tool_args.OwnedSearchQueryInput;
 
 const Match = struct {
     skill: *const skill_runtime.Skill,
@@ -41,42 +34,10 @@ pub fn decode(
     ctx: tool_dispatch.DispatchContext,
     args_json: []const u8,
 ) tool_dispatch.DispatchError!tool_dispatch.DecodeResult {
-    var parsed = std.json.parseFromSlice(std.json.Value, ctx.allocator, args_json, .{}) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return failure(ctx.allocator, "skill_search arguments must be valid JSON"),
+    return switch (try tool_args.decodeOwnedSearchQuery(ctx.allocator, args_json, "skill_search")) {
+        .failure => |body| .{ .failure = body },
+        .input => |input| .{ .input = .{ .ptr = input, .deinit_fn = tool_args.destroyOwnedSearchQueryInput } },
     };
-    defer parsed.deinit();
-
-    if (parsed.value != .object) {
-        return failure(ctx.allocator, "skill_search arguments must be an object");
-    }
-    const query_value = parsed.value.object.get("query") orelse {
-        return failure(ctx.allocator, "skill_search field \"query\" is required");
-    };
-    if (query_value != .string) {
-        return failure(ctx.allocator, "skill_search field \"query\" must be a string");
-    }
-    if (query_value.string.len > lexical_relevance.max_query_bytes) {
-        return failure(ctx.allocator, "skill_search query must not exceed 4096 bytes");
-    }
-
-    const query = try ctx.allocator.dupe(u8, query_value.string);
-    errdefer ctx.allocator.free(query);
-    const prepared = lexical_relevance.prepare(query) catch |err| switch (err) {
-        error.QueryTooLong => unreachable,
-        error.TooManyTokens => {
-            const result = try failure(
-                ctx.allocator,
-                "skill_search query must not exceed 64 tokens",
-            );
-            ctx.allocator.free(query);
-            return result;
-        },
-    };
-    const input = try ctx.allocator.create(Input);
-    errdefer ctx.allocator.destroy(input);
-    input.* = .{ .query = query, .prepared = prepared };
-    return .{ .input = .{ .ptr = input, .deinit_fn = inputDeinit } };
 }
 
 pub fn validate(
@@ -135,16 +96,6 @@ pub fn readsOnly(_: tool_dispatch.ToolInput) bool {
 
 pub fn isIrreversible(_: tool_dispatch.ToolInput) bool {
     return false;
-}
-
-fn inputDeinit(ptr: *anyopaque, alloc: Allocator) void {
-    const input: *Input = @ptrCast(@alignCast(ptr));
-    input.deinit(alloc);
-    alloc.destroy(input);
-}
-
-fn failure(alloc: Allocator, message: []const u8) Allocator.Error!tool_dispatch.DecodeResult {
-    return .{ .failure = try alloc.dupe(u8, message) };
 }
 
 fn reportDiagnostics(


### PR DESCRIPTION
## Summary

- Keep capability and skill search schemas, bounds, rankings, and outputs unchanged.
- Keep control-record and terminal-authority error identities unchanged.
- Remove 4,999 bytes of macOS arm64 ReleaseSafe `__TEXT`; file size remains unchanged until the next 16 KiB alignment boundary.