### PR TITLE
Add terminal color palette option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Config precedence (highest wins):
 4. `<workspace>/.fx.json` (committed project defaults)
 5. Built-in defaults
 
-Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `permission_mode`, `credential_source`, and `permission` are ignored from project config before their values are parsed.
+Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `color_palette`, `permission_mode`, `credential_source`, and `permission` are ignored from project config before their values are parsed.
 
 Runtime state lives under `~/.fx/sessions/<session-id>/` (`session.json`, `background/`, `subagent/`, `logs/`). Sessions are global and portable across workspaces. Each session tracks its `workspace_root`, which updates when resumed in a different workspace. A subagent child is an internal ordinary session with its own history. Its parent owns one bounded `subagent/children.json` registry, and the child carries only an immutable owner marker. Child sessions stay out of ordinary session discovery and cannot be resumed directly. A first `subagent.message` creates a named persistent child in that parent; later messages continue it, and optional instructions replace only its child-specific system overlay.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Config precedence (highest wins):
 4. `<workspace>/.fx.json` (committed project defaults)
 5. Built-in defaults
 
-Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `update_channel`, `permission_mode`, and `permission` are ignored from project config before their values are parsed.
+Project `.fx.json` accepts only repo-safe defaults: `sandbox`, `max_agent_steps`, `max_tool_result_bytes`, and `context`. Profile-owned keys such as `model`, `effort`, `fast_mode`, `slash_menu_categories`, `startup_scrollback`, `prompt_history`, `statusLine`, `skill_match_fuzzy`, `first_call_tool_choice`, `auto_upgrade`, `update_channel`, `color_palette`, `permission_mode`, and `permission` are ignored from project config before their values are parsed.
 
 Runtime state lives under `~/.fx/`:
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ The current directory becomes the primary workspace. Enter a prompt, or run `/he
 
 Tool calls are expanded by default. Enable `Collapse tool calls` in `/settings`, or set `"collapse_tool_calls": true` in `~/.fx/settings.json`, to show one summary per tool-call group in the main transcript. Individual calls remain available in the full transcript with Ctrl+O.
 
+fx uses its built-in color palette by default. To use the colors configured by your terminal theme, select `terminal` for `Color palette` in `/settings`, or set the profile preference in `~/.fx/settings.json`:
+
+```json
+{
+  "color_palette": "terminal"
+}
+```
+
+The terminal palette uses the terminal's default foreground and background plus its ANSI color slots. Select `fx` again to restore the built-in palette.
+
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fx uses its built-in color palette by default. To use the colors configured by y
 }
 ```
 
-The terminal palette uses the terminal's default foreground and background plus its ANSI color slots. Select `fx` again to restore the built-in palette.
+The terminal palette uses the terminal's default foreground and background plus its ANSI color slots. Changes apply immediately to fx-owned interface chrome and output from newly started turns and persist for future launches. Retained transcript entries and in-flight turns keep the styling they were created with. Select `fx` again to restore the built-in palette under the same rules.
 
 The status line hides the workspace path and Git branch by default. Enable the `Status line workspace` option in `/settings`, run `/statusline workspace`, or set it in `~/.fx/settings.json`:
 

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -11,6 +11,7 @@ const js_host_tools = if (host_target.is_wasm)
 else
     struct {};
 const io_mod = @import("../core/shared/io.zig");
+const presentation_palette = @import("../core/shared/presentation_palette.zig");
 const image_attachments = @import("../core/images/image_attachments.zig");
 const jsonrpc = @import("jsonrpc.zig");
 const acp_types = @import("types.zig");
@@ -328,6 +329,9 @@ const AcpContext = struct {
         }
         var tc: tool_runtime.Context = .{
             .workspace_root = self.state.workspace_root,
+            // ACP has no terminal theme negotiation; make its stable built-in
+            // presentation explicit for any child admission it creates.
+            .presentation_snapshot = presentation_palette.snapshot(false, .fx, false),
             .access_scope = self.state.workspace_access.scope(self.state.workspace_root),
             .ignored_list_entries = self.state.cfg.ignored_list_entries,
             .max_list_entries = self.state.cfg.max_list_entries,
@@ -1692,7 +1696,7 @@ fn writePermissionOption(
     try writer.writeByte('}');
 }
 
-fn describeToolAction(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+fn describeToolAction(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, _: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     return tool_presentation.formatPlainAction(arena, .{
         .tool_registry = ctx.toolRegistry(),
@@ -1713,7 +1717,7 @@ fn resolveToolActionDisplayTarget(raw_ctx: *anyopaque, arena: Allocator, call: T
     );
 }
 
-fn describeToolActionCompleted(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+fn describeToolActionCompleted(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, _: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     return tool_presentation.formatPlainAction(arena, .{
         .tool_registry = ctx.toolRegistry(),
@@ -1723,7 +1727,7 @@ fn describeToolActionCompleted(raw_ctx: *anyopaque, arena: Allocator, call: Tool
     });
 }
 
-fn describeToolActionDenied(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+fn describeToolActionDenied(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, _: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     const action = try tool_presentation.formatPlainAction(arena, .{
         .tool_registry = ctx.toolRegistry(),
@@ -1857,6 +1861,7 @@ fn completeToolCallTransport(
 fn publishCommittedFileHandoff(
     _: *anyopaque,
     _: file_mutation.CommittedFileHandoff,
+    _: agent_runtime.PresentationStyles,
 ) agent_runtime.SecondaryPublicationReport {
     return .{ .diff = .skipped, .tracker = .skipped };
 }

--- a/src/core/agent/agent_runtime.zig
+++ b/src/core/agent/agent_runtime.zig
@@ -8,6 +8,8 @@ const runtime_finalization = @import("runtime/finalization.zig");
 const runtime_lifecycle = @import("runtime/lifecycle.zig");
 const runtime_orchestrator = @import("runtime/orchestrator.zig");
 const runtime_tool_contracts = @import("runtime/tool_contracts.zig");
+const assistant_presentation = @import("assistant_presentation.zig");
+const worker_runtime = @import("worker_runtime.zig");
 
 pub const ToolExecutionStatus = runtime_tool_contracts.ToolExecutionStatus;
 pub const Agent = runtime_agent.Agent;
@@ -24,6 +26,7 @@ pub const ToolExecutionRequest = runtime_tool_contracts.ToolExecutionRequest;
 pub const DiffEntryPayload = runtime_tool_contracts.DiffEntryPayload;
 pub const ToolCallValidationResult = runtime_tool_contracts.ToolCallValidationResult;
 pub const AgentRuntimeDeps = runtime_deps.AgentRuntimeDeps;
+pub const PresentationStyles = runtime_deps.PresentationStyles;
 pub const TextEmission = runtime_deps.TextEmission;
 pub const ParentTurnDeliveryAck = runtime_deps.ParentTurnDeliveryAck;
 pub const PreparedParentTurnContext = runtime_deps.PreparedParentTurnContext;
@@ -38,7 +41,33 @@ pub const prepareToolCallForLifecycle = runtime_lifecycle.prepareToolCallForLife
 pub const dispatchAttentionRequiredCheckpoint = runtime_lifecycle.dispatchAttentionRequiredCheckpoint;
 pub const TurnFinalizationGuard = runtime_finalization.TurnFinalizationGuard;
 pub const Config = runtime_config.Config;
-pub const processAgentPrompt = runtime_orchestrator.processAgentPrompt;
+pub fn processAgentPrompt(
+    agent: *Agent,
+    deps: *const AgentRuntimeDeps,
+    semantic_presentation: ?SemanticPresentationSink,
+    lifecycle: LifecycleContext,
+    config: Config,
+    job: worker_runtime.QueuedPrompt,
+) !void {
+    const prior_inline_code = assistant_presentation.currentInlineCodeStyle();
+    const prior_task_completed = assistant_presentation.currentTaskCompletedStyle();
+    defer assistant_presentation.setPresentationStyles(
+        prior_inline_code,
+        prior_task_completed,
+    );
+    assistant_presentation.setPresentationStyles(
+        deps.presentation_styles.inline_code,
+        deps.presentation_styles.task_completed,
+    );
+    return runtime_orchestrator.processAgentPrompt(
+        agent,
+        deps,
+        semantic_presentation,
+        lifecycle,
+        config,
+        job,
+    );
+}
 pub const compactContextTransaction = runtime_orchestrator.compactContextTransaction;
 pub const persistedStatusForCurrentFxLocalResult = runtime_execution_memory.persistedStatusForCurrentFxLocalResult;
 pub const classifyProviderExecutedResultStatus = runtime_execution_memory.classifyProviderExecutedResultStatus;

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -14,6 +14,9 @@ var link_id_counter: u32 = 1;
 
 pub const setInlineCodeTheme = ansi.setInlineCodeTheme;
 pub const setInlineCodePalette = ansi.setInlineCodePalette;
+pub const setPresentationStyles = ansi.setPresentationStyles;
+pub const currentInlineCodeStyle = ansi.currentInlineCodeStyle;
+pub const currentTaskCompletedStyle = ansi.currentTaskCompletedStyle;
 pub const writeHorizontalRule = ansi.writeHorizontalRule;
 
 pub const TableColumnAlign = payload.TableColumnAlign;

--- a/src/core/agent/assistant_presentation.zig
+++ b/src/core/agent/assistant_presentation.zig
@@ -13,6 +13,7 @@ const block_render = @import("presentation/block_render.zig");
 var link_id_counter: u32 = 1;
 
 pub const setInlineCodeTheme = ansi.setInlineCodeTheme;
+pub const setInlineCodePalette = ansi.setInlineCodePalette;
 pub const writeHorizontalRule = ansi.writeHorizontalRule;
 
 pub const TableColumnAlign = payload.TableColumnAlign;

--- a/src/core/agent/presentation/ansi.zig
+++ b/src/core/agent/presentation/ansi.zig
@@ -14,13 +14,13 @@ pub const underline_open = "\x1b[4m";
 pub const underline_close = "\x1b[24m";
 const task_completed_dark_open = "\x1b[38;5;252m";
 const task_completed_light_open = "\x1b[38;5;238m";
-pub var task_completed_open: []const u8 = task_completed_dark_open;
+pub threadlocal var task_completed_open: []const u8 = task_completed_dark_open;
 pub const task_completed_close = "\x1b[39m";
 pub const strike_open = "\x1b[9m";
 pub const strike_close = "\x1b[29m";
 const inline_code_dark_open = "\x1b[38;5;245m";
 const inline_code_light_open = "\x1b[38;5;247m";
-pub var inline_code_open: []const u8 = inline_code_dark_open;
+pub threadlocal var inline_code_open: []const u8 = inline_code_dark_open;
 pub const inline_code_close = "\x1b[39m";
 
 pub fn setInlineCodeTheme(light: bool) void {
@@ -33,8 +33,20 @@ pub fn setInlineCodeTheme(light: bool) void {
 /// configuration yet.
 pub fn setInlineCodePalette(light: bool, palette: ColorPalette) void {
     const styles = presentation_palette.styles(light, palette);
-    inline_code_open = styles.inline_code;
-    task_completed_open = styles.task_completed;
+    setPresentationStyles(styles.inline_code, styles.task_completed);
+}
+
+pub fn setPresentationStyles(inline_code: []const u8, task_completed: []const u8) void {
+    inline_code_open = inline_code;
+    task_completed_open = task_completed;
+}
+
+pub fn currentInlineCodeStyle() []const u8 {
+    return inline_code_open;
+}
+
+pub fn currentTaskCompletedStyle() []const u8 {
+    return task_completed_open;
 }
 
 pub fn inlineCodeStyle(light: bool, palette: ColorPalette) []const u8 {

--- a/src/core/agent/presentation/ansi.zig
+++ b/src/core/agent/presentation/ansi.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const presentation_palette = @import("../../shared/presentation_palette.zig");
+
+pub const ColorPalette = presentation_palette.ColorPalette;
 
 pub const bold_open = "\x1b[1m";
 pub const bold_close = "\x1b[22m";
@@ -21,8 +24,37 @@ pub var inline_code_open: []const u8 = inline_code_dark_open;
 pub const inline_code_close = "\x1b[39m";
 
 pub fn setInlineCodeTheme(light: bool) void {
-    inline_code_open = if (light) inline_code_light_open else inline_code_dark_open;
-    task_completed_open = if (light) task_completed_light_open else task_completed_dark_open;
+    setInlineCodePalette(light, .fx);
+}
+
+/// Set the markdown colors for an explicit presentation palette.  The
+/// one-argument `setInlineCodeTheme` wrapper above intentionally retains the
+/// historical .fx bytes for callers that do not participate in palette
+/// configuration yet.
+pub fn setInlineCodePalette(light: bool, palette: ColorPalette) void {
+    const styles = presentation_palette.styles(light, palette);
+    inline_code_open = styles.inline_code;
+    task_completed_open = styles.task_completed;
+}
+
+pub fn inlineCodeStyle(light: bool, palette: ColorPalette) []const u8 {
+    return presentation_palette.styles(light, palette).inline_code;
+}
+
+pub fn taskCompletedStyle(light: bool, palette: ColorPalette) []const u8 {
+    return presentation_palette.styles(light, palette).task_completed;
+}
+
+pub fn isInlineCodeOpen(seq: []const u8) bool {
+    return std.mem.eql(u8, seq, inline_code_dark_open) or
+        std.mem.eql(u8, seq, inline_code_light_open) or
+        std.mem.eql(u8, seq, presentation_palette.styles(false, .terminal).inline_code);
+}
+
+pub fn isTaskCompletedOpen(seq: []const u8) bool {
+    return std.mem.eql(u8, seq, task_completed_dark_open) or
+        std.mem.eql(u8, seq, task_completed_light_open) or
+        std.mem.eql(u8, seq, presentation_palette.styles(false, .terminal).task_completed);
 }
 
 // Keeps table intersections aligned with row separators.
@@ -50,4 +82,12 @@ pub fn writeHorizontalRule(alloc: Allocator, out: *std.ArrayList(u8)) !void {
     var i: usize = 0;
     while (i < horizontal_rule_width) : (i += 1) try out.appendSlice(alloc, table_horiz);
     try out.appendSlice(alloc, dim_close);
+}
+
+test "terminal palette selects ANSI-16 markdown styles" {
+    setInlineCodePalette(false, .terminal);
+    defer setInlineCodeTheme(false);
+
+    try std.testing.expectEqualStrings("\x1b[90m", inline_code_open);
+    try std.testing.expectEqualStrings("\x1b[32m", task_completed_open);
 }

--- a/src/core/agent/runtime/assistant_stream.zig
+++ b/src/core/agent/runtime/assistant_stream.zig
@@ -750,11 +750,11 @@ const NoticeCapture = struct {
         };
     }
 
-    fn describeAction(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, _: []const []const u8) ![]const u8 {
+    fn describeAction(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return arena.dupe(u8, call.name);
     }
 
-    fn describeDenied(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: []const []const u8) ![]const u8 {
+    fn describeDenied(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return std.fmt.allocPrint(arena, "{s} {s}", .{ label, call.name });
     }
 
@@ -772,6 +772,7 @@ const NoticeCapture = struct {
     fn publishCommittedFileHandoff(
         _: *anyopaque,
         _: file_mutation.CommittedFileHandoff,
+        _: runtime_deps.PresentationStyles,
     ) SecondaryPublicationReport {
         return .{ .diff = .skipped, .tracker = .skipped };
     }
@@ -870,10 +871,10 @@ const StreamCapture = struct {
     fn noopRequestPermission(_: *anyopaque, _: Allocator, _: ToolCall, _: permission_auto_classifier.ReviewTurnContext, _: PermissionMode, _: []const PermissionGrant, _: ?runtime_tool_contracts.LiveToolAuthority, _: ?runtime_tool_contracts.LivePermissionRevalidation, _: []const []const u8) !command_admission.PermissionOutcome {
         return .{ .decision = .once, .execution_authority = .ordinary };
     }
-    fn noopDescribeAction(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, _: []const []const u8) ![]const u8 {
+    fn noopDescribeAction(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return arena.dupe(u8, call.name);
     }
-    fn noopDescribeDenied(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: []const []const u8) ![]const u8 {
+    fn noopDescribeDenied(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return std.fmt.allocPrint(arena, "{s} {s}", .{ label, call.name });
     }
     fn noopPermissionTarget(_: *anyopaque, arena: Allocator, _: ToolCall, _: []const []const u8) ![]const u8 {
@@ -882,7 +883,7 @@ const StreamCapture = struct {
     fn noopExecute(_: *anyopaque, _: runtime_tool_contracts.ToolExecutionRequest) !ToolExecutionResult {
         return .{ .model_output = "" };
     }
-    fn noopPublishCommittedFileHandoff(_: *anyopaque, _: file_mutation.CommittedFileHandoff) SecondaryPublicationReport {
+    fn noopPublishCommittedFileHandoff(_: *anyopaque, _: file_mutation.CommittedFileHandoff, _: runtime_deps.PresentationStyles) SecondaryPublicationReport {
         return .{ .diff = .skipped, .tracker = .skipped };
     }
     fn noopPropagateHistory(_: *anyopaque, _: HistoryTurn) !void {}

--- a/src/core/agent/runtime/deps.zig
+++ b/src/core/agent/runtime/deps.zig
@@ -14,6 +14,7 @@ const tool_admission = @import("../../tooling/tool_admission.zig");
 const tool_dispatch = @import("../../tooling/tool_dispatch.zig");
 const tool_contracts = @import("tool_contracts.zig");
 const context_contract = @import("../../workspace/context_contract.zig");
+const presentation_palette = @import("../../shared/presentation_palette.zig");
 
 const Allocator = std.mem.Allocator;
 const ChatMessage = types.ChatMessage;
@@ -172,6 +173,24 @@ pub const DiffMarkerStyles = struct {
     removed: []const u8 = "",
 };
 
+/// Presentation colors captured when a runtime is constructed. Keeping these
+/// slices in the dependency value avoids worker threads consulting mutable UI
+/// globals and lets independent runtimes use different palettes safely.
+pub const PresentationStyles = struct {
+    dim: []const u8 = "\x1b[38;5;245m",
+    accent: []const u8 = "\x1b[38;5;252m",
+    inline_code: []const u8 = "\x1b[38;5;245m",
+    task_completed: []const u8 = "\x1b[38;5;252m",
+    diff_added: []const u8 = "\x1b[38;5;252m",
+    diff_removed: []const u8 = "\x1b[38;5;252m",
+    diff_added_marker: []const u8 = "\x1b[38;5;71m",
+    diff_removed_marker: []const u8 = "\x1b[38;5;167m",
+    /// Complete immutable turn snapshot. The role-specific fields above stay
+    /// flattened for formatter call sites; this value crosses child-admission
+    /// and queued-event boundaries without reconstructing from mutable state.
+    snapshot: presentation_palette.PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
+};
+
 pub const AgentRuntimeDeps = struct {
     ctx: *anyopaque,
     agent_stream_provider: agent_stream_provider.Provider = agent_stream_provider.unavailable_provider,
@@ -205,12 +224,12 @@ pub const AgentRuntimeDeps = struct {
     /// Admission consumes `prepared`; callers must not retry the same value through the raw callback.
     request_prepared_file_mutation_permission: ?*const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, prepared: *tool_admission.PreparedFileMutationCall, review_turn: permission_auto_classifier.ReviewTurnContext, permission_mode: PermissionMode, local_grants: []const PermissionGrant, live_authority: ?LiveToolAuthority, advertised_dynamic_tool_names: []const []const u8) anyerror!command_admission.PermissionOutcome = null,
     resolve_tool_action_display_target: ?*const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall) anyerror!?[]const u8 = null,
-    describe_tool_action: *const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) anyerror![]const u8,
-    describe_tool_action_completed: *const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) anyerror![]const u8,
-    describe_tool_action_denied: *const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) anyerror![]const u8,
+    describe_tool_action: *const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, styles: PresentationStyles, advertised_dynamic_tool_names: []const []const u8) anyerror![]const u8,
+    describe_tool_action_completed: *const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, styles: PresentationStyles, advertised_dynamic_tool_names: []const []const u8) anyerror![]const u8,
+    describe_tool_action_denied: *const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, styles: PresentationStyles, advertised_dynamic_tool_names: []const []const u8) anyerror![]const u8,
     permission_target_for_call: *const fn (ctx: *anyopaque, arena: Allocator, call: ToolCall, advertised_dynamic_tool_names: []const []const u8) anyerror![]const u8,
     execute_tool_call: *const fn (ctx: *anyopaque, request: ToolExecutionRequest) anyerror!ToolExecutionResult,
-    publish_committed_file_handoff: *const fn (ctx: *anyopaque, handoff: file_mutation.CommittedFileHandoff) tool_contracts.SecondaryPublicationReport,
+    publish_committed_file_handoff: *const fn (ctx: *anyopaque, handoff: file_mutation.CommittedFileHandoff, styles: PresentationStyles) tool_contracts.SecondaryPublicationReport,
     publish_deferred_tool_completion: ?*const fn (ctx: *anyopaque, completion: DeferredToolCompletion) TransportPublicationOutcome = null,
     propagate_history_turn: *const fn (ctx: *anyopaque, turn: HistoryTurn) anyerror!void,
     commit_context_compaction: ?ContextCompactionCommitEffect = null,
@@ -239,9 +258,9 @@ pub const AgentRuntimeDeps = struct {
     report_inner_tool_usage: ?*const fn (ctx: *anyopaque, tool_name: []const u8, usage: types.ToolUsage) void = null,
     usage: ?*session_usage.Usage = null,
     usage_allocator: Allocator = std.heap.c_allocator,
+    presentation_styles: PresentationStyles = .{},
     // Accent for the +N / -N counts in a committed file's status line.
-    // Captured by value at construction; that is safe only while the marker
-    // colors never change after startup (they are theme-independent).
+    // Captured by value at construction with the complete presentation value.
     diff_marker_styles: DiffMarkerStyles = .{},
 
     pub fn pushContextNotice(self: *const AgentRuntimeDeps, text: []const u8) !void {

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3781,7 +3781,10 @@ fn appendPermissionFeedbackAfterToolResult(
     for (feedback) |text| {
         if (text.len == 0) continue;
         const event = worker_runtime.WorkerEvent{
-            .append_user_feedback = try std.heap.c_allocator.dupe(u8, text),
+            .append_user_feedback_styled = .{
+                .text = try std.heap.c_allocator.dupe(u8, text),
+                .styles = deps.presentation_styles.snapshot,
+            },
         };
         errdefer worker_runtime.freeWorkerEvent(std.heap.c_allocator, event);
         try deps.push_event(deps.ctx, event);

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -22,6 +22,7 @@ const file_mutation = @import("../../../tooling/file_mutation.zig");
 const file_mutation_contract = @import("../../../tooling/file_mutation_contract.zig");
 const context_contract = @import("../../../workspace/context_contract.zig");
 const io_mod = @import("../../../shared/io.zig");
+const presentation_palette = @import("../../../shared/presentation_palette.zig");
 const pathing = @import("../../../workspace/pathing.zig");
 const tool_dispatch = @import("../../../tooling/tool_dispatch.zig");
 const tool_runtime = @import("../../../tooling/tool_runtime.zig");
@@ -592,6 +593,8 @@ pub const FakeAgentRuntimeDeps = struct {
     history_turns: std.ArrayList(HistoryTurn) = .empty,
     interrupted_history_count: usize = 0,
     interrupted_event_count: usize = 0,
+    presentation_snapshot: presentation_palette.PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
+    feedback_presentations: std.ArrayList(presentation_palette.PresentationSnapshot) = .empty,
     interrupted_tool_name: ?[]u8 = null,
     http_status: ?std.http.Status = null,
     http_detail: ?[]u8 = null,
@@ -731,6 +734,7 @@ pub const FakeAgentRuntimeDeps = struct {
             worker_runtime.freeToolLifecycleEvent(self.alloc, event);
         }
         self.lifecycle_events.deinit(self.alloc);
+        self.feedback_presentations.deinit(self.alloc);
         freeStringList(self.alloc, &self.capability_queries);
         self.credential_refresh_sources.deinit(self.alloc);
         self.credential_refresh_modes.deinit(self.alloc);
@@ -798,6 +802,7 @@ pub const FakeAgentRuntimeDeps = struct {
             .report_inner_tool_usage = reportCapturedInnerToolUsage,
             .usage = self.usage,
             .usage_allocator = self.alloc,
+            .presentation_styles = .{ .snapshot = self.presentation_snapshot },
         };
     }
 
@@ -1344,21 +1349,21 @@ pub const FakeAgentRuntimeDeps = struct {
         return try arena.dupe(u8, value);
     }
 
-    fn describeAction(_: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, _: []const []const u8) ![]const u8 {
+    fn describeAction(_: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return if (display_target) |target|
             std.fmt.allocPrint(arena, "start {s} {s}", .{ call.name, target })
         else
             std.fmt.allocPrint(arena, "start {s}", .{call.name});
     }
 
-    fn describeCompleted(_: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, _: []const []const u8) ![]const u8 {
+    fn describeCompleted(_: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return if (display_target) |target|
             std.fmt.allocPrint(arena, "done {s} {s}", .{ call.name, target })
         else
             std.fmt.allocPrint(arena, "done {s}", .{call.name});
     }
 
-    fn describeDenied(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: []const []const u8) ![]const u8 {
+    fn describeDenied(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return std.fmt.allocPrint(arena, "{s} {s}", .{ label, call.name });
     }
 
@@ -1554,6 +1559,7 @@ pub const FakeAgentRuntimeDeps = struct {
     fn publishCommittedFileHandoff(
         raw: *anyopaque,
         _: file_mutation.CommittedFileHandoff,
+        _: runtime_deps.PresentationStyles,
     ) SecondaryPublicationReport {
         const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
         self.record("publish:committed_file", .{}) catch
@@ -1650,6 +1656,9 @@ pub const FakeAgentRuntimeDeps = struct {
                         if (update.output_exact) "exact" else "approx",
                     },
                 );
+            },
+            .append_user_feedback_styled => |feedback| {
+                try self.feedback_presentations.append(self.alloc, feedback.styles);
             },
             else => {},
         }

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -11,6 +11,7 @@ const result_store = @import("../../../session/result_store.zig");
 const debug_trace = @import("../../../shared/debug_trace.zig");
 const image_attachments = @import("../../../images/image_attachments.zig");
 const io_mod = @import("../../../shared/io.zig");
+const presentation_palette = @import("../../../shared/presentation_palette.zig");
 const diff = @import("../../../output/diff.zig");
 const file_mutation = @import("../../../tooling/file_mutation.zig");
 const command_result_mapping = @import("../../../tooling/command_result_mapping.zig");
@@ -4235,11 +4236,25 @@ test "permission feedback follows the matching tool result" {
     defer gateway.deinit();
     var hooks = FakeAgentRuntimeDeps.init(alloc);
     defer hooks.deinit();
+    hooks.presentation_snapshot = presentation_palette.snapshot(false, .terminal, false);
     hooks.permission_feedback = &.{"Summarize the file after reading it."};
     hooks.exec_plans = &.{.{ .result = .{ .model_output = "read output" } }};
     var fixture = PromptFixture{};
 
     try runFakePrompt(&gateway, &hooks, fixture.config(), fixture.job());
+
+    // Simulate a palette switch after the old turn queued its UI event but
+    // before a renderer drains it. The queued event keeps the turn snapshot.
+    hooks.presentation_snapshot = presentation_palette.snapshot(false, .fx, false);
+    try std.testing.expectEqual(@as(usize, 1), hooks.feedback_presentations.items.len);
+    try std.testing.expectEqual(
+        presentation_palette.PresentationTheme.terminal,
+        hooks.feedback_presentations.items[0].theme,
+    );
+    try std.testing.expectEqualStrings(
+        "\x1b[96m",
+        hooks.feedback_presentations.items[0].styles.user_marker,
+    );
 
     try std.testing.expectEqual(@as(usize, 1), hooks.permission_user_intent_contexts.items.len);
     const review_context = hooks.permission_user_intent_contexts.items[0];

--- a/src/core/agent/runtime/tool_batch.zig
+++ b/src/core/agent/runtime/tool_batch.zig
@@ -377,6 +377,7 @@ pub fn processCommittedFileResult(
     const publication = hooks.publish_committed_file_handoff(
         hooks.ctx,
         handoff,
+        hooks.presentation_styles,
     );
     debug_trace.eventf(
         "tool",

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -3,6 +3,7 @@ const command_admission = @import("../../permissions/command_admission.zig");
 const managed_execution = @import("../../execution/managed_execution.zig");
 const permission_auto_classifier = @import("../../permissions/auto_classifier.zig");
 const types = @import("../../shared/types.zig");
+const presentation_palette = @import("../../shared/presentation_palette.zig");
 const text_utils = @import("../../shared/text_utils.zig");
 const tool_dispatch = @import("../../tooling/tool_dispatch.zig");
 const tool_specs = @import("../../tooling/tool_specs.zig");
@@ -703,7 +704,11 @@ fn formatProvisionalProgressLabel(
     label_value: ?[]const u8,
 ) ![]const u8 {
     if (label_value) |value| {
-        return std.fmt.bufPrint(buf, "● {s}\x1b[0m \x1b[38;5;245m{s}\x1b[0m", .{ action_label, value });
+        return std.fmt.bufPrint(
+            buf,
+            "● {s}\x1b[0m {s}{s}\x1b[0m",
+            .{ action_label, presentation_palette.currentStyles().dim, value },
+        );
     }
     return std.fmt.bufPrint(buf, "● {s}\x1b[0m", .{action_label});
 }
@@ -1365,14 +1370,16 @@ pub fn finishCommittedFileStatus(
 }
 
 fn formatWebSearchCompletion(arena: Allocator, base: []const u8, completion: types.WebSearchCompletion) ![]const u8 {
+    const dim = presentation_palette.currentStyles().dim;
     return std.fmt.allocPrint(
         arena,
-        "{s} \x1b[38;5;245m| {d} search{s} | {d}ms\x1b[0m",
-        .{ base, completion.searches, if (completion.searches == 1) "" else "es", completion.duration_ms },
+        "{s} {s}| {d} search{s} | {d}ms\x1b[0m",
+        .{ base, dim, completion.searches, if (completion.searches == 1) "" else "es", completion.duration_ms },
     );
 }
 
 fn formatWebFetchCompletion(arena: Allocator, base: []const u8, completion: types.WebFetchCompletion) ![]const u8 {
+    const dim = presentation_palette.currentStyles().dim;
     const cache = if (completion.cache_hit) "cache hit" else "fetched";
     const artifact = switch (completion.artifact_state) {
         .none => "",
@@ -1381,8 +1388,8 @@ fn formatWebFetchCompletion(arena: Allocator, base: []const u8, completion: type
     };
     return std.fmt.allocPrint(
         arena,
-        "{s} \x1b[38;5;245m| {s} | {d} bytes | HTTP {d} | {d}ms | {s}{s}\x1b[0m",
-        .{ base, completion.url(), completion.bytes, completion.status, completion.duration_ms, cache, artifact },
+        "{s} {s}| {s} | {d} bytes | HTTP {d} | {d}ms | {s}{s}\x1b[0m",
+        .{ base, dim, completion.url(), completion.bytes, completion.status, completion.duration_ms, cache, artifact },
     );
 }
 
@@ -1393,8 +1400,9 @@ pub fn formatToolStatusWithStats(
     deletions: usize,
     markers: runtime_deps.DiffMarkerStyles,
 ) ![]const u8 {
-    const accent = "\x1b[38;5;252m";
-    const dim = "\x1b[38;5;245m";
+    const styles = presentation_palette.currentStyles();
+    const accent = styles.user_accent;
+    const dim = styles.dim;
     const reset = "\x1b[0m";
     // Fall back to the neutral accent when no marker color is supplied.
     const add_style = if (markers.added.len != 0) markers.added else accent;

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -3,7 +3,6 @@ const command_admission = @import("../../permissions/command_admission.zig");
 const managed_execution = @import("../../execution/managed_execution.zig");
 const permission_auto_classifier = @import("../../permissions/auto_classifier.zig");
 const types = @import("../../shared/types.zig");
-const presentation_palette = @import("../../shared/presentation_palette.zig");
 const text_utils = @import("../../shared/text_utils.zig");
 const tool_dispatch = @import("../../tooling/tool_dispatch.zig");
 const tool_specs = @import("../../tooling/tool_specs.zig");
@@ -130,7 +129,12 @@ pub const ProvisionalToolStatuses = struct {
         }
 
         var buf: [512]u8 = undefined;
-        const label = try formatProvisionalProgressLabel(&buf, action_label, label_value);
+        const label = try formatProvisionalProgressLabel(
+            &buf,
+            action_label,
+            label_value,
+            hooks.presentation_styles,
+        );
         const recorded = try self.recordTracked(
             alloc,
             tool_id,
@@ -702,12 +706,13 @@ fn formatProvisionalProgressLabel(
     buf: []u8,
     action_label: []const u8,
     label_value: ?[]const u8,
+    styles: runtime_deps.PresentationStyles,
 ) ![]const u8 {
     if (label_value) |value| {
         return std.fmt.bufPrint(
             buf,
             "● {s}\x1b[0m {s}{s}\x1b[0m",
-            .{ action_label, presentation_palette.currentStyles().dim, value },
+            .{ action_label, styles.dim, value },
         );
     }
     return std.fmt.bufPrint(buf, "● {s}\x1b[0m", .{action_label});
@@ -749,6 +754,7 @@ pub noinline fn startToolVisibleLifecycle(
         arena,
         call,
         display_target,
+        hooks.presentation_styles,
         advertised_dynamic_tool_names,
     );
     try hooks.push_tool_lifecycle(hooks.ctx, .{ .authoritative_started = .{
@@ -805,6 +811,7 @@ fn finishDeferredToolStatus(
         call,
         null,
         types.context_deferred_tool_status_label,
+        hooks.presentation_styles,
         advertised_dynamic_tool_names,
     );
     try hooks.push_tool_lifecycle(hooks.ctx, .{ .terminal = .{
@@ -837,6 +844,7 @@ pub fn finishDeniedToolStatusWithResultMemory(
         status_started,
         display_target,
         label,
+        hooks.presentation_styles,
         advertised_dynamic_tool_names,
         safe_result,
         result_memory,
@@ -864,6 +872,7 @@ fn finishDeniedToolStatusInternal(
         call,
         display_target,
         label,
+        hooks.presentation_styles,
         advertised_dynamic_tool_names,
     );
     const command_artifact_handle = if (activityKindForCall(arena, hooks.tool_registry, call) == .command)
@@ -910,6 +919,7 @@ pub fn finishCancelledToolStatus(
         call,
         display_target,
         label,
+        hooks.presentation_styles,
         advertised_dynamic_tool_names,
     );
     const command_activity = activityKindForCall(
@@ -994,6 +1004,7 @@ pub fn finishExecutedToolStatus(
             call,
             display_target,
             decision.label,
+            hooks.presentation_styles,
             advertised_dynamic_tool_names,
         );
         break :blk if (decision.detail) |detail|
@@ -1009,6 +1020,7 @@ pub fn finishExecutedToolStatus(
                 arena,
                 call,
                 display_target,
+                hooks.presentation_styles,
                 advertised_dynamic_tool_names,
             ),
         .failure => blk: {
@@ -1018,6 +1030,7 @@ pub fn finishExecutedToolStatus(
                 call,
                 display_target,
                 "Failed",
+                hooks.presentation_styles,
                 advertised_dynamic_tool_names,
             );
             if (std.mem.eql(u8, call.name, "shell")) {
@@ -1048,13 +1061,20 @@ pub fn finishExecutedToolStatus(
         },
     };
     const summary_line = if (result.web_fetch_completion) |completion|
-        try formatWebFetchCompletion(arena, base_line, completion)
+        try formatWebFetchCompletion(arena, base_line, completion, hooks.presentation_styles)
     else if (result.web_search_completion) |completion|
-        try formatWebSearchCompletion(arena, base_line, completion)
+        try formatWebSearchCompletion(arena, base_line, completion, hooks.presentation_styles)
     else
         base_line;
     const line = if (diff_entry) |payload| blk: {
-        break :blk try formatToolStatusWithStats(arena, summary_line, payload.additions, payload.deletions, hooks.diff_marker_styles);
+        break :blk try formatToolStatusWithStats(
+            arena,
+            summary_line,
+            payload.additions,
+            payload.deletions,
+            hooks.presentation_styles,
+            hooks.diff_marker_styles,
+        );
     } else summary_line;
     const shell_command = activity_kind == .command and
         std.mem.eql(u8, call.name, "shell");
@@ -1349,6 +1369,7 @@ pub fn finishCommittedFileStatus(
         arena,
         call,
         display_target,
+        hooks.presentation_styles,
         advertised_dynamic_tool_names,
     );
     const line = try formatToolStatusWithStats(
@@ -1356,6 +1377,7 @@ pub fn finishCommittedFileStatus(
         base_line,
         preview.additions,
         preview.deletions,
+        hooks.presentation_styles,
         hooks.diff_marker_styles,
     );
     try hooks.push_tool_lifecycle(hooks.ctx, .{
@@ -1369,17 +1391,15 @@ pub fn finishCommittedFileStatus(
     });
 }
 
-fn formatWebSearchCompletion(arena: Allocator, base: []const u8, completion: types.WebSearchCompletion) ![]const u8 {
-    const dim = presentation_palette.currentStyles().dim;
+fn formatWebSearchCompletion(arena: Allocator, base: []const u8, completion: types.WebSearchCompletion, styles: runtime_deps.PresentationStyles) ![]const u8 {
     return std.fmt.allocPrint(
         arena,
         "{s} {s}| {d} search{s} | {d}ms\x1b[0m",
-        .{ base, dim, completion.searches, if (completion.searches == 1) "" else "es", completion.duration_ms },
+        .{ base, styles.dim, completion.searches, if (completion.searches == 1) "" else "es", completion.duration_ms },
     );
 }
 
-fn formatWebFetchCompletion(arena: Allocator, base: []const u8, completion: types.WebFetchCompletion) ![]const u8 {
-    const dim = presentation_palette.currentStyles().dim;
+fn formatWebFetchCompletion(arena: Allocator, base: []const u8, completion: types.WebFetchCompletion, styles: runtime_deps.PresentationStyles) ![]const u8 {
     const cache = if (completion.cache_hit) "cache hit" else "fetched";
     const artifact = switch (completion.artifact_state) {
         .none => "",
@@ -1389,7 +1409,7 @@ fn formatWebFetchCompletion(arena: Allocator, base: []const u8, completion: type
     return std.fmt.allocPrint(
         arena,
         "{s} {s}| {s} | {d} bytes | HTTP {d} | {d}ms | {s}{s}\x1b[0m",
-        .{ base, dim, completion.url(), completion.bytes, completion.status, completion.duration_ms, cache, artifact },
+        .{ base, styles.dim, completion.url(), completion.bytes, completion.status, completion.duration_ms, cache, artifact },
     );
 }
 
@@ -1398,10 +1418,10 @@ pub fn formatToolStatusWithStats(
     base: []const u8,
     additions: usize,
     deletions: usize,
+    styles: runtime_deps.PresentationStyles,
     markers: runtime_deps.DiffMarkerStyles,
 ) ![]const u8 {
-    const styles = presentation_palette.currentStyles();
-    const accent = styles.user_accent;
+    const accent = styles.accent;
     const dim = styles.dim;
     const reset = "\x1b[0m";
     // Fall back to the neutral accent when no marker color is supplied.
@@ -1479,10 +1499,10 @@ const ProvisionalStatusTestCapture = struct {
     fn noopRequestPermission(_: *anyopaque, _: Allocator, _: ToolCall, _: permission_auto_classifier.ReviewTurnContext, _: types.PermissionMode, _: []const types.PermissionGrant, _: ?runtime_tool_contracts.LiveToolAuthority, _: ?runtime_tool_contracts.LivePermissionRevalidation, _: []const []const u8) !command_admission.PermissionOutcome {
         return .{ .decision = .once, .execution_authority = .ordinary };
     }
-    fn describeToolAction(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, _: []const []const u8) ![]const u8 {
+    fn describeToolAction(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return std.fmt.allocPrint(arena, "started {s}", .{call.name});
     }
-    fn describeDeniedToolAction(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: []const []const u8) ![]const u8 {
+    fn describeDeniedToolAction(_: *anyopaque, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: runtime_deps.PresentationStyles, _: []const []const u8) ![]const u8 {
         return std.fmt.allocPrint(arena, "{s} {s}", .{ label, call.name });
     }
     fn noopPermissionTarget(_: *anyopaque, arena: Allocator, _: ToolCall, _: []const []const u8) ![]const u8 {
@@ -1491,7 +1511,7 @@ const ProvisionalStatusTestCapture = struct {
     fn noopExecuteToolCall(_: *anyopaque, _: runtime_tool_contracts.ToolExecutionRequest) !ToolExecutionResult {
         return .{ .model_output = "" };
     }
-    fn noopPublishCommittedFileHandoff(_: *anyopaque, _: @import("../../tooling/file_mutation.zig").CommittedFileHandoff) runtime_tool_contracts.SecondaryPublicationReport {
+    fn noopPublishCommittedFileHandoff(_: *anyopaque, _: @import("../../tooling/file_mutation.zig").CommittedFileHandoff, _: runtime_deps.PresentationStyles) runtime_tool_contracts.SecondaryPublicationReport {
         return .{ .diff = .skipped, .tracker = .skipped };
     }
     fn noopPropagateHistoryTurn(_: *anyopaque, _: types.HistoryTurn) !void {}
@@ -1537,15 +1557,27 @@ fn eligibleActionLabel(tool_name: []const u8) []const u8 {
 test "formatToolStatusWithStats accents the +/- counts and falls back to neutral" {
     const alloc = std.testing.allocator;
 
-    const colored = try formatToolStatusWithStats(alloc, "Edited x", 3, 1, .{ .added = "[G]", .removed = "[R]" });
+    const colored = try formatToolStatusWithStats(alloc, "Edited x", 3, 1, .{}, .{ .added = "[G]", .removed = "[R]" });
     defer alloc.free(colored);
     try std.testing.expect(std.mem.find(u8, colored, "[G]+3") != null);
     try std.testing.expect(std.mem.find(u8, colored, "[R]-1") != null);
 
-    const neutral = try formatToolStatusWithStats(alloc, "Edited x", 3, 1, .{});
+    const neutral = try formatToolStatusWithStats(alloc, "Edited x", 3, 1, .{}, .{});
     defer alloc.free(neutral);
     try std.testing.expect(std.mem.find(u8, neutral, "\x1b[38;5;252m+3") != null);
     try std.testing.expect(std.mem.find(u8, neutral, "\x1b[38;5;252m-1") != null);
+
+    const terminal = try formatToolStatusWithStats(
+        alloc,
+        "Edited x",
+        3,
+        1,
+        .{ .dim = "[DIM]", .accent = "[ACCENT]" },
+        .{},
+    );
+    defer alloc.free(terminal);
+    try std.testing.expect(std.mem.find(u8, terminal, "[ACCENT]+3") != null);
+    try std.testing.expect(std.mem.find(u8, terminal, "[DIM]/") != null);
 }
 
 test "provisional lifecycle preflight distinguishes unknown eligible and ineligible tools" {
@@ -2067,7 +2099,7 @@ test "native web_search completion status includes searches and duration" {
     const line = try formatWebSearchCompletion(std.testing.allocator, "Searched current news", .{
         .searches = 2,
         .duration_ms = 17,
-    });
+    }, .{});
     defer std.testing.allocator.free(line);
 
     try std.testing.expect(std.mem.find(u8, line, "2 searches") != null);
@@ -2245,6 +2277,7 @@ test "terminal path scope failure appends the exact status detail" {
             _: ToolCall,
             _: ?[]const u8,
             label: []const u8,
+            _: runtime_deps.PresentationStyles,
             _: []const []const u8,
         ) ![]const u8 {
             return std.fmt.allocPrint(target, "{s} start", .{label});

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -17,6 +17,7 @@ const tool_result_limits = @import("../tooling/tool_result_limits.zig");
 const command_output_content = @import("../tooling/command_output_content.zig");
 const paste_blocks = @import("../input/pasted_blocks.zig");
 const entity_spans = @import("../shared/entity_spans.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const types = @import("../shared/types.zig");
 const model_provider = @import("../config/model_provider.zig");
 const assistant_presentation = @import("assistant_presentation.zig");
@@ -46,6 +47,30 @@ pub const BeginPromptWithSkillBindings = struct {
     prompt: types.UserTurn,
     skill_bindings: []SkillBinding = &.{},
     skill_display_spans: []SkillDisplaySpan = &.{},
+};
+
+pub const PresentationSnapshot = presentation_palette.PresentationSnapshot;
+
+pub const StyledBeginPrompt = struct {
+    prompt: types.UserTurn,
+    styles: PresentationSnapshot,
+};
+
+pub const StyledBeginPromptWithSkillBindings = struct {
+    prompt: types.UserTurn,
+    skill_bindings: []SkillBinding = &.{},
+    skill_display_spans: []SkillDisplaySpan = &.{},
+    styles: PresentationSnapshot,
+};
+
+pub const StyledUserFeedback = struct {
+    text: []u8,
+    styles: PresentationSnapshot,
+};
+
+pub const StyledAssistantPresentation = struct {
+    presentation: assistant_presentation.Event,
+    styles: PresentationSnapshot,
 };
 
 pub const QueueReviewDraft = struct {
@@ -595,9 +620,13 @@ pub const PendingQuestionBatchSnapshot = struct {
 pub const WorkerEvent = union(enum) {
     begin_prompt: types.UserTurn,
     begin_prompt_with_skill_bindings: BeginPromptWithSkillBindings,
+    begin_prompt_styled: StyledBeginPrompt,
+    begin_prompt_with_skill_bindings_styled: StyledBeginPromptWithSkillBindings,
     begin_presented_prompt: u64,
     append_user_feedback: []u8,
+    append_user_feedback_styled: StyledUserFeedback,
     assistant_presentation: assistant_presentation.Event,
+    assistant_presentation_styled: StyledAssistantPresentation,
     notification: notification_contract.Notification,
     question_requested,
     open_model_picker,
@@ -667,6 +696,14 @@ pub const WorkerRuntime = struct {
     pending_question_response: QuestionResponse = .pending,
     agent_turn_settings: AgentTurnSettings = .{},
     active_agent_turn_settings: ?AgentTurnSettings = null,
+    active_presentation_dim_style: []const u8 = "\x1b[38;5;245m",
+    /// Snapshot used for events that begin a new root turn.  It is updated on
+    /// the UI thread when preferences change and is read under worker_mutex
+    /// while admitting the turn.
+    presentation_styles: PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
+    /// Snapshot captured when the active turn starts.  It remains stable while
+    /// a palette switch updates `presentation_styles` for the next root turn.
+    active_presentation_styles: PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
     active_context_snapshot: ?*const context_contract.GatheredContextSnapshot = null,
     active_prompt_is_root_authority: bool = false,
     active_prompt_snapshot_ownership: ?*ActivePromptSnapshotOwnership = null,
@@ -1127,7 +1164,10 @@ pub const WorkerRuntime = struct {
             messages[copied] = try alloc.dupe(u8, prompt.prompt);
             copied += 1;
             events[event_count] = .{
-                .append_user_feedback = try alloc.dupe(u8, prompt.prompt),
+                .append_user_feedback_styled = .{
+                    .text = try alloc.dupe(u8, prompt.prompt),
+                    .styles = self.active_presentation_styles,
+                },
             };
             event_count += 1;
         }
@@ -1463,6 +1503,9 @@ pub const WorkerRuntime = struct {
         if (self.worker_stop_requested or self.queued_prompts.items.len == 0) return null;
 
         const queued = self.queued_prompts.items[0];
+        const active_presentation = self.presentation_styles;
+        self.active_presentation_styles = active_presentation;
+        self.active_presentation_dim_style = active_presentation.styles.dim;
         if (queued.recovery_checkpoint == null and queued.user_prompt_already_presented) {
             try self.worker_events.append(alloc, .{
                 .begin_presented_prompt = queued.turn_id,
@@ -1476,14 +1519,18 @@ pub const WorkerRuntime = struct {
                 const skill_display_spans = try dupeSkillDisplaySpans(alloc, queued.skill_display_spans);
                 errdefer freeSkillDisplaySpans(alloc, skill_display_spans);
                 try self.worker_events.append(alloc, .{
-                    .begin_prompt_with_skill_bindings = .{
+                    .begin_prompt_with_skill_bindings_styled = .{
                         .prompt = begin_prompt,
                         .skill_bindings = skill_bindings,
                         .skill_display_spans = skill_display_spans,
+                        .styles = active_presentation,
                     },
                 });
             } else {
-                try self.worker_events.append(alloc, .{ .begin_prompt = begin_prompt });
+                try self.worker_events.append(alloc, .{ .begin_prompt_styled = .{
+                    .prompt = begin_prompt,
+                    .styles = active_presentation,
+                } });
             }
         }
 
@@ -1861,6 +1908,37 @@ pub const WorkerRuntime = struct {
         self.worker_mutex.lockUncancelable(io_mod.getIo());
         defer self.worker_mutex.unlock(io_mod.getIo());
         self.active_agent_turn_settings = null;
+    }
+
+    pub fn setActivePresentationDimStyle(self: *WorkerRuntime, style: []const u8) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        self.active_presentation_dim_style = style;
+    }
+
+    pub fn setPresentationStyles(self: *WorkerRuntime, styles: PresentationSnapshot) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        self.presentation_styles = styles;
+    }
+
+    pub fn setActivePresentationStyles(self: *WorkerRuntime, styles: PresentationSnapshot) void {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        self.active_presentation_styles = styles;
+        self.active_presentation_dim_style = styles.styles.dim;
+    }
+
+    pub fn activePresentationStyles(self: *WorkerRuntime) PresentationSnapshot {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        return self.active_presentation_styles;
+    }
+
+    pub fn activePresentationDimStyle(self: *WorkerRuntime) []const u8 {
+        self.worker_mutex.lockUncancelable(io_mod.getIo());
+        defer self.worker_mutex.unlock(io_mod.getIo());
+        return self.active_presentation_dim_style;
     }
 
     pub fn effectiveAgentTurnSettings(self: *WorkerRuntime) AgentTurnSettings {
@@ -3462,10 +3540,37 @@ pub fn dupeWorkerEvent(alloc: std.mem.Allocator, event: WorkerEvent) !WorkerEven
                 .skill_display_spans = skill_display_spans,
             } };
         },
+        .begin_prompt_styled => |begin| .{ .begin_prompt_styled = .{
+            .prompt = try types.dupeUserTurn(alloc, begin.prompt),
+            .styles = begin.styles,
+        } },
+        .begin_prompt_with_skill_bindings_styled => |begin| blk: {
+            const prompt = try types.dupeUserTurn(alloc, begin.prompt);
+            errdefer types.freeUserTurn(alloc, prompt);
+            const skill_bindings = try dupeSkillBindings(alloc, begin.skill_bindings);
+            errdefer freeSkillBindings(alloc, skill_bindings);
+            const skill_display_spans = try dupeSkillDisplaySpans(alloc, begin.skill_display_spans);
+            break :blk .{ .begin_prompt_with_skill_bindings_styled = .{
+                .prompt = prompt,
+                .skill_bindings = skill_bindings,
+                .skill_display_spans = skill_display_spans,
+                .styles = begin.styles,
+            } };
+        },
         .begin_presented_prompt => |turn_id| .{ .begin_presented_prompt = turn_id },
         .append_user_feedback => |text| .{ .append_user_feedback = try alloc.dupe(u8, text) },
+        .append_user_feedback_styled => |feedback| .{ .append_user_feedback_styled = .{
+            .text = try alloc.dupe(u8, feedback.text),
+            .styles = feedback.styles,
+        } },
         .assistant_presentation => |presentation| .{
             .assistant_presentation = try presentation.clone(alloc),
+        },
+        .assistant_presentation_styled => |presentation| .{
+            .assistant_presentation_styled = .{
+                .presentation = try presentation.presentation.clone(alloc),
+                .styles = presentation.styles,
+            },
         },
         .notification => |notification| .{ .notification = notification },
         .question_requested => .question_requested,
@@ -3542,10 +3647,21 @@ pub fn freeWorkerEvent(alloc: std.mem.Allocator, event: WorkerEvent) void {
             freeSkillBindings(alloc, begin.skill_bindings);
             freeSkillDisplaySpans(alloc, begin.skill_display_spans);
         },
+        .begin_prompt_styled => |begin| types.freeUserTurn(alloc, begin.prompt),
+        .begin_prompt_with_skill_bindings_styled => |begin| {
+            types.freeUserTurn(alloc, begin.prompt);
+            freeSkillBindings(alloc, begin.skill_bindings);
+            freeSkillDisplaySpans(alloc, begin.skill_display_spans);
+        },
         .begin_presented_prompt => {},
         .append_user_feedback => |text| alloc.free(text),
+        .append_user_feedback_styled => |feedback| alloc.free(feedback.text),
         .assistant_presentation => |presentation| {
             var owned = presentation;
+            owned.deinit(alloc);
+        },
+        .assistant_presentation_styled => |presentation| {
+            var owned = presentation.presentation;
             owned.deinit(alloc);
         },
         .notification => {},
@@ -3818,8 +3934,8 @@ test "active prompt admission drains steering in FIFO order" {
     try std.testing.expectEqualStrings("second", guidance[1]);
     try std.testing.expectEqual(@as(usize, 0), runtime.queued_prompts.items.len);
     try std.testing.expectEqual(@as(usize, 2), runtime.worker_events.items.len);
-    try std.testing.expectEqualStrings("first", runtime.worker_events.items[0].append_user_feedback);
-    try std.testing.expectEqualStrings("second", runtime.worker_events.items[1].append_user_feedback);
+    try std.testing.expectEqualStrings("first", runtime.worker_events.items[0].append_user_feedback_styled.text);
+    try std.testing.expectEqualStrings("second", runtime.worker_events.items[1].append_user_feedback_styled.text);
 }
 
 test "immediate steering owns and clears only its cancellation" {
@@ -4383,9 +4499,9 @@ test "queue, event, snapshot, sync, history, and grant behavior" {
     var events = runtime.takeEvents();
     defer freeEventList(alloc, &events);
     try std.testing.expectEqual(@as(usize, 1), events.items.len);
-    try std.testing.expect(events.items[0] == .begin_prompt);
-    try std.testing.expectEqualStrings("first", events.items[0].begin_prompt.text);
-    try std.testing.expect(events.items[0].begin_prompt.text.ptr != job.prompt.ptr);
+    try std.testing.expect(events.items[0] == .begin_prompt_styled);
+    try std.testing.expectEqualStrings("first", events.items[0].begin_prompt_styled.prompt.text);
+    try std.testing.expect(events.items[0].begin_prompt_styled.prompt.text.ptr != job.prompt.ptr);
 
     try runtime.syncQueuedPromptModel(alloc, "next");
     try std.testing.expectEqualStrings("next", runtime.queued_prompts.items[0].model);
@@ -4579,20 +4695,20 @@ test "waitAndTakeNextPrompt emits bound skill prompt event when queued prompt ha
     var events = runtime.takeEvents();
     defer freeEventList(alloc, &events);
     try std.testing.expectEqual(@as(usize, 1), events.items.len);
-    try std.testing.expect(events.items[0] == .begin_prompt_with_skill_bindings);
-    try std.testing.expectEqualStrings("raw $review then $review and $review", events.items[0].begin_prompt_with_skill_bindings.prompt.text);
-    try std.testing.expectEqual(@as(usize, 1), events.items[0].begin_prompt_with_skill_bindings.skill_bindings.len);
-    try std.testing.expectEqualStrings("review", events.items[0].begin_prompt_with_skill_bindings.skill_bindings[0].name);
-    try std.testing.expectEqualStrings("/tmp/.codex/skills/review", events.items[0].begin_prompt_with_skill_bindings.skill_bindings[0].path);
-    try std.testing.expectEqual(@as(usize, 2), events.items[0].begin_prompt_with_skill_bindings.skill_display_spans.len);
-    try std.testing.expectEqual(@as(usize, "raw $review then ".len), events.items[0].begin_prompt_with_skill_bindings.skill_display_spans[0].raw_start);
-    try std.testing.expectEqual(@as(usize, "raw $review then $review".len), events.items[0].begin_prompt_with_skill_bindings.skill_display_spans[0].raw_end);
-    try std.testing.expectEqualStrings("review", events.items[0].begin_prompt_with_skill_bindings.skill_display_spans[0].name);
+    try std.testing.expect(events.items[0] == .begin_prompt_with_skill_bindings_styled);
+    try std.testing.expectEqualStrings("raw $review then $review and $review", events.items[0].begin_prompt_with_skill_bindings_styled.prompt.text);
+    try std.testing.expectEqual(@as(usize, 1), events.items[0].begin_prompt_with_skill_bindings_styled.skill_bindings.len);
+    try std.testing.expectEqualStrings("review", events.items[0].begin_prompt_with_skill_bindings_styled.skill_bindings[0].name);
+    try std.testing.expectEqualStrings("/tmp/.codex/skills/review", events.items[0].begin_prompt_with_skill_bindings_styled.skill_bindings[0].path);
+    try std.testing.expectEqual(@as(usize, 2), events.items[0].begin_prompt_with_skill_bindings_styled.skill_display_spans.len);
+    try std.testing.expectEqual(@as(usize, "raw $review then ".len), events.items[0].begin_prompt_with_skill_bindings_styled.skill_display_spans[0].raw_start);
+    try std.testing.expectEqual(@as(usize, "raw $review then $review".len), events.items[0].begin_prompt_with_skill_bindings_styled.skill_display_spans[0].raw_end);
+    try std.testing.expectEqualStrings("review", events.items[0].begin_prompt_with_skill_bindings_styled.skill_display_spans[0].name);
     try std.testing.expectEqual(
         skill_contract.SkillSource.workspace_codex,
-        events.items[0].begin_prompt_with_skill_bindings.skill_display_spans[0].display_source.?,
+        events.items[0].begin_prompt_with_skill_bindings_styled.skill_display_spans[0].display_source.?,
     );
-    try std.testing.expect(events.items[0].begin_prompt_with_skill_bindings.skill_display_spans[0].owns_trailing_separator);
+    try std.testing.expect(events.items[0].begin_prompt_with_skill_bindings_styled.skill_display_spans[0].owns_trailing_separator);
 }
 
 test "permission snapshot keeps the full file review borrowed and request-bound" {
@@ -5332,7 +5448,37 @@ test "waitAndTakeNextPrompt assigns turn id and resets cancellation for next pro
     var events = runtime.takeEvents();
     defer freeEventList(alloc, &events);
     try std.testing.expectEqual(@as(usize, 1), events.items.len);
-    try std.testing.expect(events.items[0] == .begin_prompt);
+    try std.testing.expect(events.items[0] == .begin_prompt_styled);
+}
+
+test "palette updates affect the next turn without restyling the active turn" {
+    const alloc = std.testing.allocator;
+    var runtime = WorkerRuntime{};
+    defer runtime.deinit(alloc);
+
+    const first_styles = presentation_palette.snapshot(false, .fx, false);
+    const next_styles = presentation_palette.snapshot(false, .terminal, false);
+    runtime.setPresentationStyles(first_styles);
+    try runtime.enqueuePrompt(alloc, try makePrompt(alloc, "first", "model"));
+
+    const first = (try runtime.tryTakeNextPrompt(alloc)).?;
+    defer freeQueuedPrompt(alloc, first);
+    var first_events = runtime.takeEvents();
+    defer freeEventList(alloc, &first_events);
+    try std.testing.expect(first_events.items[0] == .begin_prompt_styled);
+    try std.testing.expectEqual(presentation_palette.PresentationTheme.dark, first_events.items[0].begin_prompt_styled.styles.theme);
+
+    runtime.setPresentationStyles(next_styles);
+    try std.testing.expectEqual(presentation_palette.PresentationTheme.dark, runtime.activePresentationStyles().theme);
+
+    runtime.finishProcessing();
+    try runtime.enqueuePrompt(alloc, try makePrompt(alloc, "second", "model"));
+    const second = (try runtime.tryTakeNextPrompt(alloc)).?;
+    defer freeQueuedPrompt(alloc, second);
+    var second_events = runtime.takeEvents();
+    defer freeEventList(alloc, &second_events);
+    try std.testing.expect(second_events.items[0] == .begin_prompt_styled);
+    try std.testing.expectEqual(presentation_palette.PresentationTheme.terminal, second_events.items[0].begin_prompt_styled.styles.theme);
 }
 
 test "already-presented queued prompt emits identity without duplicating user payload" {

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -125,6 +125,7 @@ pub fn Runtime(comptime App: type) type {
                 gateway_retry_count,
                 gateway_chat_url,
                 null,
+                null,
             );
         }
 
@@ -140,6 +141,7 @@ pub fn Runtime(comptime App: type) type {
             gateway_chat_url: []const u8,
             admission: subagent_domain.AdmissionSnapshot,
         ) tool_runtime.Context {
+            const presentation = admission.presentation.styles;
             return toolContextWithAuthority(
                 app,
                 ignored_list_entries,
@@ -155,6 +157,44 @@ pub fn Runtime(comptime App: type) type {
                     .grants = admission.grants,
                     .rules = admission.rules,
                 },
+                .{
+                    .dim = presentation.dim,
+                    .accent = presentation.user_accent,
+                    .inline_code = presentation.inline_code,
+                    .task_completed = presentation.task_completed,
+                    .diff_added = presentation.diff_added,
+                    .diff_removed = presentation.diff_removed,
+                    .diff_added_marker = presentation.diff_added_marker,
+                    .diff_removed_marker = presentation.diff_removed_marker,
+                    .snapshot = admission.presentation,
+                },
+            );
+        }
+
+        fn toolContextWithPresentationStyles(
+            app: *App,
+            ignored_list_entries: []const []const u8,
+            max_list_entries: usize,
+            max_read_file_bytes: usize,
+            max_read_file_lines: usize,
+            max_read_file_line_len: usize,
+            max_command_output_bytes: usize,
+            gateway_retry_count: usize,
+            gateway_chat_url: []const u8,
+            presentation_styles: agent_runtime.PresentationStyles,
+        ) tool_runtime.Context {
+            return toolContextWithAuthority(
+                app,
+                ignored_list_entries,
+                max_list_entries,
+                max_read_file_bytes,
+                max_read_file_lines,
+                max_read_file_line_len,
+                max_command_output_bytes,
+                gateway_retry_count,
+                gateway_chat_url,
+                null,
+                presentation_styles,
             );
         }
 
@@ -169,6 +209,7 @@ pub fn Runtime(comptime App: type) type {
             gateway_retry_count: usize,
             gateway_chat_url: []const u8,
             authority: ?ToolAuthorityView,
+            captured_presentation: ?agent_runtime.PresentationStyles,
         ) tool_runtime.Context {
             const host_workspace = appHostWorkspaceInfo(app);
             const workspace_root = if (host_workspace) |info|
@@ -202,8 +243,34 @@ pub fn Runtime(comptime App: type) type {
                 provider_set.Bundle.Capabilities{ .fx_search = true, .vision_fallback = true }
             else
                 provider_set.Bundle.Capabilities{};
+            const live_presentation = if (captured_presentation == null)
+                if (comptime @hasDecl(App, "activePresentationStyles"))
+                    app.activePresentationStyles()
+                else
+                    presentation_palette.styles(false, .fx)
+            else
+                null;
+            const live_presentation_snapshot = if (captured_presentation == null)
+                if (comptime @hasDecl(@TypeOf(app.worker), "activePresentationStyles"))
+                    app.worker.activePresentationStyles()
+                else
+                    presentation_palette.PresentationSnapshot{
+                        .styles = live_presentation.?,
+                        .theme = .dark,
+                    }
+            else
+                null;
             var ctx: tool_runtime.Context = .{
                 .workspace_root = workspace_root,
+                .presentation_snapshot = if (captured_presentation) |styles| styles.snapshot else live_presentation_snapshot.?,
+                .presentation_dim_style = if (captured_presentation) |styles| styles.dim else live_presentation.?.dim,
+                .presentation_accent_style = if (captured_presentation) |styles| styles.accent else live_presentation.?.user_accent,
+                .presentation_inline_code_style = if (captured_presentation) |styles| styles.inline_code else live_presentation.?.inline_code,
+                .presentation_task_completed_style = if (captured_presentation) |styles| styles.task_completed else live_presentation.?.task_completed,
+                .presentation_diff_added_style = if (captured_presentation) |styles| styles.diff_added else live_presentation.?.diff_added,
+                .presentation_diff_removed_style = if (captured_presentation) |styles| styles.diff_removed else live_presentation.?.diff_removed,
+                .presentation_diff_added_marker_style = if (captured_presentation) |styles| styles.diff_added_marker else live_presentation.?.diff_added_marker,
+                .presentation_diff_removed_marker_style = if (captured_presentation) |styles| styles.diff_removed_marker else live_presentation.?.diff_removed_marker,
                 .access_scope = if (host_workspace != null)
                     workspace_access.AccessScope.primaryOnly(workspace_root)
                 else
@@ -558,6 +625,26 @@ pub fn Runtime(comptime App: type) type {
             return formatToolAction(ctx, arena, call, display_target, .active, null);
         }
 
+        pub fn describeToolActionWithPresentationStyles(
+            app: *App,
+            arena: Allocator,
+            call: ToolCall,
+            display_target: ?[]const u8,
+            presentation_styles: agent_runtime.PresentationStyles,
+            advertised_dynamic_tool_names: []const []const u8,
+            ignored_list_entries: []const []const u8,
+            max_list_entries: usize,
+            max_read_file_bytes: usize,
+            max_read_file_lines: usize,
+            max_read_file_line_len: usize,
+            max_command_output_bytes: usize,
+            gateway_retry_count: usize,
+            gateway_chat_url: []const u8,
+        ) ![]const u8 {
+            const ctx = tool_runtime.withAdvertisedDynamicToolNames(toolContextWithPresentationStyles(app, ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, gateway_retry_count, gateway_chat_url, presentation_styles), advertised_dynamic_tool_names);
+            return formatToolAction(ctx, arena, call, display_target, .active, null);
+        }
+
         pub fn describeToolActionCompleted(
             app: *App,
             arena: Allocator,
@@ -574,6 +661,26 @@ pub fn Runtime(comptime App: type) type {
             gateway_chat_url: []const u8,
         ) ![]const u8 {
             const ctx = tool_runtime.withAdvertisedDynamicToolNames(toolContext(app, ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, gateway_retry_count, gateway_chat_url), advertised_dynamic_tool_names);
+            return formatToolAction(ctx, arena, call, display_target, .completed, null);
+        }
+
+        pub fn describeToolActionCompletedWithPresentationStyles(
+            app: *App,
+            arena: Allocator,
+            call: ToolCall,
+            display_target: ?[]const u8,
+            presentation_styles: agent_runtime.PresentationStyles,
+            advertised_dynamic_tool_names: []const []const u8,
+            ignored_list_entries: []const []const u8,
+            max_list_entries: usize,
+            max_read_file_bytes: usize,
+            max_read_file_lines: usize,
+            max_read_file_line_len: usize,
+            max_command_output_bytes: usize,
+            gateway_retry_count: usize,
+            gateway_chat_url: []const u8,
+        ) ![]const u8 {
+            const ctx = tool_runtime.withAdvertisedDynamicToolNames(toolContextWithPresentationStyles(app, ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, gateway_retry_count, gateway_chat_url, presentation_styles), advertised_dynamic_tool_names);
             return formatToolAction(ctx, arena, call, display_target, .completed, null);
         }
 
@@ -594,6 +701,27 @@ pub fn Runtime(comptime App: type) type {
             gateway_chat_url: []const u8,
         ) ![]const u8 {
             const ctx = tool_runtime.withAdvertisedDynamicToolNames(toolContext(app, ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, gateway_retry_count, gateway_chat_url), advertised_dynamic_tool_names);
+            return formatToolAction(ctx, arena, call, display_target, .denied, label);
+        }
+
+        pub fn describeToolActionDeniedWithPresentationStyles(
+            app: *App,
+            arena: Allocator,
+            call: ToolCall,
+            display_target: ?[]const u8,
+            label: []const u8,
+            presentation_styles: agent_runtime.PresentationStyles,
+            advertised_dynamic_tool_names: []const []const u8,
+            ignored_list_entries: []const []const u8,
+            max_list_entries: usize,
+            max_read_file_bytes: usize,
+            max_read_file_lines: usize,
+            max_read_file_line_len: usize,
+            max_command_output_bytes: usize,
+            gateway_retry_count: usize,
+            gateway_chat_url: []const u8,
+        ) ![]const u8 {
+            const ctx = tool_runtime.withAdvertisedDynamicToolNames(toolContextWithPresentationStyles(app, ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, gateway_retry_count, gateway_chat_url, presentation_styles), advertised_dynamic_tool_names);
             return formatToolAction(ctx, arena, call, display_target, .denied, label);
         }
 
@@ -1033,7 +1161,14 @@ pub fn Runtime(comptime App: type) type {
                 else
                     null;
 
-            const deps = app_callbacks.Bindings(App).agentRuntimeDeps(app);
+            const active_presentation = if (comptime @hasDecl(@TypeOf(app.worker), "activePresentationStyles"))
+                app.worker.activePresentationStyles()
+            else
+                presentation_palette.snapshot(false, .fx, false);
+            const deps = app_callbacks.Bindings(App).agentRuntimeDepsWithPresentationSnapshot(
+                app,
+                active_presentation,
+            );
             const semantic_presentation = app_callbacks.Bindings(App).semanticPresentationSink(app);
             const config = buildQueuedPromptConfig(
                 app,
@@ -1326,15 +1461,15 @@ fn formatToolAction(
     denied_label: ?[]const u8,
 ) ![]const u8 {
     if (std.mem.eql(u8, call.name, "web_search") or tool_presentation.isProviderSearchAlias(call.name)) {
-        return formatWebSearchAction(arena, call, state, denied_label);
+        return formatWebSearchAction(arena, call, state, denied_label, ctx.presentation_dim_style);
     }
     const spec = ctx.tool_registry.lookup(call.name) orelse {
         if (dynamicMcpActionLabel(state)) |label| {
             if (mcpToolAvailable(ctx, call.name)) {
-                return formatToolActionValue(arena, label, call.name);
+                return formatToolActionValue(arena, label, call.name, ctx.presentation_dim_style);
             }
         }
-        return formatMissingSpecToolAction(arena, state, denied_label, call.name);
+        return formatMissingSpecToolAction(arena, state, denied_label, call.name, ctx.presentation_dim_style);
     };
     if (try tool_presentation.formatRunCommandActivity(arena, ctx.tool_registry, ctx.workspace_root, call)) |activity| {
         defer arena.free(activity.detail);
@@ -1349,6 +1484,7 @@ fn formatToolAction(
             arena,
             label,
             activity.detail,
+            ctx.presentation_dim_style,
         );
     }
     if (std.mem.eql(u8, call.name, "write_file") or
@@ -1358,52 +1494,53 @@ fn formatToolAction(
             arena,
             specLabel(spec, state, denied_label),
             display_target orelse spec.label_arg_default,
+            ctx.presentation_dim_style,
         );
     }
     const args = tool_args.parseToolArgsObject(arena, call.arguments_json) catch {
-        return formatInvalidArgsToolAction(arena, state, denied_label);
+        return formatInvalidArgsToolAction(arena, state, denied_label, ctx.presentation_dim_style);
     };
 
     const presentation = tool_dispatch.presentationForArgs(spec.*, args);
     const value = display_target orelse
         tool_dispatch.presentationLabelValue(presentation, args) orelse
         presentation.label_arg_default;
-    return formatToolActionValue(arena, presentationLabel(presentation, state, denied_label), value);
+    return formatToolActionValue(arena, presentationLabel(presentation, state, denied_label), value, ctx.presentation_dim_style);
 }
 
-fn formatWebSearchAction(arena: Allocator, call: ToolCall, state: ToolActionState, denied_label: ?[]const u8) ![]const u8 {
+fn formatWebSearchAction(arena: Allocator, call: ToolCall, state: ToolActionState, denied_label: ?[]const u8, dim_style: []const u8) ![]const u8 {
     const args = tool_args.parseToolArgsObject(arena, call.arguments_json) catch {
-        return formatInvalidArgsToolAction(arena, state, denied_label);
+        return formatInvalidArgsToolAction(arena, state, denied_label, dim_style);
     };
     const label = switch (state) {
         .active => "Searching",
         .completed => "Searched",
         .denied => denied_label.?,
     };
-    return formatToolActionValue(arena, label, try tool_presentation.formatWebSearchActionDetail(arena, args));
+    return formatToolActionValue(arena, label, try tool_presentation.formatWebSearchActionDetail(arena, args), dim_style);
 }
 
-fn formatMissingSpecToolAction(arena: Allocator, state: ToolActionState, denied_label: ?[]const u8, name: []const u8) ![]const u8 {
+fn formatMissingSpecToolAction(arena: Allocator, state: ToolActionState, denied_label: ?[]const u8, name: []const u8, dim_style: []const u8) ![]const u8 {
     return switch (state) {
-        .active => formatToolActionValue(arena, "Working", name),
-        .completed => formatToolActionValue(arena, "Completed", name),
-        .denied => formatToolActionValue(arena, denied_label.?, name),
+        .active => formatToolActionValue(arena, "Working", name, dim_style),
+        .completed => formatToolActionValue(arena, "Completed", name, dim_style),
+        .denied => formatToolActionValue(arena, denied_label.?, name, dim_style),
     };
 }
 
-fn formatInvalidArgsToolAction(arena: Allocator, state: ToolActionState, denied_label: ?[]const u8) ![]const u8 {
+fn formatInvalidArgsToolAction(arena: Allocator, state: ToolActionState, denied_label: ?[]const u8, dim_style: []const u8) ![]const u8 {
     return switch (state) {
         .active => std.fmt.allocPrint(arena, "● Working…\x1b[0m", .{}),
-        .completed => formatToolActionValue(arena, "Completed", "tool call"),
-        .denied => formatToolActionValue(arena, denied_label.?, "tool call"),
+        .completed => formatToolActionValue(arena, "Completed", "tool call", dim_style),
+        .denied => formatToolActionValue(arena, denied_label.?, "tool call", dim_style),
     };
 }
 
-fn formatToolActionValue(arena: Allocator, label: []const u8, value: []const u8) ![]const u8 {
+fn formatToolActionValue(arena: Allocator, label: []const u8, value: []const u8, dim_style: []const u8) ![]const u8 {
     return std.fmt.allocPrint(
         arena,
         "● {s}\x1b[0m {s}{s}\x1b[0m",
-        .{ label, presentation_palette.currentStyles().dim, value },
+        .{ label, dim_style, value },
     );
 }
 
@@ -1819,6 +1956,10 @@ const FakeApp = struct {
         return Runtime(FakeApp).describeToolAction(self, arena, call, display_target, advertised_dynamic_tool_names, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     }
 
+    pub fn describeToolActionWithAdvertisedStyles(self: *FakeApp, arena: Allocator, call: ToolCall, display_target: ?[]const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        return Runtime(FakeApp).describeToolActionWithPresentationStyles(self, arena, call, display_target, styles, advertised_dynamic_tool_names, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
+    }
+
     pub fn describeToolActionCompleted(self: *FakeApp, arena: Allocator, call: ToolCall) ![]const u8 {
         return Runtime(FakeApp).describeToolActionCompleted(self, arena, call, null, &.{}, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     }
@@ -1827,12 +1968,20 @@ const FakeApp = struct {
         return Runtime(FakeApp).describeToolActionCompleted(self, arena, call, display_target, advertised_dynamic_tool_names, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     }
 
+    pub fn describeToolActionCompletedWithAdvertisedStyles(self: *FakeApp, arena: Allocator, call: ToolCall, display_target: ?[]const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        return Runtime(FakeApp).describeToolActionCompletedWithPresentationStyles(self, arena, call, display_target, styles, advertised_dynamic_tool_names, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
+    }
+
     pub fn describeToolActionDenied(self: *FakeApp, arena: Allocator, call: ToolCall, label: []const u8) ![]const u8 {
         return Runtime(FakeApp).describeToolActionDenied(self, arena, call, null, label, &.{}, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     }
 
     pub fn describeToolActionDeniedWithAdvertised(self: *FakeApp, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
         return Runtime(FakeApp).describeToolActionDenied(self, arena, call, display_target, label, advertised_dynamic_tool_names, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
+    }
+
+    pub fn describeToolActionDeniedWithAdvertisedStyles(self: *FakeApp, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        return Runtime(FakeApp).describeToolActionDeniedWithPresentationStyles(self, arena, call, display_target, label, styles, advertised_dynamic_tool_names, &test_ignored_list_entries, 100, 1024, 40, 120, 2048, 2, test_gateway_chat_url);
     }
 
     pub fn permissionTargetForCall(self: *FakeApp, arena: Allocator, call: ToolCall) ![]const u8 {
@@ -2733,7 +2882,7 @@ test "app direct ask delivers semantic presentation through the runtime sink" {
     var semantic_events: [3]SemanticEvent = undefined;
     var semantic_event_count: usize = 0;
     for (events.items) |event| switch (event) {
-        .assistant_presentation => |presentation| switch (presentation) {
+        .assistant_presentation_styled => |styled| switch (styled.presentation) {
             .table => |table| {
                 table_count += 1;
                 semantic_events[semantic_event_count] = .table;
@@ -2936,8 +3085,12 @@ test "subagent tool context uses immutable admission authority" {
         .permission_mode = .auto,
         .rules = .{ .rules = &admission_rules },
         .grants = &admission_grants,
+        .presentation = presentation_palette.snapshot(false, .terminal, false),
     });
     defer admission.deinit(alloc);
+
+    // A newer root turn must not recolor an already-admitted child.
+    app.worker.setActivePresentationStyles(presentation_palette.snapshot(true, .fx, true));
 
     const ctx = app.subagentToolContextForAdmission(admission);
     try std.testing.expectEqual(PermissionMode.auto, ctx.permission_mode);
@@ -2951,6 +3104,11 @@ test "subagent tool context uses immutable admission authority" {
         "run_command",
         ctx.permission_grants[0].tool_name,
     );
+    try std.testing.expectEqual(
+        presentation_palette.PresentationTheme.terminal,
+        ctx.presentation_snapshot.theme,
+    );
+    try std.testing.expectEqualStrings("\x1b[96m", ctx.presentation_snapshot.styles.user_marker);
 }
 
 test "app agent runtime discards queued snapshots when tool projection preflight fails" {

--- a/src/core/app/app_agent_runtime.zig
+++ b/src/core/app/app_agent_runtime.zig
@@ -31,6 +31,7 @@ const subagent_agent_adapter = @import("../subagent/agent_adapter.zig");
 const subagent_domain = @import("../subagent/domain.zig");
 const subagent_execution = @import("../subagent/execution.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const text_utils = @import("../shared/text_utils.zig");
 const tool_args = @import("../tooling/tool_args.zig");
 const tool_admission = @import("../tooling/tool_admission.zig");
@@ -1399,7 +1400,11 @@ fn formatInvalidArgsToolAction(arena: Allocator, state: ToolActionState, denied_
 }
 
 fn formatToolActionValue(arena: Allocator, label: []const u8, value: []const u8) ![]const u8 {
-    return std.fmt.allocPrint(arena, "● {s}\x1b[0m \x1b[38;5;245m{s}\x1b[0m", .{ label, value });
+    return std.fmt.allocPrint(
+        arena,
+        "● {s}\x1b[0m {s}{s}\x1b[0m",
+        .{ label, presentation_palette.currentStyles().dim, value },
+    );
 }
 
 fn specLabel(spec: *const tool_dispatch.Tool, state: ToolActionState, denied_label: ?[]const u8) []const u8 {

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -28,6 +28,7 @@ const ui_render = @import("../../ui/render.zig");
 const ui_input = @import("../../ui/input/runtime.zig");
 const shell_runtime = @import("../../ui/shell_runtime.zig");
 const transcript_runtime = @import("../../ui/transcript/runtime.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -205,6 +206,33 @@ pub fn Runtime(comptime App: type) type {
                 .fx_version = App.app_version,
             });
             defer startup.deinit(app.alloc);
+
+            if (comptime @hasField(App, "color_palette")) {
+                app.color_palette = startup.color_palette;
+            }
+            if (comptime @hasField(App, "active_color_palette")) {
+                app.active_color_palette.store(@intFromEnum(startup.color_palette), .release);
+            }
+            if (comptime @hasField(App, "presentation_light")) {
+                app.presentation_light.store(ui_render.is_light, .release);
+            }
+            if (comptime @hasField(App, "presentation_truecolor")) {
+                app.presentation_truecolor = ui_render.truecolorEnabled();
+            }
+            if (comptime @hasDecl(@TypeOf(app.worker), "setPresentationStyles")) {
+                const presentation = presentation_palette.snapshot(
+                    ui_render.is_light,
+                    startup.color_palette,
+                    if (comptime @hasField(App, "presentation_truecolor"))
+                        app.presentation_truecolor
+                    else
+                        false,
+                );
+                app.worker.setPresentationStyles(presentation);
+                if (comptime @hasDecl(@TypeOf(app.worker), "setActivePresentationStyles")) {
+                    app.worker.setActivePresentationStyles(presentation);
+                }
+            }
 
             app.workspace_root = startup.takeWorkspaceRoot();
             if (comptime @hasDecl(App, "adoptWorkspaceAccess")) {

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -15,6 +15,7 @@ const app_worker_runtime = @import("app_worker_runtime.zig");
 const app_session_runtime = @import("app_session_runtime.zig");
 const change_tracker_mod = @import("../workspace/change_tracker.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const diagnostics = @import("../workspace/diagnostics.zig");
 const diff_mod = @import("../output/diff.zig");
 const file_mutation = @import("../tooling/file_mutation.zig");
@@ -50,14 +51,16 @@ const reset_style = ui_render.reset_style;
 fn preparedDiffPayload(
     alloc: Allocator,
     handoff: file_mutation.CommittedFileHandoff,
+    styles: agent_runtime.PresentationStyles,
 ) !diff_mod.DiffEntryPayload {
-    return preparedDiffPayloadWithFullAllocator(alloc, alloc, handoff);
+    return preparedDiffPayloadWithFullAllocator(alloc, alloc, handoff, styles);
 }
 
 fn preparedDiffPayloadWithFullAllocator(
     alloc: Allocator,
     full_alloc: Allocator,
     handoff: file_mutation.CommittedFileHandoff,
+    styles: agent_runtime.PresentationStyles,
 ) !diff_mod.DiffEntryPayload {
     return diff_mod.formatFileChangePayload(
         alloc,
@@ -69,11 +72,11 @@ fn preparedDiffPayloadWithFullAllocator(
             .lifecycle_id = snapshot.lifecycle_id,
         } else null,
         .{
-            .added_fg = ui_render.diff_added_style,
-            .removed_fg = ui_render.diff_removed_style,
-            .context_fg = ui_render.dim_style,
-            .added_marker_fg = ui_render.diff_added_marker_style,
-            .removed_marker_fg = ui_render.diff_removed_marker_style,
+            .added_fg = styles.diff_added,
+            .removed_fg = styles.diff_removed,
+            .context_fg = styles.dim,
+            .added_marker_fg = styles.diff_added_marker,
+            .removed_marker_fg = styles.diff_removed_marker,
             .reset = ui_render.reset_style,
         },
     );
@@ -164,7 +167,7 @@ test "prepared diff payload keeps compact elision and retains the complete appro
         .lifecycle_id = .{ .turn_id = 39, .call_id = "full-review" },
     };
 
-    const payload = try preparedDiffPayload(alloc, enriched_handoff);
+    const payload = try preparedDiffPayload(alloc, enriched_handoff, .{});
     defer diff_mod.freeDiffEntryPayload(alloc, payload);
 
     try std.testing.expect(std.mem.indexOf(u8, payload.preview, "⋯ +118 omitted") != null);
@@ -190,6 +193,7 @@ test "prepared diff payload keeps compact output when full formatting is unavail
         std.testing.allocator,
         failing.allocator(),
         enriched_handoff,
+        .{},
     );
     defer diff_mod.freeDiffEntryPayload(std.testing.allocator, payload);
 
@@ -266,6 +270,30 @@ test "full diff formatter renders unchanged review elisions" {
 pub fn Bindings(comptime App: type) type {
     return struct {
         pub fn agentRuntimeDeps(app: *App) agent_runtime.AgentRuntimeDeps {
+            const presentation = if (comptime @hasDecl(@TypeOf(app.worker), "activePresentationStyles"))
+                app.worker.activePresentationStyles()
+            else if (comptime @hasDecl(App, "activePresentationStyles"))
+                worker_runtime.PresentationSnapshot{
+                    .styles = app.activePresentationStyles(),
+                    .theme = .dark,
+                }
+            else
+                presentation_palette.snapshot(false, .fx, false);
+            return agentRuntimeDepsWithPresentationSnapshot(app, presentation);
+        }
+
+        pub fn agentRuntimeDepsWithPresentationSnapshot(
+            app: *App,
+            presentation: worker_runtime.PresentationSnapshot,
+        ) agent_runtime.AgentRuntimeDeps {
+            return agentRuntimeDepsWithStyles(app, presentation);
+        }
+
+        fn agentRuntimeDepsWithStyles(
+            app: *App,
+            presentation: worker_runtime.PresentationSnapshot,
+        ) agent_runtime.AgentRuntimeDeps {
+            const styles = presentation.styles;
             var deps: agent_runtime.AgentRuntimeDeps = .{
                 .ctx = @ptrCast(app),
                 .agent_stream_provider = if (comptime @hasDecl(App, "agentStreamProvider"))
@@ -347,10 +375,18 @@ pub fn Bindings(comptime App: type) type {
                 .report_usage = agentReportUsage,
                 .report_inner_tool_usage = agentReportInnerToolUsage,
                 .usage_allocator = app.alloc,
-                .diff_marker_styles = .{
-                    .added = ui_render.diff_added_marker_style,
-                    .removed = ui_render.diff_removed_marker_style,
+                .presentation_styles = .{
+                    .dim = styles.dim,
+                    .accent = styles.user_accent,
+                    .inline_code = styles.inline_code,
+                    .task_completed = styles.task_completed,
+                    .diff_added = styles.diff_added,
+                    .diff_removed = styles.diff_removed,
+                    .diff_added_marker = styles.diff_added_marker,
+                    .diff_removed_marker = styles.diff_removed_marker,
+                    .snapshot = presentation,
                 },
+                .diff_marker_styles = .{ .added = styles.diff_added_marker, .removed = styles.diff_removed_marker },
             };
             if (comptime @hasField(@TypeOf(app.session), "usage")) {
                 deps.usage = &app.session.usage;
@@ -431,11 +467,16 @@ pub fn Bindings(comptime App: type) type {
                 .ctx = @ptrCast(app),
                 .tool_lifecycle = worker_tool_lifecycle_presenter(app),
                 .write_user_prompt = workerBridgeWriteUserPrompt,
+                .write_user_prompt_styled = workerBridgeWriteUserPromptStyled,
                 .write_user_prompt_with_skill_bindings = workerBridgeWriteUserPromptWithSkillBindings,
+                .write_user_prompt_with_skill_bindings_styled = workerBridgeWriteUserPromptWithSkillBindingsStyled,
                 .append_text = workerBridgeAppendText,
                 .append_table = workerBridgeAppendTable,
+                .append_table_styled = workerBridgeAppendTableStyled,
                 .append_code_block = workerBridgeAppendCodeBlock,
+                .append_code_block_styled = workerBridgeAppendCodeBlockStyled,
                 .append_thematic_rule = workerBridgeAppendThematicRule,
+                .append_thematic_rule_styled = workerBridgeAppendThematicRuleStyled,
                 .drain_assistant_text = workerBridgeDrainAssistantText,
                 .open_model_picker = workerBridgeOpenModelPicker,
                 .semantic_notice = workerBridgeSemanticNotice,
@@ -668,19 +709,19 @@ pub fn Bindings(comptime App: type) type {
             return app.resolveToolActionDisplayTarget(arena, call);
         }
 
-        fn agentDescribeToolAction(ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        fn agentDescribeToolAction(ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
             const app: *App = @ptrCast(@alignCast(ctx));
-            return app.describeToolActionWithAdvertised(arena, call, display_target, advertised_dynamic_tool_names);
+            return app.describeToolActionWithAdvertisedStyles(arena, call, display_target, styles, advertised_dynamic_tool_names);
         }
 
-        fn agentDescribeToolActionCompleted(ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        fn agentDescribeToolActionCompleted(ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
             const app: *App = @ptrCast(@alignCast(ctx));
-            return app.describeToolActionCompletedWithAdvertised(arena, call, display_target, advertised_dynamic_tool_names);
+            return app.describeToolActionCompletedWithAdvertisedStyles(arena, call, display_target, styles, advertised_dynamic_tool_names);
         }
 
-        fn agentDescribeToolActionDenied(ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        fn agentDescribeToolActionDenied(ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
             const app: *App = @ptrCast(@alignCast(ctx));
-            return app.describeToolActionDeniedWithAdvertised(arena, call, display_target, label, advertised_dynamic_tool_names);
+            return app.describeToolActionDeniedWithAdvertisedStyles(arena, call, display_target, label, styles, advertised_dynamic_tool_names);
         }
 
         fn agentPermissionTargetForCall(ctx: *anyopaque, arena: Allocator, call: ToolCall, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
@@ -716,10 +757,11 @@ pub fn Bindings(comptime App: type) type {
         fn agentPublishCommittedFileHandoff(
             ctx: *anyopaque,
             handoff: file_mutation.CommittedFileHandoff,
+            styles: agent_runtime.PresentationStyles,
         ) agent_runtime.SecondaryPublicationReport {
             const app: *App = @ptrCast(@alignCast(ctx));
             return .{
-                .diff = publishCommittedDiff(app, handoff),
+                .diff = publishCommittedDiff(app, handoff, styles),
                 .tracker = publishCommittedTracker(app, handoff),
             };
         }
@@ -727,10 +769,12 @@ pub fn Bindings(comptime App: type) type {
         fn publishCommittedDiff(
             app: *App,
             handoff: file_mutation.CommittedFileHandoff,
+            styles: agent_runtime.PresentationStyles,
         ) agent_runtime.SecondarySinkOutcome {
             const payload = preparedDiffPayload(
                 std.heap.c_allocator,
                 handoff,
+                styles,
             ) catch |err| {
                 debug_trace.logf(
                     "tool",
@@ -1044,6 +1088,19 @@ pub fn Bindings(comptime App: type) type {
             try app.writeUserPromptCard(prompt);
         }
 
+        fn workerBridgeWriteUserPromptStyled(
+            ctx: *anyopaque,
+            prompt: types.UserTurn,
+            styles: worker_runtime.PresentationSnapshot,
+        ) !void {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            if (comptime @hasDecl(App, "writeUserPromptCardWithPresentationStyles")) {
+                try app.writeUserPromptCardWithPresentationStyles(prompt, styles);
+            } else {
+                try app.writeUserPromptCard(prompt);
+            }
+        }
+
         fn workerBridgeWriteUserPromptWithSkillBindings(
             ctx: *anyopaque,
             prompt: types.UserTurn,
@@ -1053,6 +1110,28 @@ pub fn Bindings(comptime App: type) type {
             const app: *App = @ptrCast(@alignCast(ctx));
             if (comptime @hasDecl(App, "writeUserPromptCardWithSkillBindings")) {
                 try app.writeUserPromptCardWithSkillBindings(prompt, skill_bindings, skill_display_spans);
+            } else {
+                try app.writeUserPromptCard(prompt);
+            }
+        }
+
+        fn workerBridgeWriteUserPromptWithSkillBindingsStyled(
+            ctx: *anyopaque,
+            prompt: types.UserTurn,
+            skill_bindings: []const worker_runtime.SkillBinding,
+            skill_display_spans: []const worker_runtime.SkillDisplaySpan,
+            styles: worker_runtime.PresentationSnapshot,
+        ) !void {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            if (comptime @hasDecl(App, "writeUserPromptCardWithSkillBindingsAndPresentationStyles")) {
+                try app.writeUserPromptCardWithSkillBindingsAndPresentationStyles(
+                    prompt,
+                    skill_bindings,
+                    skill_display_spans,
+                    styles,
+                );
+            } else if (comptime @hasDecl(App, "writeUserPromptCardWithPresentationStyles")) {
+                try app.writeUserPromptCardWithPresentationStyles(prompt, styles);
             } else {
                 try app.writeUserPromptCard(prompt);
             }
@@ -1077,6 +1156,29 @@ pub fn Bindings(comptime App: type) type {
             handed_off = true;
         }
 
+        fn workerBridgeAppendTableStyled(
+            ctx: *anyopaque,
+            table: assistant_presentation.TablePayload,
+            styles: worker_runtime.PresentationSnapshot,
+        ) !void {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            var owned = table;
+            var handed_off = false;
+            errdefer if (!handed_off) owned.deinit(app.alloc);
+            if (comptime @hasDecl(App, "appendAssistantTableWithPresentationStyles")) {
+                try app.appendAssistantTableWithPresentationStyles(owned, styles);
+                handed_off = true;
+                return;
+            }
+            if (comptime @hasDecl(App, "appendAssistantTable")) {
+                try app.appendAssistantTable(owned);
+                handed_off = true;
+                return;
+            }
+            owned.deinit(app.alloc);
+            handed_off = true;
+        }
+
         fn workerBridgeAppendCodeBlock(ctx: *anyopaque, block: assistant_presentation.CodeBlockPayload) !void {
             const app: *App = @ptrCast(@alignCast(ctx));
             var owned = block;
@@ -1091,9 +1193,44 @@ pub fn Bindings(comptime App: type) type {
             handed_off = true;
         }
 
+        fn workerBridgeAppendCodeBlockStyled(
+            ctx: *anyopaque,
+            block: assistant_presentation.CodeBlockPayload,
+            styles: worker_runtime.PresentationSnapshot,
+        ) !void {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            var owned = block;
+            var handed_off = false;
+            errdefer if (!handed_off) owned.deinit(app.alloc);
+            if (comptime @hasDecl(App, "appendAssistantCodeBlockWithPresentationStyles")) {
+                try app.appendAssistantCodeBlockWithPresentationStyles(owned, styles);
+                handed_off = true;
+                return;
+            }
+            if (comptime @hasDecl(App, "appendAssistantCodeBlock")) {
+                try app.appendAssistantCodeBlock(owned);
+                handed_off = true;
+                return;
+            }
+            owned.deinit(app.alloc);
+            handed_off = true;
+        }
+
         fn workerBridgeAppendThematicRule(ctx: *anyopaque) !void {
             const app: *App = @ptrCast(@alignCast(ctx));
             if (comptime @hasDecl(App, "appendAssistantThematicRule")) {
+                try app.appendAssistantThematicRule();
+            }
+        }
+
+        fn workerBridgeAppendThematicRuleStyled(
+            ctx: *anyopaque,
+            styles: worker_runtime.PresentationSnapshot,
+        ) !void {
+            const app: *App = @ptrCast(@alignCast(ctx));
+            if (comptime @hasDecl(App, "appendAssistantThematicRuleWithPresentationStyles")) {
+                try app.appendAssistantThematicRuleWithPresentationStyles(styles);
+            } else if (comptime @hasDecl(App, "appendAssistantThematicRule")) {
                 try app.appendAssistantThematicRule();
             }
         }
@@ -1233,6 +1370,10 @@ const FakeWorker = struct {
         if (self.fail_semantic_push) {
             switch (event) {
                 .assistant_presentation => |presentation| switch (presentation) {
+                    .table, .code_block => return error.TestSemanticPresentationPublicationFailure,
+                    .text, .thematic_rule => {},
+                },
+                .assistant_presentation_styled => |styled| switch (styled.presentation) {
                     .table, .code_block => return error.TestSemanticPresentationPublicationFailure,
                     .text, .thematic_rule => {},
                 },
@@ -1440,6 +1581,7 @@ const FakeApp = struct {
     last_notice_visibility: types.NoticeVisibility = .compact_and_full,
     last_notice_record: bool = false,
     capability_request_count: usize = 0,
+    presentation_styles: presentation_palette.Styles = presentation_palette.styles(false, .fx),
 
     fn init(alloc: std.mem.Allocator) FakeApp {
         return .{ .alloc = alloc };
@@ -1454,6 +1596,10 @@ const FakeApp = struct {
         self.pacer.deinit(self.alloc);
         self.transcript.deinit(self.alloc);
         self.last_notice_topic.deinit(self.alloc);
+    }
+
+    pub fn activePresentationStyles(self: *const FakeApp) presentation_palette.Styles {
+        return self.presentation_styles;
     }
 
     pub fn modelCompletions(self: *FakeApp, _: []const u8, out: *[32][]const u8) usize {
@@ -1531,17 +1677,17 @@ const FakeApp = struct {
         return null;
     }
 
-    fn describeToolActionWithAdvertised(self: *FakeApp, arena: Allocator, call: ToolCall, _: ?[]const u8, _: []const []const u8) ![]const u8 {
+    fn describeToolActionWithAdvertisedStyles(self: *FakeApp, arena: Allocator, call: ToolCall, _: ?[]const u8, styles: agent_runtime.PresentationStyles, _: []const []const u8) ![]const u8 {
         _ = self;
-        return std.fmt.allocPrint(arena, "run {s}", .{call.name});
+        return std.fmt.allocPrint(arena, "run {s}{s}", .{ styles.dim, call.name });
     }
 
-    fn describeToolActionCompletedWithAdvertised(self: *FakeApp, arena: Allocator, call: ToolCall, _: ?[]const u8, _: []const []const u8) ![]const u8 {
+    fn describeToolActionCompletedWithAdvertisedStyles(self: *FakeApp, arena: Allocator, call: ToolCall, _: ?[]const u8, _: agent_runtime.PresentationStyles, _: []const []const u8) ![]const u8 {
         _ = self;
         return std.fmt.allocPrint(arena, "done {s}", .{call.name});
     }
 
-    fn describeToolActionDeniedWithAdvertised(self: *FakeApp, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: []const []const u8) ![]const u8 {
+    fn describeToolActionDeniedWithAdvertisedStyles(self: *FakeApp, arena: Allocator, call: ToolCall, _: ?[]const u8, label: []const u8, _: agent_runtime.PresentationStyles, _: []const []const u8) ![]const u8 {
         _ = self;
         return std.fmt.allocPrint(arena, "denied {s} {s}", .{ call.name, label });
     }
@@ -1866,6 +2012,34 @@ test "agent deps forward app callbacks through core types" {
     try std.testing.expectEqualStrings("tool:Boom", formatted);
 }
 
+test "agent deps retain one immutable palette snapshot per runtime" {
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+
+    const fx_deps = Bindings(FakeApp).agentRuntimeDeps(&app);
+    app.presentation_styles = presentation_palette.styles(false, .terminal);
+    const terminal_deps = Bindings(FakeApp).agentRuntimeDeps(&app);
+
+    const in_flight_action = try fx_deps.describe_tool_action(
+        fx_deps.ctx,
+        std.testing.allocator,
+        .{ .id = "snapshot", .name = "read_file", .arguments_json = "{}" },
+        null,
+        fx_deps.presentation_styles,
+        &.{},
+    );
+    defer std.testing.allocator.free(in_flight_action);
+
+    try std.testing.expectEqualStrings("\x1b[38;5;245m", fx_deps.presentation_styles.dim);
+    try std.testing.expectEqualStrings("\x1b[38;5;71m", fx_deps.presentation_styles.diff_added_marker);
+    try std.testing.expectEqualStrings("\x1b[38;5;71m", fx_deps.diff_marker_styles.added);
+    try std.testing.expectEqualStrings("\x1b[90m", terminal_deps.presentation_styles.dim);
+    try std.testing.expectEqualStrings("\x1b[32m", terminal_deps.presentation_styles.diff_added_marker);
+    try std.testing.expectEqualStrings("\x1b[32m", terminal_deps.diff_marker_styles.added);
+    try std.testing.expect(std.mem.find(u8, in_flight_action, "\x1b[38;5;245m") != null);
+    try std.testing.expect(std.mem.find(u8, in_flight_action, "\x1b[90m") == null);
+}
+
 test "agent deps use request-time model capability resolution when available" {
     var app = FakeApp.init(std.testing.allocator);
     defer app.deinit();
@@ -1926,14 +2100,14 @@ test "app semantic presentation sink retains payload ownership only after succes
     });
 
     try std.testing.expectEqual(@as(usize, 2), app.worker.events.items.len);
-    try std.testing.expect(app.worker.events.items[0] == .assistant_presentation);
-    try std.testing.expect(app.worker.events.items[0].assistant_presentation == .table);
-    try std.testing.expectEqualStrings("api", app.worker.events.items[0].assistant_presentation.table.rows[1].cells[0]);
-    try std.testing.expect(app.worker.events.items[0].assistant_presentation.table.rows[1].cells[0].ptr != table_source_cell);
-    try std.testing.expect(app.worker.events.items[1] == .assistant_presentation);
-    try std.testing.expect(app.worker.events.items[1].assistant_presentation == .code_block);
-    try std.testing.expectEqualStrings("const ready = true;\n", app.worker.events.items[1].assistant_presentation.code_block.code);
-    try std.testing.expect(app.worker.events.items[1].assistant_presentation.code_block.code.ptr != code_source_ptr);
+    try std.testing.expect(app.worker.events.items[0] == .assistant_presentation_styled);
+    try std.testing.expect(app.worker.events.items[0].assistant_presentation_styled.presentation == .table);
+    try std.testing.expectEqualStrings("api", app.worker.events.items[0].assistant_presentation_styled.presentation.table.rows[1].cells[0]);
+    try std.testing.expect(app.worker.events.items[0].assistant_presentation_styled.presentation.table.rows[1].cells[0].ptr != table_source_cell);
+    try std.testing.expect(app.worker.events.items[1] == .assistant_presentation_styled);
+    try std.testing.expect(app.worker.events.items[1].assistant_presentation_styled.presentation == .code_block);
+    try std.testing.expectEqualStrings("const ready = true;\n", app.worker.events.items[1].assistant_presentation_styled.presentation.code_block.code);
+    try std.testing.expect(app.worker.events.items[1].assistant_presentation_styled.presentation.code_block.code.ptr != code_source_ptr);
 
     app.worker.fail_semantic_push = true;
     const failed_table = try assistant_presentation.parseTablePayload(
@@ -2055,7 +2229,7 @@ test "committed file handoff publishes prepared diff and cloned tracker state" {
 
     const deps = Bindings(FakeApp).agentRuntimeDeps(&app);
     const handoff = testCommittedFileHandoff();
-    const report = deps.publish_committed_file_handoff(deps.ctx, handoff);
+    const report = deps.publish_committed_file_handoff(deps.ctx, handoff, deps.presentation_styles);
 
     try std.testing.expectEqual(
         agent_runtime.SecondarySinkOutcome.published,

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -3732,19 +3732,42 @@ pub fn applySettingsCatalogChange(app: anytype, change: settings_catalog.Change)
             const palette = config_runtime.ColorPalette.parse(change.value) orelse
                 return error.InvalidSettingsCatalogValue;
             const App = @TypeOf(app.*);
-            const runtime_changed = if (comptime @hasDecl(App, "colorPalette"))
+            const preference_changed = if (comptime @hasDecl(App, "colorPalette"))
                 palette != app.colorPalette()
             else
                 false;
-            if (runtime_changed and comptime @hasDecl(App, "applyColorPaletteUpdate")) {
-                try app.applyColorPaletteUpdate(palette);
+            const patch: config_runtime.UserSettingsPatch = .{ .color_palette = palette };
+            var attempt = config_runtime.attemptUserPreferences(app.alloc, patch);
+            defer attempt.deinit(app.alloc);
+            switch (attempt) {
+                .failure => |failure| try session_commands.reportUserSettingsFailure(
+                    app,
+                    "color palette",
+                    failure.err,
+                    failure.cleanup,
+                    false,
+                ),
+                .outcome => |outcome| {
+                    var session_error: ?anyerror = null;
+                    if (preference_changed) {
+                        if (comptime @hasDecl(App, "applyColorPaletteUpdate")) {
+                            app.applyColorPaletteUpdate(palette) catch |err| {
+                                session_error = err;
+                            };
+                        } else if (comptime @hasDecl(App, "setColorPalettePreference")) {
+                            app.setColorPalettePreference(palette);
+                        }
+                    }
+                    _ = try session_commands.reportUserSettingsCommit(
+                        app,
+                        "color palette",
+                        patch,
+                        outcome,
+                        session_error,
+                        true,
+                    );
+                },
             }
-            try persistUserPreferences(
-                app,
-                "color palette",
-                .{ .color_palette = palette },
-                runtime_changed,
-            );
         },
         .slash_menu_categories => {
             const enabled = parseOnOff(change.value) orelse return error.InvalidSettingsCatalogValue;

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -3651,6 +3651,7 @@ pub fn settingsCatalogSnapshot(app: anytype) settings_catalog.Snapshot {
     if (comptime @hasField(App, "shell") and @hasField(@TypeOf(app.shell), "collapse_tool_calls")) {
         snapshot.collapse_tool_calls = app.shell.collapse_tool_calls;
     }
+    if (comptime @hasDecl(App, "colorPalette")) snapshot.color_palette = app.colorPalette().label();
     if (comptime @hasField(App, "statusline_context")) snapshot.statusline_context = app.statusline_context;
     if (comptime @hasField(App, "statusline_session")) snapshot.statusline_session = app.statusline_session;
     if (comptime @hasField(App, "workspace_identity")) snapshot.statusline_workspace = app.workspace_identity.enabled;
@@ -3724,6 +3725,24 @@ pub fn applySettingsCatalogChange(app: anytype, change: settings_catalog.Change)
                 app,
                 "collapse tool calls",
                 .{ .collapse_tool_calls = enabled },
+                runtime_changed,
+            );
+        },
+        .color_palette => {
+            const palette = config_runtime.ColorPalette.parse(change.value) orelse
+                return error.InvalidSettingsCatalogValue;
+            const App = @TypeOf(app.*);
+            const runtime_changed = if (comptime @hasDecl(App, "colorPalette"))
+                palette != app.colorPalette()
+            else
+                false;
+            if (runtime_changed and comptime @hasDecl(App, "applyColorPaletteUpdate")) {
+                try app.applyColorPaletteUpdate(palette);
+            }
+            try persistUserPreferences(
+                app,
+                "color palette",
+                .{ .color_palette = palette },
                 runtime_changed,
             );
         },

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -150,6 +150,7 @@ pub const StartupState = struct {
     notification_turn_end: bool = false,
     notification_attention_required: bool = false,
     notification_max: bool = false,
+    color_palette: config_runtime.ColorPalette = .fx,
     theme_monitor_enabled: bool = false,
 
     pub fn deinit(self: *StartupState, alloc: Allocator) void {
@@ -481,6 +482,7 @@ fn loadStartupStateFromOwnedWorkspace(
     state.notification_turn_end = sound_on_override orelse settings.notification_turn_end orelse notification_sound.default_enabled;
     state.notification_attention_required = sound_on_override orelse settings.notification_attention_required orelse notification_sound.default_enabled;
     state.notification_max = max_override orelse settings.notification_max orelse false;
+    state.color_palette = settings.color_palette orelse .fx;
 
     return state;
 }
@@ -561,7 +563,7 @@ pub fn bootstrapInteractiveApp(cfg: BootstrapConfig) !StartupState {
         io_mod.getenv("TERM_PROGRAM"),
     ));
     const theme = ui_render.detectTheme(cfg.alloc, cfg.terminal);
-    ui_render.initTheme(theme.light, theme.rgb);
+    ui_render.initThemeForPalette(theme.light, theme.rgb, state.color_palette);
     state.theme_monitor_enabled = ui_render.explicitThemeOverride() == null;
 
     const cursor = cfg.terminal.queryCursorPosition() catch blk: {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -498,15 +498,34 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn applyThemeUpdate(app: *App, light: bool, rgb: ?ui_render.TerminalRgb) !void {
-            if (!ui_render.themeNeedsUpdate(light, rgb)) return;
+            return applyThemeUpdateForPalette(app, light, rgb, ui_render.currentColorPalette());
+        }
+
+        pub fn applyThemeUpdateForPalette(
+            app: *App,
+            light: bool,
+            rgb: ?ui_render.TerminalRgb,
+            palette: ui_render.ColorPalette,
+        ) !void {
+            if (!ui_render.themeNeedsUpdateForPalette(light, rgb, palette)) return;
 
             const prior_light = ui_render.is_light;
-            app.shell.retintEntriesForTheme(app.alloc, prior_light, light) catch |err| {
+            const prior_palette = ui_render.currentColorPalette();
+            app.shell.retintEntriesForPalette(
+                app.alloc,
+                prior_light,
+                light,
+                prior_palette,
+                palette,
+            ) catch |err| {
                 debug_trace.logf("theme", "theme_transcript_retint_failed err={s}", .{@errorName(err)});
                 return;
             };
-            app.pacer.rethemeInlineCode(light);
-            ui_render.initTheme(light, rgb);
+            app.pacer.rethemeInlineCodeForPalette(app.alloc, light, palette) catch |err| {
+                debug_trace.logf("theme", "theme_pacer_retint_failed err={s}", .{@errorName(err)});
+                return;
+            };
+            ui_render.initThemeForPalette(light, rgb, palette);
             app.shell.setCommandOutputRenderPolicy(shellStyles());
             try app.shell.requestTerminalReset(&app.metrics);
             app.shell.render_requests.request(.transcript);
@@ -525,7 +544,12 @@ pub fn Runtime(comptime App: type) type {
                 .notice_warning_style = ui_render.warning_style,
                 .notice_error_style = ui_render.red_style,
                 .notice_cancelled_style = ui_render.dim_style,
-                .code_highlight_theme = if (ui_render.is_light) .light else .dark,
+                .code_highlight_theme = if (ui_render.currentColorPalette() == .terminal)
+                    .terminal
+                else if (ui_render.is_light)
+                    .light
+                else
+                    .dark,
             };
         }
 

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -56,6 +56,7 @@ const transcript_runtime = @import("../../ui/transcript/runtime.zig");
 const ui_render = @import("../../ui/render.zig");
 const assistant_pacer = @import("../../ui/assistant/pacer.zig");
 const user_message_card = @import("../../ui/assistant/user_message_card.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 
 fn set_transcript_assistant_tail_writable(
     runtime: *transcript_runtime.TranscriptRuntime,
@@ -436,6 +437,20 @@ noinline fn approvalScreenNeedsClear(
 
 pub fn Runtime(comptime App: type) type {
     return struct {
+        fn syncNextTurnPresentation(app: *App, light: bool, palette: ui_render.ColorPalette) void {
+            if (comptime @hasDecl(@TypeOf(app.worker), "setPresentationStyles")) {
+                const truecolor = if (comptime @hasField(App, "presentation_truecolor"))
+                    app.presentation_truecolor
+                else
+                    false;
+                app.worker.setPresentationStyles(presentation_palette.snapshot(
+                    light,
+                    palette,
+                    truecolor,
+                ));
+            }
+        }
+
         fn appendDeferredHistoryForVisualEpoch(
             ctx: *anyopaque,
             finished: *const types.FinishedPrompt,
@@ -498,37 +513,43 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn applyThemeUpdate(app: *App, light: bool, rgb: ?ui_render.TerminalRgb) !void {
-            return applyThemeUpdateForPalette(app, light, rgb, ui_render.currentColorPalette());
-        }
-
-        pub fn applyThemeUpdateForPalette(
-            app: *App,
-            light: bool,
-            rgb: ?ui_render.TerminalRgb,
-            palette: ui_render.ColorPalette,
-        ) !void {
+            const palette = ui_render.currentColorPalette();
             if (!ui_render.themeNeedsUpdateForPalette(light, rgb, palette)) return;
 
             const prior_light = ui_render.is_light;
-            const prior_palette = ui_render.currentColorPalette();
-            app.shell.retintEntriesForPalette(
-                app.alloc,
-                prior_light,
-                light,
-                prior_palette,
-                palette,
-            ) catch |err| {
-                debug_trace.logf("theme", "theme_transcript_retint_failed err={s}", .{@errorName(err)});
-                return;
-            };
-            app.pacer.rethemeInlineCodeForPalette(app.alloc, light, palette) catch |err| {
-                debug_trace.logf("theme", "theme_pacer_retint_failed err={s}", .{@errorName(err)});
-                return;
-            };
+            if (palette == .fx) {
+                app.shell.retintEntriesForTheme(app.alloc, prior_light, light) catch |err| {
+                    debug_trace.logf("theme", "theme_transcript_retint_failed err={s}", .{@errorName(err)});
+                    return err;
+                };
+                app.pacer.rethemeInlineCode(light);
+            }
             ui_render.initThemeForPalette(light, rgb, palette);
+            if (comptime @hasField(App, "presentation_light")) {
+                app.presentation_light.store(light, .release);
+            }
+            syncNextTurnPresentation(app, light, palette);
             app.shell.setCommandOutputRenderPolicy(shellStyles());
             try app.shell.requestTerminalReset(&app.metrics);
             app.shell.render_requests.request(.transcript);
+        }
+
+        /// Activate fx-owned live chrome after the preference commit succeeds.
+        /// Existing transcript bytes and arbitrary command ANSI are retained
+        /// verbatim; new runtime snapshots observe the newly published value.
+        pub fn applyColorPaletteUpdate(app: *App, palette: ui_render.ColorPalette) !void {
+            if (ui_render.currentColorPalette() == palette) return;
+
+            ui_render.applyColorPalette(palette);
+            if (comptime @hasField(App, "active_color_palette")) {
+                app.active_color_palette.store(@intFromEnum(palette), .release);
+            }
+            syncNextTurnPresentation(app, ui_render.is_light, palette);
+            app.shell.setCommandOutputRenderPolicy(shellStyles());
+            try app.shell.requestTerminalReset(&app.metrics);
+            app.shell.render_requests.request(.first_frame);
+            app.shell.render_requests.request(.footer);
+            app.shell.render_requests.request(.modal);
         }
 
         pub fn shellStyles() transcript_runtime.Styles {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -8,6 +8,7 @@ const assistant_presentation = @import("../agent/assistant_presentation.zig");
 const tool_admission = @import("../agent/runtime/tool_admission.zig");
 const tool_presentation = @import("../agent/runtime/tool_presentation.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const runtime_profile = @import("../hosts/runtime_profile.zig");
 const host_capability = @import("../hosts/host.zig");
 const host_target = @import("../hosts/target.zig");
@@ -4155,6 +4156,13 @@ pub fn Runtime(comptime App: type) type {
                 base,
                 presentation.additions,
                 presentation.deletions,
+                blk: {
+                    const styles = presentation_palette.styles(
+                        ui_render.is_light,
+                        ui_render.currentColorPalette(),
+                    );
+                    break :blk .{ .dim = styles.dim, .accent = styles.user_accent };
+                },
                 .{
                     .added = ui_render.diff_added_marker_style,
                     .removed = ui_render.diff_removed_marker_style,

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -1039,13 +1039,13 @@ fn formatWebSearchProgress(alloc: std.mem.Allocator, progress: types.WebSearchPr
     return switch (progress) {
         .query_started => |query| std.fmt.allocPrint(
             alloc,
-            "● Searching\x1b[0m \x1b[38;5;245m{s}\x1b[0m",
-            .{text_utils.clippedLabel(&query_buf, query, 120)},
+            "● Searching\x1b[0m {s}{s}\x1b[0m",
+            .{ ui_render.dim_style, text_utils.clippedLabel(&query_buf, query, 120) },
         ),
         .results_received => |entry| std.fmt.allocPrint(
             alloc,
-            "● Found {d} result{s}\x1b[0m \x1b[38;5;245m{s}\x1b[0m",
-            .{ entry.result_count, if (entry.result_count == 1) "" else "s", text_utils.clippedLabel(&query_buf, entry.query, 120) },
+            "● Found {d} result{s}\x1b[0m {s}{s}\x1b[0m",
+            .{ entry.result_count, if (entry.result_count == 1) "" else "s", ui_render.dim_style, text_utils.clippedLabel(&query_buf, entry.query, 120) },
         ),
     };
 }
@@ -1055,13 +1055,13 @@ fn formatWebFetchProgress(alloc: std.mem.Allocator, progress: types.WebFetchProg
     return switch (progress) {
         .fetching => |url| std.fmt.allocPrint(
             alloc,
-            "● Fetching\x1b[0m \x1b[38;5;245m{s}\x1b[0m",
-            .{text_utils.clippedLabel(&url_buf, url, 120)},
+            "● Fetching\x1b[0m {s}{s}\x1b[0m",
+            .{ ui_render.dim_style, text_utils.clippedLabel(&url_buf, url, 120) },
         ),
         .converting => |url| std.fmt.allocPrint(
             alloc,
-            "● Converting\x1b[0m \x1b[38;5;245m{s}\x1b[0m",
-            .{text_utils.clippedLabel(&url_buf, url, 120)},
+            "● Converting\x1b[0m {s}{s}\x1b[0m",
+            .{ ui_render.dim_style, text_utils.clippedLabel(&url_buf, url, 120) },
         ),
     };
 }

--- a/src/core/app/app_worker_runtime.zig
+++ b/src/core/app/app_worker_runtime.zig
@@ -10,6 +10,7 @@ const io_mod = @import("../shared/io.zig");
 const permission_request = @import("../permissions/permission_request.zig");
 const text_utils = @import("../shared/text_utils.zig");
 const types = @import("../shared/types.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
 const assistant_presentation = @import("../agent/assistant_presentation.zig");
 const assistant_pacer = @import("../../ui/assistant/pacer.zig");
@@ -63,11 +64,16 @@ pub const WorkerEventHandlers = struct {
     ctx: *anyopaque,
     tool_lifecycle: activity_runtime.LifecyclePresenter,
     write_user_prompt: *const fn (*anyopaque, types.UserTurn) anyerror!void,
+    write_user_prompt_styled: ?*const fn (*anyopaque, types.UserTurn, worker_runtime.PresentationSnapshot) anyerror!void = null,
     write_user_prompt_with_skill_bindings: ?*const fn (*anyopaque, types.UserTurn, []const worker_runtime.SkillBinding, []const worker_runtime.SkillDisplaySpan) anyerror!void = null,
+    write_user_prompt_with_skill_bindings_styled: ?*const fn (*anyopaque, types.UserTurn, []const worker_runtime.SkillBinding, []const worker_runtime.SkillDisplaySpan, worker_runtime.PresentationSnapshot) anyerror!void = null,
     append_text: *const fn (*anyopaque, []const u8) anyerror!void,
     append_table: *const fn (*anyopaque, assistant_presentation.TablePayload) anyerror!void = discardTable,
+    append_table_styled: ?*const fn (*anyopaque, assistant_presentation.TablePayload, worker_runtime.PresentationSnapshot) anyerror!void = null,
     append_code_block: *const fn (*anyopaque, assistant_presentation.CodeBlockPayload) anyerror!void = discardCodeBlock,
+    append_code_block_styled: ?*const fn (*anyopaque, assistant_presentation.CodeBlockPayload, worker_runtime.PresentationSnapshot) anyerror!void = null,
     append_thematic_rule: *const fn (*anyopaque) anyerror!void = discardThematicRule,
+    append_thematic_rule_styled: ?*const fn (*anyopaque, worker_runtime.PresentationSnapshot) anyerror!void = null,
     drain_assistant_text: *const fn (*anyopaque) anyerror!AssistantTextDrainResult,
     open_model_picker: *const fn (*anyopaque) anyerror!void,
     semantic_notice: *const fn (*anyopaque, types.SemanticNotice) anyerror!void,
@@ -153,7 +159,12 @@ fn batchContainsInterruptedClosure(
 fn batchSegmentEndsInterrupted(events: []const WorkerEvent) bool {
     for (events, 0..) |event, index| {
         if (index > 0) switch (event) {
-            .begin_prompt, .begin_prompt_with_skill_bindings, .begin_presented_prompt => return false,
+            .begin_prompt,
+            .begin_prompt_with_skill_bindings,
+            .begin_prompt_styled,
+            .begin_prompt_with_skill_bindings_styled,
+            .begin_presented_prompt,
+            => return false,
             else => {},
         };
         const lifecycle = switch (event) {
@@ -187,6 +198,7 @@ pub fn Runtime(comptime App: type) type {
         ) CancelledEventAdmission {
             return switch (event) {
                 .assistant_presentation,
+                .assistant_presentation_styled,
                 .open_model_picker,
                 .semantic_notice,
                 .command_output,
@@ -214,8 +226,11 @@ pub fn Runtime(comptime App: type) type {
                 },
                 .begin_prompt,
                 .begin_prompt_with_skill_bindings,
+                .begin_prompt_styled,
+                .begin_prompt_with_skill_bindings_styled,
                 .begin_presented_prompt,
                 .append_user_feedback,
+                .append_user_feedback_styled,
                 .notification,
                 .question_requested,
                 .clear_route_recovery_status,
@@ -346,15 +361,36 @@ pub fn Runtime(comptime App: type) type {
         }
 
         pub fn pushTable(app: *App, table: assistant_presentation.TablePayload) !void {
-            try pushEvent(app, .{ .assistant_presentation = .{ .table = table } });
+            const styles = if (comptime @hasDecl(@TypeOf(app.worker), "activePresentationStyles"))
+                app.worker.activePresentationStyles()
+            else
+                presentation_palette.snapshot(false, .fx, false);
+            try pushEvent(app, .{ .assistant_presentation_styled = .{
+                .presentation = .{ .table = table },
+                .styles = styles,
+            } });
         }
 
         pub fn pushCodeBlock(app: *App, block: assistant_presentation.CodeBlockPayload) !void {
-            try pushEvent(app, .{ .assistant_presentation = .{ .code_block = block } });
+            const styles = if (comptime @hasDecl(@TypeOf(app.worker), "activePresentationStyles"))
+                app.worker.activePresentationStyles()
+            else
+                presentation_palette.snapshot(false, .fx, false);
+            try pushEvent(app, .{ .assistant_presentation_styled = .{
+                .presentation = .{ .code_block = block },
+                .styles = styles,
+            } });
         }
 
         pub fn pushThematicRule(app: *App) !void {
-            try pushEvent(app, .{ .assistant_presentation = .thematic_rule });
+            const styles = if (comptime @hasDecl(@TypeOf(app.worker), "activePresentationStyles"))
+                app.worker.activePresentationStyles()
+            else
+                presentation_palette.snapshot(false, .fx, false);
+            try pushEvent(app, .{ .assistant_presentation_styled = .{
+                .presentation = .thematic_rule,
+                .styles = styles,
+            } });
         }
 
         pub fn pushCommandOutput(
@@ -400,7 +436,11 @@ pub fn Runtime(comptime App: type) type {
                 );
                 return;
             }
-            const label = try formatWebSearchProgress(std.heap.c_allocator, progress);
+            const dim_style = if (comptime @hasDecl(@TypeOf(app.worker), "activePresentationDimStyle"))
+                app.worker.activePresentationDimStyle()
+            else
+                "";
+            const label = try formatWebSearchProgress(std.heap.c_allocator, progress, dim_style);
             defer std.heap.c_allocator.free(label);
             try pushToolLifecycle(app, .{ .progress = .{
                 .id = .{ .turn_id = turn_id, .call_id = call_id },
@@ -418,7 +458,11 @@ pub fn Runtime(comptime App: type) type {
                 );
                 return;
             }
-            const label = try formatWebFetchProgress(std.heap.c_allocator, progress);
+            const dim_style = if (comptime @hasDecl(@TypeOf(app.worker), "activePresentationDimStyle"))
+                app.worker.activePresentationDimStyle()
+            else
+                "";
+            const label = try formatWebFetchProgress(std.heap.c_allocator, progress, dim_style);
             defer std.heap.c_allocator.free(label);
             try pushToolLifecycle(app, .{ .progress = .{
                 .id = .{ .turn_id = turn_id, .call_id = call_id },
@@ -649,7 +693,12 @@ pub fn Runtime(comptime App: type) type {
 
             events: while (batch.claim()) |event| {
                 if (!first_event) switch (event) {
-                    .begin_prompt, .begin_prompt_with_skill_bindings, .begin_presented_prompt => {
+                    .begin_prompt,
+                    .begin_prompt_with_skill_bindings,
+                    .begin_prompt_styled,
+                    .begin_prompt_with_skill_bindings_styled,
+                    .begin_presented_prompt,
+                    => {
                         interrupted_segment = cancel_requested or
                             batchSegmentEndsInterrupted(batch.claimedAndRemaining());
                     },
@@ -716,6 +765,48 @@ pub fn Runtime(comptime App: type) type {
                             try handlers.write_user_prompt(handlers.ctx, begin.prompt);
                         }
                     },
+                    .begin_prompt_styled => |begin| {
+                        if (!try requireAssistantTextDrain(handlers)) {
+                            try retainClaimedEventAndSuffix(app, &batch, "assistant_text_drain_blocked");
+                            drain_owns_current = false;
+                            break :events;
+                        }
+                        resetStream(app, true);
+                        app.stream.active = true;
+                        app.stream.turn_started_ms = io_mod.milliTimestamp();
+                        app.shell.render_requests.request(.footer);
+                        if (handlers.write_user_prompt_styled) |write_styled_prompt| {
+                            try write_styled_prompt(handlers.ctx, begin.prompt, begin.styles);
+                        } else {
+                            try handlers.write_user_prompt(handlers.ctx, begin.prompt);
+                        }
+                    },
+                    .begin_prompt_with_skill_bindings_styled => |begin| {
+                        if (!try requireAssistantTextDrain(handlers)) {
+                            try retainClaimedEventAndSuffix(app, &batch, "assistant_text_drain_blocked");
+                            drain_owns_current = false;
+                            break :events;
+                        }
+                        resetStream(app, true);
+                        app.stream.active = true;
+                        app.stream.turn_started_ms = io_mod.milliTimestamp();
+                        app.shell.render_requests.request(.footer);
+                        if (handlers.write_user_prompt_with_skill_bindings_styled) |write_styled_bound_prompt| {
+                            try write_styled_bound_prompt(
+                                handlers.ctx,
+                                begin.prompt,
+                                begin.skill_bindings,
+                                begin.skill_display_spans,
+                                begin.styles,
+                            );
+                        } else if (handlers.write_user_prompt_styled) |write_styled_prompt| {
+                            try write_styled_prompt(handlers.ctx, begin.prompt, begin.styles);
+                        } else if (handlers.write_user_prompt_with_skill_bindings) |write_bound_prompt| {
+                            try write_bound_prompt(handlers.ctx, begin.prompt, begin.skill_bindings, begin.skill_display_spans);
+                        } else {
+                            try handlers.write_user_prompt(handlers.ctx, begin.prompt);
+                        }
+                    },
                     .begin_presented_prompt => |turn_id| {
                         if (!try requireAssistantTextDrain(handlers)) {
                             try retainClaimedEventAndSuffix(app, &batch, "assistant_text_drain_blocked");
@@ -742,6 +833,13 @@ pub fn Runtime(comptime App: type) type {
                         if (app.stream.active and app.stream.phase != .thinking) {
                             app.stream.phase = .thinking;
                             app.shell.render_requests.request(.footer);
+                        }
+                    },
+                    .append_user_feedback_styled => |feedback| {
+                        if (handlers.write_user_prompt_styled) |write_styled_prompt| {
+                            try write_styled_prompt(handlers.ctx, .{ .text = feedback.text }, feedback.styles);
+                        } else {
+                            try handlers.write_user_prompt(handlers.ctx, .{ .text = feedback.text });
                         }
                     },
                     .assistant_presentation => |presentation| {
@@ -772,6 +870,50 @@ pub fn Runtime(comptime App: type) type {
                             .thematic_rule => {
                                 drain_owns_current = false;
                                 try handlers.append_thematic_rule(handlers.ctx);
+                            },
+                        }
+                    },
+                    .assistant_presentation_styled => |styled| {
+                        const presentation = styled.presentation;
+                        if (presentation.requiresTextDrain() and !try requireAssistantTextDrain(handlers)) {
+                            try retainClaimedEventAndSuffix(app, &batch, "assistant_text_drain_blocked");
+                            drain_owns_current = false;
+                            break :events;
+                        }
+                        switch (presentation) {
+                            .text => |text| {
+                                try handlers.append_text(handlers.ctx, text);
+                                debug_trace.eventf(
+                                    "worker",
+                                    "assistant_chunk_applied",
+                                    .{},
+                                    "chunk_bytes={d}",
+                                    .{text.len},
+                                );
+                            },
+                            .table => |table| {
+                                drain_owns_current = false;
+                                if (handlers.append_table_styled) |append_styled_table| {
+                                    try append_styled_table(handlers.ctx, table, styled.styles);
+                                } else {
+                                    try handlers.append_table(handlers.ctx, table);
+                                }
+                            },
+                            .code_block => |block| {
+                                drain_owns_current = false;
+                                if (handlers.append_code_block_styled) |append_styled_code| {
+                                    try append_styled_code(handlers.ctx, block, styled.styles);
+                                } else {
+                                    try handlers.append_code_block(handlers.ctx, block);
+                                }
+                            },
+                            .thematic_rule => {
+                                drain_owns_current = false;
+                                if (handlers.append_thematic_rule_styled) |append_styled_rule| {
+                                    try append_styled_rule(handlers.ctx, styled.styles);
+                                } else {
+                                    try handlers.append_thematic_rule(handlers.ctx);
+                                }
                             },
                         }
                     },
@@ -1034,50 +1176,50 @@ pub fn Runtime(comptime App: type) type {
     };
 }
 
-fn formatWebSearchProgress(alloc: std.mem.Allocator, progress: types.WebSearchProgress) ![]u8 {
+fn formatWebSearchProgress(alloc: std.mem.Allocator, progress: types.WebSearchProgress, dim_style: []const u8) ![]u8 {
     var query_buf: [160]u8 = undefined;
     return switch (progress) {
         .query_started => |query| std.fmt.allocPrint(
             alloc,
             "● Searching\x1b[0m {s}{s}\x1b[0m",
-            .{ ui_render.dim_style, text_utils.clippedLabel(&query_buf, query, 120) },
+            .{ dim_style, text_utils.clippedLabel(&query_buf, query, 120) },
         ),
         .results_received => |entry| std.fmt.allocPrint(
             alloc,
             "● Found {d} result{s}\x1b[0m {s}{s}\x1b[0m",
-            .{ entry.result_count, if (entry.result_count == 1) "" else "s", ui_render.dim_style, text_utils.clippedLabel(&query_buf, entry.query, 120) },
+            .{ entry.result_count, if (entry.result_count == 1) "" else "s", dim_style, text_utils.clippedLabel(&query_buf, entry.query, 120) },
         ),
     };
 }
 
-fn formatWebFetchProgress(alloc: std.mem.Allocator, progress: types.WebFetchProgress) ![]u8 {
+fn formatWebFetchProgress(alloc: std.mem.Allocator, progress: types.WebFetchProgress, dim_style: []const u8) ![]u8 {
     var url_buf: [types.WebFetchCompletion.max_url_len]u8 = undefined;
     return switch (progress) {
         .fetching => |url| std.fmt.allocPrint(
             alloc,
             "● Fetching\x1b[0m {s}{s}\x1b[0m",
-            .{ ui_render.dim_style, text_utils.clippedLabel(&url_buf, url, 120) },
+            .{ dim_style, text_utils.clippedLabel(&url_buf, url, 120) },
         ),
         .converting => |url| std.fmt.allocPrint(
             alloc,
             "● Converting\x1b[0m {s}{s}\x1b[0m",
-            .{ ui_render.dim_style, text_utils.clippedLabel(&url_buf, url, 120) },
+            .{ dim_style, text_utils.clippedLabel(&url_buf, url, 120) },
         ),
     };
 }
 
 test "core.app_worker_runtime web progress labels keep the non-bold status style" {
     const alloc = std.testing.allocator;
-    const searching = try formatWebSearchProgress(alloc, .{ .query_started = @constCast("zig terminal") });
+    const searching = try formatWebSearchProgress(alloc, .{ .query_started = @constCast("zig terminal") }, "[DIM]");
     defer alloc.free(searching);
     const results = try formatWebSearchProgress(alloc, .{ .results_received = .{
         .query = @constCast("zig terminal"),
         .result_count = 2,
-    } });
+    } }, "[DIM]");
     defer alloc.free(results);
-    const fetching = try formatWebFetchProgress(alloc, .{ .fetching = @constCast("https://example.com") });
+    const fetching = try formatWebFetchProgress(alloc, .{ .fetching = @constCast("https://example.com") }, "[DIM]");
     defer alloc.free(fetching);
-    const converting = try formatWebFetchProgress(alloc, .{ .converting = @constCast("https://example.com") });
+    const converting = try formatWebFetchProgress(alloc, .{ .converting = @constCast("https://example.com") }, "[DIM]");
     defer alloc.free(converting);
     const cases = [_][]u8{
         searching,
@@ -1090,19 +1232,19 @@ test "core.app_worker_runtime web progress labels keep the non-bold status style
         try std.testing.expect(std.mem.find(u8, label, "\x1b[1m") == null);
     }
     try std.testing.expectEqualStrings(
-        "● Searching\x1b[0m \x1b[38;5;245mzig terminal\x1b[0m",
+        "● Searching\x1b[0m [DIM]zig terminal\x1b[0m",
         cases[0],
     );
     try std.testing.expectEqualStrings(
-        "● Found 2 results\x1b[0m \x1b[38;5;245mzig terminal\x1b[0m",
+        "● Found 2 results\x1b[0m [DIM]zig terminal\x1b[0m",
         cases[1],
     );
     try std.testing.expectEqualStrings(
-        "● Fetching\x1b[0m \x1b[38;5;245mhttps://example.com\x1b[0m",
+        "● Fetching\x1b[0m [DIM]https://example.com\x1b[0m",
         cases[2],
     );
     try std.testing.expectEqualStrings(
-        "● Converting\x1b[0m \x1b[38;5;245mhttps://example.com\x1b[0m",
+        "● Converting\x1b[0m [DIM]https://example.com\x1b[0m",
         cases[3],
     );
 }
@@ -1150,10 +1292,22 @@ const FakeWorker = struct {
     propagated_grants: usize = 0,
     reset_cancel_after_take_events: bool = false,
     admission_snapshot: worker_runtime.InteractiveAdmissionSnapshot = .open,
+    active_presentation: worker_runtime.PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
 
     fn deinit(self: *FakeWorker) void {
         for (self.events.items) |event| worker_runtime.freeWorkerEvent(std.heap.c_allocator, event);
         self.events.deinit(std.heap.c_allocator);
+    }
+
+    fn setActivePresentationStyles(
+        self: *FakeWorker,
+        presentation: worker_runtime.PresentationSnapshot,
+    ) void {
+        self.active_presentation = presentation;
+    }
+
+    fn activePresentationStyles(self: *FakeWorker) worker_runtime.PresentationSnapshot {
+        return self.active_presentation;
     }
 
     fn queuePreview(self: *FakeWorker) QueuePreview {
@@ -4075,6 +4229,48 @@ test "core.app_worker_runtime writes queued approval feedback after a tool termi
     try std.testing.expectEqual(@as(usize, 1), capture.user_count);
     try std.testing.expect(capture.saw_feedback);
     try std.testing.expect(capture.stream_remained_active);
+}
+
+test "queued styled feedback keeps its turn palette when live palette changes before drain" {
+    const Capture = struct {
+        theme: ?presentation_palette.PresentationTheme = null,
+        marker: ?[]const u8 = null,
+
+        fn fallback(_: *anyopaque, _: types.UserTurn) !void {
+            return error.TestUnexpectedFallback;
+        }
+
+        fn styled(
+            raw: *anyopaque,
+            _: types.UserTurn,
+            snapshot: worker_runtime.PresentationSnapshot,
+        ) !void {
+            const self: *@This() = @ptrCast(@alignCast(raw));
+            self.theme = snapshot.theme;
+            self.marker = snapshot.styles.user_marker;
+        }
+    };
+
+    var app = FakeApp.init(std.testing.allocator);
+    defer app.deinit();
+    const old_turn = presentation_palette.snapshot(false, .terminal, false);
+    try app.worker.pushEvent(std.heap.c_allocator, .{
+        .append_user_feedback_styled = .{
+            .text = try std.heap.c_allocator.dupe(u8, "old turn feedback"),
+            .styles = old_turn,
+        },
+    });
+    app.worker.setActivePresentationStyles(presentation_palette.snapshot(true, .fx, true));
+
+    var capture = Capture{};
+    var handlers = NoopBridge.handlers(&app);
+    handlers.ctx = @ptrCast(&capture);
+    handlers.write_user_prompt = Capture.fallback;
+    handlers.write_user_prompt_styled = Capture.styled;
+    try Runtime(FakeApp).tick(&app, handlers);
+
+    try std.testing.expectEqual(presentation_palette.PresentationTheme.terminal, capture.theme.?);
+    try std.testing.expectEqualStrings("\x1b[96m", capture.marker.?);
 }
 
 test "core.app_worker_runtime drains diff block through bridge handler" {

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -574,6 +574,7 @@ const AskContext = struct {
     auth_failure: ?auth_runtime.FailureSnapshot = null,
     output_mode: OutputMode = .raw,
     prompt_permissions: bool = false,
+    presentation_styles: agent_runtime.PresentationStyles = .{},
     presenter: ?*ask_presentation.Runtime = null,
     pending_tool_progress: std.ArrayList(PendingToolProgress) = .empty,
     deferred_tool_progress: std.ArrayList([]u8) = .empty,
@@ -972,6 +973,15 @@ const AskContext = struct {
         }
         var tc: tool_runtime.Context = .{
             .workspace_root = self.workspace_root,
+            .presentation_snapshot = self.presentation_styles.snapshot,
+            .presentation_dim_style = self.presentation_styles.dim,
+            .presentation_accent_style = self.presentation_styles.accent,
+            .presentation_inline_code_style = self.presentation_styles.inline_code,
+            .presentation_task_completed_style = self.presentation_styles.task_completed,
+            .presentation_diff_added_style = self.presentation_styles.diff_added,
+            .presentation_diff_removed_style = self.presentation_styles.diff_removed,
+            .presentation_diff_added_marker_style = self.presentation_styles.diff_added_marker,
+            .presentation_diff_removed_marker_style = self.presentation_styles.diff_removed_marker,
             .access_scope = self.workspace_access.scope(self.workspace_root),
             .ignored_list_entries = self.cfg.ignored_list_entries,
             .max_list_entries = self.cfg.max_list_entries,
@@ -1446,7 +1456,7 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     if (permission_override) |explicit| permission_mode = explicit;
 
     if (permission_mode == .yolo and !startup.yolo_acknowledged) {
-        try emitHeadlessYoloWarning(alloc, options);
+        try emitHeadlessYoloWarning(alloc, options, startup.color_palette);
     }
 
     for (startup.config_diagnostics) |diagnostic| {
@@ -1519,6 +1529,11 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
         }, options.output_mode == .terminal_no_color, startup.color_palette);
         ctx.presenter = &presenter.?;
     }
+    ctx.presentation_styles = askPresentationStyles(
+        if (presenter) |*value| value.presentationLight() else false,
+        startup.color_palette,
+        if (presenter) |*value| value.presentationTruecolor() else false,
+    );
     try ctx.configureNotifications(
         startup.notification_turn_end,
         startup.notification_attention_required,
@@ -1841,6 +1856,49 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     return result;
 }
 
+fn askPresentationStyles(
+    light: bool,
+    color_palette: presentation_palette.ColorPalette,
+    truecolor: bool,
+) agent_runtime.PresentationStyles {
+    const selected = presentation_palette.stylesForTerminal(light, color_palette, truecolor);
+    return .{
+        .dim = selected.dim,
+        .accent = selected.user_accent,
+        .inline_code = selected.inline_code,
+        .task_completed = selected.task_completed,
+        .diff_added = selected.diff_added,
+        .diff_removed = selected.diff_removed,
+        .diff_added_marker = selected.diff_added_marker,
+        .diff_removed_marker = selected.diff_removed_marker,
+        .snapshot = presentation_palette.snapshot(light, color_palette, truecolor),
+    };
+}
+
+test "fx ask presentation styles follow the detected terminal theme" {
+    const light = askPresentationStyles(true, .fx, true);
+    try std.testing.expectEqualStrings("\x1b[38;5;247m", light.dim);
+    try std.testing.expectEqualStrings("\x1b[38;5;238m", light.accent);
+    try std.testing.expectEqualStrings("\x1b[38;5;247m", light.inline_code);
+    try std.testing.expectEqualStrings("\x1b[38;5;238m", light.task_completed);
+
+    const dark = askPresentationStyles(false, .fx, true);
+    try std.testing.expect(!std.mem.eql(u8, light.inline_code, dark.inline_code));
+    try std.testing.expect(!std.mem.eql(u8, light.task_completed, dark.task_completed));
+
+    const terminal_light = askPresentationStyles(true, .terminal, true);
+    const terminal_dark = askPresentationStyles(false, .terminal, false);
+    try std.testing.expectEqualStrings("\x1b[90m", terminal_light.inline_code);
+    try std.testing.expectEqualStrings("\x1b[32m", terminal_light.task_completed);
+    try std.testing.expectEqualStrings(terminal_light.inline_code, terminal_dark.inline_code);
+    try std.testing.expectEqualStrings(terminal_light.task_completed, terminal_dark.task_completed);
+
+    const truecolor = askPresentationStyles(false, .fx, true);
+    const fallback = askPresentationStyles(false, .fx, false);
+    try std.testing.expectEqualStrings("\x1b[38;2;48;164;108m", truecolor.diff_added_marker);
+    try std.testing.expectEqualStrings("\x1b[38;5;71m", fallback.diff_added_marker);
+}
+
 fn takePromptRunResult(ctx: *AskContext, alloc: Allocator) !PromptRunResult {
     const assistant_output = try alloc.dupe(u8, ctx.assistant_output.items);
     errdefer alloc.free(assistant_output);
@@ -1993,6 +2051,11 @@ fn agentRuntimeDeps(ctx: *AskContext) agent_runtime.AgentRuntimeDeps {
         .report_usage = reportUsage,
         .usage = &ctx.session.usage,
         .usage_allocator = ctx.alloc,
+        .presentation_styles = ctx.presentation_styles,
+        .diff_marker_styles = .{
+            .added = ctx.presentation_styles.diff_added_marker,
+            .removed = ctx.presentation_styles.diff_removed_marker,
+        },
     };
 }
 
@@ -2441,7 +2504,7 @@ fn cliContextPermissionPromptAllowed(ctx: *const AskContext) bool {
     );
 }
 
-fn describeToolAction(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+fn describeToolAction(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, _: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
     return tool_presentation.formatPlainAction(arena, .{
         .tool_registry = ctx.toolRegistry(),
@@ -2463,7 +2526,7 @@ fn resolveToolActionDisplayTarget(raw_ctx: *anyopaque, arena: Allocator, call: T
     );
 }
 
-fn describeToolActionCompleted(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+fn describeToolActionCompleted(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, _: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
     return tool_presentation.formatPlainAction(arena, .{
         .tool_registry = ctx.toolRegistry(),
@@ -2474,7 +2537,7 @@ fn describeToolActionCompleted(raw_ctx: *anyopaque, arena: Allocator, call: Tool
     });
 }
 
-fn describeToolActionDenied(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+fn describeToolActionDenied(raw_ctx: *anyopaque, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, _: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
     const ctx: *AskContext = @ptrCast(@alignCast(raw_ctx));
     const action = try tool_presentation.formatPlainAction(arena, .{
         .tool_registry = ctx.toolRegistry(),
@@ -2579,6 +2642,7 @@ fn captureToolExecutionResult(
 fn publishCommittedFileHandoff(
     _: *anyopaque,
     _: file_mutation.CommittedFileHandoff,
+    _: agent_runtime.PresentationStyles,
 ) agent_runtime.SecondaryPublicationReport {
     return .{ .diff = .skipped, .tracker = .skipped };
 }
@@ -3655,9 +3719,13 @@ fn parseOptionsWithStdin(alloc: Allocator, args: []const [:0]const u8, stdin: St
     return opts;
 }
 
-fn emitHeadlessYoloWarning(alloc: Allocator, options: RunOptions) !void {
+fn emitHeadlessYoloWarning(
+    alloc: Allocator,
+    options: RunOptions,
+    color_palette: config_runtime.ColorPalette,
+) !void {
     if (options.color_enabled and options.deps.stderr_is_tty(options.deps.stderr_ctx)) {
-        const warning_style = presentation_palette.currentStyles().warning;
+        const warning_style = presentation_palette.styles(false, color_palette).warning;
         const warning = try std.fmt.allocPrint(
             alloc,
             "{s}{s}\x1b[0m\n",
@@ -4147,6 +4215,12 @@ fn testPresentKeyStartup(alloc: Allocator, _: oauth_transport.Provider, _: host.
 fn testMissingKeyAcknowledgedStartup(alloc: Allocator, transport: oauth_transport.Provider, secret_store: host.SecretStore, default_model: []const u8, default_agent_step_limit: usize) !app_lifecycle.StartupState {
     var state = try testMissingKeyStartup(alloc, transport, secret_store, default_model, default_agent_step_limit);
     state.yolo_acknowledged = true;
+    return state;
+}
+
+fn testMissingKeyTerminalPaletteStartup(alloc: Allocator, transport: oauth_transport.Provider, secret_store: host.SecretStore, default_model: []const u8, default_agent_step_limit: usize) !app_lifecycle.StartupState {
+    var state = try testMissingKeyStartup(alloc, transport, secret_store, default_model, default_agent_step_limit);
+    state.color_palette = .terminal;
     return state;
 }
 
@@ -5061,6 +5135,30 @@ test "fx ask ChatGPT route disables Gateway-backed auxiliary providers" {
     try std.testing.expect(tool_ctx.permission_reviewer_provider == null);
 }
 
+test "fx ask tool context carries the complete terminal presentation snapshot" {
+    const alloc = std.testing.allocator;
+    var stdout_capture = TestCapture{};
+    defer stdout_capture.deinit(alloc);
+    var stderr_capture = TestCapture{};
+    defer stderr_capture.deinit(alloc);
+    var ctx = AskContext.init(
+        alloc,
+        testConfig(),
+        testPromptRunDeps(&stdout_capture, &stderr_capture, testPresentKeyStartup),
+        "/tmp/workspace",
+    );
+    defer ctx.deinit();
+    ctx.presentation_styles = askPresentationStyles(false, .terminal, false);
+
+    const tool_ctx = ctx.toolContext();
+    try std.testing.expectEqual(
+        presentation_palette.PresentationTheme.terminal,
+        tool_ctx.presentation_snapshot.theme,
+    );
+    try std.testing.expectEqualStrings("\x1b[96m", tool_ctx.presentation_snapshot.styles.user_marker);
+    try std.testing.expectEqualStrings(ctx.presentation_styles.dim, tool_ctx.presentation_dim_style);
+}
+
 test "fx ask finalization fails every failed turn" {
     const cases = [_]struct {
         outcome: types.TurnPresentationOutcome,
@@ -5246,7 +5344,7 @@ test "headless yolo persistence is skipped when warning emission fails" {
         emitHeadlessYoloWarning(std.testing.allocator, .{
             .output_mode = .raw,
             .deps = deps,
-        }),
+        }, .fx),
     );
     try std.testing.expectEqual(@as(usize, 0), TestYoloPersistence.calls);
 }
@@ -5293,6 +5391,26 @@ test "headless yolo warning respects acknowledgment and no-color" {
         u8,
         stderr_capture.bytes.items,
         "\x1b[38;5;252m" ++ permissions.yolo_warning_text ++ "\x1b[0m\n",
+    ));
+
+    stderr_capture.bytes.clearRetainingCapacity();
+    var terminal_palette_deps = testPromptRunDeps(
+        &stdout_capture,
+        &stderr_capture,
+        testMissingKeyTerminalPaletteStartup,
+    );
+    terminal_palette_deps.stderr_is_tty = TestTty.yes;
+    terminal_palette_deps.persist_yolo_acknowledgment = TestYoloPersistence.persist;
+    _ = try runWithDeps(
+        alloc,
+        &.{ "--yolo", "hello" },
+        testConfig(),
+        terminal_palette_deps,
+    );
+    try std.testing.expect(std.mem.startsWith(
+        u8,
+        stderr_capture.bytes.items,
+        "\x1b[33m" ++ permissions.yolo_warning_text ++ "\x1b[0m\n",
     ));
 
     stderr_capture.bytes.clearRetainingCapacity();

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -21,6 +21,7 @@ const host = @import("../hosts/host.zig");
 const pathing = @import("../workspace/pathing.zig");
 const workspace_access = @import("../workspace/workspace_access.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const diff_mod = @import("../output/diff.zig");
 const file_mutation = @import("../tooling/file_mutation.zig");
 const gateway_error_format = @import("../shared/gateway_error_format.zig");
@@ -1512,10 +1513,10 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     ctx.permission_rules = try takeCorePermissionRules(alloc, &startup);
     ctx.context_enabled = startup.context_enabled;
     if (options.output_mode.isTerminal()) {
-        presenter = try ask_presentation.Runtime.init(alloc, .{
+        presenter = try ask_presentation.Runtime.initForPalette(alloc, .{
             .text = owned_prompt,
             .images = @constCast(options.images),
-        }, options.output_mode == .terminal_no_color);
+        }, options.output_mode == .terminal_no_color, startup.color_palette);
         ctx.presenter = &presenter.?;
     }
     try ctx.configureNotifications(
@@ -3656,9 +3657,16 @@ fn parseOptionsWithStdin(alloc: Allocator, args: []const [:0]const u8, stdin: St
 
 fn emitHeadlessYoloWarning(alloc: Allocator, options: RunOptions) !void {
     if (options.color_enabled and options.deps.stderr_is_tty(options.deps.stderr_ctx)) {
+        const warning_style = presentation_palette.currentStyles().warning;
+        const warning = try std.fmt.allocPrint(
+            alloc,
+            "{s}{s}\x1b[0m\n",
+            .{ warning_style, permissions.yolo_warning_text },
+        );
+        defer alloc.free(warning);
         try options.deps.write_stderr(
             options.deps.stderr_ctx,
-            "\x1b[38;5;252m" ++ permissions.yolo_warning_text ++ "\x1b[0m\n",
+            warning,
         );
     } else {
         try options.deps.write_stderr(options.deps.stderr_ctx, permissions.yolo_warning_text ++ "\n");

--- a/src/core/config/color_palette.zig
+++ b/src/core/config/color_palette.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+
+pub const ColorPalette = enum {
+    fx,
+    terminal,
+
+    pub fn parse(raw: []const u8) ?ColorPalette {
+        if (std.ascii.eqlIgnoreCase(raw, "fx")) return .fx;
+        if (std.ascii.eqlIgnoreCase(raw, "terminal")) return .terminal;
+        return null;
+    }
+
+    pub fn label(self: ColorPalette) []const u8 {
+        return @tagName(self);
+    }
+};
+
+test "color palette parsing is case insensitive and labels are canonical" {
+    try std.testing.expectEqual(ColorPalette.fx, ColorPalette.parse("fx").?);
+    try std.testing.expectEqual(ColorPalette.terminal, ColorPalette.parse("TERMINAL").?);
+    try std.testing.expectEqualStrings("fx", ColorPalette.fx.label());
+    try std.testing.expectEqualStrings("terminal", ColorPalette.terminal.label());
+    try std.testing.expect(ColorPalette.parse("system") == null);
+}

--- a/src/core/config/config_runtime.zig
+++ b/src/core/config/config_runtime.zig
@@ -11,6 +11,7 @@ const project_config = @import("../mcp/project_config.zig");
 const model_provider = @import("model_provider.zig");
 const model_preferences = @import("model_preferences.zig");
 const update_target = @import("../upgrade/update_target.zig");
+const color_palette = @import("color_palette.zig");
 pub const context_limits = @import("context_limits.zig");
 
 const Allocator = std.mem.Allocator;
@@ -39,6 +40,7 @@ pub const Paths = struct {
 pub const Settings = struct {
     models: model_preferences.Preferences = .{},
     provider: ?model_provider.ProviderId = null,
+    color_palette: ?color_palette.ColorPalette = null,
     permission_mode: ?types.PermissionMode = null,
     credential_source: ?types.CredentialSource = null,
     yolo_acknowledged: ?bool = null,
@@ -113,6 +115,7 @@ pub const ModelSource = ConfigSource;
 pub const ConfigSources = struct {
     models: ProviderModelSources = .{},
     provider: ConfigSource = .compiled_default,
+    color_palette: ConfigSource = .compiled_default,
     permission_mode: ConfigSource = .compiled_default,
     effort: ConfigSource = .compiled_default,
     fast_mode: ConfigSource = .compiled_default,
@@ -580,6 +583,7 @@ fn hasLegacyWorkspacePreferences(root: std.json.Value) bool {
             "slash_menu_categories",
             "collapse_tool_calls",
             "startup_scrollback",
+            "color_palette",
         }) |key| {
             if (workspace.contains(key)) return true;
         }
@@ -622,6 +626,7 @@ fn isProfileOnlySettingKey(key: []const u8) bool {
         "permission_mode",
         "credential_source",
         "yolo_acknowledged",
+        "color_palette",
         "permission",
         "additional_directories",
     }) |profile_key| {
@@ -652,6 +657,7 @@ fn updateConfigSources(sources: *ConfigSources, settings: Settings, source: Conf
         if (settings.models.get(provider) != null) sources.models.set(provider, source);
     }
     if (settings.provider != null) sources.provider = source;
+    if (settings.color_palette != null) sources.color_palette = source;
     if (settings.permission_mode != null) sources.permission_mode = source;
     if (settings.effort != null) sources.effort = source;
     if (settings.fast_mode != null) sources.fast_mode = source;
@@ -816,6 +822,7 @@ pub const AllowlistResetScope = settings_store.AllowlistResetScope;
 pub const PermissionMutation = settings_store.PermissionMutation;
 pub const PermissionScope = settings_store.PermissionScope;
 pub const StatuslineItem = settings_store.StatuslineItem;
+pub const ColorPalette = color_palette.ColorPalette;
 pub const UserSettingsPatch = settings_store.UserSettingsPatch;
 pub const WorkspaceDirectoryMutation = settings_store.WorkspaceDirectoryMutation;
 pub const CommitOutcome = settings_store.CommitOutcome;
@@ -1362,6 +1369,12 @@ fn parseProfileOnlyFields(
             return error.InvalidProviderValue;
     }
 
+    if (root.object.get("color_palette")) |color_palette_value| {
+        if (color_palette_value != .string) return error.InvalidColorPaletteType;
+        settings.color_palette = color_palette.ColorPalette.parse(color_palette_value.string) orelse
+            return error.InvalidColorPaletteValue;
+    }
+
     if (root.object.get("codex_model")) |model_value| {
         if (model_value != .string) return error.InvalidCodexModelType;
         settings_store.validateModel(model_value.string) catch return error.InvalidCodexModelValue;
@@ -1547,6 +1560,7 @@ fn parseProjectSafeFields(settings: *Settings, root: std.json.Value) !void {
 fn mergeSettings(target: *Settings, incoming: *Settings, alloc: Allocator) void {
     target.models.mergeOwnedFrom(alloc, &incoming.models);
     if (incoming.provider) |value| target.provider = value;
+    if (incoming.color_palette) |value| target.color_palette = value;
     if (incoming.permission_mode) |value| target.permission_mode = value;
     if (incoming.credential_source) |value| target.credential_source = value;
     if (incoming.yolo_acknowledged) |value| target.yolo_acknowledged = value;
@@ -3558,6 +3572,73 @@ test "all currently parsed read-only settings survive detailed loading" {
     try std.testing.expectEqual(false, parsed.context.?);
     try std.testing.expectEqual(false, parsed.auto_upgrade.?);
     try std.testing.expectEqual(update_target.Channel.dev, parsed.update_channel.?);
+}
+
+test "color palette settings parse, merge, and reject invalid values" {
+    var global = try parseSettingsJson(std.testing.allocator, "{\"color_palette\":\"fx\"}");
+    defer global.deinit(std.testing.allocator);
+    var workspace = try parseSettingsJson(std.testing.allocator, "{\"color_palette\":\"TERMINAL\"}");
+    defer workspace.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(color_palette.ColorPalette.fx, global.color_palette.?);
+    mergeSettings(&global, &workspace, std.testing.allocator);
+    try std.testing.expectEqual(color_palette.ColorPalette.terminal, global.color_palette.?);
+
+    try std.testing.expectError(
+        error.InvalidColorPaletteType,
+        parseSettingsJson(std.testing.allocator, "{\"color_palette\":true}"),
+    );
+    try std.testing.expectError(
+        error.InvalidColorPaletteValue,
+        parseSettingsJson(std.testing.allocator, "{\"color_palette\":\"unknown\"}"),
+    );
+}
+
+test "color palette settings track profile sources and ignore project values" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(std.testing.io, "home/.fx");
+    try tmp.dir.createDir(std.testing.io, "workspace", .default_dir);
+
+    const home_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "home");
+    defer std.testing.allocator.free(home_root);
+    const workspace_root = try io_mod.dirRealpathAlloc(std.testing.allocator, tmp.dir, "workspace");
+    defer std.testing.allocator.free(workspace_root);
+
+    try writeFixtureFile(tmp.dir, "home/.fx/settings.json", "{\"color_palette\":\"fx\"}\n");
+    try writeFixtureFile(tmp.dir, "workspace/.fx.json", "{\"color_palette\":123,\"max_agent_steps\":17}\n");
+
+    {
+        var detailed = try loadMergedSettingsDetailedFromHome(
+            std.testing.allocator,
+            home_root,
+            workspace_root,
+        );
+        defer detailed.deinit(std.testing.allocator);
+        try std.testing.expectEqual(color_palette.ColorPalette.fx, detailed.settings.color_palette.?);
+        try std.testing.expectEqual(ConfigSource.user_global, detailed.sources.color_palette);
+        try std.testing.expectEqual(@as(usize, 1), detailed.diagnostics.len);
+        try expectIgnoredProjectKey(detailed.diagnostics, "color_palette");
+        try std.testing.expectEqual(@as(usize, 17), detailed.settings.max_agent_steps.?);
+    }
+
+    const workspace_fixture = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"color_palette\":\"fx\",\"workspaces\":{{\"{s}\":{{\"color_palette\":\"terminal\"}}}}}}\n",
+        .{workspace_root},
+    );
+    defer std.testing.allocator.free(workspace_fixture);
+    try writeFixtureFile(tmp.dir, "home/.fx/settings.json", workspace_fixture);
+    try writeFixtureFile(tmp.dir, "workspace/.fx.json", "{}\n");
+
+    var detailed = try loadMergedSettingsDetailedFromHome(
+        std.testing.allocator,
+        home_root,
+        workspace_root,
+    );
+    defer detailed.deinit(std.testing.allocator);
+    try std.testing.expectEqual(color_palette.ColorPalette.terminal, detailed.settings.color_palette.?);
+    try std.testing.expectEqual(ConfigSource.user_workspace, detailed.sources.color_palette);
 }
 
 test "additional directories load only from the current profile workspace" {

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -260,7 +260,7 @@ const specs = [_]Spec{
     .{ .id = .statusline_workspace, .category = .interface, .label = "Status line workspace", .description = "Show the workspace path and Git branch in the status line" },
     .{ .id = .slash_menu_categories, .category = .interface, .label = "Slash menu categories", .description = "Show categories and skill sources in slash-command results" },
     .{ .id = .collapse_tool_calls, .category = .interface, .label = "Collapse tool calls", .description = "Show only a summary for each group of tool calls" },
-    .{ .id = .color_palette, .category = .interface, .label = "Color palette", .description = "Choose fx or terminal colors for the interface" },
+    .{ .id = .color_palette, .category = .interface, .label = "Color palette", .description = "Apply fx or terminal colors to live UI and new output" },
     .{ .id = .model, .category = .agent, .label = "Model", .description = "Choose the model used for new turns" },
     .{ .id = .effort, .category = .agent, .label = "Reasoning effort", .description = "Control how much reasoning the model applies" },
     .{ .id = .fast_mode, .category = .agent, .label = "Fast mode", .description = "Use faster inference when the model supports it" },
@@ -498,7 +498,7 @@ test "settings catalog exposes color palette choices" {
 
     try std.testing.expectEqual(SettingId.color_palette, item.id);
     try std.testing.expectEqualStrings("Color palette", item.label);
-    try std.testing.expectEqualStrings("Choose fx or terminal colors for the interface", item.description);
+    try std.testing.expectEqualStrings("Apply fx or terminal colors to live UI and new output", item.description);
     try std.testing.expectEqualStrings("fx", item.value);
     try std.testing.expectEqual(@as(usize, 2), optionCount(&snapshot, .color_palette));
     try std.testing.expectEqualStrings("fx", optionAt(&snapshot, .color_palette, 0).?);

--- a/src/core/config/settings_catalog.zig
+++ b/src/core/config/settings_catalog.zig
@@ -28,6 +28,7 @@ pub const SettingId = enum {
     statusline_workspace,
     slash_menu_categories,
     collapse_tool_calls,
+    color_palette,
     model,
     effort,
     fast_mode,
@@ -56,6 +57,7 @@ pub const Snapshot = struct {
     statusline_workspace: bool = false,
     slash_menu_categories: bool = true,
     collapse_tool_calls: bool = false,
+    color_palette: []const u8 = "fx",
     startup_scrollback: bool = true,
     prompt_history: bool = true,
     sound_level: []const u8 = "on",
@@ -71,6 +73,7 @@ pub const Snapshot = struct {
             .statusline_workspace => onOff(self.statusline_workspace),
             .slash_menu_categories => onOff(self.slash_menu_categories),
             .collapse_tool_calls => onOff(self.collapse_tool_calls),
+            .color_palette => self.color_palette,
             .startup_scrollback => onOff(self.startup_scrollback),
             .prompt_history => onOff(self.prompt_history),
             .sound_level => self.sound_level,
@@ -257,6 +260,7 @@ const specs = [_]Spec{
     .{ .id = .statusline_workspace, .category = .interface, .label = "Status line workspace", .description = "Show the workspace path and Git branch in the status line" },
     .{ .id = .slash_menu_categories, .category = .interface, .label = "Slash menu categories", .description = "Show categories and skill sources in slash-command results" },
     .{ .id = .collapse_tool_calls, .category = .interface, .label = "Collapse tool calls", .description = "Show only a summary for each group of tool calls" },
+    .{ .id = .color_palette, .category = .interface, .label = "Color palette", .description = "Choose fx or terminal colors for the interface" },
     .{ .id = .model, .category = .agent, .label = "Model", .description = "Choose the model used for new turns" },
     .{ .id = .effort, .category = .agent, .label = "Reasoning effort", .description = "Control how much reasoning the model applies" },
     .{ .id = .fast_mode, .category = .agent, .label = "Fast mode", .description = "Use faster inference when the model supports it" },
@@ -269,6 +273,7 @@ const specs = [_]Spec{
 const on_off_options = [_][]const u8{ "off", "on" };
 const permission_options = [_][]const u8{ "ask", "auto", "yolo" };
 const sound_level_options = [_][]const u8{ "off", "on", "max" };
+const color_palette_options = [_][]const u8{ "fx", "terminal" };
 
 pub fn filteredCount(snapshot: Snapshot, category: Category, query: []const u8) usize {
     var count: usize = 0;
@@ -375,6 +380,7 @@ fn staticOptionsFor(id: SettingId) []const []const u8 {
         .startup_scrollback,
         .prompt_history,
         => &on_off_options,
+        .color_palette => &color_palette_options,
         .sound_level => &sound_level_options,
         .permission_mode => &permission_options,
     };
@@ -430,8 +436,8 @@ test "settings catalog projects grouped searchable preferences" {
         .sound_level = "on",
     };
 
-    try std.testing.expectEqual(@as(usize, 12), filteredCount(snapshot, .all, ""));
-    try std.testing.expectEqual(@as(usize, 5), filteredCount(snapshot, .interface, ""));
+    try std.testing.expectEqual(@as(usize, 13), filteredCount(snapshot, .all, ""));
+    try std.testing.expectEqual(@as(usize, 6), filteredCount(snapshot, .interface, ""));
     try std.testing.expectEqual(@as(usize, 4), filteredCount(snapshot, .agent, ""));
     try std.testing.expectEqual(@as(usize, 1), filteredCount(snapshot, .notifications, ""));
     try std.testing.expectEqual(@as(usize, 2), filteredCount(snapshot, .advanced, ""));
@@ -484,6 +490,23 @@ test "settings catalog exposes collapse tool calls as an interface toggle" {
     const collapse = changeAt(&expanded, .collapse_tool_calls, 1).?;
     try std.testing.expectEqual(SettingId.collapse_tool_calls, collapse.setting);
     try std.testing.expectEqualStrings("on", collapse.value);
+}
+
+test "settings catalog exposes color palette choices" {
+    const snapshot: Snapshot = .{};
+    const item = itemAt(snapshot, .interface, "color palette", 0).?;
+
+    try std.testing.expectEqual(SettingId.color_palette, item.id);
+    try std.testing.expectEqualStrings("Color palette", item.label);
+    try std.testing.expectEqualStrings("Choose fx or terminal colors for the interface", item.description);
+    try std.testing.expectEqualStrings("fx", item.value);
+    try std.testing.expectEqual(@as(usize, 2), optionCount(&snapshot, .color_palette));
+    try std.testing.expectEqualStrings("fx", optionAt(&snapshot, .color_palette, 0).?);
+    try std.testing.expectEqualStrings("terminal", optionAt(&snapshot, .color_palette, 1).?);
+
+    const terminal = changeAt(&snapshot, .color_palette, 1).?;
+    try std.testing.expectEqual(SettingId.color_palette, terminal.setting);
+    try std.testing.expectEqualStrings("terminal", terminal.value);
 }
 
 test "settings catalog exposes slash menu categories as an interface toggle" {

--- a/src/core/config/settings_store.zig
+++ b/src/core/config/settings_store.zig
@@ -10,6 +10,7 @@ const model_provider = @import("model_provider.zig");
 const workspace_access = @import("../workspace/workspace_access.zig");
 const sort_utils = @import("../shared/sort_utils.zig");
 const update_target = @import("../upgrade/update_target.zig");
+const color_palette = @import("color_palette.zig");
 
 const Allocator = std.mem.Allocator;
 const max_settings_bytes: usize = 64 * 1024;
@@ -93,6 +94,7 @@ pub const ProjectMcpMutation = struct {
 pub const UserSettingsPatch = struct {
     model_preference: ?ModelPreferencePatch = null,
     provider: ?model_provider.ProviderId = null,
+    color_palette: ?color_palette.ColorPalette = null,
     permission_mode: ?types.PermissionMode = null,
     credential_source: ?types.CredentialSource = null,
     /// Removes the key entirely so resolution returns to plain precedence.
@@ -114,6 +116,7 @@ pub const UserSettingsPatch = struct {
     fn isEmpty(self: UserSettingsPatch) bool {
         return self.model_preference == null and
             self.provider == null and
+            self.color_palette == null and
             self.permission_mode == null and
             self.credential_source == null and
             !self.clear_credential_source and
@@ -210,6 +213,7 @@ const PatchApplication = struct {
 
 const UserPreferenceField = enum(u4) {
     model,
+    color_palette,
     permission_mode,
     effort,
     fast_mode,
@@ -228,6 +232,7 @@ const UserPreferenceField = enum(u4) {
     fn snapshotName(self: UserPreferenceField) []const u8 {
         return switch (self) {
             .model => "settings.json.preference-migration.model.json",
+            .color_palette => "settings.json.preference-migration.color_palette.json",
             .permission_mode => "settings.json.preference-migration.permission_mode.json",
             .effort => "settings.json.preference-migration.effort.json",
             .fast_mode => "settings.json.preference-migration.fast_mode.json",
@@ -244,6 +249,7 @@ const UserPreferenceField = enum(u4) {
 
 const user_preference_fields = [_]UserPreferenceField{
     .model,
+    .color_palette,
     .permission_mode,
     .effort,
     .fast_mode,
@@ -933,6 +939,18 @@ test "collapse tool calls user patch writes the profile preference" {
     try std.testing.expect(root.object.get("collapse_tool_calls").?.bool);
 }
 
+test "color palette user patch writes the profile preference" {
+    const alloc = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    var root = try std.json.parseFromSlice(std.json.Value, arena.allocator(), "{}", .{});
+    defer root.deinit();
+
+    const application = try applyUserPatchToRoot(arena.allocator(), &root.value, .{ .color_palette = .terminal });
+    try std.testing.expect(application.changed);
+    try std.testing.expectEqualStrings("terminal", root.value.object.get("color_palette").?.string);
+}
+
 test "provider patch writes one bounded provider model collection" {
     const alloc = std.testing.allocator;
     var arena = std.heap.ArenaAllocator.init(alloc);
@@ -1011,6 +1029,7 @@ fn applyUserPatchToRoot(
         application.changed = try putModelPreference(arena, &root.object, preference) or application.changed;
     }
     if (patch.provider) |value| application.changed = try putString(arena, &root.object, "provider", @tagName(value)) or application.changed;
+    if (patch.color_palette) |value| application.changed = try putString(arena, &root.object, "color_palette", value.label()) or application.changed;
     if (patch.permission_mode) |value| application.changed = try putString(arena, &root.object, "permission_mode", @tagName(value)) or application.changed;
     if (patch.credential_source) |value| application.changed = try putString(arena, &root.object, "credential_source", @tagName(value)) or application.changed;
     if (patch.clear_credential_source and root.object.contains("credential_source")) {
@@ -1123,6 +1142,13 @@ fn cleanupLegacyWorkspacePreferences(
             "model",
             .model,
             patch.model_preference != null and patch.model_preference.?.provider == .gateway,
+            application,
+        );
+        removeLegacyLeaf(
+            &entry.value_ptr.object,
+            "color_palette",
+            .color_palette,
+            patch.color_palette != null,
             application,
         );
         removeLegacyLeaf(
@@ -1829,6 +1855,11 @@ fn validateKnownSettingsObject(
             return error.InvalidSettingsFormat;
         }
     }
+    if (object.get("color_palette")) |value| {
+        if (value != .string or color_palette.ColorPalette.parse(value.string) == null) {
+            return error.InvalidSettingsFormat;
+        }
+    }
     if (object.get("codex_model")) |value| {
         if (value != .string) return error.InvalidSettingsFormat;
         try validateModel(value.string);
@@ -2122,6 +2153,28 @@ test "user patch writes user preferences at top level" {
     try std.testing.expect(std.mem.find(u8, bytes, "\"notifications\":{\"turn_end\":true,\"attention_required\":false}") != null);
     try std.testing.expect(std.mem.find(u8, bytes, "\"future\":{\"nested\":7}") != null);
     try std.testing.expect(std.mem.find(u8, bytes, "\"workspaces\"") == null);
+}
+
+test "color palette user patch persists the canonical global value" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try writeStoreFixture(tmp.dir, "home/.fx/settings.json", "{\"future\":true}\n");
+
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    var store = try Store.initFromHome(alloc, home, .writable);
+    defer store.deinit(alloc);
+
+    var outcome = try store.applyUserPatch(alloc, .{ .color_palette = .terminal });
+    defer outcome.deinit(alloc);
+    try std.testing.expect(outcome == .committed);
+
+    const bytes = try store.readPrimaryForTest(alloc);
+    defer alloc.free(bytes);
+    try std.testing.expect(std.mem.find(u8, bytes, "\"color_palette\":\"terminal\"") != null);
+    try std.testing.expect(std.mem.find(u8, bytes, "\"future\":true") != null);
 }
 
 test "user patch retires presentation settings without rejecting their values" {
@@ -3017,6 +3070,46 @@ test "startup scrollback user patch removes matching legacy workspace value" {
     try std.testing.expect(outcome == .committed);
     try std.testing.expectEqual(@as(usize, 1), outcome.committed.cleanup.fields_removed);
     try std.testing.expectEqual(@as(usize, 1), outcome.committed.cleanup.workspaces_changed);
+}
+
+test "color palette user patch removes matching legacy workspace value" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io_mod.getIo(), "home/.fx");
+    try tmp.dir.createDirPath(io_mod.getIo(), "workspace");
+    const home = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "home");
+    defer alloc.free(home);
+    const workspace = try io_mod.dirRealpathAlloc(alloc, tmp.dir, "workspace");
+    defer alloc.free(workspace);
+
+    const fixture = try std.fmt.allocPrint(
+        alloc,
+        "{{\"color_palette\":\"fx\",\"workspaces\":{{\"{s}\":{{\"color_palette\":\"terminal\",\"future\":8}}}}}}\n",
+        .{workspace},
+    );
+    defer alloc.free(fixture);
+    try writeStoreFixture(tmp.dir, "home/.fx/settings.json", fixture);
+
+    var store = try Store.initFromHome(alloc, home, .writable);
+    defer store.deinit(alloc);
+    var outcome = try store.applyUserPatch(alloc, .{ .color_palette = .terminal });
+    defer outcome.deinit(alloc);
+
+    try std.testing.expect(outcome == .committed);
+    try std.testing.expectEqual(@as(usize, 1), outcome.committed.cleanup.fields_removed);
+    try std.testing.expectEqual(@as(usize, 1), outcome.committed.cleanup.workspaces_changed);
+    try std.testing.expectEqual(@as(usize, 1), outcome.committed.cleanup.recovery_paths.len);
+
+    const bytes = try store.readPrimaryForTest(alloc);
+    defer alloc.free(bytes);
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, bytes, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("terminal", parsed.value.object.get("color_palette").?.string);
+    const workspaces = parsed.value.object.get("workspaces").?.object;
+    const workspace_value = workspaces.get(workspace).?.object;
+    try std.testing.expect(workspace_value.get("color_palette") == null);
+    try std.testing.expectEqual(@as(i64, 8), workspace_value.get("future").?.integer);
 }
 
 test "unrelated user patch preserves inert output level values" {

--- a/src/core/output/full_transcript_page.zig
+++ b/src/core/output/full_transcript_page.zig
@@ -11,6 +11,10 @@ pub const Request = struct {
     content_revision: u64,
     cols: u16,
     anchor: Anchor,
+    /// Presentation generation is part of the page identity.  A page built
+    /// before a palette/presentation-policy switch must never become visible
+    /// after that switch, even when its content, width, and anchor match.
+    presentation_generation: u64 = 0,
 };
 
 pub const SourceRange = struct {
@@ -41,11 +45,14 @@ pub fn sourceRange(request: Request, total_entries: usize) SourceRange {
 pub fn sameRequest(lhs: Request, rhs: Request) bool {
     return lhs.content_revision == rhs.content_revision and
         lhs.cols == rhs.cols and
+        lhs.presentation_generation == rhs.presentation_generation and
         std.meta.eql(lhs.anchor, rhs.anchor);
 }
 
 pub fn sameSurface(lhs: Request, rhs: Request) bool {
-    return lhs.cols == rhs.cols and std.meta.eql(lhs.anchor, rhs.anchor);
+    return lhs.cols == rhs.cols and
+        lhs.presentation_generation == rhs.presentation_generation and
+        std.meta.eql(lhs.anchor, rhs.anchor);
 }
 
 pub fn previousAnchor(range: SourceRange) ?Anchor {
@@ -88,16 +95,18 @@ test "full transcript page range centers an entry without crossing bounds" {
     try std.testing.expectEqual(SourceRange{ .start = 0, .end = 3 }, head);
 }
 
-test "full transcript page request identity includes revision width and anchor" {
+test "full transcript page request identity includes revision width anchor and presentation generation" {
     const request = Request{
         .content_revision = 73,
         .cols = 96,
         .anchor = .tail,
+        .presentation_generation = 5,
     };
     try std.testing.expect(sameRequest(request, .{
         .content_revision = 73,
         .cols = 96,
         .anchor = .tail,
+        .presentation_generation = 5,
     }));
     try std.testing.expect(!sameRequest(request, .{
         .content_revision = 72,
@@ -114,13 +123,20 @@ test "full transcript page request identity includes revision width and anchor" 
         .cols = 96,
         .anchor = .{ .entry_index = 42 },
     }));
+    try std.testing.expect(!sameRequest(request, .{
+        .content_revision = 73,
+        .cols = 96,
+        .anchor = .tail,
+        .presentation_generation = 4,
+    }));
 }
 
-test "full transcript page surface ignores revisions but not width or anchor" {
+test "full transcript page surface ignores revisions but not width anchor or presentation generation" {
     const original = Request{
         .content_revision = 73,
         .cols = 96,
         .anchor = .tail,
+        .presentation_generation = 5,
     };
     var changed = original;
     changed.content_revision = 74;
@@ -130,6 +146,9 @@ test "full transcript page surface ignores revisions but not width or anchor" {
     try std.testing.expect(!sameSurface(original, changed));
     changed.cols = original.cols;
     changed.anchor = .{ .entry_index = 42 };
+    try std.testing.expect(!sameSurface(original, changed));
+    changed.anchor = original.anchor;
+    changed.presentation_generation = original.presentation_generation - 1;
     try std.testing.expect(!sameSurface(original, changed));
 }
 

--- a/src/core/shared/presentation_palette.zig
+++ b/src/core/shared/presentation_palette.zig
@@ -38,6 +38,20 @@ pub const Styles = struct {
     code_comment: []const u8,
 };
 
+pub const PresentationTheme = enum {
+    dark,
+    light,
+    terminal,
+};
+
+/// Immutable presentation inputs captured at a worker/event boundary.  The
+/// full role set is intentional: UI-side semantic event handlers must not
+/// consult mutable renderer globals after a palette switch.
+pub const PresentationSnapshot = struct {
+    styles: Styles,
+    theme: PresentationTheme,
+};
+
 // .fx is the existing product palette. Keep these bytes in one place, but do
 // not normalize or otherwise rewrite them: retained transcript fixtures and
 // downstream integrations depend on their exact historical representation.
@@ -126,8 +140,7 @@ const terminal: Styles = .{
     .permission_auto = "\x1b[36m",
     .diff_added_marker = "\x1b[32m",
     .diff_removed_marker = "\x1b[31m",
-    // Inline code and comments share the muted ANSI slot so the same raw
-    // token can be retinted safely in retained assistant text.
+    // Inline code and comments share the terminal's muted ANSI slot.
     .inline_code = "\x1b[90m",
     .task_completed = "\x1b[32m",
     .user_marker = "\x1b[96m",
@@ -138,9 +151,6 @@ const terminal: Styles = .{
     .code_comment = "\x1b[90m",
 };
 
-var active_light: bool = false;
-var active_palette: ColorPalette = .fx;
-
 pub fn styles(light: bool, palette: ColorPalette) Styles {
     return switch (palette) {
         .fx => if (light) fx_light else fx_dark,
@@ -148,21 +158,45 @@ pub fn styles(light: bool, palette: ColorPalette) Styles {
     };
 }
 
-pub fn setActive(light: bool, palette: ColorPalette) void {
-    active_light = light;
-    active_palette = palette;
+const diff_added_marker_truecolor = "\x1b[38;2;48;164;108m";
+const diff_removed_marker_truecolor = "\x1b[38;2;229;72;77m";
+
+/// Resolve presentation styles for a concrete terminal capability snapshot.
+/// Terminal palettes always use ANSI slots; the built-in palette preserves
+/// its historical truecolor diff markers where supported.
+pub fn stylesForTerminal(light: bool, palette: ColorPalette, truecolor: bool) Styles {
+    var resolved = styles(light, palette);
+    if (palette == .fx and truecolor) {
+        resolved.diff_added_marker = diff_added_marker_truecolor;
+        resolved.diff_removed_marker = diff_removed_marker_truecolor;
+    }
+    return resolved;
 }
 
-pub fn currentStyles() Styles {
-    return styles(active_light, active_palette);
+pub fn snapshot(
+    light: bool,
+    palette: ColorPalette,
+    truecolor: bool,
+) PresentationSnapshot {
+    return .{
+        .styles = stylesForTerminal(light, palette, truecolor),
+        .theme = switch (palette) {
+            .terminal => .terminal,
+            .fx => if (light) .light else .dark,
+        },
+    };
 }
 
-pub fn currentPalette() ColorPalette {
-    return active_palette;
-}
-
-pub fn isFx(palette: ColorPalette) bool {
-    return palette == .fx;
+/// Reconstruct the canonical static snapshot for a retained presentation
+/// theme. Retained prompt and code entries need only the theme identity: the
+/// truecolor capability changes diff markers, which those entry kinds do not
+/// use.
+pub fn snapshotForTheme(theme: PresentationTheme) PresentationSnapshot {
+    return switch (theme) {
+        .dark => snapshot(false, .fx, false),
+        .light => snapshot(true, .fx, false),
+        .terminal => snapshot(false, .terminal, false),
+    };
 }
 
 test "terminal presentation palette uses defaults and ANSI-16 slots" {
@@ -171,4 +205,31 @@ test "terminal presentation palette uses defaults and ANSI-16 slots" {
     try std.testing.expect(std.mem.startsWith(u8, palette.approval_active, "\x1b[39m\x1b[49m"));
     try std.testing.expect(std.mem.indexOf(u8, palette.green, "38;5;") == null);
     try std.testing.expect(std.mem.indexOf(u8, palette.green, "38;2;") == null);
+}
+
+test "every terminal presentation role stays portable and ignores truecolor" {
+    inline for ([_]bool{ false, true }) |light| {
+        const fallback = stylesForTerminal(light, .terminal, false);
+        const capable = stylesForTerminal(light, .terminal, true);
+        inline for (@typeInfo(Styles).@"struct".fields) |field| {
+            const fallback_value = @field(fallback, field.name);
+            const capable_value = @field(capable, field.name);
+            try std.testing.expectEqualStrings(fallback_value, capable_value);
+            try std.testing.expect(std.mem.indexOf(u8, fallback_value, "38;5;") == null);
+            try std.testing.expect(std.mem.indexOf(u8, fallback_value, "38;2;") == null);
+            try std.testing.expect(std.mem.indexOf(u8, fallback_value, "48;5;") == null);
+            try std.testing.expect(std.mem.indexOf(u8, fallback_value, "48;2;") == null);
+        }
+    }
+}
+
+test "terminal capability only changes built-in diff markers" {
+    const fx = stylesForTerminal(false, .fx, true);
+    try std.testing.expectEqualStrings(diff_added_marker_truecolor, fx.diff_added_marker);
+    try std.testing.expectEqualStrings(diff_removed_marker_truecolor, fx.diff_removed_marker);
+
+    const terminal_truecolor = stylesForTerminal(false, .terminal, true);
+    const terminal_fallback = stylesForTerminal(false, .terminal, false);
+    try std.testing.expectEqualStrings(terminal_fallback.diff_added_marker, terminal_truecolor.diff_added_marker);
+    try std.testing.expectEqualStrings(terminal_fallback.diff_removed_marker, terminal_truecolor.diff_removed_marker);
 }

--- a/src/core/shared/presentation_palette.zig
+++ b/src/core/shared/presentation_palette.zig
@@ -1,0 +1,174 @@
+const std = @import("std");
+const color_palette = @import("../config/color_palette.zig");
+
+/// The configured family of colors used by fx-owned presentation.
+///
+/// This module deliberately contains only static escape strings.  It is used
+/// by both core markdown presentation and the UI renderer, so neither side
+/// needs to import the other to agree on the palette's wire format.
+pub const ColorPalette = color_palette.ColorPalette;
+
+pub const Styles = struct {
+    divider: []const u8,
+    hint: []const u8,
+    statusline: []const u8,
+    tag: []const u8,
+    subtitle: []const u8,
+    system_notice_label: []const u8,
+    system_notice_text: []const u8,
+    dim: []const u8,
+    warning: []const u8,
+    green: []const u8,
+    red: []const u8,
+    diff_added: []const u8,
+    diff_removed: []const u8,
+    approval_active: []const u8,
+    approval_inactive: []const u8,
+    selected_completion: []const u8,
+    permission_auto: []const u8,
+    diff_added_marker: []const u8,
+    diff_removed_marker: []const u8,
+    inline_code: []const u8,
+    task_completed: []const u8,
+    user_marker: []const u8,
+    user_accent: []const u8,
+    code_keyword: []const u8,
+    code_string: []const u8,
+    code_number: []const u8,
+    code_comment: []const u8,
+};
+
+// .fx is the existing product palette. Keep these bytes in one place, but do
+// not normalize or otherwise rewrite them: retained transcript fixtures and
+// downstream integrations depend on their exact historical representation.
+const fx_dark: Styles = .{
+    .divider = "\x1b[38;5;240m",
+    .hint = "\x1b[38;5;255m",
+    .statusline = "\x1b[38;5;245m",
+    .tag = "\x1b[1;38;5;255m",
+    .subtitle = "\x1b[1;38;5;255m",
+    .system_notice_label = "\x1b[1;38;5;252m",
+    .system_notice_text = "\x1b[38;5;250m",
+    .dim = "\x1b[38;5;245m",
+    .warning = "\x1b[38;5;252m",
+    .green = "\x1b[38;5;252m",
+    .red = "\x1b[38;5;252m",
+    .diff_added = "\x1b[38;5;252m",
+    .diff_removed = "\x1b[38;5;252m",
+    .approval_active = "\x1b[48;5;255m\x1b[38;5;235m\x1b[1m",
+    .approval_inactive = "\x1b[48;5;239m\x1b[38;5;255m",
+    .selected_completion = "\x1b[1;38;5;255m",
+    .permission_auto = "\x1b[38;5;252m",
+    .diff_added_marker = "\x1b[38;5;71m",
+    .diff_removed_marker = "\x1b[38;5;167m",
+    .inline_code = "\x1b[38;5;245m",
+    .task_completed = "\x1b[38;5;252m",
+    .user_marker = "\x1b[38;5;255m",
+    .user_accent = "\x1b[38;5;252m",
+    .code_keyword = "\x1b[38;5;252m",
+    .code_string = "\x1b[38;5;250m",
+    .code_number = "\x1b[38;5;250m",
+    .code_comment = "\x1b[38;5;245m",
+};
+
+const fx_light: Styles = .{
+    .divider = "\x1b[38;5;250m",
+    .hint = "\x1b[38;5;235m",
+    .statusline = "\x1b[38;5;241m",
+    .tag = "\x1b[1;38;5;235m",
+    .subtitle = "\x1b[1;38;5;235m",
+    .system_notice_label = "\x1b[1;38;5;238m",
+    .system_notice_text = "\x1b[38;5;241m",
+    .dim = "\x1b[38;5;247m",
+    .warning = "\x1b[38;5;238m",
+    .green = "\x1b[38;5;238m",
+    .red = "\x1b[38;5;238m",
+    .diff_added = "\x1b[38;5;238m",
+    .diff_removed = "\x1b[38;5;238m",
+    .approval_active = "\x1b[48;5;236m\x1b[38;5;255m\x1b[1m",
+    .approval_inactive = "\x1b[48;5;251m\x1b[38;5;237m",
+    .selected_completion = "\x1b[1;38;5;235m",
+    .permission_auto = "\x1b[38;5;238m",
+    .diff_added_marker = "\x1b[38;5;71m",
+    .diff_removed_marker = "\x1b[38;5;167m",
+    .inline_code = "\x1b[38;5;247m",
+    .task_completed = "\x1b[38;5;238m",
+    .user_marker = "\x1b[38;5;235m",
+    .user_accent = "\x1b[38;5;238m",
+    .code_keyword = "\x1b[38;5;238m",
+    .code_string = "\x1b[38;5;241m",
+    .code_number = "\x1b[38;5;241m",
+    .code_comment = "\x1b[38;5;243m",
+};
+
+// The terminal palette intentionally avoids 256-color and truecolor queries.
+// SGR 39/49 return to the terminal's configured default foreground/background;
+// the remaining roles use the portable ANSI-16 slots.
+const terminal: Styles = .{
+    .divider = "\x1b[90m",
+    .hint = "\x1b[90m",
+    .statusline = "\x1b[90m",
+    .tag = "\x1b[1m",
+    .subtitle = "\x1b[1m",
+    .system_notice_label = "\x1b[1m",
+    .system_notice_text = "\x1b[39m",
+    .dim = "\x1b[90m",
+    .warning = "\x1b[33m",
+    .green = "\x1b[32m",
+    .red = "\x1b[31m",
+    .diff_added = "\x1b[32m",
+    .diff_removed = "\x1b[31m",
+    // Establish terminal defaults before reverse video so the button does
+    // not inherit an arbitrary preceding indexed color.
+    .approval_active = "\x1b[39m\x1b[49m\x1b[7m\x1b[1m",
+    .approval_inactive = "\x1b[39m\x1b[49m\x1b[90m",
+    .selected_completion = "\x1b[1m",
+    .permission_auto = "\x1b[36m",
+    .diff_added_marker = "\x1b[32m",
+    .diff_removed_marker = "\x1b[31m",
+    // Inline code and comments share the muted ANSI slot so the same raw
+    // token can be retinted safely in retained assistant text.
+    .inline_code = "\x1b[90m",
+    .task_completed = "\x1b[32m",
+    .user_marker = "\x1b[96m",
+    .user_accent = "\x1b[36m",
+    .code_keyword = "\x1b[34m",
+    .code_string = "\x1b[32m",
+    .code_number = "\x1b[36m",
+    .code_comment = "\x1b[90m",
+};
+
+var active_light: bool = false;
+var active_palette: ColorPalette = .fx;
+
+pub fn styles(light: bool, palette: ColorPalette) Styles {
+    return switch (palette) {
+        .fx => if (light) fx_light else fx_dark,
+        .terminal => terminal,
+    };
+}
+
+pub fn setActive(light: bool, palette: ColorPalette) void {
+    active_light = light;
+    active_palette = palette;
+}
+
+pub fn currentStyles() Styles {
+    return styles(active_light, active_palette);
+}
+
+pub fn currentPalette() ColorPalette {
+    return active_palette;
+}
+
+pub fn isFx(palette: ColorPalette) bool {
+    return palette == .fx;
+}
+
+test "terminal presentation palette uses defaults and ANSI-16 slots" {
+    const palette = styles(false, .terminal);
+    try std.testing.expectEqualStrings("\x1b[39m", palette.system_notice_text);
+    try std.testing.expect(std.mem.startsWith(u8, palette.approval_active, "\x1b[39m\x1b[49m"));
+    try std.testing.expect(std.mem.indexOf(u8, palette.green, "38;5;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, palette.green, "38;2;") == null);
+}

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const display_width = @import("../shared/display_width.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const list_window = @import("../shared/list_window.zig");
 const mod_registry = @import("../mods/registry.zig");
 
@@ -1404,7 +1405,10 @@ fn styleStart(style: HelpStyle, role: HelpRole) []const u8 {
         .brand => "\x1b[1m",
         .heading, .label => "\x1b[1m",
         .syntax => "\x1b[39m",
-        .muted => "\x1b[38;5;243m",
+        .muted => if (presentation_palette.currentPalette() == .terminal)
+            "\x1b[90m"
+        else
+            "\x1b[38;5;243m",
         .link => "\x1b[4m",
     };
 }

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const display_width = @import("../shared/display_width.zig");
-const presentation_palette = @import("../shared/presentation_palette.zig");
 const list_window = @import("../shared/list_window.zig");
 const mod_registry = @import("../mods/registry.zig");
 
@@ -252,9 +251,14 @@ pub const HelpMenu = struct {
 
 pub const top_level_help_default_width: usize = 80;
 
-pub const HelpStyle = enum {
-    plain,
-    ansi,
+pub const HelpStyle = struct {
+    enabled: bool = false,
+    muted: []const u8 = "",
+
+    pub const plain: HelpStyle = .{};
+    pub const ansi: HelpStyle = ansi_fx;
+    pub const ansi_fx: HelpStyle = .{ .enabled = true, .muted = "\x1b[38;5;243m" };
+    pub const ansi_terminal: HelpStyle = .{ .enabled = true, .muted = "\x1b[90m" };
 };
 
 const HelpRole = enum {
@@ -1400,21 +1404,18 @@ fn writeStyleEnd(writer: *std.Io.Writer, style: HelpStyle) !void {
 }
 
 fn styleStart(style: HelpStyle, role: HelpRole) []const u8 {
-    if (style == .plain) return "";
+    if (!style.enabled) return "";
     return switch (role) {
         .brand => "\x1b[1m",
         .heading, .label => "\x1b[1m",
         .syntax => "\x1b[39m",
-        .muted => if (presentation_palette.currentPalette() == .terminal)
-            "\x1b[90m"
-        else
-            "\x1b[38;5;243m",
+        .muted => style.muted,
         .link => "\x1b[4m",
     };
 }
 
 fn styleEnd(style: HelpStyle) []const u8 {
-    return if (style == .ansi) "\x1b[0m" else "";
+    return if (style.enabled) "\x1b[0m" else "";
 }
 
 fn writeWrappedStyledLine(writer: *std.Io.Writer, prefix: []const u8, continuation_prefix: []const u8, text: []const u8, columns: usize, style: HelpStyle, role: HelpRole) !void {
@@ -1650,6 +1651,12 @@ test "terminal top-level help adds styling without changing visible content" {
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[1mUsage:\x1b[0m") != null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[39mask <prompt>\x1b[0m") != null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;243mFast, native coding agent") != null);
+
+    const terminal_palette = try renderTopLevelHelpWithStyle(std.testing.allocator, testTopLevelRegistry(), top_level_help_default_width, "9.8.7", .ansi_terminal);
+    defer std.testing.allocator.free(terminal_palette);
+    try std.testing.expect(std.mem.find(u8, terminal_palette, "\x1b[90mFast, native coding agent") != null);
+    try std.testing.expect(std.mem.find(u8, terminal_palette, "38;5;") == null);
+    try std.testing.expect(std.mem.find(u8, terminal_palette, "38;2;") == null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[4mhttps://fx.sh/docs\x1b[0m") != null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[39mrun `/feedback` inside fx\x1b[0m") != null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;252m") == null);

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -70,6 +70,7 @@ const Context = struct {
 
     fn toolContext(self: *Context) tool_runtime.Context {
         var result = self.config.tool_context;
+        result.presentation_snapshot = self.admission.presentation;
         result.worker = self.turn.workerRuntime();
         result.session = self.turn.sessionRuntime();
         result.cancel_flag = self.cancel;
@@ -394,6 +395,21 @@ fn runtimeDeps(context: *Context) agent_runtime.AgentRuntimeDeps {
         .report_usage = reportUsage,
         .usage = &context.turn.sessionRuntime().usage,
         .usage_allocator = context.turn.alloc,
+        .presentation_styles = .{
+            .dim = context.config.tool_context.presentation_dim_style,
+            .accent = context.config.tool_context.presentation_accent_style,
+            .inline_code = context.config.tool_context.presentation_inline_code_style,
+            .task_completed = context.config.tool_context.presentation_task_completed_style,
+            .diff_added = context.config.tool_context.presentation_diff_added_style,
+            .diff_removed = context.config.tool_context.presentation_diff_removed_style,
+            .diff_added_marker = context.config.tool_context.presentation_diff_added_marker_style,
+            .diff_removed_marker = context.config.tool_context.presentation_diff_removed_marker_style,
+            .snapshot = context.admission.presentation,
+        },
+        .diff_marker_styles = .{
+            .added = context.config.tool_context.presentation_diff_added_marker_style,
+            .removed = context.config.tool_context.presentation_diff_removed_marker_style,
+        },
     };
 }
 
@@ -647,7 +663,7 @@ fn requestPreparedFileMutationPermission(
     );
 }
 
-fn describeToolAction(raw: *anyopaque, arena: Allocator, call: types.ToolCall, file_path: ?[]const u8, _: []const []const u8) ![]const u8 {
+fn describeToolAction(raw: *anyopaque, arena: Allocator, call: types.ToolCall, file_path: ?[]const u8, _: agent_runtime.PresentationStyles, _: []const []const u8) ![]const u8 {
     const context: *Context = @ptrCast(@alignCast(raw));
     return tool_presentation.formatPlainAction(arena, .{
         .tool_registry = context.config.tool_context.tool_registry,
@@ -668,8 +684,8 @@ fn resolveToolActionDisplayTarget(raw: *anyopaque, arena: Allocator, call: types
     );
 }
 
-fn describeToolActionDenied(raw: *anyopaque, arena: Allocator, call: types.ToolCall, file_path: ?[]const u8, label: []const u8, dynamic_names: []const []const u8) ![]const u8 {
-    const action = try describeToolAction(raw, arena, call, file_path, dynamic_names);
+fn describeToolActionDenied(raw: *anyopaque, arena: Allocator, call: types.ToolCall, file_path: ?[]const u8, label: []const u8, styles: agent_runtime.PresentationStyles, dynamic_names: []const []const u8) ![]const u8 {
+    const action = try describeToolAction(raw, arena, call, file_path, styles, dynamic_names);
     return std.fmt.allocPrint(arena, "{s}: {s}", .{ label, action });
 }
 
@@ -717,7 +733,7 @@ fn reportUsage(raw: *anyopaque, usage: types.Usage) void {
     if (usage.output_tokens) |value| context.output_tokens = value;
 }
 
-fn publishCommittedFileHandoff(_: *anyopaque, _: file_mutation.CommittedFileHandoff) agent_runtime.SecondaryPublicationReport {
+fn publishCommittedFileHandoff(_: *anyopaque, _: file_mutation.CommittedFileHandoff, _: agent_runtime.PresentationStyles) agent_runtime.SecondaryPublicationReport {
     return .{ .diff = .skipped, .tracker = .skipped };
 }
 

--- a/src/core/subagent/domain.zig
+++ b/src/core/subagent/domain.zig
@@ -3,6 +3,7 @@ const mcp_access = @import("../mcp/access_policy.zig");
 const model_provider = @import("../config/model_provider.zig");
 const session_layout = @import("../session/session_layout.zig");
 const session_permission_state = @import("../permissions/session_permission_state.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const types = @import("../shared/types.zig");
 
 const Allocator = std.mem.Allocator;
@@ -56,6 +57,7 @@ pub const AdmissionSnapshot = struct {
     integration_names: [][]u8,
     authority_generation: u64 = 0,
     mcp_view: ?mcp_access.View = null,
+    presentation: presentation_palette.PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
 
     pub fn deinit(self: *AdmissionSnapshot, alloc: Allocator) void {
         alloc.free(self.parent_id);
@@ -85,6 +87,7 @@ pub const AdmissionInput = struct {
     integration_names: []const []const u8 = &.{},
     authority_generation: u64 = 0,
     mcp_view: ?mcp_access.View = null,
+    presentation: presentation_palette.PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
 };
 
 pub const AdmissionError = error{
@@ -161,6 +164,7 @@ pub fn captureAdmission(
         .integration_names = integration_names,
         .authority_generation = input.authority_generation,
         .mcp_view = mcp_view,
+        .presentation = input.presentation,
     };
 }
 

--- a/src/core/subagent/tool_host.zig
+++ b/src/core/subagent/tool_host.zig
@@ -8,6 +8,7 @@ const managed_owner = @import("managed_owner.zig");
 const model_contract = @import("model_contract.zig");
 const debug_trace = @import("../shared/debug_trace.zig");
 const io_mod = @import("../shared/io.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const mcp_access = @import("../mcp/access_policy.zig");
 const mode_registry = @import("../modes/mode_registry.zig");
 const model_provider = @import("../config/model_provider.zig");
@@ -63,6 +64,7 @@ pub const ExecuteOptions = struct {
     timestamp_ms: i64,
     identity_epoch: u64 = 0,
     cancel_flag: ?*std.atomic.Value(bool) = null,
+    presentation: presentation_palette.PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
 };
 
 pub const ManagedExecutionResult = struct {
@@ -90,6 +92,8 @@ pub const Runtime = struct {
     authority_resolver: authority.Resolver,
     managed: managed_owner.Owner,
     recovery_state: std.atomic.Value(RecoveryState) = .init(.pending),
+    presentation_mutex: std.Io.Mutex = .init,
+    child_presentations: std.StringHashMapUnmanaged(presentation_palette.PresentationSnapshot) = .empty,
 
     pub fn create(
         alloc: Allocator,
@@ -134,6 +138,9 @@ pub const Runtime = struct {
     pub fn deinit(self: *Runtime) void {
         self.managed.deinit();
         self.approvals.deinit();
+        var presentation_it = self.child_presentations.iterator();
+        while (presentation_it.next()) |entry| self.alloc.free(entry.key_ptr.*);
+        self.child_presentations.deinit(self.alloc);
         self.alloc.free(self.root_id);
         const alloc = self.alloc;
         self.* = undefined;
@@ -333,6 +340,7 @@ pub const Runtime = struct {
                 operation_id,
                 options.defaults,
             );
+            try self.rememberChildPresentation(existing.id, options.presentation);
             return managedAdmissionReady(alloc, existing.id);
         }
 
@@ -356,6 +364,7 @@ pub const Runtime = struct {
                     active.id,
                     options.defaults,
                 );
+                try self.rememberChildPresentation(child_id, options.presentation);
                 return managedAdmissionReady(
                     alloc,
                     registry.children[registry.children.len - 1].id,
@@ -401,6 +410,7 @@ pub const Runtime = struct {
                     active.id,
                     options.defaults,
                 );
+                try self.rememberChildPresentation(child_id, options.presentation);
                 return managedAdmissionReady(
                     alloc,
                     registry.children[registry.children.len - 1].id,
@@ -433,6 +443,29 @@ pub const Runtime = struct {
             else => return err,
         }
         try self.childStateStore().markChildSession(alloc, child_id);
+    }
+
+    fn rememberChildPresentation(
+        self: *Runtime,
+        child_id: []const u8,
+        presentation: presentation_palette.PresentationSnapshot,
+    ) !void {
+        self.presentation_mutex.lockUncancelable(io_mod.getIo());
+        defer self.presentation_mutex.unlock(io_mod.getIo());
+        if (self.child_presentations.contains(child_id)) return;
+        const owned_id = try self.alloc.dupe(u8, child_id);
+        errdefer self.alloc.free(owned_id);
+        try self.child_presentations.put(self.alloc, owned_id, presentation);
+    }
+
+    fn childPresentation(
+        self: *Runtime,
+        child_id: []const u8,
+    ) presentation_palette.PresentationSnapshot {
+        self.presentation_mutex.lockUncancelable(io_mod.getIo());
+        defer self.presentation_mutex.unlock(io_mod.getIo());
+        return self.child_presentations.get(child_id) orelse
+            presentation_palette.snapshot(false, .fx, false);
     }
 
     fn observeManagedState(
@@ -731,6 +764,7 @@ fn captureAdmission(
         else
             0,
         .mcp_view = snapshot.mcp_view,
+        .presentation = self.childPresentation(request.child_id),
     }) catch |err| switch (err) {
         error.OutOfMemory => error.OutOfMemory,
         else => error.AdmissionFailed,
@@ -842,4 +876,29 @@ pub fn captureHostAuthorityWithMcpView(
         permission_state,
         mcp_view,
     );
+}
+
+test "managed child retains its creation presentation" {
+    const alloc = std.testing.allocator;
+    var runtime: Runtime = undefined;
+    runtime.alloc = alloc;
+    runtime.presentation_mutex = .init;
+    runtime.child_presentations = .empty;
+    defer {
+        var it = runtime.child_presentations.iterator();
+        while (it.next()) |entry| alloc.free(entry.key_ptr.*);
+        runtime.child_presentations.deinit(alloc);
+    }
+
+    const initial = presentation_palette.snapshot(false, .terminal, false);
+    const changed = presentation_palette.snapshot(true, .fx, true);
+    try runtime.rememberChildPresentation("child", initial);
+    try runtime.rememberChildPresentation("child", changed);
+
+    const retained = runtime.childPresentation("child");
+    try std.testing.expectEqual(
+        presentation_palette.PresentationTheme.terminal,
+        retained.theme,
+    );
+    try std.testing.expectEqualStrings("\x1b[96m", retained.styles.user_marker);
 }

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -62,6 +62,7 @@ const model_provider = @import("../config/model_provider.zig");
 const provider_set = @import("../gateway/provider_set.zig");
 const credential_authority = @import("../auth/credential_authority.zig");
 const worker_runtime = @import("../agent/worker_runtime.zig");
+const presentation_palette = @import("../shared/presentation_palette.zig");
 const context_contract = @import("../workspace/context_contract.zig");
 const test_builtin_tools = if (builtin.is_test)
     @import("../../builtins/tools.zig")
@@ -117,6 +118,15 @@ test {
 
 pub const Context = struct {
     workspace_root: []const u8,
+    presentation_snapshot: presentation_palette.PresentationSnapshot = presentation_palette.snapshot(false, .fx, false),
+    presentation_dim_style: []const u8 = "\x1b[38;5;245m",
+    presentation_accent_style: []const u8 = "\x1b[38;5;252m",
+    presentation_inline_code_style: []const u8 = "\x1b[38;5;245m",
+    presentation_task_completed_style: []const u8 = "\x1b[38;5;252m",
+    presentation_diff_added_style: []const u8 = "\x1b[38;5;252m",
+    presentation_diff_removed_style: []const u8 = "\x1b[38;5;252m",
+    presentation_diff_added_marker_style: []const u8 = "\x1b[38;5;71m",
+    presentation_diff_removed_marker_style: []const u8 = "\x1b[38;5;167m",
     access_scope: ?workspace_access.AccessScope = null,
     ignored_list_entries: []const []const u8,
     max_list_entries: usize,
@@ -1909,6 +1919,7 @@ fn executeSubagentProvider(
         .timestamp_ms = io_mod.milliTimestamp(),
         .identity_epoch = identity_epoch,
         .cancel_flag = runtimeCancelFlag(ctx),
+        .presentation = ctx.presentation_snapshot,
     }) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
         if (err == error.Cancelled) return error.Cancelled;

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,6 +46,7 @@ const statusline_identity = @import("core/workspace/statusline_identity.zig");
 const collections = @import("core/shared/collections.zig");
 const agent_steps = @import("core/config/agent_steps.zig");
 const config_runtime = @import("core/config/config_runtime.zig");
+const presentation_palette = @import("core/shared/presentation_palette.zig");
 const model_provider = @import("core/config/model_provider.zig");
 const js_host_prompt_history = @import("core/session/js_host_prompt_history.zig");
 const model_capabilities = @import("core/config/model_capabilities.zig");
@@ -417,16 +418,24 @@ const App = struct {
     const WorkerAppRuntime = app_worker_runtime.Runtime(Self);
     const WorkspaceAppRuntime = app_workspace_runtime.Runtime(Self);
 
-    pub fn colorPalette(_: *const Self) config_runtime.ColorPalette {
-        return ui_render.currentColorPalette();
+    pub fn colorPalette(self: *const Self) config_runtime.ColorPalette {
+        return self.color_palette;
+    }
+
+    pub fn setColorPalettePreference(self: *Self, palette: config_runtime.ColorPalette) void {
+        self.color_palette = palette;
     }
 
     pub fn applyColorPaletteUpdate(self: *Self, palette: config_runtime.ColorPalette) !void {
-        try RenderAppRuntime.applyThemeUpdateForPalette(
-            self,
-            ui_render.is_light,
-            null,
-            palette,
+        self.setColorPalettePreference(palette);
+        try RenderAppRuntime.applyColorPaletteUpdate(self, palette);
+    }
+
+    pub fn activePresentationStyles(self: *const Self) presentation_palette.Styles {
+        return presentation_palette.stylesForTerminal(
+            self.presentation_light.load(.acquire),
+            @enumFromInt(self.active_color_palette.load(.acquire)),
+            self.presentation_truecolor,
         );
     }
 
@@ -526,6 +535,10 @@ const App = struct {
     }
 
     alloc: Allocator,
+    color_palette: config_runtime.ColorPalette = .fx,
+    active_color_palette: std.atomic.Value(u8) = .init(@intFromEnum(config_runtime.ColorPalette.fx)),
+    presentation_light: std.atomic.Value(bool) = .init(false),
+    presentation_truecolor: bool = true,
     terminal: TerminalState = .{},
 
     auth: auth_runtime.Runtime = auth_runtime.Runtime.init(
@@ -1215,6 +1228,19 @@ const App = struct {
         try self.writeUserPromptCardWithSpacing(user, self.session.historyLen() > 0);
     }
 
+    pub fn writeUserPromptCardWithPresentationStyles(
+        self: *App,
+        user: types.UserTurn,
+        presentation: worker_runtime.PresentationSnapshot,
+    ) !void {
+        try self.writeUserPromptCardWithSpacingAndSkillTokensAndPresentation(
+            user,
+            self.session.historyLen() > 0,
+            &.{},
+            presentation,
+        );
+    }
+
     pub fn writeUserPromptCardWithSkillBindings(
         self: *App,
         user: types.UserTurn,
@@ -1225,6 +1251,24 @@ const App = struct {
         const skill_tokens = try promptCardSkillTokensFromDisplaySpans(self.alloc, skill_display_spans);
         defer if (skill_tokens.len > 0) self.alloc.free(skill_tokens);
         try self.writeUserPromptCardWithSpacingAndSkillTokens(user, self.session.historyLen() > 0, skill_tokens);
+    }
+
+    pub fn writeUserPromptCardWithSkillBindingsAndPresentationStyles(
+        self: *App,
+        user: types.UserTurn,
+        skill_bindings: []const worker_runtime.SkillBinding,
+        skill_display_spans: []const worker_runtime.SkillDisplaySpan,
+        presentation: worker_runtime.PresentationSnapshot,
+    ) !void {
+        _ = skill_bindings;
+        const skill_tokens = try promptCardSkillTokensFromDisplaySpans(self.alloc, skill_display_spans);
+        defer if (skill_tokens.len > 0) self.alloc.free(skill_tokens);
+        try self.writeUserPromptCardWithSpacingAndSkillTokensAndPresentation(
+            user,
+            self.session.historyLen() > 0,
+            skill_tokens,
+            presentation,
+        );
     }
 
     pub fn writeUserPromptCardWithSpacing(self: *App, user: types.UserTurn, has_prior_turns: bool) !void {
@@ -1243,6 +1287,23 @@ const App = struct {
             user,
             has_prior_turns,
             skill_tokens,
+        );
+    }
+
+    fn writeUserPromptCardWithSpacingAndSkillTokensAndPresentation(
+        self: *App,
+        user: types.UserTurn,
+        has_prior_turns: bool,
+        skill_tokens: []const registered_entities.SkillTokenSpan,
+        presentation: worker_runtime.PresentationSnapshot,
+    ) !void {
+        _ = try self.shell.writeUserPromptCardWithPresentationStyles(
+            self.alloc,
+            &self.metrics,
+            user,
+            has_prior_turns,
+            skill_tokens,
+            presentation,
         );
     }
 
@@ -2045,6 +2106,10 @@ const App = struct {
         return self.describeToolAction(arena, call, display_target, advertised_dynamic_tool_names);
     }
 
+    pub fn describeToolActionWithAdvertisedStyles(self: *App, arena: Allocator, call: ToolCall, display_target: ?[]const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        return AgentAppRuntime.describeToolActionWithPresentationStyles(self, arena, call, display_target, styles, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+    }
+
     pub fn describeToolActionCompleted(self: *App, arena: Allocator, call: ToolCall, display_target: ?[]const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
         return AgentAppRuntime.describeToolActionCompleted(self, arena, call, display_target, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
     }
@@ -2053,12 +2118,20 @@ const App = struct {
         return self.describeToolActionCompleted(arena, call, display_target, advertised_dynamic_tool_names);
     }
 
+    pub fn describeToolActionCompletedWithAdvertisedStyles(self: *App, arena: Allocator, call: ToolCall, display_target: ?[]const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        return AgentAppRuntime.describeToolActionCompletedWithPresentationStyles(self, arena, call, display_target, styles, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
+    }
+
     pub fn describeToolActionDenied(self: *App, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
         return AgentAppRuntime.describeToolActionDenied(self, arena, call, display_target, label, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
     }
 
     pub fn describeToolActionDeniedWithAdvertised(self: *App, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
         return self.describeToolActionDenied(arena, call, display_target, label, advertised_dynamic_tool_names);
+    }
+
+    pub fn describeToolActionDeniedWithAdvertisedStyles(self: *App, arena: Allocator, call: ToolCall, display_target: ?[]const u8, label: []const u8, styles: agent_runtime.PresentationStyles, advertised_dynamic_tool_names: []const []const u8) ![]const u8 {
+        return AgentAppRuntime.describeToolActionDeniedWithPresentationStyles(self, arena, call, display_target, label, styles, advertised_dynamic_tool_names, &ignored_list_entries, max_list_entries, max_read_file_bytes, max_read_file_lines, max_read_file_line_len, max_command_output_bytes, builtin_gateway.retry_count, builtin_gateway.defaultChatUrl());
     }
 
     pub fn requestToolPermissionSync(self: *App, arena: Allocator, call: ToolCall, review_turn: permission_auto_classifier.ReviewTurnContext, permission_mode: PermissionMode, local_grants: []const PermissionGrant, live_authority: ?agent_runtime.LiveToolAuthority, revalidation: ?agent_runtime.LivePermissionRevalidation, advertised_dynamic_tool_names: []const []const u8) !command_admission.PermissionOutcome {
@@ -2616,12 +2689,46 @@ const App = struct {
         _ = try self.shell.appendAssistantTableOwned(self.alloc, table);
     }
 
+    pub fn appendAssistantTableWithPresentationStyles(
+        self: *App,
+        table: assistant_presentation.TablePayload,
+        presentation: worker_runtime.PresentationSnapshot,
+    ) !void {
+        _ = try self.shell.appendAssistantTableOwnedWithPresentationStyles(
+            self.alloc,
+            table,
+            presentation,
+        );
+    }
+
     pub fn appendAssistantCodeBlock(self: *App, block: assistant_presentation.CodeBlockPayload) !void {
         _ = try self.shell.appendAssistantCodeBlockOwned(self.alloc, block);
     }
 
+    pub fn appendAssistantCodeBlockWithPresentationStyles(
+        self: *App,
+        block: assistant_presentation.CodeBlockPayload,
+        presentation: worker_runtime.PresentationSnapshot,
+    ) !void {
+        _ = try self.shell.appendAssistantCodeBlockOwnedWithPresentationStyles(
+            self.alloc,
+            block,
+            presentation,
+        );
+    }
+
     pub fn appendAssistantThematicRule(self: *App) !void {
         _ = try self.shell.appendAssistantThematicRule(self.alloc);
+    }
+
+    pub fn appendAssistantThematicRuleWithPresentationStyles(
+        self: *App,
+        presentation: worker_runtime.PresentationSnapshot,
+    ) !void {
+        _ = try self.shell.appendAssistantThematicRuleWithPresentationStyles(
+            self.alloc,
+            presentation,
+        );
     }
 
     pub fn appendHistoryTurn(self: *App, turn: types.HistoryTurn) !void {
@@ -3479,7 +3586,7 @@ fn topLevelHelpStyle(raw_env: RawEnviron) command_specs.HelpStyle {
 }
 
 fn topLevelHelpStyleForValues(is_terminal: bool, no_color: bool, dumb_terminal: bool) command_specs.HelpStyle {
-    return if (is_terminal and !no_color and !dumb_terminal) .ansi else .plain;
+    return if (is_terminal and !no_color and !dumb_terminal) .ansi_terminal else .plain;
 }
 
 fn stdoutIsTerminal() bool {
@@ -3918,10 +4025,11 @@ test "raw benchmark preflight matches no-arg FX_BENCH presence" {
 }
 
 test "terminal help styling respects terminal capability and color opt-outs" {
-    try std.testing.expectEqual(command_specs.HelpStyle.ansi, topLevelHelpStyleForValues(true, false, false));
-    try std.testing.expectEqual(command_specs.HelpStyle.plain, topLevelHelpStyleForValues(false, false, false));
-    try std.testing.expectEqual(command_specs.HelpStyle.plain, topLevelHelpStyleForValues(true, true, false));
-    try std.testing.expectEqual(command_specs.HelpStyle.plain, topLevelHelpStyleForValues(true, false, true));
+    try std.testing.expect(topLevelHelpStyleForValues(true, false, false).enabled);
+    try std.testing.expectEqualStrings("\x1b[90m", topLevelHelpStyleForValues(true, false, false).muted);
+    try std.testing.expect(!topLevelHelpStyleForValues(false, false, false).enabled);
+    try std.testing.expect(!topLevelHelpStyleForValues(true, true, false).enabled);
+    try std.testing.expect(!topLevelHelpStyleForValues(true, false, true).enabled);
 }
 
 test "follow up prompt card top margin is renderer-owned" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -417,6 +417,19 @@ const App = struct {
     const WorkerAppRuntime = app_worker_runtime.Runtime(Self);
     const WorkspaceAppRuntime = app_workspace_runtime.Runtime(Self);
 
+    pub fn colorPalette(_: *const Self) config_runtime.ColorPalette {
+        return ui_render.currentColorPalette();
+    }
+
+    pub fn applyColorPaletteUpdate(self: *Self, palette: config_runtime.ColorPalette) !void {
+        try RenderAppRuntime.applyThemeUpdateForPalette(
+            self,
+            ui_render.is_light,
+            null,
+            palette,
+        );
+    }
+
     pub fn contextRegistry(_: *const Self) context_contract.Registry {
         return default_context_registry;
     }

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -23,6 +23,8 @@ pub const Runtime = struct {
     shell: TranscriptRuntime,
     metrics: Metrics = .{},
     no_color: bool,
+    presentation_light: bool,
+    presentation_truecolor: bool,
     terminal_prepared: bool = false,
     finished: bool = false,
     pending_error: ?anyerror = null,
@@ -41,10 +43,14 @@ pub const Runtime = struct {
         no_color: bool,
         color_palette: ui_render.ColorPalette,
     ) !Runtime {
-        ui_render.setColorPalette(color_palette);
+        const presentation_truecolor = !no_color and ui_render.truecolorSupportedForValues(
+            io_mod.getenv("COLORTERM"),
+            io_mod.getenv("TERM_PROGRAM"),
+        );
+        ui_render.setTruecolorSupport(presentation_truecolor);
         const layout = zeroFooterLayout(try ui_terminal.queryLayout(std.posix.STDOUT_FILENO, 0));
         var terminal = shell_runtime.TerminalState{};
-        const cursor = probeTerminal(&terminal, layout, no_color);
+        const cursor = probeTerminal(&terminal, layout, no_color, color_palette);
         return initConfigured(
             alloc,
             user,
@@ -53,6 +59,7 @@ pub const Runtime = struct {
             layout,
             cursor,
             shell_runtime.detectSyncUpdatesEnabled(alloc),
+            presentation_truecolor,
         );
     }
 
@@ -64,6 +71,7 @@ pub const Runtime = struct {
         layout: types.Layout,
         cursor: shell_runtime.CursorPosition,
         sync_updates_enabled: bool,
+        presentation_truecolor: bool,
     ) !Runtime {
         var self = Runtime{
             .alloc = alloc,
@@ -75,6 +83,8 @@ pub const Runtime = struct {
                 .transcript_release = .{ .policy = .append_only },
             },
             .no_color = no_color,
+            .presentation_light = ui_render.is_light,
+            .presentation_truecolor = presentation_truecolor,
         };
         errdefer self.deinit();
 
@@ -111,6 +121,14 @@ pub const Runtime = struct {
         _ = try self.shell.appendUserTurnOwned(alloc, owned_user);
         try self.render();
         return self;
+    }
+
+    pub fn presentationLight(self: *const Runtime) bool {
+        return self.presentation_light;
+    }
+
+    pub fn presentationTruecolor(self: *const Runtime) bool {
+        return self.presentation_truecolor;
     }
 
     pub fn deinit(self: *Runtime) void {
@@ -411,10 +429,11 @@ fn probeTerminal(
     terminal: *shell_runtime.TerminalState,
     layout: types.Layout,
     no_color: bool,
+    color_palette: ui_render.ColorPalette,
 ) shell_runtime.CursorPosition {
     const fallback = shell_runtime.CursorPosition{ .row = layout.rows, .col = 1 };
     const fallback_light = if (no_color) false else ui_render.explicitThemeOverride() orelse false;
-    ui_render.initThemeForPalette(fallback_light, null, ui_render.currentColorPalette());
+    ui_render.initThemeForPalette(fallback_light, null, color_palette);
     if (std.c.isatty(std.posix.STDIN_FILENO) == 0) return fallback;
     terminal.captureOriginalTermios() catch return fallback;
     terminal.enableRawMode() catch return fallback;
@@ -422,7 +441,7 @@ fn probeTerminal(
 
     if (!no_color) {
         const theme = ui_render.detectTheme(std.heap.c_allocator, terminal);
-        ui_render.initThemeForPalette(theme.light, theme.rgb, ui_render.currentColorPalette());
+        ui_render.initThemeForPalette(theme.light, theme.rgb, color_palette);
     }
     return terminal.queryCursorPosition() catch fallback;
 }
@@ -487,6 +506,7 @@ test "ask presentation paints Minimal prompt and assistant into a footerless fra
         }),
         .{ .row = 1, .col = 1 },
         true,
+        true,
     );
     defer runtime.deinit();
 
@@ -543,9 +563,11 @@ test "ask presentation carries the light theme into semantic code blocks" {
         }),
         .{ .row = 1, .col = 1 },
         true,
+        true,
     );
     defer runtime.deinit();
 
+    try std.testing.expect(runtime.presentationLight());
     try std.testing.expect(runtime.shell.retainedTranscriptStyles().code_highlight_theme == .light);
 }
 
@@ -571,6 +593,7 @@ test "ask presentation retains a streaming write failure until finish" {
         output,
         layout,
         .{ .row = 1, .col = 1 },
+        true,
         true,
     );
     defer runtime.deinit();

--- a/src/ui/ask_presentation.zig
+++ b/src/ui/ask_presentation.zig
@@ -32,6 +32,16 @@ pub const Runtime = struct {
         user: types.UserTurn,
         no_color: bool,
     ) !Runtime {
+        return initForPalette(alloc, user, no_color, .fx);
+    }
+
+    pub fn initForPalette(
+        alloc: Allocator,
+        user: types.UserTurn,
+        no_color: bool,
+        color_palette: ui_render.ColorPalette,
+    ) !Runtime {
+        ui_render.setColorPalette(color_palette);
         const layout = zeroFooterLayout(try ui_terminal.queryLayout(std.posix.STDOUT_FILENO, 0));
         var terminal = shell_runtime.TerminalState{};
         const cursor = probeTerminal(&terminal, layout, no_color);
@@ -71,7 +81,12 @@ pub const Runtime = struct {
         try self.shell.initBacking(alloc);
         try self.shell.enableShadowVt(alloc);
         self.shell.setCommandOutputRenderPolicy(.{
-            .code_highlight_theme = if (ui_render.is_light) .light else .dark,
+            .code_highlight_theme = if (ui_render.currentColorPalette() == .terminal)
+                .terminal
+            else if (ui_render.is_light)
+                .light
+            else
+                .dark,
         });
         const start = normalizeStartCursor(layout, cursor);
         self.shell.shadow_vt.?.cursor_row = start.row;
@@ -399,7 +414,7 @@ fn probeTerminal(
 ) shell_runtime.CursorPosition {
     const fallback = shell_runtime.CursorPosition{ .row = layout.rows, .col = 1 };
     const fallback_light = if (no_color) false else ui_render.explicitThemeOverride() orelse false;
-    ui_render.initTheme(fallback_light, null);
+    ui_render.initThemeForPalette(fallback_light, null, ui_render.currentColorPalette());
     if (std.c.isatty(std.posix.STDIN_FILENO) == 0) return fallback;
     terminal.captureOriginalTermios() catch return fallback;
     terminal.enableRawMode() catch return fallback;
@@ -407,7 +422,7 @@ fn probeTerminal(
 
     if (!no_color) {
         const theme = ui_render.detectTheme(std.heap.c_allocator, terminal);
-        ui_render.initTheme(theme.light, theme.rgb);
+        ui_render.initThemeForPalette(theme.light, theme.rgb, ui_render.currentColorPalette());
     }
     return terminal.queryCursorPosition() catch fallback;
 }

--- a/src/ui/assistant/pacer.zig
+++ b/src/ui/assistant/pacer.zig
@@ -175,63 +175,6 @@ pub const AssistantPacer = struct {
         }
     }
 
-    /// Retint queued and active inline-code state when a configurable color
-    /// palette changes. The explicit allocator is required because ANSI-16
-    /// sequences are shorter than the historical 256-color sequences.
-    pub fn rethemeInlineCodeForPalette(
-        self: *AssistantPacer,
-        alloc: Allocator,
-        light: bool,
-        palette: presentation_palette.ColorPalette,
-    ) !void {
-        const target = assistant_ansi.inlineCodeStyle(light, palette);
-        const old_styles = [_][]const u8{
-            assistant_ansi.inlineCodeStyle(false, .fx),
-            assistant_ansi.inlineCodeStyle(true, .fx),
-            assistant_ansi.inlineCodeStyle(false, .terminal),
-        };
-
-        var rewritten: std.ArrayList(u8) = .empty;
-        errdefer rewritten.deinit(alloc);
-        var changed = false;
-        var index: usize = 0;
-        while (index < self.pending.items.len) {
-            var matched: ?[]const u8 = null;
-            for (old_styles) |old| {
-                if (std.mem.eql(u8, old, target)) continue;
-                if (std.mem.startsWith(u8, self.pending.items[index..], old)) {
-                    matched = old;
-                    break;
-                }
-            }
-            if (matched) |old| {
-                try rewritten.appendSlice(alloc, target);
-                index += old.len;
-                changed = true;
-            } else {
-                try rewritten.append(alloc, self.pending.items[index]);
-                index += 1;
-            }
-        }
-
-        if (changed) {
-            const replacement = try rewritten.toOwnedSlice(alloc);
-            self.pending.deinit(alloc);
-            self.pending = .fromOwnedSlice(replacement);
-        } else {
-            rewritten.deinit(alloc);
-        }
-
-        if (self.sgr.code_fg != .none) {
-            self.sgr.code_fg = if (palette == .terminal)
-                .terminal
-            else if (light)
-                .light
-            else
-                .dark;
-        }
-    }
-
     pub fn deferFinish(self: *AssistantPacer, alloc: Allocator, finished: FinishedPrompt) !bool {
         if (self.pending.items.len == 0) return false;
         if (self.deferred_turn) |old| {
@@ -967,26 +910,6 @@ test "theme change retints a queued inline code opener before it is emitted" {
 
     try std.testing.expect(std.mem.indexOf(u8, cap.emitted.items, "\x1b[38;5;245m") != null);
     try std.testing.expect(std.mem.indexOf(u8, cap.emitted.items, "\x1b[38;5;247m") == null);
-}
-
-test "terminal palette retints queued and active inline code" {
-    const alloc = std.testing.allocator;
-    var pacer = AssistantPacer{};
-    defer pacer.deinit(alloc);
-    var cap = TestCapture{};
-    defer cap.deinit();
-
-    try pacer.enqueue(alloc, "x\x1b[38;5;245mcode");
-    try pacer.tick(alloc, 0, cap.callbacks());
-    const emitted_before_theme_change = cap.emitted.items.len;
-
-    try pacer.rethemeInlineCodeForPalette(alloc, false, .terminal);
-    try pacer.enqueue(alloc, "\x1b[39m");
-    try pacer.tick(alloc, 1, cap.callbacks());
-
-    const after_theme_change = cap.emitted.items[emitted_before_theme_change..];
-    try std.testing.expect(std.mem.indexOf(u8, after_theme_change, "\x1b[0m\x1b[90m") != null);
-    try std.testing.expect(std.mem.indexOf(u8, after_theme_change, "38;5;") == null);
 }
 
 test "underline style is restored across rendered blocks" {

--- a/src/ui/assistant/pacer.zig
+++ b/src/ui/assistant/pacer.zig
@@ -4,6 +4,8 @@ const Allocator = std.mem.Allocator;
 const debug_trace = @import("../../core/shared/debug_trace.zig");
 const display_width = @import("../../core/shared/display_width.zig");
 const types = @import("../../core/shared/types.zig");
+const assistant_ansi = @import("../../core/agent/presentation/ansi.zig");
+const presentation_palette = @import("../../core/shared/presentation_palette.zig");
 const HistoryTurn = types.HistoryTurn;
 const FinishedPrompt = types.FinishedPrompt;
 
@@ -37,6 +39,7 @@ pub const SgrState = struct {
         none,
         dark,
         light,
+        terminal,
     };
 
     bold: bool = false,
@@ -72,7 +75,14 @@ pub const SgrState = struct {
             self.dim = false;
         } else if (std.mem.eql(u8, body, "23")) self.italic = false else if (std.mem.eql(u8, body, "24")) self.underline = false else if (std.mem.eql(u8, body, "29")) self.strike = false else if (std.mem.eql(u8, body, "39")) {
             self.code_fg = .none;
-        } else if (std.mem.eql(u8, body, "38;5;245")) self.code_fg = .dark else if (std.mem.eql(u8, body, "38;5;247")) self.code_fg = .light;
+        } else if (assistant_ansi.isInlineCodeOpen(seq)) {
+            self.code_fg = if (std.mem.eql(u8, seq, presentation_palette.styles(false, .terminal).inline_code))
+                .terminal
+            else if (std.mem.eql(u8, seq, "\x1b[38;5;247m"))
+                .light
+            else
+                .dark;
+        }
     }
 
     /// Serialize open codes for the currently-active attributes into `buf`.
@@ -97,6 +107,7 @@ pub const SgrState = struct {
             .none => {},
             .dark => append(buf, &n, "\x1b[38;5;245m"),
             .light => append(buf, &n, "\x1b[38;5;247m"),
+            .terminal => append(buf, &n, presentation_palette.styles(false, .terminal).inline_code),
         }
         return n;
     }
@@ -161,6 +172,63 @@ pub const AssistantPacer = struct {
 
         if (self.sgr.code_fg != .none) {
             self.sgr.code_fg = if (light) .light else .dark;
+        }
+    }
+
+    /// Retint queued and active inline-code state when a configurable color
+    /// palette changes. The explicit allocator is required because ANSI-16
+    /// sequences are shorter than the historical 256-color sequences.
+    pub fn rethemeInlineCodeForPalette(
+        self: *AssistantPacer,
+        alloc: Allocator,
+        light: bool,
+        palette: presentation_palette.ColorPalette,
+    ) !void {
+        const target = assistant_ansi.inlineCodeStyle(light, palette);
+        const old_styles = [_][]const u8{
+            assistant_ansi.inlineCodeStyle(false, .fx),
+            assistant_ansi.inlineCodeStyle(true, .fx),
+            assistant_ansi.inlineCodeStyle(false, .terminal),
+        };
+
+        var rewritten: std.ArrayList(u8) = .empty;
+        errdefer rewritten.deinit(alloc);
+        var changed = false;
+        var index: usize = 0;
+        while (index < self.pending.items.len) {
+            var matched: ?[]const u8 = null;
+            for (old_styles) |old| {
+                if (std.mem.eql(u8, old, target)) continue;
+                if (std.mem.startsWith(u8, self.pending.items[index..], old)) {
+                    matched = old;
+                    break;
+                }
+            }
+            if (matched) |old| {
+                try rewritten.appendSlice(alloc, target);
+                index += old.len;
+                changed = true;
+            } else {
+                try rewritten.append(alloc, self.pending.items[index]);
+                index += 1;
+            }
+        }
+
+        if (changed) {
+            const replacement = try rewritten.toOwnedSlice(alloc);
+            self.pending.deinit(alloc);
+            self.pending = .fromOwnedSlice(replacement);
+        } else {
+            rewritten.deinit(alloc);
+        }
+
+        if (self.sgr.code_fg != .none) {
+            self.sgr.code_fg = if (palette == .terminal)
+                .terminal
+            else if (light)
+                .light
+            else
+                .dark;
         }
     }
 
@@ -899,6 +967,26 @@ test "theme change retints a queued inline code opener before it is emitted" {
 
     try std.testing.expect(std.mem.indexOf(u8, cap.emitted.items, "\x1b[38;5;245m") != null);
     try std.testing.expect(std.mem.indexOf(u8, cap.emitted.items, "\x1b[38;5;247m") == null);
+}
+
+test "terminal palette retints queued and active inline code" {
+    const alloc = std.testing.allocator;
+    var pacer = AssistantPacer{};
+    defer pacer.deinit(alloc);
+    var cap = TestCapture{};
+    defer cap.deinit();
+
+    try pacer.enqueue(alloc, "x\x1b[38;5;245mcode");
+    try pacer.tick(alloc, 0, cap.callbacks());
+    const emitted_before_theme_change = cap.emitted.items.len;
+
+    try pacer.rethemeInlineCodeForPalette(alloc, false, .terminal);
+    try pacer.enqueue(alloc, "\x1b[39m");
+    try pacer.tick(alloc, 1, cap.callbacks());
+
+    const after_theme_change = cap.emitted.items[emitted_before_theme_change..];
+    try std.testing.expect(std.mem.indexOf(u8, after_theme_change, "\x1b[0m\x1b[90m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, after_theme_change, "38;5;") == null);
 }
 
 test "underline style is restored across rendered blocks" {

--- a/src/ui/assistant/user_message_card.zig
+++ b/src/ui/assistant/user_message_card.zig
@@ -6,6 +6,7 @@ const types = @import("../../core/shared/types.zig");
 const image_attachments = @import("../../core/images/image_attachments.zig");
 const visual_layout = @import("../input/visual_layout.zig");
 const vt_emulator = @import("../../core/terminal/engine.zig");
+const presentation_palette = @import("../../core/shared/presentation_palette.zig");
 
 pub const Rgb = struct { r: u8, g: u8, b: u8 };
 
@@ -25,9 +26,14 @@ var accent_style: []const u8 = accent_dark;
 
 var marker_style: []const u8 = dark_marker_style;
 
-pub fn setStyle(light: bool, _: ?Rgb) void {
-    marker_style = if (light) light_marker_style else dark_marker_style;
-    accent_style = if (light) accent_light else accent_dark;
+pub fn setStyle(light: bool, terminal_bg: ?Rgb) void {
+    setStyleForPalette(light, terminal_bg, .fx);
+}
+
+pub fn setStyleForPalette(light: bool, _: ?Rgb, palette: presentation_palette.ColorPalette) void {
+    const styles = presentation_palette.styles(light, palette);
+    marker_style = styles.user_marker;
+    accent_style = styles.user_accent;
 }
 
 pub fn promptMarkerStyle() []const u8 {
@@ -474,6 +480,18 @@ test "current presentation uses a theme-aware prompt rail" {
     const light_card = try buildUserPromptCard(alloc, "hello", &.{}, 80);
     defer alloc.free(light_card);
     try std.testing.expect(std.mem.startsWith(u8, light_card, "\x1b[38;5;235m┃\x1b[0m \x1b[1mhello"));
+}
+
+test "terminal presentation uses ANSI-16 prompt accents" {
+    const alloc = std.testing.allocator;
+    defer setStyle(false, null);
+
+    setStyleForPalette(false, null, .terminal);
+    const card = try buildUserPromptCard(alloc, "hello $review", &.{}, 80);
+    defer alloc.free(card);
+
+    try std.testing.expect(std.mem.startsWith(u8, card, "\x1b[96m┃\x1b[0m \x1b[1mhello"));
+    try std.testing.expect(std.mem.indexOf(u8, card, "38;5;") == null);
 }
 
 test "current presentation restores bold prompt text after skill tokens" {

--- a/src/ui/assistant/user_message_card.zig
+++ b/src/ui/assistant/user_message_card.zig
@@ -26,6 +26,18 @@ var accent_style: []const u8 = accent_dark;
 
 var marker_style: []const u8 = dark_marker_style;
 
+const CardStyles = struct {
+    marker: []const u8,
+    accent: []const u8,
+};
+
+fn currentCardStyles() CardStyles {
+    return .{
+        .marker = marker_style,
+        .accent = accent_style,
+    };
+}
+
 pub fn setStyle(light: bool, terminal_bg: ?Rgb) void {
     setStyleForPalette(light, terminal_bg, .fx);
 }
@@ -38,6 +50,55 @@ pub fn setStyleForPalette(light: bool, _: ?Rgb, palette: presentation_palette.Co
 
 pub fn promptMarkerStyle() []const u8 {
     return marker_style;
+}
+
+/// Render a prompt card from an immutable worker-captured snapshot without
+/// consulting or mutating the live renderer palette.
+pub fn buildUserPromptCardWithPresentationStyles(
+    alloc: std.mem.Allocator,
+    text: []const u8,
+    images: []const types.ImageAttachment,
+    cols: u16,
+    skill_tokens: []const visual_layout.SkillTokenSpan,
+    snapshot: presentation_palette.PresentationSnapshot,
+) ![]u8 {
+    return buildUserPromptCardWithPresentationStylesInterruptible(
+        alloc,
+        text,
+        images,
+        cols,
+        skill_tokens,
+        snapshot,
+        null,
+    ) catch |err| switch (err) {
+        error.InputPending => unreachable,
+        else => |other| return other,
+    };
+}
+
+pub fn buildUserPromptCardWithPresentationStylesInterruptible(
+    alloc: std.mem.Allocator,
+    text: []const u8,
+    images: []const types.ImageAttachment,
+    cols: u16,
+    skill_tokens: []const visual_layout.SkillTokenSpan,
+    snapshot: presentation_palette.PresentationSnapshot,
+    checkpoint: ?*build_checkpoint.BuildCheckpoint,
+) ![]u8 {
+    return buildUserPromptCardWithSkillTokensAndLinksInterruptible(
+        alloc,
+        text,
+        images,
+        cols,
+        skill_tokens,
+        true,
+        checkpoint,
+        null,
+        .{
+            .marker = snapshot.styles.user_marker,
+            .accent = snapshot.styles.user_accent,
+        },
+    );
 }
 
 fn emitRow(writer: *std.Io.Writer, content: []const u8) !void {
@@ -103,6 +164,7 @@ pub fn buildUserPromptCardWithSkillTokens(
         cols,
         skill_tokens,
         false,
+        currentCardStyles(),
     );
 }
 
@@ -143,6 +205,7 @@ pub fn buildUserPromptCardWithSkillTokensForTerminalPresentationInterruptible(
         true,
         checkpoint,
         null,
+        currentCardStyles(),
     );
 }
 
@@ -166,6 +229,7 @@ pub fn buildUserPromptCardTailForTerminalPresentationInterruptible(
         true,
         checkpoint,
         max_rows,
+        currentCardStyles(),
     );
 }
 
@@ -176,6 +240,7 @@ fn buildUserPromptCardWithSkillTokensAndLinks(
     cols: u16,
     skill_tokens: []const visual_layout.SkillTokenSpan,
     linked_images: bool,
+    styles: CardStyles,
 ) ![]u8 {
     return buildUserPromptCardWithSkillTokensAndLinksInterruptible(
         alloc,
@@ -186,6 +251,7 @@ fn buildUserPromptCardWithSkillTokensAndLinks(
         linked_images,
         null,
         null,
+        styles,
     ) catch |err| switch (err) {
         error.InputPending => unreachable,
         else => |other| return other,
@@ -201,6 +267,7 @@ fn buildUserPromptCardWithSkillTokensAndLinksInterruptible(
     linked_images: bool,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
     max_rows: ?usize,
+    styles: CardStyles,
 ) ![]u8 {
     const window: usize = if (cols > 2) @as(usize, cols) - 2 else 0;
 
@@ -216,7 +283,7 @@ fn buildUserPromptCardWithSkillTokensAndLinksInterruptible(
     }
 
     const token_text = if (skill_tokens.len > 0)
-        try renderSkillTokensForCard(alloc, text, skill_tokens)
+        try renderSkillTokensForCard(alloc, text, skill_tokens, styles.accent)
     else
         text;
     defer if (skill_tokens.len > 0) alloc.free(token_text);
@@ -262,6 +329,7 @@ fn buildUserPromptCardWithSkillTokensAndLinksInterruptible(
         window,
         checkpoint,
         max_rows,
+        styles.marker,
     );
 
     for (rows.items) |content| {
@@ -275,6 +343,7 @@ fn renderSkillTokensForCard(
     alloc: std.mem.Allocator,
     text: []const u8,
     skill_tokens: []const visual_layout.SkillTokenSpan,
+    skill_accent_style: []const u8,
 ) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
@@ -285,7 +354,7 @@ fn renderSkillTokensForCard(
         if (token.name.len == 0) continue;
 
         try out.writer.writeAll(text[pos..token.raw_start]);
-        try out.writer.writeAll(accent_style);
+        try out.writer.writeAll(skill_accent_style);
         try out.writer.writeAll(token.name);
         try out.writer.writeAll(restore_prompt_text_style);
         pos = token.raw_end;
@@ -320,8 +389,8 @@ fn appendVisibleRow(
     try appendRow(alloc, rows, content);
 }
 
-fn writeRowPrefix(writer: *std.Io.Writer) !void {
-    try writer.writeAll(marker_style);
+fn writeRowPrefix(writer: *std.Io.Writer, prompt_marker_style: []const u8) !void {
+    try writer.writeAll(prompt_marker_style);
     try writer.writeAll(user_turn_rail);
     try writer.writeAll(reset_style);
     try writer.writeByte(' ');
@@ -358,6 +427,7 @@ fn collectLogicalLinesWithFirstPrefix(
     window: usize,
     checkpoint: ?*build_checkpoint.BuildCheckpoint,
     max_rows: ?usize,
+    prompt_marker_style: []const u8,
 ) !void {
     var it = std.mem.splitScalar(u8, text, '\n');
     while (it.next()) |line| {
@@ -366,7 +436,7 @@ fn collectLogicalLinesWithFirstPrefix(
         var remaining = line;
         if (remaining.len == 0) {
             row_buf.clearRetainingCapacity();
-            try writeRowPrefix(&row_buf.writer);
+            try writeRowPrefix(&row_buf.writer, prompt_marker_style);
             try appendVisibleRow(alloc, rows, row_buf.written(), max_rows);
             continue;
         }
@@ -375,7 +445,7 @@ fn collectLogicalLinesWithFirstPrefix(
             try build_checkpoint.consume(checkpoint, @max(c.keep_bytes, c.skip_bytes));
             const fragment = remaining[0..c.keep_bytes];
             row_buf.clearRetainingCapacity();
-            try writeRowPrefix(&row_buf.writer);
+            try writeRowPrefix(&row_buf.writer, prompt_marker_style);
             if (active_hyperlink) |opener| try row_buf.writer.writeAll(opener);
             try row_buf.writer.writeAll(fragment);
             active_hyperlink = hyperlinkStateAfter(fragment, active_hyperlink);
@@ -492,6 +562,28 @@ test "terminal presentation uses ANSI-16 prompt accents" {
 
     try std.testing.expect(std.mem.startsWith(u8, card, "\x1b[96m┃\x1b[0m \x1b[1mhello"));
     try std.testing.expect(std.mem.indexOf(u8, card, "38;5;") == null);
+}
+
+test "captured prompt presentation is independent from the live palette" {
+    const alloc = std.testing.allocator;
+    defer setStyle(false, null);
+
+    setStyleForPalette(false, null, .fx);
+    const captured = try buildUserPromptCardWithPresentationStyles(
+        alloc,
+        "captured",
+        &.{},
+        80,
+        &.{},
+        presentation_palette.snapshot(false, .terminal, false),
+    );
+    defer alloc.free(captured);
+    try std.testing.expect(std.mem.startsWith(u8, captured, "\x1b[96m┃"));
+    try std.testing.expect(std.mem.indexOf(u8, captured, "38;5;") == null);
+
+    const live = try buildUserPromptCard(alloc, "live", &.{}, 80);
+    defer alloc.free(live);
+    try std.testing.expect(std.mem.startsWith(u8, live, "\x1b[38;5;255m┃"));
 }
 
 test "current presentation restores bold prompt text after skill tokens" {

--- a/src/ui/footer/settings_menu_presentation.zig
+++ b/src/ui/footer/settings_menu_presentation.zig
@@ -361,7 +361,7 @@ test "settings menu renders each setting on one row at wide and narrow widths" {
         .snapshot = test_snapshot,
     };
     const wide_rows = menuRowCount(projection, 100, 40);
-    try std.testing.expectEqual(@as(u16, 14), wide_rows);
+    try std.testing.expectEqual(@as(u16, 15), wide_rows);
 
     var header = try composeSettingsMenuRow(alloc, projection, 0, 100, wide_rows);
     defer header.deinit(alloc);
@@ -382,7 +382,7 @@ test "settings menu renders each setting on one row at wide and narrow widths" {
     try std.testing.expect(std.mem.find(u8, compact_item.items, "on") != null);
 
     const narrow_rows = menuRowCount(projection, 24, 40);
-    try std.testing.expectEqual(@as(u16, 14), narrow_rows);
+    try std.testing.expectEqual(@as(u16, 15), narrow_rows);
     var narrow_item = try composeSettingsMenuRow(alloc, projection, 2, 24, narrow_rows);
     defer narrow_item.deinit(alloc);
     try std.testing.expect(std.mem.find(u8, narrow_item.items, "Status line") != null);
@@ -399,7 +399,7 @@ test "settings menu values follow the widest matching setting label" {
 
     var short = try composeSettingsMenuRow(alloc, projection, 3, 100, rows);
     defer short.deinit(alloc);
-    var long = try composeSettingsMenuRow(alloc, projection, 7, 100, rows);
+    var long = try composeSettingsMenuRow(alloc, projection, 8, 100, rows);
     defer long.deinit(alloc);
 
     const short_start = std.mem.find(u8, short.items, "off") orelse
@@ -468,7 +468,7 @@ test "settings menu renders category tabs and a flat full list through the VT" {
         .active = true,
         .snapshot = test_snapshot,
     };
-    const row_budget: u16 = 14;
+    const row_budget: u16 = 15;
     const rows = menuRowCount(projection, width, row_budget);
     try std.testing.expectEqual(row_budget, rows);
 
@@ -487,7 +487,7 @@ test "settings menu renders category tabs and a flat full list through the VT" {
     var text: std.ArrayList(u8) = .empty;
     defer text.deinit(alloc);
     try grid.rowTextTrimmed(1, &text);
-    try std.testing.expect(std.mem.find(u8, text.items, "Settings 12") != null);
+    try std.testing.expect(std.mem.find(u8, text.items, "Settings 13") != null);
     try std.testing.expect(std.mem.find(u8, text.items, "[All]") != null);
     try std.testing.expect(std.mem.find(u8, text.items, "Interface") != null);
     text.clearRetainingCapacity();
@@ -495,6 +495,6 @@ test "settings menu renders category tabs and a flat full list through the VT" {
     try std.testing.expect(std.mem.find(u8, text.items, "Status line context") != null);
     try std.testing.expect(std.mem.find(u8, text.items, "Interface") == null);
     text.clearRetainingCapacity();
-    try grid.rowTextTrimmed(14, &text);
+    try grid.rowTextTrimmed(15, &text);
     try std.testing.expect(std.mem.find(u8, text.items, "Prompt history") != null);
 }

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -7,6 +7,7 @@ const text_utils = @import("../core/shared/text_utils.zig");
 const types = @import("../core/shared/types.zig");
 const image_attachments = @import("../core/images/image_attachments.zig");
 const assistant_presentation = @import("../core/agent/assistant_presentation.zig");
+const presentation_palette = @import("../core/shared/presentation_palette.zig");
 const main = @import("../main.zig");
 const theme_detection = @import("terminal/theme_detection.zig");
 const theme_protocol = @import("terminal/theme_protocol.zig");
@@ -15,6 +16,7 @@ const update_target = @import("../core/upgrade/update_target.zig");
 
 pub const input_prefix = "❯ ";
 pub const TerminalRgb = user_message_card.Rgb;
+pub const ColorPalette = presentation_palette.ColorPalette;
 pub const reset_style = "\x1b[0m";
 pub const bold_style = "\x1b[1m";
 pub const app_name = "fx";
@@ -55,6 +57,7 @@ pub var selected_completion_style: []const u8 = "\x1b[1;38;5;255m";
 // Statusbar permissions "auto": a step brighter than the statusline gray.
 pub var permission_auto_style: []const u8 = "\x1b[38;5;252m";
 var active_terminal_background: ?TerminalRgb = null;
+var active_color_palette: ColorPalette = .fx;
 
 var truecolor_enabled: bool = true;
 
@@ -62,51 +65,47 @@ pub fn setTruecolorSupport(enabled: bool) void {
     truecolor_enabled = enabled;
 }
 
+/// Compatibility entry point for callers that predate configurable palettes.
+/// It intentionally always selects the historical .fx palette.
 pub fn initTheme(light: bool, terminal_bg: ?TerminalRgb) void {
+    initThemeForPalette(light, terminal_bg, .fx);
+}
+
+pub fn initThemeForPalette(
+    light: bool,
+    terminal_bg: ?TerminalRgb,
+    palette: ColorPalette,
+) void {
     is_light = light;
     active_terminal_background = terminal_bg;
-    assistant_presentation.setInlineCodeTheme(light);
-    if (light) {
-        divider_style = "\x1b[38;5;250m";
-        hint_style = "\x1b[38;5;235m";
-        statusline_style = "\x1b[38;5;241m";
-        tag_style = "\x1b[1;38;5;235m";
-        subtitle_style = "\x1b[1;38;5;235m";
-        system_notice_label_style = "\x1b[1;38;5;238m";
-        system_notice_text_style = "\x1b[38;5;241m";
-        dim_style = "\x1b[38;5;247m";
-        warning_style = "\x1b[38;5;238m";
-        green_style = "\x1b[38;5;238m";
-        red_style = "\x1b[38;5;238m";
-        diff_added_style = "\x1b[38;5;238m";
-        diff_removed_style = "\x1b[38;5;238m";
-        approval_button_active_style = "\x1b[48;5;236m\x1b[38;5;255m\x1b[1m";
-        approval_button_inactive_style = "\x1b[48;5;251m\x1b[38;5;237m";
-        selected_completion_style = "\x1b[1;38;5;235m";
-        permission_auto_style = "\x1b[38;5;238m";
-    } else {
-        divider_style = "\x1b[38;5;240m";
-        hint_style = "\x1b[38;5;255m";
-        statusline_style = "\x1b[38;5;245m";
-        tag_style = "\x1b[1;38;5;255m";
-        subtitle_style = "\x1b[1;38;5;255m";
-        system_notice_label_style = "\x1b[1;38;5;252m";
-        system_notice_text_style = "\x1b[38;5;250m";
-        dim_style = "\x1b[38;5;245m";
-        warning_style = "\x1b[38;5;252m";
-        green_style = "\x1b[38;5;252m";
-        red_style = "\x1b[38;5;252m";
-        diff_added_style = "\x1b[38;5;252m";
-        diff_removed_style = "\x1b[38;5;252m";
-        approval_button_active_style = "\x1b[48;5;255m\x1b[38;5;235m\x1b[1m";
-        approval_button_inactive_style = "\x1b[48;5;239m\x1b[38;5;255m";
-        selected_completion_style = "\x1b[1;38;5;255m";
-        permission_auto_style = "\x1b[38;5;252m";
-    }
+    active_color_palette = palette;
+    presentation_palette.setActive(light, palette);
+    const styles = presentation_palette.styles(light, palette);
+    divider_style = styles.divider;
+    hint_style = styles.hint;
+    statusline_style = styles.statusline;
+    tag_style = styles.tag;
+    subtitle_style = styles.subtitle;
+    system_notice_label_style = styles.system_notice_label;
+    system_notice_text_style = styles.system_notice_text;
+    dim_style = styles.dim;
+    warning_style = styles.warning;
+    green_style = styles.green;
+    red_style = styles.red;
+    diff_added_style = styles.diff_added;
+    diff_removed_style = styles.diff_removed;
+    approval_button_active_style = styles.approval_active;
+    approval_button_inactive_style = styles.approval_inactive;
+    selected_completion_style = styles.selected_completion;
+    permission_auto_style = styles.permission_auto;
+    assistant_presentation.setInlineCodePalette(light, palette);
 
     // The diff marker green/red reads the same on light and dark, so it is set
     // once here rather than per-theme.
-    if (truecolor_enabled) {
+    if (palette == .terminal) {
+        diff_added_marker_style = styles.diff_added_marker;
+        diff_removed_marker_style = styles.diff_removed_marker;
+    } else if (truecolor_enabled) {
         diff_added_marker_style = diff_added_marker_truecolor;
         diff_removed_marker_style = diff_removed_marker_truecolor;
     } else {
@@ -114,14 +113,32 @@ pub fn initTheme(light: bool, terminal_bg: ?TerminalRgb) void {
         diff_removed_marker_style = diff_removed_marker_fallback;
     }
 
-    user_message_card.setStyle(light, terminal_bg);
+    user_message_card.setStyleForPalette(light, terminal_bg, palette);
 }
 
 pub fn themeNeedsUpdate(light: bool, terminal_bg: ?TerminalRgb) bool {
+    return themeNeedsUpdateForPalette(light, terminal_bg, .fx);
+}
+
+pub fn themeNeedsUpdateForPalette(
+    light: bool,
+    terminal_bg: ?TerminalRgb,
+    palette: ColorPalette,
+) bool {
+    if (palette != active_color_palette) return true;
     if (light != is_light) return true;
     const background = terminal_bg orelse return false;
     const current = active_terminal_background orelse return true;
     return current.r != background.r or current.g != background.g or current.b != background.b;
+}
+
+pub fn setColorPalette(palette: ColorPalette) void {
+    active_color_palette = palette;
+    presentation_palette.setActive(is_light, palette);
+}
+
+pub fn currentColorPalette() ColorPalette {
+    return active_color_palette;
 }
 
 // Explicit theme overrides skip OSC 11, leaving `rgb` null for fallback shading.
@@ -867,6 +884,19 @@ test "initTheme selects the light inline code foreground" {
 
     try processor.push(alloc, "run `zig build` now\n", &out);
     try std.testing.expectEqualStrings("run \x1b[38;5;247mzig build\x1b[39m now\n", out.items);
+}
+
+test "terminal palette uses default foreground and ANSI-16 semantic styles" {
+    initThemeForPalette(false, null, .terminal);
+    defer initTheme(false, null);
+
+    try std.testing.expectEqual(ColorPalette.terminal, currentColorPalette());
+    try std.testing.expectEqualStrings("\x1b[39m", system_notice_text_style);
+    try std.testing.expectEqualStrings("\x1b[32m", green_style);
+    try std.testing.expectEqualStrings("\x1b[31m", red_style);
+    try std.testing.expectEqualStrings("\x1b[90m", dim_style);
+    try std.testing.expect(std.mem.indexOf(u8, approval_button_active_style, "38;5;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, approval_button_active_style, "48;5;") == null);
 }
 
 test "welcomeMessage shows version and help hint" {

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -45,12 +45,8 @@ pub var diff_removed_style: []const u8 = "\x1b[38;5;252m";
 // monochrome diff: green for additions (#30A46C), red for deletions
 // (#E5484D). The line text stays neutral. Truecolor when the terminal
 // supports it, 256-color fallback otherwise.
-const diff_added_marker_truecolor = "\x1b[38;2;48;164;108m";
-const diff_removed_marker_truecolor = "\x1b[38;2;229;72;77m";
-const diff_added_marker_fallback = "\x1b[38;5;71m";
-const diff_removed_marker_fallback = "\x1b[38;5;167m";
-pub var diff_added_marker_style: []const u8 = diff_added_marker_fallback;
-pub var diff_removed_marker_style: []const u8 = diff_removed_marker_fallback;
+pub var diff_added_marker_style: []const u8 = "\x1b[38;5;71m";
+pub var diff_removed_marker_style: []const u8 = "\x1b[38;5;167m";
 pub var approval_button_active_style: []const u8 = "\x1b[48;5;255m\x1b[38;5;235m\x1b[1m";
 pub var approval_button_inactive_style: []const u8 = "\x1b[48;5;239m\x1b[38;5;255m";
 pub var selected_completion_style: []const u8 = "\x1b[1;38;5;255m";
@@ -63,6 +59,10 @@ var truecolor_enabled: bool = true;
 
 pub fn setTruecolorSupport(enabled: bool) void {
     truecolor_enabled = enabled;
+}
+
+pub fn truecolorEnabled() bool {
+    return truecolor_enabled;
 }
 
 /// Compatibility entry point for callers that predate configurable palettes.
@@ -79,8 +79,7 @@ pub fn initThemeForPalette(
     is_light = light;
     active_terminal_background = terminal_bg;
     active_color_palette = palette;
-    presentation_palette.setActive(light, palette);
-    const styles = presentation_palette.styles(light, palette);
+    const styles = presentation_palette.stylesForTerminal(light, palette, truecolor_enabled);
     divider_style = styles.divider;
     hint_style = styles.hint;
     statusline_style = styles.statusline;
@@ -100,18 +99,8 @@ pub fn initThemeForPalette(
     permission_auto_style = styles.permission_auto;
     assistant_presentation.setInlineCodePalette(light, palette);
 
-    // The diff marker green/red reads the same on light and dark, so it is set
-    // once here rather than per-theme.
-    if (palette == .terminal) {
-        diff_added_marker_style = styles.diff_added_marker;
-        diff_removed_marker_style = styles.diff_removed_marker;
-    } else if (truecolor_enabled) {
-        diff_added_marker_style = diff_added_marker_truecolor;
-        diff_removed_marker_style = diff_removed_marker_truecolor;
-    } else {
-        diff_added_marker_style = diff_added_marker_fallback;
-        diff_removed_marker_style = diff_removed_marker_fallback;
-    }
+    diff_added_marker_style = styles.diff_added_marker;
+    diff_removed_marker_style = styles.diff_removed_marker;
 
     user_message_card.setStyleForPalette(light, terminal_bg, palette);
 }
@@ -132,13 +121,14 @@ pub fn themeNeedsUpdateForPalette(
     return current.r != background.r or current.g != background.g or current.b != background.b;
 }
 
-pub fn setColorPalette(palette: ColorPalette) void {
-    active_color_palette = palette;
-    presentation_palette.setActive(is_light, palette);
-}
-
 pub fn currentColorPalette() ColorPalette {
     return active_color_palette;
+}
+
+/// Switch only fx-owned live presentation. Retained transcript bytes are not
+/// inspected or rewritten; the next redraw interprets those bytes unchanged.
+pub fn applyColorPalette(palette: ColorPalette) void {
+    initThemeForPalette(is_light, active_terminal_background, palette);
 }
 
 // Explicit theme overrides skip OSC 11, leaving `rgb` null for fallback shading.

--- a/src/ui/render_engine/assistant_wrap.zig
+++ b/src/ui/render_engine/assistant_wrap.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const build_checkpoint = @import("build_checkpoint.zig");
 const display_width = @import("../../core/shared/display_width.zig");
 const assistant_pacer = @import("../assistant/pacer.zig");
+const assistant_ansi = @import("../../core/agent/presentation/ansi.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -986,7 +987,11 @@ fn dimTaskMarkerWidth(text: []const u8, start: usize) ?usize {
 
 fn taskMarkerWidth(text: []const u8, start: usize) ?usize {
     const dim_open = "\x1b[2m";
-    const completed_opens = [_][]const u8{ "\x1b[38;5;252m", "\x1b[38;5;238m" };
+    const completed_opens = [_][]const u8{
+        "\x1b[38;5;252m",
+        "\x1b[38;5;238m",
+        assistant_ansi.taskCompletedStyle(false, .terminal),
+    };
     const completed_close = "\x1b[39m";
     const completed = "\xe2\x9c\x93";
 

--- a/src/ui/render_engine/code_highlight.zig
+++ b/src/ui/render_engine/code_highlight.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const languages = @import("code_highlight_languages.zig");
+const presentation_palette = @import("../../core/shared/presentation_palette.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -8,6 +9,7 @@ const reset_style = "\x1b[39m";
 pub const Theme = enum {
     dark,
     light,
+    terminal,
 };
 
 const Palette = struct {
@@ -17,24 +19,25 @@ const Palette = struct {
     comment_style: []const u8,
 };
 
-const dark_palette: Palette = .{
-    .keyword_style = "\x1b[38;5;252m",
-    .string_style = "\x1b[38;5;250m",
-    .number_style = "\x1b[38;5;250m",
-    .comment_style = "\x1b[38;5;245m",
-};
-
-const light_palette: Palette = .{
-    .keyword_style = "\x1b[38;5;238m",
-    .string_style = "\x1b[38;5;241m",
-    .number_style = "\x1b[38;5;241m",
-    .comment_style = "\x1b[38;5;243m",
-};
-
 fn paletteForTheme(theme: Theme) Palette {
+    const configured = switch (theme) {
+        .dark => presentation_palette.styles(false, .fx),
+        .light => presentation_palette.styles(true, .fx),
+        .terminal => presentation_palette.styles(false, .terminal),
+    };
     return switch (theme) {
-        .dark => dark_palette,
-        .light => light_palette,
+        .dark, .light => .{
+            .keyword_style = configured.code_keyword,
+            .string_style = configured.code_string,
+            .number_style = configured.code_number,
+            .comment_style = configured.code_comment,
+        },
+        .terminal => .{
+            .keyword_style = configured.code_keyword,
+            .string_style = configured.code_string,
+            .number_style = configured.code_number,
+            .comment_style = configured.code_comment,
+        },
     };
 }
 
@@ -242,6 +245,22 @@ test "light theme uses a readable syntax palette without changing code bytes" {
     try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[38;5;241m\"ready\"\x1b[39m") != null);
     try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[38;5;243m// comment\x1b[39m") != null);
     try std.testing.expectEqual(count(styled, "\x1b[38;5;"), count(styled, "\x1b[39m"));
+}
+
+test "terminal theme uses default-safe ANSI-16 syntax colors" {
+    const alloc = std.testing.allocator;
+    const source = "const value = \"ready\"; // comment\n";
+    const styled = try highlight(alloc, source, languages.resolve("zig").?, .terminal);
+    defer alloc.free(styled);
+
+    const plain = try stripAnsi(alloc, styled);
+    defer alloc.free(plain);
+    try std.testing.expectEqualStrings(source, plain);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[34mconst\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[32m\"ready\"\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "\x1b[90m// comment\x1b[39m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "38;5;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, styled, "38;2;") == null);
 }
 
 test "every registered profile highlights representative source" {

--- a/src/ui/render_engine/transcript_blocks.zig
+++ b/src/ui/render_engine/transcript_blocks.zig
@@ -10,6 +10,7 @@ const user_message_card = @import("../assistant/user_message_card.zig");
 const input_visual_layout = @import("../input/visual_layout.zig");
 const vt_emulator = @import("../../core/terminal/engine.zig");
 const assistant_presentation = @import("../../core/agent/assistant_presentation.zig");
+const presentation_palette = @import("../../core/shared/presentation_palette.zig");
 const code_highlight = @import("code_highlight.zig");
 const code_highlight_languages = @import("code_highlight_languages.zig");
 
@@ -332,6 +333,7 @@ pub const TranscriptEntry = union(enum) {
         created_at_ms: i64 = 0,
         turn: types.UserTurn,
         skill_tokens: []input_visual_layout.SkillTokenSpan = &.{},
+        presentation: ?presentation_palette.PresentationTheme = null,
     };
 
     pub const AssistantTurnEntry = struct {
@@ -350,6 +352,7 @@ pub const TranscriptEntry = union(enum) {
         id: u32,
         created_at_ms: i64 = 0,
         block: assistant_presentation.CodeBlockPayload,
+        presentation: ?presentation_palette.PresentationTheme = null,
     };
 
     pub const AssistantThematicRuleEntry = struct {
@@ -1569,14 +1572,25 @@ fn renderEntryToBlockForPresentationInterruptible(
             break :blk try normalizeOwnedRenderedBlock(alloc, kind, rendered);
         },
         .user_turn => |e| blk: {
-            const card = try user_message_card.buildUserPromptCardWithSkillTokensForTerminalPresentationInterruptible(
-                alloc,
-                e.turn.text,
-                e.turn.images,
-                cols,
-                e.skill_tokens,
-                checkpoint,
-            );
+            const card = if (e.presentation) |theme|
+                try user_message_card.buildUserPromptCardWithPresentationStylesInterruptible(
+                    alloc,
+                    e.turn.text,
+                    e.turn.images,
+                    cols,
+                    e.skill_tokens,
+                    presentation_palette.snapshotForTheme(theme),
+                    checkpoint,
+                )
+            else
+                try user_message_card.buildUserPromptCardWithSkillTokensForTerminalPresentationInterruptible(
+                    alloc,
+                    e.turn.text,
+                    e.turn.images,
+                    cols,
+                    e.skill_tokens,
+                    checkpoint,
+                );
             break :blk try normalizeOwnedRenderedBlock(alloc, kind, card);
         },
         .assistant_turn => |e| blk: {
@@ -1611,7 +1625,11 @@ fn renderEntryToBlockForPresentationInterruptible(
                 alloc,
                 e.block,
                 cols -| gutter,
-                styles.code_highlight_theme,
+                if (e.presentation) |theme| switch (theme) {
+                    .dark => .dark,
+                    .light => .light,
+                    .terminal => .terminal,
+                } else styles.code_highlight_theme,
             );
             defer alloc.free(rendered);
             const prefixed = try assistant_wrap.prefixStructuralRows(alloc, rendered, gutter);

--- a/src/ui/transcript/command_output_runtime.zig
+++ b/src/ui/transcript/command_output_runtime.zig
@@ -28,6 +28,21 @@ const transcript_blocks = render_engine.transcript_blocks;
 
 const Styles = transcript_blocks.Styles;
 
+fn stylesEqual(lhs: Styles, rhs: Styles) bool {
+    return std.mem.eql(u8, lhs.system_notice_label_style, rhs.system_notice_label_style) and
+        std.mem.eql(u8, lhs.system_notice_text_style, rhs.system_notice_text_style) and
+        std.mem.eql(u8, lhs.reset_style, rhs.reset_style) and
+        std.mem.eql(u8, lhs.dim_style, rhs.dim_style) and
+        std.mem.eql(u8, lhs.red_style, rhs.red_style) and
+        std.mem.eql(u8, lhs.cancelled_text_style, rhs.cancelled_text_style) and
+        std.mem.eql(u8, lhs.notice_information_style, rhs.notice_information_style) and
+        std.mem.eql(u8, lhs.notice_success_style, rhs.notice_success_style) and
+        std.mem.eql(u8, lhs.notice_warning_style, rhs.notice_warning_style) and
+        std.mem.eql(u8, lhs.notice_error_style, rhs.notice_error_style) and
+        std.mem.eql(u8, lhs.notice_cancelled_style, rhs.notice_cancelled_style) and
+        lhs.code_highlight_theme == rhs.code_highlight_theme;
+}
+
 fn requestTranscriptPaint(shell: anytype, entry_id: ?u32) void {
     const Runtime = @TypeOf(shell.*);
     if (entry_id) |dirty_entry_id| {
@@ -319,9 +334,16 @@ pub fn resetCommandOutputDisplay(shell: anytype, alloc: Allocator, reason: []con
 }
 
 pub fn setCommandOutputRenderPolicy(shell: anytype, styles: Styles) void {
+    const changed = !stylesEqual(shell.command_output_render.styles, styles);
     shell.command_output_render = .{
         .styles = styles,
     };
+    if (changed) {
+        const Runtime = @TypeOf(shell.*);
+        if (comptime @hasDecl(Runtime, "noteCommandOutputRenderPolicyChanged")) {
+            shell.noteCommandOutputRenderPolicyChanged();
+        }
+    }
 }
 
 const PreparedCanonicalRecord = struct {

--- a/src/ui/transcript/painter.zig
+++ b/src/ui/transcript/painter.zig
@@ -395,12 +395,17 @@ fn foldedLineBytes(
     stream: command_output_content.Stream,
     styles: transcript_blocks.Styles,
 ) ![]u8 {
+    // These are only a last-resort path for detached/test shells whose
+    // command-output policy has not been initialized yet.  Keep them in the
+    // portable ANSI range so an uninitialized terminal render can never leak
+    // the Fx 256-color palette.  Normal initialized shells always provide the
+    // policy styles above and therefore keep their exact existing output.
     const style = if (stream == .stderr)
-        if (styles.red_style.len > 0) styles.red_style else "\x1b[38;5;252m"
+        if (styles.red_style.len > 0) styles.red_style else "\x1b[31m"
     else if (styles.dim_style.len > 0)
         styles.dim_style
     else
-        "\x1b[38;5;245m";
+        "\x1b[90m";
     const trimmed = stripTrailingNewline(text);
     const reset = "\x1b[0m";
     const bytes = try alloc.alloc(u8, style.len + "│ ".len + trimmed.len + reset.len);
@@ -4126,6 +4131,23 @@ test "transcript surface painter renders folded stdout and stderr" {
     defer target.deinit();
     try expectGridContains(&target, alloc, "stdout");
     try expectGridContains(&target, alloc, "stderr");
+}
+
+test "empty command-output policy uses portable ANSI fallback" {
+    const alloc = std.testing.allocator;
+    const styles: transcript_blocks.Styles = .{};
+
+    const stdout = try foldedLineBytes(alloc, "stdout\n", .stdout, styles);
+    defer alloc.free(stdout);
+    try std.testing.expectEqualStrings("\x1b[90m│ stdout\x1b[0m", stdout);
+
+    const stderr = try foldedLineBytes(alloc, "stderr\n", .stderr, styles);
+    defer alloc.free(stderr);
+    try std.testing.expectEqualStrings("\x1b[31m│ stderr\x1b[0m", stderr);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "38;5;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stdout, "38;2;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stderr, "38;5;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, stderr, "38;2;") == null);
 }
 
 test "transcript surface painter renders block gap rows" {

--- a/src/ui/transcript/painter.zig
+++ b/src/ui/transcript/painter.zig
@@ -289,7 +289,12 @@ fn renderTranscriptRows(
                 rendered.last_visible_row_blank = blank;
             },
             .folded_line => |folded| {
-                var folded_bytes = try foldedLineBytes(alloc, folded.text, folded.stream);
+                var folded_bytes = try foldedLineBytes(
+                    alloc,
+                    folded.text,
+                    folded.stream,
+                    commandOutputStyles(self),
+                );
                 var folded_bytes_needs_free = true;
                 errdefer if (folded_bytes_needs_free) alloc.free(folded_bytes);
                 const rows_touched = visualRowsForLine(folded_bytes, self.layout.cols);
@@ -376,8 +381,26 @@ fn foldedPartialTailBytes(self: anytype, bytes: []const u8, partial_skip_rows: u
     return if (offset < bytes.len) bytes[offset..] else "";
 }
 
-fn foldedLineBytes(alloc: Allocator, text: []const u8, stream: command_output_content.Stream) ![]u8 {
-    const style = if (stream == .stderr) "\x1b[38;5;252m" else "\x1b[38;5;245m";
+fn commandOutputStyles(self: anytype) transcript_blocks.Styles {
+    const Runtime = @TypeOf(self.*);
+    if (comptime @hasField(Runtime, "command_output_render")) {
+        return self.command_output_render.styles;
+    }
+    return .{};
+}
+
+fn foldedLineBytes(
+    alloc: Allocator,
+    text: []const u8,
+    stream: command_output_content.Stream,
+    styles: transcript_blocks.Styles,
+) ![]u8 {
+    const style = if (stream == .stderr)
+        if (styles.red_style.len > 0) styles.red_style else "\x1b[38;5;252m"
+    else if (styles.dim_style.len > 0)
+        styles.dim_style
+    else
+        "\x1b[38;5;245m";
     const trimmed = stripTrailingNewline(text);
     const reset = "\x1b[0m";
     const bytes = try alloc.alloc(u8, style.len + "│ ".len + trimmed.len + reset.len);

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -35,6 +35,7 @@ const tool_result_errors = @import("../../core/tooling/tool_result_errors.zig");
 const vt_emulator = @import("../../core/terminal/engine.zig");
 const result_store = @import("../../core/session/result_store.zig");
 const session_child_store = @import("../../core/session/session_child_store.zig");
+const presentation_palette = @import("../../core/shared/presentation_palette.zig");
 
 const Allocator = std.mem.Allocator;
 const Layout = types.Layout;
@@ -1548,6 +1549,7 @@ test "compact transcript cache survives navigation and invalidates on content ch
         runtime.full_transcript_content_revision,
         runtime.layout.cols,
         runtime.has_committed_frame,
+        runtime.presentation_style_generation,
     ).?;
     const compact_bytes = cached_compact.bytes.ptr;
     try std.testing.expect(cached_compact.hard_line_starts.len > 0);
@@ -1570,12 +1572,14 @@ test "compact transcript cache survives navigation and invalidates on content ch
         runtime.full_transcript_content_revision,
         runtime.layout.cols,
         runtime.has_committed_frame,
+        runtime.presentation_style_generation,
     ).?.bytes.ptr);
     runtime.has_committed_frame = true;
     try std.testing.expectEqual(@as(?*TranscriptPreparationSource, null), runtime.compact_transcript_source_cache.find(
         runtime.full_transcript_content_revision,
         runtime.layout.cols,
         runtime.has_committed_frame,
+        runtime.presentation_style_generation,
     ));
     var committed_compact = try runtime.cachedTranscriptSource(alloc);
     committed_compact.deinit(alloc);
@@ -1588,6 +1592,7 @@ test "compact transcript cache survives navigation and invalidates on content ch
         runtime.full_transcript_content_revision,
         runtime.layout.cols,
         runtime.has_committed_frame,
+        runtime.presentation_style_generation,
     ).?.bytes.ptr);
 }
 
@@ -1664,6 +1669,7 @@ test "clearing a transcript releases compact source and installed page" {
         content_revision,
         runtime.layout.cols,
         runtime.has_committed_frame,
+        runtime.presentation_style_generation,
     ) != null);
     try std.testing.expect(runtime.full_transcript_installed_page != null);
 
@@ -1673,6 +1679,7 @@ test "clearing a transcript releases compact source and installed page" {
         content_revision,
         runtime.layout.cols,
         runtime.has_committed_frame,
+        runtime.presentation_style_generation,
     ) == null);
     try std.testing.expect(runtime.full_transcript_installed_page == null);
 }
@@ -4057,6 +4064,7 @@ const CachedCompactTranscriptSource = struct {
     content_revision: u64,
     cols: u16,
     has_committed_frame: bool,
+    presentation_generation: u64,
 };
 
 const CompactTranscriptSourceCache = struct {
@@ -4077,12 +4085,14 @@ const CompactTranscriptSourceCache = struct {
         content_revision: u64,
         cols: u16,
         has_committed_frame: bool,
+        presentation_generation: u64,
     ) ?*TranscriptPreparationSource {
         for (&self.entries) |*entry| {
             if (entry.*) |*cached| {
                 if (cached.content_revision == content_revision and
                     cached.cols == cols and
-                    cached.has_committed_frame == has_committed_frame)
+                    cached.has_committed_frame == has_committed_frame and
+                    cached.presentation_generation == presentation_generation)
                 {
                     return &cached.source;
                 }
@@ -4195,6 +4205,11 @@ pub const TranscriptRuntime = struct {
     full_transcript_restore_open_pending: bool = false,
     full_transcript_prepared_page_visible: bool = false,
     full_transcript_content_revision: u64 = 0,
+    /// Monotonically changes whenever the style-dependent command-output
+    /// policy changes.  It is deliberately separate from content revision:
+    /// palette switches invalidate only derived projections, never retained
+    /// transcript bytes or semantic/raw entries.
+    presentation_style_generation: u64 = 0,
     compact_transcript_source_cache: CompactTranscriptSourceCache = .{},
     /// When enabled, compact transcript tool groups render only their summary
     /// header while the full transcript retains every individual tool call.
@@ -6031,6 +6046,26 @@ pub const TranscriptRuntime = struct {
         );
     }
 
+    pub fn writeUserPromptCardWithPresentationStyles(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        metrics: *Metrics,
+        user: types.UserTurn,
+        has_prior_turns: bool,
+        skill_tokens: []const input_visual_layout.SkillTokenSpan,
+        presentation: presentation_palette.PresentationSnapshot,
+    ) !u32 {
+        return transcript_store.writeUserPromptCardWithPresentationStyles(
+            self,
+            alloc,
+            metrics,
+            user,
+            has_prior_turns,
+            skill_tokens,
+            presentation,
+        );
+    }
+
     /// Consumes `turn` regardless of outcome. All owned slices must use `alloc`;
     /// the entry owns them on success and this method frees them on failure.
     /// Returns the stamped entry id.
@@ -6065,6 +6100,20 @@ pub const TranscriptRuntime = struct {
         return transcript_store.appendAssistantTableOwned(self, alloc, table);
     }
 
+    pub fn appendAssistantTableOwnedWithPresentationStyles(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        table: @import("../../core/agent/assistant_presentation.zig").TablePayload,
+        presentation: presentation_palette.PresentationSnapshot,
+    ) !u32 {
+        return transcript_store.appendAssistantTableOwnedWithPresentationStyles(
+            self,
+            alloc,
+            table,
+            presentation,
+        );
+    }
+
     /// Takes ownership of `block` only when it returns successfully.
     pub fn appendAssistantCodeBlockOwned(
         self: *TranscriptRuntime,
@@ -6074,8 +6123,34 @@ pub const TranscriptRuntime = struct {
         return transcript_store.appendAssistantCodeBlockOwned(self, alloc, block);
     }
 
+    pub fn appendAssistantCodeBlockOwnedWithPresentationStyles(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        block: @import("../../core/agent/assistant_presentation.zig").CodeBlockPayload,
+        presentation: presentation_palette.PresentationSnapshot,
+    ) !u32 {
+        return transcript_store.appendAssistantCodeBlockOwnedWithPresentationStyles(
+            self,
+            alloc,
+            block,
+            presentation,
+        );
+    }
+
     pub fn appendAssistantThematicRule(self: *TranscriptRuntime, alloc: Allocator) !u32 {
         return transcript_store.appendAssistantThematicRule(self, alloc);
+    }
+
+    pub fn appendAssistantThematicRuleWithPresentationStyles(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        presentation: presentation_palette.PresentationSnapshot,
+    ) !u32 {
+        return transcript_store.appendAssistantThematicRuleWithPresentationStyles(
+            self,
+            alloc,
+            presentation,
+        );
     }
 
     /// Walk `entries` and return a pointer to the segments of the
@@ -6127,24 +6202,6 @@ pub const TranscriptRuntime = struct {
         to_light: bool,
     ) !void {
         return transcript_store.retintEntriesForTheme(self, alloc, from_light, to_light);
-    }
-
-    pub fn retintEntriesForPalette(
-        self: *TranscriptRuntime,
-        alloc: Allocator,
-        from_light: bool,
-        to_light: bool,
-        from_palette: ui_render.ColorPalette,
-        to_palette: ui_render.ColorPalette,
-    ) !void {
-        return transcript_store.retintEntriesForPalette(
-            self,
-            alloc,
-            from_light,
-            to_light,
-            from_palette,
-            to_palette,
-        );
     }
 
     pub fn setTranscriptPresentationDepth(
@@ -9271,6 +9328,13 @@ pub const TranscriptRuntime = struct {
         return command_output_runtime.setCommandOutputRenderPolicy(self, styles);
     }
 
+    /// Called by command_output_runtime only when the effective policy bytes
+    /// actually change.  Keeping this hook on the runtime lets all producer
+    /// paths share one generation without forcing a content mutation.
+    pub fn noteCommandOutputRenderPolicyChanged(self: *TranscriptRuntime) void {
+        self.presentation_style_generation +%= 1;
+    }
+
     pub fn retainedTranscriptStyles(self: *const TranscriptRuntime) Styles {
         return self.command_output_render.styles;
     }
@@ -9477,6 +9541,7 @@ pub const TranscriptRuntime = struct {
             self.full_transcript_content_revision,
             self.layout.cols,
             self.has_committed_frame,
+            self.presentation_style_generation,
         )) |source| {
             source.preview.cursor_row = self.cursor_row;
             source.preview.cursor_col = self.cursor_col;
@@ -9500,6 +9565,7 @@ pub const TranscriptRuntime = struct {
             .content_revision = self.full_transcript_content_revision,
             .cols = self.layout.cols,
             .has_committed_frame = self.has_committed_frame,
+            .presentation_generation = self.presentation_style_generation,
         });
         return cached.clone(alloc);
     }
@@ -9835,6 +9901,7 @@ pub const TranscriptRuntime = struct {
             .content_revision = self.full_transcript_content_revision,
             .cols = self.layout.cols,
             .anchor = self.full_transcript_page_anchor,
+            .presentation_generation = self.presentation_style_generation,
         };
     }
 

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -6129,6 +6129,24 @@ pub const TranscriptRuntime = struct {
         return transcript_store.retintEntriesForTheme(self, alloc, from_light, to_light);
     }
 
+    pub fn retintEntriesForPalette(
+        self: *TranscriptRuntime,
+        alloc: Allocator,
+        from_light: bool,
+        to_light: bool,
+        from_palette: ui_render.ColorPalette,
+        to_palette: ui_render.ColorPalette,
+    ) !void {
+        return transcript_store.retintEntriesForPalette(
+            self,
+            alloc,
+            from_light,
+            to_light,
+            from_palette,
+            to_palette,
+        );
+    }
+
     pub fn setTranscriptPresentationDepth(
         self: *TranscriptRuntime,
         alloc: Allocator,

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -26,12 +26,12 @@ const render_engine = @import("../render_engine.zig");
 const source_preparation = @import("source_preparation.zig");
 const user_message_card = @import("../assistant/user_message_card.zig");
 const input_visual_layout = @import("../input/visual_layout.zig");
+const presentation_palette = @import("../../core/shared/presentation_palette.zig");
 
 const Allocator = std.mem.Allocator;
 const Metrics = types.Metrics;
 const transcript_blocks = render_engine.transcript_blocks;
 const assistant_presentation = @import("../../core/agent/assistant_presentation.zig");
-const presentation_palette = @import("../../core/shared/presentation_palette.zig");
 
 const AssistantTurnSegments = transcript_blocks.AssistantTurnSegments;
 const RawEntryClass = transcript_blocks.RawEntryClass;
@@ -2016,6 +2016,7 @@ pub fn cloneEntryForSnapshot(alloc: Allocator, entry: TranscriptEntry) !Transcri
                 .created_at_ms = user.created_at_ms,
                 .turn = turn,
                 .skill_tokens = skill_tokens,
+                .presentation = user.presentation,
             } };
         },
         .assistant_turn => |assistant| blk: {
@@ -2037,6 +2038,7 @@ pub fn cloneEntryForSnapshot(alloc: Allocator, entry: TranscriptEntry) !Transcri
             .id = assistant.id,
             .created_at_ms = assistant.created_at_ms,
             .block = try assistant.block.clone(alloc),
+            .presentation = assistant.presentation,
         } },
         .assistant_thematic_rule => |assistant| .{ .assistant_thematic_rule = .{
             .id = assistant.id,
@@ -2456,6 +2458,46 @@ pub fn writeUserPromptCard(
     has_prior_turns: bool,
     skill_tokens: []const SkillTokenSpan,
 ) !u32 {
+    return writeUserPromptCardWithOptionalPresentation(
+        self,
+        alloc,
+        metrics,
+        user,
+        has_prior_turns,
+        skill_tokens,
+        null,
+    );
+}
+
+pub fn writeUserPromptCardWithPresentationStyles(
+    self: anytype,
+    alloc: Allocator,
+    metrics: *Metrics,
+    user: types.UserTurn,
+    has_prior_turns: bool,
+    skill_tokens: []const SkillTokenSpan,
+    presentation: presentation_palette.PresentationSnapshot,
+) !u32 {
+    return writeUserPromptCardWithOptionalPresentation(
+        self,
+        alloc,
+        metrics,
+        user,
+        has_prior_turns,
+        skill_tokens,
+        presentation,
+    );
+}
+
+fn writeUserPromptCardWithOptionalPresentation(
+    self: anytype,
+    alloc: Allocator,
+    metrics: *Metrics,
+    user: types.UserTurn,
+    has_prior_turns: bool,
+    skill_tokens: []const SkillTokenSpan,
+    presentation: ?presentation_palette.PresentationSnapshot,
+) !u32 {
     try self.assertCanMutateTranscript();
 
     var shadow = try cloneRecordedMutationState(self, alloc);
@@ -2470,13 +2512,23 @@ pub fn writeUserPromptCard(
         );
     }
 
-    const card = try user_message_card.buildUserPromptCardWithSkillTokensForTerminalPresentation(
-        alloc,
-        user.text,
-        user.images,
-        shadow.layout.cols,
-        skill_tokens,
-    );
+    const card = if (presentation) |snapshot|
+        try user_message_card.buildUserPromptCardWithPresentationStyles(
+            alloc,
+            user.text,
+            user.images,
+            shadow.layout.cols,
+            skill_tokens,
+            snapshot,
+        )
+    else
+        try user_message_card.buildUserPromptCardWithSkillTokensForTerminalPresentation(
+            alloc,
+            user.text,
+            user.images,
+            shadow.layout.cols,
+            skill_tokens,
+        );
     defer alloc.free(card);
     try shadow.writeTranscriptBytes(alloc, metrics, card, true);
 
@@ -2486,6 +2538,7 @@ pub fn writeUserPromptCard(
         alloc,
         user_copy,
         skill_tokens,
+        presentation,
     );
 
     try commitAuthoritativeRecordedMutationStateFromEntry(
@@ -2515,6 +2568,7 @@ pub fn appendUserTurnOwnedWithSkillTokens(
         alloc,
         turn,
         skill_tokens,
+        null,
     )).entry_id;
 }
 
@@ -2528,6 +2582,7 @@ fn appendUserTurnOwnedWithSkillTokensAndRetention(
     alloc: Allocator,
     turn: types.UserTurn,
     skill_tokens: []const SkillTokenSpan,
+    presentation: ?presentation_palette.PresentationSnapshot,
 ) !UserTurnAdmission {
     var owned_skill_tokens: []SkillTokenSpan = &.{};
     var handed_off = false;
@@ -2543,6 +2598,7 @@ fn appendUserTurnOwnedWithSkillTokensAndRetention(
         .created_at_ms = io_mod.milliTimestamp(),
         .turn = turn,
         .skill_tokens = owned_skill_tokens,
+        .presentation = if (presentation) |snapshot| snapshot.theme else null,
     } });
     handed_off = true;
     const retention_changed = try enforceStructuredRetentionAndReport(
@@ -2569,6 +2625,24 @@ pub fn appendAssistantTableOwned(
     self: anytype,
     alloc: Allocator,
     table: assistant_presentation.TablePayload,
+) !u32 {
+    return appendAssistantTableOwnedWithOptionalPresentation(self, alloc, table, null);
+}
+
+pub fn appendAssistantTableOwnedWithPresentationStyles(
+    self: anytype,
+    alloc: Allocator,
+    table: assistant_presentation.TablePayload,
+    presentation: presentation_palette.PresentationSnapshot,
+) !u32 {
+    return appendAssistantTableOwnedWithOptionalPresentation(self, alloc, table, presentation);
+}
+
+fn appendAssistantTableOwnedWithOptionalPresentation(
+    self: anytype,
+    alloc: Allocator,
+    table: assistant_presentation.TablePayload,
+    _: ?presentation_palette.PresentationSnapshot,
 ) !u32 {
     const entry_id = self.next_entry_id;
     try self.entries.append(alloc, .{ .assistant_table = .{
@@ -2601,11 +2675,30 @@ pub fn appendAssistantCodeBlockOwned(
     alloc: Allocator,
     block: assistant_presentation.CodeBlockPayload,
 ) !u32 {
+    return appendAssistantCodeBlockOwnedWithOptionalPresentation(self, alloc, block, null);
+}
+
+pub fn appendAssistantCodeBlockOwnedWithPresentationStyles(
+    self: anytype,
+    alloc: Allocator,
+    block: assistant_presentation.CodeBlockPayload,
+    presentation: presentation_palette.PresentationSnapshot,
+) !u32 {
+    return appendAssistantCodeBlockOwnedWithOptionalPresentation(self, alloc, block, presentation);
+}
+
+fn appendAssistantCodeBlockOwnedWithOptionalPresentation(
+    self: anytype,
+    alloc: Allocator,
+    block: assistant_presentation.CodeBlockPayload,
+    presentation: ?presentation_palette.PresentationSnapshot,
+) !u32 {
     const entry_id = self.next_entry_id;
     try self.entries.append(alloc, .{ .assistant_code_block = .{
         .id = entry_id,
         .created_at_ms = io_mod.milliTimestamp(),
         .block = block,
+        .presentation = if (presentation) |snapshot| snapshot.theme else null,
     } });
     errdefer {
         _ = self.entries.pop();
@@ -2627,6 +2720,22 @@ pub fn appendAssistantCodeBlockOwned(
 }
 
 pub fn appendAssistantThematicRule(self: anytype, alloc: Allocator) !u32 {
+    return appendAssistantThematicRuleWithOptionalPresentation(self, alloc, null);
+}
+
+pub fn appendAssistantThematicRuleWithPresentationStyles(
+    self: anytype,
+    alloc: Allocator,
+    presentation: presentation_palette.PresentationSnapshot,
+) !u32 {
+    return appendAssistantThematicRuleWithOptionalPresentation(self, alloc, presentation);
+}
+
+fn appendAssistantThematicRuleWithOptionalPresentation(
+    self: anytype,
+    alloc: Allocator,
+    _: ?presentation_palette.PresentationSnapshot,
+) !u32 {
     const entry_id = self.next_entry_id;
     try self.entries.append(alloc, .{ .assistant_thematic_rule = .{
         .id = entry_id,
@@ -2836,18 +2945,7 @@ pub fn retintEntriesForTheme(
     from_light: bool,
     to_light: bool,
 ) !void {
-    return retintEntriesForPalette(self, alloc, from_light, to_light, .fx, .fx);
-}
-
-pub fn retintEntriesForPalette(
-    self: anytype,
-    alloc: Allocator,
-    from_light: bool,
-    to_light: bool,
-    from_palette: presentation_palette.ColorPalette,
-    to_palette: presentation_palette.ColorPalette,
-) !void {
-    if (from_light == to_light and from_palette == to_palette) return;
+    if (from_light == to_light) return;
     try self.assertCanMutateTranscript();
 
     var shadow = try cloneMutationState(self, alloc);
@@ -2857,27 +2955,13 @@ pub fn retintEntriesForPalette(
         switch (entry.*) {
             .raw_bytes => |*raw| {
                 if (!themeOwnsRawEntry(raw.class)) continue;
-                if (try retintThemeBytes(
-                    alloc,
-                    raw.bytes,
-                    from_light,
-                    to_light,
-                    from_palette,
-                    to_palette,
-                )) |replacement| {
+                if (try retintThemeBytes(alloc, raw.bytes, from_light, to_light)) |replacement| {
                     alloc.free(raw.bytes);
                     raw.bytes = replacement;
                 }
             },
             .assistant_turn => |*assistant| {
-                if (try retintThemeBytes(
-                    alloc,
-                    assistant.segments.text.items,
-                    from_light,
-                    to_light,
-                    from_palette,
-                    to_palette,
-                )) |replacement| {
+                if (try retintThemeBytes(alloc, assistant.segments.text.items, from_light, to_light)) |replacement| {
                     assistant.segments.text.deinit(alloc);
                     assistant.segments.text = .fromOwnedSlice(replacement);
                 }
@@ -2903,6 +2987,29 @@ pub fn retintEntriesForPalette(
     );
 }
 
+const ThemeToken = struct {
+    from: []const u8,
+    to: []const u8,
+};
+
+const dark_to_light_theme_tokens = [_]ThemeToken{
+    .{ .from = "\x1b[1;38;5;255m", .to = "\x1b[1;38;5;235m" },
+    .{ .from = "\x1b[38;5;255m", .to = "\x1b[38;5;235m" },
+    .{ .from = "\x1b[1;38;5;252m", .to = "\x1b[1;38;5;238m" },
+    .{ .from = "\x1b[38;5;252m", .to = "\x1b[38;5;238m" },
+    .{ .from = "\x1b[38;5;250m", .to = "\x1b[38;5;241m" },
+    .{ .from = "\x1b[38;5;245m", .to = "\x1b[38;5;247m" },
+};
+
+const light_to_dark_theme_tokens = [_]ThemeToken{
+    .{ .from = "\x1b[1;38;5;235m", .to = "\x1b[1;38;5;255m" },
+    .{ .from = "\x1b[38;5;235m", .to = "\x1b[38;5;255m" },
+    .{ .from = "\x1b[1;38;5;238m", .to = "\x1b[1;38;5;252m" },
+    .{ .from = "\x1b[38;5;238m", .to = "\x1b[38;5;252m" },
+    .{ .from = "\x1b[38;5;241m", .to = "\x1b[38;5;250m" },
+    .{ .from = "\x1b[38;5;247m", .to = "\x1b[38;5;245m" },
+};
+
 fn themeOwnsRawEntry(class: RawEntryClass) bool {
     return switch (class) {
         .welcome,
@@ -2921,60 +3028,9 @@ fn retintThemeBytes(
     bytes: []const u8,
     from_light: bool,
     to_light: bool,
-    from_palette: presentation_palette.ColorPalette,
-    to_palette: presentation_palette.ColorPalette,
 ) !?[]u8 {
-    if (from_light == to_light and from_palette == to_palette) return null;
-
-    const from_styles = presentation_palette.styles(from_light, from_palette);
-    const to_styles = presentation_palette.styles(to_light, to_palette);
-    const ThemeToken = struct { from: []const u8, to: []const u8 };
-    var token_storage: [16]ThemeToken = undefined;
-    var token_count: usize = 0;
-
-    const appendToken = struct {
-        fn add(storage: []ThemeToken, count: *usize, from: []const u8, to: []const u8) void {
-            if (std.mem.eql(u8, from, to)) return;
-            if (count.* >= storage.len) return;
-            storage[count.*] = .{ .from = from, .to = to };
-            count.* += 1;
-        }
-    }.add;
-
-    if (from_palette == .fx and to_palette == .fx) {
-        // Keep the historical light/dark retint map byte-for-byte identical.
-        appendToken(token_storage[0..], &token_count, from_styles.tag, to_styles.tag);
-        appendToken(token_storage[0..], &token_count, from_styles.user_marker, to_styles.user_marker);
-        appendToken(token_storage[0..], &token_count, from_styles.system_notice_label, to_styles.system_notice_label);
-        appendToken(token_storage[0..], &token_count, from_styles.user_accent, to_styles.user_accent);
-        appendToken(token_storage[0..], &token_count, from_styles.system_notice_text, to_styles.system_notice_text);
-        appendToken(token_storage[0..], &token_count, from_styles.dim, to_styles.dim);
-    } else if (from_palette == .fx and to_palette == .terminal) {
-        // .fx intentionally shares a neutral foreground for several semantic
-        // roles. Retained bytes cannot recover that lost distinction, so move
-        // those roles to the terminal default foreground while preserving
-        // marker, label, and muted roles that remain unambiguous.
-        appendToken(token_storage[0..], &token_count, from_styles.tag, to_styles.tag);
-        appendToken(token_storage[0..], &token_count, from_styles.user_marker, to_styles.user_marker);
-        appendToken(token_storage[0..], &token_count, from_styles.system_notice_label, to_styles.system_notice_label);
-        appendToken(token_storage[0..], &token_count, from_styles.user_accent, to_styles.system_notice_text);
-        appendToken(token_storage[0..], &token_count, from_styles.system_notice_text, to_styles.system_notice_text);
-        appendToken(token_storage[0..], &token_count, from_styles.dim, to_styles.dim);
-    } else if (from_palette == .terminal and to_palette == .fx) {
-        appendToken(token_storage[0..], &token_count, from_styles.user_marker, to_styles.user_marker);
-        appendToken(token_storage[0..], &token_count, from_styles.user_accent, to_styles.user_accent);
-        appendToken(token_storage[0..], &token_count, from_styles.code_keyword, to_styles.code_keyword);
-        appendToken(token_storage[0..], &token_count, from_styles.green, to_styles.green);
-        appendToken(token_storage[0..], &token_count, from_styles.red, to_styles.red);
-        appendToken(token_storage[0..], &token_count, from_styles.warning, to_styles.warning);
-        appendToken(token_storage[0..], &token_count, from_styles.system_notice_text, to_styles.system_notice_text);
-        appendToken(token_storage[0..], &token_count, from_styles.dim, to_styles.dim);
-    } else {
-        // Both terminal palettes are independent of light/dark detection.
-        return null;
-    }
-
-    const tokens = token_storage[0..token_count];
+    if (from_light == to_light) return null;
+    const tokens = if (to_light) dark_to_light_theme_tokens[0..] else light_to_dark_theme_tokens[0..];
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
 
@@ -3344,23 +3400,4 @@ test "refreshFoldedCommandSummaryIndices uses final preparation indices" {
     for (runtime.folded_command_blocks.items, expected.folded_summary_indices) |block, index| {
         try std.testing.expectEqual(index, block.summary_transcript_index);
     }
-}
-
-test "retintThemeBytes maps fx-owned presentation into terminal defaults" {
-    const source = "\x1b[38;5;252mowned\x1b[0m \x1b[38;5;245mmuted\x1b[0m";
-    const converted = try retintThemeBytes(
-        std.testing.allocator,
-        source,
-        false,
-        false,
-        .fx,
-        .terminal,
-    );
-    defer if (converted) |bytes| std.testing.allocator.free(bytes);
-
-    try std.testing.expect(converted != null);
-    try std.testing.expectEqualStrings(
-        "\x1b[39mowned\x1b[0m \x1b[90mmuted\x1b[0m",
-        converted.?,
-    );
 }

--- a/src/ui/transcript/store.zig
+++ b/src/ui/transcript/store.zig
@@ -31,6 +31,7 @@ const Allocator = std.mem.Allocator;
 const Metrics = types.Metrics;
 const transcript_blocks = render_engine.transcript_blocks;
 const assistant_presentation = @import("../../core/agent/assistant_presentation.zig");
+const presentation_palette = @import("../../core/shared/presentation_palette.zig");
 
 const AssistantTurnSegments = transcript_blocks.AssistantTurnSegments;
 const RawEntryClass = transcript_blocks.RawEntryClass;
@@ -2835,7 +2836,18 @@ pub fn retintEntriesForTheme(
     from_light: bool,
     to_light: bool,
 ) !void {
-    if (from_light == to_light) return;
+    return retintEntriesForPalette(self, alloc, from_light, to_light, .fx, .fx);
+}
+
+pub fn retintEntriesForPalette(
+    self: anytype,
+    alloc: Allocator,
+    from_light: bool,
+    to_light: bool,
+    from_palette: presentation_palette.ColorPalette,
+    to_palette: presentation_palette.ColorPalette,
+) !void {
+    if (from_light == to_light and from_palette == to_palette) return;
     try self.assertCanMutateTranscript();
 
     var shadow = try cloneMutationState(self, alloc);
@@ -2845,13 +2857,27 @@ pub fn retintEntriesForTheme(
         switch (entry.*) {
             .raw_bytes => |*raw| {
                 if (!themeOwnsRawEntry(raw.class)) continue;
-                if (try retintThemeBytes(alloc, raw.bytes, from_light, to_light)) |replacement| {
+                if (try retintThemeBytes(
+                    alloc,
+                    raw.bytes,
+                    from_light,
+                    to_light,
+                    from_palette,
+                    to_palette,
+                )) |replacement| {
                     alloc.free(raw.bytes);
                     raw.bytes = replacement;
                 }
             },
             .assistant_turn => |*assistant| {
-                if (try retintThemeBytes(alloc, assistant.segments.text.items, from_light, to_light)) |replacement| {
+                if (try retintThemeBytes(
+                    alloc,
+                    assistant.segments.text.items,
+                    from_light,
+                    to_light,
+                    from_palette,
+                    to_palette,
+                )) |replacement| {
                     assistant.segments.text.deinit(alloc);
                     assistant.segments.text = .fromOwnedSlice(replacement);
                 }
@@ -2877,29 +2903,6 @@ pub fn retintEntriesForTheme(
     );
 }
 
-const ThemeToken = struct {
-    from: []const u8,
-    to: []const u8,
-};
-
-const dark_to_light_theme_tokens = [_]ThemeToken{
-    .{ .from = "\x1b[1;38;5;255m", .to = "\x1b[1;38;5;235m" },
-    .{ .from = "\x1b[38;5;255m", .to = "\x1b[38;5;235m" },
-    .{ .from = "\x1b[1;38;5;252m", .to = "\x1b[1;38;5;238m" },
-    .{ .from = "\x1b[38;5;252m", .to = "\x1b[38;5;238m" },
-    .{ .from = "\x1b[38;5;250m", .to = "\x1b[38;5;241m" },
-    .{ .from = "\x1b[38;5;245m", .to = "\x1b[38;5;247m" },
-};
-
-const light_to_dark_theme_tokens = [_]ThemeToken{
-    .{ .from = "\x1b[1;38;5;235m", .to = "\x1b[1;38;5;255m" },
-    .{ .from = "\x1b[38;5;235m", .to = "\x1b[38;5;255m" },
-    .{ .from = "\x1b[1;38;5;238m", .to = "\x1b[1;38;5;252m" },
-    .{ .from = "\x1b[38;5;238m", .to = "\x1b[38;5;252m" },
-    .{ .from = "\x1b[38;5;241m", .to = "\x1b[38;5;250m" },
-    .{ .from = "\x1b[38;5;247m", .to = "\x1b[38;5;245m" },
-};
-
 fn themeOwnsRawEntry(class: RawEntryClass) bool {
     return switch (class) {
         .welcome,
@@ -2918,9 +2921,60 @@ fn retintThemeBytes(
     bytes: []const u8,
     from_light: bool,
     to_light: bool,
+    from_palette: presentation_palette.ColorPalette,
+    to_palette: presentation_palette.ColorPalette,
 ) !?[]u8 {
-    if (from_light == to_light) return null;
-    const tokens = if (to_light) dark_to_light_theme_tokens[0..] else light_to_dark_theme_tokens[0..];
+    if (from_light == to_light and from_palette == to_palette) return null;
+
+    const from_styles = presentation_palette.styles(from_light, from_palette);
+    const to_styles = presentation_palette.styles(to_light, to_palette);
+    const ThemeToken = struct { from: []const u8, to: []const u8 };
+    var token_storage: [16]ThemeToken = undefined;
+    var token_count: usize = 0;
+
+    const appendToken = struct {
+        fn add(storage: []ThemeToken, count: *usize, from: []const u8, to: []const u8) void {
+            if (std.mem.eql(u8, from, to)) return;
+            if (count.* >= storage.len) return;
+            storage[count.*] = .{ .from = from, .to = to };
+            count.* += 1;
+        }
+    }.add;
+
+    if (from_palette == .fx and to_palette == .fx) {
+        // Keep the historical light/dark retint map byte-for-byte identical.
+        appendToken(token_storage[0..], &token_count, from_styles.tag, to_styles.tag);
+        appendToken(token_storage[0..], &token_count, from_styles.user_marker, to_styles.user_marker);
+        appendToken(token_storage[0..], &token_count, from_styles.system_notice_label, to_styles.system_notice_label);
+        appendToken(token_storage[0..], &token_count, from_styles.user_accent, to_styles.user_accent);
+        appendToken(token_storage[0..], &token_count, from_styles.system_notice_text, to_styles.system_notice_text);
+        appendToken(token_storage[0..], &token_count, from_styles.dim, to_styles.dim);
+    } else if (from_palette == .fx and to_palette == .terminal) {
+        // .fx intentionally shares a neutral foreground for several semantic
+        // roles. Retained bytes cannot recover that lost distinction, so move
+        // those roles to the terminal default foreground while preserving
+        // marker, label, and muted roles that remain unambiguous.
+        appendToken(token_storage[0..], &token_count, from_styles.tag, to_styles.tag);
+        appendToken(token_storage[0..], &token_count, from_styles.user_marker, to_styles.user_marker);
+        appendToken(token_storage[0..], &token_count, from_styles.system_notice_label, to_styles.system_notice_label);
+        appendToken(token_storage[0..], &token_count, from_styles.user_accent, to_styles.system_notice_text);
+        appendToken(token_storage[0..], &token_count, from_styles.system_notice_text, to_styles.system_notice_text);
+        appendToken(token_storage[0..], &token_count, from_styles.dim, to_styles.dim);
+    } else if (from_palette == .terminal and to_palette == .fx) {
+        appendToken(token_storage[0..], &token_count, from_styles.user_marker, to_styles.user_marker);
+        appendToken(token_storage[0..], &token_count, from_styles.user_accent, to_styles.user_accent);
+        appendToken(token_storage[0..], &token_count, from_styles.code_keyword, to_styles.code_keyword);
+        appendToken(token_storage[0..], &token_count, from_styles.green, to_styles.green);
+        appendToken(token_storage[0..], &token_count, from_styles.red, to_styles.red);
+        appendToken(token_storage[0..], &token_count, from_styles.warning, to_styles.warning);
+        appendToken(token_storage[0..], &token_count, from_styles.system_notice_text, to_styles.system_notice_text);
+        appendToken(token_storage[0..], &token_count, from_styles.dim, to_styles.dim);
+    } else {
+        // Both terminal palettes are independent of light/dark detection.
+        return null;
+    }
+
+    const tokens = token_storage[0..token_count];
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
 
@@ -3290,4 +3344,23 @@ test "refreshFoldedCommandSummaryIndices uses final preparation indices" {
     for (runtime.folded_command_blocks.items, expected.folded_summary_indices) |block, index| {
         try std.testing.expectEqual(index, block.summary_transcript_index);
     }
+}
+
+test "retintThemeBytes maps fx-owned presentation into terminal defaults" {
+    const source = "\x1b[38;5;252mowned\x1b[0m \x1b[38;5;245mmuted\x1b[0m";
+    const converted = try retintThemeBytes(
+        std.testing.allocator,
+        source,
+        false,
+        false,
+        .fx,
+        .terminal,
+    );
+    defer if (converted) |bytes| std.testing.allocator.free(bytes);
+
+    try std.testing.expect(converted != null);
+    try std.testing.expectEqualStrings(
+        "\x1b[39mowned\x1b[0m \x1b[90mmuted\x1b[0m",
+        converted.?,
+    );
 }

--- a/tests/e2e/config-persistence.test.ts
+++ b/tests/e2e/config-persistence.test.ts
@@ -126,6 +126,149 @@ describe.skipIf(!tmuxAvailable())("config persistence", () => {
   });
 
   serialTest(
+    "color palette setting updates live chrome without retinting retained transcript bytes",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-color-palette-persistence-"));
+      try {
+        const home = join(root, "home");
+        const workspace = join(root, "workspace");
+        const settingsPath = join(home, ".fx", "settings.json");
+        mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+        mkdirSync(workspace);
+        writeFileSync(settingsPath, "{}\n", { mode: 0o600 });
+        const env = {
+          ...NO_AUTH,
+          HOME: home,
+          NO_COLOR: undefined,
+          FX_DISABLE_KEYCHAIN: "1",
+          FX_SKIP_ONBOARDING: "1",
+        };
+
+        session = await TmuxSession.create({ cwd: workspace, env });
+        await session.waitForText("Run /help", TIMEOUT);
+        expect(await session.capturePaneEscapes()).toContain("\x1b[38;5;");
+
+        await session.sendText("/settings");
+        await session.waitForText("←→ Change", TIMEOUT);
+        await session.sendLiteral("color palette");
+        await session.waitForPane(
+          (pane) => pane.includes("Color palette") && pane.includes("live UI and new output"),
+          TIMEOUT,
+        );
+        const fxSettingsLine = (await session.capturePaneEscapes())
+          .split("\n")
+          .find((line) => line.includes("Color palette"));
+        expect(fxSettingsLine).toContain("\x1b[38;5;");
+        await session.sendKeys("Right");
+
+        const deadline = Date.now() + TIMEOUT;
+        let storedPalette: unknown;
+        while (Date.now() < deadline) {
+          storedPalette = JSON.parse(readFileSync(settingsPath, "utf8")).color_palette;
+          if (storedPalette === "terminal") break;
+          await Bun.sleep(25);
+        }
+        expect(storedPalette).toBe("terminal");
+
+        await session.waitForPane(
+          (pane) => pane.includes("Color palette") && pane.includes("terminal"),
+          TIMEOUT,
+        );
+        const livePane = await session.capturePaneEscapes();
+        const terminalSettingsLine = livePane
+          .split("\n")
+          .find((line) => line.includes("Color palette"));
+        expect(terminalSettingsLine).toBeDefined();
+        expect(terminalSettingsLine).toContain("\x1b[90m");
+        expect(terminalSettingsLine).not.toContain("\x1b[38;5;");
+        expect(terminalSettingsLine).not.toContain("\x1b[38;2;");
+        // The welcome transcript was retained byte-for-byte while the open
+        // settings chrome immediately moved to ANSI-16 terminal colors.
+        expect(livePane).toContain("\x1b[38;5;");
+
+        // With an active settings filter, the first Escape clears the filter
+        // and the second closes the menu.
+        await session.sendKeys("Escape");
+        await session.sendKeys("Escape");
+        await session.waitForPane(
+          (pane) => hasEmptyComposer(pane) && !pane.includes("←→ Change"),
+          TIMEOUT,
+        );
+        await session.sendText("/quit");
+        await session.waitForSessionEnd(TIMEOUT);
+        session = null;
+
+        secondSession = await TmuxSession.create({ cwd: workspace, env });
+        await secondSession.waitForText("Run /help", TIMEOUT);
+        const restarted = await secondSession.capturePaneEscapes();
+        expect(restarted).toContain("\x1b[36mauto\x1b[90m");
+        expect(restarted).not.toContain("\x1b[38;5;");
+        expect(restarted).not.toContain("\x1b[38;2;");
+      } finally {
+        await session?.kill();
+        await secondSession?.kill();
+        session = null;
+        secondSession = null;
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT * 2,
+  );
+
+  serialTest(
+    "color palette persistence failure leaves preference and live chrome unchanged",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-color-palette-failure-"));
+      try {
+        const home = join(root, "home");
+        const workspace = join(root, "workspace");
+        const settingsPath = join(home, ".fx", "settings.json");
+        const externalSettings = join(root, "external-settings.json");
+        mkdirSync(join(home, ".fx"), { recursive: true, mode: 0o700 });
+        mkdirSync(workspace);
+        writeFileSync(settingsPath, "{}\n", { mode: 0o600 });
+        writeFileSync(externalSettings, "{}\n", { mode: 0o600 });
+
+        session = await TmuxSession.create({
+          cwd: workspace,
+          env: {
+            ...NO_AUTH,
+            HOME: home,
+            NO_COLOR: undefined,
+            FX_DISABLE_KEYCHAIN: "1",
+            FX_SKIP_ONBOARDING: "1",
+          },
+        });
+        await session.waitForText("Run /help", TIMEOUT);
+        await session.sendText("/settings");
+        await session.waitForText("←→ Change", TIMEOUT);
+        await session.sendLiteral("color palette");
+        await session.waitForText("Color palette", TIMEOUT);
+
+        // The settings store rejects symlink primaries. Introduce one only
+        // after startup so the attempted change deterministically fails.
+        rmSync(settingsPath);
+        symlinkSync(externalSettings, settingsPath);
+        await session.sendKeys("Right");
+        await session.waitForText("not saved to user settings", TIMEOUT);
+
+        const pane = await session.capturePaneEscapes();
+        const settingsLine = pane
+          .split("\n")
+          .find((line) => line.includes("Color palette"));
+        expect(settingsLine).toContain("\x1b[1;38;5;255mfx");
+        expect(settingsLine).toContain("\x1b[38;5;");
+        expect(readFileSync(externalSettings, "utf8")).toBe("{}\n");
+      } finally {
+        await session?.kill();
+        session = null;
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
+
+  serialTest(
     "user preferences migrate globally and load in another project",
     async () => {
       const root = mkdtempSync(join(tmpdir(), "fx-config-persistence-"));


### PR DESCRIPTION
## Summary

  - Add an `fx` or `terminal` color palette preference to `/settings`
  - Let terminal themes supply colors through the default foreground, background, and ANSI color slots
  - Keep the existing fx palette as the default
  - Preserve external command and tool ANSI output

  This allows terminal themes to style fx without embedding theme-specific color tables.

  ## Design

  - The typed contract is `ColorPalette { fx, terminal }`
  - The preference is profile-owned and stored in `~/.fx/settings.json`
  - Project `.fx.json` cannot set the preference
  - Palette changes update fx-owned UI and newly generated output immediately and persist across launches
  - transcript and external ANSI content remain unchanged.
  - Interactive fx and terminal-formatted `fx ask` use the selected palette

  ## Verification

  - `zig fmt --check src/`
  - `git diff --check`
  - `zig build`
  - Focused palette, configuration, persistence, presentation-snapshot, nested-runtime, and transcript-cache tests
  - Exercised `./zig-out/bin/fx` under Nushell
  - Verified live UI and new-output switching in both directions without rewriting retained output
  - Verified persistence after restarting fx
  - Verified terminal mode emits default and ANSI-16 colors
  - Verified external ANSI content remains unchanged