### PR TITLE
Import macOS signing private key

### DIFF
--- a/scripts/sign-and-notarize-macos.sh
+++ b/scripts/sign-and-notarize-macos.sh
@@ -56,7 +56,6 @@ printf '%s' "${APPLE_NOTARY_KEY_P8_BASE64}" \
 "${security_bin}" import "${certificate_path}" \
     -k "${signing_keychain}" \
     -P "${APPLE_DEVELOPER_ID_P12_PASSWORD}" \
-    -t cert \
     -f pkcs12 \
     -T /usr/bin/codesign \
     -T /usr/bin/security

--- a/scripts/tests/test_macos_signing.py
+++ b/scripts/tests/test_macos_signing.py
@@ -76,11 +76,18 @@ import pathlib
 import sys
 
 args = sys.argv[1:]
-with pathlib.Path(os.environ["FX_SIGNING_TEST_LOG"]).open("a") as log:
+event_log = pathlib.Path(os.environ["FX_SIGNING_TEST_LOG"])
+with event_log.open("a") as log:
     log.write("security " + " ".join(args) + "\\n")
-if args and args[0] == "set-key-partition-list" and "-s" in args:
-    print("error: The specified item could not be found in the keychain.", file=sys.stderr)
-    raise SystemExit(1)
+if args and args[0] == "set-key-partition-list":
+    import_event = next(
+        line
+        for line in event_log.read_text(encoding="utf-8").splitlines()
+        if line.startswith("security import ")
+    )
+    if "-s" in args or " -t cert " in f" {{import_event}} ":
+        print("error: The specified item could not be found in the keychain.", file=sys.stderr)
+        raise SystemExit(1)
 if args and args[0] == "find-identity":
     print('  1) HASH "{SIGNING_IDENTITY}"')
     print("     1 valid identities found")
@@ -229,7 +236,7 @@ else:
             self.assertIn("xcrun notarytool submit", events)
             self.assertIn("xcrun notarytool log", events)
 
-    def test_imports_pkcs12_for_codesign_and_security(self) -> None:
+    def test_imports_pkcs12_private_key_for_codesign_and_security(self) -> None:
         self.assertTrue(SCRIPT_PATH.is_file(), "macOS signing helper is missing")
         with tempfile.TemporaryDirectory(prefix="fx-macos-signing-test-") as tmp:
             root = pathlib.Path(tmp)
@@ -242,7 +249,7 @@ else:
                 for line in event_log.read_text(encoding="utf-8").splitlines()
                 if line.startswith("security import ")
             )
-            self.assertIn(" -t cert ", f" {import_event} ")
+            self.assertNotIn(" -t cert ", f" {import_event} ")
             self.assertIn(" -f pkcs12 ", f" {import_event} ")
             self.assertIn(" -T /usr/bin/codesign ", f" {import_event} ")
             self.assertIn(" -T /usr/bin/security ", f" {import_event} ")


### PR DESCRIPTION
## Summary

- Import the complete Developer ID PKCS#12 bundle so signing has both the certificate and private key.
- Keep explicit trust for `codesign` and `security` while preserving notarization validation and cleanup.