### PR TITLE
Replace code block frames with solid rules

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -3919,13 +3919,13 @@ test "semantic code block preserves indentation on wrapped continuation rows" {
     const wide = try transcript_runtime.renderEntriesToBytes(alloc, entries.items, 80, .{});
     defer alloc.free(wide);
     try std.testing.expect(std.mem.find(u8, wide, "text") != null);
-    try std.testing.expect(std.mem.find(u8, wide, "┌") != null);
-    try std.testing.expect(std.mem.find(u8, wide, "└") != null);
+    try std.testing.expect(std.mem.find(u8, wide, "┈") != null);
+    try std.testing.expect(std.mem.find(u8, wide, "│") == null);
     try std.testing.expect(std.mem.find(u8, wide, "  abcdefghijkl") != null);
 
     const narrow = try transcript_runtime.renderEntriesToBytes(alloc, entries.items, 12, .{});
     defer alloc.free(narrow);
-    try std.testing.expect(std.mem.find(u8, narrow, "\n  │   efgh │\n") != null);
+    try std.testing.expect(std.mem.find(u8, narrow, "\n    ijkl\n") != null);
     var lines = std.mem.splitScalar(u8, narrow, '\n');
     while (lines.next()) |line| {
         try std.testing.expect(display_width.visibleWidthIgnoringAnsi(line) <= 12);

--- a/src/main.zig
+++ b/src/main.zig
@@ -3919,7 +3919,7 @@ test "semantic code block preserves indentation on wrapped continuation rows" {
     const wide = try transcript_runtime.renderEntriesToBytes(alloc, entries.items, 80, .{});
     defer alloc.free(wide);
     try std.testing.expect(std.mem.find(u8, wide, "text") != null);
-    try std.testing.expect(std.mem.find(u8, wide, "┈") != null);
+    try std.testing.expect(std.mem.find(u8, wide, "─") != null);
     try std.testing.expect(std.mem.find(u8, wide, "│") == null);
     try std.testing.expect(std.mem.find(u8, wide, "  abcdefghijkl") != null);
 

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -934,33 +934,29 @@ fn renderCodeBlockForTranscriptWithTheme(
     const code = styled_code orelse block.code;
 
     const max_code_width = maxCodeLineWidth(block.code);
-    const available_width: usize = cols;
-    const frame_would_wrap =
-        max_code_width > available_width -| 4 and max_code_width <= available_width;
-    if (cols <= 5 or frame_would_wrap) {
+    if (cols <= 5) {
         try renderUnboxedCode(alloc, code, cols, &rendered);
         return rendered.toOwnedSlice(alloc);
     }
 
     const panel_width = codePanelWidth(max_code_width, language, cols);
-    const inner_width = panel_width - 4;
     if (language.len > 0) {
         try appendCodePanelHeader(alloc, &rendered, panel_width, language);
     } else {
-        try appendCodePanelBorder(alloc, &rendered, panel_width, "┌", "┐");
+        try appendCodePanelRule(alloc, &rendered, panel_width);
     }
 
     var start: usize = 0;
     var emitted_line = false;
     while (start < code.len) {
         const end = std.mem.indexOfScalarPos(u8, code, start, '\n') orelse code.len;
-        try appendCodePanelLine(alloc, &rendered, code[start..end], inner_width);
+        try appendCodePanelLine(alloc, &rendered, code[start..end], panel_width);
         emitted_line = true;
         if (end == code.len) break;
         start = end + 1;
     }
-    if (!emitted_line) try appendCodePanelLine(alloc, &rendered, "", inner_width);
-    try appendCodePanelBorder(alloc, &rendered, panel_width, "└", "┘");
+    if (!emitted_line) try appendCodePanelLine(alloc, &rendered, "", panel_width);
+    try appendCodePanelRule(alloc, &rendered, panel_width);
     return rendered.toOwnedSlice(alloc);
 }
 
@@ -1031,9 +1027,9 @@ fn maxCodeLineWidth(code: []const u8) usize {
 fn codePanelWidth(max_code_width: usize, language: []const u8, cols: u16) usize {
     const label_width = if (language.len == 0) 0 else @min(
         display_width.visibleWidth(language),
-        @as(usize, cols) - 5,
+        @as(usize, cols) - 4,
     );
-    return @min(@as(usize, cols), @max(@as(usize, 6), @max(max_code_width + 4, label_width + 5)));
+    return @min(@as(usize, cols), @max(@as(usize, 6), @max(max_code_width, label_width + 4)));
 }
 
 fn appendCodePanelHeader(
@@ -1042,31 +1038,27 @@ fn appendCodePanelHeader(
     panel_width: usize,
     language: []const u8,
 ) !void {
-    const label_limit = panel_width - 5;
+    const label_limit = panel_width - 4;
     const label_prefix = display_width.prefixByWidth(language, label_limit);
     const label = if (label_prefix.len > 0) label_prefix else "?";
     const label_width = display_width.visibleWidth(label);
 
-    try out.appendSlice(alloc, "┌ ");
+    try out.appendSlice(alloc, "┈ ");
     try out.appendSlice(alloc, "\x1b[2m");
     try out.appendSlice(alloc, label);
     try out.appendSlice(alloc, "\x1b[22m ");
     var edge: usize = 0;
-    while (edge < panel_width - 4 - label_width) : (edge += 1) try out.appendSlice(alloc, "─");
-    try out.appendSlice(alloc, "┐\n");
+    while (edge < panel_width - 3 - label_width) : (edge += 1) try out.appendSlice(alloc, "┈");
+    try out.append(alloc, '\n');
 }
 
-fn appendCodePanelBorder(
+fn appendCodePanelRule(
     alloc: Allocator,
     out: *std.ArrayList(u8),
     panel_width: usize,
-    left: []const u8,
-    right: []const u8,
 ) !void {
-    try out.appendSlice(alloc, left);
     var edge: usize = 0;
-    while (edge < panel_width - 2) : (edge += 1) try out.appendSlice(alloc, "─");
-    try out.appendSlice(alloc, right);
+    while (edge < panel_width) : (edge += 1) try out.appendSlice(alloc, "┈");
     try out.append(alloc, '\n');
 }
 
@@ -1074,7 +1066,7 @@ fn appendCodePanelLine(
     alloc: Allocator,
     out: *std.ArrayList(u8),
     line: []const u8,
-    inner_width: usize,
+    panel_width: usize,
 ) !void {
     const indent = leadingCodeIndent(line);
     const indent_width = display_width.visibleWidth(indent);
@@ -1082,12 +1074,12 @@ fn appendCodePanelLine(
     var continuation = false;
     var style: CodeStyle = .{};
     if (remaining.len == 0) {
-        try appendPaddedCodeRow(alloc, out, "", .{}, "", .{}, inner_width);
+        try out.append(alloc, '\n');
         return;
     }
     while (remaining.len > 0) {
-        const continuation_indent = if (continuation and indent_width < inner_width) indent else "";
-        const available_width = inner_width - display_width.visibleWidth(continuation_indent);
+        const continuation_indent = if (continuation and indent_width < panel_width) indent else "";
+        const available_width = panel_width - display_width.visibleWidth(continuation_indent);
         var prefix = display_width.prefixByWidthIgnoringAnsi(remaining, available_width);
         if (firstCodeGlyph(prefix) == null) {
             const rune = firstCodeGlyph(remaining) orelse {
@@ -1097,7 +1089,7 @@ fn appendCodePanelLine(
             if (rune.width > available_width) {
                 var fallback_style = style;
                 fallback_style.apply(remaining[0..rune.start]);
-                try appendPaddedCodeRow(alloc, out, continuation_indent, fallback_style, "?", fallback_style, inner_width);
+                try appendCodeRow(alloc, out, continuation_indent, fallback_style, "?", fallback_style);
                 style = fallback_style;
                 remaining = remaining[rune.start + rune.len ..];
                 continuation = true;
@@ -1107,7 +1099,7 @@ fn appendCodePanelLine(
         }
         const row_style = style;
         style.apply(prefix);
-        try appendPaddedCodeRow(alloc, out, continuation_indent, row_style, prefix, style, inner_width);
+        try appendCodeRow(alloc, out, continuation_indent, row_style, prefix, style);
         remaining = remaining[prefix.len..];
         continuation = true;
     }
@@ -1119,23 +1111,19 @@ fn leadingCodeIndent(line: []const u8) []const u8 {
     return line[0..index];
 }
 
-fn appendPaddedCodeRow(
+fn appendCodeRow(
     alloc: Allocator,
     out: *std.ArrayList(u8),
     leading: []const u8,
     before: CodeStyle,
     content: []const u8,
     after: CodeStyle,
-    inner_width: usize,
 ) !void {
-    const visible = display_width.visibleWidthIgnoringAnsi(leading) + display_width.visibleWidthIgnoringAnsi(content);
-    try out.appendSlice(alloc, "│ ");
     try out.appendSlice(alloc, leading);
     if (before.foreground) |foreground| try out.appendSlice(alloc, foreground);
     try out.appendSlice(alloc, content);
     if (after.foreground != null) try out.appendSlice(alloc, "\x1b[0m");
-    try out.appendNTimes(alloc, ' ', inner_width -| visible);
-    try out.appendSlice(alloc, " │\n");
+    try out.append(alloc, '\n');
 }
 
 fn renderUnboxedCode(
@@ -2970,7 +2958,7 @@ test "notice palette changes leave non-system rendering unchanged" {
     try std.testing.expectEqualStrings(first, second);
 }
 
-test "renderCodeBlockForTranscript frames language labels in the top border" {
+test "renderCodeBlockForTranscript uses dotted horizontal rules without side rails" {
     const alloc = std.testing.allocator;
 
     const labeled_language = try alloc.dupe(u8, "zig");
@@ -2983,9 +2971,9 @@ test "renderCodeBlockForTranscript frames language labels in the top border" {
     }, 80);
     defer alloc.free(labeled);
     try std.testing.expectEqualStrings(
-        "┌ \x1b[2mzig\x1b[22m ─┐\n" ++
-            "│ x    │\n" ++
-            "└──────┘\n",
+        "┈ \x1b[2mzig\x1b[22m ┈\n" ++
+            "x\n" ++
+            "┈┈┈┈┈┈┈\n",
         labeled,
     );
 
@@ -2999,9 +2987,9 @@ test "renderCodeBlockForTranscript frames language labels in the top border" {
     }, 80);
     defer alloc.free(unlabeled);
     try std.testing.expectEqualStrings(
-        "┌────┐\n" ++
-            "│ x  │\n" ++
-            "└────┘\n",
+        "┈┈┈┈┈┈\n" ++
+            "x\n" ++
+            "┈┈┈┈┈┈\n",
         unlabeled,
     );
 
@@ -3015,9 +3003,9 @@ test "renderCodeBlockForTranscript frames language labels in the top border" {
     }, 8);
     defer alloc.free(truncated);
     try std.testing.expectEqualStrings(
-        "┌ \x1b[2mtyp\x1b[22m ─┐\n" ++
-            "│ x    │\n" ++
-            "└──────┘\n",
+        "┈ \x1b[2mtype\x1b[22m ┈\n" ++
+            "x\n" ++
+            "┈┈┈┈┈┈┈┈\n",
         truncated,
     );
 
@@ -3031,9 +3019,9 @@ test "renderCodeBlockForTranscript frames language labels in the top border" {
     }, 6);
     defer alloc.free(wide_rune);
     try std.testing.expectEqualStrings(
-        "┌ \x1b[2m?\x1b[22m ─┐\n" ++
-            "│ x  │\n" ++
-            "└────┘\n",
+        "┈ \x1b[2m漢\x1b[22m ┈\n" ++
+            "x\n" ++
+            "┈┈┈┈┈┈\n",
         wide_rune,
     );
 }
@@ -3082,7 +3070,7 @@ test "renderCodeBlockForTranscript highlights registered profiles without stylin
         .code = python_code,
     }, 80);
     defer alloc.free(python);
-    try std.testing.expect(std.mem.indexOf(u8, python, "┌ \x1b[2mpython\x1b[22m ─") != null);
+    try std.testing.expect(std.mem.indexOf(u8, python, "┈ \x1b[2mpython\x1b[22m ┈") != null);
     try std.testing.expect(std.mem.indexOf(u8, python, "\x1b[38;5;252mdef\x1b[39m") != null);
 
     const unknown_language = try alloc.dupe(u8, "brainfuck");
@@ -3134,7 +3122,7 @@ test "renderCodeBlockForTranscript infers registered high-confidence code blocks
         .code = code,
     }, 100);
     defer alloc.free(unlabeled);
-    try std.testing.expect(std.mem.indexOf(u8, unlabeled, "┌ \x1b[2mts\x1b[22m ─") != null);
+    try std.testing.expect(std.mem.indexOf(u8, unlabeled, "┈ \x1b[2mts\x1b[22m ┈") != null);
     try std.testing.expect(std.mem.indexOf(u8, unlabeled, "\x1b[38;5;252mconst\x1b[39m") != null);
     try std.testing.expect(std.mem.indexOf(u8, unlabeled, "\x1b[38;5;252mawait\x1b[39m") != null);
 
@@ -3147,7 +3135,7 @@ test "renderCodeBlockForTranscript infers registered high-confidence code blocks
         .code = json_code,
     }, 100);
     defer alloc.free(json);
-    try std.testing.expect(std.mem.indexOf(u8, json, "┌ \x1b[2mjson\x1b[22m ─") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "┈ \x1b[2mjson\x1b[22m ┈") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\x1b[38;5;250m\"ready\"\x1b[39m") != null);
 
     const ambiguous_language = try alloc.dupe(u8, "");
@@ -3171,11 +3159,11 @@ test "renderCodeBlockForTranscript infers registered high-confidence code blocks
         .code = explicit_unknown_code,
     }, 100);
     defer alloc.free(explicit_unknown);
-    try std.testing.expect(std.mem.indexOf(u8, explicit_unknown, "┌ \x1b[2mbrainfuck\x1b[22m ─") != null);
+    try std.testing.expect(std.mem.indexOf(u8, explicit_unknown, "┈ \x1b[2mbrainfuck\x1b[22m ┈") != null);
     try std.testing.expect(std.mem.indexOf(u8, explicit_unknown, "\x1b[38;5;") == null);
 }
 
-test "renderCodeBlockForTranscript contains CJK fallback color in boxed and unboxed rows" {
+test "renderCodeBlockForTranscript contains CJK fallback color in ruled and unboxed rows" {
     const alloc = std.testing.allocator;
     const language = try alloc.dupe(u8, "zig");
     defer alloc.free(language);
@@ -3186,28 +3174,28 @@ test "renderCodeBlockForTranscript contains CJK fallback color in boxed and unbo
         .code = code,
     };
 
-    const boxed = try renderCodeBlockForTranscript(alloc, block, 6);
-    defer alloc.free(boxed);
-    var boxed_grid = try vt_emulator.Grid.init(alloc, 6, 24);
-    defer boxed_grid.deinit();
-    try boxed_grid.feed(boxed);
-    try boxed_grid.feed("z");
+    const ruled = try renderCodeBlockForTranscript(alloc, block, 6);
+    defer alloc.free(ruled);
+    var ruled_grid = try vt_emulator.Grid.init(alloc, 6, 24);
+    defer ruled_grid.deinit();
+    try ruled_grid.feed(ruled);
+    try ruled_grid.feed("z");
 
-    var boxed_fallback: ?vt_emulator.Cell = null;
+    var ruled_wide_rune: ?vt_emulator.Cell = null;
     var row: u16 = 1;
     while (row <= 24) : (row += 1) {
         var col: u16 = 1;
         while (col <= 6) : (col += 1) {
-            const cell = boxed_grid.cellAt(row, col).?;
-            if (cell.codepoint == '?') boxed_fallback = cell;
-            if (cell.codepoint == '\u{2502}' or cell.codepoint == '\u{2500}' or cell.codepoint == ' ') {
+            const cell = ruled_grid.cellAt(row, col).?;
+            if (cell.codepoint == '\u{6f22}') ruled_wide_rune = cell;
+            if (cell.codepoint == '\u{2508}' or cell.codepoint == ' ') {
                 try std.testing.expect(cell.style.fg.eql(.default));
             }
             if (cell.codepoint == 'z') try std.testing.expect(cell.style.fg.eql(.default));
         }
     }
-    try std.testing.expect(boxed_fallback != null);
-    try std.testing.expect(boxed_fallback.?.style.fg.eql(.{ .indexed = 245 }));
+    try std.testing.expect(ruled_wide_rune != null);
+    try std.testing.expect(ruled_wide_rune.?.style.fg.eql(.{ .indexed = 245 }));
 
     const unboxed = try renderCodeBlockForTranscript(alloc, block, 1);
     defer alloc.free(unboxed);
@@ -4115,7 +4103,7 @@ test "renderEntriesToBytes indents semantic table and code rows" {
     defer alloc.free(out);
     try std.testing.expect(std.mem.startsWith(u8, out, "  ┌"));
     try std.testing.expect(std.mem.find(u8, out, "\n  │") != null);
-    try std.testing.expect(std.mem.find(u8, out, "\n\n  ┌ \x1b[2mzig") != null);
+    try std.testing.expect(std.mem.find(u8, out, "\n\n  ┈ \x1b[2mzig") != null);
 
     for (1..6) |width| {
         const cols: u16 = @intCast(width);
@@ -4309,8 +4297,8 @@ test "renderEntriesToBytes keeps semantic code as its own assistant entry" {
     defer alloc.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "Before code.").? < std.mem.indexOf(u8, out, "const").?);
     try std.testing.expect(std.mem.indexOf(u8, out, "const").? < std.mem.indexOf(u8, out, "After code.").?);
-    try std.testing.expect(std.mem.find(u8, out, "┌ \x1b[2mzig\x1b[22m ─") != null);
-    try std.testing.expect(std.mem.find(u8, out, "\x1b[2mzig\x1b[22m\n┌") == null);
+    try std.testing.expect(std.mem.find(u8, out, "┈ \x1b[2mzig\x1b[22m ┈") != null);
+    try std.testing.expect(std.mem.find(u8, out, "\x1b[2mzig\x1b[22m\n┈") == null);
 
     const narrow = try renderEntriesToBytes(alloc, entries.items, 6, .{});
     defer alloc.free(narrow);

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -1043,12 +1043,12 @@ fn appendCodePanelHeader(
     const label = if (label_prefix.len > 0) label_prefix else "?";
     const label_width = display_width.visibleWidth(label);
 
-    try out.appendSlice(alloc, "┈ ");
+    try out.appendSlice(alloc, "─ ");
     try out.appendSlice(alloc, "\x1b[2m");
     try out.appendSlice(alloc, label);
     try out.appendSlice(alloc, "\x1b[22m ");
     var edge: usize = 0;
-    while (edge < panel_width - 3 - label_width) : (edge += 1) try out.appendSlice(alloc, "┈");
+    while (edge < panel_width - 3 - label_width) : (edge += 1) try out.appendSlice(alloc, "─");
     try out.append(alloc, '\n');
 }
 
@@ -1058,7 +1058,7 @@ fn appendCodePanelRule(
     panel_width: usize,
 ) !void {
     var edge: usize = 0;
-    while (edge < panel_width) : (edge += 1) try out.appendSlice(alloc, "┈");
+    while (edge < panel_width) : (edge += 1) try out.appendSlice(alloc, "─");
     try out.append(alloc, '\n');
 }
 
@@ -2958,7 +2958,7 @@ test "notice palette changes leave non-system rendering unchanged" {
     try std.testing.expectEqualStrings(first, second);
 }
 
-test "renderCodeBlockForTranscript uses dotted horizontal rules without side rails" {
+test "renderCodeBlockForTranscript uses solid horizontal rules without side rails" {
     const alloc = std.testing.allocator;
 
     const labeled_language = try alloc.dupe(u8, "zig");
@@ -2971,9 +2971,9 @@ test "renderCodeBlockForTranscript uses dotted horizontal rules without side rai
     }, 80);
     defer alloc.free(labeled);
     try std.testing.expectEqualStrings(
-        "┈ \x1b[2mzig\x1b[22m ┈\n" ++
+        "─ \x1b[2mzig\x1b[22m ─\n" ++
             "x\n" ++
-            "┈┈┈┈┈┈┈\n",
+            "───────\n",
         labeled,
     );
 
@@ -2987,9 +2987,9 @@ test "renderCodeBlockForTranscript uses dotted horizontal rules without side rai
     }, 80);
     defer alloc.free(unlabeled);
     try std.testing.expectEqualStrings(
-        "┈┈┈┈┈┈\n" ++
+        "──────\n" ++
             "x\n" ++
-            "┈┈┈┈┈┈\n",
+            "──────\n",
         unlabeled,
     );
 
@@ -3003,9 +3003,9 @@ test "renderCodeBlockForTranscript uses dotted horizontal rules without side rai
     }, 8);
     defer alloc.free(truncated);
     try std.testing.expectEqualStrings(
-        "┈ \x1b[2mtype\x1b[22m ┈\n" ++
+        "─ \x1b[2mtype\x1b[22m ─\n" ++
             "x\n" ++
-            "┈┈┈┈┈┈┈┈\n",
+            "────────\n",
         truncated,
     );
 
@@ -3019,9 +3019,9 @@ test "renderCodeBlockForTranscript uses dotted horizontal rules without side rai
     }, 6);
     defer alloc.free(wide_rune);
     try std.testing.expectEqualStrings(
-        "┈ \x1b[2m漢\x1b[22m ┈\n" ++
+        "─ \x1b[2m漢\x1b[22m ─\n" ++
             "x\n" ++
-            "┈┈┈┈┈┈\n",
+            "──────\n",
         wide_rune,
     );
 }
@@ -3070,7 +3070,7 @@ test "renderCodeBlockForTranscript highlights registered profiles without stylin
         .code = python_code,
     }, 80);
     defer alloc.free(python);
-    try std.testing.expect(std.mem.indexOf(u8, python, "┈ \x1b[2mpython\x1b[22m ┈") != null);
+    try std.testing.expect(std.mem.indexOf(u8, python, "─ \x1b[2mpython\x1b[22m ─") != null);
     try std.testing.expect(std.mem.indexOf(u8, python, "\x1b[38;5;252mdef\x1b[39m") != null);
 
     const unknown_language = try alloc.dupe(u8, "brainfuck");
@@ -3122,7 +3122,7 @@ test "renderCodeBlockForTranscript infers registered high-confidence code blocks
         .code = code,
     }, 100);
     defer alloc.free(unlabeled);
-    try std.testing.expect(std.mem.indexOf(u8, unlabeled, "┈ \x1b[2mts\x1b[22m ┈") != null);
+    try std.testing.expect(std.mem.indexOf(u8, unlabeled, "─ \x1b[2mts\x1b[22m ─") != null);
     try std.testing.expect(std.mem.indexOf(u8, unlabeled, "\x1b[38;5;252mconst\x1b[39m") != null);
     try std.testing.expect(std.mem.indexOf(u8, unlabeled, "\x1b[38;5;252mawait\x1b[39m") != null);
 
@@ -3135,7 +3135,7 @@ test "renderCodeBlockForTranscript infers registered high-confidence code blocks
         .code = json_code,
     }, 100);
     defer alloc.free(json);
-    try std.testing.expect(std.mem.indexOf(u8, json, "┈ \x1b[2mjson\x1b[22m ┈") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "─ \x1b[2mjson\x1b[22m ─") != null);
     try std.testing.expect(std.mem.indexOf(u8, json, "\x1b[38;5;250m\"ready\"\x1b[39m") != null);
 
     const ambiguous_language = try alloc.dupe(u8, "");
@@ -3159,7 +3159,7 @@ test "renderCodeBlockForTranscript infers registered high-confidence code blocks
         .code = explicit_unknown_code,
     }, 100);
     defer alloc.free(explicit_unknown);
-    try std.testing.expect(std.mem.indexOf(u8, explicit_unknown, "┈ \x1b[2mbrainfuck\x1b[22m ┈") != null);
+    try std.testing.expect(std.mem.indexOf(u8, explicit_unknown, "─ \x1b[2mbrainfuck\x1b[22m ─") != null);
     try std.testing.expect(std.mem.indexOf(u8, explicit_unknown, "\x1b[38;5;") == null);
 }
 
@@ -4103,7 +4103,7 @@ test "renderEntriesToBytes indents semantic table and code rows" {
     defer alloc.free(out);
     try std.testing.expect(std.mem.startsWith(u8, out, "  ┌"));
     try std.testing.expect(std.mem.find(u8, out, "\n  │") != null);
-    try std.testing.expect(std.mem.find(u8, out, "\n\n  ┈ \x1b[2mzig") != null);
+    try std.testing.expect(std.mem.find(u8, out, "\n\n  ─ \x1b[2mzig") != null);
 
     for (1..6) |width| {
         const cols: u16 = @intCast(width);
@@ -4297,8 +4297,8 @@ test "renderEntriesToBytes keeps semantic code as its own assistant entry" {
     defer alloc.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "Before code.").? < std.mem.indexOf(u8, out, "const").?);
     try std.testing.expect(std.mem.indexOf(u8, out, "const").? < std.mem.indexOf(u8, out, "After code.").?);
-    try std.testing.expect(std.mem.find(u8, out, "┈ \x1b[2mzig\x1b[22m ┈") != null);
-    try std.testing.expect(std.mem.find(u8, out, "\x1b[2mzig\x1b[22m\n┈") == null);
+    try std.testing.expect(std.mem.find(u8, out, "─ \x1b[2mzig\x1b[22m ─") != null);
+    try std.testing.expect(std.mem.find(u8, out, "\x1b[2mzig\x1b[22m\n─") == null);
 
     const narrow = try renderEntriesToBytes(alloc, entries.items, 6, .{});
     defer alloc.free(narrow);

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2053,13 +2053,11 @@ test "semantic code block colors source and keeps current footer rail styled thr
     try h.flush();
 
     var code_row = try findRowContaining(&h, "const hook");
-    var code_cell = h.vt.cellAt(code_row, 5) orelse return error.TestMissingCodeCell;
+    var code_cell = h.vt.cellAt(code_row, 3) orelse return error.TestMissingCodeCell;
     try std.testing.expectEqual(@as(u21, 'c'), code_cell.codepoint);
     try std.testing.expect(code_cell.style.fg.eql(.{ .indexed = 252 }));
-    const code_border = h.vt.cellAt(code_row, 3) orelse return error.TestMissingCodeBorder;
-    try std.testing.expect(code_border.style.fg.eql(.default));
     var python_row = try findRowContaining(&h, "def ready");
-    var python_cell = h.vt.cellAt(python_row, 5) orelse return error.TestMissingCodeCell;
+    var python_cell = h.vt.cellAt(python_row, 3) orelse return error.TestMissingCodeCell;
     try std.testing.expectEqual(@as(u21, 'd'), python_cell.codepoint);
     try std.testing.expect(python_cell.style.fg.eql(.{ .indexed = 252 }));
     const initial_footer = try findFirstDividerRowAfter(&h, code_row);
@@ -2073,11 +2071,9 @@ test "semantic code block colors source and keeps current footer rail styled thr
     try h.flush();
 
     code_row = try findRowContaining(&h, "const hook");
-    code_cell = h.vt.cellAt(code_row, 5) orelse return error.TestMissingCodeCell;
+    code_cell = h.vt.cellAt(code_row, 3) orelse return error.TestMissingCodeCell;
     try std.testing.expectEqual(@as(u21, 'c'), code_cell.codepoint);
     try std.testing.expect(code_cell.style.fg.eql(.{ .indexed = 252 }));
-    const resized_border = h.vt.cellAt(code_row, 3) orelse return error.TestMissingCodeBorder;
-    try std.testing.expect(resized_border.style.fg.eql(.default));
     python_row = try findRowContaining(&h, "def ready");
     python_cell = h.vt.cellAt(python_row, 3) orelse return error.TestMissingCodeCell;
     try std.testing.expectEqual(@as(u21, 'd'), python_cell.codepoint);
@@ -2106,18 +2102,18 @@ test "semantic code block keeps readable light theme colors through resize" {
     try h.flush();
 
     var code_row = try findRowContaining(&h, "const value");
-    var keyword_cell = h.vt.cellAt(code_row, 5) orelse return error.TestMissingCodeCell;
+    var keyword_cell = h.vt.cellAt(code_row, 3) orelse return error.TestMissingCodeCell;
     try std.testing.expectEqual(@as(u21, 'c'), keyword_cell.codepoint);
     try std.testing.expect(keyword_cell.style.fg.eql(.{ .indexed = 238 }));
 
     try h.driveResize(20, 40, 4, true);
     code_row = try findRowContaining(&h, "const value");
-    keyword_cell = h.vt.cellAt(code_row, 5) orelse return error.TestMissingCodeCell;
+    keyword_cell = h.vt.cellAt(code_row, 3) orelse return error.TestMissingCodeCell;
     try std.testing.expectEqual(@as(u21, 'c'), keyword_cell.codepoint);
     try std.testing.expect(keyword_cell.style.fg.eql(.{ .indexed = 238 }));
 }
 
-test "semantic code block drops its frame before wrapping source that fits" {
+test "semantic code block keeps dotted rules while source reflows" {
     var h = try Harness.init(std.testing.allocator, 44, 40, 4);
     defer h.deinit();
     try h.shell.initViewport(&h.metrics, 1);
@@ -2137,20 +2133,20 @@ test "semantic code block drops its frame before wrapping source that fits" {
     }
     try h.renderTranscriptFrame();
     try h.flush();
-    try expectGridContains(&h, "┌ text");
+    try expectGridContains(&h, "┈ text");
 
     try h.driveResize(40, 40, 4, true);
-    try expectGridNotContains(&h, "┌ text");
+    try expectGridContains(&h, "┈ text");
     const first_source_row = try findRowContaining(&h, "┌────────────────────────────────┐");
     try expectRowTrimmedEquals(&h, first_source_row, "      ┌────────────────────────────────┐");
     try expectRowTrimmedEquals(&h, first_source_row + 1, "      │ ROOT                           │");
     try expectRowTrimmedEquals(&h, first_source_row + 2, "      └────────────────────────────────┘");
 
     try h.driveResize(39, 40, 4, true);
-    try expectGridContains(&h, "┌ text");
+    try expectGridContains(&h, "┈ text");
 
     try h.driveResize(44, 40, 4, true);
-    try expectGridContains(&h, "┌ text");
+    try expectGridContains(&h, "┈ text");
 }
 
 test "streamed paragraphs keep words together through shrink and grow" {

--- a/src/ui/resize_tests.zig
+++ b/src/ui/resize_tests.zig
@@ -2113,7 +2113,7 @@ test "semantic code block keeps readable light theme colors through resize" {
     try std.testing.expect(keyword_cell.style.fg.eql(.{ .indexed = 238 }));
 }
 
-test "semantic code block keeps dotted rules while source reflows" {
+test "semantic code block keeps solid rules while source reflows" {
     var h = try Harness.init(std.testing.allocator, 44, 40, 4);
     defer h.deinit();
     try h.shell.initViewport(&h.metrics, 1);
@@ -2133,20 +2133,20 @@ test "semantic code block keeps dotted rules while source reflows" {
     }
     try h.renderTranscriptFrame();
     try h.flush();
-    try expectGridContains(&h, "┈ text");
+    try expectGridContains(&h, "─ text");
 
     try h.driveResize(40, 40, 4, true);
-    try expectGridContains(&h, "┈ text");
+    try expectGridContains(&h, "─ text");
     const first_source_row = try findRowContaining(&h, "┌────────────────────────────────┐");
     try expectRowTrimmedEquals(&h, first_source_row, "      ┌────────────────────────────────┐");
     try expectRowTrimmedEquals(&h, first_source_row + 1, "      │ ROOT                           │");
     try expectRowTrimmedEquals(&h, first_source_row + 2, "      └────────────────────────────────┘");
 
     try h.driveResize(39, 40, 4, true);
-    try expectGridContains(&h, "┈ text");
+    try expectGridContains(&h, "─ text");
 
     try h.driveResize(44, 40, 4, true);
-    try expectGridContains(&h, "┈ text");
+    try expectGridContains(&h, "─ text");
 }
 
 test "streamed paragraphs keep words together through shrink and grow" {

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -541,7 +541,7 @@ describe("fx ask presentation", () => {
       expect(pane).toContain("bold and docs");
       expect(pane).toContain("first item");
       expect(pane).toContain("const answer: u8 = 42;");
-      expect(pane).toContain("┈ zig ┈");
+      expect(pane).toContain("─ zig ─");
       expect(pane).not.toContain("│ const answer: u8 = 42;");
       expect(pane).not.toContain("# Ask presentation");
       expect(pane).not.toContain("**bold**");

--- a/tests/e2e/ask-presentation.test.ts
+++ b/tests/e2e/ask-presentation.test.ts
@@ -541,6 +541,8 @@ describe("fx ask presentation", () => {
       expect(pane).toContain("bold and docs");
       expect(pane).toContain("first item");
       expect(pane).toContain("const answer: u8 = 42;");
+      expect(pane).toContain("┈ zig ┈");
+      expect(pane).not.toContain("│ const answer: u8 = 42;");
       expect(pane).not.toContain("# Ask presentation");
       expect(pane).not.toContain("**bold**");
       expect(escaped).toContain("\x1b[");

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -8593,7 +8593,7 @@ describe.skipIf(!tmuxAvailable())("transcript scrollback release", () => {
         expect(phaseOneHistory).toContain("• BLOCK_BULLET");
         expect(phaseOneHistory).toContain("✓ BLOCK_TASK_COMPLETE");
         expect(phaseOneHistory).toContain("│ QUOTE_BLOCK_FIRST");
-        expect(phaseOneHistory).toContain("┌ zig ");
+        expect(phaseOneHistory).toContain("─ zig ─");
         expect(phaseOneHistory).toContain("┬");
         expect(phaseOneHistory).toContain("┼");
         expect(phaseOneHistory).toContain("┴");

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -1649,8 +1649,11 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
         .sort()
         .map((name) => readFileSync(join(framesRoot, "frames", name), "utf8"));
       const prefixLength = (grid: string): number => {
+        const rows = grid.split("\n");
         for (let count = renderedSentence.length; count > 0; count -= 1) {
-          if (grid.includes(renderedSentence.slice(0, count))) return count;
+          if (rows.some((row) => row.startsWith(`|  ${renderedSentence.slice(0, count)}`))) {
+            return count;
+          }
         }
         return 0;
       };

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -694,10 +694,10 @@ function expectRenderedMarkdown(
 }
 
 function expectInferredTypeScriptCodeBlock(scrollback: string): void {
-  expect(scrollback).toContain("┌ ts");
+  expect(scrollback).toContain("─ ts ─");
   expect(scrollback).toContain("inferredHook = await");
   expect(scrollback).toContain("{ cleanup: true } as");
-  expect(scrollback).toContain("pSignal);");
+  expect(scrollback).toContain("nupSignal)");
 }
 
 function expectInferredTypeScriptColors(scrollback: string): void {
@@ -706,9 +706,9 @@ function expectInferredTypeScriptColors(scrollback: string): void {
 }
 
 function expectExpandedCodeProfiles(scrollback: string): void {
-  expect(scrollback).toContain("┌ json");
+  expect(scrollback).toContain("─ json ─");
   expect(scrollback).toContain('"json_ready"');
-  expect(scrollback).toContain("┌ python");
+  expect(scrollback).toContain("─ python ─");
   expect(scrollback).toContain("def render_ready");
 }
 


### PR DESCRIPTION
## Summary

- replace boxed code-block frames with solid horizontal rules
- keep the language label in the top rule
- remove side rails and row padding so copied source stays clean
- preserve syntax highlighting, wrapping, indentation, and narrow-terminal behavior

## Verification

- `zig fmt --check src/main.zig src/ui/render_engine/transcript_blocks.zig src/ui/resize_tests.zig`
- `zig build test --summary all` (8,594 passed, 2 skipped)
- `cd tests/e2e && bun test ask-presentation.test.ts` (13 passed)
- `./zig-out/bin/fx --help` (exit 0, clean stderr)
