### PR TITLE
Clarify tool calls that did not run

### DIFF
--- a/src/core/agent/runtime/tests/tool_flow.zig
+++ b/src/core/agent/runtime/tests/tool_flow.zig
@@ -2880,7 +2880,10 @@ test "modern context delta defers effectful call exactly once" {
     try std.testing.expect(hooks.lifecycle_events.items[2] == .terminal);
     const terminal = hooks.lifecycle_events.items[2].terminal;
     try std.testing.expectEqual(types.ToolOutcomeKind.deferred, terminal.outcome.kind);
-    try std.testing.expectEqualStrings("Context updated write_file", terminal.outcome.summary);
+    try std.testing.expectEqualStrings(
+        "Not run — project instructions changed: write_file",
+        terminal.outcome.summary,
+    );
 }
 
 test "modern context delta does not defer unrelated effectful call" {
@@ -4879,7 +4882,10 @@ test "parallel permission preflight failure terminalizes its started lifecycle" 
     });
     const terminal = hooks.lifecycle_events.items[9].terminal;
     try std.testing.expectEqual(types.ToolOutcomeKind.failed, terminal.outcome.kind);
-    try std.testing.expect(std.mem.endsWith(u8, terminal.outcome.summary, ": preflight failed"));
+    try std.testing.expectEqualStrings(
+        "Failed read_file: permission preflight failed",
+        terminal.outcome.summary,
+    );
 }
 
 test "web_search denial trace records redacted query without api keys or result bodies" {

--- a/src/core/agent/runtime/tool_presentation.zig
+++ b/src/core/agent/runtime/tool_presentation.zig
@@ -1205,24 +1205,27 @@ fn failureStatusDetail(
     advertised_dynamic_tool_names: []const []const u8,
 ) !?[]const u8 {
     if (result.status_detail) |detail| {
-        if (!std.mem.eql(u8, detail, "preflight failed") or
-            !file_mutation_contract.isToolName(call.name) or
-            !std.mem.startsWith(u8, safe_result, call.name))
+        if (!std.mem.eql(u8, detail, "preflight failed")) return detail;
+
+        if (file_mutation_contract.isToolName(call.name) and
+            std.mem.startsWith(u8, safe_result, call.name))
         {
-            return detail;
+            const failure_prefix = " failed: ";
+            const remainder = safe_result[call.name.len..];
+            if (std.mem.startsWith(u8, remainder, failure_prefix)) {
+                const actionable = remainder[failure_prefix.len..];
+                if (actionable.len > 0 and
+                    std.mem.findScalar(u8, actionable, '\n') == null and
+                    std.mem.findScalar(u8, actionable, '\r') == null)
+                {
+                    return actionable;
+                }
+            }
         }
 
-        const failure_prefix = " failed: ";
-        const remainder = safe_result[call.name.len..];
-        if (!std.mem.startsWith(u8, remainder, failure_prefix)) return detail;
-        const actionable = remainder[failure_prefix.len..];
-        if (actionable.len == 0 or
-            std.mem.findScalar(u8, actionable, '\n') != null or
-            std.mem.findScalar(u8, actionable, '\r') != null)
-        {
-            return detail;
-        }
-        return actionable;
+        if (safe_result.len == 0) return detail;
+        const encoded = try text_utils.encodeTerminalSafe(arena, safe_result, 256);
+        return if (encoded.bytes.len == 0) detail else encoded.bytes;
     }
 
     if (safe_result.len == 0 or
@@ -2135,6 +2138,47 @@ test "file edit preflight failure reports the exact mismatch" {
     try std.testing.expectEqual(types.ToolOutcomeKind.failed, terminal.outcome.kind);
     try std.testing.expectEqualStrings(
         "Failed edit_file: old_string not found in file",
+        terminal.outcome.summary,
+    );
+}
+
+test "permission target preflight failure reports the actionable reason" {
+    const alloc = std.testing.allocator;
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var capture = ProvisionalStatusTestCapture{ .alloc = alloc };
+    defer capture.deinit();
+    const hooks = capture.hooks();
+    const failure = "Permission target resolution failed for grep_files: FileNotFound";
+
+    try finishExecutedToolStatus(
+        &hooks,
+        arena,
+        5,
+        .{
+            .id = "grep_preflight",
+            .name = "grep_files",
+            .arguments_json = "{\"pattern\":\"upgrade\",\"path\":\"/tmp/missing\"}",
+        },
+        true,
+        null,
+        .{
+            .status = .failure,
+            .model_output = failure,
+            .status_detail = "preflight failed",
+        },
+        failure,
+        .{ .output_bytes = failure.len, .stored_output_bytes = failure.len },
+        null,
+        &.{},
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), capture.events.items.len);
+    const terminal = capture.events.items[0].terminal;
+    try std.testing.expectEqual(types.ToolOutcomeKind.failed, terminal.outcome.kind);
+    try std.testing.expectEqualStrings(
+        "Failed grep_files: Permission target resolution failed for grep_files: FileNotFound",
         terminal.outcome.summary,
     );
 }

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -7181,8 +7181,8 @@ test "execution replay preserves paired deferred tools without command output" {
         app.completed_tool_outcomes.items,
     );
     try std.testing.expectEqual(@as(usize, 3), app.completed_tool_statuses.items.len);
-    try std.testing.expectEqualStrings("● Context updated read_file\n", app.completed_tool_statuses.items[0]);
-    try std.testing.expectEqualStrings("● Context updated run_command\n", app.completed_tool_statuses.items[1]);
+    try std.testing.expectEqualStrings("● Not run — project instructions changed: read_file\n", app.completed_tool_statuses.items[0]);
+    try std.testing.expectEqualStrings("● Not run — project instructions changed: run_command\n", app.completed_tool_statuses.items[1]);
     try std.testing.expectEqualStrings("● Not executed read_file\n", app.completed_tool_statuses.items[2]);
     try std.testing.expectEqual(@as(usize, 3), app.historical_tool_detail_entry_ids.items.len);
     try std.testing.expectEqual(@as(usize, 0), app.transcript.items.len);

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -2914,7 +2914,7 @@ fn settlePendingToolProgress(ctx: *AskContext, call_id: []const u8, outcome: typ
     var pending = takePendingToolProgressLocked(ctx, call_id) orelse return;
     defer pending.deinit(ctx.alloc);
     const context_deferred = outcome.kind == .deferred and
-        std.mem.startsWith(u8, outcome.summary, types.context_deferred_tool_status_label ++ ": ");
+        std.mem.startsWith(u8, outcome.summary, types.context_deferred_tool_status_label ++ " ");
     const legacy_deferred = outcome.kind == .denied and
         std.mem.startsWith(u8, outcome.summary, types.deferred_tool_result_output ++ ": ");
     if (!context_deferred and !legacy_deferred) return;
@@ -8873,7 +8873,7 @@ test "CLI command output completion terminates only an open display line" {
     );
 }
 
-test "CLI nonterminal progress preserves distinct deferred labels without duplicates" {
+test "CLI nonterminal progress preserves distinct not-run labels without duplicates" {
     const alloc = std.testing.allocator;
     var stdout_capture: TestCapture = .{};
     defer stdout_capture.deinit(alloc);
@@ -8901,7 +8901,7 @@ test "CLI nonterminal progress preserves distinct deferred labels without duplic
     } });
     try deps.push_tool_lifecycle(deps.ctx, .{ .terminal = .{
         .id = .{ .turn_id = 1, .call_id = "deferred_write" },
-        .outcome = .{ .kind = .deferred, .summary = "Context updated: Writing file" },
+        .outcome = .{ .kind = .deferred, .summary = "Not run — project instructions changed: Writing file" },
     } });
     try std.testing.expectEqualStrings("Writing file\n", stderr_capture.bytes.items);
 
@@ -8918,7 +8918,7 @@ test "CLI nonterminal progress preserves distinct deferred labels without duplic
     try std.testing.expectEqualStrings("Writing file\n", stderr_capture.bytes.items);
     try deps.push_tool_lifecycle(deps.ctx, .{ .terminal = .{
         .id = .{ .turn_id = 2, .call_id = "retry_write" },
-        .outcome = .{ .kind = .deferred, .summary = "Context updated: Writing file" },
+        .outcome = .{ .kind = .deferred, .summary = "Not run — project instructions changed: Writing file" },
     } });
 
     try deps.push_tool_lifecycle(deps.ctx, .{ .authoritative_started = .{

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -864,7 +864,7 @@ pub const TerminalActionPresentation = union(enum) {
 
 pub const deferred_tool_result_output = "Not executed";
 pub const context_deferred_tool_result_output = "Scoped project instructions were added before execution. Review them and reissue this tool call if it is still appropriate.";
-pub const context_deferred_tool_status_label = "Context updated";
+pub const context_deferred_tool_status_label = "Not run — project instructions changed:";
 
 pub fn isContextDeferredToolResult(result: PersistedToolResult) bool {
     return result.status == .failure and

--- a/src/ui/transcript/runtime.zig
+++ b/src/ui/transcript/runtime.zig
@@ -2596,7 +2596,7 @@ test "historical tool detail attaches to the exact replayed status entry" {
     try std.testing.expectEqual(@as(i64, 123), detail.created_at_ms);
 }
 
-test "historical deferred tool detail keeps the call without result evidence" {
+test "historical context-withheld tool detail keeps the call without result evidence" {
     const alloc = std.testing.allocator;
     var runtime = TranscriptRuntime{};
     defer runtime.deinit(alloc);
@@ -2606,7 +2606,7 @@ test "historical deferred tool detail keeps the call without result evidence" {
         alloc,
         &metrics,
         .deferred,
-        "Context updated: Running cat nested/input.txt",
+        "Not run — project instructions changed: Running cat nested/input.txt",
         true,
     );
     try runtime.attachHistoricalToolDetail(

--- a/src/ui/transcript/tool_group_projection.zig
+++ b/src/ui/transcript/tool_group_projection.zig
@@ -421,7 +421,11 @@ fn formatGroupHeader(
     try appendSegment(&out.writer, summary.failed, "failed");
     try appendSegment(&out.writer, summary.denied, "denied");
     try appendSegment(&out.writer, summary.cancelled, "cancelled");
-    try appendSegment(&out.writer, summary.deferred, "deferred");
+    try appendSegment(
+        &out.writer,
+        summary.deferred,
+        if (summary.deferred == 1) "command not run" else "commands not run",
+    );
 
     const plain = try out.toOwnedSlice();
     defer alloc.free(plain);
@@ -1162,11 +1166,11 @@ test "small minimal tool groups surface canonical action targets" {
     );
 }
 
-test "minimal tool groups preserve denied and deferred action text" {
+test "minimal tool groups preserve denied and not-run action text" {
     const alloc = std.testing.allocator;
     const entries = [_]TranscriptEntry{
         .{ .raw_bytes = .{ .id = 1, .bytes = "⊘ Denied by auto agent zig build\n", .class = .tool_status } },
-        .{ .raw_bytes = .{ .id = 2, .bytes = "↻ Context updated runtime.zig\n", .class = .tool_status } },
+        .{ .raw_bytes = .{ .id = 2, .bytes = "↻ Not run — project instructions changed: runtime.zig\n", .class = .tool_status } },
     };
     const details = [_]ToolDetailRecord{
         .{ .entry_id = 1, .tool_name = @constCast("terminal"), .activity_kind = .command, .outcome = .denied },
@@ -1177,10 +1181,26 @@ test "minimal tool groups preserve denied and deferred action text" {
     defer projection.deinit(alloc);
 
     try std.testing.expectEqualStrings(
-        "● 2 tool calls · 1 read · 1 command · 1 denied · 1 deferred\n" ++
+        "● 2 tool calls · 1 read · 1 command · 1 denied · 1 command not run\n" ++
             "├ Denied by auto agent zig build\n" ++
-            "└ Context updated runtime.zig",
+            "└ Not run — project instructions changed: runtime.zig",
         projection.entry_actions.items[0].override.bytes,
+    );
+}
+
+test "minimal tool group pluralizes context-withheld commands" {
+    const alloc = std.testing.allocator;
+    const header = try formatGroupHeader(
+        alloc,
+        .{ .total = 3, .deferred = 3 },
+        120,
+        .{},
+    );
+    defer alloc.free(header);
+
+    try std.testing.expectEqualStrings(
+        "● 3 tool calls · 3 commands not run",
+        header,
     );
 }
 

--- a/tests/e2e/tui-permissions.test.ts
+++ b/tests/e2e/tui-permissions.test.ts
@@ -1528,6 +1528,37 @@ describe.skipIf(!tmuxAvailable())("tui: file permissions", () => {
   );
 
   test(
+    "search preflight failure shows the target resolution reason",
+    async () => {
+      const root = createIsolatedRoot();
+      const gateway = startFakeGateway([
+        toolCall("grep_preflight_failure", "grep_files", {
+          pattern: "upgrade",
+          path: "missing-map/behavior-index",
+        }),
+        finalText("search failure handled"),
+      ]);
+      const { session, stderrPath } = await launch(root, gateway);
+
+      await session.sendText("Search the generated map once.");
+      const settled = await session.waitForText(
+        "search failure handled",
+        TIMEOUT,
+      );
+      const scrollback = await session.captureFullScrollback();
+
+      expect(scrollback).toContain(
+        "Permission target resolution failed for grep_files: FileNotFound",
+      );
+      expect(scrollback).not.toContain("preflight failed");
+      expect(settled).not.toContain(APPLY_QUESTION);
+      expect(gateway.requests).toHaveLength(2);
+      expectCleanStderr(stderrPath);
+    },
+    TIMEOUT,
+  );
+
+  test(
     "persistent session reevaluates every write and edit turn",
     async () => {
       const root = createIsolatedRoot();

--- a/tests/e2e/tui-resume.test.ts
+++ b/tests/e2e/tui-resume.test.ts
@@ -4158,7 +4158,7 @@ test.skipIf(!tmuxAvailable())(
 );
 
 test.skipIf(!tmuxAvailable())(
-  "context-deferred scoped tools remain deferred after resume",
+  "context-withheld scoped tools remain explicitly not run after resume",
   async () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "fx-tui-resume-deferred-tools-")));
     const home = join(root, "home");
@@ -4271,8 +4271,9 @@ test.skipIf(!tmuxAvailable())(
 
     function expectDeferredPresentation(scrollback: string): void {
       expect(scrollback).toContain("1 failed");
-      expect(scrollback).toContain("1 deferred");
-      expect(scrollback).toContain(`Context updated ${command}`);
+      expect(scrollback).toContain("1 command not run");
+      expect(scrollback).not.toContain("1 deferred");
+      expect(scrollback).toContain(`Not run — project instructions changed: ${command}`);
       expect(scrollback).not.toContain("Not executed");
       expect(scrollback).not.toContain("├ terminal");
       expect(scrollback).not.toContain("└ terminal");
@@ -4328,16 +4329,17 @@ test.skipIf(!tmuxAvailable())(
       await active.sendKeys("C-o");
       const detail = await active.waitForPane(
         (pane) =>
-          pane.includes(`Context updated ${command}`) &&
+          pane.includes(`Not run — project instructions changed: ${command}`) &&
           pane.includes("ordinary-failure-control"),
         TIMEOUT,
       );
-      expect(countOccurrences(detail, "Context updated")).toBe(1);
+      expect(countOccurrences(detail, "Not run — project instructions changed:")).toBe(1);
       expect(detail).not.toContain("Not executed");
       expect(detail).not.toContain('{"path":"nested/input.txt"}');
       expect(detail).not.toContain(JSON.stringify({ command, cwd: "nested" }));
       expect(detail).toContain(failureCommand);
-      expect(detail).toContain("1 deferred");
+      expect(detail).toContain("1 command not run");
+      expect(detail).not.toContain("1 deferred");
       expect(detail).toContain("1 failed");
       expect(readFileSync(resumeStderrPath, "utf8")).toBe("");
 


### PR DESCRIPTION
## Summary

- Show the actionable reason when a tool fails before execution.
- Tell users when a tool call was not run because project instructions changed.
- Describe grouped withheld calls as commands not run instead of deferred.