### PR TITLE
Fix macOS signing key access

### DIFF
--- a/scripts/sign-and-notarize-macos.sh
+++ b/scripts/sign-and-notarize-macos.sh
@@ -56,10 +56,12 @@ printf '%s' "${APPLE_NOTARY_KEY_P8_BASE64}" \
 "${security_bin}" import "${certificate_path}" \
     -k "${signing_keychain}" \
     -P "${APPLE_DEVELOPER_ID_P12_PASSWORD}" \
-    -T /usr/bin/codesign
+    -t cert \
+    -f pkcs12 \
+    -T /usr/bin/codesign \
+    -T /usr/bin/security
 "${security_bin}" set-key-partition-list \
     -S apple-tool:,apple:,codesign: \
-    -s \
     -k "${keychain_password}" \
     "${signing_keychain}" >/dev/null
 

--- a/scripts/tests/test_macos_signing.py
+++ b/scripts/tests/test_macos_signing.py
@@ -77,7 +77,10 @@ import sys
 
 args = sys.argv[1:]
 with pathlib.Path(os.environ["FX_SIGNING_TEST_LOG"]).open("a") as log:
-    log.write("security " + " ".join(args[:1]) + "\\n")
+    log.write("security " + " ".join(args) + "\\n")
+if args and args[0] == "set-key-partition-list" and "-s" in args:
+    print("error: The specified item could not be found in the keychain.", file=sys.stderr)
+    raise SystemExit(1)
 if args and args[0] == "find-identity":
     print('  1) HASH "{SIGNING_IDENTITY}"')
     print("     1 valid identities found")
@@ -225,6 +228,24 @@ else:
             self.assertIn("--timestamp", events)
             self.assertIn("xcrun notarytool submit", events)
             self.assertIn("xcrun notarytool log", events)
+
+    def test_imports_pkcs12_for_codesign_and_security(self) -> None:
+        self.assertTrue(SCRIPT_PATH.is_file(), "macOS signing helper is missing")
+        with tempfile.TemporaryDirectory(prefix="fx-macos-signing-test-") as tmp:
+            root = pathlib.Path(tmp)
+            result, _, _, event_log = self.run_script(root)
+
+            output = result.stdout + result.stderr
+            self.assertEqual(0, result.returncode, output)
+            import_event = next(
+                line
+                for line in event_log.read_text(encoding="utf-8").splitlines()
+                if line.startswith("security import ")
+            )
+            self.assertIn(" -t cert ", f" {import_event} ")
+            self.assertIn(" -f pkcs12 ", f" {import_event} ")
+            self.assertIn(" -T /usr/bin/codesign ", f" {import_event} ")
+            self.assertIn(" -T /usr/bin/security ", f" {import_event} ")
 
     def test_rejects_notarization_log_issues_and_cleans_credentials(self) -> None:
         self.assertTrue(SCRIPT_PATH.is_file(), "macOS signing helper is missing")


### PR DESCRIPTION
## Summary

- Import the Developer ID identity with explicit PKCS#12 keychain handling.
- Update private-key partitions without the Intel-incompatible signing filter.
- Keep identity, notarization, and ticket validation unchanged.