### PR TITLE
Make steering feedback immediate and resumable

### DIFF
--- a/src/core/agent/runtime/deps.zig
+++ b/src/core/agent/runtime/deps.zig
@@ -186,15 +186,14 @@ pub const AgentRuntimeDeps = struct {
     snapshot_root_permission_mode: ?*const fn (ctx: *anyopaque) PermissionMode = null,
     tool_activity_recorder: ?ToolActivityRecorder = null,
     finalize_turn: *const fn (ctx: *anyopaque, turn_id: u64, outcome: types.TurnPresentationOutcome, disposition: ?types.ProviderCompletionDisposition) anyerror!void = acknowledgePromptFinalization,
-    /// Drains user guidance admitted to the active turn. Returned text is owned
-    /// by `arena` and is non-authoritative context, never permission evidence.
-    take_steering: ?*const fn (ctx: *anyopaque, arena: Allocator, turn_id: u64) anyerror![]const []const u8 = null,
-    /// Drains guidance whose admission cancelled the current provider wait.
-    /// A non-empty result also clears that host-owned cancellation request.
-    take_immediate_steering: ?*const fn (ctx: *anyopaque, arena: Allocator, turn_id: u64) anyerror![]const []const u8 = null,
-    /// True when pending interactive guidance cannot be transferred into the
-    /// current request and must start after the active turn settles.
-    steering_handoff_required: ?*const fn (ctx: *anyopaque, turn_id: u64) bool = null,
+    /// Classifies one observed steering boundary. Continued text is arena-owned
+    /// non-authoritative context; handoff leaves the prompt host-owned.
+    take_steering_boundary: ?*const fn (
+        ctx: *anyopaque,
+        arena: Allocator,
+        turn_id: u64,
+        kind: worker_runtime.SteeringBoundaryKind,
+    ) anyerror!worker_runtime.SteeringBoundaryResult = null,
     release_agent_terminal_lease: *const fn (ctx: *anyopaque, session_id: []const u8) anyerror!void = terminalLeaseCleanupUnavailable,
     prepare_parent_turn_context: ?*const fn (ctx: *anyopaque, arena: Allocator) anyerror!?PreparedParentTurnContext = null,
     acknowledge_parent_turn_context: ?*const fn (ctx: *anyopaque, arena: Allocator, acknowledgements: []const ParentTurnDeliveryAck) void = null,

--- a/src/core/agent/runtime/execution_memory.zig
+++ b/src/core/agent/runtime/execution_memory.zig
@@ -61,23 +61,64 @@ pub fn buildExecutionMemory(alloc: Allocator, within_turn_suffix: []const ChatMe
     );
     errdefer types.freeExecutionMemory(alloc, execution);
 
-    var steering: std.ArrayList([]u8) = .empty;
+    var steering: std.ArrayList(types.PersistedSteering) = .empty;
     errdefer {
-        for (steering.items) |text| alloc.free(text);
+        for (steering.items) |item| {
+            alloc.free(item.text);
+            if (item.assistant_prefix) |prefix| alloc.free(prefix);
+        }
         steering.deinit(alloc);
     }
-    for (within_turn_suffix) |message| {
+    var tool_step_count: usize = 0;
+    var assistant_prefix: ?[]const u8 = null;
+    for (within_turn_suffix, 0..) |message, index| {
+        if (startsPersistedToolStep(within_turn_suffix, index)) {
+            tool_step_count += 1;
+            assistant_prefix = null;
+        } else if (message.role == .assistant) {
+            assistant_prefix = message.content;
+        }
         if (message.role != .user) continue;
         const content = message.content orelse continue;
-        const text = steeringText(content) orelse continue;
+        const text = steeringText(content) orelse {
+            assistant_prefix = null;
+            continue;
+        };
         const copy = try alloc.dupe(u8, text);
-        steering.append(alloc, copy) catch |err| {
+        const prefix_copy = if (assistant_prefix) |prefix|
+            execution_memory_helpers.redactText(alloc, prefix) catch |err| {
+                alloc.free(copy);
+                return err;
+            }
+        else
+            null;
+        steering.append(alloc, .{
+            .text = copy,
+            .assistant_prefix = prefix_copy,
+            .after_tool_step_count = tool_step_count,
+        }) catch |err| {
             alloc.free(copy);
+            if (prefix_copy) |prefix| alloc.free(prefix);
             return err;
         };
+        assistant_prefix = null;
     }
+    std.debug.assert(tool_step_count == execution.tool_steps.len);
     execution.steering = try steering.toOwnedSlice(alloc);
     return execution;
+}
+
+fn startsPersistedToolStep(messages: []const ChatMessage, assistant_index: usize) bool {
+    const assistant = messages[assistant_index];
+    if (assistant.role != .assistant or assistant.tool_calls.len == 0) return false;
+    var result_index = assistant_index + 1;
+    while (result_index < messages.len and messages[result_index].role == .tool) : (result_index += 1) {
+        const result_call_id = messages[result_index].tool_call_id orelse continue;
+        for (assistant.tool_calls) |call| {
+            if (std.mem.eql(u8, call.id, result_call_id)) return true;
+        }
+    }
+    return false;
 }
 
 fn steeringText(content: []const u8) ?[]const u8 {
@@ -1164,8 +1205,46 @@ test "execution memory persists consumed steering without protocol wrappers" {
     defer types.freeExecutionMemory(alloc, execution);
 
     try std.testing.expectEqual(@as(usize, 2), execution.steering.len);
-    try std.testing.expectEqualStrings("focus on rendering", execution.steering[0]);
-    try std.testing.expectEqualStrings("run the focused test", execution.steering[1]);
+    try std.testing.expectEqualStrings("focus on rendering", execution.steering[0].text);
+    try std.testing.expectEqualStrings("run the focused test", execution.steering[1].text);
+    try std.testing.expectEqual(@as(usize, 0), execution.steering[0].after_tool_step_count);
+    try std.testing.expectEqual(@as(usize, 0), execution.steering[1].after_tool_step_count);
+}
+
+test "execution memory records each steering tool boundary" {
+    const alloc = std.testing.allocator;
+    const first_steering = try steeringMessage(alloc, "after first");
+    defer alloc.free(first_steering);
+    const second_steering = try steeringMessage(alloc, "after second");
+    defer alloc.free(second_steering);
+    var first_calls = [_]ToolCall{.{
+        .id = "call_first",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"first\"}",
+    }};
+    var second_calls = [_]ToolCall{.{
+        .id = "call_second",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"second\"}",
+    }};
+    const messages = [_]ChatMessage{
+        .{ .role = .assistant, .tool_calls = &first_calls },
+        .{ .role = .tool, .content = "first result", .tool_call_id = "call_first", .tool_name = "read_file", .tool_result_status = .success },
+        .{ .role = .user, .content = first_steering },
+        .{ .role = .assistant, .tool_calls = &second_calls },
+        .{ .role = .tool, .content = "second result", .tool_call_id = "call_second", .tool_name = "read_file", .tool_result_status = .success },
+        .{ .role = .user, .content = second_steering },
+    };
+
+    const execution = try buildExecutionMemory(alloc, &messages);
+    defer types.freeExecutionMemory(alloc, execution);
+
+    try std.testing.expectEqual(@as(usize, 2), execution.tool_steps.len);
+    try std.testing.expectEqual(@as(usize, 2), execution.steering.len);
+    try std.testing.expectEqualStrings("after first", execution.steering[0].text);
+    try std.testing.expectEqual(@as(usize, 1), execution.steering[0].after_tool_step_count);
+    try std.testing.expectEqualStrings("after second", execution.steering[1].text);
+    try std.testing.expectEqual(@as(usize, 2), execution.steering[1].after_tool_step_count);
 }
 
 test "transcript does not mark native web_search as provider resource placeholder" {

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -85,6 +85,30 @@ const TurnFinalizationGuard = runtime_finalization.TurnFinalizationGuard;
 const PromptFinishTrace = runtime_finalization.PromptFinishTrace;
 const ToolExecutionResult = runtime_tool_contracts.ToolExecutionResult;
 
+fn take_steering_boundary(
+    deps: *const AgentRuntimeDeps,
+    arena: Allocator,
+    turn_id: u64,
+    kind: worker_runtime.SteeringBoundaryKind,
+) !worker_runtime.SteeringBoundaryResult {
+    const take = deps.take_steering_boundary orelse
+        return if (kind == .cancelled) .interrupt else .none;
+    return take(deps.ctx, arena, turn_id, kind);
+}
+
+fn append_steering_guidance(
+    arena: Allocator,
+    within_turn_suffix: *std.ArrayList(ChatMessage),
+    guidance: []const []const u8,
+) !void {
+    for (guidance) |text| {
+        try within_turn_suffix.append(arena, .{
+            .role = .user,
+            .content = try runtime_execution_memory.steeringMessage(arena, text),
+        });
+    }
+}
+
 fn append_pending_steering_after_assistant(
     deps: *const AgentRuntimeDeps,
     arena: Allocator,
@@ -92,20 +116,17 @@ fn append_pending_steering_after_assistant(
     turn_id: u64,
     assistant_text: []const u8,
 ) !bool {
-    const take_steering = deps.take_steering orelse return false;
-    const guidance = try take_steering(deps.ctx, arena, turn_id);
-    if (guidance.len == 0) return false;
+    const boundary = try take_steering_boundary(deps, arena, turn_id, .model);
+    const guidance = switch (boundary) {
+        .continue_turn => |messages| messages,
+        .none, .handoff, .interrupt => return false,
+    };
 
     try within_turn_suffix.append(arena, .{
         .role = .assistant,
         .content = assistant_text,
     });
-    for (guidance) |text| {
-        try within_turn_suffix.append(arena, .{
-            .role = .user,
-            .content = try runtime_execution_memory.steeringMessage(arena, text),
-        });
-    }
+    try append_steering_guidance(arena, within_turn_suffix, guidance);
     return true;
 }
 
@@ -116,9 +137,11 @@ fn append_immediate_steering_after_cancel(
     turn_id: u64,
     assistant_text: []const u8,
 ) !bool {
-    const take_immediate_steering = deps.take_immediate_steering orelse return false;
-    const guidance = try take_immediate_steering(deps.ctx, arena, turn_id);
-    if (guidance.len == 0) return false;
+    const boundary = try take_steering_boundary(deps, arena, turn_id, .cancelled);
+    const guidance = switch (boundary) {
+        .continue_turn => |messages| messages,
+        .none, .handoff, .interrupt => return false,
+    };
 
     if (assistant_text.len > 0) {
         try within_turn_suffix.append(arena, .{
@@ -126,12 +149,7 @@ fn append_immediate_steering_after_cancel(
             .content = try arena.dupe(u8, assistant_text),
         });
     }
-    for (guidance) |text| {
-        try within_turn_suffix.append(arena, .{
-            .role = .user,
-            .content = try runtime_execution_memory.steeringMessage(arena, text),
-        });
-    }
+    try append_steering_guidance(arena, within_turn_suffix, guidance);
     return true;
 }
 
@@ -3944,7 +3962,7 @@ fn processQueuedPromptInner(
         "history_turns={d} gateway_messages_before={d} interrupted_turns={d} history_turn_kinds={s}",
         .{ active_history.len, history_messages_before, interrupted_turns, history_turn_kinds },
     );
-    if (job.steering_continuation) {
+    if (job.delivery.isContinuation()) {
         try session_runtime.appendSteeringActiveContextHistoryChatMessages(
             arena,
             &history_messages,
@@ -3973,7 +3991,7 @@ fn processQueuedPromptInner(
 
     const current_user_message: ChatMessage = .{
         .role = .user,
-        .content = if (job.steering_continuation)
+        .content = if (job.delivery.isContinuation())
             try runtime_execution_memory.steeringMessage(arena, job.prompt)
         else
             job.prompt,
@@ -4721,8 +4739,16 @@ fn processQueuedPromptLoop(
             finish_trace.finish("interrupted");
             return;
         }
-        if (deps.steering_handoff_required) |handoff_required| {
-            if (handoff_required(deps.ctx, turn_id)) {
+        _ = overlay_arena_state.reset(.retain_capacity);
+        const overlay_arena = overlay_arena_state.allocator();
+        const steering_boundary = try take_steering_boundary(
+            deps,
+            overlay_arena,
+            turn_id,
+            .model,
+        );
+        switch (steering_boundary) {
+            .handoff => {
                 try runtime_interruption.persistInterruptedTurnOnce(
                     deps,
                     finalization,
@@ -4738,20 +4764,15 @@ fn processQueuedPromptLoop(
                 );
                 finish_trace.finish("steering_handoff");
                 return;
-            }
+            },
+            .continue_turn => |guidance| try append_steering_guidance(
+                arena,
+                &within_turn_suffix,
+                guidance,
+            ),
+            .none, .interrupt => {},
         }
-        _ = overlay_arena_state.reset(.retain_capacity);
-        const overlay_arena = overlay_arena_state.allocator();
         var ephemeral_overlay: std.ArrayList(ChatMessage) = .empty;
-        if (deps.take_steering) |take_steering| {
-            const guidance = try take_steering(deps.ctx, overlay_arena, turn_id);
-            for (guidance) |text| {
-                try within_turn_suffix.append(arena, .{
-                    .role = .user,
-                    .content = try runtime_execution_memory.steeringMessage(arena, text),
-                });
-            }
-        }
         if (config.explicit_skills_prompt_section.len > 0) {
             try ephemeral_overlay.append(overlay_arena, .{ .role = .system, .content = config.explicit_skills_prompt_section });
         }

--- a/src/core/agent/runtime/tests/gateway_flow.zig
+++ b/src/core/agent/runtime/tests/gateway_flow.zig
@@ -243,7 +243,7 @@ test "terminal assistant completion continues with steering admitted during the 
     try std.testing.expectEqual(@as(usize, 1), hooks.history_turns.items.len);
     const execution = hooks.history_turns.items[0].assistant.execution;
     try std.testing.expectEqual(@as(usize, 1), execution.steering.len);
-    try std.testing.expectEqualStrings("change direction", execution.steering[0]);
+    try std.testing.expectEqualStrings("change direction", execution.steering[0].text);
 
     const resumed_completions = [_]FakeCompletion{.{ .content = "Follow-up answer" }};
     var resumed_gateway = FakeGateway.init(alloc, &resumed_completions);
@@ -264,6 +264,7 @@ test "terminal assistant completion continues with steering admitted during the 
 
     try expectBodyContainsInOrder(&resumed_gateway, 0, &.{
         "user prompt",
+        "Original answer",
         "change direction",
         "Updated answer",
         "follow up",
@@ -279,7 +280,7 @@ test "promoted steering remains model marked across the worker handoff" {
     defer hooks.deinit();
     var fixture = PromptFixture{};
     var job = fixture.job();
-    job.steering_continuation = true;
+    job.delivery = .continuation;
 
     try runFakePrompt(&gateway, &hooks, fixture.config(), job);
 

--- a/src/core/agent/runtime/tests/interruption_flow.zig
+++ b/src/core/agent/runtime/tests/interruption_flow.zig
@@ -203,8 +203,8 @@ test "automatic text steering resumes the same turn without interrupted history"
     try std.testing.expectEqualStrings("Updated answer", hooks.finish_assistant_text.?);
     const execution = hooks.history_turns.items[0].assistant.execution;
     try std.testing.expectEqual(@as(usize, 2), execution.steering.len);
-    try std.testing.expectEqualStrings("first update", execution.steering[0]);
-    try std.testing.expectEqualStrings("second update", execution.steering[1]);
+    try std.testing.expectEqualStrings("first update", execution.steering[0].text);
+    try std.testing.expectEqualStrings("second update", execution.steering[1].text);
 }
 
 test "streamed presentation preserves raw partial through cancellation" {

--- a/src/core/agent/runtime/tests/support.zig
+++ b/src/core/agent/runtime/tests/support.zig
@@ -786,8 +786,11 @@ pub const FakeAgentRuntimeDeps = struct {
             .request_route_recovery = if (self.enable_route_recovery) requestRouteRecovery else null,
             .available_model_capabilities = availableModelCapabilities,
             .resolve_model_capabilities = resolveModelCapabilities,
-            .take_steering = if (self.steering_messages.len > 0) takeSteering else null,
-            .take_immediate_steering = if (self.immediate_steering_messages.len > 0) takeImmediateSteering else null,
+            .take_steering_boundary = if (self.steering_messages.len > 0 or
+                self.immediate_steering_messages.len > 0)
+                takeSteeringBoundary
+            else
+                null,
             .format_tool_execution_error = formatError,
             .record_tool_call_rejected = recordRejected,
             .report_inner_tool_usage = reportCapturedInnerToolUsage,
@@ -868,23 +871,30 @@ pub const FakeAgentRuntimeDeps = struct {
         return try alloc.dupe(u8, token);
     }
 
-    fn takeSteering(raw: *anyopaque, arena: Allocator, _: u64) ![]const []const u8 {
+    fn takeSteeringBoundary(
+        raw: *anyopaque,
+        arena: Allocator,
+        _: u64,
+        kind: worker_runtime.SteeringBoundaryKind,
+    ) !worker_runtime.SteeringBoundaryResult {
         const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
-        self.steering_take_count += 1;
-        if (self.steering_take_count != self.steering_take_at) return &.{};
-        const messages = try arena.alloc([]const u8, self.steering_messages.len);
-        @memcpy(messages, self.steering_messages);
-        return messages;
-    }
-
-    fn takeImmediateSteering(raw: *anyopaque, arena: Allocator, _: u64) ![]const []const u8 {
-        const self: *FakeAgentRuntimeDeps = @ptrCast(@alignCast(raw));
-        self.immediate_steering_take_count += 1;
-        if (self.immediate_steering_take_count != 1) return &.{};
-        const messages = try arena.alloc([]const u8, self.immediate_steering_messages.len);
-        @memcpy(messages, self.immediate_steering_messages);
-        if (self.immediate_steering_cancel_flag) |flag| flag.store(false, .seq_cst);
-        return messages;
+        const source = switch (kind) {
+            .model => blk: {
+                self.steering_take_count += 1;
+                if (self.steering_take_count != self.steering_take_at) return .none;
+                break :blk self.steering_messages;
+            },
+            .cancelled => blk: {
+                self.immediate_steering_take_count += 1;
+                if (self.immediate_steering_take_count != 1) return .interrupt;
+                if (self.immediate_steering_cancel_flag) |flag| flag.store(false, .seq_cst);
+                break :blk self.immediate_steering_messages;
+            },
+        };
+        if (source.len == 0) return if (kind == .cancelled) .interrupt else .none;
+        const messages = try arena.alloc([]u8, source.len);
+        for (source, messages) |text, *copy| copy.* = try arena.dupe(u8, text);
+        return .{ .continue_turn = messages };
     }
 
     fn requestRouteRecovery(raw: *anyopaque, _: Allocator, request: runtime_deps.RouteRecoveryRequest) !runtime_deps.RouteRecoveryDecision {

--- a/src/core/agent/worker_runtime.zig
+++ b/src/core/agent/worker_runtime.zig
@@ -55,14 +55,46 @@ pub const QueueReviewDraft = struct {
     skill_display_spans: []SkillDisplaySpan = &.{},
 };
 
+pub const PromptDelivery = union(enum) {
+    ordinary,
+    active_turn: u64,
+    continuation,
+
+    pub fn activeTurnId(self: PromptDelivery) ?u64 {
+        return switch (self) {
+            .active_turn => |turn_id| turn_id,
+            .ordinary, .continuation => null,
+        };
+    }
+
+    pub fn isSteering(self: PromptDelivery) bool {
+        return switch (self) {
+            .ordinary => false,
+            .active_turn, .continuation => true,
+        };
+    }
+
+    pub fn isContinuation(self: PromptDelivery) bool {
+        return self == .continuation;
+    }
+};
+
+pub const SteeringBoundaryKind = enum {
+    model,
+    cancelled,
+};
+
+pub const SteeringBoundaryResult = union(enum) {
+    none,
+    continue_turn: [][]u8,
+    handoff,
+    interrupt,
+};
+
 pub const QueuedPrompt = struct {
     turn_id: u64 = 0,
-    /// The active turn that may consume this prompt as steering. When that turn
-    /// finishes, the target is cleared in place so admission order is retained.
-    steer_target_turn_id: ?u64 = null,
-    /// Set when steering must start as the next worker turn after the active
-    /// turn settles. The model still receives the prompt as live guidance.
-    steering_continuation: bool = false,
+    /// Runtime-derived delivery state. The worker retains ownership in every state.
+    delivery: PromptDelivery = .ordinary,
     prompt: []u8,
     images: []types.ImageAttachment,
     authorized_image_catalog: []types.ImageAttachment = &.{},
@@ -286,6 +318,19 @@ pub const QueuePreview = struct {
     count: usize = 0,
     steering_count: usize = 0,
     paused: bool = false,
+};
+
+pub const QueuePresentationSnapshot = struct {
+    ordinary_count: usize = 0,
+    steering_messages: [][]u8 = &.{},
+    steering_waits_for_tool: bool = false,
+    paused: bool = false,
+
+    pub fn deinit(self: *QueuePresentationSnapshot, alloc: std.mem.Allocator) void {
+        for (self.steering_messages) |message| alloc.free(message);
+        if (self.steering_messages.len > 0) alloc.free(self.steering_messages);
+        self.* = .{};
+    }
 };
 
 pub const QueueReviewReason = enum {
@@ -684,8 +729,8 @@ pub const WorkerRuntime = struct {
         defer self.worker_mutex.unlock(io_mod.getIo());
 
         const steering_pending = for (self.queued_prompts.items) |prompt| {
-            if (prompt.steer_target_turn_id == self.active_turn_id or
-                prompt.steering_continuation) break true;
+            if (prompt.delivery.activeTurnId() == self.active_turn_id or
+                prompt.delivery.isContinuation()) break true;
         } else false;
         const paused = if (steering_pending)
             false
@@ -967,7 +1012,7 @@ pub const WorkerRuntime = struct {
         queued.agent_settings = self.agent_turn_settings;
         var interrupt_after_admission = false;
         if (steer_if_active and self.worker_processing and self.active_turn_id != 0) {
-            queued.steer_target_turn_id = self.active_turn_id;
+            queued.delivery = .{ .active_turn = self.active_turn_id };
             interrupt_after_admission = self.active_tool_calls.count() == 0;
         }
         try self.enqueuePromptLocked(alloc, queued);
@@ -986,19 +1031,7 @@ pub const WorkerRuntime = struct {
     }
 
     fn isSteeringPrompt(prompt: QueuedPrompt) bool {
-        return prompt.steer_target_turn_id != null or prompt.steering_continuation;
-    }
-
-    pub fn steeringHandoffRequired(self: *WorkerRuntime, turn_id: u64) bool {
-        self.worker_mutex.lockUncancelable(io_mod.getIo());
-        defer self.worker_mutex.unlock(io_mod.getIo());
-        if (!self.worker_processing or self.active_turn_id != turn_id) return false;
-        for (self.queued_prompts.items) |prompt| {
-            if (prompt.steer_target_turn_id == turn_id and !sameTurnSteeringEligible(prompt)) {
-                return true;
-            }
-        }
-        return false;
+        return prompt.delivery.isSteering();
     }
 
     fn enqueuePromptLocked(self: *WorkerRuntime, alloc: std.mem.Allocator, queued: QueuedPrompt) !void {
@@ -1019,46 +1052,53 @@ pub const WorkerRuntime = struct {
         self.worker_cond.broadcast(io_mod.getIo());
     }
 
-    /// Returns allocator-owned steering text for `turn_id`, removing only those
-    /// entries from the shared admission-ordered queue.
-    pub fn takeSteering(self: *WorkerRuntime, alloc: std.mem.Allocator, turn_id: u64) ![][]u8 {
+    /// Classifies and drains steering at one observed agent boundary. Returned
+    /// text is allocator-owned; handoff leaves the queued prompt worker-owned.
+    pub fn takeSteeringBoundary(
+        self: *WorkerRuntime,
+        alloc: std.mem.Allocator,
+        turn_id: u64,
+        kind: SteeringBoundaryKind,
+    ) !SteeringBoundaryResult {
         self.worker_mutex.lockUncancelable(io_mod.getIo());
         defer self.worker_mutex.unlock(io_mod.getIo());
+        const cancel_requested = self.worker_cancel_requested.load(.seq_cst);
         if (!self.worker_processing or
             self.active_turn_id != turn_id or
             self.queue_admission != null)
         {
-            return &.{};
+            return if (kind == .cancelled and cancel_requested) .interrupt else .none;
         }
 
-        return self.takeSteeringLocked(alloc, turn_id);
-    }
-
-    /// Consumes only text steering that owns the current provider cancellation.
-    /// A successful drain atomically returns the cancel flag to the active turn.
-    pub fn takeImmediateSteering(self: *WorkerRuntime, alloc: std.mem.Allocator, turn_id: u64) ![][]u8 {
-        self.worker_mutex.lockUncancelable(io_mod.getIo());
-        defer self.worker_mutex.unlock(io_mod.getIo());
-        if (!self.worker_processing or
-            self.active_turn_id != turn_id or
-            self.queue_admission != null or
-            self.steering_cancel_turn_id != turn_id or
-            !self.worker_cancel_requested.load(.seq_cst))
-        {
-            return &.{};
+        switch (kind) {
+            .cancelled => {
+                if (!cancel_requested) return .none;
+                if (self.steering_cancel_turn_id != turn_id) return .interrupt;
+                const messages = try self.takeSteeringLocked(alloc, turn_id);
+                if (messages.len == 0) return .interrupt;
+                self.steering_cancel_turn_id = null;
+                self.worker_cancel_requested.store(false, .seq_cst);
+                return .{ .continue_turn = messages };
+            },
+            .model => {
+                if (cancel_requested) return .none;
+                for (self.queued_prompts.items) |prompt| {
+                    if (prompt.delivery.activeTurnId() == turn_id and
+                        !sameTurnSteeringEligible(prompt)) return .handoff;
+                }
+                const messages = try self.takeSteeringLocked(alloc, turn_id);
+                return if (messages.len == 0)
+                    .none
+                else
+                    .{ .continue_turn = messages };
+            },
         }
-
-        const messages = try self.takeSteeringLocked(alloc, turn_id);
-        if (messages.len == 0) return &.{};
-        self.steering_cancel_turn_id = null;
-        self.worker_cancel_requested.store(false, .seq_cst);
-        return messages;
     }
 
     fn takeSteeringLocked(self: *WorkerRuntime, alloc: std.mem.Allocator, turn_id: u64) ![][]u8 {
         var steering_count: usize = 0;
         for (self.queued_prompts.items) |prompt| {
-            if (prompt.steer_target_turn_id != turn_id) continue;
+            if (prompt.delivery.activeTurnId() != turn_id) continue;
             if (!sameTurnSteeringEligible(prompt)) return &.{};
             steering_count += 1;
         }
@@ -1077,7 +1117,7 @@ pub const WorkerRuntime = struct {
             alloc.free(events);
         }
         for (self.queued_prompts.items) |prompt| {
-            if (prompt.steer_target_turn_id != turn_id) continue;
+            if (prompt.delivery.activeTurnId() != turn_id) continue;
             messages[copied] = try alloc.dupe(u8, prompt.prompt);
             copied += 1;
             events[event_count] = .{
@@ -1091,7 +1131,7 @@ pub const WorkerRuntime = struct {
 
         var index: usize = 0;
         while (index < self.queued_prompts.items.len) {
-            if (self.queued_prompts.items[index].steer_target_turn_id != turn_id) {
+            if (self.queued_prompts.items[index].delivery.activeTurnId() != turn_id) {
                 index += 1;
                 continue;
             }
@@ -1449,11 +1489,10 @@ pub const WorkerRuntime = struct {
         self.recovery_continuation_ready = false;
         self.worker_processing = true;
         self.active_turn_id = job.turn_id;
-        if (job.steering_continuation) {
+        if (job.delivery.isContinuation()) {
             for (self.queued_prompts.items) |*prompt| {
-                if (!prompt.steering_continuation or !sameTurnSteeringEligible(prompt.*)) continue;
-                prompt.steer_target_turn_id = job.turn_id;
-                prompt.steering_continuation = false;
+                if (!prompt.delivery.isContinuation() or !sameTurnSteeringEligible(prompt.*)) continue;
+                prompt.delivery = .{ .active_turn = job.turn_id };
             }
         }
         self.active_context_compaction = false;
@@ -1479,9 +1518,8 @@ pub const WorkerRuntime = struct {
         // order in which steering and ordinary prompts were submitted.
         const finished_turn_id = self.active_turn_id;
         for (self.queued_prompts.items) |*prompt| {
-            if (prompt.steer_target_turn_id == finished_turn_id) {
-                prompt.steer_target_turn_id = null;
-                prompt.steering_continuation = true;
+            if (prompt.delivery.activeTurnId() == finished_turn_id) {
+                prompt.delivery = .continuation;
             }
         }
         self.worker_processing = false;
@@ -1658,37 +1696,36 @@ pub const WorkerRuntime = struct {
         };
     }
 
-    /// Returns allocator-owned copies of steering that is visibly waiting on
-    /// the active tool boundary. Immediate steering remains hidden until it is
-    /// committed as a user turn after the model cutoff.
-    pub fn snapshotVisibleSteeringMessages(self: *WorkerRuntime, alloc: std.mem.Allocator) ![][]u8 {
+    /// Returns one coherent, allocator-owned queue presentation snapshot.
+    pub fn snapshotQueuePresentation(self: *WorkerRuntime, alloc: std.mem.Allocator) !QueuePresentationSnapshot {
         self.worker_mutex.lockUncancelable(io_mod.getIo());
         defer self.worker_mutex.unlock(io_mod.getIo());
 
-        var count: usize = 0;
+        const queued_count = self.queued_prompts.items.len;
+        var steering_count: usize = 0;
         for (self.queued_prompts.items) |prompt| {
-            if (self.pendingSteeringVisibleLocked(prompt)) count += 1;
+            if (isSteeringPrompt(prompt)) steering_count += 1;
         }
-        if (count == 0) return &.{};
+        var snapshot: QueuePresentationSnapshot = .{
+            .ordinary_count = queued_count -| steering_count,
+            .steering_waits_for_tool = steering_count > 0 and self.active_tool_calls.count() > 0,
+            .paused = self.queue_admission != null,
+        };
+        if (steering_count == 0) return snapshot;
 
-        const messages = try alloc.alloc([]u8, count);
+        const messages = try alloc.alloc([]u8, steering_count);
         var copied: usize = 0;
         errdefer {
             for (messages[0..copied]) |message| alloc.free(message);
             alloc.free(messages);
         }
         for (self.queued_prompts.items) |prompt| {
-            if (!self.pendingSteeringVisibleLocked(prompt)) continue;
+            if (!isSteeringPrompt(prompt)) continue;
             messages[copied] = try alloc.dupe(u8, prompt.prompt);
             copied += 1;
         }
-        return messages;
-    }
-
-    fn pendingSteeringVisibleLocked(self: *const WorkerRuntime, prompt: QueuedPrompt) bool {
-        if (!isSteeringPrompt(prompt)) return false;
-        return self.steering_cancel_turn_id == null or
-            prompt.steer_target_turn_id != self.steering_cancel_turn_id;
+        snapshot.steering_messages = messages;
+        return snapshot;
     }
 
     pub fn queuedPromptCount(self: *WorkerRuntime) usize {
@@ -3705,6 +3742,13 @@ fn freeEventList(alloc: std.mem.Allocator, events: *std.ArrayList(WorkerEvent)) 
     events.deinit(alloc);
 }
 
+fn expectContinuedSteering(result: SteeringBoundaryResult) ![]const []const u8 {
+    return switch (result) {
+        .continue_turn => |messages| messages,
+        .none, .handoff, .interrupt => error.TestExpectedContinuedSteering,
+    };
+}
+
 test "interactive prompt admission derives steering from active worker state" {
     const alloc = std.testing.allocator;
     var runtime = WorkerRuntime{};
@@ -3714,7 +3758,9 @@ test "interactive prompt admission derives steering from active worker state" {
 
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "steer", "model"));
 
-    const guidance = try runtime.takeSteering(alloc, 41);
+    const guidance = try expectContinuedSteering(
+        try runtime.takeSteeringBoundary(alloc, 41, .cancelled),
+    );
     defer {
         for (guidance) |text| alloc.free(text);
         alloc.free(guidance);
@@ -3732,7 +3778,9 @@ test "active prompt admission drains steering in FIFO order" {
 
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "first", "model"));
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "second", "model"));
-    const guidance = try runtime.takeSteering(alloc, 41);
+    const guidance = try expectContinuedSteering(
+        try runtime.takeSteeringBoundary(alloc, 41, .cancelled),
+    );
     defer {
         for (guidance) |text| alloc.free(text);
         alloc.free(guidance);
@@ -3761,7 +3809,9 @@ test "immediate steering owns and clears only its cancellation" {
     try std.testing.expect(steering_snapshot.cancel_requested);
     try std.testing.expect(steering_snapshot.cancel_continues_turn);
 
-    const guidance = try runtime.takeImmediateSteering(alloc, 41);
+    const guidance = try expectContinuedSteering(
+        try runtime.takeSteeringBoundary(alloc, 41, .cancelled),
+    );
     defer {
         for (guidance) |text| alloc.free(text);
         alloc.free(guidance);
@@ -3787,8 +3837,8 @@ test "explicit interrupt overrides immediate steering cancellation" {
     try std.testing.expect(interrupt_snapshot.cancel_requested);
     try std.testing.expect(!interrupt_snapshot.cancel_continues_turn);
 
-    const guidance = try runtime.takeImmediateSteering(alloc, 41);
-    try std.testing.expectEqual(@as(usize, 0), guidance.len);
+    const boundary = try runtime.takeSteeringBoundary(alloc, 41, .cancelled);
+    try std.testing.expect(boundary == .interrupt);
     try std.testing.expect(runtime.isCancelRequested());
     try std.testing.expectEqual(@as(usize, 1), runtime.queuedPromptCount());
 }
@@ -3884,14 +3934,12 @@ test "rich interactive input remains steering and hands off at the tool boundary
     const preview = runtime.queuePreview();
     try std.testing.expectEqual(@as(usize, 1), preview.steering_count);
     try std.testing.expect(!runtime.isCancelRequested());
-    try std.testing.expect(runtime.steeringHandoffRequired(41));
-
-    const guidance = try runtime.takeSteering(alloc, 41);
-    try std.testing.expectEqual(@as(usize, 0), guidance.len);
+    const boundary = try runtime.takeSteeringBoundary(alloc, 41, .model);
+    try std.testing.expect(boundary == .handoff);
     try std.testing.expectEqual(@as(usize, 1), runtime.queuedPromptCount());
 }
 
-test "immediate steering stays hidden until the cutoff commits its user turn" {
+test "immediate steering is visible while the provider cutoff settles" {
     const alloc = std.testing.allocator;
     var runtime = WorkerRuntime{};
     defer runtime.deinit(alloc);
@@ -3900,18 +3948,13 @@ test "immediate steering stays hidden until the cutoff commits its user turn" {
 
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "first", "model"));
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "second", "model"));
-    const messages = try runtime.snapshotVisibleSteeringMessages(alloc);
-    defer {
-        for (messages) |message| alloc.free(message);
-        alloc.free(messages);
-    }
+    var snapshot = try runtime.snapshotQueuePresentation(alloc);
+    defer snapshot.deinit(alloc);
 
-    const guidance = try runtime.takeSteering(alloc, 41);
-    defer {
-        for (guidance) |text| alloc.free(text);
-        alloc.free(guidance);
-    }
-    try std.testing.expectEqual(@as(usize, 0), messages.len);
+    try std.testing.expectEqual(@as(usize, 2), snapshot.steering_messages.len);
+    try std.testing.expectEqualStrings("first", snapshot.steering_messages[0]);
+    try std.testing.expectEqualStrings("second", snapshot.steering_messages[1]);
+    try std.testing.expect(!snapshot.steering_waits_for_tool);
 }
 
 test "tool-blocked steering snapshot owns visible messages in admission order" {
@@ -3930,14 +3973,12 @@ test "tool-blocked steering snapshot owns visible messages in admission order" {
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "first", "model"));
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "second", "model"));
 
-    const messages = try runtime.snapshotVisibleSteeringMessages(alloc);
-    defer {
-        for (messages) |message| alloc.free(message);
-        alloc.free(messages);
-    }
-    try std.testing.expectEqual(@as(usize, 2), messages.len);
-    try std.testing.expectEqualStrings("first", messages[0]);
-    try std.testing.expectEqualStrings("second", messages[1]);
+    var snapshot = try runtime.snapshotQueuePresentation(alloc);
+    defer snapshot.deinit(alloc);
+    try std.testing.expectEqual(@as(usize, 2), snapshot.steering_messages.len);
+    try std.testing.expectEqualStrings("first", snapshot.steering_messages[0]);
+    try std.testing.expectEqualStrings("second", snapshot.steering_messages[1]);
+    try std.testing.expect(snapshot.steering_waits_for_tool);
 }
 
 test "manual queue review does not intercept active steering" {
@@ -3950,7 +3991,9 @@ test "manual queue review does not intercept active steering" {
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "before", "model"));
     try std.testing.expect(!runtime.beginQueueReview(.manual));
 
-    const guidance = try runtime.takeSteering(alloc, 41);
+    const guidance = try expectContinuedSteering(
+        try runtime.takeSteeringBoundary(alloc, 41, .cancelled),
+    );
     defer {
         for (guidance) |text| alloc.free(text);
         alloc.free(guidance);
@@ -3974,10 +4017,9 @@ test "late steering keeps admission order when demoted on finish" {
     try std.testing.expectEqual(@as(u64, 0), runtime.active_turn_id);
     try std.testing.expectEqual(@as(usize, 2), runtime.queuedPromptCount());
     try std.testing.expectEqualStrings("steer first", runtime.queued_prompts.items[0].prompt);
-    try std.testing.expect(runtime.queued_prompts.items[0].steer_target_turn_id == null);
-    try std.testing.expect(runtime.queued_prompts.items[0].steering_continuation);
+    try std.testing.expect(runtime.queued_prompts.items[0].delivery.isContinuation());
     try std.testing.expectEqualStrings("queue second", runtime.queued_prompts.items[1].prompt);
-    try std.testing.expect(!runtime.queued_prompts.items[1].steering_continuation);
+    try std.testing.expect(!runtime.queued_prompts.items[1].delivery.isContinuation());
 }
 
 test "promoted steering retargets remaining guidance without exposing a queue" {
@@ -3993,10 +4035,12 @@ test "promoted steering retargets remaining guidance without exposing a queue" {
 
     const promoted = (try runtime.tryTakeNextPrompt(alloc)).?;
     defer freeQueuedPrompt(alloc, promoted);
-    try std.testing.expect(promoted.steering_continuation);
+    try std.testing.expect(promoted.delivery.isContinuation());
     try std.testing.expectEqual(@as(usize, 1), runtime.queuePreview().steering_count);
 
-    const guidance = try runtime.takeSteering(alloc, promoted.turn_id);
+    const guidance = try expectContinuedSteering(
+        try runtime.takeSteeringBoundary(alloc, promoted.turn_id, .model),
+    );
     defer {
         for (guidance) |text| alloc.free(text);
         alloc.free(guidance);
@@ -4028,16 +4072,17 @@ test "promoted steering keeps rich trailing guidance for its own turn" {
 
     const promoted = (try runtime.tryTakeNextPrompt(alloc)).?;
     defer freeQueuedPrompt(alloc, promoted);
-    try std.testing.expect(promoted.steering_continuation);
+    try std.testing.expect(promoted.delivery.isContinuation());
     try std.testing.expectEqual(@as(usize, 1), runtime.queuePreview().steering_count);
-    try std.testing.expect(!runtime.steeringHandoffRequired(promoted.turn_id));
+    const boundary = try runtime.takeSteeringBoundary(alloc, promoted.turn_id, .model);
+    try std.testing.expect(boundary == .none);
     try std.testing.expect(!runtime.requestInteractiveCancel());
     try std.testing.expect(runtime.queueReviewReason() == null);
 
     runtime.finishProcessing();
     const trailing = (try runtime.tryTakeNextPrompt(alloc)).?;
     defer freeQueuedPrompt(alloc, trailing);
-    try std.testing.expect(trailing.steering_continuation);
+    try std.testing.expect(trailing.delivery.isContinuation());
     try std.testing.expectEqualStrings("second with image", trailing.prompt);
 }
 
@@ -4054,7 +4099,8 @@ test "clear queued prompts also clears steering" {
 
     try std.testing.expectEqual(@as(usize, 0), runtime.queuePreview().count);
     try std.testing.expectEqual(@as(usize, 0), runtime.queuedPromptCount());
-    try std.testing.expectEqual(@as(usize, 0), (try runtime.takeSteering(alloc, 9)).len);
+    const boundary = try runtime.takeSteeringBoundary(alloc, 9, .model);
+    try std.testing.expect(boundary == .none);
 }
 
 test "idle interactive admission uses ordinary queue" {
@@ -4064,7 +4110,7 @@ test "idle interactive admission uses ordinary queue" {
 
     try runtime.admitInteractivePrompt(alloc, try makePrompt(alloc, "next", "model"));
     try std.testing.expectEqual(@as(usize, 1), runtime.queuedPromptCount());
-    try std.testing.expect(runtime.queued_prompts.items[0].steer_target_turn_id == null);
+    try std.testing.expect(runtime.queued_prompts.items[0].delivery == .ordinary);
 }
 
 test "request shutdown sets stop and cancel flags" {

--- a/src/core/app/app_callbacks.zig
+++ b/src/core/app/app_callbacks.zig
@@ -293,9 +293,7 @@ pub fn Bindings(comptime App: type) type {
                 else
                     null,
                 .finalize_turn = agentFinalizeTurn,
-                .take_steering = if (comptime @hasDecl(@TypeOf(app.worker), "takeSteering")) agentTakeSteering else null,
-                .take_immediate_steering = if (comptime @hasDecl(@TypeOf(app.worker), "takeImmediateSteering")) agentTakeImmediateSteering else null,
-                .steering_handoff_required = if (comptime @hasDecl(@TypeOf(app.worker), "steeringHandoffRequired")) agentSteeringHandoffRequired else null,
+                .take_steering_boundary = if (comptime @hasDecl(@TypeOf(app.worker), "takeSteeringBoundary")) agentTakeSteeringBoundary else null,
                 .append_runtime_context = agentAppendRuntimeContext,
                 .append_static_context = agentAppendStaticContext,
                 .validate_tool_call = agentValidateToolCall,
@@ -575,32 +573,37 @@ pub fn Bindings(comptime App: type) type {
             });
         }
 
-        fn agentTakeSteering(ctx: *anyopaque, arena: std.mem.Allocator, turn_id: u64) ![]const []const u8 {
+        fn agentTakeSteeringBoundary(
+            ctx: *anyopaque,
+            arena: std.mem.Allocator,
+            turn_id: u64,
+            kind: worker_runtime.SteeringBoundaryKind,
+        ) !worker_runtime.SteeringBoundaryResult {
             const app: *App = @ptrCast(@alignCast(ctx));
-            const owned = try app.worker.takeSteering(std.heap.c_allocator, turn_id);
-            return copyOwnedSteering(arena, owned);
+            const result = try app.worker.takeSteeringBoundary(
+                std.heap.c_allocator,
+                turn_id,
+                kind,
+            );
+            return switch (result) {
+                .continue_turn => |owned| .{
+                    .continue_turn = try copyOwnedSteering(arena, owned),
+                },
+                .none => .none,
+                .handoff => .handoff,
+                .interrupt => .interrupt,
+            };
         }
 
-        fn agentTakeImmediateSteering(ctx: *anyopaque, arena: std.mem.Allocator, turn_id: u64) ![]const []const u8 {
-            const app: *App = @ptrCast(@alignCast(ctx));
-            const owned = try app.worker.takeImmediateSteering(std.heap.c_allocator, turn_id);
-            return copyOwnedSteering(arena, owned);
-        }
-
-        fn copyOwnedSteering(arena: std.mem.Allocator, owned: [][]u8) ![]const []const u8 {
+        fn copyOwnedSteering(arena: std.mem.Allocator, owned: [][]u8) ![][]u8 {
             if (owned.len == 0) return &.{};
             defer {
                 for (owned) |text| std.heap.c_allocator.free(text);
                 std.heap.c_allocator.free(owned);
             }
-            const result = try arena.alloc([]const u8, owned.len);
+            const result = try arena.alloc([]u8, owned.len);
             for (owned, result) |text, *dest| dest.* = try arena.dupe(u8, text);
             return result;
-        }
-
-        fn agentSteeringHandoffRequired(ctx: *anyopaque, turn_id: u64) bool {
-            const app: *App = @ptrCast(@alignCast(ctx));
-            return app.worker.steeringHandoffRequired(turn_id);
         }
 
         fn agentAppendStaticContext(ctx: *anyopaque, arena: Allocator, messages: *std.ArrayList(ChatMessage)) !void {

--- a/src/core/app/app_render_runtime.zig
+++ b/src/core/app/app_render_runtime.zig
@@ -137,6 +137,7 @@ const RenderReconciliation = union(enum) {
 const QueuedCardProjection = struct {
     cards: []render_input.QueuedPromptCard = &.{},
     steering_messages: [][]u8 = &.{},
+    steering_waits_for_tool: bool = false,
     ordinary_count: usize = 0,
     paused: bool = false,
     row_count: u16 = 0,
@@ -321,20 +322,25 @@ fn previewWithPendingCard(
 fn buildQueuedCardProjection(comptime App: type, app: *App) !QueuedCardProjection {
     var projection: QueuedCardProjection = .{};
     errdefer projection.deinit(app.alloc);
-    const queue_preview = app.worker.queuePreview();
-    const steering_count = if (comptime @hasField(@TypeOf(queue_preview), "steering_count"))
-        queue_preview.steering_count
-    else
-        0;
-    projection.ordinary_count = queue_preview.count -| steering_count;
-    projection.paused = if (comptime @hasField(@TypeOf(queue_preview), "paused"))
-        queue_preview.paused
-    else
-        false;
-    if (comptime @hasDecl(@TypeOf(app.worker), "snapshotVisibleSteeringMessages")) {
-        if (steering_count > 0) {
-            projection.steering_messages = try app.worker.snapshotVisibleSteeringMessages(app.alloc);
-        }
+    if (comptime @hasDecl(@TypeOf(app.worker), "snapshotQueuePresentation")) {
+        var snapshot = try app.worker.snapshotQueuePresentation(app.alloc);
+        defer snapshot.deinit(app.alloc);
+        projection.ordinary_count = snapshot.ordinary_count;
+        projection.paused = snapshot.paused;
+        projection.steering_waits_for_tool = snapshot.steering_waits_for_tool;
+        projection.steering_messages = snapshot.steering_messages;
+        snapshot.steering_messages = &.{};
+    } else {
+        const queue_preview = app.worker.queuePreview();
+        const steering_count = if (comptime @hasField(@TypeOf(queue_preview), "steering_count"))
+            queue_preview.steering_count
+        else
+            0;
+        projection.ordinary_count = queue_preview.count -| steering_count;
+        projection.paused = if (comptime @hasField(@TypeOf(queue_preview), "paused"))
+            queue_preview.paused
+        else
+            false;
     }
     if (comptime !@hasField(App, "queued_prompt_review")) return projection;
     const review_entries = app.queued_prompt_review.entries;
@@ -649,6 +655,7 @@ pub fn Runtime(comptime App: type) type {
                 else
                     queued_cards.ordinary_count + queued_cards.steering_messages.len,
                 .steering_messages = queued_cards.steering_messages,
+                .steering_waits_for_tool = queued_cards.steering_waits_for_tool,
                 .queued_paused = queued_cards.paused,
                 .queued_cancel_all_available = if (comptime @hasField(App, "queued_prompt_review"))
                     app.queued_prompt_review.active() and

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -3767,7 +3767,15 @@ pub fn Runtime(comptime App: type) type {
             sink: anytype,
             execution: types.ExecutionMemory,
         ) !void {
-            for (execution.tool_steps) |step| {
+            var steering_index: usize = 0;
+            for (execution.tool_steps, 0..) |step, step_index| {
+                try writePersistedSteeringAtBoundary(
+                    app,
+                    sink,
+                    execution.steering,
+                    &steering_index,
+                    step_index,
+                );
                 if (step.assistant) |assistant| {
                     if (assistant.len > 0) try writeAssistantHistoryMarkdownToSink(app, sink, assistant);
                 }
@@ -3788,7 +3796,35 @@ pub fn Runtime(comptime App: type) type {
                     }
                 }
             }
-            try writePermissionFeedback(sink, execution.steering);
+            while (steering_index < execution.steering.len) : (steering_index += 1) {
+                const steering = execution.steering[steering_index];
+                if (steering.assistant_prefix) |prefix| {
+                    if (prefix.len > 0) try writeAssistantHistoryMarkdownToSink(app, sink, prefix);
+                }
+                if (steering.text.len == 0) continue;
+                try sink.appendUserTurn(.{ .text = steering.text }, true);
+            }
+        }
+
+        fn writePersistedSteeringAtBoundary(
+            app: *App,
+            sink: anytype,
+            steering: []const types.PersistedSteering,
+            index: *usize,
+            tool_step_count: usize,
+        ) !void {
+            while (index.* < steering.len and
+                steering[index.*].after_tool_step_count == tool_step_count)
+            {
+                const item = steering[index.*];
+                if (item.assistant_prefix) |prefix| {
+                    if (prefix.len > 0) try writeAssistantHistoryMarkdownToSink(app, sink, prefix);
+                }
+                if (item.text.len > 0) {
+                    try sink.appendUserTurn(.{ .text = item.text }, true);
+                }
+                index.* += 1;
+            }
         }
 
         fn writePermissionFeedback(sink: anytype, feedback: []const []const u8) !void {

--- a/src/core/output/output_contracts.zig
+++ b/src/core/output/output_contracts.zig
@@ -2600,7 +2600,7 @@ test "core session detail JSON includes assistant execution memory" {
 
     const json = try (SessionDetailSnapshot{ .detail = detail }).renderJson(std.testing.allocator);
     defer std.testing.allocator.free(json);
-    try std.testing.expect(std.mem.find(u8, json, "\"execution\":{\"schema_version\":2") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"execution\":{\"schema_version\":3") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"turn_summary\"") == null);
     try std.testing.expect(std.mem.find(u8, json, "\"name\":\"web_fetch\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "artifact-file.pdf") != null);

--- a/src/core/session/session.zig
+++ b/src/core/session/session.zig
@@ -3074,7 +3074,22 @@ fn appendExecutionMemoryMessages(
     messages: *std.ArrayList(message.Message),
     execution: core_types.ExecutionMemory,
 ) !void {
-    for (execution.tool_steps) |step| {
+    var steering_index: usize = 0;
+    for (execution.tool_steps, 0..) |step, step_index| {
+        while (steering_index < execution.steering.len and
+            execution.steering[steering_index].after_tool_step_count == step_index)
+        {
+            const steering = execution.steering[steering_index];
+            if (steering.assistant_prefix) |prefix| {
+                if (prefix.len > 0) {
+                    try messages.append(alloc, message.Message.assistantBorrowed(prefix, &.{}));
+                }
+            }
+            if (steering.text.len > 0) {
+                try messages.append(alloc, message.Message.userText(steering.text));
+            }
+            steering_index += 1;
+        }
         if (step.tool_calls.len == 0) continue;
         try messages.append(alloc, .{
             .role = .assistant,
@@ -3101,9 +3116,15 @@ fn appendExecutionMemoryMessages(
         errdefer alloc.free(text);
         try messages.append(alloc, message.Message.userOwned(text));
     }
-    for (execution.steering) |text| {
-        if (text.len == 0) continue;
-        try messages.append(alloc, message.Message.userText(text));
+    while (steering_index < execution.steering.len) : (steering_index += 1) {
+        const steering = execution.steering[steering_index];
+        if (steering.assistant_prefix) |prefix| {
+            if (prefix.len > 0) {
+                try messages.append(alloc, message.Message.assistantBorrowed(prefix, &.{}));
+            }
+        }
+        if (steering.text.len == 0) continue;
+        try messages.append(alloc, message.Message.userText(steering.text));
     }
 }
 
@@ -3112,7 +3133,22 @@ pub fn appendExecutionMemoryChatMessages(
     messages: *std.ArrayList(core_types.ChatMessage),
     execution: core_types.ExecutionMemory,
 ) !void {
-    for (execution.tool_steps) |step| {
+    var steering_index: usize = 0;
+    for (execution.tool_steps, 0..) |step, step_index| {
+        while (steering_index < execution.steering.len and
+            execution.steering[steering_index].after_tool_step_count == step_index)
+        {
+            const steering = execution.steering[steering_index];
+            if (steering.assistant_prefix) |prefix| {
+                if (prefix.len > 0) {
+                    try messages.append(alloc, .{ .role = .assistant, .content = prefix });
+                }
+            }
+            if (steering.text.len > 0) {
+                try messages.append(alloc, .{ .role = .user, .content = steering.text });
+            }
+            steering_index += 1;
+        }
         if (step.tool_calls.len == 0) continue;
         try messages.append(alloc, .{
             .role = .assistant,
@@ -3144,9 +3180,15 @@ pub fn appendExecutionMemoryChatMessages(
         errdefer alloc.free(text);
         try messages.append(alloc, .{ .role = .user, .content = text });
     }
-    for (execution.steering) |text| {
-        if (text.len == 0) continue;
-        try messages.append(alloc, .{ .role = .user, .content = text });
+    while (steering_index < execution.steering.len) : (steering_index += 1) {
+        const steering = execution.steering[steering_index];
+        if (steering.assistant_prefix) |prefix| {
+            if (prefix.len > 0) {
+                try messages.append(alloc, .{ .role = .assistant, .content = prefix });
+            }
+        }
+        if (steering.text.len == 0) continue;
+        try messages.append(alloc, .{ .role = .user, .content = steering.text });
     }
 }
 
@@ -4186,9 +4228,9 @@ test "history projection keeps system role only for leading summaries" {
 
 test "resume history projects steering before the final assistant" {
     const alloc = std.testing.allocator;
-    var steering = [_][]u8{
-        @constCast("use file B instead"),
-        @constCast("keep the result concise"),
+    var steering = [_]core_types.PersistedSteering{
+        .{ .text = @constCast("use file B instead"), .after_tool_step_count = 0 },
+        .{ .text = @constCast("keep the result concise"), .after_tool_step_count = 0 },
     };
     const history = [_]HistoryTurn{.{ .assistant = .{
         .user = .{ .text = @constCast("modify file A") },
@@ -4222,6 +4264,73 @@ test "resume history projects steering before the final assistant" {
         try std.testing.expectEqualStrings(text, projected.content.?.asText());
         try std.testing.expectEqualStrings(text, chat.content.?);
     }
+}
+
+test "resume history preserves steering between tool episodes" {
+    const alloc = std.testing.allocator;
+    var first_calls = [_]ToolCall{.{
+        .id = "call_first",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"first\"}",
+    }};
+    var first_results = [_]PersistedToolResult{.{
+        .tool_call_id = @constCast("call_first"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("first result"),
+        .output_bytes = "first result".len,
+        .stored_output_bytes = "first result".len,
+    }};
+    var second_calls = [_]ToolCall{.{
+        .id = "call_second",
+        .name = "read_file",
+        .arguments_json = "{\"path\":\"second\"}",
+    }};
+    var second_results = [_]PersistedToolResult{.{
+        .tool_call_id = @constCast("call_second"),
+        .tool_name = @constCast("read_file"),
+        .status = .success,
+        .output = @constCast("second result"),
+        .output_bytes = "second result".len,
+        .stored_output_bytes = "second result".len,
+    }};
+    var steps = [_]ToolExecutionStep{
+        .{ .tool_calls = &first_calls, .tool_results = &first_results },
+        .{ .tool_calls = &second_calls, .tool_results = &second_results },
+    };
+    var steering = [_]core_types.PersistedSteering{
+        .{ .text = @constCast("after first"), .after_tool_step_count = 1 },
+        .{ .text = @constCast("after second"), .after_tool_step_count = 2 },
+    };
+    const history = [_]HistoryTurn{.{ .assistant = .{
+        .user = .{ .text = @constCast("run both") },
+        .assistant = @constCast("finished"),
+        .execution = .{
+            .tool_steps = &steps,
+            .steering = &steering,
+        },
+    } }};
+
+    var messages: std.ArrayList(message.Message) = .empty;
+    defer deinitMessages(alloc, &messages);
+    try appendHistoryMessages(alloc, &messages, &history);
+
+    try std.testing.expectEqual(@as(usize, 8), messages.items.len);
+    const expected_roles = [_]message.Role{
+        .user,
+        .assistant,
+        .tool,
+        .user,
+        .assistant,
+        .tool,
+        .user,
+        .assistant,
+    };
+    for (messages.items, expected_roles) |projected, role| {
+        try std.testing.expectEqual(role, projected.role);
+    }
+    try std.testing.expectEqualStrings("after first", messages.items[3].content.?.asText());
+    try std.testing.expectEqualStrings("after second", messages.items[6].content.?.asText());
 }
 
 test "resume projection replays assistant tool execution memory before final answer" {

--- a/src/core/session/session_codec.zig
+++ b/src/core/session/session_codec.zig
@@ -1121,7 +1121,7 @@ fn writeSnapshotLocator(writer: *std.Io.Writer, value: ?[]const u8) !void {
 }
 
 fn writeExecutionMemory(writer: *std.Io.Writer, execution: session.ExecutionMemory) !void {
-    try writer.writeAll("{\"schema_version\":6,\"tool_steps\":[");
+    try writer.writeAll("{\"schema_version\":7,\"tool_steps\":[");
     for (execution.tool_steps, 0..) |step, i| {
         if (i > 0) try writer.writeByte(',');
         try writer.writeAll("{\"assistant\":");
@@ -1144,9 +1144,13 @@ fn writeExecutionMemory(writer: *std.Io.Writer, execution: session.ExecutionMemo
         try writeFileEvidence(writer, file);
     }
     try writer.writeAll("],\"steering\":[");
-    for (execution.steering, 0..) |text, i| {
+    for (execution.steering, 0..) |steering, i| {
         if (i > 0) try writer.writeByte(',');
-        try writeDurableBytes(writer, text);
+        try writer.writeAll("{\"text\":");
+        try writeDurableBytes(writer, steering.text);
+        try writer.writeAll(",\"assistant_prefix\":");
+        try writeOptionalDurableBytes(writer, steering.assistant_prefix);
+        try writer.print(",\"after_tool_step_count\":{d}}}", .{steering.after_tool_step_count});
     }
     try writer.writeAll("],\"turn_summary\":");
     if (execution.turn_summary) |summary| {
@@ -1504,6 +1508,7 @@ fn parseExecutionMemory(alloc: Allocator, value: std.json.Value) !session.Execut
         1...4 => try exactObject(value, &.{ "schema_version", "tool_steps", "files" }),
         5 => try exactObject(value, &.{ "schema_version", "tool_steps", "files", "turn_summary" }),
         6 => try exactObject(value, &.{ "schema_version", "tool_steps", "files", "steering", "turn_summary" }),
+        7 => try exactObject(value, &.{ "schema_version", "tool_steps", "files", "steering", "turn_summary" }),
         else => return error.InvalidSessionFormat,
     };
     const tool_steps = try parseToolSteps(
@@ -1514,14 +1519,16 @@ fn parseExecutionMemory(alloc: Allocator, value: std.json.Value) !session.Execut
     errdefer session.freeExecutionMemory(alloc, .{ .tool_steps = tool_steps });
     const files = try parseFiles(alloc, object.get("files") orelse return error.InvalidSessionFormat);
     errdefer types.freeFileEvidenceSlice(alloc, files);
-    const steering: [][]u8 = if (schema_version >= 6)
-        try parseDurableBytesArray(
+    const steering: []types.PersistedSteering = if (schema_version >= 6)
+        try parsePersistedSteering(
             alloc,
             object.get("steering") orelse return error.InvalidSessionFormat,
+            schema_version,
+            tool_steps.len,
         )
     else
         &.{};
-    errdefer types.freePermissionFeedback(alloc, steering);
+    errdefer types.freePersistedSteering(alloc, steering);
     const turn_summary = if (schema_version >= 5)
         try parseOptionalTurnSummary(object.get("turn_summary").?)
     else
@@ -1532,6 +1539,60 @@ fn parseExecutionMemory(alloc: Allocator, value: std.json.Value) !session.Execut
         .steering = steering,
         .turn_summary = turn_summary,
     };
+}
+
+fn parsePersistedSteering(
+    alloc: Allocator,
+    value: std.json.Value,
+    schema_version: u64,
+    tool_step_count: usize,
+) ![]types.PersistedSteering {
+    if (value != .array) return error.InvalidSessionFormat;
+    if (value.array.items.len == 0) return &.{};
+    const steering = try alloc.alloc(types.PersistedSteering, value.array.items.len);
+    errdefer alloc.free(steering);
+    var parsed_count: usize = 0;
+    errdefer for (steering[0..parsed_count]) |item| {
+        alloc.free(item.text);
+        if (item.assistant_prefix) |prefix| alloc.free(prefix);
+    };
+    var prior_tool_step_count: usize = 0;
+    for (value.array.items, 0..) |item, index| {
+        const parsed = if (schema_version == 6)
+            types.PersistedSteering{
+                .text = try parseDurableBytes(alloc, item),
+                .after_tool_step_count = tool_step_count,
+            }
+        else blk: {
+            const object = try exactObject(item, &.{ "text", "assistant_prefix", "after_tool_step_count" });
+            const after_tool_step_count = try requireUsize(object, "after_tool_step_count");
+            if (after_tool_step_count > tool_step_count or
+                (index > 0 and after_tool_step_count < prior_tool_step_count))
+            {
+                return error.InvalidSessionFormat;
+            }
+            const text = try parseDurableBytes(
+                alloc,
+                object.get("text") orelse return error.InvalidSessionFormat,
+            );
+            const assistant_prefix = parseOptionalDurableBytes(
+                alloc,
+                object.get("assistant_prefix") orelse return error.InvalidSessionFormat,
+            ) catch |err| {
+                alloc.free(text);
+                return err;
+            };
+            break :blk types.PersistedSteering{
+                .text = text,
+                .assistant_prefix = assistant_prefix,
+                .after_tool_step_count = after_tool_step_count,
+            };
+        };
+        steering[index] = parsed;
+        parsed_count += 1;
+        prior_tool_step_count = parsed.after_tool_step_count;
+    }
+    return steering;
 }
 
 fn parseOptionalTurnSummary(value: std.json.Value) !?types.TurnSummary {
@@ -1780,7 +1841,7 @@ fn parseToolResult(
         1 => .{ .object = try exactObject(value, v1_keys), .extended = false },
         2 => try exactVariantObject(value, v2_keys, v2_extended_keys),
         3 => .{ .object = try exactObject(value, v3_keys), .extended = true },
-        4, 5, 6 => .{ .object = try exactObject(value, v4_keys), .extended = true },
+        4, 5, 6, 7 => .{ .object = try exactObject(value, v4_keys), .extended = true },
         else => return error.InvalidSessionFormat,
     };
     const object = result_shape.object;
@@ -2948,7 +3009,11 @@ test "execution memory codec preserves feedback and reads v1 results without it"
         .tool_calls = calls[0..],
         .tool_results = results[0..],
     }};
-    var steering = [_][]u8{@constCast("focus on persistence")};
+    var steering = [_]types.PersistedSteering{.{
+        .text = @constCast("focus on persistence"),
+        .assistant_prefix = @constCast("partial assistant"),
+        .after_tool_step_count = 1,
+    }};
     const turn: session.HistoryTurn = .{ .assistant = .{
         .user = .{ .text = @constCast("write a note") },
         .assistant = @constCast("done"),
@@ -2968,8 +3033,10 @@ test "execution memory codec preserves feedback and reads v1 results without it"
     var encoded: std.Io.Writer.Allocating = .init(alloc);
     defer encoded.deinit();
     try writeHistoryTurn(&encoded.writer, turn);
-    try std.testing.expect(std.mem.find(u8, encoded.written(), "\"schema_version\":6") != null);
-    try std.testing.expect(std.mem.find(u8, encoded.written(), "\"steering\":[\"focus on persistence\"]") != null);
+    try std.testing.expect(std.mem.find(u8, encoded.written(), "\"schema_version\":7") != null);
+    try std.testing.expect(std.mem.find(u8, encoded.written(), "\"text\":\"focus on persistence\"") != null);
+    try std.testing.expect(std.mem.find(u8, encoded.written(), "\"assistant_prefix\":\"partial assistant\"") != null);
+    try std.testing.expect(std.mem.find(u8, encoded.written(), "\"after_tool_step_count\":1") != null);
     try std.testing.expect(std.mem.find(u8, encoded.written(), "\"permission_feedback\"") != null);
     try std.testing.expect(std.mem.find(u8, encoded.written(), "\"committed_file_presentation\"") != null);
     try std.testing.expect(std.mem.find(u8, encoded.written(), "\"command_output_replay\"") != null);
@@ -2987,7 +3054,15 @@ test "execution memory codec preserves feedback and reads v1 results without it"
     try std.testing.expectEqual(@as(usize, 1), decoded.assistant.execution.steering.len);
     try std.testing.expectEqualStrings(
         "focus on persistence",
-        decoded.assistant.execution.steering[0],
+        decoded.assistant.execution.steering[0].text,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        decoded.assistant.execution.steering[0].after_tool_step_count,
+    );
+    try std.testing.expectEqualStrings(
+        "partial assistant",
+        decoded.assistant.execution.steering[0].assistant_prefix.?,
     );
     try std.testing.expectEqual(@as(usize, 1), decoded_result.permission_feedback.len);
     try std.testing.expectEqualStrings("read it after writing", decoded_result.permission_feedback[0]);
@@ -3043,6 +3118,43 @@ test "execution memory codec preserves feedback and reads v1 results without it"
     const v5_decoded = try parseHistoryTurn(alloc, v5_parsed.value);
     defer session.freeHistoryTurn(alloc, v5_decoded);
     try std.testing.expectEqual(@as(usize, 0), v5_decoded.assistant.execution.steering.len);
+
+    const v6 =
+        "{\"kind\":\"assistant\",\"user\":{\"text\":\"prompt\",\"images\":[]},\"assistant\":\"done\",\"execution\":{\"schema_version\":6,\"tool_steps\":[],\"files\":[],\"steering\":[\"legacy steer\"],\"turn_summary\":null}}";
+    var v6_parsed = try std.json.parseFromSlice(std.json.Value, alloc, v6, .{});
+    defer v6_parsed.deinit();
+    const v6_decoded = try parseHistoryTurn(alloc, v6_parsed.value);
+    defer session.freeHistoryTurn(alloc, v6_decoded);
+    try std.testing.expectEqualStrings("legacy steer", v6_decoded.assistant.execution.steering[0].text);
+    try std.testing.expectEqual(@as(usize, 0), v6_decoded.assistant.execution.steering[0].after_tool_step_count);
+
+    const invalid_v7 =
+        "{\"kind\":\"assistant\",\"user\":{\"text\":\"prompt\",\"images\":[]},\"assistant\":\"done\",\"execution\":{\"schema_version\":7,\"tool_steps\":[],\"files\":[],\"steering\":[{\"text\":\"invalid\",\"assistant_prefix\":null,\"after_tool_step_count\":1}],\"turn_summary\":null}}";
+    var invalid_v7_parsed = try std.json.parseFromSlice(std.json.Value, alloc, invalid_v7, .{});
+    defer invalid_v7_parsed.deinit();
+    try std.testing.expectError(
+        error.InvalidSessionFormat,
+        parseHistoryTurn(alloc, invalid_v7_parsed.value),
+    );
+}
+
+fn checkV7SteeringAllocationFailures(alloc: Allocator) !void {
+    const json =
+        "[{\"text\":\"first\",\"assistant_prefix\":\"prefix one\",\"after_tool_step_count\":0}," ++
+        "{\"text\":\"second\",\"assistant_prefix\":\"prefix two\",\"after_tool_step_count\":1}]";
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    const steering = try parsePersistedSteering(alloc, parsed.value, 7, 1);
+    defer types.freePersistedSteering(alloc, steering);
+    try std.testing.expectEqual(@as(usize, 2), steering.len);
+}
+
+test "v7 steering cleans up every allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        checkV7SteeringAllocationFailures,
+        .{},
+    );
 }
 
 test "private codec preserves summary-only interrupted turns" {
@@ -3519,8 +3631,10 @@ fn expectHistoryTurnEqual(expected: session.HistoryTurn, actual: session.History
 fn expectExecutionMemoryEqual(expected: session.ExecutionMemory, actual: session.ExecutionMemory) !void {
     try std.testing.expectEqual(expected.turn_summary, actual.turn_summary);
     try std.testing.expectEqual(expected.steering.len, actual.steering.len);
-    for (expected.steering, actual.steering) |text, got_text| {
-        try std.testing.expectEqualSlices(u8, text, got_text);
+    for (expected.steering, actual.steering) |steering, got_steering| {
+        try std.testing.expectEqualSlices(u8, steering.text, got_steering.text);
+        try expectOptionalBytesEqual(steering.assistant_prefix, got_steering.assistant_prefix);
+        try std.testing.expectEqual(steering.after_tool_step_count, got_steering.after_tool_step_count);
     }
     try std.testing.expectEqual(expected.tool_steps.len, actual.tool_steps.len);
     for (expected.tool_steps, actual.tool_steps) |step, got_step| {

--- a/src/core/session/session_json.zig
+++ b/src/core/session/session_json.zig
@@ -140,7 +140,7 @@ fn writeToolCallJson(writer: *std.Io.Writer, tool_call: session.ToolCall) !void 
 }
 
 pub fn writeExecutionMemoryJson(writer: *std.Io.Writer, execution: session.ExecutionMemory) !void {
-    try writer.writeAll("{\"schema_version\":2,\"tool_steps\":[");
+    try writer.writeAll("{\"schema_version\":3,\"tool_steps\":[");
     for (execution.tool_steps, 0..) |step, i| {
         if (i > 0) try writer.writeByte(',');
         try writer.writeAll("{\"assistant\":");
@@ -167,9 +167,17 @@ pub fn writeExecutionMemoryJson(writer: *std.Io.Writer, execution: session.Execu
         try writeFileEvidenceJson(writer, file);
     }
     try writer.writeAll("],\"steering\":[");
-    for (execution.steering, 0..) |text, i| {
+    for (execution.steering, 0..) |steering, i| {
         if (i > 0) try writer.writeByte(',');
-        try std.json.Stringify.value(text, .{}, writer);
+        try writer.writeAll("{\"text\":");
+        try std.json.Stringify.value(steering.text, .{}, writer);
+        try writer.writeAll(",\"assistant_prefix\":");
+        if (steering.assistant_prefix) |prefix| {
+            try std.json.Stringify.value(prefix, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.print(",\"after_tool_step_count\":{d}}}", .{steering.after_tool_step_count});
     }
     try writer.writeAll("]}");
 }
@@ -759,7 +767,7 @@ fn parseOptionalExecutionMemory(alloc: Allocator, maybe_value: ?std.json.Value) 
     if (value == .null) return .{};
     const object = try requireObject(value);
     const schema_version: i64 = if (object.get("schema_version")) |version| blk: {
-        if (version != .integer or (version.integer != 1 and version.integer != 2)) {
+        if (version != .integer or version.integer < 1 or version.integer > 3) {
             return error.InvalidSessionFormat;
         }
         break :blk version.integer;
@@ -770,10 +778,67 @@ fn parseOptionalExecutionMemory(alloc: Allocator, maybe_value: ?std.json.Value) 
         schema_version,
     );
     errdefer session.freeExecutionMemory(alloc, .{ .tool_steps = tool_steps });
-    const steering = try parseOptionalStringArray(alloc, object.get("steering"));
-    errdefer types.freePermissionFeedback(alloc, steering);
+    const steering = try parseOptionalSteering(
+        alloc,
+        object.get("steering"),
+        schema_version,
+        tool_steps.len,
+    );
+    errdefer types.freePersistedSteering(alloc, steering);
     const files = try parseFileEvidenceSlice(alloc, object.get("files"));
     return .{ .tool_steps = tool_steps, .files = files, .steering = steering };
+}
+
+fn parseOptionalSteering(
+    alloc: Allocator,
+    maybe_value: ?std.json.Value,
+    schema_version: i64,
+    tool_step_count: usize,
+) ![]types.PersistedSteering {
+    const value = maybe_value orelse return &.{};
+    if (value != .array) return error.InvalidSessionFormat;
+    if (value.array.items.len == 0) return &.{};
+    const steering = try alloc.alloc(types.PersistedSteering, value.array.items.len);
+    errdefer alloc.free(steering);
+    var parsed_count: usize = 0;
+    errdefer for (steering[0..parsed_count]) |item| {
+        alloc.free(item.text);
+        if (item.assistant_prefix) |prefix| alloc.free(prefix);
+    };
+    var prior_tool_step_count: usize = 0;
+    for (value.array.items, 0..) |item, index| {
+        const parsed = if (schema_version <= 2)
+            types.PersistedSteering{
+                .text = try alloc.dupe(u8, if (item == .string) item.string else return error.InvalidSessionFormat),
+                .after_tool_step_count = tool_step_count,
+            }
+        else blk: {
+            const object = try requireObject(item);
+            const after_tool_step_count = try requireUsize(object, "after_tool_step_count");
+            if (after_tool_step_count > tool_step_count or
+                (index > 0 and after_tool_step_count < prior_tool_step_count))
+            {
+                return error.InvalidSessionFormat;
+            }
+            const text = try alloc.dupe(u8, try requireString(object, "text"));
+            const assistant_prefix = optionalStringDup(
+                alloc,
+                object.get("assistant_prefix"),
+            ) catch |err| {
+                alloc.free(text);
+                return err;
+            };
+            break :blk types.PersistedSteering{
+                .text = text,
+                .assistant_prefix = assistant_prefix,
+                .after_tool_step_count = after_tool_step_count,
+            };
+        };
+        steering[index] = parsed;
+        parsed_count += 1;
+        prior_tool_step_count = parsed.after_tool_step_count;
+    }
+    return steering;
 }
 
 fn parseToolExecutionSteps(
@@ -1479,7 +1544,11 @@ test "session JSON round-trips assistant execution memory" {
         .tool_calls = calls[0..],
         .tool_results = results[0..],
     }};
-    var steering = [_][]u8{@constCast("focus on rendering")};
+    var steering = [_]types.PersistedSteering{.{
+        .text = @constCast("focus on rendering"),
+        .assistant_prefix = @constCast("partial assistant"),
+        .after_tool_step_count = 1,
+    }};
     var files = [_]session.FileEvidence{.{
         .path = @constCast("src/main.zig"),
         .tool_call_id = @constCast("call_read"),
@@ -1500,9 +1569,11 @@ test "session JSON round-trips assistant execution memory" {
     try std.testing.expect(std.mem.find(u8, json, "\"execution\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"tool_steps\"") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"files\"") != null);
-    try std.testing.expect(std.mem.find(u8, json, "\"schema_version\":2") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"execution\":{\"schema_version\":3") != null);
     try std.testing.expect(std.mem.find(u8, json, "\"permission_feedback\"") != null);
-    try std.testing.expect(std.mem.find(u8, json, "\"steering\":[\"focus on rendering\"]") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"text\":\"focus on rendering\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"assistant_prefix\":\"partial assistant\"") != null);
+    try std.testing.expect(std.mem.find(u8, json, "\"after_tool_step_count\":1") != null);
 
     var loaded = try parseStoredSession(TestStoredSession, alloc, json);
     defer loaded.deinit(alloc);
@@ -1524,7 +1595,28 @@ test "session JSON round-trips assistant execution memory" {
     try std.testing.expectEqual(.read, execution.files[0].action);
     try std.testing.expect(execution.files[0].model_view_covers_full_file);
     try std.testing.expectEqual(@as(usize, 1), execution.steering.len);
-    try std.testing.expectEqualStrings("focus on rendering", execution.steering[0]);
+    try std.testing.expectEqualStrings("focus on rendering", execution.steering[0].text);
+    try std.testing.expectEqualStrings("partial assistant", execution.steering[0].assistant_prefix.?);
+    try std.testing.expectEqual(@as(usize, 1), execution.steering[0].after_tool_step_count);
+}
+
+fn checkV3SteeringAllocationFailures(alloc: Allocator) !void {
+    const json =
+        "[{\"text\":\"first\",\"assistant_prefix\":\"prefix one\",\"after_tool_step_count\":0}," ++
+        "{\"text\":\"second\",\"assistant_prefix\":\"prefix two\",\"after_tool_step_count\":1}]";
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    const steering = try parseOptionalSteering(alloc, parsed.value, 3, 1);
+    defer types.freePersistedSteering(alloc, steering);
+    try std.testing.expectEqual(@as(usize, 2), steering.len);
+}
+
+test "session JSON steering cleans up every allocation failure" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        checkV3SteeringAllocationFailures,
+        .{},
+    );
 }
 
 const legacy_execution_memory_fixture =
@@ -1534,7 +1626,8 @@ const legacy_execution_memory_fixture =
     "\"execution\":{\"schema_version\":2,\"tool_steps\":[" ++
     "{\"assistant\":\"checking\",\"tool_calls\":[{\"id\":\"call_write\",\"name\":\"write_file\",\"arguments_json\":\"{}\",\"provider_result\":null}],\"tool_results\":[{\"tool_call_id\":\"call_write\",\"tool_name\":\"write_file\",\"status\":\"success\",\"output\":\"wrote\",\"output_handle\":null,\"preview\":null,\"output_bytes\":5,\"stored_output_bytes\":5,\"truncated\":false,\"provider_native\":false,\"created_at_ms\":1,\"permission_feedback\":[\"read it\"]}]}],\"files\":[" ++
     "{\"path\":\"src/main.zig\",\"new_path\":null,\"tool_call_id\":\"call_read\",\"tool_name\":\"read_file\"," ++
-    "\"action\":\"read\",\"status\":\"success\",\"model_view_covers_full_file\":true,\"stale\":false}]}}]}";
+    "\"action\":\"read\",\"status\":\"success\",\"model_view_covers_full_file\":true,\"stale\":false}]," ++
+    "\"steering\":[\"legacy steer\"]}}]}";
 
 fn checkLegacyExecutionMemoryAllocationFailures(alloc: Allocator) !void {
     var loaded = try parseStoredSession(
@@ -1550,6 +1643,14 @@ fn checkLegacyExecutionMemoryAllocationFailures(alloc: Allocator) !void {
     try std.testing.expectEqual(
         @as(usize, 1),
         loaded.history[0].assistant.execution.files.len,
+    );
+    try std.testing.expectEqualStrings(
+        "legacy steer",
+        loaded.history[0].assistant.execution.steering[0].text,
+    );
+    try std.testing.expectEqual(
+        @as(usize, 1),
+        loaded.history[0].assistant.execution.steering[0].after_tool_step_count,
     );
     try std.testing.expectEqual(
         @as(usize, 1),

--- a/src/core/shared/types.zig
+++ b/src/core/shared/types.zig
@@ -928,6 +928,12 @@ pub const ToolExecutionStep = struct {
     tool_results: []PersistedToolResult = &.{},
 };
 
+pub const PersistedSteering = struct {
+    text: []u8,
+    assistant_prefix: ?[]u8 = null,
+    after_tool_step_count: usize,
+};
+
 pub const FileEvidence = struct {
     path: []u8,
     new_path: ?[]u8 = null,
@@ -942,8 +948,8 @@ pub const FileEvidence = struct {
 pub const ExecutionMemory = struct {
     tool_steps: []ToolExecutionStep = &.{},
     files: []FileEvidence = &.{},
-    /// User guidance consumed between model steps, in presentation order.
-    steering: [][]u8 = &.{},
+    /// User guidance consumed between model steps, with its chronological tool boundary.
+    steering: []PersistedSteering = &.{},
     turn_summary: ?TurnSummary = null,
 
     pub fn isEmpty(self: ExecutionMemory) bool {
@@ -2035,7 +2041,7 @@ pub fn dupeExecutionMemory(alloc: std.mem.Allocator, memory: ExecutionMemory) !E
     errdefer freeToolExecutionSteps(alloc, tool_steps);
     const files = try dupeFileEvidenceSlice(alloc, memory.files);
     errdefer freeFileEvidenceSlice(alloc, files);
-    const steering = try dupePermissionFeedback(alloc, memory.steering);
+    const steering = try dupePersistedSteering(alloc, memory.steering);
     return .{
         .tool_steps = tool_steps,
         .files = files,
@@ -2047,7 +2053,45 @@ pub fn dupeExecutionMemory(alloc: std.mem.Allocator, memory: ExecutionMemory) !E
 pub fn freeExecutionMemory(alloc: std.mem.Allocator, memory: ExecutionMemory) void {
     freeToolExecutionSteps(alloc, memory.tool_steps);
     freeFileEvidenceSlice(alloc, memory.files);
-    freePermissionFeedback(alloc, memory.steering);
+    freePersistedSteering(alloc, memory.steering);
+}
+
+pub fn dupePersistedSteering(
+    alloc: std.mem.Allocator,
+    steering: []const PersistedSteering,
+) ![]PersistedSteering {
+    if (steering.len == 0) return &.{};
+    const copy = try alloc.alloc(PersistedSteering, steering.len);
+    errdefer alloc.free(copy);
+    var copied: usize = 0;
+    errdefer for (copy[0..copied]) |item| {
+        alloc.free(item.text);
+        if (item.assistant_prefix) |prefix| alloc.free(prefix);
+    };
+    for (steering, copy) |item, *dest| {
+        const text = try alloc.dupe(u8, item.text);
+        errdefer alloc.free(text);
+        const assistant_prefix = if (item.assistant_prefix) |prefix|
+            try alloc.dupe(u8, prefix)
+        else
+            null;
+        errdefer if (assistant_prefix) |prefix| alloc.free(prefix);
+        dest.* = .{
+            .text = text,
+            .assistant_prefix = assistant_prefix,
+            .after_tool_step_count = item.after_tool_step_count,
+        };
+        copied += 1;
+    }
+    return copy;
+}
+
+pub fn freePersistedSteering(alloc: std.mem.Allocator, steering: []PersistedSteering) void {
+    for (steering) |item| {
+        alloc.free(item.text);
+        if (item.assistant_prefix) |prefix| alloc.free(prefix);
+    }
+    if (steering.len > 0) alloc.free(steering);
 }
 
 pub fn dupeToolExecutionSteps(alloc: std.mem.Allocator, steps: []const ToolExecutionStep) ![]ToolExecutionStep {

--- a/src/ui/footer/paint_plan.zig
+++ b/src/ui/footer/paint_plan.zig
@@ -592,7 +592,8 @@ fn pushQueuedPromptBannerRows(
                 var row = try input_presentation.composeSteeringMessageRow(
                     alloc,
                     message,
-                    index + 1 == ctx.steering_messages.len,
+                    ctx.steering_waits_for_tool and
+                        index + 1 == ctx.steering_messages.len,
                     width,
                 );
                 try pushFooterBandRow(
@@ -1616,6 +1617,7 @@ test "clamped steering banner keeps newest messages and escape hint" {
     var ctx = testContext(&input);
     ctx.queued_count = messages.len;
     ctx.steering_messages = &messages;
+    ctx.steering_waits_for_tool = true;
     const planner_input: FooterPlannerInput = .{
         .active_label = null,
         .ctx = ctx,

--- a/src/ui/footer/render_input.zig
+++ b/src/ui/footer/render_input.zig
@@ -422,6 +422,7 @@ pub const RenderContext = struct {
     permission_mode: types.PermissionMode = .ask,
     queued_count: usize,
     steering_messages: []const []const u8 = &.{},
+    steering_waits_for_tool: bool = false,
     queued_paused: bool = false,
     queued_cancel_all_available: bool = false,
     queued_prompt_cards: []const QueuedPromptCard = &.{},


### PR DESCRIPTION
## Summary

- Show active-turn guidance immediately while a tool-free response is being cut off.
- Show the Escape hint only while guidance waits on a running tool.
- Preserve partial assistant output and exact tool-guidance order across session resume.