### PR TITLE
Preserve provider-valid post-tool retries

### DIFF
--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -3881,9 +3881,15 @@ fn processQueuedPromptLoop(
                     pending_image_ids.len,
                 },
             );
-            const recovery_source_messages = try appendReadFailureRecoveryContext(
+            const decision_source_messages = try append_post_tool_decision_prompt(
                 overlay_arena,
                 gateway_messages.items,
+                post_tool_decision_pending or
+                    recovery_strategy == .continue_after_confirmed_tool,
+            );
+            const recovery_source_messages = try appendReadFailureRecoveryContext(
+                overlay_arena,
+                decision_source_messages,
                 recovery_strategy,
                 try recoveryCheckpointAssistantSource(
                     arena,
@@ -3891,20 +3897,14 @@ fn processQueuedPromptLoop(
                     stream_ctx.raw_text.items,
                 ),
             );
-            const decision_source_messages = try append_post_tool_decision_prompt(
-                overlay_arena,
-                recovery_source_messages,
-                post_tool_decision_pending or
-                    recovery_strategy == .continue_after_confirmed_tool,
-            );
             const projected_request_messages = blk: {
                 if (job.authorized_image_catalog.len == 0 and job.images.len == 0) {
-                    break :blk decision_source_messages;
+                    break :blk recovery_source_messages;
                 }
                 break :blk switch (vision_policy.route) {
                     .native => try runtime_vision_contracts.project_native_messages(
                         overlay_arena,
-                        decision_source_messages,
+                        recovery_source_messages,
                         current_user_message_index,
                     ),
                     .fallback => fallback: {
@@ -3913,7 +3913,7 @@ fn processQueuedPromptLoop(
                         }
                         break :fallback try runtime_vision_contracts.project_text_only_messages(
                             overlay_arena,
-                            decision_source_messages,
+                            recovery_source_messages,
                             current_user_message_index,
                             job.authorized_image_catalog,
                         );

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -3743,6 +3743,7 @@ test "processQueuedPrompt pauses when uncertain tool reconciliation returns anot
 
 test "processQueuedPrompt preserves a confirmed provider tool result across recovery" {
     const alloc = std.testing.allocator;
+    const decision_prompt = "Continue the original task. If work remains and you can proceed, briefly tell the user what you are doing next, then perform that action with the appropriate tool. Do not end the turn with only a progress update. If the task is complete, respond with the result. If a genuine blocker prevents further action, explain the blocker and what is needed to continue.";
     const calls = [_]ToolCall{.{
         .id = "provider_search_1",
         .name = "perplexity_search",
@@ -3780,9 +3781,14 @@ test "processQueuedPrompt preserves a confirmed provider tool result across reco
     try expectGatewayPromptTailText(
         &gateway,
         1,
-        .user,
-        "Continue the original task. If work remains and you can proceed, briefly tell the user what you are doing next, then perform that action with the appropriate tool. Do not end the turn with only a progress update. If the task is complete, respond with the result. If a genuine blocker prevents further action, explain the blocker and what is needed to continue.",
+        .system,
+        "confirmed tool result",
     );
+    try expectGatewayPromptTextCount(&gateway, 1, decision_prompt, 1);
+    try expectBodyContainsInOrder(&gateway, 1, &.{
+        decision_prompt,
+        "confirmed tool result",
+    });
     const execution = hooks.history_turns.items[0].assistant.execution;
     try std.testing.expectEqual(@as(usize, 1), execution.tool_steps.len);
     try std.testing.expectEqual(@as(usize, 1), execution.tool_steps[0].tool_results.len);
@@ -3830,9 +3836,14 @@ test "processQueuedPrompt preserves a confirmed provider tool result across reco
     try expectGatewayPromptTailText(
         &restored_gateway,
         0,
-        .user,
-        "Continue the original task. If work remains and you can proceed, briefly tell the user what you are doing next, then perform that action with the appropriate tool. Do not end the turn with only a progress update. If the task is complete, respond with the result. If a genuine blocker prevents further action, explain the blocker and what is needed to continue.",
+        .system,
+        "confirmed tool result",
     );
+    try expectGatewayPromptTextCount(&restored_gateway, 0, decision_prompt, 1);
+    try expectBodyContainsInOrder(&restored_gateway, 0, &.{
+        decision_prompt,
+        "confirmed tool result",
+    });
 }
 
 test "processQueuedPrompt preserves the provider-executed subset of mixed failed tools" {
@@ -3943,20 +3954,14 @@ test "processQueuedPrompt suppresses a repeated confirmed provider tool identity
 
     try std.testing.expectEqual(@as(usize, 3), gateway.request_models.items.len);
     try std.testing.expectEqual(@as(usize, 0), hooks.executed_names.items.len);
-    for ([_]usize{ 1, 2 }) |request_index| {
-        try expectGatewayPromptTailText(
-            &gateway,
-            request_index,
-            .user,
-            decision_prompt,
-        );
-        try expectGatewayPromptTextCount(
-            &gateway,
-            request_index,
-            decision_prompt,
-            1,
-        );
-    }
+    try expectGatewayPromptTailText(&gateway, 1, .system, "confirmed tool result");
+    try expectGatewayPromptTextCount(&gateway, 1, decision_prompt, 1);
+    try expectBodyContainsInOrder(&gateway, 1, &.{
+        decision_prompt,
+        "confirmed tool result",
+    });
+    try expectGatewayPromptTailText(&gateway, 2, .user, decision_prompt);
+    try expectGatewayPromptTextCount(&gateway, 2, decision_prompt, 1);
     const execution = hooks.history_turns.items[0].assistant.execution;
     try std.testing.expectEqual(@as(usize, 1), execution.tool_steps.len);
     try std.testing.expectEqual(@as(usize, 1), execution.tool_steps[0].tool_results.len);
@@ -4024,6 +4029,38 @@ test "processQueuedPrompt retries replay-safe provider errors before success" {
     try expectRouteStatus(&hooks, 2, .auto_retry, "⚠ Provider unavailable · provider_error: route failed twice · retrying request in 1s · attempt 2/3");
     try expectRouteStatus(&hooks, 3, .auto_retry, "⚠ Provider unavailable · provider_error: route failed twice · retrying request · attempt 3/3");
     try expectRouteStatus(&hooks, 4, .auto_recovered, "✓ recovered · succeeded on attempt 3/3");
+}
+
+test "processQueuedPrompt keeps recovery system last after post-tool provider error" {
+    const alloc = std.testing.allocator;
+    const decision_prompt = "Continue the original task. If work remains and you can proceed, briefly tell the user what you are doing next, then perform that action with the appropriate tool. Do not end the turn with only a progress update. If the task is complete, respond with the result. If a genuine blocker prevents further action, explain the blocker and what is needed to continue.";
+    const calls = [_]ToolCall{toolCall("call_read", "read_file", "{\"path\":\"a\"}")};
+    const completions = [_]FakeCompletion{
+        .{ .tool_calls = &calls, .finish_reason = .tool_calls },
+        .{ .finish_reason = .provider_error, .provider_failure_detail = "route failed after tool" },
+        .{ .content = "Recovered after tool" },
+    };
+    var gateway = FakeGateway.init(alloc, &completions);
+    defer gateway.deinit();
+    var hooks = FakeAgentRuntimeDeps.init(alloc);
+    defer hooks.deinit();
+    var fixture = PromptFixture{};
+    var config = fixture.config();
+    config.gateway_retry_count = 1;
+    config.max_provider_attempts = 2;
+
+    try runFakePrompt(&gateway, &hooks, config, fixture.job());
+
+    try std.testing.expectEqual(@as(usize, 3), gateway.request_bodies.items.len);
+    const retry_roles = [_]types.ChatRole{ .system, .user, .assistant, .tool, .user, .system };
+    try expectGatewayPromptRoles(&gateway, 2, &retry_roles);
+    try expectGatewayPromptTextCount(&gateway, 2, decision_prompt, 1);
+    try expectBodyContainsInOrder(&gateway, 2, &.{
+        decision_prompt,
+        "<network_recovery>",
+    });
+    try std.testing.expectEqual(@as(usize, 1), hooks.executed_names.items.len);
+    try std.testing.expectEqualStrings("read_file", hooks.executed_names.items[0]);
 }
 
 test "processQueuedPrompt masks and terminal-encodes provider diagnostics" {
@@ -4664,8 +4701,8 @@ test "processQueuedPrompt counts only failed provider attempts across tool follo
     try expectGatewayPromptTailText(
         &continued_gateway,
         0,
-        .user,
-        decision_prompt,
+        .system,
+        "Re-run the response for the same user request.",
     );
     try expectGatewayPromptTextCount(
         &continued_gateway,
@@ -4673,6 +4710,10 @@ test "processQueuedPrompt counts only failed provider attempts across tool follo
         decision_prompt,
         1,
     );
+    try expectBodyContainsInOrder(&continued_gateway, 0, &.{
+        decision_prompt,
+        "Re-run the response for the same user request.",
+    });
     try std.testing.expectEqualStrings("Finished after Continue", continued_hooks.history_assistant_text.?);
 }
 

--- a/tests/e2e/gateway-stream-lifecycle.test.ts
+++ b/tests/e2e/gateway-stream-lifecycle.test.ts
@@ -6406,6 +6406,74 @@ printf '%s' ${JSON.stringify(trailingMarker)} > ${JSON.stringify(effectPath)}
     }
   });
 
+  test("post-tool provider retry keeps recovery system provider-valid", async () => {
+    const root = createFixtureRoot("post-tool-retry-order");
+    const tracePath = join(root.root, "trace.log");
+    writeFileSync(join(root.workspace, "fixture.txt"), "deterministic fixture\n");
+    let requestIndex = 0;
+    const recoveredText = "Recovered after provider-valid retry.";
+    const gateway = startDynamicFakeGateway((body) => {
+      requestIndex += 1;
+      if (requestIndex === 1) {
+        return fakeGatewayToolCall("read_retry_order", "read_file", {
+          path: "fixture.txt",
+        });
+      }
+      if (requestIndex === 2) return unavailableResponse();
+
+      const prompt = gatewayRequest(body).prompt;
+      let sawNonSystem = false;
+      const invalidSystemIndex = prompt.findIndex((message, index) => {
+        if (message.role !== "system") {
+          sawNonSystem = true;
+          return false;
+        }
+        if (!sawNonSystem || index === prompt.length - 1) return false;
+        return prompt[index + 1]?.role !== "assistant";
+      });
+      if (invalidSystemIndex >= 0) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              message:
+                `messages.${invalidSystemIndex}: role 'system' must precede an 'assistant' message or end the array`,
+            },
+          }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        );
+      }
+      return fakeGatewayFinalText(recoveredText);
+    }, {
+      models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
+    });
+    try {
+      const result = await runFx(
+        ["ask", "--json", "--auto", "--no-save", "Read fixture.txt, then continue."],
+        {
+          cwd: root.workspace,
+          env: fixtureEnv(root, gateway, tracePath),
+          timeoutMs: 15_000,
+        },
+      );
+      const json = parseAskJson(result.stdout);
+      const retryPrompt = gatewayRequest(gateway.requests[2]!.body).prompt;
+
+      expect(result.code).toBe(0);
+      expect(json.exit_code).toBe(0);
+      expect(json.output).toBe(recoveredText);
+      expect(json.tool_calls).toEqual([{ name: "read_file", status: "success" }]);
+      expect(gateway.requestCount()).toBe(3);
+      expect(retryPrompt.at(-2)?.role).toBe("user");
+      expect(contentText(retryPrompt.at(-2)?.content)).toBe(POST_TOOL_DECISION_PROMPT);
+      expect(retryPrompt.at(-1)?.role).toBe("system");
+      expect(contentText(retryPrompt.at(-1)?.content)).toContain("<network_recovery>");
+      expect(result.stderr).not.toContain("HTTP 400");
+    } finally {
+      gateway.stop();
+      rmSync(root.root, { recursive: true, force: true });
+    }
+  });
+
   test("streamed tool calls without finish reconcile without executing the uncertain call", async () => {
     const root = createFixtureRoot("tool-without-finish");
     const tracePath = join(root.root, "trace.log");


### PR DESCRIPTION
## Summary

- Keep automatic retries valid when recovery follows a completed tool result.
- Preserve the existing continuation prompt and completed tool evidence across recovery.