### PR TITLE
Reduce duplicate tool result state

### DIFF
--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -2655,6 +2655,8 @@ test "built-in vision dispatch uses supplied runtime provider" {
 
     var fixture = Fixture{};
     const vision_registry = tool_dispatch.Registry{ .tools = &.{vision} };
+    var status_detail: ?[]u8 = null;
+    defer if (status_detail) |detail| std.testing.allocator.free(detail);
     var result = try tool_dispatch.dispatchAuthorizedToolCall(.{
         .allocator = std.testing.allocator,
         .vision_provider = .{
@@ -2665,7 +2667,7 @@ test "built-in vision dispatch uses supplied runtime provider" {
         .id = "vision_1",
         .name = "vision",
         .arguments_json = "{\"image_ids\":[7,9],\"focus\":\"read status\"}",
-    });
+    }, &status_detail);
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expectEqual(.success, result.status);

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -25,7 +25,6 @@ const tool_result_errors = @import("../../tooling/tool_result_errors.zig");
 const tooling_tool_admission = @import("../../tooling/tool_admission.zig");
 const tool_args = @import("../../tooling/tool_args.zig");
 const hooks = @import("../../hooks/hooks.zig");
-const command_contract = @import("../../execution/command_contract.zig");
 const command_environment = @import("../../execution/command_environment.zig");
 const terminal_contracts = @import("../../terminal/contracts.zig");
 const context_contract = @import("../../workspace/context_contract.zig");
@@ -7294,7 +7293,7 @@ fn processQueuedPromptLoop(
                 }
                 continue;
             }
-            if (execution.prepared_result_memory != null or
+            if (execution.tool_result_memory_prepared or
                 execution.deferred_tool_completion != null)
             {
                 return error.InvalidPreparedToolExecutionResult;
@@ -7311,8 +7310,6 @@ fn processQueuedPromptLoop(
             runtime_parallel_execution.reportInnerToolUsage(deps, tool_call.name, execution);
             if (execution.diff_entry) |payload| {
                 try deps.push_diff_block(deps.ctx, payload);
-            } else if (execution.display_output) |display| {
-                try deps.push_text(deps.ctx, .{ .operational = display });
             }
             var replay_handed_off = execution.command_replay_capture == null;
             defer if (!replay_handed_off) {
@@ -7427,37 +7424,21 @@ fn processQueuedPromptLoop(
                 else
                     "";
                 stop_state.terminal_materializing = true;
-                if (execution.background_command) |background| {
-                    try finishCommonBackgroundTerminal(
-                        deps,
-                        finalization,
-                        arena,
-                        job,
-                        within_turn_suffix.items,
-                        &summary_accumulator,
-                        assistant_text,
-                        background,
-                        &finish_trace,
-                    );
-                    debug_trace.eventf("tool", "after_tool_execution", step_ctx, "call_id={s} name={s} result_kind=background model_output_bytes={d}", .{ tool_call.id, tool_call.name, safe_tool_output.len });
-                    debug_trace.eventf("tool", "execution_result", step_ctx, "call_id={s} name={s} result_kind=background model_output_bytes={d}", .{ tool_call.id, tool_call.name, safe_tool_output.len });
-                } else {
-                    try finishCommonAssistantTerminal(
-                        deps,
-                        finalization,
-                        arena,
-                        job,
-                        within_turn_suffix.items,
-                        &summary_accumulator,
-                        assistant_text,
-                        .completed,
-                        null,
-                        &finish_trace,
-                        "tool",
-                    );
-                    debug_trace.eventf("tool", "after_tool_execution", step_ctx, "call_id={s} name={s} result_kind=finish_turn model_output_bytes={d}", .{ tool_call.id, tool_call.name, safe_tool_output.len });
-                    debug_trace.eventf("tool", "execution_result", step_ctx, "call_id={s} name={s} result_kind=finish_turn model_output_bytes={d}", .{ tool_call.id, tool_call.name, safe_tool_output.len });
-                }
+                try finishCommonAssistantTerminal(
+                    deps,
+                    finalization,
+                    arena,
+                    job,
+                    within_turn_suffix.items,
+                    &summary_accumulator,
+                    assistant_text,
+                    .completed,
+                    null,
+                    &finish_trace,
+                    "tool",
+                );
+                debug_trace.eventf("tool", "after_tool_execution", step_ctx, "call_id={s} name={s} result_kind=finish_turn model_output_bytes={d}", .{ tool_call.id, tool_call.name, safe_tool_output.len });
+                debug_trace.eventf("tool", "execution_result", step_ctx, "call_id={s} name={s} result_kind=finish_turn model_output_bytes={d}", .{ tool_call.id, tool_call.name, safe_tool_output.len });
                 return;
             }
 
@@ -7835,49 +7816,6 @@ fn finishCommonAssistantTerminalWithExecution(
         finish_trace,
         trace_outcome,
     );
-}
-
-fn finishCommonBackgroundTerminal(
-    deps: *const AgentRuntimeDeps,
-    finalization: *TurnFinalizationGuard,
-    arena: Allocator,
-    job: QueuedPrompt,
-    current_turn_messages: []const ChatMessage,
-    summary_accumulator: *runtime_telemetry.TurnSummaryAccumulator,
-    assistant_text: []const u8,
-    background: command_contract.BackgroundCommand,
-    finish_trace: *PromptFinishTrace,
-) !void {
-    const execution_memory = try runtime_execution_memory.buildExecutionMemory(
-        arena,
-        current_turn_messages,
-    );
-    const completed_summary = summary_accumulator.finish();
-    var turn: HistoryTurn = .{ .background_command = .{
-        .user = .{ .text = job.prompt, .images = job.images },
-        .assistant = @constCast(assistant_text),
-        .execution = execution_memory,
-        .log_path = @constCast(background.log_path),
-        .expect_url = background.expect_url,
-        .url = if (background.url) |url| @constCast(url) else null,
-        .background_record_id = background.background_record_id,
-    } };
-    types.setHistoryTurnSummary(&turn, completed_summary);
-    const finished = try types.dupeFinishedPrompt(
-        std.heap.c_allocator,
-        .{
-            .turn = turn,
-            .summary = completed_summary,
-        },
-    );
-
-    var propagation_error: ?anyerror = null;
-    deps.propagate_history_turn(deps.ctx, turn) catch |err| {
-        propagation_error = err;
-    };
-    try finalization.finish(.completed, null, finished);
-    finish_trace.finish("background");
-    if (propagation_error) |err| return err;
 }
 
 pub fn copyLatestStopPartial(

--- a/src/core/agent/runtime/parallel_execution.zig
+++ b/src/core/agent/runtime/parallel_execution.zig
@@ -274,12 +274,11 @@ fn duplicateParallelToolResult(alloc: Allocator, call: ToolCall, execution: Tool
     const tool_name = try alloc.dupe(u8, call.name);
     errdefer alloc.free(tool_name);
 
-    if (execution.background_command != null or
-        execution.diff_entry != null or
+    if (execution.diff_entry != null or
         execution.finish_turn or
         execution.selected_dynamic_tool_name != null or
         execution.selected_dynamic_tool_schema_json != null or
-        execution.prepared_result_memory != null or
+        execution.tool_result_memory_prepared or
         execution.committed_file_handoff != null or
         execution.deferred_tool_completion != null)
     {
@@ -302,9 +301,6 @@ fn duplicateParallelToolResult(alloc: Allocator, call: ToolCall, execution: Tool
     errdefer freeOwnedToolExecutionResult(alloc, duplicated_execution);
     if (execution.status_detail) |detail| {
         duplicated_execution.status_detail = try alloc.dupe(u8, detail);
-    }
-    if (execution.display_output) |display| {
-        duplicated_execution.display_output = try alloc.dupe(u8, display);
     }
     if (execution.system_notice) |notice| {
         duplicated_execution.system_notice = try alloc.dupe(u8, notice);
@@ -377,7 +373,6 @@ fn freeParallelToolResult(alloc: Allocator, result: ParallelToolResult) void {
 fn freeOwnedToolExecutionResult(alloc: Allocator, result: ToolExecutionResult) void {
     alloc.free(result.model_output);
     if (result.status_detail) |value| alloc.free(value);
-    if (result.display_output) |value| alloc.free(value);
     if (result.system_notice) |value| alloc.free(value);
     if (result.interactive_notice) |notice| types.freeSemanticNotice(alloc, notice);
     freeContextNotices(alloc, result.context_notices);
@@ -708,7 +703,6 @@ fn checkParallelResultDuplicationAllocationFailures(alloc: Allocator) !void {
     const execution: ToolExecutionResult = .{
         .model_output = "contents",
         .status_detail = "detail",
-        .display_output = "display",
         .system_notice = "notice",
         .interactive_notice = .{
             .topic = "background",

--- a/src/core/agent/runtime/telemetry.zig
+++ b/src/core/agent/runtime/telemetry.zig
@@ -322,7 +322,6 @@ pub fn traceGatewayProviderOptions(ctx: TraceContext, model: []const u8, fast_mo
 pub fn toolExecutionResultKind(result: ToolExecutionResult) []const u8 {
     if (result.status == .failure) return "error";
     if (result.diff_entry != null) return "diff";
-    if (result.display_output != null) return "display";
     return "model_output";
 }
 

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -1470,7 +1470,7 @@ pub const FakeAgentRuntimeDeps = struct {
                 u8,
                 result.model_output,
             );
-            if (result.prepared_result_memory) |*memory| {
+            if (result.tool_result_memory) |*memory| {
                 if (memory.output_handle) |handle| {
                     memory.output_handle = try request.result_allocator.dupe(
                         u8,

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -4727,31 +4727,6 @@ test "processQueuedPrompt includes structured failure detail in tool status" {
     try expectBodyContains(&gateway, 1, "browser_cdp_error");
 }
 
-test "processQueuedPrompt pushes display output but returns only masked model output to model" {
-    const alloc = std.testing.allocator;
-    const calls = [_]ToolCall{toolCall("call_1", "read_file", "{\"path\":\"a\"}")};
-    const completions = [_]FakeCompletion{
-        .{ .tool_calls = &calls },
-        .{ .content = "Final" },
-    };
-    var gateway = FakeGateway.init(alloc, &completions);
-    defer gateway.deinit();
-    var hooks = FakeAgentRuntimeDeps.init(alloc);
-    hooks.exec_plans = &.{.{ .result = .{
-        .model_output = "TOKEN=abcdefghijklmnop",
-        .display_output = "DISPLAY ONLY",
-    } }};
-    defer hooks.deinit();
-    var fixture = PromptFixture{};
-
-    try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
-
-    try std.testing.expect(textContains(&hooks, "DISPLAY ONLY"));
-    try expectBodyContains(&gateway, 1, "TOKEN=[redacted]");
-    try expectBodyNotContains(&gateway, 1, "TOKEN=abcdefghijklmnop");
-    try expectBodyNotContains(&gateway, 1, "DISPLAY ONLY");
-}
-
 test "processQueuedPrompt caps chatty grep_files model output" {
     const alloc = std.testing.allocator;
     const calls = [_]ToolCall{toolCall("call_1", "grep_files", "{\"pattern\":\"x\"}")};
@@ -4817,7 +4792,6 @@ test "processQueuedPrompt forwards diff payload instead of display text" {
     var hooks = FakeAgentRuntimeDeps.init(alloc);
     hooks.exec_plans = &.{.{ .result = .{
         .model_output = "patched",
-        .display_output = "SHOULD NOT PUSH",
         .diff_entry = .{
             .preview = @constCast("diff preview"),
         },
@@ -4829,7 +4803,6 @@ test "processQueuedPrompt forwards diff payload instead of display text" {
 
     try std.testing.expectEqual(@as(usize, 1), hooks.diff_count);
     try std.testing.expectEqualStrings("diff preview", hooks.diff_preview.?);
-    try std.testing.expect(!textContains(&hooks, "SHOULD NOT PUSH"));
 }
 
 test "processQueuedPrompt records permission preflight failures as denied tool calls" {

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -311,23 +311,23 @@ pub fn processCommittedFileResult(
     }
     const committed_contract_degraded =
         execution.status != .success or
-        execution.prepared_result_memory == null or
+        !execution.tool_result_memory_prepared or
+        execution.tool_result_memory == null or
         execution.diff_entry != null or
-        execution.display_output != null or
         execution.finish_turn;
     if (committed_contract_degraded) {
         debug_trace.eventf(
             "tool",
             "committed_result_contract_degraded",
             step_ctx,
-            "call_id={s} name={s} status={s} memory={s} diff={s} display={s} finish_turn={s}",
+            "call_id={s} name={s} status={s} memory={s} diff={s} finish_turn={s}",
             .{
                 tool_call.id,
                 tool_call.name,
                 @tagName(execution.status),
-                if (execution.prepared_result_memory != null) "true" else "false",
+                if (execution.tool_result_memory_prepared and
+                    execution.tool_result_memory != null) "true" else "false",
                 if (execution.diff_entry != null) "true" else "false",
-                if (execution.display_output != null) "true" else "false",
                 if (execution.finish_turn) "true" else "false",
             },
         );
@@ -336,11 +336,14 @@ pub fn processCommittedFileResult(
         }
     }
 
-    var prepared_memory = execution.prepared_result_memory orelse
-        types.ToolResultMemory{
-            .output_bytes = execution.model_output.len,
-            .stored_output_bytes = execution.model_output.len,
-        };
+    const fallback_memory = types.ToolResultMemory{
+        .output_bytes = execution.model_output.len,
+        .stored_output_bytes = execution.model_output.len,
+    };
+    var prepared_memory = if (execution.tool_result_memory_prepared)
+        execution.tool_result_memory orelse fallback_memory
+    else
+        fallback_memory;
     prepared_memory.committed_file_presentation = runtime_execution_memory.captureCommittedFilePresentation(
         history_allocator,
         handoff,

--- a/src/core/agent/runtime/tool_contracts.zig
+++ b/src/core/agent/runtime/tool_contracts.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const command_admission = @import("../../permissions/command_admission.zig");
-const command_contract = @import("../../execution/command_contract.zig");
 const types = @import("../../shared/types.zig");
 const diff = @import("../../output/diff.zig");
 const file_mutation = @import("../../tooling/file_mutation.zig");
@@ -76,13 +75,11 @@ pub const ToolExecutionResult = struct {
     status: ToolExecutionStatus = .success,
     cancelled: bool = false,
     status_detail: ?[]const u8 = null,
-    display_output: ?[]const u8 = null,
     diff_entry: ?DiffEntryPayload = null,
     finish_turn: bool = false,
     system_notice: ?[]const u8 = null,
     interactive_notice: ?types.SemanticNotice = null,
     context_notices: []const []const u8 = &.{},
-    background_command: ?command_contract.BackgroundCommand = null,
     command_result_json: ?[]const u8 = null,
     web_search_completion: ?types.WebSearchCompletion = null,
     web_fetch_completion: ?types.WebFetchCompletion = null,
@@ -90,11 +87,17 @@ pub const ToolExecutionResult = struct {
     selected_dynamic_tool_name: ?[]const u8 = null,
     selected_dynamic_tool_schema_json: ?[]const u8 = null,
     tool_result_memory: ?types.ToolResultMemory = null,
-    prepared_result_memory: ?types.ToolResultMemory = null,
+    tool_result_memory_prepared: bool = false,
     committed_file_handoff: ?file_mutation.CommittedFileHandoff = null,
     deferred_tool_completion: ?DeferredToolCompletion = null,
     command_replay_capture: ?*command_replay_store.Capture = null,
 };
+
+test "tool result retains one memory payload across preparation" {
+    try std.testing.expect(@hasField(ToolExecutionResult, "tool_result_memory"));
+    try std.testing.expect(@hasField(ToolExecutionResult, "tool_result_memory_prepared"));
+    try std.testing.expect(!@hasField(ToolExecutionResult, "prepared_result_memory"));
+}
 
 pub inline fn failToolExecutionResult(err: anytype) @TypeOf(err)!ToolExecutionResult {
     return @errorCast(failToolExecutionResultDynamic(err));

--- a/src/core/tooling/file_mutation_execution.zig
+++ b/src/core/tooling/file_mutation_execution.zig
@@ -123,7 +123,8 @@ pub fn execute(input: Input) Error!ToolExecutionResult {
             break :blk .{
                 .status = .success,
                 .model_output = prepared_result.model_output,
-                .prepared_result_memory = prepared_result.memory,
+                .tool_result_memory = prepared_result.memory,
+                .tool_result_memory_prepared = true,
                 .committed_file_handoff = handoff,
             };
         },

--- a/src/core/tooling/tool_dispatch.zig
+++ b/src/core/tooling/tool_dispatch.zig
@@ -309,14 +309,15 @@ pub const AuthorizedCallAdapterFn = *const fn (
     DispatchContext,
     Registry,
     message.ToolCall,
-) DispatchError!DispatchResult;
+) DispatchError!AuthorizedDispatchResult;
 
 /// Optional Core mapper selected by a registered tool descriptor after an
 /// authorized call has produced its structured dispatch result.
 pub const AuthorizedResultMapperFn = *const fn (
     Allocator,
-    DispatchResult,
-) Allocator.Error!DispatchResult;
+    AuthorizedDispatchResult,
+    *?[]u8,
+) Allocator.Error!AuthorizedDispatchResult;
 
 pub const RunCommandCompatibility = struct {
     matches: *const fn ([]const u8) bool,
@@ -769,6 +770,18 @@ pub const DispatchResult = struct {
     }
 };
 
+/// Owned authorized-dispatch result. Runtime metadata is published through
+/// the caller-provided sinks in `DispatchContext` instead of being copied into
+/// this transport result.
+pub const AuthorizedDispatchResult = struct {
+    status: DispatchResult.Status,
+    body: []u8,
+
+    pub fn deinit(self: AuthorizedDispatchResult, alloc: Allocator) void {
+        alloc.free(self.body);
+    }
+};
+
 /// Runs one model-requested tool call through lookup, validation, gate, and call.
 pub fn dispatchToolCall(ctx: DispatchContext, registry: Registry, call: message.ToolCall) DispatchError!DispatchResult {
     var captured_usage: ?core_types.ToolUsage = null;
@@ -816,16 +829,22 @@ pub fn dispatchToolCall(ctx: DispatchContext, registry: Registry, call: message.
 }
 
 /// Runs one already-authorized registered tool call through lookup, validation, and call.
-pub fn dispatchAuthorizedToolCall(ctx: DispatchContext, registry: Registry, call: message.ToolCall) DispatchError!DispatchResult {
-    const tool = registry.lookup(call.name) orelse return failure(
-        try std.fmt.allocPrint(ctx.allocator, "unknown tool: {s}", .{call.name}),
-    );
+pub fn dispatchAuthorizedToolCall(
+    ctx: DispatchContext,
+    registry: Registry,
+    call: message.ToolCall,
+    status_detail: *?[]u8,
+) DispatchError!AuthorizedDispatchResult {
+    const tool = registry.lookup(call.name) orelse return .{
+        .status = .failure,
+        .body = try std.fmt.allocPrint(ctx.allocator, "unknown tool: {s}", .{call.name}),
+    };
     const result = if (tool.authorized_call_adapter) |adapter|
         try adapter(ctx, registry, call)
     else
         try dispatchAuthorizedToolCallDefault(ctx, registry, call);
     if (tool.authorized_result_mapper) |mapper| {
-        return mapper(ctx.allocator, result) catch |err| {
+        return mapper(ctx.allocator, result, status_detail) catch |err| {
             result.deinit(ctx.allocator);
             return err;
         };
@@ -836,52 +855,30 @@ pub fn dispatchAuthorizedToolCall(ctx: DispatchContext, registry: Registry, call
 /// Runs the ordinary authorized decode/validate/call path without consulting a
 /// descriptor's lifecycle adapter. Focused adapters use this to wrap one call
 /// without recursively selecting themselves again.
-pub fn dispatchAuthorizedToolCallDefault(ctx: DispatchContext, registry: Registry, call: message.ToolCall) DispatchError!DispatchResult {
-    var captured_usage: ?core_types.ToolUsage = null;
-    var captured_web_search_completion: ?core_types.WebSearchCompletion = null;
-    var captured_web_fetch_completion: ?core_types.WebFetchCompletion = null;
-    var captured_tool_result_memory: ?core_types.ToolResultMemory = null;
-    var call_ctx = ctx;
-    if (call_ctx.inner_usage_sink == null) call_ctx.inner_usage_sink = &captured_usage;
-    if (call_ctx.web_search_completion_sink == null) call_ctx.web_search_completion_sink = &captured_web_search_completion;
-    if (call_ctx.web_fetch_completion_sink == null) call_ctx.web_fetch_completion_sink = &captured_web_fetch_completion;
-    if (call_ctx.tool_result_memory_sink == null) call_ctx.tool_result_memory_sink = &captured_tool_result_memory;
-
-    const validated = try decodeAndValidateRegisteredToolCall(call_ctx, registry, call);
+pub fn dispatchAuthorizedToolCallDefault(ctx: DispatchContext, registry: Registry, call: message.ToolCall) DispatchError!AuthorizedDispatchResult {
+    const validated = try decodeAndValidateRegisteredToolCall(ctx, registry, call);
     switch (validated) {
-        .not_registered => return failure(try std.fmt.allocPrint(call_ctx.allocator, "unknown tool: {s}", .{call.name})),
-        .failure => |reason| return failure(reason),
+        .not_registered => return .{ .status = .failure, .body = try std.fmt.allocPrint(ctx.allocator, "unknown tool: {s}", .{call.name}) },
+        .failure => |reason| return .{ .status = .failure, .body = reason },
         .input => |input| {
-            defer input.value.deinit(call_ctx.allocator);
+            defer input.value.deinit(ctx.allocator);
 
-            const result = try input.tool.call(call_ctx, input.value);
+            const result = try input.tool.call(ctx, input.value);
             if (input.tool.cancel_if_requested_after_call and
-                call_ctx.cancel_flag != null and
-                call_ctx.cancel_flag.?.load(.seq_cst))
+                ctx.cancel_flag != null and
+                ctx.cancel_flag.?.load(.seq_cst))
             {
-                result.deinit(call_ctx.allocator);
+                result.deinit(ctx.allocator);
                 return error.Cancelled;
             }
-            const inner_usage = if (call_ctx.inner_usage_sink) |slot| slot.* else captured_usage;
-            const web_search_completion = if (call_ctx.web_search_completion_sink) |slot| slot.* else captured_web_search_completion;
-            const web_fetch_completion = if (call_ctx.web_fetch_completion_sink) |slot| slot.* else captured_web_fetch_completion;
-            const tool_result_memory = if (call_ctx.tool_result_memory_sink) |slot| slot.* else captured_tool_result_memory;
             return switch (result) {
                 .success => |body| .{
                     .status = .success,
                     .body = body,
-                    .inner_usage = inner_usage,
-                    .web_search_completion = web_search_completion,
-                    .web_fetch_completion = web_fetch_completion,
-                    .tool_result_memory = tool_result_memory,
                 },
                 .failure => |body| .{
                     .status = .failure,
                     .body = body,
-                    .inner_usage = inner_usage,
-                    .web_search_completion = web_search_completion,
-                    .web_fetch_completion = web_fetch_completion,
-                    .tool_result_memory = tool_result_memory,
                 },
             };
         },

--- a/src/core/tooling/tool_mcp_registry.zig
+++ b/src/core/tooling/tool_mcp_registry.zig
@@ -146,6 +146,8 @@ test "dynamic MCP descriptor executes through registered dispatch" {
     const tools = [_]tool_dispatch.Tool{tool};
     const registry = tool_dispatch.Registry{ .tools = tools[0..] };
     var execution_error: ?anyerror = null;
+    var status_detail: ?[]u8 = null;
+    defer if (status_detail) |detail| std.testing.allocator.free(detail);
     const result = try tool_dispatch.dispatchAuthorizedToolCall(.{
         .allocator = std.testing.allocator,
         .tool_call_name = "mcp_fs_read",
@@ -156,7 +158,7 @@ test "dynamic MCP descriptor executes through registered dispatch" {
         .id = "dynamic-test",
         .name = "mcp_fs_read",
         .arguments_json = "{\"path\":\"README.md\"}",
-    });
+    }, &status_detail);
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(execution_error == null);

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -565,7 +565,9 @@ fn executeWorkspaceToolCallInner(
     }
 
     var command_backend = RunCommandBackendState{ .runtime = ctx };
+    var dispatch_metadata: DispatchMetadata = .{};
     var dispatch_ctx = typedDispatchContextForCall(ctx, arena, call);
+    dispatch_metadata.attach(&dispatch_ctx);
     dispatch_ctx.execution_authority = authority;
     dispatch_ctx.captured_command_host = spec.captured_command_host;
     dispatch_ctx.run_command_backend = .{
@@ -576,15 +578,16 @@ fn executeWorkspaceToolCallInner(
         dispatch_ctx,
         ctx.tool_registry,
         call,
+        &dispatch_metadata.status_detail,
     );
     if (command_backend.execution_error) |err| {
         dispatched.deinit(arena);
         return err;
     }
     var execution = command_backend.completion orelse
-        toolExecutionResultFromDispatch(dispatched);
+        toolExecutionResultFromDispatch(dispatched, dispatch_metadata);
     execution.model_output = dispatched.body;
-    if (dispatched.status_detail) |detail| execution.status_detail = detail;
+    if (dispatch_metadata.status_detail) |detail| execution.status_detail = detail;
     return execution;
 }
 
@@ -677,7 +680,9 @@ fn executeRegisteredTool(
     var mcp_progress_bridge = McpProgressBridge{ .ctx = ctx };
     var mcp_call_status: ?tool_mcp_runtime.CallStatus = null;
     var mcp_execution_error: ?anyerror = null;
+    var dispatch_metadata: DispatchMetadata = .{};
     var dispatch_ctx = typedDispatchContextForCall(ctx, arena, call);
+    dispatch_metadata.attach(&dispatch_ctx);
     dispatch_ctx.execution_authority = authority;
     dispatch_ctx.mcp_call_options = .{
         .expected_runtime_generation = ctx.expected_mcp_runtime_generation,
@@ -719,6 +724,7 @@ fn executeRegisteredTool(
         dispatch_ctx,
         registry,
         call,
+        &dispatch_metadata.status_detail,
     );
     if (command_backend.execution_error) |err| {
         dispatched.deinit(arena);
@@ -738,9 +744,9 @@ fn executeRegisteredTool(
     else if (vision_provider.completion) |completion|
         completion
     else
-        toolExecutionResultFromDispatch(dispatched);
+        toolExecutionResultFromDispatch(dispatched, dispatch_metadata);
     execution.model_output = dispatched.body;
-    if (dispatched.status_detail) |detail| execution.status_detail = detail;
+    if (dispatch_metadata.status_detail) |detail| execution.status_detail = detail;
     if (mcp_call_status == .input_required or
         (execution.status == .failure and
             tool_mcp_feature_dispatch.isInputRequiredFailure(execution.model_output)))
@@ -793,24 +799,42 @@ fn executeRunCommandBackend(
     };
 }
 
-fn toolExecutionResultFromDispatch(result: tool_dispatch.DispatchResult) ToolExecutionResult {
+const DispatchMetadata = struct {
+    status_detail: ?[]u8 = null,
+    inner_usage: ?types.ToolUsage = null,
+    web_search_completion: ?types.WebSearchCompletion = null,
+    web_fetch_completion: ?types.WebFetchCompletion = null,
+    tool_result_memory: ?types.ToolResultMemory = null,
+
+    fn attach(self: *DispatchMetadata, ctx: *tool_dispatch.DispatchContext) void {
+        ctx.inner_usage_sink = &self.inner_usage;
+        ctx.web_search_completion_sink = &self.web_search_completion;
+        ctx.web_fetch_completion_sink = &self.web_fetch_completion;
+        ctx.tool_result_memory_sink = &self.tool_result_memory;
+    }
+};
+
+fn toolExecutionResultFromDispatch(
+    result: tool_dispatch.AuthorizedDispatchResult,
+    metadata: DispatchMetadata,
+) ToolExecutionResult {
     return switch (result.status) {
         .success => .{
             .model_output = result.body,
-            .status_detail = result.status_detail,
-            .inner_usage = result.inner_usage,
-            .web_search_completion = result.web_search_completion,
-            .web_fetch_completion = result.web_fetch_completion,
-            .tool_result_memory = result.tool_result_memory,
+            .status_detail = metadata.status_detail,
+            .inner_usage = metadata.inner_usage,
+            .web_search_completion = metadata.web_search_completion,
+            .web_fetch_completion = metadata.web_fetch_completion,
+            .tool_result_memory = metadata.tool_result_memory,
         },
         .failure => .{
             .status = .failure,
             .model_output = result.body,
-            .status_detail = result.status_detail,
-            .inner_usage = result.inner_usage,
-            .web_search_completion = result.web_search_completion,
-            .web_fetch_completion = result.web_fetch_completion,
-            .tool_result_memory = result.tool_result_memory,
+            .status_detail = metadata.status_detail,
+            .inner_usage = metadata.inner_usage,
+            .web_search_completion = metadata.web_search_completion,
+            .web_fetch_completion = metadata.web_fetch_completion,
+            .tool_result_memory = metadata.tool_result_memory,
         },
     };
 }
@@ -5208,7 +5232,8 @@ test "file mutation lifecycle decodes each call at most once" {
         applied.status,
     );
     try std.testing.expect(applied.committed_file_handoff != null);
-    try std.testing.expect(applied.prepared_result_memory != null);
+    try std.testing.expect(applied.tool_result_memory_prepared);
+    try std.testing.expect(applied.tool_result_memory != null);
     call_arena_state.deinit();
     call_arena_live = false;
     try std.testing.expectEqualStrings(

--- a/src/tools/terminal/terminal.zig
+++ b/src/tools/terminal/terminal.zig
@@ -1444,9 +1444,10 @@ fn projectResult(
 
 pub fn mapAuthorizedResult(
     alloc: Allocator,
-    result: tool_dispatch.DispatchResult,
-) Allocator.Error!tool_dispatch.DispatchResult {
-    if (result.status != .failure or result.status_detail != null) return result;
+    result: tool_dispatch.AuthorizedDispatchResult,
+    status_detail: *?[]u8,
+) Allocator.Error!tool_dispatch.AuthorizedDispatchResult {
+    if (result.status != .failure or status_detail.* != null) return result;
     var parsed = std.json.parseFromSlice(
         contracts.Result,
         alloc,
@@ -1461,12 +1462,11 @@ pub fn mapAuthorizedResult(
         .success => return result,
         .failure => |failure| failure.code,
     };
-    var mapped = result;
-    mapped.status_detail = try alloc.dupe(
+    status_detail.* = try alloc.dupe(
         u8,
         terminalFailurePresentation(code).detail(),
     );
-    return mapped;
+    return result;
 }
 
 fn structuredFailure(
@@ -2580,19 +2580,21 @@ test "terminal result mapper adds detail for actionable failures" {
 
     for (cases) |case| {
         const body = try alloc.dupe(u8, case.body);
+        var status_detail: ?[]u8 = null;
+        defer if (status_detail) |detail| alloc.free(detail);
         var mapped = try mapAuthorizedResult(alloc, .{
             .status = case.status,
             .body = body,
-        });
+        }, &status_detail);
         defer mapped.deinit(alloc);
         try std.testing.expectEqualStrings(case.body, mapped.body);
         if (case.expected_detail) |expected| {
             try std.testing.expectEqualStrings(
                 expected,
-                mapped.status_detail orelse return error.TestExpectedDetail,
+                status_detail orelse return error.TestExpectedDetail,
             );
         } else {
-            try std.testing.expect(mapped.status_detail == null);
+            try std.testing.expect(status_detail == null);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Keep existing tool behavior and schemas while reducing duplicate tool-result and authorized-dispatch state.
- Remove unused result variants while preserving active terminal background handling.