### PR TITLE
Report direct web searches in traces

### DIFF
--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -1101,8 +1101,6 @@ pub fn providerToolsJson(alloc: Allocator, input: ProviderToolInput) ![]u8 {
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
     if (input.backend.eql(exa_search_backend_id)) {
-        const result_count = @max(@as(usize, input.max_results), 1);
-        const max_characters = @max(input.max_output_chars / result_count, 1);
         try out.writer.print(
             "[{{\"type\":\"provider\",\"id\":\"gateway.exa_search\",\"name\":\"exa_search\",\"args\":{{\"numResults\":{d}",
             .{input.max_results},
@@ -1112,8 +1110,7 @@ pub fn providerToolsJson(alloc: Allocator, input: ProviderToolInput) ![]u8 {
         } else if (hasValues(input.blocked_domains)) {
             try writeExaDomains(&out.writer, "excludeDomains", input.blocked_domains.?);
         }
-        try out.writer.print(",\"contents\":{{\"highlights\":{{\"maxCharacters\":{d}", .{max_characters});
-        try out.writer.writeAll("}}}}]");
+        try out.writer.writeAll(",\"contents\":{\"highlights\":true}}}]");
     } else if (input.backend.eql(perplexity_search_backend_id)) {
         try out.writer.print(
             "[{{\"type\":\"provider\",\"id\":\"gateway.perplexity_search\",\"name\":\"perplexity_search\",\"args\":{{\"maxResults\":{d},\"maxTokens\":{d}",
@@ -1425,7 +1422,7 @@ test "built-in search rejects an unknown provider-owned backend identity" {
     }));
 }
 
-test "private exa worker advertises bounded results with allowed domains" {
+test "private exa worker requests concise highlights with allowed domains" {
     const alloc = std.testing.allocator;
     const allowed_domains = [_][]const u8{"ziglang.org"};
     const tools_json = try providerToolsJson(alloc, .{
@@ -1440,7 +1437,8 @@ test "private exa worker advertises bounded results with allowed domains" {
     try std.testing.expect(std.mem.find(u8, tools_json, "\"name\":\"exa_search\"") != null);
     try std.testing.expect(std.mem.find(u8, tools_json, "\"numResults\":7") != null);
     try std.testing.expect(std.mem.find(u8, tools_json, "\"includeDomains\":[\"ziglang.org\"]") != null);
-    try std.testing.expect(std.mem.find(u8, tools_json, "\"maxCharacters\":585") != null);
+    try std.testing.expect(std.mem.find(u8, tools_json, "\"contents\":{\"highlights\":true}") != null);
+    try std.testing.expect(std.mem.find(u8, tools_json, "maxCharacters") == null);
 }
 
 test "private exa worker preserves blocked domains" {
@@ -1455,7 +1453,7 @@ test "private exa worker preserves blocked domains" {
     defer alloc.free(tools_json);
 
     try std.testing.expect(std.mem.find(u8, tools_json, "\"excludeDomains\":[\"example.com\"]") != null);
-    try std.testing.expect(std.mem.find(u8, tools_json, "\"maxCharacters\":1200") != null);
+    try std.testing.expect(std.mem.find(u8, tools_json, "\"contents\":{\"highlights\":true}") != null);
 }
 
 test "private perplexity worker advertises only selected gateway provider search tool" {

--- a/src/builtins/tools.zig
+++ b/src/builtins/tools.zig
@@ -2224,7 +2224,7 @@ test "built-in web_search owns its Gateway provider advertisement" {
     defer std.testing.allocator.free(json);
 
     try std.testing.expectEqualStrings(
-        "{\"type\":\"provider\",\"id\":\"gateway.exa_search\",\"name\":\"exa_search\",\"args\":{\"numResults\":10,\"contents\":{\"highlights\":{\"maxCharacters\":10000}}}}",
+        "{\"type\":\"provider\",\"id\":\"gateway.exa_search\",\"name\":\"exa_search\",\"args\":{\"numResults\":10,\"contents\":{\"highlights\":true}}}",
         json,
     );
 }

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1376,6 +1376,16 @@ fn providerExecutedResult(call: ToolCall) ?ToolExecutionResult {
     };
 }
 
+fn reportProviderExecutedUsage(
+    deps: *const AgentRuntimeDeps,
+    calls: []const ToolCall,
+) void {
+    for (calls) |call| {
+        const execution = providerExecutedResult(call) orelse continue;
+        runtime_parallel_execution.reportInnerToolUsage(deps, call.name, execution);
+    }
+}
+
 test "provider executed result reports one observed request only for search aliases" {
     const aliases = [_][]const u8{
         "exa_search",
@@ -1434,7 +1444,6 @@ fn appendProviderExecutedToolResult(
     const provider_status = runtime_execution_memory.classifyProviderExecutedResultStatus(
         provider_result,
     );
-    runtime_parallel_execution.reportInnerToolUsage(deps, call.name, execution);
     const prepared = try runtime_execution_memory.prepareToolModelOutput(
         arena,
         config,
@@ -1548,6 +1557,7 @@ fn materializeConfirmedProviderTools(
         completion.provider_state_json,
     );
     var batch: runtime_tool_batch.StepBatchState = .{};
+    reportProviderExecutedUsage(deps, novel_calls);
     for (novel_calls) |call| {
         try appendProviderExecutedToolResult(
             deps,
@@ -4934,7 +4944,7 @@ fn processQueuedPromptLoop(
         if (disposition == .completed and completion.tool_calls.len > 0) {
             const admission = types.authoritativeToolAdmission(completion);
             switch (admission) {
-                .admitted => {},
+                .admitted => reportProviderExecutedUsage(deps, completion.tool_calls),
                 .reject_duplicate_identity => {
                     try stream_ctx.provisional_statuses.finishRejectedCompletions(deps, arena, turn_id, completion.tool_calls, advertised_dynamic_tool_names);
                     debug_trace.eventf("agent", "authoritative_tool_admission_rejected", step_ctx, "failure=duplicate", .{});

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -1369,7 +1369,41 @@ fn providerExecutedResult(call: ToolCall) ?ToolExecutionResult {
     return .{
         .status = if (provider_status == .success) .success else .failure,
         .model_output = provider_result,
+        .inner_usage = if (runtime_tool_presentation.isProviderSearchAlias(call.name))
+            .{ .web_search_requests = 1 }
+        else
+            null,
     };
+}
+
+test "provider executed result reports one observed request only for search aliases" {
+    const aliases = [_][]const u8{
+        "exa_search",
+        "parallel_search",
+        "perplexity_search",
+    };
+    for (aliases) |name| {
+        const result = providerExecutedResult(.{
+            .id = "provider_call",
+            .name = name,
+            .arguments_json = "{}",
+            .provider_result = "{\"results\":[]}",
+            .provenance = .provider_executed,
+        }) orelse return error.TestExpectedProviderResult;
+        const usage = result.inner_usage orelse return error.TestExpectedSearchUsage;
+        try std.testing.expectEqual(@as(u32, 1), usage.web_search_requests);
+        try std.testing.expectEqual(@as(u64, 0), usage.input_tokens);
+        try std.testing.expectEqual(@as(u64, 0), usage.output_tokens);
+    }
+
+    const non_search = providerExecutedResult(.{
+        .id = "provider_call",
+        .name = "provider_tool",
+        .arguments_json = "{}",
+        .provider_result = "{}",
+        .provenance = .provider_executed,
+    }) orelse return error.TestExpectedProviderResult;
+    try std.testing.expectEqual(@as(?types.ToolUsage, null), non_search.inner_usage);
 }
 
 fn hasToolResult(messages: []const ChatMessage, call_id: []const u8) bool {
@@ -1394,15 +1428,13 @@ fn appendProviderExecutedToolResult(
     completed_tool_names: *std.ArrayList([]u8),
     batch: *runtime_tool_batch.StepBatchState,
 ) !void {
-    const provider_result = call.provider_result orelse
+    const execution = providerExecutedResult(call) orelse
         return error.MalformedProviderResultIdentity;
+    const provider_result = execution.model_output;
     const provider_status = runtime_execution_memory.classifyProviderExecutedResultStatus(
         provider_result,
     );
-    const execution: ToolExecutionResult = .{
-        .status = if (provider_status == .success) .success else .failure,
-        .model_output = provider_result,
-    };
+    runtime_parallel_execution.reportInnerToolUsage(deps, call.name, execution);
     const prepared = try runtime_execution_memory.prepareToolModelOutput(
         arena,
         config,

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -2083,12 +2083,12 @@ test "vision denial settles the authorized attempt without reading the image" {
     try std.testing.expectEqualStrings("Final", hooks.finish_assistant_text.?);
 }
 
-test "provider search emits visible lifecycle and retains URL result detail" {
+test "provider search emits visible lifecycle retains detail and reports observed usage" {
     const alloc = std.testing.allocator;
     const provider_result = "{\"results\":[{\"url\":\"https://example.test/source\"}]}";
     const calls = [_]ToolCall{.{
         .id = "provider_search",
-        .name = "perplexity_search",
+        .name = "exa_search",
         .arguments_json = "{}",
         .provider_result = provider_result,
         .provenance = .provider_executed,
@@ -2107,6 +2107,9 @@ test "provider search emits visible lifecycle and retains URL result detail" {
 
     try std.testing.expectEqual(@as(usize, 0), hooks.permission_names.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
+    try std.testing.expectEqual(@as(usize, 1), hooks.inner_usages.items.len);
+    try std.testing.expectEqualStrings("exa_search", hooks.inner_usage_names.items[0]);
+    try std.testing.expectEqual(@as(u32, 1), hooks.inner_usages.items[0].web_search_requests);
     try expectLifecycleCallIds(
         hooks.lifecycle_events.items,
         &.{ "provider_search", "provider_search", "provider_search" },

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -1440,6 +1440,13 @@ test "parallel streamed cancellation closes every concrete tool action" {
         toolCall("call_read", "read_file", "{\"path\":\"README.md\"}"),
         toolCall("call_fetch", "web_fetch", "{\"url\":\"https://example.com\"}"),
         toolCall("call_glob", "glob_files", "{\"pattern\":\"README.md\"}"),
+        .{
+            .id = "call_search",
+            .name = "exa_search",
+            .arguments_json = "{}",
+            .provider_result = "{\"results\":[]}",
+            .provenance = .provider_executed,
+        },
     };
     const cancellation_points = [_][]const u8{ "read_file", "web_fetch" };
 
@@ -1464,12 +1471,16 @@ test "parallel streamed cancellation closes every concrete tool action" {
         try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
         try std.testing.expectEqual(types.TurnPresentationOutcome.interrupted, hooks.finalized_outcome.?);
         for (calls) |call| {
+            if (call.provenance == .provider_executed) continue;
             try expectSingleTerminalOutcome(
                 hooks.lifecycle_events.items,
                 call.id,
                 .cancelled,
             );
         }
+        try std.testing.expectEqual(@as(usize, 1), hooks.inner_usages.items.len);
+        try std.testing.expectEqualStrings("exa_search", hooks.inner_usage_names.items[0]);
+        try std.testing.expectEqual(@as(u32, 1), hooks.inner_usages.items[0].web_search_requests);
         for (hooks.lifecycle_events.items) |event| {
             if (event != .terminal) continue;
             try std.testing.expect(!std.mem.eql(u8, event.terminal.outcome.summary, "Tool cancelled"));
@@ -5566,7 +5577,7 @@ test "execution cancellation closes every later streamed tool action" {
         toolCall("later_read", "read_file", "{\"path\":\"README.md\"}"),
         .{
             .id = "later_search",
-            .name = "web_search",
+            .name = "exa_search",
             .arguments_json = "{\"query\":\"zig\"}",
             .provider_result = "{\"results\":[]}",
             .provenance = .provider_executed,
@@ -5595,6 +5606,9 @@ test "execution cancellation closes every later streamed tool action" {
     try expectSingleTerminalOutcome(deps.lifecycle_events.items, "active_command", .cancelled);
     try expectSingleTerminalOutcome(deps.lifecycle_events.items, "later_read", .cancelled);
     try expectSingleTerminalOutcome(deps.lifecycle_events.items, "later_search", .completed);
+    try std.testing.expectEqual(@as(usize, 1), deps.inner_usages.items.len);
+    try std.testing.expectEqualStrings("exa_search", deps.inner_usage_names.items[0]);
+    try std.testing.expectEqual(@as(u32, 1), deps.inner_usages.items[0].web_search_requests);
     for (deps.lifecycle_events.items) |event| {
         if (event != .terminal) continue;
         try std.testing.expect(!std.mem.eql(u8, event.terminal.outcome.summary, "Tool cancelled"));

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -20,6 +20,7 @@ const file_mutation = @import("../tooling/file_mutation.zig");
 const file_mutation_contract = @import("../tooling/file_mutation_contract.zig");
 const command_output_content = @import("../tooling/command_output_content.zig");
 const tool_admission = @import("../tooling/tool_admission.zig");
+const tool_presentation = @import("../tooling/tool_presentation.zig");
 const gateway_error_format = @import("../shared/gateway_error_format.zig");
 const io_mod = @import("../shared/io.zig");
 const session_runtime = @import("../session/session.zig");
@@ -1022,7 +1023,8 @@ pub fn Bindings(comptime App: type) type {
         }
 
         fn agentReportInnerToolUsage(ctx: *anyopaque, tool_name: []const u8, usage: types.ToolUsage) void {
-            if (!std.mem.eql(u8, tool_name, "web_search")) return;
+            if (!std.mem.eql(u8, tool_name, "web_search") and
+                !tool_presentation.isProviderSearchAlias(tool_name)) return;
             const app: *App = @ptrCast(@alignCast(ctx));
             app.total_web_search_requests +|= @as(u64, usage.web_search_requests);
         }
@@ -1915,15 +1917,25 @@ test "inner search tokens do not replace outer context counters" {
         .input_tokens = 100,
         .output_tokens = 20,
     });
-    (deps.report_inner_tool_usage orelse return error.TestExpectedEqual)(deps.ctx, "web_search", .{
-        .input_tokens = 999,
-        .output_tokens = 888,
-        .web_search_requests = 3,
-    });
+    const report = deps.report_inner_tool_usage orelse return error.TestExpectedEqual;
+    const search_names = [_][]const u8{
+        "web_search",
+        "exa_search",
+        "parallel_search",
+        "perplexity_search",
+    };
+    for (search_names) |name| {
+        report(deps.ctx, name, .{
+            .input_tokens = 999,
+            .output_tokens = 888,
+            .web_search_requests = 1,
+        });
+    }
+    report(deps.ctx, "provider_tool", .{ .web_search_requests = 7 });
 
     try std.testing.expectEqual(@as(u64, 100), app.total_input_tokens);
     try std.testing.expectEqual(@as(u64, 20), app.total_output_tokens);
-    try std.testing.expectEqual(@as(u64, 3), app.total_web_search_requests);
+    try std.testing.expectEqual(@as(u64, 4), app.total_web_search_requests);
 }
 
 test "agent diff block callback enqueues worker event without direct transcript mutation" {

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -32,6 +32,7 @@ const session_permission_state = @import("../permissions/session_permission_stat
 const skill_commands = @import("../skills/skill_commands.zig");
 const skill_runtime = @import("../skills/skill_runtime.zig");
 const text_utils = @import("../shared/text_utils.zig");
+const tool_presentation = @import("../tooling/tool_presentation.zig");
 const session_commands = @import("../session/session_commands.zig");
 const usage_recovery = @import("../session/usage_recovery.zig");
 const usage_dashboard_runtime = @import("usage_dashboard_runtime.zig");
@@ -2179,6 +2180,45 @@ noinline fn writeMaskedInline(writer: *std.Io.Writer, alloc: std.mem.Allocator, 
     try writer.writeAll(masked);
 }
 
+fn traceToolDisplayName(tool_name: []const u8) []const u8 {
+    return if (tool_presentation.isProviderSearchAlias(tool_name))
+        "web_search"
+    else
+        tool_name;
+}
+
+fn isTraceToolTokenByte(byte: u8) bool {
+    return std.ascii.isAlphanumeric(byte) or byte == '_';
+}
+
+fn providerSearchAliasPrefixLen(token: []const u8) ?usize {
+    var end: usize = 1;
+    while (end <= token.len) : (end += 1) {
+        if (!tool_presentation.isProviderSearchAlias(token[0..end])) continue;
+        if (end == token.len or token[end] == '_') return end;
+    }
+    return null;
+}
+
+fn writeTraceTextNeutralized(writer: *std.Io.Writer, text: []const u8) !void {
+    var token_start: usize = 0;
+    var scan_index: usize = 0;
+    var written_through: usize = 0;
+    while (scan_index < text.len) {
+        if (!isTraceToolTokenByte(text[scan_index])) {
+            scan_index += 1;
+            continue;
+        }
+        token_start = scan_index;
+        while (scan_index < text.len and isTraceToolTokenByte(text[scan_index])) : (scan_index += 1) {}
+        const alias_len = providerSearchAliasPrefixLen(text[token_start..scan_index]) orelse continue;
+        try writer.writeAll(text[written_through..token_start]);
+        try writer.writeAll("web_search");
+        written_through = token_start + alias_len;
+    }
+    try writer.writeAll(text[written_through..]);
+}
+
 fn writeCurrentStateSummary(writer: *std.Io.Writer, app: anytype, alloc: std.mem.Allocator) !void {
     const App = @TypeOf(app.*);
     try writer.writeAll("\n## Current State\n");
@@ -2387,7 +2427,7 @@ fn writeProblemsSummary(writer: *std.Io.Writer, app: anytype, alloc: std.mem.All
     if (lastInterruptedTurn(app.session.history.items)) |entry| {
         count += 1;
         try writer.writeAll("- interrupted turn");
-        if (entry.tool_call) |call| try writer.print(" in_flight_tool={s}", .{call.name});
+        if (entry.tool_call) |call| try writer.print(" in_flight_tool={s}", .{traceToolDisplayName(call.name)});
         if (entry.completed_tool_names.len > 0) try writer.print(" completed_tools={d}", .{entry.completed_tool_names.len});
         try writer.writeByte('\n');
     }
@@ -2656,7 +2696,7 @@ fn writePermissionsSummary(writer: *std.Io.Writer, grants: []const types.Permiss
     }
     try writer.print("\n## Permissions\npermission grants ({d}):\n", .{grants.len});
     for (grants) |grant| {
-        try writer.print("  - {s} :: {s}\n", .{ grant.tool_name, grant.target_path });
+        try writer.print("  - {s} :: {s}\n", .{ traceToolDisplayName(grant.tool_name), grant.target_path });
     }
 }
 
@@ -2682,14 +2722,13 @@ fn writeSubagentsSummary(writer: *std.Io.Writer, alloc: std.mem.Allocator, contr
 
 fn writeToolCallCompact(writer: *std.Io.Writer, call: diagnostics.ToolCallMetric) !void {
     try writeTraceTimestampUtc(writer, call.started_at_ms);
-    try writer.print(" name={s} status={s} duration={d}ms", .{ call.name(), if (call.ok) "ok" else "err", call.duration_ms });
+    try writer.print(" name={s} status={s} duration={d}ms", .{ traceToolDisplayName(call.name()), if (call.ok) "ok" else "err", call.duration_ms });
     if (call.subagent_id != 0) try writer.print(" source=subagent#{d}", .{call.subagent_id}) else try writer.writeAll(" source=parent");
     try writer.writeByte('\n');
 }
 
 const ProviderToolCallSummary = struct {
     call_id: []const u8,
-    tool_name: []const u8,
     status: ?types.PersistedToolStatus,
 };
 
@@ -2721,10 +2760,10 @@ fn projectProviderToolCalls(
         };
         for (execution.tool_steps) |step| {
             for (step.tool_calls) |call| {
-                if (call.provenance != .provider_executed) continue;
+                if (call.provenance != .provider_executed or
+                    !tool_presentation.isProviderSearchAlias(call.name)) continue;
                 const summary: ProviderToolCallSummary = .{
                     .call_id = call.id,
-                    .tool_name = call.name,
                     .status = if (findPersistedToolResult(execution, call.id)) |result|
                         result.status
                     else
@@ -2806,7 +2845,7 @@ noinline fn writeToolCallsSummary(
         }
     }
 
-    try writer.writeAll("### Provider Executed\n");
+    try writer.writeAll("### Web Search\n");
     if (provider_n == 0) {
         try writer.writeAll("(none retained)\n");
         return;
@@ -2814,8 +2853,8 @@ noinline fn writeToolCallsSummary(
     try writer.print("last={d}\n", .{provider_n});
     for (provider_buf[0..provider_n]) |call| {
         try writer.print(
-            "name={s} call_id={s} status={s} source=provider\n",
-            .{ call.tool_name, call.call_id, providerToolStatusLabel(call.status) },
+            "name=web_search status={s}\n",
+            .{providerToolStatusLabel(call.status)},
         );
     }
 }
@@ -2885,7 +2924,7 @@ fn writeLastInterruptedDetail(writer: *std.Io.Writer, items: []const types.Histo
         .interrupted => |t| {
             try writer.writeAll("\n## Interrupted Turn\nlast turn was interrupted by user\n");
             if (t.tool_call) |call| {
-                try writer.print("  in_flight_tool: {s}\n", .{call.name});
+                try writer.print("  in_flight_tool: {s}\n", .{traceToolDisplayName(call.name)});
                 if (call.arguments_json.len > 0) {
                     try writer.writeAll("  in_flight_args:\n");
                     if (call.arguments_json.len > trace_tool_args_max_bytes) {
@@ -2901,7 +2940,7 @@ fn writeLastInterruptedDetail(writer: *std.Io.Writer, items: []const types.Histo
             }
             if (t.completed_tool_names.len > 0) {
                 try writer.print("  completed_tools ({d}):", .{t.completed_tool_names.len});
-                for (t.completed_tool_names) |name| try writer.print(" {s}", .{name});
+                for (t.completed_tool_names) |name| try writer.print(" {s}", .{traceToolDisplayName(name)});
                 try writer.writeByte('\n');
             }
         },
@@ -2950,11 +2989,14 @@ fn writeTraceLogTail(writer: *std.Io.Writer, alloc: std.mem.Allocator, path: []c
     for (lines.items[start..]) |line| {
         const masked = try text_utils.maskSecrets(alloc, line);
         defer if (masked.ptr != line.ptr) alloc.free(masked);
+        const visible = if (masked.len > trace_transcript_max_line_bytes)
+            masked[0..trace_transcript_max_line_bytes]
+        else
+            masked;
+        try writeTraceTextNeutralized(writer, visible);
         if (masked.len > trace_transcript_max_line_bytes) {
-            try writer.writeAll(masked[0..trace_transcript_max_line_bytes]);
             try writer.writeAll(" ...\n");
         } else {
-            try writer.writeAll(masked);
             try writer.writeByte('\n');
         }
     }
@@ -4259,7 +4301,7 @@ test "trace omits web_fetch URL and result bodies from tool-call diagnostics" {
     try std.testing.expect(std.mem.find(u8, text, "result_preview:") == null);
 }
 
-test "trace provider tool calls match results by id without retaining payloads" {
+test "trace web search calls hide provider names and payloads" {
     const alloc = std.testing.allocator;
     diagnostics.resetForTest();
     defer diagnostics.resetForTest();
@@ -4325,13 +4367,32 @@ test "trace provider tool calls match results by id without retaining payloads" 
     try writeToolCallsSummary(&out.writer, alloc, &history);
     const text = out.written();
 
-    try std.testing.expect(std.mem.find(u8, text, "name=exa_search call_id=call_exa status=ok source=provider") != null);
-    try std.testing.expect(std.mem.find(u8, text, "name=parallel_search call_id=call_parallel status=err source=provider") != null);
-    try std.testing.expect(std.mem.find(u8, text, "name=perplexity_search call_id=call_pending status=pending source=provider") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=web_search status=ok") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=web_search status=err") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=web_search status=pending") != null);
+    try std.testing.expect(std.mem.find(u8, text, "call_id=") == null);
+    try std.testing.expect(std.mem.find(u8, text, "exa_search") == null);
+    try std.testing.expect(std.mem.find(u8, text, "parallel_search") == null);
+    try std.testing.expect(std.mem.find(u8, text, "perplexity_search") == null);
     try std.testing.expect(std.mem.find(u8, text, "name=read_file") == null);
     try std.testing.expect(std.mem.find(u8, text, "PROVIDER_ARGUMENT_SECRET") == null);
     try std.testing.expect(std.mem.find(u8, text, "PROVIDER_RESULT_SECRET") == null);
     try std.testing.expect(std.mem.find(u8, text, "(none recorded)") == null);
+}
+
+test "trace text normalizes internal search aliases" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    try writeTraceTextNeutralized(
+        &out.writer,
+        "name=exa_search call_id=exa_search_0 fallback=parallel_search legacy=perplexity_search visible=web_search",
+    );
+
+    try std.testing.expectEqualStrings(
+        "name=web_search call_id=web_search_0 fallback=web_search legacy=web_search visible=web_search",
+        out.written(),
+    );
 }
 
 test "trace provider tool projection keeps the most recent bounded calls" {

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -2142,7 +2142,7 @@ fn buildTraceReport(app: anytype) ![]u8 {
     try writeProblemsSummary(&out.writer, app, app.alloc);
     try writeLastInterruptedDetail(&out.writer, app.session.history.items, app.alloc);
     try writeNetworkCallsSummary(&out.writer);
-    try writeToolCallsSummary(&out.writer, app.alloc);
+    try writeToolCallsSummary(&out.writer, app.alloc, app.session.history.items);
     try writeSubagentsSummary(&out.writer, app.alloc, &app.subagents);
     try writePermissionsSummary(&out.writer, app.permission_engine.grants.items);
     try writeRuntimeContextSummary(&out.writer, app, app.alloc);
@@ -2202,7 +2202,13 @@ fn writeCurrentStateSummary(writer: *std.Io.Writer, app: anytype, alloc: std.mem
         try writer.print("tokens_total: {d}->{d}\n", .{ app.total_input_tokens, app.total_output_tokens });
     }
     if (comptime @hasField(App, "total_web_search_requests")) {
-        try writer.print("web_search_requests_total: {d}\n", .{app.total_web_search_requests});
+        var usage = try app.session.usage.snapshot(alloc);
+        defer usage.deinit(alloc);
+        try writeSearchUsageSummary(
+            writer,
+            app.total_web_search_requests,
+            usage.billable_web_search_calls,
+        );
     }
     try writeAuthStateSummary(writer, app);
     try writeProcessSummary(writer, alloc);
@@ -2681,40 +2687,136 @@ fn writeToolCallCompact(writer: *std.Io.Writer, call: diagnostics.ToolCallMetric
     try writer.writeByte('\n');
 }
 
-noinline fn writeToolCallsSummary(writer: *std.Io.Writer, alloc: std.mem.Allocator) !void {
+const ProviderToolCallSummary = struct {
+    call_id: []const u8,
+    tool_name: []const u8,
+    status: ?types.PersistedToolStatus,
+};
+
+fn findPersistedToolResult(
+    execution: types.ExecutionMemory,
+    call_id: []const u8,
+) ?types.PersistedToolResult {
+    for (execution.tool_steps) |step| {
+        for (step.tool_results) |result| {
+            if (std.mem.eql(u8, result.tool_call_id, call_id)) return result;
+        }
+    }
+    return null;
+}
+
+fn projectProviderToolCalls(
+    history: []const types.HistoryTurn,
+    output: []ProviderToolCallSummary,
+) usize {
+    if (output.len == 0) return 0;
+
+    var count: usize = 0;
+    for (history) |turn| {
+        const execution: types.ExecutionMemory = switch (turn) {
+            .assistant => |entry| entry.execution,
+            .background_command => |entry| entry.execution,
+            .interrupted => |entry| entry.execution,
+            .compacted_summary => continue,
+        };
+        for (execution.tool_steps) |step| {
+            for (step.tool_calls) |call| {
+                if (call.provenance != .provider_executed) continue;
+                const summary: ProviderToolCallSummary = .{
+                    .call_id = call.id,
+                    .tool_name = call.name,
+                    .status = if (findPersistedToolResult(execution, call.id)) |result|
+                        result.status
+                    else
+                        null,
+                };
+                if (count < output.len) {
+                    output[count] = summary;
+                    count += 1;
+                } else {
+                    std.mem.copyForwards(
+                        ProviderToolCallSummary,
+                        output[0 .. output.len - 1],
+                        output[1..],
+                    );
+                    output[output.len - 1] = summary;
+                }
+            }
+        }
+    }
+    return count;
+}
+
+fn providerToolStatusLabel(status: ?types.PersistedToolStatus) []const u8 {
+    return if (status) |value| switch (value) {
+        .success => "ok",
+        .failure => "err",
+    } else "pending";
+}
+
+fn writeSearchUsageSummary(writer: *std.Io.Writer, observed: u64, billed: u64) !void {
+    try writer.print("web_search_requests_total: {d} (observed)\n", .{observed});
+    try writer.print("billable_web_search_calls: {d} (billed)\n", .{billed});
+}
+
+noinline fn writeToolCallsSummary(
+    writer: *std.Io.Writer,
+    alloc: std.mem.Allocator,
+    history: []const types.HistoryTurn,
+) !void {
     var buf: [diagnostics.tool_call_ring_capacity]diagnostics.ToolCallMetric = undefined;
     const n = diagnostics.snapshotToolCalls(&buf);
-    if (n == 0) {
+    var provider_buf: [diagnostics.tool_call_ring_capacity]ProviderToolCallSummary = undefined;
+    const provider_n = projectProviderToolCalls(history, &provider_buf);
+    if (n == 0 and provider_n == 0) {
         try writer.writeAll("\n## Tool Calls\n(none recorded)\n");
         return;
     }
 
-    var ok_count: u32 = 0;
-    var error_count: u32 = 0;
-    var total_ms: u64 = 0;
-    for (buf[0..n]) |call| {
-        if (call.ok) ok_count += 1 else error_count += 1;
-        total_ms += call.duration_ms;
-    }
-
-    try writer.print("\n## Tool Calls\nlast={d} ok={d} errors={d} total={d}ms\n", .{ n, ok_count, error_count, total_ms });
-    if (error_count > 0) {
-        try writer.writeAll("errors first:\n");
+    try writer.writeAll("\n## Tool Calls\n### Local\n");
+    if (n == 0) {
+        try writer.writeAll("(none locally executed)\n");
+    } else {
+        var ok_count: u32 = 0;
+        var error_count: u32 = 0;
+        var total_ms: u64 = 0;
         for (buf[0..n]) |call| {
-            if (call.ok) continue;
+            if (call.ok) ok_count += 1 else error_count += 1;
+            total_ms += call.duration_ms;
+        }
+
+        try writer.print("last={d} ok={d} errors={d} total={d}ms\n", .{ n, ok_count, error_count, total_ms });
+        if (error_count > 0) {
+            try writer.writeAll("errors first:\n");
+            for (buf[0..n]) |call| {
+                if (call.ok) continue;
+                try writeToolCallCompact(writer, call);
+                try writeToolFieldBlock(writer, alloc, "args", call.args(), call.args_len, call.args_total_bytes);
+                try writeToolFieldBlock(writer, alloc, "result", call.result(), call.result_len, call.result_total_bytes);
+            }
+            try writer.writeAll("recent successes (compact):\n");
+        } else {
+            try writer.writeAll("recent successes (compact):\n");
+        }
+        for (buf[0..n]) |call| {
+            if (!call.ok) continue;
             try writeToolCallCompact(writer, call);
             try writeToolFieldBlock(writer, alloc, "args", call.args(), call.args_len, call.args_total_bytes);
-            try writeToolFieldBlock(writer, alloc, "result", call.result(), call.result_len, call.result_total_bytes);
+            try writeToolResultPreview(writer, alloc, call.result(), call.result_total_bytes);
         }
-        try writer.writeAll("recent successes (compact):\n");
-    } else {
-        try writer.writeAll("recent successes (compact):\n");
     }
-    for (buf[0..n]) |call| {
-        if (!call.ok) continue;
-        try writeToolCallCompact(writer, call);
-        try writeToolFieldBlock(writer, alloc, "args", call.args(), call.args_len, call.args_total_bytes);
-        try writeToolResultPreview(writer, alloc, call.result(), call.result_total_bytes);
+
+    try writer.writeAll("### Provider Executed\n");
+    if (provider_n == 0) {
+        try writer.writeAll("(none retained)\n");
+        return;
+    }
+    try writer.print("last={d}\n", .{provider_n});
+    for (provider_buf[0..provider_n]) |call| {
+        try writer.print(
+            "name={s} call_id={s} status={s} source=provider\n",
+            .{ call.tool_name, call.call_id, providerToolStatusLabel(call.status) },
+        );
     }
 }
 
@@ -4098,7 +4200,7 @@ test "trace tool calls print errors first and mask obvious secrets" {
 
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
-    try writeToolCallsSummary(&out.writer, alloc);
+    try writeToolCallsSummary(&out.writer, alloc, &.{});
     const text = out.written();
 
     const error_pos = std.mem.find(u8, text, "name=run_command") orelse return error.TestExpectedEqual;
@@ -4123,7 +4225,7 @@ test "trace successful tool calls use compact result previews" {
 
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
-    try writeToolCallsSummary(&out.writer, alloc);
+    try writeToolCallsSummary(&out.writer, alloc, &.{});
     const text = out.written();
 
     try std.testing.expect(std.mem.find(u8, text, "recent successes (compact):") != null);
@@ -4145,7 +4247,7 @@ test "trace omits web_fetch URL and result bodies from tool-call diagnostics" {
 
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
-    try writeToolCallsSummary(&out.writer, alloc);
+    try writeToolCallsSummary(&out.writer, alloc, &.{});
     const text = out.written();
 
     try std.testing.expect(std.mem.find(u8, text, "name=web_fetch") != null);
@@ -4155,6 +4257,124 @@ test "trace omits web_fetch URL and result bodies from tool-call diagnostics" {
     try std.testing.expect(std.mem.find(u8, text, "EXTRACTED_RESULT_SECRET") == null);
     try std.testing.expect(std.mem.find(u8, text, "args:") == null);
     try std.testing.expect(std.mem.find(u8, text, "result_preview:") == null);
+}
+
+test "trace provider tool calls match results by id without retaining payloads" {
+    const alloc = std.testing.allocator;
+    diagnostics.resetForTest();
+    defer diagnostics.resetForTest();
+
+    var calls = [_]types.ToolCall{
+        .{
+            .id = "call_exa",
+            .name = "exa_search",
+            .arguments_json = "{\"query\":\"PROVIDER_ARGUMENT_SECRET\"}",
+            .provenance = .provider_executed,
+        },
+        .{
+            .id = "call_parallel",
+            .name = "parallel_search",
+            .arguments_json = "{}",
+            .provenance = .provider_executed,
+        },
+        .{
+            .id = "call_pending",
+            .name = "perplexity_search",
+            .arguments_json = "{}",
+            .provenance = .provider_executed,
+        },
+        .{
+            .id = "call_local",
+            .name = "read_file",
+            .arguments_json = "{}",
+            .provenance = .fx_local,
+        },
+    };
+    var results = [_]types.PersistedToolResult{
+        .{
+            .tool_call_id = @constCast("call_parallel"),
+            .tool_name = @constCast("parallel_search"),
+            .status = .failure,
+            .output = @constCast("PROVIDER_RESULT_SECRET"),
+            .output_bytes = 22,
+            .stored_output_bytes = 22,
+            .provider_native = true,
+        },
+        .{
+            .tool_call_id = @constCast("call_exa"),
+            .tool_name = @constCast("exa_search"),
+            .status = .success,
+            .output = @constCast("{\"results\":[]}"),
+            .output_bytes = 14,
+            .stored_output_bytes = 14,
+            .provider_native = true,
+        },
+    };
+    var steps = [_]types.ToolExecutionStep{.{
+        .tool_calls = &calls,
+        .tool_results = &results,
+    }};
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("search") },
+        .assistant = @constCast("answer"),
+        .execution = .{ .tool_steps = &steps },
+    } }};
+
+    var out: std.Io.Writer.Allocating = .init(alloc);
+    defer out.deinit();
+    try writeToolCallsSummary(&out.writer, alloc, &history);
+    const text = out.written();
+
+    try std.testing.expect(std.mem.find(u8, text, "name=exa_search call_id=call_exa status=ok source=provider") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=parallel_search call_id=call_parallel status=err source=provider") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=perplexity_search call_id=call_pending status=pending source=provider") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=read_file") == null);
+    try std.testing.expect(std.mem.find(u8, text, "PROVIDER_ARGUMENT_SECRET") == null);
+    try std.testing.expect(std.mem.find(u8, text, "PROVIDER_RESULT_SECRET") == null);
+    try std.testing.expect(std.mem.find(u8, text, "(none recorded)") == null);
+}
+
+test "trace provider tool projection keeps the most recent bounded calls" {
+    var calls: [diagnostics.tool_call_ring_capacity + 1]types.ToolCall = undefined;
+    for (&calls, 0..) |*call, index| {
+        call.* = .{
+            .id = if (index == 0)
+                "oldest"
+            else if (index + 1 == calls.len)
+                "newest"
+            else
+                "middle",
+            .name = "exa_search",
+            .arguments_json = "{}",
+            .provenance = .provider_executed,
+        };
+    }
+    var steps = [_]types.ToolExecutionStep{.{ .tool_calls = &calls }};
+    const history = [_]types.HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("search") },
+        .assistant = @constCast("answer"),
+        .execution = .{ .tool_steps = &steps },
+    } }};
+    var summaries: [diagnostics.tool_call_ring_capacity]ProviderToolCallSummary = undefined;
+
+    const count = projectProviderToolCalls(&history, &summaries);
+
+    try std.testing.expectEqual(diagnostics.tool_call_ring_capacity, count);
+    try std.testing.expectEqualStrings("middle", summaries[0].call_id);
+    try std.testing.expectEqualStrings("newest", summaries[count - 1].call_id);
+}
+
+test "trace labels observed and billed search usage independently" {
+    var out: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer out.deinit();
+
+    try writeSearchUsageSummary(&out.writer, 3, 1);
+
+    try std.testing.expectEqualStrings(
+        "web_search_requests_total: 3 (observed)\n" ++
+            "billable_web_search_calls: 1 (billed)\n",
+        out.written(),
+    );
 }
 
 test "trace renders web search request count without content" {

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -6958,7 +6958,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
   );
 
   test(
-    "provider search renders a transcript lifecycle row with URL detail",
+    "provider search renders lifecycle detail and trace observability",
     async () => {
       root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-provider-search-")));
       const home = join(root, "home");
@@ -7018,6 +7018,7 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
           FX_GATEWAY_CHAT_URL: providerGateway.chatUrl,
           FX_E2E_GATEWAY_CHAT_URL: providerGateway.chatUrl,
           FX_MODEL: MODEL,
+          TMPDIR: root,
           FX_RECORD: tapePath,
           FX_RECORD_INPUT: "1",
           FX_TRACE_LOG: tracePath,
@@ -7070,6 +7071,29 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const detail = await session.waitForText(sourceUrl, TIMEOUT);
       expect(detail).toContain(sourceUrl);
       expect(detail).toContain("└ Searched web");
+
+      await session.sendKeys("Escape");
+      await session.waitForComposer(TIMEOUT);
+      await session.sendText("/trace");
+      await waitForCondition(
+        () => readdirSync(root!).some((entry) =>
+          entry.startsWith("fx-trace-") && entry.endsWith(".md")
+        ),
+        "provider search trace report",
+      );
+      const traceReportName = readdirSync(root)
+        .filter((entry) => entry.startsWith("fx-trace-") && entry.endsWith(".md"))
+        .sort()
+        .at(-1);
+      expect(traceReportName).toBeDefined();
+      const traceReport = readFileSync(join(root, traceReportName!), "utf8");
+      expect(traceReport).toContain("web_search_requests_total: 1 (observed)");
+      expect(traceReport).toContain("billable_web_search_calls: 0 (billed)");
+      expect(traceReport).toContain("### Provider Executed");
+      expect(traceReport).toContain(
+        "name=exa_search call_id=provider_search_direct status=ok source=provider",
+      );
+      expect(traceReport).not.toContain("(none recorded)");
 
       const replay = execFileSync(FX_BIN, ["replay", tapePath, "--frames"], {
         encoding: "utf8",

--- a/tests/e2e/tui-gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/tui-gateway-stream-lifecycle.test.ts
@@ -7089,10 +7089,13 @@ describe.skipIf(!tmuxAvailable())("TUI gateway stream lifecycle", () => {
       const traceReport = readFileSync(join(root, traceReportName!), "utf8");
       expect(traceReport).toContain("web_search_requests_total: 1 (observed)");
       expect(traceReport).toContain("billable_web_search_calls: 0 (billed)");
-      expect(traceReport).toContain("### Provider Executed");
+      expect(traceReport).toContain("### Web Search");
       expect(traceReport).toContain(
-        "name=exa_search call_id=provider_search_direct status=ok source=provider",
+        "name=web_search status=ok",
       );
+      expect(traceReport).not.toContain("exa_search");
+      expect(traceReport).not.toContain("parallel_search");
+      expect(traceReport).not.toContain("perplexity_search");
       expect(traceReport).not.toContain("(none recorded)");
 
       const replay = execFileSync(FX_BIN, ["replay", tapePath, "--frames"], {


### PR DESCRIPTION
## Summary

- Count direct web searches in the observed web-search total.
- List completed web searches in `/trace` without exposing internal provider names, call IDs, arguments, or result bodies.
- Show observed and billed web-search usage separately.
- Use Exa's default highlights instead of a fixed 10,000-character highlight budget.