### PR TITLE
Hide private child session details

### DIFF
--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -1332,7 +1332,8 @@ fn runNonInteractiveWithDeps(
                     return .handled_success;
                 },
                 .id => |id| {
-                    var detail = store.loadReadOnlyDetail(
+                    var detail = subagent_resume_admission.loadVisibleReadOnlyDetail(
+                        store,
                         alloc,
                         id,
                         .{},

--- a/src/core/subagent/resume_admission.zig
+++ b/src/core/subagent/resume_admission.zig
@@ -111,6 +111,28 @@ pub fn latestVisibleWorkspaceSummary(
     );
 }
 
+pub fn loadVisibleReadOnlyDetail(
+    store: session_store.Store,
+    alloc: Allocator,
+    session_id: []const u8,
+    options: session_store.ResumeOptions,
+) !session_store.ReadOnlyDetail {
+    const managed = child_state.hasManagedChildMarker(
+        store,
+        alloc,
+        session_id,
+    ) catch |err| switch (err) {
+        error.OutOfMemory, error.InvalidSessionId => return err,
+        else => return error.SessionNotFound,
+    };
+    if (managed) return error.SessionNotFound;
+
+    var detail = try store.loadReadOnlyDetail(alloc, session_id, options);
+    errdefer detail.deinit(alloc);
+    if (detail.state.subagent_child) return error.SessionNotFound;
+    return detail;
+}
+
 pub fn listActionablePage(
     store: session_store.Store,
     alloc: Allocator,
@@ -366,7 +388,7 @@ fn ensureLoadedExternalPromptAllowed(
     if (loaded.state.subagent_child) return error.OneOffSessionNotResumable;
 }
 
-test "managed child marker is hidden from external resume" {
+test "managed child marker is hidden from external access" {
     const alloc = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -399,8 +421,15 @@ test "managed child marker is hidden from external resume" {
     var writable = try store.startWritableSession(alloc, durable);
     writable.deinit(alloc);
 
+    var visible = try loadVisibleReadOnlyDetail(store, alloc, "child", .{});
+    visible.deinit(alloc);
+
     const state_store = child_state.Store{ .sessions = &store, .parent_id = "parent" };
     try state_store.markChildSession(alloc, "child");
+    try std.testing.expectError(
+        error.SessionNotFound,
+        loadVisibleReadOnlyDetail(store, alloc, "child", .{}),
+    );
     try std.testing.expectError(
         error.OneOffSessionNotResumable,
         resumeForExternalPrompt(store, alloc, .{ .id = "child" }, workspace, .{}),
@@ -442,6 +471,10 @@ test "subagent work identity hides a partial child without owner sidecar" {
     var writable = try store.startWritableSession(alloc, durable);
     writable.deinit(alloc);
 
+    try std.testing.expectError(
+        error.SessionNotFound,
+        loadVisibleReadOnlyDetail(store, alloc, "partial-child", .{}),
+    );
     try std.testing.expectError(
         error.OneOffSessionNotResumable,
         resumeForExternalPrompt(

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -3624,6 +3624,73 @@ describe("cli: session", () => {
     },
     TIMEOUT,
   );
+
+  test(
+    "fx session exact id hides managed child detail",
+    async () => {
+      const root = mkdtempSync(join(tmpdir(), "fx-e2e-private-child-detail-"));
+      try {
+        const home = join(root, "home");
+        const workspace = join(root, "workspace");
+        mkdirSync(join(home, ".fx", "sessions"), {
+          recursive: true,
+          mode: 0o700,
+        });
+        mkdirSync(workspace);
+        const workspaceRoot = realpathSync(workspace);
+        const parentId = "visible-parent";
+        const childId = "private-child";
+
+        writeLegacySession(home, workspaceRoot, parentId);
+        writeLegacySession(home, workspaceRoot, childId);
+        const childControl = join(
+          home,
+          ".fx",
+          "sessions",
+          childId,
+          "subagent",
+        );
+        mkdirSync(childControl, { recursive: true, mode: 0o700 });
+        writeFileSync(
+          join(childControl, "owner.json"),
+          JSON.stringify({ schema_version: 1, parent_id: parentId }),
+          { mode: 0o600 },
+        );
+
+        const parent = await runFx(
+          ["session", "--id", parentId, "--json"],
+          {
+            cwd: workspaceRoot,
+            env: { HOME: home, FX_DISABLE_KEYCHAIN: "1" },
+          },
+        );
+        expect(parent).toMatchObject({ code: 0, stderr: "" });
+        expect(JSON.parse(parent.stdout)).toMatchObject({
+          kind: "session_detail",
+          id: parentId,
+        });
+
+        const child = await runFx(
+          ["session", "--id", childId, "--json"],
+          {
+            cwd: workspaceRoot,
+            env: { HOME: home, FX_DISABLE_KEYCHAIN: "1" },
+          },
+        );
+        expect(child.code).toBe(1);
+        expect(child.stderr).toBe("");
+        expect(JSON.parse(child.stdout)).toEqual({
+          kind: "session",
+          error: "record not found",
+          code: "SessionNotFound",
+        });
+        expect(child.stdout).not.toContain(childId);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+    TIMEOUT,
+  );
 });
 
 describe("cli: interactive startup", () => {


### PR DESCRIPTION
## Summary

- Return `SessionNotFound` when exact-ID inspection targets a managed child.
- Keep normal session inspection and parent-owned child access unchanged.