### PR TITLE
Shorten generated session IDs

### DIFF
--- a/src/core/session/session_layout.zig
+++ b/src/core/session/session_layout.zig
@@ -2,7 +2,8 @@ const std = @import("std");
 const io_mod = @import("../shared/io.zig");
 
 const Allocator = std.mem.Allocator;
-const session_id_random_bytes: usize = 8;
+const session_id_random_bytes: usize = 9;
+const session_id_encoded_bytes = std.base64.url_safe_no_pad.Encoder.calcSize(session_id_random_bytes);
 
 pub fn sessionDirPath(alloc: Allocator, sessions_dir: []const u8, session_id: []const u8) ![]u8 {
     try validateSessionId(session_id);
@@ -25,33 +26,22 @@ pub fn validateSessionId(session_id: []const u8) !void {
 pub fn generateSessionId(alloc: Allocator) ![]u8 {
     var random_bytes: [session_id_random_bytes]u8 = undefined;
     io_mod.getIo().random(&random_bytes);
-    const random_hex = std.fmt.bytesToHex(random_bytes, .lower);
-    return std.fmt.allocPrint(alloc, "{d}-{d}-{s}", .{ io_mod.milliTimestamp(), io_mod.nanoTimestamp(), random_hex });
+    const id = try alloc.alloc(u8, session_id_encoded_bytes);
+    _ = std.base64.url_safe_no_pad.Encoder.encode(id, &random_bytes);
+    return id;
 }
 
-fn isLowerHex(text: []const u8) bool {
-    for (text) |c| {
-        if (!((c >= '0' and c <= '9') or (c >= 'a' and c <= 'f'))) return false;
-    }
-    return true;
-}
-
-test "generated session id includes random hex suffix" {
+test "generated session id is a compact url-safe token" {
     const id = try generateSessionId(std.testing.allocator);
     defer std.testing.allocator.free(id);
 
-    var segments = std.mem.splitScalar(u8, id, '-');
-    const millis = segments.next() orelse return error.TestExpectedEqual;
-    const nanos = segments.next() orelse return error.TestExpectedEqual;
-    const suffix = segments.next() orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(@as(usize, 12), id.len);
+    try validateSessionId(id);
+    for (id) |byte| {
+        try std.testing.expect(std.ascii.isAlphanumeric(byte) or byte == '-' or byte == '_');
+    }
 
-    try std.testing.expect(segments.next() == null);
-    try std.testing.expect(millis.len > 0);
-    try std.testing.expect(nanos.len > 0);
-    _ = try std.fmt.parseInt(i64, millis, 10);
-    _ = try std.fmt.parseInt(i128, nanos, 10);
-    try std.testing.expectEqual(@as(usize, 16), suffix.len);
-    try std.testing.expect(isLowerHex(suffix));
+    try validateSessionId("1786460757753-1786460757753277000-ef75d8fd94fdab1");
 }
 
 test "session directory path rejects unsafe ids" {

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -2707,7 +2707,7 @@ describe("gateway stream lifecycle", () => {
         session_id: string;
       };
       expect(firstJson.model).toBe(MODEL);
-      expect(firstJson.session_id.length).toBeGreaterThan(0);
+      expect(firstJson.session_id).toMatch(/^[A-Za-z0-9_-]{12}$/);
       const eventsPath = join(
         root.home,
         ".fx",

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -4441,6 +4441,7 @@ test.skipIf(!tmuxAvailable())(
       await active.sendText("Save this conversation for the exit handoff.");
       await active.waitForText(marker, TIMEOUT);
       const sessionId = sessionIdFromHome(home);
+      expect(sessionId).toMatch(/^[A-Za-z0-9_-]{12}$/);
 
       await active.sendText("/quit");
       await waitForCondition(


### PR DESCRIPTION
## Summary

- Generate 12-character IDs for every newly created session.
- Print and accept the same compact ID in exact resume commands.
- Keep existing long session IDs resumable without migration.
