### PR TITLE
Retry tmux PGSO scenarios with fresh state

### DIFF
--- a/scripts/pgso/README.md
+++ b/scripts/pgso/README.md
@@ -71,6 +71,12 @@ Sound-bearing `notifications.test.ts` and `tui-command-permissions.test.ts` are 
 
 Each training scenario must create a new nonempty raw profile. The driver merges that batch into the accumulator atomically, deletes only the successfully merged raw files, and stops before profile use on any missing scenario, timeout, warning, merge failure, or cleanup failure.
 
+Tmux-backed E2E scenarios receive one bounded file-level retry, matching Full
+CI. Before that retry, the driver removes the failed scenario HOME, isolated
+tmux directory, debug trace, and every raw profile created by the failed
+attempt. A second failure remains terminal. Direct commands and non-tmux E2E
+scenarios are never retried.
+
 Candidate behavior qualification records each scenario's debug trace under `candidate-behavior/traces/` without restricting its trace scopes. A failed tmux case therefore preserves its internal startup subtype and cleanup evidence instead of retaining only the public protocol error, while tests that select their own trace path or scopes keep their intended behavior.
 
 ## Qualification policy

--- a/scripts/pgso/corpus.py
+++ b/scripts/pgso/corpus.py
@@ -9,6 +9,7 @@ import pathlib
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import uuid
 from collections.abc import Callable, Iterator, Mapping, Sequence
@@ -552,6 +553,7 @@ def _execute_scenario(
     command_runner: Callable[..., CommandResult],
     run_index: int = 0,
     run_count: int = 1,
+    attempt_index: int = 0,
 ) -> CommandResult:
     scenario_home = runtime_home / scenario.name
     _prepare_runtime_home(scenario_home, allow_keychain=scenario.allow_keychain)
@@ -573,6 +575,8 @@ def _execute_scenario(
             if run_count == 1
             else f"{scenario.name}-run-{run_index + 1:03d}"
         )
+        if attempt_index > 0:
+            log_name += f"-attempt-{attempt_index + 1}"
         return command_runner(
             _scenario_argv(scenario, canonical, bun),
             cwd=_resolve_cwd(corpus.repo_root, scenario.cwd),
@@ -590,6 +594,32 @@ def _execute_scenario(
             except Exception:
                 if primary_error is None:
                     raise
+
+
+def _reset_failed_tmux_e2e_attempt(
+    runtime_home: pathlib.Path,
+    scenario: Scenario,
+    environment: Mapping[str, str],
+    state: object,
+) -> None:
+    scenario_home = runtime_home / scenario.name
+    if scenario_home.parent != runtime_home or scenario_home.is_symlink():
+        raise PgsoError(f"refusing to reset unsafe scenario home: {scenario_home}")
+    shutil.rmtree(scenario_home, ignore_errors=False)
+
+    profile_pattern = environment.get("LLVM_PROFILE_FILE")
+    if profile_pattern is not None:
+        if not isinstance(state, set):
+            raise PgsoError("invalid training profile snapshot")
+        profile_dir = pathlib.Path(profile_pattern).parent
+        for profile in set(profile_dir.glob("*.profraw")) - state:
+            if profile.parent != profile_dir or profile.suffix != ".profraw":
+                raise PgsoError(f"refusing to remove unsafe profile path: {profile}")
+            profile.unlink()
+
+    trace_path = environment.get("FX_TRACE_LOG")
+    if trace_path is not None:
+        pathlib.Path(trace_path).unlink(missing_ok=True)
 
 
 def _run_scenarios(
@@ -617,18 +647,41 @@ def _run_scenarios(
                 state = prepare(scenario, environment)
                 run_count = scenario.profile_runs if repeat_profile_runs else 1
                 for run_index in range(run_count):
-                    command_result = _execute_scenario(
-                        corpus,
-                        scenario,
-                        canonical,
-                        bun,
-                        runtime_home,
-                        log_dir,
-                        environment,
-                        command_runner,
-                        run_index,
-                        run_count,
-                    )
+                    attempts = 2 if (
+                        scenario.test_file is not None and
+                        scenario.requires_tmux and
+                        run_count == 1
+                    ) else 1
+                    for attempt_index in range(attempts):
+                        try:
+                            command_result = _execute_scenario(
+                                corpus,
+                                scenario,
+                                canonical,
+                                bun,
+                                runtime_home,
+                                log_dir,
+                                environment,
+                                command_runner,
+                                run_index,
+                                run_count,
+                                attempt_index,
+                            )
+                            break
+                        except Exception:
+                            if attempt_index + 1 >= attempts:
+                                raise
+                            _reset_failed_tmux_e2e_attempt(
+                                runtime_home,
+                                scenario,
+                                environment,
+                                state,
+                            )
+                            print(
+                                f"[pgso] retrying failed tmux E2E scenario "
+                                f"after isolated state reset: {scenario.name}",
+                                file=sys.stderr,
+                            )
                     elapsed_seconds += command_result.elapsed_seconds
                 assert command_result is not None
                 raw_profiles = finish(scenario, command_result, state)

--- a/scripts/pgso/tests/test_corpus.py
+++ b/scripts/pgso/tests/test_corpus.py
@@ -697,6 +697,129 @@ class PgsoCorpusTests(unittest.TestCase):
         self.assertLess(len(f"{tmux_tmp}/tmux-501/default".encode()), 104)
         self.assertFalse(tmux_tmp.exists())
 
+    def test_tmux_e2e_retries_once_with_fresh_state_and_profiles(self) -> None:
+        scenario = dataclasses_replace_test_file(
+            self.make_scenario("tui-retry", requires_tmux=True),
+            "tui-retry.test.ts",
+        )
+        corpus = self.make_corpus(scenario)
+        output = self.root / "retry-output"
+        profile_dir = output / "profiles" / "raw"
+        profile_dir.mkdir(parents=True)
+        binary = self.root / "retry-instrumented-fx"
+        binary.write_bytes(b"instrumented")
+        calls: list[dict[str, str]] = []
+        merged_profiles: list[str] = []
+        cleaned_tmux_dirs: list[pathlib.Path] = []
+
+        def command_runner(argv, **kwargs):
+            environment = dict(kwargs["env"])
+            calls.append(environment)
+            home = pathlib.Path(environment["HOME"])
+            stale = home / "failed-attempt"
+            pattern = environment["LLVM_PROFILE_FILE"]
+            raw = pathlib.Path(
+                pattern.replace("%m", "module")
+                .replace("%p", str(len(calls)))
+                .replace("%c", "")
+            )
+            raw.write_bytes(f"attempt-{len(calls)}".encode())
+            if len(calls) == 1:
+                stale.write_text("stale")
+                raise PgsoError("transient tmux failure")
+            self.assertFalse(stale.exists())
+            return CommandResult(
+                argv=tuple(argv),
+                returncode=0,
+                stdout="ok\n",
+                stderr="",
+                elapsed_seconds=0.25,
+            )
+
+        def profile_merger(_toolchain, raw_profiles, merged, _log_path):
+            merged_profiles.extend(path.name for path in raw_profiles)
+            merged.write_bytes(b"merged")
+            for raw in raw_profiles:
+                raw.unlink()
+            return len(raw_profiles)
+
+        def cleanup_tmux(_environment, tmux_dir):
+            cleaned_tmux_dirs.append(tmux_dir)
+            tmux_dir.rmdir()
+
+        with mock.patch("scripts.pgso.corpus._cleanup_tmux", cleanup_tmux):
+            result = run_corpus(
+                corpus,
+                binary,
+                profile_dir,
+                output / "profiles" / "merged.profdata",
+                toolchain=object(),
+                command_runner=command_runner,
+                profile_merger=profile_merger,
+            )
+
+        self.assertEqual(1, result.passed)
+        self.assertEqual(2, len(calls))
+        self.assertNotEqual(calls[0]["TMUX_TMPDIR"], calls[1]["TMUX_TMPDIR"])
+        self.assertEqual(2, len(cleaned_tmux_dirs))
+        self.assertEqual(["tui-retry-module-2-.profraw"], merged_profiles)
+
+    def test_tmux_e2e_second_failure_remains_fatal(self) -> None:
+        scenario = dataclasses_replace_test_file(
+            self.make_scenario("tui-fails", requires_tmux=True),
+            "tui-fails.test.ts",
+        )
+        corpus = self.make_corpus(scenario)
+        binary = self.root / "failed-candidate-fx"
+        binary.write_bytes(b"candidate")
+        calls = 0
+
+        def command_runner(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            raise PgsoError("persistent tmux failure")
+
+        def cleanup_tmux(_environment, tmux_dir):
+            tmux_dir.rmdir()
+
+        with (
+            mock.patch("scripts.pgso.corpus._cleanup_tmux", cleanup_tmux),
+            self.assertRaises(CorpusRunError),
+        ):
+            run_behavior_corpus(
+                corpus,
+                binary,
+                self.root / "failed-behavior-output",
+                command_runner=command_runner,
+            )
+
+        self.assertEqual(2, calls)
+
+    def test_non_tmux_e2e_failure_is_not_retried(self) -> None:
+        scenario = dataclasses_replace_test_file(
+            self.make_scenario("plain-e2e"),
+            "plain-e2e.test.ts",
+        )
+        corpus = self.make_corpus(scenario)
+        binary = self.root / "plain-candidate-fx"
+        binary.write_bytes(b"candidate")
+        calls = 0
+
+        def command_runner(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            raise PgsoError("plain failure")
+
+        with self.assertRaises(CorpusRunError):
+            run_behavior_corpus(
+                corpus,
+                binary,
+                self.root / "plain-behavior-output",
+                command_runner=command_runner,
+            )
+
+        self.assertEqual(1, calls)
+
     def test_keychain_access_is_scoped_to_the_declared_scenario_home(self) -> None:
         host_home = self.root / "host-home"
         host_keychains = host_home / "Library" / "Keychains"
@@ -875,6 +998,19 @@ def dataclasses_replace_allow_keychain(scenario: Scenario) -> Scenario:
     import dataclasses
 
     return dataclasses.replace(scenario, allow_keychain=True)
+
+
+def dataclasses_replace_test_file(
+    scenario: Scenario,
+    test_file: str,
+) -> Scenario:
+    import dataclasses
+
+    return dataclasses.replace(
+        scenario,
+        argv=("bun", "test", "--max-concurrency", "1", f"./{test_file}"),
+        test_file=test_file,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Retry a failed tmux-backed PGSO E2E scenario once after resetting its isolated runtime state.
- Discard failed-attempt traces and profiles before the retry.
- Keep second failures fatal and leave non-tmux scenarios single-attempt.