### PR TITLE
Keep arm64 signing inside the release workflow

### DIFF
--- a/.github/workflows/pgso-macos-arm64.yml
+++ b/.github/workflows/pgso-macos-arm64.yml
@@ -2,12 +2,6 @@ name: macOS arm64 PGSO candidate
 
 on:
   workflow_call:
-    inputs:
-      package_release:
-        description: Package the eligible candidate as the stable macOS arm64 artifact
-        required: false
-        type: boolean
-        default: false
   workflow_dispatch:
   pull_request:
     paths:
@@ -463,56 +457,3 @@ jobs:
           path: ${{ runner.temp }}/fx-pgso-aggregate
           if-no-files-found: error
           retention-days: 14
-
-  sign-stable-release:
-    name: Sign stable macOS arm64 release
-    needs: aggregate
-    if: inputs.package_release
-    runs-on: macos-15
-    environment: apple-signing
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-
-      - name: Require native arm64 host
-        run: test "$(uname -m)" = arm64
-
-      - name: Download eligible candidate
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: pgso-evidence-macos-arm64-${{ github.sha }}
-          path: ${{ runner.temp }}/fx-pgso-aggregate
-
-      - name: Restore executable mode
-        run: chmod +x "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx"
-
-      - name: Confirm release eligibility
-        run: python3 -m scripts.pgso report --output-dir "$RUNNER_TEMP/fx-pgso-aggregate" >/dev/null
-
-      - name: Sign and notarize stable release candidate
-        env:
-          APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}
-          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
-          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
-          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-        run: scripts/sign-and-notarize-macos.sh "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx"
-
-      - name: Package stable release candidate
-        run: |
-          archive="$RUNNER_TEMP/fx-macos-aarch64.tar.gz"
-          package_dir="$RUNNER_TEMP/fx-release-package"
-          mkdir -p "$package_dir"
-          cp "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx" LICENSE THIRD_PARTY_NOTICES.md "$package_dir/"
-          tar -czf "$archive" -C "$package_dir" fx LICENSE THIRD_PARTY_NOTICES.md
-          cd "$RUNNER_TEMP"
-          shasum -a 256 fx-macos-aarch64.tar.gz > fx-macos-aarch64.tar.gz.sha256
-
-      - name: Upload stable release artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: fx-macos-aarch64
-          path: |
-            ${{ runner.temp }}/fx-macos-aarch64.tar.gz
-            ${{ runner.temp }}/fx-macos-aarch64.tar.gz.sha256
-          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,11 +130,65 @@ jobs:
       actions: read
       contents: read
     uses: ./.github/workflows/pgso-macos-arm64.yml
-    with:
-      package_release: true
+
+  sign-macos-arm64:
+    needs: [check-version, build-macos-arm64]
+    if: needs.check-version.outputs.needed == 'true'
+    name: Sign macos-arm64
+    runs-on: macos-15
+    environment: apple-signing
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Require native arm64 host
+        run: test "$(uname -m)" = arm64
+
+      - name: Download eligible candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: pgso-evidence-macos-arm64-${{ github.sha }}
+          path: ${{ runner.temp }}/fx-pgso-aggregate
+
+      - name: Restore executable mode
+        run: chmod +x "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx"
+
+      - name: Confirm release eligibility
+        run: python3 -m scripts.pgso report --output-dir "$RUNNER_TEMP/fx-pgso-aggregate" >/dev/null
+
+      - name: Sign and notarize stable release candidate
+        env:
+          APPLE_DEVELOPER_ID_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_NOTARY_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+        run: scripts/sign-and-notarize-macos.sh "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx"
+
+      - name: Package stable release candidate
+        run: |
+          archive="$RUNNER_TEMP/fx-macos-aarch64.tar.gz"
+          package_dir="$RUNNER_TEMP/fx-release-package"
+          mkdir -p "$package_dir"
+          cp "$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx" LICENSE THIRD_PARTY_NOTICES.md "$package_dir/"
+          tar -czf "$archive" -C "$package_dir" fx LICENSE THIRD_PARTY_NOTICES.md
+          cd "$RUNNER_TEMP"
+          shasum -a 256 fx-macos-aarch64.tar.gz > fx-macos-aarch64.tar.gz.sha256
+
+      - name: Upload stable release artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fx-macos-aarch64
+          path: |
+            ${{ runner.temp }}/fx-macos-aarch64.tar.gz
+            ${{ runner.temp }}/fx-macos-aarch64.tar.gz.sha256
+          if-no-files-found: error
 
   release:
-    needs: [check-version, build-linux, build-macos-x86_64, build-macos-arm64]
+    needs: [check-version, build-linux, build-macos-x86_64, sign-macos-arm64]
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/scripts/tests/test_macos_signing.py
+++ b/scripts/tests/test_macos_signing.py
@@ -477,26 +477,35 @@ class MacosSigningWorkflowTests(unittest.TestCase):
 
         self.assertIn("build-macos-x86_64:", release)
         self.assertIn("runs-on: macos-15-intel", release)
-        self.assertEqual(1, release.count("environment: apple-signing"))
+        self.assertIn("sign-macos-arm64:", release)
+        self.assertEqual(2, release.count("environment: apple-signing"))
         self.assertIn("scripts/sign-and-notarize-macos.sh zig-out/bin/fx", release)
-        self.assertIn("sign-stable-release:", pgso)
-        self.assertIn("needs: aggregate", pgso)
-        self.assertEqual(1, pgso.count("environment: apple-signing"))
+        self.assertNotIn("sign-stable-release:", pgso)
+        self.assertNotIn("package_release", pgso)
+        self.assertNotIn("environment: apple-signing", pgso)
         self.assertIn(
             "scripts/sign-and-notarize-macos.sh "
             '"$RUNNER_TEMP/fx-pgso-aggregate/candidate/fx"',
-            pgso,
+            release,
         )
-        self.assertIn("if: inputs.package_release", pgso)
         arm64_caller = release.split("  build-macos-arm64:\n", 1)[1].split(
-            "\n  release:\n", 1
+            "\n  sign-macos-arm64:\n", 1
         )[0]
         self.assertNotIn("secrets:", arm64_caller)
+        self.assertNotIn("package_release", arm64_caller)
+        sign_release = release.split("  sign-macos-arm64:\n", 1)[1].split(
+            "\n  release:\n", 1
+        )[0]
+        self.assertIn("needs: [check-version, build-macos-arm64]", sign_release)
+        self.assertIn("environment: apple-signing", sign_release)
+        self.assertIn(
+            "needs: [check-version, build-linux, build-macos-x86_64, sign-macos-arm64]",
+            release,
+        )
         workflow_call = pgso.split("  workflow_dispatch:\n", 1)[0]
         aggregate = pgso.split("  aggregate:\n", 1)[1].split(
-            "\n  sign-stable-release:\n", 1
+            "\n  sign-macos-arm64:\n", 1
         )[0]
-        sign_release = pgso.split("  sign-stable-release:\n", 1)[1]
         self.assertIn(
             "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
             sign_release,
@@ -520,7 +529,9 @@ class MacosSigningWorkflowTests(unittest.TestCase):
             self.assertIn(secret_reference, sign_release)
             self.assertNotIn(secret_name, workflow_call)
             self.assertNotIn(secret_name, aggregate)
+            self.assertNotIn(secret_name, pgso)
             self.assertNotIn(secret_name, dev_release)
+        self.assertNotIn("sign-and-notarize-macos", pgso)
         self.assertNotIn("sign-and-notarize-macos", dev_release)
 
     def test_pgso_release_chain_pins_every_external_action(self) -> None:


### PR DESCRIPTION
The stable arm64 signing job ran inside a reusable workflow and received empty Apple environment secrets.

Move the final signer into the release workflow, after secret-free PGSO qualification, so the protected apple-signing environment supplies credentials directly. Publication now waits for that signed artifact.

Verification:
- `python3 -m unittest scripts.tests.test_macos_signing -v`
- `actionlint .github/workflows/release.yml .github/workflows/pgso-macos-arm64.yml`
- `zig fmt --check src/`