### PR TITLE
Allow closing compact command menus with Esc

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1381,6 +1381,10 @@ pub fn Runtime(comptime App: type) type {
                         _ = moveCompactCommandMenu(app, menu, -1);
                         app.shell.render_requests.request(.footer);
                     },
+                    27 => {
+                        _ = cancelCompactCommandMenu(app);
+                        app.shell.render_requests.request(.footer);
+                    },
                     else => {},
                 }
                 return true;


### PR DESCRIPTION
When a compact command menu (such as usage, statusline, or workspace) is active, `routeActiveModalInput` intercepts raw input bytes and returns `true` for all unhandled keys.

Because raw byte `27` (`Esc`) fell through to `else => {}`, pressing `Esc` was swallowed without closing the active compact menu.

Handle byte `27` by invoking `cancelCompactCommandMenu` and requesting a footer redraw.

Fixes #196.