### PR TITLE
Open skill menus from any dollar trigger

### DIFF
--- a/src/core/app/app_input_runtime.zig
+++ b/src/core/app/app_input_runtime.zig
@@ -1713,11 +1713,12 @@ pub fn Runtime(comptime App: type) type {
                             selection.start
                         else
                             app.input_runtime.edit_state.cursor;
-                        if (byte == '$' and insertion_start == 0 and !helpMenuActive(app) and !commandSkillsMenuActive(app) and !modelMenuActive(app)) {
+                        if (byte == '$' and !helpMenuActive(app) and !commandSkillsMenuActive(app) and !modelMenuActive(app)) {
                             if ((try insertComposerSliceBounded(app, &.{byte}, max_input_len, false)) == .limit_exceeded) {
                                 try input_limit_feedback.report(App, app, .composer, 1);
                                 return;
                             }
+                            app.input_runtime.picker.resetInlinePickerEpisode();
                             if (comptime @hasField(App, "skills")) {
                                 app.skills.openMenuWithQuery(.dollar, .{ .start = insertion_start, .end = insertion_start + 1 }, "");
                             }
@@ -1909,7 +1910,7 @@ pub fn Runtime(comptime App: type) type {
 
         fn skillsMenuActive(app: *App) bool {
             if (comptime !@hasField(App, "skills")) return false;
-            return app.skills.menu.active;
+            return app.skills.menuVisible();
         }
 
         fn modelMenuActive(app: *App) bool {
@@ -2954,7 +2955,7 @@ pub fn Runtime(comptime App: type) type {
 
         fn cycleSkillsMenuSource(app: *App, delta: i32) bool {
             if (comptime !@hasField(App, "skills")) return false;
-            if (!app.skills.menu.active) return false;
+            if (!app.skills.menuVisible()) return false;
             return app.skills.moveMenuSourceFilter(delta);
         }
 
@@ -3174,9 +3175,11 @@ pub fn Runtime(comptime App: type) type {
 
         fn cancelSkillsMenu(app: *App) bool {
             if (comptime !@hasField(App, "skills")) return false;
-            if (!app.skills.menu.active) return false;
-            const clear_query = !app.skills.menu.origin.isMention();
+            if (!app.skills.menuVisible()) return false;
+            const mention = app.skills.menu.origin.isMention();
+            const clear_query = !mention;
             app.skills.closeMenu();
+            if (mention) app.input_runtime.picker.dismissInlinePicker(.skill);
             if (clear_query) {
                 app.input_runtime.inputResetState().clearCurrent(app.alloc);
                 paste_blocks.clearBlocks(app.alloc, &app.input_runtime.entities.pasted_blocks);
@@ -5548,9 +5551,19 @@ test "app_input_runtime dollar opens skills menu and Escape preserves raw text" 
     try Runtime(RoutingFakeApp).resolveEscape(&app, false, 102);
     try std.testing.expect(!app.skills.menu.active);
     try std.testing.expectEqualStrings("$s", app.input_runtime.edit_state.input.items);
+    try std.testing.expect(app.input_runtime.picker.isInlinePickerDismissed(.skill));
+
+    try Runtime(RoutingFakeApp).handleByte(&app, 'c', 4096, 103);
+    try std.testing.expect(!app.skills.menu.active);
+    try std.testing.expect(input_completion_runtime.CompletionRuntime(RoutingFakeApp).visibleInlineSkillCompletion(&app) == null);
+
+    try Runtime(RoutingFakeApp).handleByte(&app, '$', 4096, 104);
+    try std.testing.expect(app.skills.menu.active);
+    try std.testing.expect(!app.input_runtime.picker.isInlinePickerDismissed(.skill));
+    try std.testing.expectEqual(@as(usize, "$sc".len), app.skills.menu.target.?.start);
 }
 
-test "app_input_runtime non-leading dollar stays in the composer" {
+test "app_input_runtime typed dollar opens an anchored skills menu at every composer position" {
     const alloc = std.testing.allocator;
     const skills = [_]skill_runtime.Skill{.{
         .name = "scale",
@@ -5558,7 +5571,7 @@ test "app_input_runtime non-leading dollar stays in the composer" {
         .path = "/tmp/scale/SKILL.md",
         .source = .global_fx,
     }};
-    const inputs = [_][]const u8{ " $", "hello $" };
+    const inputs = [_][]const u8{ " $", "hello $", "price$" };
 
     for (inputs) |input| {
         var app = try RoutingFakeApp.init(alloc);
@@ -5568,7 +5581,11 @@ test "app_input_runtime non-leading dollar stays in the composer" {
         try feedRoutingBytes(&app, input);
 
         try std.testing.expectEqualStrings(input, app.input_runtime.edit_state.input.items);
-        try std.testing.expect(!app.skills.menu.active);
+        try std.testing.expect(app.skills.menu.active);
+        try std.testing.expectEqual(skill_runtime.SkillMenuOrigin.dollar, app.skills.menu.origin);
+        try std.testing.expectEqual(input.len - 1, app.skills.menu.target.?.start);
+        try std.testing.expectEqual(input.len, app.skills.menu.target.?.end);
+        try std.testing.expectEqualStrings("", app.skills.menu.query());
     }
 }
 
@@ -5585,7 +5602,7 @@ test "app_input_runtime Tab and Right Arrow accept visible inline skill completi
         var app = try RoutingFakeApp.init(alloc);
         defer app.deinit();
         app.skills.items = @constCast(&skills);
-        try feedRoutingBytes(&app, "explain $man");
+        try app.input_runtime.textReplacementState().replace(alloc, "explain $man");
 
         const completion = input_completion_runtime.CompletionRuntime(RoutingFakeApp).visibleInlineSkillCompletion(&app).?;
         try std.testing.expectEqualStrings("aged-menu", completion.suffix);
@@ -5650,7 +5667,7 @@ test "app_input_runtime Right Arrow collapses selection before inline completion
     var app = try RoutingFakeApp.init(alloc);
     defer app.deinit();
     app.skills.items = @constCast(&skills);
-    try feedRoutingBytes(&app, "explain $man");
+    try app.input_runtime.textReplacementState().replace(alloc, "explain $man");
     const end = app.input_runtime.edit_state.input.items.len;
     _ = app.input_runtime.selectionState().begin(end - 1);
     _ = app.input_runtime.selectionState().extend(end);
@@ -5741,7 +5758,7 @@ test "app_input_runtime inline skill acceptance preserves input on limit rejecti
         .source = .global_fx,
     }};
     app.skills.items = @constCast(&skills);
-    try feedRoutingBytes(&app, "explain $man");
+    try app.input_runtime.textReplacementState().replace(alloc, "explain $man");
     const original_len = app.input_runtime.edit_state.input.items.len;
 
     try Runtime(RoutingFakeApp).handleByte(&app, '\t', original_len, 100);
@@ -5767,7 +5784,8 @@ test "app_input_runtime no-match dollar text keeps spaces and submits raw" {
     app.skills.items = @constCast(&skills);
 
     try feedRoutingBytes(&app, "Explain echo $HOME");
-    try std.testing.expect(!app.skills.menu.active);
+    try std.testing.expect(app.skills.menu.active);
+    try std.testing.expect(!app.skills.menuVisible());
     try std.testing.expectEqualStrings("Explain echo $HOME", app.input_runtime.edit_state.input.items);
 
     try feedRoutingBytes(&app, " please");
@@ -5897,16 +5915,43 @@ test "app_input_runtime zero-match dollar query recovers matches on backspace" {
 
     try feedRoutingBytes(&app, "$mzz");
     try std.testing.expect(app.skills.menu.active);
+    try std.testing.expect(!app.skills.menuVisible());
     try std.testing.expect(app.skills.selectedMenuSkill() == null);
 
     try feedRoutingBytes(&app, "\x7f\x7f");
     try std.testing.expect(app.skills.menu.active);
+    try std.testing.expect(app.skills.menuVisible());
     try std.testing.expectEqualStrings("m", app.skills.menu.query());
     try std.testing.expect(app.skills.selectedMenuSkill() != null);
 
     try feedRoutingBytes(&app, "\r");
     try std.testing.expectEqual(@as(usize, 1), app.input_runtime.entities.skill_tokens.items.len);
     try std.testing.expectEqualStrings("managed", app.input_runtime.entities.skill_tokens.items[0].name);
+}
+
+test "app_input_runtime hidden zero-match dollar menu yields navigation to the composer" {
+    const alloc = std.testing.allocator;
+    var app = try RoutingFakeApp.init(alloc);
+    defer app.deinit();
+    const skills = [_]skill_runtime.Skill{.{
+        .name = "managed",
+        .description = "",
+        .path = "/tmp/managed/SKILL.md",
+        .source = .global_fx,
+    }};
+    app.skills.items = @constCast(&skills);
+
+    try feedRoutingBytes(&app, "$missing");
+    try std.testing.expect(app.skills.menu.active);
+    try std.testing.expect(!app.skills.menuVisible());
+    try std.testing.expectEqual("$missing".len, app.input_runtime.edit_state.cursor);
+
+    try Runtime(RoutingFakeApp).routeModifiedHistory(&app, .up, 1);
+
+    try std.testing.expectEqualStrings("$missing", app.input_runtime.edit_state.input.items);
+    try std.testing.expectEqual(@as(usize, 0), app.input_runtime.edit_state.cursor);
+    try std.testing.expect(app.skills.menu.active);
+    try std.testing.expect(!app.skills.menuVisible());
 }
 
 test "app_input_runtime Escape cancels an idle session picker before empty-composer handling" {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -2640,7 +2640,7 @@ pub fn Runtime(comptime App: type) type {
         }
 
         fn skillsMenuActive(app: *const App) bool {
-            if (comptime @hasField(App, "skills")) return app.skills.menu.active;
+            if (comptime @hasField(App, "skills")) return app.skills.menuVisible();
             return false;
         }
 

--- a/src/core/app/input_completion_runtime.zig
+++ b/src/core/app/input_completion_runtime.zig
@@ -717,7 +717,7 @@ pub fn CompletionRuntime(comptime App: type) type {
             if (app.input_runtime.help_menu.active or app.input_runtime.settings_menu.active) return true;
             if (comptime @hasField(App, "skills")) {
                 if (comptime @hasField(@TypeOf(app.skills), "menu")) {
-                    if (app.skills.menu.active) return true;
+                    if (app.skills.menuVisible()) return true;
                 }
             }
             if (comptime @hasField(App, "model_cache")) {
@@ -1390,12 +1390,7 @@ const InlineCompletionTestApp = struct {
     input_runtime: core_input_runtime.Runtime = .{},
     pending_images: std.ArrayList(types.ImageAttachment) = .empty,
     queued_prompt_review: input_queue_runtime.State = .{},
-    skills: struct {
-        items: []const skill_runtime.Skill = &.{},
-        menu: struct {
-            active: bool = false,
-        } = .{},
-    } = .{},
+    skills: skill_runtime.Runtime = .{},
     model_cache: struct {
         menu: struct {
             active: bool = false,
@@ -1625,7 +1620,7 @@ test "root slash completion follows multiline and command argument ownership" {
     }};
     var app = InlineCompletionTestApp{
         .alloc = alloc,
-        .skills = .{ .items = &skills },
+        .skills = .{ .items = @constCast(&skills) },
     };
     defer app.deinit();
 
@@ -1648,7 +1643,7 @@ test "inline skill completion stays inactive when its suffix cannot render" {
     }};
     var app = InlineCompletionTestApp{
         .alloc = alloc,
-        .skills = .{ .items = &skills },
+        .skills = .{ .items = @constCast(&skills) },
     };
     defer app.deinit();
     try app.input_runtime.textReplacementState().replace(alloc, "x $man");
@@ -1694,7 +1689,7 @@ test "model picker ownership suppresses inline skill completion" {
     }};
     var app = InlineCompletionTestApp{
         .alloc = alloc,
-        .skills = .{ .items = &skills },
+        .skills = .{ .items = @constCast(&skills) },
     };
     defer app.deinit();
     try app.input_runtime.textReplacementState().replace(alloc, "/model anything $man");
@@ -1722,7 +1717,7 @@ test "dedicated catalog ownership suppresses inline skill completion" {
     }};
     var app = InlineCompletionTestApp{
         .alloc = alloc,
-        .skills = .{ .items = &skills },
+        .skills = .{ .items = @constCast(&skills) },
     };
     defer app.deinit();
     try app.input_runtime.textReplacementState().replace(alloc, "x $man");

--- a/src/core/input/picker_state.zig
+++ b/src/core/input/picker_state.zig
@@ -362,19 +362,19 @@ fn findFilePickerQuery(items: []const u8, cursor: usize) ?FilePickerQuery {
 fn findInlineSkillQuery(items: []const u8, cursor: usize) ?InlineSkillQuery {
     if (cursor != items.len) return null;
 
-    var token_start = cursor;
-    while (token_start > 0 and !isFilePickerTerminator(items[token_start - 1])) {
-        token_start -= 1;
+    var index = cursor;
+    while (index > 0) {
+        const byte = items[index - 1];
+        if (isFilePickerTerminator(byte)) return null;
+        index -= 1;
+        if (byte != '$') continue;
+        return .{
+            .query = items[index + 1 .. cursor],
+            .dollar_offset = index,
+            .token_start = index + 1,
+        };
     }
-    if (token_start == 0 or token_start == cursor or items[token_start] != '$') return null;
-
-    const query_start = token_start + 1;
-    if (query_start == cursor) return null;
-    return .{
-        .query = items[query_start..cursor],
-        .dollar_offset = token_start,
-        .token_start = query_start,
-    };
+    return null;
 }
 
 fn findInlineSlashQuery(items: []const u8, cursor: usize) ?InlineSlashQuery {
@@ -444,6 +444,41 @@ test "picker state resolves model file skill and slash queries" {
 
     try editor.setText(alloc, "then /help");
     try std.testing.expectEqualStrings("/help", state.activeInlineSlashQuery(&editor).?.prefix);
+}
+
+test "skill query binds the nearest dollar anywhere at the cursor" {
+    const alloc = std.testing.allocator;
+    var editor: editor_state.State = .{};
+    defer editor.deinit(alloc);
+    var state: State = .{};
+    defer state.deinit(alloc);
+
+    const cases = [_]struct {
+        input: []const u8,
+        query: []const u8,
+        dollar_offset: usize,
+    }{
+        .{ .input = "$", .query = "", .dollar_offset = 0 },
+        .{ .input = "$blue", .query = "blue", .dollar_offset = 0 },
+        .{ .input = "use $", .query = "", .dollar_offset = "use ".len },
+        .{ .input = "price$100", .query = "100", .dollar_offset = "price".len },
+        .{ .input = "one$two$three", .query = "three", .dollar_offset = "one$two".len },
+    };
+
+    for (cases) |case| {
+        try editor.setText(alloc, case.input);
+        const maybe_query = state.activeInlineSkillQuery(&editor);
+        try std.testing.expect(maybe_query != null);
+        const query = maybe_query.?;
+        try std.testing.expectEqualStrings(case.query, query.query);
+        try std.testing.expectEqual(case.dollar_offset, query.dollar_offset);
+        try std.testing.expectEqual(case.dollar_offset + 1, query.token_start);
+    }
+
+    try editor.setText(alloc, "price$100 tail");
+    try std.testing.expect(state.activeInlineSkillQuery(&editor) == null);
+    _ = editor.setCursor("price$10".len);
+    try std.testing.expect(state.activeInlineSkillQuery(&editor) == null);
 }
 
 test "model picker query takes precedence over file syntax" {

--- a/src/core/skills/skill_runtime.zig
+++ b/src/core/skills/skill_runtime.zig
@@ -1382,6 +1382,12 @@ pub const Runtime = struct {
         return skillMenuSkillAtQuery(self.items, self.menu.source_filter, self.menu.query(), self.menu.selected_index % item_count);
     }
 
+    pub fn menuVisible(self: Runtime) bool {
+        if (!self.menu.active) return false;
+        if (!self.menu.origin.isMention()) return true;
+        return skillMenuFilterQueryCount(self.items, .all, self.menu.query()) > 0;
+    }
+
     pub fn buildRoutedSystemPromptSection(
         self: Runtime,
         alloc: Allocator,
@@ -2160,6 +2166,33 @@ test "skill menu opens focuses moves and clamps loaded items" {
     runtime.closeMenu();
     try std.testing.expect(!runtime.menu.active);
     try std.testing.expect(runtime.selectedMenuSkill() == null);
+}
+
+test "skill menu visibility hides only zero-result mention queries" {
+    const skills = [_]Skill{
+        staticSkill("managed", "managed skill", .global_fx),
+        staticSkill("workspace", "workspace skill", .workspace_shared),
+    };
+    var runtime = Runtime{ .items = @constCast(&skills) };
+
+    try std.testing.expect(!runtime.menuVisible());
+
+    runtime.openMenuWithQuery(.command, null, "missing");
+    try std.testing.expect(runtime.menuVisible());
+
+    runtime.openMenuWithQuery(.dollar, .{ .start = 4, .end = 5 }, "");
+    try std.testing.expect(runtime.menuVisible());
+
+    runtime.menu.setQuery("missing");
+    try std.testing.expect(!runtime.menuVisible());
+
+    runtime.menu.setQuery("managed");
+    runtime.menu.source_filter = .claude;
+    try std.testing.expect(runtime.selectedMenuSkill() == null);
+    try std.testing.expect(runtime.menuVisible());
+
+    runtime.closeMenu();
+    try std.testing.expect(!runtime.menuVisible());
 }
 
 test "skill menu movement uses rendered visible rows before scrolling" {

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -349,7 +349,7 @@ pub fn helpMenuProjection(
 
 pub fn skillsMenuProjection(skills: *const skill_runtime.Runtime) SkillsMenuProjection {
     return .{
-        .active = skills.menu.active,
+        .active = skills.menuVisible(),
         .items = skills.items,
         .source_filter = skills.menu.source_filter,
         .selected_index = skills.menu.selected_index,
@@ -728,6 +728,22 @@ test "skillsMenuProjection mirrors runtime menu state" {
     try std.testing.expectEqual(@as(usize, 1), projection.selected_index);
     try std.testing.expectEqual(@as(usize, 1), projection.window_start);
     try std.testing.expectEqualStrings("work", projection.query);
+}
+
+test "skillsMenuProjection hides zero-result mentions and preserves command menus" {
+    var skills = [_]skill_runtime.Skill{
+        .{ .name = "managed", .description = "managed desc", .path = "/tmp/managed/SKILL.md", .source = .global_fx },
+    };
+    var runtime: skill_runtime.Runtime = .{ .items = &skills };
+
+    runtime.openMenuWithQuery(.dollar, .{ .start = 0, .end = "$missing".len }, "missing");
+    try std.testing.expect(!skillsMenuProjection(&runtime).active);
+
+    runtime.menu.setQuery("man");
+    try std.testing.expect(skillsMenuProjection(&runtime).active);
+
+    runtime.openMenuWithQuery(.command, null, "missing");
+    try std.testing.expect(skillsMenuProjection(&runtime).active);
 }
 
 test "modelMenuProjection mirrors cache-owned catalog state" {

--- a/src/ui/input/runtime.zig
+++ b/src/ui/input/runtime.zig
@@ -1333,19 +1333,24 @@ test "active inline skill query recognizes a later whitespace-delimited prefix" 
     try std.testing.expectEqual(picker_state.InlinePickerKind.skill, runtime.picker.inlinePickerTriggerKind(&runtime.edit_state).?);
 }
 
-test "active inline skill query rejects leading empty embedded and mid-cursor tokens" {
-    const cases = [_][]const u8{
+test "active inline skill query accepts root empty and embedded tokens" {
+    const accepted = [_][]const u8{
         "$man",
         "explain $",
         "explain$man",
-        "explain $man ",
+        "explain one$two$man",
     };
-    for (cases) |input| {
+    for (accepted) |input| {
         var runtime = InputRuntime{};
         defer runtime.deinit(std.testing.allocator);
         try runtime.textReplacementState().replace(std.testing.allocator, input);
-        try std.testing.expectEqual(@as(?picker_state.InlineSkillQuery, null), runtime.picker.activeInlineSkillQuery(&runtime.edit_state));
+        try std.testing.expect(runtime.picker.activeInlineSkillQuery(&runtime.edit_state) != null);
     }
+
+    var terminated = InputRuntime{};
+    defer terminated.deinit(std.testing.allocator);
+    try terminated.textReplacementState().replace(std.testing.allocator, "explain $man ");
+    try std.testing.expectEqual(@as(?picker_state.InlineSkillQuery, null), terminated.picker.activeInlineSkillQuery(&terminated.edit_state));
 
     var mid_cursor = InputRuntime{};
     defer mid_cursor.deinit(std.testing.allocator);

--- a/tests/e2e/tui-slash-menu.test.ts
+++ b/tests/e2e/tui-slash-menu.test.ts
@@ -2447,16 +2447,19 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       await session.sendKeys("C-u");
 
       await session.sendLiteralText(" $");
+      grid = await waitForSkillsMenu(session, 4);
+      expect(composerContains(grid.join("\n"), " $")).toBe(true);
+      await session.sendKeys("C-[");
       await session.waitForPane(
-        (current) =>
-          composerContains(current, " $") &&
-          current.includes("𝒇x") &&
-          !current.includes("Skills 4"),
+        (current) => composerContains(current, " $") && !current.includes("Skills 4"),
         5_000,
       );
       await session.sendKeys("C-u");
 
       await session.sendLiteralText("hello $");
+      grid = await waitForSkillsMenu(session, 4);
+      expect(composerContains(grid.join("\n"), "hello $")).toBe(true);
+      await session.sendKeys("C-[");
       await session.waitForPane(
         (current) =>
           composerContains(current, "hello $") &&
@@ -2466,52 +2469,62 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
       );
       await session.sendKeys("C-u");
 
-      await session.sendLiteralText("explain $man");
+      await session.sendLiteralText("price$");
+      grid = await waitForSkillsMenu(session, 4);
+      expect(composerContains(grid.join("\n"), "price$")).toBe(true);
+      await session.sendKeys("C-[");
       await session.waitForPane(
         (current) =>
-          composerContains(current, "explain $managed-menu") &&
+          composerContains(current, "price$") &&
           !current.includes("Skills 4"),
         5_000,
       );
-      let inlineEscapes = await session.capturePaneEscapes();
-      expect(inlineEscapes).toContain(`${DIM_SGR}aged-menu`);
+      await session.sendKeys("C-u");
+
+      await session.sendLiteralText("explain $man");
+      grid = await waitForSkillsMenu(session, 1);
+      expect(composerContains(grid.join("\n"), "explain $man")).toBe(true);
+      expect(await session.capturePaneEscapes()).not.toContain(`${DIM_SGR}aged-menu`);
+
+      await session.sendLiteralText("zzzzzz");
+      await session.waitForPane(
+        (current) =>
+          composerContains(current, "explain $manzzzzzz") &&
+          !current.includes("Skills ") &&
+          !current.includes("No skills found.") &&
+          !current.includes("Enter Use"),
+        5_000,
+      );
+
+      await session.sendKeys("BSpace BSpace BSpace BSpace BSpace BSpace");
+      grid = await waitForSkillsMenu(session, 1);
+      expect(composerContains(grid.join("\n"), "explain $man")).toBe(true);
 
       await session.sendKeys("C-[");
       await session.waitForPane(
         (current) =>
           composerContains(current, "explain $man") &&
+          !current.includes("Skills "),
+        5_000,
+      );
+      await session.sendLiteralText("x");
+      await session.waitForPane(
+        (current) =>
+          composerContains(current, "explain $manx") &&
+          !current.includes("Skills ") &&
           !current.includes("aged-menu"),
         5_000,
       );
       await session.sendKeys("C-u");
 
-      await session.sendLiteralText("explain $man");
-      await session.waitForPane(
-        (current) => composerContains(current, "explain $managed-menu"),
-        5_000,
-      );
-      await session.sendKeys("Tab");
+      await session.sendLiteralText("prefix$man");
+      grid = await waitForSkillsMenu(session, 1);
+      expect(composerContains(grid.join("\n"), "prefix$man")).toBe(true);
+      await session.sendKeys("Enter");
       await session.waitForPane(
         (current) =>
-          composerContains(current, "explain managed-menu") &&
-          !current.includes("Skills 4"),
-        5_000,
-      );
-      inlineEscapes = await session.capturePaneEscapes();
-      expect(inlineEscapes).toContain(`${SELECTED_COMPLETION_SGR}managed-menu`);
-      expect(inlineEscapes).not.toContain(`${DIM_SGR}aged-menu`);
-      await session.sendKeys("C-u");
-
-      await session.sendLiteralText("explain $man");
-      await session.waitForPane(
-        (current) => composerContains(current, "explain $managed-menu"),
-        5_000,
-      );
-      await session.sendKeys("Right");
-      await session.waitForPane(
-        (current) =>
-          composerContains(current, "explain managed-menu") &&
-          !current.includes("Skills 4"),
+          composerContains(current, "prefixmanaged-menu") &&
+          !current.includes("Skills "),
         5_000,
       );
       await session.sendKeys("C-u");
@@ -2524,7 +2537,7 @@ describe.skipIf(SKIP)("tui: slash menu", () => {
           !current.includes("Skills 4"),
         5_000,
       );
-      inlineEscapes = await session.capturePaneEscapes();
+      let inlineEscapes = await session.capturePaneEscapes();
       expect(inlineEscapes).toContain(`${DIM_SGR}ills`);
 
       await session.sendKeys("C-[");


### PR DESCRIPTION
## Summary

- Open the full skills menu whenever a dollar trigger is typed at any composer position.
- Hide zero-result dollar menus without changing prompt text, and restore them when matches return.
- Keep Escape dismissed for the current dollar token and reopen on a later trigger.