### PR TITLE
Reduce retained runtime initialization overhead

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -502,7 +502,9 @@ fn streamAgentCompletion(
     request: agent_stream_provider_contract.ModelRequest,
 ) anyerror!agent_stream_provider_contract.Result {
     if (request.credential.source == .chatgpt_subscription or request.credential.source == .grok_subscription) {
-        return error.SubscriptionCredentialCannotAuthorizeGateway;
+        return agent_stream_provider_contract.failResult(
+            error.SubscriptionCredentialCannotAuthorizeGateway,
+        );
     }
     const payload = try buildAgentRequest(alloc, request.data());
     defer alloc.free(payload);

--- a/src/core/agent/runtime/gateway_step.zig
+++ b/src/core/agent/runtime/gateway_step.zig
@@ -50,7 +50,9 @@ pub fn streamModelCompletion(
     usage: ?*session_usage.Usage,
     usage_allocator: Allocator,
 ) !StreamResult {
-    if (request_value.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request_value.cancel_flag.load(.seq_cst)) {
+        return agent_stream_provider.failResult(error.Cancelled);
+    }
     const started_at_ms = io_mod.milliTimestamp();
     var admission = InvocationAdmission{
         .usage = usage,
@@ -70,7 +72,7 @@ pub fn streamModelCompletion(
     };
     errdefer result.deinit(alloc);
     const observation = admission.observation orelse
-        return error.ProviderAdmissionMissing;
+        return agent_stream_provider.failResult(error.ProviderAdmissionMissing);
 
     recordProviderResultMetric(request.model, started_at_ms, result, request.trace_ctx);
     switch (result) {

--- a/src/core/agent/runtime/tool_contracts.zig
+++ b/src/core/agent/runtime/tool_contracts.zig
@@ -96,6 +96,22 @@ pub const ToolExecutionResult = struct {
     command_replay_capture: ?*command_replay_store.Capture = null,
 };
 
+pub inline fn failToolExecutionResult(err: anytype) @TypeOf(err)!ToolExecutionResult {
+    return @errorCast(failToolExecutionResultDynamic(err));
+}
+
+noinline fn failToolExecutionResultDynamic(err: anyerror) anyerror!ToolExecutionResult {
+    return err;
+}
+
+test "tool result failure writer preserves exact error type and identity" {
+    const failure = failToolExecutionResult(error.LiveToolAuthorityUnavailable);
+    try std.testing.expect(
+        @TypeOf(failure) == error{LiveToolAuthorityUnavailable}!ToolExecutionResult,
+    );
+    try std.testing.expectError(error.LiveToolAuthorityUnavailable, failure);
+}
+
 pub fn unavailableHostToolResult(alloc: Allocator) Allocator.Error!ToolExecutionResult {
     return .{
         .status = .failure,

--- a/src/core/agent/stream_provider.zig
+++ b/src/core/agent/stream_provider.zig
@@ -299,6 +299,20 @@ pub const Result = union(enum) {
     }
 };
 
+pub inline fn failResult(err: anytype) @TypeOf(err)!Result {
+    return @errorCast(failResultDynamic(err));
+}
+
+noinline fn failResultDynamic(err: anyerror) anyerror!Result {
+    return err;
+}
+
+test "result failure writer preserves exact error type and identity" {
+    const failure = failResult(error.Cancelled);
+    try std.testing.expect(@TypeOf(failure) == error{Cancelled}!Result);
+    try std.testing.expectError(error.Cancelled, failure);
+}
+
 pub const StreamFn = *const fn (
     context: ?*anyopaque,
     alloc: Allocator,
@@ -316,7 +330,7 @@ pub const Provider = struct {
 };
 
 fn unavailableStream(_: ?*anyopaque, _: Allocator, _: ModelRequest) anyerror!Result {
-    return error.AgentStreamProviderUnavailable;
+    return failResult(error.AgentStreamProviderUnavailable);
 }
 
 pub const unavailable_provider = Provider{

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -1268,13 +1268,13 @@ pub fn Runtime(comptime App: type) type {
             else
                 .{};
             ctx.help_menu = .{};
-            ctx.settings_menu = .{};
+            ctx.settings_menu.active = false;
             ctx.model_menu = if (comptime @hasField(App, "model_cache"))
                 render_input.modelMenuProjection(&app.model_cache)
             else
                 .{};
             ctx.session_menu = .{};
-            ctx.statusline_menu = .{};
+            ctx.statusline_menu.active = false;
             ctx.usage_menu = .{};
             ctx.workspace_menu = .{};
             ctx.upgrade_status = "";

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -1091,6 +1091,36 @@ pub const Persistence = struct {
     resume_handoff_intent: ResumeHandoffIntent = .none,
     pending_live_session_policy: ?BackgroundSessionPolicy = null,
 
+    /// Fieldwise initialization avoids retaining undefined optional payloads
+    /// in a static release-binary template.
+    pub fn initInto(storage: *Persistence) void {
+        comptime {
+            if (std.meta.fields(Persistence).len != 19) {
+                @compileError("update Persistence.initInto for the changed field set");
+            }
+        }
+        storage.* = undefined;
+        storage.write_mutex = .init;
+        storage.store = null;
+        storage.writable = null;
+        storage.subagent_host = null;
+        storage.workspace_preferences = null;
+        storage.session_preferences = null;
+        storage.js_host_store = .{};
+        storage.js_host_session = null;
+        storage.process_model_override = null;
+        storage.session_picker = .{};
+        storage.session_picker_load = .{};
+        storage.session_picker_current_cache = .{};
+        storage.session_picker_all_cache = .{};
+        storage.degraded_warning_emitted = false;
+        storage.pending_cancelled_command = null;
+        storage.image_snapshot_temp_dir = null;
+        storage.resume_view_admission = null;
+        storage.resume_handoff_intent = .none;
+        storage.pending_live_session_policy = null;
+    }
+
     pub fn deinit(self: *Persistence, alloc: Allocator) void {
         if (self.pending_live_session_policy) |policy| {
             debug_trace.logf(
@@ -1116,9 +1146,24 @@ pub const Persistence = struct {
         self.session_picker_load.deinit();
         self.session_picker_current_cache.deinit();
         self.session_picker_all_cache.deinit();
-        self.* = .{};
+        self.* = undefined;
     }
 };
+
+test "persistence in-place initialization preserves empty ownership" {
+    var persistence: Persistence = undefined;
+    Persistence.initInto(&persistence);
+    defer persistence.deinit(std.testing.allocator);
+
+    try std.testing.expect(persistence.store == null);
+    try std.testing.expect(persistence.writable == null);
+    try std.testing.expect(persistence.subagent_host == null);
+    try std.testing.expect(!persistence.session_picker.active);
+    try std.testing.expect(persistence.session_picker_load.task == null);
+    try std.testing.expect(!persistence.session_picker_current_cache.ready);
+    try std.testing.expect(!persistence.session_picker_all_cache.ready);
+    try std.testing.expect(persistence.resume_handoff_intent == .none);
+}
 
 pub fn Runtime(comptime App: type) type {
     return struct {

--- a/src/core/app/usage_dashboard_runtime.zig
+++ b/src/core/app/usage_dashboard_runtime.zig
@@ -75,6 +75,25 @@ pub const Runtime = struct {
         return .{ .alloc = alloc };
     }
 
+    /// Fieldwise initialization avoids retaining undefined cache payloads in
+    /// a static release-binary template.
+    pub fn initInto(storage: *Self, alloc: Allocator) void {
+        comptime {
+            if (std.meta.fields(Self).len != 8) {
+                @compileError("update Runtime.initInto for the changed field set");
+            }
+        }
+        storage.* = undefined;
+        storage.alloc = alloc;
+        storage.mutex = .init;
+        storage.thread = null;
+        storage.state = .idle;
+        storage.completion_pending = false;
+        storage.cache = null;
+        storage.last_error = null;
+        storage.cancel_requested = .init(false);
+    }
+
     pub fn deinit(self: *Self) void {
         self.cancel_requested.store(true, .seq_cst);
         if (self.thread) |thread| {
@@ -205,6 +224,19 @@ pub const Runtime = struct {
         self.mutex.unlock(io_mod.getIo());
     }
 };
+
+test "usage dashboard in-place initialization preserves idle state" {
+    var runtime: Runtime = undefined;
+    Runtime.initInto(&runtime, std.testing.allocator);
+    defer runtime.deinit();
+
+    try std.testing.expect(runtime.thread == null);
+    try std.testing.expect(runtime.state == .idle);
+    try std.testing.expect(!runtime.completion_pending);
+    try std.testing.expect(runtime.cache == null);
+    try std.testing.expect(runtime.last_error == null);
+    try std.testing.expect(!runtime.cancel_requested.load(.seq_cst));
+}
 
 fn loadProfileSnapshots(
     context: *anyopaque,

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -803,6 +803,46 @@ pub const Runtime = struct {
         };
     }
 
+    /// Fieldwise initialization avoids retaining inactive credential and
+    /// worker payloads in a static release-binary template.
+    pub fn initInto(
+        storage: *Self,
+        validator: api_key_validator.Provider,
+        transport: oauth_transport.Provider,
+        secret_store: host.SecretStore,
+    ) void {
+        comptime {
+            if (std.meta.fields(Self).len != 24) {
+                @compileError("update Runtime.initInto for the changed field set");
+            }
+        }
+        storage.* = undefined;
+        storage.api_key_validator = validator;
+        storage.oauth_transport = transport;
+        storage.secret_store = secret_store;
+        storage.selected_credential = null;
+        storage.credential_refresh_failure_source = null;
+        storage.source_inventory = .empty;
+        storage.stored_key_status = .not_attempted;
+        storage.onboarding_skipped = false;
+        storage.picker_active = false;
+        storage.picker_selection = null;
+        storage.picker_include_skip = false;
+        storage.picker_stage = .root;
+        storage.provider_picker_active = .gateway;
+        storage.fx_login_session_available = false;
+        storage.team_selection = null;
+        storage.team_query = .empty;
+        storage.sign_in_flow = .{};
+        storage.sign_in_source = .fx_login;
+        storage.sign_in_returns_to_root = false;
+        storage.sign_in_code_visible = false;
+        storage.sign_in_code_input = .empty;
+        storage.api_key_input = .empty;
+        storage.api_key_returns_to_root = false;
+        storage.api_key_save = .{};
+    }
+
     pub fn deinit(self: *Self, alloc: Allocator) void {
         self.api_key_save.deinit(alloc);
         self.sign_in_flow.deinit(alloc);
@@ -811,7 +851,7 @@ pub const Runtime = struct {
         self.clearTeamSelection(alloc);
         self.team_query.deinit(alloc);
         if (self.selected_credential) |*credential| credential.deinit(alloc);
-        self.* = .{};
+        self.* = undefined;
     }
 
     /// Borrows the current credential until this runtime replaces or releases it.
@@ -1751,6 +1791,30 @@ pub const Runtime = struct {
         }
     }
 };
+
+test "auth in-place initialization preserves empty runtime state" {
+    var runtime: Runtime = undefined;
+    Runtime.initInto(
+        &runtime,
+        api_key_validator.unavailable_provider,
+        oauth_transport.unavailable_provider,
+        host.unavailable_secret_store,
+    );
+    defer runtime.deinit(std.testing.allocator);
+
+    try std.testing.expect(runtime.selected_credential == null);
+    try std.testing.expect(runtime.credential_refresh_failure_source == null);
+    try std.testing.expect(runtime.source_inventory.count() == 0);
+    try std.testing.expect(runtime.stored_key_status == .not_attempted);
+    try std.testing.expect(!runtime.picker_active);
+    try std.testing.expect(runtime.picker_selection == null);
+    try std.testing.expect(runtime.picker_stage == .root);
+    try std.testing.expect(runtime.provider_picker_active == .gateway);
+    try std.testing.expect(runtime.team_selection == null);
+    try std.testing.expect(runtime.team_query.items.len == 0);
+    try std.testing.expect(runtime.sign_in_code_input.items.len == 0);
+    try std.testing.expect(runtime.api_key_input.items.len == 0);
+}
 
 fn probeCredentialSource(raw_context: ?*anyopaque, alloc: Allocator, source: credentials.Source) !bool {
     const self: *Runtime = @ptrCast(@alignCast(raw_context.?));

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -851,7 +851,7 @@ pub const Runtime = struct {
         self.clearTeamSelection(alloc);
         self.team_query.deinit(alloc);
         if (self.selected_credential) |*credential| credential.deinit(alloc);
-        self.* = undefined;
+        self.* = .{};
     }
 
     /// Borrows the current credential until this runtime replaces or releases it.

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -308,6 +308,20 @@ pub const PromptRunResult = struct {
     }
 };
 
+inline fn failPromptRunResult(err: anytype) @TypeOf(err)!PromptRunResult {
+    return @errorCast(failPromptRunResultDynamic(err));
+}
+
+noinline fn failPromptRunResultDynamic(err: anyerror) anyerror!PromptRunResult {
+    return err;
+}
+
+test "prompt result failure writer preserves exact error type and identity" {
+    const failure = failPromptRunResult(error.NoPendingRecovery);
+    try std.testing.expect(@TypeOf(failure) == error{NoPendingRecovery}!PromptRunResult);
+    try std.testing.expectError(error.NoPendingRecovery, failure);
+}
+
 /// Resume selector parsed from fx ask --resume.
 const ResumeTarget = session_store.ResumeTarget;
 
@@ -1519,9 +1533,9 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     var recovery_checkpoint: ?session_codec.RecoveryCheckpoint = null;
     defer if (recovery_checkpoint) |*checkpoint| checkpoint.deinit(alloc);
     if (options.continue_recovery) {
-        const writable = if (ctx.writable) |*value| value else return error.RecoverySessionUnavailable;
+        const writable = if (ctx.writable) |*value| value else return failPromptRunResult(error.RecoverySessionUnavailable);
         const checkpoint = writable.state.recovery_checkpoint orelse
-            return error.NoPendingRecovery;
+            return failPromptRunResult(error.NoPendingRecovery);
         recovery_checkpoint = try checkpoint.dupe(alloc);
         alloc.free(owned_prompt);
         owned_prompt = try alloc.dupe(u8, recovery_checkpoint.?.user.text);
@@ -1596,7 +1610,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
             usize,
             restored_image_bounds.next_id,
             current_images.len - 1,
-        ) catch return error.ImageIdOverflow;
+        ) catch return failPromptRunResult(error.ImageIdOverflow);
         for (current_images, 0..) |*image, index| image.id = restored_image_bounds.next_id + index;
         try ctx.captureImageAttachments(current_images);
         try ctx.checkCancellation();
@@ -1669,7 +1683,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
             try ctx.writeStderr("fx ask: ");
             try ctx.writeStderr(failure);
             try ctx.writeStderr("\n");
-            return error.McpRequiredServerUnavailable;
+            return failPromptRunResult(error.McpRequiredServerUnavailable);
         }
     }
     const session_child_capability = if (ctx.writable) |*writable|
@@ -2242,6 +2256,22 @@ fn requestToolPermissionOutcomeWithRequest(raw_ctx: *anyopaque, arena: Allocator
     );
 }
 
+inline fn failPermissionOutcome(err: anytype) @TypeOf(err)!command_admission.PermissionOutcome {
+    return @errorCast(failPermissionOutcomeDynamic(err));
+}
+
+noinline fn failPermissionOutcomeDynamic(err: anyerror) anyerror!command_admission.PermissionOutcome {
+    return err;
+}
+
+test "permission outcome failure writer preserves exact error type and identity" {
+    const failure = failPermissionOutcome(error.NonInteractivePermissionRequired);
+    try std.testing.expect(
+        @TypeOf(failure) == error{NonInteractivePermissionRequired}!command_admission.PermissionOutcome,
+    );
+    try std.testing.expectError(error.NonInteractivePermissionRequired, failure);
+}
+
 fn finishCliPermissionOutcome(
     ctx: *AskContext,
     tool_ctx: tool_runtime.Context,
@@ -2282,7 +2312,7 @@ fn finishCliPermissionOutcome(
         "Permission required",
         null,
     );
-    return error.NonInteractivePermissionRequired;
+    return failPermissionOutcome(error.NonInteractivePermissionRequired);
 }
 
 const TestReviewTurn = struct {

--- a/src/core/gateway/gateway_provider.zig
+++ b/src/core/gateway/gateway_provider.zig
@@ -174,7 +174,7 @@ pub const CapabilityResolver = struct {
                             "model catalog lookup outcome=cancelled model={s}",
                             .{model},
                         );
-                        return error.Cancelled;
+                        return failCapabilities(error.Cancelled);
                     }
                     self.state = .failed;
                     debug_trace.logf(
@@ -252,6 +252,22 @@ pub const CapabilityResolver = struct {
         self.state = .ready;
     }
 };
+
+inline fn failCapabilities(err: anytype) @TypeOf(err)!model_capabilities.Capabilities {
+    return @errorCast(failCapabilitiesDynamic(err));
+}
+
+noinline fn failCapabilitiesDynamic(err: anyerror) anyerror!model_capabilities.Capabilities {
+    return err;
+}
+
+test "capability failure writer preserves exact error type and identity" {
+    const failure = failCapabilities(error.Cancelled);
+    try std.testing.expect(
+        @TypeOf(failure) == error{Cancelled}!model_capabilities.Capabilities,
+    );
+    try std.testing.expectError(error.Cancelled, failure);
+}
 
 const FakeCatalog = struct {
     outcome: enum {

--- a/src/core/terminal/client.zig
+++ b/src/core/terminal/client.zig
@@ -57,6 +57,20 @@ pub const Completion = struct {
     }
 };
 
+inline fn failCompletion(err: anytype) @TypeOf(err)!Completion {
+    return @errorCast(failCompletionDynamic(err));
+}
+
+noinline fn failCompletionDynamic(err: anyerror) anyerror!Completion {
+    return err;
+}
+
+test "completion failure writer preserves exact error type and identity" {
+    const failure = failCompletion(error.InvalidHostMessage);
+    try std.testing.expect(@TypeOf(failure) == error{InvalidHostMessage}!Completion);
+    try std.testing.expectError(error.InvalidHostMessage, failure);
+}
+
 const Intent = struct {
     correlation_id: contracts.CorrelationId,
     request: contracts.OwnedActionRequest,
@@ -674,7 +688,7 @@ fn exchangeConnected(
                 const correlation_id = message.envelope.correlation_id.?;
                 if (correlation_id.value != intent.correlation_id.value) {
                     frame.deinit();
-                    return error.InvalidResponseCorrelation;
+                    return failCompletion(error.InvalidResponseCorrelation);
                 }
                 return .{
                     .kind = .response,
@@ -684,7 +698,7 @@ fn exchangeConnected(
             },
             .hello, .request, .cancel => {
                 frame.deinit();
-                return error.InvalidHostMessage;
+                return failCompletion(error.InvalidHostMessage);
             },
         }
     }

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -371,7 +371,9 @@ pub fn executeToolCallAuthorized(
         if (!containsName(authority.tools, request.call.name) and
             !containsName(authority.integrations, request.call.name))
         {
-            return error.LiveToolAuthorityUnavailable;
+            return tool_contracts.failToolExecutionResult(
+                error.LiveToolAuthorityUnavailable,
+            );
         }
         execution_ctx.permission_mode = authority.permission_mode;
         execution_ctx.permission_grants = authority.grants;

--- a/src/gateway/openai_codex.zig
+++ b/src/gateway/openai_codex.zig
@@ -133,15 +133,15 @@ fn streamCompletion(
     alloc: Allocator,
     request: stream_provider.ModelRequest,
 ) !stream_provider.Result {
-    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
     if (request.credential.source != .chatgpt_subscription) {
-        return error.CodexSubscriptionCredentialRequired;
+        return stream_provider.failResult(error.CodexSubscriptionCredentialRequired);
     }
     try validateModel(request.model);
     const payload = try buildRequest(alloc, request.data());
     defer alloc.free(payload);
     return streamPrepared(alloc, request, payload) catch |err| {
-        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+        if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
         request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(err, request.delivery.load());
         return err;
     };
@@ -188,13 +188,15 @@ pub fn streamPrepared(
     request: stream_provider.ModelRequest,
     payload: []const u8,
 ) !stream_provider.Result {
-    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
     const account_id = try chatgpt_oauth.extractAccountId(alloc, request.credential.secret);
     defer alloc.free(account_id);
     const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.credential.secret});
     defer secret.zeroAndFree(alloc, auth_header);
     const request_endpoint = if (io_mod.getenv(e2e_endpoint_env)) |override| endpoint: {
-        if (!gateway_client.isLoopbackHttpUrl(override)) return error.InvalidE2EOpenAICodexEndpoint;
+        if (!gateway_client.isLoopbackHttpUrl(override)) {
+            return stream_provider.failResult(error.InvalidE2EOpenAICodexEndpoint);
+        }
         break :endpoint override;
     } else endpoint;
     const uri = try std.Uri.parse(request_endpoint);

--- a/src/gateway/xai_grok.zig
+++ b/src/gateway/xai_grok.zig
@@ -120,25 +120,27 @@ fn streamCompletion(
     alloc: Allocator,
     request: stream_provider.ModelRequest,
 ) !stream_provider.Result {
-    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
     if (request.credential.source != .grok_subscription) {
-        return error.GrokSubscriptionCredentialRequired;
+        return stream_provider.failResult(error.GrokSubscriptionCredentialRequired);
     }
     const account_id = request.credential.account_id orelse
-        return error.GrokSubscriptionAccountRequired;
-    if (!grok_session.validAccountId(account_id)) return error.InvalidGrokSubscriptionAccount;
+        return stream_provider.failResult(error.GrokSubscriptionAccountRequired);
+    if (!grok_session.validAccountId(account_id)) {
+        return stream_provider.failResult(error.InvalidGrokSubscriptionAccount);
+    }
     try validateModel(request.model);
     const payload = try buildRequest(alloc, request.data());
     defer alloc.free(payload);
     var result = streamPrepared(alloc, request, payload) catch |err| {
-        if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
-        if (requestDeadlineExpired(request)) return error.Timeout;
+        if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
+        if (requestDeadlineExpired(request)) return stream_provider.failResult(error.Timeout);
         request.attempt_evidence.network_failure = gateway_client.networkFailureEvidence(err, request.delivery.load());
         return err;
     };
     if (requestDeadlineExpired(request)) {
         result.deinit(alloc);
-        return error.Timeout;
+        return stream_provider.failResult(error.Timeout);
     }
     return result;
 }
@@ -190,12 +192,14 @@ pub fn streamPrepared(
     request: stream_provider.ModelRequest,
     payload: []const u8,
 ) !stream_provider.Result {
-    if (request.cancel_flag.load(.seq_cst)) return error.Cancelled;
+    if (request.cancel_flag.load(.seq_cst)) return stream_provider.failResult(error.Cancelled);
     const account_id = request.credential.account_id.?;
     const auth_header = try std.fmt.allocPrint(alloc, "Bearer {s}", .{request.credential.secret});
     defer secret.zeroAndFree(alloc, auth_header);
     const request_endpoint = if (io_mod.getenv(e2e_endpoint_env)) |override| endpoint: {
-        if (!gateway_client.isLoopbackHttpUrl(override)) return error.InvalidE2EXaiGrokEndpoint;
+        if (!gateway_client.isLoopbackHttpUrl(override)) {
+            return stream_provider.failResult(error.InvalidE2EXaiGrokEndpoint);
+        }
         break :endpoint override;
     } else endpoint;
     const uri = try std.Uri.parse(request_endpoint);

--- a/src/main.zig
+++ b/src/main.zig
@@ -355,6 +355,21 @@ test "skill submit snapshot keeps display spans exact while agent bindings dedup
 var resize_interlock = shell_runtime.ResizeApprovalInterlock{};
 const default_context_registry = context_contract.Registry{ .default_provider = builtin_context.provider };
 const WorkspaceHostRuntime = if (host_target.is_wasm) js_host_workspace.Runtime else struct {};
+const selected_host_profile = if (host_target.is_wasm) host_runtime_profile.wasm else host_runtime_profile.native;
+const app_api_key_validator = if (host_target.is_wasm)
+    api_key_validator.unavailable_provider
+else
+    builtin_gateway.api_key_validator;
+const app_oauth_transport = if (selected_host_profile.js_host_auth)
+    js_host_auth.oauth_provider
+else if (selected_host_profile.native_auth)
+    builtin_gateway.oauth_transport_provider
+else
+    oauth_transport.unavailable_provider;
+const app_secret_store = if (host_target.is_wasm)
+    host.unavailable_secret_store
+else
+    native_host.secret_store;
 const wasm_skill_root_policy: @import("core/skills/skill_contract.zig").RootPolicy = .{
     .managed_root_source = null,
 };
@@ -368,7 +383,7 @@ fn currentBuild() update_target.CurrentBuild {
 
 const App = struct {
     pub const app_version = version;
-    pub const host_profile = if (host_target.is_wasm) host_runtime_profile.wasm else host_runtime_profile.native;
+    pub const host_profile = selected_host_profile;
     pub const input_limits = paste_framing.default_input_limits;
     pub const build_update_channel = compiled_update_channel;
     pub const build_revision = build_options.git_commit;
@@ -490,14 +505,9 @@ const App = struct {
     terminal: TerminalState = .{},
 
     auth: auth_runtime.Runtime = auth_runtime.Runtime.init(
-        if (host_target.is_wasm) api_key_validator.unavailable_provider else builtin_gateway.api_key_validator,
-        if (host_profile.js_host_auth)
-            js_host_auth.oauth_provider
-        else if (host_profile.native_auth)
-            builtin_gateway.oauth_transport_provider
-        else
-            oauth_transport.unavailable_provider,
-        if (host_target.is_wasm) host.unavailable_secret_store else native_host.secret_store,
+        app_api_key_validator,
+        app_oauth_transport,
+        app_secret_store,
     ),
     provider_selection: provider_runtime.Runtime = provider_runtime.Runtime.init(std.heap.c_allocator),
     model_cache: model_cache_runtime.Runtime = model_cache_runtime.Runtime.init(std.heap.c_allocator, builtin_gateway.models_path),
@@ -586,6 +596,9 @@ const App = struct {
     pub fn init(alloc: Allocator, launch: *cli_surface.InteractiveLaunch) !Self {
         var app = Self{
             .alloc = alloc,
+            .auth = undefined,
+            .usage_dashboard = undefined,
+            .session_persistence = undefined,
             .shell = TranscriptRuntime.init(),
             .subagents = ui_subagents.Controller.init(),
             .lifecycle_runtime = hooks.Runtime.init(alloc),
@@ -598,6 +611,14 @@ const App = struct {
             else
                 background_process.provider),
         };
+        auth_runtime.Runtime.initInto(
+            &app.auth,
+            app_api_key_validator,
+            app_oauth_transport,
+            app_secret_store,
+        );
+        usage_dashboard_runtime.Runtime.initInto(&app.usage_dashboard, std.heap.c_allocator);
+        app_session_runtime.Persistence.initInto(&app.session_persistence);
         if (comptime host_profile.js_host_workspace) {
             app.workspace_host = js_host_workspace.Runtime.init(alloc) catch |err| blk: {
                 if (err != error.WorkspaceUnavailable) {


### PR DESCRIPTION
## Summary

- Initialize large runtime state without retaining unused payload templates.
- Preserve provider, permission, terminal, and CLI failure behavior while sharing cold error-result construction.
- Reduce the macOS arm64 ReleaseSafe binary by 32,864 bytes on current main.