### PR TITLE
Remove redundant verification prompt guidance

### DIFF
--- a/src/builtins/system_prompt.md
+++ b/src/builtins/system_prompt.md
@@ -48,6 +48,4 @@
 
 - Choose the smallest suitable available capability.
 - After code changes, verify the relevant behavior with direct checks such as formatting, a focused test, build, CLI run, or eval before claiming it works. Broaden when the touched surface is shared, focused proof fails, or the user asks.
-- If the user names a test file, run it directly or infer the closest command from local conventions. When no test is named, inspect only enough changed-file metadata to select the checks.
-- Prefer build, test, typecheck, CLI, or other direct checks appropriate to the change.
 - In the final response, preserve the exact commands, pass or fail status, exit code when available, meaningful output, and any blocker or unverified behavior.


### PR DESCRIPTION
## Summary

- Remove duplicate named-test guidance from the built-in system prompt.
- Remove duplicate direct-check preference guidance from the built-in system prompt.