### PR TITLE
Fix macOS signing keychain contract

### DIFF
--- a/scripts/sign-and-notarize-macos.sh
+++ b/scripts/sign-and-notarize-macos.sh
@@ -45,6 +45,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
+fail_stage() {
+    echo "Apple signing failed during $1" >&2
+    exit 1
+}
+
 printf '%s' "${APPLE_DEVELOPER_ID_P12_BASE64}" \
     | "${openssl_bin}" base64 -d -A -out "${certificate_path}"
 printf '%s' "${APPLE_NOTARY_KEY_P8_BASE64}" \
@@ -53,39 +58,52 @@ printf '%s' "${APPLE_NOTARY_KEY_P8_BASE64}" \
 "${security_bin}" create-keychain -p "${keychain_password}" "${signing_keychain}"
 "${security_bin}" set-keychain-settings -lut 21600 "${signing_keychain}"
 "${security_bin}" unlock-keychain -p "${keychain_password}" "${signing_keychain}"
-"${security_bin}" import "${certificate_path}" \
+if ! "${security_bin}" import "${certificate_path}" \
     -k "${signing_keychain}" \
     -P "${APPLE_DEVELOPER_ID_P12_PASSWORD}" \
     -f pkcs12 \
     -T /usr/bin/codesign \
-    -T /usr/bin/security
-"${security_bin}" set-key-partition-list \
-    -S apple-tool:,apple:,codesign: \
+    -T /usr/bin/security; then
+    fail_stage "PKCS#12 import"
+fi
+if ! "${security_bin}" set-key-partition-list \
+    -S apple-tool:,apple: \
     -t private \
+    -l "${signing_identity}" \
     -k "${keychain_password}" \
-    "${signing_keychain}" >/dev/null
+    "${signing_keychain}" >/dev/null; then
+    fail_stage "private-key ACL configuration"
+fi
 
-signing_identities="$(
+if ! signing_identities="$(
     "${security_bin}" find-identity -v -p codesigning "${signing_keychain}"
-)"
+)"; then
+    fail_stage "signing identity lookup"
+fi
 if [[ "${signing_identities}" != *"${signing_identity}"* ]]; then
     echo "Developer ID signing identity is unavailable" >&2
     exit 1
 fi
 
-"${codesign_bin}" \
+if ! "${codesign_bin}" \
     --force \
     --sign "${signing_identity}" \
     --keychain "${signing_keychain}" \
     --identifier "${signing_identifier}" \
     --options runtime \
     --timestamp \
-    "${binary_path}"
-"${codesign_bin}" --verify --strict --verbose=4 "${binary_path}"
+    "${binary_path}"; then
+    fail_stage "code signing"
+fi
+if ! "${codesign_bin}" --verify --strict --verbose=4 "${binary_path}"; then
+    fail_stage "signature verification"
+fi
 
-signature_details="$(
+if ! signature_details="$(
     "${codesign_bin}" --display --verbose=4 "${binary_path}" 2>&1
-)"
+)"; then
+    fail_stage "signature inspection"
+fi
 if [[ "${signature_details}" != *"Identifier=${signing_identifier}"* ]]; then
     echo "Signed binary has the wrong signing identifier" >&2
     exit 1
@@ -104,12 +122,14 @@ if [[ -z "${signed_cdhash}" ]]; then
 fi
 
 "${ditto_bin}" -c -k "${binary_path}" "${notary_archive_path}"
-"${xcrun_bin}" notarytool submit "${notary_archive_path}" \
+if ! "${xcrun_bin}" notarytool submit "${notary_archive_path}" \
     --key "${notary_key_path}" \
     --key-id "${APPLE_NOTARY_KEY_ID}" \
     --issuer "${APPLE_NOTARY_ISSUER_ID}" \
     --wait \
-    --output-format json >"${notary_result_path}"
+    --output-format json >"${notary_result_path}"; then
+    fail_stage "notarization submission"
+fi
 
 notary_status="$("${jq_bin}" -r '.status' "${notary_result_path}")"
 submission_id="$("${jq_bin}" -r '.id' "${notary_result_path}")"
@@ -118,11 +138,13 @@ if [[ "${notary_status}" != "Accepted" || -z "${submission_id}" ]]; then
     exit 1
 fi
 
-"${xcrun_bin}" notarytool log "${submission_id}" \
+if ! "${xcrun_bin}" notarytool log "${submission_id}" \
     --key "${notary_key_path}" \
     --key-id "${APPLE_NOTARY_KEY_ID}" \
     --issuer "${APPLE_NOTARY_ISSUER_ID}" \
-    "${notary_log_path}"
+    "${notary_log_path}"; then
+    fail_stage "notarization log retrieval"
+fi
 if ! "${jq_bin}" -e \
     '.status == "Accepted" and ((.issues // []) | length == 0)' \
     "${notary_log_path}" >/dev/null; then

--- a/scripts/sign-and-notarize-macos.sh
+++ b/scripts/sign-and-notarize-macos.sh
@@ -66,13 +66,8 @@ if ! "${security_bin}" import "${certificate_path}" \
     -T /usr/bin/security; then
     fail_stage "PKCS#12 import"
 fi
-if ! "${security_bin}" set-key-partition-list \
-    -S apple-tool:,apple: \
-    -t private \
-    -l "${signing_identity}" \
-    -k "${keychain_password}" \
-    "${signing_keychain}" >/dev/null; then
-    fail_stage "private-key ACL configuration"
+if ! "${security_bin}" list-keychains -d user -s "${signing_keychain}"; then
+    fail_stage "keychain search configuration"
 fi
 
 if ! signing_identities="$(
@@ -83,6 +78,14 @@ fi
 if [[ "${signing_identities}" != *"${signing_identity}"* ]]; then
     echo "Developer ID signing identity is unavailable" >&2
     exit 1
+fi
+
+if ! "${security_bin}" set-key-partition-list \
+    -S apple-tool:,apple: \
+    -t private \
+    -k "${keychain_password}" \
+    "${signing_keychain}" >/dev/null; then
+    fail_stage "private-key ACL configuration"
 fi
 
 if ! "${codesign_bin}" \

--- a/scripts/tests/test_macos_signing.py
+++ b/scripts/tests/test_macos_signing.py
@@ -90,12 +90,16 @@ if args and args[0] == "set-key-partition-list":
     )
     partition_list = args[args.index("-S") + 1] if "-S" in args else ""
     key_type = args[args.index("-t") + 1] if "-t" in args else ""
-    key_label = args[args.index("-l") + 1] if "-l" in args else ""
+    search_list_configured = any(
+        line.startswith("security list-keychains -d user -s ")
+        for line in event_log.read_text(encoding="utf-8").splitlines()
+    )
     if (
         "-s" in args
         or partition_list != "apple-tool:,apple:"
         or key_type != "private"
-        or key_label != {SIGNING_IDENTITY!r}
+        or "-l" in args
+        or not search_list_configured
         or " -t cert " in f" {{import_event}} "
     ):
         print("error: The specified item could not be found in the keychain.", file=sys.stderr)
@@ -285,9 +289,17 @@ else:
                 "private",
                 partition_args[partition_args.index("-t") + 1],
             )
-            self.assertIn(f" -l {SIGNING_IDENTITY} ", f" {partition_event} ")
+            self.assertNotIn("-l", partition_args)
             self.assertNotIn("-s", partition_args)
             self.assertNotIn("codesign:", partition_args)
+            events = event_log.read_text(encoding="utf-8").splitlines()
+            search_index = next(
+                index
+                for index, line in enumerate(events)
+                if line.startswith("security list-keychains -d user -s ")
+            )
+            partition_index = events.index(partition_event)
+            self.assertLess(search_index, partition_index)
 
     def test_reports_failing_signing_stage_without_printing_secrets(self) -> None:
         self.assertTrue(SCRIPT_PATH.is_file(), "macOS signing helper is missing")
@@ -295,6 +307,10 @@ else:
             (
                 {"FX_SIGNING_TEST_SECURITY_FAIL_COMMAND": "import"},
                 "PKCS#12 import",
+            ),
+            (
+                {"FX_SIGNING_TEST_SECURITY_FAIL_COMMAND": "list-keychains"},
+                "keychain search configuration",
             ),
             (
                 {"FX_SIGNING_TEST_SECURITY_FAIL_COMMAND": "set-key-partition-list"},

--- a/scripts/tests/test_macos_signing.py
+++ b/scripts/tests/test_macos_signing.py
@@ -79,16 +79,23 @@ args = sys.argv[1:]
 event_log = pathlib.Path(os.environ["FX_SIGNING_TEST_LOG"])
 with event_log.open("a") as log:
     log.write("security " + " ".join(args) + "\\n")
+if args and args[0] == os.environ.get("FX_SIGNING_TEST_SECURITY_FAIL_COMMAND"):
+    print("injected security failure", file=sys.stderr)
+    raise SystemExit(1)
 if args and args[0] == "set-key-partition-list":
     import_event = next(
         line
         for line in event_log.read_text(encoding="utf-8").splitlines()
         if line.startswith("security import ")
     )
-    partition_args = f" {{' '.join(args)}} "
+    partition_list = args[args.index("-S") + 1] if "-S" in args else ""
+    key_type = args[args.index("-t") + 1] if "-t" in args else ""
+    key_label = args[args.index("-l") + 1] if "-l" in args else ""
     if (
         "-s" in args
-        or " -t private " not in partition_args
+        or partition_list != "apple-tool:,apple:"
+        or key_type != "private"
+        or key_label != {SIGNING_IDENTITY!r}
         or " -t cert " in f" {{import_event}} "
     ):
         print("error: The specified item could not be found in the keychain.", file=sys.stderr)
@@ -109,6 +116,9 @@ import sys
 args = sys.argv[1:]
 with pathlib.Path(os.environ["FX_SIGNING_TEST_LOG"]).open("a") as log:
     log.write("codesign " + " ".join(args) + "\\n")
+if os.environ.get("FX_SIGNING_TEST_CODESIGN_FAIL_STAGE") == "sign" and "--force" in args:
+    print("injected codesign failure", file=sys.stderr)
+    raise SystemExit(1)
 if "--force" in args:
     binary = pathlib.Path(args[-1])
     binary.write_bytes(binary.read_bytes() + b"signed\\n")
@@ -146,6 +156,9 @@ import sys
 args = sys.argv[1:]
 with pathlib.Path(os.environ["FX_SIGNING_TEST_LOG"]).open("a") as log:
     log.write("xcrun " + " ".join(args[:2]) + "\\n")
+if len(args) > 1 and args[1] == os.environ.get("FX_SIGNING_TEST_XCRUN_FAIL_COMMAND"):
+    print("injected xcrun failure", file=sys.stderr)
+    raise SystemExit(1)
 if args[:2] == ["notarytool", "submit"]:
     status = os.environ.get("FX_SIGNING_TEST_SUBMISSION_STATUS", "Accepted")
     print(json.dumps({{"id": "test-submission", "status": status}}))
@@ -263,7 +276,56 @@ else:
                 for line in event_log.read_text(encoding="utf-8").splitlines()
                 if line.startswith("security set-key-partition-list ")
             )
-            self.assertIn(" -t private ", f" {partition_event} ")
+            partition_args = partition_event.split()[2:]
+            self.assertEqual(
+                "apple-tool:,apple:",
+                partition_args[partition_args.index("-S") + 1],
+            )
+            self.assertEqual(
+                "private",
+                partition_args[partition_args.index("-t") + 1],
+            )
+            self.assertIn(f" -l {SIGNING_IDENTITY} ", f" {partition_event} ")
+            self.assertNotIn("-s", partition_args)
+            self.assertNotIn("codesign:", partition_args)
+
+    def test_reports_failing_signing_stage_without_printing_secrets(self) -> None:
+        self.assertTrue(SCRIPT_PATH.is_file(), "macOS signing helper is missing")
+        cases = (
+            (
+                {"FX_SIGNING_TEST_SECURITY_FAIL_COMMAND": "import"},
+                "PKCS#12 import",
+            ),
+            (
+                {"FX_SIGNING_TEST_SECURITY_FAIL_COMMAND": "set-key-partition-list"},
+                "private-key ACL configuration",
+            ),
+            (
+                {"FX_SIGNING_TEST_SECURITY_FAIL_COMMAND": "find-identity"},
+                "signing identity lookup",
+            ),
+            (
+                {"FX_SIGNING_TEST_CODESIGN_FAIL_STAGE": "sign"},
+                "code signing",
+            ),
+            (
+                {"FX_SIGNING_TEST_XCRUN_FAIL_COMMAND": "submit"},
+                "notarization submission",
+            ),
+        )
+        for extra_env, stage in cases:
+            with self.subTest(stage=stage):
+                with tempfile.TemporaryDirectory(
+                    prefix="fx-macos-signing-test-"
+                ) as tmp:
+                    root = pathlib.Path(tmp)
+                    result, _, _, _ = self.run_script(root, extra_env)
+
+                    output = result.stdout + result.stderr
+                    self.assertNotEqual(0, result.returncode, output)
+                    self.assertIn(f"Apple signing failed during {stage}", output)
+                    self.assertNotIn("p12-password", output)
+                    self.assertNotIn("p8-private-material", output)
 
     def test_rejects_notarization_log_issues_and_cleans_credentials(self) -> None:
         self.assertTrue(SCRIPT_PATH.is_file(), "macOS signing helper is missing")


### PR DESCRIPTION
## Summary

- Put the temporary signing keychain in the user search list before identity and ACL checks.
- Target private keys in that isolated keychain with `apple-tool:,apple:` partitions.
- Report distinct failures for import, ACL setup, identity lookup, signing, and notarization.