### PR TITLE
Make terminal recording developer-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,10 +297,11 @@ cd tests/e2e && bun test tui-resize.test.ts
 
 Set `FX_DEBUG_RECORD=1` to create an automatic private tape under
 `~/.fx/recordings/`. Set `FX_DEBUG_RECORD_SILENT_BANNER=1` as well when the
-developer-only recording notice must stay hidden during a screen share. Use
-`FX_RECORD=<path>` when a test or investigation needs an exact destination.
-Recording dumps every byte fx writes and every resize into a framed binary
-tape. Replay the tape through the built-in virtual terminal:
+developer-only recording notice must stay out of the inline transcript during
+a screen share. The notice remains available in the Ctrl+O full transcript.
+Use `FX_RECORD=<path>` when a test or investigation needs an exact destination.
+Recording dumps every byte fx writes and every resize into a framed binary tape.
+Replay the tape through the built-in virtual terminal:
 
 ```bash
 FX_DEBUG_RECORD=1 ./zig-out/bin/fx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,16 +293,22 @@ Best for resize and SIGWINCH interactions. The helper in `tests/e2e/tmux-helpers
 cd tests/e2e && bun test tui-resize.test.ts
 ```
 
-### FX\_RECORD + fx replay (capture-and-replay)
+### Debug terminal recording and replay
 
-Run fx with `FX_RECORD=<path>` to dump every byte fx writes, every resize, and every Ctrl+C into a framed binary tape. Replay the tape through the built-in virtual terminal:
+Set `FX_DEBUG_RECORD=1` to create an automatic private tape under
+`~/.fx/recordings/`. Set `FX_DEBUG_RECORD_SILENT_BANNER=1` as well when the
+developer-only recording notice must stay hidden during a screen share. Use
+`FX_RECORD=<path>` when a test or investigation needs an exact destination.
+Recording dumps every byte fx writes and every resize into a framed binary
+tape. Replay the tape through the built-in virtual terminal:
 
 ```bash
-FX_RECORD=/tmp/bug.fxtape fx        # user reproduces the glitch
-fx replay /tmp/bug.fxtape           # print the final cell grid
-fx replay /tmp/bug.fxtape --frames  # scrub through every intermediate frame
-fx replay /tmp/bug.fxtape --json    # structured frame metadata + grid
-fx replay /tmp/bug.fxtape --golden out.txt   # write grid to a file
+FX_DEBUG_RECORD=1 ./zig-out/bin/fx
+FX_RECORD=/tmp/bug.fxtape ./zig-out/bin/fx
+./zig-out/bin/fx replay /tmp/bug.fxtape
+./zig-out/bin/fx replay /tmp/bug.fxtape --frames
+./zig-out/bin/fx replay /tmp/bug.fxtape --json
+./zig-out/bin/fx replay /tmp/bug.fxtape --golden out.txt
 ```
 
 The tape is deterministic — any reviewer can replay it without a TTY, and a golden file can be checked in as a regression test.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,9 +384,10 @@ test("my scenario", async () => {
 
 For bugs reported by a user, have them run the built binary with an exact
 `FX_RECORD=<path>`, or use `FX_DEBUG_RECORD=1` for an automatic private tape.
-`FX_DEBUG_RECORD_SILENT_BANNER=1` hides the developer-only startup notice
-without disabling capture. Drop the tape in `tests/e2e/tapes/<name>.fxtape`
-and assert against the built replay command:
+`FX_DEBUG_RECORD_SILENT_BANNER=1` hides the developer-only startup notice from
+the inline transcript without disabling capture; Ctrl+O still shows it. Drop
+the tape in `tests/e2e/tapes/<name>.fxtape` and assert against the built replay
+command:
 
 ```bash
 ./zig-out/bin/fx replay tests/e2e/tapes/my-bug.fxtape --golden tests/e2e/tapes/my-bug.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -382,10 +382,14 @@ test("my scenario", async () => {
 
 ### Tape-based test (replay a real capture)
 
-For bugs reported by a user, have them run fx with `FX_RECORD=<path>`. Drop the tape in `tests/e2e/tapes/<name>.fxtape` and assert against `fx replay --golden`:
+For bugs reported by a user, have them run the built binary with an exact
+`FX_RECORD=<path>`, or use `FX_DEBUG_RECORD=1` for an automatic private tape.
+`FX_DEBUG_RECORD_SILENT_BANNER=1` hides the developer-only startup notice
+without disabling capture. Drop the tape in `tests/e2e/tapes/<name>.fxtape`
+and assert against the built replay command:
 
 ```bash
-fx replay tests/e2e/tapes/my-bug.fxtape --golden tests/e2e/tapes/my-bug.txt
+./zig-out/bin/fx replay tests/e2e/tapes/my-bug.fxtape --golden tests/e2e/tapes/my-bug.txt
 ```
 
 Check in the golden file and wire a regression test that re-runs `fx replay` in CI and diffs.

--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -193,7 +193,7 @@ pub const top_level_specs = [_]TopLevelSpec{
     .{
         .kind = .session,
         .token = "session",
-        .usage = "session <last|id>|--id <id> [--json] | session resume [last|<id>] [--record] | session resume --id <id> [--record] | session migrate <id>|--id <id> [--allow-large] [--json] | session recover <id>|--id <id> [--json]",
+        .usage = "session <last|id>|--id <id> [--json] | session resume [last|<id>] | session resume --id <id> | session migrate <id>|--id <id> [--allow-large] [--json] | session recover <id>|--id <id> [--json]",
         .summary = "Inspect, resume, migrate, or recover saved sessions",
         .options = &.{
             .{ .flag = "last", .description = "Inspect the current workspace session" },
@@ -222,14 +222,13 @@ pub const top_level_specs = [_]TopLevelSpec{
         .token = "resume",
         .aliases = &.{ "--resume", "--resume-last", "--continue", "-c", "-r" },
         .hidden_from_top_level_help = true,
-        .usage = "session resume [last|<id>] [--record] | session resume --id <id> [--record] | --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>",
+        .usage = "session resume [last|<id>] | session resume --id <id> | --resume [last|<id>] | resume [last|<id>] | resume --id <id> | --resume-last | --continue | -c | -r | --resume-<id>",
         .summary = "Continue a saved interactive session",
         .options = &.{
             .{ .flag = "-r", .description = "Choose the session to resume from a picker" },
             .{ .flag = "last", .description = "Resume the most recent session" },
             .{ .flag = "<id>", .description = "Resume a session by id" },
             .{ .flag = "--id <id>", .description = "Resume a session by exact id" },
-            .{ .flag = "--record", .description = "Capture visible terminal content while running" },
         },
     },
     .{
@@ -269,6 +268,7 @@ pub const top_level_specs = [_]TopLevelSpec{
         .token = "replay",
         .usage = "replay <tape> [--frames] [--json] [--golden <path>] [--frames-dir <path>]",
         .summary = "Replay a recorded terminal session",
+        .hidden_from_top_level_help = true,
         .options = &.{
             .{ .flag = "--frames", .description = "Render each captured frame" },
             .{ .flag = "--golden <path>", .description = "Write the final rendered grid to a file" },
@@ -312,7 +312,6 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
         .{ .usage = "session resume [last|id]", .summary = "Resume the latest workspace session or a session by id" },
         .{ .usage = "session migrate <id>", .summary = "Migrate a saved session to the current format" },
         .{ .usage = "session recover <id>", .summary = "Copy a recoverable corrupt session" },
-        .{ .kind = .replay, .usage = "replay <tape>" },
     } },
     .{ .entries = &.{
         .{ .kind = .login, .usage = "login [vercel|codex|grok]" },
@@ -337,10 +336,6 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
 };
 
 pub const top_level_flags = [_]TopLevelFlag{
-    .{
-        .usage = "--record",
-        .description = "Record terminal output",
-    },
     .{
         .usage = "--context-limit <spec>",
         .description = "Set name=bytes|off; repeatable",

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -388,7 +388,7 @@ pub fn Runtime(comptime App: type) type {
             }
             var recording = try record_tape.captureStatus(app.alloc);
             defer recording.deinit(app.alloc);
-            if (recording == .active and recording.active.show_startup_notice) {
+            if (recording == .active) {
                 const recording_body = try std.fmt.allocPrint(
                     app.alloc,
                     "visual terminal capture: {s}\nvisible terminal content, including typed prompt text, is recorded",
@@ -399,6 +399,7 @@ pub fn Runtime(comptime App: type) type {
                     .topic = "recording",
                     .tone = .warning,
                     .body = recording_body,
+                    .visibility = if (recording.active.show_inline_notice) .compact_and_full else .full_only,
                 }, true);
             }
             {

--- a/src/core/app/app_bootstrap_runtime.zig
+++ b/src/core/app/app_bootstrap_runtime.zig
@@ -83,7 +83,6 @@ pub fn Runtime(comptime App: type) type {
             default_model: []const u8,
             default_agent_step_limit: usize,
             resize_handler: app_lifecycle.ResizeHandler,
-            record_requested: bool,
             capability_providers: CapabilityProviders,
         ) !void {
             try bootstrapWithDeps(
@@ -92,7 +91,6 @@ pub fn Runtime(comptime App: type) type {
                 default_model,
                 default_agent_step_limit,
                 resize_handler,
-                record_requested,
                 defaultDeps(capability_providers),
             );
         }
@@ -182,7 +180,6 @@ pub fn Runtime(comptime App: type) type {
             default_model: []const u8,
             default_agent_step_limit: usize,
             resize_handler: app_lifecycle.ResizeHandler,
-            record_requested: bool,
             deps: BootstrapDeps(App),
         ) !void {
             errdefer app.deinit();
@@ -203,7 +200,6 @@ pub fn Runtime(comptime App: type) type {
                     host.unavailable_secret_store,
                 .resize_handler = resize_handler,
                 .fx_version = App.app_version,
-                .record_requested = record_requested,
             });
             defer startup.deinit(app.alloc);
 
@@ -392,11 +388,11 @@ pub fn Runtime(comptime App: type) type {
             }
             var recording = try record_tape.captureStatus(app.alloc);
             defer recording.deinit(app.alloc);
-            if (recording == .active) {
+            if (recording == .active and recording.active.show_startup_notice) {
                 const recording_body = try std.fmt.allocPrint(
                     app.alloc,
                     "visual terminal capture: {s}\nvisible terminal content, including typed prompt text, is recorded",
-                    .{recording.active},
+                    .{recording.active.path},
                 );
                 defer app.alloc.free(recording_body);
                 try app.writeDomainNotice(.{
@@ -856,7 +852,6 @@ fn runBootstrapForTest(app: *TestApp, capture: *TestCapture) !void {
         "default-model",
         24,
         resizeHandlerForTest,
-        false,
         testDeps(),
     );
 }

--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -138,10 +138,6 @@ fn runWithDeps(comptime App: type, alloc: Allocator, args: []const [:0]const u8,
 }
 
 pub fn runBeforeInteractive(alloc: Allocator, args: []const [:0]const u8, cfg: Config) !BeforeInteractiveResult {
-    _ = cli_surface.recordRequested(args) catch {
-        writeStderr(.{}, cli_surface.record_modifier_usage);
-        return .{ .exit = 1 };
-    };
     const run_result = cli_surface.runIfRequested(alloc, args, cliSurfaceConfig(cfg)) catch |err| switch (err) {
         error.UnknownCliCommand => return .{ .exit = 1 },
         else => {
@@ -163,10 +159,6 @@ pub fn runNoConfigBeforeInteractive(
 }
 
 fn runBeforeInteractiveWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: RunDeps) !BeforeInteractiveResult {
-    _ = cli_surface.recordRequested(args) catch {
-        writeStderr(deps, cli_surface.record_modifier_usage);
-        return .{ .exit = 1 };
-    };
     const run_result = deps.run_if_requested(deps.cli_ctx, alloc, args, cliSurfaceConfig(cfg)) catch |err| switch (err) {
         error.UnknownCliCommand => return .{ .exit = 1 },
         else => {

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -252,7 +252,6 @@ pub const BootstrapConfig = struct {
     secret_store: host.SecretStore,
     resize_handler: ResizeHandler,
     fx_version: []const u8 = "",
-    record_requested: bool = false,
 };
 
 pub fn loadStartupState(
@@ -479,11 +478,9 @@ pub fn bootstrapInteractiveApp(cfg: BootstrapConfig) !StartupState {
 
     record_tape.configureFromEnv(
         cfg.alloc,
-        state.workspace_root,
         cfg.shell.layout.cols,
         cfg.shell.layout.rows,
         cfg.fx_version,
-        cfg.record_requested,
     ) catch |err| {
         debug_trace.logf("record", "startup recording failed err={s}", .{@errorName(err)});
         return error.RecordingStartFailed;

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -133,7 +133,6 @@ pub const LaunchModifiers = struct {
 pub const InteractiveLaunch = struct {
     requested_resume: ?ResumeTarget = null,
     upgrade_relaunch: bool = false,
-    record_requested: bool = false,
     modifiers: LaunchModifiers = .{},
 
     pub fn deinit(self: *InteractiveLaunch, alloc: Allocator) void {
@@ -150,26 +149,7 @@ pub const RunResult = union(enum) {
     handled_exit: u8,
 };
 
-pub const record_modifier_usage = "usage: fx --record is only supported for interactive startup\n";
 const version_usage = "usage: fx --version\n";
-
-pub fn recordRequested(args: []const [:0]const u8) error{RecordModifierRequiresInteractive}!bool {
-    var count: usize = 0;
-    for (args) |arg| {
-        if (std.mem.eql(u8, arg, "--record")) count += 1;
-    }
-    if (count == 0) return false;
-    if (count != 1) return error.RecordModifierRequiresInteractive;
-    if (args.len == 1 and std.mem.eql(u8, args[0], "--record")) return true;
-    if (args.len >= 2 and
-        (std.mem.eql(u8, args[0], "resume") or std.mem.eql(u8, args[0], "--resume")) and
-        std.mem.eql(u8, args[args.len - 1], "--record")) return true;
-    if (args.len >= 3 and
-        std.mem.eql(u8, args[0], "session") and
-        std.mem.eql(u8, args[1], "resume") and
-        std.mem.eql(u8, args[args.len - 1], "--record")) return true;
-    return error.RecordModifierRequiresInteractive;
-}
 
 pub const Config = struct {
     version: []const u8 = "",
@@ -558,14 +538,6 @@ pub fn parseInteractiveLaunch(
         return .{ .interactive = .{ .modifiers = global_args.takeModifiers() } };
     }
 
-    const record_requested = try recordRequested(effective_args);
-    if (record_requested and effective_args.len == 1) {
-        return .{ .interactive = .{
-            .record_requested = true,
-            .modifiers = global_args.takeModifiers(),
-        } };
-    }
-
     const command = parse(command_catalog, effective_args);
     if (topLevelHelpRequest(command_catalog, effective_args) != null) {
         return .{ .noninteractive = .{
@@ -576,14 +548,10 @@ pub fn parseInteractiveLaunch(
     }
     switch (command) {
         .interactive => return .{ .interactive = .{
-            .record_requested = record_requested,
             .modifiers = global_args.takeModifiers(),
         } },
         .resume_session => |invocation| {
-            const resume_args = if (record_requested)
-                invocation.args[0 .. invocation.args.len - 1]
-            else
-                invocation.args;
+            const resume_args = invocation.args;
             const upgrade_relaunch = !invocation.top_level_alias and
                 resume_args.len == 2 and
                 std.mem.eql(u8, resume_args[1], upgrade_relaunch_arg);
@@ -600,7 +568,6 @@ pub fn parseInteractiveLaunch(
             return .{ .interactive = .{
                 .requested_resume = target,
                 .upgrade_relaunch = upgrade_relaunch,
-                .record_requested = record_requested,
                 .modifiers = global_args.takeModifiers(),
             } };
         },
@@ -640,10 +607,6 @@ fn runNoConfigIfRequestedWithDeps(
     command_catalog: CommandCatalog,
     deps: RunDeps,
 ) !bool {
-    _ = recordRequested(args) catch {
-        try writeStderr(deps, record_modifier_usage);
-        return true;
-    };
     if (args.len != 1 or !command_specs.matchesTopLevel(command_catalog, args[0], .help)) {
         return false;
     }
@@ -817,10 +780,6 @@ fn activateProviderSelection(
 
 fn runIfRequestedWithDeps(alloc: Allocator, args: []const [:0]const u8, cfg: Config, deps: RunDeps) !RunResult {
     const parsed_launch = parseInteractiveLaunch(alloc, args, cfg.command_catalog) catch |err| {
-        if (err == error.RecordModifierRequiresInteractive) {
-            try writeStderr(deps, record_modifier_usage);
-            return .handled_failure;
-        }
         if (err == error.InvalidResumeArgs) {
             try writeTopLevelUsage(cfg.command_catalog, deps, .@"resume");
             return .handled_failure;
@@ -4971,95 +4930,21 @@ test "workspace unknown directory errors keep stable json codes" {
     try std.testing.expectEqualStrings("", capture.stderr.written());
 }
 
-test "runIfRequested rejects record modifier outside interactive startup" {
+test "runIfRequested rejects removed record flag as unknown input" {
     var capture = CaptureOutput.init(std.testing.allocator);
     defer capture.deinit();
 
-    const result = try runIfRequestedWithDeps(
-        std.testing.allocator,
-        &.{ @constCast("help"), @constCast("--record") },
-        testConfig(),
-        capture.deps(),
+    try std.testing.expectError(
+        error.UnknownCliCommand,
+        runIfRequestedWithDeps(
+            std.testing.allocator,
+            &.{@constCast("--record")},
+            testConfig(),
+            capture.deps(),
+        ),
     );
 
-    try std.testing.expectEqual(RunResult.handled_failure, result);
-    try std.testing.expectEqualStrings("usage: fx --record is only supported for interactive startup\n", capture.stderr.written());
-}
-
-test "runIfRequested carries record intent through supported interactive launches" {
-    var capture = CaptureOutput.init(std.testing.allocator);
-    defer capture.deinit();
-
-    const plain = try runIfRequestedWithDeps(
-        std.testing.allocator,
-        &.{@constCast("--record")},
-        testConfig(),
-        capture.deps(),
-    );
-    switch (plain) {
-        .interactive => |launch| {
-            try std.testing.expect(launch.record_requested);
-            try std.testing.expect(launch.requested_resume == null);
-        },
-        else => return error.TestExpectedInteractiveLaunch,
-    }
-
-    const resumed = try runIfRequestedWithDeps(
-        std.testing.allocator,
-        &.{ @constCast("--resume"), @constCast("session-123"), @constCast("--record") },
-        testConfig(),
-        capture.deps(),
-    );
-    switch (resumed) {
-        .interactive => |launch_value| {
-            var launch = launch_value;
-            defer launch.deinit(std.testing.allocator);
-            try std.testing.expect(launch.record_requested);
-            switch (launch.requested_resume.?) {
-                .id => |id| try std.testing.expectEqualStrings("session-123", id),
-                .pick, .last => return error.TestExpectedResumeId,
-            }
-        },
-        else => return error.TestExpectedInteractiveLaunch,
-    }
-
-    const grouped = try runIfRequestedWithDeps(
-        std.testing.allocator,
-        &.{ @constCast("session"), @constCast("resume"), @constCast("session-123"), @constCast("--record") },
-        testConfig(),
-        capture.deps(),
-    );
-    switch (grouped) {
-        .interactive => |launch_value| {
-            var launch = launch_value;
-            defer launch.deinit(std.testing.allocator);
-            try std.testing.expect(launch.record_requested);
-            switch (launch.requested_resume.?) {
-                .id => |id| try std.testing.expectEqualStrings("session-123", id),
-                .pick, .last => return error.TestExpectedResumeId,
-            }
-        },
-        else => return error.TestExpectedInteractiveLaunch,
-    }
-}
-
-test "runIfRequested rejects record modifier before noninteractive handlers" {
-    const cases = [_][]const [:0]const u8{
-        &.{ @constCast("ask"), @constCast("--record"), @constCast("hello") },
-        &.{ @constCast("acp"), @constCast("--record") },
-        &.{ @constCast("pr"), @constCast("--record") },
-        &.{ @constCast("issue"), @constCast("--record") },
-        &.{ @constCast("--version"), @constCast("--record") },
-        &.{ @constCast("-v"), @constCast("--record") },
-    };
-    for (cases) |args| {
-        var capture = CaptureOutput.init(std.testing.allocator);
-        defer capture.deinit();
-
-        const result = try runIfRequestedWithDeps(std.testing.allocator, args, testConfig(), capture.deps());
-        try std.testing.expectEqual(RunResult.handled_failure, result);
-        try std.testing.expectEqualStrings(record_modifier_usage, capture.stderr.written());
-    }
+    try std.testing.expect(std.mem.find(u8, capture.stderr.written(), "fx: unknown subcommand: --record") != null);
 }
 
 test "runNoConfigIfRequested handles help without config" {
@@ -5323,7 +5208,7 @@ test "runIfRequested rejects malformed resume aliases with canonical usage" {
         );
         try std.testing.expectEqual(RunResult.handled_failure, result);
         try std.testing.expectEqualStrings(
-            "usage: fx session resume [last|<id>] [--record] | session resume --id <id> [--record] | --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>\n",
+            "usage: fx session resume [last|<id>] | session resume --id <id> | --resume [last|<id>] | resume [last|<id>] | resume --id <id> | --resume-last | --continue | -c | -r | --resume-<id>\n",
             capture.stderr.written(),
         );
     }
@@ -5354,7 +5239,7 @@ test "runIfRequested invalid resume writes usage" {
     const result = try runIfRequestedWithDeps(std.testing.allocator, &.{ @constCast("resume"), @constCast("a"), @constCast("b") }, testConfig(), capture.deps());
     try std.testing.expectEqual(RunResult.handled_failure, result);
     try std.testing.expectEqualStrings(
-        "usage: fx session resume [last|<id>] [--record] | session resume --id <id> [--record] | --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>\n",
+        "usage: fx session resume [last|<id>] | session resume --id <id> | --resume [last|<id>] | resume [last|<id>] | resume --id <id> | --resume-last | --continue | -c | -r | --resume-<id>\n",
         capture.stderr.written(),
     );
 }

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1647,25 +1647,26 @@ test "top-level help renders flags as compact aligned rows" {
     const narrow = try renderTopLevelHelp(std.testing.allocator, testTopLevelRegistry(), 60, "9.8.7");
     defer std.testing.allocator.free(narrow);
 
-    try std.testing.expect(lineContainsBoth(wide, "--record", "Record terminal output"));
     try std.testing.expect(lineContainsBoth(wide, "--context-limit <spec>", "Set name=bytes|off; repeatable"));
     try std.testing.expect(lineContainsBoth(wide, "--add-dir <path>", "Add a workspace directory; repeatable"));
     try std.testing.expect(lineContainsBoth(wide, "-c, --continue", "Resume the latest workspace session"));
     try std.testing.expect(lineContainsBoth(wide, "-r", "Open the saved-session picker"));
     try std.testing.expect(lineContainsBoth(wide, "--resume [last|<id>]", "Resume the latest workspace session or an exact ID"));
     try std.testing.expect(lineContainsBoth(wide, "--resume-last", "Resume the latest workspace session"));
-    try std.testing.expect(std.mem.find(u8, wide, "Record terminal output\n\n  --context-limit") == null);
     try std.testing.expect(std.mem.find(u8, wide, "Print the 𝒇x version and exit\n\nExamples:") != null);
     try expectAllLinesFit(narrow, 60);
+}
 
-    var lines = std.mem.splitScalar(u8, wide, '\n');
-    while (lines.next()) |line| {
-        const description_start = std.mem.find(u8, line, "Record terminal output") orelse continue;
-        try std.testing.expect(display_width.visibleWidth(line[0..description_start]) <= 28);
-        break;
-    } else {
-        return error.TestExpectedEqual;
-    }
+test "top-level help hides developer recording surfaces" {
+    const text = try renderTopLevelHelp(std.testing.allocator, testTopLevelRegistry(), 120, "9.8.7");
+    defer std.testing.allocator.free(text);
+
+    try std.testing.expect(std.mem.find(u8, text, "--record") == null);
+    try std.testing.expect(std.mem.find(u8, text, "replay <tape>") == null);
+
+    const replay = try renderTopLevelCommandHelp(std.testing.allocator, testTopLevelRegistry(), .replay);
+    defer std.testing.allocator.free(replay);
+    try std.testing.expect(std.mem.find(u8, replay, "fx replay") != null);
 }
 
 test "default top-level help styles fit the startup buffer" {
@@ -1689,13 +1690,13 @@ test "per-command help renders header usage options and details" {
     try std.testing.expect(std.mem.find(u8, text, "Modes:") != null);
 }
 
-test "per-command help preserves long resume usage outside top-level index" {
+test "per-command help preserves long resume usage without debug recording" {
     const text = try renderTopLevelCommandHelp(std.testing.allocator, testTopLevelRegistry(), .@"resume");
     defer std.testing.allocator.free(text);
 
-    try std.testing.expect(std.mem.find(u8, text, "Usage:\n  fx session resume [last|<id>] [--record] | session resume --id <id> [--record] | --resume [last|<id>] [--record] | resume [last|<id>] [--record] | resume --id <id> [--record] | --resume-last | --continue | -c | -r | --resume-<id>") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Usage:\n  fx session resume [last|<id>] | session resume --id <id> | --resume [last|<id>] | resume [last|<id>] | resume --id <id> | --resume-last | --continue | -c | -r | --resume-<id>") != null);
     try std.testing.expect(std.mem.find(u8, text, "Options:") != null);
-    try std.testing.expect(std.mem.find(u8, text, "--record") != null);
+    try std.testing.expect(std.mem.find(u8, text, "--record") == null);
 }
 
 test "ACP help documents accepted options" {

--- a/src/core/workspace/record_tape.zig
+++ b/src/core/workspace/record_tape.zig
@@ -23,7 +23,7 @@ const State = struct {
     enabled: bool = false,
     failed: bool = false,
     record_stdin: bool = false,
-    show_startup_notice: bool = false,
+    show_inline_notice: bool = false,
     file: ?std.Io.File = null,
     path: ?[]u8 = null,
     path_alloc: ?Allocator = null,
@@ -51,7 +51,7 @@ const StartupPolicy = struct {
     destination: StartupDestination,
     record_stdin: bool,
     strict_start: bool,
-    show_startup_notice: bool,
+    show_inline_notice: bool,
 };
 
 fn debug_env_truthy(raw: ?[]const u8) bool {
@@ -91,7 +91,7 @@ fn resolve_startup_policy(input: StartupPolicyInput) StartupPolicy {
         .destination = destination,
         .record_stdin = active and record_input_enabled(input.record_input),
         .strict_start = debug_record,
-        .show_startup_notice = active and !debug_env_truthy(input.silent_banner),
+        .show_inline_notice = active and !debug_env_truthy(input.silent_banner),
     };
 }
 
@@ -103,7 +103,7 @@ pub const CaptureStatus = union(enum) {
     inactive,
     active: struct {
         path: []u8,
-        show_startup_notice: bool,
+        show_inline_notice: bool,
     },
     failed,
 
@@ -135,7 +135,7 @@ pub fn configureFromEnv(
             initial_cols,
             initial_rows,
             fx_version,
-            policy.show_startup_notice,
+            policy.show_inline_notice,
         ),
         .explicit => |path| configureWithOptions(
             alloc,
@@ -145,7 +145,7 @@ pub fn configureFromEnv(
             fx_version,
             false,
             false,
-            policy.show_startup_notice,
+            policy.show_inline_notice,
         ) catch |err| {
             if (policy.strict_start) return err;
             return;
@@ -175,7 +175,7 @@ fn configureAutomatic(
     initial_cols: u16,
     initial_rows: u16,
     fx_version: []const u8,
-    show_startup_notice: bool,
+    show_inline_notice: bool,
 ) !void {
     const home = if (io_mod.getenv("HOME")) |value| blk: {
         const trimmed = std.mem.trim(u8, value, " \t\r\n");
@@ -196,7 +196,7 @@ fn configureAutomatic(
         const path = try std.fmt.allocPrint(alloc, "{s}/fx-record-{d}-{s}.fxtape", .{ root, nowMs(), random_hex });
         defer alloc.free(path);
 
-        configureWithOptions(alloc, path, initial_cols, initial_rows, fx_version, true, true, show_startup_notice) catch |err| switch (err) {
+        configureWithOptions(alloc, path, initial_cols, initial_rows, fx_version, true, true, show_inline_notice) catch |err| switch (err) {
             error.PathAlreadyExists => continue,
             else => return err,
         };
@@ -213,7 +213,7 @@ fn configureWithOptions(
     fx_version: []const u8,
     exclusive: bool,
     private: bool,
-    show_startup_notice: bool,
+    show_inline_notice: bool,
 ) !void {
     const zio = io_mod.getIo();
     state_mutex.lockUncancelable(zio);
@@ -238,7 +238,7 @@ fn configureWithOptions(
     const now = nowMs();
     state = .{
         .enabled = true,
-        .show_startup_notice = show_startup_notice,
+        .show_inline_notice = show_inline_notice,
         .file = file,
         .path = owned_path,
         .path_alloc = alloc,
@@ -375,7 +375,7 @@ pub fn captureStatus(alloc: Allocator) !CaptureStatus {
     if (state.enabled and state.path != null) {
         return .{ .active = .{
             .path = try alloc.dupe(u8, state.path.?),
-            .show_startup_notice = state.show_startup_notice,
+            .show_inline_notice = state.show_inline_notice,
         } };
     }
     return if (state.failed) .failed else .inactive;
@@ -766,7 +766,7 @@ test "startup policy resolves recording environment without effects" {
         explicit_path: ?[]const u8 = null,
         record_stdin: bool = false,
         strict_start: bool = false,
-        show_startup_notice: bool = false,
+        show_inline_notice: bool = false,
     }{
         .{
             .input = .{},
@@ -776,7 +776,7 @@ test "startup policy resolves recording environment without effects" {
             .input = .{ .debug_record = "1" },
             .destination = .automatic,
             .strict_start = true,
-            .show_startup_notice = true,
+            .show_inline_notice = true,
         },
         .{
             .input = .{ .debug_record = "0", .record_input = "1" },
@@ -801,7 +801,7 @@ test "startup policy resolves recording environment without effects" {
             .destination = .explicit,
             .explicit_path = "/tmp/explicit.fxtape",
             .strict_start = true,
-            .show_startup_notice = true,
+            .show_inline_notice = true,
         },
         .{
             .input = .{
@@ -810,7 +810,7 @@ test "startup policy resolves recording environment without effects" {
             },
             .destination = .explicit,
             .explicit_path = "/tmp/input-yes.fxtape",
-            .show_startup_notice = true,
+            .show_inline_notice = true,
         },
     };
 
@@ -818,7 +818,7 @@ test "startup policy resolves recording environment without effects" {
         const policy = resolve_startup_policy(case.input);
         try testing.expectEqual(case.record_stdin, policy.record_stdin);
         try testing.expectEqual(case.strict_start, policy.strict_start);
-        try testing.expectEqual(case.show_startup_notice, policy.show_startup_notice);
+        try testing.expectEqual(case.show_inline_notice, policy.show_inline_notice);
         switch (policy.destination) {
             .inactive => try testing.expectEqual(ExpectedDestination.inactive, case.destination),
             .automatic => try testing.expectEqual(ExpectedDestination.automatic, case.destination),

--- a/src/core/workspace/record_tape.zig
+++ b/src/core/workspace/record_tape.zig
@@ -23,6 +23,7 @@ const State = struct {
     enabled: bool = false,
     failed: bool = false,
     record_stdin: bool = false,
+    show_startup_notice: bool = false,
     file: ?std.Io.File = null,
     path: ?[]u8 = null,
     path_alloc: ?Allocator = null,
@@ -33,18 +34,82 @@ const State = struct {
 var state_mutex: std.Io.Mutex = .init;
 var state: State = .{};
 
+const StartupDestination = union(enum) {
+    inactive,
+    automatic,
+    explicit: []const u8,
+};
+
+const StartupPolicyInput = struct {
+    debug_record: ?[]const u8 = null,
+    configured_path: ?[]const u8 = null,
+    record_input: ?[]const u8 = null,
+    silent_banner: ?[]const u8 = null,
+};
+
+const StartupPolicy = struct {
+    destination: StartupDestination,
+    record_stdin: bool,
+    strict_start: bool,
+    show_startup_notice: bool,
+};
+
+fn debug_env_truthy(raw: ?[]const u8) bool {
+    const value = raw orelse return false;
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.ascii.eqlIgnoreCase(trimmed, "1") or
+        std.ascii.eqlIgnoreCase(trimmed, "true") or
+        std.ascii.eqlIgnoreCase(trimmed, "yes") or
+        std.ascii.eqlIgnoreCase(trimmed, "on");
+}
+
+fn record_input_enabled(raw: ?[]const u8) bool {
+    const value = raw orelse return false;
+    const trimmed = std.mem.trim(u8, value, " \t\r\n");
+    return std.ascii.eqlIgnoreCase(trimmed, "1") or
+        std.ascii.eqlIgnoreCase(trimmed, "true") or
+        std.ascii.eqlIgnoreCase(trimmed, "on");
+}
+
+fn resolve_startup_policy(input: StartupPolicyInput) StartupPolicy {
+    const configured_path = if (input.configured_path) |path|
+        std.mem.trim(u8, path, " \t\r\n")
+    else
+        "";
+    const debug_record = debug_env_truthy(input.debug_record);
+    const destination: StartupDestination = if (configured_path.len > 0)
+        .{ .explicit = configured_path }
+    else if (debug_record)
+        .automatic
+    else
+        .inactive;
+    const active = switch (destination) {
+        .inactive => false,
+        .automatic, .explicit => true,
+    };
+    return .{
+        .destination = destination,
+        .record_stdin = active and record_input_enabled(input.record_input),
+        .strict_start = debug_record,
+        .show_startup_notice = active and !debug_env_truthy(input.silent_banner),
+    };
+}
+
 fn nowMs() i64 {
     return io_mod.milliTimestamp();
 }
 
 pub const CaptureStatus = union(enum) {
     inactive,
-    active: []u8,
+    active: struct {
+        path: []u8,
+        show_startup_notice: bool,
+    },
     failed,
 
     pub fn deinit(self: *CaptureStatus, alloc: Allocator) void {
         switch (self.*) {
-            .active => |path| alloc.free(path),
+            .active => |active| alloc.free(active.path),
             .inactive, .failed => {},
         }
         self.* = undefined;
@@ -53,40 +118,45 @@ pub const CaptureStatus = union(enum) {
 
 pub fn configureFromEnv(
     alloc: Allocator,
-    workspace_root: []const u8,
     initial_cols: u16,
     initial_rows: u16,
     fx_version: []const u8,
-    record_requested: bool,
 ) !void {
-    _ = workspace_root;
-
-    const configured_path = if (io_mod.getenv("FX_RECORD")) |raw_path|
-        std.mem.trim(u8, raw_path, " \t\r\n")
-    else
-        "";
-    if (configured_path.len > 0) {
-        configure(alloc, configured_path, initial_cols, initial_rows, fx_version) catch |err| {
-            if (record_requested) return err;
+    const policy = resolve_startup_policy(.{
+        .debug_record = io_mod.getenv("FX_DEBUG_RECORD"),
+        .configured_path = io_mod.getenv("FX_RECORD"),
+        .record_input = io_mod.getenv("FX_RECORD_INPUT"),
+        .silent_banner = io_mod.getenv("FX_DEBUG_RECORD_SILENT_BANNER"),
+    });
+    switch (policy.destination) {
+        .inactive => return,
+        .automatic => try configureAutomatic(
+            alloc,
+            initial_cols,
+            initial_rows,
+            fx_version,
+            policy.show_startup_notice,
+        ),
+        .explicit => |path| configureWithOptions(
+            alloc,
+            path,
+            initial_cols,
+            initial_rows,
+            fx_version,
+            false,
+            false,
+            policy.show_startup_notice,
+        ) catch |err| {
+            if (policy.strict_start) return err;
             return;
-        };
-    } else if (record_requested) {
-        try configureAutomatic(alloc, initial_cols, initial_rows, fx_version);
-    } else {
-        return;
+        },
     }
 
-    if (io_mod.getenv("FX_RECORD_INPUT")) |raw_value| {
-        const value = std.mem.trim(u8, raw_value, " \t\r\n");
-        if (std.ascii.eqlIgnoreCase(value, "1") or
-            std.ascii.eqlIgnoreCase(value, "true") or
-            std.ascii.eqlIgnoreCase(value, "on"))
-        {
-            const zio = io_mod.getIo();
-            state_mutex.lockUncancelable(zio);
-            defer state_mutex.unlock(zio);
-            state.record_stdin = true;
-        }
+    if (policy.record_stdin) {
+        const zio = io_mod.getIo();
+        state_mutex.lockUncancelable(zio);
+        defer state_mutex.unlock(zio);
+        state.record_stdin = true;
     }
 }
 
@@ -97,7 +167,7 @@ pub fn configure(
     initial_rows: u16,
     fx_version: []const u8,
 ) !void {
-    try configureWithOptions(alloc, path, initial_cols, initial_rows, fx_version, false, false);
+    try configureWithOptions(alloc, path, initial_cols, initial_rows, fx_version, false, false, true);
 }
 
 fn configureAutomatic(
@@ -105,6 +175,7 @@ fn configureAutomatic(
     initial_cols: u16,
     initial_rows: u16,
     fx_version: []const u8,
+    show_startup_notice: bool,
 ) !void {
     const home = if (io_mod.getenv("HOME")) |value| blk: {
         const trimmed = std.mem.trim(u8, value, " \t\r\n");
@@ -125,7 +196,7 @@ fn configureAutomatic(
         const path = try std.fmt.allocPrint(alloc, "{s}/fx-record-{d}-{s}.fxtape", .{ root, nowMs(), random_hex });
         defer alloc.free(path);
 
-        configureWithOptions(alloc, path, initial_cols, initial_rows, fx_version, true, true) catch |err| switch (err) {
+        configureWithOptions(alloc, path, initial_cols, initial_rows, fx_version, true, true, show_startup_notice) catch |err| switch (err) {
             error.PathAlreadyExists => continue,
             else => return err,
         };
@@ -142,6 +213,7 @@ fn configureWithOptions(
     fx_version: []const u8,
     exclusive: bool,
     private: bool,
+    show_startup_notice: bool,
 ) !void {
     const zio = io_mod.getIo();
     state_mutex.lockUncancelable(zio);
@@ -166,6 +238,7 @@ fn configureWithOptions(
     const now = nowMs();
     state = .{
         .enabled = true,
+        .show_startup_notice = show_startup_notice,
         .file = file,
         .path = owned_path,
         .path_alloc = alloc,
@@ -300,7 +373,10 @@ pub fn captureStatus(alloc: Allocator) !CaptureStatus {
     defer state_mutex.unlock(zio);
 
     if (state.enabled and state.path != null) {
-        return .{ .active = try alloc.dupe(u8, state.path.?) };
+        return .{ .active = .{
+            .path = try alloc.dupe(u8, state.path.?),
+            .show_startup_notice = state.show_startup_notice,
+        } };
     }
     return if (state.failed) .failed else .inactive;
 }
@@ -643,7 +719,7 @@ test "recordStdin suppresses input by default" {
     try expectNoFrame(bytes);
 }
 
-test "requested recording creates a private tape under home" {
+test "debug recording request creates a private tape under home" {
     const alloc = testing.allocator;
     resetEnvForTest();
     defer resetEnvForTest();
@@ -657,20 +733,21 @@ test "requested recording creates a private tape under home" {
     var env = std.process.Environ.Map.init(alloc);
     defer env.deinit();
     try env.put("HOME", home);
+    try env.put("FX_DEBUG_RECORD", "1");
 
     shutdown();
     defer shutdown();
     io_mod.setEnvironMap(&env);
-    try configureFromEnv(alloc, "/ignored/workspace", 80, 24, "vtest", true);
+    try configureFromEnv(alloc, 80, 24, "vtest");
 
     var status = try captureStatus(alloc);
     defer status.deinit(alloc);
     switch (status) {
-        .active => |path| {
+        .active => |active| {
             const expected_dir = try profile_paths.recordingsDir(alloc, home);
             defer alloc.free(expected_dir);
-            try testing.expect(std.mem.startsWith(u8, path, expected_dir));
-            const file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), path, .{});
+            try testing.expect(std.mem.startsWith(u8, active.path, expected_dir));
+            const file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), active.path, .{});
             defer file.close(io_mod.getIo());
             if (@import("builtin").os.tag != .windows) {
                 const stat = try file.stat(io_mod.getIo());
@@ -681,7 +758,79 @@ test "requested recording creates a private tape under home" {
     }
 }
 
-test "requested recording uses the temporary fallback when HOME is empty" {
+test "startup policy resolves recording environment without effects" {
+    const ExpectedDestination = enum { inactive, automatic, explicit };
+    const cases = [_]struct {
+        input: StartupPolicyInput,
+        destination: ExpectedDestination,
+        explicit_path: ?[]const u8 = null,
+        record_stdin: bool = false,
+        strict_start: bool = false,
+        show_startup_notice: bool = false,
+    }{
+        .{
+            .input = .{},
+            .destination = .inactive,
+        },
+        .{
+            .input = .{ .debug_record = "1" },
+            .destination = .automatic,
+            .strict_start = true,
+            .show_startup_notice = true,
+        },
+        .{
+            .input = .{ .debug_record = "0", .record_input = "1" },
+            .destination = .inactive,
+        },
+        .{
+            .input = .{
+                .configured_path = " /tmp/recording.fxtape ",
+                .record_input = "true",
+                .silent_banner = "yes",
+            },
+            .destination = .explicit,
+            .explicit_path = "/tmp/recording.fxtape",
+            .record_stdin = true,
+        },
+        .{
+            .input = .{
+                .debug_record = "ON",
+                .configured_path = "/tmp/explicit.fxtape",
+                .silent_banner = "false",
+            },
+            .destination = .explicit,
+            .explicit_path = "/tmp/explicit.fxtape",
+            .strict_start = true,
+            .show_startup_notice = true,
+        },
+        .{
+            .input = .{
+                .configured_path = "/tmp/input-yes.fxtape",
+                .record_input = "yes",
+            },
+            .destination = .explicit,
+            .explicit_path = "/tmp/input-yes.fxtape",
+            .show_startup_notice = true,
+        },
+    };
+
+    for (cases) |case| {
+        const policy = resolve_startup_policy(case.input);
+        try testing.expectEqual(case.record_stdin, policy.record_stdin);
+        try testing.expectEqual(case.strict_start, policy.strict_start);
+        try testing.expectEqual(case.show_startup_notice, policy.show_startup_notice);
+        switch (policy.destination) {
+            .inactive => try testing.expectEqual(ExpectedDestination.inactive, case.destination),
+            .automatic => try testing.expectEqual(ExpectedDestination.automatic, case.destination),
+            .explicit => |path| {
+                try testing.expectEqual(ExpectedDestination.explicit, case.destination);
+                try testing.expectEqualStrings(case.explicit_path.?, path);
+            },
+        }
+    }
+}
+
+test "debug recording request uses the temporary fallback when HOME is empty" {
     const alloc = testing.allocator;
     resetEnvForTest();
     defer resetEnvForTest();
@@ -689,22 +838,23 @@ test "requested recording uses the temporary fallback when HOME is empty" {
     var env = std.process.Environ.Map.init(alloc);
     defer env.deinit();
     try env.put("HOME", "");
+    try env.put("FX_DEBUG_RECORD", "1");
 
     shutdown();
     defer shutdown();
     io_mod.setEnvironMap(&env);
-    try configureFromEnv(alloc, "/ignored/workspace", 80, 24, "vtest", true);
+    try configureFromEnv(alloc, 80, 24, "vtest");
 
     var status = try captureStatus(alloc);
     defer status.deinit(alloc);
     switch (status) {
-        .active => |path| {
-            try testing.expect(std.mem.startsWith(u8, path, "/tmp/fx-recordings/"));
+        .active => |active| {
+            try testing.expect(std.mem.startsWith(u8, active.path, "/tmp/fx-recordings/"));
             shutdown();
-            if (std.fs.path.isAbsolute(path)) {
-                std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), path) catch {};
+            if (std.fs.path.isAbsolute(active.path)) {
+                std.Io.Dir.deleteFileAbsolute(io_mod.getIo(), active.path) catch {};
             } else {
-                std.Io.Dir.cwd().deleteFile(io_mod.getIo(), path) catch {};
+                std.Io.Dir.cwd().deleteFile(io_mod.getIo(), active.path) catch {};
             }
         },
         else => return error.TestExpectedActiveRecording,
@@ -734,7 +884,7 @@ test "configureFromEnv enables stdin for the accepted truthy values only" {
         shutdown();
         io_mod.setEnvironMap(&env);
         defer resetEnvForTest();
-        try configureFromEnv(alloc, "/ignored/workspace", 80, 24, "v", false);
+        try configureFromEnv(alloc, 80, 24, "v");
         recordStdin("typed");
         shutdown();
 
@@ -758,7 +908,7 @@ test "configureFromEnv enables stdin for the accepted truthy values only" {
 
     shutdown();
     io_mod.setEnvironMap(&env);
-    try configureFromEnv(alloc, "/ignored/workspace", 80, 24, "v", false);
+    try configureFromEnv(alloc, 80, 24, "v");
     recordStdin("typed");
     shutdown();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -649,7 +649,6 @@ const App = struct {
             builtin_gateway.default_model,
             default_max_agent_steps,
             handle_sigwinch,
-            launch.record_requested,
             .{
                 .load_mcp_runtime = if (comptime host_target.is_wasm) loadNoMcpRuntime else builtin_mcp.loadRuntime,
                 .skill_root_policy = if (comptime host_target.is_wasm) wasm_skill_root_policy else builtin_skills.root_policy,
@@ -3241,10 +3240,6 @@ fn mainC(c_argc: c_int, c_argv: [*][*:0]c_char, c_envp: [*:null]?[*:0]c_char) !v
         try command_runner.runForegroundSessionBootstrap(cli_args);
         return;
     }
-    _ = cli_surface.recordRequested(cli_args) catch {
-        try writeStderrFast(cli_surface.record_modifier_usage);
-        exitFast(1);
-    };
     if (cli_args.len > 0 and isTopLevelHelp(cli_args)) {
         try writeTopLevelHelpFast(raw_env);
         exitFast(0);

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -434,17 +434,28 @@ With --prompt-permissions, JSON and quiet requests may prompt on stderr only whe
 
   for (const alias of ["help", "--help", "-h"]) {
     test(
-      `fx ${alias} --record rejects the interactive-only modifier`,
+      `fx ${alias} hides developer recording surfaces`,
       async () => {
-        const r = await runFx([alias, "--record"]);
-        expect(r.code).not.toBe(0);
-        expect(r.stderr).toContain(
-          "usage: fx --record is only supported for interactive startup",
-        );
+        const r = await runFx([alias]);
+        expect(r.code).toBe(0);
+        expect(r.stdout).not.toContain("--record");
+        expect(r.stdout).not.toContain("replay <tape>");
+        expect(r.stderr).toBe("");
       },
       TIMEOUT,
     );
   }
+
+  test(
+    "fx rejects the removed record flag as unknown input",
+    async () => {
+      const r = await runFx(["--record"]);
+      expect(r.code).not.toBe(0);
+      expect(r.stderr).toContain("fx: unknown subcommand: --record");
+      expect(r.stderr).not.toContain("visual terminal capture:");
+    },
+    TIMEOUT,
+  );
 });
 
 describe("cli: version", () => {

--- a/tests/e2e/tui-permissions.test.ts
+++ b/tests/e2e/tui-permissions.test.ts
@@ -1336,9 +1336,9 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
       const stderrPath = join(root.root, "stderr.log");
       writeFileSync(stderrPath, "");
       activeSession = await TmuxSession.create({
-        cmd: `${FX_BIN} --record`,
+        cmd: FX_BIN,
         cwd: root.workspace,
-        env: gatewayEnv(root, gateway),
+        env: { ...gatewayEnv(root, gateway), FX_DEBUG_RECORD: "1" },
         stderrPath,
         width: 180,
         height: 40,

--- a/tests/e2e/tui-render-replay.test.ts
+++ b/tests/e2e/tui-render-replay.test.ts
@@ -457,7 +457,7 @@ describe("tui: render record/replay", () => {
   );
 
   test.skipIf(SKIP)(
-    "silent automatic recording omits its banner and remains replayable",
+    "silent automatic recording hides its banner inline but keeps it in Ctrl-O",
     async () => {
       const marker = "silent_automatic_recording_marker";
       const launched = await launchAutomaticRecording({ silentBanner: true });
@@ -467,6 +467,15 @@ describe("tui: render record/replay", () => {
         "visual terminal capture:",
       );
       expect(statSync(launched.tapePath).mode & 0o077).toBe(0);
+
+      await session.sendKeys("C-o");
+      await session.waitForText("Full detail · ctrl o close", 5_000);
+      await session.waitForText("visual terminal capture:", 5_000);
+      await session.sendKeys("C-o");
+      await session.waitForComposer(5_000);
+      expect(await session.captureFullScrollback()).not.toContain(
+        "visual terminal capture:",
+      );
 
       await session.sendText(marker);
       await session.waitForText("fx needs access to Vercel AI Gateway", 5_000);

--- a/tests/e2e/tui-render-replay.test.ts
+++ b/tests/e2e/tui-render-replay.test.ts
@@ -1,6 +1,15 @@
 import { execFileSync } from "node:child_process";
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN } from "../evals/eval-helpers";
@@ -84,7 +93,9 @@ function parseReplayJson(output: string): {
   return JSON.parse(output.trim());
 }
 
-async function launchAutomaticRecording(): Promise<{
+async function launchAutomaticRecording(options: {
+  silentBanner?: boolean;
+} = {}): Promise<{
   session: TmuxSession;
   tapePath: string;
   goldenPath: string;
@@ -103,23 +114,33 @@ async function launchAutomaticRecording(): Promise<{
   const goldenPath = join(workDir, "grid.txt");
   const tracePath = join(workDir, "trace.log");
   const s = await TmuxSession.create({
-    cmd: `env -u AI_GATEWAY_API_KEY -u VERCEL_OIDC_TOKEN FX_DISABLE_KEYCHAIN=1 FX_SKIP_ONBOARDING=1 ${FX_BIN} --record`,
+    cmd: `env -u AI_GATEWAY_API_KEY -u VERCEL_OIDC_TOKEN FX_DISABLE_KEYCHAIN=1 FX_SKIP_ONBOARDING=1 ${FX_BIN}`,
     cwd: workDir,
     width: 180,
     height: 36,
     env: {
       HOME: home,
+      FX_DEBUG_RECORD: "1",
+      ...(options.silentBanner
+        ? { FX_DEBUG_RECORD_SILENT_BANNER: "1" }
+        : {}),
       FX_TRACE_LOG: tracePath,
       FX_TRACE_SCOPES: TRACE_SCOPES,
     },
   });
   session = s;
-  await s.waitForText("visual terminal capture:", 10_000);
-  const grid = (await s.capturePaneGrid()).join("\n");
-  const tapePath = grid.match(/visual terminal capture:\s*(\S+\.fxtape)/)?.[1];
-  if (!tapePath) {
-    throw new Error(`recording path was not printed:\n${grid}`);
+  if (!options.silentBanner) {
+    await s.waitForText("visual terminal capture:", 10_000);
   }
+  await s.waitForComposer(10_000);
+  const recordingsDir = join(home, ".fx", "recordings");
+  const tapes = readdirSync(recordingsDir).filter((name) =>
+    name.endsWith(".fxtape")
+  );
+  if (tapes.length !== 1) {
+    throw new Error(`expected one automatic tape, found ${tapes.length}`);
+  }
+  const tapePath = join(recordingsDir, tapes[0]!);
   return { session: s, tapePath, goldenPath, tracePath, home };
 }
 
@@ -402,6 +423,10 @@ describe("tui: render record/replay", () => {
       session = launched.session;
 
       expect(launched.tapePath.startsWith(join(launched.home, ".fx", "recordings"))).toBe(true);
+      expect(statSync(launched.tapePath).mode & 0o077).toBe(0);
+      expect(await session.captureFullScrollback()).toContain(
+        "visual terminal capture:",
+      );
       await session.sendText(marker);
       await session.waitForText("fx needs access to Vercel AI Gateway", 5_000);
       await session.sendKeys(`-l '${inputTail}'`);
@@ -427,6 +452,36 @@ describe("tui: render record/replay", () => {
       session = null;
 
       expect(failures).toEqual([]);
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(SKIP)(
+    "silent automatic recording omits its banner and remains replayable",
+    async () => {
+      const marker = "silent_automatic_recording_marker";
+      const launched = await launchAutomaticRecording({ silentBanner: true });
+      session = launched.session;
+
+      expect(await session.captureFullScrollback()).not.toContain(
+        "visual terminal capture:",
+      );
+      expect(statSync(launched.tapePath).mode & 0o077).toBe(0);
+
+      await session.sendText(marker);
+      await session.waitForText("fx needs access to Vercel AI Gateway", 5_000);
+      execFileSync(FX_BIN, [
+        "replay",
+        launched.tapePath,
+        "--golden",
+        launched.goldenPath,
+      ]);
+      expect(readFileSync(launched.goldenPath, "utf8")).toContain(marker);
+
+      await session.sendKeys("C-u");
+      await session.sendText("/quit");
+      expect(await session.waitForSessionEnd(5_000)).toBe(true);
+      session = null;
     },
     TIMEOUT,
   );


### PR DESCRIPTION
## Summary

- Start automatic terminal recording with `FX_DEBUG_RECORD=1`.
- Let developers keep the recording notice out of the main transcript during screen shares while retaining it in Ctrl-O.
- Remove the `--record` startup flag from interactive and resume commands.
- Keep direct tape replay available while removing it from top-level help.
- Preserve exact-path and raw-input recording controls for tests and debugging.