### PR TITLE
Classify tool outcomes in trace reports

### DIFF
--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -694,7 +694,7 @@ pub fn Bindings(comptime App: type) type {
                 .name = call.name,
                 .arguments_json = call.arguments_json,
                 .model_output = model_output,
-                .ok = false,
+                .outcome = .rejected,
                 .started_at_ms = io_mod.milliTimestamp(),
             });
         }
@@ -1866,7 +1866,7 @@ test "agent deps record rejected tool calls in feedback diagnostics" {
     var buf: [1]diagnostics.ToolCallMetric = undefined;
     const n = diagnostics.snapshotToolCalls(&buf);
     try std.testing.expectEqual(@as(usize, 1), n);
-    try std.testing.expect(!buf[0].ok);
+    try std.testing.expectEqual(diagnostics.ToolCallOutcome.rejected, buf[0].outcome);
     try std.testing.expectEqualStrings("run_command", buf[0].name());
     try std.testing.expect(std.mem.find(u8, buf[0].args(), "touch /tmp/denied") != null);
     try std.testing.expect(std.mem.find(u8, buf[0].result(), "tool_permission_denied") != null);

--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -2501,7 +2501,7 @@ fn writeProblemsSummary(writer: *std.Io.Writer, app: anytype, alloc: std.mem.All
     while (ti > 0 and tool_reported < 5) {
         ti -= 1;
         const call = tool_buf[ti];
-        if (call.ok) continue;
+        if (call.outcome == .succeeded) continue;
         count += 1;
         tool_reported += 1;
         try writer.writeAll("- tool ");
@@ -2717,7 +2717,7 @@ fn writePermissionsSummary(writer: *std.Io.Writer, grants: []const types.Permiss
 
 fn writeToolCallCompact(writer: *std.Io.Writer, call: diagnostics.ToolCallMetric) !void {
     try writeTraceTimestampUtc(writer, call.started_at_ms);
-    try writer.print(" name={s} status={s} duration={d}ms", .{ traceToolDisplayName(call.name()), if (call.ok) "ok" else "err", call.duration_ms });
+    try writer.print(" name={s} outcome={s} duration={d}ms", .{ traceToolDisplayName(call.name()), @tagName(call.outcome), call.duration_ms });
     if (call.subagent_id != 0) try writer.print(" source=subagent#{d}", .{call.subagent_id}) else try writer.writeAll(" source=parent");
     try writer.writeByte('\n');
 }
@@ -2810,19 +2810,31 @@ noinline fn writeToolCallsSummary(
     if (n == 0) {
         try writer.writeAll("(none locally executed)\n");
     } else {
-        var ok_count: u32 = 0;
-        var error_count: u32 = 0;
+        var succeeded_count: u32 = 0;
+        var rejected_count: u32 = 0;
+        var command_failed_count: u32 = 0;
+        var tool_failed_count: u32 = 0;
+        var runtime_failed_count: u32 = 0;
         var total_ms: u64 = 0;
         for (buf[0..n]) |call| {
-            if (call.ok) ok_count += 1 else error_count += 1;
+            switch (call.outcome) {
+                .succeeded => succeeded_count += 1,
+                .rejected => rejected_count += 1,
+                .command_failed => command_failed_count += 1,
+                .tool_failed => tool_failed_count += 1,
+                .runtime_failed => runtime_failed_count += 1,
+            }
             total_ms += call.duration_ms;
         }
 
-        try writer.print("last={d} ok={d} errors={d} total={d}ms\n", .{ n, ok_count, error_count, total_ms });
-        if (error_count > 0) {
-            try writer.writeAll("errors first:\n");
+        try writer.print(
+            "last={d} succeeded={d} rejected={d} command_failed={d} tool_failed={d} runtime_failed={d} total={d}ms\n",
+            .{ n, succeeded_count, rejected_count, command_failed_count, tool_failed_count, runtime_failed_count, total_ms },
+        );
+        if (succeeded_count != n) {
+            try writer.writeAll("non-successes first:\n");
             for (buf[0..n]) |call| {
-                if (call.ok) continue;
+                if (call.outcome == .succeeded) continue;
                 try writeToolCallCompact(writer, call);
                 try writeToolFieldBlock(writer, alloc, "args", call.args(), call.args_len, call.args_total_bytes);
                 try writeToolFieldBlock(writer, alloc, "result", call.result(), call.result_len, call.result_total_bytes);
@@ -2832,7 +2844,7 @@ noinline fn writeToolCallsSummary(
             try writer.writeAll("recent successes (compact):\n");
         }
         for (buf[0..n]) |call| {
-            if (!call.ok) continue;
+            if (call.outcome != .succeeded) continue;
             try writeToolCallCompact(writer, call);
             try writeToolFieldBlock(writer, alloc, "args", call.args(), call.args_len, call.args_total_bytes);
             try writeToolResultPreview(writer, alloc, call.result(), call.result_total_bytes);
@@ -4219,31 +4231,50 @@ test "trace auth summary preserves missing and loaded status text" {
     );
 }
 
-test "trace tool calls print errors first and mask obvious secrets" {
+test "trace tool calls preserve outcomes and mask obvious secrets" {
     const alloc = std.testing.allocator;
     diagnostics.resetForTest();
     defer diagnostics.resetForTest();
 
-    var ok: diagnostics.ToolCallMetric = .{ .started_at_ms = 1000, .duration_ms = 7, .ok = true };
-    ok.setName("read_file");
-    ok.setArgs("{\"path\":\"README.md\"}");
-    ok.setResult("read ok");
-    diagnostics.recordToolCall(ok);
-
-    var failed: diagnostics.ToolCallMetric = .{ .started_at_ms = 2000, .duration_ms = 9, .ok = false, .subagent_id = 3 };
-    failed.setName("run_command");
-    failed.setArgs("{\"command\":\"AI_GATEWAY_API_KEY=abcdefghijklmnop zig build\"}");
-    failed.setResult("failed with PASSWORD=abcdefghijklmnop");
-    diagnostics.recordToolCall(failed);
+    const fixtures = [_]struct {
+        name: []const u8,
+        outcome: diagnostics.ToolCallOutcome,
+        args: []const u8,
+        result: []const u8,
+        subagent_id: u64 = 0,
+    }{
+        .{ .name = "read_file", .outcome = .succeeded, .args = "{\"path\":\"README.md\"}", .result = "read ok" },
+        .{ .name = "edit_file", .outcome = .rejected, .args = "{}", .result = "not unique" },
+        .{ .name = "shell", .outcome = .command_failed, .args = "{}", .result = "exit 7" },
+        .{ .name = "read_file", .outcome = .tool_failed, .args = "{}", .result = "missing" },
+        .{ .name = "run_command", .outcome = .runtime_failed, .args = "{\"command\":\"AI_GATEWAY_API_KEY=abcdefghijklmnop zig build\"}", .result = "failed with PASSWORD=abcdefghijklmnop", .subagent_id = 3 },
+    };
+    for (fixtures, 0..) |fixture, index| {
+        var call: diagnostics.ToolCallMetric = .{
+            .started_at_ms = @intCast(1000 + index),
+            .duration_ms = 1,
+            .outcome = fixture.outcome,
+            .subagent_id = fixture.subagent_id,
+        };
+        call.setName(fixture.name);
+        call.setArgs(fixture.args);
+        call.setResult(fixture.result);
+        diagnostics.recordToolCall(call);
+    }
 
     var out: std.Io.Writer.Allocating = .init(alloc);
     defer out.deinit();
     try writeToolCallsSummary(&out.writer, alloc, &.{});
     const text = out.written();
 
-    const error_pos = std.mem.find(u8, text, "name=run_command") orelse return error.TestExpectedEqual;
-    const success_pos = std.mem.find(u8, text, "name=read_file") orelse return error.TestExpectedEqual;
-    try std.testing.expect(error_pos < success_pos);
+    try std.testing.expect(std.mem.find(u8, text, "last=5 succeeded=1 rejected=1 command_failed=1 tool_failed=1 runtime_failed=1") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=edit_file outcome=rejected") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=shell outcome=command_failed") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=read_file outcome=tool_failed") != null);
+    try std.testing.expect(std.mem.find(u8, text, "name=run_command outcome=runtime_failed") != null);
+    const non_success_pos = std.mem.find(u8, text, "name=run_command") orelse return error.TestExpectedEqual;
+    const success_pos = std.mem.find(u8, text, "name=read_file outcome=succeeded") orelse return error.TestExpectedEqual;
+    try std.testing.expect(non_success_pos < success_pos);
     try std.testing.expect(std.mem.find(u8, text, "source=subagent#3") != null);
     try std.testing.expect(std.mem.find(u8, text, "abcdefghijklmnop") == null);
     try std.testing.expect(std.mem.find(u8, text, "AI_GATEWAY_API_KEY=[redacted]") != null);
@@ -4255,7 +4286,7 @@ test "trace successful tool calls use compact result previews" {
     diagnostics.resetForTest();
     defer diagnostics.resetForTest();
 
-    var call: diagnostics.ToolCallMetric = .{ .started_at_ms = 3000, .duration_ms = 1, .ok = true };
+    var call: diagnostics.ToolCallMetric = .{ .started_at_ms = 3000, .duration_ms = 1, .outcome = .succeeded };
     call.setName("read_file");
     call.setArgs("{\"path\":\"README.md\"}");
     call.setResult("<path>README.md</path>\n<content>\n# fx\n\nlong body line\n</content>");
@@ -4277,7 +4308,7 @@ test "trace omits web_fetch URL and result bodies from tool-call diagnostics" {
     diagnostics.resetForTest();
     defer diagnostics.resetForTest();
 
-    var call: diagnostics.ToolCallMetric = .{ .started_at_ms = 4000, .duration_ms = 3, .ok = true };
+    var call: diagnostics.ToolCallMetric = .{ .started_at_ms = 4000, .duration_ms = 3, .outcome = .succeeded };
     call.setName("web_fetch");
     call.setArgs("{\"url\":\"https://example.com/docs\"}");
     call.setResult("<content>\nFETCHED_PAGE_SECRET_RAW\nEXTRACTED_RESULT_SECRET\n</content>");

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -449,10 +449,11 @@ pub fn executeToolCallAuthorized(
 }
 
 fn classifyToolExecutionError(err: anyerror) diagnostics.ToolCallOutcome {
-    return if (err == error.CancelledBeforeExecution)
-        .rejected
-    else
-        .runtime_failed;
+    return switch (err) {
+        error.CancelledBeforeExecution => .rejected,
+        error.Cancelled => .tool_failed,
+        else => .runtime_failed,
+    };
 }
 
 fn classifyReturnedToolCallOutcome(
@@ -494,6 +495,10 @@ test "returned tool results retain diagnostic outcome identity" {
     try std.testing.expectEqual(
         diagnostics.ToolCallOutcome.rejected,
         classifyToolExecutionError(error.CancelledBeforeExecution),
+    );
+    try std.testing.expectEqual(
+        diagnostics.ToolCallOutcome.tool_failed,
+        classifyToolExecutionError(error.Cancelled),
     );
     try std.testing.expectEqual(
         diagnostics.ToolCallOutcome.runtime_failed,

--- a/src/core/tooling/tool_runtime.zig
+++ b/src/core/tooling/tool_runtime.zig
@@ -427,26 +427,78 @@ pub fn executeToolCallAuthorized(
             .name = request.call.name,
             .arguments_json = request.call.arguments_json,
             .model_output = "",
-            .ok = false,
+            .outcome = classifyToolExecutionError(err),
             .started_at_ms = started_at_ms,
         });
         return if (err == error.CancelledBeforeExecution) error.Cancelled else err;
-    };
-    const ok = switch (result.status) {
-        .success => true,
-        else => false,
     };
     diagnostics.recordToolCallResult(.{
         .name = request.call.name,
         .arguments_json = request.call.arguments_json,
         .model_output = result.model_output,
-        .ok = ok,
+        .outcome = classifyReturnedToolCallOutcome(
+            uses_file_mutation_contract,
+            result,
+        ),
         .started_at_ms = started_at_ms,
     });
     if (request.command_replay_capture) |continued| {
         replay_continuation_transferred = result.command_replay_capture == continued;
     }
     return result;
+}
+
+fn classifyToolExecutionError(err: anyerror) diagnostics.ToolCallOutcome {
+    return if (err == error.CancelledBeforeExecution)
+        .rejected
+    else
+        .runtime_failed;
+}
+
+fn classifyReturnedToolCallOutcome(
+    uses_file_mutation_contract: bool,
+    result: ToolExecutionResult,
+) diagnostics.ToolCallOutcome {
+    if (result.status == .success) return .succeeded;
+    if (result.command_result_json != null) return .command_failed;
+    if (uses_file_mutation_contract) return .rejected;
+    return .tool_failed;
+}
+
+test "returned tool results retain diagnostic outcome identity" {
+    const success = ToolExecutionResult{ .model_output = "ok" };
+    const rejection = ToolExecutionResult{ .model_output = "rejected", .status = .failure };
+    const command_failure = ToolExecutionResult{
+        .model_output = "exit 7",
+        .status = .failure,
+        .command_result_json = "{\"exit_code\":7}",
+    };
+    const tool_failure = ToolExecutionResult{ .model_output = "missing", .status = .failure };
+
+    try std.testing.expectEqual(
+        diagnostics.ToolCallOutcome.succeeded,
+        classifyReturnedToolCallOutcome(false, success),
+    );
+    try std.testing.expectEqual(
+        diagnostics.ToolCallOutcome.rejected,
+        classifyReturnedToolCallOutcome(true, rejection),
+    );
+    try std.testing.expectEqual(
+        diagnostics.ToolCallOutcome.command_failed,
+        classifyReturnedToolCallOutcome(false, command_failure),
+    );
+    try std.testing.expectEqual(
+        diagnostics.ToolCallOutcome.tool_failed,
+        classifyReturnedToolCallOutcome(false, tool_failure),
+    );
+    try std.testing.expectEqual(
+        diagnostics.ToolCallOutcome.rejected,
+        classifyToolExecutionError(error.CancelledBeforeExecution),
+    );
+    try std.testing.expectEqual(
+        diagnostics.ToolCallOutcome.runtime_failed,
+        classifyToolExecutionError(error.Unexpected),
+    );
 }
 
 pub fn executeHostToolCallAuthorized(
@@ -3431,7 +3483,7 @@ test "parent web_fetch tool-call metric omits URL and fetched result content" {
     const n = diagnostics.snapshotToolCalls(&buf);
     try std.testing.expectEqual(@as(usize, 1), n);
     try std.testing.expectEqualStrings("web_fetch", buf[0].name());
-    try std.testing.expect(buf[0].ok);
+    try std.testing.expectEqual(diagnostics.ToolCallOutcome.succeeded, buf[0].outcome);
     try std.testing.expectEqualStrings("", buf[0].args());
     try std.testing.expectEqualStrings("", buf[0].result());
     try std.testing.expectEqual(@as(u32, 0), buf[0].args_total_bytes);
@@ -3447,7 +3499,7 @@ test "non-web_fetch tool-call metrics retain bounded args and result" {
         .name = "read_file",
         .arguments_json = "{\"path\":\"README.md\"}",
         .model_output = "<path>README.md</path>\n<content>\n# fx\nnormal result\n</content>",
-        .ok = true,
+        .outcome = .succeeded,
         .started_at_ms = 1000,
     });
 

--- a/src/core/workspace/diagnostics.zig
+++ b/src/core/workspace/diagnostics.zig
@@ -11,6 +11,7 @@ pub const NetworkCall = network_metrics.NetworkCall;
 pub const NetworkCallKind = network_metrics.NetworkCallKind;
 pub const ToolCallMetric = tool_call_metrics.ToolCallMetric;
 pub const ToolCallRecord = tool_call_metrics.ToolCallRecord;
+pub const ToolCallOutcome = tool_call_metrics.ToolCallOutcome;
 pub const network_ring_capacity = network_metrics.ring_capacity;
 pub const tool_call_ring_capacity = tool_call_metrics.ring_capacity;
 

--- a/src/core/workspace/tool_call_metrics.zig
+++ b/src/core/workspace/tool_call_metrics.zig
@@ -12,10 +12,18 @@ pub const max_args_len: usize = 1200;
 pub const max_result_len: usize = 2000;
 pub const ring_capacity: usize = 64;
 
+pub const ToolCallOutcome = enum(u8) {
+    succeeded,
+    rejected,
+    command_failed,
+    tool_failed,
+    runtime_failed,
+};
+
 pub const ToolCallMetric = struct {
     started_at_ms: i64 = 0,
     duration_ms: u32 = 0,
-    ok: bool = true,
+    outcome: ToolCallOutcome = .succeeded,
     subagent_id: u64 = 0,
     name_buf: [max_name_len]u8 = [_]u8{0} ** max_name_len,
     name_len: u8 = 0,
@@ -82,7 +90,7 @@ pub const ToolCallRecord = struct {
     name: []const u8,
     arguments_json: []const u8,
     model_output: []const u8,
-    ok: bool,
+    outcome: ToolCallOutcome,
     started_at_ms: i64,
     subagent_id: u64 = 0,
 };
@@ -117,7 +125,7 @@ pub fn recordResult(input: ToolCallRecord) void {
     var metric: ToolCallMetric = .{
         .started_at_ms = input.started_at_ms,
         .duration_ms = @intCast(@min(@as(i64, elapsed), std.math.maxInt(u32))),
-        .ok = input.ok,
+        .outcome = input.outcome,
         .subagent_id = input.subagent_id,
     };
     metric.setName(input.name);
@@ -190,4 +198,23 @@ test "args and result are truncated and total length tracked" {
     try std.testing.expectEqual(@as(u32, huge_len), buf[0].args_total_bytes);
     try std.testing.expectEqual(@as(u16, max_result_len), buf[0].result_len);
     try std.testing.expectEqual(@as(u32, huge_len), buf[0].result_total_bytes);
+}
+
+test "tool call outcome labels remain exact" {
+    const cases = [_]struct {
+        outcome: ToolCallOutcome,
+        label: []const u8,
+        success: bool,
+    }{
+        .{ .outcome = .succeeded, .label = "succeeded", .success = true },
+        .{ .outcome = .rejected, .label = "rejected", .success = false },
+        .{ .outcome = .command_failed, .label = "command_failed", .success = false },
+        .{ .outcome = .tool_failed, .label = "tool_failed", .success = false },
+        .{ .outcome = .runtime_failed, .label = "runtime_failed", .success = false },
+    };
+    for (cases) |case| {
+        try std.testing.expectEqualStrings(case.label, @tagName(case.outcome));
+        try std.testing.expectEqual(case.success, case.outcome == .succeeded);
+    }
+    try std.testing.expectEqual(@as(u8, 0), @intFromEnum(ToolCallOutcome.succeeded));
 }

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -1623,6 +1623,69 @@ describe("effect-aware command permissions", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
+    "TUI trace distinguishes rejected edits from failed commands",
+    async () => {
+      const root = createIsolatedRoot();
+      const fixturePath = join(root.workspace, "duplicate.txt");
+      const stderrPath = join(root.root, "stderr.log");
+      writeFileSync(fixturePath, "same twice same\n");
+      writeFileSync(stderrPath, "");
+      installClipboardFixture(root, "#!/bin/sh\nexit 1\n");
+      const gateway = startFakeGateway([
+        gatewayToolCall("edit_file", {
+          path: "duplicate.txt",
+          old_string: "same",
+          new_string: "new",
+        }, "trace_edit_rejected"),
+        toolCall("exit 7", {}, "trace_command_failed"),
+        finalText("diagnostic fixture complete"),
+      ]);
+
+      activeSession = await TmuxSession.create({
+        cmd: FX_BIN,
+        cwd: root.workspace,
+        env: gatewayEnv(root, gateway, {
+          PATH: hostilePath(root),
+          TMPDIR: root.root,
+          FX_PERMISSION_MODE: "yolo",
+        }),
+        stderrPath,
+        width: 120,
+        height: 40,
+      });
+      await activeSession.waitForComposer(TIMEOUT);
+      await activeSession.sendText("Run the diagnostic outcome fixture.");
+      await activeSession.waitForText("diagnostic fixture complete", TIMEOUT);
+      expect(readFileSync(fixturePath, "utf8")).toBe("same twice same\n");
+
+      await activeSession.sendText("/trace");
+      await activeSession.waitForText(
+        process.platform === "darwin"
+          ? "Clipboard copy failed"
+          : "Trace saved at",
+        TIMEOUT,
+      );
+      const report = readFileSync(latestTraceReportPath(root), "utf8");
+
+      expect(gateway.requests).toHaveLength(3);
+      expect(report).toContain(
+        "last=2 succeeded=0 rejected=1 command_failed=1 tool_failed=0 runtime_failed=0",
+      );
+      expect(report).toContain("name=edit_file outcome=rejected");
+      expect(report).toContain("name=shell outcome=command_failed");
+      expect(report).not.toContain("name=edit_file outcome=runtime_failed");
+      expect(report).not.toContain("name=shell outcome=runtime_failed");
+      expect(readFileSync(stderrPath, "utf8")).toBe("");
+
+      await activeSession.sendText("/quit");
+      expect(await activeSession.waitForSessionEnd()).toBe(true);
+      await activeSession.kill();
+      activeSession = null;
+    },
+    TIMEOUT,
+  );
+
+  test.skipIf(!tmuxAvailable())(
     "TUI writes Gateway schema diagnostics to a trace after Gateway 400",
     async () => {
       const root = createIsolatedRoot();


### PR DESCRIPTION
## Summary

- Report rejected tool requests separately from execution failures.
- Report completed nonzero commands separately from Shell runtime failures.
- Keep tool execution, permissions, and model-facing results unchanged.