### PR TITLE
Show recent tool calls while streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, press Enter to queue a follow-up or Ctrl+Enter to steer the active turn at its next model boundary. If the turn has already closed, fx safely queues the steering prompt as the next turn.
 
-Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O.
+Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show the latest five calls while a turn is active, then one summary per tool-call group when the turn finishes. Individual calls remain available in the full transcript with Ctrl+O.
 
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ fx
 
 The current directory becomes the primary workspace. Enter a prompt, or run `/help` to browse interactive commands. While fx is working, press Enter to queue a follow-up or Ctrl+Enter to steer the active turn at its next model boundary. If the turn has already closed, fx safely queues the steering prompt as the next turn.
 
-Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show the latest five calls while a turn is active, then one summary per tool-call group when the turn finishes. Individual calls remain available in the full transcript with Ctrl+O.
+Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show the latest five calls from the active tool group, then collapse that group to one summary as soon as all of its calls finish. Individual calls remain available in the full transcript with Ctrl+O.
 
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -256,7 +256,7 @@ const specs = [_]Spec{
     .{ .id = .statusline_session, .category = .interface, .label = "Status line session", .description = "Show the session title in the status line" },
     .{ .id = .statusline_workspace, .category = .interface, .label = "Status line workspace", .description = "Show the workspace path and Git branch in the status line" },
     .{ .id = .slash_menu_categories, .category = .interface, .label = "Slash menu categories", .description = "Show categories and skill sources in slash-command results" },
-    .{ .id = .collapse_tool_calls, .category = .interface, .label = "Collapse tool calls", .description = "Show five live calls, then one summary per group" },
+    .{ .id = .collapse_tool_calls, .category = .interface, .label = "Collapse tool calls", .description = "Show five calls until each tool group finishes" },
     .{ .id = .model, .category = .agent, .label = "Model", .description = "Choose the model used for new turns" },
     .{ .id = .effort, .category = .agent, .label = "Reasoning effort", .description = "Control how much reasoning the model applies" },
     .{ .id = .fast_mode, .category = .agent, .label = "Fast mode", .description = "Use faster inference when the model supports it" },

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -256,7 +256,7 @@ const specs = [_]Spec{
     .{ .id = .statusline_session, .category = .interface, .label = "Status line session", .description = "Show the session title in the status line" },
     .{ .id = .statusline_workspace, .category = .interface, .label = "Status line workspace", .description = "Show the workspace path and Git branch in the status line" },
     .{ .id = .slash_menu_categories, .category = .interface, .label = "Slash menu categories", .description = "Show categories and skill sources in slash-command results" },
-    .{ .id = .collapse_tool_calls, .category = .interface, .label = "Collapse tool calls", .description = "Show only a summary for each group of tool calls" },
+    .{ .id = .collapse_tool_calls, .category = .interface, .label = "Collapse tool calls", .description = "Show five live calls, then one summary per group" },
     .{ .id = .model, .category = .agent, .label = "Model", .description = "Choose the model used for new turns" },
     .{ .id = .effort, .category = .agent, .label = "Reasoning effort", .description = "Control how much reasoning the model applies" },
     .{ .id = .fast_mode, .category = .agent, .label = "Fast mode", .description = "Use faster inference when the model supports it" },

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -4584,6 +4584,13 @@ pub const TranscriptRuntime = struct {
         return self.lifecycle_state.finalized_turn_watermark;
     }
 
+    pub fn toolTurnPresentationWatermark(self: *const TranscriptRuntime) u64 {
+        return @max(
+            self.lifecycle_state.finalized_turn_watermark,
+            self.lifecycle_state.batch_finalized_turn_watermark orelse 0,
+        );
+    }
+
     pub fn clearTranscript(self: *TranscriptRuntime, alloc: Allocator) void {
         const pending_resume_bytes = self.releasePendingResumeSource(alloc);
         if (pending_resume_bytes > 0) {

--- a/src/ui/transcript/source_preparation.zig
+++ b/src/ui/transcript/source_preparation.zig
@@ -788,13 +788,14 @@ fn buildCompactTranscriptProjectionInterruptible(
     focused_entry_id: ?u32,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
 ) !tool_group_projection.Projection {
-    var projection = try tool_group_projection.buildStyledFocusedInterruptible(
+    var projection = try tool_group_projection.buildStyledFocusedWithFinalityInterruptible(
         alloc,
         self.entries.items,
         self.tool_details.items,
         self.layout.cols,
         focused_entry_id,
         collapseToolCalls(self),
+        toolTurnPresentationWatermark(self),
         .{
             .marker_style = user_message_card.promptMarkerStyle(),
             .text_style = ui_render.statusline_style,
@@ -914,6 +915,14 @@ fn collapseToolCalls(self: anytype) bool {
         self.collapse_tool_calls
     else
         false;
+}
+
+fn toolTurnPresentationWatermark(self: anytype) u64 {
+    const Shell = @TypeOf(self.*);
+    return if (comptime @hasDecl(Shell, "toolTurnPresentationWatermark"))
+        self.toolTurnPresentationWatermark()
+    else
+        std.math.maxInt(u64);
 }
 
 fn observationEnabled(self: anytype, alloc: Allocator) bool {

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -571,17 +571,21 @@ fn collapsedGroupMode(
     detail_indices: *const std.AutoHashMapUnmanaged(u32, usize),
 ) ?CollapsedGroupMode {
     if (!collapse_tool_calls) return null;
+
+    var concrete_group_id: ?types.ToolPresentationGroupId = null;
+    var concrete_group_terminal = true;
     for (status_indices) |status_index| {
         const entry_id = toolStatusEntryId(entries[status_index]) orelse continue;
         const detail = detailForEntry(details, detail_indices, entry_id, null) orelse continue;
-        const turn_id = if (detail.presentation_group_id) |group|
-            group.turn_id
-        else if (detail.lifecycle_id) |lifecycle|
-            lifecycle.turn_id
-        else
+        if (detail.presentation_group_id) |group_id| {
+            concrete_group_id = group_id;
+            concrete_group_terminal = concrete_group_terminal and detail.outcome != null;
             continue;
-        if (turn_id > finalized_turn_watermark) return .live_tail;
+        }
+        const lifecycle = detail.lifecycle_id orelse continue;
+        if (lifecycle.turn_id > finalized_turn_watermark) return .live_tail;
     }
+    if (concrete_group_id != null and !concrete_group_terminal) return .live_tail;
     return .summary;
 }
 
@@ -1152,7 +1156,7 @@ test "collapsed tool groups render only the summary header" {
     try std.testing.expect(projection.entry_actions.items[1] == .hide);
 }
 
-test "collapsed live tool groups show the latest five calls until turn finalization" {
+test "collapsed live tool groups show the latest five calls until batch finalization" {
     const alloc = std.testing.allocator;
     const entries = [_]TranscriptEntry{
         .{ .raw_bytes = .{ .id = 1, .bytes = @constCast("● Read one\n"), .class = .tool_status } },
@@ -1162,13 +1166,14 @@ test "collapsed live tool groups show the latest five calls until turn finalizat
         .{ .raw_bytes = .{ .id = 5, .bytes = @constCast("● Read five\n"), .class = .tool_status } },
         .{ .raw_bytes = .{ .id = 6, .bytes = @constCast("● Read six\n"), .class = .tool_status } },
     };
-    const details = [_]ToolDetailRecord{
-        .{ .entry_id = 1, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "one" } },
-        .{ .entry_id = 2, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "two" } },
-        .{ .entry_id = 3, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "three" } },
-        .{ .entry_id = 4, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "four" } },
-        .{ .entry_id = 5, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "five" } },
-        .{ .entry_id = 6, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "six" } },
+    const group_id: types.ToolPresentationGroupId = .{ .turn_id = 1, .anchor_step_id = 1 };
+    var details = [_]ToolDetailRecord{
+        .{ .entry_id = 1, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "one" }, .presentation_group_id = group_id },
+        .{ .entry_id = 2, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "two" }, .presentation_group_id = group_id },
+        .{ .entry_id = 3, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "three" }, .presentation_group_id = group_id },
+        .{ .entry_id = 4, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "four" }, .presentation_group_id = group_id },
+        .{ .entry_id = 5, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "five" }, .presentation_group_id = group_id },
+        .{ .entry_id = 6, .tool_name = @constCast("read_file"), .activity_kind = .read, .lifecycle_id = .{ .turn_id = 1, .call_id = "six" }, .presentation_group_id = group_id },
     };
 
     var live = try buildStyledFocusedWithFinalityInterruptible(
@@ -1178,7 +1183,7 @@ test "collapsed live tool groups show the latest five calls until turn finalizat
         120,
         null,
         true,
-        0,
+        std.math.maxInt(u64),
         .{},
         .{},
         null,
@@ -1194,6 +1199,7 @@ test "collapsed live tool groups show the latest five calls until turn finalizat
         live.entry_actions.items[0].override.bytes,
     );
 
+    details[5].outcome = .completed;
     var finalized = try buildStyledFocusedWithFinalityInterruptible(
         alloc,
         &entries,
@@ -1201,7 +1207,7 @@ test "collapsed live tool groups show the latest five calls until turn finalizat
         120,
         null,
         true,
-        1,
+        0,
         .{},
         .{},
         null,

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -118,6 +118,8 @@ const BuildStats = struct {
 };
 
 const ProjectionMode = enum { compact, expanded };
+const CollapsedGroupMode = enum { summary, live_tail };
+const live_tool_call_limit = 5;
 
 const category_labels = [_][]const u8{
     "read",
@@ -438,13 +440,13 @@ fn formatGroupBlock(
     detail_indices: *const std.AutoHashMapUnmanaged(u32, usize),
     summary: Summary,
     focused_entry_id: ?u32,
-    collapse_tool_calls: bool,
+    collapsed_group_mode: ?CollapsedGroupMode,
     cols: u16,
     style: SummaryStyle,
     styles: transcript_blocks.Styles,
 ) ![]u8 {
     const header = try formatGroupHeader(alloc, summary, cols, style);
-    if (collapse_tool_calls) return header;
+    if (collapsed_group_mode == .summary) return header;
     defer alloc.free(header);
 
     var focused_in_group = false;
@@ -469,6 +471,10 @@ fn formatGroupBlock(
     errdefer out.deinit();
     try out.writer.writeAll(header);
 
+    const static_start = if (collapsed_group_mode == .live_tail)
+        static_count -| live_tool_call_limit
+    else
+        0;
     var static_index: usize = 0;
     for (status_indices) |status_index| {
         const entry = entries[status_index];
@@ -481,6 +487,7 @@ fn formatGroupBlock(
             else => null,
         } orelse if (detail) |record| record.tool_name else "tool activity";
         static_index += 1;
+        if (static_index <= static_start) continue;
         const connector = if (!focused_in_group and static_index == static_count) "└" else "├";
         const child = try std.fmt.allocPrint(scratch, "{s} {s}", .{ connector, phrase });
         const clipped = try clipSummary(scratch, child, cols);
@@ -553,6 +560,29 @@ fn installExpandedGroup(
             try alloc.dupe(u8, child);
         try projection.setOwnedOverride(alloc, status_index, .tool_status, bytes);
     }
+}
+
+fn collapsedGroupMode(
+    collapse_tool_calls: bool,
+    finalized_turn_watermark: u64,
+    status_indices: []const usize,
+    entries: []const TranscriptEntry,
+    details: []const ToolDetailRecord,
+    detail_indices: *const std.AutoHashMapUnmanaged(u32, usize),
+) ?CollapsedGroupMode {
+    if (!collapse_tool_calls) return null;
+    for (status_indices) |status_index| {
+        const entry_id = toolStatusEntryId(entries[status_index]) orelse continue;
+        const detail = detailForEntry(details, detail_indices, entry_id, null) orelse continue;
+        const turn_id = if (detail.presentation_group_id) |group|
+            group.turn_id
+        else if (detail.lifecycle_id) |lifecycle|
+            lifecycle.turn_id
+        else
+            continue;
+        if (turn_id > finalized_turn_watermark) return .live_tail;
+    }
+    return .summary;
 }
 
 fn presentationGroupId(
@@ -647,7 +677,7 @@ fn build(
     details: []const ToolDetailRecord,
     cols: u16,
 ) !Projection {
-    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, .{}, .{}, .compact, null, null) catch |err| switch (err) {
+    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, std.math.maxInt(u64), .{}, .{}, .compact, null, null) catch |err| switch (err) {
         error.InputPending => unreachable,
         else => |other| return other,
     };
@@ -661,7 +691,7 @@ pub fn buildStyled(
     style: SummaryStyle,
     styles: transcript_blocks.Styles,
 ) !Projection {
-    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, style, styles, .compact, null, null) catch |err| switch (err) {
+    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, std.math.maxInt(u64), style, styles, .compact, null, null) catch |err| switch (err) {
         error.InputPending => unreachable,
         else => |other| return other,
     };
@@ -676,7 +706,7 @@ pub fn buildExpandedStyledInterruptible(
     styles: transcript_blocks.Styles,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
 ) !Projection {
-    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, style, styles, .expanded, null, checkpoint);
+    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, std.math.maxInt(u64), style, styles, .expanded, null, checkpoint);
 }
 
 pub fn buildExpandedRelationshipsInterruptible(
@@ -692,6 +722,7 @@ pub fn buildExpandedRelationshipsInterruptible(
         std.math.maxInt(u16),
         null,
         false,
+        std.math.maxInt(u64),
         .{},
         .{},
         .expanded,
@@ -797,6 +828,32 @@ pub fn buildStyledFocusedInterruptible(
     styles: transcript_blocks.Styles,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
 ) !Projection {
+    return buildStyledFocusedWithFinalityInterruptible(
+        alloc,
+        entries,
+        details,
+        cols,
+        focused_entry_id,
+        collapse_tool_calls,
+        std.math.maxInt(u64),
+        style,
+        styles,
+        checkpoint,
+    );
+}
+
+pub fn buildStyledFocusedWithFinalityInterruptible(
+    alloc: std.mem.Allocator,
+    entries: []const TranscriptEntry,
+    details: []const ToolDetailRecord,
+    cols: u16,
+    focused_entry_id: ?u32,
+    collapse_tool_calls: bool,
+    finalized_turn_watermark: u64,
+    style: SummaryStyle,
+    styles: transcript_blocks.Styles,
+    checkpoint: ?*build_checkpoint.BuildCheckpoint,
+) !Projection {
     return buildWithStyleAndStats(
         alloc,
         entries,
@@ -804,6 +861,7 @@ pub fn buildStyledFocusedInterruptible(
         cols,
         focused_entry_id,
         collapse_tool_calls,
+        finalized_turn_watermark,
         style,
         styles,
         .compact,
@@ -819,7 +877,7 @@ fn buildWithStats(
     cols: u16,
     stats: ?*BuildStats,
 ) !Projection {
-    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, .{}, .{}, .compact, stats, null);
+    return buildWithStyleAndStats(alloc, entries, details, cols, null, false, std.math.maxInt(u64), .{}, .{}, .compact, stats, null);
 }
 
 fn buildWithStyleAndStats(
@@ -829,6 +887,7 @@ fn buildWithStyleAndStats(
     cols: u16,
     focused_entry_id: ?u32,
     collapse_tool_calls: bool,
+    finalized_turn_watermark: u64,
     style: SummaryStyle,
     styles: transcript_blocks.Styles,
     mode: ProjectionMode,
@@ -1002,7 +1061,14 @@ fn buildWithStyleAndStats(
                 &detail_indices,
                 group.summary,
                 focused_entry_id,
-                collapse_tool_calls,
+                collapsedGroupMode(
+                    collapse_tool_calls,
+                    finalized_turn_watermark,
+                    group.status_indices.items,
+                    entries,
+                    details,
+                    &detail_indices,
+                ),
                 cols,
                 style,
                 styles,
@@ -1049,7 +1115,14 @@ fn buildWithStyleAndStats(
             &detail_indices,
             summary,
             focused_entry_id,
-            collapse_tool_calls,
+            collapsedGroupMode(
+                collapse_tool_calls,
+                finalized_turn_watermark,
+                status_indices.items,
+                entries,
+                details,
+                &detail_indices,
+            ),
             cols,
             style,
             styles,
@@ -1077,6 +1150,67 @@ test "collapsed tool groups render only the summary header" {
     try std.testing.expect(std.mem.find(u8, block, "2 tool calls") != null);
     try std.testing.expect(std.mem.find(u8, block, "Read file") == null);
     try std.testing.expect(projection.entry_actions.items[1] == .hide);
+}
+
+test "collapsed live tool groups show the latest five calls until turn finalization" {
+    const alloc = std.testing.allocator;
+    const entries = [_]TranscriptEntry{
+        .{ .raw_bytes = .{ .id = 1, .bytes = @constCast("● Read one\n"), .class = .tool_status } },
+        .{ .raw_bytes = .{ .id = 2, .bytes = @constCast("● Read two\n"), .class = .tool_status } },
+        .{ .raw_bytes = .{ .id = 3, .bytes = @constCast("● Read three\n"), .class = .tool_status } },
+        .{ .raw_bytes = .{ .id = 4, .bytes = @constCast("● Read four\n"), .class = .tool_status } },
+        .{ .raw_bytes = .{ .id = 5, .bytes = @constCast("● Read five\n"), .class = .tool_status } },
+        .{ .raw_bytes = .{ .id = 6, .bytes = @constCast("● Read six\n"), .class = .tool_status } },
+    };
+    const details = [_]ToolDetailRecord{
+        .{ .entry_id = 1, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "one" } },
+        .{ .entry_id = 2, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "two" } },
+        .{ .entry_id = 3, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "three" } },
+        .{ .entry_id = 4, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "four" } },
+        .{ .entry_id = 5, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "five" } },
+        .{ .entry_id = 6, .tool_name = @constCast("read_file"), .activity_kind = .read, .outcome = .completed, .lifecycle_id = .{ .turn_id = 1, .call_id = "six" } },
+    };
+
+    var live = try buildStyledFocusedWithFinalityInterruptible(
+        alloc,
+        &entries,
+        &details,
+        120,
+        null,
+        true,
+        0,
+        .{},
+        .{},
+        null,
+    );
+    defer live.deinit(alloc);
+    try std.testing.expectEqualStrings(
+        "● 6 tool calls · 6 read\n" ++
+            "├ Read two\n" ++
+            "├ Read three\n" ++
+            "├ Read four\n" ++
+            "├ Read five\n" ++
+            "└ Read six",
+        live.entry_actions.items[0].override.bytes,
+    );
+
+    var finalized = try buildStyledFocusedWithFinalityInterruptible(
+        alloc,
+        &entries,
+        &details,
+        120,
+        null,
+        true,
+        1,
+        .{},
+        .{},
+        null,
+    );
+    defer finalized.deinit(alloc);
+    try std.testing.expectEqualStrings(
+        "● 6 tool calls · 6 read",
+        finalized.entry_actions.items[0].override.bytes,
+    );
 }
 
 test "tool relationship grouping retries cleanly after cancellation" {

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -483,6 +484,79 @@ describe("fx ask presentation", () => {
     expect(gateway.requests).toHaveLength(2);
     expect(result.stderr).toContain("Reading fixture.txt");
   }, TIMEOUT);
+
+  test.skipIf(!tmuxAvailable())(
+    "collapsed TTY tool groups show the latest five calls while active",
+    async () => {
+      const root = createRoot();
+      const fxDir = join(root.home, ".fx");
+      const settingsPath = join(fxDir, "settings.json");
+      mkdirSync(fxDir, { mode: 0o700 });
+      chmodSync(fxDir, 0o700);
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({ collapse_tool_calls: true }),
+        { mode: 0o600 },
+      );
+      chmodSync(settingsPath, 0o600);
+      for (let index = 1; index <= 6; index += 1) {
+        writeFileSync(join(root.workspace, `fixture-${index}.txt`), `${index}\n`);
+      }
+      let releaseFinal: (() => void) | undefined;
+      const finalReady = new Promise<void>((resolve) => {
+        releaseFinal = resolve;
+      });
+      const gateway = startFakeGateway([
+        fakeGatewaySse([
+          ...Array.from({ length: 6 }, (_, index) => ({
+            type: "tool-call",
+            toolCallId: `read_fixture_${index + 1}`,
+            toolName: "read_file",
+            input: { path: `fixture-${index + 1}.txt` },
+          })),
+          {
+            type: "finish",
+            finishReason: { unified: "tool-calls", raw: "tool-calls" },
+          },
+        ]),
+        async () => {
+          await finalReady;
+          return fakeGatewayFinalText("All fixtures inspected.\n");
+        },
+      ]);
+      gateways.push(gateway);
+
+      const session = await TmuxSession.create({
+        isolated: true,
+        cmd: terminalCommand([]),
+        cwd: root.workspace,
+        env: { ...gatewayEnv(root.home, gateway), NO_COLOR: undefined },
+        width: 120,
+        height: 40,
+        remainOnExit: true,
+      });
+      sessions.push(session);
+      await session.waitForText("Run /help for commands", TIMEOUT);
+      await session.sendText("Inspect all fixture files.");
+
+      await session.waitForText("6 tool calls · 6 read", TIMEOUT);
+      const activePane = await session.capturePane();
+      expect(activePane).not.toContain("Reading fixture-1.txt");
+      for (let index = 2; index <= 6; index += 1) {
+        expect(activePane).toContain(`Read fixture-${index}.txt`);
+      }
+
+      releaseFinal!();
+      await session.waitForText("All fixtures inspected.", TIMEOUT);
+      const finalPane = await session.capturePane();
+      expect(finalPane).toContain("6 tool calls · 6 read");
+      for (let index = 1; index <= 6; index += 1) {
+        expect(finalPane).not.toContain(`Read fixture-${index}.txt`);
+      }
+      expect(finalPane).toContain("All fixtures inspected.");
+    },
+    TIMEOUT,
+  );
 
   test.skipIf(!tmuxAvailable())(
     "TTY stdout uses the Minimal transcript and compact tool group",

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -486,7 +486,7 @@ describe("fx ask presentation", () => {
   }, TIMEOUT);
 
   test.skipIf(!tmuxAvailable())(
-    "collapsed TTY tool groups show the latest five calls while active",
+    "collapsed TTY tool groups collapse each completed batch before the turn ends",
     async () => {
       const root = createRoot();
       const fxDir = join(root.home, ".fx");
@@ -519,6 +519,23 @@ describe("fx ask presentation", () => {
             finishReason: { unified: "tool-calls", raw: "tool-calls" },
           },
         ]),
+        fakeGatewaySse([
+          {
+            type: "text-delta",
+            id: "batch_separator",
+            delta: "First batch inspected.\n",
+          },
+          {
+            type: "tool-call",
+            toolCallId: "read_fixture_1_again",
+            toolName: "read_file",
+            input: { path: "fixture-1.txt" },
+          },
+          {
+            type: "finish",
+            finishReason: { unified: "tool-calls", raw: "tool-calls" },
+          },
+        ]),
         async () => {
           await finalReady;
           return fakeGatewayFinalText("All fixtures inspected.\n");
@@ -532,28 +549,34 @@ describe("fx ask presentation", () => {
         cwd: root.workspace,
         env: { ...gatewayEnv(root.home, gateway), NO_COLOR: undefined },
         width: 120,
-        height: 40,
+        height: 12,
         remainOnExit: true,
       });
       sessions.push(session);
       await session.waitForText("Run /help for commands", TIMEOUT);
       await session.sendText("Inspect all fixture files.");
 
-      await session.waitForText("6 tool calls · 6 read", TIMEOUT);
+      const requestDeadline = Date.now() + TIMEOUT;
+      while (gateway.requestCount() < 3 && Date.now() < requestDeadline) {
+        await Bun.sleep(25);
+      }
+      expect(gateway.requestCount()).toBe(3);
       const activePane = await session.capturePane();
-      expect(activePane).not.toContain("Reading fixture-1.txt");
-      for (let index = 2; index <= 6; index += 1) {
-        expect(activePane).toContain(`Read fixture-${index}.txt`);
+      expect(activePane).toContain("6 tool calls · 6 read");
+      expect(activePane).toContain("1 tool call · 1 read");
+      for (let index = 1; index <= 6; index += 1) {
+        expect(activePane).not.toContain(`Read fixture-${index}.txt`);
       }
 
       releaseFinal!();
       await session.waitForText("All fixtures inspected.", TIMEOUT);
-      const finalPane = await session.capturePane();
-      expect(finalPane).toContain("6 tool calls · 6 read");
+      const finalScrollback = await session.captureFullScrollback();
+      expect(finalScrollback).toContain("6 tool calls · 6 read");
+      expect(finalScrollback).toContain("1 tool call · 1 read");
       for (let index = 1; index <= 6; index += 1) {
-        expect(finalPane).not.toContain(`Read fixture-${index}.txt`);
+        expect(finalScrollback).not.toContain(`Read fixture-${index}.txt`);
       }
-      expect(finalPane).toContain("All fixtures inspected.");
+      expect(finalScrollback).toContain("All fixtures inspected.");
     },
     TIMEOUT,
   );


### PR DESCRIPTION
## TL;DR

Collapsed tool groups now preserve useful live progress without leaving completed turns expanded.

## Issue

- Collapsed groups hide all tool activity during active turns
- Users cannot see recent progress without opening full transcript

## Fix

- Show the latest five calls while a turn is active
- Collapse the group when the turn finishes
- Preserve every call in the full transcript