### PR TITLE
Hide Vision from native image models

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -2672,13 +2672,46 @@ fn appendPermissionFeedbackAfterToolResult(
 
 fn requiresResolvedRequestCapabilities(
     has_images: bool,
+    vision_policy_needs_capabilities: bool,
     effort: types.ReasoningEffort,
     fast_mode: bool,
     available: model_capabilities.Capabilities,
 ) bool {
     return has_images or
+        (vision_policy_needs_capabilities and available.image_input_support == .unknown) or
         (!effort.isDefault() and !model_capabilities.reasoningEffortSupported(available, effort)) or
         (fast_mode and !available.supports_fast_mode);
+}
+
+test "request capabilities resolve before Vision visibility when image support is unknown" {
+    try std.testing.expect(requiresResolvedRequestCapabilities(
+        false,
+        true,
+        .auto,
+        false,
+        .{},
+    ));
+    try std.testing.expect(!requiresResolvedRequestCapabilities(
+        false,
+        true,
+        .auto,
+        false,
+        .{ .image_input_support = .non_native },
+    ));
+    try std.testing.expect(!requiresResolvedRequestCapabilities(
+        false,
+        true,
+        .auto,
+        false,
+        .{ .image_input_support = .native },
+    ));
+    try std.testing.expect(!requiresResolvedRequestCapabilities(
+        false,
+        false,
+        .auto,
+        false,
+        .{},
+    ));
 }
 
 fn request_max_output_tokens(capabilities: model_capabilities.Capabilities) ?u32 {
@@ -2778,9 +2811,12 @@ fn processQueuedPromptInner(
     if (deps.append_static_context) |append_static_context| {
         try append_static_context(deps.ctx, arena, &stable_prefix);
     }
+    const vision_fallback_available = config.provider_capabilities.vision_fallback and
+        deps.tool_registry.lookup("vision") != null;
     var request_capabilities = deps.available_model_capabilities(deps.ctx, job.model);
     if (requiresResolvedRequestCapabilities(
         job.images.len > 0 or job.authorized_image_catalog.len > 0,
+        vision_fallback_available,
         config.effort,
         config.fast_mode,
         request_capabilities,
@@ -2960,18 +2996,6 @@ fn appendAuthorizedVisionAttemptIds(
     return true;
 }
 
-fn visionCallUsesPaths(alloc: Allocator, call: ToolCall) !bool {
-    const request = runtime_vision_contracts.parse_vision_request(
-        alloc,
-        call.arguments_json,
-    ) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return false,
-    };
-    defer request.deinit(alloc);
-    return request.paths() != null;
-}
-
 fn containsImageId(image_ids: []const usize, candidate: usize) bool {
     for (image_ids) |image_id| {
         if (image_id == candidate) return true;
@@ -3058,29 +3082,98 @@ fn buildToolExecutionRootUserContext(
     );
 }
 
-fn visionFallbackMode(
-    available: bool,
+const ImageRoute = enum {
+    native,
+    fallback,
+    unavailable,
+};
+
+const VisionPolicy = struct {
+    route: ImageRoute,
+    mode: runtime_gateway_step.VisionToolMode,
+};
+
+fn visionPolicy(
+    image_input_support: model_capabilities.ImageInputSupport,
+    fallback_available: bool,
     tool_registered: bool,
-) runtime_gateway_step.VisionToolMode {
-    if (!available or !tool_registered) {
-        return .unavailable;
-    }
-    return .optional;
+    pending_images: bool,
+) VisionPolicy {
+    return switch (image_input_support) {
+        .native => .{ .route = .native, .mode = .unavailable },
+        .unknown => .{ .route = .unavailable, .mode = .unavailable },
+        .non_native => if (!fallback_available or !tool_registered)
+            .{ .route = .unavailable, .mode = .unavailable }
+        else
+            .{
+                .route = .fallback,
+                .mode = if (pending_images) .required else .optional,
+            },
+    };
 }
 
-test "vision fallback follows the selected provider capability" {
-    try std.testing.expectEqual(
-        runtime_gateway_step.VisionToolMode.optional,
-        visionFallbackMode(true, true),
-    );
-    try std.testing.expectEqual(
-        runtime_gateway_step.VisionToolMode.unavailable,
-        visionFallbackMode(true, false),
-    );
-    try std.testing.expectEqual(
-        runtime_gateway_step.VisionToolMode.unavailable,
-        visionFallbackMode(false, true),
-    );
+test "vision policy keeps image route and tool visibility coherent" {
+    const cases = [_]struct {
+        image_input_support: model_capabilities.ImageInputSupport,
+        fallback_available: bool,
+        tool_registered: bool,
+        pending_images: bool,
+        expected_route: ImageRoute,
+        expected_mode: runtime_gateway_step.VisionToolMode,
+    }{
+        .{ .image_input_support = .native, .fallback_available = true, .tool_registered = true, .pending_images = true, .expected_route = .native, .expected_mode = .unavailable },
+        .{ .image_input_support = .native, .fallback_available = false, .tool_registered = false, .pending_images = false, .expected_route = .native, .expected_mode = .unavailable },
+        .{ .image_input_support = .non_native, .fallback_available = true, .tool_registered = true, .pending_images = true, .expected_route = .fallback, .expected_mode = .required },
+        .{ .image_input_support = .non_native, .fallback_available = true, .tool_registered = true, .pending_images = false, .expected_route = .fallback, .expected_mode = .optional },
+        .{ .image_input_support = .non_native, .fallback_available = false, .tool_registered = true, .pending_images = true, .expected_route = .unavailable, .expected_mode = .unavailable },
+        .{ .image_input_support = .non_native, .fallback_available = true, .tool_registered = false, .pending_images = false, .expected_route = .unavailable, .expected_mode = .unavailable },
+        .{ .image_input_support = .unknown, .fallback_available = true, .tool_registered = true, .pending_images = true, .expected_route = .unavailable, .expected_mode = .unavailable },
+    };
+
+    for (cases) |case| {
+        const policy = visionPolicy(
+            case.image_input_support,
+            case.fallback_available,
+            case.tool_registered,
+            case.pending_images,
+        );
+        try std.testing.expectEqual(case.expected_route, policy.route);
+        try std.testing.expectEqual(case.expected_mode, policy.mode);
+        try std.testing.expect((policy.route == .fallback) == (policy.mode != .unavailable));
+    }
+
+    const support_values = [_]model_capabilities.ImageInputSupport{
+        .unknown,
+        .non_native,
+        .native,
+    };
+    const boolean_values = [_]bool{ false, true };
+    for (support_values) |support| {
+        for (boolean_values) |fallback_available| {
+            for (boolean_values) |tool_registered| {
+                for (boolean_values) |pending_images| {
+                    const policy = visionPolicy(
+                        support,
+                        fallback_available,
+                        tool_registered,
+                        pending_images,
+                    );
+                    try std.testing.expect((policy.route == .fallback) == (policy.mode != .unavailable));
+                    if (support == .native) {
+                        try std.testing.expectEqual(ImageRoute.native, policy.route);
+                        try std.testing.expectEqual(runtime_gateway_step.VisionToolMode.unavailable, policy.mode);
+                    }
+                    if (support == .unknown) {
+                        try std.testing.expectEqual(ImageRoute.unavailable, policy.route);
+                        try std.testing.expectEqual(runtime_gateway_step.VisionToolMode.unavailable, policy.mode);
+                    }
+                    if (!fallback_available or !tool_registered) {
+                        try std.testing.expect(policy.mode == .unavailable or support == .native);
+                    }
+                }
+            }
+        }
+    }
 }
 
 fn processQueuedPromptLoop(
@@ -3440,11 +3533,17 @@ fn processQueuedPromptLoop(
                 within_turn_suffix.items,
             );
             debug_trace.eventf("agent", "before_provider_preflight", step_ctx, "model={s} messages={d}", .{ gateway_model, gateway_messages.items.len });
-            var vision_route: runtime_vision_contracts.VisionRoute = .native_images;
-            var vision_mode = visionFallbackMode(
+            const vision_policy = visionPolicy(
+                request_capabilities.image_input_support,
                 config.provider_capabilities.vision_fallback,
                 deps.tool_registry.lookup("vision") != null,
+                pending_image_ids.len > 0,
             );
+            const vision_route: runtime_vision_contracts.VisionRoute = if (vision_policy.route == .fallback)
+                .text_only
+            else
+                .native_images;
+            const vision_mode = vision_policy.mode;
             const recovery_source_messages = try appendReadFailureRecoveryContext(
                 overlay_arena,
                 gateway_messages.items,
@@ -3459,27 +3558,29 @@ fn processQueuedPromptLoop(
                 if (job.authorized_image_catalog.len == 0 and job.images.len == 0) {
                     break :blk recovery_source_messages;
                 }
-                if (request_capabilities.supports_vision and request_capabilities.supports_file_input) {
-                    break :blk try runtime_vision_contracts.project_native_messages(
+                break :blk switch (vision_policy.route) {
+                    .native => try runtime_vision_contracts.project_native_messages(
                         overlay_arena,
                         recovery_source_messages,
                         current_user_message_index,
-                    );
-                }
-                if (!config.provider_capabilities.vision_fallback) {
-                    return error.SubscriptionNativeImageUnavailable;
-                }
-                if (job.authorized_image_catalog.len == 0) {
-                    return error.MissingAuthorizedImageCatalog;
-                }
-                vision_route = .text_only;
-                vision_mode = if (pending_image_ids.len > 0) .required else .optional;
-                break :blk try runtime_vision_contracts.project_text_only_messages(
-                    overlay_arena,
-                    recovery_source_messages,
-                    current_user_message_index,
-                    job.authorized_image_catalog,
-                );
+                    ),
+                    .fallback => fallback: {
+                        if (job.authorized_image_catalog.len == 0) {
+                            return error.MissingAuthorizedImageCatalog;
+                        }
+                        break :fallback try runtime_vision_contracts.project_text_only_messages(
+                            overlay_arena,
+                            recovery_source_messages,
+                            current_user_message_index,
+                            job.authorized_image_catalog,
+                        );
+                    },
+                    .unavailable => switch (request_capabilities.image_input_support) {
+                        .unknown => return error.ModelImageCapabilityUnavailable,
+                        .non_native => return error.SubscriptionNativeImageUnavailable,
+                        .native => unreachable,
+                    },
+                };
             };
             const terminal_request_eligible = terminal_request_normalization_eligible(
                 base_nested_terminal_advertised,
@@ -3502,7 +3603,7 @@ fn processQueuedPromptLoop(
                 .auto;
             var verified_images: std.ArrayList(image_attachments.VerifiedSnapshot) = .empty;
             if (job.provider != .gateway and job.images.len > 0 and
-                request_capabilities.supports_vision and request_capabilities.supports_file_input)
+                vision_policy.route == .native)
             {
                 try verified_images.ensureTotalCapacity(overlay_arena, job.images.len);
                 for (job.images) |attachment| {
@@ -5091,8 +5192,7 @@ fn processQueuedPromptLoop(
                 continue;
             }
             if (std.mem.eql(u8, tool_call.name, "vision") and
-                successful_vision_route != .text_only and
-                !try visionCallUsesPaths(arena, tool_call))
+                successful_vision_mode == .unavailable)
             {
                 const owned_call = try types.dupeToolCall(arena, tool_call);
                 errdefer types.freeToolCall(arena, owned_call);
@@ -5103,7 +5203,7 @@ fn processQueuedPromptLoop(
                         .{
                             .tool_name = "vision",
                             .message = runtime_vision_contracts.native_route_unavailable_message,
-                            .suggestion = "Continue using the model's native image input without Vision.",
+                            .suggestion = "Continue without Vision.",
                         },
                     ),
                     .kind = .route_unavailable,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3544,6 +3544,19 @@ fn processQueuedPromptLoop(
             else
                 .native_images;
             const vision_mode = vision_policy.mode;
+            debug_trace.eventf(
+                "agent",
+                "vision_policy",
+                step_ctx,
+                "model={s} image_support={s} route={s} mode={s} pending_images={d}",
+                .{
+                    gateway_model,
+                    @tagName(request_capabilities.image_input_support),
+                    @tagName(vision_policy.route),
+                    @tagName(vision_mode),
+                    pending_image_ids.len,
+                },
+            );
             const recovery_source_messages = try appendReadFailureRecoveryContext(
                 overlay_arena,
                 gateway_messages.items,

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -5203,7 +5203,11 @@ fn processQueuedPromptLoop(
                         .{
                             .tool_name = "vision",
                             .message = runtime_vision_contracts.native_route_unavailable_message,
-                            .suggestion = "Continue without Vision.",
+                            .suggestion = if (request_capabilities.image_input_support == .native or
+                                (request_capabilities.image_input_support == .unknown and job.provider != .gateway))
+                                "Continue using the model's native image input without Vision."
+                            else
+                                "Continue without Vision.",
                         },
                     ),
                     .kind = .route_unavailable,

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -2326,6 +2326,7 @@ test "processQueuedPrompt keeps native image parts for vision route model" {
     const capability_overrides = [_]ModelCapabilityOverride{.{
         .model = "google/gemini-2.5-flash",
         .capabilities = .{
+            .image_input_support = .native,
             .supports_vision = true,
             .supports_file_input = true,
         },
@@ -2364,7 +2365,7 @@ test "processQueuedPrompt never uses the vision fallback for Codex" {
     var images = [_]types.ImageAttachment{image};
     const capability_overrides = [_]ModelCapabilityOverride{.{
         .model = "gpt-5.6-sol",
-        .capabilities = .{},
+        .capabilities = .{ .image_input_support = .non_native },
     }};
     var gateway = FakeGateway.init(alloc, &.{});
     defer gateway.deinit();
@@ -2416,6 +2417,7 @@ test "processQueuedPrompt routes images natively only when vision and file input
         const capability_overrides = [_]ModelCapabilityOverride{.{
             .model = model,
             .capabilities = .{
+                .image_input_support = if (entry.expect_native) .native else .non_native,
                 .supports_vision = entry.supports_vision,
                 .supports_file_input = entry.supports_file_input,
             },
@@ -2461,7 +2463,7 @@ test "processQueuedPrompt routes images natively only when vision and file input
             try std.testing.expectEqual(@as(usize, 1), gateway.request_bodies.items.len);
             try expectBodyContains(&gateway, 0, "\"type\":\"file\"");
             try expectBodyContains(&gateway, 0, "iVBORw0KGgpmaXh0dXJlIGltYWdlIGJ5dGVz");
-            try expectBodyContains(&gateway, 0, "\"name\":\"vision\"");
+            try expectBodyNotContains(&gateway, 0, "\"name\":\"vision\"");
             try std.testing.expectEqualStrings("Native route answer", hooks.finish_assistant_text.?);
         } else {
             try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
@@ -2482,7 +2484,7 @@ test "processQueuedPrompt routes images natively only when vision and file input
     }
 }
 
-test "processQueuedPrompt rejects native-route attachment ID Vision calls before permission or execution" {
+test "processQueuedPrompt rejects unadvertised native-route Vision calls before permission or execution" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -2507,6 +2509,7 @@ test "processQueuedPrompt rejects native-route attachment ID Vision calls before
     const capability_overrides = [_]ModelCapabilityOverride{.{
         .model = "native/test-vision",
         .capabilities = .{
+            .image_input_support = .native,
             .supports_vision = true,
             .supports_file_input = true,
         },
@@ -2532,7 +2535,7 @@ test "processQueuedPrompt rejects native-route attachment ID Vision calls before
     try std.testing.expectEqualStrings("native/test-vision", gateway.request_models.items[0]);
     try std.testing.expectEqualStrings("native/test-vision", gateway.request_models.items[1]);
     try expectBodyContains(&gateway, 0, "\"type\":\"file\"");
-    try expectBodyContains(&gateway, 0, "\"name\":\"vision\"");
+    try expectBodyNotContains(&gateway, 0, "\"name\":\"vision\"");
     try expectBodyNotContains(&gateway, 1, image_path);
     try std.testing.expectEqual(@as(usize, 0), hooks.permission_names.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -638,6 +638,7 @@ pub const FakeAgentRuntimeDeps = struct {
     last_route_recovery_finish_reason: ?types.ProviderFinishReason = null,
     last_route_recovery_unsafe_reason: ?types.RouteRecoveryUnsafeReason = null,
     default_model_capabilities: model_capabilities.Capabilities = .{
+        .image_input_support = .non_native,
         .prompt_caching = true,
         .context_window = 1_000_000,
     },

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -4155,6 +4155,7 @@ test "permission review reaches serial and parallel tools after native history p
     const capability_overrides = [_]test_support.ModelCapabilityOverride{.{
         .model = "openai/gpt-5.6-sol",
         .capabilities = .{
+            .image_input_support = .native,
             .supports_tool_use = true,
             .supports_vision = true,
             .supports_file_input = true,

--- a/src/core/app/app_process_runtime.zig
+++ b/src/core/app/app_process_runtime.zig
@@ -93,6 +93,7 @@ pub fn Runtime(comptime App: type) type {
             switch (err) {
                 error.ConnectionSetupTimedOut => return alloc.dupe(u8, "Connection setup timed out after 30 seconds."),
                 error.TlsInitializationFailed => return alloc.dupe(u8, "Connection setup failed: TLS could not be initialized."),
+                error.ModelImageCapabilityUnavailable => return alloc.dupe(u8, image_attachments.model_image_capability_unavailable_notice),
                 else => {},
             }
             if (detailedErrorSummary(err)) |detail| {
@@ -171,6 +172,23 @@ test "formatErrorBody describes an interrupted provider response without present
     try std.testing.expect(std.mem.find(u8, body, "StreamInterrupted") != null);
     try std.testing.expect(std.mem.find(u8, body, "\x1b[") == null);
     try std.testing.expect(!std.mem.endsWith(u8, body, "\n"));
+}
+
+test "formatErrorBody explains unresolved image capability" {
+    const alloc = std.testing.allocator;
+    const Rt = Runtime(DummyApp);
+    const body = try Rt.formatErrorBody(
+        alloc,
+        "request failed",
+        error.ModelImageCapabilityUnavailable,
+    );
+    defer alloc.free(body);
+
+    try std.testing.expectEqualStrings(
+        "Unable to verify image support for this model, so the image was not sent. Try again later, choose another model, or remove the image.",
+        body,
+    );
+    try std.testing.expect(std.mem.find(u8, body, "ModelImageCapabilityUnavailable") == null);
 }
 
 test "formatErrorBody describes terminal connection setup failures plainly" {

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1184,6 +1184,7 @@ fn writeAskUsage(deps: RunDeps, usage: []const u8) !void {
 fn askErrorNotice(err: anyerror) ?[]const u8 {
     return switch (err) {
         error.ImagePreparationFailed => image_attachments.image_preparation_failed_notice,
+        error.ModelImageCapabilityUnavailable => image_attachments.model_image_capability_unavailable_notice,
         else => null,
     };
 }
@@ -5313,6 +5314,24 @@ test "image preparation failure has stable text and JSON contracts" {
     defer alloc.free(json);
     try std.testing.expectEqualStrings(
         "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"ImagePreparationFailed\"}\n",
+        json,
+    );
+}
+
+test "unresolved image capability has actionable text and stable JSON code" {
+    const alloc = std.testing.allocator;
+    try std.testing.expectEqualStrings(
+        "Unable to verify image support for this model, so the image was not sent. Try again later, choose another model, or remove the image.",
+        askErrorNotice(error.ModelImageCapabilityUnavailable).?,
+    );
+
+    const json = try renderErrorJsonResult(
+        alloc,
+        @errorName(error.ModelImageCapabilityUnavailable),
+    );
+    defer alloc.free(json);
+    try std.testing.expectEqualStrings(
+        "{\"output\":\"\",\"final_output\":\"\",\"exit_code\":1,\"model\":\"\",\"session_id\":\"\",\"steps\":0,\"tool_calls\":[],\"error\":\"ModelImageCapabilityUnavailable\"}\n",
         json,
     );
 }

--- a/src/core/config/model_capabilities.zig
+++ b/src/core/config/model_capabilities.zig
@@ -24,6 +24,12 @@ pub const ReasoningEffortOptions = struct {
     }
 };
 
+pub const ImageInputSupport = enum {
+    unknown,
+    non_native,
+    native,
+};
+
 pub const GatewayMetadata = struct {
     supports_reasoning: bool = false,
     reasoning_efforts: ReasoningEffortOptions = .{},
@@ -45,6 +51,7 @@ pub const Capabilities = struct {
     supports_tool_use: bool = false,
     supports_vision: bool = false,
     supports_file_input: bool = false,
+    image_input_support: ImageInputSupport = .unknown,
     supports_web_search: bool = false,
     supports_explicit_caching: bool = false,
     supports_implicit_caching: bool = false,
@@ -78,6 +85,10 @@ pub fn mergeCapabilities(capabilities_value: Capabilities, gateway_metadata: ?Ga
         capabilities.supports_tool_use = metadata.supports_tool_use;
         capabilities.supports_vision = metadata.supports_vision;
         capabilities.supports_file_input = metadata.supports_file_input;
+        capabilities.image_input_support = if (metadata.supports_vision and metadata.supports_file_input)
+            .native
+        else
+            .non_native;
         capabilities.supports_web_search = metadata.supports_web_search;
         capabilities.supports_explicit_caching = metadata.supports_explicit_caching;
         capabilities.supports_implicit_caching = metadata.supports_implicit_caching;
@@ -193,6 +204,25 @@ test "mergeCapabilities preserves provider controls and supplied fallback policy
     try std.testing.expect(capabilities.prompt_caching);
     try std.testing.expectEqual(@as(?u32, 300_000), capabilities.context_window);
     try std.testing.expectEqual(@as(?u32, 32_000), capabilities.max_output_tokens);
+}
+
+test "image input support distinguishes unknown native and non native capability" {
+    try std.testing.expectEqual(
+        ImageInputSupport.unknown,
+        capabilitiesForModel("provider/unknown").image_input_support,
+    );
+
+    const native = mergeCapabilities(.{}, .{
+        .supports_vision = true,
+        .supports_file_input = true,
+    });
+    try std.testing.expectEqual(ImageInputSupport.native, native.image_input_support);
+
+    const non_native = mergeCapabilities(.{}, .{
+        .supports_vision = true,
+        .supports_file_input = false,
+    });
+    try std.testing.expectEqual(ImageInputSupport.non_native, non_native.image_input_support);
 }
 
 test "reasoning effort picker helpers prepend default and preserve Gateway order" {

--- a/src/core/gateway/gateway_provider.zig
+++ b/src/core/gateway/gateway_provider.zig
@@ -437,6 +437,7 @@ test "capability resolver uses provider catalog metadata" {
 
     try std.testing.expect(capabilities.supports_vision);
     try std.testing.expect(capabilities.supports_file_input);
+    try std.testing.expectEqual(model_capabilities.ImageInputSupport.native, capabilities.image_input_support);
     try std.testing.expectEqual(@as(?u32, 256_000), capabilities.context_window);
     try std.testing.expectEqual(@as(?u32, 32_000), capabilities.max_output_tokens);
 
@@ -452,6 +453,7 @@ test "capability resolver uses provider catalog metadata" {
     );
     try std.testing.expect(!missing.supports_fast_mode);
     try std.testing.expect(!missing.supports_vision);
+    try std.testing.expectEqual(model_capabilities.ImageInputSupport.unknown, missing.image_input_support);
 }
 
 test "capability resolver retries rejected authenticated catalog access anonymously" {
@@ -493,6 +495,7 @@ test "capability resolver degrades terminal catalog failures to local capabiliti
         .{},
     );
     try std.testing.expect(!capabilities.supports_fast_mode);
+    try std.testing.expectEqual(model_capabilities.ImageInputSupport.unknown, capabilities.image_input_support);
 
     fake.outcome = .ready;
     const cached_failure = try resolver.resolve(
@@ -506,5 +509,6 @@ test "capability resolver degrades terminal catalog failures to local capabiliti
         .{},
     );
     try std.testing.expect(!cached_failure.supports_vision);
+    try std.testing.expectEqual(model_capabilities.ImageInputSupport.unknown, cached_failure.image_input_support);
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
 }

--- a/src/core/images/image_attachments.zig
+++ b/src/core/images/image_attachments.zig
@@ -12,6 +12,7 @@ pub const max_image_bytes: usize = 20 * 1024 * 1024;
 const max_encoded_image_bytes: usize = 5 * 1024 * 1024;
 pub const image_too_large_notice = "image exceeds the 20 MiB limit";
 pub const image_preparation_failed_notice = "Unable to prepare this image for upload. Use a smaller image.";
+pub const model_image_capability_unavailable_notice = "Unable to verify image support for this model, so the image was not sent. Try again later, choose another model, or remove the image.";
 const Sha256 = std.crypto.hash.sha2.Sha256;
 const snapshot_digest_hex_len = Sha256.digest_length * 2;
 const transfer_buffer_bytes = 64 * 1024;

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -3957,7 +3957,7 @@ describe("cli: ask success", () => {
           "explicit skill ask complete",
         );
         expect(gateway.requests).toHaveLength(1);
-        expect(gateway.modelRequests).toHaveLength(0);
+        expect(gateway.modelRequests).toHaveLength(1);
         expect(gateway.requests[0]!.body).toContain(
           "Explicitly invoked skill content for this query:",
         );
@@ -4018,7 +4018,7 @@ describe("cli: ask success", () => {
         }
 
         expect(gateway.requests).toHaveLength(sizes.length);
-        expect(gateway.modelRequests).toHaveLength(0);
+        expect(gateway.modelRequests).toHaveLength(sizes.length);
       } finally {
         gateway.stop();
         rmSync(root, { recursive: true, force: true });

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -6993,7 +6993,13 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
           },
         ]),
         fakeGatewayFinalText(finalText),
-      ]);
+      ], {
+        models: [{
+          id: MODEL,
+          type: "language",
+          tags: ["vision", "file-input", "tool-use"],
+        }],
+      });
       gateway = providerGateway;
 
       session = await TmuxSession.create({
@@ -7029,12 +7035,11 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       const initialRequest = parseGatewayRequest(providerGateway.requests[0]!.body);
       const continuingRequest = parseGatewayRequest(providerGateway.requests[1]!.body);
-      expect(serializedToolNames(initialRequest)).toEqual(
-        AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
+      const expectedToolNames = AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES.filter(
+        (name) => name !== "vision",
       );
-      expect(serializedToolNames(continuingRequest)).toEqual(
-        AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
-      );
+      expect(serializedToolNames(initialRequest)).toEqual(expectedToolNames);
+      expect(serializedToolNames(continuingRequest)).toEqual(expectedToolNames);
       expect(toolShapesWithoutDescriptions(continuingRequest)).toEqual(
         toolShapesWithoutDescriptions(initialRequest),
       );

--- a/tests/e2e/vision-route-fake-gateway.test.ts
+++ b/tests/e2e/vision-route-fake-gateway.test.ts
@@ -23,6 +23,7 @@ import { hasEmptyComposer, TmuxSession, tmuxAvailable } from "./tmux-helpers";
 const TIMEOUT = 15_000;
 const GLM_MODEL = "zai/glm-5.2-fast";
 const GEMINI_MODEL = "google/gemini-2.5-flash";
+const KIMI_MODEL = "moonshotai/kimi-k3";
 const IMAGE_PATH = join(REPO_ROOT, "tests/e2e/fixtures/placeholder-logo.png");
 
 type CapturedRequest = {
@@ -201,6 +202,7 @@ function expectVisionResponseFormat(body: string, imageCount: number) {
 function startImageGateway(
   responses: Response[],
   onChatRequest?: (index: number, body: string) => void,
+  catalogResponse?: Response,
 ) {
   const chatRequests: CapturedRequest[] = [];
   let catalogRequests = 0;
@@ -210,10 +212,16 @@ function startImageGateway(
       const url = new URL(req.url);
       if (url.pathname === "/coding-agent/v1/models") {
         catalogRequests += 1;
+        if (catalogResponse) return catalogResponse.clone();
         return Response.json({
           data: [
             {
               id: GEMINI_MODEL,
+              type: "language",
+              tags: ["vision", "file-input", "tool-use"],
+            },
+            {
+              id: KIMI_MODEL,
               type: "language",
               tags: ["vision", "file-input", "tool-use"],
             },
@@ -1051,6 +1059,49 @@ describe("Vision route fake Gateway", () => {
         expect(gateway.chatRequests).toHaveLength(1);
         expect(gateway.chatRequests[0].headers.get("ai-language-model-id")).toBe(GEMINI_MODEL);
         expect(gateway.chatRequests[0].body).toContain('"type":"file"');
+        expect(gateway.chatRequests[0].body).not.toContain('"name":"vision"');
+        expectScopedImageContext(gateway.chatRequests[0].body, fixture);
+        expect(gateway.chatRequests[0].body).not.toContain(fixture.imagePath);
+      } finally {
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "fx ask uses Kimi native vision without Vision tool",
+    async () => {
+      const root = createIsolatedRoot();
+      const fixture = createScopedImageFixture(root);
+      const gateway = startImageGateway([sseText("Kimi native image answer")]);
+      try {
+        const result = await runFx(
+          [
+            "ask",
+            "--json",
+            "--no-save",
+            "--no-color",
+            "--image",
+            fixture.imagePath,
+            "Describe the attached image.",
+          ],
+          {
+            cwd: root.workspace,
+            env: fakeGatewayEnv(root, gateway, KIMI_MODEL),
+            timeoutMs: TIMEOUT,
+          },
+        );
+
+        const json = parseFxJson(result);
+        expect(json.exit_code).toBe(0);
+        expect(json.output).toContain("Kimi native image answer");
+        expect(gateway.catalogRequests).toBe(1);
+        expect(gateway.chatRequests).toHaveLength(1);
+        expect(gateway.chatRequests[0].headers.get("ai-language-model-id")).toBe(KIMI_MODEL);
+        expect(gateway.chatRequests[0].body).toContain('"type":"file"');
+        expect(gateway.chatRequests[0].body).not.toContain('"name":"vision"');
         expectScopedImageContext(gateway.chatRequests[0].body, fixture);
         expect(gateway.chatRequests[0].body).not.toContain(fixture.imagePath);
       } finally {
@@ -1136,7 +1187,7 @@ describe("Vision route fake Gateway", () => {
   );
 
   test(
-    "saved native ID rejection recovers immediately and is filtered after resume",
+    "saved unadvertised native Vision rejection recovers and is filtered after resume",
     async () => {
       const root = createIsolatedRoot();
       const fixture = createScopedImageFixture(root);
@@ -1170,8 +1221,7 @@ describe("Vision route fake Gateway", () => {
         expect(first.stderr).not.toContain("Inspecting images");
         expect(first.stderr).not.toContain("Vision is unavailable right now");
         expect(gateway.chatRequests).toHaveLength(2);
-        expect(gateway.chatRequests[0].body).toContain('"name":"vision"');
-        expect(gateway.chatRequests[0].body).toContain('"paths":{"type":"array"');
+        expect(gateway.chatRequests[0].body).not.toContain('"name":"vision"');
         expect(gateway.chatRequests[0].body).not.toContain('"toolChoice":{"type":"required"}');
         expect(gateway.chatRequests[0].body).toContain('"type":"file"');
 
@@ -1226,8 +1276,7 @@ describe("Vision route fake Gateway", () => {
         expect(gateway.chatRequests).toHaveLength(3);
         const resumedRequest = gateway.chatRequests[2];
         expect(filePartCount(resumedRequest.body)).toBe(1);
-        expect(resumedRequest.body).toContain('"name":"vision"');
-        expect(resumedRequest.body).toContain('"paths":{"type":"array"');
+        expect(resumedRequest.body).not.toContain('"name":"vision"');
         expect(resumedRequest.body).not.toContain('"toolChoice":{"type":"required"}');
         expect(resumedRequest.body).not.toContain('"toolName":"vision"');
         expect(resumedRequest.body).not.toContain("native_vision");
@@ -1433,7 +1482,7 @@ describe("Vision route fake Gateway", () => {
   );
 
   test(
-    "text-only GLM ask skips image capability and Vision IO",
+    "text-only non-native ask resolves capability and exposes Vision",
     async () => {
       const root = createIsolatedRoot();
       const gateway = startImageGateway([sseText("text only answer")]);
@@ -1450,13 +1499,110 @@ describe("Vision route fake Gateway", () => {
         const json = parseFxJson(result);
         expect(json.exit_code).toBe(0);
         expect(json.output).toContain("text only answer");
-        expect(gateway.catalogRequests).toBe(0);
+        expect(gateway.catalogRequests).toBe(1);
         expect(gateway.chatRequests).toHaveLength(1);
         expect(gateway.chatRequests[0].headers.get("ai-language-model-id")).toBe(GLM_MODEL);
         expect(gateway.chatRequests[0].body).not.toContain('"type":"file"');
+        expect(gateway.chatRequests[0].body).toContain('"name":"vision"');
       } finally {
         gateway.stop();
         rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "text-only Kimi ask resolves capability and hides Vision",
+    async () => {
+      const root = createIsolatedRoot();
+      const gateway = startImageGateway([sseText("Kimi text only answer")]);
+      try {
+        const result = await runFx(
+          ["ask", "--json", "--no-save", "--no-color", "Reply exactly OK."],
+          {
+            cwd: root.workspace,
+            env: fakeGatewayEnv(root, gateway, KIMI_MODEL),
+            timeoutMs: TIMEOUT,
+          },
+        );
+
+        const json = parseFxJson(result);
+        expect(json.exit_code).toBe(0);
+        expect(json.output).toContain("Kimi text only answer");
+        expect(gateway.catalogRequests).toBe(1);
+        expect(gateway.chatRequests).toHaveLength(1);
+        expect(gateway.chatRequests[0].headers.get("ai-language-model-id")).toBe(KIMI_MODEL);
+        expect(gateway.chatRequests[0].body).not.toContain('"type":"file"');
+        expect(gateway.chatRequests[0].body).not.toContain('"name":"vision"');
+      } finally {
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "catalog failure hides Vision and rejects unresolved image input",
+    async () => {
+      const textRoot = createIsolatedRoot();
+      const textGateway = startImageGateway(
+        [sseText("text answer without Vision")],
+        undefined,
+        new Response("catalog unavailable", { status: 503 }),
+      );
+      try {
+        const textResult = await runFx(
+          ["ask", "--json", "--no-save", "--no-color", "Reply exactly OK."],
+          {
+            cwd: textRoot.workspace,
+            env: fakeGatewayEnv(textRoot, textGateway, KIMI_MODEL),
+            timeoutMs: TIMEOUT,
+          },
+        );
+        const textJson = parseFxJson(textResult);
+        expect(textJson.exit_code).toBe(0);
+        expect(textJson.output).toContain("text answer without Vision");
+        expect(textGateway.catalogRequests).toBe(1);
+        expect(textGateway.chatRequests).toHaveLength(1);
+        expect(textGateway.chatRequests[0].body).not.toContain('"name":"vision"');
+      } finally {
+        textGateway.stop();
+        rmSync(textRoot.root, { recursive: true, force: true });
+      }
+
+      const imageRoot = createIsolatedRoot();
+      const fixture = createScopedImageFixture(imageRoot);
+      const imageGateway = startImageGateway(
+        [],
+        undefined,
+        new Response("catalog unavailable", { status: 503 }),
+      );
+      try {
+        const imageResult = await runFx(
+          [
+            "ask",
+            "--json",
+            "--no-save",
+            "--no-color",
+            "--image",
+            fixture.imagePath,
+            "Describe the attached image.",
+          ],
+          {
+            cwd: imageRoot.workspace,
+            env: fakeGatewayEnv(imageRoot, imageGateway, KIMI_MODEL),
+            timeoutMs: TIMEOUT,
+          },
+        );
+        const imageJson = parseFxErrorJson(imageResult);
+        expect(imageJson.error).toContain("ModelImageCapabilityUnavailable");
+        expect(imageGateway.catalogRequests).toBe(1);
+        expect(imageGateway.chatRequests).toHaveLength(0);
+      } finally {
+        imageGateway.stop();
+        rmSync(imageRoot.root, { recursive: true, force: true });
       }
     },
     TIMEOUT,
@@ -1613,8 +1759,7 @@ describe("Vision route fake Gateway", () => {
         expect(gateway.chatRequests[0].body).toContain('"toolChoice":{"type":"required"}');
         expect(gateway.chatRequests[0].body).toContain("[Image #1]");
         expect(gateway.chatRequests[3].headers.get("ai-language-model-id")).toBe(GEMINI_MODEL);
-        expect(gateway.chatRequests[3].body).toContain('"name":"vision"');
-        expect(gateway.chatRequests[3].body).toContain('"paths":{"type":"array"');
+        expect(gateway.chatRequests[3].body).not.toContain('"name":"vision"');
         expect(gateway.chatRequests[3].body).not.toContain('"toolChoice":{"type":"required"}');
         expect(gateway.chatRequests[3].body).not.toContain('"toolName":"vision"');
         expect(gateway.chatRequests[3].body).not.toContain("first image evidence");
@@ -1711,8 +1856,7 @@ describe("Vision route fake Gateway", () => {
         expect(nativeJson.tool_calls).toHaveLength(0);
         expect(gateway.chatRequests).toHaveLength(1);
         expect(gateway.chatRequests[0].headers.get("ai-language-model-id")).toBe(GEMINI_MODEL);
-        expect(gateway.chatRequests[0].body).toContain('"name":"vision"');
-        expect(gateway.chatRequests[0].body).toContain('"paths":{"type":"array"');
+        expect(gateway.chatRequests[0].body).not.toContain('"name":"vision"');
         expect(gateway.chatRequests[0].body).not.toContain('"toolChoice":{"type":"required"}');
         expect(filePartCount(gateway.chatRequests[0].body)).toBe(5);
         expect(gateway.chatRequests[0].body).toContain("Legacy first image: [Image #1]");

--- a/tests/e2e/vision-route-fake-gateway.test.ts
+++ b/tests/e2e/vision-route-fake-gateway.test.ts
@@ -1609,6 +1609,49 @@ describe("Vision route fake Gateway", () => {
   );
 
   test(
+    "catalog failure explains unresolved image capability in text mode",
+    async () => {
+      const root = createIsolatedRoot();
+      const fixture = createScopedImageFixture(root);
+      const gateway = startImageGateway(
+        [],
+        undefined,
+        new Response("catalog unavailable", { status: 503 }),
+      );
+      try {
+        const result = await runFx(
+          [
+            "ask",
+            "--no-save",
+            "--no-color",
+            "--image",
+            fixture.imagePath,
+            "Describe the attached image.",
+          ],
+          {
+            cwd: root.workspace,
+            env: fakeGatewayEnv(root, gateway, KIMI_MODEL),
+            timeoutMs: TIMEOUT,
+          },
+        );
+
+        expect(result.code).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toBe(
+          "fx ask: Unable to verify image support for this model, so the image was not sent. Try again later, choose another model, or remove the image.\n",
+        );
+        expect(result.stderr).not.toContain("ModelImageCapabilityUnavailable");
+        expect(gateway.catalogRequests).toBe(1);
+        expect(gateway.chatRequests).toHaveLength(0);
+      } finally {
+        gateway.stop();
+        rmSync(root.root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  test(
     "Vision outage is an ordinary failed tool result with the exact notice",
     async () => {
       const root = createIsolatedRoot();

--- a/tests/evals/vision-capability-routing.test.ts
+++ b/tests/evals/vision-capability-routing.test.ts
@@ -1,13 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   copyFileSync,
-  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
-  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -251,63 +249,4 @@ describe.skipIf(!HAS_API_KEY)("eval: live Vision capability routing", () => {
     },
     TIMEOUT,
   );
-
-  test("missing image input stops before catalog access", async () => {
-    const root = createRoot("fx-live-missing-image");
-    const missingPath = join(root.workspace, "missing.png");
-
-    const result = await runFx(
-      [
-        "ask",
-        "--yolo",
-        "--json",
-        "--no-save",
-        "--no-color",
-        "--image",
-        missingPath,
-        "Read the image.",
-      ],
-      {
-        cwd: root.workspace,
-        env: liveEnv(root, KIMI_MODEL),
-        timeoutMs: TIMEOUT,
-      },
-    );
-
-    const json = parseResult(result);
-    expect(result.code).toBe(1);
-    expect(json.exit_code).toBe(1);
-    expect(json.error).toBe(`FileNotFound: ${missingPath}`);
-    expect(existsSync(root.tracePath)).toBe(false);
-  });
-
-  test("corrupt image input stops before catalog access", async () => {
-    const root = createRoot("fx-live-corrupt-image");
-    const imagePath = join(root.workspace, "corrupt.png");
-    writeFileSync(imagePath, "not an image");
-
-    const result = await runFx(
-      [
-        "ask",
-        "--yolo",
-        "--json",
-        "--no-save",
-        "--no-color",
-        "--image",
-        imagePath,
-        "Read the image.",
-      ],
-      {
-        cwd: root.workspace,
-        env: liveEnv(root, KIMI_MODEL),
-        timeoutMs: TIMEOUT,
-      },
-    );
-
-    const json = parseResult(result);
-    expect(result.code).toBe(1);
-    expect(json.exit_code).toBe(1);
-    expect(json.error).toBe(`UnsupportedImageType: ${imagePath}`);
-    expect(existsSync(root.tracePath)).toBe(false);
-  });
 });

--- a/tests/evals/vision-capability-routing.test.ts
+++ b/tests/evals/vision-capability-routing.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  HAS_API_KEY,
+  REPO_ROOT,
+  runFx,
+  type FxRunResult,
+  type HeadlessResult,
+} from "./eval-helpers";
+
+const TIMEOUT = 180_000;
+const KIMI_MODEL = "moonshotai/kimi-k3";
+const GLM_MODEL = "zai/glm-5.2-fast";
+const UNKNOWN_MODEL = "unknown/fx-vision-capability-probe-not-real";
+const IMAGE_FIXTURE = join(REPO_ROOT, "tests/e2e/fixtures/favicon.png");
+
+type Root = {
+  root: string;
+  home: string;
+  workspace: string;
+  tracePath: string;
+};
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function createRoot(name: string): Root {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), `${name}-`)));
+  const home = join(root, "home");
+  const workspace = join(root, "workspace");
+  mkdirSync(join(home, ".fx"), { recursive: true });
+  mkdirSync(workspace);
+  roots.push(root);
+  return {
+    root,
+    home,
+    workspace: realpathSync(workspace),
+    tracePath: join(root, "trace.log"),
+  };
+}
+
+function liveEnv(root: Root, model: string) {
+  return {
+    HOME: root.home,
+    FX_MODEL: model,
+    FX_AUTO_UPGRADE: "0",
+    FX_DISABLE_KEYCHAIN: "1",
+    FX_SKIP_ONBOARDING: "1",
+    FX_TRACE_LOG: root.tracePath,
+    FX_TRACE_SCOPES: "agent,gateway,catalog,tool",
+  };
+}
+
+function parseResult(result: FxRunResult): HeadlessResult {
+  expect(result.timedOut, result.processStateAtTimeout).toBe(false);
+  expect(result.signal).toBeNull();
+  return JSON.parse(result.stdout.trim()) as HeadlessResult;
+}
+
+function normalizedLetters(output: string): string {
+  return output.toLowerCase().replace(/[^a-z]/g, "");
+}
+
+function successfulVisionCalls(json: HeadlessResult) {
+  return json.tool_calls.filter(
+    (call) => call.name === "vision" && call.status === "success",
+  );
+}
+
+describe.skipIf(!HAS_API_KEY)("eval: live Vision capability routing", () => {
+  test(
+    "Kimi reads native image input while Vision remains unavailable",
+    async () => {
+      const root = createRoot("fx-live-native-vision");
+      const imagePath = join(root.workspace, "glyph.png");
+      copyFileSync(IMAGE_FIXTURE, imagePath);
+
+      const result = await runFx(
+        [
+          "ask",
+          "--yolo",
+          "--json",
+          "--no-save",
+          "--no-color",
+          "--image",
+          imagePath,
+          "Read the two white Latin letters shown on the black background. Reply with those two letters only.",
+        ],
+        {
+          cwd: root.workspace,
+          env: liveEnv(root, KIMI_MODEL),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      const json = parseResult(result);
+      expect(result.code, result.stderr).toBe(0);
+      expect(json.exit_code).toBe(0);
+      expect(json.model).toBe(KIMI_MODEL);
+      expect(normalizedLetters(json.final_output || json.output)).toBe("fx");
+      expect(json.tool_calls.filter((call) => call.name === "vision")).toEqual([]);
+
+      const trace = readFileSync(root.tracePath, "utf8");
+      expect(trace).toContain("model catalog lookup outcome=ready_hit model=moonshotai/kimi-k3");
+      expect(trace).toMatch(
+        /event=vision_policy .*image_support=native route=native mode=unavailable/,
+      );
+      expect(trace).not.toContain("name=vision result_kind=model_output");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "GLM uses required Vision for attached image input",
+    async () => {
+      const root = createRoot("fx-live-required-vision");
+      const imagePath = join(root.workspace, "glyph.png");
+      copyFileSync(IMAGE_FIXTURE, imagePath);
+
+      const result = await runFx(
+        [
+          "ask",
+          "--yolo",
+          "--json",
+          "--no-save",
+          "--no-color",
+          "--image",
+          imagePath,
+          "Read the two white Latin letters shown on the black background. Reply with those two letters only.",
+        ],
+        {
+          cwd: root.workspace,
+          env: liveEnv(root, GLM_MODEL),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      const json = parseResult(result);
+      expect(result.code, result.stderr).toBe(0);
+      expect(json.exit_code).toBe(0);
+      expect(json.model).toBe(GLM_MODEL);
+      expect(normalizedLetters(json.final_output || json.output)).toBe("fx");
+      expect(successfulVisionCalls(json)).toHaveLength(1);
+
+      const trace = readFileSync(root.tracePath, "utf8");
+      expect(trace).toContain("model catalog lookup outcome=ready_hit model=zai/glm-5.2-fast");
+      expect(trace).toMatch(
+        /event=vision_policy .*image_support=non_native route=fallback mode=required/,
+      );
+      expect(trace).toMatch(
+        /event=vision_policy .*image_support=non_native route=fallback mode=optional/,
+      );
+      expect(trace).toContain("name=vision result_kind=model_output");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "GLM exposes optional Vision for a workspace image path",
+    async () => {
+      const root = createRoot("fx-live-optional-vision");
+      const imagePath = join(root.workspace, "glyph.png");
+      copyFileSync(IMAGE_FIXTURE, imagePath);
+
+      const result = await runFx(
+        [
+          "ask",
+          "--yolo",
+          "--json",
+          "--no-save",
+          "--no-color",
+          `Call Vision to inspect the image file at ${imagePath}. Read the two white Latin letters and reply with those letters only.`,
+        ],
+        {
+          cwd: root.workspace,
+          env: liveEnv(root, GLM_MODEL),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      const json = parseResult(result);
+      expect(result.code, result.stderr).toBe(0);
+      expect(json.exit_code).toBe(0);
+      expect(json.model).toBe(GLM_MODEL);
+      expect(normalizedLetters(json.final_output || json.output)).toBe("fx");
+      expect(successfulVisionCalls(json)).toHaveLength(1);
+
+      const trace = readFileSync(root.tracePath, "utf8");
+      expect(trace).toMatch(
+        /event=vision_policy .*image_support=non_native route=fallback mode=optional/,
+      );
+      expect(trace).not.toContain("mode=required");
+      expect(trace).toContain("name=vision result_kind=model_output");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "unknown model capability rejects image input after a real catalog lookup",
+    async () => {
+      const root = createRoot("fx-live-unknown-vision");
+      const imagePath = join(root.workspace, "glyph.png");
+      copyFileSync(IMAGE_FIXTURE, imagePath);
+
+      const result = await runFx(
+        [
+          "ask",
+          "--yolo",
+          "--json",
+          "--no-save",
+          "--no-color",
+          "--image",
+          imagePath,
+          "Read the image.",
+        ],
+        {
+          cwd: root.workspace,
+          env: liveEnv(root, UNKNOWN_MODEL),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      const json = parseResult(result);
+      expect(result.code).toBe(1);
+      expect(json.exit_code).toBe(1);
+      expect(json.model).toBe(UNKNOWN_MODEL);
+      expect(json.error).toContain("ModelImageCapabilityUnavailable");
+
+      const trace = readFileSync(root.tracePath, "utf8");
+      expect(trace).toContain(`model catalog lookup outcome=missing_entry model=${UNKNOWN_MODEL}`);
+      expect(trace).toMatch(
+        /event=vision_policy .*image_support=unknown route=unavailable mode=unavailable/,
+      );
+      expect(trace).not.toContain("event=provider_admitted");
+    },
+    TIMEOUT,
+  );
+
+  test("missing image input stops before catalog access", async () => {
+    const root = createRoot("fx-live-missing-image");
+    const missingPath = join(root.workspace, "missing.png");
+
+    const result = await runFx(
+      [
+        "ask",
+        "--yolo",
+        "--json",
+        "--no-save",
+        "--no-color",
+        "--image",
+        missingPath,
+        "Read the image.",
+      ],
+      {
+        cwd: root.workspace,
+        env: liveEnv(root, KIMI_MODEL),
+        timeoutMs: TIMEOUT,
+      },
+    );
+
+    const json = parseResult(result);
+    expect(result.code).toBe(1);
+    expect(json.exit_code).toBe(1);
+    expect(json.error).toBe(`FileNotFound: ${missingPath}`);
+    expect(existsSync(root.tracePath)).toBe(false);
+  });
+
+  test("corrupt image input stops before catalog access", async () => {
+    const root = createRoot("fx-live-corrupt-image");
+    const imagePath = join(root.workspace, "corrupt.png");
+    writeFileSync(imagePath, "not an image");
+
+    const result = await runFx(
+      [
+        "ask",
+        "--yolo",
+        "--json",
+        "--no-save",
+        "--no-color",
+        "--image",
+        imagePath,
+        "Read the image.",
+      ],
+      {
+        cwd: root.workspace,
+        env: liveEnv(root, KIMI_MODEL),
+        timeoutMs: TIMEOUT,
+      },
+    );
+
+    const json = parseResult(result);
+    expect(result.code).toBe(1);
+    expect(json.exit_code).toBe(1);
+    expect(json.error).toBe(`UnsupportedImageType: ${imagePath}`);
+    expect(existsSync(root.tracePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Hide Vision from models that accept native image input.
- Keep Vision required for new images and optional later for non-native models.
- Hide Vision when image capability cannot be resolved.
- Explain how to recover when image capability cannot be verified.
- Preserve ModelImageCapabilityUnavailable in JSON output.
