### PR TITLE
Hide empty slash completion menus

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -4746,6 +4746,20 @@ test "app_input_runtime Escape dismisses visible slash completions without armin
     try std.testing.expect(app.shell.render_requests.hasReason(.footer));
 }
 
+test "app_input_runtime Escape leaves unmatched slash input with the composer" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    try app.input_runtime.textReplacementState().replace(alloc, "/hezzzzz");
+
+    try Runtime(RoutingFakeApp).resolveEscape(&app, false, 1);
+
+    try std.testing.expectEqualStrings("/hezzzzz", app.input_runtime.edit_state.input.items);
+    try std.testing.expect(!app.input_runtime.picker.isInlinePickerDismissed(.slash));
+    try std.testing.expectEqual(@as(?i64, 1), app.input_runtime.gestures.escapeClearArmedAt());
+    try std.testing.expect(app.shell.render_requests.hasReason(.footer));
+}
+
 test "app_input_runtime Escape dismisses slash matches with wrapped input" {
     const alloc = std.testing.allocator;
 

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -116,8 +116,7 @@ pub fn CompletionRuntime(comptime App: type) type {
             return slashCompletionQueryActive(app);
         }
 
-        /// Returns selectable completions projected by the footer. The active
-        /// query can remain visible at zero so dismissal still owns Escape.
+        /// Returns selectable completions projected by the footer.
         pub fn visibleSlashCompletionCount(app: *App) usize {
             if (!visibleSlashCompletionQueryActive(app)) return 0;
             return slashCompletionCandidateCount(app);
@@ -142,7 +141,7 @@ pub fn CompletionRuntime(comptime App: type) type {
                         return if (hasFileQuery(app)) .file else null;
                     }
                     if (visibleInlineSlashCompletion(app) != null) return .slash;
-                    if (visibleSlashCompletionQueryActive(app)) return .slash;
+                    if (visibleSlashCompletionCount(app) > 0) return .slash;
                     return null;
                 }
             }
@@ -154,7 +153,7 @@ pub fn CompletionRuntime(comptime App: type) type {
                     .slash => .slash,
                 };
             }
-            if (visibleSlashCompletionQueryActive(app)) return .slash;
+            if (visibleSlashCompletionCount(app) > 0) return .slash;
             return null;
         }
 
@@ -1598,7 +1597,7 @@ test "inline slash completion stays inactive when its suffix cannot render" {
     );
 }
 
-test "root slash query remains dismissible with zero candidates" {
+test "root slash query is dismissible only while candidates are visible" {
     const alloc = std.testing.allocator;
     const rt = CompletionRuntime(InlineCompletionTestApp);
     var app = InlineCompletionTestApp{ .alloc = alloc };
@@ -1606,9 +1605,13 @@ test "root slash query remains dismissible with zero candidates" {
     try app.input_runtime.textReplacementState().replace(alloc, "/hezzzzz");
 
     try std.testing.expectEqual(@as(usize, 0), rt.visibleSlashCompletionCount(&app));
+    try std.testing.expect(!rt.dismissVisibleInlinePicker(&app));
+    try std.testing.expect(!app.input_runtime.picker.isInlinePickerDismissed(.slash));
+
+    try app.input_runtime.textReplacementState().replace(alloc, "/he");
+    try std.testing.expect(rt.visibleSlashCompletionCount(&app) > 0);
     try std.testing.expect(rt.dismissVisibleInlinePicker(&app));
     try std.testing.expect(app.input_runtime.picker.isInlinePickerDismissed(.slash));
-    try std.testing.expect(!rt.dismissVisibleInlinePicker(&app));
 }
 
 test "root slash completion follows multiline and command argument ownership" {

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -326,12 +326,13 @@ pub fn measureRawInputGeometryPrepared(
     }, raw_anchor);
     const capped = cappedInputRows(summary.total_rows, content_bottom, input_visible);
     const window = visual_layout.visibleWindow(summary.cursor.row_index, summary.total_rows, capped.row_limit);
-    const show_slash_query = slashCompletionPickerActive(ctx, modal_active, show_model_query, show_file_query);
-    const slash_completion_count = if (show_slash_query)
+    const slash_query_active = slashCompletionPickerActive(ctx, modal_active, show_model_query, show_file_query);
+    const slash_completion_count = if (slash_query_active)
         prepared_slash_completion_count orelse
             slashCompletionPickerCount(ctx, modal_active, show_model_query, show_file_query)
     else
         0;
+    const show_slash_query = slash_query_active and slash_completion_count > 0;
     const picker_start_col = if (show_model_query or show_file_query or show_slash_query)
         visual_layout.projectedAnchorColumn(summary, terminal_cols)
     else
@@ -1465,15 +1466,31 @@ test "footer slash completion remains active across capped input rows" {
     try std.testing.expect(tiny_geometry.slash_completion_count > 0);
 }
 
-test "footer slash completion separates query activity from candidate count" {
+test "footer slash completion follows candidate visibility transitions" {
     const alloc = std.testing.allocator;
     var input = InputRuntime{};
     defer input.deinit(alloc);
 
-    try input.textReplacementState().replace(alloc, "/hezzzzz");
+    try input.textReplacementState().replace(alloc, "/mo");
+    const matching = measureRawInputGeometry(testRenderContext(&input), 80, 20, true, false, false, false);
+    try std.testing.expect(matching.show_slash_query);
+    try std.testing.expect(matching.slash_completion_count > 0);
+
+    try input.textReplacementState().replace(alloc, "/mozzzzz");
     const no_match = measureRawInputGeometry(testRenderContext(&input), 80, 20, true, false, false, false);
-    try std.testing.expect(no_match.show_slash_query);
+    try std.testing.expect(!no_match.show_slash_query);
     try std.testing.expectEqual(@as(usize, 0), no_match.slash_completion_count);
+
+    try input.textReplacementState().replace(alloc, "/mo");
+    const restored = measureRawInputGeometry(testRenderContext(&input), 80, 20, true, false, false, false);
+    try std.testing.expect(restored.show_slash_query);
+    try std.testing.expect(restored.slash_completion_count > 0);
+}
+
+test "footer slash completion preserves command argument ownership" {
+    const alloc = std.testing.allocator;
+    var input = InputRuntime{};
+    defer input.deinit(alloc);
 
     try input.textReplacementState().replace(alloc, "/resume ");
     const no_args = measureRawInputGeometry(testRenderContext(&input), 80, 20, true, false, false, false);

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -1004,9 +1004,6 @@ pub fn composeFooterFrame(
                         row += 1;
                     }
                 }
-            } else {
-                var status_row = try picker_presentation.composePickerStatusRow(alloc, .slash, ctx.model_picker_stage, false, false, input.picker_start_col, shell.layout.cols);
-                try pushFooterBandRow(alloc, &frame, plan, rows.picker_start, &status_row);
             }
         } else if (input.picker_kind == .file and input.file_picker_items.len > 0) {
             const selected = input.picker_selection_index % input.file_picker_items.len;

--- a/src/ui/footer/picker_presentation.zig
+++ b/src/ui/footer/picker_presentation.zig
@@ -861,7 +861,7 @@ pub fn composePickerStatusRow(
             "unable to index files"
         else
             "no matching files",
-        .slash => "no matching slash commands",
+        .slash => unreachable,
         .skills => "no matching skills",
         .help => "no matching commands",
         .settings => "no matching settings",

--- a/src/ui/footer/surface_frame.zig
+++ b/src/ui/footer/surface_frame.zig
@@ -613,8 +613,6 @@ fn buildFooterSurfaceProjection(
         )
     else if (slash_menu_layout) |layout|
         layout.row_count
-    else if (show_slash_query and geometry.slash_completion_count == 0)
-        picker_presentation.pickerRowCount(0)
     else if (show_picker)
         list_picker_rows
     else
@@ -1765,7 +1763,7 @@ test "surface footer measurement reserves six inline skill choices" {
     try std.testing.expectEqual(@as(u16, 8), measurement.picker_rows);
 }
 
-test "surface footer reserves one non-selectable row for zero slash results" {
+test "surface footer omits the picker for zero slash results" {
     const alloc = std.testing.allocator;
     var input = InputRuntime{};
     defer input.deinit(alloc);
@@ -1780,10 +1778,10 @@ test "surface footer reserves one non-selectable row for zero slash results" {
     var measurement = try measureSurfaceFooter(alloc, &shell, approval.projection(), surfaceTestContext(&input));
     defer measurement.deinit(alloc);
 
-    try std.testing.expect(measurement.show_picker);
-    try std.testing.expectEqual(PickerKind.slash, measurement.picker_kind);
+    try std.testing.expect(!measurement.show_picker);
     try std.testing.expectEqual(@as(usize, 0), measurement.slash_completion_count);
-    try std.testing.expectEqual(@as(u16, 1), measurement.picker_rows);
+    try std.testing.expectEqual(@as(u16, 0), measurement.picker_rows);
+    try std.testing.expectEqual(@as(u16, 0), measurement.footer_extra);
     try std.testing.expect(measurement.slash_menu_layout == null);
 }
 

--- a/tests/e2e/tui-render-stress.test.ts
+++ b/tests/e2e/tui-render-stress.test.ts
@@ -121,14 +121,15 @@ describe.skipIf(SKIP)("tui: render stress", () => {
         await session.waitForText("permission_mode", 5_000);
         const unknownCommand = `/unknown-render-stress-${run} local transcript notice`;
         await session.sendLiteralText(unknownCommand);
-        await session.waitForText("no matching slash commands", 5_000);
-        await session.sendKeys("Escape");
         await session.waitForPane(
-          (pane) =>
-            composerContains(pane, unknownCommand) &&
-            !pane.includes("no matching slash commands"),
+          (pane) => composerContains(pane, unknownCommand),
           5_000,
         );
+        await Bun.sleep(100);
+        const unmatchedPane = await session.capturePane();
+        if (unmatchedPane.includes("no matching slash commands")) {
+          failures.push(`run ${run}: unmatched slash input kept an empty picker row`);
+        }
         await session.sendKeys("C-u");
         await session.waitForPane(hasEmptyComposer, 5_000);
 

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -1399,16 +1399,33 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendLiteralText("/he");
       await session.waitForText("/help", 5_000);
       await session.sendLiteralText("zzzzz");
-      let pane = await session.waitForText("no matching slash commands", 5_000);
-      expect(composerContains(pane, "/hezzzzz")).toBe(true);
-      expect(pane).not.toContain("Enter Use");
-      await session.sendKeys("Escape");
       await session.waitForPane(
-        (current) =>
-          composerContains(current, "/hezzzzz") &&
-          !current.includes("no matching slash commands"),
+        (current) => composerContains(current, "/hezzzzz"),
         5_000,
       );
+      await Bun.sleep(100);
+      let pane = await session.capturePane();
+      expect(composerContains(pane, "/hezzzzz")).toBe(true);
+      expect(pane).not.toContain("Enter Use");
+      expect(pane).not.toContain("no matching slash commands");
+
+      for (let index = 0; index < 5; index++) await session.sendKeys("BSpace");
+      await session.waitForPane(
+        (current) => composerContains(current, "/he") && current.includes("Enter Use"),
+        5_000,
+      );
+
+      await session.sendKeys("C-u");
+      const absolutePath = "/Users/faxes/Developer/Fx";
+      await session.sendLiteralText(absolutePath);
+      await session.waitForPane(
+        (current) => composerContains(current, absolutePath),
+        5_000,
+      );
+      await Bun.sleep(100);
+      pane = await session.capturePane();
+      expect(pane).not.toContain("no matching slash commands");
+      expect(pane).not.toContain("Enter Use");
 
       await session.sendKeys("C-u");
       await session.sendLiteralText("/name");
@@ -1453,8 +1470,14 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       for (const retired of ["/appearance", "/input", "/maxxing"]) {
         await session.sendKeys("C-u");
         await session.sendLiteralText(retired);
-        pane = await session.waitForText("no matching slash commands", 5_000);
+        await session.waitForPane(
+          (current) => composerContains(current, retired),
+          5_000,
+        );
+        await Bun.sleep(100);
+        pane = await session.capturePane();
         expect(composerContains(pane, retired)).toBe(true);
+        expect(pane).not.toContain("no matching slash commands");
         expect(pane).not.toContain("minimal");
         expect(pane).not.toContain("legacy");
         expect(pane).not.toContain("resume-helper");

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -1416,7 +1416,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       );
 
       await session.sendKeys("C-u");
-      const absolutePath = "/Users/faxes/Developer/Fx";
+      const absolutePath = "/opt/project/src/main.zig";
       await session.sendLiteralText(absolutePath);
       await session.waitForPane(
         (current) => composerContains(current, absolutePath),


### PR DESCRIPTION
## Summary

- Hide the inline slash menu when the current query has no command or skill matches.
- Keep unmatched slash-prefixed text and paths under normal composer keyboard behavior.
- Reopen slash completions when editing back to a matching prefix.
- Preserve direct slash completion and Escape dismissal for visible menus.