### PR TITLE
Show only selected skill names

### DIFF
--- a/src/ui/assistant/user_message_card.zig
+++ b/src/ui/assistant/user_message_card.zig
@@ -281,10 +281,6 @@ fn renderSkillTokensForCard(
         try out.writer.writeAll(text[pos..token.raw_start]);
         try out.writer.writeAll(accent_style);
         try out.writer.writeAll(token.name);
-        if (visual_layout.skillTokenSourceLabel(token)) |source_label| {
-            try out.writer.writeAll(visual_layout.skill_source_separator);
-            try out.writer.writeAll(source_label);
-        }
         try out.writer.writeAll(restore_prompt_text_style);
         pos = token.raw_end;
     }
@@ -569,7 +565,7 @@ test "buildUserPromptCardWithSkillTokens colors selected skills without dollar p
     try std.testing.expect(std.mem.find(u8, card, "$review") == null);
 }
 
-test "buildUserPromptCardWithSkillTokens labels an ambiguous source" {
+test "buildUserPromptCardWithSkillTokens hides an ambiguous source" {
     setStyle(false, null);
     const alloc = std.testing.allocator;
     const tokens = [_]visual_layout.SkillTokenSpan{.{
@@ -582,7 +578,8 @@ test "buildUserPromptCardWithSkillTokens labels an ambiguous source" {
     const card = try buildUserPromptCardWithSkillTokens(alloc, "use $review now", &.{}, 80, &tokens);
     defer alloc.free(card);
 
-    try std.testing.expect(std.mem.find(u8, card, "review · workspace .codex") != null);
+    try std.testing.expect(std.mem.find(u8, card, "review") != null);
+    try std.testing.expect(std.mem.find(u8, card, "workspace .codex") == null);
     try std.testing.expect(std.mem.find(u8, card, "$review") == null);
 }
 

--- a/src/ui/footer/input_presentation.zig
+++ b/src/ui/footer/input_presentation.zig
@@ -1034,31 +1034,6 @@ fn appendLayoutUnitContent(
             }
             try row.appendSlice(alloc, ui_render.tag_style);
             try row_text.appendClipped(alloc, row, token.name, @intCast(@min(emit_cells, std.math.maxInt(u16))));
-            if (visual_layout.skillTokenSourceLabel(token)) |source_label| {
-                const emitted_name_cells = @min(display_width.visibleWidth(token.name), emit_cells);
-                const label_cells = emit_cells - emitted_name_cells;
-                if (label_cells > 0) {
-                    try row_text.appendClipped(
-                        alloc,
-                        row,
-                        visual_layout.skill_source_separator,
-                        @intCast(@min(label_cells, std.math.maxInt(u16))),
-                    );
-                    const emitted_separator_cells = @min(
-                        display_width.visibleWidth(visual_layout.skill_source_separator),
-                        label_cells,
-                    );
-                    const source_cells = label_cells - emitted_separator_cells;
-                    if (source_cells > 0) {
-                        try row_text.appendClipped(
-                            alloc,
-                            row,
-                            source_label,
-                            @intCast(@min(source_cells, std.math.maxInt(u16))),
-                        );
-                    }
-                }
-            }
             try row.appendSlice(alloc, ui_render.reset_style);
             remaining_cells.* -= emit_cells;
             omitted_positive_unit.* = unit.cell_width > emit_cells;
@@ -1129,6 +1104,31 @@ test "composer badge labels a later-turn image with its own id" {
     try std.testing.expectEqual(@as(usize, 1), composed.rows.items.len);
     try std.testing.expect(std.mem.find(u8, composed.rows.items[0].items, "[Image 2]") != null);
     try std.testing.expect(std.mem.find(u8, composed.rows.items[0].items, "[Image 1]") == null);
+}
+
+test "composer skill token shows only its name" {
+    const alloc = std.testing.allocator;
+    const skill_tokens = [_]visual_layout.SkillTokenSpan{.{
+        .raw_start = 0,
+        .raw_end = "$review".len,
+        .name = "review",
+        .path = "/tmp/review",
+        .display_source = .workspace_codex,
+    }};
+    const source = visual_layout.Source{
+        .input = "$review",
+        .cursor = "$review".len,
+        .terminal_cols = 40,
+        .skill_tokens = &skill_tokens,
+    };
+    const summary = visual_layout.summarize(source, null);
+    const window = visual_layout.visibleWindow(summary.cursor.row_index, summary.total_rows, 1);
+    var composed = try composeVisibleInputRows(alloc, source, window);
+    defer composed.deinit(alloc);
+
+    try std.testing.expectEqual(@as(usize, 1), composed.rows.items.len);
+    try std.testing.expect(std.mem.find(u8, composed.rows.items[0].items, "review") != null);
+    try std.testing.expect(std.mem.find(u8, composed.rows.items[0].items, "workspace .codex") == null);
 }
 
 test "composeVisibleInputRows avoids clear-to-eol after full-width input" {

--- a/src/ui/input/visual_layout.zig
+++ b/src/ui/input/visual_layout.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const display_width = @import("../../core/shared/display_width.zig");
 const image_attachments = @import("../../core/images/image_attachments.zig");
 const entity_spans = @import("../../core/shared/entity_spans.zig");
-const skill_runtime = @import("../../core/skills/skill_runtime.zig");
 const types = @import("../../core/shared/types.zig");
 const paste_blocks = @import("../../core/input/pasted_blocks.zig");
 const registered_entities = @import("../../core/input/registered_entities.zig");
@@ -30,20 +29,8 @@ pub const RawRange = struct {
     end: usize,
 };
 
-pub const skill_source_separator = " · ";
-
-pub fn skillTokenSourceLabel(token: SkillTokenSpan) ?[]const u8 {
-    const source = token.display_source orelse return null;
-    return skill_runtime.skillSourceShortLabel(source);
-}
-
 fn skillTokenVisibleWidth(token: SkillTokenSpan) usize {
-    var width = display_width.visibleWidth(token.name);
-    if (skillTokenSourceLabel(token)) |label| {
-        width +|= display_width.visibleWidth(skill_source_separator);
-        width +|= display_width.visibleWidth(label);
-    }
-    return width;
+    return display_width.visibleWidth(token.name);
 }
 
 pub const ImageTokenSpan = entity_spans.ImageTokenSpan;
@@ -1344,7 +1331,7 @@ test "visual layout handles direct-limit and longer restored input without alloc
     try std.testing.expectEqual(@as(usize, countRows(testSource(direct, direct.len, 80))), direct_summary.total_rows);
 }
 
-test "skill token width includes an ambiguous source label" {
+test "skill token width ignores internal source metadata" {
     const unique = SkillTokenSpan{
         .raw_start = 0,
         .raw_end = "$review".len,
@@ -1360,8 +1347,5 @@ test "skill token width includes an ambiguous source label" {
     };
 
     try std.testing.expectEqual(@as(usize, "review".len), skillTokenVisibleWidth(unique));
-    try std.testing.expectEqual(
-        display_width.visibleWidth("review · workspace .codex"),
-        skillTokenVisibleWidth(ambiguous),
-    );
+    try std.testing.expectEqual(@as(usize, "review".len), skillTokenVisibleWidth(ambiguous));
 }

--- a/src/ui/render.zig
+++ b/src/ui/render.zig
@@ -519,10 +519,6 @@ fn copyVisualRowToBuffer(source: visual_layout.Source, target_row: usize, out: [
                     const token = source.skill_tokens[token_index];
                     if (unit.cell_width <= remaining_cells) {
                         appendBytesToBuffer(out, &len, token.name);
-                        if (visual_layout.skillTokenSourceLabel(token)) |source_label| {
-                            appendBytesToBuffer(out, &len, visual_layout.skill_source_separator);
-                            appendBytesToBuffer(out, &len, source_label);
-                        }
                         remaining_cells -= unit.cell_width;
                         omitted_positive_unit = false;
                     } else {

--- a/tests/e2e/tui-composer-edit-contracts.test.ts
+++ b/tests/e2e/tui-composer-edit-contracts.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { FX_BIN } from "../evals/eval-helpers";
 import {
+  composerContains,
   FAKE_GATEWAY_MODEL,
   fakeGatewayFinalText,
   startFakeGateway,
@@ -816,12 +817,17 @@ for (
 }
 
 tmuxTest(
-  "history recall preserves the selected duplicate skill source",
+  "history recall preserves duplicate skill provenance without showing it",
   async () => {
     const active = await startFx(true, 2, true);
 
     await selectReviewSkill(active, true);
-    await active.waitForText("review · workspace skills/", TIMEOUT);
+    await active.waitForPane(
+      (pane) =>
+        composerContains(pane, "review") &&
+        !composerContains(pane, "review · workspace skills/"),
+      TIMEOUT,
+    );
     await active.sendLiteralText("history skill");
     await active.sendKeys("Enter");
     await waitForGatewayRequest();
@@ -834,8 +840,13 @@ tmuxTest(
     );
 
     await active.sendKeys("Up");
-    await active.waitForText("history skill", TIMEOUT);
-    await active.waitForText("review · workspace skills/", TIMEOUT);
+    await active.waitForPane(
+      (pane) =>
+        composerContains(pane, "history skill") &&
+        composerContains(pane, "review") &&
+        !composerContains(pane, "review · workspace skills/"),
+      TIMEOUT,
+    );
     await active.sendKeys("Enter");
     await waitForGatewayRequest(2);
 


### PR DESCRIPTION
## Summary

- Show selected skill tokens by name only in the composer and submitted messages.
- Keep source details in the picker so duplicate skills remain distinguishable.
- Preserve the exact selected skill through editing and prompt history.