### PR TITLE
Normalize optional tool arguments

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -221,7 +221,7 @@ const subagent_model_request_properties = [_]model_tool_schema.Property{.{
 const vision_description =
     "Inspect authorized images attached by the user or local image paths supplied in the conversation, and return structured factual evidence. Pass exactly one source: image_ids for attached images, or paths for local images. When to use: read visible text, UI state, objects, layout, or other visual details needed for the task. When NOT to use: inspect paths the user did not supply, infer details not visible in an image, or repeat evidence already available in the conversation.";
 const read_tool_result_description =
-    "Read a stored tool result or captured command output by opaque handle from the active session or process, using a bounded byte range or literal query. When to use: inspect more after a tool-result preview or command-output handle says retained output is available. When NOT to use: read arbitrary files, search the workspace, recover secrets, or inspect results from another session or process.";
+    "Read a stored tool result or captured command output by opaque handle from the active session or process. Pass request.query to find a known literal line; otherwise use the optional request byte range. When to use: inspect more after a tool-result preview or command-output handle says retained output is available. When NOT to use: read arbitrary files, search the workspace, recover secrets, or inspect results from another session or process.";
 
 pub const glob_files = ToolSpec{
     .name = "glob_files",
@@ -232,7 +232,7 @@ pub const glob_files = ToolSpec{
         .input_schema = .{
             .properties = &.{
                 .{ .name = "pattern", .json_type = .string, .description = "Glob pattern to match, such as src/**/*.zig or *.md." },
-                .{ .name = "path", .json_type = .string, .description = "Optional search root relative to the workspace root, or an external path using an absolute path, ~/..., or a relative workspace escape such as ../...; external access is subject to permission policy. Defaults to current directory; narrow it when possible." },
+                .{ .name = "path", .json_type = .string, .bounds = &.{ .min_length = 1 }, .description = "Optional search root relative to the workspace root, or an external path using an absolute path, ~/..., or a relative workspace escape such as ../...; external access is subject to permission policy. Omit this field to use the current directory; never send an empty string. Narrow it when possible." },
                 .{ .name = "mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "matches", "count" } }, .description = "Use matches to return sample paths, or count to return an exact matching path count without listing entries." },
             },
             .required = &.{"pattern"},
@@ -262,7 +262,7 @@ pub const grep_files = ToolSpec{
         .input_schema = .{
             .properties = &.{
                 .{ .name = "pattern", .json_type = .string, .description = "Literal plain-text pattern to search for." },
-                .{ .name = "path", .json_type = .string, .description = "Optional search root relative to the workspace root, or an external path using an absolute path, ~/..., or a relative workspace escape such as ../...; external access is subject to permission policy. Defaults to current directory; narrow it when possible." },
+                .{ .name = "path", .json_type = .string, .bounds = &.{ .min_length = 1 }, .description = "Optional search root relative to the workspace root, or an external path using an absolute path, ~/..., or a relative workspace escape such as ../...; external access is subject to permission policy. Omit this field to use the current directory; never send an empty string. Narrow it when possible." },
                 .{ .name = "include", .json_type = .string, .description = "Optional glob pattern applied to candidate file paths before reading files, such as *.zig or src/**/*.ts." },
                 .{ .name = "case_insensitive", .json_type = .boolean, .description = "Search case-insensitively when true." },
                 .{ .name = "mode", .json_type = .string, .shape = &.{ .enum_values = &.{ "matches", "files_with_matches", "count" } }, .description = "Use matches for line matches, files_with_matches for unique matching paths, or count for exact matching-line and matching-file counts." },
@@ -778,6 +778,26 @@ pub const vision = ToolSpec{
     .irreversible_fn = vision_impl.isIrreversible,
 };
 
+const read_tool_result_range_properties = [_]model_tool_schema.Property{
+    .{ .name = "handle", .json_type = .string, .description = "Opaque handle from a prior tool-result preview or captured command output." },
+    .{ .name = "start_byte", .json_type = .integer, .description = "Optional 1-based byte offset. Defaults to 1." },
+    .{ .name = "byte_count", .json_type = .integer, .description = "Optional positive byte count. Bounded by the tool." },
+};
+
+const read_tool_result_query_properties = [_]model_tool_schema.Property{
+    .{ .name = "handle", .json_type = .string, .description = "Opaque handle from a prior tool-result preview or captured command output." },
+    .{ .name = "query", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = lexical_relevance.max_query_bytes }, .description = "Non-empty literal line query." },
+};
+
+const read_tool_result_input_schemas = [_]model_tool_schema.ObjectSchema{
+    .{ .properties = &read_tool_result_range_properties, .required = &.{"handle"}, .additional_properties = false },
+    .{ .properties = &read_tool_result_query_properties, .required = &.{ "handle", "query" }, .additional_properties = false },
+};
+
+const read_tool_result_request_schema = model_tool_schema.ObjectSchema{
+    .one_of = &read_tool_result_input_schemas,
+};
+
 pub const read_tool_result = ToolSpec{
     .name = "read_tool_result",
     .description = read_tool_result_description,
@@ -785,13 +805,14 @@ pub const read_tool_result = ToolSpec{
         .name = "read_tool_result",
         .description = read_tool_result_description,
         .input_schema = .{
-            .properties = &.{
-                .{ .name = "handle", .json_type = .string, .description = "Opaque handle from a prior tool-result preview or captured command output." },
-                .{ .name = "start_byte", .json_type = .integer, .description = "Optional 1-based byte offset for range reads. Defaults to 1." },
-                .{ .name = "byte_count", .json_type = .integer, .description = "Optional positive byte count for range reads. Bounded by the tool." },
-                .{ .name = "query", .json_type = .string, .bounds = &.{ .min_length = 1, .max_length = lexical_relevance.max_query_bytes }, .description = "Optional non-empty literal line query. When set, range fields are ignored." },
-            },
-            .required = &.{"handle"},
+            .properties = &.{.{
+                .name = "request",
+                .json_type = .object,
+                .shape = &.{ .object = &read_tool_result_request_schema },
+                .description = "Choose one request: handle plus query, or handle plus an optional byte range.",
+            }},
+            .required = &.{"request"},
+            .additional_properties = false,
         },
     },
     .executor_kind = .read_tool_result,
@@ -917,7 +938,7 @@ test "built-in model-facing tool contract stays byte exact" {
 
     const actual_hex = std.fmt.bytesToHex(hasher.finalResult(), .lower);
     try std.testing.expectEqualStrings(
-        "14209d2ea5707d98618a0e98f70b03e739074b66f48e2f59299e1d1d4376ff6e",
+        "7fed627d6a17a6c38bf2bd635c074121c2fb5eae8be33f124bb42abe47dfbe34",
         &actual_hex,
     );
 }
@@ -1106,7 +1127,8 @@ test "built-in glob_files owns product metadata schema and callbacks" {
     try std.testing.expect(std.mem.find(u8, glob_files.description, "external access is subject to permission policy") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"required\":[\"pattern\"]") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"mode\":{\"type\":\"string\",\"enum\":[\"matches\",\"count\"]") != null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"path\":{\"type\":\"string\"") != null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "\"path\":{\"type\":\"string\",\"minLength\":1") != null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "Omit this field to use the current directory") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "external path") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "~/...") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "../...") != null);
@@ -1145,6 +1167,8 @@ test "built-in grep_files owns product metadata schema and callbacks" {
     try std.testing.expect(std.mem.find(u8, schema_json, "\"head_limit\"") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"offset\"") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "\"context_lines\"") != null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "\"path\":{\"type\":\"string\",\"minLength\":1") != null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "Omit this field to use the current directory") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "external path") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "~/...") != null);
     try std.testing.expect(std.mem.find(u8, schema_json, "../...") != null);
@@ -1647,17 +1671,31 @@ test "built-in vision dispatch uses supplied runtime provider" {
 test "built-in read_tool_result owns product metadata schema and callbacks" {
     const schema_json = try tool_specs.toolGatewaySchemaJson(std.testing.allocator, read_tool_result);
     defer std.testing.allocator.free(schema_json);
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, schema_json, .{});
+    defer parsed.deinit();
 
     try std.testing.expectEqualStrings("read_tool_result", read_tool_result.name);
     try std.testing.expect(std.mem.find(u8, read_tool_result.description, "opaque handle from the active session or process") != null);
-    try std.testing.expect(std.mem.find(u8, read_tool_result.description, "bounded byte range or literal query") != null);
+    try std.testing.expect(std.mem.find(u8, read_tool_result.description, "Pass request.query") != null);
     try std.testing.expect(std.mem.find(u8, read_tool_result.description, "inspect results from another session or process") != null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"handle\":{\"type\":\"string\"") != null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"start_byte\":{\"type\":\"integer\"") != null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"byte_count\":{\"type\":\"integer\"") != null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"query\":{\"type\":\"string\",\"minLength\":1") != null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"query\":{\"type\":\"string\"") != null);
-    try std.testing.expect(std.mem.find(u8, schema_json, "\"required\":[\"handle\"]") != null);
+    try std.testing.expect(std.mem.find(u8, schema_json, "\"mode\"") == null);
+    const input_schema = parsed.value.object.get("inputSchema").?.object;
+    try std.testing.expectEqualStrings("object", input_schema.get("type").?.string);
+    try std.testing.expectEqualStrings("request", input_schema.get("required").?.array.items[0].string);
+    try std.testing.expect(!input_schema.get("additionalProperties").?.bool);
+    const request = input_schema.get("properties").?.object.get("request").?.object;
+    const alternatives = request.get("oneOf").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), alternatives.len);
+    const range = alternatives[0].object;
+    const query = alternatives[1].object;
+    try std.testing.expect(range.get("properties").?.object.get("query") == null);
+    try std.testing.expect(query.get("properties").?.object.get("start_byte") == null);
+    try std.testing.expect(query.get("properties").?.object.get("byte_count") == null);
+    try std.testing.expectEqualStrings("handle", range.get("required").?.array.items[0].string);
+    try std.testing.expectEqualStrings("handle", query.get("required").?.array.items[0].string);
+    try std.testing.expectEqualStrings("query", query.get("required").?.array.items[1].string);
+    try std.testing.expect(!range.get("additionalProperties").?.bool);
+    try std.testing.expect(!query.get("additionalProperties").?.bool);
     try std.testing.expectEqual(tool_dispatch.ExecutorKind.read_tool_result, read_tool_result.executor_kind);
     try std.testing.expectEqual(types.ToolActivityKind.read, read_tool_result.activity_kind);
     try std.testing.expect(!read_tool_result.requires_approval);

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -81,11 +81,12 @@ const TurnFinalizationGuard = runtime_finalization.TurnFinalizationGuard;
 const PromptFinishTrace = runtime_finalization.PromptFinishTrace;
 const ToolExecutionResult = runtime_tool_contracts.ToolExecutionResult;
 
-fn terminal_request_schema_advertised(
+fn request_union_schema_advertised(
     advertised_functions: []const model_tool_schema.FunctionSchema,
+    tool_name: []const u8,
 ) bool {
     for (advertised_functions) |function| {
-        if (!std.mem.eql(u8, function.name, "shell")) continue;
+        if (!std.mem.eql(u8, function.name, tool_name)) continue;
         return model_tool_schema.isSingleRequiredObjectUnionField(
             function.input_schema,
             "request",
@@ -105,6 +106,21 @@ fn subagent_request_schema_advertised(
         );
     }
     return false;
+}
+
+fn terminal_request_schema_advertised(
+    advertised_functions: []const model_tool_schema.FunctionSchema,
+) bool {
+    return request_union_schema_advertised(advertised_functions, "shell");
+}
+
+fn read_tool_result_request_schema_advertised(
+    advertised_functions: []const model_tool_schema.FunctionSchema,
+) bool {
+    return request_union_schema_advertised(
+        advertised_functions,
+        "read_tool_result",
+    );
 }
 
 fn terminal_request_normalization_eligible(
@@ -241,6 +257,34 @@ fn projected_terminal_request_arguments(
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
     std.json.Stringify.value(.{ .request = parsed.value }, .{}, &out.writer) catch return error.OutOfMemory;
+    return try out.toOwnedSlice();
+}
+
+fn projected_read_tool_result_arguments(
+    alloc: Allocator,
+    arguments_json: []const u8,
+) Allocator.Error!?[]u8 {
+    var parsed = std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        arguments_json,
+        .{},
+    ) catch |err| return switch (err) {
+        error.OutOfMemory => error.OutOfMemory,
+        else => null,
+    };
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    if (parsed.value.object.count() == 1 and
+        parsed.value.object.get("request") != null)
+    {
+        return null;
+    }
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    std.json.Stringify.value(.{ .request = parsed.value }, .{}, &out.writer) catch
+        return error.OutOfMemory;
     return try out.toOwnedSlice();
 }
 
@@ -882,6 +926,39 @@ test "subagent history projection cleans every partial allocation failure" {
     );
 }
 
+fn project_read_tool_result_request_messages(
+    arena: Allocator,
+    eligible: bool,
+    source: []const ChatMessage,
+) Allocator.Error![]const ChatMessage {
+    if (!eligible) return source;
+
+    var projected: ?[]ChatMessage = null;
+    for (source, 0..) |message, message_index| {
+        if (message.role != .assistant) continue;
+        for (message.tool_calls, 0..) |call, call_index| {
+            if (call.argument_integrity != .valid or
+                !std.mem.eql(u8, call.name, "read_tool_result")) continue;
+            const arguments_json = try projected_read_tool_result_arguments(
+                arena,
+                call.arguments_json,
+            ) orelse continue;
+            if (projected == null) {
+                projected = try arena.dupe(ChatMessage, source);
+            }
+            if (projected.?[message_index].tool_calls.ptr == message.tool_calls.ptr) {
+                projected.?[message_index].tool_calls = try arena.dupe(
+                    ToolCall,
+                    message.tool_calls,
+                );
+            }
+            @constCast(projected.?[message_index].tool_calls)[call_index].arguments_json =
+                arguments_json;
+        }
+    }
+    return projected orelse source;
+}
+
 fn normalized_terminal_request_arguments(
     alloc: Allocator,
     arguments_json: []const u8,
@@ -1299,6 +1376,49 @@ test "shell request projection wraps eligible flat objects without changing sour
     const idempotent = try project_terminal_request_messages(arena, registry, true, projected);
     try std.testing.expectEqual(projected.ptr, idempotent.ptr);
     const ineligible = try project_terminal_request_messages(arena, registry, false, &messages);
+    try std.testing.expectEqual(messages[0..].ptr, ineligible.ptr);
+}
+
+test "legacy read_tool_result history gains one nested request wrapper" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const calls = [_]ToolCall{
+        .{ .id = "legacy", .name = "read_tool_result", .arguments_json = "{\"handle\":\"legacy.bin\",\"start_byte\":1,\"byte_count\":160}" },
+        .{ .id = "nested", .name = "read_tool_result", .arguments_json = "{\"request\":{\"handle\":\"new.bin\",\"query\":\"needle\"}}" },
+    };
+    const messages = [_]ChatMessage{.{ .role = .assistant, .tool_calls = &calls }};
+
+    const projected = try project_read_tool_result_request_messages(
+        arena,
+        true,
+        &messages,
+    );
+    try std.testing.expect(projected.ptr != messages[0..].ptr);
+    try std.testing.expectEqualStrings(
+        "{\"request\":{\"handle\":\"legacy.bin\",\"start_byte\":1,\"byte_count\":160}}",
+        projected[0].tool_calls[0].arguments_json,
+    );
+    try std.testing.expectEqualStrings(
+        calls[1].arguments_json,
+        projected[0].tool_calls[1].arguments_json,
+    );
+    try std.testing.expectEqualStrings(
+        "{\"handle\":\"legacy.bin\",\"start_byte\":1,\"byte_count\":160}",
+        messages[0].tool_calls[0].arguments_json,
+    );
+
+    const idempotent = try project_read_tool_result_request_messages(
+        arena,
+        true,
+        projected,
+    );
+    try std.testing.expectEqual(projected.ptr, idempotent.ptr);
+    const ineligible = try project_read_tool_result_request_messages(
+        arena,
+        false,
+        &messages,
+    );
     try std.testing.expectEqual(messages[0..].ptr, ineligible.ptr);
 }
 
@@ -3596,6 +3716,10 @@ fn processQueuedPromptInner(
     const base_nested_subagent_advertised = subagent_request_schema_advertised(
         config.advertised_functions,
     );
+    const base_nested_read_tool_result_advertised =
+        read_tool_result_request_schema_advertised(
+            config.advertised_functions,
+        );
 
     var stable_prefix: std.ArrayList(ChatMessage) = .empty;
     defer stable_prefix.deinit(arena);
@@ -3731,6 +3855,7 @@ fn processQueuedPromptInner(
         request_capabilities,
         base_nested_terminal_advertised,
         base_nested_subagent_advertised,
+        base_nested_read_tool_result_advertised,
         finalization,
         arena,
         turn_id,
@@ -3989,6 +4114,7 @@ fn processQueuedPromptLoop(
     request_capabilities: model_capabilities.Capabilities,
     base_nested_terminal_advertised: bool,
     base_nested_subagent_advertised: bool,
+    base_nested_read_tool_result_advertised: bool,
     finalization: *TurnFinalizationGuard,
     arena: Allocator,
     turn_id: u64,
@@ -4428,17 +4554,27 @@ fn processQueuedPromptLoop(
                 base_nested_subagent_advertised,
                 vision_mode,
             );
+            const read_tool_result_request_eligible =
+                terminal_request_normalization_eligible(
+                    base_nested_read_tool_result_advertised,
+                    vision_mode,
+                );
             const terminal_request_messages = try project_terminal_request_messages(
                 overlay_arena,
                 deps.tool_registry,
                 terminal_request_eligible,
                 projected_request_messages,
             );
-            const request_messages = try project_subagent_request_messages(
+            const subagent_request_messages = try project_subagent_request_messages(
                 overlay_arena,
                 deps.tool_registry,
                 subagent_request_eligible,
                 terminal_request_messages,
+            );
+            const request_messages = try project_read_tool_result_request_messages(
+                overlay_arena,
+                read_tool_result_request_eligible,
+                subagent_request_messages,
             );
             last_gateway_message_count = request_messages.len;
             const provider_opts = model_capabilities.resolveProviderOptionsForCapabilities(request_capabilities, config.effort, route_fast_mode);

--- a/src/core/permissions/permissions.zig
+++ b/src/core/permissions/permissions.zig
@@ -191,7 +191,7 @@ pub fn permissionTargetForCall(
         .url => arena.dupe(u8, try tool_args.requiredStringArg(args, "url")),
         .path_optional_existing => blk: {
             const path_arg = tool_args.optionalStringArg(args, "path") orelse ".";
-            break :blk if (std.mem.eql(u8, path_arg, "."))
+            break :blk if (path_arg.len == 0 or std.mem.eql(u8, path_arg, "."))
                 arena.dupe(u8, workspace_root)
             else
                 try resolveFileToolPath(arena, workspace_root, call.name, path_arg, .existing);
@@ -2192,6 +2192,16 @@ test "permissionTargetForCall covers active target kinds" {
             .call = .{ .id = "grep", .name = "grep_files", .arguments_json = "{\"pattern\":\"main\",\"path\":\"src\"}" },
             .target_kind = .path_optional_existing,
             .expected = src_dir,
+        },
+        .{
+            .call = .{ .id = "glob_root", .name = "glob_files", .arguments_json = "{\"pattern\":\"*.zig\",\"path\":\"\"}" },
+            .target_kind = .path_optional_existing,
+            .expected = workspace,
+        },
+        .{
+            .call = .{ .id = "grep_root", .name = "grep_files", .arguments_json = "{\"pattern\":\"main\"}" },
+            .target_kind = .path_optional_existing,
+            .expected = workspace,
         },
         .{
             .call = .{ .id = "read", .name = "read_file", .arguments_json = "{\"path\":\"src/app.zig\"}" },

--- a/src/tools/filesystem/glob_files.zig
+++ b/src/tools/filesystem/glob_files.zig
@@ -60,7 +60,11 @@ pub fn decode(ctx: tool_dispatch.DispatchContext, args_json: []const u8) tool_di
 
     const owned_pattern = try ctx.allocator.dupe(u8, pattern_value.string);
     errdefer ctx.allocator.free(owned_pattern);
-    const owned_path = try ctx.allocator.dupe(u8, path_string orelse ".");
+    const effective_path = if (path_string) |path|
+        if (path.len == 0) "." else path
+    else
+        ".";
+    const owned_path = try ctx.allocator.dupe(u8, effective_path);
     errdefer ctx.allocator.free(owned_path);
 
     const input = try ctx.allocator.create(Input);
@@ -608,6 +612,7 @@ test "glob_files decodes invalid argument shapes as failures" {
 
 test "glob_files decodes omitted path and valid input" {
     try expectDecodeInput("{\"pattern\":\"*.zig\"}", "*.zig", ".");
+    try expectDecodeInput("{\"pattern\":\"*.zig\",\"path\":\"\"}", "*.zig", ".");
     try expectDecodeInput("{\"pattern\":\"*.zig\",\"path\":\"src\"}", "*.zig", "src");
     try expectDecodeInput("{\"pattern\":\"*.zig\",\"path\":1}", "*.zig", ".");
 }

--- a/src/tools/filesystem/grep_files.zig
+++ b/src/tools/filesystem/grep_files.zig
@@ -91,7 +91,11 @@ pub fn decode(ctx: tool_dispatch.DispatchContext, args_json: []const u8) tool_di
 
     const owned_pattern = try ctx.allocator.dupe(u8, pattern_value.string);
     errdefer ctx.allocator.free(owned_pattern);
-    const owned_path = try ctx.allocator.dupe(u8, path_string orelse ".");
+    const effective_path = if (path_string) |path|
+        if (path.len == 0) "." else path
+    else
+        ".";
+    const owned_path = try ctx.allocator.dupe(u8, effective_path);
     errdefer ctx.allocator.free(owned_path);
     const owned_include = if (include_string) |value| try ctx.allocator.dupe(u8, value) else null;
     errdefer if (owned_include) |include| ctx.allocator.free(include);
@@ -826,6 +830,7 @@ test "grep_files validate preserves active raw pattern and path values" {
 
 test "grep_files decodes defaults and all fields" {
     try expectDecodeInput("{\"pattern\":\"needle\"}", "needle", ".", null, false, output_cap, 0);
+    try expectDecodeInput("{\"pattern\":\"needle\",\"path\":\"\"}", "needle", ".", null, false, output_cap, 0);
     try expectDecodeInput(
         "{\"pattern\":\"needle\",\"path\":\"src\",\"include\":\"*.zig\",\"case_insensitive\":true,\"head_limit\":5,\"offset\":2}",
         "needle",

--- a/src/tools/session/read_tool_result.zig
+++ b/src/tools/session/read_tool_result.zig
@@ -14,13 +14,20 @@ const HandleNormalization = struct {
 
 pub const Input = struct {
     handle: []u8,
-    start_byte: usize = 1,
-    byte_count: usize = result_store.read_default_bytes,
-    query: ?[]u8 = null,
+    selector: union(enum) {
+        range: struct {
+            start_byte: usize = 1,
+            byte_count: usize = result_store.read_default_bytes,
+        },
+        query: []u8,
+    } = .{ .range = .{} },
 
     pub fn deinit(self: *Input, alloc: Allocator) void {
         alloc.free(self.handle);
-        if (self.query) |query| alloc.free(query);
+        switch (self.selector) {
+            .range => {},
+            .query => |query| alloc.free(query),
+        }
         self.* = .{ .handle = &.{} };
     }
 };
@@ -33,8 +40,13 @@ pub fn decode(ctx: tool_dispatch.DispatchContext, args_json: []const u8) tool_di
     if (parsed.value != .object) {
         return .{ .failure = try ctx.allocator.dupe(u8, "read_tool_result arguments must be an object") };
     }
-
-    const handle_value = parsed.value.object.get("handle") orelse {
+    const args = if (parsed.value.object.get("request")) |request| blk: {
+        if (request != .object) {
+            return .{ .failure = try ctx.allocator.dupe(u8, "read_tool_result field \"request\" must be an object") };
+        }
+        break :blk request.object;
+    } else parsed.value.object;
+    const handle_value = args.get("handle") orelse {
         return .{ .failure = try ctx.allocator.dupe(u8, "read_tool_result requires string field \"handle\"") };
     };
     if (handle_value != .string) {
@@ -46,23 +58,25 @@ pub fn decode(ctx: tool_dispatch.DispatchContext, args_json: []const u8) tool_di
     input.* = .{ .handle = try ctx.allocator.dupe(u8, handle_value.string) };
     errdefer input.deinit(ctx.allocator);
 
-    if (parsed.value.object.get("start_byte")) |value| {
+    if (args.get("start_byte")) |value| {
         const start_byte = parsePositiveInteger(value) orelse {
             return .{ .failure = try ctx.allocator.dupe(u8, "read_tool_result field \"start_byte\" must be a positive integer") };
         };
-        input.start_byte = @intCast(start_byte);
+        input.selector.range.start_byte = @intCast(start_byte);
     }
-    if (parsed.value.object.get("byte_count")) |value| {
+    if (args.get("byte_count")) |value| {
         const byte_count = parsePositiveInteger(value) orelse {
             return .{ .failure = try ctx.allocator.dupe(u8, "read_tool_result field \"byte_count\" must be a positive integer") };
         };
-        input.byte_count = @intCast(@min(byte_count, result_store.read_max_bytes));
+        input.selector.range.byte_count = @intCast(@min(byte_count, result_store.read_max_bytes));
     }
-    if (parsed.value.object.get("query")) |value| {
+    if (args.get("query")) |value| {
         if (value != .string) {
             return .{ .failure = try ctx.allocator.dupe(u8, "read_tool_result field \"query\" must be a string") };
         }
-        input.query = try ctx.allocator.dupe(u8, value.string);
+        if (value.string.len > 0) {
+            input.selector = .{ .query = try ctx.allocator.dupe(u8, value.string) };
+        }
     }
 
     return .{ .input = .{ .ptr = input, .deinit_fn = inputDeinit } };
@@ -118,55 +132,55 @@ pub fn call(ctx: tool_dispatch.DispatchContext, erased: tool_dispatch.ToolInput)
 
 fn readOutput(ctx: tool_dispatch.DispatchContext, input: *Input) ![]u8 {
     if (ctx.session_child_capability) |capability| {
-        const ordinary = if (input.query) |query|
-            result_store.searchByQueryManaged(ctx.allocator, capability, input.handle, query)
-        else
-            result_store.readByRangeManaged(ctx.allocator, capability, input.handle, input.start_byte, input.byte_count);
+        const ordinary = switch (input.selector) {
+            .query => |query| result_store.searchByQueryManaged(ctx.allocator, capability, input.handle, query),
+            .range => |range| result_store.readByRangeManaged(ctx.allocator, capability, input.handle, range.start_byte, range.byte_count),
+        };
         return ordinary catch |err| switch (err) {
-            error.ResultHandleNotFound => if (input.query) |query|
-                command_replay_store.searchAgentQueryManaged(
+            error.ResultHandleNotFound => switch (input.selector) {
+                .query => |query| command_replay_store.searchAgentQueryManaged(
                     ctx.allocator,
                     capability,
                     input.handle,
                     query,
                     result_store.read_max_bytes,
-                )
-            else
-                command_replay_store.readAgentPageManaged(
+                ),
+                .range => |range| command_replay_store.readAgentPageManaged(
                     ctx.allocator,
                     capability,
                     input.handle,
-                    input.start_byte,
-                    input.byte_count,
+                    range.start_byte,
+                    range.byte_count,
                 ),
+            },
             else => return err,
         };
     }
 
     if (ctx.ephemeral_command_replay) |store| {
-        return if (input.query) |query|
-            command_replay_store.searchAgentQueryEphemeral(
+        return switch (input.selector) {
+            .query => |query| command_replay_store.searchAgentQueryEphemeral(
                 ctx.allocator,
                 store,
                 input.handle,
                 query,
                 result_store.read_max_bytes,
-            )
-        else
-            command_replay_store.readAgentPageEphemeral(
+            ),
+            .range => |range| command_replay_store.readAgentPageEphemeral(
                 ctx.allocator,
                 store,
                 input.handle,
-                input.start_byte,
-                input.byte_count,
-            );
+                range.start_byte,
+                range.byte_count,
+            ),
+        };
     }
 
     const dir = ctx.tool_result_dir.?;
-    return if (input.query) |query|
-        result_store.searchByQuery(ctx.allocator, dir, input.handle, query)
-    else
-        result_store.readByRange(ctx.allocator, dir, input.handle, input.start_byte, input.byte_count);
+    return switch (input.selector) {
+        .query => |query| result_store.searchByQuery(ctx.allocator, dir, input.handle, query),
+        .range => |range| result_store.readByRange(ctx.allocator, dir, input.handle, range.start_byte, range.byte_count),
+    };
 }
 
 fn formatReadFailure(alloc: Allocator, handle: []const u8, err: anyerror) ![]u8 {
@@ -190,7 +204,41 @@ pub fn isIrreversible(_: tool_dispatch.ToolInput) bool {
 
 test "read_tool_result decodes range and query inputs" {
     const alloc = std.testing.allocator;
-    const decoded = try decode(.{ .allocator = alloc }, "{\"handle\":\"h.txt\",\"start_byte\":2,\"byte_count\":9,\"query\":\"needle\"}");
+    const decoded_range = try decode(.{ .allocator = alloc }, "{\"handle\":\"h.txt\",\"start_byte\":2,\"byte_count\":9}");
+    const range_input = switch (decoded_range) {
+        .input => |value| value,
+        .failure => return error.TestUnexpectedDecodeFailure,
+    };
+    defer range_input.deinit(alloc);
+    const typed_range = range_input.as(Input);
+    switch (typed_range.selector) {
+        .range => |range| {
+            try std.testing.expectEqual(@as(usize, 2), range.start_byte);
+            try std.testing.expectEqual(@as(usize, 9), range.byte_count);
+        },
+        .query => return error.TestUnexpectedDecodeFailure,
+    }
+
+    const decoded_query = try decode(.{ .allocator = alloc }, "{\"handle\":\"h.txt\",\"query\":\"needle\"}");
+    const query_input = switch (decoded_query) {
+        .input => |value| value,
+        .failure => return error.TestUnexpectedDecodeFailure,
+    };
+    defer query_input.deinit(alloc);
+    const typed_query = query_input.as(Input);
+    try std.testing.expectEqualStrings("h.txt", typed_query.handle);
+    switch (typed_query.selector) {
+        .query => |query| try std.testing.expectEqualStrings("needle", query),
+        .range => return error.TestUnexpectedDecodeFailure,
+    }
+}
+
+test "read_tool_result decodes nested model requests" {
+    const alloc = std.testing.allocator;
+    const decoded = try decode(
+        .{ .allocator = alloc },
+        "{\"request\":{\"handle\":\"h.txt\",\"query\":\"needle\"}}",
+    );
     const input = switch (decoded) {
         .input => |value| value,
         .failure => return error.TestUnexpectedDecodeFailure,
@@ -198,9 +246,31 @@ test "read_tool_result decodes range and query inputs" {
     defer input.deinit(alloc);
     const typed = input.as(Input);
     try std.testing.expectEqualStrings("h.txt", typed.handle);
-    try std.testing.expectEqual(@as(usize, 2), typed.start_byte);
-    try std.testing.expectEqual(@as(usize, 9), typed.byte_count);
-    try std.testing.expectEqualStrings("needle", typed.query.?);
+    switch (typed.selector) {
+        .query => |query| try std.testing.expectEqualStrings("needle", query),
+        .range => return error.TestUnexpectedDecodeFailure,
+    }
+}
+
+test "read_tool_result treats exact empty legacy query as range" {
+    const alloc = std.testing.allocator;
+    const decoded = try decode(
+        .{ .allocator = alloc },
+        "{\"handle\":\"h.txt\",\"start_byte\":2,\"byte_count\":9,\"query\":\"\"}",
+    );
+    const input = switch (decoded) {
+        .input => |value| value,
+        .failure => return error.TestUnexpectedDecodeFailure,
+    };
+    defer input.deinit(alloc);
+    const typed = input.as(Input);
+    switch (typed.selector) {
+        .range => |range| {
+            try std.testing.expectEqual(@as(usize, 2), range.start_byte);
+            try std.testing.expectEqual(@as(usize, 9), range.byte_count);
+        },
+        .query => return error.TestUnexpectedDecodeFailure,
+    }
 }
 
 test "read_tool_result admission restores only omitted stored-result suffixes" {
@@ -339,8 +409,10 @@ test "read_tool_result pages and searches saved command replay handles" {
 
     var page_input = Input{
         .handle = try alloc.dupe(u8, descriptor.handle),
-        .start_byte = 1,
-        .byte_count = 4096,
+        .selector = .{ .range = .{
+            .start_byte = 1,
+            .byte_count = 4096,
+        } },
     };
     defer page_input.deinit(alloc);
     const page = try readOutput(.{
@@ -355,7 +427,7 @@ test "read_tool_result pages and searches saved command replay handles" {
 
     var query_input = Input{
         .handle = try alloc.dupe(u8, descriptor.handle),
-        .query = try alloc.dupe(u8, "needle"),
+        .selector = .{ .query = try alloc.dupe(u8, "needle") },
     };
     defer query_input.deinit(alloc);
     const query = try readOutput(.{

--- a/tests/e2e/file-tool-paths.test.ts
+++ b/tests/e2e/file-tool-paths.test.ts
@@ -344,6 +344,45 @@ async function runTerminalToolScenario(args: {
 
 describe("filesystem path handling", () => {
   test(
+    "empty optional search paths use the workspace root",
+    async () => {
+      const root = createIsolatedRoot();
+      try {
+        const fixture = join(root.workspace, "empty-root.txt");
+        writeFileSync(fixture, "EMPTY_ROOT_NEEDLE\n");
+        const cases = [
+          {
+            id: "glob_empty_root_1",
+            name: "glob_files",
+            input: { pattern: "empty-root.txt", path: "" },
+            expected: "empty-root.txt",
+          },
+          {
+            id: "grep_empty_root_1",
+            name: "grep_files",
+            input: { pattern: "EMPTY_ROOT_NEEDLE", path: "" },
+            expected: "EMPTY_ROOT_NEEDLE",
+          },
+        ];
+
+        for (const scenario of cases) {
+          await runFirstCallToolScenario({
+            root,
+            id: scenario.id,
+            name: scenario.name,
+            input: scenario.input,
+            expectedResultRequest: [root.workspace],
+            expectedResultOutput: [scenario.expected],
+          });
+        }
+      } finally {
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "active added roots reach read cwd and search admission without loading their instructions",
     async () => {
       const root = createIsolatedRoot();

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2994,6 +2994,7 @@ describe("gateway stream lifecycle", () => {
     const tracePath = join(root.root, "trace.log");
     const readFileCallId = "suffixless_handle_read_file_1";
     const readResultCallId = "suffixless_handle_read_result_1";
+    const readRangeCallId = "suffixless_handle_read_range_1";
     const needle = "E2E_SUFFIX_NEEDLE";
     const lines = Array.from(
       { length: 500 },
@@ -3005,6 +3006,8 @@ describe("gateway stream lifecycle", () => {
     let step = 0;
     let canonicalHandle = "";
     let suffixlessHandle = "";
+    let projectedQueryInput: unknown = null;
+    let projectedRangeInput: unknown = null;
     const gateway = startGateway((body) => {
       switch (step++) {
         case 0:
@@ -3020,8 +3023,10 @@ describe("gateway stream lifecycle", () => {
           expect(canonicalHandle.endsWith(".txt")).toBe(true);
           suffixlessHandle = canonicalHandle.slice(0, -4);
           return fakeGatewayToolCall(readResultCallId, "read_tool_result", {
-            handle: suffixlessHandle,
-            query: needle,
+            request: {
+              handle: suffixlessHandle,
+              query: needle,
+            },
           });
         }
         case 2: {
@@ -3030,6 +3035,35 @@ describe("gateway stream lifecycle", () => {
           expect(output).toContain(
             `<tool_result_query handle="${canonicalHandle}">`,
           );
+          const request = JSON.parse(body) as {
+            prompt: Array<{ content?: Array<Record<string, unknown>> }>;
+          };
+          const parts = request.prompt.flatMap((message) => message.content ?? []);
+          projectedQueryInput = parts.find((part) =>
+            part.type === "tool-call" &&
+            part.toolCallId === readResultCallId &&
+            part.toolName === "read_tool_result"
+          )?.input;
+          return fakeGatewayToolCall(readRangeCallId, "read_tool_result", {
+            request: {
+              handle: suffixlessHandle,
+              start_byte: 1,
+              byte_count: 512,
+            },
+          });
+        }
+        case 3: {
+          const output = toolResultOutput(body, readRangeCallId);
+          expect(output).toContain("fixture line 000");
+          const request = JSON.parse(body) as {
+            prompt: Array<{ content?: Array<Record<string, unknown>> }>;
+          };
+          const parts = request.prompt.flatMap((message) => message.content ?? []);
+          projectedRangeInput = parts.find((part) =>
+            part.type === "tool-call" &&
+            part.toolCallId === readRangeCallId &&
+            part.toolName === "read_tool_result"
+          )?.input;
           return fakeGatewayFinalText("Suffixless result handle inspected.");
         }
         default:
@@ -3052,17 +3086,31 @@ describe("gateway stream lifecycle", () => {
       expect(result.code).toBe(0);
       expect(json.error).toBeUndefined();
       expect(json.output).toContain("Suffixless result handle inspected.");
-      expect(gateway.requestCount()).toBe(3);
+      expect(gateway.requestCount()).toBe(4);
       expect(json.tool_calls).toContainEqual({ name: "read_file", status: "success" });
       expect(json.tool_calls).toContainEqual({
         name: "read_tool_result",
         status: "success",
       });
+      expect(json.tool_calls.filter((call) => call.name === "read_tool_result")).toHaveLength(2);
       expect(existsSync(join(sessionRoot, "tool-results", canonicalHandle))).toBe(true);
       const sessionEvents = readFileSync(join(sessionRoot, "events.jsonl"), "utf8");
       expect(sessionEvents).toContain(suffixlessHandle);
       expect(sessionEvents).toContain(canonicalHandle);
       expect(sessionEvents).toContain(needle);
+      expect(projectedQueryInput).toEqual({
+        request: {
+          handle: suffixlessHandle,
+          query: needle,
+        },
+      });
+      expect(projectedRangeInput).toEqual({
+        request: {
+          handle: suffixlessHandle,
+          start_byte: 1,
+          byte_count: 512,
+        },
+      });
       expect(result.stderr).not.toContain("ResultHandleNotFound");
     } finally {
       gateway.stop();


### PR DESCRIPTION
## Summary

- Treat empty glob and grep paths as workspace-root defaults.
- Make retained-output query and range reads usable across supported model providers.
- Preserve older flat retained-output calls when conversations resume.