### PR TITLE
Complete ACP tool-call reporting

### DIFF
--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -192,12 +192,10 @@ const AcpContext = struct {
         const publication = self.published_tool_calls.getPtr(tool_call_id) orelse return;
         if (publication.* != .pending) return;
         const status = providerTerminalStatus(outcome.kind) orelse return;
-        const plain = try stripAnsiAlloc(self.alloc, outcome.summary);
-        defer if (plain.ptr != outcome.summary.ptr) self.alloc.free(plain);
 
         switch (status) {
-            .completed => try self.sendToolCallCompletedWithCommandResult(tool_call_id, plain, null),
-            .failed => try self.sendToolCallErrorWithCommandResult(tool_call_id, plain, null),
+            .completed => try self.sendToolCallCompletedWithCommandResult(tool_call_id, "Web search completed", null),
+            .failed => try self.sendToolCallErrorWithCommandResult(tool_call_id, "Web search failed", null),
             .pending, .in_progress => unreachable,
         }
         const updated = self.published_tool_calls.getPtr(tool_call_id) orelse
@@ -3583,7 +3581,7 @@ test "ACP pending tool_call updates keep provider ids stable and dedupe" {
     try std.testing.expectEqual(@as(usize, 1), malformed_count);
 }
 
-test "ACP provider search lifecycle publishes one public terminal update" {
+test "ACP provider search lifecycle publishes only public terminal updates" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const alloc = arena_state.allocator();
@@ -3613,6 +3611,39 @@ test "ACP provider search lifecycle publishes one public terminal update" {
     } };
     try pushToolLifecycle(&ctx, completed);
     try pushToolLifecycle(&ctx, completed);
+    try pushToolLifecycle(&ctx, .{ .provisional = .{
+        .id = .{ .turn_id = 1, .call_id = "provider_search_2" },
+        .tool_name = "perplexity_search",
+        .activity_kind = .read,
+    } });
+    const failed = types.ToolLifecycleEvent{ .terminal = .{
+        .id = .{ .turn_id = 1, .call_id = "provider_search_2" },
+        .outcome = .{ .kind = .failed, .summary = "perplexity_search failed: invalid JSON arguments" },
+    } };
+    try pushToolLifecycle(&ctx, failed);
+    try pushToolLifecycle(&ctx, failed);
+    try pushToolLifecycle(&ctx, .{ .provisional = .{
+        .id = .{ .turn_id = 1, .call_id = "provider_search_3" },
+        .tool_name = "parallel_search",
+        .activity_kind = .read,
+    } });
+    try pushToolLifecycle(&ctx, .{ .terminal = .{
+        .id = .{ .turn_id = 1, .call_id = "provider_search_3" },
+        .outcome = .{ .kind = .cancelled, .summary = "Cancelled parallel_search" },
+    } });
+    try pushToolLifecycle(&ctx, .{ .provisional = .{
+        .id = .{ .turn_id = 1, .call_id = "provider_search_4" },
+        .tool_name = "exa_search",
+        .activity_kind = .read,
+    } });
+    try pushToolLifecycle(&ctx, .{ .terminal = .{
+        .id = .{ .turn_id = 1, .call_id = "provider_search_4" },
+        .outcome = .{ .kind = .deferred, .summary = "Deferred exa_search" },
+    } });
+    try pushToolLifecycle(&ctx, .{ .terminal = .{
+        .id = .{ .turn_id = 1, .call_id = "unknown_provider_search" },
+        .outcome = .{ .kind = .failed, .summary = "exa_search failed" },
+    } });
     try pushToolLifecycle(&ctx, .{ .authoritative_started = .{
         .id = .{ .turn_id = 1, .call_id = "read_1" },
         .reconciles_provisional_call_id = null,
@@ -3632,11 +3663,14 @@ test "ACP provider search lifecycle publishes one public terminal update" {
     var lines = std.mem.splitScalar(u8, captured, '\n');
     var provider_pending: usize = 0;
     var provider_completed: usize = 0;
+    var provider_failed: usize = 0;
     var read_pending: usize = 0;
     var read_completed: usize = 0;
     while (lines.next()) |line| {
         if (line.len == 0) continue;
         try std.testing.expect(std.mem.find(u8, line, "exa_search") == null);
+        try std.testing.expect(std.mem.find(u8, line, "perplexity_search") == null);
+        try std.testing.expect(std.mem.find(u8, line, "parallel_search") == null);
         var parsed = try std.json.parseFromSlice(std.json.Value, alloc, line, .{});
         defer parsed.deinit();
         const update = parsed.value.object.get("params").?.object.get("update").?.object;
@@ -3652,14 +3686,37 @@ test "ACP provider search lifecycle publishes one public terminal update" {
             } else if (std.mem.eql(u8, session_update, "tool_call_update")) {
                 provider_completed += 1;
                 try std.testing.expectEqualStrings("completed", update.get("status").?.string);
+                try std.testing.expectEqualStrings(
+                    "Web search completed",
+                    update.get("content").?.array.items[0].object.get("content").?.object.get("text").?.string,
+                );
             }
+        } else if (std.mem.eql(u8, call_id, "provider_search_2") or
+            std.mem.eql(u8, call_id, "provider_search_3"))
+        {
+            if (std.mem.eql(u8, session_update, "tool_call")) {
+                provider_pending += 1;
+            } else if (std.mem.eql(u8, session_update, "tool_call_update")) {
+                provider_failed += 1;
+                try std.testing.expectEqualStrings("failed", update.get("status").?.string);
+                try std.testing.expectEqualStrings(
+                    "Web search failed",
+                    update.get("content").?.array.items[0].object.get("content").?.object.get("text").?.string,
+                );
+            }
+        } else if (std.mem.eql(u8, call_id, "provider_search_4")) {
+            try std.testing.expectEqualStrings("tool_call", session_update);
+            provider_pending += 1;
         } else if (std.mem.eql(u8, call_id, "read_1")) {
             if (std.mem.eql(u8, session_update, "tool_call")) read_pending += 1;
             if (std.mem.eql(u8, session_update, "tool_call_update")) read_completed += 1;
+        } else {
+            return error.TestUnexpectedToolCallId;
         }
     }
-    try std.testing.expectEqual(@as(usize, 1), provider_pending);
+    try std.testing.expectEqual(@as(usize, 4), provider_pending);
     try std.testing.expectEqual(@as(usize, 1), provider_completed);
+    try std.testing.expectEqual(@as(usize, 2), provider_failed);
     try std.testing.expectEqual(@as(usize, 1), read_pending);
     try std.testing.expectEqual(@as(usize, 0), read_completed);
 }

--- a/src/acp/prompt.zig
+++ b/src/acp/prompt.zig
@@ -12,6 +12,7 @@ const acp_types = @import("types.zig");
 const server = @import("server.zig");
 const sessions = @import("sessions.zig");
 const agent_runtime = @import("../core/agent/agent_runtime.zig");
+const agent_execution_memory = @import("../core/agent/execution_memory.zig");
 const diff_mod = @import("../core/output/diff.zig");
 const file_mutation = @import("../core/tooling/file_mutation.zig");
 const file_mutation_contract = @import("../core/tooling/file_mutation_contract.zig");
@@ -84,6 +85,12 @@ pub const TerminalOutcome = union(enum) {
     rpc_error: jsonrpc.RpcError,
 };
 
+const ProviderTerminalPublication = enum {
+    not_applicable,
+    pending,
+    published,
+};
+
 const AcpContext = struct {
     alloc: Allocator,
     state: *server.ServerState,
@@ -91,7 +98,7 @@ const AcpContext = struct {
     /// Tool-call IDs already announced with a pending update. Keys are owned
     /// copies of provider call ids so the ID stays stable from permission
     /// review through execution.
-    published_tool_calls: std.StringHashMapUnmanaged(void) = .empty,
+    published_tool_calls: std.StringHashMapUnmanaged(ProviderTerminalPublication) = .empty,
     stop_reason: acp_types.StopReason = .end_turn,
     auto_classifier: permission_auto_classifier.Classifier =
         permission_auto_classifier.Classifier.disabled(),
@@ -147,16 +154,55 @@ const AcpContext = struct {
         if (self.published_tool_calls.getKey(call.id)) |published| return published;
         const registry = self.toolRegistry();
         const title = describeToolTitle(registry, arena, call) catch "Tool call";
-        const kind = mapToolKind(call.name);
+        const name = acpToolName(call.name);
+        const kind = mapToolKind(name);
+        const masked_arguments = try agent_execution_memory.redactToolArgumentsJson(
+            arena,
+            call.name,
+            call.arguments_json,
+        );
+        defer arena.free(masked_arguments);
+        var parsed_arguments: ?std.json.Parsed(std.json.Value) = std.json.parseFromSlice(
+            std.json.Value,
+            arena,
+            masked_arguments,
+            .{},
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => null,
+        };
+        defer if (parsed_arguments) |*parsed| parsed.deinit();
+        const raw_input = if (parsed_arguments) |*parsed| parsed.value else null;
 
+        try self.published_tool_calls.ensureUnusedCapacity(self.alloc, 1);
         const owned_id = try self.alloc.dupe(u8, call.id);
         errdefer self.alloc.free(owned_id);
         var out: std.Io.Writer.Allocating = .init(self.alloc);
         defer out.deinit();
-        try acp_types.writeToolCall(&out.writer, owned_id, title, kind, .pending);
+        try acp_types.writeToolCall(&out.writer, owned_id, name, title, kind, .pending, raw_input);
         try self.sendUpdate(out.writer.buffered());
-        try self.published_tool_calls.put(self.alloc, owned_id, {});
+        self.published_tool_calls.putAssumeCapacity(
+            owned_id,
+            if (tool_presentation.isProviderSearchAlias(call.name)) .pending else .not_applicable,
+        );
         return owned_id;
+    }
+
+    fn sendProviderTerminal(self: *AcpContext, tool_call_id: []const u8, outcome: types.ToolOutcome) !void {
+        const publication = self.published_tool_calls.getPtr(tool_call_id) orelse return;
+        if (publication.* != .pending) return;
+        const status = providerTerminalStatus(outcome.kind) orelse return;
+        const plain = try stripAnsiAlloc(self.alloc, outcome.summary);
+        defer if (plain.ptr != outcome.summary.ptr) self.alloc.free(plain);
+
+        switch (status) {
+            .completed => try self.sendToolCallCompletedWithCommandResult(tool_call_id, plain, null),
+            .failed => try self.sendToolCallErrorWithCommandResult(tool_call_id, plain, null),
+            .pending, .in_progress => unreachable,
+        }
+        const updated = self.published_tool_calls.getPtr(tool_call_id) orelse
+            return error.ToolCallPublicationStateLost;
+        updated.* = .published;
     }
 
     fn sendToolCallProgressText(self: *AcpContext, tool_call_id: []const u8, text: ?[]const u8) !void {
@@ -1339,6 +1385,8 @@ fn requestAcpPermission(
     try jsonrpc.writeJsonStr(ctx.session_id, &params.writer);
     try params.writer.writeAll(",\"toolCall\":{\"toolCallId\":");
     try jsonrpc.writeJsonStr(tool_call_id, &params.writer);
+    try params.writer.writeAll(",\"name\":");
+    try jsonrpc.writeJsonStr(acpToolName(call.name), &params.writer);
     try params.writer.writeAll(",\"title\":");
     try jsonrpc.writeJsonStr(request.label, &params.writer);
     try params.writer.writeAll(",\"kind\":");
@@ -1916,6 +1964,18 @@ fn pushText(raw_ctx: *anyopaque, emission: agent_runtime.TextEmission) !void {
 fn pushToolLifecycle(raw_ctx: *anyopaque, event: types.ToolLifecycleEvent) !void {
     const ctx: *AcpContext = @ptrCast(@alignCast(raw_ctx));
     switch (event) {
+        .provisional => |provisional| {
+            const tool_name = provisional.tool_name orelse return;
+            if (!tool_presentation.isProviderSearchAlias(tool_name)) return;
+            var arena_state = std.heap.ArenaAllocator.init(ctx.alloc);
+            defer arena_state.deinit();
+            _ = try ctx.sendToolCallPending(arena_state.allocator(), .{
+                .id = provisional.id.call_id,
+                .name = tool_name,
+                .arguments_json = "{}",
+                .provenance = .provider_executed,
+            });
+        },
         .authoritative_started => |started| {
             var arena_state = std.heap.ArenaAllocator.init(ctx.alloc);
             defer arena_state.deinit();
@@ -1925,7 +1985,8 @@ fn pushToolLifecycle(raw_ctx: *anyopaque, event: types.ToolLifecycleEvent) !void
                 .arguments_json = started.arguments_json orelse "{}",
             });
         },
-        .provisional, .progress, .terminal, .turn_finished => {},
+        .terminal => |terminal| try ctx.sendProviderTerminal(terminal.id.call_id, terminal.outcome),
+        .progress, .turn_finished => {},
     }
 }
 
@@ -2445,10 +2506,11 @@ fn activeMcp(ctx: *AcpContext) ?*mcp_runtime.McpRuntime {
 fn onBackgroundUrlReady(_: *anyopaque, _: u64, _: []const u8) void {}
 
 pub fn mapToolKind(tool_name: []const u8) acp_types.ToolCallKind {
+    if (tool_presentation.isProviderSearchAlias(tool_name)) return .search;
     if (std.mem.eql(u8, tool_name, "glob_files")) return .read;
     if (std.mem.eql(u8, tool_name, "grep_files")) return .search;
     if (std.mem.eql(u8, tool_name, "read_file")) return .read;
-    if (std.mem.eql(u8, tool_name, "web_fetch")) return .read;
+    if (std.mem.eql(u8, tool_name, "web_fetch")) return .fetch;
     if (std.mem.eql(u8, tool_name, "web_search")) return .search;
     if (std.mem.eql(u8, tool_name, "write_file")) return .edit;
     if (std.mem.eql(u8, tool_name, "edit_file")) return .edit;
@@ -2459,7 +2521,25 @@ pub fn mapToolKind(tool_name: []const u8) acp_types.ToolCallKind {
     return .other;
 }
 
+fn acpToolName(tool_name: []const u8) []const u8 {
+    return if (tool_presentation.isProviderSearchAlias(tool_name)) "web_search" else tool_name;
+}
+
+fn providerTerminalStatus(outcome: types.ToolOutcomeKind) ?acp_types.ToolCallStatus {
+    return switch (outcome) {
+        .completed => .completed,
+        .denied, .cancelled, .failed => .failed,
+        .deferred => null,
+    };
+}
+
 fn describeToolTitle(registry: tool_dispatch.Registry, arena: Allocator, call: ToolCall) ![]const u8 {
+    if (tool_presentation.isProviderSearchAlias(call.name)) {
+        return tool_presentation.formatPlainAction(arena, .{
+            .tool_registry = registry,
+            .call = call,
+        });
+    }
     if (tool_dispatch.toolCallPresentation(arena, registry, call)) |presentation| {
         return std.fmt.allocPrint(arena, "{s}", .{presentation.action_label});
     }
@@ -2562,8 +2642,18 @@ test "mapToolKind maps common tools" {
     try std.testing.expectEqual(acp_types.ToolCallKind.edit, mapToolKind("write_file"));
     try std.testing.expectEqual(acp_types.ToolCallKind.edit, mapToolKind("edit_file"));
     try std.testing.expectEqual(acp_types.ToolCallKind.search, mapToolKind("grep_files"));
+    try std.testing.expectEqual(acp_types.ToolCallKind.fetch, mapToolKind("web_fetch"));
+    try std.testing.expectEqual(acp_types.ToolCallKind.search, mapToolKind("exa_search"));
     try std.testing.expectEqual(acp_types.ToolCallKind.execute, mapToolKind("run_command"));
     try std.testing.expectEqual(acp_types.ToolCallKind.other, mapToolKind("unknown_tool"));
+}
+
+test "provider terminal status maps only terminal outcomes" {
+    try std.testing.expectEqual(acp_types.ToolCallStatus.completed, providerTerminalStatus(.completed).?);
+    try std.testing.expectEqual(acp_types.ToolCallStatus.failed, providerTerminalStatus(.failed).?);
+    try std.testing.expectEqual(acp_types.ToolCallStatus.failed, providerTerminalStatus(.denied).?);
+    try std.testing.expectEqual(acp_types.ToolCallStatus.failed, providerTerminalStatus(.cancelled).?);
+    try std.testing.expect(providerTerminalStatus(.deferred) == null);
 }
 
 test "ACP usage checkpoints honor the active session write boundary" {
@@ -3450,12 +3540,18 @@ test "ACP pending tool_call updates keep provider ids stable and dedupe" {
     const call = ToolCall{
         .id = "provider_call_7",
         .name = "terminal",
-        .arguments_json = "{\"action\":\"exec\",\"command\":\"ls\"}",
+        .arguments_json = "{\"action\":\"exec\",\"command\":\"ls\",\"api_key\":\"secret-value\"}",
     };
     const first = try ctx.sendToolCallPending(alloc, call);
     const second = try ctx.sendToolCallPending(alloc, call);
     try std.testing.expectEqualStrings("provider_call_7", first);
     try std.testing.expect(first.ptr == second.ptr);
+    _ = try ctx.sendToolCallPending(alloc, .{
+        .id = "malformed_call",
+        .name = "read_file",
+        .arguments_json = "{",
+        .argument_integrity = .malformed_json,
+    });
     try capture.sync(io_mod.getIo());
 
     var captured_file = try tmp.dir.openFile(io_mod.getIo(), "acp-tool-call.jsonl", .{});
@@ -3463,13 +3559,109 @@ test "ACP pending tool_call updates keep provider ids stable and dedupe" {
     const captured = try io_mod.readFileToEnd(alloc, &captured_file, 64 * 1024);
     var lines = std.mem.splitScalar(u8, captured, '\n');
     var pending_count: usize = 0;
+    var malformed_count: usize = 0;
     while (lines.next()) |line| {
         if (line.len == 0) continue;
-        try std.testing.expect(std.mem.find(u8, line, "\"toolCallId\":\"provider_call_7\"") != null);
-        try std.testing.expect(std.mem.find(u8, line, "\"sessionUpdate\":\"tool_call\"") != null);
-        pending_count += 1;
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, line, .{});
+        defer parsed.deinit();
+        const update = parsed.value.object.get("params").?.object.get("update").?.object;
+        try std.testing.expectEqualStrings("tool_call", update.get("sessionUpdate").?.string);
+        const call_id = update.get("toolCallId").?.string;
+        if (std.mem.eql(u8, call_id, "provider_call_7")) {
+            try std.testing.expectEqualStrings("terminal", update.get("name").?.string);
+            const raw_input = update.get("rawInput").?.object;
+            try std.testing.expectEqualStrings("exec", raw_input.get("action").?.string);
+            try std.testing.expectEqualStrings("ls", raw_input.get("command").?.string);
+            try std.testing.expectEqualStrings("[REDACTED]", raw_input.get("api_key").?.string);
+            pending_count += 1;
+        } else if (std.mem.eql(u8, call_id, "malformed_call")) {
+            try std.testing.expect(update.get("rawInput") == null);
+            malformed_count += 1;
+        }
     }
     try std.testing.expectEqual(@as(usize, 1), pending_count);
+    try std.testing.expectEqual(@as(usize, 1), malformed_count);
+}
+
+test "ACP provider search lifecycle publishes one public terminal update" {
+    var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena_state.deinit();
+    const alloc = arena_state.allocator();
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var capture = try tmp.dir.createFile(io_mod.getIo(), "acp-provider-search.jsonl", .{ .read = true });
+    defer capture.close(io_mod.getIo());
+    var state = try initTestAcpState(alloc, "/tmp/workspace", .ask);
+    defer state.deinit();
+    state.writer = .{ .stdout = capture };
+    var ctx = AcpContext{
+        .alloc = alloc,
+        .state = &state,
+        .session_id = "session_1",
+    };
+    defer ctx.deinitPublishedToolCalls();
+
+    try pushToolLifecycle(&ctx, .{ .provisional = .{
+        .id = .{ .turn_id = 1, .call_id = "provider_search_1" },
+        .tool_name = "exa_search",
+        .activity_kind = .read,
+    } });
+    const completed = types.ToolLifecycleEvent{ .terminal = .{
+        .id = .{ .turn_id = 1, .call_id = "provider_search_1" },
+        .outcome = .{ .kind = .completed, .summary = "Searched web" },
+    } };
+    try pushToolLifecycle(&ctx, completed);
+    try pushToolLifecycle(&ctx, completed);
+    try pushToolLifecycle(&ctx, .{ .authoritative_started = .{
+        .id = .{ .turn_id = 1, .call_id = "read_1" },
+        .reconciles_provisional_call_id = null,
+        .tool_name = "read_file",
+        .activity_kind = .read,
+        .arguments_json = "{\"path\":\"README.md\"}",
+    } });
+    try pushToolLifecycle(&ctx, .{ .terminal = .{
+        .id = .{ .turn_id = 1, .call_id = "read_1" },
+        .outcome = .{ .kind = .completed, .summary = "Read README.md" },
+    } });
+    try capture.sync(io_mod.getIo());
+
+    var captured_file = try tmp.dir.openFile(io_mod.getIo(), "acp-provider-search.jsonl", .{});
+    defer captured_file.close(io_mod.getIo());
+    const captured = try io_mod.readFileToEnd(alloc, &captured_file, 64 * 1024);
+    var lines = std.mem.splitScalar(u8, captured, '\n');
+    var provider_pending: usize = 0;
+    var provider_completed: usize = 0;
+    var read_pending: usize = 0;
+    var read_completed: usize = 0;
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        try std.testing.expect(std.mem.find(u8, line, "exa_search") == null);
+        var parsed = try std.json.parseFromSlice(std.json.Value, alloc, line, .{});
+        defer parsed.deinit();
+        const update = parsed.value.object.get("params").?.object.get("update").?.object;
+        const call_id = update.get("toolCallId").?.string;
+        const session_update = update.get("sessionUpdate").?.string;
+        if (std.mem.eql(u8, call_id, "provider_search_1")) {
+            if (std.mem.eql(u8, session_update, "tool_call")) {
+                provider_pending += 1;
+                try std.testing.expectEqualStrings("web_search", update.get("name").?.string);
+                try std.testing.expectEqualStrings("Searching web", update.get("title").?.string);
+                try std.testing.expectEqualStrings("search", update.get("kind").?.string);
+                try std.testing.expectEqual(@as(usize, 0), update.get("rawInput").?.object.count());
+            } else if (std.mem.eql(u8, session_update, "tool_call_update")) {
+                provider_completed += 1;
+                try std.testing.expectEqualStrings("completed", update.get("status").?.string);
+            }
+        } else if (std.mem.eql(u8, call_id, "read_1")) {
+            if (std.mem.eql(u8, session_update, "tool_call")) read_pending += 1;
+            if (std.mem.eql(u8, session_update, "tool_call_update")) read_completed += 1;
+        }
+    }
+    try std.testing.expectEqual(@as(usize, 1), provider_pending);
+    try std.testing.expectEqual(@as(usize, 1), provider_completed);
+    try std.testing.expectEqual(@as(usize, 1), read_pending);
+    try std.testing.expectEqual(@as(usize, 0), read_completed);
 }
 
 test "ACP propagateGrant stores deduped runtime session grants" {

--- a/src/acp/types.zig
+++ b/src/acp/types.zig
@@ -138,15 +138,29 @@ pub fn writeUserMessageChunk(w: *std.Io.Writer, text: []const u8) !void {
     try w.writeAll("}}");
 }
 
-pub fn writeToolCall(w: *std.Io.Writer, tool_call_id: []const u8, title: []const u8, kind: ToolCallKind, status: ToolCallStatus) !void {
+pub fn writeToolCall(
+    w: *std.Io.Writer,
+    tool_call_id: []const u8,
+    name: []const u8,
+    title: []const u8,
+    kind: ToolCallKind,
+    status: ToolCallStatus,
+    raw_input: ?std.json.Value,
+) !void {
     try w.writeAll("{\"sessionUpdate\":\"tool_call\",\"toolCallId\":");
     try writeJsonStr(tool_call_id, w);
+    try w.writeAll(",\"name\":");
+    try writeJsonStr(name, w);
     try w.writeAll(",\"title\":");
     try writeJsonStr(title, w);
     try w.writeAll(",\"kind\":");
     try writeJsonStr(kind.jsonString(), w);
     try w.writeAll(",\"status\":");
     try writeJsonStr(status.jsonString(), w);
+    if (raw_input) |value| {
+        try w.writeAll(",\"rawInput\":");
+        try std.json.Stringify.value(value, .{}, w);
+    }
     try w.writeAll("}");
 }
 
@@ -216,9 +230,33 @@ test "writeToolCall produces valid json" {
     const alloc = std.testing.allocator;
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
-    try writeToolCall(&out.writer, "call_001", "Reading file", .read, .pending);
-    try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"toolCallId\":\"call_001\"") != null);
-    try std.testing.expect(std.mem.find(u8, out.writer.buffered(), "\"kind\":\"read\"") != null);
+    var raw_input = try std.json.parseFromSlice(
+        std.json.Value,
+        alloc,
+        "{\"path\":\"README.md\"}",
+        .{},
+    );
+    defer raw_input.deinit();
+
+    try writeToolCall(
+        &out.writer,
+        "call_001",
+        "read_file",
+        "Reading file",
+        .read,
+        .pending,
+        raw_input.value,
+    );
+    var parsed = try std.json.parseFromSlice(std.json.Value, alloc, out.writer.buffered(), .{});
+    defer parsed.deinit();
+
+    try std.testing.expectEqualStrings("call_001", parsed.value.object.get("toolCallId").?.string);
+    try std.testing.expectEqualStrings("read_file", parsed.value.object.get("name").?.string);
+    try std.testing.expectEqualStrings("read", parsed.value.object.get("kind").?.string);
+    try std.testing.expectEqualStrings(
+        "README.md",
+        parsed.value.object.get("rawInput").?.object.get("path").?.string,
+    );
 }
 
 test "writePromptResponse produces valid json" {
@@ -240,6 +278,7 @@ test "ToolCallKind jsonString values" {
     try std.testing.expectEqualStrings("edit", ToolCallKind.edit.jsonString());
     try std.testing.expectEqualStrings("execute", ToolCallKind.execute.jsonString());
     try std.testing.expectEqualStrings("search", ToolCallKind.search.jsonString());
+    try std.testing.expectEqualStrings("fetch", ToolCallKind.fetch.jsonString());
     try std.testing.expectEqualStrings("other", ToolCallKind.other.jsonString());
 }
 

--- a/src/core/agent/execution_memory.zig
+++ b/src/core/agent/execution_memory.zig
@@ -508,7 +508,7 @@ pub fn dupeRedactedToolCall(alloc: Allocator, call: ToolCall) !ToolCall {
     errdefer alloc.free(id);
     const name = try alloc.dupe(u8, call.name);
     errdefer alloc.free(name);
-    const arguments_json = try redactToolArgumentsJsonForTool(
+    const arguments_json = try redactToolArgumentsJson(
         alloc,
         call.name,
         call.arguments_json,
@@ -533,7 +533,7 @@ const ArgumentRedactionPolicy = struct {
     web_fetch: bool = false,
 };
 
-fn redactToolArgumentsJsonForTool(
+pub fn redactToolArgumentsJson(
     alloc: Allocator,
     tool_name: []const u8,
     arguments_json: []const u8,

--- a/tests/e2e/acp.test.ts
+++ b/tests/e2e/acp.test.ts
@@ -7066,6 +7066,11 @@ describe("acp: model-independent", () => {
         expect(permission).toBeDefined();
         expect(permission.params.sessionId).toBeDefined();
         expect(permission.params.toolCall.toolCallId).toBe("approved_call_1");
+        expect(permission.params.toolCall.name).toBe("write_file");
+        expect(permission.params.toolCall.rawInput).toEqual({
+          path: target,
+          content: "first\n",
+        });
         expect(permission.params.options).toEqual([
           { optionId: "allow_once", name: "Allow once", kind: "allow_once" },
           { optionId: "allow_always", name: "Allow for this session", kind: "allow_always" },
@@ -7079,6 +7084,11 @@ describe("acp: model-independent", () => {
         const permissionIndex = first.messages.indexOf(permission);
         expect(pendingIndex).toBeGreaterThanOrEqual(0);
         expect(pendingIndex).toBeLessThan(permissionIndex);
+        expect(first.messages[pendingIndex]?.params.update.name).toBe("write_file");
+        expect(first.messages[pendingIndex]?.params.update.rawInput).toEqual({
+          path: target,
+          content: "first\n",
+        });
         const firstWire = JSON.stringify(first.messages);
         expect(firstWire).toContain('"toolCallId":"approved_call_1"');
         expect(firstWire).toContain('"status":"completed"');

--- a/tests/e2e/web-fetch-fake-network.test.ts
+++ b/tests/e2e/web-fetch-fake-network.test.ts
@@ -536,11 +536,22 @@ describe("web_fetch Gateway fixture", () => {
           (message) =>
             message.method === "session/update" &&
             message.params?.update?.sessionUpdate === "tool_call" &&
-            message.params.update.kind === "read" &&
-            message.params.update.title === "Fetching",
+            message.params.update.toolCallId === "fetch_outer_1",
         );
 
         expect(fetchStarts).toHaveLength(1);
+        expect(fetchStarts[0]?.params.update).toEqual({
+          sessionUpdate: "tool_call",
+          toolCallId: "fetch_outer_1",
+          name: "web_fetch",
+          title: "Fetching",
+          kind: "fetch",
+          status: "pending",
+          rawInput: {
+            url: "https://example.com/docs",
+            prompt: "legacy",
+          },
+        });
       } finally {
         await client.close();
         gateway.stop();

--- a/tests/e2e/web-search-fake-gateway.test.ts
+++ b/tests/e2e/web-search-fake-gateway.test.ts
@@ -1027,6 +1027,9 @@ describe("web_search Gateway fixture", () => {
         await startAcpCodeSession(client);
         const messages = await runAcpPrompt(client, "Search the web for the latest Zig release.");
         const updates = JSON.stringify(messages);
+        const toolUpdates = messages
+          .filter((message: any) => message.params?.update?.toolCallId === "search_direct_1")
+          .map((message: any) => message.params.update);
 
         expect(gateway.requests).toHaveLength(2);
         expect(gateway.requests[0].body).toContain("gateway.exa_search");
@@ -1042,6 +1045,21 @@ describe("web_search Gateway fixture", () => {
         );
         expect(updates).not.toContain("Searching latest Zig release");
         expect(updates).not.toContain("Found 1 result for latest Zig release");
+        expect(toolUpdates).toHaveLength(2);
+        expect(toolUpdates[0]).toEqual({
+          sessionUpdate: "tool_call",
+          toolCallId: "search_direct_1",
+          name: "web_search",
+          title: "Searching web",
+          kind: "search",
+          status: "pending",
+          rawInput: {},
+        });
+        expect(toolUpdates[1]?.sessionUpdate).toBe("tool_call_update");
+        expect(toolUpdates[1]?.status).toBe("completed");
+        expect(updates).not.toContain("exa_search");
+        expect(updates).not.toContain("perplexity_search");
+        expect(updates).not.toContain("parallel_search");
         expect(updates).toContain(SOURCE_URL);
       } finally {
         await client.close();


### PR DESCRIPTION
## Summary

- Include public tool names and redacted input when ACP tool calls begin.
- Report provider-backed searches as `web_search` without exposing routing aliases.
- Publish one terminal ACP update for each provider-backed search.
- Classify `web_fetch` calls with the ACP `fetch` kind.