### PR TITLE
Preserve automatic review evidence

### DIFF
--- a/src/builtins/gateway/permission_reviewer.zig
+++ b/src/builtins/gateway/permission_reviewer.zig
@@ -203,13 +203,32 @@ fn sendGatewayReview(
     }
     if (stream.completion.finish_reason) |reason| switch (reason) {
         .provider_error => {
+            debug_trace.logf(
+                "permission",
+                "event=auto_review_transport result=transient_failure reason=provider_error",
+                .{},
+            );
             return .transient_failure;
         },
         .content_filter => {
+            debug_trace.logf(
+                "permission",
+                "event=auto_review_transport result=permanent_failure reason=content_filter",
+                .{},
+            );
             return .permanent_failure;
         },
         .stop, .length, .tool_calls, .other => {},
     };
+    debug_trace.logf(
+        "permission",
+        "event=auto_review_transport result=completion finish_reason={s} tool_calls={d} content_bytes={d}",
+        .{
+            if (stream.completion.finish_reason) |reason| @tagName(reason) else "absent",
+            stream.completion.tool_calls.len,
+            if (stream.completion.content) |content| content.len else 0,
+        },
+    );
 
     const owned = try alloc.create(OwnedStream);
     owned.* = .{ .stream = stream };
@@ -250,15 +269,21 @@ fn mapTransportError(
     cancel_flag: *std.atomic.Value(bool),
 ) error{OutOfMemory}!permission_auto_classifier.TransportOutcome {
     if (err == error.OutOfMemory) return error.OutOfMemory;
-    if (err == error.Cancelled or cancel_flag.load(.seq_cst)) return .cancelled;
-    if (err == error.Timeout) return .timed_out;
-    if (gateway_client.isRetryableGatewayError(err)) return .transient_failure;
+    const outcome: permission_auto_classifier.TransportOutcome =
+        if (err == error.Cancelled or cancel_flag.load(.seq_cst))
+            .cancelled
+        else if (err == error.Timeout)
+            .timed_out
+        else if (gateway_client.isRetryableGatewayError(err))
+            .transient_failure
+        else
+            .permanent_failure;
     debug_trace.logf(
         "permission",
-        "event=auto_review_transport result=permanent_failure err={s}",
-        .{@errorName(err)},
+        "event=auto_review_transport result={s} reason=transport_error error={s}",
+        .{ @tagName(std.meta.activeTag(outcome)), @errorName(err) },
     );
-    return .permanent_failure;
+    return outcome;
 }
 
 fn mapHttpStatus(status: std.http.Status) permission_auto_classifier.TransportOutcome {
@@ -583,6 +608,10 @@ test "gateway automatic reviewer distinguishes transient and permanent HTTP fail
         std.meta.Tag(permission_auto_classifier.ParseOutcome).invalid,
         std.meta.activeTag(transient),
     );
+    try std.testing.expectEqual(
+        permission_auto_classifier.InvalidReason.transport_transient,
+        transient.invalid,
+    );
     try std.testing.expectEqual(@as(usize, 1), transient_fake.calls);
 
     var permanent_fake = FakeStream{ .outcomes = &.{ .permanent_http, .valid } };
@@ -591,6 +620,10 @@ test "gateway automatic reviewer distinguishes transient and permanent HTTP fail
     try std.testing.expectEqual(
         std.meta.Tag(permission_auto_classifier.ParseOutcome).invalid,
         std.meta.activeTag(permanent),
+    );
+    try std.testing.expectEqual(
+        permission_auto_classifier.InvalidReason.transport_permanent,
+        permanent.invalid,
     );
     try std.testing.expectEqual(@as(usize, 1), permanent_fake.calls);
 }
@@ -641,6 +674,10 @@ test "gateway automatic reviewer distinguishes timeout permanent failure and can
         std.meta.Tag(permission_auto_classifier.ParseOutcome).invalid,
         std.meta.activeTag(timed_out),
     );
+    try std.testing.expectEqual(
+        permission_auto_classifier.InvalidReason.transport_timed_out,
+        timed_out.invalid,
+    );
     try std.testing.expectEqual(@as(usize, 1), timeout_fake.calls);
 
     var permanent_fake = FakeStream{ .outcomes = &.{ .permanent_error, .valid } };
@@ -649,6 +686,10 @@ test "gateway automatic reviewer distinguishes timeout permanent failure and can
     try std.testing.expectEqual(
         std.meta.Tag(permission_auto_classifier.ParseOutcome).invalid,
         std.meta.activeTag(permanent),
+    );
+    try std.testing.expectEqual(
+        permission_auto_classifier.InvalidReason.transport_permanent,
+        permanent.invalid,
     );
     try std.testing.expectEqual(@as(usize, 1), permanent_fake.calls);
 

--- a/src/core/agent/runtime/orchestrator.zig
+++ b/src/core/agent/runtime/orchestrator.zig
@@ -8707,6 +8707,7 @@ fn processQueuedPromptLoop(
                             result.rationale
                         else
                             null,
+                        permission_outcome.auto_review_failure,
                     ),
                     .user_denied, .auto_denied, .policy_denied, .permission_required => try tool_result_errors.toolPermissionDeniedJson(
                         arena,

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -6526,6 +6526,7 @@ test "execution replay preserves permission denial reasons" {
                 "run_command",
                 reason,
                 null,
+                null,
             ),
             .user_denied, .auto_denied, .policy_denied, .permission_required => try tool_result_errors.toolPermissionDeniedJson(
                 alloc,

--- a/src/core/cli/cli_ask.zig
+++ b/src/core/cli/cli_ask.zig
@@ -5503,9 +5503,10 @@ test "fx ask automatic review observes worker cancellation" {
             input: permission_auto_classifier.ProviderInput,
             _: permission_auto_classifier.ReviewRequest,
         ) anyerror!permission_auto_classifier.ParseOutcome {
-            const cancel_flag = input.cancel_flag orelse return .invalid;
+            const cancel_flag = input.cancel_flag orelse
+                return .{ .invalid = .provider_context_missing };
             if (cancel_flag.load(.seq_cst)) return error.Cancelled;
-            return .invalid;
+            return .{ .invalid = .provider_failed };
         }
     };
 

--- a/src/core/gateway/provider_set.zig
+++ b/src/core/gateway/provider_set.zig
@@ -134,7 +134,7 @@ test "provider set selects each provider's complete route" {
             _: auto_classifier.ProviderInput,
             _: auto_classifier.ReviewRequest,
         ) anyerror!auto_classifier.ParseOutcome {
-            return .invalid;
+            return .{ .invalid = .provider_failed };
         }
     };
 

--- a/src/core/permissions/auto_classifier.zig
+++ b/src/core/permissions/auto_classifier.zig
@@ -49,10 +49,35 @@ pub const HostSafetyOverride = enum {
     untrusted_action_copy,
 };
 
+pub const InvalidReason = enum {
+    reviewer_unconfigured,
+    override_context_missing,
+    override_failed,
+    transport_unconfigured,
+    invalid_context,
+    construction_timed_out,
+    construction_failed,
+    transport_call_failed,
+    transport_transient,
+    transport_permanent,
+    transport_timed_out,
+    provider_context_missing,
+    provider_failed,
+    completion_text,
+    completion_tool_call_count,
+    completion_tool_name,
+    completion_argument_integrity,
+    arguments_json,
+    arguments_shape,
+    arguments_risk,
+    arguments_decision,
+    arguments_rationale,
+};
+
 pub const ParseOutcome = union(enum) {
     valid: Result,
     evidence_incomplete,
-    invalid,
+    invalid: InvalidReason,
 
     pub fn deinit(self: *ParseOutcome, alloc: std.mem.Allocator) void {
         switch (self.*) {
@@ -401,15 +426,15 @@ pub const Reviewer = struct {
     ) !ParseOutcome {
         if (self.override_fn) |override_fn| {
             return override_fn(
-                self.override_context orelse return .invalid,
+                self.override_context orelse return .{ .invalid = .override_context_missing },
                 alloc,
                 request,
             ) catch |err| switch (err) {
                 error.OutOfMemory, error.Cancelled => return err,
-                else => return .invalid,
+                else => return .{ .invalid = .override_failed },
             };
         }
-        const transport = self.transport orelse return .invalid;
+        const transport = self.transport orelse return .{ .invalid = .transport_unconfigured };
         var fallback_cancel = std.atomic.Value(bool).init(false);
         const cancel_flag = self.cancel_flag orelse &fallback_cancel;
         const deadline = std.Io.Clock.Timestamp.fromNow(io_mod.getIo(), .{
@@ -445,7 +470,7 @@ pub const Reviewer = struct {
                 "event=auto_review_compose_result result=invalid_context elapsed_ms={d} target_call_id={s}",
                 .{ io_mod.milliTimestamp() - started_ms, review_turn.target_call_id },
             );
-            return .invalid;
+            return .{ .invalid = .invalid_context };
         }
 
         var evidence = serializeEvidence(alloc, request, deadline, cancel_flag) catch |err| {
@@ -497,7 +522,7 @@ pub const Reviewer = struct {
         var message_index: usize = 1;
         const target_call_index = for (review_turn.pending_assistant.tool_calls, 0..) |call, index| {
             if (std.mem.eql(u8, call.id, review_turn.target_call_id)) break index;
-        } else return .invalid;
+        } else return .{ .invalid = .invalid_context };
         var target_pending_assistant = review_turn.pending_assistant;
         target_pending_assistant.tool_calls = review_turn.pending_assistant.tool_calls[target_call_index .. target_call_index + 1];
         // Forward only the exact pending call. Assistant prose and native
@@ -539,11 +564,13 @@ pub const Reviewer = struct {
             cancel_flag,
         ) catch |err| switch (err) {
             error.OutOfMemory, error.Cancelled => return err,
-            else => return .invalid,
+            else => return .{ .invalid = .transport_call_failed },
         };
         switch (transport_outcome) {
             .cancelled => return error.Cancelled,
-            .timed_out, .permanent_failure, .transient_failure => return .invalid,
+            .timed_out => return .{ .invalid = .transport_timed_out },
+            .permanent_failure => return .{ .invalid = .transport_permanent },
+            .transient_failure => return .{ .invalid = .transport_transient },
             .completion => |*owned| {
                 defer owned.deinit(alloc);
                 return try parseCompletion(alloc, owned.completion);
@@ -589,15 +616,15 @@ pub const Classifier = struct {
     ) error{ OutOfMemory, Cancelled }!ParseOutcome {
         if (self.override_fn) |review_fn| {
             return Reviewer.withOverride(
-                self.override_ctx orelse return .invalid,
+                self.override_ctx orelse return .{ .invalid = .override_context_missing },
                 review_fn,
             ).review(alloc, request) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.Cancelled => return error.Cancelled,
-                else => return .invalid,
+                else => return .{ .invalid = .override_failed },
             };
         }
-        const provider = self.provider orelse return .invalid;
+        const provider = self.provider orelse return .{ .invalid = .reviewer_unconfigured };
         return provider.review_fn(
             provider.context,
             alloc,
@@ -606,7 +633,7 @@ pub const Classifier = struct {
         ) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.Cancelled => return error.Cancelled,
-            else => return .invalid,
+            else => return .{ .invalid = .provider_failed },
         };
     }
 };
@@ -1044,7 +1071,8 @@ fn checkBudget(
 fn constructionFailure(err: anyerror) !ParseOutcome {
     return switch (err) {
         error.OutOfMemory, error.Cancelled => err,
-        else => .invalid,
+        error.TimedOut => .{ .invalid = .construction_timed_out },
+        else => .{ .invalid = .construction_failed },
     };
 }
 
@@ -1231,39 +1259,51 @@ fn buildTestReviewPayload(
 
 fn parseCompletion(alloc: std.mem.Allocator, completion: types.ModelCompletion) !ParseOutcome {
     if (completion.content) |content| {
-        if (std.mem.trim(u8, content, " \t\r\n").len > 0) return .invalid;
+        if (std.mem.trim(u8, content, " \t\r\n").len > 0) {
+            return .{ .invalid = .completion_text };
+        }
     }
-    if (completion.tool_calls.len != 1) return .invalid;
+    if (completion.tool_calls.len != 1) {
+        return .{ .invalid = .completion_tool_call_count };
+    }
 
     const call = completion.tool_calls[0];
-    if (!std.mem.eql(u8, call.name, tool_name)) return .invalid;
-    if (call.argument_integrity != .valid) return .invalid;
+    if (!std.mem.eql(u8, call.name, tool_name)) {
+        return .{ .invalid = .completion_tool_name };
+    }
+    if (call.argument_integrity != .valid) {
+        return .{ .invalid = .completion_argument_integrity };
+    }
     return parseArguments(alloc, call.arguments_json);
 }
 
 fn parseArguments(alloc: std.mem.Allocator, arguments_json: []const u8) !ParseOutcome {
     var parsed = std.json.parseFromSlice(std.json.Value, alloc, arguments_json, .{}) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
-        else => return .invalid,
+        else => return .{ .invalid = .arguments_json },
     };
     defer parsed.deinit();
 
-    if (parsed.value != .object) return .invalid;
+    if (parsed.value != .object) return .{ .invalid = .arguments_shape };
     const object = parsed.value.object;
-    if (object.count() != schema_required.len) return .invalid;
+    if (object.count() != schema_required.len) return .{ .invalid = .arguments_shape };
 
-    const risk_value = object.get("risk") orelse return .invalid;
-    if (risk_value != .string) return .invalid;
-    const risk = std.meta.stringToEnum(Risk, risk_value.string) orelse return .invalid;
+    const risk_value = object.get("risk") orelse return .{ .invalid = .arguments_risk };
+    if (risk_value != .string) return .{ .invalid = .arguments_risk };
+    const risk = std.meta.stringToEnum(Risk, risk_value.string) orelse
+        return .{ .invalid = .arguments_risk };
 
-    const decision_value = object.get("decision") orelse return .invalid;
-    if (decision_value != .string) return .invalid;
-    const decision = std.meta.stringToEnum(Decision, decision_value.string) orelse return .invalid;
+    const decision_value = object.get("decision") orelse
+        return .{ .invalid = .arguments_decision };
+    if (decision_value != .string) return .{ .invalid = .arguments_decision };
+    const decision = std.meta.stringToEnum(Decision, decision_value.string) orelse
+        return .{ .invalid = .arguments_decision };
 
-    const rationale_value = object.get("rationale") orelse return .invalid;
-    if (rationale_value != .string) return .invalid;
+    const rationale_value = object.get("rationale") orelse
+        return .{ .invalid = .arguments_rationale };
+    if (rationale_value != .string) return .{ .invalid = .arguments_rationale };
     if (rationale_value.string.len == 0 or rationale_value.string.len > max_rationale_bytes) {
-        return .invalid;
+        return .{ .invalid = .arguments_rationale };
     }
 
     // Risk is informational for traces and presentation. The host grants only
@@ -1307,7 +1347,7 @@ test "automatic reviewer classifier routes through the registered provider" {
                 std.mem.eql(u8, input.tenant orelse "", "team_1") and
                 std.mem.eql(u8, input.endpoint, "https://example.test/chat") and
                 std.meta.activeTag(request.action) == .tool;
-            return .invalid;
+            return .{ .invalid = .provider_failed };
         }
     };
 
@@ -1422,7 +1462,10 @@ test "review outcome reduces to clear caution or unavailable without effects" {
     } };
     try std.testing.expectEqual(HostDisposition.clear, hostDisposition(clear));
     try std.testing.expectEqual(HostDisposition.caution, hostDisposition(caution));
-    try std.testing.expectEqual(HostDisposition.unavailable, hostDisposition(.invalid));
+    try std.testing.expectEqual(
+        HostDisposition.unavailable,
+        hostDisposition(.{ .invalid = .transport_timed_out }),
+    );
 }
 
 test "action provenance records only exact current-turn tool-result copies" {
@@ -1680,6 +1723,25 @@ test "automatic review rejects malformed extra and legacy decision assessments" 
             std.meta.activeTag(try parseCompletion(std.testing.allocator, completion)),
         );
     }
+}
+
+test "automatic review preserves the exact invalid completion cause" {
+    const unexpected_text = try parseCompletion(std.testing.allocator, .{
+        .content = "review prose must not be accepted",
+    });
+    try std.testing.expectEqual(
+        InvalidReason.completion_text,
+        unexpected_text.invalid,
+    );
+
+    const legacy_decision = try parseArguments(
+        std.testing.allocator,
+        "{\"risk\":\"low\",\"decision\":\"allow\",\"rationale\":\"legacy\"}",
+    );
+    try std.testing.expectEqual(
+        InvalidReason.arguments_decision,
+        legacy_decision.invalid,
+    );
 }
 
 test "automatic review does not send redacted action evidence" {

--- a/src/core/permissions/command_admission.zig
+++ b/src/core/permissions/command_admission.zig
@@ -107,6 +107,7 @@ pub const PermissionOutcome = struct {
     feedback: ?[]const u8 = null,
     /// Owned by the allocator passed to the permission request.
     auto_review_result: ?auto_classifier.Result = null,
+    auto_review_failure: ?auto_classifier.InvalidReason = null,
 };
 
 pub const PermissionRequirement = enum {

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -672,9 +672,12 @@ fn findSecretSpan(text: []const u8, start: usize) ?SecretSpan {
     if (matchesAwsAccessKey(text, start)) |span| return span;
     if (matchesSensitiveAssignment(text, start)) |span| return span;
     for (secret_prefixes) |prefix| {
-        if (start + prefix.len < text.len and eqlIgnoreCase(text[start .. start + prefix.len], prefix)) {
+        if ((start == 0 or !isAssignmentKeyChar(text[start - 1])) and
+            start + prefix.len < text.len and
+            eqlIgnoreCase(text[start .. start + prefix.len], prefix))
+        {
             const value_start = start + prefix.len;
-            if (secretAssignmentValueSpan(text, value_start)) |value| {
+            if (secretAssignmentValueSpan(text, start, value_start)) |value| {
                 return .{ .prefix_end = value.prefix_end, .value_len = value.value_len, .kind = "assignment" };
             }
         }
@@ -758,7 +761,7 @@ fn matchesSensitiveAssignment(text: []const u8, start: usize) ?SecretSpan {
     if (!sensitiveAssignmentKey(key)) return null;
 
     const value_start = eq + 1;
-    if (secretAssignmentValueSpan(text, value_start)) |value| {
+    if (secretAssignmentValueSpan(text, start, value_start)) |value| {
         return .{ .prefix_end = value.prefix_end, .value_len = value.value_len, .kind = "assignment" };
     }
     return null;
@@ -769,14 +772,19 @@ const AssignmentValueSpan = struct {
     value_len: usize,
 };
 
-fn secretAssignmentValueSpan(text: []const u8, value_start: usize) ?AssignmentValueSpan {
+fn secretAssignmentValueSpan(
+    text: []const u8,
+    assignment_start: usize,
+    value_start: usize,
+) ?AssignmentValueSpan {
     const value = assignmentValueSpan(text, value_start) orelse return null;
-    if (isPureSymbolicAssignment(text, value_start, value)) return null;
+    if (isPureSymbolicAssignment(text, assignment_start, value_start, value)) return null;
     return value;
 }
 
 fn isPureSymbolicAssignment(
     text: []const u8,
+    assignment_start: usize,
     value_start: usize,
     value: AssignmentValueSpan,
 ) bool {
@@ -786,7 +794,11 @@ fn isPureSymbolicAssignment(
     )) return false;
     const value_end = value.prefix_end + value.value_len;
     if (text[value_start] != '"') {
-        return value_end == text.len or isShellWordBoundary(text, value_end);
+        if (value_end == text.len or isShellWordBoundary(text, value_end)) return true;
+        if (text[value_end] != '"' or assignment_start == 0 or
+            text[assignment_start - 1] != '"') return false;
+        const next = value_end + 1;
+        return next == text.len or isShellWordBoundary(text, next);
     }
 
     const closing_quote = value_end;
@@ -1004,6 +1016,7 @@ test "maskSecrets preserves pure symbolic sensitive assignments" {
     const alloc = std.testing.allocator;
     const input =
         "AI_GATEWAY_API_KEY=\"$key\"\n" ++
+        "sandbox -e \"AI_GATEWAY_API_KEY=$key\" \"$@\"\n" ++
         "GITHUB_TOKEN=$token\n" ++
         "DATABASE_URL=\"${database_url}\"\n" ++
         "TOKEN=\"$token\"; run-next\n" ++
@@ -1021,6 +1034,9 @@ test "maskSecrets masks compound or literal sensitive assignments" {
     const alloc = std.testing.allocator;
     const input =
         "AI_GATEWAY_API_KEY=\"literal-value\"\n" ++
+        "sandbox -e \"AI_GATEWAY_API_KEY=literal-value\"\n" ++
+        "sandbox -e \"GITHUB_TOKEN=$token-suffix\"\n" ++
+        "sandbox -e \"API_KEY=$(load-key)\"\n" ++
         "GITHUB_TOKEN=\"$token-suffix\"\n" ++
         "DATABASE_URL=\"${database_url:-fallback}\"\n" ++
         "API_KEY=\"$(load-key)\"\n" ++
@@ -1039,6 +1055,9 @@ test "maskSecrets masks compound or literal sensitive assignments" {
 
     try std.testing.expectEqualStrings(
         "AI_GATEWAY_API_KEY=\"[redacted]\"\n" ++
+            "sandbox -e \"AI_GATEWAY_API_KEY=[redacted]\"\n" ++
+            "sandbox -e \"GITHUB_TOKEN=[redacted]\"\n" ++
+            "sandbox -e \"API_KEY=[redacted]\"\n" ++
             "GITHUB_TOKEN=\"[redacted]\"\n" ++
             "DATABASE_URL=\"[redacted]\"\n" ++
             "API_KEY=\"[redacted]\"\n" ++

--- a/src/core/shared/text_utils.zig
+++ b/src/core/shared/text_utils.zig
@@ -777,7 +777,7 @@ fn secretAssignmentValueSpan(
     assignment_start: usize,
     value_start: usize,
 ) ?AssignmentValueSpan {
-    const value = assignmentValueSpan(text, value_start) orelse return null;
+    const value = assignmentValueSpan(text, assignment_start, value_start) orelse return null;
     if (isPureSymbolicAssignment(text, assignment_start, value_start, value)) return null;
     return value;
 }
@@ -793,12 +793,10 @@ fn isPureSymbolicAssignment(
         text[value.prefix_end .. value.prefix_end + value.value_len],
     )) return false;
     const value_end = value.prefix_end + value.value_len;
-    if (text[value_start] != '"') {
-        if (value_end == text.len or isShellWordBoundary(text, value_end)) return true;
-        if (text[value_end] != '"' or assignment_start == 0 or
-            text[assignment_start - 1] != '"') return false;
-        const next = value_end + 1;
-        return next == text.len or isShellWordBoundary(text, next);
+    const outer_double_quoted = assignment_start > 0 and
+        text[assignment_start - 1] == '"';
+    if (text[value_start] != '"' and !outer_double_quoted) {
+        return value_end == text.len or isShellWordBoundary(text, value_end);
     }
 
     const closing_quote = value_end;
@@ -834,7 +832,11 @@ fn isShellVariableName(value: []const u8) bool {
     return true;
 }
 
-fn assignmentValueSpan(text: []const u8, value_start: usize) ?AssignmentValueSpan {
+fn assignmentValueSpan(
+    text: []const u8,
+    assignment_start: usize,
+    value_start: usize,
+) ?AssignmentValueSpan {
     if (value_start >= text.len) return null;
 
     if (text[value_start] == '"' or text[value_start] == '\'') {
@@ -844,6 +846,16 @@ fn assignmentValueSpan(text: []const u8, value_start: usize) ?AssignmentValueSpa
         while (end < text.len and text[end] != '\n' and text[end] != '\r' and text[end] != quote) : (end += 1) {}
         const value_len = end - content_start;
         if (value_len >= 1) return .{ .prefix_end = content_start, .value_len = value_len };
+        return null;
+    }
+
+    if (assignment_start > 0 and text[assignment_start - 1] == '"') {
+        var end = value_start;
+        while (end < text.len and text[end] != '\n' and text[end] != '\r' and
+            text[end] != '"') : (end += 1)
+        {}
+        const value_len = end - value_start;
+        if (value_len >= 1) return .{ .prefix_end = value_start, .value_len = value_len };
         return null;
     }
 
@@ -1035,6 +1047,10 @@ test "maskSecrets masks compound or literal sensitive assignments" {
     const input =
         "AI_GATEWAY_API_KEY=\"literal-value\"\n" ++
         "sandbox -e \"AI_GATEWAY_API_KEY=literal-value\"\n" ++
+        "sandbox -e \"AI_GATEWAY_API_KEY=$key literal-suffix\"\n" ++
+        "sandbox -e \"GITHUB_TOKEN=$token;literal-suffix\"\n" ++
+        "sandbox -e \"ACCESS_TOKEN=$token>token.out\"\n" ++
+        "sandbox -e \"SECRET_KEY=$key$tail\"\n" ++
         "sandbox -e \"GITHUB_TOKEN=$token-suffix\"\n" ++
         "sandbox -e \"API_KEY=$(load-key)\"\n" ++
         "GITHUB_TOKEN=\"$token-suffix\"\n" ++
@@ -1056,6 +1072,10 @@ test "maskSecrets masks compound or literal sensitive assignments" {
     try std.testing.expectEqualStrings(
         "AI_GATEWAY_API_KEY=\"[redacted]\"\n" ++
             "sandbox -e \"AI_GATEWAY_API_KEY=[redacted]\"\n" ++
+            "sandbox -e \"AI_GATEWAY_API_KEY=[redacted]\"\n" ++
+            "sandbox -e \"GITHUB_TOKEN=[redacted]\"\n" ++
+            "sandbox -e \"ACCESS_TOKEN=[redacted]\"\n" ++
+            "sandbox -e \"SECRET_KEY=[redacted]\"\n" ++
             "sandbox -e \"GITHUB_TOKEN=[redacted]\"\n" ++
             "sandbox -e \"API_KEY=[redacted]\"\n" ++
             "GITHUB_TOKEN=\"[redacted]\"\n" ++

--- a/src/core/tooling/tool_admission.zig
+++ b/src/core/tooling/tool_admission.zig
@@ -922,19 +922,26 @@ test "direct git push branch proof accepts only explicit literal operands" {
 
 /// An unavailable or invalid automatic review never executes anything. It is
 /// returned to the primary model as neutral advisory unavailability.
-fn traceReviewerUnavailable(call: ToolCall) void {
+fn traceReviewerUnavailable(
+    call: ToolCall,
+    failure: permission_auto_classifier.InvalidReason,
+) void {
     debug_trace.logf(
         "permission",
-        "event=auto_review_result tool_name={s} decision=unavailable fallback_reason=reviewer_unavailable recovery=agent_replan execution_started=false call_id={s}",
-        .{ call.name, call.id },
+        "event=auto_review_result tool_name={s} decision=unavailable fallback_reason={s} recovery=agent_replan execution_started=false call_id={s}",
+        .{ call.name, @tagName(failure), call.id },
     );
 }
 
-fn reviewerUnavailableOutcome(call: ToolCall) command_admission.PermissionOutcome {
-    traceReviewerUnavailable(call);
+fn reviewerUnavailableOutcome(
+    call: ToolCall,
+    failure: permission_auto_classifier.InvalidReason,
+) command_admission.PermissionOutcome {
+    traceReviewerUnavailable(call, failure);
     return .{
         .decision = .deny,
         .denial_reason = .review_unavailable,
+        .auto_review_failure = failure,
     };
 }
 
@@ -955,9 +962,13 @@ fn nonAllowAutoReviewOutcome(
         review,
     )) {
         .clear => null,
-        .unavailable => .{
-            .decision = .deny,
-            .denial_reason = .review_unavailable,
+        .unavailable => switch (review) {
+            .invalid => |failure| .{
+                .decision = .deny,
+                .denial_reason = .review_unavailable,
+                .auto_review_failure = failure,
+            },
+            .valid, .evidence_incomplete => unreachable,
         },
         .caution => switch (review) {
             .valid => |result| if (result.decision == .caution)
@@ -995,8 +1006,12 @@ fn automaticReviewOutcome(
     is_dynamic_tool: bool,
     file_authorization: ?file_mutation_contract.FileExecutionAuthorization,
 ) !command_admission.PermissionOutcome {
-    if (!input.auto_classifier.enabled()) return reviewerUnavailableOutcome(call);
-    if (input.permission_review_turn == null) return reviewerUnavailableOutcome(call);
+    if (!input.auto_classifier.enabled()) {
+        return reviewerUnavailableOutcome(call, .reviewer_unconfigured);
+    }
+    if (input.permission_review_turn == null) {
+        return reviewerUnavailableOutcome(call, .invalid_context);
+    }
 
     const request = try reviewRequestForCall(
         input,
@@ -1068,10 +1083,10 @@ fn runAutomaticReview(
             "event=auto_review_result tool_name={s} decision=held fallback_reason=review_evidence_incomplete recovery=agent_replan elapsed_ms={d} execution_started=false call_id={s}",
             .{ call.name, io_mod.milliTimestamp() - started_ms, call.id },
         ),
-        .invalid => debug_trace.logf(
+        .invalid => |reason| debug_trace.logf(
             "permission",
-            "event=auto_review_result tool_name={s} decision=unavailable fallback_reason=invalid_or_unavailable recovery=agent_replan elapsed_ms={d} execution_started=false call_id={s}",
-            .{ call.name, io_mod.milliTimestamp() - started_ms, call.id },
+            "event=auto_review_result tool_name={s} decision=unavailable fallback_reason={s} recovery=agent_replan elapsed_ms={d} execution_started=false call_id={s}",
+            .{ call.name, @tagName(reason), io_mod.milliTimestamp() - started_ms, call.id },
         ),
     }
     return review;
@@ -3503,6 +3518,7 @@ const FakeAutoClassifier = struct {
     risk: permission_auto_classifier.Risk = .low,
     rationale: []const u8 = "test automatic review",
     invalid: bool = false,
+    invalid_reason: ?permission_auto_classifier.InvalidReason = null,
     review_model: []const u8 = "",
     review_root_text: []const u8 = "",
     review_target_call_id: []const u8 = "",
@@ -3547,7 +3563,8 @@ const FakeAutoClassifier = struct {
                 self.schema_json = tool.schema_json;
             },
         }
-        if (self.invalid) return .invalid;
+        if (self.invalid_reason) |reason| return .{ .invalid = reason };
+        if (self.invalid) return .{ .invalid = .provider_failed };
         return .{ .valid = .{
             .risk = self.risk,
             .decision = self.decision,
@@ -3876,6 +3893,69 @@ test "automatic non-allow is recoverable regardless tool approval policy" {
     try std.testing.expect(unavailable.auto_review_result == null);
     try std.testing.expectEqual(@as(usize, 3), fake.calls);
     try std.testing.expectEqual(@as(usize, 1), recording.calls);
+}
+
+test "automatic review trace preserves the typed unavailable cause without action text" {
+    const alloc = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try io_mod.dirRealpathAlloc(alloc, tmp.dir, ".");
+    defer alloc.free(root);
+    const trace_path = try std.fs.path.join(alloc, &.{ root, "permission.log" });
+    defer alloc.free(trace_path);
+
+    debug_trace.resetForTest();
+    defer debug_trace.resetForTest();
+    try debug_trace.configureForTestWithScopes(alloc, trace_path, "permission");
+
+    var arena_state = std.heap.ArenaAllocator.init(alloc);
+    defer arena_state.deinit();
+    var worker: WorkerRuntime = .{};
+    defer worker.deinit(alloc);
+    var fake = FakeAutoClassifier{ .invalid_reason = .transport_timed_out };
+    const calls = [_]ToolCall{.{
+        .id = "typed-unavailable",
+        .name = "shell",
+        .arguments_json = "{\"request\":{\"action\":\"run\",\"command\":\"gh auth token SECRET_SHOULD_NOT_APPEAR\"}}",
+    }};
+    var input = testInputWithClassifier(
+        &worker,
+        permission_auto_classifier.Classifier.withOverride(
+            @ptrCast(&fake),
+            FakeAutoClassifier.classify,
+        ),
+    );
+    input.permission_review_turn = .{
+        .model = "test/source-model",
+        .pending_assistant = .{ .role = .assistant, .tool_calls = &calls },
+        .target_call_id = calls[0].id,
+        .origin = .root,
+        .trusted_root_context = "Inspect repository status.",
+    };
+
+    const outcome = try requestPermissionOutcome(
+        input,
+        arena_state.allocator(),
+        calls[0],
+        .auto,
+        &.{},
+    );
+    try std.testing.expectEqual(ToolPermissionDecision.deny, outcome.decision);
+    try std.testing.expectEqual(
+        types.ToolPermissionDenialReason.review_unavailable,
+        outcome.denial_reason.?,
+    );
+
+    var trace_file = try std.Io.Dir.openFileAbsolute(io_mod.getIo(), trace_path, .{});
+    defer trace_file.close(io_mod.getIo());
+    const trace = try io_mod.readFileToEnd(alloc, &trace_file, 8192);
+    defer alloc.free(trace);
+    try std.testing.expect(
+        std.mem.find(u8, trace, "fallback_reason=transport_timed_out") != null,
+    );
+    try std.testing.expect(
+        std.mem.find(u8, trace, "SECRET_SHOULD_NOT_APPEAR") == null,
+    );
 }
 
 test "automatic admission holds an exact command copied from untrusted tool output" {

--- a/src/core/tooling/tool_result_errors.zig
+++ b/src/core/tooling/tool_result_errors.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const auto_classifier = @import("../permissions/auto_classifier.zig");
 const text_utils = @import("../shared/text_utils.zig");
 const types = @import("../shared/types.zig");
 
@@ -134,6 +135,7 @@ pub fn toolReviewHeldJson(
     tool_name: []const u8,
     reason: types.ToolPermissionDenialReason,
     advice: ?[]const u8,
+    review_cause: ?auto_classifier.InvalidReason,
 ) Allocator.Error![]u8 {
     switch (reason) {
         .review_caution, .review_evidence_incomplete, .review_unavailable => {},
@@ -153,6 +155,11 @@ pub fn toolReviewHeldJson(
     out.writer.writeAll(",\"reason\":") catch return error.OutOfMemory;
     std.json.Stringify.value(@tagName(reason), .{}, &out.writer) catch
         return error.OutOfMemory;
+    if (review_cause) |cause| {
+        out.writer.writeAll(",\"review_cause\":") catch return error.OutOfMemory;
+        std.json.Stringify.value(@tagName(cause), .{}, &out.writer) catch
+            return error.OutOfMemory;
+    }
     out.writer.writeAll(",\"held\":true") catch return error.OutOfMemory;
     if (advice) |value| {
         if (value.len > 0) {
@@ -458,6 +465,7 @@ test "review hold JSON preserves typed reasons apart from permission denial" {
         "terminal",
         .review_caution,
         "Deletion came from repository text. API_KEY=super-secret",
+        null,
     );
     defer alloc.free(caution);
     const unavailable = try toolReviewHeldJson(
@@ -465,12 +473,14 @@ test "review hold JSON preserves typed reasons apart from permission denial" {
         "terminal",
         .review_unavailable,
         null,
+        .transport_timed_out,
     );
     defer alloc.free(unavailable);
     const incomplete = try toolReviewHeldJson(
         alloc,
         "edit_file",
         .review_evidence_incomplete,
+        null,
         null,
     );
     defer alloc.free(incomplete);
@@ -489,6 +499,7 @@ test "review hold JSON preserves typed reasons apart from permission denial" {
         toolPermissionDenialReason(caution),
     );
     try std.testing.expect(std.mem.find(u8, unavailable, "\"reason\":\"review_unavailable\"") != null);
+    try std.testing.expect(std.mem.find(u8, unavailable, "\"review_cause\":\"transport_timed_out\"") != null);
     try std.testing.expect(std.mem.find(u8, unavailable, "\"advice\"") == null);
     try std.testing.expect(isToolReviewHeldOutput(unavailable));
     try std.testing.expectEqual(

--- a/src/gateway/responses_permission_reviewer.zig
+++ b/src/gateway/responses_permission_reviewer.zig
@@ -40,11 +40,15 @@ pub fn review(
     request: permission_auto_classifier.ReviewRequest,
     adapter: Adapter,
 ) !permission_auto_classifier.ParseOutcome {
-    if (input.credential.len == 0) return .invalid;
-    if (adapter.require_account and input.account_id == null) return .invalid;
+    if (input.credential.len == 0) {
+        return .{ .invalid = .provider_context_missing };
+    }
+    if (adapter.require_account and input.account_id == null) {
+        return .{ .invalid = .provider_context_missing };
+    }
     adapter.validate_fn(alloc, input) catch |err| {
         if (err == error.OutOfMemory) return error.OutOfMemory;
-        return .invalid;
+        return .{ .invalid = .provider_failed };
     };
     var runtime = Runtime{ .input = input, .adapter = adapter };
     return permission_auto_classifier.Reviewer.withTransportModel(
@@ -199,9 +203,19 @@ fn sendReview(
             return .permanent_failure;
         };
         if (err == error.OutOfMemory) return error.OutOfMemory;
-        if (err == error.Cancelled or cancel_flag.load(.seq_cst)) return .cancelled;
-        if (err == error.Timeout) return .timed_out;
-        return .transient_failure;
+        const outcome: permission_auto_classifier.TransportOutcome =
+            if (err == error.Cancelled or cancel_flag.load(.seq_cst))
+                .cancelled
+            else if (err == error.Timeout)
+                .timed_out
+            else
+                .transient_failure;
+        debug_trace.logf(
+            "permission",
+            "event=auto_review_transport result={s} reason=transport_error error={s}",
+            .{ @tagName(std.meta.activeTag(outcome)), @errorName(err) },
+        );
+        return outcome;
     };
     var result_owned = true;
     defer if (result_owned) result.deinit(alloc);
@@ -221,15 +235,46 @@ fn sendReview(
         return .permanent_failure;
     };
     if (cancel_flag.load(.seq_cst)) return .cancelled;
-    if (std.meta.activeTag(result) == .failed) return switch (result.failed.kind) {
-        .rate_limited, .server_error, .bad_gateway, .unavailable, .gateway_timeout => .transient_failure,
-        else => .permanent_failure,
-    };
+    if (std.meta.activeTag(result) == .failed) {
+        const outcome: permission_auto_classifier.TransportOutcome = switch (result.failed.kind) {
+            .rate_limited, .server_error, .bad_gateway, .unavailable, .gateway_timeout => .transient_failure,
+            else => .permanent_failure,
+        };
+        debug_trace.logf(
+            "permission",
+            "event=auto_review_transport result={s} reason=provider_failure failure_kind={s}",
+            .{ @tagName(std.meta.activeTag(outcome)), @tagName(result.failed.kind) },
+        );
+        return outcome;
+    }
     if (result.completed.completion.finish_reason) |reason| switch (reason) {
-        .provider_error => return .transient_failure,
-        .content_filter => return .permanent_failure,
+        .provider_error => {
+            debug_trace.logf(
+                "permission",
+                "event=auto_review_transport result=transient_failure reason=provider_error",
+                .{},
+            );
+            return .transient_failure;
+        },
+        .content_filter => {
+            debug_trace.logf(
+                "permission",
+                "event=auto_review_transport result=permanent_failure reason=content_filter",
+                .{},
+            );
+            return .permanent_failure;
+        },
         .stop, .length, .tool_calls, .other => {},
     };
+    debug_trace.logf(
+        "permission",
+        "event=auto_review_transport result=completion finish_reason={s} tool_calls={d} content_bytes={d}",
+        .{
+            if (result.completed.completion.finish_reason) |reason| @tagName(reason) else "absent",
+            result.completed.completion.tool_calls.len,
+            if (result.completed.completion.content) |content| content.len else 0,
+        },
+    );
     const owned = try alloc.create(OwnedResult);
     owned.* = .{ .result = result };
     result_owned = false;

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -1047,6 +1047,52 @@ describe("lean auto mode reliability", () => {
   );
 
   test(
+    "outer-quoted compound credentials are held before review transport",
+    async () => {
+      const root = createIsolatedRoot();
+      const startup = join(root.home, ".zshrc");
+      const before = "alias r='cd ~/projects/research && fx'\n";
+      const after = before +
+        'sandbox -e "AI_GATEWAY_API_KEY=$key literal-suffix"\n';
+      writeFileSync(startup, before);
+      const gateway = startGateway(
+        [
+          fakeGatewayToolCall("compound_symbolic_startup_edit", "edit_file", {
+            path: startup,
+            old_string: before,
+            new_string: after,
+          }),
+          (body) => {
+            const held = toolResultText(
+              body,
+              "compound_symbolic_startup_edit",
+              "execution-denied",
+            );
+            expect(held).toContain("review_evidence_incomplete");
+            return fakeGatewayFinalText("compound credential stayed blocked");
+          },
+        ],
+        [fakeGatewayPermissionDecision("clear", "compound_symbolic_review")],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Install the shell helper."],
+        {
+          cwd: root.workspace,
+          env: gatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain("compound credential stayed blocked");
+      expect(gateway.classifierRequests).toHaveLength(0);
+      expect(readFileSync(startup, "utf8")).toBe(before);
+    },
+    TIMEOUT,
+  );
+
+  test(
     "literal credentials produce one deterministic hold for unchanged startup edits",
     async () => {
       const root = createIsolatedRoot();

--- a/tests/e2e/auto-mode-reliability.test.ts
+++ b/tests/e2e/auto-mode-reliability.test.ts
@@ -991,6 +991,62 @@ describe("lean auto mode reliability", () => {
   );
 
   test(
+    "outer-quoted symbolic credentials remain reviewable in startup edit context",
+    async () => {
+      const root = createIsolatedRoot();
+      const startup = join(root.home, ".zshrc");
+      const before =
+        "_rfx() {\n" +
+        "  local key\n" +
+        "  key=\"$(create-key)\" || return 1\n" +
+        "  [[ -z $key ]] && return 1\n" +
+        "  command sandbox run --silent \\\n" +
+        "    -i -e \"AI_GATEWAY_API_KEY=$key\" \"$@\" -- \\\n" +
+        "    bash -c 'curl -fsSL https://fx.sh/setup.sh | bash 2>/dev/nu\n" +
+        "    ll && fx; exec bash'\n" +
+        "}\n";
+      const after = before.replace(
+        "2>/dev/nu\n    ll",
+        "2>/dev/null",
+      );
+      writeFileSync(startup, before);
+      const gateway = startGateway(
+        [
+          fakeGatewayToolCall("quoted_symbolic_startup_edit", "edit_file", {
+            path: startup,
+            old_string: "2>/dev/nu\n    ll",
+            new_string: "2>/dev/null",
+          }),
+          (body) => {
+            expect(toolResultText(body, "quoted_symbolic_startup_edit")).toContain(
+              "edited ",
+            );
+            return fakeGatewayFinalText("startup helper repaired");
+          },
+        ],
+        [fakeGatewayPermissionDecision("clear", "quoted_symbolic_startup_review")],
+      );
+
+      const result = await runFx(
+        ["ask", "--quiet", "--json", "--no-save", "Repair the shell helper."],
+        {
+          cwd: root.workspace,
+          env: gatewayEnv(root, gateway),
+          timeoutMs: TIMEOUT,
+        },
+      );
+
+      expect(result.code, `stdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+      expect(gateway.classifierRequests).toHaveLength(1);
+      const review = gateway.classifierRequests[0]!.body;
+      expect(review).toContain('AI_GATEWAY_API_KEY=$key');
+      expect(review).not.toContain("AI_GATEWAY_API_KEY=[redacted]");
+      expect(readFileSync(startup, "utf8")).toBe(after);
+    },
+    TIMEOUT,
+  );
+
+  test(
     "literal credentials produce one deterministic hold for unchanged startup edits",
     async () => {
       const root = createIsolatedRoot();

--- a/tests/e2e/tui-command-permissions.test.ts
+++ b/tests/e2e/tui-command-permissions.test.ts
@@ -2342,7 +2342,7 @@ describe("effect-aware command permissions", () => {
       expect(gateway.classifierRequests).toHaveLength(4);
       const trace = readFileSync(tracePath, "utf8");
       expect(
-        trace.match(/decision=unavailable fallback_reason=invalid_or_unavailable/g),
+        trace.match(/decision=unavailable fallback_reason=completion_text/g),
       ).toHaveLength(4);
       expect(trace).not.toContain("event=automatic_recovery_exhausted");
       expect(readFileSync(stderrPath, "utf8")).toBe("");
@@ -3112,6 +3112,7 @@ describe("effect-aware command permissions", () => {
           toolCall(command),
           (body) => {
             expect(body).toContain("review_unavailable");
+            expect(body).toContain('\\"review_cause\\":\\"completion_text\\"');
             return toolCall("pwd", "safe_after_malformed");
           },
           finalText("classifier recovery complete"),
@@ -3142,7 +3143,7 @@ describe("effect-aware command permissions", () => {
       expect(trace.match(/event=auto_review_transport_start/g)).toHaveLength(1);
       expect(trace.match(/event=auto_review_result/g)).toHaveLength(1);
       expect(trace).toContain("decision=unavailable");
-      expect(trace).toContain("fallback_reason=invalid_or_unavailable");
+      expect(trace).toContain("fallback_reason=completion_text");
       expect(result.stderr).not.toContain("Auto agent approved this request:");
     },
     TIMEOUT,
@@ -3159,6 +3160,7 @@ describe("effect-aware command permissions", () => {
           toolCall(command),
           (body) => {
             expect(body).toContain("review_unavailable");
+            expect(body).toContain('\\"review_cause\\":\\"completion_text\\"');
             return finalText("classifier fallback handled");
           },
         ],
@@ -3187,7 +3189,7 @@ describe("effect-aware command permissions", () => {
       expect(trace.match(/event=auto_review_transport_start/g)).toHaveLength(1);
       expect(trace.match(/event=auto_review_result/g)).toHaveLength(1);
       expect(trace).toContain("decision=unavailable");
-      expect(trace).toContain("fallback_reason=invalid_or_unavailable");
+      expect(trace).toContain("fallback_reason=completion_text");
       expect(result.stderr).not.toContain(COMMAND_APPROVAL_PROMPT);
     },
     TIMEOUT,
@@ -3204,6 +3206,7 @@ describe("effect-aware command permissions", () => {
           toolCall(command),
           (body) => {
             expect(body).toContain("review_unavailable");
+            expect(body).toContain('\\"review_cause\\":\\"transport_transient\\"');
             return finalText("provider failure handled");
           },
         ],
@@ -3237,7 +3240,10 @@ describe("effect-aware command permissions", () => {
       expect(trace.match(/event=auto_review_transport_start/g)).toHaveLength(1);
       expect(trace.match(/event=auto_review_result/g)).toHaveLength(1);
       expect(trace).toContain("decision=unavailable");
-      expect(trace).toContain("fallback_reason=invalid_or_unavailable");
+      expect(trace).toContain(
+        "event=auto_review_transport result=transient_failure http_status=502",
+      );
+      expect(trace).toContain("fallback_reason=transport_transient");
     },
     TIMEOUT,
   );


### PR DESCRIPTION
## Summary

- Preserve symbolic credential references in quoted environment arguments during automatic file review.
- Include specific automatic review failure causes in held tool results and permission traces.