### PR TITLE
Skip user settings writes on js-host surfaces

### DIFF
--- a/src/core/app/app_commands.zig
+++ b/src/core/app/app_commands.zig
@@ -166,6 +166,9 @@ fn persistUserPreferences(
     patch: config_runtime.UserSettingsPatch,
     runtime_changed: bool,
 ) !void {
+    // js-host surfaces have no user settings file; the host config store
+    // owns preferences there, so a HOME-based write has nothing to report.
+    if (comptime runtime_profile.allows(@TypeOf(app.*), .js_host_config)) return;
     var attempt = config_runtime.attemptUserPreferences(app.alloc, patch);
     defer attempt.deinit(app.alloc);
     switch (attempt) {
@@ -3598,26 +3601,28 @@ fn handleNotificationsCommand(app: anytype, rest: []const u8) !void {
         .notification_attention_required = sound_on,
         .notification_max = max,
     };
-    var attempt = config_runtime.attemptUserPreferences(app.alloc, patch);
-    defer attempt.deinit(app.alloc);
-    switch (attempt) {
-        .failure => |failure| try session_commands.reportUserSettingsFailure(
-            app,
-            "sound",
-            failure.err,
-            failure.cleanup,
-            runtime_changed,
-        ),
-        // announce_commit=false drops the routine "saved" line (the state
-        // notice below covers it, matching /fast) but keeps warnings.
-        .outcome => |outcome| _ = try session_commands.reportUserSettingsCommit(
-            app,
-            "sound",
-            patch,
-            outcome,
-            null,
-            false,
-        ),
+    if (comptime !runtime_profile.allows(@TypeOf(app.*), .js_host_config)) {
+        var attempt = config_runtime.attemptUserPreferences(app.alloc, patch);
+        defer attempt.deinit(app.alloc);
+        switch (attempt) {
+            .failure => |failure| try session_commands.reportUserSettingsFailure(
+                app,
+                "sound",
+                failure.err,
+                failure.cleanup,
+                runtime_changed,
+            ),
+            // announce_commit=false drops the routine "saved" line (the state
+            // notice below covers it, matching /fast) but keeps warnings.
+            .outcome => |outcome| _ = try session_commands.reportUserSettingsCommit(
+                app,
+                "sound",
+                patch,
+                outcome,
+                null,
+                false,
+            ),
+        }
     }
 
     try app.writeDomainNotice(.{
@@ -3685,6 +3690,9 @@ fn persistUserPreferencesSilently(
     patch: config_runtime.UserSettingsPatch,
     runtime_changed: bool,
 ) !void {
+    // js-host surfaces have no user settings file; the host config store
+    // owns preferences there, so a HOME-based write has nothing to report.
+    if (comptime runtime_profile.allows(@TypeOf(app.*), .js_host_config)) return;
     var attempt = config_runtime.attemptUserPreferences(app.alloc, patch);
     defer attempt.deinit(app.alloc);
     switch (attempt) {

--- a/src/core/app/app_session_runtime.zig
+++ b/src/core/app/app_session_runtime.zig
@@ -2776,20 +2776,24 @@ pub fn Runtime(comptime App: type) type {
                 result.session_error = err;
             };
 
-            var settings_attempt = config_runtime.attemptUserPreferences(
-                app.alloc,
-                patch.userSettingsPatch(),
-            );
-            switch (settings_attempt) {
-                .outcome => |outcome| {
-                    result.settings_outcome = outcome;
-                    settings_attempt = undefined;
-                },
-                .failure => |failure| {
-                    result.settings_error = failure.err;
-                    result.settings_failure_cleanup = failure.cleanup;
-                    settings_attempt = undefined;
-                },
+            // js-host surfaces have no user settings file; the host config
+            // store owns preferences there (app_host_config_runtime).
+            if (comptime !runtime_profile.allows(App, .js_host_config)) {
+                var settings_attempt = config_runtime.attemptUserPreferences(
+                    app.alloc,
+                    patch.userSettingsPatch(),
+                );
+                switch (settings_attempt) {
+                    .outcome => |outcome| {
+                        result.settings_outcome = outcome;
+                        settings_attempt = undefined;
+                    },
+                    .failure => |failure| {
+                        result.settings_error = failure.err;
+                        result.settings_failure_cleanup = failure.cleanup;
+                        settings_attempt = undefined;
+                    },
+                }
             }
             if (result.settings_error == null) {
                 applyPreferencePatch(


### PR DESCRIPTION
## Summary

The js-host runtime profile persists the model and permission mode through the host config store (`app_host_config_runtime`). It has no HOME directory and no user settings file. Commands that also write user preferences still attempted the HOME-based write and reported its inevitable failure on every use. On the wasm terminal, `/model` prints "Model picker: active for this process but not saved to user settings (HomeNotSet)" although the host store had saved the choice.

This change returns before the HOME-based attempt when the profile allows `js_host_config`, in the two shared helpers (`persistUserPreferences`, `persistUserPreferencesSilently`) and the inline attempt in `/sound`. Native builds are unchanged.

## Verification

- `zig build -Dwasm-surface=term` on upstream `main` `19ae8f54`.
- On a JavaScript host with a config store, `/model` switches and persists the model with no error notice; on restart the host store restores it.
- Native `fx`: `/model` still writes `~/.fx` user settings and reports failures as before.
