### PR TITLE
Clarify top-level help

### DIFF
--- a/src/builtins/commands.zig
+++ b/src/builtins/commands.zig
@@ -314,22 +314,26 @@ pub const top_level_help_groups = [_]TopLevelHelpGroup{
         .{ .usage = "session recover <id>", .summary = "Copy a recoverable corrupt session" },
     } },
     .{ .entries = &.{
-        .{ .kind = .login, .usage = "login [vercel|codex|grok]" },
-        .{ .kind = .logout, .usage = "logout [vercel|codex|grok]" },
-        .{ .kind = .provider, .usage = "provider <gateway|codex|grok>" },
-        .{ .kind = .setup, .usage = "setup" },
-        .{ .kind = .teams, .usage = "teams" },
-        .{ .kind = .credits, .usage = "credits|balance" },
-        .{ .kind = .usage, .usage = "usage [--period <24h|7d|30d>]" },
+        .{ .kind = .login, .usage = "login [vercel|codex|grok]", .summary = "Sign in to a model provider" },
+        .{ .kind = .logout, .usage = "logout [vercel|codex|grok]", .summary = "Sign out of a model provider" },
+        .{ .kind = .provider, .usage = "provider <gateway|codex|grok>", .summary = "Choose the active model provider" },
+        .{ .kind = .models, .usage = "models" },
+    } },
+    .{ .entries = &.{
+        .{ .kind = .setup, .usage = "setup", .summary = "Configure a Vercel AI Gateway API key" },
+        .{ .kind = .teams, .usage = "teams", .summary = "Choose a Vercel AI Gateway team" },
+        .{ .kind = .credits, .usage = "credits|balance", .summary = "Show Vercel AI Gateway credits" },
+    } },
+    .{ .entries = &.{
+        .{ .kind = .usage, .usage = "usage [--period <24h|7d|30d>]", .summary = "Show locally recorded token usage and spend" },
     } },
     .{ .entries = &.{
         .{ .kind = .status, .usage = "status" },
         .{ .kind = .doctor, .usage = "doctor" },
         .{ .kind = .mcp, .usage = "mcp <command> ..." },
-        .{ .kind = .models, .usage = "models" },
         .{ .kind = .permissions, .usage = "permissions" },
         .{ .kind = .workspace, .usage = "workspace" },
-        .{ .kind = .upgrade, .usage = "upgrade" },
+        .{ .kind = .upgrade, .usage = "upgrade", .summary = "Upgrade fx on the selected release channel" },
         .{ .kind = .acp, .usage = "acp" },
         .{ .kind = .help, .usage = "help" },
     } },
@@ -374,7 +378,7 @@ pub const top_level_flags = [_]TopLevelFlag{
     },
     .{
         .usage = "-v, --version",
-        .description = "Print the 𝒇x version and exit",
+        .description = "Print the fx version and exit",
     },
 };
 
@@ -386,19 +390,19 @@ pub const top_level_examples = [_]TopLevelExample{
 };
 
 pub const top_level_notes = [_][]const u8{
-    "Run `fx <command> --help` for command-specific options and examples.",
+    "Run `fx <command> --help` for command-specific usage and options.",
     "Run `/help` inside an interactive session for slash commands.",
 };
 
 pub const top_level_resources = [_]TopLevelResource{
-    .{ .label = "Learn more about 𝒇x:", .value = "https://fx.sh/docs", .link = true },
-    .{ .label = "Report a problem:", .value = "run `/feedback` inside 𝒇x" },
+    .{ .label = "Learn more about fx:", .value = "https://fx.sh/docs", .link = true },
+    .{ .label = "Report a problem:", .value = "run `/feedback` inside fx" },
 };
 
 pub const top_level_registry = TopLevelRegistry{
     .specs = top_level_specs[0..],
     .description = "Fast, native coding agent for the terminal.",
-    .interactive_hint = "𝒇x starts an interactive session by default. Use `fx ask` to run one noninteractive request.",
+    .interactive_hint = "fx starts an interactive session by default. Use `fx ask` to run one noninteractive request.",
     .help_groups = top_level_help_groups[0..],
     .flags = top_level_flags[0..],
     .examples = top_level_examples[0..],

--- a/src/core/slash_commands/command_specs.zig
+++ b/src/core/slash_commands/command_specs.zig
@@ -1583,14 +1583,21 @@ test "rendered top-level help is a complete CLI navigation page" {
     defer std.testing.allocator.free(text);
 
     try std.testing.expect(std.mem.startsWith(u8, text, "𝒇x v9.8.7\nFast, native coding agent for the terminal."));
-    try std.testing.expect(std.mem.find(u8, text, "𝒇x starts an interactive session by default.") != null);
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, text, "𝒇x"));
+    try std.testing.expect(std.mem.find(u8, text, "fx starts an interactive session by default.") != null);
     try std.testing.expect(std.mem.find(u8, text, "fx <command> [...flags] [...args]") != null);
     try std.testing.expect(std.mem.find(u8, text, "Commands:") != null);
     try std.testing.expect(std.mem.find(u8, text, "ask <prompt>") != null);
     try std.testing.expect(std.mem.find(u8, text, "Run one noninteractive request") != null);
     try std.testing.expect(std.mem.find(u8, text, "Draft or publish a GitHub issue") != null);
     try std.testing.expect(std.mem.find(u8, text, "credits|balance") != null);
-    try std.testing.expect(std.mem.find(u8, text, "Show the AI Gateway credit balance") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Sign in to a model provider") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Sign out of a model provider") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Choose the active model provider") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Configure a Vercel AI Gateway API key") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Choose a Vercel AI Gateway team") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Show Vercel AI Gateway credits") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Sign in to Vercel or a selected provider") == null);
     try std.testing.expect(std.mem.find(u8, text, "Flags:") != null);
     try std.testing.expect(std.mem.find(u8, text, "--context-limit <spec>") != null);
     try std.testing.expect(std.mem.find(u8, text, "Set name=bytes|off; repeatable") != null);
@@ -1610,15 +1617,25 @@ test "rendered top-level help is a complete CLI navigation page" {
     try std.testing.expect(std.mem.find(u8, text, "fx session resume last") != null);
     try std.testing.expect(std.mem.find(u8, text, "session resume [last|id]") != null);
     try std.testing.expect(std.mem.find(u8, text, "fx status --json") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Run `fx <command> --help` for command-specific usage and options.") != null);
+    try std.testing.expect(std.mem.find(u8, text, "command-specific options and examples") == null);
     try std.testing.expect(std.mem.find(u8, text, "Run `/help` inside an interactive session for slash commands.") != null);
-    try std.testing.expect(std.mem.find(u8, text, "Learn more about 𝒇x:  https://fx.sh/docs") != null);
-    try std.testing.expect(std.mem.find(u8, text, "\nReport a problem:     run `/feedback` inside 𝒇x\n") != null);
+    try std.testing.expect(std.mem.find(u8, text, "Learn more about fx:  https://fx.sh/docs") != null);
+    try std.testing.expect(std.mem.find(u8, text, "\nReport a problem:     run `/feedback` inside fx\n") != null);
     try std.testing.expect(std.mem.find(u8, text, "\n\n\nRun `fx <command> --help`") == null);
     try std.testing.expect(std.mem.find(u8, text, "Start:") == null);
     try std.testing.expect(std.mem.find(u8, text, "  Work      ") == null);
     try std.testing.expect(std.mem.find(u8, text, "More:") == null);
     try std.testing.expect(std.mem.find(u8, text, "resume [last|<id>] [--record]") == null);
     try std.testing.expect(std.mem.find(u8, text, "session migrate <id>|--id <id>") == null);
+}
+
+test "top-level help summary overrides do not change command-specific help" {
+    const login = try renderTopLevelCommandHelp(std.testing.allocator, testTopLevelRegistry(), .login);
+    defer std.testing.allocator.free(login);
+
+    try std.testing.expect(std.mem.find(u8, login, "Sign in to Vercel or a selected provider") != null);
+    try std.testing.expect(std.mem.find(u8, login, "Sign in to a model provider") == null);
 }
 
 test "terminal top-level help adds styling without changing visible content" {
@@ -1635,7 +1652,7 @@ test "terminal top-level help adds styling without changing visible content" {
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[39mask <prompt>\x1b[0m") != null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;243mFast, native coding agent") != null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[4mhttps://fx.sh/docs\x1b[0m") != null);
-    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[39mrun `/feedback` inside 𝒇x\x1b[0m") != null);
+    try std.testing.expect(std.mem.find(u8, terminal, "\x1b[39mrun `/feedback` inside fx\x1b[0m") != null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;252m") == null);
     try std.testing.expect(std.mem.find(u8, terminal, "\x1b[38;5;245m") == null);
     try std.testing.expectEqualStrings(plain, stripped);
@@ -1653,7 +1670,9 @@ test "top-level help renders flags as compact aligned rows" {
     try std.testing.expect(lineContainsBoth(wide, "-r", "Open the saved-session picker"));
     try std.testing.expect(lineContainsBoth(wide, "--resume [last|<id>]", "Resume the latest workspace session or an exact ID"));
     try std.testing.expect(lineContainsBoth(wide, "--resume-last", "Resume the latest workspace session"));
-    try std.testing.expect(std.mem.find(u8, wide, "Print the 𝒇x version and exit\n\nExamples:") != null);
+    try std.testing.expect(std.mem.find(u8, wide, "Print the fx version and exit\n\nExamples:") != null);
+    try std.testing.expect(std.mem.find(u8, wide, "List available models\n\n  setup") != null);
+    try std.testing.expect(std.mem.find(u8, wide, "Show Vercel AI Gateway credits\n\n  usage") != null);
     try expectAllLinesFit(narrow, 60);
 }
 

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -248,57 +248,59 @@ function writeLegacySession(
 
 describe("cli: help", () => {
   test(
-    "fx help exits 0 and renders the complete navigation page",
+    "top-level help aliases render the same accurate navigation page",
     async () => {
-      const r = await runFx(["help"]);
-      expect(r.code).toBe(0);
-      expect(r.stderr).toBe("");
-      expect(r.stdout).not.toContain("\x1b[");
-      expect(r.stdout).not.toContain("\x1b]2;");
-      expect(r.stdout).toStartWith(
+      const outputs: string[] = [];
+      for (const args of [["help"], ["--help"], ["-h"]]) {
+        const result = await runFx(args);
+        expect(result.code).toBe(0);
+        expect(result.stderr).toBe("");
+        outputs.push(result.stdout);
+      }
+
+      expect(outputs[1]).toBe(outputs[0]);
+      expect(outputs[2]).toBe(outputs[0]);
+      const stdout = outputs[0]!;
+      expect(stdout).not.toContain("\x1b[");
+      expect(stdout).not.toContain("\x1b]2;");
+      expect(stdout).toStartWith(
         `𝒇x v${sourceVersion()}\nFast, native coding agent for the terminal.\n`,
       );
-      expect(r.stdout).toContain("Commands:\n");
-      expect(r.stdout).toContain("Run one noninteractive request");
-      expect(r.stdout).toContain("credits|balance");
-      expect(r.stdout).toContain("Flags:\n");
-      expect(r.stdout).toContain("--context-limit <spec>");
-      expect(r.stdout).toContain("Set name=bytes|off; repeatable");
-      expect(r.stdout).toContain("--add-dir <path>");
-      expect(r.stdout).toContain("-c, --continue");
-      expect(r.stdout).toContain("-r");
-      expect(r.stdout).toContain("Open the saved-session picker");
-      expect(r.stdout).not.toContain("-c, -r, --continue");
-      expect(r.stdout).toContain("--resume [last|<id>]");
-      expect(r.stdout).toContain("--resume-last");
-      expect(r.stdout).toContain("session resume [last|id]");
-      expect(r.stdout).toContain("-v, --version");
-      expect(r.stdout).not.toContain("Must appear before the command");
-      expect(r.stdout).toContain("Examples:\n");
-      expect(r.stdout).toContain("https://fx.sh/docs");
-      expect(r.stdout).toContain("run `/feedback` inside 𝒇x");
-      expect(r.stdout).not.toContain("  Work      ");
-      expect(r.stdout).not.toContain("\n\n\nRun `fx <command> --help`");
-    },
-    TIMEOUT,
-  );
-
-  test(
-    "fx --help exits 0",
-    async () => {
-      const r = await runFx(["--help"]);
-      expect(r.code).toBe(0);
-      expect(r.stdout).toContain("ask");
-    },
-    TIMEOUT,
-  );
-
-  test(
-    "fx -h exits 0",
-    async () => {
-      const r = await runFx(["-h"]);
-      expect(r.code).toBe(0);
-      expect(r.stdout).toContain("ask");
+      expect(stdout.match(/𝒇x/g) ?? []).toHaveLength(1);
+      expect(stdout).toContain("fx starts an interactive session by default.");
+      expect(stdout).toContain("Commands:\n");
+      expect(stdout).toContain("Run one noninteractive request");
+      expect(stdout).toContain("Sign in to a model provider");
+      expect(stdout).toContain("Sign out of a model provider");
+      expect(stdout).toContain("Choose the active model provider");
+      expect(stdout).toContain("Configure a Vercel AI Gateway API key");
+      expect(stdout).toContain("Choose a Vercel AI Gateway team");
+      expect(stdout).toContain("Show Vercel AI Gateway credits");
+      expect(stdout).not.toContain("Sign in to Vercel or a selected provider");
+      expect(stdout).toContain("credits|balance");
+      expect(stdout).toContain("Flags:\n");
+      expect(stdout).toContain("--context-limit <spec>");
+      expect(stdout).toContain("Set name=bytes|off; repeatable");
+      expect(stdout).toContain("--add-dir <path>");
+      expect(stdout).toContain("-c, --continue");
+      expect(stdout).toContain("-r");
+      expect(stdout).toContain("Open the saved-session picker");
+      expect(stdout).not.toContain("-c, -r, --continue");
+      expect(stdout).toContain("--resume [last|<id>]");
+      expect(stdout).toContain("--resume-last");
+      expect(stdout).toContain("session resume [last|id]");
+      expect(stdout).toContain("-v, --version");
+      expect(stdout).toContain("Print the fx version and exit");
+      expect(stdout).not.toContain("Must appear before the command");
+      expect(stdout).toContain("Examples:\n");
+      expect(stdout).toContain("https://fx.sh/docs");
+      expect(stdout).toContain("run `/feedback` inside fx");
+      expect(stdout).toContain(
+        "Run `fx <command> --help` for command-specific usage and options.",
+      );
+      expect(stdout).not.toContain("command-specific options and examples");
+      expect(stdout).not.toContain("  Work      ");
+      expect(stdout).not.toContain("\n\n\nRun `fx <command> --help`");
     },
     TIMEOUT,
   );


### PR DESCRIPTION
## Summary

- Keep the stylized `𝒇x` mark only in the top-level version header.
- Use plain `fx` throughout the rest of top-level help.
- Separate provider-neutral actions from Vercel AI Gateway-specific commands.
- Replace stale command-help guidance with current usage and options behavior.