### PR TITLE
Accept trailing-slash differences in OAuth metadata issuers

### DIFF
--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -587,11 +587,10 @@ fn issuerWithoutTrailingSlash(issuer: []const u8) []const u8 {
     return issuer;
 }
 
-/// RFC 8414 issuer identifiers are compared as exact strings, but a server can
-/// publish the same origin with and without a trailing slash across its
-/// protected-resource and authorization-server documents. Ignore that one
-/// difference; everything else still fails closed.
-fn issuersEqual(a: []const u8, b: []const u8) bool {
+/// Accept a trailing-slash discrepancy between protected-resource discovery
+/// and authorization-server metadata. Authorization responses still require
+/// the exact metadata issuer required by RFC 9207.
+fn authorizationMetadataIssuersEqual(a: []const u8, b: []const u8) bool {
     return std.mem.eql(u8, issuerWithoutTrailingSlash(a), issuerWithoutTrailingSlash(b));
 }
 
@@ -605,7 +604,7 @@ fn parseAuthorizationMetadataOutcome(
     if (parsed.value != .object) return error.InvalidAuthorizationMetadata;
     const object = parsed.value.object;
     const issuer = try requiredString(object, "issuer");
-    if (!issuersEqual(issuer, expected_issuer)) {
+    if (!authorizationMetadataIssuersEqual(issuer, expected_issuer)) {
         return .{ .issuer_mismatch = try IssuerMismatch.init(
             alloc,
             .authorization_metadata,
@@ -700,7 +699,7 @@ pub fn validateAuthorizationResponse(
         return error.AuthorizationResponseIssuerMissing;
     }
     if (response.issuer) |issuer| {
-        if (!issuersEqual(expected_issuer, issuer)) {
+        if (!std.mem.eql(u8, expected_issuer, issuer)) {
             return error.AuthorizationResponseIssuerMismatch;
         }
     }
@@ -2395,8 +2394,15 @@ test "authorization metadata accepts an issuer that differs only by a trailing s
         "https://login.example.com/",
     );
     defer metadata.deinit(alloc);
-
     try std.testing.expectEqualStrings("https://login.example.com", metadata.issuer);
+
+    var reverse = try parseAuthorizationMetadata(
+        alloc,
+        "{\"issuer\":\"https://login.example.com/\",\"authorization_endpoint\":\"https://login.example.com/authorize\",\"token_endpoint\":\"https://login.example.com/token\"}",
+        "https://login.example.com",
+    );
+    defer reverse.deinit(alloc);
+    try std.testing.expectEqualStrings("https://login.example.com/", reverse.issuer);
 }
 
 test "authorization metadata rejects an issuer whose path differs" {
@@ -2480,11 +2486,14 @@ test "authorization response uses exact state and issuer comparison" {
         true,
         response,
     );
-    try validateAuthorizationResponse(
-        "state-1",
-        "https://login.example.com/",
-        true,
-        response,
+    try std.testing.expectError(
+        error.AuthorizationResponseIssuerMismatch,
+        validateAuthorizationResponse(
+            "state-1",
+            "https://login.example.com/",
+            true,
+            response,
+        ),
     );
     try std.testing.expectError(
         error.OAuthStateMismatch,

--- a/src/core/mcp/mcp_auth.zig
+++ b/src/core/mcp/mcp_auth.zig
@@ -582,6 +582,19 @@ const AuthorizationMetadataOutcome = union(enum) {
     issuer_mismatch: IssuerMismatch,
 };
 
+fn issuerWithoutTrailingSlash(issuer: []const u8) []const u8 {
+    if (issuer.len > 1 and issuer[issuer.len - 1] == '/') return issuer[0 .. issuer.len - 1];
+    return issuer;
+}
+
+/// RFC 8414 issuer identifiers are compared as exact strings, but a server can
+/// publish the same origin with and without a trailing slash across its
+/// protected-resource and authorization-server documents. Ignore that one
+/// difference; everything else still fails closed.
+fn issuersEqual(a: []const u8, b: []const u8) bool {
+    return std.mem.eql(u8, issuerWithoutTrailingSlash(a), issuerWithoutTrailingSlash(b));
+}
+
 fn parseAuthorizationMetadataOutcome(
     alloc: Allocator,
     bytes: []const u8,
@@ -592,7 +605,7 @@ fn parseAuthorizationMetadataOutcome(
     if (parsed.value != .object) return error.InvalidAuthorizationMetadata;
     const object = parsed.value.object;
     const issuer = try requiredString(object, "issuer");
-    if (!std.mem.eql(u8, issuer, expected_issuer)) {
+    if (!issuersEqual(issuer, expected_issuer)) {
         return .{ .issuer_mismatch = try IssuerMismatch.init(
             alloc,
             .authorization_metadata,
@@ -687,7 +700,7 @@ pub fn validateAuthorizationResponse(
         return error.AuthorizationResponseIssuerMissing;
     }
     if (response.issuer) |issuer| {
-        if (!std.mem.eql(u8, expected_issuer, issuer)) {
+        if (!issuersEqual(expected_issuer, issuer)) {
             return error.AuthorizationResponseIssuerMismatch;
         }
     }
@@ -2338,7 +2351,7 @@ test "authorization metadata mismatch retains exact issuer values and fails clos
     var outcome = try parseAuthorizationMetadataOutcome(
         alloc,
         bytes,
-        "https://login.example.com/",
+        "https://login.evil.example/",
     );
     defer switch (outcome) {
         .metadata => |*metadata| metadata.deinit(alloc),
@@ -2352,7 +2365,7 @@ test "authorization metadata mismatch retains exact issuer values and fails clos
                 mismatch.source,
             );
             try std.testing.expectEqualStrings(
-                "https://login.example.com/",
+                "https://login.evil.example/",
                 mismatch.expected,
             );
             try std.testing.expectEqualStrings(
@@ -2366,6 +2379,33 @@ test "authorization metadata mismatch retains exact issuer values and fails clos
         parseAuthorizationMetadata(
             alloc,
             bytes,
+            "https://login.evil.example/",
+        ),
+    );
+}
+
+test "authorization metadata accepts an issuer that differs only by a trailing slash" {
+    const alloc = std.testing.allocator;
+    const bytes =
+        "{\"issuer\":\"https://login.example.com\",\"authorization_endpoint\":\"https://login.example.com/authorize\",\"token_endpoint\":\"https://login.example.com/token\"}";
+
+    var metadata = try parseAuthorizationMetadata(
+        alloc,
+        bytes,
+        "https://login.example.com/",
+    );
+    defer metadata.deinit(alloc);
+
+    try std.testing.expectEqualStrings("https://login.example.com", metadata.issuer);
+}
+
+test "authorization metadata rejects an issuer whose path differs" {
+    const alloc = std.testing.allocator;
+    try std.testing.expectError(
+        error.AuthorizationMetadataIssuerMismatch,
+        parseAuthorizationMetadata(
+            alloc,
+            "{\"issuer\":\"https://login.example.com/tenant\",\"authorization_endpoint\":\"https://login.example.com/authorize\",\"token_endpoint\":\"https://login.example.com/token\"}",
             "https://login.example.com/",
         ),
     );
@@ -2440,11 +2480,26 @@ test "authorization response uses exact state and issuer comparison" {
         true,
         response,
     );
+    try validateAuthorizationResponse(
+        "state-1",
+        "https://login.example.com/",
+        true,
+        response,
+    );
+    try std.testing.expectError(
+        error.OAuthStateMismatch,
+        validateAuthorizationResponse(
+            "state-2",
+            "https://login.example.com",
+            true,
+            response,
+        ),
+    );
     try std.testing.expectError(
         error.AuthorizationResponseIssuerMismatch,
         validateAuthorizationResponse(
             "state-1",
-            "https://login.example.com/",
+            "https://login.evil.example",
             true,
             response,
         ),

--- a/tests/e2e/mcp-auth.test.ts
+++ b/tests/e2e/mcp-auth.test.ts
@@ -194,6 +194,7 @@ function startAuthFixture(
     rejectResourceTemplateAuth?: boolean;
     authorizationServerTrailingSlash?: boolean;
     authorizationResponseIssuer?: string;
+    authorizationResponseTrailingSlash?: boolean;
     omitScopes?: boolean;
     rejectDiscoveryWithoutChallenge?: boolean;
     rejectDiscoveryWithRestAuthorizationDocument?: boolean;
@@ -456,7 +457,8 @@ function startAuthFixture(
         );
         redirect.searchParams.set(
           "iss",
-          options.authorizationResponseIssuer ?? origin,
+          options.authorizationResponseIssuer ??
+            (options.authorizationResponseTrailingSlash ? `${origin}/` : origin),
         );
         return Response.redirect(redirect, 302);
       }
@@ -2480,7 +2482,7 @@ describe("MCP remote authentication lifecycle", () => {
   );
 
   test.skipIf(!tmuxAvailable())(
-    "issuer mismatch stays exact and reports the configuration override",
+    "authorization metadata accepts a trailing-slash discrepancy",
     async () => {
       upstream = startModernMcpHttpFixture("json");
       auth = startAuthFixture(upstream.url, {
@@ -2504,43 +2506,23 @@ describe("MCP remote authentication lifecycle", () => {
       await tui.waitForComposer(15_000);
 
       await tui.sendText("/mcp auth fixture --open");
-      const mismatch = await tui.waitForText(
-        "Add \"oauth\":{\"issuer\":",
-        15_000,
-      );
-      const origin = new URL(auth.url).origin;
-      const compactMismatch = mismatch.replace(/\s+/g, " ");
-      expect(compactMismatch).toContain(`expected issuer "${origin}/"`);
-      expect(compactMismatch).toContain(`metadata returned "${origin}"`);
-      expect(compactMismatch).toContain(`\"issuer\":\"${origin}\"`);
-      expect(auth.authorizationRequests).toBe(0);
-      expect(auth.tokenExchanges).toBe(0);
-
-      const profilePath = join(root.home, ".fx", "mcp.json");
-      const profile = JSON.parse(readFileSync(profilePath, "utf8"));
-      profile.mcp.fixture.oauth.issuer = origin;
-      writeFileSync(profilePath, JSON.stringify(profile));
-      await tui.sendText("/mcp reload");
-      await tui.waitForText(
-        "MCP configuration reloaded, but server 'fixture' is unavailable.",
-        15_000,
-      );
-      await tui.sendText("/mcp auth fixture --open");
       await tui.waitForText("Authenticated MCP server 'fixture'.", 15_000);
       expect(auth.authorizationRequests).toBe(1);
       expect(auth.tokenExchanges).toBe(1);
+      expect(existsSync(join(root.home, ".fx", "mcp-credentials", "credentials.json")))
+        .toBe(true);
     },
-    45_000,
+    30_000,
   );
 
   test.skipIf(!tmuxAvailable())(
     "authorization response issuer mismatch names the response and preserves the trust boundary",
     async () => {
       upstream = startModernMcpHttpFixture("json");
-      const returnedIssuer = "https://authorization-response.example.test";
       auth = startAuthFixture(upstream.url, {
-        authorizationResponseIssuer: returnedIssuer,
+        authorizationResponseTrailingSlash: true,
       });
+      const returnedIssuer = `${new URL(auth.url).origin}/`;
       const root = createRoot(auth);
       gateway = startFakeGateway([], {
         models: [{ id: MODEL, type: "language", tags: ["tool-use"] }],
@@ -2562,7 +2544,7 @@ describe("MCP remote authentication lifecycle", () => {
       const mismatch = await tui.waitForText("was rejected", 15_000);
       const compactMismatch = mismatch.replace(/\s+/g, " ");
       expect(compactMismatch).toContain("authorization response returned issuer");
-      expect(compactMismatch).toContain("authorization-response.example.test");
+      expect(compactMismatch).toContain(returnedIssuer);
       expect(compactMismatch).toContain("stopped before token exchange");
       expect(compactMismatch).toContain("Contact the MCP server provider");
       expect(compactMismatch).not.toContain('Add "oauth":{"issuer":');


### PR DESCRIPTION
## Summary

- Accept a single trailing-slash difference between the authorization server identifier discovered from protected-resource metadata and the issuer published by authorization-server metadata.
- Preserve the authorization-server metadata issuer exactly for authorization, token exchange, and credential persistence.
- Reject authorization response `iss` values unless they exactly match the accepted authorization-server metadata issuer.
- Continue rejecting issuer differences in scheme, host, port, path, query, fragment, casing, encoding, or additional trailing slashes.
- Remove the configuration-override requirement when protected-resource and authorization-server metadata differ only by one trailing slash.
