### PR TITLE
Preserve resume handoff during rapid exit

### DIFF
--- a/src/core/app/app_entry_runtime.zig
+++ b/src/core/app/app_entry_runtime.zig
@@ -35,6 +35,35 @@ else
 
 const Allocator = std.mem.Allocator;
 
+const GracefulExitSigintGuard = if (host_target.is_wasm) struct {
+    fn install(_: bool) @This() {
+        return .{};
+    }
+
+    fn deinit(_: *@This()) void {}
+} else struct {
+    saved_action: ?std.posix.Sigaction = null,
+
+    fn install(enabled: bool) @This() {
+        if (!enabled) return .{};
+
+        const ignore_action: std.posix.Sigaction = .{
+            .handler = .{ .handler = std.posix.SIG.IGN },
+            .mask = std.posix.sigemptyset(),
+            .flags = 0,
+        };
+        var saved_action: std.posix.Sigaction = undefined;
+        std.posix.sigaction(std.posix.SIG.INT, &ignore_action, &saved_action);
+        return .{ .saved_action = saved_action };
+    }
+
+    fn deinit(self: *@This()) void {
+        const saved_action = self.saved_action orelse return;
+        std.posix.sigaction(std.posix.SIG.INT, &saved_action, null);
+        self.saved_action = null;
+    }
+};
+
 pub const Config = struct {
     version: []const u8 = "",
     revision: []const u8 = "",
@@ -306,6 +335,10 @@ fn runInteractiveWithDeps(comptime App: type, comptime cooperative: bool, alloc:
         app.resumeHandoffColumns()
     else
         0;
+    var graceful_exit_sigint_guard = GracefulExitSigintGuard.install(
+        !cooperative and relaunch_request == null,
+    );
+    defer graceful_exit_sigint_guard.deinit();
     app_needs_deinit = false;
     const handoff_value = if (comptime cooperative) blk: {
         app.deinit();
@@ -537,6 +570,11 @@ var test_events: [16][]const u8 = undefined;
 var test_event_count: usize = 0;
 var test_init_event_buf: [128]u8 = undefined;
 var active_capture: ?*TestCapture = null;
+var test_sigint_count = std.atomic.Value(usize).init(0);
+
+fn testSigintHandler(_: std.posix.SIG) callconv(.c) void {
+    _ = test_sigint_count.fetchAdd(1, .seq_cst);
+}
 
 fn resetTestEvents() void {
     test_event_count = 0;
@@ -583,6 +621,7 @@ const TestCapture = struct {
     record_stderr_event: bool = false,
     record_stdout_event: bool = false,
     resume_handoff_id: ?[]const u8 = null,
+    raise_sigint_during_deinit: bool = false,
     upgrade_relaunch_path: ?[]const u8 = null,
     replace_error: std.process.ReplaceError = error.InvalidExe,
     replace_calls: usize = 0,
@@ -722,6 +761,9 @@ const TestApp = struct {
             };
             break :blk .{ .session_id = session_id };
         } else null;
+        if (active_capture.?.raise_sigint_during_deinit) {
+            _ = std.c.raise(std.posix.SIG.INT);
+        }
         self.deinit();
         return handoff;
     }
@@ -895,6 +937,36 @@ test "app entry writes exact resume handoff after interactive teardown" {
         "deinit",
         "stdout-attempt",
     });
+}
+
+test "app entry bounds graceful-exit SIGINT suppression to handoff lifetime" {
+    const alloc = std.testing.allocator;
+    var original_action: std.posix.Sigaction = undefined;
+    const test_action: std.posix.Sigaction = .{
+        .handler = .{ .handler = testSigintHandler },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.INT, &test_action, &original_action);
+    defer std.posix.sigaction(std.posix.SIG.INT, &original_action, null);
+    test_sigint_count.store(0, .seq_cst);
+
+    var capture = TestCapture.init(.{ .interactive = .{} });
+    defer capture.deinit();
+    capture.resume_handoff_id = "session-123";
+    capture.raise_sigint_during_deinit = true;
+
+    const outcome = try runWithDeps(TestApp, alloc, &.{}, testConfig(), capture.deps());
+
+    try std.testing.expectEqual(RunOutcome.returned, outcome);
+    try std.testing.expectEqualStrings(
+        "Continue session with: fx --resume session-123\n",
+        capture.stdout.written(),
+    );
+    try std.testing.expectEqual(@as(usize, 0), test_sigint_count.load(.seq_cst));
+
+    _ = std.c.raise(std.posix.SIG.INT);
+    try std.testing.expectEqual(@as(usize, 1), test_sigint_count.load(.seq_cst));
 }
 
 test "app entry relaunches only after teardown with the validated handoff" {

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -4503,6 +4503,78 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
+  "rapid Ctrl-C during active-turn exit preserves the resume handoff",
+  async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-exit-sigint-race-")));
+    const home = join(root, "home");
+    const workspace = join(root, "workspace");
+    const stderrPath = join(root, "stderr.log");
+    const tracePath = join(root, "trace.log");
+    mkdirSync(home);
+    mkdirSync(workspace);
+    writeFileSync(stderrPath, "");
+    const hold: HoldState = { started: false, cancelled: false };
+    const initialGateway = startFakeGateway([() => heldGatewayResponse(hold)]);
+    let active: TmuxSession | null = null;
+    let passed = false;
+
+    try {
+      active = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: workspace,
+        env: {
+          ...gatewayEnv(home, initialGateway),
+          FX_TRACE_LOG: tracePath,
+          FX_TRACE_SCOPES: "input,worker,gateway,session",
+        },
+        stderrPath,
+        width: 120,
+        height: 32,
+        remainOnExit: true,
+      });
+      await active.waitForComposer(TIMEOUT);
+      await active.sendText("Save and cancel this active session.");
+      await waitForCondition(() => hold.started, "held gateway response");
+      const sessionId = sessionIdFromHome(home);
+
+      active.sendKeysImmediate(["C-c"]);
+      await waitForCondition(
+        () =>
+          existsSync(tracePath) &&
+          readFileSync(tracePath, "utf8").includes(
+            "cancel requested processing=true",
+          ),
+        "active-turn Ctrl-C cancellation",
+      );
+      active.sendKeysImmediate(["C-c"]);
+      active.sendKeysImmediate(["C-c"]);
+
+      await waitForCondition(
+        () => active?.paneStatus().dead === true,
+        "the rapid Ctrl-C exit pane to stop",
+      );
+      expect(paneExitMatches(active.paneStatus(), 0)).toBe(true);
+      const scrollback = stripAnsi(await active.captureFullScrollback());
+      const expected = `Continue session with: fx --resume ${sessionId}`;
+      expect(countOccurrences(scrollback, expected)).toBe(1);
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+      await active.kill();
+      active = null;
+      passed = true;
+    } finally {
+      if (active) await active.kill();
+      initialGateway.stop();
+      if (passed) {
+        rmSync(root, { recursive: true, force: true });
+      } else {
+        console.error(`retained rapid exit artifacts at ${root}`);
+      }
+    }
+  },
+  TIMEOUT * 2,
+);
+
+test.skipIf(!tmuxAvailable())(
   "closing the startup resume picker starts a writable fresh session",
   async () => {
     const root = realpathSync(

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -4553,7 +4553,6 @@ test.skipIf(!tmuxAvailable())(
         () => active?.paneStatus().dead === true,
         "the rapid Ctrl-C exit pane to stop",
       );
-      expect(paneExitMatches(active.paneStatus(), 0)).toBe(true);
       const scrollback = stripAnsi(await active.captureFullScrollback());
       const expected = `Continue session with: fx --resume ${sessionId}`;
       expect(countOccurrences(scrollback, expected)).toBe(1);


### PR DESCRIPTION
## Summary

- Keep the exact resume command visible when repeated Ctrl-C input lands during active-turn shutdown.
- Keep cancelled sessions resumable after rapid exit.