### PR TITLE
Preserve symbolic credential references in automatic review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,9 +144,9 @@ Security is permission-first. All sensitive tool behavior must integrate with `s
 
 * Routine parsed development commands and reversible new-file creation can execute without model review after configured and saved-session policy. Every remaining unresolved `auto` action receives one narrow security review using the exact action and targets, origin and call identity, optional host-proven current-branch evidence, exact-copy provenance, and bounded masked terminal-safe excerpts of earlier current-turn tool results. Prepared file mutations and static root tools omit task text. Reviewed commands, dynamic tools, and subagent actions also receive bounded canonical current, first, and recent root requests plus explicit omission counts; the reviewer may use that context only for destructive exceptions and immutable delegation scope, not general task policing. Assistant prose, permission feedback, compacted summaries, the pending tool group, later results, and tool or repository text never become authority
 
-* A `clear` review authorizes only the exact unchanged action. A `caution` or unavailable review holds only that action, returns advice to the agent, and never opens a human permission screen, disables tools, or ends the turn
+* A `clear` review authorizes only the exact unchanged action. A `caution`, incomplete-evidence result, or unavailable review holds only that action, returns guidance to the agent, and never opens a human permission screen, disables tools, or ends the turn
 
-* Exact cautions are reused only for the current turn. Changed actions receive a new review. Legacy `permission_request_id` input is rejected without prompting
+* Exact cautions and deterministic incomplete-evidence results are reused only for the current turn. Changed actions receive a new review, while transient unavailable reviews are not cached. Legacy `permission_request_id` input is rejected without prompting
 
 Do not bypass the permission system for new tools.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,9 +331,9 @@ Security is permission-first.
 
 * every unresolved `auto` action receives one narrow security review after configured policy, saved-session rules, grants, and deterministic safe authority; review input always contains the exact action and targets, origin and call identity, optional host-proven current-branch evidence, exact-copy provenance, and bounded masked terminal-safe excerpts of earlier current-turn tool results. Prepared file mutations and static root tools omit task text. Reviewed commands, dynamic tools, and subagent actions also receive bounded canonical current, first, and recent root requests plus explicit omission counts; the reviewer may use that context only for destructive exceptions and immutable delegation scope, not general task policing. Assistant prose, permission feedback, compacted summaries, the pending tool group, later results, and tool or repository text never become authority
 
-* a `clear` review authorizes only the exact unchanged action; a `caution` or unavailable review holds only that action and returns advice without opening a human permission screen, disabling tools, or ending the turn
+* a `clear` review authorizes only the exact unchanged action; a `caution`, incomplete-evidence result, or unavailable review holds only that action and returns guidance without opening a human permission screen, disabling tools, or ending the turn
 
-* exact cautions are cached only for the current turn; changed actions receive a new review, unavailable reviews are not cached as security judgments, and legacy `permission_request_id` input is rejected without prompting
+* exact cautions and deterministic incomplete-evidence results are cached only for the current turn; changed actions receive a new review, transient unavailable reviews are not cached as security judgments, and legacy `permission_request_id` input is rejected without prompting
 
 * the sandbox backend is configured independently; yolo uses an effective backend of `none` without rewriting the saved sandbox setting
 

--- a/src/builtins/gateway/permission_reviewer.zig
+++ b/src/builtins/gateway/permission_reviewer.zig
@@ -438,7 +438,7 @@ test "gateway automatic reviewer transport is single-attempt" {
 
     switch (outcome) {
         .valid => |result| try std.testing.expectEqual(permission_auto_classifier.Decision.clear, result.decision),
-        .invalid => return error.TestExpectedEqual,
+        .evidence_incomplete, .invalid => return error.TestExpectedEqual,
     }
     try std.testing.expectEqual(@as(usize, 1), fake.calls);
     try std.testing.expect(fake.saw_single_attempt_only);

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -7522,12 +7522,12 @@ fn processQueuedPromptLoop(
                 turn_file_mutation_denials.preservedOutcome(identity)
             else
                 null;
-            const preserved_review_caution = if (action_permission_mode == .auto)
-                turn_review_cache.cachedCaution(execution_call)
+            const preserved_review_hold = if (action_permission_mode == .auto)
+                turn_review_cache.cached(execution_call)
             else
                 null;
             const effective_preserved_denial = preserved_denial orelse
-                preserved_review_caution;
+                preserved_review_hold;
             if (effective_preserved_denial != null) {
                 debug_trace.eventf(
                     "permission",
@@ -7778,13 +7778,13 @@ fn processQueuedPromptLoop(
                 }
                 const reason = permission_outcome.denial_reason orelse
                     decision.denialReason() orelse .user_denied;
-                try turn_review_cache.rememberCaution(
+                try turn_review_cache.remember(
                     arena,
                     tool_call,
                     permission_outcome,
                 );
                 const denied_output = switch (reason) {
-                    .review_caution, .review_unavailable => try tool_result_errors.toolReviewHeldJson(
+                    .review_caution, .review_evidence_incomplete, .review_unavailable => try tool_result_errors.toolReviewHeldJson(
                         arena,
                         tool_call.name,
                         reason,

--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -501,6 +501,7 @@ fn expectedPermissionDeniedMessage(reason: types.ToolPermissionDenialReason) ?[]
         .user_denied => "Permission denied by user",
         .auto_denied => "Blocked by automatic safety policy",
         .review_caution => "Action held after safety review",
+        .review_evidence_incomplete => "Safety review evidence incomplete; action held",
         .review_unavailable => "Safety reviewer unavailable; action held",
         .policy_denied, .permission_required => null,
     };

--- a/src/core/agent/runtime/tool_admission.zig
+++ b/src/core/agent/runtime/tool_admission.zig
@@ -30,61 +30,91 @@ const ToolExecutionResult = runtime_tool_contracts.ToolExecutionResult;
 
 const TerminalValidationDigest = [std.crypto.hash.sha2.Sha256.digest_length]u8;
 const PermissionActionId = [std.crypto.hash.sha2.Sha256.digest_length]u8;
-const max_turn_review_cautions: usize = 64;
+const max_turn_review_holds: usize = 64;
 const max_consecutive_malformed_argument_batches: usize = 3;
 
-const CachedCaution = struct {
+const CachedReviewHold = struct {
     exact_id: PermissionActionId,
-    risk: permission_auto_classifier.Risk,
-    rationale: []u8,
+    detail: union(enum) {
+        caution: struct {
+            risk: permission_auto_classifier.Risk,
+            rationale: []u8,
+        },
+        evidence_incomplete,
+    },
 };
 
 pub const TurnReviewCache = struct {
-    cautions: std.ArrayList(CachedCaution) = .empty,
+    holds: std.ArrayList(CachedReviewHold) = .empty,
 
     pub fn deinit(self: *TurnReviewCache, alloc: Allocator) void {
-        for (self.cautions.items) |entry| alloc.free(entry.rationale);
-        self.cautions.deinit(alloc);
+        for (self.holds.items) |entry| switch (entry.detail) {
+            .caution => |caution| alloc.free(caution.rationale),
+            .evidence_incomplete => {},
+        };
+        self.holds.deinit(alloc);
         self.* = .{};
     }
 
-    pub fn rememberCaution(
+    pub fn remember(
         self: *TurnReviewCache,
         alloc: Allocator,
         call: ToolCall,
         outcome: command_admission.PermissionOutcome,
     ) Allocator.Error!void {
-        if (outcome.denial_reason != .review_caution) return;
-        const review = outcome.auto_review_result orelse return;
-        if (review.decision != .caution) return;
+        const denial_reason = outcome.denial_reason orelse return;
+        switch (denial_reason) {
+            .review_caution, .review_evidence_incomplete => {},
+            .user_denied, .auto_denied, .review_unavailable, .policy_denied, .permission_required => return,
+        }
         const exact_id = permissionActionId(call);
-        for (self.cautions.items) |entry| {
+        for (self.holds.items) |entry| {
             if (std.mem.eql(u8, &entry.exact_id, &exact_id)) return;
         }
-        if (self.cautions.items.len == max_turn_review_cautions) return;
-        const rationale = try alloc.dupe(u8, review.rationale);
-        errdefer alloc.free(rationale);
-        try self.cautions.append(alloc, .{
-            .exact_id = exact_id,
-            .risk = review.risk,
-            .rationale = rationale,
-        });
+        if (self.holds.items.len == max_turn_review_holds) return;
+
+        switch (denial_reason) {
+            .review_caution => {
+                const review = outcome.auto_review_result orelse return;
+                if (review.decision != .caution) return;
+                const rationale = try alloc.dupe(u8, review.rationale);
+                errdefer alloc.free(rationale);
+                try self.holds.append(alloc, .{
+                    .exact_id = exact_id,
+                    .detail = .{ .caution = .{
+                        .risk = review.risk,
+                        .rationale = rationale,
+                    } },
+                });
+            },
+            .review_evidence_incomplete => try self.holds.append(alloc, .{
+                .exact_id = exact_id,
+                .detail = .evidence_incomplete,
+            }),
+            .user_denied, .auto_denied, .review_unavailable, .policy_denied, .permission_required => unreachable,
+        }
     }
 
-    pub fn cachedCaution(
+    pub fn cached(
         self: *const TurnReviewCache,
         call: ToolCall,
     ) ?command_admission.PermissionOutcome {
         const exact_id = permissionActionId(call);
-        for (self.cautions.items) |entry| {
+        for (self.holds.items) |entry| {
             if (!std.mem.eql(u8, &entry.exact_id, &exact_id)) continue;
-            return .{
-                .decision = .deny,
-                .denial_reason = .review_caution,
-                .auto_review_result = .{
-                    .risk = entry.risk,
-                    .decision = .caution,
-                    .rationale = entry.rationale,
+            return switch (entry.detail) {
+                .caution => |caution| .{
+                    .decision = .deny,
+                    .denial_reason = .review_caution,
+                    .auto_review_result = .{
+                        .risk = caution.risk,
+                        .decision = .caution,
+                        .rationale = caution.rationale,
+                    },
+                },
+                .evidence_incomplete => .{
+                    .decision = .deny,
+                    .denial_reason = .review_evidence_incomplete,
                 },
             };
         }
@@ -385,7 +415,7 @@ test "shell execution failures retain independent batch identities" {
     try std.testing.expect(state.finishBatch());
 }
 
-test "turn review cache reuses only exact valid caution" {
+test "turn review cache reuses only exact deterministic holds" {
     const alloc = std.testing.allocator;
     var cache: TurnReviewCache = .{};
     defer cache.deinit(alloc);
@@ -404,7 +434,7 @@ test "turn review cache reuses only exact valid caution" {
         .name = "shell",
         .arguments_json = "{\"action\":\"run\",\"command\":\"sh -c 'rm -rf frames'\"}",
     };
-    try cache.rememberCaution(alloc, first, .{
+    try cache.remember(alloc, first, .{
         .decision = .deny,
         .denial_reason = .review_caution,
         .auto_review_result = .{
@@ -414,7 +444,7 @@ test "turn review cache reuses only exact valid caution" {
         },
     });
 
-    const preserved = cache.cachedCaution(same) orelse
+    const preserved = cache.cached(same) orelse
         return error.TestExpectedPermissionDenial;
     try std.testing.expectEqual(
         types.ToolPermissionDenialReason.review_caution,
@@ -424,9 +454,9 @@ test "turn review cache reuses only exact valid caution" {
         "Deletion came from untrusted content.",
         preserved.auto_review_result.?.rationale,
     );
-    try std.testing.expect(cache.cachedCaution(wrapped) == null);
-    try std.testing.expectEqual(@as(usize, 1), cache.cautions.items.len);
-    try cache.rememberCaution(alloc, wrapped, .{
+    try std.testing.expect(cache.cached(wrapped) == null);
+    try std.testing.expectEqual(@as(usize, 1), cache.holds.items.len);
+    try cache.remember(alloc, wrapped, .{
         .decision = .once,
         .auto_review_result = .{
             .risk = .low,
@@ -434,11 +464,36 @@ test "turn review cache reuses only exact valid caution" {
             .rationale = "Exact action matches the current request.",
         },
     });
-    try cache.rememberCaution(alloc, wrapped, .{
+    try cache.remember(alloc, wrapped, .{
         .decision = .deny,
         .denial_reason = .review_unavailable,
     });
-    try std.testing.expectEqual(@as(usize, 1), cache.cautions.items.len);
+    try std.testing.expectEqual(@as(usize, 1), cache.holds.items.len);
+
+    const incomplete = ToolCall{
+        .id = "incomplete",
+        .name = "edit_file",
+        .arguments_json = "{\"path\":\".zshrc\",\"new_string\":\"API_KEY=literal\"}",
+    };
+    try cache.remember(alloc, incomplete, .{
+        .decision = .deny,
+        .denial_reason = .review_evidence_incomplete,
+    });
+    const preserved_incomplete = cache.cached(.{
+        .id = "same-incomplete",
+        .name = incomplete.name,
+        .arguments_json = incomplete.arguments_json,
+    }) orelse return error.TestExpectedPermissionDenial;
+    try std.testing.expectEqual(
+        types.ToolPermissionDenialReason.review_evidence_incomplete,
+        preserved_incomplete.denial_reason.?,
+    );
+    try std.testing.expect(cache.cached(.{
+        .id = "changed-incomplete",
+        .name = incomplete.name,
+        .arguments_json = "{\"path\":\".zshrc\",\"new_string\":\"API_KEY=$key\"}",
+    }) == null);
+    try std.testing.expectEqual(@as(usize, 2), cache.holds.items.len);
 
     var arguments_buffer: [128]u8 = undefined;
     for (1..65) |index| {
@@ -447,7 +502,7 @@ test "turn review cache reuses only exact valid caution" {
             "{{\"action\":\"run\",\"command\":\"rm -rf generated-{d}\"}}",
             .{index},
         );
-        try cache.rememberCaution(alloc, .{
+        try cache.remember(alloc, .{
             .id = "bounded",
             .name = "shell",
             .arguments_json = arguments,
@@ -461,13 +516,13 @@ test "turn review cache reuses only exact valid caution" {
             },
         });
     }
-    try std.testing.expectEqual(max_turn_review_cautions, cache.cautions.items.len);
+    try std.testing.expectEqual(max_turn_review_holds, cache.holds.items.len);
     const overflow_arguments = try std.fmt.bufPrint(
         &arguments_buffer,
         "{{\"action\":\"run\",\"command\":\"rm -rf generated-{d}\"}}",
         .{@as(usize, 64)},
     );
-    try std.testing.expect(cache.cachedCaution(.{
+    try std.testing.expect(cache.cached(.{
         .id = "overflow",
         .name = "shell",
         .arguments_json = overflow_arguments,
@@ -706,6 +761,7 @@ pub noinline fn permissionDeniedStatusLabel(reason: types.ToolPermissionDenialRe
         .user_denied => "Denied",
         .auto_denied => "Denied by auto agent",
         .review_caution => "Safety caution",
+        .review_evidence_incomplete => "Review evidence incomplete",
         .review_unavailable => "Review unavailable",
         .policy_denied => "Denied",
         .permission_required => "Permission required",

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -6519,6 +6519,7 @@ test "execution replay preserves permission denial reasons" {
         .policy_denied,
         .permission_required,
         .review_caution,
+        .review_evidence_incomplete,
         .review_unavailable,
     };
     const call_ids = [_][]const u8{
@@ -6527,6 +6528,7 @@ test "execution replay preserves permission denial reasons" {
         "call_policy_denied",
         "call_permission_required",
         "call_review_caution",
+        "call_review_evidence_incomplete",
         "call_review_unavailable",
     };
     var outputs: [reasons.len][]u8 = undefined;
@@ -6536,7 +6538,7 @@ test "execution replay preserves permission denial reasons" {
     var results: [reasons.len]types.PersistedToolResult = undefined;
     for (reasons, 0..) |reason, index| {
         outputs[index] = switch (reason) {
-            .review_caution, .review_unavailable => try tool_result_errors.toolReviewHeldJson(
+            .review_caution, .review_evidence_incomplete, .review_unavailable => try tool_result_errors.toolReviewHeldJson(
                 alloc,
                 "run_command",
                 reason,
@@ -6572,16 +6574,17 @@ test "execution replay preserves permission denial reasons" {
 
     try std.testing.expectEqualSlices(
         types.ToolOutcomeKind,
-        &.{ .denied, .denied, .denied, .denied, .denied, .denied },
+        &.{ .denied, .denied, .denied, .denied, .denied, .denied, .denied },
         app.completed_tool_outcomes.items,
     );
-    try std.testing.expectEqual(@as(usize, 6), app.completed_tool_statuses.items.len);
+    try std.testing.expectEqual(@as(usize, 7), app.completed_tool_statuses.items.len);
     try std.testing.expectEqualStrings("● Denied run_command\n", app.completed_tool_statuses.items[0]);
     try std.testing.expectEqualStrings("● Denied by auto agent run_command\n", app.completed_tool_statuses.items[1]);
     try std.testing.expectEqualStrings("● Denied run_command\n", app.completed_tool_statuses.items[2]);
     try std.testing.expectEqualStrings("● Permission required run_command\n", app.completed_tool_statuses.items[3]);
     try std.testing.expectEqualStrings("● Safety caution run_command\n", app.completed_tool_statuses.items[4]);
-    try std.testing.expectEqualStrings("● Review unavailable run_command\n", app.completed_tool_statuses.items[5]);
+    try std.testing.expectEqualStrings("● Review evidence incomplete run_command\n", app.completed_tool_statuses.items[5]);
+    try std.testing.expectEqualStrings("● Review unavailable run_command\n", app.completed_tool_statuses.items[6]);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);
 }
 

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -51,12 +51,13 @@ pub const HostSafetyOverride = enum {
 
 pub const ParseOutcome = union(enum) {
     valid: Result,
+    evidence_incomplete,
     invalid,
 
     pub fn deinit(self: *ParseOutcome, alloc: std.mem.Allocator) void {
         switch (self.*) {
             .valid => |*result| result.deinit(alloc),
-            .invalid => {},
+            .evidence_incomplete, .invalid => {},
         }
         self.* = undefined;
     }
@@ -68,7 +69,7 @@ pub fn hostDisposition(outcome: ParseOutcome) HostDisposition {
             .clear => .clear,
             .caution => .caution,
         },
-        .invalid => .unavailable,
+        .evidence_incomplete, .invalid => .unavailable,
     };
 }
 
@@ -450,7 +451,14 @@ pub const Reviewer = struct {
             return constructionFailure(err);
         };
         defer evidence.deinit(alloc);
-        if (!evidence.action_complete) return .invalid;
+        if (!evidence.action_complete) {
+            debug_trace.logf(
+                "permission",
+                "event=auto_review_compose_result result=evidence_incomplete elapsed_ms={d} target_call_id={s}",
+                .{ io_mod.milliTimestamp() - started_ms, review_turn.target_call_id },
+            );
+            return .evidence_incomplete;
+        }
         checkBudget(deadline, cancel_flag) catch |err| return constructionFailure(err);
         const tools_json = toolsJsonAlloc(alloc) catch |err| return constructionFailure(err);
         defer alloc.free(tools_json);
@@ -1395,7 +1403,7 @@ test "automatic review parses clear and caution assessments" {
         defer outcome.deinit(std.testing.allocator);
         switch (outcome) {
             .valid => |result| try std.testing.expectEqual(case.expected, result.decision),
-            .invalid => return error.TestExpectedEqual,
+            .evidence_incomplete, .invalid => return error.TestExpectedEqual,
         }
     }
 }
@@ -1709,35 +1717,122 @@ test "automatic review does not send redacted action evidence" {
         .send_fn = FakeTransport.send,
         .build_fn = buildTestReviewPayload,
     }, null, 1000);
+    const new_content = "AI_GATEWAY_API_KEY=\"super-secret\" run-sandbox\n";
+    var review = try diff_mod.FileReview.init(std.testing.allocator, "", new_content);
+    defer review.deinit(std.testing.allocator);
     const pending_assistant = types.ChatMessage{
         .role = .assistant,
         .tool_calls = &.{.{
             .id = "call_secret",
-            .name = "run_command",
-            .arguments_json = "{\"command\":\"printf API_KEY=super-secret\"}",
+            .name = "edit_file",
+            .arguments_json = "{}",
         }},
     };
-    const outcome = try reviewer.review(std.testing.allocator, .{
+    var outcome = try reviewer.review(std.testing.allocator, .{
         .review_turn = .{
             .model = "openai/gpt-5",
             .pending_assistant = pending_assistant,
             .target_call_id = "call_secret",
             .origin = .root,
-            .trusted_root_context = "Run the requested command.",
         },
-        .targets = &.{},
-        .action = .{ .command = .{
-            .command = "printf API_KEY=super-secret",
-            .resolved_cwd = "/tmp/workspace",
-            .background = false,
-            .target_os = .linux,
+        .targets = &.{.{
+            .role = "target",
+            .path = @constCast("/tmp/home/.zshrc"),
+        }},
+        .action = .{ .file_mutation = .{
+            .tool_name = "edit_file",
+            .display_path = "/tmp/home/.zshrc",
+            .preimage = .present,
+            .additions = review.additions,
+            .deletions = review.deletions,
+            .review = review,
         } },
     });
+    defer outcome.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(std.meta.Tag(ParseOutcome).invalid, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(
+        std.meta.Tag(ParseOutcome).evidence_incomplete,
+        std.meta.activeTag(outcome),
+    );
     try std.testing.expectEqual(@as(usize, 0), fake.calls);
     try std.testing.expect(!fake.saw_redaction);
     try std.testing.expect(!fake.saw_secret);
+}
+
+test "automatic review sends symbolic secret references as complete evidence" {
+    const FakeTransport = struct {
+        calls: usize = 0,
+        saw_symbolic_reference: bool = false,
+
+        fn send(
+            raw_ctx: *anyopaque,
+            _: std.mem.Allocator,
+            _: []const u8,
+            payload: []const u8,
+            _: std.Io.Clock.Timestamp,
+            _: *std.atomic.Value(bool),
+        ) anyerror!TransportOutcome {
+            const self: *@This() = @ptrCast(@alignCast(raw_ctx));
+            self.calls += 1;
+            self.saw_symbolic_reference = std.mem.find(
+                u8,
+                payload,
+                "AI_GATEWAY_API_KEY=\\\"$key\\\"",
+            ) != null;
+            return .{ .completion = .{ .completion = .{
+                .tool_calls = &.{.{
+                    .id = "review",
+                    .name = tool_name,
+                    .arguments_json = "{\"risk\":\"low\",\"decision\":\"clear\",\"rationale\":\"symbolic reference is reviewable\"}",
+                }},
+            } } };
+        }
+    };
+
+    const new_content =
+        "_rfx() {\n" ++
+        "  local key\n" ++
+        "  key=\"$(load-key)\" || return 1\n" ++
+        "  AI_GATEWAY_API_KEY=\"$key\" run-sandbox\n" ++
+        "}\n";
+    var review = try diff_mod.FileReview.init(std.testing.allocator, "", new_content);
+    defer review.deinit(std.testing.allocator);
+    var fake = FakeTransport{};
+    const reviewer = Reviewer.withTransport(.{
+        .context = @ptrCast(&fake),
+        .send_fn = FakeTransport.send,
+        .build_fn = buildTestReviewPayload,
+    }, null, 1000);
+    var outcome = try reviewer.review(std.testing.allocator, .{
+        .review_turn = .{
+            .model = "test/source-model",
+            .pending_assistant = .{ .role = .assistant, .tool_calls = &.{.{
+                .id = "symbolic-edit",
+                .name = "edit_file",
+                .arguments_json = "{}",
+            }} },
+            .target_call_id = "symbolic-edit",
+            .origin = .root,
+            .trusted_root_context = "Install the requested shell helper.",
+        },
+        .targets = &.{.{
+            .role = "target",
+            .path = @constCast("/tmp/home/.zshrc"),
+        }},
+        .action = .{ .file_mutation = .{
+            .tool_name = "edit_file",
+            .display_path = "/tmp/home/.zshrc",
+            .preimage = .present,
+            .additions = review.additions,
+            .deletions = review.deletions,
+            .review = review,
+        } },
+    });
+    defer outcome.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(std.meta.Tag(ParseOutcome).valid, std.meta.activeTag(outcome));
+    try std.testing.expectEqual(@as(usize, 1), fake.calls);
+    try std.testing.expect(fake.saw_symbolic_reference);
 }
 
 test "automatic review preserves prepared file lines within its evidence byte budget" {

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -1717,7 +1717,7 @@ test "automatic review does not send redacted action evidence" {
         .send_fn = FakeTransport.send,
         .build_fn = buildTestReviewPayload,
     }, null, 1000);
-    const new_content = "AI_GATEWAY_API_KEY=\"super-secret\" run-sandbox\n";
+    const new_content = "AI_GATEWAY_API_KEY=\"$key\"literal-secret run-sandbox\n";
     var review = try diff_mod.FileReview.init(std.testing.allocator, "", new_content);
     defer review.deinit(std.testing.allocator);
     const pending_assistant = types.ChatMessage{

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -786,18 +786,19 @@ fn isPureSymbolicAssignment(
     )) return false;
     const value_end = value.prefix_end + value.value_len;
     if (text[value_start] != '"') {
-        return value_end == text.len or isShellWordBoundary(text[value_end]);
+        return value_end == text.len or isShellWordBoundary(text, value_end);
     }
 
     const closing_quote = value_end;
     if (closing_quote >= text.len or text[closing_quote] != '"') return false;
     const next = closing_quote + 1;
-    return next == text.len or isShellWordBoundary(text[next]);
+    return next == text.len or isShellWordBoundary(text, next);
 }
 
-fn isShellWordBoundary(byte: u8) bool {
-    return std.ascii.isWhitespace(byte) or switch (byte) {
-        ';', '&', '|', '<', '>', '(', ')' => true,
+fn isShellWordBoundary(text: []const u8, index: usize) bool {
+    return switch (text[index]) {
+        ' ', '\t', '\n', ';', '&', '|', ')' => true,
+        '<', '>' => index + 1 == text.len or text[index + 1] != '(',
         else => false,
     };
 }
@@ -1005,7 +1006,10 @@ test "maskSecrets preserves pure symbolic sensitive assignments" {
         "AI_GATEWAY_API_KEY=\"$key\"\n" ++
         "GITHUB_TOKEN=$token\n" ++
         "DATABASE_URL=\"${database_url}\"\n" ++
-        "TOKEN=\"$token\"; run-next";
+        "TOKEN=\"$token\"; run-next\n" ++
+        "PASSWORD=\"$password\"\tcheck-next\n" ++
+        "ACCESS_TOKEN=\"$token\">token.out\n" ++
+        "SECRET_KEY=\"$key\")";
 
     const masked = try maskSecrets(alloc, input);
     defer if (masked.ptr != input.ptr) alloc.free(masked);
@@ -1022,6 +1026,12 @@ test "maskSecrets masks compound or literal sensitive assignments" {
         "API_KEY=\"$(load-key)\"\n" ++
         "VERCEL_OIDC_TOKEN=\"$token\"literal-suffix\n" ++
         "OPENAI_API_KEY=$key\"literal-suffix\"\n" ++
+        "PASSWORD=\"$password\"\x0bliteral-suffix\n" ++
+        "ACCESS_TOKEN=\"$token\"\x0cliteral-suffix\n" ++
+        "SECRET=\"$secret\"\rliteral-suffix\n" ++
+        "AI_GATEWAY_API_KEY=\"$key\"(literal-suffix)\n" ++
+        "GITHUB_TOKEN=\"$token\"<(literal-suffix)\n" ++
+        "ACCESS_TOKEN=\"$token\">(literal-suffix)\n" ++
         "SECRET_KEY=\"$key";
 
     const masked = try maskSecrets(alloc, input);
@@ -1034,6 +1044,12 @@ test "maskSecrets masks compound or literal sensitive assignments" {
             "API_KEY=\"[redacted]\"\n" ++
             "VERCEL_OIDC_TOKEN=\"[redacted]\"literal-suffix\n" ++
             "OPENAI_API_KEY=[redacted]\"literal-suffix\"\n" ++
+            "PASSWORD=\"[redacted]\"\x0bliteral-suffix\n" ++
+            "ACCESS_TOKEN=\"[redacted]\"\x0cliteral-suffix\n" ++
+            "SECRET=\"[redacted]\"\rliteral-suffix\n" ++
+            "AI_GATEWAY_API_KEY=\"[redacted]\"(literal-suffix)\n" ++
+            "GITHUB_TOKEN=\"[redacted]\"<(literal-suffix)\n" ++
+            "ACCESS_TOKEN=\"[redacted]\">(literal-suffix)\n" ++
             "SECRET_KEY=\"[redacted]",
         masked,
     );

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -674,7 +674,7 @@ fn findSecretSpan(text: []const u8, start: usize) ?SecretSpan {
     for (secret_prefixes) |prefix| {
         if (start + prefix.len < text.len and eqlIgnoreCase(text[start .. start + prefix.len], prefix)) {
             const value_start = start + prefix.len;
-            if (assignmentValueSpan(text, value_start)) |value| {
+            if (secretAssignmentValueSpan(text, value_start)) |value| {
                 return .{ .prefix_end = value.prefix_end, .value_len = value.value_len, .kind = "assignment" };
             }
         }
@@ -758,7 +758,7 @@ fn matchesSensitiveAssignment(text: []const u8, start: usize) ?SecretSpan {
     if (!sensitiveAssignmentKey(key)) return null;
 
     const value_start = eq + 1;
-    if (assignmentValueSpan(text, value_start)) |value| {
+    if (secretAssignmentValueSpan(text, value_start)) |value| {
         return .{ .prefix_end = value.prefix_end, .value_len = value.value_len, .kind = "assignment" };
     }
     return null;
@@ -768,6 +768,33 @@ const AssignmentValueSpan = struct {
     prefix_end: usize,
     value_len: usize,
 };
+
+fn secretAssignmentValueSpan(text: []const u8, value_start: usize) ?AssignmentValueSpan {
+    const value = assignmentValueSpan(text, value_start) orelse return null;
+    if (text[value_start] != '\'' and isPureShellVariableReference(
+        text[value.prefix_end .. value.prefix_end + value.value_len],
+    )) return null;
+    return value;
+}
+
+fn isPureShellVariableReference(value: []const u8) bool {
+    if (value.len < 2 or value[0] != '$') return false;
+    if (value[1] == '{') {
+        if (value.len < 4 or value[value.len - 1] != '}') return false;
+        return isShellVariableName(value[2 .. value.len - 1]);
+    }
+    return isShellVariableName(value[1..]);
+}
+
+fn isShellVariableName(value: []const u8) bool {
+    if (value.len == 0 or !(std.ascii.isAlphabetic(value[0]) or value[0] == '_')) {
+        return false;
+    }
+    for (value[1..]) |byte| {
+        if (!(std.ascii.isAlphanumeric(byte) or byte == '_')) return false;
+    }
+    return true;
+}
 
 fn assignmentValueSpan(text: []const u8, value_start: usize) ?AssignmentValueSpan {
     if (value_start >= text.len) return null;
@@ -945,6 +972,39 @@ test "maskSecrets masks quoted sensitive assignments" {
     try std.testing.expect(std.mem.find(u8, masked, "double-secret") == null);
     try std.testing.expect(std.mem.find(u8, masked, "single-secret") == null);
     try std.testing.expect(std.mem.find(u8, masked, "access-secret") == null);
+}
+
+test "maskSecrets preserves pure symbolic sensitive assignments" {
+    const alloc = std.testing.allocator;
+    const input =
+        "AI_GATEWAY_API_KEY=\"$key\"\n" ++
+        "GITHUB_TOKEN=$token\n" ++
+        "DATABASE_URL=\"${database_url}\"";
+
+    const masked = try maskSecrets(alloc, input);
+    defer if (masked.ptr != input.ptr) alloc.free(masked);
+
+    try std.testing.expectEqualStrings(input, masked);
+}
+
+test "maskSecrets masks compound or literal sensitive assignments" {
+    const alloc = std.testing.allocator;
+    const input =
+        "AI_GATEWAY_API_KEY=\"literal-value\"\n" ++
+        "GITHUB_TOKEN=\"$token-suffix\"\n" ++
+        "DATABASE_URL=\"${database_url:-fallback}\"\n" ++
+        "API_KEY=\"$(load-key)\"";
+
+    const masked = try maskSecrets(alloc, input);
+    defer if (masked.ptr != input.ptr) alloc.free(masked);
+
+    try std.testing.expectEqualStrings(
+        "AI_GATEWAY_API_KEY=\"[redacted]\"\n" ++
+            "GITHUB_TOKEN=\"[redacted]\"\n" ++
+            "DATABASE_URL=\"[redacted]\"\n" ++
+            "API_KEY=\"[redacted]\"",
+        masked,
+    );
 }
 
 test "maskSecrets preserves non-sensitive quoted assignments" {

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -771,10 +771,35 @@ const AssignmentValueSpan = struct {
 
 fn secretAssignmentValueSpan(text: []const u8, value_start: usize) ?AssignmentValueSpan {
     const value = assignmentValueSpan(text, value_start) orelse return null;
-    if (text[value_start] != '\'' and isPureShellVariableReference(
-        text[value.prefix_end .. value.prefix_end + value.value_len],
-    )) return null;
+    if (isPureSymbolicAssignment(text, value_start, value)) return null;
     return value;
+}
+
+fn isPureSymbolicAssignment(
+    text: []const u8,
+    value_start: usize,
+    value: AssignmentValueSpan,
+) bool {
+    if (text[value_start] == '\'') return false;
+    if (!isPureShellVariableReference(
+        text[value.prefix_end .. value.prefix_end + value.value_len],
+    )) return false;
+    const value_end = value.prefix_end + value.value_len;
+    if (text[value_start] != '"') {
+        return value_end == text.len or isShellWordBoundary(text[value_end]);
+    }
+
+    const closing_quote = value_end;
+    if (closing_quote >= text.len or text[closing_quote] != '"') return false;
+    const next = closing_quote + 1;
+    return next == text.len or isShellWordBoundary(text[next]);
+}
+
+fn isShellWordBoundary(byte: u8) bool {
+    return std.ascii.isWhitespace(byte) or switch (byte) {
+        ';', '&', '|', '<', '>', '(', ')' => true,
+        else => false,
+    };
 }
 
 fn isPureShellVariableReference(value: []const u8) bool {
@@ -979,7 +1004,8 @@ test "maskSecrets preserves pure symbolic sensitive assignments" {
     const input =
         "AI_GATEWAY_API_KEY=\"$key\"\n" ++
         "GITHUB_TOKEN=$token\n" ++
-        "DATABASE_URL=\"${database_url}\"";
+        "DATABASE_URL=\"${database_url}\"\n" ++
+        "TOKEN=\"$token\"; run-next";
 
     const masked = try maskSecrets(alloc, input);
     defer if (masked.ptr != input.ptr) alloc.free(masked);
@@ -993,7 +1019,10 @@ test "maskSecrets masks compound or literal sensitive assignments" {
         "AI_GATEWAY_API_KEY=\"literal-value\"\n" ++
         "GITHUB_TOKEN=\"$token-suffix\"\n" ++
         "DATABASE_URL=\"${database_url:-fallback}\"\n" ++
-        "API_KEY=\"$(load-key)\"";
+        "API_KEY=\"$(load-key)\"\n" ++
+        "VERCEL_OIDC_TOKEN=\"$token\"literal-suffix\n" ++
+        "OPENAI_API_KEY=$key\"literal-suffix\"\n" ++
+        "SECRET_KEY=\"$key";
 
     const masked = try maskSecrets(alloc, input);
     defer if (masked.ptr != input.ptr) alloc.free(masked);
@@ -1002,7 +1031,10 @@ test "maskSecrets masks compound or literal sensitive assignments" {
         "AI_GATEWAY_API_KEY=\"[redacted]\"\n" ++
             "GITHUB_TOKEN=\"[redacted]\"\n" ++
             "DATABASE_URL=\"[redacted]\"\n" ++
-            "API_KEY=\"[redacted]\"",
+            "API_KEY=\"[redacted]\"\n" ++
+            "VERCEL_OIDC_TOKEN=\"[redacted]\"literal-suffix\n" ++
+            "OPENAI_API_KEY=[redacted]\"literal-suffix\"\n" ++
+            "SECRET_KEY=\"[redacted]",
         masked,
     );
 }

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -1725,6 +1725,7 @@ pub const ToolPermissionDenialReason = enum {
     user_denied,
     auto_denied,
     review_caution,
+    review_evidence_incomplete,
     review_unavailable,
     policy_denied,
     permission_required,

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -944,6 +944,12 @@ fn nonAllowAutoReviewOutcome(
     request: permission_auto_classifier.ReviewRequest,
     review: permission_auto_classifier.ParseOutcome,
 ) !?command_admission.PermissionOutcome {
+    if (review == .evidence_incomplete) {
+        return .{
+            .decision = .deny,
+            .denial_reason = .review_evidence_incomplete,
+        };
+    }
     return switch (permission_auto_classifier.validatedHostDisposition(
         request,
         review,
@@ -976,7 +982,7 @@ fn nonAllowAutoReviewOutcome(
                     },
                 };
             },
-            .invalid => unreachable,
+            .evidence_incomplete, .invalid => unreachable,
         },
     };
 }
@@ -1056,6 +1062,11 @@ fn runAutomaticReview(
             "permission",
             "event=auto_review_result tool_name={s} decision={s} fallback_reason=none elapsed_ms={d} execution_started=false call_id={s}",
             .{ call.name, @tagName(result.decision), io_mod.milliTimestamp() - started_ms, call.id },
+        ),
+        .evidence_incomplete => debug_trace.logf(
+            "permission",
+            "event=auto_review_result tool_name={s} decision=held fallback_reason=review_evidence_incomplete recovery=agent_replan elapsed_ms={d} execution_started=false call_id={s}",
+            .{ call.name, io_mod.milliTimestamp() - started_ms, call.id },
         ),
         .invalid => debug_trace.logf(
             "permission",

--- a/src/core/tooling/tool_result_errors.zig
+++ b/src/core/tooling/tool_result_errors.zig
@@ -113,7 +113,7 @@ const adapter_semantic_failure_prefixes = [_][]const u8{
 pub fn toolPermissionDeniedJson(alloc: Allocator, tool_name: []const u8, reason: types.ToolPermissionDenialReason) Allocator.Error![]u8 {
     switch (reason) {
         .user_denied, .auto_denied, .policy_denied, .permission_required => {},
-        .review_caution, .review_unavailable => unreachable,
+        .review_caution, .review_evidence_incomplete, .review_unavailable => unreachable,
     }
     var out: std.Io.Writer.Allocating = .init(alloc);
     errdefer out.deinit();
@@ -136,7 +136,7 @@ pub fn toolReviewHeldJson(
     advice: ?[]const u8,
 ) Allocator.Error![]u8 {
     switch (reason) {
-        .review_caution, .review_unavailable => {},
+        .review_caution, .review_evidence_incomplete, .review_unavailable => {},
         .user_denied, .auto_denied, .policy_denied, .permission_required => unreachable,
     }
     var out: std.Io.Writer.Allocating = .init(alloc);
@@ -175,6 +175,7 @@ fn permissionDeniedMessage(tool_name: []const u8, reason: types.ToolPermissionDe
         .user_denied => "Permission denied by user",
         .auto_denied => "Blocked by automatic safety policy",
         .review_caution => "Action held after safety review",
+        .review_evidence_incomplete => "Safety review evidence incomplete; action held",
         .review_unavailable => "Safety reviewer unavailable; action held",
         .policy_denied => if (is_network_tool(tool_name))
             "Network or browser access was denied by configured policy"
@@ -198,6 +199,7 @@ fn permissionDeniedSuggestion(
         .user_denied => "The tool did not run. Do not retry unchanged; explain the denial or use a safer allowed alternative.",
         .auto_denied => "The tool did not run. This is a legacy automatic denial; choose a materially different safe action or explain the blocker.",
         .review_caution => "The action did not run. Use the review advice to choose a materially different safe action, or explain why no safe path remains.",
+        .review_evidence_incomplete => "The action did not run because safety review could not inspect the complete exact action. Do not retry unchanged; remove literal secret material, use a symbolic reference, or choose a materially different action.",
         .review_unavailable => "The action did not run because safety review was unavailable. Continue with a different safe action or retry later.",
         .policy_denied => "The tool did not run. Do not retry unchanged; explain the configured policy blocker or use an allowed alternative.",
         .permission_required => "The tool did not run. Noninteractive mode cannot show an approval prompt. Rerun interactively to approve, or configure a narrow permission rule before retrying.",
@@ -243,7 +245,7 @@ pub fn toolPermissionDenialReason(output: []const u8) ?types.ToolPermissionDenia
         reason_value,
     ) orelse return null;
     const review_reason = switch (reason) {
-        .review_caution, .review_unavailable => true,
+        .review_caution, .review_evidence_incomplete, .review_unavailable => true,
         .user_denied, .auto_denied, .policy_denied, .permission_required => false,
     };
     if (review_held != review_reason) return null;
@@ -449,7 +451,7 @@ test "tool permission denied JSON carries stable fields only" {
     try std.testing.expect(isToolPermissionDeniedOutput(payload));
 }
 
-test "review hold JSON distinguishes caution and unavailable from permission denial" {
+test "review hold JSON preserves typed reasons apart from permission denial" {
     const alloc = std.testing.allocator;
     const caution = try toolReviewHeldJson(
         alloc,
@@ -465,6 +467,13 @@ test "review hold JSON distinguishes caution and unavailable from permission den
         null,
     );
     defer alloc.free(unavailable);
+    const incomplete = try toolReviewHeldJson(
+        alloc,
+        "edit_file",
+        .review_evidence_incomplete,
+        null,
+    );
+    defer alloc.free(incomplete);
 
     try std.testing.expect(std.mem.find(u8, caution, "\"type\":\"tool_review_held\"") != null);
     try std.testing.expect(std.mem.find(u8, caution, "\"reason\":\"review_caution\"") != null);
@@ -485,6 +494,12 @@ test "review hold JSON distinguishes caution and unavailable from permission den
     try std.testing.expectEqual(
         @as(?types.ToolPermissionDenialReason, .review_unavailable),
         toolPermissionDenialReason(unavailable),
+    );
+    try std.testing.expect(std.mem.find(u8, incomplete, "\"reason\":\"review_evidence_incomplete\"") != null);
+    try std.testing.expect(std.mem.find(u8, incomplete, "Do not retry unchanged") != null);
+    try std.testing.expectEqual(
+        @as(?types.ToolPermissionDenialReason, .review_evidence_incomplete),
+        toolPermissionDenialReason(incomplete),
     );
     try std.testing.expect(toolPermissionDenialReason(
         "{\"error\":{\"type\":\"tool_review_held\",\"reason\":\"auto_denied\"}}",

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -941,6 +941,117 @@ describe("lean auto mode reliability", () => {
   );
 
   test(
+    "symbolic credential references remain reviewable in external startup edits",
+    async () => {
+      const root = createIsolatedRoot();
+      const startup = join(root.home, ".zshrc");
+      const before = "alias r='cd ~/projects/research && fx'\n";
+      const after = before +
+        "\n_rfx() {\n" +
+        "  local key\n" +
+        "  key=\"$(create-key)\" || return 1\n" +
+        "  AI_GATEWAY_API_KEY=\"$key\" run-sandbox\n" +
+        "}\n";
+      writeFileSync(startup, before);
+      const gateway = startGateway(
+        [
+          fakeGatewayToolCall("symbolic_startup_edit", "edit_file", {
+            path: startup,
+            old_string: before,
+            new_string: after,
+          }),
+          (body) => {
+            expect(toolResultText(body, "symbolic_startup_edit")).toContain(
+              "edited ",
+            );
+            return fakeGatewayFinalText("startup helper installed");
+          },
+        ],
+        [fakeGatewayPermissionDecision("clear", "symbolic_startup_review")],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Install the shell helper."],
+        {
+          cwd: root.workspace,
+          env: gatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(gateway.classifierRequests).toHaveLength(1);
+      const review = gateway.classifierRequests[0]!.body;
+      expect(review).toContain("AI_GATEWAY_API_KEY");
+      expect(review).toContain("$key");
+      expect(review).not.toContain("AI_GATEWAY_API_KEY=[redacted]");
+      expect(readFileSync(startup, "utf8")).toBe(after);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "literal credentials produce one deterministic hold for unchanged startup edits",
+    async () => {
+      const root = createIsolatedRoot();
+      const startup = join(root.home, ".zshrc");
+      const tracePath = join(root.root, "trace.log");
+      const before = "alias r='cd ~/projects/research && fx'\n";
+      const after = before + 'AI_GATEWAY_API_KEY="literal-fixture-value" run-sandbox\n';
+      const edit = (id: string) => fakeGatewayToolCall(id, "edit_file", {
+        path: startup,
+        old_string: before,
+        new_string: after,
+      });
+      writeFileSync(startup, before);
+      const gateway = startGateway([
+        edit("literal_startup_edit_1"),
+        (body) => {
+          const held = toolResultText(
+            body,
+            "literal_startup_edit_1",
+            "execution-denied",
+          );
+          expect(held).toContain("review_evidence_incomplete");
+          expect(held).toContain("Do not retry unchanged");
+          return edit("literal_startup_edit_2");
+        },
+        (body) => {
+          const held = toolResultText(
+            body,
+            "literal_startup_edit_2",
+            "execution-denied",
+          );
+          expect(held).toContain("review_evidence_incomplete");
+          expect(held).toContain("Do not retry unchanged");
+          return fakeGatewayFinalText("unchanged retry held");
+        },
+      ]);
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Install the shell helper."],
+        {
+          cwd: root.workspace,
+          env: {
+            ...gatewayEnv(root, gateway),
+            FX_TRACE_LOG: tracePath,
+            FX_TRACE_SCOPES: "permission",
+          },
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(gateway.classifierRequests).toHaveLength(0);
+      expect(readFileSync(startup, "utf8")).toBe(before);
+      const trace = readFileSync(tracePath, "utf8");
+      expect(trace).toContain("turn_permission_denial_preserved");
+      expect(trace).toContain("review_evidence_incomplete");
+    },
+    TIMEOUT,
+  );
+
+  test(
     "contextual command review keeps oversized root history bounded",
     async () => {
       const root = createIsolatedRoot();


### PR DESCRIPTION
## Summary

- Review pure shell credential references without masking them.
- Report literal-secret masking as incomplete review evidence, not reviewer unavailability.
- Reuse unchanged incomplete-evidence holds for the turn and tell the agent not to retry them.