### PR TITLE
Keep prompt history navigation on recalled slash commands

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -8561,6 +8561,38 @@ test "app_input_runtime ctrl+p and ctrl+n navigate prompt history directly" {
     try std.testing.expectEqualStrings("draft", app.input_runtime.edit_state.input.items);
 }
 
+test "app_input_runtime plain arrows keep history ownership across recalled slash commands" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    try app.input_runtime.composer_history.installTextEntries(alloc, &.{ "older", "/help" });
+
+    try input_completion_runtime.CompletionRuntime(RoutingFakeApp).navigatePromptHistory(&app, -1);
+    try std.testing.expectEqualStrings("/help", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(
+        @as(usize, 0),
+        input_completion_runtime.CompletionRuntime(RoutingFakeApp).visibleSlashCompletionCount(&app),
+    );
+
+    try feedRoutingBytes(&app, "\x1b[A");
+    try feedRoutingBytes(&app, "\x1b[A");
+    try std.testing.expectEqualStrings("older", app.input_runtime.edit_state.input.items);
+
+    try feedRoutingBytes(&app, "\x1b[B");
+    try std.testing.expectEqualStrings("/help", app.input_runtime.edit_state.input.items);
+    try feedRoutingBytes(&app, "\x7f");
+    try std.testing.expectEqualStrings("/hel", app.input_runtime.edit_state.input.items);
+    try std.testing.expect(
+        input_completion_runtime.CompletionRuntime(RoutingFakeApp).visibleSlashCompletionCount(&app) > 0,
+    );
+
+    app.input_runtime.inputResetState().clearCurrent(alloc);
+    try Runtime(RoutingFakeApp).handleByte(&app, '/', 4096, 100);
+    try std.testing.expect(
+        input_completion_runtime.CompletionRuntime(RoutingFakeApp).visibleSlashCompletionCount(&app) > 0,
+    );
+}
+
 test "app_input_runtime decoded history recall disarms pending Ctrl-C exit" {
     const alloc = std.testing.allocator;
     var app = try RoutingFakeApp.init(alloc);

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -87,7 +87,7 @@ pub fn CompletionRuntime(comptime App: type) type {
         }
 
         fn slashCompletionQueryActive(app: *App) bool {
-            if (app.input_runtime.picker.isInlinePickerDismissed(.slash)) return false;
+            if (app.input_runtime.picker.isInlinePickerSuppressed(.slash)) return false;
             if (app.input_runtime.picker.inlinePickerTriggerKind(&app.input_runtime.edit_state) != .slash) return false;
             // Model query always owns this slot. Mid-turn bare `/model` does too
             // (list stays hidden); idle bare `/model` still surfaces slash rows.

--- a/src/core/input/composer_history.zig
+++ b/src/core/input/composer_history.zig
@@ -535,6 +535,11 @@ pub const State = struct {
         }
 
         replaceActiveComposer(alloc, active, &prepared);
+        if (restoring_draft) {
+            active.picker.resetInlinePickerEpisode();
+        } else {
+            active.picker.resetInlinePickerForHistoryRecall(active.edit);
+        }
         if (active.images) |images| {
             if (entering_history) {
                 for (images.items) |image| types.freeImageAttachment(alloc, image);
@@ -596,7 +601,6 @@ fn replaceActiveComposer(
     );
     previous_text.deinit(alloc);
 
-    active.picker.resetInlinePickerEpisode();
     active.picker.model_completion_index = 0;
     active.picker.model_completion_window_start = 0;
     active.picker.resetFilePickerIndex();
@@ -669,6 +673,50 @@ test "navigation recalls entries and restores the unsent draft" {
     try std.testing.expectEqualStrings("unsent draft", edit.input.items);
     try std.testing.expect(state.draftText() == null);
     try std.testing.expectEqual(@as(?usize, null), state.activeIndex());
+}
+
+test "history recall suppresses slash queries until edit and restores draft eligibility" {
+    const alloc = std.testing.allocator;
+    var state: State = .{};
+    defer state.deinit(alloc);
+    try state.installTextEntries(alloc, &.{"/hel"});
+
+    var edit: editor_state.State = .{};
+    defer edit.deinit(alloc);
+    try edit.setText(alloc, "/he");
+    var entities: registered_entities.State = .{};
+    defer entities.deinit(alloc);
+    var picker: picker_state.State = .{};
+    defer picker.deinit(alloc);
+    var vertical_intent: vertical_navigation.State = .{};
+    var limit_rejection: input_limit_rejection.State = .{};
+    const active = ActiveComposer{
+        .edit = &edit,
+        .entities = &entities,
+        .picker = &picker,
+        .vertical_navigation = &vertical_intent,
+        .input_limit_rejection = &limit_rejection,
+        .images = null,
+    };
+
+    try std.testing.expectEqual(
+        NavigationResult{ .moved = 0 },
+        try state.navigate(alloc, -1, active, 1, 4096),
+    );
+    try std.testing.expectEqualStrings("/hel", edit.input.items);
+    try std.testing.expect(picker.isInlinePickerSuppressed(.slash));
+    try std.testing.expect(!picker.isInlinePickerDismissed(.slash));
+
+    try edit.setText(alloc, "/he");
+    picker.reconcileInlinePickerAfterEdit(&edit);
+    try std.testing.expect(!picker.isInlinePickerSuppressed(.slash));
+
+    try std.testing.expectEqual(
+        NavigationResult{ .moved = 0 },
+        try state.navigate(alloc, 1, active, 1, 4096),
+    );
+    try std.testing.expectEqualStrings("/he", edit.input.items);
+    try std.testing.expect(!picker.isInlinePickerSuppressed(.slash));
 }
 
 test "oversized recall leaves active composer and history position unchanged" {

--- a/src/core/input/picker_state.zig
+++ b/src/core/input/picker_state.zig
@@ -17,6 +17,18 @@ pub const InlinePickerKind = enum {
     skill,
 };
 
+const InlinePickerSuppression = union(enum) {
+    dismissed_until_trigger_change: InlinePickerKind,
+    history_slash_recall_until_edit,
+
+    fn kind(self: InlinePickerSuppression) InlinePickerKind {
+        return switch (self) {
+            .dismissed_until_trigger_change => |suppressed_kind| suppressed_kind,
+            .history_slash_recall_until_edit => .slash,
+        };
+    }
+};
+
 pub const model_picker_fast_options = [_][]const u8{ "normal", "fast" };
 
 pub const ModelPickerQuery = struct {
@@ -55,7 +67,7 @@ pub const InlineSlashQuery = struct {
 pub const State = struct {
     slash_completion_index: usize = 0,
     slash_completion_window_start: usize = 0,
-    dismissed_inline_picker: ?InlinePickerKind = null,
+    inline_picker_suppression: ?InlinePickerSuppression = null,
     model_completion_index: usize = 0,
     model_completion_window_start: usize = 0,
     model_completion_anchor_current: bool = false,
@@ -77,22 +89,40 @@ pub const State = struct {
     pub fn resetInlinePickerEpisode(self: *State) void {
         self.slash_completion_index = 0;
         self.slash_completion_window_start = 0;
-        self.dismissed_inline_picker = null;
+        self.inline_picker_suppression = null;
+    }
+
+    pub fn resetInlinePickerForHistoryRecall(self: *State, editor: *const editor_state.State) void {
+        self.resetInlinePickerEpisode();
+        self.inline_picker_suppression = suppressionForHistoryRecall(
+            self.inlinePickerTriggerKind(editor),
+        );
     }
 
     pub fn dismissInlinePicker(self: *State, kind: InlinePickerKind) void {
-        self.dismissed_inline_picker = kind;
+        self.inline_picker_suppression = .{ .dismissed_until_trigger_change = kind };
     }
 
     pub fn isInlinePickerDismissed(self: *const State, kind: InlinePickerKind) bool {
-        return self.dismissed_inline_picker == kind;
+        const suppression = self.inline_picker_suppression orelse return false;
+        return switch (suppression) {
+            .dismissed_until_trigger_change => |dismissed| dismissed == kind,
+            .history_slash_recall_until_edit => false,
+        };
+    }
+
+    pub fn isInlinePickerSuppressed(self: *const State, kind: InlinePickerKind) bool {
+        const suppression = self.inline_picker_suppression orelse return false;
+        return suppression.kind() == kind;
     }
 
     pub fn reconcileInlinePickerAfterEdit(self: *State, editor: *const editor_state.State) void {
         self.slash_completion_index = 0;
         self.slash_completion_window_start = 0;
-        const dismissed = self.dismissed_inline_picker orelse return;
-        if (self.inlinePickerTriggerKind(editor) != dismissed) self.dismissed_inline_picker = null;
+        self.inline_picker_suppression = suppressionAfterEdit(
+            self.inline_picker_suppression,
+            self.inlinePickerTriggerKind(editor),
+        );
     }
 
     pub fn resetFilePickerIndex(self: *State) void {
@@ -101,22 +131,22 @@ pub const State = struct {
     }
 
     pub fn activeFilePickerQuery(self: *const State, editor: *const editor_state.State) ?FilePickerQuery {
-        if (self.isInlinePickerDismissed(.file)) return null;
+        if (self.isInlinePickerSuppressed(.file)) return null;
         return self.rawFilePickerQuery(editor);
     }
 
     pub fn activeModelPickerQuery(self: *const State, editor: *const editor_state.State) ?ModelPickerQuery {
-        if (self.isInlinePickerDismissed(.model)) return null;
+        if (self.isInlinePickerSuppressed(.model)) return null;
         return self.rawModelPickerQuery(editor);
     }
 
     pub fn activeInlineSkillQuery(self: *const State, editor: *const editor_state.State) ?InlineSkillQuery {
-        if (self.isInlinePickerDismissed(.skill)) return null;
+        if (self.isInlinePickerSuppressed(.skill)) return null;
         return findInlineSkillQuery(editor.input.items, editor.cursor);
     }
 
     pub fn activeInlineSlashQuery(self: *const State, editor: *const editor_state.State) ?InlineSlashQuery {
-        if (self.isInlinePickerDismissed(.slash)) return null;
+        if (self.isInlinePickerSuppressed(.slash)) return null;
         return findInlineSlashQuery(editor.input.items, editor.cursor);
     }
 
@@ -234,6 +264,25 @@ pub const State = struct {
         return self.model_picker_fast_index % model_picker_fast_options.len == 1;
     }
 };
+
+fn suppressionForHistoryRecall(trigger: ?InlinePickerKind) ?InlinePickerSuppression {
+    if (trigger != .slash) return null;
+    return .history_slash_recall_until_edit;
+}
+
+fn suppressionAfterEdit(
+    current: ?InlinePickerSuppression,
+    trigger: ?InlinePickerKind,
+) ?InlinePickerSuppression {
+    const suppression = current orelse return null;
+    return switch (suppression) {
+        .dismissed_until_trigger_change => |dismissed| if (trigger == dismissed)
+            suppression
+        else
+            null,
+        .history_slash_recall_until_edit => null,
+    };
+}
 
 pub fn isBareModelCommandAtCursor(editor: *const editor_state.State) bool {
     if (editor.cursor != editor.input.items.len) return false;

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -244,7 +244,7 @@ pub fn cappedInputRows(total_rows: usize, content_bottom: u16, input_visible: bo
 }
 
 pub fn slashCompletionPickerPrefix(ctx: RenderContext, modal_active: bool, show_model_query: bool, show_file_query: bool) ?[]const u8 {
-    if (ctx.input.picker.isInlinePickerDismissed(.slash) or modal_active or show_model_query or show_file_query) return null;
+    if (ctx.input.picker.isInlinePickerSuppressed(.slash) or modal_active or show_model_query or show_file_query) return null;
     if (ctx.input.picker.inlinePickerTriggerKind(&ctx.input.edit_state) != .slash) return null;
     // Mid-turn model-shaped input owns the footer slot even while the model list is hidden.
     if (ctx.stream.active and ctx.input.picker.isModelShapedInput(&ctx.input.edit_state)) return null;

--- a/src/ui/input/runtime.zig
+++ b/src/ui/input/runtime.zig
@@ -3331,7 +3331,7 @@ test "inline picker dismissal follows the active trigger kind" {
 
     runtime.inputResetState().clearCurrent(alloc);
     try runtime.insertionState().insertSlice(alloc, "/", .preserve);
-    try std.testing.expect(runtime.picker.dismissed_inline_picker == null);
+    try std.testing.expect(runtime.picker.inline_picker_suppression == null);
 }
 
 test "registered paste skill and image spans are atomic editor boundaries" {

--- a/tests/e2e/prompt-history.test.ts
+++ b/tests/e2e/prompt-history.test.ts
@@ -46,6 +46,12 @@ function currentComposerLine(pane: string): string {
   return pane.split("\n").filter(isComposerLine).at(-1) ?? "";
 }
 
+function slashMenuRows(pane: string): string[] {
+  return pane.split("\n").filter((line) =>
+    !isComposerLine(line) && line.trimStart().startsWith("/")
+  );
+}
+
 async function disablePromptHistory(
   session: TmuxSession,
   settingsPath: string,
@@ -129,26 +135,55 @@ describe.skipIf(!tmuxAvailable())("prompt history", () => {
           env: rejectedGatewayEnv(home, gateway),
         });
         await session.waitForText("Run /help", TIMEOUT);
+
+        await session.sendLiteral("/");
+        await session.waitForPane((current) => slashMenuRows(current).length > 0, TIMEOUT);
+        await session.sendKeys("C-u");
+        await session.waitForPane(hasEmptyComposer, TIMEOUT);
+
         await session.sendKeys("Up");
         let pane = await session.waitForPane(
           (current) => currentComposerLine(current).includes("/quit"),
           TIMEOUT,
         );
         expect(currentComposerLine(pane)).toContain("/quit");
+        expect(slashMenuRows(pane)).toEqual([]);
 
-        await session.sendKeys("C-p");
+        await session.sendKeys("Up");
+        await session.sendKeys("Up");
         pane = await session.waitForPane(
           (current) => currentComposerLine(current).includes("/help"),
           TIMEOUT,
         );
         expect(currentComposerLine(pane)).toContain("/help");
+        expect(slashMenuRows(pane)).toEqual([]);
 
-        await session.sendKeys("C-p");
+        await session.sendKeys("Up");
+        await session.sendKeys("Up");
         pane = await session.waitForPane(
           (current) => currentComposerLine(current).includes("PLAN10_PROMPT_HISTORY_SENTINEL"),
           TIMEOUT,
         );
         expect(currentComposerLine(pane)).toContain("PLAN10_PROMPT_HISTORY_SENTINEL");
+
+        await session.sendKeys("Down");
+        pane = await session.waitForPane(
+          (current) => currentComposerLine(current).includes("/help"),
+          TIMEOUT,
+        );
+        expect(slashMenuRows(pane)).toEqual([]);
+
+        await session.sendKeys("BSpace");
+        pane = await session.waitForPane(
+          (current) =>
+            currentComposerLine(current).includes("/hel") &&
+            slashMenuRows(current).length > 0,
+          TIMEOUT,
+        );
+        expect(currentComposerLine(pane)).toContain("/hel");
+        await session.sendKeys("C-u");
+        await session.waitForPane(hasEmptyComposer, TIMEOUT);
+        expect(session.isAlive()).toBe(true);
       } finally {
         rmSync(root, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

- Keep Up and Down browsing prompt history when a recalled entry is a slash command.
- Hide slash completions for recalled commands until the composer is edited.
- Preserve slash completion behavior for directly typed input.