### PR TITLE
Reduce auth caller decisions

### DIFF
--- a/src/acp/server.zig
+++ b/src/acp/server.zig
@@ -419,15 +419,13 @@ pub fn selectCredentialForProvider(
             .source = .ai_gateway_api_key,
         }
     else blk: {
-        var preparation = try auth_runtime.prepareCredential(
+        break :blk (try auth_runtime.prepareCredential(
             state.alloc,
             state.cfg.gateway_provider.oauth_transport,
             state.cfg.secret_store,
             provider,
             if (provider == .gateway) state.gateway_source_preference else state.credential_source,
-        );
-        defer preparation.deinit(state.alloc);
-        break :blk preparation.takeReady() orelse return false;
+        )) orelse return false;
     };
     defer credential.deinit(state.alloc);
     adoptServerCredential(state, &credential);
@@ -1806,15 +1804,13 @@ fn handleInitialize(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Message
     } else if (startup_credential_is_final)
         &startup_credential.?
     else routed: {
-        var preparation = try auth_runtime.prepareCredential(
+        routed_credential = try auth_runtime.prepareCredential(
             alloc,
             state.cfg.gateway_provider.oauth_transport,
             state.cfg.secret_store,
             state.provider,
             if (state.provider == .gateway) startup.credential_source_preference else null,
         );
-        defer preparation.deinit(alloc);
-        routed_credential = preparation.takeReady();
         if (routed_credential == null) {
             return state.writer.writeError(alloc, msg.id, .{
                 .code = ErrorCode.invalid_request,
@@ -2104,15 +2100,13 @@ fn handleSetConfigOption(state: *ServerState, alloc: Allocator, msg: *jsonrpc.Me
                     .source = .ai_gateway_api_key,
                 }
             else credential: {
-                var preparation = try auth_runtime.prepareCredential(
+                break :credential (try auth_runtime.prepareCredential(
                     alloc,
                     state.cfg.gateway_provider.oauth_transport,
                     state.cfg.secret_store,
                     target,
                     if (target == .gateway) state.gateway_source_preference else null,
-                );
-                defer preparation.deinit(alloc);
-                break :credential preparation.takeReady() orelse
+                )) orelse
                     return state.writer.writeError(alloc, msg.id, .{
                         .code = ErrorCode.invalid_request,
                         .message = if (target == .codex)

--- a/src/builtins/gateway.zig
+++ b/src/builtins/gateway.zig
@@ -918,7 +918,6 @@ fn fetchCliModelCatalog(
         .endpoint = input.endpoint,
         .cancel_flag = input.cancel_flag,
         .view = .full,
-        .allow_public_fallback = input.allow_public_fallback,
     });
     return switch (result) {
         .loaded => |loaded| project: {

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -5076,7 +5076,6 @@ fn processQueuedPromptLoop(
                 .delivery_safe = stream_ctx.raw_text.items.len == 0 and
                     !stream_ctx.saw_tool_start and
                     streamCompletion(stream_result).tool_calls.len == 0,
-                .authority_stable = true,
                 .already_replayed = auth_retry_used,
             });
             if (auth_replay == .refresh_and_replay) {

--- a/src/core/app/app_auth_runtime.zig
+++ b/src/core/app/app_auth_runtime.zig
@@ -835,7 +835,7 @@ pub fn Runtime(comptime App: type) type {
             };
             defer settings.deinit(app.alloc);
 
-            var preparation = auth_runtime.prepareCredential(
+            var credential = (auth_runtime.prepareCredential(
                 app.alloc,
                 app.auth.oauthTransport(),
                 app.auth.secretStore(),
@@ -853,9 +853,7 @@ pub fn Runtime(comptime App: type) type {
                     ),
                 }, true);
                 return;
-            };
-            defer preparation.deinit(app.alloc);
-            var credential = preparation.takeReady() orelse {
+            }) orelse {
                 if (target == .codex and allow_login) {
                     try beginCodexSignInForProviderSwitch(app);
                     return;

--- a/src/core/app/app_lifecycle.zig
+++ b/src/core/app/app_lifecycle.zig
@@ -185,7 +185,11 @@ pub const StartupState = struct {
     }
 
     pub fn modelCatalogAccess(self: *const StartupState) credentials.CatalogAccess {
-        return credentials.catalogAccessAt(self.credential, io_mod.milliTimestamp());
+        const access = credentials.catalogAccessAt(self.credential, io_mod.milliTimestamp());
+        return if (self.credential_source_preference == null)
+            access
+        else
+            access.withExplicitAuthority();
     }
 
     pub fn gatewayTeam(self: *const StartupState) ?[]const u8 {

--- a/src/core/auth/auth_runtime.zig
+++ b/src/core/auth/auth_runtime.zig
@@ -167,31 +167,8 @@ fn loadCredentialForRefresh(
     };
 }
 
-pub const CredentialPreparation = union(enum) {
-    ready: credentials.Credential,
-    blocked,
-
-    pub fn deinit(self: *CredentialPreparation, alloc: Allocator) void {
-        switch (self.*) {
-            .ready => |*credential| credential.deinit(alloc),
-            .blocked => {},
-        }
-        self.* = undefined;
-    }
-
-    pub fn takeReady(self: *CredentialPreparation) ?credentials.Credential {
-        return switch (self.*) {
-            .ready => |credential| blk: {
-                self.* = .blocked;
-                break :blk credential;
-            },
-            .blocked => null,
-        };
-    }
-};
-
-/// Resolves and refreshes one provider credential. The returned ready value is
-/// owned by the caller and must be released with `CredentialPreparation.deinit`.
+/// Resolves and refreshes one provider credential. The returned value is owned
+/// by the caller and must be released with `Credential.deinit`.
 /// Non-null `preferred` is exact; only null permits Gateway precedence.
 pub fn prepareCredential(
     alloc: Allocator,
@@ -199,7 +176,7 @@ pub fn prepareCredential(
     secret_store: host.SecretStore,
     provider: model_provider.ProviderId,
     preferred: ?credentials.Source,
-) Allocator.Error!CredentialPreparation {
+) Allocator.Error!?credentials.Credential {
     var resolution = credentials.resolveForProvider(
         alloc,
         transport,
@@ -218,7 +195,7 @@ pub fn prepareCredential(
                 @errorName(err),
             },
         );
-        return .blocked;
+        return null;
     };
     return prepareResolvedCredential(
         alloc,
@@ -233,8 +210,8 @@ fn prepareResolvedCredential(
     provider: model_provider.ProviderId,
     now_ms: i64,
     resolution: *credentials.Resolution,
-) CredentialPreparation {
-    var credential = resolution.credential orelse return .blocked;
+) ?credentials.Credential {
+    var credential = resolution.credential orelse return null;
     resolution.credential = null;
 
     const blocked = credential.token.len == 0 or
@@ -249,9 +226,9 @@ fn prepareResolvedCredential(
 
     if (blocked) {
         credential.deinit(alloc);
-        return .blocked;
+        return null;
     }
-    return .{ .ready = credential };
+    return credential;
 }
 
 fn requestedSource(
@@ -267,18 +244,13 @@ fn requestedSource(
 
 test "credential preparation blocks an unavailable explicit source" {
     var resolution = credentials.Resolution{ .fx_login_status = .unavailable };
-    var prepared = prepareResolvedCredential(
+    const prepared = prepareResolvedCredential(
         std.testing.allocator,
         .gateway,
         100,
         &resolution,
     );
-    defer prepared.deinit(std.testing.allocator);
-
-    switch (prepared) {
-        .blocked => {},
-        .ready => return error.TestExpectedBlockedCredential,
-    }
+    try std.testing.expect(prepared == null);
 }
 
 test "credential preparation moves one fresh provider-authorized credential" {
@@ -288,21 +260,18 @@ test "credential preparation moves one fresh provider-authorized credential" {
         .team_id = try std.testing.allocator.dupe(u8, "team_123"),
         .refresh_after_ms = 200,
     } };
-    var prepared = prepareResolvedCredential(
+    var credential = prepareResolvedCredential(
         std.testing.allocator,
         .gateway,
         100,
         &resolution,
-    );
-    defer prepared.deinit(std.testing.allocator);
+    ) orelse return error.TestExpectedPreparedCredential;
+    defer credential.deinit(std.testing.allocator);
 
     try std.testing.expect(resolution.credential == null);
-    var credential = prepared.takeReady() orelse return error.TestExpectedPreparedCredential;
-    defer credential.deinit(std.testing.allocator);
     try std.testing.expectEqual(credentials.Source.fx_login, credential.source);
     try std.testing.expectEqualStrings("fresh-token", credential.token);
     try std.testing.expectEqualStrings("team_123", credential.gatewayTeam().?);
-    try std.testing.expect(prepared.takeReady() == null);
 }
 
 test "credential preparation rejects refresh-due and provider-mismatched credentials" {
@@ -335,11 +304,8 @@ test "credential preparation rejects refresh-due and provider-mismatched credent
             100,
             &resolution,
         );
-        defer prepared.deinit(std.testing.allocator);
-        switch (prepared) {
-            .blocked => {},
-            .ready => return error.TestExpectedBlockedCredential,
-        }
+        defer if (prepared) |*credential| credential.deinit(std.testing.allocator);
+        try std.testing.expect(prepared == null);
     }
 }
 

--- a/src/core/auth/auth_transition.zig
+++ b/src/core/auth/auth_transition.zig
@@ -108,7 +108,6 @@ pub const AuthReplayFacts = struct {
     authentication_rejected: bool,
     refreshable: bool,
     delivery_safe: bool,
-    authority_stable: bool,
     already_replayed: bool,
 };
 
@@ -121,7 +120,6 @@ pub fn decideAuthReplay(facts: AuthReplayFacts) AuthReplayDecision {
     if (!facts.authentication_rejected or
         !facts.refreshable or
         !facts.delivery_safe or
-        !facts.authority_stable or
         facts.already_replayed)
     {
         return .fail;
@@ -220,12 +218,11 @@ test "credential change distinguishes secret rotation from authority replacement
     );
 }
 
-test "auth replay is one safe same-authority refresh outside semantic policy" {
+test "auth replay is one delivery-safe refresh outside semantic policy" {
     const eligible = AuthReplayFacts{
         .authentication_rejected = true,
         .refreshable = true,
         .delivery_safe = true,
-        .authority_stable = true,
         .already_replayed = false,
     };
     try std.testing.expectEqual(AuthReplayDecision.refresh_and_replay, decideAuthReplay(eligible));
@@ -235,8 +232,5 @@ test "auth replay is one safe same-authority refresh outside semantic policy" {
     try std.testing.expectEqual(AuthReplayDecision.fail, decideAuthReplay(blocked));
     blocked = eligible;
     blocked.delivery_safe = false;
-    try std.testing.expectEqual(AuthReplayDecision.fail, decideAuthReplay(blocked));
-    blocked = eligible;
-    blocked.authority_stable = false;
     try std.testing.expectEqual(AuthReplayDecision.fail, decideAuthReplay(blocked));
 }

--- a/src/core/auth/credentials.zig
+++ b/src/core/auth/credentials.zig
@@ -62,6 +62,11 @@ pub const CatalogAuthenticatedSource = enum {
     }
 };
 
+const CatalogAuthority = enum {
+    automatic,
+    explicit,
+};
+
 /// A borrowed authorization decision for one model-catalog request. Public-only
 /// states cannot carry credential or team bytes; authenticated states carry the
 /// only values the request is allowed to send.
@@ -72,6 +77,7 @@ pub const CatalogAccess = union(enum) {
         credential: []const u8,
         team_context: ?[]const u8,
         account_id: ?[]const u8 = null,
+        authority: CatalogAuthority = .automatic,
     },
 
     pub fn credentialSource(self: CatalogAccess) ?Source {
@@ -96,7 +102,9 @@ pub const CatalogAccess = union(enum) {
     pub fn publicFallbackAfterRejection(self: CatalogAccess) ?CatalogAccess {
         return switch (self) {
             .public_only => null,
-            .authenticated => |access| if (access.source == .chatgpt_subscription or access.source == .grok_subscription)
+            .authenticated => |access| if (access.authority == .explicit or
+                access.source == .chatgpt_subscription or
+                access.source == .grok_subscription)
                 null
             else
                 .{
@@ -104,6 +112,19 @@ pub const CatalogAccess = union(enum) {
                         .authenticated_credential_rejected = access.source.credentialSource(),
                     },
                 },
+        };
+    }
+
+    pub fn withExplicitAuthority(self: CatalogAccess) CatalogAccess {
+        return switch (self) {
+            .public_only => |access| .{ .public_only = access },
+            .authenticated => |access| .{ .authenticated = .{
+                .source = access.source,
+                .credential = access.credential,
+                .team_context = access.team_context,
+                .account_id = access.account_id,
+                .authority = .explicit,
+            } },
         };
     }
 
@@ -892,6 +913,9 @@ test "authenticated catalog access carries source and permitted request context"
         try std.testing.expect(fallback.authorizationCredential() == null);
         try std.testing.expect(fallback.teamContext() == null);
         try std.testing.expect(fallback.publicFallbackAfterRejection() == null);
+
+        const explicit = authenticated.withExplicitAuthority();
+        try std.testing.expect(explicit.publicFallbackAfterRejection() == null);
     }
 }
 

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -1544,15 +1544,13 @@ fn runPromptInternal(alloc: Allocator, prompt: []const u8, permission_override: 
     const credential: *const credentials.Credential = if (startup_credential_is_final)
         &startup.credential.?
     else routed: {
-        var preparation = try auth_runtime.prepareCredential(
+        routed_credential = try auth_runtime.prepareCredential(
             alloc,
             cfg.gateway_provider.oauth_transport,
             cfg.secret_store,
             ctx.provider,
             if (ctx.provider == .gateway) startup.credential_source_preference else null,
         );
-        defer preparation.deinit(alloc);
-        routed_credential = preparation.takeReady();
         if (routed_credential == null) {
             return missingCredentialResult(alloc, options, ctx.provider);
         }

--- a/src/core/cli/cli_surface.zig
+++ b/src/core/cli/cli_surface.zig
@@ -659,15 +659,13 @@ fn activateProviderSelection(
     defer settings.deinit(alloc);
 
     const preferred_source = exact_source orelse settings.credential_source;
-    var preparation = try auth_runtime.prepareCredential(
+    var prepared_credential = try auth_runtime.prepareCredential(
         alloc,
         cfg.gateway_provider.oauth_transport,
         cfg.secret_store,
         target,
         preferred_source,
     );
-    defer preparation.deinit(alloc);
-    var prepared_credential = preparation.takeReady();
     defer if (prepared_credential) |*credential| credential.deinit(alloc);
 
     const already_selected = (settings.provider orelse .gateway) == target;
@@ -688,15 +686,13 @@ fn activateProviderSelection(
             return false;
         };
         performed_login = .codex;
-        preparation.deinit(alloc);
-        preparation = try auth_runtime.prepareCredential(
+        prepared_credential = try auth_runtime.prepareCredential(
             alloc,
             cfg.gateway_provider.oauth_transport,
             cfg.secret_store,
             target,
             preferred_source,
         );
-        prepared_credential = preparation.takeReady();
     }
     if (prepared_credential == null and target == .grok and caller == .provider_command) {
         grok_oauth.runLogin(alloc, cfg.gateway_provider.oauth_transport, cfg.url_opener) catch |err| {
@@ -705,15 +701,13 @@ fn activateProviderSelection(
             return false;
         };
         performed_login = .grok;
-        preparation.deinit(alloc);
-        preparation = try auth_runtime.prepareCredential(
+        prepared_credential = try auth_runtime.prepareCredential(
             alloc,
             cfg.gateway_provider.oauth_transport,
             cfg.secret_store,
             target,
             preferred_source,
         );
-        prepared_credential = preparation.takeReady();
     }
 
     const credential = if (prepared_credential) |*value| value else {
@@ -738,10 +732,12 @@ fn activateProviderSelection(
         return false;
     };
     const fetch_result = model_catalog.fetchWithPublicFallback(catalog_provider, alloc, .{
-        .access = credentials.catalogAccessAt(credential.*, io_mod.milliTimestamp()),
+        .access = credentials.catalogAccessAt(
+            credential.*,
+            io_mod.milliTimestamp(),
+        ).withExplicitAuthority(),
         .endpoint = cfg.models_path,
         .view = .picker,
-        .allow_public_fallback = false,
     });
     var loaded = switch (fetch_result) {
         .loaded => |loaded| blk: {
@@ -1223,7 +1219,6 @@ fn runNonInteractiveWithDeps(
             const loaded = switch (catalog_provider.fetch(alloc, .{
                 .access = catalog_access,
                 .endpoint = cfg.models_path,
-                .allow_public_fallback = startup.credential_source_preference == null,
             })) {
                 .loaded => |loaded| loaded,
                 .failure => |failure| {

--- a/src/core/gateway/gateway_provider.zig
+++ b/src/core/gateway/gateway_provider.zig
@@ -25,7 +25,6 @@ pub const CliModelCatalogInput = struct {
     access: credentials.CatalogAccess = .{ .public_only = .no_credential },
     endpoint: []const u8,
     cancel_flag: ?*std.atomic.Value(bool) = null,
-    allow_public_fallback: bool = true,
 };
 
 pub const CliModelCatalogResult = union(enum) {

--- a/src/core/gateway/model_catalog.zig
+++ b/src/core/gateway/model_catalog.zig
@@ -19,7 +19,6 @@ pub const FetchInput = struct {
     endpoint: []const u8,
     cancel_flag: ?*std.atomic.Value(bool) = null,
     view: View = .full,
-    allow_public_fallback: bool = true,
 };
 
 pub const FailureCategory = enum {
@@ -188,7 +187,7 @@ fn fetchWithPublicFallbackUntraced(
             .provenance = .{ .access = .init(attempt.access) },
         } },
         .failure => |failure| {
-            if (!attempt.allow_public_fallback or !failure.allowsPublicFallback()) {
+            if (!failure.allowsPublicFallback()) {
                 return failedOutcome(attempt.access, false, failure);
             }
             attempt.access = attempt.access.publicFallbackAfterRejection() orelse
@@ -744,14 +743,13 @@ test "strict authenticated catalog requests never retry anonymously" {
         .fx_login,
         "test-token",
         "team_123",
-    );
+    ).withExplicitAuthority();
     const rejection = Failure{ .category = .authentication, .http_status = .unauthorized };
     var probe = FallbackProbe{ .failures = .{ rejection, null } };
 
     const failed = fetchWithPublicFallback(probe.provider(), std.testing.allocator, .{
         .access = access,
         .endpoint = "/v1/models",
-        .allow_public_fallback = false,
     }).failed;
     try std.testing.expectEqual(AccessLevel.authenticated, failed.access.level);
     try std.testing.expect(!failed.anonymous_fallback_used);

--- a/src/core/subagent/agent_adapter.zig
+++ b/src/core/subagent/agent_adapter.zig
@@ -148,7 +148,7 @@ pub fn run(
         admission.provider,
         config.tool_context.credential_source,
     )) {
-        var preparation = auth_runtime.prepareCredential(
+        routed_credential = auth_runtime.prepareCredential(
             turn.alloc,
             config.tool_context.oauth_transport,
             config.tool_context.secret_store,
@@ -160,8 +160,6 @@ pub fn run(
                 return error.OutOfMemory;
             return error.ProviderFailed;
         };
-        defer preparation.deinit(turn.alloc);
-        routed_credential = preparation.takeReady();
         const credential = if (routed_credential) |*value| value else {
             turn.setFailureDiagnostic("model_credential_missing", admission.model) catch
                 return error.OutOfMemory;

--- a/src/gateway/openai_codex_models.zig
+++ b/src/gateway/openai_codex_models.zig
@@ -35,7 +35,6 @@ fn fetchCliModelCatalog(
         .endpoint = input.endpoint,
         .cancel_flag = input.cancel_flag,
         .view = .full,
-        .allow_public_fallback = input.allow_public_fallback,
     })) {
         .loaded => |loaded| blk: {
             var catalog = loaded.catalog;

--- a/src/gateway/xai_grok_models.zig
+++ b/src/gateway/xai_grok_models.zig
@@ -35,7 +35,6 @@ fn fetchCliModelCatalog(
         .endpoint = input.endpoint,
         .cancel_flag = input.cancel_flag,
         .view = .full,
-        .allow_public_fallback = input.allow_public_fallback,
     })) {
         .loaded => |loaded| blk: {
             var catalog = loaded.catalog;


### PR DESCRIPTION
## Summary

- Return prepared credentials directly to their owning runtime.
- Keep authenticated catalog fallback policy with the catalog access authority.
- Keep replay eligibility tied to refreshability, delivery state, and retry count without a caller-supplied authority flag.