### PR TITLE
Prefer Exa for web search

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -53,15 +53,31 @@ const oauth_request_timeout_ms: i64 = 15_000;
 const oauth_response_max_bytes: usize = 64 * 1024;
 
 const web_search_system_prompt = "Research the user's query with the web_search tool and preserve sources for citation.";
+const exa_search_backend_id = web_search_contract.SearchBackendId{ .value = "ai_gateway_exa_search" };
 const perplexity_search_backend_id = web_search_contract.SearchBackendId{ .value = "ai_gateway_perplexity_search" };
 const parallel_search_backend_id = web_search_contract.SearchBackendId{ .value = "ai_gateway_parallel_search" };
 const default_web_search_backend_order = [_]web_search_contract.SearchBackendId{
-    perplexity_search_backend_id,
+    exa_search_backend_id,
     parallel_search_backend_id,
 };
+const exa_search_backend = [_]web_search_contract.SearchBackendId{exa_search_backend_id};
 const perplexity_search_backend = [_]web_search_contract.SearchBackendId{perplexity_search_backend_id};
 const parallel_search_backend = [_]web_search_contract.SearchBackendId{parallel_search_backend_id};
 const default_web_search_backend_policies = [_]web_search_policy.BackendPolicy{
+    .{
+        .id = exa_search_backend_id,
+        .features = .{
+            .max_uses = .best_effort,
+            .allowed_domains = .pass_through,
+            .blocked_domains = .pass_through,
+            .ordered_sources = true,
+            .usage = true,
+            .terminal_incomplete = true,
+            .timeout = true,
+            .cancellation = true,
+            .result_bounds = .post_filter,
+        },
+    },
     .{
         .id = perplexity_search_backend_id,
         .features = .{
@@ -843,6 +859,7 @@ test "API key validator preserves Gateway status mapping" {
 pub fn preferredWebSearchBackendsOverride(raw: ?[]const u8) !?[]const web_search_contract.SearchBackendId {
     const value = raw orelse return null;
     if (value.len == 0) return null;
+    if (std.mem.eql(u8, value, "ai_gateway_exa_search")) return &exa_search_backend;
     if (std.mem.eql(u8, value, "ai_gateway_perplexity_search")) return &perplexity_search_backend;
     if (std.mem.eql(u8, value, "ai_gateway_parallel_search")) return &parallel_search_backend;
     return error.InvalidWebSearchBackend;
@@ -1083,7 +1100,21 @@ pub fn providerToolsJson(alloc: Allocator, input: ProviderToolInput) ![]u8 {
 
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
-    if (input.backend.eql(perplexity_search_backend_id)) {
+    if (input.backend.eql(exa_search_backend_id)) {
+        const result_count = @max(@as(usize, input.max_results), 1);
+        const max_characters = @max(input.max_output_chars / result_count, 1);
+        try out.writer.print(
+            "[{{\"type\":\"provider\",\"id\":\"gateway.exa_search\",\"name\":\"exa_search\",\"args\":{{\"numResults\":{d}",
+            .{input.max_results},
+        );
+        if (hasValues(input.allowed_domains)) {
+            try writeExaDomains(&out.writer, "includeDomains", input.allowed_domains.?);
+        } else if (hasValues(input.blocked_domains)) {
+            try writeExaDomains(&out.writer, "excludeDomains", input.blocked_domains.?);
+        }
+        try out.writer.print(",\"contents\":{{\"highlights\":{{\"maxCharacters\":{d}", .{max_characters});
+        try out.writer.writeAll("}}}}]");
+    } else if (input.backend.eql(perplexity_search_backend_id)) {
         try out.writer.print(
             "[{{\"type\":\"provider\",\"id\":\"gateway.perplexity_search\",\"name\":\"perplexity_search\",\"args\":{{\"maxResults\":{d},\"maxTokens\":{d}",
             .{ input.max_results, input.max_output_tokens },
@@ -1324,6 +1355,7 @@ fn stringField(object: std.json.ObjectMap, names: []const []const u8) ?[]const u
 }
 
 fn selectedToolName(backend: web_search_contract.SearchBackendId) ![]const u8 {
+    if (backend.eql(exa_search_backend_id)) return "exa_search";
     if (backend.eql(perplexity_search_backend_id)) return "perplexity_search";
     if (backend.eql(parallel_search_backend_id)) return "parallel_search";
     return error.InvalidWebSearchBackend;
@@ -1340,6 +1372,15 @@ fn writePerplexityDomains(alloc: Allocator, writer: *std.Io.Writer, domains: []c
         } else {
             try std.json.Stringify.value(domain, .{}, writer);
         }
+    }
+    try writer.writeByte(']');
+}
+
+fn writeExaDomains(writer: *std.Io.Writer, name: []const u8, domains: []const []const u8) !void {
+    try writer.print(",\"{s}\":[", .{name});
+    for (domains, 0..) |domain, index| {
+        if (index > 0) try writer.writeByte(',');
+        try std.json.Stringify.value(domain, .{}, writer);
     }
     try writer.writeByte(']');
 }
@@ -1382,6 +1423,39 @@ test "built-in search rejects an unknown provider-owned backend identity" {
         .max_results = 1,
         .max_output_chars = 1024,
     }));
+}
+
+test "private exa worker advertises bounded results with allowed domains" {
+    const alloc = std.testing.allocator;
+    const allowed_domains = [_][]const u8{"ziglang.org"};
+    const tools_json = try providerToolsJson(alloc, .{
+        .backend = .{ .value = "ai_gateway_exa_search" },
+        .allowed_domains = &allowed_domains,
+        .max_results = 7,
+        .max_output_chars = 4096,
+    });
+    defer alloc.free(tools_json);
+
+    try std.testing.expect(std.mem.find(u8, tools_json, "gateway.exa_search") != null);
+    try std.testing.expect(std.mem.find(u8, tools_json, "\"name\":\"exa_search\"") != null);
+    try std.testing.expect(std.mem.find(u8, tools_json, "\"numResults\":7") != null);
+    try std.testing.expect(std.mem.find(u8, tools_json, "\"includeDomains\":[\"ziglang.org\"]") != null);
+    try std.testing.expect(std.mem.find(u8, tools_json, "\"maxCharacters\":585") != null);
+}
+
+test "private exa worker preserves blocked domains" {
+    const alloc = std.testing.allocator;
+    const blocked_domains = [_][]const u8{"example.com"};
+    const tools_json = try providerToolsJson(alloc, .{
+        .backend = .{ .value = "ai_gateway_exa_search" },
+        .blocked_domains = &blocked_domains,
+        .max_results = 5,
+        .max_output_chars = 6000,
+    });
+    defer alloc.free(tools_json);
+
+    try std.testing.expect(std.mem.find(u8, tools_json, "\"excludeDomains\":[\"example.com\"]") != null);
+    try std.testing.expect(std.mem.find(u8, tools_json, "\"maxCharacters\":1200") != null);
 }
 
 test "private perplexity worker advertises only selected gateway provider search tool" {
@@ -1525,11 +1599,17 @@ fn expectGatewayWorkerAdapterExecutes(backend: web_search_contract.SearchBackend
     var usage_snapshot = try usage.snapshot(alloc);
     defer usage_snapshot.deinit(alloc);
     try std.testing.expectEqual(@as(usize, 1), usage_snapshot.pending.len);
-    if (backend.eql(perplexity_search_backend_id)) {
+    if (backend.eql(exa_search_backend_id)) {
+        try std.testing.expect(fake.saw_exa);
+        try std.testing.expect(!fake.saw_perplexity);
+        try std.testing.expect(!fake.saw_parallel);
+    } else if (backend.eql(perplexity_search_backend_id)) {
+        try std.testing.expect(!fake.saw_exa);
         try std.testing.expect(fake.saw_perplexity);
         try std.testing.expect(!fake.saw_parallel);
     } else {
         try std.testing.expect(backend.eql(parallel_search_backend_id));
+        try std.testing.expect(!fake.saw_exa);
         try std.testing.expect(!fake.saw_perplexity);
         try std.testing.expect(fake.saw_parallel);
     }
@@ -1539,6 +1619,10 @@ fn expectGatewayWorkerAdapterExecutes(backend: web_search_contract.SearchBackend
 
 test "gateway worker adapter executes private perplexity backend with bounded payload" {
     try expectGatewayWorkerAdapterExecutes(perplexity_search_backend_id);
+}
+
+test "gateway worker adapter executes private exa backend with bounded payload" {
+    try expectGatewayWorkerAdapterExecutes(.{ .value = "ai_gateway_exa_search" });
 }
 
 test "gateway worker adapter executes private parallel backend with bounded payload" {
@@ -1727,6 +1811,7 @@ const FakeStream = struct {
     fail_after_send: bool = false,
     team: ?[]const u8 = null,
     deadline: ?std.Io.Clock.Timestamp = null,
+    saw_exa: bool = false,
     saw_perplexity: bool = false,
     saw_parallel: bool = false,
     saw_inner_prompt: bool = false,
@@ -1757,12 +1842,18 @@ const FakeStream = struct {
         }
         self.team = team;
         self.deadline = deadline;
+        self.saw_exa = std.mem.find(u8, payload, "gateway.exa_search") != null;
         self.saw_perplexity = std.mem.find(u8, payload, "gateway.perplexity_search") != null;
         self.saw_parallel = std.mem.find(u8, payload, "gateway.parallel_search") != null;
         self.saw_inner_prompt = std.mem.find(u8, payload, "Research the user's query with the web_search tool and preserve sources for citation.") != null;
         self.saw_output_bound = std.mem.find(u8, payload, "\"maxOutputTokens\":4096") != null;
         self.saw_required_tool_choice = std.mem.find(u8, payload, "\"toolChoice\":{\"type\":\"required\"}") != null;
-        const tool_name = if (self.saw_parallel) "parallel_search" else "perplexity_search";
+        const tool_name = if (self.saw_exa)
+            "exa_search"
+        else if (self.saw_parallel)
+            "parallel_search"
+        else
+            "perplexity_search";
         self.saw_expected_provider_tool = std.mem.eql(u8, expected_provider_tool_name, tool_name);
         return .{
             .status = .ok,
@@ -2073,8 +2164,8 @@ test "built-in model catalog owns default and loopback target resolution" {
 
 test "built-in gateway owns the admitted web search provider policy" {
     try std.testing.expect(web_search_policy.hasAdmittedBackendPolicy(default_web_search_policy.backend_policies));
-    try std.testing.expectEqual(@as(usize, 2), default_web_search_policy.backend_policies.len);
-    try std.testing.expect(perplexity_search_backend_id.eql(default_web_search_policy.preferred_backends[0]));
+    try std.testing.expectEqual(@as(usize, 3), default_web_search_policy.backend_policies.len);
+    try std.testing.expectEqualStrings("ai_gateway_exa_search", default_web_search_policy.preferred_backends[0].value);
     try std.testing.expect(parallel_search_backend_id.eql(default_web_search_policy.preferred_backends[1]));
 
     for (default_web_search_policy.backend_policies) |backend| {
@@ -2113,6 +2204,7 @@ test "built-in web search provider preserves missing worker configuration error"
 test "built-in gateway web search override selects one backend and rejects unknown values" {
     try std.testing.expect((try preferredWebSearchBackendsOverride(null)) == null);
     try std.testing.expect((try preferredWebSearchBackendsOverride("")) == null);
+    try std.testing.expectEqualStrings("ai_gateway_exa_search", (try preferredWebSearchBackendsOverride("ai_gateway_exa_search")).?[0].value);
     try std.testing.expect(perplexity_search_backend_id.eql((try preferredWebSearchBackendsOverride("ai_gateway_perplexity_search")).?[0]));
     try std.testing.expect(parallel_search_backend_id.eql((try preferredWebSearchBackendsOverride("ai_gateway_parallel_search")).?[0]));
     try std.testing.expectError(error.InvalidWebSearchBackend, preferredWebSearchBackendsOverride("parallel_search"));

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -2224,7 +2224,7 @@ test "built-in web_search owns its Gateway provider advertisement" {
     defer std.testing.allocator.free(json);
 
     try std.testing.expectEqualStrings(
-        "{\"type\":\"provider\",\"id\":\"gateway.perplexity_search\",\"name\":\"perplexity_search\",\"args\":{\"maxResults\":10,\"maxTokens\":4096}}",
+        "{\"type\":\"provider\",\"id\":\"gateway.exa_search\",\"name\":\"exa_search\",\"args\":{\"numResults\":10,\"contents\":{\"highlights\":{\"maxCharacters\":10000}}}}",
         json,
     );
 }

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -1453,7 +1453,7 @@ test "provisional lifecycle preflight distinguishes unknown eligible and ineligi
         .ineligible => return error.TestExpectedEqual,
     }
 
-    for ([_][]const u8{ "perplexity_search", "parallel_search" }) |name| {
+    for ([_][]const u8{ "exa_search", "perplexity_search", "parallel_search" }) |name| {
         const provider_preflight = ProvisionalToolStatuses.preflight(test_tool_registry, name) orelse return error.TestExpectedEqual;
         switch (provider_preflight) {
             .eligible => |metadata| try std.testing.expectEqualStrings("Searching", metadata.action_label),
@@ -1474,6 +1474,10 @@ test "stream start execution certainty follows provider ownership" {
     try std.testing.expect(streamStartMayHaveExecutedAtProvider(
         provider_registry,
         "web_search",
+    ));
+    try std.testing.expect(streamStartMayHaveExecutedAtProvider(
+        test_tool_registry,
+        "exa_search",
     ));
     try std.testing.expect(streamStartMayHaveExecutedAtProvider(
         test_tool_registry,

--- a/src/core/tooling/tool_presentation.zig
+++ b/src/core/tooling/tool_presentation.zig
@@ -34,7 +34,8 @@ pub const RunCommandActivity = struct {
 };
 
 pub fn isProviderSearchAlias(name: []const u8) bool {
-    return std.mem.eql(u8, name, "perplexity_search") or
+    return std.mem.eql(u8, name, "exa_search") or
+        std.mem.eql(u8, name, "perplexity_search") or
         std.mem.eql(u8, name, "parallel_search");
 }
 
@@ -929,7 +930,7 @@ test "tool presentation frees all formatted output with a normal allocator" {
         .tool_registry = test_tool_registry,
         .call = .{
             .id = "provider_search",
-            .name = "perplexity_search",
+            .name = "exa_search",
             .arguments_json = "{}",
             .provenance = .provider_executed,
         },

--- a/src/gateway/client.zig
+++ b/src/gateway/client.zig
@@ -1190,6 +1190,12 @@ fn expectedProviderToolName(alloc: std.mem.Allocator, payload: []const u8) !?[]c
         const name = tool.object.get("name") orelse continue;
         if (tool_type != .string or id != .string or name != .string) continue;
         if (std.mem.eql(u8, tool_type.string, "provider") and
+            std.mem.eql(u8, id.string, "gateway.exa_search") and
+            std.mem.eql(u8, name.string, "exa_search"))
+        {
+            return "exa_search";
+        }
+        if (std.mem.eql(u8, tool_type.string, "provider") and
             std.mem.eql(u8, id.string, "gateway.perplexity_search") and
             std.mem.eql(u8, name.string, "perplexity_search"))
         {
@@ -1206,15 +1212,31 @@ fn expectedProviderToolName(alloc: std.mem.Allocator, payload: []const u8) !?[]c
 }
 
 test "expected provider tool name only trusts advertised provider schemas" {
-    const direct_payload =
-        \\{"tools":[{"type":"provider","id":"gateway.perplexity_search","name":"perplexity_search"}]}
-    ;
-    const expected = try expectedProviderToolName(std.testing.allocator, direct_payload);
-    try std.testing.expect(expected != null);
-    try std.testing.expectEqualStrings("perplexity_search", expected.?);
+    const cases = [_]struct {
+        payload: []const u8,
+        name: []const u8,
+    }{
+        .{
+            .payload = "{\"tools\":[{\"type\":\"provider\",\"id\":\"gateway.exa_search\",\"name\":\"exa_search\"}]}",
+            .name = "exa_search",
+        },
+        .{
+            .payload = "{\"tools\":[{\"type\":\"provider\",\"id\":\"gateway.perplexity_search\",\"name\":\"perplexity_search\"}]}",
+            .name = "perplexity_search",
+        },
+        .{
+            .payload = "{\"tools\":[{\"type\":\"provider\",\"id\":\"gateway.parallel_search\",\"name\":\"parallel_search\"}]}",
+            .name = "parallel_search",
+        },
+    };
+    for (cases) |case| {
+        const expected = try expectedProviderToolName(std.testing.allocator, case.payload);
+        try std.testing.expect(expected != null);
+        try std.testing.expectEqualStrings(case.name, expected.?);
+    }
 
     const prompt_only_payload =
-        \\{"prompt":"call gateway.perplexity_search with name perplexity_search","tools":[]}
+        \\{"prompt":"call gateway.exa_search with name exa_search","tools":[]}
     ;
     try std.testing.expect((try expectedProviderToolName(std.testing.allocator, prompt_only_payload)) == null);
 }

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -17,7 +17,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { FX_BIN, HAS_API_KEY, REPO_ROOT, runFx } from "../evals/eval-helpers";
 import {
-  AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
+  AUTO_EXA_SERIALIZED_TOOL_NAMES,
   customProviderGuidanceState,
   findUnavailableCapabilityReferences,
   parseGatewayRequest,
@@ -1467,10 +1467,10 @@ describe("acp: model-independent", () => {
         expect(request.tools).toHaveLength(18);
         const toolNames = serializedToolNames(oracleRequest);
         expect(toolNames).toEqual(
-          AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
+          AUTO_EXA_SERIALIZED_TOOL_NAMES,
         );
         expect(toolNames.filter((name) => name === "terminal")).toHaveLength(1);
-        expect(toolNames.filter((name) => name === "perplexity_search"))
+        expect(toolNames.filter((name) => name === "exa_search"))
           .toHaveLength(1);
         expect(findUnavailableCapabilityReferences(oracleRequest)).toEqual([]);
         expect(customProviderGuidanceState(oracleRequest)).toEqual({
@@ -7887,7 +7887,7 @@ describe("acp: model-independent", () => {
         await waitForCondition("the code-mode Gateway request", () => gateway.requests.length === 1);
         const codeRequest = parseGatewayRequest(gateway.requests[0]!.body);
         expect(serializedToolNames(codeRequest)).toEqual(
-          AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
+          AUTO_EXA_SERIALIZED_TOOL_NAMES,
         );
         expect(findUnavailableCapabilityReferences(codeRequest)).toEqual([]);
         expect(customProviderGuidanceState(codeRequest).guidanceMessageIndices).toEqual([1]);

--- a/tests/e2e/conditional-guidance-oracle.ts
+++ b/tests/e2e/conditional-guidance-oracle.ts
@@ -30,20 +30,20 @@ export const VERIFY_SERIALIZED_TOOL_NAMES = [
   "terminal",
 ] as const;
 
-export const WEB_PERPLEXITY_SERIALIZED_TOOL_NAMES = [
+export const WEB_EXA_SERIALIZED_TOOL_NAMES = [
   ...READ_ONLY_SERIALIZED_TOOL_NAMES,
   "web_fetch",
-  "perplexity_search",
+  "exa_search",
 ] as const;
 
-export const AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES = CANONICAL_BUILTIN_NAMES.map(
-  (name) => (name === "web_search" ? "perplexity_search" : name),
+export const AUTO_EXA_SERIALIZED_TOOL_NAMES = CANONICAL_BUILTIN_NAMES.map(
+  (name) => (name === "web_search" ? "exa_search" : name),
 );
 
 // Durable-only tools are capability-gated on a writable session. `terminal`
 // remains available because its exec action does not require a session store.
-export const AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES =
-  AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES.filter((name) =>
+export const AUTO_EXA_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES =
+  AUTO_EXA_SERIALIZED_TOOL_NAMES.filter((name) =>
     name !== "subagent"
   );
 
@@ -118,7 +118,11 @@ export function contentText(content: unknown): string {
 }
 
 export function canonicalToolName(name: string): string {
-  if (name === "perplexity_search" || name === "parallel_search") {
+  if (
+    name === "exa_search" ||
+    name === "perplexity_search" ||
+    name === "parallel_search"
+  ) {
     return "web_search";
   }
   return name;

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -19,7 +19,7 @@ import { join } from "node:path";
 import { FX_BIN, runFx } from "../evals/eval-helpers";
 import {
   AMBIGUOUS_CAPABILITY_CLAUSES,
-  AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
+  AUTO_EXA_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
   customProviderGuidanceState,
   findUnavailableCapabilityReferences,
   parseGatewayRequest,
@@ -224,7 +224,7 @@ function providerToolResultResponse(finish: "provider_error" | "tool-calls"): Re
     `data: ${JSON.stringify({
       type: "tool-call",
       toolCallId: "provider_search_recovery_1",
-      toolName: "perplexity_search",
+      toolName: "exa_search",
       input: { query: "zig recovery" },
       providerExecuted: true,
     })}\n\n` +
@@ -743,7 +743,7 @@ describe("gateway stream lifecycle", () => {
       const oracleRequest = parseGatewayRequest(gateway.requests[0]!.body);
       expect(promptText(gateway.requests[0]!.body)).toContain(submitted);
       expect(serializedToolNames(oracleRequest)).toEqual(
-        AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
+        AUTO_EXA_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
       );
       expect(request.tools).toHaveLength(17);
       expect(findUnavailableCapabilityReferences(oracleRequest)).toEqual([]);

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -18,7 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, REPO_ROOT } from "../evals/eval-helpers";
 import {
-  AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES,
+  AUTO_EXA_SERIALIZED_TOOL_NAMES,
   customProviderGuidanceState,
   findUnavailableCapabilityReferences,
   parseGatewayRequest,
@@ -6977,7 +6977,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
           {
             type: "tool-call",
             toolCallId: "provider_search_direct",
-            toolName: "perplexity_search",
+            toolName: "exa_search",
             input: {},
           },
           {
@@ -7035,7 +7035,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
 
       const initialRequest = parseGatewayRequest(providerGateway.requests[0]!.body);
       const continuingRequest = parseGatewayRequest(providerGateway.requests[1]!.body);
-      const expectedToolNames = AUTO_PERPLEXITY_SERIALIZED_TOOL_NAMES.filter(
+      const expectedToolNames = AUTO_EXA_SERIALIZED_TOOL_NAMES.filter(
         (name) => name !== "vision",
       );
       expect(serializedToolNames(initialRequest)).toEqual(expectedToolNames);
@@ -7046,7 +7046,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       for (const request of [initialRequest, continuingRequest]) {
         const toolNames = serializedToolNames(request);
         expect(toolNames.filter((name) => name === "terminal")).toHaveLength(1);
-        expect(toolNames.filter((name) => name === "perplexity_search"))
+        expect(toolNames.filter((name) => name === "exa_search"))
           .toHaveLength(1);
         expect(findUnavailableCapabilityReferences(request)).toEqual([]);
         expect(customProviderGuidanceState(request)).toEqual({
@@ -7064,7 +7064,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       expect(compact).toContain("● 1 tool call · 1 read");
       expect(compact).toContain("└ Searched web");
       expect(compact).not.toContain("● Running");
-      expect(compact).not.toContain("Working perplexity_search");
+      expect(compact).not.toContain("Working exa_search");
 
       await session.sendKeys("C-o");
       const detail = await session.waitForText(sourceUrl, TIMEOUT);
@@ -7076,7 +7076,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       });
       expect(replay).toContain("● 1 tool call · 1 read");
       expect(replay).toContain("└ Searched web");
-      expect(replay).not.toContain("Working perplexity_search");
+      expect(replay).not.toContain("Working exa_search");
       expect(existsSync(tracePath)).toBe(true);
       expect(readFileSync(stderrPath, "utf8")).toBe("");
     },

--- a/tests/e2e/web-fetch-fake-network.test.ts
+++ b/tests/e2e/web-fetch-fake-network.test.ts
@@ -309,7 +309,7 @@ describe("web_fetch Gateway fixture", () => {
           expect(gateway.requests).toHaveLength(1);
           expect(gateway.requests[0].headers.get("ai-language-model-id")).toBe(model);
           expectWebFetchSchema(gateway.requests[0]);
-          expect(gateway.requests[0].body).toContain("gateway.perplexity_search");
+          expect(gateway.requests[0].body).toContain("gateway.exa_search");
         } finally {
           gateway.stop();
           rmSync(root.root, { recursive: true, force: true });

--- a/tests/e2e/web-search-fake-gateway.test.ts
+++ b/tests/e2e/web-search-fake-gateway.test.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN, runFx } from "../evals/eval-helpers";
 import {
-  AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
+  AUTO_EXA_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
   customProviderGuidanceState,
   findUnavailableCapabilityReferences,
   parseGatewayRequest,
@@ -22,7 +22,6 @@ import {
   toolByName,
   toolShapesWithoutDescriptions,
   VERIFY_SERIALIZED_TOOL_NAMES,
-  WEB_PERPLEXITY_SERIALIZED_TOOL_NAMES,
   WEB_SEARCH_GUIDANCE,
   contentText,
 } from "./conditional-guidance-oracle";
@@ -143,7 +142,7 @@ function outerSearchCall(input: object = { query: "latest Zig release" }) {
   return outerToolCalls([{ id: "search_outer_1", name: "web_search", input }]);
 }
 
-function outerDirectProviderSearch(toolName = "perplexity_search", result: object = {
+function outerDirectProviderSearch(toolName = "exa_search", result: object = {
   results: [{ title: "Zig downloads", url: SOURCE_URL }],
 }) {
   return sse([
@@ -479,7 +478,7 @@ describe("web_search Gateway fixture", () => {
         const json = parseFxJson(result);
         expect(json.output).toContain("native search call was rejected");
         expect(gateway.requests).toHaveLength(2);
-        expect(gateway.requests[0].body).toContain("gateway.perplexity_search");
+        expect(gateway.requests[0].body).toContain("gateway.exa_search");
         expect(gateway.requests[1].body).toContain(
           "web_search is unavailable: no local runtime with a configured Gateway transport policy is installed",
         );
@@ -524,7 +523,7 @@ describe("web_search Gateway fixture", () => {
   );
 
   test(
-    "no-rule default uses direct Perplexity search and returns a linked source",
+    "no-rule default uses direct Exa search and returns a linked source",
     async () => {
       const root = createIsolatedRoot(null);
       const gateway = startFakeGateway();
@@ -546,8 +545,9 @@ describe("web_search Gateway fixture", () => {
         expect(gateway.requests).toHaveLength(2);
         expect(gateway.requests[0].headers.get("ai-language-model-id")).toBe(OUTER_MODEL);
         expect(gateway.requests[0].body).not.toContain('"name":"web_search"');
-        expect(gateway.requests[0].body).toContain("gateway.perplexity_search");
-        expect(gateway.requests[0].body).toContain('"name":"perplexity_search"');
+        expect(gateway.requests[0].body).toContain("gateway.exa_search");
+        expect(gateway.requests[0].body).toContain('"name":"exa_search"');
+        expect(gateway.requests[0].body).not.toContain('"name":"perplexity_search"');
         expect(gateway.requests[0].body).not.toContain('"name":"parallel_search"');
         expect(gateway.requests[0].body).not.toContain("google/gemini-3-flash");
         expect(gateway.requests[1].headers.get("ai-language-model-id")).toBe(OUTER_MODEL);
@@ -556,10 +556,10 @@ describe("web_search Gateway fixture", () => {
         const initial = parseGatewayRequest(gateway.requests[0]!.body);
         const continuing = parseGatewayRequest(gateway.requests[1]!.body);
         expect(serializedToolNames(initial)).toEqual(
-          AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
+          AUTO_EXA_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
         );
         expect(serializedToolNames(continuing)).toEqual(
-          AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
+          AUTO_EXA_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES,
         );
         expect(toolShapesWithoutDescriptions(continuing)).toEqual(
           toolShapesWithoutDescriptions(initial),
@@ -595,7 +595,7 @@ describe("web_search Gateway fixture", () => {
     async () => {
       const root = createIsolatedRoot();
       const gateway = startFakeGateway([
-        malformedDirectProviderResult("perplexity_search"),
+        malformedDirectProviderResult("exa_search"),
       ]);
       try {
         const result = await runFx(
@@ -623,7 +623,7 @@ describe("web_search Gateway fixture", () => {
     async () => {
       const root = createIsolatedRoot();
       const gateway = startFakeGateway([
-        malformedDirectProviderArguments("perplexity_search"),
+        malformedDirectProviderArguments("exa_search"),
       ]);
       try {
         const result = await runFx(
@@ -714,14 +714,15 @@ describe("web_search Gateway fixture", () => {
         expect(gateway.requests).toHaveLength(2);
         expect(gateway.requests[0].headers.get("ai-language-model-id")).toBe(PARALLEL_OUTER_MODEL);
         expect(gateway.requests[0].body).not.toContain('"name":"web_search"');
+        expect(gateway.requests[0].body).not.toContain('"name":"exa_search"');
         expect(gateway.requests[0].body).not.toContain('"name":"perplexity_search"');
         expect(gateway.requests[0].body).toContain("gateway.parallel_search");
         expect(gateway.requests[0].body).toContain('"name":"parallel_search"');
         expect(gateway.requests[0].body).not.toContain("gateway.perplexity_search");
         const request = parseGatewayRequest(gateway.requests[0]!.body);
         expect(serializedToolNames(request)).toEqual(
-          AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES.map((name) =>
-            name === "perplexity_search" ? "parallel_search" : name
+          AUTO_EXA_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES.map((name) =>
+            name === "exa_search" ? "parallel_search" : name
           ),
         );
         expect(findUnavailableCapabilityReferences(request)).toEqual([]);
@@ -761,7 +762,8 @@ describe("web_search Gateway fixture", () => {
 
         parseFxJson(result);
         expect(gateway.requests).toHaveLength(2);
-        expect(gateway.requests[0].body).toContain('"name":"perplexity_search"');
+        expect(gateway.requests[0].body).toContain('"name":"exa_search"');
+        expect(gateway.requests[0].body).not.toContain('"name":"perplexity_search"');
         expect(gateway.requests[0].body).not.toContain('"name":"parallel_search"');
         expect(JSON.parse(gateway.requests[0].body)).toMatchObject({ reasoning: "high" });
         expect(JSON.parse(gateway.requests[1].body)).toMatchObject({ reasoning: "high" });
@@ -914,13 +916,14 @@ describe("web_search Gateway fixture", () => {
           expect(json.output).toContain("search capability unavailable");
           expect(json.tool_calls).toHaveLength(0);
           expect(gateway.requests).toHaveLength(1);
+          expect(gateway.requests[0].body).not.toContain("gateway.exa_search");
           expect(gateway.requests[0].body).not.toContain("gateway.perplexity_search");
           expect(gateway.requests[0].body).not.toContain("gateway.parallel_search");
           expect(gateway.requests[0].body).not.toContain('"name":"web_search"');
           const request = parseGatewayRequest(gateway.requests[0]!.body);
           expect(serializedToolNames(request)).toEqual(
-            AUTO_PERPLEXITY_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES.filter((name) =>
-              name !== "perplexity_search"
+            AUTO_EXA_WITHOUT_DURABLE_TOOLS_SERIALIZED_TOOL_NAMES.filter((name) =>
+              name !== "exa_search"
             ),
           );
           expect(findUnavailableCapabilityReferences(request)).toEqual([]);
@@ -942,7 +945,7 @@ describe("web_search Gateway fixture", () => {
     async () => {
       const root = createIsolatedRoot();
       const gateway = startFakeGateway([
-        outerDirectProviderSearch("perplexity_search", { results: [] }),
+        outerDirectProviderSearch("exa_search", { results: [] }),
         outerText("zero search handled"),
       ]);
       try {
@@ -1026,7 +1029,7 @@ describe("web_search Gateway fixture", () => {
         const updates = JSON.stringify(messages);
 
         expect(gateway.requests).toHaveLength(2);
-        expect(gateway.requests[0].body).toContain("gateway.perplexity_search");
+        expect(gateway.requests[0].body).toContain("gateway.exa_search");
         expect(gateway.requests[0].body).not.toContain('"name":"web_search"');
         const initial = parseGatewayRequest(gateway.requests[0]!.body);
         const continuing = parseGatewayRequest(gateway.requests[1]!.body);
@@ -1098,6 +1101,7 @@ describe("web_search Gateway fixture", () => {
         const messages = await runAcpPrompt(client, "Issue denied web search.");
 
         expect(gateway.requests).toHaveLength(1);
+        expect(gateway.requests[0].body).not.toContain("gateway.exa_search");
         expect(gateway.requests[0].body).not.toContain("gateway.perplexity_search");
         expect(gateway.requests[0].body).not.toContain('"name":"web_search"');
         const request = parseGatewayRequest(gateway.requests[0]!.body);

--- a/tests/e2e/web-search-live.test.ts
+++ b/tests/e2e/web-search-live.test.ts
@@ -7,7 +7,7 @@ import { HAS_API_KEY, runFx } from "../evals/eval-helpers";
 const TIMEOUT = 180_000;
 const OUTER_MODEL = "anthropic/claude-sonnet-4.6";
 const BACKENDS = [
-  "ai_gateway_perplexity_search",
+  "ai_gateway_exa_search",
   "ai_gateway_parallel_search",
 ] as const;
 
@@ -92,6 +92,7 @@ describe.skipIf(!HAS_API_KEY)("live web_search private backends", () => {
           expect(json.model).not.toContain("perplexity");
           expect(json.model).not.toContain("parallel");
           expect(json.tool_calls).toHaveLength(0);
+          expect(json.tool_calls.some((call) => call.name === "exa_search")).toBe(false);
           expect(json.tool_calls.some((call) => call.name === "perplexity_search")).toBe(false);
           expect(json.tool_calls.some((call) => call.name === "parallel_search")).toBe(false);
           expect(json.tool_calls.some((call) => call.name === "web_fetch")).toBe(false);


### PR DESCRIPTION
## Summary

- Use Exa for web search by default.
- Keep Parallel as the fallback backend.
- Preserve explicit Perplexity backend selection.